### PR TITLE
ci: emit MODEL_FAMILY variable in generated CI YAML

### DIFF
--- a/tests/ci_tests/utils/generate_ci_tests.py
+++ b/tests/ci_tests/utils/generate_ci_tests.py
@@ -268,6 +268,7 @@ def generate_pipeline(automodel_dir: str, scope: str, test_folder: str):
         job["variables"]["MODEL_FAMILY"] = model_name
         pipeline[f'{config_name}'] = job
         if vllm_job:
+            vllm_job["variables"]["MODEL_FAMILY"] = model_name
             pipeline[f"{config_name}_vllm_deploy"] = vllm_job
 
     return pipeline

--- a/tests/ci_tests/utils/generate_ci_tests.py
+++ b/tests/ci_tests/utils/generate_ci_tests.py
@@ -265,6 +265,7 @@ def generate_pipeline(automodel_dir: str, scope: str, test_folder: str):
         job, vllm_job = generate_job(config, config_override, scope, test_folder, automodel_dir)
         if job is None:
             continue  # skipped via ci.known_issue_id (no allow_failure)
+        job["variables"]["MODEL_FAMILY"] = model_name
         pipeline[f'{config_name}'] = job
         if vllm_job:
             pipeline[f"{config_name}_vllm_deploy"] = vllm_job


### PR DESCRIPTION
## Summary
- Emit `MODEL_FAMILY` CI variable in generated test YAML, derived from the recipe's parent directory name
- e.g., `examples/llm_finetune/llama3_2/llama3_2_1b_squad.yaml` → `MODEL_FAMILY=llama3_2`
- 1-line change in `generate_ci_tests.py`

## Motivation
nemo-ci is adding a standardized `test_metadata.json` artifact to every CI job. The `model_family` field currently falls back to `CI_JOB_NAME` which includes the full matrix suffix. This PR exposes a clean `MODEL_FAMILY` variable so nemo-ci can emit queryable values.

## Non-breaking
- Adds a new variable to generated CI YAML without changing existing variables or behavior
- Jobs that don't use `MODEL_FAMILY` are unaffected
- No changes to recipe YAML files needed — auto-derived from directory structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)