### PR TITLE
docs: Add build timestamp meta tag to docs 

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           repository: NVIDIA-NeMo/FW-CI-templates
-          ref: v0.74.0
+          ref: 0796c2c2b65085259f4d14c02aa5853ff5c487a5
           path: FW-CI-templates
 
       - uses: ./FW-CI-templates/.github/actions/publish-docs

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           repository: NVIDIA-NeMo/FW-CI-templates
-          ref: 0796c2c2b65085259f4d14c02aa5853ff5c487a5
+          ref: v0.74.0
           path: FW-CI-templates
 
       - uses: ./FW-CI-templates/.github/actions/publish-docs

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,11 +20,16 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
+import datetime
 import os
 import sys
 
 # flake8: noqa
 # pylint: skip-file
+
+# Embed a build timestamp so every docs build produces unique content,
+# ensuring Akamai ECCU revalidate detects changed ETags on S3.
+build_timestamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 project = "NeMo-AutoModel"
 copyright = "2026, NVIDIA Corporation"
@@ -105,7 +110,8 @@ html_theme_options = {
         "version_match": release,
     },
     "extra_head": {
-        """
+        f"""
+    <meta name="build-timestamp" content="{build_timestamp}">
     <script src="https://assets.adobedtm.com/5d4962a43b79/c1061d2c5e7b/launch-191c2462b890.min.js" ></script>
     """
     },


### PR DESCRIPTION
# What does this PR do ?

docs: Add build timestamp meta tag to docs 

The automodel docs continue to be pulling from an old cache. It seems to be an Akamai problem. However, it's unclear why the cache seems to revert. Adding a build timestamp to try to force the cache to be busted when docs change.

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
