### PR TITLE
fix: handle transformers.FineGrainedFP8Config quantization config

### DIFF
--- a/nemo_automodel/components/_peft/lora.py
+++ b/nemo_automodel/components/_peft/lora.py
@@ -77,6 +77,12 @@ class PeftConfig:
         )
 
 
+def _extract_base_dtype(quantization_config, default_dtype=torch.bfloat16) -> torch.dtype:
+    if hasattr(quantization_config, "bnb_4bit_compute_dtype"):
+        return quantization_config.bnb_4bit_compute_dtype
+    return default_dtype
+
+
 class LinearLoRA(nn.Linear):
     """
     Linear + LoRA, maintains ckpts structure (i.e. Linear's weight/bias remain at the same FQN).
@@ -543,7 +549,7 @@ def apply_lora_to_linear_modules(
                 num_modules_matched += 1
                 lora_dtype = peft_config.lora_dtype
                 if quantization_config is not None and lora_dtype is None:
-                    lora_dtype = quantization_config.bnb_4bit_compute_dtype or torch.bfloat16
+                    lora_dtype = _extract_base_dtype(quantization_config, torch.bfloat16)
 
                 # Compute effective LoRA rank for MoE modules
                 moe_dim = peft_config.dim
@@ -588,7 +594,7 @@ def apply_lora_to_linear_modules(
                 # For QLora, set lora_dtype to float16/bfloat16 since base weights are quantized
                 lora_dtype = peft_config.lora_dtype
                 if quantization_config is not None and lora_dtype is None:
-                    lora_dtype = quantization_config.bnb_4bit_compute_dtype or torch.bfloat16
+                    lora_dtype = _extract_base_dtype(quantization_config, torch.bfloat16)
 
                 patch_linear_module(
                     module,


### PR DESCRIPTION
# What does this PR do ?

Fixes issue with `examples/llm_finetune/mistral/ministral3_3b_squad_peft.yaml` config, where base-model uses fp8 weights.

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
