### PR TITLE
fix: Set ``max_steps`` config option for nanogpt pretraining

### DIFF
--- a/examples/llm_pretrain/nanogpt_pretrain.yaml
+++ b/examples/llm_pretrain/nanogpt_pretrain.yaml
@@ -6,6 +6,7 @@ step_scheduler:
   local_batch_size: 2
   ckpt_every_steps: 2000
   num_epochs: 1
+  max_steps: 9500
 
 dist_env:
   backend: nccl


### PR DESCRIPTION
This PR makes it so the nanogpt pretraining example

```
python examples/llm_pretrain/pretrain.py \
  --config examples/llm_pretrain/nanogpt_pretrain.yaml
```

highlighted here https://docs.nvidia.com/nemo/automodel/latest/guides/llm/pretraining.html works out of the box. Currently it raises this error 

```
[rank0]: Traceback (most recent call last):
[rank0]:   File "/Workspace/Users/jbourbeau@nvidia.com/Automodel/examples/llm_pretrain/pretrain.py", line 37, in <module>
[rank0]:     main()
[rank0]:   File "/Workspace/Users/jbourbeau@nvidia.com/Automodel/examples/llm_pretrain/pretrain.py", line 32, in main
[rank0]:     recipe.setup()
[rank0]:   File "/databricks/python3/lib/python3.11/site-packages/nemo_automodel/recipes/llm/train_ft.py", line 831, in setup
[rank0]:     self.step_scheduler = build_step_scheduler(
[rank0]:                           ^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/databricks/python3/lib/python3.11/site-packages/nemo_automodel/recipes/llm/train_ft.py", line 518, in build_step_scheduler
[rank0]:     return StepScheduler(**default_kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/databricks/python3/lib/python3.11/site-packages/nemo_automodel/components/training/step_scheduler.py", line 89, in __init__
[rank0]:     assert self.epoch_len is not None, "epoch_len must be provided if max_steps is not provided"
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]: AssertionError: epoch_len must be provided if max_steps is not provided
```

