### PR TITLE
feat: Abstract LLM/VLM forward-backward step

### DIFF
--- a/nemo_automodel/components/training/forward_backward.py
+++ b/nemo_automodel/components/training/forward_backward.py
@@ -19,9 +19,14 @@ from contextlib import nullcontext
 from typing import Any
 
 import torch
+import torch.distributed as dist
 
+from nemo_automodel.components.distributed.cp_utils import make_cp_batch_and_ctx
+from nemo_automodel.components.distributed.mesh_utils import get_flat_mesh
+from nemo_automodel.components.distributed.utils import get_sync_ctx
 from nemo_automodel.components.loss.linear_ce import FusedLinearCrossEntropy
 from nemo_automodel.components.training.model_output_utils import get_final_hidden_states
+from nemo_automodel.components.utils.model_utils import filter_forward_kwargs
 
 
 def move_to_device(value: Any, device: torch.device) -> Any:
@@ -37,54 +42,97 @@ def move_to_device(value: Any, device: torch.device) -> Any:
     return value
 
 
+def _get_dp_group_size(device_mesh: Any, *, include_cp: bool = True) -> int:
+    if device_mesh is None:
+        if dist.is_available() and dist.is_initialized():
+            return dist.get_world_size()
+        return 1
+
+    mesh_dim_names = getattr(device_mesh, "mesh_dim_names", ())
+    cp_size = device_mesh["cp"].size() if include_cp and "cp" in mesh_dim_names else 1
+    if cp_size > 1:
+        return get_flat_mesh(device_mesh, "dp_cp").get_group().size()
+    return get_flat_mesh(device_mesh, "dp").get_group().size()
+
+
+def calculate_loss(
+    loss_fn: Callable[..., torch.Tensor],
+    *,
+    logits: torch.Tensor,
+    labels: torch.Tensor,
+    model: torch.nn.Module,
+    hidden_states: Any,
+    num_label_tokens: int | None,
+) -> torch.Tensor:
+    loss_fn_kwargs = {"num_label_tokens": num_label_tokens}
+    if isinstance(loss_fn, FusedLinearCrossEntropy):
+        lm_head = None
+        if hasattr(model, "get_output_embeddings"):
+            lm_head = model.get_output_embeddings().weight
+        else:
+            for name, param in model.named_parameters(remove_duplicate=False):
+                if "lm_head" in name and name.endswith(".weight"):
+                    lm_head = param
+                    break
+        if lm_head is None:
+            raise ValueError("lm_head.weight not found in model")
+
+        lm_head = lm_head.full_tensor() if hasattr(lm_head, "full_tensor") else lm_head
+        loss_fn_kwargs.update(
+            {
+                "hidden_states": hidden_states,
+                "labels": labels,
+                "lm_weight": lm_head,
+            }
+        )
+    else:
+        loss_fn_kwargs.update(
+            {
+                "logits": logits,
+                "labels": labels,
+            }
+        )
+
+    return loss_fn(**loss_fn_kwargs)
+
+
 def forward_backward_step(
     *,
-    idx: int,
     batch: MutableMapping[str, Any],
     device: torch.device,
     device_mesh: Any,
     model_parts: list[torch.nn.Module],
     distributed_config: Any,
     loss_fn: Callable[..., torch.Tensor] | None,
-    calculate_loss_fn: Callable[..., torch.Tensor],
-    loss_buffer: list[torch.Tensor],
     num_label_tokens: int | None,
-    num_batches: int,
     is_train: bool,
-    pp_enabled: bool,
     pp: Any | None,
-    dp_group_size: int,
-    make_cp_batch_and_ctx_fn: Callable[..., tuple[Callable[[], Any], MutableMapping[str, Any]]],
-    get_sync_ctx_fn: Callable[..., Any],
-    filter_forward_kwargs_fn: Callable[[torch.nn.Module, MutableMapping[str, Any]], MutableMapping[str, Any]],
+    is_last_microbatch: bool = True,
     make_cp_batch_kwargs: dict[str, Any] | None = None,
     prepare_batch_before_cp: Callable[[MutableMapping[str, Any]], MutableMapping[str, Any]] | None = None,
     model_context_factory: Callable[[], Any] | None = None,
     pp_batch_context_factory: Callable[[MutableMapping[str, Any]], Any] | None = None,
-    filter_pp_batch: bool = True,
     hidden_states_error_message: str = (
         "FusedLinearCrossEntropy requires the model to output hidden states. "
         "Set `model.output_hidden_states=True` in the config."
     ),
-) -> None:
+) -> torch.Tensor:
     """Run one LLM/VLM forward-backward step.
 
     Recipes supply hooks for modality-specific preparation while sharing the
     common CP, PP, loss, and backward control flow.
     """
+    pp_enabled = pp is not None
     batch = {key: move_to_device(value, device) for key, value in batch.items()}
 
     if prepare_batch_before_cp is not None:
         batch = prepare_batch_before_cp(batch)
 
-    train_ctx, batch = make_cp_batch_and_ctx_fn(device_mesh, batch, **(make_cp_batch_kwargs or {}))
+    train_ctx, batch = make_cp_batch_and_ctx(device_mesh, batch, **(make_cp_batch_kwargs or {}))
     labels = batch.pop("labels")
     model_ctx = model_context_factory() if model_context_factory is not None else nullcontext()
 
     if pp_enabled:
-        if pp is None:
-            raise ValueError("pp must be provided when pp_enabled=True")
-
         with train_ctx(), model_ctx:
             losses = [] if pp.info.has_last_stage else None
             targets = labels.clone() if pp.info.has_last_stage else None
