### PR TITLE
fix: remove in-place change model config

### DIFF
--- a/nemo_automodel/components/distributed/parallelizer.py
+++ b/nemo_automodel/components/distributed/parallelizer.py
@@ -791,12 +791,6 @@ def _update_attention_head_counts_for_tp(model: nn.Module, tp_size: int) -> None
     config = getattr(model, "config", None)
     if config is None or not hasattr(config, "num_attention_heads"):
         return
-    model_arch = None
-    if hasattr(config, "architectures") and config.architectures:
-        try:
-            model_arch = config.architectures[0]
-        except Exception:
-            model_arch = None
     inner = getattr(model, "model", model)
     layers = getattr(inner, "layers", None)
     if layers is None and hasattr(model, "language_model"):

--- a/tests/unit_tests/distributed/test_parallelizer.py
+++ b/tests/unit_tests/distributed/test_parallelizer.py
@@ -1026,11 +1026,11 @@ class TestUpdateAttentionHeadCountsForTP:
         assert model.config.num_attention_heads == 64
         assert model.config.num_key_value_heads == 8
 
-    def test_updates_config_and_layer_attrs(self):
+    def test_preserves_config_and_updates_layer_attrs(self):
         model = self._make_model(num_heads=64, num_kv_heads=8, hidden_size=8192)
         _update_attention_head_counts_for_tp(model, tp_size=2)
-        assert model.config.num_attention_heads == 32
-        assert model.config.num_key_value_heads == 4
+        assert model.config.num_attention_heads == 64
+        assert model.config.num_key_value_heads == 8
         assert model.config.head_dim == 128
         for layer in model.model.layers:
             assert layer.self_attn.num_heads == 32


### PR DESCRIPTION
## Background
The test [test_dtensor_worker_v1_v2_model_config_equivalence](https://github.com/NVIDIA-NeMo/RL/blob/a7f39f16f85e21d7ee31e60dbc4618d33091a0d3/tests/unit/models/policy/test_dtensor_worker_v2.py#L232) in NeMo-RL verifies that dtensor v1 and v2 workers produce equivalent model configurations.
The test was failing because the model config was being mutated in-place in Automodel.
This may also affect the model config when saving checkpoint.

## Root Cause
In `_update_attention_head_counts_for_tp` inside `parallelizer.py`, the original code contained:
```python
is_decilm_nemotron_nas = model_arch == "DeciLMForCausalLM" and getattr(config, "model_type", None) == "nemotron-nas"
if not is_decilm_nemotron_nas:
    config.num_attention_heads = local_num_attention_heads
    if local_num_key_value_heads is not None:
        config.num_key_value_heads = local_num_key_value_heads
```
This directly mutated the passed-in `config` object (i.e., `model.config`), dividing `num_attention_heads` and `num_key_value_heads` by `tp_size`.

## Fix
Simply remove these lines that mutate the config in-place. The per-rank splitting of `num_attention_heads` and `num_key_value_heads` is already handled by the per-layer `self_attn` processing that follows — the config object itself does not need to be modified; only the attention module parameters on each layer need to be updated.