### PR TITLE
fix(vlm): fail loudly in PP chunker when pixel_values cannot be aligned

### DIFF
--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -326,13 +326,20 @@ def _chunk_vlm_media(
             patch_end = cumsum[img_end - 1].item() if img_end > 0 else 0
             pixel_values_chunks.append(pixel_values[int(patch_start) : int(patch_end)])
     else:
-        pixel_values_chunks.append(pixel_values)
-        image_grid_chunks.append(image_grid)
-        for _ in range(n_microbatches - 1):
-            pixel_values_chunks.append(pixel_values[:0])
-            image_grid_chunks.append(image_grid[:0])
-        logging.warning(
-            f"VLM chunking: n_images={n_images} != batch_size={batch_size}, giving all images to first microbatch"
+        # No layout matched. Previously this branch logged a warning and gave all
+        # images to mb0 with empty tensors for mb1..N, but trailing microbatches
+        # whose text still contains media tokens would then scatter into empty
+        # pixel_values — silent corruption. Fail loudly so the calling collate is
+        # forced to provide n_images_per_sample (or align n_images with batch_size)
+        # instead of training on broken data.
+        raise ValueError(
+            "VLM PP chunking cannot align pixel_values with the batch: "
+            f"pixel_values.shape={tuple(pixel_values.shape)}, "
+            f"image_grid.shape={tuple(image_grid.shape)}, "
+            f"n_images={n_images}, batch_size={batch_size}, "
+            f"n_images_per_sample={'set' if n_images_per_sample is not None else 'None'}. "
+            "Either ensure pixel_values has shape [batch_size, ...] (one media tensor per "
+            "sample) or pass n_images_per_sample so the chunker can map images to samples."
         )
 
     return pixel_values_chunks, image_grid_chunks

--- a/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
+++ b/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
@@ -1518,10 +1518,9 @@ class TestForwardBackwardStepPP:
         # Verify loss was computed
         assert len(loss_buffer) == 1
 
-    def test_pp_vlm_chunking_mismatched_images_and_batch(self, pp_recipe, monkeypatch, caplog):
-        """Test VLM chunking when n_images != batch_size (fallback path)."""
-        import logging
-
+    def test_pp_vlm_chunking_mismatched_images_raises(self, pp_recipe, monkeypatch):
+        """When n_images != batch_size with no n_images_per_sample, _forward_backward_step
+        now bubbles up a ValueError from the chunker instead of silently emptying mb1..N."""
         pp_recipe.pp = _MockAutoPipeline(has_first_stage=True, has_last_stage=True, n_microbatches=2)
 
         monkeypatch.setattr(
@@ -1530,7 +1529,6 @@ class TestForwardBackwardStepPP:
         )
 
         batch_size = 4
-        n_images = 2  # Different from batch_size
         image_grid_hws = torch.tensor([[2, 2], [3, 3]])
         total_patches = 4 + 9
         pixel_values = torch.randn(total_patches, 3, 14, 14)
@@ -1543,7 +1541,7 @@ class TestForwardBackwardStepPP:
         }
         loss_buffer = []
 
-        with caplog.at_level(logging.WARNING):
+        with pytest.raises(ValueError, match="VLM PP chunking cannot align"):
             pp_recipe._forward_backward_step(
                 idx=0,
                 batch=batch,
@@ -1552,9 +1550,6 @@ class TestForwardBackwardStepPP:
                 num_batches=1,
                 is_train=True,
             )
-
-        # Should log warning about mismatched images
-        assert any("giving all images to first microbatch" in record.message for record in caplog.records)
 
     def test_pp_vlm_chunking_with_image_sizes(self, pp_recipe, monkeypatch):
         """Test VLM pixel_values chunking with image_sizes fallback (e.g., Mistral4-style)."""
@@ -2419,19 +2414,19 @@ class TestChunkVlmMedia:
         assert pv_chunks[0].shape[0] == 4 + 9  # first 2 images
         assert pv_chunks[1].shape[0] == 4 + 9  # last 2 images
 
-    def test_fallback_mismatched_images(self):
-        """When n_images != batch_size and no n_images_per_sample, all go to first mb."""
+    def test_fallback_mismatched_images_raises(self):
+        """n_images != batch_size with no n_images_per_sample now raises rather
+        than silently emptying mb1..N (which previously caused trailing microbatches
+        to scatter media tokens into empty pixel_values)."""
         from nemo_automodel.recipes.vlm.finetune import _chunk_vlm_media
 
         image_grid = torch.tensor([[1, 2, 2], [1, 2, 2], [1, 2, 2]])
         pixel_values = torch.randn(12, 64)  # 3 images but batch_size=2
 
-        pv_chunks, ig_chunks = _chunk_vlm_media(
-            pixel_values, image_grid, batch_size=2, n_microbatches=2,
-        )
-        assert len(pv_chunks) == 2
-        assert pv_chunks[0].shape[0] == 12  # all in first
-        assert pv_chunks[1].shape[0] == 0   # empty
+        with pytest.raises(ValueError, match="VLM PP chunking cannot align"):
+            _chunk_vlm_media(
+                pixel_values, image_grid, batch_size=2, n_microbatches=2,
+            )
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

\`_chunk_vlm_media\`'s legacy fallback (\`n_images != batch_size\` AND \`n_images_per_sample is None\` AND pixel_values is not shaped \`[batch_size, ...]\`) used to dump every image into mb0, emit empty pixel_values for mb1..N, and log a warning. Subsequent microbatches whose text still carried media tokens would then scatter into empty tensors — silent corruption rather than a crash.

This patch replaces the warn-and-continue with \`raise ValueError\`, forcing the calling collate to align with the chunker's contract instead of training on broken data.

## Changelog

- **fix(vlm)**: \`_chunk_vlm_media\` now raises \`ValueError\` when no layout matches, with a message listing the actual shapes / counts and pointing at the two valid options (\`pixel_values [batch_size, ...]\` or \`n_images_per_sample\` set).
- **test(vlm)**: rewrite \`test_fallback_mismatched_images\` and \`test_pp_vlm_chunking_mismatched_images_and_batch\` to assert the new \`pytest.raises\` contract instead of the old "warn and continue" behavior.

## Behavioral note

This is a breaking change for any caller relying on the previous warn-and-continue behavior. Such callers were already producing incorrect training data — empty pixel_values scattered into media tokens cannot yield meaningful gradients — so the breakage is intentional. All in-tree collates already set \`n_images_per_sample\`, so no in-tree recipe is affected.

## Test plan

- [x] \`uv run pytest tests/unit_tests/recipes/test_finetune_vlm_helpers.py\` — 65 passed, 3 skipped (skips are pre-existing \`fused_linear_ce\` GPU cases)
- [x] \`uv run ruff check\` on \`recipes/vlm/finetune.py\` — clean