### PR TITLE
chore: Include formats in ``CheckpointingConfig`` validation error message

### DIFF
--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -99,8 +99,9 @@ class CheckpointingConfig:
         """
         Convert a raw string such as "safetensors" into the right Enum.
         """
-        assert self.model_save_format in [v.value for v in SerializationFormat], (
-            f"Unsupported model save format: {self.model_save_format}"
+        formats = [v.value for v in SerializationFormat]
+        assert self.model_save_format in formats, (
+            f"Unsupported model save format: {self.model_save_format}. Supported formats: {formats}"
         )
         self.model_save_format = SerializationFormat[self.model_save_format.upper()]
 


### PR DESCRIPTION
Just a small quality of life improvement. This PR turns this error message

```
AssertionError: Unsupported model save format: safetensor
```

into this slightly more informative one

```
AssertionError: Unsupported model save format: safetensor. Supported formats: ['torch_save', 'safetensors']
```

since we have the supported formats handy anyways. 