### PR TITLE
fix: respect trust_remote_code when building AutoConfig

### DIFF
--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -412,7 +412,7 @@ def compute_trust_remote_code_from_model(cfg_model):
         cfg_model (ConfigNode): Model configuration.
 
     Returns:
-        Whether to trust remote code.
+        bool: Whether to trust remote code.
     """
     if hasattr(cfg_model, "trust_remote_code"):
         return getattr(cfg_model, "trust_remote_code")


### PR DESCRIPTION
# What does this PR do ?

Respect trust_remote_code when building AutoConfig

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to #952
