### PR TITLE
ci: drop scheduled nightly-docs trigger, add manual dispatch 

### DIFF
--- a/.github/workflows/config/.secrets.baseline
+++ b/.github/workflows/config/.secrets.baseline
@@ -138,15 +138,6 @@
         "line_number": 121
       }
     ],
-    ".github/workflows/release-nightly-docs.yml": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/release-nightly-docs.yml",
-        "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
-        "is_verified": false,
-        "line_number": 34
-      }
-    ],
     "docs/guides/mlflow-logging.md": [
       {
         "type": "Basic Auth Credentials",
@@ -172,6 +163,15 @@
         "hashed_secret": "4702220fec9261c7d9b0c427aceeca118b66c702",
         "is_verified": false,
         "line_number": 42
+      }
+    ],
+    "tests/unit_tests/_cli/test_app.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit_tests/_cli/test_app.py",
+        "hashed_secret": "a02c54a1935bda726904a619061de5b73db2f2e2",
+        "is_verified": false,
+        "line_number": 295
       }
     ],
     "tests/unit_tests/config/test_allowed_import_prefixes.py": [
@@ -223,5 +223,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-18T10:18:13Z"
+  "generated_at": "2026-04-27T17:50:25Z"
 }

--- a/.github/workflows/release-nightly-docs.yml
+++ b/.github/workflows/release-nightly-docs.yml
@@ -20,8 +20,11 @@ on:
       - main
     paths:
       - 'docs/**'
-  schedule:
-    - cron: "0 10 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-docs-publish
+  cancel-in-progress: false
 
 jobs:
   call-release-docs:

--- a/.github/workflows/release-nightly-docs.yml
+++ b/.github/workflows/release-nightly-docs.yml
@@ -34,4 +34,4 @@ jobs:
       publish-as-latest: false
       docs-version-override: "nightly"
       update-version-picker: false
-    secrets: inherit
+    secrets: inherit  # pragma: allowlist secret


### PR DESCRIPTION
# What does this PR do ?

  - `release-nightly-docs.yml` could race itself: the schedule and the `push: docs/**` triggers each kicked off a publish to the same Akamai/S3
   nightly path with no concurrency control, so close-together runs left the live nightly docs serving a mix of files from two commits.
  - Drop the schedule, add `workflow_dispatch` for ad-hoc refreshes (covers the docstring-only case where the path filter doesn't fire), and
  add a `concurrency: nightly-docs-publish` group so close-together `docs/**` pushes serialize.

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
