### PR TITLE
fix: TP paralellizer with replicated qkvs

### DIFF
--- a/nemo_automodel/components/distributed/parallelizer.py
+++ b/nemo_automodel/components/distributed/parallelizer.py
@@ -175,7 +175,8 @@ class DefaultParallelizationStrategy(ParallelizationStrategy):
                         category=UserWarning,
                     )
                     parallelize_module(model, tp_mesh, model_parallel_plan)
-                _update_attention_head_counts_for_tp(model, tp_mesh.size())
+                if _attention_is_head_sharded(model_parallel_plan):
+                    _update_attention_head_counts_for_tp(model, tp_mesh.size())
 
         # Apply activation checkpointing to linear layers if requested
         if activation_checkpointing:
@@ -747,6 +748,33 @@ def translate_to_torch_parallel_style(style: str):
         return SequenceParallel()
     else:
         raise ValueError(f"Unknown parallel style: {style}")
+
+
+def _attention_is_head_sharded(model_parallel_plan: dict) -> bool:
+    """Return True when the TP plan column-wise shards any QKV attention projection.
+
+    When Q/K/V projections use ``ColwiseParallel`` with sharded output (the
+    default), each TP rank holds ``num_heads / tp_size`` heads and the model
+    config / layer attributes must be updated accordingly.
+
+    Plans that keep attention replicated (e.g. Phi-3 with ``RowwiseParallel``
+    on fused QKV and ``Replicate`` output) should *not* trigger a head-count
+    update.
+    """
+    attn_proj_suffixes = ("self_attn.q_proj", "self_attn.k_proj", "self_attn.v_proj", "self_attn.qkv_proj")
+    for key, style in model_parallel_plan.items():
+        if not any(key.endswith(s) for s in attn_proj_suffixes):
+            continue
+        if isinstance(style, ColwiseParallel):
+            out = getattr(style, "output_layouts", None)
+            if out is None:
+                return True
+            if isinstance(out, (list, tuple)):
+                if any(isinstance(p, Shard) for p in out):
+                    return True
+            elif isinstance(out, Shard):
+                return True
+    return False
 
 
 def _update_attention_head_counts_for_tp(model: nn.Module, tp_size: int) -> None:

--- a/tests/unit_tests/distributed/test_parallelizer.py
+++ b/tests/unit_tests/distributed/test_parallelizer.py
@@ -25,10 +25,12 @@ from torch.distributed.tensor.parallel import (
     RowwiseParallel,
     SequenceParallel,
 )
+from torch.distributed.tensor.placement_types import Replicate, Shard
 from transformers.models.gemma3.modeling_gemma3 import Gemma3ForConditionalGeneration
 
 # Import the function under test
 from nemo_automodel.components.distributed.parallelizer import (
+    _attention_is_head_sharded,
     _get_parallel_plan,
     _update_attention_head_counts_for_tp,
     apply_fsdp2_sharding_recursively,
@@ -1073,3 +1075,55 @@ class TestUpdateAttentionHeadCountsForTP:
         model = nn.Module()
         model.config = SimpleNamespace(num_attention_heads=8, hidden_size=64)
         _update_attention_head_counts_for_tp(model, tp_size=2)
+
+
+class TestAttentionIsHeadSharded:
+    """Tests for _attention_is_head_sharded."""
+
+    def test_colwise_default_is_sharded(self):
+        """ColwiseParallel() with default output (Shard) → heads are sharded."""
+        plan = {
+            "model.layers.*.self_attn.q_proj": ColwiseParallel(),
+            "model.layers.*.self_attn.k_proj": ColwiseParallel(),
+            "model.layers.*.self_attn.v_proj": ColwiseParallel(),
+            "model.layers.*.self_attn.o_proj": RowwiseParallel(),
+        }
+        assert _attention_is_head_sharded(plan) is True
+
+    def test_colwise_explicit_shard_is_sharded(self):
+        plan = {
+            "model.layers.*.self_attn.q_proj": ColwiseParallel(output_layouts=Shard(-1)),
+        }
+        assert _attention_is_head_sharded(plan) is True
+
+    def test_rowwise_replicate_is_not_sharded(self):
+        """Phi-3 style: RowwiseParallel with Replicate output → not sharded."""
+        plan = {
+            "model.layers.*.self_attn.qkv_proj": RowwiseParallel(
+                input_layouts=Replicate(),
+                output_layouts=Replicate(),
+            ),
+            "model.layers.*.self_attn.o_proj": ColwiseParallel(
+                input_layouts=Replicate(),
+                output_layouts=Replicate(),
+            ),
+        }
+        assert _attention_is_head_sharded(plan) is False
+
+    def test_colwise_replicate_output_is_not_sharded(self):
+        """ColwiseParallel with explicit Replicate output → not sharded."""
+        plan = {
+            "model.layers.*.self_attn.q_proj": ColwiseParallel(output_layouts=Replicate()),
+        }
+        assert _attention_is_head_sharded(plan) is False
+
+    def test_no_attn_keys_is_not_sharded(self):
+        """Plan with only MLP entries → not sharded."""
+        plan = {
+            "model.layers.*.mlp.gate_up_proj": ColwiseParallel(),
+            "model.layers.*.mlp.down_proj": RowwiseParallel(),
+        }
+        assert _attention_is_head_sharded(plan) is False
+
+    def test_empty_plan_is_not_sharded(self):
+        assert _attention_is_head_sharded({}) is False


### PR DESCRIPTION
# What does this PR do ?

Root cause: Commit c86eebb5 ("fix: tp plan for nemotron super (#1487)") introduced _update_attention_head_counts_for_tp which unconditionally halves num_attention_heads and num_key_value_heads on every model after TP parallelization. This was needed for models like Llama/DeciLM where ColwiseParallel on Q/K/V actually splits heads across ranks.

However, Phi3ForCausalLM (the architecture phi-4 uses) has a TP plan (_parallelize_phi3) that keeps attention replicated — fused qkv_proj uses RowwiseParallel(output_layouts=Replicate()), so the QKV output remains full-size on every rank. The unconditional head count halving causes Phi3Attention.forward() to slice the QKV tensor with wrong offsets (query_pos = self.num_heads * self.head_dim uses the halved count), producing a value tensor with a shape that flash attention rejects.


# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
