### PR TITLE
fix(devstral): point 24B Squad recipes at official FP8 model

### DIFF
--- a/examples/llm_finetune/devstral/devstral2_small_2512_squad.yaml
+++ b/examples/llm_finetune/devstral/devstral2_small_2512_squad.yaml
@@ -37,7 +37,10 @@ rng:
 
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
-  pretrained_model_name_or_path: akoumpa/Devstral-Small-2-24B-Instruct-2512-BF16
+  pretrained_model_name_or_path: mistralai/Devstral-Small-2-24B-Instruct-2512
+  quantization_config:
+    _target_: transformers.FineGrainedFP8Config
+    dequantize: true
 
 checkpoint:
   enabled: true

--- a/examples/llm_finetune/devstral/devstral2_small_2512_squad_peft.yaml
+++ b/examples/llm_finetune/devstral/devstral2_small_2512_squad_peft.yaml
@@ -37,7 +37,10 @@ rng:
 
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
-  pretrained_model_name_or_path: akoumpa/Devstral-Small-2-24B-Instruct-2512-BF16
+  pretrained_model_name_or_path: mistralai/Devstral-Small-2-24B-Instruct-2512
+  quantization_config:
+    _target_: transformers.FineGrainedFP8Config
+    dequantize: true
 
 peft:
   _target_: nemo_automodel.components._peft.lora.PeftConfig


### PR DESCRIPTION
## Summary
The ci shows success but the training is corrupted, with ~11 loss and 0 gradnorm.
https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/302124999

- The two Devstral-Small-2-24B Squad recipes (`devstral2_small_2512_squad.yaml` and `devstral2_small_2512_squad_peft.yaml`) pointed at `akoumpa/Devstral-Small-2-24B-Instruct-2512-BF16`, a third-party BF16 conversion whose weights are scaled ~14× smaller than the upstream checkpoint.
- Swap both recipes to the official `mistralai/Devstral-Small-2-24B-Instruct-2512` FP8 checkpoint, loaded with `transformers.FineGrainedFP8Config(dequantize=true)` — the same pattern as `examples/llm_finetune/mistral/ministral3_3b_squad.yaml`.

## Why

Running either shipped recipe against the akoumpa BF16 conversion produces **`loss = log(131072) = 11.7835` exactly on every step, with `grad_norm = 0.0`** — the `lm_head` outputs uniform logits. Reproducible with no code changes, on both full-FT (`devstral2_small_2512_squad.yaml`, 8×H100) and PEFT (`devstral2_small_2512_squad_peft.yaml`, 8×H100). The model loads and inference works (the checkpoint passes `lm_head.weight.norm() = 92.6`), but training is a no-op because the weights are 14× too small: `lm_head @ hidden_states ≈ 0 → uniform softmax → log(vocab_size)`.

Param L2 norms:
- `akoumpa/Devstral-Small-2-24B-Instruct-2512-BF16`: **92.60** (broken)
- `mistralai/Devstral-Small-2-24B-Instruct-2512` (FP8 dequantized): **1289.56** (healthy)

Evidence log excerpt (default `devstral2_small_2512_squad.yaml` on akoumpa):
```
step 0 | loss 11.7835 | grad_norm 0.0000 | lr 7.75e-06 | num_label_tokens 400
step 1 | loss 11.7835 | grad_norm 0.0000 | lr 3.25e-06 | num_label_tokens 459
step 2 | loss 11.7835 | grad_norm 0.0000 | lr 1.00e-06 | num_label_tokens 355
[val]  loss 11.7835 | num_label_tokens 273
```

After the fix (official FP8, PEFT, 8×H100):
```
step 0 | loss 0.6766 | grad_norm 16.8750 | lr 9.14e-06 | num_label_tokens 316
step 1 | loss 0.5631 | grad_norm 17.3750 | lr 6.89e-06 | num_label_tokens 377
step 2 | loss 0.4935 | grad_norm 10.3750 | lr 4.11e-06 | num_label_tokens 276
step 3 | loss 0.3529 | grad_norm  9.8750 | lr 1.86e-06 | num_label_tokens 278
[val]  loss 0.2520 | num_label_tokens 203
```


🤖 Generated with [Claude Code](https://claude.com/claude-code)