### PR TITLE
ci: add --tb=short to pytest invocations in CI test scripts

### DIFF
--- a/tests/ci_tests/scripts/finetune_launcher.sh
+++ b/tests/ci_tests/scripts/finetune_launcher.sh
@@ -86,7 +86,7 @@ if [[ "${CONFIG_PATH}" == *peft* ]] || [[ "${CONFIG_PATH}" == *lora* ]]; then
 fi
 
 ROBUSTNESS_CMD="${CMD} --tee 3 --log-dir $PIPELINE_DIR/$TEST_NAME/robustness_logs \
-  -m pytest tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py \
+  -m pytest --tb=short tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py \
   ${ROBUSTNESS_COMMON}"
 
 # --- Finetune ---

--- a/tests/ci_tests/scripts/vllm_launcher.sh
+++ b/tests/ci_tests/scripts/vllm_launcher.sh
@@ -37,13 +37,13 @@ fi
 echo "Using checkpoint: ${CKPT_BASE}"
 
 if [[ "$CI_JOB_STAGE" == *"peft"* ]]; then
-    python -m pytest $TEST_SCRIPT \
+    python -m pytest --tb=short $TEST_SCRIPT \
         --deploy_mode peft \
         --config_path "$CONFIG_PATH" \
         --adapter_path "${CKPT_BASE}/model/" \
         --max_new_tokens 50
 else
-    python -m pytest $TEST_SCRIPT \
+    python -m pytest --tb=short $TEST_SCRIPT \
         --deploy_mode sft \
         --config_path "$CONFIG_PATH" \
         --deploy_model_path "${CKPT_BASE}/model/consolidated/" \


### PR DESCRIPTION
# What does this PR do ?

  - Adds --tb=short to all pytest calls in tests/ci_tests/scripts/ to reduce traceback noise in CI logs
  - Fixes error extraction misclassification where pytest's long traceback source context (e.g. except ImportError:) was
  matching before the actual failure line

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
