### PR TITLE
fix: param override in fallback

### DIFF
--- a/nemo_automodel/components/_transformers/auto_model.py
+++ b/nemo_automodel/components/_transformers/auto_model.py
@@ -16,11 +16,12 @@ import functools
 import inspect
 import logging
 import types
-from typing import Optional, List
+from typing import List, Optional, Union
 
 import torch
 from torch.nn.attention import SDPBackend, sdpa_kernel
-from transformers import PreTrainedModel, AutoModelForCausalLM, AutoModelForImageTextToText
+from transformers import AutoModelForCausalLM, AutoModelForImageTextToText, PreTrainedModel
+from transformers.models.auto.auto_factory import _BaseAutoModelClass
 
 from nemo_automodel import __version__
 from nemo_automodel.shared.import_utils import safe_import
@@ -41,7 +42,7 @@ def _assert_same_signature(original, patched):
         raise AssertionError(f"Signature mismatch:\n  original: {sig_orig}\n  patched : {sig_patch}")
 
 
-def patch_attention(obj, sdpa_method=None):
+def _patch_attention(obj, sdpa_method=None):
     """
     Wrap the `forward` method of `obj` in an `sdap_kernel` context manager.
 
@@ -98,18 +99,246 @@ def _patch_liger_kernel(model):
     """
     if not HAS_LIGER_KERNEL:
         logging.warning("Asked to use Liger Kernel, but could not import")
-    else:
+        return model
+
+    try:
+        liger_kernel_trf._apply_liger_kernel_to_instance(model=model)
+        logging.info("Applied liger-kernel to model")
+        return model
+    except Exception:
+        logging.warning("Failed to apply liger-kernels to model; falling back to eager")
+        del model
+        raise RuntimeError("Failed to patch model")
+
+
+class _BaseNeMoAutoModelClass(_BaseAutoModelClass):
+    """
+    Drop-in replacement for ``_BaseAutoModelClass`` that includes custom-kernels.
+
+    The class only overrides ``from_pretrained`` and ``from_config`` to add the
+    optional ``use_liger_kernel`` flag.  If the flag is ``True`` (default) and
+    the Liger kernel is available, the model's attention layers are
+    monkey-patched in place.  If patching fails for any reason, the call is
+    retried once with ``use_liger_kernel=False`` so that users still obtain a
+    functional model.
+
+
+    TODO(@akoumpa): extend this beyond liger_kernel.
+
+    Notes:
+    -----
+    - No changes are made to the model's public API; forward signatures,
+      generation utilities, and weight shapes remain identical.
+    - Only decoder-style (causal) architectures are currently supported by the
+      Liger patch.  Unsupported models will silently fall back.
+    """
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path,
+        *model_args,
+        use_liger_kernel: bool = True,
+        use_sdpa_patching: bool = True,
+        sdpa_method: Optional[List[SDPBackend]] = None,
+        torch_dtype="auto",
+        attn_implementation: str = "flash_attention_2",
+        **kwargs,
+    ) -> PreTrainedModel:
+        """
+        Instantiate and (optionally) patch a causal-language model.
+
+        This is a light wrapper around
+        `transformers.AutoModelForCausalLM.from_pretrained` that can
+        automatically apply Liger and/or SDPA (scaled-dot-product
+        attention) kernel optimizations.
+
+        Args:
+            pretrained_model_name_or_path (str | os.PathLike): Hugging Face
+                hub repo ID or local path accepted by
+                `AutoModelForCausalLM.from_pretrained`.
+            *model_args: Positional arguments forwarded verbatim to
+                `AutoModelForCausalLM.from_pretrained`.
+            use_liger_kernel (bool, default=True): If `True`, try to patch
+                the model with Liger kernels for faster inference/training.
+            use_sdpa_patching (bool, default=True): If `True`, patch the
+                model with SDPA-based attention optimizations.
+            sdpa_method (list[SDPBackend] | None, optional): Explicit list of
+                SDPA back-ends to consider when `use_sdpa_patching=True`.
+            torch_dtype (str | torch.dtype | Literal["auto"], default="auto"):
+                Data type passed to the underlying `from_pretrained` call.
+            attn_implementation (str, default="flash_attention_2"): Desired
+                attention implementation; forwarded to the HF config.
+            **kwargs: Additional keyword arguments forwarded verbatim to
+                `AutoModelForCausalLM.from_pretrained`.
+
+        Returns:
+            transformers.PreTrainedModel: The loaded (and possibly patched)
+            model instance.
+
+        Warns:
+            UserWarning: Emitted when `use_liger_kernel=True` but the Liger
+            package is unavailable.
+
+        Notes:
+            If kernel patching fails, the partially constructed model is
+              deleted and the method recurses once with
+              `use_liger_kernel=False` or `use_sdpa_patching=False`
+        """
+        torch_dtype = dtype_from_str(torch_dtype) if torch_dtype != "auto" else torch_dtype
+
+        def _retry(**override):
+            """Internal helper to re-enter this function with patched args."""
+            return cls.from_pretrained(
+                pretrained_model_name_or_path,
+                *model_args,
+                torch_dtype=torch_dtype,
+                attn_implementation=override.get("attn_implementation", attn_implementation),
+                use_liger_kernel=override.get("use_liger_kernel", use_liger_kernel),
+                use_sdpa_patching=override.get("use_sdpa_patching", use_sdpa_patching),
+                sdpa_method=sdpa_method,
+                **kwargs,
+            )
+
+        # load model
         try:
