### PR TITLE
fix: update defer_fsdp_grad_sync in recipes

### DIFF
--- a/examples/llm_finetune/devstral/devstral2_small_2512_squad.yaml
+++ b/examples/llm_finetune/devstral/devstral2_small_2512_squad.yaml
@@ -50,8 +50,8 @@ distributed:
   dp_size: none
   tp_size: 1
   cp_size: 1
-
   sequence_parallel: false
+  defer_fsdp_grad_sync: false
 
 loss_fn:
   _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy

--- a/examples/llm_finetune/llama3_1/llama3_1_8b_hellaswag_fp8.yaml
+++ b/examples/llm_finetune/llama3_1/llama3_1_8b_hellaswag_fp8.yaml
@@ -53,7 +53,7 @@ distributed:
   dp_size: none
   tp_size: 1
   cp_size: 1
-
+  defer_fsdp_grad_sync: false
   sequence_parallel: false
 
 compile:

--- a/nemo_automodel/__init__.py
+++ b/nemo_automodel/__init__.py
@@ -116,6 +116,23 @@ class _ModelsAliasFinder(importlib.abc.MetaPathFinder):
 sys.meta_path.insert(0, _ModelsAliasFinder())
 
 
+# ---------------------------------------------------------------------------
+# Register a lightweight import hook that widens ``ALLOWED_LAYER_TYPES`` the
+# moment ``transformers.configuration_utils`` is loaded. The hook module imports
+# only stdlib + logging, so it does NOT force a transformers import at
+# ``import nemo_automodel`` time — preserving the lightweight-import promise.
+# ---------------------------------------------------------------------------
+try:
+    from nemo_automodel._transformers.v4_patches.layer_types import (
+        install_layer_types_patch_hook as _install_layer_types_patch_hook,
+    )
+
+    _install_layer_types_patch_hook()
+except Exception:
+    # Never let a hook failure break ``import nemo_automodel``.
+    pass
+
+
 def __getattr__(name: str) -> ModuleType | Any:
     """
     Lazily import and cache selected submodules / exported symbols when accessed.

--- a/nemo_automodel/_transformers/v4_patches/__init__.py
+++ b/nemo_automodel/_transformers/v4_patches/__init__.py
@@ -14,9 +14,18 @@
 
 """Compatibility patches for legacy v4-style transformer models."""
 
+from nemo_automodel._transformers.v4_patches.layer_types import (
+    install_layer_types_patch_hook,
+    patch_allowed_layer_types,
+)
 from nemo_automodel._transformers.v4_patches.rotary import (
     fix_rotary_embeddings,
     should_fix_rotary_embeddings,
 )
 
-__all__ = ["fix_rotary_embeddings", "should_fix_rotary_embeddings"]
+__all__ = [
+    "fix_rotary_embeddings",
+    "install_layer_types_patch_hook",
+    "patch_allowed_layer_types",
+    "should_fix_rotary_embeddings",
+]

--- a/nemo_automodel/_transformers/v4_patches/layer_types.py
+++ b/nemo_automodel/_transformers/v4_patches/layer_types.py
@@ -1,0 +1,213 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Widen transformers' ``ALLOWED_LAYER_TYPES`` so legacy custom configs load.
+
+Some community models (e.g. ``nvidia/Nemotron-Flash-1B``) ship a custom
+``configuration_*.py`` whose ``layer_types`` entries (e.g. ``'deltanet'``,
+``'f'``, ``'m2'``, ``'a'``) are not in the upstream allow-list. Loading them
+via ``AutoConfig.from_pretrained`` triggers ``validate_layer_type`` and raises
+``StrictDataclassClassValidationError`` before model instantiation.
+
+The validator performs a module-global lookup of ``ALLOWED_LAYER_TYPES`` at
+call time, so rebinding it in place takes effect on subsequent validations.
+"""
+
+from __future__ import annotations
+
+import importlib.abc
+import logging
+import sys
+from typing import Iterable
+
+logger = logging.getLogger(__name__)
+
+_TARGET_MODULE = "transformers.configuration_utils"
+
+DEFAULT_EXTRA_LAYER_TYPES: tuple[str, ...] = (
+    "deltanet",
+    "f",
+    "m2",
+    "a",
+)
+
+_PATCHED: bool = False
+
+
+def patch_allowed_layer_types(extra: Iterable[str] = DEFAULT_EXTRA_LAYER_TYPES) -> bool:
+    """Extend ``transformers.configuration_utils.ALLOWED_LAYER_TYPES`` in place.
+
+    Idempotent and best-effort: any failure (missing attribute, transformers
+    not installed, unexpected container type) is logged and swallowed so the
+    caller's import path is not broken.
+
+    Args:
+        extra: Layer-type names to append if not already present.
+
+    Returns:
+        ``True`` if the tuple was modified on this call, ``False`` otherwise.
+    """
+    global _PATCHED
+    if _PATCHED:
+        return False
+
+    try:
+        from transformers import configuration_utils as cu
+    except ImportError:
+        logger.debug("[v4_patches.layer_types] transformers not importable; skipping.")
+        return False
+    except Exception as exc:
+        logger.warning("[v4_patches.layer_types] transformers import failed: %s", exc)
+        return False
+
+    existing = getattr(cu, "ALLOWED_LAYER_TYPES", None)
+    if existing is None:
+        logger.debug("[v4_patches.layer_types] ALLOWED_LAYER_TYPES missing; nothing to patch.")
+        _PATCHED = True
+        return False
+
+    try:
+        existing_set = set(existing)
+    except TypeError:
+        logger.warning(
+            "[v4_patches.layer_types] ALLOWED_LAYER_TYPES is not iterable (%s); skipping.",
+            type(existing).__name__,
+        )
+        return False
+
+    try:
+        additions = tuple(lt for lt in extra if lt not in existing_set)
+    except TypeError:
+        logger.warning("[v4_patches.layer_types] `extra` is not iterable; skipping.")
+        return False
+
+    if not additions:
+        _PATCHED = True
+        return False
+
+    try:
+        cu.ALLOWED_LAYER_TYPES = tuple(existing) + additions
+    except Exception as exc:
+        logger.warning("[v4_patches.layer_types] failed to rebind ALLOWED_LAYER_TYPES: %s", exc)
+        return False
+
+    _PATCHED = True
+    logger.info("[v4_patches.layer_types] extended ALLOWED_LAYER_TYPES with %s", additions)
+    return True
+
+
+_HOOK_INSTALLED: bool = False
+
+
+class _LayerTypesPatchFinder(importlib.abc.MetaPathFinder):
+    """Meta-path finder that applies ``patch_allowed_layer_types`` the moment
+    ``transformers.configuration_utils`` finishes loading.
+
+    The finder only intercepts the single target module name. For that name it
+    delegates to the remaining finders to obtain a real spec, then wraps the
+    loader's ``exec_module`` so the patch runs once, post-exec. All deviations
+    from the happy path (missing loader, unexpected spec shape, patch failure)
+    are swallowed with a log — the finder must never break imports.
+    """
+
+    def __init__(self) -> None:
+        self._applied = False
+
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname != _TARGET_MODULE or self._applied:
+            return None
+
+        real_spec = None
+        for finder in sys.meta_path:
+            # Skip any instance of our own finder class to avoid wrapping our
+            # own wrapped loader (can happen if the hook is installed twice).
+            if isinstance(finder, _LayerTypesPatchFinder):
+                continue
+            find_spec = getattr(finder, "find_spec", None)
+            if find_spec is None:
+                continue
+            try:
+                real_spec = find_spec(fullname, path, target)
+            except Exception:
+                continue
+            if real_spec is not None:
+                break
+
+        if real_spec is None or real_spec.loader is None:
+            return real_spec
+
+        loader = real_spec.loader
+        original_exec_module = getattr(loader, "exec_module", None)
+        if original_exec_module is None:
+            return real_spec
+
+        finder_self = self
+
+        def exec_module(module):
+            try:
+                original_exec_module(module)
+            finally:
+                finder_self._applied = True
+                try:
+                    patch_allowed_layer_types()
+                except Exception as exc:
+                    logger.warning("[v4_patches.layer_types] post-import patch failed: %s", exc)
+
+        try:
+            loader.exec_module = exec_module  # type: ignore[method-assign]
+        except Exception as exc:
+            logger.debug("[v4_patches.layer_types] could not wrap loader.exec_module: %s", exc)
+
+        return real_spec
+
+
+def install_layer_types_patch_hook() -> bool:
+    """Ensure ``patch_allowed_layer_types`` runs before any call to
+    ``PreTrainedConfig.validate_layer_type``.
+
+    Two paths:
+      * If ``transformers.configuration_utils`` is already loaded, patch
+        immediately.
+      * Otherwise, register a meta-path finder that patches on first import.
+
+    Idempotent; safe to call multiple times.
+
+    Returns:
+        ``True`` if a hook was installed (or the patch was applied directly on
+        this call), ``False`` if a previous call already arranged one.
+    """
+    global _HOOK_INSTALLED
+    if _HOOK_INSTALLED:
+        return False
+
+    if _TARGET_MODULE in sys.modules:
+        _HOOK_INSTALLED = True
+        patch_allowed_layer_types()
+        return True
+
+    try:
+        sys.meta_path.insert(0, _LayerTypesPatchFinder())
+    except Exception as exc:
+        logger.warning("[v4_patches.layer_types] failed to install import hook: %s", exc)
+        return False
+
+    _HOOK_INSTALLED = True
+    return True
+
+
+__all__ = [
+    "DEFAULT_EXTRA_LAYER_TYPES",
+    "install_layer_types_patch_hook",
+    "patch_allowed_layer_types",
+]

