### PR TITLE
fix: 0 token routed expert bug fix & update moe bias

### DIFF
--- a/nemo_automodel/components/moe/layers.py
+++ b/nemo_automodel/components/moe/layers.py
@@ -31,7 +31,9 @@ except ImportError:
 try:
     from grouped_gemm import ops
 except ImportError:
-    print("grouped_gemm is not available. Please run:pip install git+https://github.com/fanshiqing/grouped_gemm@v1.1.4")
+    print(
+        "grouped_gemm is not available. Please run:pip install git+https://github.com/fanshiqing/grouped_gemm@v1.1.4"
+    )
 
 from nemo_automodel.components.moe.megatron.moe_utils import (
     MoEAuxLossAutoScaler,
@@ -495,9 +497,9 @@ class GroupedExpertsDeepEP(nn.Module):
                 down_bias = self.down_proj_bias.to_local()
                 output2 = self._apply_bias(output2, down_bias, tokens_per_expert, permuted_probs)
         else:
-            output2 = torch.zeros((1, x.size(-1)), dtype=x.dtype, device=x.device)
-            output2 = output2 * permuted_probs
-            output2 = output2.to(x.dtype)
+            output1 = torch.matmul(x[0] * 0, self.gate_and_up_projs.to_local()[0])
+            output1_ = self.expert_activation(output1, permuted_probs)
+            output2 = torch.matmul(output1_, self.down_projs.to_local()[0])
 
         y = self.token_dispatcher.token_unpermutation(output2)
         return y
@@ -817,7 +819,9 @@ class Gate(nn.Module):
                 context_length, device_mesh=cp_mesh, placements=[Partial()]
             ).full_tensor()
             expert_load = DTensor.from_local(expert_load, device_mesh=cp_mesh, placements=[Partial()]).full_tensor()
-            expert_scores = DTensor.from_local(expert_scores, device_mesh=cp_mesh, placements=[Partial()]).full_tensor()
+            expert_scores = DTensor.from_local(
+                expert_scores, device_mesh=cp_mesh, placements=[Partial()]
+            ).full_tensor()
 
         # Compute f_i (fraction of tokens dispatched to each expert).
         # If uniform distribution, expert_load will be topk * num_location / n_experts, and f_i will be 1

--- a/nemo_automodel/components/moe/layers.py
+++ b/nemo_automodel/components/moe/layers.py
@@ -497,9 +497,7 @@ class GroupedExpertsDeepEP(nn.Module):
                 down_bias = self.down_proj_bias.to_local()
                 output2 = self._apply_bias(output2, down_bias, tokens_per_expert, permuted_probs)
         else:
-            output1 = torch.matmul(x[0] * 0, self.gate_and_up_projs.to_local()[0])
-            output1_ = self.expert_activation(output1, permuted_probs)
-            output2 = torch.matmul(output1_, self.down_projs.to_local()[0])
+            output2 = torch.zeros((0, x.size(-1)), dtype=x.dtype, device=x.device)
 
         y = self.token_dispatcher.token_unpermutation(output2)
         return y

--- a/nemo_automodel/components/moe/layers.py
+++ b/nemo_automodel/components/moe/layers.py
@@ -31,9 +31,7 @@ except ImportError:
 try:
     from grouped_gemm import ops
 except ImportError:
-    print(
-        "grouped_gemm is not available. Please run:pip install git+https://github.com/fanshiqing/grouped_gemm@v1.1.4"
-    )
+    print("grouped_gemm is not available. Please run:pip install git+https://github.com/fanshiqing/grouped_gemm@v1.1.4")
 
 from nemo_automodel.components.moe.megatron.moe_utils import (
     MoEAuxLossAutoScaler,
@@ -823,9 +821,7 @@ class Gate(nn.Module):
                 context_length, device_mesh=cp_mesh, placements=[Partial()]
             ).full_tensor()
             expert_load = DTensor.from_local(expert_load, device_mesh=cp_mesh, placements=[Partial()]).full_tensor()
