### PR TITLE
fix(vlm): forward get_rope_index to neat packing for mRoPE models

### DIFF
--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -348,6 +348,7 @@ def build_dataloader(
     local_batch_size,
     cfg_model=None,
     cfg_ps=None,
+    get_rope_index=None,
 ) -> tuple[DataLoader, ProcessorMixin]:
     """Build a DataLoader for the VLM dataset.
 
@@ -362,6 +363,11 @@ def build_dataloader(
         cfg_model: Model configuration (used to detect attention backend).
         cfg_ps: Packed sequence configuration (top-level ``packed_sequence:`` section).
             When provided, takes precedence over ``dataset.packing``.
+        get_rope_index: Optional ``model.get_rope_index`` callable. When provided,
+            VLM neat packing computes mRoPE 3D position IDs per sample so packed
+            mRoPE-aware models (Qwen2.5-VL, Qwen3-VL, ...) preserve multimodal
+            position semantics across pack boundaries instead of falling back to
+            plain 1D positions.
 
     Returns:
         The instantiated DataLoader and processor.
@@ -479,6 +485,7 @@ def build_dataloader(
                     packing_ratio=packing_cfg.get("packing_ratio", 1.0),
                     processor=processor,
                     balance_media_tokens=packing_cfg.get("balance_media_tokens", True),
+                    get_rope_index=get_rope_index,
                 )
                 _pad_id = getattr(processor.tokenizer, "pad_token_id", 0) or 0
                 _collate_max_length = packing_cfg.get("collate_max_length", None)
@@ -832,6 +839,11 @@ class FinetuneRecipeForVLM(BaseRecipe):
             self.model_parts = [model]
             self.pp = None
 
+        # Extract mRoPE position-id builder from the model so VLM neat packing can
+        # produce 3D position_ids per sample. Without this, packed Qwen2.5-VL /
+        # Qwen3-VL training silently degrades mRoPE to plain 1D positions.
+        get_rope_index = getattr(self.model_parts[0], "get_rope_index", None)
+
         self.dataloader, self.processor = build_dataloader(
             self.cfg.dataset,
             self.cfg.dataloader,
@@ -842,6 +854,7 @@ class FinetuneRecipeForVLM(BaseRecipe):
             local_batch_size=self.cfg.get("step_scheduler.local_batch_size", 1),
             cfg_model=self.cfg.model,
             cfg_ps=self.cfg.get("packed_sequence", None),
+            get_rope_index=get_rope_index,
         )
 
         # Build validation dataloader if the config provides it
@@ -855,6 +868,7 @@ class FinetuneRecipeForVLM(BaseRecipe):
                 device_mesh=self.device_mesh,
                 seed=self.cfg.get("seed", 42),
                 local_batch_size=self.cfg.get("step_scheduler.local_batch_size", 1),
+                get_rope_index=get_rope_index,
             )
 
         self.best_metric_key = self.cfg.get("checkpoint.best_metric_key", "default")

--- a/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
+++ b/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
@@ -2432,3 +2432,133 @@ class TestChunkVlmMedia:
         assert len(pv_chunks) == 2
         assert pv_chunks[0].shape[0] == 12  # all in first
         assert pv_chunks[1].shape[0] == 0   # empty
+
+
+# -----------------------------------------------------------------------------
+# get_rope_index forwarding tests for build_dataloader
+#
+# Guard against a regression where the VLM recipe forgot to pass
+# get_rope_index to neat_pack_dataset_vlm, silently degrading mRoPE to
+# plain 1D positions for packed Qwen2.5-VL / Qwen3-VL training.
+# -----------------------------------------------------------------------------
+
+
+def _make_packing_cfg(pack_size=128):
+    cfg = MagicMock()
+    cfg.pack_size = pack_size
+    cfg.pretokenize = True
+    cfg.max_length = pack_size
+    cfg.get.side_effect = lambda key, default=None: {
+        "pack_size": pack_size,
+        "drop_long_samples": True,
+        "max_packs": None,
+        "packing_ratio": 1.0,
+        "balance_media_tokens": True,
+        "collate_max_length": None,
+        "post_tokenize_hook_fn": None,
+    }.get(key, default)
+    return cfg
+
+
+def _make_dataset_cfg():
+    cfg = MagicMock(spec=["get", "instantiate", "path_or_dataset"])
+    cfg.get.side_effect = lambda key, default=None: {
+        "path_or_dataset": None,
+        "truncate": True,
+    }.get(key, default)
+    cfg.path_or_dataset = None
+    cfg.instantiate.return_value = []
+    return cfg
+
+
+def _patches_for_packing(neat_pack_side_effect):
+    processor = MagicMock()
+    processor.tokenizer.pad_token_id = 0
+    processor.chat_template = "{{ x }}"
+    return processor, [
+        patch("transformers.AutoProcessor.from_pretrained", return_value=processor),
+        patch("torch.utils.data.distributed.DistributedSampler"),
+        patch(
+            "nemo_automodel.components.datasets.vlm.datasets.PreTokenizedDatasetWrapper",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "nemo_automodel.components.datasets.vlm.neat_packing_vlm.neat_pack_dataset_vlm",
+            side_effect=neat_pack_side_effect,
+        ),
+        patch("nemo_automodel.components.models.common.packing.configure_packing"),
+        patch(
+            "nemo_automodel.components.models.common.packing.get_attn_implementation",
+            return_value="sdpa",
+        ),
+    ]
+
+
+def test_build_dataloader_forwards_get_rope_index_to_packing():
+    """get_rope_index passed to build_dataloader must reach neat_pack_dataset_vlm."""
+    from contextlib import ExitStack
+
+    from nemo_automodel.recipes.vlm.finetune import build_dataloader
+
+    sentinel = MagicMock(name="get_rope_index")
+    captured = {}
+
+    def fake_neat_pack(*args, **kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    _, ctx_managers = _patches_for_packing(fake_neat_pack)
+
+    with ExitStack() as stack:
+        for cm in ctx_managers:
+            stack.enter_context(cm)
+        build_dataloader(
+            _make_dataset_cfg(),
+            MagicMock(get=MagicMock(return_value=None), instantiate=MagicMock(return_value=MagicMock())),
+            "test/model",
+            None,
+            None,
+            42,
+            1,
+            cfg_ps=_make_packing_cfg(pack_size=64),
+            get_rope_index=sentinel,
+        )
+
+    assert captured.get("get_rope_index") is sentinel, (
+        "build_dataloader must forward get_rope_index to neat_pack_dataset_vlm; "
+        f"got kwargs={list(captured.keys())}"
+    )
+
+
+def test_build_dataloader_default_get_rope_index_is_none():
+    """When the model does not expose get_rope_index, packing must receive None."""
+    from contextlib import ExitStack
+
+    from nemo_automodel.recipes.vlm.finetune import build_dataloader
+
+    captured = {}
+
+    def fake_neat_pack(*args, **kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    _, ctx_managers = _patches_for_packing(fake_neat_pack)
+
+    with ExitStack() as stack:
+        for cm in ctx_managers:
+            stack.enter_context(cm)
+        build_dataloader(
+            _make_dataset_cfg(),
+            MagicMock(get=MagicMock(return_value=None), instantiate=MagicMock(return_value=MagicMock())),
+            "test/model",
+            None,
+            None,
+            42,
+            1,
+            cfg_ps=_make_packing_cfg(pack_size=64),
+        )
+
+    assert "get_rope_index" in captured, (
+        "neat_pack_dataset_vlm must receive get_rope_index kwarg even when None"
+    )
+    assert captured["get_rope_index"] is None


### PR DESCRIPTION
## What

When VLM neat-packing is enabled for an mRoPE-aware model (Qwen2.5-VL, Qwen3-VL, Qwen3-VL-MoE, Qwen3-Omni), the recipe never passes `model.get_rope_index` to `neat_pack_dataset_vlm`. With it absent, packed `position_ids` are emitted as 1D `range(seq_len)` per sample and the model's internal mRoPE auto-fill is skipped.

This PR plumbs `get_rope_index` from the model through `build_dataloader` to `neat_pack_dataset_vlm`. Models without the method (Mistral3, LLaVA-OV, KimiVL, Gemma4-VLM) keep prior behavior since `getattr(model, "get_rope_index", None)` returns `None`.

## Exact trigger conditions

All of the following must hold simultaneously:

1. **VLM recipe** (`recipes/vlm/finetune.py`) — not LLM/diffusion/retrieval.
2. **Packing enabled** — `packed_sequence.pack_size > 0` (or legacy `dataset.packing.enabled`).
3. **Pretokenize on** — `packed_sequence.pretokenize: true` (so the path goes through `PreTokenizedDatasetWrapper` + `neat_pack_dataset_vlm`).
4. **Model implements `get_rope_index`** — i.e. mRoPE-aware: `Qwen2_5_VLForConditionalGeneration`, `Qwen3VLForConditionalGeneration`, `Qwen3VLMoeForConditionalGeneration`, `Qwen3OmniMoeForConditionalGeneration`.
5. **No user-supplied `post_tokenize_hook_fn`** that pre-computes 3D `position_ids`.

The path is **independent of CP**. CP-specific mRoPE handling (PR #1482, `cp_utils.py:294`) is correct *given* 3D `position_ids` enter CP — that fix shards correctly on `dim=2` for `ndim==3`. This PR is about how 3D `position_ids` originate in the first place under packing.

Unaffected combinations (no behavior change):
- Non-packing VLM training — `default_collate_fn` deliberately omits `position_ids` so the model auto-calls `get_rope_index` (see comment at `collate_fns.py:1277-1281`).
- Non-mRoPE VLMs — `getattr(model, "get_rope_index", None)` returns `None`, packing falls through the existing 1D path, identical to current behavior.
- LLM neat packing — uses `neat_pack_dataset` (not `_vlm`), unrelated.

## Code path (failure case before this PR)

```
recipe `build_dataloader` → neat_pack_dataset_vlm(get_rope_index=None)
  → PackedDatasetWrapper.has_mrope = False                  # neat_packing_vlm.py:450
  → _build_packed_vlm_sample(has_mrope=False)
      → all_position_ids_1d.extend(range(seq_len))          # line 367-370
      → packed["position_ids"] = 1D [total_len]             # line 400
  → neat_packed_vlm_collater
      → 1D path: stack to [B, max_len]                      # collate_fns.py:1528
  → batch sent to model.forward via filter_forward_kwargs
  → Qwen3VLMoe.forward (model.py:230)
      → if position_ids is None: ... # FALSE (we passed 2D), skipped
  → language_model.forward (model.py:354-357)
      → elif position_ids.ndim == 2:
            position_ids = position_ids[None, ...].expand(3, B, S)  # 3 identical channels
```

The `expand(3, B, S)` produces three identical position channels, so the t/h/w mRoPE chunks rotate by the same angle in image regions. This is mathematically not equivalent to standard mRoPE, which requires distinct temporal/height/width coordinates for image tokens.

## With this PR

```
recipe `build_dataloader` → neat_pack_dataset_vlm(get_rope_index=model.get_rope_index)
  → PackedDatasetWrapper.has_mrope = True
  → __getitem__: _compute_mrope_position_ids(sample, get_rope_index)
      → returns 3D [3, seq_len] per sample
  → _build_packed_vlm_sample(has_mrope=True)
      → packed["position_ids"] = torch.cat(mrope_list, dim=1)  # [3, total_len]
  → collater stacks to [3, B, max_len]                          # collate_fns.py:1525
  → CP path (if enabled) shards on dim=2 (PR #1482)
  → model.forward sees 3D position_ids, uses as-is
```

## Open question for reviewers

A NeMo CP researcher mentioned mRoPE is "already taken care of" in the codebase. I traced this to `cp_utils.py:287-295` (PR #1482) which **shards** 3D mRoPE correctly. I could not find a path that **generates** 3D mRoPE under packing without `get_rope_index` being passed through. If such a path exists, please point me to it and I will close this PR. Otherwise this fix is plumbing-only and safe.

What I have *not* measured: the empirical convergence delta between degenerate-mRoPE and proper-mRoPE on packed Qwen-VL training. The fix is a correctness improvement for the packed path; magnitude requires an A/B convergence run.

## Changelog

- `recipes/vlm/finetune.py`: extract `get_rope_index` via `getattr(self.model_parts[0], "get_rope_index", None)` and forward it through `build_dataloader` → `neat_pack_dataset_vlm`. 14 lines added.
- `tests/unit_tests/recipes/test_finetune_vlm_helpers.py`: two unit tests verifying the wiring (sentinel forwarded; default `None` for non-mRoPE models).

## Pre-checks

- [x] `ruff format` and `ruff check` clean on touched lines.
- [x] Two new unit tests pass locally: `pytest tests/unit_tests/recipes/test_finetune_vlm_helpers.py -k get_rope_index`.
- [x] DCO sign-off present.
- [x] Branch `khazic/fix/vlm-packed-mrope-position-ids` from latest `upstream/main`.

## Affected example configs

- `examples/vlm_finetune/qwen3/qwen3_vl_4b_neat_packing.yaml`
- `examples/vlm_finetune/qwen3/qwen3_vl_moe_30b_neat_packing.yaml`
- `examples/vlm_finetune/qwen3_5_moe/qwen3_5_35b_neat_packing.yaml`
- `examples/vlm_finetune/qwen3_5/qwen3_5_4b_neat_packing.yaml`

All four match all 5 trigger conditions above with no `post_tokenize_hook_fn` override.