### PR TITLE
fix(vlm): align KD distributed train step

### DIFF
--- a/docs/model-coverage/llm/lgai-exaone/exaone.md
+++ b/docs/model-coverage/llm/lgai-exaone/exaone.md
@@ -1,6 +1,6 @@
 # EXAONE
 
-[EXAONE](https://www.lgresearch.ai/exaone) is a bilingual (Korean-English) language model series from LG AI Research, with strong performance on Korean-language benchmarks.
+EXAONE is a bilingual (Korean-English) language model series from LG AI Research, with strong performance on Korean-language benchmarks.
 
 :::{card}
 | | |

--- a/nemo_automodel/recipes/vlm/kd.py
+++ b/nemo_automodel/recipes/vlm/kd.py
@@ -55,8 +55,15 @@ from nemo_automodel.components.distributed.cp_utils import make_cp_batch_and_ctx
 from nemo_automodel.components.distributed.utils import get_sync_ctx
 from nemo_automodel.components.loggers.metric_logger import MetricsSample
 from nemo_automodel.components.loss.linear_ce import FusedLinearCrossEntropy
+from nemo_automodel.components.moe.megatron.moe_utils import MoEAuxLossAutoScaler
 from nemo_automodel.components.training.rng import ScopedRNG
-from nemo_automodel.components.training.utils import ScopedModuleOffloading, count_tail_padding
+from nemo_automodel.components.training.utils import (
+    ScopedModuleOffloading,
+    count_tail_padding,
+    prepare_for_final_backward,
+    prepare_for_grad_accumulation,
+    scale_grads_and_clip_grad_norm,
+)
 from nemo_automodel.components.utils.model_utils import VLM_INPUT_KEYS, filter_forward_kwargs
 from nemo_automodel.recipes.vlm.finetune import FinetuneRecipeForVLM, build_model, calculate_loss
 
@@ -328,6 +335,8 @@ class KnowledgeDistillationRecipeForVLM(FinetuneRecipeForVLM):
         )
         num_label_tokens = self._dp_allreduce(num_label_tokens).item()
 
+        MoEAuxLossAutoScaler.main_loss_backward_scale = torch.tensor(float(self._get_dp_group_size(include_cp=True)))
+
         loss_buffer: list[torch.Tensor] = []
 
         num_tokens_in_batch = torch.tensor(
@@ -337,27 +346,38 @@ class KnowledgeDistillationRecipeForVLM(FinetuneRecipeForVLM):
         num_tokens_in_batch = self._dp_allreduce(num_tokens_in_batch).item()
 
         num_batches = len(batches)
+        prepare_for_grad_accumulation(self.model_parts, pp_enabled=self.pp_enabled)
+
         for i, batch in enumerate(batches):
+            if i == num_batches - 1:
+                prepare_for_final_backward(self.model_parts, pp_enabled=self.pp_enabled)
+
             self._forward_backward_step(
                 i, batch, loss_buffer=loss_buffer, num_label_tokens=num_label_tokens, num_batches=num_batches
             )
 
-        grad_norm = 0
-        if max_grad_norm is not None:
-            if not self.device_mesh or self.device_mesh["tp"].size() == 1:
-                grad_norm = torch.nn.utils.clip_grad_norm_(
-                    [p for p in self.model_parts[0].parameters() if p.requires_grad], max_grad_norm
-                )
-                if hasattr(grad_norm, "full_tensor"):
-                    grad_norm = grad_norm.full_tensor()
-
-            if isinstance(grad_norm, torch.Tensor):
-                grad_norm = grad_norm.item()
+        grad_norm = scale_grads_and_clip_grad_norm(
+            max_grad_norm=max_grad_norm,
+            model_parts=self.model_parts,
+            norm_type=2.0,
+            pp_enabled=self.pp_enabled,
+            device_mesh=self.device_mesh,
+            moe_mesh=self.moe_mesh,
+            ep_axis_name="ep" if self.moe_mesh is not None and "ep" in self.moe_mesh.mesh_dim_names else None,
+            pp_axis_name="pp" if self.pp_enabled else None,
+            foreach=True,
+            num_label_tokens=num_label_tokens,
+            dp_group_size=self._get_dp_group_size(include_cp=True),
+        )
 
         self.checkpointer.maybe_wait_for_staging()
         for opt in self.optimizer:
             opt.step()
-            opt.zero_grad()
+            opt.zero_grad(set_to_none=True)
+
+        if hasattr(self.model_parts[0], "update_moe_gate_bias"):
+            for mp in self.model_parts:
+                mp.update_moe_gate_bias()
 
         if self.lr_scheduler is not None:
             for scheduler in self.lr_scheduler:
@@ -397,7 +417,7 @@ class KnowledgeDistillationRecipeForVLM(FinetuneRecipeForVLM):
                 "lr": self.optimizer[0].param_groups[0]["lr"],
                 "mem": torch.cuda.max_memory_allocated() / 1024**3,
                 "tps": tps,
-                "tps_per_gpu": tps / max(self._get_dp_group_size(), 1),
+                "tps_per_gpu": tps / self._get_cp_group_size() / max(self._get_dp_group_size(), 1),
                 "num_tokens_per_step": num_tokens_in_batch,
                 "num_label_tokens": num_label_tokens,
                 "kd_ratio": self.kd_ratio,

--- a/nemo_automodel/recipes/vlm/kd.py
+++ b/nemo_automodel/recipes/vlm/kd.py
@@ -335,7 +335,12 @@ class KnowledgeDistillationRecipeForVLM(FinetuneRecipeForVLM):
         )
         num_label_tokens = self._dp_allreduce(num_label_tokens).item()
 
