### PR TITLE
feat: add inbatch neg sampling for training

### DIFF
--- a/nemo_automodel/_transformers/retrieval.py
+++ b/nemo_automodel/_transformers/retrieval.py
@@ -227,11 +227,18 @@ class BiEncoderModel(nn.Module):
 
     _TASK = "embedding"
 
-    def __init__(self, model: PreTrainedModel, pooling: str = "avg", l2_normalize: bool = True):
+    def __init__(
+        self,
+        model: PreTrainedModel,
+        pooling: str = "avg",
+        l2_normalize: bool = True,
+        do_distributed_inbatch_negative: bool = False,
+    ):
         super().__init__()
         _init_encoder_common(self, model)
         self.pooling = pooling
         self.l2_normalize = l2_normalize
+        self.do_distributed_inbatch_negative = do_distributed_inbatch_negative
 
     @classmethod
     def build(
@@ -240,6 +247,7 @@ class BiEncoderModel(nn.Module):
         task: str = None,
         pooling: str = "avg",
         l2_normalize: bool = True,
+        do_distributed_inbatch_negative: bool = False,
         trust_remote_code: bool = False,
         **hf_kwargs,
     ):
@@ -254,7 +262,12 @@ class BiEncoderModel(nn.Module):
             model_name_or_path, effective_task, trust_remote_code=trust_remote_code, pooling=pooling, **hf_kwargs
         )
 
-        return cls(model=backbone, pooling=pooling, l2_normalize=l2_normalize)
+        return cls(
+            model=backbone,
+            pooling=pooling,
+            l2_normalize=l2_normalize,
+            do_distributed_inbatch_negative=do_distributed_inbatch_negative,
+        )
 
     def save_pretrained(self, save_directory: str, **kwargs):
         save_encoder_pretrained(self, save_directory, **kwargs)

--- a/nemo_automodel/components/datasets/llm/retrieval_collator.py
+++ b/nemo_automodel/components/datasets/llm/retrieval_collator.py
@@ -25,6 +25,7 @@ def _doc_id_str_to_int64(doc_id: str) -> int:
     h = hashlib.md5(doc_id.encode("utf-8")).digest()[:8]
     return int.from_bytes(h, "little", signed=False) & ((1 << 63) - 1)
 
+
 if TYPE_CHECKING:
     from transformers import BatchEncoding
 

--- a/nemo_automodel/components/datasets/llm/retrieval_collator.py
+++ b/nemo_automodel/components/datasets/llm/retrieval_collator.py
@@ -12,11 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import hashlib
 from typing import TYPE_CHECKING, Any, Dict, List, Union
 
 import torch
 from transformers import DataCollatorWithPadding, PreTrainedTokenizerBase
 from transformers.file_utils import PaddingStrategy
+
+
+def _doc_id_str_to_int64(doc_id: str) -> int:
+    """Stable 63-bit int for corpus doc id strings (for in-batch duplicate masking)."""
+    h = hashlib.md5(doc_id.encode("utf-8")).digest()[:8]
+    return int.from_bytes(h, "little", signed=False) & ((1 << 63) - 1)
 
 if TYPE_CHECKING:
     from transformers import BatchEncoding
@@ -192,6 +199,18 @@ class BiEncoderCollator:
         # Add dummy labels (required by some training frameworks)
         labels = torch.zeros(len(query_features), dtype=torch.long)
         merged_batch_dict["labels"] = labels
+
+        # Per-passage corpus doc ids (positive + negatives, flattened in d_input_ids
+        # order) for distributed in-batch same-doc negative masking. Top-level key
+        # so it bypasses the q_/d_ unpacking in the trainer.
+        if batch and batch[0].get("doc_id") is not None:
+            doc_id_flat: List[str] = []
+            for x in batch:
+                doc_id_flat.extend(x["doc_id"])
+            merged_batch_dict["passage_doc_ids"] = torch.tensor(
+                [_doc_id_str_to_int64(s) for s in doc_id_flat],
+                dtype=torch.long,
+            )
 
         return merged_batch_dict
 

