### PR TITLE
fix(test): initialize weights in mimo_v2_flash round-trip fixture

### DIFF
--- a/tests/unit_tests/models/mimo_v2_flash/test_state_dict_adapter.py
+++ b/tests/unit_tests/models/mimo_v2_flash/test_state_dict_adapter.py
@@ -364,6 +364,18 @@ class TestRoundTrip:
 
         torch.manual_seed(0)
         model = MiMoV2FlashForCausalLM(real_config, backend=backend_config)
+        # Run the model's own weight initializer. Several parameters --
+        # notably ``Gate.weight`` -- are created via ``nn.Parameter(torch.empty(...))``
+        # and only filled by ``init_weights`` / ``initialize_weights``. Without
+        # this call the underlying storage is whatever ``torch.empty`` happens
+        # to return: on CPU malloc usually hands back a zeroed page so the
+        # round-trip silently passes, but on CUDA ``cudaMalloc`` reuses freed
+        # device memory and the buffer often contains NaNs. NaNs are not
+        # mutated by ``to_hf`` / ``from_hf`` either, but
+        # ``torch.testing.assert_close`` defaults to ``equal_nan=False`` and
+        # treats NaN != NaN, so the test flakes only on the GPU L0 job at
+        # ``model.layers.1.mlp.gate.weight``.
+        model.initialize_weights(buffer_device=torch.device("cpu"), dtype=torch.float32)
         return model.to(torch.float32).eval()
 
     @pytest.fixture


### PR DESCRIPTION
## Summary

``tests/unit_tests/models/mimo_v2_flash/test_state_dict_adapter.py::TestRoundTrip::test_state_dict_roundtrip`` is intermittently failing in ``L0_Unit_Tests_GPU`` on main, e.g. the 2026-05-17 16:42 push CICD failure on ``c4a4c83``, and tripping check on PRs #2256, #2257, #2258, #2259, #2260:

```
AssertionError: Round-trip mismatch at model.layers.1.mlp.gate.weight
```

## Root cause

The ``tiny_model`` fixture constructs ``MiMoV2FlashForCausalLM`` and goes straight to ``.to(torch.float32).eval()`` without ever calling ``model.initialize_weights``. Several parameters -- ``Gate.weight`` for the routed-MoE layer in particular -- are declared as ``nn.Parameter(torch.empty(...))`` and only get filled by ``Gate.init_weights`` (reachable from ``MiMoV2FlashForCausalLM.initialize_weights``).

Without that call the parameter storage is whatever ``torch.empty`` returns:

- **CPU**: glibc ``malloc`` for fresh pages usually hands back zeroed memory, so the round-trip compares 0 == 0 and silently passes.
- **CUDA**: ``cudaMalloc`` reuses freed device memory, so the buffer occasionally contains NaNs. The ``to_hf`` / ``from_hf`` path preserves the bytes faithfully, but ``torch.testing.assert_close(..., equal_nan=False)`` (the default) treats NaN != NaN and the assertion fails. The flake rate is non-trivial -- see the empirical measurement below.

This is why the failure is GPU-only and always lands on ``mlp.gate.weight``: ``Gate`` is the first parameter in this model that is declared as raw ``torch.empty`` without an implicit ``reset_parameters``-style fallback.

## Empirical verification (single CUDA host, 5 runs each)

Running the same single test 5 times on a real CUDA box, switching ``test_state_dict_adapter.py`` between ``origin/main`` and this PR:

| fixture | pass | fail | result |
|---|---|---|---|
| ``origin/main`` (no ``initialize_weights``) | 3/5 | 2/5 | runs 2 and 4 raised ``Round-trip mismatch at model.layers.1.mlp.gate.weight`` |
| this PR (``initialize_weights`` added)      | 5/5 | 0/5 | all green |

The 40% empirical flake rate on a single host matches the qualitative "uninitialized memory occasionally contains NaN" story and lines up with the on-and-off failure we see across recent NVIDIA CI runs on main.

## Fix

Call ``model.initialize_weights(buffer_device=torch.device(""cpu""), dtype=torch.float32)`` in the fixture before ``.to(torch.float32).eval()``. This replaces every uninitialized ``torch.empty`` storage with a deterministic ``normal_`` sample and removes the NaN exposure on CUDA without changing semantics on CPU.

## Test plan

- [x] Local CPU: ``pytest tests/unit_tests/models/mimo_v2_flash/`` -- 97 passed (no regressions).
- [x] Local CUDA, ``origin/main`` fixture: 5 runs -> 3 PASS, 2 FAIL (confirms flake).
- [x] Local CUDA, this PR's fixture: 5 runs -> 5 PASS (confirms fix).
- [ ] Expected: ``L0_Unit_Tests_GPU`` now passes ``test_state_dict_roundtrip`` deterministically on every PR.