### PR TITLE
fix(checkpoint): allow partial optimizer load for params with no gradient state

### DIFF
--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -375,7 +375,7 @@ class Checkpointer:
         """
         optimizer_state = OptimizerState(model, optimizer, scheduler, is_peft=self.config.is_peft)
         state_dict = optimizer_state.state_dict()
-        self._do_load(state_dict, os.path.join(weights_path, "optim"))
+        self._do_load(state_dict, os.path.join(weights_path, "optim"), allow_partial_load=True)
         optimizer_state.load_state_dict(state_dict)
 
     @torch.no_grad()
@@ -790,6 +790,7 @@ class Checkpointer:
         path: str,
         storage_reader: Optional[_HuggingFaceStorageReader] = None,
         is_init_step: bool = False,
+        allow_partial_load: bool = False,
     ) -> dict[str, torch.Tensor]:
         """
         Load a state dictionary from `path` using DCP or PEFT special-case logic.
@@ -799,6 +800,9 @@ class Checkpointer:
             path: Checkpoint directory path.
             storage_reader: Optional HF storage reader for safetensors.
             is_init_step: True if loading from a base checkpoint during initialization.
+            allow_partial_load: If True, skip state_dict keys absent in the checkpoint
+                (e.g. optimizer params that never received a gradient and therefore have
+                no per-parameter state saved).
 
         Returns:
             The populated state dictionary (may be replaced for PEFT).
@@ -809,7 +813,12 @@ class Checkpointer:
         if self.config.is_peft and is_model and (not is_init_step):
             state_dict = load_file(os.path.join(path, "adapter_model.safetensors"))
         else:
-            dcp.load(state_dict, checkpoint_id=path, storage_reader=storage_reader)
+            planner = None
+            if allow_partial_load:
+                from torch.distributed.checkpoint import DefaultLoadPlanner
+
+                planner = DefaultLoadPlanner(allow_partial_load=True)
+            dcp.load(state_dict, checkpoint_id=path, storage_reader=storage_reader, planner=planner)
         return state_dict
 
     def _do_save(


### PR DESCRIPTION
## Problem

MoE models with non-differentiable routing (sigmoid, top-k hard selection)
have gate weights that sit in the optimizer `param_groups` but **never
receive gradients**.  AdamW lazily initialises per-parameter state only
on the first backward pass, so after training these weights have an empty
`{}` state entry.

On resume, `get_optimizer_state_dict(flatten_optimizer_state_dict=True)`
produces **placeholder tensors** for every `param_group` entry — including
the no-gradient gate weights.  DCP then raises:

```
RuntimeError: Missing key in checkpoint state_dict:
    optim.state.model.layers.1.mlp.gate.weight.step
```

This affects any MoE model whose routing gate is not differentiable
(e.g. HYV3, and potentially others using sigmoid or hard top-k routing).

## Fix

Pass `DefaultLoadPlanner(allow_partial_load=True)` when loading optimizer
state so that checkpoint keys absent from the state dict — and state dict
keys absent from the checkpoint — are silently skipped.

For params that never received a gradient this is the correct semantic:
they resume with fresh (zero) optimizer state, identical to a cold start.

## Test plan

- [x] Ran HYV3 4-layer P1 resume on 8×A100 — no longer crashes on `gate.weight`
- [x] Resume loss at step 50 matches original run within expected bf16 tolerance
- [ ] Existing checkpoint CI tests