### PR TITLE
feat(model): add Ling 2.0 / BailingMoeV2 (mini, flash, 1T) (#2242)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,4 @@ slurm*.out
 # Local launcher job output directories
 slurm_jobs/
 skypilot_jobs/
+training_logs/

--- a/docs/model-coverage/llm/inclusionai/ling-2.md
+++ b/docs/model-coverage/llm/inclusionai/ling-2.md
@@ -49,8 +49,11 @@ expert and a per-expert correction bias (aux-loss-free routing).
 |---|---|---|
 | {download}`ling_mini_2_0_squad.yaml <../../../../examples/llm_finetune/ling/ling_mini_2_0_squad.yaml>` | LoRA SFT — Ling-mini-2.0 on SQuAD | 2× H100 80GB |
 | {download}`ling_mini_2_0_hellaswag.yaml <../../../../examples/llm_finetune/ling/ling_mini_2_0_hellaswag.yaml>` | LoRA SFT — Ling-mini-2.0 on HellaSwag | 2× H100 80GB |
+| {download}`ling_mini_2_0_sft.yaml <../../../../examples/llm_finetune/ling/ling_mini_2_0_sft.yaml>` | Full SFT — Ling-mini-2.0 on HellaSwag, FSDP2 + EP=8 | 8× H100 80GB |
 | {download}`ling_flash_2_0_lora.yaml <../../../../examples/llm_finetune/ling/ling_flash_2_0_lora.yaml>` | LoRA SFT — Ling-flash-2.0 on HellaSwag | 8× H100 80GB |
+| {download}`ling_flash_2_0_sft.yaml <../../../../examples/llm_finetune/ling/ling_flash_2_0_sft.yaml>` | Full SFT — Ling-flash-2.0 on HellaSwag, FSDP2 + EP=32 | 32× H100 80GB (4 nodes) |
 | {download}`ling_1t_lora_pp.yaml <../../../../examples/llm_finetune/ling/ling_1t_lora_pp.yaml>` | LoRA SFT — Ling-1T on HellaSwag, FSDP2 + PP=4 + EP=8 | 32× H100 80GB (4 nodes) |
+| {download}`ling_1t_sft.yaml <../../../../examples/llm_finetune/ling/ling_1t_sft.yaml>` | Full SFT — Ling-1T on HellaSwag, FSDP2 + PP=4 + EP=64 | 256× H100 80GB (32 nodes) |
 
 ## Try with NeMo AutoModel
 

--- a/docs/model-coverage/llm/inclusionai/ling-2.md
+++ b/docs/model-coverage/llm/inclusionai/ling-2.md
@@ -45,9 +45,12 @@ expert and a per-expert correction bias (aux-loss-free routing).
 
 ## Example Recipes
 
-| Recipe | Description |
-|---|---|
-| {download}`ling_mini_2_0_squad.yaml <../../../../examples/llm_finetune/ling/ling_mini_2_0_squad.yaml>` | LoRA SFT — Ling-mini-2.0 on SQuAD |
+| Recipe | Description | Min HW |
+|---|---|---|
+| {download}`ling_mini_2_0_squad.yaml <../../../../examples/llm_finetune/ling/ling_mini_2_0_squad.yaml>` | LoRA SFT — Ling-mini-2.0 on SQuAD | 2× H100 80GB |
+| {download}`ling_mini_2_0_hellaswag.yaml <../../../../examples/llm_finetune/ling/ling_mini_2_0_hellaswag.yaml>` | LoRA SFT — Ling-mini-2.0 on HellaSwag | 2× H100 80GB |
+| {download}`ling_flash_2_0_lora.yaml <../../../../examples/llm_finetune/ling/ling_flash_2_0_lora.yaml>` | LoRA SFT — Ling-flash-2.0 on HellaSwag | 8× H100 80GB |
+| {download}`ling_1t_lora_pp.yaml <../../../../examples/llm_finetune/ling/ling_1t_lora_pp.yaml>` | LoRA SFT — Ling-1T on HellaSwag, FSDP2 + PP=4 + EP=8 | 32× H100 80GB (4 nodes) |
 
 ## Try with NeMo AutoModel
 

--- a/docs/model-coverage/llm/inclusionai/ling-2.md
+++ b/docs/model-coverage/llm/inclusionai/ling-2.md
@@ -52,7 +52,7 @@ expert and a per-expert correction bias (aux-loss-free routing).
 | {download}`ling_mini_2_0_sft.yaml <../../../../examples/llm_finetune/ling/ling_mini_2_0_sft.yaml>` | Full SFT — Ling-mini-2.0 on HellaSwag, FSDP2 + EP=8 | 8× H100 80GB |
 | {download}`ling_flash_2_0_lora.yaml <../../../../examples/llm_finetune/ling/ling_flash_2_0_lora.yaml>` | LoRA SFT — Ling-flash-2.0 on HellaSwag | 8× H100 80GB |
 | {download}`ling_flash_2_0_sft.yaml <../../../../examples/llm_finetune/ling/ling_flash_2_0_sft.yaml>` | Full SFT — Ling-flash-2.0 on HellaSwag, FSDP2 + EP=32 | 32× H100 80GB (4 nodes) |
-| {download}`ling_1t_lora_pp.yaml <../../../../examples/llm_finetune/ling/ling_1t_lora_pp.yaml>` | LoRA SFT — Ling-1T on HellaSwag, FSDP2 + PP=4 + EP=8 | 32× H100 80GB (4 nodes) |
+| {download}`ling_1t_lora_pp.yaml <../../../../examples/llm_finetune/ling/ling_1t_lora_pp.yaml>` | LoRA SFT — Ling-1T on HellaSwag, FSDP2 + PP=8 + EP=8 | 64× H100 80GB (8 nodes) |
 | {download}`ling_1t_sft.yaml <../../../../examples/llm_finetune/ling/ling_1t_sft.yaml>` | Full SFT — Ling-1T on HellaSwag, FSDP2 + PP=4 + EP=64 | 256× H100 80GB (32 nodes) |
 
 ## Try with NeMo AutoModel

--- a/docs/model-coverage/llm/inclusionai/ling-2.md
+++ b/docs/model-coverage/llm/inclusionai/ling-2.md
@@ -1,0 +1,64 @@
+# Ling 2.0
+
+[Ling 2.0](https://huggingface.co/collections/inclusionAI/ling-20) is the Mixture-of-Experts
+LLM family from inclusionAI (Ant Group), released under the `bailing_moe` HF
+architecture (`BailingMoeV2ForCausalLM`).  The line spans a 16 B mini through
+a 1 T flagship while sharing the same architecture.
+
+:::{card}
+| | |
+|---|---|
+| **Task** | Text Generation (MoE) |
+| **Architecture** | `BailingMoeV2ForCausalLM` |
+| **Parameters** | 16 B – 1 T total |
+| **HF Org** | [inclusionAI](https://huggingface.co/inclusionAI) |
+:::
+
+## Available Models
+
+- **Ling-mini-2.0**: 16 B total / ~1.4 B activated per token (20 layers, 256 experts, 8 activated).
+- **Ling-flash-2.0**: 100 B total / ~6 B activated per token (32 layers, 256 experts, 8 activated).
+- **Ling-1T**: 1 T total / ~50 B activated per token (80 layers, `first_k_dense_replace=4`).
+- **Ling-mini-base-2.0** / **Ling-flash-base-2.0**: base (pre-instruct) variants.
+
+All variants share the same architecture: GQA + per-head QK-RMSNorm + half RoPE
+(`partial_rotary_factor=0.5`) + sigmoid-routed grouped MoE with one shared
+expert and a per-expert correction bias (aux-loss-free routing).
+
+## Architecture
+
+- `BailingMoeV2ForCausalLM` (HF `model_type: "bailing_moe"`)
+- GQA attention; `use_qk_norm: true`
+- Half RoPE (`partial_rotary_factor=0.5`)
+- DeepSeek-V3-style routing: sigmoid scoring, per-expert bias, grouped top-k
+  (`n_group=8`, `topk_group=4`)
+- 1 shared expert at `moe_intermediate_size`
+- `first_k_dense_replace` dense MLP layer(s) at the start of the stack
+
+## Example HF Models
+
+| Model | HF ID |
+|---|---|
+| Ling-mini-2.0 | [`inclusionAI/Ling-mini-2.0`](https://huggingface.co/inclusionAI/Ling-mini-2.0) |
+| Ling-flash-2.0 | [`inclusionAI/Ling-flash-2.0`](https://huggingface.co/inclusionAI/Ling-flash-2.0) |
+| Ling-1T | [`inclusionAI/Ling-1T`](https://huggingface.co/inclusionAI/Ling-1T) |
+
+## Example Recipes
+
+| Recipe | Description |
+|---|---|
+| {download}`ling_mini_2_0_squad.yaml <../../../../examples/llm_finetune/ling/ling_mini_2_0_squad.yaml>` | LoRA SFT — Ling-mini-2.0 on SQuAD |
+
+## Try with NeMo AutoModel
+
+**1. Install** ([full instructions](../../../guides/installation.md)).
+
+**2. Run LoRA fine-tuning:**
+
+```bash
+automodel examples/llm_finetune/ling/ling_mini_2_0_squad.yaml --nproc-per-node 1
+```
+
+A single 80 GB H100 / A100 fits Ling-mini-2.0 in bf16 with the LoRA defaults
+in the example.  Set `distributed.ep_size > 1` for multi-GPU expert
+parallelism on the larger variants.

--- a/docs/model-coverage/llm/index.md
+++ b/docs/model-coverage/llm/index.md
@@ -74,6 +74,7 @@ NeMo AutoModel supports the [AutoModelForCausalLM](https://huggingface.co/transf
 | Parasail AI | [GritLM](parasail-ai/gritlm.md) | `GritLM` |
 | Tencent | [Hy3-preview](tencent/hy3.md) | `HYV3ForCausalLM` |
 | Xiaomi MiMo | [MiMo-V2-Flash](xiaomimimo/mimo-v2-flash.md) | `MiMoV2FlashForCausalLM` |
+| inclusionAI | [Ling 2.0](inclusionai/ling-2.md) | `BailingMoeV2ForCausalLM` |
 
 ## Fine-Tuning LLMs with NeMo AutoModel
 
@@ -146,4 +147,5 @@ stepfun-ai/step-3-5
 parasail-ai/gritlm
 tencent/hy3
 xiaomimimo/mimo-v2-flash
+inclusionai/ling-2
 ```

--- a/examples/llm_finetune/ling/ling_1t_lora_pp.yaml
+++ b/examples/llm_finetune/ling/ling_1t_lora_pp.yaml
@@ -1,0 +1,123 @@
+
+# ------------------------------------------------------------------------------------------------
+# WARNING: HARDWARE REQUIREMENTS
+# ------------------------------------------------------------------------------------------------
+# Ling-1T (BailingMoeV2: ~1T total / ~50B activated, 80 layers, 256 experts,
+# first_k_dense_replace=4, rotary_dim=64 -> half-RoPE).
+#
+# Memory: bf16 base weights ~ 2 TB.  Even with LoRA the BASE model must be
+# loaded -> requires a multi-node setup with pipeline parallelism.  This
+# config targets 32 x H100 80GB (4 nodes x 8) with FSDP2 + PP=4 + EP=8 + LoRA
+# + activation checkpointing, modelled after deepseek_v32_hellaswag_pp.yaml.
+# For larger node counts increase pp_size or ep_size; do NOT try to run this
+# on fewer than ~32 H100 80GB.
+# ------------------------------------------------------------------------------------------------
+#
+# To run this recipe on 32 H100 80GB (4 nodes x 8) via Slurm:
+#   sbatch slurm.sub examples/llm_finetune/ling/ling_1t_lora_pp.yaml
+#
+# Architecture: same BailingMoeV2 family as Ling-mini / Ling-flash.  The 1T
+# config.json sets first_k_dense_replace=4 and rotary_dim=64 (no
+# partial_rotary_factor); both are derived automatically by
+# BailingMoeV2Config.from_pretrained.
+
+recipe: TrainFinetuneRecipeForNextTokenPrediction
+
+seed: 1234
+
+step_scheduler:
+  global_batch_size: 512
+  local_batch_size: 4
+  ckpt_every_steps: 200
+  val_every_steps: 100
+  num_epochs: 1
+  max_steps: 500
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 30
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: inclusionAI/Ling-1T
+  torch_dtype: bfloat16
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: sdpa  # TE attention needs latest cuDNN; sdpa is safer baseline at 1T scale
+    linear: te
+    rms_norm: torch_fp32
+    rope_fusion: false
+    experts: torch_mm
+    dispatcher: deepep
+    fake_balanced_gate: false
+    enable_hf_state_dict_adapter: true
+    enable_fsdp_optimizations: true
+
+peft:
+  _target_: nemo_automodel.components._peft.lora.PeftConfig
+  target_modules: '*_proj'
+  dim: 16
+  alpha: 32
+  dropout: 0.0
+
+checkpoint:
+  enabled: true
+  checkpoint_dir: checkpoints/ling_1t_lora_pp
+  model_save_format: safetensors
+  save_consolidated: true
+
+distributed:
+  strategy: fsdp2
+  tp_size: 1
+  cp_size: 1
+  pp_size: 4
+  ep_size: 8
+  sequence_parallel: false
+  activation_checkpointing: true
+
+  pipeline:
+    pp_schedule: interleaved1f1b
+    pp_microbatch_size: 1
+    round_virtual_stages_to_pp_multiple: down
+    scale_grads_in_schedule: false
+    layers_per_stage: 5  # 80 layers / pp_size 4 / virtual_stages 4 = 5
+
+  moe:
+    reshard_after_forward: false
+    wrap_outer_model: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.hellaswag.HellaSwag
+  path_or_dataset: rowan/hellaswag
+  split: train
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  shuffle: true
+  num_workers: 4
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.llm.hellaswag.HellaSwag
+  path_or_dataset: rowan/hellaswag
+  split: validation
+  num_samples_limit: 128
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  num_workers: 4
+
+optimizer:
+  _target_: torch.optim.AdamW
+  lr: 5.0e-5
+  weight_decay: 0.01
+  betas: [0.9, 0.95]
+  eps: 1e-8
+
+lr_scheduler:
+  lr_decay_style: cosine
+  min_lr: 1.0e-6

--- a/examples/llm_finetune/ling/ling_1t_lora_pp.yaml
+++ b/examples/llm_finetune/ling/ling_1t_lora_pp.yaml
@@ -6,14 +6,16 @@
 # first_k_dense_replace=4, rotary_dim=64 -> half-RoPE).
 #
 # Memory: bf16 base weights ~ 2 TB.  Even with LoRA the BASE model must be
-# loaded -> requires a multi-node setup with pipeline parallelism.  This
-# config targets 32 x H100 80GB (4 nodes x 8) with FSDP2 + PP=4 + EP=8 + LoRA
-# + activation checkpointing, modelled after deepseek_v32_hellaswag_pp.yaml.
-# For larger node counts increase pp_size or ep_size; do NOT try to run this
-# on fewer than ~32 H100 80GB.
+# loaded -> requires a multi-node setup with pipeline parallelism.  Validated
+# topology (per Huiying @ NVIDIA): 64 x H100 80GB (8 nodes x 8) with
+# FSDP2 + PP=8 + EP=8 + LoRA + activation checkpointing.  At pp=8 each stage
+# holds ~10 of the 80 layers; combined with ep=8 the per-rank base weight
+# footprint stays ~33 GB which leaves room for activations + LoRA state on
+# 80 GB cards.  Smaller setups (pp=4, ep=8 on 4 nodes / 32 GPUs) will OOM at
+# load-time.
 # ------------------------------------------------------------------------------------------------
 #
-# To run this recipe on 32 H100 80GB (4 nodes x 8) via Slurm:
+# To run this recipe on 64 H100 80GB (8 nodes x 8) via Slurm:
 #   sbatch slurm.sub examples/llm_finetune/ling/ling_1t_lora_pp.yaml
 #
 # Architecture: same BailingMoeV2 family as Ling-mini / Ling-flash.  The 1T
@@ -70,7 +72,7 @@ distributed:
   strategy: fsdp2
   tp_size: 1
   cp_size: 1
-  pp_size: 4
+  pp_size: 8
   ep_size: 8
   sequence_parallel: false
   activation_checkpointing: true
@@ -80,7 +82,13 @@ distributed:
     pp_microbatch_size: 1
     round_virtual_stages_to_pp_multiple: down
     scale_grads_in_schedule: false
-    layers_per_stage: 5  # 80 layers / pp_size 4 / virtual_stages 4 = 5
+    layers_per_stage: 2  # 80 layers / pp_size 8 / virtual_stages 5 = 2
+    # BailingMoeV2ForCausalLM declares _pp_keep_self_forward=True, so the PP
+    # splitter preserves our gpt_oss-style freqs_cis forward.  These two
+    # explicit flags are defensive and prevent any future regression where
+    # someone overrides _pp_keep_self_forward at the recipe level.
+    patch_inner_model: false
+    patch_causal_lm_model: false
 
   moe:
     reshard_after_forward: false

--- a/examples/llm_finetune/ling/ling_1t_lora_pp.yaml
+++ b/examples/llm_finetune/ling/ling_1t_lora_pp.yaml
@@ -18,10 +18,8 @@
 # To run this recipe on 64 H100 80GB (8 nodes x 8) via Slurm:
 #   sbatch slurm.sub examples/llm_finetune/ling/ling_1t_lora_pp.yaml
 #
-# Architecture: same BailingMoeV2 family as Ling-mini / Ling-flash.  The 1T
-# config.json sets first_k_dense_replace=4 and rotary_dim=64 (no
-# partial_rotary_factor); both are derived automatically by
-# BailingMoeV2Config.from_pretrained.
+# Uses dispatcher=hybridep (DeepEP times out at hidden_size=8192).
+# Requires NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN=8 (set in ci.env_vars).
 
 recipe: TrainFinetuneRecipeForNextTokenPrediction
 
@@ -50,7 +48,7 @@ model:
     rms_norm: torch_fp32
     rope_fusion: false
     experts: torch_mm
-    dispatcher: deepep
+    dispatcher: hybridep
     fake_balanced_gate: false
     enable_hf_state_dict_adapter: true
     enable_fsdp_optimizations: true
@@ -82,11 +80,7 @@ distributed:
     pp_microbatch_size: 1
     round_virtual_stages_to_pp_multiple: down
     scale_grads_in_schedule: false
-    layers_per_stage: 2  # 80 layers / pp_size 8 / virtual_stages 5 = 2
-    # BailingMoeV2ForCausalLM declares _pp_keep_self_forward=True, so the PP
-    # splitter preserves our gpt_oss-style freqs_cis forward.  These two
-    # explicit flags are defensive and prevent any future regression where
-    # someone overrides _pp_keep_self_forward at the recipe level.
+    layers_per_stage: 2  # 80 / pp=8 / virtual=5
     patch_inner_model: false
     patch_causal_lm_model: false
 
@@ -129,3 +123,10 @@ optimizer:
 lr_scheduler:
   lr_decay_style: cosine
   min_lr: 1.0e-6
+
+ci:
+  recipe_owner: Hayden727
+  nodes: 8
+  time: "01:00:00"
+  env_vars:
+    NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN: "8"

--- a/examples/llm_finetune/ling/ling_1t_sft.yaml
+++ b/examples/llm_finetune/ling/ling_1t_sft.yaml
@@ -73,6 +73,11 @@ distributed:
     round_virtual_stages_to_pp_multiple: down
     scale_grads_in_schedule: false
     layers_per_stage: 5  # 80 layers / pp=4 / 4 virtual stages
+    # See note in ling_1t_lora_pp.yaml.  These flags pair with the
+    # _pp_keep_self_forward=True class attribute on BailingMoeV2ForCausalLM
+    # and keep our freqs_cis-based forward intact under PP.
+    patch_inner_model: false
+    patch_causal_lm_model: false
 
   moe:
     reshard_after_forward: false

--- a/examples/llm_finetune/ling/ling_1t_sft.yaml
+++ b/examples/llm_finetune/ling/ling_1t_sft.yaml
@@ -10,13 +10,14 @@
 # Use ling_1t_lora_pp.yaml (32 GPUs) if full SFT is not feasible.
 # ------------------------------------------------------------------------------------------------
 #
-# Modelled after deepseek_v32_hellaswag_pp.yaml (671B / 256 H100 / pp=4 / ep=64).
-# Topology: PP=4 across 4 node-groups, EP=64 across 8 nodes, FSDP shards
-# remaining params across data-parallel groups.
+# Topology: PP=4, EP=64; FSDP shards the rest.
+# Uses dispatcher=hybridep (DeepEP times out at hidden_size=8192).
+# Requires env vars (set in ci.env_vars):
+#   NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN=8
+#   NUM_OF_STAGES_G2S_COMBINE_API=4   # multi-node ep=64 backward combine
 #
 # To run:
 #   automodel examples/llm_finetune/ling/ling_1t_sft.yaml --nproc-per-node 8
-# (Launch on 32 nodes via slurm.sub or the SkyPilot launcher; see launcher-config skill.)
 
 recipe: TrainFinetuneRecipeForNextTokenPrediction
 
@@ -46,7 +47,7 @@ model:
     linear: te
     rms_norm: torch_fp32
     experts: torch_mm
-    dispatcher: deepep
+    dispatcher: hybridep
     fake_balanced_gate: false
     enable_hf_state_dict_adapter: true
     enable_fsdp_optimizations: true
@@ -72,10 +73,7 @@ distributed:
     pp_microbatch_size: 1
     round_virtual_stages_to_pp_multiple: down
     scale_grads_in_schedule: false
-    layers_per_stage: 5  # 80 layers / pp=4 / 4 virtual stages
-    # See note in ling_1t_lora_pp.yaml.  These flags pair with the
-    # _pp_keep_self_forward=True class attribute on BailingMoeV2ForCausalLM
-    # and keep our freqs_cis-based forward intact under PP.
+    layers_per_stage: 5  # 80 / pp=4 / virtual=4
     patch_inner_model: false
     patch_causal_lm_model: false
 
@@ -122,3 +120,11 @@ optimizer:
 lr_scheduler:
   lr_decay_style: cosine
   min_lr: 1.0e-6
+
+ci:
+  recipe_owner: Hayden727
+  nodes: 32
+  time: "01:00:00"
+  env_vars:
+    NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN: "8"
+    NUM_OF_STAGES_G2S_COMBINE_API: "4"

--- a/examples/llm_finetune/ling/ling_1t_sft.yaml
+++ b/examples/llm_finetune/ling/ling_1t_sft.yaml
@@ -1,0 +1,119 @@
+
+# ------------------------------------------------------------------------------------------------
+# WARNING: HARDWARE REQUIREMENTS
+# ------------------------------------------------------------------------------------------------
+# Ling-1T (BailingMoeV2: 1T total / ~50B activated, 80 layers, 256 experts,
+# first_k_dense_replace=4).  Full SFT requires ~12 TB for params + grads +
+# Adam state in fp32.
+# Minimum:    256x H100 80GB (32 nodes) -- 47 GB/rank, comfortable.
+# Lower bound: 128x H100 80GB (16 nodes) -- 94 GB/rank, will OOM without offload.
+# Use ling_1t_lora_pp.yaml (32 GPUs) if full SFT is not feasible.
+# ------------------------------------------------------------------------------------------------
+#
+# Modelled after deepseek_v32_hellaswag_pp.yaml (671B / 256 H100 / pp=4 / ep=64).
+# Topology: PP=4 across 4 node-groups, EP=64 across 8 nodes, FSDP shards
+# remaining params across data-parallel groups.
+#
+# To run:
+#   automodel examples/llm_finetune/ling/ling_1t_sft.yaml --nproc-per-node 8
+# (Launch on 32 nodes via slurm.sub or the SkyPilot launcher; see launcher-config skill.)
+
+recipe: TrainFinetuneRecipeForNextTokenPrediction
+
+step_scheduler:
+  global_batch_size: 512
+  local_batch_size: 4
+  ckpt_every_steps: 500
+  val_every_steps: 500
+  num_epochs: 2
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 30
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 42
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: inclusionAI/Ling-1T
+  torch_dtype: bfloat16
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: sdpa
+    linear: te
+    rms_norm: torch_fp32
+    experts: torch_mm
+    dispatcher: deepep
+    fake_balanced_gate: false
+    enable_hf_state_dict_adapter: true
+    enable_fsdp_optimizations: true
+    rope_fusion: false
+
+checkpoint:
+  enabled: true
+  checkpoint_dir: checkpoints/ling_1t_sft
+  model_save_format: safetensors
+  save_consolidated: true
+
+distributed:
+  strategy: fsdp2
+  tp_size: 1
+  cp_size: 1
+  pp_size: 4
+  ep_size: 64
+  sequence_parallel: false
+  activation_checkpointing: true
+
+  pipeline:
+    pp_schedule: interleaved1f1b
+    pp_microbatch_size: 1
+    round_virtual_stages_to_pp_multiple: down
+    scale_grads_in_schedule: false
+    layers_per_stage: 5  # 80 layers / pp=4 / 4 virtual stages
+
+  moe:
+    reshard_after_forward: false
+    wrap_outer_model: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.hellaswag.HellaSwag
+  path_or_dataset: rowan/hellaswag
+  split: train
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn:
+    _target_: nemo_automodel.components.datasets.utils.default_collater
+    pad_seq_len_divisible: 160
+  shuffle: true
+  num_workers: 4
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.llm.hellaswag.HellaSwag
+  path_or_dataset: rowan/hellaswag
+  split: validation
+  num_samples_limit: 128
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn:
+    _target_: nemo_automodel.components.datasets.utils.default_collater
+    pad_seq_len_divisible: 160
+  num_workers: 4
+
+optimizer:
+  _target_: torch.optim.AdamW
+  lr: 5.0e-6
+  weight_decay: 0.01
+  betas: [0.9, 0.95]
+  eps: 1e-8
+
+lr_scheduler:
+  lr_decay_style: cosine
+  min_lr: 1.0e-6

--- a/examples/llm_finetune/ling/ling_flash_2_0_lora.yaml
+++ b/examples/llm_finetune/ling/ling_flash_2_0_lora.yaml
@@ -1,0 +1,109 @@
+
+# ------------------------------------------------------------------------------------------------
+# WARNING: HARDWARE REQUIREMENTS
+# ------------------------------------------------------------------------------------------------
+# Ling-flash-2.0 (BailingMoeV2: ~100B total / ~6B activated, 32 layers, 256 experts).
+# This config targets 8x H100 80GB with FSDP2 + EP=8 + LoRA + activation checkpointing.
+# Reduce local_batch_size first if you run with fewer GPUs.
+# ------------------------------------------------------------------------------------------------
+#
+# To run this recipe:
+#   automodel examples/llm_finetune/ling/ling_flash_2_0_lora.yaml --nproc-per-node 8
+# Adjust --nproc-per-node to the number of GPUs available; ep_size must match.
+#
+# Architecture: same as Ling-mini-2.0 (sigmoid + grouped topk MoE, 1 shared expert,
+# GQA + per-head QK-RMSNorm, half RoPE, first_k_dense_replace=1).  The
+# BailingMoeV2Config + BailingMoeV2ForCausalLM picks up the size differences
+# from inclusionAI/Ling-flash-2.0's HF config.json automatically.
+
+recipe: TrainFinetuneRecipeForNextTokenPrediction
+
+step_scheduler:
+  global_batch_size: 256
+  local_batch_size: 8
+  ckpt_every_steps: 200
+  val_every_steps: 100
+  num_epochs: 1
+  max_steps: 500
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 20
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 42
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: inclusionAI/Ling-flash-2.0
+  torch_dtype: bfloat16
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: te
+    linear: torch
+    rms_norm: torch_fp32
+    experts: torch_mm
+    dispatcher: deepep
+    fake_balanced_gate: false
+    enable_hf_state_dict_adapter: true
+    enable_fsdp_optimizations: true
+
+peft:
+  _target_: nemo_automodel.components._peft.lora.PeftConfig
+  target_modules: '*_proj'
+  dim: 16
+  alpha: 32
+  dropout: 0.0
+
+checkpoint:
+  enabled: true
+  checkpoint_dir: checkpoints/ling_flash_2_0_lora
+  model_save_format: safetensors
+  save_consolidated: true
+
+distributed:
+  strategy: fsdp2
+  tp_size: 1
+  cp_size: 1
+  pp_size: 1
+  ep_size: 8
+  sequence_parallel: false
+  activation_checkpointing: true
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.hellaswag.HellaSwag
+  path_or_dataset: rowan/hellaswag
+  split: train
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  shuffle: true
+  num_workers: 4
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.llm.hellaswag.HellaSwag
+  path_or_dataset: rowan/hellaswag
+  split: validation
+  num_samples_limit: 128
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  num_workers: 4
+
+optimizer:
+  _target_: torch.optim.AdamW
+  lr: 1.0e-4
+  weight_decay: 0.01
+  betas: [0.9, 0.95]
+  eps: 1e-8
+
+lr_scheduler:
+  lr_decay_style: cosine
+  min_lr: 1.0e-6

--- a/examples/llm_finetune/ling/ling_flash_2_0_sft.yaml
+++ b/examples/llm_finetune/ling/ling_flash_2_0_sft.yaml
@@ -1,0 +1,103 @@
+
+# ------------------------------------------------------------------------------------------------
+# WARNING: HARDWARE REQUIREMENTS
+# ------------------------------------------------------------------------------------------------
+# Ling-flash-2.0 (BailingMoeV2: ~100B total / ~6B activated, 32 layers, 256 experts).
+# Full SFT requires ~1.2 TB total for params + grads + Adam state in fp32.
+# Minimum: 16x H100 80GB (2 nodes) -- 75 GB/rank, very tight.
+# Recommended: 32x H100 80GB (4 nodes) -- 37 GB/rank, comfortable.
+# Use the LoRA variant (ling_flash_2_0_lora.yaml) if you only have 1 node.
+# ------------------------------------------------------------------------------------------------
+#
+# To run (32 GPUs across 4 nodes):
+#   automodel examples/llm_finetune/ling/ling_flash_2_0_sft.yaml --nproc-per-node 8
+# Adjust --nproc-per-node and ep_size to your topology.
+
+recipe: TrainFinetuneRecipeForNextTokenPrediction
+
+step_scheduler:
+  global_batch_size: 1024
+  local_batch_size: 4
+  ckpt_every_steps: 200
+  val_every_steps: 100
+  num_epochs: 2
+  max_steps: 1000
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 30
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 42
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: inclusionAI/Ling-flash-2.0
+  torch_dtype: bfloat16
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: te
+    linear: torch
+    rms_norm: torch_fp32
+    experts: torch_mm
+    dispatcher: deepep
+    fake_balanced_gate: false
+    enable_hf_state_dict_adapter: true
+    enable_fsdp_optimizations: true
+
+checkpoint:
+  enabled: true
+  checkpoint_dir: checkpoints/ling_flash_2_0_sft
+  model_save_format: safetensors
+  save_consolidated: true
+
+distributed:
+  strategy: fsdp2
+  tp_size: 1
+  cp_size: 1
+  pp_size: 1
+  ep_size: 32
+  sequence_parallel: false
+  activation_checkpointing: true
+
+  moe:
+    reshard_after_forward: false
+    wrap_outer_model: true
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.hellaswag.HellaSwag
+  path_or_dataset: rowan/hellaswag
+  split: train
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  shuffle: true
+  num_workers: 4
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.llm.hellaswag.HellaSwag
+  path_or_dataset: rowan/hellaswag
+  split: validation
+  num_samples_limit: 128
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  num_workers: 4
+
+optimizer:
+  _target_: torch.optim.AdamW
+  lr: 1.0e-5
+  weight_decay: 0.01
+  betas: [0.9, 0.95]
+  eps: 1e-8
+
+lr_scheduler:
+  lr_decay_style: cosine
+  min_lr: 1.0e-6

--- a/examples/llm_finetune/ling/ling_mini_2_0_hellaswag.yaml
+++ b/examples/llm_finetune/ling/ling_mini_2_0_hellaswag.yaml
@@ -1,0 +1,102 @@
+
+# ------------------------------------------------------------------------------------------------
+# Ling-mini-2.0 (BailingMoeV2: 16B total / 1.43B activated) LoRA SFT on HellaSwag.
+# ------------------------------------------------------------------------------------------------
+# Companion recipe to ling_mini_2_0_squad.yaml.  HellaSwag is multiple-choice
+# commonsense reasoning; initial loss for a well-warmed-up instruct base sits
+# around 2-3 (vs. SQuAD's ~12 from answer-only masking on rare entities).
+# ------------------------------------------------------------------------------------------------
+#
+# To run (4 GPUs, ep matches nproc-per-node — see ling_mini_2_0_squad.yaml note):
+#   automodel examples/llm_finetune/ling/ling_mini_2_0_hellaswag.yaml --nproc-per-node 4
+
+recipe: TrainFinetuneRecipeForNextTokenPrediction
+
+step_scheduler:
+  global_batch_size: 32
+  local_batch_size: 4
+  ckpt_every_steps: 200
+  val_every_steps: 100
+  num_epochs: 1
+  max_steps: 500
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 20
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 42
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: inclusionAI/Ling-mini-2.0
+  torch_dtype: bfloat16
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: sdpa
+    linear: torch
+    rms_norm: torch_fp32
+    experts: torch_mm
+    dispatcher: torch
+    enable_hf_state_dict_adapter: true
+
+peft:
+  _target_: nemo_automodel.components._peft.lora.PeftConfig
+  target_modules: '*_proj'
+  dim: 16
+  alpha: 32
+  dropout: 0.0
+
+checkpoint:
+  enabled: true
+  checkpoint_dir: checkpoints/ling_mini_2_0_hellaswag_lora
+  model_save_format: safetensors
+  save_consolidated: true
+
+distributed:
+  strategy: fsdp2
+  tp_size: 1
+  cp_size: 1
+  pp_size: 1
+  # ep_size must match --nproc-per-node (see ling_mini_2_0_squad.yaml note).
+  ep_size: 4
+  sequence_parallel: false
+  activation_checkpointing: true
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.hellaswag.HellaSwag
+  path_or_dataset: rowan/hellaswag
+  split: train
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  shuffle: true
+  num_workers: 2
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.llm.hellaswag.HellaSwag
+  path_or_dataset: rowan/hellaswag
+  split: validation
+  num_samples_limit: 128
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  num_workers: 2
+
+optimizer:
+  _target_: torch.optim.AdamW
+  lr: 1.0e-4
+  weight_decay: 0.01
+  betas: [0.9, 0.95]
+  eps: 1e-8
+
+lr_scheduler:
+  lr_decay_style: cosine
+  min_lr: 1.0e-6

--- a/examples/llm_finetune/ling/ling_mini_2_0_sft.yaml
+++ b/examples/llm_finetune/ling/ling_mini_2_0_sft.yaml
@@ -1,0 +1,98 @@
+
+# ------------------------------------------------------------------------------------------------
+# Ling-mini-2.0 (BailingMoeV2: 16B total / 1.43B activated) FULL SFT on HellaSwag.
+# ------------------------------------------------------------------------------------------------
+# Companion to ling_mini_2_0_hellaswag.yaml (LoRA).  Removes the `peft:` block so
+# every parameter is trainable.  Recommended hardware: 8x H100 80GB with FSDP2
+# + EP=8 + activation_checkpointing (Adam state for 16B params in fp32 is
+# ~190GB total, ~24GB/rank when sharded across 8 GPUs).  Reduce
+# local_batch_size first if running on fewer GPUs.
+# ------------------------------------------------------------------------------------------------
+#
+# To run:
+#   automodel examples/llm_finetune/ling/ling_mini_2_0_sft.yaml --nproc-per-node 8
+
+recipe: TrainFinetuneRecipeForNextTokenPrediction
+
+step_scheduler:
+  global_batch_size: 256
+  local_batch_size: 8
+  ckpt_every_steps: 200
+  val_every_steps: 100
+  num_epochs: 2
+  max_steps: 1000
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 20
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 42
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: inclusionAI/Ling-mini-2.0
+  torch_dtype: bfloat16
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: te
+    linear: torch
+    rms_norm: torch_fp32
+    experts: torch_mm
+    dispatcher: deepep
+    fake_balanced_gate: false
+    enable_hf_state_dict_adapter: true
+    enable_fsdp_optimizations: true
+
+checkpoint:
+  enabled: true
+  checkpoint_dir: checkpoints/ling_mini_2_0_sft
+  model_save_format: safetensors
+  save_consolidated: true
+
+distributed:
+  strategy: fsdp2
+  tp_size: 1
+  cp_size: 1
+  pp_size: 1
+  ep_size: 8
+  sequence_parallel: false
+  activation_checkpointing: true
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.hellaswag.HellaSwag
+  path_or_dataset: rowan/hellaswag
+  split: train
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  shuffle: true
+  num_workers: 4
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.llm.hellaswag.HellaSwag
+  path_or_dataset: rowan/hellaswag
+  split: validation
+  num_samples_limit: 128
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  num_workers: 4
+
+optimizer:
+  _target_: torch.optim.AdamW
+  lr: 2.0e-5
+  weight_decay: 0.01
+  betas: [0.9, 0.95]
+  eps: 1e-8
+
+lr_scheduler:
+  lr_decay_style: cosine
+  min_lr: 2.0e-6

--- a/examples/llm_finetune/ling/ling_mini_2_0_squad.yaml
+++ b/examples/llm_finetune/ling/ling_mini_2_0_squad.yaml
@@ -1,0 +1,109 @@
+
+# ------------------------------------------------------------------------------------------------
+# Ling-mini-2.0 (BailingMoeV2: 16B total / 1.43B activated) LoRA SFT on SQuAD.
+# ------------------------------------------------------------------------------------------------
+# Hardware: one H100/A100 80GB is enough for LoRA at local_batch_size=4 with bf16.
+# For multi-GPU expert parallelism, set distributed.ep_size to the GPU count.
+# ------------------------------------------------------------------------------------------------
+#
+# To run:
+#   automodel examples/llm_finetune/ling/ling_mini_2_0_squad.yaml --nproc-per-node 1
+#
+# Architecture notes for BailingMoeV2 (shared by Ling-mini / -flash / -1T):
+#   - GQA attention (16 / 4 heads on mini) with per-head QK-RMSNorm.
+#   - Half-RoPE: partial_rotary_factor=0.5 rotates only first 64 / 128 dims.
+#   - Sigmoid routing + per-expert bias (aux-loss-free), grouped topk
+#     (n_group=8, topk_group=4), 1 shared expert.
+#   - first_k_dense_replace=1: layer 0 uses a dense MLP, layers 1-19 are MoE.
+
+recipe: TrainFinetuneRecipeForNextTokenPrediction
+
+step_scheduler:
+  global_batch_size: 32
+  local_batch_size: 4
+  ckpt_every_steps: 200
+  val_every_steps: 100
+  num_epochs: 1
+  max_steps: 500
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 20
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 42
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: inclusionAI/Ling-mini-2.0
+  torch_dtype: bfloat16
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: te
+    linear: torch
+    rms_norm: torch_fp32
+    experts: torch_mm
+    dispatcher: torch
+    enable_hf_state_dict_adapter: true
+
+peft:
+  _target_: nemo_automodel.components._peft.lora.PeftConfig
+  target_modules: ["*_proj"]
+  dim: 16
+  alpha: 32
+  dropout: 0.0
+
+checkpoint:
+  enabled: true
+  checkpoint_dir: checkpoints/ling_mini_2_0_lora
+  model_save_format: safetensors
+  save_consolidated: true
+
+distributed:
+  strategy: fsdp2
+  tp_size: 1
+  cp_size: 1
+  pp_size: 1
+  ep_size: 1
+  sequence_parallel: false
+  activation_checkpointing: true
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
+  tokenizer:
+    _target_: nemo_automodel._transformers.auto_tokenizer.NeMoAutoTokenizer.from_pretrained
+    pretrained_model_name_or_path: inclusionAI/Ling-mini-2.0
+  split: train
+  seq_length: 2048
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  shuffle: true
+  num_workers: 2
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
+  tokenizer:
+    _target_: nemo_automodel._transformers.auto_tokenizer.NeMoAutoTokenizer.from_pretrained
+    pretrained_model_name_or_path: inclusionAI/Ling-mini-2.0
+  split: validation
+  seq_length: 2048
+  num_samples_limit: 128
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  num_workers: 2
+
+optimizer:
+  _target_: torch.optim.AdamW
+  lr: 1.0e-4
+  weight_decay: 0.01
+  betas: [0.9, 0.95]
+  eps: 1e-8

--- a/examples/llm_finetune/ling/ling_mini_2_0_squad.yaml
+++ b/examples/llm_finetune/ling/ling_mini_2_0_squad.yaml
@@ -2,12 +2,13 @@
 # ------------------------------------------------------------------------------------------------
 # Ling-mini-2.0 (BailingMoeV2: 16B total / 1.43B activated) LoRA SFT on SQuAD.
 # ------------------------------------------------------------------------------------------------
-# Hardware: one H100/A100 80GB is enough for LoRA at local_batch_size=4 with bf16.
-# For multi-GPU expert parallelism, set distributed.ep_size to the GPU count.
+# Hardware: tested on 4x H100 80GB with FSDP2; LoRA + activation checkpointing
+# keeps per-rank memory under 25 GB.  For more / fewer GPUs, only adjust
+# --nproc-per-node; the YAML's per-rank fields stay the same.
 # ------------------------------------------------------------------------------------------------
 #
 # To run:
-#   automodel examples/llm_finetune/ling/ling_mini_2_0_squad.yaml --nproc-per-node 1
+#   automodel examples/llm_finetune/ling/ling_mini_2_0_squad.yaml --nproc-per-node 4
 #
 # Architecture notes for BailingMoeV2 (shared by Ling-mini / -flash / -1T):
 #   - GQA attention (16 / 4 heads on mini) with per-head QK-RMSNorm.
@@ -41,7 +42,7 @@ model:
   torch_dtype: bfloat16
   backend:
     _target_: nemo_automodel.components.models.common.BackendConfig
-    attn: te
+    attn: sdpa
     linear: torch
     rms_norm: torch_fp32
     experts: torch_mm
@@ -50,7 +51,7 @@ model:
 
 peft:
   _target_: nemo_automodel.components._peft.lora.PeftConfig
-  target_modules: ["*_proj"]
+  target_modules: '*_proj'
   dim: 16
   alpha: 32
   dropout: 0.0
@@ -66,7 +67,11 @@ distributed:
   tp_size: 1
   cp_size: 1
   pp_size: 1
-  ep_size: 1
+  # ep_size must match --nproc-per-node (the framework's HF state-dict adapter
+  # for grouped MoE experts requires an `ep` mesh dimension to split sharded
+  # expert tensors back into per-expert HF tensors).  Override from the CLI
+  # if your GPU count differs from the recommended 4.
+  ep_size: 4
   sequence_parallel: false
   activation_checkpointing: true
 
@@ -75,9 +80,7 @@ loss_fn:
 
 dataset:
   _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
-  tokenizer:
-    _target_: nemo_automodel._transformers.auto_tokenizer.NeMoAutoTokenizer.from_pretrained
-    pretrained_model_name_or_path: inclusionAI/Ling-mini-2.0
+  dataset_name: rajpurkar/squad
   split: train
   seq_length: 2048
 
@@ -89,12 +92,10 @@ dataloader:
 
 validation_dataset:
   _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
-  tokenizer:
-    _target_: nemo_automodel._transformers.auto_tokenizer.NeMoAutoTokenizer.from_pretrained
-    pretrained_model_name_or_path: inclusionAI/Ling-mini-2.0
+  dataset_name: rajpurkar/squad
   split: validation
   seq_length: 2048
-  num_samples_limit: 128
+  limit_dataset_samples: 128
 
 validation_dataloader:
   _target_: torchdata.stateful_dataloader.StatefulDataLoader
@@ -107,3 +108,7 @@ optimizer:
   weight_decay: 0.01
   betas: [0.9, 0.95]
   eps: 1e-8
+
+lr_scheduler:
+  lr_decay_style: cosine
+  min_lr: 1.0e-6

--- a/nemo_automodel/_transformers/registry.py
+++ b/nemo_automodel/_transformers/registry.py
@@ -36,6 +36,10 @@ MODEL_ARCH_MAPPING = OrderedDict(
             ("nemo_automodel.components.models.baichuan.model", "BaichuanForCausalLM"),
         ),
         (
+            "BailingMoeV2ForCausalLM",
+            ("nemo_automodel.components.models.ling_v2.model", "BailingMoeV2ForCausalLM"),
+        ),
+        (
             "DeepseekV3ForCausalLM",
             ("nemo_automodel.components.models.deepseek_v3.model", "DeepseekV3ForCausalLM"),
         ),
@@ -200,6 +204,7 @@ MODEL_ARCH_MAPPING = OrderedDict(
 # AutoConfig.from_pretrained can resolve them without trust_remote_code.
 _CUSTOM_CONFIG_REGISTRATIONS: Dict[str, Tuple[str, str]] = {
     "baichuan": ("nemo_automodel.components.models.baichuan.configuration", "BaichuanConfig"),
+    "bailing_moe": ("nemo_automodel.components.models.ling_v2.config", "BailingMoeV2Config"),
     "deepseek_v4": ("nemo_automodel.components.models.deepseek_v4.config", "DeepseekV4Config"),
     "hy_v3": ("nemo_automodel.components.models.hy_v3.config", "HYV3Config"),
     "kimi_k25": ("nemo_automodel.components.models.kimi_k25_vl.model", "KimiK25VLConfig"),

--- a/nemo_automodel/components/models/ling_v2/__init__.py
+++ b/nemo_automodel/components/models/ling_v2/__init__.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nemo_automodel.components.models.ling_v2.config import BailingMoeV2Config
+from nemo_automodel.components.models.ling_v2.model import BailingMoeV2ForCausalLM
+
+__all__ = ["BailingMoeV2Config", "BailingMoeV2ForCausalLM"]

--- a/nemo_automodel/components/models/ling_v2/config.py
+++ b/nemo_automodel/components/models/ling_v2/config.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Configuration for BailingMoeV2 (Ling 2.0 family: Ling-mini, Ling-flash, Ling-1T).
+
+Mirrors the ``BailingMoeV2Config`` shipped in the official HuggingFace checkpoints'
+``configuration_bailing_moe_v2.py``.  Registered against ``AutoConfig`` so that
+``AutoConfig.from_pretrained(...)`` resolves without ``trust_remote_code``.
+"""
+
+from transformers.configuration_utils import PretrainedConfig
+
+
+class BailingMoeV2Config(PretrainedConfig):
+    """Configuration class for the BailingMoeV2 model (Ling 2.0).
+
+    The defaults reflect the ``Ling-mini-2.0`` (16B-A1.4B) variant.  Larger
+    variants (``Ling-flash-2.0`` 100B-A6B and ``Ling-1T`` 1T-A50B) override
+    sizing knobs but share the same architecture: GQA attention with per-head
+    QK-RMSNorm, partial RoPE, sigmoid-routed grouped MoE with shared experts,
+    and ``first_k_dense_replace`` dense MLP layers at the start.
+    """
+
+    model_type = "bailing_moe"
+    keys_to_ignore_at_inference = ["past_key_values"]
+
+    def __init__(
+        self,
+        vocab_size: int = 157184,
+        hidden_size: int = 2048,
+        intermediate_size: int = 5120,
+        num_hidden_layers: int = 20,
+        num_attention_heads: int = 16,
+        num_key_value_heads: int = 4,
+        hidden_act: str = "silu",
+        use_qkv_bias: bool = False,
+        use_bias: bool = False,
+        rms_norm_eps: float = 1e-06,
+        tie_word_embeddings: bool = False,
+        embedding_dropout: float = 0.0,
+        attention_dropout: float = 0.0,
+        output_dropout: float = 0.0,
+        initializer_range: float = 0.02,
+        max_position_embeddings: int = 32768,
+        rope_theta: float = 600000.0,
+        use_cache: bool = True,
+        max_window_layers: int = 20,
+        rope_scaling: dict | None = None,
+        pad_token_id: int = 156892,
+        eos_token_id: int = 156892,
+        num_experts: int = 256,
+        num_shared_experts: int = 1,
+        num_experts_per_tok: int = 8,
+        n_group: int = 8,
+        topk_group: int = 4,
+        moe_intermediate_size: int = 512,
+        first_k_dense_replace: int = 1,
+        head_dim: int = 128,
+        output_router_logits: bool = False,
+        use_qk_norm: bool = True,
+        partial_rotary_factor: float = 1.0,
+        num_nextn_predict_layers: int = 0,
+        mtp_loss_scaling_factor: float = 0,
+        moe_router_enable_expert_bias: bool = True,
+        routed_scaling_factor: float = 1.0,
+        norm_topk_prob: bool = True,
+        score_function: str = "sigmoid",
+        rotary_dim: int | None = None,
+        **kwargs,
+    ):
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.num_key_value_heads = num_key_value_heads
+        self.hidden_act = hidden_act
+        self.use_qkv_bias = use_qkv_bias
+        self.use_bias = use_bias
+        self.rms_norm_eps = rms_norm_eps
+        self.embedding_dropout = embedding_dropout
+        self.attention_dropout = attention_dropout
+        self.output_dropout = output_dropout
+        self.initializer_range = initializer_range
+        self.max_position_embeddings = max_position_embeddings
+        self.rope_theta = rope_theta
+        self.use_cache = use_cache
+        self.max_window_layers = max_window_layers
+        self.rope_scaling = rope_scaling
+        self.head_dim = head_dim or (hidden_size // num_attention_heads)
+        self.use_qk_norm = use_qk_norm
+
+        # The Ling 2.0 checkpoints disagree on how to express half-RoPE.  Mini
+        # and Flash set ``partial_rotary_factor`` (e.g. 0.5); Ling-1T omits it
+        # and uses an explicit ``rotary_dim`` field instead (e.g. 64 with
+        # head_dim=128 is also a 0.5 factor).  Prefer the explicit ``rotary_dim``
+        # when it is present so that the two layouts produce the same rope_dim.
+        if rotary_dim is not None and rotary_dim > 0:
+            partial_rotary_factor = float(rotary_dim) / float(self.head_dim)
+        self.partial_rotary_factor = partial_rotary_factor
+        self.rotary_dim = rotary_dim
+
+        # MoE
+        self.num_experts = num_experts
+        self.num_shared_experts = num_shared_experts
+        self.num_experts_per_tok = num_experts_per_tok
+        self.n_group = n_group
+        self.topk_group = topk_group
+        self.moe_intermediate_size = moe_intermediate_size
+        self.first_k_dense_replace = first_k_dense_replace
+        self.output_router_logits = output_router_logits
+        self.moe_router_enable_expert_bias = moe_router_enable_expert_bias
+        self.routed_scaling_factor = routed_scaling_factor
+        self.norm_topk_prob = norm_topk_prob
+        self.score_function = score_function
+
+        # MTP (disabled in all published Ling 2.0 checkpoints; reserved)
+        self.num_nextn_predict_layers = num_nextn_predict_layers
+        self.mtp_loss_scaling_factor = mtp_loss_scaling_factor
+
+        super().__init__(
+            pad_token_id=pad_token_id,
+            eos_token_id=eos_token_id,
+            tie_word_embeddings=tie_word_embeddings,
+            **kwargs,
+        )

--- a/nemo_automodel/components/models/ling_v2/layers.py
+++ b/nemo_automodel/components/models/ling_v2/layers.py
@@ -1,0 +1,161 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Attention layer for BailingMoeV2 (Ling 2.0).
+
+GQA + per-head QK-RMSNorm + partial RoPE.  Equivalent to Qwen3-MoE attention
+with an additional ``partial_rotary_factor`` knob that rotates only the first
+``head_dim * partial_rotary_factor`` channels and passes the rest through
+(GPT-J / GPT-NeoX half-RoPE).
+"""
+
+from typing import Any
+
+import torch
+from torch import nn
+
+from nemo_automodel.components.attention.utils import (
+    initialize_attn_module_and_func,
+    postprocess_output_for_attn,
+    preprocess_args_and_kwargs_for_attn,
+)
+from nemo_automodel.components.models.common import (
+    BackendConfig,
+    initialize_linear_module,
+    initialize_rms_norm_module,
+)
+from nemo_automodel.components.models.gpt_oss.rope_utils import apply_rotary_emb_qk
+
+
+class BailingMoeV2Attention(nn.Module):
+    """Bailing MoE V2 attention block.
+
+    Shapes:
+      - Input ``x``: ``[B, S, H]`` (or ``[T, H]`` in THD format).
+      - Projections:
+          ``q``: ``[B, S, n_heads, head_dim]``
+          ``k, v``: ``[B, S, n_kv_heads, head_dim]``
+      - Output: ``[B, S, H]``.
+    """
+
+    def __init__(self, config, backend: BackendConfig):
+        super().__init__()
+        self.backend = backend
+
+        self.num_heads = config.num_attention_heads
+        self.num_kv_heads = config.num_key_value_heads
+        self.head_dim = getattr(config, "head_dim", None) or (config.hidden_size // self.num_heads)
+        self.use_qk_norm = bool(getattr(config, "use_qk_norm", False))
+
+        attention_bias = bool(getattr(config, "use_qkv_bias", False))
+        out_bias = bool(getattr(config, "use_bias", False))
+
+        # Separate q / k / v projections.  HF Bailing fuses them into a single
+        # ``query_key_value`` linear; the state_dict adapter splits that fused
+        # tensor at load time so this module can stay aligned with the rest of
+        # the framework (and with TP plans that expect separate q/k/v).
+        self.q_proj = initialize_linear_module(
+            backend.linear, config.hidden_size, self.num_heads * self.head_dim, attention_bias
+        )
+        self.k_proj = initialize_linear_module(
+            backend.linear, config.hidden_size, self.num_kv_heads * self.head_dim, attention_bias
+        )
+        self.v_proj = initialize_linear_module(
+            backend.linear, config.hidden_size, self.num_kv_heads * self.head_dim, attention_bias
+        )
+        self.o_proj = initialize_linear_module(
+            backend.linear, self.num_heads * self.head_dim, config.hidden_size, out_bias
+        )
+
+        if self.use_qk_norm:
+            self.q_norm = initialize_rms_norm_module(backend.rms_norm, self.head_dim, eps=config.rms_norm_eps)
+            self.k_norm = initialize_rms_norm_module(backend.rms_norm, self.head_dim, eps=config.rms_norm_eps)
+        else:
+            self.q_norm = None
+            self.k_norm = None
+
+        softmax_scale = self.head_dim**-0.5
+        self.attn_module, self.attn_func = initialize_attn_module_and_func(
+            attn_impl=backend.attn,
+            num_attention_heads=self.num_heads,
+            num_qk_channels=self.head_dim,
+            num_v_channels=self.head_dim,
+            softmax_scale=softmax_scale,
+            num_gqa_groups=self.num_kv_heads,
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        *,
+        freqs_cis: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        **attn_kwargs: Any,
+    ) -> torch.Tensor:
+        if len(x.shape) == 2:
+            qkv_format = "thd"
+            num_tokens = x.shape[0]
+        else:
+            qkv_format = "bshd"
+            bsz, seqlen, _ = x.size()
+
+        q = self.q_proj(x)
+        k = self.k_proj(x)
+        v = self.v_proj(x)
+
+        if qkv_format == "thd":
+            q = q.view(num_tokens, self.num_heads, self.head_dim)
+            k = k.view(num_tokens, self.num_kv_heads, self.head_dim)
+            v = v.view(num_tokens, self.num_kv_heads, self.head_dim)
+        else:
+            q = q.view(bsz, seqlen, self.num_heads, self.head_dim)
+            k = k.view(bsz, seqlen, self.num_kv_heads, self.head_dim)
+            v = v.view(bsz, seqlen, self.num_kv_heads, self.head_dim)
+
+        if self.use_qk_norm:
+            q = self.q_norm(q)
+            k = self.k_norm(k)
+
+        # ``freqs_cis`` is shaped for the rotary half (``rotary_dim``) when
+        # ``partial_rotary_factor < 1``; ``apply_rotary_emb_qk`` -> ``apply_rotary_emb``
+        # detects that and only rotates the first ``rotary_dim`` channels of each head.
+        q, k = apply_rotary_emb_qk(
+            q,
+            k,
+            freqs_cis,
+            format=qkv_format,
+            rope_fusion=self.backend.rope_fusion,
+            cu_seqlens=attn_kwargs.get("cu_seqlens", None),
+            cp_size=attn_kwargs.get("cp_size", 1),
+            cp_rank=attn_kwargs.get("cp_rank", 0),
+        )
+
+        q, k, v, _attn_kwargs = preprocess_args_and_kwargs_for_attn(
+            q, k, v, attention_mask, self.backend.attn, **attn_kwargs
+        )
+        out = self.attn_func(q, k, v, **_attn_kwargs)
+        out = postprocess_output_for_attn(out, self.backend.attn)
+
+        flatten_dim = 2 if qkv_format == "bshd" else 1
+        out = self.o_proj(out.flatten(flatten_dim))
+        return out
+
+    def init_weights(self, buffer_device: torch.device, init_std: float = 0.02) -> None:
+        for linear in (self.q_proj, self.k_proj, self.v_proj, self.o_proj):
+            nn.init.trunc_normal_(linear.weight, mean=0.0, std=init_std)
+            if getattr(linear, "bias", None) is not None:
+                nn.init.zeros_(linear.bias)
+        if self.use_qk_norm:
+            self.q_norm.reset_parameters()
+            self.k_norm.reset_parameters()

--- a/nemo_automodel/components/models/ling_v2/model.py
+++ b/nemo_automodel/components/models/ling_v2/model.py
@@ -266,6 +266,16 @@ class BailingMoeV2ForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin)
     # model is bf16; tiny quantization errors in the bias change routing.
     _keep_in_fp32_modules_strict = ["e_score_correction_bias"]
 
+    # PP compatibility: our forward computes ``freqs_cis`` inline and threads it
+    # through the decoder blocks (gpt_oss-style rotary convention).  The generic
+    # ``patch_hf_model_for_pp`` would replace our forward with an HF-style one
+    # that calls ``self.model.rotary_emb(hidden_states, position_ids)`` expecting
+    # a ``(cos, sin)`` return — that signature mismatches our
+    # ``RotaryEmbedding.forward(query, key)`` and crashes inside
+    # ``apply_rotary_emb`` with a tensor-shape mismatch at ``torch.cat``.
+    # Setting this flag instructs the PP split to leave our forwards intact.
+    _pp_keep_self_forward: bool = True
+
     @classmethod
     def from_config(
         cls,

--- a/nemo_automodel/components/models/ling_v2/model.py
+++ b/nemo_automodel/components/models/ling_v2/model.py
@@ -1,0 +1,383 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""BailingMoeV2 model (Ling 2.0 family).
+
+Architecture summary (from the public ``inclusionAI/Ling-{mini,flash,1T}-2.0``
+checkpoints):
+
+- GQA attention with per-head QK-RMSNorm and partial RoPE
+  (rotates the first ``head_dim * partial_rotary_factor`` channels only).
+- ``first_k_dense_replace`` dense MLP layers at the start of the stack;
+  the remaining layers are sigmoid-routed grouped MoE with shared experts
+  and an aux-loss-free per-expert bias (DeepSeek-V3-style routing).
+- Single shared expert with intermediate size ``moe_intermediate_size``.
+- MTP heads (``num_nextn_predict_layers``) are disabled in all published
+  checkpoints and intentionally not modeled here.
+
+Example (YAML):
+
+```yaml
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: inclusionAI/Ling-mini-2.0
+```
+"""
+
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from nemo_automodel.components.models.common import (
+    BackendConfig,
+    initialize_linear_module,
+    initialize_rms_norm_module,
+)
+from nemo_automodel.components.models.common.hf_checkpointing_mixin import HFCheckpointingMixin
+from nemo_automodel.components.models.common.utils import cast_model_to_dtype
+from nemo_automodel.components.models.gpt_oss.rope_utils import RotaryEmbedding, position_ids_to_freqs_cis
+from nemo_automodel.components.models.ling_v2.config import BailingMoeV2Config
+from nemo_automodel.components.models.ling_v2.layers import BailingMoeV2Attention
+from nemo_automodel.components.models.ling_v2.state_dict_adapter import BailingMoeV2StateDictAdapter
+from nemo_automodel.components.moe.config import MoEConfig
+from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
+from nemo_automodel.components.moe.layers import MLP, MoE
+from nemo_automodel.components.utils.model_utils import squeeze_input_for_thd
+from nemo_automodel.shared.utils import dtype_from_str as get_dtype
+
+
+class Block(nn.Module):
+    """Single transformer block: attention + (dense MLP or MoE) + residuals."""
+
+    def __init__(
+        self,
+        layer_idx: int,
+        config: BailingMoeV2Config,
+        moe_config: MoEConfig,
+        backend: BackendConfig,
+    ):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.self_attn = BailingMoeV2Attention(config, backend)
+
+        if layer_idx < config.first_k_dense_replace:
+            self.mlp = MLP(config.hidden_size, config.intermediate_size, backend.linear)
+        else:
+            self.mlp = MoE(moe_config, backend)
+
+        self.input_layernorm = initialize_rms_norm_module(backend.rms_norm, config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = initialize_rms_norm_module(
+            backend.rms_norm, config.hidden_size, eps=config.rms_norm_eps
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        *,
+        freqs_cis: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        padding_mask: torch.Tensor | None = None,
+        **attn_kwargs: Any,
+    ) -> torch.Tensor:
+        if attention_mask is not None and padding_mask is None:
+            padding_mask = attention_mask.bool().logical_not()
+
+        attn_out = self.self_attn(
+            x=self.input_layernorm(x),
+            freqs_cis=freqs_cis,
+            attention_mask=attention_mask,
+            **attn_kwargs,
+        )
+        x = x + attn_out
+
+        mlp_out = self._mlp(x=self.post_attention_layernorm(x), padding_mask=padding_mask)
+        x = x + mlp_out
+        return x
+
+    def _mlp(self, x: torch.Tensor, padding_mask: torch.Tensor | None) -> torch.Tensor:
+        if isinstance(self.mlp, MLP):
+            return self.mlp(x)
+        assert isinstance(self.mlp, MoE)
+        return self.mlp(x, padding_mask)
+
+    def init_weights(self, buffer_device: torch.device) -> None:
+        for norm in (self.input_layernorm, self.post_attention_layernorm):
+            norm.reset_parameters()
+        self.self_attn.init_weights(buffer_device)
+        self.mlp.init_weights(buffer_device)
+
+
+class BailingMoeV2Model(nn.Module):
+    """Embedding + decoder stack + final norm.  No LM head."""
+
+    def __init__(
+        self,
+        config: BailingMoeV2Config,
+        backend: BackendConfig,
+        *,
+        moe_config: MoEConfig | None = None,
+        moe_overrides: dict | None = None,
+    ):
+        super().__init__()
+        self.backend = backend
+        self.config = config
+
+        if moe_config is not None and moe_overrides is not None:
+            raise ValueError("Cannot pass both moe_config and moe_overrides; use one or the other.")
+
+        # MoE wiring: DeepSeek-V3-style sigmoid + grouped topk + per-expert bias
+        # + shared expert.  The framework's ``Gate`` (score_func='sigmoid', n_groups>1,
+        # force_e_score_correction_bias=True) is bit-equivalent to BailingMoeV2Gate.
+        moe_defaults = dict(
+            dim=config.hidden_size,
+            inter_dim=config.intermediate_size,
+            moe_inter_dim=config.moe_intermediate_size,
+            n_routed_experts=config.num_experts,
+            n_shared_experts=config.num_shared_experts,
+            n_activated_experts=config.num_experts_per_tok,
+            n_expert_groups=config.n_group,
+            n_limited_groups=config.topk_group,
+            train_gate=True,
+            # Aux-loss-free routing: bias buffer is loaded from the HF checkpoint
+            # but not updated by SFT (set to >0 to enable DeepSeek-V3-style bias
+            # auto-tuning during pretraining).
+            gate_bias_update_factor=0.0,
+            force_e_score_correction_bias=bool(config.moe_router_enable_expert_bias),
+            score_func=config.score_function,
+            route_scale=config.routed_scaling_factor,
+            aux_loss_coeff=0.0,
+            norm_topk_prob=config.norm_topk_prob,
+            expert_bias=False,
+            router_bias=False,
+            expert_activation="swiglu",
+            shared_expert_inter_dim=config.moe_intermediate_size,
+            shared_expert_activation="swiglu",
+            softmax_before_topk=False,
+        )
+        if moe_overrides:
+            moe_defaults.update(moe_overrides)
+        self.moe_config = moe_config or MoEConfig(**moe_defaults)
+
+        self.embed_tokens = nn.Embedding(
+            config.vocab_size, config.hidden_size, dtype=get_dtype(config.torch_dtype, torch.bfloat16)
+        )
+        self.layers = torch.nn.ModuleDict()
+        for layer_id in range(config.num_hidden_layers):
+            self.layers[str(layer_id)] = Block(layer_id, config, self.moe_config, backend)
+        self.norm = initialize_rms_norm_module(backend.rms_norm, config.hidden_size, eps=config.rms_norm_eps)
+
+        self.max_seq_len = config.max_position_embeddings
+        self.head_dim = config.head_dim
+        rope_scaling = getattr(config, "rope_scaling", None) or {}
+
+        self.rotary_emb = RotaryEmbedding(
+            head_dim=self.head_dim,
+            base=int(config.rope_theta),
+            dtype=torch.float32,
+            initial_context_length=rope_scaling.get("original_max_position_embeddings", config.max_position_embeddings),
+            scaling_factor=rope_scaling.get("factor", 1.0),
+            ntk_alpha=rope_scaling.get("beta_slow", 1.0),
+            ntk_beta=rope_scaling.get("beta_fast", 32.0),
+            partial_rotary_factor=float(getattr(config, "partial_rotary_factor", 1.0)),
+            device=torch.device(f"cuda:{torch.cuda.current_device()}") if torch.cuda.is_available() else None,
+        )
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None = None,
+        *,
+        inputs_embeds: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        padding_mask: torch.Tensor | None = None,
+        **attn_kwargs: Any,
+    ) -> torch.Tensor:
+        if (input_ids is None) == (inputs_embeds is None):
+            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids) if self.embed_tokens is not None else input_ids
+
+        if position_ids is None:
+            seq_len = inputs_embeds.shape[1]
+            position_ids = (
+                torch.arange(seq_len, device=inputs_embeds.device).unsqueeze(0).expand(inputs_embeds.shape[0], -1)
+            )
+
+        freqs_cis = position_ids_to_freqs_cis(
+            self.rotary_emb,
+            position_ids,
+            qkv_format=attn_kwargs.get("qkv_format", "bshd"),
+            for_fused_rope=self.backend.rope_fusion,
+            cp_size=attn_kwargs.get("cp_size", 1),
+        )
+
+        h = inputs_embeds
+        for layer in self.layers.values():
+            h = layer(
+                x=h,
+                freqs_cis=freqs_cis,
+                attention_mask=attention_mask,
+                padding_mask=padding_mask,
+                **attn_kwargs,
+            )
+
+        h = self.norm(h) if self.norm else h
+        return h
+
+    def update_moe_gate_bias(self) -> None:
+        """No-op for SFT; published Ling checkpoints freeze the expert_bias buffer."""
+        with torch.no_grad():
+            for _, block in self.layers.named_children():
+                if isinstance(block.mlp, MoE) and block.mlp.gate.bias_update_factor > 0:
+                    block.mlp.gate.update_bias()
+
+    @torch.no_grad()
+    def init_weights(self, buffer_device: torch.device | None = None) -> None:
+        buffer_device = buffer_device or torch.device(f"cuda:{torch.cuda.current_device()}")
+        with buffer_device:
+            if self.embed_tokens is not None:
+                nn.init.normal_(self.embed_tokens.weight)
+            if self.norm is not None:
+                self.norm.reset_parameters()
+            self.rotary_emb.device = buffer_device
+
+        for layer in self.layers.values():
+            if layer is not None:
+                layer.init_weights(buffer_device=buffer_device)
+
+
+class BailingMoeV2ForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
+    """Causal-LM head wrapping ``BailingMoeV2Model``."""
+
+    # ``e_score_correction_bias`` must stay in fp32 even when the rest of the
+    # model is bf16; tiny quantization errors in the bias change routing.
+    _keep_in_fp32_modules_strict = ["e_score_correction_bias"]
+
+    @classmethod
+    def from_config(
+        cls,
+        config: BailingMoeV2Config,
+        moe_config: MoEConfig | None = None,
+        backend: BackendConfig | None = None,
+        **kwargs,
+    ):
+        return cls(config, moe_config, backend, **kwargs)
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str,
+        *model_args,
+        **kwargs,
+    ):
+        config = BailingMoeV2Config.from_pretrained(pretrained_model_name_or_path)
+        return cls.from_config(config, *model_args, **kwargs)
+
+    def __init__(
+        self,
+        config: BailingMoeV2Config,
+        moe_config: MoEConfig | None = None,
+        backend: BackendConfig | None = None,
+        **kwargs,
+    ):
+        super().__init__()
+        self.config = config
+        self.backend = backend or BackendConfig()
+        moe_overrides = kwargs.pop("moe_overrides", None)
+        self.model = BailingMoeV2Model(
+            config,
+            backend=self.backend,
+            moe_config=moe_config,
+            moe_overrides=moe_overrides,
+        )
+        self.lm_head = initialize_linear_module(self.backend.linear, config.hidden_size, config.vocab_size, bias=False)
+        if self.backend.enable_hf_state_dict_adapter:
+            self.state_dict_adapter = BailingMoeV2StateDictAdapter(
+                self.config,
+                self.model.moe_config,
+                self.backend,
+                dtype=get_dtype(config.torch_dtype, torch.bfloat16),
+            )
+
+    def get_input_embeddings(self):
+        return self.model.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.model.embed_tokens = value
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def set_output_embeddings(self, new_embeddings):
+        self.lm_head = new_embeddings
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        *,
+        position_ids: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        padding_mask: torch.Tensor | None = None,
+        **attn_kwargs: Any,
+    ) -> torch.Tensor:
+        if "qkv_format" in attn_kwargs and attn_kwargs["qkv_format"] == "thd":
+            input_ids, position_ids, padding_mask, attn_kwargs = squeeze_input_for_thd(
+                input_ids, position_ids, padding_mask, attn_kwargs
+            )
+            attention_mask = None
+
+        hidden = self.model(
+            input_ids,
+            position_ids=position_ids,
+            attention_mask=attention_mask,
+            padding_mask=padding_mask,
+            **attn_kwargs,
+        )
+        logits = self.lm_head(hidden) if self.lm_head else hidden
+        if "qkv_format" in attn_kwargs and attn_kwargs["qkv_format"] == "thd":
+            logits = logits.unsqueeze(0)
+        return logits
+
+    def update_moe_gate_bias(self) -> None:
+        with torch.no_grad():
+            for _, block in self.model.layers.named_children():
+                if isinstance(block.mlp, MoE) and block.mlp.gate.bias_update_factor > 0:
+                    block.mlp.gate.update_bias()
+
+    @torch.no_grad()
+    def initialize_weights(
+        self, buffer_device: torch.device | None = None, dtype: torch.dtype = torch.bfloat16
+    ) -> None:
+        buffer_device = buffer_device or torch.device(f"cuda:{torch.cuda.current_device()}")
+        with buffer_device:
+            self.model.init_weights(buffer_device=buffer_device)
+            final_out_std = self.config.hidden_size**-0.5
+            cutoff_factor = 3
+            if self.lm_head is not None:
+                nn.init.trunc_normal_(
+                    self.lm_head.weight,
+                    mean=0.0,
+                    std=final_out_std,
+                    a=-cutoff_factor * final_out_std,
+                    b=cutoff_factor * final_out_std,
+                )
+
+        cast_model_to_dtype(self, dtype)
+        with buffer_device:
+            self.model.rotary_emb.device = buffer_device
+
+
+ModelClass = BailingMoeV2ForCausalLM

--- a/nemo_automodel/components/models/ling_v2/state_dict_adapter.py
+++ b/nemo_automodel/components/models/ling_v2/state_dict_adapter.py
@@ -1,0 +1,208 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""HF <-> NeMo state-dict adapter for BailingMoeV2 (Ling 2.0).
+
+Handles the rename map between the HuggingFace checkpoint layout
+
+    model.word_embeddings.weight
+    model.layers.{N}.attention.query_key_value.weight      # fused [Q | K | V]
+    model.layers.{N}.attention.dense.weight
+    model.layers.{N}.attention.query_layernorm.weight
+    model.layers.{N}.attention.key_layernorm.weight
+    model.layers.{N}.mlp.gate.weight
+    model.layers.{N}.mlp.gate.expert_bias
+    model.layers.{N}.mlp.experts.{E}.{gate_proj,up_proj,down_proj}.weight
+    model.layers.{N}.mlp.shared_experts.{gate_proj,up_proj,down_proj}.weight
+
+and the native NeMo layout used by this package
+
+    model.embed_tokens.weight
+    model.layers.{N}.self_attn.{q_proj,k_proj,v_proj,o_proj}.weight
+    model.layers.{N}.self_attn.{q_norm,k_norm}.weight
+    model.layers.{N}.mlp.gate.weight
+    model.layers.{N}.mlp.gate.e_score_correction_bias
+    model.layers.{N}.mlp.experts.{gate_and_up_projs,down_projs}
+    model.layers.{N}.mlp.shared_experts.{gate_proj,up_proj,down_proj}.weight
+
+The per-expert grouping is delegated to ``MoESplitExpertsStateDictMixin``; this
+adapter only normalises the surrounding key names and splits the fused QKV.
+"""
+
+import re
+from typing import Any, Optional
+
+import torch
+from torch.distributed.device_mesh import DeviceMesh
+
+from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.models.ling_v2.config import BailingMoeV2Config
+from nemo_automodel.components.moe.config import MoEConfig
+from nemo_automodel.components.moe.state_dict_mixin import MoESplitExpertsStateDictMixin
+
+# Map of single-key renames applied in both directions.  Each tuple is
+# (HF substring, native substring); replacement is whole-substring and
+# stops after the first match.
+_RENAME_PAIRS_HF_TO_NATIVE: tuple[tuple[str, str], ...] = (
+    ("model.word_embeddings.", "model.embed_tokens."),
+    (".attention.dense.", ".self_attn.o_proj."),
+    (".attention.query_layernorm.", ".self_attn.q_norm."),
+    (".attention.key_layernorm.", ".self_attn.k_norm."),
+    (".mlp.gate.expert_bias", ".mlp.gate.e_score_correction_bias"),
+)
+
+_LAYER_QKV_RE = re.compile(r"^(?P<prefix>(?:.*\.)?layers\.\d+)\.attention\.query_key_value\.weight$")
+
+
+def _rename_hf_to_native(key: str) -> str:
+    for hf, native in _RENAME_PAIRS_HF_TO_NATIVE:
+        if hf in key:
+            return key.replace(hf, native)
+    return key
+
+
+def _rename_native_to_hf(key: str) -> str:
+    # Reverse renames; order matters only for the expert_bias rule which is
+    # the longest match and applied first to avoid the substring overlap with
+    # ".mlp.gate.weight".
+    for hf, native in _RENAME_PAIRS_HF_TO_NATIVE:
+        if native in key:
+            return key.replace(native, hf)
+    return key
+
+
+class BailingMoeV2StateDictAdapter(MoESplitExpertsStateDictMixin, StateDictAdapter):
+    """State-dict adapter for BailingMoeV2 / Ling 2.0 checkpoints."""
+
+    def __init__(
+        self,
+        config: BailingMoeV2Config,
+        moe_config: MoEConfig,
+        backend: BackendConfig,
+        dtype: torch.dtype = torch.bfloat16,
+    ):
+        self.config = config
+        self.moe_config = moe_config
+        self.backend = backend
+        self.dtype = dtype
+        self._uses_model_prefix = True
+
+    # ---- HF -> native ----------------------------------------------------
+
+    def from_hf(
+        self,
+        hf_state_dict: dict[str, Any],
+        device_mesh: Optional["DeviceMesh"] = None,
+        **kwargs,
+    ) -> dict[str, Any]:
+        for key in hf_state_dict.keys():
+            if ".mlp.experts." in key and key.endswith(".weight"):
+                self._uses_model_prefix = key.startswith("model.")
+                break
+
+        renamed = self._split_fused_qkv_and_rename(hf_state_dict)
+        return self._from_hf_w_merged_experts(renamed, device_mesh)
+
+    def _split_fused_qkv_and_rename(self, hf_state_dict: dict[str, Any]) -> dict[str, Any]:
+        """Split each fused ``query_key_value`` weight into q/k/v and apply renames."""
+        out: dict[str, Any] = {}
+        num_heads = self.config.num_attention_heads
+        num_kv_heads = self.config.num_key_value_heads
+        head_dim = self.config.head_dim
+        q_size = num_heads * head_dim
+        kv_size = num_kv_heads * head_dim
+
+        for key, tensor in hf_state_dict.items():
+            m = _LAYER_QKV_RE.match(key)
+            if m:
+                expected = q_size + 2 * kv_size
+                if tensor.shape[0] != expected:
+                    raise ValueError(
+                        f"Fused qkv weight {key} has shape[0]={tensor.shape[0]} but expected "
+                        f"{expected} = num_heads({num_heads}) * head_dim({head_dim}) + 2 * "
+                        f"num_kv_heads({num_kv_heads}) * head_dim({head_dim})."
+                    )
+                q, k, v = torch.split(tensor, [q_size, kv_size, kv_size], dim=0)
+                prefix = m.group("prefix")
+                out[f"{prefix}.self_attn.q_proj.weight"] = q.contiguous()
+                out[f"{prefix}.self_attn.k_proj.weight"] = k.contiguous()
+                out[f"{prefix}.self_attn.v_proj.weight"] = v.contiguous()
+                continue
+            out[_rename_hf_to_native(key)] = tensor
+
+        return out
+
+    # ---- native -> HF ----------------------------------------------------
+
+    def to_hf(
+        self,
+        state_dict: dict[str, Any],
+        exclude_key_regex: Optional[str] = None,
+        quantization: bool = False,
+        **kwargs,
+    ) -> dict[str, Any]:
+        del quantization  # Bailing MoE V2 ships BF16 only; no FP8 path.
+        hf_state_dict: dict[str, Any] = {}
+
+        # Collect q/k/v per layer so we can re-fuse them.
+        pending_qkv: dict[str, dict[str, torch.Tensor]] = {}
+
+        for fqn, tensor in state_dict.items():
+            # Try expert merging first (these tensors live under .mlp.experts.*)
+            converted = self._convert_single_merged_expert_to_hf_split_experts(fqn, tensor, **kwargs)
+            if converted is not None:
+                for k, v in converted:
+                    hf_state_dict[k] = v
+                continue
+
+            m = re.match(r"^(?P<prefix>(?:.*\.)?layers\.\d+)\.self_attn\.(?P<proj>[qkv])_proj\.weight$", fqn)
+            if m:
+                pending_qkv.setdefault(m.group("prefix"), {})[m.group("proj")] = tensor
+                continue
+
+            hf_state_dict[_rename_native_to_hf(fqn)] = tensor
+
+        for prefix, parts in pending_qkv.items():
+            if {"q", "k", "v"} - parts.keys():
+                # Partial set (e.g. only one rank shard available) — drop back to per-proj keys
+                for proj, t in parts.items():
+                    hf_state_dict[f"{prefix}.attention.{proj}_proj.weight"] = t
+                continue
+            fused = torch.cat([parts["q"], parts["k"], parts["v"]], dim=0)
+            hf_state_dict[f"{prefix}.attention.query_key_value.weight"] = fused.contiguous()
+
+        if exclude_key_regex:
+            hf_state_dict = {k: v for k, v in hf_state_dict.items() if not re.search(exclude_key_regex, k)}
+
+        return hf_state_dict
+
+    def convert_single_tensor_to_hf(self, fqn: str, tensor: Any, **kwargs) -> list[tuple[str, Any]]:
+        """Convert a single native tensor to HuggingFace format.
+
+        ``q_proj`` / ``k_proj`` / ``v_proj`` tensors cannot be re-fused without
+        their two siblings; the caller should batch them through :meth:`to_hf`
+        instead.  This single-tensor path emits the per-projection HF key (which
+        is **not** the standard fused name) so that the value is not silently
+        dropped during DCP save adapters that walk tensors one-by-one.
+        """
+        converted = self._convert_single_merged_expert_to_hf_split_experts(fqn, tensor, **kwargs)
+        if converted is not None:
+            return converted
+
+        m = re.match(r"^(?P<prefix>(?:.*\.)?layers\.\d+)\.self_attn\.(?P<proj>[qkv])_proj\.weight$", fqn)
+        if m:
+            return [(f"{m.group('prefix')}.attention.{m.group('proj')}_proj.weight", tensor)]
+
+        return [(_rename_native_to_hf(fqn), tensor)]

--- a/tests/unit_tests/models/ling_v2/__init__.py
+++ b/tests/unit_tests/models/ling_v2/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/unit_tests/models/ling_v2/_real_forward_smoke.py
+++ b/tests/unit_tests/models/ling_v2/_real_forward_smoke.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Single-GPU real-checkpoint forward smoke test for BailingMoeV2.
+
+Strategy: load weights on CPU first (the framework's expert-tensor stacking
+needs ~2x peak working memory which OOMs an 80 GB GPU for the 16B-A1.4B Mini
+when load+stack happen on-device), assemble the full NeMo model in CPU RAM,
+then move to GPU for inference.  Verifies that the real checkpoint loads
+without missing/unexpected keys and that the forward pass produces finite,
+non-degenerate logits.
+
+Run inside the dev container::
+
+    cd /work && HF_HOME=/work/hf_cache python \
+        tests/unit_tests/models/ling_v2/_real_forward_smoke.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+import sys
+import time
+
+import torch
+from huggingface_hub import snapshot_download
+from safetensors.torch import load_file
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--hf-model", default="inclusionAI/Ling-mini-2.0")
+    parser.add_argument("--seq-len", type=int, default=32)
+    parser.add_argument("--out-device", default="cuda:0")
+    args = parser.parse_args(argv)
+
+    from nemo_automodel.components.models.common import BackendConfig
+    from nemo_automodel.components.models.ling_v2.config import BailingMoeV2Config
+    from nemo_automodel.components.models.ling_v2.model import BailingMoeV2ForCausalLM
+    from nemo_automodel.components.models.ling_v2.state_dict_adapter import BailingMoeV2StateDictAdapter
+    from nemo_automodel.components.moe.config import MoEConfig
+
+    t0 = time.time()
+    cfg = BailingMoeV2Config.from_pretrained(args.hf_model)
+    print(
+        f"config: hidden={cfg.hidden_size} layers={cfg.num_hidden_layers} "
+        f"experts={cfg.num_experts} first_k_dense={cfg.first_k_dense_replace} "
+        f"partial_rotary={cfg.partial_rotary_factor}"
+    )
+
+    backend = BackendConfig(
+        attn="sdpa",
+        linear="torch",
+        rms_norm="torch",
+        experts="torch",
+        dispatcher="torch",
+        enable_hf_state_dict_adapter=True,
+        rope_fusion=False,
+    )
+
+    # Construct the NeMo model directly on CPU.  We must NOT go through
+    # NeMoAutoModelForCausalLM.from_pretrained because that pulls in the full
+    # infrastructure layer (FSDP2 manager, mesh, etc.) and lands tensors on GPU
+    # early, which triggers the expert-stack OOM on a single 80 GB device.
+    print("\nbuilding empty NeMo model on CPU ...")
+    moe_cfg = MoEConfig(
+        dim=cfg.hidden_size,
+        inter_dim=cfg.intermediate_size,
+        moe_inter_dim=cfg.moe_intermediate_size,
+        n_routed_experts=cfg.num_experts,
+        n_shared_experts=cfg.num_shared_experts,
+        n_activated_experts=cfg.num_experts_per_tok,
+        n_expert_groups=cfg.n_group,
+        n_limited_groups=cfg.topk_group,
+        train_gate=True,
+        gate_bias_update_factor=0.0,
+        force_e_score_correction_bias=bool(cfg.moe_router_enable_expert_bias),
+        score_func=cfg.score_function,
+        route_scale=cfg.routed_scaling_factor,
+        aux_loss_coeff=0.0,
+        norm_topk_prob=cfg.norm_topk_prob,
+        router_bias=False,
+        expert_bias=False,
+        expert_activation="swiglu",
+        shared_expert_inter_dim=cfg.moe_intermediate_size,
+        shared_expert_activation="swiglu",
+        softmax_before_topk=False,
+        dtype=torch.bfloat16,
+    )
+    model = BailingMoeV2ForCausalLM(cfg, moe_config=moe_cfg, backend=backend)
+    model = model.to(dtype=torch.bfloat16)
+
+    n_params = sum(p.numel() for p in model.parameters())
+    print(f"model params: {n_params / 1e9:.2f} B")
+
+    print("\nloading + grouping HF safetensors ...")
+    ckpt_dir = snapshot_download(args.hf_model, allow_patterns=["*.safetensors", "*.json"])
+    shards = sorted(glob.glob(os.path.join(ckpt_dir, "*.safetensors")))
+    hf_sd: dict[str, torch.Tensor] = {}
+    for s in shards:
+        hf_sd.update(load_file(s, device="cpu"))
+    print(f"  {len(hf_sd)} HF tensors")
+
+    adapter = BailingMoeV2StateDictAdapter(cfg, moe_cfg, backend, dtype=torch.bfloat16)
+    native_sd = adapter.from_hf(hf_sd, device_mesh=None)
+    print(f"  {len(native_sd)} native tensors after grouping")
+    del hf_sd
+
+    missing, unexpected = model.load_state_dict(native_sd, strict=False)
+    print(f"  load_state_dict: missing={len(missing)} unexpected={len(unexpected)}")
+    if missing:
+        print(f"    missing example: {missing[:3]}")
+    if unexpected:
+        print(f"    unexpected example: {unexpected[:3]}")
+
+    print(f"\nmoving model to {args.out_device} ...")
+    model = model.to(args.out_device).eval()
+    print(f"GPU mem after move: {torch.cuda.memory_allocated() / 1e9:.1f} GB")
+
+    print("\nforward pass ...")
+    torch.manual_seed(0)
+    input_ids = torch.randint(0, cfg.vocab_size, (1, args.seq_len), device=args.out_device)
+    with torch.no_grad():
+        logits = model(input_ids)
+    logits = logits.float()
+
+    finite = torch.isfinite(logits).all().item()
+    log_sm = torch.log_softmax(logits, dim=-1)
+    avg_neg_log_p = -log_sm.mean().item()
+    top1 = logits.argmax(dim=-1)
+    top1_unique = top1.unique().numel()
+
+    elapsed = time.time() - t0
+    print(f"\nlogits: shape={tuple(logits.shape)} dtype={logits.dtype}")
+    print(f"  finite={finite}  avg(-log p)={avg_neg_log_p:.3f}  top1 unique={top1_unique}")
+    print(f"  argmax sample (first 10): {top1[0, :10].tolist()}")
+    print(f"\ndone in {elapsed:.1f}s")
+
+    ok = finite and missing == [] and unexpected == [] and top1_unique > 1
+    print(f"\n{'PASS' if ok else 'FAIL'}")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit_tests/models/ling_v2/parity_ling_v2.py
+++ b/tests/unit_tests/models/ling_v2/parity_ling_v2.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end parity script for BailingMoeV2 / Ling-mini-2.0.
+
+NOT a pytest test — meant to be run by hand inside a GPU container against
+the real ``inclusionAI/Ling-mini-2.0`` checkpoint.  Implements the three
+levels from ``skills/parity-testing/SKILL.md``:
+
+    Level 1  state-dict round-trip                       CPU / fp32
+    Level 2  per-component (RoPE, gate) parity           CPU / fp32
+    Level 3  full forward-pass logits parity vs HF       GPU / bf16
+
+Usage::
+
+    python tests/unit_tests/models/ling_v2/parity_ling_v2.py \
+        --hf-model inclusionAI/Ling-mini-2.0 \
+        --levels 1,2,3
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+import sys
+import time
+
+import torch
+import torch.nn.functional as F
+from huggingface_hub import snapshot_download
+from safetensors.torch import load_file
+
+
+def compare(a: torch.Tensor, b: torch.Tensor, name: str = "") -> tuple[float, float, float]:
+    a32 = a.detach().float().flatten()
+    b32 = b.detach().float().flatten()
+    max_diff = (a32 - b32).abs().max().item()
+    mean_diff = (a32 - b32).abs().mean().item()
+    cos = F.cosine_similarity(a32, b32, dim=0).item()
+    print(f"  [{name}] max={max_diff:.3e}  mean={mean_diff:.3e}  cos={cos:.7f}")
+    return max_diff, mean_diff, cos
+
+
+# -------------------------------------------------------------- Level 1
+def level1_state_dict_roundtrip(hf_model_id: str) -> bool:
+    print(f"\n=== Level 1: state-dict round-trip on {hf_model_id} (CPU/fp32) ===")
+    from nemo_automodel.components.models.common import BackendConfig
+    from nemo_automodel.components.models.ling_v2.config import BailingMoeV2Config
+    from nemo_automodel.components.moe.config import MoEConfig
+
+    cfg = BailingMoeV2Config.from_pretrained(hf_model_id)
+    print(f"  config: {cfg.num_hidden_layers} layers, {cfg.num_experts} experts, head_dim={cfg.head_dim}")
+
+    moe_cfg = MoEConfig(
+        dim=cfg.hidden_size,
+        inter_dim=cfg.intermediate_size,
+        moe_inter_dim=cfg.moe_intermediate_size,
+        n_routed_experts=cfg.num_experts,
+        n_shared_experts=cfg.num_shared_experts,
+        n_activated_experts=cfg.num_experts_per_tok,
+        n_expert_groups=cfg.n_group,
+        n_limited_groups=cfg.topk_group,
+        train_gate=True,
+        gate_bias_update_factor=0.0,
+        force_e_score_correction_bias=True,
+        score_func=cfg.score_function,
+        route_scale=cfg.routed_scaling_factor,
+        aux_loss_coeff=0.0,
+        norm_topk_prob=cfg.norm_topk_prob,
+        router_bias=False,
+        expert_bias=False,
+        expert_activation="swiglu",
+        shared_expert_inter_dim=cfg.moe_intermediate_size,
+        shared_expert_activation="swiglu",
+        softmax_before_topk=False,
+    )
+
+    backend = BackendConfig(
+        attn="sdpa",
+        linear="torch",
+        rms_norm="torch",
+        experts="torch",
+        dispatcher="torch",
+        enable_hf_state_dict_adapter=True,
+        rope_fusion=False,
+    )
+
+    from nemo_automodel.components.models.ling_v2.state_dict_adapter import BailingMoeV2StateDictAdapter
+
+    adapter = BailingMoeV2StateDictAdapter(cfg, moe_cfg, backend, dtype=torch.float32)
+
+    print("  resolving HF checkpoint files (safetensors only) ...")
+    ckpt_dir = snapshot_download(hf_model_id, allow_patterns=["*.safetensors", "*.json"])
+    shards = sorted(glob.glob(os.path.join(ckpt_dir, "*.safetensors")))
+    print(f"  loading {len(shards)} shards ...")
+    hf_sd: dict[str, torch.Tensor] = {}
+    for shard in shards:
+        # load_file returns CPU tensors in their stored dtype (bf16 for Ling).
+        # Upcast to fp32 for the round-trip equality check.
+        for k, v in load_file(shard, device="cpu").items():
+            hf_sd[k] = v.float()
+    print(f"  HF state_dict has {len(hf_sd)} keys")
+
+    print("  HF -> native ...")
+    native_sd = adapter.from_hf(hf_sd, device_mesh=None)
+    print(f"  native state_dict has {len(native_sd)} keys")
+
+    print("  native -> HF ...")
+    rt = adapter.to_hf(native_sd)
+    print(f"  round-tripped state_dict has {len(rt)} keys")
+
+    missing = set(hf_sd) - set(rt)
+    extra = set(rt) - set(hf_sd)
+    if missing:
+        print(f"  ERROR: {len(missing)} keys missing after round-trip, e.g. {sorted(missing)[:5]}")
+    if extra:
+        print(f"  ERROR: {len(extra)} extra keys after round-trip, e.g. {sorted(extra)[:5]}")
+
+    diffs = []
+    for k in sorted(set(hf_sd) & set(rt)):
+        d = (hf_sd[k].float() - rt[k].float()).abs().max().item()
+        if d > 0:
+            diffs.append((k, d))
+
+    if diffs:
+        print(f"  ERROR: {len(diffs)} tensors differ after round-trip, worst:")
+        for k, d in sorted(diffs, key=lambda kv: -kv[1])[:5]:
+            print(f"    {k}: max_diff={d:.3e}")
+        return False
+
+    if missing or extra:
+        return False
+
+    print("  Level 1 PASSED")
+    return True
+
+
+# -------------------------------------------------------------- Level 2
+def level2_component_parity() -> bool:
+    """Component checks: half-RoPE equivalence vs HF reference; sigmoid+group gate sanity."""
+    print("\n=== Level 2: component parity (CPU/fp32) ===")
+    from nemo_automodel.components.models.gpt_oss.rope_utils import RotaryEmbedding, apply_rotary_emb
+
+    head_dim = 128
+    rotary_dim = head_dim // 2  # partial_rotary_factor=0.5
+    bsz, seq, n_heads = 2, 16, 4
+    torch.manual_seed(0)
+    # Framework apply_rotary_emb consumes BSHD (B, T, H, D); see qwen3_moe.layers.
+    q = torch.randn(bsz, seq, n_heads, head_dim, dtype=torch.float32)
+
+    rope = RotaryEmbedding(
+        head_dim=head_dim,
+        base=600000,
+        dtype=torch.float32,
+        initial_context_length=32768,
+        scaling_factor=1.0,
+        partial_rotary_factor=0.5,
+        device=torch.device("cpu"),
+    )
+    _, inv_freq = rope._compute_concentration_and_inv_freq()
+    assert inv_freq.shape == (rotary_dim // 2,), f"inv_freq {inv_freq.shape} != ({rotary_dim // 2},)"
+
+    pos = torch.arange(seq, dtype=torch.float32)
+    angles = torch.einsum("t,d->td", pos, inv_freq)  # (T, R/2)
+    cos = angles.cos()
+    sin = angles.sin()
+
+    # Framework path: cos/sin shape (T, R/2); apply_rotary_emb does the head unsqueeze.
+    q_out = apply_rotary_emb(q, cos, sin)
+
+    # Reference: equivalent to GPT-NeoX rotate_half on the first rotary_dim channels.
+    # Both formulations are mathematically identical when cos/sin are duplicated; here
+    # we test the framework's "two-halves" formulation (used by GPT-J/gpt_oss) directly.
+    cos_b = cos.view(1, seq, 1, rotary_dim // 2)
+    sin_b = sin.view(1, seq, 1, rotary_dim // 2)
+    q_rot, q_pass = q[..., :rotary_dim], q[..., rotary_dim:]
+    x1, x2 = q_rot.chunk(2, dim=-1)
+    o1 = x1 * cos_b - x2 * sin_b
+    o2 = x2 * cos_b + x1 * sin_b
+    q_ref = torch.cat([o1, o2, q_pass], dim=-1)
+
+    max_diff, _, cos_sim = compare(q_out, q_ref, name="half-rope q")
+    if max_diff > 1e-5 or cos_sim < 1.0 - 1e-7:
+        print("  ERROR: half-RoPE outputs diverge from GPT-NeoX reference.")
+        return False
+
+    print("  Level 2 PASSED")
+    return True
+
+
+# -------------------------------------------------------------- Level 3
+def level3_e2e_logits(hf_model_id: str) -> bool:
+    if not torch.cuda.is_available():
+        print("  Level 3 skipped: no CUDA")
+        return True
+    print(f"\n=== Level 3: full forward-pass parity on {hf_model_id} (GPU/bf16) ===")
+
+    # Local import to avoid a top-level dependency on transformers' AutoModel —
+    # this lets the rest of the script run on environments where the HF reference
+    # (trust_remote_code=True) is incompatible with the installed transformers.
+    from transformers import AutoModelForCausalLM
+
+    from nemo_automodel._transformers.auto_model import NeMoAutoModelForCausalLM
+
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+
+    print("  loading HF model ...")
+    hf_model = AutoModelForCausalLM.from_pretrained(
+        hf_model_id,
+        torch_dtype=dtype,
+        trust_remote_code=True,
+        low_cpu_mem_usage=True,
+        device_map="auto",
+    ).eval()
+
+    print("  loading NeMo model ...")
+    nemo_model = NeMoAutoModelForCausalLM.from_pretrained(
+        hf_model_id,
+        torch_dtype=dtype,
+        force_hf=False,
+        use_liger_kernel=False,
+        use_sdpa_patching=False,
+        attn_implementation="sdpa",
+    ).eval()
+
+    vocab = hf_model.config.vocab_size
+    torch.manual_seed(0)
+    input_ids = torch.randint(0, vocab, (1, 64), device=device)
+    with torch.no_grad():
+        hf_out = hf_model(input_ids).logits.float()
+        nemo_out = nemo_model(input_ids).float()
+
+    if nemo_out.shape != hf_out.shape:
+        print(f"  ERROR: shape mismatch hf {hf_out.shape} vs nemo {nemo_out.shape}")
+        return False
+
+    max_diff, mean_diff, cos_sim = compare(nemo_out, hf_out, name="logits")
+    ok = max_diff < 5e-2 and cos_sim > 0.9999
+    print(f"  Level 3 {'PASSED' if ok else 'FAILED'}")
+    return ok
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--hf-model", default="inclusionAI/Ling-mini-2.0")
+    p.add_argument("--levels", default="1,2,3", help="comma-separated subset of {1,2,3}")
+    args = p.parse_args(argv)
+
+    wanted = {int(x) for x in args.levels.split(",")}
+    started = time.time()
+    results: dict[int, bool] = {}
+    if 1 in wanted:
+        results[1] = level1_state_dict_roundtrip(args.hf_model)
+    if 2 in wanted:
+        results[2] = level2_component_parity()
+    if 3 in wanted:
+        results[3] = level3_e2e_logits(args.hf_model)
+
+    print(f"\n=== Summary (elapsed {time.time() - started:.1f}s) ===")
+    for level in sorted(results):
+        print(f"  Level {level}: {'PASS' if results[level] else 'FAIL'}")
+    return 0 if all(results.values()) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit_tests/models/ling_v2/test_ling_v2_config.py
+++ b/tests/unit_tests/models/ling_v2/test_ling_v2_config.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nemo_automodel.components.models.ling_v2.config import BailingMoeV2Config
+
+
+def test_default_matches_ling_mini_2_0():
+    """The dataclass defaults must reproduce the inclusionAI/Ling-mini-2.0 config.json."""
+    cfg = BailingMoeV2Config()
+    assert cfg.model_type == "bailing_moe"
+    assert cfg.vocab_size == 157184
+    assert cfg.hidden_size == 2048
+    assert cfg.intermediate_size == 5120
+    assert cfg.moe_intermediate_size == 512
+    assert cfg.num_hidden_layers == 20
+    assert cfg.num_attention_heads == 16
+    assert cfg.num_key_value_heads == 4
+    assert cfg.head_dim == 128
+    assert cfg.num_experts == 256
+    assert cfg.num_experts_per_tok == 8
+    assert cfg.num_shared_experts == 1
+    assert cfg.first_k_dense_replace == 1
+    assert cfg.n_group == 8
+    assert cfg.topk_group == 4
+    assert cfg.score_function == "sigmoid"
+    assert cfg.use_qk_norm is True
+    assert cfg.moe_router_enable_expert_bias is True
+    assert cfg.tie_word_embeddings is False
+
+
+def test_auto_config_registration():
+    """Importing nemo_automodel must register 'bailing_moe' with transformers' AutoConfig."""
+    from transformers.models.auto.configuration_auto import CONFIG_MAPPING
+
+    # Touch the registry to trigger registration.
+    import nemo_automodel._transformers.registry  # noqa: F401
+
+    assert "bailing_moe" in CONFIG_MAPPING
+    assert CONFIG_MAPPING["bailing_moe"] is BailingMoeV2Config
+
+
+def test_head_dim_falls_back_to_hidden_over_heads():
+    cfg = BailingMoeV2Config(hidden_size=512, num_attention_heads=8, head_dim=0)
+    assert cfg.head_dim == 64
+
+
+def test_overriding_first_k_dense_replace():
+    cfg = BailingMoeV2Config(first_k_dense_replace=4, num_hidden_layers=80)
+    assert cfg.first_k_dense_replace == 4
+    assert cfg.num_hidden_layers == 80
+
+
+def test_rotary_dim_derives_partial_rotary_factor():
+    """Ling-1T's config.json uses ``rotary_dim`` (e.g. 64) instead of
+    ``partial_rotary_factor`` — we must derive the latter or layers will
+    silently apply full RoPE."""
+    cfg = BailingMoeV2Config(head_dim=128, rotary_dim=64)
+    assert cfg.partial_rotary_factor == 0.5
+    assert cfg.rotary_dim == 64
+
+
+def test_partial_rotary_factor_preserved_when_rotary_dim_absent():
+    cfg = BailingMoeV2Config(head_dim=128, partial_rotary_factor=0.5)
+    assert cfg.partial_rotary_factor == 0.5
+    assert cfg.rotary_dim is None
+
+
+def test_rotary_dim_wins_over_partial_rotary_factor():
+    """If both fields are present, the explicit dim is authoritative — matches
+    HF reference modeling which reads rotary_dim directly when set."""
+    cfg = BailingMoeV2Config(head_dim=128, partial_rotary_factor=1.0, rotary_dim=64)
+    assert cfg.partial_rotary_factor == 0.5

--- a/tests/unit_tests/models/ling_v2/test_ling_v2_state_dict_adapter.py
+++ b/tests/unit_tests/models/ling_v2/test_ling_v2_state_dict_adapter.py
@@ -1,0 +1,224 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.models.ling_v2.config import BailingMoeV2Config
+from nemo_automodel.components.models.ling_v2.state_dict_adapter import BailingMoeV2StateDictAdapter
+from nemo_automodel.components.moe.config import MoEConfig
+
+
+@pytest.fixture
+def config():
+    # Tiny but realistic: 2 layers, first dense, second MoE, 4 experts, 1 shared.
+    return BailingMoeV2Config(
+        vocab_size=128,
+        hidden_size=64,
+        intermediate_size=128,
+        moe_intermediate_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        num_experts=4,
+        num_shared_experts=1,
+        num_experts_per_tok=2,
+        n_group=2,
+        topk_group=1,
+        first_k_dense_replace=1,
+        partial_rotary_factor=0.5,
+        max_position_embeddings=128,
+        rope_theta=10000.0,
+    )
+
+
+@pytest.fixture
+def moe_config(config):
+    return MoEConfig(
+        dim=config.hidden_size,
+        inter_dim=config.intermediate_size,
+        moe_inter_dim=config.moe_intermediate_size,
+        n_routed_experts=config.num_experts,
+        n_shared_experts=config.num_shared_experts,
+        n_activated_experts=config.num_experts_per_tok,
+        n_expert_groups=config.n_group,
+        n_limited_groups=config.topk_group,
+        train_gate=True,
+        gate_bias_update_factor=0.0,
+        force_e_score_correction_bias=True,
+        score_func="sigmoid",
+        route_scale=config.routed_scaling_factor,
+        aux_loss_coeff=0.0,
+        norm_topk_prob=config.norm_topk_prob,
+        router_bias=False,
+        expert_bias=False,
+        expert_activation="swiglu",
+        shared_expert_inter_dim=config.moe_intermediate_size,
+        shared_expert_activation="swiglu",
+        softmax_before_topk=False,
+    )
+
+
+@pytest.fixture
+def backend_config():
+    return BackendConfig(
+        attn="sdpa",
+        linear="torch",
+        rms_norm="torch",
+        experts="torch",
+        dispatcher="torch",
+        enable_hf_state_dict_adapter=False,
+    )
+
+
+@pytest.fixture
+def adapter(config, moe_config, backend_config):
+    return BailingMoeV2StateDictAdapter(
+        config=config, moe_config=moe_config, backend=backend_config, dtype=torch.float32
+    )
+
+
+def _make_hf_state_dict(config):
+    """Build a synthetic HF BailingMoeV2 checkpoint matching the public layout."""
+    H = config.hidden_size
+    D = config.head_dim
+    Q = config.num_attention_heads * D
+    K = config.num_key_value_heads * D
+    sd = {}
+    sd["model.word_embeddings.weight"] = torch.randn(config.vocab_size, H)
+    sd["model.norm.weight"] = torch.ones(H)
+    sd["lm_head.weight"] = torch.randn(config.vocab_size, H)
+    for L in range(config.num_hidden_layers):
+        # Attention: fused QKV + dense
+        sd[f"model.layers.{L}.attention.query_key_value.weight"] = torch.randn(Q + 2 * K, H)
+        sd[f"model.layers.{L}.attention.dense.weight"] = torch.randn(H, Q)
+        sd[f"model.layers.{L}.attention.query_layernorm.weight"] = torch.ones(D)
+        sd[f"model.layers.{L}.attention.key_layernorm.weight"] = torch.ones(D)
+        # Block norms
+        sd[f"model.layers.{L}.input_layernorm.weight"] = torch.ones(H)
+        sd[f"model.layers.{L}.post_attention_layernorm.weight"] = torch.ones(H)
+        # MLP: dense for first_k_dense_replace, MoE otherwise
+        if L < config.first_k_dense_replace:
+            sd[f"model.layers.{L}.mlp.gate_proj.weight"] = torch.randn(config.intermediate_size, H)
+            sd[f"model.layers.{L}.mlp.up_proj.weight"] = torch.randn(config.intermediate_size, H)
+            sd[f"model.layers.{L}.mlp.down_proj.weight"] = torch.randn(H, config.intermediate_size)
+        else:
+            sd[f"model.layers.{L}.mlp.gate.weight"] = torch.randn(config.num_experts, H)
+            sd[f"model.layers.{L}.mlp.gate.expert_bias"] = torch.zeros(config.num_experts)
+            for E in range(config.num_experts):
+                sd[f"model.layers.{L}.mlp.experts.{E}.gate_proj.weight"] = torch.randn(config.moe_intermediate_size, H)
+                sd[f"model.layers.{L}.mlp.experts.{E}.up_proj.weight"] = torch.randn(config.moe_intermediate_size, H)
+                sd[f"model.layers.{L}.mlp.experts.{E}.down_proj.weight"] = torch.randn(H, config.moe_intermediate_size)
+            sd[f"model.layers.{L}.mlp.shared_experts.gate_proj.weight"] = torch.randn(config.moe_intermediate_size, H)
+            sd[f"model.layers.{L}.mlp.shared_experts.up_proj.weight"] = torch.randn(config.moe_intermediate_size, H)
+            sd[f"model.layers.{L}.mlp.shared_experts.down_proj.weight"] = torch.randn(H, config.moe_intermediate_size)
+    return sd
+
+
+class TestSplitFusedQKV:
+    def test_splits_into_q_k_v_in_order(self, adapter, config):
+        hf_sd = _make_hf_state_dict(config)
+        native = adapter._split_fused_qkv_and_rename(hf_sd)
+
+        for L in range(config.num_hidden_layers):
+            assert f"model.layers.{L}.self_attn.q_proj.weight" in native
+            assert f"model.layers.{L}.self_attn.k_proj.weight" in native
+            assert f"model.layers.{L}.self_attn.v_proj.weight" in native
+            assert f"model.layers.{L}.attention.query_key_value.weight" not in native
+
+            fused = hf_sd[f"model.layers.{L}.attention.query_key_value.weight"]
+            q_size = config.num_attention_heads * config.head_dim
+            kv_size = config.num_key_value_heads * config.head_dim
+            assert torch.equal(native[f"model.layers.{L}.self_attn.q_proj.weight"], fused[:q_size])
+            assert torch.equal(native[f"model.layers.{L}.self_attn.k_proj.weight"], fused[q_size : q_size + kv_size])
+            assert torch.equal(native[f"model.layers.{L}.self_attn.v_proj.weight"], fused[q_size + kv_size :])
+
+    def test_renames_attention_subkeys(self, adapter, config):
+        hf_sd = _make_hf_state_dict(config)
+        native = adapter._split_fused_qkv_and_rename(hf_sd)
+
+        for L in range(config.num_hidden_layers):
+            assert f"model.layers.{L}.self_attn.o_proj.weight" in native
+            assert f"model.layers.{L}.self_attn.q_norm.weight" in native
+            assert f"model.layers.{L}.self_attn.k_norm.weight" in native
+            assert f"model.layers.{L}.attention.dense.weight" not in native
+
+    def test_renames_embed_and_expert_bias(self, adapter, config):
+        hf_sd = _make_hf_state_dict(config)
+        native = adapter._split_fused_qkv_and_rename(hf_sd)
+
+        assert "model.embed_tokens.weight" in native
+        assert "model.word_embeddings.weight" not in native
+        # MoE layers (>= first_k_dense_replace) carry the bias buffer.
+        assert "model.layers.1.mlp.gate.e_score_correction_bias" in native, (
+            "expert_bias must be renamed to e_score_correction_bias"
+        )
+        assert "model.layers.1.mlp.gate.expert_bias" not in native
+
+    def test_rejects_wrong_fused_qkv_shape(self, adapter, config):
+        bad = {
+            "model.layers.0.attention.query_key_value.weight": torch.randn(7, config.hidden_size),
+        }
+        with pytest.raises(ValueError, match="Fused qkv"):
+            adapter._split_fused_qkv_and_rename(bad)
+
+
+class TestToHFRefusion:
+    def test_refuses_q_k_v_back_into_query_key_value(self, adapter, config):
+        H = config.hidden_size
+        D = config.head_dim
+        q_size = config.num_attention_heads * D
+        kv_size = config.num_key_value_heads * D
+        native = {
+            "model.layers.0.self_attn.q_proj.weight": torch.randn(q_size, H),
+            "model.layers.0.self_attn.k_proj.weight": torch.randn(kv_size, H),
+            "model.layers.0.self_attn.v_proj.weight": torch.randn(kv_size, H),
+            "model.layers.0.self_attn.o_proj.weight": torch.randn(H, q_size),
+            "model.layers.0.self_attn.q_norm.weight": torch.ones(D),
+            "model.layers.0.self_attn.k_norm.weight": torch.ones(D),
+            "model.embed_tokens.weight": torch.randn(config.vocab_size, H),
+        }
+        hf = adapter.to_hf(native)
+        assert "model.layers.0.attention.query_key_value.weight" in hf
+        assert hf["model.layers.0.attention.query_key_value.weight"].shape == (q_size + 2 * kv_size, H)
+        assert "model.layers.0.attention.dense.weight" in hf
+        assert "model.layers.0.attention.query_layernorm.weight" in hf
+        assert "model.layers.0.attention.key_layernorm.weight" in hf
+        assert "model.word_embeddings.weight" in hf
+
+        # Round-trip: re-split the just-fused tensor and ensure each slice matches the input.
+        fused = hf["model.layers.0.attention.query_key_value.weight"]
+        torch.testing.assert_close(fused[:q_size], native["model.layers.0.self_attn.q_proj.weight"])
+        torch.testing.assert_close(fused[q_size : q_size + kv_size], native["model.layers.0.self_attn.k_proj.weight"])
+        torch.testing.assert_close(fused[q_size + kv_size :], native["model.layers.0.self_attn.v_proj.weight"])
+
+
+class TestRoundTrip:
+    def test_hf_to_native_to_hf_is_lossless_for_qkv_path(self, adapter, config):
+        """fused -> split -> fused must reproduce the original (the slowest, finickiest path)."""
+        hf_sd = _make_hf_state_dict(config)
+        native = adapter._split_fused_qkv_and_rename(hf_sd)
+        roundtripped = adapter.to_hf(native)
+
+        for L in range(config.num_hidden_layers):
+            key = f"model.layers.{L}.attention.query_key_value.weight"
+            assert key in roundtripped
+            torch.testing.assert_close(roundtripped[key], hf_sd[key])
+            torch.testing.assert_close(
+                roundtripped[f"model.layers.{L}.attention.dense.weight"],
+                hf_sd[f"model.layers.{L}.attention.dense.weight"],
+            )
+        torch.testing.assert_close(roundtripped["model.word_embeddings.weight"], hf_sd["model.word_embeddings.weight"])

--- a/tests/unit_tests/models/ling_v2/test_ling_v2_variants.py
+++ b/tests/unit_tests/models/ling_v2/test_ling_v2_variants.py
@@ -95,6 +95,20 @@ def _moe_cfg(cfg: BailingMoeV2Config) -> MoEConfig:
     )
 
 
+def test_pp_keep_self_forward_is_declared():
+    """Pipeline parallelism opts out of patch_hf_model_for_pp via this class flag.
+    Without it, the framework replaces our forward with a generic HF-style one
+    that calls rotary_emb(hidden_states, position_ids) and crashes inside
+    apply_rotary_emb because our gpt_oss-style RotaryEmbedding.forward(query, key)
+    rotates q and k rather than returning (cos, sin).  See PR #2255 for the
+    original symptom (RuntimeError: Sizes of tensors must match... at torch.cat
+    in apply_rotary_emb)."""
+    assert getattr(BailingMoeV2ForCausalLM, "_pp_keep_self_forward", False) is True, (
+        "BailingMoeV2ForCausalLM must declare _pp_keep_self_forward = True so "
+        "the PP wrapper preserves the model's own freqs_cis-based forward."
+    )
+
+
 @pytest.mark.parametrize("variant", ["mini", "flash", "1T"])
 def test_tiny_variant_forward(variant):
     cfg = _tiny_cfg_for_variant(variant)

--- a/tests/unit_tests/models/ling_v2/test_ling_v2_variants.py
+++ b/tests/unit_tests/models/ling_v2/test_ling_v2_variants.py
@@ -1,0 +1,129 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Per-variant smoke tests: every Ling 2.0 size class (mini / flash / 1T) is
+exercised at tiny scale.  This catches variant-specific bugs (such as Ling-1T's
+``first_k_dense_replace=4`` or its ``rotary_dim``-instead-of-``partial_rotary_factor``
+config) that would otherwise be invisible to a single-variant test."""
+
+import pytest
+import torch
+
+from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.models.ling_v2.config import BailingMoeV2Config
+from nemo_automodel.components.models.ling_v2.model import BailingMoeV2ForCausalLM
+from nemo_automodel.components.moe.config import MoEConfig
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="GPU required for forward smoke")
+
+
+def _tiny_cfg_for_variant(variant: str) -> BailingMoeV2Config:
+    """Tiny replica of each variant's ratio of dense-vs-MoE layers and rope layout."""
+    common = dict(
+        vocab_size=128,
+        hidden_size=64,
+        intermediate_size=128,
+        moe_intermediate_size=32,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        num_experts=4,
+        num_shared_experts=1,
+        num_experts_per_tok=2,
+        n_group=2,
+        topk_group=1,
+        max_position_embeddings=128,
+        rope_theta=10000.0,
+    )
+    if variant == "mini":
+        return BailingMoeV2Config(num_hidden_layers=2, first_k_dense_replace=1, partial_rotary_factor=0.5, **common)
+    if variant == "flash":
+        return BailingMoeV2Config(num_hidden_layers=4, first_k_dense_replace=1, partial_rotary_factor=0.5, **common)
+    if variant == "1T":
+        # Ling-1T sets rotary_dim (not partial_rotary_factor) and uses 4 dense layers.
+        return BailingMoeV2Config(num_hidden_layers=6, first_k_dense_replace=4, rotary_dim=8, **common)
+    raise ValueError(variant)
+
+
+def _backend() -> BackendConfig:
+    return BackendConfig(
+        attn="sdpa",
+        linear="torch",
+        rms_norm="torch",
+        experts="torch",
+        dispatcher="torch",
+        enable_hf_state_dict_adapter=False,
+        rope_fusion=False,
+    )
+
+
+def _moe_cfg(cfg: BailingMoeV2Config) -> MoEConfig:
+    return MoEConfig(
+        dim=cfg.hidden_size,
+        inter_dim=cfg.intermediate_size,
+        moe_inter_dim=cfg.moe_intermediate_size,
+        n_routed_experts=cfg.num_experts,
+        n_shared_experts=cfg.num_shared_experts,
+        n_activated_experts=cfg.num_experts_per_tok,
+        n_expert_groups=cfg.n_group,
+        n_limited_groups=cfg.topk_group,
+        train_gate=True,
+        gate_bias_update_factor=0.0,
+        force_e_score_correction_bias=True,
+        score_func=cfg.score_function,
+        route_scale=cfg.routed_scaling_factor,
+        aux_loss_coeff=0.0,
+        norm_topk_prob=cfg.norm_topk_prob,
+        router_bias=False,
+        expert_bias=False,
+        expert_activation="swiglu",
+        shared_expert_inter_dim=cfg.moe_intermediate_size,
+        shared_expert_activation="swiglu",
+        softmax_before_topk=False,
+        dtype=torch.float32,
+    )
+
+
+@pytest.mark.parametrize("variant", ["mini", "flash", "1T"])
+def test_tiny_variant_forward(variant):
+    cfg = _tiny_cfg_for_variant(variant)
+    # All three variants must end up with half-RoPE regardless of how the
+    # checkpoint expresses it.
+    assert cfg.partial_rotary_factor == 0.5
+    rope_dim = int(cfg.head_dim * cfg.partial_rotary_factor)
+    assert rope_dim == 8
+
+    model = BailingMoeV2ForCausalLM(cfg, moe_config=_moe_cfg(cfg), backend=_backend())
+    model.initialize_weights(buffer_device=torch.device("cuda:0"), dtype=torch.float32)
+    model = model.to("cuda:0").eval()
+
+    # Confirm the dense-vs-MoE split matches first_k_dense_replace.
+    from nemo_automodel.components.moe.layers import MLP, MoE
+
+    dense_layers = sum(1 for i in range(cfg.num_hidden_layers) if isinstance(model.model.layers[str(i)].mlp, MLP))
+    moe_layers = sum(1 for i in range(cfg.num_hidden_layers) if isinstance(model.model.layers[str(i)].mlp, MoE))
+    assert dense_layers == cfg.first_k_dense_replace, (
+        f"{variant}: expected {cfg.first_k_dense_replace} dense layers, got {dense_layers}"
+    )
+    assert dense_layers + moe_layers == cfg.num_hidden_layers
+
+    torch.manual_seed(0)
+    ids = torch.randint(0, cfg.vocab_size, (1, 16), device="cuda:0")
+    with torch.no_grad():
+        logits = model(ids)
+
+    assert logits.shape == (1, 16, cfg.vocab_size)
+    assert torch.isfinite(logits).all(), f"{variant}: non-finite logits"
+    # The model should not collapse to a constant prediction.
+    assert logits.argmax(dim=-1).unique().numel() > 1, f"{variant}: degenerate (constant) argmax"


### PR DESCRIPTION
# What does this PR do?

Adds support for the `inclusionAI/Ling-2.0` MoE family (`BailingMoeV2ForCausalLM`):
**Ling-mini-2.0** (16B-A1.4B), **Ling-flash-2.0** (100B-A6B), and **Ling-1T** (1T-A50B).
All three variants share the same architecture and are handled by a single implementation.

Closes #2242.

# Changelog

- Add `nemo_automodel/components/models/ling_v2/` with `BailingMoeV2Config`, `BailingMoeV2ForCausalLM`, attention layer (GQA + per-head QK-RMSNorm + half RoPE), and state-dict adapter (HF↔native).
- Register `BailingMoeV2ForCausalLM` arch and `bailing_moe` custom config in `nemo_automodel/_transformers/registry.py`.
- Reuse the framework's existing sigmoid + grouped-topk + per-expert-bias `Gate` (DeepSeek-V3-style) — no new MoE routing code.
- Reuse `gpt_oss/rope_utils.py`'s `partial_rotary_factor` support — no new RoPE code.
- Derive `partial_rotary_factor` from `rotary_dim` when present (Ling-1T uses `rotary_dim=64`; mini/flash use `partial_rotary_factor=0.5`).
- Add LoRA SFT example recipe: `examples/llm_finetune/ling/ling_mini_2_0_squad.yaml`.
- Add model-coverage page: `docs/model-coverage/llm/inclusionai/ling-2.md`.
- Add 16 unit tests including HF↔native state-dict round-trip and per-variant GPU smoke tests for mini / flash / 1T shapes.
- Add manual parity script (`tests/unit_tests/models/ling_v2/parity_ling_v2.py`) implementing the 3 levels from the parity-testing skill, plus a single-GPU real-checkpoint smoke (`_real_forward_smoke.py`).

# Validation

Run inside `nvcr.io/nvidia/nemo-automodel:26.04` on a single H100 80GB:

- **16 unit tests** pass (CPU + GPU; covers all three variant shapes incl. Ling-1T's `first_k_dense_replace=4` and the `rotary_dim`→`partial_rotary_factor` derivation).
- **Level 1** state-dict round-trip on the real 16B `inclusionAI/Ling-mini-2.0` checkpoint: 14813 HF tensors → 299 grouped native → 14813 HF, **zero diff**.
- **Level 2** half-RoPE component parity vs a GPT-NeoX-style reference: `max_diff=0`, `cos=1.0`.
- **Real-checkpoint forward** on H100: 16.26B params loaded, `load_state_dict` reports `missing=0 unexpected=0`, GPU memory 32.5 GB (matches bf16), logits finite, top-1 argmax shows 22 distinct tokens over 32 positions (non-degenerate).
- **Adjacent `tests/unit_tests/_transformers/`** suite (366 tests): no regression.
- **Recipe YAML** accepted by `tools/lint_example_yamls.py` (the CI validator that runs in `validate-recipe-configs.yml`).
- **Level 3** end-to-end HF logits parity is **deferred**: HF's bundled `modeling_bailing_moe_v2.py` imports `is_torch_fx_available` which was removed in `transformers>=5`. To be revisited once upstream Ling patches that or via a `transformers<5` shim.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

# Additional Information

- Related to #2242
- External contributor: please post `/ok to test <full-sha>` so `copy-pr-bot` can run CI.