### PR TITLE
fix(dsv4/moe): clamp shared-expert SwiGLU in fp32

### DIFF
--- a/nemo_automodel/components/moe/layers.py
+++ b/nemo_automodel/components/moe/layers.py
@@ -60,6 +60,7 @@ class MLP(nn.Module):
         dtype: torch.dtype = torch.bfloat16,
         activation: str = "swiglu",
         bias: bool = False,
+        swiglu_limit: float = 0.0,
     ):
         """
         Initializes the MLP layer.
@@ -71,6 +72,9 @@ class MLP(nn.Module):
             dtype (torch.dtype): Data type for weights.
             activation (str): Activation function - "swiglu" (default) or "relu2".
             bias (bool): Whether to use bias in linear layers.
+            swiglu_limit (float): When > 0 and activation is gated, run SwiGLU
+                in fp32 with one-sided gate clamp ``max=limit`` and symmetric
+                up clamp ``±limit``. Matches DSV4 reference ``Expert.forward``.
         """
         super().__init__()
         if activation not in ("swiglu", "relu2"):
@@ -78,6 +82,7 @@ class MLP(nn.Module):
 
         self.activation = activation
         self.is_gated = is_gated_activation(activation)
+        self.swiglu_limit = float(swiglu_limit)
 
         self.up_proj = initialize_linear_module(
             linear_impl=backend, in_features=dim, out_features=inter_dim, bias=bias, dtype=dtype
@@ -103,10 +108,16 @@ class MLP(nn.Module):
         Returns:
             torch.Tensor: Output tensor after MLP computation.
         """
-        if self.is_gated:
-            return self.down_proj(F.silu(self.gate_proj(x)) * self.up_proj(x))
-        else:
+        if not self.is_gated:
             return self.down_proj(F.relu(self.up_proj(x)).pow(2))
+        if self.swiglu_limit > 0.0:
+            # Mirror DSV4 reference Expert.forward: fp32 SwiGLU with one-sided
+            # gate clamp and symmetric up clamp; cast back before down_proj.
+            dtype = x.dtype
+            gate = self.gate_proj(x).float().clamp(max=self.swiglu_limit)
+            up = self.up_proj(x).float().clamp(min=-self.swiglu_limit, max=self.swiglu_limit)
+            return self.down_proj((F.silu(gate) * up).to(dtype))
+        return self.down_proj(F.silu(self.gate_proj(x)) * self.up_proj(x))
 
     def init_weights(self, buffer_device: torch.device, init_std: float = 0.02) -> None:
         init_weights_fn = partial(_init_weights, buffer_device=buffer_device, init_std=init_std)
@@ -626,6 +637,7 @@ class MoE(nn.Module):
                 dtype=config.dtype,
                 activation=config.shared_expert_activation,
                 bias=config.expert_bias,
+                swiglu_limit=config.swiglu_limit,
             )
             if config.shared_expert_gate:
                 self.shared_expert_gate = initialize_linear_module(backend.linear, config.dim, 1, False)


### PR DESCRIPTION
Fix issue https://github.com/NVIDIA-NeMo/Automodel/issues/2170

DSV4-Flash reference upstream (HF commit 2b2bebc, ~2026-04-26) added swiglu_limit to shared experts so they clamp identically to routed experts. Mirror that here: extend MLP with an optional swiglu_limit and have MoE pass config.swiglu_limit through to the shared-expert MLP. When swiglu_limit > 0, the gated path runs gate/up in fp32 with one-sided gate clamp (max=limit) and symmetric up clamp (+/-limit) and casts back before down_proj, matching reference Expert.forward. Non-DSV4 callers default swiglu_limit=0.0 and keep their current bf16 path unchanged.

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
