### PR TITLE
feat(datasets): add S3/MSC object-storage support for MegatronPretrai…

### DIFF
--- a/docker/common/uv-pytorch.lock
+++ b/docker/common/uv-pytorch.lock
@@ -647,6 +647,43 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.43.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/a8/5422bd25bd2520a6122cb82b2dfa280c66e380102533761b96e7a10f1a4d/boto3-1.43.8.tar.gz", hash = "sha256:d1235602d715c727c1923ef4bcdb5612a20575a9a5e4f2db00d571e0ea1f85fc", size = 113144, upload-time = "2026-05-14T19:34:36.518Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/48/920c58e5b4450dd389ef3e56dca8803af093ccc0a8e04dd69a60812b7f94/boto3-1.43.8-py3-none-any.whl", hash = "sha256:1894497c383e3cdf50e210f1f57a43e9f4047a5d3accc73ffdb7eacc3b0f011b", size = 140523, upload-time = "2026-05-14T19:34:33.883Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/bb/7c1f5d12e1fbaf88a03d504bfa2f03fa6913f127051a7b121fe3bcaadefb/botocore-1.43.8.tar.gz", hash = "sha256:611ad8b1f60661373cd39d9391ff16f1eaf8f5cb1d0a691563a4201d1a2603ce", size = 15358475, upload-time = "2026-05-14T19:34:23.195Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/d8/c5486e4f0c6790f830368a171017d0687d89ffd3a57511bba533b56ee50f/botocore-1.43.8-py3-none-any.whl", hash = "sha256:6257d2655c3abe75eaa49e218b7d883cdc7cea64652b451e5feb08a6c169da3c", size = 15038825, upload-time = "2026-05-14T19:34:18.877Z" },
+]
+
+[[package]]
+name = "bracex"
+version = "2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/9a/fec38644694abfaaeca2798b58e276a8e61de49e2e37494ace423395febc/bracex-2.6.tar.gz", hash = "sha256:98f1347cd77e22ee8d967a30ad4e310b233f7754dbf31ff3fceb76145ba47dc7", size = 26642, upload-time = "2025-06-22T19:12:31.254Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/2a/9186535ce58db529927f6cf5990a849aa9e052eea3e2cfefe20b9e1802da/bracex-2.6-py3-none-any.whl", hash = "sha256:0b0049264e7340b3ec782b5cb99beb325f36c3782a32e36e876452fd49a09952", size = 11508, upload-time = "2025-06-22T19:12:29.781Z" },
+]
+
+[[package]]
 name = "cachetools"
 version = "6.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1505,11 +1542,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.20.0"
+version = "3.29.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/46/0028a82567109b5ef6e4d2a1f04a583fb513e6cf9527fcdd09afd817deeb/filelock-3.20.0.tar.gz", hash = "sha256:711e943b4ec6be42e1d4e6690b48dc175c822967466bb31c0c293f34334c13f4", size = 18922, upload-time = "2025-10-08T18:03:50.056Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/91/7216b27286936c16f5b4d0c530087e4a54eead683e6b0b73dd0c64844af6/filelock-3.20.0-py3-none-any.whl", hash = "sha256:339b4732ffda5cd79b13f4e2711a31b0365ce445d95d243bb996273d072546a2", size = 16054, upload-time = "2025-10-08T18:03:48.35Z" },
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
 ]
 
 [[package]]
@@ -1889,7 +1926,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/ed/6bfa4109fcb23a58819600392564fea69cdc6551ffd5e69ccf1d52a40cbc/greenlet-3.2.4-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:8c68325b0d0acf8d91dde4e6f930967dd52a5302cd4062932a6b2e7c2969f47c", size = 271061, upload-time = "2025-08-07T13:17:15.373Z" },
     { url = "https://files.pythonhosted.org/packages/2a/fc/102ec1a2fc015b3a7652abab7acf3541d58c04d3d17a8d3d6a44adae1eb1/greenlet-3.2.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:94385f101946790ae13da500603491f04a76b6e4c059dab271b3ce2e283b2590", size = 629475, upload-time = "2025-08-07T13:42:54.009Z" },
     { url = "https://files.pythonhosted.org/packages/c5/26/80383131d55a4ac0fb08d71660fd77e7660b9db6bdb4e8884f46d9f2cc04/greenlet-3.2.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f10fd42b5ee276335863712fa3da6608e93f70629c631bf77145021600abc23c", size = 640802, upload-time = "2025-08-07T13:45:25.52Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/7c/e7833dbcd8f376f3326bd728c845d31dcde4c84268d3921afcae77d90d08/greenlet-3.2.4-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c8c9e331e58180d0d83c5b7999255721b725913ff6bc6cf39fa2a45841a4fd4b", size = 636703, upload-time = "2025-08-07T13:53:12.622Z" },
     { url = "https://files.pythonhosted.org/packages/e9/49/547b93b7c0428ede7b3f309bc965986874759f7d89e4e04aeddbc9699acb/greenlet-3.2.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:58b97143c9cc7b86fc458f215bd0932f1757ce649e05b640fea2e79b54cedb31", size = 635417, upload-time = "2025-08-07T13:18:25.189Z" },
     { url = "https://files.pythonhosted.org/packages/7f/91/ae2eb6b7979e2f9b035a9f612cf70f1bf54aad4e1d125129bef1eae96f19/greenlet-3.2.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c2ca18a03a8cfb5b25bc1cbe20f3d9a4c80d8c3b13ba3df49ac3961af0b1018d", size = 584358, upload-time = "2025-08-07T13:18:23.708Z" },
     { url = "https://files.pythonhosted.org/packages/f7/85/433de0c9c0252b22b16d413c9407e6cb3b41df7389afc366ca204dbc1393/greenlet-3.2.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:9fe0a28a7b952a21e2c062cd5756d34354117796c6d9215a87f55e38d15402c5", size = 1113550, upload-time = "2025-08-07T13:42:37.467Z" },
@@ -1900,7 +1936,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/de/f28ced0a67749cac23fecb02b694f6473f47686dff6afaa211d186e2ef9c/greenlet-3.2.4-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:96378df1de302bc38e99c3a9aa311967b7dc80ced1dcc6f171e99842987882a2", size = 272305, upload-time = "2025-08-07T13:15:41.288Z" },
     { url = "https://files.pythonhosted.org/packages/09/16/2c3792cba130000bf2a31c5272999113f4764fd9d874fb257ff588ac779a/greenlet-3.2.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1ee8fae0519a337f2329cb78bd7a8e128ec0f881073d43f023c7b8d4831d5246", size = 632472, upload-time = "2025-08-07T13:42:55.044Z" },
     { url = "https://files.pythonhosted.org/packages/ae/8f/95d48d7e3d433e6dae5b1682e4292242a53f22df82e6d3dda81b1701a960/greenlet-3.2.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94abf90142c2a18151632371140b3dba4dee031633fe614cb592dbb6c9e17bc3", size = 644646, upload-time = "2025-08-07T13:45:26.523Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/5e/405965351aef8c76b8ef7ad370e5da58d57ef6068df197548b015464001a/greenlet-3.2.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:4d1378601b85e2e5171b99be8d2dc85f594c79967599328f95c1dc1a40f1c633", size = 640519, upload-time = "2025-08-07T13:53:13.928Z" },
     { url = "https://files.pythonhosted.org/packages/25/5d/382753b52006ce0218297ec1b628e048c4e64b155379331f25a7316eb749/greenlet-3.2.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0db5594dce18db94f7d1650d7489909b57afde4c580806b8d9203b6e79cdc079", size = 639707, upload-time = "2025-08-07T13:18:27.146Z" },
     { url = "https://files.pythonhosted.org/packages/1f/8e/abdd3f14d735b2929290a018ecf133c901be4874b858dd1c604b9319f064/greenlet-3.2.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2523e5246274f54fdadbce8494458a2ebdcdbc7b802318466ac5606d3cded1f8", size = 587684, upload-time = "2025-08-07T13:18:25.164Z" },
     { url = "https://files.pythonhosted.org/packages/5d/65/deb2a69c3e5996439b0176f6651e0052542bb6c8f8ec2e3fba97c9768805/greenlet-3.2.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1987de92fec508535687fb807a5cea1560f6196285a4cde35c100b8cd632cc52", size = 1116647, upload-time = "2025-08-07T13:42:38.655Z" },
