### PR TITLE
fix: disable packed sequences for nemotron_nano_4b_squad

### DIFF
--- a/examples/llm_finetune/nemotron/nemotron_nano_4b_squad.yaml
+++ b/examples/llm_finetune/nemotron/nemotron_nano_4b_squad.yaml
@@ -64,7 +64,7 @@ dataset:
   split: train
 
 packed_sequence:
-  packed_sequence_size: 1024
+  packed_sequence_size: 0
 
 dataloader:
   _target_: torchdata.stateful_dataloader.StatefulDataLoader


### PR DESCRIPTION
## Summary

- Unbreaks the `nemotron_nano_4b_squad` SFT CI job (e.g. [job 301287481](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/301287481)).
- `NemotronHForCausalLM` (`nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16`) does not support Flash Attention 2. When `packed_sequence_size > 0`, `_apply_preload_overrides` forces `attn_implementation="flash_attention_2"`, which transformers rejects for this model; the `_build_model` retry loop cannot escape because the override re-applies on every retry. After 5 retries the job terminates with `ValueError: NemotronHForCausalLM does not support Flash Attention 2`.
- Setting `packed_sequence_size: 0` trains the model with unpacked batches, side-stepping the FA2 requirement until upstream FA2 support for NemotronH lands.
- No other configs in the repo combine NemotronH with packed sequences, so this change is scoped to the one failing test.

## Test plan

- [x] 8×H100 local SFT run on the updated yaml: 10 steps completed, loss descends 6.75 → 2.25, validation runs (val_loss=2.7962), exit 0.
- [ ] CI `release` pipeline on `nemotron_nano_4b_squad` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)