### PR TITLE
fix(vlm): qwen3_5_4b_neat_packing OOM - reduce seqlen to 4096

### DIFF
--- a/examples/vlm_finetune/qwen3_5/qwen3_5_4b_neat_packing.yaml
+++ b/examples/vlm_finetune/qwen3_5/qwen3_5_4b_neat_packing.yaml
@@ -73,8 +73,8 @@ dataset:
 
 packed_sequence:
   pretokenize: true
-  max_length: 8192
-  pack_size: 8192
+  max_length: 4096
+  pack_size: 4096
   packing_ratio: 0.9
   drop_long_samples: true
 


### PR DESCRIPTION
## Summary
- `examples/vlm_finetune/qwen3_5/qwen3_5_4b_neat_packing.yaml` at `max_length=pack_size=8192` hits CUDA OOM on 8xH100 80GB during backward.
- Dropping both to `4096` keeps peak memory to ~42 GiB (vs ~65-76 GiB) with plenty of headroom.
- `local_batch_size` is already 1, so reducing pack/seqlen is the only lever.

## Repro of the OOM
CI job failure: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/302124823

```
[rank5]: torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 4.34 GiB.
         GPU 5 has a total capacity of 79.11 GiB of which 2.59 GiB is free.
         ... this process has 76.51 GiB memory in use.
```

Reproduced locally on the same hardware/container with the unchanged config — OOM hit at step 61 (rank 0) with similar memory fingerprint. Because packed-sequence composition varies per run, the exact failing step drifts, making the failure intermittent rather than deterministic.

## After the change
8-GPU torchrun, 100 steps + validation + checkpoint consolidation:
- 0 OOMs, 0 tracebacks, exit code 0
- **Peak memory 42.20 GiB** (well under the 80 GiB limit)
- Checkpoint saved and symlinked successfully

## Test plan
- [x] `torchrun --nproc-per-node=8 examples/vlm_finetune/finetune.py --config examples/vlm_finetune/qwen3_5/qwen3_5_4b_neat_packing.yaml` completes cleanly
- [ ] Re-run CI pipeline for `qwen3_5_4b_neat_packing`

🤖 Generated with [Claude Code](https://claude.com/claude-code)