@@ -93,7 +141,7 @@ def forward_backward_step(
             pp.update_seq_len(input_ids.shape[1])
 
             pp_batch = batch
-            if filter_pp_batch:
+            if pp_batch_context_factory is None:
                 pp_batch = {
                     key: value
                     for key, value in batch.items()
@@ -114,14 +162,13 @@ def forward_backward_step(
             local_loss = torch.sum(torch.stack(losses))
         else:
             local_loss = torch.tensor(0.0, device=device)
-        loss_buffer.append(local_loss.clone().detach())
-        return
+        return local_loss.detach()
 
     model = model_parts[0]
     sync_ctx = (
-        get_sync_ctx_fn(
+        get_sync_ctx(
             model,
-            idx == num_batches - 1,
+            is_last_microbatch,
             defer_fsdp_grad_sync=getattr(distributed_config, "defer_fsdp_grad_sync", True),
         )
         if is_train
@@ -129,7 +176,7 @@ def forward_backward_step(
     )
 
     with train_ctx(), sync_ctx, model_ctx:
-        batch = filter_forward_kwargs_fn(model, batch)
+        batch = filter_forward_kwargs(model, batch)
         if isinstance(loss_fn, FusedLinearCrossEntropy):
             out = model(logits_to_keep=1, **batch)
             hidden_states = get_final_hidden_states(out)
@@ -139,17 +186,21 @@ def forward_backward_step(
             out = model(**batch)
             hidden_states = get_final_hidden_states(out)
 
-        local_loss = calculate_loss_fn(
-            loss_fn,
+        if loss_fn is None:
+            raise ValueError("loss_fn must be provided for non-PP forward-backward")
+
+        local_loss = calculate_loss(
+            loss_fn=loss_fn,
             logits=getattr(out, "logits", out),
             labels=labels,
             model=model,
             hidden_states=hidden_states,
             num_label_tokens=num_label_tokens,
         )
-        loss_buffer.append(local_loss.clone().detach())
         if is_train:
+            dp_group_size = _get_dp_group_size(device_mesh, include_cp=True)
             (local_loss * dp_group_size).backward()
+        return local_loss.detach()
 
 
-__all__ = ["forward_backward_step", "move_to_device"]
+__all__ = ["calculate_loss", "forward_backward_step", "move_to_device"]

--- a/nemo_automodel/components/training/forward_backward.py
+++ b/nemo_automodel/components/training/forward_backward.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import logging
 from collections.abc import Callable, MutableMapping
 from contextlib import nullcontext
 from typing import Any
@@ -63,8 +62,6 @@ def forward_backward_step(
     model_context_factory: Callable[[], Any] | None = None,
     pp_batch_context_factory: Callable[[MutableMapping[str, Any]], Any] | None = None,
     filter_pp_batch: bool = True,
-    pp_eval_enabled: bool = True,
-    pp_validation_skip_message: str = "Skipping forward pass for validation because pipeline parallelism is enabled",
     hidden_states_error_message: str = (
         "FusedLinearCrossEntropy requires the model to output hidden states. "
         "Set `model.output_hidden_states=True` in the config."
@@ -87,9 +84,6 @@ def forward_backward_step(
     if pp_enabled:
         if pp is None:
             raise ValueError("pp must be provided when pp_enabled=True")
-        if not is_train and not pp_eval_enabled:
-            logging.info(pp_validation_skip_message)
-            return
 
         with train_ctx(), model_ctx:
             losses = [] if pp.info.has_last_stage else None

--- a/nemo_automodel/components/training/forward_backward.py
+++ b/nemo_automodel/components/training/forward_backward.py
@@ -1,0 +1,161 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, MutableMapping
+from contextlib import nullcontext
+from typing import Any
+
+import torch
+
+from nemo_automodel.components.loss.linear_ce import FusedLinearCrossEntropy
+from nemo_automodel.components.training.model_output_utils import get_final_hidden_states
+
+
+def move_to_device(value: Any, device: torch.device) -> Any:
+    """Recursively move tensors in a batch value to ``device``."""
+    if isinstance(value, torch.Tensor):
+        return value.to(device, non_blocking=True)
+    if isinstance(value, dict):
+        return {key: move_to_device(item, device) if item is not None else None for key, item in value.items()}
+    if isinstance(value, list):
+        return [move_to_device(item, device) for item in value]
+    if isinstance(value, tuple):
+        return tuple(move_to_device(item, device) for item in value)
+    return value
+
+
+def forward_backward_step(
+    *,
+    idx: int,
+    batch: MutableMapping[str, Any],
+    device: torch.device,
+    device_mesh: Any,
+    model_parts: list[torch.nn.Module],
+    distributed_config: Any,
+    loss_fn: Callable[..., torch.Tensor] | None,
+    calculate_loss_fn: Callable[..., torch.Tensor],
+    loss_buffer: list[torch.Tensor],
+    num_label_tokens: int | None,
+    num_batches: int,
+    is_train: bool,
+    pp_enabled: bool,
+    pp: Any | None,
+    dp_group_size: int,
+    make_cp_batch_and_ctx_fn: Callable[..., tuple[Callable[[], Any], MutableMapping[str, Any]]],
+    get_sync_ctx_fn: Callable[..., Any],
+    filter_forward_kwargs_fn: Callable[[torch.nn.Module, MutableMapping[str, Any]], MutableMapping[str, Any]],
+    make_cp_batch_kwargs: dict[str, Any] | None = None,
+    prepare_batch_before_cp: Callable[[MutableMapping[str, Any]], MutableMapping[str, Any]] | None = None,
+    model_context_factory: Callable[[], Any] | None = None,
+    pp_batch_context_factory: Callable[[MutableMapping[str, Any]], Any] | None = None,
+    filter_pp_batch: bool = True,
+    pp_eval_enabled: bool = True,
+    pp_validation_skip_message: str = "Skipping forward pass for validation because pipeline parallelism is enabled",
+    hidden_states_error_message: str = (
+        "FusedLinearCrossEntropy requires the model to output hidden states. "
+        "Set `model.output_hidden_states=True` in the config."
+    ),
+) -> None:
+    """Run one LLM/VLM forward-backward step.
+
+    Recipes supply hooks for modality-specific preparation while sharing the
+    common CP, PP, loss, and backward control flow.
+    """
+    batch = {key: move_to_device(value, device) for key, value in batch.items()}
+
+    if prepare_batch_before_cp is not None:
+        batch = prepare_batch_before_cp(batch)
+
+    train_ctx, batch = make_cp_batch_and_ctx_fn(device_mesh, batch, **(make_cp_batch_kwargs or {}))
+    labels = batch.pop("labels")
+    model_ctx = model_context_factory() if model_context_factory is not None else nullcontext()
+
+    if pp_enabled:
+        if pp is None:
+            raise ValueError("pp must be provided when pp_enabled=True")
+        if not is_train and not pp_eval_enabled:
+            logging.info(pp_validation_skip_message)
+            return
+
+        with train_ctx(), model_ctx:
+            losses = [] if pp.info.has_last_stage else None
+            targets = labels.clone() if pp.info.has_last_stage else None
+
+            input_ids = batch.pop("input_ids")
+            pp.update_seq_len(input_ids.shape[1])
+
+            pp_batch = batch
+            if filter_pp_batch:
+                pp_batch = {
+                    key: value
+                    for key, value in batch.items()
+                    if value is not None and not (isinstance(value, dict) and len(value) == 0)
+                }
+
+            pp_batch_ctx = (
+                pp_batch_context_factory(pp_batch) if pp_batch_context_factory is not None else nullcontext()
+            )
+            schedule_fn = pp.info.schedule.step if is_train else pp.info.schedule.eval
+            with pp_batch_ctx:
+                if pp.info.has_first_stage:
+                    schedule_fn(input_ids, target=targets, losses=losses, **pp_batch)
+                else:
+                    schedule_fn(target=targets, losses=losses, **pp_batch)
+
+        if pp.info.has_last_stage:
+            local_loss = torch.sum(torch.stack(losses))
+        else:
+            local_loss = torch.tensor(0.0, device=device)
+        loss_buffer.append(local_loss.clone().detach())
+        return
+
+    model = model_parts[0]
+    sync_ctx = (
+        get_sync_ctx_fn(
+            model,
+            idx == num_batches - 1,
+            defer_fsdp_grad_sync=getattr(distributed_config, "defer_fsdp_grad_sync", True),
+        )
+        if is_train
+        else nullcontext()
+    )
+
+    with train_ctx(), sync_ctx, model_ctx:
+        batch = filter_forward_kwargs_fn(model, batch)
+        if isinstance(loss_fn, FusedLinearCrossEntropy):
+            out = model(logits_to_keep=1, **batch)
+            hidden_states = get_final_hidden_states(out)
+            if hidden_states is None:
+                raise ValueError(hidden_states_error_message)
+        else:
+            out = model(**batch)
+            hidden_states = get_final_hidden_states(out)
+
+        local_loss = calculate_loss_fn(
+            loss_fn,
+            logits=getattr(out, "logits", out),
+            labels=labels,
+            model=model,
+            hidden_states=hidden_states,
+            num_label_tokens=num_label_tokens,
+        )
+        loss_buffer.append(local_loss.clone().detach())
+        if is_train:
+            (local_loss * dp_group_size).backward()
+
+
+__all__ = ["forward_backward_step", "move_to_device"]

--- a/nemo_automodel/recipes/llm/benchmark.py
+++ b/nemo_automodel/recipes/llm/benchmark.py
@@ -287,13 +287,13 @@ class BenchmarkingRecipeForNextTokenPrediction(TrainFinetuneRecipeForNextTokenPr
                     num_label_tokens += (batch["labels"] != -100).sum().item()
 
                     with self.timers(f"forward_backward_{ga_step_idx}", log_level=2):
-                        self._forward_backward_step(
-                            ga_step_idx,
-                            batch,
-                            loss_buffer=loss_buffer,
-                            num_label_tokens=None,
-                            num_batches=ga_steps,
-                            is_train=True,
+                        loss_buffer.append(
+                            self._forward_backward_step(
+                                batch,
+                                num_label_tokens=None,
+                                is_train=True,
+                                is_last_microbatch=ga_step_idx == ga_steps - 1,
+                            )
                         )
 
                     torch.cuda.nvtx.range_pop()

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -1362,7 +1362,6 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
             },
             model_context_factory=self.te_fp8.maybe_te_autocast if self.te_fp8 is not None else None,
             filter_pp_batch=True,
-            pp_eval_enabled=True,
             hidden_states_error_message=(
                 "FusedLinearCrossEntropy requires the model to output hidden states. "
                 "Set `model.output_hidden_states=True` in the config."

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -29,7 +29,6 @@ import inspect
 import logging
 import pathlib
 import time
-from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import torch
@@ -79,7 +78,7 @@ from nemo_automodel.components.moe.megatron.moe_utils import MoEAuxLossAutoScale
 from nemo_automodel.components.optim.scheduler import OptimizerParamScheduler
 from nemo_automodel.components.optim.utils import build_dion_optimizer, is_dion_optimizer
 from nemo_automodel.components.quantization.fp8 import build_fp8_config
-from nemo_automodel.components.training.model_output_utils import get_final_hidden_states
+from nemo_automodel.components.training.forward_backward import forward_backward_step
 from nemo_automodel.components.training.rng import ScopedRNG, StatefulRNG
 from nemo_automodel.components.training.step_scheduler import StepScheduler
 from nemo_automodel.components.training.utils import (
@@ -1334,101 +1333,41 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
         num_batches,
         is_train: bool = True,
     ):
-        # Move batch to device (handle both tensors and dicts of tensors like causal_mask_mapping)
-        batch = {
-            k: (
-                {dk: dv.to(self.dist_env.device, non_blocking=True) for dk, dv in v.items() if dv is not None}
-                if isinstance(v, dict)
-                else (v.to(self.dist_env.device, non_blocking=True) if isinstance(v, torch.Tensor) else v)
-            )
-            for k, v in batch.items()
-        }
-        train_ctx, batch = make_cp_batch_and_ctx(
-            self.device_mesh,
-            batch,
-            use_te=_uses_te_dot_product_attention(
-                self.model_parts[0] if hasattr(self, "model_parts") else self.cfg.model
-            )
-            and _uses_thd_collater(self.cfg.dataloader),
-            padding_token_id=self.tokenizer.pad_token_id if self.tokenizer else 0,
-            num_chunks=_get_num_thd_chunks(self.pp_enabled, self.cfg),
+        forward_backward_step(
+            idx=idx,
+            batch=batch,
+            device=self.dist_env.device,
+            device_mesh=self.device_mesh,
+            model_parts=getattr(self, "model_parts", []),
+            distributed_config=getattr(self, "distributed_config", None),
+            loss_fn=getattr(self, "loss_fn", None),
+            calculate_loss_fn=calculate_loss,
+            loss_buffer=loss_buffer,
+            num_label_tokens=num_label_tokens,
+            num_batches=num_batches,
+            is_train=is_train,
+            pp_enabled=self.pp_enabled,
+            pp=self.pp,
+            dp_group_size=1 if self.pp_enabled else self._get_dp_group_size(include_cp=True),
+            make_cp_batch_and_ctx_fn=make_cp_batch_and_ctx,
+            get_sync_ctx_fn=get_sync_ctx,
+            filter_forward_kwargs_fn=filter_forward_kwargs,
+            make_cp_batch_kwargs={
+                "use_te": _uses_te_dot_product_attention(
+                    self.model_parts[0] if hasattr(self, "model_parts") else self.cfg.model
+                )
+                and _uses_thd_collater(self.cfg.dataloader),
+                "padding_token_id": self.tokenizer.pad_token_id if self.tokenizer else 0,
+                "num_chunks": _get_num_thd_chunks(self.pp_enabled, self.cfg),
+            },
+            model_context_factory=self.te_fp8.maybe_te_autocast if self.te_fp8 is not None else None,
+            filter_pp_batch=True,
+            pp_eval_enabled=True,
+            hidden_states_error_message=(
+                "FusedLinearCrossEntropy requires the model to output hidden states. "
+                "Set `model.output_hidden_states=True` in the config."
+            ),
         )
-        labels = batch.pop("labels")
-        fp8_ctx = self.te_fp8.maybe_te_autocast() if self.te_fp8 is not None else nullcontext()
-
-        if self.pp_enabled:
-            with train_ctx(), fp8_ctx:
-                losses = [] if self.pp.info.has_last_stage else None
-                if self.pp.info.has_last_stage:
-                    masked_labels = labels.clone()
-                    targets = masked_labels
-                else:
-                    targets = None
-
-                input_ids = batch.pop("input_ids")
-
-                # Update PP stage shapes for the current batch's seq_len.
-                # This is a no-op when the length hasn't changed.
-                self.pp.update_seq_len(input_ids.shape[1])
-
-                # Filter out None values and empty dicts from batch to avoid PP chunking errors
-                batch_filtered = {
-                    k: v for k, v in batch.items() if v is not None and not (isinstance(v, dict) and len(v) == 0)
-                }
-
-                if is_train:
-                    # Use step for training (forward + backward)
-                    if self.pp.info.has_first_stage:
-                        self.pp.info.schedule.step(input_ids, target=targets, losses=losses, **batch_filtered)
-                    else:
-                        self.pp.info.schedule.step(target=targets, losses=losses, **batch_filtered)
-                else:
-                    # Use eval for validation (forward only, no backward)
-                    if self.pp.info.has_first_stage:
-                        self.pp.info.schedule.eval(input_ids, target=targets, losses=losses, **batch_filtered)
-                    else:
-                        self.pp.info.schedule.eval(target=targets, losses=losses, **batch_filtered)
-
-            if self.pp.info.has_last_stage:
-                local_loss = torch.sum(torch.stack(losses))
-            else:
-                local_loss = torch.tensor(0.0, device=self.dist_env.device)
-
-            loss_buffer.append(local_loss.clone().detach())
-        else:
-            model = self.model_parts[0]
-            sync_ctx = (
-                get_sync_ctx(
-                    model,
-                    idx == num_batches - 1,
-                    defer_fsdp_grad_sync=getattr(self.distributed_config, "defer_fsdp_grad_sync", True),
-                )
-                if is_train
-                else nullcontext()
-            )
-            with train_ctx(), sync_ctx, fp8_ctx:
-                batch = filter_forward_kwargs(model, batch)
-                if isinstance(self.loss_fn, FusedLinearCrossEntropy):
-                    # use num_logits_to_keep to avoid full logits matrix in memory
-                    out = model(logits_to_keep=1, **batch)
-                    if "hidden_states" not in out:
-                        raise ValueError(
-                            "FusedLinearCrossEntropy requires the model to output hidden states. Set `model.output_hidden_states=True` in the config."
-                        )
-                else:
-                    out = model(**batch)
-
-                local_loss = calculate_loss(
-                    self.loss_fn,
-                    logits=getattr(out, "logits", out),
-                    labels=labels,
-                    model=model,
-                    hidden_states=get_final_hidden_states(out),
-                    num_label_tokens=num_label_tokens,
-                )
-                loss_buffer.append(local_loss.clone().detach())
-                if is_train:
-                    (local_loss * self._get_dp_group_size(include_cp=True)).backward()
 
     def _run_train_optim_step(self, batches, max_grad_norm: Optional[float] = None):
         """Execute a single training step.

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -59,20 +59,18 @@ from nemo_automodel.components.datasets.llm.megatron.sampler import create_megat
 from nemo_automodel.components.datasets.llm.megatron_dataset import MegatronPretraining
 from nemo_automodel.components.datasets.llm.packed_sequence import pack_dataset
 from nemo_automodel.components.distributed.config import MegatronFSDPConfig
-from nemo_automodel.components.distributed.cp_utils import make_cp_batch_and_ctx
 from nemo_automodel.components.distributed.init_utils import (
     initialize_distributed,
 )
 from nemo_automodel.components.distributed.megatron_fsdp import fully_shard_optimizer
 from nemo_automodel.components.distributed.mesh import MeshContext
 from nemo_automodel.components.distributed.pipelining import AutoPipeline
-from nemo_automodel.components.distributed.utils import FirstRankPerNode, get_sync_ctx
+from nemo_automodel.components.distributed.utils import FirstRankPerNode
 from nemo_automodel.components.loggers.comet_utils import build_comet
 from nemo_automodel.components.loggers.log_utils import setup_logging
 from nemo_automodel.components.loggers.metric_logger import MetricsSample, build_metric_logger
 from nemo_automodel.components.loggers.mlflow_utils import build_mlflow
 from nemo_automodel.components.loggers.wandb_utils import suppress_wandb_log_messages
-from nemo_automodel.components.loss.linear_ce import FusedLinearCrossEntropy
 from nemo_automodel.components.loss.masked_ce import MaskedCrossEntropy
 from nemo_automodel.components.moe.megatron.moe_utils import MoEAuxLossAutoScaler
 from nemo_automodel.components.optim.scheduler import OptimizerParamScheduler
@@ -95,7 +93,6 @@ from nemo_automodel.components.utils.flops_utils import calculate_mfu
 from nemo_automodel.components.utils.model_utils import (
     _supports_logits_to_keep,
     _supports_seq_lens,
-    filter_forward_kwargs,
     resolve_trust_remote_code,
 )
 from nemo_automodel.recipes._dist_setup import setup_distributed
@@ -803,53 +800,6 @@ def build_wandb(cfg) -> wandb.Run:
     return run
 
 
-def calculate_loss(loss_fn, **kwargs) -> torch.Tensor:
-    """Calculate the loss.
-
-    Args:
-        loss_fn: Loss function.
-        **kwargs: Keyword arguments for the loss function.
-
-    Returns:
-        The loss.
-    """
-    loss_fn_kwargs = {"num_label_tokens": kwargs.pop("num_label_tokens", None)}
-    if isinstance(loss_fn, FusedLinearCrossEntropy):
-        model = kwargs.pop("model")
-        labels = kwargs.pop("labels")
-
-        # find the lm_head in the model
-        lm_head = None
-        if hasattr(model, "get_output_embeddings"):
-            lm_head = model.get_output_embeddings().weight
-        else:
-            for n, p in model.named_parameters(remove_duplicate=False):
-                if "lm_head" in n and n.endswith(".weight"):
-                    lm_head = p
-                    break
-        if lm_head is None:
-            raise ValueError("lm_head.weight not found in model")
-
-        # unshard the possibly sharded lm_head
-        lm_head = lm_head.full_tensor() if hasattr(lm_head, "full_tensor") else lm_head
-        loss_fn_kwargs.update(
-            {
-                "hidden_states": kwargs.pop("hidden_states"),
-                "labels": labels,
-                "lm_weight": lm_head,
-            }
-        )
-    else:
-        loss_fn_kwargs.update(
-            {
-                "logits": kwargs.pop("logits"),
-                "labels": kwargs.pop("labels"),
-            }
-        )
-
-    return loss_fn(**loss_fn_kwargs)
-
-
 def build_validation_dataloader(cfg, dp_world_size, dp_rank, pp_enabled, model: Optional[nn.Module] = None):
     def _prepare_val_ds_name(val_ds_name):
         val_ds_name = val_ds_name.replace("validation_dataset", "")
@@ -1325,33 +1275,23 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
     # ------------------ helpers ------------------
     def _forward_backward_step(
         self,
-        idx,
         batch,
         *,
-        loss_buffer,
         num_label_tokens,
-        num_batches,
         is_train: bool = True,
+        is_last_microbatch: bool = True,
     ):
-        forward_backward_step(
-            idx=idx,
+        return forward_backward_step(
             batch=batch,
             device=self.dist_env.device,
             device_mesh=self.device_mesh,
             model_parts=getattr(self, "model_parts", []),
             distributed_config=getattr(self, "distributed_config", None),
             loss_fn=getattr(self, "loss_fn", None),
-            calculate_loss_fn=calculate_loss,
-            loss_buffer=loss_buffer,
             num_label_tokens=num_label_tokens,
-            num_batches=num_batches,
             is_train=is_train,
-            pp_enabled=self.pp_enabled,
-            pp=self.pp,
-            dp_group_size=1 if self.pp_enabled else self._get_dp_group_size(include_cp=True),
-            make_cp_batch_and_ctx_fn=make_cp_batch_and_ctx,
-            get_sync_ctx_fn=get_sync_ctx,
-            filter_forward_kwargs_fn=filter_forward_kwargs,
+            pp=self.pp if self.pp_enabled else None,
+            is_last_microbatch=is_last_microbatch,
             make_cp_batch_kwargs={
                 "use_te": _uses_te_dot_product_attention(
                     self.model_parts[0] if hasattr(self, "model_parts") else self.cfg.model
@@ -1361,7 +1301,6 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
                 "num_chunks": _get_num_thd_chunks(self.pp_enabled, self.cfg),
             },
             model_context_factory=self.te_fp8.maybe_te_autocast if self.te_fp8 is not None else None,
-            filter_pp_batch=True,
             hidden_states_error_message=(
                 "FusedLinearCrossEntropy requires the model to output hidden states. "
                 "Set `model.output_hidden_states=True` in the config."
@@ -1417,8 +1356,12 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
             if i == num_batches - 1:
                 prepare_for_final_backward(self.model_parts, pp_enabled=self.pp_enabled)
 
-            self._forward_backward_step(
-                i, batch, loss_buffer=loss_buffer, num_label_tokens=num_label_tokens, num_batches=num_batches
+            loss_buffer.append(
+                self._forward_backward_step(
+                    batch,
+                    num_label_tokens=num_label_tokens,
+                    is_last_microbatch=i == num_batches - 1,
+                )
             )
 
             if i == 0:
@@ -1544,18 +1487,10 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
             total_num_label_tokens = 0
 
             for batch in val_dataloader:
-                loss_buffer = []
                 num_label_tokens = (batch["labels"] != -100).sum().item()
-                self._forward_backward_step(
-                    0,
-                    batch,
-                    loss_buffer=loss_buffer,
-                    num_label_tokens=None,  # we will normalize outside.
-                    num_batches=1,
-                    is_train=False,
-                )
+                loss = self._forward_backward_step(batch, num_label_tokens=None, is_train=False)
 
-                total_loss += torch.sum(torch.stack(loss_buffer)).item()
+                total_loss += loss.item()
                 total_num_label_tokens += num_label_tokens
 
         total_loss = self._dp_allreduce(total_loss, include_cp=True)

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -795,6 +795,7 @@ class FinetuneRecipeForVLM(BaseRecipe):
                 seed=self.cfg.get("seed", 42),
                 local_batch_size=self.cfg.get("step_scheduler.local_batch_size", 1),
                 get_rope_index=get_rope_index,
+                pp_n_microbatches=pp_n_microbatches,
             )
 
         self.best_metric_key = self.cfg.get("checkpoint.best_metric_key", "default")
@@ -852,12 +853,9 @@ class FinetuneRecipeForVLM(BaseRecipe):
 
                     val_loss = {}
                     if self.step_scheduler.is_val_step and self.val_dataloader is not None:
-                        if self.pp_enabled:
-                            logger.warning("Validation is not supported for pipeline parallelism")
-                        else:
-                            val_log_data = self._run_validation_epoch(self.val_dataloader)
-                            val_loss["val_loss"] = val_log_data.metrics["val_loss"]
-                            self.log_val_metrics(val_log_data)
+                        val_log_data = self._run_validation_epoch(self.val_dataloader)
+                        val_loss["val_loss"] = val_log_data.metrics["val_loss"]
+                        self.log_val_metrics(val_log_data)
                         for mp in self.model_parts:
                             mp.train()
 
@@ -932,12 +930,25 @@ class FinetuneRecipeForVLM(BaseRecipe):
             prepare_batch_before_cp=self._prepare_vlm_batch_for_cp,
             pp_batch_context_factory=lambda pp_batch: stage_vlm_media_for_pp(self.pp, self.model_parts, pp_batch),
             filter_pp_batch=False,
-            pp_eval_enabled=False,
+            pp_eval_enabled=True,
             hidden_states_error_message=(
                 "FusedLinearCrossEntropy requires the model to output hidden states. "
                 "Set `model.text_config.output_hidden_states=True` in the config."
             ),
         )
+
+    def _get_pp_last_stage_rank_for_reporting(self):
+        if self.device_mesh is not None and "pp" in self.device_mesh.mesh_dim_names:
+            dim_names = list(self.device_mesh.mesh_dim_names)
+            mesh = self.device_mesh.mesh
+            idx = []
+            for name in dim_names:
+                if name == "pp":
+                    idx.append(-1)
+                else:
+                    idx.append(0)
+            return mesh[tuple(idx)].item()
+        return self.device_mesh.mesh.reshape(-1)[-1].item()
 
     def _run_train_optim_step(self, batches, max_grad_norm: Optional[float] = None):
         """Execute a single training step.
@@ -1049,18 +1060,7 @@ class FinetuneRecipeForVLM(BaseRecipe):
             reporting_loss = reporting_loss.float().to(self.dist_env.device)
             # Send loss to first rank from the last PP stage of rank0's mesh coords.
             # This avoids picking a global-rank sender from a different EP/PP group.
-            if self.device_mesh is not None and "pp" in self.device_mesh.mesh_dim_names:
-                dim_names = list(self.device_mesh.mesh_dim_names)
-                mesh = self.device_mesh.mesh
-                idx = []
-                for name in dim_names:
-                    if name == "pp":
-                        idx.append(-1)
-                    else:
-                        idx.append(0)
-                src_rank = mesh[tuple(idx)].item()
-            else:
-                src_rank = self.device_mesh.mesh.reshape(-1)[-1].item()
+            src_rank = self._get_pp_last_stage_rank_for_reporting()
             if self.dist_env.rank == src_rank:
                 torch.distributed.send(reporting_loss, dst=0)
             elif self.dist_env.is_main:
@@ -1091,60 +1091,42 @@ class FinetuneRecipeForVLM(BaseRecipe):
             for mp in self.model_parts:
                 mp.eval()
 
-            total_loss = 0.0
-            total_tokens = 0
+            total_loss = torch.tensor(0.0, dtype=torch.float32, device=self.dist_env.device)
             total_num_label_tokens = 0
             for batch in val_dataloader:
-                batch = {
-                    k: (v.to(self.dist_env.device, non_blocking=True) if isinstance(v, torch.Tensor) else v)
-                    for k, v in batch.items()
-                }
+                loss_buffer = []
                 num_label_tokens = (batch["labels"] != -100).sum().item()
-
-                _model = self.model_parts[0]
-                _cp_active = (
-                    self.device_mesh is not None
-                    and "cp" in getattr(self.device_mesh, "mesh_dim_names", ())
-                    and self.device_mesh["cp"].size() > 1
-                    and not self.pp_enabled
+                self._forward_backward_step(
+                    0,
+                    batch,
+                    loss_buffer=loss_buffer,
+                    num_label_tokens=None,
+                    num_batches=1,
+                    is_train=False,
                 )
-                if _cp_active and hasattr(_model, "prepare_model_inputs_for_cp"):
-                    mm_kwargs = {k: batch[k] for k in VLM_INPUT_KEYS if batch.get(k) is not None}
-                    with torch.no_grad():
-                        prepared = _model(_pre_embed_only=True, **mm_kwargs)
-                    for k in VLM_INPUT_KEYS:
-                        batch.pop(k, None)
-                    batch.update(prepared)
-
-                train_ctx, batch = make_cp_batch_and_ctx(self.device_mesh, batch)
-                labels = batch.pop("labels")
-                with train_ctx():
-                    batch = filter_forward_kwargs(self.model_parts[0], batch)
-                    if isinstance(self.loss_fn, FusedLinearCrossEntropy):
-                        out = self.model_parts[0](logits_to_keep=1, **batch)
-                    else:
-                        out = self.model_parts[0](**batch)
-                    local_loss = calculate_loss(
-                        self.loss_fn,
-                        logits=getattr(out, "logits", out),
-                        labels=labels,
-                        model=self.model_parts[0],
-                        hidden_states=out.hidden_states[-1]
-                        if getattr(out, "hidden_states", None) is not None
-                        else None,
-                        num_label_tokens=num_label_tokens,
-                    )
-                    total_num_label_tokens += num_label_tokens
-
-                total_loss += local_loss.item() * num_label_tokens
-                total_tokens += num_label_tokens
+                total_loss += torch.sum(torch.stack(loss_buffer)).item()
+                total_num_label_tokens += num_label_tokens
 
         # Aggregate across ranks if distributed is initialized
-        total_loss = self._dp_allreduce(torch.FloatTensor([total_loss]), include_cp=True).item()
-        total_tokens = self._dp_allreduce(torch.LongTensor([total_tokens]), include_cp=True).item()
-        total_num_label_tokens = self._dp_allreduce(torch.LongTensor([total_num_label_tokens])).item()
+        total_loss = self._dp_allreduce(total_loss, include_cp=True)
+        total_num_label_tokens = self._dp_allreduce(
+            torch.tensor(total_num_label_tokens, dtype=torch.long, device=self.dist_env.device)
+        ).item()
+        val_loss = total_loss / max(total_num_label_tokens, 1e-8)
 
-        val_loss = total_loss / max(total_tokens, 1e-8)
+        if self.pp_enabled:
+            val_loss = val_loss.to(self.dist_env.device)
+            pp_num_tokens = torch.tensor(total_num_label_tokens, dtype=torch.long, device=self.dist_env.device)
+            src_rank = self._get_pp_last_stage_rank_for_reporting()
+            if self.dist_env.rank == src_rank:
+                torch.distributed.send(val_loss, dst=0)
+                torch.distributed.send(pp_num_tokens, dst=0)
+            elif self.dist_env.is_main:
+                torch.distributed.recv(val_loss, src=src_rank)
+                torch.distributed.recv(pp_num_tokens, src=src_rank)
+                total_num_label_tokens = pp_num_tokens.item()
+
+        val_loss = val_loss.item() if isinstance(val_loss, torch.Tensor) else val_loss
 
         return MetricsSample(
             step=self.step_scheduler.step,

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -54,14 +54,12 @@ from nemo_automodel.components.datasets.llm.formatting_utils import _resolve_cha
 from nemo_automodel.components.datasets.vlm.collate_fns import COLLATE_FNS
 from nemo_automodel.components.datasets.vlm.pp_media import stage_vlm_media_for_pp, wrap_vlm_collate_for_pp
 from nemo_automodel.components.distributed.config import MegatronFSDPConfig
-from nemo_automodel.components.distributed.cp_utils import make_cp_batch_and_ctx
 from nemo_automodel.components.distributed.init_utils import initialize_distributed
 from nemo_automodel.components.distributed.pipelining import AutoPipeline
-from nemo_automodel.components.distributed.utils import FirstRankPerNode, get_sync_ctx
+from nemo_automodel.components.distributed.utils import FirstRankPerNode
 from nemo_automodel.components.loggers.log_utils import setup_logging
 from nemo_automodel.components.loggers.metric_logger import MetricsSample, build_metric_logger
 from nemo_automodel.components.loggers.wandb_utils import suppress_wandb_log_messages
-from nemo_automodel.components.loss.linear_ce import FusedLinearCrossEntropy
 from nemo_automodel.components.loss.masked_ce import MaskedCrossEntropy
 from nemo_automodel.components.moe.megatron.moe_utils import MoEAuxLossAutoScaler
 from nemo_automodel.components.optim.scheduler import OptimizerParamScheduler
@@ -76,7 +74,7 @@ from nemo_automodel.components.training.utils import (
     scale_grads_and_clip_grad_norm,
 )
 from nemo_automodel.components.utils.compile_utils import build_compile_config
-from nemo_automodel.components.utils.model_utils import VLM_INPUT_KEYS, _supports_logits_to_keep, filter_forward_kwargs
+from nemo_automodel.components.utils.model_utils import VLM_INPUT_KEYS, _supports_logits_to_keep
 from nemo_automodel.recipes._dist_setup import setup_distributed
 from nemo_automodel.recipes.base_recipe import BaseRecipe
 
@@ -580,53 +578,6 @@ def build_wandb(cfg) -> wandb.Run:
     return run
 
 
-def calculate_loss(loss_fn, **kwargs) -> torch.Tensor:
-    """Calculate the loss.
-
-    Args:
-        loss_fn: Loss function.
-        **kwargs: Keyword arguments for the loss function.
-
-    Returns:
-        The loss.
-    """
-    loss_fn_kwargs = {"num_label_tokens": kwargs.pop("num_label_tokens", None)}
-    if isinstance(loss_fn, FusedLinearCrossEntropy):
-        model = kwargs.pop("model")
-        labels = kwargs.pop("labels")
-
-        # find the lm_head in the model
-        lm_head = None
-        if hasattr(model, "get_output_embeddings"):
-            lm_head = model.get_output_embeddings().weight
-        else:
-            for n, p in model.named_parameters(remove_duplicate=False):
-                if "lm_head" in n and n.endswith(".weight"):
-                    lm_head = p
-                    break
-        if lm_head is None:
-            raise ValueError("lm_head.weight not found in model")
-
-        # unshard the possibly sharded lm_head
-        lm_head = lm_head.full_tensor() if hasattr(lm_head, "full_tensor") else lm_head
-        loss_fn_kwargs.update(
-            {
-                "hidden_states": kwargs.pop("hidden_states"),
-                "labels": labels,
-                "lm_weight": lm_head,
-            }
-        )
-    else:
-        loss_fn_kwargs.update(
-            {
-                "logits": kwargs.pop("logits"),
-                "labels": kwargs.pop("labels"),
-            }
-        )
-
-    return loss_fn(**loss_fn_kwargs)
-
-
 # ---------------------------------------------------------------------------
 #  Trainer class – orchestration only
 # ---------------------------------------------------------------------------
@@ -900,36 +851,25 @@ class FinetuneRecipeForVLM(BaseRecipe):
 
     def _forward_backward_step(
         self,
-        idx,
         batch,
         *,
-        loss_buffer,
         num_label_tokens,
-        num_batches,
         is_train: bool = True,
+        is_last_microbatch: bool = True,
     ):
-        forward_backward_step(
-            idx=idx,
+        return forward_backward_step(
             batch=batch,
             device=self.dist_env.device,
             device_mesh=self.device_mesh,
             model_parts=self.model_parts,
             distributed_config=self.distributed_config,
             loss_fn=self.loss_fn,
-            calculate_loss_fn=calculate_loss,
-            loss_buffer=loss_buffer,
             num_label_tokens=num_label_tokens,
-            num_batches=num_batches,
             is_train=is_train,
-            pp_enabled=self.pp_enabled,
-            pp=getattr(self, "pp", None),
-            dp_group_size=1 if self.pp_enabled else self._get_dp_group_size(include_cp=True),
-            make_cp_batch_and_ctx_fn=make_cp_batch_and_ctx,
-            get_sync_ctx_fn=get_sync_ctx,
-            filter_forward_kwargs_fn=filter_forward_kwargs,
+            pp=getattr(self, "pp", None) if self.pp_enabled else None,
+            is_last_microbatch=is_last_microbatch,
             prepare_batch_before_cp=self._prepare_vlm_batch_for_cp,
             pp_batch_context_factory=lambda pp_batch: stage_vlm_media_for_pp(self.pp, self.model_parts, pp_batch),
-            filter_pp_batch=False,
             hidden_states_error_message=(
                 "FusedLinearCrossEntropy requires the model to output hidden states. "
                 "Set `model.text_config.output_hidden_states=True` in the config."
@@ -997,8 +937,12 @@ class FinetuneRecipeForVLM(BaseRecipe):
             if i == num_batches - 1:
                 prepare_for_final_backward(self.model_parts, pp_enabled=self.pp_enabled)
 
-            self._forward_backward_step(
-                i, batch, loss_buffer=loss_buffer, num_label_tokens=num_label_tokens, num_batches=num_batches
+            loss_buffer.append(
+                self._forward_backward_step(
+                    batch,
+                    num_label_tokens=num_label_tokens,
+                    is_last_microbatch=i == num_batches - 1,
+                )
             )
 
         grad_norm = scale_grads_and_clip_grad_norm(
@@ -1093,17 +1037,9 @@ class FinetuneRecipeForVLM(BaseRecipe):
             total_loss = torch.tensor(0.0, dtype=torch.float32, device=self.dist_env.device)
             total_num_label_tokens = 0
             for batch in val_dataloader:
-                loss_buffer = []
                 num_label_tokens = (batch["labels"] != -100).sum().item()
-                self._forward_backward_step(
-                    0,
-                    batch,
-                    loss_buffer=loss_buffer,
-                    num_label_tokens=None,
-                    num_batches=1,
-                    is_train=False,
-                )
-                total_loss += torch.sum(torch.stack(loss_buffer)).item()
+                loss = self._forward_backward_step(batch, num_label_tokens=None, is_train=False)
+                total_loss += loss.item()
                 total_num_label_tokens += num_label_tokens
 
         # Aggregate across ranks if distributed is initialized

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -28,7 +28,6 @@ except ImportError:
 import logging
 import pathlib
 import time
-from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import torch
@@ -67,6 +66,7 @@ from nemo_automodel.components.loss.masked_ce import MaskedCrossEntropy
 from nemo_automodel.components.moe.megatron.moe_utils import MoEAuxLossAutoScaler
 from nemo_automodel.components.optim.scheduler import OptimizerParamScheduler
 from nemo_automodel.components.quantization.fp8 import build_fp8_config
+from nemo_automodel.components.training.forward_backward import forward_backward_step
 from nemo_automodel.components.training.rng import ScopedRNG, StatefulRNG
 from nemo_automodel.components.training.step_scheduler import StepScheduler
 from nemo_automodel.components.training.utils import (
@@ -252,18 +252,6 @@ def build_loss_fn(cfg_loss):
         The instantiated loss function.
     """
     return cfg_loss.instantiate()
-
-
-def _move_to_device(value: Any, device: torch.device) -> Any:
-    if isinstance(value, torch.Tensor):
-        return value.to(device, non_blocking=True)
-    if isinstance(value, dict):
-        return {k: _move_to_device(v, device) if v is not None else None for k, v in value.items()}
-    if isinstance(value, list):
-        return [_move_to_device(v, device) for v in value]
-    if isinstance(value, tuple):
-        return tuple(_move_to_device(v, device) for v in value)
-    return value
 
 
 def build_dataloader(
@@ -893,6 +881,25 @@ class FinetuneRecipeForVLM(BaseRecipe):
         self.checkpointer.close()
 
     # ------------------ helpers ------------------
+    def _prepare_vlm_batch_for_cp(self, batch):
+        # Routed through __call__ so FSDP2 forward pre-hook fires and
+        # unshards the vision tower's weights before the embed/scatter.
+        model = self.model_parts[0]
+        cp_active = (
+            self.device_mesh is not None
+            and "cp" in getattr(self.device_mesh, "mesh_dim_names", ())
+            and self.device_mesh["cp"].size() > 1
+            and not self.pp_enabled
+        )
+        if cp_active and hasattr(model, "prepare_model_inputs_for_cp"):
+            mm_kwargs = {k: batch[k] for k in VLM_INPUT_KEYS if batch.get(k) is not None}
+            with torch.no_grad():
+                prepared = model(_pre_embed_only=True, **mm_kwargs)
+            for key in VLM_INPUT_KEYS:
+                batch.pop(key, None)
+            batch.update(prepared)
+        return batch
+
     def _forward_backward_step(
         self,
         idx,
@@ -903,91 +910,34 @@ class FinetuneRecipeForVLM(BaseRecipe):
         num_batches,
         is_train: bool = True,
     ):
-        batch = {k: _move_to_device(v, self.dist_env.device) for k, v in batch.items()}
-
-        # Routed through __call__ so FSDP2 forward pre-hook fires and
-        # unshards the vision tower's weights before the embed/scatter.
-        _model = self.model_parts[0]
-        _cp_active = (
-            self.device_mesh is not None
-            and "cp" in getattr(self.device_mesh, "mesh_dim_names", ())
-            and self.device_mesh["cp"].size() > 1
-            and not self.pp_enabled
+        forward_backward_step(
+            idx=idx,
+            batch=batch,
+            device=self.dist_env.device,
+            device_mesh=self.device_mesh,
+            model_parts=self.model_parts,
+            distributed_config=self.distributed_config,
+            loss_fn=self.loss_fn,
+            calculate_loss_fn=calculate_loss,
+            loss_buffer=loss_buffer,
+            num_label_tokens=num_label_tokens,
+            num_batches=num_batches,
+            is_train=is_train,
+            pp_enabled=self.pp_enabled,
+            pp=getattr(self, "pp", None),
+            dp_group_size=1 if self.pp_enabled else self._get_dp_group_size(include_cp=True),
+            make_cp_batch_and_ctx_fn=make_cp_batch_and_ctx,
+            get_sync_ctx_fn=get_sync_ctx,
+            filter_forward_kwargs_fn=filter_forward_kwargs,
+            prepare_batch_before_cp=self._prepare_vlm_batch_for_cp,
+            pp_batch_context_factory=lambda pp_batch: stage_vlm_media_for_pp(self.pp, self.model_parts, pp_batch),
+            filter_pp_batch=False,
+            pp_eval_enabled=False,
+            hidden_states_error_message=(
+                "FusedLinearCrossEntropy requires the model to output hidden states. "
+                "Set `model.text_config.output_hidden_states=True` in the config."
+            ),
         )
-        if _cp_active and hasattr(_model, "prepare_model_inputs_for_cp"):
-            mm_kwargs = {k: batch[k] for k in VLM_INPUT_KEYS if batch.get(k) is not None}
-            with torch.no_grad():
-                prepared = _model(_pre_embed_only=True, **mm_kwargs)
-            for k in VLM_INPUT_KEYS:
-                batch.pop(k, None)
-            batch.update(prepared)
-
-        train_ctx, batch = make_cp_batch_and_ctx(self.device_mesh, batch)
-        labels = batch.pop("labels")
-
-        if self.pp_enabled:
-            if not is_train:
-                logging.info("Skipping forward pass for validation because pipeline parallelism is enabled")
-                return
-
-            with train_ctx():
-                losses = [] if self.pp.info.has_last_stage else None
-                if self.pp.info.has_last_stage:
-                    masked_labels = labels.clone()
-                    targets = masked_labels
-                else:
-                    targets = None
-
-                input_ids = batch.pop("input_ids")
-                self.pp.update_seq_len(input_ids.shape[1])
-
-                with stage_vlm_media_for_pp(self.pp, self.model_parts, batch):
-                    if self.pp.info.has_first_stage:
-                        self.pp.info.schedule.step(input_ids, target=targets, losses=losses, **batch)
-                    else:
-                        self.pp.info.schedule.step(target=targets, losses=losses, **batch)
-
-            if self.pp.info.has_last_stage:
-                local_loss = torch.sum(torch.stack(losses))
-            else:
-                local_loss = torch.tensor(0.0, device=self.dist_env.device)
-
-            loss_buffer.append(local_loss.clone().detach())
-        else:
-            model = self.model_parts[0]
-            sync_ctx = (
-                get_sync_ctx(
-                    model,
-                    idx == num_batches - 1,
-                    defer_fsdp_grad_sync=getattr(self.distributed_config, "defer_fsdp_grad_sync", True),
-                )
-                if is_train
-                else nullcontext()
-            )
-            with sync_ctx, train_ctx():
-                batch = filter_forward_kwargs(model, batch)
-                if isinstance(self.loss_fn, FusedLinearCrossEntropy):
-                    # use num_logits_to_keep to avoid full logits matrix in memory
-                    out = model(logits_to_keep=1, **batch)
-                    if "hidden_states" not in out:
-                        raise ValueError(
-                            "FusedLinearCrossEntropy requires the model to output hidden states. "
-                            "Set `model.text_config.output_hidden_states=True` in the config."
-                        )
-                else:
-                    out = model(**batch)
-
-                local_loss = calculate_loss(
-                    self.loss_fn,
-                    logits=getattr(out, "logits", out),
-                    labels=labels,
-                    model=model,
-                    hidden_states=out.hidden_states[-1] if getattr(out, "hidden_states", None) is not None else None,
-                    num_label_tokens=num_label_tokens,
-                )
-                loss_buffer.append(local_loss.clone().detach())
-                if is_train:
-                    (local_loss * self._get_dp_group_size(include_cp=True)).backward()
 
     def _run_train_optim_step(self, batches, max_grad_norm: Optional[float] = None):
         """Execute a single training step.

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -930,7 +930,6 @@ class FinetuneRecipeForVLM(BaseRecipe):
             prepare_batch_before_cp=self._prepare_vlm_batch_for_cp,
             pp_batch_context_factory=lambda pp_batch: stage_vlm_media_for_pp(self.pp, self.model_parts, pp_batch),
             filter_pp_batch=False,
-            pp_eval_enabled=True,
             hidden_states_error_message=(
                 "FusedLinearCrossEntropy requires the model to output hidden states. "
                 "Set `model.text_config.output_hidden_states=True` in the config."

--- a/tests/unit_tests/recipes/llm/test_benchmark.py
+++ b/tests/unit_tests/recipes/llm/test_benchmark.py
@@ -302,10 +302,9 @@ class TestBenchmarkingRecipeRunBenchmark:
         """Test that run_benchmark sets all models to training mode."""
         mock_recipe._get_dp_group_size = MagicMock(return_value=8)
 
-        # Mock _forward_backward_step to append loss to loss_buffer
-        def mock_forward_backward_step(ga_step_idx, batch, loss_buffer=None, **kwargs):
-            if loss_buffer is not None:
-                loss_buffer.append(torch.tensor(0.5))
+        # Mock _forward_backward_step to return loss
+        def mock_forward_backward_step(batch, **kwargs):
+            return torch.tensor(0.5)
 
         mock_recipe._forward_backward_step = MagicMock(side_effect=mock_forward_backward_step)
         # Mock timers to return a dict with the expected structure
@@ -344,10 +343,9 @@ class TestBenchmarkingRecipeRunBenchmark:
         """Test that gradient accumulation steps are calculated correctly."""
         mock_recipe._get_dp_group_size = MagicMock(return_value=8)
 
-        # Mock _forward_backward_step to append loss to loss_buffer
-        def mock_forward_backward_step(ga_step_idx, batch, loss_buffer=None, **kwargs):
-            if loss_buffer is not None:
-                loss_buffer.append(torch.tensor(0.5))
+        # Mock _forward_backward_step to return loss
+        def mock_forward_backward_step(batch, **kwargs):
+            return torch.tensor(0.5)
 
         mock_recipe._forward_backward_step = MagicMock(side_effect=mock_forward_backward_step)
         # Mock timers to return a dict with the expected structure
@@ -389,10 +387,9 @@ class TestBenchmarkingRecipeRunBenchmark:
         """Test that gradients are zeroed at the start of each iteration."""
         mock_recipe._get_dp_group_size = MagicMock(return_value=8)
 
-        # Mock _forward_backward_step to append loss to loss_buffer
-        def mock_forward_backward_step(ga_step_idx, batch, loss_buffer=None, **kwargs):
-            if loss_buffer is not None:
-                loss_buffer.append(torch.tensor(0.5))
+        # Mock _forward_backward_step to return loss
+        def mock_forward_backward_step(batch, **kwargs):
+            return torch.tensor(0.5)
 
         mock_recipe._forward_backward_step = MagicMock(side_effect=mock_forward_backward_step)
         # Mock timers to return a dict with the expected structure
@@ -431,10 +428,9 @@ class TestBenchmarkingRecipeRunBenchmark:
         """Test that optimizer step is called once per iteration."""
         mock_recipe._get_dp_group_size = MagicMock(return_value=8)
 
-        # Mock _forward_backward_step to append loss to loss_buffer
-        def mock_forward_backward_step(ga_step_idx, batch, loss_buffer=None, **kwargs):
-            if loss_buffer is not None:
-                loss_buffer.append(torch.tensor(0.5))
+        # Mock _forward_backward_step to return loss
+        def mock_forward_backward_step(batch, **kwargs):
+            return torch.tensor(0.5)
 
         mock_recipe._forward_backward_step = MagicMock(side_effect=mock_forward_backward_step)
         # Mock timers to return a dict with the expected structure
@@ -473,9 +469,8 @@ class TestBenchmarkingRecipeRunBenchmark:
         mock_recipe._get_dp_group_size = MagicMock(return_value=8)
         mock_recipe._maybe_collect_garbage = MagicMock()
 
-        def mock_forward_backward_step(ga_step_idx, batch, loss_buffer=None, **kwargs):
-            if loss_buffer is not None:
-                loss_buffer.append(torch.tensor(0.5))
+        def mock_forward_backward_step(batch, **kwargs):
+            return torch.tensor(0.5)
 
         mock_recipe._forward_backward_step = MagicMock(side_effect=mock_forward_backward_step)
         mock_recipe.timers._get_global_min_max_time = MagicMock(
@@ -807,10 +802,10 @@ class TestBenchmarkingRecipeLossCalculation:
         # Track loss_buffer contents
         captured_loss_buffers = []
 
-        def mock_forward_backward_step(ga_step_idx, batch, loss_buffer=None, **kwargs):
-            if loss_buffer is not None:
-                loss_buffer.append(torch.tensor(0.5 + ga_step_idx * 0.1))
-                captured_loss_buffers.append(list(loss_buffer))
+        def mock_forward_backward_step(batch, **kwargs):
+            loss = torch.tensor(0.5 + len(captured_loss_buffers) * 0.1)
+            captured_loss_buffers.append(loss)
+            return loss
 
         mock_recipe._forward_backward_step = MagicMock(side_effect=mock_forward_backward_step)
 
@@ -846,8 +841,8 @@ class TestBenchmarkingRecipeLossCalculation:
         with patch("torch.distributed.barrier"):
             mock_recipe.run_benchmark()
 
-        # Verify loss_buffer was populated correctly (8 GA steps)
-        assert len(captured_loss_buffers[-1]) == 8
+        # Verify losses were produced for all 8 GA steps
+        assert len(captured_loss_buffers) == 8
 
     def test_dp_allreduce_called_for_loss(self, mock_recipe):
         """Test that DP allreduce is called for loss synchronization."""
@@ -862,9 +857,8 @@ class TestBenchmarkingRecipeLossCalculation:
         mock_recipe.__dict__["_dp_allreduce"] = MagicMock(side_effect=track_allreduce)
 
         # Mock forward_backward_step
-        def mock_forward_backward_step(ga_step_idx, batch, loss_buffer=None, **kwargs):
-            if loss_buffer is not None:
-                loss_buffer.append(torch.tensor(0.5))
+        def mock_forward_backward_step(batch, **kwargs):
+            return torch.tensor(0.5)
 
         mock_recipe._forward_backward_step = MagicMock(side_effect=mock_forward_backward_step)
 

--- a/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
+++ b/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
@@ -347,16 +347,16 @@ def test_run_train_step_supports_tensor_outputs(monkeypatch):
         return torch.tensor(1.0, requires_grad=True)
 
     monkeypatch.setattr(
-        "nemo_automodel.recipes.vlm.finetune.make_cp_batch_and_ctx",
+        "nemo_automodel.components.training.forward_backward.make_cp_batch_and_ctx",
         lambda device_mesh, batch: (lambda: nullcontext(), batch),
     )
     monkeypatch.setattr(
-        "nemo_automodel.recipes.vlm.finetune.get_sync_ctx",
+        "nemo_automodel.components.training.forward_backward.get_sync_ctx",
         lambda model, is_last, defer_fsdp_grad_sync=True: nullcontext(),
     )
 
     calculate_mock = MagicMock(side_effect=fake_calculate_loss)
-    monkeypatch.setattr("nemo_automodel.recipes.vlm.finetune.calculate_loss", calculate_mock)
+    monkeypatch.setattr("nemo_automodel.components.training.forward_backward.calculate_loss", calculate_mock)
 
     grad_clip_mock = MagicMock(return_value=2.5)
     monkeypatch.setattr(
@@ -442,10 +442,10 @@ def test_run_train_step_pp_zero_label_tokens_no_nan(monkeypatch):
     """
     recipe, batches = _build_pp_recipe_for_optim_step(num_label_tokens_in_batch=0)
 
-    def fake_forward_backward_step(idx, batch, loss_buffer, num_label_tokens, num_batches):
+    def fake_forward_backward_step(batch, *, num_label_tokens, is_last_microbatch=True, is_train=True):
         # Mirror the PP path: append a finite per-microbatch sum loss. With the guard,
         # this must still yield reporting_loss == 0.0.
-        loss_buffer.append(torch.tensor(5.0))
+        return torch.tensor(5.0)
 
     recipe._forward_backward_step = fake_forward_backward_step
     _patch_pp_optim_step_dependencies(monkeypatch)
@@ -464,8 +464,8 @@ def test_run_train_step_pp_nonzero_label_tokens_divides(monkeypatch):
     """PP reporting loss is the summed microbatch loss divided by num_label_tokens."""
     recipe, batches = _build_pp_recipe_for_optim_step(num_label_tokens_in_batch=4)
 
-    def fake_forward_backward_step(idx, batch, loss_buffer, num_label_tokens, num_batches):
-        loss_buffer.append(torch.tensor(8.0))
+    def fake_forward_backward_step(batch, *, num_label_tokens, is_last_microbatch=True, is_train=True):
+        return torch.tensor(8.0)
 
     recipe._forward_backward_step = fake_forward_backward_step
     _patch_pp_optim_step_dependencies(monkeypatch)
@@ -989,8 +989,8 @@ from nemo_automodel.recipes.vlm.finetune import (
     build_checkpoint_config,
     build_lr_scheduler,
     build_step_scheduler,
-    calculate_loss,
 )
+from nemo_automodel.components.training.forward_backward import calculate_loss
 
 # -----------------------------------------------------------------------------
 # build_step_scheduler tests
@@ -1437,7 +1437,7 @@ class TestForwardBackwardStepPP:
         pp_recipe.pp = _MockAutoPipeline()
 
         monkeypatch.setattr(
-            "nemo_automodel.recipes.vlm.finetune.make_cp_batch_and_ctx",
+            "nemo_automodel.components.training.forward_backward.make_cp_batch_and_ctx",
             lambda device_mesh, batch: (lambda: nullcontext(), batch),
         )
 
@@ -1445,28 +1445,22 @@ class TestForwardBackwardStepPP:
             "labels": torch.tensor([[1, 2]]),
             "input_ids": torch.tensor([[1, 2]]),
         }
-        loss_buffer = []
-
-        pp_recipe._forward_backward_step(
-            idx=0,
+        loss = pp_recipe._forward_backward_step(
             batch=batch,
-            loss_buffer=loss_buffer,
             num_label_tokens=2,
-            num_batches=1,
             is_train=False,  # Validation mode
         )
 
         pp_recipe.pp.info.schedule.eval.assert_called_once()
         pp_recipe.pp.info.schedule.step.assert_not_called()
-        assert len(loss_buffer) == 1
-        assert torch.isclose(loss_buffer[0], torch.tensor(1.0))
+        assert torch.isclose(loss, torch.tensor(1.0))
 
     def test_pp_vlm_chunking_equal_images_and_batch(self, pp_recipe, monkeypatch):
         """Test VLM pixel_values chunking when n_images == batch_size."""
         pp_recipe.pp = _MockAutoPipeline(has_first_stage=True, has_last_stage=True, n_microbatches=2)
 
         monkeypatch.setattr(
-            "nemo_automodel.recipes.vlm.finetune.make_cp_batch_and_ctx",
+            "nemo_automodel.components.training.forward_backward.make_cp_batch_and_ctx",
             lambda device_mesh, batch: (lambda: nullcontext(), batch),
         )
 
@@ -1483,7 +1477,6 @@ class TestForwardBackwardStepPP:
             "image_grid_hws": image_grid_hws,
         }
         _prepare_pp_vlm_batch(batch)
-        loss_buffer = []
         captured_chunks = {}
 
         def step_side_effect(*args, **kwargs):
@@ -1496,12 +1489,9 @@ class TestForwardBackwardStepPP:
 
         pp_recipe.pp.info.schedule.step = MagicMock(side_effect=step_side_effect)
 
-        pp_recipe._forward_backward_step(
-            idx=0,
+        loss = pp_recipe._forward_backward_step(
             batch=batch,
-            loss_buffer=loss_buffer,
             num_label_tokens=40,
-            num_batches=1,
             is_train=True,
         )
 
@@ -1520,14 +1510,14 @@ class TestForwardBackwardStepPP:
         pp_recipe.pp.info.schedule.step.assert_called_once()
 
         # Verify loss was computed
-        assert len(loss_buffer) == 1
+        assert isinstance(loss, torch.Tensor)
 
     def test_pp_vlm_chunking_videos_uses_video_grid_and_counts(self, pp_recipe, monkeypatch):
         """Video tensors are chunked by per-sample video counts before schedule.step."""
         pp_recipe.pp = _MockAutoPipeline(has_first_stage=True, has_last_stage=True, n_microbatches=2)
 
         monkeypatch.setattr(
-            "nemo_automodel.recipes.vlm.finetune.make_cp_batch_and_ctx",
+            "nemo_automodel.components.training.forward_backward.make_cp_batch_and_ctx",
             lambda device_mesh, batch: (lambda: nullcontext(), batch),
         )
 
@@ -1559,14 +1549,9 @@ class TestForwardBackwardStepPP:
             "n_videos_per_sample": n_videos_per_sample,
         }
         _prepare_pp_vlm_batch(batch)
-        loss_buffer = []
-
-        pp_recipe._forward_backward_step(
-            idx=0,
+        loss = pp_recipe._forward_backward_step(
             batch=batch,
-            loss_buffer=loss_buffer,
             num_label_tokens=40,
-            num_batches=1,
             is_train=True,
         )
 
@@ -1574,7 +1559,7 @@ class TestForwardBackwardStepPP:
         assert model._vlm_pixel_values_videos_chunks is None
         assert model._vlm_video_grid_thw_chunks is None
         assert model._vlm_chunk_idx is None
-        assert len(loss_buffer) == 1
+        assert isinstance(loss, torch.Tensor)
 
     def test_pp_vlm_chunking_image_and_video_mixed(self, pp_recipe, monkeypatch):
         """When a batch carries both images and videos, both streams chunk independently
@@ -1582,7 +1567,7 @@ class TestForwardBackwardStepPP:
         pp_recipe.pp = _MockAutoPipeline(has_first_stage=True, has_last_stage=True, n_microbatches=2)
 
         monkeypatch.setattr(
-            "nemo_automodel.recipes.vlm.finetune.make_cp_batch_and_ctx",
+            "nemo_automodel.components.training.forward_backward.make_cp_batch_and_ctx",
             lambda device_mesh, batch: (lambda: nullcontext(), batch),
         )
 
@@ -1642,14 +1627,9 @@ class TestForwardBackwardStepPP:
             "n_videos_per_sample": n_videos_per_sample,
         }
         _prepare_pp_vlm_batch(batch)
-        loss_buffer = []
-
-        pp_recipe._forward_backward_step(
-            idx=0,
+        loss = pp_recipe._forward_backward_step(
             batch=batch,
-            loss_buffer=loss_buffer,
             num_label_tokens=40,
-            num_batches=1,
             is_train=True,
         )
 
@@ -1659,14 +1639,14 @@ class TestForwardBackwardStepPP:
         assert model._vlm_pixel_values_videos_chunks is None
         assert model._vlm_video_grid_thw_chunks is None
         assert model._vlm_chunk_idx is None
-        assert len(loss_buffer) == 1
+        assert isinstance(loss, torch.Tensor)
 
     def test_pp_vlm_chunking_with_image_grid_thw(self, pp_recipe, monkeypatch):
         """Test VLM pixel_values chunking with image_grid_thw (3D grid) instead of image_grid_hws."""
         pp_recipe.pp = _MockAutoPipeline(has_first_stage=True, has_last_stage=True, n_microbatches=2)
 
         monkeypatch.setattr(
-            "nemo_automodel.recipes.vlm.finetune.make_cp_batch_and_ctx",
+            "nemo_automodel.components.training.forward_backward.make_cp_batch_and_ctx",
             lambda device_mesh, batch: (lambda: nullcontext(), batch),
         )
 
@@ -1683,14 +1663,9 @@ class TestForwardBackwardStepPP:
             "image_grid_thw": image_grid_thw,  # Using thw instead of hws
         }
         _prepare_pp_vlm_batch(batch)
-        loss_buffer = []
-
-        pp_recipe._forward_backward_step(
-            idx=0,
+        loss = pp_recipe._forward_backward_step(
             batch=batch,
-            loss_buffer=loss_buffer,
             num_label_tokens=40,
-            num_batches=1,
             is_train=True,
         )
 
@@ -1704,14 +1679,14 @@ class TestForwardBackwardStepPP:
         pp_recipe.pp.info.schedule.step.assert_called_once()
 
         # Verify loss was computed
-        assert len(loss_buffer) == 1
+        assert isinstance(loss, torch.Tensor)
 
     def test_pp_vlm_chunking_qwen35_ep4_pp2_local_batch_images(self, pp_recipe, monkeypatch):
         """Qwen3.5 35B EP4/PP2-style local batch keeps proper image chunks during schedule.step."""
         pp_recipe.pp = _MockAutoPipeline(has_first_stage=True, has_last_stage=True, n_microbatches=2)
 
         monkeypatch.setattr(
-            "nemo_automodel.recipes.vlm.finetune.make_cp_batch_and_ctx",
+            "nemo_automodel.components.training.forward_backward.make_cp_batch_and_ctx",
             lambda device_mesh, batch: (lambda: nullcontext(), batch),
         )
 
@@ -1726,7 +1701,6 @@ class TestForwardBackwardStepPP:
             "n_images_per_sample": torch.tensor([1, 1]),
         }
         _prepare_pp_vlm_batch(batch)
-        loss_buffer = []
         captured_chunks = {}
 
         def step_side_effect(*args, **kwargs):
@@ -1738,12 +1712,9 @@ class TestForwardBackwardStepPP:
 
         pp_recipe.pp.info.schedule.step = MagicMock(side_effect=step_side_effect)
 
-        pp_recipe._forward_backward_step(
-            idx=0,
+        loss = pp_recipe._forward_backward_step(
             batch=batch,
-            loss_buffer=loss_buffer,
             num_label_tokens=20,
-            num_batches=1,
             is_train=True,
         )
 
@@ -1753,7 +1724,7 @@ class TestForwardBackwardStepPP:
         assert torch.equal(captured_chunks["image_grid"][0], image_grid_thw[:1])
         assert torch.equal(captured_chunks["image_grid"][1], image_grid_thw[1:])
         assert pp_recipe.model_parts[0]._vlm_pixel_values_chunks is None
-        assert len(loss_buffer) == 1
+        assert isinstance(loss, torch.Tensor)
 
     def test_pp_vlm_chunking_mismatched_images_raises(self):
         """When media cannot be aligned to samples, VLM PP data prep raises."""
@@ -1777,7 +1748,7 @@ class TestForwardBackwardStepPP:
         pp_recipe.pp = _MockAutoPipeline(has_first_stage=True, has_last_stage=True, n_microbatches=2)
 
         monkeypatch.setattr(
-            "nemo_automodel.recipes.vlm.finetune.make_cp_batch_and_ctx",
+            "nemo_automodel.components.training.forward_backward.make_cp_batch_and_ctx",
             lambda device_mesh, batch: (lambda: nullcontext(), batch),
         )
 
@@ -1794,14 +1765,9 @@ class TestForwardBackwardStepPP:
             "image_sizes": image_sizes,
         }
         _prepare_pp_vlm_batch(batch)
-        loss_buffer = []
-
-        pp_recipe._forward_backward_step(
-            idx=0,
+        loss = pp_recipe._forward_backward_step(
             batch=batch,
-            loss_buffer=loss_buffer,
             num_label_tokens=40,
-            num_batches=1,
             is_train=True,
         )
 
@@ -1810,14 +1776,14 @@ class TestForwardBackwardStepPP:
         assert model._vlm_image_grid_hws_chunks is None
         assert model._vlm_chunk_idx is None
         pp_recipe.pp.info.schedule.step.assert_called_once()
-        assert len(loss_buffer) == 1
+        assert isinstance(loss, torch.Tensor)
 
     def test_pp_vlm_chunking_4d_pixel_values(self, pp_recipe, monkeypatch):
         """Test VLM pixel_values chunking when pixel_values is 4D [N, C, H, W]."""
         pp_recipe.pp = _MockAutoPipeline(has_first_stage=True, has_last_stage=True, n_microbatches=2)
 
         monkeypatch.setattr(
-            "nemo_automodel.recipes.vlm.finetune.make_cp_batch_and_ctx",
+            "nemo_automodel.components.training.forward_backward.make_cp_batch_and_ctx",
             lambda device_mesh, batch: (lambda: nullcontext(), batch),
         )
 
@@ -1833,14 +1799,9 @@ class TestForwardBackwardStepPP:
             "image_grid_hws": image_grid_hws,
         }
         _prepare_pp_vlm_batch(batch)
-        loss_buffer = []
-
-        pp_recipe._forward_backward_step(
-            idx=0,
+        loss = pp_recipe._forward_backward_step(
             batch=batch,
-            loss_buffer=loss_buffer,
             num_label_tokens=40,
-            num_batches=1,
             is_train=True,
         )
 
@@ -1849,7 +1810,7 @@ class TestForwardBackwardStepPP:
         assert model._vlm_image_grid_hws_chunks is None
         assert model._vlm_chunk_idx is None
         pp_recipe.pp.info.schedule.step.assert_called_once()
-        assert len(loss_buffer) == 1
+        assert isinstance(loss, torch.Tensor)
 
     def test_pp_last_stage_computes_loss(self, pp_recipe, monkeypatch):
         """Test that last stage computes and buffers loss."""
@@ -1865,7 +1826,7 @@ class TestForwardBackwardStepPP:
         pp_recipe.pp = pp
 
         monkeypatch.setattr(
-            "nemo_automodel.recipes.vlm.finetune.make_cp_batch_and_ctx",
+            "nemo_automodel.components.training.forward_backward.make_cp_batch_and_ctx",
             lambda device_mesh, batch: (lambda: nullcontext(), batch),
         )
 
@@ -1873,20 +1834,15 @@ class TestForwardBackwardStepPP:
             "labels": torch.tensor([[1, 2]]),
             "input_ids": torch.tensor([[1, 2]]),
         }
-        loss_buffer = []
-
-        pp_recipe._forward_backward_step(
-            idx=0,
+        loss = pp_recipe._forward_backward_step(
             batch=batch,
-            loss_buffer=loss_buffer,
             num_label_tokens=2,
-            num_batches=1,
             is_train=True,
         )
 
         # Loss should be sum of microbatch losses
-        assert len(loss_buffer) == 1
-        assert torch.isclose(loss_buffer[0], torch.tensor(0.8))
+        assert isinstance(loss, torch.Tensor)
+        assert torch.isclose(loss, torch.tensor(0.8))
 
     def test_pp_non_last_stage_returns_zero_loss(self, pp_recipe, monkeypatch):
         """Test that non-last stage returns zero loss."""
@@ -1894,7 +1850,7 @@ class TestForwardBackwardStepPP:
         pp_recipe.pp = pp
 
         monkeypatch.setattr(
-            "nemo_automodel.recipes.vlm.finetune.make_cp_batch_and_ctx",
+            "nemo_automodel.components.training.forward_backward.make_cp_batch_and_ctx",
             lambda device_mesh, batch: (lambda: nullcontext(), batch),
         )
 
@@ -1902,19 +1858,14 @@ class TestForwardBackwardStepPP:
             "labels": torch.tensor([[1, 2]]),
             "input_ids": torch.tensor([[1, 2]]),
         }
-        loss_buffer = []
-
-        pp_recipe._forward_backward_step(
-            idx=0,
+        loss = pp_recipe._forward_backward_step(
             batch=batch,
-            loss_buffer=loss_buffer,
             num_label_tokens=2,
-            num_batches=1,
             is_train=True,
         )
 
-        assert len(loss_buffer) == 1
-        assert loss_buffer[0].item() == 0.0
+        assert isinstance(loss, torch.Tensor)
+        assert loss.item() == 0.0
 
     def test_pp_non_first_stage_skips_input_ids(self, pp_recipe, monkeypatch):
         """Test that non-first stage doesn't pass input_ids to schedule."""
@@ -1931,7 +1882,7 @@ class TestForwardBackwardStepPP:
         pp_recipe.pp = pp
 
         monkeypatch.setattr(
-            "nemo_automodel.recipes.vlm.finetune.make_cp_batch_and_ctx",
+            "nemo_automodel.components.training.forward_backward.make_cp_batch_and_ctx",
             lambda device_mesh, batch: (lambda: nullcontext(), batch),
         )
 
@@ -1939,14 +1890,9 @@ class TestForwardBackwardStepPP:
             "labels": torch.tensor([[1, 2]]),
             "input_ids": torch.tensor([[1, 2]]),
         }
-        loss_buffer = []
-
-        pp_recipe._forward_backward_step(
-            idx=0,
+        loss = pp_recipe._forward_backward_step(
             batch=batch,
-            loss_buffer=loss_buffer,
             num_label_tokens=2,
-            num_batches=1,
             is_train=True,
         )
 
@@ -1969,9 +1915,9 @@ def test_vlm_run_validation_epoch_pp_sends_loss_from_last_stage(monkeypatch):
 
     calls = []
 
-    def fake_forward_backward_step(idx, batch, *, loss_buffer, num_label_tokens, num_batches, is_train):
-        calls.append((idx, num_label_tokens, num_batches, is_train))
-        loss_buffer.append(torch.tensor(6.0))
+    def fake_forward_backward_step(batch, *, num_label_tokens, is_train, is_last_microbatch=True):
+        calls.append((num_label_tokens, is_train, is_last_microbatch))
+        return torch.tensor(6.0)
 
     recipe._forward_backward_step = fake_forward_backward_step
     monkeypatch.setattr("nemo_automodel.recipes.vlm.finetune.ScopedRNG", lambda **kwargs: nullcontext())
@@ -1986,7 +1932,7 @@ def test_vlm_run_validation_epoch_pp_sends_loss_from_last_stage(monkeypatch):
     val_dataloader = [{"input_ids": torch.tensor([[1, 2, 3]]), "labels": torch.tensor([[1, 2, 3]])}]
     result = recipe._run_validation_epoch(val_dataloader)
 
-    assert calls == [(0, None, 1, False)]
+    assert calls == [(None, False, True)]
     assert result.metrics["val_loss"] == pytest.approx(2.0)
     assert result.metrics["num_label_tokens"] == 3
     assert len(send_calls) == 2
@@ -2166,11 +2112,11 @@ class TestForwardBackwardStepNonPP:
         non_pp_recipe.__dict__["loss_fn"] = FusedLinearCrossEntropy()
 
         monkeypatch.setattr(
-            "nemo_automodel.recipes.vlm.finetune.make_cp_batch_and_ctx",
+            "nemo_automodel.components.training.forward_backward.make_cp_batch_and_ctx",
             lambda device_mesh, batch: (lambda: nullcontext(), batch),
         )
         monkeypatch.setattr(
-            "nemo_automodel.recipes.vlm.finetune.get_sync_ctx",
+            "nemo_automodel.components.training.forward_backward.get_sync_ctx",
             lambda model, is_last, defer_fsdp_grad_sync=True: nullcontext(),
         )
 
@@ -2178,19 +2124,13 @@ class TestForwardBackwardStepNonPP:
             "labels": torch.randint(0, 50, (2, 5)),
             "input_ids": torch.randint(0, 100, (2, 5)),
         }
-        loss_buffer = []
-
-        non_pp_recipe._forward_backward_step(
-            idx=0,
+        loss = non_pp_recipe._forward_backward_step(
             batch=batch,
-            loss_buffer=loss_buffer,
             num_label_tokens=10,
-            num_batches=1,
             is_train=True,
         )
 
-        assert len(loss_buffer) == 1
-        assert isinstance(loss_buffer[0], torch.Tensor)
+        assert isinstance(loss, torch.Tensor)
 
     def test_non_pp_fused_ce_requires_hidden_states(self, monkeypatch):
         """Test that FusedLinearCE raises error when hidden_states not in output."""
@@ -2213,11 +2153,11 @@ class TestForwardBackwardStepNonPP:
         non_pp_recipe.__dict__["loss_fn"] = FusedLinearCrossEntropy()
 
         monkeypatch.setattr(
-            "nemo_automodel.recipes.vlm.finetune.make_cp_batch_and_ctx",
+            "nemo_automodel.components.training.forward_backward.make_cp_batch_and_ctx",
             lambda device_mesh, batch: (lambda: nullcontext(), batch),
         )
         monkeypatch.setattr(
-            "nemo_automodel.recipes.vlm.finetune.get_sync_ctx",
+            "nemo_automodel.components.training.forward_backward.get_sync_ctx",
             lambda model, is_last, defer_fsdp_grad_sync=True: nullcontext(),
         )
 
@@ -2225,15 +2165,10 @@ class TestForwardBackwardStepNonPP:
             "labels": torch.randint(0, 50, (2, 5)),
             "input_ids": torch.randint(0, 100, (2, 5)),
         }
-        loss_buffer = []
-
         with pytest.raises(ValueError, match="FusedLinearCrossEntropy requires the model to output hidden states"):
             non_pp_recipe._forward_backward_step(
-                idx=0,
                 batch=batch,
-                loss_buffer=loss_buffer,
                 num_label_tokens=10,
-                num_batches=1,
                 is_train=True,
             )
 
@@ -2256,11 +2191,11 @@ class TestForwardBackwardStepNonPP:
         non_pp_recipe.__dict__["loss_fn"] = MaskedCrossEntropy()
 
         monkeypatch.setattr(
-            "nemo_automodel.recipes.vlm.finetune.make_cp_batch_and_ctx",
+            "nemo_automodel.components.training.forward_backward.make_cp_batch_and_ctx",
             lambda device_mesh, batch: (lambda: nullcontext(), batch),
         )
         monkeypatch.setattr(
-            "nemo_automodel.recipes.vlm.finetune.get_sync_ctx",
+            "nemo_automodel.components.training.forward_backward.get_sync_ctx",
             lambda model, is_last, defer_fsdp_grad_sync=True: nullcontext(),
         )
 
@@ -2268,19 +2203,13 @@ class TestForwardBackwardStepNonPP:
             "labels": torch.randint(0, 50, (2, 5)),
             "input_ids": torch.randint(0, 100, (2, 5)),
         }
-        loss_buffer = []
-
-        non_pp_recipe._forward_backward_step(
-            idx=0,
+        loss = non_pp_recipe._forward_backward_step(
             batch=batch,
-            loss_buffer=loss_buffer,
             num_label_tokens=10,
-            num_batches=1,
             is_train=True,
         )
 
-        assert len(loss_buffer) == 1
-        assert isinstance(loss_buffer[0], torch.Tensor)
+        assert isinstance(loss, torch.Tensor)
 
     def test_non_pp_validation_mode_no_backward(self, monkeypatch):
         """Test that validation mode doesn't call backward."""
@@ -2299,7 +2228,7 @@ class TestForwardBackwardStepNonPP:
         non_pp_recipe.__dict__["loss_fn"] = MaskedCrossEntropy()
 
         monkeypatch.setattr(
-            "nemo_automodel.recipes.vlm.finetune.make_cp_batch_and_ctx",
+            "nemo_automodel.components.training.forward_backward.make_cp_batch_and_ctx",
             lambda device_mesh, batch: (lambda: nullcontext(), batch),
         )
 
@@ -2307,19 +2236,14 @@ class TestForwardBackwardStepNonPP:
             "labels": torch.randint(0, 50, (2, 5)),
             "input_ids": torch.randint(0, 100, (2, 5)),
         }
-        loss_buffer = []
-
         # Should complete without error and not call backward
-        non_pp_recipe._forward_backward_step(
-            idx=0,
+        loss = non_pp_recipe._forward_backward_step(
             batch=batch,
-            loss_buffer=loss_buffer,
             num_label_tokens=10,
-            num_batches=1,
             is_train=False,  # Validation mode
         )
 
-        assert len(loss_buffer) == 1
+        assert isinstance(loss, torch.Tensor)
 
     def test_non_pp_handles_dict_batch_values(self, monkeypatch):
         """Test that nested dict values in batch are moved to device."""
@@ -2333,7 +2257,7 @@ class TestForwardBackwardStepNonPP:
         non_pp_recipe.__dict__["loss_fn"] = MaskedCrossEntropy()
 
         monkeypatch.setattr(
-            "nemo_automodel.recipes.vlm.finetune.make_cp_batch_and_ctx",
+            "nemo_automodel.components.training.forward_backward.make_cp_batch_and_ctx",
             lambda device_mesh, batch: (lambda: nullcontext(), batch),
         )
 
@@ -2346,19 +2270,14 @@ class TestForwardBackwardStepNonPP:
                 "none_value": None,
             },
         }
-        loss_buffer = []
-
         # Should handle nested dict without error
-        non_pp_recipe._forward_backward_step(
-            idx=0,
+        loss = non_pp_recipe._forward_backward_step(
             batch=batch,
-            loss_buffer=loss_buffer,
             num_label_tokens=10,
-            num_batches=1,
             is_train=False,
         )
 
-        assert len(loss_buffer) == 1
+        assert isinstance(loss, torch.Tensor)
 
 
 # -----------------------------------------------------------------------------

--- a/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
+++ b/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
@@ -1374,13 +1374,14 @@ class _MockPPInfo:
         self.schedule = MagicMock()
         self.schedule._n_microbatches = n_microbatches
 
-        def step_side_effect(*args, **kwargs):
+        def schedule_side_effect(*args, **kwargs):
             if self._add_losses and kwargs.get("losses") is not None:
                 # Add mock losses for each microbatch
                 for _ in range(n_microbatches):
                     kwargs["losses"].append(torch.tensor(0.5))
 
-        self.schedule.step = MagicMock(side_effect=step_side_effect)
+        self.schedule.step = MagicMock(side_effect=schedule_side_effect)
+        self.schedule.eval = MagicMock(side_effect=schedule_side_effect)
 
 
 class _MockAutoPipeline:
@@ -1431,8 +1432,8 @@ class TestForwardBackwardStepPP:
         """Create a recipe configured for PP testing."""
         return _create_pp_recipe()
 
-    def test_pp_skips_validation_forward(self, pp_recipe, monkeypatch):
-        """Test that PP mode skips forward pass during validation."""
+    def test_pp_uses_eval_for_validation(self, pp_recipe, monkeypatch):
+        """Test that PP mode uses schedule.eval() during validation."""
         pp_recipe.pp = _MockAutoPipeline()
 
         monkeypatch.setattr(
@@ -1446,7 +1447,6 @@ class TestForwardBackwardStepPP:
         }
         loss_buffer = []
 
-        # Should return early without error
         pp_recipe._forward_backward_step(
             idx=0,
             batch=batch,
@@ -1456,8 +1456,10 @@ class TestForwardBackwardStepPP:
             is_train=False,  # Validation mode
         )
 
-        # Loss buffer should be empty (no forward pass)
-        assert len(loss_buffer) == 0
+        pp_recipe.pp.info.schedule.eval.assert_called_once()
+        pp_recipe.pp.info.schedule.step.assert_not_called()
+        assert len(loss_buffer) == 1
+        assert torch.isclose(loss_buffer[0], torch.tensor(1.0))
 
     def test_pp_vlm_chunking_equal_images_and_batch(self, pp_recipe, monkeypatch):
         """Test VLM pixel_values chunking when n_images == batch_size."""
@@ -1953,6 +1955,43 @@ class TestForwardBackwardStepPP:
         args, kwargs = step_calls[0]
         assert len(args) == 0  # No positional args
         assert "target" in kwargs
+
+
+@pytest.mark.cuda(False)
+def test_vlm_run_validation_epoch_pp_sends_loss_from_last_stage(monkeypatch):
+    """VLM PP validation should reuse _forward_backward_step and report from the last stage."""
+    recipe = _create_pp_recipe()
+    recipe.dist_env = SimpleNamespace(device=torch.device("cpu"), rank=1, is_main=False)
+    recipe.device_mesh = SimpleNamespace(mesh=torch.tensor([[0, 1]]), mesh_dim_names=("dp", "pp"))
+    recipe.step_scheduler = SimpleNamespace(step=7, epoch=2)
+    recipe.optimizer = [SimpleNamespace(param_groups=[{"lr": 0.01}])]
+    recipe._dp_allreduce = lambda tensor, include_cp=False: tensor
+
+    calls = []
+
+    def fake_forward_backward_step(idx, batch, *, loss_buffer, num_label_tokens, num_batches, is_train):
+        calls.append((idx, num_label_tokens, num_batches, is_train))
+        loss_buffer.append(torch.tensor(6.0))
+
+    recipe._forward_backward_step = fake_forward_backward_step
+    monkeypatch.setattr("nemo_automodel.recipes.vlm.finetune.ScopedRNG", lambda **kwargs: nullcontext())
+
+    send_calls = []
+
+    def fake_send(tensor, dst):
+        send_calls.append((tensor.clone(), dst))
+
+    monkeypatch.setattr("torch.distributed.send", fake_send)
+
+    val_dataloader = [{"input_ids": torch.tensor([[1, 2, 3]]), "labels": torch.tensor([[1, 2, 3]])}]
+    result = recipe._run_validation_epoch(val_dataloader)
+
+    assert calls == [(0, None, 1, False)]
+    assert result.metrics["val_loss"] == pytest.approx(2.0)
+    assert result.metrics["num_label_tokens"] == 3
+    assert len(send_calls) == 2
+    assert send_calls[0][0].item() == pytest.approx(2.0)
+    assert send_calls[1][0].item() == 3
 
 
 # -----------------------------------------------------------------------------
@@ -2582,6 +2621,56 @@ def test_vlm_rope_fusion_stays_false_when_already_disabled(monkeypatch):
     trainer.setup()
 
     assert cfg.model.backend.rope_fusion is False
+
+
+def test_vlm_setup_wraps_validation_dataloader_for_pp(monkeypatch):
+    """PP VLM validation dataloader gets the same media microbatch prep as training."""
+    cfg = _minimal_vlm_cfg(cp_size=1, rope_fusion=False)
+    cfg.validation_dataset = ConfigNode({"path_or_dataset": "val"})
+    cfg.distributed.pipeline = ConfigNode({"pp_microbatch_size": 2})
+    cfg.step_scheduler.local_batch_size = 4
+
+    _patch_vlm_setup_minimals(monkeypatch, cp_size=1)
+
+    class FakeAutoPipeline:
+        pp_batch_size = 4
+        pp_microbatch_size = 2
+
+        def __init__(self):
+            self.parts = [DummyModel()]
+
+    fake_pipeline = FakeAutoPipeline()
+    pipeline_config = SimpleNamespace()
+    monkeypatch.setattr("nemo_automodel.recipes.vlm.finetune.AutoPipeline", FakeAutoPipeline)
+    monkeypatch.setattr("nemo_automodel.recipes.vlm.finetune._supports_logits_to_keep", lambda model: True)
+    monkeypatch.setattr("nemo_automodel.recipes.vlm.finetune.build_model", lambda *a, **k: fake_pipeline)
+    monkeypatch.setattr(
+        "nemo_automodel.recipes.vlm.finetune.setup_distributed",
+        lambda cfg, world_size: SimpleNamespace(
+            strategy_config=None,
+            pipeline_config=pipeline_config,
+            moe_config=None,
+            activation_checkpointing=False,
+            pp_enabled=True,
+            pp_size=2,
+            device_mesh=None,
+            moe_mesh=None,
+            cp_size=1,
+        ),
+    )
+
+    dataloader_calls = []
+
+    def fake_build_dataloader(*args, **kwargs):
+        dataloader_calls.append(kwargs)
+        return ("dl", "proc")
+
+    monkeypatch.setattr("nemo_automodel.recipes.vlm.finetune.build_dataloader", fake_build_dataloader)
+
+    trainer = FinetuneRecipeForVLM(cfg)
+    trainer.setup()
+
+    assert [call["pp_n_microbatches"] for call in dataloader_calls] == [2, 2]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/recipes/test_train_ft.py
+++ b/tests/unit_tests/recipes/test_train_ft.py
@@ -808,7 +808,7 @@ def test_forward_backward_step_pp_uses_eval_for_validation(monkeypatch):
 
     # Mock make_cp_batch_and_ctx to return a no-op context manager
     monkeypatch.setattr(
-        "nemo_automodel.recipes.llm.train_ft.make_cp_batch_and_ctx",
+        "nemo_automodel.components.training.forward_backward.make_cp_batch_and_ctx",
         lambda device_mesh, batch, **kwargs: (nullcontext, batch),
     )
 
@@ -818,15 +818,7 @@ def test_forward_backward_step_pp_uses_eval_for_validation(monkeypatch):
         "labels": torch.tensor([[1, 2, 3]]),
     }
 
-    loss_buffer = []
-    recipe._forward_backward_step(
-        idx=0,
-        batch=batch,
-        loss_buffer=loss_buffer,
-        num_label_tokens=None,
-        num_batches=1,
-        is_train=False,  # Validation mode
-    )
+    recipe._forward_backward_step(batch=batch, num_label_tokens=None, is_train=False)
 
     # Should use eval, not step
     assert len(pp_info.schedule.eval_calls) == 1, "schedule.eval() should be called once for validation"
@@ -842,7 +834,7 @@ def test_forward_backward_step_pp_uses_step_for_training(monkeypatch):
 
     # Mock make_cp_batch_and_ctx to return a no-op context manager
     monkeypatch.setattr(
-        "nemo_automodel.recipes.llm.train_ft.make_cp_batch_and_ctx",
+        "nemo_automodel.components.training.forward_backward.make_cp_batch_and_ctx",
         lambda device_mesh, batch, **kwargs: (nullcontext, batch),
     )
 
@@ -852,15 +844,7 @@ def test_forward_backward_step_pp_uses_step_for_training(monkeypatch):
         "labels": torch.tensor([[1, 2, 3]]),
     }
 
-    loss_buffer = []
-    recipe._forward_backward_step(
-        idx=0,
-        batch=batch,
-        loss_buffer=loss_buffer,
-        num_label_tokens=None,
-        num_batches=1,
-        is_train=True,  # Training mode
-    )
+    recipe._forward_backward_step(batch=batch, num_label_tokens=None, is_train=True)
 
     # Should use step, not eval
     assert len(pp_info.schedule.step_calls) == 1, "schedule.step() should be called once for training"
@@ -876,7 +860,7 @@ def test_forward_backward_step_pp_non_first_stage_uses_eval_for_validation(monke
 
     # Mock make_cp_batch_and_ctx to return a no-op context manager
     monkeypatch.setattr(
-        "nemo_automodel.recipes.llm.train_ft.make_cp_batch_and_ctx",
+        "nemo_automodel.components.training.forward_backward.make_cp_batch_and_ctx",
         lambda device_mesh, batch, **kwargs: (nullcontext, batch),
     )
 
@@ -886,15 +870,7 @@ def test_forward_backward_step_pp_non_first_stage_uses_eval_for_validation(monke
         "labels": torch.tensor([[1, 2, 3]]),
     }
 
-    loss_buffer = []
-    recipe._forward_backward_step(
-        idx=0,
-        batch=batch,
-        loss_buffer=loss_buffer,
-        num_label_tokens=None,
-        num_batches=1,
-        is_train=False,  # Validation mode
-    )
+    recipe._forward_backward_step(batch=batch, num_label_tokens=None, is_train=False)
 
     # Should use eval without input_ids as first positional arg
     assert len(pp_info.schedule.eval_calls) == 1
@@ -912,7 +888,7 @@ def test_forward_backward_step_pp_non_first_stage_uses_step_for_training(monkeyp
 
     # Mock make_cp_batch_and_ctx to return a no-op context manager
     monkeypatch.setattr(
-        "nemo_automodel.recipes.llm.train_ft.make_cp_batch_and_ctx",
+        "nemo_automodel.components.training.forward_backward.make_cp_batch_and_ctx",
         lambda device_mesh, batch, **kwargs: (nullcontext, batch),
     )
 
@@ -922,15 +898,7 @@ def test_forward_backward_step_pp_non_first_stage_uses_step_for_training(monkeyp
         "labels": torch.tensor([[1, 2, 3]]),
     }
 
-    loss_buffer = []
-    recipe._forward_backward_step(
-        idx=0,
-        batch=batch,
-        loss_buffer=loss_buffer,
-        num_label_tokens=None,
-        num_batches=1,
-        is_train=True,  # Training mode
-    )
+    recipe._forward_backward_step(batch=batch, num_label_tokens=None, is_train=True)
 
     # Should use step without input_ids as first positional arg
     assert len(pp_info.schedule.step_calls) == 1
@@ -974,9 +942,9 @@ def test_run_validation_epoch_pp_sends_loss_from_last_stage_to_main(monkeypatch)
     # Set dist_env.rank to 0 (last stage and main rank are the same in this test)
     object.__setattr__(recipe, "dist_env", SimpleNamespace(device=torch.device("cpu"), rank=0, is_main=True))
 
-    # Mock the forward_backward_step to populate loss_buffer
-    def mock_forward_backward_step(idx, batch, *, loss_buffer, num_label_tokens, num_batches, is_train):
-        loss_buffer.append(torch.tensor(0.5))
+    # Mock the forward_backward_step to return loss
+    def mock_forward_backward_step(batch, *, num_label_tokens, is_train, is_last_microbatch=True):
+        return torch.tensor(0.5)
 
     monkeypatch.setattr(recipe, "_forward_backward_step", mock_forward_backward_step)
 
@@ -990,7 +958,7 @@ def test_run_validation_epoch_pp_sends_loss_from_last_stage_to_main(monkeypatch)
 
     # Mock make_cp_batch_and_ctx
     monkeypatch.setattr(
-        "nemo_automodel.recipes.llm.train_ft.make_cp_batch_and_ctx",
+        "nemo_automodel.components.training.forward_backward.make_cp_batch_and_ctx",
         lambda device_mesh, batch, **kwargs: (nullcontext, batch),
     )
 
@@ -1043,8 +1011,8 @@ def test_run_validation_epoch_pp_main_rank_receives_from_last_stage(monkeypatch)
     # Main rank (0) is different from last stage (3)
     object.__setattr__(recipe, "dist_env", SimpleNamespace(device=torch.device("cpu"), rank=0, is_main=True))
 
-    def mock_forward_backward_step(idx, batch, *, loss_buffer, num_label_tokens, num_batches, is_train):
-        loss_buffer.append(torch.tensor(0.0))  # Non-last stage has 0 loss
+    def mock_forward_backward_step(batch, *, num_label_tokens, is_train, is_last_microbatch=True):
+        return torch.tensor(0.0)  # Non-last stage has 0 loss
 
     monkeypatch.setattr(recipe, "_forward_backward_step", mock_forward_backward_step)
 
@@ -1056,7 +1024,7 @@ def test_run_validation_epoch_pp_main_rank_receives_from_last_stage(monkeypatch)
     monkeypatch.setattr(recipe, "_dp_allreduce", mock_dp_allreduce)
 
     monkeypatch.setattr(
-        "nemo_automodel.recipes.llm.train_ft.make_cp_batch_and_ctx",
+        "nemo_automodel.components.training.forward_backward.make_cp_batch_and_ctx",
         lambda device_mesh, batch, **kwargs: (nullcontext, batch),
     )
 
@@ -1740,8 +1708,8 @@ class TestRunTrainOptimStepSetsMoEScale:
         monkeypatch.setattr(recipe, "_get_dp_group_size", lambda include_cp=False: dp_group_size)
         monkeypatch.setattr(recipe, "_get_cp_group_size", lambda: 1)
 
-        def mock_forward_backward_step(idx, batch, *, loss_buffer, num_label_tokens, num_batches, is_train=True):
-            loss_buffer.append(torch.tensor(0.5))
+        def mock_forward_backward_step(batch, *, num_label_tokens, is_train=True, is_last_microbatch=True):
+            return torch.tensor(0.5)
 
         monkeypatch.setattr(recipe, "_forward_backward_step", mock_forward_backward_step)
         monkeypatch.setattr(


### PR DESCRIPTION
## Summary

- Add a shared forward/backward helper for LLM and VLM fine-tuning paths.
- Route LLM and VLM recipes through the shared helper while keeping recipe-specific hooks for CP prep, FP8 context, and VLM PP media staging.
- Enable VLM pipeline-parallel validation by preparing validation dataloader media chunks for PP and running validation through `schedule.eval`.

## Why

The LLM and VLM recipes had largely duplicated forward/backward control flow. VLM PP validation was previously skipped because validation used a direct model-forward path and did not prepare VLM media tensors for PP microbatches.

## Validation

- `python -m py_compile nemo_automodel/components/training/forward_backward.py nemo_automodel/recipes/llm/train_ft.py nemo_automodel/recipes/vlm/finetune.py`
- `python -m ruff check nemo_automodel/components/training/forward_backward.py nemo_automodel/recipes/llm/train_ft.py nemo_automodel/recipes/vlm/finetune.py`
- `git diff --check`
- `pytest -q tests/unit_tests/recipes/test_train_ft.py`
- `pytest -q tests/unit_tests/recipes/test_finetune_vlm_helpers.py`
- Local Qwen3 VL MoE 30B EP4/PP2 smoke run with validation:
  - train: `loss 2.3266`, `num_label_tokens 930`
  - val: `loss 2.2712`, `num_label_tokens 941`
