### PR TITLE
fix(streaming): raise TypeError from iterable dataset __len__/__getitem__

### DIFF
--- a/nemo_automodel/components/datasets/llm/column_mapped_text_instruction_iterable_dataset.py
+++ b/nemo_automodel/components/datasets/llm/column_mapped_text_instruction_iterable_dataset.py
@@ -223,10 +223,10 @@ class ColumnMappedTextInstructionIterableDataset(IterableDataset, ColumnMappedTe
                 pass
 
     def __len__(self) -> int:
-        raise RuntimeError("__len__ is not supported in streaming mode.")
+        raise TypeError("__len__ is not supported in streaming mode.")
 
     def __getitem__(self, idx: int) -> Dict[str, List[int]]:
-        raise RuntimeError("__getitem__ is not supported in streaming mode.")
+        raise TypeError("__getitem__ is not supported in streaming mode.")
 
     def set_epoch(self, epoch: int) -> None:
         if self.dataset is not None and hasattr(self.dataset, "set_epoch"):

--- a/nemo_automodel/components/training/step_scheduler.py
+++ b/nemo_automodel/components/training/step_scheduler.py
@@ -116,7 +116,7 @@ class StepScheduler(Stateful):
         # Throws with IterableDataset.
         try:
             self.epoch_len = ceil(len(dataloader) / self.grad_acc_steps)
-        except (NotImplementedError, TypeError):
+        except (NotImplementedError, TypeError, RuntimeError):
             self.epoch_len = None
 
         # This is for backward compatibility in the sense that num_epochs's default value was 10


### PR DESCRIPTION
## Summary

Fix a crash that prevents any training run from starting when using the streaming `ColumnMappedTextInstructionIterableDataset`. The dataset's `__len__`/`__getitem__` raised `RuntimeError`, but `StepScheduler` only caught `(NotImplementedError, TypeError)` around its `len(dataloader)` call, so streaming mode was effectively broken end-to-end.

## Root cause

`StepScheduler.__init__` does:

```python
# Throws with IterableDataset.
try:
    self.epoch_len = ceil(len(dataloader) / self.grad_acc_steps)
except (NotImplementedError, TypeError):
    self.epoch_len = None
```

`ColumnMappedTextInstructionIterableDataset.__len__` raised `RuntimeError("__len__ is not supported in streaming mode.")`, which escaped the guard and propagated all the way up, killing the run before the first step.

Per Python convention, an object that doesn't support a protocol should raise `TypeError` — that's exactly what builtin `len()` raises for any non-`Sized` object. Using `RuntimeError` here was incorrect and caused the regression.

## Changes

- `column_mapped_text_instruction_iterable_dataset.py`: raise `TypeError` from `__len__` and `__getitem__` (correct Python convention).
- `step_scheduler.py`: widen the `except` to also catch `RuntimeError` as a defensive measure so any other iterable dataset making the same mistake doesn't silently break streaming again.

## Test

Minimal smoke config that exercises the streaming iterable dataset path with PEFT + FSDP2:

```yaml
# stream.yaml
step_scheduler:
  global_batch_size: 8
  local_batch_size: 2
  ckpt_every_steps: 200
  val_every_steps: 100
  max_steps: 35   # required for IterableDataset

dist_env: { backend: nccl, timeout_minutes: 1 }
rng:
  _target_: nemo_automodel.components.training.rng.StatefulRNG
  seed: 1111
  ranked: true

model:
  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
  pretrained_model_name_or_path: meta-llama/Llama-3.2-1B

peft:
  _target_: nemo_automodel.components._peft.lora.PeftConfig
  match_all_linear: True
  dim: 8
  alpha: 32
  use_triton: True

dataset:
  _target_: nemo_automodel.components.datasets.llm.column_mapped_text_instruction_iterable_dataset.ColumnMappedTextInstructionIterableDataset
  path_or_dataset_id: Muennighoff/natural-instructions
  split: train
  column_mapping:
    context: definition
    question: inputs
    answer: targets
  answer_only_loss_mask: true
  seq_length: 1024
  padding: do_not_pad
  truncation: True
  limit_dataset_samples: 128

dataloader:
  _target_: torchdata.stateful_dataloader.StatefulDataLoader
  collate_fn: nemo_automodel.components.datasets.utils.default_collater
  batch_size: 2
  num_workers: 2
  shuffle: true

loss_fn:
  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy

optimizer:
  _target_: torch.optim.Adam
  betas: [0.9, 0.999]
  eps: 1e-8
  lr: 1.0e-5
  weight_decay: 0

distributed:
  _target_: nemo_automodel.components.distributed.fsdp2.FSDP2Manager
  dp_size: none
  tp_size: 1
  cp_size: 1
```

```bash
python nemo_automodel/recipes/llm/train_ft.py -c stream.yaml
```

### Before fix

```
[rank0]: File ".../step_scheduler.py", line 118, in __init__
[rank0]:     self.epoch_len = ceil(len(dataloader) / self.grad_acc_steps)
[rank0]: File ".../column_mapped_text_instruction_iterable_dataset.py", line 226, in __len__
[rank0]:     raise RuntimeError("__len__ is not supported in streaming mode.")
[rank0]: RuntimeError: __len__ is not supported in streaming mode.
```

Training never starts.

### After fix

Training runs to completion (`max_steps=35`) and checkpoints successfully:

```
step 31 | epoch 0 | loss 0.7432 | grad_norm 9.1914 | lr 1.00e-05 | mem 6.15 GiB | tps 15731.25
step 32 | epoch 0 | loss 1.1590 | grad_norm 9.7861 | lr 1.00e-05 | mem 7.39 GiB | tps 17310.87
step 33 | epoch 0 | loss 0.8986 | grad_norm 9.4487 | lr 1.00e-05 | mem 7.37 GiB | tps 18429.88
step 34 | epoch 0 | loss 0.6272 | grad_norm 7.8226 | lr 1.00e-05 | mem 7.39 GiB | tps 17376.36
Training: 100%|█| 35/35 [00:12<00:00,  3.79step/s, loss=0.6272, lr=1.00e-05]
Saving checkpoint to checkpoints/epoch_0_step_34
```

## Test plan

- [x] Reproduce the crash on `main` with the streaming config above
- [x] Apply the patch and confirm training reaches `max_steps` and saves a checkpoint
- [ ] CI

## Follow-up (not in this PR)

`build_lr_scheduler` in `train_ft.py` also calls `len(step_scheduler.dataloader)` unconditionally. It only fires when `lr_scheduler` is configured, so it does not affect this test, but full streaming support will need the same guard there.