### PR TITLE
fix: Log exception and error in FirstRankPerNode before exiting

### DIFF
--- a/nemo_automodel/components/distributed/utils.py
+++ b/nemo_automodel/components/distributed/utils.py
@@ -159,8 +159,14 @@ class FirstRankPerNode(ContextDecorator):
                 if not success:
                     logger.warning("Barrier timed out during exit, continuing anyway")
                 if exc_type is not None:
-                    # TODO: propagate failure to the entire job
-                    quit(1)
+                    # Log the exception and make the error visible
+                    logger.error(
+                        "Exception inside FirstRankPerNode: %s: %s",
+                        exc_type.__name__,
+                        exc_val,
+                        exc_info=(exc_type, exc_val, exc_tb),
+                    )
+                    raise SystemExit(1) from exc_val
         finally:
             if self._created_pg:
                 dist.destroy_process_group()


### PR DESCRIPTION
# What does this PR do ?

[FirstRankPerNode() silently quit](https://github.com/NVIDIA-NeMo/Automodel/blob/main/nemo_automodel/components/distributed/utils.py#L163) when there was an error/exception making the real error invisible and hard to debug. This PR logs the error before exiting which is useful. 

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