@@ -1911,7 +1946,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
     { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
-    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
     { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
@@ -1922,7 +1956,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
     { url = "https://files.pythonhosted.org/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
     { url = "https://files.pythonhosted.org/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
@@ -1933,7 +1966,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
     { url = "https://files.pythonhosted.org/packages/c0/aa/687d6b12ffb505a4447567d1f3abea23bd20e73a5bed63871178e0831b7a/greenlet-3.2.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c17b6b34111ea72fc5a4e4beec9711d2226285f0386ea83477cbb97c30a3f3a5", size = 699218, upload-time = "2025-08-07T13:45:30.969Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
     { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },
@@ -2299,6 +2331,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
 name = "joblib"
 version = "1.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2456,6 +2497,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/33/01/a8ea7c5ea32a9b45ceeaee051a04c8ed4320f5add3c51bfa20879b765b70/kiwisolver-1.4.9-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:85b5352f94e490c028926ea567fc569c52ec79ce131dadb968d3853e809518c2", size = 80281, upload-time = "2025-08-10T21:27:45.369Z" },
     { url = "https://files.pythonhosted.org/packages/da/e3/dbd2ecdce306f1d07a1aaf324817ee993aab7aee9db47ceac757deabafbe/kiwisolver-1.4.9-pp311-pypy311_pp73-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:464415881e4801295659462c49461a24fb107c140de781d55518c4b80cb6790f", size = 78009, upload-time = "2025-08-10T21:27:46.376Z" },
     { url = "https://files.pythonhosted.org/packages/da/e9/0d4add7873a73e462aeb45c036a2dead2562b825aa46ba326727b3f31016/kiwisolver-1.4.9-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:fb940820c63a9590d31d88b815e7a3aa5915cad3ce735ab45f0c730b39547de1", size = 73929, upload-time = "2025-08-10T21:27:48.236Z" },
+]
+
+[[package]]
+name = "lark"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/34/28fff3ab31ccff1fd4f6c7c7b0ceb2b6968d8ea4950663eadcb5720591a0/lark-1.3.1.tar.gz", hash = "sha256:b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905", size = 382732, upload-time = "2025-10-27T18:25:56.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3d/14ce75ef66813643812f3093ab17e46d3a206942ce7376d31ec2d36229e7/lark-1.3.1-py3-none-any.whl", hash = "sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12", size = 113151, upload-time = "2025-10-27T18:25:54.882Z" },
 ]
 
 [[package]]
@@ -3118,6 +3168,40 @@ wheels = [
 ]
 
 [[package]]
+name = "multi-storage-client"
+version = "0.48.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "jmespath" },
+    { name = "jsonschema" },
+    { name = "lark" },
+    { name = "opentelemetry-api" },
+    { name = "prettytable" },
+    { name = "psutil" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "tzdata" },
+    { name = "wcmatch" },
+    { name = "xattr" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/a3/abb130e608379ff64e35482be6facf92ba7cf1df71f00851fa6ab9317c15/multi_storage_client-0.48.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:d81acc25db9405027543332a68e0a171e9fac40ff983c89937b8c7f6a1f8704e", size = 9930523, upload-time = "2026-05-04T23:40:44.159Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/c5/f9bdb63607f37fc47564b8c7a32e1af8b67ceaa8aad3cef35e222dbdb588/multi_storage_client-0.48.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c7c48842a394b0720ef674a3cbfcc30513d299689bbc6d704c2f54db74258d3", size = 6180115, upload-time = "2026-05-04T23:40:11.623Z" },
+    { url = "https://files.pythonhosted.org/packages/31/2c/96eeade65ac296a2870900389361dd5ac455747edb8cb1da4d0188d82410/multi_storage_client-0.48.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0a4177303b68e20175a2dbae0dbcce735364e22be1a9835a3d95530eb35cf739", size = 6377313, upload-time = "2026-05-04T23:39:41.015Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/09/ce4c0bfa731cfd11d6e38110c3de72ee89192539e0edf556bf6fecc3a5c1/multi_storage_client-0.48.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:c58a64a239e678dba6b6032fd887d805ac70f00607a395c8c5ff23718362c4b9", size = 10113132, upload-time = "2026-05-04T23:39:15.208Z" },
+    { url = "https://files.pythonhosted.org/packages/96/92/9f7d085971485a204c56b56b8e2b6483a75509753c6c37a40d9aa6aa8461/multi_storage_client-0.48.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2cf9ba18ef3bace23a9bfd5b19467c9d3860c5d0be43765df9a0f59fd78936dc", size = 6364058, upload-time = "2026-05-04T23:38:43.184Z" },
+    { url = "https://files.pythonhosted.org/packages/41/0a/a5bfc67e5dd11021d215c680edcbacefbe840759c2822409f9e962158070/multi_storage_client-0.48.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:221785dfd47db25b76895a1af9c751c620076de832738a1000152539052965bf", size = 6561123, upload-time = "2026-05-04T23:38:14.012Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/3d/aaf68ab3771849146faa7189a97564bc98db8fc1cf3c39405dfc58c216e8/multi_storage_client-0.48.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:62bddddeeea4b028a87f4dcaf59a07678f56e2ae418c5b5ba3c4dc1fc013273e", size = 10082802, upload-time = "2026-05-04T23:37:43.112Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/af/80ee5ba9f4748a5c113eb5ae7be6a8d3e1d11a77c3c636b940a3f87e5490/multi_storage_client-0.48.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:011558bb9ae0b5c8293e7e3b57d0f3c9d1222ba66bdd074391953c74252e39af", size = 6335934, upload-time = "2026-05-04T23:37:16.003Z" },
+    { url = "https://files.pythonhosted.org/packages/16/49/f2acaae4608e5860fdfb05c3253a8da5a16fc1495eac8de6c50777059dc4/multi_storage_client-0.48.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f884080f0b22fc5c22b86187013637e97d0c78be0fa83eb07517cffef75e535", size = 6534750, upload-time = "2026-05-04T23:36:49.577Z" },
+    { url = "https://files.pythonhosted.org/packages/68/14/b5ef4090aa659ae476f841a2642d53481b7275523af2a0ac9d7bad9f3227/multi_storage_client-0.48.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:8daf18534f96876fb5baa65be105253e8b890bfe79cd2c534fcf28403790460d", size = 10082075, upload-time = "2026-05-04T23:36:16.799Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/cb/45e442c3aadd76665a6d1d3c5d9986b02317920511aee780f6370e176ff4/multi_storage_client-0.48.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:66b46f880b764ceba1acc6beb0278b9e75fc472a052e12933b5d8f5319b7dcb7", size = 6338266, upload-time = "2026-05-04T23:35:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/dda248860a93c2e74ad5bb7cc1f2e615d7de96a144a6f7af3997450ad7f8/multi_storage_client-0.48.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d737b7678681fe7cb491337a722041a0853b8f53f8354eaa0239fca1707b82de", size = 6537974, upload-time = "2026-05-04T23:35:29.366Z" },
+]
+
+[[package]]
 name = "multidict"
 version = "6.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3315,6 +3399,7 @@ dependencies = [
 all = [
     { name = "albumentations" },
     { name = "backoff" },
+    { name = "boto3" },
     { name = "causal-conv1d" },
     { name = "databricks-sql-connector" },
     { name = "deltalake" },
@@ -3396,6 +3481,12 @@ moe = [
     { name = "onnxscript" },
     { name = "transformer-engine", marker = "sys_platform == 'never'" },
 ]
+msc = [
+    { name = "multi-storage-client" },
+]
+s3 = [
+    { name = "boto3" },
+]
 vlm = [
     { name = "albumentations" },
     { name = "backoff" },
@@ -3454,6 +3545,7 @@ requires-dist = [
     { name = "albumentations", marker = "extra == 'vlm'" },
     { name = "backoff", marker = "extra == 'vlm'" },
     { name = "bitsandbytes", marker = "extra == 'cuda-source'" },
+    { name = "boto3", marker = "extra == 's3'", specifier = ">=1.34" },
     { name = "causal-conv1d", marker = "extra == 'cuda'" },
     { name = "databricks-sql-connector", marker = "extra == 'delta-databricks'", specifier = ">=3.0.0" },
     { name = "datasets", specifier = ">=4.0.0" },
@@ -3472,6 +3564,7 @@ requires-dist = [
     { name = "mistral-common", extras = ["audio", "hf-hub", "image", "sentencepiece"] },
     { name = "mistral-common", extras = ["opencv"], marker = "extra == 'vlm'", specifier = ">=1.11.0" },
     { name = "mlflow" },
+    { name = "multi-storage-client", marker = "extra == 'msc'", specifier = ">=0.13" },
     { name = "nemo-automodel", extras = ["cuda"], marker = "extra == 'all'" },
     { name = "nemo-automodel", extras = ["cuda"], marker = "extra == 'moe'" },
     { name = "nemo-automodel", extras = ["delta-databricks"], marker = "extra == 'all'" },
@@ -3480,6 +3573,7 @@ requires-dist = [
     { name = "nemo-automodel", extras = ["extra"], marker = "extra == 'all'" },
     { name = "nemo-automodel", extras = ["fla"], marker = "extra == 'all'" },
     { name = "nemo-automodel", extras = ["fla"], marker = "extra == 'moe'" },
+    { name = "nemo-automodel", extras = ["s3"], marker = "extra == 'all'" },
     { name = "nemo-automodel", extras = ["vlm"], marker = "extra == 'all'" },
     { name = "numba", marker = "extra == 'vlm'" },
     { name = "numpy", marker = "extra == 'vlm'" },
@@ -3511,7 +3605,7 @@ requires-dist = [
     { name = "transformers", specifier = "==5.5.0" },
     { name = "wandb", specifier = ">=0.26.1" },
 ]
-provides-extras = ["diffusion", "diffusion-kernels", "cuda", "cuda-source", "extra", "fa", "fla", "delta-databricks", "moe", "vlm", "cli", "all"]
+provides-extras = ["diffusion", "diffusion-kernels", "cuda", "cuda-source", "extra", "fa", "fla", "delta-databricks", "moe", "vlm", "cli", "s3", "msc", "all"]
 
 [package.metadata.requires-dev]
 build = [
@@ -5322,6 +5416,18 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/ec/7c692cde9125b77e84b307354d4fb705f98b8ccad59a036d5957ca75bfc3/s3transfer-0.17.0.tar.gz", hash = "sha256:9edeb6d1c3c2f89d6050348548834ad8289610d886e5bf7b7207728bd43ce33a", size = 155337, upload-time = "2026-04-29T22:07:36.33Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/72/c6c32d2b657fa3dad1de340254e14390b1e334ce38268b7ad51abda3c8c2/s3transfer-0.17.0-py3-none-any.whl", hash = "sha256:ce3801712acf4ad3e89fb9990df97b4972e93f4b3b0004d214be5bce12814c20", size = 86811, upload-time = "2026-04-29T22:07:34.966Z" },
+]
+
+[[package]]
 name = "safetensors"
 version = "0.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -6937,6 +7043,18 @@ wheels = [
 ]
 
 [[package]]
+name = "wcmatch"
+version = "10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bracex" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/3e/c0bdc27cf06f4e47680bd5803a07cb3dfd17de84cde92dd217dcb9e05253/wcmatch-10.1.tar.gz", hash = "sha256:f11f94208c8c8484a16f4f48638a85d771d9513f4ab3f37595978801cb9465af", size = 117421, upload-time = "2025-06-22T19:14:02.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/d8/0d1d2e9d3fabcf5d6840362adcf05f8cf3cd06a73358140c3a97189238ae/wcmatch-10.1-py3-none-any.whl", hash = "sha256:5848ace7dbb0476e5e55ab63c6bbd529745089343427caa5537f230cc01beb8a", size = 39854, upload-time = "2025-06-22T19:14:00.978Z" },
+]
+
+[[package]]
 name = "wcwidth"
 version = "0.2.14"
 source = { registry = "https://pypi.org/simple" }
@@ -7107,6 +7225,59 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/01/3a/07cd60a9d26fe73efead61c7830af975dfdba8537632d410462672e4432b/wrapt-2.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:61c4956171c7434634401db448371277d07032a81cc21c599c22953374781395", size = 64038, upload-time = "2025-11-07T00:45:00.948Z" },
     { url = "https://files.pythonhosted.org/packages/41/99/8a06b8e17dddbf321325ae4eb12465804120f699cd1b8a355718300c62da/wrapt-2.0.1-cp314-cp314t-win_arm64.whl", hash = "sha256:35cdbd478607036fee40273be8ed54a451f5f23121bd9d4be515158f9498f7ad", size = 60634, upload-time = "2025-11-07T00:45:02.087Z" },
     { url = "https://files.pythonhosted.org/packages/15/d1/b51471c11592ff9c012bd3e2f7334a6ff2f42a7aed2caffcf0bdddc9cb89/wrapt-2.0.1-py3-none-any.whl", hash = "sha256:4d2ce1bf1a48c5277d7969259232b57645aae5686dba1eaeade39442277afbca", size = 44046, upload-time = "2025-11-07T00:45:32.116Z" },
+]
+
+[[package]]
+name = "xattr"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/d5/25f7b19af3a2cb4000cac4f9e5525a40bec79f4f5d0ac9b517c0544586a0/xattr-1.3.0.tar.gz", hash = "sha256:30439fabd7de0787b27e9a6e1d569c5959854cb322f64ce7380fedbfa5035036", size = 17148, upload-time = "2025-10-13T22:16:47.353Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/11/bbb25ab921e02efb789efcab5b7d03581b5d28f71d829f21e4ea6aba09fb/xattr-1.3.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a80c4617e08670cdc3ba71f1dbb275c1627744c5c3641280879cb3bc95a07237", size = 23453, upload-time = "2025-10-13T22:15:50.753Z" },
+    { url = "https://files.pythonhosted.org/packages/be/88/66021fdfbb2037a94fc5b16c1dce1894b8e9da7a1829e4be0b491b3f24ff/xattr-1.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:51cdaa359f5cd2861178ae01ea3647b56dbdfd98e724a8aa3c04f77123b78217", size = 18551, upload-time = "2025-10-13T22:15:51.961Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f7/5dd21fcfc48487a59fcec33ffe02eb671f256424869e9aef87e33c65d95b/xattr-1.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2fea070768d7d2d25797817bea93bf0a6fda6449e88cfee8bb3d75de9ed11c7b", size = 18852, upload-time = "2025-10-13T22:15:53.104Z" },
+    { url = "https://files.pythonhosted.org/packages/af/2a/e29753ac17a92aadf27b9e16b1d600584d9f10acd0b399d2c06f47af2dff/xattr-1.3.0-cp310-cp310-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:69bca34be2d7a928389aff4e32f27857e1c62d04c91ec7c1519b1636870bd58f", size = 38547, upload-time = "2025-10-13T22:15:54.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/46/b2c9185d24b93542e4307ce30cd3d4eb6af8efdc843d98ff9f07fcb048d9/xattr-1.3.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:05f8e068409742d246babba60cff8310b2c577745491f498b08bf068e0c867a3", size = 38755, upload-time = "2025-10-13T22:15:55.738Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/0a/93cf1f03536bf38e8fd3fe57eb04124e4dfe2e16c0c5ced589d3360a1858/xattr-1.3.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:bbd06987102bc11f5cbd08b15d1029832b862cf5bc61780573fc0828812f01ca", size = 38052, upload-time = "2025-10-13T22:15:57.031Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ad/60e43f7e1037cee671e14c2a283e3e7168b756c9938eba62f0616e6599aa/xattr-1.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b8589744116d2c37928b771c50383cb281675cd6dcfd740abfab6883e3d4af85", size = 37560, upload-time = "2025-10-13T22:15:58.295Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/64/292426ad5653e72c6e1325bbff22868a20077290d967cebb9c0624ad08b6/xattr-1.3.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:331a51bf8f20c27822f44054b0d760588462d3ed472d5e52ba135cf0bea510e8", size = 23448, upload-time = "2025-10-13T22:15:59.229Z" },
+    { url = "https://files.pythonhosted.org/packages/63/84/6539fbe620da8e5927406e76b9c8abad8953025d5f578d792747c38a8c0e/xattr-1.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:196360f068b74fa0132a8c6001ce1333f095364b8f43b6fd8cdaf2f18741ef89", size = 18553, upload-time = "2025-10-13T22:16:00.151Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/bb/c1c2e24a49f8d13ff878fb85aabc42ea1b2f98ce08d8205b9661d517a9cc/xattr-1.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:405d2e4911d37f2b9400fa501acd920fe0c97fe2b2ec252cb23df4b59c000811", size = 18848, upload-time = "2025-10-13T22:16:01.046Z" },
+    { url = "https://files.pythonhosted.org/packages/02/c2/a60aad150322b217dfe33695d8d9f32bc01e8f300641b6ba4b73f4b3c03f/xattr-1.3.0-cp311-cp311-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4ae3a66ae1effd40994f64defeeaa97da369406485e60bfb421f2d781be3b75d", size = 38547, upload-time = "2025-10-13T22:16:01.973Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/58/2eca142bad4ea0a2be6b58d3122d0acce310c4e53fa7defd168202772178/xattr-1.3.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:69cd3bfe779f7ba87abe6473fdfa428460cf9e78aeb7e390cfd737b784edf1b5", size = 38753, upload-time = "2025-10-13T22:16:03.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/50/d032e5254c2c27d36bdb02abdf2735db6768a441f0e3d0f139e0f9f56638/xattr-1.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c5742ca61761a99ae0c522f90a39d5fb8139280f27b254e3128482296d1df2db", size = 38054, upload-time = "2025-10-13T22:16:04.656Z" },
+    { url = "https://files.pythonhosted.org/packages/04/24/458a306439aabe0083ca0a7b14c3e6a800ab9782b5ec0bdcec4ec9f3dc6c/xattr-1.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4a04ada131e9bdfd32db3ab1efa9f852646f4f7c9d6fde0596c3825c67161be3", size = 37562, upload-time = "2025-10-13T22:16:05.97Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/78/00bdc9290066173e53e1e734d8d8e1a84a6faa9c66aee9df81e4d9aeec1c/xattr-1.3.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dd4e63614722d183e81842cb237fd1cc978d43384166f9fe22368bfcb187ebe5", size = 23476, upload-time = "2025-10-13T22:16:06.942Z" },
+    { url = "https://files.pythonhosted.org/packages/53/16/5243722294eb982514fa7b6b87a29dfb7b29b8e5e1486500c5babaf6e4b3/xattr-1.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:995843ef374af73e3370b0c107319611f3cdcdb6d151d629449efecad36be4c4", size = 18556, upload-time = "2025-10-13T22:16:08.209Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5c/d7ab0e547bea885b55f097206459bd612cefb652c5fc1f747130cbc0d42c/xattr-1.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fa23a25220e29d956cedf75746e3df6cc824cc1553326d6516479967c540e386", size = 18869, upload-time = "2025-10-13T22:16:10.319Z" },
+    { url = "https://files.pythonhosted.org/packages/98/25/25cc7d64f07de644b7e9057842227adf61017e5bcfe59a79df79f768874c/xattr-1.3.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b4345387087fffcd28f709eb45aae113d911e1a1f4f0f70d46b43ba81e69ccdd", size = 38797, upload-time = "2025-10-13T22:16:11.624Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/24/cc350bcdbed006dfcc6ade0ac817693b8b3d4b2787f20e427fd0697042e4/xattr-1.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fe92bb05eb849ab468fe13e942be0f8d7123f15d074f3aba5223fad0c4b484de", size = 38956, upload-time = "2025-10-13T22:16:13.121Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/b2/9416317ac89e2ed759a861857cda0d5e284c3691e6f460d36cc2bd5ce4d1/xattr-1.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6c42ef5bdac3febbe28d3db14d3a8a159d84ba5daca2b13deae6f9f1fc0d4092", size = 38214, upload-time = "2025-10-13T22:16:14.389Z" },
+    { url = "https://files.pythonhosted.org/packages/38/63/188f7cb41ab35d795558325d5cc8ab552171d5498cfb178fd14409651e18/xattr-1.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2aaa5d66af6523332189108f34e966ca120ff816dfa077ca34b31e6263f8a236", size = 37754, upload-time = "2025-10-13T22:16:15.306Z" },
+    { url = "https://files.pythonhosted.org/packages/27/d3/6a1731a339842afcbb2643bc93628d4ab9c52d1bf26a7b085ca8f35bba6e/xattr-1.3.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:937d8c91f6f372788aff8cc0984c4be3f0928584839aaa15ff1c95d64562071c", size = 23474, upload-time = "2025-10-13T22:16:16.33Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/25/6741ed3d4371eaa2fae70b259d17a580d858ebff8af0042a59e11bb6385f/xattr-1.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e470b3f15e9c3e263662506ff26e73b3027e1c9beac2cbe9ab89cad9c70c0495", size = 18558, upload-time = "2025-10-13T22:16:17.251Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/84/cc450688abeb8647aa93a62c1435bb532db11313abfeb9d43b28b4751503/xattr-1.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f2238b2a973fcbf5fefa1137db97c296d27f4721f7b7243a1fac51514565e9ec", size = 18869, upload-time = "2025-10-13T22:16:18.607Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/49/0e2315225ba7557e9801f9f0168a0195a7e13a3223088081eb32d2760533/xattr-1.3.0-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f32bb00395371f4a3bed87080ae315b19171ba114e8a5aa403a2c8508998ce78", size = 38702, upload-time = "2025-10-13T22:16:19.539Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8c/de4f4441c318ac38a5d3d7d4b8b940305a667e9320c34a45e57f6eb6b0e8/xattr-1.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:78df56bfe3dd4912548561ed880225437d6d49ef082fe6ccd45670810fa53cfe", size = 38869, upload-time = "2025-10-13T22:16:20.554Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/2a/38e0498c22aa733a9b5265f4929af4613e5b967659cf3e5f2f933b3ba118/xattr-1.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:864c34c14728f21c3ef89a9f276d75ae5e31dd34f48064e0d37e4bf0f671fc6e", size = 38210, upload-time = "2025-10-13T22:16:22.212Z" },
+    { url = "https://files.pythonhosted.org/packages/62/21/49b386eb8dcf42ac8e3ff55b6e8ea0a1e8b6b799571599c795265d2dc1b5/xattr-1.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1fd185b3f01121bd172c98b943f9341ca3b9ea6c6d3eb7fe7074723614d959ff", size = 37753, upload-time = "2025-10-13T22:16:23.959Z" },
+    { url = "https://files.pythonhosted.org/packages/24/49/b8bc589427696d67bc2b0992c188e576f70242c586a379f97698772c0c3d/xattr-1.3.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:630c85020282bd0bcb72c3d031491c4e91d7f29bb4c094ebdfb9db51375c5b07", size = 23543, upload-time = "2025-10-13T22:16:25.242Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/0a/03192e78071cfb86e6d8ceae0e5dcec4bacf0fd734755263aabd01532e50/xattr-1.3.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:95f1e14a4d9ca160b4b78c527bf2bac6addbeb0fd9882c405fc0b5e3073a8752", size = 18673, upload-time = "2025-10-13T22:16:26.224Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/36/9ab4f0b5c3d10df3aceaecf7e395cabe7fb7c7c004b2dc3f3cff0ef70fc3/xattr-1.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:88557c0769f64b1d014aada916c9630cfefa38b0be6c247eae20740d2d8f7b47", size = 18877, upload-time = "2025-10-13T22:16:27.164Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/1c/ab905d19a1349e847e37e02933316d17adfd1dd70b64d366885ab0bd959d/xattr-1.3.0-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c6992eb5da32c0a1375a9eeacfab15c66eebc8bd34be63ebd1eae80cc2f8bf03", size = 38782, upload-time = "2025-10-13T22:16:28.157Z" },
+    { url = "https://files.pythonhosted.org/packages/83/a7/f615a6e5d48d47e9febbe5a62b94ffa0d8bfc6d325b899873281abac10c4/xattr-1.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:da5954424099ca9d402933eaf6112c29ddde26e6da59b32f0bf5a4e35eec0b28", size = 38936, upload-time = "2025-10-13T22:16:29.291Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/6c/a8221567a7cbc00ac305a4842318562f90bb1fdd16636e1379361133f1f4/xattr-1.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:726b4d0b66724759132cacdcd84a5b19e00b0cdf704f4c2cf96d0c08dc5eaeb5", size = 38268, upload-time = "2025-10-13T22:16:30.238Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/4d/38a98df630e19360d98df8d98ec4a2560612840823f0bf55f81e0e84c866/xattr-1.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:928c49ceb0c70fc04732e46fa236d7c8281bfc3db1b40875e5f548bb14d2668c", size = 37825, upload-time = "2025-10-13T22:16:31.557Z" },
+    { url = "https://files.pythonhosted.org/packages/97/3f/6d50237645edd83e9dc6bf6521e4e28335845b674cabefd69f12bc4db59a/xattr-1.3.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:f3bef26fd2d5d7b17488f4cc4424a69894c5a8ed71dd5f657fbbf69f77f68a51", size = 23788, upload-time = "2025-10-13T22:16:32.465Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/8b/3efd48c85e08d1bfcbd46f87368b155d3d3de78bb660b408fbaff7623572/xattr-1.3.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:64f1fb511f8463851e0d97294eb0e0fde54b059150da90582327fb43baa1bb92", size = 18825, upload-time = "2025-10-13T22:16:33.442Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/19/4b4e3e2ea5fa213ff4220e84450628fecde042b0961e7b4e6d845e555ade/xattr-1.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1e6c216927b16fd4b72df655d5124b69b2a406cb3132b5231179021182f0f0d1", size = 19023, upload-time = "2025-10-13T22:16:34.395Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/4a/6460befb22ce8d43abdb22d2bf5aa63b8311507c75dc50ad402681b4b095/xattr-1.3.0-cp314-cp314t-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c0d9ab346cdd20539afddf2f9e123efee0fe8d54254d9fc580b4e2b4e6d77351", size = 43732, upload-time = "2025-10-13T22:16:35.41Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a8/3fa83e9f91dc868d764b2ca3758bf449945c4b1511e137e33a6210609b58/xattr-1.3.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2c5e7ba0e893042deef4e8638db7a497680f587ac7bd6d68925f29af633dfa6b", size = 43851, upload-time = "2025-10-13T22:16:36.416Z" },
+    { url = "https://files.pythonhosted.org/packages/28/b3/06bf7f691c3f35e94a37e097ae1868fbaa916cc174b1b916fb7aeca441e4/xattr-1.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1e0dabb39596d8d7b83d6f9f7fa30be68cf15bfb135cb633e2aad9887d308a32", size = 43274, upload-time = "2025-10-13T22:16:37.805Z" },
+    { url = "https://files.pythonhosted.org/packages/df/41/d6298c95513eabe091a6851bff5e7928fab49ffd9143808feaaf7721cf33/xattr-1.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5eeaa944516b7507ec51456751334b4880e421de169bbd067c4f32242670d606", size = 42864, upload-time = "2025-10-13T22:16:38.811Z" },
 ]
 
 [[package]]

--- a/nemo_automodel/components/datasets/llm/megatron/gpt_dataset.py
+++ b/nemo_automodel/components/datasets/llm/megatron/gpt_dataset.py
@@ -29,7 +29,7 @@ import torch
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 
 from nemo_automodel.components.datasets.llm.formatting_utils import _get_right_trailing_pad_mask
-from nemo_automodel.components.datasets.llm.megatron.indexed_dataset import IndexedDataset
+from nemo_automodel.components.datasets.llm.megatron.indexed_dataset import IndexedDataset, ObjectStorageConfig
 
 # taken and modified from https://github.com/NVIDIA/Megatron-LM/blob/5e798111e60f45e82c336ef7b89d8d793c93208f/megatron/core/datasets/gpt_dataset.py
 logger = logging.getLogger(__name__)
@@ -100,6 +100,11 @@ class BlendedMegatronDatasetConfig:
        if the top level dataset oversamples the mid level dataset(s). This value may be set to 0.0
        in future if the top level dataset is constrained to not oversample the mid level
        datasets(s).
+    """
+
+    object_storage_config: Optional[ObjectStorageConfig] = None
+    """When set, the .idx files are downloaded to path_to_idx_cache and .bin files are streamed
+       from S3/MSC via chunked GETs. mmap_bin_files is automatically overridden to False.
     """
 
     def __post_init__(self) -> None:
@@ -358,7 +363,13 @@ class GPTDataset(torch.utils.data.Dataset):
         Returns:
             IndexedDataset: The underlying IndexedDataset
         """
-        return IndexedDataset(dataset_path, multimodal=False, mmap=config.mmap_bin_files)
+        use_mmap = config.mmap_bin_files and config.object_storage_config is None
+        return IndexedDataset(
+            dataset_path,
+            multimodal=False,
+            mmap=use_mmap,
+            object_storage_config=config.object_storage_config,
+        )
 
     def __len__(self) -> int:
         """Abstract method implementation

--- a/nemo_automodel/components/datasets/llm/megatron/indexed_dataset.py
+++ b/nemo_automodel/components/datasets/llm/megatron/indexed_dataset.py
@@ -17,9 +17,9 @@
 """A self-contained port of Megatron-Core's indexed dataset loader.
 
 Supports the original mmap and file-pointer readers for local *.bin / *.idx
-pairs. The file pair is expected to live on a local filesystem.
+pairs, plus optional streaming readers for object storage (S3 and MSC).
 
-All three calls below are equivalent:
+All three calls below are equivalent for local data:
 
     from nemo_automodel.datasets.llm.indexed_dataset import IndexedDataset
 
@@ -31,6 +31,11 @@ All three calls below are equivalent:
 
     ds = IndexedDataset("/path/to/shard_00_text_document.idx")
     print(len(ds), ds[0][:20])
+
+For object-storage data, pass an :class:`ObjectStorageConfig`:
+
+    cfg = ObjectStorageConfig(path_to_idx_cache="/tmp/idx_cache")
+    ds = IndexedDataset("s3://bucket/path/shard_00_text_document", object_storage_config=cfg)
 """
 
 from __future__ import annotations
@@ -41,16 +46,115 @@ import os
 import shutil
 import struct
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from enum import Enum
 from functools import lru_cache
 from itertools import accumulate
 from types import TracebackType
-from typing import Any, List, Optional, Tuple, Type, Union
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 import numpy
 import torch
 
+from nemo_automodel.shared.import_utils import safe_import
+
 logger = logging.getLogger(__name__)
+
+# Optional dependencies for object-storage support. Install via
+# ``pip install nemo_automodel[s3]`` (boto3) or ``[msc]`` (multi-storage-client).
+HAS_BOTO3, boto3 = safe_import("boto3")
+HAS_MSC, multi_storage_client = safe_import("multi_storage_client")
+
+_S3_PREFIX = "s3://"
+_MSC_PREFIX = "msc://"
+
+
+@dataclass
+class ObjectStorageConfig:
+    """Configuration for reading ``.bin``/``.idx`` files from object storage.
+
+    Attributes:
+        path_to_idx_cache: Local directory where the ``.idx`` file is cached on
+            first use. Re-used across ranks via a per-host directory layout.
+        bin_chunk_nbytes: Size in bytes of each chunked range read against the
+            ``.bin`` object. Defaults to 256 MiB. Larger values reduce request
+            count but increase per-rank memory footprint.
+    """
+
+    path_to_idx_cache: str
+    bin_chunk_nbytes: int = 256 * 1024 * 1024
+
+
+def _is_object_storage_path(path: str) -> bool:
+    """Return ``True`` if ``path`` is an ``s3://`` or ``msc://`` URI."""
+    return path.startswith(_S3_PREFIX) or path.startswith(_MSC_PREFIX)
+
+
+def _parse_s3_path(path: str) -> Tuple[str, str]:
+    """Split an ``s3://bucket/key`` URI into ``(bucket, key)``."""
+    if not path.startswith(_S3_PREFIX):
+        raise ValueError(f"Not an S3 path: {path}")
+    parts = path[len(_S3_PREFIX) :].split("/")
+    bucket = parts[0]
+    key = "/".join(parts[1:]) if len(parts) > 1 else ""
+    return bucket, key
+
+
+def _get_index_cache_path(idx_path: str, object_storage_config: ObjectStorageConfig) -> str:
+    """Return the local cache path for ``idx_path`` under ``path_to_idx_cache``."""
+    if idx_path.startswith(_S3_PREFIX):
+        stripped = idx_path[len(_S3_PREFIX) :]
+    elif idx_path.startswith(_MSC_PREFIX):
+        stripped = idx_path[len(_MSC_PREFIX) :]
+    else:
+        raise ValueError(f"Not an object storage path: {idx_path}")
+    return os.path.join(object_storage_config.path_to_idx_cache, stripped)
+
+
+def _cache_index_file(remote_path: str, local_path: str) -> None:
+    """Download ``.idx`` from object storage to ``local_path``.
+
+    Rank 0 performs the download and other ranks wait on a ``torch.distributed``
+    barrier. If the local file already exists this is a no-op.
+
+    Raises:
+        ImportError: If the relevant client library (``boto3`` for ``s3://`` or
+            ``multi_storage_client`` for ``msc://``) is not installed.
+        ValueError: If ``remote_path`` is neither an ``s3://`` nor an
+            ``msc://`` URI.
+    """
+    torch_dist_enabled = torch.distributed.is_initialized()
+    rank = torch.distributed.get_rank() if torch_dist_enabled else 0
+
+    if remote_path.startswith(_S3_PREFIX):
+        if not HAS_BOTO3:
+            raise ImportError("boto3 is required to read s3:// datasets. Install via `pip install nemo_automodel[s3]`.")
+        if not os.path.exists(local_path):
+            if not torch_dist_enabled or rank == 0:
+                os.makedirs(os.path.dirname(local_path), exist_ok=True)
+                bucket, key = _parse_s3_path(remote_path)
+                client = boto3.client("s3")
+                logger.info("Downloading %s -> %s", remote_path, local_path)
+                client.download_file(bucket, key, local_path)
+                client.close()
+    elif remote_path.startswith(_MSC_PREFIX):
+        if not HAS_MSC:
+            raise ImportError(
+                "multi_storage_client is required to read msc:// datasets. "
+                "Install via `pip install nemo_automodel[msc]`."
+            )
+        if not os.path.exists(local_path):
+            if not torch_dist_enabled or rank == 0:
+                os.makedirs(os.path.dirname(local_path), exist_ok=True)
+                multi_storage_client.download_file(remote_path, local_path)
+    else:
+        raise ValueError(f"Unsupported object storage path: {remote_path}")
+
+    if torch_dist_enabled:
+        torch.distributed.barrier()
+    if not os.path.exists(local_path):
+        raise RuntimeError(f"Index cache file not found after download: {local_path}")
+
 
 _INDEX_HEADER = b"MMIDIDX\x00\x00"
 
@@ -422,33 +526,157 @@ class _FileBinReader(_BinReader):
         return out
 
 
+class _S3BinReader(_BinReader):
+    """Stream ``.bin`` data from S3 via chunked ranged ``GetObject`` calls.
+
+    A single in-memory chunk (sized by
+    :attr:`ObjectStorageConfig.bin_chunk_nbytes`) is cached so consecutive
+    reads within the same chunk avoid network round-trips. Random-access
+    reads outside the current chunk trigger a new ranged ``GetObject``.
+    """
+
+    def __init__(self, bin_path: str, object_storage_config: ObjectStorageConfig) -> None:
+        if not HAS_BOTO3:
+            raise ImportError("boto3 is required to read s3:// datasets. Install via `pip install nemo_automodel[s3]`.")
+        if object_storage_config.bin_chunk_nbytes <= 0:
+            raise ValueError(f"bin_chunk_nbytes must be positive, got {object_storage_config.bin_chunk_nbytes}")
+        self._client = boto3.client("s3")
+        self._s3_bucket, self._s3_key = _parse_s3_path(bin_path)
+        self._cache_nbytes = object_storage_config.bin_chunk_nbytes
+        self._cache_bytes_start: int = 0
+        self._cache_bytes_end: int = 0
+        self._cache: Optional[bytes] = None
+
+    def _extract_from_cache(self, offset: int, size: int) -> bytes:
+        if self._cache is None:
+            raise RuntimeError("Cache is empty; cannot extract before first read")
+        start = offset - self._cache_bytes_start
+        end = start + size
+        if start < 0 or end > len(self._cache):
+            raise IndexError(
+                f"Cache window [{self._cache_bytes_start}, {self._cache_bytes_end}) "
+                f"does not contain requested range [{offset}, {offset + size})"
+            )
+        return self._cache[start:end]
+
+    def read(self, dtype: Type[numpy.number], count: int, offset: int) -> numpy.ndarray:
+        """Read ``count`` elements of ``dtype`` starting at byte ``offset``."""
+        size = count * DType.size(dtype)
+        if self._cache is not None and offset >= self._cache_bytes_start and offset + size <= self._cache_bytes_end:
+            return numpy.frombuffer(self._extract_from_cache(offset, size), dtype=dtype)
+
+        bytes_start = (offset // self._cache_nbytes) * self._cache_nbytes
+        bytes_end = max(bytes_start + self._cache_nbytes, offset + size)
+        self._cache = self._client.get_object(
+            Bucket=self._s3_bucket,
+            Key=self._s3_key,
+            Range=f"bytes={bytes_start}-{bytes_end - 1}",
+        )["Body"].read()
+        self._cache_bytes_start = bytes_start
+        self._cache_bytes_end = bytes_end
+        return numpy.frombuffer(self._extract_from_cache(offset, size), dtype=dtype)
+
+    def __del__(self) -> None:
+        try:
+            self._client.close()
+        except Exception:
+            pass
+
+
+class _MultiStorageClientBinReader(_BinReader):
+    """Read ``.bin`` data via NVIDIA's :mod:`multi_storage_client`."""
+
+    def __init__(self, bin_path: str, object_storage_config: ObjectStorageConfig) -> None:
+        if not HAS_MSC:
+            raise ImportError(
+                "multi_storage_client is required to read msc:// datasets. "
+                "Install via `pip install nemo_automodel[msc]`."
+            )
+        self._client, self._bin_path = multi_storage_client.resolve_storage_client(bin_path)
+
+    def read(self, dtype: Type[numpy.number], count: int, offset: int) -> numpy.ndarray:
+        """Read ``count`` elements of ``dtype`` starting at byte ``offset``."""
+        size = count * DType.size(dtype)
+        buffer = self._client.read(
+            path=self._bin_path,
+            byte_range=multi_storage_client.types.Range(offset=offset, size=size),
+        )
+        return numpy.frombuffer(buffer, dtype=dtype)
+
+
+OBJECT_STORAGE_BIN_READERS: Dict[str, Type[_BinReader]] = {
+    "s3": _S3BinReader,
+    "msc": _MultiStorageClientBinReader,
+}
+
+
 class IndexedDataset(torch.utils.data.Dataset):
     """A fast, on-disk dataset backed by Megatron-style index + binary files."""
 
-    def __init__(self, path_prefix: str, multimodal: bool = False, mmap: bool = True) -> None:
+    def __init__(
+        self,
+        path_prefix: str,
+        multimodal: bool = False,
+        mmap: bool = True,
+        object_storage_config: Optional[ObjectStorageConfig] = None,
+    ) -> None:
         """Initialize the IndexedDataset
 
         Args:
-        path_prefix (str): The index (.idx) and data (.bin) prefix
-
-        multimodal (bool): Whether the dataset is multimodal. Defaults to False.
-
-        mmap (bool): Whether to mmap the .bin files. Defaults to True.
+            path_prefix (str): The index (.idx) and data (.bin) prefix. May be an S3 URI
+                (``s3://bucket/key``) when ``object_storage_config`` is provided.
+            multimodal (bool): Whether the dataset is multimodal. Defaults to False.
+            mmap (bool): Whether to mmap the .bin files. Defaults to True. Must be False
+                for object-storage paths.
+            object_storage_config (Optional[ObjectStorageConfig]): When provided and
+                ``path_prefix`` is an S3/MSC URI, the .idx file is downloaded to
+                ``object_storage_config.path_to_idx_cache`` and the .bin file is streamed
+                via chunked GETs.
         """
         super().__init__()
         normalized_prefix = _normalize_prefix(path_prefix)
-        self.initialize(normalized_prefix, multimodal, mmap)
+        if _is_object_storage_path(normalized_prefix) and object_storage_config is not None:
+            if mmap:
+                raise ValueError(
+                    "mmap must be False for object-storage prefixes; "
+                    "set mmap=False (or set `mmap_bin_files: false` in the recipe)."
+                )
+            idx_path = get_idx_path(normalized_prefix)
+            cache_idx_path = _get_index_cache_path(idx_path, object_storage_config)
+            _cache_index_file(idx_path, cache_idx_path)
+        self.initialize(normalized_prefix, multimodal, mmap, object_storage_config)
 
-    def initialize(self, path_prefix: str, multimodal: bool, mmap: bool) -> None:
-        idx_path, bin_path = get_idx_path(path_prefix), get_bin_path(path_prefix)
-        assert os.path.exists(idx_path) and os.path.exists(bin_path), f"Missing .idx or .bin at prefix {path_prefix}"
+    def initialize(
+        self,
+        path_prefix: str,
+        multimodal: bool,
+        mmap: bool,
+        object_storage_config: Optional[ObjectStorageConfig] = None,
+    ) -> None:
+        idx_path = get_idx_path(path_prefix)
+        bin_path = get_bin_path(path_prefix)
+
+        if _is_object_storage_path(path_prefix) and object_storage_config is not None:
+            # .idx is already cached locally; determine local path for _IndexReader
+            local_idx_path = _get_index_cache_path(idx_path, object_storage_config)
+            if not os.path.exists(local_idx_path):
+                raise RuntimeError(f"Cached .idx not found: {local_idx_path}")
+            access = "s3" if path_prefix.startswith(_S3_PREFIX) else "msc"
+            bin_reader: _BinReader = OBJECT_STORAGE_BIN_READERS[access](bin_path, object_storage_config)
+            index_reader = _IndexReader(local_idx_path, multimodal)
+        else:
+            assert os.path.exists(idx_path) and os.path.exists(bin_path), (
+                f"Missing .idx or .bin at prefix {path_prefix}"
+            )
+            bin_reader = _MMapBinReader(bin_path) if mmap else _FileBinReader(bin_path)
+            index_reader = _IndexReader(idx_path, multimodal)
 
         self.path_prefix = path_prefix
         self.multimodal = multimodal
         self.mmap = mmap
-
-        self.bin_reader = _MMapBinReader(bin_path) if mmap else _FileBinReader(bin_path)
-        self.index = _IndexReader(idx_path, multimodal)
+        self.object_storage_config = object_storage_config
+        self.bin_reader = bin_reader
+        self.index = index_reader
 
     def __len__(self) -> int:
         return len(self.index)
@@ -503,6 +731,8 @@ class IndexedDataset(torch.utils.data.Dataset):
 
     @staticmethod
     def exists(path_prefix: str) -> bool:
+        if _is_object_storage_path(path_prefix):
+            return True  # existence check deferred to download time
         return os.path.exists(get_idx_path(path_prefix)) and os.path.exists(get_bin_path(path_prefix))
 
 

--- a/nemo_automodel/components/datasets/llm/megatron/indexed_dataset.py
+++ b/nemo_automodel/components/datasets/llm/megatron/indexed_dataset.py
@@ -573,7 +573,7 @@ class _S3BinReader(_BinReader):
             Range=f"bytes={bytes_start}-{bytes_end - 1}",
         )["Body"].read()
         self._cache_bytes_start = bytes_start
-        self._cache_bytes_end = bytes_end
+        self._cache_bytes_end = bytes_start + len(self._cache)
         return numpy.frombuffer(self._extract_from_cache(offset, size), dtype=dtype)
 
     def __del__(self) -> None:

--- a/nemo_automodel/components/datasets/llm/megatron_dataset.py
+++ b/nemo_automodel/components/datasets/llm/megatron_dataset.py
@@ -25,6 +25,7 @@ from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 
 from nemo_automodel.components.datasets.llm.megatron.builder import BlendedMegatronDatasetBuilder
 from nemo_automodel.components.datasets.llm.megatron.gpt_dataset import GPTDatasetConfig
+from nemo_automodel.components.datasets.llm.megatron.indexed_dataset import ObjectStorageConfig, _is_object_storage_path
 from nemo_automodel.components.datasets.llm.megatron.megatron_utils import compile_helper, get_blend_from_list
 
 logger = logging.getLogger(__name__)
@@ -52,6 +53,7 @@ class MegatronPretraining:
         trainer_limit_test_batches: Union[int, float] = 1,
         mmap_bin_files: bool = True,
         splits_to_build: Optional[Union[str, List[str]]] = None,
+        object_storage_config: Optional[Union[Dict, "ObjectStorageConfig"]] = None,
     ) -> None:
         """Pretraining dataset class for Megatron-LM datasets.
         Args:
@@ -104,6 +106,9 @@ class MegatronPretraining:
             trainer_limit_val_batches (Union[int, float]): Limit for validation batches.
             trainer_limit_test_batches (Union[int, float]): Limit for test batches.
             splits_to_build (Optional[Union[str, List[str]]]): Splits to build. If None, builds all splits.
+            object_storage_config (Optional[Union[Dict, ObjectStorageConfig]]): Configuration for
+                reading .bin/.idx files from S3/MSC. A dict with ``path_to_idx_cache`` (required)
+                and ``bin_chunk_nbytes`` (optional, default 256 MiB) is also accepted.
         """
         if find_spec("nemo_automodel.components.datasets.llm.megatron.helpers_cpp") is None:
             try:
@@ -119,6 +124,10 @@ class MegatronPretraining:
                     "Could not compile megatron dataset C++ helper functions and therefore cannot import helpers python file."
                 )
 
+        # Normalise object_storage_config: accept plain dict from YAML
+        if isinstance(object_storage_config, dict):
+            object_storage_config = ObjectStorageConfig(**object_storage_config)
+
         if not isinstance(paths, (list, tuple, dict)):
             # Check if paths is a JSON file containing blend configuration
             blend_config_or_none = try_load_blend_from_json(paths)
@@ -126,7 +135,7 @@ class MegatronPretraining:
                 paths = blend_config_or_none
             else:
                 paths = get_list_of_files(paths)
-        validate_dataset_asset_accessibility(paths)
+        validate_dataset_asset_accessibility(paths, object_storage_config=object_storage_config)
 
         if isinstance(split, (list, tuple)):
             split = [str(s) for s in split]
@@ -171,6 +180,7 @@ class MegatronPretraining:
                 f"Invalid splits: {splits_to_build}"
             )
         self.splits_to_build = splits_to_build
