### PR TITLE
fix: correctly resume moe lora ckpt

### DIFF
--- a/tests/functional_tests/hf_transformer_finetune/L2_HF_Transformer_Qwen3_MoE_LoRA_ckpt_resume.sh
+++ b/tests/functional_tests/hf_transformer_finetune/L2_HF_Transformer_Qwen3_MoE_LoRA_ckpt_resume.sh
@@ -28,6 +28,7 @@ TRANSFORMERS_OFFLINE=1 python -m torch.distributed.run --nproc_per_node=2 --nnod
     --config examples/llm_finetune/qwen/qwen3_moe_2layer_proxy_lora.yaml \
     --step_scheduler.max_steps 5 \
     --step_scheduler.ckpt_every_steps 5 \
+    --dataset.split "train[:200]" \
     --checkpoint.checkpoint_dir $CKPT_DIR
 
 # 2. Resume from checkpoint
@@ -36,6 +37,7 @@ TRANSFORMERS_OFFLINE=1 python -m torch.distributed.run --nproc_per_node=2 --nnod
     examples/llm_finetune/finetune.py \
     --config examples/llm_finetune/qwen/qwen3_moe_2layer_proxy_lora.yaml \
     --step_scheduler.max_steps 10 \
+    --dataset.split "train[:200]" \
     --checkpoint.checkpoint_dir $CKPT_DIR
 
 echo "Test passed!"


### PR DESCRIPTION
## Problem

Resuming training of MoE LoRA or QLoRA models from a checkpoint causes a loss spike (back to random-init levels). The LoRA adapter weights are silently not loaded.

## Root Cause

PyTorch DCP (`get_model_state_dict` / `set_model_state_dict`) loading cannot handle:
- **EP (Expert Parallelism):** MoE expert modules use custom FQNs (e.g. `gate_up_linear.weight0`) that DCP's FQN resolution cannot traverse → `KeyError` on save, silent skip on load, i.e. the model weight is from scratch.


## Solution

Bypass DCP entirely for PEFT models with EP or quantization. All changes in `nemo_automodel/components/checkpoint/stateful_wrappers.py`:

- **Load:** `_set_peft_state_dict()` — matches saved tensors by name, redistributes full tensors back into EP DTensor shards.

## Test
* loss curve matched now: https://wandb.ai/nvidia/automodel-dev-zhiyul/workspace?nw=9bbvcvbsr3k

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
