### PR TITLE
fix: nemotron_super_v3_hellaswag checkpoint robustness batch size

### DIFF
--- a/examples/llm_finetune/nemotron/nemotron_super_v3_hellaswag.yaml
+++ b/examples/llm_finetune/nemotron/nemotron_super_v3_hellaswag.yaml
@@ -111,5 +111,6 @@ ci:
     tokenizer_name: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
     hf_device_map_auto: true
     no_check_resume: true
+    step_scheduler.global_batch_size: 64
     dataset.num_samples_limit: 500
     validation_dataset.num_samples_limit: 500


### PR DESCRIPTION
## Summary

- Phase 1 of the checkpoint-robustness test crashes in `StepScheduler.__init__` with `AssertionError: global_batch_size (32) must be divisible by local_batch_size * dp_size (2 * 32)`.
- The CI robustness launcher (`tests/ci_tests/scripts/finetune_launcher.sh`) hardcodes `--step_scheduler.local_batch_size 2` and `--step_scheduler.global_batch_size 32`, but this config runs on 4 nodes x 8 GPUs (`dp_size=32` with `fsdp2`, `tp=1`, `cp=1`, `ep=32`), so 32 is not divisible by `2 * 32 = 64`.
- YAML-only fix: add `step_scheduler.global_batch_size: 64` under `ci.checkpoint_robustness`. The test harness (`_extract_custom_args` in `test_checkpoint_robustness_llm.py`) extends dotted YAML entries to the tail of the argv, so the YAML value overrides the launcher's CLI value. `64 % (2 * 32) == 0`, grad-accum = 1.

Fixes CI job 301287545 in pipeline 48953745.

## Test plan

- [x] Locally simulated `_extract_custom_args` + arg parser: confirmed `--step_scheduler.global_batch_size 64` is appended after the launcher's `32` and becomes the final value.
- [x] cw-dfw multi-node repro was attempted but blocked by the local sqsh container lacking `transformers.models.gemma4` (pre-dates PR #1925); CI container has it. The fix is a single YAML bump with verified override order.
- [ ] CI re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)