### PR TITLE
feat(dsv4): apply YaRN frequency interpolation to compress-rope

### DIFF
--- a/nemo_automodel/components/models/deepseek_v4/layers.py
+++ b/nemo_automodel/components/models/deepseek_v4/layers.py
@@ -157,9 +157,40 @@ def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
     return hidden_states.reshape(batch, num_kv_heads * n_rep, slen, head_dim)
 
 
+def _yarn_correction_dim(num_rotations: float, dim: int, base: float, max_seq_len: int) -> float:
+    import math
+    return dim * math.log(max_seq_len / (num_rotations * 2 * math.pi)) / (2 * math.log(base))
+
+
+def _yarn_correction_range(
+    low_rot: float, high_rot: float, dim: int, base: float, max_seq_len: int
+) -> tuple[int, int]:
+    import math
+    low = math.floor(_yarn_correction_dim(low_rot, dim, base, max_seq_len))
+    high = math.ceil(_yarn_correction_dim(high_rot, dim, base, max_seq_len))
+    return max(low, 0), min(high, dim - 1)
+
+
+def _yarn_linear_ramp(min_v: float, max_v: float, dim: int, device=None) -> torch.Tensor:
+    if min_v == max_v:
+        max_v += 0.001
+    linear = (torch.arange(dim, dtype=torch.float32, device=device) - min_v) / (max_v - min_v)
+    return torch.clamp(linear, 0, 1)
+
+
 class DeepseekV4RotaryEmbedding(nn.Module):
     """V4 rotary embedding.  Produces ``(cos, sin)`` sized to ``qk_rope_head_dim``
     (via ``partial_rotary_factor = qk_rope_head_dim / head_dim``), matching HF.
+
+    YaRN: when ``rope_scaling`` is a YaRN-typed dict
+    (``{"type": "yarn", "factor": F, "original_max_position_embeddings": L0,
+    "beta_fast": ..., "beta_slow": ...}``), modify ``inv_freq`` per
+    ``dsv4flash/inference/model.py:precompute_freqs_cis`` — frequency
+    interpolation with a smooth linear ramp between beta_fast/beta_slow
+    correction dims.  Used by the compress-rope (theta=160000) on layers
+    with ``compress_ratio > 0``.  The main rope (theta=10000, used only on
+    sliding-window layers) gets ``rope_scaling=None`` because the reference
+    builds it with ``original_seq_len=0`` for those layers.
     """
 
     inv_freq: torch.Tensor
@@ -171,12 +202,22 @@ class DeepseekV4RotaryEmbedding(nn.Module):
         partial_rotary_factor: float,
         attention_scaling: float = 1.0,
         device: torch.device | None = None,
+        rope_scaling: dict | None = None,
     ):
         super().__init__()
         dim = int(head_dim * partial_rotary_factor)
         inv_freq = 1.0 / (
             rope_theta ** (torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float) / dim)
         )
