### PR TITLE
fix(deepseek-v4): align HCA backward graph under FSDP2

### DIFF
--- a/nemo_automodel/components/models/deepseek_v4/fsdp.py
+++ b/nemo_automodel/components/models/deepseek_v4/fsdp.py
@@ -39,6 +39,42 @@ _DSV4_FP32_MODULE_SUFFIXES = (
 )
 
 
+def _hca_param_sync_group_from_1d_mesh(mesh):
+    """Return the 1D PyTorch FSDP2 group used for HCA graph alignment.
+
+    HCA graph alignment is an FSDP/FSDP2 parameter-sync invariant: ranks that
+    synchronize the same sharded HCA parameters must agree on whether the HCA
+    compressor path participates in backward. This DeepSeek-V4 wrapper gets
+    that domain from its 1D PyTorch FSDP2 mesh. The mesh may be named or
+    unnamed; multi-dimensional meshes need an explicit owner dimension to avoid
+    reducing across unrelated parallel groups. Until that is available, disable
+    HCA graph alignment instead of using a broader or wrong group.
+    """
+    if mesh is None:
+        return None
+
+    mesh_ndim = getattr(mesh, "ndim", None)
+    mesh_shape = getattr(mesh, "shape", None)
+    mesh_dim_names = getattr(mesh, "mesh_dim_names", None)
+    if mesh_ndim is not None:
+        is_1d_mesh = mesh_ndim == 1
+    elif mesh_shape is not None:
+        is_1d_mesh = len(mesh_shape) == 1
+    elif mesh_dim_names is not None:
+        is_1d_mesh = len(mesh_dim_names) == 1
+    else:
+        return None
+    if not is_1d_mesh:
+        return None
+
+    try:
+        if mesh.size() <= 1:
+            return None
+        return mesh.get_group()
+    except (AttributeError, RuntimeError, TypeError, ValueError):
+        return None
+
+
 def _matches_suffix(name: str, suffix: str) -> bool:
     return name == suffix or name.endswith(f".{suffix}")
 
@@ -131,6 +167,17 @@ def _iter_dsv4_fp32_modules(module: nn.Module):
         yield submodule
 
 
+def _attach_hca_param_sync_group(module: nn.Module, mesh) -> None:
+    process_group = _hca_param_sync_group_from_1d_mesh(mesh)
+    for submodule in module.modules():
+        setter = getattr(submodule, "_set_hca_param_sync_group", None)
+        if submodule.__class__.__name__ == "DeepseekV4Compressor" and setter is not None:
+            # The FSDP2 mesh is only known while wrapping. Bind its parameter
+            # sync group narrowly to the DeepSeek-V4 HCA compressor instead of
+            # adding public config.
+            setter(process_group)
+
+
 def fully_shard_deepseek_v4(module: nn.Module, mesh, mp_policy, offload_policy=None, **fsdp_kwargs):
     """Apply FSDP2 to DeepSeek-V4 without mixing fp32 and bf16 params in one unit.
 
@@ -138,6 +185,10 @@ def fully_shard_deepseek_v4(module: nn.Module, mesh, mp_policy, offload_policy=N
     reference-sensitive tensors in fp32, while the existing DeepEP path expects
     the transformer block itself to remain the main FSDP unit.
     """
