### PR TITLE
docs: Fix 0.2.0 docs version switcher

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ import sys
 project = "NeMo-AutoModel"
 copyright = "2025, NVIDIA Corporation"
 author = "NVIDIA Corporation"
-release = "0.1.0"
+release = "0.2.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
@@ -96,7 +96,7 @@ html_theme_options = {
         }
     ],
     "switcher": {
-        "json_url": "versions1.json",
+        "json_url": "../versions1.json",
         "version_match": release,
     },
     "extra_head": {

--- a/docs/project.json
+++ b/docs/project.json
@@ -1,1 +1,1 @@
-{"name": "nemo-automodel", "version": "0.1.0"}
+{"name": "nemo-automodel", "version": "0.2.0"}


### PR DESCRIPTION
# What does this PR do ?

docs: Fix 0.2.0 docs version switcher

The docs version switcher breaks for the 0.1.0 and 0.2.0 docs because it's pointing to the versions1.json in the wrong directory. It should use the repo's docs root directory.

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
