### PR TITLE
fix: launcher option from being consumed as a config override.

### DIFF
--- a/nemo_automodel/cli/app.py
+++ b/nemo_automodel/cli/app.py
@@ -148,7 +148,7 @@ def main():
         from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
         from nemo_automodel.components.launcher.interactive import InteractiveLauncher
 
-        cfg = parse_args_and_load_config(str(config_path))
+        cfg = parse_args_and_load_config(str(config_path), argv=extra)
         return InteractiveLauncher().launch(cfg, config_path, recipe_target, args.nproc_per_node, extra)
 
 

--- a/nemo_automodel/components/config/_arg_parser.py
+++ b/nemo_automodel/components/config/_arg_parser.py
@@ -17,12 +17,13 @@ import sys
 from nemo_automodel.components.config.loader import ConfigNode, load_yaml_config, translate_value
 
 
-def parse_cli_argv(default_cfg_path: str | None = None) -> tuple[str, list[str]]:
+def parse_cli_argv(default_cfg_path: str | None = None, argv: list[str] | None = None) -> tuple[str, list[str]]:
     """
     Parses CLI args, pulls out --config and collects other --dotted.path options.
 
     Args:
         default_cfg_path (str, optional): Default config (yaml) path. Defaults to None.
+        argv (list[str], optional): Argument list to parse. Defaults to ``sys.argv[1:]``.
 
     Raises:
         ValueError: if there's no --config and cfg_path = None
@@ -31,7 +32,8 @@ def parse_cli_argv(default_cfg_path: str | None = None) -> tuple[str, list[str]]
     Returns:
         (str, list[str]): the config path along with the config overrides.
     """
-    argv = sys.argv[1:]
+    if argv is None:
+        argv = sys.argv[1:]
     overrides = []
     i = 0
     cfg_path = default_cfg_path
@@ -74,11 +76,15 @@ def parse_cli_argv(default_cfg_path: str | None = None) -> tuple[str, list[str]]
     return cfg_path, overrides
 
 
-def parse_args_and_load_config(default_cfg_path: str | None = None) -> ConfigNode:
+def parse_args_and_load_config(default_cfg_path: str | None = None, argv: list[str] | None = None) -> ConfigNode:
     """
     Loads YAML, applies overrides via ConfigNode.set_by_dotted.
+
+    Args:
+        default_cfg_path (str, optional): Default config (yaml) path.
+        argv (list[str], optional): Argument list to parse. Defaults to ``sys.argv[1:]``.
     """
-    cfg_path, overrides = parse_cli_argv(default_cfg_path)
+    cfg_path, overrides = parse_cli_argv(default_cfg_path, argv=argv)
     print(f"cfg-path: {cfg_path}")
     # load the base YAML
     cfg = load_yaml_config(cfg_path)

--- a/nemo_automodel/components/launcher/interactive.py
+++ b/nemo_automodel/components/launcher/interactive.py
@@ -74,12 +74,16 @@ class InteractiveLauncher(Launcher):
     def _is_torchrun_worker() -> bool:
         """Return True when this process was already spawned by torchrun.
 
-        torchrun (``torch.distributed.run``) sets ``LOCAL_RANK`` in the
-        environment of every worker it spawns.  When the user launches the CLI
-        via ``torchrun --nproc-per-node N -m nemo_automodel.cli.app config.yaml``,
+        torchrun (``torch.distributed.run``) sets both ``LOCAL_RANK`` and
+        ``TORCHELASTIC_RUN_ID`` in the environment of every worker it spawns.
+        We check for both to avoid false positives from environments (e.g.
+        SLURM) that may set ``LOCAL_RANK`` without an active torchrun session.
+
+        When the user launches the CLI via
+        ``torchrun --nproc-per-node N -m nemo_automodel.cli.app config.yaml``,
         each worker must run the recipe in-process instead of re-launching torchrun.
         """
-        return "LOCAL_RANK" in os.environ
+        return "LOCAL_RANK" in os.environ and "TORCHELASTIC_RUN_ID" in os.environ
 
     def _run_recipe_in_process(self, recipe_target: str, config: Dict[str, Any]) -> int:
         """Instantiate and run a recipe in the current process."""

--- a/tests/unit_tests/config/test_cli.py
+++ b/tests/unit_tests/config/test_cli.py
@@ -114,3 +114,55 @@ def test_parse_args_and_load_config(monkeypatch):
         ("opt.lr", "<T:1e-4>"),
         ("seed", "<T:123>"),
     ]
