### PR TITLE
fix: preserve arg names

### DIFF
--- a/nemo_automodel/_transformers/auto_model.py
+++ b/nemo_automodel/_transformers/auto_model.py
@@ -23,7 +23,6 @@ from nemo_automodel import __version__
 from nemo_automodel.shared.import_utils import safe_import
 import types
 import inspect
-import textwrap
 import functools
 
 


### PR DESCRIPTION
Previous patching approach was not preserving method's signature, breaking any code relying on signature inspection.