### PR TITLE
fix: guard against zero label tokens causing NaN loss in VLM training

### DIFF
--- a/nemo_automodel/components/loss/masked_ce.py
+++ b/nemo_automodel/components/loss/masked_ce.py
@@ -82,5 +82,7 @@ class MaskedCrossEntropy(nn.Module):
         loss = F.cross_entropy(logits, labels, reduction=self.reduction)
         if num_label_tokens is not None:
             assert self.reduction == "sum", "num_label_tokens is only supported when reduction is 'sum'"
+            if num_label_tokens == 0:
+                return loss * 0.0
             loss = loss / num_label_tokens
         return loss

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -1133,7 +1133,7 @@ class FinetuneRecipeForVLM(BaseRecipe):
         if self.pp_enabled:
             # PP uses sum reduction per microbatch (no internal normalization).
             # Divide by num_label_tokens to get the mean loss, same as non-PP.
-            reporting_loss = reporting_loss / num_label_tokens
+            reporting_loss = reporting_loss / num_label_tokens if num_label_tokens > 0 else reporting_loss * 0.0
             reporting_loss = reporting_loss.float().to(self.dist_env.device)
             # Send loss to first rank from the last PP stage of rank0's mesh coords.
             # This avoids picking a global-rank sender from a different EP/PP group.

--- a/tests/unit_tests/loss/test_masked_ce.py
+++ b/tests/unit_tests/loss/test_masked_ce.py
@@ -87,6 +87,15 @@ def test_masked_cross_entropy_gpu():
     assert loss_gpu is not None
 
 
+def test_masked_cross_entropy_zero_label_tokens_no_nan():
+    """Loss must be exactly 0.0 (not NaN) when num_label_tokens=0 (empty supervision)."""
+    logits = torch.randn(2, 10, 1000)
+    labels = torch.full((2, 10), -100, dtype=torch.long)
+    loss = MaskedCrossEntropy(reduction="sum")(logits, labels, num_label_tokens=0)
+    assert not torch.isnan(loss), "Loss should not be NaN when num_label_tokens=0"
+    assert loss.item() == 0.0, f"Loss should be 0.0 when num_label_tokens=0, got {loss.item()}"
+
+
 def test_masked_cross_entropy_num_label_tokens_normalization():
     """Ensure that the loss is divided by ``num_label_tokens`` when provided."""
 
@@ -106,9 +115,7 @@ def test_masked_cross_entropy_num_label_tokens_normalization():
     expected_loss = loss_sum / num_label_tokens
 
     # Loss from ChunkedCrossEntropy with num_label_tokens specified
-    loss_masked = MaskedCrossEntropy()(
-        logits, targets, num_label_tokens=num_label_tokens
-    )
+    loss_masked = MaskedCrossEntropy()(logits, targets, num_label_tokens=num_label_tokens)
 
     assert torch.allclose(loss_masked, expected_loss, atol=1e-6), (
         f"Expected normalized loss {expected_loss.item()}, but got {loss_masked.item()}."


### PR DESCRIPTION
# What does this PR do ?

Add a defensive guard against division by zero in \`MaskedCrossEntropy\` when \`num_label_tokens=0\`.

# Changelog

- \`masked_ce.py\`: return \`loss * 0.0\` instead of dividing by zero when \`num_label_tokens=0\`
- \`finetune.py\`: guard PP reporting loss normalization against \`num_label_tokens=0\`
- \`test_masked_ce.py\`: add regression test for the empty-supervision case

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

# Additional Information

Related to #1883.

I attempted to reproduce the SDPA NaN described in #1883 using the exact repro command on transformers 5.5.0 / PyTorch 2.11.0 (CUDA 13.1) / 8xH100, but could not reproduce it. The issue was filed against \`transformers==5.5.0.dev0\`, and I believe the underlying SDPA masking bug has since been fixed in the stable 5.5.0 release.

While investigating, I noticed that \`MaskedCrossEntropy\` has no guard for \`num_label_tokens=0\`, which produces \`NaN\` via division by zero. In the **multi-GPU training path**, \`num_label_tokens\` is all-reduced across DP ranks, so hitting zero in practice would require every sample across every rank to have no valid labels simultaneously -- extremely unlikely. However, two paths are genuinely exposed:

1. **Validation loop**: \`num_label_tokens\` is computed per-batch with no all-reduce. If a single validation batch has all labels set to \`-100\` (e.g. due to label-building failure, as already noted in the \`collate_fns.py\` comment: *"may produce nan loss"*), \`MaskedCrossEntropy\` produces NaN, which propagates into the reported validation loss.
2. **Single-GPU training**: the all-reduce is a no-op (world size = 1), so a single bad sample is enough to trigger it.

This PR adds a minimal defensive guard so that an empty-supervision batch contributes zero loss instead of NaN, keeping training and validation metrics clean.