### PR TITLE
fix: widen qwen3_moe_30b_hellaswag ckpt-robustness KL threshold to 3e-2

### DIFF
--- a/examples/llm_finetune/qwen/qwen3_moe_30b_hellaswag.yaml
+++ b/examples/llm_finetune/qwen/qwen3_moe_30b_hellaswag.yaml
@@ -94,7 +94,7 @@ ci:
   recipe_owner: hemildesai
   time: "00:15:00"
   checkpoint_robustness:
-    hf_kl_threshold: 1e-2
+    hf_kl_threshold: 3e-2
     tokenizer_name: Qwen/Qwen3-30B-A3B
     no_check_resume: true
     dataset.num_samples_limit: 500


### PR DESCRIPTION
## Summary
- Bumps `ci.checkpoint_robustness.hf_kl_threshold` in `examples/llm_finetune/qwen/qwen3_moe_30b_hellaswag.yaml` from `1e-2` to `3e-2` to keep the sft_ckpt_robustness job green under transformers v5.5.
- CI job 301287530 (pipeline 48953745, pre-#1916 commit 45537f96) failed Phase 4 with `max per-token KL = 9.151315e-03 > threshold 1.000000e-03`. #1916 already nudged the YAML to `1e-2` but that leaves only ~9% headroom; this further bump (~3x observed CI, ~5x cw-dfw) aligns with the sibling-MoE pattern from #1867 (gpt_oss_20b 1e-1) and the v5.5-drift bumps in #1932 / #1937 / #1938 / #1939 / #1940.
- Root cause is the transformers v5.5 forward-pass drift (Phase 3 `automodel-from-consolidated` remains bit-exact at `max KL = 0`), not a save/reload bug. `no_check_resume: true` keeps Phase 6 disabled as before. No code changes.

## Test plan
- [x] Reproduced failure signature from CI trace (`[Phase 4] HF-loaded max KL: 9.151315e-03` against `hf_kl_threshold: 1e-3`).
- [x] Verified fix on cw-dfw 8xH100 with the exact CI launcher overrides (`--step_scheduler.max_steps 5 --step_scheduler.ckpt_every_steps 5 --step_scheduler.val_every_steps 5 --step_scheduler.global_batch_size 32 --step_scheduler.local_batch_size 2 --checkpoint.checkpoint_dir /tmp/qwen3_moe_ckpts`), `transformers==5.5.4`, `HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1`: `[Phase 3] max KL = 0.000000e+00`, `[Phase 4] max KL = 5.796895e-03 (threshold: 3.000000e-02)`, `1 passed, 50 warnings in 263.77s (0:04:23)`.
- [ ] Next nightly sft_ckpt_robustness `qwen3_moe_30b_hellaswag` job passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)