### PR TITLE
fix(deepseek-v4): keep MoE routing scores and attention softmax in fp32

### DIFF
--- a/nemo_automodel/components/models/deepseek_v4/layers.py
+++ b/nemo_automodel/components/models/deepseek_v4/layers.py
@@ -46,8 +46,9 @@ HC (Hyper-Connections):
   See ``_hc_split_sinkhorn`` for the pure-torch port of the reference mixer
   (ported from miles PR 1045's ``kernel/sinkhorn.py``).
 
-Sliding-window / compress-ratio attention is NOT yet implemented.
-All layers use full causal attention regardless of compress_ratios.
+Compress-ratio attention (Compressor + Indexer) is wired into
+DeepseekV4Attention.forward for layers with compress_ratio > 0.
+All layers share the same sliding-window causal mask on the local KV path.
 """
 
 from __future__ import annotations
@@ -473,7 +474,7 @@ def eager_attention_with_sink(
     sinks = module.sinks.reshape(1, -1, 1, 1).expand(query.shape[0], -1, query.shape[-2], -1)
     combined = torch.cat([attn_weights, sinks.to(attn_weights.dtype)], dim=-1)
     combined = combined - combined.max(dim=-1, keepdim=True).values
-    probs = F.softmax(combined, dim=-1, dtype=combined.dtype)[..., :-1]
+    probs = F.softmax(combined, dim=-1, dtype=torch.float32)[..., :-1]
     probs = F.dropout(probs, p=dropout, training=module.training).to(value_states.dtype)
     return torch.matmul(probs, value_states).transpose(1, 2).contiguous(), probs
 

--- a/nemo_automodel/components/moe/layers.py
+++ b/nemo_automodel/components/moe/layers.py
@@ -355,7 +355,7 @@ class Gate(nn.Module):
             weights = original_scores.gather(1, indices)
         elif self.score_func == "sqrtsoftplus":
             # sqrt(softplus(x)) = sqrt(log(1 + exp(x))), used in DeepSeek V4.
-            scores = torch.sqrt(F.softplus(scores.float())).to(scores.dtype)
+            scores = torch.sqrt(F.softplus(scores.float()))
             original_scores = scores
 
             if self.e_score_correction_bias is not None:


### PR DESCRIPTION
## Summary

Fixes two numerical precision issues in the DeepSeek V4 backbone that compound across 61 layers and degrade parity vs the reference implementation. Discovered during MTP parity testing in #2191.

**1. `sqrtsoftplus` Gate routing scores truncated to bf16** (`moe/layers.py`)

The generic Gate computed `sqrt(softplus(scores.float()))` then immediately cast back to bf16 via `.to(scores.dtype)`. This loses precision for expert selection — when two experts have close scores in bf16, the wrong one can be selected. The `DeepseekV4HashGate` (used for the first `num_hash_layers` layers) stays in fp32 throughout, so only non-hash layers were affected.

Fix: remove the `.to(scores.dtype)` cast, keeping scores in fp32 until the final `gate_precision` cast.

**2. Attention softmax in bf16** (`deepseek_v4/layers.py`)

`eager_attention_with_sink` ran `F.softmax(combined, dim=-1, dtype=combined.dtype)`, which under autocast runs in bf16. This produces slightly different attention patterns than fp32 softmax.

Fix: force `dtype=torch.float32` for the softmax computation.

**3. Stale docstring** (`deepseek_v4/layers.py`)

The module docstring claimed "Sliding-window / compress-ratio attention is NOT yet implemented" — this was outdated. The Compressor + Indexer have been wired into `DeepseekV4Attention.forward` for `compress_ratio > 0` layers.

### Parity context (from #2191)

| Metric | Full pipeline | Isolated MTP (ref HC input) |
|--------|--------------|---------------------------|
| cosine | 0.9924 | 0.9987 |
| top1 match | 1397/2047 (68.2%) | Isolated MTP 1832/2047 (89.5%) |

The 21-point gap is attributed to backbone error propagation. These precision fixes target the two most likely sources of compounding divergence in the backbone path.

---

## Reference verification

Both fixes are verified against the **official DSV4-Flash inference code** ([`inference/model.py`](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash/blob/main/inference/model.py) and [`inference/kernel.py`](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash/blob/main/inference/kernel.py)).

### Fix 1: `sqrtsoftplus` routing scores — fp32 throughout

Official `Gate.forward` (`inference/model.py`):
```python
def forward(self, x, input_ids=None):
    scores = linear(x.float(), self.weight.float())       # fp32
    # ...
    scores = F.softplus(scores).sqrt()                     # stays fp32
    original_scores = scores
    if self.bias is not None:
        scores = scores + self.bias
    # ...
    indices = scores.topk(self.topk, dim=-1)[1]
    weights = original_scores.gather(1, indices)           # fp32
    weights /= weights.sum(dim=-1, keepdim=True)
    weights *= self.route_scale
    return weights, indices                                # returns fp32
```

NeMo before this PR:
```python
scores = torch.sqrt(F.softplus(scores.float())).to(scores.dtype)  # cast back to bf16!
```

NeMo after this PR:
```python
scores = torch.sqrt(F.softplus(scores.float()))                   # stays fp32
```

### Fix 2: Attention softmax — fp32 accumulators

Official `sparse_attn_kernel` (`inference/kernel.py`) allocates **all softmax accumulators in FP32**:
```python
acc_s = T.alloc_fragment((h, block), FP32)       # score accumulator
scores_max = T.alloc_fragment(h, FP32)
scores_sum = T.alloc_fragment(h, FP32)
sum_exp = T.alloc_fragment(h, FP32)

# softmax exp in fp32
for i, j in T.Parallel(h, block):
    acc_s[i, j] = T.exp(acc_s[i, j] - scores_max[i])

# attention sink added to fp32 denominator
for i in T.Parallel(h):
    sum_exp[i] += T.exp(attn_sink[i] - scores_max[i])

# final normalization in fp32
for i, j in T.Parallel(h, d):
    acc_o[i, j] /= sum_exp[i]
```

NeMo before this PR:
```python
probs = F.softmax(combined, dim=-1, dtype=combined.dtype)[..., :-1]   # bf16
```

NeMo after this PR:
```python
probs = F.softmax(combined, dim=-1, dtype=torch.float32)[..., :-1]    # fp32
```

### Note on HF transformers

HF transformers (`modular_deepseek_v4.py`) imports `eager_attention_forward` from `modeling_gpt_oss.py`, which uses `F.softmax(combined_logits, dim=-1, dtype=combined_logits.dtype)` — i.e. **bf16 softmax**. This diverges from the official inference kernel. This PR aligns NeMo with the official reference, not HF.

| Aspect | Official inference | HF transformers | NeMo (before) | NeMo (after) |
|--------|-------------------|-----------------|---------------|-------------|
| sqrtsoftplus scores | fp32 | fp32 | **bf16** | fp32 ✅ |
| Attention softmax | fp32 (kernel) | **bf16** | **bf16** | fp32 ✅ |

---

## Changelog

- Keep `sqrtsoftplus` MoE routing scores in fp32 (removes premature bf16 cast)
- Force fp32 softmax in `eager_attention_with_sink`
- Fix stale docstring about compress-ratio attention

## Pre-checks

- [x] `ruff format . && ruff check --fix .` passes
- [x] DeepSeek V4 unit tests pass (52 passed, 3 skipped)
- [x] MoE unit tests pass (280 passed, 47 skipped; 1 pre-existing failure unrelated)
- [x] Commits are signed off (DCO)