### PR TITLE
fix: update VLM first-microbatch state during gradient accumulation

### DIFF
--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -77,6 +77,7 @@ from nemo_automodel.components.training.rng import ScopedRNG, StatefulRNG
 from nemo_automodel.components.training.step_scheduler import StepScheduler
 from nemo_automodel.components.training.utils import (
     count_tail_padding,
+    prepare_after_first_microbatch,
     prepare_for_final_backward,
     prepare_for_grad_accumulation,
     scale_grads_and_clip_grad_norm,
@@ -1054,6 +1055,9 @@ class FinetuneRecipeForVLM(BaseRecipe):
             self._forward_backward_step(
                 i, batch, loss_buffer=loss_buffer, num_label_tokens=num_label_tokens, num_batches=num_batches
             )
+
+            if i == 0:
+                prepare_after_first_microbatch()
 
         grad_norm = scale_grads_and_clip_grad_norm(
             max_grad_norm=max_grad_norm,

--- a/nemo_automodel/recipes/vlm/kd.py
+++ b/nemo_automodel/recipes/vlm/kd.py
@@ -60,6 +60,7 @@ from nemo_automodel.components.training.rng import ScopedRNG
 from nemo_automodel.components.training.utils import (
     ScopedModuleOffloading,
     count_tail_padding,
+    prepare_after_first_microbatch,
     prepare_for_final_backward,
     prepare_for_grad_accumulation,
     scale_grads_and_clip_grad_norm,
@@ -360,6 +361,9 @@ class KnowledgeDistillationRecipeForVLM(FinetuneRecipeForVLM):
             self._forward_backward_step(
                 i, batch, loss_buffer=loss_buffer, num_label_tokens=num_label_tokens, num_batches=num_batches
             )
+
+            if i == 0:
+                prepare_after_first_microbatch()
 
         grad_norm = scale_grads_and_clip_grad_norm(
             max_grad_norm=max_grad_norm,

--- a/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
+++ b/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
@@ -162,7 +162,7 @@ def test_build_model_passes_freeze_config():
             return {"freeze_language_model": False, "freeze_vision_tower": True}
 
     with patch("nemo_automodel.recipes.vlm.finetune._supports_logits_to_keep", return_value=True):
-        model = build_model(
+        build_model(
             cfg_model=cfg_model,
             cfg_freeze=FreezeConfig(),
             cfg_peft=None,
@@ -430,6 +430,53 @@ def _patch_pp_optim_step_dependencies(monkeypatch):
         "nemo_automodel.recipes.vlm.finetune.prepare_for_final_backward",
         lambda model_parts, pp_enabled: None,
     )
+    monkeypatch.setattr(
+        "nemo_automodel.recipes.vlm.finetune.prepare_after_first_microbatch",
+        lambda: None,
+    )
+
+
+@pytest.mark.cuda(False)
+def test_run_train_step_clears_first_microbatch_after_first_batch(monkeypatch):
+    recipe, _ = _build_pp_recipe_for_optim_step(num_label_tokens_in_batch=2)
+    batches = [
+        {
+            "labels": torch.tensor([[1, -100, 2, -100]]),
+            "input_ids": torch.tensor([[1, 2, 3, 4]]),
+        },
+        {
+            "labels": torch.tensor([[-100, 3, -100, 4]]),
+            "input_ids": torch.tensor([[5, 6, 7, 8]]),
+        },
+    ]
+    events = []
+
+    monkeypatch.setattr(
+        "nemo_automodel.recipes.vlm.finetune.prepare_for_grad_accumulation",
+        lambda model_parts, pp_enabled: events.append("prepare"),
+    )
+    monkeypatch.setattr(
+        "nemo_automodel.recipes.vlm.finetune.prepare_for_final_backward",
+        lambda model_parts, pp_enabled: events.append("final"),
+    )
+    monkeypatch.setattr(
+        "nemo_automodel.recipes.vlm.finetune.prepare_after_first_microbatch",
+        lambda: events.append("after_first"),
+    )
+    monkeypatch.setattr(
+        "nemo_automodel.recipes.vlm.finetune.scale_grads_and_clip_grad_norm",
+        lambda **kwargs: 0.0,
+    )
+
+    def fake_forward_backward_step(idx, batch, loss_buffer, num_label_tokens, num_batches):
+        events.append(f"forward_{idx}")
+        loss_buffer.append(torch.tensor(1.0))
+
+    recipe._forward_backward_step = fake_forward_backward_step
+
+    recipe._run_train_optim_step(batches, max_grad_norm=1.0)
+
+    assert events == ["prepare", "forward_0", "after_first", "final", "forward_1"]
 
 
 @pytest.mark.cuda(False)
@@ -793,8 +840,6 @@ class DummyModelConfigWithAdapter:
 def test_vlm_build_model_with_adapter():
     """Test that model with state_dict_adapter is properly instantiated in VLM."""
 
-    cfg_opt = DummyOptConfig(lr=0.01)
-
     # Create a config that simulates NeMoAutoModel's internal infrastructure handling
     from nemo_automodel._transformers import NeMoAutoModelForImageTextToText
 
@@ -980,7 +1025,7 @@ def test_vlm_build_optimizer_disables_foreach_with_tp():
             seed=42,
             device_mesh=mock_device_mesh,
         )
-        optimizer = build_optimizer(model, cfg_opt, None, mock_device_mesh)
+        build_optimizer(model, cfg_opt, None, mock_device_mesh)
 
     assert cfg_opt.foreach is False
 

--- a/tests/unit_tests/recipes/test_vlm_kd_distributed.py
+++ b/tests/unit_tests/recipes/test_vlm_kd_distributed.py
@@ -63,6 +63,8 @@ class _Model(nn.Module):
 )
 def test_vlm_kd_train_step_uses_distributed_step_helpers(monkeypatch, pp_enabled, expected_aux_scale):
     calls = {
+        "after_first": [],
+        "events": [],
         "prepare": [],
         "final": [],
         "scale": [],
@@ -70,16 +72,30 @@ def test_vlm_kd_train_step_uses_distributed_step_helpers(monkeypatch, pp_enabled
     }
 
     monkeypatch.setattr(vlm_kd.time, "perf_counter", lambda: 2.0)
+
+    def _prepare_for_grad_accumulation(model_parts, pp_enabled):
+        calls["prepare"].append((model_parts, pp_enabled))
+        calls["events"].append("prepare")
+
+    def _prepare_for_final_backward(model_parts, pp_enabled):
+        calls["final"].append((model_parts, pp_enabled))
+        calls["events"].append("final")
+
+    def _prepare_after_first_microbatch():
+        calls["after_first"].append("called")
+        calls["events"].append("after_first")
+
     monkeypatch.setattr(
         vlm_kd,
         "prepare_for_grad_accumulation",
-        lambda model_parts, pp_enabled: calls["prepare"].append((model_parts, pp_enabled)),
+        _prepare_for_grad_accumulation,
     )
     monkeypatch.setattr(
         vlm_kd,
         "prepare_for_final_backward",
-        lambda model_parts, pp_enabled: calls["final"].append((model_parts, pp_enabled)),
+        _prepare_for_final_backward,
     )
+    monkeypatch.setattr(vlm_kd, "prepare_after_first_microbatch", _prepare_after_first_microbatch)
 
     def _fake_scale_grads_and_clip_grad_norm(**kwargs):
         calls["scale"].append(kwargs)
@@ -110,6 +126,7 @@ def test_vlm_kd_train_step_uses_distributed_step_helpers(monkeypatch, pp_enabled
 
     def _fake_forward_backward_step(idx, batch, *, loss_buffer, num_label_tokens, num_batches, is_train=True):
         calls["forward"].append((idx, num_label_tokens, num_batches, is_train))
+        calls["events"].append(f"forward_{idx}")
         loss_buffer.append(torch.tensor(1.0))
         recipe._ce_loss_buffer.append(torch.tensor(0.25))
         recipe._kd_loss_buffer.append(torch.tensor(0.75))
@@ -127,6 +144,8 @@ def test_vlm_kd_train_step_uses_distributed_step_helpers(monkeypatch, pp_enabled
     assert isinstance(metrics, MetricsSample)
     assert calls["prepare"] == [([model], pp_enabled)]
     assert calls["final"] == [([model], pp_enabled)]
+    assert calls["after_first"] == ["called"]
+    assert calls["events"] == ["prepare", "forward_0", "after_first", "final", "forward_1"]
     assert calls["forward"] == [(0, 3, 2, True), (1, 3, 2, True)]
     assert calls["scale"] == [
         {


### PR DESCRIPTION
## Summary

- call `prepare_after_first_microbatch()` after the first VLM finetune microbatch
- apply the same first-microbatch state transition to VLM KD
- add unit coverage for the first-microbatch transition in VLM finetune and KD

## Why

`prepare_for_grad_accumulation()` marks the next pass as the first microbatch, but the VLM recipes did not clear that state after the first forward/backward when gradient accumulation was greater than one. In PP + GA runs this left the first-microbatch state active for later microbatches, which can interact badly with FP8/FSDP preparation state.

## Validation

- `pytest -q tests/unit_tests/recipes/test_finetune_vlm_helpers.py tests/unit_tests/recipes/test_vlm_kd_distributed.py`
- `ruff check nemo_automodel/recipes/vlm/finetune.py nemo_automodel/recipes/vlm/kd.py tests/unit_tests/recipes/test_finetune_vlm_helpers.py tests/unit_tests/recipes/test_vlm_kd_distributed.py`
- `python -m compileall -q nemo_automodel/recipes/vlm/finetune.py nemo_automodel/recipes/vlm/kd.py tests/unit_tests/recipes/test_finetune_vlm_helpers.py tests/unit_tests/recipes/test_vlm_kd_distributed.py`
- `git diff --check`
