### PR TITLE
fix: squad special symbol handling

### DIFF
--- a/nemo_automodel/datasets/llm/squad.py
+++ b/nemo_automodel/datasets/llm/squad.py
@@ -71,12 +71,14 @@ def make_squad_dataset(
             example['answers']['text'][0].strip(),
         ]
         context_ids, answer_ids = list(map(lambda x: tokenizer(x)['input_ids'], formatted_text))
-        bos_id = getattr(tokenizer, 'bos_id', None)
-        eos_id = getattr(tokenizer, 'eos_id', None)
-        if len(context_ids) > 0 and bos_id is not None and context_ids[0] != bos_id:
-            context_ids.insert(0, bos_id)
-        if len(answer_ids) > 0 and eos_id is not None and answer_ids[-1] != eos_id:
-            answer_ids.append(eos_id)
+        bos_id = getattr(tokenizer, 'bos_token_id', None)
+        eos_id = getattr(tokenizer, 'eos_token_id', None)
+        # Remove EOS token from context's end
+        if len(context_ids) > 0 and context_ids[-1] == eos_id:
+            context_ids = context_ids[:-1]
+        # Remove BOS token from answer's start
+        if len(answer_ids) > 0 and answer_ids[0] == bos_id:
+            answer_ids = answer_ids[1:]
 
         input_ids = context_ids + answer_ids
         return dict(


### PR DESCRIPTION
If the `context_ids` ends with `eos_id` it will remove it, and similarly for the `answer_ids` if it starts with `bos_id` it will remove it. The training `input_ids` is created by concatenating the two (`context_ids` and `answer_ids`).