### PR TITLE
fix(checkpoint): disable DCP plan caching on PyTorch 2.10

### DIFF
--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -840,7 +840,7 @@ class Checkpointer:
             return
 
         ret = None
-        planner = dcp.DefaultSavePlanner(enable_plan_caching=True)
+        planner = dcp.DefaultSavePlanner()
         if self.config.is_async:
             ctx = self._model_ctx if is_model else self._optim_ctx
             ret = dcp.async_save(


### PR DESCRIPTION
## Problem

`DefaultSavePlanner(enable_plan_caching=True)` was introduced in #635.
On **PyTorch 2.10** this causes every checkpoint save to crash with:

```
RuntimeError: unexpected pos 704 vs 598
```

## Root cause

When `enable_plan_caching=True`, the planner pre-computes the expected
byte size of each `BYTE_IO` item as the raw `BytesIO` payload length
(e.g. 598 bytes).  However the DCP filesystem writer wraps each item in
a **zip stream** (`transform_to`), which appends a central directory +
EOCD record (~106 bytes of overhead), making the actual written size
704 bytes.  The C++ inline-container assertion

```
current_pos_ == expected_pos_   // inline_container.cc:668
```

fires on every rank and aborts training.

## Fix

Remove the `enable_plan_caching=True` argument so `DefaultSavePlanner`
uses the default (non-caching) path, which does not pre-compute sizes
and therefore never triggers the assertion.

## Test plan

- [x] Ran HYV3 4-layer P1 (checkpoint save/resume) on 8×A100 — save no longer crashes
- [ ] Existing checkpoint CI tests