### PR TITLE
feat: Support VLM context parallel inputs in PP

### DIFF
--- a/nemo_automodel/components/distributed/cp_utils.py
+++ b/nemo_automodel/components/distributed/cp_utils.py
@@ -265,8 +265,15 @@ def make_cp_batch_and_ctx(
     seq_len = primary_seq_tensor.shape[1]
 
     # Skip 1D injection if position_ids already in batch (e.g. mRoPE pre-computed)
+    batch_size = primary_seq_tensor.shape[0]
     if "position_ids" not in batch and (_get_mesh_size(cp_mesh) > 1 or _get_mesh_size(tp_mesh) > 1):
-        batch["position_ids"] = torch.arange(0, seq_len).unsqueeze(0).to(primary_seq_tensor.device)
+        batch["position_ids"] = (
+            torch.arange(0, seq_len, device=primary_seq_tensor.device).unsqueeze(0).expand(batch_size, -1).contiguous()
+        )
+    elif "position_ids" in batch:
+        position_ids = batch["position_ids"]
+        if position_ids.ndim == 2 and position_ids.shape[0] == 1 and batch_size > 1:
+            batch["position_ids"] = position_ids.expand(batch_size, -1).contiguous()
 
     position_ids = batch["position_ids"]
 

--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -348,9 +348,9 @@ def apply_cp(model: torch.nn.Module, cp_mesh: DeviceMesh, cp_comm_type: str = "p
     _model._cp_enabled = True
 
     for _, block in _model.layers.named_children():
-        layer_type = getattr(block, "layer_type", "full_attention")
+        layer_type = getattr(block, "layer_type", getattr(block, "attention_type", "full_attention"))
 
-        if layer_type == "full_attention":
+        if layer_type in ("full_attention", "sliding_attention"):
             attn_module = block.self_attn.attn_module
             if not isinstance(attn_module, DotProductAttention):
                 logger.warning(
@@ -358,11 +358,12 @@ def apply_cp(model: torch.nn.Module, cp_mesh: DeviceMesh, cp_comm_type: str = "p
                     type(attn_module).__name__,
                 )
                 continue
+            attn_cp_comm_type = "all_gather" if layer_type == "sliding_attention" else cp_comm_type
             attn_module.set_context_parallel_group(
                 cp_mesh.get_group(),
                 torch.distributed.get_process_group_ranks(cp_mesh.get_group()),
                 _get_cp_stream(),
-                cp_comm_type=cp_comm_type,
+                cp_comm_type=attn_cp_comm_type,
             )
         elif layer_type == "mamba":
             from nemo_automodel.components.distributed.mamba_cp import MambaContextParallel

--- a/nemo_automodel/components/utils/model_utils.py
+++ b/nemo_automodel/components/utils/model_utils.py
@@ -93,6 +93,10 @@ VLM_INPUT_KEYS: tuple[str, ...] = (
     "image_grid_hws",
     "image_grid_thw",
     "image_sizes",
+    "patch_pixel_values",
+    "num_patches",
+    "patch_newline_mask",
+    "image_embeds",
     # Video
     "pixel_values_videos",
     # Audio / sound

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -785,11 +785,16 @@ class FinetuneRecipeForVLM(BaseRecipe):
             self.pp = None
 
         # Extract mRoPE position-id builder from the model so VLM neat packing can
-        # produce 3D position_ids per sample. Without this, packed Qwen2.5-VL /
-        # Qwen3-VL training silently degrades mRoPE to plain 1D positions.
+        # produce 3D position_ids per sample. Without this, packed multimodal
+        # training silently degrades mRoPE to plain 1D positions.
         get_rope_index = getattr(self.model_parts[0], "get_rope_index", None)
         pp_n_microbatches = None
-        if self.pp_enabled:
+        pp_cp_preembed = (
+            self.pp_enabled
+            and self.dist_setup.cp_size > 1
+            and hasattr(self.model_parts[0], "prepare_model_inputs_for_cp")
+        )
+        if self.pp_enabled and not pp_cp_preembed:
             pp_n_microbatches = self.pp.pp_batch_size // self.pp.pp_microbatch_size
 
         self.dataloader, self.processor = build_dataloader(
@@ -908,6 +913,27 @@ class FinetuneRecipeForVLM(BaseRecipe):
             end_mlflow_active_run_as_killed()
 
     # ------------------ helpers ------------------
+    def _maybe_set_pp_first_stage_embed_input_meta(self, model_input: torch.Tensor) -> None:
+        if (
+            not self.pp_enabled
+            or not getattr(self.pp.info, "has_first_stage", False)
+            or not model_input.dtype.is_floating_point
+            or model_input.ndim != 3
+        ):
+            return
+
+        for stage in self.pp.info.stages:
+            if stage.is_first:
+                stage.inputs_meta = (
+                    torch.empty(
+                        self.pp.pp_microbatch_size,
+                        model_input.shape[1],
+                        model_input.shape[2],
+                        device="meta",
+                        dtype=model_input.dtype,
+                    ),
+                )
+
     def _forward_backward_step(
         self,
         idx,
@@ -927,15 +953,19 @@ class FinetuneRecipeForVLM(BaseRecipe):
             self.device_mesh is not None
             and "cp" in getattr(self.device_mesh, "mesh_dim_names", ())
             and self.device_mesh["cp"].size() > 1
-            and not self.pp_enabled
         )
         if _cp_active and hasattr(_model, "prepare_model_inputs_for_cp"):
-            mm_kwargs = {k: batch[k] for k in VLM_INPUT_KEYS if batch.get(k) is not None}
-            with torch.no_grad():
-                prepared = _model(_pre_embed_only=True, **mm_kwargs)
-            for k in VLM_INPUT_KEYS:
-                batch.pop(k, None)
-            batch.update(prepared)
+            if not self.pp_enabled or getattr(self.pp.info, "has_first_stage", False):
+                mm_kwargs = {k: batch[k] for k in VLM_INPUT_KEYS if batch.get(k) is not None}
+                with torch.no_grad():
+                    prepared = _model(_pre_embed_only=True, **mm_kwargs)
+                for k in VLM_INPUT_KEYS:
+                    batch.pop(k, None)
+                batch.update(prepared)
+            else:
+                for k in VLM_INPUT_KEYS:
+                    if k != "input_ids":
+                        batch.pop(k, None)
 
         train_ctx, batch = make_cp_batch_and_ctx(self.device_mesh, batch)
         labels = batch.pop("labels")
@@ -953,12 +983,14 @@ class FinetuneRecipeForVLM(BaseRecipe):
                 else:
                     targets = None
 
-                input_ids = batch.pop("input_ids")
-                self.pp.update_seq_len(input_ids.shape[1])
+                model_input_key = "inputs_embeds" if "inputs_embeds" in batch else "input_ids"
+                model_input = batch.pop(model_input_key)
+                self.pp.update_seq_len(model_input.shape[1])
+                self._maybe_set_pp_first_stage_embed_input_meta(model_input)
 
                 with stage_vlm_media_for_pp(self.pp, self.model_parts, batch):
                     if self.pp.info.has_first_stage:
-                        self.pp.info.schedule.step(input_ids, target=targets, losses=losses, **batch)
+                        self.pp.info.schedule.step(model_input, target=targets, losses=losses, **batch)
                     else:
                         self.pp.info.schedule.step(target=targets, losses=losses, **batch)
 

--- a/tests/unit_tests/distributed/test_cp_utils_inputs_embeds.py
+++ b/tests/unit_tests/distributed/test_cp_utils_inputs_embeds.py
@@ -139,6 +139,51 @@ def test_position_ids_synthesized_from_inputs_embeds_seq_dim(monkeypatch):
     assert torch.equal(pos[0], torch.arange(12))
 
 
+def test_position_ids_synthesized_for_each_batch_row(monkeypatch):
+    """Synthesized 2D position_ids must match the batch dimension so later CP
+    sharding keeps positions aligned with each sample."""
+    monkeypatch.setattr(_cu, "create_context_parallel_ctx", lambda **kw: object())
+    monkeypatch.setattr(_cu, "get_train_context", lambda *a, **kw: "ctx")
+
+    device_mesh = _DummyDeviceMesh(cp_size=2, tp_size=1)
+    inputs_embeds = torch.randn(3, 8, 16)
+    batch = {"inputs_embeds": inputs_embeds, "labels": torch.zeros(3, 8, dtype=torch.long)}
+
+    _cu.make_cp_batch_and_ctx(device_mesh, batch)
+
+    assert batch["position_ids"].shape == (3, 8)
+    expected = torch.arange(8).expand(3, -1)
+    assert torch.equal(batch["position_ids"], expected)
+
+
+def test_singleton_position_ids_expand_to_batch_size(monkeypatch):
+    """A caller-provided [1, S] position tensor should expand to [B, S] before
+    the CP context records buffers."""
+    captured = {}
+
+    def _fake_create_ctx(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(_cu, "create_context_parallel_ctx", _fake_create_ctx)
+    monkeypatch.setattr(_cu, "get_train_context", lambda *a, **kw: "ctx")
+
+    device_mesh = _DummyDeviceMesh(cp_size=2, tp_size=1)
+    inputs_embeds = torch.randn(2, 8, 16)
+    position_ids = torch.arange(8).unsqueeze(0)
+    batch = {
+        "inputs_embeds": inputs_embeds,
+        "position_ids": position_ids,
+        "labels": torch.zeros(2, 8, dtype=torch.long),
+    }
+
+    _cu.make_cp_batch_and_ctx(device_mesh, batch)
+
+    assert batch["position_ids"].shape == (2, 8)
+    assert captured["cp_buffers"][2] is batch["position_ids"]
+    assert torch.equal(batch["position_ids"], torch.arange(8).expand(2, -1))
+
+
 def test_inputs_embeds_no_op_when_cp_size_le_1():
     """cp_size<=1 short-circuit must apply to the inputs_embeds path too."""
     device_mesh = _DummyDeviceMesh(cp_size=1, tp_size=1)
@@ -324,12 +369,8 @@ def test_padding_mask_pad_value_is_True_not_False(monkeypatch):
     # Positions 0..3 unchanged
     assert torch.equal(padded[0, :6], padding_mask[0])
     # Positions 6, 7 are cp-pad slots -- MUST be True (pad), not False
-    assert bool(padded[0, 6].item()) is True, (
-        "cp-pad slot 6 should be marked as padding (True)"
-    )
-    assert bool(padded[0, 7].item()) is True, (
-        "cp-pad slot 7 should be marked as padding (True)"
-    )
+    assert bool(padded[0, 6].item()) is True, "cp-pad slot 6 should be marked as padding (True)"
+    assert bool(padded[0, 7].item()) is True, "cp-pad slot 7 should be marked as padding (True)"
 
 
 def test_padding_attention_mask_pad_value_is_zero(monkeypatch):
@@ -344,9 +385,7 @@ def test_padding_attention_mask_pad_value_is_zero(monkeypatch):
     # (the runtime code path is currently unreachable because attention_mask
     # is popped at line 272).
     src = open(_cu.__file__).read()
-    assert '"attention_mask": False' in src, (
-        "PAD_FILL must explicitly map attention_mask -> False (HF: 0 = pad)"
-    )
+    assert '"attention_mask": False' in src, "PAD_FILL must explicitly map attention_mask -> False (HF: 0 = pad)"
 
 
 def test_padding_mirrors_padding_mask_back_into_batch(monkeypatch):
@@ -384,9 +423,7 @@ def test_padding_mirrors_padding_mask_back_into_batch(monkeypatch):
     assert batch["position_ids"].shape[1] == expected_padded_len
     assert batch["padding_mask"].shape[1] == expected_padded_len
     # And the mirror is the same object the cp_buffers hold (not a stale copy)
-    pmask_idx = next(
-        i for i, b in enumerate(captured["cp_buffers"]) if b is batch["padding_mask"]
-    )
+    pmask_idx = next(i for i, b in enumerate(captured["cp_buffers"]) if b is batch["padding_mask"])
     assert pmask_idx >= 3, "padding_mask must come after the primary trio"
 
 
@@ -428,7 +465,6 @@ def test_padding_input_ids_path_int_padding_with_zero(monkeypatch):
     monkeypatch.setattr(_cu, "get_train_context", lambda *a, **kw: "ctx")
 
     device_mesh = _DummyDeviceMesh(cp_size=2, tp_size=1)  # divisor = 4
-    seq_len = 6
     input_ids = torch.tensor([[1, 2, 3, 4, 5, 6]])
     labels = torch.tensor([[1, 2, 3, 4, 5, 6]])
     batch = {"input_ids": input_ids, "labels": labels}

--- a/tests/unit_tests/moe/test_parallelizer.py
+++ b/tests/unit_tests/moe/test_parallelizer.py
@@ -1492,7 +1492,11 @@ def test_apply_ac_text_config_takes_priority_over_llm_config(monkeypatch):
         return "CTX"
 
     monkeypatch.setattr(P, "create_selective_checkpoint_contexts", fake_create_selective_checkpoint_contexts)
-    monkeypatch.setattr(P, "ptd_checkpoint_wrapper", MagicMock(side_effect=lambda b, **kw: (kw.get("context_fn") and kw["context_fn"](), b)[1]))
+    monkeypatch.setattr(
+        P,
+        "ptd_checkpoint_wrapper",
+        MagicMock(side_effect=lambda b, **kw: (kw.get("context_fn") and kw["context_fn"](), b)[1]),
+    )
 
     class TextConfig:
         hidden_size = 256
@@ -2108,9 +2112,13 @@ class _FakeSelfAttn:
 
 
 class _FakeBlockWithAttn:
-    def __init__(self, attn_module, moe=None):
+    def __init__(self, attn_module, moe=None, layer_type=None, attention_type=None):
         self.self_attn = _FakeSelfAttn(attn_module)
         self.mlp = moe if moe is not None else object()
+        if layer_type is not None:
+            self.layer_type = layer_type
+        if attention_type is not None:
+            self.attention_type = attention_type
 
 
 def test_apply_cp_skips_non_te_attention(monkeypatch):
@@ -2178,6 +2186,31 @@ def test_apply_cp_configures_te_attention(monkeypatch):
     P.apply_cp(model, cp_mesh)
 
     te_attn.set_context_parallel_group.assert_called_once()
+
+
+def test_apply_cp_uses_attention_type_and_all_gather_for_sliding_attention(monkeypatch):
+    """Blocks that name attention style with ``attention_type`` should still
+    receive TE context-parallel setup."""
+    P = _import_parallelizer_with_stubs(monkeypatch)
+
+    class DotProductAttention:
+        def __init__(self):
+            self.set_context_parallel_group = MagicMock()
+
+    _setup_te_and_dist_stubs(monkeypatch, DotProductAttention)
+
+    te_attn = DotProductAttention()
+    block = _FakeBlockWithAttn(te_attn, attention_type="sliding_attention")
+    model = DummyModel([block])
+
+    cp_mesh = MagicMock()
+    cp_mesh.get_group.return_value = MagicMock()
+
+    P.apply_cp(model, cp_mesh, cp_comm_type="p2p")
+
+    te_attn.set_context_parallel_group.assert_called_once()
+    _, kwargs = te_attn.set_context_parallel_group.call_args
+    assert kwargs["cp_comm_type"] == "all_gather"
 
 
 def test_apply_cp_mixed_te_and_non_te(monkeypatch):

--- a/tests/unit_tests/recipes/test_finetune_vlm_cp_wiring.py
+++ b/tests/unit_tests/recipes/test_finetune_vlm_cp_wiring.py
@@ -29,11 +29,14 @@ full recipe — exercising the code shape that gets shipped:
 
 from __future__ import annotations
 
+from contextlib import nullcontext
 from types import SimpleNamespace
 
 import pytest
 import torch
 
+import nemo_automodel.recipes.vlm.finetune as vlm_finetune
+from nemo_automodel.components.config.loader import ConfigNode
 from nemo_automodel.components.utils.model_utils import VLM_INPUT_KEYS
 from nemo_automodel.recipes.vlm.finetune import FinetuneRecipeForVLM
 
@@ -280,6 +283,221 @@ def test_maybe_set_pp_first_stage_embed_input_meta_guard_conditions(recipe_kwarg
 
     assert first_stage.inputs_meta == ("old-first",)
     assert later_stage.inputs_meta == ("old-later",)
+
+
+class _FakeCPMesh:
+    mesh_dim_names = ("cp",)
+
+    def __getitem__(self, key):
+        assert key == "cp"
+        return SimpleNamespace(size=lambda: 2)
+
+
+class _ScheduleSpy:
+    def __init__(self):
+        self.calls = []
+
+    def step(self, model_input=None, *, target=None, losses=None, **batch):
+        self.calls.append({"model_input": model_input, "target": target, "batch": batch})
+        if losses is not None:
+            losses.append(torch.tensor(1.25))
+
+
+def test_forward_backward_step_pp_cp_first_stage_uses_inputs_embeds(monkeypatch):
+    inputs_embeds = torch.randn(2, 6, 8)
+    labels = torch.arange(12, dtype=torch.long).reshape(2, 6)
+    model = _SpyVLM(prepared={"inputs_embeds": inputs_embeds})
+    schedule = _ScheduleSpy()
+    seq_lens = []
+    first_stage = SimpleNamespace(is_first=True, inputs_meta=None)
+    recipe = object.__new__(FinetuneRecipeForVLM)
+    recipe.dist_env = SimpleNamespace(device=torch.device("cpu"))
+    recipe.device_mesh = _FakeCPMesh()
+    recipe.distributed_config = SimpleNamespace(defer_fsdp_grad_sync=True)
+    recipe.model_parts = [model]
+    recipe.pp_enabled = True
+    recipe.pp = SimpleNamespace(
+        pp_microbatch_size=2,
+        info=SimpleNamespace(
+            has_first_stage=True,
+            has_last_stage=True,
+            stages=[first_stage, SimpleNamespace(is_first=False, inputs_meta=None)],
+            schedule=schedule,
+        ),
+        update_seq_len=seq_lens.append,
+    )
+    batch = {
+        "input_ids": torch.ones(2, 6, dtype=torch.long),
+        "pixel_values": torch.zeros(2, 3, 4, 4),
+        "labels": labels,
+    }
+    seen_cp_batch = {}
+
+    def _make_cp_batch_and_ctx(device_mesh, cp_batch):
+        seen_cp_batch.update(cp_batch)
+        return nullcontext, cp_batch
+
+    monkeypatch.setattr(vlm_finetune, "make_cp_batch_and_ctx", _make_cp_batch_and_ctx)
+    monkeypatch.setattr(vlm_finetune, "stage_vlm_media_for_pp", lambda *args, **kwargs: nullcontext())
+
+    loss_buffer = []
+    FinetuneRecipeForVLM._forward_backward_step(
+        recipe,
+        0,
+        batch,
+        loss_buffer=loss_buffer,
+        num_label_tokens=labels.numel(),
+        num_batches=1,
+    )
+
+    assert len(model.calls) == 1
+    assert model.calls[0]["_pre_embed_only"] is True
+    assert "inputs_embeds" in seen_cp_batch
+    assert "input_ids" not in seen_cp_batch
+    assert "pixel_values" not in seen_cp_batch
+    assert seq_lens == [inputs_embeds.shape[1]]
+    assert len(schedule.calls) == 1
+    assert schedule.calls[0]["model_input"] is inputs_embeds
+    assert torch.equal(schedule.calls[0]["target"], labels)
+    assert schedule.calls[0]["batch"] == {}
+    assert tuple(first_stage.inputs_meta[0].shape) == (2, 6, 8)
+    assert first_stage.inputs_meta[0].dtype == inputs_embeds.dtype
+    assert torch.equal(loss_buffer[0], torch.tensor(1.25))
+
+
+class _FakePPModel:
+    def __init__(self, stage0):
+        self.parts = [stage0]
+        self.pp_batch_size = 4
+        self.pp_microbatch_size = 2
+
+
+class _StageWithCPPrepare:
+    def prepare_model_inputs_for_cp(self):
+        return {}
+
+
+class _StageWithoutCPPrepare:
+    pass
+
+
+def _patch_pp_setup_minimals(monkeypatch, *, cp_size, stage0, dataloader_calls):
+    monkeypatch.setattr(vlm_finetune, "AutoPipeline", _FakePPModel)
+    monkeypatch.setattr(
+        vlm_finetune,
+        "build_distributed",
+        lambda cfg: SimpleNamespace(world_size=1, is_main=True, device=torch.device("cpu"), rank=0),
+    )
+    monkeypatch.setattr(vlm_finetune, "setup_logging", lambda: None)
+    monkeypatch.setattr(vlm_finetune, "apply_cache_compatibility_patches", lambda: None)
+    monkeypatch.setattr(vlm_finetune, "StatefulRNG", lambda *args, **kwargs: "rng")
+    monkeypatch.setattr(vlm_finetune, "build_loss_fn", lambda cfg: "loss_fn")
+    monkeypatch.setattr(vlm_finetune, "_supports_logits_to_keep", lambda model: True)
+    monkeypatch.setattr(
+        vlm_finetune,
+        "setup_distributed",
+        lambda cfg, world_size: SimpleNamespace(
+            strategy_config=SimpleNamespace(),
+            pipeline_config=SimpleNamespace(),
+            moe_config=None,
+            activation_checkpointing=False,
+            pp_enabled=True,
+            device_mesh=None,
+            moe_mesh=None,
+            cp_size=cp_size,
+            pp_size=2,
+        ),
+    )
+    monkeypatch.setattr(
+        vlm_finetune,
+        "build_checkpoint_config",
+        lambda *args, **kwargs: SimpleNamespace(checkpoint_dir="ckpts", model_state_dict_keys=None),
+    )
+    monkeypatch.setattr(
+        vlm_finetune,
+        "Checkpointer",
+        lambda **kwargs: SimpleNamespace(
+            config=kwargs["config"],
+            load_base_model=lambda *args, **kwargs: None,
+            maybe_wait_for_staging=lambda: None,
+            close=lambda: None,
+        ),
+    )
+    monkeypatch.setattr(vlm_finetune, "build_model", lambda *args, **kwargs: _FakePPModel(stage0))
+    monkeypatch.setattr(
+        vlm_finetune,
+        "build_optimizer",
+        lambda *args, **kwargs: [SimpleNamespace(param_groups=[{"lr": 0.01}], step=lambda: None)],
+    )
+
+    def _build_dataloader(*args, **kwargs):
+        dataloader_calls.append(kwargs)
+        return "dl", "processor"
+
+    monkeypatch.setattr(vlm_finetune, "build_dataloader", _build_dataloader)
+    monkeypatch.setattr(
+        vlm_finetune,
+        "build_step_scheduler",
+        lambda *args, **kwargs: SimpleNamespace(step=0, epoch=0, epochs=[]),
+    )
+    monkeypatch.setattr(vlm_finetune, "build_lr_scheduler", lambda *args, **kwargs: [])
+    monkeypatch.setattr(
+        vlm_finetune,
+        "build_metric_logger",
+        lambda *args, **kwargs: SimpleNamespace(log=lambda *args, **kwargs: None, close=lambda: None),
+    )
+    monkeypatch.setattr(vlm_finetune.torch.cuda, "reset_peak_memory_stats", lambda: None, raising=False)
+    monkeypatch.setattr(FinetuneRecipeForVLM, "_log_experiment_details", lambda self: None)
+    monkeypatch.setattr(FinetuneRecipeForVLM, "_log_library_versions", lambda self: None)
+    monkeypatch.setattr(FinetuneRecipeForVLM, "_log_model_and_optimizer_details", lambda *args, **kwargs: None)
+    monkeypatch.setattr(FinetuneRecipeForVLM, "_setup_garbage_collection", lambda *args, **kwargs: None)
+    monkeypatch.setattr(FinetuneRecipeForVLM, "load_checkpoint", lambda *args, **kwargs: None)
+    monkeypatch.setattr(FinetuneRecipeForVLM, "_log_step_scheduler_details", lambda *args, **kwargs: None)
+    monkeypatch.setattr(FinetuneRecipeForVLM, "_get_dp_rank", lambda self, include_cp=False: 0)
+    monkeypatch.setattr(FinetuneRecipeForVLM, "_get_tp_rank", lambda self: 0)
+    monkeypatch.setattr(FinetuneRecipeForVLM, "_get_pp_rank", lambda self: 0)
+    monkeypatch.setattr(FinetuneRecipeForVLM, "_get_dp_group_size", lambda self, include_cp=False: 1)
+
+
+def _minimal_pp_setup_cfg():
+    return ConfigNode(
+        {
+            "model": {
+                "pretrained_model_name_or_path": "dummy/model",
+                "backend": {},
+            },
+            "dataset": {"path_or_dataset": "dummy"},
+            "dataloader": {},
+            "step_scheduler": {"local_batch_size": 4, "global_batch_size": 4},
+            "optimizer": {},
+            "loss_fn": {},
+            "checkpoint": {"best_metric_key": "default"},
+            "distributed": {"pipeline": {"pp_microbatch_size": 2}},
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    ("cp_size", "stage0", "expected_pp_n_microbatches"),
+    [
+        (2, _StageWithCPPrepare(), None),
+        (1, _StageWithCPPrepare(), 2),
+        (2, _StageWithoutCPPrepare(), 2),
+    ],
+)
+def test_setup_skips_pp_media_prechunk_when_cp_preembeds_vlm_inputs(
+    monkeypatch,
+    cp_size,
+    stage0,
+    expected_pp_n_microbatches,
+):
+    dataloader_calls = []
+    _patch_pp_setup_minimals(monkeypatch, cp_size=cp_size, stage0=stage0, dataloader_calls=dataloader_calls)
+    trainer = FinetuneRecipeForVLM(_minimal_pp_setup_cfg())
+
+    trainer.setup()
+
+    assert dataloader_calls[0]["pp_n_microbatches"] == expected_pp_n_microbatches
 
 
 # -----------------------------------------------------------------------------

--- a/tests/unit_tests/recipes/test_finetune_vlm_cp_wiring.py
+++ b/tests/unit_tests/recipes/test_finetune_vlm_cp_wiring.py
@@ -35,23 +35,29 @@ import pytest
 import torch
 
 from nemo_automodel.components.utils.model_utils import VLM_INPUT_KEYS
+from nemo_automodel.recipes.vlm.finetune import FinetuneRecipeForVLM
 
 # -----------------------------------------------------------------------------
 # Helpers reproducing the recipe's CP-prepare block (train + val flavors).
 # -----------------------------------------------------------------------------
 
 
-def _train_cp_prepare(_model, batch):
+def _train_cp_prepare(_model, batch, *, pp_enabled=False, has_first_stage=True):
     """Replicates the train-side CP prepare block in
     ``recipes/vlm/finetune.py::_forward_backward_step`` (lines 960-967)."""
     if not hasattr(_model, "prepare_model_inputs_for_cp"):
         return batch
-    mm_kwargs = {k: batch[k] for k in VLM_INPUT_KEYS if batch.get(k) is not None}
-    with torch.no_grad():
-        prepared = _model(_pre_embed_only=True, **mm_kwargs)
-    for k in VLM_INPUT_KEYS:
-        batch.pop(k, None)
-    batch.update(prepared)
+    if not pp_enabled or has_first_stage:
+        mm_kwargs = {k: batch[k] for k in VLM_INPUT_KEYS if batch.get(k) is not None}
+        with torch.no_grad():
+            prepared = _model(_pre_embed_only=True, **mm_kwargs)
+        for k in VLM_INPUT_KEYS:
+            batch.pop(k, None)
+        batch.update(prepared)
+    else:
+        for k in VLM_INPUT_KEYS:
+            if k != "input_ids":
+                batch.pop(k, None)
     return batch
 
 
@@ -173,9 +179,7 @@ def test_train_cp_prepare_uses_torch_no_grad():
             return {"inputs_embeds": torch.zeros(1, 4, 8)}
 
         def __call__(self, **kw):
-            assert not torch.is_grad_enabled(), (
-                "prepare step must run under torch.no_grad()"
-            )
+            assert not torch.is_grad_enabled(), "prepare step must run under torch.no_grad()"
             return {"inputs_embeds": torch.zeros(1, 4, 8)}
 
     model = _GradSensitive()
@@ -184,6 +188,98 @@ def test_train_cp_prepare_uses_torch_no_grad():
         "labels": torch.tensor([[1, 2, 3, 4]]),
     }
     _train_cp_prepare(model, batch)
+
+
+def test_train_cp_prepare_pp_first_stage_preembeds_inputs():
+    """When CP and PP are both enabled, only the first stage should materialize
+    multimodal inputs before sequence sharding."""
+    inputs_embeds = torch.randn(1, 4, 8)
+    model = _SpyVLM(prepared={"inputs_embeds": inputs_embeds})
+    batch = {
+        "input_ids": torch.tensor([[1, 2, 3, 4]]),
+        "pixel_values": torch.zeros(1, 3, 4, 4),
+        "patch_pixel_values": torch.zeros(1, 2, 3, 4, 4),
+        "num_patches": torch.tensor([2]),
+        "labels": torch.tensor([[1, 2, 3, 4]]),
+    }
+
+    out_batch = _train_cp_prepare(model, batch, pp_enabled=True, has_first_stage=True)
+
+    assert len(model.calls) == 1
+    assert model.calls[0]["_pre_embed_only"] is True
+    assert "patch_pixel_values" in model.calls[0]
+    assert "num_patches" in model.calls[0]
+    assert "inputs_embeds" in out_batch
+    assert "input_ids" not in out_batch
+    assert "pixel_values" not in out_batch
+
+
+def test_train_cp_prepare_pp_later_stage_drops_media_without_preembedding():
+    """Later PP stages should not run the media encoder, but should remove
+    unneeded media tensors before CP batch processing."""
+    model = _SpyVLM()
+    batch = {
+        "input_ids": torch.tensor([[1, 2, 3, 4]]),
+        "pixel_values": torch.zeros(1, 3, 4, 4),
+        "patch_pixel_values": torch.zeros(1, 2, 3, 4, 4),
+        "num_patches": torch.tensor([2]),
+        "labels": torch.tensor([[1, 2, 3, 4]]),
+    }
+
+    out_batch = _train_cp_prepare(model, batch, pp_enabled=True, has_first_stage=False)
+
+    assert model.calls == []
+    assert "input_ids" in out_batch
+    assert "inputs_embeds" not in out_batch
+    assert "pixel_values" not in out_batch
+    assert "patch_pixel_values" not in out_batch
+    assert "num_patches" not in out_batch
+    assert "labels" in out_batch
+
+
+def _make_recipe_with_pp_stages(*, pp_enabled=True, has_first_stage=True, pp_microbatch_size=2):
+    first_stage = SimpleNamespace(is_first=True, inputs_meta=("old-first",))
+    later_stage = SimpleNamespace(is_first=False, inputs_meta=("old-later",))
+    recipe = SimpleNamespace(
+        pp_enabled=pp_enabled,
+        pp=SimpleNamespace(
+            pp_microbatch_size=pp_microbatch_size,
+            info=SimpleNamespace(has_first_stage=has_first_stage, stages=[first_stage, later_stage]),
+        ),
+    )
+    return recipe, first_stage, later_stage
+
+
+def test_maybe_set_pp_first_stage_embed_input_meta_sets_first_stage_meta():
+    recipe, first_stage, later_stage = _make_recipe_with_pp_stages(pp_microbatch_size=3)
+    model_input = torch.empty(5, 11, 13, dtype=torch.bfloat16)
+
+    FinetuneRecipeForVLM._maybe_set_pp_first_stage_embed_input_meta(recipe, model_input)
+
+    assert later_stage.inputs_meta == ("old-later",)
+    assert len(first_stage.inputs_meta) == 1
+    meta = first_stage.inputs_meta[0]
+    assert tuple(meta.shape) == (3, 11, 13)
+    assert meta.dtype == torch.bfloat16
+    assert meta.device.type == "meta"
+
+
+@pytest.mark.parametrize(
+    ("recipe_kwargs", "model_input"),
+    [
+        ({"pp_enabled": False}, torch.empty(5, 11, 13)),
+        ({"has_first_stage": False}, torch.empty(5, 11, 13)),
+        ({}, torch.empty(5, 11, 13, dtype=torch.int64)),
+        ({}, torch.empty(5, 11)),
+    ],
+)
+def test_maybe_set_pp_first_stage_embed_input_meta_guard_conditions(recipe_kwargs, model_input):
+    recipe, first_stage, later_stage = _make_recipe_with_pp_stages(**recipe_kwargs)
+
+    FinetuneRecipeForVLM._maybe_set_pp_first_stage_embed_input_meta(recipe, model_input)
+
+    assert first_stage.inputs_meta == ("old-first",)
+    assert later_stage.inputs_meta == ("old-later",)
 
 
 # -----------------------------------------------------------------------------
@@ -217,9 +313,7 @@ def test_val_pos_ids_uses_dist_env_device_not_model_device():
         # Intentionally has NO ``.device`` attribute (mirrors real FSDP wrapper).
         def __getattr__(self, name):
             if name == "device":
-                raise AttributeError(
-                    "'FSDPWrapped' object has no attribute 'device'"
-                )
+                raise AttributeError("'FSDPWrapped' object has no attribute 'device'")
             raise AttributeError(name)
 
     model = _FSDPWrapped()


### PR DESCRIPTION
## Summary
- Pre-embed multimodal inputs before context-parallel sequence sharding when a VLM exposes a CP input-preparation hook.
- Allow pipeline-parallel VLM fine-tuning to pass embedding tensors through the first stage.
- Expand generated 2D position ids to the batch size and configure CP for sliding attention blocks.

## Tests
- `python -m pytest tests/unit_tests/distributed/test_cp_utils_inputs_embeds.py tests/unit_tests/recipes/test_finetune_vlm_cp_wiring.py tests/unit_tests/moe/test_parallelizer.py`
- `python -m ruff check nemo_automodel/components/distributed/cp_utils.py nemo_automodel/components/moe/parallelizer.py nemo_automodel/components/utils/model_utils.py nemo_automodel/recipes/vlm/finetune.py tests/unit_tests/distributed/test_cp_utils_inputs_embeds.py tests/unit_tests/moe/test_parallelizer.py tests/unit_tests/recipes/test_finetune_vlm_cp_wiring.py`
- `python -m ruff format --check nemo_automodel/components/distributed/cp_utils.py nemo_automodel/components/moe/parallelizer.py nemo_automodel/components/utils/model_utils.py nemo_automodel/recipes/vlm/finetune.py tests/unit_tests/distributed/test_cp_utils_inputs_embeds.py tests/unit_tests/moe/test_parallelizer.py tests/unit_tests/recipes/test_finetune_vlm_cp_wiring.py`