### PR TITLE
fix(metric_logger): handle non-scalar tensor metrics without crashing

### DIFF
--- a/nemo_automodel/components/loggers/metric_logger.py
+++ b/nemo_automodel/components/loggers/metric_logger.py
@@ -75,7 +75,8 @@ def stack_and_move_tensor_metrics_to_cpu(metric_vector: List[MetricsSample]) -> 
         # Write back the CPU tensors to each sample's metrics
         for pos, sample_index in enumerate(indices):
             for name in names_key:
-                metric_vector[sample_index].metrics[name] = stacked_by_name[name][pos].item()
+                t = stacked_by_name[name][pos]
+                metric_vector[sample_index].metrics[name] = t.item() if t.numel() == 1 else t.tolist()
 
     return metric_vector
 


### PR DESCRIPTION
## Summary

- `stack_and_move_tensor_metrics_to_cpu` called `.item()` unconditionally on `stacked_by_name[name][pos]`
- `.item()` raises `RuntimeError` if the tensor has more than one element (i.e., any non-scalar metric)
- Fix: use `.item()` for scalars (`numel() == 1`) and `.tolist()` for multi-element tensors, both of which produce JSON-serialisable Python types

## Test plan

- [ ] Log a scalar tensor metric → still works, `.item()` path taken
- [ ] Log a 1-D tensor metric (e.g. per-token loss array) → now works, `.tolist()` path taken, no `RuntimeError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)