### PR TITLE
Mute wandb logger

### DIFF
--- a/nemo_automodel/loggers/wandb_utils.py
+++ b/nemo_automodel/loggers/wandb_utils.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+
+def suppress_wandb_log_messages():
+    """ Patches wandb logger to suppress upload messages, commonly occuring on KeyboardInterrupt
+        or program crash.
+
+        To print the log url:
+        run = wandb.init(...)
+        print(run.url)
+    """
+
+    # (1) kill off all wandb logger output below CRITICAL
+    logging.getLogger("wandb").setLevel(logging.CRITICAL)
+
+    # (2) monkey‐patch any of the internal "_footer…" functions to no‐ops
+    def _suppress_footer(*args, **kwargs):
+        return None
+
+    # Depending on your wandb version these lives under sdk.internal.file_pusher
+    try:
+        import wandb.sdk.internal.file_pusher as _fp
+        for name in dir(_fp):
+            if name.startswith("_footer"):
+                setattr(_fp, name, _suppress_footer)
+    except ImportError:
+        pass
+
+    # There is also a per‐run footer in
+    # wandb.sdk.internal.run._footer_single_run_status_info
+    try:
+        import wandb.sdk.internal.run as _run
+        if hasattr(_run, "_footer_single_run_status_info"):
+            _run._footer_single_run_status_info = _suppress_footer
+    except ImportError:
+        pass

--- a/recipes/llm/finetune.py
+++ b/recipes/llm/finetune.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import wandb
+from wandb import Settings
+from nemo_automodel.loggers.wandb_utils import suppress_wandb_log_messages
+
 import torch.distributed as dist
 from typing import Any, Dict
 
@@ -196,13 +199,16 @@ class FinetuneRecipeForNextTokenPrediction(BaseRecipe):
         torch.manual_seed(self.cfg.get("seed", 42) + self.dist_env.rank)
 
         if self.dist_env.is_main and hasattr(self.cfg, 'logger'):
-            wandb.init(
+            suppress_wandb_log_messages()
+            run = wandb.init(
                 project=self.cfg.logger.get("wandb_project", "default_project"),
                 entity=self.cfg.logger.get("wandb_entity"),
                 name=self.cfg.logger.get("wandb_exp_name"),
                 dir=self.cfg.logger.get("wandb_save_dir"),
                 config=self.cfg,
+                settings=Settings(silent=True),
             )
+            print("🚀 View run at {}".format(run.url))
 
         # Build components
         self.model = build_model(self.dist_env.device, self.cfg.model, self.cfg.get('peft', None), self.model_wrapper)


### PR DESCRIPTION
During KeyboardInterrupt or program crashes the wandb daemon gets stuck at uploading to wandb and keeps printing a spinner. This PR monkey patches a few functions to avoid this. If there are better solutions we can change this.

The wandb log is printed from the finetune.py code.

<img width="827" alt="Screenshot 2025-06-02 at 7 13 54 PM" src="https://github.com/user-attachments/assets/840b38f9-7e95-412b-b99e-cceb36aad61d" />
