### PR TITLE
fix(vlm): chunk video inputs for pipeline parallelism

### DIFF
--- a/nemo_automodel/components/models/qwen3_5_moe/model.py
+++ b/nemo_automodel/components/models/qwen3_5_moe/model.py
@@ -181,9 +181,9 @@ class Qwen3_5MoeModel(HFQwen3_5MoeModel):
             else:
                 raise ValueError("inputs_embeds must be provided for pipeline stages without embed_tokens")
 
-        # If we have pixel values and a vision encoder, go through the full HF
+        # If we have visual pixel values and a vision encoder, go through the full HF
         # VL forward (vision encoding + multimodal scatter + text).
-        if pixel_values is not None and self.visual is not None:
+        if (pixel_values is not None or pixel_values_videos is not None) and self.visual is not None:
             return super().forward(
                 input_ids=None,
                 attention_mask=attention_mask,
@@ -491,23 +491,25 @@ class Qwen3_5MoeForConditionalGeneration(HFCheckpointingMixin, HFQwen3_5MoeForCo
     ):
         # PP VLM support: retrieve pixel_values from stored chunks if not passed
         pixel_values = kwargs.get("pixel_values", None)
+        pixel_values_videos = kwargs.get("pixel_values_videos", None)
         image_grid_thw = kwargs.get("image_grid_thw", None)
-        if (
-            pixel_values is None
-            and hasattr(self, "_vlm_pixel_values_chunks")
-            and self._vlm_pixel_values_chunks is not None
-        ):
-            image_token_id = self.config.image_token_id
-            vision_start_token_id = self.config.vision_start_token_id
-            has_media_tokens = input_ids is not None and (
-                (input_ids == image_token_id).any() or (input_ids == vision_start_token_id).any()
-            )
+        video_grid_thw = kwargs.get("video_grid_thw", None)
+        image_token_id = self.config.image_token_id
+        vision_start_token_id = self.config.vision_start_token_id
+        has_media_tokens = input_ids is not None and (
+            (input_ids == image_token_id).any() or (input_ids == vision_start_token_id).any()
+        )
 
-            if has_media_tokens:
-                chunk_idx = getattr(self, "_vlm_chunk_idx", 0)
-                if chunk_idx < len(self._vlm_pixel_values_chunks):
-                    pixel_values = self._vlm_pixel_values_chunks[chunk_idx]
-                    image_grid_hws = self._vlm_image_grid_hws_chunks[chunk_idx]
+        chunk_idx = getattr(self, "_vlm_chunk_idx", 0)
+        consumed_vlm_chunk = False
+
+        if pixel_values is None and has_media_tokens:
+            image_chunks = getattr(self, "_vlm_pixel_values_chunks", None)
+            if image_chunks is not None and chunk_idx < len(image_chunks):
+                pixel_values = image_chunks[chunk_idx]
+                image_grid_chunks = getattr(self, "_vlm_image_grid_hws_chunks", None)
+                if image_grid_chunks is not None and chunk_idx < len(image_grid_chunks):
+                    image_grid_hws = image_grid_chunks[chunk_idx]
                     if image_grid_hws is not None and image_grid_hws.numel() > 0:
                         if image_grid_hws.shape[-1] == 2:
                             ones = torch.ones(
@@ -516,9 +518,25 @@ class Qwen3_5MoeForConditionalGeneration(HFCheckpointingMixin, HFQwen3_5MoeForCo
                             image_grid_thw = torch.cat([ones, image_grid_hws], dim=-1)
                         else:
                             image_grid_thw = image_grid_hws
-                    kwargs["pixel_values"] = pixel_values
-                    kwargs["image_grid_thw"] = image_grid_thw
-                    self._vlm_chunk_idx = chunk_idx + 1
+                kwargs["pixel_values"] = pixel_values
+                kwargs["image_grid_thw"] = image_grid_thw
+                consumed_vlm_chunk = True
+
+        if pixel_values_videos is None and has_media_tokens:
+            video_chunks = getattr(self, "_vlm_pixel_values_videos_chunks", None)
+            if video_chunks is not None and chunk_idx < len(video_chunks):
+                video_chunk = video_chunks[chunk_idx]
+                if video_chunk.numel() > 0:
+                    pixel_values_videos = video_chunk
+                    video_grid_chunks = getattr(self, "_vlm_video_grid_thw_chunks", None)
+                    if video_grid_chunks is not None and chunk_idx < len(video_grid_chunks):
+                        video_grid_thw = video_grid_chunks[chunk_idx]
+                    kwargs["pixel_values_videos"] = pixel_values_videos
+                    kwargs["video_grid_thw"] = video_grid_thw
+                consumed_vlm_chunk = True
+
+        if consumed_vlm_chunk:
+            self._vlm_chunk_idx = chunk_idx + 1
 
         if "qkv_format" in kwargs and kwargs["qkv_format"] == "thd":
             input_ids, position_ids, padding_mask, kwargs = squeeze_input_for_thd(

--- a/nemo_automodel/components/models/qwen3_omni_moe/model.py
+++ b/nemo_automodel/components/models/qwen3_omni_moe/model.py
@@ -315,6 +315,42 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
             )
             attention_mask = None
 
+        chunk_idx = getattr(self, "_vlm_chunk_idx", 0)
+        consumed_vlm_chunk = False
+
+        if pixel_values is None:
+            image_chunks = getattr(self, "_vlm_pixel_values_chunks", None)
+            if image_chunks is not None and chunk_idx < len(image_chunks):
+                image_chunk = image_chunks[chunk_idx]
+                if image_chunk.numel() > 0:
+                    pixel_values = image_chunk
+                    image_grid_chunks = getattr(self, "_vlm_image_grid_hws_chunks", None)
+                    if image_grid_chunks is not None and chunk_idx < len(image_grid_chunks):
+                        image_grid = image_grid_chunks[chunk_idx]
+                        if image_grid is not None and image_grid.numel() > 0:
+                            if image_grid.shape[-1] == 2:
+                                ones = torch.ones(
+                                    image_grid.shape[0], 1, dtype=image_grid.dtype, device=image_grid.device
+                                )
+                                image_grid_thw = torch.cat([ones, image_grid], dim=-1)
+                            else:
+                                image_grid_thw = image_grid
+                consumed_vlm_chunk = True
+
+        if pixel_values_videos is None:
+            video_chunks = getattr(self, "_vlm_pixel_values_videos_chunks", None)
+            if video_chunks is not None and chunk_idx < len(video_chunks):
+                video_chunk = video_chunks[chunk_idx]
+                if video_chunk.numel() > 0:
+                    pixel_values_videos = video_chunk
+                    video_grid_chunks = getattr(self, "_vlm_video_grid_thw_chunks", None)
+                    if video_grid_chunks is not None and chunk_idx < len(video_grid_chunks):
+                        video_grid_thw = video_grid_chunks[chunk_idx]
+                consumed_vlm_chunk = True
+
+        if consumed_vlm_chunk:
+            self._vlm_chunk_idx = chunk_idx + 1
+
         # 1. Get input embeddings
         if inputs_embeds is None:
             inputs_embeds = self.get_input_embeddings()(input_ids)

--- a/nemo_automodel/components/models/qwen3_vl_moe/model.py
+++ b/nemo_automodel/components/models/qwen3_vl_moe/model.py
@@ -526,21 +526,26 @@ class Qwen3VLMoeForConditionalGeneration(HFCheckpointingMixin, HFQwen3VLMoeForCo
     ):
         # PP VLM support: retrieve pixel_values from stored chunks if not passed directly
         pixel_values = kwargs.get("pixel_values", None)
+        pixel_values_videos = kwargs.get("pixel_values_videos", None)
         image_grid_thw = kwargs.get("image_grid_thw", None)
-        if (
-            pixel_values is None
-            and hasattr(self, "_vlm_pixel_values_chunks")
-            and self._vlm_pixel_values_chunks is not None
-        ):
-            # Check if we have media tokens in input_ids
-            # 151655 = <|image_pad|>, 151656 = <|video_pad|>
-            has_media_tokens = input_ids is not None and ((input_ids == 151655).any() or (input_ids == 151656).any())
+        video_grid_thw = kwargs.get("video_grid_thw", None)
+        if input_ids is not None:
+            has_image_tokens = (input_ids == 151655).any()
+            has_video_tokens = (input_ids == 151656).any()
+        else:
+            has_image_tokens = False
+            has_video_tokens = False
 
-            if has_media_tokens:
-                chunk_idx = getattr(self, "_vlm_chunk_idx", 0)
-                if chunk_idx < len(self._vlm_pixel_values_chunks):
-                    pixel_values = self._vlm_pixel_values_chunks[chunk_idx]
-                    image_grid_hws = self._vlm_image_grid_hws_chunks[chunk_idx]
+        chunk_idx = getattr(self, "_vlm_chunk_idx", 0)
+        consumed_vlm_chunk = False
+
+        if pixel_values is None and has_image_tokens:
+            image_chunks = getattr(self, "_vlm_pixel_values_chunks", None)
+            if image_chunks is not None and chunk_idx < len(image_chunks):
+                pixel_values = image_chunks[chunk_idx]
+                image_grid_chunks = getattr(self, "_vlm_image_grid_hws_chunks", None)
+                if image_grid_chunks is not None and chunk_idx < len(image_grid_chunks):
+                    image_grid_hws = image_grid_chunks[chunk_idx]
                     # Convert image_grid_hws [N, 2] to image_grid_thw [N, 3] by prepending T=1
                     if image_grid_hws is not None and image_grid_hws.numel() > 0:
                         if image_grid_hws.shape[-1] == 2:
@@ -550,9 +555,23 @@ class Qwen3VLMoeForConditionalGeneration(HFCheckpointingMixin, HFQwen3VLMoeForCo
                             image_grid_thw = torch.cat([ones, image_grid_hws], dim=-1)
                         else:
                             image_grid_thw = image_grid_hws
-                    kwargs["pixel_values"] = pixel_values
-                    kwargs["image_grid_thw"] = image_grid_thw
-                    self._vlm_chunk_idx = chunk_idx + 1
+                kwargs["pixel_values"] = pixel_values
+                kwargs["image_grid_thw"] = image_grid_thw
+                consumed_vlm_chunk = True
+
+        if pixel_values_videos is None and has_video_tokens:
+            video_chunks = getattr(self, "_vlm_pixel_values_videos_chunks", None)
+            if video_chunks is not None and chunk_idx < len(video_chunks):
+                pixel_values_videos = video_chunks[chunk_idx]
+                video_grid_chunks = getattr(self, "_vlm_video_grid_thw_chunks", None)
+                if video_grid_chunks is not None and chunk_idx < len(video_grid_chunks):
+                    video_grid_thw = video_grid_chunks[chunk_idx]
+                kwargs["pixel_values_videos"] = pixel_values_videos
+                kwargs["video_grid_thw"] = video_grid_thw
+                consumed_vlm_chunk = True
+
+        if consumed_vlm_chunk:
+            self._vlm_chunk_idx = chunk_idx + 1
 
         # With pipeline parallelism, attention_mask (from batch kwargs) can have a
         # different sequence length than inputs_embeds (hidden states from prev stage).

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -1026,6 +1026,9 @@ class FinetuneRecipeForVLM(BaseRecipe):
                 image_sizes = batch.pop("image_sizes", None)
                 image_position_ids = batch.pop("image_position_ids", None)
                 n_images_per_sample = batch.pop("n_images_per_sample", None)
+                pixel_values_videos = batch.pop("pixel_values_videos", None)
+                video_grid_thw = batch.pop("video_grid_thw", None)
+                n_videos_per_sample = batch.pop("n_videos_per_sample", None)
 
                 image_grid = image_grid_hws if image_grid_hws is not None else image_grid_thw
                 if image_grid is None and image_sizes is not None:
@@ -1050,6 +1053,30 @@ class FinetuneRecipeForVLM(BaseRecipe):
                     stage0_model._vlm_pixel_values_chunks = pixel_values_chunks
                     stage0_model._vlm_image_grid_hws_chunks = image_grid_chunks
                     stage0_model._vlm_chunk_idx = 0
+                elif pixel_values is not None:
+                    batch["pixel_values"] = pixel_values
+
+                if self.pp.info.has_first_stage and pixel_values_videos is not None and video_grid_thw is not None:
+                    stage0_model = self.model_parts[0]
+                    n_microbatches = self.pp._info.schedule._n_microbatches
+                    batch_size = input_ids.shape[0]
+
+                    pixel_values_videos_chunks, video_grid_thw_chunks = _chunk_vlm_media(
+                        pixel_values_videos,
+                        video_grid_thw,
+                        batch_size,
+                        n_microbatches,
+                        n_images_per_sample=n_videos_per_sample,
+                    )
+
+                    stage0_model._vlm_pixel_values_videos_chunks = pixel_values_videos_chunks
+                    stage0_model._vlm_video_grid_thw_chunks = video_grid_thw_chunks
+                    stage0_model._vlm_chunk_idx = 0
+                else:
+                    if pixel_values_videos is not None:
+                        batch["pixel_values_videos"] = pixel_values_videos
+                    if video_grid_thw is not None:
+                        batch["video_grid_thw"] = video_grid_thw
 
                 if self.pp.info.has_first_stage:
                     self.pp.info.schedule.step(input_ids, target=targets, losses=losses, **batch)
@@ -1061,6 +1088,11 @@ class FinetuneRecipeForVLM(BaseRecipe):
                     stage0_model = self.model_parts[0]
                     stage0_model._vlm_pixel_values_chunks = None
                     stage0_model._vlm_image_grid_hws_chunks = None
+                    stage0_model._vlm_chunk_idx = None
+                if self.pp.info.has_first_stage and pixel_values_videos is not None and video_grid_thw is not None:
+                    stage0_model = self.model_parts[0]
+                    stage0_model._vlm_pixel_values_videos_chunks = None
+                    stage0_model._vlm_video_grid_thw_chunks = None
                     stage0_model._vlm_chunk_idx = None
 
             if self.pp.info.has_last_stage:

--- a/tests/unit_tests/models/qwen3_vl_moe/test_qwen3_vl_moe_model.py
+++ b/tests/unit_tests/models/qwen3_vl_moe/test_qwen3_vl_moe_model.py
@@ -824,17 +824,25 @@ class TestQwen3VLMoeForConditionalGenerationPPGuard:
         assert captured_kwargs["attention_mask"] is None
 
     def test_video_token_id_is_151656(self, vl_config, backend_config, moe_config, device):
-        """Test that video token ID 151656 (not 151652) is used for media token detection."""
+        """Test that video token ID 151656 (not 151652) is used for media token detection.
+
+        After the PP video chunking refactor, image and video chunks live on
+        separate attributes (``_vlm_pixel_values_chunks`` /
+        ``_vlm_image_grid_hws_chunks`` for images,
+        ``_vlm_pixel_values_videos_chunks`` / ``_vlm_video_grid_thw_chunks``
+        for videos). A video token in ``input_ids`` must therefore consume a
+        video chunk, not an image chunk.
+        """
         model = Qwen3VLMoeForConditionalGeneration(vl_config, backend=backend_config, moe_config=moe_config).to(device)
         model_dtype = next(model.parameters()).dtype
 
         # input_ids with video token 151656
         input_ids = torch.tensor([[1, 151656, 2, 3]], device=device)
 
-        pixel_values_chunk = torch.randn(1, 3, 4, 4, device=device, dtype=model_dtype)
-        image_grid_hws_chunk = torch.tensor([[2, 2]], device=device)
-        model._vlm_pixel_values_chunks = [pixel_values_chunk]
-        model._vlm_image_grid_hws_chunks = [image_grid_hws_chunk]
+        pixel_values_videos_chunk = torch.randn(8, 3, 2, 2, device=device, dtype=model_dtype)
+        video_grid_thw_chunk = torch.tensor([[1, 2, 2]], device=device)
+        model._vlm_pixel_values_videos_chunks = [pixel_values_videos_chunk]
+        model._vlm_video_grid_thw_chunks = [video_grid_thw_chunk]
         model._vlm_chunk_idx = 0
 
         with patch.object(model.model, "forward") as mock_forward:

--- a/tests/unit_tests/models/qwen3_vl_moe/test_qwen3_vl_moe_model.py
+++ b/tests/unit_tests/models/qwen3_vl_moe/test_qwen3_vl_moe_model.py
@@ -1159,8 +1159,8 @@ class TestQwen3VLMoeForConditionalGenerationPpGuardCpu:
         assert captured["attention_mask"] is not None
         torch.testing.assert_close(captured["attention_mask"], attention_mask)
 
-    @pytest.mark.parametrize("media_token_id", [151655, 151656])
-    def test_chunked_pixel_values_consumed_for_media_tokens(self, media_token_id):
+    def test_chunked_pixel_values_consumed_for_image_token(self):
+        """Image chunks are consumed when input_ids contains <|image_pad|> (151655)."""
         ms = self._mock_self()
         pixel_chunk = torch.randn(4, 3, 2, 2)
         grid_hws_chunk = torch.tensor([[2, 2]])
@@ -1168,7 +1168,7 @@ class TestQwen3VLMoeForConditionalGenerationPpGuardCpu:
         ms._vlm_image_grid_hws_chunks = [grid_hws_chunk]
         ms._vlm_chunk_idx = 0
 
-        input_ids = torch.tensor([[1, media_token_id, 2, 3]])
+        input_ids = torch.tensor([[1, 151655, 2, 3]])
 
         captured = {}
 
@@ -1189,6 +1189,43 @@ class TestQwen3VLMoeForConditionalGenerationPpGuardCpu:
         assert thw is not None and thw.shape == (1, 3)
         assert torch.equal(thw[:, 0], torch.ones(1, dtype=thw.dtype))
         assert torch.equal(thw[:, 1:], grid_hws_chunk)
+
+    def test_chunked_pixel_values_videos_consumed_for_video_token(self):
+        """Video chunks are consumed when input_ids contains <|video_pad|> (151656).
+
+        Image chunks must not be consumed for video-only input — image and video
+        streams now route through separate chunk arrays after the PP video
+        chunking refactor.
+        """
+        ms = self._mock_self()
+        video_chunk = torch.randn(8, 3, 2, 2)
+        video_grid_chunk = torch.tensor([[1, 2, 2]])
+        ms._vlm_pixel_values_videos_chunks = [video_chunk]
+        ms._vlm_video_grid_thw_chunks = [video_grid_chunk]
+        ms._vlm_pixel_values_chunks = None
+        ms._vlm_image_grid_hws_chunks = None
+        ms._vlm_chunk_idx = 0
+
+        input_ids = torch.tensor([[1, 151656, 2, 3]])
+
+        captured = {}
+
+        def capture(**kw):
+            captured["pixel_values_videos"] = kw.get("pixel_values_videos")
+            captured["video_grid_thw"] = kw.get("video_grid_thw")
+            captured["pixel_values"] = kw.get("pixel_values")
+            out = MagicMock()
+            out.last_hidden_state = torch.randn(1, 4, 8)
+            return out
+
+        ms.model.side_effect = lambda **kw: capture(**kw)
+
+        Qwen3VLMoeForConditionalGeneration.forward(ms, input_ids=input_ids)
+
+        assert ms._vlm_chunk_idx == 1
+        assert captured["pixel_values_videos"] is video_chunk
+        assert captured["video_grid_thw"] is video_grid_chunk
+        assert captured["pixel_values"] is None  # image stream untouched
 
     def test_chunked_pixel_values_skipped_without_media_tokens(self):
         ms = self._mock_self()

--- a/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
+++ b/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
@@ -1473,6 +1473,59 @@ class TestForwardBackwardStepPP:
         # Verify loss was computed
         assert len(loss_buffer) == 1
 
+    def test_pp_vlm_chunking_videos_uses_video_grid_and_counts(self, pp_recipe, monkeypatch):
+        """Video tensors are chunked by per-sample video counts before schedule.step."""
+        pp_recipe.pp = _MockAutoPipeline(has_first_stage=True, has_last_stage=True, n_microbatches=2)
+
+        monkeypatch.setattr(
+            "nemo_automodel.recipes.vlm.finetune.make_cp_batch_and_ctx",
+            lambda device_mesh, batch: (lambda: nullcontext(), batch),
+        )
+
+        batch_size = 4
+        video_grid_thw = torch.tensor([[1, 2, 2], [1, 3, 3], [1, 2, 3], [1, 4, 4]])
+        pixel_values_videos = torch.randn(int(video_grid_thw.prod(dim=1).sum().item()), 64)
+        n_videos_per_sample = torch.tensor([1, 0, 2, 1])
+
+        def step_side_effect(*args, **kwargs):
+            model = pp_recipe.model_parts[0]
+            assert "pixel_values_videos" not in kwargs
+            assert "video_grid_thw" not in kwargs
+            assert len(model._vlm_pixel_values_videos_chunks) == 2
+            assert len(model._vlm_video_grid_thw_chunks) == 2
+            assert model._vlm_video_grid_thw_chunks[0].shape[0] == 1
+            assert model._vlm_video_grid_thw_chunks[1].shape[0] == 3
+            assert model._vlm_pixel_values_videos_chunks[0].shape[0] == 4
+            assert model._vlm_pixel_values_videos_chunks[1].shape[0] == 9 + 6 + 16
+            for _ in range(2):
+                kwargs["losses"].append(torch.tensor(0.5))
+
+        pp_recipe.pp.info.schedule.step.side_effect = step_side_effect
+
+        batch = {
+            "labels": torch.randint(0, 100, (batch_size, 10)),
+            "input_ids": torch.randint(0, 100, (batch_size, 10)),
+            "pixel_values_videos": pixel_values_videos,
+            "video_grid_thw": video_grid_thw,
+            "n_videos_per_sample": n_videos_per_sample,
+        }
+        loss_buffer = []
+
+        pp_recipe._forward_backward_step(
+            idx=0,
+            batch=batch,
+            loss_buffer=loss_buffer,
+            num_label_tokens=40,
+            num_batches=1,
+            is_train=True,
+        )
+
+        model = pp_recipe.model_parts[0]
+        assert model._vlm_pixel_values_videos_chunks is None
+        assert model._vlm_video_grid_thw_chunks is None
+        assert model._vlm_chunk_idx is None
+        assert len(loss_buffer) == 1
+
     def test_pp_vlm_chunking_with_image_grid_thw(self, pp_recipe, monkeypatch):
         """Test VLM pixel_values chunking with image_grid_thw (3D grid) instead of image_grid_hws."""
         pp_recipe.pp = _MockAutoPipeline(has_first_stage=True, has_last_stage=True, n_microbatches=2)
@@ -2427,6 +2480,28 @@ class TestChunkVlmMedia:
             _chunk_vlm_media(
                 pixel_values, image_grid, batch_size=2, n_microbatches=2,
             )
+
+    def test_n_videos_per_sample_packed(self):
+        """The media chunk helper also handles video grids/counts."""
+        from nemo_automodel.recipes.vlm.finetune import _chunk_vlm_media
+
+        video_grid = torch.tensor([[1, 2, 2], [1, 3, 3], [1, 2, 3], [1, 4, 4]])
+        pixel_values_videos = torch.randn(int(video_grid.prod(dim=1).sum().item()), 64)
+        n_videos_per_sample = torch.tensor([1, 0, 2, 1])
+
+        pv_chunks, vg_chunks = _chunk_vlm_media(
+            pixel_values_videos,
+            video_grid,
+            batch_size=4,
+            n_microbatches=2,
+            n_images_per_sample=n_videos_per_sample,
+        )
+
+        assert len(pv_chunks) == 2
+        assert vg_chunks[0].shape[0] == 1
+        assert vg_chunks[1].shape[0] == 3
+        assert pv_chunks[0].shape[0] == 4
+        assert pv_chunks[1].shape[0] == 9 + 6 + 16
 
 
 # -----------------------------------------------------------------------------

--- a/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
+++ b/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
@@ -32,6 +32,8 @@ from nemo_automodel.recipes.vlm.finetune import (
 class _Cfg(SimpleNamespace):
     def get(self, key, default=None):
         return getattr(self, key, default)
+
+
 def test_get_model_name_prefers_pretrained_path():
     cfg = _Cfg(pretrained_model_name_or_path="org/model")
     assert _get_model_name(cfg) == "org/model"
@@ -42,11 +44,9 @@ def test_get_model_name_prefers_pretrained_path():
     assert _get_model_name(_Cfg()) is None
 
 
-
-
-
 def _count_trainable(parameters):
     return sum(p.numel() for p in parameters if getattr(p, "requires_grad", False))
+
 
 @pytest.fixture(autouse=True)
 def _mock_missing_cuda(monkeypatch):
@@ -86,6 +86,7 @@ class DummyOptConfig:
     def __init__(self, lr: float = 0.01):
         self.lr = lr
         self.foreach = None
+
     def instantiate(self, params):
         # Always return an SGD optimizer for the given params
         return torch.optim.SGD(params, lr=self.lr)
@@ -93,11 +94,13 @@ class DummyOptConfig:
     def get(self, key, default):
         return getattr(self, key, default)
 
+
 class DummyModelConfig:
     """Mimics the Hydra/OmegaConf model config with an *instantiate* method."""
 
     def __init__(self):
         from nemo_automodel._transformers import NeMoAutoModelForImageTextToText
+
         # Add _target_ to make the config valid for VLM finetuning
         self._target_ = NeMoAutoModelForImageTextToText.from_pretrained
 
@@ -112,12 +115,13 @@ class DummyModelConfig:
 # build_model / build_optimizer
 # -----------------------------------------------------------------------------
 
+
 def test_build_model_and_optimizer_basic():
     """Test basic build_model and build_optimizer for VLM."""
     cfg_model = DummyModelConfig()
     cfg_opt = DummyOptConfig(lr=0.01)
 
-    with patch('nemo_automodel.recipes.vlm.finetune._supports_logits_to_keep', return_value=True):
+    with patch("nemo_automodel.recipes.vlm.finetune._supports_logits_to_keep", return_value=True):
         model = build_model(
             cfg_model=cfg_model,
             cfg_freeze=None,
@@ -156,7 +160,7 @@ def test_build_model_passes_freeze_config():
         def to_dict(self):
             return {"freeze_language_model": False, "freeze_vision_tower": True}
 
-    with patch('nemo_automodel.recipes.vlm.finetune._supports_logits_to_keep', return_value=True):
+    with patch("nemo_automodel.recipes.vlm.finetune._supports_logits_to_keep", return_value=True):
         model = build_model(
             cfg_model=cfg_model,
             cfg_freeze=FreezeConfig(),
@@ -190,7 +194,7 @@ def test_build_model_passes_moe_config_from_parallelizer_config():
     cfg_model = CapturingModelConfig()
     moe_cfg = MoEParallelizerConfig()
 
-    with patch('nemo_automodel.recipes.vlm.finetune._supports_logits_to_keep', return_value=True):
+    with patch("nemo_automodel.recipes.vlm.finetune._supports_logits_to_keep", return_value=True):
         build_model(
             cfg_model=cfg_model,
             cfg_freeze=None,
@@ -232,7 +236,7 @@ def test_build_model_passes_moe_config_from_dict_like():
 
     cfg_model = CapturingModelConfig()
 
-    with patch('nemo_automodel.recipes.vlm.finetune._supports_logits_to_keep', return_value=True):
+    with patch("nemo_automodel.recipes.vlm.finetune._supports_logits_to_keep", return_value=True):
         build_model(
             cfg_model=cfg_model,
             cfg_freeze=None,
@@ -266,7 +270,7 @@ def test_build_model_no_moe_config_when_cfg_moe_is_none():
 
     cfg_model = CapturingModelConfig()
 
-    with patch('nemo_automodel.recipes.vlm.finetune._supports_logits_to_keep', return_value=True):
+    with patch("nemo_automodel.recipes.vlm.finetune._supports_logits_to_keep", return_value=True):
         build_model(
             cfg_model=cfg_model,
             cfg_freeze=None,
@@ -475,10 +479,11 @@ def test_run_train_step_pp_nonzero_label_tokens_divides(monkeypatch):
 # AutoProcessor exception handling test
 # -----------------------------------------------------------------------------
 
+
 def test_autoprocessor_success():
     """Test successful AutoProcessor creation."""
 
-    with patch('transformers.AutoProcessor') as mock_auto_processor:
+    with patch("transformers.AutoProcessor") as mock_auto_processor:
         mock_processor = MagicMock()
         mock_auto_processor.from_pretrained.return_value = mock_processor
 
@@ -496,11 +501,12 @@ def test_autoprocessor_exception_handling(caplog):
 
     from nemo_automodel.recipes.vlm.finetune import build_dataloader
 
-    with patch('transformers.AutoProcessor.from_pretrained') as mock_from_pretrained, \
-         patch('nemo_automodel.components.training.rng.StatefulRNG'), \
-         patch('torch.utils.data.distributed.DistributedSampler'), \
-         patch('nemo_automodel.components.datasets.vlm.collate_fns.COLLATE_FNS', {'NoneType': MagicMock()}):
-
+    with (
+        patch("transformers.AutoProcessor.from_pretrained") as mock_from_pretrained,
+        patch("nemo_automodel.components.training.rng.StatefulRNG"),
+        patch("torch.utils.data.distributed.DistributedSampler"),
+        patch("nemo_automodel.components.datasets.vlm.collate_fns.COLLATE_FNS", {"NoneType": MagicMock()}),
+    ):
         # Set up the exception
         mock_from_pretrained.side_effect = Exception("Model does not have AutoProcessor")
 
@@ -509,8 +515,11 @@ def test_autoprocessor_exception_handling(caplog):
         cfg_ds.instantiate.return_value = []
         cfg_ds.path_or_dataset = "test/dataset"
         cfg_ds.get.side_effect = lambda key, default=None: {
-            "pretokenize": False, "packing": None, "max_length": None,
-            "chat_template": None, "preload_media": False,
+            "pretokenize": False,
+            "packing": None,
+            "max_length": None,
+            "chat_template": None,
+            "preload_media": False,
         }.get(key, default)
 
         cfg_dl = MagicMock()
@@ -544,19 +553,24 @@ def test_autoprocessor_retries_on_layer_types_mismatch():
             raise StrictDataclassClassValidationError(validator="validate_layer_type", cause=cause)
         return stub_processor
 
-    with patch('transformers.AutoProcessor.from_pretrained', side_effect=fake_from_pretrained), \
-         patch('nemo_automodel._transformers.v4_patches.layer_types.relax_layer_types_validator',
-               return_value=True) as mock_relax, \
-         patch('nemo_automodel.components.training.rng.StatefulRNG'), \
-         patch('torch.utils.data.distributed.DistributedSampler'), \
-         patch('nemo_automodel.components.datasets.vlm.collate_fns.COLLATE_FNS', {'MagicMock': MagicMock()}):
-
+    with (
+        patch("transformers.AutoProcessor.from_pretrained", side_effect=fake_from_pretrained),
+        patch(
+            "nemo_automodel._transformers.v4_patches.layer_types.relax_layer_types_validator", return_value=True
+        ) as mock_relax,
+        patch("nemo_automodel.components.training.rng.StatefulRNG"),
+        patch("torch.utils.data.distributed.DistributedSampler"),
+        patch("nemo_automodel.components.datasets.vlm.collate_fns.COLLATE_FNS", {"MagicMock": MagicMock()}),
+    ):
         cfg_ds = MagicMock()
         cfg_ds.instantiate.return_value = []
         cfg_ds.path_or_dataset = "test/dataset"
         cfg_ds.get.side_effect = lambda key, default=None: {
-            "pretokenize": False, "packing": None, "max_length": None,
-            "chat_template": None, "preload_media": False,
+            "pretokenize": False,
+            "packing": None,
+            "max_length": None,
+            "chat_template": None,
+            "preload_media": False,
         }.get(key, default)
 
         cfg_dl = MagicMock()
@@ -590,12 +604,13 @@ def test_autoprocessor_loads_inside_first_rank_per_node():
         call_order.append("autoprocessor")
         return MagicMock()
 
-    with patch('nemo_automodel.recipes.vlm.finetune.FirstRankPerNode', TrackingFirstRankPerNode), \
-         patch('transformers.AutoProcessor.from_pretrained', side_effect=tracking_from_pretrained), \
-         patch('nemo_automodel.components.training.rng.StatefulRNG'), \
-         patch('torch.utils.data.distributed.DistributedSampler'), \
-         patch('nemo_automodel.components.datasets.vlm.collate_fns.COLLATE_FNS', {'NoneType': MagicMock()}):
-
+    with (
+        patch("nemo_automodel.recipes.vlm.finetune.FirstRankPerNode", TrackingFirstRankPerNode),
+        patch("transformers.AutoProcessor.from_pretrained", side_effect=tracking_from_pretrained),
+        patch("nemo_automodel.components.training.rng.StatefulRNG"),
+        patch("torch.utils.data.distributed.DistributedSampler"),
+        patch("nemo_automodel.components.datasets.vlm.collate_fns.COLLATE_FNS", {"NoneType": MagicMock()}),
+    ):
         cfg_ds = MagicMock()
         cfg_ds.instantiate.return_value = []
         cfg_ds.path_or_dataset = "test/dataset"
@@ -628,11 +643,12 @@ def test_autoprocessor_with_processor_kwargs(caplog):
         def to_dict(self):
             return {"trust_remote_code": True, "some_param": "value"}
 
-    with patch('transformers.AutoProcessor.from_pretrained') as mock_from_pretrained, \
-         patch('nemo_automodel.components.training.rng.StatefulRNG'), \
-         patch('torch.utils.data.distributed.DistributedSampler'), \
-         patch('nemo_automodel.components.datasets.vlm.collate_fns.COLLATE_FNS', {'NoneType': MagicMock()}):
-
+    with (
+        patch("transformers.AutoProcessor.from_pretrained") as mock_from_pretrained,
+        patch("nemo_automodel.components.training.rng.StatefulRNG"),
+        patch("torch.utils.data.distributed.DistributedSampler"),
+        patch("nemo_automodel.components.datasets.vlm.collate_fns.COLLATE_FNS", {"NoneType": MagicMock()}),
+    ):
         # Set up the exception
         mock_from_pretrained.side_effect = Exception("Model does not have AutoProcessor")
 
@@ -641,8 +657,11 @@ def test_autoprocessor_with_processor_kwargs(caplog):
         cfg_ds.instantiate.return_value = []
         cfg_ds.path_or_dataset = "test/dataset"
         cfg_ds.get.side_effect = lambda key, default=None: {
-            "pretokenize": False, "packing": None, "max_length": None,
-            "chat_template": None, "preload_media": False,
+            "pretokenize": False,
+            "packing": None,
+            "max_length": None,
+            "chat_template": None,
+            "preload_media": False,
         }.get(key, default)
 
         cfg_dl = MagicMock()
@@ -687,9 +706,11 @@ def test_build_dataloader_chat_template_applied():
     cfg_dl.get.return_value = None
     cfg_dl.instantiate.return_value = MagicMock()
 
-    with patch("transformers.AutoProcessor.from_pretrained", return_value=processor), \
-         patch("torch.utils.data.distributed.DistributedSampler"), \
-         patch("nemo_automodel.components.datasets.vlm.collate_fns.COLLATE_FNS", {"default": MagicMock()}):
+    with (
+        patch("transformers.AutoProcessor.from_pretrained", return_value=processor),
+        patch("torch.utils.data.distributed.DistributedSampler"),
+        patch("nemo_automodel.components.datasets.vlm.collate_fns.COLLATE_FNS", {"default": MagicMock()}),
+    ):
         _, built_processor = build_dataloader(cfg_ds, cfg_dl, "model", None, None, 42, 1)
 
     assert built_processor.chat_template == "{{ custom }}"
@@ -715,9 +736,11 @@ def test_build_dataloader_no_chat_template():
     cfg_dl.get.return_value = None
     cfg_dl.instantiate.return_value = MagicMock()
 
-    with patch("transformers.AutoProcessor.from_pretrained", return_value=processor), \
-         patch("torch.utils.data.distributed.DistributedSampler"), \
-         patch("nemo_automodel.components.datasets.vlm.collate_fns.COLLATE_FNS", {"default": MagicMock()}):
+    with (
+        patch("transformers.AutoProcessor.from_pretrained", return_value=processor),
+        patch("torch.utils.data.distributed.DistributedSampler"),
+        patch("nemo_automodel.components.datasets.vlm.collate_fns.COLLATE_FNS", {"default": MagicMock()}),
+    ):
         _, built_processor = build_dataloader(cfg_ds, cfg_dl, "model", None, None, 42, 1)
 
     assert built_processor.chat_template == "{{ original }}"
@@ -755,6 +778,7 @@ class DummyModelConfigWithAdapter:
 
     def __init__(self):
         from nemo_automodel._transformers import NeMoAutoModelForImageTextToText
+
         # Add _target_ to make the config valid for VLM finetuning
         self._target_ = NeMoAutoModelForImageTextToText.from_pretrained
 
@@ -785,7 +809,7 @@ def test_vlm_build_model_with_adapter():
 
     cfg_model = NeMoModelConfigWithAdapter()
 
-    with patch('nemo_automodel.recipes.vlm.finetune._supports_logits_to_keep', return_value=True):
+    with patch("nemo_automodel.recipes.vlm.finetune._supports_logits_to_keep", return_value=True):
         model = build_model(
             cfg_model=cfg_model,
             cfg_freeze=None,
@@ -816,7 +840,7 @@ def test_vlm_build_model_without_adapter():
 
     cfg_model = NeMoModelConfigNoAdapter()
 
-    with patch('nemo_automodel.recipes.vlm.finetune._supports_logits_to_keep', return_value=True):
+    with patch("nemo_automodel.recipes.vlm.finetune._supports_logits_to_keep", return_value=True):
         model = build_model(
             cfg_model=cfg_model,
             cfg_freeze=None,
@@ -849,7 +873,7 @@ def test_vlm_build_model_with_quantization_config():
 
     cfg_model = DummyQuantizedVLMModelConfig()
 
-    with patch('nemo_automodel.recipes.vlm.finetune._supports_logits_to_keep', return_value=True):
+    with patch("nemo_automodel.recipes.vlm.finetune._supports_logits_to_keep", return_value=True):
         model = build_model(
             cfg_model=cfg_model,
             cfg_freeze=None,
@@ -879,7 +903,7 @@ def test_vlm_build_model_without_quantization_config():
 
     cfg_model = DummyNoQuantVLMModelConfig()
 
-    with patch('nemo_automodel.recipes.vlm.finetune._supports_logits_to_keep', return_value=True):
+    with patch("nemo_automodel.recipes.vlm.finetune._supports_logits_to_keep", return_value=True):
         model = build_model(
             cfg_model=cfg_model,
             cfg_freeze=None,
@@ -922,8 +946,6 @@ def test_vlm_build_model_raises_value_error_for_non_nemo_auto_model():
         )
 
 
-
-
 def test_vlm_build_optimizer_disables_foreach_with_tp():
     """Test that when device_mesh has tp > 1, cfg_opt.foreach is set to False in VLM."""
     from nemo_automodel._transformers import NeMoAutoModelForImageTextToText
@@ -949,7 +971,7 @@ def test_vlm_build_optimizer_disables_foreach_with_tp():
     mock_device_mesh.mesh_dim_names = ("dp", "tp")
     mock_device_mesh.__getitem__ = lambda self, key: mock_tp_submesh if key == "tp" else MagicMock()
 
-    with patch('nemo_automodel.recipes.vlm.finetune._supports_logits_to_keep', return_value=True):
+    with patch("nemo_automodel.recipes.vlm.finetune._supports_logits_to_keep", return_value=True):
         model = build_model(
             cfg_model=cfg_model,
             cfg_freeze=None,
@@ -2255,7 +2277,7 @@ def test_build_optimizer_disables_foreach_with_tp():
     mock_device_mesh.mesh_dim_names = ("dp", "tp")
     mock_device_mesh.__getitem__ = lambda self, key: mock_tp_submesh if key == "tp" else MagicMock()
 
-    with patch('nemo_automodel.recipes.vlm.finetune._supports_logits_to_keep', return_value=True):
+    with patch("nemo_automodel.recipes.vlm.finetune._supports_logits_to_keep", return_value=True):
         model = build_model(
             cfg_model=cfg_model,
             cfg_freeze=None,
@@ -2289,7 +2311,7 @@ def test_vlm_build_model_and_optimizer_return_values():
     cfg_model = NeMoVLMModelConfig()
     cfg_opt = DummyOptConfig(lr=0.01)
 
-    with patch('nemo_automodel.recipes.vlm.finetune._supports_logits_to_keep', return_value=True):
+    with patch("nemo_automodel.recipes.vlm.finetune._supports_logits_to_keep", return_value=True):
         model = build_model(
             cfg_model=cfg_model,
             cfg_freeze=None,
@@ -2321,7 +2343,7 @@ def test_vlm_build_model_validates_nemo_auto_model_entry_points(entry_point):
 
     cfg_model = NeMoVLMModelConfig()
 
-    with patch('nemo_automodel.recipes.vlm.finetune._supports_logits_to_keep', return_value=True):
+    with patch("nemo_automodel.recipes.vlm.finetune._supports_logits_to_keep", return_value=True):
         # Should not raise - entry point should be recognized
         model = build_model(
             cfg_model=cfg_model,
@@ -2352,7 +2374,7 @@ def test_vlm_build_model_accepts_multimodal_lm_entry_points(entry_point):
 
     cfg_model = NeMoVLMModelConfig()
 
-    with patch('nemo_automodel.recipes.vlm.finetune._supports_logits_to_keep', return_value=True):
+    with patch("nemo_automodel.recipes.vlm.finetune._supports_logits_to_keep", return_value=True):
         model = build_model(
             cfg_model=cfg_model,
             cfg_freeze=None,
@@ -2440,8 +2462,12 @@ def _patch_vlm_setup_minimals(monkeypatch, cp_size):
         lambda *a, **k: None,
     )
     monkeypatch.setattr("nemo_automodel.recipes.vlm.finetune.torch.cuda.reset_peak_memory_stats", lambda: None)
-    monkeypatch.setattr("nemo_automodel.recipes.vlm.finetune.FinetuneRecipeForVLM._get_dp_rank", lambda self, include_cp=False: 0)
-    monkeypatch.setattr("nemo_automodel.recipes.vlm.finetune.FinetuneRecipeForVLM._get_dp_group_size", lambda self, include_cp=False: 1)
+    monkeypatch.setattr(
+        "nemo_automodel.recipes.vlm.finetune.FinetuneRecipeForVLM._get_dp_rank", lambda self, include_cp=False: 0
+    )
+    monkeypatch.setattr(
+        "nemo_automodel.recipes.vlm.finetune.FinetuneRecipeForVLM._get_dp_group_size", lambda self, include_cp=False: 1
+    )
     monkeypatch.setattr("nemo_automodel.recipes.vlm.finetune.FinetuneRecipeForVLM._get_cp_group_size", lambda self: 1)
     monkeypatch.setattr("nemo_automodel.recipes.vlm.finetune.FinetuneRecipeForVLM._get_tp_rank", lambda self: 0)
     monkeypatch.setattr("nemo_automodel.recipes.vlm.finetune.FinetuneRecipeForVLM._get_pp_rank", lambda self: 0)
@@ -2525,14 +2551,17 @@ class TestChunkVlmMedia:
         n_images_per_sample = torch.tensor([3, 1])
 
         pv_chunks, ig_chunks = _chunk_vlm_media(
-            pixel_values, image_grid, batch_size=2, n_microbatches=2,
+            pixel_values,
+            image_grid,
+            batch_size=2,
+            n_microbatches=2,
             n_images_per_sample=n_images_per_sample,
         )
         assert len(pv_chunks) == 2
         assert ig_chunks[0].shape[0] == 3  # first batch item: 3 images
         assert ig_chunks[1].shape[0] == 1  # second batch item: 1 image
         assert pv_chunks[0].shape[0] == 12  # 3 images * 4 patches
-        assert pv_chunks[1].shape[0] == 4   # 1 image * 4 patches
+        assert pv_chunks[1].shape[0] == 4  # 1 image * 4 patches
 
     def test_legacy_one_image_per_sample(self):
         from nemo_automodel.recipes.vlm.finetune import _chunk_vlm_media
@@ -2543,7 +2572,10 @@ class TestChunkVlmMedia:
         pixel_values = torch.randn(int(patch_counts.sum()), 64)
 
         pv_chunks, ig_chunks = _chunk_vlm_media(
-            pixel_values, image_grid, batch_size=4, n_microbatches=2,
+            pixel_values,
+            image_grid,
+            batch_size=4,
+            n_microbatches=2,
         )
         assert len(pv_chunks) == 2
         assert ig_chunks[0].shape[0] == 2
@@ -2562,7 +2594,10 @@ class TestChunkVlmMedia:
 
         with pytest.raises(ValueError, match="VLM PP chunking cannot align"):
             _chunk_vlm_media(
-                pixel_values, image_grid, batch_size=2, n_microbatches=2,
+                pixel_values,
+                image_grid,
+                batch_size=2,
+                n_microbatches=2,
             )
 
     def test_n_videos_per_sample_packed(self):

--- a/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
+++ b/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
@@ -2714,8 +2714,7 @@ def test_build_dataloader_forwards_get_rope_index_to_packing():
         )
 
     assert captured.get("get_rope_index") is sentinel, (
-        "build_dataloader must forward get_rope_index to neat_pack_dataset_vlm; "
-        f"got kwargs={list(captured.keys())}"
+        f"build_dataloader must forward get_rope_index to neat_pack_dataset_vlm; got kwargs={list(captured.keys())}"
     )
 
 
@@ -2747,7 +2746,5 @@ def test_build_dataloader_default_get_rope_index_is_none():
             cfg_ps=_make_packing_cfg(pack_size=64),
         )
 
-    assert "get_rope_index" in captured, (
-        "neat_pack_dataset_vlm must receive get_rope_index kwarg even when None"
-    )
+    assert "get_rope_index" in captured, "neat_pack_dataset_vlm must receive get_rope_index kwarg even when None"
     assert captured["get_rope_index"] is None

--- a/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
+++ b/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
@@ -1526,6 +1526,90 @@ class TestForwardBackwardStepPP:
         assert model._vlm_chunk_idx is None
         assert len(loss_buffer) == 1
 
+    def test_pp_vlm_chunking_image_and_video_mixed(self, pp_recipe, monkeypatch):
+        """When a batch carries both images and videos, both streams chunk independently
+        but share a single _vlm_chunk_idx initialized once at 0; both clean up to None."""
+        pp_recipe.pp = _MockAutoPipeline(has_first_stage=True, has_last_stage=True, n_microbatches=2)
+
+        monkeypatch.setattr(
+            "nemo_automodel.recipes.vlm.finetune.make_cp_batch_and_ctx",
+            lambda device_mesh, batch: (lambda: nullcontext(), batch),
+        )
+
+        batch_size = 4
+
+        # n_images_per_sample=[2,0,1,0]: mb0 (samples 0..1) covers images 0..1; mb1 covers image 2.
+        image_grid_thw = torch.tensor([[1, 2, 2], [1, 3, 3], [1, 2, 3]])  # patch counts: 4, 9, 6
+        pixel_values = torch.randn(int(image_grid_thw.prod(dim=1).sum().item()), 32)
+        n_images_per_sample = torch.tensor([2, 0, 1, 0])
+
+        # n_videos_per_sample=[1,0,2,1]: mb0 covers video 0; mb1 covers videos 1..3.
+        video_grid_thw = torch.tensor([[1, 2, 2], [1, 3, 3], [1, 2, 3], [1, 4, 4]])  # patch counts: 4, 9, 6, 16
+        pixel_values_videos = torch.randn(int(video_grid_thw.prod(dim=1).sum().item()), 64)
+        n_videos_per_sample = torch.tensor([1, 0, 2, 1])
+
+        def step_side_effect(*args, **kwargs):
+            model = pp_recipe.model_parts[0]
+
+            # Both modalities are popped before schedule.step so the schedule never
+            # tries to chunk the misaligned multimodal tensors along dim 0.
+            assert "pixel_values" not in kwargs
+            assert "image_grid_hws" not in kwargs
+            assert "image_grid_thw" not in kwargs
+            assert "pixel_values_videos" not in kwargs
+            assert "video_grid_thw" not in kwargs
+
+            assert len(model._vlm_pixel_values_chunks) == 2
+            assert len(model._vlm_image_grid_hws_chunks) == 2
+            assert model._vlm_image_grid_hws_chunks[0].shape[0] == 2
+            assert model._vlm_image_grid_hws_chunks[1].shape[0] == 1
+            assert model._vlm_pixel_values_chunks[0].shape[0] == 4 + 9
+            assert model._vlm_pixel_values_chunks[1].shape[0] == 6
+
+            assert len(model._vlm_pixel_values_videos_chunks) == 2
+            assert len(model._vlm_video_grid_thw_chunks) == 2
+            assert model._vlm_video_grid_thw_chunks[0].shape[0] == 1
+            assert model._vlm_video_grid_thw_chunks[1].shape[0] == 3
+            assert model._vlm_pixel_values_videos_chunks[0].shape[0] == 4
+            assert model._vlm_pixel_values_videos_chunks[1].shape[0] == 9 + 6 + 16
+
+            # Single shared cursor: image-branch sets it to 0 first, video branch resets to 0 again.
+            assert model._vlm_chunk_idx == 0
+
+            for _ in range(2):
+                kwargs["losses"].append(torch.tensor(0.5))
+
+        pp_recipe.pp.info.schedule.step.side_effect = step_side_effect
+
+        batch = {
+            "labels": torch.randint(0, 100, (batch_size, 10)),
+            "input_ids": torch.randint(0, 100, (batch_size, 10)),
+            "pixel_values": pixel_values,
+            "image_grid_thw": image_grid_thw,
+            "n_images_per_sample": n_images_per_sample,
+            "pixel_values_videos": pixel_values_videos,
+            "video_grid_thw": video_grid_thw,
+            "n_videos_per_sample": n_videos_per_sample,
+        }
+        loss_buffer = []
+
+        pp_recipe._forward_backward_step(
+            idx=0,
+            batch=batch,
+            loss_buffer=loss_buffer,
+            num_label_tokens=40,
+            num_batches=1,
+            is_train=True,
+        )
+
+        model = pp_recipe.model_parts[0]
+        assert model._vlm_pixel_values_chunks is None
+        assert model._vlm_image_grid_hws_chunks is None
+        assert model._vlm_pixel_values_videos_chunks is None
+        assert model._vlm_video_grid_thw_chunks is None
+        assert model._vlm_chunk_idx is None
+        assert len(loss_buffer) == 1
+
     def test_pp_vlm_chunking_with_image_grid_thw(self, pp_recipe, monkeypatch):
         """Test VLM pixel_values chunking with image_grid_thw (3D grid) instead of image_grid_hws."""
         pp_recipe.pp = _MockAutoPipeline(has_first_stage=True, has_last_stage=True, n_microbatches=2)


### PR DESCRIPTION
## Summary

VLM pipeline parallelism previously only chunked image tensors per microbatch; video tensors (`pixel_values_videos`, `video_grid_thw`, `n_videos_per_sample`) were left in the batch and got sliced along dim 0 by `schedule.step`, which is wrong because their dim 0 is total-patches / video-count, not batch-size. Result: VLM + PP + video either crashes on shape mismatch or silently miscorrelates patches with text tokens.

This PR mirrors the existing image chunking path for video.

## Changelog

- **fix(vlm)**: pop `pixel_values_videos` / `video_grid_thw` / `n_videos_per_sample` in `_forward_backward_step` (PP branch) and pre-chunk them onto stage 0 via `_chunk_vlm_media`, then consume per-microbatch inside `forward()` of `qwen3_5_moe`, `qwen3_omni_moe`, `qwen3_vl_moe`. A shared `_vlm_chunk_idx` is incremented once per call via a `consumed_vlm_chunk` flag so image+video coexisting on stage 0 advance the cursor correctly.
- **test(vlm)**: add unit coverage for video-only chunking (`_chunk_vlm_media` + end-to-end `_forward_backward_step`) and image+video mixed chunking, asserting popped kwargs, per-microbatch shapes, single shared cursor at 0, and post-step cleanup.
- **style(vlm)**: run `ruff format` on `tests/unit_tests/recipes/test_finetune_vlm_helpers.py` to clean up pre-existing whitespace/quote drift. No behavioral changes.

## Test plan

- [x] `uv run pytest tests/unit_tests/recipes/test_finetune_vlm_helpers.py` — 68 passed, 3 skipped (skips are pre-existing `fused_linear_ce` GPU cases)
- [x] `uv run ruff format --check` on the touched files — clean
- [ ] PP=2 functional run on a Qwen3-VL-MoE recipe with video data (requires multi-GPU host)