+
+
+# ---------------------------------------------------------------------------
+# parse_cli_argv / parse_args_and_load_config with explicit argv
+# ---------------------------------------------------------------------------
+def test_parse_cli_argv_with_explicit_argv():
+    """When argv is passed explicitly, sys.argv should be ignored."""
+    cfg_path, overrides = cli.parse_cli_argv(
+        default_cfg_path="default.yaml",
+        argv=["--step_scheduler.max_steps", "10", "--checkpoint.checkpoint_dir", "/tmp/ckpt"],
+    )
+    assert cfg_path == "default.yaml"
+    assert overrides == [
+        "step_scheduler.max_steps=10",
+        "checkpoint.checkpoint_dir=/tmp/ckpt",
+    ]
+
+
+def test_parse_cli_argv_explicit_argv_excludes_nproc():
+    """Simulates the automodel CLI passing extra args (without --nproc-per-node)."""
+    cfg_path, overrides = cli.parse_cli_argv(
+        default_cfg_path="/path/to/config.yaml",
+        argv=["--step_scheduler.max_steps", "10"],
+    )
+    assert cfg_path == "/path/to/config.yaml"
+    assert overrides == ["step_scheduler.max_steps=10"]
+    # nproc-per-node should NOT appear in overrides
+    assert not any("nproc" in o for o in overrides)
+
+
+def test_parse_cli_argv_explicit_empty_argv():
+    """Empty argv with default_cfg_path should return no overrides."""
+    cfg_path, overrides = cli.parse_cli_argv(
+        default_cfg_path="config.yaml",
+        argv=[],
+    )
+    assert cfg_path == "config.yaml"
+    assert overrides == []
+
+
+def test_parse_args_and_load_config_with_argv(monkeypatch):
+    """parse_args_and_load_config should respect explicit argv parameter."""
+    dummy_cfg = DummyConfig()
+    monkeypatch.setattr(cli, "load_yaml_config", lambda path: dummy_cfg, raising=True)
+    monkeypatch.setattr(cli, "translate_value", lambda s: f"<T:{s}>", raising=True)
+
+    returned_cfg = cli.parse_args_and_load_config(
+        default_cfg_path="cfg.yaml",
+        argv=["--opt.lr", "1e-4"],
+    )
+    assert returned_cfg is dummy_cfg
+    assert dummy_cfg._calls == [("opt.lr", "<T:1e-4>")]

--- a/tests/unit_tests/launcher/test_interactive_launcher.py
+++ b/tests/unit_tests/launcher/test_interactive_launcher.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import sys
 from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
