### PR TITLE
fix: add THD logit unsqueeze for GPT-OSS model

### DIFF
--- a/examples/llm_finetune/gpt_oss/gpt_oss_20b_te_packed_sequence.yaml
+++ b/examples/llm_finetune/gpt_oss/gpt_oss_20b_te_packed_sequence.yaml
@@ -1,0 +1,116 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# To run this recipe:
+#   automodel examples/llm_finetune/gpt_oss/gpt_oss_20b_te_packed_sequence.yaml --nproc-per-node 8
+# Adjust --nproc-per-node to the number of GPUs available on your machine.
+
+recipe: TrainFinetuneRecipeForNextTokenPrediction
+
+step_scheduler:
+  global_batch_size: 32
+  local_batch_size: 4
+  ckpt_every_steps: 500
+  num_epochs: 2
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 10
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 1111
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: openai/gpt-oss-20b
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: flex
+    linear: te
+    rms_norm: te
+    experts: te
+    dispatcher: deepep
+    fake_balanced_gate: false
+    enable_hf_state_dict_adapter: true
+
+checkpoint:
+  enabled: false
+  checkpoint_dir: checkpoints/
+  model_save_format: torch_save
+  save_consolidated: false
+
+distributed:
+  strategy: fsdp2
+  tp_size: 1
+  cp_size: 1
+  pp_size: 1
+  ep_size: 8
+
+  sequence_parallel: false
+
+  pipeline:
+    pp_schedule: interleaved1f1b
+    pp_microbatch_size: 4
+    round_virtual_stages_to_pp_multiple: down
+    scale_grads_in_schedule: false
+    patch_inner_model: false
+    patch_causal_lm_model: false
+    layers_per_stage: 2
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.hellaswag.HellaSwag
+  path_or_dataset: rowan/hellaswag
+  split: train
+  pad_to_max_length: false
+
+packed_sequence:
+  packed_sequence_size: 1024
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.packed_sequence_thd_collater
+  shuffle: true
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.llm.hellaswag.HellaSwag
+  path_or_dataset: rowan/hellaswag
+  split: validation
+  pad_to_max_length: false
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.packed_sequence_thd_collater
+
+optimizer:
+  _target_: torch.optim.Adam
+  betas: [0.9, 0.95]
+  eps: 1e-5
+  lr: 1.0e-4
+  weight_decay: 0.0
+  foreach: false
+
+# Uncomment and configure for W&B logging
+# wandb:
+#   project: <your_wandb_project>
+#   entity: <your_wandb_entity>
+#   name: <your_wandb_exp_name>
+#   save_dir: <your_wandb_save_dir>
+
+ci:
+  recipe_owner: hemildesai

--- a/nemo_automodel/components/models/gpt_oss/layers.py
+++ b/nemo_automodel/components/models/gpt_oss/layers.py
@@ -94,8 +94,14 @@ class GptOssAttention(nn.Module):
         attention_mask: torch.Tensor | None = None,
         **attn_kwargs: Any,
     ) -> torch.Tensor:
+        # Detect THD format: either 2D [T, hidden] or 3D [1, T, hidden] with
+        # cu_seqlens in kwargs (from PP schedule splitting [N, T, hidden] → [1, T, hidden]).
         if len(x.shape) == 2:
             qkv_format = "thd"
+            num_tokens = x.shape[0]
+        elif "cu_seqlens" in attn_kwargs and x.shape[0] == 1:
+            qkv_format = "thd"
+            x = x.squeeze(0)
             num_tokens = x.shape[0]
         else:
             qkv_format = "bshd"

--- a/nemo_automodel/components/models/gpt_oss/model.py
+++ b/nemo_automodel/components/models/gpt_oss/model.py
@@ -25,6 +25,7 @@ from nemo_automodel.components.models.common import (
     initialize_linear_module,
     initialize_rms_norm_module,
 )
+from nemo_automodel.components.utils.model_utils import squeeze_input_for_thd
 from nemo_automodel.components.models.common.hf_checkpointing_mixin import HFCheckpointingMixin
 from nemo_automodel.components.models.common.utils import cast_model_to_dtype
 from nemo_automodel.components.models.gpt_oss.layers import GptOssAttention
@@ -251,6 +252,12 @@ class GptOssForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
         padding_mask: torch.Tensor | None = None,
         **attn_kwargs: Any,
     ) -> torch.Tensor:
+        if "qkv_format" in attn_kwargs and attn_kwargs["qkv_format"] == "thd":
+            input_ids, position_ids, padding_mask, attn_kwargs = squeeze_input_for_thd(
+                input_ids, position_ids, padding_mask, attn_kwargs
+            )
+            attention_mask = None
+
         hidden = self.model(
             input_ids,
             position_ids=position_ids,
@@ -259,6 +266,8 @@ class GptOssForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
             **attn_kwargs,
         )
         logits = self.lm_head(hidden) if self.lm_head else hidden
+        if "qkv_format" in attn_kwargs and attn_kwargs["qkv_format"] == "thd":
+            logits = logits.unsqueeze(0)
         return logits
 
     @torch.no_grad()

--- a/nemo_automodel/components/models/gpt_oss/model.py
+++ b/nemo_automodel/components/models/gpt_oss/model.py
@@ -149,11 +149,15 @@ class GptOssModel(nn.Module):
         **attn_kwargs: Any,
     ) -> torch.Tensor:
         if position_ids is None:
-            position_ids = (
-                torch.arange(0, input_ids.shape[1], device=input_ids.device).unsqueeze(0).expand(input_ids.shape[0], -1)
-            )
+            if input_ids.ndim == 1:
+                position_ids = torch.arange(0, input_ids.shape[0], device=input_ids.device)
+            else:
+                position_ids = (
+                    torch.arange(0, input_ids.shape[1], device=input_ids.device)
+                    .unsqueeze(0)
+                    .expand(input_ids.shape[0], -1)
+                )
 
