### PR TITLE
fix: skip instantiation of nested configs overridden by kwargs in ConfigNode

### DIFF
--- a/nemo_automodel/components/config/loader.py
+++ b/nemo_automodel/components/config/loader.py
@@ -456,6 +456,8 @@ class ConfigNode:
         for k, v in self.__dict__.items():
             if k in ("_target_", "raise_on_missing_attr", "_raw_config", "_original_strings"):
                 continue
+            if k in kwargs:
+                continue  # will be overridden — skip expensive instantiation
             if k.endswith("_fn"):
                 config_kwargs[k] = v
             else:


### PR DESCRIPTION
- `ConfigNode.instantiate()` unconditionally resolved all nested `_target_` configs via `_instantiate_value()` **before** applying `**kwargs` overrides. When callers passed a pre-built object as a kwarg, the nested config was instantiated wastefully and the result immediately discarded.
- Added a one-line early `continue` to skip `_instantiate_value()` for keys already present in `kwargs`.
- This eliminates the double-instantiation problem that recipes currently work around (e.g. `del cfg_dl.dataset` in biencoder, lambda-wrapping `collate_fn` in LLM fine-tuning).


**Pre checks**:

- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [X] Did you write any new necessary tests?
- [X] Did you add or update any necessary documentation?

