### PR TITLE
feat: Allow to conditionally skip malformed jsonl lines when loading dataset

### DIFF
--- a/docs/guides/dataset-overview.md
+++ b/docs/guides/dataset-overview.md
@@ -76,7 +76,7 @@ See the detailed guide, [Column-Mapped Text Instruction Dataset](llm/column-mapp
     - `truncation`: truncation strategy ("do_not_truncate", "longest_first", etc.)
     - `start_of_turn_token`: token marking assistant response start (for answer-only loss)
     - `chat_template`: optional override for tokenizer's chat template
-    - `skip_invalid_samples`: if ``true``, skip malformed JSONL lines when reading local files and drop samples that fail OpenAI message validation after load (warnings log skip counts); default ``false`` fails fast on bad rows
+    - `skip_invalid_samples`: if ``true``, skip malformed JSONL lines when reading local files (warnings log skip counts); default ``false`` fails fast on a bad line
   - Notes:
     - Requires a tokenizer with chat template support
     - Supports both single-turn and multi-turn tool calling
@@ -98,7 +98,7 @@ See the detailed guide, [Column-Mapped Text Instruction Dataset](llm/column-mapp
   - `start_of_turn_token`: token marking assistant response start (for answer-only loss)
   - `chat_template`: optional override for tokenizer's chat template
   - `mask_reasoning_content`: optionally exclude rendered `reasoning_content` tokens from loss
-  - `skip_invalid_samples`: if ``true``, skip malformed JSONL lines when reading local files and drop samples that fail OpenAI message validation after load (warnings log skip counts); default ``false`` fails fast on bad rows
+  - `skip_invalid_samples`: if ``true``, skip malformed JSONL lines when reading local files (warnings log skip counts); default ``false`` fails fast on a bad line
 :::{note}
 - Requires a tokenizer with chat template support
 - Supports both single-turn and multi-turn tool calling
@@ -109,7 +109,7 @@ See the detailed guide, [Column-Mapped Text Instruction Dataset](llm/column-mapp
 - If your dataset contains `reasoning_content`, your chat template must render it explicitly or it will be dropped
 - For multi-turn tool-calling datasets, prefer chat templates that use `{% generation %}` blocks so assistant-turn loss masking is exact
 - Set `mask_reasoning_content: true` if you want to train on the final assistant answer while excluding rendered reasoning traces from loss
-- Set `skip_invalid_samples: true` for noisy local JSONL or mixed-quality Hub rows so bad lines are skipped instead of failing the run
+- Set `skip_invalid_samples: true` for noisy local JSONL so lines that are not valid JSON are skipped instead of failing the load
 :::
 - Example YAML:
 ```yaml

--- a/nemo_automodel/components/datasets/llm/chat_dataset.py
+++ b/nemo_automodel/components/datasets/llm/chat_dataset.py
@@ -308,9 +308,9 @@ class ChatDataset(Dataset):
             shuffle_seed: If set, shuffles Hub/Parquet data before applying a split slice.
             mask_reasoning_content: If ``True``, exclude rendered reasoning traces from the loss mask.
             unshifted: Passed through to ``format_chat_template``.
-            skip_invalid_samples: If ``True``, skip non-JSON JSONL lines when reading local files and drop rows
-                that fail message validation after load (warning logs include skip counts). If ``False``, invalid
-                data raises during load or first use.
+            skip_invalid_samples: If ``True``, skip malformed JSONL lines when reading local files (warning logs
+                include skip counts). If ``False``, a bad line raises. Does not skip invalid structured rows after
+                load; those still raise when a sample is accessed.
         """
         if tokenizer is None:
             raise ValueError("Tokenizer is required")
@@ -338,26 +338,6 @@ class ChatDataset(Dataset):
             shuffle_seed=shuffle_seed,
             skip_invalid_samples=skip_invalid_samples,
         )
-
-        if self.skip_invalid_samples:
-            filtered_rows: List[Dict[str, Any]] = []
-            skipped_rows = 0
-            for row in self.dataset:
-                try:
-                    messages = row.get("messages")
-                    if not isinstance(messages, list):
-                        raise ValueError("Each sample must contain a `messages` list in OpenAI format")
-                    _normalize_messages(messages)
-                    filtered_rows.append(row)
-                except Exception:
-                    skipped_rows += 1
-
-            if skipped_rows:
-                logging.getLogger(__name__).warning(
-                    "Skipped %d invalid chat sample(s) after loading (skip_invalid_samples=True)",
-                    skipped_rows,
-                )
-            self.dataset = filtered_rows
 
         # Ensure pad token presence for downstream padding
         eos_token_id = getattr(self.tokenizer, "eos_token_id", 0)

--- a/tests/unit_tests/datasets/llm/test_chat_dataset.py
+++ b/tests/unit_tests/datasets/llm/test_chat_dataset.py
@@ -321,7 +321,8 @@ def test_tool_calling_chat_dataset_happy_path_and_edge_cases(monkeypatch):
         _ = ds_bad[0]
 
 
-def test_chat_dataset_skip_invalid_samples_filters_bad_rows(monkeypatch):
+def test_chat_dataset_skip_invalid_samples_does_not_filter_structured_bad_rows(monkeypatch):
+    """skip_invalid_samples only affects JSONL parse errors, not invalid message rows after load."""
     class Tok:
         eos_token_id = 1
         chat_template = "{{ default }}"
@@ -339,9 +340,11 @@ def test_chat_dataset_skip_invalid_samples_filters_bad_rows(monkeypatch):
     monkeypatch.setattr(tcd, "_load_openai_messages", lambda *a, **k: dataset_rows)
 
     ds = tcd.ChatDataset("ignored", tok, skip_invalid_samples=True)
-    assert len(ds) == 2
+    assert len(ds) == 3
     assert ds[0]["input_ids"] == [1]
-    assert ds[1]["attention_mask"] == [1]
+    with pytest.raises(ValueError):
+        _ = ds[1]
+    assert ds[2]["attention_mask"] == [1]
 
 
 def test_resolve_chat_template_none():


### PR DESCRIPTION
# What does this PR do ?

Adds a config flag to allow skipping lines in jsonl dataset that are malformed and cant be loaded so that it doesnt crash and instead just skips the sample.

# Changelog

- `skip_invalid_samples` flag added (defaults to false for backward compat)

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)