### PR TITLE
fix: correct total parameter count for quantized models 

### DIFF
--- a/nemo_automodel/components/utils/model_utils.py
+++ b/nemo_automodel/components/utils/model_utils.py
@@ -81,7 +81,7 @@ def _get_logical_numel(param) -> int:
     packs multiple values per byte. We recover the logical count from
     the original shape stored in param.quant_state.
     """
-    if HAVE_BNB and isinstance(param, bnb.nn.Params4bit) and getattr(param, 'quant_state', None) is not None:
+    if HAVE_BNB and isinstance(param, bnb.nn.Params4bit) and getattr(param, "quant_state", None) is not None:
         return math.prod(param.quant_state.shape)
     return param.numel()
 


### PR DESCRIPTION
Before
```
INFO:root:--------------------------------
INFO:root:Trainable parameters: 1,050,939,392
INFO:root:Total parameters: 4,540,600,320
INFO:root:Trainable parameters percentage: 23.15%
INFO:root:Param L2 norm: 8063837.3990
```

After
```
INFO:root:--------------------------------
INFO:root:Trainable parameters: 1,050,939,392
INFO:root:Total parameters: 8,030,261,248
INFO:root:Trainable parameters percentage: 13.09%
INFO:root:Param L2 norm: 8063837.3990
INFO:root:--------------------------------
```

Fixes #1290 