### PR TITLE
fix: Propagate torch_dtype to sub-configs correctly

### DIFF
--- a/nemo_automodel/_transformers/model_init.py
+++ b/nemo_automodel/_transformers/model_init.py
@@ -148,6 +148,36 @@ def local_torch_dtype(
         torch.set_default_dtype(original_dtype)
 
 
+def _propagate_torch_dtype_to_subconfigs(hf_config, torch_dtype: torch.dtype) -> None:
+    """Recursively set ``torch_dtype`` on ``hf_config`` and all nested sub-configs.
+
+    Multimodal configs (e.g. ``Gemma4ForConditionalGeneration``) hold nested
+    sub-configs such as ``text_config``, ``vision_config``, and ``audio_config``.
+    During model construction, HF builds sub-modules via
+    ``AutoModel.from_config(sub_config)``, which reads ``torch_dtype`` from the
+    sub-config rather than the parent. Without propagation, those sub-modules
+    keep the checkpoint dtype while directly instantiated ``nn.Linear`` modules
+    take the requested default dtype, producing a mixed-dtype model that FSDP2's
+    uniform-original-dtype check rejects.
+
+    Args:
+        hf_config: The top-level HuggingFace config to update in place.
+        torch_dtype: The dtype to assign to every nested ``PretrainedConfig``.
+    """
+    seen: set[int] = set()
+
+    def _recurse(cfg) -> None:
+        if id(cfg) in seen:
+            return
+        seen.add(id(cfg))
+        cfg.torch_dtype = torch_dtype
+        for value in vars(cfg).values():
+            if isinstance(value, PretrainedConfig):
+                _recurse(value)
+
+    _recurse(hf_config)
+
+
 def _is_config_compatible_with_custom_model(arch_name: str, config) -> bool:
     """
     Check if a HuggingFace config is compatible with our custom model implementation.
@@ -650,6 +680,15 @@ def __init_model(
     )
     architectures = get_architectures(hf_config)
 
+    # Propagate the user-requested dtype to the top-level config and every nested
+    # sub-config (text/vision/audio). Multimodal models like Gemma4 build their
+    # sub-towers via AutoModel.from_config(sub_config), which reads torch_dtype
+    # from the sub-config; without this, sub-towers stay at the checkpoint dtype
+    # while directly instantiated modules (lm_head, embed_vision, embed_audio)
+    # take the requested dtype, tripping FSDP2's uniform-dtype check.
+    if torch_dtype != "auto":
+        _propagate_torch_dtype_to_subconfigs(hf_config, torch_dtype)
+
     # Streaming BnB loading: when quantization is requested and we're loading from a
     # pretrained checkpoint, use streaming quantization to avoid materializing the full
     # bf16 model in memory. This is critical for unified-memory systems (DGX Spark)
@@ -740,9 +779,6 @@ def __init_model(
                 from nemo_automodel.components.models.common.utils import BackendConfig
 
                 kwargs["backend"] = BackendConfig(**kwargs["backend"])
-            # Override config's torch_dtype with user-requested dtype so model __init__ uses correct dtype
-            if torch_dtype != "auto":
-                hf_config.torch_dtype = torch_dtype
             with local_torch_dtype(torch_dtype, model_cls.__name__):
                 return True, model_cls(hf_config, *model_args, **kwargs)
 

--- a/tests/unit_tests/_transformers/test_model_init.py
+++ b/tests/unit_tests/_transformers/test_model_init.py
@@ -26,6 +26,7 @@ from nemo_automodel._transformers.model_init import (
     _has_safetensors,
     _init_model,
     _load_config_with_layer_types_fix,
+    _propagate_torch_dtype_to_subconfigs,
     _resolve_model_dir,
     _setup_bnb_loading_kwargs,
     _stream_load_bnb_weights,
@@ -72,6 +73,61 @@ class TestConsumeConfigOverridesNestedDict:
 
         assert config.some_field == {"key": "val"}
         assert "some_field" not in kwargs
+
+
+class TestPropagateTorchDtypeToSubconfigs:
+    """Nested PretrainedConfig sub-configs must receive the requested torch_dtype."""
+
+    def test_propagates_to_nested_multimodal_subconfigs(self):
+        """Gemma4-style VLM configs expose text/vision/audio sub-configs that all need updating."""
+        from transformers import PretrainedConfig
+
+        text_config = PretrainedConfig()
+        text_config.torch_dtype = torch.bfloat16
+        vision_config = PretrainedConfig()
+        vision_config.torch_dtype = torch.bfloat16
+        audio_config = PretrainedConfig()
+        audio_config.torch_dtype = torch.bfloat16
+
+        top = PretrainedConfig()
+        top.torch_dtype = torch.bfloat16
+        top.text_config = text_config
+        top.vision_config = vision_config
+        top.audio_config = audio_config
+
+        _propagate_torch_dtype_to_subconfigs(top, torch.float32)
+
+        assert top.torch_dtype == torch.float32
+        assert text_config.torch_dtype == torch.float32
+        assert vision_config.torch_dtype == torch.float32
+        assert audio_config.torch_dtype == torch.float32
+
+    def test_ignores_non_config_attributes(self):
+        """Non-config attributes (e.g. plain dicts, ints) must not be traversed or mutated."""
+        from transformers import PretrainedConfig
+
+        top = PretrainedConfig()
+        top.torch_dtype = torch.bfloat16
+        top.some_dict = {"not": "a_config"}
+        top.hidden_size = 4096
+
+        _propagate_torch_dtype_to_subconfigs(top, torch.float32)
+
+        assert top.torch_dtype == torch.float32
+        assert top.some_dict == {"not": "a_config"}
+        assert top.hidden_size == 4096
+
+    def test_handles_cycles(self):
+        """Self-referencing configs must not cause infinite recursion."""
+        from transformers import PretrainedConfig
+
+        top = PretrainedConfig()
+        top.torch_dtype = torch.bfloat16
+        top.self_ref = top
+
+        _propagate_torch_dtype_to_subconfigs(top, torch.float32)
+
+        assert top.torch_dtype == torch.float32
 
 
 class TestBackendDictCoercion:


### PR DESCRIPTION
# What does this PR do ?

Fixes #2017.
Verified by running `examples/vlm_finetune/gemma4/gemma4_4b_mock.yaml` with `torch_dtype: torch.float32` and dont see the error mentioned in the issue anymore.

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