-            liger_kernel_trf._apply_liger_kernel_to_instance(model=model)
-            logging.info("Applied liger-kernel to model")
-        except Exception:
-            logging.warning("Failed to apply liger-kernels to model; falling back to eager")
-            del model
-            raise RuntimeError("Failed to patch model")
-    return model
+            model = super().from_pretrained(
+                pretrained_model_name_or_path,
+                *model_args,
+                torch_dtype=torch_dtype,
+                attn_implementation=attn_implementation,
+                **kwargs,
+            )
+        except ValueError as e:
+            if "does not support" in str(e):
+                logging.warning("Falling back to eager attention.")
+                return _retry(attn_implementation="eager")
+            raise e
+
+        # Kernel patching
+        try:
+            if use_liger_kernel:
+                model = _patch_liger_kernel(model)
+        except RuntimeError:
+            logging.warning("Retrying without Liger kernels.")
+            return _retry(use_liger_kernel=False)
+
+        # Patch sdpa attention
+        try:
+            if use_sdpa_patching:
+                model = _patch_attention(model, sdpa_method)
+        except:
+            logging.warning("Retrying without Liger kernels.")
+            return _retry(use_sdpa_patching=False)
+
+        model.config.update({"nemo_version": __version__})
+        return model
+
+    @classmethod
+    def from_config(
+        cls,
+        config,
+        *model_args,
+        use_liger_kernel: bool = True,
+        use_sdpa_patching: bool = True,
+        sdpa_method: Optional[List[SDPBackend]] = None,
+        torch_dtype: Union[str, torch.dtype] = "auto",
+        attn_implementation: str = "flash_attention_2",
+        **kwargs,
+    ) -> PreTrainedModel:
+        """
+        Instantiate a model from a ``transformers.PretrainedConfig`` and optionally
+        patch it with Liger or SDPA-optimized kernels.
+
+        Args:
+            config (transformers.PretrainedConfig):
+                The configuration object used to build the model.
+            *model_args:
+                Positional arguments forwarded to the underlying
+                ``transformers.AutoModelForCausalLM.from_config`` call.
+            use_liger_kernel (bool, optional):
+                If ``True``, tries to patch the instantiated model with Liger
+                optimized attention kernels. Defaults to ``True``.
+            use_sdpa_patching (bool, optional):
+                If ``True``, applies in-place SDPA (Scaled-Dot-Product-Attention)
+                kernel optimizations wherever possible. Defaults to ``True``.
+            sdpa_method (Optional[List[SDPBackend]], optional):
+                One or multiple SDPA back-ends to prefer when applying SDPA
+                patching. When ``None``, the default backend resolution logic is
+                used. Defaults to ``None``.
+            torch_dtype (Union[str, torch.dtype], optional):
+                The desired data type for model initialization
+                (e.g., ``"auto"``, ``torch.float16``). Passed through to
+                ``transformers.AutoModel``. Defaults to ``"auto"``.
+            attn_implementation (str, optional):
+                Specifies which attention implementation to use (e.g.,
+                ``"flash_attention_2"``, ``"eager"``). Only applied when the
+                base model supports this kwarg. Defaults to
+                ``"flash_attention_2"``.
+            **kwargs:
+                Additional keyword arguments forwarded to the superclass
+                constructor and underlying ``from_config`` logic.
+
+        Returns:
+            transformers.PreTrainedModel: The instantiated (and possibly
+            kernel-patched) model.
+
+        Notes:
+            If kernel patching fails, the partially constructed model is
+              deleted and the method recurses once with
+              `use_liger_kernel=False` or `use_sdpa_patching=False`
+        """
+        torch_dtype = dtype_from_str(torch_dtype) if torch_dtype != "auto" else torch_dtype
+
+        def _retry(**override):
+            """Internal helper to re-enter this function with patched args."""
+            return cls.from_config(
+                config,
+                *model_args,
+                torch_dtype=torch_dtype,
+                attn_implementation=override.get("attn_implementation", attn_implementation),
+                use_liger_kernel=override.get("use_liger_kernel", use_liger_kernel),
+                use_sdpa_patching=override.get("use_sdpa_patching", use_sdpa_patching),
+                sdpa_method=sdpa_method,
+                **kwargs,
+            )
+
+        # load model
+        try:
+            model = super().from_config(
+                config,
+                *model_args,
+                torch_dtype=torch_dtype,
+                attn_implementation=attn_implementation,
+                **kwargs,
+            )
+        except ValueError as e:
+            if "does not support" in str(e):
+                logging.warning("Falling back to eager attention.")
+                return _retry(attn_implementation="eager")
+            raise e
+
+        # Kernel patching
+        try:
+            if use_liger_kernel:
+                model = _patch_liger_kernel(model)
+        except RuntimeError:
+            logging.warning("Retrying without Liger kernels.")
+            return _retry(use_liger_kernel=False)
+
+        # Patch sdpa attention
+        try:
+            if use_sdpa_patching:
+                model = _patch_attention(model, sdpa_method)
+        except:
+            logging.warning("Retrying without Liger kernels.")
+            return _retry(use_sdpa_patching=False)
+
+        model.config.update({"nemo_version": __version__})
+        return model
 
 
-class NeMoAutoModelForCausalLM(AutoModelForCausalLM):
+class NeMoAutoModelForCausalLM(_BaseNeMoAutoModelClass, AutoModelForCausalLM):
     """
     Drop-in replacement for ``transformers.AutoModelForCausalLM`` that includes custom-kernels.
 
@@ -137,145 +366,10 @@ class NeMoAutoModelForCausalLM(AutoModelForCausalLM):
     ...     "gpt2", use_liger_kernel=False)                                 # skip Liger
     """
 