-        # Compute cos/sin from RotaryEmbedding inv_freq and current position_ids; then concat [cos, sin]
         freqs_cis = position_ids_to_freqs_cis(
             self.rotary_emb,
             position_ids,

--- a/nemo_automodel/components/models/gpt_oss/model.py
+++ b/nemo_automodel/components/models/gpt_oss/model.py
@@ -25,7 +25,6 @@ from nemo_automodel.components.models.common import (
     initialize_linear_module,
     initialize_rms_norm_module,
 )
-from nemo_automodel.components.utils.model_utils import squeeze_input_for_thd
 from nemo_automodel.components.models.common.hf_checkpointing_mixin import HFCheckpointingMixin
 from nemo_automodel.components.models.common.utils import cast_model_to_dtype
 from nemo_automodel.components.models.gpt_oss.layers import GptOssAttention
@@ -34,6 +33,7 @@ from nemo_automodel.components.models.gpt_oss.state_dict_adapter import GPTOSSSt
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
 from nemo_automodel.components.moe.layers import MLP, MoE
+from nemo_automodel.components.utils.model_utils import squeeze_input_for_thd
 from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 
 logger = logging.getLogger(__name__)

--- a/nemo_automodel/components/models/gpt_oss/rope_utils.py
+++ b/nemo_automodel/components/models/gpt_oss/rope_utils.py
@@ -192,11 +192,15 @@ def position_ids_to_freqs_cis(
 ) -> torch.Tensor:
     if qkv_format == "thd":
         if for_fused_rope:
+            # shape[0] is T for 1D [T] or batch for 2D [B, T].
+            # For THD with PP schedule, position_ids may be [1, T] — use shape[-1].
+            seq_len = position_ids.shape[-1] if position_ids.ndim >= 2 else position_ids.shape[0]
             position_ids = torch.arange(
-                position_ids.shape[0] * cp_size, device=position_ids.device, dtype=torch.int32
+                seq_len * cp_size, device=position_ids.device, dtype=torch.int32
             ).unsqueeze(0)
         else:
-            position_ids = position_ids.unsqueeze(0)
+            if position_ids.ndim == 1:
+                position_ids = position_ids.unsqueeze(0)
 
     concentration, inv_freq = rotary_emb._compute_concentration_and_inv_freq()
     inv_freq = inv_freq.to(device=position_ids.device, dtype=torch.float32)

--- a/nemo_automodel/components/models/gpt_oss/rope_utils.py
+++ b/nemo_automodel/components/models/gpt_oss/rope_utils.py
@@ -195,9 +195,7 @@ def position_ids_to_freqs_cis(
             # shape[0] is T for 1D [T] or batch for 2D [B, T].
             # For THD with PP schedule, position_ids may be [1, T] — use shape[-1].
             seq_len = position_ids.shape[-1] if position_ids.ndim >= 2 else position_ids.shape[0]
-            position_ids = torch.arange(
-                seq_len * cp_size, device=position_ids.device, dtype=torch.int32
-            ).unsqueeze(0)
+            position_ids = torch.arange(seq_len * cp_size, device=position_ids.device, dtype=torch.int32).unsqueeze(0)
         else:
             if position_ids.ndim == 1:
                 position_ids = position_ids.unsqueeze(0)

--- a/tests/unit_tests/models/gpt_oss/test_gptoss_model.py
+++ b/tests/unit_tests/models/gpt_oss/test_gptoss_model.py
@@ -12,18 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tempfile
-from unittest.mock import MagicMock, Mock, patch
+from contextlib import ExitStack
+from unittest.mock import patch
 
 import pytest
 import torch
 from transformers.models.gpt_oss.configuration_gpt_oss import GptOssConfig
 
-from nemo_automodel.components.models.common.hf_checkpointing_mixin import HFCheckpointingMixin
+from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.models.gpt_oss.model import Block, GptOssForCausalLM, GptOssModel
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.layers import MLP, MoE
-from nemo_automodel.components.models.common import BackendConfig
+
 
 @pytest.fixture
 def device():
@@ -132,14 +132,23 @@ class TestBlock:
         x = torch.randn(batch_size, seq_len, gpt_config.hidden_size, dtype=torch.bfloat16, device=device)
         freqs_cis = torch.randn(batch_size, seq_len, gpt_config.head_dim, dtype=torch.bfloat16, device=device)
 
-        with patch.object(block.self_attn.attn_module, "__call__") as mock_attn, \
-             patch.object(block.mlp, "forward") as mock_mlp:
+        with (
+            patch.object(block.self_attn.attn_module, "__call__") as mock_attn,
+            patch.object(block.mlp, "forward") as mock_mlp,
+        ):
             # Mock attention output
             mock_attn.return_value = torch.randn(
-                batch_size, gpt_config.num_attention_heads, seq_len, gpt_config.head_dim, dtype=torch.bfloat16, device=device
+                batch_size,
+                gpt_config.num_attention_heads,
+                seq_len,
+                gpt_config.head_dim,
+                dtype=torch.bfloat16,
+                device=device,
             )
             # Mock MLP output (return just tensor, not tuple)
-            mock_mlp.return_value = torch.randn(batch_size, seq_len, gpt_config.hidden_size, dtype=torch.bfloat16, device=device)
+            mock_mlp.return_value = torch.randn(
+                batch_size, seq_len, gpt_config.hidden_size, dtype=torch.bfloat16, device=device
+            )
 
             output = block(x, freqs_cis=freqs_cis)
 
@@ -158,14 +167,23 @@ class TestBlock:
         attention_mask = torch.ones(batch_size, seq_len, dtype=torch.long, device=device)
         attention_mask[:, -2:] = 0  # Mask last 2 tokens
 
-        with patch.object(block.self_attn.attn_module, "__call__") as mock_attn, \
-             patch.object(block.mlp, "forward") as mock_mlp:
+        with (
+            patch.object(block.self_attn.attn_module, "__call__") as mock_attn,
+            patch.object(block.mlp, "forward") as mock_mlp,
+        ):
             mock_attn.return_value = torch.randn(
-                batch_size, gpt_config.num_attention_heads, seq_len, gpt_config.head_dim, dtype=torch.bfloat16, device=device
+                batch_size,
+                gpt_config.num_attention_heads,
+                seq_len,
+                gpt_config.head_dim,
+                dtype=torch.bfloat16,
+                device=device,
             )
-            mock_mlp.return_value = torch.randn(batch_size, seq_len, gpt_config.hidden_size, dtype=torch.bfloat16, device=device)
+            mock_mlp.return_value = torch.randn(
+                batch_size, seq_len, gpt_config.hidden_size, dtype=torch.bfloat16, device=device
+            )
 
-            output = block(x, freqs_cis=freqs_cis, attention_mask=attention_mask)
+            block(x, freqs_cis=freqs_cis, attention_mask=attention_mask)
 
             # Verify that MLP received the correct padding mask
             mock_mlp.assert_called_once()
@@ -181,11 +199,25 @@ class TestBlock:
         """Test _mlp method with regular MLP."""
         # Create a config that would result in regular MLP
         moe_config = MoEConfig(
-            dim=128, inter_dim=256, moe_inter_dim=256, n_routed_experts=0, n_shared_experts=1, n_activated_experts=1,
-            n_expert_groups=1, n_limited_groups=1, train_gate=True, gate_bias_update_factor=0,
-            score_func="softmax", route_scale=1.0, aux_loss_coeff=0.01, norm_topk_prob=False,
-            expert_bias=True, router_bias=True, expert_activation="quick_geglu",
-            activation_alpha=1.702, activation_limit=7.0,
+            dim=128,
+            inter_dim=256,
+            moe_inter_dim=256,
+            n_routed_experts=0,
+            n_shared_experts=1,
+            n_activated_experts=1,
+            n_expert_groups=1,
+            n_limited_groups=1,
+            train_gate=True,
+            gate_bias_update_factor=0,
+            score_func="softmax",
+            route_scale=1.0,
+            aux_loss_coeff=0.01,
+            norm_topk_prob=False,
+            expert_bias=True,
+            router_bias=True,
+            expert_activation="quick_geglu",
+            activation_alpha=1.702,
+            activation_limit=7.0,
         )
 
         block = Block(0, gpt_config, moe_config, backend_config)
@@ -204,11 +236,12 @@ class TestBlock:
         """Test Block weight initialization."""
         block = Block(0, gpt_config, moe_config, backend_config)
 
-        with patch.object(block.input_layernorm, "reset_parameters") as mock_input_norm, \
-             patch.object(block.post_attention_layernorm, "reset_parameters") as mock_post_norm, \
-             patch.object(block.self_attn, "init_weights") as mock_attn_init, \
-             patch.object(block.mlp, "init_weights") as mock_mlp_init:
-
+        with (
+            patch.object(block.input_layernorm, "reset_parameters") as mock_input_norm,
+            patch.object(block.post_attention_layernorm, "reset_parameters") as mock_post_norm,
+            patch.object(block.self_attn, "init_weights") as mock_attn_init,
+            patch.object(block.mlp, "init_weights") as mock_mlp_init,
+        ):
             block.init_weights(device)
 
             mock_input_norm.assert_called_once()
@@ -274,7 +307,9 @@ class TestGptOssModel:
             # Mock each layer's forward pass
             for layer in model.layers.values():
                 with patch.object(layer, "forward") as mock_layer:
-                    mock_layer.return_value = torch.randn(batch_size, seq_len, gpt_config.hidden_size, dtype=torch.bfloat16, device=device)
+                    mock_layer.return_value = torch.randn(
+                        batch_size, seq_len, gpt_config.hidden_size, dtype=torch.bfloat16, device=device
+                    )
 
             output = model(input_ids)
 
@@ -295,7 +330,9 @@ class TestGptOssModel:
 
             for layer in model.layers.values():
                 with patch.object(layer, "forward") as mock_layer:
-                    mock_layer.return_value = torch.randn(batch_size, seq_len, gpt_config.hidden_size, dtype=torch.bfloat16, device=device)
+                    mock_layer.return_value = torch.randn(
+                        batch_size, seq_len, gpt_config.hidden_size, dtype=torch.bfloat16, device=device
+                    )
 
             output = model(input_ids, position_ids=position_ids)
 
@@ -316,7 +353,9 @@ class TestGptOssModel:
 
             for layer in model.layers.values():
                 with patch.object(layer, "forward") as mock_layer:
-                    mock_layer.return_value = torch.randn(batch_size, seq_len, gpt_config.hidden_size, dtype=torch.bfloat16, device=device)
+                    mock_layer.return_value = torch.randn(
+                        batch_size, seq_len, gpt_config.hidden_size, dtype=torch.bfloat16, device=device
+                    )
 
             output = model(input_ids, padding_mask=padding_mask)
 
@@ -330,7 +369,7 @@ class TestGptOssModel:
 
         with patch.object(model.norm, "reset_parameters") as mock_norm:
             for layer in model.layers.values():
-                with patch.object(layer, "init_weights") as mock_layer_init:
+                with patch.object(layer, "init_weights"):
                     pass
 
             model.init_weights(device)
@@ -348,11 +387,13 @@ class TestGptOssForCausalLM:
 
     def test_from_config_with_string(self, gpt_config, backend_config):
         """Test from_config class method with string path."""
-        with patch("transformers.models.gpt_oss.configuration_gpt_oss.GptOssConfig.from_pretrained") as mock_from_pretrained:
+        with patch(
+            "transformers.models.gpt_oss.configuration_gpt_oss.GptOssConfig.from_pretrained"
+        ) as mock_from_pretrained:
             mock_from_pretrained.return_value = gpt_config
 
             with pytest.raises(AttributeError):
-                model = GptOssForCausalLM.from_config("test-model", backend=backend_config)
+                GptOssForCausalLM.from_config("test-model", backend=backend_config)
 
     def test_from_config_with_config_object(self, gpt_config, backend_config):
         """Test from_config class method with config object."""
@@ -388,7 +429,9 @@ class TestGptOssForCausalLM:
         input_ids = torch.randint(0, gpt_config.vocab_size, (batch_size, seq_len), dtype=torch.long, device=device)
 
         with patch.object(model.model, "forward") as mock_model:
-            mock_model.return_value = torch.randn(batch_size, seq_len, gpt_config.hidden_size, dtype=torch.bfloat16, device=device)
+            mock_model.return_value = torch.randn(
+                batch_size, seq_len, gpt_config.hidden_size, dtype=torch.bfloat16, device=device
+            )
 
             output = model(input_ids)
 
@@ -414,7 +457,9 @@ class TestGptOssForCausalLM:
 
         with patch.object(model.model, "forward") as mock_model:
             # After squeeze_input_for_thd, input is 1D [T], so backbone returns [T, H]
-            mock_model.return_value = torch.randn(total_tokens, gpt_config.hidden_size, dtype=torch.bfloat16, device=device)
+            mock_model.return_value = torch.randn(
+                total_tokens, gpt_config.hidden_size, dtype=torch.bfloat16, device=device
+            )
 
             output = model(
                 input_ids,
@@ -442,7 +487,9 @@ class TestGptOssForCausalLM:
         input_ids = torch.randint(0, gpt_config.vocab_size, (batch_size, seq_len), dtype=torch.long, device=device)
 
         with patch.object(model.model, "forward") as mock_model:
-            mock_model.return_value = torch.randn(batch_size, seq_len, gpt_config.hidden_size, dtype=torch.bfloat16, device=device)
+            mock_model.return_value = torch.randn(
+                batch_size, seq_len, gpt_config.hidden_size, dtype=torch.bfloat16, device=device
+            )
 
             output = model(input_ids)
 
@@ -499,7 +546,9 @@ class TestGptOssForCausalLM:
         attention_mask = torch.ones(batch_size, seq_len, device=device)
 
         with patch.object(model.model, "forward") as mock_model:
-            mock_model.return_value = torch.randn(batch_size, seq_len, gpt_config.hidden_size, dtype=torch.bfloat16, device=device)
+            mock_model.return_value = torch.randn(
+                batch_size, seq_len, gpt_config.hidden_size, dtype=torch.bfloat16, device=device
+            )
 
             model(input_ids, attention_mask=attention_mask, custom_kwarg="test")
 
@@ -512,10 +561,14 @@ class TestGptOssForCausalLM:
 
     def test_from_pretrained_classmethod(self, gpt_config, backend_config):
         """Ensure classmethod from_pretrained builds config then delegates to from_config."""
-        with patch("transformers.models.gpt_oss.configuration_gpt_oss.GptOssConfig.from_pretrained") as mock_from_pretrained:
+        with patch(
+            "transformers.models.gpt_oss.configuration_gpt_oss.GptOssConfig.from_pretrained"
+        ) as mock_from_pretrained:
             mock_from_pretrained.return_value = gpt_config
 
-            with patch.object(GptOssForCausalLM, "from_config", wraps=GptOssForCausalLM.from_config) as mock_from_config:
+            with patch.object(
+                GptOssForCausalLM, "from_config", wraps=GptOssForCausalLM.from_config
+            ) as mock_from_config:
                 model = GptOssForCausalLM.from_pretrained("some/model")
                 assert isinstance(model, GptOssForCausalLM)
                 mock_from_pretrained.assert_called_once_with("some/model")
@@ -543,10 +596,13 @@ class TestGptOssAttentionTHD:
         with patch.object(attn.attn_module, "__call__") as mock_attn:
             # THD attention returns [T, num_heads, head_dim]
             mock_attn.return_value = torch.randn(
-                total_tokens, gpt_config.num_attention_heads, gpt_config.head_dim,
-                dtype=torch.bfloat16, device=device,
+                total_tokens,
+                gpt_config.num_attention_heads,
+                gpt_config.head_dim,
+                dtype=torch.bfloat16,
+                device=device,
             )
-            output = attn(x, freqs_cis=freqs_cis, cu_seqlens=cu_seqlens)
+            attn(x, freqs_cis=freqs_cis, cu_seqlens=cu_seqlens)
 
             # Verify attention was called — the input should have been squeezed
             mock_attn.assert_called_once()
@@ -566,10 +622,13 @@ class TestGptOssAttentionTHD:
 
         with patch.object(attn.attn_module, "__call__") as mock_attn:
             mock_attn.return_value = torch.randn(
-                total_tokens, gpt_config.num_attention_heads, gpt_config.head_dim,
-                dtype=torch.bfloat16, device=device,
+                total_tokens,
+                gpt_config.num_attention_heads,
+                gpt_config.head_dim,
+                dtype=torch.bfloat16,
+                device=device,
             )
-            output = attn(x, freqs_cis=freqs_cis)
+            attn(x, freqs_cis=freqs_cis)
             mock_attn.assert_called_once()
             call_kwargs = mock_attn.call_args[1]
             assert call_kwargs.get("qkv_format") == "thd"
@@ -587,7 +646,11 @@ class TestRopeUtilsTHD:
         position_ids = torch.arange(seq_len, device=device)
 
         result = position_ids_to_freqs_cis(
-            model.rotary_emb, position_ids, qkv_format="thd", for_fused_rope=True, cp_size=1,
+            model.rotary_emb,
+            position_ids,
+            qkv_format="thd",
+            for_fused_rope=True,
+            cp_size=1,
         )
         # Should produce valid freqs_cis without errors
         assert result.ndim >= 2
@@ -601,7 +664,11 @@ class TestRopeUtilsTHD:
         position_ids = torch.arange(seq_len, device=device).unsqueeze(0)
 
         result = position_ids_to_freqs_cis(
-            model.rotary_emb, position_ids, qkv_format="thd", for_fused_rope=True, cp_size=1,
+            model.rotary_emb,
+            position_ids,
+            qkv_format="thd",
+            for_fused_rope=True,
+            cp_size=1,
         )
         assert result.ndim >= 2
 
@@ -614,7 +681,11 @@ class TestRopeUtilsTHD:
         position_ids = torch.arange(seq_len, device=device)
 
         result = position_ids_to_freqs_cis(
-            model.rotary_emb, position_ids, qkv_format="thd", for_fused_rope=False, cp_size=1,
+            model.rotary_emb,
+            position_ids,
+            qkv_format="thd",
+            for_fused_rope=False,
+            cp_size=1,
         )
         assert result.ndim >= 2
 
@@ -627,7 +698,11 @@ class TestRopeUtilsTHD:
         position_ids = torch.arange(seq_len, device=device).unsqueeze(0)
 
         result = position_ids_to_freqs_cis(
-            model.rotary_emb, position_ids, qkv_format="thd", for_fused_rope=False, cp_size=1,
+            model.rotary_emb,
+            position_ids,
+            qkv_format="thd",
+            for_fused_rope=False,
+            cp_size=1,
         )
         # Should be valid without double-unsqueezing to [1, 1, T]
         assert result.ndim >= 2
@@ -647,15 +722,19 @@ class TestGptOssModelTHD:
         with patch.object(model.rotary_emb, "_compute_concentration_and_inv_freq") as mock_rope:
             mock_rope.return_value = (1.0, torch.randn(16, dtype=torch.bfloat16, device=device))
 
-            for layer in model.layers.values():
-                with patch.object(layer, "forward") as mock_layer:
+            with ExitStack() as stack:
+                for layer in model.layers.values():
+                    mock_layer = stack.enter_context(patch.object(layer, "forward"))
                     mock_layer.return_value = torch.randn(
-                        total_tokens, gpt_config.hidden_size, dtype=torch.bfloat16, device=device,
+                        total_tokens,
+                        gpt_config.hidden_size,
+                        dtype=torch.bfloat16,
+                        device=device,
                     )
 
-            output = model(input_ids, qkv_format="thd")
-            # Should not crash — 1D input_ids handled correctly
-            assert output.shape == (total_tokens, gpt_config.hidden_size)
+                output = model(input_ids, qkv_format="thd")
+                # Should not crash — 1D input_ids handled correctly
+                assert output.shape == (total_tokens, gpt_config.hidden_size)
 
     def test_2d_input_ids_generates_2d_position_ids(self, gpt_config, backend_config, device):
         """Standard 2D [B, S] input should still generate 2D position_ids."""
@@ -667,14 +746,19 @@ class TestGptOssModelTHD:
         with patch.object(model.rotary_emb, "_compute_concentration_and_inv_freq") as mock_rope:
             mock_rope.return_value = (1.0, torch.randn(16, dtype=torch.bfloat16, device=device))
 
-            for layer in model.layers.values():
-                with patch.object(layer, "forward") as mock_layer:
+            with ExitStack() as stack:
+                for layer in model.layers.values():
+                    mock_layer = stack.enter_context(patch.object(layer, "forward"))
                     mock_layer.return_value = torch.randn(
-                        batch_size, seq_len, gpt_config.hidden_size, dtype=torch.bfloat16, device=device,
+                        batch_size,
+                        seq_len,
+                        gpt_config.hidden_size,
+                        dtype=torch.bfloat16,
+                        device=device,
                     )
 
-            output = model(input_ids)
-            assert output.shape == (batch_size, seq_len, gpt_config.hidden_size)
+                output = model(input_ids)
+                assert output.shape == (batch_size, seq_len, gpt_config.hidden_size)
 
 
 # NOTE: HFCheckpointingMixin tests are now in tests/unit_tests/models/common/test_hf_checkpointing_mixin.py

--- a/tests/unit_tests/models/gpt_oss/test_gptoss_model.py
+++ b/tests/unit_tests/models/gpt_oss/test_gptoss_model.py
@@ -524,4 +524,157 @@ class TestGptOssForCausalLM:
                 assert called_cfg is gpt_config
 
 
+class TestGptOssAttentionTHD:
+    """Test THD format handling in GptOssAttention."""
+
+    def test_3d_input_with_cu_seqlens_detected_as_thd(self, gpt_config, backend_config, device):
+        """PP schedule produces [1, T, H] with cu_seqlens — attention must squeeze to [T, H]."""
+        from nemo_automodel.components.models.gpt_oss.layers import GptOssAttention
+
+        attn = GptOssAttention(gpt_config, layer_idx=0, backend=backend_config).to(device)
+        total_tokens = 16
+        hidden = gpt_config.hidden_size
+
+        # 3D input from PP schedule: [1, T, H]
+        x = torch.randn(1, total_tokens, hidden, dtype=torch.bfloat16, device=device)
+        freqs_cis = torch.randn(1, total_tokens, gpt_config.head_dim, dtype=torch.bfloat16, device=device)
+        cu_seqlens = torch.tensor([0, 8, 16], dtype=torch.int32, device=device)
+
+        with patch.object(attn.attn_module, "__call__") as mock_attn:
+            # THD attention returns [T, num_heads, head_dim]
+            mock_attn.return_value = torch.randn(
+                total_tokens, gpt_config.num_attention_heads, gpt_config.head_dim,
+                dtype=torch.bfloat16, device=device,
+            )
+            output = attn(x, freqs_cis=freqs_cis, cu_seqlens=cu_seqlens)
+
+            # Verify attention was called — the input should have been squeezed
+            mock_attn.assert_called_once()
+            call_kwargs = mock_attn.call_args[1]
+            assert call_kwargs.get("qkv_format") == "thd"
+
+    def test_2d_input_detected_as_thd(self, gpt_config, backend_config, device):
+        """Native THD format: 2D [T, H] input should be detected without cu_seqlens."""
+        from nemo_automodel.components.models.gpt_oss.layers import GptOssAttention
+
+        attn = GptOssAttention(gpt_config, layer_idx=0, backend=backend_config).to(device)
+        total_tokens = 16
+        hidden = gpt_config.hidden_size
+
+        x = torch.randn(total_tokens, hidden, dtype=torch.bfloat16, device=device)
+        freqs_cis = torch.randn(1, total_tokens, gpt_config.head_dim, dtype=torch.bfloat16, device=device)
+
+        with patch.object(attn.attn_module, "__call__") as mock_attn:
+            mock_attn.return_value = torch.randn(
+                total_tokens, gpt_config.num_attention_heads, gpt_config.head_dim,
+                dtype=torch.bfloat16, device=device,
+            )
+            output = attn(x, freqs_cis=freqs_cis)
+            mock_attn.assert_called_once()
+            call_kwargs = mock_attn.call_args[1]
+            assert call_kwargs.get("qkv_format") == "thd"
+
+
+class TestRopeUtilsTHD:
+    """Test position_ids_to_freqs_cis THD handling."""
+
+    def test_thd_1d_position_ids_fused_rope(self, gpt_config, backend_config, device):
+        """1D position_ids [T] with fused_rope should use shape[0] for seq_len."""
+        from nemo_automodel.components.models.gpt_oss.rope_utils import position_ids_to_freqs_cis
+
+        model = GptOssModel(gpt_config, backend_config).to(device)
+        seq_len = 16
+        position_ids = torch.arange(seq_len, device=device)
+
+        result = position_ids_to_freqs_cis(
+            model.rotary_emb, position_ids, qkv_format="thd", for_fused_rope=True, cp_size=1,
+        )
+        # Should produce valid freqs_cis without errors
+        assert result.ndim >= 2
+
+    def test_thd_2d_position_ids_fused_rope(self, gpt_config, backend_config, device):
+        """2D position_ids [1, T] from PP schedule should use shape[-1] for seq_len."""
+        from nemo_automodel.components.models.gpt_oss.rope_utils import position_ids_to_freqs_cis
+
+        model = GptOssModel(gpt_config, backend_config).to(device)
+        seq_len = 16
+        position_ids = torch.arange(seq_len, device=device).unsqueeze(0)
+
+        result = position_ids_to_freqs_cis(
+            model.rotary_emb, position_ids, qkv_format="thd", for_fused_rope=True, cp_size=1,
+        )
+        assert result.ndim >= 2
+
+    def test_thd_1d_position_ids_no_fused_rope(self, gpt_config, backend_config, device):
+        """1D position_ids [T] without fused_rope should unsqueeze to [1, T]."""
+        from nemo_automodel.components.models.gpt_oss.rope_utils import position_ids_to_freqs_cis
+
+        model = GptOssModel(gpt_config, backend_config).to(device)
+        seq_len = 16
+        position_ids = torch.arange(seq_len, device=device)
+
+        result = position_ids_to_freqs_cis(
+            model.rotary_emb, position_ids, qkv_format="thd", for_fused_rope=False, cp_size=1,
+        )
+        assert result.ndim >= 2
+
+    def test_thd_2d_position_ids_no_fused_rope_no_double_unsqueeze(self, gpt_config, backend_config, device):
+        """2D position_ids [1, T] without fused_rope should NOT be double-unsqueezed."""
+        from nemo_automodel.components.models.gpt_oss.rope_utils import position_ids_to_freqs_cis
+
+        model = GptOssModel(gpt_config, backend_config).to(device)
+        seq_len = 16
+        position_ids = torch.arange(seq_len, device=device).unsqueeze(0)
+
+        result = position_ids_to_freqs_cis(
+            model.rotary_emb, position_ids, qkv_format="thd", for_fused_rope=False, cp_size=1,
+        )
+        # Should be valid without double-unsqueezing to [1, 1, T]
+        assert result.ndim >= 2
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+class TestGptOssModelTHD:
+    """Test GptOssModel THD-specific behavior."""
+
+    def test_1d_input_ids_generates_1d_position_ids(self, gpt_config, backend_config, device):
+        """When input_ids is 1D [T] (after THD squeeze), position_ids should be 1D [T]."""
+        model = GptOssModel(gpt_config, backend_config).to(device)
+        total_tokens = 16
+
+        input_ids = torch.randint(0, gpt_config.vocab_size, (total_tokens,), dtype=torch.long, device=device)
+
+        with patch.object(model.rotary_emb, "_compute_concentration_and_inv_freq") as mock_rope:
+            mock_rope.return_value = (1.0, torch.randn(16, dtype=torch.bfloat16, device=device))
+
+            for layer in model.layers.values():
+                with patch.object(layer, "forward") as mock_layer:
+                    mock_layer.return_value = torch.randn(
+                        total_tokens, gpt_config.hidden_size, dtype=torch.bfloat16, device=device,
+                    )
+
+            output = model(input_ids, qkv_format="thd")
+            # Should not crash — 1D input_ids handled correctly
+            assert output.shape == (total_tokens, gpt_config.hidden_size)
+
+    def test_2d_input_ids_generates_2d_position_ids(self, gpt_config, backend_config, device):
+        """Standard 2D [B, S] input should still generate 2D position_ids."""
+        model = GptOssModel(gpt_config, backend_config).to(device)
+        batch_size, seq_len = 2, 8
+
+        input_ids = torch.randint(0, gpt_config.vocab_size, (batch_size, seq_len), dtype=torch.long, device=device)
+
+        with patch.object(model.rotary_emb, "_compute_concentration_and_inv_freq") as mock_rope:
+            mock_rope.return_value = (1.0, torch.randn(16, dtype=torch.bfloat16, device=device))
+
+            for layer in model.layers.values():
+                with patch.object(layer, "forward") as mock_layer:
+                    mock_layer.return_value = torch.randn(
+                        batch_size, seq_len, gpt_config.hidden_size, dtype=torch.bfloat16, device=device,
+                    )
+
+            output = model(input_ids)
+            assert output.shape == (batch_size, seq_len, gpt_config.hidden_size)
+
+
 # NOTE: HFCheckpointingMixin tests are now in tests/unit_tests/models/common/test_hf_checkpointing_mixin.py

--- a/tests/unit_tests/models/gpt_oss/test_gptoss_model.py
+++ b/tests/unit_tests/models/gpt_oss/test_gptoss_model.py
@@ -581,10 +581,10 @@ class TestGptOssAttentionTHD:
     """Test THD format handling in GptOssAttention."""
 
     def test_3d_input_with_cu_seqlens_detected_as_thd(self, gpt_config, backend_config, device):
-        """PP schedule produces [1, T, H] with cu_seqlens — attention must squeeze to [T, H]."""
+        """PP schedule produces [1, T, H] with cu_seqlens — attention must squeeze and not crash."""
         from nemo_automodel.components.models.gpt_oss.layers import GptOssAttention
 
-        attn = GptOssAttention(gpt_config, layer_idx=0, backend=backend_config).to(device)
+        attn = GptOssAttention(gpt_config, backend=backend_config).to(device)
         total_tokens = 16
         hidden = gpt_config.hidden_size
 
@@ -593,8 +593,7 @@ class TestGptOssAttentionTHD:
         freqs_cis = torch.randn(1, total_tokens, gpt_config.head_dim, dtype=torch.bfloat16, device=device)
         cu_seqlens = torch.tensor([0, 8, 16], dtype=torch.int32, device=device)
 
-        with patch.object(attn.attn_module, "__call__") as mock_attn:
-            # THD attention returns [T, num_heads, head_dim]
+        with patch.object(attn, "attn_func") as mock_attn:
             mock_attn.return_value = torch.randn(
                 total_tokens,
                 gpt_config.num_attention_heads,
@@ -602,25 +601,26 @@ class TestGptOssAttentionTHD:
                 dtype=torch.bfloat16,
                 device=device,
             )
-            attn(x, freqs_cis=freqs_cis, cu_seqlens=cu_seqlens)
+            output = attn(x, freqs_cis=freqs_cis, cu_seqlens=cu_seqlens)
 
-            # Verify attention was called — the input should have been squeezed
+            # Forward should succeed and attn_func should be called
             mock_attn.assert_called_once()
-            call_kwargs = mock_attn.call_args[1]
-            assert call_kwargs.get("qkv_format") == "thd"
+            # Output should be 2D [T, hidden] (THD flattened)
+            assert output.ndim == 2
+            assert output.shape[0] == total_tokens
 
     def test_2d_input_detected_as_thd(self, gpt_config, backend_config, device):
         """Native THD format: 2D [T, H] input should be detected without cu_seqlens."""
         from nemo_automodel.components.models.gpt_oss.layers import GptOssAttention
 
-        attn = GptOssAttention(gpt_config, layer_idx=0, backend=backend_config).to(device)
+        attn = GptOssAttention(gpt_config, backend=backend_config).to(device)
         total_tokens = 16
         hidden = gpt_config.hidden_size
 
         x = torch.randn(total_tokens, hidden, dtype=torch.bfloat16, device=device)
         freqs_cis = torch.randn(1, total_tokens, gpt_config.head_dim, dtype=torch.bfloat16, device=device)
 
-        with patch.object(attn.attn_module, "__call__") as mock_attn:
+        with patch.object(attn, "attn_func") as mock_attn:
             mock_attn.return_value = torch.randn(
                 total_tokens,
                 gpt_config.num_attention_heads,
@@ -628,25 +628,43 @@ class TestGptOssAttentionTHD:
                 dtype=torch.bfloat16,
                 device=device,
             )
-            attn(x, freqs_cis=freqs_cis)
+            output = attn(x, freqs_cis=freqs_cis)
             mock_attn.assert_called_once()
-            call_kwargs = mock_attn.call_args[1]
-            assert call_kwargs.get("qkv_format") == "thd"
+            # Output should be 2D [T, hidden] (THD flattened)
+            assert output.ndim == 2
+            assert output.shape[0] == total_tokens
 
 
 class TestRopeUtilsTHD:
     """Test position_ids_to_freqs_cis THD handling."""
 
+    @staticmethod
+    def _make_rotary_emb(gpt_config, device):
+        from nemo_automodel.components.models.common import get_rope_config
+        from nemo_automodel.components.models.gpt_oss.rope_utils import RotaryEmbedding
+
+        rope_theta, rope_scaling, _ = get_rope_config(gpt_config)
+        return RotaryEmbedding(
+            head_dim=gpt_config.head_dim,
+            base=rope_theta,
+            dtype=torch.float32,
+            initial_context_length=rope_scaling.get("original_max_position_embeddings", 4096),
+            scaling_factor=rope_scaling.get("factor", 1.0),
+            ntk_alpha=rope_scaling.get("beta_slow", 1.0),
+            ntk_beta=rope_scaling.get("beta_fast", 32.0),
+            device=device,
+        )
+
     def test_thd_1d_position_ids_fused_rope(self, gpt_config, backend_config, device):
         """1D position_ids [T] with fused_rope should use shape[0] for seq_len."""
         from nemo_automodel.components.models.gpt_oss.rope_utils import position_ids_to_freqs_cis
 
-        model = GptOssModel(gpt_config, backend_config).to(device)
+        rotary_emb = self._make_rotary_emb(gpt_config, device)
         seq_len = 16
         position_ids = torch.arange(seq_len, device=device)
 
         result = position_ids_to_freqs_cis(
-            model.rotary_emb,
+            rotary_emb,
             position_ids,
             qkv_format="thd",
             for_fused_rope=True,
@@ -659,12 +677,12 @@ class TestRopeUtilsTHD:
         """2D position_ids [1, T] from PP schedule should use shape[-1] for seq_len."""
         from nemo_automodel.components.models.gpt_oss.rope_utils import position_ids_to_freqs_cis
 
-        model = GptOssModel(gpt_config, backend_config).to(device)
+        rotary_emb = self._make_rotary_emb(gpt_config, device)
         seq_len = 16
         position_ids = torch.arange(seq_len, device=device).unsqueeze(0)
 
         result = position_ids_to_freqs_cis(
-            model.rotary_emb,
+            rotary_emb,
             position_ids,
             qkv_format="thd",
             for_fused_rope=True,
@@ -676,12 +694,12 @@ class TestRopeUtilsTHD:
         """1D position_ids [T] without fused_rope should unsqueeze to [1, T]."""
         from nemo_automodel.components.models.gpt_oss.rope_utils import position_ids_to_freqs_cis
 
-        model = GptOssModel(gpt_config, backend_config).to(device)
+        rotary_emb = self._make_rotary_emb(gpt_config, device)
         seq_len = 16
         position_ids = torch.arange(seq_len, device=device)
 
         result = position_ids_to_freqs_cis(
-            model.rotary_emb,
+            rotary_emb,
             position_ids,
             qkv_format="thd",
             for_fused_rope=False,
@@ -693,12 +711,12 @@ class TestRopeUtilsTHD:
         """2D position_ids [1, T] without fused_rope should NOT be double-unsqueezed."""
         from nemo_automodel.components.models.gpt_oss.rope_utils import position_ids_to_freqs_cis
 
-        model = GptOssModel(gpt_config, backend_config).to(device)
+        rotary_emb = self._make_rotary_emb(gpt_config, device)
         seq_len = 16
         position_ids = torch.arange(seq_len, device=device).unsqueeze(0)
 
         result = position_ids_to_freqs_cis(
-            model.rotary_emb,
+            rotary_emb,
             position_ids,
             qkv_format="thd",
             for_fused_rope=False,

--- a/tests/unit_tests/models/gpt_oss/test_gptoss_model.py
+++ b/tests/unit_tests/models/gpt_oss/test_gptoss_model.py
@@ -395,6 +395,61 @@ class TestGptOssForCausalLM:
             assert output.shape == (batch_size, seq_len, gpt_config.vocab_size)
             assert output.device == device
 
+    def test_forward_thd_unsqueeze(self, gpt_config, backend_config, device):
+        """Test that THD format produces 3D logits with unsqueezed batch dimension.
+
+        When qkv_format='thd' is used (sequence packing with TE attention),
+        the model squeezes [1, T] inputs to [T] via squeeze_input_for_thd,
+        producing 2D [T, V] logits. The forward method must unsqueeze to
+        [1, T, V] to match the expected 3D batch format.
+        """
+        model = GptOssForCausalLM(gpt_config, backend=backend_config)
+        model = model.to(device)
+
+        total_tokens = 16
+        # THD inputs arrive as [1, total_tokens] from the PP schedule
+        input_ids = torch.randint(0, gpt_config.vocab_size, (1, total_tokens), dtype=torch.long, device=device)
+        position_ids = torch.arange(total_tokens, device=device).unsqueeze(0)
+        cu_seqlens = torch.tensor([[0, 8, 16]], dtype=torch.int32, device=device)
+
+        with patch.object(model.model, "forward") as mock_model:
+            # After squeeze_input_for_thd, input is 1D [T], so backbone returns [T, H]
+            mock_model.return_value = torch.randn(total_tokens, gpt_config.hidden_size, dtype=torch.bfloat16, device=device)
+
+            output = model(
+                input_ids,
+                position_ids=position_ids,
+                qkv_format="thd",
+                cu_seqlens=cu_seqlens,
+            )
+
+            # Logits must be 3D [1, T, V] after unsqueeze
+            assert output.ndim == 3
+            assert output.shape == (1, total_tokens, gpt_config.vocab_size)
+
+            # Verify backbone received squeezed 1D input_ids
+            call_args = mock_model.call_args
+            actual_input_ids = call_args[0][0]
+            assert actual_input_ids.ndim == 1
+            assert actual_input_ids.shape[0] == total_tokens
+
+    def test_forward_non_thd_no_unsqueeze(self, gpt_config, backend_config, device):
+        """Test that non-THD forward does not add extra dimensions."""
+        model = GptOssForCausalLM(gpt_config, backend=backend_config)
+        model = model.to(device)
+
+        batch_size, seq_len = 2, 8
+        input_ids = torch.randint(0, gpt_config.vocab_size, (batch_size, seq_len), dtype=torch.long, device=device)
+
+        with patch.object(model.model, "forward") as mock_model:
+            mock_model.return_value = torch.randn(batch_size, seq_len, gpt_config.hidden_size, dtype=torch.bfloat16, device=device)
+
+            output = model(input_ids)
+
+            # Standard 3D output [B, S, V] without unsqueeze
+            assert output.ndim == 3
+            assert output.shape == (batch_size, seq_len, gpt_config.vocab_size)
+
     def test_initialize_weights(self, gpt_config, backend_config, device):
         """Test weight initialization."""
         model = GptOssForCausalLM(gpt_config, backend=backend_config)


### PR DESCRIPTION
## Summary

Wandb runs - https://wandb.ai/Nemo-automodel/gptoss-thd-comparison/runs/5k9e5a6h, https://wandb.ai/Nemo-automodel/gptoss-thd-comparison/runs/5um0d071

- GPT-OSS `GptOssForCausalLM.forward()` was missing THD format handling that all other custom models (DeepSeek-V3, Qwen3-MoE, MiniMax-M2, etc.) already have.
- When `qkv_format="thd"` is used (sequence packing with TE attention), the forward method now:
  1. Calls `squeeze_input_for_thd()` to squeeze `[1, T]` inputs to `[T]` and process cu_seqlens
  2. Unsqueezes the resulting `[T, V]` logits to `[1, T, V]` to match the expected 3D batch format
- Adds unit tests verifying both THD unsqueeze behavior and non-THD passthrough.

## Test plan

- [x] `test_forward_thd_unsqueeze` — verifies 3D `[1, T, V]` output when `qkv_format="thd"` and squeezed 1D input to backbone
- [x] `test_forward_non_thd_no_unsqueeze` — verifies standard `[B, S, V]` output without THD kwargs
- [ ] Existing `test_forward_output_shape` continues to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)