### PR TITLE
fix: Add per-tensor conversion in gemma4 state_dict_adapter.py

### DIFF
--- a/nemo_automodel/components/models/gemma4_moe/state_dict_adapter.py
+++ b/nemo_automodel/components/models/gemma4_moe/state_dict_adapter.py
@@ -267,5 +267,43 @@ class Gemma4MoEStateDictAdapter(StateDictAdapter):
         return global_tensor
 
     def convert_single_tensor_to_hf(self, fqn: str, tensor: Any, **kwargs) -> list[tuple[str, Any]]:
-        """Convert a single native tensor back to HF format (used by to_hf for non-expert keys)."""
+        """Convert a single native tensor back to HF format.
+
+        Handles per-tensor conversion for weight streaming (IPC refit) required in RL training:
+        - Router keys: moe.gate.{proj.weight,scale} -> router.{proj.weight,scale}
+        - Expert gate_and_up_projs: transpose [E, hidden, 2*inter] -> [E, 2*inter, hidden]
+          and rename to experts.gate_up_proj
+        - Expert down_projs: transpose [E, inter, hidden] -> [E, hidden, inter],
+          rename to experts.down_proj, and emit router.per_expert_scale as ones
+        """
+        exclude_key_regex = kwargs.get("exclude_key_regex")
+        if exclude_key_regex and re.match(exclude_key_regex, fqn):
+            return []
+
+        # --- Router keys: moe.gate.{attr} -> router.{attr} ---
+        gate_match = re.search(r"(layers\.\d+)\.moe\.gate\.(proj\.weight|scale)$", fqn)
+        if gate_match:
+            layer_path = gate_match.group(1)
+            gate_attr = gate_match.group(2)
+            hf_key = fqn.replace(f"{layer_path}.moe.gate.{gate_attr}", f"{layer_path}.router.{gate_attr}")
+            return [(hf_key, tensor)]
+
+        # --- Expert: gate_and_up_projs -> experts.gate_up_proj (transposed) ---
+        if ".moe.experts.gate_and_up_projs" in fqn:
+            hf_key = fqn.replace(".moe.experts.gate_and_up_projs", ".experts.gate_up_proj")
+            return [(hf_key, tensor.transpose(-2, -1).contiguous())]
+
+        # --- Expert: down_projs -> experts.down_proj (transposed) + per_expert_scale ---
+        if ".moe.experts.down_projs" in fqn:
+            hf_key = fqn.replace(".moe.experts.down_projs", ".experts.down_proj")
+            transposed = tensor.transpose(-2, -1).contiguous()
+            layer_match = re.search(r"(.*layers\.\d+)\.", fqn)
+            scale_key = f"{layer_match.group(1)}.router.per_expert_scale"
+            n_experts = tensor.shape[0]
+            return [
+                (hf_key, transposed),
+                (scale_key, torch.ones(n_experts, dtype=tensor.dtype)),
+            ]
+
+        # --- Pass-through for all other keys ---
         return [(fqn, tensor)]

--- a/tests/unit_tests/models/gemma4/test_gemma4_state_dict_adapter.py
+++ b/tests/unit_tests/models/gemma4/test_gemma4_state_dict_adapter.py
@@ -366,3 +366,69 @@ class TestConvertSingleTensorToHf:
         assert len(result) == 1
         assert result[0][0] == fqn
         assert result[0][1] is tensor
+
+    def test_router_proj_weight_remapped(self, adapter):
+        tensor = torch.randn(HIDDEN, HIDDEN)
+        fqn = "model.language_model.layers.0.moe.gate.proj.weight"
+
+        result = adapter.convert_single_tensor_to_hf(fqn, tensor)
+
+        assert len(result) == 1
+        assert result[0][0] == "model.language_model.layers.0.router.proj.weight"
+        assert result[0][1] is tensor
+
+    def test_router_scale_remapped(self, adapter):
+        tensor = torch.randn(HIDDEN)
+        fqn = "model.language_model.layers.1.moe.gate.scale"
+
+        result = adapter.convert_single_tensor_to_hf(fqn, tensor)
+
+        assert len(result) == 1
+        assert result[0][0] == "model.language_model.layers.1.router.scale"
+        assert result[0][1] is tensor
+
+    def test_gate_and_up_projs_transposed_and_renamed(self, adapter):
+        tensor = torch.randn(N_EXPERTS, HIDDEN, 2 * EXPERT_INTER)
+        fqn = "model.language_model.layers.0.moe.experts.gate_and_up_projs"
+
+        result = adapter.convert_single_tensor_to_hf(fqn, tensor)
+
+        assert len(result) == 1
+        assert result[0][0] == "model.language_model.layers.0.experts.gate_up_proj"
+        assert result[0][1].shape == (N_EXPERTS, 2 * EXPERT_INTER, HIDDEN)
+        torch.testing.assert_close(result[0][1], tensor.transpose(-2, -1).contiguous())
+
+    def test_down_projs_transposed_renamed_and_emits_scale(self, adapter):
+        tensor = torch.randn(N_EXPERTS, EXPERT_INTER, HIDDEN)
+        fqn = "model.language_model.layers.0.moe.experts.down_projs"
+
+        result = adapter.convert_single_tensor_to_hf(fqn, tensor)
+
+        assert len(result) == 2
+        hf_key, transposed = result[0]
+        scale_key, scale_tensor = result[1]
+
+        assert hf_key == "model.language_model.layers.0.experts.down_proj"
+        assert transposed.shape == (N_EXPERTS, HIDDEN, EXPERT_INTER)
+        torch.testing.assert_close(transposed, tensor.transpose(-2, -1).contiguous())
+
+        assert scale_key == "model.language_model.layers.0.router.per_expert_scale"
+        assert scale_tensor.shape == (N_EXPERTS,)
+        torch.testing.assert_close(scale_tensor, torch.ones(N_EXPERTS, dtype=tensor.dtype))
+
+    def test_exclude_key_regex_filters_key(self, adapter):
+        tensor = torch.randn(HIDDEN, HIDDEN)
+        fqn = "model.language_model.layers.0.moe.gate.proj.weight"
+
+        result = adapter.convert_single_tensor_to_hf(fqn, tensor, exclude_key_regex=r".*moe\.gate.*")
+
+        assert result == []
+
+    def test_exclude_key_regex_does_not_filter_non_matching(self, adapter):
+        tensor = torch.randn(HIDDEN, HIDDEN)
+        fqn = "model.language_model.layers.0.self_attn.q_proj.weight"
+
+        result = adapter.convert_single_tensor_to_hf(fqn, tensor, exclude_key_regex=r".*moe\.gate.*")
+
+        assert len(result) == 1
+        assert result[0][0] == fqn


### PR DESCRIPTION
# What does this PR do ?
 
 Adds  per-tensor conversion for weight streaming (IPC refit) in convert_single_tensor_to_hf method of gemma4's state_dict_adapter.py required in RL training. Requested in #1761 

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
