### PR TITLE
fix: resume activation_checkpointing setting in qwen3_moe_30b_lora recipe

### DIFF
--- a/examples/llm_finetune/qwen/qwen3_moe_30b_lora.yaml
+++ b/examples/llm_finetune/qwen/qwen3_moe_30b_lora.yaml
@@ -58,6 +58,7 @@ distributed:
   cp_size: 1
   pp_size: 1
   ep_size: 8
+  activation_checkpointing: true
 
 loss_fn:
   _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy


### PR DESCRIPTION


# What does this PR do ?

Activation_checkpointing is needed in this recipe to fit in the memory. It was mistakenly remove in the recent commit
```
git diff 194103bfc0a9cdccf1874b3ddf18cb87d9c84821~ 194103bfc0a9cdccf1874b3ddf18cb87d9c84821  examples/llm_finetune/qwen/qwen3_moe_30b_lora.yaml
diff --git a/examples/llm_finetune/qwen/qwen3_moe_30b_lora.yaml b/examples/llm_finetune/qwen/qwen3_moe_30b_lora.yaml
index 1ce0a506..f9c977f7 100644
--- a/examples/llm_finetune/qwen/qwen3_moe_30b_lora.yaml
+++ b/examples/llm_finetune/qwen/qwen3_moe_30b_lora.yaml
@@ -52,19 +52,13 @@ checkpoint:
   checkpoint_dir: checkpoints/qwen3_moe_lora
   model_save_format: safetensors
 
-moe_config:
-  _target_: nemo_automodel.components.moe.config.MoEParallelizerConfig
-  activation_checkpointing: true
-
 distributed:
+  strategy: fsdp2
   tp_size: 1
   cp_size: 1
   pp_size: 1
   ep_size: 8
 
-distributed_config:
-  _target_: nemo_automodel.components.distributed.config.FSDP2Config
-
 loss_fn:
   _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
```
`activation_checkpointing: true` was in moe_config.

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
