### PR TITLE
feat: add MoE expert metrics

### DIFF
--- a/nemo_automodel/components/moe/config.py
+++ b/nemo_automodel/components/moe/config.py
@@ -90,3 +90,23 @@ class MoEConfig:
     def __post_init__(self):
         if isinstance(self.dtype, str):
             self.dtype = dtype_from_str(self.dtype, default=torch.bfloat16)
+
+
+@dataclass
+class MoEMetricsConfig:
+    """Configuration for MoE load balance metrics logging.
+
+    Attributes:
+        enabled: Whether to enable load balance metric tracking.
+        mode: Logging mode - "brief" for scalar line charts only,
+            "detailed" adds per-layer breakdowns.
+        detailed_every_steps: How often to log detailed metrics (only used when mode="detailed").
+            None means every step.
+        top_k_experts: Number of top (highest) and bottom (lowest) utilization experts
+            to emit per layer. Reduces wandb key count for models with many experts.
+    """
+
+    enabled: bool = False
+    mode: str = "brief"
+    detailed_every_steps: Optional[int] = None
+    top_k_experts: int = 5

--- a/nemo_automodel/components/moe/load_balance_metrics.py
+++ b/nemo_automodel/components/moe/load_balance_metrics.py
@@ -1,0 +1,313 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MoE load balance metrics utilities.
+
+Provides functions to enable load balance tracking on Gate modules,
+collect per-layer expert load data, and compute brief/detailed metrics
+suitable for wandb logging.
+
+Expert utilization is a ratio of ``current_load / ideal_load`` where
+``ideal_load = total_tokens / n_experts``.  A value of 1.0 means the
+expert receives exactly its fair share; >1 = overloaded, <1 = underloaded,
+0 = dead expert.
+
+Modes:
+- **brief**: Aggregated scalars (mean/median/min/max of cv and expert
+  utilization) plus top-K/bottom-K individual expert utilization ratios.
+- **detailed**: Everything in brief, plus per-layer breakdowns
+  (``moe/layer_{i}/cv``, ``moe/layer_{i}/utilization_mean``, etc.).
+"""
+
+from __future__ import annotations
+
+import statistics
+
+import torch
+import torch.nn as nn
+
+
+def enable_load_balance_tracking(model: nn.Module) -> None:
+    """Enable load balance tracking on all Gate modules in the model.
+
+    Sets ``_track_load_balance = True`` on every Gate instance found via
+    ``model.modules()``.  This causes each Gate to store its most recent
+    ``expert_load`` tensor after every forward pass with negligible overhead
+    (one ``.detach()`` copy per layer).
+
+    Args:
+        model: The model (or model part) to enable tracking on.
+    """
+    from nemo_automodel.components.moe.layers import Gate
+
+    for module in model.modules():
+        if isinstance(module, Gate):
+            module._track_load_balance = True
+
+
+def collect_expert_loads(
+    model: nn.Module,
+    dp_group: torch.distributed.ProcessGroup | None = None,
+) -> dict[str, dict]:
+    """Collect the most recent expert load data from all Gate modules.
+
+    When ``dp_group`` is provided, expert loads are all-reduced across the
+    data-parallel group so the metrics reflect global token routing rather
+    than a single rank's view.  This is important when DP > 1 or EP > 1
+    because each rank only routes its local shard of tokens through the
+    (replicated) gate.
+
+    Args:
+        model: The model (or model part) to collect from.
+        dp_group: Optional DP (or DP+CP) process group for all-reducing
+            expert loads.  Pass ``None`` to skip reduction (rank-local view).
+
+    Returns:
+        Dictionary mapping layer names to dicts with keys:
+        - ``"expert_load"``: ``Tensor[n_experts]`` with token counts per expert.
+        - ``"aux_loss"``: ``Optional[Tensor]`` scalar aux loss (if computed).
+        - ``"n_experts"``: ``int`` number of routed experts.
+    """
+    from nemo_automodel.components.moe.layers import Gate
+
+    loads: dict[str, dict] = {}
+    for name, module in model.named_modules():
+        if isinstance(module, Gate) and module._last_expert_load is not None:
+            expert_load = module._last_expert_load
+            if dp_group is not None:
+                expert_load = expert_load.clone()
+                torch.distributed.all_reduce(expert_load, group=dp_group)
+            loads[name] = {
+                "expert_load": expert_load,
+                "aux_loss": module._last_aux_loss,
+                "n_experts": module.n_experts,
+            }
+    return loads
+
+
+def _compute_per_layer_stats(layer_loads: dict[str, dict]):
+    """Compute per-layer CV, aux_loss and per-layer utilization ratios.
+
+    Returns:
+        (per_layer_metrics, per_layer_utilizations) where:
+        - per_layer_metrics: list of dicts with keys cv, aux_loss
+        - per_layer_utilizations: list of Tensor[n_experts] with utilization ratio per layer
+          (1.0 = ideal, >1 = overloaded, <1 = underloaded)
+    """
+    per_layer_metrics = []
+    per_layer_utilizations = []
+
+    for _name, data in sorted(layer_loads.items()):
+        load = data["expert_load"].float()
+        mean = load.mean()
+        std = load.std()
+        total = load.sum()
+
+        cv = (std / mean).item() if mean > 0 else 0.0
+        aux_loss = data["aux_loss"].item() if data["aux_loss"] is not None else None
+
+        per_layer_metrics.append(
+            {
+                "cv": cv,
+                "aux_loss": aux_loss,
+            }
+        )
+
+        # Utilization ratio: current / ideal (1.0 = perfect balance)
+        n_experts = load.shape[0]
+        ideal = total / n_experts if n_experts > 0 else total
+        utilization_ratio = (load / ideal) if ideal > 0 else torch.zeros_like(load)
+        per_layer_utilizations.append(utilization_ratio)
+
+    return per_layer_metrics, per_layer_utilizations
+
+
+def _aggregate_stats(values: list[float], prefix: str) -> dict[str, float]:
+    """Compute mean, median, min, max for a list of per-layer values.
+
+    Args:
+        values: List of per-layer scalar values.
+        prefix: Key prefix, e.g. ``"moe/cv"``.
+
+    Returns:
+        Dict like ``{"moe/cv_mean": .., "moe/cv_median": .., "moe/cv_min": .., "moe/cv_max": ..}``.
+    """
+    return {
+        f"{prefix}_mean": sum(values) / len(values),
+        f"{prefix}_median": statistics.median(values),
+        f"{prefix}_min": min(values),
+        f"{prefix}_max": max(values),
+    }
+
+
+def _compute_expert_utilization(
+    per_layer_utilizations: list[torch.Tensor],
+    top_k: int = 5,
+) -> dict[str, float]:
+    """Compute top-K and bottom-K expert utilization ratios globally.
+
+    Flattens utilization across all layers and experts, then emits only the
+    ``top_k`` highest and ``top_k`` lowest entries.  This keeps the total
+    number of wandb keys to at most ``2 * top_k`` regardless of model size.
+
+    Values are ratios relative to ideal load: 1.0 = perfect balance,
+    >1 = overloaded, <1 = underloaded, 0 = dead expert.
+
+    All keys share the ``moe_expert_utilization/`` prefix so wandb
+    renders them on a single chart.
+
+    Args:
+        per_layer_utilizations: List of Tensor[n_experts] utilization ratio per layer.
+        top_k: Number of top (highest) and bottom (lowest) experts to emit.
+
+    Returns:
+        Dict like ``{"moe_expert_utilization/layer_0_expert_5": 1.23, ...}``.
+    """
+    if not per_layer_utilizations:
+        return {}
+
+    # Build flat list of (utilization, layer_idx, expert_idx)
+    all_entries: list[tuple[float, int, int]] = []
+    for layer_idx, util in enumerate(per_layer_utilizations):
+        for expert_idx in range(util.shape[0]):
+            all_entries.append((util[expert_idx].item(), layer_idx, expert_idx))
+
+    all_entries.sort(key=lambda x: x[0])
+    k = min(top_k, len(all_entries))
+
+    metrics: dict[str, float] = {}
+    # Bottom-K (lowest utilization)
+    for val, layer_idx, expert_idx in all_entries[:k]:
+        metrics[f"moe_expert_utilization/layer_{layer_idx}_expert_{expert_idx}"] = val
+    # Top-K (highest utilization)
+    for val, layer_idx, expert_idx in all_entries[-k:]:
+        metrics[f"moe_expert_utilization/layer_{layer_idx}_expert_{expert_idx}"] = val
+
+    return metrics
+
+
+def _compute_utilization_aggregates(
+    per_layer_utilizations: list[torch.Tensor],
+    per_layer: bool = False,
+) -> dict[str, float]:
+    """Compute aggregate utilization stats across all experts globally.
+
+    Args:
+        per_layer_utilizations: List of Tensor[n_experts] utilization ratio per layer.
+        per_layer: If True, also emit per-layer utilization means.
+
+    Returns:
+        Dict with ``moe/expert_utilization_{p25,median,p75,min,max}`` and optionally
+        ``moe/layer_{i}/utilization_mean`` when ``per_layer=True``.
+    """
+    metrics: dict[str, float] = {}
+    if not per_layer_utilizations:
+        return metrics
+
+    all_ratios: list[float] = []
+    for layer_idx, util in enumerate(per_layer_utilizations):
+        ratios = util.tolist()
+        all_ratios.extend(ratios)
+        if per_layer:
+            metrics[f"moe/layer_{layer_idx}/utilization_mean"] = util.mean().item()
+
+    # Global aggregates (skip mean — it's always 1.0 by construction)
+    sorted_ratios = sorted(all_ratios)
+    n = len(sorted_ratios)
+    metrics["moe/expert_utilization_p25"] = sorted_ratios[n // 4] if n >= 4 else sorted_ratios[0]
+    metrics["moe/expert_utilization_median"] = statistics.median(all_ratios)
+    metrics["moe/expert_utilization_p75"] = sorted_ratios[3 * n // 4] if n >= 4 else sorted_ratios[-1]
+    metrics["moe/expert_utilization_min"] = sorted_ratios[0]
+    metrics["moe/expert_utilization_max"] = sorted_ratios[-1]
+    return metrics
+
+
+def compute_brief_metrics(
+    layer_loads: dict[str, dict],
+    top_k: int = 5,
+) -> dict[str, float]:
+    """Compute brief load-balance metrics: aggregated scalars + top-K/bottom-K utilization.
+
+    Metrics produced:
+    - ``moe/cv_{mean,median,min,max}`` — CV aggregated across all MoE layers.
+    - ``moe/expert_utilization_{p25,median,p75,min,max}`` — utilization ratio stats
+      across all experts globally (1.0 = ideal).
+    - ``moe/aux_loss_mean`` — aux loss averaged across layers (when available).
+    - ``moe_expert_utilization/layer_{i}_expert_{j}`` — top-K highest and bottom-K
+      lowest utilization experts globally.
+
+    Args:
+        layer_loads: Output of :func:`collect_expert_loads`.
+        top_k: Number of top/bottom experts to emit globally.
+
+    Returns:
+        Flat dictionary suitable for ``wandb.log()``.
+    """
+    per_layer, per_layer_utils = _compute_per_layer_stats(layer_loads)
+    if not per_layer:
+        return {}
+
+    metrics: dict[str, float] = {}
+
+    cvs = [m["cv"] for m in per_layer]
+    aux_losses = [m["aux_loss"] for m in per_layer if m["aux_loss"] is not None]
+
+    metrics.update(_aggregate_stats(cvs, "moe/cv"))
+    if aux_losses:
+        metrics["moe/aux_loss_mean"] = sum(aux_losses) / len(aux_losses)
+
+    metrics.update(_compute_expert_utilization(per_layer_utils, top_k=top_k))
+    metrics.update(_compute_utilization_aggregates(per_layer_utils, per_layer=False))
+    return metrics
+
+
+def compute_detailed_metrics(
+    layer_loads: dict[str, dict],
+    top_k: int = 5,
+) -> dict[str, float]:
+    """Compute detailed load-balance metrics: per-layer scalars + aggregates + utilization.
+
+    Includes everything from :func:`compute_brief_metrics` plus per-layer
+    breakdowns:
+    - ``moe/layer_{i}/cv``, ``moe/layer_{i}/aux_loss``
+    - ``moe/layer_{i}/utilization_mean`` — per-layer mean utilization.
+
+    Args:
+        layer_loads: Output of :func:`collect_expert_loads`.
+        top_k: Number of top/bottom experts to emit globally.
+
+    Returns:
+        Flat dictionary suitable for ``wandb.log()``.
+    """
+    per_layer, per_layer_utils = _compute_per_layer_stats(layer_loads)
+    if not per_layer:
+        return {}
+
+    metrics: dict[str, float] = {}
+
+    cvs, aux_losses = [], []
+    for i, m in enumerate(per_layer):
+        metrics[f"moe/layer_{i}/cv"] = m["cv"]
+        cvs.append(m["cv"])
+        if m["aux_loss"] is not None:
+            metrics[f"moe/layer_{i}/aux_loss"] = m["aux_loss"]
+            aux_losses.append(m["aux_loss"])
+
+    metrics.update(_aggregate_stats(cvs, "moe/cv"))
+    if aux_losses:
+        metrics["moe/aux_loss_mean"] = sum(aux_losses) / len(aux_losses)
+
+    metrics.update(_compute_expert_utilization(per_layer_utils, top_k=top_k))
+    metrics.update(_compute_utilization_aggregates(per_layer_utils, per_layer=True))
+    return metrics

--- a/nemo_automodel/recipes/llm/benchmark.py
+++ b/nemo_automodel/recipes/llm/benchmark.py
@@ -283,6 +283,11 @@ class BenchmarkingRecipeForNextTokenPrediction(TrainFinetuneRecipeForNextTokenPr
                     f"loss={reporting_loss:.4f}"
                 )
 
+            # Collect and log MoE load balance metrics (inherited from train_ft)
+            self._collect_moe_load_balance()
+            if self._wandb_enabled and self.wandb_run is not None:
+                self._log_moe_metrics(i, self.wandb_run.log)
+
             # Calculate and log MFU
             self._log_iteration_metrics(iter_timer, ga_steps, peak_tflops, rank, i)
 

--- a/tests/unit_tests/moe/test_load_balance_metrics.py
+++ b/tests/unit_tests/moe/test_load_balance_metrics.py
@@ -1,0 +1,341 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for MoE load balance metrics."""
+
+import math
+
+import pytest
+import torch
+import torch.nn as nn
+
+from nemo_automodel.components.moe.load_balance_metrics import (
+    collect_expert_loads,
+    compute_brief_metrics,
+    compute_detailed_metrics,
+    enable_load_balance_tracking,
+)
+
+
+def _make_layer_loads(loads_list, aux_losses=None):
+    """Helper to build a layer_loads dict from a list of 1-D tensors."""
+    result = {}
+    for i, load in enumerate(loads_list):
+        al = None if aux_losses is None else aux_losses[i]
+        result[f"layers.{i}.moe.gate"] = {
+            "expert_load": torch.tensor(load, dtype=torch.float32),
+            "aux_loss": torch.tensor(al) if al is not None else None,
+            "n_experts": len(load),
+        }
+    return result
+
+
+class TestComputeBriefMetrics:
+    def test_uniform_load(self):
+        """Uniform load should give CV=0, utilization=1.0 for all experts."""
+        layer_loads = _make_layer_loads([[100.0, 100.0, 100.0, 100.0]])
+        metrics = compute_brief_metrics(layer_loads, top_k=4)
+
+        assert metrics["moe/cv_mean"] == pytest.approx(0.0, abs=1e-6)
+        assert metrics["moe/expert_utilization_p25"] == pytest.approx(1.0, abs=1e-4)
+        assert metrics["moe/expert_utilization_median"] == pytest.approx(1.0, abs=1e-4)
+        assert metrics["moe/expert_utilization_p75"] == pytest.approx(1.0, abs=1e-4)
+        assert metrics["moe/expert_utilization_min"] == pytest.approx(1.0, abs=1e-4)
+        assert metrics["moe/expert_utilization_max"] == pytest.approx(1.0, abs=1e-4)
+
+    def test_skewed_load(self):
+        """Skewed load should give CV > 0, utilization_max > 1."""
+        layer_loads = _make_layer_loads([[400.0, 100.0, 100.0, 100.0]])
+        metrics = compute_brief_metrics(layer_loads)
+
+        assert metrics["moe/cv_mean"] > 0.5
+        # expert_utilization_max = max(load) / mean(load) = 400 / 175
+        assert metrics["moe/expert_utilization_max"] == pytest.approx(400.0 / 175.0, abs=1e-4)
+        # expert_utilization_min = min(load) / mean(load) = 100 / 175
+        assert metrics["moe/expert_utilization_min"] == pytest.approx(100.0 / 175.0, abs=1e-4)
+
+    def test_only_aggregates_no_per_layer(self):
+        """Brief mode should NOT produce per-layer keys."""
+        layer_loads = _make_layer_loads([[100.0, 200.0], [150.0, 150.0]])
+        metrics = compute_brief_metrics(layer_loads)
+
+        assert "moe/cv_mean" in metrics
+        assert "moe/layer_0/cv" not in metrics
+        assert "moe/layer_1/cv" not in metrics
+        assert "moe/layer_0/utilization_mean" not in metrics
+
+    def test_cv_aggregate_stats(self):
+        """Brief mode should produce mean, median, min, max for CV."""
+        # Layer 0: skewed, Layer 1: uniform
+        layer_loads = _make_layer_loads([[400.0, 100.0], [150.0, 150.0]])
+        metrics = compute_brief_metrics(layer_loads)
+
+        for suffix in ["_mean", "_median", "_min", "_max"]:
+            assert f"moe/cv{suffix}" in metrics
+
+        # Layer 1 is uniform -> cv=0, Layer 0 is skewed -> cv>0
+        assert metrics["moe/cv_min"] == pytest.approx(0.0, abs=1e-6)
+        assert metrics["moe/cv_max"] > 0.0
+
+    def test_no_imbalance_or_entropy_keys(self):
+        """Brief mode should NOT have imbalance or entropy keys."""
+        layer_loads = _make_layer_loads([[100.0, 200.0]])
+        metrics = compute_brief_metrics(layer_loads)
+
+        assert not any("imbalance" in k for k in metrics)
+        assert not any("entropy" in k for k in metrics)
+
+    def test_no_utilization_mean(self):
+        """expert_utilization_mean should NOT be present (always 1.0)."""
+        layer_loads = _make_layer_loads([[100.0, 200.0, 300.0]])
+        metrics = compute_brief_metrics(layer_loads)
+
+        assert "moe/expert_utilization_mean" not in metrics
+
+    def test_expert_utilization_top_k_global(self):
+        """Top-K filtering should emit top/bottom K experts globally across all layers."""
+        layer_loads = _make_layer_loads([
+            [100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 900.0],
+            [50.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0],
+        ])
+        metrics = compute_brief_metrics(layer_loads, top_k=2)
+
+        util_keys = [k for k in metrics if k.startswith("moe_expert_utilization/layer_")]
+        assert len(util_keys) <= 4
+
+        # Global top and bottom should be present
+        assert "moe_expert_utilization/layer_0_expert_7" in metrics
+        assert "moe_expert_utilization/layer_1_expert_0" in metrics
+
+    def test_top_k_caps_total_keys(self):
+        """With many layers, total expert utilization keys should be at most 2*top_k."""
+        layer_loads = _make_layer_loads([
+            [100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0],
+            [110.0, 210.0, 310.0, 410.0, 510.0, 610.0, 710.0, 810.0],
+            [120.0, 220.0, 320.0, 420.0, 520.0, 620.0, 720.0, 820.0],
+            [130.0, 230.0, 330.0, 430.0, 530.0, 630.0, 730.0, 830.0],
+        ])
+        metrics = compute_brief_metrics(layer_loads, top_k=3)
+
+        util_keys = [k for k in metrics if k.startswith("moe_expert_utilization/layer_")]
+        assert len(util_keys) <= 6
+
+    def test_no_aux_loss(self):
+        """When aux_loss is None, aux_loss_mean should be absent."""
+        layer_loads = _make_layer_loads([[100.0, 100.0]])
+        metrics = compute_brief_metrics(layer_loads)
+
+        assert "moe/aux_loss_mean" not in metrics
+
+    def test_with_aux_loss(self):
+        """Aux loss mean should be computed when available."""
+        layer_loads = _make_layer_loads(
+            [[100.0, 100.0], [200.0, 100.0]],
+            aux_losses=[0.1, 0.3],
+        )
+        metrics = compute_brief_metrics(layer_loads)
+
+        assert metrics["moe/aux_loss_mean"] == pytest.approx(0.2, abs=1e-6)
+
+    def test_zero_load_expert(self):
+        """Zero-load expert should give utilization_min=0."""
+        layer_loads = _make_layer_loads([[100.0, 0.0, 100.0, 100.0]])
+        metrics = compute_brief_metrics(layer_loads)
+
+        assert metrics["moe/expert_utilization_min"] == pytest.approx(0.0, abs=1e-6)
+        # max = 100 / 75 (ideal = 300/4 = 75)
+        assert metrics["moe/expert_utilization_max"] == pytest.approx(100.0 / 75.0, abs=1e-4)
+
+    def test_percentiles(self):
+        """p25 and p75 should reflect the utilization distribution."""
+        # 8 experts: loads [0, 100, 200, 300, 400, 500, 600, 700]
+        # total=2800, ideal=350, ratios sorted: [0, 2/7, 4/7, 6/7, 8/7, 10/7, 12/7, 14/7]
+        # p25 = sorted[2] = 4/7, p75 = sorted[6] = 12/7
+        layer_loads = _make_layer_loads([[0.0, 100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0]])
+        metrics = compute_brief_metrics(layer_loads)
+
+        assert metrics["moe/expert_utilization_p25"] == pytest.approx(200.0 / 350.0, abs=1e-4)
+        assert metrics["moe/expert_utilization_p75"] == pytest.approx(600.0 / 350.0, abs=1e-4)
+
+
+class TestComputeDetailedMetrics:
+    def test_includes_per_layer_keys(self):
+        """Detailed mode should include per-layer CV breakdowns."""
+        layer_loads = _make_layer_loads([[100.0, 200.0], [150.0, 150.0]])
+        metrics = compute_detailed_metrics(layer_loads)
+
+        assert "moe/layer_0/cv" in metrics
+        assert "moe/layer_1/cv" in metrics
+
+    def test_no_per_layer_imbalance_or_entropy(self):
+        """Detailed mode should NOT have imbalance or entropy keys."""
+        layer_loads = _make_layer_loads([[100.0, 200.0]])
+        metrics = compute_detailed_metrics(layer_loads)
+
+        assert not any("imbalance" in k for k in metrics)
+        assert not any("entropy" in k for k in metrics)
+
+    def test_includes_cv_aggregates(self):
+        """Detailed mode should include mean, median, min, max for CV."""
+        layer_loads = _make_layer_loads([[100.0, 200.0]])
+        metrics = compute_detailed_metrics(layer_loads)
+
+        for suffix in ["_mean", "_median", "_min", "_max"]:
+            assert f"moe/cv{suffix}" in metrics
+
+    def test_includes_utilization_aggregates(self):
+        """Detailed mode should include utilization p25, median, p75, min, max."""
+        layer_loads = _make_layer_loads([[100.0, 200.0]])
+        metrics = compute_detailed_metrics(layer_loads)
+
+        assert "moe/expert_utilization_p25" in metrics
+        assert "moe/expert_utilization_median" in metrics
+        assert "moe/expert_utilization_p75" in metrics
+        assert "moe/expert_utilization_min" in metrics
+        assert "moe/expert_utilization_max" in metrics
+        assert "moe/expert_utilization_mean" not in metrics
+
+    def test_includes_expert_utilization(self):
+        """Detailed mode should include top-K/bottom-K expert utilization."""
+        layer_loads = _make_layer_loads([[100.0, 200.0, 300.0, 800.0]])
+        metrics = compute_detailed_metrics(layer_loads, top_k=2)
+
+        util_keys = [k for k in metrics if k.startswith("moe_expert_utilization/layer_")]
+        assert len(util_keys) <= 4
+        assert "moe_expert_utilization/layer_0_expert_3" in metrics
+        assert "moe_expert_utilization/layer_0_expert_0" in metrics
+
+    def test_per_layer_values_correct(self):
+        """Per-layer CV should match expected values."""
+        layer_loads = _make_layer_loads(
+            [[100.0, 100.0, 100.0, 100.0]],
+            aux_losses=[0.5],
+        )
+        metrics = compute_detailed_metrics(layer_loads)
+
+        assert metrics["moe/layer_0/cv"] == pytest.approx(0.0, abs=1e-6)
+        assert metrics["moe/layer_0/aux_loss"] == pytest.approx(0.5, abs=1e-6)
+
+    def test_includes_per_layer_utilization_mean(self):
+        """Detailed mode should include per-layer utilization means."""
+        layer_loads = _make_layer_loads([[100.0, 300.0], [200.0, 200.0]])
+        metrics = compute_detailed_metrics(layer_loads)
+
+        # Layer 0: ideal=200, ratios=[0.5, 1.5] -> mean=1.0
+        assert "moe/layer_0/utilization_mean" in metrics
+        assert metrics["moe/layer_0/utilization_mean"] == pytest.approx(1.0, abs=1e-4)
+        # Layer 1: ideal=200, ratios=[1.0, 1.0] -> mean=1.0
+        assert "moe/layer_1/utilization_mean" in metrics
+        assert metrics["moe/layer_1/utilization_mean"] == pytest.approx(1.0, abs=1e-4)
+
+
+class TestEnableLoadBalanceTracking:
+    def test_sets_flag_on_gate_modules(self):
+        """enable_load_balance_tracking should set _track_load_balance on all Gates."""
+        from nemo_automodel.components.moe.config import MoEConfig
+        from nemo_automodel.components.moe.layers import Gate
+
+        config = MoEConfig(
+            n_routed_experts=4,
+            n_shared_experts=0,
+            n_activated_experts=2,
+            n_expert_groups=1,
+            n_limited_groups=1,
+            train_gate=False,
+            gate_bias_update_factor=0.0,
+            aux_loss_coeff=0.0,
+            score_func="softmax",
+            route_scale=1.0,
+            dim=16,
+            inter_dim=32,
+            moe_inter_dim=32,
+            norm_topk_prob=False,
+        )
+        gate = Gate(config)
+        parent = nn.Module()
+        parent.gate = gate
+        assert gate._track_load_balance is False
+
+        enable_load_balance_tracking(parent)
+        assert gate._track_load_balance is True
+
+
+class TestCollectExpertLoads:
+    def test_returns_correct_structure(self):
+        """collect_expert_loads should return data from Gates with stored loads."""
+        from nemo_automodel.components.moe.config import MoEConfig
+        from nemo_automodel.components.moe.layers import Gate
+
+        config = MoEConfig(
+            n_routed_experts=4,
+            n_shared_experts=0,
+            n_activated_experts=2,
+            n_expert_groups=1,
+            n_limited_groups=1,
+            train_gate=False,
+            gate_bias_update_factor=0.0,
+            aux_loss_coeff=0.0,
+            score_func="softmax",
+            route_scale=1.0,
+            dim=16,
+            inter_dim=32,
+            moe_inter_dim=32,
+            norm_topk_prob=False,
+        )
+        gate = Gate(config)
+        gate._track_load_balance = True
+        gate._last_expert_load = torch.tensor([10.0, 20.0, 30.0, 40.0])
+        gate._last_aux_loss = torch.tensor(0.5)
+
+        parent = nn.Module()
+        parent.gate = gate
+
+        loads = collect_expert_loads(parent)
+        assert len(loads) == 1
+
+        key = list(loads.keys())[0]
+        assert "gate" in key
+        assert loads[key]["n_experts"] == 4
+        assert torch.equal(loads[key]["expert_load"], torch.tensor([10.0, 20.0, 30.0, 40.0]))
+        assert loads[key]["aux_loss"].item() == pytest.approx(0.5)
+
+    def test_skips_gates_without_load(self):
+        """Gates without stored expert_load should be skipped."""
+        from nemo_automodel.components.moe.config import MoEConfig
+        from nemo_automodel.components.moe.layers import Gate
+
+        config = MoEConfig(
+            n_routed_experts=4,
+            n_shared_experts=0,
+            n_activated_experts=2,
+            n_expert_groups=1,
+            n_limited_groups=1,
+            train_gate=False,
+            gate_bias_update_factor=0.0,
+            aux_loss_coeff=0.0,
+            score_func="softmax",
+            route_scale=1.0,
+            dim=16,
+            inter_dim=32,
+            moe_inter_dim=32,
+            norm_topk_prob=False,
+        )
+        gate = Gate(config)
+        gate._track_load_balance = True
+
+        parent = nn.Module()
+        parent.gate = gate
+
+        loads = collect_expert_loads(parent)
+        assert len(loads) == 0


