### PR TITLE
fix(vlm): broaden fake-image vision-token detection beyond Qwen

### DIFF
--- a/nemo_automodel/components/datasets/vlm/fake_image.py
+++ b/nemo_automodel/components/datasets/vlm/fake_image.py
@@ -28,8 +28,11 @@ keeping the visual encoder active.
 """
 
 import copy
+import logging
 
 from PIL import Image as PILImage
+
+logger = logging.getLogger(__name__)
 
 # Constant 56x56 white PIL image used as the fake placeholder.
 _FAKE_IMAGE = PILImage.new("RGB", (56, 56), (255, 255, 255))
@@ -90,25 +93,127 @@ def inject_fake_image_into_conversation(conversation):
     return conversation
 
 
-def _get_vision_token_ids(processor):
-    """Collect vision token IDs from a processor/tokenizer."""
-    vision_token_ids = set()
+# Attribute names that VLM processors / configs use to expose vision token IDs.
+# Different model families use different names; we scan all of them.
+_VISION_TOKEN_ID_ATTRS = (
+    "image_token_id",  # Qwen2/3-VL, generic HF VLMs (also Gemma3 alias)
+    "video_token_id",  # Qwen2/3-VL
+    "image_token_index",  # LLaVA family, Pixtral/Mistral3, Gemma3
+    "video_token_index",  # LLaVA-OneVision / NeXT-Video
+    "media_placeholder_token_id",  # Kimi K2.5, KimiVL
+    "vision_start_token_id",  # Qwen
+    "vision_end_token_id",  # Qwen
+    "vision_token_id",  # Qwen
+    "image_break_token_id",  # Pixtral / Mistral3
+    "image_end_token_id",  # Pixtral / Mistral3
+    "boi_token_index",  # Gemma3 (begin-of-image)
+    "eoi_token_index",  # Gemma3 (end-of-image)
+    "boi_token_id",  # Gemma3 alias
+    "eoi_token_id",  # Gemma3 alias
+)
 
-    for attr in ("image_token_id", "video_token_id"):
-        tid = getattr(processor, attr, None)
-        if tid is not None:
-            vision_token_ids.add(tid)
+# Explicit vision token strings used across VLM families.
+_VISION_TOKEN_STRINGS = (
+    "<|vision_start|>",
+    "<|vision_end|>",  # Qwen
+    "<|image_pad|>",
+    "<|video_pad|>",  # Qwen
+    "<|media_start|>",
+    "<|media_content|>",  # Kimi K2.5 / KimiVL
+    "<|media_end|>",
+    "<|media_pad|>",  # Kimi K2.5 / KimiVL
+    "<image>",
+    "<video>",  # LLaVA family
+    "<|image|>",
+    "<|video|>",  # Some HF chat templates
+    "[IMG]",
+    "[IMG_END]",
+    "[IMG_BREAK]",  # Pixtral / Mistral3
+)
+
+# Substrings used to fuzzy-match additional vision tokens from the tokenizer's
+# added_tokens_decoder.  Kept short enough to avoid colliding with non-vision
+# tokens like ``<|imagine|>`` (no such real token, but be defensive).
+_VISION_TOKEN_KEYWORDS = ("image", "video", "media", "vision", "img_pad", "vid_pad")
+
+
+def _scan_attrs(source, attr_names):
+    """Yield integer token IDs found via ``getattr`` on *source*."""
+    if source is None:
+        return
+    for attr in attr_names:
+        tid = getattr(source, attr, None)
+        if isinstance(tid, int):
+            yield tid
+
+
+def _get_vision_token_ids(processor):
+    """Collect vision token IDs from a processor / tokenizer / config.
+
+    Walks three sources to be robust across VLM families:
+    1. Known attribute names on the processor *and* its ``config`` (Gemma4,
+       LLaVA put the IDs on the config rather than the processor).
+    2. A curated list of vision token strings looked up via
+       ``tokenizer.convert_tokens_to_ids``.
+    3. A keyword-based fuzzy scan of ``tokenizer.added_tokens_decoder`` so
+       custom or future VLMs are picked up automatically.
+    """
+    vision_token_ids: set[int] = set()
+
+    config = getattr(processor, "config", None)
+    for tid in _scan_attrs(processor, _VISION_TOKEN_ID_ATTRS):
+        vision_token_ids.add(tid)
+    for tid in _scan_attrs(config, _VISION_TOKEN_ID_ATTRS):
+        vision_token_ids.add(tid)
 
     tokenizer = getattr(processor, "tokenizer", processor)
-    for token in ("<|vision_start|>", "<|vision_end|>", "<|image_pad|>", "<|video_pad|>"):
+    unk_id = getattr(tokenizer, "unk_token_id", None)
+
+    for token in _VISION_TOKEN_STRINGS:
         try:
             tid = tokenizer.convert_tokens_to_ids(token)
-            if isinstance(tid, int) and tid != getattr(tokenizer, "unk_token_id", None):
-                vision_token_ids.add(tid)
         except Exception:
-            pass
+            continue
+        if isinstance(tid, int) and tid != unk_id:
+            vision_token_ids.add(tid)
+
+    added = getattr(tokenizer, "added_tokens_decoder", None)
+    if isinstance(added, dict):
+        for tid, tok in added.items():
+            try:
+                tok_str = getattr(tok, "content", str(tok)).lower()
+            except Exception:
+                continue
+            if any(kw in tok_str for kw in _VISION_TOKEN_KEYWORDS):
+                try:
+                    vision_token_ids.add(int(tid))
+                except (TypeError, ValueError):
+                    continue
 
     return vision_token_ids
+
+
+_warned_unknown_processors: set[str] = set()
+
+
+def _warn_no_vision_tokens(processor) -> None:
+    """Log a one-time warning when a processor exposes no recognizable vision tokens.
+
+    Without this warning a fake-image injection silently leaves the vision
+    tokens visible to attention, which can degrade training quality without
+    any other observable symptom.
+    """
+    key = type(processor).__name__
+    if key in _warned_unknown_processors:
+        return
+    _warned_unknown_processors.add(key)
+    logger.warning(
+        "fake_image: could not detect any vision token IDs from processor %s. "
+        "Fake-image vision tokens will NOT be masked from attention. "
+        "If this model uses a non-standard vision token, extend "
+        "_VISION_TOKEN_ID_ATTRS / _VISION_TOKEN_STRINGS in fake_image.py.",
+        key,
+    )
 
 
 def mask_fake_vision_tokens_single(sample_dict, processor):
@@ -117,8 +222,11 @@ def mask_fake_vision_tokens_single(sample_dict, processor):
     Sets ``attention_mask = 0`` for every vision token in *sample_dict*.
     This is used at ``__getitem__`` time for pre-tokenized datasets.
     """
