### PR TITLE
ci: triage rc9 finetune failures

### DIFF
--- a/examples/llm_finetune/gpt_oss/gpt_oss_120b.yaml
+++ b/examples/llm_finetune/gpt_oss/gpt_oss_120b.yaml
@@ -116,4 +116,3 @@ ci:
   local_batch_size: 16
   nodes: 4
   time: "01:00:00"
-  known_issue_id: AM-157

--- a/examples/llm_finetune/llama3_3/llama_3_3_70b_instruct_squad.yaml
+++ b/examples/llm_finetune/llama3_3/llama_3_3_70b_instruct_squad.yaml
@@ -102,4 +102,4 @@ lr_scheduler:
 
 ci:
   recipe_owner: akoumpa
-  nodes: 2
+  nodes: 4

--- a/examples/llm_finetune/mistral/ministral3_3b_squad.yaml
+++ b/examples/llm_finetune/mistral/ministral3_3b_squad.yaml
@@ -105,6 +105,8 @@ lr_scheduler:
 ci:
   recipe_owner: akoumpa
   time: "00:15:00"
+  known_issue_id: AM-154
+  allow_failure: true
   checkpoint_robustness:
     hf_kl_threshold: 5e-3
     distributed.tp_size: 2

--- a/examples/llm_finetune/mistral/mixtral-8x7b-v0-1_squad.yaml
+++ b/examples/llm_finetune/mistral/mixtral-8x7b-v0-1_squad.yaml
@@ -103,3 +103,4 @@ lr_scheduler:
 ci:
   recipe_owner: HuiyingLi
   time: "00:20:00"
+  nodes: 2

--- a/examples/llm_finetune/moonlight/moonlight_16b_te.yaml
+++ b/examples/llm_finetune/moonlight/moonlight_16b_te.yaml
@@ -132,4 +132,3 @@ optimizer:
 ci:
   recipe_owner: hemildesai
   node_multiplier: true
-  known_issue_id: AM-153

--- a/examples/llm_finetune/moonlight/moonlight_16b_te_packed_sequence.yaml
+++ b/examples/llm_finetune/moonlight/moonlight_16b_te_packed_sequence.yaml
@@ -122,4 +122,3 @@ optimizer:
 
 ci:
   recipe_owner: hemildesai
-  known_issue_id: AM-153

--- a/examples/llm_finetune/nemotron/customizer_nemotron_nano_peft.yaml
+++ b/examples/llm_finetune/nemotron/customizer_nemotron_nano_peft.yaml
@@ -90,6 +90,7 @@ parallelizer:
 ci:
   time: "00:30:00"
   nproc_per_node: 4
+  known_issue_id: AM-149
   checkpoint_robustness:
     hf_kl_threshold: 1e-1
     tokenizer_name: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16

--- a/examples/llm_finetune/nemotron/customizer_nemotron_nano_peft_packing.yaml
+++ b/examples/llm_finetune/nemotron/customizer_nemotron_nano_peft_packing.yaml
@@ -93,6 +93,7 @@ parallelizer:
 ci:
   time: "00:30:00"
   nproc_per_node: 4
+  known_issue_id: AM-149
   checkpoint_robustness:
     hf_kl_threshold: 1e-1
     tokenizer_name: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16

--- a/examples/llm_finetune/nemotron/nemotron_super_v3_hellaswag.yaml
+++ b/examples/llm_finetune/nemotron/nemotron_super_v3_hellaswag.yaml
@@ -104,6 +104,7 @@ ci:
   vllm_smoke_test: true
   recipe_owner: adil-a
   time: "00:25:00"
+  known_issue_id: AM-156
   checkpoint_robustness:
     hf_kl_threshold: 7e-2
     experts_implementation: grouped_mm

--- a/examples/llm_finetune/qwen/qwen3_moe_30b_lora.yaml
+++ b/examples/llm_finetune/qwen/qwen3_moe_30b_lora.yaml
@@ -104,6 +104,8 @@ ci:
   recipe_owner: adil-a
   time: "00:15:00"
   nodes: 1
+  env_vars:
+    PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True"
   checkpoint_robustness:
     hf_kl_threshold: 7e-2
     tokenizer_name: Qwen/Qwen3-30B-A3B

--- a/examples/llm_finetune/qwen/qwq_32b_squad_peft.yaml
+++ b/examples/llm_finetune/qwen/qwq_32b_squad_peft.yaml
@@ -101,6 +101,7 @@ optimizer:
 ci:
   recipe_owner: adil-a
   nodes: 4
+  local_batch_size: 2
 
 # Uncomment and configure for W&B logging
 # wandb:

--- a/examples/vlm_finetune/gemma4/gemma4_31b.yaml
+++ b/examples/vlm_finetune/gemma4/gemma4_31b.yaml
@@ -111,3 +111,4 @@ freeze_config:
 
 ci:
   recipe_owner: athitten
+  time: "00:20:00"


### PR DESCRIPTION
# What does this PR do ?

  - Tagged 3 more finetune recipes as known issues: `customizer_nemotron_nano_peft{,_packing}` under AM-149 (same NemotronH FA2 gap), `ministral3_3b_squad` under AM-154 + allow_failure (same KL-threshold signature as its `_peft` sibling).
  - Recipe `ci:` fixes for rc9 finetune failures: bumped `llama_3_3_70b_instruct_squad` nodes 2→4, set `qwq_32b_squad_peft` `local_batch_size:  2` to satisfy the divisibility check after the prior nodes bump, added `nodes: 2` to `mixtral-8x7b-v0-1_squad`, added `PYTORCH_CUDA_ALLOC_CONF=expandable_segments` to `qwen3_moe_30b_lora`, and bumped `gemma4_31b` `ci.time` to `00:20:00`.

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
