### PR TITLE
fix: wrong mesh name wit cp>1 by removing stale codes

### DIFF
--- a/nemo_automodel/components/distributed/fsdp2.py
+++ b/nemo_automodel/components/distributed/fsdp2.py
@@ -186,10 +186,6 @@ class FSDP2Manager:
             mesh_shape=mesh_shape,
             mesh_dim_names=mesh_names,
         )
-        # flatten dp+cp if cp>1
-        if self.cp_size > 1:
-            self.device_mesh[("dp", "cp")]._flatten(mesh_dim_name="dp_cp")
-
         # based on https://github.com/pytorch/torchtitan/blob/d282cf2ce9ca8049b4b8423c1d7578c80426576f/torchtitan/distributed/parallel_dims.py#L191
         # Create all the submesh here to ensure all required process groups are
         # initialized:


### PR DESCRIPTION
## Error
As titled, got the following error with cp>1
```
[rank0]:     self.device_mesh[("dp", "cp")]._flatten(mesh_dim_name="dp_cp")
[rank0]:     ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
[rank0]:   File "/opt/venv/lib/python3.12/site-packages/torch/distributed/device_mesh.py", line 718, in __getitem__
[rank0]:     slice_mesh_dims = _mesh_resources._get_slice_mesh_dims(
[rank0]:                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/opt/venv/lib/python3.12/site-packages/torch/distributed/device_mesh.py", line 314, in _get_slice_mesh_dims
[rank0]:     raise KeyError(
[rank0]: KeyError: "Invalid mesh_dim_names ('dp', 'cp') specified. Valid mesh_dim_names are ['dp_replicate', 'dp_shard', 'cp', 'tp']."
```

## Solution
Remove the stale codes since "dp_cp" has already been handled https://github.com/NVIDIA-NeMo/Automodel/blob/26bbeaea55303cf66660e9973e649b9e867a86b2/nemo_automodel/components/distributed/fsdp2.py#L218-L219

Have tested and verified locally with the change.