### PR TITLE
ci: add LoRA nightly tests for Wan, Hunyuan, Flux diffusion recipes

### DIFF
--- a/examples/diffusion/finetune/flux_t2i_flow_lora.yaml
+++ b/examples/diffusion/finetune/flux_t2i_flow_lora.yaml
@@ -108,3 +108,7 @@ checkpoint:
   model_save_format: torch_save
   save_consolidated: false
   restore_from: null
+
+ci:
+  recipe_owner: pthombre
+  time: "00:30:00"

--- a/examples/diffusion/finetune/hunyuan_t2v_flow_lora.yaml
+++ b/examples/diffusion/finetune/hunyuan_t2v_flow_lora.yaml
@@ -15,7 +15,10 @@ model:
   # for model-specific setup (no pre-inject hook needed for Hunyuan).
   model_type: "hunyuan"
   mode: "finetune"
-  attention_backend: "flash"
+  # Hunyuan's attention processor passes attn_mask to dispatch_attention_fn,
+  # which flash-attn 2 rejects ("`attn_mask` is not supported for flash-attn 2.").
+  # Use diffusers' native (PyTorch SDPA) backend, which handles attn_mask correctly.
+  attention_backend: "native"
 
 # ── LoRA / PEFT configuration ─────────────────────────────────────────────────
 # Remove this section for full fine-tune.
@@ -103,3 +106,7 @@ checkpoint:
   model_save_format: torch_save
   save_consolidated: false
   restore_from: null
+
+ci:
+  recipe_owner: pthombre
+  time: "01:30:00"

--- a/examples/diffusion/finetune/wan2_1_t2v_flow_lora.yaml
+++ b/examples/diffusion/finetune/wan2_1_t2v_flow_lora.yaml
@@ -94,3 +94,7 @@ checkpoint:
   model_save_format: torch_save
   save_consolidated: false
   restore_from: null
+
+ci:
+  recipe_owner: pthombre
+  time: "00:30:00"

--- a/tests/ci_tests/configs/diffusion_finetune/nightly_recipes.yml
+++ b/tests/ci_tests/configs/diffusion_finetune/nightly_recipes.yml
@@ -18,3 +18,6 @@ configs:
   - hunyuan_t2v_flow.yaml
   - flux_t2i_flow.yaml
   - qwen_image_t2i_flow.yaml
+  - wan2_1_t2v_flow_lora.yaml
+  - hunyuan_t2v_flow_lora.yaml
+  - flux_t2i_flow_lora.yaml

--- a/tests/ci_tests/scripts/diffusion_finetune_launcher.sh
+++ b/tests/ci_tests/scripts/diffusion_finetune_launcher.sh
@@ -64,7 +64,15 @@ case "$RECIPE_NAME" in
         exit 1
         ;;
 esac
-echo "[config] Recipe=$RECIPE_NAME  MediaType=$MEDIA_TYPE  Processor=$PROCESSOR  Model=$MODEL_NAME"
+
+# LoRA recipes are named *_lora.yaml — they save PEFT adapter artifacts
+# (adapter_model.safetensors + adapter_config.json) that generate.py loads via
+# model.lora_weights, not model.checkpoint.
+IS_LORA=false
+if [[ "$RECIPE_NAME" == *_lora ]]; then
+    IS_LORA=true
+fi
+echo "[config] Recipe=$RECIPE_NAME  MediaType=$MEDIA_TYPE  Processor=$PROCESSOR  Model=$MODEL_NAME  LoRA=$IS_LORA"
 
 # ============================================
 # Stage 1: Download dataset
@@ -156,11 +164,23 @@ echo "[inference] Running inference smoke test..."
 echo "============================================"
 CKPT_STEP_DIR=$(ls -d $CKPT_DIR/epoch_*_step_* | sort -t_ -k4 -n | tail -1)
 
