### PR TITLE
fix: ministral tp plan (#1963)

### DIFF
--- a/examples/llm_finetune/mistral/ministral3_3b_squad.yaml
+++ b/examples/llm_finetune/mistral/ministral3_3b_squad.yaml
@@ -113,6 +113,10 @@ ci:
     cross_tp_kl_threshold: 5e-3
     dataset.limit_dataset_samples: 500
     validation_dataset.limit_dataset_samples: 500
+    # vision_tower params receive no grads from text-only batches, so Adam
+    # never materialises per-param `step` state for them; DCP resume load is
+    # strict and fails with `Missing key ... optim.state.model.vision_tower.*`.
+    no_check_resume: true
 
 # Uncomment and configure for W&B logging
 # wandb:

--- a/examples/llm_finetune/mistral/ministral3_3b_squad_peft.yaml
+++ b/examples/llm_finetune/mistral/ministral3_3b_squad_peft.yaml
@@ -122,6 +122,10 @@ ci:
     tokenizer_name: mistralai/Ministral-3-3B-Instruct-2512
     dataset.limit_dataset_samples: 500
     validation_dataset.limit_dataset_samples: 500
+    # vision_tower params receive no grads from text-only batches, so Adam
+    # never materialises per-param `step` state for them; DCP resume load is
+    # strict and fails with `Missing key ... optim.state.model.vision_tower.*`.
+    no_check_resume: true
 
 # Uncomment and configure for W&B logging
 # wandb:

--- a/nemo_automodel/components/config/loader.py
+++ b/nemo_automodel/components/config/loader.py
@@ -345,13 +345,23 @@ class ConfigNode:
         self.raise_on_missing_attr = raise_on_missing_attr
 
     def __getattr__(self, key: str) -> Any:
+        # Dunder methods must raise AttributeError so that Python's
+        # copy/pickle/repr protocols (which call
+        # getattr(obj, "__setstate__", None), etc.) treat them as absent
+        # rather than as missing regular attributes — returning None here
+        # would break copy.deepcopy and isinstance checks.
+        if key.startswith("__") and key.endswith("__"):
+            raise AttributeError(key)
         try:
             return self.__dict__[key]
-        except:
-            if self.raise_on_missing_attr:
-                raise AttributeError
-            else:
-                return None
+        except KeyError:
+            # Read the flag safely: on a partially-constructed node
+            # (e.g. a deepcopy target that has not yet had __setstate__
+            # called) raise_on_missing_attr may itself be missing, which
+            # would recurse back into __getattr__.  Default to True.
+            if self.__dict__.get("raise_on_missing_attr", True):
+                raise AttributeError(key)
+            return None
 
     def _wrap(self, k: str, v: Any) -> Any:
         """Wrap a configuration value based on its type.

--- a/nemo_automodel/components/distributed/parallelizer.py
+++ b/nemo_automodel/components/distributed/parallelizer.py
@@ -1380,36 +1380,50 @@ def _get_parallel_plan(
             model_parallel_plan = get_hf_tp_shard_plan(model)
 
     else:
-        base_model_tp_plan = {
-            "model.embed_tokens": VocabParallelEmbedding(input_layouts=Replicate()),
-            "model.layers.*.self_attn.q_proj": ColwiseParallel(),
-            "model.layers.*.self_attn.k_proj": ColwiseParallel(),
-            "model.layers.*.self_attn.v_proj": ColwiseParallel(),
-            "model.layers.*.self_attn.qkv_proj": ColwiseParallel(),  # Combined QKV projection
-            "model.layers.*.self_attn.o_proj": RowwiseParallel(),
-            "model.layers.*.mlp.gate_up_proj": ColwiseParallel(),  # Fused gate and up projection
-            "model.layers.*.mlp.up_proj": ColwiseParallel(),
-            "model.layers.*.mlp.gate_proj": ColwiseParallel(),
-            "model.layers.*.mlp.down_proj": RowwiseParallel(),
-            "lm_head": ColwiseParallel(output_layouts=Replicate()),
-        }
-        if sequence_parallel:
-            base_model_sp_plan = {
-                "model.embed_tokens": VocabParallelEmbedding(
-                    input_layouts=Replicate(),
-                    output_layouts=Shard(1),
-                    use_local_output=False,
-                ),
-                "model.norm": SequenceParallel(),
-                "model.layers.*.input_layernorm": SequenceParallel(),
-                "model.layers.*.self_attn.o_proj": RowwiseParallel(output_layouts=Shard(1), use_local_output=False),
-                "model.layers.*.post_attention_layernorm": SequenceParallel(),
-                "model.layers.*.mlp.down_proj": RowwiseParallel(output_layouts=Shard(1), use_local_output=False),
-                "lm_head": ColwiseParallel(input_layouts=Shard(1), output_layouts=Replicate()),
+        # Try HF's per-model _tp_plan first — it correctly handles multimodal
+        # architectures like Mistral3ForConditionalGeneration whose text layers
+        # live under model.language_model.layers.* and would be missed by the
+        # hardcoded llama-style wildcards below.
+        hf_plan = None
+        try:
+            hf_plan = get_hf_tp_shard_plan(model)
+        except Exception as e:
+            logger.info(f"HF tp plan not available ({e}). Falling back to default base plan.")
+
+        if hf_plan:
+            model_parallel_plan = hf_plan
+            logger.info(f"Using HF-native tp plan for {model_cls.__name__}.")
+        else:
+            base_model_tp_plan = {
+                "model.embed_tokens": VocabParallelEmbedding(input_layouts=Replicate()),
+                "model.layers.*.self_attn.q_proj": ColwiseParallel(),
+                "model.layers.*.self_attn.k_proj": ColwiseParallel(),
+                "model.layers.*.self_attn.v_proj": ColwiseParallel(),
+                "model.layers.*.self_attn.qkv_proj": ColwiseParallel(),  # Combined QKV projection
+                "model.layers.*.self_attn.o_proj": RowwiseParallel(),
+                "model.layers.*.mlp.gate_up_proj": ColwiseParallel(),  # Fused gate and up projection
+                "model.layers.*.mlp.up_proj": ColwiseParallel(),
+                "model.layers.*.mlp.gate_proj": ColwiseParallel(),
+                "model.layers.*.mlp.down_proj": RowwiseParallel(),
+                "lm_head": ColwiseParallel(output_layouts=Replicate()),
             }
-            base_model_tp_plan.update(base_model_sp_plan)
-        model_parallel_plan = base_model_tp_plan
-        logger.info("Using default base TP plan. Compatible with huggingface llama3-style models.")
+            if sequence_parallel:
+                base_model_sp_plan = {
+                    "model.embed_tokens": VocabParallelEmbedding(
+                        input_layouts=Replicate(),
+                        output_layouts=Shard(1),
+                        use_local_output=False,
+                    ),
+                    "model.norm": SequenceParallel(),
+                    "model.layers.*.input_layernorm": SequenceParallel(),
+                    "model.layers.*.self_attn.o_proj": RowwiseParallel(output_layouts=Shard(1), use_local_output=False),
+                    "model.layers.*.post_attention_layernorm": SequenceParallel(),
+                    "model.layers.*.mlp.down_proj": RowwiseParallel(output_layouts=Shard(1), use_local_output=False),
+                    "lm_head": ColwiseParallel(input_layouts=Shard(1), output_layouts=Replicate()),
+                }
+                base_model_tp_plan.update(base_model_sp_plan)
+            model_parallel_plan = base_model_tp_plan
+            logger.info("Using default base TP plan. Compatible with huggingface llama3-style models.")
 
     return model_parallel_plan
 

--- a/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
+++ b/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
@@ -234,6 +234,36 @@ def _fix_meta_rotary_embeddings(model):
     return model
 
 
+def _tp_size_from_argv(argv) -> int:
+    """Peek at --distributed.tp_size / --config YAML without constructing the cfg.
+
+    Returns 1 if no TP setting is found. Used before cfg parsing to pick a
+    reasonable default kl_threshold.
+    """
+    for i, a in enumerate(argv):
+        if a == "--distributed.tp_size" and i + 1 < len(argv):
+            try:
+                return int(argv[i + 1])
+            except (TypeError, ValueError):
+                return 1
+    config_path = None
+    for i, a in enumerate(argv):
+        if a == "--config" and i + 1 < len(argv):
+            config_path = argv[i + 1]
+            break
+    if config_path:
+        try:
+            import yaml
+
+            with open(config_path) as f:
+                raw_cfg = yaml.safe_load(f) or {}
+            tp = (raw_cfg.get("distributed") or {}).get("tp_size", 1)
+            return int(tp) if tp is not None else 1
+        except Exception:
+            pass
+    return 1
+
+
 def _rank0() -> bool:
     return not dist.is_initialized() or dist.get_rank() == 0
 
@@ -247,7 +277,15 @@ def test_checkpoint_robustness():
     """Train -> checkpoint -> reload automodel from consolidated -> reload vanilla HF, compare logits."""
     custom_args, config_argv = _extract_custom_args(sys.argv[1:])
     sys.argv = [sys.argv[0]] + config_argv
-    kl_threshold = float(custom_args.get("kl_threshold", "0"))
+    # When tensor parallelism is active the forward pass uses row-parallel
+    # all-reduces and cuBLASLt plan caches whose order of accumulation is
+    # process-dependent; this produces ULP-level bf16 drift between the
+    # trainer's and restored model's logits even with bit-identical weights.
+    # Use a small tolerance when TP>1; keep strict 0 otherwise so real
+    # save/load regressions in non-TP setups still fail.
+    _tp_size = _tp_size_from_argv(config_argv)
+    _default_kl_threshold = "1e-5" if _tp_size > 1 else "0"
+    kl_threshold = float(custom_args.get("kl_threshold", _default_kl_threshold))
     hf_kl_threshold = float(custom_args.get("hf_kl_threshold", "5e-3"))
     cross_tp_size = int(custom_args.get("cross_tp_size", "0"))
     cross_tp_kl_threshold = float(custom_args.get("cross_tp_kl_threshold", "5e-3"))
@@ -294,6 +332,21 @@ def test_checkpoint_robustness():
 
     is_peft = hasattr(cfg, "peft")
     original_pretrained_path = cfg.model.pretrained_model_name_or_path
+    # Some FP8-quantized checkpoints (e.g. ministral3) require dequantize=True
+    # at load time to avoid a Triton-only FP8 matmul kernel dispatch in the
+    # vanilla HF forward pass (Phase 4).  Materialise the yaml quantization
+    # sub-tree into an HF config object here so Phase 4 can forward it
+    # to `from_pretrained` — passing the raw ConfigNode directly would
+    # trip transformers' internal deepcopy (triggers ConfigNode.__getattr__
+    # on `__setstate__`, which then fails recursively).
+    _raw_qc = getattr(cfg.model, "quantization_config", None)
+    if _raw_qc is not None and hasattr(_raw_qc, "instantiate"):
+        try:
+            original_quantization_config = _raw_qc.instantiate()
+        except Exception:
+            original_quantization_config = None
+    else:
+        original_quantization_config = _raw_qc
 
     del trainer
     gc.collect()
@@ -360,6 +413,8 @@ def test_checkpoint_robustness():
             hf_kwargs["trust_remote_code"] = False
         if hf_device_map_auto:
             hf_kwargs["device_map"] = "auto"
+        if original_quantization_config is not None:
+            hf_kwargs["quantization_config"] = original_quantization_config
 
         if is_peft:
             from peft import PeftModel

--- a/tests/unit_tests/distributed/test_get_parallel_plan.py
+++ b/tests/unit_tests/distributed/test_get_parallel_plan.py
@@ -151,18 +151,15 @@ def test_optimised_plan_fallback_to_hf(monkeypatch):
     assert result is sentinel
 
 
-# 4. HF fallback when no optimised plan exists
+# 4. HF plan is used when no optimised plan exists
 def test_hf_fallback(monkeypatch):
-    # When no optimised plan exists and HF is not explicitly requested, the helper
-    # should return the default base plan.
-    monkeypatch.setattr(parallelizer, "get_hf_tp_shard_plan", lambda m: {"hf": "plan2"}, raising=True)
+    # When no optimised plan exists, the helper should prefer the HF-provided plan.
+    hf_plan = {"model.embed_tokens": "embed", "lm_head": "head"}
+    monkeypatch.setattr(parallelizer, "get_hf_tp_shard_plan", lambda m: hf_plan, raising=True)
     _set_global_model_cls(monkeypatch, _DummyModel)
 
     result = _get_parallel_plan(_DummyModel(), sequence_parallel=False)
-    assert isinstance(result, dict)
-    # base plan should include embed_tokens and lm_head entries
-    assert "model.embed_tokens" in result
-    assert "lm_head" in result
+    assert result is hf_plan
 
 
 def test_hf_fallback_sequence_parallel_assert(monkeypatch):


### PR DESCRIPTION
manual cherry-pick because of conflict in https://github.com/NVIDIA-NeMo/Automodel/actions/runs/24757057907/job/72432395945

* test(ckpt-robustness): default kl_threshold to 1e-5 when TP is active

When tensor parallelism is enabled the forward pass uses row-parallel all-reduces and cuBLASLt plan caches whose accumulation order is process-dependent; this produces ULP-level bf16 drift between the trainer's and restored model's logits even with bit-identical weights.

Default kl_threshold to 1e-5 when tp_size > 1 (peeked from argv/YAML before cfg is parsed) and keep it strictly 0 otherwise so non-TP regressions still fail. Users can still override via --kl_threshold.



* fix(parallelizer): fall back to HF tp plan before hardcoded llama-style default

The hardcoded default plan in _get_parallel_plan matches `model.layers.*` paths only, which silently fails to TP-parallelize any multimodal model whose text layers live under `model.language_model.layers.*` (e.g. Mistral3ForConditionalGeneration / ministral3). In those cases TP is configured but never applied: LoRA and base weights are initialised per-rank with unsynchronised RNG, drift across ranks during training, and the checkpoint-robustness test then fails on reload because reference_logits uses per-rank-divergent weights while restored_logits uses rank-0's broadcast version.

Try get_hf_tp_shard_plan(model) first (it already handles VLMs, see parallelizer.py:889 for Mistral3ForConditionalGeneration) and only fall back to the llama-style default when that fails.



* fix(ckpt-robustness): forward quantization_config to Phase-4 HF load; skip Phase-6 resume on ministral3

Phase 4 (vanilla HF load) of the checkpoint-robustness test was failing for PEFT when the base model is FP8-quantized (ministral3): HF's fused FP8 forward path dispatches to w8a8_fp8_matmul, which is None when the Triton FP8 kernel module isn't available in the test container, yielding AttributeError: 'NoneType' object has no attribute 'w8a8_fp8_matmul'.

Capture cfg.model.quantization_config at Phase 2 and forward it into hf_kwargs at Phase 4, so vanilla HF also takes the FP8->bf16 dequant path that Phase 1/3 use.

Phase 6 (training resumption) was failing for ministral3 SFT with `Missing key in checkpoint state_dict: optim.state.model.vision_tower. patch_conv.weight.step`.  The vision_tower params never receive grads from a text-only batch, so Adam never materialises per-param `step` state for them; DCP writes the sparse optim state and the resume-side strict load rejects it.  Use the existing `no_check_resume: true` escape hatch for both ministral3 configs, consistent with other configs in the repo that exhibit sparse optim state.



* fix(ckpt-robustness): instantiate quantization_config ConfigNode before Phase-4 HF load

The previous commit forwarded cfg.model.quantization_config directly into hf_kwargs, but cfg.model.quantization_config is a ConfigNode (unresolved yaml sub-tree) until explicitly instantiated.  Passing it to HF's AutoModelForCausalLM.from_pretrained triggers transformers' internal deepcopy, which calls getattr(obj, '__setstate__', None); that lookup hits ConfigNode.__getattr__, which on a miss tries to read self.raise_on_missing_attr, which is also missing on the deepcopy's partially-constructed target object — producing a recursive KeyError that trashed Phase 5 (and the whole test) on rank 0.

Materialise the quantization_config into an HF config object via .instantiate() before forwarding; leave it alone for non-ConfigNode values.



* fix(config): make ConfigNode.__getattr__ safe against recursion on missing attrs

Two pre-existing footguns in ConfigNode.__getattr__:

1. The except handler read `self.raise_on_missing_attr`, which itself goes through __getattr__ whenever that attribute is missing (e.g. on a partially-constructed copy that has not yet had __setstate__ called, such as a deepcopy target).  The recursive lookup re-raised KeyError indefinitely, producing pages of "During handling of the above exception..." traces and obscuring the real caller.  Read the flag via self.__dict__.get() so the fallback path can never recurse.

2. Dunder methods were being returned as None (when raise_on_missing_attr was False) or treated as regular missing attrs.  Python's copy / pickle / repr protocols call `getattr(obj, "__setstate__", None)` and expect AttributeError on absence — a stub None breaks copy.deepcopy (it calls obj.__setstate__(state) and gets NoneType is not callable). Raise AttributeError for any dunder regardless of the flag.

Together these mean `copy.deepcopy(node)` and `hasattr(node, "__foo__")` now behave correctly.



---------

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
