### PR TITLE
fix: pre-cache HF dynamic modules to prevent filesystem race in robustness test

### DIFF
--- a/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
+++ b/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
@@ -247,6 +247,20 @@ def test_checkpoint_robustness():
                     assert "_scales" not in key, f"Phantom mxfp4 key leaked: {key} in {sf_path.name}"
         print(f"[Phantom keys] Scanned {len(sf_files)} files, no _blocks/_scales keys ✓")
 
+    # Pre-populate HF dynamic module cache on rank 0 to prevent filesystem races
+    # when all ranks simultaneously load trust_remote_code models from local paths.
+    # On shared filesystems (e.g. Lustre), concurrent shutil.copy2 calls from
+    # multiple ranks cause PermissionError.
+    if not is_peft:
+        if _rank0():
+            from transformers import AutoConfig
+
+            try:
+                AutoConfig.from_pretrained(str(consolidated_dir), trust_remote_code=True)
+            except Exception:
+                pass
+        _barrier()
+
     cfg = parse_args_and_load_config()
     if not is_peft:
         cfg.model.pretrained_model_name_or_path = str(consolidated_dir)


### PR DESCRIPTION
## Summary
- Fix `PermissionError` in checkpoint robustness test for `nemotron_nano_v3_hellaswag` (and any other `trust_remote_code` model)
- When all 8 ranks simultaneously call `from_pretrained(consolidated_dir, trust_remote_code=True)`, HF's transformers copies dynamic module files (e.g. `configuration_nemotron_h.py`) to the shared HF module cache. On Lustre, these concurrent `shutil.copy2` calls race and cause `PermissionError: [Errno 1] Operation not permitted`
- Fix: rank 0 pre-populates the HF module cache via `AutoConfig.from_pretrained` before a barrier, so subsequent ranks find the files already cached

## Test plan
- [x] Ran full `nemotron_nano_v3_hellaswag` robustness test locally with 8x H100: `1 passed` in 272s (previously crashed with PermissionError + cascading OOM)
- [ ] CI nightly pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)