### PR TITLE
fix: use config.expert_dim for MoE expert LoRA init

### DIFF
--- a/nemo_automodel/components/_peft/lora_experts.py
+++ b/nemo_automodel/components/_peft/lora_experts.py
@@ -92,10 +92,11 @@ class GroupedExpertsLoRA(GroupedExperts):
         device = obj.gate_and_up_projs.device
 
         up_proj_dim = obj.config.moe_inter_dim * 2 if obj.is_gated else obj.config.moe_inter_dim
+        expert_dim = obj.config.expert_dim
 
         # LoRA weights for gate+up (or just up if non-gated) and down projections
         obj.lora_gate_and_up_A = nn.Parameter(
-            torch.empty(obj.n_routed_experts, obj.config.dim, lora_dim, dtype=dtype, device=device)
+            torch.empty(obj.n_routed_experts, expert_dim, lora_dim, dtype=dtype, device=device)
         )
         obj.lora_gate_and_up_B = nn.Parameter(
             torch.empty(obj.n_routed_experts, lora_dim, up_proj_dim, dtype=dtype, device=device)
@@ -105,7 +106,7 @@ class GroupedExpertsLoRA(GroupedExperts):
             torch.empty(obj.n_routed_experts, obj.config.moe_inter_dim, lora_dim, dtype=dtype, device=device)
         )
         obj.lora_down_B = nn.Parameter(
-            torch.empty(obj.n_routed_experts, lora_dim, obj.config.dim, dtype=dtype, device=device)
+            torch.empty(obj.n_routed_experts, lora_dim, expert_dim, dtype=dtype, device=device)
         )
 
         # Initialize LoRA weights
@@ -410,10 +411,11 @@ class GroupedExpertsDeepEPLoRA(GroupedExpertsDeepEP):
         device = obj.gate_and_up_projs.device
 
         up_proj_dim = obj.config.moe_inter_dim * 2 if obj.is_gated else obj.config.moe_inter_dim
+        expert_dim = obj.config.expert_dim
 
         # LoRA weights
         obj.lora_gate_and_up_A = nn.Parameter(
-            torch.empty(obj.config.n_routed_experts, obj.config.dim, lora_dim, dtype=dtype, device=device)
+            torch.empty(obj.config.n_routed_experts, expert_dim, lora_dim, dtype=dtype, device=device)
         )
         obj.lora_gate_and_up_B = nn.Parameter(
             torch.empty(obj.config.n_routed_experts, lora_dim, up_proj_dim, dtype=dtype, device=device)
@@ -423,7 +425,7 @@ class GroupedExpertsDeepEPLoRA(GroupedExpertsDeepEP):
             torch.empty(obj.config.n_routed_experts, obj.config.moe_inter_dim, lora_dim, dtype=dtype, device=device)
         )
         obj.lora_down_B = nn.Parameter(
-            torch.empty(obj.config.n_routed_experts, lora_dim, obj.config.dim, dtype=dtype, device=device)
+            torch.empty(obj.config.n_routed_experts, lora_dim, expert_dim, dtype=dtype, device=device)
         )
 
         GroupedExpertsDeepEPLoRA.init_lora_weights(obj, lora_A_init_method)


### PR DESCRIPTION
## Summary

Fixes #1814.

`GroupedExpertsLoRA._init_adapter` and `GroupedExpertsDeepEPLoRA._init_adapter` allocated `lora_gate_and_up_A` / `lora_down_B` using `config.dim`, while the underlying experts allocate base weights using `config.expert_dim` (= `moe_latent_size if not None else dim`).

For models with a latent MoE projection (Nemotron Super 120B uses `moe_latent_size=1024`, `dim=4096`), this caused a contraction-dim mismatch in `torch._grouped_mm` at the very first forward step:

```
RuntimeError: contraction dimension of mat_a and mat_b must match
```

## Fix

Use `config.expert_dim` consistently in both `_init_adapter` methods.

**No-op for non-latent MoEs** because `expert_dim == dim` when `moe_latent_size is None` — the LoRA tensor shapes are unchanged for DeepSeek-V4, Qwen3-MoE, Nemotron Nano V3, etc.

## Test plan

Verified on Nemotron Super 120B (1× 8×H100) with [`examples/llm_finetune/nemotron/nemotron_super_v3_hellaswag_peft_issue1814.yaml`](https://github.com/NVIDIA-NeMo/Automodel/issues/1814):

- [x] 8 train + 1 val step on `rowan/hellaswag` completes cleanly (loss 2.81 → 2.90)
- [x] `adapter_model.safetensors` saved with **per-expert split** keys (no fused 3D tensors); 81,920 expert LoRA tensors with `expert_dim=1024` threading through `lora_A`/`lora_B` shapes
- [x] `transformers.AutoModelForCausalLM.from_pretrained` + `PeftModel.from_pretrained(adapter_dir)` loads the adapter cleanly
- [x] `model.merge_and_unload()` succeeds across all ~20k LoRA modules; merged weight delta matches `(lora_B @ lora_A) * (alpha/r)` within bf16 tolerance (max abs diff 1.37e−5)

### Sample post-fix shapes (Nemotron Super 120B, `r=8`, `expert_dim=1024`, `moe_inter_dim=2688`)

| Tensor | Shape |
|---|---|
| `experts.E.up_proj.lora_A.weight` | `(8, 1024)` |
| `experts.E.up_proj.lora_B.weight` | `(2688, 8)` |
| `experts.E.down_proj.lora_A.weight` | `(8, 2688)` |
| `experts.E.down_proj.lora_B.weight` | `(1024, 8)` |

The `1024` dim threading through `up_proj.lora_A` and `down_proj.lora_B` is the latent `expert_dim` — confirms the fix lands correctly in the saved format.
