### PR TITLE
fix: chat dataset

### DIFF
--- a/nemo_automodel/components/datasets/llm/chat_dataset.py
+++ b/nemo_automodel/components/datasets/llm/chat_dataset.py
@@ -208,12 +208,16 @@ def _normalize_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                 raise ValueError(f"assistant message `tool_calls[{idx}]` must be a dict")
 
             tool_call_id = tool_call.get("id")
-            if not isinstance(tool_call_id, str) or not tool_call_id:
-                raise ValueError(f"assistant message `tool_calls[{idx}].id` must be a non-empty string")
+            if tool_call_id is None or tool_call_id == "":
+                tool_call_id = f"call_{idx}"
+            elif not isinstance(tool_call_id, str):
+                raise ValueError(f"assistant message `tool_calls[{idx}].id` must be a string when provided")
 
             tool_call_type = tool_call.get("type")
-            if not isinstance(tool_call_type, str) or not tool_call_type:
-                raise ValueError(f"assistant message `tool_calls[{idx}].type` must be a non-empty string")
+            if tool_call_type is None or tool_call_type == "":
+                tool_call_type = "function"
+            elif not isinstance(tool_call_type, str):
+                raise ValueError(f"assistant message `tool_calls[{idx}].type` must be a string when provided")
 
             function = tool_call.get("function")
             if not isinstance(function, dict):
@@ -232,6 +236,8 @@ def _normalize_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                 normalized_function["arguments"] = json.dumps(function_arguments)
 
             normalized_tool_call = dict(tool_call)
+            normalized_tool_call["id"] = tool_call_id
+            normalized_tool_call["type"] = tool_call_type
             normalized_tool_call["function"] = normalized_function
             normalized_tool_calls.append(normalized_tool_call)
 

--- a/tests/unit_tests/datasets/llm/test_chat_dataset.py
+++ b/tests/unit_tests/datasets/llm/test_chat_dataset.py
@@ -74,6 +74,26 @@ def test_normalize_messages_supports_reasoning_and_tool_call_fields():
     assert none_reasoning[0]["reasoning_content"] == ""
 
 
+def test_normalize_tool_calls_autofills_missing_id_and_type():
+    msgs = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"function": {"name": "fn_a", "arguments": {"x": 1}}},
+                {"id": "", "type": "", "function": {"name": "fn_b", "arguments": "{}"}},
+            ],
+        }
+    ]
+    norm = tcd._normalize_messages(msgs)
+    calls = norm[0]["tool_calls"]
+    assert calls[0]["id"] == "call_0"
+    assert calls[0]["type"] == "function"
+    assert calls[0]["function"]["arguments"] == '{"x": 1}'
+    assert calls[1]["id"] == "call_1"
+    assert calls[1]["type"] == "function"
+
+
 @pytest.mark.parametrize(
     ("message", "error_pattern"),
     [
@@ -90,7 +110,7 @@ def test_normalize_messages_supports_reasoning_and_tool_call_fields():
                 {
                     "role": "assistant",
                     "content": "",
-                    "tool_calls": [{"type": "function", "function": {"name": "fn", "arguments": "{}"}}],
+                    "tool_calls": [{"id": 123, "type": "function", "function": {"name": "fn", "arguments": "{}"}}],
                 }
             ],
             "tool_calls\\[0\\]\\.id",
@@ -100,7 +120,7 @@ def test_normalize_messages_supports_reasoning_and_tool_call_fields():
                 {
                     "role": "assistant",
                     "content": "",
-                    "tool_calls": [{"id": "call_1", "function": {"name": "fn", "arguments": "{}"}}],
+                    "tool_calls": [{"id": "call_1", "type": 1, "function": {"name": "fn", "arguments": "{}"}}],
                 }
             ],
             "tool_calls\\[0\\]\\.type",
