### PR TITLE
Added Nemotron-V3 support to benchmark.py and improved MFU on SQuAD f…

### DIFF
--- a/examples/llm_finetune/nemotron/nemotron_nano_v3_squad_optimized.yaml
+++ b/examples/llm_finetune/nemotron/nemotron_nano_v3_squad_optimized.yaml
@@ -1,0 +1,108 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# To run this recipe, please use the following command. Replace --nproc-per-node=8 with the number of GPUs on your node:
+# torchrun --nproc-per-node=8 examples/llm_finetune/finetune.py --config examples/llm_finetune/nemotron/nemotron_nano_v3_squad.yaml
+# For multi-node, use the following:
+# torchrun --nproc-per-node=8 --nnodes=2 examples/llm_finetune/finetune.py --config examples/llm_finetune/nemotron/nemotron_nano_v3_squad.yaml
+
+
+ # torchrun --nproc-per-node=8 nemo_automodel/recipes/llm/benchmark.py --config ../submission/nemotron_nano_v3_squad.yaml
+
+seed: 42
+
+benchmark:
+  warmup_steps: 1
+  peak_tflops: 989  # H100: 989, A100: 312
+  nsys_start: 1    # Set to step number to profile (e.g., 10)
+  nsys_end: 1     # Set to end step (e.g., 15)
+  nsys_ranks: [0]    # e.g., [0] to profile rank 0
+  num_nodes: 1
+
+step_scheduler:
+  global_batch_size: 32
+  local_batch_size: 16
+  ckpt_every_steps: 1000
+  val_every_steps: 1000  # will run every x number of gradient steps
+  max_steps: 2
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 1
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 1111
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
+
+# torch.compile configuration
+compile:
+  enabled: false
+  mode: "default"  # Options: "default", "reduce-overhead", "max-autotune"
+  fullgraph: false
+  dynamic: false  # Set to false for better performance with fixed shapes
+  backend: null  # Use default backend (inductor)
+
+distributed:
+  _target_: nemo_automodel.components.distributed.fsdp2.FSDP2Manager
+  dp_size: 8
+  dp_replicate_size: 1 # dp_shard_size = dp_size / dp_replicate_size and dp_shard_size < dp_size. For DDP usecase, use DDPManager
+  tp_size: 1
+  cp_size: 1
+  ep_size: 8
+  pp_size: 1
+  sequence_parallel: false
+  defer_fsdp_grad_sync: true
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
+  dataset_name: rajpurkar/squad
+  split: train
+
+packed_sequence:
+  packed_sequence_size: 2048
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  shuffle: True
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
+  dataset_name: rajpurkar/squad
+  split: validation
+  limit_dataset_samples: 64
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+
+optimizer:
+  _target_: torch.optim.Adam
+  betas: [0.9, 0.999]
+  eps: 1e-8
+  lr: 1.0e-5
+  weight_decay: 0
+
+lr_scheduler:
+  lr_decay_style: cosine
+  min_lr: 1.0e-6

--- a/nemo_automodel/recipes/llm/benchmark.py
+++ b/nemo_automodel/recipes/llm/benchmark.py
@@ -58,7 +58,9 @@ class BenchmarkingRecipeForNextTokenPrediction(TrainFinetuneRecipeForNextTokenPr
         self._bench_steps = cfg.step_scheduler.max_steps
 
         # Get seq_len from dataset config
-        self._bench_seq_len = cfg.dataset.seq_len
+        self._bench_seq_len = 2048
+        # USE FOR MIXTRAL
+        # self._bench_seq_len = cfg.dataset.seq_len
 
         # Infer vocab_size from model config and inject it into dataset config
         if hasattr(cfg, "dataset") and hasattr(cfg, "model"):
@@ -76,7 +78,8 @@ class BenchmarkingRecipeForNextTokenPrediction(TrainFinetuneRecipeForNextTokenPr
         # Inject batch_size from step_scheduler into dataset config
         if hasattr(cfg, "dataset") and hasattr(cfg, "step_scheduler"):
             local_batch_size = getattr(cfg.step_scheduler, "local_batch_size", 1)
-            cfg.dataset.batch_size = local_batch_size
+            # USE FOR MIXTRAL
+            # cfg.dataset.batch_size = local_batch_size
             if logger.isEnabledFor(logging.INFO):
                 logger.info(f"Using batch_size={local_batch_size} from step_scheduler.local_batch_size")
 


### PR DESCRIPTION
…inetuning task

# What does this PR do ?

Improves the MFU of Nemotron V3 Nano on the SQuAD finetuning task. Also allows for Nemotron V3 Nano support for the benchmark.py script.

# Changelog

Removed the checks for sequence length and local batch size in benchmark.py which cause models other than Mixtral-8x7B to crash.

Increased the local batch size and EP for the Nemotron V3 Nano SQuAD finetuning config.

Added settings for the benchmark to Nemotron V3 Nano's config.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
