### PR TITLE
fix: Update container workdir

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -134,6 +134,8 @@ RUN cd /opt/Automodel && \
     fi && \
     uv sync --locked --extra $AUTOMODEL_INSTALL --all-groups
 
+WORKDIR /opt/Automodel
+
 COPY <<EOF /opt/venv/env.sh
 export UV_PROJECT_ENVIRONMENT=/opt/venv
 export PATH="/opt/venv/bin:$PATH"


### PR DESCRIPTION
# What does this PR do ?

The default container workdir pointed to `/opt` which leads to confusion as users might assume the Automodel code doesn't exist and pull it manually, leading to mismatch with the container code.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.