### PR TITLE
fix(ci): add retry with backoff to approve-test-queue bot

### DIFF
--- a/.github/workflows/cicd-approve-test-queue.yml
+++ b/.github/workflows/cicd-approve-test-queue.yml
@@ -45,6 +45,7 @@ jobs:
           python - <<EOF
           import os
           import requests
+          import time
 
 
           # GitHub API configuration
@@ -60,26 +61,51 @@ jobs:
               "X-GitHub-Api-Version": "2022-11-28",
           }
 
-          def make_request(endpoint, method="GET", data=None):
-              """Make a request to the GitHub API with error handling."""
+          def make_request(endpoint, method="GET", data=None, max_retries=5):
+              """Make a request to the GitHub API with retry on transient errors."""
               url = f"{API_BASE}/{endpoint}"
-              try:
-                  if method == "GET":
-                      response = requests.get(url, headers=headers)
-                  else:
-                      response = requests.post(url, headers=headers, json=data)
-                  response.raise_for_status()
-                  return response.json()
-              except requests.exceptions.RequestException as e:
-                  print(f"Error making request to {endpoint}: {str(e)}")
-                  if hasattr(e.response, 'text'):
-                      print(f"Response: {e.response.text}")
-                  return None
+              for attempt in range(max_retries):
+                  try:
+                      if method == "GET":
+                          response = requests.get(url, headers=headers, timeout=30)
+                      else:
+                          response = requests.post(url, headers=headers, json=data, timeout=30)
+                      if response.status_code == 429:
+                          retry_after = int(response.headers.get("Retry-After", 2 ** attempt))
+                          print(f"Rate limited on {endpoint}, retrying in {retry_after}s (attempt {attempt + 1}/{max_retries})")
+                          time.sleep(retry_after)
+                          continue
+                      if response.status_code >= 500:
+                          delay = 2 ** attempt
+                          print(f"Server error {response.status_code} on {endpoint}, retrying in {delay}s (attempt {attempt + 1}/{max_retries})")
+                          time.sleep(delay)
+                          continue
+                      response.raise_for_status()
+                      return response.json()
+                  except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
+                      delay = 2 ** attempt
+                      print(f"Transient error on {endpoint}: {e}, retrying in {delay}s (attempt {attempt + 1}/{max_retries})")
+                      time.sleep(delay)
+                  except requests.exceptions.RequestException as e:
+                      print(f"Error making request to {endpoint}: {str(e)}")
+                      if hasattr(e, 'response') and e.response is not None:
+                          print(f"Response: {e.response.text}")
+                      return None
+              print(f"Max retries ({max_retries}) exceeded for {endpoint}")
+              return None
 
           # Get current running and queued workflows
           print("Fetching workflow runs...")
-          queued_workflow_runs = make_request("actions/runs?status=queued").get("workflow_runs", [])
-          in_progress_workflow_runs = make_request("actions/runs?status=in_progress").get("workflow_runs", [])
+          queued_resp = make_request("actions/runs?status=queued")
+          if queued_resp is None:
+              print("Failed to fetch queued workflow runs after retries, exiting")
+              exit(1)
+          queued_workflow_runs = queued_resp.get("workflow_runs", [])
+          in_progress_resp = make_request("actions/runs?status=in_progress")
+          if in_progress_resp is None:
+              print("Failed to fetch in-progress workflow runs after retries, exiting")
+              exit(1)
+          in_progress_workflow_runs = in_progress_resp.get("workflow_runs", [])
 
           # Count running and queued workflows
           queued_workflows = sum(1 for run in queued_workflow_runs if run["name"] == "CICD NeMo")
@@ -97,7 +123,11 @@ jobs:
 
           # Get waiting CI workflows for test environment
           print("Fetching deployments...")
-          pending_workflows = make_request("actions/runs?status=waiting").get("workflow_runs", [])
+          waiting_resp = make_request("actions/runs?status=waiting")
+          if waiting_resp is None:
+              print("Failed to fetch waiting workflow runs after retries, exiting")
+              exit(1)
+          pending_workflows = waiting_resp.get("workflow_runs", [])
           pending_workflows = [run for run in pending_workflows if run["name"] == "CICD NeMo"]
 
           # Sort deployments by creation date (oldest first)
@@ -116,7 +146,11 @@ jobs:
               print(f"Approving workflow {workflow_name} with Run Id: {workflow_id}")
 
               deployment_url = f"actions/runs/{workflow_id}/pending_deployments"
-              deployment = make_request(deployment_url)[0]
+              deployments = make_request(deployment_url)
+              if not deployments:
+                  print(f"Failed to fetch pending deployments for run {workflow_id}")
+                  exit(1)
+              deployment = deployments[0]
               environment_id = deployment["environment"]["id"]
 
               # Approve the deployment


### PR DESCRIPTION
<details><summary>Claude summary</summary>

Port of NVIDIA-NeMo/Megatron-Bridge#3607.

`make_request` returned `None` on transient connection timeouts, but all call sites chained `.get()` or `[0]` directly on the result, causing an immediate `AttributeError` crash.

**Changes:**
- `make_request` now retries up to 5 times with exponential backoff (`2^attempt` seconds) for `ConnectionError`, `Timeout`, HTTP 429 (honours `Retry-After`), and HTTP 5xx
- Explicit `timeout=30` added to every request so OS-level hangs can't block indefinitely
- All four unsafe call sites guard against a `None` return after exhausted retries and exit with a clear message

</details>
