### PR TITLE
fix: checkpoint test additional testing

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -193,15 +193,15 @@ jobs:
             runner: linux-amd64-gpu-rtxa6000-latest-2-nemo
           - script: L2_HF_Transformer_PEFT_nvfsdp
             runner: linux-amd64-gpu-rtxa6000-latest-2-nemo
-          - script: L2_DCP_Checkpoint
+          - script: L2_DCP_FSDP2_Checkpoint
             runner: linux-amd64-gpu-rtxa6000-latest-2-nemo
-          - script: L2_HF_DCP_Checkpoint
+          - script: L2_HF_DCP_FSDP2_Checkpoint
             runner: linux-amd64-gpu-rtxa6000-latest-2-nemo
-          - script: L2_HF_Consolidated_Checkpoint
+          - script: L2_HF_Consolidated_FSDP2_Checkpoint
             runner: linux-amd64-gpu-rtxa6000-latest-2-nemo
-#          - script: L2_HF_PEFT_Triton_Checkpoint
+#          - script: L2_HF_PEFT_Triton_FSDP2_Checkpoint
 #            runner: linux-amd64-gpu-rtxa6000-latest-2-nemo
-          - script: L2_HF_PEFT_Checkpoint
+          - script: L2_HF_PEFT_FSDP2_Checkpoint
             runner: linux-amd64-gpu-rtxa6000-latest-2-nemo
     needs: [cicd-unit-tests]
     runs-on: ${{ matrix.runner }}

--- a/tests/functional_tests/L2_DCP_FSDP2_Checkpoint.sh
+++ b/tests/functional_tests/L2_DCP_FSDP2_Checkpoint.sh
@@ -33,5 +33,10 @@ TRANSFORMERS_OFFLINE=1 python -m torch.distributed.run --nproc_per_node=2 --nnod
     --checkpoint.enabled true \
     --checkpoint.checkpoint_dir checkpoints/ \
     --checkpoint.model_save_format torch_save \
-    --dataloader.batch_size 8
+    --dataloader.batch_size 8 \
+    --distributed._target_ nemo_automodel.distributed.fsdp2.FSDP2Manager \
+    --distributed.dp_size none \
+    --distributed.tp_size 1 \
+    --distributed.cp_size 1 \
+    --distributed.sequence_parallel false
 coverage combine

--- a/tests/functional_tests/L2_HF_Consolidated_FSDP2_Checkpoint.sh
+++ b/tests/functional_tests/L2_HF_Consolidated_FSDP2_Checkpoint.sh
@@ -34,5 +34,10 @@ TRANSFORMERS_OFFLINE=1 python -m torch.distributed.run --nproc_per_node=2 --nnod
     --checkpoint.checkpoint_dir checkpoints/ \
     --checkpoint.model_save_format safetensors \
     --checkpoint.save_consolidated true \
-    --dataloader.batch_size 8
+    --dataloader.batch_size 8 \
+    --distributed._target_ nemo_automodel.distributed.fsdp2.FSDP2Manager \
+    --distributed.dp_size none \
+    --distributed.tp_size 1 \
+    --distributed.cp_size 1 \
+    --distributed.sequence_parallel false
 coverage combine

--- a/tests/functional_tests/L2_HF_DCP_FSDP2_Checkpoint.sh
+++ b/tests/functional_tests/L2_HF_DCP_FSDP2_Checkpoint.sh
@@ -18,8 +18,8 @@ set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 export PYTHONPATH=${PYTHONPATH:-}:$(pwd)
 export CUDA_VISIBLE_DEVICES="0,1"
 
-TRANSFORMERS_OFFLINE=1 python -m torch.distributed.run --nproc_per_node=2 --nnodes=1 -m coverage run --data-file=/workspace/.coverage --source=/workspace --parallel-mode \
--m pytest tests/functional_tests/checkpoint/test_peft.py \
+TRANSFORMERS_OFFLINE=1 python -m torch.distributed.run --nproc_per_node=2 --nnodes=1 -m coverage run --data-file=/workspace/.coverage --source=/workspace/ --parallel-mode \
+-m pytest tests/functional_tests/checkpoint/test_hf_sharded.py \
     --config recipes/llm/llama_3_2_1b_squad.yaml \
     --model.pretrained_model_name_or_path /home/TestData/akoumparouli/hf_mixtral_2l/ \
     --step_scheduler.max_steps 10 \
@@ -32,10 +32,11 @@ TRANSFORMERS_OFFLINE=1 python -m torch.distributed.run --nproc_per_node=2 --nnod
     --step_scheduler.ckpt_every_steps 10 \
     --checkpoint.enabled true \
     --checkpoint.checkpoint_dir checkpoints/ \
+    --checkpoint.model_save_format safetensors \
     --dataloader.batch_size 8 \
