### PR TITLE
fix: add kwargs argument to mock tokenizers

### DIFF
--- a/nemo_automodel/components/datasets/llm/mock.py
+++ b/nemo_automodel/components/datasets/llm/mock.py
@@ -44,7 +44,7 @@ def build_unpacked_dataset(
     vocab_size: int = 100,
     max_sentence_len: int = 64,
     seed: int = 0,
-    **kwargs,
+    tokenizer=None,
 ):
     """
     Build a dataset where each example is one sentence (variable length).

--- a/nemo_automodel/components/datasets/llm/mock.py
+++ b/nemo_automodel/components/datasets/llm/mock.py
@@ -44,7 +44,7 @@ def build_unpacked_dataset(
     vocab_size: int = 100,
     max_sentence_len: int = 64,
     seed: int = 0,
-    **kwargs
+    **kwargs,
 ):
     """
     Build a dataset where each example is one sentence (variable length).

--- a/nemo_automodel/components/datasets/llm/mock.py
+++ b/nemo_automodel/components/datasets/llm/mock.py
@@ -44,6 +44,7 @@ def build_unpacked_dataset(
     vocab_size: int = 100,
     max_sentence_len: int = 64,
     seed: int = 0,
+    **kwargs
 ):
     """
     Build a dataset where each example is one sentence (variable length).

--- a/nemo_automodel/components/datasets/llm/mock_packed.py
+++ b/nemo_automodel/components/datasets/llm/mock_packed.py
@@ -62,7 +62,7 @@ def build_packed_dataset(
     vocab_size: int = 100,
     max_sentence_len: int = 64,
     seed: int = 0,
-    **kwargs
+    **kwargs,
 ):
     """
     Dataset builder.

--- a/nemo_automodel/components/datasets/llm/mock_packed.py
+++ b/nemo_automodel/components/datasets/llm/mock_packed.py
@@ -62,6 +62,7 @@ def build_packed_dataset(
     vocab_size: int = 100,
     max_sentence_len: int = 64,
     seed: int = 0,
+    **kwargs
 ):
     """
     Dataset builder.

--- a/nemo_automodel/components/datasets/llm/mock_packed.py
+++ b/nemo_automodel/components/datasets/llm/mock_packed.py
@@ -62,7 +62,7 @@ def build_packed_dataset(
     vocab_size: int = 100,
     max_sentence_len: int = 64,
     seed: int = 0,
-    **kwargs,
+    tokenizer=None,
 ):
     """
     Dataset builder.


### PR DESCRIPTION
Adds `**kwargs` to mock tokenizers. This ensures that the tokenizer will be compatible with `recipes.llm.finetune.FinetuneRecipeForNextTokenPrediction`, which assumes they will accept a `tokenizer` keyword, but also with any keyword that might be required by another recipe.