### PR TITLE
test(vlm): cover KD TP and CP correctness

### DIFF
--- a/nemo_automodel/components/loss/kd_loss.py
+++ b/nemo_automodel/components/loss/kd_loss.py
@@ -15,6 +15,7 @@
 from typing import Optional
 
 import torch
+import torch.distributed.nn.functional as dist_nn_func
 import torch.nn as nn
 import torch.nn.functional as F
 
@@ -74,17 +75,18 @@ def _kl_forward_tp(
 
     # --- Stable global log-softmax for student: log Q ---
     student_max, _ = torch.max(s_logits, dim=-1, keepdim=True)
+    student_max = student_max.detach()
     torch.distributed.all_reduce(student_max, op=torch.distributed.ReduceOp.MAX, group=tp_group)
     output_student = s_logits - student_max
     denom_student = torch.sum(torch.exp(output_student), dim=-1, keepdim=True)
-    torch.distributed.all_reduce(denom_student, op=torch.distributed.ReduceOp.SUM, group=tp_group)
+    denom_student = dist_nn_func.all_reduce(denom_student, op=torch.distributed.ReduceOp.SUM, group=tp_group)
     student_log_prob = output_student - torch.log(denom_student.clamp(min=1e-12))
 
     # --- Per-token sum(P * log Q): local accumulate then global reduce ---
     # Mask -inf student logits so that 0 * -inf does not produce NaN.
     inf_mask = torch.isinf(s_logits)
     ce_local = torch.masked_fill(teacher_prob * student_log_prob, inf_mask, 0.0).sum(dim=-1)
-    torch.distributed.all_reduce(ce_local, op=torch.distributed.ReduceOp.SUM, group=tp_group)
+    ce_local = dist_nn_func.all_reduce(ce_local, op=torch.distributed.ReduceOp.SUM, group=tp_group)
 
     return ce_local  # shape: [valid_tokens]
 

--- a/nemo_automodel/recipes/vlm/kd.py
+++ b/nemo_automodel/recipes/vlm/kd.py
@@ -142,6 +142,44 @@ def _verify_tokenizer_compatibility(student_cfg, teacher_cfg, trust_remote_code=
     del student_tokenizer, teacher_tokenizer
 
 
+def _get_model_input_embedding_dim(model: torch.nn.Module) -> int | None:
+    """Return the model input embedding width when it can be inferred."""
+    get_input_embeddings = getattr(model, "get_input_embeddings", None)
+    if callable(get_input_embeddings):
+        embeddings = get_input_embeddings()
+        if embeddings is not None:
+            embedding_dim = getattr(embeddings, "embedding_dim", None)
+            if embedding_dim is not None:
+                return int(embedding_dim)
+            weight = getattr(embeddings, "weight", None)
+            if isinstance(weight, torch.Tensor) and weight.ndim >= 2:
+                return int(weight.shape[-1])
+
+    config = getattr(model, "config", None)
+    text_config = getattr(config, "text_config", None)
+    for cfg in (text_config, config):
+        hidden_size = getattr(cfg, "hidden_size", None)
+        if hidden_size is not None:
+            return int(hidden_size)
+    return None
+
+
+def _validate_cp_pre_embed_teacher_compatibility(inputs_embeds: torch.Tensor, teacher_model: torch.nn.Module) -> None:
+    """Reject CP pre-embed when the teacher cannot consume the student's embedding width."""
+    teacher_hidden_size = _get_model_input_embedding_dim(teacher_model)
+    if teacher_hidden_size is None:
+        return
+
+    student_hidden_size = int(inputs_embeds.shape[-1])
+    if student_hidden_size != teacher_hidden_size:
+        raise ValueError(
+            "VLM KD with context parallelism pre-embeds multimodal inputs with the student model before CP "
+            "sharding, so teacher and student input embedding hidden sizes must match. "
+            f"Got student inputs_embeds hidden size {student_hidden_size} and teacher input embedding hidden "
+            f"size {teacher_hidden_size}."
+        )
+
+
 class KnowledgeDistillationRecipeForVLM(FinetuneRecipeForVLM):
     """Fine-tune a student VLM via knowledge distillation from a teacher VLM."""
 
@@ -206,6 +244,8 @@ class KnowledgeDistillationRecipeForVLM(FinetuneRecipeForVLM):
             mm_kwargs = {k: batch[k] for k in VLM_INPUT_KEYS if batch.get(k) is not None}
             with torch.no_grad():
                 prepared = _model(_pre_embed_only=True, **mm_kwargs)
+            if "inputs_embeds" in prepared:
+                _validate_cp_pre_embed_teacher_compatibility(prepared["inputs_embeds"], self.teacher_model)
             for k in VLM_INPUT_KEYS:
                 batch.pop(k, None)
             batch.update(prepared)

--- a/tests/unit_tests/recipes/test_vlm_kd_tp_cp_correctness.py
+++ b/tests/unit_tests/recipes/test_vlm_kd_tp_cp_correctness.py
@@ -220,3 +220,90 @@ def test_vlm_kd_cp_rejects_teacher_student_hidden_size_mismatch(monkeypatch):
             num_batches=1,
             is_train=False,
         )
+
+
+class _WeightOnlyEmbedding(nn.Module):
+    """Embedding-like module exposing only ``weight`` (no ``embedding_dim``)."""
+
+    def __init__(self, num_embeddings: int, hidden: int):
+        super().__init__()
+        self.weight = nn.Parameter(torch.empty(num_embeddings, hidden))
+
+
+class _ModelWithWeightOnlyEmbedding(nn.Module):
+    def __init__(self, hidden: int):
+        super().__init__()
+        self._emb = _WeightOnlyEmbedding(5, hidden)
+
+    def get_input_embeddings(self):
+        return self._emb
+
+
+class _ModelWithDegenerateEmbedding(nn.Module):
+    """Embedding lookup returns something with no usable shape info."""
+
+    def __init__(self):
+        super().__init__()
+
+    def get_input_embeddings(self):
+        # No embedding_dim and weight is 1-D, so both inner checks fail.
+        emb = nn.Module()
+        emb.weight = nn.Parameter(torch.empty(4))
+        return emb
+
+
+class _ModelWithTextConfig(nn.Module):
+    def __init__(self, text_hidden: int, outer_hidden: int | None = None):
+        super().__init__()
+        self.config = SimpleNamespace(
+            text_config=SimpleNamespace(hidden_size=text_hidden),
+            hidden_size=outer_hidden,
+        )
+
+
+class _ModelWithOuterConfigOnly(nn.Module):
+    def __init__(self, outer_hidden: int):
+        super().__init__()
+        # No text_config attribute at all.
+        self.config = SimpleNamespace(hidden_size=outer_hidden)
+
+
+class _ModelWithNoEmbeddingOrConfig(nn.Module):
+    pass
+
+
+def test_get_model_input_embedding_dim_uses_embedding_dim_when_available():
+    model = _StudentVLM(hidden_size=17)
+    assert vlm_kd._get_model_input_embedding_dim(model) == 17
+
+
+def test_get_model_input_embedding_dim_falls_back_to_weight_shape():
+    model = _ModelWithWeightOnlyEmbedding(hidden=13)
+    assert vlm_kd._get_model_input_embedding_dim(model) == 13
+
+
+def test_get_model_input_embedding_dim_prefers_text_config_hidden_size():
+    model = _ModelWithDegenerateEmbedding()
+    model.config = SimpleNamespace(
+        text_config=SimpleNamespace(hidden_size=21),
+        hidden_size=999,
+    )
+    assert vlm_kd._get_model_input_embedding_dim(model) == 21
+
+
+def test_get_model_input_embedding_dim_uses_outer_config_when_no_text_config():
+    model = _ModelWithOuterConfigOnly(outer_hidden=19)
+    assert vlm_kd._get_model_input_embedding_dim(model) == 19
+
+
+def test_get_model_input_embedding_dim_returns_none_when_unknown():
+    model = _ModelWithNoEmbeddingOrConfig()
+    assert vlm_kd._get_model_input_embedding_dim(model) is None
+
+
+def test_validate_cp_pre_embed_skips_when_teacher_hidden_size_unknown(monkeypatch):
+    monkeypatch.setattr(vlm_kd, "_get_model_input_embedding_dim", lambda model: None)
+    inputs_embeds = torch.zeros(1, 4, 8)
+    teacher = _ModelWithNoEmbeddingOrConfig()
+    # Should be a no-op (no exception) when teacher hidden size cannot be inferred.
+    assert vlm_kd._validate_cp_pre_embed_teacher_compatibility(inputs_embeds, teacher) is None

--- a/tests/unit_tests/recipes/test_vlm_kd_tp_cp_correctness.py
+++ b/tests/unit_tests/recipes/test_vlm_kd_tp_cp_correctness.py
@@ -1,0 +1,222 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+from nemo_automodel.components.loss import kd_loss as kd_loss_module
+from nemo_automodel.components.loss.kd_loss import KDLoss
+from nemo_automodel.recipes.vlm import kd as vlm_kd
+
+
+class _MeshDim:
+    def __init__(self, size: int):
+        self._size = size
+
+    def size(self) -> int:
+        return self._size
+
+
+class _DeviceMesh:
+    mesh_dim_names = ("cp", "tp")
+
+    def __init__(self, *, cp_size: int = 1, tp_size: int = 1):
+        self._dims = {"cp": _MeshDim(cp_size), "tp": _MeshDim(tp_size)}
+
+    def __getitem__(self, key: str) -> _MeshDim:
+        return self._dims[key]
+
+
+class _StudentVLM(nn.Module):
+    def __init__(self, *, hidden_size: int = 8, vocab_size: int = 11):
+        super().__init__()
+        self.embedding = nn.Embedding(32, hidden_size)
+        self.proj = nn.Linear(hidden_size, vocab_size, bias=False)
+        self.pre_embed_calls = []
+        self.forward_calls = []
+
+    def get_input_embeddings(self):
+        return self.embedding
+
+    def prepare_model_inputs_for_cp(self, **kwargs):
+        return {"inputs_embeds": self.embedding(kwargs["input_ids"])}
+
+    def forward(self, _pre_embed_only: bool = False, input_ids=None, inputs_embeds=None, **kwargs):
+        if _pre_embed_only:
+            self.pre_embed_calls.append(dict(kwargs, input_ids=input_ids))
+            return self.prepare_model_inputs_for_cp(input_ids=input_ids, **kwargs)
+
+        self.forward_calls.append({"input_ids": input_ids, "inputs_embeds": inputs_embeds, **kwargs})
+        if inputs_embeds is None:
+            inputs_embeds = self.embedding(input_ids)
+        return SimpleNamespace(logits=self.proj(inputs_embeds), hidden_states=None)
+
+
+class _TeacherVLM(nn.Module):
+    def __init__(self, *, hidden_size: int = 8, vocab_size: int = 11):
+        super().__init__()
+        self.embedding = nn.Embedding(32, hidden_size)
+        self.proj = nn.Linear(hidden_size, vocab_size, bias=False)
+        self.forward_calls = []
+
+    def get_input_embeddings(self):
+        return self.embedding
+
+    def forward(self, input_ids=None, inputs_embeds=None, **kwargs):
+        self.forward_calls.append({"input_ids": input_ids, "inputs_embeds": inputs_embeds, **kwargs})
+        if inputs_embeds is None:
+            inputs_embeds = self.embedding(input_ids)
+        return SimpleNamespace(logits=self.proj(inputs_embeds), hidden_states=None)
+
+
+def _make_recipe(*, student: nn.Module, teacher: nn.Module, kd_loss_fn: KDLoss, device_mesh=None):
+    recipe = object.__new__(vlm_kd.KnowledgeDistillationRecipeForVLM)
+    recipe.dist_env = SimpleNamespace(device=torch.device("cpu"))
+    recipe.device_mesh = device_mesh
+    recipe.pp_enabled = False
+    recipe.model_parts = [student]
+    recipe.teacher_model = teacher
+    recipe.loss_fn = nn.CrossEntropyLoss(ignore_index=-100)
+    recipe.kd_loss_fn = kd_loss_fn
+    recipe.kd_ratio = 1.0
+    recipe.distributed_config = SimpleNamespace(defer_fsdp_grad_sync=False)
+    recipe._ce_loss_buffer = []
+    recipe._kd_loss_buffer = []
+    recipe._get_dp_group_size = lambda include_cp=False: 1
+    return recipe
+
+
+def _batch():
+    return {
+        "input_ids": torch.tensor([[1, 2, 3, 4]]),
+        "pixel_values": torch.ones(1, 3, 2, 2),
+        "attention_mask": torch.ones(1, 4),
+        "labels": torch.tensor([[1, 2, -100, 4]]),
+    }
+
+
+@pytest.fixture(scope="module")
+def trivial_pg(tmp_path_factory):
+    if not torch.distributed.is_available():
+        pytest.skip("torch.distributed not available")
+    if not torch.distributed.is_initialized():
+        store_path = tmp_path_factory.mktemp("dist") / "store"
+        torch.distributed.init_process_group(
+            backend="gloo",
+            init_method=f"file://{store_path}",
+            rank=0,
+            world_size=1,
+        )
+    return torch.distributed.group.WORLD
+
+
+def test_vlm_kd_uses_tp_kd_loss_path(monkeypatch, trivial_pg):
+    original_kl_forward_tp = kd_loss_module._kl_forward_tp
+    tp_calls = []
+
+    def wrapped_kl_forward_tp(t_logits, s_logits, tp_group):
+        tp_calls.append((t_logits.shape, s_logits.shape, tp_group))
+        return original_kl_forward_tp(t_logits, s_logits, tp_group)
+
+    monkeypatch.setattr(kd_loss_module, "_kl_forward_tp", wrapped_kl_forward_tp)
+    monkeypatch.setattr(vlm_kd, "get_sync_ctx", lambda *args, **kwargs: nullcontext())
+
+    student = _StudentVLM()
+    teacher = _TeacherVLM()
+    recipe = _make_recipe(student=student, teacher=teacher, kd_loss_fn=KDLoss(tp_group=trivial_pg))
+    loss_buffer = []
+
+    recipe._forward_backward_step(
+        0,
+        _batch(),
+        loss_buffer=loss_buffer,
+        num_label_tokens=3,
+        num_batches=1,
+        is_train=True,
+    )
+
+    assert len(tp_calls) == 1
+    assert tp_calls[0][2] is trivial_pg
+    assert student.proj.weight.grad is not None
+    assert len(loss_buffer) == 1
+    assert torch.isfinite(loss_buffer[0])
+
+
+def test_vlm_kd_cp_prepare_feeds_student_inputs_embeds_to_cp_and_teacher(monkeypatch):
+    make_cp_calls = []
+
+    def fake_make_cp_batch_and_ctx(device_mesh, batch):
+        make_cp_calls.append((device_mesh, dict(batch)))
+        return nullcontext, batch
+
+    monkeypatch.setattr(vlm_kd, "make_cp_batch_and_ctx", fake_make_cp_batch_and_ctx)
+
+    student = _StudentVLM(hidden_size=8)
+    teacher = _TeacherVLM(hidden_size=8)
+    recipe = _make_recipe(
+        student=student,
+        teacher=teacher,
+        kd_loss_fn=KDLoss(),
+        device_mesh=_DeviceMesh(cp_size=2),
+    )
+    loss_buffer = []
+
+    recipe._forward_backward_step(
+        0,
+        _batch(),
+        loss_buffer=loss_buffer,
+        num_label_tokens=3,
+        num_batches=1,
+        is_train=False,
+    )
+
+    assert len(student.pre_embed_calls) == 1
+    assert len(make_cp_calls) == 1
+    cp_batch = make_cp_calls[0][1]
+    assert "inputs_embeds" in cp_batch
+    assert "input_ids" not in cp_batch
+    assert "pixel_values" not in cp_batch
+    assert "labels" in cp_batch
+    assert teacher.forward_calls[0]["inputs_embeds"] is cp_batch["inputs_embeds"]
+    assert teacher.forward_calls[0]["input_ids"] is None
+    assert torch.isfinite(loss_buffer[0])
+
+
+def test_vlm_kd_cp_rejects_teacher_student_hidden_size_mismatch(monkeypatch):
+    monkeypatch.setattr(vlm_kd, "make_cp_batch_and_ctx", lambda *args, **kwargs: pytest.fail("CP sharding skipped"))
+
+    student = _StudentVLM(hidden_size=8)
+    teacher = _TeacherVLM(hidden_size=12)
+    recipe = _make_recipe(
+        student=student,
+        teacher=teacher,
+        kd_loss_fn=KDLoss(),
+        device_mesh=_DeviceMesh(cp_size=2),
+    )
+
+    with pytest.raises(ValueError, match="teacher and student input embedding hidden sizes must match"):
+        recipe._forward_backward_step(
+            0,
+            _batch(),
+            loss_buffer=[],
+            num_label_tokens=3,
+            num_batches=1,
+            is_train=False,
+        )


### PR DESCRIPTION
# What does this PR do ?

Adds VLM KD correctness coverage for the existing non-PP TP and CP paths, and tightens the CP pre-embed edge case for teacher/student hidden-size mismatch.

# Changelog

- Add a VLM KD recipe-level test that verifies the TP KDLoss path is exercised and remains differentiable.
- Add a VLM KD CP smoke test that verifies student pre-embedded inputs flow through CP batch preparation and into the teacher forward.
- Add an explicit error for VLM KD CP pre-embed when teacher and student input embedding hidden sizes differ.
- Use autograd-aware TP reductions in KDLoss for differentiable student-side distributed softmax terms.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

# Additional Information

Validation run locally:

- ...............................                                          [100%]
=============================== warnings summary ===============================
.venv/lib/python3.12/site-packages/megatron_fsdp/utils.py:108
  /Users/liuyibo/Desktop/Automodel_lao.nosync/.venv/lib/python3.12/site-packages/megatron_fsdp/utils.py:108: UserWarning: Transformer Engine and Apex are not installed. Falling back to local implementations of multi_tensor_applier and multi_tensor_scale
    warnings.warn(

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

.venv/lib/python3.12/site-packages/torch/jit/_script.py:362: 14 warnings
  /Users/liuyibo/Desktop/Automodel_lao.nosync/.venv/lib/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
31 passed, 17 warnings in 4.85s
- All checks passed!
- 3 files already formatted
- 