### PR TITLE
feat: Limit dataset samples for Column Mapped datasets (#521)

### DIFF
--- a/nemo_automodel/components/datasets/llm/column_mapped_text_instruction_dataset.py
+++ b/nemo_automodel/components/datasets/llm/column_mapped_text_instruction_dataset.py
@@ -154,6 +154,7 @@ class ColumnMappedTextInstructionDataset(Dataset):
         answer_only_loss_mask: bool = True,
         seq_length: Optional[int] = None,
         start_of_turn_token: Optional[str] = None,
+        limit_dataset_samples: Optional[int] = None,
     ) -> None:
         """
         Initialize the dataset.
@@ -166,6 +167,7 @@ class ColumnMappedTextInstructionDataset(Dataset):
             answer_only_loss_mask: Whether to compute the loss mask only on the answer tokens.
             seq_length: The sequence length to use for padding.
             start_of_turn_token: The token to use to indicate the start of a turn.
+            limit_dataset_samples: The number of samples to load from the dataset.
         """
 
         if _has_chat_template(tokenizer):
@@ -180,6 +182,9 @@ class ColumnMappedTextInstructionDataset(Dataset):
         self.tokenizer = tokenizer
 
         self.dataset = _load_dataset(path_or_dataset_id, split=split, streaming=False)
+
+        if limit_dataset_samples is not None:
+            self.dataset = self.dataset.select(range(limit_dataset_samples))
 
         # Keep mapping: dest -> source (i.e. public_field -> raw_column_name)
 


### PR DESCRIPTION
Users should be able to specify only a subset of datasets while training. Oftentimes, the entire dataset is not needed for validation and just a small subset is required.