### PR TITLE
cp: 1813 fix: FSDP2 meta-device crash for Qwen3.5 GatedDeltaNet fp32 params

### DIFF
--- a/nemo_automodel/components/models/qwen3_5_moe/cp_linear_attn.py
+++ b/nemo_automodel/components/models/qwen3_5_moe/cp_linear_attn.py
@@ -77,6 +77,121 @@ class CPAwareGatedDeltaNet(Qwen3_5MoeGatedDeltaNet):
         super().__init__(config, layer_idx)
         self._cp_mesh = None
 
+    def _compute_gate(self, a: torch.Tensor) -> torch.Tensor:
+        """Compute the gating value ``g`` using fp32 params.
+
+        When ``_fp32_params`` exists (FSDP mixed-dtype), delegates to
+        the holder's forward so FSDP unshard/reshard lifecycle is natural.
+        Otherwise falls back to the inline computation.
+        """
+        if hasattr(self, "_fp32_params"):
+            return self._fp32_params(a, self.dt_bias)
+        return -self.A_log.float().exp() * F.softplus(a.float() + self.dt_bias)
+
+    def _forward_no_cp(
+        self,
+        hidden_states: torch.Tensor,
+        cache_params=None,
+        cache_position=None,
+        attention_mask: torch.Tensor | None = None,
+    ):
+        """HF GatedDeltaNet forward with FSDP-safe fp32 gate computation.
+
+        Copied from transformers==5.3.0 Qwen3_5GatedDeltaNet.forward
+        with gate computation replaced by self._compute_gate(a).
+        """
+        from transformers.models.qwen3_5.modeling_qwen3_5 import apply_mask_to_padding_states
+
+        hidden_states = apply_mask_to_padding_states(hidden_states, attention_mask)
+        batch_size, seq_len, _ = hidden_states.shape
+
+        use_precomputed_states = (
+            cache_params is not None and cache_params.has_previous_state and seq_len == 1 and cache_position is not None
+        )
+
+        if cache_params is not None:
+            conv_state = cache_params.conv_states[self.layer_idx]
+            recurrent_state = cache_params.recurrent_states[self.layer_idx]
+
+        mixed_qkv = self.in_proj_qkv(hidden_states)
+        mixed_qkv = mixed_qkv.transpose(1, 2)
+
+        z = self.in_proj_z(hidden_states)
+        z = z.reshape(batch_size, seq_len, -1, self.head_v_dim)
+
+        b = self.in_proj_b(hidden_states)
+        a = self.in_proj_a(hidden_states)
+
+        if use_precomputed_states:
+            mixed_qkv = self.causal_conv1d_update(
+                mixed_qkv,
+                conv_state,
+                self.conv1d.weight.squeeze(1),
+                self.conv1d.bias,
+                self.activation,
+            )
+        else:
+            if cache_params is not None:
+                conv_state = F.pad(mixed_qkv, (self.conv_kernel_size - mixed_qkv.shape[-1], 0))
+                cache_params.conv_states[self.layer_idx] = conv_state
+            if self.causal_conv1d_fn is not None:
+                mixed_qkv = self.causal_conv1d_fn(
+                    x=mixed_qkv,
+                    weight=self.conv1d.weight.squeeze(1),
+                    bias=self.conv1d.bias,
+                    activation=self.activation,
+                    seq_idx=None,
+                )
+            else:
+                mixed_qkv = F.silu(self.conv1d(mixed_qkv)[:, :, :seq_len])
+
+        mixed_qkv = mixed_qkv.transpose(1, 2)
+        query, key, value = torch.split(mixed_qkv, [self.key_dim, self.key_dim, self.value_dim], dim=-1)
+
+        query = query.reshape(batch_size, seq_len, -1, self.head_k_dim)
+        key = key.reshape(batch_size, seq_len, -1, self.head_k_dim)
+        value = value.reshape(batch_size, seq_len, -1, self.head_v_dim)
+
+        beta = b.sigmoid()
+        g = self._compute_gate(a)
+
+        if self.num_v_heads // self.num_k_heads > 1:
+            query = query.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
+            key = key.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
+
+        if not use_precomputed_states:
+            core_attn_out, last_recurrent_state = self.chunk_gated_delta_rule(
+                query,
+                key,
+                value,
+                g=g,
+                beta=beta,
+                initial_state=None,
+                output_final_state=cache_params is not None,
+                use_qk_l2norm_in_kernel=True,
+            )
+        else:
+            core_attn_out, last_recurrent_state = self.recurrent_gated_delta_rule(
+                query,
+                key,
+                value,
+                g=g,
+                beta=beta,
+                initial_state=recurrent_state,
+                output_final_state=cache_params is not None,
+                use_qk_l2norm_in_kernel=True,
+            )
+
+        if cache_params is not None:
+            cache_params.recurrent_states[self.layer_idx] = last_recurrent_state
+
+        core_attn_out = core_attn_out.reshape(-1, self.head_v_dim)
+        z = z.reshape(-1, self.head_v_dim)
+        core_attn_out = self.norm(core_attn_out, z)
+        core_attn_out = core_attn_out.reshape(batch_size, seq_len, -1)
+
+        return self.out_proj(core_attn_out)
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -88,9 +203,9 @@ class CPAwareGatedDeltaNet(Qwen3_5MoeGatedDeltaNet):
         cu_seqlens: torch.Tensor | None = None,
         seq_index: torch.Tensor | None = None,
     ):
-        # Fast path: no CP → original HF forward
+        # Fast path: no CP → run HF forward with fp32-safe gate computation
         if self._cp_mesh is None or self._cp_mesh.size() <= 1:
