### PR TITLE
ci: Support per-recipe env_vars in CI config

### DIFF
--- a/examples/llm_benchmark/glm/glm_5_te_deepep.yaml
+++ b/examples/llm_benchmark/glm/glm_5_te_deepep.yaml
@@ -113,3 +113,5 @@ optimizer:
 ci:
   time: "00:45:00"
   nodes: 32
+  env_vars:
+    PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True"

--- a/examples/llm_benchmark/gpt_oss/gptoss_20b_torch.yaml
+++ b/examples/llm_benchmark/gpt_oss/gptoss_20b_torch.yaml
@@ -107,3 +107,5 @@ optimizer:
 ci:
   time: "00:15:00"
   nodes: 1
+  env_vars:
+    PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True"

--- a/examples/llm_benchmark/qwen/qwen3_moe_30b_te_fp8.yaml
+++ b/examples/llm_benchmark/qwen/qwen3_moe_30b_te_fp8.yaml
@@ -116,3 +116,5 @@ optimizer:
 ci:
   time: "00:15:00"
   nodes: 1
+  env_vars:
+    PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True"

--- a/examples/llm_finetune/glm/glm_4.7_te_deepep.yaml
+++ b/examples/llm_finetune/glm/glm_4.7_te_deepep.yaml
@@ -118,3 +118,5 @@ ci:
   recipe_owner: hemildesai
   nodes: 16
   time: "01:00:00"
+  env_vars:
+    PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True"

--- a/tests/ci_tests/utils/generate_ci_tests.py
+++ b/tests/ci_tests/utils/generate_ci_tests.py
@@ -149,6 +149,10 @@ def generate_job(config: str, config_override: Dict[str, Any], scope: str, test_
             else:
                 job['variables'][ci_var] = value
 
+    # Pass through env_vars as CI variables (exported to container via --export=ALL)
+    for key, value in ci_config.get('env_vars', {}).items():
+        job['variables'][key] = str(value)
+
     has_robustness = bool(ci_config.get('checkpoint_robustness'))
     job['variables']['HAS_ROBUSTNESS'] = str(has_robustness).lower()
 


### PR DESCRIPTION
# What does this PR do ?

  - Add `ci.env_vars` support in generate_ci_tests.py to pass arbitrary env vars per recipe
  - Set `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` on 4 large-model configs to reduce CUDA
  memory fragmentation

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
