### PR TITLE
fix: skip embedding[padding_idx] = 0 with TP

### DIFF
--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -1390,50 +1390,6 @@ def _model_has_dtensors(module: nn.Module) -> bool:
     return any(type(p).__name__ == "DTensor" for p in module.parameters())
 
 
-def _zero_dtensor_embedding_padding_row(embedding: nn.Embedding) -> None:
-    """Zero the ``padding_idx`` row of a TP-sharded embedding weight via local tensor ops.
-
-    When the weight is a DTensor sharded along dim 0 (vocab-parallel), only the
-    rank whose local shard contains the ``padding_idx`` row performs the zeroing.
-    For replicated weights or weights sharded on other dims, every rank zeros
-    the row in its local tensor.
-    """
-    padding_idx = embedding.padding_idx
-    weight = embedding.weight
-    if padding_idx is None:
-        return
-    if type(weight).__name__ != "DTensor":
-        return
-
-    local = weight._local_tensor
-    spec = weight._spec
-
-    for mesh_dim, placement in enumerate(spec.placements):
-        if placement.is_shard() and placement.dim == 0:
-            mesh = spec.mesh
-            tp_size = mesh.size(mesh_dim)
-            rank = mesh.get_local_rank(mesh_dim)
-            vocab_size = weight.shape[0]
-
-            chunk = vocab_size // tp_size
-            rem = vocab_size % tp_size
-            if rank < rem:
-                local_off = rank * (chunk + 1)
-                local_size = chunk + 1
-            else:
-                local_off = rem * (chunk + 1) + (rank - rem) * chunk
-                local_size = chunk
-
-            local_idx = padding_idx - local_off
-            if 0 <= local_idx < local_size:
-                with torch.no_grad():
-                    local[local_idx].zero_()
-            return
-
-    with torch.no_grad():
-        local[padding_idx].zero_()
-
-
 def _is_custom_model(module: nn.Module) -> bool:
     """True if the model has a custom implementation in nemo_automodel/components/models/.
 

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -534,12 +534,31 @@ class Checkpointer:
                 if hasattr(module, "_is_hf_initialized"):
                     module._is_hf_initialized = False
 
+            # HF's _init_weights calls init.zeros_(weight[padding_idx]) on
+            # nn.Embedding layers.  When the weight is a DTensor (TP-sharded),
+            # the integer index triggers a redistribute that fails.  Temporarily
+            # clear padding_idx so the zeroing is skipped, then restore it and
+            # zero the row via local-tensor ops instead.
+            saved_padding_idx: dict[nn.Embedding, int] = {}
+            for mod in model.modules():
+                if (
+                    isinstance(mod, nn.Embedding)
+                    and getattr(mod, "padding_idx", None) is not None
+                    and type(getattr(mod, "weight", None)).__name__ == "DTensor"
+                ):
+                    saved_padding_idx[mod] = mod.padding_idx
+                    mod.padding_idx = None
+
             if hasattr(model, "initialize_weights"):
                 model.initialize_weights()
             else:
                 logging.warning(
-                    "Warning: Model does not have initialize_weights method. Requires custom initialization to be implemented."
+                    "Warning: Model does not have initialize_weights method."
+                    "Custom initialization is required to be implemented."
                 )
+
+            for mod, idx in saved_padding_idx.items():
+                mod.padding_idx = idx
 
         if peft_init_method is not None:
             _init_peft_adapters(model, peft_init_method)

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -520,6 +520,17 @@ class Checkpointer:
             and getattr(model.config, "n_routed_experts", None)  # is Nemotron V3
             and hasattr(model, "backbone")  # is HF remote code
         )
+        # HF's _init_weights calls init.zeros_(weight[padding_idx]) on
+        # nn.Embedding layers.  When the weight is a DTensor (TP-sharded),
+        # the integer index triggers a redistribute that fails.  Temporarily
+        # clear padding_idx so the zeroing is skipped, then restore it and
+        # zero the row via local-tensor ops instead.
+        has_padding_idx = any(
+            isinstance(mod, nn.Embedding)
+            and type(mod.weight).__name__ == "DTensor"
+            and getattr(mod, "padding_idx", None) is not None
+            for mod in model.modules()
+        )
         skip_initialize_weights = (
             model_class
             in [
@@ -528,37 +539,20 @@ class Checkpointer:
             ]
             or is_nemotron_v2
             or is_nemotron_v3_hf
+            or has_padding_idx
         )
         if not skip_initialize_weights:
             for _, module in model.named_modules():
                 if hasattr(module, "_is_hf_initialized"):
                     module._is_hf_initialized = False
 
-            # HF's _init_weights calls init.zeros_(weight[padding_idx]) on
-            # nn.Embedding layers.  When the weight is a DTensor (TP-sharded),
-            # the integer index triggers a redistribute that fails.  Temporarily
-            # clear padding_idx so the zeroing is skipped, then restore it and
-            # zero the row via local-tensor ops instead.
-            saved_padding_idx: dict[nn.Embedding, int] = {}
-            for mod in model.modules():
-                if (
-                    isinstance(mod, nn.Embedding)
-                    and getattr(mod, "padding_idx", None) is not None
-                    and type(getattr(mod, "weight", None)).__name__ == "DTensor"
-                ):
-                    saved_padding_idx[mod] = mod.padding_idx
-                    mod.padding_idx = None
-
             if hasattr(model, "initialize_weights"):
                 model.initialize_weights()
             else:
                 logging.warning(
                     "Warning: Model does not have initialize_weights method."
-                    "Custom initialization is required to be implemented."
+                    " Requires custom initialization to be implemented."
                 )
-
-            for mod, idx in saved_padding_idx.items():
-                mod.padding_idx = idx
 
         if peft_init_method is not None:
             _init_peft_adapters(model, peft_init_method)
@@ -1394,6 +1388,50 @@ def _equally_divide_layers(num_shards: int, keys: list[str]) -> dict[str, int]:
 def _model_has_dtensors(module: nn.Module) -> bool:
     """True if any parameter is a DTensor (model is already sharded)."""
     return any(type(p).__name__ == "DTensor" for p in module.parameters())
+
+
+def _zero_dtensor_embedding_padding_row(embedding: nn.Embedding) -> None:
+    """Zero the ``padding_idx`` row of a TP-sharded embedding weight via local tensor ops.
+
+    When the weight is a DTensor sharded along dim 0 (vocab-parallel), only the
+    rank whose local shard contains the ``padding_idx`` row performs the zeroing.
+    For replicated weights or weights sharded on other dims, every rank zeros
+    the row in its local tensor.
+    """
+    padding_idx = embedding.padding_idx
+    weight = embedding.weight
+    if padding_idx is None:
+        return
+    if type(weight).__name__ != "DTensor":
+        return
+
+    local = weight._local_tensor
+    spec = weight._spec
+
+    for mesh_dim, placement in enumerate(spec.placements):
+        if placement.is_shard() and placement.dim == 0:
+            mesh = spec.mesh
+            tp_size = mesh.size(mesh_dim)
+            rank = mesh.get_local_rank(mesh_dim)
+            vocab_size = weight.shape[0]
+
+            chunk = vocab_size // tp_size
+            rem = vocab_size % tp_size
+            if rank < rem:
+                local_off = rank * (chunk + 1)
+                local_size = chunk + 1
+            else:
+                local_off = rem * (chunk + 1) + (rank - rem) * chunk
+                local_size = chunk
+
+            local_idx = padding_idx - local_off
+            if 0 <= local_idx < local_size:
+                with torch.no_grad():
+                    local[local_idx].zero_()
+            return
+
+    with torch.no_grad():
+        local[padding_idx].zero_()
 
 
 def _is_custom_model(module: nn.Module) -> bool:


### PR DESCRIPTION
# What does this PR do ?

Context:
HF may initialize models and set the padding_idx to zero. When the embedding layer is row-wise sharded this can cause the following error:
```
  File "/opt/Automodel/nemo_automodel/components/checkpoint/checkpointing.py", line 538, in initialize_model_weights
    model.initialize_weights()
  File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 124, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/transformers/modeling_utils.py", line 2410, in initialize_weights
    self.smart_apply(self._initialize_weights, self.is_remote_code())
  File "/opt/venv/lib/python3.12/site-packages/transformers/modeling_utils.py", line 2401, in smart_apply
    module.smart_apply(module._initialize_weights, is_remote_code)
  File "/opt/venv/lib/python3.12/site-packages/transformers/modeling_utils.py", line 2403, in smart_apply
    module.smart_apply(fn, is_remote_code)
  File "/opt/venv/lib/python3.12/site-packages/transformers/modeling_utils.py", line 2404, in smart_apply
    fn(self, is_remote_code)
  File "/opt/venv/lib/python3.12/site-packages/transformers/modeling_utils.py", line 2381, in _initialize_weights
    self._init_weights(module)
  File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 124, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/transformers/modeling_utils.py", line 2327, in _init_weights
    init.zeros_(module.weight[module.padding_idx])
                ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/distributed/tensor/_dispatch.py", line 261, in _dispatch_get_local_results_slow_path
    self.redistribute_local_args(
  File "/usr/local/lib/python3.12/dist-packages/torch/distributed/tensor/_dispatch.py", line 486, in redistribute_local_args
    resharded_local_tensor = redistribute_local_tensor(
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/distributed/tensor/_redistribute.py", line 864, in redistribute_local_tensor
    transform_infos = _gen_transform_infos(
                      ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/distributed/tensor/_redistribute.py", line 826, in _gen_transform_infos
    return _gen_transform_infos_non_cached(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/distributed/tensor/_redistribute.py", line 790, in _gen_transform_infos_non_cached
    assert src_shard_order is not None and dst_shard_order is not None
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
the `[]` operator fails in this case. 



Alternatively, we could remap the padding_idx to the local shard and zero as follows, but I'm not sure that's better either.
```
def _zero_dtensor_embedding_padding_row(embedding: nn.Embedding) -> None:
    """Zero the ``padding_idx`` row of a TP-sharded embedding weight via local tensor ops.

    When the weight is a DTensor sharded along dim 0 (vocab-parallel), only the
    rank whose local shard contains the ``padding_idx`` row performs the zeroing.
    For replicated weights or weights sharded on other dims, every rank zeros
    the row in its local tensor.
    """
    padding_idx = embedding.padding_idx
    weight = embedding.weight
    if padding_idx is None:
        return
    if type(weight).__name__ != "DTensor":
        return

    local = weight._local_tensor
    spec = weight._spec

    for mesh_dim, placement in enumerate(spec.placements):
        if placement.is_shard() and placement.dim == 0:
            mesh = spec.mesh
            tp_size = mesh.size(mesh_dim)
            rank = mesh.get_local_rank(mesh_dim)
            vocab_size = weight.shape[0]

            chunk = vocab_size // tp_size
            rem = vocab_size % tp_size
            if rank < rem:
                local_off = rank * (chunk + 1)
                local_size = chunk + 1
            else:
                local_off = rem * (chunk + 1) + (rank - rem) * chunk
                local_size = chunk

            local_idx = padding_idx - local_off
            if 0 <= local_idx < local_size:
                with torch.no_grad():
                    local[local_idx].zero_()
            return

    with torch.no_grad():
        local[padding_idx].zero_()
```
# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
