### PR TITLE
fix: add best_metric_key field to CheckpointingConfig dataclass

### DIFF
--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -141,6 +141,7 @@ class CheckpointingConfig:
     # instead of the in-memory v5 config.  Useful when downstream consumers (e.g. vLLM) expect a v4-format config.
     diffusers_compatible: bool = False  # If True, use diffusers-compatible index filename
     # (diffusion_pytorch_model.safetensors.index.json) so checkpoints are loadable via diffusers from_pretrained().
+    best_metric_key: str = "default"  # Validation metric key used to select the best checkpoint.
 
     def __post_init__(self):
         """


### PR DESCRIPTION
# What does this PR do?

Add the missing `best_metric_key` field to `CheckpointingConfig` dataclass, fixing a crash when users set this field in their checkpoint YAML config.

Fixes #971.

## Bug

Setting `best_metric_key` in the checkpoint config crashes with `CheckpointingConfig.__init__() got an unexpected keyword argument 'best_metric_key'` because the dataclass doesn't include this field.

The recipes (`train_ft.py`, `train_seq_cls.py`, `finetune.py`, `kd.py`) already read `checkpoint.best_metric_key` from config and pass it to `_maybe_save_checkpoint()`, but the `CheckpointingConfig` dataclass rejects it during construction at `build_checkpoint_config()`.

## Fix

Add `best_metric_key: str = "default"` to `CheckpointingConfig`. The default value `"default"` matches the fallback used in all 4 recipe files.

## Related

- #971 — Original bug report by IBM Research

CC @akoumpa @adil-a