### PR TITLE
fix: cast input dtype in LinearLoRA.forward() to prevent dtype mismatch

### DIFF
--- a/nemo_automodel/components/_peft/lora.py
+++ b/nemo_automodel/components/_peft/lora.py
@@ -225,6 +225,8 @@ class LinearLoRA(nn.Linear):
             Tensor: Output tensor of shape (batch_size, out_features).
         """
         # pylint: disable=C0115,C0116
+        # Cast input to match weight dtype to avoid dtype mismatch (e.g. float32 input with bfloat16 weights)
+        x = x.to(self.weight.dtype)
         # If LinearLoRA is used to monkey-patch a nn.Linear module, we want to use nn.Linear's
         # forward in the case where it uses quantized weights. We store a reference to nn.Linear's
         # forward in `super_fwd` attribute. If the attribute does not exist we do the usual linear.


### PR DESCRIPTION
# What does this PR do?

Fix a dtype mismatch error in `LinearLoRA.forward()` that causes LoRA training to fail when the input tensor dtype differs from the model weight dtype (e.g., float32 input with bfloat16 weights).

Fixes #1540.

## Root Cause

When model weights are loaded in bfloat16 (standard for LLMs), both the main linear layer (`self.weight`) and LoRA adapter layers (`lora_A`, `lora_B`) are in bfloat16. If the input `x` arrives as float32 (e.g., without autocast), `F.linear` raises:

RuntimeError: expected mat1 and mat2 to have the same dtype, but got: float != c10::BFloat16


## Fix

Cast input `x` to match `self.weight.dtype` at the top of `forward()`:

```python
x = x.to(self.weight.dtype)

This single line handles all downstream operations — the main linear, lora_A, lora_B, and DoRA paths — without needing per-call dtype casts.

Verification
Reproduced and verified on A100 GPU:

original_linear = nn.Linear(768, 768, bias=False).to(dtype=torch.bfloat16, device='cuda')
lora_linear = LinearLoRA(original_linear, dim=8, alpha=32).to('cuda')

# Before fix: RuntimeError (dtype mismatch)
# After fix: works correctly
x = torch.randn(2, 128, 768, dtype=torch.float32, device='cuda')
output = lora_linear(x)  # SUCCESS: shape=[2, 128, 768], dtype=bfloat16

Both float32 and bfloat16 inputs produce correct outputs after the fix.