### PR TITLE
fix: CombinedProjectionStateDictAdapter._gather_1d_bias

### DIFF
--- a/nemo_automodel/components/models/common/combined_projection/state_dict_adapter.py
+++ b/nemo_automodel/components/models/common/combined_projection/state_dict_adapter.py
@@ -89,12 +89,12 @@ class CombinedProjectionStateDictAdapter:
     #   (e.g. hidden_size elements).
     #
     # The two helpers form a pair:
-    #   _gather_1d_bias  – all-gather to Replicate so reshape/split/cat work
-    #   _restore_1d_bias – redistribute back to the original Shard(0)
+    #   _gather_1d_bias  – materialize the full bias so reshape/split/cat work
+    #   _restore_1d_bias – re-create a DTensor and restore the original sharding
 
     @staticmethod
     def _gather_1d_bias(tensor: torch.Tensor) -> tuple[torch.Tensor, tuple | None]:
-        """All-gather a 1-D bias DTensor to ``Replicate``.
+        """Materialize a 1-D bias DTensor as a full tensor.
 
         Must only be called on 1-D bias tensors.  Returns
         ``(gathered, orig_placement)`` where *orig_placement* is a
@@ -113,7 +113,10 @@ class CombinedProjectionStateDictAdapter:
         new_placements = tuple(Replicate() if isinstance(p, Shard) and p.dim == 0 else p for p in tensor.placements)
         if new_placements == tensor.placements:
             return tensor, orig
-        return tensor.redistribute(tensor.device_mesh, new_placements), orig
+        # PyTorch 2.10 tightened DTensor shard-order validation during
+        # shard->replicate redistribute for some 1-D tensors. Bias tensors are
+        # tiny, so materializing the full value is the safest cross-version path.
+        return tensor.full_tensor(), orig
 
     @staticmethod
     def _restore_1d_bias(tensor: torch.Tensor, orig_placement: tuple | None) -> torch.Tensor:
@@ -124,7 +127,25 @@ class CombinedProjectionStateDictAdapter:
         assert tensor.ndim == 1, f"_restore_1d_bias expects a 1-D bias tensor, got ndim={tensor.ndim}"
         if orig_placement is None:
             return tensor
-        return tensor.redistribute(*orig_placement)
+        try:
+            from torch.distributed.tensor import DTensor
+            from torch.distributed.tensor.placement_types import Replicate
+        except ImportError:
+            return tensor
+
+        device_mesh, placements = orig_placement
+        if isinstance(tensor, DTensor):
+            if tensor.device_mesh == device_mesh and tensor.placements == placements:
+                return tensor
+            return tensor.redistribute(device_mesh, placements)
+
+        replicated = DTensor.from_local(
+            tensor,
+            device_mesh=device_mesh,
+            placements=tuple(Replicate() for _ in placements),
+            run_check=False,
+        )
+        return replicated.redistribute(device_mesh, placements)
 
     # ── Interleave / de-interleave ──────────────────────────────────────
 

--- a/tests/unit_tests/models/common/test_combined_projection_state_dict_adapter.py
+++ b/tests/unit_tests/models/common/test_combined_projection_state_dict_adapter.py
@@ -16,7 +16,6 @@
 
 from types import SimpleNamespace
 
-import pytest
 import torch
 from transformers import LlamaConfig
 
@@ -321,9 +320,7 @@ class TestLlamaLoRAFunctionalSplit:
         ]
         for fragment in forbidden_fragments:
             offending = [k for k in hf_sd if fragment in k]
-            assert offending == [], (
-                f"Found forbidden fragment '{fragment}' in converted state dict keys: {offending}"
-            )
+            assert offending == [], f"Found forbidden fragment '{fragment}' in converted state dict keys: {offending}"
 
     def test_split_qkv_lora_a_identical(self):
         """lora_A weights for q/k/v must be identical (replicated, not split)."""
@@ -437,3 +434,108 @@ class TestLlamaLoRAFunctionalSplit:
             assert f"{pre}.self_attn.v_proj" in target_modules
             assert f"{pre}.mlp.gate_proj" in target_modules
             assert f"{pre}.mlp.up_proj" in target_modules
