### PR TITLE
ci: Increase benchmark timeout for GLM and Qwen3.5 MoE LoRA recipes

### DIFF
--- a/examples/llm_benchmark/glm/glm_4.7_flash_lora.yaml
+++ b/examples/llm_benchmark/glm/glm_4.7_flash_lora.yaml
@@ -112,5 +112,5 @@ optimizer:
   weight_decay: 0
 
 ci:
-  time: "00:15:00"
+  time: "00:25:00"
   nodes: 1

--- a/examples/llm_benchmark/glm/glm_4.7_flash_te_deepep_lora.yaml
+++ b/examples/llm_benchmark/glm/glm_4.7_flash_te_deepep_lora.yaml
@@ -112,5 +112,5 @@ optimizer:
   weight_decay: 0
 
 ci:
-  time: "00:15:00"
+  time: "00:25:00"
   nodes: 1

--- a/examples/llm_benchmark/qwen/qwen3.5_moe_lora.yaml
+++ b/examples/llm_benchmark/qwen/qwen3.5_moe_lora.yaml
@@ -111,5 +111,5 @@ optimizer:
   weight_decay: 0
 
 ci:
-  time: "00:15:00"
+  time: "00:25:00"
   nodes: 1

--- a/examples/llm_benchmark/qwen/qwen3.5_moe_te_deepep_lora.yaml
+++ b/examples/llm_benchmark/qwen/qwen3.5_moe_te_deepep_lora.yaml
@@ -111,5 +111,5 @@ optimizer:
   weight_decay: 0
 
 ci:
-  time: "00:15:00"
+  time: "00:25:00"
   nodes: 1


### PR DESCRIPTION
# What does this PR do ?

  - Bump CI time from 15m to 25m for 4 benchmark recipes that are timing out
    - `glm_4.7_flash_lora`
    - `glm_4.7_flash_te_deepep_lora`
    - `qwen3.5_moe_lora`
    - `qwen3.5_moe_te_deepep_lora`
  - Jobs were completing 14-19 of 30 steps before hitting the 15m limit (~27-29s/iteration + setup overhead)

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