-    @classmethod
-    def from_pretrained(
-        cls,
-        pretrained_model_name_or_path,
-        *model_args,
-        use_liger_kernel: bool = True,
-        use_sdpa_patching: bool = True,
-        sdpa_method: Optional[List[SDPBackend]] = None,
-        torch_dtype="auto",
-        attn_implementation: str = "flash_attention_2",
-        **kwargs,
-    ) -> PreTrainedModel:
-        """
-        Load a pretrained causal-language-model and (optionally) patch it with custom kernels.
-
-        Parameters
-        ----------
-        pretrained_model_name_or_path : str or os.PathLike
-            Repository ID or local path accepted by
-            ``transformers.AutoModelForCausalLM.from_pretrained``.
-        *model_args
-            Positional arguments forwarded verbatim to the superclass.
-        use_liger_kernel : bool, default True
-            Whether to attempt patching the loaded model with Liger kernels.
-        use_sdpa_patching : bool, default True
-            Whether to patch the model with SDPA kernel optimizations.
-        **kwargs
-            Keyword arguments forwarded verbatim to the superclass.
-
-        Returns:
-        -------
-        transformers.PreTrainedModel
-            The instantiated model, possibly Liger-patched.
-
-        Warnings:
-        --------
-        Emits a ``logging.warning`` if ``use_liger_kernel=True`` but the Liger
-        package is not available.
-
-        Retries
-        -------
-        If patching raises an exception, the method deletes the partially
-        constructed model and recursively reloads it once with
-        ``use_liger_kernel=False``.
-        """
-        torch_dtype = dtype_from_str(torch_dtype) if torch_dtype != "auto" else torch_dtype
-
-        def _retry(**override):
-            """Internal helper to re-enter this function with patched args."""
-            return cls.from_pretrained(
-                pretrained_model_name_or_path,
-                *model_args,
-                torch_dtype=torch_dtype,
-                attn_implementation=override.get("attn_implementation", attn_implementation),
-                use_liger_kernel=override.get("use_liger_kernel", use_liger_kernel),
-                use_sdpa_patching=override.get("use_sdpa_patching", use_sdpa_patching),
-                sdpa_method=sdpa_method,
-                **kwargs,
-            )
-        # load model
-        try:
-            model = super().from_pretrained(
-                pretrained_model_name_or_path,
-                *model_args,
-                torch_dtype=torch_dtype,
-                attn_implementation=attn_implementation,
-                **kwargs,
-            )
-        except ValueError as e:
-            if "does not support" in str(e):
-                logging.warning("Falling back to eager attention.")
-                return _retry(attn_implementation="eager")
-            raise e
-
-        # Kernel patching
-        try:
-            if use_liger_kernel:
-                model = _patch_liger_kernel(model)
-        except RuntimeError as err:
-            logging.warning("Retrying without Liger kernels.")
-            return _retry(use_liger_kernel=False)
-
-        # Patch sdpa attention
-        try:
-            if use_sdpa_patching:
-                model = patch_attention(model, sdpa_method)
-        except:
-            logging.warning("Retrying without Liger kernels.")
-            return _retry(use_sdpa_patching=False)
-
-        model.config.update({"nemo_version": __version__})
-        return model
-
-    @classmethod
-    def from_config(cls, config, **kwargs):
-        """
-        Instantiate a model from a config object and (optionally) patch it with custom kernels.
-
-        Parameters
-        ----------
-        config : transformers.PretrainedConfig
-            Configuration used to build the model.
-        use_liger_kernel : bool, default True
-            Whether to attempt patching the instantiated model with Liger
-            kernels.
-        use_sdpa_patching : bool, default True
-            Whether to patch the model with SDPA kernel optimizations.
-        **kwargs
-            Additional keyword arguments forwarded to the superclass.
-
-        Returns:
-        -------
-        transformers.PreTrainedModel
-            The instantiated model, possibly Liger-patched.
-
-        See Also:
-        --------
-        NeMoAutoModelForCausalLM.from_pretrained : Same logic for checkpoint
-        loading.
-        """
-        torch_dtype = kwargs.pop("torch_dtype", torch.bfloat16)
-        if torch_dtype != "auto":
-            torch_dtype = dtype_from_str(torch_dtype)
-        use_liger_kernel = kwargs.pop("use_liger_kernel", True)
-        use_sdpa_patching = kwargs.pop("use_sdpa_patching", True)
-        sdpa_method = kwargs.pop("sdpa_method", None)
-        attn_implementation = kwargs.pop("attn_implementation", "flash_attention_2")
-        model = super().from_config(config, **kwargs, attn_implementation=attn_implementation, torch_dtype=torch_dtype)
-        try:
-            return patch_model(model, use_liger_kernel, use_sdpa_patching, sdpa_method)
-        except RuntimeError:
-            del model
-            # If patching failed, retry
-            return cls.from_config(
-                config, **kwargs, use_liger_kernel=False, torch_dtype=torch_dtype, use_sdpa_patching=use_sdpa_patching
-            )
+    pass
 
 
-class NeMoAutoModelForImageTextToText(AutoModelForImageTextToText):
+class NeMoAutoModelForImageTextToText(_BaseNeMoAutoModelClass, AutoModelForImageTextToText):
     """Drop-in replacement for ``transformers.AutoModelForImageTextToText`` with custom-kernels.
 
     The class only overrides ``from_pretrained`` and ``from_config`` to add the
@@ -302,139 +396,4 @@ class NeMoAutoModelForImageTextToText(AutoModelForImageTextToText):
     ...     "Qwen/Qwen2.5-VL-3B-Instruct", use_liger_kernel=False)                            # skip Liger
     """
 
