### PR TITLE
fix(eagle3): drop dead cur_loss_mask, raise on too-shallow aux recipe

### DIFF
--- a/nemo_automodel/components/speculative/eagle/core.py
+++ b/nemo_automodel/components/speculative/eagle/core.py
@@ -105,7 +105,6 @@ class Eagle3TrainerModule(nn.Module):
         running_valid = hidden_states.new_zeros(())
 
         cur_input_ids = input_ids
-        cur_loss_mask = loss_mask
         cur_position_mask = position_mask
         cur_target_probs = target_probs
         cur_hidden_states = hidden_states
@@ -147,7 +146,6 @@ class Eagle3TrainerModule(nn.Module):
 
             if step_idx + 1 < self.ttt_steps:
                 cur_input_ids = _shift_left_with_zero(cur_input_ids)
-                cur_loss_mask = _shift_left_with_zero(cur_loss_mask)
                 cur_position_mask = _shift_left_with_zero(cur_position_mask)
                 cur_target_probs = _shift_left_with_zero(cur_target_probs)
 

--- a/nemo_automodel/components/speculative/eagle/target.py
+++ b/nemo_automodel/components/speculative/eagle/target.py
@@ -54,21 +54,26 @@ class HFEagle3TargetModel:
         self.aux_layer_ids = list(aux_layer_ids) if aux_layer_ids is not None else self._default_aux_layer_ids()
 
     def _default_aux_layer_ids(self) -> list[int]:
-        # Three reference points: an early layer, a middle one, and a late
-        # one. ``max(1, ...)`` keeps the indices in-bounds for shallow
-        # toy models, but the raw recipe collides on small ``num_layers``
-        # (e.g. 5 layers -> ``[1, 1, 1]``); deduplicate preserving order
-        # so ``generate_batch`` cannot end up registering multiple hooks
-        # on the same module and tripping the post-forward length check.
+        # EAGLE-3 default 3-layer recipe (low / mid / high).
+        #
+        # The downstream draft model's ``fc`` projection is sized for
+        # exactly ``num_aux_hidden_states`` layers (default 3) of
+        # concatenated target hidden states. Silently deduplicating
+        # collisions on shallow targets would yield fewer than 3
+        # captured tensors and crash later inside the draft ``fc`` with
+        # a confusing shape-mismatch error -- raise here instead so the
+        # caller picks 3 distinct in-bounds ids that match the draft
+        # config.
         num_layers = self.model.config.num_hidden_layers
