### PR TITLE
feat: TP-aware KDLoss with distributed softmax and T² scaling

### DIFF
--- a/nemo_automodel/components/loss/kd_loss.py
+++ b/nemo_automodel/components/loss/kd_loss.py
@@ -12,18 +12,116 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torch.distributed.tensor import DTensor
+
+try:
+    from torch.distributed.tensor import DTensor, Shard
+
+    _HAVE_DTENSOR = True
+except Exception:
+    DTensor = None  # type: ignore[assignment, misc]
+    Shard = None  # type: ignore[assignment, misc]
+    _HAVE_DTENSOR = False
+
+
+def _infer_tp_group_from_dtensor(logits: torch.Tensor) -> Optional[torch.distributed.ProcessGroup]:
+    """If *logits* is a DTensor sharded on the vocab (last) dimension, return its TP process group.
+
+    Iterates over the DTensor placements to find the mesh dimension that holds a vocab-dim
+    ``Shard`` and returns the corresponding process group.  Returns ``None`` for plain tensors
+    or DTensors that are not vocab-sharded.
+    """
+    if not _HAVE_DTENSOR or not isinstance(logits, DTensor):
+        return None
+    vocab_dim = logits.ndim - 1
+    for mesh_dim, placement in enumerate(logits.placements):
+        if isinstance(placement, Shard) and (placement.dim == -1 or placement.dim == vocab_dim):
+            return logits.device_mesh.get_group(mesh_dim)
+    return None
+
+
+def _kl_forward_tp(
+    t_logits: torch.Tensor,
+    s_logits: torch.Tensor,
+    tp_group: torch.distributed.ProcessGroup,
+) -> torch.Tensor:
+    """Compute per-token negative cross-entropy ``sum(P * log Q)`` with tensor parallelism.
+
+    Both ``t_logits`` and ``s_logits`` are **local** vocab-sharded tensors of shape
+    ``[valid_tokens, local_vocab_size]``.  A numerically stable global softmax / log-softmax is
+    computed via ``all_reduce`` over ``tp_group``, avoiding the need to gather the full vocab.
+
+    Args:
+        t_logits: Local teacher logit shard, shape ``[valid_tokens, local_vocab_size]``.
+        s_logits: Local student logit shard, shape ``[valid_tokens, local_vocab_size]``.
+        tp_group: Process group spanning the tensor-parallel ranks.
+
+    Returns:
+        Per-token sum(P * log Q), shape ``[valid_tokens]``.  This is the *negative* KL term;
+        negate and average in the caller to obtain the final loss.
+    """
+    # --- Stable global softmax for teacher: P ---
+    teacher_max, _ = torch.max(t_logits, dim=-1, keepdim=True)
+    torch.distributed.all_reduce(teacher_max, op=torch.distributed.ReduceOp.MAX, group=tp_group)
+    output_teacher = t_logits - teacher_max
+    denom_teacher = torch.sum(torch.exp(output_teacher), dim=-1, keepdim=True)
+    torch.distributed.all_reduce(denom_teacher, op=torch.distributed.ReduceOp.SUM, group=tp_group)
+    teacher_prob = torch.exp(output_teacher) / denom_teacher.clamp(min=1e-12)
+
+    # --- Stable global log-softmax for student: log Q ---
+    student_max, _ = torch.max(s_logits, dim=-1, keepdim=True)
+    torch.distributed.all_reduce(student_max, op=torch.distributed.ReduceOp.MAX, group=tp_group)
+    output_student = s_logits - student_max
+    denom_student = torch.sum(torch.exp(output_student), dim=-1, keepdim=True)
+    torch.distributed.all_reduce(denom_student, op=torch.distributed.ReduceOp.SUM, group=tp_group)
+    student_log_prob = output_student - torch.log(denom_student.clamp(min=1e-12))
+
+    # --- Per-token sum(P * log Q): local accumulate then global reduce ---
+    # Mask -inf student logits so that 0 * -inf does not produce NaN.
+    inf_mask = torch.isinf(s_logits)
+    ce_local = torch.masked_fill(teacher_prob * student_log_prob, inf_mask, 0.0).sum(dim=-1)
+    torch.distributed.all_reduce(ce_local, op=torch.distributed.ReduceOp.SUM, group=tp_group)
+
+    return ce_local  # shape: [valid_tokens]
 
 
 class KDLoss(nn.Module):