@@ -140,19 +160,23 @@ def test_load_openai_messages_local_and_errors(tmp_path, monkeypatch):
     # Create local files: JSONL and JSON
     jsonl = tmp_path / "data.jsonl"
     jsonl.write_text(
-        "\n".join([
-            json.dumps({"messages": [{"role": "user", "content": "u1"}]}),
-            json.dumps({"messages": [{"role": "assistant", "content": "a1"}]}),
-        ]),
+        "\n".join(
+            [
+                json.dumps({"messages": [{"role": "user", "content": "u1"}]}),
+                json.dumps({"messages": [{"role": "assistant", "content": "a1"}]}),
+            ]
+        ),
         encoding="utf-8",
     )
 
     json_file = tmp_path / "data.json"
     json_file.write_text(
-        json.dumps([
-            {"messages": [{"role": "user", "content": "u2"}]},
-            {"messages": [{"role": "assistant", "content": "a2"}]},
-        ]),
+        json.dumps(
+            [
+                {"messages": [{"role": "user", "content": "u2"}]},
+                {"messages": [{"role": "assistant", "content": "a2"}]},
+            ]
+        ),
         encoding="utf-8",
     )
 
@@ -260,12 +284,14 @@ def test_tool_calling_chat_dataset_happy_path_and_edge_cases(monkeypatch):
     calls = []
 
     def fake_format(tokenizer, normalized, eos_id, pad_id, **kwargs):
-        calls.append({
-            "normalized": normalized,
-            "eos": eos_id,
-            "pad": pad_id,
-            "kwargs": kwargs,
-        })
+        calls.append(
+            {
+                "normalized": normalized,
+                "eos": eos_id,
+                "pad": pad_id,
+                "kwargs": kwargs,
+            }
+        )
         return {"input_ids": [1, 2], "labels": [0, 1], "attention_mask": [1, 1]}
 
     monkeypatch.setattr(tcd, "format_chat_template", fake_format)
@@ -323,6 +349,7 @@ def test_tool_calling_chat_dataset_happy_path_and_edge_cases(monkeypatch):
 
 def test_chat_dataset_skip_invalid_samples_does_not_filter_structured_bad_rows(monkeypatch):
     """skip_invalid_samples only affects JSONL parse errors, not invalid message rows after load."""
+
     class Tok:
         eos_token_id = 1
         chat_template = "{{ default }}"
@@ -330,7 +357,9 @@ def test_chat_dataset_skip_invalid_samples_does_not_filter_structured_bad_rows(m
     tok = Tok()
     monkeypatch.setattr(tcd, "_has_chat_template", lambda _tok: True)
     monkeypatch.setattr(tcd, "_add_pad_token", lambda _tok: 3)
-    monkeypatch.setattr(tcd, "format_chat_template", lambda *a, **k: {"input_ids": [1], "labels": [1], "attention_mask": [1]})
+    monkeypatch.setattr(
+        tcd, "format_chat_template", lambda *a, **k: {"input_ids": [1], "labels": [1], "attention_mask": [1]}
+    )
 
     dataset_rows = [
         {"messages": [{"role": "user", "content": "ok"}]},


### PR DESCRIPTION
# What does this PR do ?

  Changes

  nemo_automodel/components/datasets/llm/chat_dataset.py (_normalize_tool_calls):
  - Missing/empty id → auto-filled with f"call_{idx}".
  - Missing/empty type → auto-filled with "function".
  - Wrong-type values (e.g. id: 123) still raise — catches real data bugs.
  - Normalized id/type are written back into the returned dict so downstream chat templates see them populated.

  tests/unit_tests/datasets/llm/test_chat_dataset.py:
  - The two parametrize cases that previously required missing id/type to raise now pass a wrong-type value instead (still expects raise).
  - Added test_normalize_tool_calls_autofills_missing_id_and_type covering both missing-key and empty-string forms.

  Both OpenAI-style data (with id) and customizer-style data (without) now flow through the same validator.

- With id (OpenAI-style)
```
  {"messages":[{"role":"user","content":"Weather in Seattle?"},{"role":"assistant","content":"","tool_calls":[{"id":"call_abc","type":"function","function":{"name":"get_weather","arguments":{"city":"Seattle"}}}]
  },{"role":"tool","tool_call_id":"call_abc","content":"72F sunny"},{"role":"assistant","content":"It's 72F and sunny."}]}
```
- Without id (customizer-style)
```
  {"messages":[{"role":"user","content":"Weather in Seattle?"},{"role":"assistant","content":"","tool_calls":[{"type":"function","function":{"name":"get_weather","arguments":{"city":"Seattle"}}}]}]}
```
  Differences:
  - No id on the tool_call (auto-filled to "call_0" by the normalizer).
  - No follow-up tool role message / final assistant reply — customizer data trains the model to emit the call, not to consume its response.


# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
