### PR TITLE
fix: patch missing mock in meta-tensor retry test

### DIFF
--- a/tests/unit_tests/_transformers/test_auto_model.py
+++ b/tests/unit_tests/_transformers/test_auto_model.py
@@ -937,6 +937,10 @@ class TestBuildModelRetryDepth:
             patch("nemo_automodel._transformers.auto_model._init_model") as mock_init,
             patch("nemo_automodel._transformers.auto_model.get_world_size_safe", return_value=2),
             patch("nemo_automodel._transformers.auto_model._verify_sdpa_support"),
+            patch(
+                "nemo_automodel._transformers.capabilities.attach_capabilities_and_validate",
+                return_value=sentinel_model,
+            ),
             patch("nemo_automodel._transformers.auto_model.apply_model_infrastructure", return_value=sentinel_model),
             patch("nemo_automodel._transformers.auto_model.get_hf_config", return_value=mock_config),
             patch("nemo_automodel._transformers.auto_model._maybe_dequantize_fp8_for_peft", return_value=False),


### PR DESCRIPTION
## Summary
- Fix `test_meta_tensor_runtime_error_retries_without_meta_device` failing in L0 unit tests on main
- The test was missing a mock for `attach_capabilities_and_validate` (added in #1542), causing `validate_for_mesh` to compare MagicMock mesh attributes (`pp_size`, `ep_size`) with integers via `>`, resulting in `TypeError: '>' not supported between instances of 'MagicMock' and 'int'`
- Adds the missing patch, consistent with the sibling test `test_retry_succeeds_within_limit`

## Test plan
- [x] `test_meta_tensor_runtime_error_retries_without_meta_device` passes
- [x] All 60 tests in `test_auto_model.py` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)