### PR TITLE
fix(tests): clean up sys.modules pollution in training fixtures

### DIFF
--- a/tests/unit_tests/training/test_timers.py
+++ b/tests/unit_tests/training/test_timers.py
@@ -64,7 +64,7 @@ def patch_torch_distributed(monkeypatch):
     dist_stub._all_gather_base = _all_gather
 
     monkeypatch.setattr(torch, "distributed", dist_stub, raising=False)
-    sys.modules["torch.distributed"] = dist_stub
+    monkeypatch.setitem(sys.modules, "torch.distributed", dist_stub)
 
     # Import the module *after* stubs are in place so it picks them up.
     # Force reload in case it was imported by another test module

--- a/tests/unit_tests/training/test_train_ft_mlflow_logging.py
+++ b/tests/unit_tests/training/test_train_ft_mlflow_logging.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib.util
 import sys
 import types
 from unittest.mock import Mock
@@ -26,6 +27,8 @@ def _install_fake_wandb():
     Provide a minimal 'wandb' package so train_ft can be imported without the real dependency.
     """
     wandb = types.ModuleType("wandb")
+    # accelerate calls importlib.util.find_spec("wandb"), which raises if __spec__ is None
+    wandb.__spec__ = importlib.util.spec_from_loader("wandb", loader=None)
     wandb.run = None
 
     class Settings:


### PR DESCRIPTION
# What does this PR do ?

Fix two cooperating fixture bugs in `tests/unit_tests/training/` that cause order-dependent failures when the affected files are run as a subset (e.g. focused local iteration), without affecting the full-suite CI run.

# Changelog

- `tests/unit_tests/training/test_timers.py`
  - Replace direct `sys.modules["torch.distributed"] = dist_stub` with `monkeypatch.setitem(sys.modules, "torch.distributed", dist_stub)` so the stub is reverted at fixture teardown. The previous assignment bypassed `monkeypatch`'s undo log and leaked the stub for the rest of the pytest session, causing later tests that triggered a fresh `torchao` import to fail with `ModuleNotFoundError: No module named 'torch.distributed._tensor'; 'torch.distributed' is not a package`.
- `tests/unit_tests/training/test_train_ft_mlflow_logging.py`
  - Set `wandb.__spec__` on the fake wandb stub via `importlib.util.spec_from_loader("wandb", loader=None)`. `types.ModuleType("wandb")` defaults `__spec__` to `None`, which made `accelerate`'s `importlib.util.find_spec("wandb")` raise `ValueError: wandb.__spec__ is None` whenever the file was run in isolation.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? No new tests — the fix is to test fixtures themselves; correctness is observable via the existing tests, which now pass when run as a subset.
- [x] Did you add or update any necessary documentation? Not applicable.

# Additional Information

To reproduce the fixed errors, run (against `main` before this PR merges):

```bash
uv run --no-sync pytest \
    tests/unit_tests/training/test_timers.py \
    tests/unit_tests/training/test_train_ft_mlflow_logging.py \
    -v --tb=short
```

Pre-fix: both tests in `test_train_ft_mlflow_logging.py` fail with `ModuleNotFoundError: No module named 'torch.distributed._tensor'; 'torch.distributed' is not a package`. After this PR: 17 / 17 pass.

## Why CI did not catch this

Full-suite runs collect `tests/unit_tests/` alphabetically, so directories like `_cli/` (e.g. `test_app.py`, `test_pretrain_cli.py`) run long before `training/` and import `nemo_automodel.recipes.llm.train_ft`, which transitively caches `torchao.float8` in `sys.modules`. Once cached, the leaked `torch.distributed` stub from `test_timers.py` no longer triggers a re-import of torchao, so the failure is masked. Verified locally:

| Scenario (pre-fix) | Result |
|---|---|
| `pytest training/test_timers.py training/test_train_ft_mlflow_logging.py` | 2 failed, 15 passed |
| `pytest _cli/test_app.py training/test_timers.py training/test_train_ft_mlflow_logging.py` | 33 passed |

Full `tests/unit_tests/training/` regression sweep after fix: 55 / 55. `ruff format` and `ruff check` clean on the two changed files.