### PR TITLE
feat: change default to sdpa if fa unavailable

### DIFF
--- a/nemo_automodel/_transformers/auto_model.py
+++ b/nemo_automodel/_transformers/auto_model.py
@@ -74,6 +74,7 @@ if TYPE_CHECKING:
 
 HAS_LIGER_KERNEL, liger_kernel_trf = safe_import("liger_kernel.transformers")
 HAS_FA, _ = safe_import("flash_attn")
+DEFAULT_ATTN_IMPLEMENTATION = "flash_attention_2" if HAS_FA else "sdpa"
 
 logger = logging.getLogger(__name__)
 
@@ -799,7 +800,7 @@ class _BaseNeMoAutoModelClass(_BaseAutoModelClass):
         use_sdpa_patching: bool = True,
         sdpa_method: Optional[List[SDPBackend]] = None,
         torch_dtype="auto",
-        attn_implementation: str = "flash_attention_2",
+        attn_implementation: str = DEFAULT_ATTN_IMPLEMENTATION,
         quantization_config=None,
         force_hf: bool = False,
         model_wrapper=None,
@@ -835,8 +836,11 @@ class _BaseNeMoAutoModelClass(_BaseAutoModelClass):
                 SDPA back-ends to consider when `use_sdpa_patching=True`.
             torch_dtype (str | torch.dtype | Literal["auto"], default="auto"):
                 Data type passed to the underlying `from_pretrained` call.
-            attn_implementation (str, default="flash_attention_2"): Desired
-                attention implementation; forwarded to the HF config.
+            attn_implementation (str, optional):
+                Specifies which attention implementation to use (e.g.,
+                ``"flash_attention_2"``, ``"eager"``). Only applied when the
+                base model supports this kwarg. Defaults to ``"flash_attention_2"``,
+                if flash attention is not available, defaults to ``"sdpa"``.
             quantization_config (optional): BitsAndBytesConfig configuration object that
                 specifies all quantization settings. If provided, quantization
                 will be applied to the model.
@@ -1001,7 +1005,7 @@ class _BaseNeMoAutoModelClass(_BaseAutoModelClass):
         use_sdpa_patching: bool = True,
         sdpa_method: Optional[List[SDPBackend]] = None,
         torch_dtype: Union[str, torch.dtype] = "auto",
-        attn_implementation: str = "flash_attention_2",
+        attn_implementation: str = DEFAULT_ATTN_IMPLEMENTATION,
         quantization_config=None,
         force_hf: bool = False,
         model_wrapper=None,
@@ -1045,7 +1049,8 @@ class _BaseNeMoAutoModelClass(_BaseAutoModelClass):
             attn_implementation (str, optional):
                 Specifies which attention implementation to use (e.g.,
                 ``"flash_attention_2"``, ``"eager"``). Only applied when the
-                base model supports this kwarg. Defaults to ``"flash_attention_2"``.
+                base model supports this kwarg. Defaults to ``"flash_attention_2"``,
+                if flash attention is not available, defaults to ``"sdpa"``.
             quantization_config (optional): BitsAndBytesConfig configuration object that
                 specifies all quantization settings. If provided, quantization
                 will be applied to the model.


### PR DESCRIPTION
# What does this PR do ?

For cases where FA is unavailable, switch `attn_implementation` to `sdpa` instead of `flash_attention_2`.

This is useful for cases where the script is invoked with `--extra fa`, fa is installed, but the .so has ABI-incompatibility between the installed PyT and the PyT FA was compiled against, leading to undefined symbols as shown bellow.

We will update the installation guide to ensure FA is correctly installed, and in the meantime want to ensure best ux possible.


Sample output of undefined symbol error
```
akoumparouli@1604ab7-lcedt:/mnt/4tb/auto/Automodel8$ uv run --extra fa python3
warning: The `extra-build-dependencies` option is experimental and may change without warning. Pass `--preview-features extra-build-dependencies` to disable this warning.
░░░░░░░░░░░░░░░░░░░░ [0/1] Installing wheels...
warning: Failed to hardlink files; falling back to full copy. This may lead to degraded performance.
         If the cache and target directories are on different filesystems, hardlinking may not be supported.
         If this is intentional, set `export UV_LINK_MODE=copy` or use `--link-mode=copy` to suppress this warning.
Installed 1 package in 447ms
Python 3.12.11 (main, Jun 12 2025, 12:40:51) [Clang 20.1.4 ] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import flash_attn
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/mnt/4tb/auto/Automodel8/.venv/lib/python3.12/site-packages/flash_attn/__init__.py", line 3, in <module>
    from flash_attn.flash_attn_interface import (
  File "/mnt/4tb/auto/Automodel8/.venv/lib/python3.12/site-packages/flash_attn/flash_attn_interface.py", line 15, in <module>
    import flash_attn_2_cuda as flash_attn_gpu
ImportError: /mnt/4tb/auto/Automodel8/.venv/lib/python3.12/site-packages/flash_attn_2_cuda.cpython-312-x86_64-linux-gnu.so: undefined symbol: _ZNK3c106SymInt6sym_neERKS0_
```

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
