### PR TITLE
fix: Fix Qwen3-VL-MoE lm_head checkpoint loading

### DIFF
--- a/nemo_automodel/components/checkpoint/utils.py
+++ b/nemo_automodel/components/checkpoint/utils.py
@@ -49,6 +49,7 @@ def is_tied_word_embeddings(model: nn.Module) -> bool:
     """
     non_tied_lm_head_models = {
         "Qwen3OmniMoeThinkerForConditionalGeneration",  # complicated config structure
+        "Qwen3VLMoeForConditionalGeneration",  # top-level lm_head is untied despite nested text config
     }
     model_class_name = type(model).__name__
     for m in non_tied_lm_head_models:

--- a/nemo_automodel/components/models/qwen3_vl_moe/state_dict_adapter.py
+++ b/nemo_automodel/components/models/qwen3_vl_moe/state_dict_adapter.py
@@ -127,6 +127,8 @@ class Qwen3VLMoeStateDictAdapter(StateDictAdapter):
 
             if key.startswith("model."):
                 state_dict[key] = value
+            elif key.startswith("lm_head."):
+                state_dict[key] = value
             else:
                 state_dict[f"{model_prefix}{key}"] = value
 

--- a/tests/unit_tests/models/qwen3_vl_moe/test_qwen3_vl_moe_state_dict_adapter.py
+++ b/tests/unit_tests/models/qwen3_vl_moe/test_qwen3_vl_moe_state_dict_adapter.py
@@ -235,6 +235,18 @@ class TestFromHF:
 
         assert not any("scale_inv" in k for k in out)
 
+    def test_keeps_top_level_lm_head_key_with_model_prefixed_checkpoint(self, adapter):
+        lm_head = torch.randn(8, 8)
+        hf_state = {
+            "model.language_model.layers.0.self_attn.q_proj.weight": torch.randn(8, 8),
+            "lm_head.weight": lm_head,
+        }
+
+        out = adapter.from_hf(hf_state)
+
+        assert out["lm_head.weight"] is lm_head
+        assert "model.lm_head.weight" not in out
+
 
 class TestConvertSingleTensorToHf:
     def test_expert_tensor_passthrough(self, adapter):

--- a/tests/unit_tests/utils/test_checkpoint_utils.py
+++ b/tests/unit_tests/utils/test_checkpoint_utils.py
@@ -41,6 +41,25 @@ def test_is_tied_word_embeddings_prefers_text_config_value():
     assert checkpoint_utils.is_tied_word_embeddings(model) is False
 
 
+def test_is_tied_word_embeddings_respects_qwen3_vl_moe_exclusion():
+    class DummyTextConfig:
+        tie_word_embeddings = True
+
+    class DummyConfig:
+        tie_word_embeddings = False
+
+        def get_text_config(self):
+            return DummyTextConfig()
+
+    class Qwen3VLMoeForConditionalGeneration(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.config = DummyConfig()
+
+    model = Qwen3VLMoeForConditionalGeneration()
+    assert checkpoint_utils.is_tied_word_embeddings(model) is False
+
+
 def test_is_tied_word_embeddings_falls_back_to_top_level_when_no_text_config():
     class DummyModel(nn.Module):
         def __init__(self) -> None:


### PR DESCRIPTION
## Summary
- Preserve top-level `lm_head.*` keys in the Qwen3-VL-MoE Hugging Face state dict adapter instead of incorrectly prefixing them with `model.`.
- Add `Qwen3VLMoeForConditionalGeneration` to the checkpoint utility existing non-tied LM head exclusion list, avoiding a broad change to generic `get_text_config()` precedence.
- Add regression coverage for both the Qwen3-VL-MoE state dict adapter behavior and the model-specific tied-LM-head exclusion.

## Root Cause
After the Transformers 5.5 update, Qwen3-VL-MoE configs expose a nested text config with `tie_word_embeddings = True` while the outer VLM config has `tie_word_embeddings = False`. Transformers gates actual model-level tied-weight behavior from the outer config, so Qwen3-VL-MoE has a real untied top-level `lm_head.weight`. The checkpoint loading path used the nested text value and treated the model as tied, which skipped or rematerialized the real top-level head on the non-PP/full model path. PP last-stage loading still worked because it did not include embeddings in the same way.

## Validation
- `python -m pytest tests/unit_tests/utils/test_checkpoint_utils.py tests/unit_tests/models/qwen3_vl_moe/test_qwen3_vl_moe_state_dict_adapter.py`
- EP8/PP1: `automodel examples/vlm_finetune/qwen3/qwen3_vl_moe_30b_te_deepep.yaml --nproc-per-node 8 --step_scheduler.max_steps=5 --checkpoint.enabled=false`
  - step 0 loss: `2.1957`
  - step 1 loss: `2.1561`
  - step 2 loss: `1.9272`
  - step 3 loss: `2.2200`
  - step 4 loss: `1.7390`
  - validation loss at step 4: `2.1030`
- EP4/PP2: `automodel examples/vlm_finetune/qwen3/qwen3_vl_moe_30b_te_deepep.yaml --nproc-per-node 8 --step_scheduler.max_steps=5 --checkpoint.enabled=false --distributed.pp_size=2 --distributed.ep_size=4 --step_scheduler.local_batch_size=2`
  - step 0 loss: `2.1911`
  - step 1 loss: `2.1627`
  - step 2 loss: `1.9161`
  - step 3 loss: `2.2247`
  - step 4 loss: `1.7748`