### PR TITLE
feat: TP+PP support for Gemma4 VLM (with tied lm_head fix and 31B recipes)

### DIFF
--- a/examples/vlm_finetune/gemma4/gemma4_31b_tp4_pp2.yaml
+++ b/examples/vlm_finetune/gemma4/gemma4_31b_tp4_pp2.yaml
@@ -1,0 +1,110 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Single-node fine-tune of Gemma4 31B with TP=4 and PP=2.
+# Topology: 1 node x 8 GPUs = 8 GPUs total (TP4 x PP2, DP1).
+# Gemma4 31B has 46 decoder layers, split evenly: 23 layers on each PP rank.
+#
+# torchrun --nproc-per-node=8 examples/vlm_finetune/finetune.py \
+#          -c examples/vlm_finetune/gemma4/gemma4_31b_tp4_pp2.yaml
+
+recipe: FinetuneRecipeForVLM
+
+step_scheduler:
+  global_batch_size: 8
+  local_batch_size: 1
+  ckpt_every_steps: 500
+  val_every_steps: 500
+  num_epochs: 2
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 60
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 42
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained
+  pretrained_model_name_or_path: google/gemma-4-31B-it
+  torch_dtype: torch.bfloat16
+  use_liger_kernel: true
+  use_sdpa_patching: false
+  attn_implementation: sdpa
+  text_config:
+    use_cache: false
+
+checkpoint:
+  enabled: true
+  checkpoint_dir: vlm_checkpoints/gemma4_31b_it_tp4_pp2/
+  model_save_format: torch_save
+  save_consolidated: false
+
+distributed:
+  strategy: fsdp2
+  dp_size: none
+  tp_size: 4
+  cp_size: 1
+  pp_size: 2
+  ep_size: 1
+
+  sequence_parallel: false
+  activation_checkpointing: true
+
+  pipeline:
+    pp_schedule: 1f1b
+    pp_microbatch_size: 1
+    scale_grads_in_schedule: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.vlm.datasets.make_medpix_dataset
+  path_or_dataset: mmoukouba/MedPix-VQA
+  split: train[:1000]
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  num_workers: 0
+  pin_memory: true
+  collate_fn:
+    _target_: nemo_automodel.components.datasets.vlm.collate_fns.gemma4_prefix_collate_fn
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.vlm.datasets.make_medpix_dataset
+  path_or_dataset: mmoukouba/MedPix-VQA
+  split: validation[:500]
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn:
+    _target_: nemo_automodel.components.datasets.vlm.collate_fns.gemma4_prefix_collate_fn
+
+optimizer:
+  _target_: torch.optim.AdamW
+  lr: 1e-5
+  weight_decay: 0.01
+  betas: [0.9, 0.95]
+
+lr_scheduler:
+  lr_decay_style: cosine
+
+freeze_config:
+  freeze_embeddings: true
+  freeze_vision_tower: true
+  freeze_audio_tower: true
+  freeze_language_model: false

--- a/examples/vlm_finetune/gemma4/gemma4_31b_tp4_pp4.yaml
+++ b/examples/vlm_finetune/gemma4/gemma4_31b_tp4_pp4.yaml
@@ -1,0 +1,117 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Multi-node (4 nodes) fine-tune of Gemma4 31B with TP=4, PP=4 and DP=2.
+# Topology: 4 nodes x 8 GPUs = 32 GPUs total (TP4 x PP4 x DP2).
+# Gemma4 31B has 46 decoder layers; PP=4 splits them across 4 stages.
+#
+# Per-node launch (set MASTER_ADDR to the rendezvous host and NODE_RANK
+# per node, e.g. via SLURM/MPI):
+#
+#   torchrun --nnodes=4 --nproc-per-node=8 \
+#            --master-addr=$MASTER_ADDR --master-port=29500 \
+#            --node-rank=$NODE_RANK \
+#            examples/vlm_finetune/finetune.py \
+#            -c examples/vlm_finetune/gemma4/gemma4_31b_tp4_pp4.yaml
+
+recipe: FinetuneRecipeForVLM
+
+step_scheduler:
+  global_batch_size: 8
+  local_batch_size: 1
+  ckpt_every_steps: 500
+  val_every_steps: 500
+  num_epochs: 2
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 60
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 42
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained
+  pretrained_model_name_or_path: google/gemma-4-31B-it
+  torch_dtype: torch.bfloat16
+  use_liger_kernel: true
+  use_sdpa_patching: false
+  attn_implementation: sdpa
+  text_config:
+    use_cache: false
+
+checkpoint:
+  enabled: true
+  checkpoint_dir: vlm_checkpoints/gemma4_31b_it_tp4_pp4/
+  model_save_format: torch_save
+  save_consolidated: false
+
+distributed:
+  strategy: fsdp2
+  dp_size: none
+  tp_size: 4
+  cp_size: 1
+  pp_size: 4
+  ep_size: 1
+
+  sequence_parallel: false
+  activation_checkpointing: true
+
+  pipeline:
+    pp_schedule: 1f1b
+    pp_microbatch_size: 1
+    scale_grads_in_schedule: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.vlm.datasets.make_medpix_dataset
+  path_or_dataset: mmoukouba/MedPix-VQA
+  split: train[:1000]
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  num_workers: 0
+  pin_memory: true
+  drop_last: true
+  collate_fn:
+    _target_: nemo_automodel.components.datasets.vlm.collate_fns.gemma4_prefix_collate_fn
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.vlm.datasets.make_medpix_dataset
+  path_or_dataset: mmoukouba/MedPix-VQA
+  split: validation[:500]
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn:
+    _target_: nemo_automodel.components.datasets.vlm.collate_fns.gemma4_prefix_collate_fn
+
+optimizer:
+  _target_: torch.optim.AdamW
+  lr: 1e-5
+  weight_decay: 0.01
+  betas: [0.9, 0.95]
+
+lr_scheduler:
+  lr_decay_style: cosine
+
+freeze_config:
+  freeze_embeddings: true
+  freeze_vision_tower: true
+  freeze_audio_tower: true
+  freeze_language_model: false

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -40,6 +40,7 @@ from nemo_automodel.components.checkpoint._backports.consolidate_hf_safetensors 
     consolidate_safetensors_files_on_every_rank,
 )
 from nemo_automodel.components.checkpoint._backports.filesystem import SerializationFormat
