### PR TITLE
fix(tests): stub _offload_teacher_model on VLM KD recipe fixture

### DIFF
--- a/tests/unit_tests/recipes/test_vlm_kd_tp_cp_correctness.py
+++ b/tests/unit_tests/recipes/test_vlm_kd_tp_cp_correctness.py
@@ -99,6 +99,7 @@ def _make_recipe(*, student: nn.Module, teacher: nn.Module, kd_loss_fn: KDLoss, 
     recipe.distributed_config = SimpleNamespace(defer_fsdp_grad_sync=False)
     recipe._ce_loss_buffer = []
     recipe._kd_loss_buffer = []
+    recipe._offload_teacher_model = False
     recipe._get_dp_group_size = lambda include_cp=False: 1
     return recipe
 


### PR DESCRIPTION
## What

Restores L0 unit-test job on ``main``. Both ``L0_Unit_Tests_CPU`` and
``L0_Unit_Tests_GPU`` are currently red with:

```
AttributeError: 'KnowledgeDistillationRecipeForVLM' object has no
attribute '_offload_teacher_model'
  at nemo_automodel/recipes/vlm/kd.py:272 in _forward_backward_step
```

#2211 added ``self._offload_teacher_model`` to ``setup()`` and reads it
in ``_forward_backward_step``. The fixture in
``tests/unit_tests/recipes/test_vlm_kd_tp_cp_correctness.py`` constructs
the recipe via ``object.__new__`` to skip distributed setup, so it must
stub every attribute that ``_forward_backward_step`` touches. The two
PRs (#2211 and #2215) landed independently and the missing stub only
surfaced after both were on main.

## Changelog

- Stub ``recipe._offload_teacher_model = False`` in ``_make_recipe`` so
  the non-offload code path the tests were designed for runs cleanly.

## Pre-checks

- [x] ``ruff format`` / ``ruff check``
- [x] All 9 tests in ``test_vlm_kd_tp_cp_correctness.py`` pass locally
- [x] DCO sign-off