### PR TITLE
fix(examples): use HF model ids for Nemotron-Omni and MiniMax-M2.7 yamls

### DIFF
--- a/examples/llm_finetune/minimax_m2/minimax_m2.7_hellaswag_lora.yaml
+++ b/examples/llm_finetune/minimax_m2/minimax_m2.7_hellaswag_lora.yaml
@@ -45,7 +45,7 @@ dist_env:
 
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
-  pretrained_model_name_or_path: /lustre/fsw/portfolios/coreai/users/huiyingl/copper-meadow_vv0-hf
+  pretrained_model_name_or_path: MiniMaxAI/MiniMax-M2.7
   trust_remote_code: true
   backend:
     _target_: nemo_automodel.components.models.common.BackendConfig

--- a/examples/vlm_finetune/nemotron_omni/nemotron_omni_cord_v2.yaml
+++ b/examples/vlm_finetune/nemotron_omni/nemotron_omni_cord_v2.yaml
@@ -24,7 +24,7 @@ rng:
 
 model:
   _target_: nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained
-  pretrained_model_name_or_path: /lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_nemofw/users/huiyingl/omniv/nemotron-3-nano-omni-ea1_v2.0
+  pretrained_model_name_or_path: nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16
   trust_remote_code: true
   torch_dtype: torch.bfloat16
   backend:
@@ -39,12 +39,12 @@ model:
 
 processor:
   _target_: transformers.AutoProcessor.from_pretrained
-  pretrained_model_name_or_path: /lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_nemofw/users/huiyingl/omniv/nemotron-3-nano-omni-ea1_v2.0
+  pretrained_model_name_or_path: nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16
   trust_remote_code: true
 
 checkpoint:
   enabled: true
-  checkpoint_dir: /lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_nemofw/users/huiyingl/omniv/logs/cordv2_v2_lr1e4_ckpts/
+  checkpoint_dir: vlm_checkpoints/
   model_save_format: safetensors
   save_consolidated: true
 

--- a/examples/vlm_finetune/nemotron_omni/nemotron_omni_cord_v2_peft.yaml
+++ b/examples/vlm_finetune/nemotron_omni/nemotron_omni_cord_v2_peft.yaml
@@ -24,7 +24,7 @@ rng:
 
 model:
   _target_: nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained
-  pretrained_model_name_or_path: /lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_nemofw/users/huiyingl/omniv/nemotron-3-nano-omni-ea1_v2.0
+  pretrained_model_name_or_path: nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16
   trust_remote_code: true
   torch_dtype: torch.bfloat16
   backend:
@@ -53,12 +53,12 @@ peft:
 
 processor:
   _target_: transformers.AutoProcessor.from_pretrained
-  pretrained_model_name_or_path: /lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_nemofw/users/huiyingl/omniv/nemotron-3-nano-omni-ea1_v2.0
+  pretrained_model_name_or_path: nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16
   trust_remote_code: true
 
 checkpoint:
   enabled: true
-  checkpoint_dir: /lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_nemofw/users/huiyingl/omniv/logs/cordv2_v2_lora_r64_ckpts/
+  checkpoint_dir: vlm_checkpoints/
   model_save_format: safetensors
   save_consolidated: true
 


### PR DESCRIPTION
## Summary

The committed example yamls for two models still pointed at absolute internal `/lustre/...` paths, leaving the recipes unreproducible outside NVIDIA's filesystem. With the V2 dump's architecture entry removed in #2063, the Nemotron-Omni cases additionally crash with:

```
ValueError: Unrecognized configuration class
  ...NemotronH_Nano_VL_V2_Config... for AutoModelForImageTextToText.
```

This PR switches all three offending yamls to the corresponding public HF model ids and relativizes the Nemotron-Omni `checkpoint_dir`s to match the project's other VLM examples.

| File | `pretrained_model_name_or_path` | `checkpoint_dir` |
|---|---|---|
| `examples/vlm_finetune/nemotron_omni/nemotron_omni_cord_v2.yaml` | `/lustre/.../v2.0` → `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16` | `/lustre/.../cordv2_v2_lr1e4_ckpts/` → `vlm_checkpoints/` |
| `examples/vlm_finetune/nemotron_omni/nemotron_omni_cord_v2_peft.yaml` | same as above | `/lustre/.../cordv2_v2_lora_r64_ckpts/` → `vlm_checkpoints/` |
| `examples/llm_finetune/minimax_m2/minimax_m2.7_hellaswag_lora.yaml` | `/lustre/.../copper-meadow_vv0-hf` → `MiniMaxAI/MiniMax-M2.7` | unchanged |

A wide sweep across `examples/`, `tests/`, `configs/` confirms these were the only three yamls with absolute internal paths.

## Test plan

- [x] Verified locally that `nemotron_omni_cord_v2.yaml` reaches step 0 with the expected baseline loss (0.6319) when `pretrained_model_name_or_path` is set to a v3 dump on disk.
- [ ] CI on this branch