### PR TITLE
docs(nemotron-omni): use device_map fast path for SFT inference

### DIFF
--- a/docs/guides/vlm/nemotron-omni.md
+++ b/docs/guides/vlm/nemotron-omni.md
@@ -313,7 +313,7 @@ to spot-check structured output.
 ```python
 import torch
 import json
-from transformers import AutoConfig, AutoModel, AutoProcessor
+from transformers import AutoModel, AutoProcessor
 from datasets import load_dataset
 from nemo_automodel.components.datasets.vlm.utils import json2token
 
@@ -323,19 +323,18 @@ CKPT = "<checkpoint_dir>/LOWEST_VAL/model/consolidated"
 processor = AutoProcessor.from_pretrained(CKPT, trust_remote_code=True)
 tokenizer = processor.tokenizer
 
-# Resolve the trust_remote_code model class via from_config, then load weights.
-# Using AutoModel.from_pretrained directly can mis-route on v3 dumps.
-config = AutoConfig.from_pretrained(CKPT, trust_remote_code=True)
-model_class = type(AutoModel.from_config(config, trust_remote_code=True))
-if not hasattr(model_class, "all_tied_weights_keys"):
-    model_class.all_tied_weights_keys = {}
-model = model_class.from_pretrained(CKPT, trust_remote_code=True, torch_dtype=torch.bfloat16)
+# `device_map` streams weights directly to GPU; skipping the AutoModel.from_config
+# CPU-instantiation step saves ~5 min on the 30B v3 dump.
+model = AutoModel.from_pretrained(
+    CKPT, trust_remote_code=True, torch_dtype=torch.bfloat16,
+    device_map={"": torch.cuda.current_device()},
+)
 
 # Reset RADIO's `summary_idxs` (non-persistent buffer; can be a meta tensor after load)
 if hasattr(model, "vision_model") and hasattr(model.vision_model, "radio_model"):
     model.vision_model.radio_model.summary_idxs = None
 
-model = model.cuda().eval()
+model.eval()
 
 # Load dataset
 dataset = load_dataset("naver-clova-ix/cord-v2")


### PR DESCRIPTION
## Summary
Replace the SFT inference snippet's CPU-instantiation workaround with the existing fast path used by the LoRA section.

The current `Step 4 — Run Inference` SFT example does:

```python
config = AutoConfig.from_pretrained(CKPT, trust_remote_code=True)
model_class = type(AutoModel.from_config(config, trust_remote_code=True))
if not hasattr(model_class, "all_tied_weights_keys"):
    model_class.all_tied_weights_keys = {}
model = model_class.from_pretrained(CKPT, trust_remote_code=True, torch_dtype=torch.bfloat16)
...
model = model.cuda().eval()
```

That pattern resolves the `trust_remote_code` model class by **instantiating** a 30B model on CPU with random weights just to read `type(...)`. On the v3 dump that CPU init alone burns ~5 minutes before any real loading happens. The comment claims `AutoModel.from_pretrained` "can mis-route on v3 dumps", but that is no longer true on current `transformers` / `auto26.04` containers.

## What changes
Use the same direct-to-GPU pattern the LoRA section already documents:

```python
model = AutoModel.from_pretrained(
    CKPT, trust_remote_code=True, torch_dtype=torch.bfloat16,
    device_map={"": torch.cuda.current_device()},
)
```

- Drops `AutoConfig` import.
- Drops the `from_config` round-trip and the `all_tied_weights_keys` patch.
- Replaces `model.cuda().eval()` with `model.eval()` (weights already on GPU).
- Keeps the RADIO `summary_idxs = None` reset and the `PROCESSOR_METADATA_KEYS` filter — those are independent.

## Verification
Ran the fast path locally on `auto2604rc4` against:

| Checkpoint | Load time | Class resolved | Generation |
|---|---|---|---|
| `nemotron-3-nano-omni-ea1_v2.0` (base v3 dump) | ~21 s | `NemotronH_Nano_VL_V2` | OK |
| `cordv2_v3_400_ckpts/LOWEST_VAL/model/consolidated` (SFT) | ~85 s | `NemotronH_Nano_Omni_Reasoning_V3` | `<s_total><s_total_price>45,500</s_total_price>...<s_nm>REAL GANACHE</s_nm>...` |

Total Step 4 inference setup drops from ~5 min → ~85 s on the consolidated dump. No mis-routing observed.

## Test plan
- [ ] Render the docs locally and confirm the SFT code block compiles cleanly.
- [ ] Optional: re-run the snippet against an internal SFT consolidated dump on a current container to confirm the same class resolution.