-        MoEAuxLossAutoScaler.main_loss_backward_scale = torch.tensor(float(self._get_dp_group_size(include_cp=True)))
+        if self.pp_enabled:
+            MoEAuxLossAutoScaler.main_loss_backward_scale = torch.tensor(float(num_label_tokens))
+        else:
+            MoEAuxLossAutoScaler.main_loss_backward_scale = torch.tensor(
+                float(self._get_dp_group_size(include_cp=True))
+            )
 
         loss_buffer: list[torch.Tensor] = []
 

--- a/tests/unit_tests/recipes/test_vlm_kd_distributed.py
+++ b/tests/unit_tests/recipes/test_vlm_kd_distributed.py
@@ -54,7 +54,14 @@ class _Model(nn.Module):
 
 
 @pytest.mark.cuda(False)
-def test_vlm_kd_train_step_uses_distributed_step_helpers(monkeypatch):
+@pytest.mark.parametrize(
+    ("pp_enabled", "expected_aux_scale"),
+    [
+        (False, 4.0),
+        (True, 3.0),
+    ],
+)
+def test_vlm_kd_train_step_uses_distributed_step_helpers(monkeypatch, pp_enabled, expected_aux_scale):
     calls = {
         "prepare": [],
         "final": [],
@@ -84,7 +91,7 @@ def test_vlm_kd_train_step_uses_distributed_step_helpers(monkeypatch):
     model = _Model()
     optimizer = _Optimizer()
     recipe.model_parts = [model]
-    recipe.pp_enabled = False
+    recipe.pp_enabled = pp_enabled
     recipe.device_mesh = None
     recipe.moe_mesh = SimpleNamespace(mesh_dim_names=("ep",))
     recipe.optimizer = [optimizer]
@@ -118,25 +125,25 @@ def test_vlm_kd_train_step_uses_distributed_step_helpers(monkeypatch):
     metrics = recipe._run_train_optim_step(batches, max_grad_norm=1.0)
 
     assert isinstance(metrics, MetricsSample)
-    assert calls["prepare"] == [([model], False)]
-    assert calls["final"] == [([model], False)]
+    assert calls["prepare"] == [([model], pp_enabled)]
+    assert calls["final"] == [([model], pp_enabled)]
     assert calls["forward"] == [(0, 3, 2, True), (1, 3, 2, True)]
     assert calls["scale"] == [
         {
             "max_grad_norm": 1.0,
             "model_parts": [model],
             "norm_type": 2.0,
-            "pp_enabled": False,
+            "pp_enabled": pp_enabled,
             "device_mesh": None,
             "moe_mesh": recipe.moe_mesh,
             "ep_axis_name": "ep",
-            "pp_axis_name": None,
+            "pp_axis_name": "pp" if pp_enabled else None,
             "foreach": True,
             "num_label_tokens": 3,
             "dp_group_size": 4,
         }
     ]
-    assert MoEAuxLossAutoScaler.main_loss_backward_scale.item() == pytest.approx(4.0)
+    assert MoEAuxLossAutoScaler.main_loss_backward_scale.item() == pytest.approx(expected_aux_scale)
     assert optimizer.step_called
     assert optimizer.zero_grad_set_to_none is True
     assert model.update_moe_gate_bias_called

--- a/tests/unit_tests/recipes/test_vlm_kd_distributed.py
+++ b/tests/unit_tests/recipes/test_vlm_kd_distributed.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from nemo_automodel.components.loggers.metric_logger import MetricsSample
+from nemo_automodel.components.moe.megatron.moe_utils import MoEAuxLossAutoScaler
+from nemo_automodel.recipes.vlm import kd as vlm_kd
+
+
+class _Cfg:
+    def get(self, key, default=None):
+        if key == "fp8":
+            return None
+        return default
+
+
+class _Optimizer:
+    def __init__(self):
+        self.param_groups = [{"lr": 0.1}]
+        self.step_called = False
+        self.zero_grad_set_to_none = None
+
+    def step(self):
+        self.step_called = True
+
+    def zero_grad(self, set_to_none=False):
+        self.zero_grad_set_to_none = set_to_none
+
+
+class _Model(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = nn.Parameter(torch.tensor(1.0))
+        self.update_moe_gate_bias_called = False
+
+    def update_moe_gate_bias(self):
+        self.update_moe_gate_bias_called = True
+
+
+@pytest.mark.cuda(False)
+def test_vlm_kd_train_step_uses_distributed_step_helpers(monkeypatch):
+    calls = {
+        "prepare": [],
+        "final": [],
+        "scale": [],
+        "forward": [],
+    }
+
+    monkeypatch.setattr(vlm_kd.time, "perf_counter", lambda: 2.0)
+    monkeypatch.setattr(
+        vlm_kd,
+        "prepare_for_grad_accumulation",
+        lambda model_parts, pp_enabled: calls["prepare"].append((model_parts, pp_enabled)),
+    )
+    monkeypatch.setattr(
+        vlm_kd,
+        "prepare_for_final_backward",
+        lambda model_parts, pp_enabled: calls["final"].append((model_parts, pp_enabled)),
+    )
+
+    def _fake_scale_grads_and_clip_grad_norm(**kwargs):
+        calls["scale"].append(kwargs)
+        return 2.5
+
+    monkeypatch.setattr(vlm_kd, "scale_grads_and_clip_grad_norm", _fake_scale_grads_and_clip_grad_norm)
+
+    recipe = vlm_kd.KnowledgeDistillationRecipeForVLM.__new__(vlm_kd.KnowledgeDistillationRecipeForVLM)
+    model = _Model()
+    optimizer = _Optimizer()
+    recipe.model_parts = [model]
+    recipe.pp_enabled = False
+    recipe.device_mesh = None
+    recipe.moe_mesh = SimpleNamespace(mesh_dim_names=("ep",))
+    recipe.optimizer = [optimizer]
+    recipe.lr_scheduler = None
+    recipe.checkpointer = SimpleNamespace(maybe_wait_for_staging=lambda: None)
+    recipe.cfg = _Cfg()
+    recipe.timestamp = 1.0
+    recipe.step_scheduler = SimpleNamespace(step=7, epoch=1)
+    recipe.kd_ratio = 0.5
+    recipe.kd_loss_fn = SimpleNamespace(temperature=1.0)
+    recipe._ce_loss_buffer = []
+    recipe._kd_loss_buffer = []
+    recipe._dp_allreduce = lambda tensor, include_cp=False: tensor
+    recipe._get_dp_group_size = lambda include_cp=False: 4
+    recipe._get_cp_group_size = lambda: 2
+
+    def _fake_forward_backward_step(idx, batch, *, loss_buffer, num_label_tokens, num_batches, is_train=True):
+        calls["forward"].append((idx, num_label_tokens, num_batches, is_train))
+        loss_buffer.append(torch.tensor(1.0))
+        recipe._ce_loss_buffer.append(torch.tensor(0.25))
+        recipe._kd_loss_buffer.append(torch.tensor(0.75))
+
+    recipe._forward_backward_step = _fake_forward_backward_step
+
+    batches = [
+        {"labels": torch.tensor([[1, -100, 2]])},
+        {"labels": torch.tensor([[-100, 3, -100]])},
+    ]
+
+    MoEAuxLossAutoScaler.main_loss_backward_scale = None
+    metrics = recipe._run_train_optim_step(batches, max_grad_norm=1.0)
+
+    assert isinstance(metrics, MetricsSample)
+    assert calls["prepare"] == [([model], False)]
+    assert calls["final"] == [([model], False)]
+    assert calls["forward"] == [(0, 3, 2, True), (1, 3, 2, True)]
+    assert calls["scale"] == [
+        {
+            "max_grad_norm": 1.0,
+            "model_parts": [model],
+            "norm_type": 2.0,
+            "pp_enabled": False,
+            "device_mesh": None,
+            "moe_mesh": recipe.moe_mesh,
+            "ep_axis_name": "ep",
+            "pp_axis_name": None,
+            "foreach": True,
+            "num_label_tokens": 3,
+            "dp_group_size": 4,
+        }
+    ]
+    assert MoEAuxLossAutoScaler.main_loss_backward_scale.item() == pytest.approx(4.0)
+    assert optimizer.step_called
+    assert optimizer.zero_grad_set_to_none is True
+    assert model.update_moe_gate_bias_called
+    assert metrics.metrics["grad_norm"] == 2.5
+    assert metrics.metrics["loss"] == 2.0
+    assert metrics.metrics["ce_loss"] == pytest.approx(0.5)
+    assert metrics.metrics["kd_loss"] == pytest.approx(1.5)
+    assert metrics.metrics["tps"] == 5.0
+    assert metrics.metrics["tps_per_gpu"] == pytest.approx(5.0 / 2 / 4)
+    assert metrics.metrics["num_label_tokens"] == 3


### PR DESCRIPTION
## Summary
- align the VLM KD non-PP optimizer step with the VLM finetuning distributed step
- add grad-accumulation/final-backward hooks before KD backward passes
- route gradient scaling and clipping through scale_grads_and_clip_grad_norm
- set MoE auxiliary-loss backward scale and update MoE gate bias after optimizer steps
- account for CP size in VLM KD tps_per_gpu logging

## Tests
- uv run python -m pytest -q tests/unit_tests/recipes/test_vlm_kd_distributed.py
- uv run python -m pytest -q tests/unit_tests/recipes/test_finetune_vlm_helpers.py
- uv run ruff check nemo_automodel/recipes/vlm/kd.py tests/unit_tests/recipes/test_vlm_kd_distributed.py
- uv run ruff format --check nemo_automodel/recipes/vlm/kd.py tests/unit_tests/recipes/test_vlm_kd_distributed.py