-    @classmethod
-    def from_pretrained(
-        cls,
-        pretrained_model_name_or_path,
-        *model_args,
-        use_liger_kernel: bool = True,
-        use_sdpa_patching: bool = True,
-        sdpa_method: Optional[List[SDPBackend]] = None,
-        torch_dtype="auto",
-        attn_implementation: str = "flash_attention_2",
-        **kwargs,
-    ) -> PreTrainedModel:
-        """
-        Load a pretrained image-text-to-text model and (optionally) patch it with custom kernels.
-
-        Parameters
-        ----------
-        pretrained_model_name_or_path : str or os.PathLike
-            Repository ID or local path accepted by
-            ``transformers.AutoModelForImageTextToText.from_pretrained``.
-        *model_args
-            Positional arguments forwarded verbatim to the superclass.
-        use_liger_kernel : bool, default True
-            Whether to attempt patching the loaded model with Liger kernels.
-        use_sdpa_patching : bool, default True
-            Whether to patch the model with SDPA kernel optimizations.
-        **kwargs
-            Keyword arguments forwarded verbatim to the superclass.
-
-        Returns:
-        -------
-        transformers.PreTrainedModel
-            The instantiated model, possibly Liger-patched.
-
-        Warnings:
-        --------
-        Emits a ``logging.warning`` if ``use_liger_kernel=True`` but the Liger
-        package is not available.
-
-        Retries
-        -------
-        If patching raises an exception, the method deletes the partially
-        constructed model and recursively reloads it once with
-        ``use_liger_kernel=False``.
-        """
-        torch_dtype = dtype_from_str(torch_dtype) if torch_dtype != "auto" else torch_dtype
-
-        def _retry(**override):
-            """Internal helper to re-enter this function with patched args."""
-            return cls.from_pretrained(
-                pretrained_model_name_or_path,
-                *model_args,
-                torch_dtype=torch_dtype,
-                attn_implementation=override.get("attn_implementation", attn_implementation),
-                use_liger_kernel=override.get("use_liger_kernel", use_liger_kernel),
-                use_sdpa_patching=override.get("use_sdpa_patching", use_sdpa_patching),
-                sdpa_method=sdpa_method,
-                **kwargs,
-            )
-        # load model
-        try:
-            model = super().from_pretrained(
-                pretrained_model_name_or_path,
-                *model_args,
-                torch_dtype=torch_dtype,
-                attn_implementation=attn_implementation,
-                **kwargs,
-            )
-        except ValueError as e:
-            if "does not support" in str(e):
-                logging.warning("Falling back to eager attention.")
-                return _retry(attn_implementation="eager")
-            raise e
-
-        # Kernel patching
-        try:
-            if use_liger_kernel:
-                model = _patch_liger_kernel(model)
-        except RuntimeError as err:
-            logging.warning("Retrying without Liger kernels.")
-            return _retry(use_liger_kernel=False)
-
-        # Patch sdpa attention
-        try:
-            if use_sdpa_patching:
-                model = patch_attention(model, sdpa_method)
-        except:
-            logging.warning("Retrying without Liger kernels.")
-            return _retry(use_sdpa_patching=False)
-
-        model.config.update({"nemo_version": __version__})
-        return model
-
-    @classmethod
-    def from_config(cls, config, **kwargs):
-        """
-        Instantiate a model from a config object and (optionally) patch it with custom kernels.
-
-        Parameters
-        ----------
-        config : transformers.PretrainedConfig
-            Configuration used to build the model.
-        use_liger_kernel : bool, default True
-            Whether to attempt patching the instantiated model with Liger
-            kernels.
-        use_sdpa_patching : bool, default True
-            Whether to patch the model with SDPA kernel optimizations.
-        **kwargs
-            Additional keyword arguments forwarded to the superclass.
-
-        Returns:
-        -------
-        transformers.PreTrainedModel
-            The instantiated model, possibly Liger-patched.
-
-        See Also:
-        --------
-        NeMoAutoModelForImageTextToText.from_pretrained : Same logic for checkpoint
-        loading.
-        """
-        torch_dtype = kwargs.pop("torch_dtype", torch.bfloat16)
-        if torch_dtype != "auto":
-            torch_dtype = dtype_from_str(torch_dtype)
-        use_liger_kernel = kwargs.pop("use_liger_kernel", True)
-        use_sdpa_patching = kwargs.pop("use_sdpa_patching", True)
-        sdpa_method = kwargs.pop("sdpa_method", None)
-        attn_implementation = kwargs.pop("attn_implementation", "flash_attention_2")
-        model = super().from_config(config, **kwargs, attn_implementation=attn_implementation, torch_dtype=torch_dtype)
-        try:
-            return patch_model(model, use_liger_kernel, use_sdpa_patching, sdpa_method)
-        except RuntimeError:
-            del model
-            # If patching failed, retry
-            return cls.from_config(
-                config, **kwargs, use_liger_kernel=False, torch_dtype=torch_dtype, use_sdpa_patching=use_sdpa_patching
-            )
+    pass

--- a/nemo_automodel/components/_transformers/auto_model.py
+++ b/nemo_automodel/components/_transformers/auto_model.py
@@ -202,6 +202,9 @@ class _BaseNeMoAutoModelClass(_BaseAutoModelClass):
 
         # load model
         try:
+            name = cls.__name__
+            if name.startswith("NeMo"):
+                cls.__name__ = name[4:]
             model = super().from_pretrained(
                 pretrained_model_name_or_path,
                 *model_args,
@@ -209,6 +212,7 @@ class _BaseNeMoAutoModelClass(_BaseAutoModelClass):
                 attn_implementation=attn_implementation,
                 **kwargs,
             )
+            cls.__name__ = name
         except ValueError as e:
             if "does not support" in str(e):
                 logging.warning("Falling back to eager attention.")
@@ -305,6 +309,9 @@ class _BaseNeMoAutoModelClass(_BaseAutoModelClass):
 
         # load model
         try:
+            name = cls.__name__
+            if name.startswith("NeMo"):
+                cls.__name__ = name[4:]
             model = super().from_config(
                 config,
                 *model_args,
@@ -312,6 +319,7 @@ class _BaseNeMoAutoModelClass(_BaseAutoModelClass):
                 attn_implementation=attn_implementation,
                 **kwargs,
             )
+            cls.__name__ = name
         except ValueError as e:
             if "does not support" in str(e):
                 logging.warning("Falling back to eager attention.")

--- a/nemo_automodel/components/_transformers/auto_model.py
+++ b/nemo_automodel/components/_transformers/auto_model.py
@@ -16,7 +16,7 @@ import functools
 import inspect
 import logging
 import types
-from types import Optional, List
+from typing import Optional, List
 
 import torch
 from torch.nn.attention import SDPBackend, sdpa_kernel

