### PR TITLE
fix: grouped experts ep comms

### DIFF
--- a/tests/unit_tests/moe/run_zero_active_experts_gradient_test.py
+++ b/tests/unit_tests/moe/run_zero_active_experts_gradient_test.py
@@ -24,19 +24,13 @@ from nemo_automodel.components.moe.layers import GroupedExperts
 activation_called = [False]
 
 
-def tracking_swiglu(x, *, gate_and_up_proj, down_proj, gate_up_proj_bias=None, down_proj_bias=None):
-    """Tracking version of swiglu that sets activation_called[0] = True."""
+def tracking_activation(gate_and_up_out, weights):
+    """Tracking version of expert_activation_grouped that sets activation_called[0] = True."""
     global activation_called
     activation_called[0] = True
-    gate_and_up_out = x @ gate_and_up_proj
-    if gate_up_proj_bias is not None:
-        gate_and_up_out = gate_and_up_out + gate_up_proj_bias
     gate_out, up_out = torch.chunk(gate_and_up_out, 2, -1)
     inter = F.silu(gate_out) * up_out
-    inter = inter @ down_proj
-    if down_proj_bias is not None:
-        inter = inter + down_proj_bias
-    return inter
+    return inter * weights
 
 
 def main(device_str: str = "cuda:0") -> int:
@@ -78,7 +72,7 @@ def main(device_str: str = "cuda:0") -> int:
 
     device = torch.device(device_str)
     experts = GroupedExperts(moe_config)
-    experts.expert_activation = tracking_swiglu
+    experts.expert_activation_grouped = tracking_activation
     experts = experts.to(device)
 
     with torch.no_grad():


### PR DESCRIPTION
## Fix GroupedExperts convergence gap with expert parallelism

Wandb: https://wandb.ai/Nemo-automodel/automodel-moe-torch-comms

### Problem

`GroupedExperts` (torch dispatcher) has significantly worse convergence than `GroupedExpertsDeepEP` when using expert parallelism — ~1.6 loss vs ~1.4 at step 106 with Qwen3 MoE 30B config (~14% gap).

### Root Cause

The primary issue is a **missing reduce-scatter in the backward pass** of the input all-gather.

`GroupedExperts.forward()` uses DTensor to all-gather inputs across EP ranks:

```python
x = DTensor.from_local(x, ..., placements=[Shard(0)]).full_tensor()
```

`DTensor.full_tensor()` internally calls `_ToTorchTensor.apply(redist_res, grad_placements)`. When `grad_placements=None` (the default), the backward falls back to the redistributed tensor's placements — which is `Replicate` (from the `redistribute([Replicate()])` inside `full_tensor`):

```python
# _ToTorchTensor.backward():
grad_placements = grad_placements or dtensor_spec.placements  # → Replicate
```

This tells DTensor the gradient is **identical on all ranks**. The backward of `Shard(0) → Replicate` with a `Replicate` gradient is just a **slice** — no communication. But in our case, each rank computes different experts, so the gradient is **different on each rank**. Each token needs gradient contributions from all experts it was routed to (potentially across multiple ranks). With the default behavior, each token only receives gradients from its own rank's local experts.

The model still trains (residual connections preserve gradient flow), but the MoE block's gradient contribution to earlier layers is incomplete, causing the convergence gap.

### Fix

**1. `grad_placements=[Partial()]` for the input all-gather** (primary fix)

```python
x = DTensor.from_local(x, ..., placements=[Shard(0)]).full_tensor(grad_placements=[Partial()])
weights = DTensor.from_local(weights.float(), ..., placements=[Shard(0)]).full_tensor(grad_placements=[Partial()])
```

`Partial()` tells DTensor the gradient is a partial sum across ranks, triggering a **reduce-scatter** in the backward. This correctly accumulates gradient contributions from all EP ranks.

**2. Restructured `_forward_loop` to match DeepEP compute pattern**

The loop path now separates up-projection, weighted activation (via `WeightedSwiGLUFunction`), and down-projection — matching the grouped-mm path and `GroupedExpertsDeepEP` exactly. Routing weights are applied between up and down projections instead of after.

**3. Float32 `scatter_add` accumulation**

Both `_forward_loop` and `_forward_grouped_mm` now use float32 accumulation buffers for `scatter_add_`, with a single cast back to input dtype in `forward()`.