### PR DESCRIPTION
## Summary

Wandb - https://wandb.ai/Nemo-automodel/automodel-moe-metrics-test-6

- Add configurable MoE load balance metrics logging to wandb for training and benchmarking
- Track per-expert token routing distribution to detect expert collapse, routing bias, and dead experts
- Support two logging tiers: **brief** (scalar aggregates) and **detailed** (per-layer breakdowns)
- Cap wandb key count at `2 * top_k` regardless of model size via global top-K/bottom-K filtering

## Motivation

MoE models like Qwen3-30B-A3B (128 routed experts, 8 activated per token, 48 MoE layers) can suffer from expert collapse or severe routing imbalance during finetuning, especially on narrow domains. Without visibility into per-expert token routing, these issues go undetected until training loss stalls or evaluation metrics degrade.

Previously, the codebase computed `expert_load` inside `Gate.forward()` but only when `aux_loss_coeff > 0` or `gate_bias_update_factor > 0`, and this data was never surfaced to the training loop or logged.

## Metrics

All metrics use **expert utilization ratio** = `current_load / ideal_load` where `ideal_load = total_tokens / n_experts`:
- **1.0** = expert receives exactly its fair share
- **>1.0** = overloaded (receives more tokens than expected)
- **<1.0** = underloaded
- **0.0** = dead expert (receives no tokens)