+    if "attention_mask" not in sample_dict:
+        return
     vision_token_ids = _get_vision_token_ids(processor)
-    if not vision_token_ids or "attention_mask" not in sample_dict:
+    if not vision_token_ids:
+        _warn_no_vision_tokens(processor)
         return
 
     input_ids = sample_dict["input_ids"]
@@ -133,8 +241,11 @@ def mask_fake_vision_tokens_batch(batch, processor, sample_indices):
     Sets ``attention_mask = 0`` for every vision token in the given
     *sample_indices* of the batch.
     """
+    if "attention_mask" not in batch or not sample_indices:
+        return
     vision_token_ids = _get_vision_token_ids(processor)
-    if not vision_token_ids or "attention_mask" not in batch or not sample_indices:
+    if not vision_token_ids:
+        _warn_no_vision_tokens(processor)
         return
 
     for idx in sample_indices:

--- a/tests/unit_tests/datasets/vlm/test_fake_image.py
+++ b/tests/unit_tests/datasets/vlm/test_fake_image.py
@@ -150,14 +150,13 @@ class TestGetVisionTokenIdsAddedTokens:
         assert 600 in fake_image._get_vision_token_ids(proc)
 
     def test_non_vision_token_not_matched(self):
+        # "image" is NOT a substring of "imagine" ("imag-e" vs "imag-ine"), so
+        # this token must NOT be matched.  Pins the keyword set's precision:
+        # near-collisions on shared prefixes do not over-trigger.
         added = {700: _StubAddedToken("<|imagine_this|>")}
         tok = _StubTokenizer(added_tokens_decoder=added)
         proc = _StubProcessor(tok)
-        # 'image' substring would erroneously match — keyword set must be tight.
-        # Current implementation accepts 'image' so 'imagine' WILL match.  This test
-        # documents the trade-off: we err on the side of over-masking unknown
-        # tokens that look vision-related rather than under-masking real ones.
-        assert 700 in fake_image._get_vision_token_ids(proc)
+        assert 700 not in fake_image._get_vision_token_ids(proc)
 
     def test_unk_token_excluded(self):
         # convert_tokens_to_ids returning unk_token_id should not pollute the set.

--- a/tests/unit_tests/datasets/vlm/test_fake_image.py
+++ b/tests/unit_tests/datasets/vlm/test_fake_image.py
@@ -1,0 +1,316 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Vision-token detection robustness tests for fake_image.py.
+
+The original implementation only recognized Qwen-style vision tokens
+(``image_token_id`` / ``video_token_id`` attributes plus the
+``<|vision_start|>`` family of strings).  Other VLMs in the codebase use
+different conventions:
+
+- Kimi K2.5 / KimiVL: ``media_placeholder_token_id`` + ``<|media_pad|>``
+- LLaVA family / Mistral4: ``image_token_index`` + ``<image>`` / ``[IMG]``
+- Gemma4: token id lives on ``processor.config``, not the processor itself
+
+Without coverage for these, fake-image vision tokens silently remain visible
+to attention.  These tests pin down the broadened detection logic and the
+warning that fires when no vision tokens can be located at all.
+"""
+
+import logging
+
+import pytest
+import torch
+
+from nemo_automodel.components.datasets.vlm import fake_image
+
+
+class _StubTokenizer:
+    """Minimal tokenizer stand-in: vocab dict + optional unk + optional added tokens."""
+
+    def __init__(self, vocab=None, unk_token_id=0, added_tokens_decoder=None):
+        self._vocab = dict(vocab or {})
+        self.unk_token_id = unk_token_id
+        if added_tokens_decoder is not None:
+            self.added_tokens_decoder = added_tokens_decoder
+
+    def convert_tokens_to_ids(self, token):
+        return self._vocab.get(token, self.unk_token_id)
+
+
+class _StubProcessor:
+    """Minimal processor stand-in.  Accepts any kwargs as attributes."""
+
+    def __init__(self, tokenizer, config=None, **attrs):
+        self.tokenizer = tokenizer
+        if config is not None:
+            self.config = config
+        for k, v in attrs.items():
+            setattr(self, k, v)
+
+
+class _StubAddedToken:
+    """Mimic ``transformers.AddedToken`` so tests don't need transformers."""
+
+    def __init__(self, content):
+        self.content = content
+
+
+@pytest.fixture(autouse=True)
+def _reset_warning_cache():
+    """Each test starts with a clean warning-dedup cache."""
+    fake_image._warned_unknown_processors.clear()
+    yield
+    fake_image._warned_unknown_processors.clear()
+
+
+# ---------------------------------------------------------------------------
+# _get_vision_token_ids — per VLM family
+# ---------------------------------------------------------------------------
+
+
+class TestGetVisionTokenIdsQwen:
+    def test_picks_up_attributes_and_strings(self):
+        tok = _StubTokenizer(
+            {
+                "<|vision_start|>": 100,
+                "<|vision_end|>": 101,
+                "<|image_pad|>": 102,
+                "<|video_pad|>": 103,
+            }
+        )
+        proc = _StubProcessor(tok, image_token_id=102, video_token_id=103)
+        assert fake_image._get_vision_token_ids(proc) == {100, 101, 102, 103}
+
+
+class TestGetVisionTokenIdsKimi:
+    def test_media_placeholder_attr(self):
+        tok = _StubTokenizer({"<|media_pad|>": 163605})
+        proc = _StubProcessor(tok, media_placeholder_token_id=163605)
+        assert 163605 in fake_image._get_vision_token_ids(proc)
+
+    def test_media_pad_string_only(self):
+        # Even without the attribute, the string lookup must catch it.
+        tok = _StubTokenizer({"<|media_pad|>": 163605})
+        proc = _StubProcessor(tok)
+        assert 163605 in fake_image._get_vision_token_ids(proc)
+
+
+class TestGetVisionTokenIdsLlava:
+    def test_image_token_index_and_string(self):
+        tok = _StubTokenizer({"<image>": 32000})
+        proc = _StubProcessor(tok, image_token_index=32000)
+        ids = fake_image._get_vision_token_ids(proc)
+        assert 32000 in ids
+
+
+class TestGetVisionTokenIdsMistral:
+    def test_mistral_bracket_tokens(self):
+        tok = _StubTokenizer({"[IMG]": 10, "[IMG_END]": 11, "[IMG_BREAK]": 12})
+        proc = _StubProcessor(
+            tok,
+            image_token_index=10,
+            image_break_token_id=12,
+            image_end_token_id=11,
+        )
+        ids = fake_image._get_vision_token_ids(proc)
+        assert {10, 11, 12} <= ids
+
+
+class TestGetVisionTokenIdsConfigPath:
+    def test_token_id_on_config(self):
+        # Gemma4 / LLaVA stash IDs on processor.config rather than the processor itself.
+        tok = _StubTokenizer({})
+        config = type("Cfg", (), {"image_token_id": 256000})()
+        proc = _StubProcessor(tok, config=config)
+        assert 256000 in fake_image._get_vision_token_ids(proc)
+
+
+class TestGetVisionTokenIdsAddedTokens:
+    def test_fuzzy_match_image_keyword(self):
+        added = {500: _StubAddedToken("<|custom_image_pad|>")}
+        tok = _StubTokenizer(added_tokens_decoder=added)
+        proc = _StubProcessor(tok)
+        assert 500 in fake_image._get_vision_token_ids(proc)
+
+    def test_fuzzy_match_video_keyword(self):
+        added = {600: _StubAddedToken("<custom_video_marker>")}
+        tok = _StubTokenizer(added_tokens_decoder=added)
+        proc = _StubProcessor(tok)
+        assert 600 in fake_image._get_vision_token_ids(proc)
+
+    def test_non_vision_token_not_matched(self):
+        added = {700: _StubAddedToken("<|imagine_this|>")}
+        tok = _StubTokenizer(added_tokens_decoder=added)
+        proc = _StubProcessor(tok)
+        # 'image' substring would erroneously match — keyword set must be tight.
+        # Current implementation accepts 'image' so 'imagine' WILL match.  This test
+        # documents the trade-off: we err on the side of over-masking unknown
+        # tokens that look vision-related rather than under-masking real ones.
+        assert 700 in fake_image._get_vision_token_ids(proc)
+
+    def test_unk_token_excluded(self):
+        # convert_tokens_to_ids returning unk_token_id should not pollute the set.
+        tok = _StubTokenizer(vocab={}, unk_token_id=0)
+        proc = _StubProcessor(tok)
+        assert fake_image._get_vision_token_ids(proc) == set()
+
+
+class TestGetVisionTokenIdsRobustness:
+    def test_processor_without_tokenizer(self):
+        # Some processors are themselves callable-tokenizers.
+        tok = _StubTokenizer({"<|image_pad|>": 42})
+        # No .tokenizer attr — _get_vision_token_ids should fall back to processor itself.
+        ids = fake_image._get_vision_token_ids(tok)
+        assert 42 in ids
+
+    def test_convert_tokens_to_ids_raises(self):
+        class RaisingTokenizer:
+            unk_token_id = 0
+
+            def convert_tokens_to_ids(self, token):
+                raise RuntimeError("boom")
+
+        proc = _StubProcessor(RaisingTokenizer())
+        # Should not propagate; just returns empty set.
+        assert fake_image._get_vision_token_ids(proc) == set()
+
+    def test_non_int_attribute_ignored(self):
+        tok = _StubTokenizer({})
+        proc = _StubProcessor(tok, image_token_id=[1, 2, 3])
+        assert fake_image._get_vision_token_ids(proc) == set()
+
+
+# ---------------------------------------------------------------------------
+# Warning behavior
+# ---------------------------------------------------------------------------
+
+
+class TestWarningOnUnknownProcessor:
+    def test_warns_when_batch_masking_finds_nothing(self, caplog):
+        tok = _StubTokenizer({})
+        proc = _StubProcessor(tok)
+        batch = {
+            "input_ids": torch.tensor([[1, 2, 3]]),
+            "attention_mask": torch.ones(1, 3, dtype=torch.long),
+        }
+        with caplog.at_level(logging.WARNING, logger=fake_image.logger.name):
+            fake_image.mask_fake_vision_tokens_batch(batch, proc, [0])
+        msgs = [r.message.lower() for r in caplog.records]
+        assert any("could not detect any vision token" in m for m in msgs), msgs
+        # Mask must remain unchanged (the warning is informational only).
+        assert batch["attention_mask"][0].tolist() == [1, 1, 1]
+
+    def test_warns_when_single_masking_finds_nothing(self, caplog):
+        tok = _StubTokenizer({})
+        proc = _StubProcessor(tok)
+        sample = {
+            "input_ids": torch.tensor([1, 2, 3]),
+            "attention_mask": torch.ones(3, dtype=torch.long),
+        }
+        with caplog.at_level(logging.WARNING, logger=fake_image.logger.name):
+            fake_image.mask_fake_vision_tokens_single(sample, proc)
+        assert any("could not detect any vision token" in r.message.lower() for r in caplog.records)
+
+    def test_warns_only_once_per_processor_class(self, caplog):
+        tok = _StubTokenizer({})
+        proc = _StubProcessor(tok)
+        batch = {
+            "input_ids": torch.tensor([[1, 2, 3]]),
+            "attention_mask": torch.ones(1, 3, dtype=torch.long),
+        }
+        with caplog.at_level(logging.WARNING, logger=fake_image.logger.name):
+            fake_image.mask_fake_vision_tokens_batch(batch, proc, [0])
+            fake_image.mask_fake_vision_tokens_batch(batch, proc, [0])
+            fake_image.mask_fake_vision_tokens_batch(batch, proc, [0])
+        warnings = [r for r in caplog.records if "could not detect any vision token" in r.message.lower()]
+        assert len(warnings) == 1
+
+    def test_no_warning_when_indices_empty(self, caplog):
+        tok = _StubTokenizer({})
+        proc = _StubProcessor(tok)
+        batch = {
+            "input_ids": torch.tensor([[1, 2, 3]]),
+            "attention_mask": torch.ones(1, 3, dtype=torch.long),
+        }
+        with caplog.at_level(logging.WARNING, logger=fake_image.logger.name):
+            fake_image.mask_fake_vision_tokens_batch(batch, proc, [])
+        assert not any("could not detect any vision token" in r.message.lower() for r in caplog.records)
+
+    def test_no_warning_when_tokens_resolved(self, caplog):
+        tok = _StubTokenizer({"<|media_pad|>": 99})
+        proc = _StubProcessor(tok, media_placeholder_token_id=99)
+        batch = {
+            "input_ids": torch.tensor([[99, 1, 99]]),
+            "attention_mask": torch.ones(1, 3, dtype=torch.long),
+        }
+        with caplog.at_level(logging.WARNING, logger=fake_image.logger.name):
+            fake_image.mask_fake_vision_tokens_batch(batch, proc, [0])
+        assert not any("could not detect any vision token" in r.message.lower() for r in caplog.records)
+        # And the masking actually worked.
+        assert batch["attention_mask"][0].tolist() == [0, 1, 0]
+
+
+# ---------------------------------------------------------------------------
+# End-to-end masking with the broadened detection
+# ---------------------------------------------------------------------------
+
+
+class TestMaskingIntegration:
+    def test_masks_kimi_media_pad(self):
+        MEDIA_PAD = 163605
+        tok = _StubTokenizer({"<|media_pad|>": MEDIA_PAD})
+        proc = _StubProcessor(tok, media_placeholder_token_id=MEDIA_PAD)
+        batch = {
+            "input_ids": torch.tensor([[1, MEDIA_PAD, MEDIA_PAD, 4, 5]]),
+            "attention_mask": torch.ones(1, 5, dtype=torch.long),
+        }
+        fake_image.mask_fake_vision_tokens_batch(batch, proc, [0])
+        assert batch["attention_mask"][0].tolist() == [1, 0, 0, 1, 1]
+
+    def test_masks_mistral_bracket_tokens(self):
+        IMG, IMG_END, IMG_BREAK = 10, 11, 12
+        tok = _StubTokenizer({"[IMG]": IMG, "[IMG_END]": IMG_END, "[IMG_BREAK]": IMG_BREAK})
+        proc = _StubProcessor(tok, image_token_index=IMG)
+        batch = {
+            "input_ids": torch.tensor([[1, IMG, IMG_BREAK, IMG, IMG_END, 6]]),
+            "attention_mask": torch.ones(1, 6, dtype=torch.long),
+        }
+        fake_image.mask_fake_vision_tokens_batch(batch, proc, [0])
+        assert batch["attention_mask"][0].tolist() == [1, 0, 0, 0, 0, 1]
+
+    def test_masks_token_id_from_config(self):
+        IMG = 256000
+        tok = _StubTokenizer({})
+        config = type("Cfg", (), {"image_token_id": IMG})()
+        proc = _StubProcessor(tok, config=config)
+        batch = {
+            "input_ids": torch.tensor([[1, IMG, 3]]),
+            "attention_mask": torch.ones(1, 3, dtype=torch.long),
+        }
+        fake_image.mask_fake_vision_tokens_batch(batch, proc, [0])
+        assert batch["attention_mask"][0].tolist() == [1, 0, 1]
+
+    def test_does_not_touch_unflagged_samples(self):
+        IMG = 7
+        tok = _StubTokenizer({})
+        proc = _StubProcessor(tok, image_token_id=IMG)
+        batch = {
+            "input_ids": torch.tensor([[IMG, 1, IMG], [IMG, 2, IMG]]),
+            "attention_mask": torch.ones(2, 3, dtype=torch.long),
+        }
+        fake_image.mask_fake_vision_tokens_batch(batch, proc, [1])
+        # Sample 0: untouched.
+        assert batch["attention_mask"][0].tolist() == [1, 1, 1]
+        # Sample 1: masked.
+        assert batch["attention_mask"][1].tolist() == [0, 1, 0]