+        self.object_storage_config = object_storage_config
 
         # Store trainer arguments
         self.trainer_max_steps = trainer_max_steps
@@ -269,6 +279,7 @@ class MegatronPretraining:
             reset_attention_mask=False,
             eod_mask_loss=False,
             num_dataset_builder_threads=self.num_dataset_builder_threads,
+            object_storage_config=self.object_storage_config,
             **self.build_kwargs,
         )
 
@@ -298,9 +309,10 @@ def is_zipped_list(paths):
     return is_num[0]
 
 
-def validate_dataset_asset_accessibility(paths):
+def validate_dataset_asset_accessibility(paths, object_storage_config=None):
     """
     Validate the accessibility of the dataset assets.
+    Skips local-filesystem checks for S3/MSC paths when object_storage_config is provided.
     """
     if paths is None:
         raise ValueError("Expected path to have a value.")
@@ -310,15 +322,19 @@ def validate_dataset_asset_accessibility(paths):
             # remove weights from paths.
             paths = paths[1::2]
         for p in paths:
-            validate_dataset_asset_accessibility(p)
+            validate_dataset_asset_accessibility(p, object_storage_config=object_storage_config)
         return
     elif isinstance(paths, dict):
         for p in paths.values():
-            validate_dataset_asset_accessibility(p)
+            validate_dataset_asset_accessibility(p, object_storage_config=object_storage_config)
         return
 
     if not isinstance(paths, str) and not isinstance(paths, Path):
         raise ValueError("Expected path to be of string or Path type.")