-        candidates = [1, max(1, num_layers // 2 - 1), max(1, num_layers - 4)]
-        seen: set[int] = set()
-        unique: list[int] = []
-        for lid in candidates:
-            if lid not in seen:
-                unique.append(lid)
-                seen.add(lid)
-        return unique
+        candidates = [1, num_layers // 2 - 1, num_layers - 4]
+        if any(c < 0 or c >= num_layers for c in candidates) or len(set(candidates)) != 3:
+            raise ValueError(
+                f"Target model has num_hidden_layers={num_layers}, which is too shallow "
+                f"for the default EAGLE-3 aux recipe {candidates}. Pass aux_layer_ids "
+                f"explicitly (must be 3 distinct in-bounds layer indices, matching the "
+                f"draft model's num_aux_hidden_states)."
+            )
+        return candidates
 
     def _get_transformer_layers(self) -> Iterable[nn.Module]:
         if hasattr(self.model, "model") and hasattr(self.model.model, "layers"):

--- a/nemo_automodel/components/speculative/eagle/target.py
+++ b/nemo_automodel/components/speculative/eagle/target.py
@@ -51,7 +51,8 @@ class HFEagle3TargetModel:
 
     def __init__(self, model: nn.Module, aux_layer_ids: Sequence[int] | None = None):
         self.model = model.eval()
-        self.aux_layer_ids = list(aux_layer_ids) if aux_layer_ids is not None else self._default_aux_layer_ids()
+        candidate_ids = list(aux_layer_ids) if aux_layer_ids is not None else self._default_aux_layer_ids()
+        self.aux_layer_ids = self._validate_aux_layer_ids(candidate_ids)
 
     def _default_aux_layer_ids(self) -> list[int]:
         # EAGLE-3 default 3-layer recipe (low / mid / high).
@@ -74,6 +75,25 @@ class HFEagle3TargetModel:
                 f"draft model's num_aux_hidden_states)."
             )
         return candidates
+
+    def _validate_aux_layer_ids(self, aux_layer_ids: Sequence[int]) -> list[int]:
+        """Validate aux-layer selection before any forward hooks are registered."""
+        num_layers = self.model.config.num_hidden_layers
+        aux_layer_ids = list(aux_layer_ids)
+        if len(aux_layer_ids) != 3:
+            raise ValueError(
+                f"EAGLE-3 expects exactly 3 aux_layer_ids, but got {len(aux_layer_ids)}: "
+                f"{aux_layer_ids}. This must match the draft model's num_aux_hidden_states."
+            )
+        if len(set(aux_layer_ids)) != len(aux_layer_ids):
+            raise ValueError(
+                f"EAGLE-3 aux_layer_ids must be distinct, but got {aux_layer_ids}. "
+                "Duplicate ids would collapse the captured aux hidden states."
+            )
+        for layer_id in aux_layer_ids:
+            if layer_id < 0 or layer_id >= num_layers:
+                raise ValueError(f"aux layer id {layer_id} is out of bounds for model with {num_layers} layers")
+        return aux_layer_ids
 
     def _get_transformer_layers(self) -> Iterable[nn.Module]:
         if hasattr(self.model, "model") and hasattr(self.model.model, "layers"):

--- a/tests/unit_tests/speculative/test_eagle3_target.py
+++ b/tests/unit_tests/speculative/test_eagle3_target.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import torch
 from transformers import LlamaConfig, LlamaForCausalLM
 
@@ -42,19 +43,32 @@ def test_default_aux_layer_ids_returns_three_unique_for_normal_models():
     assert len(set(ids)) == len(ids)
 
 
-def test_default_aux_layer_ids_deduplicates_on_shallow_models():
-    """Models with fewer than ~7 layers must not collide on the default recipe.
+def test_default_aux_layer_ids_raises_on_shallow_models():
+    """Shallow targets must raise instead of silently returning fewer than 3 ids.
 
     With ``num_layers=5`` the raw recipe yields ``[1, 1, 1]``; with
-    ``num_layers=6`` it yields ``[1, 2, 2]``. Both must be deduplicated
-    (order-preserving) so ``generate_batch`` does not register multiple
-    hooks on the same module and fail the post-forward length check.
+    ``num_layers=6`` it yields ``[1, 2, 2]``. The draft model's ``fc``
+    is sized for exactly ``num_aux_hidden_states`` (default 3) layers,
+    so silently collapsing the list would only defer the crash to a
+    confusing shape mismatch inside the draft. Raise here instead.
     """
-    target_5 = HFEagle3TargetModel(_build_tiny_target(num_hidden_layers=5))
-    assert target_5.aux_layer_ids == [1]
+    with pytest.raises(ValueError, match="too shallow"):
+        HFEagle3TargetModel(_build_tiny_target(num_hidden_layers=5))
+    with pytest.raises(ValueError, match="too shallow"):
+        HFEagle3TargetModel(_build_tiny_target(num_hidden_layers=6))
 
-    target_6 = HFEagle3TargetModel(_build_tiny_target(num_hidden_layers=6))
-    assert target_6.aux_layer_ids == [1, 2]
+
+def test_shallow_model_with_explicit_aux_layer_ids_is_allowed():
+    """Explicit ``aux_layer_ids`` bypasses the default-recipe check.
+
+    Users with shallow targets can still drive the trainer by passing
+    3 in-bounds ids that match the draft's ``num_aux_hidden_states``.
+    """
+    target = HFEagle3TargetModel(
+        _build_tiny_target(num_hidden_layers=5),
+        aux_layer_ids=[0, 2, 4],
+    )
+    assert target.aux_layer_ids == [0, 2, 4]
 
 
 def test_generate_batch_aux_hidden_states_shape_and_layer_capture():

--- a/tests/unit_tests/speculative/test_eagle3_target.py
+++ b/tests/unit_tests/speculative/test_eagle3_target.py
@@ -71,6 +71,20 @@ def test_shallow_model_with_explicit_aux_layer_ids_is_allowed():
     assert target.aux_layer_ids == [0, 2, 4]
 
 
+def test_explicit_aux_layer_ids_raises_when_count_does_not_match_recipe():
+    model = _build_tiny_target(num_hidden_layers=8)
+    with pytest.raises(ValueError, match="exactly 3 aux_layer_ids"):
+        HFEagle3TargetModel(model, aux_layer_ids=[1, 3])
+    with pytest.raises(ValueError, match="exactly 3 aux_layer_ids"):
+        HFEagle3TargetModel(model, aux_layer_ids=[0, 2, 4, 6])
+
+
+def test_explicit_aux_layer_ids_raises_when_not_distinct():
+    model = _build_tiny_target(num_hidden_layers=8)
+    with pytest.raises(ValueError, match="must be distinct"):
+        HFEagle3TargetModel(model, aux_layer_ids=[1, 3, 3])
+
+
 def test_generate_batch_aux_hidden_states_shape_and_layer_capture():
     """``aux_hidden_states`` must be the per-layer hiddens concatenated along H.
 
@@ -133,14 +147,5 @@ def test_generate_batch_shifts_logits_input_ids_and_loss_mask():
 
 def test_generate_batch_raises_for_out_of_bounds_aux_layer_id():
     model = _build_tiny_target(num_hidden_layers=4)
-    target = HFEagle3TargetModel(model, aux_layer_ids=[1, 2, 99])
-
-    input_ids = torch.tensor([[1, 2, 3, 4]], dtype=torch.long)
-    attention_mask = torch.ones_like(input_ids)
-    loss_mask = torch.ones_like(input_ids)
-    try:
-        target.generate_batch(input_ids=input_ids, attention_mask=attention_mask, loss_mask=loss_mask)
-    except ValueError as exc:
-        assert "out of bounds" in str(exc)
-    else:
-        raise AssertionError("expected ValueError for out-of-bounds aux layer id")
+    with pytest.raises(ValueError, match="out of bounds"):
+        HFEagle3TargetModel(model, aux_layer_ids=[1, 2, 99])


### PR DESCRIPTION
## Summary

Two small correctness/cleanup fixes in the minimal EAGLE-3 trainer:

- **`Eagle3TrainerModule.forward`**: ``cur_loss_mask`` was initialized and left-shifted every TTT step, but the loop body never read it — supervision is driven by ``cur_position_mask``. Removed the dead variable and its per-step shift.
- **`HFEagle3TargetModel._default_aux_layer_ids`**: silently deduplicating collisions on shallow targets (e.g. ``num_layers=5`` → ``[1, 1, 1]`` → ``[1]``) leaves the captured aux tensor with fewer than 3 channels, which then crashes inside the draft model's ``fc`` (sized for ``num_aux_hidden_states=3``) with a confusing shape-mismatch error. Replaced the silent dedup with an explicit ``ValueError`` that points the caller at the ``aux_layer_ids`` argument. Users with shallow targets can still pass explicit ids matching their draft config.

## Test plan

- [x] Replaced ``test_default_aux_layer_ids_deduplicates_on_shallow_models`` with ``test_default_aux_layer_ids_raises_on_shallow_models``
- [x] Added ``test_shallow_model_with_explicit_aux_layer_ids_is_allowed`` to confirm the escape hatch still works
- [x] ``pytest tests/unit_tests/speculative/`` — 24 passed, 2 skipped (FA2 path, requires CUDA)