### PR TITLE
fix: cherry-pick EP collective deadlock fix into r0.3.0 (#1365)

### DIFF
--- a/nemo_automodel/components/moe/experts.py
+++ b/nemo_automodel/components/moe/experts.py
@@ -16,10 +16,13 @@ from functools import partial
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import torch
+import torch.distributed as dist
+import torch.distributed.nn.functional as dist_nn_f
 import torch.nn as nn
 import torch.nn.functional as F
+from torch.autograd import Function
 from torch.distributed.device_mesh import DeviceMesh
-from torch.distributed.tensor import DTensor, Partial, Shard
+from torch.distributed.tensor import DTensor
 
 from nemo_automodel.components.moe.state_dict_utils import create_dtensor_from_local
 
@@ -33,6 +36,46 @@ from nemo_automodel.components.moe.megatron.moe_utils import (
     weighted_bias_swiglu_impl,
 )
 from nemo_automodel.components.moe.megatron.token_dispatcher import MoEFlexTokenDispatcher, TokenDispatcherConfig
+
+# ── EP variable-length collective helpers ──
+
+
+class _AllGatherConcatVarlenFn(Function):
+    """All-gather with variable local lengths and autograd-safe backward.
+
+    Backward uses all-reduce + local narrow instead of reduce-scatter to avoid
+    monitoredBarrier deadlocks observed with mixed FSDP/EP backward collective ordering.
+    """
+
+    @staticmethod
+    def forward(ctx, local_tensor: torch.Tensor, group: dist.ProcessGroup, gathered_lens: list[int], max_len: int):
+        local_len = local_tensor.size(0)
+        if local_len < max_len:
+            pad_shape = (max_len - local_len,) + tuple(local_tensor.shape[1:])
+            pad = torch.zeros(pad_shape, dtype=local_tensor.dtype, device=local_tensor.device)
+            local_padded = torch.cat([local_tensor, pad], dim=0)
+        else:
+            local_padded = local_tensor
+
+        world_size = len(gathered_lens)
+        gathered = [torch.empty_like(local_padded) for _ in range(world_size)]
+        dist.all_gather(gathered, local_padded, group=group)
+        gathered = [g[:n] for g, n in zip(gathered, gathered_lens)]
+
+        ctx.group = group
+        ctx.gathered_lens = gathered_lens
+        ctx.rank = dist.get_rank(group)
+        return torch.cat(gathered, dim=0)
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        grad_full = grad_output.contiguous()
+        start = sum(ctx.gathered_lens[: ctx.rank])
+        local_len = ctx.gathered_lens[ctx.rank]
+        dist.all_reduce(grad_full, op=dist.ReduceOp.SUM, group=ctx.group)
+        grad_local = grad_full.narrow(0, start, local_len).contiguous()
+        return grad_local, None, None, None
+
 
 if TYPE_CHECKING:
     from transformer_engine.pytorch import GroupedLinear
@@ -211,13 +254,36 @@ class GroupedExperts(nn.Module):
             f"Number of experts must be divisible by ep_size (ep_size={ep_size})"
         )
 
-        # Replicate the tensor to all experts. This is sub-optimal but is
-        # used by this implementation for correctness.
+        # EP variable-length all-gather
         if ep_size > 1:
-            x = DTensor.from_local(x, device_mesh=ep_mesh, placements=[Shard(0)]).full_tensor()
-            weights = DTensor.from_local(weights.float(), device_mesh=ep_mesh, placements=[Shard(0)]).full_tensor()
-            indices = DTensor.from_local(indices, device_mesh=ep_mesh, placements=[Shard(0)]).full_tensor()
-            token_mask = DTensor.from_local(token_mask, device_mesh=ep_mesh, placements=[Shard(0)]).full_tensor()
+            ep_group = ep_mesh.get_group()
+            local_num_tokens = x.size(0)
+
+            # Exchange per-rank token counts
+            local_len_t = torch.tensor([local_num_tokens], device=x.device, dtype=torch.int64)
+            gathered_len_t = [torch.zeros_like(local_len_t) for _ in range(ep_size)]
+            dist.all_gather(gathered_len_t, local_len_t, group=ep_group)
+            gathered_lens = [int(t.item()) for t in gathered_len_t]
+            max_len = max(gathered_lens)
+
+            def _all_gather_dim0_var(local_tensor: torch.Tensor, *, differentiable: bool) -> torch.Tensor:
+                if differentiable:
+                    return _AllGatherConcatVarlenFn.apply(local_tensor, ep_group, gathered_lens, max_len)
+                if max_len > local_tensor.size(0):
+                    pad_shape = (max_len - local_tensor.size(0),) + tuple(local_tensor.shape[1:])
+                    pad = torch.zeros(pad_shape, dtype=local_tensor.dtype, device=local_tensor.device)
+                    local_padded = torch.cat([local_tensor, pad], dim=0)
+                else:
+                    local_padded = local_tensor
+                gathered = [torch.empty_like(local_padded) for _ in range(ep_size)]
+                dist.all_gather(gathered, local_padded, group=ep_group)
+                gathered = [g[:n] for g, n in zip(gathered, gathered_lens)]
+                return torch.cat(gathered, dim=0)
+
+            x = _all_gather_dim0_var(x, differentiable=True)
+            weights = _all_gather_dim0_var(weights.float(), differentiable=False)
+            indices = _all_gather_dim0_var(indices, differentiable=False)
+            token_mask = _all_gather_dim0_var(token_mask, differentiable=False)
 
         n_local_experts = self.n_routed_experts // ep_size
         experts_start_idx = ep_rank * n_local_experts
@@ -279,9 +345,15 @@ class GroupedExperts(nn.Module):
             )
             y[0] += expert_out[0]
 
+        # Gradient anchor
         if ep_size > 1:
-            y = DTensor.from_local(y, device_mesh=ep_mesh, placements=[Partial()])
-            y = y.redistribute(placements=[Shard(0)]).to_local()
+            y = y + (x * 0.0)
+
+        # Variable-length reduce: all_reduce + narrow to original per-rank token boundaries
+        if ep_size > 1:
+            y = dist_nn_f.all_reduce(y, op=dist.ReduceOp.SUM, group=ep_group)
+            start = sum(gathered_lens[:ep_rank])
+            y = y.narrow(0, start, local_num_tokens).contiguous()
 
         return y
 


### PR DESCRIPTION
## Summary
- Cherry-pick of #1365 into `r0.3.0`
- Fixes NCCL communication deadlocks in Expert Parallelism caused by variable-length token counts from sequence packing
- Replaces DTensor-based all-gather/reduce with padding-based variable-length collectives and adds gradient anchors

## Changes
- **Stage 1**: Padding-based all-gather for variable-length token counts (replaces `DTensor.from_local(..., [Shard(0)]).full_tensor()`)
- **Stage 2**: `all_reduce` + `narrow` for correct per-rank output boundaries (replaces `DTensor [Partial()] → [Shard(0)]` redistribute)
- **Stage 3**: Gradient anchor (`y + x*0.0`) to ensure all ranks participate in backward collectives

## Conflict resolution
- Resolved merge conflict in `nemo_automodel/components/moe/experts.py` due to r0.3.0 using inline expert loop with `get_local_proj()` helper vs main's refactored `_forward_loop()`/`_forward_grouped_mm()` structure
- All three fix stages applied correctly to r0.3.0's code structure

## Test plan
- [ ] Verify EP training with variable-length sequence packing does not deadlock
- [ ] Verify non-EP training is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)