### PR TITLE
fix: add embed_vision to MULTIMODAL_SUFFIXES and set lbs=2 for Gemma4 PP2 recipe

### DIFF
--- a/examples/vlm_finetune/gemma4/gemma4_31b_tp4_pp2.yaml
+++ b/examples/vlm_finetune/gemma4/gemma4_31b_tp4_pp2.yaml
@@ -23,7 +23,7 @@ recipe: FinetuneRecipeForVLM
 
 step_scheduler:
   global_batch_size: 8
-  local_batch_size: 1
+  local_batch_size: 2
   ckpt_every_steps: 500
   val_every_steps: 500
   num_epochs: 2

--- a/nemo_automodel/components/distributed/pipelining/hf_utils.py
+++ b/nemo_automodel/components/distributed/pipelining/hf_utils.py
@@ -31,6 +31,7 @@ MULTIMODAL_SUFFIXES = (
     "visual",
     "image_encoder",
     "vision_encoder",
+    "embed_vision",
     "audio_tower",
     "audio_encoder",
     "audio_model",


### PR DESCRIPTION
# What does this PR do ?

Two small follow-up fixes to #1904, caught in review by @HuiyingLi: correct \`embed_vision\` stage-0 assignment for Gemma4 PP, and fix \`local_batch_size\` in the PP2 recipe to avoid a 100% pipeline bubble.

# Changelog

- Add \`embed_vision\` to \`MULTIMODAL_SUFFIXES\` in \`hf_utils.py\` so Gemma4's vision projection layer is correctly assigned to PP Stage 0 alongside \`vision_tower\`. It was missing because original PP testing used pure-text inputs only.
- Set \`local_batch_size: 2\` in \`gemma4_31b_tp4_pp2.yaml\`. \`lbs=1\` technically runs (the per-rank stage count for 1F1B is 1, so no warning triggers), but produces zero pipeline overlap (100% bubble). Local runs were always done with \`lbs=2\`; the recipe was submitted with \`lbs=1\` by mistake.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

# Additional Information

- Related to #1904