### PR TITLE
fix(deepseek_v4): use scatter_add_ for indexer_topk mask

### DIFF
--- a/nemo_automodel/components/models/deepseek_v4/layers.py
+++ b/nemo_automodel/components/models/deepseek_v4/layers.py
@@ -478,6 +478,31 @@ def eager_attention_with_sink(
     return torch.matmul(probs, value_states).transpose(1, 2).contiguous(), probs
 
 
+def _build_indexer_topk_compressed_mask(
+    attention_mask: torch.Tensor,
+    indexer_topk: torch.Tensor,
+    n_pooled: int,
+) -> torch.Tensor:
+    """Build the additive compressed-position mask for Indexer-selected pool IDs."""
+    min_val = torch.finfo(attention_mask.dtype).min
+    indexer_topk = indexer_topk.to(device=attention_mask.device)
+    batch, seq_len = indexer_topk.shape[:2]
+    valid = indexer_topk != -1  # [B, S, K]
+    safe_idx = indexer_topk.clamp(min=0)
+    indicator_counts = torch.zeros(
+        (batch, seq_len, n_pooled),
+        dtype=torch.int32,
+        device=attention_mask.device,
+    )
+    indicator_counts.scatter_add_(-1, safe_idx, valid.to(torch.int32))
+    indicator = indicator_counts > 0
+    return torch.where(
+        indicator,
+        torch.zeros((), dtype=attention_mask.dtype, device=attention_mask.device),
+        torch.full((), min_val, dtype=attention_mask.dtype, device=attention_mask.device),
+    )  # [B, S, P]
+
+
 class DeepseekV4Indexer(nn.Module):
     """HF PR 45616 port.  Picks the top-k compressed positions per query when
     ``compress_ratio == 4``.  Owns its own pool at ``index_head_dim`` plus a
@@ -873,19 +898,10 @@ class DeepseekV4Attention(nn.Module):
             if attention_mask is not None and n_pooled > 0:
                 min_val = torch.finfo(attention_mask.dtype).min
                 if indexer_topk is not None:
-                    valid = indexer_topk != -1  # [B, S, K]
-                    safe_idx = indexer_topk.clamp(min=0)
-                    indicator = torch.zeros(
-                        (batch, seq_len, n_pooled),
-                        dtype=torch.bool,
-                        device=full_kv.device,
-                    )
-                    indicator.scatter_(-1, safe_idx, valid)
-                    compressed_mask = torch.where(
-                        indicator,
-                        torch.zeros((), dtype=attention_mask.dtype, device=full_kv.device),
-                        torch.full((), min_val, dtype=attention_mask.dtype, device=full_kv.device),
-                    )  # [B, S, P]
+                    # OR-aggregate via scatter_add_: clamping -1 to 0 collides
+                    # with valid index 0, and scatter_'s duplicate-index order
+                    # is unspecified, so use count-then-threshold instead.
+                    compressed_mask = _build_indexer_topk_compressed_mask(attention_mask, indexer_topk, n_pooled)
                 else:
                     q_pos = torch.arange(seq_len, device=full_kv.device)
                     p_pos = torch.arange(n_pooled, device=full_kv.device)

--- a/tests/unit_tests/models/deepseek_v4/test_dsv4_layers.py
+++ b/tests/unit_tests/models/deepseek_v4/test_dsv4_layers.py
@@ -28,10 +28,23 @@ from nemo_automodel.components.models.deepseek_v4.layers import (
     DeepseekV4HyperConnection,
     DeepseekV4RotaryEmbedding,
     _apply_partial_rope_interleaved,
+    _build_indexer_topk_compressed_mask,
     _yarn_correction_dim,
     _yarn_correction_range,
     _yarn_linear_ramp,
 )
+
+
+class TestDeepseekV4AttentionMask:
+    def test_indexer_topk_mask_preserves_pool_zero_with_clamped_invalid_entries(self):
+        """A valid pool index 0 must survive duplicate writes from clamped ``-1`` slots."""
+        attention_mask = torch.zeros(1, 1, 1, 1)
+        indexer_topk = torch.tensor([[[2, 0, -1, -1]]])
+
+        min_val = torch.finfo(attention_mask.dtype).min
+        expected_compressed_mask = torch.tensor([[[[0.0, min_val, 0.0, min_val, min_val]]]])
+        compressed_mask = _build_indexer_topk_compressed_mask(attention_mask, indexer_topk, n_pooled=5).unsqueeze(1)
+        torch.testing.assert_close(compressed_mask, expected_compressed_mask)
 
 
 class TestDeepseekV4GroupedLinear:


### PR DESCRIPTION

# What does this PR do ?

fixed #2144 

Fix the DSV4 sparse-attention compressed mask so a query can still attend to pool position 0 when its indexer_topk row contains both a valid 0 and at least one -1 (clamped-to-0) slot.

# Changelog

- nemo_automodel/components/models/deepseek_v4/layers.py
    - Add _build_indexer_topk_compressed_mask(attention_mask, indexer_topk, n_pooled) helper. Builds the [B, S, P] additive compressed-position mask from indexer_topk using a count-then-threshold pattern.
  - tests/unit_tests/models/deepseek_v4/test_dsv4_layers.py
    - Add TestDeepseekV4AttentionMask::test_indexer_topk_mask_preserves_pool_zero_with_clamped_invalid_entries.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
#2144 