### PR TITLE
fix: bug in happy path for from_config _BaseNeMoAutoModelClass.

### DIFF
--- a/nemo_automodel/components/_transformers/auto_model.py
+++ b/nemo_automodel/components/_transformers/auto_model.py
@@ -288,6 +288,7 @@ class _BaseNeMoAutoModelClass(_BaseAutoModelClass):
               deleted and the method recurses once with
               `use_liger_kernel=False` or `use_sdpa_patching=False`
         """
+
         def _retry(**override):
             """Internal helper to re-enter this function with patched args."""
             return cls.from_config(

--- a/nemo_automodel/components/_transformers/auto_model.py
+++ b/nemo_automodel/components/_transformers/auto_model.py
@@ -270,10 +270,6 @@ class _BaseNeMoAutoModelClass(_BaseAutoModelClass):
                 One or multiple SDPA back-ends to prefer when applying SDPA
                 patching. When ``None``, the default backend resolution logic is
                 used. Defaults to ``None``.
-            torch_dtype (Union[str, torch.dtype], optional):
-                The desired data type for model initialization
-                (e.g., ``"auto"``, ``torch.float16``). Passed through to
-                ``transformers.AutoModel``. Defaults to ``"auto"``.
             attn_implementation (str, optional):
                 Specifies which attention implementation to use (e.g.,
                 ``"flash_attention_2"``, ``"eager"``). Only applied when the
@@ -292,14 +288,11 @@ class _BaseNeMoAutoModelClass(_BaseAutoModelClass):
               deleted and the method recurses once with
               `use_liger_kernel=False` or `use_sdpa_patching=False`
         """
-        torch_dtype = dtype_from_str(torch_dtype) if torch_dtype != "auto" else torch_dtype
-
         def _retry(**override):
             """Internal helper to re-enter this function with patched args."""
             return cls.from_config(
                 config,
                 *model_args,
-                torch_dtype=torch_dtype,
                 attn_implementation=override.get("attn_implementation", attn_implementation),
                 use_liger_kernel=override.get("use_liger_kernel", use_liger_kernel),
                 use_sdpa_patching=override.get("use_sdpa_patching", use_sdpa_patching),
@@ -315,7 +308,6 @@ class _BaseNeMoAutoModelClass(_BaseAutoModelClass):
             model = super().from_config(
                 config,
                 *model_args,
-                torch_dtype=torch_dtype,
                 attn_implementation=attn_implementation,
                 **kwargs,
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ classifiers = [
 ]
 dependencies = [
     "bitsandbytes==0.45.5; (platform_machine == 'x86_64' and platform_system != 'Darwin')",
-    "datasets>=4.0.0",
+    "datasets<4.0.0",
     "liger-kernel==0.5.8; (platform_machine == 'x86_64' and platform_system != 'Darwin')",
     "pyyaml",
     "torch",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ classifiers = [
 ]
 dependencies = [
     "bitsandbytes==0.45.5; (platform_machine == 'x86_64' and platform_system != 'Darwin')",
-    "datasets<4.0.0",
+    "datasets>=4.0.0",
     "liger-kernel==0.5.8; (platform_machine == 'x86_64' and platform_system != 'Darwin')",
     "pyyaml",
     "torch",

--- a/tests/unit_tests/_transformers/test_auto_model.py
+++ b/tests/unit_tests/_transformers/test_auto_model.py
@@ -73,6 +73,13 @@ class TestNeMoAutoModelForCausalLM:
             assert model is mock_model
             assert mock_from_config.call_count == 1
 
+    def test_from_config_happy_path(self):
+        """Test the basic from_config functionality works."""
+        config = AutoConfig.from_pretrained("hf-internal-testing/tiny-random-gpt2")
+        
+        model = NeMoAutoModelForCausalLM.from_config(config, attn_implementation="eager")
+        assert model.config.nemo_version == __version__
+
     def test_from_pretrained_runtimeerror_triggers_reload(self):
         """When _patch_liger_kernel raises, the loader should retry with
         use_liger_kernel=False and return the second model instance."""
@@ -179,6 +186,13 @@ class TestNeMoAutoModelForImageTextToText:
             assert "Asked to use Liger Kernel, but could not import" in caplog.text
             assert model is mock_model
             assert mock_from_config.call_count == 1
+
+    def test_from_config_happy_path(self):
+        """Test the basic from_config functionality works."""
+        config = AutoConfig.from_pretrained("hf-internal-testing/tiny-random-gpt2")
+        
+        model = NeMoAutoModelForImageTextToText.from_config(config, attn_implementation="eager")
+        assert model.config.nemo_version == __version__
 
     def test_from_pretrained_runtimeerror_triggers_reload(self):
         """When _patch_liger_kernel raises, the loader should retry with

--- a/tests/unit_tests/_transformers/test_auto_model.py
+++ b/tests/unit_tests/_transformers/test_auto_model.py
@@ -187,13 +187,6 @@ class TestNeMoAutoModelForImageTextToText:
             assert model is mock_model
             assert mock_from_config.call_count == 1
 
-    def test_from_config_happy_path(self):
-        """Test the basic from_config functionality works."""
-        config = AutoConfig.from_pretrained("hf-internal-testing/tiny-random-gpt2")
-
-        model = NeMoAutoModelForImageTextToText.from_config(config, attn_implementation="eager")
-        assert model.config.nemo_version == __version__
-
     def test_from_pretrained_runtimeerror_triggers_reload(self):
         """When _patch_liger_kernel raises, the loader should retry with
         use_liger_kernel=False and return the second model instance."""

--- a/tests/unit_tests/_transformers/test_auto_model.py
+++ b/tests/unit_tests/_transformers/test_auto_model.py
@@ -76,7 +76,7 @@ class TestNeMoAutoModelForCausalLM:
     def test_from_config_happy_path(self):
         """Test the basic from_config functionality works."""
         config = AutoConfig.from_pretrained("hf-internal-testing/tiny-random-gpt2")
-        
+
         model = NeMoAutoModelForCausalLM.from_config(config, attn_implementation="eager")
         assert model.config.nemo_version == __version__
 
@@ -190,7 +190,7 @@ class TestNeMoAutoModelForImageTextToText:
     def test_from_config_happy_path(self):
         """Test the basic from_config functionality works."""
         config = AutoConfig.from_pretrained("hf-internal-testing/tiny-random-gpt2")
-        
+
         model = NeMoAutoModelForImageTextToText.from_config(config, attn_implementation="eager")
         assert model.config.nemo_version == __version__
 

--- a/tests/unit_tests/distributed/test_parallelizer.py
+++ b/tests/unit_tests/distributed/test_parallelizer.py
@@ -1399,4 +1399,3 @@ class TestUnshardFsdp2Model:
 
             # Verify reshard was still called despite the exception
             assert test_fsdp_module.reshard_called is True
-


### PR DESCRIPTION
This PR removes the torch_dtype as an argument from from_config() method in  _BaseNeMoAutoModelClass.