### PR TITLE
fix: preserve root mesh for multi-node Gemma4 TP4 FSDP2 runs

### DIFF
--- a/examples/vlm_finetune/gemma4/gemma4_31b_tp4.yaml
+++ b/examples/vlm_finetune/gemma4/gemma4_31b_tp4.yaml
@@ -1,0 +1,106 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Configuration for fine-tuning Gemma 4 31B (dense) with TP4 and MedPix dataset
+# Requires 8 GPUs with NVLink (TP4 x DP2 — max TP=4 due to 4 global KV heads)
+# torchrun --nproc-per-node=8 examples/vlm_finetune/finetune.py -c examples/vlm_finetune/gemma4/gemma4_31b_tp4.yaml
+
+recipe: FinetuneRecipeForVLM
+
+step_scheduler:
+  global_batch_size: 8
+  local_batch_size: 1
+  ckpt_every_steps: 500
+  val_every_steps: 500
+  num_epochs: 2
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 60
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 42
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained
+  pretrained_model_name_or_path: google/gemma-4-31B-it
+  torch_dtype: torch.bfloat16
+  use_liger_kernel: true
+  use_sdpa_patching: false
+  attn_implementation: sdpa
+  # 31B does not use kv_shared layers (only used in 2B, 4B), hence use_cache: false.
+  text_config:
+    use_cache: false
+
+checkpoint:
+  enabled: true
+  checkpoint_dir: vlm_checkpoints/gemma4_31b_it_tp4/
+  model_save_format: torch_save
+  save_consolidated: false
+
+distributed:
+  strategy: fsdp2
+  dp_size: none
+  tp_size: 4
+  cp_size: 1
+
+  sequence_parallel: false
+  activation_checkpointing: true
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.vlm.datasets.make_medpix_dataset
+  path_or_dataset: mmoukouba/MedPix-VQA
+  split: train[:1000]
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  num_workers: 0
+  pin_memory: true
+  collate_fn:
+    _target_: nemo_automodel.components.datasets.vlm.collate_fns.gemma4_prefix_collate_fn
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.vlm.datasets.make_medpix_dataset
+  path_or_dataset: mmoukouba/MedPix-VQA
+  split: validation[:500]
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn:
+    _target_: nemo_automodel.components.datasets.vlm.collate_fns.gemma4_prefix_collate_fn
+
+optimizer:
+  _target_: torch.optim.AdamW
+  lr: 1e-5
+  weight_decay: 0.01
+  betas: [0.9, 0.95]
+
+lr_scheduler:
+  lr_decay_style: cosine
+
+freeze_config:
+  freeze_embeddings: true
+  freeze_vision_tower: true
+  freeze_audio_tower: true
+  freeze_language_model: false
+
+# wandb:
+#   project: <your-project>
+#   entity: <your-entity>
+#   name: <your-run-name>

--- a/nemo_automodel/components/distributed/mesh_utils.py
+++ b/nemo_automodel/components/distributed/mesh_utils.py
@@ -409,3 +409,49 @@ def get_submesh(device_mesh: "DeviceMesh", names: tuple) -> "DeviceMesh":
         f"No parent flattened mesh found for dims {names} with target size {target}. "
         f"Available: {set(root._flatten_mapping)}"
     )
+
+
+def get_fsdp_dp_mesh(
+    device_mesh: "DeviceMesh",
+    dp_replicate_name: str = MeshAxisName.DP_REPLICATE,
+    dp_shard_cp_name: str = MeshAxisName.DP_SHARD_CP,
+) -> "DeviceMesh":
+    """Return the DP mesh for FSDP2 without losing the original root mesh.
+
+    ``get_submesh()`` may rebuild a fresh DeviceMesh when asked to compose native
+    and flattened dims like ``("dp_replicate", "dp_shard_cp")``. That is fine
+    for many local operations, but FSDP2 expects its DP mesh to share the same
+    root mesh as TP/EP meshes. On multi-node TP runs this can break group
+    construction in non-obvious ways.
+
+    Prefer native dimensions whenever possible:
+    - cp=1, dp_replicate=1  -> ``device_mesh["dp_shard"]``
+    - cp=1, dp_replicate>1  -> ``device_mesh[("dp_replicate", "dp_shard")]``
+    - cp>1, dp_replicate=1  -> ``device_mesh[("dp_shard", "cp")]``
+
+    When both CP and replicated DP are active we fall back to ``get_submesh()``
+    because the composed mesh is genuinely multi-level.
+    """
+
+    dp_shard_name = MeshAxisName.DP_SHARD
+    cp_name = MeshAxisName.CP
+
+    native_dims_available = (
+        dp_replicate_name in device_mesh.mesh_dim_names
+        and dp_shard_name in device_mesh.mesh_dim_names
+        and cp_name in device_mesh.mesh_dim_names
+    )
+    if native_dims_available:
+        cp_size = device_mesh[cp_name].size()
+        dp_replicate_size = device_mesh[dp_replicate_name].size()
+
+        if dp_replicate_size > 1 and cp_size > 1:
+            pass
+        elif dp_replicate_size > 1:
+            return device_mesh[(dp_replicate_name, dp_shard_name)]
+        elif cp_size > 1:
+            return device_mesh[(dp_shard_name, cp_name)]
+        else:
+            return device_mesh[dp_shard_name]
+
+    return get_submesh(device_mesh, (dp_replicate_name, dp_shard_cp_name))