@@ -95,10 +94,7 @@ def test_get_repo_root_editable_checkout_appends_pythonpath(tmp_path, monkeypatc
 def test_get_repo_root_not_checkout(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     result = _get_repo_root()
-    expected = Path(__file__).parents[3] / "nemo_automodel" / "components" / "launcher"
-    assert result == Path(
-        nemo_automodel.components.launcher.interactive.__file__
-    ).parents[3]
+    assert result == Path(nemo_automodel.components.launcher.interactive.__file__).parents[3]
 
 
 # ---------------------------------------------------------------------------
@@ -109,9 +105,7 @@ def test_interactive_launcher_returns_1_when_torch_missing(monkeypatch, tmp_path
     cfg_file = tmp_path / "config.yaml"
     cfg_file.write_text("recipe:\n  _target_: some.Recipe\n")
 
-    import nemo_automodel.components.launcher.interactive as mod
-
-    original_import = __builtins__.__import__ if hasattr(__builtins__, '__import__') else __import__
+    original_import = __builtins__.__import__ if hasattr(__builtins__, "__import__") else __import__
 
     def fake_import(name, *args, **kwargs):
         if name == "torch.distributed.run":
@@ -139,9 +133,7 @@ def _make_torch_distributed_mock(world_size=1, run_return=0):
     mock_module.determine_local_world_size.return_value = world_size
     mock_module.run.return_value = run_return
     mock_parser = mock.MagicMock()
-    mock_args = SimpleNamespace(
-        training_script="", training_script_args=[], nproc_per_node=0
-    )
+    mock_args = SimpleNamespace(training_script="", training_script_args=[], nproc_per_node=0)
     mock_parser.parse_known_args.return_value = (mock_args, [])
     mock_module.get_args_parser.return_value = mock_parser
     return mock_module, mock_args
@@ -270,10 +262,11 @@ def test_interactive_launcher_multi_device_with_extra_args(tmp_path):
 # InteractiveLauncher.launch – torchrun worker detection (in-process path)
 # ---------------------------------------------------------------------------
 def test_interactive_launcher_torchrun_worker_runs_in_process(tmp_path, monkeypatch):
-    """When LOCAL_RANK is set (i.e. already inside torchrun), run in-process."""
+    """When LOCAL_RANK and TORCHELASTIC_RUN_ID are set (i.e. already inside torchrun), run in-process."""
     cfg_file = tmp_path / "config.yaml"
     cfg_file.write_text("")
     monkeypatch.setenv("LOCAL_RANK", "3")
+    monkeypatch.setenv("TORCHELASTIC_RUN_ID", "test-run-123")
 
     mock_recipe_instance = mock.MagicMock()
     mock_recipe_instance.run_train_validation_loop.return_value = 0
@@ -306,6 +299,7 @@ def test_interactive_launcher_torchrun_worker_ignores_nproc(tmp_path, monkeypatc
     cfg_file = tmp_path / "config.yaml"
     cfg_file.write_text("")
     monkeypatch.setenv("LOCAL_RANK", "0")
+    monkeypatch.setenv("TORCHELASTIC_RUN_ID", "test-run-456")
 
     mock_recipe_instance = mock.MagicMock()
     mock_recipe_instance.run_train_validation_loop.return_value = 0
@@ -331,14 +325,78 @@ def test_interactive_launcher_torchrun_worker_ignores_nproc(tmp_path, monkeypatc
     mock_dist.run.assert_not_called()
 
 
+def test_interactive_launcher_local_rank_without_torchelastic_launches_torchrun(tmp_path, monkeypatch):
+    """When LOCAL_RANK is set but TORCHELASTIC_RUN_ID is not (e.g. SLURM),
+    the CLI should NOT treat this as a torchrun worker and should launch torchrun."""
+    cfg_file = tmp_path / "config.yaml"
+    cfg_file.write_text("")
+    monkeypatch.setenv("LOCAL_RANK", "0")
+    monkeypatch.delenv("TORCHELASTIC_RUN_ID", raising=False)
+
+    mock_dist, mock_args = _make_torch_distributed_mock(world_size=8, run_return=0)
+
+    with (
+        mock.patch.dict("sys.modules", {"torch.distributed.run": mock_dist}),
+        mock.patch(
+            "nemo_automodel.components.launcher.interactive._get_repo_root",
+            return_value=Path("/opt/Automodel"),
+        ),
+    ):
+        launcher = InteractiveLauncher()
+        rc = launcher.launch(
+            config={"key": "val"},
+            config_path=cfg_file,
+            recipe_target="some.module.Recipe",
+            launcher_config=8,
+        )
+    assert rc == 0
+    mock_dist.run.assert_called_once()
+    assert mock_args.nproc_per_node == 8
+
+
+def test_interactive_launcher_multi_device_explicit_nproc(tmp_path):
+    """Explicit --nproc-per-node 8 with 8 GPUs should launch torchrun with 8 workers."""
+    cfg_file = tmp_path / "config.yaml"
+    cfg_file.write_text("")
+
+    mock_dist, mock_args = _make_torch_distributed_mock(world_size=8, run_return=0)
+
+    with (
+        mock.patch.dict("sys.modules", {"torch.distributed.run": mock_dist}),
+        mock.patch(
+            "nemo_automodel.components.launcher.interactive._get_repo_root",
+            return_value=Path("/opt/Automodel"),
+        ),
+    ):
+        launcher = InteractiveLauncher()
+        rc = launcher.launch(
+            config={"key": "val"},
+            config_path=cfg_file,
+            recipe_target="some.module.Recipe",
+            launcher_config=8,
+        )
+    assert rc == 0
+    mock_dist.run.assert_called_once()
+    assert mock_args.nproc_per_node == 8
+
+
 def test_is_torchrun_worker_false(monkeypatch):
     monkeypatch.delenv("LOCAL_RANK", raising=False)
+    monkeypatch.delenv("TORCHELASTIC_RUN_ID", raising=False)
     assert InteractiveLauncher._is_torchrun_worker() is False
 
 
 def test_is_torchrun_worker_true(monkeypatch):
     monkeypatch.setenv("LOCAL_RANK", "0")
+    monkeypatch.setenv("TORCHELASTIC_RUN_ID", "test-run-789")
     assert InteractiveLauncher._is_torchrun_worker() is True
+
+
+def test_is_torchrun_worker_false_local_rank_only(monkeypatch):
+    """LOCAL_RANK alone (e.g. set by SLURM) should NOT be detected as torchrun."""
+    monkeypatch.setenv("LOCAL_RANK", "0")
+    monkeypatch.delenv("TORCHELASTIC_RUN_ID", raising=False)
+    assert InteractiveLauncher._is_torchrun_worker() is False
 
 
 import nemo_automodel.components.launcher.interactive


### PR DESCRIPTION
# What does this PR do ?

```
python3 app.py config.yaml --nproc-per-node=8
```
would cause `nproc-per-node` to become an option in `config.yaml`, now it correctly skips it and becomes a launcher option.

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
