### PR TITLE
feat: Add discrete diffusion LLM (dLLM) supervised fine-tuning support

### DIFF
--- a/examples/dllm_sft/finetune.py
+++ b/examples/dllm_sft/finetune.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Example launcher for dLLM (diffusion LLM) SFT fine-tuning.
+
+Usage (single GPU):
+    python examples/dllm_sft/finetune.py -c examples/dllm_sft/mdlm_sft.yaml
+
+Usage (multi-GPU):
+    python -m torch.distributed.run --nproc-per-node=8 \
+        examples/dllm_sft/finetune.py -c examples/dllm_sft/mdlm_sft.yaml
+
+When run without ``-c`` it defaults to the MDLM YAML.
+"""
+
+from __future__ import annotations
+
+from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
+from nemo_automodel.recipes.dllm.train_ft import DiffusionLMSFTRecipe
+
+
+def main(default_config_path="examples/dllm_sft/mdlm_sft.yaml") -> None:
+    """Entry-point for dLLM SFT training."""
+    cfg = parse_args_and_load_config(default_config_path)
+    recipe = DiffusionLMSFTRecipe(cfg)
+    recipe.setup()
+    recipe.run_train_validation_loop()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/nemo_automodel/components/datasets/dllm/__init__.py
+++ b/nemo_automodel/components/datasets/dllm/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/nemo_automodel/components/datasets/dllm/collate.py
+++ b/nemo_automodel/components/datasets/dllm/collate.py
@@ -1,0 +1,161 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Collate function for dLLM training.
+
+Expects datasets that produce **unshifted** format (``input_ids`` +
+``loss_mask``, via ``_package_tokenized_example(unshifted=True)``).
+Goes directly from variable-length sample lists to block-aligned tensors
+in a single pass.
+
+Two-stage block-aligned padding layout::
+
+    [real tokens][EOS block-pad, loss=1][PAD global-pad, loss=0]
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Dict, List, Optional
+
+import torch
+
+
+class DLLMCollator:
+    """Collator for dLLM (diffusion LLM) training.
+
+    Goes directly from variable-length sample dicts to block-aligned
+    tensors in a single pass — no intermediate pad-to-max step.
+
+    Expects each sample to have ``input_ids``, ``loss_mask``, and
+    ``attention_mask`` (as produced by
+    ``_package_tokenized_example(unshifted=True)``).
+
+    Args:
+        pad_token_id: Token ID for global (stage-2) padding.
+        eos_token_id: Token ID for block (stage-1) padding.  Only used
+            when *block_size* is set.
+        block_size: If set, apply two-stage block-aligned padding.
+        pad_seq_len_divisible: Round final length to
+            ``lcm(block_size, pad_seq_len_divisible)``.
+    """
+
+    def __init__(
+        self,
+        pad_token_id: int = 0,
+        eos_token_id: Optional[int] = None,
+        block_size: Optional[int] = None,
+        pad_seq_len_divisible: Optional[int] = None,
+        max_seq_len: Optional[int] = None,
+    ) -> None:
+        self.pad_token_id = pad_token_id
+        self.eos_token_id = eos_token_id
+        self.block_size = block_size
+        self.pad_seq_len_divisible = pad_seq_len_divisible
+        self.max_seq_len = max_seq_len
+        self.block_pad_token_id = eos_token_id if eos_token_id is not None else pad_token_id
+
+    def __call__(self, batch: List[Dict[str, list]]) -> Dict[str, torch.Tensor]:
+        for sample in batch:
+            sample.pop("___PAD_TOKEN_IDS___", None)
+
+        content_lengths = torch.tensor([len(s["input_ids"]) for s in batch], dtype=torch.long)
+        target_len = self._compute_target_length(content_lengths)
+
+        input_ids = self._pad_and_fill(
+            [s["input_ids"] for s in batch],
+            content_lengths,
+            target_len,
+            pad_value=self.pad_token_id,
+            block_pad_value=self.block_pad_token_id,
+        )
+        loss_mask = self._pad_and_fill(
+            [s["loss_mask"] for s in batch],
+            content_lengths,
+            target_len,
+            pad_value=0,
+            block_pad_value=1,
+        ).float()
+        attention_mask = self._pad_and_fill(
+            [s["attention_mask"] for s in batch],
+            content_lengths,
+            target_len,
+            pad_value=0,
+            block_pad_value=0,
+            apply_block_fill=False,
+        )
+
+        return {
+            "input_ids": input_ids,
+            "loss_mask": loss_mask,
+            "attention_mask": attention_mask,
+            "input_lengths": content_lengths,
+        }
+
+    def _compute_target_length(self, content_lengths: torch.Tensor) -> int:
+        # Clamp individual content lengths to max_seq_len before alignment
+        if self.max_seq_len is not None:
+            content_lengths = content_lengths.clamp(max=self.max_seq_len)
+
+        bs = self.block_size
+        if bs is not None and bs > 1:
+            block_aligned = ((content_lengths + bs - 1) // bs) * bs
+            max_len = block_aligned.max().item()
+        else:
+            max_len = content_lengths.max().item()
+
+        psd = self.pad_seq_len_divisible
+        if psd is not None and psd > 1:
+            alignment = math.lcm(bs or 1, psd)
+            max_len = ((max_len + alignment - 1) // alignment) * alignment
+
+        # Hard cap after alignment to prevent OOM
+        if self.max_seq_len is not None:
+            max_len = min(max_len, self.max_seq_len)
+
+        return max_len
+
+    def _pad_and_fill(
+        self,
+        samples: List[list],
+        content_lengths: torch.Tensor,
+        target_len: int,
+        pad_value: int,
+        block_pad_value: int,
+        apply_block_fill: bool = True,
+        dtype: torch.dtype = torch.long,
+    ) -> torch.Tensor:
+        """Pad variable-length lists to *target_len* with two-stage fill.
+
+        For each sample:
+          - ``[0, content_length)`` → original content
+          - ``[content_length, block_aligned)`` → *block_pad_value*
+          - ``[block_aligned, target_len)`` → *pad_value*
+        """
+        B = len(samples)
+        out = torch.full((B, target_len), pad_value, dtype=dtype)
+        bs = self.block_size
+
+        for b in range(B):
+            cl = content_lengths[b].item()
+            seq = samples[b]
+            copy_len = min(cl, target_len, len(seq))
+            out[b, :copy_len] = torch.tensor(seq[:copy_len], dtype=dtype)
+
+            if apply_block_fill and bs is not None and bs > 1:
+                ba = min(((cl + bs - 1) // bs) * bs, target_len)
+                if ba > cl:
+                    out[b, cl:ba] = block_pad_value
+
+        return out

--- a/nemo_automodel/components/datasets/dllm/corruption.py
+++ b/nemo_automodel/components/datasets/dllm/corruption.py
@@ -1,0 +1,219 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Data corruption utilities for diffusion LLM (dLLM) training.
+
+Provides masking strategies for dLLM SFT:
+- ``corrupt_uniform``: uniform per-sequence corruption
+- ``corrupt_blockwise``: per-block weighted corruption with exponential position bias
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+
+
+def gumbel_topk(log_w: torch.Tensor, k: int) -> torch.Tensor:
+    """Return a bool mask of length ``len(log_w)`` with exactly *k* ``True`` entries.
+
+    Uses the Gumbel-max trick for stochastic top-k selection.
+    """
+    g = -torch.log(-torch.log(torch.rand_like(log_w) + 1e-9) + 1e-9)
+    topk = torch.topk(log_w + g, k).indices
+    mask = torch.zeros_like(log_w, dtype=torch.bool)
+    mask[topk] = True
+    return mask
+
+
+def _batched_gumbel_topk(log_w: torch.Tensor, k: torch.Tensor) -> torch.Tensor:
+    """Batched variable-*k* Gumbel top-k selection.
+
+    Vectorised replacement for calling :func:`gumbel_topk` in a Python loop.
+    Each row ``i`` of *log_w* gets exactly ``k[i]`` ``True`` entries selected
+    via the Gumbel-max trick.
+
+    Algebraically identical to per-row ``gumbel_topk``: both select the *k*
+    indices with the highest ``log_w + Gumbel`` score.  ``torch.sort`` gives
+    a full ranking; ``positions < k`` picks the top-k in sorted order;
+    ``scatter_`` maps them back to original positions.
+
+    Args:
+        log_w: Log-weights, shape ``[N, D]``.  Positions that should never
+            be selected must be set to ``-inf``.
+        k: Number of positions to select per row, shape ``[N]``.
+            Rows with ``k=0`` produce an all-False mask.
+
+    Returns:
+        Boolean mask of shape ``[N, D]``.
+    """
+    g = -torch.log(-torch.log(torch.rand_like(log_w) + 1e-9) + 1e-9)
+    _, sorted_indices = torch.sort(log_w + g, dim=1, descending=True)
+    # positions[i, j] = j  →  "is this the j-th largest in row i?"
+    positions = torch.arange(log_w.shape[1], device=log_w.device).expand_as(log_w)
+    selected = positions < k.unsqueeze(1)  # top-k mask in sorted order
+    mask = torch.zeros_like(log_w, dtype=torch.bool)
+    mask.scatter_(1, sorted_indices, selected)
+    return mask
+
+
+def corrupt_uniform(
+    input_ids: torch.Tensor,
+    loss_mask: torch.Tensor,
+    mask_token_id: int,
+    eps: float = 1e-3,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Per-sequence uniform corruption for MDLM training.
+
+    For each sequence, sample ``t ~ U[0, 1]`` and derive a masking probability
+    ``p = (1 - eps) * t + eps``.  Each token at a supervised position (where
+    ``loss_mask == 1``) is independently replaced with ``mask_token_id`` with
+    probability *p*.
+
+    Args:
+        input_ids: Token IDs, shape ``[B, L]``.
+        loss_mask: Binary mask indicating supervised positions, shape ``[B, L]``.
+        mask_token_id: The token ID used for masking.
+        eps: Minimum corruption ratio.
+
+    Returns:
+        Tuple of ``(noisy_input_ids, noise_mask, p_mask)`` each of shape ``[B, L]``.
+        - ``noisy_input_ids``: input_ids with masked positions replaced.
+        - ``noise_mask``: bool mask of which positions were corrupted.
+        - ``p_mask``: per-position masking probability (float32).
+    """
+    B, L = input_ids.shape
+    device = input_ids.device
+
+    # t ~ U[0, 1] per sequence
+    t = torch.rand((B,), device=device)
+    p_mask = (1 - eps) * t + eps
+    p_mask = p_mask[:, None].expand(B, L)  # (B, L)
+
+    # Sample noise mask: each position independently masked with probability p
+    noise_mask = torch.rand((B, L), device=device) < p_mask
+    noise_mask = noise_mask & loss_mask.bool()
+
+    noisy_input_ids = torch.where(noise_mask, mask_token_id, input_ids)
+
+    return noisy_input_ids, noise_mask, p_mask.float()
+
+
+def corrupt_blockwise(
+    input_ids: torch.Tensor,
+    loss_mask: torch.Tensor,
+    mask_token_id: int,
+    block_size: int | None = None,
+    eps: float = 1e-3,
+    half_life_ratio: float = 0.25,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Two-stage corruption with optional per-block sampling.
+
+    This function combines three independent concerns that could be separated
+    if a future model needs a different mix (e.g., blocks without position
+    bias, or sequence-level with bias):
+
+    1. **Sampling scope** — per-sequence vs per-block ``m`` sampling
+       (controlled by ``block_size``).
+    2. **Selection method** — Gumbel-max top-k for exact-``k`` masking.
+    3. **Position bias** — exponential weighting via ``half_life_ratio``.
+
+    Stage 1: Sample ``m ~ U(eps, 1)`` per sequence (or per block), compute
+    ``k = round(m * length)`` positions to mask.
+
+    Stage 2: Sample exactly *k* positions using exponentially weighted
+    probabilities ``w_i(m) = exp[lambda * (1-m) * i]`` which bias toward
+    later positions when ``m`` is small (few masks → mask later tokens) and
+    become uniform when ``m`` is large (many masks).
+
+    If ``block_size`` is given, stages 1 and 2 operate independently within
+    each contiguous block of that length.
+
+    All operations are fully vectorised (no Python loops over batch or
+    blocks) via :func:`_batched_gumbel_topk`.
+
+    Args:
+        input_ids: Token IDs, shape ``[B, L]``.
+        loss_mask: Binary mask indicating supervised positions, shape ``[B, L]``.
+        mask_token_id: The token ID used for masking.
+        block_size: If not None, operate block-wise with per-block *m* sampling.
+        eps: Minimum corruption ratio.
+        half_life_ratio: Controls steepness of positional bias when ``m → 0``.
+
+    Returns:
+        Tuple of ``(noisy_input_ids, noise_mask, p_mask)`` each of shape ``[B, L]``.
+    """
+    B, L = input_ids.shape
+    device = input_ids.device
+    dtype = torch.float32
+
+    if block_size is None:
+        # --- Vectorised per-sequence path ---
+        lam_base = math.log(2.0) / (half_life_ratio * L)
+
+        m = eps + (1.0 - eps) * torch.rand(B, device=device)  # [B]
+        k = torch.round(m * L).long().clamp(1, L)  # [B]
+
+        p_mask = m.unsqueeze(1).expand(B, L)  # [B, L]
+        slope = 1.0 - m  # [B]
+
+        pos = torch.arange(L, device=device, dtype=dtype)  # [L]
+        log_w = lam_base * slope.unsqueeze(1) * pos.unsqueeze(0)  # [B, L]
+
+        masked_indices = _batched_gumbel_topk(log_w, k)
+    else:
+        # --- Vectorised per-block path ---
+        num_blocks = math.ceil(L / block_size)
+        N = B * num_blocks  # total number of blocks
+        padded_L = num_blocks * block_size
+
+        lam_base = math.log(2.0) / (half_life_ratio * block_size)
+
+        # Effective length of each block (last block per sequence may be shorter)
+        block_lens = torch.full((N,), block_size, dtype=torch.long, device=device)
+        if L % block_size != 0:
+            last_len = L % block_size
+            last_indices = torch.arange(num_blocks - 1, N, num_blocks, device=device)
+            block_lens[last_indices] = last_len
+
+        m = eps + (1.0 - eps) * torch.rand(N, device=device)  # [N]
+        k = torch.round(m * block_lens.float()).long()  # [N]
+        k = torch.min(k.clamp(min=0), block_lens)  # [N]
+
+        slope = 1.0 - m  # [N]
+        pos = torch.arange(block_size, device=device, dtype=dtype)  # [block_size]
+        log_w = lam_base * slope.unsqueeze(1) * pos.unsqueeze(0)  # [N, block_size]
+
+        # Invalidate padding positions in partial last blocks so they
+        # are never selected by _batched_gumbel_topk.
+        valid = pos.unsqueeze(0).expand(N, block_size) < block_lens.unsqueeze(1)
+        log_w[~valid] = -float("inf")
+
+        block_masked = _batched_gumbel_topk(log_w, k)
+
+        # Reshape [N, block_size] → [B, padded_L] and trim to [B, L]
+        masked_indices = block_masked.view(B, padded_L)[:, :L]
+
+        # Expand per-block m to full sequence length
+        p_mask = m.view(B, num_blocks, 1).expand(B, num_blocks, block_size)
+        p_mask = p_mask.reshape(B, padded_L)[:, :L]
+
+    # Only mask at supervised positions
+    if loss_mask is not None:
+        masked_indices[loss_mask == 0] = False
+
+    noisy_input_ids = torch.where(masked_indices, mask_token_id, input_ids)
+
+    return noisy_input_ids, masked_indices, p_mask.float()

--- a/nemo_automodel/components/datasets/llm/chat_dataset.py
+++ b/nemo_automodel/components/datasets/llm/chat_dataset.py
@@ -212,6 +212,7 @@ class ChatDataset(Dataset):
         start_of_turn_token: Optional[str] = None,
         chat_template: Optional[str] = None,
         shuffle_seed: Optional[int] = None,
+        unshifted: bool = False,
     ) -> None:
         if tokenizer is None:
             raise ValueError("Tokenizer is required")
@@ -228,6 +229,7 @@ class ChatDataset(Dataset):
         self.padding = padding
         self.truncation = truncation
         self.start_of_turn_token = start_of_turn_token
+        self.unshifted = unshifted
 
         self.dataset = _load_openai_messages(path_or_dataset_id, split=split, name=name, shuffle_seed=shuffle_seed)
 
@@ -259,5 +261,6 @@ class ChatDataset(Dataset):
             padding=self.padding,
             truncation=self.truncation,
             tools=tools,
+            unshifted=self.unshifted,
         )
         return sample

--- a/nemo_automodel/components/datasets/llm/formatting_utils.py
+++ b/nemo_automodel/components/datasets/llm/formatting_utils.py
@@ -165,6 +165,7 @@ def _package_tokenized_example(
     seq_length,
     truncation="do_not_truncate",
     padding="do_not_pad",
+    unshifted=False,
 ):
     """
     Package a tokenized example with proper masking and padding.
@@ -178,9 +179,47 @@ def _package_tokenized_example(
         seq_length: Optional sequence length for padding.
         truncation: Optional truncation strategy.
         padding: Optional padding strategy.
+        unshifted: If True, return unshifted format for dLLM training
+            (``input_ids`` at full length with ``loss_mask`` instead of
+            shifted ``input_ids``/``labels``).
     Returns:
         A dictionary with input_ids, labels, and attention_mask.
+        When *unshifted* is True, ``labels`` is replaced by ``loss_mask``.
     """
+    if unshifted:
+        # --- Unshifted dLLM format ---
+        # No shift: input_ids stays at full length, loss_mask = assistant_masks.
+        loss_mask = [int(bool(m)) for m in assistant_masks]
+
+        # Compute content length (skip trailing pad tokens).
+        content_length = len(input_ids)
+        if pad_token_id is not None and content_length > 0:
+            end = content_length
+            while end > 0 and input_ids[end - 1] == pad_token_id:
+                end -= 1
+            if pad_token_id == eos_token_id:
+                content_length = min(end + 1, content_length)
+            else:
+                content_length = end
+        attention_mask = [1] * content_length + [0] * (len(input_ids) - content_length)
+
+        if isinstance(seq_length, int) and padding in ("max_length",):
+            input_ids = _pad_to_seq_length(input_ids, pad_token_id, seq_length)
+            loss_mask = _pad_to_seq_length(loss_mask, 0, seq_length)
+
+        attention_mask += [0] * (len(input_ids) - len(attention_mask))
+        return {
+            "input_ids": input_ids,
+            "loss_mask": loss_mask,
+            "attention_mask": attention_mask,
+            "___PAD_TOKEN_IDS___": {
+                "input_ids": pad_token_id,
+                "loss_mask": 0,
+                "attention_mask": 0,
+            },
+        }
+
+    # --- Standard shifted NTP format ---
     labels = input_ids.copy()
     # Compute content length on the original input_ids (before the next-token
     # shift) so that pre-padded and non-padded inputs produce identical
@@ -240,6 +279,7 @@ def format_prompt_completion(
     padding: Union[str, bool] = "do_not_pad",
     truncation: Union[str, bool] = "do_not_truncate",
     answer_only_loss_mask: bool = True,
+    unshifted: bool = False,
 ) -> Dict[str, List[int]]:
     """
     Format a prompt-completion style example (without chat template).
@@ -295,6 +335,7 @@ def format_prompt_completion(
         seq_length=seq_length,
         truncation=truncation,
         padding=padding,
+        unshifted=unshifted,
     )
 
 
@@ -308,6 +349,7 @@ def format_chat_template(
     truncation: Union[str, bool] = "do_not_truncate",
     tools: Optional[List[Dict]] = None,
     answer_only_loss_mask: bool = True,
+    unshifted: bool = False,
 ) -> Dict[str, List[int]]:
     """
     Format a chat template style example.
@@ -381,4 +423,5 @@ def format_chat_template(
         seq_length=seq_length,
         truncation=truncation,
         padding=padding,
+        unshifted=unshifted,
     )

--- a/nemo_automodel/components/distributed/config.py
+++ b/nemo_automodel/components/distributed/config.py
@@ -57,7 +57,20 @@ class FSDP2Config:
         sequence_parallel (bool): Enable sequence parallelism in TP plan.
         tp_plan (Optional[dict]): Custom TP plan. If None, auto-selected based on model type.
         mp_policy (Optional[MixedPrecisionPolicy]): MixedPrecisionPolicy for FSDP2.
+            Can be configured from YAML using the ``_target_`` pattern::
+
+                mp_policy:
+                  _target_: torch.distributed.fsdp.MixedPrecisionPolicy
+                  param_dtype: bfloat16
+                  reduce_dtype: float32
+                  output_dtype: float32
+
         offload_policy (Optional[CPUOffloadPolicy]): CPUOffloadPolicy for CPU offloading.
+        autocast_dtype (Optional[torch.dtype]): If set, wraps the forward pass in
+            ``torch.autocast(device_type="cuda", dtype=autocast_dtype)``.  Use with
+            ``output_dtype=float32`` in mp_policy to keep the residual stream in fp32
+            while running matmuls in lower precision.  Set to ``None`` to disable.
+            Can be set from YAML as a string (e.g. ``autocast_dtype: bfloat16``).
         activation_checkpointing (bool): Enable activation checkpointing.
         defer_fsdp_grad_sync (bool): Defer FSDP gradient sync to final micro-batch.
         backend (str): Distributed backend.
@@ -67,6 +80,7 @@ class FSDP2Config:
     tp_plan: Optional[dict] = None
     mp_policy: Optional[MixedPrecisionPolicy] = None
     offload_policy: Optional[CPUOffloadPolicy] = None
+    autocast_dtype: Optional[torch.dtype] = None
     activation_checkpointing: bool = False
     defer_fsdp_grad_sync: bool = True
     backend: str = "nccl"

--- a/nemo_automodel/components/loss/dllm_loss.py
+++ b/nemo_automodel/components/loss/dllm_loss.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Loss functions for diffusion LLM (dLLM) training.
+
+Both loss classes return :class:`DLLMLossOutput` so the recipe can handle them
+uniformly without branching on model type.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple, Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.distributed.tensor import DTensor
+
+
+def _compute_per_token_nll(
+    logits: torch.Tensor,
+    target_ids: torch.Tensor,
+) -> torch.Tensor:
+    """Compute per-token negative log-likelihood, shape ``[B, L]``."""
+    if isinstance(logits, DTensor):
+        logits = logits.full_tensor()
+
+    V = logits.size(-1)
+    return F.cross_entropy(
+        logits.reshape(-1, V),
+        target_ids.reshape(-1).to(logits.device),
+        reduction="none",
+    ).reshape(target_ids.shape)
+
+
+class DLLMLossOutput(NamedTuple):
+    """Unified return type for all dLLM loss functions.
+
+    Attributes:
+        total_loss: Loss used for backward (may include AR component).
+        dllm_loss: Pure diffusion loss for logging/metrics.
+    """
+
+    total_loss: torch.Tensor
+    dllm_loss: torch.Tensor
+
+
+class MDLMCrossEntropyLoss(nn.Module):
+    """Cross-entropy loss for MDLM training.
+
+    Computes loss only at positions where ``noise_mask=True``, weighted by
+    ``1/p_mask`` (inverse corruption probability). Loss is normalized by
+    answer length to keep it scale-invariant w.r.t. corruption ratio.
+
+    Loss computation::
+
+        logprobs = log_softmax(logits).gather(target_ids)
+        logprobs_normalized = logprobs / answer_length
+        loss = -sum(logprobs_normalized[noise_mask] / p_mask[noise_mask]) / num_valid_seqs
+    """
+
+    def __init__(self, fp32_upcast: bool = True):
+        super().__init__()
+        self.fp32_upcast = fp32_upcast
+
+    def forward(
+        self,
+        logits: torch.Tensor,
+        target_ids: torch.Tensor,
+        noise_mask: torch.Tensor,
+        p_mask: torch.Tensor,
+        loss_mask: torch.Tensor,
+        num_diffusion_tokens: Optional[int] = None,
+    ) -> DLLMLossOutput:
+        """Compute the MDLM cross-entropy loss.
+
+        Args:
+            logits: Model output logits, shape ``[B, L, V]``.
+            target_ids: Clean (uncorrupted) token IDs, shape ``[B, L]``.
+            noise_mask: Boolean mask of corrupted positions, shape ``[B, L]``.
+            p_mask: Per-position masking probability, shape ``[B, L]``.
+            loss_mask: Supervised positions mask, shape ``[B, L]``.
+            num_diffusion_tokens: If provided, used for global normalization
+                (total supervised tokens across all grad-acc microbatches).
+
+        Returns:
+            :class:`DLLMLossOutput` where ``total_loss == dllm_loss``.
+        """
+        token_nll = _compute_per_token_nll(logits, target_ids)  # [B, L]
+        del logits
+
+        # Effective mask: corrupted AND supervised positions
+        mask = noise_mask & loss_mask.bool()  # [B, L]
+
+        # Normalize by answer length per sequence
+        answer_lengths = loss_mask.sum(dim=-1, keepdim=True).clamp(min=1)  # [B, 1]
+        token_nll_norm = token_nll / answer_lengths
+
+        # Weighted loss: divide by corruption probability at masked positions
+        p_mask_safe = p_mask.clamp(min=1e-8)
+        token_loss = token_nll_norm[mask] / p_mask_safe[mask]
+
+        loss = token_loss.sum()
+
+        if num_diffusion_tokens is not None:
+            loss = loss / max(num_diffusion_tokens, 1)
+
+        return DLLMLossOutput(total_loss=loss, dllm_loss=loss.detach().clone())

--- a/nemo_automodel/recipes/_dist_setup.py
+++ b/nemo_automodel/recipes/_dist_setup.py
@@ -101,6 +101,48 @@ def parse_distributed_section(cfg_dict: dict) -> dict:
     # Everything still in *cfg* is forwarded to the strategy constructor.
     strategy_kwargs: Dict[str, Any] = cfg
 
+    # Instantiate mp_policy from YAML dict for the strategy config.
+    # Follows the same ``_target_`` pattern used for MoE mp_policy below.
+    if "mp_policy" in strategy_kwargs:
+        mp_raw = strategy_kwargs["mp_policy"]
+        if isinstance(mp_raw, dict):
+            mp_raw = mp_raw.copy()
+            target = mp_raw.pop("_target_", None)
+            for key in ("param_dtype", "reduce_dtype", "output_dtype"):
+                if key in mp_raw and isinstance(mp_raw[key], str):
+                    mp_raw[key] = dtype_from_str(mp_raw[key])
+            if target is not None and callable(target):
+                strategy_kwargs["mp_policy"] = target(**mp_raw)
+            else:
+                from torch.distributed.fsdp import MixedPrecisionPolicy
+
+                strategy_kwargs["mp_policy"] = MixedPrecisionPolicy(**mp_raw)
+
+    # Instantiate offload_policy from YAML dict (same ``_target_`` pattern).
+    if "offload_policy" in strategy_kwargs:
+        op_raw = strategy_kwargs["offload_policy"]
+        if isinstance(op_raw, dict):
+            op_raw = op_raw.copy()
+            target = op_raw.pop("_target_", None)
+            if target is not None:
+                if isinstance(target, str):
+                    # Resolve dotted path to class
+                    import importlib
+
+                    mod_path, cls_name = target.rsplit(".", 1)
+                    target = getattr(importlib.import_module(mod_path), cls_name)
+                strategy_kwargs["offload_policy"] = target(**op_raw)
+            else:
+                from torch.distributed.fsdp import CPUOffloadPolicy
+
+                strategy_kwargs["offload_policy"] = CPUOffloadPolicy(**op_raw)
+
+    # Convert autocast_dtype string to torch.dtype if present.
+    if "autocast_dtype" in strategy_kwargs:
+        val = strategy_kwargs["autocast_dtype"]
+        if isinstance(val, str):
+            strategy_kwargs["autocast_dtype"] = dtype_from_str(val)
+
     _validate_strategy_kwargs(strategy_name, strategy_cls, strategy_kwargs)
 
     # Route activation_checkpointing: for non-EP configs it goes on the

--- a/nemo_automodel/recipes/dllm/__init__.py
+++ b/nemo_automodel/recipes/dllm/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/nemo_automodel/recipes/dllm/strategy.py
+++ b/nemo_automodel/recipes/dllm/strategy.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Model-specific strategies for diffusion LLM (dLLM) training.
+
+Each strategy encapsulates three variation points that differ across dLLM
+model families:
+
+1. **Loss function creation** — which loss module to use.
+2. **Corruption** — how tokens are corrupted before the forward pass.
+3. **Batch preparation** — how the batch dict is shaped for the model's
+   forward signature.
+
+To add a new dLLM variant (e.g., LLADA), implement a new
+:class:`DLLMStrategy` subclass and register it in :data:`DLLM_STRATEGIES`.
+No changes to the recipe are required.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Dict, Optional, Tuple
+
+import torch
+import torch.nn as nn
+
+from nemo_automodel.components.datasets.dllm.corruption import (
+    corrupt_uniform,
+)
+from nemo_automodel.components.loss.dllm_loss import (
+    MDLMCrossEntropyLoss,
+)
+
+
+class DLLMStrategy(ABC):
+    """Abstract base for dLLM model strategies."""
+
+    @abstractmethod
+    def create_loss_fn(self, dllm_cfg: dict) -> nn.Module:
+        """Return the loss module for this model type."""
+
+    @abstractmethod
+    def apply_corruption(
+        self,
+        input_ids: torch.Tensor,
+        loss_mask: torch.Tensor,
+        mask_token_id: int,
+        *,
+        eps: float,
+        block_size: Optional[int],
+        half_life_ratio: Optional[float],
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Return ``(noisy_input_ids, noise_mask, p_mask)``."""
+
+    @abstractmethod
+    def prepare_batch(
+        self,
+        batch: Dict[str, torch.Tensor],
+        noisy_input_ids: torch.Tensor,
+        noise_mask: torch.Tensor,
+        clean_input_ids: torch.Tensor,
+    ) -> Dict[str, torch.Tensor]:
+        """Mutate *batch* in-place for the model's forward pass and return it."""
+
+
+class MDLMStrategy(DLLMStrategy):
+    """Strategy for MDLM models.
+
+    - Loss: :class:`MDLMCrossEntropyLoss`
+    - Corruption: always uniform (``corrupt_uniform``)
+    - Batch: model receives noisy (corrupted) tokens as ``input_ids``
+    """
+
+    def create_loss_fn(self, dllm_cfg: dict) -> nn.Module:
+        return MDLMCrossEntropyLoss()
+
+    def apply_corruption(self, input_ids, loss_mask, mask_token_id, *, eps, block_size, half_life_ratio):
+        return corrupt_uniform(input_ids, loss_mask, mask_token_id, eps=eps)
+
+    def prepare_batch(self, batch, noisy_input_ids, noise_mask, clean_input_ids):
+        batch["input_ids"] = noisy_input_ids
+        return batch
+
+
+DLLM_STRATEGIES: Dict[str, type] = {
+    "mdlm": MDLMStrategy,
+}
+
+
+def get_dllm_strategy(mode: str) -> DLLMStrategy:
+    """Look up and instantiate a dLLM strategy by mode name.
+
+    Raises:
+        ValueError: If *mode* is not registered in :data:`DLLM_STRATEGIES`.
+    """
+    cls = DLLM_STRATEGIES.get(mode)
+    if cls is None:
+        raise ValueError(f"Unknown dllm.mode: {mode!r}. Available: {sorted(DLLM_STRATEGIES)}")
+    return cls()

--- a/nemo_automodel/recipes/dllm/train_ft.py
+++ b/nemo_automodel/recipes/dllm/train_ft.py
@@ -1,0 +1,512 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Diffusion LLM (dLLM) SFT recipe for Automodel.
+
+Extends ``TrainFinetuneRecipeForNextTokenPrediction`` to support diffusion LLM
+training. Instead of next-token prediction, the model is trained as a denoiser:
+tokens are randomly corrupted and the model predicts the clean token at each
+position.  Loss is weighted by the inverse corruption probability.
+
+Model-specific behaviour (loss function, corruption strategy, batch preparation)
+is encapsulated in :mod:`~nemo_automodel.recipes.dllm.strategy` so that new
+dLLM variants can be added without modifying this recipe.  Current modes:
+
+- **mdlm**: Pure masked denoising.  Uses ``MDLMCrossEntropyLoss``.
+
+Usage::
+
+    python -m torch.distributed.run --nproc-per-node=8 \\
+        nemo_automodel/recipes/dllm/train_ft.py \\
+        -c examples/dllm_sft/mdlm_sft.yaml
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from contextlib import nullcontext
+from typing import Optional
+
+import torch
+import wandb
+from torchao.float8 import precompute_float8_dynamic_scale_for_fsdp
+
+from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
+from nemo_automodel.components.datasets.dllm.collate import DLLMCollator
+from nemo_automodel.components.distributed.cp_utils import make_cp_batch_and_ctx
+from nemo_automodel.components.distributed.utils import get_sync_ctx
+from nemo_automodel.components.loggers.metric_logger import MetricsSample
+from nemo_automodel.components.training.rng import ScopedRNG
+from nemo_automodel.components.training.utils import (
+    prepare_after_first_microbatch,
+    prepare_for_final_backward,
+    prepare_for_grad_accumulation,
+    scale_grads_and_clip_grad_norm,
+)
+from nemo_automodel.components.utils.flops_utils import calculate_mfu
+from nemo_automodel.recipes.dllm.strategy import get_dllm_strategy
+from nemo_automodel.recipes.llm.train_ft import TrainFinetuneRecipeForNextTokenPrediction
+
+logger = logging.getLogger(__name__)
+
+
+class DiffusionLMSFTRecipe(TrainFinetuneRecipeForNextTokenPrediction):
+    """Recipe for dLLM (diffusion LLM) supervised fine-tuning.
+
+    Extends the standard fine-tuning recipe by:
+
+    1. Wrapping the dataloader collate function to produce unshifted batches
+    2. Applying token corruption before each forward pass
+    3. Using dLLM-specific loss functions via a pluggable strategy
+    """
+
+    def setup(self):
+        """Build all training components, then apply dLLM-specific overrides."""
+        # Let parent build model, optimizer, dataloader, scheduler, etc.
+        super().setup()
+
+        # --- dLLM config ---
+        dllm_cfg = self.cfg.get("dllm", None)
+        if dllm_cfg is None:
+            raise ValueError("Config must contain a 'dllm' section for DiffusionLMSFTRecipe")
+
+        self.dllm_mode = dllm_cfg.get("mode", "mdlm")
+        self.dllm_strategy = get_dllm_strategy(self.dllm_mode)
+
+        self.dllm_eps = float(dllm_cfg.get("eps", 1e-3))
+        self.dllm_block_size = dllm_cfg.get("block_size", None)
+        if self.dllm_block_size is not None:
+            self.dllm_block_size = int(self.dllm_block_size)
+        hlr = dllm_cfg.get("half_life_ratio", 0.25)
+        self.dllm_half_life_ratio = float(hlr) if hlr is not None else None
+
+        # Padding config (two-stage block-aligned padding)
+        pbs = dllm_cfg.get("pad_block_size", None)
+        self.dllm_pad_block_size = int(pbs) if pbs is not None else None
+        psld = dllm_cfg.get("pad_seq_len_divisible", None)
+        self.dllm_pad_seq_len_divisible = int(psld) if psld is not None else None
+
+        # Resolve mask_token_id
+        self.mask_token_id = dllm_cfg.get("mask_token_id", None)
+        if self.mask_token_id is None:
+            # Try to get from tokenizer
+            if (
+                self.tokenizer is not None
+                and hasattr(self.tokenizer, "mask_token_id")
+                and self.tokenizer.mask_token_id is not None
+            ):
+                self.mask_token_id = self.tokenizer.mask_token_id
+            else:
+                raise ValueError("dllm.mask_token_id must be set in config, or the tokenizer must have a mask_token_id")
+        self.mask_token_id = int(self.mask_token_id)
+
+        # --- Build dLLM loss function via strategy ---
+        self.dllm_loss_fn = self.dllm_strategy.create_loss_fn(dllm_cfg)
+
+        logger.info(
+            f"dLLM SFT setup: mode={self.dllm_mode}, mask_token_id={self.mask_token_id}, "
+            f"eps={self.dllm_eps}, block_size={self.dllm_block_size}, "
+            f"half_life_ratio={self.dllm_half_life_ratio}"
+        )
+
+        # --- Wrap dataloader collate to produce unshifted format ---
+        self._wrap_dataloader_collate()
+
+        # Buffers for dLLM-specific metrics
+        self._dllm_loss_buffer = []
+
+    def _wrap_dataloader_collate(self):
+        """Replace dataloader collate functions with the dLLM single-pass collater.
+
+        Uses :class:`DLLMCollator` which goes directly from
+        variable-length sample lists to block-aligned tensors in one pass.
+
+        Requires datasets to produce unshifted format (``input_ids`` +
+        ``loss_mask``, via ``_package_tokenized_example(unshifted=True)``).
+        """
+        pad_token_id = 0
+        if (
+            self.tokenizer is not None
+            and hasattr(self.tokenizer, "pad_token_id")
+            and self.tokenizer.pad_token_id is not None
+        ):
+            pad_token_id = self.tokenizer.pad_token_id
+
+        eos_token_id = None
+        if (
+            self.tokenizer is not None
+            and hasattr(self.tokenizer, "eos_token_id")
+            and self.tokenizer.eos_token_id is not None
+        ):
+            eos_token_id = self.tokenizer.eos_token_id
+
+        max_seq_len = self.cfg.get("dataset.seq_length", None)
+        if max_seq_len is not None:
+            max_seq_len = int(max_seq_len)
+
+        collator = DLLMCollator(
+            pad_token_id=pad_token_id,
+            eos_token_id=eos_token_id,
+            block_size=self.dllm_pad_block_size,
+            pad_seq_len_divisible=self.dllm_pad_seq_len_divisible,
+            max_seq_len=max_seq_len,
+        )
+
+        self.dataloader.collate_fn = collator
+        for _name, val_dl in self.val_dataloaders.items():
+            val_dl.collate_fn = collator
+
+    def _apply_corruption(self, input_ids, loss_mask):
+        """Apply token corruption via the configured strategy.
+
+        Args:
+            input_ids: Clean token IDs, shape [B, L].
+            loss_mask: Supervised positions mask, shape [B, L].
+
+        Returns:
+            Tuple of (noisy_input_ids, noise_mask, p_mask).
+        """
+        return self.dllm_strategy.apply_corruption(
+            input_ids,
+            loss_mask,
+            self.mask_token_id,
+            eps=self.dllm_eps,
+            block_size=self.dllm_block_size,
+            half_life_ratio=self.dllm_half_life_ratio,
+        )
+
+    def _forward_backward_step(
+        self,
+        idx,
+        batch,
+        *,
+        loss_buffer,
+        num_diffusion_tokens,
+        num_batches,
+        is_train: bool = True,
+    ):
+        """Override: apply dLLM corruption and compute dLLM loss."""
+        # Move batch to device
+        batch = {
+            k: (
+                {dk: dv.to(self.dist_env.device, non_blocking=True) for dk, dv in v.items() if dv is not None}
+                if isinstance(v, dict)
+                else (v.to(self.dist_env.device, non_blocking=True) if isinstance(v, torch.Tensor) else v)
+            )
+            for k, v in batch.items()
+        }
+
+        # Use pre-computed corruption if available (from _run_train_optim_step),
+        # otherwise compute on the fly (validation path).
+        if "_noise_mask" in batch:
+            noisy_input_ids = batch.pop("_noisy_input_ids")
+            noise_mask = batch.pop("_noise_mask")
+            p_mask = batch.pop("_p_mask")
+            clean_input_ids = batch.pop("_clean_input_ids")
+            loss_mask = batch.pop("loss_mask")
+        else:
+            loss_mask = batch.pop("loss_mask")
+            clean_input_ids = batch["input_ids"].clone()
+            noisy_input_ids, noise_mask, p_mask = self._apply_corruption(clean_input_ids, loss_mask)
+
+        batch = self.dllm_strategy.prepare_batch(batch, noisy_input_ids, noise_mask, clean_input_ids)
+
+        model = self.model_parts[0]
+
+        # Context parallel setup (no labels to pass for dLLM)
+        train_ctx, batch = make_cp_batch_and_ctx(self.device_mesh, batch)
+        fp8_ctx = self.te_fp8.maybe_te_autocast() if self.te_fp8 is not None else nullcontext()
+        sync_ctx = (
+            get_sync_ctx(
+                model,
+                idx == num_batches - 1,
+                defer_fsdp_grad_sync=getattr(self.distributed_config, "defer_fsdp_grad_sync", True),
+            )
+            if is_train
+            else nullcontext()
+        )
+
+        autocast_dtype = getattr(self.distributed_config, "autocast_dtype", None)
+        autocast_ctx = (
+            torch.autocast(device_type="cuda", dtype=autocast_dtype) if autocast_dtype is not None else nullcontext()
+        )
+
+        with train_ctx(), sync_ctx, fp8_ctx, autocast_ctx:
+            out = model(**batch)
+            logits = getattr(out, "logits", out)
+            del out
+
+            # Compute dLLM loss (unified interface via DLLMLossOutput)
+            loss_result = self.dllm_loss_fn(
+                logits=logits,
+                target_ids=clean_input_ids,
+                noise_mask=noise_mask,
+                p_mask=p_mask,
+                loss_mask=loss_mask,
+                num_diffusion_tokens=num_diffusion_tokens,
+            )
+            microbatch_loss = loss_result.total_loss
+            dllm_loss = loss_result.dllm_loss.detach().clone()
+
+            loss_buffer.append(microbatch_loss.clone().detach())
+            self._dllm_loss_buffer.append(dllm_loss)
+
+            if is_train:
+                (microbatch_loss * self._get_dp_group_size(include_cp=True)).backward()
+
+    def _run_train_optim_step(self, batches, max_grad_norm: Optional[float] = None):
+        """Execute a single training step with dLLM loss.
+
+        Follows the parent pattern but uses loss_mask from the collate wrapper
+        instead of labels != -100 for token counting.
+        """
+        # Pre-corrupt all microbatches so we can count noise tokens globally
+        # before any forward pass.
+        num_noise_tokens = 0  # diffusion loss denominator (corrupted positions)
+
+        for batch in batches:
+            noisy_input_ids, noise_mask, p_mask = self._apply_corruption(batch["input_ids"], batch["loss_mask"])
+            batch["_noisy_input_ids"] = noisy_input_ids
+            batch["_noise_mask"] = noise_mask
+            batch["_p_mask"] = p_mask
+            batch["_clean_input_ids"] = batch["input_ids"].clone()
+            num_noise_tokens += noise_mask.sum().item()
+
+        num_noise_tokens = self._dp_allreduce(torch.tensor(num_noise_tokens, dtype=torch.long)).item()
+
+        loss_buffer = []
+
+        # Count total tokens excluding tail padding
+        num_tokens_in_batch = torch.tensor(sum(batch["input_ids"].numel() for batch in batches), dtype=torch.long)
+        num_tokens_in_batch = self._dp_allreduce(num_tokens_in_batch).item()
+
+        num_batches = len(batches)
+        prepare_for_grad_accumulation(self.model_parts, pp_enabled=self.pp_enabled)
+
+        for i, batch in enumerate(batches):
+            if i == num_batches - 1:
+                prepare_for_final_backward(self.model_parts, pp_enabled=self.pp_enabled)
+
+            self._forward_backward_step(
+                i,
+                batch,
+                loss_buffer=loss_buffer,
+                num_diffusion_tokens=num_noise_tokens,
+                num_batches=num_batches,
+            )
+
+            if i == 0:
+                prepare_after_first_microbatch()
+
+        grad_norm = scale_grads_and_clip_grad_norm(
+            max_grad_norm,
+            self.model_parts,
+            norm_type=2.0,
+            pp_enabled=self.pp_enabled,
+            device_mesh=self.device_mesh,
+            moe_mesh=self.moe_mesh,
+            ep_axis_name="ep" if self.moe_mesh is not None and "ep" in self.moe_mesh.mesh_dim_names else None,
+            pp_axis_name="pp" if self.pp_enabled else None,
+            foreach=True,
+            num_label_tokens=num_noise_tokens,
+            dp_group_size=self._get_dp_group_size(include_cp=True),
+        )
+
+        self.checkpointer.maybe_wait_for_staging()
+        for opt in self.optimizer:
+            opt.step()
+            opt.zero_grad()
+
+        if self.lr_scheduler is not None:
+            for scheduler in self.lr_scheduler:
+                scheduler.step(1)
+
+        # Precompute FP8 scales
+        fp8_config = self.cfg.get("fp8", None)
+        if (
+            fp8_config is not None
+            and fp8_config.get("enabled", False)
+            and fp8_config.get("precompute_float8_dynamic_scale_for_fsdp", False)
+            and not self.pp_enabled
+            and self.device_mesh is not None
+            and self.device_mesh["dp_shard"].size() > 1
+        ):
+            precompute_float8_dynamic_scale_for_fsdp(self.model_parts[0])
+
+        t = time.perf_counter()
+        time_delta = t - self.timestamp
+        self.timestamp = t
+        tps = num_tokens_in_batch / time_delta
+
+        mfu = None
+        mfu_calculator = getattr(self, "mfu_calculator", None)
+        if batches and mfu_calculator is not None:
+            step_flops = 0.0
+            flops_supported = True
+            for batch in batches:
+                input_ids = batch.get("input_ids")
+                if input_ids is None:
+                    flops_supported = False
+                    break
+                batch_flops = mfu_calculator.get_flops(input_ids)
+                if batch_flops is None:
+                    flops_supported = False
+                    break
+                step_flops += float(batch_flops)
+
+            if flops_supported:
+                step_flops = self._dp_allreduce(
+                    torch.tensor(step_flops, dtype=torch.float64, device=self.dist_env.device), include_cp=True
+                ).item()
+                mfu = calculate_mfu(step_flops / 1e12, self.dist_env.world_size, time_delta)
+
+        total_loss = torch.sum(torch.stack(loss_buffer))
+        total_loss = self._dp_allreduce(total_loss, include_cp=True).cpu().item()
+
+        dllm_loss = self._dp_allreduce(torch.stack(self._dllm_loss_buffer).sum(), include_cp=True).item()
+        self._dllm_loss_buffer.clear()
+
+        return MetricsSample(
+            step=self.step_scheduler.step,
+            epoch=self.step_scheduler.epoch,
+            metrics={
+                "loss": total_loss,
+                "Loss/Train_Total": total_loss,
+                "Loss/Train_DLLM": dllm_loss,
+                "grad_norm": grad_norm,
+                "Train/grad_norm": grad_norm,
+                "lr": self.optimizer[0].param_groups[0]["lr"],
+                "Train/lr": self.optimizer[0].param_groups[0]["lr"],
+                "Train/mem": torch.cuda.max_memory_allocated() / 1024**3,
+                "Train/tps": tps,
+                "Train/tps_per_gpu": tps / self._get_cp_group_size() / max(self._get_dp_group_size(), 1),
+                "Train/mfu": mfu,
+                "Train/tokens_per_step": num_tokens_in_batch,
+                "Train/mode": self.dllm_mode,
+            },
+        )
+
+    @torch.no_grad()
+    def _run_validation_epoch(self, val_dataloader):
+        """Run one validation pass with dLLM corruption and loss.
+
+        Computes per-batch loss with proper denominators, then accumulates
+        weighted by noise token count to produce a per-noise-token average
+        across the val set.
+        """
+        with ScopedRNG(seed=1, ranked=True):
+            for mp in self.model_parts:
+                mp.eval()
+
+            total_weighted_loss = torch.tensor(0.0, dtype=torch.float32, device=self.dist_env.device)
+            total_noise_tokens = 0
+
+            for batch in val_dataloader:
+                # Pre-corrupt this val batch (same as training path)
+                input_ids = batch["input_ids"]
+                loss_mask = batch["loss_mask"]
+                noisy_input_ids, noise_mask, p_mask = self._apply_corruption(input_ids, loss_mask)
+                batch["_noisy_input_ids"] = noisy_input_ids
+                batch["_noise_mask"] = noise_mask
+                batch["_p_mask"] = p_mask
+                batch["_clean_input_ids"] = input_ids.clone()
+
+                # Count tokens for this batch (all-reduce across DP for this batch)
+                num_noise = self._dp_allreduce(torch.tensor(noise_mask.sum().item(), dtype=torch.long)).item()
+
+                loss_buffer = []
+                self._forward_backward_step(
+                    0,
+                    batch,
+                    loss_buffer=loss_buffer,
+                    num_diffusion_tokens=num_noise,
+                    num_batches=1,
+                    is_train=False,
+                )
+
+                # Accumulate: per-token-avg loss * noise_count
+                batch_loss = torch.sum(torch.stack(loss_buffer)).item()
+                batch_loss = self._dp_allreduce(
+                    torch.tensor(batch_loss, dtype=torch.float32, device=self.dist_env.device),
+                    include_cp=True,
+                ).item()
+                total_weighted_loss += batch_loss * num_noise
+                total_noise_tokens += num_noise
+
+        val_loss = total_weighted_loss / max(total_noise_tokens, 1e-8)
+        val_loss = val_loss.item() if isinstance(val_loss, torch.Tensor) else val_loss
+
+        # Clear dLLM loss buffer from validation
+        self._dllm_loss_buffer.clear()
+
+        return MetricsSample(
+            step=self.step_scheduler.step,
+            epoch=self.step_scheduler.epoch,
+            metrics={
+                "val_loss": val_loss,
+                "lr": self.optimizer[0].param_groups[0]["lr"],
+                "num_label_tokens": total_noise_tokens,
+                "mem": torch.cuda.max_memory_allocated() / 1024**3,
+            },
+        )
+
+    def log_train_metrics(self, log_data):
+        """Log dLLM-specific training metrics."""
+        if not self.dist_env.is_main:
+            return
+
+        if self.step_scheduler.is_remote_logging_step:
+            # Filter out step/epoch/timestamp — they're redundant with the
+            # x-axis and would create separate wandb panels.
+            remote_metrics = {k: v for k, v in log_data.to_dict().items() if k not in ("step", "epoch", "timestamp")}
+            if wandb.run is not None:
+                wandb.log(remote_metrics, step=self.step_scheduler.step)
+            if self.mlflow_logger is not None:
+                self.mlflow_logger.log_metrics(remote_metrics, step=log_data.step)
+            if self.comet_logger is not None:
+                self.comet_logger.log_metrics(remote_metrics, step=log_data.step)
+
+        self.metric_logger_train.log(log_data)
+        logging.info(
+            "step {} | epoch {} | loss {:.4f} | dllm_loss {:.4f} | grad_norm {:.4f} | "
+            "lr {:.2e} | mem {:.2f} GiB | tps {:.2f}({:.2f}/gpu) | mode {}".format(
+                log_data.step,
+                log_data.epoch,
+                log_data.metrics["Loss/Train_Total"],
+                log_data.metrics["Loss/Train_DLLM"],
+                log_data.metrics["Train/grad_norm"],
+                log_data.metrics["Train/lr"],
+                log_data.metrics["Train/mem"],
+                log_data.metrics["Train/tps"],
+                log_data.metrics["Train/tps_per_gpu"],
+                log_data.metrics["Train/mode"],
+            )
+        )
+        torch.cuda.reset_peak_memory_stats()
+
+
+# Entry point
+def main(config_path=None):
+    """Main entry point for dLLM SFT recipe."""
+    if config_path is None:
+        config_path = "examples/dllm_sft/mdlm_sft.yaml"
+    cfg = parse_args_and_load_config(config_path)
+    trainer = DiffusionLMSFTRecipe(cfg)
+    trainer.setup()
+    trainer.run_train_validation_loop()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit_tests/datasets/dllm/test_collate.py
+++ b/tests/unit_tests/datasets/dllm/test_collate.py
@@ -1,0 +1,167 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for DLLMCollator (two-stage block-aligned padding)."""
+
+import pytest
+import torch
+
+from nemo_automodel.components.datasets.dllm.collate import DLLMCollator
+
+
+def _make_sample(length, pad_token_id=0):
+    """Create a minimal unshifted sample dict."""
+    return {
+        "input_ids": list(range(1, length + 1)),
+        "loss_mask": [1] * length,
+        "attention_mask": [1] * length,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Basic collation
+# ---------------------------------------------------------------------------
+
+
+class TestDLLMCollatorBasic:
+    def test_output_keys(self):
+        collator = DLLMCollator()
+        batch = [_make_sample(10)]
+        out = collator(batch)
+        assert set(out.keys()) == {"input_ids", "loss_mask", "attention_mask", "input_lengths"}
+
+    def test_output_shapes(self):
+        collator = DLLMCollator()
+        batch = [_make_sample(10), _make_sample(15)]
+        out = collator(batch)
+        B = 2
+        L = out["input_ids"].shape[1]
+        assert out["input_ids"].shape == (B, L)
+        assert out["loss_mask"].shape == (B, L)
+        assert out["attention_mask"].shape == (B, L)
+        assert out["input_lengths"].shape == (B,)
+
+    def test_content_preserved(self):
+        collator = DLLMCollator()
+        batch = [_make_sample(5)]
+        out = collator(batch)
+        assert out["input_ids"][0, :5].tolist() == [1, 2, 3, 4, 5]
+
+    def test_input_lengths_correct(self):
+        collator = DLLMCollator()
+        batch = [_make_sample(7), _make_sample(12)]
+        out = collator(batch)
+        assert out["input_lengths"].tolist() == [7, 12]
+
+    def test_pads_to_longest(self):
+        collator = DLLMCollator()
+        batch = [_make_sample(5), _make_sample(10)]
+        out = collator(batch)
+        assert out["input_ids"].shape[1] >= 10
+
+
+# ---------------------------------------------------------------------------
+# Block-aligned padding
+# ---------------------------------------------------------------------------
+
+
+class TestDLLMCollatorBlockAlign:
+    def test_output_length_divisible_by_block_size(self):
+        collator = DLLMCollator(block_size=8)
+        batch = [_make_sample(10)]  # 10 -> aligned to 16
+        out = collator(batch)
+        assert out["input_ids"].shape[1] % 8 == 0
+
+    def test_block_padding_uses_eos_token(self):
+        collator = DLLMCollator(block_size=8, eos_token_id=2, pad_token_id=0)
+        batch = [_make_sample(5)]  # content=5, block-aligned=8
+        out = collator(batch)
+        # Positions 5-7 should be eos (block padding)
+        assert (out["input_ids"][0, 5:8] == 2).all()
+
+    def test_block_padding_loss_mask_is_one(self):
+        """Block padding (eos fill) should have loss_mask=1."""
+        collator = DLLMCollator(block_size=8, eos_token_id=2)
+        batch = [_make_sample(5)]
+        out = collator(batch)
+        # Content positions 0-4: loss_mask=1, block pad 5-7: loss_mask=1
+        assert (out["loss_mask"][0, :8] == 1).all()
+
+    def test_global_padding_loss_mask_is_zero(self):
+        """Global padding should have loss_mask=0."""
+        collator = DLLMCollator(block_size=8, pad_token_id=0)
+        batch = [_make_sample(5), _make_sample(14)]
+        out = collator(batch)
+        L = out["input_ids"].shape[1]
+        # For the short sample (len=5, block-aligned=8), positions 8+ are global padding
+        assert (out["loss_mask"][0, 8:] == 0).all()
+
+    def test_attention_mask_zero_for_all_padding(self):
+        """attention_mask should be 0 for both block and global padding."""
+        collator = DLLMCollator(block_size=8)
+        batch = [_make_sample(5)]
+        out = collator(batch)
+        # Content: 5 positions with attn=1, rest should be 0
+        assert out["attention_mask"][0, :5].sum() == 5
+        assert out["attention_mask"][0, 5:].sum() == 0
+
+
+# ---------------------------------------------------------------------------
+# pad_seq_len_divisible
+# ---------------------------------------------------------------------------
+
+
+class TestDLLMCollatorSeqLenDivisible:
+    def test_divisible_alignment(self):
+        collator = DLLMCollator(block_size=32, pad_seq_len_divisible=1024)
+        batch = [_make_sample(100)]
+        out = collator(batch)
+        L = out["input_ids"].shape[1]
+        assert L % 1024 == 0
+
+    def test_lcm_alignment(self):
+        """Output should be divisible by lcm(block_size, pad_seq_len_divisible)."""
+        import math
+
+        collator = DLLMCollator(block_size=32, pad_seq_len_divisible=48)
+        batch = [_make_sample(10)]
+        out = collator(batch)
+        L = out["input_ids"].shape[1]
+        assert L % math.lcm(32, 48) == 0
+
+
+# ---------------------------------------------------------------------------
+# max_seq_len
+# ---------------------------------------------------------------------------
+
+
+class TestDLLMCollatorMaxSeqLen:
+    def test_caps_output_length(self):
+        collator = DLLMCollator(max_seq_len=64)
+        batch = [_make_sample(100)]
+        out = collator(batch)
+        assert out["input_ids"].shape[1] <= 64
+
+    def test_caps_with_block_alignment(self):
+        collator = DLLMCollator(block_size=32, max_seq_len=64)
+        batch = [_make_sample(50)]
+        out = collator(batch)
+        assert out["input_ids"].shape[1] <= 64
+
+    def test_content_truncated_to_max_seq_len(self):
+        collator = DLLMCollator(max_seq_len=10)
+        batch = [_make_sample(20)]
+        out = collator(batch)
+        # Only first 10 tokens should be copied
+        assert out["input_ids"][0, :10].tolist() == list(range(1, 11))

--- a/tests/unit_tests/datasets/dllm/test_corruption.py
+++ b/tests/unit_tests/datasets/dllm/test_corruption.py
@@ -1,0 +1,173 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for dLLM corruption functions (corrupt_uniform, corrupt_blockwise)."""
+
+import pytest
+import torch
+
+from nemo_automodel.components.datasets.dllm.corruption import (
+    corrupt_blockwise,
+    corrupt_uniform,
+    gumbel_topk,
+)
+
+B, L = 4, 32
+MASK_TOKEN_ID = 999
+
+
+@pytest.fixture
+def inputs():
+    torch.manual_seed(0)
+    input_ids = torch.randint(0, 100, (B, L))
+    # Supervised positions: first 24 of 32
+    loss_mask = torch.zeros(B, L, dtype=torch.long)
+    loss_mask[:, :24] = 1
+    return input_ids, loss_mask
+
+
+# ---------------------------------------------------------------------------
+# gumbel_topk
+# ---------------------------------------------------------------------------
+
+
+class TestGumbelTopk:
+    def test_exact_k_selected(self):
+        torch.manual_seed(0)
+        log_w = torch.zeros(50)
+        for k in [1, 5, 25, 50]:
+            mask = gumbel_topk(log_w, k)
+            assert mask.sum().item() == k
+
+    def test_output_is_bool(self):
+        mask = gumbel_topk(torch.zeros(10), 3)
+        assert mask.dtype == torch.bool
+
+
+# ---------------------------------------------------------------------------
+# corrupt_uniform
+# ---------------------------------------------------------------------------
+
+
+class TestCorruptUniform:
+    def test_output_shapes(self, inputs):
+        input_ids, loss_mask = inputs
+        noisy, noise_mask, p_mask = corrupt_uniform(input_ids, loss_mask, MASK_TOKEN_ID)
+        assert noisy.shape == (B, L)
+        assert noise_mask.shape == (B, L)
+        assert p_mask.shape == (B, L)
+
+    def test_noise_mask_is_subset_of_loss_mask(self, inputs):
+        input_ids, loss_mask = inputs
+        _, noise_mask, _ = corrupt_uniform(input_ids, loss_mask, MASK_TOKEN_ID)
+        # Every corrupted position must be a supervised position
+        assert (noise_mask & ~loss_mask.bool()).sum() == 0
+
+    def test_corrupted_positions_have_mask_token(self, inputs):
+        input_ids, loss_mask = inputs
+        noisy, noise_mask, _ = corrupt_uniform(input_ids, loss_mask, MASK_TOKEN_ID)
+        assert (noisy[noise_mask] == MASK_TOKEN_ID).all()
+
+    def test_uncorrupted_positions_unchanged(self, inputs):
+        input_ids, loss_mask = inputs
+        noisy, noise_mask, _ = corrupt_uniform(input_ids, loss_mask, MASK_TOKEN_ID)
+        assert (noisy[~noise_mask] == input_ids[~noise_mask]).all()
+
+    def test_p_mask_in_valid_range(self, inputs):
+        input_ids, loss_mask = inputs
+        _, _, p_mask = corrupt_uniform(input_ids, loss_mask, MASK_TOKEN_ID, eps=0.01)
+        # p = (1-eps)*t + eps, t in [0,1], so p in [eps, 1]
+        assert (p_mask >= 0.01 - 1e-6).all()
+        assert (p_mask <= 1.0 + 1e-6).all()
+
+    def test_p_mask_constant_per_sequence(self, inputs):
+        """Uniform corruption uses a single t per sequence."""
+        input_ids, loss_mask = inputs
+        _, _, p_mask = corrupt_uniform(input_ids, loss_mask, MASK_TOKEN_ID)
+        for b in range(B):
+            assert (p_mask[b] == p_mask[b, 0]).all()
+
+    def test_no_corruption_outside_loss_mask(self, inputs):
+        """Positions with loss_mask=0 should never be corrupted."""
+        input_ids, loss_mask = inputs
+        noisy, _, _ = corrupt_uniform(input_ids, loss_mask, MASK_TOKEN_ID)
+        unsupervised = ~loss_mask.bool()
+        assert (noisy[unsupervised] == input_ids[unsupervised]).all()
+
+
+# ---------------------------------------------------------------------------
+# corrupt_blockwise
+# ---------------------------------------------------------------------------
+
+
+class TestCorruptBlockwise:
+    def test_output_shapes(self, inputs):
+        input_ids, loss_mask = inputs
+        noisy, noise_mask, p_mask = corrupt_blockwise(
+            input_ids, loss_mask, MASK_TOKEN_ID, block_size=8
+        )
+        assert noisy.shape == (B, L)
+        assert noise_mask.shape == (B, L)
+        assert p_mask.shape == (B, L)
+
+    def test_noise_mask_is_subset_of_loss_mask(self, inputs):
+        input_ids, loss_mask = inputs
+        _, noise_mask, _ = corrupt_blockwise(
+            input_ids, loss_mask, MASK_TOKEN_ID, block_size=8
+        )
+        assert (noise_mask & ~loss_mask.bool()).sum() == 0
+
+    def test_corrupted_positions_have_mask_token(self, inputs):
+        input_ids, loss_mask = inputs
+        noisy, noise_mask, _ = corrupt_blockwise(
+            input_ids, loss_mask, MASK_TOKEN_ID, block_size=8
+        )
+        assert (noisy[noise_mask] == MASK_TOKEN_ID).all()
+
+    def test_uncorrupted_positions_unchanged(self, inputs):
+        input_ids, loss_mask = inputs
+        noisy, noise_mask, _ = corrupt_blockwise(
+            input_ids, loss_mask, MASK_TOKEN_ID, block_size=8
+        )
+        assert (noisy[~noise_mask] == input_ids[~noise_mask]).all()
+
+    def test_p_mask_in_valid_range(self, inputs):
+        input_ids, loss_mask = inputs
+        _, _, p_mask = corrupt_blockwise(
+            input_ids, loss_mask, MASK_TOKEN_ID, block_size=8, eps=0.01
+        )
+        assert (p_mask >= 0.01 - 1e-6).all()
+        assert (p_mask <= 1.0 + 1e-6).all()
+
+    def test_sequence_level_when_no_block_size(self, inputs):
+        """block_size=None should do per-sequence sampling."""
+        input_ids, loss_mask = inputs
+        noisy, noise_mask, p_mask = corrupt_blockwise(
+            input_ids, loss_mask, MASK_TOKEN_ID, block_size=None
+        )
+        # p_mask should be constant per sequence (single m sampled)
+        for b in range(B):
+            assert (p_mask[b] == p_mask[b, 0]).all()
+
+    def test_blockwise_p_mask_varies_across_blocks(self, inputs):
+        """With block_size, different blocks can have different p values."""
+        input_ids, loss_mask = inputs
+        torch.manual_seed(123)
+        _, _, p_mask = corrupt_blockwise(
+            input_ids, loss_mask, MASK_TOKEN_ID, block_size=8
+        )
+        # With 4 blocks of size 8, p values should differ across blocks
+        # (not guaranteed per run, but with seed=123 and 4 blocks it's very likely)
+        block_ps = [p_mask[0, i * 8].item() for i in range(4)]
+        assert len(set(block_ps)) > 1, "Expected different p values across blocks"

--- a/tests/unit_tests/loss/test_dllm_loss.py
+++ b/tests/unit_tests/loss/test_dllm_loss.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for dLLM loss functions (MDLMCrossEntropyLoss, HybridDiffusionLLMLoss)."""
+
+import pytest
+import torch
+
+import torch.nn.functional as F
+
+from nemo_automodel.components.loss.dllm_loss import (
+    DLLMLossOutput,
+    MDLMCrossEntropyLoss,
+    _compute_per_token_nll,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+B, L, V = 2, 8, 32  # batch, seq_len, vocab
+
+
+@pytest.fixture
+def dummy_inputs():
+    """Create minimal inputs shared across tests."""
+    torch.manual_seed(42)
+    logits = torch.randn(B, L, V)
+    target_ids = torch.randint(0, V, (B, L))
+    # Supervised positions: first 6 of 8
+    loss_mask = torch.tensor([[1, 1, 1, 1, 1, 1, 0, 0]] * B)
+    # Corrupted positions: subset of supervised
+    noise_mask = torch.tensor([[0, 1, 0, 1, 1, 0, 0, 0]] * B).bool()
+    p_mask = torch.full((B, L), 0.5)
+    return logits, target_ids, noise_mask, p_mask, loss_mask
+
+
+# ---------------------------------------------------------------------------
+# MDLMCrossEntropyLoss
+# ---------------------------------------------------------------------------
+
+
+class TestMDLMCrossEntropyLoss:
+    def test_returns_dllm_loss_output(self, dummy_inputs):
+        logits, target_ids, noise_mask, p_mask, loss_mask = dummy_inputs
+        loss_fn = MDLMCrossEntropyLoss()
+        result = loss_fn(logits, target_ids, noise_mask, p_mask, loss_mask)
+        assert isinstance(result, DLLMLossOutput)
+
+    def test_total_loss_equals_dllm_loss(self, dummy_inputs):
+        """For MDLM, total_loss and dllm_loss should be equal (no AR component)."""
+        logits, target_ids, noise_mask, p_mask, loss_mask = dummy_inputs
+        loss_fn = MDLMCrossEntropyLoss()
+        result = loss_fn(logits, target_ids, noise_mask, p_mask, loss_mask)
+        assert torch.allclose(result.total_loss, result.dllm_loss, atol=1e-6)
+
+    def test_loss_is_positive(self, dummy_inputs):
+        logits, target_ids, noise_mask, p_mask, loss_mask = dummy_inputs
+        loss_fn = MDLMCrossEntropyLoss()
+        result = loss_fn(logits, target_ids, noise_mask, p_mask, loss_mask)
+        assert result.total_loss.item() > 0
+
+    def test_zero_loss_when_no_noise(self, dummy_inputs):
+        """If nothing is corrupted, loss should be zero."""
+        logits, target_ids, _, p_mask, loss_mask = dummy_inputs
+        noise_mask = torch.zeros(B, L, dtype=torch.bool)
+        loss_fn = MDLMCrossEntropyLoss()
+        result = loss_fn(logits, target_ids, noise_mask, p_mask, loss_mask)
+        assert result.total_loss.item() == 0.0
+
+    def test_normalization_by_num_diffusion_tokens(self, dummy_inputs):
+        logits, target_ids, noise_mask, p_mask, loss_mask = dummy_inputs
+        loss_fn = MDLMCrossEntropyLoss()
+        result_unnorm = loss_fn(logits, target_ids, noise_mask, p_mask, loss_mask)
+        result_norm = loss_fn(
+            logits, target_ids, noise_mask, p_mask, loss_mask, num_diffusion_tokens=10
+        )
+        # Normalized loss should be unnormalized / 10
+        assert torch.allclose(result_norm.total_loss, result_unnorm.total_loss / 10, atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# _compute_per_token_nll helper
+# ---------------------------------------------------------------------------
+
+
+class TestComputePerTokenNLL:
+    def test_plain_tensor_matches_ce(self):
+        """Plain tensor path should match F.cross_entropy(reduction='none')."""
+        torch.manual_seed(42)
+        logits = torch.randn(2, 8, 32)
+        targets = torch.randint(0, 32, (2, 8))
+        nll = _compute_per_token_nll(logits, targets)
+        ref = F.cross_entropy(
+            logits.reshape(-1, 32), targets.reshape(-1), reduction="none"
+        ).reshape(2, 8)
+        assert torch.allclose(nll, ref)
+
+    def test_output_shape(self):
+        """Output shape should be [B, L]."""
+        logits = torch.randn(4, 16, 64)
+        targets = torch.randint(0, 64, (4, 16))
+        nll = _compute_per_token_nll(logits, targets)
+        assert nll.shape == (4, 16)
+
+    def test_positive_values(self):
+        """NLL should be non-negative."""
+        logits = torch.randn(2, 8, 32)
+        targets = torch.randint(0, 32, (2, 8))
+        nll = _compute_per_token_nll(logits, targets)
+        assert (nll >= 0).all()


### PR DESCRIPTION
# What does this PR do ?

Add supervised fine-tuning (SFT) support for diffusion language models (dLLMs) to Automodel. Instead of next-token prediction, dLLM trains a model to denoise corrupted tokens. Each training step corrupts a subset of supervised tokens and the model predicts the clean token at each position. 

# Changelog

 **dLLM SFT recipe and components**
  - Add `DiffusionLMSFTRecipe` extending the LLM fine-tuning recipe (`nemo_automodel/recipes/dllm/train_ft.py`)
  - Add pluggable strategy pattern (`nemo_automodel/recipes/dllm/strategy.py`) so new dLLM variants can be added without modifying the recipe
  - Add `MDLMCrossEntropyLoss` with inverse-corruption-probability weighting and unified `DLLMLossOutput` return type
  (`nemo_automodel/components/loss/dllm_loss.py`)
  - Add `corrupt_uniform` and `corrupt_blockwise` corruption functions with vectorized Gumbel-max top-k selection
  (`nemo_automodel/components/datasets/dllm/corruption.py`)
  - Add `DLLMCollator` for two-stage block-aligned padding (block fill + global pad) (`nemo_automodel/components/datasets/dllm/collate.py`)
  - Add `dllm_sft` command to CLI (`nemo_automodel/_cli/app.py`)
 
  **Dataset support**
  - Add `unshifted` format to `ChatDataset` and formatting utilities for dLLM training (returns `input_ids` + `loss_mask` instead of shifted `input_ids`/`labels`)

 **FSDP2**
  - Add `autocast_dtype` field to `FSDP2Config` for wrapping forward pass in `torch.autocast`
  - Add YAML-to-object instantiation for `mp_policy`, `offload_policy`, and `autocast_dtype` in `_dist_setup.py`
  - Skip `model.to(device)` when FSDP2 CPU offload is active (FSDP manages GPU placement during forward/backward)

  **Tests**
  - Add unit tests for `DLLMCollator` (block alignment, two-stage padding, `max_seq_len` cap)
  - Add unit tests for `corrupt_uniform` and `corrupt_blockwise` (output shapes, mask invariants, block-level sampling)
  - Add unit tests for `MDLMCrossEntropyLoss` (normalization, zero-loss invariant)

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.


