### PR TITLE
ci: triage vllm_deploy rc9 failures

### DIFF
--- a/docker/Dockerfile.deploy
+++ b/docker/Dockerfile.deploy
@@ -15,8 +15,9 @@
 ARG VLLM_IMAGE=nvcr.io/nvidia/vllm:25.12-py3
 FROM ${VLLM_IMAGE} AS deploy
 
-# Build mamba-ssm and causal-conv1d CUDA extensions against the container's matching CUDA/torch
-RUN pip install --no-build-isolation mamba-ssm causal-conv1d
+# Build mamba-ssm and causal-conv1d from source against the container's torch (--no-binary avoids PyPI wheels compiled against a different torch ABI)
+RUN pip install --no-build-isolation --no-binary=mamba-ssm,causal-conv1d \
+    mamba-ssm causal-conv1d
 
 # Test dependencies
 RUN pip install peft pytest pyyaml

--- a/docker/Dockerfile.deploy
+++ b/docker/Dockerfile.deploy
@@ -15,7 +15,8 @@
 ARG VLLM_IMAGE=nvcr.io/nvidia/vllm:25.12-py3
 FROM ${VLLM_IMAGE} AS deploy
 
-# Build mamba-ssm and causal-conv1d from source against the container's torch (--no-binary avoids PyPI wheels compiled against a different torch ABI)
+# Build mamba-ssm and causal-conv1d from source against the container's torch
+ENV MAMBA_FORCE_BUILD=TRUE CAUSAL_CONV1D_FORCE_BUILD=TRUE
 RUN pip install --no-build-isolation --no-binary=mamba-ssm,causal-conv1d \
     mamba-ssm causal-conv1d
 

--- a/examples/llm_finetune/gemma/gemma_3_270m_squad_peft.yaml
+++ b/examples/llm_finetune/gemma/gemma_3_270m_squad_peft.yaml
@@ -102,6 +102,8 @@ ci:
   vllm_deploy: true
   recipe_owner: HuiyingLi
   time: "00:20:00"
+  known_issue_id: AM-154
+  allow_failure: true
   checkpoint_robustness:
     hf_kl_threshold: 1e-1
     tokenizer_name: google/gemma-3-270m

--- a/examples/llm_finetune/nemotron/llama3_3_nemotron_super_49B_squad_peft.yaml
+++ b/examples/llm_finetune/nemotron/llama3_3_nemotron_super_49B_squad_peft.yaml
@@ -110,6 +110,7 @@ lr_scheduler:
 ci:
   time: "01:00:00"
   vllm_deploy: true
+  vllm_deploy_known_issue_id: AM-176
   recipe_owner: HuiyingLi
   checkpoint_robustness:
     hf_kl_threshold: 5e-3

--- a/examples/llm_finetune/qwen/qwen2_5_7b_squad_peft.yaml
+++ b/examples/llm_finetune/qwen/qwen2_5_7b_squad_peft.yaml
@@ -104,6 +104,8 @@ ci:
   vllm_deploy: true
   recipe_owner: HuiyingLi
   time: "00:30:00"
+  known_issue_id: AM-154
+  allow_failure: true
   checkpoint_robustness:
     hf_kl_threshold: 8e-2
     distributed.tp_size: 2

--- a/tests/ci_tests/utils/generate_ci_tests.py
+++ b/tests/ci_tests/utils/generate_ci_tests.py
@@ -193,9 +193,12 @@ def generate_job(config: str, config_override: Dict[str, Any], scope: str, test_
         slurm_time = job["variables"].get("TIME", "00:10:00")
         job["variables"]["TIME"] = DQ(slurm_time_multiplier(slurm_time, 2))
 
-    # Generate vLLM deploy job if recipe opts in
+    # Generate vLLM deploy job if recipe opts in.
+    # `ci.vllm_deploy_known_issue_id` suppresses just the vllm_deploy variant
+    # (base job still runs) -- use for bugs that only manifest in vllm deploy.
     vllm_job = None
-    if ci_config.get("vllm_deploy"):
+    vllm_deploy_known_issue_id = ci_config.get("vllm_deploy_known_issue_id")
+    if ci_config.get("vllm_deploy") and not vllm_deploy_known_issue_id:
         vllm_stage = "peft_vllm_deploy" if "peft" in config.stem else "sft_vllm_deploy"
         vllm_job = {
             "extends": ".vllm_deploy_test",

--- a/tests/functional_tests/checkpoint_robustness/test_checkpoint_vllm_deploy.py
+++ b/tests/functional_tests/checkpoint_robustness/test_checkpoint_vllm_deploy.py
@@ -46,8 +46,12 @@ PROMPTS = [
 
 def _extract_custom_args(argv):
     custom_keys = {
-        "--deploy_model_path", "--tokenizer", "--max_new_tokens",
-        "--adapter_path", "--config_path", "--deploy_mode",
+        "--deploy_model_path",
+        "--tokenizer",
+        "--max_new_tokens",
+        "--adapter_path",
+        "--config_path",
+        "--deploy_mode",
     }
     boolean_keys = {"--vllm_smoke_test", "--trust_remote_code"}
     custom = {}
@@ -111,13 +115,16 @@ def _resolve_args(custom_args):
         tokenizer = model_path
 
     # -- flags --
-    trust_remote_code = custom_args.get("trust_remote_code", False)
-    if not trust_remote_code and model_cfg.get("trust_remote_code"):
-        trust_remote_code = True
+    # trust_remote_code placement varies: top-level `model:` or nested under
+    # `ci.checkpoint_robustness:`. Accept any source that says true.
+    ckpt_robustness_cfg = ci_cfg.get("checkpoint_robustness") or {}
+    trust_remote_code = bool(
+        custom_args.get("trust_remote_code")
+        or model_cfg.get("trust_remote_code")
+        or ckpt_robustness_cfg.get("trust_remote_code")
+    )
 
-    smoke_test = custom_args.get("vllm_smoke_test", False)
-    if not smoke_test and ci_cfg.get("vllm_smoke_test"):
-        smoke_test = True
+    smoke_test = bool(custom_args.get("vllm_smoke_test") or ci_cfg.get("vllm_smoke_test"))
 
     max_new_tokens = int(custom_args.get("max_new_tokens", "20"))
 


### PR DESCRIPTION
# What does this PR do ?

  - Infra/launcher fixes for vllm_deploy: `Dockerfile.deploy` forces `mamba-ssm` / `causal-conv1d` source builds (`--no-binary`) so the CUDA extensions link against the container's torch, and `_resolve_args` in`test_checkpoint_vllm_deploy.py` now reads `trust_remote_code` from`ci.checkpoint_robustness` in addition to the top-level `model:` section.
  - New recipe key `ci.vllm_deploy_known_issue_id` lets a recipe skip just its `_vllm_deploy` sibling while leaving the base job unchanged; used to tag `llama3_3_nemotron_super_49B_squad_peft` with AM-176 (model's trust_remote_code module incompatible with transformers 5.5). Also agged `qwen2_5_7b_squad_peft` and `gemma_3_270m_squad_peft` with AM-154 + `allow_failure` (vllm vs. HF greedy token mismatch).

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
