### PR TITLE
refactor: extract initialize_model_weights from load_base_model

### DIFF
--- a/nemo_automodel/_transformers/auto_model.py
+++ b/nemo_automodel/_transformers/auto_model.py
@@ -573,7 +573,7 @@ class _BaseNeMoAutoModelClass(_BaseAutoModelClass):
             peft_config=peft_config,
             fp8_config=fp8_config,
             compile_config=compile_config,
-            load_base_model=False,
+            load_base_model=kwargs.pop("load_base_model", False),
             **kwargs,
         )
 

--- a/tests/unit_tests/_transformers/test_infrastructure.py
+++ b/tests/unit_tests/_transformers/test_infrastructure.py
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
+
 import pytest
+import torch
 
 from nemo_automodel._transformers.utils import _should_load_before_shard
 
@@ -97,3 +101,230 @@ class TestShouldLoadBeforeShard:
     def test_ep_size_exactly_1_allows_load(self):
         """ep_size=1 should not block load-before-shard."""
         assert _should_load_before_shard(**{**self._DEFAULTS, "ep_size": 1}) is True
+
+
+# =============================================================================
+# Tests for apply_model_infrastructure: post-shard initialize_model_weights
+# =============================================================================
+
+
+class _DummyModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = torch.nn.Linear(4, 4)
+        self.config = SimpleNamespace()
+
+
+_INFRA_MODULE = "nemo_automodel._transformers.infrastructure"
+
+
+def _run_apply_model_infrastructure(*, is_meta_device, load_base_model, model_wrapper=None):
+    """Helper that invokes apply_model_infrastructure with heavy dependencies stubbed out."""
+    from nemo_automodel._transformers.infrastructure import apply_model_infrastructure
+
+    model = _DummyModel()
+
+    with (
+        patch(f"{_INFRA_MODULE}.get_world_size_safe", return_value=1),
+        patch(f"{_INFRA_MODULE}._supports_logits_to_keep", return_value=True),
+        patch(f"{_INFRA_MODULE}.print_trainable_parameters"),
+        patch(f"{_INFRA_MODULE}._should_load_before_shard", return_value=False),
+        patch(f"{_INFRA_MODULE}.Checkpointer") as MockCheckpointer,
+    ):
+        mock_ckpt = MockCheckpointer.return_value
+        mock_ckpt.config = MagicMock()
+        mock_ckpt.config.dequantize_base_checkpoint = False
+
+        result = apply_model_infrastructure(
+            model=model,
+            is_meta_device=is_meta_device,
+            device=torch.device("cpu"),
+            load_base_model=load_base_model,
+            model_wrapper=model_wrapper,
+            pretrained_model_name_or_path="test/model" if load_base_model else "",
+        )
+
+        return result, mock_ckpt
+
+
+class TestApplyModelInfrastructurePostShardInit:
+    """Tests for initialize_model_weights being called in apply_model_infrastructure."""
+
+    def test_from_config_meta_calls_initialize_model_weights(self):
+        """from_config path (load_base_model=False) on meta device should call initialize_model_weights."""
+        _, mock_ckpt = _run_apply_model_infrastructure(is_meta_device=True, load_base_model=False)
+
+        mock_ckpt.initialize_model_weights.assert_called_once()
+
+    def test_from_config_meta_does_not_call_load_base_model(self):
+        """from_config path should NOT call load_base_model (no checkpoint to load)."""
+        _, mock_ckpt = _run_apply_model_infrastructure(is_meta_device=True, load_base_model=False)
+
+        mock_ckpt.load_base_model.assert_not_called()
+
+    def test_from_pretrained_meta_calls_both(self):
+        """from_pretrained path on meta device should call both initialize_model_weights and load_base_model."""
+        _, mock_ckpt = _run_apply_model_infrastructure(is_meta_device=True, load_base_model=True)
+
+        mock_ckpt.initialize_model_weights.assert_called_once()
+        mock_ckpt.load_base_model.assert_called_once()
+
+    def test_non_meta_skips_initialize_model_weights(self):
+        """Non-meta device model should not call initialize_model_weights."""
+        _, mock_ckpt = _run_apply_model_infrastructure(is_meta_device=False, load_base_model=False)
+
+        mock_ckpt.initialize_model_weights.assert_not_called()
+
+    def test_megatron_fsdp_skips_post_shard_init(self):
+        """MegatronFSDPManager wrapper should skip post-shard initialize_model_weights."""
+        mock_wrapper = MagicMock(spec=["parallelize", "moe_mesh"])
+        mock_wrapper.moe_mesh = None
+        # Make isinstance check work for MegatronFSDPManager
+        from nemo_automodel.components.distributed.megatron_fsdp import MegatronFSDPManager
+
+        mock_wrapper.__class__ = MegatronFSDPManager
+
+        _, mock_ckpt = _run_apply_model_infrastructure(
+            is_meta_device=True, load_base_model=False, model_wrapper=mock_wrapper
+        )
+
+        mock_ckpt.initialize_model_weights.assert_not_called()
+
+    def test_peft_init_method_forwarded_to_initialize_model_weights(self):
+        """peft_config.lora_A_init should be forwarded as peft_init_method."""
+        from nemo_automodel._transformers.infrastructure import apply_model_infrastructure
+
+        model = _DummyModel()
+        peft_config = SimpleNamespace(lora_A_init="xavier", use_triton=False)
+
+        with (
+            patch(f"{_INFRA_MODULE}.get_world_size_safe", return_value=1),
+            patch(f"{_INFRA_MODULE}._supports_logits_to_keep", return_value=True),
+            patch(f"{_INFRA_MODULE}.print_trainable_parameters"),
+            patch(f"{_INFRA_MODULE}._should_load_before_shard", return_value=False),
+            patch(f"{_INFRA_MODULE}._apply_peft_and_lower_precision", return_value=model),
+            patch(f"{_INFRA_MODULE}.Checkpointer") as MockCheckpointer,
+        ):
+            mock_ckpt = MockCheckpointer.return_value
+            mock_ckpt.config = MagicMock()
+            mock_ckpt.config.dequantize_base_checkpoint = False
+
+            apply_model_infrastructure(
+                model=model,
+                is_meta_device=True,
+                device=torch.device("cpu"),
+                load_base_model=False,
+                peft_config=peft_config,
+                pretrained_model_name_or_path="",
+            )
+
+            mock_ckpt.initialize_model_weights.assert_called_once_with(
+                model, torch.device("cpu"), peft_init_method="xavier"
+            )
+
+
+# =============================================================================
+# Tests for load_before_shard path in apply_model_infrastructure
+# =============================================================================
+
+
+def _run_apply_model_infrastructure_load_before_shard(*, peft_config=None):
+    """Helper that invokes apply_model_infrastructure with load_before_shard=True."""
+    from nemo_automodel._transformers.infrastructure import apply_model_infrastructure
+
+    model = _DummyModel()
+
+    with (
+        patch(f"{_INFRA_MODULE}.get_world_size_safe", return_value=1),
+        patch(f"{_INFRA_MODULE}._supports_logits_to_keep", return_value=True),
+        patch(f"{_INFRA_MODULE}.print_trainable_parameters"),
+        patch(f"{_INFRA_MODULE}._should_load_before_shard", return_value=True),
+        patch(f"{_INFRA_MODULE}.Checkpointer") as MockCheckpointer,
+    ):
+        mock_ckpt = MockCheckpointer.return_value
+        mock_ckpt.config = MagicMock()
+        mock_ckpt.config.dequantize_base_checkpoint = False
+
+        result = apply_model_infrastructure(
+            model=model,
+            is_meta_device=True,
+            device=torch.device("cpu"),
+            load_base_model=True,
+            peft_config=peft_config,
+            pretrained_model_name_or_path="test/model",
+            cache_dir="/tmp/cache",
+        )
+
+        return result, mock_ckpt, model
+
+
+class TestLoadBeforeShardPath:
+    """Tests for the load_before_shard code path in apply_model_infrastructure."""
+
+    def test_load_before_shard_calls_initialize_then_load(self):
+        """load_before_shard should call initialize_model_weights before load_base_model."""
+        _, mock_ckpt, model = _run_apply_model_infrastructure_load_before_shard()
+
+        mock_ckpt.initialize_model_weights.assert_called_once_with(
+            model, torch.device("cpu"), peft_init_method=None
+        )
+        mock_ckpt.load_base_model.assert_called_once_with(
+            model, torch.device("cpu"), "/tmp/cache", "test/model", load_base_model=True
+        )
+
+        init_idx = mock_ckpt.method_calls.index(
+            call.initialize_model_weights(model, torch.device("cpu"), peft_init_method=None)
+        )
+        load_idx = mock_ckpt.method_calls.index(
+            call.load_base_model(model, torch.device("cpu"), "/tmp/cache", "test/model", load_base_model=True)
+        )
+        assert init_idx < load_idx
+
+    def test_load_before_shard_skips_post_shard_init(self):
+        """When load_before_shard is True, post-shard initialize_model_weights should not run again."""
+        _, mock_ckpt, _ = _run_apply_model_infrastructure_load_before_shard()
+
+        assert mock_ckpt.initialize_model_weights.call_count == 1
+
+    def test_load_before_shard_does_not_call_load_base_model_with_peft_init_method(self):
+        """load_base_model should NOT receive peft_init_method (moved to initialize_model_weights)."""
+        _, mock_ckpt, _ = _run_apply_model_infrastructure_load_before_shard()
+
+        _, kwargs = mock_ckpt.load_base_model.call_args
+        assert "peft_init_method" not in kwargs
+
+
+# =============================================================================
+# Tests for from_config load_base_model kwarg forwarding
+# =============================================================================
+
+
+class TestFromConfigLoadBaseModelKwarg:
+    """Tests for from_config accepting and forwarding load_base_model as a kwarg."""
+
+    def test_from_config_defaults_load_base_model_to_false(self):
+        """from_config should default load_base_model to False when not provided."""
+        from nemo_automodel._transformers.auto_model import _BaseNeMoAutoModelClass
+
+        with patch.object(_BaseNeMoAutoModelClass, "_build_model", return_value=MagicMock()) as mock_build:
+            _BaseNeMoAutoModelClass.from_config(
+                config=MagicMock(name_or_path="test"),
+                trust_remote_code=False,
+            )
+
+        _, build_kwargs = mock_build.call_args
+        assert build_kwargs["load_base_model"] is False
+
+    def test_from_config_forwards_load_base_model_true(self):
+        """from_config should forward load_base_model=True when provided as kwarg."""
+        from nemo_automodel._transformers.auto_model import _BaseNeMoAutoModelClass
+
+        with patch.object(_BaseNeMoAutoModelClass, "_build_model", return_value=MagicMock()) as mock_build:
+            _BaseNeMoAutoModelClass.from_config(
+                config=MagicMock(name_or_path="test"),
+                trust_remote_code=False,
+                load_base_model=True,
+            )
+
+        _, build_kwargs = mock_build.call_args
+        assert build_kwargs["load_base_model"] is True


