### PR TITLE
fix: gradient checkpointing broken for MoE models on single GPU (ep_size=1)

### DIFF
--- a/nemo_automodel/_transformers/capabilities.py
+++ b/nemo_automodel/_transformers/capabilities.py
@@ -215,7 +215,7 @@ class ModelSupports:
     @property
     def supports_gradient_checkpointing(self) -> bool:
         """Gradient checkpointing is supported."""
-        if self.supports_ep:
+        if self.supports_ep and self.ep_size > 1:
             return False
         for cls in type(self._model).__mro__:
             if "supports_gradient_checkpointing" in cls.__dict__:

--- a/nemo_automodel/components/models/gemma4_moe/model.py
+++ b/nemo_automodel/components/models/gemma4_moe/model.py
@@ -398,6 +398,7 @@ class Gemma4MoEModel(HFGemma4Model):
 # Top-level conditional-generation model
 # ---------------------------------------------------------------------------
 class Gemma4ForConditionalGeneration(HFCheckpointingMixin, HFGemma4ForConditionalGeneration, MoEFSDPSyncMixin):
+    supports_gradient_checkpointing = True
     """Gemma4 VL conditional generation model with NeMo MoE backend.
 
     When the checkpoint has ``enable_moe_block=True`` in its text config,


### PR DESCRIPTION
# What does this PR do?
Fixes activation checkpointing being incorrectly disabled for MoE models training on a single GPU with `ep_size=1`. Without this fix, any attempt to use `activation_checkpointing: true` with a MoE model on a single GPU raises `ValueError: Gemma4ForConditionalGeneration does not support gradient checkpointing.`

# Changelog
- `capabilities.py`: `supports_gradient_checkpointing` now returns `False` only when EP is actually active (`ep_size > 1`), not just because the model is capable of EP (`supports_ep`)
- `gemma4_moe/model.py`: explicitly declares `supports_gradient_checkpointing = True` on `Gemma4ForConditionalGeneration`, consistent with other custom model classes (Llama, Qwen2, Baichuan)

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

# Additional Information
- Discovered and fixed by Vijay Murugesan @ RDA Develop Together while building an internal AI platform.
- Tested on NVIDIA DGX Spark GB10 (128GB unified memory), single GPU, LoRA fine-tuning of `google/gemma-4-26b-a4b`