### PR TITLE
fix: add required YAML frontmatter to skills

### DIFF
--- a/skills/developer-guide/SKILL.md
+++ b/skills/developer-guide/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: developer-guide
+description: Environment setup and day-to-day development workflow for NeMo AutoModel, including installation, tooling, and code quality commands.
+---
+
 # NeMo AutoModel Developer Guide
 
 ## Quick Start

--- a/skills/distributed-training/SKILL.md
+++ b/skills/distributed-training/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: distributed-training
+description: Guide for selecting and configuring distributed training strategies in NeMo AutoModel, including FSDP2, Megatron FSDP, DDP, and parallelism settings.
+---
+
 # Distributed Training in NeMo AutoModel
 
 NeMo AutoModel uses PyTorch-native distributed training.

--- a/skills/launcher-config/SKILL.md
+++ b/skills/launcher-config/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: launcher-config
+description: Configure NeMo AutoModel job launches for interactive runs, Slurm clusters, and SkyPilot cloud execution.
+---
+
 # Launcher Configuration
 
 NeMo AutoModel supports three launch methods: interactive (torchrun), Slurm (HPC clusters), and SkyPilot (cloud-agnostic).

--- a/skills/model-onboarding/SKILL.md
+++ b/skills/model-onboarding/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: model-onboarding
+description: Guide for onboarding new model families into NeMo AutoModel, including architecture discovery, implementation patterns, registration, and validation.
+---
+
 # Adding Model Support to NeMo AutoModel
 
 This skill guides implementation of new model architectures in NeMo AutoModel. Follow the five phases in order.

--- a/skills/parity-testing/SKILL.md
+++ b/skills/parity-testing/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: parity-testing
+description: Verify numerical parity between NeMo AutoModel implementations and reference HuggingFace models, including state dict and forward-pass checks.
+---
+
 # Parity Testing Skill for NeMo AutoModel
 
 NeMo AutoModel adds custom model implementations (combined projections, backend switching, kernel patches) on top of HuggingFace transformers. Parity testing verifies that NeMo AutoModel's implementation produces numerically equivalent results to the reference HF implementation.

--- a/skills/recipe-development/SKILL.md
+++ b/skills/recipe-development/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: recipe-development
+description: Create and modify NeMo AutoModel training and evaluation recipes, including YAML structure, builders, and execution flow.
+---
+
 # NeMo AutoModel Recipe Development
 
 ## Recipe Architecture


### PR DESCRIPTION
# What does this PR do ?

Add the required YAML frontmatter to all repository `skills/*/SKILL.md` files so each skill exposes the mandatory `name` and `description` metadata.

> Skills use progressive disclosure to manage context efficiently. Agent loads the full SKILL.md instructions only when it decides to use a skill.

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
- https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview#skill-structure
- https://developers.openai.com/codex/skills
- Co-authored-by Codex