### PR TITLE
fix: fixing local TPS for CP

### DIFF
--- a/nemo_automodel/recipes/base_recipe.py
+++ b/nemo_automodel/recipes/base_recipe.py
@@ -435,6 +435,11 @@ class BaseRecipe:
         dp_group = self._get_dp_group(include_cp=include_cp)
         return 1 if dp_group is None else dp_group.size()
 
+    def _get_cp_group_size(self):
+        if not self.device_mesh or self.device_mesh["cp"].size() == 1:
+            return 1
+        return self.device_mesh["cp"].size()
+
     def _get_dp_rank(self, include_cp: bool = False):
         if not self.device_mesh:
             return 0

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -1231,7 +1231,7 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
                 "lr": self.optimizer[0].param_groups[0]["lr"],
                 "mem": torch.cuda.max_memory_allocated() / 1024**3,
                 "tps": tps,
-                "tps_per_gpu": tps / max(self._get_dp_group_size(), 1),
+                "tps_per_gpu": tps / self._get_cp_group_size() / max(self._get_dp_group_size(), 1),
                 "num_tokens_per_step": num_tokens_in_batch,
                 "num_label_tokens": num_label_tokens,
             },


### PR DESCRIPTION
CP breaks up the sequence inside fwd/bwd context manager, and we calculate the TPS outside the CP context. As such, we need to correctly account for the CP group size when reporting the per-GPU TPS.