--- a/nemo_automodel/components/_transformers/auto_model.py
+++ b/nemo_automodel/components/_transformers/auto_model.py
@@ -16,6 +16,7 @@ import functools
 import inspect
 import logging
 import types
+from types import Optional, List
 
 import torch
 from torch.nn.attention import SDPBackend, sdpa_kernel

--- a/tests/unit_tests/_transformers/test_auto_model.py
+++ b/tests/unit_tests/_transformers/test_auto_model.py
@@ -24,8 +24,9 @@ from transformers import AutoConfig
 from nemo_automodel.components._transformers.auto_model import (
     NeMoAutoModelForCausalLM,
     NeMoAutoModelForImageTextToText,
-    patch_attention,
+    _patch_attention,
 )
+from nemo_automodel import __version__
 
 
 class TestNeMoAutoModelForCausalLM:
@@ -35,63 +36,63 @@ class TestNeMoAutoModelForCausalLM:
         """Test warning when Liger kernel is not available."""
         with (
             patch("nemo_automodel.components._transformers.auto_model.HAS_LIGER_KERNEL", False),
-            patch("nemo_automodel.components._transformers.auto_model.patch_attention", lambda obj, sdpa_method=None: obj),
+            patch("nemo_automodel.components._transformers.auto_model._patch_attention", lambda obj, sdpa_method=None: obj),
+            patch.object(transformers.AutoModelForCausalLM, "from_pretrained") as mock_from_pretrained,
         ):
-            with patch.object(transformers.AutoModelForCausalLM, "from_pretrained") as mock_from_pretrained:
-                mock_model = Mock()
-                mock_model.config = Mock()
-                mock_from_pretrained.return_value = mock_model
+            mock_model = MagicMock()
+            mock_model.config = {}
+            mock_from_pretrained.return_value = mock_model
 
-                # Test line 208 - warning when HAS_LIGER_KERNEL is False
-                with caplog.at_level(logging.WARNING):
-                    model = NeMoAutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2")
+            # Test line 208 - warning when HAS_LIGER_KERNEL is False
+            with caplog.at_level(logging.WARNING):
+                model = NeMoAutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2")
+                assert model.config["nemo_version"] == __version__
 
-                assert "Asked to use Liger Kernel, but could not import" in caplog.text
-                assert model is mock_model
-                mock_from_pretrained.assert_called_once()
+            assert "Asked to use Liger Kernel, but could not import" in caplog.text
+            assert model is mock_model
+            assert mock_from_pretrained.call_count == 1
 
     def test_from_config_liger_kernel_not_available(self, caplog):
         """Test warning when Liger kernel is not available in from_config."""
         with (
             patch("nemo_automodel.components._transformers.auto_model.HAS_LIGER_KERNEL", False),
-            patch("nemo_automodel.components._transformers.auto_model.patch_attention", lambda obj, sdpa_method=None: obj),
+            patch("nemo_automodel.components._transformers.auto_model._patch_attention", lambda obj, sdpa_method=None: obj),
+            patch.object(transformers.AutoModelForCausalLM, "from_config") as mock_from_config,
         ):
-            with patch.object(transformers.AutoModelForCausalLM, "from_config") as mock_from_config:
-                mock_model = Mock()
-                mock_model.config = Mock()
-                mock_from_config.return_value = mock_model
+            mock_model = MagicMock()
+            mock_model.config = {}
+            mock_from_config.return_value = mock_model
 
-                config = AutoConfig.from_pretrained("hf-internal-testing/tiny-random-gpt2")
+            config = AutoConfig.from_pretrained("hf-internal-testing/tiny-random-gpt2")
 
-                # Test line 297 - warning when HAS_LIGER_KERNEL is False
-                with caplog.at_level(logging.WARNING):
-                    model = NeMoAutoModelForCausalLM.from_config(config)
+            # Test line 297 - warning when HAS_LIGER_KERNEL is False
+            with caplog.at_level(logging.WARNING):
+                model = NeMoAutoModelForCausalLM.from_config(config)
+                assert model.config["nemo_version"] == __version__
 
-                assert "Asked to use Liger Kernel, but could not import" in caplog.text
-                assert model is mock_model
-                mock_from_config.assert_called_once()
+            assert "Asked to use Liger Kernel, but could not import" in caplog.text
+            assert model is mock_model
+            assert mock_from_config.call_count == 1
 
     def test_from_pretrained_runtimeerror_triggers_reload(self):
