### PR TITLE
fix: Skip snapshot_download when HF_HUB_OFFLINE=1

### DIFF
--- a/nemo_automodel/_transformers/model_init.py
+++ b/nemo_automodel/_transformers/model_init.py
@@ -228,6 +228,12 @@ def get_is_hf_model(config, force_hf):
 
 def _download_model_weights(hf_config, pretrained_model_name_or_path):
     if not os.path.isdir(pretrained_model_name_or_path):
+        if os.environ.get("HF_HUB_OFFLINE", "0") == "1":
+            logger.info(
+                "HF_HUB_OFFLINE=1: skipping weight download for %s (using cached weights)",
+                pretrained_model_name_or_path,
+            )
+            return
         num_nodes = (get_world_size_safe() % get_local_world_size_preinit()) + 1  # 1-indexed
         if num_nodes > 1:
             logger.info(

--- a/nemo_automodel/_transformers/tokenization/tokenization_mistral_common.py
+++ b/nemo_automodel/_transformers/tokenization/tokenization_mistral_common.py
@@ -1942,9 +1942,7 @@ class MistralCommonBackend(PreTrainedTokenizerBase):
         if not os.path.isdir(pretrained_model_name_or_path) and os.environ.get("HF_HUB_OFFLINE", "0") == "1":
             from huggingface_hub import snapshot_download
 
-            pretrained_model_name_or_path = snapshot_download(
-                pretrained_model_name_or_path, local_files_only=True
-            )
+            pretrained_model_name_or_path = snapshot_download(pretrained_model_name_or_path, local_files_only=True)
 
         if not os.path.isdir(pretrained_model_name_or_path):
             tokenizer_path = download_tokenizer_from_hf_hub(

--- a/nemo_automodel/_transformers/tokenization/tokenization_mistral_common.py
+++ b/nemo_automodel/_transformers/tokenization/tokenization_mistral_common.py
@@ -1938,6 +1938,14 @@ class MistralCommonBackend(PreTrainedTokenizerBase):
 
         mode = cls._get_validation_mode(mode)
 
+        # Resolve hub ID to cached snapshot directory when offline
+        if not os.path.isdir(pretrained_model_name_or_path) and os.environ.get("HF_HUB_OFFLINE", "0") == "1":
+            from huggingface_hub import snapshot_download
+
+            pretrained_model_name_or_path = snapshot_download(
+                pretrained_model_name_or_path, local_files_only=True
+            )
+
         if not os.path.isdir(pretrained_model_name_or_path):
             tokenizer_path = download_tokenizer_from_hf_hub(
                 repo_id=pretrained_model_name_or_path,


### PR DESCRIPTION
# What does this PR do ?

  - _download_model_weights calls snapshot_download() for hub IDs, which internally calls list_repo_tree() -- an HTTP
  request blocked by HF_HUB_OFFLINE=1
  - Adds early return when offline mode is enabled, since weights must already be in the HF cache
  - Fixes nightly CI failures for all custom models (e.g. Devstral) loaded via hub ID with HF_HUB_OFFLINE=1

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
