### PR TITLE
feat: Add faster fp8 dequant kernels and fix dtensor dequantization for dsv3

### DIFF
--- a/tests/unit_tests/models/deepseek_v3/test_dsv3_state_dict_adapter.py
+++ b/tests/unit_tests/models/deepseek_v3/test_dsv3_state_dict_adapter.py
@@ -23,6 +23,10 @@ from nemo_automodel.components.models.deepseek_v3.state_dict_adapter import (
     dequantize_from_fp8,
     _dequantize_with_torch,
     _dequantize_with_triton,
+    _slice_scale_for_dtensor,
+    should_quantize_key,
+    create_scale_inv_for_weight,
+    NON_QUANTIZED_KEY_PATTERNS,
     _TRITON_AVAILABLE,
     BLOCK_SIZE,
 )
@@ -143,53 +147,7 @@ class TestDeepSeekV3StateDictAdapter:
             assert len(result) == 2
             assert "layer1.weight_scale_inv" not in result
             assert "layer2.weight" in result
-            mock_dequant.assert_called_once_with(weight, scale_inv, dtype=torch.float32)
-
-    def test_add_quantization_scale_inv_tensors_cpu(self):
-        config = self.create_mock_config()
-        moe_config = self.create_mock_moe_config()
-        backend = self.create_mock_backend_config()
-
-        adapter = DeepSeekV3StateDictAdapter(config, moe_config, backend)
-
-        state_dict = {
-            "model.layers.0.self_attn.q_proj.weight": torch.randn(512, 256),
-            "model.layers.0.input_layernorm.weight": torch.randn(256),
-            "model.layers.0.mlp.gate.weight": torch.randn(128, 256),
-            "model.embed_tokens.weight": torch.randn(1000, 256),
-        }
-
-        result = adapter._add_quantization_scale_inv_tensors(state_dict)
-
-        assert "model.layers.0.self_attn.q_proj.weight_scale_inv" in result
-        assert "model.layers.0.input_layernorm.weight_scale_inv" not in result
-        assert "model.layers.0.mlp.gate.weight_scale_inv" not in result
-        assert "model.embed_tokens.weight_scale_inv" not in result
-
-        assert result["model.layers.0.self_attn.q_proj.weight"].dtype == torch.float8_e4m3fn
-
-    @skip_if_no_gpu
-    def test_add_quantization_scale_inv_tensors_gpu(self):
-        if not torch.cuda.is_available():
-            pytest.skip("CUDA not available")
-
-        config = self.create_mock_config()
-        moe_config = self.create_mock_moe_config()
-        backend = self.create_mock_backend_config()
-
-        adapter = DeepSeekV3StateDictAdapter(config, moe_config, backend)
-
-        device = torch.device("cuda")
-        state_dict = {
-            "model.layers.0.self_attn.q_proj.weight": torch.randn(512, 256, device=device),
-            "model.layers.0.input_layernorm.weight": torch.randn(256, device=device),
-        }
-
-        result = adapter._add_quantization_scale_inv_tensors(state_dict)
-
-        scale_inv = result["model.layers.0.self_attn.q_proj.weight_scale_inv"]
-        assert scale_inv.device.type == device.type
-        assert scale_inv.dtype == torch.float32
+            mock_dequant.assert_called_once_with(weight, scale_inv, dtype=torch.float32, name="layer1.weight")
 
     def test_to_hf(self):
         config = self.create_mock_config()
@@ -406,6 +364,146 @@ class TestCalculateScaleShape:
         assert result == expected_shape
 
 
