### PR TITLE
refactor(ci): extract finetune launcher config into ci_config + resolver

### DIFF
--- a/.github/workflows/validate-recipe-configs.yml
+++ b/.github/workflows/validate-recipe-configs.yml
@@ -20,6 +20,7 @@ on:
       - 'tests/ci_tests/configs/**'
       - 'examples/**/*.yaml'
       - 'tests/ci_tests/utils/validate_nightly_recipes.py'
+      - 'tests/ci_tests/utils/validate_generate_ci.py'
       - 'tests/ci_tests/utils/generate_ci_tests.py'
       - 'tools/lint_example_yamls.py'
 
@@ -50,3 +51,6 @@ jobs:
 
       - name: Validate nightly recipe references
         run: .venv-validator/bin/python tests/ci_tests/utils/validate_nightly_recipes.py --automodel-dir .
+
+      - name: Validate generate_ci_tests across all (folder, scope) combos
+        run: .venv-validator/bin/python tests/ci_tests/utils/validate_generate_ci.py --automodel-dir .

--- a/docker/common/uv-pytorch.lock
+++ b/docker/common/uv-pytorch.lock
@@ -1926,6 +1926,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/ed/6bfa4109fcb23a58819600392564fea69cdc6551ffd5e69ccf1d52a40cbc/greenlet-3.2.4-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:8c68325b0d0acf8d91dde4e6f930967dd52a5302cd4062932a6b2e7c2969f47c", size = 271061, upload-time = "2025-08-07T13:17:15.373Z" },
     { url = "https://files.pythonhosted.org/packages/2a/fc/102ec1a2fc015b3a7652abab7acf3541d58c04d3d17a8d3d6a44adae1eb1/greenlet-3.2.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:94385f101946790ae13da500603491f04a76b6e4c059dab271b3ce2e283b2590", size = 629475, upload-time = "2025-08-07T13:42:54.009Z" },
     { url = "https://files.pythonhosted.org/packages/c5/26/80383131d55a4ac0fb08d71660fd77e7660b9db6bdb4e8884f46d9f2cc04/greenlet-3.2.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f10fd42b5ee276335863712fa3da6608e93f70629c631bf77145021600abc23c", size = 640802, upload-time = "2025-08-07T13:45:25.52Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/7c/e7833dbcd8f376f3326bd728c845d31dcde4c84268d3921afcae77d90d08/greenlet-3.2.4-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c8c9e331e58180d0d83c5b7999255721b725913ff6bc6cf39fa2a45841a4fd4b", size = 636703, upload-time = "2025-08-07T13:53:12.622Z" },
     { url = "https://files.pythonhosted.org/packages/e9/49/547b93b7c0428ede7b3f309bc965986874759f7d89e4e04aeddbc9699acb/greenlet-3.2.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:58b97143c9cc7b86fc458f215bd0932f1757ce649e05b640fea2e79b54cedb31", size = 635417, upload-time = "2025-08-07T13:18:25.189Z" },
     { url = "https://files.pythonhosted.org/packages/7f/91/ae2eb6b7979e2f9b035a9f612cf70f1bf54aad4e1d125129bef1eae96f19/greenlet-3.2.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c2ca18a03a8cfb5b25bc1cbe20f3d9a4c80d8c3b13ba3df49ac3961af0b1018d", size = 584358, upload-time = "2025-08-07T13:18:23.708Z" },
     { url = "https://files.pythonhosted.org/packages/f7/85/433de0c9c0252b22b16d413c9407e6cb3b41df7389afc366ca204dbc1393/greenlet-3.2.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:9fe0a28a7b952a21e2c062cd5756d34354117796c6d9215a87f55e38d15402c5", size = 1113550, upload-time = "2025-08-07T13:42:37.467Z" },
@@ -1936,6 +1937,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/de/f28ced0a67749cac23fecb02b694f6473f47686dff6afaa211d186e2ef9c/greenlet-3.2.4-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:96378df1de302bc38e99c3a9aa311967b7dc80ced1dcc6f171e99842987882a2", size = 272305, upload-time = "2025-08-07T13:15:41.288Z" },
     { url = "https://files.pythonhosted.org/packages/09/16/2c3792cba130000bf2a31c5272999113f4764fd9d874fb257ff588ac779a/greenlet-3.2.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1ee8fae0519a337f2329cb78bd7a8e128ec0f881073d43f023c7b8d4831d5246", size = 632472, upload-time = "2025-08-07T13:42:55.044Z" },
     { url = "https://files.pythonhosted.org/packages/ae/8f/95d48d7e3d433e6dae5b1682e4292242a53f22df82e6d3dda81b1701a960/greenlet-3.2.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94abf90142c2a18151632371140b3dba4dee031633fe614cb592dbb6c9e17bc3", size = 644646, upload-time = "2025-08-07T13:45:26.523Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/5e/405965351aef8c76b8ef7ad370e5da58d57ef6068df197548b015464001a/greenlet-3.2.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:4d1378601b85e2e5171b99be8d2dc85f594c79967599328f95c1dc1a40f1c633", size = 640519, upload-time = "2025-08-07T13:53:13.928Z" },
     { url = "https://files.pythonhosted.org/packages/25/5d/382753b52006ce0218297ec1b628e048c4e64b155379331f25a7316eb749/greenlet-3.2.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0db5594dce18db94f7d1650d7489909b57afde4c580806b8d9203b6e79cdc079", size = 639707, upload-time = "2025-08-07T13:18:27.146Z" },
     { url = "https://files.pythonhosted.org/packages/1f/8e/abdd3f14d735b2929290a018ecf133c901be4874b858dd1c604b9319f064/greenlet-3.2.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2523e5246274f54fdadbce8494458a2ebdcdbc7b802318466ac5606d3cded1f8", size = 587684, upload-time = "2025-08-07T13:18:25.164Z" },
     { url = "https://files.pythonhosted.org/packages/5d/65/deb2a69c3e5996439b0176f6651e0052542bb6c8f8ec2e3fba97c9768805/greenlet-3.2.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1987de92fec508535687fb807a5cea1560f6196285a4cde35c100b8cd632cc52", size = 1116647, upload-time = "2025-08-07T13:42:38.655Z" },
