### PR TITLE
fix: save QLoRA PEFT checkpoints with HF adapter prefix

### DIFF
--- a/nemo_automodel/components/checkpoint/stateful_wrappers.py
+++ b/nemo_automodel/components/checkpoint/stateful_wrappers.py
@@ -285,9 +285,10 @@ class ModelState:
         if self.has_local_tied_lm_head:
             model_state_dict.pop(self.lm_head_param_name, None)
 
-        if self.is_peft and not _has_quantized_params(self.model[0]):
+        if self.is_peft:
             # HF PEFT models are saved with a "base.model." prefix. This is so they can be loaded
-            # correctly with the HF PEFT API.
+            # correctly with the HF PEFT API. Quantized PEFT bypasses DCP above, but the collected
+            # trainable tensors still need the same on-disk key normalization.
             _add_outer_prefix(model_state_dict, "base_model.model.")
             # DoRA: rename lora_magnitude to match HF PEFT's expected key format
             _rename_dora_keys_to_hf(model_state_dict)


### PR DESCRIPTION
## Summary

Fix PEFT checkpoint saving so quantized PEFT adapters use the same HF PEFT key prefix as non-quantized adapters.

QLoRA checkpoint saving bypasses PyTorch DCP and directly collects trainable adapter tensors, but those tensors still need the `base_model.model.` prefix on disk so `PeftModel.from_pretrained` can load them.

## Validation

- `git diff --check`
- Trained Gemma4 31B QLoRA for 100 steps with this change and saved a checkpoint.
- Loaded the saved adapter directly with HF PEFT via `PeftModel.from_pretrained(base_model, checkpoint_dir)`.
- Ran PubMedQA validation prediction from the HF-loaded adapter: accuracy `0.82`, macro F1 `0.5801503298051848`.