### Brief mode (`mode: brief`)
| Key | Description |
|-----|-------------|
| `moe/cv_{mean,median,min,max}` | Coefficient of Variation across MoE layers. CV = std(load)/mean(load). 0 = perfect balance, >0.5 = problematic |
| `moe/expert_utilization_{p25,median,p75,min,max}` | Utilization ratio percentiles across all experts globally |
| `moe/aux_loss_mean` | Aux loss averaged across layers (when available) |
| `moe_expert_utilization/layer_{i}_expert_{j}` | Top-K highest and bottom-K lowest utilization experts globally (at most `2 * top_k` keys) |

### Detailed mode (`mode: detailed`)
Everything in brief, plus:
| Key | Description |
|-----|-------------|
| `moe/layer_{i}/cv` | Per-layer CV breakdown |
| `moe/layer_{i}/aux_loss` | Per-layer aux loss |
| `moe/layer_{i}/utilization_mean` | Per-layer mean utilization (always 1.0 per-layer, useful as sanity check) |

### Notes
- **No `expert_utilization_mean`** in global aggregates — it's always 1.0 by construction (ratios sum to n_experts)
- **Global top-K/bottom-K** — flattens all (layer, expert) pairs and emits only the extremes, keeping wandb key count bounded at `2 * top_k` regardless of model size (e.g., 128 experts × 48 layers = 6,144 → 10 keys with default top_k=5)

## Interpreting metrics (real-world example)

On **Qwen3-30B-A3B finetuning HellaSwag (answer-only loss)** we observed:
| Metric | Value | Interpretation |
|--------|-------|----------------|
| `expert_utilization_p25` | 0.1 | ~32 experts nearly starved (10% of fair share) |
| `expert_utilization_median` | 0.5 | Typical expert gets half its fair share |
| `expert_utilization_p75` | 1.5 | Top quarter handles 1.5x ideal load |

## YAML config

```yaml
moe_metrics:
  enabled: true
  mode: detailed           # "brief" or "detailed"
  detailed_every_steps: 50 # null = every step
  top_k_experts: 5         # top/bottom K experts to emit
```
