### PR TITLE
ci: improve functional test msg

### DIFF
--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 import os
-import subprocess
 import signal
+import subprocess
 import sys
+
 
 def run_test_script(folder, test_filename):
     dir_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
@@ -24,24 +25,36 @@ def run_test_script(folder, test_filename):
     # If pytest is invoked from a different (or problematic) cwd (e.g., stale NFS/autofs),
     # inheriting that cwd can make `pwd`/getcwd() block and the test appears to "hang".
     repo_root = os.path.dirname(dir_path)
-    test_file_path = os.path.join(dir_path, 'functional_tests', folder, test_filename)
-    
+    test_file_path = os.path.join(dir_path, "functional_tests", folder, test_filename)
+
     # Check if -s flag was passed to pytest and propagate it to the bash script
     env = os.environ.copy()
-    if '-s' in sys.argv or '--capture=no' in sys.argv:
-        env['PYTEST_PROPAGATE_S'] = '1'
-    
+    if "-s" in sys.argv or "--capture=no" in sys.argv:
+        env["PYTEST_PROPAGATE_S"] = "1"
+
     p = subprocess.Popen(
         ["bash", test_file_path],
         cwd=repo_root,
         env=env,
-        preexec_fn=os.setsid          # On Unix: puts it in a new session/process group
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        preexec_fn=os.setsid,
     )
 
+    output_lines = []
     try:
-        assert p.wait() == 0
+        for line in p.stdout:
+            decoded = line.decode("utf-8", errors="replace")
+            output_lines.append(decoded)
+            sys.stdout.write(decoded)
+            sys.stdout.flush()
+        p.wait()
+        if p.returncode != 0:
+            tail = "".join(output_lines[-50:])
+            raise AssertionError(
+                f"Script {test_filename} failed with exit code {p.returncode}.\n--- last 50 lines of output ---\n{tail}"
+            )
     finally:
-        # Kill the entire process group, not just p
         try:
             os.killpg(os.getpgid(p.pid), signal.SIGTERM)
         except ProcessLookupError:


### PR DESCRIPTION
# What does this PR do ?

run_test_script does `assert p.wait() == 0`, which gives zero context about what actually failed inside the bash script.

This PR captures the subprocess output and includes the tail in the error message.


# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
