### PR TITLE
fix: take max_step in lr scheduler

### DIFF
--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -989,7 +989,7 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
         log_data["learning_rate"] = current_lr
 
         if wandb.run is not None:
-            wandb.log(log_data)
+            wandb.log(log_data, step=self.step_scheduler.step)
 
         if self.dist_env.is_main:
             logging.info(

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -413,6 +413,8 @@ def build_lr_scheduler(cfg, optimizer, step_scheduler) -> list[OptimizerParamSch
 
     # Total optimizer steps (accounting for gradient accumulation)
     total_steps = (total_epochs * epoch_len) // grad_acc_steps
+    if step_scheduler.max_steps is not None:
+        total_steps = min(total_steps, step_scheduler.max_steps)
 
     # Extract learning rate from optimizer
     base_lrs = [opt.param_groups[0]["lr"] for opt in optimizer]

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -809,7 +809,7 @@ class FinetuneRecipeForVLM(BaseRecipe):
         log_data["learning_rate"] = current_lr
 
         if wandb.run is not None:
-            wandb.log(log_data)
+            wandb.log(log_data, step=self.step_scheduler.step)
 
         logging.info(
             "step {} | epoch {} | loss {:.4f} | grad_norm {:.4f} | lr {:.2e} | mem {:.2f} GiB | tps {:.2f} | num_label_tokens {}".format(

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -384,6 +384,8 @@ def build_lr_scheduler(cfg, optimizer, step_scheduler) -> OptimizerParamSchedule
 
     # Total optimizer steps (accounting for gradient accumulation)
     total_steps = (total_epochs * epoch_len) // grad_acc_steps
+    if step_scheduler.max_steps is not None:
+        total_steps = min(total_steps, step_scheduler.max_steps)
 
     # Extract learning rate from optimizer
     base_lr = optimizer.param_groups[0]["lr"]


### PR DESCRIPTION
multiple fixes
- take max_steps and pass to lr scheduler
- fix wandb call so multiple resumed runs show nicely
before:
<img width="961" height="315" alt="image" src="https://github.com/user-attachments/assets/2f3980a1-40e8-44b7-9dea-5e31c30de696" />
after:
<img width="960" height="316" alt="image" src="https://github.com/user-attachments/assets/d5c13300-d898-4a97-8e25-ba9851d8b70c" />
