### PR TITLE
refactor(eagle3): align draft model module names with sglang

### DIFF
--- a/nemo_automodel/components/speculative/eagle/draft_llama.py
+++ b/nemo_automodel/components/speculative/eagle/draft_llama.py
@@ -12,7 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Minimal Llama-based draft model for EAGLE-3 training."""
+"""Minimal Llama-based draft model for EAGLE-3 training.
+
+Module naming is aligned to ``sglang/srt/models/llama_eagle3.py`` so that a
+checkpoint produced by this trainer can be loaded directly by SGLang's
+``LlamaForCausalLMEagle3.load_weights`` without any key remapping. The state
+dict layout is:
+
+    model.embed_tokens.weight
+    model.fc.weight
+    model.layers.0.input_layernorm.weight
+    model.layers.0.hidden_norm.weight
+    model.layers.0.post_attention_layernorm.weight
+    model.layers.0.self_attn.{q,k,v,o}_proj.weight
+    model.layers.0.mlp.{gate,up,down}_proj.weight
+    model.norm.weight
+    lm_head.weight
+
+SGLang merges ``q_proj/k_proj/v_proj`` into a single ``qkv_proj`` and
+``gate_proj/up_proj`` into ``gate_up_proj`` via its ``stacked_params_mapping``
+at load time, so the un-fused storage above is the canonical on-disk format.
+"""
 
 from __future__ import annotations
 
@@ -191,16 +211,24 @@ class Eagle3LlamaMLP(nn.Module):
 
 
 class Eagle3LlamaDecoderLayer(nn.Module):
-    """Single decoder layer used by the minimal EAGLE-3 draft model."""
+    """Single decoder layer used by the minimal EAGLE-3 draft model.
 
-    def __init__(self, config: LlamaConfig):
+    Attribute names mirror SGLang's ``LlamaDecoderLayer`` in
+    ``sglang/srt/models/llama_eagle3.py``: ``input_layernorm`` is applied
+    to the per-step token embeddings (``embeds`` in SGLang),
+    ``hidden_norm`` is applied to the carried hidden state.
+    ``is_input_layer`` is the layer-0 flag that gates the ``[embeds,
+    hidden]`` concatenation (always true for our single-layer draft).
+    """
+
+    def __init__(self, config: LlamaConfig, layer_id: int = 0):
         super().__init__()
-        self.input_emb_layernorm = initialize_rms_norm_module(
+        self.layer_id = layer_id
+        self.is_input_layer = layer_id == 0
+        self.input_layernorm = initialize_rms_norm_module(
             "torch", config.hidden_size, eps=config.rms_norm_eps, device=None
         )
-        self.hidden_layernorm = initialize_rms_norm_module(
-            "torch", config.hidden_size, eps=config.rms_norm_eps, device=None
-        )
+        self.hidden_norm = initialize_rms_norm_module("torch", config.hidden_size, eps=config.rms_norm_eps, device=None)
         self.post_attention_layernorm = initialize_rms_norm_module(
             "torch", config.hidden_size, eps=config.rms_norm_eps, device=None
         )
@@ -216,8 +244,8 @@ class Eagle3LlamaDecoderLayer(nn.Module):
         cache_hidden: list[list[torch.Tensor]],
     ) -> torch.Tensor:
         residual = hidden_states
-        norm_input_embeds = self.input_emb_layernorm(input_embeds)
-        norm_hidden_states = self.hidden_layernorm(hidden_states)
+        norm_input_embeds = self.input_layernorm(input_embeds)
+        norm_hidden_states = self.hidden_norm(hidden_states)
         combined_states = torch.cat((norm_input_embeds, norm_hidden_states), dim=-1)
         hidden_states = residual + self.self_attn(
             combined_states,
@@ -232,8 +260,39 @@ class Eagle3LlamaDecoderLayer(nn.Module):
         return hidden_states
 
 
+class Eagle3LlamaModel(nn.Module):
+    """Inner backbone matching SGLang's ``LlamaModel`` in ``llama_eagle3.py``.
+
+    Owns ``embed_tokens``, the ``fc`` projection from concatenated target
+    aux hidden states to draft hidden size, the (single-element) draft
+    ``layers`` ModuleList, and the final ``norm``. The ``LlamaEagle3DraftModel``
+    wrapper around this module adds the top-level ``lm_head`` and the
+    training-facing public API.
+    """
+
+    def __init__(self, config: LlamaConfig):
+        super().__init__()
+        self.config = config
+        target_hidden_size = getattr(config, "target_hidden_size", config.hidden_size)
+        # SGLang uses ``num_aux_hidden_states`` (default 3) to size ``fc``'s
+        # input dim. We mirror that convention so the weight shape is
+        # identical and the key ``model.fc.weight`` round-trips cleanly.
+        num_aux_hidden_states = getattr(config, "num_aux_hidden_states", 3)
+
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, padding_idx=config.pad_token_id)
+        self.fc = nn.Linear(target_hidden_size * num_aux_hidden_states, config.hidden_size, bias=False)
+        self.layers = nn.ModuleList([Eagle3LlamaDecoderLayer(config, layer_id=0)])
+        self.norm = initialize_rms_norm_module("torch", config.hidden_size, eps=config.rms_norm_eps, device=None)
+
+
 class LlamaEagle3DraftModel(PreTrainedModel):
     """Minimal Llama-only EAGLE-3 draft model.