+
+    # Skip local filesystem checks for object-storage paths
+    if object_storage_config is not None and _is_object_storage_path(str(paths)):
+        return
 
     path = Path(paths)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,12 +153,19 @@ vlm = [
 cli = [
     "pyyaml",
 ]
+s3 = [
+    "boto3>=1.34",
+]
+msc = [
+    "multi-storage-client>=0.13",
+]
 all = [
     "nemo_automodel[cuda]",
     "nemo_automodel[delta-databricks]",
     "nemo_automodel[diffusion]",
     "nemo_automodel[extra]",
     "nemo_automodel[fla]",
+    "nemo_automodel[s3]",
     "nemo_automodel[vlm]",
 ]
 

--- a/tests/unit_tests/datasets/llm/test_indexed_dataset_object_storage.py
+++ b/tests/unit_tests/datasets/llm/test_indexed_dataset_object_storage.py
@@ -1,0 +1,245 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for S3 / MSC object-storage support in MegatronPretraining.
+
+All S3 interactions are mocked via ``unittest.mock``; no real network calls.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from nemo_automodel.components.datasets.llm.megatron import indexed_dataset as ids
+from nemo_automodel.components.datasets.llm.megatron.indexed_dataset import (
+    ObjectStorageConfig,
+    _cache_index_file,
+    _get_index_cache_path,
+    _is_object_storage_path,
+    _parse_s3_path,
+    _S3BinReader,
+)
+from nemo_automodel.components.datasets.llm.megatron_dataset import (
+    validate_dataset_asset_accessibility,
+)
+
+# ---------------------------------------------------------------------------
+# Pure helpers (no I/O)
+# ---------------------------------------------------------------------------
+
+
+class TestObjectStorageConfig:
+    def test_defaults(self):
+        cfg = ObjectStorageConfig(path_to_idx_cache="/tmp/idx_cache")
+        assert cfg.path_to_idx_cache == "/tmp/idx_cache"
+        assert cfg.bin_chunk_nbytes == 256 * 1024 * 1024
+
+    def test_custom_chunk_size(self):
+        cfg = ObjectStorageConfig(path_to_idx_cache="/x", bin_chunk_nbytes=16 * 1024 * 1024)
+        assert cfg.bin_chunk_nbytes == 16 * 1024 * 1024
+
+
+class TestIsObjectStoragePath:
+    @pytest.mark.parametrize(
+        "path,expected",
+        [
+            ("s3://bucket/key", True),
+            ("msc://profile/path", True),
+            ("/local/path", False),
+            ("relative/path", False),
+            ("", False),
+            ("file:///tmp/x", False),
+        ],
+    )
+    def test_detection(self, path, expected):
+        assert _is_object_storage_path(path) is expected
+
+
+class TestParseS3Path:
+    def test_bucket_and_key(self):
+        assert _parse_s3_path("s3://my-bucket/path/to/object") == ("my-bucket", "path/to/object")
+
+    def test_bucket_only(self):
+        assert _parse_s3_path("s3://my-bucket") == ("my-bucket", "")
+
+    def test_rejects_non_s3(self):
+        with pytest.raises(ValueError, match="Not an S3 path"):
+            _parse_s3_path("/local/path")
+
+
+class TestGetIndexCachePath:
+    def test_s3_path(self):
+        cfg = ObjectStorageConfig(path_to_idx_cache="/cache")
+        out = _get_index_cache_path("s3://bucket/dir/shard.idx", cfg)
+        assert out == "/cache/bucket/dir/shard.idx"
+
+    def test_msc_path(self):
+        cfg = ObjectStorageConfig(path_to_idx_cache="/cache")
+        out = _get_index_cache_path("msc://profile/dir/shard.idx", cfg)
+        assert out == "/cache/profile/dir/shard.idx"
+
+    def test_rejects_local(self):
+        cfg = ObjectStorageConfig(path_to_idx_cache="/cache")
+        with pytest.raises(ValueError, match="Not an object storage path"):
+            _get_index_cache_path("/local/shard.idx", cfg)
+
+
+# ---------------------------------------------------------------------------
+# _cache_index_file: rank-0 download, others wait
+# ---------------------------------------------------------------------------
+
+
+class TestCacheIndexFile:
+    def test_downloads_when_missing(self, tmp_path):
+        local = tmp_path / "sub" / "shard.idx"
+        # Stand in for boto3.client("s3") — record download_file invocation.
+        fake_client = MagicMock()
+
+        def fake_download(bucket, key, dest):
+            os.makedirs(os.path.dirname(dest), exist_ok=True)
+            with open(dest, "wb") as f:
+                f.write(b"FAKE_IDX")
+
+        fake_client.download_file.side_effect = fake_download
+
+        with patch.object(ids, "HAS_BOTO3", True), patch.object(ids, "boto3") as boto3_mod:
+            boto3_mod.client.return_value = fake_client
+            _cache_index_file("s3://bucket/dir/shard.idx", str(local))
+
+        assert local.exists()
+        fake_client.download_file.assert_called_once_with("bucket", "dir/shard.idx", str(local))
+
+    def test_skips_when_cached(self, tmp_path):
+        local = tmp_path / "shard.idx"
+        local.write_bytes(b"EXISTING")
+        with patch.object(ids, "HAS_BOTO3", True), patch.object(ids, "boto3") as boto3_mod:
+            _cache_index_file("s3://bucket/dir/shard.idx", str(local))
+            boto3_mod.client.assert_not_called()
+
+    def test_raises_when_boto3_missing(self, tmp_path):
+        local = tmp_path / "shard.idx"
+        with patch.object(ids, "HAS_BOTO3", False):
+            with pytest.raises(ImportError, match="boto3 is required"):
+                _cache_index_file("s3://bucket/dir/shard.idx", str(local))
+
+    def test_rejects_unknown_scheme(self, tmp_path):
+        local = tmp_path / "shard.idx"
+        with pytest.raises(ValueError, match="Unsupported object storage path"):
+            _cache_index_file("/local/shard.idx", str(local))
+
+
+# ---------------------------------------------------------------------------
+# _S3BinReader: ranged GETs and in-memory chunk caching
+# ---------------------------------------------------------------------------
+
+
+class TestS3BinReader:
+    @staticmethod
+    def _make_reader(payload: bytes, chunk_nbytes: int = 32):
+        """Return an _S3BinReader whose client returns ``payload`` for any GET."""
+        fake_client = MagicMock()
+
+        def fake_get_object(Bucket, Key, Range):
+            # Range looks like "bytes=<start>-<end>"
+            start_end = Range.split("=")[1]
+            start, end = (int(x) for x in start_end.split("-"))
+            chunk = payload[start : end + 1]
+            return {"Body": io.BytesIO(chunk)}
+
+        fake_client.get_object.side_effect = fake_get_object
+
+        cfg = ObjectStorageConfig(path_to_idx_cache="/cache", bin_chunk_nbytes=chunk_nbytes)
+        with patch.object(ids, "HAS_BOTO3", True), patch.object(ids, "boto3") as boto3_mod:
+            boto3_mod.client.return_value = fake_client
+            reader = _S3BinReader("s3://b/key", cfg)
+        return reader, fake_client
+
+    def test_read_in_chunk_uses_cache(self):
+        payload = np.arange(64, dtype=np.int32).tobytes()  # 256 bytes total
+        reader, fake_client = self._make_reader(payload, chunk_nbytes=128)
+
+        # First read fetches one chunk; second read within same window must reuse cache.
+        a = reader.read(np.int32, count=4, offset=0)
+        b = reader.read(np.int32, count=4, offset=16)
+        np.testing.assert_array_equal(a, np.arange(4, dtype=np.int32))
+        np.testing.assert_array_equal(b, np.arange(4, 8, dtype=np.int32))
+        assert fake_client.get_object.call_count == 1, "Second read should hit in-memory cache"
+
+    def test_read_crossing_chunk_refetches(self):
+        payload = np.arange(64, dtype=np.int32).tobytes()
+        reader, fake_client = self._make_reader(payload, chunk_nbytes=32)
+
+        reader.read(np.int32, count=4, offset=0)  # bytes [0, 16) — chunk [0,32)
+        reader.read(np.int32, count=4, offset=128)  # bytes [128,144) — new chunk
+        assert fake_client.get_object.call_count == 2
+
+    def test_init_rejects_invalid_chunk_size(self):
+        cfg = ObjectStorageConfig(path_to_idx_cache="/cache", bin_chunk_nbytes=0)
+        with patch.object(ids, "HAS_BOTO3", True), patch.object(ids, "boto3"):
+            with pytest.raises(ValueError, match="bin_chunk_nbytes must be positive"):
+                _S3BinReader("s3://b/key", cfg)
+
+    def test_init_raises_when_boto3_missing(self):
+        cfg = ObjectStorageConfig(path_to_idx_cache="/cache")
+        with patch.object(ids, "HAS_BOTO3", False):
+            with pytest.raises(ImportError, match="boto3 is required"):
+                _S3BinReader("s3://b/key", cfg)
+
+
+# ---------------------------------------------------------------------------
+# IndexedDataset.exists short-circuit
+# ---------------------------------------------------------------------------
+
+
+class TestIndexedDatasetExistsObjectStorage:
+    def test_s3_prefix_returns_true_without_network_call(self):
+        # exists() is a @staticmethod; should not touch boto3 at all.
+        assert ids.IndexedDataset.exists("s3://b/anything") is True
+
+    def test_msc_prefix_returns_true_without_network_call(self):
+        assert ids.IndexedDataset.exists("msc://profile/anything") is True
+
+    def test_local_prefix_still_checks_filesystem(self, tmp_path):
+        prefix = tmp_path / "shard"
+        # Neither .idx nor .bin exist — should return False.
+        assert ids.IndexedDataset.exists(str(prefix)) is False
+
+
+# ---------------------------------------------------------------------------
+# validate_dataset_asset_accessibility: skip local FS check for s3://
+# ---------------------------------------------------------------------------
+
+
+class TestValidateAssetAccessibilityObjectStorage:
+    def test_skips_s3_path_when_config_provided(self):
+        cfg = ObjectStorageConfig(path_to_idx_cache="/cache")
+        # Would raise FileNotFoundError if it tried Path(...).exists()
+        validate_dataset_asset_accessibility("s3://bucket/does/not/exist", object_storage_config=cfg)
+
+    def test_skips_s3_paths_in_zipped_list(self):
+        cfg = ObjectStorageConfig(path_to_idx_cache="/cache")
+        validate_dataset_asset_accessibility(
+            ["0.5", "s3://bucket/a", "0.5", "s3://bucket/b"], object_storage_config=cfg
+        )
+
+    def test_local_path_still_validated(self, tmp_path):
+        cfg = ObjectStorageConfig(path_to_idx_cache="/cache")
+        missing = tmp_path / "shard"
+        with pytest.raises(FileNotFoundError):
+            validate_dataset_asset_accessibility(str(missing), object_storage_config=cfg)

--- a/uv.lock
+++ b/uv.lock
@@ -630,6 +630,43 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.43.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/a8/5422bd25bd2520a6122cb82b2dfa280c66e380102533761b96e7a10f1a4d/boto3-1.43.8.tar.gz", hash = "sha256:d1235602d715c727c1923ef4bcdb5612a20575a9a5e4f2db00d571e0ea1f85fc", size = 113144, upload-time = "2026-05-14T19:34:36.518Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/48/920c58e5b4450dd389ef3e56dca8803af093ccc0a8e04dd69a60812b7f94/boto3-1.43.8-py3-none-any.whl", hash = "sha256:1894497c383e3cdf50e210f1f57a43e9f4047a5d3accc73ffdb7eacc3b0f011b", size = 140523, upload-time = "2026-05-14T19:34:33.883Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/bb/7c1f5d12e1fbaf88a03d504bfa2f03fa6913f127051a7b121fe3bcaadefb/botocore-1.43.8.tar.gz", hash = "sha256:611ad8b1f60661373cd39d9391ff16f1eaf8f5cb1d0a691563a4201d1a2603ce", size = 15358475, upload-time = "2026-05-14T19:34:23.195Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/d8/c5486e4f0c6790f830368a171017d0687d89ffd3a57511bba533b56ee50f/botocore-1.43.8-py3-none-any.whl", hash = "sha256:6257d2655c3abe75eaa49e218b7d883cdc7cea64652b451e5feb08a6c169da3c", size = 15038825, upload-time = "2026-05-14T19:34:18.877Z" },
+]
+
+[[package]]
+name = "bracex"
+version = "2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/9a/fec38644694abfaaeca2798b58e276a8e61de49e2e37494ace423395febc/bracex-2.6.tar.gz", hash = "sha256:98f1347cd77e22ee8d967a30ad4e310b233f7754dbf31ff3fceb76145ba47dc7", size = 26642, upload-time = "2025-06-22T19:12:31.254Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/2a/9186535ce58db529927f6cf5990a849aa9e052eea3e2cfefe20b9e1802da/bracex-2.6-py3-none-any.whl", hash = "sha256:0b0049264e7340b3ec782b5cb99beb325f36c3782a32e36e876452fd49a09952", size = 11508, upload-time = "2025-06-22T19:12:29.781Z" },
+]
+
+[[package]]
 name = "cachetools"
 version = "6.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1497,11 +1534,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.20.0"
