### PR TITLE
fix(checkpoint): exclude TE _extra_state keys from load-time mismatch warning

### DIFF
--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -554,7 +554,9 @@ class Checkpointer:
             state_dict[lm_head_param_name] = state_dict.pop(compat_tied_lm_head_source_key)
 
         state_dict = _maybe_adapt_state_dict_from_hf(model_state.model[0], state_dict, moe_mesh=self.moe_mesh)
-        key_diff = _summarize_state_dict_key_diff(expected_keys, set(state_dict.keys()))
+        expected_keys_for_diff = {k for k in expected_keys if not k.endswith("_extra_state")}
+        loaded_keys_for_diff = {k for k in state_dict if not k.endswith("_extra_state")}
+        key_diff = _summarize_state_dict_key_diff(expected_keys_for_diff, loaded_keys_for_diff)
         if key_diff["missing_count"] or key_diff["unexpected_count"]:
             logging.warning(
                 "Checkpoint key mismatch for %s: missing=%d unexpected=%d "


### PR DESCRIPTION
## What

When loading an HF safetensors checkpoint into a model that contains
TransformerEngine modules, the checkpoint loader emits a noisy
`Checkpoint key mismatch` warning. The "missing" keys are all
`_extra_state` entries that TE attaches to its own modules for internal
bookkeeping (FP8 amax history, etc.) and that are not part of the HF
safetensors checkpoint. The framework already neutralizes these via the
`set_extra_state` shim in `components/checkpoint/stateful_wrappers.py`,
so reporting them as missing weights is misleading.

This PR filters `*_extra_state` keys out of both sides of the
mismatch summary so the warning only fires when real weights are
actually missing or unexpected.

## Observed warning (8-rank FSDP2 + EP load of NVIDIA-Nemotron-3-Nano-30B-A3B-BF16)

```
WARNING:root:Checkpoint key mismatch for FSDPNemotronHForCausalLM: missing=77 unexpected=0 (missing examples=['lm_head._extra_state', 'model.layers.1.mixer.shared_experts.down_proj._extra_state', 'model.layers.1.mixer.shared_experts.up_proj._extra_state', 'model.layers.10.mixer.shared_experts.down_proj._extra_state', 'model.layers.10.mixer.shared_experts.up_proj._extra_state', 'model.layers.12.mixer.attn_module._extra_state', 'model.layers.12.mixer.k_proj._extra_state', 'model.layers.12.mixer.o_proj._extra_state', 'model.layers.12.mixer.q_proj._extra_state', 'model.layers.12.mixer.v_proj._extra_state'], unexpected examples=[])
```

All 77 missing keys end in `._extra_state`.

## Changelog

- Exclude `*_extra_state` keys from the load-time
  `Checkpoint key mismatch` warning so it focuses on real weight
  mismatches.

## Pre-checks

- [x] Linting: no formatting/style changes required
- [x] DCO sign-off