+from nemo_automodel.components.checkpoint._backports.filesystem import FileSystemReader
 from nemo_automodel.components.checkpoint._backports.hf_storage import (
     _HuggingFaceStorageReader,
     _HuggingFaceStorageWriter,
@@ -52,7 +53,11 @@ from nemo_automodel.components.checkpoint.conversion_mapping import (
     requires_tensor_merging,
 )
 from nemo_automodel.components.checkpoint.stateful_wrappers import ModelState, OptimizerState
-from nemo_automodel.components.checkpoint.utils import is_tied_word_embeddings
+from nemo_automodel.components.checkpoint.utils import (
+    get_tied_lm_head_source_names,
+    is_tied_word_embeddings,
+    materialize_missing_tied_lm_head,
+)
 
 if TYPE_CHECKING:
     from peft import PeftConfig
@@ -88,6 +93,33 @@ def _is_bin_checkpoint(path: str) -> bool:
     if os.path.isfile(os.path.join(path, "pytorch_model.bin")):
         return True
     return len(glob.glob(os.path.join(path, "*.bin"))) > 0
+
+
+def _summarize_state_dict_key_diff(
+    expected_keys: set[str],
+    loaded_keys: set[str],
+    *,
+    limit: int = 10,
+) -> dict[str, Any]:
+    """Summarize state-dict key mismatches for checkpoint load diagnostics."""
+    missing = sorted(expected_keys - loaded_keys)
+    unexpected = sorted(loaded_keys - expected_keys)
+    return {
+        "missing_count": len(missing),
+        "unexpected_count": len(unexpected),
+        "missing_examples": missing[:limit],
+        "unexpected_examples": unexpected[:limit],
+    }
+
+
+def _get_checkpoint_metadata_keys(
+    path: str,
+    storage_reader: Optional[_HuggingFaceStorageReader] = None,
+) -> set[str]:
+    """Return checkpoint FQNs present in metadata."""
+    reader = storage_reader if storage_reader is not None else FileSystemReader(path)
+    metadata = reader.read_metadata()
+    return set(metadata.state_dict_metadata.keys())
 
 
 if _is_geq_torch_2_9():
@@ -390,6 +422,16 @@ class Checkpointer:
         if is_init_step and model_type and requires_tensor_merging(model_type) and not has_state_dict_adapter:
             converted_state_dict = _convert_checkpoint_with_transformers(model_state.model[0], model_path, key_mapping)
             if converted_state_dict:
+                materialized_tied_lm_head = materialize_missing_tied_lm_head(
+                    converted_state_dict,
+                    model_state.model[0],
+                    allow_current_lm_head_fallback=False,
+                )
+                if materialized_tied_lm_head:
+                    logging.info(
+                        "Materialized missing tied lm_head.weight from embedding weights for %s during init load.",
+                        type(model_state.model[0]).__name__,
+                    )
                 # Load using full_state_dict=True to properly convert tensors to DTensors for FSDP
                 _load_full_state_dict_into_model(model_state.model, converted_state_dict)
                 return
@@ -426,6 +468,17 @@ class Checkpointer:
             if key_mapping and state_dict_from_disk:
                 state_dict_from_disk = _apply_key_mapping(state_dict_from_disk, key_mapping)
 
+            materialized_tied_lm_head = materialize_missing_tied_lm_head(
+                state_dict_from_disk,
+                model_state.model[0],
+                allow_current_lm_head_fallback=False,
+            )
+            if materialized_tied_lm_head:
+                logging.info(
+                    "Materialized missing tied lm_head.weight from embedding weights for %s during init load.",
+                    type(model_state.model[0]).__name__,
+                )
+
             total_bytes = sum(
                 t.nelement() * t.element_size() for t in state_dict_from_disk.values() if isinstance(t, torch.Tensor)
             )
@@ -447,6 +500,7 @@ class Checkpointer:
 
         # Standard loading path (DCP copies into model's existing tensors; dtypes follow the model)
         state_dict = model_state.state_dict()
+        expected_keys = set(state_dict.keys())
         # When the model has a state_dict_adapter, it handles all key transformations
         # (to_hf/from_hf). Passing key_mapping to the storage reader would double-transform
         # keys: the storage reader renames checkpoint keys in metadata, and then to_hf also
@@ -461,9 +515,57 @@ class Checkpointer:
             device_mesh=self.moe_mesh,
         )
 
+        compat_tied_lm_head_source_key: str | None = None
+        lm_head_param_name = getattr(model_state, "lm_head_param_name", None)
+        should_try_tied_lm_head_compat = (
+            getattr(model_state, "uses_tied_lm_head", False)
+            and not getattr(model_state, "has_local_tied_lm_head", False)
+            and isinstance(lm_head_param_name, str)
+            and lm_head_param_name in state_dict
+        )
+        if should_try_tied_lm_head_compat:
+            checkpoint_metadata_keys = _get_checkpoint_metadata_keys(model_path, storage_reader)
+            if lm_head_param_name not in checkpoint_metadata_keys:
+                for source_name in get_tied_lm_head_source_names(model_state.model[0], lm_head_param_name):
+                    if source_name not in checkpoint_metadata_keys or source_name in state_dict:
+                        continue
+                    compat_tied_lm_head_source_key = source_name
+                    state_dict[source_name] = state_dict.pop(lm_head_param_name)
+                    logging.warning(
+                        "Checkpoint %s is missing %s. Loading tied source %s into lm_head "
+                        "(HF tied-embedding checkpoints omit lm_head, and pre-fix DCP "
+                        "checkpoints with PP also omit it).",
+                        model_path,
+                        lm_head_param_name,
+                        source_name,
+                    )
+                    break
+                if compat_tied_lm_head_source_key is None:
+                    logging.warning(
+                        "Checkpoint %s is missing %s and no tied source key was found. "
+                        "Keeping the current lm_head initialization for compatibility.",
+                        model_path,
+                        lm_head_param_name,
+                    )
+                    state_dict.pop(lm_head_param_name, None)
+
         state_dict = self._do_load(state_dict, model_path, storage_reader, is_init_step=is_init_step)
 
+        if compat_tied_lm_head_source_key is not None and isinstance(lm_head_param_name, str):
+            state_dict[lm_head_param_name] = state_dict.pop(compat_tied_lm_head_source_key)
+
         state_dict = _maybe_adapt_state_dict_from_hf(model_state.model[0], state_dict, moe_mesh=self.moe_mesh)
+        key_diff = _summarize_state_dict_key_diff(expected_keys, set(state_dict.keys()))
+        if key_diff["missing_count"] or key_diff["unexpected_count"]:
+            logging.warning(
+                "Checkpoint key mismatch for %s: missing=%d unexpected=%d "
+                "(missing examples=%s, unexpected examples=%s)",
+                type(model_state.model[0]).__name__,
+                key_diff["missing_count"],
+                key_diff["unexpected_count"],
+                key_diff["missing_examples"],
+                key_diff["unexpected_examples"],
+            )
         model_state.load_state_dict(state_dict, strict=not (len(model_state.model) > 1 or has_state_dict_adapter))
 
         del state_dict
@@ -611,7 +713,12 @@ class Checkpointer:
         is_tied_lm_head = is_tied_word_embeddings(model)
         self.config.original_model_root_dir = root_dir
         if hasattr(model, "tie_weights") and is_tied_lm_head:
-            model.tie_weights()
+            try:
+                model.tie_weights()
+            except AttributeError:
+                # PP splitting sets unused modules to None; skip weight tying
+                # on stages that don't own both embed_tokens and lm_head.
+                pass
 
     def maybe_wait_for_staging(self) -> None:
         """

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -916,7 +916,10 @@ class Checkpointer:
                 # buffer keys are not saved during checkpointing
                 # The `_pre_shard_hf_state_dict_keys` attribute is set in the `apply_model_infrastructure` in auto_model.py
                 keys_to_remove = list(set(fqn_to_file_index_mapping.keys()) - set(pre_shard_hf_state_dict_keys))
-                if model_state.is_tied_lm_head:
+                # Only drop lm_head from the save map when it is actually an alias
+                # of the embedding (e.g. single-rank tied case). PP last stages have
+                # `uses_tied_lm_head=True` but must still persist their own lm_head.
+                if getattr(model_state, "has_local_tied_lm_head", False):
                     keys_to_remove.append(model_state.lm_head_param_name)
                 for key in keys_to_remove:
                     fqn_to_file_index_mapping.pop(key, None)

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -39,8 +39,7 @@ from torch.distributed.device_mesh import DeviceMesh
 from nemo_automodel.components.checkpoint._backports.consolidate_hf_safetensors import (
     consolidate_safetensors_files_on_every_rank,
 )
-from nemo_automodel.components.checkpoint._backports.filesystem import SerializationFormat
-from nemo_automodel.components.checkpoint._backports.filesystem import FileSystemReader
+from nemo_automodel.components.checkpoint._backports.filesystem import FileSystemReader, SerializationFormat
 from nemo_automodel.components.checkpoint._backports.hf_storage import (
     _HuggingFaceStorageReader,
     _HuggingFaceStorageWriter,

--- a/nemo_automodel/components/checkpoint/stateful_wrappers.py
+++ b/nemo_automodel/components/checkpoint/stateful_wrappers.py
@@ -56,7 +56,12 @@ from torch.distributed.checkpoint.state_dict import (
     set_optimizer_state_dict,
 )
 
-from nemo_automodel.components.checkpoint.utils import is_tied_word_embeddings
+from nemo_automodel.components.checkpoint.utils import (
+    get_lm_head_weight_and_name,
+    has_local_tied_lm_head,
+    is_tied_word_embeddings,
+    materialize_missing_tied_lm_head,
+)
 
 _PREFIX = "model."
 
@@ -193,12 +198,7 @@ def _rename_dora_keys_from_hf(sd: dict[str, Any]) -> None:
 
 
 def _get_lm_head_weight_and_name(model: torch.nn.Module) -> Optional[tuple[torch.Tensor, str]]:
-    for name, param in model.named_parameters(remove_duplicate=False):
-        if "lm_head" in name and name.endswith(".weight"):
-            normalized_name = name.replace("_orig_mod.", "")
-            return param, normalized_name
-
-    return None, None
+    return get_lm_head_weight_and_name(model)
 
 
 # modified from pytorch tutorial https://pytorch.org/tutorials/recipes/distributed_checkpoint_recipe.html
@@ -240,9 +240,10 @@ class ModelState:
                 - ["score."] for some classification heads
         """
         self.model = [model] if isinstance(model, torch.nn.Module) else model
