### PR TITLE
fix(vlm): use build_labels_from_template in phi4_mm_collate_fn

### DIFF
--- a/nemo_automodel/components/datasets/vlm/collate_fns.py
+++ b/nemo_automodel/components/datasets/vlm/collate_fns.py
@@ -496,7 +496,7 @@ def phi4_mm_collate_fn(examples, processor):
         else:
             batch["input_mode"] = 0
 
-    labels = build_labels(
+    labels = build_labels_from_template(
         batch["input_ids"],
         conversations,
         processor,
@@ -1644,8 +1644,8 @@ def gemma4_prefix_collate_fn(
 
     Wraps ``default_collate_fn`` and injects ``<|channel>thought\\n<channel|>``
     after every ``<|turn>model\\n`` marker before labels are built.  The injected
-    tokens are automatically masked to -100 by ``build_labels`` (which only
-    unmasks tokens matching the assistant answer text), so the model sees its
+    tokens are automatically masked to -100 by ``build_labels_from_template``
+    (which only unmasks tokens inside assistant turns), so the model sees its
     expected thinking prefix without being penalised for it.
     """
 

--- a/tests/unit_tests/datasets/vlm/test_collate_fns.py
+++ b/tests/unit_tests/datasets/vlm/test_collate_fns.py
@@ -333,7 +333,7 @@ def test_phi4_mm_collate_fn_handles_audio_and_trimming(collate_mod, monkeypatch)
         captured["processor"] = processor_arg
         return labels_stub
 
-    monkeypatch.setattr(collate_mod, "build_labels", fake_build_labels, raising=True)
+    monkeypatch.setattr(collate_mod, "build_labels_from_template", fake_build_labels, raising=True)
 
     batch = collate_mod.phi4_mm_collate_fn(examples, processor)
 
@@ -381,7 +381,10 @@ def test_phi4_mm_collate_fn_input_mode_from_processor(collate_mod, monkeypatch):
 
     examples = [{"conversation": CONVERSATION, "audio": {"array": [0.1], "sampling_rate": 16000}}]
     monkeypatch.setattr(
-        collate_mod, "build_labels", lambda *a, **kw: torch.tensor([[1, 2, 3]], dtype=torch.long), raising=True
+        collate_mod,
+        "build_labels_from_template",
+        lambda *a, **kw: torch.tensor([[1, 2, 3]], dtype=torch.long),
+        raising=True,
     )
     batch = collate_mod.phi4_mm_collate_fn(examples, Phi4ProcessorWithInputMode())
     assert torch.equal(batch["input_mode"], torch.tensor([2]))
@@ -405,7 +408,10 @@ def test_phi4_mm_collate_fn_input_mode_fallback(collate_mod, monkeypatch):
 
     examples = [{"conversation": CONVERSATION, "audio": {"array": [0.1], "sampling_rate": 16000}}]
     monkeypatch.setattr(
-        collate_mod, "build_labels", lambda *a, **kw: torch.tensor([[1, 2, 3]], dtype=torch.long), raising=True
+        collate_mod,
+        "build_labels_from_template",
+        lambda *a, **kw: torch.tensor([[1, 2, 3]], dtype=torch.long),
+        raising=True,
     )
     batch = collate_mod.phi4_mm_collate_fn(examples, Phi4ProcessorWithAudioEmbeds())
     assert batch["input_mode"] == 2  # SPEECH
@@ -421,7 +427,10 @@ def test_phi4_mm_collate_fn_raw_audio_passthrough(collate_mod, monkeypatch):
         {"conversation": CONVERSATION, "audio": raw_array},
     ]
     monkeypatch.setattr(
-        collate_mod, "build_labels", lambda *a, **kw: torch.tensor([[1, 2, 3]], dtype=torch.long), raising=True
+        collate_mod,
+        "build_labels_from_template",
+        lambda *a, **kw: torch.tensor([[1, 2, 3]], dtype=torch.long),
+        raising=True,
     )
     collate_mod.phi4_mm_collate_fn(examples, processor)
     # The raw array should be wrapped as a single-element tuple by the collate fn
@@ -1966,12 +1975,12 @@ class TestBuildLabelsFromTemplate:
 # ---------------------------------------------------------------------------
 
 # Synthetic token IDs for a Gemma4-style tokenizer.
-_SOT = 2       # <start_of_turn>
+_SOT = 2  # <start_of_turn>
 _USER_TK = 1645  # "user"
 _MODEL_TK = 2516  # "model"
-_NL = 108      # "\n"
-_EOT = 107     # <end_of_turn>
-_U_CONTENT = 506   # "u"
+_NL = 108  # "\n"
+_EOT = 107  # <end_of_turn>
+_U_CONTENT = 506  # "u"
 # sentinel encoded as two distinct ids
 _SEN_A = 999
 _SEN_B = 888


### PR DESCRIPTION
## Problem

`phi4_mm_collate_fn` was calling `build_labels` to construct training labels. `build_labels` re-tokenizes the assistant text **standalone** and searches for that token sequence inside the full `input_ids` via `_find_pattern_indices`.

Due to BPE context sensitivity, standalone tokenization can produce different token IDs than in-context tokenization:

```
# standalone
tokenizer("sure") → [1234]

# in-context (same word, different boundary due to surrounding tokens)
tokenizer("...Assistant: sure<|im_end|>") → [..., 5678]
```

When `_find_pattern_indices` fails to find a match, the sample's labels stay all `-100`. That sample contributes **zero loss silently** — the forward pass still runs (consuming GPU compute), but no gradient flows and the training data is effectively wasted.

## Fix

- Replace `build_labels` with `build_labels_from_template` in `phi4_mm_collate_fn`. This function locates assistant turns via structural chat-template markers and falls back to `build_labels` only if no markers can be derived, making the change safe for all tokenizer types.
- Fix a stale docstring in `gemma4_prefix_collate_fn` that incorrectly referenced `build_labels` when the function actually uses `build_labels_from_template` via `default_collate_fn`.

This is the same fix applied to `kimi_vl_collate_fn` in #2060.

## Tests

Updated the four affected `phi4_mm_collate_fn` unit tests to monkeypatch `build_labels_from_template` instead of `build_labels`. All 4 tests pass.

## Checklist

- [x] One-line production change, zero behaviour change for correct samples
- [x] `ruff format` + `ruff check` clean
- [x] DCO sign-off included