### PR TITLE
docs: Add nightly CI test summary for LLM and VLM finetune configs

### DIFF
--- a/tests/ci_tests/configs/llm_finetune/SUMMARY.md
+++ b/tests/ci_tests/configs/llm_finetune/SUMMARY.md
@@ -8,62 +8,62 @@ The nightly scope uses only the recipes listed in [nightly_recipes.yml](nightly_
 ## SFT
 
 | Recipe | Time | Nodes | Ckpt Robustness | vLLM Deploy | vLLM Smoke |
-|---|---|---|---|---|---|
-| baichuan_2_7b_squad | 00:45:00 | 1 | Yes | Yes | No |
-| cohere_command_r_7b_squad | 00:10:00 | 1 | No | No | No |
-| devstral2_small_2512_squad | 00:15:00 | 1 | No | No | No |
-| falcon3_7b_instruct_squad | 00:10:00 | 1 | No | No | No |
-| gemma_2_9b_it_squad | 00:10:00 | 1 | No | No | No |
-| gemma_3_270m_squad | 00:20:00 | 1 | Yes | Yes | No |
-| glm_4_9b_chat_hf_squad | 00:10:00 | 1 | No | No | No |
-| gpt_oss_20b | 00:15:00 | 1 | Yes | Yes | Yes |
-| gpt_oss_20b_single_gpu | 00:10:00 | 1 | No | No | No |
-| granite_3_3_2b_instruct_squad | 00:10:00 | 1 | No | No | No |
-| llama3_1_8b_hellaswag_pp | 00:10:00 | 1 | No | No | No |
-| llama3_2_1b_hellaswag | 00:15:00 | 1 | Yes | No | No |
-| llama3_2_1b_squad | 00:10:00 | 1 | No | No | No |
-| llama3_3_nemotron_super_49B_squad | 00:45:00 | 2 | Yes | Yes | No |
-| ministral3_3b_squad | 00:15:00 | 1 | Yes | No | No |
-| mistral_nemo_2407_squad | 00:10:00 | 1 | No | No | No |
-| moonlight_16b_te | 00:10:00 | 1 | No | No | No |
-| nemotron_flash_1b_squad | 00:15:00 | 1 | Yes | Yes | No |
-| nemotron_nano_8b_v1_squad | 00:20:00 | 1 | Yes | No | No |
-| nemotron_nano_9b_squad | 00:25:00 | 1 | Yes | Yes | No |
-| nemotron_nano_v3_hellaswag | 00:15:00 | 1 | Yes | Yes | Yes |
-| nemotron_super_v3_hellaswag | 00:15:00 | 4 | Yes | Yes | Yes |
-| olmo_2_0425_1b_instruct_squad | 00:10:00 | 1 | No | No | No |
-| phi_3_mini_it_squad | 00:10:00 | 1 | No | No | No |
-| phi_4_squad | 00:35:00 | 1 | Yes | Yes | No |
-| qwen2_5_7b_squad | 00:45:00 | 1 | Yes | Yes | No |
-| qwen3_moe_30b_hellaswag | 00:15:00 | 1 | Yes | No | No |
-| qwen3_moe_30b_te_deepep | 00:15:00 | 1 | Yes | Yes | Yes |
-| seed_coder_8b_instruct_squad | 00:10:00 | 1 | No | No | No |
-| starcoder_2_7b_squad | 00:15:00 | 1 | No | No | No |
-| step_3.5_flash_hellaswag_pp | 00:30:00 | 16 | No | No | No |
+|---|---|---|:---:|:---:|:---:|
+| baichuan_2_7b_squad | 00:45:00 | 1 | ✅ | ✅ | N/A |
+| cohere_command_r_7b_squad | 00:10:00 | 1 | N/A | N/A | N/A |
+| devstral2_small_2512_squad | 00:15:00 | 1 | N/A | N/A | N/A |
+| falcon3_7b_instruct_squad | 00:10:00 | 1 | N/A | N/A | N/A |
+| gemma_2_9b_it_squad | 00:10:00 | 1 | N/A | N/A | N/A |
+| gemma_3_270m_squad | 00:20:00 | 1 | ✅ | ✅ | N/A |
+| glm_4_9b_chat_hf_squad | 00:10:00 | 1 | N/A | N/A | N/A |
+| gpt_oss_20b | 00:15:00 | 1 | ✅ | ✅ | ✅ |
+| gpt_oss_20b_single_gpu | 00:10:00 | 1 | N/A | N/A | N/A |
+| granite_3_3_2b_instruct_squad | 00:10:00 | 1 | N/A | N/A | N/A |
+| llama3_1_8b_hellaswag_pp | 00:10:00 | 1 | N/A | N/A | N/A |
+| llama3_2_1b_hellaswag | 00:15:00 | 1 | ✅ | N/A | N/A |
+| llama3_2_1b_squad | 00:10:00 | 1 | N/A | N/A | N/A |
+| llama3_3_nemotron_super_49B_squad | 00:45:00 | 2 | ✅ | ✅ | N/A |
+| ministral3_3b_squad | 00:15:00 | 1 | ✅ | N/A | N/A |
+| mistral_nemo_2407_squad | 00:10:00 | 1 | N/A | N/A | N/A |
+| moonlight_16b_te | 00:10:00 | 1 | N/A | N/A | N/A |
+| nemotron_flash_1b_squad | 00:15:00 | 1 | ✅ | ✅ | N/A |
+| nemotron_nano_8b_v1_squad | 00:20:00 | 1 | ✅ | N/A | N/A |
+| nemotron_nano_9b_squad | 00:25:00 | 1 | ✅ | ✅ | N/A |
+| nemotron_nano_v3_hellaswag | 00:15:00 | 1 | ✅ | ✅ | ✅ |
+| nemotron_super_v3_hellaswag | 00:15:00 | 4 | ✅ | ✅ | ✅ |
+| olmo_2_0425_1b_instruct_squad | 00:10:00 | 1 | N/A | N/A | N/A |
+| phi_3_mini_it_squad | 00:10:00 | 1 | N/A | N/A | N/A |
+| phi_4_squad | 00:35:00 | 1 | ✅ | ✅ | N/A |
+| qwen2_5_7b_squad | 00:45:00 | 1 | ✅ | ✅ | N/A |
+| qwen3_moe_30b_hellaswag | 00:15:00 | 1 | ✅ | N/A | N/A |
+| qwen3_moe_30b_te_deepep | 00:15:00 | 1 | ✅ | ✅ | ✅ |
+| seed_coder_8b_instruct_squad | 00:10:00 | 1 | N/A | N/A | N/A |
+| starcoder_2_7b_squad | 00:15:00 | 1 | N/A | N/A | N/A |
+| step_3.5_flash_hellaswag_pp | 00:30:00 | 16 | N/A | N/A | N/A |
 
 ## PEFT
 
 | Recipe | Time | Nodes | Ckpt Robustness | vLLM Deploy | vLLM Smoke |
-|---|---|---|---|---|---|
-| baichuan_2_7b_squad_peft | 00:45:00 | 1 | Yes | Yes | No |
-| falcon3_7b_instruct_squad_peft | 00:10:00 | 1 | No | No | No |
-| gemma_2_9b_it_squad_peft | 00:15:00 | 1 | No | No | No |
-| gemma_3_270m_squad_peft | 00:20:00 | 1 | Yes | Yes | No |
-| gpt_oss_20b_peft | 00:15:00 | 1 | Yes | Yes | Yes |
-| gpt_oss_20b_single_gpu_peft | 00:10:00 | 1 | No | No | No |
-| llama3_2_1b_hellaswag_peft | 00:15:00 | 1 | Yes | No | No |
-| llama3_3_nemotron_super_49B_squad_peft | 00:45:00 | 1 | Yes | Yes | No |
-| ministral3_3b_squad_peft | 00:15:00 | 1 | Yes | No | No |
-| nemotron_flash_1b_squad_peft | 00:15:00 | 1 | Yes | Yes | No |
-| nemotron_nano_8b_v1_squad_peft | 00:15:00 | 1 | Yes | No | No |
-| nemotron_nano_9b_squad_peft | 00:25:00 | 1 | Yes | Yes | No |
-| nemotron_nano_v3_hellaswag_peft | 00:15:00 | 1 | Yes | Yes | Yes |
-| nemotron_super_v3_hellaswag_peft | 00:15:00 | 1 | Yes | Yes | Yes |
-| phi_2_squad_peft | 00:10:00 | 1 | No | No | No |
-| phi_2_squad_tp2_peft | 00:10:00 | 1 | No | No | No |
-| phi_4_squad_peft | 00:35:00 | 1 | Yes | Yes | No |
-| phi_4_squad_tp2_peft | 00:10:00 | 1 | No | No | No |
-| qwen2_5_7b_peft_benchmark | 00:10:00 | 1 | No | No | No |
-| qwen2_5_7b_squad_peft | 00:30:00 | 1 | Yes | Yes | No |
-| qwen3_moe_30b_lora | 00:15:00 | 1 | Yes | No | No |
-| seed_coder_8b_instruct_squad_peft | 00:10:00 | 1 | No | No | No |
+|---|---|---|:---:|:---:|:---:|
+| baichuan_2_7b_squad_peft | 00:45:00 | 1 | ✅ | ✅ | N/A |
+| falcon3_7b_instruct_squad_peft | 00:10:00 | 1 | N/A | N/A | N/A |
+| gemma_2_9b_it_squad_peft | 00:15:00 | 1 | N/A | N/A | N/A |
+| gemma_3_270m_squad_peft | 00:20:00 | 1 | ✅ | ✅ | N/A |
+| gpt_oss_20b_peft | 00:15:00 | 1 | ✅ | ✅ | ✅ |
+| gpt_oss_20b_single_gpu_peft | 00:10:00 | 1 | N/A | N/A | N/A |
+| llama3_2_1b_hellaswag_peft | 00:15:00 | 1 | ✅ | N/A | N/A |
+| llama3_3_nemotron_super_49B_squad_peft | 00:45:00 | 1 | ✅ | ✅ | N/A |
+| ministral3_3b_squad_peft | 00:15:00 | 1 | ✅ | N/A | N/A |
+| nemotron_flash_1b_squad_peft | 00:15:00 | 1 | ✅ | ✅ | N/A |
+| nemotron_nano_8b_v1_squad_peft | 00:15:00 | 1 | ✅ | N/A | N/A |
+| nemotron_nano_9b_squad_peft | 00:25:00 | 1 | ✅ | ✅ | N/A |
+| nemotron_nano_v3_hellaswag_peft | 00:15:00 | 1 | ✅ | ✅ | ✅ |
+| nemotron_super_v3_hellaswag_peft | 00:15:00 | 1 | ✅ | ✅ | ✅ |
+| phi_2_squad_peft | 00:10:00 | 1 | N/A | N/A | N/A |
+| phi_2_squad_tp2_peft | 00:10:00 | 1 | N/A | N/A | N/A |
+| phi_4_squad_peft | 00:35:00 | 1 | ✅ | ✅ | N/A |
+| phi_4_squad_tp2_peft | 00:10:00 | 1 | N/A | N/A | N/A |
+| qwen2_5_7b_peft_benchmark | 00:10:00 | 1 | N/A | N/A | N/A |
+| qwen2_5_7b_squad_peft | 00:30:00 | 1 | ✅ | ✅ | N/A |
+| qwen3_moe_30b_lora | 00:15:00 | 1 | ✅ | N/A | N/A |
+| seed_coder_8b_instruct_squad_peft | 00:10:00 | 1 | N/A | N/A | N/A |

--- a/tests/ci_tests/configs/llm_finetune/SUMMARY.md
+++ b/tests/ci_tests/configs/llm_finetune/SUMMARY.md
@@ -1,0 +1,69 @@
+# LLM Finetune Nightly Recipes
+
+Defaults: Time = 00:10:00, Nodes = 1, vLLM deploy time = 00:30:00 (separate job)
+
+For release testing, all recipes under `llm_finetune/` are added automatically.
+The nightly scope uses only the recipes listed in [nightly_recipes.yml](nightly_recipes.yml).
+
+## SFT
+
+| Recipe | Time | Nodes | Ckpt Robustness | vLLM Deploy | vLLM Smoke |
+|---|---|---|---|---|---|
+| baichuan_2_7b_squad | 00:45:00 | 1 | Yes | Yes | No |
+| cohere_command_r_7b_squad | 00:10:00 | 1 | No | No | No |
+| devstral2_small_2512_squad | 00:15:00 | 1 | No | No | No |
+| falcon3_7b_instruct_squad | 00:10:00 | 1 | No | No | No |
+| gemma_2_9b_it_squad | 00:10:00 | 1 | No | No | No |
+| gemma_3_270m_squad | 00:20:00 | 1 | Yes | Yes | No |
+| glm_4_9b_chat_hf_squad | 00:10:00 | 1 | No | No | No |
+| gpt_oss_20b | 00:15:00 | 1 | Yes | Yes | Yes |
+| gpt_oss_20b_single_gpu | 00:10:00 | 1 | No | No | No |
+| granite_3_3_2b_instruct_squad | 00:10:00 | 1 | No | No | No |
+| llama3_1_8b_hellaswag_pp | 00:10:00 | 1 | No | No | No |
+| llama3_2_1b_hellaswag | 00:15:00 | 1 | Yes | No | No |
+| llama3_2_1b_squad | 00:10:00 | 1 | No | No | No |
+| llama3_3_nemotron_super_49B_squad | 00:45:00 | 2 | Yes | Yes | No |
+| ministral3_3b_squad | 00:15:00 | 1 | Yes | No | No |
+| mistral_nemo_2407_squad | 00:10:00 | 1 | No | No | No |
+| moonlight_16b_te | 00:10:00 | 1 | No | No | No |
+| nemotron_flash_1b_squad | 00:15:00 | 1 | Yes | Yes | No |
+| nemotron_nano_8b_v1_squad | 00:20:00 | 1 | Yes | No | No |
+| nemotron_nano_9b_squad | 00:25:00 | 1 | Yes | Yes | No |
+| nemotron_nano_v3_hellaswag | 00:15:00 | 1 | Yes | Yes | Yes |
+| nemotron_super_v3_hellaswag | 00:15:00 | 4 | Yes | Yes | Yes |
+| olmo_2_0425_1b_instruct_squad | 00:10:00 | 1 | No | No | No |
+| phi_3_mini_it_squad | 00:10:00 | 1 | No | No | No |
+| phi_4_squad | 00:35:00 | 1 | Yes | Yes | No |
+| qwen2_5_7b_squad | 00:45:00 | 1 | Yes | Yes | No |
+| qwen3_moe_30b_hellaswag | 00:15:00 | 1 | Yes | No | No |
+| qwen3_moe_30b_te_deepep | 00:15:00 | 1 | Yes | Yes | Yes |
+| seed_coder_8b_instruct_squad | 00:10:00 | 1 | No | No | No |
+| starcoder_2_7b_squad | 00:15:00 | 1 | No | No | No |
+| step_3.5_flash_hellaswag_pp | 00:30:00 | 16 | No | No | No |
+
+## PEFT
+
+| Recipe | Time | Nodes | Ckpt Robustness | vLLM Deploy | vLLM Smoke |
+|---|---|---|---|---|---|
+| baichuan_2_7b_squad_peft | 00:45:00 | 1 | Yes | Yes | No |
+| falcon3_7b_instruct_squad_peft | 00:10:00 | 1 | No | No | No |
+| gemma_2_9b_it_squad_peft | 00:15:00 | 1 | No | No | No |
+| gemma_3_270m_squad_peft | 00:20:00 | 1 | Yes | Yes | No |
+| gpt_oss_20b_peft | 00:15:00 | 1 | Yes | Yes | Yes |
+| gpt_oss_20b_single_gpu_peft | 00:10:00 | 1 | No | No | No |
+| llama3_2_1b_hellaswag_peft | 00:15:00 | 1 | Yes | No | No |
+| llama3_3_nemotron_super_49B_squad_peft | 00:45:00 | 1 | Yes | Yes | No |
+| ministral3_3b_squad_peft | 00:15:00 | 1 | Yes | No | No |
+| nemotron_flash_1b_squad_peft | 00:15:00 | 1 | Yes | Yes | No |
+| nemotron_nano_8b_v1_squad_peft | 00:15:00 | 1 | Yes | No | No |
+| nemotron_nano_9b_squad_peft | 00:25:00 | 1 | Yes | Yes | No |
+| nemotron_nano_v3_hellaswag_peft | 00:15:00 | 1 | Yes | Yes | Yes |
+| nemotron_super_v3_hellaswag_peft | 00:15:00 | 1 | Yes | Yes | Yes |
+| phi_2_squad_peft | 00:10:00 | 1 | No | No | No |
+| phi_2_squad_tp2_peft | 00:10:00 | 1 | No | No | No |
+| phi_4_squad_peft | 00:35:00 | 1 | Yes | Yes | No |
+| phi_4_squad_tp2_peft | 00:10:00 | 1 | No | No | No |
+| qwen2_5_7b_peft_benchmark | 00:10:00 | 1 | No | No | No |
+| qwen2_5_7b_squad_peft | 00:30:00 | 1 | Yes | Yes | No |
+| qwen3_moe_30b_lora | 00:15:00 | 1 | Yes | No | No |
+| seed_coder_8b_instruct_squad_peft | 00:10:00 | 1 | No | No | No |

--- a/tests/ci_tests/configs/llm_finetune/SUMMARY.md
+++ b/tests/ci_tests/configs/llm_finetune/SUMMARY.md
@@ -8,62 +8,62 @@ The nightly scope uses only the recipes listed in [nightly_recipes.yml](nightly_
 ## SFT
 
 | Recipe | Time | Nodes | Ckpt Robustness | vLLM Deploy | vLLM Smoke |
-|---|---|---|:---:|:---:|:---:|
-| baichuan_2_7b_squad | 00:45:00 | 1 | ✅ | ✅ | N/A |
-| cohere_command_r_7b_squad | 00:10:00 | 1 | N/A | N/A | N/A |
-| devstral2_small_2512_squad | 00:15:00 | 1 | N/A | N/A | N/A |
-| falcon3_7b_instruct_squad | 00:10:00 | 1 | N/A | N/A | N/A |
-| gemma_2_9b_it_squad | 00:10:00 | 1 | N/A | N/A | N/A |
-| gemma_3_270m_squad | 00:20:00 | 1 | ✅ | ✅ | N/A |
-| glm_4_9b_chat_hf_squad | 00:10:00 | 1 | N/A | N/A | N/A |
+|---|:---:|:---:|:---:|:---:|:---:|
+| baichuan_2_7b_squad | 00:45:00 | 1 | ✅ | ✅ | - |
+| cohere_command_r_7b_squad | 00:10:00 | 1 | - | - | - |
+| devstral2_small_2512_squad | 00:15:00 | 1 | - | - | - |
+| falcon3_7b_instruct_squad | 00:10:00 | 1 | - | - | - |
+| gemma_2_9b_it_squad | 00:10:00 | 1 | - | - | - |
+| gemma_3_270m_squad | 00:20:00 | 1 | ✅ | ✅ | - |
+| glm_4_9b_chat_hf_squad | 00:10:00 | 1 | - | - | - |
 | gpt_oss_20b | 00:15:00 | 1 | ✅ | ✅ | ✅ |
-| gpt_oss_20b_single_gpu | 00:10:00 | 1 | N/A | N/A | N/A |
-| granite_3_3_2b_instruct_squad | 00:10:00 | 1 | N/A | N/A | N/A |
-| llama3_1_8b_hellaswag_pp | 00:10:00 | 1 | N/A | N/A | N/A |
-| llama3_2_1b_hellaswag | 00:15:00 | 1 | ✅ | N/A | N/A |
-| llama3_2_1b_squad | 00:10:00 | 1 | N/A | N/A | N/A |
-| llama3_3_nemotron_super_49B_squad | 00:45:00 | 2 | ✅ | ✅ | N/A |
-| ministral3_3b_squad | 00:15:00 | 1 | ✅ | N/A | N/A |
-| mistral_nemo_2407_squad | 00:10:00 | 1 | N/A | N/A | N/A |
-| moonlight_16b_te | 00:10:00 | 1 | N/A | N/A | N/A |
-| nemotron_flash_1b_squad | 00:15:00 | 1 | ✅ | ✅ | N/A |
-| nemotron_nano_8b_v1_squad | 00:20:00 | 1 | ✅ | N/A | N/A |
-| nemotron_nano_9b_squad | 00:25:00 | 1 | ✅ | ✅ | N/A |
+| gpt_oss_20b_single_gpu | 00:10:00 | 1 | - | - | - |
+| granite_3_3_2b_instruct_squad | 00:10:00 | 1 | - | - | - |
+| llama3_1_8b_hellaswag_pp | 00:10:00 | 1 | - | - | - |
+| llama3_2_1b_hellaswag | 00:15:00 | 1 | ✅ | - | - |
+| llama3_2_1b_squad | 00:10:00 | 1 | - | - | - |
+| llama3_3_nemotron_super_49B_squad | 00:45:00 | 2 | ✅ | ✅ | - |
+| ministral3_3b_squad | 00:15:00 | 1 | ✅ | - | - |
+| mistral_nemo_2407_squad | 00:10:00 | 1 | - | - | - |
+| moonlight_16b_te | 00:10:00 | 1 | - | - | - |
+| nemotron_flash_1b_squad | 00:15:00 | 1 | ✅ | ✅ | - |
+| nemotron_nano_8b_v1_squad | 00:20:00 | 1 | ✅ | - | - |
+| nemotron_nano_9b_squad | 00:25:00 | 1 | ✅ | ✅ | - |
 | nemotron_nano_v3_hellaswag | 00:15:00 | 1 | ✅ | ✅ | ✅ |
 | nemotron_super_v3_hellaswag | 00:15:00 | 4 | ✅ | ✅ | ✅ |
-| olmo_2_0425_1b_instruct_squad | 00:10:00 | 1 | N/A | N/A | N/A |
-| phi_3_mini_it_squad | 00:10:00 | 1 | N/A | N/A | N/A |
-| phi_4_squad | 00:35:00 | 1 | ✅ | ✅ | N/A |
-| qwen2_5_7b_squad | 00:45:00 | 1 | ✅ | ✅ | N/A |
-| qwen3_moe_30b_hellaswag | 00:15:00 | 1 | ✅ | N/A | N/A |
+| olmo_2_0425_1b_instruct_squad | 00:10:00 | 1 | - | - | - |
+| phi_3_mini_it_squad | 00:10:00 | 1 | - | - | - |
+| phi_4_squad | 00:35:00 | 1 | ✅ | ✅ | - |
+| qwen2_5_7b_squad | 00:45:00 | 1 | ✅ | ✅ | - |
+| qwen3_moe_30b_hellaswag | 00:15:00 | 1 | ✅ | - | - |
 | qwen3_moe_30b_te_deepep | 00:15:00 | 1 | ✅ | ✅ | ✅ |
-| seed_coder_8b_instruct_squad | 00:10:00 | 1 | N/A | N/A | N/A |
-| starcoder_2_7b_squad | 00:15:00 | 1 | N/A | N/A | N/A |
-| step_3.5_flash_hellaswag_pp | 00:30:00 | 16 | N/A | N/A | N/A |
+| seed_coder_8b_instruct_squad | 00:10:00 | 1 | - | - | - |
+| starcoder_2_7b_squad | 00:15:00 | 1 | - | - | - |
+| step_3.5_flash_hellaswag_pp | 00:30:00 | 16 | - | - | - |
 
 ## PEFT
 
 | Recipe | Time | Nodes | Ckpt Robustness | vLLM Deploy | vLLM Smoke |
-|---|---|---|:---:|:---:|:---:|
-| baichuan_2_7b_squad_peft | 00:45:00 | 1 | ✅ | ✅ | N/A |
-| falcon3_7b_instruct_squad_peft | 00:10:00 | 1 | N/A | N/A | N/A |
-| gemma_2_9b_it_squad_peft | 00:15:00 | 1 | N/A | N/A | N/A |
-| gemma_3_270m_squad_peft | 00:20:00 | 1 | ✅ | ✅ | N/A |
+|---|:---:|:---:|:---:|:---:|:---:|
+| baichuan_2_7b_squad_peft | 00:45:00 | 1 | ✅ | ✅ | - |
+| falcon3_7b_instruct_squad_peft | 00:10:00 | 1 | - | - | - |
+| gemma_2_9b_it_squad_peft | 00:15:00 | 1 | - | - | - |
+| gemma_3_270m_squad_peft | 00:20:00 | 1 | ✅ | ✅ | - |
 | gpt_oss_20b_peft | 00:15:00 | 1 | ✅ | ✅ | ✅ |
-| gpt_oss_20b_single_gpu_peft | 00:10:00 | 1 | N/A | N/A | N/A |
-| llama3_2_1b_hellaswag_peft | 00:15:00 | 1 | ✅ | N/A | N/A |
-| llama3_3_nemotron_super_49B_squad_peft | 00:45:00 | 1 | ✅ | ✅ | N/A |
-| ministral3_3b_squad_peft | 00:15:00 | 1 | ✅ | N/A | N/A |
-| nemotron_flash_1b_squad_peft | 00:15:00 | 1 | ✅ | ✅ | N/A |
-| nemotron_nano_8b_v1_squad_peft | 00:15:00 | 1 | ✅ | N/A | N/A |
-| nemotron_nano_9b_squad_peft | 00:25:00 | 1 | ✅ | ✅ | N/A |
+| gpt_oss_20b_single_gpu_peft | 00:10:00 | 1 | - | - | - |
+| llama3_2_1b_hellaswag_peft | 00:15:00 | 1 | ✅ | - | - |
+| llama3_3_nemotron_super_49B_squad_peft | 00:45:00 | 1 | ✅ | ✅ | - |
+| ministral3_3b_squad_peft | 00:15:00 | 1 | ✅ | - | - |
+| nemotron_flash_1b_squad_peft | 00:15:00 | 1 | ✅ | ✅ | - |
+| nemotron_nano_8b_v1_squad_peft | 00:15:00 | 1 | ✅ | - | - |
+| nemotron_nano_9b_squad_peft | 00:25:00 | 1 | ✅ | ✅ | - |
 | nemotron_nano_v3_hellaswag_peft | 00:15:00 | 1 | ✅ | ✅ | ✅ |
 | nemotron_super_v3_hellaswag_peft | 00:15:00 | 1 | ✅ | ✅ | ✅ |
-| phi_2_squad_peft | 00:10:00 | 1 | N/A | N/A | N/A |
-| phi_2_squad_tp2_peft | 00:10:00 | 1 | N/A | N/A | N/A |
-| phi_4_squad_peft | 00:35:00 | 1 | ✅ | ✅ | N/A |
-| phi_4_squad_tp2_peft | 00:10:00 | 1 | N/A | N/A | N/A |
-| qwen2_5_7b_peft_benchmark | 00:10:00 | 1 | N/A | N/A | N/A |
-| qwen2_5_7b_squad_peft | 00:30:00 | 1 | ✅ | ✅ | N/A |
-| qwen3_moe_30b_lora | 00:15:00 | 1 | ✅ | N/A | N/A |
-| seed_coder_8b_instruct_squad_peft | 00:10:00 | 1 | N/A | N/A | N/A |
+| phi_2_squad_peft | 00:10:00 | 1 | - | - | - |
+| phi_2_squad_tp2_peft | 00:10:00 | 1 | - | - | - |
+| phi_4_squad_peft | 00:35:00 | 1 | ✅ | ✅ | - |
+| phi_4_squad_tp2_peft | 00:10:00 | 1 | - | - | - |
+| qwen2_5_7b_peft_benchmark | 00:10:00 | 1 | - | - | - |
+| qwen2_5_7b_squad_peft | 00:30:00 | 1 | ✅ | ✅ | - |
+| qwen3_moe_30b_lora | 00:15:00 | 1 | ✅ | - | - |
+| seed_coder_8b_instruct_squad_peft | 00:10:00 | 1 | - | - | - |

--- a/tests/ci_tests/configs/vlm_finetune/SUMMARY.md
+++ b/tests/ci_tests/configs/vlm_finetune/SUMMARY.md
@@ -1,0 +1,30 @@
+# VLM Finetune Nightly Recipes
+
+Defaults: Time = 00:10:00, Nodes = 1
+
+For release testing, all recipes under `vlm_finetune/` are added automatically.
+The nightly scope uses only the recipes listed in [nightly_recipes.yml](nightly_recipes.yml).
+
+## SFT
+
+| Recipe | Time | Nodes |
+|---|---|---|
+| gemma3_vl_4b_cord_v2 | 00:10:00 | 1 |
+| gemma3n_vl_4b_medpix | 00:30:00 | 1 |
+| internvl_3_5_4b | 00:10:00 | 1 |
+| kimi2vl_cordv2 | 00:10:00 | 1 |
+| ministral3_3b_medpix | 00:10:00 | 1 |
+| mistral4_medpix | 00:30:00 | 4 |
+| nemotron_parse_v1_1 | 00:30:00 | 1 |
+| phi4_mm_cv17 | 00:10:00 | 1 |
+| qwen2_5_vl_3b_rdr | 00:10:00 | 1 |
+| qwen3_5_4b | 00:30:00 | 1 |
+| qwen3_5_35b | 00:30:00 | 1 |
+| qwen3_vl_4b_instruct_rdr | 00:10:00 | 1 |
+
+## PEFT
+
+| Recipe | Time | Nodes |
+|---|---|---|
+| gemma3_vl_4b_cord_v2_peft | 00:10:00 | 1 |
+| gemma3n_vl_4b_medpix_peft | 00:10:00 | 1 |

--- a/tests/ci_tests/configs/vlm_finetune/SUMMARY.md
+++ b/tests/ci_tests/configs/vlm_finetune/SUMMARY.md
@@ -8,7 +8,7 @@ The nightly scope uses only the recipes listed in [nightly_recipes.yml](nightly_
 ## SFT
 
 | Recipe | Time | Nodes |
-|---|---|---|
+|---|:---:|:---:|
 | gemma3_vl_4b_cord_v2 | 00:10:00 | 1 |
 | gemma3n_vl_4b_medpix | 00:30:00 | 1 |
 | internvl_3_5_4b | 00:10:00 | 1 |
@@ -25,6 +25,6 @@ The nightly scope uses only the recipes listed in [nightly_recipes.yml](nightly_
 ## PEFT
 
 | Recipe | Time | Nodes |
-|---|---|---|
+|---|:---:|:---:|
 | gemma3_vl_4b_cord_v2_peft | 00:10:00 | 1 |
 | gemma3n_vl_4b_medpix_peft | 00:10:00 | 1 |


### PR DESCRIPTION
# What does this PR do ?

  Adds a SUMMARY.md to each test config folder (llm_finetune/, vlm_finetune/) with a quick-reference table of all nightly recipes and their CI
  properties: SLURM time, node count, checkpoint robustness, and vLLM deploy/smoke enablement.

  Makes it easier to audit nightly coverage and spot recipes missing robustness or vLLM testing without reading individual YAMLs.

  - llm_finetune/SUMMARY.md -- 53 recipes (31 SFT + 22 PEFT)
  - vlm_finetune/SUMMARY.md -- 14 recipes (12 SFT + 2 PEFT)

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
