### PR TITLE
docs: use absolute raw.githubusercontent.com URLs for embedded images

### DIFF
--- a/docs/guides/llm/toolcalling.md
+++ b/docs/guides/llm/toolcalling.md
@@ -98,7 +98,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/gemma/functiongemma_xlam.yaml
 You should be able to see a training loss curve similar to the one shown below:
 
 <p align="center">
-  <img src="https://github.com/NVIDIA-NeMo/Automodel/blob/main/docs/guides/llm/functiongemma-sft-loss.png" alt="FunctionGemma SFT loss" width="400">
+  <img src="https://raw.githubusercontent.com/NVIDIA-NeMo/Automodel/main/docs/guides/llm/functiongemma-sft-loss.png" alt="FunctionGemma SFT loss" width="400">
 </p>
 
 ## Run PEFT (LoRA)
@@ -118,5 +118,5 @@ automodel examples/llm_finetune/gemma/functiongemma_xlam.yaml
 ```
 
 <p align="center">
-  <img src="https://github.com/NVIDIA-NeMo/Automodel/blob/main/docs/guides/llm/functiongemma-peft-loss.png" alt="FunctionGemma PEFT loss" width="400">
+  <img src="https://raw.githubusercontent.com/NVIDIA-NeMo/Automodel/main/docs/guides/llm/functiongemma-peft-loss.png" alt="FunctionGemma PEFT loss" width="400">
 </p>

--- a/docs/guides/vlm/mistral-medium-3-5.md
+++ b/docs/guides/vlm/mistral-medium-3-5.md
@@ -93,5 +93,5 @@ The training loss curves for Mistral Medium 3.5 fine-tuned on
 MedPix-VQA are shown below.
 
 <p align="center">
-  <img src="mistralm35.png" alt="Mistral Medium 3.5 Training Loss Curve" width="500">
+  <img src="https://raw.githubusercontent.com/NVIDIA-NeMo/Automodel/main/docs/guides/vlm/mistralm35.png" alt="Mistral Medium 3.5 Training Loss Curve" width="500">
 </p>

--- a/docs/guides/vlm/qwen3-5.md
+++ b/docs/guides/vlm/qwen3-5.md
@@ -4,7 +4,7 @@
 
 [Qwen/Qwen3.5-397B-A17B](https://huggingface.co/Qwen/Qwen3.5-397B-A17B) is the latest vision-language model in the Qwen series developed by Alibaba. It’s a 397B-parameter (17B active) hybrid MoE model that uses a repeated layout of Gated DeltaNet and Gated Attention blocks, each paired with sparse MoE (512 experts; 10 routed + 1 shared active). Qwen3.5 is a major upgrade that unifies vision+language, boosts efficiency and multilingual coverage, delivering higher performance at lower latency/cost for developers and enterprises. Qwen3.5-397B-A17B shows competitive benchmark performance across knowledge, reasoning, coding, and agent tasks.
 <p align="center">
-  <img src="qwen3_5scores.png" alt="Qwen3.5 benchmark" width="500">
+  <img src="https://raw.githubusercontent.com/NVIDIA-NeMo/Automodel/main/docs/guides/vlm/qwen3_5scores.png" alt="Qwen3.5 benchmark" width="500">
 </p>
 
 This guide walks you through fine-tuning Qwen3.5 on a medical Visual Question Answering task using NVIDIA NeMo Automodel. You will learn how to prepare the dataset, launch training on a Slurm cluster, and inspect the results.
@@ -58,5 +58,5 @@ srun --output=output.out \
 The training loss curves for Qwen3.5-VL fine-tuned on MedPix-VQA are shown below.
 
 <p align="center">
-  <img src="qwen3_5.png" alt="Qwen3.5-VL Training Loss Curve" width="500">
+  <img src="https://raw.githubusercontent.com/NVIDIA-NeMo/Automodel/main/docs/guides/vlm/qwen3_5.png" alt="Qwen3.5-VL Training Loss Curve" width="500">
 </p>


### PR DESCRIPTION
## Summary
- Convert relative `<img src="...">` paths in VLM guides (`qwen3-5.md`, `mistral-medium-3-5.md`) to absolute `raw.githubusercontent.com` URLs so images render in built docs, not just from the GitHub repo viewer.
- Convert two `github.com/.../blob/.../*.png` URLs in `toolcalling.md` to `raw.githubusercontent.com` for the same reason — `blob/` links serve the GitHub file viewer page rather than the raw image.

## Test plan
- [ ] Build the docs (Sphinx/MkDocs) and confirm the Qwen3.5, Mistral Medium 3.5, and FunctionGemma SFT/PEFT loss images load.
- [ ] Confirm the same pages still render correctly on github.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)