### PR TITLE
feat: add MoE expert diversity metrics

### DIFF
--- a/nemo_automodel/components/moe/load_balance_metrics.py
+++ b/nemo_automodel/components/moe/load_balance_metrics.py
@@ -23,15 +23,23 @@ Expert utilization is a ratio of ``current_load / ideal_load`` where
 expert receives exactly its fair share; >1 = overloaded, <1 = underloaded,
 0 = dead expert.
 
+Expert diversity measures how many experts are meaningfully used:
+- ``dead_expert_frac``: fraction of experts receiving zero tokens.
+- ``expert_diversity``: ``exp(H) / N`` where ``H`` is Shannon entropy of the
+  routing distribution (1.0 = all experts equally used, 0 = collapsed).
+
 Modes:
 - **brief**: Aggregated scalars (mean/median/min/max of cv and expert
-  utilization) plus top-K/bottom-K individual expert utilization ratios.
+  utilization, diversity metrics) plus top-K/bottom-K individual expert
+  utilization ratios.
 - **detailed**: Everything in brief, plus per-layer breakdowns
-  (``moe/layer_{i}/cv``, ``moe/layer_{i}/utilization_mean``, etc.).
+  (``moe/layer_{i}/cv``, ``moe/layer_{i}/utilization_mean``,
+  ``moe/layer_{i}/expert_diversity``, etc.).
 """
 
 from __future__ import annotations
 
+import math
 import statistics
 
 import torch
@@ -233,6 +241,79 @@ def _compute_utilization_aggregates(
     return metrics
 
 
+def _compute_diversity_per_layer(
+    per_layer_utilizations: list[torch.Tensor],
+) -> list[dict[str, float]]:
+    """Compute per-layer expert diversity metrics from utilization ratios.
+
+    For each layer, computes:
+    - ``dead_expert_frac``: fraction of experts with zero load.
+    - ``expert_diversity``: ``exp(H) / N`` where ``H`` is Shannon entropy of
+      the token routing distribution.  1.0 = perfectly uniform, 1/N = all
+      tokens routed to a single expert, 0 = all-zero load.
+
+    Args:
+        per_layer_utilizations: List of ``Tensor[n_experts]`` with utilization
+            ratios (1.0 = ideal load).
+
+    Returns:
+        List of dicts (one per layer) with the metrics above.
+    """
+    results: list[dict[str, float]] = []
+    for util in per_layer_utilizations:
+        n_experts = util.shape[0]
+        total = util.sum()
+
+        if total == 0:
+            results.append({"dead_expert_frac": 1.0, "expert_diversity": 0.0})
+            continue
+
+        dead_expert_frac = (util == 0).float().mean().item()
+
+        # Probability distribution: p_i = util_i / sum(util)
+        p = util / total
+        p_nonzero = p[p > 0]
+        H = -(p_nonzero * p_nonzero.log()).sum().item()
+        effective_frac = math.exp(H) / n_experts if n_experts > 0 else 0.0
+
+        results.append({"dead_expert_frac": dead_expert_frac, "expert_diversity": effective_frac})
+    return results
+
+
+def _aggregate_diversity_metrics(
+    per_layer_diversity: list[dict[str, float]],
+    per_layer: bool = False,
+) -> dict[str, float]:
+    """Aggregate per-layer diversity metrics into model-level summaries.
+
+    Args:
+        per_layer_diversity: Output of :func:`_compute_diversity_per_layer`.
+        per_layer: If ``True``, also emit per-layer keys (for detailed mode).
+
+    Returns:
+        Dict with ``moe/dead_expert_frac_mean``, ``moe/expert_diversity_mean``,
+        ``moe/expert_diversity_min``, and optionally per-layer keys.
+    """
+    if not per_layer_diversity:
+        return {}
+
+    metrics: dict[str, float] = {}
+
+    dead_fracs = [m["dead_expert_frac"] for m in per_layer_diversity]
+    diversities = [m["expert_diversity"] for m in per_layer_diversity]
+
+    metrics["moe/dead_expert_frac_mean"] = sum(dead_fracs) / len(dead_fracs)
+    metrics["moe/expert_diversity_mean"] = sum(diversities) / len(diversities)
+    metrics["moe/expert_diversity_min"] = min(diversities)
+
+    if per_layer:
+        for i, m in enumerate(per_layer_diversity):
+            metrics[f"moe/layer_{i}/dead_expert_frac"] = m["dead_expert_frac"]
+            metrics[f"moe/layer_{i}/expert_diversity"] = m["expert_diversity"]
+
+    return metrics
+
+
 def compute_brief_metrics(
     layer_loads: dict[str, dict],
     top_k: int = 5,
@@ -269,6 +350,7 @@ def compute_brief_metrics(
 
     metrics.update(_compute_expert_utilization(per_layer_utils, top_k=top_k))
     metrics.update(_compute_utilization_aggregates(per_layer_utils, per_layer=False))
+    metrics.update(_aggregate_diversity_metrics(_compute_diversity_per_layer(per_layer_utils), per_layer=False))
     return metrics
 
 
@@ -310,4 +392,5 @@ def compute_detailed_metrics(
 
     metrics.update(_compute_expert_utilization(per_layer_utils, top_k=top_k))
     metrics.update(_compute_utilization_aggregates(per_layer_utils, per_layer=True))
+    metrics.update(_aggregate_diversity_metrics(_compute_diversity_per_layer(per_layer_utils), per_layer=True))
     return metrics

--- a/tests/unit_tests/moe/test_load_balance_metrics.py
+++ b/tests/unit_tests/moe/test_load_balance_metrics.py
@@ -263,6 +263,76 @@ class TestComputeDetailedMetrics:
         assert metrics["moe/layer_1/utilization_mean"] == pytest.approx(1.0, abs=1e-4)
 
 
+class TestDiversityMetrics:
+    def test_uniform_load(self):
+        """Uniform load: no dead experts, diversity=1.0."""
+        layer_loads = _make_layer_loads([[100.0, 100.0, 100.0, 100.0]])
+        metrics = compute_brief_metrics(layer_loads)
+
+        assert metrics["moe/dead_expert_frac_mean"] == pytest.approx(0.0, abs=1e-6)
+        assert metrics["moe/expert_diversity_mean"] == pytest.approx(1.0, abs=1e-4)
+        assert metrics["moe/expert_diversity_min"] == pytest.approx(1.0, abs=1e-4)
+
+    def test_single_expert_receives_all(self):
+        """All tokens to one expert: dead_frac=0.75, diversity=0.25."""
+        layer_loads = _make_layer_loads([[400.0, 0.0, 0.0, 0.0]])
+        metrics = compute_brief_metrics(layer_loads)
+
+        assert metrics["moe/dead_expert_frac_mean"] == pytest.approx(0.75, abs=1e-4)
+        # exp(0) / 4 = 1/4 = 0.25
+        assert metrics["moe/expert_diversity_mean"] == pytest.approx(0.25, abs=1e-4)
+
+    def test_two_of_four_experts_used(self):
+        """Two equally loaded experts out of 4: diversity=0.5."""
+        layer_loads = _make_layer_loads([[200.0, 200.0, 0.0, 0.0]])
+        metrics = compute_brief_metrics(layer_loads)
+
+        assert metrics["moe/dead_expert_frac_mean"] == pytest.approx(0.5, abs=1e-4)
+        # exp(log(2)) / 4 = 2/4 = 0.5
+        assert metrics["moe/expert_diversity_mean"] == pytest.approx(0.5, abs=1e-4)
+
+    def test_all_zero_load(self):
+        """All experts receive 0 tokens: dead_frac=1.0, diversity=0."""
+        layer_loads = _make_layer_loads([[0.0, 0.0, 0.0, 0.0]])
+        metrics = compute_brief_metrics(layer_loads)
+
+        assert metrics["moe/dead_expert_frac_mean"] == pytest.approx(1.0, abs=1e-4)
+        assert metrics["moe/expert_diversity_mean"] == pytest.approx(0.0, abs=1e-4)
+
+    def test_diversity_min_across_layers(self):
+        """Min should reflect the worst layer."""
+        # Layer 0: uniform (diversity=1.0), Layer 1: single expert (diversity=0.5)
+        layer_loads = _make_layer_loads([[100.0, 100.0], [200.0, 0.0]])
+        metrics = compute_brief_metrics(layer_loads)
+
+        assert metrics["moe/expert_diversity_min"] == pytest.approx(0.5, abs=1e-4)
+        assert metrics["moe/expert_diversity_mean"] == pytest.approx(0.75, abs=1e-4)
+
+    def test_detailed_includes_per_layer(self):
+        """Detailed mode should include per-layer diversity keys."""
+        layer_loads = _make_layer_loads([[100.0, 200.0], [150.0, 150.0]])
+        metrics = compute_detailed_metrics(layer_loads)
+
+        assert "moe/layer_0/dead_expert_frac" in metrics
+        assert "moe/layer_0/expert_diversity" in metrics
+        assert "moe/layer_1/dead_expert_frac" in metrics
+        assert "moe/layer_1/expert_diversity" in metrics
+
+    def test_brief_no_per_layer(self):
+        """Brief mode should NOT include per-layer diversity keys."""
+        layer_loads = _make_layer_loads([[100.0, 200.0], [150.0, 150.0]])
+        metrics = compute_brief_metrics(layer_loads)
+
+        assert "moe/layer_0/dead_expert_frac" not in metrics
+        assert "moe/layer_0/expert_diversity" not in metrics
+
+    def test_empty_input(self):
+        """Empty input should produce empty metrics."""
+        metrics = compute_brief_metrics({})
+        assert "moe/dead_expert_frac_mean" not in metrics
+        assert "moe/expert_diversity_mean" not in metrics
+
+
 class TestEnableLoadBalanceTracking:
     def test_sets_flag_on_gate_modules(self):
         """enable_load_balance_tracking should set _track_load_balance on all Gates."""


### PR DESCRIPTION
## Summary
- Add two new MoE diversity metrics to `load_balance_metrics.py`:
  - `dead_expert_frac`: fraction of experts receiving zero tokens
  - `expert_diversity`: `exp(H)/N` where H is Shannon entropy of the routing distribution (1.0 = all experts equally used, 0 = collapsed)
- Metrics are computed per-layer and aggregated: `moe/dead_expert_frac_mean`, `moe/expert_diversity_mean`, `moe/expert_diversity_min` (brief mode); per-layer keys added in detailed mode
- No config or training recipe changes needed — metrics flow through existing `compute_brief/detailed_metrics` return dicts

## Wandb run
https://wandb.ai/Nemo-automodel/automodel-diversity-metrics/runs/hrhglh2o

## Test plan
- [x] All 32 unit tests pass (`pytest tests/unit_tests/moe/test_load_balance_metrics.py`)
- [x] 8 new tests in `TestDiversityMetrics` covering uniform load, single-expert collapse, partial usage, all-zero edge case, multi-layer min, detailed vs brief mode, empty input
- [x] Existing negative assertion tests (`test_no_imbalance_or_entropy_keys`) still pass
- [x] Verified end-to-end with Qwen3-30B-A3B finetuning (100 steps, detailed mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)