+
+
+class TestCombinedProjectionBiasDTensorHelpers:
+    def test_gather_1d_bias_uses_full_tensor_for_sharded_dtensor(self, monkeypatch):
+        import torch.distributed.tensor as dtensor_mod
+        import torch.distributed.tensor.placement_types as placement_types
+
+        class FakeShard:
+            def __init__(self, dim):
+                self.dim = dim
+
+        class FakeReplicate:
+            pass
+
+        class FakeDTensor:
+            def __init__(self, tensor, device_mesh, placements):
+                self._tensor = tensor
+                self.device_mesh = device_mesh
+                self.placements = tuple(placements)
+                self.ndim = tensor.ndim
+                self.full_tensor_calls = 0
+                self.redistribute_calls = []
+
+            def full_tensor(self):
+                self.full_tensor_calls += 1
+                return self._tensor.clone()
+
+            def redistribute(self, device_mesh=None, placements=None):
+                self.redistribute_calls.append((device_mesh, placements))
+                return FakeDTensor(
+                    self._tensor.clone(),
+                    device_mesh if device_mesh is not None else self.device_mesh,
+                    placements if placements is not None else self.placements,
+                )
+
+        monkeypatch.setattr(dtensor_mod, "DTensor", FakeDTensor)
+        monkeypatch.setattr(placement_types, "Replicate", FakeReplicate)
+        monkeypatch.setattr(placement_types, "Shard", FakeShard)
+
+        mesh = object()
+        dtensor = FakeDTensor(torch.arange(8.0), mesh, (FakeShard(0),))
+
+        gathered, orig = CombinedProjectionStateDictAdapter._gather_1d_bias(dtensor)
+
+        assert isinstance(gathered, torch.Tensor)
+        torch.testing.assert_close(gathered, torch.arange(8.0))
+        assert orig == (mesh, dtensor.placements)
+        assert dtensor.full_tensor_calls == 1
+        assert dtensor.redistribute_calls == []
+
+    def test_restore_1d_bias_rebuilds_replicated_dtensor_before_resharding(self, monkeypatch):
+        import torch.distributed.tensor as dtensor_mod
+        import torch.distributed.tensor.placement_types as placement_types
+
+        class FakeShard:
+            def __init__(self, dim):
+                self.dim = dim
+
+        class FakeReplicate:
+            pass
+
+        class FakeDTensor:
+            from_local_calls = []
+            redistribute_calls = []
+
+            def __init__(self, tensor, device_mesh, placements):
+                self._tensor = tensor
+                self.device_mesh = device_mesh
+                self.placements = tuple(placements)
+                self.ndim = tensor.ndim
+
+            @classmethod
+            def from_local(cls, local_tensor, device_mesh=None, placements=None, **kwargs):
+                cls.from_local_calls.append((local_tensor.clone(), device_mesh, tuple(placements), kwargs))
+                return cls(local_tensor.clone(), device_mesh, placements)
+
+            def redistribute(self, device_mesh=None, placements=None):
+                FakeDTensor.redistribute_calls.append((device_mesh, tuple(placements)))
+                return FakeDTensor(
+                    self._tensor.clone(),
+                    device_mesh if device_mesh is not None else self.device_mesh,
+                    placements if placements is not None else self.placements,
+                )
+
+        monkeypatch.setattr(dtensor_mod, "DTensor", FakeDTensor)
+        monkeypatch.setattr(placement_types, "Replicate", FakeReplicate)
+        monkeypatch.setattr(placement_types, "Shard", FakeShard)
+
+        mesh = object()
+        shard = FakeShard(0)
+        full_bias = torch.arange(8.0)
+
+        restored = CombinedProjectionStateDictAdapter._restore_1d_bias(full_bias, (mesh, (shard,)))
+
+        assert isinstance(restored, FakeDTensor)
+        assert restored.device_mesh is mesh
+        assert restored.placements == (shard,)
+        assert len(FakeDTensor.from_local_calls) == 1
+        gathered_bias, gathered_mesh, gathered_placements, kwargs = FakeDTensor.from_local_calls[0]
+        torch.testing.assert_close(gathered_bias, full_bias)
+        assert gathered_mesh is mesh
+        assert len(gathered_placements) == 1
+        assert isinstance(gathered_placements[0], FakeReplicate)
+        assert kwargs == {"run_check": False}
+        assert FakeDTensor.redistribute_calls == [(mesh, (shard,))]


### PR DESCRIPTION
# What does this PR do ?

The failure is caused by `CombinedProjectionStateDictAdapter._gather_1d_bias()` doing a `DTensor.redistribute(... Replicate())` on 1-D sharded biases.

With the newer base container’s PyTorch (2.10.0 here), that path now asserts on missing shard-order metadata.

See [here](https://github.com/NVIDIA-NeMo/Automodel/actions/runs/22772542178/job/66095990929) for the failing pipeline.

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
