### PR TITLE
fix: handle Nemotron V3 with force_hf=True in weight initialization skip logic

### DIFF
--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -512,10 +512,12 @@ class Checkpointer:
         is_nemotron_v3_hf = (
             model_class == "NemotronHForCausalLM"
             and getattr(model.config, "n_routed_experts", None)  # is Nemotron V3
-            and hasattr(model, "backbone")                       # is HF remote code
+            and hasattr(model, "backbone")  # is HF remote code
         )
         skip_initialize_weights = (
-            model_class in ["Gemma3ForConditionalGeneration", "Gemma3ForCausalLM"] or is_nemotron_v2 or is_nemotron_v3_hf
+            model_class in ["Gemma3ForConditionalGeneration", "Gemma3ForCausalLM"]
+            or is_nemotron_v2
+            or is_nemotron_v3_hf
         )
         if not skip_initialize_weights:
             for _, module in model.named_modules():


### PR DESCRIPTION
# What does this PR do ?

### Background

In `Checkpointer`'s weight initialization logic, the HF remote code's `_init_weights` for
`NemotronHForCausalLM` calls `dt_bias.copy_()`, which is incompatible with DTensors and causes
a crash during training.

The existing logic skips weight initialization for `is_nemotron_v2` (i.e., `NemotronHForCausalLM`
without `n_routed_experts`), but **missed the case where Nemotron V3 (MoE) runs with `force_hf=True`**.

### Root Cause

Nemotron V3 (MoE, has `n_routed_experts`) has two distinct code paths:

| Mode | Model structure | `_init_weights` used | DTensor compatible? |
|---|---|---|---|
| `force_hf=False` (default) | `model.model` (ModuleDict layers, custom impl) | Custom implementation, handles DTensor correctly | ✅ No issue |
| `force_hf=True` | `model.backbone` (HF remote code) | HF remote code, calls `dt_bias.copy_()` | ❌ Crashes |

The original code only skipped the V2 case. The V3 + `force_hf=True` path was unhandled,
causing the incompatible `_init_weights` to still be invoked.


# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
