### PR TITLE
fix(tests): recompute nemotron-nas rotary buffers in HF phase of checkpoint robustness

### DIFF
--- a/examples/llm_finetune/nemotron/llama3_3_nemotron_super_49B_squad_peft.yaml
+++ b/examples/llm_finetune/nemotron/llama3_3_nemotron_super_49B_squad_peft.yaml
@@ -29,7 +29,7 @@ step_scheduler:
 
 dist_env:
   backend: nccl
-  timeout_minutes: 1
+  timeout_minutes: 20
 
 rng:
   _target_: nemo_automodel.components.training.rng.StatefulRNG
@@ -113,6 +113,7 @@ ci:
   recipe_owner: HuiyingLi
   checkpoint_robustness:
     hf_kl_threshold: 5e-3
+    resume_loss_threshold: 5e-2
     trust_remote_code: true
     distributed.tp_size: 2
     tokenizer_name: nvidia/Llama-3_3-Nemotron-Super-49B-v1_5

--- a/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
+++ b/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
@@ -35,6 +35,10 @@ import torch.distributed as dist
 import torch.nn.functional as F
 from torch.distributed.tensor import DTensor
 
+from nemo_automodel.components.checkpoint.checkpointing import (
+    _MODELS_REQUIRING_BUFFER_REINIT,
+    _reinit_non_persistent_buffers,
+)
 from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
 from nemo_automodel.recipes.llm.train_ft import TrainFinetuneRecipeForNextTokenPrediction
 
@@ -214,6 +218,31 @@ def _get_logits(model, input_ids, device, trainer=None) -> torch.Tensor:
         return logits.float().cpu()
 
 
+def _reinit_rotary_per_module(model, default_device):
+    """Recompute DeciLM / Gemma3 style non-persistent rotary buffers on each
+    module's own device.
+
+    HF `from_pretrained` in transformers 5.x leaves ``inv_freq`` uninitialized
+    for models whose rotary buffers are computed in ``__init__`` and never
+    saved to the state dict (e.g. nemotron-nas, gemma3). With
+    ``device_map='auto'`` each rotary module can live on a different GPU, so
+    we drive the recompute per-module using its own inv_freq device rather
+    than a single fixed device.
+    """
+    model_type = getattr(model.config, "model_type", None)
+    if model_type not in _MODELS_REQUIRING_BUFFER_REINIT:
+        return model
+    for mod in model.modules():
+        inv = getattr(mod, "inv_freq", None)
+        if inv is None:
+            continue
+        mod_device = inv.device
+        if mod_device.type == "meta":
+            mod_device = next((p.device for p in mod.parameters()), default_device)
+        _reinit_non_persistent_buffers(mod, mod_device, model_type=model_type)
+    return model
+
+
 def _fix_meta_rotary_embeddings(model):
     """Re-materialize RotaryEmbedding tensors stuck on meta device.
 
@@ -370,6 +399,7 @@ def test_checkpoint_robustness():
                 base_model = _fix_meta_rotary_embeddings(
                     AutoModelForCausalLM.from_pretrained(original_pretrained_path, **hf_kwargs)
                 ).to(device)
+            _reinit_rotary_per_module(base_model, device)
             peft_model = PeftModel.from_pretrained(base_model, str(ckpt_step_dir / "model"))
             hf_logits = _get_logits(peft_model, input_ids, device)
 
@@ -396,6 +426,7 @@ def test_checkpoint_robustness():
                 hf_model = _fix_meta_rotary_embeddings(
                     AutoModelForCausalLM.from_pretrained(str(consolidated_dir), **hf_kwargs)
                 ).to(device)
+            _reinit_rotary_per_module(hf_model, device)
             hf_logits = _get_logits(hf_model, input_ids, device)
             del hf_model
 


### PR DESCRIPTION
## Summary
- Phase 4 of `test_checkpoint_robustness_llm.py` reloads the trained model via plain `transformers.AutoModelForCausalLM` and compares logits against the training reference. For `model_type="nemotron-nas"` (and `"gemma3"`), rotary `inv_freq` is a non-persistent buffer computed in `__init__` and not written to the checkpoint — transformers 5.x default meta-device init never runs the computation on a real device, so the buffer contains uninitialized GPU memory. Attention rotates Q/K by garbage frequencies, diverging the HF reload from the training reference.
- `nemo-automodel`'s own loader already handles this via `_reinit_non_persistent_buffers` (allow-listed for `"nemotron-nas"` and `"gemma3"`) inside `apply_model_infrastructure`. The robustness test's HF path did not call it, so Phase 4 was measuring a broken HF model.
- This patch calls the same reinit helper after every HF `from_pretrained` site in Phase 4 (PEFT + SFT, both `hf_device_map_auto` branches) via `_reinit_rotary_per_module`, which resolves each module's own device so it works correctly under `device_map="auto"`.
- Also carries over the `timeout_minutes: 20` bump and `resume_loss_threshold: 5e-2` from the now-closed #1951; the `hf_kl_threshold` bump in that PR is no longer needed and stays at the standard `5e-3`.

## Verification
Full robustness run on `nvidia/Llama-3_3-Nemotron-Super-49B-v1_5` (command matches `scripts/finetune_launcher.sh`'s `ROBUSTNESS_CMD` template):

```
[Memory]   Peak VRAM 16.93 GB, CPU RSS 2.92 GB
[Phase 3]  Automodel-from-consolidated max KL = 0.00e+00  (threshold 0.00)           PASS
[Fused QKV] No combined projection keys in adapter (874 keys checked)                PASS
[Phase 4]  HF-loaded max KL = 9.17e-04                    (threshold 5.00e-03)       PASS
[Phase 6]  Step 5 diff=1.71e-02, Step 6 diff=3.04e-02, Step 7 diff=1.91e-02
           Training resumption verified (3 steps compared)                           PASS
================= 1 passed, 28 warnings in 1459.42s (0:24:19) ==================
```

Prior to this fix the same Phase 4 produced max KL ~**1.05e+01** against the same reference — roughly **11,000x worse**, which is why #1951 had been raising `hf_kl_threshold` from `5e-3` to `1.5e1` to mask the loader bug.

## Test plan
- [x] Full `finetune_launcher.sh` robustness test on `llama3_3_nemotron_super_49B_squad_peft.yaml` passes with standard `hf_kl_threshold: 5e-3`.
- [x] Per-module device handling verified on a 2-layer DeciLM load forced onto multiple GPUs via `device_map="auto"` with `max_memory` caps — rotary buffers land on each module's own device after reinit, forward pass produces finite logits without cross-device errors.
- [ ] Smoke-test other `nemotron-nas` / `gemma3` recipes whose robustness thresholds had been inflated (none observed on main).

Closes #1951