--- a/nemo_automodel/components/distributed/config.py
+++ b/nemo_automodel/components/distributed/config.py
@@ -105,7 +105,7 @@ class FSDP2Config:
     offload_policy: Optional[CPUOffloadPolicy] = None
     autocast_dtype: Optional[torch.dtype] = None
     activation_checkpointing: bool = False
-    defer_fsdp_grad_sync: bool = False
+    defer_fsdp_grad_sync: bool = True
     backend: str = "nccl"
     enable_async_tensor_parallel: bool = False
     enable_compile: bool = False

--- a/nemo_automodel/components/distributed/config.py
+++ b/nemo_automodel/components/distributed/config.py
@@ -105,7 +105,7 @@ class FSDP2Config:
     offload_policy: Optional[CPUOffloadPolicy] = None
     autocast_dtype: Optional[torch.dtype] = None
     activation_checkpointing: bool = False
-    defer_fsdp_grad_sync: bool = True
+    defer_fsdp_grad_sync: bool = False
     backend: str = "nccl"
     enable_async_tensor_parallel: bool = False
     enable_compile: bool = False

--- a/tests/unit_tests/_transformers/v4_patches/test_layer_types.py
+++ b/tests/unit_tests/_transformers/v4_patches/test_layer_types.py
@@ -1,0 +1,217 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``nemo_automodel._transformers.v4_patches.layer_types``.
+
+Tests are kept hermetic by swapping ``transformers.configuration_utils`` in
+``sys.modules`` with a stand-in module, rather than touching the real
+package (which may or may not be installed and may already be imported).
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from nemo_automodel._transformers.v4_patches import layer_types as lt_mod
+
+
+@pytest.fixture
+def isolated_layer_types_state():
+    """Reset module globals and meta-path / sys.modules mutations after each test."""
+    saved_patched = lt_mod._PATCHED
+    saved_hook_installed = lt_mod._HOOK_INSTALLED
+    saved_meta_path = list(sys.meta_path)
+    saved_transformers = sys.modules.get("transformers")
+    saved_cu = sys.modules.get(lt_mod._TARGET_MODULE)
+
+    lt_mod._PATCHED = False
+    lt_mod._HOOK_INSTALLED = False
+    # The package installs a finder at import time; strip it so each test can
+    # reason about the finders it inserts in isolation. The original list is
+    # restored verbatim on teardown.
+    sys.meta_path[:] = [f for f in sys.meta_path if not isinstance(f, lt_mod._LayerTypesPatchFinder)]
+
+    try:
+        yield
+    finally:
+        lt_mod._PATCHED = saved_patched
+        lt_mod._HOOK_INSTALLED = saved_hook_installed
+        sys.meta_path[:] = saved_meta_path
+        _restore(sys.modules, "transformers", saved_transformers)
+        _restore(sys.modules, lt_mod._TARGET_MODULE, saved_cu)
+
+
+def _restore(mapping, key, value):
+    if value is None:
+        mapping.pop(key, None)
+    else:
+        mapping[key] = value
+
+
+def _install_fake_transformers(initial_types=("sliding_attention", "full_attention")):
+    """Register a minimal transformers package exposing ``configuration_utils``."""
+    fake_pkg = types.ModuleType("transformers")
+    fake_pkg.__path__ = []  # mark as package so submodule imports resolve
+
+    fake_cu = types.ModuleType("transformers.configuration_utils")
+    fake_cu.ALLOWED_LAYER_TYPES = tuple(initial_types)
+
+    fake_pkg.configuration_utils = fake_cu
+
+    sys.modules["transformers"] = fake_pkg
+    sys.modules["transformers.configuration_utils"] = fake_cu
+    return fake_cu
+
+
+class TestPatchAllowedLayerTypes:
+    def test_extends_allowed_layer_types(self, isolated_layer_types_state):
+        fake_cu = _install_fake_transformers(initial_types=("sliding_attention",))
+
+        modified = lt_mod.patch_allowed_layer_types()
+
+        assert modified is True
+        assert "sliding_attention" in fake_cu.ALLOWED_LAYER_TYPES  # preserved
+        for extra in lt_mod.DEFAULT_EXTRA_LAYER_TYPES:
+            assert extra in fake_cu.ALLOWED_LAYER_TYPES
+
+    def test_idempotent_second_call_noop(self, isolated_layer_types_state):
+        fake_cu = _install_fake_transformers(initial_types=("sliding_attention",))
+
+        assert lt_mod.patch_allowed_layer_types() is True
+        after_first = fake_cu.ALLOWED_LAYER_TYPES
+
+        # _PATCHED should short-circuit; tuple must be identical.
+        assert lt_mod.patch_allowed_layer_types() is False
+        assert fake_cu.ALLOWED_LAYER_TYPES == after_first
+
+    def test_no_duplicates_when_guard_reset(self, isolated_layer_types_state):
+        """Even if the _PATCHED guard is bypassed, entries aren't duplicated."""
+        fake_cu = _install_fake_transformers(initial_types=("sliding_attention",))
+
+        lt_mod.patch_allowed_layer_types()
+        lt_mod._PATCHED = False  # simulate a stale/unguarded re-call
+        lt_mod.patch_allowed_layer_types()
+
+        for extra in lt_mod.DEFAULT_EXTRA_LAYER_TYPES:
+            assert fake_cu.ALLOWED_LAYER_TYPES.count(extra) == 1
+
+    def test_custom_extra_argument(self, isolated_layer_types_state):
+        fake_cu = _install_fake_transformers(initial_types=("existing",))
+
+        assert lt_mod.patch_allowed_layer_types(extra=("foo", "bar")) is True
+        assert "foo" in fake_cu.ALLOWED_LAYER_TYPES
+        assert "bar" in fake_cu.ALLOWED_LAYER_TYPES
+        # Defaults should NOT have been added when a custom extra is supplied.
+        for default_extra in lt_mod.DEFAULT_EXTRA_LAYER_TYPES:
+            assert default_extra not in fake_cu.ALLOWED_LAYER_TYPES
+
+    def test_skips_when_attribute_missing(self, isolated_layer_types_state):
+        fake_pkg = types.ModuleType("transformers")
+        fake_pkg.__path__ = []
+        fake_cu = types.ModuleType("transformers.configuration_utils")
+        # Intentionally no ALLOWED_LAYER_TYPES attribute.
+        fake_pkg.configuration_utils = fake_cu
+        sys.modules["transformers"] = fake_pkg
+        sys.modules["transformers.configuration_utils"] = fake_cu
+
+        assert lt_mod.patch_allowed_layer_types() is False
+        assert not hasattr(fake_cu, "ALLOWED_LAYER_TYPES")
+
+
+class TestInstallLayerTypesPatchHook:
+    def test_defers_when_transformers_not_loaded(self, isolated_layer_types_state):
+        sys.modules.pop(lt_mod._TARGET_MODULE, None)
+        sys.modules.pop("transformers", None)
+
+        assert lt_mod.install_layer_types_patch_hook() is True
+
+        finders = [f for f in sys.meta_path if isinstance(f, lt_mod._LayerTypesPatchFinder)]
+        assert len(finders) == 1
+        # Patch must NOT have run yet — no configuration_utils was present.
+        assert lt_mod._PATCHED is False
+
+    def test_patches_immediately_when_already_loaded(self, isolated_layer_types_state):
+        fake_cu = _install_fake_transformers(initial_types=("sliding_attention",))
+
+        assert lt_mod.install_layer_types_patch_hook() is True
+
+        # Already-imported branch: patch is applied directly, no finder added.
+        assert lt_mod._PATCHED is True
+        for extra in lt_mod.DEFAULT_EXTRA_LAYER_TYPES:
+            assert extra in fake_cu.ALLOWED_LAYER_TYPES
+        finders = [f for f in sys.meta_path if isinstance(f, lt_mod._LayerTypesPatchFinder)]
+        assert finders == []
+
+    def test_hook_install_is_idempotent(self, isolated_layer_types_state):
+        sys.modules.pop(lt_mod._TARGET_MODULE, None)
+        sys.modules.pop("transformers", None)
+
+        assert lt_mod.install_layer_types_patch_hook() is True
+        assert lt_mod.install_layer_types_patch_hook() is False
+
+        finders = [f for f in sys.meta_path if isinstance(f, lt_mod._LayerTypesPatchFinder)]
+        assert len(finders) == 1
+
+    def test_finder_triggers_patch_on_import(self, isolated_layer_types_state):
+        """End-to-end: installing the hook, then loading the target module,
+        should cause ``ALLOWED_LAYER_TYPES`` to be extended post-exec."""
+        sys.modules.pop(lt_mod._TARGET_MODULE, None)
+        sys.modules.pop("transformers", None)
+
+        assert lt_mod.install_layer_types_patch_hook() is True
+        assert lt_mod._PATCHED is False
+
+        # Simulate transformers.configuration_utils landing in sys.modules *after*
+        # the hook was installed, then manually drive the finder's wrapped loader
+        # flow the way importlib would.
+        finder = next(f for f in sys.meta_path if isinstance(f, lt_mod._LayerTypesPatchFinder))
+
+        fake_pkg = types.ModuleType("transformers")
+        fake_pkg.__path__ = []
+        sys.modules["transformers"] = fake_pkg
+
+        fake_cu = types.ModuleType("transformers.configuration_utils")
+        fake_cu.ALLOWED_LAYER_TYPES = ("sliding_attention",)
+
+        class _StubLoader:
+            def exec_module(self, module):
+                # Populate the module the way the real loader would.
+                module.ALLOWED_LAYER_TYPES = fake_cu.ALLOWED_LAYER_TYPES
+
+        class _StubSpec:
+            def __init__(self):
+                self.loader = _StubLoader()
+
+        class _StubFinder:
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname == lt_mod._TARGET_MODULE:
+                    return _StubSpec()
+                return None
+
+        # Place the stub finder *after* ours so our finder delegates to it.
+        sys.meta_path.append(_StubFinder())
+
+        spec = finder.find_spec(lt_mod._TARGET_MODULE)
+        assert spec is not None and spec.loader is not None
+
+        # Driving the wrapped exec_module should apply the patch.
+        sys.modules[lt_mod._TARGET_MODULE] = fake_cu
+        spec.loader.exec_module(fake_cu)
+
+        assert lt_mod._PATCHED is True
+        for extra in lt_mod.DEFAULT_EXTRA_LAYER_TYPES:
+            assert extra in fake_cu.ALLOWED_LAYER_TYPES


