### PR TITLE
fix: erroneous import

### DIFF
--- a/examples/llm_kd/kd.py
+++ b/examples/llm_kd/kd.py
@@ -23,7 +23,7 @@ When run without ``-c`` it defaults to the YAML above.
 from __future__ import annotations
 
 from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
-from nemo_automodel.recipes.llm.knowledge_distillation import (
+from nemo_automodel.recipes.llm.kd import (
     KnowledgeDistillationRecipeForNextTokenPrediction,
 )
 

--- a/nemo_automodel/_cli/app.py
+++ b/nemo_automodel/_cli/app.py
@@ -226,7 +226,8 @@ def get_repo_root():
 def run_interactive(args):
     from torch.distributed.run import determine_local_world_size, get_args_parser
     from torch.distributed.run import run as thrun
-    COMMAND_ALIASES = {'finetune': 'train_ft', 'pretrain': 'train_ft'}
+
+    COMMAND_ALIASES = {"finetune": "train_ft", "pretrain": "train_ft"}
     # remap commands: finetune -> train_ft
     command = COMMAND_ALIASES.get(args.command, args.command)
     config_path = args.config.resolve()

--- a/nemo_automodel/_cli/app.py
+++ b/nemo_automodel/_cli/app.py
@@ -226,10 +226,12 @@ def get_repo_root():
 def run_interactive(args):
     from torch.distributed.run import determine_local_world_size, get_args_parser
     from torch.distributed.run import run as thrun
-
+    COMMAND_ALIASES = {'finetune': 'train_ft', 'pretrain': 'train_ft'}
+    # remap commands: finetune -> train_ft
+    command = COMMAND_ALIASES.get(args.command, args.command)
     config_path = args.config.resolve()
     repo_root = get_repo_root()
-    script_path = repo_root / "nemo_automodel" / "recipes" / args.domain / f"{args.command}.py"
+    script_path = repo_root / "nemo_automodel" / "recipes" / args.domain / f"{command}.py"
 
     # launch job on this node
     num_devices = determine_local_world_size(nproc_per_node="gpu")


### PR DESCRIPTION
fixes minor error in the import path;  alternatively, the recipe can be used directly, e.g.:
```
torchrun --nproc-per-node=4 nemo_automodel/recipes/llm/kd.py -c ..
```
instead of the one in examples/