### PR TITLE
fix: break FA2 retry loop for packed sequences on FA2-unsupported models

### DIFF
--- a/nemo_automodel/_transformers/auto_model.py
+++ b/nemo_automodel/_transformers/auto_model.py
@@ -321,6 +321,11 @@ class _BaseNeMoAutoModelClass(_BaseAutoModelClass):
                 has_packed_sequence,
                 attn_implementation,
                 use_liger_kernel,
+                model_name_or_path=(
+                    pretrained_model_name_or_path_or_config
+                    if isinstance(pretrained_model_name_or_path_or_config, str)
+                    else None
+                ),
             )
         device = torch.cuda.current_device()
 

--- a/nemo_automodel/_transformers/kernel_patches.py
+++ b/nemo_automodel/_transformers/kernel_patches.py
@@ -209,7 +209,15 @@ def _get_next_fallback_attn(attn_implementation: str) -> str:
         return priorities[0]
 
 
-def _apply_preload_overrides(tp_size, cp_size, has_packed_sequence, attn_implementation, use_liger_kernel):
+def _apply_preload_overrides(
+    tp_size,
+    cp_size,
+    has_packed_sequence,
+    attn_implementation,
+    use_liger_kernel,
+    *,
+    model_name_or_path=None,
+):
     """
     Compute final attention implementation and liger-kernel flag based on TP/CP and packed sequence constraints.
     """
