### PR TITLE
refactor(ci): unify job construction in generate_ci_tests + add PR check

### DIFF
--- a/.github/workflows/validate-recipe-configs.yml
+++ b/.github/workflows/validate-recipe-configs.yml
@@ -20,6 +20,7 @@ on:
       - 'tests/ci_tests/configs/**'
       - 'examples/**/*.yaml'
       - 'tests/ci_tests/utils/validate_nightly_recipes.py'
+      - 'tests/ci_tests/utils/validate_generate_ci.py'
       - 'tests/ci_tests/utils/generate_ci_tests.py'
       - 'tools/lint_example_yamls.py'
 
@@ -50,3 +51,6 @@ jobs:
 
       - name: Validate nightly recipe references
         run: .venv-validator/bin/python tests/ci_tests/utils/validate_nightly_recipes.py --automodel-dir .
+
+      - name: Validate generate_ci_tests across all (folder, scope) combos
+        run: .venv-validator/bin/python tests/ci_tests/utils/validate_generate_ci.py --automodel-dir .

--- a/tests/ci_tests/utils/generate_ci_tests.py
+++ b/tests/ci_tests/utils/generate_ci_tests.py
@@ -58,14 +58,38 @@ def slurm_time_multiplier(time: str, multiplier: int):
 
 
 # Scopes that auto-discover all configs via rglob (no recipe list needed).
+# Each entry maps test_folder -> subpath under examples/ (defaults to test_folder
+# when the two diverge, e.g. diffusion_finetune lives at examples/diffusion/finetune).
 # All other scope/folder combinations read from {scope}_recipes.yml.
 AUTO_DISCOVER_SCOPES = {
-    "release": ["llm_finetune", "vlm_finetune", "diffusion_finetune"],
-    "performance": ["llm_benchmark", "vlm_benchmark"],
+    "release": {
+        "llm_finetune": "llm_finetune",
+        "vlm_finetune": "vlm_finetune",
+        "diffusion_finetune": "diffusion/finetune",
+    },
+    "performance": {
+        "llm_benchmark": "llm_benchmark",
+        "vlm_benchmark": "vlm_benchmark",
+    },
 }
 
 
-def detect_yml_configurations(automodel_dir: str, scope: str, test_folder: str):
+def _discover_via_glob(automodel_dir: str, examples_subpath: str) -> list[Path]:
+    """Discover every recipe YAML under examples/<examples_subpath>/."""
+    automodel_path = Path(automodel_dir)
+    return sorted(p.relative_to(automodel_path) for p in (automodel_path / "examples" / examples_subpath).rglob("*.yaml"))
+
+
+def _discover_via_recipe_list(automodel_dir: str, scope: str, test_folder: str) -> list[Path]:
+    """Read configs/<test_folder>/<scope>_recipes.yml and return the recipe paths it lists."""
+    config_path = Path(automodel_dir) / "tests" / "ci_tests" / "configs" / test_folder / f"{scope}_recipes.yml"
+    with open(config_path, "r", encoding="utf-8") as f:
+        test_configs = yaml.load(f)
+    examples_dir = test_configs.get("examples_dir", test_folder)
+    return [Path(f"examples/{examples_dir}/{c}") for c in test_configs["configs"]]
+
+
+def detect_yml_configurations(automodel_dir: str, scope: str, test_folder: str) -> list[Path]:
     """
     Detect recipe YAML configurations to include in the CI pipeline.
 
@@ -80,28 +104,98 @@ def detect_yml_configurations(automodel_dir: str, scope: str, test_folder: str):
     Returns:
         yml_configs: List of yaml configs with path format examples/{test_folder}/
     """
-    yml_configs = []
-    search_path = f"{automodel_dir}/examples/{test_folder}"
-
-    auto_folders = AUTO_DISCOVER_SCOPES.get(scope, [])
+    auto_folders = AUTO_DISCOVER_SCOPES.get(scope, {})
     if test_folder in auto_folders:
