### PR TITLE
fix: MoE aux-loss dtype mismatch under activation checkpointing

### DIFF
--- a/nemo_automodel/components/moe/layers.py
+++ b/nemo_automodel/components/moe/layers.py
@@ -384,10 +384,7 @@ class Gate(nn.Module):
 
         if self.gate_precision is not None:
             weights = weights.to(dtype=original_dtype)
-            # Keep original_scores in gate_precision (fp32 for numerical stability) — it
-            # only feeds _compute_aux_loss, and casting back to bf16 here makes the saved
-            # tensors of that path mismatch their recomputed counterparts under
-            # activation checkpointing (forward saves bf16, recompute produces fp32).
+            original_scores = original_scores.to(dtype=original_dtype)
 
         if self.bias_update_factor > 0 or self.aux_loss_coeff > 0 or self._track_load_balance:
             expert_load = self._compute_expert_load(indices, token_mask)
@@ -525,6 +522,16 @@ class Gate(nn.Module):
             torch.Tensor: Auxiliary loss for load balancing.
                 Shape is [].
         """
+        # Pin aux-loss arithmetic to fp32. The activation-checkpoint recompute pass
+        # does not replay FSDP2 MixedPrecisionPolicy cast_forward_inputs, so `x` and
+        # anything derived from `x.dtype` (including original_scores in some MoE
+        # configs) can differ between forward and recompute. Doing the cast inside
+        # the AC region — rather than at the Gate level — guarantees the saved
+        # tensors of this region (expert_scores [n_experts] and the aux-loss scalar)
+        # are fp32 on both passes regardless of upstream behavior.
+        original_scores = original_scores.float()
+        expert_load = expert_load.float()
+
         context_length = token_mask.sum()
         expert_scores = (original_scores * token_mask.unsqueeze(-1)).sum(dim=0)
 

--- a/nemo_automodel/components/moe/layers.py
+++ b/nemo_automodel/components/moe/layers.py
@@ -384,7 +384,10 @@ class Gate(nn.Module):
 
         if self.gate_precision is not None:
             weights = weights.to(dtype=original_dtype)
-            original_scores = original_scores.to(dtype=original_dtype)
+            # Keep original_scores in gate_precision (fp32 for numerical stability) — it
+            # only feeds _compute_aux_loss, and casting back to bf16 here makes the saved
+            # tensors of that path mismatch their recomputed counterparts under
+            # activation checkpointing (forward saves bf16, recompute produces fp32).
 
         if self.bias_update_factor > 0 or self.aux_loss_coeff > 0 or self._track_load_balance:
             expert_load = self._compute_expert_load(indices, token_mask)

--- a/nemo_automodel/components/moe/megatron/moe_utils.py
+++ b/nemo_automodel/components/moe/megatron/moe_utils.py
@@ -562,7 +562,10 @@ class MoEAuxLossAutoScaler(torch.autograd.Function):
         Returns:
             torch.Tensor: The output tensor.
         """
-        ctx.save_for_backward(aux_loss)
+        # Pin aux_loss dtype so the AC saved/recomputed metadata cannot diverge
+        # regardless of upstream casts. The backward path uses torch.ones_like(aux_loss)
+        # only for shape, so dtype here is behaviorally invisible to gradient flow.
+        ctx.save_for_backward(aux_loss.float())
         return output
 
     @staticmethod

--- a/tests/unit_tests/moe/test_layers.py
+++ b/tests/unit_tests/moe/test_layers.py
@@ -828,18 +828,22 @@ class TestGate:
         assert aux_loss.numel() == 1  # Scalar loss
         assert aux_loss.requires_grad
 
-    def test_gate_aux_loss_under_activation_checkpointing(self, moe_config, device):
+    @pytest.mark.parametrize("gate_precision", [None, torch.float32])
+    def test_gate_aux_loss_under_activation_checkpointing(
+        self, moe_config, device, gate_precision
+    ):
         """Aux-loss path must be activation-checkpoint safe: saved tensors that AC
         observes during forward must match dtype on backward recompute. Regression
         test for the case where Gate cast `original_scores` back to bf16 right
         before `_compute_aux_loss`, producing bf16 saved tensors that recomputed as
         fp32 inside `torch.utils.checkpoint.NO_REENTRANT` and tripped
         `check_recomputed_tensors_match`.
+
+        Parametrized over gate_precision so both Nemotron-3-Nano's forced fp32
+        path and the default (None) path are covered.
         """
         moe_config.aux_loss_coeff = 0.01
