### PR TITLE
fix(vlm): ceil-divide PP chunker so trailing samples are not dropped

### DIFF
--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -282,7 +282,11 @@ def _chunk_vlm_media(
         # Gemma4 multi-image: pixel_values is [N_total_images, max_patches, patch_dim].
         # All images are padded to the same max_patches, so split by image count directly.
         cumsum_images = torch.cumsum(n_images_per_sample, dim=0)
-        samples_per_mb = batch_size // n_microbatches
+        # Ceil division so trailing samples are not dropped when batch_size is not
+        # divisible by n_microbatches.  Mirrors torch.tensor.chunk(n) semantics used
+        # by the PP schedule on input_ids/labels — keeps image chunks aligned with
+        # text chunks even on uneven splits.
+        samples_per_mb = -(-batch_size // n_microbatches)
         for mb_idx in range(n_microbatches):
             s_start = mb_idx * samples_per_mb
             s_end = min(s_start + samples_per_mb, batch_size)
@@ -297,7 +301,7 @@ def _chunk_vlm_media(
         cumsum_patches = torch.cumsum(patch_counts, dim=0)
         cumsum_images = torch.cumsum(n_images_per_sample, dim=0)
 
-        samples_per_mb = batch_size // n_microbatches
+        samples_per_mb = -(-batch_size // n_microbatches)
         for mb_idx in range(n_microbatches):
             s_start = mb_idx * samples_per_mb
             s_end = min(s_start + samples_per_mb, batch_size)
@@ -315,7 +319,7 @@ def _chunk_vlm_media(
         patch_counts = image_grid.prod(dim=1)
         cumsum = torch.cumsum(patch_counts, dim=0)
 
-        images_per_mb = batch_size // n_microbatches
+        images_per_mb = -(-batch_size // n_microbatches)
         for mb_idx in range(n_microbatches):
             img_start = mb_idx * images_per_mb
             img_end = min(img_start + images_per_mb, n_images)

--- a/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
+++ b/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
@@ -2433,6 +2433,77 @@ class TestChunkVlmMedia:
         assert pv_chunks[0].shape[0] == 12  # all in first
         assert pv_chunks[1].shape[0] == 0   # empty
 
+    def test_uneven_batch_size_general_branch_covers_all_samples(self):
+        """batch_size not divisible by n_microbatches must not drop trailing samples.
+
+        torch.tensor.chunk(n) used by schedule.step on input_ids returns ceil-sized
+        chunks. _chunk_vlm_media must mirror that or the last sample's images are
+        silently lost while its text still flows through the schedule.
+        """
+        from nemo_automodel.recipes.vlm.finetune import _chunk_vlm_media
+
+        # 7 samples across 3 microbatches: ceil(7/3)=3, expect splits [3, 3, 1].
+        batch_size, n_microbatches = 7, 3
+        image_grid = torch.tensor([[1, 2, 2]] * batch_size)  # 4 patches/image
+        pixel_values = torch.randn(int(image_grid.prod(dim=1).sum().item()), 64)
+        n_images_per_sample = torch.tensor([1] * batch_size)
+
+        pv_chunks, ig_chunks = _chunk_vlm_media(
+            pixel_values,
+            image_grid,
+            batch_size=batch_size,
+            n_microbatches=n_microbatches,
+            n_images_per_sample=n_images_per_sample,
+        )
+
+        assert len(ig_chunks) == n_microbatches
+        assert [c.shape[0] for c in ig_chunks] == [3, 3, 1]
+        assert sum(c.shape[0] for c in ig_chunks) == batch_size  # no sample dropped
+        assert sum(c.shape[0] for c in pv_chunks) == pixel_values.shape[0]
+
+    def test_uneven_batch_size_legacy_branch_covers_all_images(self):
+        """Legacy 1-image-per-sample branch must also use ceil division."""
+        from nemo_automodel.recipes.vlm.finetune import _chunk_vlm_media
+
+        # 5 images across 3 microbatches: ceil(5/3)=2, expect splits [2, 2, 1].
+        batch_size, n_microbatches = 5, 3
+        image_grid = torch.tensor([[1, 2, 2]] * batch_size)
+        pixel_values = torch.randn(int(image_grid.prod(dim=1).sum().item()), 64)
+
+        pv_chunks, ig_chunks = _chunk_vlm_media(
+            pixel_values,
+            image_grid,
+            batch_size=batch_size,
+            n_microbatches=n_microbatches,
+        )
+
+        assert len(ig_chunks) == n_microbatches
+        assert [c.shape[0] for c in ig_chunks] == [2, 2, 1]
+        assert sum(c.shape[0] for c in ig_chunks) == batch_size
+
+    def test_uneven_batch_size_gemma4_branch_covers_all_samples(self):
+        """Gemma4 branch (3D pixel_values + n_images_per_sample) must also use ceil."""
+        from nemo_automodel.recipes.vlm.finetune import _chunk_vlm_media
+
+        # 7 samples, exactly 1 image each, padded patches per image (Gemma4-style).
+        batch_size, n_microbatches = 7, 3
+        max_patches = 4
+        image_grid = torch.tensor([[1, 2, 2]] * batch_size)
+        pixel_values = torch.randn(batch_size, max_patches, 64)  # 3D
+        n_images_per_sample = torch.tensor([1] * batch_size)
+
+        pv_chunks, ig_chunks = _chunk_vlm_media(
+            pixel_values,
+            image_grid,
+            batch_size=batch_size,
+            n_microbatches=n_microbatches,
+            n_images_per_sample=n_images_per_sample,
+        )
+
+        assert len(ig_chunks) == n_microbatches
+        assert [c.shape[0] for c in pv_chunks] == [3, 3, 1]
+        assert sum(c.shape[0] for c in pv_chunks) == batch_size
+
 
 # -----------------------------------------------------------------------------
 # get_rope_index forwarding tests for build_dataloader

--- a/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
+++ b/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
@@ -2481,16 +2481,18 @@ class TestChunkVlmMedia:
         assert [c.shape[0] for c in ig_chunks] == [2, 2, 1]
         assert sum(c.shape[0] for c in ig_chunks) == batch_size
 
-    def test_uneven_batch_size_gemma4_branch_covers_all_samples(self):
-        """Gemma4 branch (3D pixel_values + n_images_per_sample) must also use ceil."""
+    def test_uneven_batch_size_gemma4_multi_image_branch_covers_all_samples(self):
+        """Gemma4 multi-image branch (3D pixel_values + counts) must also use ceil."""
         from nemo_automodel.recipes.vlm.finetune import _chunk_vlm_media
 
-        # 7 samples, exactly 1 image each, padded patches per image (Gemma4-style).
+        # 7 samples across 3 microbatches: ceil(7/3)=3, expect sample splits [3, 3, 1].
+        # Image counts per split are [2 + 1 + 0, 3 + 1 + 2, 1] = [3, 6, 1].
         batch_size, n_microbatches = 7, 3
         max_patches = 4
-        image_grid = torch.tensor([[1, 2, 2]] * batch_size)
-        pixel_values = torch.randn(batch_size, max_patches, 64)  # 3D
-        n_images_per_sample = torch.tensor([1] * batch_size)
+        n_images_per_sample = torch.tensor([2, 1, 0, 3, 1, 2, 1])
+        n_images = int(n_images_per_sample.sum().item())
+        image_grid = torch.tensor([[1, 2, 2]] * n_images)
+        pixel_values = torch.randn(n_images, max_patches, 64)  # 3D, one row per image.
 
         pv_chunks, ig_chunks = _chunk_vlm_media(
             pixel_values,
@@ -2501,8 +2503,9 @@ class TestChunkVlmMedia:
         )
 
         assert len(ig_chunks) == n_microbatches
-        assert [c.shape[0] for c in pv_chunks] == [3, 3, 1]
-        assert sum(c.shape[0] for c in pv_chunks) == batch_size
+        assert [c.shape[0] for c in ig_chunks] == [3, 6, 1]
+        assert [c.shape[0] for c in pv_chunks] == [3, 6, 1]
+        assert sum(c.shape[0] for c in pv_chunks) == n_images
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

\`_chunk_vlm_media\` partitioned samples per microbatch with \`batch_size // n_microbatches\`. When that division is uneven the trailing \`batch_size % n_microbatches\` samples never get assigned to a chunk — their image tensors are silently dropped. Meanwhile \`schedule.step\` slices \`input_ids\`/\`labels\` via \`torch.tensor.chunk(n_microbatches)\` which uses ceil-sized chunks and covers every sample, so the affected microbatches end up with media tokens in text but no pixel data, breaking vision scatter or producing wrong outputs.

This patch switches all three internal branches to ceil division so the chunker mirrors \`tensor.chunk\` semantics.

## Changelog

- **fix(vlm)**: replace \`batch_size // n_microbatches\` with \`-(-batch_size // n_microbatches)\` (ceil) in \`_chunk_vlm_media\`'s Gemma4 multi-image, general flat-patches, and legacy 1-image-per-sample branches.
- **test(vlm)**: add three regression tests covering uneven \`batch_size\` across each branch (\`batch_size=7, n_microbatches=3\` for general/Gemma4; \`batch_size=5, n_microbatches=3\` for legacy). Each asserts no sample is dropped and chunk sizes match \`tensor.chunk\`.

## Test plan

- [x] \`uv run pytest tests/unit_tests/recipes/test_finetune_vlm_helpers.py\` — 68 passed, 3 skipped (skips are pre-existing \`fused_linear_ce\` GPU cases)
- [x] \`uv run ruff format --check\` and \`ruff check\` on \`recipes/vlm/finetune.py\` — clean
- [ ] PP=3 functional verification on a VLM recipe with \`local_batch_size: 7\` (requires multi-GPU host)