### PR TITLE
feat(vlm): support teacher offload for VLM KD

### DIFF
--- a/examples/vlm_kd/qwen3_5/qwen3_5_vl_4b_kd.yaml
+++ b/examples/vlm_kd/qwen3_5/qwen3_5_vl_4b_kd.yaml
@@ -49,6 +49,8 @@ teacher_model:
   pretrained_model_name_or_path: Qwen/Qwen3.5-9B
   attn_implementation: sdpa
 
+offload_teacher_model: false
+
 processor:
   _target_: transformers.AutoProcessor.from_pretrained
   pretrained_model_name_or_path: Qwen/Qwen3.5-4B

--- a/nemo_automodel/recipes/vlm/kd.py
+++ b/nemo_automodel/recipes/vlm/kd.py
@@ -56,7 +56,7 @@ from nemo_automodel.components.distributed.utils import get_sync_ctx
 from nemo_automodel.components.loggers.metric_logger import MetricsSample
 from nemo_automodel.components.loss.linear_ce import FusedLinearCrossEntropy
 from nemo_automodel.components.training.rng import ScopedRNG
-from nemo_automodel.components.training.utils import count_tail_padding
+from nemo_automodel.components.training.utils import ScopedModuleOffloading, count_tail_padding
 from nemo_automodel.components.utils.model_utils import VLM_INPUT_KEYS, filter_forward_kwargs
 from nemo_automodel.recipes.vlm.finetune import FinetuneRecipeForVLM, build_model, calculate_loss
 
@@ -154,6 +154,9 @@ class KnowledgeDistillationRecipeForVLM(FinetuneRecipeForVLM):
         if self.pp_enabled:
             raise NotImplementedError("Pipeline parallelism is not supported for VLM knowledge distillation yet.")
 
+        self._offload_teacher_model = self.cfg.get("offload_teacher_model", False)
+        teacher_device = self.dist_env.device if not self._offload_teacher_model else "cpu"
+
         self.teacher_model = _build_teacher_model(
             cfg_teacher=self.cfg.get("teacher_model", None),
             cfg_freeze=self.cfg.get("teacher_freeze_config", None),
@@ -161,7 +164,7 @@ class KnowledgeDistillationRecipeForVLM(FinetuneRecipeForVLM):
             device_mesh=self.device_mesh,
             moe_mesh=self.moe_mesh,
             distributed_config=self.distributed_config,
-            device=self.dist_env.device,
+            device=teacher_device,
         )
 
         logger.info("Teacher Model: " + str(self.teacher_model))
@@ -225,10 +228,13 @@ class KnowledgeDistillationRecipeForVLM(FinetuneRecipeForVLM):
         )
         with sync_ctx, train_ctx():
             # Teacher forward (no grad) — free intermediates immediately.
-            with torch.no_grad():
+            with (
+                ScopedModuleOffloading(self.teacher_model, enabled=self._offload_teacher_model),
+                torch.no_grad(),
+            ):
                 teacher_batch = filter_forward_kwargs(self.teacher_model, batch)
                 teacher_out = self.teacher_model(**teacher_batch)
-                teacher_logits = getattr(teacher_out, "logits", teacher_out).detach()
+                teacher_logits = getattr(teacher_out, "logits", teacher_out).detach().clone()
                 del teacher_out, teacher_batch
 
             # Student forward.

