### PR TITLE
fix: mute unsupported field attribute warning on startup

### DIFF
--- a/app.py
+++ b/app.py
@@ -31,17 +31,18 @@ import os
 import sys
 import warnings
 
-from nemo_automodel.cli.app import main
-
 # Pydantic v2 emits UnsupportedFieldAttributeWarning for Field(repr=...) /
 # Field(frozen=...) used inside 3.12-style `type` aliases in third-party libs.
 # There is nothing actionable for us here, so silence them globally.
+# Must run before any import that triggers pydantic schema generation.
 try:
     from pydantic.warnings import UnsupportedFieldAttributeWarning
 
     warnings.filterwarnings("ignore", category=UnsupportedFieldAttributeWarning)
 except ImportError:
     pass
+
+from nemo_automodel.cli.app import main
 
 logger = logging.getLogger(__name__)
 

--- a/nemo_automodel/__init__.py
+++ b/nemo_automodel/__init__.py
@@ -16,8 +16,20 @@ import importlib
 import importlib.abc
 import importlib.machinery
 import sys
+import warnings
 from types import ModuleType
 from typing import Any
+
+# Pydantic v2 emits UnsupportedFieldAttributeWarning for Field(repr=...) /
+# Field(frozen=...) used inside 3.12-style `type` aliases in third-party libs.
+# Suppress early so any later import that triggers pydantic schema generation
+# (e.g. transformers, huggingface_hub) won't emit these warnings.
+try:
+    from pydantic.warnings import UnsupportedFieldAttributeWarning
+
+    warnings.filterwarnings("ignore", category=UnsupportedFieldAttributeWarning)
+except ImportError:
+    pass
 
 from .package_info import __package_name__, __version__
 

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -14,6 +14,17 @@
 
 from __future__ import annotations
 
+import warnings
+
+# Suppress pydantic v2 UnsupportedFieldAttributeWarning before heavy imports
+# (transformers, huggingface_hub) trigger schema generation.
+try:
+    from pydantic.warnings import UnsupportedFieldAttributeWarning
+
+    warnings.filterwarnings("ignore", category=UnsupportedFieldAttributeWarning)
+except ImportError:
+    pass
+
 import inspect
 import logging
 import pathlib

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -14,6 +14,17 @@
 
 from __future__ import annotations
 
+import warnings
+
+# Suppress pydantic v2 UnsupportedFieldAttributeWarning before heavy imports
+# (transformers, huggingface_hub) trigger schema generation.
+try:
+    from pydantic.warnings import UnsupportedFieldAttributeWarning
+
+    warnings.filterwarnings("ignore", category=UnsupportedFieldAttributeWarning)
+except ImportError:
+    pass
+
 import logging
 import pathlib
 import time


### PR DESCRIPTION
# What does this PR do ?

While confirming https://github.com/NVIDIA-NeMo/Automodel/pull/1766#issuecomment-4226071778 I saw there were more warning left, with this filtering

```
root@c16f65276617:/mnt/4tb/auto/26_04/Automodel# python3 app.py examples/llm_finetune/llama3_2/llama3_2_1b_squad_peft.yaml --nproc-per-node=2
INFO:__main__:Running from source checkout (app.py). For production use, install the package and run `automodel` or `am` instead.
INFO:nemo_automodel.cli.app:Config: /mnt/4tb/auto/26_04/Automodel/examples/llm_finetune/llama3_2/llama3_2_1b_squad_peft.yaml
INFO:nemo_automodel.cli.app:Recipe: nemo_automodel.recipes.llm.train_ft.``
INFO:nemo_automodel.cli.app:Launching job interactively (local)
cfg-path: /mnt/4tb/auto/26_04/Automodel/examples/llm_finetune/llama3_2/llama3_2_1b_squad_peft.yaml
/usr/local/lib/python3.12/dist-packages/torch/cuda/__init__.py:61: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report t
his to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
INFO:nemo_automodel.components.launcher.interactive:Running job using source from: /mnt/4tb/auto/26_04/Automodel
INFO:nemo_automodel.components.launcher.interactive:Launching job locally on 2 devices
W0410 19:01:12.990000 450 torch/distributed/run.py:851]
W0410 19:01:12.990000 450 torch/distributed/run.py:851] *****************************************
W0410 19:01:12.990000 450 torch/distributed/run.py:851] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variabl
e for optimal performance in your application as needed.
W0410 19:01:12.990000 450 torch/distributed/run.py:851] *****************************************
/usr/local/lib/python3.12/dist-packages/torch/cuda/__init__.py:61: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report t
his to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
/usr/local/lib/python3.12/dist-packages/torch/cuda/__init__.py:61: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report t
his to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
cfg-path: /mnt/4tb/auto/26_04/Automodel/examples/llm_finetune/llama3_2/llama3_2_1b_squad_peft.yaml
cfg-path: /mnt/4tb/auto/26_04/Automodel/examples/llm_finetune/llama3_2/llama3_2_1b_squad_peft.yaml
> initializing torch distributed with 2 workers.
2026-04-10 19:01:21 | INFO | nemo_automodel.components.loggers.log_utils | Setting logging level to 20
2026-04-10 19:01:21 | INFO | nemo_automodel.shared.te_patches | Applied FusedAdam QuantizedTensor monkey-patch.
2026-04-10 19:01:21 | INFO | root | Experiment_details:
2026-04-10 19:01:21 | INFO | root | Timestamp: '2026-04-10T19:01:21'
2026-04-10 19:01:21 | INFO | root | User: root
2026-04-10 19:01:21 | INFO | root | Host: c16f65276617
2026-04-10 19:01:21 | INFO | root | World size: 2
2026-04-10 19:01:21 | INFO | root | Backend: nccl
2026-04-10 19:01:21 | INFO | root | Recipe: TrainFinetuneRecipeForNextTokenPrediction
2026-04-10 19:01:21 | INFO | root | Model name: meta-llama/Llama-3.2-1B
recipe: TrainFinetuneRecipeForNextTokenPrediction
step_scheduler:
  global_batch_size: 64
  local_batch_size: 8
  ckpt_every_steps: 1000
```

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
