### PR TITLE
feat(speculative): add llama eagle2 recipe alias

### DIFF
--- a/examples/speculative/eagle1/llama_eagle1_mvp.yaml
+++ b/examples/speculative/eagle1/llama_eagle1_mvp.yaml
@@ -1,0 +1,31 @@
+recipe: TrainEagle1Recipe
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 30
+
+recipe_args:
+  target_model_name_or_path: meta-llama/Llama-3.2-1B
+  train_data_path: /path/to/train.jsonl
+  val_data_path: null
+  train_split: null
+  val_split: null
+  output_dir: ./outputs/eagle1_llama_mvp
+  seq_length: 1024
+  micro_batch_size: 1
+  grad_accumulation_steps: 1
+  num_workers: 0
+  num_epochs: 1
+  draft_num_hidden_layers: 1
+  hidden_loss_weight: 1.0
+  token_loss_weight: 0.1
+  freeze_embeddings: true
+  trust_remote_code: false
+  shuffle_seed: 42
+  log_every_steps: 10
+  max_grad_norm: 1.0
+
+optimizer:
+  lr: 1.0e-4
+  betas: [0.9, 0.95]
+  weight_decay: 0.0

--- a/examples/speculative/eagle2/llama_eagle2_mvp.yaml
+++ b/examples/speculative/eagle2/llama_eagle2_mvp.yaml
@@ -1,0 +1,31 @@
+recipe: TrainEagle2Recipe
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 30
+
+recipe_args:
+  target_model_name_or_path: meta-llama/Llama-3.2-1B
+  train_data_path: /path/to/train.jsonl
+  val_data_path: null
+  train_split: null
+  val_split: null
+  output_dir: ./outputs/eagle2_llama_mvp
+  seq_length: 1024
+  micro_batch_size: 1
+  grad_accumulation_steps: 1
+  num_workers: 0
+  num_epochs: 1
+  draft_num_hidden_layers: 1
+  hidden_loss_weight: 1.0
+  token_loss_weight: 0.1
+  freeze_embeddings: true
+  trust_remote_code: false
+  shuffle_seed: 42
+  log_every_steps: 10
+  max_grad_norm: 1.0
+
+optimizer:
+  lr: 1.0e-4
+  betas: [0.9, 0.95]
+  weight_decay: 0.0

--- a/nemo_automodel/components/speculative/eagle/__init__.py
+++ b/nemo_automodel/components/speculative/eagle/__init__.py
@@ -25,11 +25,17 @@ Import them directly from those modules.
 """
 
 from nemo_automodel.components.speculative.eagle.core import Eagle3TrainerModule
+from nemo_automodel.components.speculative.eagle.core_v12 import EagleTrainerModule
 from nemo_automodel.components.speculative.eagle.draft_llama import LlamaEagle3DraftModel
+from nemo_automodel.components.speculative.eagle.draft_llama_v12 import LlamaEagleDraftModel
 from nemo_automodel.components.speculative.eagle.target import HFEagle3TargetModel
+from nemo_automodel.components.speculative.eagle.target_v12 import HFEagleTargetModel
 
 __all__ = [
+    "EagleTrainerModule",
     "Eagle3TrainerModule",
+    "HFEagleTargetModel",
     "HFEagle3TargetModel",
+    "LlamaEagleDraftModel",
     "LlamaEagle3DraftModel",
 ]

--- a/nemo_automodel/components/speculative/eagle/core_v12.py
+++ b/nemo_automodel/components/speculative/eagle/core_v12.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Core EAGLE-1 / EAGLE-2 draft-training logic."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from nemo_automodel.components.loss.soft_ce import masked_soft_cross_entropy
+
+
+@dataclass
+class EagleStepMetrics:
+    """Aggregated metrics from one EAGLE-1 / EAGLE-2 training step."""
+
+    loss: torch.Tensor
+    hidden_loss: torch.Tensor
+    token_loss: torch.Tensor
+    accuracy: torch.Tensor
+    valid_tokens: torch.Tensor
+
+
+class EagleTrainerModule(nn.Module):
+    """Draft-side trainer for EAGLE-1 / EAGLE-2 hidden-state prediction."""
+
+    def __init__(
+        self,
+        draft_model: nn.Module,
+        *,
+        target_lm_head: nn.Module,
+        hidden_loss_weight: float = 1.0,
+        token_loss_weight: float = 0.1,
+    ):
+        super().__init__()
+        self.draft_model = draft_model
+        # Keep a non-registered reference so we do not duplicate the target lm_head
+        # inside DDP/state_dict, while still using its frozen weights for gradients
+        # w.r.t. the predicted hidden states.
+        object.__setattr__(self, "_target_lm_head", target_lm_head)
+        self.hidden_loss_weight = hidden_loss_weight
+        self.token_loss_weight = token_loss_weight
+        self.hidden_loss_fn = nn.SmoothL1Loss(reduction="none")
+
+    def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Project predicted hidden states through the frozen target lm_head."""
+        return F.linear(hidden_states, self._target_lm_head.weight)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+        loss_mask: torch.Tensor,
+        input_hidden_states: torch.Tensor,
+        target_hidden_states: torch.Tensor,
+        target_logits: torch.Tensor,
+    ) -> EagleStepMetrics:
+        """Run one EAGLE-1 / EAGLE-2 training step."""
+        predicted_hidden_states = self.draft_model(
+            input_ids=input_ids,
+            target_hidden_states=input_hidden_states,
+            attention_mask=attention_mask,
+        )
+        predicted_logits = self.compute_logits(predicted_hidden_states)
+
+        valid_mask = loss_mask.bool()
+        position_mask = valid_mask.unsqueeze(-1)
+        valid_tokens = valid_mask.sum()
+
+        hidden_loss = self.hidden_loss_fn(predicted_hidden_states, target_hidden_states).mean(dim=-1)
+        hidden_loss = hidden_loss[valid_mask].mean() if valid_mask.any() else hidden_loss.new_zeros(())
+
+        target_probs = torch.softmax(target_logits.float(), dim=-1).detach()
+        token_loss = masked_soft_cross_entropy(
+            logits=predicted_logits,
+            target_probs=target_probs,
+            position_mask=position_mask,
+        )
+        loss = self.hidden_loss_weight * hidden_loss + self.token_loss_weight * token_loss
+
+        target_token_ids = target_logits.argmax(dim=-1)
+        predicted_token_ids = predicted_logits.argmax(dim=-1)
+        correct = (predicted_token_ids == target_token_ids) & valid_mask
+        accuracy = correct.sum() / valid_tokens.clamp_min(1)
+
+        return EagleStepMetrics(
+            loss=loss,
+            hidden_loss=hidden_loss,
+            token_loss=token_loss,
+            accuracy=accuracy,
+            valid_tokens=valid_tokens,
+        )

