### PR TITLE
ci: add retrieval bi-encoder and cross-encoder nightly tests

### DIFF
--- a/examples/retrieval/bi_encoder/llama3_2_1b.yaml
+++ b/examples/retrieval/bi_encoder/llama3_2_1b.yaml
@@ -18,6 +18,11 @@
 
 recipe: TrainBiEncoderRecipe
 
+ci:
+  time: "00:20:00"
+  nodes: 1
+  retrieval_eval: true
+
 seed: 42
 
 temperature: 0.02

--- a/examples/retrieval/bi_encoder/llama3_2_1b.yaml
+++ b/examples/retrieval/bi_encoder/llama3_2_1b.yaml
@@ -21,7 +21,7 @@ recipe: TrainBiEncoderRecipe
 ci:
   time: "00:20:00"
   nodes: 1
-  retrieval_eval: true
+  embed_eval: true
 
 seed: 42
 

--- a/examples/retrieval/bi_encoder/llama3_2_1b.yaml
+++ b/examples/retrieval/bi_encoder/llama3_2_1b.yaml
@@ -19,7 +19,7 @@
 recipe: TrainBiEncoderRecipe
 
 ci:
-  time: "00:20:00"
+  time: "02:00:00"
   nodes: 1
   embed_eval: true
 
@@ -148,4 +148,4 @@ distributed:
 #   project: <your_wandb_project>
 #   entity: <your_wandb_entity>
 #   name: <your_wandb_exp_name>
-#   save_dir: <your_wandb_save_dir> 
+#   save_dir: <your_wandb_save_dir>

--- a/examples/retrieval/bi_encoder/llama3_2_1b.yaml
+++ b/examples/retrieval/bi_encoder/llama3_2_1b.yaml
@@ -18,11 +18,6 @@
 
 recipe: TrainBiEncoderRecipe
 
-ci:
-  time: "01:30:00"
-  nodes: 1
-  embed_eval: true
-
 seed: 42
 
 temperature: 0.02
@@ -149,3 +144,9 @@ distributed:
 #   entity: <your_wandb_entity>
 #   name: <your_wandb_exp_name>
 #   save_dir: <your_wandb_save_dir>
+
+ci:
+  recipe_owner: oliverholworthy
+  time: "01:30:00"
+  nodes: 1
+  embed_eval: true

--- a/examples/retrieval/bi_encoder/llama3_2_1b.yaml
+++ b/examples/retrieval/bi_encoder/llama3_2_1b.yaml
@@ -19,7 +19,7 @@
 recipe: TrainBiEncoderRecipe
 
 ci:
-  time: "02:00:00"
+  time: "01:15:00"
   nodes: 1
   embed_eval: true
 

--- a/examples/retrieval/bi_encoder/llama3_2_1b.yaml
+++ b/examples/retrieval/bi_encoder/llama3_2_1b.yaml
@@ -19,7 +19,7 @@
 recipe: TrainBiEncoderRecipe
 
 ci:
-  time: "01:15:00"
+  time: "01:30:00"
   nodes: 1
   embed_eval: true
 

--- a/examples/retrieval/cross_encoder/llama3_2_1b.yaml
+++ b/examples/retrieval/cross_encoder/llama3_2_1b.yaml
@@ -18,6 +18,11 @@
 
 recipe: TrainCrossEncoderRecipe
 
+ci:
+  time: "00:20:00"
+  nodes: 1
+  rerank_eval: true
+
 seed: 42
 
 step_scheduler:

--- a/examples/retrieval/cross_encoder/llama3_2_1b.yaml
+++ b/examples/retrieval/cross_encoder/llama3_2_1b.yaml
@@ -19,7 +19,7 @@
 recipe: TrainCrossEncoderRecipe
 
 ci:
-  time: "00:20:00"
+  time: "02:00:00"
   nodes: 1
   rerank_eval: true
 
@@ -141,4 +141,4 @@ distributed:
 #   project: <your_wandb_project>
 #   entity: <your_wandb_entity>
 #   name: <your_wandb_exp_name>
-#   save_dir: <your_wandb_save_dir> 
+#   save_dir: <your_wandb_save_dir>

--- a/examples/retrieval/cross_encoder/llama3_2_1b.yaml
+++ b/examples/retrieval/cross_encoder/llama3_2_1b.yaml
@@ -19,7 +19,7 @@
 recipe: TrainCrossEncoderRecipe
 
 ci:
-  time: "01:00:00"
+  time: "01:30:00"
   nodes: 1
   rerank_eval: true
 

--- a/examples/retrieval/cross_encoder/llama3_2_1b.yaml
+++ b/examples/retrieval/cross_encoder/llama3_2_1b.yaml
@@ -19,7 +19,7 @@
 recipe: TrainCrossEncoderRecipe
 
 ci:
-  time: "02:00:00"
+  time: "01:00:00"
   nodes: 1
   rerank_eval: true
 

--- a/examples/retrieval/cross_encoder/llama3_2_1b.yaml
+++ b/examples/retrieval/cross_encoder/llama3_2_1b.yaml
@@ -18,11 +18,6 @@
 
 recipe: TrainCrossEncoderRecipe
 
-ci:
-  time: "01:30:00"
-  nodes: 1
-  rerank_eval: true
-
 seed: 42
 
 step_scheduler:
@@ -142,3 +137,9 @@ distributed:
 #   entity: <your_wandb_entity>
 #   name: <your_wandb_exp_name>
 #   save_dir: <your_wandb_save_dir>
+
+ci:
+  recipe_owner: oliverholworthy
+  time: "01:30:00"
+  nodes: 1
+  rerank_eval: true

--- a/tests/ci_tests/configs/retrieval_bi_encoder/nightly_recipes.yml
+++ b/tests/ci_tests/configs/retrieval_bi_encoder/nightly_recipes.yml
@@ -1,0 +1,18 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+examples_dir: retrieval
+
+configs:
+  - bi_encoder/llama3_2_1b.yaml

--- a/tests/ci_tests/configs/retrieval_bi_encoder/override_recipes.yml
+++ b/tests/ci_tests/configs/retrieval_bi_encoder/override_recipes.yml
@@ -1,0 +1,19 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+exempt_models:
+
+exempt_configs:
+
+known_issue:

--- a/tests/ci_tests/configs/retrieval_cross_encoder/nightly_recipes.yml
+++ b/tests/ci_tests/configs/retrieval_cross_encoder/nightly_recipes.yml
@@ -1,0 +1,18 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+examples_dir: retrieval
+
+configs:
+  - cross_encoder/llama3_2_1b.yaml

--- a/tests/ci_tests/configs/retrieval_cross_encoder/override_recipes.yml
+++ b/tests/ci_tests/configs/retrieval_cross_encoder/override_recipes.yml
@@ -1,0 +1,19 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+exempt_models:
+
+exempt_configs:
+
+known_issue:

--- a/tests/ci_tests/utils/generate_ci_tests.py
+++ b/tests/ci_tests/utils/generate_ci_tests.py
@@ -173,6 +173,8 @@ def generate_job(config: str, config_override: Dict[str, Any], scope: str, test_
         job["stage"] = "benchmark"
     elif test_folder.startswith("diffusion"):
         job["stage"] = "diffusion_peft" if ("lora" in config.stem or "peft" in config.stem) else "diffusion_sft"
+    elif test_folder.startswith("retrieval"):
+        job["stage"] = "retrieval"
     elif "peft" in config.stem or "lora" in config.stem:
         job["stage"] = "peft_ckpt_robustness" if has_robustness else "peft"
     else:
@@ -214,7 +216,24 @@ def generate_job(config: str, config_override: Dict[str, Any], scope: str, test_
         if known_issue_id:
             vllm_job['variables']['KNOWN_ISSUE_ID'] = known_issue_id
 
-    return job, vllm_job
+    # Generate retrieval eval job if recipe opts in
+    retrieval_eval_job = None
+    if ci_config.get("retrieval_eval"):
+        retrieval_eval_job = {
+            "extends": f".{test_folder}_eval_test",
+            "stage": "retrieval_eval",
+            "variables": {
+                "CONFIG_PATH": f"{config}",
+                "TEST_LEVEL": f"{scope}",
+                "FINETUNE_TEST_NAME": f"{config.stem}",
+            },
+        }
+        if recipe_allow_failure:
+            retrieval_eval_job['allow_failure'] = True
+        if known_issue_id:
+            retrieval_eval_job['variables']['KNOWN_ISSUE_ID'] = known_issue_id
+
+    return job, vllm_job, retrieval_eval_job
 
 
 def generate_pipeline(automodel_dir: str, scope: str, test_folder: str):
@@ -262,12 +281,14 @@ def generate_pipeline(automodel_dir: str, scope: str, test_folder: str):
         if model_name in exempt_models_list or config_name in exempt_configs_list:
             continue
 
-        job, vllm_job = generate_job(config, config_override, scope, test_folder, automodel_dir)
+        job, vllm_job, retrieval_eval_job = generate_job(config, config_override, scope, test_folder, automodel_dir)
         if job is None:
             continue  # skipped via ci.known_issue_id (no allow_failure)
         pipeline[f'{config_name}'] = job
         if vllm_job:
             pipeline[f"{config_name}_vllm_deploy"] = vllm_job
+        if retrieval_eval_job:
+            pipeline[f"{config_name}_retrieval_eval"] = retrieval_eval_job
 
     return pipeline
 

--- a/tests/ci_tests/utils/generate_ci_tests.py
+++ b/tests/ci_tests/utils/generate_ci_tests.py
@@ -216,10 +216,10 @@ def generate_job(config: str, config_override: Dict[str, Any], scope: str, test_
         if known_issue_id:
             vllm_job['variables']['KNOWN_ISSUE_ID'] = known_issue_id
 
-    # Generate retrieval eval job if recipe opts in
-    retrieval_eval_job = None
-    if ci_config.get("retrieval_eval"):
-        retrieval_eval_job = {
+    # Generate embedding eval job if recipe opts in (bi-encoder retrieval models)
+    embed_eval_job = None
+    if ci_config.get("embed_eval"):
+        embed_eval_job = {
             "extends": f".{test_folder}_eval_test",
             "stage": "retrieval_eval",
             "variables": {
@@ -229,11 +229,28 @@ def generate_job(config: str, config_override: Dict[str, Any], scope: str, test_
             },
         }
         if recipe_allow_failure:
-            retrieval_eval_job['allow_failure'] = True
+            embed_eval_job['allow_failure'] = True
         if known_issue_id:
-            retrieval_eval_job['variables']['KNOWN_ISSUE_ID'] = known_issue_id
+            embed_eval_job['variables']['KNOWN_ISSUE_ID'] = known_issue_id
 
-    return job, vllm_job, retrieval_eval_job
+    # Generate reranking eval job if recipe opts in (cross-encoder retrieval models)
+    rerank_eval_job = None
+    if ci_config.get("rerank_eval"):
+        rerank_eval_job = {
+            "extends": f".{test_folder}_eval_test",
+            "stage": "retrieval_eval",
+            "variables": {
+                "CONFIG_PATH": f"{config}",
+                "TEST_LEVEL": f"{scope}",
+                "FINETUNE_TEST_NAME": f"{config.stem}",
+            },
+        }
+        if recipe_allow_failure:
+            rerank_eval_job['allow_failure'] = True
+        if known_issue_id:
+            rerank_eval_job['variables']['KNOWN_ISSUE_ID'] = known_issue_id
+
+    return job, vllm_job, embed_eval_job, rerank_eval_job
 
 
 def generate_pipeline(automodel_dir: str, scope: str, test_folder: str):
@@ -281,14 +298,18 @@ def generate_pipeline(automodel_dir: str, scope: str, test_folder: str):
         if model_name in exempt_models_list or config_name in exempt_configs_list:
             continue
 
-        job, vllm_job, retrieval_eval_job = generate_job(config, config_override, scope, test_folder, automodel_dir)
+        job, vllm_job, embed_eval_job, rerank_eval_job = generate_job(
+            config, config_override, scope, test_folder, automodel_dir
+        )
         if job is None:
             continue  # skipped via ci.known_issue_id (no allow_failure)
         pipeline[f'{config_name}'] = job
         if vllm_job:
             pipeline[f"{config_name}_vllm_deploy"] = vllm_job
-        if retrieval_eval_job:
-            pipeline[f"{config_name}_retrieval_eval"] = retrieval_eval_job
+        if embed_eval_job:
+            pipeline[f"{config_name}_embed_eval"] = embed_eval_job
+        if rerank_eval_job:
+            pipeline[f"{config_name}_rerank_eval"] = rerank_eval_job
 
     return pipeline
 


### PR DESCRIPTION
- New test folders `tests/ci_tests/configs/retrieval_{bi,cross}_encoder/` register `llama3_2_1b.yaml` from each encoder's examples directory. Both use `examples_dir: retrieval` so paths resolve to `examples/retrieval/{bi,cross}_encoder/llama3_2_1b.yaml`.
- `generate_ci_tests.py` gains:
  - A `retrieval` stage branch for training jobs (parallel to the existing `diffusion_sft` branch).
  - Two paired-job emitters (parallel to `vllm_deploy`): `ci.embed_eval: true` → `<name>_embed_eval`; `ci.rerank_eval: true` → `<name>_rerank_eval`. Both target the `retrieval_eval` stage in the child pipeline.
- Recipe `ci:` blocks added to both retrieval `llama3_2_1b.yaml` files (20 min / 1 node / eval flag). Runtime recipe behaviour is unchanged — the block is read only by CI.

## Test plan

- [x] `python generate_ci_tests.py --scope nightly --test-folder retrieval_bi_encoder` emits `llama3_2_1b` + `llama3_2_1b_embed_eval`.
- [x] `python generate_ci_tests.py --scope nightly --test-folder retrieval_cross_encoder` emits `llama3_2_1b` + `llama3_2_1b_rerank_eval`.
- [ ] after PR merges launch a real nightly with `--test-case llama3_2_1b_embed_eval,llama3_2_1b_rerank_eval --test-cluster eos` and confirm both training + eval jobs succeed.
