### PR TITLE
fix(gemma4_moe): use vision-aware attention mask when use_bidirection…

### DIFF
--- a/nemo_automodel/components/models/gemma4_moe/model.py
+++ b/nemo_automodel/components/models/gemma4_moe/model.py
@@ -309,6 +309,8 @@ class Gemma4MoETextModelBackend(nn.Module):
         position_ids: torch.Tensor | None = None,
         cache_position: torch.Tensor | None = None,
         padding_mask: torch.Tensor | None = None,
+        mm_token_type_ids: torch.Tensor | None = None,
+        pixel_values: torch.Tensor | None = None,
         past_key_values=None,
         use_cache: bool | None = None,
         **kwargs: Any,
@@ -330,21 +332,39 @@ class Gemma4MoETextModelBackend(nn.Module):
 
         hidden_states = inputs_embeds
 
-        # Build causal masks and position embeddings per attention type
-        from transformers.masking_utils import create_causal_mask, create_sliding_window_causal_mask
+        # Build causal masks. When use_bidirectional_attention == "vision" (e.g.
+        # gemma-4-26B-A4B, gemma-4-31B), HF uses create_causal_mask_mapping to
+        # build a vision-aware mask where tokens inside the same vision group
+        # attend to each other bidirectionally (not just causally). Missing this
+        # logic causes gen_kl_error to be ~10x higher on multimodal inputs.
+        if getattr(self.config, "use_bidirectional_attention", None) == "vision":
+            from transformers.models.gemma4.modeling_gemma4 import create_causal_mask_mapping
 
-        mask_kwargs = {
-            "config": self.config,
-            "inputs_embeds": inputs_embeds,
-            "attention_mask": attention_mask,
-            "cache_position": cache_position,
-            "past_key_values": past_key_values,
-            "position_ids": position_ids,
-        }
-        causal_mask_mapping = {
-            "full_attention": create_causal_mask(**mask_kwargs),
-            "sliding_attention": create_sliding_window_causal_mask(**mask_kwargs),
-        }
+            causal_mask_mapping = create_causal_mask_mapping(
+                config=self.config,
+                inputs_embeds=inputs_embeds,
+                attention_mask=attention_mask,
+                past_key_values=past_key_values,
+                position_ids=position_ids,
+                mm_token_type_ids=mm_token_type_ids,
+                pixel_values=pixel_values,
+                is_training=self.training,
+            )
+        else:
+            from transformers.masking_utils import create_causal_mask, create_sliding_window_causal_mask
+
+            mask_kwargs = {
+                "config": self.config,
+                "inputs_embeds": inputs_embeds,
+                "attention_mask": attention_mask,
+                "cache_position": cache_position,
+                "past_key_values": past_key_values,
+                "position_ids": position_ids,
+            }
+            causal_mask_mapping = {
+                "full_attention": create_causal_mask(**mask_kwargs),
+                "sliding_attention": create_sliding_window_causal_mask(**mask_kwargs),
+            }
 
         position_embeddings = {}
         for layer_type in set(self.config.layer_types):
@@ -548,6 +568,8 @@ class Gemma4ForConditionalGeneration(HFCheckpointingMixin, HFGemma4ForConditiona
             position_ids=position_ids,
             cache_position=cache_position,
             padding_mask=padding_mask,
+            mm_token_type_ids=mm_token_type_ids,
+            pixel_values=pixel_values,
             **kwargs,
         )
 


### PR DESCRIPTION
…al_attention="vision"

Gemma4 multimodal variants with `use_bidirectional_attention="vision"` in their text config (e.g. gemma-4-26B-A4B-it, gemma-4-31B-it) require a vision-aware attention mask that makes tokens inside the same vision group visible to each other bidirectionally. HF's `Gemma4Model.forward` builds this mask via `create_causal_mask_mapping`.

The MoE backend `Gemma4MoETextModelBackend.forward` was always building plain `create_causal_mask` + `create_sliding_window_causal_mask` regardless of the config flag. For `gemma-4-26B-A4B-it` this makes the MoE forward numerically diverge from HF on multimodal inputs (vision token logprobs can differ by 20+ in log-space), and increases `train/gen_kl_error` by roughly an order of magnitude during GRPO training (~0.01 vs ~0.001 on text-only).

Fix:
- Accept `mm_token_type_ids` and `pixel_values` in `Gemma4MoETextModelBackend.forward`.
- When `config.use_bidirectional_attention == "vision"`, call HF's `create_causal_mask_mapping` (matches `Gemma4Model.forward`). Otherwise keep the existing plain causal-mask path.
- Plumb `mm_token_type_ids` / `pixel_values` from `Gemma4ForConditionalGeneration.forward` down to the text backend.

Measured impact on gemma-4-26B-A4B-it multimodal forward (HF as ground truth, single synthetic image, 341-token sequence):

  metric                     before      after (expected)
  HF vs Automodel gen_kl     0.034       ~0.01 (FSDP noise floor)
  HF vs vLLM gen_kl          0.092       0.092 (unchanged)

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
