### PR TITLE
feat: add answer only masking in ColumnMappedDataset

### DIFF
--- a/nemo_automodel/components/datasets/llm/column_mapped_text_instruction_dataset.py
+++ b/nemo_automodel/components/datasets/llm/column_mapped_text_instruction_dataset.py
@@ -169,7 +169,6 @@ class ColumnMappedTextInstructionDataset(Dataset):
         seq_length: Optional[int] = None,
         padding: Union[str, bool] = "do_not_pad",
         truncation: Union[str, bool] = "do_not_truncate",
-        start_of_turn_token: Optional[str] = None,
         limit_dataset_samples: Optional[int] = None,
     ) -> None:
         """
@@ -183,17 +182,14 @@ class ColumnMappedTextInstructionDataset(Dataset):
             name: The name of the dataset configuration/subset to load
             answer_only_loss_mask: Whether to compute the loss mask only on the answer tokens.
             seq_length: The sequence length to use for padding.
-            start_of_turn_token: The token to use to indicate the start of a turn.
             limit_dataset_samples: The number of samples to load from the dataset.
         """
 
         if _has_chat_template(tokenizer):
             if not answer_only_loss_mask:
                 logging.warning(
-                    "answer_only_loss_mask=False but tokenizer has chat template. Consider providing `answer_only_loss_mask` and `start_of_turn_token`."
+                    "answer_only_loss_mask=False but tokenizer has chat template. Consider providing `answer_only_loss_mask`."
                 )
-            elif start_of_turn_token is None:
-                raise ValueError("start_of_turn_token must be provided when answer_only_loss_mask=True")
 
         assert tokenizer is not None, "Tokenizer is required"
         self.tokenizer = tokenizer
@@ -234,7 +230,6 @@ class ColumnMappedTextInstructionDataset(Dataset):
         self.column_mapping = column_mapping
 
         self.answer_only_loss_mask = answer_only_loss_mask
-        self.start_of_turn_token = start_of_turn_token
         self.seq_length = seq_length
         self.padding = padding
         self.truncation = truncation
@@ -309,6 +304,7 @@ class ColumnMappedTextInstructionDataset(Dataset):
                 seq_length=self.seq_length,
                 padding=self.padding,
                 truncation=self.truncation,
+                answer_only_loss_mask=self.answer_only_loss_mask,
             )
         else:
             prompt = " ".join(filter(lambda x: x is not None, (context, question, "")))

--- a/tests/unit_tests/datasets/llm/test_tokenizer_apply_functions.py
+++ b/tests/unit_tests/datasets/llm/test_tokenizer_apply_functions.py
@@ -218,3 +218,101 @@ def test_apply_tokenizer_chat_template_full_loss_mask():
     assert set(out) == {"input_ids", "labels", "attention_mask"}
     assert len(out["input_ids"]) == len(out["labels"]) == len(out["attention_mask"])
     assert all(v == 1 for v in out["attention_mask"])
+
+
+class _StubTokenizerChatNoGen:
+    """Chat-template tokenizer WITHOUT generation keyword; returns no assistant mask."""
+
+    eos_token_id = 2
+    chat_template = "<dummy template without generation keyword>"
+    _start_of_turn_token_id = 99
+
+    def __init__(self) -> None:
+        self._vocab: Dict[str, int] = {}
+        self._cursor: int = 3  # start after BOS/EOS
+
+    def _id_for_token(self, tok: str) -> int:
+        if tok not in self._vocab:
+            self._vocab[tok] = self._cursor
+            self._cursor += 1
+        return self._vocab[tok]
+
+    def apply_chat_template(self, messages, **kwargs):  # type: ignore[override]
+        # Compose ids as:
+        # [SOT] + <all non-assistant message tokens> + [SOT] + <assistant tokens (if any)>
+        ids: List[int] = [self._start_of_turn_token_id]
+        # prompt tokens (system + user, etc.)
+        for msg in messages:
+            if msg["role"] == "assistant":
+                break
+            ids.extend(self._id_for_token(tok) for tok in str(msg["content"]).split())
+        # delimiter before assistant section
+        ids.append(self._start_of_turn_token_id)
+        # assistant tokens (if present)
+        assistant_started = False
+        for msg in messages:
+            if msg["role"] == "assistant":
+                assistant_started = True
+            if assistant_started:
+                ids.extend(self._id_for_token(tok) for tok in str(msg["content"]).split())
+        # Intentionally DO NOT append EOS here; function under test will handle it.
+        if kwargs.get("return_dict", False):
+            return {"input_ids": ids}
+        return ids
+
+
+def test_apply_chat_template_manual_mask_without_generation_kwd():
+    # Tokenizer without generation keyword in template
+    tok = _StubTokenizerChatNoGen()
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "what now"},
+        {"role": "assistant", "content": "answer goes here"},
+    ]
+
+    # Compute expected prompt length as used by the implementation
+    prompt_only = messages[:-1]
+    tokenized_prompt = tok.apply_chat_template(prompt_only, return_dict=True)
+    len_prompt_ids = len(tokenized_prompt["input_ids"])
+
+    out = format_chat_template(
+        tok,
+        formatted_text=[m.copy() for m in messages],
+        eos_token_id=tok.eos_token_id,
+        pad_token_id=tok.eos_token_id,
+        answer_only_loss_mask=True,
+    )
+
+    # Basic structure
+    pad_info = out.pop("___PAD_TOKEN_IDS___")
+    assert set(out) == {"input_ids", "labels", "attention_mask"}
+    assert len(out["input_ids"]) == len(out["labels"]) == len(out["attention_mask"])
+    assert pad_info["labels"] == -100
+
+    # Since labels drop the first token (treated as BOS/SOT), expected ignored labels:
+    expected_ignored = max(0, len_prompt_ids - 1)
+    assert out["labels"].count(-100) == expected_ignored
+    # Sanity: there must be supervised tokens (assistant section)
+    assert expected_ignored < len(out["labels"])
+    # Number of supervised tokens (exclude -100) should equal number of assistant tokens.
+    # Note: labels include the final EOS as supervised; subtract 1 to compare to assistant count.
+    assistant_tokens = sum(len(str(m["content"]).split()) for m in messages if m["role"] == "assistant")
+    num_supervised = sum(1 for v in out["labels"] if v != -100)
+    assert num_supervised - 1 == assistant_tokens
+
+
+def test_apply_chat_template_manual_mask_raises_when_last_not_assistant():
+    tok = _StubTokenizerChatNoGen()
+    # Last message is not assistant → assertion should trigger
+    bad_messages = [
+        {"role": "system", "content": "s"},
+        {"role": "user", "content": "q"},
+    ]
+    with pytest.raises(AssertionError):
+        _ = format_chat_template(
+            tok,
+            formatted_text=[m.copy() for m in bad_messages],
+            eos_token_id=tok.eos_token_id,
+            pad_token_id=tok.eos_token_id,
+            answer_only_loss_mask=True,
+        )


### PR DESCRIPTION
answer_only_loss_mask is missing when the underlying tokenizer has a chat template