### PR TITLE
[refactor] make tokenizer optional

### DIFF
--- a/recipes/llm/llama_3_2_1b_hellaswag.yaml
+++ b/recipes/llm/llama_3_2_1b_hellaswag.yaml
@@ -30,9 +30,6 @@ dataset:
   _target_: nemo_automodel.datasets.llm.hellaswag.HellaSwag
   path_or_dataset: rowan/hellaswag
   split: train
-  tokenizer:
-    _target_: transformers.AutoTokenizer.from_pretrained
-    pretrained_model_name_or_path: meta-llama/Llama-3.2-1B
 
 dataloader:
   _target_: torchdata.stateful_dataloader.StatefulDataLoader
@@ -44,9 +41,6 @@ validation_dataset:
   _target_: nemo_automodel.datasets.llm.hellaswag.HellaSwag
   path_or_dataset: rowan/hellaswag
   split: validation
-  tokenizer:
-    _target_: transformers.AutoTokenizer.from_pretrained
-    pretrained_model_name_or_path: meta-llama/Llama-3.2-1B
   num_samples_limit: 64
 
 validation_dataloader:

--- a/recipes/llm/llama_3_2_1b_hellaswag_nvfsdp.yaml
+++ b/recipes/llm/llama_3_2_1b_hellaswag_nvfsdp.yaml
@@ -29,9 +29,6 @@ dataset:
   _target_: nemo_automodel.datasets.llm.hellaswag.HellaSwag
   path_or_dataset: rowan/hellaswag
   split: train
-  tokenizer:
-    _target_: transformers.AutoTokenizer.from_pretrained
-    pretrained_model_name_or_path: meta-llama/Llama-3.2-1B
 
 dataloader:
   _target_: torchdata.stateful_dataloader.StatefulDataLoader
@@ -43,9 +40,6 @@ validation_dataset:
   _target_: nemo_automodel.datasets.llm.hellaswag.HellaSwag
   path_or_dataset: rowan/hellaswag
   split: validation
-  tokenizer:
-    _target_: transformers.AutoTokenizer.from_pretrained
-    pretrained_model_name_or_path: meta-llama/Llama-3.2-1B
   num_samples_limit: 64
 
 validation_dataloader:

--- a/recipes/llm/llama_3_2_1b_hellaswag_peft.yaml
+++ b/recipes/llm/llama_3_2_1b_hellaswag_peft.yaml
@@ -38,9 +38,6 @@ dataset:
   _target_: nemo_automodel.datasets.llm.hellaswag.HellaSwag
   path_or_dataset: rowan/hellaswag
   split: train
-  tokenizer:
-    _target_: transformers.AutoTokenizer.from_pretrained
-    pretrained_model_name_or_path: meta-llama/Llama-3.2-1B
 
 dataloader:
   _target_: torchdata.stateful_dataloader.StatefulDataLoader
@@ -52,9 +49,6 @@ validation_dataset:
   _target_: nemo_automodel.datasets.llm.hellaswag.HellaSwag
   path_or_dataset: rowan/hellaswag
   split: validation
-  tokenizer:
-    _target_: transformers.AutoTokenizer.from_pretrained
-    pretrained_model_name_or_path: meta-llama/Llama-3.2-1B
   num_samples_limit: 64
 
 validation_dataloader:

--- a/recipes/llm/llama_3_2_1b_squad.yaml
+++ b/recipes/llm/llama_3_2_1b_squad.yaml
@@ -31,9 +31,6 @@ dataset:
   _target_: nemo_automodel.datasets.llm.squad.make_squad_dataset
   dataset_name: rajpurkar/squad
   split: train
-  tokenizer:
-    _target_: transformers.AutoTokenizer.from_pretrained
-    pretrained_model_name_or_path: meta-llama/Llama-3.2-1B
 
 dataloader:
   _target_: torchdata.stateful_dataloader.StatefulDataLoader
@@ -45,9 +42,6 @@ validation_dataset:
   _target_: nemo_automodel.datasets.llm.squad.make_squad_dataset
   dataset_name: rajpurkar/squad
   split: validation
-  tokenizer:
-    _target_: transformers.AutoTokenizer.from_pretrained
-    pretrained_model_name_or_path: meta-llama/Llama-3.2-1B
   limit_dataset_samples: 64
 
 validation_dataloader:


### PR DESCRIPTION
Currently, the tokenizer needs to be explicitly passed to the dataset sections, resulting in duplicated sections and requires redundant changes if the model-id changes.

This PR makes the tokenizer section optional, and if not present, it will figure out the tokenizer based on the current model.