-        self.is_tied_lm_head = is_tied_word_embeddings(self.model[0])
+        self.uses_tied_lm_head = is_tied_word_embeddings(self.model[0])
+        self.has_local_tied_lm_head = has_local_tied_lm_head(self.model[0])
 
-        if self.is_tied_lm_head:
+        if self.uses_tied_lm_head:
             _, lm_head_param_name = _get_lm_head_weight_and_name(self.model[0])
             self.lm_head_param_name = lm_head_param_name
         self.is_peft = is_peft
@@ -281,8 +282,7 @@ class ModelState:
         if self.is_peft:
             model_state_dict = {k: v for k, v in model_state_dict.items() if "lora_" in k}
 
-        if self.is_tied_lm_head:
-            # PP models don't have tied embeddings. Safe to pass in model[0] here.
+        if self.has_local_tied_lm_head:
             model_state_dict.pop(self.lm_head_param_name, None)
 
         if self.is_peft and not _has_quantized_params(self.model[0]):
@@ -324,13 +324,12 @@ class ModelState:
         # If we intentionally skipped saving "lm_head.weight" (tied embeddings)
         # PyTorch will complain during load even with strict=False.
         # To be fully compatible we inject a reference tensor so the key exists.
-        if self.is_tied_lm_head and not self.is_peft:
-            # PP models don't have tied embeddings. Safe to pass in model[0] here.
-            lm_head_weight, lm_head_param_name = _get_lm_head_weight_and_name(self.model[0])
-            # Skip for Encoder models as it doesn't have a lm_head at the top level
-            if lm_head_weight is not None and lm_head_param_name not in state_dict:
-                # weight tying guarantees this is identical to the embedding weight
-                state_dict[lm_head_param_name] = lm_head_weight.detach()
+        if self.uses_tied_lm_head and not self.is_peft:
+            materialize_missing_tied_lm_head(
+                state_dict,
+                self.model[0],
+                allow_current_lm_head_fallback=True,
+            )
 
         for model_part in self.model:
             set_model_state_dict(model_part, state_dict, options=options)
@@ -338,8 +337,7 @@ class ModelState:
     def _get_base_model_state_dict(self) -> dict[str, Any]:
         model_state_dict = {k: v for sd in map(get_model_state_dict, self.model) for k, v in sd.items()}
 
-        if self.is_tied_lm_head:
-            # PP models don't have tied embeddings. Safe to pass in model[0] here.
+        if self.has_local_tied_lm_head:
             model_state_dict.pop(self.lm_head_param_name, None)
 
         if self.is_peft:

--- a/nemo_automodel/components/checkpoint/utils.py
+++ b/nemo_automodel/components/checkpoint/utils.py
@@ -131,7 +131,11 @@ def get_tied_lm_head_source_names(model: nn.Module, lm_head_param_name: str | No
         for target_name, source_name in tied_keys.items():
             if not isinstance(target_name, str) or not isinstance(source_name, str):
                 continue
-            if lm_head_param_name is None or target_name == lm_head_param_name or target_name.endswith("lm_head.weight"):
+            if (
+                lm_head_param_name is None
+                or target_name == lm_head_param_name
+                or target_name.endswith("lm_head.weight")
+            ):
                 candidate_source_names.append(source_name)
 
     _, input_embeddings_param_name = get_input_embeddings_weight_and_name(model)
@@ -174,9 +178,7 @@ def has_local_tied_lm_head(model: nn.Module) -> bool:
     lm_head_weight, _ = get_lm_head_weight_and_name(model)
     input_embeddings_weight, _ = get_input_embeddings_weight_and_name(model)
     return (
-        lm_head_weight is not None
-        and input_embeddings_weight is not None
-        and lm_head_weight is input_embeddings_weight
+        lm_head_weight is not None and input_embeddings_weight is not None and lm_head_weight is input_embeddings_weight
     )
 
 

--- a/nemo_automodel/components/checkpoint/utils.py
+++ b/nemo_automodel/components/checkpoint/utils.py
@@ -170,24 +170,35 @@ def get_tied_lm_head_source_names(model: nn.Module, lm_head_param_name: str | No
 
 
 def has_local_tied_lm_head(model: nn.Module) -> bool:
-    """Return whether the current model partition owns a truly tied LM head.
+    """Return whether the current model partition can locally satisfy a tied LM head.
 
     This is intentionally stricter than ``is_tied_word_embeddings()``: pipeline
     stages often keep the config flag set to ``True`` even though ``lm_head`` and
-    ``embed_tokens`` live on different partitions and therefore cannot share the
-    same tensor object locally.
+    ``embed_tokens`` live on different partitions and therefore cannot be
+    reconstructed from each other locally.
+
+    Note: we purposefully do NOT check ``lm_head.weight is embed_tokens.weight``.
+    After FSDP/TP sharding both are wrapped into separate ``DTensor``s and the
+    ``is``-identity is broken, but HF's ``tie_weights()`` can still relink them
+    locally on load. The only case we actually need to distinguish is "is the
+    embedding source present on this partition at all?", which answers "can we
+    safely omit ``lm_head.weight`` during save and rematerialize on load?".
 
     Args:
         model: Model or pipeline stage to inspect.
 
     Returns:
-        ``True`` only when both local weights exist and share the same tensor.
+        ``True`` when the model is configured with tied word embeddings AND
+        both the local ``lm_head`` and the input embedding live on this
+        partition. ``False`` when the config isn't tied, or when the local
+        partition is missing one of the two (typical for PP non-last / non-first
+        stages).
     """
+    if not is_tied_word_embeddings(model):
+        return False
     lm_head_weight, _ = get_lm_head_weight_and_name(model)
     input_embeddings_weight, _ = get_input_embeddings_weight_and_name(model)
-    return (
-        lm_head_weight is not None and input_embeddings_weight is not None and lm_head_weight is input_embeddings_weight
-    )
+    return lm_head_weight is not None and input_embeddings_weight is not None
 
 
 def materialize_missing_tied_lm_head(

--- a/nemo_automodel/components/checkpoint/utils.py
+++ b/nemo_automodel/components/checkpoint/utils.py
@@ -59,6 +59,171 @@ def is_tied_word_embeddings(model: nn.Module) -> bool:
     return bool(getattr(text_config, "tie_word_embeddings", getattr(config, "tie_word_embeddings", False)))
 
 
+def _normalize_param_name(name: str) -> str:
+    """Strip wrapper-specific prefixes from a parameter name."""
+    return name.replace("_orig_mod.", "")
+
+
+def get_lm_head_weight_and_name(model: nn.Module) -> tuple[torch.Tensor | None, str | None]:
+    """Return the first ``lm_head.weight`` parameter found on a model.
+
+    Args:
+        model: Model to inspect.
+
+    Returns:
+        Tuple of the parameter tensor and its normalized FQN, or ``(None, None)``
+        when the model has no LM head weight.
+    """
+    for name, param in model.named_parameters(remove_duplicate=False):
+        normalized_name = _normalize_param_name(name)
+        if "lm_head" in normalized_name and normalized_name.endswith(".weight"):
+            return param, normalized_name
+    return None, None
+
+
+def get_input_embeddings_weight_and_name(model: nn.Module) -> tuple[torch.Tensor | None, str | None]:
+    """Return the input embedding weight and normalized name if present.
+
+    Args:
+        model: Model to inspect.
+
+    Returns:
+        Tuple of the embedding weight tensor and its normalized FQN, or
+        ``(None, None)`` when the current model partition does not own the input
+        embedding.
+    """
+    get_input_embeddings = getattr(model, "get_input_embeddings", None)
+    if callable(get_input_embeddings):
+        try:
+            input_embeddings = get_input_embeddings()
+        except Exception:
+            input_embeddings = None
+        if input_embeddings is not None and hasattr(input_embeddings, "weight"):
+            for name, param in model.named_parameters(remove_duplicate=False):
+                if param is input_embeddings.weight:
+                    return param, _normalize_param_name(name)
+
+    candidate_suffixes = (
+        "embed_tokens.weight",
+        "language_model.embed_tokens.weight",
+        "model.language_model.embed_tokens.weight",
+    )
+    for name, param in model.named_parameters(remove_duplicate=False):
+        normalized_name = _normalize_param_name(name)
+        if normalized_name.endswith(candidate_suffixes):
+            return param, normalized_name
+    return None, None
+
+
+def get_tied_lm_head_source_names(model: nn.Module, lm_head_param_name: str | None = None) -> list[str]:
+    """Return candidate checkpoint keys that can source a tied LM head.
+
+    Args:
+        model: Model or pipeline stage to inspect.
+        lm_head_param_name: Optional normalized LM head FQN.
+
+    Returns:
+        Ordered list of possible source FQNs.
+    """
+    candidate_source_names: list[str] = []
+    tied_keys = getattr(model, "_tied_weights_keys", None)
+    if isinstance(tied_keys, dict):
+        for target_name, source_name in tied_keys.items():
+            if not isinstance(target_name, str) or not isinstance(source_name, str):
+                continue
+            if lm_head_param_name is None or target_name == lm_head_param_name or target_name.endswith("lm_head.weight"):
+                candidate_source_names.append(source_name)
+
+    _, input_embeddings_param_name = get_input_embeddings_weight_and_name(model)
+    if input_embeddings_param_name is not None:
+        candidate_source_names.append(input_embeddings_param_name)
+
+    candidate_source_names.extend(
+        [
+            "model.language_model.embed_tokens.weight",
+            "language_model.embed_tokens.weight",
+            "model.embed_tokens.weight",
+            "embed_tokens.weight",
+        ]
+    )
+
+    seen_source_names: set[str] = set()
+    deduped_source_names: list[str] = []
+    for source_name in candidate_source_names:
+        if source_name in seen_source_names:
+            continue
+        seen_source_names.add(source_name)
+        deduped_source_names.append(source_name)
+    return deduped_source_names
+
+
+def has_local_tied_lm_head(model: nn.Module) -> bool:
+    """Return whether the current model partition owns a truly tied LM head.
+
+    This is intentionally stricter than ``is_tied_word_embeddings()``: pipeline
+    stages often keep the config flag set to ``True`` even though ``lm_head`` and
+    ``embed_tokens`` live on different partitions and therefore cannot share the
+    same tensor object locally.
+
+    Args:
+        model: Model or pipeline stage to inspect.
+
+    Returns:
+        ``True`` only when both local weights exist and share the same tensor.
+    """
+    lm_head_weight, _ = get_lm_head_weight_and_name(model)
+    input_embeddings_weight, _ = get_input_embeddings_weight_and_name(model)
+    return (
+        lm_head_weight is not None
+        and input_embeddings_weight is not None
+        and lm_head_weight is input_embeddings_weight
+    )
+
+
+def materialize_missing_tied_lm_head(
+    state_dict: dict[str, Any],
+    model: nn.Module,
+    *,
+    allow_current_lm_head_fallback: bool = False,
+) -> bool:
+    """Populate a missing tied ``lm_head.weight`` from its embedding source.
+
+    Hugging Face checkpoints for tied-embedding models often omit
+    ``lm_head.weight`` entirely. That is fine for unsplit models where
+    ``tie_weights()`` can restore the alias, but it breaks pipeline-parallel last
+    stages which own ``lm_head`` but not ``embed_tokens``.
+
+    Args:
+        state_dict: Checkpoint state dict to mutate in place.
+        model: Target model or pipeline stage.
+        allow_current_lm_head_fallback: If ``True``, fall back to the current
+            ``lm_head`` tensor when the tied source cannot be found in
+            ``state_dict``. This preserves legacy resume behavior for older
+            checkpoints that were saved without a local ``lm_head.weight``.
+
+    Returns:
+        ``True`` if a missing ``lm_head.weight`` was materialized, else ``False``.
+    """
+    if not is_tied_word_embeddings(model):
+        return False
+
+    lm_head_weight, lm_head_param_name = get_lm_head_weight_and_name(model)
+    if lm_head_weight is None or lm_head_param_name is None or lm_head_param_name in state_dict:
+        return False
+
+    for source_name in get_tied_lm_head_source_names(model, lm_head_param_name):
+        tensor = state_dict.get(source_name)
+        if isinstance(tensor, torch.Tensor):
+            state_dict[lm_head_param_name] = tensor.detach()
+            return True
+
+    if allow_current_lm_head_fallback:
+        state_dict[lm_head_param_name] = lm_head_weight.detach()
+        return True
+
+    return False
+
+
 def _get_checkpoint_tensor_dtypes(
     pretrained_model_name_or_path: str,
     hf_config: Any,

--- a/nemo_automodel/components/checkpoint/utils.py
+++ b/nemo_automodel/components/checkpoint/utils.py
@@ -127,6 +127,14 @@ def get_tied_lm_head_source_names(model: nn.Module, lm_head_param_name: str | No
     """
     candidate_source_names: list[str] = []
     tied_keys = getattr(model, "_tied_weights_keys", None)
+    # ``_tied_weights_keys`` has two shapes in practice:
+    #   - dict: NeMo custom models set an explicit target->source map
+    #     (e.g. ``{"lm_head.weight": "model.embed_tokens.weight"}``);
+    #   - list/tuple/set of str: HF upstream lists only the *target* FQNs
+    #     that are tied to the input embedding. The source is resolved via
+    #     ``get_input_embeddings()`` below, so for the list shape we only use
+    #     the dict for target-name matching and rely on the fallbacks to find
+    #     the source.
     if isinstance(tied_keys, dict):
         for target_name, source_name in tied_keys.items():
             if not isinstance(target_name, str) or not isinstance(source_name, str):

--- a/nemo_automodel/components/distributed/parallelizer.py
+++ b/nemo_automodel/components/distributed/parallelizer.py
@@ -46,6 +46,7 @@ from torch.distributed.tensor.placement_types import Replicate, Shard
 from transformers.models.gemma3.modeling_gemma3 import (
     Gemma3ForConditionalGeneration,
 )
+from nemo_automodel.components.models.gemma4_moe.model import Gemma4ForConditionalGeneration
 
 from nemo_automodel.components.distributed.mesh_utils import get_fsdp_dp_mesh
 
@@ -1148,7 +1149,7 @@ def validate_tp_mesh(model, tp_mesh):
         num_attention_heads = model.language_model.model.config.num_attention_heads
         num_key_value_heads = model.language_model.model.config.num_key_value_heads
 
-    elif model_cls == Gemma3ForConditionalGeneration:
+    elif model_cls in [Gemma3ForConditionalGeneration, Gemma4ForConditionalGeneration]:
         num_attention_heads = model.config.text_config.num_attention_heads
         num_key_value_heads = model.config.text_config.num_key_value_heads
     elif model_arch == "DeciLMForCausalLM" and getattr(model.config, "model_type", None) == "nemotron-nas":
@@ -1265,6 +1266,9 @@ def _extract_model_layers(model: nn.Module) -> List[nn.Module]:
         ],
         Mistral3ForConditionalGeneration: ["model.language_model.layers", "model.vision_tower.transformer.layers"],
         Llama4ForConditionalGeneration: ["language_model.model.layers", "vision_model.model.layers"],
+        Gemma4ForConditionalGeneration: ["model.language_model.layers"],
+        # String fallback in case of class identity mismatch across imports
+        "Gemma4ForConditionalGeneration": ["model.language_model.layers"],
     }
     LLM_MODEL_CLS_TO_LAYERS = {
         "NemotronHForCausalLM": ["backbone.layers"],

--- a/nemo_automodel/components/distributed/parallelizer.py
+++ b/nemo_automodel/components/distributed/parallelizer.py
@@ -46,7 +46,9 @@ from torch.distributed.tensor.placement_types import Replicate, Shard
 from transformers.models.gemma3.modeling_gemma3 import (
     Gemma3ForConditionalGeneration,
 )
-from nemo_automodel.components.models.gemma4_moe.model import Gemma4ForConditionalGeneration
+from transformers.models.gemma4.modeling_gemma4 import (
+    Gemma4ForConditionalGeneration,
+)
 
 from nemo_automodel.components.distributed.mesh_utils import get_fsdp_dp_mesh
 

--- a/nemo_automodel/components/distributed/pipelining/hf_utils.py
+++ b/nemo_automodel/components/distributed/pipelining/hf_utils.py
@@ -239,16 +239,240 @@ def create_pipeline_forward_causal_lm() -> Callable:
     return pipeline_forward_causal_lm
 
 
+def create_pipeline_forward_gemma4_text() -> Callable:
+    """Pipeline-compatible forward for the Gemma4 text decoder backbone.
+
+    Works for both HF Gemma4TextModel (dense path) and Gemma4MoETextModelBackend (MoE path).
+    Handles:
+    - Optional embed_tokens (None on non-first PP stages; hidden states arrive in input_ids slot)
+    - Both full_attention and sliding_attention causal masks (Gemma4 uses mixed layer types)
+    - Per-layer-type position embeddings: Gemma4RotaryEmbedding.forward(x, pos_ids, layer_type)
+    """
+
+    def pipeline_forward_gemma4_text(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        padding_mask: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        if inputs_embeds is None:
+            if hasattr(self, "embed_tokens") and self.embed_tokens is not None:
+                if input_ids is None:
+                    raise ValueError("input_ids or inputs_embeds must be provided")
+                inputs_embeds = self.embed_tokens(input_ids)
+            else:
+                # Non-first PP stage: previous stage output arrives as a float tensor in input_ids
+                if input_ids is not None and input_ids.dtype in (torch.float16, torch.bfloat16, torch.float32):
+                    inputs_embeds = input_ids
+                else:
+                    raise ValueError("inputs_embeds must be provided for pipeline stages without embed_tokens")
+
+        if cache_position is None:
+            cache_position = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device)
+
+        if position_ids is None:
+            position_ids = cache_position.unsqueeze(0)
+
+        if padding_mask is None and attention_mask is not None:
+            padding_mask = attention_mask.bool().logical_not()
+
+        from transformers.masking_utils import create_causal_mask, create_sliding_window_causal_mask
+
+        mask_kwargs = {
+            "config": self.config,
+            "input_embeds": inputs_embeds,
+            "attention_mask": attention_mask,
+            "cache_position": cache_position,
+            "past_key_values": None,
+            "position_ids": position_ids,
+        }
+        causal_mask_mapping = {
+            "full_attention": create_causal_mask(**mask_kwargs),
+            "sliding_attention": create_sliding_window_causal_mask(**mask_kwargs),
+        }
+
+        # Per-layer-type rotary embeddings: Gemma4RotaryEmbedding takes (x, pos_ids, layer_type)
+        position_embeddings_map: dict = {}
+        if hasattr(self, "rotary_emb") and self.rotary_emb is not None:
+            for lt in set(getattr(self.config, "layer_types", ["full_attention"])):
+                try:
+                    position_embeddings_map[lt] = self.rotary_emb(inputs_embeds, position_ids, lt)
+                except TypeError:
+                    position_embeddings_map[lt] = self.rotary_emb(inputs_embeds, position_ids)
+
+        hidden_states = inputs_embeds
+        config_layer_types = getattr(self.config, "layer_types", None)
+        if hasattr(self, "layers") and self.layers is not None:
+            layer_iter = self.layers.values() if hasattr(self.layers, "values") else self.layers
+            for decoder_layer in layer_iter:
+                # Prefer config.layer_types[layer_idx] over decoder_layer attribute — the
+                # attribute lookup defaults to "full_attention" and mis-assigns position
+                # embeddings (wrong head_dim) to sliding-window layers.
+                if config_layer_types is not None and hasattr(decoder_layer, "layer_idx"):
+                    idx = decoder_layer.layer_idx
+                    layer_type = config_layer_types[idx] if idx < len(config_layer_types) else "full_attention"
+                else:
+                    layer_type = getattr(decoder_layer, "attention_type", "full_attention")
+                layer_attention_mask = causal_mask_mapping.get(
+                    layer_type, causal_mask_mapping.get("full_attention")
+                )
+                position_embeddings = position_embeddings_map.get(
+                    layer_type, position_embeddings_map.get("full_attention")
+                )
+                layer_outputs = decoder_layer(
+                    hidden_states,
+                    attention_mask=layer_attention_mask,
+                    position_ids=position_ids,
+                    cache_position=cache_position,
+                    position_embeddings=position_embeddings,
+                    padding_mask=padding_mask,
+                )
+                hidden_states = layer_outputs[0] if isinstance(layer_outputs, tuple) else layer_outputs
+
+        if hasattr(self, "norm") and self.norm is not None:
+            hidden_states = self.norm(hidden_states)
+
+        return hidden_states
+
+    return pipeline_forward_gemma4_text
+
+
+def create_pipeline_forward_gemma4_vlm() -> Callable:
+    """Pipeline-compatible forward for Gemma4ForConditionalGeneration (VLM top-level).
+
+    Stage 0: embeds text tokens, merges image features from vision tower (if pixel_values
+    provided or stored in _vlm_pixel_values_chunks), then calls the patched language model.
+    Non-first stages: passes hidden states straight to the patched language model.
+    Last stage: applies lm_head and final-logit softcapping.
+    """
+
+    def pipeline_forward_gemma4_vlm(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        pixel_values: Optional[torch.FloatTensor] = None,
+        image_position_ids: Optional[torch.LongTensor] = None,
+        mm_token_type_ids: Optional[torch.LongTensor] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        **kwargs,
+    ):
+        lang_model = self.model.language_model
+        embed_tokens = getattr(lang_model, "embed_tokens", None)
+        is_first_stage = embed_tokens is not None
+
+        # PP VLM: retrieve pixel_values from chunks stored by the training loop
+        if (
+            pixel_values is None
+            and is_first_stage
+            and getattr(self, "_vlm_pixel_values_chunks", None) is not None
+        ):
+            has_media_tokens = (
+                input_ids is not None
+                and hasattr(self.config, "image_token_id")
+                and (input_ids == self.config.image_token_id).any()
+            )
+            if has_media_tokens:
+                chunk_idx = getattr(self, "_vlm_chunk_idx", 0)
+                if chunk_idx < len(self._vlm_pixel_values_chunks):
+                    pixel_values = self._vlm_pixel_values_chunks[chunk_idx]
+                    image_grid_chunk = (
+                        self._vlm_image_grid_hws_chunks[chunk_idx]
+                        if getattr(self, "_vlm_image_grid_hws_chunks", None) is not None
+                        else None
+                    )
+                    if image_grid_chunk is not None:
+                        image_position_ids = image_grid_chunk
+                    self._vlm_chunk_idx = chunk_idx + 1
+
+        if is_first_stage:
+            if inputs_embeds is None:
+                inputs_embeds = embed_tokens(input_ids)
+
+            vision_tower = getattr(self.model, "vision_tower", None)
+            if vision_tower is not None and pixel_values is not None:
+                image_features = self.model.get_image_features(
+                    pixel_values, image_position_ids=image_position_ids, return_dict=True
+                ).pooler_output
+                image_features = image_features.to(inputs_embeds.device, inputs_embeds.dtype)
+
+                if mm_token_type_ids is not None:
+                    special_image_mask = mm_token_type_ids == 1
+                elif input_ids is not None:
+                    special_image_mask = input_ids == self.config.image_token_id
+                else:
+                    special_image_mask = torch.zeros(
+                        inputs_embeds.shape[:2], dtype=torch.bool, device=inputs_embeds.device
+                    )
+                image_mask = special_image_mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device)
+                inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_features)
+        else:
+            # Non-first stage: input_ids carries hidden states from the previous PP stage
+            if inputs_embeds is None:
+                if input_ids is not None and input_ids.dtype in (torch.float16, torch.bfloat16, torch.float32):
+                    inputs_embeds = input_ids
+                else:
+                    raise ValueError("Expected float hidden states for non-first PP stage")
+
+        if cache_position is None and inputs_embeds is not None:
+            cache_position = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device)
+
+        hidden_states = lang_model(
+            input_ids=None,
+            inputs_embeds=inputs_embeds,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            cache_position=cache_position,
+            **kwargs,
+        )
+        if not isinstance(hidden_states, torch.Tensor):
+            hidden_states = hidden_states.last_hidden_state
+
+        if hasattr(self, "lm_head") and self.lm_head is not None:
+            logits = self.lm_head(hidden_states)
+            text_config = getattr(self.config, "text_config", self.config)
+            final_logit_softcapping = getattr(text_config, "final_logit_softcapping", None)
+            if final_logit_softcapping is not None:
+                logits = logits / final_logit_softcapping
+                logits = torch.tanh(logits)
+                logits = logits * final_logit_softcapping
+            return logits
+        return hidden_states
+
+    return pipeline_forward_gemma4_vlm
+
+
 def patch_hf_model_for_pp(model, patch_inner_model: bool = True, patch_causal_lm_model: bool = True) -> None:
     """Patch a HF model/module to produce pipeline-compatible forward.
 
     - If model has .model (e.g., LlamaForCausalLM), patch inner and outer.
+    - If model.model has .language_model (e.g., Gemma4 VLM), patch the text backbone
+      and outer with Gemma4-specific VLM-aware forwards.
     - Else, patch the module itself.
     """
