### PR TITLE
feat(devstral): restore 24B SQuAD recipes via force_hf

### DIFF
--- a/examples/llm_finetune/devstral/devstral2_small_2512_squad.yaml
+++ b/examples/llm_finetune/devstral/devstral2_small_2512_squad.yaml
@@ -1,0 +1,114 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+
+# To run this recipe:
+#   automodel examples/llm_finetune/devstral/devstral2_small_2512_squad.yaml --nproc-per-node 8
+# Adjust --nproc-per-node to the number of GPUs available on your machine.
+#
+# This recipe uses the stock HF Mistral3ForConditionalGeneration loader
+# (force_hf: true). The custom Devstral FP8 path was removed in the
+# mistral3_vlm refactor; the FP8 checkpoint is dequantized on load via
+# transformers.FineGrainedFP8Config(dequantize=true).
+
+recipe: TrainFinetuneRecipeForNextTokenPrediction
+
+step_scheduler:
+  global_batch_size: 64
+  local_batch_size: 1
+  ckpt_every_steps: 200
+  val_every_steps: 100  # will run every x number of gradient steps
+  num_epochs: 1
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 1
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 1111
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: mistralai/Devstral-Small-2-24B-Instruct-2512
+  force_hf: true
+  quantization_config:
+    _target_: transformers.FineGrainedFP8Config
+    dequantize: true
+
+checkpoint:
+  enabled: true
+  checkpoint_dir: checkpoints/
+  model_save_format: torch_save # torch_save or safetensors
+  save_consolidated: false # saves the model in a consolidated safetensors format. Requires model_save_format to be safetensors.
+
+distributed:
+  strategy: fsdp2
+  dp_size: none
+  tp_size: 1
+  cp_size: 1
+  sequence_parallel: false
+  defer_fsdp_grad_sync: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
+  dataset_name: rajpurkar/squad
+  split: train
+
+packed_sequence:
+  # Set packed_sequence_size > 0 to run with packed sequences
+  packed_sequence_size: 0
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  shuffle: true
+
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
+  dataset_name: rajpurkar/squad
+  split: validation
+  limit_dataset_samples: 64
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+
+optimizer:
+  _target_: torch.optim.Adam
+  betas: [0.9, 0.999]
+  eps: 1e-8
+  lr: 1.0e-5
+  weight_decay: 0
+  # min_lr: 1.0e-5
+
+lr_scheduler:
+  lr_decay_style: cosine
+  min_lr: 1.0e-6
+
+wandb:
+  project: huiyingl_workspace
+  entity: Nemo-automodel
+  name: devstral_24b_squad
+  dir: logs/wandb
+
+ci:
+  recipe_owner: akoumpa
+  node_multiplier: true
+  time: "00:15:00"

--- a/examples/llm_finetune/devstral/devstral2_small_2512_squad_peft.yaml
+++ b/examples/llm_finetune/devstral/devstral2_small_2512_squad_peft.yaml
@@ -1,0 +1,122 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+
+# To run this recipe:
+#   automodel examples/llm_finetune/devstral/devstral2_small_2512_squad_peft.yaml --nproc-per-node 8
+# Adjust --nproc-per-node to the number of GPUs available on your machine.
+#
+# This recipe uses the stock HF Mistral3ForConditionalGeneration loader
+# (force_hf: true). The custom Devstral FP8 path was removed in the
+# mistral3_vlm refactor; the FP8 checkpoint is dequantized on load via
+# transformers.FineGrainedFP8Config(dequantize=true).
+
+recipe: TrainFinetuneRecipeForNextTokenPrediction
+
+step_scheduler:
+  global_batch_size: 64
+  local_batch_size: 1
+  ckpt_every_steps: 200
+  val_every_steps: 100  # will run every x number of gradient steps
+  num_epochs: 1
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 1
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 1111
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: mistralai/Devstral-Small-2-24B-Instruct-2512
+  force_hf: true
+  quantization_config:
+    _target_: transformers.FineGrainedFP8Config
+    dequantize: true
+
+peft:
+  _target_: nemo_automodel.components._peft.lora.PeftConfig
+  match_all_linear: True
+  dim: 8
+  alpha: 32
+  use_triton: True
+  # dtype needs a fix to resolve to type instead of string
+  # lora_dtype: torch.bfloat16
+
+checkpoint:
+  enabled: true
+  checkpoint_dir: checkpoints/
+  model_save_format: safetensors
+  save_consolidated: false # saves the model in a consolidated safetensors format. Requires model_save_format to be safetensors.
+
+distributed:
+  strategy: fsdp2
+  dp_size: none
+  tp_size: 1
+  cp_size: 1
+
+  sequence_parallel: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
+  dataset_name: rajpurkar/squad
+  split: train
+
+packed_sequence:
+  # Set packed_sequence_size > 0 to run with packed sequences
+  packed_sequence_size: 0
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  shuffle: true
+
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
+  dataset_name: rajpurkar/squad
+  split: validation
+  limit_dataset_samples: 64
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+
+optimizer:
+  _target_: torch.optim.Adam
+  betas: [0.9, 0.999]
+  eps: 1e-8
+  lr: 1.0e-5
+  weight_decay: 0
+  # min_lr: 1.0e-5
+
+lr_scheduler:
+  lr_decay_style: cosine
+  min_lr: 1.0e-6
+
+ci:
+  recipe_owner: akoumpa
+  time: "00:30:00"
+
+wandb:
+  project: huiyingl_workspace
+  entity: Nemo-automodel
+  name: devstral_24b_squad_peft
+  dir: logs/wandb

--- a/tests/ci_tests/configs/llm_finetune/nightly_recipes.yml
+++ b/tests/ci_tests/configs/llm_finetune/nightly_recipes.yml
@@ -26,6 +26,9 @@ configs:
   # -- falcon --
   - falcon/falcon3_7b_instruct_squad.yaml
 
+  # -- devstral --
+  - devstral/devstral2_small_2512_squad.yaml
+
   # -- gemma --
   - gemma/gemma_2_9b_it_squad.yaml
   - gemma/gemma_3_270m_squad.yaml


### PR DESCRIPTION
## Summary
- Restore the two `devstral2_small_2512_squad{,_peft}.yaml` recipes that were dropped in the mistral3_vlm refactor (#2090) along with the custom Devstral FP8 streaming loader they used.
- Run on the stock HF path: `force_hf: true` skips the custom resolver hook and routes through `Mistral3ForConditionalGeneration` wrapped by the NeMo HF mixin; `FineGrainedFP8Config(dequantize=true)` handles FP8 → BF16 at load time.
- No source changes.

Per-rank BF16 materialization (~46 GB) is fine on 80 GB H100 under FSDP2 single-node; the deleted streaming path was needed for PP, which these recipes do not use.

## Test plan
- [x] `devstral2_small_2512_squad_peft.yaml` — 8×H100, 50 steps: loss 0.6766 → 0.1594, val 0.1702. [wandb](https://wandb.ai/Nemo-automodel/huiyingl_workspace/runs/mbho2wmb)
- [x] `devstral2_small_2512_squad.yaml` — 8×H100, 50 steps: loss 0.6766 → 0.1678, val 0.2605. [wandb](https://wandb.ai/Nemo-automodel/huiyingl_workspace/runs/jhj70tw6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)