### PR TITLE
fix: Restrict auto-discovery scopes in generate_ci_tests.py

### DIFF
--- a/tests/ci_tests/utils/generate_ci_tests.py
+++ b/tests/ci_tests/utils/generate_ci_tests.py
@@ -56,14 +56,24 @@ def slurm_time_multiplier(time: str, multiplier: int):
     return updated_time
 
 
+# Scopes that auto-discover all configs via rglob (no recipe list needed).
+# All other scope/folder combinations read from {scope}_recipes.yml.
+AUTO_DISCOVER_SCOPES = {
+    "release": ["llm_finetune", "vlm_finetune"],
+    "performance": ["llm_benchmark", "vlm_benchmark"],
+}
+
+
 def detect_yml_configurations(automodel_dir: str, scope: str, test_folder: str):
     """
-    Detect recipe YAML configurations to include in the CI pipeline. Nightly scope reads from
-    a scope-specific recipe list. Release scope collects all YAML configurations within the test_folder.
+    Detect recipe YAML configurations to include in the CI pipeline.
+
+    Auto-discovery scopes (defined in AUTO_DISCOVER_SCOPES) collect all YAML files
+    via rglob. All other scopes read from a scope-specific recipe list.
 
     Args:
         automodel_dir: Path to the Automodel directory
-        scope: Scope of the testing (nightly, release)
+        scope: Scope of the testing (nightly, release, convergence, performance)
         test_folder: Name of the test folder under Automodel/examples
 
     Returns:
@@ -72,8 +82,8 @@ def detect_yml_configurations(automodel_dir: str, scope: str, test_folder: str):
     yml_configs = []
     search_path = f"{automodel_dir}/examples/{test_folder}"
 
-    # Check scope
-    if scope in ("release", "perf"):
+    auto_folders = AUTO_DISCOVER_SCOPES.get(scope, [])
+    if test_folder in auto_folders:
         for f in Path(f"{search_path}").rglob("*.yaml"):
             relative_path = f.relative_to(automodel_dir)
             yml_configs.append(relative_path)


### PR DESCRIPTION
# What does this PR do ?

  The performance scope was triggering release-level auto-discovery (rglob) for all test folders, causing finetune
  recipes to run when only benchmarks were intended.

  Introduces an explicit AUTO_DISCOVER_SCOPES mapping that defines which scope/folder combinations use rglob vs
  recipe lists:
  - release: llm_finetune, vlm_finetune
  - performance: llm_benchmark, vlm_benchmark

  All other combinations fall through to scope-specific recipe lists (e.g., nightly_recipes.yml).

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