+class TestShouldQuantizeKey:
+    """Tests for should_quantize_key function."""
+
+    def test_quantizable_weight_keys(self):
+        """Test that normal weight keys are marked for quantization."""
+        assert should_quantize_key("model.layers.0.self_attn.q_proj.weight") is True
+        assert should_quantize_key("model.layers.0.mlp.experts.0.gate_proj.weight") is True
+        assert should_quantize_key("model.layers.0.mlp.experts.0.up_proj.weight") is True
+        assert should_quantize_key("model.layers.0.mlp.experts.0.down_proj.weight") is True
+
+    def test_non_quantizable_layernorm_keys(self):
+        """Test that layernorm weights are not quantized."""
+        assert should_quantize_key("model.layers.0.input_layernorm.weight") is False
+        assert should_quantize_key("model.layers.0.post_attention_layernorm.weight") is False
+
+    def test_non_quantizable_special_keys(self):
+        """Test that special weights are not quantized."""
+        assert should_quantize_key("model.norm.weight") is False
+        assert should_quantize_key("lm_head.weight") is False
+        assert should_quantize_key("model.embed_tokens.weight") is False
+        assert should_quantize_key("model.layers.0.mlp.gate.weight") is False
+
+    def test_non_weight_keys(self):
+        """Test that non-weight keys are not quantized."""
+        assert should_quantize_key("model.layers.0.self_attn.q_proj.bias") is False
+        assert should_quantize_key("model.layers.0.input_layernorm.bias") is False
+        assert should_quantize_key("some_random_key") is False
+
+    def test_non_quantized_patterns_constant(self):
+        """Test that NON_QUANTIZED_KEY_PATTERNS contains expected patterns."""
+        assert "input_layernorm.weight" in NON_QUANTIZED_KEY_PATTERNS
+        assert "post_attention_layernorm.weight" in NON_QUANTIZED_KEY_PATTERNS
+        assert "norm.weight" in NON_QUANTIZED_KEY_PATTERNS
+        assert "lm_head.weight" in NON_QUANTIZED_KEY_PATTERNS
+        assert "embed_tokens.weight" in NON_QUANTIZED_KEY_PATTERNS
+        assert "mlp.gate.weight" in NON_QUANTIZED_KEY_PATTERNS
+
+
+class TestCreateScaleInvForWeight:
+    """Tests for create_scale_inv_for_weight function."""
+
+    def test_regular_tensor(self):
+        """Test scale_inv creation for regular tensors."""
+        weight = torch.randn(256, 128, dtype=torch.float32)
+        scale_inv = create_scale_inv_for_weight(weight)
+
+        expected_shape = calculate_scale_shape(weight)
+        assert scale_inv.shape == expected_shape
+        assert scale_inv.dtype == torch.float32
+        assert torch.all(scale_inv == 1.0)
+
+    def test_regular_tensor_on_gpu(self):
+        """Test scale_inv creation for GPU tensors."""
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+
+        weight = torch.randn(256, 128, dtype=torch.float32, device="cuda")
+        scale_inv = create_scale_inv_for_weight(weight)
+
+        assert scale_inv.device.type == "cuda"
+        assert scale_inv.dtype == torch.float32
+
+    def test_dtensor_uses_global_shape(self):
+        """Test that DTensor weights use global shape for scale_inv."""
+        # Create mock DTensor with global shape different from local shape
+        local_weight = torch.randn(128, 128, dtype=torch.float32)  # Local portion
+        mock_weight = Mock()
+        mock_weight.to_local.return_value = local_weight
+        mock_weight.shape = torch.Size([256, 128])  # Global shape (2x local in rows)
+
+        with patch('nemo_automodel.components.models.deepseek_v3.state_dict_adapter.is_dtensor') as mock_is_dtensor:
+            mock_is_dtensor.return_value = True
+
+            scale_inv = create_scale_inv_for_weight(mock_weight)
+
+            # Should use global shape (256, 128) -> (2, 1) blocks
+            assert scale_inv.shape == torch.Size((2, 1))
+            assert scale_inv.dtype == torch.float32
+
+    def test_custom_block_size(self):
+        """Test scale_inv creation with custom block size."""
+        weight = torch.randn(200, 100, dtype=torch.float32)
+        scale_inv = create_scale_inv_for_weight(weight, block_size=50)
+
+        # 200/50=4, 100/50=2
+        assert scale_inv.shape == torch.Size((4, 2))
+
+
+class TestSliceScaleForDtensor:
+    """Tests for _slice_scale_for_dtensor function."""
+
+    def test_shard_on_dim0(self):
+        """Test slicing scale_inv when weight is sharded on dimension 0."""
+        from torch.distributed._tensor import Shard
+
+        # Full scale_inv for a 512x256 weight (4x2 blocks with BLOCK_SIZE=128)
+        scale_inv = torch.arange(1, 9, dtype=torch.float32).reshape(4, 2)
+
+        # Mock DTensor setup: weight sharded on dim 0 across 2 ranks
+        mock_device_mesh = Mock()
+        mock_device_mesh.size.return_value = 2  # 2 ranks
+        mock_device_mesh.get_local_rank.return_value = 0  # First rank
+
+        mock_weight = Mock()
+        mock_weight.device_mesh = mock_device_mesh
+        mock_weight.placements = [Shard(0)]  # Sharded on dim 0
+
+        # Local weight is half the rows: 256x256
+        weight_local = torch.randn(256, 256, dtype=torch.float32)
+
+        result = _slice_scale_for_dtensor(scale_inv, mock_weight, weight_local)
+
+        # First rank should get first 2 row blocks (rows 0-255 -> blocks 0-1)
+        assert result.shape == torch.Size((2, 2))
+
+    def test_shard_on_dim1(self):
+        """Test slicing scale_inv when weight is sharded on dimension 1."""
+        from torch.distributed._tensor import Shard
+
+        # Full scale_inv for a 256x512 weight (2x4 blocks with BLOCK_SIZE=128)
+        scale_inv = torch.arange(1, 9, dtype=torch.float32).reshape(2, 4)
+
+        # Mock DTensor setup: weight sharded on dim 1 across 2 ranks
+        mock_device_mesh = Mock()
+        mock_device_mesh.size.return_value = 2  # 2 ranks
+        mock_device_mesh.get_local_rank.return_value = 1  # Second rank
+
+        mock_weight = Mock()
+        mock_weight.device_mesh = mock_device_mesh
+        mock_weight.placements = [Shard(1)]  # Sharded on dim 1
+
+        # Local weight is half the cols: 256x256
+        weight_local = torch.randn(256, 256, dtype=torch.float32)
+
+        result = _slice_scale_for_dtensor(scale_inv, mock_weight, weight_local)
+
+        # Second rank should get last 2 col blocks (cols 256-511 -> blocks 2-3)
+        assert result.shape == torch.Size((2, 2))
+
+
 class TestDequantizeFromFp8:
     def test_dequantize_single_block(self):
         weight = torch.randn(64, 32, dtype=torch.float32).to(torch.float8_e4m3fn)
