### PR TITLE
feat: Enable custom chat_template override for VLM fine-tuning

### DIFF
--- a/docs/guides/dataset-overview.md
+++ b/docs/guides/dataset-overview.md
@@ -466,6 +466,18 @@ Each example follows the conversation schema expected by `apply_chat_template`, 
 }
 ```
 
+### Custom Chat Template
+By default, VLM fine-tuning uses the chat template built into the model's `AutoProcessor`. To override it, add `chat_template` under `dataset:` in your YAML config:
+
+```yaml
+dataset:
+  _target_: nemo_automodel.components.datasets.vlm.datasets.make_medpix_dataset
+  split: train
+  chat_template: "{% for msg in messages %}{{ msg.role }}: {{ msg.content }}\n{% endfor %}"
+```
+
+`chat_template` accepts a Jinja template string, a path to a `.jinja` file, or a path to a JSON file containing a `chat_template` key. The override is applied to both the processor and its tokenizer before dataset instantiation.
+
 ### Collate Functions
 - `nemo_automodel.components.datasets.vlm.collate_fns.default_collate_fn`
 - `nemo_automodel.components.datasets.vlm.collate_fns.qwen2_5_collate_fn` (Qwen2.5 VL)

--- a/docs/guides/vlm/dataset.md
+++ b/docs/guides/vlm/dataset.md
@@ -136,6 +136,24 @@ dataset:
 This will call `build_my_dataset()` from the specified file with the other keys (e.g., num_blocks) as arguments. This approach allows you to integrate custom datasets via config alone—no need to alter the codebase or package structure.
 
 
+## Custom Chat Template
+
+By default, VLM fine-tuning uses the chat template built into the model's `AutoProcessor`. To use a custom template, add `chat_template` under `dataset:` in your YAML config:
+
+```yaml
+dataset:
+  _target_: nemo_automodel.components.datasets.vlm.datasets.make_medpix_dataset
+  split: train
+  chat_template: /path/to/template.jinja
+```
+
+Accepted values:
+- A Jinja template string (e.g., `"{% for msg in messages %}..."`)
+- A path to a `.jinja` template file
+- A path to a JSON file containing a `chat_template` key (e.g., `tokenizer_config.json`)
+
+The override is applied to both `processor.chat_template` and `processor.tokenizer.chat_template` before dataset loading.
+
 ## Troubleshooting Tips
 
 - **Tokenization Mismatch?** Ensure your tokenizer aligns with the model's expected inputs.

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -36,6 +36,7 @@ from nemo_automodel._transformers import NeMoAutoModelForImageTextToText, NeMoAu
 from nemo_automodel._transformers.utils import apply_cache_compatibility_patches
 from nemo_automodel.components.checkpoint.checkpointing import Checkpointer, CheckpointingConfig
 from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
+from nemo_automodel.components.datasets.llm.formatting_utils import _resolve_chat_template
 from nemo_automodel.components.datasets.vlm.collate_fns import COLLATE_FNS
 from nemo_automodel.components.distributed.config import MegatronFSDPConfig
 from nemo_automodel.components.distributed.cp_utils import make_cp_batch_and_ctx
@@ -271,6 +272,12 @@ def build_dataloader(
                     # Some models do not provide an AutoProcessor
                     processor = None
                     logging.warning(f"AutoProcessor not available for {pretrained_model_name_or_path} ({e}). ")
+
+            chat_template_raw = cfg_ds.__dict__.pop("chat_template", None)
+            # Update chat_template if chat_template is given
+            if chat_template_raw is not None and processor is not None:
+                processor.chat_template = _resolve_chat_template(chat_template_raw)
+                processor.tokenizer.chat_template = processor.chat_template
 
             ds = cfg_ds.instantiate(path_or_dataset=cfg_ds.path_or_dataset)
 

--- a/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
+++ b/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
@@ -519,6 +519,71 @@ def test_autoprocessor_with_processor_kwargs(caplog):
 
 
 # -----------------------------------------------------------------------------
+# chat_template override tests for build_dataloader
+# -----------------------------------------------------------------------------
+
+
+def test_build_dataloader_chat_template_applied():
+    """chat_template in dataset config is applied to processor and not leaked to dataset target."""
+    from nemo_automodel.recipes.vlm.finetune import build_dataloader
+
+    ds_calls = []
+
+    def ds_factory(path_or_dataset, split=None):
+        ds_calls.append({"path_or_dataset": path_or_dataset, "split": split})
+        return []
+
+    class DummyProcessor:
+        def __init__(self):
+            self.chat_template = "{{ default }}"
+            self.tokenizer = SimpleNamespace(chat_template="{{ default }}")
+
+    processor = DummyProcessor()
+    cfg_ds = ConfigNode(
+        {"_target_": ds_factory, "path_or_dataset": "ds/path", "split": "train", "chat_template": "{{ custom }}"}
+    )
+    cfg_dl = MagicMock()
+    cfg_dl.get.return_value = None
+    cfg_dl.instantiate.return_value = MagicMock()
+
+    with patch("transformers.AutoProcessor.from_pretrained", return_value=processor), \
+         patch("torch.utils.data.distributed.DistributedSampler"), \
+         patch("nemo_automodel.components.datasets.vlm.collate_fns.COLLATE_FNS", {"default": MagicMock()}):
+        _, built_processor = build_dataloader(cfg_ds, cfg_dl, "model", None, None, 42, 1)
+
+    assert built_processor.chat_template == "{{ custom }}"
+    assert built_processor.tokenizer.chat_template == "{{ custom }}"
+    assert ds_calls == [{"path_or_dataset": "ds/path", "split": "train"}]
+
+
+def test_build_dataloader_no_chat_template():
+    """Without chat_template, processor template stays unchanged."""
+    from nemo_automodel.recipes.vlm.finetune import build_dataloader
+
+    def ds_factory(path_or_dataset, split=None):
+        return []
+
+    class DummyProcessor:
+        def __init__(self):
+            self.chat_template = "{{ original }}"
+            self.tokenizer = SimpleNamespace(chat_template="{{ original }}")
+
+    processor = DummyProcessor()
+    cfg_ds = ConfigNode({"_target_": ds_factory, "path_or_dataset": "ds/path", "split": "train"})
+    cfg_dl = MagicMock()
+    cfg_dl.get.return_value = None
+    cfg_dl.instantiate.return_value = MagicMock()
+
+    with patch("transformers.AutoProcessor.from_pretrained", return_value=processor), \
+         patch("torch.utils.data.distributed.DistributedSampler"), \
+         patch("nemo_automodel.components.datasets.vlm.collate_fns.COLLATE_FNS", {"default": MagicMock()}):
+        _, built_processor = build_dataloader(cfg_ds, cfg_dl, "model", None, None, 42, 1)
+
+    assert built_processor.chat_template == "{{ original }}"
+    assert built_processor.tokenizer.chat_template == "{{ original }}"
+
+
+# -----------------------------------------------------------------------------
 # State dict adapter tests for _maybe_adapt_state_dict_to_hf in VLM
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
# What does this PR do ?

Enable custom chat template override for VLM fine-tuning, matching the existing LLM `ChatDataset` capability. Users can now specify `chat_template` under `dataset:` in any VLM YAML config to override the processor's default template.

# Changelog

- Import `_resolve_chat_template` from LLM formatting utilities in `nemo_automodel/recipes/vlm/finetune.py`.
- In `build_dataloader()`, pop optional `chat_template` from dataset config before `instantiate()` to prevent it leaking as an unexpected kwarg.
- If `chat_template` is provided and a processor is available, resolve and apply the template to both `processor.chat_template` and `processor.tokenizer.chat_template`.
- Add two unit tests in `tests/unit_tests/recipes/test_finetune_vlm_helpers.py` covering override and no-override paths.
- Add "Custom Chat Template" documentation section to `docs/guides/dataset-overview.md` and `docs/guides/vlm/dataset.md`.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

# Additional Information

- Related to https://github.com/NVIDIA-NeMo/Automodel/discussions/1161