-        for f in Path(f"{search_path}").rglob("*.yaml"):
-            relative_path = f.relative_to(automodel_dir)
-            yml_configs.append(relative_path)
-    else:
-        config_path = f"{automodel_dir}/tests/ci_tests/configs/{test_folder}/{scope}_recipes.yml"
-        with open(config_path, "r", encoding="utf-8") as f:
-            test_configs = yaml.load(f)
-            examples_dir = test_configs.get("examples_dir", test_folder)
-            yml_configs = [Path(f"examples/{examples_dir}/{c}") for c in test_configs["configs"]]
-
-    return yml_configs
+        return _discover_via_glob(automodel_dir, auto_folders[test_folder])
+    return _discover_via_recipe_list(automodel_dir, scope, test_folder)
 
 
-def generate_job(config: str, config_override: Dict[str, Any], scope: str, test_folder: str, automodel_dir: str):
+# Recipe ci: section keys mapped to the CI variables they populate on the base job.
+CI_KEY_TO_VAR = {
+    "time": "TIME",
+    "nodes": "TEST_NODE_COUNT",
+    "node_multiplier": "NODE_MULTIPLIER",
+    "local_batch_size": "LOCAL_BATCH_SIZE",
+    "recipe_owner": "RECIPE_OWNER",
+    "nproc_per_node": "CONFIG_NPROC_PER_NODE",
+}
+
+
+def _compute_base_stage(test_folder: str, config: Path, has_robustness: bool) -> str:
+    """Pick the GitLab CI stage for a base recipe job."""
+    if "benchmark" in test_folder:
+        return "performance"
+    if "benchmark" in config.stem:
+        return "benchmark"
+    if test_folder.startswith("diffusion"):
+        return "diffusion_peft" if ("lora" in config.stem or "peft" in config.stem) else "diffusion_sft"
+    if test_folder.startswith("retrieval"):
+        return "retrieval"
+    if "peft" in config.stem or "lora" in config.stem:
+        return "peft_ckpt_robustness" if has_robustness else "peft"
+    return "sft_ckpt_robustness" if has_robustness else "sft"
+
+
+def _build_job(
+    config: Path,
+    scope: str,
+    *,
+    extends: str,
+    stage: str,
+    extra_vars: Dict[str, Any] | None = None,
+    allow_failure: bool = False,
+    known_issue_id: str | None = None,
+) -> Dict[str, Any]:
+    """Build a CI job dict with the keys common to every variant (base, vllm_deploy, eval)."""
+    job: Dict[str, Any] = {
+        "extends": extends,
+        "stage": stage,
+        "variables": {
+            "CONFIG_PATH": f"{config}",
+            "TEST_LEVEL": f"{scope}",
+            **(extra_vars or {}),
+        },
+    }
+    if allow_failure:
+        job["allow_failure"] = True
+    if known_issue_id:
+        job["variables"]["KNOWN_ISSUE_ID"] = known_issue_id
+    return job
+
+
+def _enrich_base_job(job: Dict[str, Any], ci_config: Dict[str, Any], scope: str) -> None:
+    """Add base-only extras: resource overrides, env_vars, HAS_ROBUSTNESS, convergence time."""
+    for ci_key, ci_var in CI_KEY_TO_VAR.items():
+        if ci_key not in ci_config:
+            continue
+        value = ci_config[ci_key]
+        if ci_var == "TIME":
+            job["variables"][ci_var] = DQ(str(value))
+        elif ci_var == "NODE_MULTIPLIER":
+            job["variables"][ci_var] = str(value).lower()
+        else:
+            job["variables"][ci_var] = value
+
+    for key, value in ci_config.get("env_vars", {}).items():
+        job["variables"][key] = str(value)
+
+    job["variables"]["HAS_ROBUSTNESS"] = str(bool(ci_config.get("checkpoint_robustness"))).lower()
+
+    # Convergence tests run for 2 epochs; double the slurm time allocation.
+    if scope == "convergence":
+        slurm_time = job["variables"].get("TIME", "00:10:00")
+        job["variables"]["TIME"] = DQ(slurm_time_multiplier(slurm_time, 2))
+
+
+def generate_job(
+    config: Path,
+    config_override: Dict[str, Any],
+    scope: str,
+    test_folder: str,
+    automodel_dir: str,
+) -> list[tuple[str, Dict[str, Any]]]:
     """
-    Generate a CI test job definition for a single recipe configuration.
-    Resource requirements (time, nodes, etc.) are read from the recipe's `ci:` section.
+    Generate every CI job (base + opt-in variants) for a single recipe configuration.
 
     Args:
         config: Relative path to the recipe YAML configuration
@@ -111,149 +205,67 @@ def generate_job(config: str, config_override: Dict[str, Any], scope: str, test_
         automodel_dir: Path to the Automodel directory
 
     Returns:
-        job: Dictionary defining a single CI test job
+        List of (suffix, job_dict) pairs. The base job has suffix "". An empty list
+        means the recipe is fully skipped (e.g. ci.known_issue_id without ci.allow_failure).
     """
