### PR TITLE
ci: Reduce default finetune step count from 100 to 50

### DIFF
--- a/tests/ci_tests/scripts/finetune_launcher.sh
+++ b/tests/ci_tests/scripts/finetune_launcher.sh
@@ -38,9 +38,9 @@ elif [ "$TEST_LEVEL" = "performance" ]; then
   CONFIG="${CONFIG}"
 else
   CONFIG="${CONFIG} \
-        --step_scheduler.ckpt_every_steps 100 \
-        --step_scheduler.max_steps ${MAX_STEPS:-100} \
-        --step_scheduler.val_every_steps 100"
+        --step_scheduler.ckpt_every_steps 50 \
+        --step_scheduler.max_steps ${MAX_STEPS:-50} \
+        --step_scheduler.val_every_steps 50"
 fi
 
 # Per-config nproc override (set via ci.nproc_per_node in recipe YAML)


### PR DESCRIPTION
# What does this PR do ?

Reduce step count for finetune step from 100 to 50 to reduce runtime.

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