@@ -450,16 +548,17 @@ class TestDequantizeFromFp8:
             mock_logger.warning.assert_not_called()
             assert result.shape == weight.shape
 
-    def test_dequantize_mismatched_scale_shape_warning_actual_mismatch(self):
+    def test_dequantize_mismatched_scale_shape_logs_debug(self):
+        """Test that mismatched scale shape logs debug message for non-DTensor."""
         weight = torch.randn(128, 64, dtype=torch.float32).to(torch.float8_e4m3fn)  # Should be (1, 1) scale shape
         scale_inv = torch.ones((2, 1), dtype=torch.float32)  # Wrong shape - too many scale values
 
         with patch('nemo_automodel.components.models.deepseek_v3.state_dict_adapter.logger') as mock_logger:
-            # This will still process but use only the available scale values
+            # For non-DTensor, mismatched scale shape logs debug (not warning)
             result = dequantize_from_fp8(weight, scale_inv, dtype=torch.float32)
 
-            mock_logger.warning.assert_called_once()
-            assert "scale_inv shape" in mock_logger.warning.call_args[0][0]
+            # Debug should be called for the shape mismatch
+            mock_logger.debug.assert_called()
             assert result.shape == weight.shape
 
     def test_dequantize_custom_block_size(self):
@@ -599,6 +698,53 @@ class TestDequantizeFromFp8:
             mock_from_local.assert_called_once_with(dequantized_local, mock_device_mesh, mock_placements)
 
             # Verify result is the DTensor