-        """When patch_model raises, the loader should retry with
+        """When _patch_liger_kernel raises, the loader should retry with
         use_liger_kernel=False and return the second model instance."""
         # first and second dummy model objects
         model1, model2 = Mock(name="m1"), Mock(name="m2")
-        model1.config = Mock()
-        model2.config = Mock()
+        model1.config = {}
+        model2.config = {}
 
-        # record every call to patch_model
+        # record every call to _patch_liger_kernel
         patch_calls = []
 
-        def fake_patch_model(model, use_liger_kernel, use_sdpa_patching, sdpa_method):
-            patch_calls.append((model, use_liger_kernel))
-            if use_liger_kernel:  # first attempt -> raise
-                raise RuntimeError("boom")
-            return model  # second attempt succeeds
+        def fake__patch_liger_kernel(model):
+            patch_calls.append(model)
+            raise RuntimeError("boom")
 
         with (
             patch("nemo_automodel.components._transformers.auto_model.HAS_LIGER_KERNEL", True),
-            patch("nemo_automodel.components._transformers.auto_model.patch_model", new=fake_patch_model),
-            patch("nemo_automodel.components._transformers.auto_model.patch_attention", lambda obj, sdpa_method=None: obj),
+            patch("nemo_automodel.components._transformers.auto_model._patch_liger_kernel", new=fake__patch_liger_kernel),
+            patch("nemo_automodel.components._transformers.auto_model._patch_attention", lambda obj, sdpa_method=None: obj),
             patch.object(
                 transformers.AutoModelForCausalLM,
                 "from_pretrained",
@@ -99,9 +100,10 @@ class TestNeMoAutoModelForCausalLM:
             ) as mock_from_pretrained,
         ):
             returned = NeMoAutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2")
+            assert returned.config["nemo_version"] == __version__
 
-        # patch_model called twice, first with ligand=True, then False
-        assert patch_calls == [(model1, True), (model2, False)]
+        # _patch_liger_kernel called twice, first with ligand=True, then False
+        assert patch_calls == [model1]
         # The underlying HF loader is also called twice
         assert mock_from_pretrained.call_count == 2
         # The final object returned by our helper is the *second* model
@@ -109,30 +111,28 @@ class TestNeMoAutoModelForCausalLM:
 
     def test_from_config_runtimeerror_triggers_reload(self):
         model1, model2 = Mock(name="m1"), Mock(name="m2")
-        model1.config = Mock()
-        model2.config = Mock()
+        model1.config = {}
+        model2.config = {}
 
         patch_calls = []
-
-        def fake_patch_model(model, use_liger_kernel, use_sdpa_patching, sdpa_method):
-            patch_calls.append((model, use_liger_kernel))
-            if use_liger_kernel:
-                raise RuntimeError("boom")
-            return model
+        def fake__patch_liger_kernel(model):
+            patch_calls.append(model)
+            raise RuntimeError("boom")
 
         cfg = AutoConfig.from_pretrained("hf-internal-testing/tiny-random-gpt2")
 
         with (
             patch("nemo_automodel.components._transformers.auto_model.HAS_LIGER_KERNEL", True),
-            patch("nemo_automodel.components._transformers.auto_model.patch_model", new=fake_patch_model),
-            patch("nemo_automodel.components._transformers.auto_model.patch_attention", lambda obj, sdpa_method=None: obj),
+            patch("nemo_automodel.components._transformers.auto_model._patch_liger_kernel", new=fake__patch_liger_kernel),
+            patch("nemo_automodel.components._transformers.auto_model._patch_attention", lambda obj, sdpa_method=None: obj),
             patch.object(
                 transformers.AutoModelForCausalLM, "from_config", side_effect=[model1, model2]
             ) as mock_from_config,
         ):
             returned = NeMoAutoModelForCausalLM.from_config(cfg)
+            assert returned.config["nemo_version"] == __version__
 
-        assert patch_calls == [(model1, True), (model2, False)]
+        assert patch_calls == [model1]
         assert mock_from_config.call_count == 2
         assert returned is model2
 
@@ -144,63 +144,60 @@ class TestNeMoAutoModelForImageTextToText:
         """Test warning when Liger kernel is not available."""
         with (
             patch("nemo_automodel.components._transformers.auto_model.HAS_LIGER_KERNEL", False),
-            patch("nemo_automodel.components._transformers.auto_model.patch_attention", lambda obj, sdpa_method=None: obj),
+            patch("nemo_automodel.components._transformers.auto_model._patch_attention", lambda obj, sdpa_method=None: obj),
+            patch.object(transformers.AutoModelForImageTextToText, "from_pretrained") as mock_from_pretrained,
         ):
-            with patch.object(transformers.AutoModelForImageTextToText, "from_pretrained") as mock_from_pretrained:
-                mock_model = Mock()
-                mock_model.config = Mock()
-                mock_from_pretrained.return_value = mock_model
+            mock_model = Mock()
+            mock_model.config = {}
+            mock_from_pretrained.return_value = mock_model
 
-                # Test line 356 - warning when HAS_LIGER_KERNEL is False
-                with caplog.at_level(logging.WARNING):
-                    model = NeMoAutoModelForImageTextToText.from_pretrained("dummy_model")
+            # Test line 356 - warning when HAS_LIGER_KERNEL is False
+            with caplog.at_level(logging.WARNING):
+                model = NeMoAutoModelForImageTextToText.from_pretrained("dummy_model")
+                assert model.config["nemo_version"] == __version__
 
-                assert "Asked to use Liger Kernel, but could not import" in caplog.text
-                assert model is mock_model
-                mock_from_pretrained.assert_called_once()
+            assert "Asked to use Liger Kernel, but could not import" in caplog.text
+            assert model is mock_model
+            assert mock_from_pretrained.call_count == 1
 
     def test_from_config_liger_kernel_not_available(self, caplog):
         """Test warning when Liger kernel is not available in from_config."""
         with (
             patch("nemo_automodel.components._transformers.auto_model.HAS_LIGER_KERNEL", False),
-            patch("nemo_automodel.components._transformers.auto_model.patch_attention", lambda obj, sdpa_method=None: obj),
+            patch("nemo_automodel.components._transformers.auto_model._patch_attention", lambda obj, sdpa_method=None: obj),
+            patch.object(transformers.AutoModelForImageTextToText, "from_config") as mock_from_config,
         ):
-            with patch.object(transformers.AutoModelForImageTextToText, "from_config") as mock_from_config:
-                mock_model = Mock()
-                mock_model.config = Mock()
-                mock_from_config.return_value = mock_model
+            mock_model = Mock()
+            mock_model.config = Mock()
+            mock_from_config.return_value = mock_model
 
-                config = AutoConfig.from_pretrained("hf-internal-testing/tiny-random-gpt2")
+            config = AutoConfig.from_pretrained("hf-internal-testing/tiny-random-gpt2")
 
-                # Test warning when HAS_LIGER_KERNEL is False
-                with caplog.at_level(logging.WARNING):
-                    model = NeMoAutoModelForImageTextToText.from_config(config)
+            # Test warning when HAS_LIGER_KERNEL is False
+            with caplog.at_level(logging.WARNING):
+                model = NeMoAutoModelForImageTextToText.from_config(config)
 
-                assert "Asked to use Liger Kernel, but could not import" in caplog.text
-                assert model is mock_model
-                mock_from_config.assert_called_once()
+            assert "Asked to use Liger Kernel, but could not import" in caplog.text
+            assert model is mock_model
+            assert mock_from_config.call_count == 1
 
     def test_from_pretrained_runtimeerror_triggers_reload(self):
-        """When patch_model raises, the loader should retry with
+        """When _patch_liger_kernel raises, the loader should retry with
         use_liger_kernel=False and return the second model instance."""
         # first and second dummy model objects
         model1, model2 = Mock(name="m1"), Mock(name="m2")