--- a/nemo_automodel/components/speculative/eagle/draft_llama_v12.py
+++ b/nemo_automodel/components/speculative/eagle/draft_llama_v12.py
@@ -1,0 +1,185 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Minimal Llama-based draft model for EAGLE-1 / EAGLE-2 training."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+from transformers import LlamaConfig, PreTrainedModel
+
+from nemo_automodel.components.models.common import initialize_rms_norm_module
+from nemo_automodel.components.models.llama.rope_utils import (
+    LlamaRotaryEmbedding,
+    apply_rotary_pos_emb,
+)
+
+
+def _build_causal_mask(
+    attention_mask: torch.Tensor,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Build a standard causal + padding mask for eager attention."""
+    batch_size, seq_len = attention_mask.shape
+    causal = torch.full((seq_len, seq_len), torch.finfo(dtype).min, device=attention_mask.device, dtype=dtype)
+    causal = torch.triu(causal, diagonal=1)
+    causal = causal.unsqueeze(0).unsqueeze(0).expand(batch_size, 1, seq_len, seq_len)
+
+    expanded = (1.0 - attention_mask[:, None, None, :].to(dtype)) * torch.finfo(dtype).min
+    return causal + expanded
+
+
+class EagleLlamaAttention(nn.Module):
+    """Standard Llama-style self attention for the EAGLE-1/2 draft."""
+
+    def __init__(self, config: LlamaConfig):
+        super().__init__()
+        self.config = config
+        self.head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+        self.num_heads = config.num_attention_heads
+        self.num_key_value_heads = config.num_key_value_heads
+        self.num_key_value_groups = self.num_heads // self.num_key_value_heads
+        self.scaling = self.head_dim**-0.5
+
+        self.q_proj = nn.Linear(config.hidden_size, self.num_heads * self.head_dim, bias=config.attention_bias)
+        self.k_proj = nn.Linear(
+            config.hidden_size, self.num_key_value_heads * self.head_dim, bias=config.attention_bias
+        )
+        self.v_proj = nn.Linear(
+            config.hidden_size, self.num_key_value_heads * self.head_dim, bias=config.attention_bias
+        )
+        self.o_proj = nn.Linear(self.num_heads * self.head_dim, config.hidden_size, bias=config.attention_bias)
+        self.rotary_emb = LlamaRotaryEmbedding(config)
+
+    def _repeat_kv(self, tensor: torch.Tensor) -> torch.Tensor:
+        if self.num_key_value_groups == 1:
+            return tensor
+        return tensor.repeat_interleave(self.num_key_value_groups, dim=1)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor,
+        position_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        batch_size, seq_len, _ = hidden_states.shape
+        q = self.q_proj(hidden_states).view(batch_size, seq_len, self.num_heads, self.head_dim).transpose(1, 2)
+        k = (
+            self.k_proj(hidden_states)
+            .view(batch_size, seq_len, self.num_key_value_heads, self.head_dim)
+            .transpose(1, 2)
+        )
+        v = (
+            self.v_proj(hidden_states)
+            .view(batch_size, seq_len, self.num_key_value_heads, self.head_dim)
+            .transpose(1, 2)
+        )
+
+        cos, sin = self.rotary_emb(hidden_states, position_ids)
+        q, k = apply_rotary_pos_emb(q, k, cos, sin)
+        k = self._repeat_kv(k)
+        v = self._repeat_kv(v)
+
+        attn_weights = torch.matmul(q, k.transpose(-2, -1)) * self.scaling
+        attn_weights = attn_weights + attention_mask
+        attn_probs = torch.softmax(attn_weights.float(), dim=-1).to(q.dtype)
+        attn_output = torch.matmul(attn_probs, v)
+        attn_output = attn_output.transpose(1, 2).contiguous().view(batch_size, seq_len, -1)
+        return self.o_proj(attn_output)
+
+
+class EagleLlamaMLP(nn.Module):
+    """Standard SwiGLU MLP used by the EAGLE-1/2 draft."""
+
+    def __init__(self, config: LlamaConfig):
+        super().__init__()
+        self.gate_proj = nn.Linear(config.hidden_size, config.intermediate_size, bias=config.mlp_bias)
+        self.up_proj = nn.Linear(config.hidden_size, config.intermediate_size, bias=config.mlp_bias)
+        self.down_proj = nn.Linear(config.intermediate_size, config.hidden_size, bias=config.mlp_bias)
+        self.act_fn = nn.SiLU()
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.down_proj(self.act_fn(self.gate_proj(hidden_states)) * self.up_proj(hidden_states))
+
+
+class EagleLlamaDecoderLayer(nn.Module):
+    """Single decoder layer for the minimal EAGLE-1/2 draft model."""
+
+    def __init__(self, config: LlamaConfig):
+        super().__init__()
+        self.self_attn = EagleLlamaAttention(config)
+        self.mlp = EagleLlamaMLP(config)
+        self.input_layernorm = initialize_rms_norm_module("torch", config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = initialize_rms_norm_module("torch", config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor,
+        position_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states = self.self_attn(hidden_states, attention_mask=attention_mask, position_ids=position_ids)
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        return residual + hidden_states
+
+
+class LlamaEagleDraftModel(PreTrainedModel):
+    """Minimal Llama draft that predicts next-step hidden states."""
+
+    config_class = LlamaConfig
+    main_input_name = "input_ids"
+
+    def __init__(self, config: LlamaConfig):
+        super().__init__(config)
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.fc = nn.Linear(config.hidden_size * 2, config.hidden_size, bias=False)
+        num_layers = max(1, int(getattr(config, "draft_num_hidden_layers", config.num_hidden_layers)))
+        self.layers = nn.ModuleList([EagleLlamaDecoderLayer(config) for _ in range(num_layers)])
+        self.norm = initialize_rms_norm_module("torch", config.hidden_size, eps=config.rms_norm_eps)
+        self.post_init()
+
+    def copy_embeddings_from_target(self, target_embeddings: nn.Embedding) -> None:
+        """Copy the target model token embeddings into the draft embeddings."""
+        with torch.no_grad():
+            self.embed_tokens.weight.copy_(target_embeddings.weight.to(self.embed_tokens.weight.device))
+
+    def freeze_embeddings(self) -> None:
+        """Freeze draft token embeddings."""
+        self.embed_tokens.weight.requires_grad_(False)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        target_hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        inputs_embeds = self.embed_tokens(input_ids).to(target_hidden_states.dtype)
+        hidden_states = self.fc(torch.cat((inputs_embeds, target_hidden_states), dim=-1))
+
+        batch_size, seq_len, _ = hidden_states.shape
+        position_ids = (
+            torch.arange(seq_len, device=hidden_states.device, dtype=torch.long).unsqueeze(0).expand(batch_size, -1)
+        )
+        causal_mask = _build_causal_mask(attention_mask, hidden_states.dtype)
+
+        for layer in self.layers:
+            hidden_states = layer(hidden_states, attention_mask=causal_mask, position_ids=position_ids)
+        return self.norm(hidden_states)

--- a/nemo_automodel/components/speculative/eagle/target_v12.py
+++ b/nemo_automodel/components/speculative/eagle/target_v12.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Target-model wrapper for EAGLE-1 / EAGLE-2 training."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+import torch.nn as nn
+
+
+def _shift_left_with_zero(tensor: torch.Tensor) -> torch.Tensor:
+    """Shift a batched sequence tensor left and zero-fill the tail."""
+    tail = torch.zeros_like(tensor[:, :1])
+    return torch.cat((tensor[:, 1:], tail), dim=1)
+
+
+@dataclass
+class EagleTargetBatch:
+    """Target-model outputs needed by the EAGLE-1 / EAGLE-2 trainer."""
+
+    input_hidden_states: torch.Tensor
+    target_hidden_states: torch.Tensor
+    target_logits: torch.Tensor
+    input_ids: torch.Tensor
+    attention_mask: torch.Tensor
+    loss_mask: torch.Tensor
+
+
+class HFEagleTargetModel:
+    """Thin wrapper that exposes hidden-state supervision from a causal LM."""
+
+    def __init__(self, model: nn.Module):
+        self.model = model.eval()
+
+    def get_input_embeddings(self) -> nn.Embedding:
+        """Return the target model input embeddings."""
+        return self.model.get_input_embeddings()
+
+    def get_lm_head(self) -> nn.Module:
+        """Return the target model lm_head."""
+        return self.model.lm_head
+
+    @torch.no_grad()
+    def generate_batch(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+        loss_mask: torch.Tensor,
+    ) -> EagleTargetBatch:
+        """Run the target transformer and prepare shifted supervision tensors."""
+        outputs = self.model.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            output_attentions=False,
+            output_hidden_states=False,
+            use_cache=False,
+        )
+        hidden_states = outputs[0]
+        logits = self.model.lm_head(hidden_states)
+        return EagleTargetBatch(
+            input_hidden_states=hidden_states,
+            target_hidden_states=_shift_left_with_zero(hidden_states),
+            target_logits=_shift_left_with_zero(logits),
+            input_ids=_shift_left_with_zero(input_ids),
+            attention_mask=attention_mask,
+            loss_mask=_shift_left_with_zero(loss_mask),
+        )

--- a/nemo_automodel/recipes/llm/train_eagle1.py
+++ b/nemo_automodel/recipes/llm/train_eagle1.py
@@ -1,0 +1,314 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Minimal Llama-only EAGLE-1 training recipe."""
+
+from __future__ import annotations
+
+import logging
+import math
+import pathlib
+from types import SimpleNamespace
+
+import torch
+import torch.distributed as dist
+from torch.nn.parallel import DistributedDataParallel
+from transformers import AutoConfig, LlamaConfig
+
+from nemo_automodel._transformers import NeMoAutoModelForCausalLM
+from nemo_automodel._transformers.auto_tokenizer import NeMoAutoTokenizer
+from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
+from nemo_automodel.components.datasets.llm.eagle3 import build_eagle3_dataloader
+from nemo_automodel.components.distributed.init_utils import initialize_distributed
+from nemo_automodel.components.loggers.log_utils import setup_logging
+from nemo_automodel.components.speculative.eagle.core_v12 import EagleTrainerModule
+from nemo_automodel.components.speculative.eagle.draft_llama_v12 import LlamaEagleDraftModel
+from nemo_automodel.components.speculative.eagle.target_v12 import HFEagleTargetModel
+from nemo_automodel.recipes.base_recipe import BaseRecipe
+
+logger = logging.getLogger(__name__)
+
+
+def _all_reduce_mean(value: torch.Tensor) -> torch.Tensor:
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(value, op=dist.ReduceOp.SUM)
+        value = value / dist.get_world_size()
+    return value
+
+
+class TrainEagle1Recipe(BaseRecipe):
+    """Recipe for minimal Llama-only EAGLE-1 training."""
+
+    def __init__(self, cfg):
+        self.cfg = cfg
+
+    def setup(self):
+        """Build target model, draft model, data, optimizer, and trainer module."""
+        self.dist_env = initialize_distributed(
+            backend=self.cfg.get("dist_env", {}).get("backend", "nccl"),
+            timeout_minutes=self.cfg.get("dist_env", {}).get("timeout_minutes", 30),
+        )
+        setup_logging()
+
+        recipe_cfg = self.cfg.recipe_args
+        self.device = self.dist_env.device or torch.device("cpu")
+
+        target_path = recipe_cfg.target_model_name_or_path
+        target_config = AutoConfig.from_pretrained(
+            target_path, trust_remote_code=recipe_cfg.get("trust_remote_code", False)
+        )
+        architectures = getattr(target_config, "architectures", []) or []
+        if "LlamaForCausalLM" not in architectures:
+            raise ValueError(f"TrainEagle1Recipe currently supports only LlamaForCausalLM, got {architectures}")
+        if not isinstance(target_config, LlamaConfig):
+            raise ValueError(f"Expected LlamaConfig for EAGLE-1 training, got {type(target_config).__name__}")
+
+        self.tokenizer = NeMoAutoTokenizer.from_pretrained(
+            target_path,
+            trust_remote_code=recipe_cfg.get("trust_remote_code", False),
+        )
+        self.compute_dtype = torch.bfloat16 if self.device.type == "cuda" else torch.float32
+        self.target_model = NeMoAutoModelForCausalLM.from_pretrained(
+            target_path,
+            trust_remote_code=recipe_cfg.get("trust_remote_code", False),
+            torch_dtype=self.compute_dtype,
+            force_hf=True,
+        ).to(self.device)
+        self.target_model.requires_grad_(False)
+        self.target_wrapper = HFEagleTargetModel(self.target_model)
+
+        self.train_dataloader = build_eagle3_dataloader(
+            data_path=recipe_cfg.train_data_path,
+            tokenizer=self.tokenizer,
+            seq_length=recipe_cfg.seq_length,
+            batch_size=recipe_cfg.micro_batch_size,
+            shuffle=True,
+            num_workers=recipe_cfg.get("num_workers", 0),
+            split=recipe_cfg.get("train_split", None),
+            distributed=self.dist_env.world_size > 1,
+            shuffle_seed=recipe_cfg.get("shuffle_seed", 42),
+        )
+        self.val_dataloader = None
+        if recipe_cfg.get("val_data_path", None):
+            self.val_dataloader = build_eagle3_dataloader(
+                data_path=recipe_cfg.val_data_path,
+                tokenizer=self.tokenizer,
+                seq_length=recipe_cfg.seq_length,
+                batch_size=recipe_cfg.micro_batch_size,
+                shuffle=False,
+                num_workers=recipe_cfg.get("num_workers", 0),
+                split=recipe_cfg.get("val_split", None),
+                distributed=self.dist_env.world_size > 1,
+                shuffle_seed=recipe_cfg.get("shuffle_seed", 42),
+            )
+
+        draft_config = target_config.to_dict()
+        draft_config["architectures"] = ["LlamaEagleDraftModel"]
+        draft_config["draft_num_hidden_layers"] = int(recipe_cfg.get("draft_num_hidden_layers", 1))
+        self.draft_model = LlamaEagleDraftModel(LlamaConfig.from_dict(draft_config)).to(
+            device=self.device, dtype=self.compute_dtype
+        )
+        self.draft_model.copy_embeddings_from_target(self.target_wrapper.get_input_embeddings())
+        if recipe_cfg.get("freeze_embeddings", True):
+            self.draft_model.freeze_embeddings()
+
+        trainer_module = EagleTrainerModule(
+            self.draft_model,
+            target_lm_head=self.target_wrapper.get_lm_head(),
+            hidden_loss_weight=float(recipe_cfg.get("hidden_loss_weight", 1.0)),
+            token_loss_weight=float(recipe_cfg.get("token_loss_weight", 0.1)),
+        ).to(self.device)
+        if self.dist_env.world_size > 1:
+            trainer_module = DistributedDataParallel(
+                trainer_module,
+                device_ids=[self.device.index] if self.device.type == "cuda" else None,
+                output_device=self.device.index if self.device.type == "cuda" else None,
+                broadcast_buffers=False,
+                find_unused_parameters=False,
+            )
+        self.trainer_module = trainer_module
+
+        opt_cfg = self.cfg.optimizer
+        self.peak_lr = float(opt_cfg.lr)
+        self.optimizer = torch.optim.AdamW(
+            [p for p in self.trainer_module.parameters() if p.requires_grad],
+            lr=self.peak_lr,
+            betas=tuple(opt_cfg.get("betas", (0.9, 0.95))),
+            weight_decay=opt_cfg.get("weight_decay", 0.0),
+        )
+        self.grad_accumulation_steps = recipe_cfg.get("grad_accumulation_steps", 1)
+        self.max_grad_norm = recipe_cfg.get("max_grad_norm", 1.0)
+        self.num_epochs = recipe_cfg.num_epochs
+        self.log_every_steps = recipe_cfg.get("log_every_steps", 10)
+        self.output_dir = pathlib.Path(recipe_cfg.output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+        try:
+            num_batches_per_epoch = len(self.train_dataloader)
+        except TypeError:
+            num_batches_per_epoch = 0
+        total_optim_steps = max(1, (self.num_epochs * num_batches_per_epoch) // self.grad_accumulation_steps)
+        warmup_ratio = float(opt_cfg.get("warmup_ratio", 0.05))
+        min_lr_ratio = float(opt_cfg.get("min_lr_ratio", 0.1))
+        warmup_steps = max(1, int(warmup_ratio * total_optim_steps))
+
+        def _lr_lambda(step: int) -> float:
+            if step < warmup_steps:
+                return float(step + 1) / float(warmup_steps)
+            progress = (step - warmup_steps) / max(1, total_optim_steps - warmup_steps)
+            progress = min(max(progress, 0.0), 1.0)
+            cosine = 0.5 * (1.0 + math.cos(math.pi * progress))
+            return min_lr_ratio + (1.0 - min_lr_ratio) * cosine
+
+        self.lr_scheduler = torch.optim.lr_scheduler.LambdaLR(self.optimizer, _lr_lambda)
+        self.total_optim_steps = total_optim_steps
+        self.runtime = SimpleNamespace(global_step=0)
+
+    def _module(self):
+        return (
+            self.trainer_module.module
+            if isinstance(self.trainer_module, DistributedDataParallel)
+            else self.trainer_module
+        )
+
+    def _save_checkpoint(self, name: str):
+        if not self.dist_env.is_main:
+            return
+        save_dir = self.output_dir / name
+        save_dir.mkdir(parents=True, exist_ok=True)
+        torch.save(self._module().draft_model.state_dict(), save_dir / "draft_model.pt")
+        self._module().draft_model.config.save_pretrained(save_dir)
+        torch.save({"global_step": self.runtime.global_step}, save_dir / "eagle1_meta.pt")
+
+    def _run_eval(self):
+        if self.val_dataloader is None:
+            return None
+        self.trainer_module.eval()
+        total_loss = torch.zeros((), device=self.device)
+        total_acc = torch.zeros((), device=self.device)
+        total_batches = torch.zeros((), device=self.device)
+        with torch.no_grad():
+            for batch in self.val_dataloader:
+                batch = {k: v.to(self.device, non_blocking=True) for k, v in batch.items()}
+                target_batch = self.target_wrapper.generate_batch(
+                    input_ids=batch["input_ids"],
+                    attention_mask=batch["attention_mask"],
+                    loss_mask=batch["loss_mask"],
+                )
+                metrics = self.trainer_module(
+                    input_ids=target_batch.input_ids,
+                    attention_mask=target_batch.attention_mask,
+                    loss_mask=target_batch.loss_mask,
+                    input_hidden_states=target_batch.input_hidden_states,
+                    target_hidden_states=target_batch.target_hidden_states,
+                    target_logits=target_batch.target_logits,
+                )
+                total_loss += metrics.loss.detach()
+                total_acc += metrics.accuracy.detach()
+                total_batches += 1
+
+        total_loss = _all_reduce_mean(total_loss)
+        total_acc = _all_reduce_mean(total_acc)
+        total_batches = _all_reduce_mean(total_batches)
+        self.trainer_module.train()
+        return {
+            "val_loss": (total_loss / total_batches.clamp_min(1)).item(),
+            "val_accuracy": (total_acc / total_batches.clamp_min(1)).item(),
+        }
+
+    def run_train_validation_loop(self):
+        """Run the training loop."""
+        self.trainer_module.train()
+        for epoch_idx in range(self.num_epochs):
+            if hasattr(self.train_dataloader, "sampler") and hasattr(self.train_dataloader.sampler, "set_epoch"):
+                self.train_dataloader.sampler.set_epoch(epoch_idx)
+
+            running_loss = 0.0
+            running_acc = 0.0
+            micro_step = 0
+            completed_steps = 0
+            last_batch_idx = -1
+            for batch_idx, batch in enumerate(self.train_dataloader):
+                last_batch_idx = batch_idx
+                batch = {k: v.to(self.device, non_blocking=True) for k, v in batch.items()}
+                target_batch = self.target_wrapper.generate_batch(
+                    input_ids=batch["input_ids"],
+                    attention_mask=batch["attention_mask"],
+                    loss_mask=batch["loss_mask"],
+                )
+                metrics = self.trainer_module(
+                    input_ids=target_batch.input_ids,
+                    attention_mask=target_batch.attention_mask,
+                    loss_mask=target_batch.loss_mask,
+                    input_hidden_states=target_batch.input_hidden_states,
+                    target_hidden_states=target_batch.target_hidden_states,
+                    target_logits=target_batch.target_logits,
+                )
+                loss = metrics.loss / self.grad_accumulation_steps
+                loss.backward()
+
+                running_loss += metrics.loss.detach().item()
+                running_acc += metrics.accuracy.detach().item()
+                micro_step += 1
+
+                if micro_step % self.grad_accumulation_steps == 0:
+                    torch.nn.utils.clip_grad_norm_(self.trainer_module.parameters(), self.max_grad_norm)
+                    self.optimizer.step()
+                    self.optimizer.zero_grad(set_to_none=True)
+                    self.lr_scheduler.step()
+                    self.runtime.global_step += 1
+                    completed_steps += 1
+
+                    if self.dist_env.is_main and self.runtime.global_step % self.log_every_steps == 0:
+                        avg_loss = running_loss / self.log_every_steps
+                        avg_acc = running_acc / self.log_every_steps
+                        logger.info(
+                            "epoch=%d step=%d loss=%.4f acc=%.4f lr=%.6g",
+                            epoch_idx,
+                            self.runtime.global_step,
+                            avg_loss,
+                            avg_acc,
+                            self.lr_scheduler.get_last_lr()[0],
+                        )
+                        running_loss = 0.0
+                        running_acc = 0.0
+
+            if micro_step % self.grad_accumulation_steps != 0:
+                torch.nn.utils.clip_grad_norm_(self.trainer_module.parameters(), self.max_grad_norm)
+                self.optimizer.step()
+                self.optimizer.zero_grad(set_to_none=True)
+                self.lr_scheduler.step()
+                self.runtime.global_step += 1
+                completed_steps += 1
+
+            eval_metrics = self._run_eval()
+            if self.dist_env.is_main:
+                msg = f"Finished epoch {epoch_idx + 1}/{self.num_epochs} completed_steps={completed_steps}"
+                if eval_metrics is not None:
+                    msg += f" val_loss={eval_metrics['val_loss']:.4f} val_accuracy={eval_metrics['val_accuracy']:.4f}"
+                logger.info(msg)
+
+            checkpoint_name = f"epoch_{epoch_idx + 1}"
+            if last_batch_idx >= 0:
+                self._save_checkpoint(checkpoint_name)
+
+
+def main(config_path: str | None = None):
+    """Entrypoint for ``TrainEagle1Recipe``."""
+    if config_path is None:
+        raise ValueError("config_path is required for TrainEagle1Recipe")
+    cfg = parse_args_and_load_config(config_path)
+    trainer = TrainEagle1Recipe(cfg)
+    trainer.setup()
+    trainer.run_train_validation_loop()

--- a/nemo_automodel/recipes/llm/train_eagle2.py
+++ b/nemo_automodel/recipes/llm/train_eagle2.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Minimal Llama-only EAGLE-2 training recipe.
+
+EAGLE-2 reuses the same draft-model training objective as EAGLE-1. The
+difference is in the speculative decoding tree policy at inference time.
+This recipe exists as an explicit entrypoint so users can train a draft
+checkpoint intended for an EAGLE-2 deployment workflow without having to
+remember that the underlying optimization is identical to EAGLE-1.
+"""
+
+from __future__ import annotations
+
+from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
+from nemo_automodel.recipes.llm.train_eagle1 import TrainEagle1Recipe
+
+
+class TrainEagle2Recipe(TrainEagle1Recipe):
+    """Recipe alias for EAGLE-2 draft training."""
+
+
+def main(config_path: str | None = None):
+    """Entrypoint for ``TrainEagle2Recipe``."""
+    if config_path is None:
+        raise ValueError("config_path is required for TrainEagle2Recipe")
+    cfg = parse_args_and_load_config(config_path)
+    trainer = TrainEagle2Recipe(cfg)
+    trainer.setup()
+    trainer.run_train_validation_loop()

--- a/tests/unit_tests/speculative/test_eagle12.py
+++ b/tests/unit_tests/speculative/test_eagle12.py
@@ -1,0 +1,129 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+from transformers import LlamaConfig, LlamaForCausalLM
+
+from nemo_automodel.components.speculative.eagle.core_v12 import EagleTrainerModule
+from nemo_automodel.components.speculative.eagle.draft_llama_v12 import LlamaEagleDraftModel
+from nemo_automodel.components.speculative.eagle.target_v12 import (
+    HFEagleTargetModel,
+    _shift_left_with_zero,
+)
+
+
+def _build_tiny_target(num_hidden_layers: int = 4) -> LlamaForCausalLM:
+    config = LlamaConfig(
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=num_hidden_layers,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        vocab_size=64,
+        max_position_embeddings=32,
+    )
+    config.torch_dtype = torch.float32
+    return LlamaForCausalLM(config).to(torch.float32).eval()
+
+
+def _build_tiny_draft_model() -> LlamaEagleDraftModel:
+    config = LlamaConfig(
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        vocab_size=64,
+        max_position_embeddings=32,
+    )
+    config.torch_dtype = torch.float32
+    config.draft_num_hidden_layers = 1
+    return LlamaEagleDraftModel(config).to(torch.float32)
+
+
+def test_llama_eagle_draft_forward_shape():
+    model = _build_tiny_draft_model()
+    batch_size, seq_len = 2, 8
+    input_ids = torch.randint(0, model.config.vocab_size, (batch_size, seq_len))
+    target_hidden_states = torch.randn(batch_size, seq_len, model.config.hidden_size)
+    attention_mask = torch.ones(batch_size, seq_len, dtype=torch.long)
+
+    hidden_states = model(
+        input_ids=input_ids,
+        target_hidden_states=target_hidden_states,
+        attention_mask=attention_mask,
+    )
+    assert hidden_states.shape == (batch_size, seq_len, model.config.hidden_size)
+
+
+def test_eagle_target_batch_shifts_hidden_states_logits_and_ids():
+    torch.manual_seed(0)
+    model = _build_tiny_target()
+    target = HFEagleTargetModel(model)
+
+    input_ids = torch.randint(1, model.config.vocab_size, (2, 5))
+    attention_mask = torch.ones_like(input_ids)
+    loss_mask = torch.tensor([[1, 1, 1, 1, 0], [0, 1, 1, 1, 1]], dtype=torch.long)
+
+    batch = target.generate_batch(input_ids=input_ids, attention_mask=attention_mask, loss_mask=loss_mask)
+
+    torch.testing.assert_close(batch.input_ids, _shift_left_with_zero(input_ids))
+    torch.testing.assert_close(batch.loss_mask, _shift_left_with_zero(loss_mask))
+    torch.testing.assert_close(batch.attention_mask, attention_mask)
+    torch.testing.assert_close(batch.target_hidden_states, _shift_left_with_zero(batch.input_hidden_states))
+
+    with torch.no_grad():
+        outputs = model.model(input_ids=input_ids, attention_mask=attention_mask, use_cache=False)
+        expected_logits = _shift_left_with_zero(model.lm_head(outputs[0]))
+    torch.testing.assert_close(batch.target_logits, expected_logits)
+
+
+def test_eagle_trainer_runs_and_backprops():
+    torch.manual_seed(0)
+    target_model = _build_tiny_target()
+    target_model.requires_grad_(False)
+    draft_model = _build_tiny_draft_model()
+    trainer = EagleTrainerModule(draft_model, target_lm_head=target_model.lm_head)
+
+    batch_size, seq_len = 2, 6
+    input_ids = torch.randint(0, draft_model.config.vocab_size, (batch_size, seq_len))
+    attention_mask = torch.ones(batch_size, seq_len, dtype=torch.long)
+    loss_mask = torch.ones(batch_size, seq_len, dtype=torch.long)
+    input_hidden_states = torch.randn(batch_size, seq_len, draft_model.config.hidden_size)
+    target_hidden_states = torch.randn(batch_size, seq_len, draft_model.config.hidden_size)
+    target_logits = torch.randn(batch_size, seq_len, target_model.config.vocab_size)
+
+    metrics = trainer(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        loss_mask=loss_mask,
+        input_hidden_states=input_hidden_states,
+        target_hidden_states=target_hidden_states,
+        target_logits=target_logits,
+    )
+
+    assert metrics.loss.dim() == 0
+    assert metrics.hidden_loss.dim() == 0
+    assert metrics.token_loss.dim() == 0
+    assert torch.isfinite(metrics.loss)
+    assert 0.0 <= metrics.accuracy.item() <= 1.0
+    assert metrics.valid_tokens.item() == batch_size * seq_len
+
+    metrics.loss.backward()
+    has_grad = any(
+        p.grad is not None and torch.isfinite(p.grad).all() and p.grad.abs().sum().item() > 0
+        for p in draft_model.parameters()
+        if p.requires_grad
+    )
+    assert has_grad, "expected at least one parameter to receive a non-zero gradient"

--- a/tests/unit_tests/speculative/test_eagle12_coverage.py
+++ b/tests/unit_tests/speculative/test_eagle12_coverage.py
@@ -1,0 +1,463 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Additional unit tests for EAGLE-1/2 coverage: draft helpers, target accessors,
+recipe utilities, trainer module edge cases, and entrypoint validation."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+from transformers import LlamaConfig, LlamaForCausalLM
+
+from nemo_automodel.components.speculative.eagle.core_v12 import EagleStepMetrics, EagleTrainerModule
+from nemo_automodel.components.speculative.eagle.draft_llama_v12 import (
+    LlamaEagleDraftModel,
+    _build_causal_mask,
+)
+from nemo_automodel.components.speculative.eagle.target_v12 import (
+    EagleTargetBatch,
+    HFEagleTargetModel,
+    _shift_left_with_zero,
+)
+from nemo_automodel.recipes.llm.train_eagle1 import TrainEagle1Recipe, _all_reduce_mean
+from nemo_automodel.recipes.llm.train_eagle1 import main as eagle1_main
+from nemo_automodel.recipes.llm.train_eagle2 import TrainEagle2Recipe
+from nemo_automodel.recipes.llm.train_eagle2 import main as eagle2_main
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _tiny_llama_config(**overrides) -> LlamaConfig:
+    defaults = dict(
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        vocab_size=64,
+        max_position_embeddings=32,
+    )
+    defaults.update(overrides)
+    cfg = LlamaConfig(**defaults)
+    cfg.torch_dtype = torch.float32
+    return cfg
+
+
+def _tiny_target() -> LlamaForCausalLM:
+    return LlamaForCausalLM(_tiny_llama_config()).to(torch.float32).eval()
+
+
+def _tiny_draft() -> LlamaEagleDraftModel:
+    cfg = _tiny_llama_config()
+    cfg.draft_num_hidden_layers = 1
+    return LlamaEagleDraftModel(cfg).to(torch.float32)
+
+
+# ---------------------------------------------------------------------------
+# draft_llama_v12: _build_causal_mask
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCausalMask:
+    def test_shape_and_dtype(self):
+        mask = torch.ones(2, 4, dtype=torch.long)
+        result = _build_causal_mask(mask, torch.float32)
+        assert result.shape == (2, 1, 4, 4)
+        assert result.dtype == torch.float32
+
+    def test_causal_upper_triangle_is_masked(self):
+        mask = torch.ones(1, 3, dtype=torch.long)
+        result = _build_causal_mask(mask, torch.float32)
+        result = result.squeeze()
+        assert result[0, 0].item() == 0.0
+        assert result[0, 1] < -1e30
+        assert result[1, 0].item() == 0.0
+        assert result[1, 1].item() == 0.0
+        assert result[1, 2] < -1e30
+
+    def test_padding_positions_are_masked(self):
+        mask = torch.tensor([[1, 1, 0]], dtype=torch.long)
+        result = _build_causal_mask(mask, torch.float32).squeeze()
+        assert result[0, 2] < -1e30
+        assert result[1, 2] < -1e30
+
+
+# ---------------------------------------------------------------------------
+# draft_llama_v12: copy_embeddings / freeze_embeddings / _repeat_kv
+# ---------------------------------------------------------------------------
+
+
+class TestDraftModelHelpers:
+    def test_copy_embeddings_from_target(self):
+        target = _tiny_target()
+        draft = _tiny_draft()
+        draft.copy_embeddings_from_target(target.get_input_embeddings())
+        torch.testing.assert_close(
+            draft.embed_tokens.weight.data,
+            target.get_input_embeddings().weight.data,
+        )
+
+    def test_freeze_embeddings(self):
+        draft = _tiny_draft()
+        assert draft.embed_tokens.weight.requires_grad
+        draft.freeze_embeddings()
+        assert not draft.embed_tokens.weight.requires_grad
+
+    def test_repeat_kv_noop_when_groups_equal_one(self):
+        cfg = _tiny_llama_config(num_attention_heads=2, num_key_value_heads=2)
+        cfg.draft_num_hidden_layers = 1
+        draft = LlamaEagleDraftModel(cfg)
+        attn = draft.layers[0].self_attn
+        assert attn.num_key_value_groups == 1
+        t = torch.randn(1, 2, 4, 8)
+        out = attn._repeat_kv(t)
+        assert out is t
+
+    def test_repeat_kv_when_groups_greater_than_one(self):
+        cfg = _tiny_llama_config(num_attention_heads=4, num_key_value_heads=2)
+        cfg.draft_num_hidden_layers = 1
+        draft = LlamaEagleDraftModel(cfg)
+        attn = draft.layers[0].self_attn
+        assert attn.num_key_value_groups == 2
+        t = torch.randn(1, 2, 4, 8)
+        out = attn._repeat_kv(t)
+        assert out.shape == (1, 4, 4, 8)
+
+    def test_draft_model_respects_draft_num_hidden_layers(self):
+        cfg = _tiny_llama_config(num_hidden_layers=4)
+        cfg.draft_num_hidden_layers = 2
+        model = LlamaEagleDraftModel(cfg)
+        assert len(model.layers) == 2
+
+
+# ---------------------------------------------------------------------------
+# target_v12: accessors
+# ---------------------------------------------------------------------------
+
+
+class TestTargetAccessors:
+    def test_get_input_embeddings(self):
+        target = _tiny_target()
+        wrapper = HFEagleTargetModel(target)
+        assert wrapper.get_input_embeddings() is target.get_input_embeddings()
+
+    def test_get_lm_head(self):
+        target = _tiny_target()
+        wrapper = HFEagleTargetModel(target)
+        assert wrapper.get_lm_head() is target.lm_head
+
+
+# ---------------------------------------------------------------------------
+# target_v12: _shift_left_with_zero edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestShiftLeftWithZero:
+    def test_single_element_sequence(self):
+        t = torch.tensor([[42]])
+        result = _shift_left_with_zero(t)
+        assert result.shape == (1, 1)
+        assert result[0, 0].item() == 0
+
+    def test_3d_tensor(self):
+        t = torch.tensor([[[1.0, 2.0], [3.0, 4.0]]])
+        result = _shift_left_with_zero(t)
+        torch.testing.assert_close(result[0, 0], torch.tensor([3.0, 4.0]))
+        torch.testing.assert_close(result[0, 1], torch.tensor([0.0, 0.0]))
+
+
+# ---------------------------------------------------------------------------
+# target_v12: EagleTargetBatch dataclass
+# ---------------------------------------------------------------------------
+
+
+def test_eagle_target_batch_fields():
+    dummy = torch.zeros(1)
+    batch = EagleTargetBatch(
+        input_hidden_states=dummy,
+        target_hidden_states=dummy,
+        target_logits=dummy,
+        input_ids=dummy,
+        attention_mask=dummy,
+        loss_mask=dummy,
+    )
+    assert hasattr(batch, "input_hidden_states")
+    assert hasattr(batch, "target_logits")
+
+
+# ---------------------------------------------------------------------------
+# core_v12: EagleStepMetrics dataclass
+# ---------------------------------------------------------------------------
+
+
+def test_eagle_step_metrics_fields():
+    dummy = torch.zeros(1)
+    m = EagleStepMetrics(loss=dummy, hidden_loss=dummy, token_loss=dummy, accuracy=dummy, valid_tokens=dummy)
+    assert m.loss is dummy
+
+
+# ---------------------------------------------------------------------------
+# core_v12: compute_logits
+# ---------------------------------------------------------------------------
+
+
+def test_compute_logits_shape():
+    target = _tiny_target()
+    draft = _tiny_draft()
+    trainer = EagleTrainerModule(draft, target_lm_head=target.lm_head)
+    hidden = torch.randn(2, 4, 16)
+    logits = trainer.compute_logits(hidden)
+    assert logits.shape == (2, 4, 64)
+
+
+# ---------------------------------------------------------------------------
+# core_v12: forward with all-zero loss_mask (edge case)
+# ---------------------------------------------------------------------------
+
+
+def test_trainer_forward_with_zero_loss_mask():
+    torch.manual_seed(0)
+    target = _tiny_target()
+    target.requires_grad_(False)
+    draft = _tiny_draft()
+    trainer = EagleTrainerModule(draft, target_lm_head=target.lm_head)
+
+    bs, sl = 2, 4
+    metrics = trainer(
+        input_ids=torch.randint(0, 64, (bs, sl)),
+        attention_mask=torch.ones(bs, sl, dtype=torch.long),
+        loss_mask=torch.zeros(bs, sl, dtype=torch.long),
+        input_hidden_states=torch.randn(bs, sl, 16),
+        target_hidden_states=torch.randn(bs, sl, 16),
+        target_logits=torch.randn(bs, sl, 64),
+    )
+    assert metrics.valid_tokens.item() == 0
+    assert torch.isfinite(metrics.loss)
+
+
+# ---------------------------------------------------------------------------
+# core_v12: custom loss weights
+# ---------------------------------------------------------------------------
+
+
+def test_trainer_custom_loss_weights():
+    torch.manual_seed(0)
+    target = _tiny_target()
+    target.requires_grad_(False)
+    draft = _tiny_draft()
+
+    trainer_h = EagleTrainerModule(draft, target_lm_head=target.lm_head, hidden_loss_weight=10.0, token_loss_weight=0.0)
+    bs, sl = 1, 4
+    kwargs = dict(
+        input_ids=torch.randint(0, 64, (bs, sl)),
+        attention_mask=torch.ones(bs, sl, dtype=torch.long),
+        loss_mask=torch.ones(bs, sl, dtype=torch.long),
+        input_hidden_states=torch.randn(bs, sl, 16),
+        target_hidden_states=torch.randn(bs, sl, 16),
+        target_logits=torch.randn(bs, sl, 64),
+    )
+    metrics = trainer_h(**kwargs)
+    torch.testing.assert_close(metrics.loss, 10.0 * metrics.hidden_loss, atol=1e-5, rtol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# train_eagle1: _all_reduce_mean (non-distributed path)
+# ---------------------------------------------------------------------------
+
+
+def test_all_reduce_mean_non_distributed():
+    t = torch.tensor(4.0)
+    result = _all_reduce_mean(t)
+    assert result.item() == 4.0
+
+
+# ---------------------------------------------------------------------------
+# train_eagle1: main() / train_eagle2: main() ValueError guards
+# ---------------------------------------------------------------------------
+
+
+def test_eagle1_main_requires_config():
+    with pytest.raises(ValueError, match="config_path is required"):
+        eagle1_main(config_path=None)
+
+
+def test_eagle2_main_requires_config():
+    with pytest.raises(ValueError, match="config_path is required"):
+        eagle2_main(config_path=None)
+
+
+# ---------------------------------------------------------------------------
+# train_eagle1: TrainEagle1Recipe construction
+# ---------------------------------------------------------------------------
+
+
+def test_eagle1_recipe_init():
+    cfg = MagicMock()
+    recipe = TrainEagle1Recipe(cfg)
+    assert recipe.cfg is cfg
+
+
+# ---------------------------------------------------------------------------
+# train_eagle2: TrainEagle2Recipe is subclass of TrainEagle1Recipe
+# ---------------------------------------------------------------------------
+
+
+def test_eagle2_is_subclass():
+    assert issubclass(TrainEagle2Recipe, TrainEagle1Recipe)
+
+
+# ---------------------------------------------------------------------------
+# train_eagle1: _module(), _save_checkpoint(), _run_eval() via manual wiring
+# ---------------------------------------------------------------------------
+
+
+class TestRecipeInternals:
+    def _build_recipe(self, tmp_path):
+        """Wire up a recipe with tiny models, no distributed init needed."""
+        target = _tiny_target()
+        target.requires_grad_(False)
+        draft = _tiny_draft()
+
+        trainer_module = EagleTrainerModule(draft, target_lm_head=target.lm_head)
+
+        recipe = TrainEagle1Recipe.__new__(TrainEagle1Recipe)
+        recipe.device = torch.device("cpu")
+        recipe.dist_env = SimpleNamespace(is_main=True, world_size=1)
+        recipe.trainer_module = trainer_module
+        recipe.target_wrapper = HFEagleTargetModel(target)
+        recipe.output_dir = tmp_path
+        recipe.runtime = SimpleNamespace(global_step=5)
+        recipe.grad_accumulation_steps = 1
+        recipe.max_grad_norm = 1.0
+        recipe.num_epochs = 1
+        recipe.log_every_steps = 1
+        recipe.peak_lr = 1e-4
+
+        recipe.optimizer = torch.optim.AdamW([p for p in trainer_module.parameters() if p.requires_grad], lr=1e-4)
+        recipe.lr_scheduler = torch.optim.lr_scheduler.LambdaLR(recipe.optimizer, lambda s: 1.0)
+
+        return recipe
+
+    def test_module_returns_unwrapped(self, tmp_path):
+        recipe = self._build_recipe(tmp_path)
+        assert recipe._module() is recipe.trainer_module
+
+    def test_save_checkpoint_creates_files(self, tmp_path):
+        recipe = self._build_recipe(tmp_path)
+        recipe._save_checkpoint("test_ckpt")
+        ckpt_dir = tmp_path / "test_ckpt"
+        assert (ckpt_dir / "draft_model.pt").exists()
+        assert (ckpt_dir / "eagle1_meta.pt").exists()
+        meta = torch.load(ckpt_dir / "eagle1_meta.pt", weights_only=True)
+        assert meta["global_step"] == 5
+
+    def test_save_checkpoint_skipped_when_not_main(self, tmp_path):
+        recipe = self._build_recipe(tmp_path)
+        recipe.dist_env.is_main = False
+        recipe._save_checkpoint("skipped")
+        assert not (tmp_path / "skipped").exists()
+
+    def test_run_eval_returns_none_without_val_loader(self, tmp_path):
+        recipe = self._build_recipe(tmp_path)
+        recipe.val_dataloader = None
+        assert recipe._run_eval() is None
+
+    def test_run_eval_returns_metrics_with_val_loader(self, tmp_path):
+        recipe = self._build_recipe(tmp_path)
+        bs, sl = 2, 6
+        val_data = TensorDataset(
+            torch.randint(0, 64, (4, sl)),
+            torch.ones(4, sl, dtype=torch.long),
+            torch.ones(4, sl, dtype=torch.long),
+        )
+        val_loader = DataLoader(val_data, batch_size=bs)
+
+        class _KeyedLoader:
+            def __init__(self, loader):
+                self._loader = loader
+
+            def __iter__(self):
+                for ids, attn, lm in self._loader:
+                    yield {"input_ids": ids, "attention_mask": attn, "loss_mask": lm}
+
+        recipe.val_dataloader = _KeyedLoader(val_loader)
+        result = recipe._run_eval()
+        assert result is not None
+        assert "val_loss" in result
+        assert "val_accuracy" in result
+
+    def test_run_train_validation_loop_single_epoch(self, tmp_path):
+        recipe = self._build_recipe(tmp_path)
+        recipe.val_dataloader = None
+        bs, sl = 2, 6
+        train_data = TensorDataset(
+            torch.randint(0, 64, (4, sl)),
+            torch.ones(4, sl, dtype=torch.long),
+            torch.ones(4, sl, dtype=torch.long),
+        )
+        train_loader = DataLoader(train_data, batch_size=bs)
+
+        class _KeyedLoader:
+            def __init__(self, loader):
+                self._loader = loader
+
+            def __iter__(self):
+                for ids, attn, lm in self._loader:
+                    yield {"input_ids": ids, "attention_mask": attn, "loss_mask": lm}
+
+            def __len__(self):
+                return len(self._loader)
+
+        recipe.train_dataloader = _KeyedLoader(train_loader)
+        recipe.num_epochs = 1
+        recipe.log_every_steps = 1
+        recipe.run_train_validation_loop()
+        assert recipe.runtime.global_step >= 1
+        assert (tmp_path / "epoch_1").exists()
+
+    def test_run_train_loop_with_grad_accumulation(self, tmp_path):
+        recipe = self._build_recipe(tmp_path)
+        recipe.val_dataloader = None
+        recipe.grad_accumulation_steps = 3
+        bs, sl = 1, 6
+        train_data = TensorDataset(
+            torch.randint(0, 64, (5, sl)),
+            torch.ones(5, sl, dtype=torch.long),
+            torch.ones(5, sl, dtype=torch.long),
+        )
+        train_loader = DataLoader(train_data, batch_size=bs)
+
+        class _KeyedLoader:
+            def __init__(self, loader):
+                self._loader = loader
+
+            def __iter__(self):
+                for ids, attn, lm in self._loader:
+                    yield {"input_ids": ids, "attention_mask": attn, "loss_mask": lm}
+
+            def __len__(self):
+                return len(self._loader)
+
+        recipe.train_dataloader = _KeyedLoader(train_loader)
+        recipe.num_epochs = 1
+        initial_step = recipe.runtime.global_step
+        recipe.run_train_validation_loop()
+        assert recipe.runtime.global_step - initial_step == 2

--- a/tests/unit_tests/speculative/test_eagle2_recipe.py
+++ b/tests/unit_tests/speculative/test_eagle2_recipe.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nemo_automodel.cli.utils import resolve_recipe_name
+from nemo_automodel.recipes.llm.train_eagle1 import TrainEagle1Recipe
+from nemo_automodel.recipes.llm.train_eagle2 import TrainEagle2Recipe
+
+
+def test_eagle2_recipe_resolves_and_inherits_eagle1():
+    assert issubclass(TrainEagle2Recipe, TrainEagle1Recipe)
+    assert resolve_recipe_name("TrainEagle2Recipe") == "nemo_automodel.recipes.llm.train_eagle2.TrainEagle2Recipe"


### PR DESCRIPTION
## Summary

- Add `nemo_automodel/recipes/llm/train_eagle2.py` as a thin subclass alias of `TrainEagle1Recipe`.
- Add an explicit `examples/speculative/eagle2/llama_eagle2_mvp.yaml` so users can target an EAGLE-2 deployment workflow without remembering that the draft training objective is identical to EAGLE-1.
- EAGLE-2 differs from EAGLE-1 only in the speculative-decoding tree policy at inference time; reusing the EAGLE-1 trainer keeps a single source of truth and avoids fabricating a second training loop.

Stacked on top of #2263 (EAGLE-1 training recipe). The eagle2 PR will collapse to a single commit once #2263 lands.

## Test plan

- [x] `pytest tests/unit_tests/speculative/test_eagle2_recipe.py` — confirms `TrainEagle2Recipe` is registered via `resolve_recipe_name` and inherits from `TrainEagle1Recipe`.
- [x] `ruff format --check` and `ruff check` pass on all touched files.