### PR TITLE
feat(eagle3): add FlashAttention-2 backend for draft attention

### DIFF
--- a/examples/speculative/eagle3/llama_eagle3_mvp_flash_attn.yaml
+++ b/examples/speculative/eagle3/llama_eagle3_mvp_flash_attn.yaml
@@ -1,0 +1,56 @@
+recipe: TrainEagle3Recipe
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 30
+
+recipe_args:
+  target_model_name_or_path: meta-llama/Llama-3.2-1B
+  # ``train_data_path`` accepts either a HF dataset id or a local
+  # ``.jsonl`` / directory of ``.jsonl`` files. Each row must follow the
+  # OpenAI chat schema -- the ``ChatDataset`` ingestion path keys on a
+  # ``messages`` list of ``{role, content}`` entries:
+  #
+  #   {"messages": [
+  #     {"role": "system",    "content": "You are a helpful assistant."},
+  #     {"role": "user",      "content": "What is the capital of France?"},
+  #     {"role": "assistant", "content": "Paris."}
+  #   ]}
+  #
+  # If a dataset ships the conversations under a different key (e.g.
+  # PerfectBlend uses ``conversations``), rename the column locally
+  # before pointing the recipe at it. See the inline one-liner in
+  # ``llama_eagle3_perfectblend.yaml``.
+  train_data_path: /path/to/train.jsonl
+  val_data_path: null
+  train_split: null
+  val_split: null
+  output_dir: ./outputs/eagle3_llama_mvp_flash_attn
+  seq_length: 1024
+  micro_batch_size: 1
+  grad_accumulation_steps: 1
+  num_workers: 0
+  num_epochs: 1
+  ttt_steps: 4
+  draft_vocab_size: 8192
+  freeze_embeddings: true
+  trust_remote_code: false
+  shuffle_seed: 42
+  log_every_steps: 10
+  max_grad_norm: 1.0
+  # ----------------------------------------------------------------------
+  # Draft attention backend. ``flash_attention_2`` routes the EAGLE-3 T x T
+  # causal block through ``flash_attn_func`` and merges the diagonal-extension
+  # columns (steps ``i >= 1``) into the same softmax via the FA-returned
+  # ``softmax_lse``. Requires the ``flash-attn`` package and a CUDA GPU.
+  # Fall back to ``eager`` if either is unavailable; the math is unchanged.
+  # ----------------------------------------------------------------------
+  draft_attn_implementation: flash_attention_2
+
+optimizer:
+  # TTT loss is a weighted mean (``Σ 0.8^i * L_i / Σ 0.8^i``), so LR is
+  # invariant to ``ttt_steps`` and to the decay constant in
+  # ``components/speculative/eagle/core.py``.
+  lr: 1.0e-4
+  betas: [0.9, 0.95]
+  weight_decay: 0.0

--- a/nemo_automodel/components/speculative/eagle/draft_llama.py
+++ b/nemo_automodel/components/speculative/eagle/draft_llama.py
@@ -36,6 +36,7 @@ at load time, so the un-fused storage above is the canonical on-disk format.
 
 from __future__ import annotations
 
+import logging
 from typing import Optional
 
 import torch
@@ -49,7 +50,28 @@ from nemo_automodel.components.models.llama.rope_utils import (
 )
 from nemo_automodel.shared.import_utils import safe_import_from
 
-_HAS_FA, _flash_attn_func = safe_import_from("flash_attn", "flash_attn_func")
+logger = logging.getLogger(__name__)
+
+
+def _load_flash_attn_func() -> tuple[bool, object | None]:
+    """Best-effort load of flash-attn without breaking eager-only users.
+
+    ``safe_import_from`` already handles missing modules and missing symbols, but
+    some broken ``flash-attn`` installs fail with lower-level loader errors
+    (e.g. ABI / shared-library issues) that should not prevent importing this
+    module for the eager path.
+    """
+    try:
+        has_fa, flash_attn_func = safe_import_from("flash_attn", "flash_attn_func")
+    except Exception as exc:  # pragma: no cover - depends on local flash-attn loader failures.
+        logger.warning("Failed to import flash_attn.flash_attn_func; FlashAttention-2 path will be disabled: %s", exc)
+        return False, None
+    if not has_fa:
+        return False, None
+    return True, flash_attn_func
+
+
+_HAS_FA, _flash_attn_func = _load_flash_attn_func()
 
 _SUPPORTED_ATTN_IMPLEMENTATIONS = ("eager", "flash_attention_2")
 