@@ -1946,6 +1948,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
     { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
     { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
@@ -1956,6 +1959,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
     { url = "https://files.pythonhosted.org/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
     { url = "https://files.pythonhosted.org/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
@@ -1966,6 +1970,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
     { url = "https://files.pythonhosted.org/packages/c0/aa/687d6b12ffb505a4447567d1f3abea23bd20e73a5bed63871178e0831b7a/greenlet-3.2.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c17b6b34111ea72fc5a4e4beec9711d2226285f0386ea83477cbb97c30a3f3a5", size = 699218, upload-time = "2025-08-07T13:45:30.969Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
     { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },
@@ -3540,6 +3545,7 @@ test = [
     { name = "onnxruntime-gpu", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
     { name = "peft" },
     { name = "pytest" },
+    { name = "ruamel-yaml" },
 ]
 
 [package.metadata]
@@ -3644,6 +3650,7 @@ test = [
     { name = "onnxruntime-gpu", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'", index = "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-cuda-13/pypi/simple/" },
     { name = "peft", specifier = ">=0.18.1" },
     { name = "pytest" },
+    { name = "ruamel-yaml" },
 ]
 
 [[package]]
@@ -5391,6 +5398,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
+]
+
+[[package]]
+name = "ruamel-yaml"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,7 +196,7 @@ linting = [
     "import-linter~=2.4",
     "ty>=0.0.20",
 ]
-test = ["coverage", "pytest", "peft>=0.18.1", "onnxruntime-gpu; (platform_machine == 'x86_64' and platform_system != 'Darwin')"]
+test = ["coverage", "pytest", "peft>=0.18.1", "ruamel.yaml", "onnxruntime-gpu; (platform_machine == 'x86_64' and platform_system != 'Darwin')"]
 dev = [
     "cut-cross-entropy",
     "liger-kernel; (platform_machine == 'x86_64' and platform_system != 'Darwin')",

--- a/tests/ci_tests/scripts/config_resolver.py
+++ b/tests/ci_tests/scripts/config_resolver.py
@@ -18,7 +18,7 @@ See ci_config.yaml for the layered resolution stack and override schema.
 
 CLI:
     --base       Recipe YAML
-    --phase      nightly | release | convergence | performance | robustness
+    --phase      nightly | release | convergence | performance | checkpoint_robustness
     --output     Resolved YAML path (required unless --dry-run)
     --dry-run    Print the merge stack to stdout instead of writing
 """
@@ -155,12 +155,20 @@ def main() -> int:
     recipe = _load(args.base)
     ci_config = _load(CI_CONFIG_FILE)
 
+    # Shared phase defaults from ci_config.yaml -> phases[<phase>].
     phase_defaults = (ci_config.get("phases") or {}).get(args.phase) or {}
+    # Recipe-name-pattern overrides from ci_config.yaml -> conditional[].
     conditional_layer = _resolve_conditional_layer(
         ci_config.get("conditional") or [], args.phase, args.base.stem
     )
-    ci_section = (recipe.get("ci") or {}).get(args.phase) or {}
+    # Per-recipe overrides from recipe.ci.<phase>; fixture-arg keys (read by
+    # consumers like pytest, listed under ci_config.fixture_keys) are skipped.
+    ci_section_raw = (recipe.get("ci") or {}).get(args.phase) or {}
+    fixture_keys = set((ci_config.get("fixture_keys") or {}).get(args.phase) or [])
+    ci_section = {k: v for k, v in ci_section_raw.items() if k not in fixture_keys}
+    # Env-driven overrides from ci_config.yaml -> env[].
     env_layer = _resolve_env_layer(ci_config.get("env") or {}, args.phase)
+    # Per-run dynamic values from ci_config.yaml -> computed[].
     computed_layer = _resolve_computed_layer(ci_config.get("computed") or [], args.phase)
 
     layers = [
@@ -175,7 +183,6 @@ def main() -> int:
     for _, payload in layers:
         for dotted_key, value in payload.items():
             _set_dotted(config, dotted_key, value)
-    config.pop("ci", None)
 
     if args.dry_run:
         print(f"Resolution stack for --phase {args.phase}:")

--- a/tests/ci_tests/scripts/config_resolver.py
+++ b/tests/ci_tests/scripts/config_resolver.py
@@ -1,0 +1,196 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Resolve a CI test config from a recipe + config_templates/ci_config.yaml.
+
+Resolution stack (last wins):
+    1. Recipe top-level
+    2. ci_config.yaml -> phases[<phase>]
+    3. ci_config.yaml -> conditional[...] (recipe-name-pattern, phase-filtered)
+    4. recipe.ci.<phase>
+    5. ci_config.yaml -> env[...]         (env-driven, phase-filtered)
+    6. ci_config.yaml -> computed[...]    (per-run dynamic, phase-filtered)
+
+CLI:
+    --base       Recipe YAML
+    --phase      nightly | release | convergence | performance | robustness
+    --output     Resolved YAML path (required unless --dry-run)
+    --dry-run    Print the merge stack to stdout instead of writing
+"""
+
+import argparse
+import copy
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from ruamel.yaml import YAML
+
+CI_CONFIG_FILE = Path(__file__).resolve().parent / "config_templates" / "ci_config.yaml"
+
+yaml = YAML()
+yaml.default_flow_style = False
+yaml.preserve_quotes = True
+
+
+def _load(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as f:
+        return yaml.load(f) or {}
+
+
+def _set_dotted(d: dict, dotted_key: str, value: Any) -> None:
+    keys = dotted_key.split(".")
+    cursor = d
+    for k in keys[:-1]:
+        if not isinstance(cursor.get(k), dict):
+            cursor[k] = {}
+        cursor = cursor[k]
+    cursor[keys[-1]] = value
+
+
+def _coerce(value: str) -> Any:
+    """Best-effort coerce env strings to int/float; fall back to str."""
+    try:
+        return int(value)
+    except ValueError:
+        pass
+    try:
+        return float(value)
+    except ValueError:
+        pass
+    return value
+
+
+def _resolve_env_layer(env_section: dict, phase: str) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for env_var, spec in (env_section or {}).items():
+        target = spec["target"]
+        phases = spec.get("phases")
+        if phases is not None and phase not in phases:
+            continue
+        if env_var in os.environ:
+            out[target] = _coerce(os.environ[env_var])
+    return out
+
+
+def _format_or_passthrough(value: Any, substitutions: dict[str, Any], context: str) -> Any:
+    """Apply str.format if value is a string; pass through other types unchanged."""
+    if not isinstance(value, str):
+        return value
+    try:
+        return value.format(**substitutions)
+    except KeyError as missing:
+        sys.exit(f"ERROR: {context} missing substitution {missing} (template={value!r})")
+
+
+def _resolve_computed_layer(computed_entries: list, phase: str) -> dict[str, Any]:
+    substitutions: dict[str, Any] = {"date": datetime.now(), **os.environ}
+    out: dict[str, Any] = {}
+    for entry in computed_entries or []:
+        phases = entry.get("phases")
+        if phases is not None and phase not in phases:
+            continue
+        out[entry["target"]] = _format_or_passthrough(
+            entry["format"], substitutions, f"computed override target={entry['target']!r}"
+        )
+    return out
+
+
+def _resolve_conditional_layer(conditional_entries: list, phase: str, recipe_stem: str) -> dict[str, Any]:
+    substitutions: dict[str, Any] = {"date": datetime.now(), **os.environ}
+    out: dict[str, Any] = {}
+    for entry in conditional_entries or []:
+        phases = entry.get("phases")
+        if phases is not None and phase not in phases:
+            continue
+        contains_all = entry.get("when_recipe_contains_all") or []
+        contains_any = entry.get("when_recipe_contains_any") or []
+        if contains_all and not all(sub in recipe_stem for sub in contains_all):
+            continue
+        if contains_any and not any(sub in recipe_stem for sub in contains_any):
+            continue
+        for target, raw_value in (entry.get("apply") or {}).items():
+            out[target] = _format_or_passthrough(
+                raw_value, substitutions, f"conditional override target={target!r}"
+            )
+    return out
+
+
+def _print_layer(label: str, payload: dict[str, Any]) -> None:
+    if not payload:
+        print(f"  [{label}] (empty)")
+        return
+    print(f"  [{label}]")
+    for k, v in payload.items():
+        print(f"    {k} = {v!r}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--base", type=Path, required=True, help="Base recipe YAML")
+    parser.add_argument("--phase", required=True, help="Phase key under ci_config.yaml.phases")
+    parser.add_argument("--output", type=Path, help="Where to write the resolved YAML (omit for --dry-run)")
+    parser.add_argument("--dry-run", action="store_true", help="Print merge stack + resolved YAML to stdout; no write")
+    args = parser.parse_args()
+
+    if not args.dry_run and args.output is None:
+        parser.error("--output is required unless --dry-run is set")
+    if not args.base.is_file():
+        sys.exit(f"ERROR: base recipe not found: {args.base}")
+
+    recipe = _load(args.base)
+    ci_config = _load(CI_CONFIG_FILE)
+
+    phase_defaults = (ci_config.get("phases") or {}).get(args.phase) or {}
+    conditional_layer = _resolve_conditional_layer(
+        ci_config.get("conditional") or [], args.phase, args.base.stem
+    )
+    ci_section = (recipe.get("ci") or {}).get(args.phase) or {}
+    env_layer = _resolve_env_layer(ci_config.get("env") or {}, args.phase)
+    computed_layer = _resolve_computed_layer(ci_config.get("computed") or [], args.phase)
+
+    layers = [
+        ("phase_defaults", phase_defaults),
+        ("conditional", conditional_layer),
+        ("recipe.ci." + args.phase, ci_section),
+        ("env", env_layer),
+        ("computed", computed_layer),
+    ]
+
+    config = copy.deepcopy(recipe)
+    for _, payload in layers:
+        for dotted_key, value in payload.items():
+            _set_dotted(config, dotted_key, value)
+    config.pop("ci", None)
+
+    if args.dry_run:
+        print(f"Resolution stack for --phase {args.phase}:")
+        print(f"  [base] {args.base}")
+        for label, payload in layers:
+            _print_layer(label, payload)
+        print("--- resolved config ---")
+        yaml.dump(config, sys.stdout)
+        return 0
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w", encoding="utf-8") as f:
+        yaml.dump(config, f)
+    print(args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ci_tests/scripts/config_resolver.py
+++ b/tests/ci_tests/scripts/config_resolver.py
@@ -47,11 +47,13 @@ yaml.preserve_quotes = True
 
 
 def _load(path: Path) -> dict:
+    """Load a YAML file and return its top-level mapping (empty dict if file is empty)."""
     with path.open("r", encoding="utf-8") as f:
         return yaml.load(f) or {}
 
 
 def _set_dotted(d: dict, dotted_key: str, value: Any) -> None:
+    """Write `value` at the dotted-key path in `d`, creating intermediate dicts as needed."""
     keys = dotted_key.split(".")
     cursor = d
     for k in keys[:-1]:
@@ -75,6 +77,7 @@ def _coerce(value: str) -> Any:
 
 
 def _resolve_env_layer(env_section: dict, phase: str) -> dict[str, Any]:
+    """Return env-driven overrides whose env var is set and whose `phases` filter matches."""
     out: dict[str, Any] = {}
     for env_var, spec in (env_section or {}).items():
         target = spec["target"]
@@ -97,6 +100,7 @@ def _format_or_passthrough(value: Any, substitutions: dict[str, Any], context: s
 
 
 def _resolve_computed_layer(computed_entries: list, phase: str) -> dict[str, Any]:
+    """Return per-run dynamic overrides (paths, dates) with env + `date` interpolated into each format string."""
     substitutions: dict[str, Any] = {"date": datetime.now(), **os.environ}
     out: dict[str, Any] = {}
     for entry in computed_entries or []:
@@ -110,6 +114,7 @@ def _resolve_computed_layer(computed_entries: list, phase: str) -> dict[str, Any
 
 
 def _resolve_conditional_layer(conditional_entries: list, phase: str, recipe_stem: str) -> dict[str, Any]:
+    """Return overrides for entries whose `phases` and recipe-name predicates both match the current run."""
     substitutions: dict[str, Any] = {"date": datetime.now(), **os.environ}
     out: dict[str, Any] = {}
     for entry in conditional_entries or []:
@@ -130,6 +135,7 @@ def _resolve_conditional_layer(conditional_entries: list, phase: str, recipe_ste
 
 
 def _print_layer(label: str, payload: dict[str, Any]) -> None:
+    """Render one layer of the resolution stack for --dry-run output."""
     if not payload:
         print(f"  [{label}] (empty)")
         return
@@ -139,6 +145,7 @@ def _print_layer(label: str, payload: dict[str, Any]) -> None:
 
 
 def main() -> int:
+    """Parse args, build each layer, merge them onto the recipe in stack order, and write or dry-print the result."""
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--base", type=Path, required=True, help="Base recipe YAML")
     parser.add_argument("--phase", required=True, help="Phase key under ci_config.yaml.phases")

--- a/tests/ci_tests/scripts/config_resolver.py
+++ b/tests/ci_tests/scripts/config_resolver.py
@@ -14,13 +14,7 @@
 
 """Resolve a CI test config from a recipe + config_templates/ci_config.yaml.
 
-Resolution stack (last wins):
-    1. Recipe top-level
-    2. ci_config.yaml -> phases[<phase>]
-    3. ci_config.yaml -> conditional[...] (recipe-name-pattern, phase-filtered)
-    4. recipe.ci.<phase>
-    5. ci_config.yaml -> env[...]         (env-driven, phase-filtered)
-    6. ci_config.yaml -> computed[...]    (per-run dynamic, phase-filtered)
+See ci_config.yaml for the layered resolution stack and override schema.
 
 CLI:
     --base       Recipe YAML
@@ -100,7 +94,7 @@ def _format_or_passthrough(value: Any, substitutions: dict[str, Any], context: s
 
 
 def _resolve_computed_layer(computed_entries: list, phase: str) -> dict[str, Any]:
-    """Return per-run dynamic overrides (paths, dates) with env + `date` interpolated into each format string."""
+    """Return per-run dynamic overrides with env + `date` interpolated into each format string."""
     substitutions: dict[str, Any] = {"date": datetime.now(), **os.environ}
     out: dict[str, Any] = {}
     for entry in computed_entries or []:
@@ -114,7 +108,7 @@ def _resolve_computed_layer(computed_entries: list, phase: str) -> dict[str, Any
 
 
 def _resolve_conditional_layer(conditional_entries: list, phase: str, recipe_stem: str) -> dict[str, Any]:
-    """Return overrides for entries whose `phases` and recipe-name predicates both match the current run."""
+    """Return overrides for entries whose phase and recipe-name predicates both match."""
     substitutions: dict[str, Any] = {"date": datetime.now(), **os.environ}
     out: dict[str, Any] = {}
     for entry in conditional_entries or []:
@@ -145,7 +139,7 @@ def _print_layer(label: str, payload: dict[str, Any]) -> None:
 
 
 def main() -> int:
-    """Parse args, build each layer, merge them onto the recipe in stack order, and write or dry-print the result."""
+    """Build each layer, merge onto the recipe, then write or dry-print the result."""
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--base", type=Path, required=True, help="Base recipe YAML")
     parser.add_argument("--phase", required=True, help="Phase key under ci_config.yaml.phases")

--- a/tests/ci_tests/scripts/config_templates/ci_config.yaml
+++ b/tests/ci_tests/scripts/config_templates/ci_config.yaml
@@ -1,0 +1,101 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# CI test configuration consumed by config_resolver.py.
+#
+# Resolution stack (last wins):
+#   1. Recipe top-level (the base config the user wrote)
+#   2. phases[<phase>]               shared defaults for this phase
+#   3. conditional[...]              recipe-name-pattern overrides (filtered by `phases`)
+#   4. recipe.ci.<phase>             per-recipe overrides
+#   5. env[...]                      env-driven overrides (filtered by `phases`)
+#   6. computed[...]                 dynamic per-run values (filtered by `phases`)
+#
+# All override targets are flat dotted keys pointing into the recipe's top-level
+# config (e.g. step_scheduler.max_steps).
+
+phases:
+  nightly: &nightly_defaults
+    step_scheduler.max_steps: 50
+    step_scheduler.ckpt_every_steps: 50
+    step_scheduler.val_every_steps: 50
+
+  release: *nightly_defaults
+
+  convergence:
+    step_scheduler.max_steps: 200
+    step_scheduler.ckpt_every_steps: 200
+    step_scheduler.val_every_steps: 200
+    wandb.entity: Nemo-automodel
+    wandb.dir: /tmp/wandb/
+
+  performance: {}
+
+  robustness:
+    step_scheduler.max_steps: 5
+    step_scheduler.ckpt_every_steps: 5
+    step_scheduler.val_every_steps: 5
+    step_scheduler.global_batch_size: 32
+    step_scheduler.local_batch_size: 2
+    checkpoint.enabled: true
+    checkpoint.model_save_format: safetensors
+    checkpoint.save_consolidated: true
+
+# Recipe-name-pattern overrides. Each entry applies if --phase is in `phases`
+# (omit = all phases) AND the recipe stem (filename without .yaml) satisfies the
+# predicate(s):
+#   when_recipe_contains_all: [s1, s2, ...]   stem must contain every substring
+#   when_recipe_contains_any: [s1, s2, ...]   stem must contain at least one
+# Both predicates may be combined; both default to "match" when omitted.
+# `apply` is a flat dotted-key dict; string values support {var} substitution
+# from env vars + built-in `date` (same as computed:).
+conditional:
+  # Customizer recipes use sample datasets shipped under NEMO_CI_PATH.
+  # All customizer_* recipes default to prompt_completion paths; the chat-flavored
+  # subset overrides to chat paths (applied after, last-wins).
+  - when_recipe_contains_all: [customizer_]
+    apply:
+      dataset.path_or_dataset_id: "{NEMO_CI_PATH}/datasets/customizer/sample-datasets/prompt_completion/train.jsonl"
+      validation_dataset.path_or_dataset_id: "{NEMO_CI_PATH}/datasets/customizer/sample-datasets/prompt_completion/validation.jsonl"
+
+  - when_recipe_contains_all: [customizer_, chat]
+    apply:
+      dataset.path_or_dataset_id: "{NEMO_CI_PATH}/datasets/customizer/sample-datasets/chat/train.jsonl"
+      validation_dataset.path_or_dataset_id: "{NEMO_CI_PATH}/datasets/customizer/sample-datasets/chat/validation.jsonl"
+
+  # Robustness phase: peft/lora recipes disable triton (incompat with the
+  # checkpoint-robustness pytest harness).
+  - when_recipe_contains_any: [peft, lora]
+    phases: [robustness]
+    apply:
+      peft.use_triton: false
+
+# Env var -> { target: dotted.config.key, phases: [...] }
+# Applied iff the env var is set AND --phase is in `phases`.
+# Values are coerced to int -> float -> str.
+env:
+  MAX_STEPS:
+    target: step_scheduler.max_steps
+    phases: [nightly, release, convergence, performance]
+  LOCAL_BATCH_SIZE:
+    target: step_scheduler.local_batch_size
+    phases: [nightly, release, convergence, performance]
+
+# Computed dynamic overrides. `format` is a Python str.format() template.
+# Substitution sources: every env var, plus built-in `date` (supports {date:%Y%m%d}).
+# `phases` restricts which --phase values trigger the entry.
+computed:
+  - target: checkpoint.checkpoint_dir
+    format: "{PIPELINE_DIR}/{TEST_NAME}/checkpoint"
+    phases: [nightly, release, convergence, performance]
+
+  - target: checkpoint.checkpoint_dir
+    format: "{PIPELINE_DIR}/{TEST_NAME}/robustness_checkpoint"
+    phases: [robustness]
+
+  - target: wandb.name
+    format: "{TEST_NAME}"
+    phases: [convergence]
+
+  - target: wandb.project
+    format: "automodel-nemo-ci-convergence-test-{date:%Y%m%d}"
+    phases: [convergence]

--- a/tests/ci_tests/scripts/config_templates/ci_config.yaml
+++ b/tests/ci_tests/scripts/config_templates/ci_config.yaml
@@ -12,18 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# CI test configuration consumed by config_resolver.py.
+# Consumed by config_resolver.py.
 #
 # Resolution stack (last wins):
-#   1. Recipe top-level (the base config the user wrote)
-#   2. phases[<phase>]               shared defaults for this phase
-#   3. conditional[...]              recipe-name-pattern overrides (filtered by `phases`)
-#   4. recipe.ci.<phase>             per-recipe overrides
-#   5. env[...]                      env-driven overrides (filtered by `phases`)
-#   6. computed[...]                 dynamic per-run values (filtered by `phases`)
+#   1. Recipe top-level
+#   2. phases[<phase>]       defaults per phase
+#   3. conditional[...]      recipe-name-pattern overrides
+#   4. recipe.ci.<phase>     per-recipe overrides
+#   5. env[...]              env-driven overrides
+#   6. computed[...]         per-run dynamic values
 #
-# All override targets are flat dotted keys pointing into the recipe's top-level
-# config (e.g. step_scheduler.max_steps).
+# Override targets are flat dotted keys into the recipe's top-level config.
 
 phases:
   nightly: &nightly_defaults
@@ -52,18 +51,13 @@ phases:
     checkpoint.model_save_format: safetensors
     checkpoint.save_consolidated: true
 
-# Recipe-name-pattern overrides. Each entry applies if --phase is in `phases`
-# (omit = all phases) AND the recipe stem (filename without .yaml) satisfies the
-# predicate(s):
-#   when_recipe_contains_all: [s1, s2, ...]   stem must contain every substring
-#   when_recipe_contains_any: [s1, s2, ...]   stem must contain at least one
-# Both predicates may be combined; both default to "match" when omitted.
-# `apply` is a flat dotted-key dict; string values support {var} substitution
-# from env vars + built-in `date` (same as computed:).
+# Recipe-name-pattern overrides. Predicate keys:
+#   when_recipe_contains_all   stem must contain every listed substring
+#   when_recipe_contains_any   stem must contain at least one
+# `phases` is optional (default = all). `apply` values support {var} substitution.
 conditional:
-  # Customizer recipes use sample datasets shipped under NEMO_CI_PATH.
-  # All customizer_* recipes default to prompt_completion paths; the chat-flavored
-  # subset overrides to chat paths (applied after, last-wins).
+  # customizer_* recipes use sample datasets under NEMO_CI_PATH;
+  # the chat-flavored subset overrides to chat paths (last-wins).
   - when_recipe_contains_all: [customizer_]
     apply:
       dataset.path_or_dataset_id: "{NEMO_CI_PATH}/datasets/customizer/sample-datasets/prompt_completion/train.jsonl"
@@ -74,16 +68,14 @@ conditional:
       dataset.path_or_dataset_id: "{NEMO_CI_PATH}/datasets/customizer/sample-datasets/chat/train.jsonl"
       validation_dataset.path_or_dataset_id: "{NEMO_CI_PATH}/datasets/customizer/sample-datasets/chat/validation.jsonl"
 
-  # Robustness phase: peft/lora recipes disable triton (incompat with the
-  # checkpoint-robustness pytest harness).
+  # peft/lora recipes disable triton in the robustness pytest harness.
   - when_recipe_contains_any: [peft, lora]
     phases: [robustness]
     apply:
       peft.use_triton: false
 
-# Env var -> { target: dotted.config.key, phases: [...] }
-# Applied iff the env var is set AND --phase is in `phases`.
-# Values are coerced to int -> float -> str.
+# Env var -> { target, phases }. Applied iff env is set and phase matches.
+# Values coerced to int -> float -> str.
 env:
   MAX_STEPS:
     target: step_scheduler.max_steps
@@ -92,9 +84,7 @@ env:
     target: step_scheduler.local_batch_size
     phases: [nightly, release, convergence, performance]
 
-# Computed dynamic overrides. `format` is a Python str.format() template.
-# Substitution sources: every env var, plus built-in `date` (supports {date:%Y%m%d}).
-# `phases` restricts which --phase values trigger the entry.
+# Computed dynamic overrides. `format` is str.format() over env vars + built-in `date`.
 computed:
   - target: checkpoint.checkpoint_dir
     format: "{PIPELINE_DIR}/{TEST_NAME}/checkpoint"
@@ -109,5 +99,5 @@ computed:
     phases: [convergence]
 
   - target: wandb.project
-    format: "automodel-nemo-ci-convergence-test-{date:%Y%m%d}"
+    format: "automodel-convergence-test-{date:%Y%m%d}"
     phases: [convergence]

--- a/tests/ci_tests/scripts/config_templates/ci_config.yaml
+++ b/tests/ci_tests/scripts/config_templates/ci_config.yaml
@@ -1,5 +1,17 @@
 # Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
 #
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # CI test configuration consumed by config_resolver.py.
 #
 # Resolution stack (last wins):

--- a/tests/ci_tests/scripts/config_templates/ci_config.yaml
+++ b/tests/ci_tests/scripts/config_templates/ci_config.yaml
@@ -23,6 +23,7 @@
 #   6. computed[...]         per-run dynamic values
 #
 # Override targets are flat dotted keys into the recipe's top-level config.
+# `fixture_keys` (see bottom) lists keys to skip when applying recipe.ci.<phase>.
 
 phases:
   nightly: &nightly_defaults
@@ -41,7 +42,9 @@ phases:
 
   performance: {}
 
-  robustness:
+  # Phase key matches the recipe's ci.checkpoint_robustness section so per-recipe
+  # overrides resolve naturally.
+  checkpoint_robustness:
     step_scheduler.max_steps: 5
     step_scheduler.ckpt_every_steps: 5
     step_scheduler.val_every_steps: 5
@@ -70,7 +73,7 @@ conditional:
 
   # peft/lora recipes disable triton in the robustness pytest harness.
   - when_recipe_contains_any: [peft, lora]
-    phases: [robustness]
+    phases: [checkpoint_robustness]
     apply:
       peft.use_triton: false
 
@@ -92,7 +95,7 @@ computed:
 
   - target: checkpoint.checkpoint_dir
     format: "{PIPELINE_DIR}/{TEST_NAME}/robustness_checkpoint"
-    phases: [robustness]
+    phases: [checkpoint_robustness]
 
   - target: wandb.name
     format: "{TEST_NAME}"
@@ -101,3 +104,23 @@ computed:
   - target: wandb.project
     format: "automodel-convergence-test-{date:%Y%m%d}"
     phases: [convergence]
+
+# Keys in recipe.ci.<phase> that are read by phase-specific consumers (pytest
+# fixtures, etc.) -- NOT config overrides. The resolver leaves them in the
+# resolved YAML's ci.<phase> block but does not apply them to the top-level.
+fixture_keys:
+  checkpoint_robustness:
+    - check_fused_qkv_keys
+    - check_phantom_keys
+    - check_resume
+    - cross_tp_kl_threshold
+    - cross_tp_size
+    - experts_implementation
+    - hf_device_map_auto
+    - hf_kl_threshold
+    - kl_threshold
+    - no_check_resume
+    - resume_loss_threshold
+    - skip_hf_reload
+    - tokenizer_name
+    - trust_remote_code

--- a/tests/ci_tests/scripts/finetune_launcher.sh
+++ b/tests/ci_tests/scripts/finetune_launcher.sh
@@ -12,22 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Automodel CI finetune launcher.
+# Finetune launcher. Config resolution happens in config_resolver.py.
 #
-# Sourced by the nemo-ci sbatch wrappers under /opt/Automodel/tests/ci_tests/scripts/.
-# All per-phase config resolution (step_scheduler, wandb, checkpoint flags,
-# env-driven overrides, dynamic paths) happens up-front in config_resolver.py
-# and produces a single resolved YAML; this launcher only handles command
-# execution + timing + customizer dataset paths + the FINETUNE_ARGS escape hatch.
-#
-# Env contract -- required:
-#   CONFIG_PATH, PIPELINE_DIR, TEST_NAME, TEST_LEVEL, TEST_SCRIPT_PATH,
-#   TEST_NODE_COUNT, NPROC_PER_NODE, MASTER_ADDR, MASTER_PORT, SLURM_JOB_ID,
-#   HAS_ROBUSTNESS
-# Env contract -- optional (with defaults):
-#   EXEC_CMD (torchrun|python|uv_python), RDZV_TIMEOUT (600), MAX_STEPS,
-#   LOCAL_BATCH_SIZE, CONFIG_NPROC_PER_NODE, FINETUNE_ARGS, NEMO_CI_PATH,
-#   WANDB_AUTOMODEL_API_KEY (convergence only), TIME
+# Env required: CONFIG_PATH, PIPELINE_DIR, TEST_NAME, TEST_LEVEL, TEST_SCRIPT_PATH,
+#   TEST_NODE_COUNT, NPROC_PER_NODE, MASTER_ADDR, MASTER_PORT, SLURM_JOB_ID, HAS_ROBUSTNESS
+# Env optional: EXEC_CMD, RDZV_TIMEOUT, MAX_STEPS, LOCAL_BATCH_SIZE,
+#   CONFIG_NPROC_PER_NODE, FINETUNE_ARGS, NEMO_CI_PATH, WANDB_AUTOMODEL_API_KEY, TIME
 
 cd /opt/Automodel
 
@@ -35,13 +25,13 @@ CONFIG_RESOLVER="python3 /opt/Automodel/tests/ci_tests/scripts/config_resolver.p
 TEST_DIR="$PIPELINE_DIR/$TEST_NAME"
 mkdir -p "$TEST_DIR"
 
-# --- Resolve finetune config (recipe + ci.<phase> + env + computed) ---
+# --- Resolve finetune config ---
 RESOLVED_FINETUNE_CONFIG=$($CONFIG_RESOLVER \
   --base "/opt/Automodel/${CONFIG_PATH}" \
   --phase "${TEST_LEVEL}" \
   --output "$TEST_DIR/finetune_config.yaml")
 
-# WANDB_API_KEY is a runtime secret env (not a config key)
+# WANDB_API_KEY is a runtime secret, not a config key.
 if [ "$TEST_LEVEL" = "convergence" ]; then
   export WANDB_API_KEY="${WANDB_AUTOMODEL_API_KEY}"
 fi

--- a/tests/ci_tests/scripts/finetune_launcher.sh
+++ b/tests/ci_tests/scripts/finetune_launcher.sh
@@ -79,7 +79,7 @@ fi
 if [[ "$HAS_ROBUSTNESS" == "true" ]]; then
   RESOLVED_ROBUSTNESS_CONFIG=$($CONFIG_RESOLVER \
     --base "/opt/Automodel/${CONFIG_PATH}" \
-    --phase robustness \
+    --phase checkpoint_robustness \
     --output "$TEST_DIR/robustness_config.yaml")
 
   ROBUSTNESS_CMD="${CMD} --tee 3 --log-dir $TEST_DIR/robustness_logs \

--- a/tests/ci_tests/scripts/finetune_launcher.sh
+++ b/tests/ci_tests/scripts/finetune_launcher.sh
@@ -12,54 +12,42 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Test variables
-CONFIG="--config /opt/Automodel/${CONFIG_PATH} \
-        --checkpoint.checkpoint_dir $PIPELINE_DIR/$TEST_NAME/checkpoint"
+# Automodel CI finetune launcher.
+#
+# Sourced by the nemo-ci sbatch wrappers under /opt/Automodel/tests/ci_tests/scripts/.
+# All per-phase config resolution (step_scheduler, wandb, checkpoint flags,
+# env-driven overrides, dynamic paths) happens up-front in config_resolver.py
+# and produces a single resolved YAML; this launcher only handles command
+# execution + timing + customizer dataset paths + the FINETUNE_ARGS escape hatch.
+#
+# Env contract -- required:
+#   CONFIG_PATH, PIPELINE_DIR, TEST_NAME, TEST_LEVEL, TEST_SCRIPT_PATH,
+#   TEST_NODE_COUNT, NPROC_PER_NODE, MASTER_ADDR, MASTER_PORT, SLURM_JOB_ID,
+#   HAS_ROBUSTNESS
+# Env contract -- optional (with defaults):
+#   EXEC_CMD (torchrun|python|uv_python), RDZV_TIMEOUT (600), MAX_STEPS,
+#   LOCAL_BATCH_SIZE, CONFIG_NPROC_PER_NODE, FINETUNE_ARGS, NEMO_CI_PATH,
+#   WANDB_AUTOMODEL_API_KEY (convergence only), TIME
 
-# Configure local batch size
-if [[ -n "$LOCAL_BATCH_SIZE" ]]; then
-  CONFIG="${CONFIG} \
-         --step_scheduler.local_batch_size ${LOCAL_BATCH_SIZE}"
-fi
+cd /opt/Automodel
 
-# For convergence runs
+CONFIG_RESOLVER="python3 /opt/Automodel/tests/ci_tests/scripts/config_resolver.py"
+TEST_DIR="$PIPELINE_DIR/$TEST_NAME"
+mkdir -p "$TEST_DIR"
+
+# --- Resolve finetune config (recipe + ci.<phase> + env + computed) ---
+RESOLVED_FINETUNE_CONFIG=$($CONFIG_RESOLVER \
+  --base "/opt/Automodel/${CONFIG_PATH}" \
+  --phase "${TEST_LEVEL}" \
+  --output "$TEST_DIR/finetune_config.yaml")
+
+# WANDB_API_KEY is a runtime secret env (not a config key)
 if [ "$TEST_LEVEL" = "convergence" ]; then
   export WANDB_API_KEY="${WANDB_AUTOMODEL_API_KEY}"
-  export TEST_DATE=$(date +%Y%m%d)
-  CONFIG="${CONFIG} \
-         --step_scheduler.ckpt_every_steps 200 \
-         --step_scheduler.max_steps 200 \
-         --step_scheduler.val_every_steps 200 \
-         --wandb.project automodel-nemo-ci-convergence-test-${TEST_DATE} \
-         --wandb.entity Nemo-automodel \
-         --wandb.name ${TEST_NAME} \
-         --wandb.dir /tmp/wandb/"
-elif [ "$TEST_LEVEL" = "performance" ]; then
-  CONFIG="${CONFIG}"
-else
-  CONFIG="${CONFIG} \
-        --step_scheduler.ckpt_every_steps 50 \
-        --step_scheduler.max_steps ${MAX_STEPS:-50} \
-        --step_scheduler.val_every_steps 50"
 fi
 
-# Per-config nproc override (set via ci.nproc_per_node in recipe YAML)
+# --- Pick executor ---
 NPROC_PER_NODE=${CONFIG_NPROC_PER_NODE:-$NPROC_PER_NODE}
-
-# Customizer contract test dataset overrides
-if [[ "${CONFIG_PATH}" == *customizer_* ]]; then
-  CUSTOMIZER_DATA="${NEMO_CI_PATH}/datasets/customizer/sample-datasets"
-  if [[ "${CONFIG_PATH}" == *chat* ]]; then
-    CUSTOMIZER_DATASET_ARGS="--dataset.path_or_dataset_id ${CUSTOMIZER_DATA}/chat/train.jsonl \
-      --validation_dataset.path_or_dataset_id ${CUSTOMIZER_DATA}/chat/validation.jsonl"
-  else
-    CUSTOMIZER_DATASET_ARGS="--dataset.path_or_dataset_id ${CUSTOMIZER_DATA}/prompt_completion/train.jsonl \
-      --validation_dataset.path_or_dataset_id ${CUSTOMIZER_DATA}/prompt_completion/validation.jsonl"
-  fi
-  CONFIG="${CONFIG} ${CUSTOMIZER_DATASET_ARGS}"
-fi
-
-# Command to execute, defaults to torchrun
 CMD="torchrun --nproc-per-node=${NPROC_PER_NODE} \
               --nnodes=${TEST_NODE_COUNT} \
               --rdzv_backend=c10d \
@@ -69,30 +57,8 @@ CMD="torchrun --nproc-per-node=${NPROC_PER_NODE} \
 if [ "$EXEC_CMD" = "python" ]; then CMD="python"; fi
 if [ "$EXEC_CMD" = "uv_python" ]; then CMD="uv run python"; fi
 
-# Checkpoint robustness variables
-ROBUSTNESS_COMMON="--config /opt/Automodel/${CONFIG_PATH} \
-  --checkpoint.checkpoint_dir $PIPELINE_DIR/$TEST_NAME/robustness_checkpoint \
-  --checkpoint.enabled true \
-  --checkpoint.model_save_format safetensors \
-  --checkpoint.save_consolidated true \
-  --step_scheduler.max_steps 5 \
-  --step_scheduler.ckpt_every_steps 5 \
-  --step_scheduler.val_every_steps 5 \
-  --step_scheduler.global_batch_size 32 \
-  --step_scheduler.local_batch_size 2 \
-  ${CUSTOMIZER_DATASET_ARGS:-}"
-
-if [[ "${CONFIG_PATH}" == *peft* ]] || [[ "${CONFIG_PATH}" == *lora* ]]; then
-  ROBUSTNESS_COMMON="${ROBUSTNESS_COMMON} --peft.use_triton false"
-fi
-
-ROBUSTNESS_CMD="${CMD} --tee 3 --log-dir $PIPELINE_DIR/$TEST_NAME/robustness_logs \
-  -m pytest --tb=short tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py \
-  ${ROBUSTNESS_COMMON}"
-
 # --- Finetune ---
-cd /opt/Automodel
-RUN_CMD="${CMD} ${TEST_SCRIPT_PATH} ${CONFIG} ${FINETUNE_ARGS}"
+RUN_CMD="${CMD} ${TEST_SCRIPT_PATH} --config ${RESOLVED_FINETUNE_CONFIG} ${FINETUNE_ARGS:-}"
 echo "============================================"
 echo "[finetune] Running finetune..."
 echo "============================================"
@@ -102,16 +68,16 @@ eval $RUN_CMD
 FINETUNE_EXIT_CODE=$?
 
 FINETUNE_ELAPSED=$((SECONDS - FINETUNE_START))
-echo "{\"test\":\"${TEST_NAME}\",\"phase\":\"finetune\",\"seconds\":${FINETUNE_ELAPSED}}" >> $PIPELINE_DIR/$TEST_NAME/timing.jsonl
+echo "{\"test\":\"${TEST_NAME}\",\"phase\":\"finetune\",\"seconds\":${FINETUNE_ELAPSED}}" >> $TEST_DIR/timing.jsonl
 echo "[timing] Finetune completed in ${FINETUNE_ELAPSED}s"
 
-# Collect benchmark artifact for performance tests
+# Performance benchmark artifact
 if [ "$TEST_LEVEL" = "performance" ]; then
   echo "[benchmark] Collecting benchmark artifact..."
   python3 /opt/Automodel/tests/ci_tests/scripts/collect_benchmark_artifact.py \
     --config /opt/Automodel/${CONFIG_PATH} \
     --log $PIPELINE_DIR/${TEST_NAME}_slurm_${SLURM_JOB_ID}.out \
-    --output $PIPELINE_DIR/$TEST_NAME/benchmark_results.json || true
+    --output $TEST_DIR/benchmark_results.json || true
 fi
 
 if [[ "$FINETUNE_EXIT_CODE" -ne 0 ]]; then
@@ -121,6 +87,15 @@ fi
 
 # --- Checkpoint Robustness ---
 if [[ "$HAS_ROBUSTNESS" == "true" ]]; then
+  RESOLVED_ROBUSTNESS_CONFIG=$($CONFIG_RESOLVER \
+    --base "/opt/Automodel/${CONFIG_PATH}" \
+    --phase robustness \
+    --output "$TEST_DIR/robustness_config.yaml")
+
+  ROBUSTNESS_CMD="${CMD} --tee 3 --log-dir $TEST_DIR/robustness_logs \
+    -m pytest --tb=short tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py \
+    --config ${RESOLVED_ROBUSTNESS_CONFIG}"
+
   echo "============================================"
   echo "[checkpoint_robustness] Running robustness test..."
   echo "============================================"
@@ -130,8 +105,8 @@ if [[ "$HAS_ROBUSTNESS" == "true" ]]; then
   ROBUSTNESS_EXIT_CODE=$?
 
   ROBUSTNESS_ELAPSED=$((SECONDS - ROBUSTNESS_START))
-  echo "{\"test\":\"${TEST_NAME}\",\"phase\":\"robustness\",\"seconds\":${ROBUSTNESS_ELAPSED}}" >> $PIPELINE_DIR/$TEST_NAME/timing.jsonl
-  echo "{\"test\":\"${TEST_NAME}\",\"phase\":\"total\",\"seconds\":$((SECONDS)),\"allocated\":\"${TIME}\"}" >> $PIPELINE_DIR/$TEST_NAME/timing.jsonl
+  echo "{\"test\":\"${TEST_NAME}\",\"phase\":\"robustness\",\"seconds\":${ROBUSTNESS_ELAPSED}}" >> $TEST_DIR/timing.jsonl
+  echo "{\"test\":\"${TEST_NAME}\",\"phase\":\"total\",\"seconds\":$((SECONDS)),\"allocated\":\"${TIME}\"}" >> $TEST_DIR/timing.jsonl
   echo "[timing] Robustness completed in ${ROBUSTNESS_ELAPSED}s (total: ${SECONDS}s)"
 
   if [[ "$ROBUSTNESS_EXIT_CODE" -ne 0 ]]; then

--- a/tests/ci_tests/utils/generate_ci_tests.py
+++ b/tests/ci_tests/utils/generate_ci_tests.py
@@ -81,8 +81,11 @@ def _discover_via_glob(automodel_dir: str, examples_subpath: str) -> list[Path]:
 
 
 def _discover_via_recipe_list(automodel_dir: str, scope: str, test_folder: str) -> list[Path]:
-    """Read configs/<test_folder>/<scope>_recipes.yml and return the recipe paths it lists."""
+    """Read configs/<test_folder>/<scope>_recipes.yml; return [] if the file is absent."""
     config_path = Path(automodel_dir) / "tests" / "ci_tests" / "configs" / test_folder / f"{scope}_recipes.yml"
+    if not config_path.is_file():
+        print(f"INFO: no recipe list at {config_path}; generating empty pipeline", file=sys.stderr)
+        return []
     with open(config_path, "r", encoding="utf-8") as f:
         test_configs = yaml.load(f)
     examples_dir = test_configs.get("examples_dir", test_folder)
@@ -281,9 +284,8 @@ def generate_pipeline(automodel_dir: str, scope: str, test_folder: str) -> Dict[
     with open(override_path, "r", encoding="utf-8") as f:
         config_override = yaml.load(f) or {}
 
+    # Empty yml_configs is fine -- some (folder, scope) combos have no recipes.
     yml_configs = detect_yml_configurations(automodel_dir, scope, test_folder)
-    if not yml_configs:
-        raise Exception(f"No yml configurations were found under {automodel_dir}/examples/{test_folder}")
 
     exempt_models = set(config_override.get("exempt_models") or [])
     exempt_configs = set(config_override.get("exempt_configs") or [])

--- a/tests/ci_tests/utils/generate_ci_tests.py
+++ b/tests/ci_tests/utils/generate_ci_tests.py
@@ -58,14 +58,38 @@ def slurm_time_multiplier(time: str, multiplier: int):
 
 
 # Scopes that auto-discover all configs via rglob (no recipe list needed).
+# Each entry maps test_folder -> subpath under examples/ (defaults to test_folder
+# when the two diverge, e.g. diffusion_finetune lives at examples/diffusion/finetune).
 # All other scope/folder combinations read from {scope}_recipes.yml.
 AUTO_DISCOVER_SCOPES = {
-    "release": ["llm_finetune", "vlm_finetune", "diffusion_finetune"],
-    "performance": ["llm_benchmark", "vlm_benchmark"],
+    "release": {
+        "llm_finetune": "llm_finetune",
+        "vlm_finetune": "vlm_finetune",
+        "diffusion_finetune": "diffusion/finetune",
+    },
+    "performance": {
+        "llm_benchmark": "llm_benchmark",
+        "vlm_benchmark": "vlm_benchmark",
+    },
 }
 
 
-def detect_yml_configurations(automodel_dir: str, scope: str, test_folder: str):
+def _discover_via_glob(automodel_dir: str, examples_subpath: str) -> list[Path]:
+    """Discover every recipe YAML under examples/<examples_subpath>/."""
+    automodel_path = Path(automodel_dir)
+    return sorted(p.relative_to(automodel_path) for p in (automodel_path / "examples" / examples_subpath).rglob("*.yaml"))
+
+
+def _discover_via_recipe_list(automodel_dir: str, scope: str, test_folder: str) -> list[Path]:
+    """Read configs/<test_folder>/<scope>_recipes.yml and return the recipe paths it lists."""
+    config_path = Path(automodel_dir) / "tests" / "ci_tests" / "configs" / test_folder / f"{scope}_recipes.yml"
+    with open(config_path, "r", encoding="utf-8") as f:
+        test_configs = yaml.load(f)
+    examples_dir = test_configs.get("examples_dir", test_folder)
+    return [Path(f"examples/{examples_dir}/{c}") for c in test_configs["configs"]]
+
+
+def detect_yml_configurations(automodel_dir: str, scope: str, test_folder: str) -> list[Path]:
     """
     Detect recipe YAML configurations to include in the CI pipeline.
 
@@ -80,28 +104,98 @@ def detect_yml_configurations(automodel_dir: str, scope: str, test_folder: str):
     Returns:
         yml_configs: List of yaml configs with path format examples/{test_folder}/
     """
-    yml_configs = []
-    search_path = f"{automodel_dir}/examples/{test_folder}"
-
-    auto_folders = AUTO_DISCOVER_SCOPES.get(scope, [])
+    auto_folders = AUTO_DISCOVER_SCOPES.get(scope, {})
     if test_folder in auto_folders:
-        for f in Path(f"{search_path}").rglob("*.yaml"):
-            relative_path = f.relative_to(automodel_dir)
-            yml_configs.append(relative_path)
-    else:
-        config_path = f"{automodel_dir}/tests/ci_tests/configs/{test_folder}/{scope}_recipes.yml"
-        with open(config_path, "r", encoding="utf-8") as f:
-            test_configs = yaml.load(f)
-            examples_dir = test_configs.get("examples_dir", test_folder)
-            yml_configs = [Path(f"examples/{examples_dir}/{c}") for c in test_configs["configs"]]
-
-    return yml_configs
+        return _discover_via_glob(automodel_dir, auto_folders[test_folder])
+    return _discover_via_recipe_list(automodel_dir, scope, test_folder)
 
 
-def generate_job(config: str, config_override: Dict[str, Any], scope: str, test_folder: str, automodel_dir: str):
+# Recipe ci: section keys mapped to the CI variables they populate on the base job.
+CI_KEY_TO_VAR = {
+    "time": "TIME",
+    "nodes": "TEST_NODE_COUNT",
+    "node_multiplier": "NODE_MULTIPLIER",
+    "local_batch_size": "LOCAL_BATCH_SIZE",
+    "recipe_owner": "RECIPE_OWNER",
+    "nproc_per_node": "CONFIG_NPROC_PER_NODE",
+}
+
+
+def _compute_base_stage(test_folder: str, config: Path, has_robustness: bool) -> str:
+    """Pick the GitLab CI stage for a base recipe job."""
+    if "benchmark" in test_folder:
+        return "performance"
+    if "benchmark" in config.stem:
+        return "benchmark"
+    if test_folder.startswith("diffusion"):
+        return "diffusion_peft" if ("lora" in config.stem or "peft" in config.stem) else "diffusion_sft"
+    if test_folder.startswith("retrieval"):
+        return "retrieval"
+    if "peft" in config.stem or "lora" in config.stem:
+        return "peft_ckpt_robustness" if has_robustness else "peft"
+    return "sft_ckpt_robustness" if has_robustness else "sft"
+
+
+def _build_job(
+    config: Path,
+    scope: str,
+    *,
+    extends: str,
+    stage: str,
+    extra_vars: Dict[str, Any] | None = None,
+    allow_failure: bool = False,
+    known_issue_id: str | None = None,
+) -> Dict[str, Any]:
+    """Build a CI job dict with the keys common to every variant (base, vllm_deploy, eval)."""
+    job: Dict[str, Any] = {
+        "extends": extends,
+        "stage": stage,
+        "variables": {
+            "CONFIG_PATH": f"{config}",
+            "TEST_LEVEL": f"{scope}",
+            **(extra_vars or {}),
+        },
+    }
+    if allow_failure:
+        job["allow_failure"] = True
+    if known_issue_id:
+        job["variables"]["KNOWN_ISSUE_ID"] = known_issue_id
+    return job
+
+
+def _enrich_base_job(job: Dict[str, Any], ci_config: Dict[str, Any], scope: str) -> None:
+    """Add base-only extras: resource overrides, env_vars, HAS_ROBUSTNESS, convergence time."""
+    for ci_key, ci_var in CI_KEY_TO_VAR.items():
+        if ci_key not in ci_config:
+            continue
+        value = ci_config[ci_key]
+        if ci_var == "TIME":
+            job["variables"][ci_var] = DQ(str(value))
+        elif ci_var == "NODE_MULTIPLIER":
+            job["variables"][ci_var] = str(value).lower()
+        else:
+            job["variables"][ci_var] = value
+
+    for key, value in ci_config.get("env_vars", {}).items():
+        job["variables"][key] = str(value)
+
+    job["variables"]["HAS_ROBUSTNESS"] = str(bool(ci_config.get("checkpoint_robustness"))).lower()
+
+    # Convergence tests run for 2 epochs; double the slurm time allocation.
+    if scope == "convergence":
+        slurm_time = job["variables"].get("TIME", "00:10:00")
+        job["variables"]["TIME"] = DQ(slurm_time_multiplier(slurm_time, 2))
+
+
+def generate_job(
+    config: Path,
+    config_override: Dict[str, Any],
+    scope: str,
+    test_folder: str,
+    automodel_dir: str,
+) -> list[tuple[str, Dict[str, Any]]]:
     """
-    Generate a CI test job definition for a single recipe configuration.
-    Resource requirements (time, nodes, etc.) are read from the recipe's `ci:` section.
+    Generate every CI job (base + opt-in variants) for a single recipe configuration.
 
     Args:
         config: Relative path to the recipe YAML configuration
@@ -111,149 +205,67 @@ def generate_job(config: str, config_override: Dict[str, Any], scope: str, test_
         automodel_dir: Path to the Automodel directory
 
     Returns:
-        job: Dictionary defining a single CI test job
+        List of (suffix, job_dict) pairs. The base job has suffix "". An empty list
+        means the recipe is fully skipped (e.g. ci.known_issue_id without ci.allow_failure).
     """
-    # Initialize test job
-    job = {
-        "variables": {
-            "CONFIG_PATH": f"{config}",
-            "TEST_LEVEL": f"{scope}",
-        }
-    }
-
-    # Configure test template
-    if "benchmark" in config.stem:
-        job["extends"] = ".llm_benchmark_test"
-    else:
-        job["extends"] = f".{test_folder}_test"
-
-    # Apply resource overrides (time, nodes, etc.) from the recipe's top-level ci: section
-    recipe_path = f"{automodel_dir}/{config}"
-    with open(recipe_path, "r", encoding="utf-8") as rf:
-        recipe = yaml.load(rf)
-
-    ci_config = recipe.get('ci') or {}
+    with open(f"{automodel_dir}/{config}", "r", encoding="utf-8") as rf:
+        ci_config = (yaml.load(rf) or {}).get("ci") or {}
 
     # allow_failure wins over known_issue_id.
-    # known_issue_id alone skips the job (and its vllm_deploy variant).
-    known_issue_id = ci_config.get('known_issue_id')
-    recipe_allow_failure = bool(ci_config.get('allow_failure'))
+    # known_issue_id alone skips the entire recipe (base + all variants).
+    known_issue_id = ci_config.get("known_issue_id")
+    recipe_allow_failure = bool(ci_config.get("allow_failure"))
     if known_issue_id and not recipe_allow_failure:
-        return None, None
+        return []
 
-    ci_key_map = {
-        "time": "TIME",
-        "nodes": "TEST_NODE_COUNT",
-        "node_multiplier": "NODE_MULTIPLIER",
-        "local_batch_size": "LOCAL_BATCH_SIZE",
-        "recipe_owner": "RECIPE_OWNER",
-        "nproc_per_node": "CONFIG_NPROC_PER_NODE",
-    }
-    for ci_key, ci_var in ci_key_map.items():
-        if ci_key in ci_config:
-            value = ci_config[ci_key]
-            if ci_var == "TIME":
-                job["variables"][ci_var] = DQ(str(value))
-            elif ci_var == "NODE_MULTIPLIER":
-                job["variables"][ci_var] = str(value).lower()
-            else:
-                job["variables"][ci_var] = value
+    has_robustness = bool(ci_config.get("checkpoint_robustness"))
+    base_allow_failure = recipe_allow_failure or config.stem in (config_override.get("known_issue") or [])
 
-    # Pass through env_vars as CI variables (exported to container via --export=ALL)
-    for key, value in ci_config.get('env_vars', {}).items():
-        job['variables'][key] = str(value)
+    base_job = _build_job(
+        config, scope,
+        extends=".llm_benchmark_test" if "benchmark" in config.stem else f".{test_folder}_test",
+        stage=_compute_base_stage(test_folder, config, has_robustness),
+        allow_failure=base_allow_failure,
+        known_issue_id=known_issue_id,
+    )
+    _enrich_base_job(base_job, ci_config, scope)
+    variants: list[tuple[str, Dict[str, Any]]] = [("", base_job)]
 
-    has_robustness = bool(ci_config.get('checkpoint_robustness'))
-    job['variables']['HAS_ROBUSTNESS'] = str(has_robustness).lower()
+    # vLLM deploy variant. `ci.vllm_deploy_known_issue_id` suppresses just this
+    # variant (base job still runs) -- use for bugs that only manifest in vllm deploy.
+    if ci_config.get("vllm_deploy") and not ci_config.get("vllm_deploy_known_issue_id"):
+        variants.append((
+            "_vllm_deploy",
+            _build_job(
+                config, scope,
+                extends=".vllm_deploy_test",
+                stage="peft_vllm_deploy" if "peft" in config.stem else "sft_vllm_deploy",
+                allow_failure=recipe_allow_failure,
+                known_issue_id=known_issue_id,
+            ),
+        ))
 
-    # Configure test stage based on recipe type and robustness config
-    if "benchmark" in test_folder:
-        job["stage"] = "performance"
-    elif "benchmark" in config.stem:
-        job["stage"] = "benchmark"
-    elif test_folder.startswith("diffusion"):
-        job["stage"] = "diffusion_peft" if ("lora" in config.stem or "peft" in config.stem) else "diffusion_sft"
-    elif test_folder.startswith("retrieval"):
-        job["stage"] = "retrieval"
-    elif "peft" in config.stem or "lora" in config.stem:
-        job["stage"] = "peft_ckpt_robustness" if has_robustness else "peft"
-    else:
-        job["stage"] = "sft_ckpt_robustness" if has_robustness else "sft"
+    # Retrieval eval variants. Bi-encoders opt into embed_eval, cross-encoders
+    # into rerank_eval. Both extend the same per-folder eval template.
+    for ci_key, suffix in (("embed_eval", "_embed_eval"), ("rerank_eval", "_rerank_eval")):
+        if not ci_config.get(ci_key):
+            continue
+        variants.append((
+            suffix,
+            _build_job(
+                config, scope,
+                extends=f".{test_folder}_eval_test",
+                stage="retrieval_eval",
+                extra_vars={"FINETUNE_TEST_NAME": f"{config.stem}"},
+                allow_failure=recipe_allow_failure,
+                known_issue_id=known_issue_id,
+            ),
+        ))
 
-    # Check if config has known issue
-    known_issue_config_list = config_override.get("known_issue") or []
-    if config.stem in known_issue_config_list:
-        job["allow_failure"] = True
-
-    # Recipe-level allow_failure + known_issue_id (skip case handled earlier).
-    if recipe_allow_failure:
-        job['allow_failure'] = True
-    if known_issue_id:
-        job['variables']['KNOWN_ISSUE_ID'] = known_issue_id
-
-    # Double time allocation as tests run for 2 epoch
-    if scope == "convergence":
-        slurm_time = job["variables"].get("TIME", "00:10:00")
-        job["variables"]["TIME"] = DQ(slurm_time_multiplier(slurm_time, 2))
-
-    # Generate vLLM deploy job if recipe opts in.
-    # `ci.vllm_deploy_known_issue_id` suppresses just the vllm_deploy variant
-    # (base job still runs) -- use for bugs that only manifest in vllm deploy.
-    vllm_job = None
-    vllm_deploy_known_issue_id = ci_config.get("vllm_deploy_known_issue_id")
-    if ci_config.get("vllm_deploy") and not vllm_deploy_known_issue_id:
-        vllm_stage = "peft_vllm_deploy" if "peft" in config.stem else "sft_vllm_deploy"
-        vllm_job = {
-            "extends": ".vllm_deploy_test",
-            "stage": vllm_stage,
-            "variables": {
-                "CONFIG_PATH": f"{config}",
-                "TEST_LEVEL": f"{scope}",
-            },
-        }
-        if recipe_allow_failure:
-            vllm_job['allow_failure'] = True
-        if known_issue_id:
-            vllm_job['variables']['KNOWN_ISSUE_ID'] = known_issue_id
-
-    # Generate embedding eval job if recipe opts in (bi-encoder retrieval models)
-    embed_eval_job = None
-    if ci_config.get("embed_eval"):
-        embed_eval_job = {
-            "extends": f".{test_folder}_eval_test",
-            "stage": "retrieval_eval",
-            "variables": {
-                "CONFIG_PATH": f"{config}",
-                "TEST_LEVEL": f"{scope}",
-                "FINETUNE_TEST_NAME": f"{config.stem}",
-            },
-        }
-        if recipe_allow_failure:
-            embed_eval_job['allow_failure'] = True
-        if known_issue_id:
-            embed_eval_job['variables']['KNOWN_ISSUE_ID'] = known_issue_id
-
-    # Generate reranking eval job if recipe opts in (cross-encoder retrieval models)
-    rerank_eval_job = None
-    if ci_config.get("rerank_eval"):
-        rerank_eval_job = {
-            "extends": f".{test_folder}_eval_test",
-            "stage": "retrieval_eval",
-            "variables": {
-                "CONFIG_PATH": f"{config}",
-                "TEST_LEVEL": f"{scope}",
-                "FINETUNE_TEST_NAME": f"{config.stem}",
-            },
-        }
-        if recipe_allow_failure:
-            rerank_eval_job['allow_failure'] = True
-        if known_issue_id:
-            rerank_eval_job['variables']['KNOWN_ISSUE_ID'] = known_issue_id
-
-    return job, vllm_job, embed_eval_job, rerank_eval_job
+    return variants
 
 
-def generate_pipeline(automodel_dir: str, scope: str, test_folder: str):
+def generate_pipeline(automodel_dir: str, scope: str, test_folder: str) -> Dict[str, Any]:
     """
     Generate a complete CI test pipeline YAML for the given test folder and scope.
 
@@ -265,71 +277,56 @@ def generate_pipeline(automodel_dir: str, scope: str, test_folder: str):
     Returns:
         pipeline: Dictionary defining the CI test pipeline
     """
-
-    # Check scope
-    if scope == "NONE":
-        scope = "nightly"
-
     override_path = f"{automodel_dir}/tests/ci_tests/configs/{test_folder}/override_recipes.yml"
     with open(override_path, "r", encoding="utf-8") as f:
-        config_override = yaml.load(f)
-    yml_configs = detect_yml_configurations(automodel_dir, scope, test_folder)
+        config_override = yaml.load(f) or {}
 
+    yml_configs = detect_yml_configurations(automodel_dir, scope, test_folder)
     if not yml_configs:
         raise Exception(f"No yml configurations were found under {automodel_dir}/examples/{test_folder}")
 
-    # Skip missing recipes so one bad reference doesn't abort the whole pipeline.
-    existing_configs = []
+    exempt_models = set(config_override.get("exempt_models") or [])
+    exempt_configs = set(config_override.get("exempt_configs") or [])
+
+    pipeline: Dict[str, Any] = {"include": ["automodel/automodel_ci_template.yml"]}
+
     for config in yml_configs:
-        if (Path(automodel_dir) / config).is_file():
-            existing_configs.append(config)
-        else:
+        # Skip missing recipes so one bad reference doesn't abort the whole pipeline.
+        if not (Path(automodel_dir) / config).is_file():
             print(f"WARNING: recipe not found, skipping: {config}", file=sys.stderr)
-
-    pipeline = {"include": ["automodel/automodel_ci_template.yml"]}
-
-    for config in existing_configs:
-        model_name = config.parent.name
-        config_name = config.stem
-
-        # Check if model is in exempt model list
-        exempt_models_list = config_override.get("exempt_models") or []
-        exempt_configs_list = config_override.get("exempt_configs") or []
-        if model_name in exempt_models_list or config_name in exempt_configs_list:
             continue
 
-        job, vllm_job, embed_eval_job, rerank_eval_job = generate_job(
-            config, config_override, scope, test_folder, automodel_dir
-        )
-        if job is None:
-            continue  # skipped via ci.known_issue_id (no allow_failure)
-        job["variables"]["MODEL_FAMILY"] = model_name
-        pipeline[f'{config_name}'] = job
-        if vllm_job:
-            vllm_job["variables"]["MODEL_FAMILY"] = model_name
-            pipeline[f"{config_name}_vllm_deploy"] = vllm_job
-        if embed_eval_job:
-            pipeline[f"{config_name}_embed_eval"] = embed_eval_job
-        if rerank_eval_job:
-            pipeline[f"{config_name}_rerank_eval"] = rerank_eval_job
+        model_name = config.parent.name
+        config_name = config.stem
+        if model_name in exempt_models or config_name in exempt_configs:
+            continue
+
+        for suffix, job in generate_job(config, config_override, scope, test_folder, automodel_dir):
+            job["variables"]["MODEL_FAMILY"] = model_name
+            pipeline[f"{config_name}{suffix}"] = job
 
     return pipeline
+
+
+def _normalize_scope(value: str) -> str:
+    """Map the GitLab CI sentinel "NONE" (unset variable) to the nightly default."""
+    return "nightly" if value == "NONE" else value
 
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--automodel-dir", type=str, required=True, help="Path to Automodel directory")
-    parser.add_argument("--scope", type=str, required=True, help="Scope of the tests (nightly, release)")
+    parser.add_argument(
+        "--scope", type=_normalize_scope, required=True, help="Scope of the tests (nightly, release)"
+    )
     parser.add_argument("--test-folder", type=str, required=True, help="Target folder to search")
-
     args = parser.parse_args()
 
     pipeline = generate_pipeline(args.automodel_dir, args.scope, args.test_folder)
-
-    if pipeline:
-        with open(f"generated_automodel_{args.test_folder}_tests.yml", "w") as f:
-            yaml.dump(pipeline, f)
-        print(f"Generated pipeline with {len([k for k in pipeline.keys() if k != 'stages'])} jobs")
+    with open(f"generated_automodel_{args.test_folder}_tests.yml", "w") as f:
+        yaml.dump(pipeline, f)
+    job_count = sum(1 for k in pipeline if k != "include")
+    print(f"Generated pipeline with {job_count} jobs")
 
 
 if __name__ == "__main__":

--- a/tests/ci_tests/utils/validate_generate_ci.py
+++ b/tests/ci_tests/utils/validate_generate_ci.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/usr/bin/env python3
+"""Validate that generate_ci_tests.generate_pipeline runs cleanly for every
+(test_folder, scope) combination defined in this repo.
+
+The matrix is auto-discovered from two sources of truth so the check stays current
+without manual maintenance:
+  * AUTO_DISCOVER_SCOPES in generate_ci_tests.py (e.g. release, performance)
+  * tests/ci_tests/configs/<folder>/<scope>_recipes.yml files
+
+Each combination is invoked; failures are collected and reported together so a
+single broken combo does not hide the rest.
+"""
+
+import argparse
+import sys
+import traceback
+from pathlib import Path
+
+# Allow `from generate_ci_tests import ...` when this script is run directly.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from generate_ci_tests import AUTO_DISCOVER_SCOPES, generate_pipeline  # noqa: E402
+
+
+def collect_matrix(automodel_dir: Path) -> list[tuple[str, str]]:
+    """Discover every (test_folder, scope) pair worth validating."""
+    matrix: set[tuple[str, str]] = set()
+
+    for scope, folders in AUTO_DISCOVER_SCOPES.items():
+        for folder in folders:
+            matrix.add((folder, scope))
+
+    configs_root = automodel_dir / "tests" / "ci_tests" / "configs"
+    for recipe_list in configs_root.glob("*/*_recipes.yml"):
+        # override_recipes.yml is not a scope; skip it.
+        if recipe_list.name == "override_recipes.yml":
+            continue
+        folder = recipe_list.parent.name
+        scope = recipe_list.stem[: -len("_recipes")]
+        matrix.add((folder, scope))
+
+    return sorted(matrix)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--automodel-dir", type=str, required=True, help="Path to Automodel directory")
+    args = parser.parse_args()
+
+    automodel_dir = Path(args.automodel_dir).resolve()
+    matrix = collect_matrix(automodel_dir)
+
+    successes: list[tuple[str, str, int]] = []
+    failures: list[tuple[str, str, str]] = []
+
+    for folder, scope in matrix:
+        try:
+            pipeline = generate_pipeline(str(automodel_dir), scope, folder)
+        except Exception:
+            failures.append((folder, scope, traceback.format_exc()))
+            continue
+        job_count = sum(1 for k in pipeline if k not in ("include", "stages"))
+        successes.append((folder, scope, job_count))
+
+    for folder, scope, job_count in successes:
+        print(f"OK   {folder}/{scope}: {job_count} jobs", file=sys.stderr)
+    for folder, scope, tb in failures:
+        print(f"\nFAIL {folder}/{scope}:\n{tb}", file=sys.stderr)
+
+    if failures:
+        print(
+            f"\n{len(failures)} of {len(matrix)} (test_folder, scope) combos failed.",
+            file=sys.stderr,
+        )
+        return 1
+    print(
+        f"\nAll {len(matrix)} (test_folder, scope) combos generated successfully.",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ci_tests/utils/validate_generate_ci.py
+++ b/tests/ci_tests/utils/validate_generate_ci.py
@@ -52,6 +52,12 @@ def collect_matrix(automodel_dir: Path) -> list[tuple[str, str]]:
         scope = recipe_list.stem[: -len("_recipes")]
         matrix.add((folder, scope))
 
+    # Also exercise every config folder with scope=nightly so folders without a
+    # nightly_recipes.yml hit the empty-pipeline path.
+    for config_dir in configs_root.iterdir():
+        if config_dir.is_dir():
+            matrix.add((config_dir.name, "nightly"))
+
     return sorted(matrix)
 
 

--- a/tests/unit_tests/ci_tests/__init__.py
+++ b/tests/unit_tests/ci_tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/unit_tests/ci_tests/test_config_resolver.py
+++ b/tests/unit_tests/ci_tests/test_config_resolver.py
@@ -81,7 +81,7 @@ def test_env_layer_applies_when_set_and_phase_matches(monkeypatch):
 
 def test_env_layer_skips_when_phase_excluded(monkeypatch):
     monkeypatch.setenv("MAX_STEPS", "99")
-    layer = config_resolver._resolve_env_layer(ENV_SPEC, phase="robustness")
+    layer = config_resolver._resolve_env_layer(ENV_SPEC, phase="checkpoint_robustness")
     assert layer == {}
 
 
@@ -152,7 +152,7 @@ CONDITIONAL_ENTRIES = [
     },
     {
         "when_recipe_contains_any": ["peft", "lora"],
-        "phases": ["robustness"],
+        "phases": ["checkpoint_robustness"],
         "apply": {"peft.use_triton": False},
     },
 ]
@@ -184,7 +184,7 @@ def test_conditional_layer_phase_filter_excludes_non_robustness(monkeypatch):
 
 
 def test_conditional_layer_contains_any_match():
-    out = config_resolver._resolve_conditional_layer(CONDITIONAL_ENTRIES, "robustness", "llama_lora")
+    out = config_resolver._resolve_conditional_layer(CONDITIONAL_ENTRIES, "checkpoint_robustness", "llama_lora")
     assert out == {"peft.use_triton": False}
 
 
@@ -228,7 +228,7 @@ def _run_resolver(args: list[str], env: dict | None = None) -> subprocess.Comple
 
 
 def test_end_to_end_phase_defaults_and_ci_section(tmp_path, synthetic_recipe):
-    """Phase defaults apply; recipe ci.<phase> overrides them; ci: block stripped from output."""
+    """Phase defaults apply; recipe ci.<phase> overrides them; ci: block preserved for downstream consumers."""
     out = tmp_path / "resolved.yaml"
     env = {"PIPELINE_DIR": str(tmp_path), "TEST_NAME": "t1"}
     _run_resolver(["--base", str(synthetic_recipe), "--phase", "nightly", "--output", str(out)], env=env)
@@ -241,8 +241,6 @@ def test_end_to_end_phase_defaults_and_ci_section(tmp_path, synthetic_recipe):
     assert resolved["step_scheduler"]["max_steps"] == 7
     # Computed override applied
     assert resolved["checkpoint"]["checkpoint_dir"] == f"{tmp_path}/t1/checkpoint"
-    # ci: section stripped
-    assert "ci" not in resolved
 
 
 def test_end_to_end_env_overrides_ci_section(tmp_path, synthetic_recipe):
@@ -259,7 +257,7 @@ def test_end_to_end_robustness_ignores_max_steps_env(tmp_path, synthetic_recipe)
     """ci_config.yaml's env entry restricts MAX_STEPS to non-robustness phases, so it must not leak in."""
     out = tmp_path / "resolved.yaml"
     env = {"PIPELINE_DIR": str(tmp_path), "TEST_NAME": "t1", "MAX_STEPS": "999"}
-    _run_resolver(["--base", str(synthetic_recipe), "--phase", "robustness", "--output", str(out)], env=env)
+    _run_resolver(["--base", str(synthetic_recipe), "--phase", "checkpoint_robustness", "--output", str(out)], env=env)
 
     resolved = yaml.load(out.open())
     assert resolved["step_scheduler"]["max_steps"] == 5  # robustness phase default holds
@@ -285,10 +283,35 @@ def test_end_to_end_robustness_peft_disables_triton(tmp_path):
     recipe.write_text("step_scheduler: {global_batch_size: 8}\nci: {recipe_owner: t}\n")
     out = tmp_path / "resolved.yaml"
     env = {"PIPELINE_DIR": str(tmp_path), "TEST_NAME": "t1"}
-    _run_resolver(["--base", str(recipe), "--phase", "robustness", "--output", str(out)], env=env)
+    _run_resolver(["--base", str(recipe), "--phase", "checkpoint_robustness", "--output", str(out)], env=env)
 
     resolved = yaml.load(out.open())
     assert resolved["peft"]["use_triton"] is False
+
+
+def test_end_to_end_fixture_keys_not_applied_as_overrides(tmp_path):
+    """Non-config fixture-arg keys in ci.checkpoint_robustness must not leak into the top-level config."""
+    recipe = tmp_path / "llama_squad.yaml"
+    recipe.write_text(
+        "step_scheduler: {global_batch_size: 8}\n"
+        "ci:\n"
+        "  checkpoint_robustness:\n"
+        "    hf_kl_threshold: 5e-3                       # fixture arg, must NOT become top-level\n"
+        "    tokenizer_name: nvidia/Test                 # fixture arg, must NOT become top-level\n"
+        "    dataset.limit_dataset_samples: 500          # dotted -> applied as override\n"
+    )
+    out = tmp_path / "resolved.yaml"
+    env = {"PIPELINE_DIR": str(tmp_path), "TEST_NAME": "t1"}
+    _run_resolver(["--base", str(recipe), "--phase", "checkpoint_robustness", "--output", str(out)], env=env)
+
+    resolved = yaml.load(out.open())
+    # Dotted key applied as a normal override
+    assert resolved["dataset"]["limit_dataset_samples"] == 500
+    # Fixture args stay under ci.checkpoint_robustness for the consumer (pytest) to read,
+    # and do NOT pollute the top level.
+    assert "hf_kl_threshold" not in resolved
+    assert "tokenizer_name" not in resolved
+    assert resolved["ci"]["checkpoint_robustness"]["hf_kl_threshold"] == 5e-3
 
 
 def test_end_to_end_dry_run_does_not_write(tmp_path, synthetic_recipe):

--- a/tests/unit_tests/ci_tests/test_config_resolver.py
+++ b/tests/unit_tests/ci_tests/test_config_resolver.py
@@ -1,0 +1,308 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from ruamel.yaml import YAML
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[3] / "tests" / "ci_tests" / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import config_resolver  # noqa: E402
+
+yaml = YAML()
+
+
+# ---------------------------------------------------------------------------
+# Helper-level tests
+# ---------------------------------------------------------------------------
+
+
+def test_set_dotted_creates_nested_path():
+    d: dict = {}
+    config_resolver._set_dotted(d, "a.b.c", 5)
+    assert d == {"a": {"b": {"c": 5}}}
+
+
+def test_set_dotted_preserves_siblings():
+    d = {"a": {"b": 1, "c": 2}}
+    config_resolver._set_dotted(d, "a.b", 99)
+    assert d == {"a": {"b": 99, "c": 2}}
+
+
+def test_set_dotted_replaces_non_dict_intermediate():
+    """If an intermediate key is not a dict, _set_dotted overwrites it with one."""
+    d = {"a": "scalar"}
+    config_resolver._set_dotted(d, "a.b", 1)
+    assert d == {"a": {"b": 1}}
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [("5", 5), ("0", 0), ("-3", -3), ("1.5", 1.5), ("hello", "hello"), ("", "")],
+)
+def test_coerce(raw, expected):
+    assert config_resolver._coerce(raw) == expected
+
+
+# ---------------------------------------------------------------------------
+# _resolve_env_layer
+# ---------------------------------------------------------------------------
+
+
+ENV_SPEC = {
+    "MAX_STEPS": {"target": "step_scheduler.max_steps", "phases": ["nightly", "convergence"]},
+    "LOCAL_BATCH_SIZE": {"target": "step_scheduler.local_batch_size", "phases": ["nightly"]},
+}
+
+
+def test_env_layer_applies_when_set_and_phase_matches(monkeypatch):
+    monkeypatch.setenv("MAX_STEPS", "99")
+    monkeypatch.delenv("LOCAL_BATCH_SIZE", raising=False)
+    layer = config_resolver._resolve_env_layer(ENV_SPEC, phase="nightly")
+    assert layer == {"step_scheduler.max_steps": 99}
+
+
+def test_env_layer_skips_when_phase_excluded(monkeypatch):
+    monkeypatch.setenv("MAX_STEPS", "99")
+    layer = config_resolver._resolve_env_layer(ENV_SPEC, phase="robustness")
+    assert layer == {}
+
+
+def test_env_layer_skips_when_var_unset(monkeypatch):
+    monkeypatch.delenv("MAX_STEPS", raising=False)
+    layer = config_resolver._resolve_env_layer(ENV_SPEC, phase="nightly")
+    assert layer == {}
+
+
+# ---------------------------------------------------------------------------
+# _resolve_computed_layer
+# ---------------------------------------------------------------------------
+
+
+def test_computed_layer_substitutes_env(monkeypatch):
+    monkeypatch.setenv("PIPELINE_DIR", "/p")
+    monkeypatch.setenv("TEST_NAME", "t1")
+    entries = [{
+        "target": "checkpoint.checkpoint_dir",
+        "format": "{PIPELINE_DIR}/{TEST_NAME}/checkpoint",
+        "phases": ["nightly"],
+    }]
+    assert config_resolver._resolve_computed_layer(entries, "nightly") == {
+        "checkpoint.checkpoint_dir": "/p/t1/checkpoint",
+    }
+
+
+def test_computed_layer_substitutes_date(monkeypatch):
+    entries = [{
+        "target": "wandb.project",
+        "format": "test-{date:%Y%m%d}",
+        "phases": ["convergence"],
+    }]
+    result = config_resolver._resolve_computed_layer(entries, "convergence")
+    today = datetime.now().strftime("%Y%m%d")
+    assert result == {"wandb.project": f"test-{today}"}
+
+
+def test_computed_layer_phase_filter():
+    entries = [{
+        "target": "wandb.name",
+        "format": "x",
+        "phases": ["convergence"],
+    }]
+    assert config_resolver._resolve_computed_layer(entries, "nightly") == {}
+
+
+def test_computed_layer_missing_substitution_exits(monkeypatch):
+    monkeypatch.delenv("DOES_NOT_EXIST", raising=False)
+    entries = [{"target": "x.y", "format": "{DOES_NOT_EXIST}", "phases": ["nightly"]}]
+    with pytest.raises(SystemExit, match="missing substitution"):
+        config_resolver._resolve_computed_layer(entries, "nightly")
+
+
+# ---------------------------------------------------------------------------
+# _resolve_conditional_layer
+# ---------------------------------------------------------------------------
+
+
+CONDITIONAL_ENTRIES = [
+    {
+        "when_recipe_contains_all": ["customizer_"],
+        "apply": {"dataset.path_or_dataset_id": "{NEMO_CI_PATH}/prompt_completion/train.jsonl"},
+    },
+    {
+        "when_recipe_contains_all": ["customizer_", "chat"],
+        "apply": {"dataset.path_or_dataset_id": "{NEMO_CI_PATH}/chat/train.jsonl"},
+    },
+    {
+        "when_recipe_contains_any": ["peft", "lora"],
+        "phases": ["robustness"],
+        "apply": {"peft.use_triton": False},
+    },
+]
+
+
+def test_conditional_layer_contains_all_matches(monkeypatch):
+    monkeypatch.setenv("NEMO_CI_PATH", "/data")
+    out = config_resolver._resolve_conditional_layer(CONDITIONAL_ENTRIES, "nightly", "customizer_foo")
+    assert out == {"dataset.path_or_dataset_id": "/data/prompt_completion/train.jsonl"}
+
+
+def test_conditional_layer_later_rule_wins(monkeypatch):
+    """Chat-specific customizer rule shadows the catch-all customizer rule."""
+    monkeypatch.setenv("NEMO_CI_PATH", "/data")
+    out = config_resolver._resolve_conditional_layer(CONDITIONAL_ENTRIES, "nightly", "customizer_foo_chat")
+    assert out == {"dataset.path_or_dataset_id": "/data/chat/train.jsonl"}
+
+
+def test_conditional_layer_skips_non_matching_recipe(monkeypatch):
+    monkeypatch.setenv("NEMO_CI_PATH", "/data")
+    assert config_resolver._resolve_conditional_layer(CONDITIONAL_ENTRIES, "nightly", "llama3_squad") == {}
+
+
+def test_conditional_layer_phase_filter_excludes_non_robustness(monkeypatch):
+    """peft rule is phase-filtered to robustness; nightly should not see it."""
+    monkeypatch.setenv("NEMO_CI_PATH", "/data")
+    out = config_resolver._resolve_conditional_layer(CONDITIONAL_ENTRIES, "nightly", "llama_lora")
+    assert out == {}
+
+
+def test_conditional_layer_contains_any_match():
+    out = config_resolver._resolve_conditional_layer(CONDITIONAL_ENTRIES, "robustness", "llama_lora")
+    assert out == {"peft.use_triton": False}
+
+
+def test_conditional_layer_passes_non_string_values_through():
+    """Non-string apply values (e.g. bool False) must not go through str.format."""
+    entries = [{"when_recipe_contains_any": ["x"], "apply": {"some.flag": False, "some.num": 5}}]
+    out = config_resolver._resolve_conditional_layer(entries, "nightly", "xfoo")
+    assert out == {"some.flag": False, "some.num": 5}
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: subprocess invocation against the real ci_config.yaml
+# ---------------------------------------------------------------------------
+
+
+RESOLVER = str(SCRIPTS_DIR / "config_resolver.py")
+
+
+@pytest.fixture
+def synthetic_recipe(tmp_path: Path) -> Path:
+    """A tiny recipe with a ci.nightly override, written to tmp_path."""
+    path = tmp_path / "recipe.yaml"
+    path.write_text(
+        "step_scheduler:\n"
+        "  global_batch_size: 8\n"
+        "  max_steps: 1000\n"
+        "ci:\n"
+        "  recipe_owner: tester\n"
+        "  nightly:\n"
+        "    step_scheduler.max_steps: 7   # per-recipe override of phase default 50\n"
+    )
+    return path
+
+
+def _run_resolver(args: list[str], env: dict | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, RESOLVER, *args],
+        check=True, capture_output=True, text=True,
+        env={**({} if env is None else env), "PATH": "/usr/bin:/bin"},
+    )
+
+
+def test_end_to_end_phase_defaults_and_ci_section(tmp_path, synthetic_recipe):
+    """Phase defaults apply; recipe ci.<phase> overrides them; ci: block stripped from output."""
+    out = tmp_path / "resolved.yaml"
+    env = {"PIPELINE_DIR": str(tmp_path), "TEST_NAME": "t1"}
+    _run_resolver(["--base", str(synthetic_recipe), "--phase", "nightly", "--output", str(out)], env=env)
+
+    resolved = yaml.load(out.open())
+    # Phase default (ckpt/val_every_steps) survives
+    assert resolved["step_scheduler"]["ckpt_every_steps"] == 50
+    assert resolved["step_scheduler"]["val_every_steps"] == 50
+    # Recipe ci.nightly wins over phase default for max_steps (7, not 50)
+    assert resolved["step_scheduler"]["max_steps"] == 7
+    # Computed override applied
+    assert resolved["checkpoint"]["checkpoint_dir"] == f"{tmp_path}/t1/checkpoint"
+    # ci: section stripped
+    assert "ci" not in resolved
+
+
+def test_end_to_end_env_overrides_ci_section(tmp_path, synthetic_recipe):
+    """Env overrides win over recipe ci.<phase> (explicit user override beats persisted recipe config)."""
+    out = tmp_path / "resolved.yaml"
+    env = {"PIPELINE_DIR": str(tmp_path), "TEST_NAME": "t1", "MAX_STEPS": "999"}
+    _run_resolver(["--base", str(synthetic_recipe), "--phase", "nightly", "--output", str(out)], env=env)
+
+    resolved = yaml.load(out.open())
+    assert resolved["step_scheduler"]["max_steps"] == 999  # env wins over ci.nightly's 7
+
+
+def test_end_to_end_robustness_ignores_max_steps_env(tmp_path, synthetic_recipe):
+    """ci_config.yaml's env entry restricts MAX_STEPS to non-robustness phases, so it must not leak in."""
+    out = tmp_path / "resolved.yaml"
+    env = {"PIPELINE_DIR": str(tmp_path), "TEST_NAME": "t1", "MAX_STEPS": "999"}
+    _run_resolver(["--base", str(synthetic_recipe), "--phase", "robustness", "--output", str(out)], env=env)
+
+    resolved = yaml.load(out.open())
+    assert resolved["step_scheduler"]["max_steps"] == 5  # robustness phase default holds
+    assert resolved["checkpoint"]["checkpoint_dir"] == f"{tmp_path}/t1/robustness_checkpoint"
+
+
+def test_end_to_end_customizer_chat_path_wins(tmp_path):
+    """A recipe whose stem contains both 'customizer_' and 'chat' picks up the chat dataset paths."""
+    recipe = tmp_path / "customizer_nano_chat.yaml"
+    recipe.write_text("step_scheduler: {global_batch_size: 8}\nci: {recipe_owner: t}\n")
+    out = tmp_path / "resolved.yaml"
+    env = {"PIPELINE_DIR": str(tmp_path), "TEST_NAME": "t1", "NEMO_CI_PATH": "/mnt/nci"}
+    _run_resolver(["--base", str(recipe), "--phase", "nightly", "--output", str(out)], env=env)
+
+    resolved = yaml.load(out.open())
+    assert resolved["dataset"]["path_or_dataset_id"] == "/mnt/nci/datasets/customizer/sample-datasets/chat/train.jsonl"
+    assert resolved["validation_dataset"]["path_or_dataset_id"] == "/mnt/nci/datasets/customizer/sample-datasets/chat/validation.jsonl"
+
+
+def test_end_to_end_robustness_peft_disables_triton(tmp_path):
+    """A robustness-phase peft recipe gets peft.use_triton: false applied."""
+    recipe = tmp_path / "llama_peft.yaml"
+    recipe.write_text("step_scheduler: {global_batch_size: 8}\nci: {recipe_owner: t}\n")
+    out = tmp_path / "resolved.yaml"
+    env = {"PIPELINE_DIR": str(tmp_path), "TEST_NAME": "t1"}
+    _run_resolver(["--base", str(recipe), "--phase", "robustness", "--output", str(out)], env=env)
+
+    resolved = yaml.load(out.open())
+    assert resolved["peft"]["use_triton"] is False
+
+
+def test_end_to_end_dry_run_does_not_write(tmp_path, synthetic_recipe):
+    out = tmp_path / "should_not_exist.yaml"
+    env = {"PIPELINE_DIR": str(tmp_path), "TEST_NAME": "t1"}
+    result = _run_resolver(["--base", str(synthetic_recipe), "--phase", "nightly", "--dry-run"], env=env)
+
+    assert not out.exists()
+    assert "Resolution stack" in result.stdout
+    assert "[phase_defaults]" in result.stdout
+    assert "[recipe.ci.nightly]" in result.stdout
+    assert "[env]" in result.stdout
+    assert "[computed]" in result.stdout
+    # Resolved YAML body included
+    resolved = yaml.load(io.StringIO(result.stdout.split("--- resolved config ---", 1)[1]))
+    assert resolved["step_scheduler"]["max_steps"] == 7

--- a/tests/unit_tests/ci_tests/test_config_resolver.py
+++ b/tests/unit_tests/ci_tests/test_config_resolver.py
@@ -48,7 +48,6 @@ def test_set_dotted_preserves_siblings():
 
 
 def test_set_dotted_replaces_non_dict_intermediate():
-    """If an intermediate key is not a dict, _set_dotted overwrites it with one."""
     d = {"a": "scalar"}
     config_resolver._set_dotted(d, "a.b", 1)
     assert d == {"a": {"b": 1}}

--- a/uv.lock
+++ b/uv.lock
@@ -1924,6 +1924,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/ed/6bfa4109fcb23a58819600392564fea69cdc6551ffd5e69ccf1d52a40cbc/greenlet-3.2.4-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:8c68325b0d0acf8d91dde4e6f930967dd52a5302cd4062932a6b2e7c2969f47c", size = 271061, upload-time = "2025-08-07T13:17:15.373Z" },
     { url = "https://files.pythonhosted.org/packages/2a/fc/102ec1a2fc015b3a7652abab7acf3541d58c04d3d17a8d3d6a44adae1eb1/greenlet-3.2.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:94385f101946790ae13da500603491f04a76b6e4c059dab271b3ce2e283b2590", size = 629475, upload-time = "2025-08-07T13:42:54.009Z" },
     { url = "https://files.pythonhosted.org/packages/c5/26/80383131d55a4ac0fb08d71660fd77e7660b9db6bdb4e8884f46d9f2cc04/greenlet-3.2.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f10fd42b5ee276335863712fa3da6608e93f70629c631bf77145021600abc23c", size = 640802, upload-time = "2025-08-07T13:45:25.52Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/7c/e7833dbcd8f376f3326bd728c845d31dcde4c84268d3921afcae77d90d08/greenlet-3.2.4-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c8c9e331e58180d0d83c5b7999255721b725913ff6bc6cf39fa2a45841a4fd4b", size = 636703, upload-time = "2025-08-07T13:53:12.622Z" },
     { url = "https://files.pythonhosted.org/packages/e9/49/547b93b7c0428ede7b3f309bc965986874759f7d89e4e04aeddbc9699acb/greenlet-3.2.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:58b97143c9cc7b86fc458f215bd0932f1757ce649e05b640fea2e79b54cedb31", size = 635417, upload-time = "2025-08-07T13:18:25.189Z" },
     { url = "https://files.pythonhosted.org/packages/7f/91/ae2eb6b7979e2f9b035a9f612cf70f1bf54aad4e1d125129bef1eae96f19/greenlet-3.2.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c2ca18a03a8cfb5b25bc1cbe20f3d9a4c80d8c3b13ba3df49ac3961af0b1018d", size = 584358, upload-time = "2025-08-07T13:18:23.708Z" },
     { url = "https://files.pythonhosted.org/packages/f7/85/433de0c9c0252b22b16d413c9407e6cb3b41df7389afc366ca204dbc1393/greenlet-3.2.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:9fe0a28a7b952a21e2c062cd5756d34354117796c6d9215a87f55e38d15402c5", size = 1113550, upload-time = "2025-08-07T13:42:37.467Z" },
@@ -1934,6 +1935,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/de/f28ced0a67749cac23fecb02b694f6473f47686dff6afaa211d186e2ef9c/greenlet-3.2.4-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:96378df1de302bc38e99c3a9aa311967b7dc80ced1dcc6f171e99842987882a2", size = 272305, upload-time = "2025-08-07T13:15:41.288Z" },
     { url = "https://files.pythonhosted.org/packages/09/16/2c3792cba130000bf2a31c5272999113f4764fd9d874fb257ff588ac779a/greenlet-3.2.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1ee8fae0519a337f2329cb78bd7a8e128ec0f881073d43f023c7b8d4831d5246", size = 632472, upload-time = "2025-08-07T13:42:55.044Z" },
     { url = "https://files.pythonhosted.org/packages/ae/8f/95d48d7e3d433e6dae5b1682e4292242a53f22df82e6d3dda81b1701a960/greenlet-3.2.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94abf90142c2a18151632371140b3dba4dee031633fe614cb592dbb6c9e17bc3", size = 644646, upload-time = "2025-08-07T13:45:26.523Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/5e/405965351aef8c76b8ef7ad370e5da58d57ef6068df197548b015464001a/greenlet-3.2.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:4d1378601b85e2e5171b99be8d2dc85f594c79967599328f95c1dc1a40f1c633", size = 640519, upload-time = "2025-08-07T13:53:13.928Z" },
     { url = "https://files.pythonhosted.org/packages/25/5d/382753b52006ce0218297ec1b628e048c4e64b155379331f25a7316eb749/greenlet-3.2.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0db5594dce18db94f7d1650d7489909b57afde4c580806b8d9203b6e79cdc079", size = 639707, upload-time = "2025-08-07T13:18:27.146Z" },
     { url = "https://files.pythonhosted.org/packages/1f/8e/abdd3f14d735b2929290a018ecf133c901be4874b858dd1c604b9319f064/greenlet-3.2.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2523e5246274f54fdadbce8494458a2ebdcdbc7b802318466ac5606d3cded1f8", size = 587684, upload-time = "2025-08-07T13:18:25.164Z" },
     { url = "https://files.pythonhosted.org/packages/5d/65/deb2a69c3e5996439b0176f6651e0052542bb6c8f8ec2e3fba97c9768805/greenlet-3.2.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1987de92fec508535687fb807a5cea1560f6196285a4cde35c100b8cd632cc52", size = 1116647, upload-time = "2025-08-07T13:42:38.655Z" },
@@ -1944,6 +1946,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
     { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
     { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
@@ -1954,6 +1957,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
     { url = "https://files.pythonhosted.org/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
     { url = "https://files.pythonhosted.org/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
@@ -1964,6 +1968,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
     { url = "https://files.pythonhosted.org/packages/c0/aa/687d6b12ffb505a4447567d1f3abea23bd20e73a5bed63871178e0831b7a/greenlet-3.2.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c17b6b34111ea72fc5a4e4beec9711d2226285f0386ea83477cbb97c30a3f3a5", size = 699218, upload-time = "2025-08-07T13:45:30.969Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
     { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },
@@ -3558,6 +3563,7 @@ test = [
     { name = "onnxruntime-gpu", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
     { name = "peft" },
     { name = "pytest" },
+    { name = "ruamel-yaml" },
 ]
 
 [package.metadata]
@@ -3662,6 +3668,7 @@ test = [
     { name = "onnxruntime-gpu", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'", index = "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-cuda-13/pypi/simple/" },
     { name = "peft", specifier = ">=0.18.1" },
     { name = "pytest" },
+    { name = "ruamel-yaml" },
 ]
 
 [[package]]
@@ -5597,6 +5604,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
+]
+
+[[package]]
+name = "ruamel-yaml"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# What does this PR do ?

  - Move per-phase flag composition, customizer dataset paths, PEFT robustness flag, env overrides, and dynamic paths out of finetune_launcher.sh into a declarative config_templates/ci_config.yaml consumed by config_resolver.py. Bash launcher drops from 141 → 116 LOC; all decisions reviewable in one YAML.
  - Adds 28 unit tests under tests/unit_tests/ci_tests/ covering layer semantics, phase filtering, recipe-pattern matching, and end-to-end resolution

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
