### PR TITLE
fix(ci): retry apt-get and Azure CLI installs to handle mirror sync failures

### DIFF
--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -96,8 +96,11 @@ runs:
     - name: Install GH CLI
       shell: bash
       run: |
-        apt-get update
-        apt-get install -y gh
+        for i in 1 2 3; do
+          apt-get update && apt-get install -y gh && break
+          echo "Attempt $i failed, retrying in 10s..."
+          sleep 10
+        done
 
     - name: Normalize repo name to lowercase
       shell: bash

--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -78,7 +78,11 @@ runs:
       run: |
         echo "::group::Install Azure CLI"
         # Create systemd override for proper dependencies
-        curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+        for i in 1 2 3; do
+          curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash && break
+          echo "Attempt $i failed, retrying in 10s..."
+          sleep 10
+        done
         echo "::endgroup::"
 
     - name: Azure Login

--- a/.github/actions/test-template/action.yml
+++ b/.github/actions/test-template/action.yml
@@ -68,7 +68,11 @@ runs:
       shell: bash
       run: |
         echo "::group::Install Azure CLI"
-        curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+        for i in 1 2 3; do
+          curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash && break
+          echo "Attempt $i failed, retrying in 10s..."
+          sleep 10
+        done
         echo "::endgroup::"
 
     - name: Azure Login

--- a/.github/actions/test-template/action.yml
+++ b/.github/actions/test-template/action.yml
@@ -88,8 +88,11 @@ runs:
       shell: bash -x -e -u -o pipefail {0}
       if: ${{ contains(inputs.runner, 'aws') }}
       run: |
-        apt-get update
-        apt-get install -y uuid-runtime
+        for i in 1 2 3; do
+          apt-get update && apt-get install -y uuid-runtime && break
+          echo "Attempt $i failed, retrying in 10s..."
+          sleep 10
+        done
 
     - name: Start container
       shell: bash

--- a/.github/workflows/_update_dependencies.yml
+++ b/.github/workflows/_update_dependencies.yml
@@ -40,7 +40,12 @@ jobs:
       TARGET_BRANCH: ${{ inputs.target-branch }}
     steps:
       - name: Install Azure CLI
-        run: curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+        run: |
+          for i in 1 2 3; do
+            curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash && break
+            echo "Attempt $i failed, retrying in 10s..."
+            sleep 10
+          done
 
       - name: Azure Login
         uses: azure/login@v2

--- a/.github/workflows/_update_dependencies.yml
+++ b/.github/workflows/_update_dependencies.yml
@@ -111,7 +111,12 @@ jobs:
           ref: ${{ env.TARGET_BRANCH }}
 
       - name: Install GPG
-        run: sudo apt-get install -y gnupg2
+        run: |
+          for i in 1 2 3; do
+            sudo apt-get update && sudo apt-get install -y gnupg2 && break
+            echo "Attempt $i failed, retrying in 10s..."
+            sleep 10
+          done
 
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -82,8 +82,11 @@ jobs:
 
       - name: Install wget
         run: |
-          apt-get update
-          apt-get install -y wget git
+          for i in 1 2 3; do
+            apt-get update && apt-get install -y wget git && break
+            echo "Attempt $i failed, retrying in 10s..."
+            sleep 10
+          done
 
       - name: Upgrade pip
         run: |
@@ -159,8 +162,11 @@ jobs:
       - name: Install automodel${{ matrix.extra-groups != '' && format('[{0}]', matrix.extra-groups) || '' }}
         shell: bash -x -e -u -o pipefail {0}
         run: |
-          apt-get update
-          apt-get install -y python3 python3-pip python3-venv git
+          for i in 1 2 3; do
+            apt-get update && apt-get install -y python3 python3-pip python3-venv git && break
+            echo "Attempt $i failed, retrying in 10s..."
+            sleep 10
+          done
           python3 -m venv ./venv
 
           . ./venv/bin/activate


### PR DESCRIPTION
## Summary

- Wraps all `apt-get update && apt-get install` calls in a 3-attempt retry loop with a 10s back-off
- Wraps the Azure CLI install script (`InstallAzureCLIDeb`) in the same retry loop — the script runs its own `apt-get update` internally and is subject to the same mirror sync failures

## Affected files

- `.github/actions/build-container/action.yml` — Install GH CLI + Install Azure CLI
- `.github/actions/test-template/action.yml` — Install uuidgen + Install Azure CLI
- `.github/workflows/install-test.yml` — Install wget/git (×2)
- `.github/workflows/_update_dependencies.yml` — Install GPG + Install Azure CLI

## Test plan

- [ ] CI passes on the next run without manual retries