+# generate.py loads LoRA adapters from model.lora_weights and consolidated
+# full-finetune checkpoints from model.checkpoint — they are distinct code paths.
+# PEFT saves adapter_model.safetensors + adapter_config.json under the `model/`
+# subdirectory of the step checkpoint; generate.py reads those files from the
+# directory passed to --model.lora_weights without descending further.
+if [ "$IS_LORA" = "true" ]; then
+    CKPT_FLAG="--model.lora_weights"
+    CKPT_STEP_DIR="$CKPT_STEP_DIR/model"
+else
+    CKPT_FLAG="--model.checkpoint"
+fi
+
 if [ "$MEDIA_TYPE" = "image" ]; then
     uv run --extra diffusion python examples/diffusion/generate/generate.py \
         --config "$GENERATE_CONFIG" \
         --model.pretrained_model_name_or_path "$MODEL_NAME" \
-        --model.checkpoint "$CKPT_STEP_DIR" \
+        $CKPT_FLAG "$CKPT_STEP_DIR" \
         --inference.num_inference_steps 5 \
         --output.output_dir "$INFER_DIR" \
         --vae.enable_slicing true \
@@ -176,7 +196,7 @@ else
     uv run --extra diffusion python examples/diffusion/generate/generate.py \
         --config "$GENERATE_CONFIG" \
         --model.pretrained_model_name_or_path "$MODEL_NAME" \
-        --model.checkpoint "$CKPT_STEP_DIR" \
+        $CKPT_FLAG "$CKPT_STEP_DIR" \
         --inference.num_inference_steps 5 \
         --inference.pipeline_kwargs.num_frames "$INFER_NUM_FRAMES" \
         --output.output_dir "$INFER_DIR" \

--- a/tests/ci_tests/utils/generate_ci_tests.py
+++ b/tests/ci_tests/utils/generate_ci_tests.py
@@ -171,8 +171,8 @@ def generate_job(config: str, config_override: Dict[str, Any], scope: str, test_
     elif "benchmark" in config.stem:
         job["stage"] = "benchmark"
     elif test_folder.startswith("diffusion"):
-        job["stage"] = "diffusion_sft"
-    elif "peft" in config.stem:
+        job["stage"] = "diffusion_peft" if ("lora" in config.stem or "peft" in config.stem) else "diffusion_sft"
+    elif "peft" in config.stem or "lora" in config.stem:
         job["stage"] = "peft_ckpt_robustness" if has_robustness else "peft"
     else:
         job["stage"] = "sft_ckpt_robustness" if has_robustness else "sft"


### PR DESCRIPTION
Registers wan2_1_t2v_flow_lora, hunyuan_t2v_flow_lora, flux_t2i_flow_lora in the diffusion nightly pipeline and teaches the launcher to handle PEFT checkpoints so the inference smoke test loads LoRA adapters instead of a consolidated checkpoint.

Changes
- nightly_recipes.yml: append the three LoRA configs.
- diffusion_finetune_launcher.sh: detect *_lora recipes, point generate.py's --model.lora_weights at $CKPT_STEP_DIR/model (where PEFT training writes adapter_model.safetensors + adapter_config.json) instead of --model.checkpoint.
- generate_ci_tests.py: treat configs containing "lora" as peft-stage jobs (diffusion_peft for diffusion, peft for LLM/VLM) — parity with LLM naming.
- *_lora.yaml: add ci: blocks (recipe_owner, time) so the generator emits TIME/RECIPE_OWNER like the full-finetune recipes.
- hunyuan_t2v_flow_lora.yaml: switch attention_backend from "flash" to "native". Hunyuan's attention processor passes attn_mask to dispatch_attention_fn, which flash-attn 2 rejects.

Verified end-to-end on 8xH100, MAX_STEPS=20, all three recipes: adapter files saved under checkpoint/epoch_*_step_*/model/, inference smoke test produced the expected sample_*.png / sample_*.mp4, and the launcher emitted [inference] SUCCESS.

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
