### PR TITLE
fix(pp): preserve VLM forward when class opts in via _pp_keep_self_forward

### DIFF
--- a/nemo_automodel/components/distributed/pipelining/functional.py
+++ b/nemo_automodel/components/distributed/pipelining/functional.py
@@ -36,6 +36,7 @@ from nemo_automodel.components.distributed.pipelining.hf_utils import (
     MULTIMODAL_SUFFIXES,
     TEXT_MODULE_ATTRS,
     get_text_module,
+    model_keeps_self_forward,
     patch_hf_model_for_pp,
 )
 
@@ -509,9 +510,18 @@ def split_model_into_stages(
         """Build a pipeline stage from specified module names."""
         # Deep copy the model
         stage_model = copy.deepcopy(model)
-        patch_hf_model_for_pp(
-            stage_model, patch_inner_model=patch_inner_model, patch_causal_lm_model=patch_causal_lm_model
-        )
+        # Two model implementation paths:
+        #   - HF / dedicated-patch path (LLMs, Gemma4 VLM, Mistral3 VLM): the
+        #     PP-aware forward lives in ``patch_hf_model_for_pp``.
+        #   - Custom-impl path that handles PP itself (Qwen3-VL-MoE, KimiVL,
+        #     Kimi-K2.5-VL, Qwen3.5-MoE): the model class declares
+        #     ``_pp_keep_self_forward = True`` so its own ``forward`` (which
+        #     pulls per-microbatch pixel_values from ``_vlm_pixel_values_chunks``)
+        #     stays intact.
+        if not model_keeps_self_forward(stage_model):
+            patch_hf_model_for_pp(
+                stage_model, patch_inner_model=patch_inner_model, patch_causal_lm_model=patch_causal_lm_model
+            )
         # Create a set of modules to keep
         modules_to_keep = set(module_names)
         modules_sorted = sorted(modules_to_keep, key=lambda x: x.split(".")[-1])

--- a/nemo_automodel/components/distributed/pipelining/hf_utils.py
+++ b/nemo_automodel/components/distributed/pipelining/hf_utils.py
@@ -586,14 +586,25 @@ def _is_gemma4_vlm(model: torch.nn.Module) -> bool:
     return getattr(text_config, "model_type", None) == "gemma4"
 
 
+def model_keeps_self_forward(model: torch.nn.Module) -> bool:
+    """Return True when *model* opts out of pipeline-aware forward patching.
+
+    Used by the pipeline split call site to skip ``patch_hf_model_for_pp``
+    entirely for models whose own ``forward`` is already PP-aware (typically
+    because it pulls pixel_values out of ``self._vlm_pixel_values_chunks``
+    set by the training loop). Currently set on Qwen3-VL-MoE, Qwen3.5-MoE,
+    KimiVL, and Kimi-K2.5-VL.
+    """
+    return bool(getattr(type(model), "_pp_keep_self_forward", False))
+
+
 def patch_hf_model_for_pp(model, patch_inner_model: bool = True, patch_causal_lm_model: bool = True) -> None:
     """Patch a HF model/module to produce pipeline-compatible forward.
 
-    - VLMs whose model class declares ``_pp_keep_self_forward = True``
-      (e.g. Qwen3-VL-MoE, KimiVL, Kimi-K2.5-VL, Qwen3.5-MoE): preserve the
-      model's own ``forward`` because it already fetches per-microbatch
-      ``pixel_values`` from ``_vlm_pixel_values_chunks``. Replacing it with
-      the generic CausalLM forward would silently bypass the vision tower.
+    The caller is responsible for skipping this function when the model
+    opts out via ``model_keeps_self_forward(model)``. This function itself
+    only branches on the patch *flavor*:
+
     - Gemma4 VLM (``config.model_type == 'gemma4'`` with a nested text
       backbone at ``model.model.language_model``): patch the text backbone
       and VLM outer with Gemma4-specific VLM-aware forwards.
@@ -605,13 +616,6 @@ def patch_hf_model_for_pp(model, patch_inner_model: bool = True, patch_causal_lm
     """
     inner_model = getattr(model, "model", None)
     text_backbone = getattr(inner_model, "language_model", None) if inner_model is not None else None
-
-    # Models that opt out of forward replacement entirely. Their own forward
-    # is already PP-aware (typically because it pulls pixel_values out of
-    # ``self._vlm_pixel_values_chunks`` set by the training loop). Patching
-    # would shadow that logic at the instance level and break vision routing.
-    if getattr(type(model), "_pp_keep_self_forward", False):
-        return
 
     if inner_model is not None and text_backbone is not None and _is_gemma4_vlm(model):
         # Gemma4 VLM: the text backbone needs sliding/full-attention RoPE

--- a/nemo_automodel/components/distributed/pipelining/hf_utils.py
+++ b/nemo_automodel/components/distributed/pipelining/hf_utils.py
@@ -589,16 +589,29 @@ def _is_gemma4_vlm(model: torch.nn.Module) -> bool:
 def patch_hf_model_for_pp(model, patch_inner_model: bool = True, patch_causal_lm_model: bool = True) -> None:
     """Patch a HF model/module to produce pipeline-compatible forward.
 
+    - VLMs whose model class declares ``_pp_keep_self_forward = True``
+      (e.g. Qwen3-VL-MoE, KimiVL, Kimi-K2.5-VL, Qwen3.5-MoE): preserve the
+      model's own ``forward`` because it already fetches per-microbatch
+      ``pixel_values`` from ``_vlm_pixel_values_chunks``. Replacing it with
+      the generic CausalLM forward would silently bypass the vision tower.
     - Gemma4 VLM (``config.model_type == 'gemma4'`` with a nested text
       backbone at ``model.model.language_model``): patch the text backbone
       and VLM outer with Gemma4-specific VLM-aware forwards.
-    - Other models with ``model.model`` (e.g., LlamaForCausalLM and most
-      other VLMs): patch inner and outer with the generic CausalLM
-      forwards.
+    - Mistral3 VLM: patch the text backbone with the generic inner forward
+      and the outer with the Mistral3-specific VLM forward.
+    - Other models with ``model.model`` (e.g., LlamaForCausalLM and other
+      LLMs): patch inner and outer with the generic CausalLM forwards.
     - Else: patch the module itself with the generic inner forward.
     """
     inner_model = getattr(model, "model", None)
     text_backbone = getattr(inner_model, "language_model", None) if inner_model is not None else None
+
+    # Models that opt out of forward replacement entirely. Their own forward
+    # is already PP-aware (typically because it pulls pixel_values out of
+    # ``self._vlm_pixel_values_chunks`` set by the training loop). Patching
+    # would shadow that logic at the instance level and break vision routing.
+    if getattr(type(model), "_pp_keep_self_forward", False):
+        return
 
     if inner_model is not None and text_backbone is not None and _is_gemma4_vlm(model):
         # Gemma4 VLM: the text backbone needs sliding/full-attention RoPE
@@ -633,6 +646,27 @@ def init_hf_model_buffers(model: torch.nn.Module, device: torch.device) -> None:
             rotary_owner.rotary_emb.register_buffer("inv_freq", inv_freq, persistent=False)
 
 
+# VLM model_types whose vision routing is handled inside ``patch_hf_model_for_pp``
+# (a dedicated ``pipeline_forward_*_vlm`` function reads ``_vlm_pixel_values_chunks``).
+_PP_VLM_MODEL_TYPES_WITH_DEDICATED_FORWARD: tuple[str, ...] = ("gemma4", "mistral3")
+
+
+def _is_vlm(model: torch.nn.Module) -> bool:
+    """Best-effort check for whether ``model`` is a vision-language model.
+
+    Looks at the standard VLM markers used elsewhere in the codebase: a nested
+    ``text_config``, a ``vision_tower`` attribute on the outer model, or a
+    ``visual`` attribute on the inner model (Qwen-VL convention).
+    """
+    config = getattr(model, "config", None)
+    if config is not None and getattr(config, "text_config", None) is not None:
+        return True
+    if hasattr(model, "vision_tower"):
+        return True
+    inner = getattr(model, "model", None)
+    return inner is not None and (hasattr(inner, "vision_tower") or hasattr(inner, "visual"))
+
+
 def validate_hf_model_for_pipeline_support(model: torch.nn.Module) -> None:
     """Validate if a model is compatible with torch.distributed.pipelining."""
     model_name = getattr(getattr(model, "config", object()), "pretrained_model_name_or_path", "Unknown")
@@ -665,6 +699,32 @@ def validate_hf_model_for_pipeline_support(model: torch.nn.Module) -> None:
                 )
         if getattr(config, "is_encoder_decoder", False):
             issues.append("Encoder-Decoder models with cross-attention are not supported yet for pipeline parallelism.")
