### PR TITLE
fix: Setup vllm testing with uv --no-config

### DIFF
--- a/tests/ci_tests/scripts/vllm_launcher.sh
+++ b/tests/ci_tests/scripts/vllm_launcher.sh
@@ -24,7 +24,7 @@ export CUDA_VISIBLE_DEVICES="0"
 cd /opt/Automodel
 uv venv /tmp/vllm_deploy_venv
 source /tmp/vllm_deploy_venv/bin/activate
-uv pip install -r tests/ci_tests/requirements_deploy.txt
+uv pip install --no-config -r tests/ci_tests/requirements_deploy.txt
 
 TEST_SCRIPT="tests/functional_tests/checkpoint_robustness/test_checkpoint_vllm_deploy.py"
 FINETUNE_TEST_NAME="${TEST_NAME%_vllm_deploy}"


### PR DESCRIPTION
# What does this PR do ?

vllm launcher skips torch installation due to uv override-dependnecies in pyproject.toml causing installation failures. Allow a full install by passing --no-config

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
