### PR TITLE
fix(distributed): error on default TP plan fallthrough at tp_size>1

### DIFF
--- a/nemo_automodel/components/distributed/megatron_fsdp.py
+++ b/nemo_automodel/components/distributed/megatron_fsdp.py
@@ -126,6 +126,7 @@ class MegatronFSDPManager:
                 model,
                 sequence_parallel=False,  # explicit: SP not supported here
                 tp_shard_plan=None,
+                tp_size=self.device_mesh["tp"].size(),
             )
         else:
             tp_shard_plan = None

--- a/nemo_automodel/components/distributed/parallelizer.py
+++ b/nemo_automodel/components/distributed/parallelizer.py
@@ -1424,6 +1424,12 @@ def _get_parallel_plan(
     https://github.com/NVIDIA-NeMo/Automodel/issues/2243); known HF
     architectures that happen to fall through (e.g. Mixtral) are left on the
     default plan with a warning, since they have been working in practice.
+
+    When the model *did* define a ``_tp_plan`` but ``get_hf_tp_shard_plan``
+    raised while translating it (e.g. styles nemo does not recognize), the
+    translator's error message is folded into the ``ValueError`` as a
+    diagnostic so the user can tell whether to add a ``_tp_plan`` from
+    scratch or fix the styles in the one they already have.
     """
     model_parallel_plan = None
     model_cls = type(model)
@@ -1485,9 +1491,11 @@ def _get_parallel_plan(
         # live under model.language_model.layers.* and would be missed by the
         # hardcoded llama-style wildcards below.
         hf_plan = None
+        hf_plan_error: Exception | None = None
         try:
             hf_plan = get_hf_tp_shard_plan(model)
         except Exception as e:
+            hf_plan_error = e
             logger.info(f"HF tp plan not available ({e}). Falling back to default base plan.")
 
         if hf_plan:
@@ -1500,25 +1508,30 @@ def _get_parallel_plan(
             # only fail-fast for them. See https://github.com/NVIDIA-NeMo/Automodel/issues/2243.
             is_remote_code = (model_cls.__module__ or "").startswith("transformers_modules.")
             if tp_size > 1 and is_remote_code:
+                # If the model author *did* define `_tp_plan` but it was unusable
+                # (e.g. styles nemo does not recognize), surface that diagnostic so the
+                # user knows whether to (a) add a missing `_tp_plan` from scratch or
+                # (b) fix the styles in the one they already have.
+                diag = f" Note: {hf_plan_error}." if hf_plan_error is not None else ""
                 raise ValueError(
                     f"No tensor-parallel plan is registered for the custom-code architecture "
-                    f"'{model_cls.__name__}' (loaded via trust_remote_code=True) and the model "
-                    f"does not expose a HuggingFace `_tp_plan`. The default base plan cannot be "
-                    f"used at tp_size={tp_size}: it produces DTensor placements without "
-                    "`shard_order` metadata, which trips an internal assert in "
+                    f"'{model_cls.__name__}' (loaded via trust_remote_code=True), and no usable "
+                    f"HuggingFace `_tp_plan` was found.{diag} The default base plan cannot be used "
+                    f"at tp_size={tp_size}: it produces DTensor placements without `shard_order` "
+                    "metadata, which trips an internal assert in "
                     "`torch.distributed.tensor._redistribute` on the first weight redistribute. "
                     "Register a working plan in one of the following ways:\n"
                     f"  1. Add an entry for '{model_cls.__name__}' to "
                     "`nemo_automodel.components.distributed.optimized_tp_plans.PARALLELIZE_FUNCTIONS`.\n"
-                    "  2. Define a `_tp_plan` on the model class (HF-native per-model TP plan).\n"
+                    "  2. Define a `_tp_plan` on the model class with styles nemo recognizes "
+                    "(e.g. `colwise`, `rowwise`, `colwise_rep`, `rowwise_rep`).\n"
                     "  3. Pass `tp_shard_plan` (dict or import path) when constructing the parallelizer.\n"
                     "Alternatively, run with tp_size=1."
                 )
             if tp_size > 1:
                 logger.warning(
-                    "No tensor-parallel plan is registered for '%s' and the model does not "
-                    "expose a HuggingFace `_tp_plan`. Falling back to the default base plan at "
-                    "tp_size=%d. If you hit an internal assert in "
+                    "No usable tensor-parallel plan is registered for '%s'. Falling back to the "
+                    "default base plan at tp_size=%d. If you hit an internal assert in "
                     "`torch.distributed.tensor._redistribute` on `shard_order is not None`, "
                     "register a plan via `PARALLELIZE_FUNCTIONS`, `_tp_plan`, or `tp_shard_plan`.",
                     model_cls.__name__,

--- a/nemo_automodel/components/distributed/parallelizer.py
+++ b/nemo_automodel/components/distributed/parallelizer.py
@@ -1412,14 +1412,18 @@ def _get_parallel_plan(
     3) Otherwise, prefer the model's HF-native ``_tp_plan`` (via ``get_hf_tp_shard_plan``).
     4) Otherwise, fall back to the default base plan.
 
-    When ``tp_size > 1`` and the model has no registered plan in
-    ``PARALLELIZE_FUNCTIONS`` and no HF-native ``_tp_plan`` (i.e. path 4 would
-    apply), this raises ``ValueError`` instead of returning the default base
-    plan. The default plan produces placements that do not populate the
-    ``shard_order`` metadata newer versions of PyTorch DTensor assert on, so
-    using it at ``tp_size > 1`` would crash inside
-    ``torch.distributed.tensor._redistribute`` with an opaque assertion. Path
-    4 is only safe at ``tp_size == 1``, where no actual sharding happens.
+    When ``tp_size > 1`` and the model falls through to path 4 *and* the
+    model class was loaded from a custom-code source (HF's
+    ``trust_remote_code=True`` path, where the dynamic class lives under
+    ``transformers_modules.*``), this raises ``ValueError`` instead of
+    returning the default base plan. On recent PyTorch the default plan's
+    placements do not populate ``shard_order`` and trip an internal assert in
+    ``torch.distributed.tensor._redistribute`` on the first weight
+    redistribute, which surfaces to the user as an opaque PyTorch internal
+    error. Custom-code architectures are the only known-broken case (see
+    https://github.com/NVIDIA-NeMo/Automodel/issues/2243); known HF
+    architectures that happen to fall through (e.g. Mixtral) are left on the
+    default plan with a warning, since they have been working in practice.
     """
     model_parallel_plan = None
     model_cls = type(model)
@@ -1490,12 +1494,18 @@ def _get_parallel_plan(
             model_parallel_plan = hf_plan
             logger.info(f"Using HF-native tp plan for {model_cls.__name__}.")
         else:
-            if tp_size > 1:
+            # HF places dynamic classes loaded via ``trust_remote_code=True`` under the
+            # ``transformers_modules.*`` namespace. Those are the only archs known to
+            # actually crash inside ``_redistribute`` with the default base plan, so we
+            # only fail-fast for them. See https://github.com/NVIDIA-NeMo/Automodel/issues/2243.
+            is_remote_code = (model_cls.__module__ or "").startswith("transformers_modules.")
+            if tp_size > 1 and is_remote_code:
                 raise ValueError(
-                    f"No tensor-parallel plan is registered for '{model_cls.__name__}' and the "
-                    f"model does not expose a HuggingFace `_tp_plan`. The default base plan "
-                    f"cannot be used at tp_size={tp_size}: it produces DTensor placements "
-                    "without `shard_order` metadata, which trips an internal assert in "
+                    f"No tensor-parallel plan is registered for the custom-code architecture "
+                    f"'{model_cls.__name__}' (loaded via trust_remote_code=True) and the model "
+                    f"does not expose a HuggingFace `_tp_plan`. The default base plan cannot be "
+                    f"used at tp_size={tp_size}: it produces DTensor placements without "
+                    "`shard_order` metadata, which trips an internal assert in "
                     "`torch.distributed.tensor._redistribute` on the first weight redistribute. "
                     "Register a working plan in one of the following ways:\n"
                     f"  1. Add an entry for '{model_cls.__name__}' to "
@@ -1503,6 +1513,16 @@ def _get_parallel_plan(
                     "  2. Define a `_tp_plan` on the model class (HF-native per-model TP plan).\n"
                     "  3. Pass `tp_shard_plan` (dict or import path) when constructing the parallelizer.\n"
                     "Alternatively, run with tp_size=1."
+                )
+            if tp_size > 1:
+                logger.warning(
+                    "No tensor-parallel plan is registered for '%s' and the model does not "
+                    "expose a HuggingFace `_tp_plan`. Falling back to the default base plan at "
+                    "tp_size=%d. If you hit an internal assert in "
+                    "`torch.distributed.tensor._redistribute` on `shard_order is not None`, "
+                    "register a plan via `PARALLELIZE_FUNCTIONS`, `_tp_plan`, or `tp_shard_plan`.",
+                    model_cls.__name__,
+                    tp_size,
                 )
             base_model_tp_plan = {
                 "model.embed_tokens": VocabParallelEmbedding(input_layouts=Replicate()),

--- a/nemo_automodel/components/distributed/parallelizer.py
+++ b/nemo_automodel/components/distributed/parallelizer.py
@@ -186,6 +186,7 @@ class DefaultParallelizationStrategy(ParallelizationStrategy):
                     model,
                     sequence_parallel,
                     tp_shard_plan,
+                    tp_size=tp_mesh.size(),
                 ).items()
             }
 
@@ -1400,6 +1401,7 @@ def _get_parallel_plan(
     model: nn.Module,
     sequence_parallel: bool = False,
     tp_shard_plan: Optional[Union[Dict[str, ParallelStyle], str]] = None,
+    tp_size: int = 1,
 ) -> Dict[str, ParallelStyle]:
     """
     Select the tensor-parallel plan for the given model.
@@ -1407,7 +1409,17 @@ def _get_parallel_plan(
     Priority order:
     1) If ``tp_shard_plan`` is provided as a dict or import path, use it.
     2) If the model type exists in ``PARALLELIZE_FUNCTIONS``, use its optimised plan; on failure, fall back to HF plan.
-    3) Otherwise, use the default base plan.
+    3) Otherwise, prefer the model's HF-native ``_tp_plan`` (via ``get_hf_tp_shard_plan``).
+    4) Otherwise, fall back to the default base plan.
+
+    When ``tp_size > 1`` and the model has no registered plan in
+    ``PARALLELIZE_FUNCTIONS`` and no HF-native ``_tp_plan`` (i.e. path 4 would
+    apply), this raises ``ValueError`` instead of returning the default base
+    plan. The default plan produces placements that do not populate the
+    ``shard_order`` metadata newer versions of PyTorch DTensor assert on, so
+    using it at ``tp_size > 1`` would crash inside
+    ``torch.distributed.tensor._redistribute`` with an opaque assertion. Path
+    4 is only safe at ``tp_size == 1``, where no actual sharding happens.
     """
     model_parallel_plan = None
     model_cls = type(model)
@@ -1478,6 +1490,20 @@ def _get_parallel_plan(
             model_parallel_plan = hf_plan
             logger.info(f"Using HF-native tp plan for {model_cls.__name__}.")
         else:
+            if tp_size > 1:
+                raise ValueError(
+                    f"No tensor-parallel plan is registered for '{model_cls.__name__}' and the "
+                    f"model does not expose a HuggingFace `_tp_plan`. The default base plan "
+                    f"cannot be used at tp_size={tp_size}: it produces DTensor placements "
+                    "without `shard_order` metadata, which trips an internal assert in "
+                    "`torch.distributed.tensor._redistribute` on the first weight redistribute. "
+                    "Register a working plan in one of the following ways:\n"
+                    f"  1. Add an entry for '{model_cls.__name__}' to "
+                    "`nemo_automodel.components.distributed.optimized_tp_plans.PARALLELIZE_FUNCTIONS`.\n"
+                    "  2. Define a `_tp_plan` on the model class (HF-native per-model TP plan).\n"
+                    "  3. Pass `tp_shard_plan` (dict or import path) when constructing the parallelizer.\n"
+                    "Alternatively, run with tp_size=1."
+                )
             base_model_tp_plan = {
                 "model.embed_tokens": VocabParallelEmbedding(input_layouts=Replicate()),
                 "model.layers.*.self_attn.q_proj": ColwiseParallel(),

--- a/tests/unit_tests/distributed/test_get_parallel_plan.py
+++ b/tests/unit_tests/distributed/test_get_parallel_plan.py
@@ -229,15 +229,53 @@ def test_not_registered_and_hf_fail_base_plan(monkeypatch):
     assert "model.norm" in result_sp
 
 
-def test_default_plan_fallthrough_raises_at_tp_size_gt_1(monkeypatch):
-    """tp_size > 1 with no registered plan and no HF `_tp_plan` should raise a clear ValueError.
+class _RemoteCodeDummyModel:
+    """Stand-in for an HF trust_remote_code model. HF places those classes
+    under the ``transformers_modules.*`` namespace at import time."""
+
+
+# Mimic HF's dynamic-module convention so the fail-fast guard triggers.
+_RemoteCodeDummyModel.__module__ = "transformers_modules.fake_repo.modeling_fake"
+
+
+def test_default_plan_fallthrough_raises_for_remote_code_at_tp_size_gt_1(monkeypatch):
+    """tp_size > 1 + custom-code arch with no registered plan should raise a clear ValueError.
 
     The default base plan produces DTensor placements without ``shard_order`` metadata,
     which trips an internal assert in ``torch.distributed.tensor._redistribute`` on the
-    first weight redistribute. We refuse early so unknown HF custom-code architectures
-    (loaded with ``trust_remote_code=True``) get an actionable error instead of an
-    opaque PyTorch assertion. See https://github.com/NVIDIA-NeMo/Automodel/issues/2243.
+    first weight redistribute. We refuse early *only* for HF custom-code architectures
+    (loaded with ``trust_remote_code=True``, i.e. living under
+    ``transformers_modules.*``), so users get an actionable error instead of an opaque
+    PyTorch assertion. See https://github.com/NVIDIA-NeMo/Automodel/issues/2243.
     """
+    parallelizer.PARALLELIZE_FUNCTIONS.pop(_get_class_qualname(_RemoteCodeDummyModel), None)
+
+    def _raise_hf(_model):
+        raise RuntimeError("hf fail")
+
+    monkeypatch.setattr(parallelizer, "get_hf_tp_shard_plan", _raise_hf, raising=True)
+    _set_global_model_cls(monkeypatch, _RemoteCodeDummyModel)
+
+    for sp in (False, True):
+        with pytest.raises(ValueError) as excinfo:
+            _get_parallel_plan(_RemoteCodeDummyModel(), sequence_parallel=sp, tp_size=2)
+
+        msg = str(excinfo.value)
+        # The error must name the offending class and the three supported registration paths.
+        assert _RemoteCodeDummyModel.__name__ in msg
+        assert "PARALLELIZE_FUNCTIONS" in msg
+        assert "_tp_plan" in msg
+        assert "tp_shard_plan" in msg
+
+
+def test_default_plan_fallthrough_known_hf_arch_warns_at_tp_size_gt_1(monkeypatch, caplog):
+    """Known HF archs (not ``transformers_modules.*``) keep working at tp_size > 1.
+
+    They have been working in practice on the default base plan, so the guard only
+    logs a warning and still returns the base plan rather than raising.
+    """
+    import logging as _logging
+
     parallelizer.PARALLELIZE_FUNCTIONS.pop(_get_class_qualname(_DummyModel), None)
 
     def _raise_hf(_model):
@@ -246,16 +284,11 @@ def test_default_plan_fallthrough_raises_at_tp_size_gt_1(monkeypatch):
     monkeypatch.setattr(parallelizer, "get_hf_tp_shard_plan", _raise_hf, raising=True)
     _set_global_model_cls(monkeypatch, _DummyModel)
 
-    for sp in (False, True):
-        with pytest.raises(ValueError) as excinfo:
-            _get_parallel_plan(_DummyModel(), sequence_parallel=sp, tp_size=2)
+    with caplog.at_level(_logging.WARNING, logger=parallelizer.logger.name):
+        result = _get_parallel_plan(_DummyModel(), sequence_parallel=False, tp_size=2)
 
-        msg = str(excinfo.value)
-        # The error must name the offending class and the three supported registration paths.
-        assert _DummyModel.__name__ in msg
-        assert "PARALLELIZE_FUNCTIONS" in msg
-        assert "_tp_plan" in msg
-        assert "tp_shard_plan" in msg
+    assert "model.embed_tokens" in result and "lm_head" in result
+    assert any("No tensor-parallel plan is registered" in r.message for r in caplog.records)
 
 
 def test_default_plan_fallthrough_tp_size_1_still_returns_base_plan(monkeypatch):
@@ -263,34 +296,34 @@ def test_default_plan_fallthrough_tp_size_1_still_returns_base_plan(monkeypatch)
 
     At tp_size == 1 no sharding actually happens, so the missing ``shard_order``
     metadata never matters. This preserves backwards compatibility for callers that
-    do not pass ``tp_size`` (default is 1).
+    do not pass ``tp_size`` (default is 1), including for custom-code archs.
     """
-    parallelizer.PARALLELIZE_FUNCTIONS.pop(_get_class_qualname(_DummyModel), None)
+    parallelizer.PARALLELIZE_FUNCTIONS.pop(_get_class_qualname(_RemoteCodeDummyModel), None)
 
     def _raise_hf(_model):
         raise RuntimeError("hf fail")
 
     monkeypatch.setattr(parallelizer, "get_hf_tp_shard_plan", _raise_hf, raising=True)
-    _set_global_model_cls(monkeypatch, _DummyModel)
+    _set_global_model_cls(monkeypatch, _RemoteCodeDummyModel)
 
-    # Explicit tp_size=1 — should still return the base plan.
-    result = _get_parallel_plan(_DummyModel(), sequence_parallel=False, tp_size=1)
+    # Explicit tp_size=1 — should still return the base plan, even for remote-code archs.
+    result = _get_parallel_plan(_RemoteCodeDummyModel(), sequence_parallel=False, tp_size=1)
     assert "model.embed_tokens" in result and "lm_head" in result
 
 
 def test_hf_native_plan_unaffected_at_tp_size_gt_1(monkeypatch):
     """Models that expose an HF-native ``_tp_plan`` must not trip the new guard.
 
-    The fail-fast check only fires when path 4 (default base plan) would be taken.
-    If ``get_hf_tp_shard_plan`` returns a non-empty plan, that plan must be used
-    regardless of ``tp_size``.
+    The fail-fast check only fires when path 4 (default base plan) would be taken
+    *and* the model is a custom-code arch. If ``get_hf_tp_shard_plan`` returns a
+    non-empty plan, that plan must be used regardless of ``tp_size``.
     """
     hf_plan = {"model.embed_tokens": "embed", "lm_head": "head"}
-    parallelizer.PARALLELIZE_FUNCTIONS.pop(_get_class_qualname(_DummyModel), None)
+    parallelizer.PARALLELIZE_FUNCTIONS.pop(_get_class_qualname(_RemoteCodeDummyModel), None)
     monkeypatch.setattr(parallelizer, "get_hf_tp_shard_plan", lambda _m: hf_plan, raising=True)
-    _set_global_model_cls(monkeypatch, _DummyModel)
+    _set_global_model_cls(monkeypatch, _RemoteCodeDummyModel)
 
-    result = _get_parallel_plan(_DummyModel(), sequence_parallel=False, tp_size=4)
+    result = _get_parallel_plan(_RemoteCodeDummyModel(), sequence_parallel=False, tp_size=4)
     assert result is hf_plan
 
 

--- a/tests/unit_tests/distributed/test_get_parallel_plan.py
+++ b/tests/unit_tests/distributed/test_get_parallel_plan.py
@@ -229,6 +229,71 @@ def test_not_registered_and_hf_fail_base_plan(monkeypatch):
     assert "model.norm" in result_sp
 
 
+def test_default_plan_fallthrough_raises_at_tp_size_gt_1(monkeypatch):
+    """tp_size > 1 with no registered plan and no HF `_tp_plan` should raise a clear ValueError.
+
+    The default base plan produces DTensor placements without ``shard_order`` metadata,
+    which trips an internal assert in ``torch.distributed.tensor._redistribute`` on the
+    first weight redistribute. We refuse early so unknown HF custom-code architectures
+    (loaded with ``trust_remote_code=True``) get an actionable error instead of an
+    opaque PyTorch assertion. See https://github.com/NVIDIA-NeMo/Automodel/issues/2243.
+    """
+    parallelizer.PARALLELIZE_FUNCTIONS.pop(_get_class_qualname(_DummyModel), None)
+
+    def _raise_hf(_model):
+        raise RuntimeError("hf fail")
+
+    monkeypatch.setattr(parallelizer, "get_hf_tp_shard_plan", _raise_hf, raising=True)
+    _set_global_model_cls(monkeypatch, _DummyModel)
+
+    for sp in (False, True):
+        with pytest.raises(ValueError) as excinfo:
+            _get_parallel_plan(_DummyModel(), sequence_parallel=sp, tp_size=2)
+
+        msg = str(excinfo.value)
+        # The error must name the offending class and the three supported registration paths.
+        assert _DummyModel.__name__ in msg
+        assert "PARALLELIZE_FUNCTIONS" in msg
+        assert "_tp_plan" in msg
+        assert "tp_shard_plan" in msg
+
+
+def test_default_plan_fallthrough_tp_size_1_still_returns_base_plan(monkeypatch):
+    """tp_size == 1 keeps the existing behavior: the default base plan is returned.
+
+    At tp_size == 1 no sharding actually happens, so the missing ``shard_order``
+    metadata never matters. This preserves backwards compatibility for callers that
+    do not pass ``tp_size`` (default is 1).
+    """
+    parallelizer.PARALLELIZE_FUNCTIONS.pop(_get_class_qualname(_DummyModel), None)
+
+    def _raise_hf(_model):
+        raise RuntimeError("hf fail")
+
+    monkeypatch.setattr(parallelizer, "get_hf_tp_shard_plan", _raise_hf, raising=True)
+    _set_global_model_cls(monkeypatch, _DummyModel)
+
+    # Explicit tp_size=1 — should still return the base plan.
+    result = _get_parallel_plan(_DummyModel(), sequence_parallel=False, tp_size=1)
+    assert "model.embed_tokens" in result and "lm_head" in result
+
+
+def test_hf_native_plan_unaffected_at_tp_size_gt_1(monkeypatch):
+    """Models that expose an HF-native ``_tp_plan`` must not trip the new guard.
+
+    The fail-fast check only fires when path 4 (default base plan) would be taken.
+    If ``get_hf_tp_shard_plan`` returns a non-empty plan, that plan must be used
+    regardless of ``tp_size``.
+    """
+    hf_plan = {"model.embed_tokens": "embed", "lm_head": "head"}
+    parallelizer.PARALLELIZE_FUNCTIONS.pop(_get_class_qualname(_DummyModel), None)
+    monkeypatch.setattr(parallelizer, "get_hf_tp_shard_plan", lambda _m: hf_plan, raising=True)
+    _set_global_model_cls(monkeypatch, _DummyModel)
+
+    result = _get_parallel_plan(_DummyModel(), sequence_parallel=False, tp_size=4)
+    assert result is hf_plan
+
+
 def test_custom_plan_imports_non_dict_raises(monkeypatch):
     """If import resolves but returns non-dict object, raise ValueError."""
 

--- a/tests/unit_tests/distributed/test_get_parallel_plan.py
+++ b/tests/unit_tests/distributed/test_get_parallel_plan.py
@@ -288,7 +288,37 @@ def test_default_plan_fallthrough_known_hf_arch_warns_at_tp_size_gt_1(monkeypatc
         result = _get_parallel_plan(_DummyModel(), sequence_parallel=False, tp_size=2)
 
     assert "model.embed_tokens" in result and "lm_head" in result
-    assert any("No tensor-parallel plan is registered" in r.message for r in caplog.records)
+    assert any("No usable tensor-parallel plan is registered" in r.message for r in caplog.records)
+
+
+def test_default_plan_fallthrough_remote_code_folds_translator_diagnostic(monkeypatch):
+    """Remote-code archs whose ``_tp_plan`` failed to translate get a diagnostic in the error.
+
+    Covers the case where the model author exposed a ``_tp_plan`` but
+    ``get_hf_tp_shard_plan`` raised while translating it (e.g. because the styles are
+    not recognized by nemo). The raised ``ValueError`` should fold the translator's
+    error message in so the user can distinguish "no `_tp_plan` at all" from
+    "`_tp_plan` defined but unusable". See
+    https://github.com/NVIDIA-NeMo/Automodel/pull/2244 discussion.
+    """
+    parallelizer.PARALLELIZE_FUNCTIONS.pop(_get_class_qualname(_RemoteCodeDummyModel), None)
+
+    def _raise_translator(_model):
+        raise ValueError("Unknown parallel style: foo_bar")
+
+    monkeypatch.setattr(parallelizer, "get_hf_tp_shard_plan", _raise_translator, raising=True)
+    _set_global_model_cls(monkeypatch, _RemoteCodeDummyModel)
+
+    with pytest.raises(ValueError) as excinfo:
+        _get_parallel_plan(_RemoteCodeDummyModel(), sequence_parallel=False, tp_size=2)
+
+    msg = str(excinfo.value)
+    # Diagnostic from get_hf_tp_shard_plan must be folded into the user-facing error.
+    assert "Unknown parallel style: foo_bar" in msg
+    # And the registration guidance must still be there.
+    assert "PARALLELIZE_FUNCTIONS" in msg
+    assert "_tp_plan" in msg
+    assert "tp_shard_plan" in msg
 
 
 def test_default_plan_fallthrough_tp_size_1_still_returns_base_plan(monkeypatch):


### PR DESCRIPTION
# What does this PR do?

Closes #2243.

When `_get_parallel_plan` falls through to the default base plan (path 4) at `tp_size > 1`, raise a clear `ValueError` instead of returning a plan that will later crash inside PyTorch's DTensor `_redistribute` with an opaque `AssertionError` on `shard_order is not None`.

This was hit in practice when running tensor parallelism over an HF custom-code architecture (a model with `auto_map.AutoModelForCausalLM` loaded via `trust_remote_code=True`) that is neither registered in `PARALLELIZE_FUNCTIONS` nor exposes a `_tp_plan` on the model class. The base plan produces `Colwise/RowwiseParallel` placements that do not populate `shard_order`, so newer PyTorch versions assert on the first weight redistribute (weight load or refit). The error surface up to here is the internal PyTorch assert, which is hard to debug without reading `parallelizer.py`.

The new `ValueError` names the offending class and points at the three supported registration paths:

1. Add a plan function to `nemo_automodel.components.distributed.optimized_tp_plans.PARALLELIZE_FUNCTIONS`.
2. Define `_tp_plan` on the model class (HF-native per-model TP plan).
3. Pass `tp_shard_plan` (dict or import path) when constructing the parallelizer.

At `tp_size == 1` no real sharding happens, so the default plan is still returned and existing single-GPU / DP-only callers are unaffected.

# Changelog

- `nemo_automodel/components/distributed/parallelizer.py`
  - `_get_parallel_plan`: new `tp_size: int = 1` parameter; raise `ValueError` with an actionable message when path 4 would apply at `tp_size > 1`; updated docstring to reflect that HF-native `_tp_plan` is preferred over the default base plan.
  - `DefaultParallelizationStrategy.parallelize`: thread `tp_size=tp_mesh.size()` through to `_get_parallel_plan`.
- `nemo_automodel/components/distributed/megatron_fsdp.py`
  - `MegatronFSDPManager.parallelize`: pass `tp_size=self.device_mesh["tp"].size()` to `_get_parallel_plan` so the MegatronFSDP path gets the same fail-fast behavior.
- `tests/unit_tests/distributed/test_get_parallel_plan.py`
  - `test_default_plan_fallthrough_raises_at_tp_size_gt_1` — verifies the new `ValueError` (with and without sequence parallel) and asserts that the message names the class and all three registration paths.
  - `test_default_plan_fallthrough_tp_size_1_still_returns_base_plan` — pins the backwards-compatible behavior at `tp_size == 1`.
  - `test_hf_native_plan_unaffected_at_tp_size_gt_1` — verifies models that expose `_tp_plan` are not affected by the new guard.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation? (docstring of `_get_parallel_plan` updated)

Verification:

- `pytest tests/unit_tests/distributed/test_get_parallel_plan.py` — 24/24 pass (3 new + 21 existing).
- `pytest tests/unit_tests/distributed/test_parallelization_strategies.py` — 32/32 pass.
- `pytest tests/unit_tests/models/qwen3_5/test_cp_linear_attn_patch.py` — 36/36 pass.
- `ruff format` / `ruff check` clean on changed files.

# Additional Information

- Picked option 2 from the issue ("refuse `tp_size > 1` for archs that hit path 4 with a clear error message") per @HuiyingLi's response on #2243. Option 1 (make the default base plan carry `shard_order`) is a strictly better fix but, as called out in the issue, needs more local knowledge of how per-arch plans populate the field — happy to follow up in a separate PR.
- Workaround that no longer crashes silently: users who hit the new error can either (a) register the arch via one of the three paths the message lists, or (b) drop to `tp_size=1` as before.