### PR TITLE
fix: DeviceMesh Flattening for PyTorch 2.10+ Compatibility

### DIFF
--- a/nemo_automodel/__init__.py
+++ b/nemo_automodel/__init__.py
@@ -14,6 +14,7 @@
 import functools
 import importlib
 import inspect
+import logging
 
 from torch.utils.data import _utils as torch_data_utils
 
@@ -38,6 +39,85 @@ if "device" not in _original_pin_memory_sig.parameters:
 
     torch_data_utils.pin_memory.pin_memory = _patched_pin_memory
     torch_data_utils.pin_memory._pin_memory_loop = _pin_memory_loop
+
+
+# Monkey patch DeviceMesh to fix corner case in mesh slicing
+# Fixes issue where _dim_group_names is accessed without checking if rank is in mesh
+# Based on https://github.com/pytorch/pytorch/pull/169454/files
+try:
+    import torch as _torch
+
+    # Only apply the patch for the specific PyTorch version with the regression
+    # TODO: Remove this once bump up to a newer PyTorch version with the fix
+    if "2.10.0" in _torch.__version__ and "nv25.11" in _torch.__version__:
+        from torch.distributed._mesh_layout import _MeshLayout
+        from torch.distributed.device_mesh import _MeshEnv
+
+        _original_get_slice_mesh_layout = _MeshEnv._get_slice_mesh_layout
+
+        def _patched_get_slice_mesh_layout(self, device_mesh, mesh_dim_names):
+            """
+            Patched _get_slice_mesh_layout based on PyTorch PR #169454.
+            This fixes:
+            1. _dim_group_names access (commit f6c8092)
+            2. Regression in mesh slicing with size-1 dims (PR #169454 / Issue #169381)
+            """
+            # 1. First, build the layout manually to bypass the legacy 'stride < pre_stride' check
+            slice_from_root = device_mesh == self.get_root_mesh(device_mesh)
+            flatten_name_to_root_layout = (
+                {key: mesh._layout for key, mesh in self.root_to_flatten_mapping.setdefault(device_mesh, {}).items()}
+                if slice_from_root
+                else {}
+            )
+
+            mesh_dim_names_list = getattr(device_mesh, "mesh_dim_names", [])
+            valid_mesh_dim_names = [*mesh_dim_names_list, *flatten_name_to_root_layout]
+            if not all(name in valid_mesh_dim_names for name in mesh_dim_names):
+                raise KeyError(f"Invalid mesh_dim_names {mesh_dim_names}. Valid: {valid_mesh_dim_names}")
+
+            layout_sliced = []
+            for name in mesh_dim_names:
+                if name in mesh_dim_names_list:
+                    layout_sliced.append(device_mesh._layout[mesh_dim_names_list.index(name)])
+                elif name in flatten_name_to_root_layout:
+                    layout_sliced.append(flatten_name_to_root_layout[name])
+
+            sliced_sizes = tuple(layout.sizes for layout in layout_sliced)
+            sliced_strides = tuple(layout.strides for layout in layout_sliced)
+
+            # Bypass the 'stride < pre_stride' check that exists in the original
+            # and create the MeshLayout directly.
+            slice_mesh_layout = _MeshLayout(sliced_sizes, sliced_strides)
+
+            if not slice_mesh_layout.check_non_overlap():
+                raise RuntimeError(f"Slicing overlapping dim_names {mesh_dim_names} is not allowed.")
+
+            # 2. Replicate the _dim_group_names fix (commit f6c8092)
+            # We need to return an object that HAS _dim_group_names if the rank is in the mesh
+            if hasattr(device_mesh, "_dim_group_names") and len(device_mesh._dim_group_names) > 0:
+                slice_dim_group_name = []
+                submesh_dim_names = mesh_dim_names if isinstance(mesh_dim_names, tuple) else (mesh_dim_names,)
+                for name in submesh_dim_names:
+                    if name in mesh_dim_names_list:
+                        slice_dim_group_name.append(device_mesh._dim_group_names[mesh_dim_names_list.index(name)])
+                    elif hasattr(device_mesh, "_flatten_mapping") and name in device_mesh._flatten_mapping:
+                        flatten_mesh = device_mesh._flatten_mapping[name]
+                        slice_dim_group_name.append(
+                            flatten_mesh._dim_group_names[flatten_mesh.mesh_dim_names.index(name)]
+                        )
+
+                # Attach the group names to the layout object so the caller can use them
+                object.__setattr__(slice_mesh_layout, "_dim_group_names", slice_dim_group_name)
+
+            return slice_mesh_layout
+
+        # Apply the patch
+        _MeshEnv._get_slice_mesh_layout = _patched_get_slice_mesh_layout
+        logging.getLogger(__name__).debug(f"Applied DeviceMesh fix for PyTorch {_torch.__version__}")
+
+except (ImportError, AttributeError) as e:
+    logging.getLogger(__name__).debug(f"Could not apply DeviceMesh patch: {e}")
+    pass
 
 
 from .package_info import __package_name__, __version__


### PR DESCRIPTION
# What does this PR do ?
* Problem
DeviceMesh flattening fails when all dimensions are size 1, causing KeyError at runtime:
```
KeyError: "Invalid mesh_dim_names ('dp_replicate', 'dp_shard_cp', 'tp') specified"
```
* Root Cause
Great thanks to @cspades 
PyTorch's DeviceMesh._flatten() has a bug https://github.com/pytorch/pytorch/issues/169381 
DeviceMesh._flatten() silently fails when all dimensions in the submesh are size 1. This causes:
Flattened dimensions (dp_shard_cp, dp, dp_cp) are never created
Later code tries to access non-existent dimensions → cryptic KeyError
Example: With dp_shard=1, cp=1:
```
mesh[("dp_shard", "cp")]._flatten("dp_shard_cp")  # Fails silently, no dimension created
mesh[("dp_replicate", "dp_shard_cp")]  # KeyError: dimension doesn't exist!
```

* Solution
patch fix in `__init__.py` following https://github.com/pytorch/pytorch/pull/169454/files 


# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
