### PR TITLE
fix: Rectify validation loss normalization

### DIFF
--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -937,7 +937,7 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
                     0,
                     batch,
                     loss_buffer=loss_buffer,
-                    num_label_tokens=num_label_tokens,
+                    num_label_tokens=None,  # we will normalize outside.
                     num_batches=1,
                     is_train=False,
                 )


### PR DESCRIPTION
Validation loss is normalized outside `_forward_backward_step`, so do not pass `num_label_tokens` to `_forward_backward_step` in the validation loop.