### PR TITLE
fix: resolve deadlock saving diffusion checkpoints in safetensors format

### DIFF
--- a/nemo_automodel/components/checkpoint/addons.py
+++ b/nemo_automodel/components/checkpoint/addons.py
@@ -76,7 +76,11 @@ class ConsolidatedHFAddon:
 
                 _maybe_strip_quantization_config(model_part)
                 with open(os.path.join(hf_metadata_dir, config_name), "w") as f:
-                    f.write(model_part.config.to_json_string())
+                    if hasattr(model_part.config, "to_json_string"):
+                        f.write(model_part.config.to_json_string())
+                    else:
+                        # Diffusers models use FrozenDict for config instead of PretrainedConfig
+                        json.dump(dict(model_part.config), f, indent=2, default=str)
 
             # save the generation_config.json file
             if getattr(model_part, "generation_config", None) is not None:

--- a/nemo_automodel/components/datasets/diffusion/sampler.py
+++ b/nemo_automodel/components/datasets/diffusion/sampler.py
@@ -170,8 +170,12 @@ class SequentialBucketSampler(Sampler[List[int]]):
             total_size = math.ceil(len(indices) / self.num_replicas) * self.num_replicas
             padding_size = total_size - len(indices)
             if padding_size > 0:
-                # Pad by repeating indices from the beginning
-                indices = indices + indices[:padding_size]
+                # Pad by cycling through indices to reach the required size.
+                # Simple slicing (indices[:padding_size]) fails when
+                # padding_size > len(indices), producing fewer elements than
+                # needed and causing uneven per-rank splits.
+                padding = [indices[i % len(indices)] for i in range(padding_size)]
+                indices = indices + padding
 
             # 5. DDP Splitting: Subsample indices for this rank
             indices = indices[self.rank :: self.num_replicas]


### PR DESCRIPTION
## Summary
- **Sampler padding bug** (`sampler.py`): `indices[:padding_size]` silently under-pads when `padding_size > len(indices)`, causing uneven batch counts across ranks (e.g., ranks 0-3 get 15 batches, ranks 4-7 get 14). At epoch boundary, some ranks enter checkpoint save while others continue training — mismatched NCCL collectives deadlock. Fixed with modular cycling.
- **FrozenDict serialization** (`addons.py`): Diffusers models use `FrozenDict` for config (no `to_json_string()`), causing `AttributeError` on rank 0 during `pre_save` while other ranks wait at barrier. Fixed by falling back to `json.dump()`.

Closes #1574

## Test plan
- [ ] Run Flux T2I finetuning with `model_save_format: safetensors` and `save_consolidated: false` on 8 GPUs — checkpoint should save without deadlock
- [ ] Run existing diffusion functional tests
- [ ] Run `pytest tests/unit_tests/ -vs -m "not pleasefixme"` for unit test regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)