### PR TITLE
fix: enable dequantization for ministral3 and dataset limit 

### DIFF
--- a/examples/llm_finetune/llama3_2/llama_3_2_3b_instruct_squad.yaml
+++ b/examples/llm_finetune/llama3_2/llama_3_2_3b_instruct_squad.yaml
@@ -85,7 +85,7 @@ validation_dataset:
 validation_dataloader:
   _target_: torchdata.stateful_dataloader.StatefulDataLoader
   collate_fn: nemo_automodel.components.datasets.utils.default_collater
-  
+
 optimizer:
   _target_: torch.optim.Adam
   betas: [0.9, 0.999]
@@ -103,8 +103,8 @@ ci:
     tokenizer_name: meta-llama/Llama-3.2-3B-Instruct
     cross_tp_size: 2
     cross_tp_kl_threshold: 5e-3
-    dataset.num_samples_limit: 500
-    validation_dataset.num_samples_limit: 500
+    dataset.limit_dataset_samples: 500
+    validation_dataset.limit_dataset_samples: 500
 
 # Uncomment and configure for W&B logging
 # wandb:

--- a/examples/llm_finetune/llama3_2/llama_3_2_3b_instruct_squad_peft.yaml
+++ b/examples/llm_finetune/llama3_2/llama_3_2_3b_instruct_squad_peft.yaml
@@ -109,8 +109,8 @@ ci:
     tokenizer_name: meta-llama/Llama-3.2-3B-Instruct
     cross_tp_size: 2
     cross_tp_kl_threshold: 5e-3
-    dataset.num_samples_limit: 500
-    validation_dataset.num_samples_limit: 500
+    dataset.limit_dataset_samples: 500
+    validation_dataset.limit_dataset_samples: 500
 
 # Uncomment and configure for W&B logging
 # wandb:

--- a/examples/llm_finetune/mistral/ministral3_3b_squad.yaml
+++ b/examples/llm_finetune/mistral/ministral3_3b_squad.yaml
@@ -39,6 +39,9 @@ rng:
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: mistralai/Ministral-3-3B-Instruct-2512
+  quantization_config:
+    _target_: transformers.FineGrainedFP8Config
+    dequantize: true
 
 checkpoint:
   enabled: true

--- a/examples/llm_finetune/mistral/ministral3_3b_squad_peft.yaml
+++ b/examples/llm_finetune/mistral/ministral3_3b_squad_peft.yaml
@@ -40,6 +40,9 @@ model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: mistralai/Ministral-3-3B-Instruct-2512
   torch_dtype: bf16
+  quantization_config:
+    _target_: transformers.FineGrainedFP8Config
+    dequantize: true
 
 checkpoint:
   enabled: true

--- a/examples/llm_finetune/mistral/ministral3_3b_squad_peft.yaml
+++ b/examples/llm_finetune/mistral/ministral3_3b_squad_peft.yaml
@@ -49,12 +49,12 @@ checkpoint:
 
 peft:
   _target_: nemo_automodel.components._peft.lora.PeftConfig
-  match_all_linear: True
   dim: 8
-  alpha: 32
-  use_triton: True
-  # dtype needs a fix to resolve to type instead of string
-  # lora_dtype: torch.bfloat16
+  alpha: 16
+  use_triton: false
+  exclude_modules:
+    - "*vision_tower*"
+    - "*multi_modal_projector*"
 
 # torch.compile configuration
 compile:

--- a/examples/llm_finetune/phi/phi_4_squad_tp2_peft.yaml
+++ b/examples/llm_finetune/phi/phi_4_squad_tp2_peft.yaml
@@ -103,3 +103,4 @@ optimizer:
 
 ci:
   recipe_owner: akoumpa
+  time: "00:15:00"


### PR DESCRIPTION
# What does this PR do ?

Enables dequantization for ministral3 (base model uses fp8). 

