### PR TITLE
fix(vlm): mask fake vision tokens in kimi_k25_vl_collate_fn

### DIFF
--- a/nemo_automodel/components/datasets/vlm/collate_fns.py
+++ b/nemo_automodel/components/datasets/vlm/collate_fns.py
@@ -845,6 +845,7 @@ def kimi_k25_vl_collate_fn(
     # Optionally drop overlong samples before processing
     if max_length is not None and drop_overlong:
         conversations, _kept = _drop_overlong_samples(conversations, processor, max_length)
+        examples = [examples[i] for i in _kept]
 
     # Get media token ID
     media_token_id = getattr(processor, "media_placeholder_token_id", None)
@@ -858,6 +859,7 @@ def kimi_k25_vl_collate_fn(
     # Process each sample individually, dropping any that exceed max_length
     # after token expansion.
     kept_conversations = []
+    kept_examples = []
     all_expanded = []
     all_pixel_values = []
     all_grid_thws = []
@@ -909,6 +911,7 @@ def kimi_k25_vl_collate_fn(
                 attention_mask = attention_mask[:max_length]
 
         kept_conversations.append(conversation)
+        kept_examples.append(examples[i])
 
         # Only include image data if all expanded image tokens survived truncation.
         # Partial truncation into image regions would cause a mismatch in the model forward.
@@ -990,6 +993,11 @@ def kimi_k25_vl_collate_fn(
         processor,
     )
     result["labels"] = labels[:, 1:]
+
+    # Mask fake vision tokens for samples that had fake images injected at dataset level.
+    fake_indices = [i for i, ex in enumerate(kept_examples) if ex.get("_injected_fake")]
+    if fake_indices:
+        mask_fake_vision_tokens_batch(result, processor, fake_indices)
 
     # Shift inputs (remove last token for autoregressive training)
     input_shape = result["input_ids"].shape

--- a/tests/unit_tests/datasets/vlm/test_collate_fns.py
+++ b/tests/unit_tests/datasets/vlm/test_collate_fns.py
@@ -1317,7 +1317,7 @@ def test_kimi_k25_vl_collate_fn_labels_shifted(collate_mod, monkeypatch):
 
 
 def test_kimi_k25_vl_collate_fn_fake_image_mask(collate_mod, monkeypatch):
-    """Fake-image vision tokens must have attention_mask=0 for injected samples."""
+    """mask_fake_vision_tokens_batch must be called with the injected sample index."""
     media_token_id = 163605
 
     class FakeImageProcessor:
@@ -1329,8 +1329,6 @@ def test_kimi_k25_vl_collate_fn_fake_image_mask(collate_mod, monkeypatch):
             return "chat:processed"
 
         def __call__(self, **kwargs):
-            # Sequence: [1, media_token_id, media_token_id, 2]
-            # Two vision tokens at positions 1 and 2
             input_ids = torch.tensor([[1, media_token_id, media_token_id, 2]])
             attention_mask = torch.ones_like(input_ids)
             return {"input_ids": input_ids, "attention_mask": attention_mask}
@@ -1343,23 +1341,27 @@ def test_kimi_k25_vl_collate_fn_fake_image_mask(collate_mod, monkeypatch):
         raising=True,
     )
 
+    mask_calls = []
+
+    def fake_mask(batch, proc, sample_indices):
+        mask_calls.append(list(sample_indices))
+
+    monkeypatch.setattr(collate_mod, "mask_fake_vision_tokens_batch", fake_mask, raising=True)
+
     conversation = [
         {"role": "user", "content": [{"type": "text", "text": "Hi"}]},
         {"role": "assistant", "content": [{"type": "text", "text": "Hello"}]},
     ]
     examples = [{"conversation": conversation, "_injected_fake": True}]
 
-    batch = collate_mod.kimi_k25_vl_collate_fn(examples, processor)
+    collate_mod.kimi_k25_vl_collate_fn(examples, processor)
 
-    # Vision token positions (1 and 2 in the unshifted sequence, 1 and 2 after [:, :-1])
-    # After [:, :-1] the sequence is [1, media, media] (positions 0,1,2)
-    assert batch["attention_mask"][0, 1] == 0, "vision token at pos 1 should be masked"
-    assert batch["attention_mask"][0, 2] == 0, "vision token at pos 2 should be masked"
-    assert batch["attention_mask"][0, 0] == 1, "non-vision token should remain unmasked"
+    assert len(mask_calls) == 1, "mask_fake_vision_tokens_batch should be called once"
+    assert mask_calls[0] == [0], "injected sample is at batch index 0"
 
 
 def test_kimi_k25_vl_collate_fn_non_fake_not_masked(collate_mod, monkeypatch):
-    """Real-image vision tokens must NOT be masked for non-injected samples."""
+    """mask_fake_vision_tokens_batch must NOT be called for non-injected samples."""
     media_token_id = 163605
 
     class RealImageProcessor:
@@ -1383,6 +1385,14 @@ def test_kimi_k25_vl_collate_fn_non_fake_not_masked(collate_mod, monkeypatch):
         raising=True,
     )
 
+    mask_calls = []
+    monkeypatch.setattr(
+        collate_mod,
+        "mask_fake_vision_tokens_batch",
+        lambda batch, proc, indices: mask_calls.append(indices),
+        raising=True,
+    )
+
     conversation = [
         {"role": "user", "content": [{"type": "text", "text": "Hi"}]},
         {"role": "assistant", "content": [{"type": "text", "text": "Hello"}]},
@@ -1390,10 +1400,9 @@ def test_kimi_k25_vl_collate_fn_non_fake_not_masked(collate_mod, monkeypatch):
     # _injected_fake is NOT set
     examples = [{"conversation": conversation}]
 
-    batch = collate_mod.kimi_k25_vl_collate_fn(examples, processor)
+    collate_mod.kimi_k25_vl_collate_fn(examples, processor)
 
-    # No masking should happen — all tokens keep attention_mask=1 (before last-token drop)
-    assert batch["attention_mask"][0, 1] == 1, "real vision token should not be masked"
+    assert len(mask_calls) == 0, "mask_fake_vision_tokens_batch should not be called for non-injected samples"
 
 
 # =============================================================================

--- a/tests/unit_tests/datasets/vlm/test_collate_fns.py
+++ b/tests/unit_tests/datasets/vlm/test_collate_fns.py
@@ -1316,6 +1316,86 @@ def test_kimi_k25_vl_collate_fn_labels_shifted(collate_mod, monkeypatch):
     assert batch["labels"].shape[1] == 4  # 5 - 1 = 4
 
 
+def test_kimi_k25_vl_collate_fn_fake_image_mask(collate_mod, monkeypatch):
+    """Fake-image vision tokens must have attention_mask=0 for injected samples."""
+    media_token_id = 163605
+
+    class FakeImageProcessor:
+        def __init__(self):
+            self.tokenizer = DummyTokenizer(pad_token_id=0)
+            self.media_placeholder_token_id = media_token_id
+
+        def apply_chat_template(self, conversation, **kwargs):
+            return "chat:processed"
+
+        def __call__(self, **kwargs):
+            # Sequence: [1, media_token_id, media_token_id, 2]
+            # Two vision tokens at positions 1 and 2
+            input_ids = torch.tensor([[1, media_token_id, media_token_id, 2]])
+            attention_mask = torch.ones_like(input_ids)
+            return {"input_ids": input_ids, "attention_mask": attention_mask}
+
+    processor = FakeImageProcessor()
+    monkeypatch.setattr(
+        collate_mod,
+        "build_labels_from_template",
+        lambda ids, convs, proc: torch.full_like(ids, -100),
+        raising=True,
+    )
+
+    conversation = [
+        {"role": "user", "content": [{"type": "text", "text": "Hi"}]},
+        {"role": "assistant", "content": [{"type": "text", "text": "Hello"}]},
+    ]
+    examples = [{"conversation": conversation, "_injected_fake": True}]
+
+    batch = collate_mod.kimi_k25_vl_collate_fn(examples, processor)
+
+    # Vision token positions (1 and 2 in the unshifted sequence, 1 and 2 after [:, :-1])
+    # After [:, :-1] the sequence is [1, media, media] (positions 0,1,2)
+    assert batch["attention_mask"][0, 1] == 0, "vision token at pos 1 should be masked"
+    assert batch["attention_mask"][0, 2] == 0, "vision token at pos 2 should be masked"
+    assert batch["attention_mask"][0, 0] == 1, "non-vision token should remain unmasked"
+
+
+def test_kimi_k25_vl_collate_fn_non_fake_not_masked(collate_mod, monkeypatch):
+    """Real-image vision tokens must NOT be masked for non-injected samples."""
+    media_token_id = 163605
+
+    class RealImageProcessor:
+        def __init__(self):
+            self.tokenizer = DummyTokenizer(pad_token_id=0)
+            self.media_placeholder_token_id = media_token_id
+
+        def apply_chat_template(self, conversation, **kwargs):
+            return "chat:processed"
+
+        def __call__(self, **kwargs):
+            input_ids = torch.tensor([[1, media_token_id, 2]])
+            attention_mask = torch.ones_like(input_ids)
+            return {"input_ids": input_ids, "attention_mask": attention_mask}
+
+    processor = RealImageProcessor()
+    monkeypatch.setattr(
+        collate_mod,
+        "build_labels_from_template",
+        lambda ids, convs, proc: torch.full_like(ids, -100),
+        raising=True,
+    )
+
+    conversation = [
+        {"role": "user", "content": [{"type": "text", "text": "Hi"}]},
+        {"role": "assistant", "content": [{"type": "text", "text": "Hello"}]},
+    ]
+    # _injected_fake is NOT set
+    examples = [{"conversation": conversation}]
+
+    batch = collate_mod.kimi_k25_vl_collate_fn(examples, processor)
+
+    # No masking should happen — all tokens keep attention_mask=1 (before last-token drop)
+    assert batch["attention_mask"][0, 1] == 1, "real vision token should not be masked"
+
+
 # =============================================================================
 # Tests for _ensure_rgb
 # =============================================================================
@@ -1966,12 +2046,12 @@ class TestBuildLabelsFromTemplate:
 # ---------------------------------------------------------------------------
 
 # Synthetic token IDs for a Gemma4-style tokenizer.
-_SOT = 2       # <start_of_turn>
+_SOT = 2  # <start_of_turn>
 _USER_TK = 1645  # "user"
 _MODEL_TK = 2516  # "model"
-_NL = 108      # "\n"
-_EOT = 107     # <end_of_turn>
-_U_CONTENT = 506   # "u"
+_NL = 108  # "\n"
+_EOT = 107  # <end_of_turn>
+_U_CONTENT = 506  # "u"
 # sentinel encoded as two distinct ids
 _SEN_A = 999
 _SEN_B = 888


### PR DESCRIPTION
## Problem

Under FSDP / DeepSpeed Zero3, pure-text samples have a 56×56 white fake image injected so the visual encoder stays active during all-gather / reduce-scatter (every parameter must participate in the collective). The injected vision tokens should be invisible to attention — their `attention_mask` must be set to 0 — so they do not contaminate the model's representations.

All other VLM collate functions call `mask_fake_vision_tokens_batch` for this purpose:

| collate function | masks fake tokens |
|---|---|
| `default_collate_fn` | ✅ |
| `qwen2_5_collate_fn` | ✅ |
| `qwen3_omni_collate_fn` | ✅ |
| `kimi_vl_collate_fn` | ✅ |
| `llava_onevision_collate_fn` | ✅ |
| **`kimi_k25_vl_collate_fn`** | ❌ **missing** |

Without the masking, real text tokens attend to fake image tokens (attention_mask=1), slightly polluting the hidden states of pure-text samples during FSDP/Zero3 training. Labels are unaffected (fake tokens are in a user turn → automatically -100), so the loss is correct, but the attention computation is not clean.

## Fix

- Track `kept_examples` alongside `kept_conversations` through the per-sample processing loop (including the early overlong-drop path that already filtered `conversations` but not `examples`).
- After stacking the result tensors, call `mask_fake_vision_tokens_batch(result, processor, fake_indices)` — identical to every other collate function.

## Tests

Added two unit tests:

- `test_kimi_k25_vl_collate_fn_fake_image_mask` — verifies `mask_fake_vision_tokens_batch` is called with batch index 0 when `_injected_fake=True`.
- `test_kimi_k25_vl_collate_fn_non_fake_not_masked` — verifies `mask_fake_vision_tokens_batch` is **not** called when no sample is injected.

All 14 `kimi_k25` tests pass.

## Checklist

- [x] `ruff format` + `ruff check` clean
- [x] DCO sign-off included