-    def __init__(self, ignore_index: int = -100, temperature: float = 1.0, fp32_upcast: bool = True):
+    """Forward KL divergence loss for knowledge distillation.
+
+    Computes ``KL(P_teacher ‖ P_student)`` averaged over valid (non-padding) tokens.
+
+    Supports tensor-parallel (TP) training: when logits are vocab-sharded ``DTensor``s, the TP
+    group is inferred automatically and a distributed softmax is used to avoid gathering the full
+    vocabulary on each rank.  A ``tp_group`` can also be supplied explicitly.
+
+    Args:
+        ignore_index: Label value marking padding tokens (default ``-100``).
+        temperature: Softmax temperature *T*.  Both teacher and student logits are divided by *T*
+            before computing probabilities.  The loss is then multiplied by *T²* so that gradient
+            magnitudes remain independent of the chosen temperature (Hinton et al., 2015).
+        fp32_upcast: Cast logits to float32 before computing softmax / log-softmax for numerical
+            stability (default ``True``).
+        tp_group: Explicit TP process group.  When ``None`` (default) the group is inferred from
+            the DTensor placement of ``student_logits``, or the non-TP path is used for plain
+            tensors.
+    """
+
+    def __init__(
+        self,
+        ignore_index: int = -100,
+        temperature: float = 1.0,
+        fp32_upcast: bool = True,
+        tp_group: Optional[torch.distributed.ProcessGroup] = None,
+    ):
         super().__init__()
         self.ignore_index = ignore_index
         self.temperature = temperature
         self.fp32_upcast = fp32_upcast
+        self.tp_group = tp_group
 
     def forward(
         self,
@@ -32,30 +130,18 @@ class KDLoss(nn.Module):
         labels: torch.Tensor,
         num_batch_labels: int | None = None,
     ) -> torch.Tensor:
-        """
-        Calculates KL(P_teacher‖P_student) averaged over valid tokens.
-
-        Logits are (optionally) cast to fp32 for numerical stability, probabilities
-        are obtained with softmax / log_softmax after temperature scaling, and
-        padding tokens (== ignore_index) are ignored in the average.
+        """Compute the KD loss.
 
         Args:
-            student_logits (torch.Tensor): The logits of the student model.
-            teacher_logits (torch.Tensor): The logits of the teacher model.
-            labels (torch.Tensor): The labels of the batch.
-            num_batch_labels (int | None): The number of valid labels in the batch.
-
-        Important note on num_batch_labels:
-            - if `num_batch_labels` is None, it will return the mean over kl_per_token.
-            - if `num_batch_labels` is not None, it will return the sum(kl_per_token) / num_batch_labels.
-            Please do note that usually, num_batch_labels > #valid labels in labels tensor, for example,
-            when doing gradient accumulation.
-
-            We prefer the num_batch_labels variable over counting the number of valid labels in the batch,
-            to allow for easier handling when doing gradient accumulation and per-token loss computation.
+            student_logits: Shape ``[*, vocab_size]`` or ``[*, local_vocab_size]`` for TP.
+            teacher_logits: Same shape as ``student_logits``.
+            labels: Shape ``[*]``.  Positions equal to ``ignore_index`` are excluded from the loss.
+            num_batch_labels: Total number of valid tokens across all gradient-accumulation steps.
+                When provided the loss is ``sum(kl_per_token) / num_batch_labels``; otherwise it
+                is ``mean(kl_per_token)`` over the valid tokens in this micro-batch.
 
         Returns:
