### PR TITLE
feat: disable packed sequence if unsupported by model

### DIFF
--- a/nemo_automodel/components/utils/model_utils.py
+++ b/nemo_automodel/components/utils/model_utils.py
@@ -30,7 +30,7 @@ def _supports_logits_to_keep(model: nn.Module) -> bool:
     Returns:
         bool: True if the model supports logits_to_keep, False otherwise.
     """
-    if callable(getattr(model, 'forward', None)):
+    if callable(getattr(model, "forward", None)):
         return "logits_to_keep" in set(inspect.signature(model.forward).parameters.keys())
     else:
         return False
@@ -40,7 +40,7 @@ def _supports_seq_lens(model: nn.Module) -> bool:
     """
     Check if the model supports seq_lens.
     """
-    if callable(getattr(model, 'forward', None)):
+    if callable(getattr(model, "forward", None)):
         return "seq_lens" in set(inspect.signature(model.forward).parameters.keys())
     else:
         return False

--- a/nemo_automodel/components/utils/model_utils.py
+++ b/nemo_automodel/components/utils/model_utils.py
@@ -30,14 +30,20 @@ def _supports_logits_to_keep(model: nn.Module) -> bool:
     Returns:
         bool: True if the model supports logits_to_keep, False otherwise.
     """
-    return "logits_to_keep" in set(inspect.signature(model.forward).parameters.keys())
+    if callable(getattr(model, 'forward')):
+        return "logits_to_keep" in set(inspect.signature(model.forward).parameters.keys())
+    else:
+        return False
 
 
 def _supports_seq_lens(model: nn.Module) -> bool:
     """
     Check if the model supports seq_lens.
     """
-    return "seq_lens" in set(inspect.signature(model.forward).parameters.keys())
+    if callable(getattr(model, 'forward')):
+        return "seq_lens" in set(inspect.signature(model.forward).parameters.keys())
+    else:
+        return False
 
 
 def _get_model_param_stats(model: nn.Module) -> tuple[int, int, float]:

--- a/nemo_automodel/components/utils/model_utils.py
+++ b/nemo_automodel/components/utils/model_utils.py
@@ -30,7 +30,7 @@ def _supports_logits_to_keep(model: nn.Module) -> bool:
     Returns:
         bool: True if the model supports logits_to_keep, False otherwise.
     """
-    if callable(getattr(model, 'forward')):
+    if callable(getattr(model, 'forward', None)):
         return "logits_to_keep" in set(inspect.signature(model.forward).parameters.keys())
     else:
         return False
@@ -40,7 +40,7 @@ def _supports_seq_lens(model: nn.Module) -> bool:
     """
     Check if the model supports seq_lens.
     """
-    if callable(getattr(model, 'forward')):
+    if callable(getattr(model, 'forward', None)):
         return "seq_lens" in set(inspect.signature(model.forward).parameters.keys())
     else:
         return False

--- a/nemo_automodel/components/utils/model_utils.py
+++ b/nemo_automodel/components/utils/model_utils.py
@@ -32,11 +32,13 @@ def _supports_logits_to_keep(model: nn.Module) -> bool:
     """
     return "logits_to_keep" in set(inspect.signature(model.forward).parameters.keys())
 
+
 def _supports_seq_lens(model: nn.Module) -> bool:
     """
     Check if the model supports seq_lens.
     """
     return "seq_lens" in set(inspect.signature(model.forward).parameters.keys())
+
 
 def _get_model_param_stats(model: nn.Module) -> tuple[int, int, float]:
     """

--- a/nemo_automodel/components/utils/model_utils.py
+++ b/nemo_automodel/components/utils/model_utils.py
@@ -32,6 +32,11 @@ def _supports_logits_to_keep(model: nn.Module) -> bool:
     """
     return "logits_to_keep" in set(inspect.signature(model.forward).parameters.keys())
 
+def _supports_seq_lens(model: nn.Module) -> bool:
+    """
+    Check if the model supports seq_lens.
+    """
+    return "seq_lens" in set(inspect.signature(model.forward).parameters.keys())
 
 def _get_model_param_stats(model: nn.Module) -> tuple[int, int, float]:
     """

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -330,7 +330,7 @@ def build_dataloader(
     dp_rank,
     dp_world_size,
     pp_enabled,
-    supports_seq_lens,
+    supports_seq_lens=True,
 ) -> tuple[DataLoader, PreTrainedTokenizerBase]:
     """Build a DataLoader for the dataset.
 
@@ -347,7 +347,7 @@ def build_dataloader(
         dp_rank: Data parallel rank.
         dp_world_size: Data parallel world size.
         pp_enabled: Whether pipeline parallelism is enabled.
-        supports_seq_lens: Whether the model supports seq_lens.
+        supports_seq_lens: Whether the model supports seq_lens (Default: True).
     Returns:
         The instantiated DataLoader and tokenizer.
     """

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -64,7 +64,11 @@ from nemo_automodel.components.utils.compile_utils import (
     build_compile_config,
     compile_model,
 )
-from nemo_automodel.components.utils.model_utils import _supports_logits_to_keep, _supports_seq_lens, print_trainable_parameters
+from nemo_automodel.components.utils.model_utils import (
+    _supports_logits_to_keep,
+    _supports_seq_lens,
+    print_trainable_parameters,
+)
 from nemo_automodel.recipes.base_recipe import BaseRecipe
 
 if TYPE_CHECKING:


### PR DESCRIPTION
Some models may not support packed sequences (e.g., lack `seq_lens` parameter). This PR introduces logic to check if the underlying model does not support packed sequences, in which case, it will print a warning and fallback to unpacked sequences.