### PR TITLE
ci: triage pipeline benchmark failures

### DIFF
--- a/examples/llm_benchmark/deepseek/deepseek_v3_te_deepep.yaml
+++ b/examples/llm_benchmark/deepseek/deepseek_v3_te_deepep.yaml
@@ -114,3 +114,5 @@ optimizer:
 ci:
   time: "00:45:00"
   nodes: 32
+  env_vars:
+    RDZV_TIMEOUT: "900"

--- a/examples/llm_benchmark/deepseek/deepseek_v3_torch.yaml
+++ b/examples/llm_benchmark/deepseek/deepseek_v3_torch.yaml
@@ -107,3 +107,5 @@ optimizer:
 ci:
   time: "00:45:00"
   nodes: 32
+  env_vars:
+    RDZV_TIMEOUT: "900"

--- a/examples/llm_benchmark/nemotron/nemotron_super_v3_te_deepep.yaml
+++ b/examples/llm_benchmark/nemotron/nemotron_super_v3_te_deepep.yaml
@@ -94,4 +94,4 @@ optimizer:
 
 ci:
   time: "00:15:00"
-  nodes: 1
+  nodes: 8

--- a/examples/llm_benchmark/qwen/qwen3_moe_30b_te_fp8.yaml
+++ b/examples/llm_benchmark/qwen/qwen3_moe_30b_te_fp8.yaml
@@ -116,5 +116,6 @@ optimizer:
 ci:
   time: "00:15:00"
   nodes: 1
+  known_issue_id: AM-150
   env_vars:
     PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True"

--- a/examples/llm_benchmark/qwen/qwen3_moe_30b_torch.yaml
+++ b/examples/llm_benchmark/qwen/qwen3_moe_30b_torch.yaml
@@ -106,5 +106,5 @@ optimizer:
 
 
 ci:
-  time: "00:15:00"
+  time: "00:30:00"
   nodes: 1

--- a/examples/vlm_benchmark/kimi/kimi25vl_lora.yaml
+++ b/examples/vlm_benchmark/kimi/kimi25vl_lora.yaml
@@ -107,3 +107,4 @@ optimizer:
 ci:
   time: "00:30:00"
   nodes: 16
+  known_issue_id: AM-173

--- a/examples/vlm_benchmark/mistral/mistral4_lora.yaml
+++ b/examples/vlm_benchmark/mistral/mistral4_lora.yaml
@@ -120,3 +120,4 @@ optimizer:
 ci:
   time: "00:20:00"
   nodes: 4
+  known_issue_id: AM-174

--- a/nemo_automodel/recipes/llm/benchmark.py
+++ b/nemo_automodel/recipes/llm/benchmark.py
@@ -43,7 +43,12 @@ def _infer_vocab_size(model_cfg):
     from transformers import AutoConfig
 
     config_section = model_cfg.config
-    trust_remote_code = getattr(config_section, "trust_remote_code", False)
+    # Recipes may set trust_remote_code either at the model level (nemo_automodel
+    # convention) or nested under `config` -- accept either.
+    trust_remote_code = (
+        getattr(model_cfg, "trust_remote_code", False)
+        or getattr(config_section, "trust_remote_code", False)
+    )
 
     # Use the config's _target_ if it's a custom config class (e.g. DeepseekV32Config)
     config_target = getattr(config_section, "_target_", None)
@@ -52,7 +57,13 @@ def _infer_vocab_size(model_cfg):
     if config_target is not None and callable(config_target):
         target_name = getattr(config_target, "__qualname__", "")
         if "AutoConfig" not in target_name:
-            model_config = config_target.from_pretrained(config_section.pretrained_model_name_or_path)
+            if hasattr(config_target, "from_pretrained"):
+                # `_target_` resolved to a config class; call its classmethod.
+                model_config = config_target.from_pretrained(config_section.pretrained_model_name_or_path)
+            else:
+                # `_target_` already resolved to the factory itself
+                # (e.g. `DeepseekV32Config.from_pretrained`); invoke it directly.
+                model_config = config_target(config_section.pretrained_model_name_or_path)
     elif isinstance(config_target, str) and "AutoConfig" not in config_target:
         import importlib
 

--- a/nemo_automodel/recipes/llm/benchmark.py
+++ b/nemo_automodel/recipes/llm/benchmark.py
@@ -45,9 +45,8 @@ def _infer_vocab_size(model_cfg):
     config_section = model_cfg.config
     # Recipes may set trust_remote_code either at the model level (nemo_automodel
     # convention) or nested under `config` -- accept either.
