### PR TITLE
ci: add default env vars ala .github/actions/test-template/action.yml L120

### DIFF
--- a/tests/functional_tests/conftest.py
+++ b/tests/functional_tests/conftest.py
@@ -11,7 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
+
 import pytest
+
+os.environ.setdefault("HF_CACHE", "/home/TestData/lite/hf_cache")
+os.environ.setdefault("HF_HOME", "/home/TestData/HF_HOME")
 
 # Ensure the repository root is importable so functional tests can do
 # `from tests.utils.test_utils import run_test_script` reliably across

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import importlib
-import sys
 import os
 import sys
 import types
@@ -20,6 +19,9 @@ from pathlib import Path
 from shutil import rmtree
 
 import pytest
+
+os.environ.setdefault("HF_CACHE", "/home/TestData/lite/hf_cache")
+os.environ.setdefault("HF_HOME", "/home/TestData/HF_HOME")
 
 # ---------------------------------------------------------------------------
 # Shim: ``transformers.initialization`` was added in transformers >=4.48.


### PR DESCRIPTION
# What does this PR do ?

Developers who run the tests locally, have to pass HF_HOME/HF_CACHE manually. 

Instead of hardcoding them everywhere (brittle if dev in multiple projects), this PR introduces default environment variables, allowing developers who have the above paths mounted on their dev machine to invoke pytest without having to pass custom environment variables.


# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