-    --peft.match_all_linear true \
-    --peft.dim 8 \
-    --peft.alpha 32 \
-    --peft.use_triton true \
-    --peft.peft_fn nemo_automodel._peft.lora.apply_lora_to_linear_modules
+    --distributed._target_ nemo_automodel.distributed.fsdp2.FSDP2Manager \
+    --distributed.dp_size none \
+    --distributed.tp_size 1 \
+    --distributed.cp_size 1 \
+    --distributed.sequence_parallel false
 coverage combine

--- a/tests/functional_tests/L2_HF_PEFT_FSDP2_Checkpoint.sh
+++ b/tests/functional_tests/L2_HF_PEFT_FSDP2_Checkpoint.sh
@@ -37,5 +37,10 @@ TRANSFORMERS_OFFLINE=1 python -m torch.distributed.run --nproc_per_node=2 --nnod
     --peft.dim 8 \
     --peft.alpha 32 \
     --peft.use_triton false \
-    --peft._target_ nemo_automodel._peft.lora.PeftConfig
+    --peft._target_ nemo_automodel._peft.lora.PeftConfig \
+    --distributed._target_ nemo_automodel.distributed.fsdp2.FSDP2Manager \
+    --distributed.dp_size none \
+    --distributed.tp_size 1 \
+    --distributed.cp_size 1 \
+    --distributed.sequence_parallel false
 coverage combine

--- a/tests/functional_tests/L2_HF_PEFT_Triton_FSDP2_Checkpoint.sh
+++ b/tests/functional_tests/L2_HF_PEFT_Triton_FSDP2_Checkpoint.sh
@@ -18,8 +18,8 @@ set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
 export PYTHONPATH=${PYTHONPATH:-}:$(pwd)
 export CUDA_VISIBLE_DEVICES="0,1"
 
-TRANSFORMERS_OFFLINE=1 python -m torch.distributed.run --nproc_per_node=2 --nnodes=1 -m coverage run --data-file=/workspace/.coverage --source=/workspace/ --parallel-mode \
--m pytest tests/functional_tests/checkpoint/test_hf_sharded.py \
+TRANSFORMERS_OFFLINE=1 python -m torch.distributed.run --nproc_per_node=2 --nnodes=1 -m coverage run --data-file=/workspace/.coverage --source=/workspace --parallel-mode \
+-m pytest tests/functional_tests/checkpoint/test_peft.py \
     --config recipes/llm/llama_3_2_1b_squad.yaml \
     --model.pretrained_model_name_or_path /home/TestData/akoumparouli/hf_mixtral_2l/ \
     --step_scheduler.max_steps 10 \
@@ -32,6 +32,15 @@ TRANSFORMERS_OFFLINE=1 python -m torch.distributed.run --nproc_per_node=2 --nnod
     --step_scheduler.ckpt_every_steps 10 \
     --checkpoint.enabled true \
     --checkpoint.checkpoint_dir checkpoints/ \
-    --checkpoint.model_save_format safetensors \
-    --dataloader.batch_size 8
+    --dataloader.batch_size 8 \
+    --peft.match_all_linear true \
+    --peft.dim 8 \
+    --peft.alpha 32 \
+    --peft.use_triton true \
+    --peft.peft_fn nemo_automodel._peft.lora.apply_lora_to_linear_modules \
+    --distributed._target_ nemo_automodel.distributed.fsdp2.FSDP2Manager \
+    --distributed.dp_size none \
+    --distributed.tp_size 1 \
+    --distributed.cp_size 1 \
+    --distributed.sequence_parallel false
 coverage combine

--- a/tests/functional_tests/checkpoint/test_peft.py
+++ b/tests/functional_tests/checkpoint/test_peft.py
@@ -17,17 +17,37 @@
 
 import json
 import os
+import shutil
 from pathlib import Path
 
 import torch
 import torch.distributed.checkpoint as dcp
 import torch.distributed.tensor
+import torch.nn as nn
+from peft import PeftModel
 from safetensors import safe_open
+from transformers import AutoModelForCausalLM
 
 from nemo_automodel.checkpoint._backports.hf_storage import _HuggingFaceStorageReader
+from nemo_automodel.checkpoint.checkpointing import load_model
 from nemo_automodel.checkpoint.stateful_wrappers import ModelState, OptimizerState
 from nemo_automodel.config.cli import parse_args_and_load_config
-from recipes.llm.finetune import FinetuneRecipeForNextTokenPrediction
+from recipes.llm.finetune import FinetuneRecipeForNextTokenPrediction, build_model_and_optimizer
+
+
+def get_new_model(trainer: FinetuneRecipeForNextTokenPrediction) -> nn.Module:
+    """Gets a new model."""
+    use_hf_fa2 = trainer.cfg.get("packed_sequence.packed_sequence_size", 0) > 0
+    return build_model_and_optimizer(
+        trainer.dist_env.device,
+        trainer.cfg.model,
+        trainer.cfg.optimizer,
+        use_hf_fa2,
+        trainer.peft_config,
+        trainer.model_wrapper,
+        trainer.cfg.get("seed", 42),
+        trainer.cfg.get("distributed.tp_size", 1),
+    )[0]
 
 
 def load_dcp(ckpt_dir: Path | str) -> dict[str, torch.Tensor]:
@@ -79,6 +99,23 @@ def to_cpu(
     Converts a state dictionary to CPU.
     """
     return {k: v.cpu() if isinstance(v, torch.Tensor) else to_cpu(v) for k, v in state_dict.items()}
+
+
+def get_validation_loss(
+    model: nn.Module, val_batch: dict[str, torch.Tensor], loss_fn: nn.Module, device: torch.device
+) -> torch.Tensor:
+    """Gets the validation loss for a model."""
+    val_batch = {k: v.to(device, non_blocking=True) for k, v in val_batch.items()}
+    model.eval()
+    labels = val_batch.pop("labels")
+    loss_mask = val_batch.pop("loss_mask", None)
+    if loss_mask is None:
+        loss_mask = (labels.detach() != -100).to(torch.int)
+
+    with torch.no_grad():
+        out = model(**val_batch)
+        loss = loss_fn(out.logits.view(-1, out.logits.size(-1)), labels.view(-1), mask=loss_mask, reduction="sum")
+        return loss
 
 
 def test_hf_peft_checkpoint():
@@ -1871,6 +1908,18 @@ def test_hf_peft_checkpoint():
     _compare_dicts(expected_config, restored_config)
     _compare_dicts(expected_automodel_peft_config, restored_automodel_peft_config)
 
+    # check if new model and current model give the same CE loss
+    val_batch = next(iter(trainer.val_dataloader))
+    restored_model = get_new_model(trainer)
+    load_model(
+        restored_model,
+        Path(trainer.checkpoint_config.checkpoint_dir) / "epoch_0_step_10",
+        trainer.checkpoint_config,
+    )
+    source_model_loss = get_validation_loss(trainer.model, val_batch, trainer.loss_fn, trainer.dist_env.device)
+    restored_model_loss = get_validation_loss(restored_model, val_batch, trainer.loss_fn, trainer.dist_env.device)
+    assert torch.allclose(source_model_loss, restored_model_loss), "Model loss mismatch"
+
     # at save time, the model is saved in a dictionary formatted as:
     # {
     #     "model": ModelState(...)
@@ -1978,6 +2027,28 @@ def test_hf_peft_checkpoint():
             f"Device mismatch for key {k}. Expected device {expected_device} but got {curr_shard.device}"
         )
         assert torch.allclose(v, curr_shard), f"Value mismatch for key {k}. Tensors are not numerically close"
+
+    # finally check if the adapters loaded into the PEFT module are the same as the model we have trained
+    if torch.distributed.get_rank() == 0:
+        base = AutoModelForCausalLM.from_pretrained(cfg.model.pretrained_model_name_or_path)
+        peft_model = PeftModel.from_pretrained(
+            base, Path(trainer.checkpoint_config.checkpoint_dir) / "epoch_0_step_10" / "model"
+        ).to(trainer.model.dtype)
+
+        for source_key, source_param in model_state_dict.items():
+            # source key example: 'base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight'
+            for peft_model_key, peft_model_param in peft_model.named_parameters():
+                if "lora" in peft_model_key and source_key.rsplit(".", 1)[0] in peft_model_key:
+                    assert torch.allclose(source_param, peft_model_param), (
+                        "Parameter values are different when they should be the same"
+                    )
+    torch.distributed.barrier()
+
+    if torch.distributed.get_rank() == 0:
+        # delete the checkpoint directory
+        if Path(trainer.checkpoint_config.checkpoint_dir).exists():
+            shutil.rmtree(Path(trainer.checkpoint_config.checkpoint_dir))
+    torch.distributed.barrier()
 
 
 def _flatten(d: dict, parent_key: str | None = None):

--- a/tests/functional_tests/conftest.py
+++ b/tests/functional_tests/conftest.py
@@ -38,6 +38,11 @@ _OVERRIDES = [
     "peft.alpha",
     "peft.use_triton",
     "peft._target_",
+    "distributed._target_",
+    "distributed.dp_size",
+    "distributed.tp_size",
+    "distributed.cp_size",
+    "distributed.sequence_parallel",
 ]
 
 


### PR DESCRIPTION
For all tests:
- Adds an extra layer of protection by loading the saved checkpoint into a new (NeMo Automodel) model and running a `torch.allclose` on the CE loss for a validation batch.
*Note:* This is actually necessary for nvFSDP because there are hooks that get set off when weights are loaded into a model. To ensure checkpoint reloading correctness, we need the above check. Checking the state dict on its own is not sufficient.

For HF (full-model) tests:
- Loads the model into `AutoModelForCausalLM` from HF API and verifies the weights are the same

For HF (PEFT) tests:
- Loads the model using the `PEFT` module and verifies the weights are correctly loaded in.

