### PR TITLE
feat: add ColumnMappedTextInstructionDataset example + update docs

### DIFF
--- a/docs/guides/llm/column-mapped-text-instruction-dataset.md
+++ b/docs/guides/llm/column-mapped-text-instruction-dataset.md
@@ -27,7 +27,6 @@ ds = ColumnMappedTextInstructionDataset(
     path_or_dataset_id="Muennighoff/natural-instructions",
     column_mapping={"instruction": "definition", "question": "inputs", "answer": "targets"},
     tokenizer=tokenizer,
-    streaming=True,
     answer_only_loss_mask=False,
 )
 
@@ -140,7 +139,6 @@ remote_ds = ColumnMappedTextInstructionDataset(
     split="train[:5%]",        # demo slice; omit (i.e. `split="train",`) for full data
     answer_only_loss_mask=True,
     start_of_turn_token="<|assistant|>",
-    streaming=True,              # <── stream instead of download whole dataset
 )
 ```
 
@@ -163,7 +161,7 @@ dataset:
 | Arg                     | Default | Description |
 |-------------------------|---------|-------------|
 | `split`                 | `None`  | Which split to pull from a HF repo (`train`, `validation`, *etc.*). Ignored for local files. |
-| `streaming`             | `False` | If `True`, loads the dataset in *streaming* mode (an HF `IterableDataset`). Useful for very large corpora or when you want to start training before the full download completes.  When enabled, `len(...)` and random access (`dataset[idx]`) are **not** available — iterate instead. |
+(`dataset[idx]`) are **not** available — iterate instead. |
 | `answer_only_loss_mask` | `True`  | Create a `loss_mask` where only the answer tokens contribute to the loss. Requires `start_of_turn_token`. |
 | `start_of_turn_token`   | `None`  | String token marking the assistant’s response. Required when `answer_only_loss_mask=True` for tokenizers with chat template. |
 

--- a/docs/guides/llm/column-mapped-text-instruction-dataset.md
+++ b/docs/guides/llm/column-mapped-text-instruction-dataset.md
@@ -167,7 +167,7 @@ dataset:
 | `split`                 | `None`  | Which split to pull from a HF repo (`train`, `validation`, *etc.*). Ignored for local files. |
 (`dataset[idx]`) are **not** available — iterate instead. |
 | `answer_only_loss_mask` | `True`  | Create a `loss_mask` where only the answer tokens contribute to the loss. Requires `start_of_turn_token`. |
-| `start_of_turn_token`   | `None`  | String token marking the assistant’s response. Required when `answer_only_loss_mask=True` for tokenizers with chat template. |
+| `start_of_turn_token`   | `None`  | String token marking the assistant's response. Required when `answer_only_loss_mask=True` for tokenizers with chat template. |
 
 ---
 ## Tokenisation Paths
@@ -213,10 +213,84 @@ Regardless of the path, the output dict is always:
 ## Parameter Requirements
 
 The following section lists important requirements and caveats for correct usage.
-* `answer_only_loss_mask=True` requires a start_of_turn_token string that exists in the tokenizer’s vocabulary and can be successfully encoded when the helper performs a lookup. Otherwise, a `ValueError` is raised at instantiation time.
+* `answer_only_loss_mask=True` requires a start_of_turn_token string that exists in the tokenizer's vocabulary and can be successfully encoded when the helper performs a lookup. Otherwise, a `ValueError` is raised at instantiation time.
 * Each sample must include at least one of `context` or `question`; omitting both will result in a `ValueError`.
+
+---
+## Slurm Configuration for Distributed Training
+
+For distributed training on Slurm clusters, add a `slurm` section to your YAML configuration. This section configures the Slurm batch job parameters and automatically generates the appropriate `#SBATCH` directives.
+
+### Basic Slurm Configuration
+
+Add the following section to your YAML configuration:
+
+```yaml
+# Your existing model, dataset, training config...
+step_scheduler:
+  grad_acc_steps: 4
+  num_epochs: 1
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: meta-llama/Llama-3.2-1B
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.column_mapped_text_instruction_dataset.ColumnMappedTextInstructionDataset
+  path_or_dataset_id: Muennighoff/natural-instructions
+  column_mapping:
+    context: definition
+    question: inputs
+    answer: targets
+
+# Add Slurm configuration
+slurm:
+  job_name: llm-finetune
+  nodes: 1
+  ntasks_per_node: 8
+  time: 00:30:00
+  account: your_account
+  partition: gpu
+  container_image: nvcr.io/nvidia/nemo:25.07
+  gpus_per_node: 8
+```
+
+### Multi-Node Slurm Configuration
+
+:::note
+**Note for Multi-Node Training**: When using Hugging Face datasets in multi-node setups, you need shared storage accessible by all nodes. Set the `HF_DATASETS_CACHE` environment variable to point to a shared directory (e.g., `HF_DATASETS_CACHE=/shared/hf_cache`) in the yaml file as shown, to ensure all nodes can access the cached datasets.
+:::
+
+When using multiple nodes with Hugging Face datasets:
+
+1. **Shared Storage**: Ensure all nodes can access the same storage paths
+2. **HF Cache**: Set `hf_home` to a shared directory accessible by all nodes
+3. **Environment Variables**: Use `env_vars` to set `HF_DATASETS_CACHE` to the shared location
+
+```yaml
+slurm:
+  job_name: llm-finetune-multi-node # name of the slurm job
+  nodes: 4 # number of nodes to use
+  ntasks_per_node: 8 # Number of tasks per node (typically equals number of GPUs)
+  time: 02:00:00 # Maximum job runtime (format: `HH:MM:SS`)
+  account: your_account # Slurm account to charge resources to
+  partition: gpu # Slurm partition to submit to
+  container_image: nvcr.io/nvidia/nemo:25.07 # Container image to use for the job
+  gpus_per_node: 8 # Number of GPUs per node (adds `#SBATCH --gpus-per-node=N`)
+  # Optional: Add extra mount points if needed
+  extra_mounts: # Additional mount points for the container
+    - /lustre:/lustre
+    - /shared:/shared
+  # Optional: Specify custom HF_HOME location
+  hf_home: /shared/hf_cache # Custom Hugging Face cache directory on shared dist space.
+  # Optional: Specify custom env vars
+  env_vars: # Additional environment variables
+    HF_DATASETS_CACHE: /shared/hf_cache  # similar to hf_home, useful when use a different directory for datasets.
+  # Optional: Specify custom job directory
+  job_dir: /path/to/slurm/jobs
+```
 
 
 ---
-### That’s It!
+### That's It!
 With the mapping specified, the rest of the NeMo Automodel pipeline (pre-tokenisation, packing, collate-fn, *etc.*) works as usual.

--- a/docs/guides/llm/column-mapped-text-instruction-dataset.md
+++ b/docs/guides/llm/column-mapped-text-instruction-dataset.md
@@ -25,7 +25,11 @@ tokenizer = AutoTokenizer.from_pretrained("meta-llama/Meta-Llama-3-8B")
 
 ds = ColumnMappedTextInstructionDataset(
     path_or_dataset_id="Muennighoff/natural-instructions",
-    column_mapping={"instruction": "definition", "question": "inputs", "answer": "targets"},
+    column_mapping={
+      "context": "definition",
+      "question": "inputs",
+      "answer": "targets"
+    },
     tokenizer=tokenizer,
     answer_only_loss_mask=False,
 )
@@ -83,7 +87,7 @@ You can configure the dataset entirely from your recipe YAML.  For example:
 ```yaml
 dataset:
   _target_: nemo_automodel.components.datasets.llm.column_mapped_text_instruction_dataset.ColumnMappedTextInstructionDataset
