### PR TITLE
Avoid passing device_id to init_process_group due to NCCL hangs

### DIFF
--- a/nemo_automodel/components/distributed/init_utils.py
+++ b/nemo_automodel/components/distributed/init_utils.py
@@ -126,7 +126,6 @@ def initialize_distributed(
             rank = get_local_rank_preinit()
             device = torch.device("cuda", rank)
             torch.cuda.set_device(device)
-            init_pg_kwargs["device_id"] = device
 
         if get_world_size_safe() == 1:
             import socket


### PR DESCRIPTION
There are some known issues wrt passing device_id to init_process_group. See  https://github.com/pytorch/pytorch/issues/153960 and https://github.com/pytorch/pytorch/issues/149119  for details. This PR avoids passing device_id until those issues are resolved.