### PR TITLE
fix: update deployment requirements

### DIFF
--- a/docker/Dockerfile.deploy
+++ b/docker/Dockerfile.deploy
@@ -21,7 +21,8 @@ RUN pip install --no-build-isolation --no-binary=mamba-ssm,causal-conv1d \
     mamba-ssm causal-conv1d
 
 # Test dependencies
-RUN pip install peft pytest pyyaml
+RUN --mount=type=bind,source=tests/ci_tests/requirements_deploy.txt,target=/tmp/requirements_deploy.txt \
+    pip install -r /tmp/requirements_deploy.txt
 
 COPY . /opt/Automodel
 WORKDIR /opt/Automodel

--- a/tests/ci_tests/requirements_deploy.txt
+++ b/tests/ci_tests/requirements_deploy.txt
@@ -1,4 +1,5 @@
-vllm==0.19.0
-peft==0.18.1
+peft
 pytest
 pyyaml
+# Required by Nemotron-Flash modeling code loaded via trust_remote_code
+flash-linear-attention


### PR DESCRIPTION
# What does this PR do ?

  - `nemotron_flash_1b_squad_peft_vllm_deploy` was failing with `ModuleNotFoundError: No module named 'fla'`; the Nemotron-Flash modeling code (loaded via `trust_remote_code`) requires `flash-linear-attention`.
  - Added it to `tests/ci_tests/requirements_deploy.txt` and switched `Dockerfile.deploy` to install via `RUN --mount=type=bind`. Also dropped `vllm==0.19.0` (already in the base image) and unpinned `peft`.

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
