### PR TITLE
fix: Improve root repo detection for interactive jobs

### DIFF
--- a/nemo_automodel/_cli/app.py
+++ b/nemo_automodel/_cli/app.py
@@ -163,16 +163,16 @@ def build_parser() -> argparse.ArgumentParser:
 
     # Two required positionals (cannot start with "--")
     parser.add_argument(
-        "domain",
-        metavar="<domain>",
-        choices=["llm", "vlm"],
-        help="Domain to operate on (e.g., LLM, VLM, etc)",
-    )
-    parser.add_argument(
         "command",
         metavar="<command>",
         choices=["finetune"],
         help="Command within the domain (e.g., finetune, generate, etc)",
+    )
+    parser.add_argument(
+        "domain",
+        metavar="<domain>",
+        choices=["llm", "vlm"],
+        help="Domain to operate on (e.g., LLM, VLM, etc)",
     )
 
     # Optional/required flag

--- a/nemo_automodel/_cli/app.py
+++ b/nemo_automodel/_cli/app.py
@@ -90,6 +90,7 @@ def load_yaml(file_path):
         logging.error(f"parsing YAML file {e} failed.")
         raise e
 
+
 def get_automodel_repo_root():
     """
     if the cwd contains:
@@ -101,6 +102,7 @@ def get_automodel_repo_root():
     if (cwd / "nemo_automodel/components").exists() and (cwd / "examples/").exists():
         return cwd
     return None
+
 
 def launch_with_slurm(args, job_conf_path, job_dir, slurm_config):
     from nemo_automodel.components.launcher.slurm.config import SlurmConfig, VolumeMapping
@@ -195,6 +197,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     return parser
 
+
 def get_repo_root():
     """
     Returns the repo root to use and if using non-default, it will modify $PYTHONPATH accordingly
@@ -204,13 +207,14 @@ def get_repo_root():
     """
     if repo_root := get_automodel_repo_root():
         new_pp = str(repo_root)
-        if 'PYTHONPATH' in os.environ:
-            new_pp += ':' + os.environ['PYTHONPATH']
+        if "PYTHONPATH" in os.environ:
+            new_pp += ":" + os.environ["PYTHONPATH"]
         os.environ["PYTHONPATH"] = new_pp
         logging.info(f"Running job using source from: {repo_root}")
     else:
         repo_root = Path(__file__).parents[2]
     return repo_root
+
 
 def run_interactive(args):
     from torch.distributed.run import determine_local_world_size, get_args_parser
@@ -246,6 +250,7 @@ def run_interactive(args):
         if args.nproc_per_node is None:
             torchrun_args.nproc_per_node = num_devices
         return thrun(torchrun_args)
+
 
 def main():
     """CLI for running finetune jobs with NeMo-Automodel, supporting torchrun, Slurm & Kubernetes.

--- a/tests/unit_tests/_cli/test_app.py
+++ b/tests/unit_tests/_cli/test_app.py
@@ -101,8 +101,8 @@ def test_launch_with_slurm(monkeypatch):
     fake_executor = mock.MagicMock()
     fake_exp = mock.MagicMock()
     dummy_args = SimpleNamespace(
-        command="finetune",
         domain="llm",
+        command="finetune",
     )
     monkeypatch.setattr(module, "load_yaml", lambda x: {"slurm": mock_slurm_config})
     monkeypatch.setitem(
@@ -150,7 +150,7 @@ def test_launch_with_slurm(monkeypatch):
 def test_main_single_node(monkeypatch, tmp_yaml_file):
     config_path = tmp_yaml_file
 
-    monkeypatch.setattr("sys.argv", ["prog", "llm", "finetune", "-c", str(config_path)])
+    monkeypatch.setattr("sys.argv", ["prog", "finetune", "llm", "-c", str(config_path)])
     monkeypatch.setattr(module, "load_yaml", lambda x: {})
     import torch.distributed.run as thrun
     monkeypatch.setattr(thrun, "determine_local_world_size", lambda **kwargs: 1)
@@ -170,7 +170,7 @@ def test_main_multi_node(monkeypatch, tmp_yaml_file):
     config_path = tmp_yaml_file
 
     # Simulate CLI args using sys.argv
-    monkeypatch.setattr("sys.argv", ["prog", "llm", "finetune", "-c", str(config_path)])
+    monkeypatch.setattr("sys.argv", ["prog", "finetune", "llm", "-c", str(config_path)])
 
     monkeypatch.setattr(module, "load_yaml", lambda x: {})
     run_mod = importlib.import_module("torch.distributed.run")
@@ -205,7 +205,7 @@ def test_main_k8s_not_implemented(monkeypatch, tmp_yaml_file):
         parser.set_defaults(config=str(config_path), domain="llm", command="finetune")
         return parser
 
-    monkeypatch.setattr("sys.argv", ["automodel", "llm", "finetune", "-c", str(config_path)])
+    monkeypatch.setattr("sys.argv", ["automodel", "finetune", "llm", "-c", str(config_path)])
     monkeypatch.setattr(module, "build_parser", custom_parser)
     monkeypatch.setattr(module, "load_yaml", lambda x: {"k8s": {}})
     monkeypatch.setattr(module.Path, "parents", [None, None, Path(__file__).parent])

--- a/tests/unit_tests/_cli/test_app.py
+++ b/tests/unit_tests/_cli/test_app.py
@@ -267,3 +267,20 @@ def test_repo_root_when_not_found(monkeypatch):
 
     # PYTHONPATH must remain unchanged
     assert os.environ["PYTHONPATH"] == "foo:bar"
+
+
+def test_repo_structure():
+    """
+    inside the nemo_automodel/_cli/app.py we assume a specific directory structure.
+    This test ensures the directory structure is preserved.
+    """
+    cwd = Path.cwd()
+    with pytest.raises(AssertionError):
+        assert (cwd / "nemo_automodel_abc").exists()
+    assert (cwd / "nemo_automodel").exists()
+    assert (cwd / "nemo_automodel" / "components").exists()
+    assert (cwd / "nemo_automodel" / "_cli").exists()
+    assert (cwd / "nemo_automodel" / "recipes").exists()
+    assert (cwd / "nemo_automodel" / "shared").exists()
+    assert (cwd / "docs").exists()
+    assert (cwd / "examples").exists()


### PR DESCRIPTION
The `automodel` cli has the capability to detect whether it's invoked from within an `Automodel` git repository or from any other directory.  If it is invoked from within a git repo, it will use repo's source code (instead of the one installed by the  pypi package). 

Issue: when running interactive jobs, the repo "rebasing" was missing. 
Fix: function `get_automodel_repo_root` is used to determine whether it's running from inside a git repo and launch the jobs accordingly, for both, interactive and batch jobs. 

----

Changed the syntax from
```
automodel llm **finetune** -c config.yaml
```

to 
```
automodel **finetune** llm -c config.yaml
```