### PR TITLE
[codex] Abstract LLM/VLM forward-backward step

### DIFF
--- a/nemo_automodel/components/training/forward_backward.py
+++ b/nemo_automodel/components/training/forward_backward.py
@@ -1,0 +1,161 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, MutableMapping
+from contextlib import nullcontext
+from typing import Any
+
+import torch
+
+from nemo_automodel.components.loss.linear_ce import FusedLinearCrossEntropy
+from nemo_automodel.components.training.model_output_utils import get_final_hidden_states
+
+
+def move_to_device(value: Any, device: torch.device) -> Any:
+    """Recursively move tensors in a batch value to ``device``."""
+    if isinstance(value, torch.Tensor):
+        return value.to(device, non_blocking=True)
+    if isinstance(value, dict):
+        return {key: move_to_device(item, device) if item is not None else None for key, item in value.items()}
+    if isinstance(value, list):
+        return [move_to_device(item, device) for item in value]
+    if isinstance(value, tuple):
+        return tuple(move_to_device(item, device) for item in value)
+    return value
+
+
+def forward_backward_step(
+    *,
+    idx: int,
+    batch: MutableMapping[str, Any],
+    device: torch.device,
+    device_mesh: Any,
+    model_parts: list[torch.nn.Module],
+    distributed_config: Any,
+    loss_fn: Callable[..., torch.Tensor] | None,
+    calculate_loss_fn: Callable[..., torch.Tensor],
+    loss_buffer: list[torch.Tensor],
+    num_label_tokens: int | None,
+    num_batches: int,
+    is_train: bool,
+    pp_enabled: bool,
+    pp: Any | None,
+    dp_group_size: int,
+    make_cp_batch_and_ctx_fn: Callable[..., tuple[Callable[[], Any], MutableMapping[str, Any]]],
+    get_sync_ctx_fn: Callable[..., Any],
+    filter_forward_kwargs_fn: Callable[[torch.nn.Module, MutableMapping[str, Any]], MutableMapping[str, Any]],
+    make_cp_batch_kwargs: dict[str, Any] | None = None,
+    prepare_batch_before_cp: Callable[[MutableMapping[str, Any]], MutableMapping[str, Any]] | None = None,
+    model_context_factory: Callable[[], Any] | None = None,
+    pp_batch_context_factory: Callable[[MutableMapping[str, Any]], Any] | None = None,
+    filter_pp_batch: bool = True,
+    pp_eval_enabled: bool = True,
+    pp_validation_skip_message: str = "Skipping forward pass for validation because pipeline parallelism is enabled",
+    hidden_states_error_message: str = (
+        "FusedLinearCrossEntropy requires the model to output hidden states. "
+        "Set `model.output_hidden_states=True` in the config."
+    ),
+) -> None:
+    """Run one LLM/VLM forward-backward step.
+
+    Recipes supply hooks for modality-specific preparation while sharing the
+    common CP, PP, loss, and backward control flow.
+    """
+    batch = {key: move_to_device(value, device) for key, value in batch.items()}
+
+    if prepare_batch_before_cp is not None:
+        batch = prepare_batch_before_cp(batch)
+
+    train_ctx, batch = make_cp_batch_and_ctx_fn(device_mesh, batch, **(make_cp_batch_kwargs or {}))
+    labels = batch.pop("labels")
+    model_ctx = model_context_factory() if model_context_factory is not None else nullcontext()
+
+    if pp_enabled:
+        if pp is None:
+            raise ValueError("pp must be provided when pp_enabled=True")
+        if not is_train and not pp_eval_enabled:
+            logging.info(pp_validation_skip_message)
+            return
+
+        with train_ctx(), model_ctx:
+            losses = [] if pp.info.has_last_stage else None
+            targets = labels.clone() if pp.info.has_last_stage else None
+
+            input_ids = batch.pop("input_ids")
+            pp.update_seq_len(input_ids.shape[1])
+
+            pp_batch = batch
+            if filter_pp_batch:
+                pp_batch = {
+                    key: value
+                    for key, value in batch.items()
+                    if value is not None and not (isinstance(value, dict) and len(value) == 0)
+                }
+
+            pp_batch_ctx = (
+                pp_batch_context_factory(pp_batch) if pp_batch_context_factory is not None else nullcontext()
+            )
+            schedule_fn = pp.info.schedule.step if is_train else pp.info.schedule.eval
+            with pp_batch_ctx:
+                if pp.info.has_first_stage:
+                    schedule_fn(input_ids, target=targets, losses=losses, **pp_batch)
+                else:
+                    schedule_fn(target=targets, losses=losses, **pp_batch)
+
+        if pp.info.has_last_stage:
+            local_loss = torch.sum(torch.stack(losses))
+        else:
+            local_loss = torch.tensor(0.0, device=device)
+        loss_buffer.append(local_loss.clone().detach())
+        return
+
+    model = model_parts[0]
+    sync_ctx = (
+        get_sync_ctx_fn(
+            model,
+            idx == num_batches - 1,
+            defer_fsdp_grad_sync=getattr(distributed_config, "defer_fsdp_grad_sync", True),
+        )
+        if is_train
+        else nullcontext()
+    )
+
+    with train_ctx(), sync_ctx, model_ctx:
+        batch = filter_forward_kwargs_fn(model, batch)
+        if isinstance(loss_fn, FusedLinearCrossEntropy):
+            out = model(logits_to_keep=1, **batch)
+            hidden_states = get_final_hidden_states(out)
+            if hidden_states is None:
+                raise ValueError(hidden_states_error_message)
+        else:
+            out = model(**batch)
+            hidden_states = get_final_hidden_states(out)
+
+        local_loss = calculate_loss_fn(
+            loss_fn,
+            logits=getattr(out, "logits", out),
+            labels=labels,
+            model=model,
+            hidden_states=hidden_states,
+            num_label_tokens=num_label_tokens,
+        )
+        loss_buffer.append(local_loss.clone().detach())
+        if is_train:
+            (local_loss * dp_group_size).backward()
+
+
+__all__ = ["forward_backward_step", "move_to_device"]

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -29,7 +29,6 @@ import inspect
 import logging
 import pathlib
 import time
