### PR TITLE
fix: relax checkpoint robustness HF KL threshold for nemotron_nano_8b_v1

### DIFF
--- a/examples/llm_finetune/nemotron/nemotron_nano_8b_v1_squad.yaml
+++ b/examples/llm_finetune/nemotron/nemotron_nano_8b_v1_squad.yaml
@@ -105,7 +105,7 @@ ci:
   recipe_owner: adil-a
   time: "00:20:00"
   checkpoint_robustness:
-    hf_kl_threshold: 7e-4
+    hf_kl_threshold: 3e-3
     distributed.tp_size: 2
     tokenizer_name: nvidia/Llama-3.1-Nemotron-Nano-8B-v1
     cross_tp_size: 2


### PR DESCRIPTION
## Summary
- Increase `hf_kl_threshold` from `7e-4` to `3e-3` in the `nemotron_nano_8b_v1_squad` checkpoint robustness config
- The robustness test trains with TP=2 (`ci.checkpoint_robustness.distributed.tp_size: 2`) and compares against vanilla HF (no TP). BF16 numerical differences between TP=2 and single-GPU execution produce ~1.86e-3 KL divergence, exceeding the previous 7e-4 threshold
- Phase 3 (automodel reload from consolidated) remains perfect at KL=0, confirming the checkpoint is correct
- New threshold of 3e-3 gives ~1.6x headroom while staying well below the default 5e-3 (which the PEFT variant already uses)

## Test plan
- [x] Ran full robustness test locally with 8x H100 using the exact `finetune_launcher.sh` command: `1 passed` in 223s
- [ ] CI nightly pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)