+version = "3.29.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/46/0028a82567109b5ef6e4d2a1f04a583fb513e6cf9527fcdd09afd817deeb/filelock-3.20.0.tar.gz", hash = "sha256:711e943b4ec6be42e1d4e6690b48dc175c822967466bb31c0c293f34334c13f4", size = 18922, upload-time = "2025-10-08T18:03:50.056Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/91/7216b27286936c16f5b4d0c530087e4a54eead683e6b0b73dd0c64844af6/filelock-3.20.0-py3-none-any.whl", hash = "sha256:339b4732ffda5cd79b13f4e2711a31b0365ce445d95d243bb996273d072546a2", size = 16054, upload-time = "2025-10-08T18:03:48.35Z" },
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
 ]
 
 [[package]]
@@ -2292,6 +2329,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
 name = "joblib"
 version = "1.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2449,6 +2495,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/33/01/a8ea7c5ea32a9b45ceeaee051a04c8ed4320f5add3c51bfa20879b765b70/kiwisolver-1.4.9-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:85b5352f94e490c028926ea567fc569c52ec79ce131dadb968d3853e809518c2", size = 80281, upload-time = "2025-08-10T21:27:45.369Z" },
     { url = "https://files.pythonhosted.org/packages/da/e3/dbd2ecdce306f1d07a1aaf324817ee993aab7aee9db47ceac757deabafbe/kiwisolver-1.4.9-pp311-pypy311_pp73-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:464415881e4801295659462c49461a24fb107c140de781d55518c4b80cb6790f", size = 78009, upload-time = "2025-08-10T21:27:46.376Z" },
     { url = "https://files.pythonhosted.org/packages/da/e9/0d4add7873a73e462aeb45c036a2dead2562b825aa46ba326727b3f31016/kiwisolver-1.4.9-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:fb940820c63a9590d31d88b815e7a3aa5915cad3ce735ab45f0c730b39547de1", size = 73929, upload-time = "2025-08-10T21:27:48.236Z" },