### PR DESCRIPTION
## Summary

The fake-image hack injects a 56×56 white image into pure-text samples so
the visual encoder stays active under FSDP / DeepSpeed Zero3 (every parameter
must participate in the all-gather collective, or training hangs).  Its
correctness depends on masking the resulting vision tokens out of attention
via `mask_fake_vision_tokens_batch` / `mask_fake_vision_tokens_single`.

The previous `_get_vision_token_ids` was copy-pasted from Qwen and only
recognised:
- `image_token_id` / `video_token_id` processor attributes
- four `<|vision_start|>`-family token strings

For non-Qwen models this silently returned an empty set, so the masking
step was a no-op and fake-image vision tokens remained visible to attention.

### Confirmed impact per model family

| Model family | Collate path | Status before this fix |
|---|---|---|
| Qwen2.5-VL / Qwen3-VL | `qwen2_5_collate_fn` | ✅ Working — `image_token_id` found |
| **Kimi K2.5 / KimiVL** | `kimi_k25_vl_collate_fn` / `kimi_vl_collate_fn` | ❌ **Full bug** — `media_placeholder_token_id` not scanned, `<\|media_pad\|>` not in string list |
| **Gemma3 / Gemma4** | `default_collate_fn` (via `gemma4_prefix_collate_fn`) | ❌ **Full bug** — `image_token_id` only accessible via `config.attribute_map`, not on processor directly; tokenizer uses `<image>` not `<\|image_pad\|>` |
| **Pixtral / Mistral3** | `default_collate_fn` | ⚠️ **Partial bug** — `image_token_id` found so `[IMG]` is masked, but `image_break_token_id` (`[IMG_BREAK]`) and `image_end_token_id` (`[IMG_END]`) were missed |
| LLaVA-OneVision | `llava_onevision_collate_fn` | ❓ Uncertain — Qwen2-based tokenizer likely has `<\|image_pad\|>` at id 151655, but actual image token is id 151646; needs real processor to verify |

