### PR TITLE
fix: revert recipe change for memory fragmentation OOM in Llama3 70B

### DIFF
--- a/examples/llm_finetune/llama3_3/llama3_3_70b_instruct_peft_benchmark.yaml
+++ b/examples/llm_finetune/llama3_3/llama3_3_70b_instruct_peft_benchmark.yaml
@@ -12,7 +12,7 @@ benchmark:
 
 step_scheduler:
   global_batch_size: 32
-  local_batch_size: 4
+  local_batch_size: 1
   ckpt_every_steps: 50
   val_every_steps: 1000
   max_steps: 10
@@ -48,20 +48,11 @@ checkpoint:
 distributed:
   _target_: nemo_automodel.components.distributed.fsdp2.FSDP2Manager
   dp_size: none
-  tp_size: 2
+  tp_size: 8
   cp_size: 1
-  pp_size: 4
+  pp_size: 1
   sequence_parallel: false
-  activation_checkpointing: true
-
-autopipeline:
-  _target_: nemo_automodel.components.distributed.pipelining.autopipeline.AutoPipeline
-  pp_schedule: interleaved1f1b
-  pp_microbatch_size: 1
-  layers_per_stage: 2
-  scale_grads_in_schedule: false
-  round_virtual_stages_to_pp_multiple: up
-  dtype: bf16
+  activation_checkpointing: false
 
 
 loss_fn:


### PR DESCRIPTION
Revert the change to llama3_3_70b_instruct_peft_benchmark.yaml (ref #790) due to OOM issues encountered with pp>1.

Conversely, the custom_llama3_3_70b_instruct_peft_benchmark.yaml configuration is stable. It is close the memory limit, the combined projection logic provides better memory efficiency by lowering fragmentation therefore no OOM issues found.