### PR TITLE
fix: update stale _peft import in vlm_generate example

### DIFF
--- a/examples/vlm_generate/generate.py
+++ b/examples/vlm_generate/generate.py
@@ -40,9 +40,9 @@ import torch
 from PIL import Image
 from transformers import AutoProcessor
 
-from nemo_automodel._peft.lora import PeftConfig, apply_lora_to_linear_modules
 from nemo_automodel._transformers import NeMoAutoModelForImageTextToText
 from nemo_automodel.checkpoint.checkpointing import CheckpointingConfig, load_model
+from nemo_automodel.components._peft.lora import PeftConfig, apply_lora_to_linear_modules
 from nemo_automodel.loggers.log_utils import setup_logging
 
 # TODO: Parse config from YAML and run generate with FSDP2/distributed in general


### PR DESCRIPTION
## Summary

`examples/vlm_generate/generate.py` still imported from the pre-reorg path `nemo_automodel._peft.lora`, which no longer exists in the package (`_peft` now lives under `nemo_automodel.components._peft`, and there is no compat shim for the old path).

Running the example from `main` therefore fails with:

```
ModuleNotFoundError: No module named 'nemo_automodel._peft'
```

This patches the import to the current location. One-line change.

Reported in #2095.

## Test plan

- [x] `python -c "from nemo_automodel.components._peft.lora import PeftConfig, apply_lora_to_linear_modules"` succeeds
- [ ] Re-run the VLM generate flow from #2095 (Qwen 2.5 VL 3B + distcp checkpoint) end-to-end