### PR TITLE
fix: fall back to HF for Mistral3 VLMs with non-Mistral4 text backbone

### DIFF
--- a/nemo_automodel/_transformers/model_init.py
+++ b/nemo_automodel/_transformers/model_init.py
@@ -201,8 +201,9 @@ def get_is_hf_model(config, force_hf):
     """
     # Finally make sure flash_attention is available
     architectures = getattr(config, "architectures", None) or []
-    is_hf_model = (not architectures or architectures[0] not in ModelRegistry.model_arch_name_to_cls) or force_hf
-    return is_hf_model
+    if force_hf or not architectures:
+        return True
+    return ModelRegistry.resolve_custom_model_cls(architectures[0], config) is None
 
 
 def _download_model_weights(hf_config, pretrained_model_name_or_path):
@@ -273,14 +274,14 @@ def _init_model(
 
     architectures = get_architectures(hf_config)
     # 2. If we have a custom model implementation available, we prioritize that over HF
-    if len(architectures) > 0 and architectures[0] in ModelRegistry.model_arch_name_to_cls:
+    model_cls = ModelRegistry.resolve_custom_model_cls(architectures[0], hf_config) if architectures else None
+    if model_cls is not None:
         # if we are able to init the custom model, we will now download the model weights on local rank 0
         # Skip download for from_config (no pretrained path) or local paths
         if pretrained_model_name_or_path:
             _download_model_weights(hf_config, pretrained_model_name_or_path)
         logger.info(f"Using custom model implementation for {architectures[0]}")
         kwargs.pop("trust_remote_code", None)
-        model_cls = ModelRegistry.model_arch_name_to_cls[architectures[0]]
         # Treat config-related kwargs as config overrides (HF behavior) and
         # avoid forwarding them into model __init__.
         init_param_names = _get_init_param_names(model_cls)

--- a/nemo_automodel/_transformers/registry.py
+++ b/nemo_automodel/_transformers/registry.py
@@ -243,6 +243,25 @@ class _ModelRegistry:
     def get_model_cls_from_model_arch(self, model_arch: str) -> Type[nn.Module]:
         return self.model_arch_name_to_cls[model_arch]
 
+    def resolve_custom_model_cls(self, architecture: str, config) -> Union[Type[nn.Module], None]:
+        """Return the custom model class if it exists and supports *config*, else ``None``.
+
+        Custom model classes may define a ``supports_config(config)`` classmethod
+        to opt out for specific HF configs (e.g. a Mistral3 VLM with a dense
+        Ministral3 text backbone instead of the expected Mistral4 MoE+MLA).
+        """
+        if architecture not in self.model_arch_name_to_cls:
+            return None
+        model_cls = self.model_arch_name_to_cls[architecture]
+        if hasattr(model_cls, "supports_config") and not model_cls.supports_config(config):
+            logger.info(
+                "Custom model %s does not support config %s, falling back to HF",
+                model_cls.__name__,
+                type(config).__name__,
+            )
+            return None
+        return model_cls
+
     def register(self, arch_name: str, model_cls: Type[nn.Module], exist_ok: bool = False) -> None:
         """Register a custom model class for a given architecture name."""
         self.model_arch_name_to_cls.register(arch_name, model_cls, exist_ok=exist_ok)

--- a/nemo_automodel/components/models/mistral4/model.py
+++ b/nemo_automodel/components/models/mistral4/model.py
@@ -609,6 +609,12 @@ if _HF_MISTRAL3_AVAILABLE:
         """
 
         @classmethod
