### PR TITLE
ci: cherry-pick #2048 (LoRA nightly tests) to r0.4.0

### DIFF
--- a/examples/diffusion/finetune/flux_t2i_flow_lora.yaml
+++ b/examples/diffusion/finetune/flux_t2i_flow_lora.yaml
@@ -106,3 +106,7 @@ checkpoint:
   model_save_format: torch_save
   save_consolidated: false
   restore_from: null
+
+ci:
+  recipe_owner: pthombre
+  time: "00:30:00"

--- a/examples/diffusion/finetune/hunyuan_t2v_flow_lora.yaml
+++ b/examples/diffusion/finetune/hunyuan_t2v_flow_lora.yaml
@@ -15,7 +15,10 @@ model:
   # for model-specific setup (no pre-inject hook needed for Hunyuan).
   model_type: "hunyuan"
   mode: "finetune"
-  attention_backend: "flash"
+  # Hunyuan's attention processor passes attn_mask to dispatch_attention_fn,
+  # which flash-attn 2 rejects ("`attn_mask` is not supported for flash-attn 2.").
+  # Use diffusers' native (PyTorch SDPA) backend, which handles attn_mask correctly.
+  attention_backend: "native"
 
 # ── LoRA / PEFT configuration ─────────────────────────────────────────────────
 # Remove this section for full fine-tune.
@@ -101,3 +104,7 @@ checkpoint:
   model_save_format: torch_save
   save_consolidated: false
   restore_from: null
+
+ci:
+  recipe_owner: pthombre
+  time: "01:30:00"

--- a/examples/diffusion/finetune/wan2_1_t2v_flow_lora.yaml
+++ b/examples/diffusion/finetune/wan2_1_t2v_flow_lora.yaml
@@ -92,3 +92,7 @@ checkpoint:
   model_save_format: torch_save
   save_consolidated: false
   restore_from: null
+
+ci:
+  recipe_owner: pthombre
+  time: "00:30:00"

--- a/tests/ci_tests/configs/diffusion_finetune/nightly_recipes.yml
+++ b/tests/ci_tests/configs/diffusion_finetune/nightly_recipes.yml
@@ -17,3 +17,6 @@ configs:
   - wan2_1_t2v_flow.yaml
   - hunyuan_t2v_flow.yaml
   - flux_t2i_flow.yaml
+  - wan2_1_t2v_flow_lora.yaml
+  - hunyuan_t2v_flow_lora.yaml
+  - flux_t2i_flow_lora.yaml

--- a/tests/ci_tests/scripts/diffusion_finetune_launcher.sh
+++ b/tests/ci_tests/scripts/diffusion_finetune_launcher.sh
@@ -57,7 +57,15 @@ case "$RECIPE_NAME" in
         exit 1
         ;;
 esac
-echo "[config] Recipe=$RECIPE_NAME  MediaType=$MEDIA_TYPE  Processor=$PROCESSOR  Model=$MODEL_NAME"
+
+# LoRA recipes are named *_lora.yaml — they save PEFT adapter artifacts
+# (adapter_model.safetensors + adapter_config.json) that generate.py loads via
+# model.lora_weights, not model.checkpoint.
+IS_LORA=false
+if [[ "$RECIPE_NAME" == *_lora ]]; then
+    IS_LORA=true
+fi
+echo "[config] Recipe=$RECIPE_NAME  MediaType=$MEDIA_TYPE  Processor=$PROCESSOR  Model=$MODEL_NAME  LoRA=$IS_LORA"
 
 # ============================================
 # Stage 1: Download dataset
@@ -149,11 +157,23 @@ echo "[inference] Running inference smoke test..."
 echo "============================================"
 CKPT_STEP_DIR=$(ls -d $CKPT_DIR/epoch_*_step_* | sort -t_ -k4 -n | tail -1)
 
