### PR TITLE
docs: Fix images not rendering in docs

### DIFF
--- a/docs/guides/fp8-training.md
+++ b/docs/guides/fp8-training.md
@@ -93,7 +93,12 @@ FP8 quantization provides measurable performance improvements while maintaining 
 - **Convergence**: FP8 training achieves loss parity with BF16 training.
 - **Memory**: FP8 training achieves on par memory usage with BF16 baseline.
 
-<img src="fp8_convergence.jpg" alt="FP8 Convergence Comparison" width="600px" />
+```{image} fp8_convergence.jpg
+:alt: FP8 Convergence Comparison
+:class: bg-primary
+:width: 600px
+:align: center
+```
 
 *Figure: Loss curves comparing FP8 tensorwise scaling + torch.compile vs. BF16 + torch.compile training on 8xH100 with 8k sequence length, demonstrating virtually identical convergence behavior with 1.24x speedup*
 

--- a/docs/guides/omni/gemma3-3n.md
+++ b/docs/guides/omni/gemma3-3n.md
@@ -218,8 +218,12 @@ peft:
 
 The training loss should look similar to the example below:
 
-<img src="medpix_peft.jpg" alt="Training Loss Curve" width="400px" />
-
+```{image} medpix_peft.jpg
+:alt: Training Loss Curve
+:class: bg-primary
+:width: 400px
+:align: center
+```
 
 ### Checkpointing
 
@@ -296,8 +300,12 @@ uv run examples/vlm_generate/generate.py \
 
 Given the following image:
 
-<img src="medpix.jpg" alt="Sample image from the MedPix dataset" width="200px" />
-
+```{image} medpix.jpg
+:alt: Sample image from the MedPix dataset
+:class: bg-primary
+:width: 200px
+:align: center
+```
 
 And the prompt:
 


### PR DESCRIPTION
This PR fixes a few images I noticed we're rendering in the docs. 

Before this PR:

<img width="1881" height="1243" alt="Screenshot 2025-12-10 at 1 33 03 PM" src="https://github.com/user-attachments/assets/63c67049-88d0-4a15-bd8f-c87627c4a865" />

After this PR:

<img width="1881" height="1243" alt="Screenshot 2025-12-10 at 1 33 21 PM" src="https://github.com/user-attachments/assets/59ea76a8-799d-44c4-8fa3-2195ee80e4f4" />
