### PR TITLE
fix: Patch wandb-core Go CVEs: bump otel SDK, add go-jose

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -164,7 +164,7 @@ RUN I_CONFIRM_THIS_IS_NOT_A_LICENSE_VIOLATION=1 \
 ARG TARGETARCH
 RUN if python3 -c "import wandb" 2>/dev/null; then \
         GRPC_VERSION=1.79.3 && \
-        OTEL_VERSION=1.35.0 && \
+        OTEL_VERSION=1.43.0 && \
         GO_VERSION=1.26.1 && \
         WANDB_VERSION=$(python3 -c "import wandb; print(wandb.__version__)") && \
         WANDB_CORE_BIN=/opt/venv/lib/python3.12/site-packages/wandb/bin/wandb-core && \
@@ -175,6 +175,7 @@ RUN if python3 -c "import wandb" 2>/dev/null; then \
         cd /tmp/wandb-src/core && \
         go get google.golang.org/grpc@v${GRPC_VERSION} && \
         go get go.opentelemetry.io/otel/sdk@v${OTEL_VERSION} && \
+        go get github.com/go-jose/go-jose/v4@v4.1.4 && \
         go mod tidy && \
         go mod vendor && \
         CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w" \


### PR DESCRIPTION
# What does this PR do ?

  - Bump otel SDK to 1.43.0 and add go-jose v4.1.4 to wandb-core CVE patching block
  - Fixes 3 High-severity container scan findings (all in wandb-core Go binary)

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
