### PR TITLE
fix(tools): add missing docstring to lint_example_yamls main

### DIFF
--- a/tools/lint_example_yamls.py
+++ b/tools/lint_example_yamls.py
@@ -213,6 +213,7 @@ def _yaml_error_line(exc: yaml.YAMLError) -> int:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Run the YAML linter over the requested paths and return a process exit code."""
     parser = argparse.ArgumentParser(description="Lint YAML files under examples/.")
     parser.add_argument(
         "paths",


### PR DESCRIPTION
## What

Add a one-line Google-style docstring to `main()` in `tools/lint_example_yamls.py`.

## Why

`ruff` D103 (missing docstring in public function) fails on this file, blocking the linting CI check for any PR that merges latest `main`. The function was missed by #2219.

## Changelog

- `tools/lint_example_yamls.py`: add docstring to `main()`

## Pre-checks

- [x] `ruff check tools/lint_example_yamls.py` passes locally
- [x] Commit is DCO-signed