-    # Initialize test job
-    job = {
-        "variables": {
-            "CONFIG_PATH": f"{config}",
-            "TEST_LEVEL": f"{scope}",
-        }
-    }
-
-    # Configure test template
-    if "benchmark" in config.stem:
-        job["extends"] = ".llm_benchmark_test"
-    else:
-        job["extends"] = f".{test_folder}_test"
-
-    # Apply resource overrides (time, nodes, etc.) from the recipe's top-level ci: section
-    recipe_path = f"{automodel_dir}/{config}"
-    with open(recipe_path, "r", encoding="utf-8") as rf:
-        recipe = yaml.load(rf)
-
-    ci_config = recipe.get('ci') or {}
+    with open(f"{automodel_dir}/{config}", "r", encoding="utf-8") as rf:
+        ci_config = (yaml.load(rf) or {}).get("ci") or {}
 
     # allow_failure wins over known_issue_id.
-    # known_issue_id alone skips the job (and its vllm_deploy variant).
-    known_issue_id = ci_config.get('known_issue_id')
-    recipe_allow_failure = bool(ci_config.get('allow_failure'))
+    # known_issue_id alone skips the entire recipe (base + all variants).
+    known_issue_id = ci_config.get("known_issue_id")
+    recipe_allow_failure = bool(ci_config.get("allow_failure"))
     if known_issue_id and not recipe_allow_failure:
-        return None, None
+        return []
 
-    ci_key_map = {
-        "time": "TIME",
-        "nodes": "TEST_NODE_COUNT",
-        "node_multiplier": "NODE_MULTIPLIER",
-        "local_batch_size": "LOCAL_BATCH_SIZE",
-        "recipe_owner": "RECIPE_OWNER",
-        "nproc_per_node": "CONFIG_NPROC_PER_NODE",
-    }
-    for ci_key, ci_var in ci_key_map.items():
-        if ci_key in ci_config:
-            value = ci_config[ci_key]
-            if ci_var == "TIME":
-                job["variables"][ci_var] = DQ(str(value))
-            elif ci_var == "NODE_MULTIPLIER":
-                job["variables"][ci_var] = str(value).lower()
-            else:
-                job["variables"][ci_var] = value
+    has_robustness = bool(ci_config.get("checkpoint_robustness"))
+    base_allow_failure = recipe_allow_failure or config.stem in (config_override.get("known_issue") or [])
 
-    # Pass through env_vars as CI variables (exported to container via --export=ALL)
-    for key, value in ci_config.get('env_vars', {}).items():
-        job['variables'][key] = str(value)
+    base_job = _build_job(
+        config, scope,
+        extends=".llm_benchmark_test" if "benchmark" in config.stem else f".{test_folder}_test",
+        stage=_compute_base_stage(test_folder, config, has_robustness),
+        allow_failure=base_allow_failure,
+        known_issue_id=known_issue_id,
+    )
+    _enrich_base_job(base_job, ci_config, scope)
+    variants: list[tuple[str, Dict[str, Any]]] = [("", base_job)]
 
-    has_robustness = bool(ci_config.get('checkpoint_robustness'))
-    job['variables']['HAS_ROBUSTNESS'] = str(has_robustness).lower()
+    # vLLM deploy variant. `ci.vllm_deploy_known_issue_id` suppresses just this
+    # variant (base job still runs) -- use for bugs that only manifest in vllm deploy.
+    if ci_config.get("vllm_deploy") and not ci_config.get("vllm_deploy_known_issue_id"):
+        variants.append((
+            "_vllm_deploy",
+            _build_job(
+                config, scope,
+                extends=".vllm_deploy_test",
+                stage="peft_vllm_deploy" if "peft" in config.stem else "sft_vllm_deploy",
+                allow_failure=recipe_allow_failure,
+                known_issue_id=known_issue_id,
+            ),
+        ))
 
