### PR TITLE
docs: Add container version to docs version picker

### DIFF
--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -4,15 +4,17 @@
         "url": "https://docs.nvidia.com/nemo/automodel/nightly/"
     },
     {
-        "name": "0.3.0 (latest)",
+        "name": "0.3.0 (latest) · 26.02",
         "version": "0.3.0",
         "url": "https://docs.nvidia.com/nemo/automodel/latest/"
     },
     {
+        "name": "0.2.0 · 25.11",
         "version": "0.2.0",
         "url": "https://docs.nvidia.com/nemo/automodel/0.2.0/"
     },
     {
+        "name": "0.1.0",
         "version": "0.1.0",
         "url": "https://docs.nvidia.com/nemo/automodel/0.1.0/"
     }


### PR DESCRIPTION
# What does this PR do ?

docs: Add container version to docs version picker

Following the example in MBridge, we want to add the container version associated with each Github release as well.  So we are adding it to the docs version picker.

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
