### PR TITLE
fix(eagle3): validate ttt_steps >= 1 instead of returning NaN loss

### DIFF
--- a/nemo_automodel/components/speculative/eagle/core.py
+++ b/nemo_automodel/components/speculative/eagle/core.py
@@ -65,6 +65,18 @@ class Eagle3TrainerModule(nn.Module):
         ttt_steps: int,
     ):
         super().__init__()
+        # The forward pass weighs each TTT step by ``0.8 ** i`` and divides
+        # the running loss by ``sum_{i=0}^{ttt_steps-1} 0.8 ** i``. With
+        # ``ttt_steps <= 0`` the loop never runs and the divisor is zero,
+        # which would silently produce a NaN loss instead of an actionable
+        # error. Catch the misconfiguration here so it surfaces during
+        # recipe setup rather than mid-training.
+        if not isinstance(ttt_steps, int) or ttt_steps < 1:
+            raise ValueError(
+                f"Eagle3TrainerModule requires ttt_steps to be an integer >= 1 "
+                f"(the draft must run at least one forward step to produce a "
+                f"loss), got ttt_steps={ttt_steps!r}."
+            )
         self.draft_model = draft_model
         self.register_buffer("selected_token_ids", selected_token_ids, persistent=True)
         self.register_buffer("selected_token_mask", selected_token_mask, persistent=True)

--- a/tests/unit_tests/speculative/test_eagle3.py
+++ b/tests/unit_tests/speculative/test_eagle3.py
@@ -127,6 +127,50 @@ def _build_tiny_draft_model() -> LlamaEagle3DraftModel:
     return LlamaEagle3DraftModel(config).to(torch.float32)
 
 
+def test_eagle3_trainer_rejects_non_positive_ttt_steps():
+    """Misconfigured ``ttt_steps`` must raise at construction.
+
+    The forward pass divides by ``sum(0.8**i for i in range(ttt_steps))``,
+    which is zero when ``ttt_steps <= 0`` and would silently produce a
+    NaN loss. Catching it in ``__init__`` keeps the failure local to the
+    recipe setup step.
+    """
+    import pytest
+
+    draft = _build_tiny_draft_model()
+    config = draft.config
+    selected_token_ids = torch.arange(config.draft_vocab_size, dtype=torch.long)
+    selected_token_mask = torch.zeros(config.vocab_size, dtype=torch.bool)
+    selected_token_mask[selected_token_ids] = True
+
+    for bad in (0, -1, -7):
+        with pytest.raises(ValueError, match="ttt_steps"):
+            Eagle3TrainerModule(
+                draft,
+                selected_token_ids=selected_token_ids,
+                selected_token_mask=selected_token_mask,
+                ttt_steps=bad,
+            )
+
+    # Non-int (e.g. a float coming from YAML) is also rejected.
+    with pytest.raises(ValueError, match="ttt_steps"):
+        Eagle3TrainerModule(
+            draft,
+            selected_token_ids=selected_token_ids,
+            selected_token_mask=selected_token_mask,
+            ttt_steps=1.0,  # type: ignore[arg-type]
+        )
+
+    # ``ttt_steps=1`` is the minimum valid configuration and must work.
+    trainer = Eagle3TrainerModule(
+        draft,
+        selected_token_ids=selected_token_ids,
+        selected_token_mask=selected_token_mask,
+        ttt_steps=1,
+    )
+    assert trainer.ttt_steps == 1
+
+
 def test_eagle3_trainer_runs_multi_step_ttt():
     """Multi-step TTT must keep target_probs / position_mask aligned with the shifted logits."""
     torch.manual_seed(0)


### PR DESCRIPTION
## Summary

``Eagle3TrainerModule.forward`` divides the accumulated TTT loss by ``sum(0.8 ** i for i in range(self.ttt_steps))``. When ``ttt_steps`` is 0 or negative, the loop body never runs and the divisor is zero, so the result is:

```
loss tensor(nan)
accuracy tensor(0.)
valid tensor(0.)
```

That is a silent misconfiguration: training appears to start, but every step produces NaN — the user finds out only after the first ``optimizer.step()`` corrupts the draft model.

Fix: validate in ``__init__`` that ``ttt_steps`` is an ``int`` ``>= 1`` and raise ``ValueError`` otherwise. The error surfaces during recipe setup, well before any forward pass.

## Test plan

- [x] Added ``test_eagle3_trainer_rejects_non_positive_ttt_steps`` covering ``ttt_steps`` in ``{0, -1, -7, 1.0}`` and confirming ``ttt_steps=1`` still constructs cleanly.
- [x] Local: ``pytest tests/unit_tests/speculative/`` — 24 passed, 2 skipped (FA2 CUDA path).