### PR TITLE
feat: add extract_submodel parameter to build_encoder_backbone

### DIFF
--- a/nemo_automodel/_transformers/retrieval.py
+++ b/nemo_automodel/_transformers/retrieval.py
@@ -16,6 +16,7 @@
 
 import inspect
 import os
+from copy import deepcopy
 from typing import Optional
 
 import torch
@@ -28,6 +29,141 @@ from nemo_automodel._transformers.registry import ModelRegistry
 from nemo_automodel.components.models.common.bidirectional import EncoderStateDictAdapter
 
 logger = logging.get_logger(__name__)
+
+_EXTRACTED_CONFIG_KWARGS = ("num_labels", "id2label", "label2id", "problem_type", "finetuning_task", "temperature")
+
+
+def _load_hf_encoder_backbone(
+    model_name_or_path: str,
+    task: str,
+    trust_remote_code: bool,
+    **hf_kwargs,
+) -> PreTrainedModel:
+    """Load an encoder backbone with HuggingFace Auto classes."""
+    if task == "score":
+        return AutoModelForSequenceClassification.from_pretrained(
+            model_name_or_path, trust_remote_code=trust_remote_code, **hf_kwargs
+        )
+    return AutoModel.from_pretrained(model_name_or_path, trust_remote_code=trust_remote_code, **hf_kwargs)
+
+
+def _load_hf_parent_for_extraction(
+    model_name_or_path: str,
+    trust_remote_code: bool,
+    **hf_kwargs,
+) -> PreTrainedModel:
+    """Load the parent model that owns the requested submodel path."""
+    load_kwargs = {k: v for k, v in hf_kwargs.items() if k not in _EXTRACTED_CONFIG_KWARGS}
+    return AutoModel.from_pretrained(model_name_or_path, trust_remote_code=trust_remote_code, **load_kwargs)
+
+
+def _extract_submodel(model: nn.Module, extract_submodel: str) -> PreTrainedModel:
+    """Extract a nested submodel from a loaded model using a dotted attribute path."""
+    extracted_model = model
+    for attr in extract_submodel.split("."):
+        extracted_model = getattr(extracted_model, attr)
+    if not hasattr(extracted_model, "config"):
+        raise ValueError(
+            f"Extracted submodel at '{extract_submodel}' has no .config attribute. "
+            f"The submodel must be a PreTrainedModel for save/reload to work. "
+            f"Got {type(extracted_model).__name__}."
+        )
+    return extracted_model
+
+
+def _get_supported_backbone_class(model_type: str, task: str, *, strict_task: bool = True) -> type[nn.Module] | None:
+    """Return the registered retrieval backbone class for a model type and task."""
+    task_map = SUPPORTED_BACKBONES.get(model_type.lower())
+    if task_map is None:
+        return None
+
+    arch_name = task_map.get(task)
+    if arch_name is None:
+        if not strict_task:
+            return None
+        raise ValueError(
+            f"Unsupported task '{task}' for model type '{model_type}'. Available tasks: {', '.join(task_map)}."
+        )
+
+    if arch_name not in ModelRegistry.model_arch_name_to_cls:
+        raise ValueError(f"Model class '{arch_name}' not found in ModelRegistry.")
+
+    logger.info(f"Using {arch_name} from registry")
+    return ModelRegistry.model_arch_name_to_cls[arch_name]
+
+
+def _convert_config_to_supported_backbone_config(config, config_class: type):
+    """Convert a source text config into the registered retrieval config class."""
+    if isinstance(config, config_class):
+        supported_config = config
+    else:
+        config_dict = config.to_dict()
+        config_dict.pop("model_type", None)
+        supported_config = config_class(**config_dict)
+
+    attn_implementation = getattr(config, "_attn_implementation", None)
+    if attn_implementation is not None:
+        supported_config._attn_implementation = attn_implementation
+    return supported_config
+
+
+def _apply_extracted_config_kwargs(config, pooling: Optional[str], hf_kwargs: dict) -> None:
+    """Apply retrieval/classification config kwargs after extracting a text backbone."""
+    if pooling is not None:
+        config.pooling = pooling
+    for key in _EXTRACTED_CONFIG_KWARGS:
+        if key in hf_kwargs:
+            setattr(config, key, hf_kwargs[key])
+
+
+def _move_to_extracted_dtype(model: nn.Module, extracted_model: nn.Module) -> nn.Module:
+    """Move a newly-built model to the dtype used by the extracted model."""
+    for parameter in extracted_model.parameters():
+        return model.to(dtype=parameter.dtype)
+    for buffer in extracted_model.buffers():
+        return model.to(dtype=buffer.dtype)
+    return model
+
+
+def _load_extracted_state_dict(model: nn.Module, extracted_model: nn.Module, task: str) -> None:
+    """Load extracted text weights into a task-specific retrieval model."""
+    target_model = model
+    if task == "score":
+        target_model = getattr(model, "base_model", None)
+        if target_model is None:
+            target_model = getattr(model, "model", None)
+        if target_model is None:
+            raise ValueError(f"Cannot load extracted text weights into {type(model).__name__}; no base model found.")
+    target_model.load_state_dict(extracted_model.state_dict())
+
+
+def _build_backbone_from_extracted_submodel(
+    extracted_model: PreTrainedModel,
+    task: str,
+    pooling: Optional[str],
+    **hf_kwargs,
+) -> PreTrainedModel:
+    """Build a task-specific retrieval backbone from an extracted text submodel."""
+    model_type = getattr(extracted_model.config, "model_type", "")
+    backbone_class = _get_supported_backbone_class(model_type, task, strict_task=False)
+    if backbone_class is None:
+        if task != "score":
+            return extracted_model
+        config = deepcopy(extracted_model.config)
+        _apply_extracted_config_kwargs(config, pooling=None, hf_kwargs=hf_kwargs)
+        backbone = AutoModelForSequenceClassification.from_config(config)
+        _load_extracted_state_dict(backbone, extracted_model, task)
+        return _move_to_extracted_dtype(backbone, extracted_model)
+
+    config_class = getattr(backbone_class, "config_class", None)
+    if config_class is None or not hasattr(extracted_model.config, "to_dict"):
+        return extracted_model
+
+    config = _convert_config_to_supported_backbone_config(extracted_model.config, config_class)
+    _apply_extracted_config_kwargs(config, pooling, hf_kwargs)
+    backbone = backbone_class(config)
+    _load_extracted_state_dict(backbone, extracted_model, task)
+    return _move_to_extracted_dtype(backbone, extracted_model)
 
 
 def pool(last_hidden_states: torch.Tensor, attention_mask: torch.Tensor, pool_type: str) -> torch.Tensor:
@@ -100,15 +236,23 @@ def build_encoder_backbone(
     task: str,
     trust_remote_code: bool = False,
     pooling: Optional[str] = None,
+    extract_submodel: Optional[str] = None,
     **hf_kwargs,
 ) -> PreTrainedModel:
     """Build an encoder backbone from a pretrained checkpoint.
 
-    For model types listed in :data:`SUPPORTED_BACKBONES`, resolves the
-    custom bidirectional architecture class from :class:`ModelRegistry`.
-    For all other model types, falls back to
-    ``AutoModel.from_pretrained`` (or ``AutoModelForSequenceClassification``
-    for the ``"score"`` task).
+    When ``extract_submodel`` is set, loads the parent model with HuggingFace
+    Auto classes and extracts the dotted path. For supported extracted text
+    backbones, it then builds the registered retrieval class for the requested
+    task (bidirectional base model for ``"embedding"``, sequence-classification
+    wrapper for ``"score"``). For unsupported extracted text backbones, it
+    returns the extracted model for ``"embedding"`` and wraps it with
+    ``AutoModelForSequenceClassification`` for ``"score"``.
+
+    Without ``extract_submodel``, model types listed in
+    :data:`SUPPORTED_BACKBONES` resolve to custom bidirectional classes from
+    :class:`ModelRegistry`; all other model types fall back to HuggingFace Auto
+    classes.
 
     Args:
         model_name_or_path: Path or HuggingFace Hub identifier.
@@ -117,6 +261,8 @@ def build_encoder_backbone(
         pooling: Bi-encoder pooling strategy for registry backbones (e.g. Llama bidirectional)
             that accept it on ``from_pretrained``. Must not be forwarded to standard HF models
             (e.g. Qwen3) loaded via ``AutoModel``; those only receive ``**hf_kwargs``.
+        extract_submodel: Dotted attribute path to extract from the loaded model
+            (e.g. ``"language_model"`` to extract the text backbone from a VLM).
         **hf_kwargs: Extra keyword arguments forwarded to ``from_pretrained``.
 
     Returns:
@@ -129,21 +275,14 @@ def build_encoder_backbone(
     config = AutoConfig.from_pretrained(model_name_or_path, trust_remote_code=trust_remote_code)
     model_type = getattr(config, "model_type", "")
 
-    task_map = SUPPORTED_BACKBONES.get(model_type.lower())
+    if extract_submodel is not None:
+        logger.info(f"Loading {model_name_or_path} with HuggingFace Auto classes to extract {extract_submodel}")
+        model = _load_hf_parent_for_extraction(model_name_or_path, trust_remote_code=trust_remote_code, **hf_kwargs)
+        extracted_model = _extract_submodel(model, extract_submodel)
+        return _build_backbone_from_extracted_submodel(extracted_model, task=task, pooling=pooling, **hf_kwargs)
 
-    if task_map is not None:
-        arch_name = task_map.get(task)
-        if arch_name is None:
-            raise ValueError(
-                f"Unsupported task '{task}' for model type '{model_type}'. Available tasks: {', '.join(task_map)}."
-            )
-
-        if arch_name not in ModelRegistry.model_arch_name_to_cls:
-            raise ValueError(f"Model class '{arch_name}' not found in ModelRegistry.")
-
-        BidirectionalModelClass = ModelRegistry.model_arch_name_to_cls[arch_name]
-        logger.info(f"Using {arch_name} from registry")
-
+    BidirectionalModelClass = _get_supported_backbone_class(model_type, task)
+    if BidirectionalModelClass is not None:
         if pooling is not None:
             hf_kwargs["pooling"] = pooling
         return BidirectionalModelClass.from_pretrained(
@@ -152,11 +291,7 @@ def build_encoder_backbone(
 
     # Fallback: use HuggingFace Auto classes for model types not in SUPPORTED_BACKBONES
     logger.info(f"Model type '{model_type}' not in SUPPORTED_BACKBONES; falling back to HuggingFace Auto classes")
-    if task == "score":
-        return AutoModelForSequenceClassification.from_pretrained(
-            model_name_or_path, trust_remote_code=trust_remote_code, **hf_kwargs
-        )
-    return AutoModel.from_pretrained(model_name_or_path, trust_remote_code=trust_remote_code, **hf_kwargs)
+    return _load_hf_encoder_backbone(model_name_or_path, task=task, trust_remote_code=trust_remote_code, **hf_kwargs)
 
 
 def save_encoder_pretrained(model: nn.Module, save_directory: str, **kwargs) -> None:

--- a/nemo_automodel/_transformers/retrieval.py
+++ b/nemo_automodel/_transformers/retrieval.py
@@ -22,6 +22,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from transformers import AutoConfig, AutoModel, AutoModelForSequenceClassification, PreTrainedModel
+from transformers.models.auto.modeling_auto import MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING
 from transformers.utils import logging
 
 from nemo_automodel._transformers.registry import ModelRegistry
@@ -72,16 +73,21 @@ def _move_to_extracted_dtype(model: nn.Module, extracted_model: nn.Module) -> nn
     return model
 
 
-def _load_extracted_state_dict(model: nn.Module, extracted_model: nn.Module, task: str) -> None:
-    """Load extracted text weights into a task-specific retrieval model."""
-    target_model = model
-    if task == "score":
-        target_model = getattr(model, "base_model", None)
-        if target_model is None:
-            target_model = getattr(model, "model", None)
-        if target_model is None:
-            raise ValueError(f"Cannot load extracted text weights into {type(model).__name__}; no base model found.")
-    target_model.load_state_dict(extracted_model.state_dict())
+def _load_from_extracted_state(
+    backbone_class: type[PreTrainedModel],
+    config,
+    extracted_model: PreTrainedModel,
+) -> PreTrainedModel:
+    """Load a target backbone from an extracted model's in-memory state dict."""
+    # Use the base HF loader because some retrieval classes override
+    # from_pretrained for path-based checkpoint loading.
+    backbone = PreTrainedModel.from_pretrained.__func__(
+        backbone_class,
+        None,
+        config=config,
+        state_dict=extracted_model.state_dict(),
+    )
+    return _move_to_extracted_dtype(backbone, extracted_model)
 
 
 def _build_backbone_from_extracted_submodel(
@@ -95,47 +101,42 @@ def _build_backbone_from_extracted_submodel(
     text_config = extracted_model.config
     model_type = getattr(text_config, "model_type", "")
     task_map = SUPPORTED_BACKBONES.get(model_type.lower())
+    has_supported_target = task_map is not None and task in task_map
 
-    if task_map is not None and task not in task_map and task != "score":
+    if task_map is not None and not has_supported_target and task != "score":
         raise ValueError(
             f"Unsupported task '{task}' for model type '{model_type}'. Available tasks: {', '.join(task_map)}."
         )
 
-    if task_map is None or task not in task_map:
-        if task != "score":
-            return extracted_model
+    if task == "score" and not has_supported_target:
         config = text_config.__class__.from_dict(text_config.to_dict())
-        attn_implementation = getattr(text_config, "_attn_implementation", None)
-        if attn_implementation is not None:
-            config._attn_implementation = attn_implementation
-        if num_labels is not None:
-            config.num_labels = num_labels
-        backbone = AutoModelForSequenceClassification.from_config(config)
-        _load_extracted_state_dict(backbone, extracted_model, task)
-        return _move_to_extracted_dtype(backbone, extracted_model)
-
-    backbone_class = _get_supported_backbone_class(model_type, task)
-    config_class = getattr(backbone_class, "config_class", None)
-    if config_class is None or not hasattr(text_config, "to_dict"):
+        try:
+            backbone_class = MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING[type(config)]
+        except KeyError as exc:
+            raise ValueError(f"No HuggingFace sequence-classification model found for '{model_type}'.") from exc
+    elif not has_supported_target:
         return extracted_model
+    else:
+        backbone_class = _get_supported_backbone_class(model_type, task)
+        config_class = getattr(backbone_class, "config_class", None)
+        if config_class is None or not hasattr(text_config, "to_dict"):
+            return extracted_model
 
-    config_dict = text_config.to_dict()
-    config_dict.pop("model_type", None)
-    config = config_class(**config_dict)
+        config_dict = text_config.to_dict()
+        config_dict.pop("model_type", None)
+        config = config_class(**config_dict)
 
     attn_implementation = getattr(text_config, "_attn_implementation", None)
     if attn_implementation is not None:
         config._attn_implementation = attn_implementation
-    if pooling is not None:
+    if has_supported_target and pooling is not None:
         config.pooling = pooling
     if num_labels is not None:
         config.num_labels = num_labels
-    if temperature is not None:
+    if has_supported_target and temperature is not None:
         config.temperature = temperature
 
-    backbone = backbone_class(config)
-    _load_extracted_state_dict(backbone, extracted_model, task)
-    return _move_to_extracted_dtype(backbone, extracted_model)
+    return _load_from_extracted_state(backbone_class, config, extracted_model)
 
 
 def pool(last_hidden_states: torch.Tensor, attention_mask: torch.Tensor, pool_type: str) -> torch.Tensor:

--- a/nemo_automodel/_transformers/retrieval.py
+++ b/nemo_automodel/_transformers/retrieval.py
@@ -333,8 +333,6 @@ SUPPORTED_BACKBONES = {
     "llama_bidirec": _LLAMA_TASKS,
     "ministral3": _MINISTRAL3_BIDIREC_TASKS,
     "ministral3_bidirec": _MINISTRAL3_BIDIREC_TASKS,
-    # Mistral3-VL Hub configs use top-level model_type "mistral3" (language is nested under text_config).
-    "mistral3": _MINISTRAL3_BIDIREC_TASKS,
 }
 
 

--- a/nemo_automodel/_transformers/retrieval.py
+++ b/nemo_automodel/_transformers/retrieval.py
@@ -16,7 +16,6 @@
 
 import inspect
 import os
-from copy import deepcopy
 from typing import Optional
 
 import torch
@@ -29,32 +28,6 @@ from nemo_automodel._transformers.registry import ModelRegistry
 from nemo_automodel.components.models.common.bidirectional import EncoderStateDictAdapter
 
 logger = logging.get_logger(__name__)
-
-_EXTRACTED_CONFIG_KWARGS = ("num_labels", "id2label", "label2id", "problem_type", "finetuning_task", "temperature")
-
-
-def _load_hf_encoder_backbone(
-    model_name_or_path: str,
-    task: str,
-    trust_remote_code: bool,
-    **hf_kwargs,
-) -> PreTrainedModel:
-    """Load an encoder backbone with HuggingFace Auto classes."""
-    if task == "score":
-        return AutoModelForSequenceClassification.from_pretrained(
-            model_name_or_path, trust_remote_code=trust_remote_code, **hf_kwargs
-        )
-    return AutoModel.from_pretrained(model_name_or_path, trust_remote_code=trust_remote_code, **hf_kwargs)
-
-
-def _load_hf_parent_for_extraction(
-    model_name_or_path: str,
-    trust_remote_code: bool,
-    **hf_kwargs,
-) -> PreTrainedModel:
-    """Load the parent model that owns the requested submodel path."""
-    load_kwargs = {k: v for k, v in hf_kwargs.items() if k not in _EXTRACTED_CONFIG_KWARGS}
-    return AutoModel.from_pretrained(model_name_or_path, trust_remote_code=trust_remote_code, **load_kwargs)
 
 
 def _extract_submodel(model: nn.Module, extract_submodel: str) -> PreTrainedModel:
@@ -71,7 +44,7 @@ def _extract_submodel(model: nn.Module, extract_submodel: str) -> PreTrainedMode
     return extracted_model
 
 
-def _get_supported_backbone_class(model_type: str, task: str, *, strict_task: bool = True) -> type[nn.Module] | None:
+def _get_supported_backbone_class(model_type: str, task: str) -> type[nn.Module] | None:
     """Return the registered retrieval backbone class for a model type and task."""
     task_map = SUPPORTED_BACKBONES.get(model_type.lower())
     if task_map is None:
@@ -79,8 +52,6 @@ def _get_supported_backbone_class(model_type: str, task: str, *, strict_task: bo
 
     arch_name = task_map.get(task)
     if arch_name is None:
-        if not strict_task:
-            return None
         raise ValueError(
             f"Unsupported task '{task}' for model type '{model_type}'. Available tasks: {', '.join(task_map)}."
         )
@@ -90,30 +61,6 @@ def _get_supported_backbone_class(model_type: str, task: str, *, strict_task: bo
 
     logger.info(f"Using {arch_name} from registry")
     return ModelRegistry.model_arch_name_to_cls[arch_name]
-
-
-def _convert_config_to_supported_backbone_config(config, config_class: type):
-    """Convert a source text config into the registered retrieval config class."""
-    if isinstance(config, config_class):
-        supported_config = config
-    else:
-        config_dict = config.to_dict()
-        config_dict.pop("model_type", None)
-        supported_config = config_class(**config_dict)
-
-    attn_implementation = getattr(config, "_attn_implementation", None)
-    if attn_implementation is not None:
-        supported_config._attn_implementation = attn_implementation
-    return supported_config
-
-
-def _apply_extracted_config_kwargs(config, pooling: Optional[str], hf_kwargs: dict) -> None:
-    """Apply retrieval/classification config kwargs after extracting a text backbone."""
-    if pooling is not None:
-        config.pooling = pooling
-    for key in _EXTRACTED_CONFIG_KWARGS:
-        if key in hf_kwargs:
-            setattr(config, key, hf_kwargs[key])
 
 
 def _move_to_extracted_dtype(model: nn.Module, extracted_model: nn.Module) -> nn.Module:
@@ -141,26 +88,51 @@ def _build_backbone_from_extracted_submodel(
     extracted_model: PreTrainedModel,
     task: str,
     pooling: Optional[str],
-    **hf_kwargs,
+    num_labels: Optional[int],
+    temperature: Optional[float],
 ) -> PreTrainedModel:
     """Build a task-specific retrieval backbone from an extracted text submodel."""
-    model_type = getattr(extracted_model.config, "model_type", "")
-    backbone_class = _get_supported_backbone_class(model_type, task, strict_task=False)
-    if backbone_class is None:
+    text_config = extracted_model.config
+    model_type = getattr(text_config, "model_type", "")
+    task_map = SUPPORTED_BACKBONES.get(model_type.lower())
+
+    if task_map is not None and task not in task_map and task != "score":
+        raise ValueError(
+            f"Unsupported task '{task}' for model type '{model_type}'. Available tasks: {', '.join(task_map)}."
+        )
+
+    if task_map is None or task not in task_map:
         if task != "score":
             return extracted_model
-        config = deepcopy(extracted_model.config)
-        _apply_extracted_config_kwargs(config, pooling=None, hf_kwargs=hf_kwargs)
+        config = text_config.__class__.from_dict(text_config.to_dict())
+        attn_implementation = getattr(text_config, "_attn_implementation", None)
+        if attn_implementation is not None:
+            config._attn_implementation = attn_implementation
+        if num_labels is not None:
+            config.num_labels = num_labels
         backbone = AutoModelForSequenceClassification.from_config(config)
         _load_extracted_state_dict(backbone, extracted_model, task)
         return _move_to_extracted_dtype(backbone, extracted_model)
 
+    backbone_class = _get_supported_backbone_class(model_type, task)
     config_class = getattr(backbone_class, "config_class", None)
-    if config_class is None or not hasattr(extracted_model.config, "to_dict"):
+    if config_class is None or not hasattr(text_config, "to_dict"):
         return extracted_model
 
-    config = _convert_config_to_supported_backbone_config(extracted_model.config, config_class)
-    _apply_extracted_config_kwargs(config, pooling, hf_kwargs)
+    config_dict = text_config.to_dict()
+    config_dict.pop("model_type", None)
+    config = config_class(**config_dict)
+
+    attn_implementation = getattr(text_config, "_attn_implementation", None)
+    if attn_implementation is not None:
+        config._attn_implementation = attn_implementation
+    if pooling is not None:
+        config.pooling = pooling
+    if num_labels is not None:
+        config.num_labels = num_labels
+    if temperature is not None:
+        config.temperature = temperature
+
     backbone = backbone_class(config)
     _load_extracted_state_dict(backbone, extracted_model, task)
     return _move_to_extracted_dtype(backbone, extracted_model)
@@ -237,6 +209,8 @@ def build_encoder_backbone(
     trust_remote_code: bool = False,
     pooling: Optional[str] = None,
     extract_submodel: Optional[str] = None,
+    num_labels: Optional[int] = None,
+    temperature: Optional[float] = None,
     **hf_kwargs,
 ) -> PreTrainedModel:
     """Build an encoder backbone from a pretrained checkpoint.
@@ -263,6 +237,8 @@ def build_encoder_backbone(
             (e.g. Qwen3) loaded via ``AutoModel``; those only receive ``**hf_kwargs``.
         extract_submodel: Dotted attribute path to extract from the loaded model
             (e.g. ``"language_model"`` to extract the text backbone from a VLM).
+        num_labels: Number of labels for reranking/classification backbones.
+        temperature: Optional retrieval score temperature for custom retrieval backbones.
         **hf_kwargs: Extra keyword arguments forwarded to ``from_pretrained``.
 
     Returns:
@@ -277,21 +253,37 @@ def build_encoder_backbone(
 
     if extract_submodel is not None:
         logger.info(f"Loading {model_name_or_path} with HuggingFace Auto classes to extract {extract_submodel}")
-        model = _load_hf_parent_for_extraction(model_name_or_path, trust_remote_code=trust_remote_code, **hf_kwargs)
+        model = AutoModel.from_pretrained(model_name_or_path, trust_remote_code=trust_remote_code, **hf_kwargs)
         extracted_model = _extract_submodel(model, extract_submodel)
-        return _build_backbone_from_extracted_submodel(extracted_model, task=task, pooling=pooling, **hf_kwargs)
+        return _build_backbone_from_extracted_submodel(
+            extracted_model,
+            task=task,
+            pooling=pooling,
+            num_labels=num_labels,
+            temperature=temperature,
+        )
 
     BidirectionalModelClass = _get_supported_backbone_class(model_type, task)
     if BidirectionalModelClass is not None:
         if pooling is not None:
             hf_kwargs["pooling"] = pooling
+        if num_labels is not None:
+            hf_kwargs["num_labels"] = num_labels
+        if temperature is not None:
+            hf_kwargs["temperature"] = temperature
         return BidirectionalModelClass.from_pretrained(
             model_name_or_path, trust_remote_code=trust_remote_code, **hf_kwargs
         )
 
     # Fallback: use HuggingFace Auto classes for model types not in SUPPORTED_BACKBONES
     logger.info(f"Model type '{model_type}' not in SUPPORTED_BACKBONES; falling back to HuggingFace Auto classes")
-    return _load_hf_encoder_backbone(model_name_or_path, task=task, trust_remote_code=trust_remote_code, **hf_kwargs)
+    if task == "score" and num_labels is not None:
+        hf_kwargs["num_labels"] = num_labels
+    if task == "score":
+        return AutoModelForSequenceClassification.from_pretrained(
+            model_name_or_path, trust_remote_code=trust_remote_code, **hf_kwargs
+        )
+    return AutoModel.from_pretrained(model_name_or_path, trust_remote_code=trust_remote_code, **hf_kwargs)
 
 
 def save_encoder_pretrained(model: nn.Module, save_directory: str, **kwargs) -> None:

--- a/nemo_automodel/components/models/ministral_bidirectional/model.py
+++ b/nemo_automodel/components/models/ministral_bidirectional/model.py
@@ -43,12 +43,14 @@ class Ministral3BidirectionalModel(Ministral3Model):
         1. Setting is_causal=False on all attention layers
         2. Using a bidirectional attention mask instead of causal mask
 
-    Loading from a Mistral3 VLM checkpoint (e.g. mistralai/Ministral-3-3B-Base-2512 or
-    mistralai/Ministral-3-3B-Instruct-2512) is handled automatically: the language
-    model weights are extracted from the VLM.
+    Loading a Mistral3 VLM checkpoint (e.g. ``mistralai/Ministral-3-3B-Base-2512``
+    or ``mistralai/Ministral-3-3B-Instruct-2512``) requires extracting the language
+    tower; this is driven by the recipe YAML via
+    ``extract_submodel: language_model`` and handled by
+    :func:`nemo_automodel._transformers.retrieval.build_encoder_backbone`.
 
-    Text-only checkpoints (e.g. mistralai/Ministral-3B-Instruct) load with the usual
-    ``from_pretrained`` path when the Hub config has no nested ``text_config``.
+    Text-only checkpoints (e.g. ``mistralai/Ministral-3B-Instruct``) load directly
+    via the standard ``from_pretrained`` path with no extraction needed.
     """
 
     config_class = Ministral3BidirectionalConfig
@@ -57,53 +59,6 @@ class Ministral3BidirectionalModel(Ministral3Model):
         super().__init__(config)
         for layer in self.layers:
             layer.self_attn.is_causal = False
-
-    @classmethod
-    def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
-        """Load from either a bidirectional text checkpoint or a Mistral3 VLM checkpoint.
-
-        When the checkpoint is a VLM (config has text_config), the language model
-        weights are extracted automatically. Otherwise, the checkpoint is loaded
-        directly as a text-only model.
-        """
-        logger.info(f"Loading Ministral3BidirectionalModel from {pretrained_model_name_or_path}")
-        hub_config = AutoConfig.from_pretrained(
-            pretrained_model_name_or_path,
-            trust_remote_code=kwargs.get("trust_remote_code", False),
-        )
-
-        text_cfg = getattr(hub_config, "text_config", None)
-        if text_cfg is not None:
-            return cls._from_vlm_checkpoint(pretrained_model_name_or_path, hub_config, **kwargs)
-        return super().from_pretrained(pretrained_model_name_or_path, *model_args, **kwargs)
-
-    @classmethod
-    def _from_vlm_checkpoint(cls, model_name_or_path, vlm_config, **kwargs):
-        """Extract and load the language model from a VLM checkpoint."""
-        torch_dtype = kwargs.get("torch_dtype", None)
-        attn_implementation = kwargs.get("attn_implementation", None)
-
-        logger.info(f"Loading VLM from {model_name_or_path} to extract language model weights")
-        vlm = AutoModel.from_pretrained(
-            model_name_or_path,
-            torch_dtype=torch_dtype,
-            trust_remote_code=True,
-        )
-        state_dict = vlm.language_model.state_dict()
-        del vlm
-
-        text_config_dict = vlm_config.text_config.to_dict()
-        text_config = cls.config_class(**text_config_dict)
-        if attn_implementation is not None:
-            text_config._attn_implementation = attn_implementation
-
-        model = cls(text_config)
-        model.load_state_dict(state_dict)
-        if torch_dtype is not None:
-            dtype = getattr(torch, torch_dtype) if isinstance(torch_dtype, str) else torch_dtype
-            model = model.to(dtype)
-
-        return model
 
     def forward(
         self,
@@ -161,7 +116,6 @@ class Ministral3BidirectionalModel(Ministral3Model):
                 position_embeddings=position_embeddings,
                 **kwargs,
             )
-
         hidden_states = self.norm(hidden_states)
         return BaseModelOutputWithPast(
             last_hidden_state=hidden_states,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -320,8 +320,6 @@ omit = [
     "nemo_automodel/components/datasets/llm/delta_lake_dataset.py",
     # Weird file suddenly appearing in coverage
     "_remote_module_non_scriptable",
-    # deleted file; may still appear in coverage data from cache
-    "nemo_automodel/_transformers/retrieval.py",
 ]
 
 [tool.ruff]

--- a/tests/unit_tests/_transformers/test_retrieval.py
+++ b/tests/unit_tests/_transformers/test_retrieval.py
@@ -1,0 +1,224 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Functional tests for retrieval backbone extraction."""
+
+import json
+
+import pytest
+import torch
+import torch.nn as nn
+from transformers import AutoModel, Mistral3Config
+
+from nemo_automodel.components.models.llama_bidirectional.model import (
+    LlamaBidirectionalForSequenceClassification,
+    LlamaBidirectionalModel,
+)
+from nemo_automodel.components.models.ministral_bidirectional.model import Ministral3BidirectionalModel
+
+
+def _tiny_mistral3_vlm_config(text_model_type: str) -> Mistral3Config:
+    """Build a tiny Mistral3 VLM config with a selectable text backbone."""
+    text_config = {
+        "model_type": text_model_type,
+        "vocab_size": 32,
+        "hidden_size": 16,
+        "intermediate_size": 32,
+        "num_hidden_layers": 1,
+        "num_attention_heads": 2,
+        "num_key_value_heads": 1,
+    }
+    if text_model_type in {"mistral", "ministral3"}:
+        text_config["head_dim"] = 8
+
+    return Mistral3Config(
+        text_config=text_config,
+        vision_config={
+            "model_type": "pixtral",
+            "hidden_size": 16,
+            "intermediate_size": 32,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 2,
+            "image_size": 16,
+            "patch_size": 4,
+            "num_channels": 3,
+        },
+    )
+
+
+def _save_tiny_vlm(tmp_path, text_model_type: str):
+    """Save a tiny local VLM checkpoint and return its language-model weights."""
+    model = AutoModel.from_config(_tiny_mistral3_vlm_config(text_model_type))
+    model_dir = tmp_path / f"{text_model_type}_vlm"
+    model.save_pretrained(model_dir)
+    language_state_dict = {key: tensor.detach().clone() for key, tensor in model.language_model.state_dict().items()}
+    return model_dir, language_state_dict
+
+
+def _assert_state_dict_equal(expected: dict[str, torch.Tensor], actual: dict[str, torch.Tensor]) -> None:
+    assert set(expected) == set(actual)
+    for key, tensor in expected.items():
+        assert torch.equal(tensor, actual[key]), f"Weight mismatch for {key}"
+
+
+def _assert_no_language_model_prefix(model: nn.Module) -> None:
+    for key in model.state_dict():
+        assert not key.startswith("language_model."), f"VLM prefix in key: {key}"
+
+
+def test_extract_submodel_unsupported_embedding_from_local_vlm(tmp_path):
+    """Unsupported extracted text backbones are returned directly for bi-encoder use."""
+    from nemo_automodel._transformers import retrieval
+
+    model_dir, language_state_dict = _save_tiny_vlm(tmp_path, "mistral")
+
+    backbone = retrieval.build_encoder_backbone(
+        model_name_or_path=str(model_dir),
+        task="embedding",
+        extract_submodel="language_model",
+    )
+
+    assert backbone.__class__.__name__ == "MistralModel"
+    assert backbone.config.model_type == "mistral"
+    _assert_no_language_model_prefix(backbone)
+    _assert_state_dict_equal(language_state_dict, backbone.state_dict())
+
+    save_dir = tmp_path / "mistral_text_backbone"
+    backbone.save_pretrained(save_dir)
+    saved_config = json.loads((save_dir / "config.json").read_text())
+    assert saved_config["model_type"] == "mistral"
+
+
+def test_extract_submodel_llama_embedding_from_local_vlm_converts_to_supported_backbone(tmp_path):
+    """A supported extracted Llama text backbone becomes the retrieval Llama encoder."""
+    from nemo_automodel._transformers import retrieval
+
+    model_dir, language_state_dict = _save_tiny_vlm(tmp_path, "llama")
+
+    backbone = retrieval.build_encoder_backbone(
+        model_name_or_path=str(model_dir),
+        task="embedding",
+        extract_submodel="language_model",
+        pooling="avg",
+    )
+
+    assert isinstance(backbone, LlamaBidirectionalModel)
+    assert backbone.config.model_type == "llama_bidirec"
+    assert backbone.config.pooling == "avg"
+    assert all(getattr(layer.self_attn, "is_causal", True) is False for layer in backbone.layers)
+    _assert_state_dict_equal(language_state_dict, backbone.state_dict())
+
+    input_ids = torch.randint(0, backbone.config.vocab_size, (2, 8))
+    attention_mask = torch.ones_like(input_ids)
+    backbone.eval()
+    with torch.no_grad():
+        outputs = backbone(input_ids=input_ids, attention_mask=attention_mask)
+    assert outputs.last_hidden_state.shape == (2, 8, backbone.config.hidden_size)
+
+
+def test_extract_submodel_ministral_embedding_from_local_vlm_converts_to_supported_backbone(tmp_path):
+    """The real Ministral3 VLM text backbone path becomes the Ministral bi-encoder."""
+    from nemo_automodel._transformers import retrieval
+
+    model_dir, language_state_dict = _save_tiny_vlm(tmp_path, "ministral3")
+
+    backbone = retrieval.build_encoder_backbone(
+        model_name_or_path=str(model_dir),
+        task="embedding",
+        extract_submodel="language_model",
+    )
+
+    assert isinstance(backbone, Ministral3BidirectionalModel)
+    assert backbone.config.model_type == "ministral3_bidirec"
+    _assert_state_dict_equal(language_state_dict, backbone.state_dict())
+
+    input_ids = torch.randint(0, backbone.config.vocab_size, (2, 8))
+    attention_mask = torch.ones_like(input_ids)
+    backbone.eval()
+    with torch.no_grad():
+        outputs = backbone(input_ids=input_ids, attention_mask=attention_mask)
+    assert outputs.last_hidden_state.shape == (2, 8, backbone.config.hidden_size)
+
+
+def test_extract_submodel_llama_score_from_local_vlm_converts_to_supported_cross_encoder(tmp_path):
+    """A supported extracted Llama text backbone becomes the retrieval reranker."""
+    from nemo_automodel._transformers import retrieval
+
+    model_dir, language_state_dict = _save_tiny_vlm(tmp_path, "llama")
+
+    backbone = retrieval.build_encoder_backbone(
+        model_name_or_path=str(model_dir),
+        task="score",
+        extract_submodel="language_model",
+        num_labels=1,
+        pooling="avg",
+        temperature=0.5,
+    )
+
+    assert isinstance(backbone, LlamaBidirectionalForSequenceClassification)
+    assert backbone.config.model_type == "llama_bidirec"
+    assert backbone.config.num_labels == 1
+    assert backbone.config.pooling == "avg"
+    assert backbone.config.temperature == 0.5
+    _assert_state_dict_equal(language_state_dict, backbone.model.state_dict())
+
+    input_ids = torch.randint(0, backbone.config.vocab_size, (2, 8))
+    attention_mask = torch.ones_like(input_ids)
+    backbone.eval()
+    with torch.no_grad():
+        outputs = backbone(input_ids=input_ids, attention_mask=attention_mask)
+    assert outputs.logits.shape == (2, 1)
+
+
+def test_extract_submodel_ministral_score_from_local_vlm_converts_to_hf_cross_encoder(tmp_path):
+    """Reranking still works when no registered score backbone exists for the text model."""
+    from nemo_automodel._transformers import retrieval
+
+    model_dir, language_state_dict = _save_tiny_vlm(tmp_path, "ministral3")
+
+    backbone = retrieval.build_encoder_backbone(
+        model_name_or_path=str(model_dir),
+        task="score",
+        extract_submodel="language_model",
+        num_labels=1,
+    )
+
+    assert backbone.__class__.__name__ == "Ministral3ForSequenceClassification"
+    assert backbone.config.model_type == "ministral3"
+    assert backbone.config.num_labels == 1
+    _assert_state_dict_equal(language_state_dict, backbone.model.state_dict())
+
+    input_ids = torch.randint(0, backbone.config.vocab_size, (2, 8))
+    attention_mask = torch.ones_like(input_ids)
+    backbone.eval()
+    with torch.no_grad():
+        outputs = backbone(input_ids=input_ids, attention_mask=attention_mask)
+    assert outputs.logits.shape == (2, 1)
+
+
+class _PlainSubmodule(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(8, 8)
+
+
+def test_extract_submodel_without_config_raises():
+    """The extracted object must carry a config so it can be saved/reloaded."""
+    from nemo_automodel._transformers.retrieval import _extract_submodel
+
+    model = nn.Module()
+    model.language_model = _PlainSubmodule()
+
+    with pytest.raises(ValueError, match="has no .config attribute"):
+        _extract_submodel(model, "language_model")

--- a/tests/unit_tests/models/bi_encoder/test_llama_bidirectional_model.py
+++ b/tests/unit_tests/models/bi_encoder/test_llama_bidirectional_model.py
@@ -17,23 +17,22 @@ import pytest
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from transformers.modeling_outputs import SequenceClassifierOutputWithPast
+from transformers.modeling_outputs import BaseModelOutputWithPast, SequenceClassifierOutputWithPast
 
+from nemo_automodel._transformers.registry import ModelRegistry
 from nemo_automodel._transformers.retrieval import (
     BiEncoderModel,
     CrossEncoderModel,
-    configure_encoder_metadata,
     _init_encoder_common,
+    configure_encoder_metadata,
     pool,
 )
-from nemo_automodel.recipes.retrieval.train_bi_encoder import contrastive_scores_and_labels
-from nemo_automodel._transformers.registry import ModelRegistry
 from nemo_automodel.components.models.llama_bidirectional.model import (
     LlamaBidirectionalConfig,
     LlamaBidirectionalForSequenceClassification,
     LlamaBidirectionalModel,
 )
-from transformers.modeling_outputs import BaseModelOutputWithPast
+from nemo_automodel.recipes.retrieval.train_bi_encoder import contrastive_scores_and_labels
 
 
 def test_contrastive_scores_and_labels_shapes_and_labels():

--- a/tests/unit_tests/models/bi_encoder/test_ministral_bidirectional_model.py
+++ b/tests/unit_tests/models/bi_encoder/test_ministral_bidirectional_model.py
@@ -161,9 +161,9 @@ def test_encoder_build_ministral3_registry_path(tmp_path, monkeypatch):
     assert any("save1" in p for p in model.model.saved)
 
 
-@pytest.mark.parametrize("top_level_model_type", ["ministral3", "ministral3_bidirec", "mistral3"])
+@pytest.mark.parametrize("top_level_model_type", ["ministral3", "ministral3_bidirec"])
 def test_encoder_build_ministral_supported_model_types(tmp_path, monkeypatch, top_level_model_type):
-    """Hub / local configs use ministral3, saved bidirectional uses ministral3_bidirec; VLM uses mistral3."""
+    """Hub / local text configs use ministral3; saved bidirectional checkpoints use ministral3_bidirec."""
     class FakeBidirectionalModel(FakeLM):
         @classmethod
         def from_pretrained(cls, *args, **kwargs):


### PR DESCRIPTION
# What does this PR do ?

Add an `extract_submodel` parameter to `build_encoder_backbone` for generic VLM text-backbone extraction via dotted attribute path.

When `extract_submodel` is set, the parent model is loaded with HuggingFace `AutoModel`, the requested submodel is extracted, and the extracted text config is used to build the appropriate retrieval backbone. Supported extracted text backbones, such as Llama and Ministral3, still use the registered retrieval classes where available; unsupported embedding backbones are returned as extracted HF models; unsupported reranking backbones use the HF sequence-classification wrapper.

This avoids adding new model-specific VLM extraction paths for each architecture.

# Changelog

- Add `extract_submodel: str | None` parameter to `build_encoder_backbone()`
- Support dotted attribute extraction, e.g. `"language_model"` or `"model.language_model"`
- Convert supported extracted text backbones to registered retrieval backbones for embedding and reranking
- Support HF sequence-classification fallback for extracted `task="score"` backbones without a registered reranker
- Add functional tests with tiny local VLM checkpoints for embedding and reranking extraction paths

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

# Additional Information

The parameter flows through the existing YAML config system via `**kwargs` passthrough:

```yaml
model:
  _target_: nemo_automodel.NeMoAutoModelBiEncoder.from_pretrained
  pretrained_model_name_or_path: mistralai/Ministral-3-3B-Base-2512
  extract_submodel: language_model
  pooling: avg
  l2_normalize: true
```

`extract_submodel` is a named parameter on `build_encoder_backbone`, so it is consumed there and not forwarded to HF's `from_pretrained`.

The same extraction path is also used by cross-encoder/reranking builds via `task="score"`.

Companion to #1837 (is_causal refactor). These two PRs are independent and can be reviewed/merged in any order.