Both trigger paths are affected:
- **`__getitem__` path** (`datasets.py:963–1063`): unconditionally active for any pure-text sample — no `preload_media` flag required
- **`collate_fn` path**: activated when `_injected_fake=True` (requires `preload_media=True`)

## Changes

**`nemo_automodel/components/datasets/vlm/fake_image.py`**
- Extend `_get_vision_token_ids` to scan three sources:
  1. 14 known processor / `processor.config` attribute names, covering
     Qwen (`image_token_id`, `vision_start/end_token_id`, …),
     Kimi (`media_placeholder_token_id`),
     LLaVA / Mistral3 / Gemma3 (`image_token_index`, `boi/eoi_token_index`, …),
     Pixtral (`image_break_token_id`, `image_end_token_id`)
  2. 13 curated vision token strings (`<\|media_pad\|>`, `<image>`, `[IMG]`, …)
  3. Keyword fuzzy scan over `tokenizer.added_tokens_decoder` for automatic
     coverage of future or custom VLMs
- Add `_warn_no_vision_tokens`: emit a **one-time `logger.warning`** per
  processor class when detection finds nothing, turning a silent no-op into
  a visible signal

**`tests/unit_tests/datasets/vlm/test_fake_image.py`** (new file)
- 22 unit tests covering Qwen / Kimi / LLaVA / Mistral / Gemma3 detection
  paths, `processor.config` attribute path, `added_tokens_decoder` fuzzy
  match, robustness edge cases (raising tokenizer, non-int attribute),
  warning emission, and one-shot dedup — all mocked, no GPU or model weights
  required

## Test plan
- [x] `ruff format` / `ruff check` clean
- [x] 22/22 unit tests pass on GPU server (Python 3.12, pytest 9.0.2)
- [ ] CI green on `NVIDIA-NeMo/Automodel`