### PR TITLE
feat: add load_base_model option to from_config

### DIFF
--- a/nemo_automodel/_transformers/auto_model.py
+++ b/nemo_automodel/_transformers/auto_model.py
@@ -498,11 +498,12 @@ class _BaseNeMoAutoModelClass(_BaseAutoModelClass):
         peft_config: Optional[dict] = None,
         fp8_config: Optional["FP8Config"] = None,
         compile_config: Optional["CompileConfig"] = None,
+        load_base_model: bool = False,
         **kwargs,
     ) -> PreTrainedModel:
         """
-        Instantiate a model from a ``transformers.PretrainedConfig`` (no pretrained
-        weights). Accepts the same infrastructure arguments as ``from_pretrained``.
+        Instantiate a model from a ``transformers.PretrainedConfig`` and optionally
+        load pretrained weights. Accepts the same infrastructure arguments as ``from_pretrained``.
 
         See ``from_pretrained`` for full parameter documentation.
 
@@ -513,6 +514,8 @@ class _BaseNeMoAutoModelClass(_BaseAutoModelClass):
                 it will create a config internally using AutoConfig.
             torch_dtype (str | torch.dtype, default="auto"):
                 Data type for model parameters. If "auto", defaults to ``torch.bfloat16``.
+            load_base_model (bool, default=False): If ``True``, load pretrained
+                base model weights from the HuggingFace checkpoint after initialization.
         """
         if tp_plan is not None and distributed_config is not None:
             distributed_config.tp_plan = tp_plan
@@ -573,7 +576,7 @@ class _BaseNeMoAutoModelClass(_BaseAutoModelClass):
             peft_config=peft_config,
             fp8_config=fp8_config,
             compile_config=compile_config,
-            load_base_model=False,
+            load_base_model=load_base_model,
             **kwargs,
         )
 


### PR DESCRIPTION
## Summary
- Adds a `load_base_model: bool = False` parameter to `_BaseNeMoAutoModelClass.from_config()` so that config-based model initialization can optionally load pretrained HuggingFace checkpoint weights
- Forwards the parameter through the `_retry()` helper and into `apply_model_infrastructure()`
- Default is `False`, preserving existing behavior (random initialization)

## Motivation
Previously, `from_config()` always hardcoded `load_base_model=False`, making it impossible to load pretrained weights when using config-based initialization. This is needed for continued pretraining and fine-tuning workflows that prefer `from_config` over `from_pretrained` (e.g., to customize architecture settings via config).

### Usage
```yaml
model:
  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_config
  config:
    _target_: transformers.AutoConfig.from_pretrained
    pretrained_model_name_or_path: openai-community/gpt2
  load_base_model: true
```

## Test plan
- [ ] Verify `from_config()` without `load_base_model` still produces randomly initialized weights (default behavior unchanged)
- [ ] Verify `from_config(load_base_model=True)` loads pretrained weights from HuggingFace checkpoint
- [ ] Verify `_retry()` preserves the `load_base_model` flag across fallback attempts
- [ ] Existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)