### PR TITLE
fix: Fixing doc building guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,10 @@ ruff check --fix .
 ruff format .
 ```
 
+## Adding Documentation
+
+If your contribution involves documentation changes, please refer to the [Documentation Development](docs/documentation.md) guide for detailed instructions on building and serving the documentation.
+
 ## Signing Your Work
 
 * We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,7 +44,7 @@ extensions = [
 ]
 
 templates_path = ["_templates"]
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "documentation.md"]
 
 # -- Options for MyST Parser (Markdown) --------------------------------------
 # MyST Parser settings

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -8,7 +8,7 @@
 
 ## Build the Documentation
 
-The following sections describe how to set up and build the NeMo RL documentation.
+The following sections describe how to set up and build the NeMo Automodel documentation.
 
 Switch to the documentation source folder and generate HTML output.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,5 @@ guides/dataset.md
 :caption: 🛠️ Development
 :hidden:
 
-documentation.md
 apidocs/index.rst
 ```


### PR DESCRIPTION
- Removes documentation.md from toctree
- Adds it to CONTRIBUTING.md instead
- Removes mention of NeMo-RL from documentation.md