### PR TITLE
ci: Update release-docs workflow to use FW-CI-templates v0.72.0

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -26,9 +26,19 @@ on:
         required: true
         type: boolean
         default: false
+      publish-as-latest:
+        description: Publish as Latest stable version.
+        required: false
+        type: boolean
+        default: true
+      docs-version-override:
+        description: Docs version if commit is not tagged
+        required: false
+        type: string
+        default: ""
       notify-emails:
         description: Email addresses to send the notification to. Format as "me@me.com,you@you.com".
-        required: true
+        required: false
         type: string
         default: "akoumparouli@nvidia.com"
       aws-region:
@@ -52,7 +62,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           repository: NVIDIA-NeMo/FW-CI-templates
-          ref: v0.67.2
+          ref: v0.72.0
           path: FW-CI-templates
 
       - uses: ./FW-CI-templates/.github/actions/publish-docs
@@ -66,10 +76,11 @@ jobs:
           artifacts-name: docs-html
           artifacts-path: _build/html
           emails-csv: ${{ env.NOTIFY_EMAILS }}
-          overwrite-latest-on-tag: false
+          overwrite-latest-on-tag: ${{ inputs.publish-as-latest }}
+          docs-version-override: ${{ inputs.docs-version-override }}
           run-on-version-tag-only: ${{ github.ref_name != 'main' }}
           request-name: automodel-publish-docs-${{ github.run_id }}
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ vars.DOCS_AWS_REGION }}
           aws-role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
# What does this PR do ?

ci: Update release-docs workflow to use FW-CI-templates v0.72.0

The latest tag in some repos was whatever was published from main branch. However, we will now designate "latest" as the latest stable version. A follow-up change will include publshing docs as part of the release repo workflow. And we will also begin to publish "nightly" docs from the main branch.

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