-    trust_remote_code = (
-        getattr(model_cfg, "trust_remote_code", False)
-        or getattr(config_section, "trust_remote_code", False)
+    trust_remote_code = getattr(model_cfg, "trust_remote_code", False) or getattr(
+        config_section, "trust_remote_code", False
     )
 
     # Use the config's _target_ if it's a custom config class (e.g. DeepseekV32Config)

--- a/tests/ci_tests/scripts/finetune_launcher.sh
+++ b/tests/ci_tests/scripts/finetune_launcher.sh
@@ -64,7 +64,8 @@ CMD="torchrun --nproc-per-node=${NPROC_PER_NODE} \
               --nnodes=${TEST_NODE_COUNT} \
               --rdzv_backend=c10d \
               --rdzv_endpoint=${MASTER_ADDR}:${MASTER_PORT} \
-              --rdzv_id=${SLURM_JOB_ID}"
+              --rdzv_id=${SLURM_JOB_ID} \
+              --rdzv_conf=timeout=${RDZV_TIMEOUT:-600}"
 if [ "$EXEC_CMD" = "python" ]; then CMD="python"; fi
 if [ "$EXEC_CMD" = "uv_python" ]; then CMD="uv run python"; fi
 

--- a/tests/unit_tests/recipes/llm/test_benchmark.py
+++ b/tests/unit_tests/recipes/llm/test_benchmark.py
@@ -202,6 +202,47 @@ class TestBenchmarkingRecipeInitialization:
             mock_module.CustomConfig.from_pretrained.assert_called_once_with("some-model")
             assert vocab_size == 131072
 
+    def test_infer_vocab_size_trust_remote_code_at_model_level(self, mock_config):
+        """trust_remote_code at model level (not nested under config) must flow to AutoConfig."""
+        mock_model_config = MagicMock(spec=["vocab_size"])
+        mock_model_config.vocab_size = 163840
+
+        model_cfg = ConfigNamespace(
+            trust_remote_code=True,
+            config=ConfigNamespace(
+                _target_="transformers.AutoConfig.from_pretrained",
+                pretrained_model_name_or_path="moonshotai/Kimi-K2-Base",
+            ),
+        )
+
+        with patch(
+            "transformers.AutoConfig.from_pretrained", return_value=mock_model_config
+        ) as mock_autoconfig:
+            vocab_size = _infer_vocab_size(model_cfg)
+            assert vocab_size == 163840
+            mock_autoconfig.assert_called_once_with(
+                "moonshotai/Kimi-K2-Base", trust_remote_code=True
+            )
+
+    def test_infer_vocab_size_method_target(self, mock_config):
+        """`_target_` resolved to a classmethod (e.g. `Class.from_pretrained`) should be invoked directly."""
+        mock_model_config = MagicMock(spec=["vocab_size"])
+        mock_model_config.vocab_size = 129280
+
+        def factory(path):
+            assert path == "deepseek-ai/DeepSeek-V3.2"
+            return mock_model_config
+
+        model_cfg = ConfigNamespace(
+            config=ConfigNamespace(
+                _target_=factory,
+                pretrained_model_name_or_path="deepseek-ai/DeepSeek-V3.2",
+            )
+        )
+
+        vocab_size = _infer_vocab_size(model_cfg)
+        assert vocab_size == 129280
+
     def test_infer_vocab_size_vl_text_config(self, mock_config):
         """Test _infer_vocab_size falls back to text_config.vocab_size for VL models."""
         mock_model_config = MagicMock(spec=[])

--- a/tests/unit_tests/recipes/llm/test_benchmark.py
+++ b/tests/unit_tests/recipes/llm/test_benchmark.py
@@ -215,14 +215,10 @@ class TestBenchmarkingRecipeInitialization:
             ),
         )
 
-        with patch(
-            "transformers.AutoConfig.from_pretrained", return_value=mock_model_config
-        ) as mock_autoconfig:
+        with patch("transformers.AutoConfig.from_pretrained", return_value=mock_model_config) as mock_autoconfig:
             vocab_size = _infer_vocab_size(model_cfg)
             assert vocab_size == 163840
-            mock_autoconfig.assert_called_once_with(
-                "moonshotai/Kimi-K2-Base", trust_remote_code=True
-            )
+            mock_autoconfig.assert_called_once_with("moonshotai/Kimi-K2-Base", trust_remote_code=True)
 
     def test_infer_vocab_size_method_target(self, mock_config):
         """`_target_` resolved to a classmethod (e.g. `Class.from_pretrained`) should be invoked directly."""


### PR DESCRIPTION
# What does this PR do ?

  - `benchmark._infer_vocab_size` fixes: support classmethod `_target_` (e.g.`DeepseekV32Config.from_pretrained`, unblocks `dsv32_lora`) and read `trust_remote_code` from the model level (unblocks `kimi_k2_te_deepep`). Two unit tests added.
  - Triaged remaining failures from pipeline: env-configurable rdzv timeout in `finetune_launcher.sh` + `RDZV_TIMEOUT=900` on the 2 DeepSeek v3 benchmarks; direct `ci:` fixes on 2 recipes; tagged 3 recipes with `known_issue_id`

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
