### PR TITLE
fix(collate): auto-derive assistant turn markers for non-Qwen models

### DIFF
--- a/nemo_automodel/components/datasets/vlm/collate_fns.py
+++ b/nemo_automodel/components/datasets/vlm/collate_fns.py
@@ -247,8 +247,8 @@ def _get_stop_token_id(tokenizer) -> Optional[int]:
 
 
 # Processor types whose chat template uses ``<|im_start|>``/``<|im_end|>``
-# markers.  For these we can reliably locate assistant turns by scanning the
-# token ids instead of re-tokenizing (which is sensitive to BPE context).
+# markers.  For these we use the fast ``_get_assistant_marker`` /
+# ``_get_stop_token_id`` helpers (no dummy-conversation overhead).
 _IMSTART_TEMPLATE_PROCESSORS = frozenset(
     {
         "Qwen2VLProcessor",
@@ -260,45 +260,109 @@ _IMSTART_TEMPLATE_PROCESSORS = frozenset(
 )
 
 
-def build_labels_from_template(
-    input_ids_batch: torch.Tensor,
-    conversations: Sequence[Sequence[Dict[str, Any]]],
-    processor,
-) -> torch.Tensor:
-    """Build training labels by scanning ``input_ids`` for chat-template role markers.
+def _derive_turn_markers(tokenizer) -> Tuple[List[int], int]:
+    """Derive the assistant-turn start marker and end-of-turn token id from the
+    tokenizer's own chat template.
 
-    Instead of re-tokenizing assistant text and searching for it (fragile due
-    to BPE context sensitivity), this function locates the structural markers
-    that the chat template inserts around each assistant turn:
+    The function applies a minimal dummy conversation that contains a known
+    sentinel string as the assistant reply, then locates the sentinel in the
+    resulting token sequence.  Everything between the end of the user turn and
+    the start of the sentinel becomes the **assistant marker**; the first token
+    *after* the sentinel becomes the **end-of-turn id**.
 
-        ``<|im_start|>assistant\\n`` … content … ``<|im_end|>``
+    This approach is robust to BPE context-sensitivity and works for any model
+    whose template wraps assistant turns with fixed token sequences — e.g.
+    Gemma4's ``<start_of_turn>model\\n`` … ``<end_of_turn>``.
 
-    Labels are set to the actual token ids for the **content** region
-    (including ``<|im_end|>``); everything else is ``-100``.
+    .. note::
+        ``apply_chat_template`` may return a :class:`~transformers.BatchEncoding`
+        (a ``UserDict`` subclass, **not** a plain :class:`dict`), so
+        ``isinstance(result, dict)`` is ``False``.  We access ``result["input_ids"]``
+        directly, which works for both ``BatchEncoding`` and plain ``dict`` / ``list``.
 
-    Falls back to the old :func:`build_labels` for processor types that do
-    not use the ``<|im_start|>``/``<|im_end|>`` convention (e.g. Kimi, Phi4,
-    Nemotron-Parse).
+    Returns
+    -------
+    tuple[list[int], int]
+        ``(assistant_marker, end_of_turn_id)``
+
+    Raises
+    ------
+    ValueError
+        If the sentinel cannot be located in the template output or if the
+        resulting marker is empty.
     """
-    processor_type = type(processor).__name__
-    if processor_type not in _IMSTART_TEMPLATE_PROCESSORS:
-        return build_labels(input_ids_batch, conversations, processor)
 
-    tokenizer = getattr(processor, "tokenizer", processor)
-    assistant_marker = _get_assistant_marker(tokenizer)
-    stop_id = _get_stop_token_id(tokenizer)
+    def _extract_ids(result) -> List[int]:
+        try:
+            return list(result["input_ids"])
+        except (KeyError, TypeError):
+            return list(result)
 
-    # Safety net: if the tokenizer somehow lacks the expected tokens, fall back.
-    if assistant_marker is None or stop_id is None:
-        logger.warning(
-            "Processor %s is listed as im_start-style but tokenizer lacks "
-            "<|im_start|>/<|im_end|> tokens. Falling back to pattern-match labels.",
-            processor_type,
+    sentinel = "XSENTINELMARKERX"
+    all_ids = _extract_ids(
+        tokenizer.apply_chat_template(
+            [{"role": "user", "content": "u"}, {"role": "assistant", "content": sentinel}],
+            tokenize=True,
+            add_generation_prompt=False,
         )
-        return build_labels(input_ids_batch, conversations, processor)
+    )
+    user_ids = _extract_ids(
+        tokenizer.apply_chat_template(
+            [{"role": "user", "content": "u"}],
+            tokenize=True,
+            add_generation_prompt=False,
+        )
+    )
+    sentinel_ids = tokenizer.encode(sentinel, add_special_tokens=False)
 
+    for i in range(len(all_ids) - len(sentinel_ids) + 1):
+        if all_ids[i : i + len(sentinel_ids)] == sentinel_ids:
+            end_idx = i + len(sentinel_ids)
+            if end_idx >= len(all_ids):
+                raise ValueError(
+                    f"No token found after sentinel in template output {all_ids}."
+                )
+            end_of_turn_id: int = all_ids[end_idx]
+            assistant_marker: List[int] = all_ids[len(user_ids) : i]
+            if not assistant_marker:
+                raise ValueError(
+                    f"Assistant marker is empty (user_len={len(user_ids)}, sentinel_pos={i}). "
+                    f"Full sequence: {all_ids}"
+                )
+            return assistant_marker, end_of_turn_id
+
+    raise ValueError(
+        f"Sentinel '{sentinel}' (ids={sentinel_ids}) not found in template output {all_ids}."
+    )
+
+
+def _build_labels_from_markers(
+    input_ids_batch: torch.Tensor,
+    assistant_marker: List[int],
+    stop_id: int,
+) -> torch.Tensor:
+    """Scan ``input_ids`` for ``assistant_marker`` … ``stop_id`` and build labels.
+
+    For each sequence in the batch, every token between the end of an
+    assistant marker and the corresponding ``stop_id`` (inclusive) is copied
+    into the labels tensor; all other positions are set to ``-100``.
+
+    Parameters
+    ----------
+    input_ids_batch:
+        Shape ``(B, L)``.
+    assistant_marker:
+        Token-id sequence that opens an assistant turn (e.g.
+        ``[<|im_start|>, assistant_id, newline_id]`` for Qwen or
+        ``[<start_of_turn>, model_id, newline_id]`` for Gemma4).
+    stop_id:
+        Single token id that closes a turn (e.g. ``<|im_end|>`` or
+        ``<end_of_turn>``).
+    """
     marker_len = len(assistant_marker)
-    marker_tensor = torch.tensor(assistant_marker, dtype=input_ids_batch.dtype, device=input_ids_batch.device)
+    marker_tensor = torch.tensor(
+        assistant_marker, dtype=input_ids_batch.dtype, device=input_ids_batch.device
+    )
 
     labels_list: List[torch.Tensor] = []
 
@@ -308,17 +372,15 @@ def build_labels_from_template(
         i = 0
 
         while i <= seq_len - marker_len:
-            # Look for the assistant marker pattern.
             if torch.equal(encoded[i : i + marker_len], marker_tensor):
                 content_start = i + marker_len  # first token of assistant content
 
-                # Scan forward to find the closing <|im_end|>.
+                # Scan forward to find the closing stop token.
                 content_end = content_start
                 while content_end < seq_len and encoded[content_end].item() != stop_id:
                     content_end += 1
 
-                # Include the <|im_end|> stop token in labels so the model
-                # learns to emit it.
+                # Include the stop token in labels so the model learns to emit it.
                 if content_end < seq_len:
                     content_end += 1
 
@@ -330,6 +392,75 @@ def build_labels_from_template(
         labels_list.append(labels)
 
     return torch.stack(labels_list)
+
+
+def build_labels_from_template(
+    input_ids_batch: torch.Tensor,
+    conversations: Sequence[Sequence[Dict[str, Any]]],
+    processor,
+) -> torch.Tensor:
+    """Build training labels by scanning ``input_ids`` for chat-template role markers.
+
+    Instead of re-tokenizing assistant text and searching for it (fragile due
+    to BPE context sensitivity), this function locates the structural markers
+    that the chat template inserts around each assistant turn and sets labels
+    only for the content region.
+
+    Two strategies are attempted in order:
+
+    1. **Fast path** (``_IMSTART_TEMPLATE_PROCESSORS``): for Qwen-family models
+       whose tokenizers expose ``<|im_start|>`` / ``<|im_end|>`` via
+       :func:`convert_tokens_to_ids`, the marker ids are resolved directly
+       without applying any dummy conversation.
+
+    2. **General path** (``_derive_turn_markers``): for all other processors
+       (e.g. Gemma4), the assistant-turn markers are derived automatically by
+       applying a minimal dummy conversation that contains a sentinel string.
+       This handles models whose tokenizers do not reliably expose special-token
+       ids via ``convert_tokens_to_ids`` or ``encode``.
+
+    If both strategies fail, the function falls back to the legacy
+    :func:`build_labels` (BPE pattern-matching), which logs a warning because
+    it is sensitive to tokenisation context and may produce ``num_label_tokens=0``
+    / nan loss on some samples.
+    """
+    processor_type = type(processor).__name__
+    tokenizer = getattr(processor, "tokenizer", processor)
+
+    # ------------------------------------------------------------------
+    # Fast path: Qwen-family processors with <|im_start|>/<|im_end|>.
+    # ------------------------------------------------------------------
+    if processor_type in _IMSTART_TEMPLATE_PROCESSORS:
+        assistant_marker = _get_assistant_marker(tokenizer)
+        stop_id = _get_stop_token_id(tokenizer)
+        if assistant_marker is not None and stop_id is not None:
+            return _build_labels_from_markers(input_ids_batch, assistant_marker, stop_id)
+        logger.warning(
+            "Processor %s is listed in _IMSTART_TEMPLATE_PROCESSORS but the tokenizer "
+            "does not expose <|im_start|>/<|im_end|>. Trying template-derived markers.",
+            processor_type,
+        )
+
+    # ------------------------------------------------------------------
+    # General path: derive markers from the chat template via sentinel.
+    # Handles Gemma4 and any future model automatically.
+    # ------------------------------------------------------------------
+    if hasattr(tokenizer, "apply_chat_template"):
+        try:
+            assistant_marker, stop_id = _derive_turn_markers(tokenizer)
+            return _build_labels_from_markers(input_ids_batch, assistant_marker, stop_id)
+        except Exception as exc:
+            logger.warning(
+                "Processor %s: could not derive turn markers from chat template (%s). "
+                "Falling back to BPE pattern-match labels, which may produce nan loss.",
+                processor_type,
+                exc,
+            )
+
+    # ------------------------------------------------------------------
+    # Last-resort fallback: BPE pattern-matching (fragile).
+    # ------------------------------------------------------------------
+    return build_labels(input_ids_batch, conversations, processor)
 
 
 def phi4_mm_collate_fn(examples, processor):

--- a/nemo_automodel/components/datasets/vlm/collate_fns.py
+++ b/nemo_automodel/components/datasets/vlm/collate_fns.py
@@ -11,9 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
+import random
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 from unittest.mock import MagicMock
 
 import torch
+from PIL import Image as PILImage
 
 from nemo_automodel.shared.import_utils import MISSING_QWEN_VL_UTILS_MSG
 
@@ -32,12 +36,6 @@ try:
 except ImportError:
     HAVE_QWEN_OMNI_UTILS = False
     process_mm_info = MagicMock()
-
-import logging
-import random
-from typing import Any, Dict, List, Optional, Sequence, Tuple
-
-from PIL import Image as PILImage
 
 logger = logging.getLogger(__name__)
 

--- a/nemo_automodel/components/datasets/vlm/collate_fns.py
+++ b/nemo_automodel/components/datasets/vlm/collate_fns.py
@@ -317,21 +317,16 @@ def _derive_turn_markers(tokenizer) -> Tuple[List[int], int]:
         if all_ids[i : i + len(sentinel_ids)] == sentinel_ids:
             end_idx = i + len(sentinel_ids)
             if end_idx >= len(all_ids):
-                raise ValueError(
-                    f"No token found after sentinel in template output {all_ids}."
-                )
+                raise ValueError(f"No token found after sentinel in template output {all_ids}.")
             end_of_turn_id: int = all_ids[end_idx]
             assistant_marker: List[int] = all_ids[len(user_ids) : i]
             if not assistant_marker:
                 raise ValueError(
-                    f"Assistant marker is empty (user_len={len(user_ids)}, sentinel_pos={i}). "
-                    f"Full sequence: {all_ids}"
+                    f"Assistant marker is empty (user_len={len(user_ids)}, sentinel_pos={i}). Full sequence: {all_ids}"
                 )
             return assistant_marker, end_of_turn_id
 
-    raise ValueError(
-        f"Sentinel '{sentinel}' (ids={sentinel_ids}) not found in template output {all_ids}."
-    )
+    raise ValueError(f"Sentinel '{sentinel}' (ids={sentinel_ids}) not found in template output {all_ids}.")
 
 
 def _build_labels_from_markers(
@@ -358,9 +353,7 @@ def _build_labels_from_markers(
         ``<end_of_turn>``).
     """
     marker_len = len(assistant_marker)
-    marker_tensor = torch.tensor(
-        assistant_marker, dtype=input_ids_batch.dtype, device=input_ids_batch.device
-    )
+    marker_tensor = torch.tensor(assistant_marker, dtype=input_ids_batch.dtype, device=input_ids_batch.device)
 
     labels_list: List[torch.Tensor] = []
 

--- a/tests/unit_tests/datasets/vlm/test_collate_fns.py
+++ b/tests/unit_tests/datasets/vlm/test_collate_fns.py
@@ -1801,6 +1801,171 @@ class TestBuildLabelsFromTemplate:
 
 
 # ---------------------------------------------------------------------------
+# Tests for _derive_turn_markers (Gemma4-style general path)
+# ---------------------------------------------------------------------------
+
+# Synthetic token IDs for a Gemma4-style tokenizer.
+_SOT = 2       # <start_of_turn>
+_USER_TK = 1645  # "user"
+_MODEL_TK = 2516  # "model"
+_NL = 108      # "\n"
+_EOT = 107     # <end_of_turn>
+_U_CONTENT = 506   # "u"
+# sentinel encoded as two distinct ids
+_SEN_A = 999
+_SEN_B = 888
+
+
+class _Gemma4StyleTokenizer:
+    """Minimal Gemma4-like tokenizer stub for _derive_turn_markers tests.
+
+    Template layout (ids):
+      user turn:      [SOT, USER, NL, <content>, EOT, NL]
+      assistant turn: [SOT, MODEL, NL, <content>, EOT]
+    """
+
+    def apply_chat_template(self, messages, tokenize=True, add_generation_prompt=False, **kwargs):
+        ids = []
+        for msg in messages:
+            if msg["role"] == "user":
+                ids += [_SOT, _USER_TK, _NL, _U_CONTENT, _EOT, _NL]
+            else:
+                # assistant
+                content = msg["content"]
+                if content == "XSENTINELMARKERX":
+                    content_ids = [_SEN_A, _SEN_B]
+                else:
+                    content_ids = [42]
+                ids += [_SOT, _MODEL_TK, _NL] + content_ids + [_EOT]
+        return ids
+
+    def encode(self, text, add_special_tokens=False):
+        if text == "XSENTINELMARKERX":
+            return [_SEN_A, _SEN_B]
+        return []
+
+
+class TestDeriveTurnMarkers:
+    """Unit tests for _derive_turn_markers."""
+
+    def test_extracts_correct_marker_and_eot(self, collate_mod):
+        """_derive_turn_markers returns the assistant prefix and EOT id."""
+        tokenizer = _Gemma4StyleTokenizer()
+        marker, eot = collate_mod._derive_turn_markers(tokenizer)
+
+        # assistant marker should be [SOT, MODEL, NL]
+        assert marker == [_SOT, _MODEL_TK, _NL]
+        # end-of-turn token should be EOT (token right after sentinel)
+        assert eot == _EOT
+
+    def test_raises_when_sentinel_absent(self, collate_mod):
+        """ValueError raised when the sentinel does not appear in template output."""
+
+        class _NoSentinelTokenizer:
+            def apply_chat_template(self, messages, tokenize=True, add_generation_prompt=False, **kwargs):
+                # Never includes sentinel
+                return [1, 2, 3, 4, 5]
+
+            def encode(self, text, add_special_tokens=False):
+                return [999, 888]  # sentinel ids that won't be found above
+
+        with pytest.raises(ValueError, match="not found"):
+            collate_mod._derive_turn_markers(_NoSentinelTokenizer())
+
+    def test_raises_when_marker_is_empty(self, collate_mod):
+        """ValueError raised when user and sentinel positions are adjacent (empty marker)."""
+
+        class _EmptyMarkerTokenizer:
+            def apply_chat_template(self, messages, tokenize=True, add_generation_prompt=False, **kwargs):
+                # user_ids == all_ids[:6], sentinel starts at position 6 → marker empty
+                user_ids = [1, 2, 3, 4, 5, 6]
+                sentinel_ids = [999, 888]
+                eot = [107]
+                msgs = messages
+                if len(msgs) == 1:
+                    return user_ids
+                return user_ids + sentinel_ids + eot
+
+            def encode(self, text, add_special_tokens=False):
+                return [999, 888]
+
+        with pytest.raises(ValueError, match="empty"):
+            collate_mod._derive_turn_markers(_EmptyMarkerTokenizer())
+
+
+class TestBuildLabelsFromTemplateGeneralPath:
+    """Tests for the general (non-Qwen) path of build_labels_from_template."""
+
+    def _make_gemma4_input_ids(self, *turns):
+        """Build input_ids matching _Gemma4StyleTokenizer layout."""
+        ids = []
+        for role, content_ids in turns:
+            if role == "user":
+                ids += [_SOT, _USER_TK, _NL, _U_CONTENT, _EOT, _NL]
+            else:
+                ids += [_SOT, _MODEL_TK, _NL] + content_ids + [_EOT]
+        return torch.tensor([ids], dtype=torch.long)
+
+    def test_general_path_labels_assistant_tokens(self, collate_mod):
+        """Non-Qwen processor with apply_chat_template uses general path and labels correctly."""
+        input_ids = self._make_gemma4_input_ids(
+            ("user", []),
+            ("assistant", [42, 43]),
+        )
+
+        class _Proc:
+            tokenizer = _Gemma4StyleTokenizer()
+
+        labels = collate_mod.build_labels_from_template(input_ids, [[]], _Proc())
+
+        # Labeled positions: content tokens [42, 43] + EOT
+        labeled = (labels[0] != -100).nonzero(as_tuple=True)[0].tolist()
+        labeled_vals = [input_ids[0, p].item() for p in labeled]
+        assert 42 in labeled_vals
+        assert 43 in labeled_vals
+        assert _EOT in labeled_vals
+        # User tokens must NOT be labeled
+        assert labels[0, 0].item() == -100  # SOT
+        assert labels[0, 1].item() == -100  # USER
+
+    def test_general_path_fallback_on_derive_failure(self, collate_mod):
+        """If _derive_turn_markers raises, falls back to build_labels without error."""
+        input_ids = torch.tensor([[1, 2, 3, 4, 5]], dtype=torch.long)
+        conv = [
+            {"role": "user", "content": [{"type": "text", "text": "Hi"}]},
+            {"role": "assistant", "content": [{"type": "text", "text": "Hello"}]},
+        ]
+
+        class _BrokenTokenizer:
+            """Has apply_chat_template but sentinel never appears → derive fails."""
+
+            def apply_chat_template(self, messages, tokenize=True, add_generation_prompt=False, **kwargs):
+                return [1, 2, 3]
+
+            def encode(self, text, add_special_tokens=False):
+                return [999, 888]
+
+            def __call__(self, text, **kwargs):
+                return {"input_ids": torch.tensor([[1, 2, 3, 4, 5]])}
+
+            def convert_tokens_to_ids(self, token):
+                return None
+
+            def decode(self, token):
+                return str(token)
+
+            pad_token_id = 0
+            eos_token = "<eos>"
+
+        class _BrokenProc:
+            tokenizer = _BrokenTokenizer()
+
+        # Must not raise; should return a tensor of correct shape
+        labels = collate_mod.build_labels_from_template(input_ids, [conv], _BrokenProc())
+        assert labels.shape == input_ids.shape
+
+
+# ---------------------------------------------------------------------------
 # Tests for _drop_overlong_samples / _estimate_media_tokens
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

`build_labels_from_template` has a fast marker-based path for Qwen-family
processors, but silently falls back to the fragile `build_labels` for any
other processor type (Gemma4, Llama, Mistral, ...).

`build_labels` re-tokenizes the assistant text standalone and searches for
it in `input_ids`. Because BPE is context-sensitive, the standalone
tokenization often differs from the in-sequence one → `_find_pattern_indices`
returns -1 → all labels = -100 → `num_label_tokens=0` → **nan loss**.

Observed on Gemma4-31B-it: intermittent and systematic `num_label_tokens=0`
steps causing nan loss and zero grad_norm during SFT training.

## Root cause

`Gemma4Processor` is not in `_IMSTART_TEMPLATE_PROCESSORS`, and
`convert_tokens_to_ids("<start_of_turn>")` returns the wrong id (3 instead
of 105) on the Gemma4 tokenizer, so a simple Gemma4-specific entry would
not be sufficient.

## Fix

Add two new helpers:

- **`_derive_turn_markers(tokenizer)`** — applies a minimal dummy conversation
  with a sentinel string and extracts the assistant-turn start marker and
  end-of-turn id directly from the resulting token ids. Works for *any* model
  without requiring per-processor registration. Also handles `BatchEncoding`
  (a `UserDict` subclass, not `dict`) correctly.

- **`_build_labels_from_markers(...)`** — shared scanning loop, eliminates
  duplication between the Qwen fast-path and the new general path.

`build_labels_from_template` now tries in order:
1. Fast path — Qwen via `convert_tokens_to_ids` (zero overhead)
2. General — `_derive_turn_markers` for all other processors
3. Last-resort — `build_labels` BPE fallback with an explicit warning

## Verification

Gemma4-31B-it SFT on 8×H100: `num_label_tokens` went from 0 (nan loss)
to the expected assistant response length after this fix.