### PR TITLE
fix: Unsafe deserialization via `torch.load` on dataset cache files

### DIFF
--- a/nemo_automodel/components/datasets/diffusion/text_to_image_dataset.py
+++ b/nemo_automodel/components/datasets/diffusion/text_to_image_dataset.py
@@ -39,10 +39,16 @@ class TextToImageDataset(BaseMultiresolutionDataset):
     def __getitem__(self, idx: int) -> Dict[str, torch.Tensor]:
         """Load a single sample."""
         item = self.metadata[idx]
-        cache_file = Path(item["cache_file"])
+        cache_file = Path(item["cache_file"]).resolve()
+        cache_dir = Path(self.cache_dir).resolve()
+
+        try:
+            cache_file.relative_to(cache_dir)
+        except ValueError as e:
+            raise ValueError(f"Cache file {cache_file} is outside cache directory {cache_dir}") from e
 
         # Load cached data
-        data = torch.load(cache_file, map_location="cpu")
+        data = torch.load(cache_file, map_location="cpu", weights_only=True)
 
         # Prepare output - support both bucket_resolution and crop_resolution keys
         resolution_key = "bucket_resolution" if "bucket_resolution" in item else "crop_resolution"


### PR DESCRIPTION
## Summary

Security: Unsafe deserialization via `torch.load` on dataset cache files

## Problem

**Severity**: `High` | **File**: `nemo_automodel/components/datasets/diffusion/text_to_image_dataset.py:L45`

The dataset loader deserializes `.pt`/cache files using `torch.load(cache_file, map_location="cpu")` without `weights_only=True` or an equivalent safe format. If an attacker can modify cache files or metadata paths, this can lead to arbitrary code execution during loading because `torch.load` uses pickle by default.

## Solution

Use `torch.load(..., weights_only=True)` where possible, or migrate cache serialization to a non-executable format (e.g., safetensors). Validate that `cache_file` resolves under an expected trusted directory before loading.

## Changes

- `nemo_automodel/components/datasets/diffusion/text_to_image_dataset.py` (modified)