### PR TITLE
feat: Enable AC and dynamic-resolution vision path for Nemotron-Omni

### DIFF
--- a/nemo_automodel/components/models/nemotron_omni/model.py
+++ b/nemo_automodel/components/models/nemotron_omni/model.py
@@ -575,6 +575,112 @@ class NemotronOmniForConditionalGeneration(HFCheckpointingMixin, nn.Module, MoEF
 
         return vit_embeds
 
+    def extract_feature_dynamic(
+        self,
+        pixel_values: torch.Tensor,
+        imgs_sizes: "torch.Tensor | list[tuple[int, int]]",
+    ) -> torch.Tensor:
+        """Dynamic-resolution feature extraction (no tile splitting).
+
+        Matches vLLM's dynamic-resolution vision path for Nano v3 VL /
+        Nemotron-Omni (see 3rdparty/vllm/vllm/model_executor/models/
+        nano_nemotron_vl.py). Required when the rollout uses
+        DynamicResolutionImageTiler — tile-based `extract_feature` would
+        produce different embeddings and break rollout/train logprob
+        agreement.
+
+        Unlike vLLM's RADIO port (which supports packed `imgs_sizes=` inputs),
+        the HF RADIO from nvidia/C-RADIOv2-H only accepts a dense
+        `(B, C, H, W)` tensor. We crop each padded image back to its real
+        size and run the vision model per-image, then concatenate features.
+
+        Args:
+            pixel_values: [num_images, C, H_padded, W_padded] batch of
+                dynamically-resized images padded to the batch max (h, w).
+            imgs_sizes: [num_images, 2] actual (h, w) per image (torch tensor
+                of ints) or an equivalent list of tuples.
+
+        Returns:
+            Vision embeddings [sum_num_embeddings_after_pixel_shuffle,
+            llm_hidden_size].
+        """
+        if isinstance(imgs_sizes, torch.Tensor):
+            imgs_sizes_list: list[tuple[int, int]] = [
+                (int(imgs_sizes[i, 0].item()), int(imgs_sizes[i, 1].item()))
+                for i in range(imgs_sizes.shape[0])
+            ]
+        else:
+            imgs_sizes_list = [(int(h), int(w)) for (h, w) in imgs_sizes]
+
+        was_training = self.vision_model.training
+        self.vision_model.eval()
+
+        # Cast to the vision model's expected dtype at the boundary (not at
+        # dataset-load) to match vLLM's normalization-in-fp32 →
+        # cast-to-model-dtype-at-boundary order exactly. Pre-casting in the
+        # data pipeline produced a subtle per-token systematic bias that
+        # showed up as `sampling_importance_ratio` ~0.80 vs mbridge ~0.99.
+        vm_dtype = next(
+            (p.dtype for p in self.vision_model.parameters()),
+            pixel_values.dtype,
+        )
+        if pixel_values.dtype != vm_dtype:
+            pixel_values = pixel_values.to(dtype=vm_dtype)
+
+        per_image_feats: list[torch.Tensor] = []
+        for i, (h, w) in enumerate(imgs_sizes_list):
+            # Crop back to the real resolution before calling RADIO — the
+            # pixel_values tensor is padded to the per-batch (H_padded,
+            # W_padded). Slice both spatial dims.
+            img = pixel_values[i : i + 1, :, :h, :w]
+            out = self.vision_model(img)
+            # HF RADIO returns either a RadioOutput namedtuple or a dict when
+            # adaptors are configured. `.features` is the per-patch features
+            # (N, L, C) layout with feature_fmt='NLC'.
+            feats = getattr(out, "features", None)
+            if feats is None:
+                # Backbone dict variant.
+                feats = out["backbone"].features if isinstance(out, dict) else out[1]
+            feats = feats.to(dtype=torch.bfloat16)
+            # feats: [1, (h//p)*(w//p), C_feat]
+            per_image_feats.append(feats)
+
+        if was_training:
+            self.vision_model.train()
+
+        # Concatenate per-image features along the sequence dim so
+        # `_pixel_shuffle_dynamic_res` can split-and-shuffle them per image.
+        vit_embeds = torch.cat(per_image_feats, dim=-2)
+        vit_embeds = self._pixel_shuffle_dynamic_res(vit_embeds, imgs_sizes_list)
+        vit_embeds = self.vision_projector(vit_embeds)
+
+        return vit_embeds
+
+    def _pixel_shuffle_dynamic_res(
+        self, x: torch.Tensor, imgs_sizes: list[tuple[int, int]]
+    ) -> torch.Tensor:
+        """Per-image pixel-shuffle for dynamic-resolution outputs.
+
+        Ported from vLLM's `NanoNemotronVLMultimodal.pixel_shuffle_dynamic_res`.
+        Splits `x` along the sequence dim by per-image patch counts, reshapes
+        each split to (N, H_patches, W_patches, C_feat), applies pixel_shuffle
+        with `downsample_ratio`, and flattens back to a concatenated (N, L', C).
+        """
+        patch_dim = self.patch_size
+        seq_lens = [
+            (h // patch_dim) * (w // patch_dim) for (h, w) in imgs_sizes
+        ]
+        splits = torch.split(x, seq_lens, dim=-2)
+        out = []
+        for i, sv in enumerate(splits):
+            h = imgs_sizes[i][0] // patch_dim
+            w = imgs_sizes[i][1] // patch_dim
+            sv = sv.reshape(sv.shape[0], h, w, -1)
+            sv = self.pixel_shuffle(sv, scale_factor=self.downsample_ratio)
+            sv = sv.flatten(1, 2)
+            out.append(sv)
+        return torch.cat(out, dim=-2)
+
     def extract_video_feature(self, pixel_values_videos: torch.Tensor) -> torch.Tensor:
         """Pack ``T = video_temporal_patch_dim`` frames into channels and run the ViT.
 
@@ -653,6 +759,7 @@ class NemotronOmniForConditionalGeneration(HFCheckpointingMixin, nn.Module, MoEF
         attention_mask: Optional[torch.Tensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
         image_flags: Optional[torch.LongTensor] = None,
+        imgs_sizes: Optional[torch.LongTensor] = None,
         past_key_values: Optional[List[torch.FloatTensor]] = None,
         labels: Optional[torch.LongTensor] = None,
         sound_features: Optional[torch.FloatTensor] = None,
@@ -694,8 +801,50 @@ class NemotronOmniForConditionalGeneration(HFCheckpointingMixin, nn.Module, MoEF
         if inputs_embeds is None:
             inputs_embeds = self.language_model.get_input_embeddings()(input_ids)
 
-        # Process vision inputs
-        if pixel_values is not None and image_flags is not None:
+        # Process vision inputs. We support two mutually-exclusive paths:
+        #
+        #   1) dynamic-resolution (imgs_sizes is not None)
+        #      — matches vLLM's DynamicResolutionImageTiler. Each image is a
+        #        single variable-resolution tensor; extract_feature_dynamic
+        #        emits exactly one contiguous run of embeddings per image.
+        #
+        #   2) tile-based (image_flags is not None)
+        #      — static InternVL-style tiling with one flag per tile. Keeps
+        #        backward compatibility with callers that stick with the
+        #        checkpoint's bundled tile processor.
+        #
+        # When both are None (or pixel_values is None), we skip image
+        # injection and run the LM path on text embeddings only.
+        if pixel_values is not None and imgs_sizes is not None:
+            B, N, C = inputs_embeds.shape
+            inputs_embeds = inputs_embeds.reshape(B * N, C)
+            input_ids_flat = input_ids.reshape(B * N)
+            selected = input_ids_flat == self.img_context_token_id
+
+            vit_embeds = self.extract_feature_dynamic(pixel_values, imgs_sizes)
+            vit_embeds = vit_embeds.reshape(-1, C)
+
+            if torch.distributed.is_initialized() and torch.distributed.get_rank() == 0:
+                logger.info(
+                    f"NemotronOmni (dynamic-res): images={pixel_values.shape[0]}, "
+                    f"imgs_sizes={imgs_sizes.tolist() if isinstance(imgs_sizes, torch.Tensor) else list(imgs_sizes)}, "
+                    f"vit_embeds.shape={tuple(vit_embeds.shape)}, "
+                    f"num_<image>_positions={int(selected.sum().item())}"
+                )
+
+            try:
+                inputs_embeds[selected] = inputs_embeds[selected] * 0.0 + vit_embeds
+            except Exception as e:
+                logger.warning(
+                    f"Shape mismatch (dynamic-res): {e}, "
+                    f"inputs_embeds[selected].shape={inputs_embeds[selected].shape}, "
+                    f"vit_embeds.shape={vit_embeds.shape}"
+                )
+                n_token = int(selected.sum().item())
+                inputs_embeds[selected] = inputs_embeds[selected] * 0.0 + vit_embeds[:n_token]
+
+            inputs_embeds = inputs_embeds.reshape(B, N, C)
+        elif pixel_values is not None and image_flags is not None:
             image_flags = image_flags.squeeze(-1)
 
             B, N, C = inputs_embeds.shape

--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -118,9 +118,11 @@ def apply_ac(
     # Derive hidden_size and num_experts from model.config if not provided
     if hidden_size is None:
         cfg = getattr(model, "config", None)
-        # VLM models nest language model config under text_config
-        hidden_size = getattr(getattr(cfg, "text_config", None), "hidden_size", None) or getattr(
-            cfg, "hidden_size", None
+        # VLM models nest language model config under text_config or llm_config
+        hidden_size = (
+            getattr(getattr(cfg, "text_config", None), "hidden_size", None)
+            or getattr(getattr(cfg, "llm_config", None), "hidden_size", None)
+            or getattr(cfg, "hidden_size", None)
         )
         if hidden_size is None:
             raise ValueError("hidden_size must be provided or model must have config.hidden_size attribute")
@@ -131,7 +133,7 @@ def apply_ac(
             num_experts = _inner.moe_config.n_routed_experts
         else:
             cfg = getattr(model, "config", None)
-            text_cfg = getattr(cfg, "text_config", cfg)
+            text_cfg = getattr(cfg, "text_config", None) or getattr(cfg, "llm_config", None) or cfg
             for attr in ["num_experts", "moe_num_experts", "n_routed_experts", "num_local_experts"]:
                 if text_cfg is not None and hasattr(text_cfg, attr):
                     num_experts = getattr(text_cfg, attr)
@@ -155,6 +157,7 @@ def apply_ac(
         _model = model.model
     else:
         _model = model
+    _model = get_text_module(_model)
     for layer_id, block in _model.layers.named_children():
         if ignore_router:
             block = ptd_checkpoint_wrapper(

--- a/tests/unit_tests/models/nemotron_omni/test_nemotron_omni_dynamic_res.py
+++ b/tests/unit_tests/models/nemotron_omni/test_nemotron_omni_dynamic_res.py
@@ -1,0 +1,276 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Tests for NemotronOmni's dynamic-resolution vision path.
+
+Covers the vLLM-aligned `extract_feature_dynamic` / `_pixel_shuffle_dynamic_res`
+helpers and the `imgs_sizes` branch of `forward()`. The vision tower and LM are
+mocked so these tests stay CPU-only and don't need RADIO weights.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+from nemo_automodel.components.models.nemotron_omni.model import (
+    NemotronOmniForConditionalGeneration,
+)
+
+
+class _StubVisionModel(nn.Module):
+    """Vision model whose `forward(img)` records the (h, w) it received and
+    returns features sized to `(h//patch) * (w//patch)` patches."""
+
+    def __init__(self, patch_size: int, c_feat: int):
+        super().__init__()
+        self.patch_size = patch_size
+        self.c_feat = c_feat
+        self.dummy = nn.Parameter(torch.zeros(1))  # ensures .parameters() yields a dtype
+        self.received_shapes: list[tuple[int, int]] = []
+
+    def forward(self, img: torch.Tensor):
+        b, _, h, w = img.shape
+        assert b == 1, "extract_feature_dynamic should crop to one image at a time"
+        self.received_shapes.append((h, w))
+        l = (h // self.patch_size) * (w // self.patch_size)
+        # Encode (h, w) into the features so callers can verify per-image
+        # routing without relying on order.
+        feats = torch.full((1, l, self.c_feat), float(h * 1000 + w), dtype=torch.float32)
+        return SimpleNamespace(features=feats)
+
+
+class _IdentityProjector(nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x
+
+
+def _make_model_stub(*, patch_size=2, downsample_ratio=0.5, c_feat=16, img_token_id=18):
+    """Build a bare NemotronOmniForConditionalGeneration with only the
+    attributes the dynamic-res path touches set up. Skips the heavy __init__
+    (RADIO + LM construction)."""
+    self = object.__new__(NemotronOmniForConditionalGeneration)
+    nn.Module.__init__(self)
+    self.patch_size = patch_size
+    self.downsample_ratio = downsample_ratio
+    self.img_context_token_id = img_token_id
+    self.ps_version = "v2"
+    self.vision_model = _StubVisionModel(patch_size, c_feat)
+    self.vision_projector = _IdentityProjector()
+    return self
+
+
+# ---------------------------------------------------------------------------
+# _pixel_shuffle_dynamic_res
+# ---------------------------------------------------------------------------
+
+
+def test_pixel_shuffle_dynamic_res_splits_per_image():
+    """Per-image split lengths must match (h//p) * (w//p) for each image, and
+    pixel_shuffle must shrink spatial dims by `downsample_ratio` while inflating
+    channels by 1/scale^2."""
+    model = _make_model_stub(patch_size=2, downsample_ratio=0.5, c_feat=16)
+
+    # Two images: 4x4 patches and 2x6 patches at patch_size=2 → input HxW (8x8)
+    # and (4x12) → seq lengths 16 and 12.
+    sizes = [(8, 8), (4, 12)]
+    seq_lens = [(8 // 2) * (8 // 2), (4 // 2) * (12 // 2)]
+    assert seq_lens == [16, 12]
+    total = sum(seq_lens)
+    x = torch.arange(total * 16, dtype=torch.float32).reshape(1, total, 16)
+
+    out = model._pixel_shuffle_dynamic_res(x, sizes)
+
+    # downsample_ratio=0.5 → spatial dims halved per side, channels x4.
+    # Image 1: (4, 4) → (2, 2) flat=4, c=64. Image 2: (2, 6) → (1, 3) flat=3, c=64.
+    expected_total = 4 + 3
+    assert out.shape == (1, expected_total, 64)
+
+
+def test_pixel_shuffle_dynamic_res_rejects_mismatched_sizes():
+    """If `sum(seq_lens)` doesn't match the input length, torch.split raises —
+    catching upstream bugs that pass wrong imgs_sizes."""
+    model = _make_model_stub(patch_size=2, downsample_ratio=0.5, c_feat=16)
+    x = torch.zeros(1, 16, 16)
+    # (4,4) at patch=2 → seq_len 4, not 16
+    with pytest.raises(RuntimeError):
+        model._pixel_shuffle_dynamic_res(x, [(4, 4)])
+
+
+# ---------------------------------------------------------------------------
+# extract_feature_dynamic
+# ---------------------------------------------------------------------------
+
+
+def test_extract_feature_dynamic_crops_padded_input_to_real_size():
+    """pixel_values is padded to per-batch max (H, W). extract_feature_dynamic
+    must crop each image back to its real (h, w) before calling the ViT — the
+    HF RADIO can't accept packed/variable inputs."""
+    model = _make_model_stub(patch_size=2, downsample_ratio=0.5, c_feat=16)
+
+    # Padded batch: 2 images, both materialized as 12x12 even though true sizes
+    # differ. Channel count = 3.
+    pixel_values = torch.zeros(2, 3, 12, 12)
+    sizes = torch.tensor([[8, 8], [4, 12]], dtype=torch.long)
+
+    out = model.extract_feature_dynamic(pixel_values, sizes)
+
+    # The vision_model must have been called exactly twice with the cropped sizes.
+    assert model.vision_model.received_shapes == [(8, 8), (4, 12)]
+
+    # Output should be the projector(pixel_shuffle(...)) of concatenated features.
+    # With downsample_ratio=0.5 and patch_size=2:
+    #   img 1: (4,4) → (2,2) flat=4
+    #   img 2: (2,6) → (1,3) flat=3
+    assert out.shape == (1, 7, 64)
+    # The stub features encode (h*1000 + w); the dynamic path casts to bfloat16
+    # internally so check via float() equality on a low-precision range.
+    assert out.dtype == torch.bfloat16
+
+
+def test_extract_feature_dynamic_accepts_list_sizes():
+    """imgs_sizes may arrive as a tensor or as a list of tuples."""
+    model = _make_model_stub(patch_size=2, downsample_ratio=0.5, c_feat=16)
+
+    pixel_values = torch.zeros(1, 3, 8, 8)
+    out_list = model.extract_feature_dynamic(pixel_values, [(8, 8)])
+    out_tensor = model.extract_feature_dynamic(
+        pixel_values, torch.tensor([[8, 8]], dtype=torch.long)
+    )
+    assert out_list.shape == out_tensor.shape
+
+
+def test_extract_feature_dynamic_restores_train_mode():
+    """The vision tower is force-evaled during feature extraction; train mode
+    must be restored on exit when it was originally training."""
+    model = _make_model_stub()
+    model.vision_model.train()
+    assert model.vision_model.training
+
+    model.extract_feature_dynamic(torch.zeros(1, 3, 8, 8), [(8, 8)])
+
+    assert model.vision_model.training, "train mode should be restored"
+
+
+# ---------------------------------------------------------------------------
+# forward() dynamic-resolution branch
+# ---------------------------------------------------------------------------
+
+
+class _StubLM(nn.Module):
+    """Mocks just enough of NemotronV3ForCausalLM for forward() to run."""
+
+    def __init__(self, hidden_size: int):
+        super().__init__()
+        self.captured_inputs_embeds: torch.Tensor | None = None
+        self.embed = nn.Embedding(32, hidden_size)
+
+    def get_input_embeddings(self):
+        return self.embed
+
+    def forward(self, *, input_ids=None, attention_mask=None, position_ids=None,
+                inputs_embeds=None, labels=None, use_cache=None,
+                output_attentions=None, output_hidden_states=None,
+                return_dict=None, **kwargs):
+        # Capture the post-injection embeddings so the test can assert on them.
+        self.captured_inputs_embeds = inputs_embeds.detach().clone()
+        from transformers.modeling_outputs import CausalLMOutputWithPast
+        return CausalLMOutputWithPast(loss=None, logits=inputs_embeds)
+
+
+def test_forward_dynamic_res_branch_fills_image_slots():
+    """When pixel_values + imgs_sizes are passed, forward() must:
+    - take the dynamic-res branch (not the tile-based one);
+    - call extract_feature_dynamic with the padded pixel_values + imgs_sizes;
+    - replace exactly the <image> token slots with vit_embeds (channels = LM hidden).
+    """
+    # LM hidden must equal c_feat * (1/scale)^2 because the identity projector
+    # passes pixel-shuffled features straight through. patch=2, scale=0.5, c=16 → 64.
+    hidden = 64
+    model = _make_model_stub(patch_size=2, downsample_ratio=0.5, c_feat=16, img_token_id=18)
+    model.language_model = _StubLM(hidden_size=hidden)
+
+    # Sequence: 2 batch x 6 tokens; image tokens scattered.
+    img = 18
+    txt = 5
+    input_ids = torch.tensor(
+        [[txt, img, img, img, img, txt],
+         [img, img, img, txt, txt, txt]],
+        dtype=torch.long,
+    )
+    # Pre-compute embeddings so we can verify text positions are untouched.
+    inputs_embeds = torch.randn(2, 6, hidden)
+    text_mask = (input_ids != img)
+    expected_text = inputs_embeds[text_mask].clone()
+
+    # Two images, padded to 12x12. img 1 real size 8x8, img 2 real size 4x12.
+    # After dynamic pixel-shuffle:
+    #   img 1: (4,4) patch grid → (2,2) flat=4 → 4 image-slot embeddings
+    #   img 2: (2,6) patch grid → (1,3) flat=3 → 3 image-slot embeddings
+    # Total = 7 image-token positions in input_ids, which matches.
+    pixel_values = torch.zeros(2, 3, 12, 12)
+    imgs_sizes = torch.tensor([[8, 8], [4, 12]], dtype=torch.long)
+
+    model(
+        input_ids=input_ids,
+        inputs_embeds=inputs_embeds.clone(),
+        pixel_values=pixel_values,
+        imgs_sizes=imgs_sizes,
+    )
+
+    final = model.language_model.captured_inputs_embeds
+    assert final is not None
+    assert final.shape == (2, 6, hidden)
+
+    # Text positions must equal the original embeddings (no overwrite).
+    torch.testing.assert_close(final[text_mask], expected_text.to(final.dtype))
+
+    # Image positions should NOT be the original random embeddings — they were
+    # zero-multiplied and replaced.
+    assert not torch.allclose(final[~text_mask].float(), inputs_embeds[~text_mask])
+
+
+def test_forward_prefers_dynamic_res_over_image_flags_when_both_present():
+    """If imgs_sizes is set, the dynamic-res branch wins regardless of image_flags."""
+    hidden = 64
+    model = _make_model_stub(patch_size=2, downsample_ratio=0.5, c_feat=16, img_token_id=18)
+    model.language_model = _StubLM(hidden_size=hidden)
+
+    # Spy on extract_feature_dynamic vs extract_feature.
+    calls = {"dynamic": 0, "tile": 0}
+    orig_dynamic = model.extract_feature_dynamic
+    orig_tile = model.extract_feature
+
+    def spy_dynamic(pv, sz):
+        calls["dynamic"] += 1
+        return orig_dynamic(pv, sz)
+
+    def spy_tile(pv):
+        calls["tile"] += 1
+        return orig_tile(pv)
+
+    model.extract_feature_dynamic = spy_dynamic
+    model.extract_feature = spy_tile
+
+    input_ids = torch.tensor([[5, 18, 18, 18, 18]], dtype=torch.long)
+    inputs_embeds = torch.randn(1, 5, hidden)
+    pixel_values = torch.zeros(1, 3, 8, 8)
+    imgs_sizes = torch.tensor([[8, 8]], dtype=torch.long)
+    image_flags = torch.tensor([[1]], dtype=torch.long)
+
+    model(
+        input_ids=input_ids,
+        inputs_embeds=inputs_embeds,
+        pixel_values=pixel_values,
+        imgs_sizes=imgs_sizes,
+        image_flags=image_flags,
+    )
+
+    assert calls["dynamic"] == 1
+    assert calls["tile"] == 0

--- a/tests/unit_tests/moe/test_parallelizer.py
+++ b/tests/unit_tests/moe/test_parallelizer.py
@@ -1385,6 +1385,143 @@ def test_apply_ac_explicit_params_override_config(monkeypatch):
     assert captured_num_experts == 64
 
 
+def test_apply_ac_derives_from_llm_config(monkeypatch):
+    """VLM nests LM config under llm_config (not text_config) — apply_ac must fall back to it."""
+    P = _import_parallelizer_with_stubs(monkeypatch)
+
+    captured_hidden_size = None
+    captured_num_experts = None
+
+    def fake_create_selective_checkpoint_contexts(policy_cb):
+        nonlocal captured_hidden_size, captured_num_experts
+        torch_stub = sys.modules["torch"]
+        for hs in [128, 256, 512, 1024]:
+            for ne in [8, 16, 32, 64]:
+                rhs = type("Mat", (), {"shape": (hs, ne)})()
+                if policy_cb(None, torch_stub.ops.aten.mm.default, object(), rhs) == P.CheckpointPolicy.MUST_SAVE:
+                    captured_hidden_size = hs
+                    captured_num_experts = ne
+                    break
+            if captured_hidden_size is not None:
+                break
+        return "CTX"
+
+    def fake_wrapper(block, preserve_rng_state, context_fn=None):
+        if context_fn is not None:
+            context_fn()
+        return block
+
+    monkeypatch.setattr(P, "create_selective_checkpoint_contexts", fake_create_selective_checkpoint_contexts)
+    monkeypatch.setattr(P, "ptd_checkpoint_wrapper", MagicMock(side_effect=fake_wrapper))
+
+    class LLMConfig:
+        hidden_size = 512
+        num_experts = 32
+
+    # No text_config and no top-level hidden_size/num_experts — must come from llm_config.
+    class Config:
+        llm_config = LLMConfig()
+
+    class ModelWithLLMConfig:
+        def __init__(self):
+            self.config = Config()
+            self.layers = LayerContainer([DummyBlock()])
+
+    P.apply_ac(ModelWithLLMConfig(), ignore_router=True)
+
+    assert captured_hidden_size == 512
+    assert captured_num_experts == 32
+
+
+def test_apply_ac_text_config_takes_priority_over_llm_config(monkeypatch):
+    """When both text_config and llm_config define hidden_size/num_experts, text_config wins."""
+    P = _import_parallelizer_with_stubs(monkeypatch)
+
+    captured_hidden_size = None
+    captured_num_experts = None
+
+    def fake_create_selective_checkpoint_contexts(policy_cb):
+        nonlocal captured_hidden_size, captured_num_experts
+        torch_stub = sys.modules["torch"]
+        for hs in [128, 256, 512, 1024]:
+            for ne in [8, 16, 32, 64]:
+                rhs = type("Mat", (), {"shape": (hs, ne)})()
+                if policy_cb(None, torch_stub.ops.aten.mm.default, object(), rhs) == P.CheckpointPolicy.MUST_SAVE:
+                    captured_hidden_size = hs
+                    captured_num_experts = ne
+                    break
+            if captured_hidden_size is not None:
+                break
+        return "CTX"
+
+    monkeypatch.setattr(P, "create_selective_checkpoint_contexts", fake_create_selective_checkpoint_contexts)
+    monkeypatch.setattr(P, "ptd_checkpoint_wrapper", MagicMock(side_effect=lambda b, **kw: (kw.get("context_fn") and kw["context_fn"](), b)[1]))
+
+    class TextConfig:
+        hidden_size = 256
+        num_experts = 16
+
+    class LLMConfig:
+        hidden_size = 1024
+        num_experts = 64
+
+    class Config:
+        text_config = TextConfig()
+        llm_config = LLMConfig()
+
+    class ModelBoth:
+        def __init__(self):
+            self.config = Config()
+            self.layers = LayerContainer([DummyBlock()])
+
+    P.apply_ac(ModelBoth(), ignore_router=True)
+
+    assert captured_hidden_size == 256
+    assert captured_num_experts == 16
+
+
+def test_apply_ac_routes_through_get_text_module(monkeypatch):
+    """For VLMs, apply_ac must wrap layers under the text sub-module (LM), not the outer wrapper."""
+    P = _import_parallelizer_with_stubs(monkeypatch)
+
+    class LM:
+        def __init__(self, blocks):
+            self.layers = LayerContainer(blocks)
+
+    class VLMInner:
+        def __init__(self, lm_blocks, vit_blocks):
+            self.language_model = LM(lm_blocks)
+            # distractor: vision tower also has .layers — must NOT be wrapped.
+            self.vision_tower = type("ViT", (), {"layers": LayerContainer(vit_blocks)})()
+            # The inner module also exposes .layers (would be hit pre-fix), but
+            # get_text_module redirects past it.
+            self.layers = LayerContainer([DummyBlock(), DummyBlock(), DummyBlock()])
+
+    class VLMOuter:
+        def __init__(self, lm_blocks, vit_blocks):
+            self.config = type("Cfg", (), {"hidden_size": 256, "num_experts": 16})()
+            self.model = VLMInner(lm_blocks, vit_blocks)
+
+    # Override get_text_module to drill into language_model (mimics the real helper).
+    def vlm_get_text_module(m):
+        return m.language_model if hasattr(m, "language_model") else m
+
+    monkeypatch.setattr(P, "get_text_module", vlm_get_text_module)
+    monkeypatch.setattr(P, "create_selective_checkpoint_contexts", MagicMock(return_value="CTX"))
+    monkeypatch.setattr(P, "ptd_checkpoint_wrapper", MagicMock(side_effect=lambda b, **kw: b))
+
+    lm_blocks = [DummyBlock(), DummyBlock()]
+    vit_blocks = [DummyBlock(), DummyBlock(), DummyBlock(), DummyBlock()]
+    model = VLMOuter(lm_blocks, vit_blocks)
+
+    P.apply_ac(model, ignore_router=True)
+
+    # LM layers should be re-registered (wrapped); vision_tower and inner.layers untouched.
+    assert set(model.model.language_model.layers.registered.keys()) == {"0", "1"}
+    assert model.model.vision_tower.layers.registered == {}
+    assert model.model.layers.registered == {}
+
+
 def test_parallelize_model_passes_ignore_router_for_ac_to_apply_ac(monkeypatch):
     """Test that parallelize_model passes ignore_router_for_ac to apply_ac."""
     P = _import_parallelizer_with_stubs(monkeypatch)


### PR DESCRIPTION


## Motivation

When using Nemotron-Omni / Nano v3 VL in RL-style training where the rollout is served by vLLM, two gaps prevented training from running correctly and efficiently:

1. Related to https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16/commit/8e00a7f6c072777ccb412f356024d9c92f602c80. **Train/rollout vision divergence.** vLLM uses a [`DynamicResolutionImageTiler`](https://github.com/vllm-project/vllm/blob/4b95e9cec4e9a1a90d3f4b2afa62e88459b2b90e/vllm/transformers_utils/processors/nano_nemotron_vl.py#L257) (one variable-resolution tensor per image, no tile splitting), but Automodel only had the static InternVL-style tile path. Same image → different ViT embeddings on the two sides → broken rollout/train logprob agreement.
2. **No activation checkpointing for the VLM.** `apply_ac` looked up `hidden_size` / `num_experts` only under `config.text_config` and wrapped layers on the outer module — both wrong for Nemotron-Omni, which nests the LM under `config.llm_config` and `model.language_model`. 

## What this PR adds

- **Dynamic-resolution vision path** (`nemo_automodel/components/models/nemotron_omni/model.py`)
  - New `extract_feature_dynamic` that crops each padded image back to its real `(h, w)` and runs RADIO per-image, matching vLLM's `NanoNemotronVLMultimodal` numerically (boundary-cast to ViT dtype, eval-mode spectral reparam).
  - New `_pixel_shuffle_dynamic_res` ported from vLLM — splits features by per-image patch counts, shuffles each, concatenates.
  - `forward()` now accepts `imgs_sizes` and dispatches to the dynamic-res branch when present; falls back to the existing tile-based `image_flags` path otherwise (fully backward compatible).

- **AC works for the VLM** (`nemo_automodel/components/moe/parallelizer.py`)
  - `apply_ac` config lookup now also consults `config.llm_config` (in addition to `text_config`).
  - Routes through `get_text_module(_model)` so blocks are wrapped under `language_model.layers`, not the outer wrapper or the vision tower.