### PR TITLE
fix: prefer moe_config for num_experts in apply_ac

### DIFF
--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -112,7 +112,8 @@ def apply_ac(
         model: The model to apply activation checkpointing to.
         ignore_router: If True, uses selective checkpointing that saves router outputs.
         hidden_size: Hidden dimension size. If None, derived from model.config.hidden_size.
-        num_experts: Number of routed experts. If None, derived from model.config.num_experts.
+        num_experts: Number of routed experts. If None, derived from moe_config.n_routed_experts
+            first, then falls back to model.config attributes.
     """
     # Derive hidden_size and num_experts from model.config if not provided
     if hidden_size is None:
@@ -122,12 +123,16 @@ def apply_ac(
             raise ValueError("hidden_size must be provided or model must have config.hidden_size attribute")
 
     if num_experts is None:
-        for attr in ["num_experts", "moe_num_experts", "n_routed_experts"]:
-            if hasattr(model, "config") and hasattr(model.config, attr):
-                num_experts = getattr(model.config, attr)
-                break
+        _inner = getattr(model, "model", model)
+        if hasattr(_inner, "moe_config") and hasattr(_inner.moe_config, "n_routed_experts"):
+            num_experts = _inner.moe_config.n_routed_experts
         else:
-            raise ValueError("num_experts must be provided or model must have config.num_experts attribute")
+            for attr in ["num_experts", "moe_num_experts", "n_routed_experts"]:
+                if hasattr(model, "config") and hasattr(model.config, attr):
+                    num_experts = getattr(model.config, attr)
+                    break
+            else:
+                raise ValueError("num_experts must be provided or model must have config.num_experts attribute")
 
     def _custom_policy(ctx, func, *args, **kwargs):
         if func == torch.ops.aten.mm.default:


### PR DESCRIPTION
## Summary
- In `apply_ac`, the `num_experts` config field name varies across HuggingFace model configs (`num_experts`, `moe_num_experts`, `n_routed_experts`, etc.)
- Now prioritizes `moe_config.n_routed_experts` (which has a stable, well-defined field name) before falling back to scanning `model.config` attributes
- Added tests verifying `moe_config` derivation and its priority over config attributes

## Test plan
- [x] `test_apply_ac_derives_num_experts_from_moe_config` — verifies moe_config path works
- [x] `test_apply_ac_prefers_moe_config_over_config_attrs` — verifies moe_config takes priority
- [x] All 38 existing parallelizer tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)