-            The KL loss.
+            Scalar KD loss.
         """
         # Exclude padding / ignored tokens from the loss.
         valid_mask = (labels != self.ignore_index).view(-1)
@@ -70,39 +156,56 @@ class KDLoss(nn.Module):
         if labels.ndim > 1:
             labels = labels.view(-1)
 
-        if isinstance(teacher_logits, DTensor):
-            teacher_logits = teacher_logits.full_tensor()
-        if isinstance(student_logits, DTensor):
-            student_logits = student_logits.full_tensor()
-        if isinstance(labels, DTensor):
-            labels = labels.full_tensor()
+        # Determine TP group: prefer explicit argument, then auto-detect from DTensor.
+        tp_group = self.tp_group
+        if tp_group is None and _HAVE_DTENSOR and isinstance(student_logits, DTensor):
+            tp_group = _infer_tp_group_from_dtensor(student_logits)
+
+        if tp_group is not None:
+            # TP path: keep local shards to avoid gathering the full vocabulary.
+            if _HAVE_DTENSOR and isinstance(student_logits, DTensor):
+                student_logits = student_logits.to_local()
+            if _HAVE_DTENSOR and isinstance(teacher_logits, DTensor):
+                teacher_logits = teacher_logits.to_local()
+        else:
+            # Non-TP path: materialise full tensors.
+            if _HAVE_DTENSOR and isinstance(student_logits, DTensor):
+                student_logits = student_logits.full_tensor()
+            if _HAVE_DTENSOR and isinstance(teacher_logits, DTensor):
+                teacher_logits = teacher_logits.full_tensor()
+            if _HAVE_DTENSOR and isinstance(labels, DTensor):
+                labels = labels.full_tensor()
 
         t_logits = teacher_logits[valid_mask]
         s_logits = student_logits[valid_mask]
-        labels = labels[valid_mask]
 
-        # Up-cast logits to fp32 for numerical stability
+        # Up-cast to fp32 for numerical stability and apply temperature scaling.
         if self.fp32_upcast:
             t_logits = t_logits.float()
             s_logits = s_logits.float()
-        #  and apply temperature scaling.
+
         if self.temperature != 1.0:
-            t_logits.mul_(1 / self.temperature)
-            s_logits.mul_(1 / self.temperature)
+            t_logits = t_logits.mul(1.0 / self.temperature)
+            s_logits = s_logits.mul(1.0 / self.temperature)
 
-        # Probabilities / log-probabilities
-        teacher_prob = F.softmax(t_logits, dim=-1, dtype=torch.float32)
-        student_logprob = F.log_softmax(s_logits, dim=-1, dtype=torch.float32)
+        # Compute per-token negative cross-entropy: sum(P * log Q).
+        if tp_group is not None:
+            kl_per_token = _kl_forward_tp(t_logits, s_logits, tp_group)
+        else:
+            teacher_prob = F.softmax(t_logits, dim=-1, dtype=torch.float32)
+            student_logprob = F.log_softmax(s_logits, dim=-1, dtype=torch.float32)
+            # mask out infinities originating *only* from student logits
+            # (teacher logits infs are extremely rare and do not
+            # affect gradients w.r.t. student parameters).
+            inf_mask = torch.isinf(s_logits)
+            kl_per_token = torch.masked_fill(teacher_prob * student_logprob, inf_mask, 0).sum(-1).view(-1)
 
-        # mask out infinities originating *only* from student logits
-        # (teacher logits infs are extremely rare and do not
-        # affect gradients w.r.t. student parameters).
-        inf_mask = torch.isinf(s_logits)
+        # T² scaling: dividing logits by T scales gradients by 1/T², so we multiply the loss by
+        # T² to keep gradient magnitudes independent of temperature (Hinton et al., 2015).
+        if self.temperature != 1.0:
+            kl_per_token = kl_per_token * (self.temperature**2)
 
-        # Compute per-token forward KL contribution and flatten.
-        kl_per_token = torch.masked_fill(teacher_prob * student_logprob, inf_mask, 0).sum(-1).view(-1)
-
-        # Average over valid tokens.
+        # kl_per_token = sum(P * log Q) ≤ 0.  Negate to obtain a positive minimisation target.
         if num_batch_labels is not None:
             return -torch.sum(kl_per_token) / num_batch_labels
         else:

--- a/tests/unit_tests/loss/test_kd_loss.py
+++ b/tests/unit_tests/loss/test_kd_loss.py
@@ -12,16 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Unit tests for :pyclass:`nemo_automodel.components.loss.kd_loss.KDLoss`.
+Unit tests for :pyclass:`nemo_automodel.components.loss.kd_loss.KDLoss` and its
+tensor-parallel helpers.
 """
 from typing import Optional
 
