### PR TITLE
fix: Set CUDA arch list for UCCL EP build to SM90+

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -119,7 +119,10 @@ RUN if [ $INSTALL_BITSANDBYTES = "True" ]; then \
 COPY scripts/setup_uccl_ep.sh /opt/setup_uccl_ep.sh
 ARG INSTALL_UCCL_EP=False
 RUN if [ "$INSTALL_UCCL_EP" = "True" ]; then \
-    bash /opt/setup_uccl_ep.sh --no-efa && \
+    apt-get update -qq && \
+    apt-get install -y --no-install-recommends libibverbs-dev librdmacm-dev && \
+    rm -rf /var/lib/apt/lists/* && \
+    bash /opt/setup_uccl_ep.sh --no-efa --skip-apt && \
     rm -f /opt/setup_uccl_ep.sh; \
     fi
 

--- a/scripts/setup_uccl_ep.sh
+++ b/scripts/setup_uccl_ep.sh
@@ -138,7 +138,7 @@ if [[ "$NO_EFA" -eq 1 ]]; then
 fi
 
 # Install into the active Python environment.
-${BUILD_EXTRA_ARGS:+env $BUILD_EXTRA_ARGS} python setup.py install
+TORCH_CUDA_ARCH_LIST="9.0 10.0 12.0" ${BUILD_EXTRA_ARGS:+env $BUILD_EXTRA_ARGS} python setup.py install
 
 popd > /dev/null
 


### PR DESCRIPTION
# What does this PR do ?

  UCCL EP build fails with PTX errors because setup.py compiles for all CUDA architectures including SM75, but the
  code uses SM90+ features (cp.async.bulk, .bulk_group). Sets TORCH_CUDA_ARCH_LIST="9.0 10.0 12.0" to match the
  DeepEP build configuration.

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
