### PR TITLE
fix: handle dict-typed chat_template in format_chat_template

### DIFF
--- a/nemo_automodel/components/datasets/llm/formatting_utils.py
+++ b/nemo_automodel/components/datasets/llm/formatting_utils.py
@@ -546,8 +546,14 @@ def format_chat_template(
     if not _has_chat_template(tokenizer):
         raise ValueError("Tokenizer lacks a usable chat template (chat_template/apply_chat_template)")
 
-    template_has_generation_kwd = GENERATION_REGEX.search(tokenizer.chat_template) is not None
-    template_mentions_reasoning_content = "reasoning_content" in tokenizer.chat_template
+    # Resolve the template string — some tokenizers store multiple templates as a dict
+    # (keyed by name, e.g. "default", "tool_use"). We need the raw string for regex checks.
+    chat_template_str = tokenizer.chat_template
+    if isinstance(chat_template_str, dict):
+        chat_template_str = chat_template_str.get("default", next(iter(chat_template_str.values())))
+
+    template_has_generation_kwd = GENERATION_REGEX.search(chat_template_str) is not None
+    template_mentions_reasoning_content = "reasoning_content" in chat_template_str
     has_reasoning_content = any(
         message.get("role") == "assistant" and bool(message.get("reasoning_content")) for message in formatted_text
     )


### PR DESCRIPTION
## Summary
- Some tokenizers (e.g. Cohere Command R `CohereForAI/c4ai-command-r7b-12-2024`) store multiple named chat templates as a `dict` (keyed by name like `"default"`, `"tool_use"`) instead of a single string
- `format_chat_template()` used `tokenizer.chat_template` directly in `GENERATION_REGEX.search()` and `in` checks, which crashed with `TypeError: expected string or bytes-like object, got 'dict'`
- Fix resolves the template string from the dict (using `"default"` key, matching HF's `get_chat_template()` behavior) before performing regex/string checks

## Test plan
- [x] 89 existing unit tests pass (squad, formatting_utils, chat_template, cohere related)
- [x] Validated on cw-dfw: `cohere_command_r_7b_squad.yaml` runs 5 steps successfully (loss 2.67→0.11)
- [x] CI job that originally failed: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/291833904

🤖 Generated with [Claude Code](https://claude.com/claude-code)