### PR TITLE
refactor: use auto_map for faster init

### DIFF
--- a/nemo_automodel/_transformers/registry.py
+++ b/nemo_automodel/_transformers/registry.py
@@ -13,82 +13,202 @@
 # limitations under the License.
 
 
-# Adapted from https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/models/registry.py
-
 import importlib
 import logging
-import pkgutil
+from collections import OrderedDict
 from dataclasses import dataclass, field
 from functools import lru_cache
-from typing import Dict, List, Type, Union
+from typing import Dict, Tuple, Type, Union
 
 import torch.nn as nn
 
 logger = logging.getLogger(__name__)
 
-MODELING_PATH = ["nemo_automodel.components.models"]
+# Static mapping: architecture name → (module_path, class_name).
+# Analogous to HuggingFace transformers' MODEL_FOR_CAUSAL_LM_MAPPING_NAMES.
+# Models are loaded lazily on first access rather than imported at startup.
+MODEL_ARCH_MAPPING = OrderedDict(
+    [
+        (
+            "DeepseekV3ForCausalLM",
+            ("nemo_automodel.components.models.deepseek_v3.model", "DeepseekV3ForCausalLM"),
+        ),
+        (
+            "DeepseekV32ForCausalLM",
+            ("nemo_automodel.components.models.deepseek_v32.model", "DeepseekV32ForCausalLM"),
+        ),
+        (
+            "Glm4MoeForCausalLM",
+            ("nemo_automodel.components.models.glm4_moe.model", "Glm4MoeForCausalLM"),
+        ),
+        (
+            "Glm4MoeLiteForCausalLM",
+            ("nemo_automodel.components.models.glm4_moe_lite.model", "Glm4MoeLiteForCausalLM"),
+        ),
+        (
+            "GptOssForCausalLM",
+            ("nemo_automodel.components.models.gpt_oss.model", "GptOssForCausalLM"),
+        ),
+        (
+            "KimiK25VLForConditionalGeneration",
+            ("nemo_automodel.components.models.kimi_k25_vl.model", "KimiK25VLForConditionalGeneration"),
+        ),
+        (
+            "KimiVLForConditionalGeneration",
+            ("nemo_automodel.components.models.kimivl.model", "KimiVLForConditionalGeneration"),
+        ),
+        (
+            "LlamaBidirectionalForSequenceClassification",
+            (
+                "nemo_automodel.components.models.llama_bidirectional.model",
+                "LlamaBidirectionalForSequenceClassification",
+            ),
+        ),
+        (
+            "LlamaBidirectionalModel",
+            ("nemo_automodel.components.models.llama_bidirectional.model", "LlamaBidirectionalModel"),
+        ),
+        (
+            "LlamaForCausalLM",
+            ("nemo_automodel.components.models.llama.model", "LlamaForCausalLM"),
+        ),
+        (
+            "MiniMaxM2ForCausalLM",
+            ("nemo_automodel.components.models.minimax_m2.model", "MiniMaxM2ForCausalLM"),
+        ),
+        (
+            "Ministral3ForCausalLM",
+            ("nemo_automodel.components.models.mistral3.model", "Ministral3ForCausalLM"),
+        ),
+        (
+            "NemotronHForCausalLM",
+            ("nemo_automodel.components.models.nemotron_v3.model", "NemotronHForCausalLM"),
+        ),
+        (
+            "NemotronParseForConditionalGeneration",
+            ("nemo_automodel.components.models.nemotron_parse.model", "NemotronParseForConditionalGeneration"),
+        ),
+        (
+            "Qwen2ForCausalLM",
+            ("nemo_automodel.components.models.qwen2.model", "Qwen2ForCausalLM"),
+        ),
+        (
+            "Qwen3MoeForCausalLM",
+            ("nemo_automodel.components.models.qwen3_moe.model", "Qwen3MoeForCausalLM"),
+        ),
+        (
+            "Qwen3NextForCausalLM",
+            ("nemo_automodel.components.models.qwen3_next.model", "Qwen3NextForCausalLM"),
+        ),
+        (
+            "Qwen3OmniMoeForConditionalGeneration",
+            (
+                "nemo_automodel.components.models.qwen3_omni_moe.model",
+                "Qwen3OmniMoeThinkerForConditionalGeneration",
+            ),
+        ),
+        (
+            "Qwen3VLMoeForConditionalGeneration",
+            ("nemo_automodel.components.models.qwen3_vl_moe.model", "Qwen3VLMoeForConditionalGeneration"),
+        ),
+        (
+            "Qwen3_5MoeForConditionalGeneration",
+            ("nemo_automodel.components.models.qwen3_5_moe.model", "Qwen3_5MoeForConditionalGeneration"),
+        ),
+        (
+            "Step3p5ForCausalLM",
+            ("nemo_automodel.components.models.step3p5.model", "Step3p5ForCausalLM"),
+        ),
+    ]
+)
+
+
+class _LazyArchMapping:
+    """Lazy-loading mapping from architecture name to model class.
+
+    Inspired by HuggingFace transformers' ``_LazyAutoMapping``.  Entries from the
+    static ``auto_map`` are imported on first access and cached.  Additional entries
+    can be added at runtime via ``register``.
+    """
+
+    def __init__(self, auto_map: Union[OrderedDict, Dict[str, Tuple[str, str]], None] = None):
+        self._auto_map: Dict[str, Tuple[str, str]] = OrderedDict(auto_map or {})
+        self._loaded: Dict[str, Type[nn.Module]] = {}
+        self._extra: Dict[str, Type[nn.Module]] = {}
+        self._modules: Dict[str, object] = {}
+
+    def _load(self, key: str) -> Type[nn.Module]:
+        if key in self._loaded:
+            return self._loaded[key]
+        module_path, class_name = self._auto_map[key]
+        if module_path not in self._modules:
+            self._modules[module_path] = importlib.import_module(module_path)
+        cls = getattr(self._modules[module_path], class_name)
+        self._loaded[key] = cls
+        return cls
+
+    def __contains__(self, key: str) -> bool:
+        if key in self._extra or key in self._loaded:
+            return True
+        if key not in self._auto_map:
+            return False
+        try:
+            self._load(key)
+            return True
+        except Exception:
+            logger.debug("Model %s unavailable (import failed), removing from auto_map", key)
+            self._auto_map.pop(key, None)
+            return False
+
+    def __getitem__(self, key: str) -> Type[nn.Module]:
+        if key in self._extra:
+            return self._extra[key]
+        if key in self._auto_map:
+            return self._load(key)
+        raise KeyError(key)
+
+    def __setitem__(self, key: str, value: Type[nn.Module]) -> None:
+        self._extra[key] = value
+
+    def register(self, key: str, value: Type[nn.Module], exist_ok: bool = False) -> None:
+        """Register a model class under the given architecture name."""
+        if not exist_ok and key in self._extra:
+            raise ValueError(f"Duplicated model implementation for {key}")
+        self._extra[key] = value
+
+    def keys(self):
+        return set(self._auto_map.keys()) | set(self._extra.keys())
+
+    def __len__(self) -> int:
+        return len(self.keys())
+
+    def __repr__(self) -> str:
+        return f"_LazyArchMapping(auto_map={len(self._auto_map)}, extra={len(self._extra)}, loaded={len(self._loaded)})"
 
 
 @dataclass
 class _ModelRegistry:
