### PR TITLE
fix(eagle3): reject non-positive draft_vocab_size / target_vocab_size

### DIFF
--- a/nemo_automodel/components/datasets/llm/eagle3.py
+++ b/nemo_automodel/components/datasets/llm/eagle3.py
@@ -88,6 +88,25 @@ def build_eagle3_token_mapping(
         - ``selected_token_ids`` has shape ``[draft_vocab_size]``
         - ``selected_token_mask`` has shape ``[target_vocab_size]``
     """
+    # Validate sizes up front. ``target_vocab_size`` must be positive (it
+    # sizes the dense count tensor + mask), and ``draft_vocab_size`` -- when
+    # supplied -- must be a positive integer. Without these guards a caller
+    # passing ``draft_vocab_size=0`` quietly gets an empty selection, and
+    # ``draft_vocab_size=-1`` interacts with the ``selected[:draft_vocab_size]``
+    # slice to drop the last special token instead of erroring -- both
+    # silently miscompile downstream rather than failing fast.
+    if not isinstance(target_vocab_size, int) or target_vocab_size <= 0:
+        raise ValueError(
+            f"build_eagle3_token_mapping requires target_vocab_size to be a "
+            f"positive integer, got target_vocab_size={target_vocab_size!r}."
+        )
+    if draft_vocab_size is not None and (not isinstance(draft_vocab_size, int) or draft_vocab_size <= 0):
+        raise ValueError(
+            f"build_eagle3_token_mapping requires draft_vocab_size to be a "
+            f"positive integer or None (= use the full target vocab), got "
+            f"draft_vocab_size={draft_vocab_size!r}."
+        )
+
     if draft_vocab_size is None or draft_vocab_size >= target_vocab_size:
         selected_token_ids = torch.arange(target_vocab_size, dtype=torch.long)
         selected_token_mask = torch.ones(target_vocab_size, dtype=torch.bool)

--- a/tests/unit_tests/speculative/test_eagle3.py
+++ b/tests/unit_tests/speculative/test_eagle3.py
@@ -90,6 +90,61 @@ def test_llama_eagle3_draft_forward_shape():
     assert logits.shape == (batch_size, seq_len, config.draft_vocab_size)
 
 
+def test_build_eagle3_token_mapping_rejects_non_positive_draft_vocab_size():
+    """``draft_vocab_size`` must be a positive int or ``None``.
+
+    Without validation, ``draft_vocab_size=0`` returns an empty selection
+    and ``draft_vocab_size=-1`` slices the special-token list (which has
+    nothing to do with the requested vocab size). Both are silent
+    miscompilations -- raise instead.
+    """
+
+    class DummyLoader:
+        def __iter__(self):
+            yield {
+                "input_ids": torch.tensor([[5, 9, 9, 3]], dtype=torch.long),
+                "loss_mask": torch.tensor([[0, 1, 1, 1]], dtype=torch.long),
+            }
+
+    for bad in (0, -1, -16):
+        with pytest.raises(ValueError, match="draft_vocab_size"):
+            build_eagle3_token_mapping(
+                DummyLoader(),
+                target_vocab_size=16,
+                draft_vocab_size=bad,
+                special_token_ids=[0, 1],
+            )
+
+    # Non-int (e.g. a float coming from YAML) is also rejected.
+    with pytest.raises(ValueError, match="draft_vocab_size"):
+        build_eagle3_token_mapping(
+            DummyLoader(),
+            target_vocab_size=16,
+            draft_vocab_size=4.0,  # type: ignore[arg-type]
+            special_token_ids=[0, 1],
+        )
+
+
+def test_build_eagle3_token_mapping_rejects_non_positive_target_vocab_size():
+    """``target_vocab_size`` must be a positive int; it sizes the count tensor."""
+
+    class DummyLoader:
+        def __iter__(self):
+            yield {
+                "input_ids": torch.tensor([[5, 9, 9, 3]], dtype=torch.long),
+                "loss_mask": torch.tensor([[0, 1, 1, 1]], dtype=torch.long),
+            }
+
+    for bad in (0, -1):
+        with pytest.raises(ValueError, match="target_vocab_size"):
+            build_eagle3_token_mapping(
+                DummyLoader(),
+                target_vocab_size=bad,
+                draft_vocab_size=4,
+                special_token_ids=[0, 1],
+            )
+
+
 def test_build_eagle3_token_mapping_keeps_requested_vocab_size():
     class DummyLoader:
         def __iter__(self):


### PR DESCRIPTION
## Summary

``build_eagle3_token_mapping`` did not validate its size inputs, so non-sensical configurations silently produced nonsensical mappings instead of erroring:

- ``draft_vocab_size=0`` returned an empty ``selected_token_ids`` tensor (downstream ``index_select`` over draft vocab would then yield zero-width logits).
- ``draft_vocab_size=-1`` interacted with ``selected[:draft_vocab_size]`` to drop the last element of the special-token list, then built an all-False ``selected_token_mask`` — a result with no defensible meaning that nevertheless trained for an arbitrarily long time before anyone noticed.

Validate up front in ``components/datasets/llm/eagle3.py``:
- ``target_vocab_size`` must be a positive ``int``.
- ``draft_vocab_size`` (when not ``None``) must be a positive ``int``.

Both raise ``ValueError`` referencing the offending field so the misconfiguration is caught at recipe setup.

## Test plan

- [x] Added ``test_build_eagle3_token_mapping_rejects_non_positive_draft_vocab_size`` covering ``{0, -1, -16, 4.0}``.
- [x] Added ``test_build_eagle3_token_mapping_rejects_non_positive_target_vocab_size`` covering ``{0, -1}``.
- [x] Local: ``pytest tests/unit_tests/speculative/`` — 25 passed, 2 skipped (FA2 CUDA path).