--- a/tests/unit_tests/recipes/test_vlm_kd.py
+++ b/tests/unit_tests/recipes/test_vlm_kd.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from nemo_automodel.recipes.vlm import kd as vlm_kd
+
+
+class _Output:
+    def __init__(self, logits: torch.Tensor):
+        self.logits = logits
+        self.hidden_states = None
+
+
+class _Teacher(nn.Module):
+    def forward(self, input_ids):
+        vocab = 4
+        logits = torch.arange(input_ids.numel() * vocab, dtype=torch.float32).view(*input_ids.shape, vocab)
+        return _Output(logits)
+
+
+class _Student(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = nn.Parameter(torch.tensor(1.0))
+
+    def forward(self, input_ids):
+        vocab = 4
+        logits = torch.ones(*input_ids.shape, vocab, dtype=torch.float32) * self.weight
+        return _Output(logits)
+
+
+class _KD:
+    temperature = 1.0
+
+    def __call__(self, student_logits, teacher_logits, labels, num_batch_labels=None):
+        del teacher_logits, labels, num_batch_labels
+        return student_logits.mean()
+
+
+@pytest.mark.cuda(False)
+def test_vlm_kd_teacher_forward_uses_scoped_offloading_when_enabled(monkeypatch):
+    seen = {}
+
+    class _FakeScopedModuleOffloading:
+        def __init__(self, model, enabled=False):
+            seen["model"] = model
+            seen["enabled"] = enabled
+
+        def __enter__(self):
+            seen["entered"] = True
+            return self
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            seen["exited"] = True
+            return False
+
+    monkeypatch.setattr(vlm_kd, "ScopedModuleOffloading", _FakeScopedModuleOffloading)
+    monkeypatch.setattr(
+        vlm_kd,
+        "calculate_loss",
+        lambda *args, **kwargs: kwargs["logits"].mean(),
+    )
+
+    recipe = vlm_kd.KnowledgeDistillationRecipeForVLM.__new__(vlm_kd.KnowledgeDistillationRecipeForVLM)
+    recipe.dist_env = SimpleNamespace(device="cpu")
+    recipe.device_mesh = None
+    recipe.pp_enabled = False
+    recipe.distributed_config = SimpleNamespace(defer_fsdp_grad_sync=True)
+    recipe.model_parts = [_Student()]
+    recipe.teacher_model = _Teacher()
+    recipe.loss_fn = object()
+    recipe.kd_loss_fn = _KD()
+    recipe.kd_ratio = 0.5
+    recipe._kd_loss_buffer = []
+    recipe._ce_loss_buffer = []
+    recipe._offload_teacher_model = True
+    recipe._get_dp_group_size = lambda include_cp=True: 1
+
+    loss_buffer = []
+    batch = {
+        "input_ids": torch.tensor([[1, 2]]),
+        "labels": torch.tensor([[1, -100]]),
+    }
+
+    recipe._forward_backward_step(
+        0,
+        batch,
+        loss_buffer=loss_buffer,
+        num_label_tokens=1,
+        num_batches=1,
+    )
+
+    assert seen == {
+        "model": recipe.teacher_model,
+        "enabled": True,
+        "entered": True,
+        "exited": True,
+    }
+    assert len(loss_buffer) == 1
+    assert len(recipe._ce_loss_buffer) == 1
+    assert len(recipe._kd_loss_buffer) == 1

--- a/tests/unit_tests/recipes/test_vlm_kd.py
+++ b/tests/unit_tests/recipes/test_vlm_kd.py
@@ -115,3 +115,79 @@ def test_vlm_kd_teacher_forward_uses_scoped_offloading_when_enabled(monkeypatch)
     assert len(loss_buffer) == 1
     assert len(recipe._ce_loss_buffer) == 1
     assert len(recipe._kd_loss_buffer) == 1
+
+
+class _Cfg:
+    def __init__(self, **values):
+        self._values = values
+
+    def get(self, key, default=None):
+        return self._values.get(key, default)
+
+
+@pytest.mark.parametrize(
+    "cfg_overrides, expected_offload, expected_device",
+    [
+        ({}, False, "cuda:0"),
+        ({"offload_teacher_model": False}, False, "cuda:0"),
+        ({"offload_teacher_model": True}, True, "cpu"),
+    ],
+)
+def test_setup_sets_offload_flag_and_teacher_device(
+    monkeypatch, cfg_overrides, expected_offload, expected_device
+):
+    captured = {}
+
+    def fake_build_teacher_model(**kwargs):
+        captured["build_teacher_kwargs"] = kwargs
+        return _Teacher()
+
+    def fake_build_kd_loss_fn(cfg_kd):
+        captured["kd_cfg"] = cfg_kd
+        return _KD()
+
+    def fake_super_setup(self):
+        captured["super_setup_called"] = True
+
+    monkeypatch.setattr(vlm_kd, "_verify_tokenizer_compatibility", lambda *a, **k: None)
+    monkeypatch.setattr(vlm_kd, "_build_teacher_model", fake_build_teacher_model)
+    monkeypatch.setattr(vlm_kd, "_build_kd_loss_fn", fake_build_kd_loss_fn)
+    monkeypatch.setattr(vlm_kd.FinetuneRecipeForVLM, "setup", fake_super_setup)
+
+    recipe = vlm_kd.KnowledgeDistillationRecipeForVLM.__new__(vlm_kd.KnowledgeDistillationRecipeForVLM)
+    recipe.cfg = _Cfg(
+        model={"pretrained_model_name_or_path": "student"},
+        teacher_model={"pretrained_model_name_or_path": "teacher"},
+        seed=7,
+        **cfg_overrides,
+    )
+    recipe.dist_env = SimpleNamespace(device="cuda:0")
+    recipe.device_mesh = None
+    recipe.moe_mesh = None
+    recipe.distributed_config = SimpleNamespace(defer_fsdp_grad_sync=True)
+    recipe.pp_enabled = False
+
+    recipe.setup()
+
+    assert captured["super_setup_called"] is True
+    assert recipe._offload_teacher_model is expected_offload
+    assert captured["build_teacher_kwargs"]["device"] == expected_device
+    assert captured["build_teacher_kwargs"]["seed"] == 7
+    assert recipe.kd_ratio == 0.5
+    assert recipe._ce_loss_buffer == []
+    assert recipe._kd_loss_buffer == []
+
+
+def test_setup_raises_when_pipeline_parallelism_enabled(monkeypatch):
+    monkeypatch.setattr(vlm_kd, "_verify_tokenizer_compatibility", lambda *a, **k: None)
+    monkeypatch.setattr(vlm_kd.FinetuneRecipeForVLM, "setup", lambda self: None)
+
+    recipe = vlm_kd.KnowledgeDistillationRecipeForVLM.__new__(vlm_kd.KnowledgeDistillationRecipeForVLM)
+    recipe.cfg = _Cfg(
+        model={"pretrained_model_name_or_path": "student"},
+        teacher_model={"pretrained_model_name_or_path": "teacher"},
+    )
+    recipe.pp_enabled = True
+
+    with pytest.raises(NotImplementedError):
+        recipe.setup()


### PR DESCRIPTION
## Summary
- add offload_teacher_model support to the VLM KD recipe
- move the teacher to CPU when offload is enabled and scope GPU residency to teacher forward
- add a focused unit test for the VLM KD offload path

## Tests
- uv run ruff format nemo_automodel/recipes/vlm/kd.py tests/unit_tests/recipes/test_vlm_kd.py
- uv run ruff check --fix nemo_automodel/recipes/vlm/kd.py tests/unit_tests/recipes/test_vlm_kd.py
- uv run python -m pytest -q tests/unit_tests/recipes/test_vlm_kd.py