### PR TITLE
feat: add support for parquet files

### DIFF
--- a/tools/preprocess_megatron_dataset.py
+++ b/tools/preprocess_megatron_dataset.py
@@ -367,7 +367,9 @@ def main():
 
     # Check parquet availability if needed
     if file_type == "parquet" and not parquet_available:
-        raise Exception("pyarrow library is required for parquet files but is not available. Install with: pip install pyarrow")
+        raise Exception(
+            "pyarrow library is required for parquet files but is not available. Install with: pip install pyarrow"
+        )
 
     # For parquet files, sentence splitting is not supported (text is already in a single column)
     if file_type == "parquet" and args.split_sentences:


### PR DESCRIPTION
To test this:
1. Download a parquet file, for example:
```
wget "https://huggingface.co/datasets/HuggingFaceFW/fineweb-edu/resolve/main/sample/10BT/000_00000.parquet"
```
2.  Tokenize the data (please ensure --input points to the location of the downloaded file -- ie 000_00000.parquet, here it is assumed that the two commands are run from the same location).
```
python tools/preprocess_megatron_dataset.py \
    --input "000_00000.parquet" \
    --input-type parquet \
    --text-column text \
    --json-keys text \
    --output-prefix fineweb_processed \
    --output-path ./processed/ \
    --workers 4 \
    --pretrained-model-name-or-path openai-community/gpt2 \
    --append-eod
```
3. Inspect the output: 
```
akoumparouli@1604ab7-lcedt:/mnt/4tb/auto/Automodel3$ ll processed/
total 1.5G
drwxr-xr-x  2 akoumparouli domain-users 4.0K Dec 16 16:23 ./
drwxr-xr-x 24 akoumparouli domain-users 4.0K Dec 16 16:16 ../
-rw-r--r--  1 akoumparouli domain-users 1.5G Dec 16 16:23 fineweb_processed_0_text_document.bin
-rw-r--r--  1 akoumparouli domain-users  14M Dec 16 16:23 fineweb_processed_0_text_document.idx
```

4. Load the actual data
```
from transformers import AutoTokenizer
from nemo_automodel.components.datasets.llm.megatron_dataset import MegatronPretraining

# Load the tokenizer (same one used for preprocessing)
tokenizer = AutoTokenizer.from_pretrained("openai-community/gpt2")

# Create the dataset
# Note: the path should be the prefix WITHOUT the "_text_document.bin/idx" suffix
dataset = MegatronPretraining(
    paths="processed/fineweb_processed_0_text_document",
    seq_length=1024,
    tokenizer=tokenizer,
    split="99,1,0",  # train, validation, test split ratios
    splits_to_build="train",  # which split to build
    index_mapping_dir="processed/index_cache",  # where to cache index mappings
    trainer_max_steps=1000,  # needed for build() to compute num samples
    global_batch_size=8,
)

# Build the dataset (this is required!)
dataset.build()

# Get the train dataset
train_dataset = dataset.get_dataset("train")

# Iterate over samples
for i, sample in enumerate(train_dataset):
    print(f"Sample {i}:")
    print(f"  tokens shape: {sample['input_ids'].shape}")
    print(f"  labels shape: {sample['labels'].shape}")
    input_ids = sample['input_ids'].tolist()
    print(f"i: {i}\t", tokenizer.decode(input_ids))
    if i >= 2:
        break
```

Running the code from (4) should give you something like the following:
```
Sample 0:
{'input_ids': tensor([  262, 12867,   286,  ...,  7545, 13844,    13]), 'labels': tensor([12867,   286,   326,  ..., 13844,    13,   198]), 'loss_mask': tensor([1., 1., 1.,  ..., 1., 1., 1.])}                                                                                                      tokens shape: torch.Size([1024])                                                                                                                  labels shape: torch.Size([1024])
i: 0      the probability of that happening, with both teams  when I realized that could be our warm-up tomorrow. So I had them lay the boards to the side and we’ll continue the game tomorrow.                                                                                                    The thing I liked best about this game was how m.... (continues)
{'input_ids': tensor([ 9655, 11558,    13,  ...,    12,  1065,  4673]), 'labels': tensor([11558,    13,   447,  ...,  1065,  4673,    13]), 'loss_mask': tensor([1., 1., 1.,  ..., 1., 1., 1.])}                                                                                                      tokens shape: torch.Size([1024])
  labels shape: torch.Size([1024])
i: 1     MC Medicine.”
Supplement with L-arginine and L-citrulline. These two amino acids might improve nitric oxide levels, according to a study conducted by lead author Edzard Schwedhelm and colleague... (continues)
```
 