### PR TITLE
fix: Re-apply PyTorch dependency overrides after full COPY in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -180,6 +180,11 @@ RUN if python3 -c "import wandb" 2>/dev/null; then \
 
 COPY . /opt/Automodel
 
+# Re-apply PyTorch overrides after full COPY (which overwrites the modified pyproject.toml/uv.lock)
+RUN if [ "$BASE_IMAGE" = "pytorch" ]; then \
+        bash docker/common/update_pyproject_pytorch.sh /opt/Automodel; \
+    fi
+
 WORKDIR /opt/Automodel
 
 COPY <<EOF /opt/venv/env.sh


### PR DESCRIPTION
# What does this PR do ?

  - COPY . /opt/Automodel overwrites the modified pyproject.toml and uv.lock with originals, losing the "never
  install" overrides for torch and CUDA packages
  - At runtime, uv run detects the mismatch and tries to re-install torch
  - Fix: re-run update_pyproject_pytorch.sh after the full COPY to restore the overrides

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
