### PR TITLE
refactor: simplify automodel patching

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -153,7 +153,7 @@ jobs:
             PIP_ARGS=(--no-build-isolation)
           fi
 
-          pip install .$EXTRA
+          pip install ${PIP_ARGS[@]} .$EXTRA
 
       - name: Checkout check-imports
         uses: actions/checkout@v4
@@ -194,7 +194,7 @@ jobs:
           echo -e "machine github.com\n  login token\n  password ${{ secrets.PAT }}" > ~/.netrc
           chmod 600 ~/.netrc 
 
-          export PATH=".bin/:$PATH"
+          export PATH="${UV_PROJECT_ENVIRONMENT}/bin/:$PATH"
 
           uv venv ${UV_PROJECT_ENVIRONMENT} --system-site-packages
 

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -95,12 +95,15 @@ jobs:
         run: |
           echo -e "machine github.com\n  login token\n  password ${{ secrets.PAT }}" > ~/.netrc
           chmod 600 ~/.netrc 
-          python -m venv ./venv
+
+          uv venv ${UV_PROJECT_ENVIRONMENT} --system-site-packages
           source ./venv/bin/activate
 
           export PATH="./bin/:$PATH"
 
-          pip install "."
+          uv sync --link-mode copy --locked --all-groups
+
+          uv pip install --no-deps -e .
 
       - name: Checkout check-imports
         uses: actions/checkout@v4
@@ -125,7 +128,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.12"]
-        extra-groups: ["", "vlm"]
+        extra-groups: ["", "vlm", "fa"]
     env:
       EXTRA: ${{ matrix.extra-groups != '' && format('[{0}]', matrix.extra-groups) || '' }}
     steps:
@@ -142,6 +145,13 @@ jobs:
           . ./venv/bin/activate
 
           pip install --upgrade pip
+
+          PIP_ARGS=()
+
+          if [[ $EXTRA == *"fa"* ]]; then
+            pip install torch setuptools
+            PIP_ARGS=(--no-build-isolation)
+          fi
 
           pip install .$EXTRA
 
@@ -188,7 +198,11 @@ jobs:
 
           uv venv ${UV_PROJECT_ENVIRONMENT} --system-site-packages
 
+          uv sync --link-mode copy --locked --only-group build
+
           uv sync --link-mode copy --locked --all-groups
+
+          uv pip install --no-deps -e .
 
       - name: Checkout check-imports
         uses: actions/checkout@v4

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -149,7 +149,7 @@ jobs:
           PIP_ARGS=()
 
           if [[ $EXTRA == *"fa"* ]]; then
-            pip install torch setuptools
+            pip install torch setuptools psutil
             PIP_ARGS=(--no-build-isolation)
           fi
 