+
+        # VLM PP routing: vision_tower only runs on stage 0, and pixel_values
+        # are passed through the training loop's _vlm_pixel_values_chunks
+        # mechanism. The model class must either (a) be on the dedicated PP
+        # forward list (Gemma4 / Mistral3) or (b) declare
+        # _pp_keep_self_forward = True so its own forward is preserved.
+        # Otherwise patch_hf_model_for_pp replaces forward with the generic
+        # CausalLM path, which silently drops pixel_values and trains the
+        # language model on placeholder text embeddings.
+        if _is_vlm(model):
+            mt_outer = getattr(config, "model_type", None)
+            mt_inner = getattr(getattr(config, "text_config", None), "model_type", None)
+            has_dedicated = (
+                mt_outer in _PP_VLM_MODEL_TYPES_WITH_DEDICATED_FORWARD
+                or mt_inner in _PP_VLM_MODEL_TYPES_WITH_DEDICATED_FORWARD
+            )
+            keeps_own = bool(getattr(type(model), "_pp_keep_self_forward", False))
+            if not has_dedicated and not keeps_own:
+                issues.append(
+                    f"VLM model_type='{mt_outer}' is not on the pipeline-aware list "
+                    f"({', '.join(_PP_VLM_MODEL_TYPES_WITH_DEDICATED_FORWARD)}) and the model class "
+                    f"{type(model).__name__} does not declare ``_pp_keep_self_forward = True``. "
+                    "Without one of these, patch_hf_model_for_pp will replace the model's forward "
+                    "with the generic CausalLM forward, and pixel_values stored in "
+                    "``_vlm_pixel_values_chunks`` will never reach the vision tower."
+                )
 
     if issues:
         error_msg = f"Model '{model_name}' is not compatible with pipeline parallelism:\n\n"