@@ -224,6 +232,18 @@ def _apply_preload_overrides(tp_size, cp_size, has_packed_sequence, attn_impleme
     if has_packed_sequence:
         if cp_size == 1:
             assert HAS_FA, "Flash Attention is not available"
+            # If we reach here on a retry (the fallback cascade already picked a non-FA
+            # backend because the model's FA2 init raised), forcing FA2 again would re-enter
+            # the same failure and exhaust retries. Fail fast with an actionable message.
+            if attn_implementation not in (None, "flash_attention_2", "flash_attention_3"):
+                model_str = f" ({model_name_or_path!r})" if model_name_or_path else ""
+                raise ValueError(
+                    f"Packed sequences require Flash Attention, but the model{model_str} "
+                    f"does not support Flash Attention 2 or 3 "
+                    f"(fallback picked attn_implementation={attn_implementation!r}). "
+                    f"Disable packed sequences (set packed_sequence.packed_sequence_size=0 "
+                    f"or remove the packed_sequence block) or use a model with FA2/FA3 support."
+                )
             attn_implementation = "flash_attention_2"
             logger.warning(
                 "Packed sequence is supported only with Flash Attention. "

--- a/tests/unit_tests/_transformers/test_kernel_patches.py
+++ b/tests/unit_tests/_transformers/test_kernel_patches.py
@@ -1,0 +1,134 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for kernel_patches helpers."""
+
+import pytest
+
+from nemo_automodel._transformers.kernel_patches import _apply_preload_overrides
+
+
+class TestApplyPreloadOverridesPackedSequenceGuard:
+    """Guard prevents the FA2-retry loop for models that don't support FA2."""
+
+    def test_forces_fa2_on_first_call(self):
+        attn, use_liger = _apply_preload_overrides(
+            tp_size=1,
+            cp_size=1,
+            has_packed_sequence=True,
+            attn_implementation="flash_attention_2",
+            use_liger_kernel=True,
+        )
+        assert attn == "flash_attention_2"
+        assert use_liger is True
+
+    def test_forces_fa2_when_attn_is_none(self):
+        attn, _ = _apply_preload_overrides(
+            tp_size=1,
+            cp_size=1,
+            has_packed_sequence=True,
+            attn_implementation=None,
+            use_liger_kernel=False,
+        )
+        assert attn == "flash_attention_2"
+
+    def test_raises_on_retry_with_sdpa(self):
+        # Simulates the fallback path: FA2 failed, retry entered with attn=sdpa.
+        # Without the guard, the override would force FA2 again and loop.
+        with pytest.raises(ValueError, match="Packed sequences require Flash Attention"):
+            _apply_preload_overrides(
+                tp_size=1,
+                cp_size=1,
+                has_packed_sequence=True,
+                attn_implementation="sdpa",
+                use_liger_kernel=False,
+            )
+
+    def test_raises_on_retry_with_eager(self):
+        with pytest.raises(ValueError, match="Packed sequences require Flash Attention"):
+            _apply_preload_overrides(
+                tp_size=1,
+                cp_size=1,
+                has_packed_sequence=True,
+                attn_implementation="eager",
+                use_liger_kernel=False,
+            )
+
+    def test_error_message_includes_model_name(self):
+        with pytest.raises(ValueError, match=r"nvidia/NemotronH"):
+            _apply_preload_overrides(
+                tp_size=1,
+                cp_size=1,
+                has_packed_sequence=True,
+                attn_implementation="sdpa",
+                use_liger_kernel=False,
+                model_name_or_path="nvidia/NemotronH",
+            )
+
+    def test_fa3_still_allowed(self):
+        attn, _ = _apply_preload_overrides(
+            tp_size=1,
+            cp_size=1,
+            has_packed_sequence=True,
+            attn_implementation="flash_attention_3",
+            use_liger_kernel=False,
+        )
+        # FA3 passes the guard; override still normalizes to FA2.
+        assert attn == "flash_attention_2"
+
+
+class TestApplyPreloadOverridesUnchangedPaths:
+    """Non-packed-sequence and CP paths are unaffected by the new guard."""
+
+    def test_no_packed_sequence_passthrough(self):
+        attn, use_liger = _apply_preload_overrides(
+            tp_size=1,
+            cp_size=1,
+            has_packed_sequence=False,
+            attn_implementation="sdpa",
+            use_liger_kernel=True,
+        )
+        assert attn == "sdpa"
+        assert use_liger is True
+
+    def test_cp_forces_sdpa_and_disables_liger(self):
+        attn, use_liger = _apply_preload_overrides(
+            tp_size=1,
+            cp_size=2,
+            has_packed_sequence=False,
+            attn_implementation="flash_attention_2",
+            use_liger_kernel=True,
+        )
+        assert attn == "sdpa"
+        assert use_liger is False
+
+    def test_tp_disables_liger(self):
+        _, use_liger = _apply_preload_overrides(
+            tp_size=2,
+            cp_size=1,
+            has_packed_sequence=False,
+            attn_implementation="sdpa",
+            use_liger_kernel=True,
+        )
+        assert use_liger is False
+
+    def test_packed_sequence_with_cp_errors(self):
+        with pytest.raises(ValueError, match="CP size 1"):
+            _apply_preload_overrides(
+                tp_size=1,
+                cp_size=2,
+                has_packed_sequence=True,
+                attn_implementation="flash_attention_2",
+                use_liger_kernel=False,
+            )


### PR DESCRIPTION
## Summary

- Fixes the 5-retry FA2 loop hit by `nemotron_nano_4b_squad` CI (e.g. [job 301287481](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/301287481)), where `NemotronHForCausalLM` + `packed_sequence_size=1024` produced 5 identical `does not support Flash Attention 2` failures before terminating.
- `_apply_preload_overrides` forces `attn_implementation="flash_attention_2"` when `has_packed_sequence=True` and `cp_size==1`. It runs at the start of every `_build_model` call, including retries, so the fallback cascade in the `except ValueError` handler (FA2 → SDPA → eager) never sticks — each retry resets to FA2 and hits the same error.
- New guard: if `has_packed_sequence=True` and `attn_implementation` has already fallen back off FA2/FA3 (i.e. we're on a retry whose previous iteration failed FA2), raise a clear `ValueError` naming the model and pointing at the two fixes (disable packed sequences, or use an FA2/FA3-supporting model) instead of re-forcing FA2.
- Scope check: only `examples/llm_finetune/nemotron/nemotron_nano_4b_squad.yaml` combines a NemotronH model with `packed_sequence_size > 0` in the repo, so no other CI configs change behavior.

## Test plan

- [x] New unit tests in `tests/unit_tests/_transformers/test_kernel_patches.py` covering the guard (10 cases: first-call forcing, None attn, retry-with-sdpa, retry-with-eager, error message contents, FA3 pass-through, no-packed passthrough, CP forces SDPA, TP disables Liger, packed+CP errors).
- [x] All 78 existing `tests/unit_tests/_transformers/test_auto_model.py` tests still pass.
- [x] Local 8×H100 repro of the failing CI job: pre-fix log showed 104 `NemotronH ... FA2` errors (retry loop across 8 ranks); post-fix shows 16 (one per rank, chained) and the new clear error surfaces as the final exception.
- [x] `ruff check`, `ruff format --check`, and `lint-imports --no-cache` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)