### PR TITLE
fix(gemma4 recipes): Change attn_impl to eager for gemma4 TP, PP configs

### DIFF
--- a/examples/vlm_finetune/gemma4/gemma4_31b_tp4.yaml
+++ b/examples/vlm_finetune/gemma4/gemma4_31b_tp4.yaml
@@ -40,7 +40,9 @@ model:
   torch_dtype: torch.bfloat16
   use_liger_kernel: true
   use_sdpa_patching: false
-  attn_implementation: sdpa
+  # SDPA backward NaNs in bf16 on Gemma4 31B's attention shapes when local_batch_size >= 2
+  # using eager attention to be robust for all bs
+  attn_implementation: eager
   # 31B does not use kv_shared layers (only used in 2B, 4B), hence use_cache: false.
   text_config:
     use_cache: false
@@ -104,3 +106,7 @@ freeze_config:
 #   project: <your-project>
 #   entity: <your-entity>
 #   name: <your-run-name>
+
+ci:
+  recipe_owner: athitten
+  time: "00:30:00"

--- a/examples/vlm_finetune/gemma4/gemma4_31b_tp4_pp2.yaml
+++ b/examples/vlm_finetune/gemma4/gemma4_31b_tp4_pp2.yaml
@@ -43,7 +43,9 @@ model:
   torch_dtype: torch.bfloat16
   use_liger_kernel: true
   use_sdpa_patching: false
-  attn_implementation: sdpa
+  # SDPA backward NaNs in bf16 on Gemma4 31B when local_batch_size >= 2.
+  # using eager attention
+  attn_implementation: eager
   text_config:
     use_cache: false
 
@@ -108,3 +110,7 @@ freeze_config:
   freeze_vision_tower: true
   freeze_audio_tower: true
   freeze_language_model: false
+
+ci:
+  recipe_owner: athitten
+  time: "00:30:00"

--- a/examples/vlm_finetune/gemma4/gemma4_31b_tp4_pp2.yaml
+++ b/examples/vlm_finetune/gemma4/gemma4_31b_tp4_pp2.yaml
@@ -22,7 +22,7 @@
 recipe: FinetuneRecipeForVLM
 
 step_scheduler:
-  global_batch_size: 8
+  global_batch_size: 4
   local_batch_size: 2
   ckpt_every_steps: 500
   val_every_steps: 500

--- a/examples/vlm_finetune/gemma4/gemma4_31b_tp4_pp4.yaml
+++ b/examples/vlm_finetune/gemma4/gemma4_31b_tp4_pp4.yaml
@@ -49,7 +49,9 @@ model:
   torch_dtype: torch.bfloat16
   use_liger_kernel: true
   use_sdpa_patching: false
-  attn_implementation: sdpa
+  # SDPA backward NaNs in bf16 on Gemma4 31B when local_batch_size >= 2.
+  # using eager attention to be robust
+  attn_implementation: eager
   text_config:
     use_cache: false
 
@@ -115,3 +117,8 @@ freeze_config:
   freeze_vision_tower: true
   freeze_audio_tower: true
   freeze_language_model: false
+
+ci:
+  recipe_owner: athitten
+  time: "00:30:00"
+  nodes: 4

--- a/examples/vlm_finetune/gemma4/gemma4_31b_tp4_pp4.yaml
+++ b/examples/vlm_finetune/gemma4/gemma4_31b_tp4_pp4.yaml
@@ -29,7 +29,7 @@ recipe: FinetuneRecipeForVLM
 
 step_scheduler:
   global_batch_size: 8
-  local_batch_size: 1
+  local_batch_size: 4
   ckpt_every_steps: 500
   val_every_steps: 500
   num_epochs: 2
@@ -49,7 +49,7 @@ model:
   torch_dtype: torch.bfloat16
   use_liger_kernel: true
   use_sdpa_patching: false
-  attn_implementation: sdpa
+  attn_implementation: eager
   text_config:
     use_cache: false
 

--- a/examples/vlm_finetune/gemma4/gemma4_31b_tp4_pp4.yaml
+++ b/examples/vlm_finetune/gemma4/gemma4_31b_tp4_pp4.yaml
@@ -49,9 +49,7 @@ model:
   torch_dtype: torch.bfloat16
   use_liger_kernel: true
   use_sdpa_patching: false
-  # SDPA backward NaNs in bf16 on Gemma4 31B when local_batch_size >= 2.
-  # using eager attention to be robust
-  attn_implementation: eager
+  attn_implementation: sdpa
   text_config:
     use_cache: false
 


### PR DESCRIPTION
# What does this PR do ?

`attn_implementation: sdpa` leads to Nan loss during gemma4 31b tp4, tp4 pp2, tp4 pp4 runs. Changing to eager for these configs. Also GBS=8 for TP4, PP2 with eager leads to OOM. Hence the GBS is reduced to 4.

Loss curves with eager attn_impl:

31B TP4:

<img width="421" height="305" alt="Screenshot 2026-05-11 at 4 36 50 PM" src="https://github.com/user-attachments/assets/ba8c9be7-2ba9-4680-8f51-3677143bc3d5" />

31B TP4, PP2 with GBS=4, LBS=2 (GBS=8 as before leads to OOM with eager attn_impl, hence it was reduced)

<img width="419" height="306" alt="Screenshot 2026-05-11 at 4 38 10 PM" src="https://github.com/user-attachments/assets/df9fd3d9-9dd7-4f89-8cf8-186ce1591969" />

31B TP4, PP4 

<img width="963" height="638" alt="Screenshot 2026-05-11 at 6 57 21 PM" src="https://github.com/user-attachments/assets/ebea361d-cdd6-4143-a312-ed55cb355e2a" />


# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
