### PR TITLE
fix: fix gradient_checkpointing overhead in transformers 5.3

### DIFF
--- a/nemo_automodel/components/distributed/parallelizer.py
+++ b/nemo_automodel/components/distributed/parallelizer.py
@@ -190,21 +190,44 @@ class DefaultParallelizationStrategy(ParallelizationStrategy):
                 except Exception:
                     pass
 
-            for i, layer in enumerate(layers):
-                if hasattr(layer, "mlp"):
-                    layers[i].mlp = checkpoint_wrapper(layer.mlp)
-                if hasattr(layer, "self_attn"):
-                    layers[i].self_attn = checkpoint_wrapper(layers[i].self_attn)  # type: ignore
+            # For HF-native models in transformers >= 5.3.0, GradientCheckpointingLayer.__call__
+            # applies torch.utils.checkpoint at full-layer granularity when gradient_checkpointing=True.
+            # This avoids OOM memory fragmentation from 4 × N_layers CheckpointWrapper sub-module
+            # objects (mlp/self_attn/layernorms) + transformers 5.3.0 output_capturing.py overhead.
+            _use_hf_native_grad_ckpt = False
+            try:
+                from transformers.modeling_layers import (
+                    GradientCheckpointingLayer as _HFGradLayer,
+                )
 
-                if hasattr(layer, "input_layernorm"):
-                    layers[i].input_layernorm = checkpoint_wrapper(
-                        layers[i].input_layernorm  # type: ignore
-                    )
+                _use_hf_native_grad_ckpt = (
+                    bool(layers)
+                    and layers[0].__class__.__module__.startswith("transformers.")
+                    and isinstance(layers[0], _HFGradLayer)
+                    and getattr(model, "supports_gradient_checkpointing", False)
+                    and hasattr(model, "gradient_checkpointing_enable")
+                )
+            except ImportError:
+                pass  # transformers < 5.3.0, fall through to sub-module wrapping
 
-                if hasattr(layer, "post_attention_layernorm"):
-                    layers[i].post_attention_layernorm = checkpoint_wrapper(
-                        layers[i].post_attention_layernorm  # type: ignore
-                    )
+            if _use_hf_native_grad_ckpt:
+                model.gradient_checkpointing_enable(gradient_checkpointing_kwargs={"use_reentrant": True})
+            else:
+                for i, layer in enumerate(layers):
+                    if hasattr(layer, "mlp"):
+                        layers[i].mlp = checkpoint_wrapper(layer.mlp)
+                    if hasattr(layer, "self_attn"):
+                        layers[i].self_attn = checkpoint_wrapper(layers[i].self_attn)  # type: ignore
+
+                    if hasattr(layer, "input_layernorm"):
+                        layers[i].input_layernorm = checkpoint_wrapper(
+                            layers[i].input_layernorm  # type: ignore
+                        )
+
+                    if hasattr(layer, "post_attention_layernorm"):
+                        layers[i].post_attention_layernorm = checkpoint_wrapper(
+                            layers[i].post_attention_layernorm  # type: ignore
+                        )
 
         # Set up mixed precision policy
         if not mp_policy:


### PR DESCRIPTION
## Summary
Use HF-native gradient checkpointing for upstream `transformers` models when `transformers >= 5.3.0` is available.

### Problem
The existing sub-module `checkpoint_wrapper` approach wraps up to 4 sub-modules per decoder layer (`mlp`, `self_attn`, `input_layernorm`, `post_attention_layernorm`), resulting in `4 × N_layers` `CheckpointWrapper` objects. In `transformers >= 5.3.0`, this interacts poorly with the new `output_capturing.py` overhead, causing OOM errors due to memory fragmentation during training.

### Solution
- Detect at runtime whether `transformers.modeling_layers.GradientCheckpointingLayer` is available (introduced in `transformers 5.3.0`).
- For HF-native models (i.e., layer modules whose `__module__` starts with `transformers.`), delegate gradient checkpointing to `model.gradient_checkpointing_enable()`, which applies `torch.utils.checkpoint` at full-layer granularity via `GradientCheckpointingLayer.__call__`. This avoids the proliferation of `CheckpointWrapper` sub-module objects.
- Custom Automodel models (`nemo_automodel.*`) are unaffected: their `model.forward` does not consult `self.gradient_checkpointing`, so they continue to use the existing sub-module wrapping path.
- Falls back gracefully to the original sub-module wrapping when `transformers < 5.3.0` (via `ImportError`).