### PR TITLE
fix(gemma4): Gemma4 packing, attention mask, and fixesMoE routing

### DIFF
--- a/examples/vlm_finetune/gemma4/gemma4_26b_a4b_moe_packing.yaml
+++ b/examples/vlm_finetune/gemma4/gemma4_26b_a4b_moe_packing.yaml
@@ -1,0 +1,107 @@
+# Configuration for fine-tuning Gemma 4 26B-A4B MoE (128 experts) with MedPix dataset and sequence packing
+# Requires 8 GPUs (FSDP2 + EP=8, 16 experts per GPU)
+# torchrun --nproc-per-node=8 examples/vlm_finetune/finetune.py -c examples/vlm_finetune/gemma4/gemma4_26b_a4b_moe_packing.yaml
+
+recipe: FinetuneRecipeForVLM
+
+step_scheduler:
+  global_batch_size: 8
+  local_batch_size: 1
+  ckpt_every_steps: 500
+  val_every_steps: 500
+  num_epochs: 2
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 60
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 42
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained
+  pretrained_model_name_or_path: /scratch/shruthan/models/gemma-4-26B-A4B-it
+  torch_dtype: torch.bfloat16
+  trust_remote_code: true
+  attn_implementation: eager
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: te
+    linear: te
+    rms_norm: te
+    rope_fusion: true
+    dispatcher: deepep
+    fake_balanced_gate: false
+    enable_hf_state_dict_adapter: true
+    enable_fsdp_optimizations: true
+  text_config:
+  # 26B-A4B does not use kv_shared layers (only used in 2B, 4B), hence use_cache: false.
+    use_cache: false
+
+processor:
+  padding_side: right
+
+checkpoint:
+  enabled: true
+  checkpoint_dir: vlm_checkpoints/gemma4_26b_a4b_moe_packing/
+  model_save_format: torch_save
+  save_consolidated: false
+
+distributed:
+  strategy: fsdp2
+  dp_size: none
+  tp_size: 1
+  cp_size: 1
+  ep_size: 8
+  sequence_parallel: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.vlm.datasets.make_medpix_dataset
+  path_or_dataset: mmoukouba/MedPix-VQA
+  split: train[:1000]
+
+packed_sequence:
+  pretokenize: true
+  max_length: 3072
+  pack_size: 3072
+  packing_ratio: 0.9
+  drop_long_samples: true
+  post_tokenize_hook_fn: nemo_automodel.components.datasets.vlm.collate_fns.gemma4_inject_thinking_prefix
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  num_workers: 4
+  persistent_workers: true
+  pin_memory: true
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.vlm.datasets.make_medpix_dataset
+  path_or_dataset: mmoukouba/MedPix-VQA
+  split: validation[:500]
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn:
+    _target_: nemo_automodel.components.datasets.vlm.collate_fns.gemma4_prefix_collate_fn
+
+optimizer:
+  _target_: torch.optim.AdamW
+  lr: 2e-5
+  weight_decay: 0.01
+  betas: [0.9, 0.95]
+
+freeze_config:
+  freeze_embeddings: true
+  freeze_vision_tower: true
+  freeze_audio_tower: true
+  freeze_language_model: false
+
+# wandb:
+#   project: <your-project>
+#   entity: <your-entity>
+#   name: <your-run-name>

--- a/examples/vlm_finetune/gemma4/gemma4_26b_a4b_moe_packing.yaml
+++ b/examples/vlm_finetune/gemma4/gemma4_26b_a4b_moe_packing.yaml
@@ -22,7 +22,7 @@ rng:
 
 model:
   _target_: nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained
-  pretrained_model_name_or_path: /scratch/shruthan/models/gemma-4-26B-A4B-it
+  pretrained_model_name_or_path: google/gemma-4-26B-A4B-it
   torch_dtype: torch.bfloat16
   trust_remote_code: true
   attn_implementation: eager

