### PR TITLE
fix: stop resolve_yaml_env_vars from scanning runtime data in instantiate()

### DIFF
--- a/nemo_automodel/components/config/loader.py
+++ b/nemo_automodel/components/config/loader.py
@@ -461,11 +461,14 @@ class ConfigNode:
             else:
                 config_kwargs[k] = self._instantiate_value(v)
 
-        # Override/add with passed kwargs
-        config_kwargs.update(kwargs)
-        # Resolve env interpolations at the last moment, so printing/saving the config
-        # does not leak secrets (e.g., `${oc.env:HF_TOKEN}` remains in YAML output).
+        # Resolve env interpolations on config-derived kwargs only, before merging
+        # runtime arguments (e.g. `examples`, `processor`).  Doing it after the
+        # update() would cause resolve_yaml_env_vars to scan actual data content,
+        # which can contain arbitrary strings like "$P" and raise spurious KeyErrors.
         config_kwargs = resolve_yaml_env_vars(config_kwargs)
+
+        # Override/add with passed kwargs (runtime data — must NOT be env-var-resolved)
+        config_kwargs.update(kwargs)
 
         import traceback
 


### PR DESCRIPTION
## Problem

`ConfigLoader.instantiate()` calls `resolve_yaml_env_vars(config_kwargs)`
**after** merging runtime kwargs (e.g. `examples=<batch>`, `processor=<obj>`):

```python
config_kwargs.update(kwargs)                      # runtime data merged in
config_kwargs = resolve_yaml_env_vars(config_kwargs)  # scans ALL values ← bug
```

This means the function walks over actual training-sample text looking for
`$VAR` patterns.  Any dataset containing a bare `$<letter>` string (source
code, prices, math, Japanese text, etc.) raises a spurious `KeyError`:

```
KeyError: "Environment variable 'P' is not set (required by '$P')."
```

The issue is triggered through the `collate_fn` path in `finetune.py`:

```python
collate_fn = lambda examples: collate_cfg.instantiate(examples=examples, processor=processor)
```

Confirmed on two real datasets with 36 and 2 affected rows respectively
(patterns like `kawaii$$$kawaii`, `uni$ys`).

## Fix

Move `resolve_yaml_env_vars` to run on **config-derived kwargs only**,
before the runtime kwargs are merged:

```python
config_kwargs = resolve_yaml_env_vars(config_kwargs)  # config only
config_kwargs.update(kwargs)                           # runtime data added after
```

Runtime arguments (`examples`, `processor`, …) are never environment-variable
interpolations and must not be scanned.