-    # Configure test stage based on recipe type and robustness config
-    if "benchmark" in test_folder:
-        job["stage"] = "performance"
-    elif "benchmark" in config.stem:
-        job["stage"] = "benchmark"
-    elif test_folder.startswith("diffusion"):
-        job["stage"] = "diffusion_peft" if ("lora" in config.stem or "peft" in config.stem) else "diffusion_sft"
-    elif test_folder.startswith("retrieval"):
-        job["stage"] = "retrieval"
-    elif "peft" in config.stem or "lora" in config.stem:
-        job["stage"] = "peft_ckpt_robustness" if has_robustness else "peft"
-    else:
-        job["stage"] = "sft_ckpt_robustness" if has_robustness else "sft"
+    # Retrieval eval variants. Bi-encoders opt into embed_eval, cross-encoders
+    # into rerank_eval. Both extend the same per-folder eval template.
+    for ci_key, suffix in (("embed_eval", "_embed_eval"), ("rerank_eval", "_rerank_eval")):
+        if not ci_config.get(ci_key):
+            continue
+        variants.append((
+            suffix,
+            _build_job(
+                config, scope,
+                extends=f".{test_folder}_eval_test",
+                stage="retrieval_eval",
+                extra_vars={"FINETUNE_TEST_NAME": f"{config.stem}"},
+                allow_failure=recipe_allow_failure,
+                known_issue_id=known_issue_id,
+            ),
+        ))
 
-    # Check if config has known issue
-    known_issue_config_list = config_override.get("known_issue") or []
-    if config.stem in known_issue_config_list:
-        job["allow_failure"] = True
-
-    # Recipe-level allow_failure + known_issue_id (skip case handled earlier).
-    if recipe_allow_failure:
-        job['allow_failure'] = True
-    if known_issue_id:
-        job['variables']['KNOWN_ISSUE_ID'] = known_issue_id
-
-    # Double time allocation as tests run for 2 epoch
-    if scope == "convergence":
-        slurm_time = job["variables"].get("TIME", "00:10:00")
-        job["variables"]["TIME"] = DQ(slurm_time_multiplier(slurm_time, 2))
-
-    # Generate vLLM deploy job if recipe opts in.
-    # `ci.vllm_deploy_known_issue_id` suppresses just the vllm_deploy variant
-    # (base job still runs) -- use for bugs that only manifest in vllm deploy.
-    vllm_job = None
-    vllm_deploy_known_issue_id = ci_config.get("vllm_deploy_known_issue_id")
-    if ci_config.get("vllm_deploy") and not vllm_deploy_known_issue_id:
-        vllm_stage = "peft_vllm_deploy" if "peft" in config.stem else "sft_vllm_deploy"
-        vllm_job = {
-            "extends": ".vllm_deploy_test",
-            "stage": vllm_stage,
-            "variables": {
-                "CONFIG_PATH": f"{config}",
-                "TEST_LEVEL": f"{scope}",
-            },
-        }
-        if recipe_allow_failure:
-            vllm_job['allow_failure'] = True
-        if known_issue_id:
-            vllm_job['variables']['KNOWN_ISSUE_ID'] = known_issue_id
-
-    # Generate embedding eval job if recipe opts in (bi-encoder retrieval models)
-    embed_eval_job = None
-    if ci_config.get("embed_eval"):
-        embed_eval_job = {
-            "extends": f".{test_folder}_eval_test",
-            "stage": "retrieval_eval",
-            "variables": {
-                "CONFIG_PATH": f"{config}",
-                "TEST_LEVEL": f"{scope}",
-                "FINETUNE_TEST_NAME": f"{config.stem}",
-            },
-        }
-        if recipe_allow_failure:
-            embed_eval_job['allow_failure'] = True
-        if known_issue_id:
-            embed_eval_job['variables']['KNOWN_ISSUE_ID'] = known_issue_id
-
-    # Generate reranking eval job if recipe opts in (cross-encoder retrieval models)
-    rerank_eval_job = None
-    if ci_config.get("rerank_eval"):
-        rerank_eval_job = {
-            "extends": f".{test_folder}_eval_test",
-            "stage": "retrieval_eval",
-            "variables": {
-                "CONFIG_PATH": f"{config}",
-                "TEST_LEVEL": f"{scope}",
-                "FINETUNE_TEST_NAME": f"{config.stem}",
-            },
-        }
-        if recipe_allow_failure:
-            rerank_eval_job['allow_failure'] = True
-        if known_issue_id:
-            rerank_eval_job['variables']['KNOWN_ISSUE_ID'] = known_issue_id
-
-    return job, vllm_job, embed_eval_job, rerank_eval_job
+    return variants
 
 
-def generate_pipeline(automodel_dir: str, scope: str, test_folder: str):
+def generate_pipeline(automodel_dir: str, scope: str, test_folder: str) -> Dict[str, Any]:
     """
     Generate a complete CI test pipeline YAML for the given test folder and scope.
 
@@ -265,71 +277,56 @@ def generate_pipeline(automodel_dir: str, scope: str, test_folder: str):
     Returns:
         pipeline: Dictionary defining the CI test pipeline
     """
