### PR TITLE
fix(vlm): support multi-image token expansion in _expand_image_tokens

### DIFF
--- a/nemo_automodel/components/datasets/vlm/collate_fns.py
+++ b/nemo_automodel/components/datasets/vlm/collate_fns.py
@@ -776,54 +776,62 @@ def _expand_image_tokens(
     media_token_id: int,
     merge_kernel_size: Tuple[int, int] = _DEFAULT_MERGE_KERNEL,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Expand single image placeholder tokens to the correct number based on grid_thws.
+    """Expand image placeholder tokens to the correct patch counts based on grid_thws.
 
     For PP, this ensures the sequence length is fixed BEFORE the model forward pass,
     eliminating dynamic sequence expansion inside the model.
 
-    Assumes 1 image per sample (1 placeholder per sequence).
+    Supports both single-image and multi-image samples.  Each placeholder token is
+    expanded to ``(h // merge_h) * (w // merge_w)`` tokens using the corresponding
+    entry in *grid_thws*.  The number of placeholders must match ``grid_thws.shape[0]``.
 
     Args:
-        input_ids: (seq_len,) tensor with 1 media_token_id placeholder
-        attention_mask: (seq_len,) tensor
-        grid_thws: (1, 3) tensor with [t, h, w] for the single image
-        media_token_id: Token ID of the image placeholder
-        merge_kernel_size: Vision tower's patch merge kernel, default (2, 2)
+        input_ids: (seq_len,) tensor containing one ``media_token_id`` per image.
+        attention_mask: (seq_len,) tensor aligned with *input_ids*.
+        grid_thws: (N, 3) tensor with ``[t, h, w]`` for each of the N images.
+        media_token_id: Token ID used as the image placeholder.
+        merge_kernel_size: Vision tower's patch merge kernel, default (2, 2).
 
     Returns:
-        expanded_input_ids: Input IDs with placeholder expanded to N tokens
-        expanded_attention_mask: Attention mask expanded accordingly
+        expanded_input_ids: Input IDs with each placeholder expanded to its patch count.
+        expanded_attention_mask: Attention mask expanded accordingly.
+
+    Raises:
+        ValueError: When the number of placeholders does not match ``grid_thws.shape[0]``.
     """
     merge_h, merge_w = merge_kernel_size
 
-    # Calculate number of image tokens: (h // merge_h) * (w // merge_w)
-    t, h, w = grid_thws[0].tolist()
-    num_image_tokens = (h // merge_h) * (w // merge_w)
-
-    # Find the placeholder position
     placeholder_positions = (input_ids == media_token_id).nonzero(as_tuple=True)[0]
     if len(placeholder_positions) == 0:
-        # No placeholder found, return as-is
         return input_ids, attention_mask
 
-    # For 1 image per sample, there should be exactly 1 placeholder
-    placeholder_pos = placeholder_positions[0].item()
+    n_placeholders = len(placeholder_positions)
+    n_images = grid_thws.shape[0]
+    if n_placeholders != n_images:
+        raise ValueError(
+            f"_expand_image_tokens: found {n_placeholders} placeholder(s) in input_ids "
+            f"but grid_thws has {n_images} row(s). They must match."
+        )
 
-    # Build expanded tensors
-    before = input_ids[:placeholder_pos]
-    after = input_ids[placeholder_pos + 1 :]
+    # Rebuild input_ids and attention_mask by expanding each placeholder in order.
+    # We iterate through the placeholder positions; between consecutive placeholders
+    # we copy the original tokens unchanged.
+    pieces_ids: List[torch.Tensor] = []
+    pieces_mask: List[torch.Tensor] = []
+    cursor = 0
+    for placeholder_pos, (_, h, w) in zip(placeholder_positions.tolist(), grid_thws.tolist()):
+        n_tokens = (int(h) // merge_h) * (int(w) // merge_w)
+        pieces_ids.append(input_ids[cursor:placeholder_pos])
+        pieces_mask.append(attention_mask[cursor:placeholder_pos])
+        pieces_ids.append(torch.full((n_tokens,), media_token_id, dtype=input_ids.dtype))
+        pieces_mask.append(torch.ones(n_tokens, dtype=attention_mask.dtype))
+        cursor = placeholder_pos + 1
 
-    # Expand: replace 1 placeholder with num_image_tokens placeholders
-    expanded_placeholder = torch.full((num_image_tokens,), media_token_id, dtype=input_ids.dtype)
-    expanded_input_ids = torch.cat([before, expanded_placeholder, after])
+    # Append tokens after the last placeholder
+    pieces_ids.append(input_ids[cursor:])
+    pieces_mask.append(attention_mask[cursor:])
 
-    # Expand attention mask similarly
-    before_mask = attention_mask[:placeholder_pos]
-    after_mask = attention_mask[placeholder_pos + 1 :]
-    expanded_mask_tokens = torch.ones(num_image_tokens, dtype=attention_mask.dtype)
-    expanded_attention_mask = torch.cat([before_mask, expanded_mask_tokens, after_mask])
-
-    return expanded_input_ids, expanded_attention_mask
+    return torch.cat(pieces_ids), torch.cat(pieces_mask)
 
 
 def kimi_k25_vl_collate_fn(

--- a/tests/unit_tests/datasets/vlm/test_collate_fns.py
+++ b/tests/unit_tests/datasets/vlm/test_collate_fns.py
@@ -867,6 +867,85 @@ class TestExpandImageTokens:
         assert expanded_ids.dtype == torch.int32
         assert expanded_mask.dtype == torch.int64
 
+    def test_expand_image_tokens_multi_image_different_sizes(self, collate_mod):
+        """Multi-image: two placeholders with different grid sizes."""
+        media_token_id = 163605
+        # [BOS, PH1, TEXT, PH2, EOS]
+        input_ids = torch.tensor([1, media_token_id, 99, media_token_id, 2])
+        attention_mask = torch.ones(5, dtype=torch.long)
+
+        # First image: [1,2,2] -> (2//2)*(2//2) = 1 token
+        # Second image: [1,4,4] -> (4//2)*(4//2) = 4 tokens
+        grid_thws = torch.tensor([[1, 2, 2], [1, 4, 4]])
+
+        expanded_ids, expanded_mask = collate_mod._expand_image_tokens(
+            input_ids, attention_mask, grid_thws, media_token_id
+        )
+
+        # 5 - 2 placeholders + 1 + 4 = 8 tokens
+        assert expanded_ids.shape[0] == 8
+        assert expanded_mask.shape[0] == 8
+
+        # [1, media*1, 99, media*4, 2]
+        assert expanded_ids[0] == 1
+        assert expanded_ids[1] == media_token_id
+        assert expanded_ids[2] == 99
+        assert (expanded_ids[3:7] == media_token_id).all()
+        assert expanded_ids[7] == 2
+
+    def test_expand_image_tokens_multi_image_same_size(self, collate_mod):
+        """Multi-image: two placeholders with identical grid sizes."""
+        media_token_id = 163605
+        input_ids = torch.tensor([media_token_id, 50, media_token_id])
+        attention_mask = torch.ones(3, dtype=torch.long)
+
+        # Both images: [1,4,4] -> 4 tokens each
+        grid_thws = torch.tensor([[1, 4, 4], [1, 4, 4]])
+
+        expanded_ids, expanded_mask = collate_mod._expand_image_tokens(
+            input_ids, attention_mask, grid_thws, media_token_id
+        )
+
+        # 3 - 2 + 4 + 4 = 9 tokens
+        assert expanded_ids.shape[0] == 9
+        assert (expanded_ids[0:4] == media_token_id).all()
+        assert expanded_ids[4] == 50
+        assert (expanded_ids[5:9] == media_token_id).all()
+
+    def test_expand_image_tokens_three_images(self, collate_mod):
+        """Multi-image: three placeholders each with 4-token expansion."""
+        media_token_id = 163605
+        input_ids = torch.tensor([1, media_token_id, 2, media_token_id, 3, media_token_id, 4])
+        attention_mask = torch.ones(7, dtype=torch.long)
+
+        # All three: [1,4,4] -> 4 tokens each
+        grid_thws = torch.tensor([[1, 4, 4], [1, 4, 4], [1, 4, 4]])
+
+        expanded_ids, expanded_mask = collate_mod._expand_image_tokens(
+            input_ids, attention_mask, grid_thws, media_token_id
+        )
+
+        # 7 - 3 + 4*3 = 16 tokens
+        assert expanded_ids.shape[0] == 16
+        assert expanded_mask.shape[0] == 16
+
+        # Spot-check non-image tokens
+        assert expanded_ids[0] == 1
+        assert expanded_ids[5] == 2
+        assert expanded_ids[10] == 3
+        assert expanded_ids[15] == 4
+
+    def test_expand_image_tokens_mismatch_raises(self, collate_mod):
+        """ValueError when placeholder count does not match grid_thws rows."""
+        media_token_id = 163605
+        # Two placeholders but only one grid entry
+        input_ids = torch.tensor([media_token_id, 5, media_token_id])
+        attention_mask = torch.ones(3, dtype=torch.long)
+        grid_thws = torch.tensor([[1, 4, 4]])
+
+        with pytest.raises(ValueError, match="placeholder"):
+            collate_mod._expand_image_tokens(input_ids, attention_mask, grid_thws, media_token_id)
+
 
 # =============================================================================
 # Tests for kimi_k25_vl_collate_fn
@@ -1966,12 +2045,12 @@ class TestBuildLabelsFromTemplate:
 # ---------------------------------------------------------------------------
 
 # Synthetic token IDs for a Gemma4-style tokenizer.
-_SOT = 2       # <start_of_turn>
+_SOT = 2  # <start_of_turn>
 _USER_TK = 1645  # "user"
 _MODEL_TK = 2516  # "model"
-_NL = 108      # "\n"
-_EOT = 107     # <end_of_turn>
-_U_CONTENT = 506   # "u"
+_NL = 108  # "\n"
+_EOT = 107  # <end_of_turn>
+_U_CONTENT = 506  # "u"
 # sentinel encoded as two distinct ids
 _SEN_A = 999
 _SEN_B = 888


### PR DESCRIPTION
## Problem

`_expand_image_tokens` in `collate_fns.py` assumed **exactly one image per sample** by hard-coding `grid_thws[0]` and `placeholder_positions[0]`. For multi-image conversations (e.g. Kimi K2.5 VL with several images per turn), only the first placeholder was expanded correctly; the remaining placeholders were left as single dummy tokens. This causes a sequence-length / shape mismatch at the PP (Pipeline Parallelism) boundary, leading to incorrect outputs or runtime errors.

## Fix

- Replace the single-image path with a loop that pairs each placeholder position with its corresponding `grid_thws` row, building the expanded sequence piece-by-piece.
- Add a `ValueError` guard when the placeholder count does not match `grid_thws.shape[0]`, making mismatches immediately visible instead of silently corrupting the batch.
- Update the docstring to reflect `(N, 3)` grid shape and the new `Raises` section.

## Tests

Added 4 new unit tests to `TestExpandImageTokens`:

| Test | What it covers |
|---|---|
| `test_expand_image_tokens_multi_image_different_sizes` | 2 images with different grid sizes |
| `test_expand_image_tokens_multi_image_same_size` | 2 images with identical grids |
| `test_expand_image_tokens_three_images` | 3 images |
| `test_expand_image_tokens_mismatch_raises` | `ValueError` on placeholder/grid count mismatch |

All 10 tests in `TestExpandImageTokens` pass (6 pre-existing + 4 new).

## Checklist

- [x] No GPU / real weights required — pure-torch mock tests
- [x] Existing single-image tests unchanged and still pass
- [x] `ruff format` + `ruff check` clean
- [x] DCO sign-off included