-    # Keyed by model_arch
-    modeling_path: List[str] = field(default_factory=list)
-    model_arch_name_to_cls: Dict[str, Union[Type[nn.Module], str]] = field(default_factory=dict)
-    naming_override: Dict[str, str] = field(default_factory=dict)
+    model_arch_name_to_cls: _LazyArchMapping = field(default=None)
 
     def __post_init__(self):
-        self.naming_override["Qwen3OmniMoeThinkerForConditionalGeneration"] = "Qwen3OmniMoeForConditionalGeneration"
-        for modeling_path in self.modeling_path:
-            self._mapping_model_arch_name_to_cls(modeling_path)
+        if self.model_arch_name_to_cls is None:
+            self.model_arch_name_to_cls = _LazyArchMapping(MODEL_ARCH_MAPPING)
 
     @property
-    def supported_models(self) -> Dict[str, Type[nn.Module]]:
+    def supported_models(self):
         return self.model_arch_name_to_cls.keys()
 
     def get_model_cls_from_model_arch(self, model_arch: str) -> Type[nn.Module]:
         return self.model_arch_name_to_cls[model_arch]
 
-    def register_modeling_path(self, path: str) -> None:
-        """Add a new modeling path and register models from it."""
-        if path not in self.modeling_path:
-            self.modeling_path.append(path)
-            self._mapping_model_arch_name_to_cls(path)
-
-    def _mapping_model_arch_name_to_cls(self, modeling_path: str):
-        package = importlib.import_module(modeling_path)
-        for _, name, ispkg in pkgutil.walk_packages(package.__path__, modeling_path + "."):
-            if not ispkg:
-                try:
-                    module = importlib.import_module(name)
-                except Exception as e:
-                    logger.warning(f"Ignore import error when loading {name}. {e}")
-                    continue
-                if hasattr(module, "ModelClass"):
-                    entry = module.ModelClass
-                    if isinstance(entry, list):
-                        for tmp in entry:
-                            name = (
-                                tmp.__name__
-                                if tmp.__name__ not in self.naming_override
-                                else self.naming_override[tmp.__name__]
-                            )
-                            assert name not in self.model_arch_name_to_cls, (
-                                f"Duplicated model implementation for {name}"
-                            )
-                            self.model_arch_name_to_cls[name] = tmp
-                    else:
-                        name = (
-                            entry.__name__
-                            if entry.__name__ not in self.naming_override
-                            else self.naming_override[entry.__name__]
-                        )
-                        assert name not in self.model_arch_name_to_cls, f"Duplicated model implementation for {name}"
-                        self.model_arch_name_to_cls[name] = entry
+    def register(self, arch_name: str, model_cls: Type[nn.Module], exist_ok: bool = False) -> None:
+        """Register a custom model class for a given architecture name."""
+        self.model_arch_name_to_cls.register(arch_name, model_cls, exist_ok=exist_ok)
 
 
 @lru_cache
 def get_registry():
-    return _ModelRegistry(modeling_path=MODELING_PATH)
+    return _ModelRegistry()
 
 
 ModelRegistry = get_registry()


### PR DESCRIPTION
# What does this PR do ?

Previously, the registry would scan all files under models to "register models" in the registry. As a result, every time any script importing this code was running would have to do this IO.

Here, we introduce a static lookup table that maps class name to import path and avoid this IO and disk traversal.


# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
