### PR TITLE
fix: TE padding masks for DSv3 MLA layer

### DIFF
--- a/nemo_automodel/components/models/deepseek_v3/model.py
+++ b/nemo_automodel/components/models/deepseek_v3/model.py
@@ -51,6 +51,8 @@ class Block(nn.Module):
         freqs_cis: torch.Tensor,
         attention_mask: torch.Tensor | None = None,
         padding_mask: torch.Tensor | None = None,
+        seq_lens: torch.Tensor | None = None,
+        **attn_kwargs: Any,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """
         Forward pass for the Transformer block.
@@ -71,6 +73,7 @@ class Block(nn.Module):
             x=self.input_layernorm(x),
             freqs_cis=freqs_cis,
             attention_mask=attention_mask,
+            **attn_kwargs,
         )
         x = x + attn_out
 
@@ -152,6 +155,7 @@ class DeepseekV3Model(nn.Module):
         position_ids: torch.Tensor | None = None,
         attention_mask: torch.Tensor | None = None,
         padding_mask: torch.Tensor | None = None,
+        seq_lens: torch.Tensor | None = None,
         **attn_kwargs: Any,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         if position_ids is None:
@@ -170,7 +174,10 @@ class DeepseekV3Model(nn.Module):
             h, aux_loss = layer(
                 x=h,
                 freqs_cis=freqs_cis,
+                attention_mask=attention_mask,
                 padding_mask=padding_mask,
+                seq_lens=seq_lens,
+                **attn_kwargs,
             )
             if aux_loss is not None:
                 aux_losses.append(aux_loss)
@@ -248,6 +255,7 @@ class DeepseekV3ForCausalLM(nn.Module):
         position_ids: torch.Tensor | None = None,
         attention_mask: torch.Tensor | None = None,
         padding_mask: torch.Tensor | None = None,
+        seq_lens: torch.Tensor | None = None,
         **attn_kwargs: Any,
     ) -> torch.Tensor:
         logits = self.model(
@@ -255,6 +263,7 @@ class DeepseekV3ForCausalLM(nn.Module):
             position_ids=position_ids,
             attention_mask=attention_mask,
             padding_mask=padding_mask,
+            seq_lens=seq_lens,
             **attn_kwargs,
         )
         logits = self.lm_head(logits) if self.lm_head else logits

--- a/tests/unit_tests/models/deepseek_v3/test_layers.py
+++ b/tests/unit_tests/models/deepseek_v3/test_layers.py
@@ -73,8 +73,8 @@ class TestPreprocessArgsAndKwargsForAttn:
 
         expected_keys = {"attn_mask_type", "window_size", "attention_mask"}
         assert set(attn_kwargs.keys()) == expected_keys
-        assert attn_kwargs["attn_mask_type"] == "padding"
-        assert attn_kwargs["window_size"] == (-1, -1)
+        assert attn_kwargs["attn_mask_type"] == "padding_causal"
+        assert attn_kwargs["window_size"] == (-1, 0)
 
         # Check padding mask shape and values
         padding_mask = attn_kwargs["attention_mask"]


### PR DESCRIPTION
Changes TE DotProduceAttention mask type to `padding_causal` for correctness.