--- a/docker/common/install.sh
+++ b/docker/common/install.sh
@@ -78,6 +78,7 @@ main() {
     uv sync \
         --link-mode copy \
         --locked \
+        --extra fa \
         --all-groups ${UV_ARGS[@]}
 
     # Run install overrides

--- a/docker/common/install.sh
+++ b/docker/common/install.sh
@@ -78,7 +78,6 @@ main() {
     uv sync \
         --link-mode copy \
         --locked \
-        --extra fa \
         --all-groups ${UV_ARGS[@]}
 
     # Run install overrides

--- a/nemo_automodel/_transformers/auto_model.py
+++ b/nemo_automodel/_transformers/auto_model.py
@@ -92,7 +92,7 @@ def patch_attention(obj, sdpa_method=None):
     """
     if sdpa_method is None:
         sdpa_method = [
-            # SDPBackend.CUDNN_ATTENTION,
+            SDPBackend.CUDNN_ATTENTION,
             SDPBackend.FLASH_ATTENTION,
             SDPBackend.EFFICIENT_ATTENTION,
             SDPBackend.MATH,

--- a/nemo_automodel/_transformers/auto_model.py
+++ b/nemo_automodel/_transformers/auto_model.py
@@ -29,6 +29,40 @@ import functools
 HAS_LIGER_KERNEL, liger_kernel_trf = safe_import("liger_kernel.transformers")
 logger = logging.getLogger(__name__)
 
+def dtype_from_str(val):
+    """
+    Translate a str val of a dtype into the corresponding torch.dtype
+    Args:
+        val (str): the dotted path of the dtype (e.g., "torch.bfloat16").
+
+    Returns:
+        torch.dtype: the actual dtype (e.g., torch.bfloat16)
+    """
+    if isinstance(val, torch.dtype):
+        return val
+    lut = {
+        'torch.float': torch.float,
+        'torch.float32': torch.float,
+        'torch.float64': torch.float64,
+        'torch.double': torch.float64,
+        'torch.complex64': torch.complex,
+        'torch.cfloat': torch.complex,
+        'torch.float16': torch.float16,
+        'torch.half': torch.float16,
+        'torch.bfloat16': torch.bfloat16,
+        'torch.uint8': torch.uint8,
+        'torch.int8': torch.int8,
+        'torch.int16': torch.int16,
+        'torch.short': torch.short,
+        'torch.int32': torch.int32,
+        'torch.int': torch.int,
+        'torch.int64': torch.int64,
+        'torch.long': torch.long,
+        'torch.bool': torch.bool,
+    }
+    return lut[val.lower()]
+
+
 def _assert_same_signature(original, patched):
     """
     Raise AssertionError if the two call signatures differ.
@@ -79,6 +113,36 @@ def patch_attention(obj, sdpa_method=None):
     _assert_same_signature(orig_forward, obj.forward)
 
     return obj
+
+def patch_model(model, use_liger_kernel, use_sdpa_patching=True, sdpa_method=None):
+    """
+    Patches a model with liger-kernel and sdpa_kernel
+
+    Args:
+        model (nn.Module): the model to patch
+        use_liger_kernel (bool): Applies liger-kernel to model Default True.
+        use_sdpa_patching (bool): Enables model patching with SDPA kernel optim. Default True.
+        sdpa_method (list[SDPBackend], optional): Ordered list of SDPBackend
+            implementations to attempt. If None, defaults to
+            [CUDNN_ATTENTION, FLASH_ATTENTION, EFFICIENT_ATTENTION, MATH].
+    Returns:
+        nn.Module: the patched model
+    """
+    if use_liger_kernel:
+        if not HAS_LIGER_KERNEL:
+            logging.warning("Asked to use Liger Kernel, but could not import")
+        else:
+            try:
+                liger_kernel_trf._apply_liger_kernel_to_instance(model=model)
+                logging.info("Applied liger-kernel to model")
+            except Exception:
+                logging.warning("Failed to apply liger-kernels to model; falling back to eager")
+                del model
+                raise RuntimeError("Failed to patch model")
+    if use_sdpa_patching:
+        model = patch_attention(model, sdpa_method)
+    model.config.update({"nemo_version": __version__})
+    return model
 
 
 class NeMoAutoModelForCausalLM(AutoModelForCausalLM):
@@ -144,7 +208,7 @@ class NeMoAutoModelForCausalLM(AutoModelForCausalLM):
         constructed model and recursively reloads it once with
         ``use_liger_kernel=False``.
         """
-        torch_dtype = kwargs.pop("torch_dtype", torch.bfloat16)
+        torch_dtype = dtype_from_str(kwargs.pop("torch_dtype", torch.bfloat16))
         use_liger_kernel = kwargs.pop("use_liger_kernel", True)
         use_sdpa_patching = kwargs.pop("use_sdpa_patching", True)
         sdpa_method = kwargs.pop("sdpa_method", None)
@@ -154,29 +218,18 @@ class NeMoAutoModelForCausalLM(AutoModelForCausalLM):
             **kwargs,
             torch_dtype=torch_dtype,
         )
-        if use_liger_kernel:
-            if not HAS_LIGER_KERNEL:
-                logging.warning("Asked to use Liger Kernel, but could not import")
-                return model
-            try:
-                liger_kernel_trf._apply_liger_kernel_to_instance(model=model)
-                logging.info("Applied liger-kernel to model")
-            except Exception as e:
-                logging.warning("Failed to apply liger-kernels to model; falling back to eager")
-                del model
-                # If patching failed, retry
-                return cls.from_pretrained(
-                    pretrained_model_name_or_path,
-                    *model_args,
-                    **kwargs,
-                    torch_dtype=torch_dtype,
-                    use_liger_kernel=False,
-                    use_sdpa_patching=use_sdpa_patching,
-                )
-        if use_sdpa_patching:
-            model = patch_attention(model, sdpa_method)
-        model.config.update({"nemo_version": __version__})
-        return model
+        try:
+            return patch_model(model, use_liger_kernel, use_sdpa_patching, sdpa_method)
+        except RuntimeError:
+            del model
+            return cls.from_pretrained(
+                pretrained_model_name_or_path,
+                *model_args,
+                **kwargs,
+                torch_dtype=torch_dtype,
+                use_liger_kernel=False,
+                use_sdpa_patching=use_sdpa_patching,
+            )
 
     @classmethod
     def from_config(cls, config, **kwargs):
@@ -205,32 +258,23 @@ class NeMoAutoModelForCausalLM(AutoModelForCausalLM):
         NeMoAutoModelForCausalLM.from_pretrained : Same logic for checkpoint
         loading.
         """
-        torch_dtype = kwargs.pop("torch_dtype", torch.bfloat16)
+        torch_dtype = dtype_from_str(kwargs.pop("torch_dtype", torch.bfloat16))
         use_liger_kernel = kwargs.pop("use_liger_kernel", True)
         use_sdpa_patching = kwargs.pop("use_sdpa_patching", True)
         sdpa_method = kwargs.pop("sdpa_method", None)
         model = super().from_config(config, **kwargs, torch_dtype=torch_dtype)
-        if use_liger_kernel:
-            if not HAS_LIGER_KERNEL:
-                logging.warning("Asked to use Liger Kernel, but could not import")
-                return model
-            try:
-                liger_kernel_trf._apply_liger_kernel_to_instance(model=model)
-            except Exception:
-                del model
-                # If patching failed, retry
-                return cls.from_config(
-                    config,
-                    **kwargs,
-                    use_liger_kernel=False,
-                    torch_dtype=torch_dtype,
-                    use_sdpa_patching=use_sdpa_patching
-                )
-        if use_sdpa_patching:
-            model = patch_attention(model, sdpa_method)
-        model.config.update({"nemo_version": __version__})
-        return model
-
+        try:
+            return patch_model(model, use_liger_kernel, use_sdpa_patching, sdpa_method)
+        except RuntimeError:
+            del model
+            # If patching failed, retry
+            return cls.from_config(
+                config,
+                **kwargs,
+                use_liger_kernel=False,
+                torch_dtype=torch_dtype,
+                use_sdpa_patching=use_sdpa_patching
+            )
 
 class NeMoAutoModelForImageTextToText(AutoModelForImageTextToText):
     """Drop-in replacement for ``transformers.AutoModelForImageTextToText`` with custom-kernels.
@@ -294,7 +338,7 @@ class NeMoAutoModelForImageTextToText(AutoModelForImageTextToText):
         constructed model and recursively reloads it once with
         ``use_liger_kernel=False``.
         """
-        torch_dtype = kwargs.pop("torch_dtype", torch.bfloat16)
+        torch_dtype = dtype_from_str(kwargs.pop("torch_dtype", torch.bfloat16))
         use_liger_kernel = kwargs.pop("use_liger_kernel", True)
         use_sdpa_patching = kwargs.pop("use_sdpa_patching", True)
         sdpa_method = kwargs.pop("sdpa_method", None)
@@ -304,27 +348,19 @@ class NeMoAutoModelForImageTextToText(AutoModelForImageTextToText):
             **kwargs,
             torch_dtype=torch_dtype,
         )
-        if use_liger_kernel:
-            if not HAS_LIGER_KERNEL:
-                logging.warning("Asked to use Liger Kernel, but could not import")
-                return model
-            try:
-                liger_kernel_trf._apply_liger_kernel_to_instance(model=model)
-            except Exception:
-                del model
-                # If patching failed, retry
-                return cls.from_pretrained(
-                    pretrained_model_name_or_path,
-                    *model_args,
-                    **kwargs,
-                    torch_dtype=torch_dtype,
-                    use_liger_kernel=False,
-                    use_sdpa_patching=use_sdpa_patching,
-                )
-        if use_sdpa_patching:
-            model = patch_attention(model, sdpa_method)
-        model.config.update({"nemo_version": __version__})
-        return model
+        try:
+            return patch_model(model, use_liger_kernel, use_sdpa_patching, sdpa_method)
+        except RuntimeError:
+            del model
+            # If patching failed, retry
+            return cls.from_pretrained(
+                pretrained_model_name_or_path,
+                *model_args,
+                **kwargs,
+                torch_dtype=torch_dtype,
+                use_liger_kernel=False,
+                use_sdpa_patching=use_sdpa_patching,
+            )
 
     @classmethod
     def from_config(cls, config, **kwargs):
@@ -353,28 +389,20 @@ class NeMoAutoModelForImageTextToText(AutoModelForImageTextToText):
         NeMoAutoModelForImageTextToText.from_pretrained : Same logic for checkpoint
         loading.
         """
-        torch_dtype = kwargs.pop("torch_dtype", torch.bfloat16)
+        torch_dtype = dtype_from_str(kwargs.pop("torch_dtype", torch.bfloat16))
         use_liger_kernel = kwargs.pop("use_liger_kernel", True)
         use_sdpa_patching = kwargs.pop("use_sdpa_patching", True)
         sdpa_method = kwargs.pop("sdpa_method", None)
         model = super().from_config(config, **kwargs, torch_dtype=torch_dtype)
-        if use_liger_kernel:
-            if not HAS_LIGER_KERNEL:
-                logging.warning("Asked to use Liger Kernel, but could not import")
-                return model
-            try:
-                liger_kernel_trf._apply_liger_kernel_to_instance(model=model)
-            except Exception:
-                del model
-                # If patching failed, retry
-                return cls.from_config(
-                    config,
-                    **kwargs,
-                    use_liger_kernel=False,
-                    torch_dtype=torch_dtype,
-                    use_sdpa_patching=use_sdpa_patching
-                )
-        if use_sdpa_patching:
-            model = patch_attention(model, sdpa_method)
-        model.config.update({"nemo_version": __version__})
-        return model
+        try:
+            return patch_model(model, use_liger_kernel, use_sdpa_patching, sdpa_method)
+        except RuntimeError:
+            del model
+            # If patching failed, retry
+            return cls.from_config(
+                config,
+                **kwargs,
+                use_liger_kernel=False,
+                torch_dtype=torch_dtype,
+                use_sdpa_patching=use_sdpa_patching
+            )

--- a/nemo_automodel/_transformers/auto_model.py
+++ b/nemo_automodel/_transformers/auto_model.py
@@ -409,7 +409,8 @@ class NeMoAutoModelForImageTextToText(AutoModelForImageTextToText):
             config,
             **kwargs,
             attn_implementation=attn_implementation,
-            torch_dtype=torch_dtype)
+            torch_dtype=torch_dtype
+        )
         try:
             return patch_model(model, use_liger_kernel, use_sdpa_patching, sdpa_method)
         except RuntimeError:

--- a/nemo_automodel/_transformers/auto_model.py
+++ b/nemo_automodel/_transformers/auto_model.py
@@ -112,6 +112,7 @@ def patch_attention(obj, sdpa_method=None):
     # runtime check
     _assert_same_signature(orig_forward, obj.forward)
 
+    logging.info("Patched model with SDPA method= {}".format(sdpa_method))
     return obj
 
 def patch_model(model, use_liger_kernel=True, use_sdpa_patching=True, sdpa_method=None):
@@ -139,8 +140,8 @@ def patch_model(model, use_liger_kernel=True, use_sdpa_patching=True, sdpa_metho
                 logging.warning("Failed to apply liger-kernels to model; falling back to eager")
                 del model
                 raise RuntimeError("Failed to patch model")
-    if use_sdpa_patching:
-        model = patch_attention(model, sdpa_method)
+    # if use_sdpa_patching:
+    #     model = patch_attention(model, sdpa_method)
     model.config.update({"nemo_version": __version__})
     return model
 

--- a/nemo_automodel/_transformers/auto_model.py
+++ b/nemo_automodel/_transformers/auto_model.py
@@ -92,7 +92,7 @@ def patch_attention(obj, sdpa_method=None):
     """
     if sdpa_method is None:
         sdpa_method = [
-            SDPBackend.CUDNN_ATTENTION,
+            # SDPBackend.CUDNN_ATTENTION,
             SDPBackend.FLASH_ATTENTION,
             SDPBackend.EFFICIENT_ATTENTION,
             SDPBackend.MATH,
@@ -140,8 +140,8 @@ def patch_model(model, use_liger_kernel=True, use_sdpa_patching=True, sdpa_metho
                 logging.warning("Failed to apply liger-kernels to model; falling back to eager")
                 del model
                 raise RuntimeError("Failed to patch model")
-    # if use_sdpa_patching:
-    #     model = patch_attention(model, sdpa_method)
+    if use_sdpa_patching:
+        model = patch_attention(model, sdpa_method)
     model.config.update({"nemo_version": __version__})
     return model
 
@@ -213,10 +213,12 @@ class NeMoAutoModelForCausalLM(AutoModelForCausalLM):
         use_liger_kernel = kwargs.pop("use_liger_kernel", True)
         use_sdpa_patching = kwargs.pop("use_sdpa_patching", True)
         sdpa_method = kwargs.pop("sdpa_method", None)
+        attn_implementation = kwargs.pop("attn_implementation", "flash_attention_2")
         model = super().from_pretrained(
             pretrained_model_name_or_path,
             *model_args,
             **kwargs,
+            attn_implementation=attn_implementation,
             torch_dtype=torch_dtype,
         )
         try:
@@ -263,7 +265,13 @@ class NeMoAutoModelForCausalLM(AutoModelForCausalLM):
         use_liger_kernel = kwargs.pop("use_liger_kernel", True)
         use_sdpa_patching = kwargs.pop("use_sdpa_patching", True)
         sdpa_method = kwargs.pop("sdpa_method", None)
-        model = super().from_config(config, **kwargs, torch_dtype=torch_dtype)
+        attn_implementation = kwargs.pop("attn_implementation", "flash_attention_2")
+        model = super().from_config(
+            config,
+            **kwargs,
+            attn_implementation=attn_implementation,
+            torch_dtype=torch_dtype
+        )
         try:
             return patch_model(model, use_liger_kernel, use_sdpa_patching, sdpa_method)
         except RuntimeError:
@@ -343,10 +351,12 @@ class NeMoAutoModelForImageTextToText(AutoModelForImageTextToText):
         use_liger_kernel = kwargs.pop("use_liger_kernel", True)
         use_sdpa_patching = kwargs.pop("use_sdpa_patching", True)
         sdpa_method = kwargs.pop("sdpa_method", None)
+        attn_implementation = kwargs.pop("attn_implementation", "flash_attention_2")
         model = super().from_pretrained(
             pretrained_model_name_or_path,
             *model_args,
             **kwargs,
+            attn_implementation=attn_implementation,
             torch_dtype=torch_dtype,
         )
         try:
@@ -394,7 +404,12 @@ class NeMoAutoModelForImageTextToText(AutoModelForImageTextToText):
         use_liger_kernel = kwargs.pop("use_liger_kernel", True)
         use_sdpa_patching = kwargs.pop("use_sdpa_patching", True)
         sdpa_method = kwargs.pop("sdpa_method", None)
-        model = super().from_config(config, **kwargs, torch_dtype=torch_dtype)
+        attn_implementation = kwargs.pop("attn_implementation", "flash_attention_2")
+        model = super().from_config(
+            config,
+            **kwargs,
+            attn_implementation=attn_implementation,
+            torch_dtype=torch_dtype)
         try:
             return patch_model(model, use_liger_kernel, use_sdpa_patching, sdpa_method)
         except RuntimeError:

--- a/nemo_automodel/_transformers/auto_model.py
+++ b/nemo_automodel/_transformers/auto_model.py
@@ -114,7 +114,7 @@ def patch_attention(obj, sdpa_method=None):
 
     return obj
 
-def patch_model(model, use_liger_kernel, use_sdpa_patching=True, sdpa_method=None):
+def patch_model(model, use_liger_kernel=True, use_sdpa_patching=True, sdpa_method=None):
     """
     Patches a model with liger-kernel and sdpa_kernel
 

--- a/nemo_automodel/_transformers/auto_model.py
+++ b/nemo_automodel/_transformers/auto_model.py
@@ -160,7 +160,9 @@ class NeMoAutoModelForCausalLM(AutoModelForCausalLM):
                 return model
             try:
                 liger_kernel_trf._apply_liger_kernel_to_instance(model=model)
-            except Exception:
+                logging.info("Applied liger-kernel to model")
+            except Exception as e:
+                logging.warning("Failed to apply liger-kernels to model; falling back to eager")
                 del model
                 # If patching failed, retry
                 return cls.from_pretrained(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ dependencies = [
     "datasets",
     "liger-kernel==0.5.8; (platform_machine == 'x86_64' and platform_system != 'Darwin')",
     "pyyaml",
+    "flash-attn",
     "torch",
     "torchdata",
     "transformers",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,11 +78,11 @@ dependencies = [
     "torchdata",
     "transformers",
     "wandb",
+    "flash-attn",
 ]
 
 [project.optional-dependencies]
 vlm = ["qwen-vl-utils[decord]", "transformers==4.53.0","timm==1.0.16"]
-fa = ["flash-attn"]
 
 [project.urls]
 Homepage = "https://docs.nvidia.com/deeplearning/nemo/user-guide/docs/en/stable/"
@@ -90,6 +90,7 @@ Repository = "https://github.com/NVIDIA/NeMo-Automodel"
 Download = "https://github.com/NVIDIA/NeMo-Automodel/releases"
 
 [dependency-groups]
+build = ["setuptools", "torch"]
 docs = [
     "sphinx",
     "sphinx-autobuild",    # For live doc serving while editing docs
@@ -98,12 +99,11 @@ docs = [
     "myst_parser",         # For our markdown docs
     "nvidia-sphinx-theme", # Our NVIDIA theme
 ]
-build = []
 test = ["coverage", "pytest"]
 nvfsdp = ["nvfsdp"]
 
 [tool.uv]
-default-groups = ["docs", "test", "nvfsdp"]
+default-groups = ["build", "docs", "test", "nvfsdp"]
 no-build-isolation-package = ["flash-attn"]
 
 [tool.uv.sources]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,11 +78,11 @@ dependencies = [
     "torchdata",
     "transformers",
     "wandb",
-    "flash-attn",
 ]
 
 [project.optional-dependencies]
 vlm = ["qwen-vl-utils[decord]", "transformers==4.53.0","timm==1.0.16"]
+fa = ["flash-attn"]
 
 [project.urls]
 Homepage = "https://docs.nvidia.com/deeplearning/nemo/user-guide/docs/en/stable/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ nvfsdp = ["nvfsdp"]
 
 [tool.uv]
 default-groups = ["docs", "test", "nvfsdp"]
+no-build-isolation-package = ["flash-attn"]
 
 [tool.uv.sources]
 nvfsdp = { git = "https://github.com/NVIDIA-NeMo/nvFSDP.git", rev = "d97136886a65d70f298a4b361571ac75c20198af" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,12 +74,11 @@ dependencies = [
     "datasets",
     "liger-kernel==0.5.8; (platform_machine == 'x86_64' and platform_system != 'Darwin')",
     "pyyaml",
-    "flash-attn",
     "torch",
     "torchdata",
     "transformers",
     "wandb",
-
+    "flash-attn",
 ]
 [project.optional-dependencies]
 vlm = ["qwen-vl-utils[decord]", "transformers==4.53.0","timm==1.0.16"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,10 +78,12 @@ dependencies = [
     "torchdata",
     "transformers",
     "wandb",
-    "flash-attn",
 ]
+
 [project.optional-dependencies]
 vlm = ["qwen-vl-utils[decord]", "transformers==4.53.0","timm==1.0.16"]
+fa = ["flash-attn"]
+
 [project.urls]
 Homepage = "https://docs.nvidia.com/deeplearning/nemo/user-guide/docs/en/stable/"
 Repository = "https://github.com/NVIDIA/NeMo-Automodel"

--- a/tests/unit_tests/_transformers/test_auto_model.py
+++ b/tests/unit_tests/_transformers/test_auto_model.py
@@ -13,15 +13,17 @@
 # limitations under the License.
 
 import logging
+import types
 import pytest
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 import transformers
 from transformers import AutoConfig
-
+import torch
 from nemo_automodel._transformers.auto_model import (
     NeMoAutoModelForCausalLM,
     NeMoAutoModelForImageTextToText,
     patch_attention,
+    patch_model,
 )
 
 
@@ -30,16 +32,17 @@ class TestNeMoAutoModelForCausalLM:
 
     def test_from_pretrained_liger_kernel_not_available(self, caplog):
         """Test warning when Liger kernel is not available."""
-        with patch('nemo_automodel._transformers.auto_model.HAS_LIGER_KERNEL', False):
+        with patch('nemo_automodel._transformers.auto_model.HAS_LIGER_KERNEL', False), \
+            patch('nemo_automodel._transformers.auto_model.patch_attention', lambda obj, sdpa_method=None: obj):
             with patch.object(transformers.AutoModelForCausalLM, 'from_pretrained') as mock_from_pretrained:
                 mock_model = Mock()
                 mock_model.config = Mock()
                 mock_from_pretrained.return_value = mock_model
-                
+
                 # Test line 208 - warning when HAS_LIGER_KERNEL is False
                 with caplog.at_level(logging.WARNING):
-                    model = NeMoAutoModelForCausalLM.from_pretrained("dummy_model")
-                
+                    model = NeMoAutoModelForCausalLM.from_pretrained("gpt2")
+
                 assert "Asked to use Liger Kernel, but could not import" in caplog.text
                 assert model is mock_model
                 mock_from_pretrained.assert_called_once()
@@ -47,18 +50,19 @@ class TestNeMoAutoModelForCausalLM:
 
     def test_from_config_liger_kernel_not_available(self, caplog):
         """Test warning when Liger kernel is not available in from_config."""
-        with patch('nemo_automodel._transformers.auto_model.HAS_LIGER_KERNEL', False):
+        with patch('nemo_automodel._transformers.auto_model.HAS_LIGER_KERNEL', False), \
+            patch('nemo_automodel._transformers.auto_model.patch_attention', lambda obj, sdpa_method=None: obj):
             with patch.object(transformers.AutoModelForCausalLM, 'from_config') as mock_from_config:
                 mock_model = Mock()
                 mock_model.config = Mock()
                 mock_from_config.return_value = mock_model
-                
+
                 config = AutoConfig.from_pretrained("gpt2")
-                
+
                 # Test line 297 - warning when HAS_LIGER_KERNEL is False
                 with caplog.at_level(logging.WARNING):
                     model = NeMoAutoModelForCausalLM.from_config(config)
-                
+
                 assert "Asked to use Liger Kernel, but could not import" in caplog.text
                 assert model is mock_model
                 mock_from_config.assert_called_once()
@@ -68,39 +72,41 @@ class TestNeMoAutoModelForImageTextToText:
 
     def test_from_pretrained_liger_kernel_not_available(self, caplog):
         """Test warning when Liger kernel is not available."""
-        with patch('nemo_automodel._transformers.auto_model.HAS_LIGER_KERNEL', False):
+        with patch('nemo_automodel._transformers.auto_model.HAS_LIGER_KERNEL', False), \
+            patch('nemo_automodel._transformers.auto_model.patch_attention', lambda obj, sdpa_method=None: obj):
             with patch.object(transformers.AutoModelForImageTextToText, 'from_pretrained') as mock_from_pretrained:
                 mock_model = Mock()
                 mock_model.config = Mock()
                 mock_from_pretrained.return_value = mock_model
-                
+
                 # Test line 356 - warning when HAS_LIGER_KERNEL is False
                 with caplog.at_level(logging.WARNING):
                     model = NeMoAutoModelForImageTextToText.from_pretrained("dummy_model")
-                
+
                 assert "Asked to use Liger Kernel, but could not import" in caplog.text
                 assert model is mock_model
                 mock_from_pretrained.assert_called_once()
 
     def test_from_config_liger_kernel_not_available(self, caplog):
         """Test warning when Liger kernel is not available in from_config."""
-        with patch('nemo_automodel._transformers.auto_model.HAS_LIGER_KERNEL', False):
+        with patch('nemo_automodel._transformers.auto_model.HAS_LIGER_KERNEL', False), \
+            patch('nemo_automodel._transformers.auto_model.patch_attention', lambda obj, sdpa_method=None: obj):
             with patch.object(transformers.AutoModelForImageTextToText, 'from_config') as mock_from_config:
                 mock_model = Mock()
                 mock_model.config = Mock()
                 mock_from_config.return_value = mock_model
-                
+
                 config = AutoConfig.from_pretrained("gpt2")
-                
+
                 # Test warning when HAS_LIGER_KERNEL is False
                 with caplog.at_level(logging.WARNING):
                     model = NeMoAutoModelForImageTextToText.from_config(config)
-                
+
                 assert "Asked to use Liger Kernel, but could not import" in caplog.text
                 assert model is mock_model
                 mock_from_config.assert_called_once()
 
-    
+
 class TestPatchAttention:
     """Test cases for patch_attention function."""
 
@@ -110,15 +116,15 @@ class TestPatchAttention:
         mock_obj = Mock()
         mock_forward = Mock()
         mock_obj.forward = mock_forward
-        
+
         # Mock the forward method to be a bound method
         mock_forward.__func__ = Mock()
         mock_forward.__self__ = mock_obj
-        
+
         with patch('nemo_automodel._transformers.auto_model.sdpa_kernel') as mock_sdpa_kernel:
             with patch('nemo_automodel._transformers.auto_model._assert_same_signature'):
                 result = patch_attention(mock_obj)
-                
+
                 assert result is mock_obj
                 # Verify that the forward method was replaced
                 assert mock_obj.forward != mock_forward
@@ -126,21 +132,21 @@ class TestPatchAttention:
     def test_patch_attention_with_custom_sdpa_method(self):
         """Test patch_attention with custom SDPA method."""
         from torch.nn.attention import SDPBackend
-        
+
         mock_obj = Mock()
         mock_forward = Mock()
         mock_obj.forward = mock_forward
-        
+
         # Mock the forward method to be a bound method
         mock_forward.__func__ = Mock()
         mock_forward.__self__ = mock_obj
-        
+
         custom_sdpa_method = [SDPBackend.FLASH_ATTENTION]
-        
+
         with patch('nemo_automodel._transformers.auto_model.sdpa_kernel') as mock_sdpa_kernel:
             with patch('nemo_automodel._transformers.auto_model._assert_same_signature'):
                 result = patch_attention(mock_obj, custom_sdpa_method)
-                
+
                 assert result is mock_obj
                 # Verify that the forward method was replaced
                 assert mock_obj.forward != mock_forward
@@ -152,26 +158,151 @@ class TestUtilityFunctions:
     def test_assert_same_signature_matching(self):
         """Test _assert_same_signature with matching signatures."""
         from nemo_automodel._transformers.auto_model import _assert_same_signature
-        
+
         def func1(a, b, c=None):
             pass
-        
+
         def func2(a, b, c=None):
             pass
-        
+
         # Should not raise an exception
         _assert_same_signature(func1, func2)
 
     def test_assert_same_signature_different(self):
         """Test _assert_same_signature with different signatures."""
         from nemo_automodel._transformers.auto_model import _assert_same_signature
-        
+
         def func1(a, b, c=None):
             pass
-        
+
         def func2(a, b, d=None):
             pass
-        
+
         # Should raise an AssertionError
         with pytest.raises(AssertionError):
-            _assert_same_signature(func1, func2) 
+            _assert_same_signature(func1, func2)
+
+
+
+class DummyModel(torch.nn.Module):
+    """A tiny nn.Module that behaves enough like a HF/BERT style model."""
+    def __init__(self):
+        super().__init__()
+        self.config = {}          # patch_model calls  model.config.update(...)
+        self.called = False       # turned on by fake liger kernel
+
+    def mark(self):
+        self.called = True
+
+def prepare_env(monkeypatch, target_mod, *,
+                has_liger=True,
+                apply_ok=True):
+    """
+    Patch every external symbol that patch_model touches.
+
+    Parameters
+    ----------
+    has_liger : bool
+        Value for HAS_LIGER_KERNEL global.
+    apply_ok : bool
+        Force liger_kernel_trf._apply_liger_kernel_to_instance to succeed/fail.
+    """
+    monkeypatch.setattr(target_mod, "HAS_LIGER_KERNEL", has_liger, raising=False)
+
+    apply_mock = MagicMock()
+
+    if apply_ok:
+        # mark model when called so we can assert later
+        apply_mock.side_effect = lambda *, model: model.mark()
+    else:
+        apply_mock.side_effect = RuntimeError("boom")
+
+    liger_stub = types.SimpleNamespace(_apply_liger_kernel_to_instance=apply_mock)
+    monkeypatch.setattr(target_mod, "liger_kernel_trf", liger_stub, raising=False)
+
+    # patch_attn_mock = MagicMock(side_effect=lambda m, _: m)
+    # monkeypatch.setattr(target_mod, "patch_attention", patch_attn_mock, raising=False)
+    patch_attn_mock = MagicMock(side_effect=lambda *args, **kwargs: args[0])
+    monkeypatch.setattr(target_mod, "patch_attention", patch_attn_mock, raising=True)
+
+    monkeypatch.setattr(target_mod, "__version__", "unit-test-ver", raising=False)
+
+    return apply_mock, patch_attn_mock
+
+@pytest.mark.parametrize("use_liger,has_liger", [(True, True), (False, True)])
+def test_success_paths(monkeypatch, use_liger, has_liger):
+    """
+    1. Liger available & requested  -> kernel applied, patch_attention called.
+    2. Liger *not* requested        -> kernel *not* applied, patch_attention called.
+    """
+    import nemo_automodel._transformers.auto_model as tgt
+    apply_mock, attn_mock = prepare_env(
+        monkeypatch,
+        tgt,
+        has_liger=has_liger,
+        apply_ok=True
+    )
+
+    model = DummyModel()
+    patched = tgt.patch_model(
+        model,
+        use_liger_kernel=use_liger,
+        use_sdpa_patching=True,
+    )
+
+    # Always returns same instance (unless exception path)
+    assert patched is model
+    # nemo_version must be set
+    assert patched.config["nemo_version"] == "unit-test-ver"
+
+    if use_liger:
+        apply_mock.assert_called_once()
+        assert model.called is True
+    else:
+        apply_mock.assert_not_called()
+        assert model.called is False
+
+    # SDPA path always taken in these tests
+    attn_mock.assert_called_once_with(model, None)
+
+
+def test_liger_not_available(monkeypatch):
+    """
+    Asked for Liger but HAS_LIGER_KERNEL is False.
+    Expect: return untouched model, patch_attention still invoked,
+            no exceptions thrown.
+    """
+    import nemo_automodel._transformers.auto_model as tgt
+    apply_mock, attn_mock = prepare_env(
+        monkeypatch,
+        tgt,
+        has_liger=False, # unavailable
+        apply_ok=True
+    )
+
+    model = DummyModel()
+    out = tgt.patch_model(model, use_liger_kernel=True, use_sdpa_patching=True)
+
+    # untouched instance returned
+    assert out is model
+    assert model.called is False
+    # _apply never called, because we short-circuit when HAS_LIGER_KERNEL==False
+    apply_mock.assert_not_called()
+    attn_mock.assert_called_once()
+
+
+def test_liger_apply_failure_raises(monkeypatch):
+    """
+    If _apply_liger_kernel_to_instance throws, patch_model must
+    clean up and raise RuntimeError.
+    """
+    import nemo_automodel._transformers.auto_model as tgt
+    prepare_env(
+        monkeypatch,
+        tgt,
+        has_liger=True,
+        apply_ok=False   # force failure
+    )
+
+    with pytest.raises(RuntimeError, match="Failed to patch model"):
+        tgt.patch_model(DummyModel(), use_liger_kernel=True, use_sdpa_patching=False)

--- a/tests/unit_tests/_transformers/test_auto_model.py
+++ b/tests/unit_tests/_transformers/test_auto_model.py
@@ -220,8 +220,6 @@ def prepare_env(monkeypatch, target_mod, *,
     liger_stub = types.SimpleNamespace(_apply_liger_kernel_to_instance=apply_mock)
     monkeypatch.setattr(target_mod, "liger_kernel_trf", liger_stub, raising=False)
 
-    # patch_attn_mock = MagicMock(side_effect=lambda m, _: m)
-    # monkeypatch.setattr(target_mod, "patch_attention", patch_attn_mock, raising=False)
     patch_attn_mock = MagicMock(side_effect=lambda *args, **kwargs: args[0])
     monkeypatch.setattr(target_mod, "patch_attention", patch_attn_mock, raising=True)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1006,7 +1006,6 @@ dependencies = [
     { name = "bitsandbytes", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
     { name = "cut-cross-entropy" },
     { name = "datasets" },
-    { name = "flash-attn" },
     { name = "liger-kernel", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
     { name = "pyyaml" },
     { name = "torch" },
@@ -1016,6 +1015,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+fa = [
+    { name = "flash-attn" },
+]
 vlm = [
     { name = "qwen-vl-utils", extra = ["decord"] },
     { name = "timm" },
@@ -1049,7 +1051,7 @@ requires-dist = [
     { name = "bitsandbytes", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'", specifier = "==0.45.5" },
     { name = "cut-cross-entropy", git = "https://github.com/apple/ml-cross-entropy.git?rev=87a86ab" },
     { name = "datasets" },
-    { name = "flash-attn" },
+    { name = "flash-attn", marker = "extra == 'fa'" },
     { name = "liger-kernel", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'", specifier = "==0.5.8" },
     { name = "pyyaml" },
     { name = "qwen-vl-utils", extras = ["decord"], marker = "extra == 'vlm'" },
@@ -1060,7 +1062,7 @@ requires-dist = [
     { name = "transformers", marker = "extra == 'vlm'", specifier = "==4.53.0" },
     { name = "wandb" },
 ]
-provides-extras = ["vlm"]
+provides-extras = ["vlm", "fa"]
 
 [package.metadata.requires-dev]
 build = [
@@ -1287,7 +1289,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.5.1.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/78/4535c9c7f859a64781e43c969a3a7e84c54634e319a996d43ef32ce46f83/nvidia_cudnn_cu12-9.5.1.17-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:30ac3869f6db17d170e0e556dd6cc5eee02647abc31ca856634d5a40f82c15b2", size = 570988386, upload-time = "2024-10-25T19:54:26.39Z" },
@@ -1298,7 +1300,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8f/16/73727675941ab8e6ffd86ca3a4b7b47065edcca7a997920b831f8147c99d/nvidia_cufft_cu12-11.3.0.4-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ccba62eb9cef5559abd5e0d54ceed2d9934030f51163df018532142a8ec533e5", size = 200221632, upload-time = "2024-11-20T17:41:32.357Z" },
@@ -1327,9 +1329,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f0/6e/c2cf12c9ff8b872e92b4a5740701e51ff17689c4d726fca91875b07f655d/nvidia_cusolver_cu12-11.7.1.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e9e49843a7707e42022babb9bcfa33c29857a93b88020c4e4434656a655b698c", size = 158229790, upload-time = "2024-11-20T17:43:43.211Z" },
@@ -1341,7 +1343,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/06/1e/b8b7c2f4099a37b96af5c9bb158632ea9e5d9d27d7391d7eb8fc45236674/nvidia_cusparse_cu12-12.5.4.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7556d9eca156e18184b94947ade0fba5bb47d69cec46bf8660fd2c71a4b48b73", size = 216561367, upload-time = "2024-11-20T17:44:54.824Z" },

--- a/uv.lock
+++ b/uv.lock
@@ -495,6 +495,15 @@ wheels = [
 ]
 
 [[package]]
+name = "einops"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/81/df4fbe24dff8ba3934af99044188e20a98ed441ad17a274539b74e82e126/einops-0.8.1.tar.gz", hash = "sha256:de5d960a7a761225532e0f1959e5315ebeafc0cd43394732f103ca44b9837e84", size = 54805, upload-time = "2025-02-09T03:17:00.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/62/9773de14fe6c45c23649e98b83231fffd7b9892b6cf863251dc2afa73643/einops-0.8.1-py3-none-any.whl", hash = "sha256:919387eb55330f5757c6bea9165c5ff5cfe63a642682ea788a6d472576d81737", size = 64359, upload-time = "2025-02-09T03:17:01.998Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -514,6 +523,16 @@ sdist = { url = "https://files.pythonhosted.org/packages/0a/10/c23352565a6544bdc
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/36/2a115987e2d8c300a974597416d9de88f2444426de9571f4b59b2cca3acc/filelock-3.18.0-py3-none-any.whl", hash = "sha256:c401f4f8377c4464e6db25fff06205fd89bdd83b65eb0488ed1b160f780e21de", size = 16215, upload-time = "2025-03-14T07:11:39.145Z" },
 ]
+
+[[package]]
+name = "flash-attn"
+version = "2.8.0.post2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "einops" },
+    { name = "torch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/5c/c7610beeb2fc0e70d0c09a93490bb2d07fb6c8fa1f80ef9617b0cd556d76/flash_attn-2.8.0.post2.tar.gz", hash = "sha256:b51d7015eb78f7ab2c332ec7c36681d7e97834f010b52eb4db1f118351982f58", size = 7857730, upload-time = "2025-06-15T01:39:32.219Z" }
 
 [[package]]
 name = "frozenlist"
@@ -987,6 +1006,7 @@ dependencies = [
     { name = "bitsandbytes", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
     { name = "cut-cross-entropy" },
     { name = "datasets" },
+    { name = "flash-attn" },
     { name = "liger-kernel", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
     { name = "pyyaml" },
     { name = "torch" },
@@ -1003,6 +1023,10 @@ vlm = [
 ]
 
 [package.dev-dependencies]
+build = [
+    { name = "setuptools" },
+    { name = "torch" },
+]
 docs = [
     { name = "myst-parser" },
     { name = "nvidia-sphinx-theme" },
@@ -1025,6 +1049,7 @@ requires-dist = [
     { name = "bitsandbytes", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'", specifier = "==0.45.5" },
     { name = "cut-cross-entropy", git = "https://github.com/apple/ml-cross-entropy.git?rev=87a86ab" },
     { name = "datasets" },
+    { name = "flash-attn" },
     { name = "liger-kernel", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'", specifier = "==0.5.8" },
     { name = "pyyaml" },
     { name = "qwen-vl-utils", extras = ["decord"], marker = "extra == 'vlm'" },
@@ -1038,7 +1063,10 @@ requires-dist = [
 provides-extras = ["vlm"]
 
 [package.metadata.requires-dev]
-build = []
+build = [
+    { name = "setuptools" },
+    { name = "torch" },
+]
 docs = [
     { name = "myst-parser" },
     { name = "nvidia-sphinx-theme" },
@@ -1259,7 +1287,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.5.1.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/78/4535c9c7f859a64781e43c969a3a7e84c54634e319a996d43ef32ce46f83/nvidia_cudnn_cu12-9.5.1.17-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:30ac3869f6db17d170e0e556dd6cc5eee02647abc31ca856634d5a40f82c15b2", size = 570988386, upload-time = "2024-10-25T19:54:26.39Z" },
@@ -1270,7 +1298,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8f/16/73727675941ab8e6ffd86ca3a4b7b47065edcca7a997920b831f8147c99d/nvidia_cufft_cu12-11.3.0.4-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ccba62eb9cef5559abd5e0d54ceed2d9934030f51163df018532142a8ec533e5", size = 200221632, upload-time = "2024-11-20T17:41:32.357Z" },
@@ -1299,9 +1327,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f0/6e/c2cf12c9ff8b872e92b4a5740701e51ff17689c4d726fca91875b07f655d/nvidia_cusolver_cu12-11.7.1.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e9e49843a7707e42022babb9bcfa33c29857a93b88020c4e4434656a655b698c", size = 158229790, upload-time = "2024-11-20T17:43:43.211Z" },
@@ -1313,7 +1341,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/06/1e/b8b7c2f4099a37b96af5c9bb158632ea9e5d9d27d7391d7eb8fc45236674/nvidia_cusparse_cu12-12.5.4.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7556d9eca156e18184b94947ade0fba5bb47d69cec46bf8660fd2c71a4b48b73", size = 216561367, upload-time = "2024-11-20T17:44:54.824Z" },
@@ -1377,7 +1405,7 @@ wheels = [
 
 [[package]]
 name = "pandas"
-version = "2.3.0"
+version = "2.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -1386,42 +1414,42 @@ dependencies = [
     { name = "pytz" },
     { name = "tzdata" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/72/51/48f713c4c728d7c55ef7444ba5ea027c26998d96d1a40953b346438602fc/pandas-2.3.0.tar.gz", hash = "sha256:34600ab34ebf1131a7613a260a61dbe8b62c188ec0ea4c296da7c9a06b004133", size = 4484490, upload-time = "2025-06-05T03:27:54.133Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/6f/75aa71f8a14267117adeeed5d21b204770189c0a0025acbdc03c337b28fc/pandas-2.3.1.tar.gz", hash = "sha256:0a95b9ac964fe83ce317827f80304d37388ea77616b1425f0ae41c9d2d0d7bb2", size = 4487493, upload-time = "2025-07-07T19:20:04.079Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/2d/df6b98c736ba51b8eaa71229e8fcd91233a831ec00ab520e1e23090cc072/pandas-2.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:625466edd01d43b75b1883a64d859168e4556261a5035b32f9d743b67ef44634", size = 11527531, upload-time = "2025-06-05T03:25:48.648Z" },
-    { url = "https://files.pythonhosted.org/packages/77/1c/3f8c331d223f86ba1d0ed7d3ed7fcf1501c6f250882489cc820d2567ddbf/pandas-2.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a6872d695c896f00df46b71648eea332279ef4077a409e2fe94220208b6bb675", size = 10774764, upload-time = "2025-06-05T03:25:53.228Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/45/d2599400fad7fe06b849bd40b52c65684bc88fbe5f0a474d0513d057a377/pandas-2.3.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f4dd97c19bd06bc557ad787a15b6489d2614ddaab5d104a0310eb314c724b2d2", size = 11711963, upload-time = "2025-06-05T03:25:56.855Z" },
-    { url = "https://files.pythonhosted.org/packages/66/f8/5508bc45e994e698dbc93607ee6b9b6eb67df978dc10ee2b09df80103d9e/pandas-2.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:034abd6f3db8b9880aaee98f4f5d4dbec7c4829938463ec046517220b2f8574e", size = 12349446, upload-time = "2025-06-05T03:26:01.292Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/fc/17851e1b1ea0c8456ba90a2f514c35134dd56d981cf30ccdc501a0adeac4/pandas-2.3.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:23c2b2dc5213810208ca0b80b8666670eb4660bbfd9d45f58592cc4ddcfd62e1", size = 12920002, upload-time = "2025-06-06T00:00:07.925Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/9b/8743be105989c81fa33f8e2a4e9822ac0ad4aaf812c00fee6bb09fc814f9/pandas-2.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:39ff73ec07be5e90330cc6ff5705c651ace83374189dcdcb46e6ff54b4a72cd6", size = 13651218, upload-time = "2025-06-05T03:26:09.731Z" },
-    { url = "https://files.pythonhosted.org/packages/26/fa/8eeb2353f6d40974a6a9fd4081ad1700e2386cf4264a8f28542fd10b3e38/pandas-2.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:40cecc4ea5abd2921682b57532baea5588cc5f80f0231c624056b146887274d2", size = 11082485, upload-time = "2025-06-05T03:26:17.572Z" },
-    { url = "https://files.pythonhosted.org/packages/96/1e/ba313812a699fe37bf62e6194265a4621be11833f5fce46d9eae22acb5d7/pandas-2.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8adff9f138fc614347ff33812046787f7d43b3cef7c0f0171b3340cae333f6ca", size = 11551836, upload-time = "2025-06-05T03:26:22.784Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/cc/0af9c07f8d714ea563b12383a7e5bde9479cf32413ee2f346a9c5a801f22/pandas-2.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e5f08eb9a445d07720776df6e641975665c9ea12c9d8a331e0f6890f2dcd76ef", size = 10807977, upload-time = "2025-06-05T16:50:11.109Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/3e/8c0fb7e2cf4a55198466ced1ca6a9054ae3b7e7630df7757031df10001fd/pandas-2.3.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fa35c266c8cd1a67d75971a1912b185b492d257092bdd2709bbdebe574ed228d", size = 11788230, upload-time = "2025-06-05T03:26:27.417Z" },
-    { url = "https://files.pythonhosted.org/packages/14/22/b493ec614582307faf3f94989be0f7f0a71932ed6f56c9a80c0bb4a3b51e/pandas-2.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14a0cc77b0f089d2d2ffe3007db58f170dae9b9f54e569b299db871a3ab5bf46", size = 12370423, upload-time = "2025-06-05T03:26:34.142Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/74/b012addb34cda5ce855218a37b258c4e056a0b9b334d116e518d72638737/pandas-2.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c06f6f144ad0a1bf84699aeea7eff6068ca5c63ceb404798198af7eb86082e33", size = 12990594, upload-time = "2025-06-06T00:00:13.934Z" },
-    { url = "https://files.pythonhosted.org/packages/95/81/b310e60d033ab64b08e66c635b94076488f0b6ce6a674379dd5b224fc51c/pandas-2.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ed16339bc354a73e0a609df36d256672c7d296f3f767ac07257801aa064ff73c", size = 13745952, upload-time = "2025-06-05T03:26:39.475Z" },
-    { url = "https://files.pythonhosted.org/packages/25/ac/f6ee5250a8881b55bd3aecde9b8cfddea2f2b43e3588bca68a4e9aaf46c8/pandas-2.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:fa07e138b3f6c04addfeaf56cc7fdb96c3b68a3fe5e5401251f231fce40a0d7a", size = 11094534, upload-time = "2025-06-05T03:26:43.23Z" },
-    { url = "https://files.pythonhosted.org/packages/94/46/24192607058dd607dbfacdd060a2370f6afb19c2ccb617406469b9aeb8e7/pandas-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2eb4728a18dcd2908c7fccf74a982e241b467d178724545a48d0caf534b38ebf", size = 11573865, upload-time = "2025-06-05T03:26:46.774Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/cc/ae8ea3b800757a70c9fdccc68b67dc0280a6e814efcf74e4211fd5dea1ca/pandas-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b9d8c3187be7479ea5c3d30c32a5d73d62a621166675063b2edd21bc47614027", size = 10702154, upload-time = "2025-06-05T16:50:14.439Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/ba/a7883d7aab3d24c6540a2768f679e7414582cc389876d469b40ec749d78b/pandas-2.3.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9ff730713d4c4f2f1c860e36c005c7cefc1c7c80c21c0688fd605aa43c9fcf09", size = 11262180, upload-time = "2025-06-05T16:50:17.453Z" },
-    { url = "https://files.pythonhosted.org/packages/01/a5/931fc3ad333d9d87b10107d948d757d67ebcfc33b1988d5faccc39c6845c/pandas-2.3.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba24af48643b12ffe49b27065d3babd52702d95ab70f50e1b34f71ca703e2c0d", size = 11991493, upload-time = "2025-06-05T03:26:51.813Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/bf/0213986830a92d44d55153c1d69b509431a972eb73f204242988c4e66e86/pandas-2.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:404d681c698e3c8a40a61d0cd9412cc7364ab9a9cc6e144ae2992e11a2e77a20", size = 12470733, upload-time = "2025-06-06T00:00:18.651Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/0e/21eb48a3a34a7d4bac982afc2c4eb5ab09f2d988bdf29d92ba9ae8e90a79/pandas-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6021910b086b3ca756755e86ddc64e0ddafd5e58e076c72cb1585162e5ad259b", size = 13212406, upload-time = "2025-06-05T03:26:55.992Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/d9/74017c4eec7a28892d8d6e31ae9de3baef71f5a5286e74e6b7aad7f8c837/pandas-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:094e271a15b579650ebf4c5155c05dcd2a14fd4fdd72cf4854b2f7ad31ea30be", size = 10976199, upload-time = "2025-06-05T03:26:59.594Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/57/5cb75a56a4842bbd0511c3d1c79186d8315b82dac802118322b2de1194fe/pandas-2.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2c7e2fc25f89a49a11599ec1e76821322439d90820108309bf42130d2f36c983", size = 11518913, upload-time = "2025-06-05T03:27:02.757Z" },
-    { url = "https://files.pythonhosted.org/packages/05/01/0c8785610e465e4948a01a059562176e4c8088aa257e2e074db868f86d4e/pandas-2.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c6da97aeb6a6d233fb6b17986234cc723b396b50a3c6804776351994f2a658fd", size = 10655249, upload-time = "2025-06-05T16:50:20.17Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/6a/47fd7517cd8abe72a58706aab2b99e9438360d36dcdb052cf917b7bf3bdc/pandas-2.3.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bb32dc743b52467d488e7a7c8039b821da2826a9ba4f85b89ea95274f863280f", size = 11328359, upload-time = "2025-06-05T03:27:06.431Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/b3/463bfe819ed60fb7e7ddffb4ae2ee04b887b3444feee6c19437b8f834837/pandas-2.3.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:213cd63c43263dbb522c1f8a7c9d072e25900f6975596f883f4bebd77295d4f3", size = 12024789, upload-time = "2025-06-05T03:27:09.875Z" },
-    { url = "https://files.pythonhosted.org/packages/04/0c/e0704ccdb0ac40aeb3434d1c641c43d05f75c92e67525df39575ace35468/pandas-2.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1d2b33e68d0ce64e26a4acc2e72d747292084f4e8db4c847c6f5f6cbe56ed6d8", size = 12480734, upload-time = "2025-06-06T00:00:22.246Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/df/815d6583967001153bb27f5cf075653d69d51ad887ebbf4cfe1173a1ac58/pandas-2.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:430a63bae10b5086995db1b02694996336e5a8ac9a96b4200572b413dfdfccb9", size = 13223381, upload-time = "2025-06-05T03:27:15.641Z" },
-    { url = "https://files.pythonhosted.org/packages/79/88/ca5973ed07b7f484c493e941dbff990861ca55291ff7ac67c815ce347395/pandas-2.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:4930255e28ff5545e2ca404637bcc56f031893142773b3468dc021c6c32a1390", size = 10970135, upload-time = "2025-06-05T03:27:24.131Z" },
-    { url = "https://files.pythonhosted.org/packages/24/fb/0994c14d1f7909ce83f0b1fb27958135513c4f3f2528bde216180aa73bfc/pandas-2.3.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:f925f1ef673b4bd0271b1809b72b3270384f2b7d9d14a189b12b7fc02574d575", size = 12141356, upload-time = "2025-06-05T03:27:34.547Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/a2/9b903e5962134497ac4f8a96f862ee3081cb2506f69f8e4778ce3d9c9d82/pandas-2.3.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78ad363ddb873a631e92a3c063ade1ecfb34cae71e9a2be6ad100f875ac1042", size = 11474674, upload-time = "2025-06-05T03:27:39.448Z" },
-    { url = "https://files.pythonhosted.org/packages/81/3a/3806d041bce032f8de44380f866059437fb79e36d6b22c82c187e65f765b/pandas-2.3.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:951805d146922aed8357e4cc5671b8b0b9be1027f0619cea132a9f3f65f2f09c", size = 11439876, upload-time = "2025-06-05T03:27:43.652Z" },
-    { url = "https://files.pythonhosted.org/packages/15/aa/3fc3181d12b95da71f5c2537c3e3b3af6ab3a8c392ab41ebb766e0929bc6/pandas-2.3.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a881bc1309f3fce34696d07b00f13335c41f5f5a8770a33b09ebe23261cfc67", size = 11966182, upload-time = "2025-06-05T03:27:47.652Z" },
-    { url = "https://files.pythonhosted.org/packages/37/e7/e12f2d9b0a2c4a2cc86e2aabff7ccfd24f03e597d770abfa2acd313ee46b/pandas-2.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e1991bbb96f4050b09b5f811253c4f3cf05ee89a589379aa36cd623f21a31d6f", size = 12547686, upload-time = "2025-06-06T00:00:26.142Z" },
-    { url = "https://files.pythonhosted.org/packages/39/c2/646d2e93e0af70f4e5359d870a63584dacbc324b54d73e6b3267920ff117/pandas-2.3.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:bb3be958022198531eb7ec2008cfc78c5b1eed51af8600c6c5d9160d89d8d249", size = 13231847, upload-time = "2025-06-05T03:27:51.465Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ca/aa97b47287221fa37a49634532e520300088e290b20d690b21ce3e448143/pandas-2.3.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:22c2e866f7209ebc3a8f08d75766566aae02bcc91d196935a1d9e59c7b990ac9", size = 11542731, upload-time = "2025-07-07T19:18:12.619Z" },
+    { url = "https://files.pythonhosted.org/packages/80/bf/7938dddc5f01e18e573dcfb0f1b8c9357d9b5fa6ffdee6e605b92efbdff2/pandas-2.3.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3583d348546201aff730c8c47e49bc159833f971c2899d6097bce68b9112a4f1", size = 10790031, upload-time = "2025-07-07T19:18:16.611Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/2f/9af748366763b2a494fed477f88051dbf06f56053d5c00eba652697e3f94/pandas-2.3.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0f951fbb702dacd390561e0ea45cdd8ecfa7fb56935eb3dd78e306c19104b9b0", size = 11724083, upload-time = "2025-07-07T19:18:20.512Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/95/79ab37aa4c25d1e7df953dde407bb9c3e4ae47d154bc0dd1692f3a6dcf8c/pandas-2.3.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cd05b72ec02ebfb993569b4931b2e16fbb4d6ad6ce80224a3ee838387d83a191", size = 12342360, upload-time = "2025-07-07T19:18:23.194Z" },
+    { url = "https://files.pythonhosted.org/packages/75/a7/d65e5d8665c12c3c6ff5edd9709d5836ec9b6f80071b7f4a718c6106e86e/pandas-2.3.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:1b916a627919a247d865aed068eb65eb91a344b13f5b57ab9f610b7716c92de1", size = 13202098, upload-time = "2025-07-07T19:18:25.558Z" },
+    { url = "https://files.pythonhosted.org/packages/65/f3/4c1dbd754dbaa79dbf8b537800cb2fa1a6e534764fef50ab1f7533226c5c/pandas-2.3.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:fe67dc676818c186d5a3d5425250e40f179c2a89145df477dd82945eaea89e97", size = 13837228, upload-time = "2025-07-07T19:18:28.344Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/d6/d7f5777162aa9b48ec3910bca5a58c9b5927cfd9cfde3aa64322f5ba4b9f/pandas-2.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:2eb789ae0274672acbd3c575b0598d213345660120a257b47b5dafdc618aec83", size = 11336561, upload-time = "2025-07-07T19:18:31.211Z" },
+    { url = "https://files.pythonhosted.org/packages/76/1c/ccf70029e927e473a4476c00e0d5b32e623bff27f0402d0a92b7fc29bb9f/pandas-2.3.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2b0540963d83431f5ce8870ea02a7430adca100cec8a050f0811f8e31035541b", size = 11566608, upload-time = "2025-07-07T19:18:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/d3/3c37cb724d76a841f14b8f5fe57e5e3645207cc67370e4f84717e8bb7657/pandas-2.3.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:fe7317f578c6a153912bd2292f02e40c1d8f253e93c599e82620c7f69755c74f", size = 10823181, upload-time = "2025-07-07T19:18:36.151Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/4c/367c98854a1251940edf54a4df0826dcacfb987f9068abf3e3064081a382/pandas-2.3.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e6723a27ad7b244c0c79d8e7007092d7c8f0f11305770e2f4cd778b3ad5f9f85", size = 11793570, upload-time = "2025-07-07T19:18:38.385Z" },
+    { url = "https://files.pythonhosted.org/packages/07/5f/63760ff107bcf5146eee41b38b3985f9055e710a72fdd637b791dea3495c/pandas-2.3.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3462c3735fe19f2638f2c3a40bd94ec2dc5ba13abbb032dd2fa1f540a075509d", size = 12378887, upload-time = "2025-07-07T19:18:41.284Z" },
+    { url = "https://files.pythonhosted.org/packages/15/53/f31a9b4dfe73fe4711c3a609bd8e60238022f48eacedc257cd13ae9327a7/pandas-2.3.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:98bcc8b5bf7afed22cc753a28bc4d9e26e078e777066bc53fac7904ddef9a678", size = 13230957, upload-time = "2025-07-07T19:18:44.187Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/94/6fce6bf85b5056d065e0a7933cba2616dcb48596f7ba3c6341ec4bcc529d/pandas-2.3.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4d544806b485ddf29e52d75b1f559142514e60ef58a832f74fb38e48d757b299", size = 13883883, upload-time = "2025-07-07T19:18:46.498Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/7b/bdcb1ed8fccb63d04bdb7635161d0ec26596d92c9d7a6cce964e7876b6c1/pandas-2.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:b3cd4273d3cb3707b6fffd217204c52ed92859533e31dc03b7c5008aa933aaab", size = 11340212, upload-time = "2025-07-07T19:18:49.293Z" },
+    { url = "https://files.pythonhosted.org/packages/46/de/b8445e0f5d217a99fe0eeb2f4988070908979bec3587c0633e5428ab596c/pandas-2.3.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:689968e841136f9e542020698ee1c4fbe9caa2ed2213ae2388dc7b81721510d3", size = 11588172, upload-time = "2025-07-07T19:18:52.054Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/e0/801cdb3564e65a5ac041ab99ea6f1d802a6c325bb6e58c79c06a3f1cd010/pandas-2.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:025e92411c16cbe5bb2a4abc99732a6b132f439b8aab23a59fa593eb00704232", size = 10717365, upload-time = "2025-07-07T19:18:54.785Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a5/c76a8311833c24ae61a376dbf360eb1b1c9247a5d9c1e8b356563b31b80c/pandas-2.3.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9b7ff55f31c4fcb3e316e8f7fa194566b286d6ac430afec0d461163312c5841e", size = 11280411, upload-time = "2025-07-07T19:18:57.045Z" },
+    { url = "https://files.pythonhosted.org/packages/da/01/e383018feba0a1ead6cf5fe8728e5d767fee02f06a3d800e82c489e5daaf/pandas-2.3.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7dcb79bf373a47d2a40cf7232928eb7540155abbc460925c2c96d2d30b006eb4", size = 11988013, upload-time = "2025-07-07T19:18:59.771Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/14/cec7760d7c9507f11c97d64f29022e12a6cc4fc03ac694535e89f88ad2ec/pandas-2.3.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:56a342b231e8862c96bdb6ab97170e203ce511f4d0429589c8ede1ee8ece48b8", size = 12767210, upload-time = "2025-07-07T19:19:02.944Z" },
+    { url = "https://files.pythonhosted.org/packages/50/b9/6e2d2c6728ed29fb3d4d4d302504fb66f1a543e37eb2e43f352a86365cdf/pandas-2.3.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ca7ed14832bce68baef331f4d7f294411bed8efd032f8109d690df45e00c4679", size = 13440571, upload-time = "2025-07-07T19:19:06.82Z" },
+    { url = "https://files.pythonhosted.org/packages/80/a5/3a92893e7399a691bad7664d977cb5e7c81cf666c81f89ea76ba2bff483d/pandas-2.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:ac942bfd0aca577bef61f2bc8da8147c4ef6879965ef883d8e8d5d2dc3e744b8", size = 10987601, upload-time = "2025-07-07T19:19:09.589Z" },
+    { url = "https://files.pythonhosted.org/packages/32/ed/ff0a67a2c5505e1854e6715586ac6693dd860fbf52ef9f81edee200266e7/pandas-2.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9026bd4a80108fac2239294a15ef9003c4ee191a0f64b90f170b40cfb7cf2d22", size = 11531393, upload-time = "2025-07-07T19:19:12.245Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/db/d8f24a7cc9fb0972adab0cc80b6817e8bef888cfd0024eeb5a21c0bb5c4a/pandas-2.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6de8547d4fdb12421e2d047a2c446c623ff4c11f47fddb6b9169eb98ffba485a", size = 10668750, upload-time = "2025-07-07T19:19:14.612Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/b0/80f6ec783313f1e2356b28b4fd8d2148c378370045da918c73145e6aab50/pandas-2.3.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:782647ddc63c83133b2506912cc6b108140a38a37292102aaa19c81c83db2928", size = 11342004, upload-time = "2025-07-07T19:19:16.857Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/e2/20a317688435470872885e7fc8f95109ae9683dec7c50be29b56911515a5/pandas-2.3.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ba6aff74075311fc88504b1db890187a3cd0f887a5b10f5525f8e2ef55bfdb9", size = 12050869, upload-time = "2025-07-07T19:19:19.265Z" },
+    { url = "https://files.pythonhosted.org/packages/55/79/20d746b0a96c67203a5bee5fb4e00ac49c3e8009a39e1f78de264ecc5729/pandas-2.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e5635178b387bd2ba4ac040f82bc2ef6e6b500483975c4ebacd34bec945fda12", size = 12750218, upload-time = "2025-07-07T19:19:21.547Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/0f/145c8b41e48dbf03dd18fdd7f24f8ba95b8254a97a3379048378f33e7838/pandas-2.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f3bf5ec947526106399a9e1d26d40ee2b259c66422efdf4de63c848492d91bb", size = 13416763, upload-time = "2025-07-07T19:19:23.939Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/c0/54415af59db5cdd86a3d3bf79863e8cc3fa9ed265f0745254061ac09d5f2/pandas-2.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:1c78cf43c8fde236342a1cb2c34bcff89564a7bfed7e474ed2fffa6aed03a956", size = 10987482, upload-time = "2025-07-07T19:19:42.699Z" },
+    { url = "https://files.pythonhosted.org/packages/48/64/2fd2e400073a1230e13b8cd604c9bc95d9e3b962e5d44088ead2e8f0cfec/pandas-2.3.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:8dfc17328e8da77be3cf9f47509e5637ba8f137148ed0e9b5241e1baf526e20a", size = 12029159, upload-time = "2025-07-07T19:19:26.362Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/0a/d84fd79b0293b7ef88c760d7dca69828d867c89b6d9bc52d6a27e4d87316/pandas-2.3.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:ec6c851509364c59a5344458ab935e6451b31b818be467eb24b0fe89bd05b6b9", size = 11393287, upload-time = "2025-07-07T19:19:29.157Z" },
+    { url = "https://files.pythonhosted.org/packages/50/ae/ff885d2b6e88f3c7520bb74ba319268b42f05d7e583b5dded9837da2723f/pandas-2.3.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:911580460fc4884d9b05254b38a6bfadddfcc6aaef856fb5859e7ca202e45275", size = 11309381, upload-time = "2025-07-07T19:19:31.436Z" },
+    { url = "https://files.pythonhosted.org/packages/85/86/1fa345fc17caf5d7780d2699985c03dbe186c68fee00b526813939062bb0/pandas-2.3.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2f4d6feeba91744872a600e6edbbd5b033005b431d5ae8379abee5bcfa479fab", size = 11883998, upload-time = "2025-07-07T19:19:34.267Z" },
+    { url = "https://files.pythonhosted.org/packages/81/aa/e58541a49b5e6310d89474333e994ee57fea97c8aaa8fc7f00b873059bbf/pandas-2.3.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fe37e757f462d31a9cd7580236a82f353f5713a80e059a29753cf938c6775d96", size = 12704705, upload-time = "2025-07-07T19:19:36.856Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f9/07086f5b0f2a19872554abeea7658200824f5835c58a106fa8f2ae96a46c/pandas-2.3.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:5db9637dbc24b631ff3707269ae4559bce4b7fd75c1c4d7e13f40edc42df4444", size = 13189044, upload-time = "2025-07-07T19:19:39.999Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Moves all the patching to `patch_model`, and fixes default value for `attn_implementation`.