### PR TITLE
fix: reduce packed_sequence_size for cohere FP8 config to prevent OOM

### DIFF
--- a/examples/llm_finetune/cohere/cohere_command_r_7b_hellaswag_fp8.yaml
+++ b/examples/llm_finetune/cohere/cohere_command_r_7b_hellaswag_fp8.yaml
@@ -81,7 +81,7 @@ dataset:
 
 packed_sequence:
   # Set packed_sequence_size > 0 to run with packed sequences
-  packed_sequence_size: 8192
+  packed_sequence_size: 4096
 
 dataloader:
   _target_: torchdata.stateful_dataloader.StatefulDataLoader


### PR DESCRIPTION
## Summary
- Reduces `packed_sequence_size` from 8192 to 4096 in `cohere_command_r_7b_hellaswag_fp8.yaml`
- The Cohere Command R 7B model has a 256K token vocabulary (2-8x larger than typical 7B models), causing the backward pass to OOM on 8x H100 80GB GPUs
- Consistent with other memory-constrained FP8 configs (gemma_2_9b_it, phi_4) which already use 4096

## Test plan
- [x] Reproduced OOM with original config (`packed_sequence_size: 8192`) — all 8 GPUs hit `torch.OutOfMemoryError` trying to allocate 7.81 GiB with 74.02 GiB already used
- [x] Verified fix with `packed_sequence_size: 4096` — 100 steps completed successfully at 47.69 GiB peak memory per GPU (~20 GiB headroom)
- [x] Training metrics healthy: loss converging (~2.3 → ~1.9), stable grad norms, ~35K tokens/sec throughput

Fixes https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/296894111

🤖 Generated with [Claude Code](https://claude.com/claude-code)