+    is_dsv4 = _is_deepseek_v4_module(module)
+    if is_dsv4:
+        _attach_hca_param_sync_group(module, mesh)
+
     if _floating_param_dtypes(module) == {torch.float32}:
         return _fully_shard_once(
             module,
@@ -148,7 +199,7 @@ def fully_shard_deepseek_v4(module: nn.Module, mesh, mp_policy, offload_policy=N
             **fsdp_kwargs,
         )
 
-    if not _is_deepseek_v4_module(module):
+    if not is_dsv4:
         return _fully_shard_once(
             module,
             mesh=mesh,

--- a/nemo_automodel/components/models/deepseek_v4/layers.py
+++ b/nemo_automodel/components/models/deepseek_v4/layers.py
@@ -56,6 +56,7 @@ from __future__ import annotations
 from typing import Any, Optional
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 
@@ -617,10 +618,32 @@ class DeepseekV4Compressor(nn.Module):
         self.ape_param = DeepseekV4FP32Parameter(torch.zeros(compress_ratio, proj_dim, dtype=torch.float32))
         self.kv_norm = initialize_rms_norm_module("torch_fp32", head_dim, eps=config.rms_norm_eps)
         self.indexer: DeepseekV4Indexer | None = DeepseekV4Indexer(config) if compress_ratio == 4 else None
+        self._hca_param_sync_group = None
 
     @property
     def ape(self) -> torch.Tensor:
         return self.ape_param()
+
+    def _set_hca_param_sync_group(self, process_group) -> None:
+        self._hca_param_sync_group = process_group
+
+    def _compute_fsdp_group_has_complete_hca_window(
+        self,
+        local_has_complete_hca_window: bool,
+        device: torch.device,
+    ) -> bool:
+        process_group = self._hca_param_sync_group
+        if process_group is None or not dist.is_available() or not dist.is_initialized():
+            return local_has_complete_hca_window
+        if dist.get_world_size(group=process_group) == 1:
+            return local_has_complete_hca_window
+
+        # A single int max-reduce tells short ranks whether any peer in the same
+        # HCA parameter sync group has a complete HCA window. It is a small
+        # synchronization point, but it avoids using a broader or world group.
+        flag = torch.tensor(int(local_has_complete_hca_window), device=device, dtype=torch.int32)
+        dist.all_reduce(flag, op=dist.ReduceOp.MAX, group=process_group)
+        return bool(flag.item())
 
     def forward(
         self,
@@ -631,6 +654,7 @@ class DeepseekV4Compressor(nn.Module):
         cache: DeepseekV4TrainCache,
         layer_idx: int,
         start_pos: int,
+        enable_hca_fsdp_graph_alignment: bool = False,
     ) -> torch.Tensor:
         input_dtype = hidden_states.dtype
         batch, seq_len, _ = hidden_states.shape
@@ -640,6 +664,30 @@ class DeepseekV4Compressor(nn.Module):
         ready_kv, ready_gate, pool_base = cache.accumulate_windows(
             kv, gate, layer_idx, "compressor_state", self.compress_ratio, start_pos
         )
+        local_has_complete_hca_window = ready_kv.shape[1] > 0
+        fsdp_group_has_complete_hca_window = (
+            self._compute_fsdp_group_has_complete_hca_window(local_has_complete_hca_window, kv.device)
+            if enable_hca_fsdp_graph_alignment
+            else local_has_complete_hca_window
+        )
+        needs_masked_synthetic_hca_window = (
+            enable_hca_fsdp_graph_alignment
+            and self.indexer is None
+            and fsdp_group_has_complete_hca_window
+            and not local_has_complete_hca_window
+            and 0 < kv.shape[1] < self.compress_ratio
+        )
+        if needs_masked_synthetic_hca_window:
+            # A mixed short/long HCA parameter sync group needs every rank to
+            # create the same compressor autograd edges. All-short groups keep
+            # the original no-HCA path so optimizer semantics stay at
+            # grad=None. Zero-length local HCA inputs are outside this narrow
+            # training fix.
+            pad_len = self.compress_ratio - kv.shape[1]
+            pad_shape = (batch, pad_len, kv.shape[-1])
+            ready_kv = torch.cat([kv, kv.new_zeros(pad_shape)], dim=1)
+            ready_gate = torch.cat([gate, gate.new_zeros(pad_shape)], dim=1)
+            pool_base = max(0, start_pos)
         new_pooled = self.kv_norm(
             _pool_windows(
                 ready_kv,
@@ -910,6 +958,14 @@ class DeepseekV4Attention(nn.Module):
                 cache=cache,
                 layer_idx=self.layer_idx,
                 start_pos=start_pos,
+                # Only DeepSeek-V4 HCA (ratio 128) needs this FSDP graph alignment.
+                # Ratio 4 uses the Indexer/SCA path and is outside this fix.
+                # Direct attention calls without an explicit mask keep the
+                # original behavior since synthetic windows must be maskable.
+                # The normal DeepSeek-V4 model path builds this mask upstream.
+                enable_hca_fsdp_graph_alignment=(
+                    self.training and attention_mask is not None and self.compress_ratio == 128
+                ),
             )
             n_pooled = pooled.shape[2]
             full_kv = torch.cat([full_kv, pooled], dim=2)

--- a/tests/unit_tests/models/deepseek_v4/test_dsv4_layers.py
+++ b/tests/unit_tests/models/deepseek_v4/test_dsv4_layers.py
@@ -22,8 +22,11 @@ Full-model behaviour is covered by ``test_dsv4_model_smoke.py``.
 
 import pytest
 import torch
+import torch.nn as nn
 
+from nemo_automodel.components.models.deepseek_v4.config import DeepseekV4Config
 from nemo_automodel.components.models.deepseek_v4.layers import (
+    DeepseekV4Attention,
     DeepseekV4GroupedLinear,
     DeepseekV4HyperConnection,
     DeepseekV4RotaryEmbedding,
@@ -32,6 +35,7 @@ from nemo_automodel.components.models.deepseek_v4.layers import (
     _yarn_correction_dim,
     _yarn_correction_range,
     _yarn_linear_ramp,
+    build_causal_padding_mask,
 )
 
 
@@ -45,6 +49,266 @@ class TestDeepseekV4AttentionMask:
         expected_compressed_mask = torch.tensor([[[[0.0, min_val, 0.0, min_val, min_val]]]])
         compressed_mask = _build_indexer_topk_compressed_mask(attention_mask, indexer_topk, n_pooled=5).unsqueeze(1)
         torch.testing.assert_close(compressed_mask, expected_compressed_mask)
+
+    def test_short_hca_training_window_stays_disabled_without_group_hca(self):
+        """All-short groups should keep the original no-HCA path and grad=None semantics."""
+        torch.manual_seed(1234)
+        cfg = self._tiny_hca_config()
+        seq_len = 7
+        hidden_states, position_embeddings, position_embeddings_compress, rotary_compress, attention_mask = (
+            self._hca_inputs(cfg, seq_len)
+        )
+
+        attention = DeepseekV4Attention(cfg, layer_idx=0)
+        attention.init_weights(torch.device("cpu"))
+        attention_ref = DeepseekV4Attention(cfg, layer_idx=0)
+        attention_ref.load_state_dict(attention.state_dict())
+
+        attention_ref.eval()
+        with torch.no_grad():
+            expected, expected_weights = attention_ref(
+                hidden_states,
+                position_embeddings=position_embeddings,
+                attention_mask=attention_mask,
+                position_embeddings_compress=position_embeddings_compress,
+                rotary_compress=rotary_compress,
+            )
+
+        attention.train()
+        actual, actual_weights = attention(
+            hidden_states,
+            position_embeddings=position_embeddings,
+            attention_mask=attention_mask,
+            position_embeddings_compress=position_embeddings_compress,
+            rotary_compress=rotary_compress,
+        )
+
+        assert expected_weights.shape[-1] == seq_len
+        assert actual_weights.shape[-1] == seq_len
+        torch.testing.assert_close(actual, expected, atol=1e-6, rtol=1e-6)
+        actual.square().sum().backward()
+
+        compressor = attention.compressor
+        assert compressor is not None
+        params = list(compressor.named_parameters())
+        before = {name: param.detach().clone() for name, param in params}
+        for name, param in params:
+            assert param.grad is None, name
+
+        optimizer = torch.optim.AdamW([param for _, param in params], lr=1e-3, weight_decay=0.1)
+        optimizer.step()
+        for name, param in params:
+            torch.testing.assert_close(param, before[name], atol=0.0, rtol=0.0)
+
+    def test_short_hca_training_window_is_fully_masked_when_group_has_hca(self, monkeypatch):
+        """Mixed short/long groups should mask the synthetic HCA position completely."""
+        torch.manual_seed(1234)
+        cfg = self._tiny_hca_config()
+        seq_len = 7
+        hidden_states, position_embeddings, position_embeddings_compress, rotary_compress, attention_mask = (
+            self._hca_inputs(cfg, seq_len)
+        )
+
+        attention = DeepseekV4Attention(cfg, layer_idx=0)
+        attention.init_weights(torch.device("cpu"))
+        attention_ref = DeepseekV4Attention(cfg, layer_idx=0)
+        attention_ref.load_state_dict(attention.state_dict())
+
+        attention_ref.eval()
+        with torch.no_grad():
+            expected, expected_weights = attention_ref(
+                hidden_states,
+                position_embeddings=position_embeddings,
+                attention_mask=attention_mask,
+                position_embeddings_compress=position_embeddings_compress,
+                rotary_compress=rotary_compress,
+            )
+
+        attention.train()
+        compressor = attention.compressor
+        assert compressor is not None
+        monkeypatch.setattr(
+            compressor,
+            "_compute_fsdp_group_has_complete_hca_window",
+            lambda local_has_complete_hca_window, device: True,
+        )
+        actual, actual_weights = attention(
+            hidden_states,
+            position_embeddings=position_embeddings,
+            attention_mask=attention_mask,
+            position_embeddings_compress=position_embeddings_compress,
+            rotary_compress=rotary_compress,
+        )
+
+        assert expected_weights.shape[-1] == seq_len
+        assert actual_weights.shape[-1] == seq_len + 1
+        torch.testing.assert_close(
+            actual_weights[..., -1], torch.zeros_like(actual_weights[..., -1]), atol=0.0, rtol=0.0
+        )
+        torch.testing.assert_close(actual, expected, atol=1e-6, rtol=1e-6)
+
+    def test_short_hca_training_window_keeps_compressor_in_backward(self, monkeypatch):
+        """Mixed-group short HCA ranks should produce zero-valued compressor gradients."""
+        torch.manual_seed(1234)
+        cfg = self._tiny_hca_config()
+        seq_len = 7
+        hidden_states, position_embeddings, position_embeddings_compress, rotary_compress, attention_mask = (
+            self._hca_inputs(cfg, seq_len)
+        )
+        attention = DeepseekV4Attention(cfg, layer_idx=0)
+        attention.init_weights(torch.device("cpu"))
+        attention.train()
+        compressor = attention.compressor
+        assert compressor is not None
+        monkeypatch.setattr(
+            compressor,
+            "_compute_fsdp_group_has_complete_hca_window",
+            lambda local_has_complete_hca_window, device: True,
+        )
+
+        output, _ = attention(
+            hidden_states,
+            position_embeddings=position_embeddings,
+            attention_mask=attention_mask,
+            position_embeddings_compress=position_embeddings_compress,
+            rotary_compress=rotary_compress,
+        )
+        output.square().sum().backward()
+
+        for name, param in compressor.named_parameters():
+            assert param.grad is not None, name
+            assert torch.isfinite(param.grad).all(), name
+            torch.testing.assert_close(param.grad, torch.zeros_like(param.grad), atol=0.0, rtol=0.0)
+
+    def test_short_hca_training_window_stays_disabled_without_attention_mask(self, monkeypatch):
+        """Synthetic HCA alignment requires a mask so the extra position can be hidden."""
+        torch.manual_seed(1234)
+        cfg = self._tiny_hca_config()
+        seq_len = 7
+        hidden_states, position_embeddings, position_embeddings_compress, rotary_compress, _ = self._hca_inputs(
+            cfg, seq_len
+        )
+        attention = DeepseekV4Attention(cfg, layer_idx=0)
+        attention.init_weights(torch.device("cpu"))
+        attention.train()
+        compressor = attention.compressor
+        assert compressor is not None
+        monkeypatch.setattr(
+            compressor,
+            "_compute_fsdp_group_has_complete_hca_window",
+            lambda local_has_complete_hca_window, device: True,
+        )
+
+        _, actual_weights = attention(
+            hidden_states,
+            position_embeddings=position_embeddings,
+            attention_mask=None,
+            position_embeddings_compress=position_embeddings_compress,
+            rotary_compress=rotary_compress,
+        )
+
+        assert actual_weights.shape[-1] == seq_len
+
+    @pytest.mark.parametrize(
+        ("seq_len", "group_has_hca", "expected_attention_width"),
+        (
+            (127, False, 127),
+            (127, True, 128),
+            (128, False, 129),
+            (129, False, 130),
+        ),
+    )
+    def test_hca_window_boundary_paths(self, monkeypatch, seq_len, group_has_hca, expected_attention_width):
+        torch.manual_seed(1234)
+        cfg = self._tiny_hca_config()
+        hidden_states, position_embeddings, position_embeddings_compress, rotary_compress, attention_mask = (
+            self._hca_inputs(cfg, seq_len)
+        )
+        attention = DeepseekV4Attention(cfg, layer_idx=0)
+        attention.init_weights(torch.device("cpu"))
+        attention.train()
+        if group_has_hca:
+            compressor = attention.compressor
+            assert compressor is not None
+            monkeypatch.setattr(
+                compressor,
+                "_compute_fsdp_group_has_complete_hca_window",
+                lambda local_has_complete_hca_window, device: True,
+            )
+
+        _, actual_weights = attention(
+            hidden_states,
+            position_embeddings=position_embeddings,
+            attention_mask=attention_mask,
+            position_embeddings_compress=position_embeddings_compress,
+            rotary_compress=rotary_compress,
+        )
+
+        assert actual_weights.shape[-1] == expected_attention_width
+
+    @staticmethod
+    def _tiny_hca_config() -> DeepseekV4Config:
+        return DeepseekV4Config(
+            vocab_size=32,
+            hidden_size=16,
+            moe_intermediate_size=8,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            head_dim=8,
+            qk_rope_head_dim=4,
+            q_lora_rank=8,
+            o_lora_rank=8,
+            o_groups=1,
+            n_routed_experts=2,
+            n_shared_experts=0,
+            num_experts_per_tok=1,
+            max_position_embeddings=256,
+            compress_ratios=[128],
+            sliding_window=128,
+            attention_dropout=0.0,
+            num_hash_layers=0,
+            hc_mult=1,
+            num_nextn_predict_layers=0,
+            rms_norm_eps=1e-6,
+            torch_dtype="float32",
+        )
+
+    @staticmethod
+    def _hca_inputs(
+        cfg: DeepseekV4Config,
+        seq_len: int,
+    ) -> tuple[
+        torch.Tensor,
+        tuple[torch.Tensor, torch.Tensor],
+        tuple[torch.Tensor, torch.Tensor],
+        nn.Module,
+        torch.Tensor,
+    ]:
+        hidden_states = torch.randn(1, seq_len, cfg.hidden_size)
+        position_ids = torch.arange(seq_len).unsqueeze(0)
+        partial_rotary_factor = float(cfg.qk_rope_head_dim) / float(cfg.head_dim)
+        rotary = DeepseekV4RotaryEmbedding(
+            rope_theta=float(cfg.rope_theta),
+            head_dim=int(cfg.head_dim),
+            partial_rotary_factor=partial_rotary_factor,
+        )
+        rotary_compress = DeepseekV4RotaryEmbedding(
+            rope_theta=float(cfg.compress_rope_theta),
+            head_dim=int(cfg.head_dim),
+            partial_rotary_factor=partial_rotary_factor,
+        )
+        position_embeddings = rotary(hidden_states, position_ids)
+        position_embeddings_compress = rotary_compress(hidden_states, position_ids)
+        attention_mask = build_causal_padding_mask(
+            None,
+            seq_len=seq_len,
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+            batch_size=hidden_states.shape[0],
+            sliding_window=cfg.sliding_window,
+        )
+        return hidden_states, position_embeddings, position_embeddings_compress, rotary_compress, attention_mask
 
 
 class TestDeepseekV4GroupedLinear:

--- a/tests/unit_tests/models/deepseek_v4/test_dsv4_model_smoke.py
+++ b/tests/unit_tests/models/deepseek_v4/test_dsv4_model_smoke.py
@@ -118,6 +118,96 @@ def _make_model(config: DeepseekV4Config) -> DeepseekV4ForCausalLM:
 
 
 class TestDeepseekV4ModelSmoke:
+    def test_dsv4_hca_param_sync_group_uses_only_1d_mesh(self):
+        named_hca_group = object()
+        unnamed_hca_group = object()
+        shape_only_hca_group = object()
+
+        class NamedOneDimMesh:
+            mesh_dim_names = ("dp",)
+
+            def size(self):
+                return 2
+
+            def get_group(self):
+                return named_hca_group
+
+        class UnnamedOneDimMesh:
+            mesh_dim_names = None
+            ndim = 1
+
+            def size(self):
+                return 2
+
+            def get_group(self):
+                return unnamed_hca_group
+
+        class UnnamedTwoDimMesh:
+            mesh_dim_names = None
+            ndim = 2
+
+        class ShapeOnlyOneDimMesh:
+            shape = (2,)
+
+            def size(self):
+                return 2
+
+            def get_group(self):
+                return shape_only_hca_group
+
+        class TwoDimMesh:
+            mesh_dim_names = ("dp", "tp")
+
+        assert dsv4_fsdp._hca_param_sync_group_from_1d_mesh(None) is None
+        assert dsv4_fsdp._hca_param_sync_group_from_1d_mesh(UnnamedOneDimMesh()) is unnamed_hca_group
+        assert dsv4_fsdp._hca_param_sync_group_from_1d_mesh(UnnamedTwoDimMesh()) is None
+        assert dsv4_fsdp._hca_param_sync_group_from_1d_mesh(ShapeOnlyOneDimMesh()) is shape_only_hca_group
+        assert dsv4_fsdp._hca_param_sync_group_from_1d_mesh(TwoDimMesh()) is None
+        assert dsv4_fsdp._hca_param_sync_group_from_1d_mesh(NamedOneDimMesh()) is named_hca_group
+
+    def test_dsv4_fsdp_attaches_hca_group_before_all_fp32_fast_path(self, monkeypatch):
+        cfg = _tiny_config(num_hidden_layers=1, num_hash_layers=0, compress_ratios=[128])
+        model = _make_model(cfg)
+        block = model.model.layers["0"]
+        calls = []
+
+        def fake_fully_shard(module, **kwargs):
+            calls.append((module, kwargs))
+            return module
+
+        monkeypatch.setattr(dsv4_fsdp, "fully_shard", fake_fully_shard)
+
+        hca_group = object()
+
+        class FakeMesh:
+            ndim = 1
+            mesh_dim_names = None
+
+            def size(self):
+                return 2
+
+            def get_group(self):
+                return hca_group
+
+        input_policy = MixedPrecisionPolicy(
+            param_dtype=torch.bfloat16,
+            reduce_dtype=torch.float32,
+            output_dtype=torch.bfloat16,
+        )
+
+        dsv4_fsdp.fully_shard_deepseek_v4(
+            block,
+            mesh=FakeMesh(),
+            mp_policy=input_policy,
+            offload_policy=object(),
+        )
+
+        assert block.self_attn.compressor._hca_param_sync_group is hca_group
+        assert len(calls) == 1
+        assert calls[0][0] is block
+        assert calls[0][1]["mp_policy"].param_dtype == torch.float32
+        assert calls[0][1]["mp_policy"].reduce_dtype == torch.float32
+
     def test_dsv4_fsdp_wraps_fp32_islands_without_ignored_trainable_tensors(self, monkeypatch):
         cfg = _tiny_config(
             num_hidden_layers=1,
@@ -152,6 +242,17 @@ class TestDeepseekV4ModelSmoke:
 
         monkeypatch.setattr(dsv4_fsdp, "fully_shard", fake_fully_shard)
 
+        hca_group = object()
+
+        class FakeMesh:
+            mesh_dim_names = ("dp",)
+
+            def size(self):
+                return 2
+
+            def get_group(self):
+                return hca_group
+
         input_policy = MixedPrecisionPolicy(
             param_dtype=torch.bfloat16,
             reduce_dtype=torch.float32,
@@ -161,12 +262,13 @@ class TestDeepseekV4ModelSmoke:
 
         dsv4_fsdp.fully_shard_deepseek_v4(
             block,
-            mesh=object(),
+            mesh=FakeMesh(),
             mp_policy=input_policy,
             offload_policy=object(),
             ignored_params=ignored_expert_params,
         )
 
+        assert block.self_attn.compressor._hca_param_sync_group is hca_group
         calls_by_name = {name: kwargs for name, kwargs in calls}
         expected_fp32_modules = {
             "attn_hc",


### PR DESCRIPTION
# What does this PR do ?

This PR fixes a DeepSeek V4 HCA backward collective mismatch in the current 1D PyTorch FSDP2
DeepSeek V4 wrapper path.

DeepSeek V4 HCA only creates compressed KV entries after a complete 128-token HCA window is available.
When ranks in the same HCA parameter sync group receive mixed short and long sequences, short ranks can
skip the HCA compressor path while long ranks execute it. That makes the backward graphs differ across
ranks and can trigger FSDP2 collective mismatch.

The fix makes the HCA compressor path group-aware:

- ranks with a complete HCA window keep the original real HCA path;
- short ranks add one fully masked synthetic HCA window only when another rank in the same HCA parameter
  sync group has a complete HCA window;
- all-short groups keep the original no-HCA path, so HCA compressor parameters keep `grad=None`.

This preserves optimizer-visible all-short semantics while aligning the backward graph in mixed
short/long groups.

# Changelog

- Add a DeepSeek V4-only helper to derive the HCA parameter sync group from a named or unnamed 1D FSDP2
  mesh.
- Attach that group to `DeepseekV4Compressor` during DeepSeek V4 FSDP wrapping.
- Add a scalar max-reduce in the HCA compressor to detect whether any rank in the parameter sync group
  has a complete HCA window.
- Add a fully masked synthetic HCA window only for mixed short/long HCA groups.
- Preserve all-short optimizer semantics by avoiding synthetic HCA windows when no rank has a complete
  HCA window.
- Add CPU unit tests for:
  - all-short no-HCA behavior and `grad=None` semantics;
  - synthetic HCA window masking;
  - zero-valued local gradients for synthetic short ranks;
  - no-mask calls keeping the original no-HCA behavior;
  - HCA boundary lengths around 128;
  - named/unnamed 1D mesh group extraction, non-1D fallback behavior, and all-fp32 wrapping.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
  - #1364 reports a different distributed variable-token-count deadlock in NemotronV3 EP. This PR fixes a
separate DeepSeek V4 HCA/FSDP2 conditional-compressor participation issue.
  - #2216 is related to DeepSeek V4 FSDP2 wrapping, but fixes fp32 parameter preservation rather than HCA
mixed short/long backward graph alignment.

# Implementation Notes

The correctness invariant is the same for FSDP and FSDP2: all ranks that synchronize the same sharded
HCA compressor parameters must either all create the HCA compressor backward graph or all skip it.

This patch wires that invariant through the existing DeepSeek V4 PyTorch FSDP2 wrapping path, where the
parameter sync domain is available as a 1D device mesh process group. The included distributed
validation uses PyTorch FSDP2, which is the DeepSeek V4 training path this issue was reproduced on.
Other FSDP backends can use the same HCA compressor alignment hook if they provide the HCA parameter
sync group, but this PR does not add or validate a separate MegatronFSDP/classic FSDP integration path.

For multi-dimensional meshes, choosing the correct HCA parameter sync domain requires explicit ownership
information. The helper returns `None` for non-1D meshes instead of guessing a broader or wrong process
group. This PR does not claim full HSDP/CP/TP/PP/EP coverage.

The scalar collective is one max-reduce per HCA compressor forward when alignment is enabled. It only
runs for DeepSeek V4 HCA training with the normal model-path attention mask and `compress_ratio == 128`.

Synthetic HCA graph alignment requires the explicit 4D additive attention mask built by the normal
DeepSeek V4 model path, so the synthetic compressed position can be fully masked. Direct/custom training
calls without an attention mask intentionally keep the original no-HCA behavior and may still see the
original mixed short/long mismatch under FSDP2.

The short-path output-equivalence tests use `attention_dropout=0.0`, matching the DeepSeek V4 default.
Nonzero custom attention dropout can change RNG consumption even though the synthetic position remains
zero-probability and zero-gradient. Zero-token local HCA inputs are also outside this narrow fix.

---

2-GPU PyTorch FSDP2 repro validation:

Run it with two GPUs:

```text
PATH=. torchrun --standalone --nproc_per_node=2 /tmp/reproduce_hca_fsdp2.py
```

<details>
<summary>reproduce_hca_fsdp2.py</summary>

```python
"""Minimal DeepSeek-V4 HCA/FSDP2 before/after reproducer.

Run with two GPUs using ``torchrun --standalone --nproc_per_node=2``. Before this fix,
``short_long`` can fail during backward; after the fix, all three cases pass.
"""

from datetime import timedelta
import os
import sys
import traceback

import torch
import torch.distributed as dist
import torch.nn as nn
from torch.distributed.device_mesh import init_device_mesh
from torch.distributed.fsdp import MixedPrecisionPolicy, fully_shard

from nemo_automodel.components.models.deepseek_v4.config import DeepseekV4Config
from nemo_automodel.components.models.deepseek_v4.layers import (
    DeepseekV4Compressor,
    DeepseekV4RotaryEmbedding,
    DeepseekV4TrainCache,
)


def make_inputs(config, seq_len, device):
    values = torch.arange(seq_len * config.hidden_size, device=device, dtype=torch.float32)
    hidden_states = (values.view(1, seq_len, config.hidden_size) % 251) / 251.0
    position_ids = torch.arange(seq_len, device=device).unsqueeze(0)
    partial_rotary_factor = float(config.qk_rope_head_dim) / float(config.head_dim)
    rotary_compress = DeepseekV4RotaryEmbedding(
        float(config.compress_rope_theta),
        int(config.head_dim),
        partial_rotary_factor,
        rope_scaling=config.rope_scaling,
    ).to(device)
    return hidden_states, rotary_compress, rotary_compress(hidden_states, position_ids)


def run_backward_case(name, seq_lens, config, mesh, mp_policy, rank, world_size, device):
    seq_len = seq_lens[rank]
    print(f"[rank {rank}] {name}: seq_len={seq_len}", flush=True)

    torch.manual_seed(20260518)
    base = nn.Linear(config.hidden_size, config.hidden_size, bias=False).to(device)
    compressor = DeepseekV4Compressor(config, 128, config.head_dim).to(device=device, dtype=torch.float32)
    compressor.train()
    if hasattr(compressor, "_set_hca_param_sync_group"):
        compressor._set_hca_param_sync_group(mesh.get_group())
    fully_shard(compressor, mesh=mesh, mp_policy=mp_policy)

    hidden_states, rotary_compress, pos_emb_compress = make_inputs(config, seq_len, device)
    kwargs = {
        "hidden_states": hidden_states,
        "q_residual": None,
        "rotary": rotary_compress,
        "position_embeddings": pos_emb_compress,
        "cache": DeepseekV4TrainCache(),
        "layer_idx": 0,
        "start_pos": 0,
    }
    if "enable_hca_fsdp_graph_alignment" in compressor.forward.__code__.co_varnames:
        kwargs["enable_hca_fsdp_graph_alignment"] = True
    pooled, _ = compressor(**kwargs)
    loss = base(hidden_states).float().square().mean() + pooled.float().square().sum()
    print(f"[rank {rank}] {name}: loss={loss.item():.8g}; backward", flush=True)
    loss.backward()

    params = [param for _, param in compressor.named_parameters()]
    presence = torch.tensor([0 if p.grad is None else 1 for p in params], device=device, dtype=torch.int32)
    gathered = [torch.empty_like(presence) for _ in range(world_size)]
    dist.all_gather(gathered, presence)
    by_rank = torch.stack(gathered).cpu().tolist()
    if rank == 0:
        print(f"[rank 0] {name}: hca_grad_presence_by_rank={by_rank}", flush=True)
        if any(row != by_rank[0] for row in by_rank[1:]):
            raise RuntimeError(f"{name}: HCA backward participation differs across ranks")
        print(f"[rank 0] {name}: PASS", flush=True)


def main():
    rank = int(os.environ["RANK"])
    world_size = int(os.environ["WORLD_SIZE"])
    local_rank = int(os.environ["LOCAL_RANK"])
    torch.cuda.set_device(local_rank)
    dist.init_process_group("nccl", timeout=timedelta(seconds=int(os.environ.get("DIST_TIMEOUT_SECONDS", "180"))))
    try:
        if world_size != 2:
            raise RuntimeError(f"expected exactly 2 ranks, got {world_size}")
        device = torch.device("cuda", local_rank)
        print(f"[rank {rank}] torch={torch.__version__}; device={torch.cuda.get_device_name(local_rank)}", flush=True)
        config = DeepseekV4Config(compress_ratios=[128])
        mesh = init_device_mesh("cuda", (world_size,), mesh_dim_names=("dp",))
        mp_policy = MixedPrecisionPolicy(torch.float32, torch.float32, torch.float32, cast_forward_inputs=False)
        for name, seq_lens in (("short_short", (7, 7)), ("long_long", (129, 129)), ("short_long", (7, 129))):
            run_backward_case(name, seq_lens, config, mesh, mp_policy, rank, world_size, device)
            dist.barrier()
        if rank == 0:
            print("[rank 0] PASS dsv4 hca fsdp2 minimal repro", flush=True)
        return 0
    except Exception:
        print(f"[rank {rank}] FAILED", flush=True)
        traceback.print_exc()
        return 1
    finally:
        dist.destroy_process_group()


if __name__ == "__main__":
    sys.exit(main())
```

</details>

```text
before patch, Slurm job 183017:
[rank 0] short_short: PASS
[rank 0] long_long: PASS
[rank 0] short_long: loss=0.11253042; backward
[rank 1] short_long: loss=512.10651; backward
[rank 0] FAILED
[rank 1] FAILED
RuntimeError: Detected mismatch between collectives on ranks.
```

```text
after patch, Slurm job 183043:
[rank 0] short_short: hca_grad_presence_by_rank=[[0, 0, 0, 0], [0, 0, 0, 0]]
[rank 0] short_short: PASS
[rank 0] long_long: hca_grad_presence_by_rank=[[1, 1, 1, 1], [1, 1, 1, 1]]
[rank 0] long_long: PASS
[rank 0] short_long: hca_grad_presence_by_rank=[[1, 1, 1, 1], [1, 1, 1, 1]]
[rank 0] short_long: PASS
[rank 0] PASS dsv4 hca fsdp2 minimal repro
```