+
+    State dict keys match SGLang's ``LlamaForCausalLMEagle3`` so the saved
+    checkpoint can be loaded by SGLang's inference engine without any
+    remapping (SGLang's ``load_weights`` fuses ``q/k/v_proj`` into
+    ``qkv_proj`` and ``gate/up_proj`` into ``gate_up_proj`` via its
+    standard ``stacked_params_mapping``).
 
     This intentionally starts narrow:
     - Llama config only
@@ -243,7 +302,7 @@ class LlamaEagle3DraftModel(PreTrainedModel):
     """
 
     config_class = LlamaConfig
-    base_model_prefix = "draft_model"
+    base_model_prefix = "model"
 
     def __init__(self, config: LlamaConfig):
         super().__init__(config)
@@ -251,10 +310,7 @@ class LlamaEagle3DraftModel(PreTrainedModel):
         self.target_hidden_size = getattr(config, "target_hidden_size", config.hidden_size)
         self.draft_vocab_size = getattr(config, "draft_vocab_size", config.vocab_size)
 
-        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, padding_idx=config.pad_token_id)
-        self.hidden_proj = nn.Linear(self.target_hidden_size * 3, config.hidden_size, bias=False)
-        self.decoder = Eagle3LlamaDecoderLayer(config)
-        self.norm = initialize_rms_norm_module("torch", config.hidden_size, eps=config.rms_norm_eps, device=None)
+        self.model = Eagle3LlamaModel(config)
         self.lm_head = nn.Linear(config.hidden_size, self.draft_vocab_size, bias=False)
 
         self.post_init()
@@ -262,23 +318,23 @@ class LlamaEagle3DraftModel(PreTrainedModel):
     def copy_embeddings_from_target(self, target_embedding: nn.Embedding) -> None:
         """Initialize draft embeddings from the target model embeddings."""
         with torch.no_grad():
-            self.embed_tokens.weight.copy_(target_embedding.weight)
+            self.model.embed_tokens.weight.copy_(target_embedding.weight)
 
     def freeze_embeddings(self) -> None:
         """Freeze draft input embeddings."""
-        self.embed_tokens.weight.requires_grad_(False)
+        self.model.embed_tokens.weight.requires_grad_(False)
 
     def project_hidden_states(self, aux_hidden_states: torch.Tensor) -> torch.Tensor:
-        """Project concatenated target aux states from ``3 * H_target`` to draft hidden size."""
-        return self.hidden_proj(aux_hidden_states)
+        """Project concatenated target aux states from ``num_aux * H_target`` to draft hidden size."""
+        return self.model.fc(aux_hidden_states)
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         """Embed input ids with the draft embedding table."""
-        return self.embed_tokens(input_ids)
+        return self.model.embed_tokens(input_ids)
 
     def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor:
         """Compute draft logits on the configured draft vocabulary."""
-        return self.lm_head(self.norm(hidden_states))
+        return self.lm_head(self.model.norm(hidden_states))
 
     def forward(
         self,
@@ -305,7 +361,7 @@ class LlamaEagle3DraftModel(PreTrainedModel):
 
         draft_input_embeds = self.embed_input_ids(input_ids)
         causal_mask = _build_causal_mask(attention_mask=attention_mask, dtype=projected_hidden_states.dtype)
-        return self.decoder(
+        return self.model.layers[0](
             input_embeds=draft_input_embeds,
             hidden_states=projected_hidden_states,
             attention_mask=causal_mask,

--- a/nemo_automodel/recipes/llm/train_eagle3.py
+++ b/nemo_automodel/recipes/llm/train_eagle3.py
@@ -140,7 +140,7 @@ class TrainEagle3Recipe(BaseRecipe):
         # Cast to the target's compute dtype so every linear / embedding / norm
         # in the draft matches the bf16 (cuda) or fp32 (cpu) hidden states fed
         # in from the target. Without this, ``initialize_rms_norm_module`` defaults
-        # to bf16 while ``nn.Linear`` defaults to fp32, and ``hidden_proj`` errors
+        # to bf16 while ``nn.Linear`` defaults to fp32, and ``model.fc`` errors
         # with ``expected mat1 and mat2 to have the same dtype``.
         self.draft_model = LlamaEagle3DraftModel(LlamaConfig.from_dict(draft_config)).to(
             device=self.device, dtype=self.compute_dtype

--- a/tests/unit_tests/speculative/test_eagle3.py
+++ b/tests/unit_tests/speculative/test_eagle3.py
@@ -345,7 +345,7 @@ def test_draft_attention_rope_shifts_position_by_step_idx():
     projected = draft.project_hidden_states(aux_hidden_states)
 
     # Wrap rotary_emb to capture which position_ids it was called with.
-    attn = draft.decoder.self_attn
+    attn = draft.model.layers[0].self_attn
     original_rotary = attn.rotary_emb
     captured: list[torch.Tensor] = []
 
@@ -420,9 +420,9 @@ def test_draft_attention_einsum_matches_loop_reference():
 
     # SpecForge-style cat-in-loop reference, driven through the same
     # decoder layer (so RMSNorm / MLP / residuals match exactly).
-    attn = draft.decoder.self_attn
+    attn = draft.model.layers[0].self_attn
     scaling = attn.scaling
-    layer = draft.decoder
+    layer = draft.model.layers[0]
 
     def _ref_attention(combined, mask, pos_ids, cache):
         bsz, q_len, _ = combined.shape
@@ -453,8 +453,8 @@ def test_draft_attention_einsum_matches_loop_reference():
         for _ in range(3):
             input_embeds = draft.embed_input_ids(input_ids)
             residual = hidden
-            norm_input = layer.input_emb_layernorm(input_embeds)
-            norm_hidden = layer.hidden_layernorm(hidden)
+            norm_input = layer.input_layernorm(input_embeds)
+            norm_hidden = layer.hidden_norm(hidden)
             combined = torch.cat((norm_input, norm_hidden), dim=-1)
             hidden = residual + _ref_attention(combined, causal_mask, position_ids, cache_ref)
             residual = hidden


### PR DESCRIPTION
# What does this PR do ?

Rename submodules and restructure the EAGLE-3 Llama draft model so the saved state dict matches SGLang's `LlamaForCausalLMEagle3` (`python/sglang/srt/models/llama_eagle3.py`) exactly. With this alignment, a checkpoint produced by `train_eagle3.py` can be loaded by SGLang for inference with **zero key remapping** — `load_weights` fuses `q/k/v_proj → qkv_proj` and `gate/up_proj → gate_up_proj` via the standard `stacked_params_mapping`.

# Changelog

- `nemo_automodel/components/speculative/eagle/draft_llama.py`:
  - Introduce inner `Eagle3LlamaModel` backbone holding `embed_tokens / fc / layers (ModuleList[1]) / norm`.
  - Rename `self.decoder` → `self.model.layers[0]`, `self.hidden_proj` → `self.model.fc`, `self.embed_tokens` → `self.model.embed_tokens`, `self.norm` → `self.model.norm`.
  - Rename `Eagle3LlamaDecoderLayer.input_emb_layernorm` → `input_layernorm`, `hidden_layernorm` → `hidden_norm`.
  - Add `layer_id` / `is_input_layer` flags on the decoder layer.
  - Source `fc` input dim from `config.num_aux_hidden_states` (default 3, matches previous hardcoded value).
  - Set `base_model_prefix = "model"`.
- `tests/unit_tests/speculative/test_eagle3.py`: update attribute accesses to the new names (`draft.model.layers[0].self_attn`, `layer.input_layernorm`, `layer.hidden_norm`).
- `nemo_automodel/recipes/llm/train_eagle3.py`: update an inline comment that referenced the old `hidden_proj` name.

**Resulting state-dict keys** (drop-in compatible with `sglang.srt.models.llama_eagle3.LlamaForCausalLMEagle3.load_weights`):

```
model.embed_tokens.weight
model.fc.weight
model.layers.0.input_layernorm.weight
model.layers.0.hidden_norm.weight
model.layers.0.post_attention_layernorm.weight
model.layers.0.self_attn.{q,k,v,o}_proj.weight
model.layers.0.mlp.{gate,up,down}_proj.weight
model.norm.weight
lm_head.weight
```

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] All 14 existing unit tests in `tests/unit_tests/speculative/test_eagle3.py` pass.
- [x] Verified bit-exact equivalence (`max_diff = 0.0`) against the previous implementation on CPU/fp32 for `project_hidden_states`, single-step forward, 3-step TTT forward, and `compute_logits` — this is a pure-rename refactor.
- [x] DCO sign-off included.

# Additional Information

This is a structural rename only; no math or training behavior changes. Verified via:
- All existing unit tests pass (14/14).
- Side-by-side comparison of `HEAD~1` vs `HEAD` with identical seed and remapped weights: bit-exact output across forward, TTT cache path, and logits.