+        def supports_config(cls, config) -> bool:
+            """Only handle configs whose text backbone is Mistral4 (MoE + MLA)."""
+            text_config = getattr(config, "text_config", None)
+            return text_config is not None and getattr(text_config, "model_type", None) == "mistral4"
+
+        @classmethod
         def from_config(
             cls,
             config,

--- a/tests/unit_tests/_transformers/test_registry.py
+++ b/tests/unit_tests/_transformers/test_registry.py
@@ -172,6 +172,76 @@ def test_default_registry_has_static_entries():
         assert arch_name in inst.model_arch_name_to_cls.keys()
 
 
+def test_resolve_custom_model_cls_found():
+    """resolve_custom_model_cls returns the class when it exists and has no supports_config."""
+    from nemo_automodel._transformers import registry as reg
+
+    inst = _new_registry_instance(reg)
+
+    class PlainModel:
+        pass
+
+    inst.register("PlainModel", PlainModel)
+    assert inst.resolve_custom_model_cls("PlainModel", object()) is PlainModel
+
+
+def test_resolve_custom_model_cls_not_found():
+    """resolve_custom_model_cls returns None for unregistered architectures."""
+    from nemo_automodel._transformers import registry as reg
+
+    inst = _new_registry_instance(reg)
+    assert inst.resolve_custom_model_cls("NonExistent", object()) is None
+
+
+def test_resolve_custom_model_cls_supports_config_true():
+    """resolve_custom_model_cls returns the class when supports_config returns True."""
+    from nemo_automodel._transformers import registry as reg
+
+    inst = _new_registry_instance(reg)
+
+    class SupportedModel:
+        @classmethod
+        def supports_config(cls, config):
+            return True
+
+    inst.register("SupportedModel", SupportedModel)
+    assert inst.resolve_custom_model_cls("SupportedModel", object()) is SupportedModel
+
+
+def test_resolve_custom_model_cls_supports_config_false():
+    """resolve_custom_model_cls returns None when supports_config returns False."""
+    from nemo_automodel._transformers import registry as reg
+
+    inst = _new_registry_instance(reg)
+
+    class UnsupportedModel:
+        @classmethod
+        def supports_config(cls, config):
+            return False
+
+    inst.register("UnsupportedModel", UnsupportedModel)
+    assert inst.resolve_custom_model_cls("UnsupportedModel", object()) is None
+
+
+def test_resolve_custom_model_cls_passes_config_to_supports():
+    """resolve_custom_model_cls passes the config to supports_config for inspection."""
+    from nemo_automodel._transformers import registry as reg
+
+    inst = _new_registry_instance(reg)
+
+    class ConfigAwareModel:
+        @classmethod
+        def supports_config(cls, config):
+            return getattr(config, "ok", False)
+
+    inst.register("ConfigAwareModel", ConfigAwareModel)
+
+    good = types.SimpleNamespace(ok=True)
+    bad = types.SimpleNamespace(ok=False)
+    assert inst.resolve_custom_model_cls("ConfigAwareModel", good) is ConfigAwareModel
+    assert inst.resolve_custom_model_cls("ConfigAwareModel", bad) is None
+
+
 def test_all_model_folders_registered_in_auto_map():
     """Every model folder with a model.py must have at least one entry in MODEL_ARCH_MAPPING.
 

--- a/tests/unit_tests/models/mistral4/test_mistral4_model.py
+++ b/tests/unit_tests/models/mistral4/test_mistral4_model.py
@@ -931,3 +931,49 @@ class TestRegistry:
         mapping = dict(MODEL_ARCH_MAPPING)
         assert mapping["Mistral4ForCausalLM"][0] == "nemo_automodel.components.models.mistral4.model"
         assert mapping["Mistral3ForConditionalGeneration"][0] == "nemo_automodel.components.models.mistral4.model"
+
+
+# ---------------------------------------------------------------------------
+# supports_config gate
+# ---------------------------------------------------------------------------
+
+
+@_skip_no_hf_mistral3
+class TestSupportsConfig:
+    def test_supports_mistral4_text_config(self, multimodal_config):
+        """supports_config returns True for Mistral3Config wrapping a Mistral4 text backbone."""
+        from nemo_automodel.components.models.mistral4.model import (
+            Mistral3ForConditionalGeneration as OurMistral3ForCG,
+        )
+
+        assert OurMistral3ForCG.supports_config(multimodal_config) is True
+
+    def test_rejects_non_mistral4_text_config(self):
+        """supports_config returns False when text_config.model_type is not 'mistral4'."""
+        from nemo_automodel.components.models.mistral4.model import (
+            Mistral3ForConditionalGeneration as OurMistral3ForCG,
+        )
+
+        config = Mock(spec=[])
+        config.text_config = Mock(spec=[])
+        config.text_config.model_type = "ministral3"
+        assert OurMistral3ForCG.supports_config(config) is False
+
+    def test_rejects_config_without_text_config(self):
+        """supports_config returns False when config has no text_config attribute."""
+        from nemo_automodel.components.models.mistral4.model import (
+            Mistral3ForConditionalGeneration as OurMistral3ForCG,
+        )
+
+        config = Mock(spec=[])
+        assert OurMistral3ForCG.supports_config(config) is False
+
+    def test_rejects_text_config_without_model_type(self):
+        """supports_config returns False when text_config has no model_type."""
+        from nemo_automodel.components.models.mistral4.model import (
+            Mistral3ForConditionalGeneration as OurMistral3ForCG,
+        )
+
+        config = Mock(spec=[])
+        config.text_config = Mock(spec=[])
+        assert OurMistral3ForCG.supports_config(config) is False


### PR DESCRIPTION
## Summary
- The custom `Mistral3ForConditionalGeneration` model (for Mistral4 MoE+MLA) was intercepting **all** models with that HF architecture, including Devstral-Small which uses a dense Ministral3 text backbone, causing `AttributeError: 'Ministral3Config' object has no attribute 'moe_intermediate_size'`
- Add `supports_config` classmethod to `Mistral3ForConditionalGeneration` that returns `False` for non-Mistral4 text configs
- Add `resolve_custom_model_cls` to `_ModelRegistry` that checks `supports_config` before returning a custom model class, falling back to HF's native implementation when unsupported
- 9 new unit tests covering `resolve_custom_model_cls` (5) and `supports_config` (4)

## Test plan
- [x] All 4129 unit tests pass locally (0 failures)
- [x] New unit tests cover `resolve_custom_model_cls` with: found/not-found/supports-true/supports-false/config-passthrough
- [x] New unit tests cover `supports_config` with: mistral4-text/non-mistral4-text/no-text-config/no-model-type
- [x] E2E: Mistral4 VLM 2-layer proxy trains successfully (custom model path)
- [x] E2E: Devstral-Small correctly falls back to HF (log: "Custom model Mistral3ForConditionalGeneration does not support config Mistral3Config, falling back to HF")
- [x] `ruff check` and `ruff format` pass on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)