### PR TITLE
ci: Add community-bot

### DIFF
--- a/.github/workflows/close-inactive-issue-pr.yml
+++ b/.github/workflows/close-inactive-issue-pr.yml
@@ -5,21 +5,4 @@ on:
 
 jobs:
   close-issues:
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      pull-requests: write
-    steps:
-      - uses: actions/stale@v6
-        with:
-          operations-per-run: 100
-          days-before-issue-stale: 30
-          days-before-issue-close: 7 
-          stale-issue-label: "stale"
-          stale-issue-message: "This issue is stale because it has been open for 30 days with no activity. Remove stale label or comment or this will be closed in 7 days."
-          close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale."
-          days-before-pr-stale: 14 
-          days-before-pr-close: 7 
-          stale-pr-message: "This PR is stale because it has been open for 14 days with no activity. Remove stale label or comment or update or this will be closed in 7 days."
-          close-pr-message: "This PR was closed because it has been inactive for 7 days since being marked as stale."
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_close_inactive_issue_pr.yml@v0.44.0

--- a/.github/workflows/community-bot.yml
+++ b/.github/workflows/community-bot.yml
@@ -1,0 +1,13 @@
+name: Community Bot
+
+on:
+  issues:
+    types: [opened, edited, reopened, closed, deleted]
+  issue_comment:
+    types: [created, edited, deleted]
+
+jobs:
+  community-bot:
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_community_bot.yml@v0.44.0
+    secrets:
+      GH_TOKEN: ${{ secrets.PAT }}


### PR DESCRIPTION
For community engagement, we want to prevent to close issues when they are waiting for us to respond. We therefore apply a label `community-request` to PRs that require our action. The action `actions/stale` will ignore such issues from marking it as stale.