-from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import torch
@@ -79,7 +78,7 @@ from nemo_automodel.components.moe.megatron.moe_utils import MoEAuxLossAutoScale
 from nemo_automodel.components.optim.scheduler import OptimizerParamScheduler
 from nemo_automodel.components.optim.utils import build_dion_optimizer, is_dion_optimizer
 from nemo_automodel.components.quantization.fp8 import build_fp8_config
-from nemo_automodel.components.training.model_output_utils import get_final_hidden_states
+from nemo_automodel.components.training.forward_backward import forward_backward_step
 from nemo_automodel.components.training.rng import ScopedRNG, StatefulRNG
 from nemo_automodel.components.training.step_scheduler import StepScheduler
 from nemo_automodel.components.training.utils import (
@@ -1334,101 +1333,41 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
         num_batches,
         is_train: bool = True,
     ):
-        # Move batch to device (handle both tensors and dicts of tensors like causal_mask_mapping)
-        batch = {
-            k: (
-                {dk: dv.to(self.dist_env.device, non_blocking=True) for dk, dv in v.items() if dv is not None}
-                if isinstance(v, dict)
-                else (v.to(self.dist_env.device, non_blocking=True) if isinstance(v, torch.Tensor) else v)
-            )
-            for k, v in batch.items()
-        }
-        train_ctx, batch = make_cp_batch_and_ctx(
-            self.device_mesh,
-            batch,
-            use_te=_uses_te_dot_product_attention(
-                self.model_parts[0] if hasattr(self, "model_parts") else self.cfg.model
-            )
-            and _uses_thd_collater(self.cfg.dataloader),
-            padding_token_id=self.tokenizer.pad_token_id if self.tokenizer else 0,
-            num_chunks=_get_num_thd_chunks(self.pp_enabled, self.cfg),
+        forward_backward_step(
+            idx=idx,
+            batch=batch,
+            device=self.dist_env.device,
+            device_mesh=self.device_mesh,
+            model_parts=getattr(self, "model_parts", []),
+            distributed_config=getattr(self, "distributed_config", None),
+            loss_fn=getattr(self, "loss_fn", None),
+            calculate_loss_fn=calculate_loss,
+            loss_buffer=loss_buffer,
+            num_label_tokens=num_label_tokens,
+            num_batches=num_batches,
+            is_train=is_train,
+            pp_enabled=self.pp_enabled,
+            pp=self.pp,
+            dp_group_size=1 if self.pp_enabled else self._get_dp_group_size(include_cp=True),
+            make_cp_batch_and_ctx_fn=make_cp_batch_and_ctx,
+            get_sync_ctx_fn=get_sync_ctx,
+            filter_forward_kwargs_fn=filter_forward_kwargs,
+            make_cp_batch_kwargs={
+                "use_te": _uses_te_dot_product_attention(
+                    self.model_parts[0] if hasattr(self, "model_parts") else self.cfg.model
+                )
+                and _uses_thd_collater(self.cfg.dataloader),
+                "padding_token_id": self.tokenizer.pad_token_id if self.tokenizer else 0,
+                "num_chunks": _get_num_thd_chunks(self.pp_enabled, self.cfg),
+            },
+            model_context_factory=self.te_fp8.maybe_te_autocast if self.te_fp8 is not None else None,
+            filter_pp_batch=True,
+            pp_eval_enabled=True,
+            hidden_states_error_message=(
+                "FusedLinearCrossEntropy requires the model to output hidden states. "
+                "Set `model.output_hidden_states=True` in the config."
+            ),
         )
-        labels = batch.pop("labels")
-        fp8_ctx = self.te_fp8.maybe_te_autocast() if self.te_fp8 is not None else nullcontext()
-
-        if self.pp_enabled:
-            with train_ctx(), fp8_ctx:
-                losses = [] if self.pp.info.has_last_stage else None
-                if self.pp.info.has_last_stage:
-                    masked_labels = labels.clone()
-                    targets = masked_labels
-                else:
-                    targets = None
-
-                input_ids = batch.pop("input_ids")
-
-                # Update PP stage shapes for the current batch's seq_len.
-                # This is a no-op when the length hasn't changed.
-                self.pp.update_seq_len(input_ids.shape[1])
-
-                # Filter out None values and empty dicts from batch to avoid PP chunking errors
-                batch_filtered = {
-                    k: v for k, v in batch.items() if v is not None and not (isinstance(v, dict) and len(v) == 0)
-                }
-
-                if is_train:
-                    # Use step for training (forward + backward)
-                    if self.pp.info.has_first_stage:
-                        self.pp.info.schedule.step(input_ids, target=targets, losses=losses, **batch_filtered)
-                    else:
-                        self.pp.info.schedule.step(target=targets, losses=losses, **batch_filtered)
-                else:
-                    # Use eval for validation (forward only, no backward)
-                    if self.pp.info.has_first_stage:
-                        self.pp.info.schedule.eval(input_ids, target=targets, losses=losses, **batch_filtered)
-                    else:
-                        self.pp.info.schedule.eval(target=targets, losses=losses, **batch_filtered)
-
-            if self.pp.info.has_last_stage:
-                local_loss = torch.sum(torch.stack(losses))
-            else:
-                local_loss = torch.tensor(0.0, device=self.dist_env.device)
-
-            loss_buffer.append(local_loss.clone().detach())
-        else:
-            model = self.model_parts[0]
-            sync_ctx = (
-                get_sync_ctx(
-                    model,
-                    idx == num_batches - 1,
-                    defer_fsdp_grad_sync=getattr(self.distributed_config, "defer_fsdp_grad_sync", True),
-                )
-                if is_train
-                else nullcontext()
-            )
-            with train_ctx(), sync_ctx, fp8_ctx:
-                batch = filter_forward_kwargs(model, batch)
-                if isinstance(self.loss_fn, FusedLinearCrossEntropy):
-                    # use num_logits_to_keep to avoid full logits matrix in memory
-                    out = model(logits_to_keep=1, **batch)
-                    if "hidden_states" not in out:
-                        raise ValueError(
-                            "FusedLinearCrossEntropy requires the model to output hidden states. Set `model.output_hidden_states=True` in the config."
-                        )
-                else:
-                    out = model(**batch)
-
-                local_loss = calculate_loss(
-                    self.loss_fn,
-                    logits=getattr(out, "logits", out),
-                    labels=labels,
-                    model=model,
-                    hidden_states=get_final_hidden_states(out),
-                    num_label_tokens=num_label_tokens,
-                )
-                loss_buffer.append(local_loss.clone().detach())
-                if is_train:
-                    (local_loss * self._get_dp_group_size(include_cp=True)).backward()
 
     def _run_train_optim_step(self, batches, max_grad_norm: Optional[float] = None):
         """Execute a single training step.

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -795,6 +795,7 @@ class FinetuneRecipeForVLM(BaseRecipe):
                 seed=self.cfg.get("seed", 42),
                 local_batch_size=self.cfg.get("step_scheduler.local_batch_size", 1),
                 get_rope_index=get_rope_index,
+                pp_n_microbatches=pp_n_microbatches,
             )
 
         self.best_metric_key = self.cfg.get("checkpoint.best_metric_key", "default")
@@ -852,12 +853,9 @@ class FinetuneRecipeForVLM(BaseRecipe):
 
                     val_loss = {}
                     if self.step_scheduler.is_val_step and self.val_dataloader is not None:
-                        if self.pp_enabled:
-                            logger.warning("Validation is not supported for pipeline parallelism")
-                        else:
-                            val_log_data = self._run_validation_epoch(self.val_dataloader)
-                            val_loss["val_loss"] = val_log_data.metrics["val_loss"]
-                            self.log_val_metrics(val_log_data)
+                        val_log_data = self._run_validation_epoch(self.val_dataloader)
+                        val_loss["val_loss"] = val_log_data.metrics["val_loss"]
+                        self.log_val_metrics(val_log_data)
                         for mp in self.model_parts:
                             mp.train()
 
@@ -932,12 +930,25 @@ class FinetuneRecipeForVLM(BaseRecipe):
             prepare_batch_before_cp=self._prepare_vlm_batch_for_cp,
             pp_batch_context_factory=lambda pp_batch: stage_vlm_media_for_pp(self.pp, self.model_parts, pp_batch),
             filter_pp_batch=False,
-            pp_eval_enabled=False,
+            pp_eval_enabled=True,
             hidden_states_error_message=(
                 "FusedLinearCrossEntropy requires the model to output hidden states. "
                 "Set `model.text_config.output_hidden_states=True` in the config."
             ),
         )
+
+    def _get_pp_last_stage_rank_for_reporting(self):
+        if self.device_mesh is not None and "pp" in self.device_mesh.mesh_dim_names:
+            dim_names = list(self.device_mesh.mesh_dim_names)
+            mesh = self.device_mesh.mesh
+            idx = []
+            for name in dim_names:
+                if name == "pp":
+                    idx.append(-1)
+                else:
+                    idx.append(0)
+            return mesh[tuple(idx)].item()
+        return self.device_mesh.mesh.reshape(-1)[-1].item()
 
     def _run_train_optim_step(self, batches, max_grad_norm: Optional[float] = None):
         """Execute a single training step.
@@ -1049,18 +1060,7 @@ class FinetuneRecipeForVLM(BaseRecipe):
             reporting_loss = reporting_loss.float().to(self.dist_env.device)
             # Send loss to first rank from the last PP stage of rank0's mesh coords.
             # This avoids picking a global-rank sender from a different EP/PP group.
-            if self.device_mesh is not None and "pp" in self.device_mesh.mesh_dim_names:
-                dim_names = list(self.device_mesh.mesh_dim_names)
-                mesh = self.device_mesh.mesh
-                idx = []
-                for name in dim_names:
-                    if name == "pp":
-                        idx.append(-1)
-                    else:
-                        idx.append(0)
-                src_rank = mesh[tuple(idx)].item()
-            else:
-                src_rank = self.device_mesh.mesh.reshape(-1)[-1].item()
+            src_rank = self._get_pp_last_stage_rank_for_reporting()
             if self.dist_env.rank == src_rank:
                 torch.distributed.send(reporting_loss, dst=0)
             elif self.dist_env.is_main:
@@ -1091,60 +1091,42 @@ class FinetuneRecipeForVLM(BaseRecipe):
             for mp in self.model_parts:
                 mp.eval()
 
-            total_loss = 0.0
-            total_tokens = 0
+            total_loss = torch.tensor(0.0, dtype=torch.float32, device=self.dist_env.device)
             total_num_label_tokens = 0
             for batch in val_dataloader:
-                batch = {
-                    k: (v.to(self.dist_env.device, non_blocking=True) if isinstance(v, torch.Tensor) else v)
-                    for k, v in batch.items()
-                }
+                loss_buffer = []
                 num_label_tokens = (batch["labels"] != -100).sum().item()
-
-                _model = self.model_parts[0]
-                _cp_active = (
-                    self.device_mesh is not None
-                    and "cp" in getattr(self.device_mesh, "mesh_dim_names", ())
-                    and self.device_mesh["cp"].size() > 1
-                    and not self.pp_enabled
+                self._forward_backward_step(
+                    0,
+                    batch,
+                    loss_buffer=loss_buffer,
+                    num_label_tokens=None,
+                    num_batches=1,
+                    is_train=False,
                 )
-                if _cp_active and hasattr(_model, "prepare_model_inputs_for_cp"):
-                    mm_kwargs = {k: batch[k] for k in VLM_INPUT_KEYS if batch.get(k) is not None}
-                    with torch.no_grad():
-                        prepared = _model(_pre_embed_only=True, **mm_kwargs)
-                    for k in VLM_INPUT_KEYS:
-                        batch.pop(k, None)
-                    batch.update(prepared)
-
-                train_ctx, batch = make_cp_batch_and_ctx(self.device_mesh, batch)
-                labels = batch.pop("labels")
-                with train_ctx():
-                    batch = filter_forward_kwargs(self.model_parts[0], batch)
-                    if isinstance(self.loss_fn, FusedLinearCrossEntropy):
-                        out = self.model_parts[0](logits_to_keep=1, **batch)
-                    else:
-                        out = self.model_parts[0](**batch)
-                    local_loss = calculate_loss(
-                        self.loss_fn,
-                        logits=getattr(out, "logits", out),
-                        labels=labels,
-                        model=self.model_parts[0],
-                        hidden_states=out.hidden_states[-1]
-                        if getattr(out, "hidden_states", None) is not None
-                        else None,
-                        num_label_tokens=num_label_tokens,
-                    )
-                    total_num_label_tokens += num_label_tokens
-
-                total_loss += local_loss.item() * num_label_tokens
-                total_tokens += num_label_tokens
+                total_loss += torch.sum(torch.stack(loss_buffer)).item()
+                total_num_label_tokens += num_label_tokens
 
         # Aggregate across ranks if distributed is initialized
-        total_loss = self._dp_allreduce(torch.FloatTensor([total_loss]), include_cp=True).item()
-        total_tokens = self._dp_allreduce(torch.LongTensor([total_tokens]), include_cp=True).item()
-        total_num_label_tokens = self._dp_allreduce(torch.LongTensor([total_num_label_tokens])).item()
+        total_loss = self._dp_allreduce(total_loss, include_cp=True)
+        total_num_label_tokens = self._dp_allreduce(
+            torch.tensor(total_num_label_tokens, dtype=torch.long, device=self.dist_env.device)
+        ).item()
+        val_loss = total_loss / max(total_num_label_tokens, 1e-8)
 
-        val_loss = total_loss / max(total_tokens, 1e-8)
+        if self.pp_enabled:
+            val_loss = val_loss.to(self.dist_env.device)
+            pp_num_tokens = torch.tensor(total_num_label_tokens, dtype=torch.long, device=self.dist_env.device)
+            src_rank = self._get_pp_last_stage_rank_for_reporting()
+            if self.dist_env.rank == src_rank:
+                torch.distributed.send(val_loss, dst=0)
+                torch.distributed.send(pp_num_tokens, dst=0)
+            elif self.dist_env.is_main:
+                torch.distributed.recv(val_loss, src=src_rank)
+                torch.distributed.recv(pp_num_tokens, src=src_rank)
+                total_num_label_tokens = pp_num_tokens.item()
+
+        val_loss = val_loss.item() if isinstance(val_loss, torch.Tensor) else val_loss
 
         return MetricsSample(
             step=self.step_scheduler.step,

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -28,7 +28,6 @@ except ImportError:
 import logging
 import pathlib
 import time
-from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import torch
@@ -67,6 +66,7 @@ from nemo_automodel.components.loss.masked_ce import MaskedCrossEntropy
 from nemo_automodel.components.moe.megatron.moe_utils import MoEAuxLossAutoScaler
 from nemo_automodel.components.optim.scheduler import OptimizerParamScheduler
 from nemo_automodel.components.quantization.fp8 import build_fp8_config
+from nemo_automodel.components.training.forward_backward import forward_backward_step
 from nemo_automodel.components.training.rng import ScopedRNG, StatefulRNG
 from nemo_automodel.components.training.step_scheduler import StepScheduler
 from nemo_automodel.components.training.utils import (
@@ -252,18 +252,6 @@ def build_loss_fn(cfg_loss):
         The instantiated loss function.
     """
     return cfg_loss.instantiate()
-
-
-def _move_to_device(value: Any, device: torch.device) -> Any:
-    if isinstance(value, torch.Tensor):
-        return value.to(device, non_blocking=True)
-    if isinstance(value, dict):
-        return {k: _move_to_device(v, device) if v is not None else None for k, v in value.items()}
-    if isinstance(value, list):
-        return [_move_to_device(v, device) for v in value]
-    if isinstance(value, tuple):
-        return tuple(_move_to_device(v, device) for v in value)
-    return value
 
 
 def build_dataloader(
@@ -893,6 +881,25 @@ class FinetuneRecipeForVLM(BaseRecipe):
         self.checkpointer.close()
 
     # ------------------ helpers ------------------
+    def _prepare_vlm_batch_for_cp(self, batch):
+        # Routed through __call__ so FSDP2 forward pre-hook fires and
+        # unshards the vision tower's weights before the embed/scatter.
+        model = self.model_parts[0]
+        cp_active = (
+            self.device_mesh is not None
+            and "cp" in getattr(self.device_mesh, "mesh_dim_names", ())
+            and self.device_mesh["cp"].size() > 1
+            and not self.pp_enabled
+        )
+        if cp_active and hasattr(model, "prepare_model_inputs_for_cp"):
+            mm_kwargs = {k: batch[k] for k in VLM_INPUT_KEYS if batch.get(k) is not None}
+            with torch.no_grad():
+                prepared = model(_pre_embed_only=True, **mm_kwargs)
+            for key in VLM_INPUT_KEYS:
+                batch.pop(key, None)
+            batch.update(prepared)
+        return batch
+
     def _forward_backward_step(
         self,
         idx,
@@ -903,91 +910,34 @@ class FinetuneRecipeForVLM(BaseRecipe):
         num_batches,
         is_train: bool = True,
     ):
-        batch = {k: _move_to_device(v, self.dist_env.device) for k, v in batch.items()}
-
-        # Routed through __call__ so FSDP2 forward pre-hook fires and
-        # unshards the vision tower's weights before the embed/scatter.
-        _model = self.model_parts[0]
-        _cp_active = (
-            self.device_mesh is not None
-            and "cp" in getattr(self.device_mesh, "mesh_dim_names", ())
-            and self.device_mesh["cp"].size() > 1
-            and not self.pp_enabled
+        forward_backward_step(
+            idx=idx,
+            batch=batch,
+            device=self.dist_env.device,
+            device_mesh=self.device_mesh,
+            model_parts=self.model_parts,
+            distributed_config=self.distributed_config,
+            loss_fn=self.loss_fn,
+            calculate_loss_fn=calculate_loss,
+            loss_buffer=loss_buffer,
+            num_label_tokens=num_label_tokens,
+            num_batches=num_batches,
+            is_train=is_train,
+            pp_enabled=self.pp_enabled,
+            pp=getattr(self, "pp", None),
+            dp_group_size=1 if self.pp_enabled else self._get_dp_group_size(include_cp=True),
+            make_cp_batch_and_ctx_fn=make_cp_batch_and_ctx,
+            get_sync_ctx_fn=get_sync_ctx,
+            filter_forward_kwargs_fn=filter_forward_kwargs,
+            prepare_batch_before_cp=self._prepare_vlm_batch_for_cp,
+            pp_batch_context_factory=lambda pp_batch: stage_vlm_media_for_pp(self.pp, self.model_parts, pp_batch),
+            filter_pp_batch=False,
+            pp_eval_enabled=False,
+            hidden_states_error_message=(
+                "FusedLinearCrossEntropy requires the model to output hidden states. "
+                "Set `model.text_config.output_hidden_states=True` in the config."
+            ),
         )
-        if _cp_active and hasattr(_model, "prepare_model_inputs_for_cp"):
-            mm_kwargs = {k: batch[k] for k in VLM_INPUT_KEYS if batch.get(k) is not None}
-            with torch.no_grad():
-                prepared = _model(_pre_embed_only=True, **mm_kwargs)
-            for k in VLM_INPUT_KEYS:
-                batch.pop(k, None)
-            batch.update(prepared)
-
-        train_ctx, batch = make_cp_batch_and_ctx(self.device_mesh, batch)
-        labels = batch.pop("labels")
-
-        if self.pp_enabled:
-            if not is_train:
-                logging.info("Skipping forward pass for validation because pipeline parallelism is enabled")
-                return
-
-            with train_ctx():
-                losses = [] if self.pp.info.has_last_stage else None
-                if self.pp.info.has_last_stage:
-                    masked_labels = labels.clone()
-                    targets = masked_labels
-                else:
-                    targets = None
-
-                input_ids = batch.pop("input_ids")
-                self.pp.update_seq_len(input_ids.shape[1])
-
-                with stage_vlm_media_for_pp(self.pp, self.model_parts, batch):
-                    if self.pp.info.has_first_stage:
-                        self.pp.info.schedule.step(input_ids, target=targets, losses=losses, **batch)
-                    else:
-                        self.pp.info.schedule.step(target=targets, losses=losses, **batch)
-
-            if self.pp.info.has_last_stage:
-                local_loss = torch.sum(torch.stack(losses))
-            else:
-                local_loss = torch.tensor(0.0, device=self.dist_env.device)
-
-            loss_buffer.append(local_loss.clone().detach())
-        else:
-            model = self.model_parts[0]
-            sync_ctx = (
-                get_sync_ctx(
-                    model,
-                    idx == num_batches - 1,
-                    defer_fsdp_grad_sync=getattr(self.distributed_config, "defer_fsdp_grad_sync", True),
-                )
-                if is_train
-                else nullcontext()
-            )
-            with sync_ctx, train_ctx():
-                batch = filter_forward_kwargs(model, batch)
-                if isinstance(self.loss_fn, FusedLinearCrossEntropy):
-                    # use num_logits_to_keep to avoid full logits matrix in memory
-                    out = model(logits_to_keep=1, **batch)
-                    if "hidden_states" not in out:
-                        raise ValueError(
-                            "FusedLinearCrossEntropy requires the model to output hidden states. "
-                            "Set `model.text_config.output_hidden_states=True` in the config."
-                        )
-                else:
-                    out = model(**batch)
-
-                local_loss = calculate_loss(
-                    self.loss_fn,
-                    logits=getattr(out, "logits", out),
-                    labels=labels,
-                    model=model,
-                    hidden_states=out.hidden_states[-1] if getattr(out, "hidden_states", None) is not None else None,
-                    num_label_tokens=num_label_tokens,
-                )
-                loss_buffer.append(local_loss.clone().detach())
-                if is_train:
-                    (local_loss * self._get_dp_group_size(include_cp=True)).backward()
 
     def _run_train_optim_step(self, batches, max_grad_norm: Optional[float] = None):
         """Execute a single training step.

--- a/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
+++ b/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
@@ -1374,13 +1374,14 @@ class _MockPPInfo:
         self.schedule = MagicMock()
         self.schedule._n_microbatches = n_microbatches
 
-        def step_side_effect(*args, **kwargs):
+        def schedule_side_effect(*args, **kwargs):
             if self._add_losses and kwargs.get("losses") is not None:
                 # Add mock losses for each microbatch
                 for _ in range(n_microbatches):
                     kwargs["losses"].append(torch.tensor(0.5))
 
-        self.schedule.step = MagicMock(side_effect=step_side_effect)
+        self.schedule.step = MagicMock(side_effect=schedule_side_effect)
+        self.schedule.eval = MagicMock(side_effect=schedule_side_effect)
 
 
 class _MockAutoPipeline:
@@ -1431,8 +1432,8 @@ class TestForwardBackwardStepPP:
         """Create a recipe configured for PP testing."""
         return _create_pp_recipe()
 
-    def test_pp_skips_validation_forward(self, pp_recipe, monkeypatch):
-        """Test that PP mode skips forward pass during validation."""
+    def test_pp_uses_eval_for_validation(self, pp_recipe, monkeypatch):
+        """Test that PP mode uses schedule.eval() during validation."""
         pp_recipe.pp = _MockAutoPipeline()
 
         monkeypatch.setattr(
@@ -1446,7 +1447,6 @@ class TestForwardBackwardStepPP:
         }
         loss_buffer = []
 
-        # Should return early without error
         pp_recipe._forward_backward_step(
             idx=0,
             batch=batch,
@@ -1456,8 +1456,10 @@ class TestForwardBackwardStepPP:
             is_train=False,  # Validation mode
         )
 
-        # Loss buffer should be empty (no forward pass)
-        assert len(loss_buffer) == 0
+        pp_recipe.pp.info.schedule.eval.assert_called_once()
+        pp_recipe.pp.info.schedule.step.assert_not_called()
+        assert len(loss_buffer) == 1
+        assert torch.isclose(loss_buffer[0], torch.tensor(1.0))
 
     def test_pp_vlm_chunking_equal_images_and_batch(self, pp_recipe, monkeypatch):
         """Test VLM pixel_values chunking when n_images == batch_size."""
@@ -1953,6 +1955,43 @@ class TestForwardBackwardStepPP:
         args, kwargs = step_calls[0]
         assert len(args) == 0  # No positional args
         assert "target" in kwargs
+
+
+@pytest.mark.cuda(False)
+def test_vlm_run_validation_epoch_pp_sends_loss_from_last_stage(monkeypatch):
+    """VLM PP validation should reuse _forward_backward_step and report from the last stage."""
+    recipe = _create_pp_recipe()
+    recipe.dist_env = SimpleNamespace(device=torch.device("cpu"), rank=1, is_main=False)
+    recipe.device_mesh = SimpleNamespace(mesh=torch.tensor([[0, 1]]), mesh_dim_names=("dp", "pp"))
+    recipe.step_scheduler = SimpleNamespace(step=7, epoch=2)
+    recipe.optimizer = [SimpleNamespace(param_groups=[{"lr": 0.01}])]
+    recipe._dp_allreduce = lambda tensor, include_cp=False: tensor
+
+    calls = []
+
+    def fake_forward_backward_step(idx, batch, *, loss_buffer, num_label_tokens, num_batches, is_train):
+        calls.append((idx, num_label_tokens, num_batches, is_train))
+        loss_buffer.append(torch.tensor(6.0))
+
+    recipe._forward_backward_step = fake_forward_backward_step
+    monkeypatch.setattr("nemo_automodel.recipes.vlm.finetune.ScopedRNG", lambda **kwargs: nullcontext())
+
+    send_calls = []
+
+    def fake_send(tensor, dst):
+        send_calls.append((tensor.clone(), dst))
+
+    monkeypatch.setattr("torch.distributed.send", fake_send)
+
+    val_dataloader = [{"input_ids": torch.tensor([[1, 2, 3]]), "labels": torch.tensor([[1, 2, 3]])}]
+    result = recipe._run_validation_epoch(val_dataloader)
+
+    assert calls == [(0, None, 1, False)]
+    assert result.metrics["val_loss"] == pytest.approx(2.0)
+    assert result.metrics["num_label_tokens"] == 3
+    assert len(send_calls) == 2
+    assert send_calls[0][0].item() == pytest.approx(2.0)
+    assert send_calls[1][0].item() == 3
 
 
 # -----------------------------------------------------------------------------
@@ -2582,6 +2621,56 @@ def test_vlm_rope_fusion_stays_false_when_already_disabled(monkeypatch):
     trainer.setup()
 
     assert cfg.model.backend.rope_fusion is False
+
+
+def test_vlm_setup_wraps_validation_dataloader_for_pp(monkeypatch):
+    """PP VLM validation dataloader gets the same media microbatch prep as training."""
+    cfg = _minimal_vlm_cfg(cp_size=1, rope_fusion=False)
+    cfg.validation_dataset = ConfigNode({"path_or_dataset": "val"})
+    cfg.distributed.pipeline = ConfigNode({"pp_microbatch_size": 2})
+    cfg.step_scheduler.local_batch_size = 4
+
+    _patch_vlm_setup_minimals(monkeypatch, cp_size=1)
+
+    class FakeAutoPipeline:
+        pp_batch_size = 4
+        pp_microbatch_size = 2
+
+        def __init__(self):
+            self.parts = [DummyModel()]
+
+    fake_pipeline = FakeAutoPipeline()
+    pipeline_config = SimpleNamespace()
+    monkeypatch.setattr("nemo_automodel.recipes.vlm.finetune.AutoPipeline", FakeAutoPipeline)
+    monkeypatch.setattr("nemo_automodel.recipes.vlm.finetune._supports_logits_to_keep", lambda model: True)
+    monkeypatch.setattr("nemo_automodel.recipes.vlm.finetune.build_model", lambda *a, **k: fake_pipeline)
+    monkeypatch.setattr(
+        "nemo_automodel.recipes.vlm.finetune.setup_distributed",
+        lambda cfg, world_size: SimpleNamespace(
+            strategy_config=None,
+            pipeline_config=pipeline_config,
+            moe_config=None,
+            activation_checkpointing=False,
+            pp_enabled=True,
+            pp_size=2,
+            device_mesh=None,
+            moe_mesh=None,
+            cp_size=1,
+        ),
+    )
+
+    dataloader_calls = []
+
+    def fake_build_dataloader(*args, **kwargs):
+        dataloader_calls.append(kwargs)
+        return ("dl", "proc")
+
+    monkeypatch.setattr("nemo_automodel.recipes.vlm.finetune.build_dataloader", fake_build_dataloader)
+
+    trainer = FinetuneRecipeForVLM(cfg)
+    trainer.setup()
+
+    assert [call["pp_n_microbatches"] for call in dataloader_calls] == [2, 2]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add a shared forward/backward helper for LLM and VLM fine-tuning paths.
- Route LLM and VLM recipes through the shared helper while keeping recipe-specific hooks for CP prep, FP8 context, and VLM PP media staging.
- Enable VLM pipeline-parallel validation by preparing validation dataloader media chunks for PP and running validation through `schedule.eval`.

## Why

The LLM and VLM recipes had largely duplicated forward/backward control flow. VLM PP validation was previously skipped because validation used a direct model-forward path and did not prepare VLM media tensors for PP microbatches.

## Validation

- `python -m py_compile nemo_automodel/components/training/forward_backward.py nemo_automodel/recipes/llm/train_ft.py nemo_automodel/recipes/vlm/finetune.py`
- `python -m ruff check nemo_automodel/components/training/forward_backward.py nemo_automodel/recipes/llm/train_ft.py nemo_automodel/recipes/vlm/finetune.py`
- `git diff --check`
- `pytest -q tests/unit_tests/recipes/test_train_ft.py`
- `pytest -q tests/unit_tests/recipes/test_finetune_vlm_helpers.py`
- Local Qwen3 VL MoE 30B EP4/PP2 smoke run with validation:
  - train: `loss 2.3266`, `num_label_tokens 930`
  - val: `loss 2.2712`, `num_label_tokens 941`