### PR DESCRIPTION
# What does this PR do ?


Fixes:
- defer_fsdp_grad_sync
  - `examples/llm_finetune/devstral/devstral2_small_2512_squad.yaml`
  - `examples/llm_finetune/llama3_1/llama3_1_8b_hellaswag_fp8.yaml`
- layer type patch for nemotron flash
  - `examples/llm_finetune/nemotron_flash/nemotron_flash_1b_squad.yaml`


The layer type patch works around the following issue

```
Traceback (most recent call last):
  File "/opt/Automodel/nemo_automodel/components/config/loader.py", line 476, in instantiate
    return func(*args, **config_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/transformers/models/auto/configuration_auto.py", line 1504, in from_pretrained
    return config_class.from_pretrained(pretrained_model_name_or_path, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/transformers/configuration_utils.py", line 647, in from_pretrained
    return cls.from_dict(config_dict, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/transformers/configuration_utils.py", line 824, in from_dict
    config = cls(**config_dict)
             ^^^^^^^^^^^^^^^^^^
  File "/lustre/fsw/coreai_dlalgo_ci/automodel_ci/hf_cache/modules/transformers_modules/nvidia/Nemotron_hyphen_Flash_hyphen_1B/da87f707f678b5936e67fdcfe598f76ebcc5fdbc/configuration_nemotron_flash.py", line 125, in __init__
    super().__init__(
  File "/opt/venv/lib/python3.12/site-packages/huggingface_hub/dataclasses.py", line 276, in init_with_validate
    cls.validate(self)  # type: ignore [attr-defined]
    ^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/huggingface_hub/dataclasses.py", line 253, in validate
    raise StrictDataclassClassValidationError(validator=validator.__name__, cause=e) from e
huggingface_hub.errors.StrictDataclassClassValidationError: Class validation error for validator 'validate_layer_type':
    ValueError: The `layer_types` entries must be in ('full_attention', 'sliding_attention', 'chunked_attention', 'linear_attention', 'conv', 'mamba', 'attention', 'sparse', 'dense', 'hybrid', 'moe') but got ['deltanet', 'f', 'm2', 'f', 'a', 'f', 'm2', 'f', 'deltanet', 'f', 'm2', 'f', 'a', 'f', 'm2', 'f', 'deltanet', 'f', 'm2', 'f', 'deltanet', 'f', 'm2', 'f']
```

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
