### PR TITLE
fix: trust_remote_code guard in robustness test

### DIFF
--- a/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
+++ b/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
@@ -275,7 +275,7 @@ def test_checkpoint_robustness():
         from transformers import AutoModelForCausalLM
 
         hf_kwargs = dict(torch_dtype=torch.bfloat16, trust_remote_code=trust_remote_code)
-        if experts_implementation:
+        if experts_implementation and not trust_remote_code:
             hf_kwargs["experts_implementation"] = experts_implementation
             hf_kwargs["trust_remote_code"] = False
         if hf_device_map_auto:


### PR DESCRIPTION
## Summary
- Fix `OfflineModeIsEnabled` error in checkpoint robustness test for `nemotron_nano_v3_hellaswag_peft`
- The test unconditionally set `trust_remote_code=False` when `experts_implementation` was configured. For NemotronV3 (which needs `trust_remote_code` for Mamba's `causal-conv1d` layers), this forced HF's native code path which tries to fetch kernels from HF Hub — failing in CI's offline environment (`HF_HUB_OFFLINE=1`)
- Fix: only pass `experts_implementation` when `trust_remote_code` is False. When `trust_remote_code` is True, the remote model code handles experts natively and doesn't accept the parameter

## Test plan
- [x] Ran full `nemotron_nano_v3_hellaswag_peft` robustness test locally with 8x H100 and `HF_HUB_OFFLINE=1`: `1 passed` in 193s
- [ ] CI nightly pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)