-        # Force gate_precision=fp32 — the configuration that triggered the bug
-        # (Nemotron-3-Nano sets this in nemotron_v3/layers.py).
-        gate = Gate(moe_config, gate_precision=torch.float32)
+        gate = Gate(moe_config, gate_precision=gate_precision)
         gate = gate.to(device)
         gate.train()
 
@@ -862,11 +866,89 @@ class TestGate:
             )
             return weights.sum()
 
-        loss = torch.utils.checkpoint.checkpoint(gate_fwd, x, use_reentrant=False)
+        # Wrap in bf16 autocast so any op that promotes to fp32 (e.g. softmax) on
+        # the original forward but not on AC's recompute would surface a dtype
+        # mismatch. Mirrors the FSDP2 MixedPrecisionPolicy(cast_forward_inputs=True)
+        # pattern that the production crash was hitting on cluster.
+        autocast_device = "cuda" if device.type == "cuda" else "cpu"
+        with torch.amp.autocast(device_type=autocast_device, dtype=torch.bfloat16):
+            loss = torch.utils.checkpoint.checkpoint(gate_fwd, x, use_reentrant=False)
         # Pre-fix this raised CheckpointError("Recomputed values for the
         # following tensors have different metadata") inside the unpack hook.
         loss.backward()
         assert x.grad is not None
+
+    @pytest.mark.skipif(not HAVE_CUDA, reason="bf16-true reproduction needs CUDA for parity with cluster")
+    @pytest.mark.parametrize("gate_precision", [None, torch.float32])
+    def test_aux_loss_under_bf16_true_default_and_ac(self, moe_config, gate_precision):
+        """Faithful reproduction of the production crash. Lightning's
+        `bf16-true` precision toggles `torch.set_default_dtype(bf16)` for
+        the duration of the forward only, so intermediate tensors created
+        inside the gate (broadcasted scalars, accumulator zeros, etc.)
+        default to bf16 on the original forward but fp32 on AC's recompute
+        (which fires during backward, after default_dtype was reset).
+
+        Pre-fix this raises `CheckpointError` on a `[n_experts]` tensor
+        (per-expert expert_scores from `_compute_aux_loss`) and a scalar
+        (the aux_loss saved by `MoEAuxLossAutoScaler.forward`) — the same
+        structural pattern as the cluster failure on 128 experts. With
+        Hunks 2 (`_compute_aux_loss` fp32 pin) and 3
+        (`MoEAuxLossAutoScaler` save fp32) applied, both saved tensors are
+        fp32 on both passes and the check passes.
+        """
+        device = torch.device("cuda:0")
+        torch.cuda.set_device(device)
+
+        moe_config.aux_loss_coeff = 0.01
+        # bf16-true: master params are bf16, no fp32 master copy.
+        gate = Gate(moe_config, gate_precision=gate_precision).to(device).to(torch.bfloat16)
+        gate.train()
+
+        num_tokens = 16
+        x = torch.randn(num_tokens, moe_config.dim, dtype=torch.bfloat16, device=device, requires_grad=True)
+        token_mask = torch.ones(num_tokens, dtype=torch.bool, device=device)
+
+        def gate_call(x_):
+            weights, _, aux_loss = gate(x_, token_mask, cp_mesh=None)
+            MoEAuxLossAutoScaler.main_loss_backward_scale = torch.tensor(1.0, device=x_.device)
+            return weights.sum()
+
+        # Mimic Lightning bf16-true: default_dtype=bf16 ONLY around the outer
+        # forward call. AC's recompute will run during loss.backward() below,
+        # at which point default_dtype is back to fp32.
+        saved_default = torch.get_default_dtype()
+        torch.set_default_dtype(torch.bfloat16)
+        try:
+            loss = torch.utils.checkpoint.checkpoint(gate_call, x, use_reentrant=False)
+        finally:
+            torch.set_default_dtype(saved_default)
+
+        loss.backward()
+        assert x.grad is not None
+
+    def test_compute_aux_loss_returns_fp32(self, moe_config, device):
+        """`_compute_aux_loss` must return fp32 regardless of input dtypes.
+        This is the dtype contract that makes the path AC-safe: saved tensors
+        inside the function are all fp32, so forward and recompute cannot
+        diverge by dtype no matter what `original_scores.dtype` happens to be.
+        """
+        moe_config.aux_loss_coeff = 0.01
+        gate = Gate(moe_config, gate_precision=None).to(device)
+        gate.train()
+
+        num_tokens = 16
+        n_experts = moe_config.n_routed_experts
+        original_scores_bf16 = torch.randn(
+            num_tokens, n_experts, dtype=torch.bfloat16, device=device, requires_grad=True
+        )
+        expert_load_int = torch.randint(0, 8, (n_experts,), dtype=torch.int64, device=device)
+        token_mask = torch.ones(num_tokens, dtype=torch.bool, device=device)
+
+        loss = gate._compute_aux_loss(original_scores_bf16, expert_load_int, token_mask, cp_mesh=None)
+        assert loss.dtype == torch.float32, (
+            f"_compute_aux_loss must return fp32 to satisfy the AC saved/recomputed "
+            f"dtype contract; got {loss.dtype}."
+        )
 
     def test_gate_update_bias(self, moe_config, device):
         """Test gate bias update mechanism."""
