### PR TITLE
feat: support file-paths as _target_ in configs

### DIFF
--- a/nemo_automodel/config/loader.py
+++ b/nemo_automodel/config/loader.py
@@ -87,8 +87,8 @@ def _resolve_target(dotted_path: str):
         parts = dotted_path.split(':')
         assert parts[0].endswith('.py'), "Expected first part to be a python script"
         assert Path(parts[0]).exists(), "Expected python script to exist"
-        spec = load_module_from_file(parts[0])
-        return getattr(spec, parts[1])
+        module = load_module_from_file(parts[0])
+        return getattr(module, parts[1])
 
     parts = dotted_path.split(".")
 

--- a/nemo_automodel/config/loader.py
+++ b/nemo_automodel/config/loader.py
@@ -87,7 +87,7 @@ def _resolve_target(dotted_path: str):
         parts = dotted_path.split(':')
         assert parts[0].endswith('.py'), "Expected first part to be a python script"
         assert Path(parts[0]).exists(), "Expected python script to exist"
-        module = load_module_from_file(parts[0])
+        module = load_module_from_file(str(Path(parts[0]).resolve()))
         return getattr(module, parts[1])
 
     parts = dotted_path.split(".")

--- a/nemo_automodel/config/loader.py
+++ b/nemo_automodel/config/loader.py
@@ -17,9 +17,10 @@ import importlib
 import importlib.util
 import os
 import sys
-
+from pathlib import Path
 import yaml
-
+import inspect
+import pprint
 
 def translate_value(v):
     """
@@ -56,6 +57,21 @@ def translate_value(v):
             # fallback to raw string
             return v
 
+def load_module_from_file(file_path):
+    """Dynamically imports a module from a given file path."""
+
+    # Create a module specification object from the file location
+    name = file_path.replace('/', '.').replace('.py', '')
+    spec = importlib.util.spec_from_file_location(name, file_path)
+
+    # Create a module object from the specification
+    module = importlib.util.module_from_spec(spec)
+
+    # Execute the module's code
+    spec.loader.exec_module(module)
+
+    return module
+
 def _resolve_target(dotted_path: str):
     """
     Resolve a dotted path to a Python object.
@@ -64,6 +80,16 @@ def _resolve_target(dotted_path: str):
     2) getattr() the rest.
     3) If that fails, fall back to scanning sys.path for .py or package dirs.
     """
+    if not isinstance(dotted_path, str):
+        return dotted_path
+
+    if ':' in dotted_path:
+        parts = dotted_path.split(':')
+        assert parts[0].endswith('.py'), "Expected first part to be a python script"
+        assert Path(parts[0]).exists(), "Expected python script to exist"
+        spec = load_module_from_file(parts[0])
+        return getattr(spec, parts[1])
+
     parts = dotted_path.split(".")
 
     # 1) Try longest‐prefix module import + getattr the rest
@@ -157,6 +183,8 @@ class ConfigNode:
             return [self._wrap('', i) for i in v]
         elif k.endswith('_fn'):
             return _resolve_target(v)
+        elif k == '_target_':
+            return _resolve_target(v)
         else:
             return translate_value(v)
 
@@ -194,7 +222,22 @@ class ConfigNode:
         # Override/add with passed kwargs
         config_kwargs.update(kwargs)
 
-        return func(*args, **config_kwargs)
+        try:
+            return func(*args, **config_kwargs)
+        except Exception as e:
+            sig = inspect.signature(func)
+            print(
+                "Instantiation failed for `{}`\n"\
+                "Accepted signature : {}\n" \
+                "Positional args    : {}\n" \
+                "Keyword args       : {}\n".format(
+                func.__name__,
+                sig,
+                args,
+                pprint.pformat(config_kwargs, compact=True, indent=4),
+                )
+            )
+            raise  # re-raise so the original traceback is preserved
 
     def _instantiate_value(self, v):
         """

--- a/nemo_automodel/config/loader.py
+++ b/nemo_automodel/config/loader.py
@@ -235,7 +235,8 @@ class ConfigNode:
                 sig,
                 args,
                 pprint.pformat(config_kwargs, compact=True, indent=4),
-                )
+                ),
+                file=sys.stderr
             )
             raise e # re-raise so the original traceback is preserved
 

--- a/nemo_automodel/config/loader.py
+++ b/nemo_automodel/config/loader.py
@@ -237,7 +237,7 @@ class ConfigNode:
                 pprint.pformat(config_kwargs, compact=True, indent=4),
                 )
             )
-            raise  # re-raise so the original traceback is preserved
+            raise e # re-raise so the original traceback is preserved
 
     def _instantiate_value(self, v):
         """


### PR DESCRIPTION
Enables `_target_` to be set to a path of a python file. In particular, it supports the following format:
```
<absolute-file-path>:<function-name>
```
where the first part is as described above (relative or absolute path of a python file), and the second part (after column) specifies the function name to load from the file found at the `<absolute-file-path>`. Therefore, the syntax after the column allows to specify which function to instantiate, for example, by calling the [`.instantiate`](https://github.com/NVIDIA-NeMo/Automodel/blob/b5fcbc27883ed23d6ce683ec094b654c59ac5cb7/nemo_automodel/config/loader.py#L163) function on it.

Previously, the value of `_target_` could be a dotted path, for example:
```
dataset:
  _target_: nemo_automodel.datasets.llm.hellaswag.HellaSwag
```

Now, we can pass a file path as is, for example:
```
dataset:
   _target_: /mnt/4tb/auto/nemo_automodel/datasets/llm/mock_packed.py:build_packed_dataset
   num_blocks: 111
```

This is very convenient for cases where you want to define your own dataset and pass it via yaml. In the above example, it will call the `build_packed_dataset` with the rest of the parameters (i.e., `num_blocks`) that are under the `dataset` section.

While the above example uses a file (i.e., `mock_packed.py`) that is included in the `Automodel` repo, this is not a requirement, the file can present in any location.