### PR TITLE
fix: Fix bug in diffusion generation

### DIFF
--- a/docker/common/uv-pytorch.lock
+++ b/docker/common/uv-pytorch.lock
@@ -1385,7 +1385,7 @@ wheels = [
 
 [[package]]
 name = "diffusers"
-version = "0.36.0"
+version = "0.37.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
@@ -1399,9 +1399,9 @@ dependencies = [
     { name = "requests" },
     { name = "safetensors" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/88/45/ccb2e2180ddf475a0f931dac6a50346310e4c464ce3cccb8a65d1fc1e16d/diffusers-0.36.0.tar.gz", hash = "sha256:a9cde8721b415bde6a678f2d02abb85396487e1b0e0d2b4abb462d14a9825ab0", size = 3795088, upload-time = "2025-12-08T10:14:34.255Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/5c/f4c2eb8d481fe8784a7e2331fbaab820079c06676185fa6d2177b386d590/diffusers-0.37.1.tar.gz", hash = "sha256:2346c21f77f835f273b7aacbaada1c34a596a3a2cc6ddc99d149efcd0ec298fa", size = 4135139, upload-time = "2026-03-25T08:04:04.515Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/50/281f92cb1f83854dbd79b6e958b3bc5018607e2542971d41604ba7a14b2f/diffusers-0.36.0-py3-none-any.whl", hash = "sha256:525d42abc74bfc3b2db594999961295c054b48ef40a11724dacf50e6abd1af98", size = 4597884, upload-time = "2025-12-08T10:14:31.979Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/dd/51c38785ce5e1c287b5ad17ba550edaaaffce0deb0da4857019c6700fbaf/diffusers-0.37.1-py3-none-any.whl", hash = "sha256:0537c0b28cb53cf39d6195489bcf8f833986df556c10f5e28ab7427b86fc8b90", size = 5001536, upload-time = "2026-03-25T08:04:02.385Z" },
 ]
 
 [[package]]
@@ -3426,7 +3426,7 @@ requires-dist = [
     { name = "datasets", specifier = ">=4.0.0" },
     { name = "deep-ep", marker = "extra == 'moe'", git = "https://github.com/deepseek-ai/DeepEP.git?rev=7febc6e25660af0f54d95dd781ecdcd62265ecca" },
     { name = "deltalake", marker = "extra == 'delta-databricks'", specifier = ">=1.0.0" },
-    { name = "diffusers", marker = "extra == 'diffusion'", specifier = ">=0.36.0" },
+    { name = "diffusers", marker = "extra == 'diffusion'", specifier = ">=0.37.0" },
     { name = "flash-attn", marker = "extra == 'fa'", specifier = "<=2.8.3" },
     { name = "flashoptim", specifier = ">=0.1.3" },
     { name = "ftfy", marker = "extra == 'diffusion'" },

--- a/examples/diffusion/generate/generate.py
+++ b/examples/diffusion/generate/generate.py
@@ -230,9 +230,7 @@ def load_checkpoint_into_pipeline(pipe, cfg):
         name.endswith(".safetensors") for name in os.listdir(consolidated_st_dir)
     ):
         logger.info("Loading consolidated safetensors checkpoint from %s", consolidated_st_dir)
-        pipe.transformer = type(pipe.transformer).from_pretrained(
-            str(consolidated_st_dir), torch_dtype=torch_dtype
-        )
+        pipe.transformer = type(pipe.transformer).from_pretrained(str(consolidated_st_dir), torch_dtype=torch_dtype)
         pipe.transformer.to("cuda")
         logger.info("Loaded consolidated safetensors checkpoint")
     elif sharded_dir.is_dir() and any(name.endswith(".distcp") for name in os.listdir(sharded_dir)):

--- a/examples/diffusion/generate/generate.py
+++ b/examples/diffusion/generate/generate.py
@@ -84,8 +84,9 @@ def maybe_init_distributed(cfg):
 def load_pipeline(cfg, dist_info):
     """Load the diffusion pipeline, auto-detecting model type.
 
-    Uses DiffusionPipeline for single-GPU or NeMoAutoDiffusionPipeline for
-    distributed inference with parallelization.
+    Uses NeMoAutoDiffusionPipeline for both single-GPU and distributed
+    inference. When no distributed config is present, parallelization is
+    skipped automatically.
 
     Args:
         cfg: Config node with `model.pretrained_model_name_or_path`.
@@ -94,7 +95,7 @@ def load_pipeline(cfg, dist_info):
     Returns:
         A diffusers pipeline instance.
     """
-    from diffusers import DiffusionPipeline
+    from nemo_automodel._diffusers.auto_diffusion_pipeline import NeMoAutoDiffusionPipeline
 
     model_id = cfg.model.pretrained_model_name_or_path
     dtype_str = getattr(cfg.inference, "dtype", "bfloat16")
@@ -105,28 +106,25 @@ def load_pipeline(cfg, dist_info):
     if torch_dtype == torch.bfloat16:
         patch_t5_layer_norm()
 
+    # Build parallel_scheme from distributed config (None for single-GPU).
+    parallel_scheme = None
     if dist_info is not None and hasattr(cfg.distributed, "parallel_scheme"):
-        # Distributed path: use NeMoAutoDiffusionPipeline with parallelization
-        from nemo_automodel._diffusers.auto_diffusion_pipeline import NeMoAutoDiffusionPipeline
-
         parallel_scheme = _build_parallel_scheme(cfg.distributed.parallel_scheme, dist_info)
-        pipe, _ = NeMoAutoDiffusionPipeline.from_pretrained(
-            model_id,
-            torch_dtype=torch_dtype,
-            parallel_scheme=parallel_scheme,
-        )
-        logger.info("Loaded distributed pipeline: %s", type(pipe).__name__)
-    else:
-        # Single-GPU path: standard diffusers auto-detection
-        pipe = DiffusionPipeline.from_pretrained(model_id, torch_dtype=torch_dtype)
-        # Skip .to("cuda") when CPU offload is configured — enable_model_cpu_offload()
-        # expects the pipeline on CPU so it can set up per-module device hooks.
-        vae_cfg = getattr(cfg, "vae", None)
-        if not (vae_cfg is not None and getattr(vae_cfg, "enable_cpu_offload", False)):
-            pipe.to("cuda")
-        logger.info("Loaded pipeline: %s", type(pipe).__name__)
+
+    # CPU offload requires modules to stay on CPU so enable_model_cpu_offload()
+    # can install per-module device hooks (called later in apply_optimizations).
+    vae_cfg = getattr(cfg, "vae", None)
+    cpu_offload = vae_cfg is not None and getattr(vae_cfg, "enable_cpu_offload", False)
+
+    pipe, _ = NeMoAutoDiffusionPipeline.from_pretrained(
+        model_id,
+        torch_dtype=torch_dtype,
+        parallel_scheme=parallel_scheme,
+        move_to_device=not cpu_offload,
+    )
 
     _fix_text_encoder_weight_tying(pipe)
+    logger.info("Loaded pipeline: %s (distributed=%s)", type(pipe).__name__, parallel_scheme is not None)
     return pipe
 
 

--- a/examples/diffusion/generate/generate.py
+++ b/examples/diffusion/generate/generate.py
@@ -211,6 +211,7 @@ def load_checkpoint_into_pipeline(pipe, cfg):
 
     ema_path = checkpoint_dir / "ema_shadow.pt"
     consolidated_path = checkpoint_dir / "consolidated_model.bin"
+    consolidated_st_dir = checkpoint_dir / "model" / "consolidated"
     sharded_dir = checkpoint_dir / "model"
 
     if ema_path.exists():
@@ -225,6 +226,15 @@ def load_checkpoint_into_pipeline(pipe, cfg):
             state_dict = state_dict["model_state_dict"]
         pipe.transformer.load_state_dict(state_dict, strict=True)
         logger.info("Loaded consolidated checkpoint")
+    elif consolidated_st_dir.is_dir() and any(
+        name.endswith(".safetensors") for name in os.listdir(consolidated_st_dir)
+    ):
+        logger.info("Loading consolidated safetensors checkpoint from %s", consolidated_st_dir)
+        pipe.transformer = type(pipe.transformer).from_pretrained(
+            str(consolidated_st_dir), torch_dtype=torch_dtype
+        )
+        pipe.transformer.to("cuda")
+        logger.info("Loaded consolidated safetensors checkpoint")
     elif sharded_dir.is_dir() and any(name.endswith(".distcp") for name in os.listdir(sharded_dir)):
         logger.info("Loading sharded FSDP checkpoint from %s", sharded_dir)
         pipe.transformer = _load_sharded_fsdp_checkpoint(pipe.transformer, str(sharded_dir), torch_dtype)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ dependencies = [
 
 [project.optional-dependencies]
 diffusion = [
-    "diffusers>=0.36.0",
+    "diffusers>=0.37.0",
     "ftfy",
     "imageio",
     "imageio-ffmpeg",

--- a/uv.lock
+++ b/uv.lock
@@ -1376,7 +1376,7 @@ wheels = [
 
 [[package]]
 name = "diffusers"
-version = "0.36.0"
+version = "0.37.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
@@ -1390,9 +1390,9 @@ dependencies = [
     { name = "requests" },
     { name = "safetensors" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/88/45/ccb2e2180ddf475a0f931dac6a50346310e4c464ce3cccb8a65d1fc1e16d/diffusers-0.36.0.tar.gz", hash = "sha256:a9cde8721b415bde6a678f2d02abb85396487e1b0e0d2b4abb462d14a9825ab0", size = 3795088, upload-time = "2025-12-08T10:14:34.255Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/5c/f4c2eb8d481fe8784a7e2331fbaab820079c06676185fa6d2177b386d590/diffusers-0.37.1.tar.gz", hash = "sha256:2346c21f77f835f273b7aacbaada1c34a596a3a2cc6ddc99d149efcd0ec298fa", size = 4135139, upload-time = "2026-03-25T08:04:04.515Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/50/281f92cb1f83854dbd79b6e958b3bc5018607e2542971d41604ba7a14b2f/diffusers-0.36.0-py3-none-any.whl", hash = "sha256:525d42abc74bfc3b2db594999961295c054b48ef40a11724dacf50e6abd1af98", size = 4597884, upload-time = "2025-12-08T10:14:31.979Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/dd/51c38785ce5e1c287b5ad17ba550edaaaffce0deb0da4857019c6700fbaf/diffusers-0.37.1-py3-none-any.whl", hash = "sha256:0537c0b28cb53cf39d6195489bcf8f833986df556c10f5e28ab7427b86fc8b90", size = 5001536, upload-time = "2026-03-25T08:04:02.385Z" },
 ]
 
 [[package]]
@@ -3442,7 +3442,7 @@ requires-dist = [
     { name = "datasets", specifier = ">=4.0.0" },
     { name = "deep-ep", marker = "extra == 'moe'", git = "https://github.com/deepseek-ai/DeepEP.git?rev=7febc6e25660af0f54d95dd781ecdcd62265ecca" },
     { name = "deltalake", marker = "extra == 'delta-databricks'", specifier = ">=1.0.0" },
-    { name = "diffusers", marker = "extra == 'diffusion'", specifier = ">=0.36.0" },
+    { name = "diffusers", marker = "extra == 'diffusion'", specifier = ">=0.37.0" },
     { name = "flash-attn", marker = "extra == 'fa'", specifier = "<=2.8.3" },
     { name = "flashoptim", specifier = ">=0.1.3" },
     { name = "ftfy", marker = "extra == 'diffusion'" },


### PR DESCRIPTION
What does this PR do?

  Add support for loading consolidated safetensors checkpoints (produced by save_consolidated: true + diffusers_compatible: true) in the diffusion generation
  script.

  Changelog

  - Add a new checkpoint loading branch in load_checkpoint_into_pipeline that detects and loads consolidated safetensors checkpoints from
  <checkpoint_dir>/model/consolidated/ using the standard from_pretrained() API (examples/diffusion/generate/generate.py)
  - Bump minimum diffusers version from >=0.36.0 to >=0.37.0 in the [diffusion] optional dependency (pyproject.toml)

  Before your PR is "Ready for review"

  Pre checks:

  - Make sure you read and followed https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md
  - Did you write any new necessary tests?
  - Did you add or update any necessary documentation?

  If you haven't finished some of the above items you can still open "Draft" PR.

  Additional Information

  - Related to # (issue)