### PR TITLE
fix: lint in llava_onevision

### DIFF
--- a/nemo_automodel/components/models/llava_onevision/rice_vit.py
+++ b/nemo_automodel/components/models/llava_onevision/rice_vit.py
@@ -18,9 +18,7 @@ from typing import Optional, Tuple
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 from torch.nn import LayerNorm
-
 from transformers.activations import ACT2FN
 
 
@@ -80,15 +78,11 @@ class RicePatchEmbed(nn.Module):
         self.embed_dim = embed_dim
 
         kernel_size = [patch_size, patch_size]
-        self.proj = nn.Conv2d(
-            in_channels, embed_dim, kernel_size=kernel_size, stride=kernel_size, bias=False
-        )
+        self.proj = nn.Conv2d(in_channels, embed_dim, kernel_size=kernel_size, stride=kernel_size, bias=False)
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         target_dtype = self.proj.weight.dtype
-        hidden_states = hidden_states.view(
-            -1, self.in_channels, self.patch_size, self.patch_size
-        )
+        hidden_states = hidden_states.view(-1, self.in_channels, self.patch_size, self.patch_size)
         hidden_states = self.proj(hidden_states.to(dtype=target_dtype)).view(-1, self.embed_dim)
         return hidden_states
 
@@ -148,12 +142,7 @@ class RiceAttention(nn.Module):
         position_embeddings: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     ) -> torch.Tensor:
         seq_length = hidden_states.shape[0]
-        q, k, v = (
-            self.qkv(hidden_states)
-            .reshape(seq_length, 3, self.num_heads, -1)
-            .permute(1, 0, 2, 3)
-            .unbind(0)
-        )
+        q, k, v = self.qkv(hidden_states).reshape(seq_length, 3, self.num_heads, -1).permute(1, 0, 2, 3).unbind(0)
 
         if position_embeddings is None:
             emb = torch.cat((rotary_pos_emb, rotary_pos_emb), dim=-1)

--- a/nemo_automodel/components/models/llava_onevision/state_dict_adapter.py
+++ b/nemo_automodel/components/models/llava_onevision/state_dict_adapter.py
@@ -16,8 +16,6 @@
 import re
 from typing import Any, Optional
 
-import torch
-
 from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
 
 


### PR DESCRIPTION
# What does this PR do ?

Fixes a couple of lint issues from the llava-onevision PR. @vgauraha62 already put in a ton of work getting [the PR](https://github.com/NVIDIA-NeMo/Automodel/pull/1790) into good shape, so I picked up the remaining lint fixes separately, to reduce burden.


# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
