### PR TITLE
fix: coverage for external members

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -611,6 +611,7 @@ jobs:
       (
         (needs.pre-flight.outputs.is_ci_workload == 'true' && !failure())
         || success()
+        || (needs.pre-flight.outputs.is_member != 'true' && needs.Nemo_CICD_Test.result == 'success')
       )
       && !cancelled()
       && vars.ENABLE_CODECOV == 'true'


### PR DESCRIPTION
# What does this PR do ?

  - Coverage was getting skipped on fork/external-contributor PRs because its `if:` used `success()`, and skipped `gb200_*` matrix children (gated to NVIDIA members) made the transitive `success()` check return false.
  - Adds a non-member branch that delegates to `needs.Nemo_CICD_Test.result == 'success'` — that job already excludes `gb200_*` from its failed-jobs count for non-members, so it's the canonical "tests passed, modulo GB200" signal. Real failures in unit/e2e/container-build jobs still block Coverage.

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