@@ -1421,6 +1503,24 @@ class TestMoEAuxLossAutoScaler:
 
         assert output.grad is not None
         assert torch.allclose(output.grad, torch.full_like(output, 2.0))
+
+    def test_apply_inside_activation_checkpoint_with_bf16_aux_loss(self):
+        """The autoscaler must be activation-checkpoint safe even when callers
+        pass a bf16 `aux_loss`: forward saves a tensor whose dtype must equal
+        the recomputed dtype, and the only durable way to guarantee that is to
+        pin the saved tensor to fp32. Regression test for Hunk 3."""
+        output = torch.randn(4, 8, dtype=torch.bfloat16, requires_grad=True)
+        aux_loss_bf16 = torch.tensor(0.5, dtype=torch.bfloat16, requires_grad=True)
+
+        def fwd(out_, aux_):
+            return MoEAuxLossAutoScaler.apply(out_, aux_).sum()
+
+        loss = torch.utils.checkpoint.checkpoint(fwd, output, aux_loss_bf16, use_reentrant=False)
+        # Pre-fix this raised CheckpointError if any inner op produced an fp32
+        # tensor on recompute that was saved as bf16 on forward.
+        loss.backward()
+        assert output.grad is not None
+        assert aux_loss_bf16.grad is not None
 
 
 class TestGateAuxLossGradientFlow:

--- a/tests/unit_tests/moe/test_layers.py
+++ b/tests/unit_tests/moe/test_layers.py
@@ -828,6 +828,46 @@ class TestGate:
         assert aux_loss.numel() == 1  # Scalar loss
         assert aux_loss.requires_grad
 
+    def test_gate_aux_loss_under_activation_checkpointing(self, moe_config, device):
+        """Aux-loss path must be activation-checkpoint safe: saved tensors that AC
+        observes during forward must match dtype on backward recompute. Regression
+        test for the case where Gate cast `original_scores` back to bf16 right
+        before `_compute_aux_loss`, producing bf16 saved tensors that recomputed as
+        fp32 inside `torch.utils.checkpoint.NO_REENTRANT` and tripped
+        `check_recomputed_tensors_match`.
+        """
+        moe_config.aux_loss_coeff = 0.01
+        # Force gate_precision=fp32 — the configuration that triggered the bug
+        # (Nemotron-3-Nano sets this in nemotron_v3/layers.py).
+        gate = Gate(moe_config, gate_precision=torch.float32)
+        gate = gate.to(device)
+        gate.train()
+
+        num_tokens = 16
+        x = torch.randn(
+            num_tokens,
+            moe_config.dim,
+            dtype=torch.bfloat16,
+            device=device,
+            requires_grad=True,
+        )
+        token_mask = torch.ones(num_tokens, dtype=torch.bool, device=device)
+
+        def gate_fwd(x_):
+            weights, _, aux_loss = gate(x_, token_mask, cp_mesh=None)
+            # Inject the aux_loss gradient the same way the real model does, so
+            # MoEAuxLossAutoScaler's saved tensor is exercised on backward.
+            MoEAuxLossAutoScaler.main_loss_backward_scale = torch.tensor(
+                1.0, device=x_.device
+            )
+            return weights.sum()
+
+        loss = torch.utils.checkpoint.checkpoint(gate_fwd, x, use_reentrant=False)
+        # Pre-fix this raised CheckpointError("Recomputed values for the
+        # following tensors have different metadata") inside the unpack hook.
+        loss.backward()
+        assert x.grad is not None
+
     def test_gate_update_bias(self, moe_config, device):
         """Test gate bias update mechanism."""
         moe_config.gate_bias_update_factor = 0.1


### PR DESCRIPTION
# What does this PR do ?

 ## Summary

Resolves an issue when Automodel is used together with PyTorch Lightning's `bf16-true` precision (`torch.set_default_dtype(torch.bfloat16)` context manager around forward), FSDP2, and activation checkpointing. Tested with Nemotron-3-Nano.

# Changelog

- Fix MoE aux-loss dtype mismatch under activation checkpointing, FSDP2, and torch.bfloat16 default dtype

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