-    if hasattr(model, "model"):
-        if patch_inner_model and getattr(model, "model", None) is not None:
-            model.model.forward = types.MethodType(create_pipeline_forward_inner("PipelineStage"), model.model)
+    inner_model = getattr(model, "model", None)
+    text_backbone = (
+        getattr(inner_model, "language_model", None)
+        if inner_model is not None
+        else None
+    )
 
+    if inner_model is not None and text_backbone is not None:
+        # VLM with nested text backbone (e.g. Gemma4): patch text backbone and VLM outer
+        if patch_inner_model:
+            text_backbone.forward = types.MethodType(
+                create_pipeline_forward_gemma4_text(), text_backbone
+            )
+        if patch_causal_lm_model:
+            model.forward = types.MethodType(create_pipeline_forward_gemma4_vlm(), model)
+    elif inner_model is not None:
+        if patch_inner_model:
+            inner_model.forward = types.MethodType(create_pipeline_forward_inner("PipelineStage"), inner_model)
         if patch_causal_lm_model:
             model.forward = types.MethodType(create_pipeline_forward_causal_lm(), model)
     else:
@@ -272,10 +496,28 @@ def validate_hf_model_for_pipeline_support(model: torch.nn.Module) -> None:
     issues: list[str] = []
 
     if config is not None:
