### PR TITLE
feat: add mfu estimation for lora

### DIFF
--- a/nemo_automodel/recipes/llm/benchmark.py
+++ b/nemo_automodel/recipes/llm/benchmark.py
@@ -102,7 +102,7 @@ class BenchmarkingRecipeForNextTokenPrediction(TrainFinetuneRecipeForNextTokenPr
         flops = flops_formula(self.model_parts[0].config, gbs=global_batch_size, seq_len=seq_len)
         self.tflops = flops / (10**12)
 
-        if "peft" in self.cfg:
+        if hasattr(self.cfg, "peft"):
             # Calculate trainable vs non-trainable parameters without lora
             lora_params = sum(p.numel() for p in self.model_parts[0].parameters() if p.requires_grad)
             total_params = sum(p.numel() for p in self.model_parts[0].parameters())


### PR DESCRIPTION
We need adjust tflops/mfu for lora finetuning:
```
2025-11-07 14:32:35 | INFO | __main__ | PEFT params - lora_params: 175,636,480, param_without_lora: 70,553,706,496, trainable params ratio: 0.0025
2025-11-07 14:32:35 | INFO | __main__ | TFLOPS multiplier for PEFT: (1 + 1 + 0.0025) / 3 = 0.6675
2025-11-07 14:32:35 | INFO | __main__ | TFLOPs/GPU: 37893.397039
```
I just multiply it by a scale for estimation.