### PR TITLE
fix: Align benchmark TEST_LEVEL check with generate_ci_tests scope

### DIFF
--- a/tests/ci_tests/scripts/finetune_launcher.sh
+++ b/tests/ci_tests/scripts/finetune_launcher.sh
@@ -34,7 +34,7 @@ if [ "$TEST_LEVEL" = "convergence" ]; then
          --wandb.entity Nemo-automodel \
          --wandb.name ${TEST_NAME} \
          --wandb.dir /tmp/wandb/"
-elif [ "$TEST_LEVEL" = "perf" ]; then
+elif [ "$TEST_LEVEL" = "performance" ]; then
   CONFIG="${CONFIG}"
 else
   CONFIG="${CONFIG} \
@@ -88,7 +88,7 @@ echo "{\"test\":\"${TEST_NAME}\",\"phase\":\"finetune\",\"seconds\":${FINETUNE_E
 echo "[timing] Finetune completed in ${FINETUNE_ELAPSED}s"
 
 # Collect benchmark artifact for performance tests
-if [ "$TEST_LEVEL" = "perf" ]; then
+if [ "$TEST_LEVEL" = "performance" ]; then
   echo "[benchmark] Collecting benchmark artifact..."
   python3 /opt/Automodel/tests/ci_tests/scripts/collect_benchmark_artifact.py \
     --config /opt/Automodel/${CONFIG_PATH} \


### PR DESCRIPTION
# What does this PR do ?

  - Fix finetune_launcher.sh to check TEST_LEVEL = "performance" instead of "perf", matching the scope string
  produced by generate_ci_tests.py since #1805
  - Without this fix, benchmark jobs fall through to the generic else branch which overrides recipe-defined
  max_steps (typically 30) with 100, causing jobs to run ~3.3x longer than intended
  - Also fixes benchmark artifact collection, which was similarly gated on the stale "perf" string

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