+import pytest
 import torch
 import torch.nn.functional as F
 
-from nemo_automodel.components.loss.kd_loss import KDLoss
+from nemo_automodel.components.loss.kd_loss import KDLoss, _infer_tp_group_from_dtensor, _kl_forward_tp
 
-import pytest
+
+# ---------------------------------------------------------------------------
+# Reference implementation (no TP, no T² scaling applied yet)
+# ---------------------------------------------------------------------------
+
 
 def _reference_kd_loss(
     student_logits: torch.Tensor,
@@ -32,8 +38,6 @@ def _reference_kd_loss(
     num_batch_labels: Optional[int] = None,
 ) -> torch.Tensor:
     """Standalone implementation mirroring :pyfunc:`KDLoss.forward`."""
-
-    # Flatten + mask
     valid_mask = (labels != ignore_index).view(-1)
     s_logits = student_logits.view(-1, student_logits.size(-1))[valid_mask]
     t_logits = teacher_logits.view(-1, teacher_logits.size(-1))[valid_mask]
@@ -45,11 +49,19 @@ def _reference_kd_loss(
     teacher_prob = F.softmax(t_logits, dim=-1, dtype=torch.float32)
     student_logprob = F.log_softmax(s_logits, dim=-1, dtype=torch.float32)
 
-    kl_per_token = -(teacher_prob * student_logprob).sum(-1)  # shape: [n_valid]
+    # T² scaling (Hinton et al., 2015)
+    scale = temperature**2
+    kl_per_token = -(teacher_prob * student_logprob).sum(-1) * scale  # shape: [n_valid]
 
     if num_batch_labels is not None:
         return kl_per_token.sum() / num_batch_labels
     return kl_per_token.mean()
+
+
+# ---------------------------------------------------------------------------
+# KDLoss – basic correctness
+# ---------------------------------------------------------------------------
+
 
 @pytest.mark.parametrize("temperature,upcast,unsqueeze", [(1.0, True, False), (2.0, False, True)])
 def test_kd_loss_basic(temperature, upcast, unsqueeze):
@@ -67,8 +79,9 @@ def test_kd_loss_basic(temperature, upcast, unsqueeze):
 
     assert torch.allclose(loss, ref, atol=1e-6), f"Expected {ref}, got {loss}"
 
+
 def test_kd_loss_basic_no_labels():
-    """Loss matches reference implementation for a simple example."""
+    """Returns zero when the entire batch is padding."""
     student_logits = torch.tensor([[2.0, 0.5, -1.0], [0.1, 0.2, 0.3]])
     teacher_logits = torch.tensor([[1.5, 0.0, -0.5], [0.2, -0.1, 0.0]])
     labels = torch.tensor([-100, -100])
@@ -79,34 +92,155 @@ def test_kd_loss_basic_no_labels():
 
 def test_kd_loss_ignore_index():
     """Tokens with ``ignore_index`` are excluded from the loss computation."""
-    student_logits = torch.tensor(
-        [[1.0, 0.0], [0.5, -0.5], [2.0, -1.0]], dtype=torch.float32
-    )
-    teacher_logits = torch.tensor(
-        [[0.8, -0.2], [0.4, -0.4], [1.5, -0.5]], dtype=torch.float32
-    )
+    student_logits = torch.tensor([[1.0, 0.0], [0.5, -0.5], [2.0, -1.0]], dtype=torch.float32)
+    teacher_logits = torch.tensor([[0.8, -0.2], [0.4, -0.4], [1.5, -0.5]], dtype=torch.float32)
     labels = torch.tensor([0, -100, 1])  # middle element ignored
 
-    kd = KDLoss(ignore_index=-100)
-    loss = kd(student_logits, teacher_logits, labels)
-
+    loss = KDLoss(ignore_index=-100)(student_logits, teacher_logits, labels)
     ref = _reference_kd_loss(student_logits, teacher_logits, labels, ignore_index=-100)
 
     assert torch.allclose(loss, ref, atol=1e-6), f"Expected {ref}, got {loss}"
 
 
 def test_kd_loss_num_labels():
-    """When ``num_batch_labels`` provided, denominator equals the given count."""
+    """When ``num_batch_labels`` is provided, denominator equals the given count."""
     student_logits = torch.tensor([[0.3, 0.7], [1.0, -1.0]])
     teacher_logits = torch.tensor([[0.2, 0.8], [0.9, -0.9]])
     labels = torch.tensor([1, 0])
-    num_labels = 10  # arbitrary count (e.g., with gradient accumulation)
+    num_labels = 10
 
-    kd = KDLoss()
-    loss = kd(student_logits, teacher_logits, labels, num_batch_labels=num_labels)
-
-    ref = _reference_kd_loss(
-        student_logits, teacher_logits, labels, num_batch_labels=num_labels
-    )
+    loss = KDLoss()(student_logits, teacher_logits, labels, num_batch_labels=num_labels)
+    ref = _reference_kd_loss(student_logits, teacher_logits, labels, num_batch_labels=num_labels)
 
     assert torch.allclose(loss, ref, atol=1e-6), f"Expected {ref}, got {loss}"
+
+
+# ---------------------------------------------------------------------------
+# T² scaling
+# ---------------------------------------------------------------------------
+
+
+def test_kd_loss_temperature_scaling():
+    """T² scaling keeps gradient magnitudes consistent across temperatures.
+
+    For any temperature T, ``KDLoss(temperature=T)`` should equal
+    ``KDLoss(temperature=1)`` only when the distributions are flat (uniform teacher
+    and uniform student), because in that case temperature does not change the
+    probabilities and the T² factor is the only difference.
+
+    Here we verify the more directly testable property: the loss computed by
+    KDLoss(temperature=T) matches _reference_kd_loss(temperature=T), which
+    applies the T² scaling explicitly.
+    """
+    torch.manual_seed(42)
+    student_logits = torch.randn(4, 8)
+    teacher_logits = torch.randn(4, 8)
+    labels = torch.tensor([0, 1, 2, 3])
+    temperature = 3.0
+
+    loss = KDLoss(temperature=temperature)(student_logits, teacher_logits, labels)
+    ref = _reference_kd_loss(student_logits, teacher_logits, labels, temperature=temperature)
+
+    assert torch.allclose(loss, ref, atol=1e-5), f"Expected {ref.item():.6f}, got {loss.item():.6f}"
+
+
+def test_kd_loss_temperature_1_no_scaling():
+    """With temperature=1 the T² factor is 1 and has no effect."""
+    torch.manual_seed(0)
+    student_logits = torch.randn(3, 5)
+    teacher_logits = torch.randn(3, 5)
+    labels = torch.tensor([0, 1, -100])
+
+    loss_t1 = KDLoss(temperature=1.0)(student_logits, teacher_logits, labels)
+    ref = _reference_kd_loss(student_logits, teacher_logits, labels, temperature=1.0)
+
+    assert torch.allclose(loss_t1, ref, atol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# _infer_tp_group_from_dtensor
+# ---------------------------------------------------------------------------
+
+
+def test_infer_tp_group_plain_tensor_returns_none():
+    """Plain tensors are not vocab-sharded DTensors; group must be None."""
+    t = torch.randn(4, 32)
+    assert _infer_tp_group_from_dtensor(t) is None
+
+
+# ---------------------------------------------------------------------------
+# TP path: _kl_forward_tp on a trivial single-process group
+#
+# With world_size=1 all collectives are identity operations, so _kl_forward_tp
+# must produce the same result as the standard non-TP softmax / log-softmax.
+# ---------------------------------------------------------------------------
+
+
+def _init_single_process_group() -> Optional[torch.distributed.ProcessGroup]:
+    """Initialise (or reuse) a trivial gloo group for single-process TP tests."""
+    if not torch.distributed.is_available():
+        return None
+    if not torch.distributed.is_initialized():
+        torch.distributed.init_process_group(
+            backend="gloo",
+            init_method="tcp://127.0.0.1:29501",
+            rank=0,
+            world_size=1,
+        )
+    return torch.distributed.group.WORLD
+
+
+@pytest.fixture(scope="module")
+def trivial_pg():
+    """Module-scoped fixture that returns a single-process gloo ProcessGroup."""
+    pg = _init_single_process_group()
+    if pg is None:
+        pytest.skip("torch.distributed not available")
+    return pg
+
+
+def test_kl_forward_tp_matches_non_tp(trivial_pg):
+    """_kl_forward_tp with world_size=1 equals standard log-softmax computation."""
+    torch.manual_seed(7)
+    t_logits = torch.randn(6, 16, dtype=torch.float32)
+    s_logits = torch.randn(6, 16, dtype=torch.float32)
+
+    # Non-TP reference
+    teacher_prob = F.softmax(t_logits, dim=-1)
+    student_logprob = F.log_softmax(s_logits, dim=-1)
+    ref = (teacher_prob * student_logprob).sum(-1)  # negative CE per token
+
+    tp_out = _kl_forward_tp(t_logits, s_logits, trivial_pg)
+
+    assert torch.allclose(tp_out, ref, atol=1e-5), f"max diff: {(tp_out - ref).abs().max().item()}"
+
+
+def test_kd_loss_tp_path_matches_non_tp(trivial_pg):
+    """KDLoss with an explicit tp_group (world_size=1) produces the same loss as without TP."""
+    torch.manual_seed(13)
+    student_logits = torch.randn(5, 20, dtype=torch.float32)
+    teacher_logits = torch.randn(5, 20, dtype=torch.float32)
+    labels = torch.tensor([0, 1, 2, -100, 4])
+
+    loss_no_tp = KDLoss()(student_logits, teacher_logits, labels)
+    loss_tp = KDLoss(tp_group=trivial_pg)(student_logits, teacher_logits, labels)
+
+    assert torch.allclose(loss_no_tp, loss_tp, atol=1e-5), (
+        f"Non-TP loss {loss_no_tp.item():.6f} != TP loss {loss_tp.item():.6f}"
+    )
+
+
+def test_kd_loss_tp_path_with_temperature(trivial_pg):
+    """TP path with temperature applies T² scaling consistently with the non-TP path."""
+    torch.manual_seed(99)
+    student_logits = torch.randn(4, 10, dtype=torch.float32)
+    teacher_logits = torch.randn(4, 10, dtype=torch.float32)
+    labels = torch.tensor([0, 1, -100, 3])
+    temperature = 2.0
+
+    loss_no_tp = KDLoss(temperature=temperature)(student_logits, teacher_logits, labels)
+    loss_tp = KDLoss(temperature=temperature, tp_group=trivial_pg)(student_logits, teacher_logits, labels)
+
+    assert torch.allclose(loss_no_tp, loss_tp, atol=1e-5), (
+        f"Non-TP loss {loss_no_tp.item():.6f} != TP loss {loss_tp.item():.6f}"
+    )


### PR DESCRIPTION
Add tensor-parallel support to KDLoss via two new module-level helpers:
- _infer_tp_group_from_dtensor: extracts the TP ProcessGroup from a vocab-sharded DTensor logit, avoiding an explicit tp_group argument in most cases.
- _kl_forward_tp: computes per-token KL using numerically stable global softmax/log-softmax over all_reduce, keeping logits on local shards to avoid gathering the full vocabulary.

KDLoss.forward gains a tp_group parameter (default None, backward- compatible) and auto-detects a TP group from DTensor student_logits. T² loss scaling (Hinton et al., 2015) is applied when temperature != 1 so that gradient magnitudes stay independent of the chosen temperature.

Tests extended with single-process gloo-backed fixtures that verify the TP path matches the non-TP path at world_size=1, plus dedicated tests for T² scaling and _infer_tp_group_from_dtensor.