### PR TITLE
ci: RC6 timeout fixes for release test recipes

### DIFF
--- a/examples/llm_finetune/llama3_3/custom_llama3_3_70b_instruct_peft_benchmark_2nodes.yaml
+++ b/examples/llm_finetune/llama3_3/custom_llama3_3_70b_instruct_peft_benchmark_2nodes.yaml
@@ -93,3 +93,5 @@ lr_scheduler:
 
 ci:
   recipe_owner: ZhiyuLi-Nvidia
+  time: "00:15:00"
+  nodes: 2

--- a/examples/llm_finetune/minimax_m2/minimax_m2.5_hellaswag_pp.yaml
+++ b/examples/llm_finetune/minimax_m2/minimax_m2.5_hellaswag_pp.yaml
@@ -117,5 +117,5 @@ optimizer:
 
 ci:
   recipe_owner: hemildesai
-  time: "00:20:00"
+  time: "00:25:00"
   nodes: 8

--- a/examples/llm_finetune/phi/phi_4_squad_tp2_peft.yaml
+++ b/examples/llm_finetune/phi/phi_4_squad_tp2_peft.yaml
@@ -103,3 +103,4 @@ optimizer:
 
 ci:
   recipe_owner: akoumpa
+  time: "00:15:00"

--- a/examples/vlm_finetune/qwen3/qwen3_vl_moe_30b_neat_packing.yaml
+++ b/examples/vlm_finetune/qwen3/qwen3_vl_moe_30b_neat_packing.yaml
@@ -109,3 +109,4 @@ freeze_config:
 
 ci:
   recipe_owner: HuiyingLi
+  time: "00:15:00"

--- a/tests/ci_tests/configs/llm_finetune/SUMMARY.md
+++ b/tests/ci_tests/configs/llm_finetune/SUMMARY.md
@@ -62,7 +62,7 @@ The nightly scope uses only the recipes listed in [nightly_recipes.yml](nightly_
 | phi_2_squad_peft | 00:10:00 | 1 | - | - | - |
 | phi_2_squad_tp2_peft | 00:10:00 | 1 | - | - | - |
 | phi_4_squad_peft | 00:35:00 | 1 | ✅ | ✅ | - |
-| phi_4_squad_tp2_peft | 00:10:00 | 1 | - | - | - |
+| phi_4_squad_tp2_peft | 00:15:00 | 1 | - | - | - |
 | qwen2_5_7b_peft_benchmark | 00:10:00 | 1 | - | - | - |
 | qwen2_5_7b_squad_peft | 00:30:00 | 1 | ✅ | ✅ | - |
 | qwen3_moe_30b_lora | 00:15:00 | 1 | ✅ | - | - |


### PR DESCRIPTION
# What does this PR do ?

  Update ci: time allocations for 4 recipes that timed out during RC6 release testing.

  - custom_llama3_3_70b_instruct_peft_benchmark_2nodes: added time: "00:15:00", nodes: 2
  - minimax_m2.5_hellaswag_pp: 00:20:00 -> 00:25:00
  - phi_4_squad_tp2_peft: added time: "00:15:00"
  - qwen3_vl_moe_30b_neat_packing: added time: "00:15:00"

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
