### PR TITLE
fix(tests): sort DTensor infrastructure imports

### DIFF
--- a/tests/unit_tests/_transformers/test_infrastructure.py
+++ b/tests/unit_tests/_transformers/test_infrastructure.py
@@ -221,8 +221,9 @@ class TestApplyModelInfrastructurePostShardInit:
 
     def test_skips_model_to_device_when_checkpoint_loaded_with_dtensor(self, monkeypatch):
         """DTensor-sharded post-shard checkpoint loads should skip model.to(device)."""
-        from nemo_automodel._transformers.infrastructure import apply_model_infrastructure
         import torch.distributed.tensor as dist_tensor
+
+        from nemo_automodel._transformers.infrastructure import apply_model_infrastructure
 
         class FakeDTensor:
             pass


### PR DESCRIPTION
## Summary
- Fix Ruff import sorting in `tests/unit_tests/_transformers/test_infrastructure.py` from PR #2146.
- Moves the `torch.distributed.tensor` import before the first-party import in the local test import block.

## Verification
- `uv run --active ruff check .`
- `uv run --active ruff format --check .`