--- a/nemo_automodel/components/datasets/vlm/collate_fns.py
+++ b/nemo_automodel/components/datasets/vlm/collate_fns.py
@@ -1496,6 +1496,12 @@ def neat_packed_vlm_collater(
     labels = torch.stack([_pad_1d(x["labels"], LABEL_PAD, max_len) for x in batch])
     attention_mask = torch.stack([_pad_1d(x["attention_mask"], 0, max_len) for x in batch])
 
+    def _get_mm_token_type_ids(item):
+        v = item.get("mm_token_type_ids")
+        return v if v is not None else torch.zeros(0, dtype=torch.long)
+
+    mm_token_type_ids = torch.stack([_pad_1d(_get_mm_token_type_ids(x), 0, max_len) for x in batch])
+
     if use_flash:
         # Keep indexed [B, S] mask for flash_attn_varlen_func.
         # The patched _get_unpad_data will extract per-document cu_seqlens.
@@ -1526,6 +1532,7 @@ def neat_packed_vlm_collater(
         "labels": labels,
         "position_ids": position_ids,
         "attention_mask": attention_mask_out,
+        "mm_token_type_ids": mm_token_type_ids,
     }
 
     # Store indexed attention mask for loss functions that need per-sample

--- a/nemo_automodel/components/datasets/vlm/collate_fns.py
+++ b/nemo_automodel/components/datasets/vlm/collate_fns.py
@@ -1811,13 +1811,6 @@ def _inject_thinking_prefix_tokens(
 ) -> Dict[str, torch.Tensor]:
     """Insert ``<|channel>thought\\n<channel|>`` tokens after every ``<|turn>model\\n`` marker.
 
-    Gemma4 31B / 26B-A4B MoE instruction-tuned models always emit a thinking-
-    channel prefix before the actual response.  When this prefix is absent from
-    training sequences the model predicts ``<|channel>`` but the label says
-    answer text, inflating initial loss to ~9.  Injecting the prefix (masked
-    as -100 in labels) lets the model see its expected pattern and brings
-    initial loss down to ~3.
-
     Modifies ``input_ids``, ``attention_mask``, and ``mm_token_type_ids``
     (if present).  Additionally, any other 2-D integer tensor whose second
     dimension matches ``input_ids`` is extended with zeros so that sequence
@@ -1892,6 +1885,25 @@ def _inject_thinking_prefix_tokens(
     return batch
 
 
+def gemma4_inject_thinking_prefix(
+    batch: Dict[str, torch.Tensor],
+    processor,
+) -> Dict[str, torch.Tensor]:
+    """Inject Gemma4's thinking-channel prefix after every assistant turn marker.
+
+    Gemma4 31B / 26B-A4B MoE instruction-tuned models always emit a thinking-
+    channel prefix before the actual response.  When this prefix is absent from
+    training sequences the model predicts ``<|channel>`` but the label says
+    answer text, inflating initial loss to ~9.  Injecting the prefix (masked
+    as -100 in labels) lets the model see its expected pattern and brings
+    initial loss down to ~3.
+
+    Safe no-op for non-Gemma4 tokenizers.
+    """
+    tokenizer = getattr(processor, "tokenizer", processor)
+    return _inject_thinking_prefix_tokens(batch, tokenizer)
+
+
 def gemma4_prefix_collate_fn(
     examples: Sequence[Dict[str, Any]],
     processor,
@@ -1907,8 +1919,7 @@ def gemma4_prefix_collate_fn(
     """
 
     def _inject(batch, proc):
-        tokenizer = getattr(proc, "tokenizer", proc)
-        batch = _inject_thinking_prefix_tokens(batch, tokenizer)
+        batch = gemma4_inject_thinking_prefix(batch, proc)
         if max_length is not None and batch["input_ids"].size(1) > max_length:
             for key in list(batch.keys()):
                 v = batch[key]

--- a/nemo_automodel/components/datasets/vlm/collate_fns.py
+++ b/nemo_automodel/components/datasets/vlm/collate_fns.py
@@ -1541,7 +1541,7 @@ def neat_packed_vlm_collater(
         if tensors:
             result[key] = torch.cat(tensors, dim=0).to(torch.bfloat16)
 
-    for key in ("image_grid_thw", "video_grid_thw", "second_per_grid_ts"):
+    for key in ("image_grid_thw", "image_position_ids", "video_grid_thw", "second_per_grid_ts"):
         tensors = [x[key] for x in batch if key in x and x[key] is not None]
         if tensors:
             result[key] = torch.cat(tensors, dim=0)

--- a/nemo_automodel/components/datasets/vlm/datasets.py
+++ b/nemo_automodel/components/datasets/vlm/datasets.py
@@ -922,12 +922,21 @@ class PreTokenizedDatasetWrapper(torch.utils.data.Dataset):
     ``pixel_values_videos``, ``video_grid_thw``).
     """
 
-    def __init__(self, dataset, processor, max_length=None, max_retries=10, truncate=False):
+    def __init__(
+        self,
+        dataset,
+        processor,
+        max_length=None,
+        max_retries=10,
+        truncate=False,
+        post_tokenize_hook=None,
+    ):
         self.dataset = dataset
         self.processor = processor
         self.max_length = max_length
         self.truncate = truncate
         self.max_retries = max_retries
+        self.post_tokenize_hook = post_tokenize_hook
         # Compatibility attributes expected by build_dataloader
         self.preload_media = False
 
@@ -998,6 +1007,8 @@ class PreTokenizedDatasetWrapper(torch.utils.data.Dataset):
                     processor_kwargs["video_metadata"] = [video_metadata]
 
                 result = self.processor(**processor_kwargs)
+                if self.post_tokenize_hook is not None:
+                    result = self.post_tokenize_hook(result, self.processor)
 
                 input_ids = result["input_ids"][0]  # (seq_len,)
                 seq_len = input_ids.shape[0]

--- a/nemo_automodel/components/datasets/vlm/neat_packing_vlm.py
+++ b/nemo_automodel/components/datasets/vlm/neat_packing_vlm.py
@@ -47,7 +47,7 @@ from nemo_automodel.components.datasets.vlm.samplers import (
 
 logger = logging.getLogger(__name__)
 
-MEDIA_KEYS = ("pixel_values", "image_grid_thw", "pixel_values_videos", "video_grid_thw", "second_per_grid_ts")
+MEDIA_KEYS = ("pixel_values", "image_grid_thw", "image_position_ids", "pixel_values_videos", "video_grid_thw", "second_per_grid_ts")
 
 
 # ---------------------------------------------------------------------------
@@ -326,6 +326,7 @@ def _build_packed_vlm_sample(
 
     pixel_values_list: list[torch.Tensor] = []
     image_grid_thw_list: list[torch.Tensor] = []
+    image_position_ids_list: list[torch.Tensor] = []
     pixel_values_videos_list: list[torch.Tensor] = []
     video_grid_thw_list: list[torch.Tensor] = []
     second_per_grid_ts_list: list[torch.Tensor] = []
@@ -355,6 +356,8 @@ def _build_packed_vlm_sample(
         if "image_grid_thw" in sample and sample["image_grid_thw"] is not None:
             n_images += sample["image_grid_thw"].shape[0]
             image_grid_thw_list.append(sample["image_grid_thw"])
+        if "image_position_ids" in sample and sample["image_position_ids"] is not None:
+            image_position_ids_list.append(sample["image_position_ids"])
         if "pixel_values_videos" in sample and sample["pixel_values_videos"] is not None:
             pixel_values_videos_list.append(sample["pixel_values_videos"])
         if "video_grid_thw" in sample and sample["video_grid_thw"] is not None:
@@ -379,6 +382,7 @@ def _build_packed_vlm_sample(
 
     packed["pixel_values"] = torch.cat(pixel_values_list, dim=0) if pixel_values_list else None
     packed["image_grid_thw"] = torch.cat(image_grid_thw_list, dim=0) if image_grid_thw_list else None
+    packed["image_position_ids"] = torch.cat(image_position_ids_list, dim=0) if image_position_ids_list else None
     packed["pixel_values_videos"] = torch.cat(pixel_values_videos_list, dim=0) if pixel_values_videos_list else None
     packed["video_grid_thw"] = torch.cat(video_grid_thw_list, dim=0) if video_grid_thw_list else None
     packed["second_per_grid_ts"] = torch.cat(second_per_grid_ts_list, dim=0) if second_per_grid_ts_list else None

--- a/nemo_automodel/components/datasets/vlm/neat_packing_vlm.py
+++ b/nemo_automodel/components/datasets/vlm/neat_packing_vlm.py
@@ -309,8 +309,8 @@ def _shift_sample(sample: dict, has_mrope: bool = False) -> dict:
     out["labels"] = sample["labels"][1:]
     out["attention_mask"] = sample["attention_mask"][:-1]
 
-    if "mm_token_type_ids" in sample and sample["mm_token_type_ids"] is not None:
-        mm_ttids = torch.as_tensor(sample["mm_token_type_ids"])
+    if (mm_ttids := sample.get("mm_token_type_ids")) is not None:
+        mm_ttids = torch.as_tensor(mm_ttids)
         out["mm_token_type_ids"] = mm_ttids[0, :-1] if mm_ttids.ndim == 2 else mm_ttids[:-1]
 
     if has_mrope and "position_ids" in sample and sample["position_ids"] is not None:

--- a/nemo_automodel/components/datasets/vlm/neat_packing_vlm.py
+++ b/nemo_automodel/components/datasets/vlm/neat_packing_vlm.py
@@ -47,7 +47,14 @@ from nemo_automodel.components.datasets.vlm.samplers import (
 
 logger = logging.getLogger(__name__)
 
-MEDIA_KEYS = ("pixel_values", "image_grid_thw", "image_position_ids", "pixel_values_videos", "video_grid_thw", "second_per_grid_ts")
+MEDIA_KEYS = (
+    "pixel_values",
+    "image_grid_thw",
+    "image_position_ids",
+    "pixel_values_videos",
+    "video_grid_thw",
+    "second_per_grid_ts",
+)
 
 
 # ---------------------------------------------------------------------------

--- a/nemo_automodel/components/datasets/vlm/neat_packing_vlm.py
+++ b/nemo_automodel/components/datasets/vlm/neat_packing_vlm.py
@@ -302,6 +302,10 @@ def _shift_sample(sample: dict, has_mrope: bool = False) -> dict:
     out["labels"] = sample["labels"][1:]
     out["attention_mask"] = sample["attention_mask"][:-1]
 
+    if "mm_token_type_ids" in sample and sample["mm_token_type_ids"] is not None:
+        mm_ttids = torch.as_tensor(sample["mm_token_type_ids"])
+        out["mm_token_type_ids"] = mm_ttids[0, :-1] if mm_ttids.ndim == 2 else mm_ttids[:-1]
+
     if has_mrope and "position_ids" in sample and sample["position_ids"] is not None:
         out["position_ids"] = sample["position_ids"][:, :-1]
 
@@ -321,6 +325,7 @@ def _build_packed_vlm_sample(
     all_input_ids: list[int] = []
     all_labels: list[int] = []
     all_attention_mask: list[int] = []
+    all_mm_token_type_ids: list[int] = []
     all_position_ids_1d: list[int] = []
     mrope_position_ids_list: list[torch.Tensor] = []
 
@@ -345,6 +350,12 @@ def _build_packed_vlm_sample(
         all_input_ids.extend(ids)
         all_labels.extend(labs)
         all_attention_mask.extend([seq_idx] * seq_len)
+
+        mm_ttids = sample.get("mm_token_type_ids")
+        if mm_ttids is not None:
+            all_mm_token_type_ids.extend(mm_ttids.tolist() if isinstance(mm_ttids, torch.Tensor) else mm_ttids)
+        else:
+            all_mm_token_type_ids.extend([0] * seq_len)
 
         if has_mrope and "position_ids" in sample:
             mrope_position_ids_list.append(sample["position_ids"])
@@ -371,6 +382,7 @@ def _build_packed_vlm_sample(
         "input_ids": torch.tensor(all_input_ids, dtype=torch.long),
         "labels": torch.tensor(all_labels, dtype=torch.long),
         "attention_mask": torch.tensor(all_attention_mask, dtype=torch.long),
+        "mm_token_type_ids": torch.tensor(all_mm_token_type_ids, dtype=torch.long),
         "n_images": n_images,
         "n_videos": n_videos,
     }

--- a/nemo_automodel/components/models/gemma4_moe/model.py
+++ b/nemo_automodel/components/models/gemma4_moe/model.py
@@ -264,6 +264,26 @@ class Gemma4MoEDecoderLayer(nn.Module):
         return x
 
 
+def _convert_bool_4d_mask_to_additive(attention_mask: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
+    """Convert a 4D bool allowed-mask to HF additive format (0.0 allowed, -inf masked)."""
+    if attention_mask.ndim != 4 or attention_mask.dtype != torch.bool:
+        return attention_mask
+    additive = torch.zeros(attention_mask.shape, dtype=dtype, device=attention_mask.device)
+    return additive.masked_fill(~attention_mask, torch.finfo(dtype).min)
+
+
+def _derive_padding_mask(attention_mask: torch.Tensor) -> torch.Tensor:
+    """Derive 2D padding mask (True = pad) from 1D, 2D, or 4D attention mask."""
+    if attention_mask.ndim == 2:
+        return attention_mask == 0
+    if attention_mask.ndim == 4:
+        diagonal = torch.diagonal(attention_mask[:, 0], dim1=-2, dim2=-1)
+        if attention_mask.dtype == torch.bool:
+            return diagonal.logical_not()
+        return diagonal != 0
+    return attention_mask.bool().logical_not()
+
+
 # ---------------------------------------------------------------------------
 # Text model backend
 # ---------------------------------------------------------------------------
@@ -356,7 +376,10 @@ class Gemma4MoETextModelBackend(nn.Module):
             position_ids = cache_position.unsqueeze(0)
 
         if padding_mask is None and attention_mask is not None:
-            padding_mask = attention_mask.bool().logical_not()
+            padding_mask = _derive_padding_mask(attention_mask)
+
+        if attention_mask is not None:
+            attention_mask = _convert_bool_4d_mask_to_additive(attention_mask, inputs_embeds.dtype)
 
         hidden_states = inputs_embeds
 

--- a/nemo_automodel/components/models/gemma4_moe/model.py
+++ b/nemo_automodel/components/models/gemma4_moe/model.py
@@ -114,9 +114,7 @@ class Gemma4Gate(nn.Module):
         expert_scores = self.proj(x_norm)
         router_probs = F.softmax(expert_scores, dim=-1)
 
-        # Top-k on raw scores (matching HF Gemma4Router behaviour)
-        _, indices = torch.topk(expert_scores, k=self.topk, dim=-1)
-        weights = router_probs.gather(-1, indices)
+        weights, indices = torch.topk(router_probs, k=self.topk, dim=-1)
         weights = weights / weights.sum(dim=-1, keepdim=True).clamp(min=1e-20)
         return weights, indices, None
 

--- a/nemo_automodel/components/models/gemma4_moe/state_dict_adapter.py
+++ b/nemo_automodel/components/models/gemma4_moe/state_dict_adapter.py
@@ -149,6 +149,22 @@ class Gemma4MoEStateDictAdapter(StateDictAdapter):
             gate_and_up_local = gate_and_up[start_expert:end_expert].to(self.dtype)
             down_local = down[start_expert:end_expert].to(self.dtype)
 
+            # Slice for EP_SHARD across the feature dimension before wrapping as DTensor.
+            if device_mesh is not None and "ep_shard" in device_mesh.mesh_dim_names:
+                ep_shard_mesh = state_dict_utils.get_submesh(device_mesh, ("ep_shard",))
+                ep_shard_size = ep_shard_mesh.size()
+                if ep_shard_size > 1:
+                    ep_shard_rank = ep_shard_mesh.get_local_rank()
+                    gate_shard_size = gate_and_up_local.shape[1] // ep_shard_size
+                    gate_start = ep_shard_rank * gate_shard_size
+                    gate_end = gate_start + gate_shard_size
+                    gate_and_up_local = gate_and_up_local[:, gate_start:gate_end, :]
+
+                    down_shard_size = down_local.shape[1] // ep_shard_size
+                    down_start = ep_shard_rank * down_shard_size
+                    down_end = down_start + down_shard_size
+                    down_local = down_local[:, down_start:down_end, :]
+
             prefix = f"{model_prefix}language_model.{layer_path}"
             state_dict[f"{prefix}.moe.experts.gate_and_up_projs"] = state_dict_utils.create_dtensor_from_local(
                 gate_and_up_local, device_mesh, rank
@@ -225,22 +241,24 @@ class Gemma4MoEStateDictAdapter(StateDictAdapter):
                 return tensor.to_local()
             return tensor
 
+        if state_dict_utils.is_dtensor(tensor):
+            split_weights, expert_ids = state_dict_utils.split_experts_weights_dtensor_aware(tensor, n_experts)
+            # Individual expert weights may still be DTensors sharded over ep_shard.
+            # Materialize them before object gather/copy into the CPU HF tensor.
+            local_weights = [
+                (weight.full_tensor() if state_dict_utils.is_dtensor(weight) else weight).to(self.dtype).cpu()
+                for weight in split_weights
+            ]
+        else:
+            start_expert, end_expert = state_dict_utils.get_expert_range_for_rank_from_mesh(device_mesh, n_experts)
+            expert_ids = list(range(start_expert, end_expert))
+            local_weights = [tensor[i].to(self.dtype).cpu() for i in range(tensor.shape[0])]
+
         global_tensor = torch.zeros(
-            (
-                n_experts,
-                tensor.shape[1] if not state_dict_utils.is_dtensor(tensor) else tensor.to_local().shape[1],
-                tensor.shape[2] if not state_dict_utils.is_dtensor(tensor) else tensor.to_local().shape[2],
-            ),
+            (n_experts, local_weights[0].shape[0], local_weights[0].shape[1]),
             dtype=self.dtype,
             device="cpu",
         )
-
-        if state_dict_utils.is_dtensor(tensor):
-            split_weights, expert_ids = state_dict_utils.split_experts_weights_dtensor_aware(tensor, n_experts)
-        else:
-            start_expert, end_expert = state_dict_utils.get_expert_range_for_rank_from_mesh(device_mesh, n_experts)
-            split_weights = [tensor[i].to(self.dtype).cpu() for i in range(tensor.shape[0])]
-            expert_ids = list(range(start_expert, end_expert))
 
         if dist.is_initialized() and "ep" in device_mesh.mesh_dim_names:
             try:
@@ -250,20 +268,20 @@ class Gemma4MoEStateDictAdapter(StateDictAdapter):
                 ep_group = None
 
             if ep_group is not None:
-                payload = (expert_ids, [w.cpu() for w in split_weights])
+                payload = (expert_ids, local_weights)
                 gathered: list[tuple[list[int], list[torch.Tensor]]] = [None] * dist.get_world_size(ep_group)
                 dist.all_gather_object(gathered, payload, group=ep_group)
                 for ids, weights in gathered:
                     for eid, w in zip(ids, weights):
                         global_tensor[eid].copy_(w.to(self.dtype).cpu())
             else:
-                for weight, expert_id in zip(split_weights, expert_ids):
-                    global_tensor[expert_id].copy_(weight.to(self.dtype).cpu())
+                for weight, expert_id in zip(local_weights, expert_ids):
+                    global_tensor[expert_id].copy_(weight)
         else:
-            for weight, expert_id in zip(split_weights, expert_ids):
-                global_tensor[expert_id].copy_(weight.to(self.dtype).cpu())
+            for weight, expert_id in zip(local_weights, expert_ids):
+                global_tensor[expert_id].copy_(weight)
 
-        del split_weights, expert_ids
+        del local_weights, expert_ids
         return global_tensor
 
     def convert_single_tensor_to_hf(self, fqn: str, tensor: Any, **kwargs) -> list[tuple[str, Any]]:

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -455,7 +455,7 @@ def build_dataloader(
             truncate = cfg_ds.get("truncate", max_length is not None)
 
             post_tokenize_hook = cfg_ps.get("post_tokenize_hook_fn", None) if cfg_ps is not None else None
-            
+
             ds = PreTokenizedDatasetWrapper(
                 ds_raw,
                 processor,

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -453,7 +453,16 @@ def build_dataloader(
 
             ds_raw = ds
             truncate = cfg_ds.get("truncate", max_length is not None)
-            ds = PreTokenizedDatasetWrapper(ds_raw, processor, max_length=max_length, truncate=truncate)
+
+            post_tokenize_hook = cfg_ps.get("post_tokenize_hook_fn", None) if cfg_ps is not None else None
+            
+            ds = PreTokenizedDatasetWrapper(
+                ds_raw,
+                processor,
+                max_length=max_length,
+                truncate=truncate,
+                post_tokenize_hook=post_tokenize_hook,
+            )
 
             if packing_cfg:
                 from nemo_automodel.components.datasets.vlm.collate_fns import neat_packed_vlm_collater

--- a/tests/unit_tests/datasets/vlm/test_collate_fns.py
+++ b/tests/unit_tests/datasets/vlm/test_collate_fns.py
@@ -2927,3 +2927,78 @@ class TestNeatPackedVlmCollaterAttnImpl:
         result = neat_packed_vlm_collater([s1, s2], attn_implementation="flash_attention_2")
         assert result["pixel_values"].shape[0] == 3  # 2 + 1
         assert result["image_grid_thw"].shape[0] == 3
+
+
+# ---------------------------------------------------------------------------
+# Tests for public gemma4_inject_thinking_prefix hook
+# ---------------------------------------------------------------------------
+
+
+class _GemmaTokenizerStub:
+    """Encodes the Gemma4 marker/prefix strings to fixed token sequences."""
+
+    pad_token_id = 0
+
+    _MARKER = "<|turn>model\n"
+    _PREFIX = "<|channel>thought\n<channel|>"
+    _MARKER_IDS = [10, 11]
+    _PREFIX_IDS = [20, 21, 22]
+
+    def encode(self, text, add_special_tokens=False):
+        if text == self._MARKER:
+            return list(self._MARKER_IDS)
+        if text == self._PREFIX:
+            return list(self._PREFIX_IDS)
+        return []
+
+
+class _NonGemmaTokenizerStub:
+    """Encodes the Gemma4 marker/prefix to empty (no matching tokens)."""
+
+    pad_token_id = 0
+
+    def encode(self, text, add_special_tokens=False):
+        return []
+
+
+def test_gemma4_inject_thinking_prefix_inserts_after_marker(collate_mod):
+    """Hook injects prefix ids after each <|turn>model\\n marker."""
+    marker = _GemmaTokenizerStub._MARKER_IDS
+    prefix = _GemmaTokenizerStub._PREFIX_IDS
+    # [user...] [marker] [answer]
+    seq = torch.tensor([[1, 2, 3, *marker, 4, 5]])
+    batch = {"input_ids": seq.clone(), "attention_mask": torch.ones_like(seq)}
+
+    out = collate_mod.gemma4_inject_thinking_prefix(batch, _GemmaTokenizerStub())
+    expected = torch.tensor([[1, 2, 3, *marker, *prefix, 4, 5]])
+    assert torch.equal(out["input_ids"], expected)
+    assert out["attention_mask"].shape == expected.shape
+    # injected positions are unmasked (visible)
+    inject_start = 3 + len(marker)
+    inject_end = inject_start + len(prefix)
+    assert (out["attention_mask"][0, inject_start:inject_end] == 1).all()
+
+
+def test_gemma4_inject_thinking_prefix_noop_for_non_gemma_tokenizer(collate_mod):
+    """For tokenizers without the marker/prefix vocab, the batch is returned unchanged."""
+    seq = torch.tensor([[1, 2, 3, 4, 5]])
+    batch = {"input_ids": seq.clone(), "attention_mask": torch.ones_like(seq)}
+
+    out = collate_mod.gemma4_inject_thinking_prefix(batch, _NonGemmaTokenizerStub())
+    assert torch.equal(out["input_ids"], seq)
+
+
+def test_gemma4_inject_thinking_prefix_accepts_processor_or_tokenizer(collate_mod):
+    """Hook unwraps processor.tokenizer and also accepts a raw tokenizer."""
+
+    class _Processor:
+        tokenizer = _GemmaTokenizerStub()
+
+    marker = _GemmaTokenizerStub._MARKER_IDS
+    seq = torch.tensor([[*marker, 9]])
+    batch_a = {"input_ids": seq.clone(), "attention_mask": torch.ones_like(seq)}
+    batch_b = {"input_ids": seq.clone(), "attention_mask": torch.ones_like(seq)}
+
+    out_proc = collate_mod.gemma4_inject_thinking_prefix(batch_a, _Processor())
+    out_tok = collate_mod.gemma4_inject_thinking_prefix(batch_b, _GemmaTokenizerStub())
+    assert torch.equal(out_proc["input_ids"], out_tok["input_ids"])

--- a/tests/unit_tests/datasets/vlm/test_neat_packing_vlm.py
+++ b/tests/unit_tests/datasets/vlm/test_neat_packing_vlm.py
@@ -77,6 +77,18 @@ class TestShiftSample:
         assert "pixel_values" in shifted
         assert shifted["pixel_values"].shape == sample["pixel_values"].shape
 
+    def test_shift_mm_token_type_ids_1d(self):
+        sample = _make_vlm_sample(5)
+        sample["mm_token_type_ids"] = torch.tensor([0, 1, 1, 0, 0])
+        shifted = _shift_sample(sample)
+        assert shifted["mm_token_type_ids"].tolist() == [0, 1, 1, 0]
+
+    def test_shift_mm_token_type_ids_2d(self):
+        sample = _make_vlm_sample(5)
+        sample["mm_token_type_ids"] = torch.tensor([[0, 1, 1, 0, 0]])
+        shifted = _shift_sample(sample)
+        assert shifted["mm_token_type_ids"].tolist() == [0, 1, 1, 0]
+
 
 class TestBuildPackedVlmSample:
     def test_basic(self):
@@ -120,6 +132,22 @@ class TestBuildPackedVlmSample:
         assert result["image_grid_thw"].shape[0] == 3
         assert result["n_images"] == 3
         assert result["n_videos"] == 0
+
+    def test_mm_token_type_ids_propagated(self):
+        samples = [
+            {
+                "input_ids": torch.tensor([1, 2, 3]),
+                "labels": torch.tensor([10, 20, 30]),
+                "mm_token_type_ids": torch.tensor([0, 1, 0]),
+            },
+            {
+                "input_ids": torch.tensor([4, 5]),
+                "labels": torch.tensor([40, 50]),
+                "mm_token_type_ids": torch.tensor([1, 1]),
+            },
+        ]
+        result = _build_packed_vlm_sample(samples, pack_size=8, padding_idx=0)
+        assert result["mm_token_type_ids"].tolist() == [0, 1, 0, 1, 1]
 
 
 class TestNeatPackDatasetVlm:

--- a/tests/unit_tests/models/gemma4/test_gemma4_model.py
+++ b/tests/unit_tests/models/gemma4/test_gemma4_model.py
@@ -26,6 +26,7 @@ from nemo_automodel.components.models.gemma4_moe.model import (
     Gemma4MoEDecoderLayer,
     Gemma4MoEModel,
     Gemma4MoETextModelBackend,
+    _derive_padding_mask,
 )
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.layers import MoE
@@ -426,6 +427,24 @@ class TestGemma4MoETextModelBackend:
         new_emb = torch.nn.Embedding(100, text_config.hidden_size)
         model.set_input_embeddings(new_emb)
         assert model.embed_tokens is new_emb
+
+
+class TestDerivePaddingMask:
+    pytestmark = []
+
+    def test_2d_zeros_are_padding(self):
+        mask = torch.tensor([[1, 1, 0, 0]])
+        assert _derive_padding_mask(mask).tolist() == [[False, False, True, True]]
+
+    def test_4d_bool_false_diagonal_is_padding(self):
+        mask = torch.ones(1, 1, 3, 3, dtype=torch.bool)
+        mask[0, 0, 2, 2] = False
+        assert _derive_padding_mask(mask).tolist() == [[False, False, True]]
+
+    def test_4d_additive_neginf_diagonal_is_padding(self):
+        mask = torch.zeros(1, 1, 3, 3)
+        mask[0, 0, 1, 1] = float("-inf")
+        assert _derive_padding_mask(mask).tolist() == [[False, True, False]]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/models/gemma4/test_gemma4_state_dict_adapter.py
+++ b/tests/unit_tests/models/gemma4/test_gemma4_state_dict_adapter.py
@@ -172,6 +172,52 @@ class TestFromHf:
         with pytest.raises(RuntimeError, match="Incomplete expert weights"):
             adapter.from_hf(hf_sd)
 
+    def test_from_hf_slices_ep_shard_feature_dimension(self, adapter, monkeypatch):
+        class FakeShardMesh:
+            def size(self):
+                return 2
+
+            def get_local_rank(self):
+                return 1
+
+            def get_rank(self):
+                return 0
+
+        class FakeDeviceMesh:
+            mesh_dim_names = ("ep_shard", "ep")
+
+        hf_sd = _make_hf_state_dict()
+        gate_up_proj = hf_sd["model.language_model.layers.0.experts.gate_up_proj"]
+        down_proj = hf_sd["model.language_model.layers.0.experts.down_proj"]
+        per_expert_scale = hf_sd["model.language_model.layers.0.router.per_expert_scale"]
+
+        monkeypatch.setattr(
+            "nemo_automodel.components.models.gemma4_moe.state_dict_adapter.state_dict_utils."
+            "get_expert_range_for_rank_from_mesh",
+            lambda device_mesh, n_experts: (0, n_experts),
+        )
+        monkeypatch.setattr(
+            "nemo_automodel.components.models.gemma4_moe.state_dict_adapter.state_dict_utils.get_submesh",
+            lambda device_mesh, dims: FakeShardMesh(),
+        )
+        monkeypatch.setattr(
+            "nemo_automodel.components.models.gemma4_moe.state_dict_adapter.state_dict_utils.create_dtensor_from_local",
+            lambda local_tensor, device_mesh, rank: local_tensor,
+        )
+
+        nemo_sd = adapter.from_hf(hf_sd, device_mesh=FakeDeviceMesh())
+
+        expected_gate_and_up = gate_up_proj.transpose(-2, -1)[:, HIDDEN // 2 :, :]
+        expected_down = (down_proj.transpose(-2, -1) * per_expert_scale[:, None, None])[:, EXPERT_INTER // 2 :, :]
+        torch.testing.assert_close(
+            nemo_sd["model.language_model.layers.0.moe.experts.gate_and_up_projs"],
+            expected_gate_and_up,
+        )
+        torch.testing.assert_close(
+            nemo_sd["model.language_model.layers.0.moe.experts.down_projs"],
+            expected_down,
+        )
+
     def test_without_model_prefix(self, adapter):
         hf_sd = _make_hf_state_dict(with_model_prefix=False)
 
@@ -261,6 +307,42 @@ class TestToHf:
         for key in hf_sd:
             assert "gate_and_up_projs" not in key
             assert "experts.down_projs" not in key
+
+    def test_gather_expert_tensor_materializes_dtensor_slices(self, adapter, monkeypatch):
+        class FakeDTensor:
+            def __init__(self, tensor):
+                self.tensor = tensor
+                self.full_tensor_called = False
+
+            def full_tensor(self):
+                self.full_tensor_called = True
+                return self.tensor
+
+        class FakeDeviceMesh:
+            mesh_dim_names = ("ep",)
+
+        source_tensor = FakeDTensor(torch.empty(0))
+        split_weights = [
+            FakeDTensor(torch.randn(HIDDEN, 2 * EXPERT_INTER)),
+            FakeDTensor(torch.randn(HIDDEN, 2 * EXPERT_INTER)),
+        ]
+
+        monkeypatch.setattr(
+            "nemo_automodel.components.models.gemma4_moe.state_dict_adapter.state_dict_utils.is_dtensor",
+            lambda tensor: isinstance(tensor, FakeDTensor),
+        )
+        monkeypatch.setattr(
+            "nemo_automodel.components.models.gemma4_moe.state_dict_adapter.state_dict_utils."
+            "split_experts_weights_dtensor_aware",
+            lambda tensor, n_experts: (split_weights, [0, 1]),
+        )
+
+        gathered = adapter._gather_expert_tensor(source_tensor, FakeDeviceMesh(), N_EXPERTS)
+
+        assert gathered.shape == (N_EXPERTS, HIDDEN, 2 * EXPERT_INTER)
+        torch.testing.assert_close(gathered[0], split_weights[0].tensor)
+        torch.testing.assert_close(gathered[1], split_weights[1].tensor)
+        assert all(weight.full_tensor_called for weight in split_weights)
 
     def test_exclude_key_regex(self, adapter):
         nemo_sd = self._make_nemo_state_dict()


### PR DESCRIPTION
# What does this PR do ?

Fixes some bugs in VLM/Gemma4 SFT with packing. 

# Changelog

- `neat_packing_vlm.py`: propagate `mm_token_type_ids` and `image_position_ids` through packing pipeline
- `collate_fns.py`: include `mm_token_type_ids` in `neat_packed_vlm_collater` output
- `gemma4_moe/model.py`: convert 4D bool attention mask to additive format before eager attention
- `gemma4_moe/model.py`: select top-k experts from `router_probs` (softmax) instead of raw `expert_scores`, consistent with HF Gemma4 implementation

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

# Additional Information

- Related to # (issue)