--- a/nemo_automodel/components/models/kimi_k25_vl/model.py
+++ b/nemo_automodel/components/models/kimi_k25_vl/model.py
@@ -885,6 +885,10 @@ class KimiK25VLForConditionalGeneration(HFCheckpointingMixin, nn.Module, MoEFSDP
     _no_split_modules = ["MoonViT3dEncoderLayer"]
     supports_gradient_checkpointing = True
 
+    # forward() pulls per-microbatch pixel_values from _vlm_pixel_values_chunks;
+    # patch_hf_model_for_pp must not replace it under PP.
+    _pp_keep_self_forward: bool = True
+
     @classmethod
     def from_config(cls, config, moe_config: MoEConfig | None = None, backend: BackendConfig | None = None, **kwargs):
         return cls(config, moe_config=moe_config, backend=backend, **kwargs)

--- a/nemo_automodel/components/models/kimivl/model.py
+++ b/nemo_automodel/components/models/kimivl/model.py
@@ -628,6 +628,10 @@ class KimiVLModel(nn.Module):
 class KimiVLForConditionalGeneration(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
     """KimiVL model with backend-aware DeepseekV3 language model."""
 
+    # forward() pulls per-microbatch pixel_values from _vlm_pixel_values_chunks;
+    # patch_hf_model_for_pp must not replace it under PP.
+    _pp_keep_self_forward: bool = True
+
     @classmethod
     def from_config(cls, config, moe_config: MoEConfig | None = None, backend: BackendConfig | None = None, **kwargs):
         return cls(config, moe_config=moe_config, backend=backend, **kwargs)

--- a/nemo_automodel/components/models/qwen3_5_moe/model.py
+++ b/nemo_automodel/components/models/qwen3_5_moe/model.py
@@ -397,6 +397,10 @@ class Qwen3_5MoeForConditionalGeneration(HFCheckpointingMixin, HFQwen3_5MoeForCo
       * ``lm_head`` with NeMo backend linear
     """
 
+    # forward() pulls per-microbatch pixel_values from _vlm_pixel_values_chunks;
+    # patch_hf_model_for_pp must not replace it under PP.
+    _pp_keep_self_forward: bool = True
+
     @classmethod
     def from_config(
         cls,

--- a/nemo_automodel/components/models/qwen3_vl_moe/model.py
+++ b/nemo_automodel/components/models/qwen3_vl_moe/model.py
@@ -434,6 +434,10 @@ class Qwen3VLMoeTextModelBackend(nn.Module):
 class Qwen3VLMoeForConditionalGeneration(HFCheckpointingMixin, HFQwen3VLMoeForConditionalGeneration, MoEFSDPSyncMixin):
     """Qwen3-VL conditional generation model using the Qwen3-MoE backend components."""
 
+    # forward() pulls per-microbatch pixel_values from _vlm_pixel_values_chunks;
+    # patch_hf_model_for_pp must not replace it under PP.
+    _pp_keep_self_forward: bool = True
+
     @classmethod
     def from_config(
         cls,

--- a/tests/unit_tests/distributed/pipelining/test_hf_utils.py
+++ b/tests/unit_tests/distributed/pipelining/test_hf_utils.py
@@ -24,6 +24,7 @@ from nemo_automodel.components.distributed.pipelining.hf_utils import (
     create_pipeline_forward_causal_lm,
     create_pipeline_forward_inner,
     init_hf_model_buffers,
+    model_keeps_self_forward,
     patch_hf_model_for_pp,
     validate_hf_model_for_pipeline_support,
 )
@@ -392,36 +393,25 @@ class TestPatchHfModelForPp:
         assert model.model.language_model.forward.__func__.__name__ == "pipeline_forward_gemma4_text"
         assert model.forward.__func__.__name__ == "pipeline_forward_gemma4_vlm"
 
-    def test_patch_respects_pp_keep_self_forward(self):
-        """VLMs declaring _pp_keep_self_forward must keep their own forward intact.
+    def test_model_keeps_self_forward_helper(self):
+        """``model_keeps_self_forward`` reflects the class-level opt-out flag.
 
         Regression for the silent-vision bug where chunk-aware VLMs (Qwen3-VL-MoE,
         KimiVL, Kimi-K2.5-VL, Qwen3.5-MoE) had their pixel_values-fetching forward
-        replaced by the generic CausalLM forward, causing vision_tower to never run.
+        replaced by the generic CausalLM forward, causing vision_tower to never
+        run. The fix splits responsibility: the model class declares the flag,
+        and the pipeline build call site uses ``model_keeps_self_forward`` to
+        decide whether to invoke ``patch_hf_model_for_pp`` at all.
         """
 
-        class _Inner(nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.language_model = nn.Module()
-
-        class _ChunkAwareVLM(nn.Module):
+        class _OptedIn(nn.Module):
             _pp_keep_self_forward = True
 
-            def __init__(self):
-                super().__init__()
-                self.config = Mock(model_type="qwen3_vl_moe", text_config=None)
-                self.model = _Inner()
+        class _Default(nn.Module):
+            pass
 
-        model = _ChunkAwareVLM()
-
-        patch_hf_model_for_pp(model, patch_inner_model=True, patch_causal_lm_model=True)
-
-        # Patcher must not install an instance-level ``forward`` attribute on
-        # either the outer or inner model. (nn.Module's ``forward`` is a class
-        # method; instance-level patching would put it in ``__dict__``.)
-        assert "forward" not in model.__dict__, "outer forward was unexpectedly replaced"
-        assert "forward" not in model.model.__dict__, "inner forward was unexpectedly replaced"
+        assert model_keeps_self_forward(_OptedIn()) is True
+        assert model_keeps_self_forward(_Default()) is False
 
 
 class TestInitHfModelBuffers:

--- a/tests/unit_tests/distributed/pipelining/test_hf_utils.py
+++ b/tests/unit_tests/distributed/pipelining/test_hf_utils.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
-from types import SimpleNamespace
 import pytest
 import torch
 import torch.nn as nn
@@ -36,15 +36,11 @@ class TestCreatePipelineForwardInner:
         forward_fn = create_pipeline_forward_inner("AutoModel")
         assert callable(forward_fn)
 
-    @patch('torch.arange')
+    @patch("torch.arange")
     def test_forward_with_embeddings(self, mock_arange):
         # Create mock model with embeddings
         mock_model = Mock()
-        mock_model.config = Mock(
-            output_attentions=False,
-            output_hidden_states=False,
-            use_cache=True
-        )
+        mock_model.config = Mock(output_attentions=False, output_hidden_states=False, use_cache=True)
         mock_model.gradient_checkpointing = False
 
         # Mock embed_tokens
@@ -88,11 +84,7 @@ class TestCreatePipelineForwardInner:
     def test_forward_without_embeddings(self):
         # Create mock model without embeddings
         mock_model = Mock()
-        mock_model.config = Mock(
-            output_attentions=False,
-            output_hidden_states=False,
-            use_cache=False
-        )
+        mock_model.config = Mock(output_attentions=False, output_hidden_states=False, use_cache=False)
         mock_model.gradient_checkpointing = False
         mock_model.embed_tokens = None
         mock_model.layers = None
@@ -111,11 +103,7 @@ class TestCreatePipelineForwardInner:
     def test_forward_with_float_input_ids(self):
         # Test when input_ids is actually hidden states (float type)
         mock_model = Mock()
-        mock_model.config = Mock(
-            output_attentions=False,
-            output_hidden_states=False,
-            use_cache=False
-        )
+        mock_model.config = Mock(output_attentions=False, output_hidden_states=False, use_cache=False)
         mock_model.gradient_checkpointing = False
         mock_model.embed_tokens = None
         mock_model.layers = None
@@ -141,16 +129,11 @@ class TestCreatePipelineForwardCausalLM:
     def test_forward_with_inner_model(self):
         # Create mock causal LM model
         mock_model = Mock()
-        mock_model.config = Mock(
-            output_attentions=False,
-            output_hidden_states=False
-        )
+        mock_model.config = Mock(output_attentions=False, output_hidden_states=False)
 
         # Mock inner model
         mock_inner = Mock()
-        mock_inner.return_value = BaseModelOutputWithPast(
-            last_hidden_state=torch.randn(1, 10, 768)
-        )
+        mock_inner.return_value = BaseModelOutputWithPast(last_hidden_state=torch.randn(1, 10, 768))
         mock_model.model = mock_inner
 
         # Mock lm_head
@@ -173,10 +156,7 @@ class TestCreatePipelineForwardCausalLM:
     def test_forward_without_inner_model(self):
         # Create mock without inner model (pipeline stage)
         mock_model = Mock()
-        mock_model.config = Mock(
-            output_attentions=False,
-            output_hidden_states=False
-        )
+        mock_model.config = Mock(output_attentions=False, output_hidden_states=False)
         mock_model.model = None
         mock_model.lm_head = None
 
@@ -191,10 +171,7 @@ class TestCreatePipelineForwardCausalLM:
 
     def test_forward_with_logits_to_keep(self):
         mock_model = Mock()
-        mock_model.config = Mock(
-            output_attentions=False,
-            output_hidden_states=False
-        )
+        mock_model.config = Mock(output_attentions=False, output_hidden_states=False)
         mock_model.model = None
 
         # Mock lm_head
@@ -214,10 +191,7 @@ class TestCreatePipelineForwardCausalLM:
     def test_forward_with_non_basemodel_output(self):
         """Test handling when inner model returns non-BaseModelOutputWithPast."""
         mock_model = Mock()
-        mock_model.config = Mock(
-            output_attentions=False,
-            output_hidden_states=False
-        )
+        mock_model.config = Mock(output_attentions=False, output_hidden_states=False)
 
         # Mock inner model that returns tensor directly
         mock_inner = Mock()
@@ -245,10 +219,7 @@ class TestCreatePipelineForwardCausalLM:
     def test_forward_with_float_input_ids_causal_lm(self):
         """Test handling float input_ids in causal LM without inner model."""
         mock_model = Mock()
-        mock_model.config = Mock(
-            output_attentions=False,
-            output_hidden_states=False
-        )
+        mock_model.config = Mock(output_attentions=False, output_hidden_states=False)
         mock_model.model = None
         mock_model.lm_head = None
 
@@ -264,10 +235,7 @@ class TestCreatePipelineForwardCausalLM:
     def test_forward_invalid_input_causal_lm(self):
         """Test error when invalid input provided to causal LM stage."""
         mock_model = Mock()
-        mock_model.config = Mock(
-            output_attentions=False,
-            output_hidden_states=False
-        )
+        mock_model.config = Mock(output_attentions=False, output_hidden_states=False)
         mock_model.model = None
         mock_model.lm_head = None
 
@@ -286,6 +254,7 @@ class TestPatchHfModelForPp:
 
     def test_patch_model_with_inner_model(self):
         """Test patching model that has inner .model attribute."""
+
         # Create model with inner model
         class OuterModel(nn.Module):
             def __init__(self):
@@ -314,6 +283,7 @@ class TestPatchHfModelForPp:
 
     def test_patch_model_selective_patching(self):
         """Test selective patching with flags."""
+
         class OuterModel(nn.Module):
             def __init__(self):
                 super().__init__()
@@ -332,6 +302,7 @@ class TestPatchHfModelForPp:
 
     def test_patch_model_with_none_inner(self):
         """Test patching when model.model is None."""
+
         class OuterModel(nn.Module):
             def __init__(self):
                 super().__init__()
@@ -348,6 +319,7 @@ class TestPatchHfModelForPp:
 
     def test_patch_gemma4_vlm_uses_gemma4_forward(self):
         """Gemma4 VLM (config.model_type == 'gemma4') gets the Gemma4-specific forwards."""
+
         class _Inner(nn.Module):
             def __init__(self):
                 super().__init__()
@@ -374,6 +346,7 @@ class TestPatchHfModelForPp:
 
     def test_patch_non_gemma4_vlm_falls_back_to_generic(self):
         """VLMs that happen to expose model.language_model but are NOT Gemma4 use the generic path."""
+
         class _Inner(nn.Module):
             def __init__(self):
                 super().__init__()
@@ -401,6 +374,7 @@ class TestPatchHfModelForPp:
 
     def test_patch_gemma4_vlm_via_text_config_model_type(self):
         """Gemma4 detection also works when model_type is only in config.text_config."""
+
         class _Inner(nn.Module):
             def __init__(self):
                 super().__init__()
@@ -418,12 +392,44 @@ class TestPatchHfModelForPp:
         assert model.model.language_model.forward.__func__.__name__ == "pipeline_forward_gemma4_text"
         assert model.forward.__func__.__name__ == "pipeline_forward_gemma4_vlm"
 
+    def test_patch_respects_pp_keep_self_forward(self):
+        """VLMs declaring _pp_keep_self_forward must keep their own forward intact.
+
+        Regression for the silent-vision bug where chunk-aware VLMs (Qwen3-VL-MoE,
+        KimiVL, Kimi-K2.5-VL, Qwen3.5-MoE) had their pixel_values-fetching forward
+        replaced by the generic CausalLM forward, causing vision_tower to never run.
+        """
+
+        class _Inner(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.language_model = nn.Module()
+
+        class _ChunkAwareVLM(nn.Module):
+            _pp_keep_self_forward = True
+
+            def __init__(self):
+                super().__init__()
+                self.config = Mock(model_type="qwen3_vl_moe", text_config=None)
+                self.model = _Inner()
+
+        model = _ChunkAwareVLM()
+
+        patch_hf_model_for_pp(model, patch_inner_model=True, patch_causal_lm_model=True)
+
+        # Patcher must not install an instance-level ``forward`` attribute on
+        # either the outer or inner model. (nn.Module's ``forward`` is a class
+        # method; instance-level patching would put it in ``__dict__``.)
+        assert "forward" not in model.__dict__, "outer forward was unexpectedly replaced"
+        assert "forward" not in model.model.__dict__, "inner forward was unexpectedly replaced"
+
 
 class TestInitHfModelBuffers:
     """Test init_hf_model_buffers function."""
 
     def test_init_buffers_with_rotary_emb(self):
         """Test buffer initialization for model with rotary embeddings."""
+
         class MockRotaryEmb(nn.Module):
             def __init__(self):
                 super().__init__()
@@ -450,7 +456,7 @@ class TestInitHfModelBuffers:
         init_hf_model_buffers(model, device)
 
         # Verify buffer was registered (mock implementation sets attribute)
-        assert hasattr(model.model.rotary_emb, 'inv_freq')
+        assert hasattr(model.model.rotary_emb, "inv_freq")
 
     def test_init_buffers_without_rotary_emb(self):
         """Test buffer initialization for model without rotary embeddings."""
@@ -462,6 +468,7 @@ class TestInitHfModelBuffers:
 
     def test_init_buffers_with_direct_rotary_emb(self):
         """Test buffer initialization when rotary_emb is directly on model."""
+
         class MockRotaryEmb(nn.Module):
             def __init__(self):
                 super().__init__()
@@ -487,7 +494,7 @@ class TestInitHfModelBuffers:
         init_hf_model_buffers(model, device)
 
         # Verify buffer was registered (mock implementation sets attribute)
-        assert hasattr(model.rotary_emb, 'inv_freq')
+        assert hasattr(model.rotary_emb, "inv_freq")
 
 
 class TestValidateHfModelForPipelineSupport:
@@ -495,6 +502,7 @@ class TestValidateHfModelForPipelineSupport:
 
     def test_validate_valid_model(self):
         """Test validation of compatible model."""
+
         class MockConfig:
             pretrained_model_name_or_path = "test/model"
             tie_word_embeddings = False
@@ -512,6 +520,7 @@ class TestValidateHfModelForPipelineSupport:
 
     def test_validate_model_with_tied_embeddings(self):
         """Validation fails only when lm_head and embed_tokens actually share storage."""
+
         class MockConfig:
             pretrained_model_name_or_path = "test/model"
             tie_word_embeddings = True  # Needed to enable the tied-weights check
@@ -538,6 +547,7 @@ class TestValidateHfModelForPipelineSupport:
 
     def test_validate_encoder_decoder_model(self):
         """Test validation fails for encoder-decoder model."""
+
         class MockConfig:
             pretrained_model_name_or_path = "test/model"
             tie_word_embeddings = False
@@ -555,10 +565,11 @@ class TestValidateHfModelForPipelineSupport:
 
     def test_validate_multiple_issues(self):
         """Test validation with multiple issues."""
+
         class MockConfig:
             pretrained_model_name_or_path = "test/model"
             tie_word_embeddings = True  # Issue 1 (only fires when weights are actually tied)
-            is_encoder_decoder = True   # Issue 2
+            is_encoder_decoder = True  # Issue 2
 
         class _Inner(nn.Module):
             def __init__(self, shared_embed):
@@ -594,6 +605,7 @@ class TestValidateHfModelForPipelineSupport:
 
     def test_validate_model_with_empty_config(self):
         """Test validation of model with empty config."""
+
         class MockModel(nn.Module):
             def __init__(self):
                 super().__init__()
@@ -602,6 +614,78 @@ class TestValidateHfModelForPipelineSupport:
         model = MockModel()
 
         # Should not raise any error (getattr with default False)
+        validate_hf_model_for_pipeline_support(model)
+
+    def test_validate_unsupported_vlm_pp_combination_raises(self):
+        """VLMs without dedicated PP forward AND without _pp_keep_self_forward must fail validation."""
+
+        class _TextCfg:
+            tie_word_embeddings = False
+
+        class MockConfig:
+            pretrained_model_name_or_path = "test/some_vlm"
+            tie_word_embeddings = False
+            is_encoder_decoder = False
+            model_type = "some_unknown_vlm"
+            text_config = _TextCfg()
+
+        class MockVLM(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.config = MockConfig()
+                self.vision_tower = nn.Linear(4, 4)
+
+        model = MockVLM()
+
+        with pytest.raises(ValueError, match="not on the pipeline-aware list"):
+            validate_hf_model_for_pipeline_support(model)
+
+    def test_validate_chunk_aware_vlm_passes(self):
+        """VLMs that opt into _pp_keep_self_forward must pass validation."""
+
+        class _TextCfg:
+            tie_word_embeddings = False
+
+        class MockConfig:
+            pretrained_model_name_or_path = "test/qwen3_vl_moe"
+            tie_word_embeddings = False
+            is_encoder_decoder = False
+            model_type = "qwen3_vl_moe"
+            text_config = _TextCfg()
+
+        class MockVLM(nn.Module):
+            _pp_keep_self_forward = True
+
+            def __init__(self):
+                super().__init__()
+                self.config = MockConfig()
+                self.vision_tower = nn.Linear(4, 4)
+
+        model = MockVLM()
+        # Should not raise.
+        validate_hf_model_for_pipeline_support(model)
+
+    def test_validate_dedicated_vlm_passes(self):
+        """VLMs on the dedicated-forward list (gemma4 / mistral3) must pass validation."""
+
+        class _TextCfg:
+            tie_word_embeddings = False
+            model_type = "gemma4"
+
+        class MockConfig:
+            pretrained_model_name_or_path = "test/gemma4"
+            tie_word_embeddings = False
+            is_encoder_decoder = False
+            model_type = "gemma4_vlm"
+            text_config = _TextCfg()
+
+        class MockVLM(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.config = MockConfig()
+                self.vision_tower = nn.Linear(4, 4)
+
+        model = MockVLM()
         validate_hf_model_for_pipeline_support(model)
 
     def test_no_gradient_checkpointing_warning(self):
@@ -619,7 +703,7 @@ class TestValidateHfModelForPipelineSupport:
 
         inputs_embeds = torch.randn(1, 10, 768)
 
-        with patch('nemo_automodel.components.distributed.pipelining.hf_utils.logger') as mock_logger:
+        with patch("nemo_automodel.components.distributed.pipelining.hf_utils.logger") as mock_logger:
             output = forward_fn(mock_model, inputs_embeds=inputs_embeds)
             # No warning should be called in the new style
             assert not mock_logger.warning_once.called
@@ -630,11 +714,7 @@ class TestValidateHfModelForPipelineSupport:
     def test_missing_input_error(self):
         """Test error when neither input_ids nor inputs_embeds provided with embed_tokens."""
         mock_model = Mock()
-        mock_model.config = Mock(
-            output_attentions=False,
-            output_hidden_states=False,
-            use_cache=False
-        )
+        mock_model.config = Mock(output_attentions=False, output_hidden_states=False, use_cache=False)
         mock_model.gradient_checkpointing = False
         mock_model.embed_tokens = Mock()
         mock_model.layers = None
@@ -650,11 +730,7 @@ class TestValidateHfModelForPipelineSupport:
     def test_invalid_inputs_embeds_error(self):
         """Test error when inputs_embeds not provided for stage without embed_tokens."""
         mock_model = Mock()
-        mock_model.config = Mock(
-            output_attentions=False,
-            output_hidden_states=False,
-            use_cache=False
-        )
+        mock_model.config = Mock(output_attentions=False, output_hidden_states=False, use_cache=False)
         mock_model.gradient_checkpointing = False
         mock_model.embed_tokens = None
         mock_model.layers = None
@@ -715,9 +791,10 @@ class TestValidateHfModelForPipelineSupport:
         mock_model.layers = nn.ModuleList([layer])
 
         # Mock the masking functions and create causal_mask_mapping
-        with patch('transformers.masking_utils.create_causal_mask') as mock_create_causal, \
-             patch('transformers.masking_utils.create_sliding_window_causal_mask') as mock_create_sliding:
-
+        with (
+            patch("transformers.masking_utils.create_causal_mask") as mock_create_causal,
+            patch("transformers.masking_utils.create_sliding_window_causal_mask") as mock_create_sliding,
+        ):
             mock_create_causal.return_value = torch.ones(1, 1, 10, 10)
             mock_create_sliding.return_value = torch.ones(1, 1, 10, 10) * 2
 
@@ -760,7 +837,7 @@ class TestValidateHfModelForPipelineSupport:
         assert isinstance(output, BaseModelOutputWithPast)
         assert output.attentions is None
 
-    @patch('nemo_automodel.components.distributed.pipelining.hf_utils.get_text_module')
+    @patch("nemo_automodel.components.distributed.pipelining.hf_utils.get_text_module")
     def test_rotary_emb_via_get_text_module(self, mock_get_text_module):
         """Test that rotary_emb is accessed via get_text_module for multimodal model support."""
         mock_model = Mock()
@@ -795,7 +872,7 @@ class TestValidateHfModelForPipelineSupport:
         # Verify rotary_emb was called
         mock_rotary.assert_called_once()
 
-    @patch('nemo_automodel.components.distributed.pipelining.hf_utils.get_text_module')
+    @patch("nemo_automodel.components.distributed.pipelining.hf_utils.get_text_module")
     def test_rotary_emb_none_via_get_text_module(self, mock_get_text_module):
         """Test that None rotary_emb from get_text_module is handled correctly."""
         mock_model = Mock()
@@ -841,6 +918,7 @@ class TestGetTextModule:
 
     def test_returns_language_model_when_present(self):
         """Test that language_model attribute is returned when present."""
+
         class VLMModel(nn.Module):
             def __init__(self):
                 super().__init__()
@@ -853,6 +931,7 @@ class TestGetTextModule:
 
     def test_returns_text_model_when_present(self):
         """Test that text_model attribute is returned when present."""
+
         class VLMModel(nn.Module):
             def __init__(self):
                 super().__init__()
@@ -865,6 +944,7 @@ class TestGetTextModule:
 
     def test_returns_text_decoder_when_present(self):
         """Test that text_decoder attribute is returned when present."""
+
         class VLMModel(nn.Module):
             def __init__(self):
                 super().__init__()
@@ -876,6 +956,7 @@ class TestGetTextModule:
 
     def test_returns_model_when_no_text_attr(self):
         """Test that model itself is returned when no text module attribute exists."""
+
         class SimpleModel(nn.Module):
             def __init__(self):
                 super().__init__()
@@ -892,6 +973,7 @@ class TestGetTextModule:
 
     def test_priority_order_language_model_first(self):
         """Test that language_model has priority over text_model."""
+
         class VLMModel(nn.Module):
             def __init__(self):
                 super().__init__()
@@ -904,6 +986,7 @@ class TestGetTextModule:
 
     def test_skips_none_attribute(self):
         """Test that None attributes are skipped."""
+
         class VLMModel(nn.Module):
             def __init__(self):
                 super().__init__()
@@ -952,21 +1035,25 @@ class TestIsMistral3Vlm:
 
     def test_model_type_mistral3_returns_true(self):
         from nemo_automodel.components.distributed.pipelining.hf_utils import _is_mistral3_vlm
+
         m = Mock()
         m.config = Mock(model_type="mistral3")
         assert _is_mistral3_vlm(m) is True
 
     def test_model_type_other_returns_false(self):
         from nemo_automodel.components.distributed.pipelining.hf_utils import _is_mistral3_vlm
+
         m = Mock()
         m.config = Mock(model_type="llama")
         assert _is_mistral3_vlm(m) is False
 
     def test_no_config_returns_false(self):
         from nemo_automodel.components.distributed.pipelining.hf_utils import _is_mistral3_vlm
+
         # Use a real object without `config` to avoid Mock auto-attributing.
         class _Bare:
             pass
+
         assert _is_mistral3_vlm(_Bare()) is False
 
 
@@ -1039,9 +1126,7 @@ class TestPipelineForwardMistral3Vlm:
                 self.model.get_image_features = Mock()
                 self.model.get_placeholder_mask = Mock()
                 # Lang model forward — return a plain tensor (last_hidden_state path).
-                self.model.language_model.forward = Mock(
-                    return_value=torch.zeros(1, 5, 4, dtype=torch.bfloat16)
-                )
+                self.model.language_model.forward = Mock(return_value=torch.zeros(1, 5, 4, dtype=torch.bfloat16))
                 # No lm_head on stage 0 (only the last stage has it).
 
         m = _Stage0()
@@ -1089,9 +1174,7 @@ class TestPipelineForwardMistral3Vlm:
         from types import SimpleNamespace as _SN
 
         m = self._make_first_stage_model(vision_feature_layer_default=-1)
-        m.model.get_image_features.return_value = _SN(
-            pooler_output=(torch.zeros(1, 4, dtype=torch.bfloat16),)
-        )
+        m.model.get_image_features.return_value = _SN(pooler_output=(torch.zeros(1, 4, dtype=torch.bfloat16),))
         m.model.get_placeholder_mask.return_value = torch.zeros(1, 5, 4, dtype=torch.bool)
         # Avoid chunk-retrieval branch by passing pixel_values directly.
         m(
@@ -1111,9 +1194,7 @@ class TestPipelineForwardMistral3Vlm:
         m._vlm_image_grid_hws_chunks = None
         m._vlm_chunk_idx = 0
         # input_ids contains NO image tokens (token 10 absent).
-        m.model.language_model.forward = Mock(
-            return_value=torch.zeros(1, 5, 4, dtype=torch.bfloat16)
-        )
+        m.model.language_model.forward = Mock(return_value=torch.zeros(1, 5, 4, dtype=torch.bfloat16))
         m(input_ids=torch.tensor([[1, 2, 3, 4, 5]]), pixel_values=None)
         m.model.get_image_features.assert_not_called()
         assert m._vlm_chunk_idx == 0  # unchanged
@@ -1134,9 +1215,7 @@ class TestPipelineForwardMistral3Vlm:
                 self.model.language_model = nn.Module()
                 # Non-first stage: embed_tokens is None (pruned in the PP split).
                 self.model.language_model.embed_tokens = None
-                self.model.language_model.forward = Mock(
-                    return_value=torch.zeros(1, 5, 4, dtype=torch.bfloat16)
-                )
+                self.model.language_model.forward = Mock(return_value=torch.zeros(1, 5, 4, dtype=torch.bfloat16))
                 self.model.vision_tower = None  # also pruned
                 # No lm_head — middle stage.
 


### PR DESCRIPTION
## What

`patch_hf_model_for_pp` unconditionally replaced `model.forward` with the generic `pipeline_forward_causal_lm` for any VLM that is not Gemma4 or Mistral3. Chunk-aware VLMs (Qwen3-VL-MoE, Qwen3.5-MoE, KimiVL, Kimi-K2.5-VL) keep the per-microbatch `pixel_values` in `self._vlm_pixel_values_chunks` and fetch them inside their **own** forward; the generic forward never reads that attribute, so under PP the vision tower silently never ran and image tokens were trained against placeholder text embeddings.

The existing recipes worked around this by setting `patch_inner_model: false` and `patch_causal_lm_model: false` in their YAMLs, but the framework had no way to enforce it — any new PP+VLM recipe that forgot the two flags would silently corrupt training.

## Repro (pre-fix)

```python
from nemo_automodel.components.distributed.pipelining.hf_utils import patch_hf_model_for_pp
# build a chunk-aware VLM, attach _vlm_pixel_values_chunks, call patch with defaults
patch_hf_model_for_pp(model, patch_inner_model=True, patch_causal_lm_model=True)
# model.forward is now generic causal_lm; pixel_values never reaches inner model
```

`grep _vlm_pixel_values_chunks pipelining/hf_utils.py` confirms only the dedicated `gemma4_vlm` and `mistral3_vlm` forwards read the chunks.

## Changelog

- Add opt-in class attribute `_pp_keep_self_forward`. When `True`, `patch_hf_model_for_pp` is a no-op for both inner and outer modules — preserves the model's chunk-aware forward.
- `validate_hf_model_for_pipeline_support` now refuses to start a PP job for a VLM that has neither a dedicated forward (gemma4 / mistral3) nor `_pp_keep_self_forward`, so the same misconfiguration cannot reach training silently again.
- Mark `Qwen3VLMoeForConditionalGeneration`, `Qwen3_5MoeForConditionalGeneration`, `KimiVLForConditionalGeneration`, `KimiK25VLForConditionalGeneration` with `_pp_keep_self_forward = True`.
- Unit tests for: the patch escape hatch, validation passing for chunk-aware VLMs, validation passing for dedicated-forward VLMs, validation raising for unsupported VLM-PP combos.

## Test plan

- [x] `pytest tests/unit_tests/distributed/pipelining/test_hf_utils.py` — 58 passed
- [x] `pytest tests/unit_tests/models/{qwen3_vl_moe,qwen3_5_moe,kimivl,kimi_k25_vl}/` — 489 passed (3 pre-existing flash-attn-env failures unrelated to this change)
- [x] End-to-end repro: confirmed `pixel_values` now reaches inner model under default `patch_*=True` for chunk-aware VLMs
- [ ] CI: L0 + L2 VLM PP suites