### PR TITLE
ci: Switch to merge-commit CI

### DIFF
--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -73,11 +73,6 @@ runs:
       with:
         python-version: 3.12
 
-    - name: Get PR info
-      id: get-pr-info
-      if: startsWith(github.ref, 'refs/heads/pull-request/')
-      uses: nv-gha-runners/get-pr-info@main
-
     - name: Install Azure CLI
       shell: bash
       run: |


### PR DESCRIPTION
# What does this PR do ?

Switches from branch CI to merge-commit CI to counter midair collisions. In this run https://github.com/NVIDIA-NeMo/Automodel/actions/runs/22761597893/job/66019321708#step:3:71 you can see that now used the internal auto-generated merge-commit https://github.com/NVIDIA-NeMo/Automodel/commits/683301eea43ceb1f8a91a93f3333d8c579c7cc15
 
# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
