### PR TITLE
fix: Remove Qwen3.5 packing known issue marker

### DIFF
--- a/examples/vlm_finetune/qwen3_5/qwen3_5_4b_neat_packing.yaml
+++ b/examples/vlm_finetune/qwen3_5/qwen3_5_4b_neat_packing.yaml
@@ -108,4 +108,3 @@ optimizer:
 
 ci:
   recipe_owner: HuiyingLi
-  known_issue_id: AM-158


### PR DESCRIPTION
## Summary
- Remove the `known_issue_id: AM-158` marker from the Qwen3.5 4B neat packing VLM finetune recipe.

## Why
- The recipe no longer needs to be marked as a known CI issue.

## Validation
- `git diff --check`
- `/opt/venv/bin/python tools/lint_example_yamls.py examples/vlm_finetune/qwen3_5/qwen3_5_4b_neat_packing.yaml`