-
-    # Check scope
-    if scope == "NONE":
-        scope = "nightly"
-
     override_path = f"{automodel_dir}/tests/ci_tests/configs/{test_folder}/override_recipes.yml"
     with open(override_path, "r", encoding="utf-8") as f:
-        config_override = yaml.load(f)
-    yml_configs = detect_yml_configurations(automodel_dir, scope, test_folder)
+        config_override = yaml.load(f) or {}
 
+    yml_configs = detect_yml_configurations(automodel_dir, scope, test_folder)
     if not yml_configs:
         raise Exception(f"No yml configurations were found under {automodel_dir}/examples/{test_folder}")
 
-    # Skip missing recipes so one bad reference doesn't abort the whole pipeline.
-    existing_configs = []
+    exempt_models = set(config_override.get("exempt_models") or [])
+    exempt_configs = set(config_override.get("exempt_configs") or [])
+
+    pipeline: Dict[str, Any] = {"include": ["automodel/automodel_ci_template.yml"]}
+
     for config in yml_configs:
-        if (Path(automodel_dir) / config).is_file():
-            existing_configs.append(config)
-        else:
+        # Skip missing recipes so one bad reference doesn't abort the whole pipeline.
+        if not (Path(automodel_dir) / config).is_file():
             print(f"WARNING: recipe not found, skipping: {config}", file=sys.stderr)
-
-    pipeline = {"include": ["automodel/automodel_ci_template.yml"]}
-
-    for config in existing_configs:
-        model_name = config.parent.name
-        config_name = config.stem
-
-        # Check if model is in exempt model list
-        exempt_models_list = config_override.get("exempt_models") or []
-        exempt_configs_list = config_override.get("exempt_configs") or []
-        if model_name in exempt_models_list or config_name in exempt_configs_list:
             continue
 
-        job, vllm_job, embed_eval_job, rerank_eval_job = generate_job(
-            config, config_override, scope, test_folder, automodel_dir
-        )
-        if job is None:
-            continue  # skipped via ci.known_issue_id (no allow_failure)
-        job["variables"]["MODEL_FAMILY"] = model_name
-        pipeline[f'{config_name}'] = job
-        if vllm_job:
-            vllm_job["variables"]["MODEL_FAMILY"] = model_name
-            pipeline[f"{config_name}_vllm_deploy"] = vllm_job
-        if embed_eval_job:
-            pipeline[f"{config_name}_embed_eval"] = embed_eval_job
-        if rerank_eval_job:
-            pipeline[f"{config_name}_rerank_eval"] = rerank_eval_job
+        model_name = config.parent.name
+        config_name = config.stem
+        if model_name in exempt_models or config_name in exempt_configs:
+            continue
+
+        for suffix, job in generate_job(config, config_override, scope, test_folder, automodel_dir):
+            job["variables"]["MODEL_FAMILY"] = model_name
+            pipeline[f"{config_name}{suffix}"] = job
 
     return pipeline
+
+
+def _normalize_scope(value: str) -> str:
+    """Map the GitLab CI sentinel "NONE" (unset variable) to the nightly default."""
+    return "nightly" if value == "NONE" else value
 
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--automodel-dir", type=str, required=True, help="Path to Automodel directory")
-    parser.add_argument("--scope", type=str, required=True, help="Scope of the tests (nightly, release)")
+    parser.add_argument(
+        "--scope", type=_normalize_scope, required=True, help="Scope of the tests (nightly, release)"
+    )
     parser.add_argument("--test-folder", type=str, required=True, help="Target folder to search")
-
     args = parser.parse_args()
 
     pipeline = generate_pipeline(args.automodel_dir, args.scope, args.test_folder)
