### PR TITLE
fix: reduce bs to walk around OOM given lack of liger kernel in transformers v5

### DIFF
--- a/examples/llm_finetune/llama3_1/llama3_1_8b_peft_benchmark.yaml
+++ b/examples/llm_finetune/llama3_1/llama3_1_8b_peft_benchmark.yaml
@@ -31,7 +31,7 @@ benchmark:
 
 step_scheduler:
   global_batch_size: 32
-  local_batch_size: 2
+  local_batch_size: 1
   ckpt_every_steps: 50
   val_every_steps: 1000
   max_steps: 10


### PR DESCRIPTION
# What does this PR do ?

llama3_8b peft recipe OOM when bumping up transformers v4 to v5 because of lack of liger kernel support:
see https://github.com/linkedin/Liger-Kernel/issues/978 for more info

I was able to resolve the OOM issue in nvcr.io#nvidian/nemo-automodel:nightly by manully bumping up the working liger-kernel version:
```
python -m pip install 'liger-kernel @ git+https://github.com/linkedin/Liger-Kernel.git@transformers-5.0.0rc1'
```

As for the next step, let me reduce the batch size first to lower the peak memory. And revert it once we have liger-kernel officially released.

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
