### PR TITLE
fix: narrow model.to(device) skip to checkpoint-loaded path only

### DIFF
--- a/nemo_automodel/_transformers/infrastructure.py
+++ b/nemo_automodel/_transformers/infrastructure.py
@@ -520,9 +520,11 @@ def apply_model_infrastructure(
     if autopipeline is None:
         print_trainable_parameters(model)  # Once model's been sharded
         # Ensure model is on the correct device.
-        # Skip when post-shard init was performed (params are already on the target device)
-        # to avoid triggering FSDP's reset_sharded_param which fails on tied parameters.
-        if not need_post_shard_init:
+        # Skip when checkpoint was loaded post-shard (params are already on the
+        # target device) to avoid triggering FSDP's reset_sharded_param which
+        # fails on tied parameters (e.g. lm_head/embed_tokens with TP>1).
+        # See: https://github.com/pytorch/pytorch/issues/151085
+        if not should_load_checkpoint:
             try:
                 model.to(device, non_blocking=True)
             except NotImplementedError as e:

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -477,16 +477,17 @@ class Checkpointer:
         to_empty_parameters_only(model, device=device)
 
         # to_empty_parameters_only only materializes parameters, not buffers.
-        # Buffers may still be on the wrong device: meta-device buffers arise
-        # from accelerate/transformers init_empty_weights(), while CPU buffers
-        # arise from our own init_empty_weights() which only intercepts
-        # register_parameter (not register_buffer).  Move any buffer that is
-        # not already on the target device so that the subsequent
-        # initialize_weights() call can overwrite them with proper values.
+        # Buffers (e.g. RoPE inv_freq) may still be on meta device.  Move them
+        # to *device* with uninitialized storage so that the subsequent
+        # initialize_weights() call can overwrite them with proper values
+        # (HF's _init_weights recomputes non-persistent buffers from config).
+        # Without this, meta buffers would survive until a later model.to_empty()
+        # call, which fills them with recycled GPU memory — values that may
+        # differ between successive model builds in the same process.
         for module in model.modules():
             for key in list(module._buffers):
                 buf = module._buffers[key]
-                if buf is not None and buf.device != device:
+                if buf is not None and buf.device.type == "meta":
                     module._buffers[key] = torch.empty_like(buf, device=device)
 
         # HF models set _is_hf_initialized to True after initialization.

--- a/tests/functional_tests/hf_transformer_llm/L2_HF_Transformer_LLM_Meta_FSDP2_TP2.sh
+++ b/tests/functional_tests/hf_transformer_llm/L2_HF_Transformer_LLM_Meta_FSDP2_TP2.sh
@@ -1,0 +1,39 @@
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/bin/bash
+set -xeuo pipefail # Exit immediately if a command exits with a non-zero status
+
+export PYTHONPATH=${PYTHONPATH:-}:$(pwd)
+export CUDA_VISIBLE_DEVICES="0,1"
+
+# Regression test for tied-param + TP=2 + meta-device init + checkpoint loading.
+# Ensures model.to(device) is correctly skipped when FSDP sharding has already
+# placed parameters on device, avoiding reset_sharded_param crash on tied params.
+# See: https://github.com/pytorch/pytorch/issues/151085
+TRANSFORMERS_OFFLINE=1 python -m torch.distributed.run --nproc_per_node=2 --nnodes=1 -m coverage run \
+-m pytest tests/functional_tests/training/test_meta_device_sft.py \
+    --config examples/llm_finetune/llama3_2/llama3_2_1b_squad.yaml \
+    --model.pretrained_model_name_or_path $TEST_DATA_DIR/hf_mixtral_2l/ \
+    --dataset.tokenizer.pretrained_model_name_or_path $TEST_DATA_DIR/hf_mixtral_2l/ \
+    --validation_dataset.tokenizer.pretrained_model_name_or_path $TEST_DATA_DIR/hf_mixtral_2l/ \
+    --dataset.dataset_name $HF_CACHE/squad/ \
+    --validation_dataset.dataset_name $HF_CACHE/squad/ \
+    --dataset.limit_dataset_samples 1000 \
+    --step_scheduler.global_batch_size 8 \
+    --step_scheduler.local_batch_size 4 \
+    --distributed.dp_size none \
+    --distributed.tp_size 2 \
+    --distributed.cp_size 1 \
+    --distributed.sequence_parallel false

--- a/tests/functional_tests/hf_transformer_llm/test_hf_transformer_llm.py
+++ b/tests/functional_tests/hf_transformer_llm/test_hf_transformer_llm.py
@@ -23,6 +23,7 @@ HF_TRANSFORMER_LLM_FSDP2_TP2_HF_TPPLAN_FILENAME = "L2_HF_Transformer_LLM_FSDP2_T
 HF_TRANSFORMER_LLM_MegatronFSDP_TP2_FILENAME = "L2_HF_Transformer_LLM_MegatronFSDP_TP2.sh"
 HF_TRANSFORMER_LLM_MegatronFSDP_TP2_HF_TPPLAN_FILENAME = "L2_HF_Transformer_LLM_MegatronFSDP_TP2_HF_TPPLAN.sh"
 HF_TRANSFORMER_LLM_DDP_FILENAME = "L2_HF_Transformer_LLM_DDP.sh"
+HF_TRANSFORMER_LLM_META_FSDP2_TP2_FILENAME = "L2_HF_Transformer_LLM_Meta_FSDP2_TP2.sh"
 
 
 
@@ -54,5 +55,11 @@ class TestHFTransformerLLM:
     def test_hf_transformer_llm_megatron_fsdp_tp2_hf_tpplan(self):
         try:
             run_test_script(TEST_FOLDER, HF_TRANSFORMER_LLM_MegatronFSDP_TP2_HF_TPPLAN_FILENAME)
+        finally:
+            shutil.rmtree("checkpoints/", ignore_errors=True)
+
+    def test_hf_transformer_llm_meta_fsdp2_tp2(self):
+        try:
+            run_test_script(TEST_FOLDER, HF_TRANSFORMER_LLM_META_FSDP2_TP2_FILENAME)
         finally:
             shutil.rmtree("checkpoints/", ignore_errors=True)

--- a/tests/unit_tests/_transformers/test_infrastructure.py
+++ b/tests/unit_tests/_transformers/test_infrastructure.py
@@ -222,8 +222,8 @@ class TestApplyModelInfrastructurePostShardInit:
             # FSDP's reset_sharded_param failure on tied parameters.
             mock_to.assert_not_called()
 
-    def test_skips_model_to_device_when_need_post_shard_init(self):
-        """model.to(device) should be skipped when need_post_shard_init is True (from_config meta path)."""
+    def test_calls_model_to_device_when_from_config_meta(self):
+        """model.to(device) should still be called on the from_config meta path (no checkpoint loaded)."""
         from nemo_automodel._transformers.infrastructure import apply_model_infrastructure
 
         model = _DummyModel()
@@ -240,7 +240,9 @@ class TestApplyModelInfrastructurePostShardInit:
             mock_ckpt.config = MagicMock()
             mock_ckpt.config.dequantize_base_checkpoint = False
 
-            # from_config on meta device: need_post_shard_init = True
+            # from_config on meta device: need_post_shard_init = True,
+            # but should_load_checkpoint = False (no pretrained path).
+            # model.to(device) should still be called to move buffers.
             apply_model_infrastructure(
                 model=model,
                 is_meta_device=True,
@@ -249,8 +251,7 @@ class TestApplyModelInfrastructurePostShardInit:
                 pretrained_model_name_or_path="",
             )
 
-            # model.to(device) should NOT be called when need_post_shard_init is True
-            mock_to.assert_not_called()
+            mock_to.assert_called_once_with(torch.device("cpu"), non_blocking=True)
 
     def test_model_to_falls_back_to_to_empty_on_meta_tensor_error(self):
         """model.to() raising 'Cannot copy out of meta tensor' should fall back to model.to_empty()."""


### PR DESCRIPTION
## Summary

Fixes CI regressions in PR #1489 by narrowing the `model.to(device)` skip condition:

- **`infrastructure.py`**: Gate skip on `should_load_checkpoint` (not `need_post_shard_init`). The original gate was too broad — it skipped `model.to()` for ALL meta-device paths including `from_config` (no checkpoint), which left CPU buffers on CPU.
- **`checkpointing.py`**: Revert buffer check to `buf.device.type == "meta"` (the original). The broadened `buf.device != device` replaced properly-initialized CPU buffers with uninitialized garbage via `torch.empty_like()`. For Gemma3 (where `initialize_weights()` is skipped due to DTensor compat), garbage persisted in `position_ids` and similar buffers.
- **New L2 test**: `L2_HF_Transformer_LLM_Meta_FSDP2_TP2` — regression test for the exact scenario this fix targets (TP=2 + meta-device init + checkpoint loading + tied params).

### Why `should_load_checkpoint` is the right gate

| Condition | `need_post_shard_init` | `should_load_checkpoint` | Should skip `model.to()`? |
|---|---|---|---|
| from_pretrained + meta + post-shard load | True | **True** | **Yes** — checkpoint already placed params on device |
| from_config + meta (no checkpoint) | True | False | No — `model.to()` needed to move CPU buffers to GPU |
| Non-meta (from_pretrained without meta) | False | False | No — `model.to()` is needed |

### Previously-failing CI checks this fixes

- `L2_HF_Transformer` — `test_consolidated_llm_checkpoint` buffer mismatch (garbage `position_ids`)
- `L2_HF_DCP` — VLM FSDP2 checkpoint tests (SIGABRT from garbage buffers)
- `L2_HF_PEFT` — VLM FSDP2 PEFT test (SIGABRT from garbage buffers)

## Test plan

- [x] All 197 `_transformers` unit tests pass (including updated model.to skip tests)
- [x] All 256 checkpoint unit tests pass
- [x] Lint clean (ruff) on changed files
- [ ] CI: `L2_HF_Transformer` (previously failing)
- [ ] CI: `L2_HF_DCP` (previously failing)
- [ ] CI: `L2_HF_PEFT` (previously failing)
- [ ] CI: `L2_HF_Transformer_LLM` (new TP=2 meta tied-param test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)