--- a/nemo_automodel/components/distributed/optimized_tp_plans.py
+++ b/nemo_automodel/components/distributed/optimized_tp_plans.py
@@ -42,6 +42,7 @@ from transformers.models.qwen2.modeling_qwen2 import Qwen2ForCausalLM
 from transformers.models.qwen3.modeling_qwen3 import Qwen3ForCausalLM, Qwen3ForSequenceClassification
 
 from nemo_automodel.components.models.baichuan.model import BaichuanForCausalLM
+from nemo_automodel.components.models.gemma4_moe.model import Gemma4ForConditionalGeneration
 from nemo_automodel.components.models.llama.model import LlamaForCausalLM as CustomLlamaForCausalLM
 from nemo_automodel.components.models.mistral3.model import Ministral3ForCausalLM
 from nemo_automodel.components.models.qwen2.model import Qwen2ForCausalLM as CustomQwen2ForCausalLM
@@ -211,6 +212,41 @@ def _parallelize_gemma3(
         base_model_tp_plan.update(cast(dict[str, ParallelStyle], base_model_sp_plan))
 
     return cast(dict[str, ParallelStyle], base_model_tp_plan)
+
+
+def _parallelize_gemma4(
+    model: Gemma4ForConditionalGeneration,
+    sequence_parallel: bool = False,
+) -> dict[str, ParallelStyle]:
+    """Parallelizes a Gemma4ForConditionalGeneration model across tensor parallel dimensions.
+
+    Gemma4 VLM uses model.language_model.{embed_tokens, layers.*} for the text
+    backbone, identical to the Gemma3 VLM layout.
+    """
+    if sequence_parallel:
+        import warnings
+
+        warnings.warn(
+            "sequence_parallel=True is not yet supported for Gemma4 and will be ignored. ",
+            stacklevel=2,
+        )
+
+    model_prefix = "model.language_model"
+
+    return cast(
+        dict[str, ParallelStyle],
+        {
+            f"{model_prefix}.embed_tokens": VocabParallelEmbedding(input_layouts=Replicate()),
+            f"{model_prefix}.layers.*.self_attn.q_proj": ColwiseParallel(),
+            f"{model_prefix}.layers.*.self_attn.k_proj": ColwiseParallel(),
+            f"{model_prefix}.layers.*.self_attn.v_proj": ColwiseParallel(),
+            f"{model_prefix}.layers.*.self_attn.o_proj": RowwiseParallel(),
+            f"{model_prefix}.layers.*.mlp.up_proj": ColwiseParallel(),
+            f"{model_prefix}.layers.*.mlp.gate_proj": ColwiseParallel(),
+            f"{model_prefix}.layers.*.mlp.down_proj": RowwiseParallel(),
+            "lm_head": ColwiseParallel(output_layouts=Shard(-1), use_local_output=False),
+        },
+    )
 
 
 def get_llama_nemotron_super_tp_plan(
@@ -557,6 +593,7 @@ PARALLELIZE_FUNCTIONS: Dict[str, Callable[..., Dict[str, ParallelStyle]]] = {
     _get_class_qualname(Gemma3ForCausalLM): _parallelize_gemma3,
     # The larger gemma models use Gemma3ForConditionalGeneration, which are for text-image input
     _get_class_qualname(Gemma3ForConditionalGeneration): _parallelize_gemma3,
+    _get_class_qualname(Gemma4ForConditionalGeneration): _parallelize_gemma4,
     _get_class_qualname(PhiForCausalLM): _parallelize_phi,
     _get_class_qualname(Phi3ForCausalLM): _parallelize_phi3,
     _get_class_qualname(CustomLlamaForCausalLM): _parallelize_llama,

--- a/nemo_automodel/components/distributed/parallelizer.py
+++ b/nemo_automodel/components/distributed/parallelizer.py
@@ -47,7 +47,7 @@ from transformers.models.gemma3.modeling_gemma3 import (
     Gemma3ForConditionalGeneration,
 )
 
-from nemo_automodel.components.distributed.mesh_utils import get_submesh
+from nemo_automodel.components.distributed.mesh_utils import get_fsdp_dp_mesh, get_submesh
 
 
 def _is_transformers_v5_or_higher() -> bool:
@@ -156,8 +156,7 @@ class DefaultParallelizationStrategy(ParallelizationStrategy):
 
         # Set FSDP sharding mesh to context parallel mesh if CP > 1, else default to the data parallel mesh.
         # if dp_replicate_size > 1, use HSDP, else use FSDP
-        dp_mesh_dim_names = (dp_replicate_mesh_name, dp_shard_cp_mesh_name)
-        dp_mesh = get_submesh(device_mesh, dp_mesh_dim_names)
+        dp_mesh = get_fsdp_dp_mesh(device_mesh, dp_replicate_mesh_name, dp_shard_cp_mesh_name)
 
         # Extract layers from the model for parallelization
         layers = _extract_model_layers(model)
@@ -388,8 +387,7 @@ class NemotronHParallelizationStrategy(ParallelizationStrategy):
                 if layers[i].block_type == "mamba":
                     layers[i] = checkpoint_wrapper(layers[i])
 
-        dp_mesh_dim_names = (dp_replicate_mesh_name, dp_shard_cp_mesh_name)
-        dp_mesh = get_submesh(device_mesh, dp_mesh_dim_names)
+        dp_mesh = get_fsdp_dp_mesh(device_mesh, dp_replicate_mesh_name, dp_shard_cp_mesh_name)
 
         for layer in layers:
             parallelizer_utils.fully_shard_by_dtype(
@@ -492,8 +490,7 @@ class WanParallelizationStrategy(ParallelizationStrategy):
     ) -> nn.Module:
         # Not using custom tp_shard_plan; apply Wan-specific plan
         tp_mesh = device_mesh[tp_mesh_name]
-        dp_mesh_dim_names = (dp_replicate_mesh_name, dp_shard_cp_mesh_name)
-        dp_mesh = get_submesh(device_mesh, dp_mesh_dim_names)
+        dp_mesh = get_fsdp_dp_mesh(device_mesh, dp_replicate_mesh_name, dp_shard_cp_mesh_name)
 
         # Apply TP only when TP group size > 1
         if tp_mesh.size() > 1:
@@ -583,8 +580,7 @@ class HunyuanParallelizationStrategy(ParallelizationStrategy):
         tp_mesh_name: str = "tp",
         **kwargs,
     ) -> nn.Module:
-        dp_mesh_dim_names = (dp_replicate_mesh_name, dp_shard_cp_mesh_name)
-        dp_mesh = get_submesh(device_mesh, dp_mesh_dim_names)
+        dp_mesh = get_fsdp_dp_mesh(device_mesh, dp_replicate_mesh_name, dp_shard_cp_mesh_name)
 
         # Mixed precision default like Default strategy
         if not mp_policy:

--- a/nemo_automodel/components/distributed/parallelizer.py
+++ b/nemo_automodel/components/distributed/parallelizer.py
@@ -47,7 +47,7 @@ from transformers.models.gemma3.modeling_gemma3 import (
     Gemma3ForConditionalGeneration,
 )
 
-from nemo_automodel.components.distributed.mesh_utils import get_fsdp_dp_mesh, get_submesh
+from nemo_automodel.components.distributed.mesh_utils import get_fsdp_dp_mesh
 
 
 def _is_transformers_v5_or_higher() -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -385,6 +385,7 @@ modules = [
 ]
 ignore_imports = [
     "nemo_automodel.components.distributed.optimized_tp_plans -> nemo_automodel.components.models.llama.model",
+    "nemo_automodel.components.distributed.optimized_tp_plans -> nemo_automodel.components.models.gemma4_moe.model",
 ]
 
 # ty: type checking (https://github.com/astral-sh/ty)

--- a/tests/unit_tests/distributed/test_mesh_utils.py
+++ b/tests/unit_tests/distributed/test_mesh_utils.py
@@ -22,6 +22,7 @@ import torch
 from nemo_automodel.components.distributed.mesh_utils import (
     _unflatten_compat,
     get_flat_mesh,
+    get_fsdp_dp_mesh,
     get_submesh,
 )
 
@@ -305,3 +306,154 @@ class TestGetSubmeshPT29Compat:
 
         result = get_submesh(mesh, ("dp_replicate", "dp_shard_cp"))
         assert result is unflatten_result
+
+
+# ---------------------------------------------------------------------------
+# get_fsdp_dp_mesh
+# ---------------------------------------------------------------------------
+
+
+class TestGetFsdpDpMesh:
+    """Tests for get_fsdp_dp_mesh covering all five code paths.
+
+    The central guarantee under test: when native mesh dimensions are
+    available, the function slices the *existing* DeviceMesh directly via
+    ``__getitem__`` (preserving the shared root mesh required by FSDP2).
+    Only when the fully-composed ``(dp_replicate, dp_shard_cp)`` mesh is
+    needed does it delegate to ``get_submesh``, which may build a fresh
+    DeviceMesh.
+    """
+
+    _ALL_NATIVE_DIMS = ("dp_replicate", "dp_shard", "cp", "tp")
+
+    def _make_mesh(self, dim_names, sizes):
+        """Return a mock DeviceMesh.
+
+        ``sizes`` maps dim-name → int (return value of ``.size()``).
+        ``__getitem__`` returns a distinct sentinel whose ``_key`` and
+        ``_mesh`` attributes let callers assert *which* slice was returned
+        and that it came from the original mesh object (not a freshly
+        constructed one).
+        """
+        mesh = Mock()
+        mesh.mesh_dim_names = dim_names
+        slices = {}
+
+        def getitem(key):
+            if key not in slices:
+                sentinel = Mock()
+                sentinel._key = key
+                sentinel._mesh = mesh
+                sentinel.size = Mock(return_value=sizes.get(key, 1))
+                slices[key] = sentinel
+            return slices[key]
+
+        mesh.__getitem__ = Mock(side_effect=getitem)
+        return mesh
+
+    # ------------------------------------------------------------------
+    # Branch 1 – all native dims present, dp_replicate=1 and cp=1
+    # ------------------------------------------------------------------
+
+    def test_no_replicate_no_cp_returns_dp_shard_slice(self):
+        """dp_replicate=1, cp=1 → device_mesh["dp_shard"] (fast path, shared root)."""
+        mesh = self._make_mesh(self._ALL_NATIVE_DIMS, {"dp_replicate": 1, "cp": 1})
+
+        result = get_fsdp_dp_mesh(mesh)
+
+        mesh.__getitem__.assert_called_once_with("dp_shard")
+        assert result._key == "dp_shard"
+        # Returned mesh is a slice of the original, not a freshly built one.
+        assert result._mesh is mesh
+
+    # ------------------------------------------------------------------
+    # Branch 2 – dp_replicate > 1, cp = 1
+    # ------------------------------------------------------------------
+
+    def test_replicate_only_returns_replicate_shard_tuple_slice(self):
+        """dp_replicate>1, cp=1 → device_mesh[("dp_replicate","dp_shard")]."""
+        mesh = self._make_mesh(self._ALL_NATIVE_DIMS, {"dp_replicate": 2, "cp": 1})
+
+        result = get_fsdp_dp_mesh(mesh)
+
+        mesh.__getitem__.assert_called_once_with(("dp_replicate", "dp_shard"))
+        assert result._key == ("dp_replicate", "dp_shard")
+        assert result._mesh is mesh
+
+    # ------------------------------------------------------------------
+    # Branch 3 – dp_replicate = 1, cp > 1
+    # ------------------------------------------------------------------
+
+    def test_cp_only_returns_shard_cp_tuple_slice(self):
+        """dp_replicate=1, cp>1 → device_mesh[("dp_shard","cp")]."""
+        mesh = self._make_mesh(self._ALL_NATIVE_DIMS, {"dp_replicate": 1, "cp": 4})
+
+        result = get_fsdp_dp_mesh(mesh)
+
+        mesh.__getitem__.assert_called_once_with(("dp_shard", "cp"))
+        assert result._key == ("dp_shard", "cp")
+        assert result._mesh is mesh
+
+    # ------------------------------------------------------------------
+    # Branch 4 – dp_replicate > 1 AND cp > 1 → get_submesh fallback
+    # ------------------------------------------------------------------
+
+    def test_replicate_and_cp_falls_back_to_get_submesh(self):
+        """dp_replicate>1 and cp>1 → get_submesh called (composed mesh needed)."""
+        mesh = self._make_mesh(self._ALL_NATIVE_DIMS, {"dp_replicate": 2, "cp": 2})
+        submesh_sentinel = Mock()
+
+        with patch(
+            "nemo_automodel.components.distributed.mesh_utils.get_submesh",
+            return_value=submesh_sentinel,
+        ) as mock_get_submesh:
+            result = get_fsdp_dp_mesh(mesh)
+
+        mock_get_submesh.assert_called_once_with(mesh, ("dp_replicate", "dp_shard_cp"))
+        assert result is submesh_sentinel
+        # __getitem__ must NOT have been called directly.
+        mesh.__getitem__.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # Branch 5 – native dims not available → get_submesh fallback
+    # ------------------------------------------------------------------
+
+    def test_missing_native_dims_falls_back_to_get_submesh(self):
+        """When dp_shard/cp are absent from mesh, get_submesh is used."""
+        mesh = self._make_mesh(
+            ("dp_replicate", "dp_shard_cp", "tp"),
+            {"dp_replicate": 2},
+        )
+        submesh_sentinel = Mock()
+
+        with patch(
+            "nemo_automodel.components.distributed.mesh_utils.get_submesh",
+            return_value=submesh_sentinel,
+        ) as mock_get_submesh:
+            result = get_fsdp_dp_mesh(mesh)
+
+        mock_get_submesh.assert_called_once_with(mesh, ("dp_replicate", "dp_shard_cp"))
+        assert result is submesh_sentinel
+        mesh.__getitem__.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # Custom dim-name parameters are forwarded correctly
+    # ------------------------------------------------------------------
+
+    def test_custom_dim_names_forwarded_to_get_submesh(self):
+        """Non-default dp_replicate_name / dp_shard_cp_name reach get_submesh."""
+        mesh = self._make_mesh(("my_rep", "my_shard_cp", "tp"), {"my_rep": 2})
+        submesh_sentinel = Mock()
+
+        with patch(
+            "nemo_automodel.components.distributed.mesh_utils.get_submesh",
+            return_value=submesh_sentinel,
+        ) as mock_get_submesh:
+            result = get_fsdp_dp_mesh(
+                mesh,
+                dp_replicate_name="my_rep",
+                dp_shard_cp_name="my_shard_cp",
+            )
+
+        mock_get_submesh.assert_called_once_with(mesh, ("my_rep", "my_shard_cp"))
+        assert result is submesh_sentinel

--- a/uv.lock
+++ b/uv.lock
@@ -2317,17 +2317,18 @@ wheels = [
 
 [[package]]
 name = "kernels"
-version = "0.12.2"
+version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
     { name = "packaging" },
     { name = "pyyaml" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tomlkit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/07/d2b635e965b232cae1aa873c6e0458947196be8dca7bb02e64d3cd6e8d19/kernels-0.12.2.tar.gz", hash = "sha256:812fc43c2814f046cee655cbebf3918cddd489715773670bdb38cca3f5203b5b", size = 57108, upload-time = "2026-03-04T10:03:00.379Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/0d/e9c158c527a7b51382fe816a7b7e60caae17ff1153640c1803211a067c99/kernels-0.13.0.tar.gz", hash = "sha256:bf7908206009bff0017d09b87f0f6b5934a1a20520562caf1cbb06cab36418cc", size = 74755, upload-time = "2026-04-10T14:30:45.356Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/be/f5d6758b48633e4f6a28198fcf4bf9f763cc6a82e2335d9fe8802a5cb440/kernels-0.12.2-py3-none-any.whl", hash = "sha256:1289261804748cf3cf8e3afab80b505b0f1b28e4ec88379cdf08dc31e64964b8", size = 55205, upload-time = "2026-03-04T10:02:59.305Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/45/2cb29e965c199ab01151fee24cbb57b23550c9e6bc897ca242b1e4b8c4bf/kernels-0.13.0-py3-none-any.whl", hash = "sha256:5d857ee4e06dc7496bcd59c4756e84eb71c019b34524dea58ccb0eaaae3bb6df", size = 69177, upload-time = "2026-04-10T14:30:43.551Z" },
 ]
 
 [[package]]
@@ -3310,7 +3311,6 @@ all = [
     { name = "ftfy" },
     { name = "imageio" },
     { name = "imageio-ffmpeg" },
-    { name = "kernels" },
     { name = "mamba-ssm" },
     { name = "mistral-common", extra = ["opencv"] },
     { name = "numba", version = "0.53.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
@@ -3352,6 +3352,17 @@ delta-databricks = [
     { name = "deltalake" },
 ]
 diffusion = [
+    { name = "diffusers" },
+    { name = "ftfy" },
+    { name = "imageio" },
+    { name = "imageio-ffmpeg" },
+    { name = "opencv-python-headless" },
+    { name = "torchvision", version = "0.24.0", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "torchvision", version = "0.24.0+cu129", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "platform_machine != 'aarch64' and sys_platform == 'linux'" },
+    { name = "torchvision", version = "0.25.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
+    { name = "torchvision", version = "0.25.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin' and sys_platform != 'linux'" },
+]
+diffusion-kernels = [
     { name = "diffusers" },
     { name = "ftfy" },
     { name = "imageio" },
@@ -3450,7 +3461,7 @@ requires-dist = [
     { name = "ftfy", marker = "extra == 'diffusion'" },
     { name = "imageio", marker = "extra == 'diffusion'" },
     { name = "imageio-ffmpeg", marker = "extra == 'diffusion'" },
-    { name = "kernels", marker = "extra == 'diffusion'" },
+    { name = "kernels", marker = "extra == 'diffusion-kernels'" },
     { name = "mamba-ssm", marker = "extra == 'cuda'" },
     { name = "megatron-fsdp", specifier = ">=0.2.3" },
     { name = "mistral-common", extras = ["audio", "hf-hub", "image", "sentencepiece"] },
@@ -3460,6 +3471,7 @@ requires-dist = [
     { name = "nemo-automodel", extras = ["cuda"], marker = "extra == 'moe'" },
     { name = "nemo-automodel", extras = ["delta-databricks"], marker = "extra == 'all'" },
     { name = "nemo-automodel", extras = ["diffusion"], marker = "extra == 'all'" },
+    { name = "nemo-automodel", extras = ["diffusion"], marker = "extra == 'diffusion-kernels'" },
     { name = "nemo-automodel", extras = ["extra"], marker = "extra == 'all'" },
     { name = "nemo-automodel", extras = ["vlm"], marker = "extra == 'all'" },
     { name = "numba", marker = "extra == 'vlm'" },
@@ -3491,7 +3503,7 @@ requires-dist = [
     { name = "transformers", specifier = "==5.5.0" },
     { name = "wandb" },
 ]
-provides-extras = ["diffusion", "cuda", "cuda-source", "extra", "fa", "delta-databricks", "moe", "vlm", "cli", "all"]
+provides-extras = ["diffusion", "diffusion-kernels", "cuda", "cuda-source", "extra", "fa", "delta-databricks", "moe", "vlm", "cli", "all"]
 
 [package.metadata.requires-dev]
 build = [
@@ -6749,6 +6761,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/46/cc36c679f09f27ded940281c38607716c86cf8ba4a518d524e349c8b4874/tomli-2.3.0-cp314-cp314t-win32.whl", hash = "sha256:a1f7f282fe248311650081faafa5f4732bdbfef5d45fe3f2e702fbc6f2d496e0", size = 107563, upload-time = "2025-10-08T22:01:44.233Z" },
     { url = "https://files.pythonhosted.org/packages/84/ff/426ca8683cf7b753614480484f6437f568fd2fda2edbdf57a2d3d8b27a0b/tomli-2.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:70a251f8d4ba2d9ac2542eecf008b3c8a9fc5c3f9f02c56a9d7952612be2fdba", size = 119756, upload-time = "2025-10-08T22:01:45.234Z" },
     { url = "https://files.pythonhosted.org/packages/77/b8/0135fadc89e73be292b473cb820b4f5a08197779206b33191e801feeae40/tomli-2.3.0-py3-none-any.whl", hash = "sha256:e95b1af3c5b07d9e643909b5abbec77cd9f1217e6d0bca72b0234736b9fb1f1b", size = 14408, upload-time = "2025-10-08T22:01:46.04Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/af/14b24e41977adb296d6bd1fb59402cf7d60ce364f90c890bd2ec65c43b5a/tomlkit-0.14.0.tar.gz", hash = "sha256:cf00efca415dbd57575befb1f6634c4f42d2d87dbba376128adb42c121b87064", size = 187167, upload-time = "2026-01-13T01:14:53.304Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl", hash = "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680", size = 39310, upload-time = "2026-01-13T01:14:51.965Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2317,18 +2317,17 @@ wheels = [
 
 [[package]]
 name = "kernels"
-version = "0.13.0"
+version = "0.12.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
     { name = "packaging" },
     { name = "pyyaml" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "tomlkit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3e/0d/e9c158c527a7b51382fe816a7b7e60caae17ff1153640c1803211a067c99/kernels-0.13.0.tar.gz", hash = "sha256:bf7908206009bff0017d09b87f0f6b5934a1a20520562caf1cbb06cab36418cc", size = 74755, upload-time = "2026-04-10T14:30:45.356Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/07/d2b635e965b232cae1aa873c6e0458947196be8dca7bb02e64d3cd6e8d19/kernels-0.12.2.tar.gz", hash = "sha256:812fc43c2814f046cee655cbebf3918cddd489715773670bdb38cca3f5203b5b", size = 57108, upload-time = "2026-03-04T10:03:00.379Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/45/2cb29e965c199ab01151fee24cbb57b23550c9e6bc897ca242b1e4b8c4bf/kernels-0.13.0-py3-none-any.whl", hash = "sha256:5d857ee4e06dc7496bcd59c4756e84eb71c019b34524dea58ccb0eaaae3bb6df", size = 69177, upload-time = "2026-04-10T14:30:43.551Z" },
+    { url = "https://files.pythonhosted.org/packages/08/be/f5d6758b48633e4f6a28198fcf4bf9f763cc6a82e2335d9fe8802a5cb440/kernels-0.12.2-py3-none-any.whl", hash = "sha256:1289261804748cf3cf8e3afab80b505b0f1b28e4ec88379cdf08dc31e64964b8", size = 55205, upload-time = "2026-03-04T10:02:59.305Z" },
 ]
 
 [[package]]
@@ -3311,6 +3310,7 @@ all = [
     { name = "ftfy" },
     { name = "imageio" },
     { name = "imageio-ffmpeg" },
+    { name = "kernels" },
     { name = "mamba-ssm" },
     { name = "mistral-common", extra = ["opencv"] },
     { name = "numba", version = "0.53.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
@@ -3352,17 +3352,6 @@ delta-databricks = [
     { name = "deltalake" },
 ]
 diffusion = [
-    { name = "diffusers" },
-    { name = "ftfy" },
-    { name = "imageio" },
-    { name = "imageio-ffmpeg" },
-    { name = "opencv-python-headless" },
-    { name = "torchvision", version = "0.24.0", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "torchvision", version = "0.24.0+cu129", source = { registry = "https://download.pytorch.org/whl/cu129" }, marker = "platform_machine != 'aarch64' and sys_platform == 'linux'" },
-    { name = "torchvision", version = "0.25.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "torchvision", version = "0.25.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin' and sys_platform != 'linux'" },
-]
-diffusion-kernels = [
     { name = "diffusers" },
     { name = "ftfy" },
     { name = "imageio" },
@@ -3461,7 +3450,7 @@ requires-dist = [
     { name = "ftfy", marker = "extra == 'diffusion'" },
     { name = "imageio", marker = "extra == 'diffusion'" },
     { name = "imageio-ffmpeg", marker = "extra == 'diffusion'" },
-    { name = "kernels", marker = "extra == 'diffusion-kernels'" },
+    { name = "kernels", marker = "extra == 'diffusion'" },
     { name = "mamba-ssm", marker = "extra == 'cuda'" },
     { name = "megatron-fsdp", specifier = ">=0.2.3" },
     { name = "mistral-common", extras = ["audio", "hf-hub", "image", "sentencepiece"] },
@@ -3471,7 +3460,6 @@ requires-dist = [
     { name = "nemo-automodel", extras = ["cuda"], marker = "extra == 'moe'" },
     { name = "nemo-automodel", extras = ["delta-databricks"], marker = "extra == 'all'" },
     { name = "nemo-automodel", extras = ["diffusion"], marker = "extra == 'all'" },
-    { name = "nemo-automodel", extras = ["diffusion"], marker = "extra == 'diffusion-kernels'" },
     { name = "nemo-automodel", extras = ["extra"], marker = "extra == 'all'" },
     { name = "nemo-automodel", extras = ["vlm"], marker = "extra == 'all'" },
     { name = "numba", marker = "extra == 'vlm'" },
@@ -3503,7 +3491,7 @@ requires-dist = [
     { name = "transformers", specifier = "==5.5.0" },
     { name = "wandb" },
 ]
-provides-extras = ["diffusion", "diffusion-kernels", "cuda", "cuda-source", "extra", "fa", "delta-databricks", "moe", "vlm", "cli", "all"]
+provides-extras = ["diffusion", "cuda", "cuda-source", "extra", "fa", "delta-databricks", "moe", "vlm", "cli", "all"]
 
 [package.metadata.requires-dev]
 build = [
@@ -6761,15 +6749,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/46/cc36c679f09f27ded940281c38607716c86cf8ba4a518d524e349c8b4874/tomli-2.3.0-cp314-cp314t-win32.whl", hash = "sha256:a1f7f282fe248311650081faafa5f4732bdbfef5d45fe3f2e702fbc6f2d496e0", size = 107563, upload-time = "2025-10-08T22:01:44.233Z" },
     { url = "https://files.pythonhosted.org/packages/84/ff/426ca8683cf7b753614480484f6437f568fd2fda2edbdf57a2d3d8b27a0b/tomli-2.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:70a251f8d4ba2d9ac2542eecf008b3c8a9fc5c3f9f02c56a9d7952612be2fdba", size = 119756, upload-time = "2025-10-08T22:01:45.234Z" },
     { url = "https://files.pythonhosted.org/packages/77/b8/0135fadc89e73be292b473cb820b4f5a08197779206b33191e801feeae40/tomli-2.3.0-py3-none-any.whl", hash = "sha256:e95b1af3c5b07d9e643909b5abbec77cd9f1217e6d0bca72b0234736b9fb1f1b", size = 14408, upload-time = "2025-10-08T22:01:46.04Z" },
-]
-
-[[package]]
-name = "tomlkit"
-version = "0.14.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/af/14b24e41977adb296d6bd1fb59402cf7d60ce364f90c890bd2ec65c43b5a/tomlkit-0.14.0.tar.gz", hash = "sha256:cf00efca415dbd57575befb1f6634c4f42d2d87dbba376128adb42c121b87064", size = 187167, upload-time = "2026-01-13T01:14:53.304Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl", hash = "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680", size = 39310, upload-time = "2026-01-13T01:14:51.965Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR builds on the Gemma4 TP4 baseline from #1861 and adds the missing multi-node FSDP2 mesh fix that allowed our TP4 experiment to initialize cleanly on a 4-node setup.

Specifically, it:

- adds the official Gemma4 TP4 example recipe
- preserves the original root `DeviceMesh` when selecting the FSDP DP mesh for multi-node FSDP2 + TP runs
- switches FSDP-capable parallelization strategies to use the new DP mesh helper
- removes an unused import left behind by the mesh helper migration

## Background

#1861 established the Gemma4 TP4 baseline by registering the correct Gemma4 TP plan and providing a TP4 example recipe. That baseline is necessary, but it was not sufficient for our multi-node run.

The remaining issue was in how the FSDP DP mesh was derived. The previous logic asked for:

```python
get_submesh(device_mesh, ("dp_replicate", "dp_shard_cp"))
```

That can synthesize a fresh `DeviceMesh` when native and flattened dimensions are composed together. In single-node cases this may go unnoticed, but in multi-node TP runs FSDP2 expects the DP mesh to continue sharing the same root mesh as the TP and EP meshes.

When that assumption is broken, distributed group construction can fail in non-obvious ways before training settles into a healthy steady state.

## What changed

`get_fsdp_dp_mesh()` now prefers native mesh dimensions whenever possible:

- `dp_shard` when `cp=1` and `dp_replicate=1`
- `(dp_replicate, dp_shard)` when `cp=1` and replicated DP is active
- `(dp_shard, cp)` when CP is active without replicated DP

It only falls back to the previous composed-submesh path when both CP and replicated DP are active and the mesh is genuinely multi-level.

The FSDP2 parallelization strategies now use this helper instead of reconstructing the DP mesh through `get_submesh()`.

## Why this is needed

Without this change, the Gemma4 TP4 baseline from #1861 can still hit multi-node FSDP2 + TP initialization issues because the DP mesh used for sharding no longer reliably shares the same root mesh as the other distributed dimensions.

This patch is the code-side change that made the TP4 experiment runnable on top of the #1861 baseline.

## Validation

- `python -m py_compile nemo_automodel/components/distributed/mesh_utils.py nemo_automodel/components/distributed/parallelizer.py`
- `ruff check nemo_automodel/components/distributed/mesh_utils.py nemo_automodel/components/distributed/parallelizer.py`