+]
+
+[[package]]
+name = "lark"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/34/28fff3ab31ccff1fd4f6c7c7b0ceb2b6968d8ea4950663eadcb5720591a0/lark-1.3.1.tar.gz", hash = "sha256:b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905", size = 382732, upload-time = "2025-10-27T18:25:56.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3d/14ce75ef66813643812f3093ab17e46d3a206942ce7376d31ec2d36229e7/lark-1.3.1-py3-none-any.whl", hash = "sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12", size = 113151, upload-time = "2025-10-27T18:25:54.882Z" },
 ]
 
 [[package]]
@@ -3118,6 +3173,40 @@ wheels = [
 ]
 
 [[package]]
+name = "multi-storage-client"
+version = "0.48.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "jmespath" },
+    { name = "jsonschema" },
+    { name = "lark" },
+    { name = "opentelemetry-api" },
+    { name = "prettytable" },
+    { name = "psutil" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "tzdata" },
+    { name = "wcmatch" },
+    { name = "xattr" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/a3/abb130e608379ff64e35482be6facf92ba7cf1df71f00851fa6ab9317c15/multi_storage_client-0.48.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:d81acc25db9405027543332a68e0a171e9fac40ff983c89937b8c7f6a1f8704e", size = 9930523, upload-time = "2026-05-04T23:40:44.159Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/c5/f9bdb63607f37fc47564b8c7a32e1af8b67ceaa8aad3cef35e222dbdb588/multi_storage_client-0.48.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c7c48842a394b0720ef674a3cbfcc30513d299689bbc6d704c2f54db74258d3", size = 6180115, upload-time = "2026-05-04T23:40:11.623Z" },
+    { url = "https://files.pythonhosted.org/packages/31/2c/96eeade65ac296a2870900389361dd5ac455747edb8cb1da4d0188d82410/multi_storage_client-0.48.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0a4177303b68e20175a2dbae0dbcce735364e22be1a9835a3d95530eb35cf739", size = 6377313, upload-time = "2026-05-04T23:39:41.015Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/09/ce4c0bfa731cfd11d6e38110c3de72ee89192539e0edf556bf6fecc3a5c1/multi_storage_client-0.48.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:c58a64a239e678dba6b6032fd887d805ac70f00607a395c8c5ff23718362c4b9", size = 10113132, upload-time = "2026-05-04T23:39:15.208Z" },
+    { url = "https://files.pythonhosted.org/packages/96/92/9f7d085971485a204c56b56b8e2b6483a75509753c6c37a40d9aa6aa8461/multi_storage_client-0.48.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2cf9ba18ef3bace23a9bfd5b19467c9d3860c5d0be43765df9a0f59fd78936dc", size = 6364058, upload-time = "2026-05-04T23:38:43.184Z" },
+    { url = "https://files.pythonhosted.org/packages/41/0a/a5bfc67e5dd11021d215c680edcbacefbe840759c2822409f9e962158070/multi_storage_client-0.48.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:221785dfd47db25b76895a1af9c751c620076de832738a1000152539052965bf", size = 6561123, upload-time = "2026-05-04T23:38:14.012Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/3d/aaf68ab3771849146faa7189a97564bc98db8fc1cf3c39405dfc58c216e8/multi_storage_client-0.48.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:62bddddeeea4b028a87f4dcaf59a07678f56e2ae418c5b5ba3c4dc1fc013273e", size = 10082802, upload-time = "2026-05-04T23:37:43.112Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/af/80ee5ba9f4748a5c113eb5ae7be6a8d3e1d11a77c3c636b940a3f87e5490/multi_storage_client-0.48.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:011558bb9ae0b5c8293e7e3b57d0f3c9d1222ba66bdd074391953c74252e39af", size = 6335934, upload-time = "2026-05-04T23:37:16.003Z" },
+    { url = "https://files.pythonhosted.org/packages/16/49/f2acaae4608e5860fdfb05c3253a8da5a16fc1495eac8de6c50777059dc4/multi_storage_client-0.48.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f884080f0b22fc5c22b86187013637e97d0c78be0fa83eb07517cffef75e535", size = 6534750, upload-time = "2026-05-04T23:36:49.577Z" },
+    { url = "https://files.pythonhosted.org/packages/68/14/b5ef4090aa659ae476f841a2642d53481b7275523af2a0ac9d7bad9f3227/multi_storage_client-0.48.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:8daf18534f96876fb5baa65be105253e8b890bfe79cd2c534fcf28403790460d", size = 10082075, upload-time = "2026-05-04T23:36:16.799Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/cb/45e442c3aadd76665a6d1d3c5d9986b02317920511aee780f6370e176ff4/multi_storage_client-0.48.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:66b46f880b764ceba1acc6beb0278b9e75fc472a052e12933b5d8f5319b7dcb7", size = 6338266, upload-time = "2026-05-04T23:35:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/dda248860a93c2e74ad5bb7cc1f2e615d7de96a144a6f7af3997450ad7f8/multi_storage_client-0.48.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d737b7678681fe7cb491337a722041a0853b8f53f8354eaa0239fca1707b82de", size = 6537974, upload-time = "2026-05-04T23:35:29.366Z" },
+]
+
+[[package]]
 name = "multidict"
 version = "6.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3317,6 +3406,7 @@ dependencies = [
 all = [
     { name = "albumentations" },
     { name = "backoff" },
+    { name = "boto3" },
     { name = "causal-conv1d" },
     { name = "databricks-sql-connector" },
     { name = "deltalake" },
@@ -3407,6 +3497,12 @@ moe = [
     { name = "onnxscript" },
     { name = "transformer-engine", extra = ["pytorch"] },
 ]
+msc = [
+    { name = "multi-storage-client" },
+]
+s3 = [
+    { name = "boto3" },
+]
 vlm = [
     { name = "albumentations" },
     { name = "backoff" },
@@ -3467,6 +3563,7 @@ requires-dist = [
     { name = "albumentations", marker = "extra == 'vlm'" },
     { name = "backoff", marker = "extra == 'vlm'" },
     { name = "bitsandbytes", marker = "extra == 'cuda-source'" },
+    { name = "boto3", marker = "extra == 's3'", specifier = ">=1.34" },
     { name = "causal-conv1d", marker = "extra == 'cuda'" },
     { name = "databricks-sql-connector", marker = "extra == 'delta-databricks'", specifier = ">=3.0.0" },
     { name = "datasets", specifier = ">=4.0.0" },
@@ -3485,6 +3582,7 @@ requires-dist = [
     { name = "mistral-common", extras = ["audio", "hf-hub", "image", "sentencepiece"] },
     { name = "mistral-common", extras = ["opencv"], marker = "extra == 'vlm'", specifier = ">=1.11.0" },
     { name = "mlflow" },
+    { name = "multi-storage-client", marker = "extra == 'msc'", specifier = ">=0.13" },
     { name = "nemo-automodel", extras = ["cuda"], marker = "extra == 'all'" },
     { name = "nemo-automodel", extras = ["cuda"], marker = "extra == 'moe'" },
     { name = "nemo-automodel", extras = ["delta-databricks"], marker = "extra == 'all'" },
@@ -3493,6 +3591,7 @@ requires-dist = [
     { name = "nemo-automodel", extras = ["extra"], marker = "extra == 'all'" },
     { name = "nemo-automodel", extras = ["fla"], marker = "extra == 'all'" },
     { name = "nemo-automodel", extras = ["fla"], marker = "extra == 'moe'" },
+    { name = "nemo-automodel", extras = ["s3"], marker = "extra == 'all'" },
     { name = "nemo-automodel", extras = ["vlm"], marker = "extra == 'all'" },
     { name = "numba", marker = "extra == 'vlm'" },
     { name = "numpy", marker = "extra == 'vlm'" },
@@ -3524,7 +3623,7 @@ requires-dist = [
     { name = "transformers", specifier = "==5.5.0" },
     { name = "wandb", specifier = ">=0.26.1" },
 ]
-provides-extras = ["diffusion", "diffusion-kernels", "cuda", "cuda-source", "extra", "fa", "fla", "delta-databricks", "moe", "vlm", "cli", "all"]
+provides-extras = ["diffusion", "diffusion-kernels", "cuda", "cuda-source", "extra", "fa", "fla", "delta-databricks", "moe", "vlm", "cli", "s3", "msc", "all"]
 
 [package.metadata.requires-dev]
 build = [
@@ -5520,6 +5619,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/8f/1f545ea6f9fcd7bf4368551fb91d2064d8f0577b3079bb3f0ae5779fb773/ruff-0.9.10-py3-none-win32.whl", hash = "sha256:bfb834e87c916521ce46b1788fbb8484966e5113c02df216680102e9eb960029", size = 10247401, upload-time = "2025-03-07T15:27:35.994Z" },
     { url = "https://files.pythonhosted.org/packages/4f/18/fb703603ab108e5c165f52f5b86ee2aa9be43bb781703ec87c66a5f5d604/ruff-0.9.10-py3-none-win_amd64.whl", hash = "sha256:f2160eeef3031bf4b17df74e307d4c5fb689a6f3a26a2de3f7ef4044e3c484f1", size = 11366360, upload-time = "2025-03-07T15:27:38.66Z" },
     { url = "https://files.pythonhosted.org/packages/35/85/338e603dc68e7d9994d5d84f24adbf69bae760ba5efd3e20f5ff2cec18da/ruff-0.9.10-py3-none-win_arm64.whl", hash = "sha256:5fd804c0327a5e5ea26615550e706942f348b197d5475ff34c19733aee4b2e69", size = 10436892, upload-time = "2025-03-07T15:27:41.687Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/ec/7c692cde9125b77e84b307354d4fb705f98b8ccad59a036d5957ca75bfc3/s3transfer-0.17.0.tar.gz", hash = "sha256:9edeb6d1c3c2f89d6050348548834ad8289610d886e5bf7b7207728bd43ce33a", size = 155337, upload-time = "2026-04-29T22:07:36.33Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/72/c6c32d2b657fa3dad1de340254e14390b1e334ce38268b7ad51abda3c8c2/s3transfer-0.17.0-py3-none-any.whl", hash = "sha256:ce3801712acf4ad3e89fb9990df97b4972e93f4b3b0004d214be5bce12814c20", size = 86811, upload-time = "2026-04-29T22:07:34.966Z" },
 ]
 
 [[package]]
@@ -7522,6 +7633,18 @@ wheels = [
 ]
 
 [[package]]
+name = "wcmatch"
+version = "10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bracex" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/3e/c0bdc27cf06f4e47680bd5803a07cb3dfd17de84cde92dd217dcb9e05253/wcmatch-10.1.tar.gz", hash = "sha256:f11f94208c8c8484a16f4f48638a85d771d9513f4ab3f37595978801cb9465af", size = 117421, upload-time = "2025-06-22T19:14:02.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/d8/0d1d2e9d3fabcf5d6840362adcf05f8cf3cd06a73358140c3a97189238ae/wcmatch-10.1-py3-none-any.whl", hash = "sha256:5848ace7dbb0476e5e55ab63c6bbd529745089343427caa5537f230cc01beb8a", size = 39854, upload-time = "2025-06-22T19:14:00.978Z" },
+]
+
+[[package]]
 name = "wcwidth"
 version = "0.2.14"
 source = { registry = "https://pypi.org/simple" }
@@ -7692,6 +7815,59 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/01/3a/07cd60a9d26fe73efead61c7830af975dfdba8537632d410462672e4432b/wrapt-2.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:61c4956171c7434634401db448371277d07032a81cc21c599c22953374781395", size = 64038, upload-time = "2025-11-07T00:45:00.948Z" },
     { url = "https://files.pythonhosted.org/packages/41/99/8a06b8e17dddbf321325ae4eb12465804120f699cd1b8a355718300c62da/wrapt-2.0.1-cp314-cp314t-win_arm64.whl", hash = "sha256:35cdbd478607036fee40273be8ed54a451f5f23121bd9d4be515158f9498f7ad", size = 60634, upload-time = "2025-11-07T00:45:02.087Z" },
     { url = "https://files.pythonhosted.org/packages/15/d1/b51471c11592ff9c012bd3e2f7334a6ff2f42a7aed2caffcf0bdddc9cb89/wrapt-2.0.1-py3-none-any.whl", hash = "sha256:4d2ce1bf1a48c5277d7969259232b57645aae5686dba1eaeade39442277afbca", size = 44046, upload-time = "2025-11-07T00:45:32.116Z" },
+]
+
+[[package]]
+name = "xattr"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/d5/25f7b19af3a2cb4000cac4f9e5525a40bec79f4f5d0ac9b517c0544586a0/xattr-1.3.0.tar.gz", hash = "sha256:30439fabd7de0787b27e9a6e1d569c5959854cb322f64ce7380fedbfa5035036", size = 17148, upload-time = "2025-10-13T22:16:47.353Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/11/bbb25ab921e02efb789efcab5b7d03581b5d28f71d829f21e4ea6aba09fb/xattr-1.3.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a80c4617e08670cdc3ba71f1dbb275c1627744c5c3641280879cb3bc95a07237", size = 23453, upload-time = "2025-10-13T22:15:50.753Z" },
+    { url = "https://files.pythonhosted.org/packages/be/88/66021fdfbb2037a94fc5b16c1dce1894b8e9da7a1829e4be0b491b3f24ff/xattr-1.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:51cdaa359f5cd2861178ae01ea3647b56dbdfd98e724a8aa3c04f77123b78217", size = 18551, upload-time = "2025-10-13T22:15:51.961Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f7/5dd21fcfc48487a59fcec33ffe02eb671f256424869e9aef87e33c65d95b/xattr-1.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2fea070768d7d2d25797817bea93bf0a6fda6449e88cfee8bb3d75de9ed11c7b", size = 18852, upload-time = "2025-10-13T22:15:53.104Z" },
+    { url = "https://files.pythonhosted.org/packages/af/2a/e29753ac17a92aadf27b9e16b1d600584d9f10acd0b399d2c06f47af2dff/xattr-1.3.0-cp310-cp310-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:69bca34be2d7a928389aff4e32f27857e1c62d04c91ec7c1519b1636870bd58f", size = 38547, upload-time = "2025-10-13T22:15:54.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/46/b2c9185d24b93542e4307ce30cd3d4eb6af8efdc843d98ff9f07fcb048d9/xattr-1.3.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:05f8e068409742d246babba60cff8310b2c577745491f498b08bf068e0c867a3", size = 38755, upload-time = "2025-10-13T22:15:55.738Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/0a/93cf1f03536bf38e8fd3fe57eb04124e4dfe2e16c0c5ced589d3360a1858/xattr-1.3.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:bbd06987102bc11f5cbd08b15d1029832b862cf5bc61780573fc0828812f01ca", size = 38052, upload-time = "2025-10-13T22:15:57.031Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ad/60e43f7e1037cee671e14c2a283e3e7168b756c9938eba62f0616e6599aa/xattr-1.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b8589744116d2c37928b771c50383cb281675cd6dcfd740abfab6883e3d4af85", size = 37560, upload-time = "2025-10-13T22:15:58.295Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/64/292426ad5653e72c6e1325bbff22868a20077290d967cebb9c0624ad08b6/xattr-1.3.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:331a51bf8f20c27822f44054b0d760588462d3ed472d5e52ba135cf0bea510e8", size = 23448, upload-time = "2025-10-13T22:15:59.229Z" },
+    { url = "https://files.pythonhosted.org/packages/63/84/6539fbe620da8e5927406e76b9c8abad8953025d5f578d792747c38a8c0e/xattr-1.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:196360f068b74fa0132a8c6001ce1333f095364b8f43b6fd8cdaf2f18741ef89", size = 18553, upload-time = "2025-10-13T22:16:00.151Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/bb/c1c2e24a49f8d13ff878fb85aabc42ea1b2f98ce08d8205b9661d517a9cc/xattr-1.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:405d2e4911d37f2b9400fa501acd920fe0c97fe2b2ec252cb23df4b59c000811", size = 18848, upload-time = "2025-10-13T22:16:01.046Z" },
+    { url = "https://files.pythonhosted.org/packages/02/c2/a60aad150322b217dfe33695d8d9f32bc01e8f300641b6ba4b73f4b3c03f/xattr-1.3.0-cp311-cp311-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4ae3a66ae1effd40994f64defeeaa97da369406485e60bfb421f2d781be3b75d", size = 38547, upload-time = "2025-10-13T22:16:01.973Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/58/2eca142bad4ea0a2be6b58d3122d0acce310c4e53fa7defd168202772178/xattr-1.3.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:69cd3bfe779f7ba87abe6473fdfa428460cf9e78aeb7e390cfd737b784edf1b5", size = 38753, upload-time = "2025-10-13T22:16:03.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/50/d032e5254c2c27d36bdb02abdf2735db6768a441f0e3d0f139e0f9f56638/xattr-1.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c5742ca61761a99ae0c522f90a39d5fb8139280f27b254e3128482296d1df2db", size = 38054, upload-time = "2025-10-13T22:16:04.656Z" },
+    { url = "https://files.pythonhosted.org/packages/04/24/458a306439aabe0083ca0a7b14c3e6a800ab9782b5ec0bdcec4ec9f3dc6c/xattr-1.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4a04ada131e9bdfd32db3ab1efa9f852646f4f7c9d6fde0596c3825c67161be3", size = 37562, upload-time = "2025-10-13T22:16:05.97Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/78/00bdc9290066173e53e1e734d8d8e1a84a6faa9c66aee9df81e4d9aeec1c/xattr-1.3.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dd4e63614722d183e81842cb237fd1cc978d43384166f9fe22368bfcb187ebe5", size = 23476, upload-time = "2025-10-13T22:16:06.942Z" },
+    { url = "https://files.pythonhosted.org/packages/53/16/5243722294eb982514fa7b6b87a29dfb7b29b8e5e1486500c5babaf6e4b3/xattr-1.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:995843ef374af73e3370b0c107319611f3cdcdb6d151d629449efecad36be4c4", size = 18556, upload-time = "2025-10-13T22:16:08.209Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5c/d7ab0e547bea885b55f097206459bd612cefb652c5fc1f747130cbc0d42c/xattr-1.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fa23a25220e29d956cedf75746e3df6cc824cc1553326d6516479967c540e386", size = 18869, upload-time = "2025-10-13T22:16:10.319Z" },
+    { url = "https://files.pythonhosted.org/packages/98/25/25cc7d64f07de644b7e9057842227adf61017e5bcfe59a79df79f768874c/xattr-1.3.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b4345387087fffcd28f709eb45aae113d911e1a1f4f0f70d46b43ba81e69ccdd", size = 38797, upload-time = "2025-10-13T22:16:11.624Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/24/cc350bcdbed006dfcc6ade0ac817693b8b3d4b2787f20e427fd0697042e4/xattr-1.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fe92bb05eb849ab468fe13e942be0f8d7123f15d074f3aba5223fad0c4b484de", size = 38956, upload-time = "2025-10-13T22:16:13.121Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/b2/9416317ac89e2ed759a861857cda0d5e284c3691e6f460d36cc2bd5ce4d1/xattr-1.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6c42ef5bdac3febbe28d3db14d3a8a159d84ba5daca2b13deae6f9f1fc0d4092", size = 38214, upload-time = "2025-10-13T22:16:14.389Z" },
+    { url = "https://files.pythonhosted.org/packages/38/63/188f7cb41ab35d795558325d5cc8ab552171d5498cfb178fd14409651e18/xattr-1.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2aaa5d66af6523332189108f34e966ca120ff816dfa077ca34b31e6263f8a236", size = 37754, upload-time = "2025-10-13T22:16:15.306Z" },
+    { url = "https://files.pythonhosted.org/packages/27/d3/6a1731a339842afcbb2643bc93628d4ab9c52d1bf26a7b085ca8f35bba6e/xattr-1.3.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:937d8c91f6f372788aff8cc0984c4be3f0928584839aaa15ff1c95d64562071c", size = 23474, upload-time = "2025-10-13T22:16:16.33Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/25/6741ed3d4371eaa2fae70b259d17a580d858ebff8af0042a59e11bb6385f/xattr-1.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e470b3f15e9c3e263662506ff26e73b3027e1c9beac2cbe9ab89cad9c70c0495", size = 18558, upload-time = "2025-10-13T22:16:17.251Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/84/cc450688abeb8647aa93a62c1435bb532db11313abfeb9d43b28b4751503/xattr-1.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f2238b2a973fcbf5fefa1137db97c296d27f4721f7b7243a1fac51514565e9ec", size = 18869, upload-time = "2025-10-13T22:16:18.607Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/49/0e2315225ba7557e9801f9f0168a0195a7e13a3223088081eb32d2760533/xattr-1.3.0-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f32bb00395371f4a3bed87080ae315b19171ba114e8a5aa403a2c8508998ce78", size = 38702, upload-time = "2025-10-13T22:16:19.539Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8c/de4f4441c318ac38a5d3d7d4b8b940305a667e9320c34a45e57f6eb6b0e8/xattr-1.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:78df56bfe3dd4912548561ed880225437d6d49ef082fe6ccd45670810fa53cfe", size = 38869, upload-time = "2025-10-13T22:16:20.554Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/2a/38e0498c22aa733a9b5265f4929af4613e5b967659cf3e5f2f933b3ba118/xattr-1.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:864c34c14728f21c3ef89a9f276d75ae5e31dd34f48064e0d37e4bf0f671fc6e", size = 38210, upload-time = "2025-10-13T22:16:22.212Z" },
+    { url = "https://files.pythonhosted.org/packages/62/21/49b386eb8dcf42ac8e3ff55b6e8ea0a1e8b6b799571599c795265d2dc1b5/xattr-1.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1fd185b3f01121bd172c98b943f9341ca3b9ea6c6d3eb7fe7074723614d959ff", size = 37753, upload-time = "2025-10-13T22:16:23.959Z" },
+    { url = "https://files.pythonhosted.org/packages/24/49/b8bc589427696d67bc2b0992c188e576f70242c586a379f97698772c0c3d/xattr-1.3.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:630c85020282bd0bcb72c3d031491c4e91d7f29bb4c094ebdfb9db51375c5b07", size = 23543, upload-time = "2025-10-13T22:16:25.242Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/0a/03192e78071cfb86e6d8ceae0e5dcec4bacf0fd734755263aabd01532e50/xattr-1.3.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:95f1e14a4d9ca160b4b78c527bf2bac6addbeb0fd9882c405fc0b5e3073a8752", size = 18673, upload-time = "2025-10-13T22:16:26.224Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/36/9ab4f0b5c3d10df3aceaecf7e395cabe7fb7c7c004b2dc3f3cff0ef70fc3/xattr-1.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:88557c0769f64b1d014aada916c9630cfefa38b0be6c247eae20740d2d8f7b47", size = 18877, upload-time = "2025-10-13T22:16:27.164Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/1c/ab905d19a1349e847e37e02933316d17adfd1dd70b64d366885ab0bd959d/xattr-1.3.0-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c6992eb5da32c0a1375a9eeacfab15c66eebc8bd34be63ebd1eae80cc2f8bf03", size = 38782, upload-time = "2025-10-13T22:16:28.157Z" },
+    { url = "https://files.pythonhosted.org/packages/83/a7/f615a6e5d48d47e9febbe5a62b94ffa0d8bfc6d325b899873281abac10c4/xattr-1.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:da5954424099ca9d402933eaf6112c29ddde26e6da59b32f0bf5a4e35eec0b28", size = 38936, upload-time = "2025-10-13T22:16:29.291Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/6c/a8221567a7cbc00ac305a4842318562f90bb1fdd16636e1379361133f1f4/xattr-1.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:726b4d0b66724759132cacdcd84a5b19e00b0cdf704f4c2cf96d0c08dc5eaeb5", size = 38268, upload-time = "2025-10-13T22:16:30.238Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/4d/38a98df630e19360d98df8d98ec4a2560612840823f0bf55f81e0e84c866/xattr-1.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:928c49ceb0c70fc04732e46fa236d7c8281bfc3db1b40875e5f548bb14d2668c", size = 37825, upload-time = "2025-10-13T22:16:31.557Z" },
+    { url = "https://files.pythonhosted.org/packages/97/3f/6d50237645edd83e9dc6bf6521e4e28335845b674cabefd69f12bc4db59a/xattr-1.3.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:f3bef26fd2d5d7b17488f4cc4424a69894c5a8ed71dd5f657fbbf69f77f68a51", size = 23788, upload-time = "2025-10-13T22:16:32.465Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/8b/3efd48c85e08d1bfcbd46f87368b155d3d3de78bb660b408fbaff7623572/xattr-1.3.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:64f1fb511f8463851e0d97294eb0e0fde54b059150da90582327fb43baa1bb92", size = 18825, upload-time = "2025-10-13T22:16:33.442Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/19/4b4e3e2ea5fa213ff4220e84450628fecde042b0961e7b4e6d845e555ade/xattr-1.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1e6c216927b16fd4b72df655d5124b69b2a406cb3132b5231179021182f0f0d1", size = 19023, upload-time = "2025-10-13T22:16:34.395Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/4a/6460befb22ce8d43abdb22d2bf5aa63b8311507c75dc50ad402681b4b095/xattr-1.3.0-cp314-cp314t-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c0d9ab346cdd20539afddf2f9e123efee0fe8d54254d9fc580b4e2b4e6d77351", size = 43732, upload-time = "2025-10-13T22:16:35.41Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a8/3fa83e9f91dc868d764b2ca3758bf449945c4b1511e137e33a6210609b58/xattr-1.3.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2c5e7ba0e893042deef4e8638db7a497680f587ac7bd6d68925f29af633dfa6b", size = 43851, upload-time = "2025-10-13T22:16:36.416Z" },
+    { url = "https://files.pythonhosted.org/packages/28/b3/06bf7f691c3f35e94a37e097ae1868fbaa916cc174b1b916fb7aeca441e4/xattr-1.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1e0dabb39596d8d7b83d6f9f7fa30be68cf15bfb135cb633e2aad9887d308a32", size = 43274, upload-time = "2025-10-13T22:16:37.805Z" },
+    { url = "https://files.pythonhosted.org/packages/df/41/d6298c95513eabe091a6851bff5e7928fab49ffd9143808feaaf7721cf33/xattr-1.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5eeaa944516b7507ec51456751334b4880e421de169bbd067c4f32242670d606", size = 42864, upload-time = "2025-10-13T22:16:38.811Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# What does this PR do ?

Adds streaming support for `s3://` and `msc://` (NVIDIA multi-storage-client) prefixes to `MegatronPretraining` so users can train against pre-tokenized Megatron `.bin`/`.idx` blends hosted on cloud storage without first staging the data locally.

Today, `IndexedDataset` opens local `.bin`/`.idx` files only; passing an `s3://` prefix raises `FileNotFoundError` from `validate_dataset_asset_accessibility`. Upstream [Megatron-LM][mlm] already ships streaming readers for cloud storage (`_S3BinReader`, `_MultiStorageClientBinReader`, `ObjectStorageConfig`); this PR ports the same pattern into Automodel, plumbs the new optional `object_storage_config` argument through `IndexedDataset → BlendedMegatronDatasetConfig → MegatronPretraining`, and skips the local-filesystem existence check for object-storage prefixes.

[mlm]: https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/core/datasets/indexed_dataset.py

Usage:

```yaml
dataset:
  _target_: nemo_automodel.components.datasets.llm.megatron_dataset.MegatronPretraining
  paths: /path/to/blend.json          # may contain s3:// prefixes
  object_storage_config:
    path_to_idx_cache: /local/scratch/idx_cache
    bin_chunk_nbytes: 268435456       # 256 MiB; default 256 MiB
  tokenizer: { _target_: ..., pretrained_model_name_or_path: ... }
  seq_length: 8192
  split: "0.999,0.001,0.0"
  splits_to_build: "train"
  mmap_bin_files: false               # required for remote prefixes
```

Each shard's `.idx` is downloaded once into `path_to_idx_cache` (rank-0 download, barrier for the rest). The `.bin` is **not** materialized — it's streamed via ranged `GetObject` calls in `bin_chunk_nbytes`-sized chunks with a single in-memory chunk cached so sequential reads inside a chunk are free. Recipes that omit `object_storage_config` and pass local paths behave exactly as before.

# Changelog

- `nemo_automodel/components/datasets/llm/megatron/indexed_dataset.py`
  - Added `ObjectStorageConfig` dataclass (`path_to_idx_cache`, `bin_chunk_nbytes`).
  - Added `_S3BinReader`: streams `.bin` via chunked ranged `GetObject` calls with a single-chunk in-memory cache to amortize sequential reads.
  - Added `_MultiStorageClientBinReader` for `msc://` paths.
  - Added `OBJECT_STORAGE_BIN_READERS` dispatch dict and `_cache_index_file` helper (rank-0 download with `torch.distributed` barrier).
  - Plumbed `object_storage_config` through `IndexedDataset.__init__` / `initialize`; force `mmap=False` for remote prefixes (with a clear `ValueError` if the caller asks for mmap on a remote prefix); short-circuit `IndexedDataset.exists` for `s3://` / `msc://`.
- `nemo_automodel/components/datasets/llm/megatron/gpt_dataset.py`
  - Added `object_storage_config: Optional[ObjectStorageConfig]` field on `BlendedMegatronDatasetConfig`; forwarded into `build_low_level_dataset`; forces `mmap=False` when remote.
- `nemo_automodel/components/datasets/llm/megatron_dataset.py`
  - `MegatronPretraining.__init__` accepts `object_storage_config` as a dict (YAML-friendly) or as an `ObjectStorageConfig`.
  - `validate_dataset_asset_accessibility` skips the local-filesystem existence check for `s3://` / `msc://` prefixes (deferred to the reader on first use).
- `pyproject.toml`
  - Added new optional-dependency groups: `s3 = ["boto3>=1.34"]`, `msc = ["multi-storage-client>=0.13"]`.
  - Added `s3` to the `all` extras group.
- Used `nemo_automodel.shared.import_utils.safe_import` for both `boto3` and `multi_storage_client` so a missing optional dep is surfaced as a clear `ImportError("pip install nemo_automodel[s3]")` only when an `s3://` / `msc://` path is actually used.
- `tests/unit_tests/datasets/llm/test_indexed_dataset_object_storage.py`: 18 unit tests (mocked `boto3`, no real network) covering `ObjectStorageConfig` defaults, path-helpers (`_is_object_storage_path`, `_parse_s3_path`, `_get_index_cache_path`), `_cache_index_file` (downloads when missing, skips when cached, raises when `boto3` missing, rejects unknown scheme), `_S3BinReader` (cache-hit, cache-miss, invalid chunk size, missing `boto3`), `IndexedDataset.exists` short-circuit, and `validate_dataset_asset_accessibility` skip behaviour.

Strictly additive. Local mmap / file-pointer code paths are unchanged. All new arguments default to `None` so existing call sites compile and run identically.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

# Additional Information

**Verification**

End-to-end on an 8× H200 single-node CPT run (Gemma-4-E4B, FSDP2, bf16, seq=8192) consuming a 13-source S3 blend from `s3://hub-dataprod-dp-seafm-converted-data/`:

- 2-step dry-run (`local_batch_size=1`): finite loss 11.32 → 7.26; memory 43.5 → 47.0 GiB/GPU; `.idx` cached locally on first use; `.bin` streamed via 256 MiB ranged `GetObject` calls with no observable I/O wait in the step-time breakdown.
- 20-step smoke run (`local_batch_size=2`): loss 11.5 → 4.6 monotone, no NaN, no S3 throttling, ~580–1080 tps depending on cache temperature.

`ruff format` and `ruff check --fix` run clean on touched files.

**Design notes**

- **Chunk-cached `.bin` reads.** `_S3BinReader` holds at most one in-memory chunk (default 256 MiB). Sequential reads within the chunk avoid the network; random reads outside it trigger a fresh ranged `GetObject`. This matches the access pattern of `IndexedDataset.__getitem__` — token-stream reads within a sample are typically contiguous. A multi-entry LRU is a possible follow-up if a workload turns out to be more random-access.
- **Rank-0 download with barrier.** `_cache_index_file` downloads the `.idx` only on rank 0; other ranks wait on `torch.distributed.barrier()`. Single-node multi-rank avoids 8 concurrent downloads of the same file. Multi-host setups still download once per host because each host has its own local cache directory — a shared NFS `path_to_idx_cache` removes that overhead.
- **`mmap=False` forced for remote.** `_MMapBinReader` calls `numpy.memmap` on a file path, which doesn't apply to HTTP streams. The code raises `ValueError` if a user explicitly passes `mmap=True` together with an object-storage prefix, rather than silently ignoring.
- **`_is_object_storage_path` / `_parse_s3_path` underscore-prefixed.** These are implementation details for the dispatch logic; the public surface is `ObjectStorageConfig` + the new kwarg.

**Open questions / future work**

1. **Existence check at validate time.** Today, `validate_dataset_asset_accessibility` *skips* checking that an `s3://` shard exists, deferring failure to the first read. A `boto3.head_object` call per prefix would catch missing data earlier at the cost of one round-trip per shard. Happy to add it behind a flag if reviewers prefer fail-fast.
2. **Multi-host `path_to_idx_cache`.** Currently each host downloads the `.idx` set into its own local cache. An option to use a shared filesystem path (with cross-host file-locking) would reduce duplicate downloads at large scale. Out of scope here.
3. **MSC tests.** `_MultiStorageClientBinReader` is structurally identical to `_S3BinReader`, but the test suite mocks only the S3 path. Can add MSC-mocked tests if helpful — held out for this PR because I don't have an MSC backend deployed to validate end-to-end.