-  path_or_dataset_id: 
+  path_or_dataset_id:
     - /data/my_corpus_1.jsonl
     - /data/my_corpus_2.jsonl
   column_mapping:
@@ -118,7 +122,7 @@ The following are examples from the training split:
 }
 ```
 
-For basic QA fine-tuning, we usually map `definition → instruction`, `inputs → question`, and `targets → answer` as follows:
+For basic QA fine-tuning, we usually map `definition → context`, `inputs → question`, and `targets → answer` as follows:
 
 ```python
 from nemo_automodel.components.datasets.llm.column_mapped_text_instruction_dataset import (
@@ -131,7 +135,7 @@ tokenizer = AutoTokenizer.from_pretrained("meta-llama/Meta-Llama-3-8B")
 remote_ds = ColumnMappedTextInstructionDataset(
     path_or_dataset_id="Muennighoff/natural-instructions",  # Hugging Face repo ID
     column_mapping={
-        "instruction": "definition",  # high-level instruction
+        "context": "definition",  # high-level context
         "question": "inputs",         # the actual prompt / input
         "answer": "targets",          # expected answer string
     },
@@ -150,9 +154,9 @@ dataset:
   path_or_dataset_id: Muennighoff/natural-instructions
   split: train
   column_mapping:
-    context: context
-    question: question
-    answer: answer
+    context: definition
+    question: inputs
+    answer: targets
   answer_only_loss_mask: true
   start_of_turn_token: "<|assistant|>"
 ```
@@ -215,4 +219,4 @@ The following section lists important requirements and caveats for correct usage
 
 ---
 ### That’s It!
-With the mapping specified, the rest of the NeMo Automodel pipeline (pre-tokenisation, packing, collate-fn, *etc.*) works as usual. 
+With the mapping specified, the rest of the NeMo Automodel pipeline (pre-tokenisation, packing, collate-fn, *etc.*) works as usual.

--- a/examples/llm_finetune/llama3_1/llama3_1_8b_columnmapped_lora.yaml
+++ b/examples/llm_finetune/llama3_1/llama3_1_8b_columnmapped_lora.yaml
@@ -1,0 +1,87 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# QLora configuration for Llama-3.1-8B on SQuAD dataset
+# Uses 4-bit quantization with LoRA adapters
+#
+# To run this recipe, please use the following command:
+# torchrun --nproc-per-node=1 examples/llm_finetune/finetune.py --config examples/llm_finetune/llama3_1/llama3_1_8b_columnmapped_lora.yaml
+
+step_scheduler:
+  global_batch_size: 32
+  local_batch_size: 4
+  ckpt_every_steps: 100
+  val_every_steps: 600
+  max_steps: 500
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 1
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 42
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: meta-llama/Llama-3.1-8B
+
+peft:
+  _target_: nemo_automodel.components._peft.lora.PeftConfig
+  match_all_linear: true
+  dim: 16
+  alpha: 32
+  dropout: 0.1
+
+distributed:
+  _target_: nemo_automodel.components.distributed.fsdp2.FSDP2Manager
+  dp_size: none
+  dp_replicate_size: 1
+  tp_size: 1
+  cp_size: 1
+  sequence_parallel: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.column_mapped_text_instruction_dataset.ColumnMappedTextInstructionDataset
+  path_or_dataset_id: Muennighoff/natural-instructions
+  column_mapping:
+    instruction: definition
+    question: inputs
+    answer: targets
+
+packed_sequence:
+  packed_sequence_size: 0
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  shuffle: false
+
+optimizer:
+  _target_: torch.optim.AdamW
+  betas: [0.9, 0.999]
+  eps: 1e-8
+  lr: 1.0e-5
+  weight_decay: 0.01
+
+# Uncomment and configure for W&B logging
+# wandb:
+#   project: <your_wandb_project>
+#   entity: <your_wandb_entity>
+#   name: llama3_1_8b_squad_qlora
+#   save_dir: <your_wandb_save_dir> 

--- a/examples/llm_finetune/llama3_1/llama3_1_8b_columnmapped_lora.yaml
+++ b/examples/llm_finetune/llama3_1/llama3_1_8b_columnmapped_lora.yaml
@@ -59,13 +59,28 @@ loss_fn:
 dataset:
   _target_: nemo_automodel.components.datasets.llm.column_mapped_text_instruction_dataset.ColumnMappedTextInstructionDataset
   path_or_dataset_id: Muennighoff/natural-instructions
+  split: train
   column_mapping:
-    instruction: definition
+    context: definition
     question: inputs
     answer: targets
 
 packed_sequence:
   packed_sequence_size: 0
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  shuffle: false
+
+# validation_dataset:
+#   _target_: nemo_automodel.components.datasets.llm.column_mapped_text_instruction_dataset.ColumnMappedTextInstructionDataset
+#   path_or_dataset_id: Muennighoff/natural-instructions
+#   split: validation
+#   column_mapping:
+#     instruction: definition
+#     question: inputs
+#     answer: targets
 
 dataloader:
   _target_: torchdata.stateful_dataloader.StatefulDataLoader

--- a/nemo_automodel/components/datasets/llm/column_mapped_text_instruction_dataset.py
+++ b/nemo_automodel/components/datasets/llm/column_mapped_text_instruction_dataset.py
@@ -113,7 +113,7 @@ def _load_dataset(path_or_dataset_id: Union[str, List[str]], split: Optional[str
         raise RuntimeError("No data files provided")
 
     return load_dataset(
-        "json", data_files=data_files, split=None, streaming=streaming, verification_mode=VerificationMode.NO_CHECKS
+        "json", data_files=data_files, split="train", streaming=streaming, verification_mode=VerificationMode.NO_CHECKS
     )
 
 

--- a/nemo_automodel/components/datasets/llm/column_mapped_text_instruction_dataset.py
+++ b/nemo_automodel/components/datasets/llm/column_mapped_text_instruction_dataset.py
@@ -18,7 +18,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Dict, Iterator, List, Optional, Union
 
-from datasets import load_dataset
+from datasets import load_dataset, VerificationMode
 from torch.utils.data import Dataset
 
 from nemo_automodel.components.datasets.llm.formatting_utils import (
@@ -104,13 +104,13 @@ def _load_dataset(path_or_dataset_id: Union[str, List[str]], split: Optional[str
         datasets.Dataset: The loaded dataset.
     """
     if isinstance(path_or_dataset_id, str) and _str_is_hf_repo_id(path_or_dataset_id):
-        return load_dataset(path_or_dataset_id, split=split or "train", streaming=streaming)
+        return load_dataset(path_or_dataset_id, split=split, streaming=streaming, verification_mode=VerificationMode.NO_CHECKS)
 
     data_files = list(make_iterable(path_or_dataset_id))
     if not data_files:
         raise RuntimeError("No data files provided")
 
-    return load_dataset("json", data_files=data_files, split="train", streaming=streaming)
+    return load_dataset("json", data_files=data_files, split=None, streaming=streaming, verification_mode=VerificationMode.NO_CHECKS)
 
 
 def _check_all_values_equal_length(sample: Dict[str, List[int]]) -> bool:
@@ -129,7 +129,7 @@ def _check_all_values_equal_length(sample: Dict[str, List[int]]) -> bool:
 
 
 class ColumnMappedTextInstructionDataset(Dataset):
-    """Generic *instruction‐tuning* dataset that maps arbitrary column names.
+    """Generic instruction-tuning dataset that maps arbitrary column names.
 
     The class is intentionally lightweight: it simply loads the raw samples
     (either from HF or from local JSON/JSONL files) and remaps the columns so

--- a/nemo_automodel/components/datasets/llm/column_mapped_text_instruction_dataset.py
+++ b/nemo_automodel/components/datasets/llm/column_mapped_text_instruction_dataset.py
@@ -18,7 +18,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Dict, Iterator, List, Optional, Union
 
-from datasets import load_dataset, VerificationMode
+from datasets import VerificationMode, load_dataset
 from torch.utils.data import Dataset
 
 from nemo_automodel.components.datasets.llm.formatting_utils import (
@@ -104,13 +104,17 @@ def _load_dataset(path_or_dataset_id: Union[str, List[str]], split: Optional[str
         datasets.Dataset: The loaded dataset.
     """
     if isinstance(path_or_dataset_id, str) and _str_is_hf_repo_id(path_or_dataset_id):
-        return load_dataset(path_or_dataset_id, split=split, streaming=streaming, verification_mode=VerificationMode.NO_CHECKS)
+        return load_dataset(
+            path_or_dataset_id, split=split, streaming=streaming, verification_mode=VerificationMode.NO_CHECKS
+        )
 
     data_files = list(make_iterable(path_or_dataset_id))
     if not data_files:
         raise RuntimeError("No data files provided")
 
-    return load_dataset("json", data_files=data_files, split=None, streaming=streaming, verification_mode=VerificationMode.NO_CHECKS)
+    return load_dataset(
+        "json", data_files=data_files, split=None, streaming=streaming, verification_mode=VerificationMode.NO_CHECKS
+    )
 
 
 def _check_all_values_equal_length(sample: Dict[str, List[int]]) -> bool:

--- a/nemo_automodel/components/distributed/utils.py
+++ b/nemo_automodel/components/distributed/utils.py
@@ -16,7 +16,7 @@
 import logging
 import os
 from contextlib import ContextDecorator, nullcontext
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Optional
 
 import torch
@@ -26,18 +26,90 @@ import torch.distributed as dist
 logger = logging.getLogger(__name__)
 
 
+def _create_gloo_group():
+    """
+    Create a Gloo process group for barrier operations.
+
+    This allows us to use monitored_barrier with Gloo backend while
+    keeping NCCL for the main training operations.
+
+    Returns:
+        ProcessGroup: Gloo process group for barriers
+    """
+    if not dist.is_initialized():
+        return None
+
+    try:
+        # Create a Gloo group for barrier operations
+        gloo_group = dist.new_group(backend="gloo")
+        logger.debug("Created Gloo group for barrier operations")
+        return gloo_group
+    except Exception as e:
+        logger.warning(f"Failed to create Gloo group: {e}")
+        return None
+
+
+def _barrier_with_timeout(timeout: timedelta, group=None):
+    """
+    A timeout wrapper for torch.distributed.barrier() using Gloo backend.
+
+    This approach creates a separate Gloo process group for barrier operations
+    while keeping the main NCCL backend for training operations.
+
+    Args:
+        timeout: Maximum time to wait for the barrier
+        group: Process group for the barrier operation
+
+    Returns:
+        bool: True if barrier completed successfully, False if timeout occurred
+    """
+    if not dist.is_initialized():
+        return True
+
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+
+    if world_size == 1:
+        return True
+
+    # Use Gloo group for barrier operations
+    gloo_group = _create_gloo_group()
+    if gloo_group is None:
+        # Fallback to regular barrier if Gloo group creation fails
+        try:
+            dist.barrier(group=group)
+            return True
+        except Exception as e:
+            logger.warning(f"Barrier failed: {e}")
+            return False
+
+    try:
+        # Use monitored_barrier with Gloo group
+        dist.monitored_barrier(group=gloo_group, timeout=timeout)
+        return True
+    except Exception as e:
+        logger.warning(f"Monitored barrier failed: {e}")
+        return False
+    finally:
+        # Clean up the Gloo group
+        try:
+            dist.destroy_process_group(gloo_group)
+        except Exception:
+            pass
+
+
 class FirstRankPerNode(ContextDecorator):
     """
     Context manager to enforce rank0 to process section over other ranks.
 
-      - Lets LOCAL_RANK==0 run the protected code first on each node.
+      - Lets RANK==0 run the protected code first on each node.
       - Inserts an extra barrier across *only* the node-local rank-0 processes.
       - Works on a single GPU (no env flags, no distributed initialisation).
 
     Note: it is assumed the scoped code is not torch.distributed heavy.
     """
 
-    def __enter__(self):
+    def __enter__(self, timeout=timedelta(hours=10)):
         """
         Create / bootstrap a (distributed) proc. group that rank0 enters first.
 
@@ -48,21 +120,23 @@ class FirstRankPerNode(ContextDecorator):
         self._created_pg = False
         self._node0_group = None
         self._first = True  # default for single-GPU / no-dist case
-
-        if not dist.is_initialized():
+        self._timeout = timeout
+        if not dist.is_initialized() or dist.get_world_size() == 1:
             # pure single GPU
             return True
 
         # Figure out local/global ranks
         env = os.environ
-        global_rank = dist.get_rank()
-        local_rank = int(env.get("LOCAL_RANK", global_rank))  # fallback
-        self._first = local_rank == 0
+        rank = dist.get_rank()
+        self._first = rank == 0
 
         # Synchronisation logic
         if not self._first:
             # Non-rank-0 processes wait for their node-rank-0
-            dist.barrier()
+            # Use Gloo group for monitored_barrier to avoid NCCL timeout issues
+            success = _barrier_with_timeout(timeout=self._timeout)
+            if not success:
+                logger.warning("Barrier timed out, continuing anyway")
 
         return self._first
 
@@ -89,9 +163,13 @@ class FirstRankPerNode(ContextDecorator):
         try:
             if self._first and dist.is_initialized():
                 # Re-sync the whole world so that non-rank-0s can proceed
-                dist.barrier()
+                # Use Gloo group for monitored_barrier to avoid NCCL timeout issues
+                success = _barrier_with_timeout(timeout=self._timeout)
+                if not success:
+                    logger.warning("Barrier timed out during exit, continuing anyway")
                 if exc_type is not None:
-                    dist.abort()  # propagate failure to the entire job
+                    # TODO: propagate failure to the entire job
+                    quit(1)
         finally:
             if self._created_pg:
                 dist.destroy_process_group()

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -359,15 +359,15 @@ def build_dataloader(
     """
     with StatefulRNG(seed=seed, ranked=True):
         kwargs, tokenizer = _build_tokenizer(cfg_model, cfg_ds)
-        with FirstRankPerNode():
-            # Megatron specific kwargs
-            if cfg_ds._target_ == MegatronPretraining:
-                kwargs["global_batch_size"] = global_batch_size
-                kwargs["trainer_max_steps"] = max_steps if max_steps is not None else None
-                kwargs["trainer_val_check_interval"] = val_check_interval
-                ds = cfg_ds.instantiate(**kwargs)
-                ds.build()
-            else:
+        # Megatron specific kwargs
+        if cfg_ds._target_ == MegatronPretraining:
+            kwargs["global_batch_size"] = global_batch_size
+            kwargs["trainer_max_steps"] = max_steps if max_steps is not None else None
+            kwargs["trainer_val_check_interval"] = val_check_interval
+            ds = cfg_ds.instantiate(**kwargs)
+            ds.build()
+        else:
+            with FirstRankPerNode():
                 ds = cfg_ds.instantiate(**kwargs)
 
         packed_sequence_size = getattr(cfg_ps, "packed_sequence_size", 0)

--- a/tests/unit_tests/datasets/llm/test_column_mapped_text_instruction.py
+++ b/tests/unit_tests/datasets/llm/test_column_mapped_text_instruction.py
@@ -53,7 +53,7 @@ def test_load_dataset_local_json(tmp_path: Path):
         json.dump(data, fp)
 
     ds = _load_dataset(str(file_path))
-    assert len(ds) == 2
+    assert len(ds) == 2, ds
     assert ds[0]["q"] == "How are you?"
 
 

--- a/tests/unit_tests/datasets/llm/test_column_mapped_text_instruction.py
+++ b/tests/unit_tests/datasets/llm/test_column_mapped_text_instruction.py
@@ -53,7 +53,7 @@ def test_load_dataset_local_json(tmp_path: Path):
         json.dump(data, fp)
 
     ds = _load_dataset(str(file_path))
-    assert len(ds) == 2, ds
+    assert len(ds) == 2
     assert ds[0]["q"] == "How are you?"
 
 


### PR DESCRIPTION
Changes:
- add yaml file showing an example of `ColumnMappedTextInstructionDataset`
- set `FirstRankPerNode` barrier timeout to 10h, useful for accommodating large dataset downloads
- update docs.  