+        if rope_scaling and str(rope_scaling.get("type", "")).lower() == "yarn":
+            factor = float(rope_scaling.get("factor", 1.0))
+            orig = int(rope_scaling.get("original_max_position_embeddings", 0))
+            beta_fast = float(rope_scaling.get("beta_fast", 32))
+            beta_slow = float(rope_scaling.get("beta_slow", 1))
+            if orig > 0 and factor > 0:
+                low, high = _yarn_correction_range(beta_fast, beta_slow, dim, rope_theta, orig)
+                smooth = 1.0 - _yarn_linear_ramp(low, high, dim // 2, device=inv_freq.device)
+                inv_freq = inv_freq / factor * (1.0 - smooth) + inv_freq * smooth
         self.attention_scaling = attention_scaling
         self.register_buffer("inv_freq", inv_freq, persistent=False)
 

--- a/nemo_automodel/components/models/deepseek_v4/layers.py
+++ b/nemo_automodel/components/models/deepseek_v4/layers.py
@@ -159,13 +159,13 @@ def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
 
 def _yarn_correction_dim(num_rotations: float, dim: int, base: float, max_seq_len: int) -> float:
     import math
+
     return dim * math.log(max_seq_len / (num_rotations * 2 * math.pi)) / (2 * math.log(base))
 
 
-def _yarn_correction_range(
-    low_rot: float, high_rot: float, dim: int, base: float, max_seq_len: int
-) -> tuple[int, int]:
+def _yarn_correction_range(low_rot: float, high_rot: float, dim: int, base: float, max_seq_len: int) -> tuple[int, int]:
     import math
+
     low = math.floor(_yarn_correction_dim(low_rot, dim, base, max_seq_len))
     high = math.ceil(_yarn_correction_dim(high_rot, dim, base, max_seq_len))
     return max(low, 0), min(high, dim - 1)

--- a/nemo_automodel/components/models/deepseek_v4/model.py
+++ b/nemo_automodel/components/models/deepseek_v4/model.py
@@ -340,15 +340,22 @@ class DeepseekV4Model(nn.Module):
         # HF partial_rotary_factor = qk_rope_head_dim / head_dim so cos/sin
         # come out sized to qk_rope_head_dim.
         partial_rotary_factor = float(config.qk_rope_head_dim) / float(config.head_dim)
+        # Reference (``dsv4flash/inference/model.py:519-525``) only applies YaRN
+        # to the compress-rope path: when compress_ratio>0 it uses
+        # ``original_seq_len=args.original_seq_len`` and theta=compress_rope_theta;
+        # otherwise ``original_seq_len=0`` (YaRN disabled) and theta=rope_theta.
+        rope_scaling = getattr(config, "rope_scaling", None)
         self.rotary_emb = DeepseekV4RotaryEmbedding(
             rope_theta=float(config.rope_theta),
             head_dim=int(config.head_dim),
             partial_rotary_factor=partial_rotary_factor,
+            rope_scaling=None,
         )
         self.rotary_emb_compress = DeepseekV4RotaryEmbedding(
             rope_theta=float(getattr(config, "compress_rope_theta", 160000.0) or 160000.0),
             head_dim=int(config.head_dim),
             partial_rotary_factor=partial_rotary_factor,
+            rope_scaling=rope_scaling,
         )
 
     def forward(

--- a/tests/unit_tests/models/deepseek_v4/test_dsv4_layers.py
+++ b/tests/unit_tests/models/deepseek_v4/test_dsv4_layers.py
@@ -26,7 +26,11 @@ import torch
 from nemo_automodel.components.models.deepseek_v4.layers import (
     DeepseekV4GroupedLinear,
     DeepseekV4HyperConnection,
+    DeepseekV4RotaryEmbedding,
     _apply_partial_rope_interleaved,
+    _yarn_correction_dim,
+    _yarn_correction_range,
+    _yarn_linear_ramp,
 )
 
 
@@ -166,3 +170,192 @@ class TestApplyPartialRopeInterleaved:
         sin = torch.zeros(bsz, seq, rd)
         y = _apply_partial_rope_interleaved(x, cos, sin, rope_head_dim=rd)
         torch.testing.assert_close(y, x)
+
+
+class TestYaRNHelpers:
+    """Sanity checks on the three pure-math helpers that build the YaRN
+    correction ramp.  Reference math: ``dsv4flash/inference/model.py:
+    precompute_freqs_cis`` (the inner ``find_correction_dim`` /
+    ``find_correction_range`` / ``linear_ramp_factor`` helpers).
+    """
+
+    def test_correction_dim_monotonic_in_rotations(self):
+        """``find_correction_dim`` is monotonically *decreasing* in
+        ``num_rotations`` (more rotations ⇒ lower dim index, since the
+        higher-frequency dims rotate more often within a fixed window).
+        """
+        # DSV4-Flash compress-rope: dim=64, base=160000, max_seq_len=65536
+        d_low = _yarn_correction_dim(num_rotations=1, dim=64, base=160000, max_seq_len=65536)
+        d_high = _yarn_correction_dim(num_rotations=32, dim=64, base=160000, max_seq_len=65536)
+        assert d_high < d_low
+
+    def test_correction_range_clamped(self):
+        """``find_correction_range`` clamps to ``[0, dim-1]``."""
+        low, high = _yarn_correction_range(
+            low_rot=32, high_rot=1, dim=64, base=160000, max_seq_len=65536
+        )
+        assert 0 <= low <= high <= 63
+
+    def test_linear_ramp_endpoints_and_clamp(self):
+        """Ramp is ``0`` below ``min_v``, ``1`` above ``max_v``, linear in
+        between.  ``dim=32`` matches DSV4 inv_freq length.
+        """
+        ramp = _yarn_linear_ramp(min_v=15.0, max_v=25.0, dim=32)
+        # Below min: 0
+        assert torch.all(ramp[:16] == 0.0)
+        # Above max: 1
+        assert torch.all(ramp[26:] == 1.0)
+        # In between: in [0, 1]
+        assert torch.all((ramp >= 0.0) & (ramp <= 1.0))
+
+    def test_linear_ramp_handles_min_eq_max(self):
+        """When ``min == max`` the helper bumps ``max`` by 1e-3 to avoid
+        division by zero; the ramp should still be a valid step function."""
+        ramp = _yarn_linear_ramp(min_v=5.0, max_v=5.0, dim=10)
+        assert torch.all((ramp >= 0.0) & (ramp <= 1.0))
+
+
+class TestDeepseekV4RotaryEmbeddingYaRN:
+    """``DeepseekV4RotaryEmbedding`` with and without ``rope_scaling``.
+
+    DSV4-Flash uses YaRN on the compress-rope path only:
+        rope_theta=160000, factor=16, original_max_position_embeddings=65536,
+        beta_fast=32, beta_slow=1.
+    """
+
+    def _yarn_kwargs(self, **overrides):
+        kwargs = dict(
+            rope_theta=160000.0,
+            head_dim=128,
+            partial_rotary_factor=0.5,  # qk_rope_head_dim=64
+            rope_scaling={
+                "type": "yarn",
+                "factor": 16,
+                "original_max_position_embeddings": 65536,
+                "beta_fast": 32,
+                "beta_slow": 1,
+            },
+        )
+        kwargs.update(overrides)
+        return kwargs
+
+    def test_no_rope_scaling_is_plain_rope(self):
+        """``rope_scaling=None`` ⇒ plain ``1 / theta^(2i/d)`` inv_freq."""
+        rope = DeepseekV4RotaryEmbedding(
+            rope_theta=10000.0, head_dim=128, partial_rotary_factor=0.5, rope_scaling=None
+        )
+        dim = 64  # head_dim * partial_rotary_factor
+        expected = 1.0 / (10000.0 ** (torch.arange(0, dim, 2, dtype=torch.float) / dim))
+        torch.testing.assert_close(rope.inv_freq, expected)
+
+    def test_yarn_attenuates_high_freq_dims_by_factor(self):
+        """The highest-frequency dims (above the correction range) are
+        divided by ``factor`` exactly; lowest-frequency dims (below the
+        correction range) are unchanged.
+        """
+        plain = DeepseekV4RotaryEmbedding(
+            rope_theta=160000.0, head_dim=128, partial_rotary_factor=0.5, rope_scaling=None
+        )
+        yarn = DeepseekV4RotaryEmbedding(**self._yarn_kwargs())
+
+        ratio = yarn.inv_freq / plain.inv_freq
+
+        # Low-frequency dims (small i, low rotation rate) are below the
+        # correction-range floor — ramp=0, smooth=1, so inv_freq is unchanged.
+        torch.testing.assert_close(ratio[:8], torch.ones(8), rtol=0, atol=1e-5)
+
+        # High-frequency dims (large i, fast rotation) are above the ceiling —
+        # ramp=1, smooth=0, so inv_freq /= factor (exactly 1/16).
+        torch.testing.assert_close(ratio[-4:], torch.full((4,), 1.0 / 16.0), rtol=0, atol=1e-5)
+
+        # Middle band is monotonically interpolating between 1.0 and 1/16.
+        mid = ratio[8:-4]
+        assert torch.all(mid <= ratio[7:-4][:-1] + 1e-6)
+        assert torch.all(mid >= 1.0 / 16.0 - 1e-6)
+
+    def test_yarn_factor_one_is_no_op(self):
+        """``factor=1`` ⇒ ``inv_freq / 1 * (1-smooth) + inv_freq*smooth`` = ``inv_freq``."""
+        plain = DeepseekV4RotaryEmbedding(
+            rope_theta=160000.0, head_dim=128, partial_rotary_factor=0.5, rope_scaling=None
+        )
+        yarn = DeepseekV4RotaryEmbedding(
+            **self._yarn_kwargs(rope_scaling={
+                "type": "yarn",
+                "factor": 1,
+                "original_max_position_embeddings": 65536,
+                "beta_fast": 32,
+                "beta_slow": 1,
+            })
+        )
+        torch.testing.assert_close(yarn.inv_freq, plain.inv_freq, rtol=0, atol=1e-7)
+
+    def test_yarn_zero_original_max_pos_is_no_op(self):
+        """``original_max_position_embeddings=0`` short-circuits YaRN
+        (matches reference's ``if original_seq_len > 0`` gate)."""
+        plain = DeepseekV4RotaryEmbedding(
+            rope_theta=160000.0, head_dim=128, partial_rotary_factor=0.5, rope_scaling=None
+        )
+        yarn = DeepseekV4RotaryEmbedding(
+            **self._yarn_kwargs(rope_scaling={
+                "type": "yarn",
+                "factor": 16,
+                "original_max_position_embeddings": 0,
+                "beta_fast": 32,
+                "beta_slow": 1,
+            })
+        )
+        torch.testing.assert_close(yarn.inv_freq, plain.inv_freq, rtol=0, atol=1e-7)
+
+    def test_yarn_unrecognized_type_is_no_op(self):
+        """A ``rope_scaling`` dict whose ``type`` is not ``"yarn"`` should
+        be ignored (the gate is exact-string-match insensitive only to case).
+        """
+        plain = DeepseekV4RotaryEmbedding(
+            rope_theta=160000.0, head_dim=128, partial_rotary_factor=0.5, rope_scaling=None
+        )
+        yarn = DeepseekV4RotaryEmbedding(
+            rope_theta=160000.0,
+            head_dim=128,
+            partial_rotary_factor=0.5,
+            rope_scaling={"type": "linear", "factor": 16},
+        )
+        torch.testing.assert_close(yarn.inv_freq, plain.inv_freq)
+
+    def test_yarn_matches_reference_math_pointwise(self):
+        """Recompute YaRN's ``inv_freq`` from the reference formula and
+        check pointwise equality (catches any drift in the helper port).
+        """
+        rope_theta = 160000.0
+        dim = 64
+        factor = 16
+        orig = 65536
+        beta_fast = 32
+        beta_slow = 1
+
+        # Reference formula from dsv4flash/inference/model.py:
+        #   freqs = 1.0 / (base ** (arange(0, dim, 2) / dim))
+        #   low, high = find_correction_range(beta_fast, beta_slow, dim, base, orig)
+        #   smooth = 1 - linear_ramp_factor(low, high, dim // 2)
+        #   freqs = freqs / factor * (1 - smooth) + freqs * smooth
+        plain_freqs = 1.0 / (rope_theta ** (torch.arange(0, dim, 2, dtype=torch.float) / dim))
+        low, high = _yarn_correction_range(beta_fast, beta_slow, dim, rope_theta, orig)
+        smooth = 1.0 - _yarn_linear_ramp(low, high, dim // 2)
+        expected = plain_freqs / factor * (1.0 - smooth) + plain_freqs * smooth
+
+        yarn = DeepseekV4RotaryEmbedding(**self._yarn_kwargs())
+        torch.testing.assert_close(yarn.inv_freq, expected, rtol=0, atol=1e-7)
+
+    def test_yarn_forward_returns_correct_shape_and_dtype(self):
+        """Smoke check: the YaRN-modified rotary still produces ``(cos, sin)``
+        sized to ``qk_rope_head_dim`` and downcasts to ``x.dtype`` if the
+        forward returns BF16-casted tensors.
+        """
+        rope = DeepseekV4RotaryEmbedding(**self._yarn_kwargs())
+        bsz, seq = 2, 16
+        x = torch.zeros(bsz, seq, dtype=torch.bfloat16)
+        position_ids = torch.arange(seq).unsqueeze(0).expand(bsz, -1)
+        cos, sin = rope(x, position_ids)
+        # rope_head_dim = head_dim * partial_rotary_factor = 64
+        assert cos.shape == (bsz, seq, 64)
+        assert sin.shape == (bsz, seq, 64)
+        assert not torch.isnan(cos).any() and not torch.isnan(sin).any()

--- a/tests/unit_tests/models/deepseek_v4/test_dsv4_layers.py
+++ b/tests/unit_tests/models/deepseek_v4/test_dsv4_layers.py
@@ -191,9 +191,7 @@ class TestYaRNHelpers:
 
     def test_correction_range_clamped(self):
         """``find_correction_range`` clamps to ``[0, dim-1]``."""
-        low, high = _yarn_correction_range(
-            low_rot=32, high_rot=1, dim=64, base=160000, max_seq_len=65536
-        )
+        low, high = _yarn_correction_range(low_rot=32, high_rot=1, dim=64, base=160000, max_seq_len=65536)
         assert 0 <= low <= high <= 63
 
     def test_linear_ramp_endpoints_and_clamp(self):
@@ -241,9 +239,7 @@ class TestDeepseekV4RotaryEmbeddingYaRN:
 
     def test_no_rope_scaling_is_plain_rope(self):
         """``rope_scaling=None`` ⇒ plain ``1 / theta^(2i/d)`` inv_freq."""
-        rope = DeepseekV4RotaryEmbedding(
-            rope_theta=10000.0, head_dim=128, partial_rotary_factor=0.5, rope_scaling=None
-        )
+        rope = DeepseekV4RotaryEmbedding(rope_theta=10000.0, head_dim=128, partial_rotary_factor=0.5, rope_scaling=None)
         dim = 64  # head_dim * partial_rotary_factor
         expected = 1.0 / (10000.0 ** (torch.arange(0, dim, 2, dtype=torch.float) / dim))
         torch.testing.assert_close(rope.inv_freq, expected)
@@ -279,13 +275,15 @@ class TestDeepseekV4RotaryEmbeddingYaRN:
             rope_theta=160000.0, head_dim=128, partial_rotary_factor=0.5, rope_scaling=None
         )
         yarn = DeepseekV4RotaryEmbedding(
-            **self._yarn_kwargs(rope_scaling={
-                "type": "yarn",
-                "factor": 1,
-                "original_max_position_embeddings": 65536,
-                "beta_fast": 32,
-                "beta_slow": 1,
-            })
+            **self._yarn_kwargs(
+                rope_scaling={
+                    "type": "yarn",
+                    "factor": 1,
+                    "original_max_position_embeddings": 65536,
+                    "beta_fast": 32,
+                    "beta_slow": 1,
+                }
+            )
         )
         torch.testing.assert_close(yarn.inv_freq, plain.inv_freq, rtol=0, atol=1e-7)
 
@@ -296,13 +294,15 @@ class TestDeepseekV4RotaryEmbeddingYaRN:
             rope_theta=160000.0, head_dim=128, partial_rotary_factor=0.5, rope_scaling=None
         )
         yarn = DeepseekV4RotaryEmbedding(
-            **self._yarn_kwargs(rope_scaling={
-                "type": "yarn",
-                "factor": 16,
-                "original_max_position_embeddings": 0,
-                "beta_fast": 32,
-                "beta_slow": 1,
-            })
+            **self._yarn_kwargs(
+                rope_scaling={
+                    "type": "yarn",
+                    "factor": 16,
+                    "original_max_position_embeddings": 0,
+                    "beta_fast": 32,
+                    "beta_slow": 1,
+                }
+            )
         )
         torch.testing.assert_close(yarn.inv_freq, plain.inv_freq, rtol=0, atol=1e-7)
 


### PR DESCRIPTION
## Summary

The released DeepSeek-V4-Flash checkpoint trains with YaRN-scaled rope on the
compress-attention path (layers with `compress_ratio > 0`), per its
`config.json`:

```json
"rope_scaling": {
    "type": "yarn",
    "factor": 16,
    "original_max_position_embeddings": 65536,
    "beta_fast": 32,
    "beta_slow": 1
}
```

`DeepseekV4RotaryEmbedding` previously ignored `rope_scaling` and always built
a plain RoPE `inv_freq`. At positions inside
`original_max_position_embeddings` this is approximately right (YaRN's smooth
ramp barely activates), but past it the compress-rope frequencies diverge
from what the trained checkpoint expects.

## Changes

- `nemo_automodel/components/models/deepseek_v4/layers.py`
  - Add `_yarn_correction_dim`, `_yarn_correction_range`, `_yarn_linear_ramp`
    helpers (port of `dsv4flash/inference/model.py:precompute_freqs_cis`).
  - Add optional `rope_scaling` kwarg to
    `DeepseekV4RotaryEmbedding.__init__`; when YaRN-typed, modify `inv_freq`
    via the standard frequency-interpolation formula:
    `inv_freq / factor * (1 - smooth) + inv_freq * smooth`.

- `nemo_automodel/components/models/deepseek_v4/model.py`
  - Pass `rope_scaling=cfg.rope_scaling` to `self.rotary_emb_compress`
    (theta=160000 path).
  - Pass `rope_scaling=None` to `self.rotary_emb` (theta=10000 path) — matches
    `dsv4flash/inference/model.py:519-525` which builds the main rope with
    `original_seq_len=0` for `compress_ratio=0` layers.

## Verification

- ✅ All 7 unit smoke tests pass (`tests/unit_tests/models/deepseek_v4/test_dsv4_model_smoke.py`)
- ✅ End-to-end 4-layer parity recipe runs successfully on 8 GPUs (PP=1,
  EP=8, FSDP2): step 0 train loss 19.23, validation loss 16.92, no NaN/Inf,
  finite gradients
- ✅ Per-tensor parity vs `dsv4flash` reference at seqlen=2048: top-1 / top-5
  logits match before and after the fix (cosine moves only ~+0.001 because
  YaRN barely activates below `original_max_position_embeddings`)
<img width="522" height="277" alt="image" src="https://github.com/user-attachments/assets/eed0ca94-a32d-4b62-8ff6-e71e206c7888" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)