### PR TITLE
fix: construct rope_parameters fallback for MiniMaxM2

### DIFF
--- a/nemo_automodel/components/models/minimax_m2/model.py
+++ b/nemo_automodel/components/models/minimax_m2/model.py
@@ -131,7 +131,7 @@ class MiniMaxM2Model(nn.Module):
         if not hasattr(config, "rope_parameters") or config.rope_parameters is None:
             rotary_dim = getattr(config, "rotary_dim", self.head_dim)
             config.rope_parameters = {
-                "rope_theta": getattr(config, "rope_theta", 10000.0),
+                "rope_theta": getattr(config, "rope_theta", 5000000.0),
                 "rope_type": "default",
                 "partial_rotary_factor": rotary_dim / self.head_dim,
             }

--- a/tests/unit_tests/models/minimax_m2/test_minimax_m2_model.py
+++ b/tests/unit_tests/models/minimax_m2/test_minimax_m2_model.py
@@ -149,7 +149,7 @@ class TestRopeParametersFallback:
         assert cfg.rope_parameters["partial_rotary_factor"] == pytest.approx(1.0)
 
     def test_defaults_when_rope_theta_missing(self, backend):
-        """When rope_theta is absent, it should default to 10000.0."""
+        """When rope_theta is absent, it should default to 5000000.0."""
         cfg = SimpleNamespace(
             vocab_size=128, hidden_size=64, intermediate_size=32, num_hidden_layers=2,
             num_attention_heads=4, num_key_value_heads=2, head_dim=16, rotary_dim=8,
@@ -158,7 +158,7 @@ class TestRopeParametersFallback:
             use_qk_norm=True, torch_dtype="bfloat16",
         )
         model = MiniMaxM2Model(cfg, backend)
-        assert cfg.rope_parameters["rope_theta"] == 10000.0
+        assert cfg.rope_parameters["rope_theta"] == 5000000.0
 
 
 class TestMiniMaxM2Block:


### PR DESCRIPTION
## Summary
- The HuggingFace `MiniMaxM2Config` (e.g. [MiniMax-M2.5](https://huggingface.co/MiniMaxAI/MiniMax-M2.5)) provides `rope_theta` and `rotary_dim` as separate config attributes but does not expose a `rope_parameters` dict, causing an `AttributeError` in `get_rope_config()` during model init.
- Constructs `rope_parameters` from available HF config fields (`rope_theta`, `rotary_dim`, `head_dim`) when the attribute is missing or `None`, matching the pattern used by other models (e.g. Mistral3).
- Adds 6 unit tests covering: missing attribute, `None` value, preservation of existing params, `partial_rotary_factor` computation, and defaults for missing `rotary_dim`/`rope_theta`.

## Test plan
- [x] All 6 new `TestRopeParametersFallback` tests pass
- [x] All 5 existing minimax_m2 tests still pass (11/11 total)
- [x] Pre-commit hooks (ruff, ruff-format, trailing whitespace) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)