-        if getattr(config, "tie_word_embeddings", False):
-            issues.append(
-                "tie_word_embeddings=True is not supported for pipelining. Use separate input/output embeddings."
+        # For VLMs, check text_config (the outer VLM config tie flag is irrelevant for PP)
+        check_config = getattr(config, "text_config", config)
+        if getattr(check_config, "tie_word_embeddings", False):
+            # Only a real problem if lm_head and embed_tokens share the same weight tensor
+            lm_head = getattr(model, "lm_head", None)
+            inner = getattr(model, "model", model)
+            embed_tokens = getattr(inner, "embed_tokens", None)
+            if embed_tokens is None:
+                lang = getattr(inner, "language_model", None)
+                if lang is not None:
+                    embed_tokens = getattr(lang, "embed_tokens", None)
+            weights_tied = (
+                lm_head is not None
+                and embed_tokens is not None
+                and hasattr(lm_head, "weight")
+                and hasattr(embed_tokens, "weight")
+                and lm_head.weight is embed_tokens.weight
             )
+            if weights_tied:
+                issues.append(
+                    "tie_word_embeddings=True is not supported for pipelining. Use separate input/output embeddings."
+                )
         if getattr(config, "is_encoder_decoder", False):
             issues.append("Encoder-Decoder models with cross-attention are not supported yet for pipeline parallelism.")
 

--- a/nemo_automodel/components/distributed/pipelining/hf_utils.py
+++ b/nemo_automodel/components/distributed/pipelining/hf_utils.py
@@ -317,9 +317,7 @@ def create_pipeline_forward_gemma4_text() -> Callable:
                     layer_type = config_layer_types[idx] if idx < len(config_layer_types) else "full_attention"
                 else:
                     layer_type = getattr(decoder_layer, "attention_type", "full_attention")
-                layer_attention_mask = causal_mask_mapping.get(
-                    layer_type, causal_mask_mapping.get("full_attention")
-                )
+                layer_attention_mask = causal_mask_mapping.get(layer_type, causal_mask_mapping.get("full_attention"))
                 position_embeddings = position_embeddings_map.get(
                     layer_type, position_embeddings_map.get("full_attention")
                 )
@@ -367,11 +365,7 @@ def create_pipeline_forward_gemma4_vlm() -> Callable:
         is_first_stage = embed_tokens is not None
 
         # PP VLM: retrieve pixel_values from chunks stored by the training loop
-        if (
-            pixel_values is None
-            and is_first_stage
-            and getattr(self, "_vlm_pixel_values_chunks", None) is not None
-        ):
+        if pixel_values is None and is_first_stage and getattr(self, "_vlm_pixel_values_chunks", None) is not None:
             has_media_tokens = (
                 input_ids is not None
                 and hasattr(self.config, "image_token_id")
@@ -456,18 +450,12 @@ def patch_hf_model_for_pp(model, patch_inner_model: bool = True, patch_causal_lm
     - Else, patch the module itself.
     """
     inner_model = getattr(model, "model", None)
-    text_backbone = (
-        getattr(inner_model, "language_model", None)
-        if inner_model is not None
-        else None
-    )
+    text_backbone = getattr(inner_model, "language_model", None) if inner_model is not None else None
 
     if inner_model is not None and text_backbone is not None:
         # VLM with nested text backbone (e.g. Gemma4): patch text backbone and VLM outer
         if patch_inner_model:
-            text_backbone.forward = types.MethodType(
-                create_pipeline_forward_gemma4_text(), text_backbone
-            )
+            text_backbone.forward = types.MethodType(create_pipeline_forward_gemma4_text(), text_backbone)
         if patch_causal_lm_model:
             model.forward = types.MethodType(create_pipeline_forward_gemma4_vlm(), model)
     elif inner_model is not None:

--- a/nemo_automodel/components/distributed/pipelining/hf_utils.py
+++ b/nemo_automodel/components/distributed/pipelining/hf_utils.py
@@ -441,19 +441,43 @@ def create_pipeline_forward_gemma4_vlm() -> Callable:
     return pipeline_forward_gemma4_vlm
 
 
+def _is_gemma4_vlm(model: torch.nn.Module) -> bool:
+    """Return True only for Gemma4 VLM variants.
+
+    ``model.model.language_model`` alone is not enough to identify Gemma4 —
+    Kimi VL, Mistral4, Qwen3 VL MoE, Llava OneVision and others share that
+    structure. Gate the Gemma4-specific PP forward on the HF ``model_type``
+    so unrelated VLMs fall through to the generic CausalLM path instead of
+    receiving Gemma4's sliding/full-attention and softcapping logic.
+    """
+    config = getattr(model, "config", None)
+    if config is None:
+        return False
+    model_type = getattr(config, "model_type", None)
+    if model_type == "gemma4":
+        return True
+    # VLM configs usually nest the text backbone under ``text_config``.
+    text_config = getattr(config, "text_config", None)
+    return getattr(text_config, "model_type", None) == "gemma4"
+
+
 def patch_hf_model_for_pp(model, patch_inner_model: bool = True, patch_causal_lm_model: bool = True) -> None:
     """Patch a HF model/module to produce pipeline-compatible forward.
 
-    - If model has .model (e.g., LlamaForCausalLM), patch inner and outer.
-    - If model.model has .language_model (e.g., Gemma4 VLM), patch the text backbone
-      and outer with Gemma4-specific VLM-aware forwards.
-    - Else, patch the module itself.
+    - Gemma4 VLM (``config.model_type == 'gemma4'`` with a nested text
+      backbone at ``model.model.language_model``): patch the text backbone
+      and VLM outer with Gemma4-specific VLM-aware forwards.
+    - Other models with ``model.model`` (e.g., LlamaForCausalLM and most
+      other VLMs): patch inner and outer with the generic CausalLM
+      forwards.
+    - Else: patch the module itself with the generic inner forward.
     """
     inner_model = getattr(model, "model", None)
     text_backbone = getattr(inner_model, "language_model", None) if inner_model is not None else None
 
-    if inner_model is not None and text_backbone is not None:
-        # VLM with nested text backbone (e.g. Gemma4): patch text backbone and VLM outer
+    if inner_model is not None and text_backbone is not None and _is_gemma4_vlm(model):
+        # Gemma4 VLM: the text backbone needs sliding/full-attention RoPE
+        # dispatch and the VLM outer needs final_logit_softcapping.
         if patch_inner_model:
             text_backbone.forward = types.MethodType(create_pipeline_forward_gemma4_text(), text_backbone)
         if patch_causal_lm_model:

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -256,19 +256,34 @@ def _chunk_vlm_media(
 ) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
     """Split VLM pixel_values and image_grid into PP microbatch chunks.
 
-    Handles three layouts:
+    Handles four layouts:
     1. ``[N, C, H, W]`` with ``N == batch_size`` — one full image per sample.
-    2. Flat patches ``[total_patches, D]`` with per-sample image counts from
+    2. ``[N, max_patches, D]`` with ``N == batch_size`` — Gemma4 style (pre-padded patches per image).
+    3. Flat patches ``[total_patches, D]`` with per-sample image counts from
        ``n_images_per_sample`` (general case, works for packed sequences too).
-    3. Flat patches with ``n_images == batch_size`` — legacy 1-image-per-sample.
+    4. Flat patches with ``n_images == batch_size`` — legacy 1-image-per-sample.
     """
     n_images = image_grid.shape[0]
     pixel_values_chunks: list[torch.Tensor] = []
     image_grid_chunks: list[torch.Tensor] = []
 
-    if pixel_values.dim() == 4 and pixel_values.shape[0] == batch_size:
+    if pixel_values.shape[0] == batch_size and pixel_values.dim() in (3, 4):
+        # Layout 1 (4D: [N, C, H, W]) and Layout 2 (3D Gemma4: [N, max_patches, patch_dim]).
+        # Both are indexed by image along dim 0, one entry per sample.
         pixel_values_chunks = list(pixel_values.chunk(n_microbatches, dim=0))
         image_grid_chunks = list(image_grid.chunk(n_microbatches, dim=0))
+    elif pixel_values.dim() == 3 and n_images_per_sample is not None:
+        # Gemma4 multi-image: pixel_values is [N_total_images, max_patches, patch_dim].
+        # All images are padded to the same max_patches, so split by image count directly.
+        cumsum_images = torch.cumsum(n_images_per_sample, dim=0)
+        samples_per_mb = batch_size // n_microbatches
+        for mb_idx in range(n_microbatches):
+            s_start = mb_idx * samples_per_mb
+            s_end = min(s_start + samples_per_mb, batch_size)
+            img_start = 0 if s_start == 0 else int(cumsum_images[s_start - 1].item())
+            img_end = int(cumsum_images[s_end - 1].item()) if s_end > 0 else 0
+            pixel_values_chunks.append(pixel_values[img_start:img_end])
+            image_grid_chunks.append(image_grid[img_start:img_end])
     elif n_images_per_sample is not None:
         # General case: use per-sample image counts to associate images with
         # batch items.  Works for packed sequences (multiple images per item).
@@ -922,6 +937,7 @@ class FinetuneRecipeForVLM(BaseRecipe):
                     targets = None
 
                 input_ids = batch.pop("input_ids")
+                self.pp.update_seq_len(input_ids.shape[1])
 
                 # VLM: Custom chunking for pixel_values and image_grid
                 # These tensors have non-standard structure that can't be naively chunked by dim 0
@@ -930,11 +946,14 @@ class FinetuneRecipeForVLM(BaseRecipe):
                 image_grid_hws = batch.pop("image_grid_hws", None)
                 image_grid_thw = batch.pop("image_grid_thw", None)
                 image_sizes = batch.pop("image_sizes", None)
+                image_position_ids = batch.pop("image_position_ids", None)
                 n_images_per_sample = batch.pop("n_images_per_sample", None)
 
                 image_grid = image_grid_hws if image_grid_hws is not None else image_grid_thw
                 if image_grid is None and image_sizes is not None:
                     image_grid = image_sizes
+                if image_grid is None and image_position_ids is not None:
+                    image_grid = image_position_ids
 
                 if self.pp.info.has_first_stage and pixel_values is not None and image_grid is not None:
                     stage0_model = self.model_parts[0]

--- a/tests/unit_tests/checkpoint/test_addons.py
+++ b/tests/unit_tests/checkpoint/test_addons.py
@@ -96,7 +96,8 @@ def test_model_state_disables_tied_embeddings_for_non_tied_models():
     model = _DummyModel()
     state = ModelState([model])
 
-    assert state.is_tied_lm_head is False
+    assert state.uses_tied_lm_head is False
+    assert state.has_local_tied_lm_head is False
     assert not hasattr(state, "lm_head_param_name")
 
     state_dict = state.state_dict()

--- a/tests/unit_tests/checkpoint/test_checkpointing.py
+++ b/tests/unit_tests/checkpoint/test_checkpointing.py
@@ -28,8 +28,13 @@ from nemo_automodel.components.checkpoint.checkpointing import (
     _is_custom_model,
     _model_has_dtensors,
     _reinit_non_persistent_buffers,
+    _summarize_state_dict_key_diff,
 )
-from nemo_automodel.components.checkpoint.stateful_wrappers import _get_lm_head_weight_and_name
+from nemo_automodel.components.checkpoint.stateful_wrappers import ModelState, _get_lm_head_weight_and_name
+from nemo_automodel.components.checkpoint.utils import (
+    has_local_tied_lm_head,
+    materialize_missing_tied_lm_head,
+)
 
 
 def _make_keys(count: int) -> list[str]:
@@ -76,6 +81,31 @@ def test_equally_divide_layers_num_shards_one():
 
     assert len(mapping) == len(keys)
     assert set(mapping.values()) == {1}
+
+
+def test_summarize_state_dict_key_diff_reports_missing_and_unexpected():
+    summary = _summarize_state_dict_key_diff(
+        {"a.weight", "b.bias", "c.weight"},
+        {"a.weight", "c.weight", "extra.weight"},
+        limit=2,
+    )
+
+    assert summary["missing_count"] == 1
+    assert summary["unexpected_count"] == 1
+    assert summary["missing_examples"] == ["b.bias"]
+    assert summary["unexpected_examples"] == ["extra.weight"]
+
+
+def test_summarize_state_dict_key_diff_limits_examples():
+    summary = _summarize_state_dict_key_diff(
+        {"a", "b", "c", "d"},
+        {"x"},
+        limit=2,
+    )
+
+    assert summary["missing_count"] == 4
+    assert summary["unexpected_count"] == 1
+    assert summary["missing_examples"] == ["a", "b"]
 
 
 # =============================================================================
@@ -134,6 +164,43 @@ class TestGetLmHeadWeightAndName:
 
         assert name == "lm_head.weight"
         assert "_orig_mod" not in name
+
+
+class _PipelineLastStageLikeModel(torch.nn.Module):
+    _tied_weights_keys = {"lm_head.weight": "model.language_model.embed_tokens.weight"}
+
+    def __init__(self):
+        super().__init__()
+        self.config = SimpleNamespace(tie_word_embeddings=True)
+        self.lm_head = torch.nn.Linear(4, 4, bias=False)
+
+
+def test_has_local_tied_lm_head_is_false_for_pp_last_stage_like_partition():
+    model = _PipelineLastStageLikeModel()
+
+    assert has_local_tied_lm_head(model) is False
+
+
+def test_materialize_missing_tied_lm_head_uses_embedding_tensor_from_checkpoint():
+    model = _PipelineLastStageLikeModel()
+    embed_weight = torch.full_like(model.lm_head.weight, 3.0)
+    state_dict = {"model.language_model.embed_tokens.weight": embed_weight}
+
+    materialized = materialize_missing_tied_lm_head(state_dict, model, allow_current_lm_head_fallback=False)
+
+    assert materialized is True
+    assert "lm_head.weight" in state_dict
+    assert torch.equal(state_dict["lm_head.weight"], embed_weight)
+    assert not torch.equal(state_dict["lm_head.weight"], model.lm_head.weight.detach())
+
+
+def test_model_state_keeps_pp_last_stage_lm_head_in_saved_state_dict():
+    model = _PipelineLastStageLikeModel()
+
+    model_state = ModelState(model, is_peft=False, is_init_step=False)
+    saved_state_dict = model_state.state_dict()
+
+    assert "lm_head.weight" in saved_state_dict
 
 
 # =============================================================================

--- a/tests/unit_tests/distributed/pipelining/test_hf_utils.py
+++ b/tests/unit_tests/distributed/pipelining/test_hf_utils.py
@@ -345,6 +345,78 @@ class TestPatchHfModelForPp:
         # Outer forward should still be patched
         assert model.forward != original_forward
 
+    def test_patch_gemma4_vlm_uses_gemma4_forward(self):
+        """Gemma4 VLM (config.model_type == 'gemma4') gets the Gemma4-specific forwards."""
+        class _Inner(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.language_model = nn.Module()
+
+        class _Gemma4(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.config = Mock(model_type="gemma4")
+                self.model = _Inner()
+
+        model = _Gemma4()
+        original_outer = model.forward
+        original_text_backbone = model.model.language_model.forward
+
+        patch_hf_model_for_pp(model, patch_inner_model=True, patch_causal_lm_model=True)
+
+        # The text backbone is the one patched (not model.model itself).
+        assert model.model.language_model.forward is not original_text_backbone
+        assert model.forward is not original_outer
+        # Sanity: the Gemma4 forward is bound to the text backbone and outer VLM.
+        assert model.model.language_model.forward.__func__.__name__ == "pipeline_forward_gemma4_text"
+        assert model.forward.__func__.__name__ == "pipeline_forward_gemma4_vlm"
+
+    def test_patch_non_gemma4_vlm_falls_back_to_generic(self):
+        """VLMs that happen to expose model.language_model but are NOT Gemma4 use the generic path."""
+        class _Inner(nn.Module):
+            def __init__(self):
+                super().__init__()
+                # Many HF VLMs (KimiVL / Mistral4 / Qwen3VL MoE / LlavaOneVision / ...)
+                # also expose language_model here. These must NOT hit Gemma4's forward.
+                self.language_model = nn.Module()
+
+        class _OtherVLM(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.config = Mock(model_type="llava_onevision", text_config=None)
+                self.model = _Inner()
+
+        model = _OtherVLM()
+        original_inner = model.model.forward
+        original_outer = model.forward
+
+        patch_hf_model_for_pp(model, patch_inner_model=True, patch_causal_lm_model=True)
+
+        # Generic path patches model.model (inner) directly, not language_model.
+        assert model.model.forward is not original_inner
+        assert model.forward is not original_outer
+        assert model.model.forward.__func__.__name__ == "pipeline_forward"
+        assert model.forward.__func__.__name__ == "pipeline_forward_causal_lm"
+
+    def test_patch_gemma4_vlm_via_text_config_model_type(self):
+        """Gemma4 detection also works when model_type is only in config.text_config."""
+        class _Inner(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.language_model = nn.Module()
+
+        class _Gemma4(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.config = Mock(model_type="gemma4_vision", text_config=Mock(model_type="gemma4"))
+                self.model = _Inner()
+
+        model = _Gemma4()
+        patch_hf_model_for_pp(model, patch_inner_model=True, patch_causal_lm_model=True)
+
+        assert model.model.language_model.forward.__func__.__name__ == "pipeline_forward_gemma4_text"
+        assert model.forward.__func__.__name__ == "pipeline_forward_gemma4_vlm"
+
 
 class TestInitHfModelBuffers:
     """Test init_hf_model_buffers function."""

--- a/tests/unit_tests/distributed/pipelining/test_hf_utils.py
+++ b/tests/unit_tests/distributed/pipelining/test_hf_utils.py
@@ -438,16 +438,25 @@ class TestValidateHfModelForPipelineSupport:
         validate_hf_model_for_pipeline_support(model)
 
     def test_validate_model_with_tied_embeddings(self):
-        """Test validation fails for model with tied embeddings."""
+        """Validation fails only when lm_head and embed_tokens actually share storage."""
         class MockConfig:
             pretrained_model_name_or_path = "test/model"
-            tie_word_embeddings = True  # This should cause validation to fail
+            tie_word_embeddings = True  # Needed to enable the tied-weights check
             is_encoder_decoder = False
+
+        class _Inner(nn.Module):
+            def __init__(self, shared_embed):
+                super().__init__()
+                self.embed_tokens = shared_embed
 
         class MockModel(nn.Module):
             def __init__(self):
                 super().__init__()
                 self.config = MockConfig()
+                self.lm_head = nn.Linear(4, 4, bias=False)
+                self.model = _Inner(nn.Embedding(4, 4))
+                # Actually tie the weights so the validator's stricter check triggers.
+                self.model.embed_tokens.weight = self.lm_head.weight
 
         model = MockModel()
 
@@ -475,13 +484,21 @@ class TestValidateHfModelForPipelineSupport:
         """Test validation with multiple issues."""
         class MockConfig:
             pretrained_model_name_or_path = "test/model"
-            tie_word_embeddings = True  # Issue 1
+            tie_word_embeddings = True  # Issue 1 (only fires when weights are actually tied)
             is_encoder_decoder = True   # Issue 2
+
+        class _Inner(nn.Module):
+            def __init__(self, shared_embed):
+                super().__init__()
+                self.embed_tokens = shared_embed
 
         class MockModel(nn.Module):
             def __init__(self):
                 super().__init__()
                 self.config = MockConfig()
+                self.lm_head = nn.Linear(4, 4, bias=False)
+                self.model = _Inner(nn.Embedding(4, 4))
+                self.model.embed_tokens.weight = self.lm_head.weight
 
         model = MockModel()
 

--- a/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
+++ b/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
@@ -1218,6 +1218,11 @@ class _MockAutoPipeline:
         self._info = _MockPPInfo(has_first_stage, has_last_stage, n_microbatches, add_losses)
         self.info = self._info
 
+    def update_seq_len(self, seq_len: int) -> None:
+        # Dynamic seq-len hook is a no-op in tests; AutoPipeline exposes this for
+        # variable-length VLM batches.
+        return None
+
 
 def _create_pp_recipe(model=None):
     """Helper to create a PP recipe bypassing BaseRecipe tracking."""


### PR DESCRIPTION
## Summary

- Add TP+PP support for Gemma4 ConditionalGeneration VLM:
  register the model in the parallelizer and add Gemma4-specific
  pipeline forwards (text backbone + VLM outer), including
  `layer_types`-based RoPE dispatch, safe `tie_weights` skipping for
  PP stages without `embed_tokens`/`lm_head`, and PP chunking that
  handles `image_position_ids`.
- Fix tied `lm_head` loading on the PP last stage. PP last stages own
  `lm_head` but not `embed_tokens`, so they cannot share storage
  locally. HF tied-embedding checkpoints (and DCP checkpoints saved
  before this fix) omit `lm_head.weight` entirely, which made the DCP
  planner fail with `Missing key in checkpoint state_dict:
  lm_head.weight`. The fix:
  - Splits `uses_tied_lm_head` (config flag) from
    `has_local_tied_lm_head` (true only when local `lm_head` and
    `embed_tokens` actually share storage). Saved state dicts now keep
    `lm_head.weight` on PP last stages.
  - Adds `materialize_missing_tied_lm_head` /
    `get_tied_lm_head_source_names` helpers using
    `_tied_weights_keys` plus HF fallbacks.
  - In the safetensors fast load path, materializes the missing
    `lm_head.weight` from the embedding tensor.
  - In the standard DCP load path, when `lm_head.weight` is absent
    from checkpoint metadata, routes the embedding source key into
    the lm_head tensor and renames back after load. This now also
    applies on init load so a fresh HF tied-embedding base loads
    cleanly into a PP last stage.
- Add two desensitized example recipes for Gemma4 31B VLM:
  - `examples/vlm_finetune/gemma4/gemma4_31b_tp4_pp2.yaml` — single
    node, 8 GPUs (TP4 x PP2 x DP1).
  - `examples/vlm_finetune/gemma4/gemma4_31b_tp4_pp4.yaml` — 4 nodes,
    32 GPUs (TP4 x PP4 x DP2), with a multi-node `torchrun` snippet.
  Both use `google/gemma-4-31B-it` and the public MedPix-VQA dataset.

## Test plan

- [x] Added/updated unit tests in
  `tests/unit_tests/checkpoint/test_checkpointing.py`
  (`has_local_tied_lm_head`, `materialize_missing_tied_lm_head`,
  PP-last-stage save behavior).
- [x] Manual run of `gemma4_31b_tp4_pp2.yaml` (single node, 8 GPU).
- [x] Manual run of `gemma4_31b_tp4_pp4.yaml` (4 nodes, 32 GPU).
- [ ] CI: ruff, unit tests, recipe smoke tests.