### PR TITLE
fix: Fix checkpoint saving for biencoder models with empty FQN mapping

### DIFF
--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -580,7 +580,8 @@ class Checkpointer:
 
         # Add any missing keys from the model_state_dict
         # These will go to the same file as the last file (or file 1 for single-file models)
-        default_index = max(fqn_to_file_index_mapping.values())
+        # Use default of 1 when mapping is empty (e.g., biencoder models with different key prefixes)
+        default_index = max(fqn_to_file_index_mapping.values()) if fqn_to_file_index_mapping else 1
 
         # add any additional keys that are not in the base checkpoint
         for fqn in list(state_dict.keys()):


### PR DESCRIPTION
### Summary

Fixes a `ValueError: max() iterable argument is empty` crash when saving checkpoints for biencoder models at the end of training.

### Problem

When finetuning a model (e.g., `nvidia/llama-nemotron-embed-1b-v2`) and saving checkpoints, the training completes successfully but crashes during the final checkpoint save with:

```
File "nemo_automodel/components/checkpoint/checkpointing.py", line 583, in _maybe_build_consolidated_index
    default_index = max(fqn_to_file_index_mapping.values())
ValueError: max() iterable argument is empty
```

### Root Cause

The issue occurs in `_maybe_build_consolidated_index()` which builds a mapping from fully-qualified parameter names (FQN) to safetensors shard file indices for HuggingFace-compatible checkpoint export.

**The flow:**

1. The method loads the FQN-to-file-index mapping from the base HuggingFace model's `model.safetensors.index.json`
2. It removes keys not present in `self.config.model_state_dict_keys`
3. For certain models, this removal can result in an **empty mapping**

**Why the mapping becomes empty:**

The `BiencoderModel` wraps two encoders with prefixes `lm_q.*` (query) and `lm_p.*` (passage). While the state dict is converted to HF format via `BiencoderStateDictAdapter` before reaching this method, the comparison with `model_state_dict_keys` can still result in a mismatch due to:

- Key structure differences between the base HF model index and the biencoder's converted keys
- Non-standard model architectures
- Cached HF index files that don't match the current model structure

When all keys are removed, calling `max()` on the empty mapping raises `ValueError`.

### Solution

Add a conditional check to handle the empty mapping case by defaulting to shard index `1`:

```diff
- default_index = max(fqn_to_file_index_mapping.values())
+ default_index = max(fqn_to_file_index_mapping.values()) if fqn_to_file_index_mapping else 1
```

**Why index `1`:**

- HuggingFace safetensors uses 1-based indexing (`model-00001-of-N.safetensors`)
- Single-file models are implicitly index `1` (`model.safetensors`)
- Consistent with the else branch: `{k: 1 for k in state_dict.keys()}`

The subsequent loop populates the mapping with all state dict keys using this default index, creating a valid single-shard consolidated checkpoint.

### Changes

- `nemo_automodel/components/checkpoint/checkpointing.py`: Handle empty `fqn_to_file_index_mapping` in `_maybe_build_consolidated_index()`

### Testing

- [x] Biencoder training completes and saves checkpoint successfully
- [x] No linter errors