+# generate.py loads LoRA adapters from model.lora_weights and consolidated
+# full-finetune checkpoints from model.checkpoint — they are distinct code paths.
+# PEFT saves adapter_model.safetensors + adapter_config.json under the `model/`
+# subdirectory of the step checkpoint; generate.py reads those files from the
+# directory passed to --model.lora_weights without descending further.
+if [ "$IS_LORA" = "true" ]; then
+    CKPT_FLAG="--model.lora_weights"
+    CKPT_STEP_DIR="$CKPT_STEP_DIR/model"
+else
+    CKPT_FLAG="--model.checkpoint"
+fi
+
 if [ "$MEDIA_TYPE" = "image" ]; then
     uv run --extra diffusion python examples/diffusion/generate/generate.py \
         --config "$GENERATE_CONFIG" \
         --model.pretrained_model_name_or_path "$MODEL_NAME" \
-        --model.checkpoint "$CKPT_STEP_DIR" \
+        $CKPT_FLAG "$CKPT_STEP_DIR" \
         --inference.num_inference_steps 5 \
         --output.output_dir "$INFER_DIR" \
         --vae.enable_slicing true \
@@ -169,7 +189,7 @@ else
     uv run --extra diffusion python examples/diffusion/generate/generate.py \
         --config "$GENERATE_CONFIG" \
         --model.pretrained_model_name_or_path "$MODEL_NAME" \
-        --model.checkpoint "$CKPT_STEP_DIR" \
+        $CKPT_FLAG "$CKPT_STEP_DIR" \
         --inference.num_inference_steps 5 \
         --inference.pipeline_kwargs.num_frames "$INFER_NUM_FRAMES" \
         --output.output_dir "$INFER_DIR" \

--- a/tests/ci_tests/utils/generate_ci_tests.py
+++ b/tests/ci_tests/utils/generate_ci_tests.py
@@ -171,8 +171,8 @@ def generate_job(config: str, config_override: Dict[str, Any], scope: str, test_
     elif "benchmark" in config.stem:
         job["stage"] = "benchmark"
     elif test_folder.startswith("diffusion"):
-        job["stage"] = "diffusion_sft"
-    elif "peft" in config.stem:
+        job["stage"] = "diffusion_peft" if ("lora" in config.stem or "peft" in config.stem) else "diffusion_sft"
+    elif "peft" in config.stem or "lora" in config.stem:
         job["stage"] = "peft_ckpt_robustness" if has_robustness else "peft"
     else:
         job["stage"] = "sft_ckpt_robustness" if has_robustness else "sft"


### PR DESCRIPTION
## Summary

Manual cherry-pick of #2048 (`ci: add LoRA nightly tests for Wan, Hunyuan, Flux diffusion recipes`) onto `r0.4.0`. Auto-cherrypick failed on a one-line context conflict in `tests/ci_tests/configs/diffusion_finetune/nightly_recipes.yml`: main has a `- qwen_image_t2i_flow.yaml` entry that does not exist on `r0.4.0`, so the patch context didn't match.

Resolution: kept the three new LoRA entries; dropped the qwen line (it isn't on this branch). All other 5 files in #2048 cherry-picked cleanly.

Original commit: `f9e20e914c3a363b02098bfacd488f16786ebf17`.

## Test plan

- [x] `git cherry-pick -x -s f9e20e91...` (commit recorded with sign-off + cherry-picked-from line)
- [x] `ruff check tests/ci_tests/utils/generate_ci_tests.py` — clean
- [x] `bash -n tests/ci_tests/scripts/diffusion_finetune_launcher.sh` — clean
- [x] `generate_ci_tests.py --scope nightly --test-folder diffusion_finetune` produces 6 jobs: 3 full-finetune (wan/hunyuan/flux) + 3 LoRA (wan/hunyuan/flux), all extending `.diffusion_finetune_test`, LoRA jobs in stage `diffusion_peft`
- [x] End-to-end verification of all three LoRA jobs (8×H100, MAX_STEPS=20) was performed on the original PR #2048 — `[inference] SUCCESS` on Flux/Wan/Hunyuan. Code path on r0.4.0 is identical except for unrelated cosmetic differences in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)