### PR TITLE
feat: fallback to MaskedCrossEntropy if model does not support logits_to_keep

### DIFF
--- a/nemo_automodel/components/utils/model_utils.py
+++ b/nemo_automodel/components/utils/model_utils.py
@@ -12,11 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 import logging
 
 import torch.nn as nn
 
 logger = logging.getLogger(__name__)
+
+
+def _supports_logits_to_keep(model: nn.Module) -> bool:
+    """
+    Check if the model supports logits_to_keep.
+
+    Args:
+        model (nn.Module): The model to check.
+
+    Returns:
+        bool: True if the model supports logits_to_keep, False otherwise.
+    """
+    return "logits_to_keep" in set(inspect.signature(model.forward).parameters.keys())
 
 
 def _get_model_param_stats(model: nn.Module) -> tuple[int, int, float]:

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -186,7 +186,7 @@ def build_model_and_optimizer(
 
                 model, optimizer = model_wrapper.parallelize(model, optimizer)
 
-                return model, [optimizer]
+                return model, [optimizer], loss_fn
 
             else:
                 model = model_wrapper.parallelize(model)

--- a/tests/functional_tests/hf_transformer_finetune/L2_HF_Transformer_SFT_no_logits.sh
+++ b/tests/functional_tests/hf_transformer_finetune/L2_HF_Transformer_SFT_no_logits.sh
@@ -1,0 +1,33 @@
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/bin/bash
+set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
+
+TRANSFORMERS_OFFLINE=1 coverage run --data-file=/workspace/.coverage --source=/workspace --parallel-mode \
+examples/llm_finetune/finetune.py \
+  --config examples/llm_finetune/llama3_2/llama3_2_1b_squad.yaml \
+  --model.pretrained_model_name_or_path /home/TestData/akoumparouli/mini_MiniCPM-1B-sft-bf16/ \
+  --step_scheduler.max_steps 3 \
+  --step_scheduler.global_batch_size 8 \
+  --step_scheduler.local_batch_size 8 \
+  --step_scheduler.val_every_steps 1 \
+  --loss_fn._target_ nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy \
+  --dataset.tokenizer.pretrained_model_name_or_path /home/TestData/akoumparouli/mini_MiniCPM-1B-sft-bf16/ \
+  --validation_dataset.tokenizer.pretrained_model_name_or_path /home/TestData/akoumparouli/mini_MiniCPM-1B-sft-bf16/ \
+  --dataset.dataset_name /home/TestData/lite/hf_cache/squad/ \
+  --dataset.limit_dataset_samples 10 \
+  --validation_dataset.dataset_name /home/TestData/lite/hf_cache/squad/ \
+  --validation_dataset.limit_dataset_samples 10 \
+

--- a/tests/functional_tests/hf_transformer_finetune/test_hf_transformer_sft.py
+++ b/tests/functional_tests/hf_transformer_finetune/test_hf_transformer_sft.py
@@ -20,7 +20,7 @@ HF_TRANSFORMER_SFT_NVFSDP_FILENAME = "L2_HF_Transformer_SFT_nvfsdp.sh"
 HF_TRANSFORMER_PEFT_FILENAME = "L2_HF_Transformer_PEFT.sh"
 HF_TRANSFORMER_PEFT_NVFSDP_FILENAME = "L2_HF_Transformer_PEFT_nvfsdp.sh"
 HF_TRANSFORMER_PEFT_NO_TOKENIZER_FILENAME = "L2_HF_Transformer_PEFT_no_tokenizer.sh"
-
+HF_TRANSFORMER_SFT_NO_LOGITS_FILENAME = "L2_HF_Transformer_SFT_no_logits.sh"
 
 class TestHFTransformerFinetune:
     def test_hf_transformer_sft(self):
@@ -37,3 +37,6 @@ class TestHFTransformerFinetune:
 
     def test_hf_transformer_peft_no_tokenizer(self):
         run_test_script(TEST_FOLDER, HF_TRANSFORMER_PEFT_NO_TOKENIZER_FILENAME)
+
+    def test_hf_transformer_sft_no_logits(self):
+        run_test_script(TEST_FOLDER, HF_TRANSFORMER_SFT_NO_LOGITS_FILENAME)

--- a/tests/unit_tests/distributed/pipelining/test_autopipeline.py
+++ b/tests/unit_tests/distributed/pipelining/test_autopipeline.py
@@ -893,7 +893,7 @@ class TestAutoPipelineIntegration:
         def loss_fn(logits: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
             return torch.tensor(0.0)
 
-        model, optimizer = ft_mod.build_model_and_optimizer(
+        model, optimizer, loss_fn = ft_mod.build_model_and_optimizer(
             device=torch.device("cpu"),
             cfg_model=CfgModelStub(),
             cfg_opt=CfgOptStub(),


### PR DESCRIPTION
For models that lack the `logits_to_keep` in their `forward` arg, fallback to `MaskedCrossEntropy`.