### PR TITLE
chore(ty): surface unresolved imports + fix stale paths in vlm_generate

### DIFF
--- a/examples/vlm_generate/generate.py
+++ b/examples/vlm_generate/generate.py
@@ -41,9 +41,9 @@ from PIL import Image
 from transformers import AutoProcessor
 
 from nemo_automodel._transformers import NeMoAutoModelForImageTextToText
-from nemo_automodel.checkpoint.checkpointing import CheckpointingConfig, load_model
 from nemo_automodel.components._peft.lora import PeftConfig, apply_lora_to_linear_modules
-from nemo_automodel.loggers.log_utils import setup_logging
+from nemo_automodel.components.checkpoint.checkpointing import Checkpointer, CheckpointingConfig
+from nemo_automodel.components.loggers.log_utils import setup_logging
 
 # TODO: Parse config from YAML and run generate with FSDP2/distributed in general
 
@@ -125,7 +125,7 @@ def load_model_from_checkpoint(
         Loaded NeMoAutoModelForImageTextToText model
     """
     # initialize distributed
-    from nemo_automodel.distributed.init_utils import initialize_distributed
+    from nemo_automodel.components.distributed.init_utils import initialize_distributed
 
     initialize_distributed(backend="nccl", timeout_minutes=10)
     device = "cuda" if torch.cuda.is_available() else "cpu"
@@ -159,7 +159,13 @@ def load_model_from_checkpoint(
         save_consolidated=False,
         is_peft=is_peft_checkpoint(checkpoint_path),
     )
-    load_model(model, str(checkpoint_path), checkpoint_config)
+    checkpointer = Checkpointer(
+        config=checkpoint_config,
+        dp_rank=0,
+        tp_rank=0,
+        pp_rank=0,
+    )
+    checkpointer.load_model(model, model_path)
     logging.info(f"✅ Model loaded successfully from {checkpoint_path}")
     return model
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -405,14 +405,47 @@ ignore_imports = [
 python-version = "3.10"
 
 [tool.ty.src]
-include = ["nemo_automodel"]
+include = ["nemo_automodel", "examples"]
 exclude = [
     "tests/**",
     "nemo_automodel/components/checkpoint/_backports/**",
 ]
 
 [tool.ty.analysis]
-allowed-unresolved-imports = ["**"]
+# Optional dependencies that ty cannot resolve in this env but are legitimately
+# imported under try/except or feature gates. Keep this list narrow so that
+# accidental stale imports (e.g. after a package reorg) are still surfaced.
+allowed-unresolved-imports = [
+    "bitsandbytes",
+    "causal_conv1d",
+    "comet_ml",
+    "cut_cross_entropy",
+    "cut_cross_entropy.**",
+    "databricks",
+    "databricks.**",
+    "deep_ep",
+    "deep_ep.**",
+    "dion",
+    "fast_hadamard_transform",
+    "fla.**",
+    "flash_attn",
+    "grouped_gemm",
+    "liger_kernel.**",
+    "lmdb",
+    "mamba_ssm.**",
+    "megatron.**",
+    "nemo_automodel.components.datasets.llm.megatron.helpers_cpp",
+    "nemo_run",
+    "pynvml",
+    "sky",
+    "torch.distributed._mesh_layout",
+    "transformer_engine",
+    "transformer_engine.**",
+    "transformer_engine_torch",
+    "transformers.tokenization_utils",
+    "uccl",
+    "uccl.**",
+]
 
 [tool.ty.rules]
 unused-ignore-comment = "warn"


### PR DESCRIPTION
## Summary

Tightens the `ty` type-checker configuration so that unresolved imports get flagged. This catches a class of bug that ruff cannot — stale module paths after a package reorg, like the one fixed in #2097 (originally reported as #2095).

### Why ruff didn't catch it

Ruff is a syntactic linter. `from foo.bar import Baz` binds `Baz` regardless of whether `foo.bar` resolves on disk. `F401` only fires when the imported name is unused; `F821` only fires when an unbound name is referenced. There is no ruff rule for "this import path doesn't resolve" — that requires actual import resolution, which is a type-checker's job.

The repo already configures `ty`, but with `allowed-unresolved-imports = [\"**\"]` (silences everything) and `include = [\"nemo_automodel\"]` (excludes `examples/`), so ty wouldn't have caught it either.

### Changes

- **`pyproject.toml`**:
  - Add `examples` to `[tool.ty.src] include`.
  - Replace the wildcard allowlist with a narrow list of legitimate optional deps (`transformer_engine.**`, `flash_attn`, `mamba_ssm.**`, `nemo_run`, `deep_ep.**`, `uccl.**`, `megatron.**`, `fla.**`, `liger_kernel.**`, `cut_cross_entropy.**`, `databricks.**`, `bitsandbytes`, etc.). Globs use `pkg.**` because `*` doesn't cross dots.
- **`examples/vlm_generate/generate.py`**: the new check immediately surfaced four issues:
  1. Three more stale `nemo_automodel.*` import paths that #2097 missed (`nemo_automodel.checkpoint.checkpointing`, `nemo_automodel.loggers.log_utils`, `nemo_automodel.distributed.init_utils`) — fixed.
  2. A genuine runtime bug: `load_model` was imported as a free function from `checkpointing`, but it has only ever been a method on `Checkpointer` (verified back to `772d317b`, the commit that introduced the file). Refactored the call site to instantiate `Checkpointer` and call `.load_model(model, model_path)`, matching the pattern at `nemo_automodel/recipes/base_recipe.py:566`. With single-process inference, ranks are `0/0/0`.

### Verification

- `unresolved-import` count: **81 → 0** with the new config.
- Reintroduced `from nemo_automodel._peft.lora ...` locally and confirmed `ty check` fails with `error[unresolved-import]: Cannot resolve imported module nemo_automodel._peft.lora` — exactly the bug class we want to catch in the future.
- `ruff check` clean on changed files.

### Caveats

- I did not run the example end-to-end (needs GPUs + a real VLM checkpoint). The `Checkpointer` refactor is structurally consistent with the existing recipe usage, but first-run validation by a maintainer is welcome.
- 2675 unrelated pre-existing ty diagnostics remain — out of scope for this PR.

## Test plan

- [ ] CI green (CICD NeMo).
- [ ] Manual smoke run of `examples/vlm_generate/generate.py` against a saved DCP checkpoint (optional; structural change only).