### PR TITLE
fix: temp walk around VocabParallelEmbedding to address OOM

### DIFF
--- a/nemo_automodel/components/distributed/optimized_tp_plans.py
+++ b/nemo_automodel/components/distributed/optimized_tp_plans.py
@@ -217,7 +217,7 @@ def _parallelize_llama(
 ) -> dict[str, ParallelStyle]:
     """Parallelizes a LlamaForCausalLM model across data and tensor parallel dimensions."""
     base_model_tp_plan: dict[str, ParallelStyle] = {
-        "model.embed_tokens": VocabParallelEmbedding(input_layouts=Replicate()),
+        "model.embed_tokens": RowwiseParallel(input_layouts=Replicate()),
         "model.layers.*.self_attn.q_proj": ColwiseParallel(),
         "model.layers.*.self_attn.k_proj": ColwiseParallel(),
         "model.layers.*.self_attn.v_proj": ColwiseParallel(),


### PR DESCRIPTION
# What does this PR do ?
```
+++ b/nemo_automodel/components/distributed/optimized_tp_plans.py
@@ -217,7 +217,7 @@ def _parallelize_llama(
 ) -> dict[str, ParallelStyle]:
     """Parallelizes a LlamaForCausalLM model across data and tensor parallel dimensions."""
     base_model_tp_plan: dict[str, ParallelStyle] = {
-        "model.embed_tokens": VocabParallelEmbedding(input_layouts=Replicate()),
+        "model.embed_tokens": RowwiseParallel(input_layouts=Replicate()),
```
I had to revert this line to avoid OOM in custom_llama3_70b_peft_recipe
```
torchrun --nproc-per-node=8 nemo_automodel/recipes/llm/benchmark.py --config examples/llm_finetune/llama3_3/custom_llama3_3_70b_instruct_peft_benchmark.yaml
```

* Before the change: OOM https://wandb.ai/nvidia/automodel-dev-zhiyul/runs/9qwq18w8/logs
* now: https://wandb.ai/nvidia/automodel-dev-zhiyul/runs/2gpqikhw/logs

see original comment https://github.com/NVIDIA-NeMo/Automodel/pull/1190#issuecomment-3867012503

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
