### PR TITLE
fix: fix pp batch issue in step3p5

### DIFF
--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -1132,10 +1132,12 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
                     targets = None
 
                 input_ids = batch.pop("input_ids")
-                
+
                 # Filter out None values and empty dicts from batch to avoid PP chunking errors
-                batch_filtered = {k: v for k, v in batch.items() if v is not None and not (isinstance(v, dict) and len(v) == 0)}
-                
+                batch_filtered = {
+                    k: v for k, v in batch.items() if v is not None and not (isinstance(v, dict) and len(v) == 0)
+                }
+
                 if is_train:
                     # Use step for training (forward + backward)
                     if self.pp.info.has_first_stage:


### PR DESCRIPTION
# What does this PR do ?

Address the issue:
```
File "/opt/Automodel/nemo_automodel/recipes/llm/train_ft.py", line 1066, in run_train_validation_loop
[default4]:[rank28]:     train_log_data = self._run_train_optim_step(batches, self.max_grad_norm)
[default4]:[rank28]:                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[default4]:[rank28]:   File "/opt/Automodel/nemo_automodel/recipes/llm/train_ft.py", line 1216, in _run_train_optim_step
[default4]:[rank28]:     self._forward_backward_step(
[default4]:[rank28]:   File "/opt/Automodel/nemo_automodel/recipes/llm/train_ft.py", line 1138, in _forward_backward_step
[default4]:[rank28]:     self.pp.info.schedule.step(input_ids, target=targets, losses=losses, **batch)
[default4]:[rank28]:   File "/usr/local/lib/python3.12/dist-packages/torch/distributed/pipelining/schedules.py", line 1549, in step
[default4]:[rank28]:     args_split, kwargs_split = self._split_inputs(args, kwargs)
[default4]:[rank28]:                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[default4]:[rank28]:   File "/usr/local/lib/python3.12/dist-packages/torch/distributed/pipelining/schedules.py", line 457, in _split_inputs
[default4]:[rank28]:     args_split, kwargs_split = split_args_kwargs_into_chunks(
[default4]:[rank28]:                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[default4]:[rank28]:   File "/usr/local/lib/python3.12/dist-packages/torch/distributed/pipelining/microbatch.py", line 319, in split_args_kwargs_into_chunks
[default4]:[rank28]:     kwargs_split = _shard_dict_of_args(
[default4]:[rank28]:                    ^^^^^^^^^^^^^^^^^^^^
[default4]:[rank28]:   File "/usr/local/lib/python3.12/dist-packages/torch/distributed/pipelining/microbatch.py", line 156, in _shard_dict_of_args
[default4]:[rank28]:     raise ValueError(
[default4]:[rank28]: ValueError: Argument value {'full_attention': None, 'sliding_attention': None} did not have the same number of values as as chunk spec TensorChunkSpec(0)
```

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
