### PR TITLE
fix: Finetune DeepSeek V3 (issue #1496)

### DIFF
--- a/nemo_automodel/recipes/_dist_setup.py
+++ b/nemo_automodel/recipes/_dist_setup.py
@@ -121,7 +121,12 @@ def parse_distributed_section(cfg_dict: dict) -> dict:
 
     strategy_config = strategy_cls(**strategy_kwargs)
 
-    pipeline_config = PipelineConfig(**pipeline_dict) if pipeline_dict is not None else None
+    if pipeline_dict is not None:
+        pipeline_config = PipelineConfig(**pipeline_dict)
+    elif pp_size > 1:
+        pipeline_config = PipelineConfig()
+    else:
+        pipeline_config = None
 
     # Instantiate nested _target_ configs (e.g. mp_policy) before constructing MoEParallelizerConfig
     if moe_dict is not None and "mp_policy" in moe_dict:

--- a/tests/unit_tests/recipes/test_dist_setup.py
+++ b/tests/unit_tests/recipes/test_dist_setup.py
@@ -128,6 +128,13 @@ class TestPipeline:
     def test_pp_enabled_true_when_pp_gt_1(self):
         assert parse_distributed_section({"pp_size": 2})["pp_enabled"] is True
 
+    def test_default_pipeline_config_created_when_pp_gt_1_and_no_pipeline_dict(self):
+        """pp_size > 1 without a pipeline section must still yield a PipelineConfig."""
+        result = parse_distributed_section({"pp_size": 4})
+        assert result["pp_enabled"] is True
+        assert isinstance(result["pipeline_config"], PipelineConfig)
+        assert result["pipeline_config"].pp_schedule == "1f1b"
+
     def test_pp_enabled_false_when_pp_eq_1(self):
         assert parse_distributed_section({"pp_size": 1})["pp_enabled"] is False
 


### PR DESCRIPTION
Closes #1496

# What does this PR do ?

Fix `AttributeError: 'NoneType' object has no attribute 'pp_batch_size'` when pipeline parallelism (`pp_size > 1`) is configured without an explicit `pipeline` section in the YAML config.

# Changelog

- `nemo_automodel/recipes/_dist_setup.py`: In `parse_distributed_section`, replaced the single-line ternary for `pipeline_config` with a three-branch conditional — if `pipeline_dict` is provided use it, else if `pp_size > 1` construct a default `PipelineConfig()`, else `None`. This ensures downstream code (e.g., `self.pipeline_config.pp_batch_size = pp_batch_size` in `train_ft.py:894`) always has a valid `PipelineConfig` object when PP is active.
- `tests/unit_tests/recipes/test_dist_setup.py`: Added `test_default_pipeline_config_created_when_pp_gt_1_and_no_pipeline_dict` to assert that calling `parse_distributed_section({"pp_size": 4})` without a `pipeline` key returns a `PipelineConfig` instance with the expected default schedule (`"1f1b"`).

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

# Additional Information

- Related to #1496

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*