### PR TITLE
cp: PEFT Checkpointing (#95) to r0.1.0

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -174,6 +174,10 @@ jobs:
             runner: linux-amd64-gpu-rtxa6000-latest-2-nemo
           - script: L2_HF_Consolidated_Checkpoint
             runner: linux-amd64-gpu-rtxa6000-latest-2-nemo
+          - script: L2_HF_PEFT_Triton_Checkpoint
+            runner: linux-amd64-gpu-rtxa6000-latest-2-nemo
+          - script: L2_HF_PEFT_Checkpoint
+            runner: linux-amd64-gpu-rtxa6000-latest-2-nemo
     needs: [cicd-unit-tests]
     runs-on: ${{ matrix.runner }}
     name: ${{ matrix.script }}

--- a/nemo_automodel/_peft/lora.py
+++ b/nemo_automodel/_peft/lora.py
@@ -24,6 +24,14 @@ from nemo_automodel._peft.lora_kernel import lora_forward_wrapper, lora_da_dx_up
 from nemo_automodel._peft.module_matcher import ModuleMatcher
 HAS_BNB, bitsandbytes = safe_import("bitsandbytes")
 
+MODEL_TYPE_TO_PEFT_TASK_TYPE = {
+        "SequenceClassification": "SEQ_CLS",
+        "Seq2SeqLM": "SEQ_2_SEQ_LM", 
+        "CausalLM": "CAUSAL_LM",
+        "TokenClassification": "TOKEN_CLS",
+        "QuestionAnswering": "QUESTION_ANS",
+        "FeatureExtraction": "FEATURE_EXTRACTION",
+    }
 
 class LinearLoRA(nn.Linear):
     """
@@ -276,14 +284,25 @@ def apply_lora_to_linear_modules(
 
     target_modules accepts wildcard fragments, e.g. ["q_proj", "k_proj", ".*fc.*"].
     """
+    # To make our PeftConfig compatible with HF, we need to keep track of the
+    # final target modules, without the wildcard fragments.
+    final_target_modules = set()
+
     # Freeze base model parameters
     for w in model.parameters():
         w.requires_grad_(False)
+    
+    is_causal_lm = False
+    if hasattr(model, "config") and "CausalLM" in model.config.architectures[0]:
+        # for example, LlamaForCausalLM
+        is_causal_lm = True
 
-    matcher = ModuleMatcher(target_modules, exclude_modules, match_all_linear)
+    matcher = ModuleMatcher(target_modules, exclude_modules, match_all_linear, is_causal_lm)
     num_modules_matched = 0
     for name, module in list(model.named_modules()):
         if matcher.match(module, name):
+            final_target_modules.add(name.split(".")[-1])
+
             num_modules_matched += 1
             patch_linear_module(
                 module,
@@ -295,6 +314,21 @@ def apply_lora_to_linear_modules(
                 lora_dtype=lora_dtype,
                 use_triton=use_triton
            )
+
+    # finalize the peft config
+    model_task = model.config.architectures[0].split("For")[-1]
+    task_type = MODEL_TYPE_TO_PEFT_TASK_TYPE[model_task]
+    model._automodel_peft_config = {
+        "task_type": task_type,
+        "peft_type": "LORA",
+        "r": dim,
+        "lora_alpha": alpha,
+        "target_modules": list(final_target_modules),
+        "bias": "none",
+        "base_model_name_or_path": model.config.name_or_path,
+        "lora_dropout": dropout,
+    }
+    
     return num_modules_matched
 
 

--- a/nemo_automodel/_peft/module_matcher.py
+++ b/nemo_automodel/_peft/module_matcher.py
@@ -50,6 +50,9 @@ class ModuleMatcher:
             Target modules can also contain wildcards. For example, you can specify
                 target_modules=['*.layers.0.*.linear_qkv', '*.layers.1.*.linear_qkv'] to add LoRA to only linear_qkv
                 on the first two layers.
+        exclude_modules (List[str], optional): A list of module names to exclude from applying LoRA to.
+        match_all_linear (bool, optional): Whether to match all linear layers.
+        is_causal_lm (bool, optional): Whether the model is a causal language model.
     """
 
     target_modules: List[str] = field(
@@ -57,6 +60,7 @@ class ModuleMatcher:
     )
     exclude_modules: List[str] = field(default_factory=list)
     match_all_linear: bool = field(default=False)
+    is_causal_lm: bool = field(default=False)
 
     def __post_init__(self):
         """ input validation """
@@ -80,6 +84,10 @@ class ModuleMatcher:
         Return (pattern, full_name) if the module matches; otherwise None.
         """
         full_name = f"{prefix}.{name}" if prefix else name
+
+        if self.is_causal_lm:
+            if "lm_head" in full_name:
+                return False
 
         # 1. matching by layer type takes absolute precedence
         if self.match_all_linear and isinstance(m, nn.Linear):

--- a/nemo_automodel/checkpoint/checkpointing.py
+++ b/nemo_automodel/checkpoint/checkpointing.py
@@ -18,11 +18,20 @@ import os
 from typing import Any, Optional
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any, Optional
+import json
 
 import torch
 import torch.nn as nn
 import torch.distributed
 import torch.distributed.checkpoint as dcp
+import torch.nn as nn
+
+from transformers import PreTrainedModel
+from safetensors.torch import save_file
+from safetensors import safe_open
+
+from nemo_automodel.checkpoint._backports.filesystem import SerializationFormat
 from nemo_automodel.checkpoint._backports.hf_storage import (
     _HuggingFaceStorageWriter,
     _HuggingFaceStorageReader,
@@ -43,6 +52,7 @@ class CheckpointingConfig:
     model_cache_dir: str | Path
     model_repo_id: str
     save_consolidated: bool
+    is_peft: bool
 
     def __post_init__(self):
         # Convert a raw string such as "safetensors" into the right Enum
@@ -53,7 +63,7 @@ class CheckpointingConfig:
 
 
 def save_model(
-        model: nn.Module,
+        model: nn.Module | PreTrainedModel,
         weights_path: str,
         checkpoint_config: CheckpointingConfig,
 ):
@@ -86,6 +96,7 @@ def save_model(
         if (
             checkpoint_config.save_consolidated 
             and checkpoint_config.model_save_format == SerializationFormat.SAFETENSORS
+            and not checkpoint_config.is_peft
         ):
             os.makedirs(consolidated_model_path, exist_ok=True)
             # save the config.json file
@@ -96,9 +107,21 @@ def save_model(
     if torch.distributed.is_initialized():
         torch.distributed.barrier()
 
-    model_state = ModelState(model, checkpoint_config.model_save_format)
-    
-    if checkpoint_config.model_save_format == SerializationFormat.SAFETENSORS:
+    model_state = ModelState(model, checkpoint_config.model_save_format, checkpoint_config.is_peft)
+
+    if checkpoint_config.is_peft:
+        if not isinstance(model, PreTrainedModel):
+            raise ValueError("PEFT checkpointing is only supported for PreTrainedModel")
+        if not hasattr(model, "_automodel_peft_config"):
+            raise ValueError("PEFT checkpointing is only supported for models that have been trained with PEFT. "
+                             "Please use the `apply_lora_to_linear_modules` function to apply LoRA to the model.")
+        peft_config = model._automodel_peft_config
+        state_dict = model_state.state_dict()
+        if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
+            with open(os.path.join(model_path, "adapter_config.json"), "w") as f:
+                json.dump(peft_config, f, indent=2, sort_keys=True)
+            save_file(state_dict, os.path.join(model_path, "adapter_model.safetensors"))
+    elif checkpoint_config.model_save_format == SerializationFormat.SAFETENSORS:
         fqn_to_file_index_mapping = None
         if checkpoint_config.save_consolidated:
             # we first need to find the FQN -> .safetensors mapping
@@ -141,7 +164,7 @@ def save_model(
 
 
 def load_model(
-    model: torch.nn.Module,
+    model: torch.nn.Module | PreTrainedModel,
     weights_path: str,
     checkpoint_config: CheckpointingConfig,
 ):
@@ -158,9 +181,20 @@ def load_model(
     # Validate checkpoint directory
     if not os.path.exists(model_path):
         raise FileNotFoundError(f"Model path {model_path} does not exist")
+    model_state = ModelState(model, checkpoint_config.model_save_format, checkpoint_config.is_peft)
 
-    if checkpoint_config.model_save_format == SerializationFormat.SAFETENSORS:
-        model_state = ModelState(model, checkpoint_config.model_save_format)
+    if checkpoint_config.is_peft:
+        if not isinstance(model, PreTrainedModel):
+            raise ValueError("PEFT checkpointing is only supported for PreTrainedModel")
+        state_dict = model.state_dict()
+        if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
+            with safe_open(os.path.join(model_path, "adapter_model.safetensors"), framework="pt") as f:
+                state_dict = {k: f.get_tensor(k) for k in f.keys()}
+        # since we're loading the PEFT adapters on rank0, we don't need to call dcp.load
+        # the call below will broadcast from rank0 to all other ranks
+        model_state.load_state_dict(state_dict)
+
+    elif checkpoint_config.model_save_format == SerializationFormat.SAFETENSORS:
         storage_reader = _HuggingFaceStorageReader(path=model_path)
 
         dcp.load(
@@ -170,7 +204,6 @@ def load_model(
             planner=dcp.DefaultLoadPlanner(),
         )
     elif checkpoint_config.model_save_format == SerializationFormat.TORCH_SAVE:
-        model_state = ModelState(model, checkpoint_config.model_save_format)
         dcp.load(state_dict={"model": model_state}, checkpoint_id=model_path)
     else:
         raise ValueError(f"Unsupported model save format: {checkpoint_config.model_save_format}")

--- a/nemo_automodel/checkpoint/stateful_wrappers.py
+++ b/nemo_automodel/checkpoint/stateful_wrappers.py
@@ -16,6 +16,7 @@ from typing import Any, Optional
 
 import torch
 from torch.distributed.checkpoint.state_dict import (
+    StateDictOptions,
     get_model_state_dict,
     get_optimizer_state_dict,
     set_model_state_dict,
@@ -24,6 +25,26 @@ from torch.distributed.checkpoint.state_dict import (
 from torch.distributed.checkpoint.stateful import Stateful
 
 from nemo_automodel.checkpoint._backports.filesystem import SerializationFormat
+
+_PREFIX = "model."
+
+def _drop_outer_prefix(sd: dict[str, Any], prefix: str = _PREFIX) -> None:
+    """
+    Remove the *first* occurrence of `prefix` on every key in-place.
+    """
+    for k in list(sd.keys()):
+        if k.startswith(prefix):
+            sd[k[len(prefix):]] = sd.pop(k)
+
+
+def _add_outer_prefix(sd: dict[str, Any], prefix: str = _PREFIX) -> None:
+    """
+    Prepend `prefix` once to every key in-place (inverse of `_drop_outer_prefix`).
+    """
+    for k in list(sd.keys()):
+        if not k.startswith(prefix):
+            sd[prefix + k] = sd.pop(k)
+
 
 # modified from pytorch tutorial https://pytorch.org/tutorials/recipes/distributed_checkpoint_recipe.html
 class ModelState(Stateful):
@@ -36,10 +57,26 @@ class ModelState(Stateful):
         model: The PyTorch model to track.
     """
 
-    def __init__(self, model: torch.nn.Module, serialization_format: SerializationFormat):
+    def __init__(self, model: torch.nn.Module, serialization_format: SerializationFormat, is_peft: bool = False):
+        """
+        Initialize a ModelState instance for distributed checkpointing.
+
+        The constructor records the model reference, detects whether the model
+        ties its language-model head to the input embeddings, and stores the
+        desired serialization backend so that DCP can correctly save and restore
+        the model’s parameters and buffers.
+
+        Args:
+            model (torch.nn.Module): The PyTorch model whose state should be
+                captured during checkpointing.
+            serialization_format (SerializationFormat): Backend/format to use when
+                persisting the model state (e.g., torch, safetensors).
+            is_peft (bool): Whether the model is PEFT.
+        """
         self.model = model
         self.is_tied_lm_head = getattr(getattr(model, 'config', {}), 'tie_word_embeddings', False)
         self.serialization_format = serialization_format
+        self.is_peft = is_peft
 
     def state_dict(self) -> dict[str, Any]:
         """Get the model's state dictionary.
@@ -47,24 +84,29 @@ class ModelState(Stateful):
         Returns:
             dict: Dictionary containing the model's state dict with CPU offloading enabled.
         """
-        # this line automatically manages FSDP FQN's
-        model_state_dict = get_model_state_dict(self.model)
-
-        # This is a hack to fix the issue with the model state dict being saved with the "model.model." prefix.
-        # This is necessary when saving consolidated safetensors. This is because calling HF's
-        # .from_pretrained() requires the model to be saved with a single "model." prefix.
-        if self.serialization_format == SerializationFormat.SAFETENSORS:
-            keys_to_fix = [k for k in model_state_dict if k.startswith("model.")]
-            for old_key in keys_to_fix:
-                new_key = old_key[len("model."):]
-                # avoid overwriting if new_key already exists (shouldn't happen, but be safe)
-                if new_key not in model_state_dict:
-                    model_state_dict[new_key] = model_state_dict[old_key]
-                # delete the old, over-prefixed key
-                del model_state_dict[old_key]
-
+        options = None
+        if self.is_peft:
+            options = StateDictOptions(
+                full_state_dict=True,
+                cpu_offload=True,
+                ignore_frozen_params=True
+            )
+        model_state_dict = get_model_state_dict(self.model, options=options)
         if self.is_tied_lm_head:
-            model_state_dict.pop("lm_head.weight", None)
+            model_state_dict.pop("model.lm_head.weight", None)
+
+        if self.is_peft:
+            # HF PEFT models are saved with a "base.model." prefix. This is so they can be loaded
+            # correctly with the HF PEFT API.
+            _add_outer_prefix(model_state_dict, "base_model.model.")
+
+        elif self.serialization_format == SerializationFormat.SAFETENSORS:
+            # This is a hack to fix the issue with the model state dict being saved with the "model.model." prefix.
+            # This is necessary when saving consolidated safetensors. This is because calling HF's
+            # .from_pretrained() requires the model to be saved with a single "model." prefix.
+            # This is not needed for torch serialization.
+            _drop_outer_prefix(model_state_dict)
+
         return model_state_dict
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
@@ -73,29 +115,30 @@ class ModelState(Stateful):
         Args:
             state_dict (dict): State dictionary to load.
         """
-        # Undo the prefix-stripping that happened at save-time: DCP removes the
-        # container name ("model") when it dispatches the dict to this
-        # ModelState, so every key now lacks the leading "model." segment that
-        # HuggingFace modules normally carry.  Re-add it so that
-        # set_model_state_dict can match parameters correctly.
-        if self.serialization_format == SerializationFormat.SAFETENSORS:
-            keys_to_fix = [k for k in state_dict if not k.startswith("model.") and k != "lm_head.weight"]
-            for old_key in keys_to_fix:
-                new_key = f"model.{old_key}"
-                if new_key not in state_dict:
-                    state_dict[new_key] = state_dict[old_key]
-                del state_dict[old_key]
+        options = None
+        if self.is_peft:
+            _drop_outer_prefix(state_dict, "base_model.model.")
+            options = StateDictOptions(strict=False, broadcast_from_rank0=True, full_state_dict=True)
+        elif self.serialization_format == SerializationFormat.SAFETENSORS:
+            # Undo the prefix-stripping that happened at save-time: DCP removes the
+            # container name ("model") when it dispatches the dict to this
+            # ModelState, so every key now lacks the leading "model." segment that
+            # HuggingFace modules normally carry.  Re-add it so that
+            # set_model_state_dict can match parameters correctly. This is not needed
+            # for torch serialization.
+            _add_outer_prefix(state_dict)
 
         # If we intentionally skipped saving "lm_head.weight" (tied embeddings)
         # PyTorch will complain during load even with strict=False.
         # To be fully compatible we inject a reference tensor so the key exists.
-        if self.is_tied_lm_head and "lm_head.weight" not in state_dict:
+        if self.is_tied_lm_head and "lm_head.weight" not in state_dict and not self.is_peft:
             # weight tying guarantees this is identical to the embedding weight
             state_dict["lm_head.weight"] = self.model.lm_head.weight.detach()
 
         set_model_state_dict(
             self.model,
             state_dict,
+            options=options,
         )
 
 

--- a/recipes/llm/finetune.py
+++ b/recipes/llm/finetune.py
@@ -82,9 +82,8 @@ def build_model(device, cfg_model, use_hf_fa2, cfg_peft, model_wrapper, seed) ->
             return model.to(device)
 
 
-def build_checkpoint_config(cfg_ckpt, cache_dir, model_repo_id):
-    """
-    Build a checkpoint configuration.
+def build_checkpoint_config(cfg_ckpt, cache_dir, model_repo_id, is_peft):
+    """Build a checkpoint configuration.
     """
     from transformers.utils import TRANSFORMERS_CACHE
 
@@ -95,6 +94,7 @@ def build_checkpoint_config(cfg_ckpt, cache_dir, model_repo_id):
         model_repo_id=model_repo_id,
         model_cache_dir=cache_dir if cache_dir is not None else TRANSFORMERS_CACHE,
         save_consolidated=False,
+        is_peft=is_peft,
     )
     if cfg_ckpt is not None:
         cfg_ckpt = cfg_ckpt.to_dict()
@@ -337,6 +337,7 @@ class FinetuneRecipeForNextTokenPrediction(BaseRecipe):
             self.cfg.get('checkpoint', None),
             self.cfg.get('model.cache_dir', None),
             self.cfg.model.pretrained_model_name_or_path,
+            True if self.cfg.get('peft', None) else False,
         )
 
         # Set up the stateful random number generator

--- a/recipes/llm/llama_3_2_1b_hellaswag_peft.yaml
+++ b/recipes/llm/llama_3_2_1b_hellaswag_peft.yaml
@@ -1,6 +1,6 @@
 step_scheduler:
   grad_acc_steps: 4
-  ckpt_every_steps: 1000
+  ckpt_every_steps: 20
   val_every_steps: 10  # will run every x number of gradient steps
   num_epochs: 1
 
@@ -17,6 +17,12 @@ model:
   _target_: transformers.AutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: meta-llama/Llama-3.2-1B
 
+checkpoint:
+  enabled: true
+  checkpoint_dir: checkpoints/
+  model_save_format: torch_save # torch_save or safetensors
+  save_consolidated: false # saves the model in a consolidated safetensors format. Requires model_save_format to be safetensors.
+
 peft:
   peft_fn: nemo_automodel._peft.lora.apply_lora_to_linear_modules
   match_all_linear: True
@@ -28,9 +34,9 @@ peft:
 
 distributed:
   _target_: nemo_automodel.distributed.fsdp2.FSDP2Manager
-  dp_size: 2
-  tp_size: 2
-  cp_size: 2
+  dp_size: none
+  tp_size: 1
+  cp_size: 1
   sequence_parallel: false
 
 loss_fn: nemo_automodel.loss.masked_ce.masked_cross_entropy
@@ -39,6 +45,11 @@ dataset:
   _target_: nemo_automodel.datasets.llm.hellaswag.HellaSwag
   path_or_dataset: rowan/hellaswag
   split: train
+
+packed_sequence:
+  # Set packed_sequence_size > 0 to run with packed sequences
+  packed_sequence_size: 0
+  split_across_pack: False
 
 dataloader:
   _target_: torchdata.stateful_dataloader.StatefulDataLoader

--- a/tests/functional_tests/L2_HF_PEFT_Checkpoint.sh
+++ b/tests/functional_tests/L2_HF_PEFT_Checkpoint.sh
@@ -1,0 +1,41 @@
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/bin/bash
+set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
+
+export PYTHONPATH=${PYTHONPATH:-}:$(pwd)
+export CUDA_VISIBLE_DEVICES="0,1"
+
+TRANSFORMERS_OFFLINE=1 python -m torch.distributed.run --nproc_per_node=2 --nnodes=1 -m coverage run --data-file=/workspace/.coverage --source=/workspace --parallel-mode \
+-m pytest tests/functional_tests/checkpoint/test_peft.py \
+    --config recipes/llm/llama_3_2_1b_squad.yaml \
+    --model.pretrained_model_name_or_path /home/TestData/akoumparouli/hf_mixtral_2l/ \
+    --step_scheduler.max_steps 10 \
+    --step_scheduler.grad_acc_steps 4 \
+    --dataset.tokenizer.pretrained_model_name_or_path /home/TestData/akoumparouli/hf_mixtral_2l/ \
+    --validation_dataset.tokenizer.pretrained_model_name_or_path /home/TestData/akoumparouli/hf_mixtral_2l/ \
+    --dataset.dataset_name /home/TestData/lite/hf_cache/squad/ \
+    --validation_dataset.dataset_name /home/TestData/lite/hf_cache/squad/ \
+    --dataset.limit_dataset_samples 1000 \
+    --step_scheduler.ckpt_every_steps 10 \
+    --checkpoint.enabled true \
+    --checkpoint.checkpoint_dir checkpoints/ \
+    --dataloader.batch_size 8 \
+    --peft.match_all_linear true \
+    --peft.dim 8 \
+    --peft.alpha 32 \
+    --peft.use_triton false \
+    --peft.peft_fn nemo_automodel._peft.lora.apply_lora_to_linear_modules
+coverage combine

--- a/tests/functional_tests/L2_HF_PEFT_Triton_Checkpoint.sh
+++ b/tests/functional_tests/L2_HF_PEFT_Triton_Checkpoint.sh
@@ -1,0 +1,41 @@
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/bin/bash
+set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
+
+export PYTHONPATH=${PYTHONPATH:-}:$(pwd)
+export CUDA_VISIBLE_DEVICES="0,1"
+
+TRANSFORMERS_OFFLINE=1 python -m torch.distributed.run --nproc_per_node=2 --nnodes=1 -m coverage run --data-file=/workspace/.coverage --source=/workspace --parallel-mode \
+-m pytest tests/functional_tests/checkpoint/test_peft.py \
+    --config recipes/llm/llama_3_2_1b_squad.yaml \
+    --model.pretrained_model_name_or_path /home/TestData/akoumparouli/hf_mixtral_2l/ \
+    --step_scheduler.max_steps 10 \
+    --step_scheduler.grad_acc_steps 4 \
+    --dataset.tokenizer.pretrained_model_name_or_path /home/TestData/akoumparouli/hf_mixtral_2l/ \
+    --validation_dataset.tokenizer.pretrained_model_name_or_path /home/TestData/akoumparouli/hf_mixtral_2l/ \
+    --dataset.dataset_name /home/TestData/lite/hf_cache/squad/ \
+    --validation_dataset.dataset_name /home/TestData/lite/hf_cache/squad/ \
+    --dataset.limit_dataset_samples 1000 \
+    --step_scheduler.ckpt_every_steps 10 \
+    --checkpoint.enabled true \
+    --checkpoint.checkpoint_dir checkpoints/ \
+    --dataloader.batch_size 8 \
+    --peft.match_all_linear true \
+    --peft.dim 8 \
+    --peft.alpha 32 \
+    --peft.use_triton true \
+    --peft.peft_fn nemo_automodel._peft.lora.apply_lora_to_linear_modules
+coverage combine

--- a/tests/functional_tests/checkpoint/test_peft.py
+++ b/tests/functional_tests/checkpoint/test_peft.py
@@ -1,0 +1,768 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=line-too-long
+"""Tests for PEFT checkpointing."""
+
+import os
+from pathlib import Path
+import json
+
+from recipes.llm.finetune import FinetuneRecipeForNextTokenPrediction
+from nemo_automodel.config.cli import parse_args_and_load_config
+from nemo_automodel.checkpoint.stateful_wrappers import ModelState, OptimizerState
+from nemo_automodel.checkpoint._backports.hf_storage import _HuggingFaceStorageReader
+import torch
+import torch.distributed.tensor
+import torch.distributed.checkpoint as dcp
+from safetensors import safe_open
+
+def load_dcp(ckpt_dir: Path | str) -> dict[str, torch.Tensor]:
+    """
+    Loads a DCP checkpoint in a state dictionary from a directory.
+    Args:
+        ckpt_dir: The directory containing the DCP checkpoint.
+    Returns:
+        A state dictionary containing the checkpoint.
+    """
+    if not isinstance(ckpt_dir, Path):
+        ckpt_dir = Path(ckpt_dir)
+    if "model" in ckpt_dir.name:
+        fs_reader = _HuggingFaceStorageReader(ckpt_dir)
+    else:
+        fs_reader = dcp.FileSystemReader(ckpt_dir)
+    metadata = fs_reader.read_metadata()
+
+    state_dict = {
+        k: torch.empty(tp.size, dtype=tp.properties.dtype)
+        for k, tp in metadata.state_dict_metadata.items()
+        if type(tp).__name__ == 'TensorStorageMetadata'
+    }
+
+    dcp.load(
+        state_dict,
+        storage_reader=fs_reader,
+    )
+    return state_dict
+
+def load_safetensors(ckpt_dir: Path | str) -> dict[str, torch.Tensor]:
+    """
+    Loads a safetensors checkpoint in a state dictionary from a directory.
+    """
+    state_dict = {}
+    if not isinstance(ckpt_dir, Path):
+        ckpt_dir = Path(ckpt_dir)
+    with safe_open(ckpt_dir, framework="pt", device="cpu") as f:
+        for key in f.keys():
+            state_dict[key] = f.get_tensor(key)
+    return state_dict
+
+def to_cpu(
+        state_dict: dict[str, torch.Tensor | dict[str, torch.Tensor]],
+    ) -> dict[str, torch.Tensor | dict[str, torch.Tensor]]:
+    """
+    Converts a state dictionary to CPU.
+    """
+    return {k: v.cpu() if isinstance(v, torch.Tensor) else to_cpu(v) for k, v in state_dict.items()}
+
+def test_hf_peft_checkpoint():
+    """
+    Tests HF PEFT checkpoint
+    """
+    expected_model_keys = {
+        "base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.self_attn.q_proj.lora_B.weight": ([512, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.self_attn.k_proj.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.self_attn.k_proj.lora_B.weight": ([128, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.self_attn.v_proj.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.self_attn.v_proj.lora_B.weight": ([128, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.self_attn.o_proj.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.self_attn.o_proj.lora_B.weight": ([512, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.gate.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.gate.lora_B.weight": ([8, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.0.w1.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.0.w1.lora_B.weight": ([448, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.0.w2.lora_A.weight": ([8, 448], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.0.w2.lora_B.weight": ([512, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.0.w3.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.0.w3.lora_B.weight": ([448, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.1.w1.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.1.w1.lora_B.weight": ([448, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.1.w2.lora_A.weight": ([8, 448], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.1.w2.lora_B.weight": ([512, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.1.w3.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.1.w3.lora_B.weight": ([448, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.2.w1.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.2.w1.lora_B.weight": ([448, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.2.w2.lora_A.weight": ([8, 448], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.2.w2.lora_B.weight": ([512, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.2.w3.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.2.w3.lora_B.weight": ([448, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.3.w1.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.3.w1.lora_B.weight": ([448, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.3.w2.lora_A.weight": ([8, 448], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.3.w2.lora_B.weight": ([512, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.3.w3.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.3.w3.lora_B.weight": ([448, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.4.w1.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.4.w1.lora_B.weight": ([448, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.4.w2.lora_A.weight": ([8, 448], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.4.w2.lora_B.weight": ([512, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.4.w3.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.4.w3.lora_B.weight": ([448, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.5.w1.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.5.w1.lora_B.weight": ([448, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.5.w2.lora_A.weight": ([8, 448], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.5.w2.lora_B.weight": ([512, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.5.w3.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.5.w3.lora_B.weight": ([448, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.6.w1.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.6.w1.lora_B.weight": ([448, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.6.w2.lora_A.weight": ([8, 448], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.6.w2.lora_B.weight": ([512, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.6.w3.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.6.w3.lora_B.weight": ([448, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.7.w1.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.7.w1.lora_B.weight": ([448, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.7.w2.lora_A.weight": ([8, 448], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.7.w2.lora_B.weight": ([512, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.7.w3.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.0.block_sparse_moe.experts.7.w3.lora_B.weight": ([448, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.self_attn.q_proj.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.self_attn.q_proj.lora_B.weight": ([512, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.self_attn.k_proj.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.self_attn.k_proj.lora_B.weight": ([128, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.self_attn.v_proj.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.self_attn.v_proj.lora_B.weight": ([128, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.self_attn.o_proj.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.self_attn.o_proj.lora_B.weight": ([512, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.gate.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.gate.lora_B.weight": ([8, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.0.w1.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.0.w1.lora_B.weight": ([448, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.0.w2.lora_A.weight": ([8, 448], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.0.w2.lora_B.weight": ([512, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.0.w3.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.0.w3.lora_B.weight": ([448, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.1.w1.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.1.w1.lora_B.weight": ([448, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.1.w2.lora_A.weight": ([8, 448], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.1.w2.lora_B.weight": ([512, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.1.w3.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.1.w3.lora_B.weight": ([448, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.2.w1.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.2.w1.lora_B.weight": ([448, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.2.w2.lora_A.weight": ([8, 448], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.2.w2.lora_B.weight": ([512, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.2.w3.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.2.w3.lora_B.weight": ([448, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.3.w1.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.3.w1.lora_B.weight": ([448, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.3.w2.lora_A.weight": ([8, 448], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.3.w2.lora_B.weight": ([512, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.3.w3.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.3.w3.lora_B.weight": ([448, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.4.w1.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.4.w1.lora_B.weight": ([448, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.4.w2.lora_A.weight": ([8, 448], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.4.w2.lora_B.weight": ([512, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.4.w3.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.4.w3.lora_B.weight": ([448, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.5.w1.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.5.w1.lora_B.weight": ([448, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.5.w2.lora_A.weight": ([8, 448], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.5.w2.lora_B.weight": ([512, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.5.w3.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.5.w3.lora_B.weight": ([448, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.6.w1.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.6.w1.lora_B.weight": ([448, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.6.w2.lora_A.weight": ([8, 448], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.6.w2.lora_B.weight": ([512, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.6.w3.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.6.w3.lora_B.weight": ([448, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.7.w1.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.7.w1.lora_B.weight": ([448, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.7.w2.lora_A.weight": ([8, 448], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.7.w2.lora_B.weight": ([512, 8], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.7.w3.lora_A.weight": ([8, 512], torch.bfloat16, "cpu"),
+        "base_model.model.model.layers.1.block_sparse_moe.experts.7.w3.lora_B.weight": ([448, 8], torch.bfloat16, "cpu"),
+    }
+    expected_optim_keys = {
+        "optim.optim.state.model.layers.0.self_attn.q_proj.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.self_attn.q_proj.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.self_attn.q_proj.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.self_attn.q_proj.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.self_attn.q_proj.lora_B.weight.exp_avg": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.self_attn.q_proj.lora_B.weight.exp_avg_sq": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.self_attn.k_proj.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.self_attn.k_proj.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.self_attn.k_proj.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.self_attn.k_proj.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.self_attn.k_proj.lora_B.weight.exp_avg": ([64, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.self_attn.k_proj.lora_B.weight.exp_avg_sq": ([64, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.self_attn.v_proj.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.self_attn.v_proj.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.self_attn.v_proj.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.self_attn.v_proj.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.self_attn.v_proj.lora_B.weight.exp_avg": ([64, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.self_attn.v_proj.lora_B.weight.exp_avg_sq": ([64, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.self_attn.o_proj.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.self_attn.o_proj.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.self_attn.o_proj.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.self_attn.o_proj.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.self_attn.o_proj.lora_B.weight.exp_avg": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.self_attn.o_proj.lora_B.weight.exp_avg_sq": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.gate.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.gate.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.gate.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.gate.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.gate.lora_B.weight.exp_avg": ([4, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.gate.lora_B.weight.exp_avg_sq": ([4, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.0.w1.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.0.w1.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.0.w1.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.0.w1.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.0.w1.lora_B.weight.exp_avg": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.0.w1.lora_B.weight.exp_avg_sq": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.0.w2.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.0.w2.lora_A.weight.exp_avg": ([4, 448], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.0.w2.lora_A.weight.exp_avg_sq": ([4, 448], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.0.w2.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.0.w2.lora_B.weight.exp_avg": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.0.w2.lora_B.weight.exp_avg_sq": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.0.w3.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.0.w3.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.0.w3.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.0.w3.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.0.w3.lora_B.weight.exp_avg": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.0.w3.lora_B.weight.exp_avg_sq": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.1.w1.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.1.w1.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.1.w1.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.1.w1.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.1.w1.lora_B.weight.exp_avg": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.1.w1.lora_B.weight.exp_avg_sq": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.1.w2.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.1.w2.lora_A.weight.exp_avg": ([4, 448], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.1.w2.lora_A.weight.exp_avg_sq": ([4, 448], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.1.w2.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.1.w2.lora_B.weight.exp_avg": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.1.w2.lora_B.weight.exp_avg_sq": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.1.w3.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.1.w3.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.1.w3.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.1.w3.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.1.w3.lora_B.weight.exp_avg": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.1.w3.lora_B.weight.exp_avg_sq": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.2.w1.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.2.w1.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.2.w1.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.2.w1.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.2.w1.lora_B.weight.exp_avg": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.2.w1.lora_B.weight.exp_avg_sq": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.2.w2.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.2.w2.lora_A.weight.exp_avg": ([4, 448], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.2.w2.lora_A.weight.exp_avg_sq": ([4, 448], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.2.w2.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.2.w2.lora_B.weight.exp_avg": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.2.w2.lora_B.weight.exp_avg_sq": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.2.w3.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.2.w3.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.2.w3.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.2.w3.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.2.w3.lora_B.weight.exp_avg": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.2.w3.lora_B.weight.exp_avg_sq": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.3.w1.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.3.w1.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.3.w1.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.3.w1.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.3.w1.lora_B.weight.exp_avg": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.3.w1.lora_B.weight.exp_avg_sq": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.3.w2.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.3.w2.lora_A.weight.exp_avg": ([4, 448], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.3.w2.lora_A.weight.exp_avg_sq": ([4, 448], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.3.w2.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.3.w2.lora_B.weight.exp_avg": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.3.w2.lora_B.weight.exp_avg_sq": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.3.w3.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.3.w3.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.3.w3.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.3.w3.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.3.w3.lora_B.weight.exp_avg": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.3.w3.lora_B.weight.exp_avg_sq": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.4.w1.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.4.w1.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.4.w1.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.4.w1.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.4.w1.lora_B.weight.exp_avg": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.4.w1.lora_B.weight.exp_avg_sq": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.4.w2.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.4.w2.lora_A.weight.exp_avg": ([4, 448], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.4.w2.lora_A.weight.exp_avg_sq": ([4, 448], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.4.w2.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.4.w2.lora_B.weight.exp_avg": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.4.w2.lora_B.weight.exp_avg_sq": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.4.w3.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.4.w3.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.4.w3.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.4.w3.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.4.w3.lora_B.weight.exp_avg": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.4.w3.lora_B.weight.exp_avg_sq": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.5.w1.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.5.w1.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.5.w1.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.5.w1.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.5.w1.lora_B.weight.exp_avg": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.5.w1.lora_B.weight.exp_avg_sq": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.5.w2.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.5.w2.lora_A.weight.exp_avg": ([4, 448], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.5.w2.lora_A.weight.exp_avg_sq": ([4, 448], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.5.w2.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.5.w2.lora_B.weight.exp_avg": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.5.w2.lora_B.weight.exp_avg_sq": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.5.w3.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.5.w3.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.5.w3.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.5.w3.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.5.w3.lora_B.weight.exp_avg": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.5.w3.lora_B.weight.exp_avg_sq": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.6.w1.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.6.w1.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.6.w1.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.6.w1.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.6.w1.lora_B.weight.exp_avg": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.6.w1.lora_B.weight.exp_avg_sq": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.6.w2.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.6.w2.lora_A.weight.exp_avg": ([4, 448], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.6.w2.lora_A.weight.exp_avg_sq": ([4, 448], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.6.w2.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.6.w2.lora_B.weight.exp_avg": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.6.w2.lora_B.weight.exp_avg_sq": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.6.w3.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.6.w3.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.6.w3.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.6.w3.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.6.w3.lora_B.weight.exp_avg": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.6.w3.lora_B.weight.exp_avg_sq": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.7.w1.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.7.w1.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.7.w1.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.7.w1.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.7.w1.lora_B.weight.exp_avg": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.7.w1.lora_B.weight.exp_avg_sq": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.7.w2.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.7.w2.lora_A.weight.exp_avg": ([4, 448], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.7.w2.lora_A.weight.exp_avg_sq": ([4, 448], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.7.w2.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.7.w2.lora_B.weight.exp_avg": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.7.w2.lora_B.weight.exp_avg_sq": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.7.w3.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.7.w3.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.7.w3.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.7.w3.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.7.w3.lora_B.weight.exp_avg": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.0.block_sparse_moe.experts.7.w3.lora_B.weight.exp_avg_sq": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.self_attn.q_proj.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.self_attn.q_proj.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.self_attn.q_proj.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.self_attn.q_proj.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.self_attn.q_proj.lora_B.weight.exp_avg": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.self_attn.q_proj.lora_B.weight.exp_avg_sq": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.self_attn.k_proj.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.self_attn.k_proj.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.self_attn.k_proj.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.self_attn.k_proj.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.self_attn.k_proj.lora_B.weight.exp_avg": ([64, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.self_attn.k_proj.lora_B.weight.exp_avg_sq": ([64, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.self_attn.v_proj.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.self_attn.v_proj.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.self_attn.v_proj.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.self_attn.v_proj.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.self_attn.v_proj.lora_B.weight.exp_avg": ([64, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.self_attn.v_proj.lora_B.weight.exp_avg_sq": ([64, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.self_attn.o_proj.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.self_attn.o_proj.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.self_attn.o_proj.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.self_attn.o_proj.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.self_attn.o_proj.lora_B.weight.exp_avg": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.self_attn.o_proj.lora_B.weight.exp_avg_sq": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.gate.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.gate.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.gate.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.gate.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.gate.lora_B.weight.exp_avg": ([4, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.gate.lora_B.weight.exp_avg_sq": ([4, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.0.w1.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.0.w1.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.0.w1.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.0.w1.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.0.w1.lora_B.weight.exp_avg": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.0.w1.lora_B.weight.exp_avg_sq": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.0.w2.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.0.w2.lora_A.weight.exp_avg": ([4, 448], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.0.w2.lora_A.weight.exp_avg_sq": ([4, 448], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.0.w2.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.0.w2.lora_B.weight.exp_avg": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.0.w2.lora_B.weight.exp_avg_sq": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.0.w3.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.0.w3.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.0.w3.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.0.w3.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.0.w3.lora_B.weight.exp_avg": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.0.w3.lora_B.weight.exp_avg_sq": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.1.w1.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.1.w1.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.1.w1.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.1.w1.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.1.w1.lora_B.weight.exp_avg": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.1.w1.lora_B.weight.exp_avg_sq": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.1.w2.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.1.w2.lora_A.weight.exp_avg": ([4, 448], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.1.w2.lora_A.weight.exp_avg_sq": ([4, 448], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.1.w2.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.1.w2.lora_B.weight.exp_avg": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.1.w2.lora_B.weight.exp_avg_sq": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.1.w3.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.1.w3.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.1.w3.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.1.w3.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.1.w3.lora_B.weight.exp_avg": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.1.w3.lora_B.weight.exp_avg_sq": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.2.w1.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.2.w1.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.2.w1.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.2.w1.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.2.w1.lora_B.weight.exp_avg": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.2.w1.lora_B.weight.exp_avg_sq": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.2.w2.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.2.w2.lora_A.weight.exp_avg": ([4, 448], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.2.w2.lora_A.weight.exp_avg_sq": ([4, 448], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.2.w2.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.2.w2.lora_B.weight.exp_avg": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.2.w2.lora_B.weight.exp_avg_sq": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.2.w3.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.2.w3.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.2.w3.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.2.w3.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.2.w3.lora_B.weight.exp_avg": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.2.w3.lora_B.weight.exp_avg_sq": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.3.w1.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.3.w1.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.3.w1.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.3.w1.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.3.w1.lora_B.weight.exp_avg": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.3.w1.lora_B.weight.exp_avg_sq": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.3.w2.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.3.w2.lora_A.weight.exp_avg": ([4, 448], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.3.w2.lora_A.weight.exp_avg_sq": ([4, 448], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.3.w2.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.3.w2.lora_B.weight.exp_avg": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.3.w2.lora_B.weight.exp_avg_sq": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.3.w3.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.3.w3.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.3.w3.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.3.w3.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.3.w3.lora_B.weight.exp_avg": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.3.w3.lora_B.weight.exp_avg_sq": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.4.w1.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.4.w1.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.4.w1.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.4.w1.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.4.w1.lora_B.weight.exp_avg": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.4.w1.lora_B.weight.exp_avg_sq": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.4.w2.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.4.w2.lora_A.weight.exp_avg": ([4, 448], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.4.w2.lora_A.weight.exp_avg_sq": ([4, 448], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.4.w2.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.4.w2.lora_B.weight.exp_avg": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.4.w2.lora_B.weight.exp_avg_sq": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.4.w3.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.4.w3.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.4.w3.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.4.w3.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.4.w3.lora_B.weight.exp_avg": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.4.w3.lora_B.weight.exp_avg_sq": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.5.w1.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.5.w1.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.5.w1.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.5.w1.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.5.w1.lora_B.weight.exp_avg": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.5.w1.lora_B.weight.exp_avg_sq": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.5.w2.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.5.w2.lora_A.weight.exp_avg": ([4, 448], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.5.w2.lora_A.weight.exp_avg_sq": ([4, 448], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.5.w2.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.5.w2.lora_B.weight.exp_avg": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.5.w2.lora_B.weight.exp_avg_sq": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.5.w3.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.5.w3.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.5.w3.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.5.w3.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.5.w3.lora_B.weight.exp_avg": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.5.w3.lora_B.weight.exp_avg_sq": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.6.w1.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.6.w1.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.6.w1.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.6.w1.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.6.w1.lora_B.weight.exp_avg": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.6.w1.lora_B.weight.exp_avg_sq": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.6.w2.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.6.w2.lora_A.weight.exp_avg": ([4, 448], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.6.w2.lora_A.weight.exp_avg_sq": ([4, 448], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.6.w2.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.6.w2.lora_B.weight.exp_avg": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.6.w2.lora_B.weight.exp_avg_sq": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.6.w3.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.6.w3.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.6.w3.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.6.w3.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.6.w3.lora_B.weight.exp_avg": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.6.w3.lora_B.weight.exp_avg_sq": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.7.w1.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.7.w1.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.7.w1.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.7.w1.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.7.w1.lora_B.weight.exp_avg": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.7.w1.lora_B.weight.exp_avg_sq": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.7.w2.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.7.w2.lora_A.weight.exp_avg": ([4, 448], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.7.w2.lora_A.weight.exp_avg_sq": ([4, 448], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.7.w2.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.7.w2.lora_B.weight.exp_avg": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.7.w2.lora_B.weight.exp_avg_sq": ([256, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.7.w3.lora_A.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.7.w3.lora_A.weight.exp_avg": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.7.w3.lora_A.weight.exp_avg_sq": ([4, 512], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.7.w3.lora_B.weight.step": ([], torch.float32, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.7.w3.lora_B.weight.exp_avg": ([224, 8], torch.bfloat16, "cpu"),
+        "optim.optim.state.model.layers.1.block_sparse_moe.experts.7.w3.lora_B.weight.exp_avg_sq": ([224, 8], torch.bfloat16, "cpu"),
+    }
+    expected_config = {
+        "base_model_name_or_path": "/home/TestData/akoumparouli/hf_mixtral_2l/",
+        "bias": "none",
+        "lora_alpha": 32,
+        "lora_dropout": 0.0,
+        "peft_type": "LORA",
+        "r": 8,
+        "target_modules": [
+            "q_proj",
+            "gate",
+            "w3",
+            "o_proj",
+            "w1",
+            "v_proj",
+            "w2",
+            "k_proj"
+        ],
+        "task_type": "CAUSAL_LM"
+}
+
+    script_path = Path(__file__).parent.resolve()
+    cfg = parse_args_and_load_config(script_path / "llama_3_2_1b_hellaswag_peft.yaml")
+    trainer = FinetuneRecipeForNextTokenPrediction(cfg)
+    trainer.setup()
+    trainer.run_train_validation_loop()
+
+    # checkpoint is saved at this point
+    # first extract the in-memory checkpoint
+    model_state_dict = ModelState(
+        trainer.model,
+        trainer.checkpoint_config.model_save_format,
+        trainer.checkpoint_config.is_peft,
+    ).state_dict()
+    optimizer_state_dict = to_cpu(OptimizerState(
+        trainer.model,
+        trainer.optimizer,
+        trainer.step_scheduler,
+    ).state_dict()["optim"]["state"])
+
+    # assert the correct paths exist
+    output_files = [
+        "model",
+        "optim",
+        "step_scheduler.pt",
+        "dataloader.pt",
+        "model/adapter_model.safetensors",
+        "model/adapter_config.json",
+        "optim/__0_0.distcp",
+        "optim/__1_0.distcp",
+        "optim/.metadata",
+        "step_scheduler.pt",
+    ]
+
+    for file in output_files:
+        path = Path(trainer.checkpoint_config.checkpoint_dir) / "epoch_0_step_10" / file
+        assert path.exists(), f"Expected {path} to exist"
+        if "." in file:
+            assert path.is_file(), f"Expected {path} to be a file"
+        else:
+            assert path.is_dir(), f"Expected {path} to be a directory"
+        assert os.access(path, os.R_OK), f"Expected {path} to be readable"
+        assert path.stat().st_size > 0, f"Expected {path} to be non-empty"
+    restored_optim_dict = load_dcp(
+        Path(trainer.checkpoint_config.checkpoint_dir) / "epoch_0_step_10" / "optim",
+    )
+    restored_model_dict_consolidated = load_safetensors(
+        Path(trainer.checkpoint_config.checkpoint_dir) / "epoch_0_step_10" / "model" / "adapter_model.safetensors",
+    )
+    restored_config = json.load(
+        open(Path(trainer.checkpoint_config.checkpoint_dir) / "epoch_0_step_10" / "model" / "adapter_config.json"),
+    )
+
+    assert len(restored_config) == len(expected_config), f"Mismatch between in-memory and on-disk config. Expected length {len(expected_config)} but got {len(restored_config)}"
+
+    for k, v in expected_config.items():
+        assert k in restored_config, "Key {} not found in restored config".format(k)
+        error_msg = "Mismatch between in-memory and on-disk config. Expected {{}} but got {{}}"
+        if isinstance(v, list):
+            assert sorted(restored_config[k]) == sorted(v), error_msg.format(sorted(v), sorted(restored_config[k]))
+        else:
+            assert restored_config[k] == v, error_msg.format(v, restored_config[k])
+
+    # at save time, the model is saved in a dictionary formatted as:
+    # {
+    #     "model": ModelState(...)
+    # }
+    # because of this, DCP will flatten the model state dictionary to:
+    # {
+    #     "model.model.embed_tokens.weight": ...
+    # }
+    # so we need to remove the first occurrence of "model." from the keys
+
+    # similarly, the optimizer states are saved in a dictionary formatted as:
+    # {
+    #     "optim": OptimizerState(...),
+    #     "step_scheduler": StepSchedulerState(...)
+    # }
+    # and in addition, the optimizer state is saved in a dictionary formatted as:
+    # {
+    #     "optim": {
+    #         "state": {
+    #             "model.layers.0.self_attn.q_proj.weight":
+    #                 "step": ...,
+    #                 "exp_avg": ...
+    #                 "exp_avg_sq": ...
+    #         }
+    #     }
+    # }
+    # because of this, DCP will flatten the optimizer state dictionary to:
+    # {
+    #     "optim.optim.state.model.layers.0.self_attn.q_proj.weight.step": ...
+    # }
+    # so we flatten the in-memory optimizer state dictionary to match the on-disk view
+    flattened_optim_dict = _flatten(optimizer_state_dict, parent_key="optim.optim.state")
+
+    # ---------------------------------------------------------------------
+    # Compare the flattened in-memory model state with the on-disk view
+    # ---------------------------------------------------------------------
+    assert set(expected_model_keys.keys()) == set(restored_model_dict_consolidated.keys()), (
+        "Mismatch between in-memory and on-disk consolidated model keys."
+    )
+
+    # ---------------------------------------------------------------------
+    # Compare the flattened in-memory optimizer state with the on-disk view
+    # ---------------------------------------------------------------------
+    assert set(expected_optim_keys.keys()) == set(restored_optim_dict.keys()), (
+        "Mismatch between in-memory and on-disk optimizer keys."
+    )
+
+    # Compare the values, shapes, dtype, and device of the in-memory and on-disk consolidated model state
+    if torch.distributed.get_rank() != 0:
+        assert len(model_state_dict) == 0, (
+            "Model state dict should be empty on non-rank-0 processes"
+        )
+
+    if torch.distributed.get_rank() == 0:
+        for k in expected_model_keys.keys():
+            v = model_state_dict[k].cpu()
+            assert k in restored_model_dict_consolidated, f"Key {k} not found in restored model state"
+            assert isinstance(
+                restored_model_dict_consolidated[k], torch.Tensor,
+            ), f"Value for key {k} is not a tensor"
+
+            # Get expected shape, dtype, device from expected_model_keys
+            expected_shape, expected_dtype, expected_device = expected_model_keys[k]
+
+            full_shard = restored_model_dict_consolidated[k]
+
+            assert list(full_shard.shape) == expected_shape, (
+                f"Shape mismatch for key {k}. "
+                f"Expected shape {expected_shape} but got {full_shard.shape}"
+            )
+            assert full_shard.dtype == expected_dtype, (
+                f"Dtype mismatch for key {k}. "
+                f"Expected dtype {expected_dtype} but got {full_shard.dtype}"
+            )
+            assert str(full_shard.device) == expected_device, (
+                f"Device mismatch for key {k}. "
+                f"Expected device {expected_device} but got {full_shard.device}"
+            )
+            assert torch.allclose(v, full_shard), (
+                f"Value mismatch for key {k}. "
+                f"Tensors are not numerically close"
+            )
+
+    # Compare the values, shapes, dtype, and device of the in-memory and on-disk optimizer state
+    for k, v in flattened_optim_dict.items():
+        if isinstance(v, torch.distributed.tensor.DTensor):
+            v = v.to_local()
+        assert k in restored_optim_dict, f"Key {k} not found in restored optimizer state"
+        assert isinstance(
+            restored_optim_dict[k], torch.Tensor,
+        ), f"Value for key {k} is not a tensor"
+
+        # Get expected shape, dtype, device from expected_optim_keys
+        expected_shape, expected_dtype, expected_device = expected_optim_keys[k]
+
+        if restored_optim_dict[k].size():
+            curr_shard = torch.split(
+                restored_optim_dict[k],
+                restored_optim_dict[k].shape[0] // 2,
+            )[torch.distributed.get_rank()]
+        else:
+            # this can be the parameter step which is a scalar Tensor
+            curr_shard = restored_optim_dict[k]
+        assert list(curr_shard.shape) == expected_shape, (
+            f"Shape mismatch for key {k}. "
+            f"Expected shape {expected_shape} but got {curr_shard.shape}"
+        )
+        assert curr_shard.dtype == expected_dtype, (
+            f"Dtype mismatch for key {k}. "
+            f"Expected dtype {expected_dtype} but got {curr_shard.dtype}"
+        )
+        assert str(curr_shard.device) == expected_device, (
+            f"Device mismatch for key {k}. "
+            f"Expected device {expected_device} but got {curr_shard.device}"
+        )
+        assert torch.allclose(v, curr_shard), (
+            f"Value mismatch for key {k}. "
+            f"Tensors are not numerically close"
+        )
+
+
+def _flatten(d: dict, parent_key: str | None = None):
+    """Recursively flatten *d* using dot-separated keys (à la DCP).
+    The first component in *parent_key* lets us prepend the outer-dict key
+    ("optim" in our case) so that the resulting keys match the exact strings
+    stored on disk by torch.distributed.checkpoint.
+    """
+
+    flat: dict[str, torch.Tensor] = {}
+    for k, v in d.items():
+        key = f"{parent_key}.{k}" if parent_key else k
+        if isinstance(v, dict):
+            flat.update(_flatten(v, key))
+        else:
+            flat[key] = v
+    return flat

--- a/tests/functional_tests/conftest.py
+++ b/tests/functional_tests/conftest.py
@@ -19,6 +19,11 @@ _OVERRIDES = [
     "checkpoint.model_save_format",
     "dataloader.batch_size",
     "checkpoint.save_consolidated",
+    "peft.peft_fn",
+    "peft.match_all_linear",
+    "peft.dim",
+    "peft.alpha",
+    "peft.use_triton",
 ]
 
 


### PR DESCRIPTION
* adding dcp peft saving functionality



* removing bkpt



* standardizing peft config with the other config



* adding a check inside module matcher to exclude lm head from lora



* moving lm_head check out of the main function



* forcing rank0 gather for peft



* adding lora ckpt support with HF format



* unifying yaml



* pushing peft tests



* fixing tests



* setting default for stateful wrapper



* adding tests to cicd



* test fixes



* removing comment



* stricter config test



---------