### PR TITLE
ci: add duration time logging (top-32) for tests 

### DIFF
--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -48,7 +48,8 @@ coverage run \
     --source=/workspace/ \
     --parallel-mode \
     -m pytest \
-    --durations 10 \
+    --durations 32 \
+    --durations-min=0 \
     $TEST_DIR \
     -o log_cli=true \
     -o log_cli_level=INFO \


### PR DESCRIPTION
# What does this PR do ?

Includes duration log
```
2026-02-05T19:48:10.5760122Z ============================= slowest 32 durations =============================
2026-02-05T19:48:10.5764008Z 21.32s call     tests/unit_tests/loss/test_chunked_ce.py::test_chunked_cross_entropy_matches_compute_cross_entropy
2026-02-05T19:48:10.5767892Z 6.02s call     tests/unit_tests/models/kimi_k25_vl/test_state_dict_adapter.py::TestKimiK25VLStateDictAdapterFromHF::test_from_hf_lm_head_key_mapping
2026-02-05T19:48:10.5772051Z 5.82s call     tests/unit_tests/models/kimi_k25_vl/test_state_dict_adapter.py::TestExpertKeyFusionDetection::test_key_prefix_replacement
2026-02-05T19:48:10.5773941Z 3.23s call     tests/unit_tests/moe/test_layers.py::TestGroupedExpertsZeroActiveExperts::test_mixed_active_and_inactive_experts
2026-02-05T19:48:10.5774691Z 2.87s call     tests/unit_tests/moe/test_layers.py::TestGroupedExpertsZeroActiveExperts::test_zero_active_experts_forward_shape
2026-02-05T19:48:10.5774954Z 2.84s call     tests/unit_tests/loss/test_chunked_ce.py::test_chunked_cross_entropy_ignore_index_and_mask
2026-02-05T19:48:10.5778701Z 2.77s call     tests/unit_tests/moe/test_layers.py::TestNonGatedActivations::test_grouped_experts_relu2_forward
2026-02-05T19:48:10.5780436Z 2.23s call     tests/unit_tests/moe/test_layers.py::TestActivationFunctions::test_swiglu_with_bias
2026-02-05T19:48:10.5781127Z 2.09s call     tests/unit_tests/moe/test_layers.py::TestGroupedExpertsZeroActiveExperts::test_zero_active_experts_quick_geglu_activation
2026-02-05T19:48:10.5781455Z 1.72s call     tests/unit_tests/moe/test_layers.py::TestGroupedExpertsZeroActiveExperts::test_zero_active_experts_backward_no_error
2026-02-05T19:48:10.5781737Z 1.58s call     tests/unit_tests/moe/test_layers.py::TestNonGatedActivations::test_relu2_function_shape_preservation
2026-02-05T19:48:10.5781991Z 1.05s call     tests/unit_tests/moe/test_layers.py::TestNonGatedActivations::test_relu2_function_with_bias
2026-02-05T19:48:10.5782235Z 1.00s call     tests/unit_tests/moe/test_layers.py::TestActivationFunctions::test_swiglu_shape_preservation
2026-02-05T19:48:10.5782536Z 0.66s call     tests/unit_tests/recipes/llm/test_benchmark.py::TestBenchmarkingRecipeSetup::test_setup_clears_val_dataloader
2026-02-05T19:48:10.5782944Z 0.59s call     tests/unit_tests/distributed/pipelining/test_pipeline_splitting.py::TestHFModelSplitting::test_split_qwen3_models_on_meta[0-8-Qwen/Qwen3-4B-Base]
2026-02-05T19:48:10.5783349Z 0.57s call     tests/unit_tests/distributed/pipelining/test_pipeline_splitting.py::TestHFModelSplitting::test_split_qwen3_models_on_meta[4-8-Qwen/Qwen3-4B-Base]
2026-02-05T19:48:10.5783756Z 0.54s call     tests/unit_tests/distributed/pipelining/test_pipeline_splitting.py::TestHFModelSplitting::test_split_qwen3_models_on_meta[2-8-Qwen/Qwen3-0.6B-Base]
2026-02-05T19:48:10.5783942Z 0.53s call     tests/unit_tests/training/test_train_utils.py::test_move_to_device_cpu
2026-02-05T19:48:10.5784341Z 0.42s call     tests/unit_tests/models/gpt_oss/test_gptoss_state_dict_adapter.py::TestGPTOSSStateDictAdapter::test_dequantize_block_scale_tensors_merges_pairs
2026-02-05T19:48:10.5784720Z 0.42s call     tests/unit_tests/models/gpt_oss/test_gptoss_state_dict_adapter.py::TestGPTOSSStateDictAdapter::test_from_hf_end_to_end_mapping_and_dequantize
2026-02-05T19:48:10.5785091Z 0.42s call     tests/unit_tests/models/gpt_oss/test_gptoss_state_dict_adapter.py::TestSingleGPUScenarios::test_from_hf_single_gpu_cpu_dequantize_and_map
2026-02-05T19:48:10.5785453Z 0.42s call     tests/unit_tests/models/gpt_oss/test_gptoss_state_dict_adapter.py::TestGPTOSSStateDictAdapter::test_from_hf_only_mapping_without_quant
2026-02-05T19:48:10.5785802Z 0.42s call     tests/unit_tests/models/gpt_oss/test_gptoss_state_dict_adapter.py::TestGPTOSSStateDictAdapter::test_from_hf_detects_model_prefix
2026-02-05T19:48:10.5786167Z 0.42s call     tests/unit_tests/models/gpt_oss/test_gptoss_state_dict_adapter.py::TestGPTOSSStateDictAdapter::test_from_hf_with_te_backend_sinks_mapping
2026-02-05T19:48:10.5786445Z 0.42s call     tests/unit_tests/models/biencoder/test_biencoder_model.py::test_from_pretrained_retries_without_liger
2026-02-05T19:48:10.5786709Z 0.42s call     tests/unit_tests/models/biencoder/test_biencoder_model.py::test_from_pretrained_retries_without_sdpa
2026-02-05T19:48:10.5787080Z 0.33s call     tests/unit_tests/models/kimi_k25_vl/test_state_dict_adapter.py::TestExpandQuantizedKeysExtended::test_expand_preserves_non_expert_keys
2026-02-05T19:48:10.5787260Z 0.32s call     tests/unit_tests/datasets/test_utils.py::test_full_process_pipeline
2026-02-05T19:48:10.5787433Z 0.30s call     tests/unit_tests/loggers/test_log_utils.py::test_setup_logging_full
2026-02-05T19:48:10.5787825Z 0.30s call     tests/unit_tests/models/kimi_k25_vl/test_state_dict_adapter.py::TestKimiK25VLStateDictAdapterFromHFExtended::test_from_hf_non_expert_keys_only
2026-02-05T19:48:10.5788286Z 0.28s call     tests/unit_tests/models/kimi_k25_vl/test_state_dict_adapter.py::TestKimiK25VLStateDictAdapterFromHF::test_from_hf_mm_projector_key_mapping
2026-02-05T19:48:10.5788630Z 0.27s call     tests/unit_tests/models/kimi_k25_vl/test_state_dict_adapter.py::TestExpertKeyFusionDetection::test_detect_expert_keys_in_llm_keys
2026-02-05T19:48:10.6551357Z [36m[1m=========================== short test summary info ============================[0m
```
# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
