### PR TITLE
fix(vlm): use build_labels_from_template in kimi_vl_collate_fn

### DIFF
--- a/nemo_automodel/components/datasets/vlm/collate_fns.py
+++ b/nemo_automodel/components/datasets/vlm/collate_fns.py
@@ -742,7 +742,7 @@ def kimi_vl_collate_fn(
 
     batch = processor(**processor_kwargs)
 
-    labels = build_labels(
+    labels = build_labels_from_template(
         batch["input_ids"],
         conversations,
         processor,

--- a/tests/unit_tests/datasets/vlm/test_collate_fns.py
+++ b/tests/unit_tests/datasets/vlm/test_collate_fns.py
@@ -599,7 +599,7 @@ def test_kimi_vl_collate_fn_shapes(collate_mod, monkeypatch):
     """Test kimi_vl_collate_fn produces correct output shapes."""
     processor = DummyKimiVLProcessor()
 
-    # Stub build_labels to return deterministic labels
+    # Stub build_labels_from_template to return deterministic labels
     # The collate fn does labels[:, 1:] so we need 5 elements to get 4 after shift
     labels_stub = torch.tensor([[10, 11, 12, 13, 14]], dtype=torch.long)
 
@@ -607,7 +607,7 @@ def test_kimi_vl_collate_fn_shapes(collate_mod, monkeypatch):
         assert processor_arg is processor
         return labels_stub
 
-    monkeypatch.setattr(collate_mod, "build_labels", fake_build_labels, raising=True)
+    monkeypatch.setattr(collate_mod, "build_labels_from_template", fake_build_labels, raising=True)
 
     examples = [{"conversation": CONVERSATION}]
     batch = collate_mod.kimi_vl_collate_fn(examples, processor)
@@ -623,7 +623,7 @@ def test_kimi_vl_collate_fn_with_max_length(collate_mod, monkeypatch):
     processor = DummyKimiVLProcessor()
 
     labels_stub = torch.tensor([[10, 11, 12, 13, 14]], dtype=torch.long)
-    monkeypatch.setattr(collate_mod, "build_labels", lambda *args, **kwargs: labels_stub, raising=True)
+    monkeypatch.setattr(collate_mod, "build_labels_from_template", lambda *args, **kwargs: labels_stub, raising=True)
 
     examples = [{"conversation": CONVERSATION}]
     collate_mod.kimi_vl_collate_fn(examples, processor, max_length=2048)
@@ -639,7 +639,7 @@ def test_kimi_vl_collate_fn_extracts_images(collate_mod, monkeypatch):
     processor = DummyKimiVLProcessor()
 
     labels_stub = torch.tensor([[10, 11, 12, 13, 14]], dtype=torch.long)
-    monkeypatch.setattr(collate_mod, "build_labels", lambda *args, **kwargs: labels_stub, raising=True)
+    monkeypatch.setattr(collate_mod, "build_labels_from_template", lambda *args, **kwargs: labels_stub, raising=True)
 
     conversation_with_image = [
         {
@@ -666,7 +666,7 @@ def test_kimi_vl_collate_fn_passes_add_special_tokens_false(collate_mod, monkeyp
     processor = DummyKimiVLProcessor()
 
     labels_stub = torch.tensor([[10, 11, 12, 13, 14]], dtype=torch.long)
-    monkeypatch.setattr(collate_mod, "build_labels", lambda *args, **kwargs: labels_stub, raising=True)
+    monkeypatch.setattr(collate_mod, "build_labels_from_template", lambda *args, **kwargs: labels_stub, raising=True)
 
     examples = [{"conversation": CONVERSATION}]
     collate_mod.kimi_vl_collate_fn(examples, processor)
@@ -685,7 +685,7 @@ def test_kimi_vl_collate_fn_multiple_examples(collate_mod, monkeypatch):
         batch_size = input_ids.shape[0]
         return torch.arange(1, 6).unsqueeze(0).repeat(batch_size, 1)
 
-    monkeypatch.setattr(collate_mod, "build_labels", fake_build_labels, raising=True)
+    monkeypatch.setattr(collate_mod, "build_labels_from_template", fake_build_labels, raising=True)
 
     examples = [{"conversation": CONVERSATION} for _ in range(3)]
     batch = collate_mod.kimi_vl_collate_fn(examples, processor)
@@ -1966,12 +1966,12 @@ class TestBuildLabelsFromTemplate:
 # ---------------------------------------------------------------------------
 
 # Synthetic token IDs for a Gemma4-style tokenizer.
-_SOT = 2       # <start_of_turn>
+_SOT = 2  # <start_of_turn>
 _USER_TK = 1645  # "user"
 _MODEL_TK = 2516  # "model"
-_NL = 108      # "\n"
-_EOT = 107     # <end_of_turn>
-_U_CONTENT = 506   # "u"
+_NL = 108  # "\n"
+_EOT = 107  # <end_of_turn>
+_U_CONTENT = 506  # "u"
 # sentinel encoded as two distinct ids
 _SEN_A = 999
 _SEN_B = 888


### PR DESCRIPTION
## Problem

`kimi_vl_collate_fn` was calling `build_labels` to construct training labels. `build_labels` re-tokenizes the assistant text **standalone** and then searches for that token sequence inside the full `input_ids` via `_find_pattern_indices`.

Due to BPE context sensitivity, standalone tokenization can produce different token IDs than in-context tokenization:

```
# standalone
tokenizer("sure") → [1234]

# in-context (same word, different boundary due to surrounding tokens)
tokenizer("...Assistant: sure<|im_end|>") → [..., 5678]
```

When `_find_pattern_indices` fails to find a match, the sample's labels stay all `-100`. That sample contributes **zero loss silently** — the forward pass still runs (consuming GPU compute), but no gradient flows and the training data is effectively wasted.

## Fix

Replace `build_labels` with `build_labels_from_template` in `kimi_vl_collate_fn`. This function locates assistant turns by scanning `input_ids` for the structural markers the chat template inserts (special-token IDs that are fixed regardless of BPE context), so matching cannot fail. It falls back to `build_labels` only if no markers can be derived, making the change safe for all tokenizer types.

This brings `kimi_vl_collate_fn` in line with `kimi_k25_vl_collate_fn`, which already used `build_labels_from_template`.

## Tests

Updated the five `kimi_vl_collate_fn` unit tests to monkeypatch `build_labels_from_template` instead of `build_labels`. All 6 tests pass.

## Checklist

- [x] One-line production change, zero behaviour change for correct samples
- [x] `ruff format` + `ruff check` clean
- [x] DCO sign-off included