### PR TITLE
fix(eagle3): flush trailing partial grad-accum window each epoch

### DIFF
--- a/nemo_automodel/recipes/llm/train_eagle3.py
+++ b/nemo_automodel/recipes/llm/train_eagle3.py
@@ -45,6 +45,20 @@ from nemo_automodel.recipes.base_recipe import BaseRecipe
 logger = logging.getLogger(__name__)
 
 
+def _optim_steps_per_epoch(num_batches_per_epoch: int, grad_accumulation_steps: int) -> int:
+    """Return ceil(num_batches / accum), the actual number of optimizer steps per epoch.
+
+    Floor division silently drops the trailing partial accumulation window
+    (up to ``grad_accumulation_steps - 1`` micro-batches) from the LR
+    scheduler's view of training, even though the trainer now flushes those
+    gradients with an explicit step. Ceil keeps the scheduler aligned with
+    the actual number of ``optimizer.step()`` calls.
+    """
+    if num_batches_per_epoch <= 0 or grad_accumulation_steps <= 0:
+        return 0
+    return -(-num_batches_per_epoch // grad_accumulation_steps)
+
+
 def _all_reduce_mean(value: torch.Tensor) -> torch.Tensor:
     if dist.is_available() and dist.is_initialized():
         dist.all_reduce(value, op=dist.ReduceOp.SUM)
@@ -194,9 +208,15 @@ class TrainEagle3Recipe(BaseRecipe):
             num_batches_per_epoch = len(self.train_dataloader)
         except TypeError:
             num_batches_per_epoch = 0
+        # Use ceil division so a trailing partial accumulation window (i.e. when
+        # ``num_batches_per_epoch`` is not a multiple of ``grad_accumulation_steps``)
+        # is counted as a real optimizer step. The training loop flushes that
+        # leftover window at the end of each epoch, so the LR scheduler must
+        # cover those steps too -- otherwise ``progress`` saturates and the
+        # final epoch trains at ``min_lr_ratio`` instead of the intended decay.
         total_optim_steps = max(
             1,
-            (self.num_epochs * num_batches_per_epoch) // self.grad_accumulation_steps,
+            self.num_epochs * _optim_steps_per_epoch(num_batches_per_epoch, self.grad_accumulation_steps),
         )
         warmup_ratio = float(opt_cfg.get("warmup_ratio", 0.05))
         min_lr_ratio = float(opt_cfg.get("min_lr_ratio", 0.1))
@@ -301,12 +321,8 @@ class TrainEagle3Recipe(BaseRecipe):
             running_steps = 0
             self.optimizer.zero_grad(set_to_none=True)
 
-            # Track batches-seen explicitly so the epoch-summary log below is
-            # well-defined even when the dataloader is empty (e.g. a filter
-            # that drops every sample, or an empty split). Without this the
-            # for-loop never binds ``batch_idx`` and the subsequent
-            # ``batch_idx + 1`` raises ``UnboundLocalError``.
-            batches_seen = 0
+            batches_processed = 0
+            pending_micro_batches = 0
             for batch_idx, batch in enumerate(self.train_dataloader):
                 batch = {k: v.to(self.device, non_blocking=True) for k, v in batch.items()}
                 target_batch = self.target_wrapper.generate_batch(
@@ -327,14 +343,16 @@ class TrainEagle3Recipe(BaseRecipe):
                 running_loss = running_loss + metrics.loss.detach()
                 running_acc = running_acc + metrics.accuracy.detach()
                 running_steps += 1
-                batches_seen = batch_idx + 1
+                batches_processed = batch_idx + 1
+                pending_micro_batches += 1
 
-                if (batch_idx + 1) % self.grad_accumulation_steps == 0:
+                if pending_micro_batches == self.grad_accumulation_steps:
                     torch.nn.utils.clip_grad_norm_(self.trainer_module.parameters(), self.max_grad_norm)
                     self.optimizer.step()
                     self.lr_scheduler.step()
                     self.optimizer.zero_grad(set_to_none=True)
                     self.runtime.global_step += 1
+                    pending_micro_batches = 0
 
                     if self.runtime.global_step % self.log_every_steps == 0:
                         mean_loss = _all_reduce_mean(running_loss / max(running_steps, 1))
@@ -353,11 +371,53 @@ class TrainEagle3Recipe(BaseRecipe):
                         running_acc.zero_()
                         running_steps = 0
 
+            # Flush the trailing partial accumulation window. When
+            # ``batches_per_epoch`` is not a multiple of
+            # ``grad_accumulation_steps``, up to ``grad_accumulation_steps - 1``
+            # micro-batches have run ``backward()`` but never reached an
+            # ``optimizer.step()`` -- those gradients would otherwise be wiped
+            # by the next epoch's ``zero_grad`` and the samples wasted.
+            #
+            # Each micro-batch divided its loss by ``grad_accumulation_steps``
+            # in anticipation of a full window. With only ``pending_micro_batches``
+            # contributors, the accumulated gradient magnitude is
+            # ``pending_micro_batches / grad_accumulation_steps`` of a normal
+            # step; rescale by the inverse so the trailing step's gradient
+            # is on the same scale as every other step.
+            if pending_micro_batches > 0:
+                scale = float(self.grad_accumulation_steps) / float(pending_micro_batches)
+                for p in self.trainer_module.parameters():
+                    if p.grad is not None:
+                        p.grad.mul_(scale)
+                torch.nn.utils.clip_grad_norm_(self.trainer_module.parameters(), self.max_grad_norm)
+                self.optimizer.step()
+                self.lr_scheduler.step()
+                self.optimizer.zero_grad(set_to_none=True)
+                self.runtime.global_step += 1
+                pending_micro_batches = 0
+
+                if running_steps > 0:
+                    mean_loss = _all_reduce_mean(running_loss / max(running_steps, 1))
+                    mean_acc = _all_reduce_mean(running_acc / max(running_steps, 1))
+                    current_lr = self.lr_scheduler.get_last_lr()[0]
+                    if self.dist_env.is_main:
+                        logger.info(
+                            "epoch=%s step=%s train_loss=%.6f train_acc=%.6f lr=%.3e (trailing flush)",
+                            epoch,
+                            self.runtime.global_step,
+                            mean_loss.item(),
+                            mean_acc.item(),
+                            current_lr,
+                        )
+                    running_loss.zero_()
+                    running_acc.zero_()
+                    running_steps = 0
+
             if self.dist_env.is_main:
                 logger.info(
                     "Epoch %s done: total_batches_seen=%s global_step=%s",
                     epoch,
-                    batches_seen,
+                    batches_processed,
                     self.runtime.global_step,
                 )
 

--- a/tests/unit_tests/recipes/llm/test_train_eagle3_flush.py
+++ b/tests/unit_tests/recipes/llm/test_train_eagle3_flush.py
@@ -1,0 +1,270 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Coverage tests for the EAGLE-3 trailing grad-accum flush and related
+recipe internals: ``_all_reduce_mean``, ``_optim_steps_per_epoch``,
+``run_train_validation_loop`` with divisible / non-divisible batch counts,
+gradient rescaling, ``_save_checkpoint``, and ``_run_eval``."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader, TensorDataset
+
+from nemo_automodel.recipes.llm.train_eagle3 import (
+    TrainEagle3Recipe,
+    _all_reduce_mean,
+    _optim_steps_per_epoch,
+)
+
+# ---------------------------------------------------------------------------
+# Minimal stand-ins that satisfy the Eagle3 training loop interface
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeBatch:
+    input_ids: torch.Tensor
+    attention_mask: torch.Tensor
+    loss_mask: torch.Tensor
+    aux_hidden_states: torch.Tensor
+    logits: torch.Tensor
+
+
+class _FakeMetrics:
+    def __init__(self):
+        self.loss = torch.tensor(1.0, requires_grad=True)
+        self.accuracy = torch.tensor(0.5)
+        self.valid_tokens = torch.tensor(4)
+
+
+class _FakeDraftModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layer = nn.Linear(4, 4)
+        self.config = SimpleNamespace(save_pretrained=lambda path: None)
+
+
+class _FakeTrainerModule(nn.Module):
+    """Minimal trainer module whose forward returns fake metrics with a
+    gradient-bearing loss so ``backward()`` and ``clip_grad_norm_`` work."""
+
+    def __init__(self):
+        super().__init__()
+        self.draft_model = _FakeDraftModel()
+        self.dummy = nn.Linear(4, 4)
+        self.register_buffer("selected_token_ids", torch.arange(8))
+        self.register_buffer("selected_token_mask", torch.ones(8, dtype=torch.bool))
+
+    def forward(self, **kwargs):
+        out = self.dummy(torch.randn(1, 4)).sum()
+        return SimpleNamespace(
+            loss=out.abs() + 1.0,
+            accuracy=torch.tensor(0.5),
+            valid_tokens=torch.tensor(4),
+        )
+
+
+class _FakeTargetWrapper:
+    def generate_batch(self, input_ids, attention_mask, loss_mask):
+        bs, sl = input_ids.shape
+        return _FakeBatch(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            loss_mask=loss_mask,
+            aux_hidden_states=torch.randn(bs, sl, 16),
+            logits=torch.randn(bs, sl, 64),
+        )
+
+
+class _KeyedLoader:
+    """Wraps a DataLoader to yield dicts with the keys the training loop expects."""
+
+    def __init__(self, loader):
+        self._loader = loader
+        self.sampler = loader.sampler
+
+    def __iter__(self):
+        for ids, attn, lm in self._loader:
+            yield {"input_ids": ids, "attention_mask": attn, "loss_mask": lm}
+
+    def __len__(self):
+        return len(self._loader)
+
+
+# ---------------------------------------------------------------------------
+# Recipe builder
+# ---------------------------------------------------------------------------
+
+
+def _build_recipe(tmp_path, num_samples=5, grad_accum=3, num_epochs=1, log_every=1):
+    """Assemble a TrainEagle3Recipe with fake components -- no GPU, no HF model."""
+    sl = 6
+    train_data = TensorDataset(
+        torch.randint(0, 64, (num_samples, sl)),
+        torch.ones(num_samples, sl, dtype=torch.long),
+        torch.ones(num_samples, sl, dtype=torch.long),
+    )
+    train_loader = _KeyedLoader(DataLoader(train_data, batch_size=1))
+
+    trainer_module = _FakeTrainerModule()
+
+    recipe = TrainEagle3Recipe.__new__(TrainEagle3Recipe)
+    recipe.device = torch.device("cpu")
+    recipe.dist_env = SimpleNamespace(is_main=True, world_size=1)
+    recipe.trainer_module = trainer_module
+    recipe.target_wrapper = _FakeTargetWrapper()
+    recipe.train_dataloader = train_loader
+    recipe.val_dataloader = None
+    recipe.output_dir = tmp_path
+    recipe.runtime = SimpleNamespace(global_step=0)
+    recipe.grad_accumulation_steps = grad_accum
+    recipe.max_grad_norm = 1.0
+    recipe.num_epochs = num_epochs
+    recipe.log_every_steps = log_every
+    recipe.peak_lr = 1e-4
+    recipe.total_optim_steps = num_epochs * _optim_steps_per_epoch(num_samples, grad_accum)
+    recipe.warmup_steps = 1
+    recipe.min_lr_ratio = 0.1
+
+    recipe.optimizer = torch.optim.AdamW([p for p in trainer_module.parameters() if p.requires_grad], lr=1e-4)
+    recipe.lr_scheduler = torch.optim.lr_scheduler.LambdaLR(recipe.optimizer, lambda s: 1.0)
+
+    return recipe
+
+
+# ---------------------------------------------------------------------------
+# _all_reduce_mean (non-distributed)
+# ---------------------------------------------------------------------------
+
+
+def test_all_reduce_mean_passthrough():
+    t = torch.tensor(3.0)
+    assert _all_reduce_mean(t).item() == 3.0
+
+
+# ---------------------------------------------------------------------------
+# Training loop: divisible batch count (no trailing flush)
+# ---------------------------------------------------------------------------
+
+
+def test_no_trailing_flush_when_divisible(tmp_path):
+    recipe = _build_recipe(tmp_path, num_samples=6, grad_accum=3)
+    recipe.run_train_validation_loop()
+    assert recipe.runtime.global_step == 2
+
+
+# ---------------------------------------------------------------------------
+# Training loop: non-divisible batch count (trailing flush fires)
+# ---------------------------------------------------------------------------
+
+
+def test_trailing_flush_fires_when_non_divisible(tmp_path):
+    recipe = _build_recipe(tmp_path, num_samples=5, grad_accum=3)
+    recipe.run_train_validation_loop()
+    assert recipe.runtime.global_step == 2
+
+
+def test_trailing_flush_single_micro_batch(tmp_path):
+    recipe = _build_recipe(tmp_path, num_samples=4, grad_accum=3)
+    recipe.run_train_validation_loop()
+    assert recipe.runtime.global_step == 2
+
+
+# ---------------------------------------------------------------------------
+# Training loop: entire epoch is one trailing flush
+# ---------------------------------------------------------------------------
+
+
+def test_entire_epoch_is_trailing_flush(tmp_path):
+    recipe = _build_recipe(tmp_path, num_samples=2, grad_accum=4)
+    recipe.run_train_validation_loop()
+    assert recipe.runtime.global_step == 1
+
+
+# ---------------------------------------------------------------------------
+# Training loop: grad_accum=1 (never triggers flush)
+# ---------------------------------------------------------------------------
+
+
+def test_grad_accum_one_no_flush(tmp_path):
+    recipe = _build_recipe(tmp_path, num_samples=3, grad_accum=1)
+    recipe.run_train_validation_loop()
+    assert recipe.runtime.global_step == 3
+
+
+# ---------------------------------------------------------------------------
+# Multi-epoch
+# ---------------------------------------------------------------------------
+
+
+def test_multi_epoch_with_trailing_flush(tmp_path):
+    recipe = _build_recipe(tmp_path, num_samples=5, grad_accum=3, num_epochs=2)
+    recipe.run_train_validation_loop()
+    assert recipe.runtime.global_step == 4
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint saving
+# ---------------------------------------------------------------------------
+
+
+def test_checkpoint_saved_after_epoch(tmp_path):
+    recipe = _build_recipe(tmp_path, num_samples=3, grad_accum=2)
+    recipe.run_train_validation_loop()
+    ckpt_dirs = list(tmp_path.glob("epoch_*"))
+    assert len(ckpt_dirs) == 1
+
+
+def test_checkpoint_skipped_when_not_main(tmp_path):
+    recipe = _build_recipe(tmp_path, num_samples=3, grad_accum=2)
+    recipe.dist_env.is_main = False
+    recipe.run_train_validation_loop()
+    ckpt_dirs = list(tmp_path.glob("epoch_*"))
+    assert len(ckpt_dirs) == 0
+
+
+# ---------------------------------------------------------------------------
+# _run_eval
+# ---------------------------------------------------------------------------
+
+
+def test_run_eval_returns_none_without_val_loader(tmp_path):
+    recipe = _build_recipe(tmp_path)
+    assert recipe._run_eval() is None
+
+
+# ---------------------------------------------------------------------------
+# _module() unwrapping
+# ---------------------------------------------------------------------------
+
+
+def test_module_returns_unwrapped(tmp_path):
+    recipe = _build_recipe(tmp_path)
+    assert recipe._module() is recipe.trainer_module
+
+
+# ---------------------------------------------------------------------------
+# Logging path: log_every_steps triggers the info log
+# ---------------------------------------------------------------------------
+
+
+def test_logging_path_is_exercised(tmp_path):
+    recipe = _build_recipe(tmp_path, num_samples=4, grad_accum=2, log_every=1)
+    recipe.run_train_validation_loop()
+    assert recipe.runtime.global_step == 2

--- a/tests/unit_tests/recipes/llm/test_train_eagle3_grad_accum.py
+++ b/tests/unit_tests/recipes/llm/test_train_eagle3_grad_accum.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for EAGLE-3 recipe gradient-accumulation arithmetic.
+
+The trainer flushes a trailing partial accumulation window at the end of
+every epoch so micro-batches in a non-divisible epoch are not silently
+discarded. The LR scheduler must therefore be sized against the *ceil*
+of ``num_batches / grad_accumulation_steps``, not the floor -- otherwise
+``progress`` saturates and the trailing flushes train at
+``min_lr_ratio``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nemo_automodel.recipes.llm.train_eagle3 import _optim_steps_per_epoch
+
+
+@pytest.mark.parametrize(
+    "num_batches,accum,expected",
+    [
+        (10, 1, 10),
+        (10, 2, 5),
+        (10, 3, 4),  # 3 full windows + 1 trailing micro-batch -> 4 steps
+        (10, 4, 3),  # 2 full windows + 2 trailing -> 3 steps
+        (1, 4, 1),  # entire epoch is one trailing flush
+        (4, 4, 1),
+        (5, 4, 2),
+        (0, 4, 0),  # iterable dataloader / no length
+    ],
+)
+def test_optim_steps_per_epoch_uses_ceil_division(num_batches, accum, expected):
+    assert _optim_steps_per_epoch(num_batches, accum) == expected
+
+
+def test_optim_steps_per_epoch_handles_invalid_inputs():
+    assert _optim_steps_per_epoch(0, 1) == 0
+    assert _optim_steps_per_epoch(-1, 4) == 0
+    assert _optim_steps_per_epoch(10, 0) == 0
+    assert _optim_steps_per_epoch(10, -1) == 0


### PR DESCRIPTION
## Summary

When ``num_batches_per_epoch`` is not a multiple of ``grad_accumulation_steps``, the EAGLE-3 recipe's training loop silently dropped the trailing micro-batches: their gradients reached ``backward()`` but never an ``optimizer.step()`` — the next epoch's ``zero_grad`` wiped them. Up to ``grad_accumulation_steps - 1`` micro-batches per epoch were wasted, and the LR scheduler (sized via floor division) was off-by-N over a full run.

Two coordinated fixes in ``recipes/llm/train_eagle3.py``:

1. **Ceil-divide optimizer steps** via new ``_optim_steps_per_epoch`` helper so the LR scheduler covers the trailing flush and ``progress`` does not saturate at ``min_lr_ratio`` prematurely.
2. **Flush the partial window** at the end of each epoch: rescale its gradients by ``grad_accumulation_steps / pending_micro_batches`` (every micro-batch had divided its loss by the full accumulation count, expecting a full window) and run one final ``clip_grad_norm_`` / ``optimizer.step`` / ``lr_scheduler.step`` / ``zero_grad`` so the trailing step's update magnitude matches every other step.

## Test plan

- [x] Added ``tests/unit_tests/recipes/llm/test_train_eagle3_grad_accum.py`` exercising ``_optim_steps_per_epoch`` on divisible / non-divisible / degenerate inputs.
- [x] Local: ``pytest tests/unit_tests/recipes/llm/test_train_eagle3_grad_accum.py tests/unit_tests/speculative/`` — 32 passed, 2 skipped (FA2 CUDA path).