-        model1.config = Mock()
-        model2.config = Mock()
+        model1.config = {}
+        model2.config = {}
 
-        # record every call to patch_model
         patch_calls = []
-
-        def fake_patch_model(model, use_liger_kernel, use_sdpa_patching, sdpa_method):
-            patch_calls.append((model, use_liger_kernel))
-            if use_liger_kernel:  # first attempt -> raise
-                raise RuntimeError("boom")
-            return model  # second attempt succeeds
+        def fake__patch_liger_kernel(model):
+            patch_calls.append(model)
+            raise RuntimeError("boom")
 
         with (
             patch("nemo_automodel.components._transformers.auto_model.HAS_LIGER_KERNEL", True),
-            patch("nemo_automodel.components._transformers.auto_model.patch_model", new=fake_patch_model),
-            patch("nemo_automodel.components._transformers.auto_model.patch_attention", lambda obj, sdpa_method=None: obj),
+            patch("nemo_automodel.components._transformers.auto_model._patch_liger_kernel", new=fake__patch_liger_kernel),
+            patch("nemo_automodel.components._transformers.auto_model._patch_attention", lambda obj, sdpa_method=None: obj),
             patch.object(
                 transformers.AutoModelForImageTextToText,
                 "from_pretrained",
@@ -208,9 +205,11 @@ class TestNeMoAutoModelForImageTextToText:
             ) as mock_from_pretrained,
         ):
             returned = NeMoAutoModelForImageTextToText.from_pretrained("dummy_model")
+            assert returned.config["nemo_version"] == __version__
 
-        # patch_model called twice, first with ligand=True, then False
-        assert patch_calls == [(model1, True), (model2, False)]
+
+        # _patch_liger_kernel called twice, first with ligand=True, then False
+        assert patch_calls == [model1]
         # The underlying HF loader is also called twice
         assert mock_from_pretrained.call_count == 2
         # The final object returned by our helper is the *second* model
@@ -218,39 +217,38 @@ class TestNeMoAutoModelForImageTextToText:
 
     def test_from_config_runtimeerror_triggers_reload(self):
         model1, model2 = Mock(name="m1"), Mock(name="m2")
-        model1.config = Mock()
-        model2.config = Mock()
+        model1.config = {}
+        model2.config = {}
 
         patch_calls = []
 
-        def fake_patch_model(model, use_liger_kernel, use_sdpa_patching, sdpa_method):
-            patch_calls.append((model, use_liger_kernel))
-            if use_liger_kernel:
-                raise RuntimeError("boom")
-            return model
+        def fake__patch_liger_kernel(model):
+            patch_calls.append(model)
+            raise RuntimeError("boom")
 
         cfg = AutoConfig.from_pretrained("hf-internal-testing/tiny-random-gpt2")
 
         with (
             patch("nemo_automodel.components._transformers.auto_model.HAS_LIGER_KERNEL", True),
-            patch("nemo_automodel.components._transformers.auto_model.patch_model", new=fake_patch_model),
-            patch("nemo_automodel.components._transformers.auto_model.patch_attention", lambda obj, sdpa_method=None: obj),
+            patch("nemo_automodel.components._transformers.auto_model._patch_liger_kernel", new=fake__patch_liger_kernel),
+            patch("nemo_automodel.components._transformers.auto_model._patch_attention", lambda obj, sdpa_method=None: obj),
             patch.object(
                 transformers.AutoModelForImageTextToText, "from_config", side_effect=[model1, model2]
             ) as mock_from_config,
         ):
             returned = NeMoAutoModelForImageTextToText.from_config(cfg)
+            assert returned.config["nemo_version"] == __version__
 
-        assert patch_calls == [(model1, True), (model2, False)]
+        assert patch_calls == [model1]
         assert mock_from_config.call_count == 2
         assert returned is model2
 
 
 class TestPatchAttention:
-    """Test cases for patch_attention function."""
+    """Test cases for _patch_attention function."""
 
-    def test_patch_attention_basic(self):
-        """Test basic patch_attention functionality."""
+    def test__patch_attention_basic(self):
+        """Test basic _patch_attention functionality."""
         # Create a mock object with a forward method
         mock_obj = Mock()
         mock_forward = Mock()
@@ -260,16 +258,18 @@ class TestPatchAttention:
         mock_forward.__func__ = Mock()
         mock_forward.__self__ = mock_obj
 
-        with patch("nemo_automodel.components._transformers.auto_model.sdpa_kernel") as mock_sdpa_kernel:  # noqa: F841
-            with patch("nemo_automodel.components._transformers.auto_model._assert_same_signature"):
-                result = patch_attention(mock_obj)
+        with (
+            patch("nemo_automodel.components._transformers.auto_model.sdpa_kernel") as mock_sdpa_kernel,  # noqa: F841
+            patch("nemo_automodel.components._transformers.auto_model._assert_same_signature"),
+        ):
+            result = _patch_attention(mock_obj)
 
-                assert result is mock_obj
-                # Verify that the forward method was replaced
-                assert mock_obj.forward != mock_forward
+            assert result is mock_obj
+            # Verify that the forward method was replaced
+            assert mock_obj.forward != mock_forward
 
-    def test_patch_attention_with_custom_sdpa_method(self):
-        """Test patch_attention with custom SDPA method."""
+    def test__patch_attention_with_custom_sdpa_method(self):
+        """Test _patch_attention with custom SDPA method."""
         from torch.nn.attention import SDPBackend
 
         mock_obj = Mock()
