### PR TITLE
fix: gpt_oss_20b_single_gpu_peft CI crash with nproc_per_node override

### DIFF
--- a/examples/llm_finetune/gpt_oss/gpt_oss_20b_single_gpu_peft.yaml
+++ b/examples/llm_finetune/gpt_oss/gpt_oss_20b_single_gpu_peft.yaml
@@ -110,3 +110,4 @@ optimizer:
 
 ci:
   recipe_owner: adil-a
+  nproc_per_node: 1

--- a/nemo_automodel/components/models/gpt_oss/state_dict_adapter.py
+++ b/nemo_automodel/components/models/gpt_oss/state_dict_adapter.py
@@ -181,17 +181,18 @@ class GPTOSSStateDictAdapter(StateDictAdapter):
         out = out.transpose(1, 2).contiguous()
         # Restore desired DTensor sharding: shard experts (dim 0) by 'ep' and hidden dim (dim 2) by 'ep_shard'.
         if isinstance(out, torch.distributed.tensor.DTensor):
-            placements = []
             mesh_dim_names = out.device_mesh.mesh_dim_names
-            for dim_name in mesh_dim_names:
-                if dim_name == "ep":
-                    placements.append(torch.distributed.tensor.Shard(0))
-                elif dim_name == "ep_shard":
-                    placements.append(torch.distributed.tensor.Shard(2))
-                else:
-                    raise ValueError(f"Unexpected dimension name: {dim_name}")
-            if placements != out.placements:
-                out = out.redistribute(placements=tuple(placements))
+            if "ep" in mesh_dim_names or "ep_shard" in mesh_dim_names:
+                placements = []
+                for dim_name in mesh_dim_names:
+                    if dim_name == "ep":
+                        placements.append(torch.distributed.tensor.Shard(0))
+                    elif dim_name == "ep_shard":
+                        placements.append(torch.distributed.tensor.Shard(2))
+                    else:
+                        placements.append(torch.distributed.tensor.Replicate())
+                if placements != out.placements:
+                    out = out.redistribute(placements=tuple(placements))
         return out
 
     def to_hf(

--- a/tests/ci_tests/scripts/finetune_launcher.sh
+++ b/tests/ci_tests/scripts/finetune_launcher.sh
@@ -43,6 +43,9 @@ else
         --step_scheduler.val_every_steps 100"
 fi
 
+# Per-config nproc override (set via ci.nproc_per_node in recipe YAML)
+NPROC_PER_NODE=${CONFIG_NPROC_PER_NODE:-$NPROC_PER_NODE}
+
 # Command to execute, defaults to torchrun
 CMD="torchrun --nproc-per-node=${NPROC_PER_NODE} \
               --nnodes=${TEST_NODE_COUNT} \

--- a/tests/ci_tests/utils/generate_ci_tests.py
+++ b/tests/ci_tests/utils/generate_ci_tests.py
@@ -127,6 +127,7 @@ def generate_job(config: str, config_override: Dict[str, Any], scope: str, test_
         'node_multiplier': 'NODE_MULTIPLIER',
         'local_batch_size': 'LOCAL_BATCH_SIZE',
         'recipe_owner': 'RECIPE_OWNER',
+        'nproc_per_node': 'CONFIG_NPROC_PER_NODE',
     }
     for ci_key, ci_var in ci_key_map.items():
         if ci_key in ci_config:


### PR DESCRIPTION
## Summary
- Adds `ci.nproc_per_node` support so per-recipe GPU count overrides work in CI (from PR #1712 pattern)
- Sets `nproc_per_node: 1` for `gpt_oss_20b_single_gpu_peft` — this recipe targets DGX Spark (1 GPU) but CI was launching it with 8 GPUs
- Fixes `ValueError: Unexpected dimension name: dp_replicate` in `state_dict_adapter.py` by skipping EP redistribution when no EP dims are in the DTensor mesh (defensive fix for non-EP configs)

## Test plan
- [x] Reproduced original crash: `ValueError: Unexpected dimension name: dp_replicate` on 8 GPUs
- [x] Verified fix on 1 GPU: 100 steps complete, loss 4.90 → 2.25, 61.7 GiB peak memory
- [x] `CONFIG_NPROC_PER_NODE` override plumbed through `generate_ci_tests.py` → CI env var → `finetune_launcher.sh`

Fixes https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/297674245

🤖 Generated with [Claude Code](https://claude.com/claude-code)