-
-    if pipeline:
-        with open(f"generated_automodel_{args.test_folder}_tests.yml", "w") as f:
-            yaml.dump(pipeline, f)
-        print(f"Generated pipeline with {len([k for k in pipeline.keys() if k != 'stages'])} jobs")
+    with open(f"generated_automodel_{args.test_folder}_tests.yml", "w") as f:
+        yaml.dump(pipeline, f)
+    job_count = sum(1 for k in pipeline if k != "include")
+    print(f"Generated pipeline with {job_count} jobs")
 
 
 if __name__ == "__main__":

--- a/tests/ci_tests/utils/validate_generate_ci.py
+++ b/tests/ci_tests/utils/validate_generate_ci.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/usr/bin/env python3
+"""Validate that generate_ci_tests.generate_pipeline runs cleanly for every
+(test_folder, scope) combination defined in this repo.
+
+The matrix is auto-discovered from two sources of truth so the check stays current
+without manual maintenance:
+  * AUTO_DISCOVER_SCOPES in generate_ci_tests.py (e.g. release, performance)
+  * tests/ci_tests/configs/<folder>/<scope>_recipes.yml files
+
+Each combination is invoked; failures are collected and reported together so a
+single broken combo does not hide the rest.
+"""
+
+import argparse
+import sys
+import traceback
+from pathlib import Path
+
+# Allow `from generate_ci_tests import ...` when this script is run directly.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from generate_ci_tests import AUTO_DISCOVER_SCOPES, generate_pipeline  # noqa: E402
+
+
+def collect_matrix(automodel_dir: Path) -> list[tuple[str, str]]:
+    """Discover every (test_folder, scope) pair worth validating."""
+    matrix: set[tuple[str, str]] = set()
+
+    for scope, folders in AUTO_DISCOVER_SCOPES.items():
+        for folder in folders:
+            matrix.add((folder, scope))
+
+    configs_root = automodel_dir / "tests" / "ci_tests" / "configs"
+    for recipe_list in configs_root.glob("*/*_recipes.yml"):
+        # override_recipes.yml is not a scope; skip it.
+        if recipe_list.name == "override_recipes.yml":
+            continue
+        folder = recipe_list.parent.name
+        scope = recipe_list.stem[: -len("_recipes")]
+        matrix.add((folder, scope))
+
+    return sorted(matrix)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--automodel-dir", type=str, required=True, help="Path to Automodel directory")
+    args = parser.parse_args()
+
+    automodel_dir = Path(args.automodel_dir).resolve()
+    matrix = collect_matrix(automodel_dir)
+
+    successes: list[tuple[str, str, int]] = []
+    failures: list[tuple[str, str, str]] = []
+
+    for folder, scope in matrix:
+        try:
+            pipeline = generate_pipeline(str(automodel_dir), scope, folder)
+        except Exception:
+            failures.append((folder, scope, traceback.format_exc()))
+            continue
+        job_count = sum(1 for k in pipeline if k not in ("include", "stages"))
+        successes.append((folder, scope, job_count))
+
+    for folder, scope, job_count in successes:
+        print(f"OK   {folder}/{scope}: {job_count} jobs", file=sys.stderr)
+    for folder, scope, tb in failures:
+        print(f"\nFAIL {folder}/{scope}:\n{tb}", file=sys.stderr)
+
+    if failures:
+        print(
+            f"\n{len(failures)} of {len(matrix)} (test_folder, scope) combos failed.",
+            file=sys.stderr,
+        )
+        return 1
+    print(
+        f"\nAll {len(matrix)} (test_folder, scope) combos generated successfully.",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
# What does this PR do ?

- Fix runtime crash in `generate_job` skip path (returned 2-tuple while caller unpacked 4) and broken `diffusion_finetune/release` auto-discover (searched `examples/diffusion_finetune/` instead of `examples/diffusion/finetune/`).
- Refactor `generate_job` to return `list[(suffix, job_dict)]` via shared `_build_job` / `_enrich_base_job` helpers — kills the variant-count duplication that caused the crash and uniformly applies `MODEL_FAMILY` across all variants. 
- Add `validate_generate_ci.py` + a step in the existing `validate-recipe-configs` workflow that runs `generate_pipeline` over every `(folder, scope)` combo on PR, so this bug class can't regress.

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
