### PR TITLE
fix: skip initialize_weights for Phi3ForCausalLM with TP sharding

### DIFF
--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -501,9 +501,10 @@ class Checkpointer:
         # We need to set them to False and call initialize_weights to re-initialize the weights.
 
         # Some models cannot call initialize_weights when sharded with DTensors:
-        # - Gemma3ForConditionalGeneration / Gemma3ForCausalLM: _init_weights() calls
-        #   init.zeros_(module.weight[module.padding_idx]) on the embedding layer, which
-        #   triggers DTensor redistribute and fails with sharded (TP) embeddings.
+        # - Gemma3ForConditionalGeneration / Gemma3ForCausalLM / Phi3ForCausalLM:
+        #   _init_weights() calls init.zeros_(module.weight[module.padding_idx]) on the
+        #   embedding layer, which triggers DTensor redistribute and fails with sharded
+        #   (TP) embeddings.
         # - NemotronHForCausalLM: the HF remote code's _init_weights uses dt_bias.copy_()
         #   which fails with DTensors. This applies to:
         #   - v2 (non-MoE, no n_routed_experts): always uses HF remote code.
@@ -521,7 +522,7 @@ class Checkpointer:
             and hasattr(model, "backbone")  # is HF remote code
         )
         skip_initialize_weights = (
-            model_class in ["Gemma3ForConditionalGeneration", "Gemma3ForCausalLM"]
+            model_class in ["Gemma3ForConditionalGeneration", "Gemma3ForCausalLM", "Phi3ForCausalLM"]
             or is_nemotron_v2
             or is_nemotron_v3_hf
         )


### PR DESCRIPTION
## Summary
- Phi-4 (`Phi3ForCausalLM`) crashes during fine-tuning with TP>1 because the base HF `_init_weights` calls `init.zeros_(module.weight[module.padding_idx])` on the embedding layer after it's already been sharded into a DTensor by `VocabParallelEmbedding`
- Adds `Phi3ForCausalLM` to the existing `skip_initialize_weights` list, matching the same workaround already in place for Gemma3

## Test plan
- [x] Run phi-4 fine-tuning with TP=2 and PEFT (`phi_4_squad_tp2_peft.yaml`)
- [x] Verify existing Gemma3 / NemotronH skip behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)