+            assert result is mock_dtensor_result
+
+    def test_dequantize_dtensor_with_scale_slicing(self):
+        """Test dequantization with DTensor weight and non-DTensor scale triggers slicing."""
+        from torch.distributed._tensor import Shard
+
+        # Create local tensors - local weight is 256x128 (2x1 blocks)
+        local_weight = torch.randn(256, 128, dtype=torch.float32).to(torch.float8_e4m3fn)
+        # Global scale_inv for 512x128 weight (4x1 blocks) - larger than local
+        global_scale = torch.arange(1, 5, dtype=torch.float32).reshape(4, 1)
+        dequantized_local = torch.randn(256, 128, dtype=torch.bfloat16)
+
+        # Create mock DTensor weight (sharded on dim 0)
+        mock_device_mesh = Mock()
+        mock_device_mesh.size.return_value = 2  # 2 ranks
+        mock_device_mesh.get_local_rank.return_value = 0  # First rank
+
+        mock_placements = [Shard(0)]
+        mock_weight = Mock()
+        mock_weight.to_local.return_value = local_weight
+        mock_weight.device_mesh = mock_device_mesh
+        mock_weight.placements = mock_placements
+
+        mock_dtensor_result = Mock()
+
+        with patch('nemo_automodel.components.models.deepseek_v3.state_dict_adapter.is_dtensor') as mock_is_dtensor, \
+             patch('nemo_automodel.components.models.deepseek_v3.state_dict_adapter._dequantize_with_torch') as mock_dequant, \
+             patch('nemo_automodel.components.models.deepseek_v3.state_dict_adapter._slice_scale_for_dtensor') as mock_slice, \
+             patch('torch.distributed._tensor.DTensor.from_local') as mock_from_local:
+
+            # weight is DTensor, scale is not
+            mock_is_dtensor.side_effect = lambda x: x is mock_weight
+            # Return sliced scale that matches local weight shape
+            sliced_scale = torch.ones((2, 1), dtype=torch.float32)
+            mock_slice.return_value = sliced_scale
+            mock_dequant.return_value = dequantized_local
+            mock_from_local.return_value = mock_dtensor_result
+
+            result = dequantize_from_fp8(mock_weight, global_scale, dtype=torch.bfloat16)
+
+            # Verify _slice_scale_for_dtensor was called
+            mock_slice.assert_called_once()
+            # Verify dequantize was called with sliced scale
+            call_args = mock_dequant.call_args
+            assert call_args is not None
+
+            # Verify result is DTensor
             assert result is mock_dtensor_result
 
 


### PR DESCRIPTION
```
--------------------------------------------------------------------------------
CORRECTNESS VERIFICATION
--------------------------------------------------------------------------------
Shape                Match      Max Diff        Mean Diff      
--------------------------------------------------------------------------------
(  256,   256)      PASS       0.000000e+00    0.000000e+00   
(  512,   512)      PASS       0.000000e+00    0.000000e+00   
( 1024,  1024)      PASS       0.000000e+00    0.000000e+00   
( 2048,  2048)      PASS       0.000000e+00    0.000000e+00   
( 4096,  4096)      PASS       0.000000e+00    0.000000e+00   
( 7168,  2048)      PASS       0.000000e+00    0.000000e+00   
( 2048,  7168)      PASS       0.000000e+00    0.000000e+00   
( 1536,  7168)      PASS       0.000000e+00    0.000000e+00   
( 7168,  1536)      PASS       0.000000e+00    0.000000e+00   
--------------------------------------------------------------------------------
Overall correctness: PASS

--------------------------------------------------------------------------------
PERFORMANCE BENCHMARK
--------------------------------------------------------------------------------
Shape                Torch (ms)      Triton (ms)     Speedup   
--------------------------------------------------------------------------------
(  256,   256)      0.1122          0.0197          5.69      x
(  512,   512)      0.3402          0.0169          20.15     x
( 1024,  1024)      1.2720          0.0168          75.51     x
( 2048,  2048)      4.9856          0.0198          251.29    x
( 4096,  4096)      19.4858         0.0179          1087.61   x
( 7168,  2048)      18.0000         0.0171          1050.13   x
( 2048,  7168)      17.0015         0.0186          915.20    x
( 1536,  7168)      12.2723         0.0188          653.16    x
( 7168,  1536)      13.1309         0.0192          682.48    x
--------------------------------------------------------------------------------
```

dsv31 finetuning 
<img width="1669" height="715" alt="Screenshot 2026-01-27 at 3 47 17 PM" src="https://github.com/user-attachments/assets/542e2084-7be3-4401-90db-35fc7dec8d84" />

https://wandb.ai/Nemo-automodel/automodel-finetunes-2026-01-26/runs/b0qvb59f?nw=nwuserhemild