-            expert_scores = DTensor.from_local(
-                expert_scores, device_mesh=cp_mesh, placements=[Partial()]
-            ).full_tensor()
+            expert_scores = DTensor.from_local(expert_scores, device_mesh=cp_mesh, placements=[Partial()]).full_tensor()
 
         # Compute f_i (fraction of tokens dispatched to each expert).
         # If uniform distribution, expert_load will be topk * num_location / n_experts, and f_i will be 1

--- a/nemo_automodel/components/moe/megatron/moe_utils.py
+++ b/nemo_automodel/components/moe/megatron/moe_utils.py
@@ -255,11 +255,12 @@ def weighted_bias_swiglu_impl(input, weights, fp8_input_store=False):
     Token-wise-weighted bias swiglu fusion.
     """
     ori_shape = input.shape
-    assert len(ori_shape) in [2, 3]
-    input = input.view(-1, ori_shape[-1])
+    assert len(ori_shape) in [1, 2, 3]
+    if len(ori_shape) != 1:
+        input = input.view(-1, ori_shape[-1])
     output = WeightedSwiGLUFunction.apply(input, weights, fp8_input_store)
 
-    return output if len(ori_shape) == 2 else output.view(ori_shape[0], ori_shape[1], -1)
+    return output if len(ori_shape) in [1, 2] else output.view(ori_shape[0], ori_shape[1], -1)
 
 
 @torch.compile

--- a/nemo_automodel/components/moe/megatron/moe_utils.py
+++ b/nemo_automodel/components/moe/megatron/moe_utils.py
@@ -255,11 +255,13 @@ def weighted_bias_swiglu_impl(input, weights, fp8_input_store=False):
     Token-wise-weighted bias swiglu fusion.
     """
     ori_shape = input.shape
-    assert len(ori_shape) in [2, 3]
-    input = input.view(-1, ori_shape[-1])
+    # assert len(ori_shape) in [2, 3]
+    if len(ori_shape) > 1:
+        input = input.view(-1, ori_shape[-1])
+
     output = WeightedSwiGLUFunction.apply(input, weights, fp8_input_store)
 
-    return output if len(ori_shape) == 2 else output.view(ori_shape[0], ori_shape[1], -1)
+    return output if len(ori_shape) <= 2 else output.view(ori_shape[0], ori_shape[1], -1)
 
 
 @torch.compile

--- a/nemo_automodel/components/moe/megatron/moe_utils.py
+++ b/nemo_automodel/components/moe/megatron/moe_utils.py
@@ -255,12 +255,11 @@ def weighted_bias_swiglu_impl(input, weights, fp8_input_store=False):
     Token-wise-weighted bias swiglu fusion.
     """
     ori_shape = input.shape
-    assert len(ori_shape) in [1, 2, 3]
-    if len(ori_shape) != 1:
-        input = input.view(-1, ori_shape[-1])
+    assert len(ori_shape) in [2, 3]
+    input = input.view(-1, ori_shape[-1])
     output = WeightedSwiGLUFunction.apply(input, weights, fp8_input_store)
 
-    return output if len(ori_shape) in [1, 2] else output.view(ori_shape[0], ori_shape[1], -1)
+    return output if len(ori_shape) == 2 else output.view(ori_shape[0], ori_shape[1], -1)
 
 
 @torch.compile

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -1017,6 +1017,10 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
             opt.step()
             opt.zero_grad()
 
+        if hasattr(self.model_parts[0], "update_moe_gate_bias"):
+            for mp in self.model_parts:
+                mp.update_moe_gate_bias()
+
         if self.lr_scheduler is not None:
             for scheduler in self.lr_scheduler:
                 scheduler.step(1)


### PR DESCRIPTION
We were incorrectly creating the tensor which was causing the crash. This PR fixes the bug by creating it with the correct shape.

It also adds the bias update for MoEs.