### PR DESCRIPTION
## Summary
- Extract weight initialization logic from `Checkpointer.load_base_model` into a new `Checkpointer.initialize_model_weights` static method, so `from_config` (which skips checkpoint loading) can still materialize meta-device parameters and call `initialize_weights`
- Move `_init_peft_adapters` into `initialize_model_weights` via a new `peft_init_method` parameter, keeping PEFT adapter init alongside weight init regardless of checkpoint loading path
- Add `need_post_shard_init` block in `apply_model_infrastructure` that calls `initialize_model_weights` after parallelisms are applied, decoupled from the checkpoint loading condition
- Make `from_config` accept `load_base_model` as a kwarg (defaults to `False`) for flexibility

## Test plan
- [x] Added 11 new unit tests for `initialize_model_weights` (materialization, HF init reset, Nemotron skip, peft_init_method forwarding, signature check)
- [x] Added 3 tests for the `load_before_shard` path (call ordering, single init call, no peft_init_method in load_base_model)
- [x] Added 1 test for peft_init_method forwarding through `apply_model_infrastructure`
- [x] Added 5 tests for post-shard init (from_config, from_pretrained, non-meta, MegatronFSDP skip)
- [x] Added 2 tests for `from_config` load_base_model kwarg forwarding
- [x] All 62 tests pass (`pytest tests/unit_tests/checkpoint/test_checkpointing.py tests/unit_tests/_transformers/test_infrastructure.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)