-            return super().forward(
+            return self._forward_no_cp(
                 hidden_states,
                 cache_params=cache_params,
                 attention_mask=attention_mask,
@@ -299,7 +414,7 @@ class CPAwareGatedDeltaNet(Qwen3_5MoeGatedDeltaNet):
 
         # ---- Gate & beta ----
         beta = b.sigmoid()
-        g = -self.A_log.float().exp() * F.softplus(a.float() + self.dt_bias)
+        g = self._compute_gate(a)
 
         # GVA: repeat q/k heads to match v heads
         if self.num_v_heads // self.num_k_heads > 1:
@@ -340,14 +455,49 @@ class CPAwareGatedDeltaNet(Qwen3_5MoeGatedDeltaNet):
         return output
 
 
+class _Fp32ParamHolder(torch.nn.Module):
+    """Holder for float32 params (A_log) that need a separate FSDP group.
+
+    The ``forward`` computes the gating value ``g`` that HF's
+    ``Qwen3_5GatedDeltaNet.forward`` would normally compute inline.
+    By doing the computation *inside* this module's forward, FSDP's
+    unshard/reshard lifecycle works naturally — the params are
+    unsharded during the computation and resharded after.
+    """
+
+    def forward(self, a: torch.Tensor, dt_bias: torch.Tensor) -> torch.Tensor:
+        return -self.A_log.float().exp() * F.softplus(a.float() + dt_bias)
+
+
+def _make_fp32_getattr(orig_getattr):
+    """Create a ``__getattr__`` that resolves fp32 params from ``_fp32_params``.
+
+    Allows ``self.A_log`` to resolve from the holder submodule so that
+    code outside forward (e.g. state_dict, checkpointing) can still
+    access the parameter by name.
+    """
+
+    def _getattr_with_fp32(self, name):
+        modules = self.__dict__.get("_modules", {})
+        fp32_holder = modules.get("_fp32_params")
+        if fp32_holder is not None and name in fp32_holder._parameters:
+            return fp32_holder._parameters[name]
+        return orig_getattr(self, name)
+
+    return _getattr_with_fp32
+
+
 def patch_hf_model(model, cp_enabled=False):
     """Patch HF Qwen3.5 GatedDeltaNet modules for FSDP and optional CP support.
 
     For FSDP compatibility, move float32 bare params (A_log) into a
-    _fp32_params submodule so fully_shard_by_dtype can wrap them separately.
+    ``_fp32_params`` submodule so ``fully_shard_by_dtype`` can wrap them
+    in a separate FSDP group.
 
-    When ``cp_enabled=True``, also swap each module's __class__ to
-    CPAwareGatedDeltaNet for context parallelism support.
+    Every module's ``__class__`` is swapped to ``CPAwareGatedDeltaNet``
+    whose ``forward()`` calls ``self._fp32_params()`` to trigger FSDP
+    unshard before accessing the fp32 params.  When ``cp_enabled=True``,
+    the CP mesh is also configured.
     """
     import logging
 
@@ -357,29 +507,37 @@ def patch_hf_model(model, cp_enabled=False):
         return
 
     _logger = logging.getLogger(__name__)
+    _PATCHED_ATTR = "_fp32_getattr_patched"
     patched = 0
+    patched_classes = set()
     for name, mod in model.named_modules():
         if not isinstance(mod, Qwen3_5GatedDeltaNet):
             continue
 
-        if cp_enabled:
-            mod.__class__ = CPAwareGatedDeltaNet
-            mod._cp_mesh = None
+        mod.__class__ = CPAwareGatedDeltaNet
+        mod._cp_mesh = None
 
         # Move float32 bare params into a holder submodule for FSDP.
-        # The __dict__ reference lets HF forward access self.A_log directly,
-        # while FSDP manages the param via the _fp32_params submodule.
+        # The CPAwareGatedDeltaNet forward calls self._fp32_params()
+        # to trigger FSDP unshard; __getattr__ redirects self.A_log
+        # to the holder so it returns the unsharded plain tensor.
         holder = None
         for pname in list(mod._parameters.keys()):
             param = mod._parameters[pname]
             if param is not None and param.dtype == torch.float32:
                 if holder is None:
-                    holder = torch.nn.Module()
+                    holder = _Fp32ParamHolder()
                 setattr(holder, pname, param)
                 del mod._parameters[pname]
-                mod.__dict__[pname] = param
         if holder is not None:
             mod.add_module("_fp32_params", holder)
+
+            # Guard against re-wrapping __getattr__ on repeated calls.
+            cls = type(mod)
+            if cls not in patched_classes and not getattr(cls, _PATCHED_ATTR, False):
+                cls.__getattr__ = _make_fp32_getattr(cls.__getattr__)
+                setattr(cls, _PATCHED_ATTR, True)
+                patched_classes.add(cls)
         patched += 1
 
     if patched > 0:

--- a/tests/unit_tests/models/qwen3_5/test_cp_linear_attn_patch.py
+++ b/tests/unit_tests/models/qwen3_5/test_cp_linear_attn_patch.py
@@ -72,30 +72,35 @@ class TestPatchHfModel:
 
         patch_hf_model(fake_model, cp_enabled=False)
 
-        # A_log (float32) should be moved out of _parameters into __dict__
+        # A_log (float32) should be moved out of _parameters
         assert "A_log" not in la._parameters
+        # Accessed via __getattr__ → _fp32_params
         assert la.A_log.dtype == torch.float32
         # dt_bias (bfloat16) stays as a regular parameter
         assert "dt_bias" in la._parameters
         # _fp32_params submodule holds the moved param
         assert hasattr(la, "_fp32_params")
         assert la._fp32_params.A_log.dtype == torch.float32
-        # __dict__ reference and holder share the same tensor
+        # __getattr__ resolves to the same tensor in _fp32_params
         assert la.A_log is la._fp32_params.A_log
 
-    def test_no_class_swap_when_cp_disabled(self, fake_model, monkeypatch):
-        """With cp_enabled=False, class should not change to CPAwareGatedDeltaNet."""
+    def test_class_always_swapped_for_fsdp(self, fake_model, monkeypatch):
+        """Class is always swapped to CPAwareGatedDeltaNet for FSDP fp32 unshard support."""
         self._stub_qwen3_5_modules(monkeypatch)
 
         cp_mod_key = "nemo_automodel.components.models.qwen3_5_moe.cp_linear_attn"
         if cp_mod_key in sys.modules:
             monkeypatch.delitem(sys.modules, cp_mod_key)
 
-        from nemo_automodel.components.models.qwen3_5_moe.cp_linear_attn import patch_hf_model
+        from nemo_automodel.components.models.qwen3_5_moe.cp_linear_attn import (
+            CPAwareGatedDeltaNet,
+            patch_hf_model,
+        )
 
         la = fake_model.layers[0].linear_attn
         patch_hf_model(fake_model, cp_enabled=False)
-        assert type(la) is _FakeGatedDeltaNet
+        assert type(la) is CPAwareGatedDeltaNet
+        assert la._cp_mesh is None
 
     def test_class_swap_when_cp_enabled(self, fake_model, monkeypatch):
         """With cp_enabled=True, class is swapped to CPAwareGatedDeltaNet."""
@@ -115,19 +120,167 @@ class TestPatchHfModel:
         assert type(la) is CPAwareGatedDeltaNet
         assert la._cp_mesh is None
 
-    def test_dict_access_preserves_tensor_identity(self, fake_model):
-        """__dict__ reference and _fp32_params hold the same tensor."""
+    def test_getattr_resolves_after_param_replacement(self, fake_model, monkeypatch):
+        """__getattr__ resolves to _fp32_params even after the underlying tensor is replaced."""
+        self._stub_qwen3_5_modules(monkeypatch)
+
+        cp_mod_key = "nemo_automodel.components.models.qwen3_5_moe.cp_linear_attn"
+        if cp_mod_key in sys.modules:
+            monkeypatch.delitem(sys.modules, cp_mod_key)
+
+        from nemo_automodel.components.models.qwen3_5_moe.cp_linear_attn import patch_hf_model
+
         la = fake_model.layers[0].linear_attn
-        original_A_log = la.A_log
+        patch_hf_model(fake_model, cp_enabled=False)
 
-        holder = nn.Module()
-        setattr(holder, "A_log", la.A_log)
-        del la._parameters["A_log"]
-        la.__dict__["A_log"] = original_A_log
-        la.add_module("_fp32_params", holder)
+        # Simulate FSDP replacing the parameter in _fp32_params
+        new_tensor = nn.Parameter(torch.zeros(4, dtype=torch.float32))
+        la._fp32_params._parameters["A_log"] = new_tensor
 
-        assert la.A_log is la._fp32_params.A_log
-        assert id(la.A_log) == id(original_A_log)
+        # __getattr__ should resolve to the NEW tensor, not the old one
+        assert la.A_log is new_tensor
+
+
+class TestFp32ParamHolder:
+    """Tests for _Fp32ParamHolder forward (gate computation)."""
+
+    @staticmethod
+    def _stub_and_import(monkeypatch):
+        for path in (
+            "transformers.models.qwen3_5_moe",
+            "transformers.models.qwen3_5_moe.modeling_qwen3_5_moe",
+            "transformers.models.qwen3_5",
+            "transformers.models.qwen3_5.modeling_qwen3_5",
+        ):
+            if path not in sys.modules:
+                stub = types.ModuleType(path)
+                stub.Qwen3_5MoeGatedDeltaNet = _FakeGatedDeltaNet
+                stub.Qwen3_5GatedDeltaNet = _FakeGatedDeltaNet
+                monkeypatch.setitem(sys.modules, path, stub)
+        cp_mod_key = "nemo_automodel.components.models.qwen3_5_moe.cp_linear_attn"
+        if cp_mod_key in sys.modules:
+            monkeypatch.delitem(sys.modules, cp_mod_key)
+        from nemo_automodel.components.models.qwen3_5_moe.cp_linear_attn import _Fp32ParamHolder
+
+        return _Fp32ParamHolder
+
+    def test_holder_forward_computes_gate(self, monkeypatch):
+        """_Fp32ParamHolder.forward returns g = -A_log.exp() * softplus(a + dt_bias)."""
+        _Fp32ParamHolder = self._stub_and_import(monkeypatch)
+        holder = _Fp32ParamHolder()
+        holder.A_log = nn.Parameter(torch.ones(4, dtype=torch.float32))
+        a = torch.zeros(4)
+        dt_bias = torch.zeros(4)
+        g = holder(a, dt_bias)
+        # g = -exp(1) * softplus(0 + 0) = -e * softplus(0) = -e * ln(2)
+        expected = -torch.ones(4).float().exp() * torch.nn.functional.softplus(torch.zeros(4))
+        assert torch.allclose(g, expected, atol=1e-5)
+
+    def test_holder_forward_dtype_is_float32(self, monkeypatch):
+        """Gate computation happens in float32 even with bfloat16 inputs."""
+        _Fp32ParamHolder = self._stub_and_import(monkeypatch)
+        holder = _Fp32ParamHolder()
+        holder.A_log = nn.Parameter(torch.ones(4, dtype=torch.float32))
+        a = torch.zeros(4, dtype=torch.bfloat16)
+        dt_bias = torch.zeros(4, dtype=torch.bfloat16)
+        g = holder(a, dt_bias)
+        assert g.dtype == torch.float32
+
+
+class TestComputeGate:
+    """Tests for CPAwareGatedDeltaNet._compute_gate routing."""
+
+    @staticmethod
+    def _stub_and_import(monkeypatch):
+        for path in (
+            "transformers.models.qwen3_5_moe",
+            "transformers.models.qwen3_5_moe.modeling_qwen3_5_moe",
+            "transformers.models.qwen3_5",
+            "transformers.models.qwen3_5.modeling_qwen3_5",
+        ):
+            if path not in sys.modules:
+                stub = types.ModuleType(path)
+                stub.Qwen3_5MoeGatedDeltaNet = _FakeGatedDeltaNet
+                stub.Qwen3_5GatedDeltaNet = _FakeGatedDeltaNet
+                monkeypatch.setitem(sys.modules, path, stub)
+        cp_mod_key = "nemo_automodel.components.models.qwen3_5_moe.cp_linear_attn"
+        if cp_mod_key in sys.modules:
+            monkeypatch.delitem(sys.modules, cp_mod_key)
+        from nemo_automodel.components.models.qwen3_5_moe.cp_linear_attn import (
+            CPAwareGatedDeltaNet,
+            _Fp32ParamHolder,
+            patch_hf_model,
+        )
+
+        return CPAwareGatedDeltaNet, _Fp32ParamHolder, patch_hf_model
+
+    def test_compute_gate_routes_through_holder(self, fake_model, monkeypatch):
+        """_compute_gate calls _fp32_params.forward when holder exists."""
+        CPAwareGatedDeltaNet, _Fp32ParamHolder, patch_hf_model = self._stub_and_import(monkeypatch)
+        patch_hf_model(fake_model, cp_enabled=False)
+        la = fake_model.layers[0].linear_attn
+        assert isinstance(la, CPAwareGatedDeltaNet)
+        a = torch.zeros(4)
+        with patch.object(la._fp32_params, "forward", return_value=torch.zeros(4)) as mock_fwd:
+            la._compute_gate(a)
+            mock_fwd.assert_called_once()
+
+    def test_compute_gate_fallback_without_holder(self, fake_model, monkeypatch):
+        """_compute_gate falls back to inline computation without _fp32_params."""
+        CPAwareGatedDeltaNet, _, patch_hf_model = self._stub_and_import(monkeypatch)
+        la = fake_model.layers[0].linear_attn
+        la.__class__ = CPAwareGatedDeltaNet
+        la._cp_mesh = None
+        # No _fp32_params — A_log is still in _parameters
+        a = torch.zeros(4)
+        g = la._compute_gate(a)
+        assert g.dtype == torch.float32
+        assert g.shape == (4,)
+
+
+class TestPatchHfModelSentinel:
+    """Test that __getattr__ patching is idempotent."""
+
+    @staticmethod
+    def _stub_and_import(monkeypatch):
+        for path in (
+            "transformers.models.qwen3_5_moe",
+            "transformers.models.qwen3_5_moe.modeling_qwen3_5_moe",
+            "transformers.models.qwen3_5",
+            "transformers.models.qwen3_5.modeling_qwen3_5",
+        ):
+            if path not in sys.modules:
+                stub = types.ModuleType(path)
+                stub.Qwen3_5MoeGatedDeltaNet = _FakeGatedDeltaNet
+                stub.Qwen3_5GatedDeltaNet = _FakeGatedDeltaNet
+                monkeypatch.setitem(sys.modules, path, stub)
+        cp_mod_key = "nemo_automodel.components.models.qwen3_5_moe.cp_linear_attn"
+        if cp_mod_key in sys.modules:
+            monkeypatch.delitem(sys.modules, cp_mod_key)
+        from nemo_automodel.components.models.qwen3_5_moe.cp_linear_attn import patch_hf_model
+
+        return patch_hf_model
+
+    def test_double_patch_does_not_rewrap_getattr(self, monkeypatch):
+        """Calling patch_hf_model twice does not chain __getattr__ wrappers."""
+        patch_hf_model = self._stub_and_import(monkeypatch)
+
+        model1 = nn.Module()
+        model1.layers = nn.ModuleList([nn.Module()])
+        model1.layers[0].linear_attn = _FakeGatedDeltaNet()
+        model1.layers[0].layer_type = "linear_attention"
+        patch_hf_model(model1, cp_enabled=False)
+        getattr_after_first = type(model1.layers[0].linear_attn).__getattr__
+
+        model2 = nn.Module()
+        model2.layers = nn.ModuleList([nn.Module()])
+        model2.layers[0].linear_attn = _FakeGatedDeltaNet()
+        model2.layers[0].layer_type = "linear_attention"
+        patch_hf_model(model2, cp_enabled=False)
+        getattr_after_second = type(model2.layers[0].linear_attn).__getattr__
+
+        # Same function, not a wrapper of a wrapper
+        assert getattr_after_first is getattr_after_second
 
 
 class TestAttachLinearAttnPositionHooks:
@@ -429,3 +582,300 @@ class TestQwen35ParallelizationStrategyParallelize:
         # fully_shard_by_dtype should have been called for the layer child
         assert len(shard_by_dtype_calls) > 0
         assert layer in shard_by_dtype_calls
+
+
+# ---------------------------------------------------------------------------
+# Helpers for _forward_no_cp tests
+# ---------------------------------------------------------------------------
+
+# Dimensions used throughout the _forward_no_cp tests.
+_HIDDEN = 16
+_NUM_K_HEADS = 2
+_NUM_V_HEADS = 2
+_HEAD_K_DIM = 4
+_HEAD_V_DIM = 4
+_KEY_DIM = _NUM_K_HEADS * _HEAD_K_DIM  # 8
+_VALUE_DIM = _NUM_V_HEADS * _HEAD_V_DIM  # 8
+_CONV_DIM = _KEY_DIM * 2 + _VALUE_DIM  # 24
+_CONV_KERNEL = 4
+
+
+class _IdentityNorm(nn.Module):
+    """Simple norm replacement that accepts (x, z) and returns x unchanged."""
+
+    def forward(self, x, z):
+        return x
+
+
+def _build_forward_module(monkeypatch):
+    """Import CPAwareGatedDeltaNet with stubs and build a module ready for _forward_no_cp.
+
+    Returns (module, CPAwareGatedDeltaNet_class).
+    """
+    # Stub transformers modules
+    for path in (
+        "transformers.models.qwen3_5_moe",
+        "transformers.models.qwen3_5_moe.modeling_qwen3_5_moe",
+        "transformers.models.qwen3_5",
+        "transformers.models.qwen3_5.modeling_qwen3_5",
+    ):
+        if path not in sys.modules:
+            stub = types.ModuleType(path)
+            stub.Qwen3_5MoeGatedDeltaNet = _FakeGatedDeltaNet
+            stub.Qwen3_5GatedDeltaNet = _FakeGatedDeltaNet
+            # apply_mask_to_padding_states is imported at runtime inside _forward_no_cp
+            stub.apply_mask_to_padding_states = lambda hidden_states, mask: hidden_states
+            monkeypatch.setitem(sys.modules, path, stub)
+        else:
+            # Ensure existing stub has the function
+            existing = sys.modules[path]
+            if not hasattr(existing, "apply_mask_to_padding_states"):
+                existing.apply_mask_to_padding_states = lambda hidden_states, mask: hidden_states
+
+    cp_mod_key = "nemo_automodel.components.models.qwen3_5_moe.cp_linear_attn"
+    if cp_mod_key in sys.modules:
+        monkeypatch.delitem(sys.modules, cp_mod_key)
+
+    from nemo_automodel.components.models.qwen3_5_moe.cp_linear_attn import CPAwareGatedDeltaNet
+
+    # Build a _FakeGatedDeltaNet and swap its class
+    mod = _FakeGatedDeltaNet()
+    mod.__class__ = CPAwareGatedDeltaNet
+    mod._cp_mesh = None
+
+    # -- Submodules expected by _forward_no_cp --
+    mod.in_proj_qkv = nn.Linear(_HIDDEN, _CONV_DIM, bias=False)
+    mod.in_proj_z = nn.Linear(_HIDDEN, _VALUE_DIM, bias=False)
+    mod.in_proj_b = nn.Linear(_HIDDEN, _NUM_V_HEADS, bias=False)
+    mod.in_proj_a = nn.Linear(_HIDDEN, _NUM_V_HEADS, bias=False)
+    mod.conv1d = nn.Conv1d(
+        _CONV_DIM, _CONV_DIM, _CONV_KERNEL, groups=_CONV_DIM, padding=_CONV_KERNEL - 1,
+    )
+    mod.out_proj = nn.Linear(_VALUE_DIM, _HIDDEN, bias=False)
+
+    # Norm that accepts (x, z) -> returns x (simplified)
+    mod.norm = _IdentityNorm()
+
+    # Override A_log and dt_bias to match num_v_heads (the _FakeGatedDeltaNet
+    # creates them with size 4, but in_proj_a output is num_v_heads=2)
+    mod.A_log = nn.Parameter(torch.ones(_NUM_V_HEADS, dtype=torch.float32))
+    mod.dt_bias = nn.Parameter(torch.ones(_NUM_V_HEADS, dtype=torch.bfloat16))
+
+    # Scalar/dim attributes
+    mod.head_k_dim = _HEAD_K_DIM
+    mod.head_v_dim = _HEAD_V_DIM
+    mod.num_k_heads = _NUM_K_HEADS
+    mod.num_v_heads = _NUM_V_HEADS
+    mod.key_dim = _KEY_DIM
+    mod.value_dim = _VALUE_DIM
+    mod.conv_kernel_size = _CONV_KERNEL
+    mod.activation = "silu"
+    mod.layer_idx = 0
+
+    # chunk_gated_delta_rule — returns (output, state) with correct shape
+    def _fake_chunk_gdn(query, key, value, *, g, beta, initial_state, output_final_state, use_qk_l2norm_in_kernel):
+        # output: same shape as value [B, S, H_v, D_v]
+        return value.clone(), None
+
+    mod.chunk_gated_delta_rule = _fake_chunk_gdn
+
+    # causal_conv1d_fn — None forces the fallback conv path
+    mod.causal_conv1d_fn = None
+
+    return mod, CPAwareGatedDeltaNet
+
+
+class TestForwardNoCp:
+    """Tests for CPAwareGatedDeltaNet._forward_no_cp covering lines 91-193."""
+
+    def test_basic_forward_pass(self, monkeypatch):
+        """_forward_no_cp produces output with correct shape (basic path, cache_params=None)."""
+        mod, _ = _build_forward_module(monkeypatch)
+        x = torch.randn(2, 8, _HIDDEN)
+        out = mod._forward_no_cp(x)
+        assert out.shape == (2, 8, _HIDDEN)
+
+    def test_forward_no_cp_cache_params_none(self, monkeypatch):
+        """Training path: cache_params=None exercises the else-branch at line 133-146."""
+        mod, _ = _build_forward_module(monkeypatch)
+        x = torch.randn(1, 4, _HIDDEN)
+        out = mod._forward_no_cp(x, cache_params=None, cache_position=None)
+        assert out.shape == (1, 4, _HIDDEN)
+
+    def test_forward_no_cp_causal_conv1d_fn_none_fallback(self, monkeypatch):
+        """When causal_conv1d_fn is None, falls back to F.silu(conv1d(...))."""
+        mod, _ = _build_forward_module(monkeypatch)
+        assert mod.causal_conv1d_fn is None  # confirm fallback path
+        x = torch.randn(1, 6, _HIDDEN)
+        out = mod._forward_no_cp(x)
+        assert out.shape == (1, 6, _HIDDEN)
+
+    def test_forward_no_cp_with_causal_conv1d_fn(self, monkeypatch):
+        """When causal_conv1d_fn is set, it is called instead of conv1d fallback."""
+        mod, _ = _build_forward_module(monkeypatch)
+        # Install a mock causal_conv1d_fn
+        def _mock_causal_conv1d_fn(*, x, weight, bias, activation, seq_idx):
+            return torch.nn.functional.silu(x)
+        mod.causal_conv1d_fn = _mock_causal_conv1d_fn
+        x = torch.randn(1, 6, _HIDDEN)
+        out = mod._forward_no_cp(x)
+        assert out.shape == (1, 6, _HIDDEN)
+
+    def test_forward_no_cp_attention_mask(self, monkeypatch):
+        """attention_mask is passed through apply_mask_to_padding_states."""
+        mod, _ = _build_forward_module(monkeypatch)
+        x = torch.randn(1, 4, _HIDDEN)
+        mask = torch.ones(1, 4, dtype=torch.bool)
+        out = mod._forward_no_cp(x, attention_mask=mask)
+        assert out.shape == (1, 4, _HIDDEN)
+
+    def test_forward_no_cp_gqa_repeat(self, monkeypatch):
+        """When num_v_heads > num_k_heads, q/k are repeat-interleaved."""
+        mod, _ = _build_forward_module(monkeypatch)
+        # Make v_heads > k_heads to trigger the repeat_interleave branch
+        new_num_v_heads = 4
+        mod.num_v_heads = new_num_v_heads
+        mod.num_k_heads = 2
+        # Adjust value_dim to match new num_v_heads
+        new_value_dim = new_num_v_heads * _HEAD_V_DIM  # 16
+        mod.value_dim = new_value_dim
+        conv_dim = _KEY_DIM * 2 + new_value_dim  # 32
+        mod.in_proj_qkv = nn.Linear(_HIDDEN, conv_dim, bias=False)
+        mod.in_proj_z = nn.Linear(_HIDDEN, new_value_dim, bias=False)
+        mod.in_proj_b = nn.Linear(_HIDDEN, new_num_v_heads, bias=False)
+        mod.in_proj_a = nn.Linear(_HIDDEN, new_num_v_heads, bias=False)
+        mod.conv1d = nn.Conv1d(conv_dim, conv_dim, _CONV_KERNEL, groups=conv_dim, padding=_CONV_KERNEL - 1)
+        mod.out_proj = nn.Linear(new_value_dim, _HIDDEN, bias=False)
+        # Update A_log and dt_bias to match new num_v_heads
+        mod.A_log = nn.Parameter(torch.ones(new_num_v_heads, dtype=torch.float32))
+        mod.dt_bias = nn.Parameter(torch.ones(new_num_v_heads, dtype=torch.bfloat16))
+
+        x = torch.randn(1, 4, _HIDDEN)
+        out = mod._forward_no_cp(x)
+        assert out.shape == (1, 4, _HIDDEN)
+
+    def test_forward_no_cp_uses_compute_gate(self, monkeypatch):
+        """_forward_no_cp delegates gate computation to _compute_gate."""
+        mod, _ = _build_forward_module(monkeypatch)
+        original_compute_gate = mod._compute_gate
+        called = []
+
+        def _tracking_compute_gate(a):
+            called.append(True)
+            return original_compute_gate(a)
+
+        mod._compute_gate = _tracking_compute_gate
+        x = torch.randn(1, 4, _HIDDEN)
+        mod._forward_no_cp(x)
+        assert len(called) == 1, "_compute_gate should be called exactly once"
+
+    def test_forward_no_cp_output_dtype_matches_input(self, monkeypatch):
+        """Output dtype follows the projection layers (float32 in this test)."""
+        mod, _ = _build_forward_module(monkeypatch)
+        x = torch.randn(1, 4, _HIDDEN, dtype=torch.float32)
+        out = mod._forward_no_cp(x)
+        assert out.dtype == torch.float32
+
+
+class TestForwardDispatch:
+    """Tests for forward() dispatching to _forward_no_cp (lines 207-213)."""
+
+    def test_forward_delegates_when_cp_mesh_none(self, monkeypatch):
+        """forward() calls _forward_no_cp when _cp_mesh is None."""
+        mod, _ = _build_forward_module(monkeypatch)
+        mod._cp_mesh = None
+        x = torch.randn(1, 4, _HIDDEN)
+        out = mod.forward(x)
+        assert out.shape == (1, 4, _HIDDEN)
+
+    def test_forward_delegates_when_cp_mesh_size_1(self, monkeypatch):
+        """forward() calls _forward_no_cp when _cp_mesh.size() <= 1."""
+        mod, _ = _build_forward_module(monkeypatch)
+        mock_mesh = MagicMock()
+        mock_mesh.size.return_value = 1
+        mod._cp_mesh = mock_mesh
+        x = torch.randn(1, 4, _HIDDEN)
+        out = mod.forward(x)
+        assert out.shape == (1, 4, _HIDDEN)
+
+    def test_forward_passes_cache_params_through(self, monkeypatch):
+        """forward() passes cache_params, cache_position, attention_mask to _forward_no_cp."""
+        mod, _ = _build_forward_module(monkeypatch)
+        mod._cp_mesh = None
+
+        called_with = {}
+        orig_fwd = mod._forward_no_cp
+
+        def _spy(hidden_states, cache_params=None, cache_position=None, attention_mask=None):
+            called_with["cache_params"] = cache_params
+            called_with["cache_position"] = cache_position
+            called_with["attention_mask"] = attention_mask
+            return orig_fwd(hidden_states, cache_params=cache_params, cache_position=cache_position, attention_mask=attention_mask)
+
+        mod._forward_no_cp = _spy
+
+        x = torch.randn(1, 4, _HIDDEN)
+        mask = torch.ones(1, 4, dtype=torch.bool)
+        mod.forward(x, attention_mask=mask)
+
+        assert called_with["cache_params"] is None
+        assert called_with["cache_position"] is None
+        assert called_with["attention_mask"] is mask
+
+    def test_forward_ignores_extra_cp_kwargs(self, monkeypatch):
+        """forward() accepts position_ids, qkv_format, etc. but ignores them on no-CP path."""
+        mod, _ = _build_forward_module(monkeypatch)
+        mod._cp_mesh = None
+        x = torch.randn(1, 4, _HIDDEN)
+        out = mod.forward(
+            x,
+            position_ids=torch.arange(4).unsqueeze(0),
+            qkv_format="bshd",
+            cu_seqlens=None,
+            seq_index=None,
+        )
+        assert out.shape == (1, 4, _HIDDEN)
+
+
+class TestMakeFp32GetattrFallback:
+    """Test _make_fp32_getattr fallback when attr is not in _fp32_params."""
+
+    @staticmethod
+    def _stub_and_import(monkeypatch):
+        for path in (
+            "transformers.models.qwen3_5_moe",
+            "transformers.models.qwen3_5_moe.modeling_qwen3_5_moe",
+            "transformers.models.qwen3_5",
+            "transformers.models.qwen3_5.modeling_qwen3_5",
+        ):
+            if path not in sys.modules:
+                stub = types.ModuleType(path)
+                stub.Qwen3_5MoeGatedDeltaNet = _FakeGatedDeltaNet
+                stub.Qwen3_5GatedDeltaNet = _FakeGatedDeltaNet
+                monkeypatch.setitem(sys.modules, path, stub)
+        cp_mod_key = "nemo_automodel.components.models.qwen3_5_moe.cp_linear_attn"
+        if cp_mod_key in sys.modules:
+            monkeypatch.delitem(sys.modules, cp_mod_key)
+        from nemo_automodel.components.models.qwen3_5_moe.cp_linear_attn import (
+            _make_fp32_getattr,
+            patch_hf_model,
+        )
+
+        return _make_fp32_getattr, patch_hf_model
+
+    def test_fallback_raises_attribute_error(self, fake_model, monkeypatch):
+        """Accessing a non-existent attr via patched __getattr__ raises AttributeError."""
+        _make_fp32_getattr, patch_hf_model = self._stub_and_import(monkeypatch)
+        patch_hf_model(fake_model, cp_enabled=False)
+        la = fake_model.layers[0].linear_attn
+        # _fp32_params exists, but "nonexistent_xyz" is not in it
+        with pytest.raises(AttributeError):
+            _ = la.nonexistent_xyz
+
+    def test_fallback_resolves_real_attrs(self, fake_model, monkeypatch):
+        """Patched __getattr__ still resolves normal module attributes."""
+        _make_fp32_getattr, patch_hf_model = self._stub_and_import(monkeypatch)
+        patch_hf_model(fake_model, cp_enabled=False)
+        la = fake_model.layers[0].linear_attn
+        # conv1d is a real submodule — should resolve fine
+        assert la.conv1d is not None

--- a/tests/unit_tests/models/qwen3_5/test_cp_linear_attn_patch.py
+++ b/tests/unit_tests/models/qwen3_5/test_cp_linear_attn_patch.py
@@ -376,13 +376,15 @@ class TestQwen35ParallelizationStrategyParallelize:
         cp_mesh.ndim = 1
 
         mesh.mesh_dim_names = ("dp_replicate", "dp_shard_cp", "tp")
-        mesh.__getitem__ = MagicMock(side_effect=lambda key: {
-            "dp_replicate": MagicMock(size=MagicMock(return_value=1), ndim=1),
-            "dp_shard_cp": dp_shard_mesh,
-            "tp": tp_mesh,
-            "cp": cp_mesh,
-            ("dp_replicate", "dp_shard_cp"): dp_shard_mesh,
-        }[key])
+        mesh.__getitem__ = MagicMock(
+            side_effect=lambda key: {
+                "dp_replicate": MagicMock(size=MagicMock(return_value=1), ndim=1),
+                "dp_shard_cp": dp_shard_mesh,
+                "tp": tp_mesh,
+                "cp": cp_mesh,
+                ("dp_replicate", "dp_shard_cp"): dp_shard_mesh,
+            }[key]
+        )
 
         return mesh, cp_mesh, tp_mesh
 
@@ -439,9 +441,7 @@ class TestQwen35ParallelizationStrategyParallelize:
         mesh, cp_mesh, tp_mesh = mock_device_mesh
         strategy = Qwen3_5ParallelizationStrategy()
 
-        with patch(
-            "nemo_automodel.components.models.qwen3_5_moe.cp_linear_attn.patch_hf_model"
-        ) as mock_patch:
+        with patch("nemo_automodel.components.models.qwen3_5_moe.cp_linear_attn.patch_hf_model") as mock_patch:
             result = strategy.parallelize(model=fake_model, device_mesh=mesh)
 
         # patch_hf_model was called (cp_enabled=False because "cp" not in mesh_dim_names)
@@ -510,11 +510,11 @@ class TestQwen35ParallelizationStrategyParallelize:
         if cp_mod_key in sys.modules:
             monkeypatch.delitem(sys.modules, cp_mod_key)
 
+        from nemo_automodel.components.distributed.parallelizer import Qwen3_5ParallelizationStrategy
         from nemo_automodel.components.models.qwen3_5_moe.cp_linear_attn import (
             CPAwareGatedDeltaNet,
             patch_hf_model,
         )
-        from nemo_automodel.components.distributed.parallelizer import Qwen3_5ParallelizationStrategy
 
         mesh, cp_mesh, tp_mesh = mock_device_mesh
         # Enable CP by adding "cp" to mesh_dim_names and making cp_mesh.size() > 1
@@ -529,9 +529,7 @@ class TestQwen35ParallelizationStrategyParallelize:
 
         strategy = Qwen3_5ParallelizationStrategy()
 
-        with patch(
-            "nemo_automodel.components.models.qwen3_5_moe.cp_linear_attn.patch_hf_model"
-        ):
+        with patch("nemo_automodel.components.models.qwen3_5_moe.cp_linear_attn.patch_hf_model"):
             strategy.parallelize(model=fake_model, device_mesh=mesh)
 
         # CP mesh should be set
@@ -551,7 +549,9 @@ class TestQwen35ParallelizationStrategyParallelize:
         # Build a model with layers in a ModuleList
         model = nn.Module()
         model.config = types.SimpleNamespace(
-            num_attention_heads=8, num_key_value_heads=8, hidden_size=64,
+            num_attention_heads=8,
+            num_key_value_heads=8,
+            hidden_size=64,
         )
         model.__class__.__name__ = "Qwen3_5ForCausalLM"
         inner = nn.Module()
@@ -564,13 +564,13 @@ class TestQwen35ParallelizationStrategyParallelize:
 
         # Capture what the custom _fsdp_by_dtype does
         shard_by_dtype_calls = []
-        with patch(
-            "nemo_automodel.components.distributed.parallelizer_utils.fully_shard_by_dtype",
-            side_effect=lambda *a, **kw: shard_by_dtype_calls.append(a[0]),
-        ), patch(
-            "nemo_automodel.components.models.qwen3_5_moe.cp_linear_attn.patch_hf_model"
-        ), patch(
-            "nemo_automodel.components.distributed.parallelizer._pre_shard_combined_projections"
+        with (
+            patch(
+                "nemo_automodel.components.distributed.parallelizer_utils.fully_shard_by_dtype",
+                side_effect=lambda *a, **kw: shard_by_dtype_calls.append(a[0]),
+            ),
+            patch("nemo_automodel.components.models.qwen3_5_moe.cp_linear_attn.patch_hf_model"),
+            patch("nemo_automodel.components.distributed.parallelizer._pre_shard_combined_projections"),
         ):
             # Make extract_layers return the real layers
             mock_env["apply_fsdp"].side_effect = lambda module, mesh, mp, offload=None: (
@@ -649,7 +649,11 @@ def _build_forward_module(monkeypatch):
     mod.in_proj_b = nn.Linear(_HIDDEN, _NUM_V_HEADS, bias=False)
     mod.in_proj_a = nn.Linear(_HIDDEN, _NUM_V_HEADS, bias=False)
     mod.conv1d = nn.Conv1d(
-        _CONV_DIM, _CONV_DIM, _CONV_KERNEL, groups=_CONV_DIM, padding=_CONV_KERNEL - 1,
+        _CONV_DIM,
+        _CONV_DIM,
+        _CONV_KERNEL,
+        groups=_CONV_DIM,
+        padding=_CONV_KERNEL - 1,
     )
     mod.out_proj = nn.Linear(_VALUE_DIM, _HIDDEN, bias=False)
 
@@ -713,9 +717,11 @@ class TestForwardNoCp:
     def test_forward_no_cp_with_causal_conv1d_fn(self, monkeypatch):
         """When causal_conv1d_fn is set, it is called instead of conv1d fallback."""
         mod, _ = _build_forward_module(monkeypatch)
+
         # Install a mock causal_conv1d_fn
         def _mock_causal_conv1d_fn(*, x, weight, bias, activation, seq_idx):
             return torch.nn.functional.silu(x)
+
         mod.causal_conv1d_fn = _mock_causal_conv1d_fn
         x = torch.randn(1, 6, _HIDDEN)
         out = mod._forward_no_cp(x)
@@ -810,7 +816,9 @@ class TestForwardDispatch:
             called_with["cache_params"] = cache_params
             called_with["cache_position"] = cache_position
             called_with["attention_mask"] = attention_mask
-            return orig_fwd(hidden_states, cache_params=cache_params, cache_position=cache_position, attention_mask=attention_mask)
+            return orig_fwd(
+                hidden_states, cache_params=cache_params, cache_position=cache_position, attention_mask=attention_mask
+            )
 
         mod._forward_no_cp = _spy
 

--- a/tests/unit_tests/models/qwen3_5_moe/test_cp_linear_attn.py
+++ b/tests/unit_tests/models/qwen3_5_moe/test_cp_linear_attn.py
@@ -262,9 +262,7 @@ class TestForwardFastPath:
         assert module._cp_mesh is None
         B, S, D = 1, 8, module.hidden_size
         hidden = torch.randn(B, S, D, device=device)
-        with patch.object(
-            module, "_forward_no_cp", return_value=torch.randn(B, S, D, device=device)
-        ) as mock_no_cp_fwd:
+        with patch.object(module, "_forward_no_cp", return_value=torch.randn(B, S, D, device=device)) as mock_no_cp_fwd:
             module.forward(hidden)
             mock_no_cp_fwd.assert_called_once()
 
@@ -276,23 +274,19 @@ class TestForwardFastPath:
 
         B, S, D = 1, 8, module.hidden_size
         hidden = torch.randn(B, S, D, device=device)
-        with patch.object(
-            module, "_forward_no_cp", return_value=torch.randn(B, S, D, device=device)
-        ) as mock_no_cp_fwd:
+        with patch.object(module, "_forward_no_cp", return_value=torch.randn(B, S, D, device=device)) as mock_no_cp_fwd:
             module.forward(hidden)
             mock_no_cp_fwd.assert_called_once()
 
     def test_no_cp_does_not_forward_cache_position(self, module, device):
-        """cache_position should not be forwarded to super (removed in transformers>=5.5)."""
+        """cache_position should not be forwarded to _forward_no_cp (removed in transformers>=5.5)."""
         assert module._cp_mesh is None
         B, S, D = 1, 8, module.hidden_size
         hidden = torch.randn(B, S, D, device=device)
-        with patch.object(
-            type(module).__bases__[0], "forward", return_value=torch.randn(B, S, D, device=device)
-        ) as mock_super_fwd:
+        with patch.object(module, "_forward_no_cp", return_value=torch.randn(B, S, D, device=device)) as mock_no_cp_fwd:
             module.forward(hidden, cache_position=torch.arange(S, device=device))
-            mock_super_fwd.assert_called_once()
-            _, kwargs = mock_super_fwd.call_args
+            mock_no_cp_fwd.assert_called_once()
+            _, kwargs = mock_no_cp_fwd.call_args
             assert "cache_position" not in kwargs
 
     def test_cp_mesh_gt_1_calls_forward_with_cp(self, module, device):

--- a/tests/unit_tests/models/qwen3_5_moe/test_cp_linear_attn.py
+++ b/tests/unit_tests/models/qwen3_5_moe/test_cp_linear_attn.py
@@ -257,19 +257,19 @@ class TestRedoAttentionLoadBalancing:
 
 
 class TestForwardFastPath:
-    def test_no_cp_mesh_delegates_to_super(self, module, device):
-        """When _cp_mesh is None, forward should delegate to the HF parent class."""
+    def test_no_cp_mesh_delegates_to_forward_no_cp(self, module, device):
+        """When _cp_mesh is None, forward should delegate to _forward_no_cp."""
         assert module._cp_mesh is None
         B, S, D = 1, 8, module.hidden_size
         hidden = torch.randn(B, S, D, device=device)
         with patch.object(
-            type(module).__bases__[0], "forward", return_value=torch.randn(B, S, D, device=device)
-        ) as mock_super_fwd:
+            module, "_forward_no_cp", return_value=torch.randn(B, S, D, device=device)
+        ) as mock_no_cp_fwd:
             module.forward(hidden)
-            mock_super_fwd.assert_called_once()
+            mock_no_cp_fwd.assert_called_once()
 
-    def test_cp_mesh_size_1_delegates_to_super(self, module, device):
-        """When _cp_mesh.size() == 1, forward should delegate to the HF parent class."""
+    def test_cp_mesh_size_1_delegates_to_forward_no_cp(self, module, device):
+        """When _cp_mesh.size() == 1, forward should delegate to _forward_no_cp."""
         mesh = MagicMock()
         mesh.size.return_value = 1
         module._cp_mesh = mesh
@@ -277,10 +277,10 @@ class TestForwardFastPath:
         B, S, D = 1, 8, module.hidden_size
         hidden = torch.randn(B, S, D, device=device)
         with patch.object(
-            type(module).__bases__[0], "forward", return_value=torch.randn(B, S, D, device=device)
-        ) as mock_super_fwd:
+            module, "_forward_no_cp", return_value=torch.randn(B, S, D, device=device)
+        ) as mock_no_cp_fwd:
             module.forward(hidden)
-            mock_super_fwd.assert_called_once()
+            mock_no_cp_fwd.assert_called_once()
 
     def test_no_cp_does_not_forward_cache_position(self, module, device):
         """cache_position should not be forwarded to super (removed in transformers>=5.5)."""


### PR DESCRIPTION
## Summary
Cherry-pick of #1813 from `r0.4.0` to `main`.

- PR #1711 changed `_should_load_before_shard` to return `False` for multi-GPU DP, so models stay on meta device through FSDP wrapping. This broke the `__dict__` trick in PR #1710's `patch_hf_model`.
- Move the gate computation (`g = -A_log.exp() * softplus(a + dt_bias)`) into `_Fp32ParamHolder.forward()` so FSDP's unshard/reshard lifecycle fires naturally around the fp32 params.
- Override `CPAwareGatedDeltaNet` forward for both CP and non-CP paths to route through the holder. Class swap is now unconditional (needed for the non-CP forward override).
- Add `__getattr__` on the class for checkpoint/state_dict access to moved params.

## Test plan
- [x] Qwen3.5 9B CP1 (100 steps): https://wandb.ai/Nemo-automodel/huiyingl_workspace/runs/stq9sl31
- [x] Qwen3.5 9B CP2 (loss parity with CP1): https://wandb.ai/Nemo-automodel/huiyingl_workspace/runs/rtqwo7bb

🤖 Generated with [Claude Code](https://claude.com/claude-code)