@@ -282,13 +282,15 @@ class TestPatchAttention:
 
         custom_sdpa_method = [SDPBackend.FLASH_ATTENTION]
 
-        with patch("nemo_automodel.components._transformers.auto_model.sdpa_kernel") as mock_sdpa_kernel:  # noqa: F841
-            with patch("nemo_automodel.components._transformers.auto_model._assert_same_signature"):
-                result = patch_attention(mock_obj, custom_sdpa_method)
+        with (
+            patch("nemo_automodel.components._transformers.auto_model.sdpa_kernel") as mock_sdpa_kernel,  # noqa: F841
+            patch("nemo_automodel.components._transformers.auto_model._assert_same_signature"),
+        ):
+            result = _patch_attention(mock_obj, custom_sdpa_method)
 
-                assert result is mock_obj
-                # Verify that the forward method was replaced
-                assert mock_obj.forward != mock_forward
+            assert result is mock_obj
+            # Verify that the forward method was replaced
+            assert mock_obj.forward != mock_forward
 
 
 class TestUtilityFunctions:
@@ -327,7 +329,7 @@ class DummyModel(torch.nn.Module):
 
     def __init__(self):
         super().__init__()
-        self.config = {}  # patch_model calls  model.config.update(...)
+        self.config = {}  # _patch_liger_kernel calls  model.config.update(...)
         self.called = False  # turned on by fake liger kernel
 
     def mark(self):
@@ -336,7 +338,7 @@ class DummyModel(torch.nn.Module):
 
 def prepare_env(monkeypatch, target_mod, *, has_liger=True, apply_ok=True):
     """
-    Patch every external symbol that patch_model touches.
+    Patch every external symbol that _patch_liger_kernel touches.
 
     Parameters
     ----------
@@ -359,9 +361,7 @@ def prepare_env(monkeypatch, target_mod, *, has_liger=True, apply_ok=True):
     monkeypatch.setattr(target_mod, "liger_kernel_trf", liger_stub, raising=False)
 
     patch_attn_mock = MagicMock(side_effect=lambda *args, **kwargs: args[0])
-    monkeypatch.setattr(target_mod, "patch_attention", patch_attn_mock, raising=True)
-
-    monkeypatch.setattr(target_mod, "__version__", "unit-test-ver", raising=False)
+    monkeypatch.setattr(target_mod, "_patch_attention", patch_attn_mock, raising=True)
 
     return apply_mock, patch_attn_mock
 
@@ -369,24 +369,21 @@ def prepare_env(monkeypatch, target_mod, *, has_liger=True, apply_ok=True):
 @pytest.mark.parametrize("use_liger,has_liger", [(True, True), (False, True)])
 def test_success_paths(monkeypatch, use_liger, has_liger):
     """
-    1. Liger available & requested  -> kernel applied, patch_attention called.
-    2. Liger *not* requested        -> kernel *not* applied, patch_attention called.
+    1. Liger available & requested  -> kernel applied, _patch_attention called.
+    2. Liger *not* requested        -> kernel *not* applied, _patch_attention called.
     """
     import nemo_automodel.components._transformers.auto_model as tgt
 
     apply_mock, attn_mock = prepare_env(monkeypatch, tgt, has_liger=has_liger, apply_ok=True)
 
     model = DummyModel()
-    patched = tgt.patch_model(
-        model,
-        use_liger_kernel=use_liger,
-        use_sdpa_patching=True,
-    )
+    if use_liger:
+        patched = tgt._patch_liger_kernel(model)
+    else:
+        patched = model
 
     # Always returns same instance (unless exception path)
     assert patched is model
-    # nemo_version must be set
-    assert patched.config["nemo_version"] == "unit-test-ver"
 
     if use_liger:
         apply_mock.assert_called_once()
@@ -395,14 +392,15 @@ def test_success_paths(monkeypatch, use_liger, has_liger):
         apply_mock.assert_not_called()
         assert model.called is False
 
-    # SDPA path always taken in these tests
-    attn_mock.assert_called_once_with(model, None)
+    # SDPA not called inside _patch_liger_kernel
+    attn_mock.assert_not_called()
+
 
 
 def test_liger_not_available(monkeypatch):
     """
     Asked for Liger but HAS_LIGER_KERNEL is False.
-    Expect: return untouched model, patch_attention still invoked,
+    Expect: return untouched model, _patch_attention still invoked,
             no exceptions thrown.
     """
     import nemo_automodel.components._transformers.auto_model as tgt
@@ -415,19 +413,19 @@ def test_liger_not_available(monkeypatch):
     )
 
     model = DummyModel()
-    out = tgt.patch_model(model, use_liger_kernel=True, use_sdpa_patching=True)
+    out = tgt._patch_liger_kernel(model)
 
     # untouched instance returned
     assert out is model
     assert model.called is False
     # _apply never called, because we short-circuit when HAS_LIGER_KERNEL==False
     apply_mock.assert_not_called()
-    attn_mock.assert_called_once()
+    attn_mock.assert_not_called()
 
 
 def test_liger_apply_failure_raises(monkeypatch):
     """
-    If _apply_liger_kernel_to_instance throws, patch_model must
+    If _apply_liger_kernel_to_instance throws, _patch_liger_kernel must
     clean up and raise RuntimeError.
     """
     import nemo_automodel.components._transformers.auto_model as tgt
@@ -440,4 +438,4 @@ def test_liger_apply_failure_raises(monkeypatch):
     )
 
     with pytest.raises(RuntimeError, match="Failed to patch model"):
-        tgt.patch_model(DummyModel(), use_liger_kernel=True, use_sdpa_patching=False)
+        tgt._patch_liger_kernel(DummyModel())


### PR DESCRIPTION
Subclassing the AutoModel classes resulted in errors when using remote code, since the internal registry was using the class' name to determine whether the external code was registered with the autoclass. This PR fixes this issue, in addition, it deduplicates the override code across autoclasses.