--- a/nemo_automodel/components/datasets/llm/retrieval_dataset.py
+++ b/nemo_automodel/components/datasets/llm/retrieval_dataset.py
@@ -435,6 +435,7 @@ def _transform_func(examples, num_neg_docs, corpus_dict, use_dataset_instruction
     batch_negatives = examples["neg_doc"]
 
     cur_pos_neg_doc_batch = []
+    cur_pos_neg_doc_id_batch = []
 
     for i_example in range(len(questions)):
         cur_pos_neg_doc = []
@@ -459,6 +460,7 @@ def _transform_func(examples, num_neg_docs, corpus_dict, use_dataset_instruction
             cur_pos_neg_doc += [negatives[n_id] for n_id in cur_neg_ids]
 
         cur_pos_neg_doc_batch.append(cur_pos_neg_doc)
+        cur_pos_neg_doc_id_batch.append([d["id"] for d in cur_pos_neg_doc])
 
     # Extract text and images from corpus
     cur_pos_neg_text_batch = []
@@ -505,6 +507,7 @@ def _transform_func(examples, num_neg_docs, corpus_dict, use_dataset_instruction
         "question": questions,
         "doc_text": cur_pos_neg_text_batch,
         "doc_image": cur_pos_neg_image_batch,
+        "doc_id": cur_pos_neg_doc_id_batch,
         "query_instruction": query_instruction_batch,
         "passage_instruction": passage_instruction_batch,
     }

--- a/nemo_automodel/components/models/common/inbatch_neg_utils.py
+++ b/nemo_automodel/components/models/common/inbatch_neg_utils.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Distributed in-batch negative utilities for bi-encoder contrastive training.
+
+Architecture-agnostic helpers used by the bi-encoder trainer to expand the
+negative pool with passages gathered across DP ranks. Backbones (Llama,
+Ministral3, Qwen3, ...) do not import these directly; the trainer wires them
+in around ``BiEncoderModel.encode``.
+"""
+
+from typing import Optional
+
+import torch
+import torch.distributed as dist
+
+
+def dist_gather_tensor(t: Optional[torch.Tensor]) -> Optional[torch.Tensor]:
+    """All-gather ``t`` along dim 0 across the default process group.
+
+    The local-rank slice is replaced with the original ``t`` so that gradients
+    flow back only to the local portion of the gathered tensor (other ranks'
+    slices are detached). Returns ``t`` unchanged when distributed is not
+    available, not initialized, or world size is 1.
+    """
+    if t is None:
+        return None
+    if not (dist.is_available() and dist.is_initialized()) or dist.get_world_size() <= 1:
+        return t
+    t = t.contiguous()
+    gathered = [torch.empty_like(t) for _ in range(dist.get_world_size())]
+    dist.all_gather(gathered, t)
+    gathered[dist.get_rank()] = t
+    return torch.cat(gathered, dim=0)
+
+
+def mask_gathered_passages_same_doc_as_positive(
+    scores: torch.Tensor,
+    passage_doc_ids: torch.Tensor,
+    train_n_passages: int,
+    rank: int,
+    local_batch_size: int,
+) -> None:
+    """In-place mask passages sharing a doc id with this row's positive.
+
+    After all-gather, each query's positive sits at column ``i * train_n_passages``
+    of the gathered passage tensor. For each local query row, set scores to
+    ``finfo(dtype).min`` on any other column whose ``passage_doc_ids`` matches
+    the positive's id, so duplicates of the positive elsewhere in the global
+    batch are not treated as negatives. The true positive column is left intact.
+
+    Args:
+        scores: ``[local_batch_size, B_global * train_n_passages]`` (already
+            sliced to the local rank's query rows).
+        passage_doc_ids: ``[B_global * train_n_passages]`` int64 doc ids for
+            every gathered passage.
+        train_n_passages: Number of passages per query (1 positive + negatives).
+        rank: Caller's DP rank.
+        local_batch_size: Number of queries per rank.
+    """
+    device = scores.device
+    n = passage_doc_ids.shape[0]
+    mask_val = torch.finfo(scores.dtype).min
+    g = torch.arange(rank * local_batch_size, (rank + 1) * local_batch_size, device=device)
+    pos_cols = g * train_n_passages
+    pos_ids = passage_doc_ids[pos_cols].unsqueeze(1)
+    j = torch.arange(n, device=device, dtype=torch.long).unsqueeze(0)
+    same_id = passage_doc_ids.unsqueeze(0) == pos_ids
+    not_pos_column = j != pos_cols.unsqueeze(1)
+    scores.masked_fill_(same_id & not_pos_column, mask_val)

--- a/nemo_automodel/recipes/retrieval/train_bi_encoder.py
+++ b/nemo_automodel/recipes/retrieval/train_bi_encoder.py
@@ -347,9 +347,43 @@ class TrainBiEncoderRecipe(BaseRecipe):
             p_reps = model(passage)
 
             n_passages = self.train_n_passages
-            scores, labels = contrastive_scores_and_labels(q_reps, p_reps, n_passages)
-            if model.l2_normalize:
-                scores = scores / self.temperature
+            if is_train and getattr(model, "do_distributed_inbatch_negative", False):
+                if getattr(model, "pooling", None) == "colbert":
+                    raise NotImplementedError("Distributed in-batch negatives are not implemented for ColBERT pooling.")
+                from nemo_automodel.components.models.common.inbatch_neg_utils import (
+                    dist_gather_tensor,
+                    mask_gathered_passages_same_doc_as_positive,
+                )
+
+                local_bs = q_reps.shape[0]
+                dist_initialized = torch.distributed.is_available() and torch.distributed.is_initialized()
+                rank = torch.distributed.get_rank() if dist_initialized else 0
+                world_size = torch.distributed.get_world_size() if dist_initialized else 1
+                all_p = dist_gather_tensor(p_reps)
+                expected_p = world_size * local_bs * n_passages
+                assert all_p.shape[0] == expected_p, (
+                    f"Gathered passage count {all_p.shape[0]} != expected {expected_p}"
+                )
+                scores = torch.mm(q_reps, all_p.t())
+                labels = (
+                    torch.arange(local_bs, device=q_reps.device) + rank * local_bs
+                ) * n_passages
+                if model.l2_normalize:
+                    scores = scores / self.temperature
+                passage_doc_ids = batch.get("passage_doc_ids")
+                if passage_doc_ids is not None:
+                    all_doc_ids = dist_gather_tensor(passage_doc_ids.contiguous())
+                    mask_gathered_passages_same_doc_as_positive(
+                        scores,
+                        all_doc_ids,
+                        train_n_passages=n_passages,
+                        rank=rank,
+                        local_batch_size=local_bs,
+                    )
+            else:
+                scores, labels = contrastive_scores_and_labels(q_reps, p_reps, n_passages)
+                if model.l2_normalize:
+                    scores = scores / self.temperature
             loss = F.cross_entropy(scores, labels)
 
             loss_buffer.append(loss.clone().detach())

--- a/nemo_automodel/recipes/retrieval/train_bi_encoder.py
+++ b/nemo_automodel/recipes/retrieval/train_bi_encoder.py
@@ -361,13 +361,9 @@ class TrainBiEncoderRecipe(BaseRecipe):
                 world_size = torch.distributed.get_world_size() if dist_initialized else 1
                 all_p = dist_gather_tensor(p_reps)
                 expected_p = world_size * local_bs * n_passages
-                assert all_p.shape[0] == expected_p, (
-                    f"Gathered passage count {all_p.shape[0]} != expected {expected_p}"
-                )
+                assert all_p.shape[0] == expected_p, f"Gathered passage count {all_p.shape[0]} != expected {expected_p}"
                 scores = torch.mm(q_reps, all_p.t())
-                labels = (
-                    torch.arange(local_bs, device=q_reps.device) + rank * local_bs
-                ) * n_passages
+                labels = (torch.arange(local_bs, device=q_reps.device) + rank * local_bs) * n_passages
                 if model.l2_normalize:
                     scores = scores / self.temperature
                 passage_doc_ids = batch.get("passage_doc_ids")

--- a/tests/unit_tests/models/common/test_inbatch_neg_utils.py
+++ b/tests/unit_tests/models/common/test_inbatch_neg_utils.py
@@ -1,0 +1,176 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for distributed in-batch negative sampling utilities."""
+
+import pytest
+import torch
+
+from nemo_automodel.components.models.common.inbatch_neg_utils import (
+    dist_gather_tensor,
+    mask_gathered_passages_same_doc_as_positive,
+)
+
+def _is_masked(x: torch.Tensor) -> bool:
+    """True when ``x`` is the dtype's ``-inf`` marker or its ``finfo.min``.
+
+    Pass a tensor (not a Python float) so the dtype is preserved — otherwise
+    ``finfo.min`` would be evaluated against the default float dtype and miss
+    masked values from lower-precision dtypes (e.g. bfloat16).
+    """
+    assert torch.is_tensor(x), "pass tensor (not .item()) to preserve dtype"
+    return bool(torch.isneginf(x).item() or x.item() <= torch.finfo(x.dtype).min)
+
+
+def test_dist_gather_tensor_single_rank_is_noop():
+    """world_size <= 1 short-circuits to identity (no allocation/copy).
+
+    ``is t`` pins the no-copy contract; downgrading to ``torch.equal`` would
+    let a regression silently allocate a needless copy.
+    """
+    t = torch.randn(4, 8)
+    assert dist_gather_tensor(t) is t
+
+
+def test_dist_gather_tensor_none_returns_none():
+    assert dist_gather_tensor(None) is None
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_mask_same_doc_basic(dtype):
+    """Duplicate of q0's positive doc id elsewhere in the batch must be masked
+    on q0's row, while q0's positive column itself stays untouched."""
+    local_bs, n_passages = 2, 2
+    scores = torch.zeros(local_bs, local_bs * n_passages, dtype=dtype)
+    # Layout: [q0_pos_id, q0_neg_id, q1_pos_id, q1_neg_id]
+    # Force q1's neg (col 3) to share q0's pos id (col 0).
+    passage_doc_ids = torch.tensor([100, 200, 300, 100], dtype=torch.long)
+
+    mask_gathered_passages_same_doc_as_positive(
+        scores,
+        passage_doc_ids,
+        train_n_passages=n_passages,
+        rank=0,
+        local_batch_size=local_bs,
+    )
+
+    # q0's row: positive (col 0) preserved, duplicate (col 3) masked.
+    assert scores[0, 0].item() == 0.0
+    assert _is_masked(scores[0, 3])
+    # Non-matching cols on q0's row stay 0.
+    assert scores[0, 1].item() == 0.0
+    assert scores[0, 2].item() == 0.0
+    # q1's row: q1's pos id (300) is unique, no masking anywhere.
+    assert torch.all(scores[1] == 0.0)
+
+
+def test_mask_same_doc_no_collisions_is_noop():
+    """All unique doc ids -> scores unchanged."""
+    local_bs, n_passages = 2, 2
+    scores = torch.full((local_bs, local_bs * n_passages), 0.5)
+    passage_doc_ids = torch.tensor([1, 2, 3, 4], dtype=torch.long)
+
+    mask_gathered_passages_same_doc_as_positive(
+        scores,
+        passage_doc_ids,
+        train_n_passages=n_passages,
+        rank=0,
+        local_batch_size=local_bs,
+    )
+
+    assert torch.all(scores == 0.5)
+
+
+def test_mask_does_not_clobber_own_positive():
+    """The labeled positive column must never be masked, even if other passages
+    share its doc id."""
+    local_bs, n_passages = 1, 3
+    scores = torch.zeros(1, 3)
+    # Col 2 shares q0's positive doc id (col 0).
+    passage_doc_ids = torch.tensor([42, 99, 42], dtype=torch.long)
+
+    mask_gathered_passages_same_doc_as_positive(
+        scores,
+        passage_doc_ids,
+        train_n_passages=n_passages,
+        rank=0,
+        local_batch_size=local_bs,
+    )
+
+    assert scores[0, 0].item() == 0.0  # positive preserved
+    assert scores[0, 1].item() == 0.0  # different id, untouched
+    assert _is_masked(scores[0, 2])  # duplicate masked
+
+
+def test_mask_respects_rank_offset_local_bs_1():
+    """For rank > 0, positives live further into the gathered tensor."""
+    local_bs, n_passages, rank = 1, 2, 1
+    # Gathered tensor: world_size=2 * local_bs=1 * n_passages=2 = 4 cols.
+    scores = torch.zeros(local_bs, 4)
+    # Rank 1's positive is at col rank*local_bs*n_passages = 2.
+    # Force col 0 (rank 0's positive) to share rank 1's positive doc id.
+    passage_doc_ids = torch.tensor([77, 1, 77, 2], dtype=torch.long)
+
+    mask_gathered_passages_same_doc_as_positive(
+        scores,
+        passage_doc_ids,
+        train_n_passages=n_passages,
+        rank=rank,
+        local_batch_size=local_bs,
+    )
+
+    assert _is_masked(scores[0, 0])  # duplicate of rank 1's positive
+    assert scores[0, 1].item() == 0.0
+    assert scores[0, 2].item() == 0.0  # rank 1's own positive, preserved
+    assert scores[0, 3].item() == 0.0
+
+
+def test_mask_respects_rank_offset_local_bs_2():
+    """rank>0 with local_bs>1 — exercises both the rank offset and the
+    per-row positive-column broadcast simultaneously."""
+    local_bs, n_passages, rank = 2, 2, 1
+    # Gathered tensor: world_size=2 * local_bs=2 * n_passages=2 = 8 cols.
+    scores = torch.zeros(local_bs, 8)
+    # Layout (col index : meaning):
+    #   0 r0_q0_pos | 1 r0_q0_neg | 2 r0_q1_pos | 3 r0_q1_neg
+    #   4 r1_q0_pos | 5 r1_q0_neg | 6 r1_q1_pos | 7 r1_q1_neg
+    # We are rank 1, so our positives live at cols 4 and 6.
+    # Make col 0 share r1_q0's pos id (500); make col 7 share r1_q1's pos id (600).
+    passage_doc_ids = torch.tensor(
+        [500, 11, 600, 13, 500, 15, 600, 600],
+        dtype=torch.long,
+    )
+
+    mask_gathered_passages_same_doc_as_positive(
+        scores,
+        passage_doc_ids,
+        train_n_passages=n_passages,
+        rank=rank,
+        local_batch_size=local_bs,
+    )
+
+    # Local q0 (row 0): own positive col is 4. Col 0 shares its id 500 -> masked.
+    # Cols with id 600 (2, 6, 7) do NOT share q0's id, untouched.
+    assert _is_masked(scores[0, 0])
+    assert scores[0, 4].item() == 0.0  # own positive preserved
+    for c in (1, 2, 3, 5, 6, 7):
+        assert scores[0, c].item() == 0.0
+
+    # Local q1 (row 1): own positive col is 6. Cols 2 and 7 share id 600 -> masked.
+    # Col 6 itself is the labeled positive and must stay.
+    assert _is_masked(scores[1, 2])
+    assert _is_masked(scores[1, 7])
+    assert scores[1, 6].item() == 0.0  # own positive preserved
+    for c in (0, 1, 3, 4, 5):
+        assert scores[1, c].item() == 0.0


### PR DESCRIPTION
# What does this PR do ?

Distributed in-batch negative sampling for bi-encoder retrieval training. 

Adds an opt-in `do_distributed_inbatch_negative` flag (default False) to BiEncoderModel that, when enabled, all-gathers passage embeddings across DP ranks so each query is contrastively scored against the global pool of positives and hard negatives, with automatic same-document masking to prevent duplicates of the local positive elsewhere in the batch from acting as false negatives. Implementation introduces a shared utility module, `inbatch_neg_utils.py`, threads doc_id through the dataset transform and passage_doc_ids through the bi-encoder collator, and adds a single conditional path in `train_bi_encoder.py` that activates only when the flag is on — defaults preserve existing recipe behavior exactly.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

