### PR TITLE
fix: Include megatron ``Makefile`` in package data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,11 @@ include-package-data = true
 [tool.setuptools.packages.find]
 include = ["nemo_automodel", "nemo_automodel.*"]
 
+[tool.setuptools.package-data]
+nemo_automodel = [
+    "components/datasets/llm/megatron/Makefile",
+]
+
 [tool.setuptools.dynamic]
 version = { attr = "nemo_automodel.package_info.__version__" } # any module attribute compatible with ast.literal_eval
 readme = { file = "README.md", content-type = "text/markdown" }


### PR DESCRIPTION
While attempting to run the `examples/llm_pretrain/pretrain.py` example with the `examples/llm_pretrain/megatron_pretrain_gpt2.yaml` configuration file, I ran into this error

```
...
...
2025-11-14 16:51:49 | INFO | root | Model summary:
2025-11-14 16:51:49 | INFO | root | --------------------------------
2025-11-14 16:51:49 | INFO | root | Trainable parameters: 124,439,808
2025-11-14 16:51:49 | INFO | root | Total parameters: 124,439,808
2025-11-14 16:51:49 | INFO | root | Trainable parameters percentage: 100.00%
2025-11-14 16:51:49 | INFO | root | Param L2 norm: 234.1920
2025-11-14 16:51:49 | INFO | root | --------------------------------
2025-11-14 16:51:49 | INFO | nemo_automodel.recipes.llm.train_ft | World size is 1, skipping parallelization.
tokenizer_config.json: 100%|██████████████████| 26.0/26.0 [00:00<00:00, 321kB/s]
vocab.json: 1.04MB [00:00, 42.8MB/s]
merges.txt: 456kB [00:00, 142MB/s]
tokenizer.json: 1.36MB [00:00, 134MB/s]
make: Entering directory '/databricks/python3/lib/python3.11/site-packages/nemo_automodel/components/datasets/llm/megatron'
make: *** No targets specified and no makefile found.  Stop.
make: Leaving directory '/databricks/python3/lib/python3.11/site-packages/nemo_automodel/components/datasets/llm/megatron'
2025-11-14 16:51:51 | ERROR | nemo_automodel.components.datasets.llm.megatron.megatron_utils | Making C++ dataset helpers module failed, exiting.
```

Looking through my `nemo_automodel` installation I found that the `Makefile` in `nemo_automodel/components/datasets/llm/megatron` was missing (though it's present in the repo here). After checking out the automodel repo locally and doing a `pip install -e .` in the root, I confirmed the `Makefile` is present when running this example. 

This PR adds that `Makefile` to the package data for `nemo_automodel` to ensure it's distributed with the package itself. 