Error:
```
rank4]:   File "/opt/Automodel/examples/llm_finetune/finetune.py", line 44, in <module>
[rank4]:     main()
[rank4]:   File "/opt/Automodel/examples/llm_finetune/finetune.py", line 39, in main
[rank4]:     recipe.setup()
[rank4]:   File "/opt/Automodel/nemo_automodel/recipes/llm/train_ft.py", line 1018, in setup
[rank4]:     model = build_model(
[rank4]:             ^^^^^^^^^^^^
[rank4]:   File "/opt/Automodel/nemo_automodel/recipes/llm/train_ft.py", line 247, in build_model
[rank4]:     model = cfg_model.instantiate(**kwargs)
[rank4]:             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank4]:   File "/opt/Automodel/nemo_automodel/components/config/loader.py", line 492, in instantiate
[rank4]:     raise e
[rank4]:   File "/opt/Automodel/nemo_automodel/components/config/loader.py", line 473, in instantiate
[rank4]:     return func(*args, **config_kwargs)
[rank4]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank4]:   File "/opt/Automodel/nemo_automodel/_transformers/auto_model.py", line 576, in from_pretrained
[rank4]:     return cls._build_model(
[rank4]:            ^^^^^^^^^^^^^^^^^
[rank4]:   File "/opt/Automodel/nemo_automodel/_transformers/auto_model.py", line 433, in _build_model
[rank4]:     model = apply_model_infrastructure(
[rank4]:             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank4]:   File "/opt/Automodel/nemo_automodel/_transformers/infrastructure.py", line 475, in apply_model_infrastructure
[rank4]:     model = _shard_ep_fsdp(model, model_wrapper, parallelize_fn, mesh)
[rank4]:             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank4]:   File "/opt/Automodel/nemo_automodel/_transformers/infrastructure.py", line 133, in _shard_ep_fsdp
[rank4]:     model = model_wrapper.parallelize(model)
[rank4]:             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank4]:   File "/opt/Automodel/nemo_automodel/components/distributed/fsdp2.py", line 127, in parallelize
[rank4]:     fsdp2_strategy_parallelize(
[rank4]:   File "/opt/Automodel/nemo_automodel/components/distributed/parallelizer.py", line 1461, in fsdp2_strategy_parallelize
[rank4]:     return strategy.parallelize(
[rank4]:            ^^^^^^^^^^^^^^^^^^^^^
[rank4]:   File "/opt/Automodel/nemo_automodel/components/distributed/parallelizer.py", line 279, in parallelize
[rank4]:     apply_fsdp2_sharding_recursively(
[rank4]:   File "/opt/Automodel/nemo_automodel/components/distributed/parallelizer.py", line 817, in apply_fsdp2_sharding_recursively
[rank4]:     apply_fsdp2_sharding_recursively(
[rank4]:   File "/opt/Automodel/nemo_automodel/components/distributed/parallelizer.py", line 817, in apply_fsdp2_sharding_recursively
[rank4]:     apply_fsdp2_sharding_recursively(
[rank4]:   File "/opt/Automodel/nemo_automodel/components/distributed/parallelizer.py", line 817, in apply_fsdp2_sharding_recursively
[rank4]:     apply_fsdp2_sharding_recursively(
[rank4]:   File "/opt/Automodel/nemo_automodel/components/distributed/parallelizer.py", line 788, in apply_fsdp2_sharding_recursively
[rank4]:     fully_shard(
[rank4]:   File "/usr/local/lib/python3.12/dist-packages/torch/distributed/_composable/contract.py", line 156, in wrapper
[rank4]:     updated = func(inp_module, *args, **kwargs)
[rank4]:               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank4]:   File "/usr/local/lib/python3.12/dist-packages/torch/distributed/fsdp/_fully_shard/_fully_shard.py", line 222, in fully_shard
[rank4]:     params, buffers = _get_managed_states(managed_modules, ignored_params)
[rank4]:                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank4]:   File "/usr/local/lib/python3.12/dist-packages/torch/distributed/fsdp/_fully_shard/_fsdp_init.py", line 200, in _get_managed_states
[rank4]:     _verify_managed_param(name, param)
[rank4]:   File "/usr/local/lib/python3.12/dist-packages/torch/distributed/fsdp/_fully_shard/_fsdp_init.py", line 176, in _verify_managed_param
[rank4]:     raise ValueError(
[rank4]: ValueError: fully_shard doesn't support scalar parameters. Change weight_scale_inv to a 1D tensor with numel equal to 1.
```
# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
