### PR TITLE
feat: add oot parallelism decorator

### DIFF
--- a/nemo_automodel/components/distributed/parallelizer.py
+++ b/nemo_automodel/components/distributed/parallelizer.py
@@ -394,6 +394,7 @@ def register_parallel_strategy(arg=None, *, name: Optional[str] = None):
         assert name not in PARALLELIZATION_STRATEGIES, f"name {name} already registered"
         PARALLELIZATION_STRATEGIES[name] = cls()
         return cls
+
     if name is None:
         raise ValueError("name is required")
     # If used with parentheses (possibly with arguments)

--- a/tests/unit_tests/distributed/test_register_parallel_strategy.py
+++ b/tests/unit_tests/distributed/test_register_parallel_strategy.py
@@ -64,6 +64,7 @@ def test_register_parallel_strategy_decorator_raises_error_if_not_a_strategy():
 def test_register_parallel_strategy_with_custom_name_registers_under_provided_key():
     original_registry = dict(p.PARALLELIZATION_STRATEGIES)
     try:
+
         @register_parallel_strategy(name="CustomKeyName")
         class SomeStrategy(ParallelizationStrategy):
             def parallelize(self, model: nn.Module, *args, **kwargs) -> nn.Module:


### PR DESCRIPTION
Support registering out-of-tree strategies with a decorator:

```
from nemo_automodel.components.distributed.parallelizer import ParallelizationStrategy, register_parallel_strategy

@register_parallel_strategy(name="MyModel")
class MyModelParallelStrategy(ParallelizationStrategy):
    def parallelize(
        self,
        model: nn.Module,
        ...
    ) -> nn.Module:
 ```
 