### PR TITLE
ci(diffusion): remove local_dir and post process directly on cache

### DIFF
--- a/tests/ci_tests/scripts/diffusion_finetune_launcher.sh
+++ b/tests/ci_tests/scripts/diffusion_finetune_launcher.sh
@@ -75,19 +75,20 @@ fi
 echo "[config] Recipe=$RECIPE_NAME  MediaType=$MEDIA_TYPE  Processor=$PROCESSOR  Model=$MODEL_NAME  LoRA=$IS_LORA"
 
 # ============================================
-# Stage 1: Download dataset
+# Stage 1: Resolve dataset
 # ============================================
 echo "============================================"
-echo "[data] Downloading dataset..."
+echo "[data] Resolving dataset..."
 echo "============================================"
 if [ "$MEDIA_TYPE" = "image" ]; then
+    RAW_DIR="$DATA_DIR/raw"
     uv run --extra diffusion python -c "
 from datasets import load_dataset
 from pathlib import Path
 import json
 
 ds = load_dataset('diffusers/tuxemon', split='train')
-out_dir = Path('$DATA_DIR/raw')
+out_dir = Path('$RAW_DIR')
 out_dir.mkdir(parents=True, exist_ok=True)
 
 jsonl_entries = []
@@ -104,11 +105,13 @@ with open(jsonl_path, 'w') as jf:
 print(f'Extracted {len(ds)} images to {out_dir}')
 "
 else
-    uv run --extra diffusion python -c "
+    # snapshot_download into HF_HUB_CACHE (no local_dir) so the dataset persists
+    # across CI runs; preprocessing reads it directly from the snapshot path.
+    RAW_DIR=$(uv run --extra diffusion python -c "
 from huggingface_hub import snapshot_download
-snapshot_download('modal-labs/dissolve', repo_type='dataset', local_dir='$DATA_DIR/raw')
-print('Dataset downloaded successfully')
-"
+print(snapshot_download('modal-labs/dissolve', repo_type='dataset'))
+" | tail -1)
+    echo "[data] Dataset resolved at: $RAW_DIR"
 fi
 
 # ============================================
@@ -119,13 +122,13 @@ echo "[preprocess] Converting ${MEDIA_TYPE}s to latents..."
 echo "============================================"
 if [ "$MEDIA_TYPE" = "image" ]; then
     uv run --extra diffusion python -m tools.diffusion.preprocessing_multiprocess image \
-        --image_dir "$DATA_DIR/raw" \
+        --image_dir "$RAW_DIR" \
         --output_dir "$DATA_DIR/cache" \
         --processor "$PROCESSOR" \
         $PREPROCESS_EXTRA_ARGS
 else
     uv run --extra diffusion python -m tools.diffusion.preprocessing_multiprocess video \
-        --video_dir "$DATA_DIR/raw" \
+        --video_dir "$RAW_DIR" \
         --output_dir "$DATA_DIR/cache" \
         --processor "$PROCESSOR" \
         --resolution_preset 512p \


### PR DESCRIPTION
# What does this PR do ?

  - `diffusion_finetune_launcher.sh` was calling `snapshot_download(..., local_dir=$DATA_DIR/raw)`, which bypasses `HF_HUB_CACHE` (modern`huggingface_hub` writes only to `local_dir`). The dataset never landed in the shared cache, so offline reruns failed with `LocalEntryNotFoundError`.
  - Drop `local_dir`, capture the resolved snapshot path, and point preprocessing at it directly. Cache fills once; subsequent offline runs hit it.

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