@@ -66,6 +88,12 @@ def _build_causal_mask(
 
     expanded = (1.0 - attention_mask[:, None, None, :].to(dtype)) * torch.finfo(dtype).min
     return causal + expanded
+
+
+def _is_right_padded_attention_mask(attention_mask: torch.Tensor) -> bool:
+    """Return True when each row is a contiguous valid-prefix followed by padding."""
+    mask_bool = attention_mask.to(dtype=torch.bool)
+    return not bool((mask_bool[:, 1:] & ~mask_bool[:, :-1]).any())
 
 
 class Eagle3LlamaAttention(nn.Module):
@@ -465,6 +493,13 @@ class LlamaEagle3DraftModel(PreTrainedModel):
             position_ids = position_ids.expand(input_ids.shape[0], -1)
         if cache_hidden is None:
             cache_hidden = [[], []]
+        if self.model.layers[
+            0
+        ].self_attn.attn_implementation == "flash_attention_2" and not _is_right_padded_attention_mask(attention_mask):
+            raise ValueError(
+                "LlamaEagle3DraftModel: attn_implementation='flash_attention_2' requires a right-padded "
+                "attention_mask (each row must be contiguous 1s followed by 0s)."
+            )
 
         draft_input_embeds = self.embed_input_ids(input_ids)
         causal_mask = _build_causal_mask(attention_mask=attention_mask, dtype=projected_hidden_states.dtype)

--- a/nemo_automodel/components/speculative/eagle/draft_llama.py
+++ b/nemo_automodel/components/speculative/eagle/draft_llama.py
@@ -47,6 +47,11 @@ from nemo_automodel.components.models.llama.rope_utils import (
     LlamaRotaryEmbedding,
     apply_rotary_pos_emb,
 )
+from nemo_automodel.shared.import_utils import safe_import_from
+
+_HAS_FA, _flash_attn_func = safe_import_from("flash_attn", "flash_attn_func")
+
+_SUPPORTED_ATTN_IMPLEMENTATIONS = ("eager", "flash_attention_2")
 
 
 def _build_causal_mask(
@@ -107,6 +112,23 @@ class Eagle3LlamaAttention(nn.Module):
         self.num_key_value_groups = self.num_heads // self.num_key_value_heads
         self.scaling = self.head_dim**-0.5
 
+        # Read only the explicit ``attn_implementation`` field; HF's private
+        # ``_attn_implementation`` is owned by ``PreTrainedModel`` and may be
+        # auto-set to "sdpa"/"flash_attention_2" by HF before this module
+        # supports those backends.
+        attn_impl = getattr(config, "attn_implementation", None) or "eager"
+        if attn_impl not in _SUPPORTED_ATTN_IMPLEMENTATIONS:
+            raise ValueError(
+                f"Eagle3LlamaAttention: unsupported attn_implementation={attn_impl!r}; "
+                f"expected one of {_SUPPORTED_ATTN_IMPLEMENTATIONS}"
+            )
+        if attn_impl == "flash_attention_2" and not _HAS_FA:
+            raise ImportError(
+                "Eagle3LlamaAttention: attn_implementation='flash_attention_2' requires the "
+                "'flash-attn' package to be installed."
+            )
+        self.attn_implementation = attn_impl
+
         in_features = config.hidden_size * 2
         self.q_proj = nn.Linear(in_features, self.num_heads * self.head_dim, bias=config.attention_bias)
         self.k_proj = nn.Linear(in_features, self.num_key_value_heads * self.head_dim, bias=config.attention_bias)
@@ -161,6 +183,24 @@ class Eagle3LlamaAttention(nn.Module):
         cache_k.append(k)
         cache_v.append(v)
 
+        if self.attn_implementation == "flash_attention_2":
+            attn_output = self._flash_attention_forward(q, cache_k, cache_v, step_idx, batch_size, seq_len)
+        else:
+            attn_output = self._eager_attention_forward(
+                q, cache_k, cache_v, attention_mask, step_idx, batch_size, seq_len
+            )
+        return self.o_proj(attn_output)
+
+    def _eager_attention_forward(
+        self,
+        q: torch.Tensor,
+        cache_k: list[torch.Tensor],
+        cache_v: list[torch.Tensor],
+        attention_mask: torch.Tensor,
+        step_idx: int,
+        batch_size: int,
+        seq_len: int,
+    ) -> torch.Tensor:
         # Block 1: full T x T causal attention against the step-0 keys.
         k0, v0 = cache_k[0], cache_v[0]
         attn_weights = torch.matmul(q, k0.transpose(-2, -1)) * self.scaling
@@ -190,8 +230,75 @@ class Eagle3LlamaAttention(nn.Module):
             diag_probs = attn_probs[..., seq_len:]  # [B, H, T, step_idx]
             attn_output = attn_output + torch.einsum("bhts,sbhtd->bhtd", diag_probs, later_v)
 
-        attn_output = attn_output.transpose(1, 2).contiguous().view(batch_size, seq_len, -1)
-        return self.o_proj(attn_output)
+        return attn_output.transpose(1, 2).contiguous().view(batch_size, seq_len, -1)
+
+    def _flash_attention_forward(
+        self,
+        q: torch.Tensor,
+        cache_k: list[torch.Tensor],
+        cache_v: list[torch.Tensor],
+        step_idx: int,
+        batch_size: int,
+        seq_len: int,
+    ) -> torch.Tensor:
+        """EAGLE-3 attention via FlashAttention-2 for the T x T causal block.
+
+        FA2 covers Block 1 (full ``T x T`` causal attention against ``K_0``) and
+        returns the un-normalized log-sum-exp (``softmax_lse``) alongside the
+        per-token output. The diagonal extension columns (Block 2) for cached
+        steps ``i >= 1`` are computed in eager mode, then merged into a single
+        softmax via the log-space identity
+        ``lse_full = logaddexp(lse_fa, logsumexp(diag))``; the FA output is
+        rescaled by ``exp(lse_fa - lse_full)`` and the diagonal contribution
+        is added with weights ``exp(diag - lse_full)``.
+
+        Padding handling: FA2 is invoked with ``causal=True``. For right-padded
+        batches, padding keys always lie strictly above the diagonal relative
+        to any non-padded query position, so causal masking alone yields the
+        same output as the eager additive padding mask at every valid query
+        position. Outputs at padding query positions differ, but those are
+        masked out at loss time.
+        """
+        # FA2 expects (B, T, H, D); eager cache is (B, H, T, D).
+        k0, v0 = cache_k[0], cache_v[0]
+        q_fa = q.transpose(1, 2).contiguous()
+        k0_fa = k0.transpose(1, 2).contiguous()
+        v0_fa = v0.transpose(1, 2).contiguous()
+        # ``softmax_lse`` is fp32 with shape (B, H, T): the log-sum-exp of the
+        # SCALED Block-1 logits (the FA kernel folds in ``softmax_scale``).
+        out_fa, lse_fa, _ = _flash_attn_func(
+            q_fa,
+            k0_fa,
+            v0_fa,
+            softmax_scale=self.scaling,
+            causal=True,
+            return_attn_probs=True,
+        )
+        # FA output is (B, T, H, D); bring back to (B, H, T, D) for downstream merge.
+        attn_output_bhtd = out_fa.transpose(1, 2)
+
+        if step_idx >= 1:
+            # Diagonal logits share the same ``self.scaling`` factor as FA's
+            # internal softmax, so ``lse_fa`` and ``diag_logits`` are commensurate.
+            later_k = torch.stack(cache_k[1:], dim=0)  # [step_idx, B, H, T, D]
+            diag_logits = torch.einsum("bhtd,sbhtd->bhts", q, later_k) * self.scaling
+
+            # Combine softmax in log-space:
+            #   lse_full = log( exp(lse_fa) + sum_i exp(diag_i) )
+            #            = logaddexp(lse_fa, logsumexp(diag, dim=-1))
+            lse_fa_f32 = lse_fa.float()  # [B, H, T]
+            diag_f32 = diag_logits.float()  # [B, H, T, step_idx]
+            diag_lse = torch.logsumexp(diag_f32, dim=-1)  # [B, H, T]
+            lse_full = torch.logaddexp(lse_fa_f32, diag_lse)  # [B, H, T]
+
+            w1 = torch.exp(lse_fa_f32 - lse_full).to(q.dtype)  # [B, H, T]
+            w2 = torch.exp(diag_f32 - lse_full.unsqueeze(-1)).to(q.dtype)  # [B, H, T, step_idx]
+
+            attn_output_bhtd = attn_output_bhtd * w1.unsqueeze(-1)
+            later_v = torch.stack(cache_v[1:], dim=0)  # [step_idx, B, H, T, D]
+            attn_output_bhtd = attn_output_bhtd + torch.einsum("bhts,sbhtd->bhtd", w2, later_v)
+
+        return attn_output_bhtd.transpose(1, 2).contiguous().view(batch_size, seq_len, -1)
 
 
 class Eagle3LlamaMLP(nn.Module):

--- a/nemo_automodel/recipes/llm/train_eagle3.py
+++ b/nemo_automodel/recipes/llm/train_eagle3.py
@@ -137,6 +137,12 @@ class TrainEagle3Recipe(BaseRecipe):
         draft_config["draft_vocab_size"] = int(selected_token_ids.numel())
         draft_config["target_hidden_size"] = target_config.hidden_size
         draft_config["architectures"] = ["LlamaEagle3DraftModel"]
+        # Draft attention backend. Defaults to ``eager`` to preserve the
+        # pre-FA2 numerics. Set ``recipe_args.draft_attn_implementation:
+        # flash_attention_2`` in YAML to opt into FlashAttention for the
+        # T x T causal block (Eagle3LlamaAttention merges FA's softmax_lse
+        # with the diagonal-extension columns in log space).
+        draft_config["attn_implementation"] = recipe_cfg.get("draft_attn_implementation", "eager")
         # Cast to the target's compute dtype so every linear / embedding / norm
         # in the draft matches the bf16 (cuda) or fp32 (cpu) hidden states fed
         # in from the target. Without this, ``initialize_rms_norm_module`` defaults

--- a/tests/functional_tests/llm_pretrain_and_kd/L2_Eagle3_FlashAttention.sh
+++ b/tests/functional_tests/llm_pretrain_and_kd/L2_Eagle3_FlashAttention.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -xeuo pipefail
+
+export PYTHONPATH=${PYTHONPATH:-}:$(pwd)
+export CUDA_VISIBLE_DEVICES="0"
+
+PYTEST_S_FLAG=""
+if [ "${PYTEST_PROPAGATE_S:-}" = "1" ]; then
+    PYTEST_S_FLAG="-s"
+fi
+
+python -m torch.distributed.run --nproc_per_node=1 --nnodes=1 -m coverage run \
+    -m pytest $PYTEST_S_FLAG tests/functional_tests/training/test_eagle3_flash_attention.py -vs

--- a/tests/functional_tests/llm_pretrain_and_kd/test_eagle3_flash_attention.py
+++ b/tests/functional_tests/llm_pretrain_and_kd/test_eagle3_flash_attention.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from tests.utils.test_utils import run_test_script
+
+TEST_FOLDER = "llm_pretrain_and_kd"
+EAGLE3_FLASH_ATTENTION_FILENAME = "L2_Eagle3_FlashAttention.sh"
+
+
+class TestEagle3FlashAttention:
+    def test_eagle3_flash_attention(self):
+        run_test_script(TEST_FOLDER, EAGLE3_FLASH_ATTENTION_FILENAME)

--- a/tests/functional_tests/training/test_eagle3_flash_attention.py
+++ b/tests/functional_tests/training/test_eagle3_flash_attention.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Functional CUDA coverage for EAGLE-3 FlashAttention-2 draft attention."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from transformers import LlamaConfig
+
+from nemo_automodel.components.speculative.eagle.draft_llama import _HAS_FA, LlamaEagle3DraftModel
+
+_SKIP_REASON = "EAGLE-3 FlashAttention-2 functional test requires CUDA and flash-attn"
+
+
+def _build_eagle3_config(attn_implementation: str) -> LlamaConfig:
+    config = LlamaConfig(
+        hidden_size=256,
+        intermediate_size=512,
+        num_hidden_layers=1,
+        num_attention_heads=8,
+        num_key_value_heads=4,
+        vocab_size=1024,
+        max_position_embeddings=128,
+    )
+    config.torch_dtype = torch.bfloat16
+    config.draft_vocab_size = 128
+    config.target_hidden_size = 256
+    config.attn_implementation = attn_implementation
+    return config
+
+
+@pytest.mark.skipif(not torch.cuda.is_available() or not _HAS_FA, reason=_SKIP_REASON)
+def test_eagle3_flash_attention_matches_eager_with_right_padding():
+    """FA2 and eager should match on valid tokens for right-padded CUDA batches."""
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+
+    eager_draft = LlamaEagle3DraftModel(_build_eagle3_config("eager")).to(device=device, dtype=dtype)
+    fa_draft = LlamaEagle3DraftModel(_build_eagle3_config("flash_attention_2")).to(device=device, dtype=dtype)
+    fa_draft.load_state_dict(eager_draft.state_dict())
+
+    batch_size, seq_len = 2, 64
+    input_ids = torch.randint(0, eager_draft.config.vocab_size, (batch_size, seq_len), device=device)
+    attention_mask = torch.tensor(
+        [
+            [1] * 48 + [0] * 16,
+            [1] * 32 + [0] * 32,
+        ],
+        dtype=torch.long,
+        device=device,
+    )
+    aux_hidden_states = torch.randn(batch_size, seq_len, eager_draft.config.hidden_size * 3, device=device, dtype=dtype)
+
+    projected_eager = eager_draft.project_hidden_states(aux_hidden_states)
+    projected_fa = fa_draft.project_hidden_states(aux_hidden_states)
+    cache_eager: list[list[torch.Tensor]] = [[], []]
+    cache_fa: list[list[torch.Tensor]] = [[], []]
+
+    with torch.no_grad():
+        h_eager = projected_eager
+        h_fa = projected_fa
+        for _ in range(3):
+            h_eager = eager_draft(
+                input_ids=input_ids,
+                projected_hidden_states=h_eager,
+                attention_mask=attention_mask,
+                cache_hidden=cache_eager,
+            )
+            h_fa = fa_draft(
+                input_ids=input_ids,
+                projected_hidden_states=h_fa,
+                attention_mask=attention_mask,
+                cache_hidden=cache_fa,
+            )
+
+    valid = attention_mask.bool().unsqueeze(-1).expand_as(h_eager)
+    torch.testing.assert_close(h_eager[valid], h_fa[valid], atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available() or not _HAS_FA, reason=_SKIP_REASON)
+def test_eagle3_flash_attention_rejects_left_padding_on_cuda():
+    """FA2 path should fail loudly when the batch is not right-padded."""
+    torch.manual_seed(1)
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+
+    draft = LlamaEagle3DraftModel(_build_eagle3_config("flash_attention_2")).to(device=device, dtype=dtype)
+    batch_size, seq_len = 2, 32
+    input_ids = torch.randint(0, draft.config.vocab_size, (batch_size, seq_len), device=device)
+    attention_mask = torch.tensor(
+        [
+            [0] * 8 + [1] * 24,
+            [0] * 4 + [1] * 28,
+        ],
+        dtype=torch.long,
+        device=device,
+    )
+    aux_hidden_states = torch.randn(batch_size, seq_len, draft.config.hidden_size * 3, device=device, dtype=dtype)
+
+    with pytest.raises(ValueError, match="right-padded attention_mask"):
+        draft(
+            input_ids=input_ids,
+            projected_hidden_states=draft.project_hidden_states(aux_hidden_states),
+            attention_mask=attention_mask,
+        )

--- a/tests/unit_tests/speculative/test_eagle3.py
+++ b/tests/unit_tests/speculative/test_eagle3.py
@@ -19,7 +19,7 @@ from transformers import LlamaConfig
 from nemo_automodel.components.datasets.llm.eagle3 import build_eagle3_token_mapping
 from nemo_automodel.components.loss.soft_ce import masked_soft_cross_entropy
 from nemo_automodel.components.speculative.eagle.core import Eagle3TrainerModule, _compute_target_distribution
-from nemo_automodel.components.speculative.eagle.draft_llama import LlamaEagle3DraftModel, _HAS_FA
+from nemo_automodel.components.speculative.eagle.draft_llama import _HAS_FA, LlamaEagle3DraftModel
 from nemo_automodel.components.speculative.eagle.target import _shift_left_with_zero
 
 
@@ -649,9 +649,7 @@ def test_eagle3_flash_attention_matches_eager():
     batch_size, seq_len = 2, 32
     input_ids = torch.randint(0, eager_config.vocab_size, (batch_size, seq_len), device=device)
     attention_mask = torch.ones(batch_size, seq_len, dtype=torch.long, device=device)
-    aux_hidden_states = torch.randn(
-        batch_size, seq_len, eager_config.hidden_size * 3, device=device, dtype=dtype
-    )
+    aux_hidden_states = torch.randn(batch_size, seq_len, eager_config.hidden_size * 3, device=device, dtype=dtype)
     projected_eager = eager_draft.project_hidden_states(aux_hidden_states)
     projected_fa = fa_draft.project_hidden_states(aux_hidden_states)
 
@@ -706,9 +704,7 @@ def test_eagle3_flash_attention_step0_matches_eager():
     batch_size, seq_len = 2, 32
     input_ids = torch.randint(0, eager_config.vocab_size, (batch_size, seq_len), device=device)
     attention_mask = torch.ones(batch_size, seq_len, dtype=torch.long, device=device)
-    aux_hidden_states = torch.randn(
-        batch_size, seq_len, eager_config.hidden_size * 3, device=device, dtype=dtype
-    )
+    aux_hidden_states = torch.randn(batch_size, seq_len, eager_config.hidden_size * 3, device=device, dtype=dtype)
 
     with torch.no_grad():
         out_eager = eager_draft(
@@ -738,3 +734,53 @@ def test_eagle3_unknown_attn_implementation_raises():
     config = _build_eagle3_config("xformers")  # unsupported
     with pytest.raises(ValueError, match="attn_implementation"):
         LlamaEagle3DraftModel(config)
+
+
+def test_eagle3_flash_attention_2_rejects_left_padded_attention_mask():
+    config = _build_eagle3_config("flash_attention_2" if _HAS_FA else "eager")
+    draft = LlamaEagle3DraftModel(config)
+    if not _HAS_FA:
+        draft.model.layers[0].self_attn.attn_implementation = "flash_attention_2"
+
+    batch_size, seq_len = 2, 8
+    input_ids = torch.randint(0, config.vocab_size, (batch_size, seq_len))
+    attention_mask = torch.tensor(
+        [
+            [0, 0, 1, 1, 1, 1, 1, 1],
+            [0, 1, 1, 1, 1, 1, 1, 1],
+        ],
+        dtype=torch.long,
+    )
+    aux_hidden_states = torch.randn(batch_size, seq_len, config.hidden_size * 3)
+
+    with pytest.raises(ValueError, match="right-padded attention_mask"):
+        draft(
+            input_ids=input_ids,
+            projected_hidden_states=draft.project_hidden_states(aux_hidden_states),
+            attention_mask=attention_mask,
+        )
+
+
+def test_eagle3_flash_attention_2_rejects_non_monotonic_attention_mask():
+    config = _build_eagle3_config("flash_attention_2" if _HAS_FA else "eager")
+    draft = LlamaEagle3DraftModel(config)
+    if not _HAS_FA:
+        draft.model.layers[0].self_attn.attn_implementation = "flash_attention_2"
+
+    batch_size, seq_len = 2, 8
+    input_ids = torch.randint(0, config.vocab_size, (batch_size, seq_len))
+    attention_mask = torch.tensor(
+        [
+            [1, 1, 0, 1, 1, 0, 0, 0],
+            [1, 0, 1, 1, 0, 0, 0, 0],
+        ],
+        dtype=torch.long,
+    )
+    aux_hidden_states = torch.randn(batch_size, seq_len, config.hidden_size * 3)
+
+    with pytest.raises(ValueError, match="right-padded attention_mask"):
+        draft(
+            input_ids=input_ids,
+            projected_hidden_states=draft.project_hidden_states(aux_hidden_states),
+            attention_mask=attention_mask,
+        )

--- a/tests/unit_tests/speculative/test_eagle3.py
+++ b/tests/unit_tests/speculative/test_eagle3.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import torch
 from transformers import LlamaConfig
 
 from nemo_automodel.components.datasets.llm.eagle3 import build_eagle3_token_mapping
 from nemo_automodel.components.loss.soft_ce import masked_soft_cross_entropy
 from nemo_automodel.components.speculative.eagle.core import Eagle3TrainerModule, _compute_target_distribution
-from nemo_automodel.components.speculative.eagle.draft_llama import LlamaEagle3DraftModel
+from nemo_automodel.components.speculative.eagle.draft_llama import LlamaEagle3DraftModel, _HAS_FA
 from nemo_automodel.components.speculative.eagle.target import _shift_left_with_zero
 
 
@@ -601,3 +602,139 @@ def test_target_shift_matches_reference_padding_behavior():
     shifted_mask = _shift_left_with_zero(mask)
     expected_mask = torch.tensor([[0, 1, 0]], dtype=torch.long)
     torch.testing.assert_close(shifted_mask, expected_mask)
+
+
+def _build_eagle3_config(attn_implementation: str) -> LlamaConfig:
+    """Realistically-sized layer config for FA2 equivalence checks."""
+    config = LlamaConfig(
+        hidden_size=256,
+        intermediate_size=512,
+        num_hidden_layers=1,
+        num_attention_heads=8,
+        num_key_value_heads=4,
+        vocab_size=1024,
+        max_position_embeddings=128,
+    )
+    config.torch_dtype = torch.bfloat16
+    config.draft_vocab_size = 128
+    config.target_hidden_size = 256
+    config.attn_implementation = attn_implementation
+    return config
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or not _HAS_FA,
+    reason="FA2 path requires a CUDA device and the 'flash-attn' package",
+)
+def test_eagle3_flash_attention_matches_eager():
+    """Multi-step TTT forward must match between eager and flash_attention_2 backends.
+
+    Builds two draft models with identical weights but different attention
+    backends, runs three chained TTT steps (exercising Block 1 + diagonal
+    extensions), and checks that the post-MLP hidden state agrees within
+    bf16 tolerances. Any regression in the log-space softmax merge between
+    FA's ``softmax_lse`` and the eager diagonal logits would surface here.
+    """
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+
+    eager_config = _build_eagle3_config("eager")
+    fa_config = _build_eagle3_config("flash_attention_2")
+
+    eager_draft = LlamaEagle3DraftModel(eager_config).to(device=device, dtype=dtype)
+    fa_draft = LlamaEagle3DraftModel(fa_config).to(device=device, dtype=dtype)
+    fa_draft.load_state_dict(eager_draft.state_dict())
+
+    batch_size, seq_len = 2, 32
+    input_ids = torch.randint(0, eager_config.vocab_size, (batch_size, seq_len), device=device)
+    attention_mask = torch.ones(batch_size, seq_len, dtype=torch.long, device=device)
+    aux_hidden_states = torch.randn(
+        batch_size, seq_len, eager_config.hidden_size * 3, device=device, dtype=dtype
+    )
+    projected_eager = eager_draft.project_hidden_states(aux_hidden_states)
+    projected_fa = fa_draft.project_hidden_states(aux_hidden_states)
+
+    cache_eager: list[list[torch.Tensor]] = [[], []]
+    cache_fa: list[list[torch.Tensor]] = [[], []]
+    with torch.no_grad():
+        h_eager = projected_eager
+        h_fa = projected_fa
+        for _ in range(3):
+            h_eager = eager_draft(
+                input_ids=input_ids,
+                projected_hidden_states=h_eager,
+                attention_mask=attention_mask,
+                cache_hidden=cache_eager,
+            )
+            h_fa = fa_draft(
+                input_ids=input_ids,
+                projected_hidden_states=h_fa,
+                attention_mask=attention_mask,
+                cache_hidden=cache_fa,
+            )
+
+    max_diff = (h_eager - h_fa).abs().max().item()
+    torch.testing.assert_close(h_eager, h_fa, atol=1e-2, rtol=1e-2)
+    assert max_diff < 1e-1, f"FA2 vs eager TTT max abs diff = {max_diff}"
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or not _HAS_FA,
+    reason="FA2 path requires a CUDA device and the 'flash-attn' package",
+)
+def test_eagle3_flash_attention_step0_matches_eager():
+    """Step-0 FA2 path (no diagonal extension) must match eager.
+
+    Isolates the simpler half of ``_flash_attention_forward`` -- when
+    ``step_idx == 0`` the merge math collapses to just rescaling FA's
+    output by ``exp(lse_fa - lse_full) == 1`` -- so any divergence here
+    points at the FA call itself (transpose / scale / causal) rather than
+    the diagonal-merge algebra.
+    """
+    torch.manual_seed(1)
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+
+    eager_config = _build_eagle3_config("eager")
+    fa_config = _build_eagle3_config("flash_attention_2")
+
+    eager_draft = LlamaEagle3DraftModel(eager_config).to(device=device, dtype=dtype)
+    fa_draft = LlamaEagle3DraftModel(fa_config).to(device=device, dtype=dtype)
+    fa_draft.load_state_dict(eager_draft.state_dict())
+
+    batch_size, seq_len = 2, 32
+    input_ids = torch.randint(0, eager_config.vocab_size, (batch_size, seq_len), device=device)
+    attention_mask = torch.ones(batch_size, seq_len, dtype=torch.long, device=device)
+    aux_hidden_states = torch.randn(
+        batch_size, seq_len, eager_config.hidden_size * 3, device=device, dtype=dtype
+    )
+
+    with torch.no_grad():
+        out_eager = eager_draft(
+            input_ids=input_ids,
+            projected_hidden_states=eager_draft.project_hidden_states(aux_hidden_states),
+            attention_mask=attention_mask,
+        )
+        out_fa = fa_draft(
+            input_ids=input_ids,
+            projected_hidden_states=fa_draft.project_hidden_states(aux_hidden_states),
+            attention_mask=attention_mask,
+        )
+
+    torch.testing.assert_close(out_eager, out_fa, atol=1e-2, rtol=1e-2)
+
+
+def test_eagle3_flash_attention_2_raises_without_flash_attn():
+    """Requesting FA2 must fail loudly when flash-attn is not installed."""
+    if _HAS_FA:
+        pytest.skip("flash-attn is installed; cannot exercise the missing-import path")
+    config = _build_eagle3_config("flash_attention_2")
+    with pytest.raises(ImportError, match="flash-attn"):
+        LlamaEagle3DraftModel(config)
+
+
+def test_eagle3_unknown_attn_implementation_raises():
+    config = _build_eagle3_config("xformers")  # unsupported
+    with pytest.raises(ValueError, match="attn_implementation"):
+        LlamaEagle3DraftModel(config)


### PR DESCRIPTION
## What

Adds an opt-in FlashAttention-2 path to the EAGLE-3 Llama draft attention,
selectable via `config.attn_implementation` (default `eager`, fully
backward-compatible).

The FA2 path runs `flash_attn_func` on the T×T causal block (Block 1) with
`return_attn_probs=True` to obtain `softmax_lse`, then folds the EAGLE-3
diagonal-extension columns (steps `i >= 1`) into the same softmax in log
space via `lse_full = logaddexp(lse_fa, logsumexp(diag))`. The FA output is
rescaled by `exp(lse_fa - lse_full)`, and the diagonal contribution is added
with weights `exp(diag - lse_full)`.

Right-padded batches are correct under FA's `causal=True` without an explicit
padding mask: padding keys lie above the diagonal for any non-padded query
position, so the eager additive padding mask is redundant there.

## Changelog

- `Eagle3LlamaAttention` now accepts `attn_implementation` in `{"eager", "flash_attention_2"}`. Eager is the default and is byte-identical to the prior implementation (the existing math was extracted into `_eager_attention_forward` with no semantic change).
- New `_flash_attention_forward` implements the FA2 + diagonal log-space merge described above.
- `train_eagle3.py` reads `recipe_args.draft_attn_implementation` (default `eager`) and injects it into the draft config.
- New `examples/speculative/eagle3/llama_eagle3_mvp_flash_attn.yaml` demonstrates the FA2-enabled config. Original `llama_eagle3_mvp.yaml` and `llama_eagle3_perfectblend.yaml` are unchanged.
- New tests:
  - `test_eagle3_flash_attention_matches_eager` — 3-step TTT bf16/CUDA equivalence between eager and FA2 (atol/rtol = 1e-2).
  - `test_eagle3_flash_attention_step0_matches_eager` — isolates the no-diagonal-extension code path.
  - `test_eagle3_flash_attention_2_raises_without_flash_attn` — clear `ImportError` when the optional dep is missing.
  - `test_eagle3_unknown_attn_implementation_raises` — `ValueError` on typos / unsupported backends.
- Existing tests untouched and still exercise the eager path verbatim; the in-repo regression test `test_draft_attention_einsum_matches_loop_reference` guards the eager numerics (max diff < 1e-5 in fp32).

## Pre-checks

- [x] DCO sign-off on both commits
- [x] Conventional Commits title
- [ ] Lint (`ruff check . && ruff format .`) — please run, no ruff in local dev env
- [ ] Functional tests on a CUDA box with `flash-attn` installed
