### PR TITLE
fix: skip load-before-shard when expert parallelism is active

### DIFF
--- a/nemo_automodel/_transformers/utils.py
+++ b/nemo_automodel/_transformers/utils.py
@@ -12,9 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any
+from typing import Any, Optional
 
 from transformers import AutoConfig
+
+
+def _should_load_before_shard(
+    *,
+    autopipeline: Optional[object],
+    tp_size: int,
+    ep_size: int,
+    pretrained_model_name_or_path: str,
+    load_base_model: bool,
+    peft_config: Optional[object],
+) -> bool:
+    """Decide whether to load the checkpoint before FSDP/TP/EP sharding.
+
+    Load-before-shard is only safe when running single-GPU (no PP, TP, or EP),
+    a checkpoint actually needs loading, and no PEFT adapter is involved.
+    With any model parallelism the post-shard load path must be used to avoid
+    NCCL collective mismatches or key/device inconsistencies.
+    """
+    no_pp = autopipeline is None
+    no_tp = tp_size <= 1
+    no_ep = ep_size <= 1
+    need_checkpoint_load = bool(pretrained_model_name_or_path and load_base_model)
+    return no_pp and no_tp and no_ep and need_checkpoint_load and (peft_config is None)
 
 
 def sliding_window_overwrite(model_name: str) -> dict[str, Any]:

--- a/tests/unit_tests/_transformers/test_infrastructure.py
+++ b/tests/unit_tests/_transformers/test_infrastructure.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from nemo_automodel._transformers.utils import _should_load_before_shard
+
+
+class TestShouldLoadBeforeShard:
+    """Tests for _should_load_before_shard.
+
+    load_before_shard should be True only when ALL of these hold:
+      - no pipeline parallelism (autopipeline is None)
+      - no tensor parallelism (tp_size <= 1)
+      - no expert parallelism (ep_size <= 1)
+      - checkpoint needs loading (pretrained_model_name_or_path and load_base_model)
+      - no PEFT (peft_config is None)
+    """
+
+    # Defaults that satisfy all conditions (single-GPU checkpoint load, no PEFT).
+    _DEFAULTS = dict(
+        autopipeline=None,
+        tp_size=1,
+        ep_size=1,
+        pretrained_model_name_or_path="/some/path",
+        load_base_model=True,
+        peft_config=None,
+    )
+
+    def test_single_gpu_loads_before_shard(self):
+        """With no parallelism and a valid checkpoint path, should load before shard."""
+        assert _should_load_before_shard(**self._DEFAULTS) is True
+
+    def test_ep_greater_than_1_skips_load_before_shard(self):
+        """With EP > 1, should NOT load before shard."""
+        assert _should_load_before_shard(**{**self._DEFAULTS, "ep_size": 2}) is False
+
+    def test_tp_greater_than_1_skips_load_before_shard(self):
+        """With TP > 1, should NOT load before shard."""
+        assert _should_load_before_shard(**{**self._DEFAULTS, "tp_size": 2}) is False
+
+    def test_pp_skips_load_before_shard(self):
+        """With pipeline parallelism, should NOT load before shard."""
+        assert _should_load_before_shard(**{**self._DEFAULTS, "autopipeline": object()}) is False
+
+    def test_peft_skips_load_before_shard(self):
+        """With PEFT config, should NOT load before shard."""
+        assert _should_load_before_shard(**{**self._DEFAULTS, "peft_config": object()}) is False
+
+    def test_no_pretrained_path_skips_load_before_shard(self):
+        """Without a pretrained path, should NOT load before shard."""
+        assert _should_load_before_shard(**{**self._DEFAULTS, "pretrained_model_name_or_path": ""}) is False
+
+    def test_load_base_model_false_skips_load_before_shard(self):
+        """With load_base_model=False, should NOT load before shard."""
+        assert _should_load_before_shard(**{**self._DEFAULTS, "load_base_model": False}) is False
+
+    @pytest.mark.parametrize(
+        "tp_size,ep_size",
+        [
+            (2, 2),
+            (4, 1),
+            (1, 4),
+            (2, 4),
+        ],
+        ids=["tp2_ep2", "tp4_ep1", "tp1_ep4", "tp2_ep4"],
+    )
+    def test_any_parallelism_skips_load_before_shard(self, tp_size, ep_size):
+        """Any TP or EP > 1 should skip load-before-shard."""
+        assert _should_load_before_shard(**{**self._DEFAULTS, "tp_size": tp_size, "ep_size": ep_size}) is False
+
+    def test_all_conditions_false(self):
+        """When every condition blocks, result is still False."""
+        assert (
+            _should_load_before_shard(
+                tp_size=2,
+                ep_size=4,
+                autopipeline=object(),
+                pretrained_model_name_or_path="",
+                load_base_model=False,
+                peft_config=object(),
+            )
+            is False
+        )
+
+    def test_ep_size_exactly_1_allows_load(self):
+        """ep_size=1 should not block load-before-shard."""
+        assert _should_load_before_shard(**{**self._DEFAULTS, "ep_size": 1}) is True


### PR DESCRIPTION
When EP > 1, loading the checkpoint before FSDP/EP sharding can cause issues.

This adds `ep_size` to the `load_before_shard` condition so that EP configurations use the post-shard checkpoint loading path.

- Extract `_should_load_before_shard()` helper into `_transformers/utils.py` for testability (avoids heavy transformer_engine import chain)
- Call the helper from `apply_model_infrastructure()` in `infrastructure.py`
- Add 13 unit tests covering every condition of the load-before-shard decision (EP, TP, PP, PEFT, pretrained path, load_base_model, and parametrized combinations)