### PR TITLE
docs(retrieval): complete fine-tuning guide integration

### DIFF
--- a/docs/guides/dataset-overview.mdx
+++ b/docs/guides/dataset-overview.mdx
@@ -5,9 +5,9 @@ position: 1
 ---
 This page summarizes the datasets supported in NeMo AutoModel for LLM, VLM, and retrieval training and shows how to plug in your own datasets using Python functions or the YAML `_target_` mechanism.
 
-- See also: [LLM datasets](/datasets/text-dataset), [VLM datasets](/datasets/multi-modal-dataset), and [Retrieval dataset](/datasets/retrieval-dataset) for deeper, task-specific guides.
+- Refer to [LLM datasets](/datasets/text-dataset), [VLM datasets](/datasets/multi-modal-dataset), [Retrieval dataset](/datasets/retrieval-dataset), and [Retrieval fine-tuning](/recipes-e2e-examples/retrieval-finetune) for deeper, task-specific guides.
 
-- If a dataset you need is missing, please open a [GitHub issue](https://github.com/NVIDIA-NeMo/Automodel/issues) with a short description and example schema so we can prioritize support.
+- If a dataset you need is missing, open a [GitHub issue](https://github.com/NVIDIA-NeMo/Automodel/issues) with a short description and example schema so we can prioritize support.
 ---
 
 ## LLM Datasets
@@ -237,26 +237,40 @@ dataset:
 See the [Function Calling guide](/recipes-e2e-examples/function-calling) for an end-to-end example with FunctionGemma.
 For a small reasoning-style chat SFT starting point, see [qwen2_5_0p5b_instruct_fineproofs_chat.yaml](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/llm_finetune/qwen/qwen2_5_0p5b_instruct_fineproofs_chat.yaml).
 
-### Retrieval (Embedding Fine-Tuning)
-- Factory: `nemo_automodel.components.datasets.llm.make_retrieval_dataset`
-- Collator: `nemo_automodel.components.datasets.llm.BiEncoderCollator`
-- Use case: embedding model fine-tuning with (query, positive doc, negative docs) contrastive learning
-- Supported schemas:
-  - Corpus-ID JSON (Merlin/NeMo-retriever style)
-  - Inline-text JSONL (e.g., `{"query": "...", "pos_doc": "...", "neg_doc": ["...", "..."]}`)
-- Example YAML:
+### Retrieval Fine-Tuning
+- Factory for corpus ID JSON and `hf://` AutoModel-schema sources:
+  `nemo_automodel.components.datasets.llm.make_retrieval_dataset`
+- Factory for inline JSONL:
+  `nemo_automodel.components.datasets.llm.retrieval_dataset_inline.make_retrieval_dataset`
+- Collators: `nemo_automodel.components.datasets.llm.BiEncoderCollator` or
+  `nemo_automodel.components.datasets.llm.CrossEncoderCollator`
+- Use case: bi-encoder embedding fine-tuning with contrastive query and passage groups, or cross-encoder reranking over
+  query and passage pairs
+- Supported retrieval sources:
+  - Corpus ID JSON (Merlin/NeMo Retriever style)
+  - `hf://` sources that already follow the AutoModel retrieval schema
+  - Inline-text JSONL, such as `{"query": "...", "pos_doc": "...", "neg_doc": ["...", "..."]}`
+
+The following example configures an inline JSONL bi-encoder dataset:
+
 ```yaml
 dataset:
-  _target_: nemo_automodel.components.datasets.llm.make_retrieval_dataset
-  data_dir_list: /abs/path/to/train.jsonl
+  _target_: nemo_automodel.components.datasets.llm.retrieval_dataset_inline.InlineRetrievalDatasetConfig
+  model_type: bi_encoder
+  data_dir_list:
+    - /abs/path/to/train.jsonl
   data_type: train
   n_passages: 5
-collate_fn:
-  _target_: nemo_automodel.components.datasets.llm.BiEncoderCollator
-  q_max_len: 512
-  p_max_len: 512
+
+dataloader:
+  collate_fn:
+    _target_: nemo_automodel.components.datasets.llm.BiEncoderCollator
+    q_max_len: 512
+    p_max_len: 512
+  shuffle: true
 ```
-See the detailed guide, [Retrieval dataset](/datasets/retrieval-dataset), for more information.
+Refer to [Retrieval dataset](/datasets/retrieval-dataset) for more information. For the end-to-end
+workflow, refer to [Retrieval fine-tuning](/recipes-e2e-examples/retrieval-finetune).
 
 ### NanoGPT Binary Shards (Pretraining)
 - Class: `nemo_automodel.components.datasets.llm.nanogpt_dataset.NanogptDataset`

--- a/docs/guides/dataset-overview.mdx
+++ b/docs/guides/dataset-overview.mdx
@@ -238,10 +238,8 @@ See the [Function Calling guide](/recipes-e2e-examples/function-calling) for an 
 For a small reasoning-style chat SFT starting point, see [qwen2_5_0p5b_instruct_fineproofs_chat.yaml](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/llm_finetune/qwen/qwen2_5_0p5b_instruct_fineproofs_chat.yaml).
 
 ### Retrieval Fine-Tuning
-- Factory for corpus ID JSON and `hf://` AutoModel-schema sources:
-  `nemo_automodel.components.datasets.llm.make_retrieval_dataset`
-- Factory for inline JSONL:
-  `nemo_automodel.components.datasets.llm.retrieval_dataset_inline.make_retrieval_dataset`
+- Dataset config for corpus ID JSON, `hf://` AutoModel-schema sources, and inline JSONL:
+  `nemo_automodel.components.datasets.llm.retrieval_dataset.RetrievalDatasetConfig`
 - Collators: `nemo_automodel.components.datasets.llm.BiEncoderCollator` or
   `nemo_automodel.components.datasets.llm.CrossEncoderCollator`
 - Use case: bi-encoder embedding fine-tuning with contrastive query and passage groups, or cross-encoder reranking over
@@ -255,7 +253,7 @@ The following example configures an inline JSONL bi-encoder dataset:
 
 ```yaml
 dataset:
-  _target_: nemo_automodel.components.datasets.llm.retrieval_dataset_inline.InlineRetrievalDatasetConfig
+  _target_: nemo_automodel.components.datasets.llm.retrieval_dataset.RetrievalDatasetConfig
   model_type: bi_encoder
   data_dir_list:
     - /abs/path/to/train.jsonl

--- a/docs/guides/llm/retrieval-dataset.mdx
+++ b/docs/guides/llm/retrieval-dataset.mdx
@@ -20,8 +20,8 @@ Face `datasets.Dataset`. At runtime, it transforms each raw record into the trai
 - `doc_text`: list of document texts in the order `[positive, negative_1, negative_2, ...]`
 - `doc_image`: list of images (or empty strings), aligned with `doc_text`
 - `doc_id`: list of document identifiers aligned with `doc_text`. Corpus-backed and `hf://` sources preserve document
-  IDs. Inline JSONL derives identifiers from document values instead of stable corpus identity, so use a corpus-backed
-  source when reliable same-document masking is required.
+  IDs. Pure inline JSONL produces empty IDs, so use a corpus-backed source or custom preprocessing when reliable
+  same-document masking is required.
 - `query_instruction` / `passage_instruction`: optional, used when `use_dataset_instruction: true` and the corpus
   provides instructions through metadata
 

--- a/docs/guides/llm/retrieval-dataset.mdx
+++ b/docs/guides/llm/retrieval-dataset.mdx
@@ -19,8 +19,9 @@ Face `datasets.Dataset`. At runtime, it transforms each raw record into the trai
 - `question`: query string
 - `doc_text`: list of document texts in the order `[positive, negative_1, negative_2, ...]`
 - `doc_image`: list of images (or empty strings), aligned with `doc_text`
-- `doc_id`: list of document IDs aligned with `doc_text` for corpus-backed and `hf://` sources. Pure inline JSONL
-  does not provide real document IDs for duplicate-document masking unless you add them in a custom preprocessing path.
+- `doc_id`: list of document identifiers aligned with `doc_text`. Corpus-backed and `hf://` sources preserve document
+  IDs. Inline JSONL derives identifiers from document values instead of stable corpus identity, so use a corpus-backed
+  source when reliable same-document masking is required.
 - `query_instruction` / `passage_instruction`: optional, used when `use_dataset_instruction: true` and the corpus
   provides instructions through metadata
 
@@ -168,7 +169,8 @@ The following behavior applies to inline records:
 - The current LLM retrieval collators tokenize text only. Do not rely on inline `image` or OCR fields unless you add a
   custom preprocessing and collator path.
 - If `corpus_id` is not provided, it defaults to `__inline__`.
-- `use_dataset_instruction: true` has no effect for pure inline records (instructions come from corpus metadata).
+- Keep `use_dataset_instruction: false` for pure inline records. Dataset instructions come from corpus metadata, which
+  inline JSONL does not provide.
 </Note>
 
 ## Configure the Dataset and Collator in YAML

--- a/docs/guides/llm/retrieval-dataset.mdx
+++ b/docs/guides/llm/retrieval-dataset.mdx
@@ -1,30 +1,79 @@
 ---
 title: "Retrieval Dataset (Embedding Fine-Tuning)"
-description: ""
+description: "Prepare corpus-backed, Hugging Face, and inline datasets for bi-encoder and cross-encoder fine-tuning."
 position: 3
 ---
-NeMo AutoModel supports **retrieval model fine-tuning** using a retrieval-style dataset: each training example is a **query** paired with **one positive** document and **one or more negative** documents.
 
-The retrieval recipes use this dataset with the `BiEncoderCollator`. Example implementations are in `examples/retrieval/bi_encoder/` and `examples/retrieval/cross_encoder/`.
+NeMo AutoModel supports **retrieval model fine-tuning** using a retrieval-style dataset: each training example is a
+**query** paired with **one positive** document and **one or more negative** documents.
 
-## What the Bi-Encoder Consumes
+This dataset is used by the retrieval recipes in `examples/retrieval/bi_encoder/` and
+`examples/retrieval/cross_encoder/`, together with the retrieval collators. For an end-to-end training workflow, refer to
+[Retrieval Fine-Tuning](/recipes-e2e-examples/retrieval-finetune).
 
-The dataset factory `nemo_automodel.components.datasets.llm.make_retrieval_dataset` returns a Hugging Face `datasets.Dataset`. At runtime, it transforms each raw record into the training-time schema:
+## Raw Records and Runtime Schemas
+
+The dataset factory `nemo_automodel.components.datasets.llm.make_retrieval_dataset` returns a Hugging Face
+`datasets.Dataset`. At runtime it transforms each raw record into the training-time schema:
 
 - `question`: query string
 - `doc_text`: list of document texts in the order `[positive, negative_1, negative_2, ...]`
 - `doc_image`: list of images (or empty strings), aligned with `doc_text`
-- `query_instruction` / `passage_instruction`: optional, used when `use_dataset_instruction: true` and the corpus provides instructions through metadata
+- `doc_id`: list of document IDs aligned with `doc_text` for corpus-backed and `hf://` sources. Pure inline JSONL
+  does not provide real document IDs for duplicate-document masking unless you add them in a custom preprocessing path.
+- `query_instruction` / `passage_instruction`: optional, used when `use_dataset_instruction: true` and the corpus
+  provides instructions through metadata
+
+The cross-encoder recipe consumes the same raw retrieval records, but sets `model_type: cross_encoder`. Its dataset
+transform flattens each query with its positive and negative passages, and `CrossEncoderCollator` serializes each
+query-passage pair for reranking.
+
+Each transformed training example uses exactly one positive passage. Corpus-backed JSON and `hf://` sources use the
+first item in `pos_doc` by default. Set `cycle_positive_docs: true` to rotate through multiple positives by epoch.
+Inline JSONL currently always uses the first positive. For multi-positive data, choose a canonical positive, enable
+cycling where supported, expand the record into one example per positive, or add a multi-positive loss/masking strategy.
+If expanded rows for the same query can share a batch, keep distributed in-batch negatives disabled unless you also
+prevent sibling positives from becoming negatives through qrels-aware sampling or masking. Keep the full set of known
+positives in your qrels or corpus metadata for evaluation and false-negative filtering, even when each transformed
+example uses one positive.
 
 ## Supported Input Formats
 
-NeMo AutoModel supports **two** input schemas:
+NeMo AutoModel supports **two** input schemas across three source types. They use different dataset factories:
 
-### Corpus ID-Based JSON (Merlin/NeMo-Retriever Style)
+- Use `nemo_automodel.components.datasets.llm.make_retrieval_dataset` for corpus ID-based JSON and `hf://` sources.
+- Use `nemo_automodel.components.datasets.llm.retrieval_dataset_inline.make_retrieval_dataset` for inline JSONL where
+  document text is stored directly in each record.
 
-This is the format used by NeMo retriever pipelines where documents live in a separate **corpus** and training examples reference documents by **ID**.
+The following table compares the three supported source types:
 
-#### Training File Example (Single JSON)
+| Source | Query field | Required document fields | Typical use |
+|--------|-------------|--------------------------|-------------|
+| Corpus ID JSON | `question` | `question_id`, `corpus_id`, `pos_doc`, and `neg_doc` IDs resolved through a local corpus | Local corpus-backed training and hard-negative mining |
+| `hf://` AutoModel schema | `question` | `pos_doc`, a companion Hugging Face corpus split, and `neg_doc` before training with `n_passages > 1` | Shared datasets that already use the AutoModel retrieval schema |
+| Inline JSONL | `query` or `question` | Inline text in `pos_doc` and `neg_doc` | Small custom text datasets |
+
+Separate query relevance judgment files, commonly called qrels, are not consumed directly by the training dataset
+factory. Convert qrels-style data into retrieval records before training:
+
+1. Put every passage in a corpus split with stable `id` and `text` values.
+2. For each query, write one or more training records with `question_id`, `question`, `corpus_id`, `pos_doc`, and
+   `neg_doc`. Use unique `question_id` values within each mining file. Hard-negative mining writes results back by ID.
+3. Put the canonical positive first in `pos_doc`. For corpus-backed JSON and `hf://` sources, you can also set
+   `cycle_positive_docs: true` to rotate through positives by epoch. Expand multi-positive queries into multiple records
+   if every positive must become a supervised positive in the same epoch.
+4. For hard-negative mining, include all known positive document IDs for that query in the row's `pos_doc`. The miner
+   excludes only IDs present in the input row, not an external qrels file.
+5. If you expand one query into multiple positive rows, keep those sibling-positive rows out of the same in-batch-negative
+   training batch or use qrels-aware masking.
+6. Preserve the complete qrels separately for full-corpus evaluation and audit mined negatives against them before
+   reusing the output for training.
+
+### Corpus ID-Based JSON
+
+Use this format when documents live in a separate corpus and training examples reference documents by ID.
+
+The following example shows one training JSON file:
 
 ```json
 {
@@ -43,28 +92,68 @@ This is the format used by NeMo retriever pipelines where documents live in a se
 }
 ```
 
-#### Corpus Requirements
+For the text retrieval workflow in this guide, configure the corpus as a `TextQADataset`. The corpus directory must
+contain a `merlin_metadata.json` file and a Hugging Face-loadable `train` split with `id` and `text` columns.
+AutoModel calls `datasets.load_dataset(<corpus path>)["train"]`, then resolves `pos_doc` and `neg_doc` IDs against
+that split.
 
-Each corpus directory must contain a `merlin_metadata.json` file.
+Other registered corpus classes support image-oriented data and have different column requirements. Use the matching
+retrieval example when you configure one of those classes.
 
-Minimal example:
+The following example is a minimal `merlin_metadata.json` file:
 
 ```json
 { "class": "TextQADataset", "corpus_id": "wiki_corpus" }
 ```
 
-<Note>
-- `pos_doc` and `neg_doc` can be lists of `{"id": ...}` dicts or raw IDs (they are normalized internally).
-- `cycle_positive_docs` defaults to `false`, which always uses the first positive document. When a training record has multiple positive documents, set `cycle_positive_docs: true` to rotate through them deterministically by epoch order (`epoch % len(pos_doc)`).
-- If you set `use_dataset_instruction: true`, optional fields like `query_instruction` and `passage_instruction` in `merlin_metadata.json` are surfaced to the collator.
+The corresponding minimal local layout is:
 
+```text
+retrieval-data/
+  train.json
+  wiki_corpus/
+    merlin_metadata.json
+    train.parquet   # or another load_dataset-compatible train split with id,text columns
+```
+
+The `corpus_id` in `merlin_metadata.json` must match the `corpus_id` in each training record. Relative corpus paths in
+`train.json` are resolved relative to the JSON file.
+
+<Note>
+The following behavior applies to corpus-backed records:
+
+- `pos_doc` and `neg_doc` can be lists of `{"id": ...}` dicts or raw IDs (they are normalized internally).
+- `cycle_positive_docs` defaults to `false`, so training uses `pos_doc[0]`. Set it to `true` to rotate through
+  multiple positive documents deterministically by epoch (`epoch % len(pos_doc)`).
+- With cycling disabled, additional positives are ignored unless you expand the data before training.
+- To train with corpus instructions, set `use_dataset_instruction: true` on both the dataset and the bi-encoder
+  collator. The dataset surfaces `query_instruction` and `passage_instruction` from `merlin_metadata.json`. The collator
+  prepends them before tokenization.
 </Note>
+
+### Hugging Face Sources
+
+Direct `hf://` loading expects the AutoModel retrieval schema, not arbitrary Hugging Face retrieval datasets. The URI
+format is:
+
+```text
+hf://<org>/<repo>/<subset>
+```
+
+Each subset must provide:
+
+- `<subset>/dataset_metadata.json` with `corpus_id` metadata and `ids_only` set to `false` or omitted
+- a `<subset>_corpus` train split with `id` and `text` columns
+- a `<subset>` train split with `question` and `pos_doc`. `neg_doc` may be absent but must be available before training
+  with `n_passages > 1`
+
+Datasets with BEIR, DPR, MS MARCO, MIRACL, or other layouts need a preprocessing step before direct `hf://` loading.
 
 ### Inline-Text JSONL (No Corpus Required)
 
 This is convenient for custom fine-tuning pipelines where the documents are included **inline**.
 
-The format uses one JSON object per line:
+The following JSONL example contains one record per line:
 
 ```json
 {"query":"Explain transformers","pos_doc":"Transformers are a type of neural network...","neg_doc":["RNNs are...","CNNs are..."]}
@@ -72,31 +161,62 @@ The format uses one JSON object per line:
 ```
 
 <Note>
+The following behavior applies to inline records:
+
 - `query` is accepted (`question` is also accepted as an alias).
 - `pos_doc` and `neg_doc` can be either:
   - strings (interpreted as document text), or
   - lists of strings, or
-  - dicts with at least `text` (optionally `image`, `nr_ocr`) for multimodal use cases.
+  - dicts with at least `text`.
+- The current LLM retrieval collators tokenize text only. Do not rely on inline `image` or OCR fields unless you add a
+  custom preprocessing and collator path.
 - If `corpus_id` is not provided, it defaults to `__inline__`.
 - `use_dataset_instruction: true` has no effect for pure inline records (instructions come from corpus metadata).
-
 </Note>
 
 ## Configure the Dataset and Collator in YAML
 
-Use the dataset factory plus the bi-encoder collator:
+Use `RetrievalDatasetConfig` with the bi-encoder collator for corpus ID-based JSON or Hugging Face `hf://` sources:
 
 ```yaml
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.retrieval_dataset.RetrievalDatasetConfig
+  model_type: bi_encoder
+  data_dir_list:
+    - /abs/path/to/train.json    # or hf://nvidia/embed-nemotron-dataset-v1/FEVER
+  data_type: train
+  n_passages: 5                 # 1 positive + 4 negatives
+  do_shuffle: true
+  use_dataset_instruction: false
+
 dataloader:
-  _target_: torchdata.stateful_dataloader.StatefulDataLoader
-  dataset:
-    _target_: nemo_automodel.components.datasets.llm.make_retrieval_dataset
-    data_dir_list:
-      - /abs/path/to/train.jsonl   # or train.json (corpus-id format)
-    data_type: train
-    n_passages: 5                 # 1 positive + 4 negatives
-    do_shuffle: true
+  collate_fn:
+    _target_: nemo_automodel.components.datasets.llm.BiEncoderCollator
+    q_max_len: 512
+    p_max_len: 512
+    query_prefix: "query:"
+    passage_prefix: "passage:"
     use_dataset_instruction: false
+    pad_to_multiple_of: 8
+```
+
+For corpus ID JSON and `hf://` sources, `do_shuffle: true` shuffles rows only when `max_train_samples` is set before
+subsampling. Training order is controlled by the dataloader or distributed sampler. For inline JSONL, `do_shuffle: true`
+shuffles the loaded rows directly.
+
+Use `InlineRetrievalDatasetConfig` for inline JSONL:
+
+```yaml
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.retrieval_dataset_inline.InlineRetrievalDatasetConfig
+  model_type: bi_encoder
+  data_dir_list:
+    - /abs/path/to/train.jsonl
+  data_type: train
+  n_passages: 5                 # 1 positive + 4 negatives
+  do_shuffle: true
+
+dataloader:
   collate_fn:
     _target_: nemo_automodel.components.datasets.llm.BiEncoderCollator
     q_max_len: 512
@@ -106,7 +226,38 @@ dataloader:
     pad_to_multiple_of: 8
 ```
 
+For cross-encoder training, keep the same dataset config, set `model_type: cross_encoder`, and use
+`CrossEncoderCollator` arguments:
+
+```yaml
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.retrieval_dataset_inline.InlineRetrievalDatasetConfig
+  model_type: cross_encoder
+  data_dir_list:
+    - /abs/path/to/train.jsonl
+  data_type: train
+  n_passages: 5
+  do_shuffle: true
+
+dataloader:
+  collate_fn:
+    _target_: nemo_automodel.components.datasets.llm.CrossEncoderCollator
+    rerank_max_length: 512
+    prompt_template: "question:{query} \n \n passage:{passage}"
+    pad_to_multiple_of: 8
+```
+
 ## Requirements
 
+The following requirements apply to retrieval records:
+
 - `pos_doc` must be **non-empty**.
-- If training requests negatives (e.g., `n_passages > 1`), `neg_doc` must contain **at least one** document.
+- `neg_doc` must be present in local JSON and JSONL training records. It may be empty only when `n_passages: 1`.
+- `hf://` sources may omit `neg_doc` in the source dataset.
+- For every source, `neg_doc` must contain at least one document before training with `n_passages > 1`.
+
+<Warning>
+`n_passages: 1` is a schema escape hatch, not a good default training setup. The standard bi-encoder and cross-encoder
+recipes need at least one negative candidate for meaningful contrastive or reranking supervision, unless you add a
+custom negative strategy such as qrels-aware in-batch negatives.
+</Warning>

--- a/docs/guides/llm/retrieval-dataset.mdx
+++ b/docs/guides/llm/retrieval-dataset.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Retrieval Dataset (Embedding Fine-Tuning)"
+title: "Retrieval Dataset"
 description: "Prepare corpus-backed, Hugging Face, and inline datasets for bi-encoder and cross-encoder fine-tuning."
 position: 3
 ---

--- a/docs/guides/llm/retrieval-dataset.mdx
+++ b/docs/guides/llm/retrieval-dataset.mdx
@@ -13,8 +13,8 @@ This dataset is used by the retrieval recipes in `examples/retrieval/bi_encoder/
 
 ## Raw Records and Runtime Schemas
 
-The dataset factory `nemo_automodel.components.datasets.llm.make_retrieval_dataset` returns a Hugging Face
-`datasets.Dataset`. At runtime it transforms each raw record into the training-time schema:
+The public config `nemo_automodel.components.datasets.llm.retrieval_dataset.RetrievalDatasetConfig` builds a Hugging
+Face `datasets.Dataset`. At runtime, it transforms each raw record into the training-time schema:
 
 - `question`: query string
 - `doc_text`: list of document texts in the order `[positive, negative_1, negative_2, ...]`
@@ -28,22 +28,17 @@ The cross-encoder recipe consumes the same raw retrieval records, but sets `mode
 transform flattens each query with its positive and negative passages, and `CrossEncoderCollator` serializes each
 query-passage pair for reranking.
 
-Each transformed training example uses exactly one positive passage. Corpus-backed JSON and `hf://` sources use the
-first item in `pos_doc` by default. Set `cycle_positive_docs: true` to rotate through multiple positives by epoch.
-Inline JSONL currently always uses the first positive. For multi-positive data, choose a canonical positive, enable
-cycling where supported, expand the record into one example per positive, or add a multi-positive loss/masking strategy.
-If expanded rows for the same query can share a batch, keep distributed in-batch negatives disabled unless you also
-prevent sibling positives from becoming negatives through qrels-aware sampling or masking. Keep the full set of known
-positives in your qrels or corpus metadata for evaluation and false-negative filtering, even when each transformed
-example uses one positive.
+Each transformed training example uses exactly one positive passage. `RetrievalDatasetConfig` uses the first item in
+`pos_doc` by default. Set `cycle_positive_docs: true` to rotate through multiple positives by epoch for any supported
+source. For guidance about expanding multi-positive data and preventing sibling positives from becoming negatives,
+refer to [Convert Qrels and Multi-Positive Data](#convert-qrels-and-multi-positive-data).
 
 ## Supported Input Formats
 
-NeMo AutoModel supports **two** input schemas across three source types. They use different dataset factories:
-
-- Use `nemo_automodel.components.datasets.llm.make_retrieval_dataset` for corpus ID-based JSON and `hf://` sources.
-- Use `nemo_automodel.components.datasets.llm.retrieval_dataset_inline.make_retrieval_dataset` for inline JSONL where
-  document text is stored directly in each record.
+NeMo AutoModel supports **two** input schemas across three source types. Configure all supported sources with
+`nemo_automodel.components.datasets.llm.retrieval_dataset.RetrievalDatasetConfig`. It selects corpus-backed JSON,
+`hf://`, or inline JSONL loading from the source URI and file extension. Name inline files with the `.jsonl` extension.
+An inline `.json` file is treated as corpus-backed data and is not detected automatically.
 
 The following table compares the three supported source types:
 
@@ -53,21 +48,23 @@ The following table compares the three supported source types:
 | `hf://` AutoModel schema | `question` | `pos_doc`, a companion Hugging Face corpus split, and `neg_doc` before training with `n_passages > 1` | Shared datasets that already use the AutoModel retrieval schema |
 | Inline JSONL | `query` or `question` | Inline text in `pos_doc` and `neg_doc` | Small custom text datasets |
 
-Separate query relevance judgment files, commonly called qrels, are not consumed directly by the training dataset
-factory. Convert qrels-style data into retrieval records before training:
+### Convert Qrels and Multi-Positive Data
+
+The training dataset does not consume query relevance judgments (qrels) as a separate input. Convert
+qrels-style data into retrieval records before training:
 
 1. Put every passage in a corpus split with stable `id` and `text` values.
-2. For each query, write one or more training records with `question_id`, `question`, `corpus_id`, `pos_doc`, and
-   `neg_doc`. Use unique `question_id` values within each mining file. Hard-negative mining writes results back by ID.
-3. Put the canonical positive first in `pos_doc`. For corpus-backed JSON and `hf://` sources, you can also set
-   `cycle_positive_docs: true` to rotate through positives by epoch. Expand multi-positive queries into multiple records
-   if every positive must become a supervised positive in the same epoch.
-4. For hard-negative mining, include all known positive document IDs for that query in the row's `pos_doc`. The miner
-   excludes only IDs present in the input row, not an external qrels file.
-5. If you expand one query into multiple positive rows, keep those sibling-positive rows out of the same in-batch-negative
-   training batch or use qrels-aware masking.
-6. Preserve the complete qrels separately for full-corpus evaluation and audit mined negatives against them before
-   reusing the output for training.
+2. For each query, write one or more records with `question_id`, `question`, `corpus_id`, `pos_doc`, and `neg_doc`. Use
+   unique `question_id` values within each mining file because hard-negative mining writes results back by ID.
+3. Put the canonical positive first in `pos_doc`. Set `cycle_positive_docs: true` to rotate through all positives by
+   epoch, or expand the query into multiple records if every positive must be supervised in the same epoch.
+4. For hard-negative mining, include every known positive document ID for the query in `pos_doc`. The miner excludes
+   only IDs in the input record, not an external qrels file.
+5. If you expand a query into multiple records, keep sibling-positive records out of the same in-batch-negative training
+   batch or use known-positive masking.
+
+Preserve the complete qrels separately for offline full-corpus retrieval evaluation and use them to audit mined negatives
+before reusing the output for training.
 
 ### Corpus ID-Based JSON
 
@@ -176,7 +173,8 @@ The following behavior applies to inline records:
 
 ## Configure the Dataset and Collator in YAML
 
-Use `RetrievalDatasetConfig` with the bi-encoder collator for corpus ID-based JSON or Hugging Face `hf://` sources:
+Use `RetrievalDatasetConfig` with the appropriate collator for every supported source. The following corpus-backed
+example also works with an `hf://` source:
 
 ```yaml
 dataset:
@@ -186,7 +184,6 @@ dataset:
     - /abs/path/to/train.json    # or hf://nvidia/embed-nemotron-dataset-v1/FEVER
   data_type: train
   n_passages: 5                 # 1 positive + 4 negatives
-  do_shuffle: true
   use_dataset_instruction: false
 
 dataloader:
@@ -200,21 +197,19 @@ dataloader:
     pad_to_multiple_of: 8
 ```
 
-For corpus ID JSON and `hf://` sources, `do_shuffle: true` shuffles rows only when `max_train_samples` is set before
-subsampling. Training order is controlled by the dataloader or distributed sampler. For inline JSONL, `do_shuffle: true`
-shuffles the loaded rows directly.
+For all supported source types, `do_shuffle: true` shuffles rows only when `max_train_samples` is set, before
+subsampling. Otherwise, the dataloader or distributed sampler controls training order.
 
-Use `InlineRetrievalDatasetConfig` for inline JSONL:
+For inline JSONL, keep the same public config and change the source path:
 
 ```yaml
 dataset:
-  _target_: nemo_automodel.components.datasets.llm.retrieval_dataset_inline.InlineRetrievalDatasetConfig
+  _target_: nemo_automodel.components.datasets.llm.retrieval_dataset.RetrievalDatasetConfig
   model_type: bi_encoder
   data_dir_list:
     - /abs/path/to/train.jsonl
   data_type: train
   n_passages: 5                 # 1 positive + 4 negatives
-  do_shuffle: true
 
 dataloader:
   collate_fn:
@@ -231,13 +226,12 @@ For cross-encoder training, keep the same dataset config, set `model_type: cross
 
 ```yaml
 dataset:
-  _target_: nemo_automodel.components.datasets.llm.retrieval_dataset_inline.InlineRetrievalDatasetConfig
+  _target_: nemo_automodel.components.datasets.llm.retrieval_dataset.RetrievalDatasetConfig
   model_type: cross_encoder
   data_dir_list:
     - /abs/path/to/train.jsonl
   data_type: train
   n_passages: 5
-  do_shuffle: true
 
 dataloader:
   collate_fn:

--- a/docs/guides/llm/retrieval-finetune.mdx
+++ b/docs/guides/llm/retrieval-finetune.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Retrieval Fine-Tuning (Bi-Encoder and Cross-Encoder)"
-description: "Fine-tune bi-encoder and cross-encoder retrieval models in NeMo AutoModel: data prep, configs, distributed launch, LoRA, hard-negative mining, and evaluation."
+description: "Fine-tune bi-encoder and cross-encoder retrieval models in NeMo AutoModel with distributed training, low-rank adaptation, hard-negative mining, and evaluation."
 ---
 
 ## Introduction
 
-Retrieval models optimize a model for search, retrieval-augmented generation (RAG), semantic similarity, and reranking.
+Retrieval fine-tuning adapts a model for search, retrieval-augmented generation (RAG), semantic similarity, and reranking.
 NeMo AutoModel provides two retrieval fine-tuning recipes:
 
 - **Bi-encoder fine-tuning** trains one encoder to produce query and passage embeddings. Use it when you need fast
@@ -30,6 +30,13 @@ Prepare retrieval data
   -> Use the consolidated checkpoint for indexing, mining, reranking, or serving
 ```
 
+<Warning>
+The Llama 3.2 quickstart checkpoint cannot currently be used with the built-in hard-negative mining script. Its
+consolidated export requires `trust_remote_code=True`, and the mining CLI does not expose that option. You can complete
+the training and evaluation steps with the quickstart, but use a compatible Hugging Face bi-encoder checkpoint for the
+mining step.
+</Warning>
+
 Start with a bi-encoder when you need embeddings for approximate nearest-neighbor search. Add hard-negative mining after
 the first pass if the model mostly sees easy negatives. Train a cross-encoder when a separate retriever already produces
 a small candidate set and you want a stronger reranking stage.
@@ -38,23 +45,23 @@ a small candidate set and you want a stronger reranking stage.
 
 Before running the examples:
 
-- Use an AutoModel environment with the full GPU training dependencies installed. The NGC container is the safest path
-  for multi-GPU runs; for source checkouts, see [Installation](/get-started/installation) and run
-  `uv sync --frozen --extra all`.
-- Run the example commands from a source checkout or an NGC/container workspace that contains the repository
-  `examples/` tree. The YAML configs and mining helpers below are repo-relative; if you use an installed package
-  without the repository, copy the referenced config/script files into your own project and update the paths.
-- From a source checkout, use `uv run automodel ...`; from an installed environment that has local copies of the
+- Use an AutoModel environment with the full GPU training dependencies installed. For multi-GPU runs, use the NGC
+  container. For source checkouts, refer to [Installation](/get-started/installation) and run
+  `uv sync --locked --all-groups --extra all`.
+- Run the commands from a source checkout or an NGC container workspace that contains the repository `examples/` tree.
+  The YAML configs and mining helpers use repository-relative paths. For an installed package without the repository,
+  place the referenced files in your project and update the paths.
+- From a source checkout, use `uv run automodel ...`. From an installed environment that has local copies of the
   configs, use `automodel ...`.
-- Accept access terms for the configured Hugging Face model and set `HF_TOKEN`, or replace the model path with a model
-  your environment can download. See the support matrix below before swapping model families.
+- Accept the access terms for the configured Hugging Face model and set `HF_TOKEN`, or select a model that your
+  environment can download. Refer to the support matrix before changing model families.
 - Make sure every rank can read the dataset paths or `hf://` sources.
 
-The commands below use `automodel`; if you are running from a source checkout, prefix them with `uv run`. For direct
-`torchrun` commands, use `uv run torchrun ...` from a source checkout, or activate an installed environment first.
+The examples use `automodel`. From a source checkout, prefix these commands with `uv run`. For direct `torchrun`
+commands, use `uv run torchrun ...` from a source checkout or activate an installed environment first.
 
-Start with a one-GPU smoke test. The timestamped checkpoint directory keeps this first command from silently resuming
-or appending metrics to an older run:
+Run a one-GPU basic verification test first. The timestamped checkpoint directory keeps this command from silently
+resuming or appending metrics to an older run:
 
 ```bash
 RUN_ID=$(date +%Y%m%d-%H%M%S)
@@ -64,15 +71,15 @@ automodel examples/retrieval/bi_encoder/llama3_2_1b.yaml --nproc-per-node 1 \
   --step_scheduler.global_batch_size 4 \
   --step_scheduler.local_batch_size 1 \
   --step_scheduler.max_steps 10 \
-  --dataloader.dataset.max_train_samples 40
+  --dataset.max_train_samples 40
 ```
 
 `max_train_samples` shortens the training rows after the configured `hf://` split and corpus are loaded. This is a
-training-step smoke test, not a cheap data-loading smoke test; first-run downloads and corpus loading can still take
-time and disk. For a tiny data-loading test, point the config at a small local retrieval JSON/JSONL sample.
+training-step verification, not a lightweight data-loading check. First-run downloads and corpus loading can still take
+time and disk. For a small data-loading check, point the config at a local retrieval JSON or JSONL sample.
 
 The first artifact to check is `training.jsonl` under `checkpoint.checkpoint_dir`. JSONL metrics are buffered, so
-stdout/stderr are still the best live signal during a very short run.
+standard output and error are still the best live signals during a very short run.
 
 Scale the Llama 3.2 1B bi-encoder example to the GPUs on your machine:
 
@@ -90,12 +97,14 @@ automodel examples/retrieval/cross_encoder/llama3_2_1b.yaml --nproc-per-node 8 \
   --checkpoint.checkpoint_dir ./output/llama3_2_1b_cross_encoder_${RUN_ID}/checkpoints
 ```
 
-Adjust `--nproc-per-node` to the number of GPUs on your machine. The examples use FSDP2 and bfloat16 by default. The
-example scheduler uses `global_batch_size: 128` and `local_batch_size: 4`, so GPU counts that do not divide `32` need an
-explicit `--step_scheduler.global_batch_size` override. For example, 6 GPUs can use
-`--step_scheduler.global_batch_size 120` or another multiple of `4 * 6`.
+Adjust `--nproc-per-node` to the number of GPUs on your machine. The examples use Fully Sharded Data Parallel version 2
+(FSDP2) and bfloat16 by default. The example scheduler uses `global_batch_size: 128` and `local_batch_size: 4`, so
+GPU counts that do not divide `32` need an explicit `--step_scheduler.global_batch_size` override.
+For example, a 6-GPU run can use `--step_scheduler.global_batch_size 120` or another multiple of `4 * 6`.
 
 ## Choose a Recipe
+
+Choose the recipe that matches your retrieval stage:
 
 | Need | Use | Why |
 |------|-----|-----|
@@ -103,6 +112,8 @@ explicit `--step_scheduler.global_batch_size` override. For example, 6 GPUs can 
 | RAG candidate generation | Bi-encoder | Produces dense vectors for approximate nearest-neighbor retrieval. |
 | Better ranking for a small shortlist | Cross-encoder | Scores each query-passage pair jointly, which is slower but usually more accurate. |
 | Better negatives for the next training run | Hard-negative mining | Uses a trained bi-encoder to find confusing passages for each query. |
+
+The following table compares the recipe components:
 
 | Component | Bi-encoder | Cross-encoder |
 |-----------|------------|---------------|
@@ -115,23 +126,24 @@ explicit `--step_scheduler.global_batch_size` override. For example, 6 GPUs can 
 The bi-encoder computes a query embedding and passage embeddings independently. The cross-encoder formats each
 query-passage pair into one sequence and predicts a score for each candidate passage.
 
-Supported model families and effective retrieval kwargs:
+The following table summarizes the supported model families and their effective retrieval keyword arguments:
 
-| Model `config.model_type` | Bi-encoder behavior | Cross-encoder behavior | Effective retrieval kwargs |
+| Model `config.model_type` | Bi-encoder behavior | Cross-encoder behavior | Effective retrieval keyword arguments |
 |---------------------------|---------------------|------------------------|----------------------------|
 | `llama`, `llama_bidirec` | Uses `LlamaBidirectionalModel` | Uses `LlamaBidirectionalForSequenceClassification` | Bi-encoder: `pooling`, wrapper-level `l2_normalize`, and top-level recipe `temperature`. Cross-encoder: `pooling`, `num_labels`, and `temperature` on the Llama scoring config. |
-| `ministral3`, `ministral3_bidirec` | Uses `Ministral3BidirectionalModel` | Direct cross-encoder scoring is not supported by the custom retrieval registry today; use a different direct cross-encoder backbone. | Bi-encoder: `pooling`, wrapper-level `l2_normalize`, and top-level recipe `temperature`. |
-| Any other Hugging Face model type | Falls back to `AutoModel` | Falls back to `AutoModelForSequenceClassification` only when the model type is not listed above | Bi-encoder fallback receives standard Hugging Face `from_pretrained` kwargs; `pooling` and `l2_normalize` still apply in the AutoModel wrapper. Cross-encoder fallback forwards `num_labels`; do not assume custom `pooling` or `temperature` are accepted unless that HF class documents them. |
+| `ministral3`, `ministral3_bidirec` | Uses `Ministral3BidirectionalModel` | Direct cross-encoder scoring is not supported by the custom retrieval registry today. Use a different direct cross-encoder backbone. | Bi-encoder: `pooling`, wrapper-level `l2_normalize`, and top-level recipe `temperature`. |
+| `llama_nemotron_vl` | Uses `LlamaNemotronVLModel` | Direct cross-encoder scoring is not supported by the custom retrieval registry today. | Bi-encoder: `pooling`, wrapper-level `l2_normalize`, and top-level recipe `temperature`. |
+| Any model type without a retrieval registry entry | Falls back to `AutoModel` | Falls back to `AutoModelForSequenceClassification` | Bi-encoder fallback receives standard Hugging Face `from_pretrained` keyword arguments. `pooling` and `l2_normalize` still apply in the AutoModel wrapper. Cross-encoder fallback forwards only `num_labels`. Custom `pooling` and `temperature` are ignored. |
 
 Known model types with a registry entry fail fast when the requested retrieval task is unsupported rather than falling
 back silently. For example, direct `ministral3` loading is supported for bi-encoder embeddings but not for the
 cross-encoder scoring recipe. If you are extracting a text tower from a parent checkpoint, set
-`model.extract_submodel: language_model`; extracted text backbones use the extraction path, where supported extracted
+`model.extract_submodel: language_model`. Extracted text backbones use the extraction path, where supported extracted
 types use registered retrieval classes and unsupported extracted types can fall back to Hugging Face sequence
 classification for cross-encoder scoring.
 
 Treat unregistered decoder-only fallback models as an architecture experiment, not just a drop-in model swap. Registered
-retrieval backbones such as the Llama bidirectional path use retrieval-specific attention behavior; a vanilla
+retrieval backbones such as the Llama bidirectional path use retrieval-specific attention behavior. A vanilla
 Hugging Face `AutoModel` fallback can keep the source model's original causal behavior, which may be lower quality for
 symmetric embedding retrieval.
 
@@ -143,7 +155,7 @@ matches the workflow you need:
 | Data path | Use when | Notes |
 |-----------|----------|-------|
 | `hf://` AutoModel retrieval schema | You want a tutorial run or shared public dataset | Requires an AutoModel-style HF subset with a companion corpus split. |
-| Inline JSONL | You want a small custom run without hard-negative mining | Documents are embedded directly in each record; no document IDs are available for same-document masking. |
+| Inline JSONL | You want a small custom run without hard-negative mining | Documents are embedded directly in each record. No document IDs are available for same-document masking. |
 | Corpus ID-based JSON | You need hard-negative mining, reusable corpora, or same-document masking | Records reference document IDs in a local corpus that can be loaded by Hugging Face `datasets`. |
 
 The key field requirements differ by source:
@@ -151,10 +163,10 @@ The key field requirements differ by source:
 | Source | Required query field | Required document fields |
 |--------|----------------------|--------------------------|
 | Corpus ID JSON | `question` | `question_id`, `corpus_id`, non-empty `pos_doc`, and present `neg_doc` |
-| `hf://` AutoModel schema | `question` | non-empty `pos_doc`; `neg_doc` is optional in the source but required before training with negatives |
+| `hf://` AutoModel schema | `question` | Non-empty `pos_doc`. `neg_doc` is optional in the source but required before training with negatives. |
 | Inline JSONL | `query` or `question` | non-empty `pos_doc`, and present `neg_doc` |
 
-`neg_doc` must be present for local JSON and JSONL sources. It may be `[]` only when `n_passages: 1`; when
+`neg_doc` must be present for local JSON and JSONL sources. It may be `[]` only when `n_passages: 1`. When
 `n_passages > 1`, provide at least one negative.
 
 <Warning>
@@ -162,6 +174,7 @@ The key field requirements differ by source:
 The standard bi-encoder and cross-encoder recipes need at least one negative candidate for meaningful contrastive or
 reranking supervision, unless you add a custom strategy such as qrels-aware in-batch negatives.
 </Warning>
+
 For quick custom experiments, inline JSONL is the simplest format. Use the inline dataset factory for these files, and
 switch to corpus ID-based JSON before hard-negative mining or full-corpus evaluation:
 
@@ -172,9 +185,10 @@ switch to corpus ID-based JSON before hard-negative mining or full-corpus evalua
 
 To migrate inline data to corpus ID JSON, assign a stable document ID to each unique passage, write those passages into
 a corpus split with `id` and `text` columns, then replace inline `pos_doc` and `neg_doc` strings with those IDs. Keep
-all known positives for each query in your qrels or source metadata, even if each training row uses only the first
-positive. Otherwise, in-batch negatives and mined hard negatives can accidentally treat another relevant passage as a
-negative. The detailed source schemas and conversion rules live in [Retrieval Dataset](/datasets/retrieval-dataset).
+all known positives for each query in your query relevance judgments (qrels) or source metadata, even if each training
+row uses only the first positive. Otherwise, in-batch negatives and mined hard negatives can accidentally treat another
+relevant passage as a negative. The detailed source schemas and conversion rules are in
+[Retrieval Dataset](/datasets/retrieval-dataset).
 
 For larger corpora, use the corpus ID-based JSON format from the dataset guide. Use
 `nemo_automodel.components.datasets.llm.make_retrieval_dataset` for corpus ID-based JSON and for `hf://` sources that
@@ -187,20 +201,22 @@ data_dir_list:
 ```
 
 `n_passages` controls the size of each query group. For example, `n_passages: 5` means one positive and four negatives.
-Training uses the first item in `pos_doc` as the positive, then takes negatives from `neg_doc` in order. If a record has
-fewer negatives than requested, negatives are repeated cyclically to fill the group. Treat repetition as a fallback for
-shape compatibility; for real training and validation, prefer enough distinct negatives or lower `n_passages`.
+Corpus-backed JSON and `hf://` sources use `pos_doc[0]` by default. Set `cycle_positive_docs: true` to rotate the
+supervised positive across epochs when a row has multiple positives. Inline JSONL always uses the first positive.
+Negatives are taken from `neg_doc` in order. If a record has fewer negatives than requested, they are repeated
+cyclically to fill the group. Treat repetition as a fallback for shape compatibility. Prefer enough distinct negatives.
 
 The training recipe does not load a separate qrels file. Materialize qrels into retrieval records before fine-tuning.
-For training, `pos_doc[0]` is the supervised positive. For mining, keep every known positive for the query in `pos_doc`
-so the miner can exclude those IDs; it does not read an external qrels file. If you expand multi-positive queries into
-one row per positive, make sure sibling positives are removed from `neg_doc` and audited out of mined negatives before
-training. For a multi-positive input row, `examples/retrieval/data_utils/unroll_pos_docs.py` emits only a suffixed
-`question_id` plus `question`, `corpus_id`, `pos_doc`, and `neg_doc`; it does not add `original_question_id`. Keep a
-separate mapping from each suffixed ID to its source question if you need that lineage. The current miner also normalizes
-rows to the required retrieval fields and does not preserve extra row metadata. Also keep sibling-positive rows out of
-the same in-batch-negative training batch, disable distributed in-batch negatives, or add qrels-aware sampling/masking.
-Keep the original qrels for offline Recall@K, MRR@K, and nDCG@K evaluation.
+For mining, keep every known positive for the query in `pos_doc` so the miner can exclude those IDs. It does not read an
+external qrels file. If you expand multi-positive queries into one row per positive, make sure sibling positives are
+removed from `neg_doc` and audited out of mined negatives before training. For a multi-positive input row,
+`examples/retrieval/data_utils/unroll_pos_docs.py` emits only a suffixed `question_id` plus `question`, `corpus_id`,
+`pos_doc`, and `neg_doc`. It does not add `original_question_id`. Keep a separate mapping from each suffixed ID to its
+source question if you need that lineage. The current miner also normalizes rows to the required retrieval fields and
+does not preserve extra row metadata. Keep sibling-positive rows out of the same in-batch-negative training batch,
+disable distributed in-batch negatives, or add qrels-aware sampling or masking. Keep the original qrels for offline
+recall at K (Recall@K), mean reciprocal rank at K (MRR@K), and normalized discounted cumulative gain at K (nDCG@K)
+evaluation.
 
 ## Minimal Config Anatomy
 
@@ -236,18 +252,18 @@ tokenizer:
   pretrained_model_name_or_path: meta-llama/Llama-3.2-1B
   add_eos_token: false
 
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.retrieval_dataset.RetrievalDatasetConfig
+  model_type: bi_encoder
+  data_dir_list:
+    - /path/to/train.json
+  data_type: train
+  n_passages: 5
+  seed: 42
+  do_shuffle: true
+  max_train_samples: 40
+
 dataloader:
-  _target_: torchdata.stateful_dataloader.StatefulDataLoader
-  dataset:
-    _target_: nemo_automodel.components.datasets.llm.retrieval_dataset.make_retrieval_dataset
-    model_type: bi_encoder
-    data_dir_list:
-      - /path/to/train.json
-    data_type: train
-    n_passages: 5
-    seed: 42
-    do_shuffle: true
-    max_train_samples: 40
   collate_fn:
     _target_: nemo_automodel.components.datasets.llm.BiEncoderCollator
     q_max_len: 512
@@ -280,7 +296,7 @@ distributed:
   cp_size: 1
 ```
 
-For a cross-encoder, change `recipe`, `model._target_`, `dataloader.dataset.model_type`, and `dataloader.collate_fn`
+For a cross-encoder, change `recipe`, `model._target_`, `dataset.model_type`, and `dataloader.collate_fn`
 to the cross-encoder values shown below. Also set `model.num_labels: 1`, set the loss temperature under
 `model.temperature`, replace `q_max_len` / `p_max_len` with `rerank_max_length` in the collator, and use a separate
 `checkpoint.checkpoint_dir` such as `./output/llama3_2_1b_cross_encoder/checkpoints`.
@@ -288,7 +304,7 @@ to the cross-encoder values shown below. Also set `model.num_labels: 1`, set the
 ## Configure a Bi-Encoder
 
 A bi-encoder config has four important parts: the model, tokenizer, retrieval dataset, and `BiEncoderCollator`. This
-snippet is an excerpt; keep the scheduler, optimizer, checkpoint, and distributed sections from the full config or one
+example is an excerpt. Keep the scheduler, optimizer, checkpoint, and distributed sections from the full config or one
 of the examples.
 
 ```yaml
@@ -308,17 +324,17 @@ tokenizer:
   pretrained_model_name_or_path: meta-llama/Llama-3.2-1B
   add_eos_token: false
 
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.retrieval_dataset.RetrievalDatasetConfig
+  model_type: bi_encoder
+  data_dir_list:
+    - /path/to/train.json
+  data_type: train
+  n_passages: 5
+  seed: 42
+  do_shuffle: true
+
 dataloader:
-  _target_: torchdata.stateful_dataloader.StatefulDataLoader
-  dataset:
-    _target_: nemo_automodel.components.datasets.llm.retrieval_dataset.make_retrieval_dataset
-    model_type: bi_encoder
-    data_dir_list:
-      - /path/to/train.json
-    data_type: train
-    n_passages: 5
-    seed: 42
-    do_shuffle: true
   collate_fn:
     _target_: nemo_automodel.components.datasets.llm.BiEncoderCollator
     q_max_len: 512
@@ -330,7 +346,7 @@ dataloader:
   num_workers: 0
 ```
 
-Important knobs:
+The following settings control bi-encoder behavior:
 
 - `pooling`: controls how token hidden states become one embedding. Common single-vector choices are `avg`, `cls`,
   `last`, and `weighted_avg`. The shipped hard-negative miner currently loads the bi-encoder wrapper with its default
@@ -344,19 +360,20 @@ Important knobs:
 - `do_distributed_inbatch_negative`: optional model setting that treats passages from other data-parallel ranks as
   additional negatives. Enable it with `model.do_distributed_inbatch_negative: true` or the CLI override
   `--model.do_distributed_inbatch_negative true`. Today it all-gathers over the default process group, so use it only
-  for pure DP/FSDP retrieval runs (`tp_size: 1`, `cp_size: 1`). Same-document masking requires `doc_id` fields from
-  corpus-backed or custom datasets; inline JSONL does not provide duplicate-document masking. For multi-positive queries
-  expanded into separate rows, keep it disabled unless your sampler or masking prevents sibling positives from becoming
-  negatives. Keep it disabled for ColBERT-style pooling.
+  for data-parallel FSDP2 retrieval runs (`tp_size: 1`, `cp_size: 1`). Same-document masking requires `doc_id` fields from
+  corpus-backed or custom datasets. Inline JSONL does not provide duplicate-document masking. The collator hashes raw
+  document IDs across the full batch, so make IDs globally unique when a run combines multiple corpora. For
+  multi-positive queries expanded into separate rows, keep distributed in-batch negatives disabled unless your sampler
+  or masking prevents sibling positives from becoming negatives.
 
 The complete example is
 [examples/retrieval/bi_encoder/llama3_2_1b.yaml](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/retrieval/bi_encoder/llama3_2_1b.yaml).
 
 ## Configure a Cross-Encoder
 
-A cross-encoder config uses the same retrieval dataset factory, but sets `model_type: cross_encoder` and uses
+A cross-encoder config uses the same retrieval dataset config, but sets `model_type: cross_encoder` and uses
 `CrossEncoderCollator`. The dataset transform flattens each query with its positive and negative passages so the model
-scores each query-passage pair. This snippet is an excerpt; keep the same scheduler, optimizer, checkpoint, and
+scores each query-passage pair. This example is an excerpt. Keep the same scheduler, optimizer, checkpoint, and
 distributed structure as the bi-encoder config.
 
 ```yaml
@@ -375,17 +392,17 @@ tokenizer:
   pretrained_model_name_or_path: meta-llama/Llama-3.2-1B
   add_eos_token: false
 
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.retrieval_dataset.RetrievalDatasetConfig
+  model_type: cross_encoder
+  data_dir_list:
+    - /path/to/train.json
+  data_type: train
+  n_passages: 5
+  seed: 42
+  do_shuffle: true
+
 dataloader:
-  _target_: torchdata.stateful_dataloader.StatefulDataLoader
-  dataset:
-    _target_: nemo_automodel.components.datasets.llm.retrieval_dataset.make_retrieval_dataset
-    model_type: cross_encoder
-    data_dir_list:
-      - /path/to/train.json
-    data_type: train
-    n_passages: 5
-    seed: 42
-    do_shuffle: true
   collate_fn:
     _target_: nemo_automodel.components.datasets.llm.CrossEncoderCollator
     rerank_max_length: 512
@@ -395,7 +412,7 @@ dataloader:
   num_workers: 0
 ```
 
-Important knobs:
+The following settings control cross-encoder behavior:
 
 - `rerank_max_length`: maximum combined query-passage sequence length.
 - `prompt_template`: controls how the pair is serialized before tokenization. It must include `{query}` and `{passage}`.
@@ -407,9 +424,9 @@ The complete example is
 
 ## Distributed Launch and Batch Size
 
-Launch single-node examples with `automodel <config.yaml> --nproc-per-node <gpus>`. The retrieval recipes support
-data-parallel training through the configured distributed strategy; pipeline parallelism is not supported for encoder
-recipes today.
+Launch single-node examples with `automodel <config.yaml> --nproc-per-node <gpus>`. The documented retrieval
+configuration uses data-parallel FSDP2. Keep `tp_size: 1` and `cp_size: 1`. The recipes raise an error when pipeline
+parallelism is enabled.
 
 For multi-node runs, launch with your cluster launcher or an external `torchrun` command so every node has an explicit
 rank and rendezvous endpoint:
@@ -426,7 +443,7 @@ uv run torchrun \
 
 Use a shared or pre-populated Hugging Face cache on every node, make dataset paths visible to every rank, and use a
 unique `checkpoint_dir` for each experiment. For multi-node training, `checkpoint_dir` must be on a shared, persistent
-filesystem mounted at the same path from every node; relative `./output/...` paths are appropriate only when they resolve
+filesystem mounted at the same path from every node. Relative `./output/...` paths are appropriate only when they resolve
 to shared storage. Increase `dist_env.timeout_minutes` for first model downloads, slow shared filesystems, multi-node
 collectives, or large checkpoint writes.
 
@@ -437,38 +454,36 @@ gradient_accumulation_steps = global_batch_size / (local_batch_size * data_paral
 ```
 
 `global_batch_size` must be divisible by `local_batch_size * data_parallel_size`, and the result must be at least `1`.
-In pure data parallelism, `data_parallel_size` is the total GPU count. With tensor or context parallelism enabled, it is
-`world_size / (tp_size * cp_size)`. For example, two 8-GPU nodes with `tp_size: 1` and `cp_size: 1` have
-`data_parallel_size: 16`; with `tp_size: 2`, they have `data_parallel_size: 8`.
+For the supported data-parallel FSDP2 configuration, `data_parallel_size` is the total GPU count. For example, two
+8-GPU nodes have `data_parallel_size: 16`.
 
 `local_batch_size` is the number of query groups per rank. For memory pressure, reduce
 `step_scheduler.local_batch_size` first, then sequence lengths (`q_max_len`, `p_max_len`, or `rerank_max_length`), then
-`n_passages`. Bi-encoders scale memory with query length plus `local_batch_size * n_passages` passage sequences;
-cross-encoders scale with `local_batch_size * n_passages` combined query-passage sequences.
+`n_passages`. Bi-encoders scale memory with query length plus `local_batch_size * n_passages` passage sequences.
+Cross-encoders scale with `local_batch_size * n_passages` combined query-passage sequences.
 
 Current retrieval datasets are map-style datasets loaded in each process, not streaming distributed inputs. Pre-cache
-HF data on each node or use a shared cache, and budget CPU RAM and local disk per rank for corpus-backed datasets.
+Hugging Face data on each node or use a shared cache, and budget CPU RAM and local disk per rank for corpus-backed datasets.
 
 ## Add Validation
 
-Both examples include a commented `validation_dataloader` block. Enable it when you have a held-out retrieval file.
-Use the same dataset family as the validation source:
-`nemo_automodel.components.datasets.llm.retrieval_dataset.make_retrieval_dataset` for `hf://` or corpus ID-based JSON,
-and `retrieval_dataset_inline.make_retrieval_dataset` only for inline JSONL. This corpus-backed example mirrors the
+Both examples include commented `validation_dataset` and `validation_dataloader` blocks. Enable them when you have a
+held-out retrieval file. Use the same dataset family as the validation source: `RetrievalDatasetConfig` for `hf://` or
+corpus ID-based JSON, and `InlineRetrievalDatasetConfig` only for inline JSONL. This corpus-backed example mirrors the
 shipped configs:
 
 ```yaml
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.llm.retrieval_dataset.RetrievalDatasetConfig
+  model_type: bi_encoder
+  data_dir_list:
+    - /path/to/validation.json
+  data_type: eval
+  n_passages: 5
+  seed: 42
+  do_shuffle: false
+
 validation_dataloader:
-  _target_: torchdata.stateful_dataloader.StatefulDataLoader
-  dataset:
-    _target_: nemo_automodel.components.datasets.llm.retrieval_dataset.make_retrieval_dataset
-    model_type: bi_encoder
-    data_dir_list:
-      - /path/to/validation.json
-    data_type: eval
-    n_passages: 5
-    seed: 42
-    do_shuffle: false
   collate_fn:
     _target_: nemo_automodel.components.datasets.llm.BiEncoderCollator
     q_max_len: 512
@@ -482,11 +497,12 @@ validation_dataloader:
 ```
 
 Validation logs `val_loss`, `val_acc1`, and `val_mrr` to `validation.jsonl` under `checkpoint.checkpoint_dir`. These
-metrics measure ranking within each candidate group in the validation file; they are not full-corpus Recall@K or nDCG
-metrics. For cross-encoder validation, use `model_type: cross_encoder` and `CrossEncoderCollator` instead. In multi-rank
-runs, validation uses the same distributed sampler path as training and can drop tail examples to keep rank shapes even;
-make the validation set divisible by the data-parallel world size or run validation on one GPU when you need every
-candidate group included.
+metrics measure ranking within each candidate group in the validation file. They are not full-corpus Recall@K or nDCG
+metrics. For cross-encoder validation, use `model_type: cross_encoder` and `CrossEncoderCollator` instead. In
+multi-rank runs, validation uses the same distributed sampler path as training and can drop tail examples to keep rank
+shapes even. Make the validation set divisible by
+`data_parallel_size * validation_dataloader.batch_size` for comparable per-batch `val_loss`, or run validation on one
+GPU when you need every candidate group included.
 
 ```bash
 tail -n 5 ./output/llama3_2_1b_encoder/checkpoints/validation.jsonl
@@ -494,21 +510,23 @@ tail -n 5 ./output/llama3_2_1b_encoder/checkpoints/validation.jsonl
 
 ## Evaluate Retrieval Quality
 
-Candidate-group validation is a smoke test for the training objective. To decide whether a bi-encoder is useful for RAG
-candidate generation, evaluate against a fixed held-out corpus and qrels:
+Candidate-group validation is a basic verification of the training objective. To decide whether a bi-encoder is useful
+for RAG candidate generation, evaluate against a fixed held-out corpus and qrels:
 
 1. Encode corpus passages with the same tokenizer, pooling, normalization, passage prefix, and `p_max_len` used in
    training.
-2. Build an ANN or exact top-k index. With `l2_normalize: true`, use inner product or cosine similarity.
+2. Build an approximate nearest-neighbor (ANN) or exact top-k index. With `l2_normalize: true`, use inner product or
+   cosine similarity.
 3. Encode held-out queries with the matching query prefix and `q_max_len`.
 4. Report full-corpus Recall@K, MRR@K, and nDCG@K for the K values your application uses.
 
-AutoModel does not currently provide a one-command full-corpus retrieval evaluator in this guide. Use your existing IR
-evaluation stack or a small script around the consolidated checkpoint and report enough run details to make the result
-repeatable: query count, corpus size, qrels source, judged/unjudged handling, exact versus ANN search settings, K
-values, baseline checkpoint, and whether confidence intervals or significance tests were used. At minimum, make the
-script inputs explicit: a consolidated bi-encoder checkpoint, a corpus table with stable document IDs, a query table with
-stable query IDs, qrels keyed by those IDs, the query/passage prefixes and max lengths, and the K values to report.
+AutoModel does not currently provide a one-command full-corpus retrieval evaluator in this guide. Use your existing
+information retrieval evaluation stack or a small script around the consolidated checkpoint. Report enough run details
+to make the result repeatable: query count, corpus size, qrels source, judged and unjudged handling, exact versus ANN
+search settings, K values, baseline checkpoint, and whether you used confidence intervals or significance tests. At
+minimum, make these script inputs explicit: a consolidated bi-encoder checkpoint, a corpus table with stable document
+IDs, a query table with stable query IDs, qrels keyed by those IDs, the query and passage prefixes and maximum lengths,
+and the K values to report.
 
 For cross-encoders, freeze a first-stage retriever, rerank its top-K candidates, and report reranking metrics on that
 same candidate set. Also report first-stage candidate recall or coverage: if a query's positive document is missing
@@ -519,35 +537,28 @@ cross-encoder candidate-group validation directly to full-corpus bi-encoder metr
 
 Training metrics are written to `training.jsonl` under `checkpoint.checkpoint_dir`. The file logger buffers records in
 chunks before writing and flushes the remaining records on close, so `tail -f` is useful for completed or longer runs
-but may not update during a short smoke test:
+but may not update during a short basic verification test:
 
 ```bash
 tail -f ./output/llama3_2_1b_encoder/checkpoints/training.jsonl
 ```
 
-Use stdout/stderr as the live per-step signal today. Watch `loss`, `grad_norm`, learning rate, GPU memory, and step time
+Use standard output and error as the live per-step signals today. Watch `loss`, `grad_norm`, learning rate, GPU
+memory, and step time
 before scaling to a longer run. On preempted or timed-out jobs, recent buffered JSONL metrics may be missing even when
-stdout/stderr showed them.
+standard output and error showed them.
 
 The examples include a commented `wandb` block. Enable it when you want remote tracking, and tune
 `step_scheduler.log_remote_every_steps` to control remote logging cadence.
 
-## Enable LoRA
+## Enable Low-Rank Adaptation
 
-Retrieval recipes support the same PEFT block used by other AutoModel fine-tuning recipes. Uncomment or add `peft` to
-train LoRA adapters instead of updating every weight:
+Retrieval recipes support the same parameter-efficient fine-tuning (PEFT) block used by other AutoModel recipes.
+Uncomment or add `peft` to train low-rank adaptation (LoRA) adapters instead of updating every weight:
 
 ```yaml
 peft:
   _target_: nemo_automodel.components._peft.lora.PeftConfig
-  target_modules:
-    - q_proj
-    - k_proj
-    - v_proj
-    - o_proj
-    - gate_proj
-    - up_proj
-    - down_proj
   exclude_modules: []
   match_all_linear: true
   dim: 16
@@ -555,21 +566,33 @@ peft:
   use_triton: true
 ```
 
+Use either `match_all_linear: true` or an explicit `target_modules` list. Setting both selection modes raises a
+configuration error.
+
 Use LoRA when you need lower memory use or want to ship a small adapter. Use full fine-tuning when you can afford the
 memory and want maximum adaptation.
 
 ## Mine Hard Negatives
 
-After an initial bi-encoder run, mine harder negatives with the consolidated encoder checkpoint. Hard-negative mining
-expects the corpus ID-based retrieval JSON format described in the dataset guide, not the inline JSONL shortcut. The
-input must reference one corpus so the miner can build a passage embedding cache, retrieve candidates, and write mined
-negatives back to each query. The miner enforces that the file resolves to exactly one corpus, but it does not verify that
-every row's `corpus_id` matches that corpus or that `question_id` values are unique. Validate those invariants before
-mining. Duplicate question IDs overwrite one another in the miner's result lookup.
+After an initial bi-encoder run, use `examples/retrieval/data_utils/mine_hard_negatives.py` to retrieve confusing
+passages from a corpus. The miner accepts the corpus ID-based local JSON format described in
+[Retrieval Dataset](/datasets/retrieval-dataset). It does not accept inline JSONL or `hf://` sources directly. Mine one
+corpus-backed JSON file at a time.
 
-The bi-encoder quickstart uses `hf://` sources; the cross-encoder quickstart already uses local retrieval JSON paths. The
-miner currently reads a local corpus-backed retrieval JSON file instead of `hf://` URIs directly. For
-`nvidia/embed-nemotron-dataset-v1`, restore the maintained local layout with:
+The miner enforces that the input resolves to exactly one corpus, but it does not enforce every required data invariant.
+Validate these conditions before launch:
+
+- Every row's `corpus_id` must match the declared corpus.
+- Every `question_id` must be unique. Duplicate IDs overwrite entries in the miner's result lookup.
+- Use an absolute corpus path, or keep the output beside the input. Relative `corpus` paths are copied without being
+  rewritten when the output moves.
+- Make `train_file_output_path` different from `train_qa_file_path`, and make sure the output does not already exist.
+  The miner opens the output in write mode and overwrites an existing file without confirmation.
+- Keep lineage or custom metadata in a separate table. Mined rows are rebuilt from normalized retrieval fields, so
+  arbitrary row-level fields are not preserved.
+
+The bi-encoder and cross-encoder quickstarts use `hf://` sources. For `nvidia/embed-nemotron-dataset-v1`, restore the
+maintained local layout with:
 
 ```bash
 uv run python examples/retrieval/bi_encoder/llama_embed_nemotron_8b/data_preparation.py \
@@ -577,39 +600,35 @@ uv run python examples/retrieval/bi_encoder/llama_embed_nemotron_8b/data_prepara
 ```
 
 The script has no subset selector. It scans the repository and restores every discovered directory containing a
-`corpus.parquet`. For each discovered subset `<name>`, it writes
+`corpus.parquet`. For each subset `<name>`, it writes
 `./embed_nemotron_dataset_v1/<name>/<name>.json` and
-`./embed_nemotron_dataset_v1/<name>/corpus/train.parquet`; the JSON stores the corpus directory as an absolute path. For
-example, use `./embed_nemotron_dataset_v1/FEVER/FEVER.json` as the FEVER mining input. The maintained
-`examples/retrieval/bi_encoder/llama_embed_nemotron_8b/llama_embed_nemotron_8b.yaml` recipe consumes this same output
-layout through its `data_dir_list` entries.
+`./embed_nemotron_dataset_v1/<name>/corpus/train.parquet`. The JSON stores the corpus directory as an absolute path.
+For example, use `./embed_nemotron_dataset_v1/FEVER/FEVER.json` as the FEVER mining input. The maintained
+`examples/retrieval/bi_encoder/llama_embed_nemotron_8b/llama_embed_nemotron_8b.yaml` recipe consumes this same layout.
 
-Before launching the miner, load the resulting JSON with the retrieval dataset path or a short smoke run to verify the
-schema and document IDs. The `llama3_2_1b.yaml` quickstart trains from both `FEVER` and
-`SyntheticClassificationData`; the maintained Llama-Embed-Nemotron recipe lists all of its restored training subsets.
-For a full train -> mine -> retrain loop, mine each desired restored subset separately, give each mined output and
-embedding cache its own run-specific path, then list all mined JSON files in the next config's `data_dir_list`. Replacing
-a multi-source config with only one mined file intentionally trains on that subset only.
+Before mining, load the resulting JSON through the retrieval dataset path or run a basic verification test to confirm
+the schema and document IDs. The Llama 3.2 quickstarts train from both `FEVER` and `SyntheticClassificationData`. For a
+complete train, mine, and retrain workflow, mine each desired subset separately. Give each output and embedding cache a
+run-specific path, then list all mined JSON files in the next config's `data_dir_list`.
 
-This single-node example uses `--standalone`:
+Because of the Llama 3.2 export limitation described in [Workflow Overview](#workflow-overview), the following command
+uses a compatible Hugging Face bi-encoder checkpoint:
 
 ```bash
-uv run torchrun --standalone --nproc_per_node=8 examples/retrieval/data_utils/mine_hard_negatives.py \
+uv run torchrun --standalone --nproc-per-node 8 examples/retrieval/data_utils/mine_hard_negatives.py \
   --config examples/retrieval/data_utils/mining_config.yaml \
-  --mining.model_name_or_path ./output/llama3_2_1b_encoder/checkpoints/epoch_0_step_499/model/consolidated \
+  --mining.model_name_or_path /path/to/compatible-hf-bi-encoder \
   --mining.train_qa_file_path ./embed_nemotron_dataset_v1/FEVER/FEVER.json \
   --mining.train_file_output_path /path/to/retrieval-data/mined/FEVER/train.json \
-  --mining.cache_embeddings_dir /shared/path/to/cache/llama3_2_1b_fever_mine_v1 \
+  --mining.cache_embeddings_dir /shared/path/to/empty-cache/fever-run-001 \
   --mining.query_prefix "query: " \
   --mining.passage_prefix "passage: " \
   --mining.query_max_length 512 \
-  --mining.passage_max_length 512 \
-  --mining.add_eos_token false
+  --mining.passage_max_length 512
 ```
 
-For multi-node mining, replace `--standalone` with the same explicit rendezvous flags you use for multi-node training.
-Every rank must be able to read `model_name_or_path`, `tokenizer_name_or_path` if set, `train_qa_file_path`, and the
-corpus path referenced by that JSON at the same filesystem paths:
+For multi-node mining, replace `--standalone` with explicit rendezvous flags. Every rank must see the model, tokenizer,
+input JSON, referenced corpus, and shared cache at the same paths:
 
 ```bash
 uv run torchrun \
@@ -620,89 +639,64 @@ uv run torchrun \
   --rdzv-endpoint ${MASTER_ADDR}:${MASTER_PORT} \
   examples/retrieval/data_utils/mine_hard_negatives.py \
   --config examples/retrieval/data_utils/mining_config.yaml \
-  --mining.model_name_or_path ./output/llama3_2_1b_encoder/checkpoints/epoch_0_step_499/model/consolidated \
+  --mining.model_name_or_path /path/to/compatible-hf-bi-encoder \
   --mining.train_qa_file_path ./embed_nemotron_dataset_v1/FEVER/FEVER.json \
   --mining.train_file_output_path /path/to/retrieval-data/mined/FEVER/train.json \
-  --mining.cache_embeddings_dir /shared/path/to/cache/llama3_2_1b_fever_mine_v1 \
+  --mining.cache_embeddings_dir /shared/path/to/empty-cache/fever-run-001 \
   --mining.query_prefix "query: " \
   --mining.passage_prefix "passage: " \
   --mining.query_max_length 512 \
-  --mining.passage_max_length 512 \
-  --mining.add_eos_token false
+  --mining.passage_max_length 512
 ```
 
-Replace `epoch_0_step_499` with the explicit checkpoint directory that you want to mine from. If you only have
-`LATEST.txt`, read it first and substitute the resolved `epoch_*_step_*` directory; the mining script loads the
-Hugging Face export directly and does not apply AutoModel's checkpoint resolver. The miner creates the output parent
-directory and opens `train_file_output_path` with write mode, so an existing file is replaced without prompting. It has no
-`overwrite_output` setting. Use a new run-specific output path and check that it does not exist before launch. The miner
-preserves the input's top-level `corpus` value without rewriting relative paths; if the output JSON moves to a different
-directory, use an absolute corpus path or arrange the output directory so the unchanged relative path still resolves.
+The mining script loads a concrete Hugging Face model path. It does not resolve AutoModel's `LATEST` keyword or pointer
+files. It creates the output parent directory and overwrites `train_file_output_path` if that file already exists. The
+miner preserves the input's top-level `corpus` value without rewriting relative paths.
 
-Key mining settings accepted by the recipe (the checked-in
-`examples/retrieval/data_utils/mining_config.yaml` supplies defaults for most of them):
+Match these mining settings to training:
 
-- `hard_negatives_to_mine`: maximum number of mined negatives to add per query. The miner can return fewer when the corpus
-  has too few non-positive candidates. Margin-filtered candidates are down-scored to `-inf` but can still appear in the
-  top-k result when too few finite candidates remain, so inspect scores and per-query counts before training.
-- `hard_neg_margin` and `hard_neg_margin_type`: filter near-positive candidates. With `hard_neg_margin_type: perc`,
-  candidates scoring above `min_positive_score * hard_neg_margin` are set to `-inf`; with `abs`, candidates scoring
-  above `min_positive_score - hard_neg_margin` are set to `-inf`. Inspect mined samples when positive scores are low or
-  negative.
-- `query_prefix` and `passage_prefix`: keep these semantically consistent with the bi-encoder training config. The
-  miner concatenates prefixes directly, while `BiEncoderCollator` inserts a space after non-empty prefixes; include the
-  trailing space in mining prefixes. The miner supports static prefixes only. If training used
-  `use_dataset_instruction: true`, materialize the same instruction text into the mining input or equivalent static
-  prefixes before mining.
-- `query_max_length` and `passage_max_length`: keep these consistent with training unless you intentionally change
-  truncation.
-- `add_bos_token` and `add_eos_token`: match the tokenizer behavior used during training. If omitted, mining falls back
-  to tokenizer defaults, which can differ from the training config.
-- `use_negatives_from_file`: include existing negatives from the input file when mining. Existing negatives are prepended
-  to the output and mined negatives are appended, so deduplicate and audit the output before using it for training.
-- `attn_implementation`: optional model-loading escape hatch for mining exports that need `sdpa`, `eager`, or
-  `flash_attention_2` pinned.
-- `cache_embeddings_dir`: required for distributed mining so ranks can share cached passage embeddings. Rank `0`
-  assembles the final embedding cache and score outputs, so plan memory and local disk accordingly. In multi-node
-  mining, this must be a shared writable path mounted at the same location on every node; node-local cache paths leave
-  rank `0` unable to read remote-rank shards.
-- Cache reuse: use a new empty cache directory for every model, mining input, prefix, sequence length,
-  `corpus_chunk_size`, and world-size combination. Query shards and corpus chunks are reused when their expected filenames
-  already exist, even when `load_embeddings_from_cache` is `false`. The miner validates rank-shard row counts during
-  assembly, but it does not store or compare a fingerprint for the model, input rows, corpus content, or embedding
-  settings.
-- `load_embeddings_from_cache`: when `true`, rank `0` reuses consolidated `query_embeddings.npz` and
-  `passage_embeddings.npz` if both files exist. The miner loads the first array from each archive without checking it
-  against the current input or configuration. Set this only for an unchanged run, and prefer a new cache path whenever
-  any input or setting changed.
+- Set `query_prefix` and `passage_prefix` to the same text used for training. Include the trailing space in mining
+  prefixes because the miner concatenates prefixes directly, while `BiEncoderCollator` inserts the space.
+- Match `query_max_length`, `passage_max_length`, `add_bos_token`, and `add_eos_token` to the training tokenizer and
+  truncation behavior.
+- Set `use_negatives_from_file` when you want to keep existing negatives before appending mined negatives. Deduplicate
+  and audit the combined list.
 
-`pooling` and `l2_normalize` are not `mining.*` config fields. Unknown mining keys are ignored rather than applied, so do
-not pass `--mining.pooling` or `--mining.l2_normalize`. The current miner calls
-`NeMoAutoModelBiEncoder.from_pretrained` without those arguments and therefore uses the wrapper defaults (`avg` and
-`true`). Use this helper only when those settings match training. For other settings, use a custom mining workflow that
-loads the encoder with the required wrapper arguments; AutoModel does not ship a metadata-retrofit exporter.
+The miner does not accept `pooling` or `l2_normalize` settings. It uses the bi-encoder wrapper defaults of `avg`
+pooling and L2 normalization. Use this helper only when those settings match training. For other settings, use a custom
+mining workflow that loads the encoder with the required wrapper arguments.
 
-Hard-negative mining parallelizes embedding generation across ranks, but the final exact scoring step still runs on
-rank `0` and materializes the full document embedding matrix there. For very large corpora, use a smaller mining slice
-or a custom ANN/blockwise mining workflow instead of expecting this helper to scale to web-scale indexing.
+Use a new, empty `cache_embeddings_dir` for every model, input, prefix, sequence length, `corpus_chunk_size`, and world
+size. The miner reuses expected shard files even when `load_embeddings_from_cache` is `false`, and it does not record
+a fingerprint for the model, data, or embedding settings. Set `load_embeddings_from_cache: true` only when rerunning an
+unchanged job with both consolidated embedding archives present.
 
-Use the mined output as the next corpus-backed `data_dir_list` source for another bi-encoder pass or for cross-encoder training. If
-the previous run used multiple sources, list the mined file for each source. Hard negative mining excludes document IDs
-listed in each input row's `pos_doc`, but it cannot read an external qrels file or know every semantically relevant
-duplicate. Put all known positive IDs for the query in the mining input, deduplicate the corpus, inspect mined samples,
-filter duplicate IDs and non-finite scores such as `-inf` from mined outputs, and avoid mining from validation or test
-corpora. If you unroll multi-positive training data, mine from rows that still carry every known positive in `pos_doc`;
-otherwise sibling positives can be mined as false negatives. The miner rebuilds each row from the normalized retrieval
-fields, refreshes `neg_doc` and positive-document scores, and drops extra row-level metadata such as
+`hard_negatives_to_mine` sets the maximum number of mined negatives per query. The miner can return fewer when the
+corpus has too few non-positive candidates. Margin filtering can leave `-inf` entries in the top results when too few
+finite candidates remain. Inspect the scores and per-query counts before training. The checked-in
+`examples/retrieval/data_utils/mining_config.yaml` documents the remaining mining defaults.
+
+Hard-negative mining distributes embedding generation, but rank `0` assembles the cache, performs final exact scoring,
+and materializes the full document embedding matrix. Use a smaller mining slice or a custom ANN or blockwise workflow
+for very large corpora.
+
+Use the mined output as a corpus-backed `data_dir_list` source for another bi-encoder pass or for cross-encoder
+training. If the previous run used multiple sources, list each mined source file. The miner excludes IDs in `pos_doc`,
+but it cannot read external qrels or identify semantic duplicates. It also drops extra row metadata such as
 `original_question_id`.
 
-AutoModel does not ship a mined-negative audit or cleanup utility. Before using the output for training, validate it with
-your own data-quality tooling. At minimum, require unique question and corpus document IDs, confirm every row references
-the single declared corpus, check that positive and negative IDs exist, reject positive/negative overlap and duplicate
-negative IDs, reject missing or non-finite scores, and require enough distinct negatives for the next config's
-`n_passages`. Keep any query-lineage mapping outside the mined JSON because the miner does not preserve extra row fields.
+AutoModel does not provide a mined-negative audit or cleanup utility. Before training, verify the output:
 
-## Save, Resume, and Use the Checkpoint
+1. Every question ID is unique, every row references the declared corpus, and every document ID exists.
+2. No known positive or sibling positive appears in `neg_doc`.
+3. Negative IDs are unique within each row.
+4. Positive and negative scores are present and finite. Remove entries with scores such as `-inf`.
+5. Each row has enough distinct negatives for the next run's `n_passages`.
+6. The corpus path resolves from the mined file, and required lineage metadata is joined back explicitly.
+
+Do not mine from validation or test corpora. Retain the original qrels for full-corpus evaluation.
+
+## Save and Resume from a Checkpoint
 
 Set checkpointing in the config:
 
@@ -736,10 +730,9 @@ symlink, read that file and substitute the resolved checkpoint directory before 
 `mine_hard_negatives.py`.
 
 PEFT/LoRA runs save adapter artifacts under the checkpoint `model/` directory instead of the full consolidated export
-path above. Resume LoRA training from the AutoModel checkpoint directory, but use full fine-tuning when you need the
-`model/consolidated` path for the mining command shown in this guide. If you need mining or serving from LoRA weights,
-first produce a HF-loadable merged/exported encoder with your adapter workflow and point
-`--mining.model_name_or_path` at that exported directory.
+path above. Resume LoRA training from the AutoModel checkpoint directory. If you need a standalone checkpoint for
+inference, first produce a Hugging Face-loadable merged encoder with your adapter workflow. The current mining
+limitation for consolidated Llama retrieval exports still applies to that model path.
 
 The `LATEST` symlink points to the most recent checkpoint when it is valid. To resume from the latest resolved
 checkpoint, set:
@@ -751,11 +744,13 @@ checkpoint:
   restore_from: LATEST
 ```
 
-`LATEST` is a resolver keyword: AutoModel follows the symlink or pointer file and can fall back to scanning
-`epoch_*_step_*` checkpoint directories if the pointer is not usable. An explicit `epoch_*_step_*` path is the exact
-restore target. If `checkpoint.restore_from` is omitted, AutoModel auto-detects the latest compatible checkpoint in
-`checkpoint_dir` and resumes from it. Use a new or empty `checkpoint_dir` for fresh experiments, and rotate or clear
-`training.jsonl` and `validation.jsonl` if you do not want logs from multiple runs appended together.
+`LATEST` is a resolver keyword: AutoModel follows the symlink or pointer file and can fall back to the highest
+`epoch_*_step_*` checkpoint directory if the pointer is not usable. An explicit restore target, including `LATEST`,
+is authoritative: AutoModel warns about an incompatibility but still restores the selected checkpoint. If
+`checkpoint.restore_from` is omitted, AutoModel selects the latest candidate and resumes only when that candidate is
+compatible. It does not continue scanning older checkpoints when the newest candidate is incompatible. Use a new or
+empty `checkpoint_dir` for fresh experiments, and rotate or clear `training.jsonl` and `validation.jsonl` if you do
+not want logs from multiple runs appended together.
 
 When `checkpoint.is_async: true`, the `LATEST` symlink can lag the most recent write at job end. For final mining,
 export, or evaluation workflows, prefer the explicit `epoch_*_step_*` checkpoint directory or keep async checkpointing
@@ -764,9 +759,16 @@ disabled for the final save.
 ## Use the Model
 
 Use a bi-encoder checkpoint to encode passages, build an approximate nearest-neighbor index, encode queries, and search
-the index. Keep the same tokenizer, pooling, normalization, prefixes, and max lengths that you used for training.
+the index. Keep the same tokenizer, pooling, normalization, prefixes, and max lengths that you used for training. These
+retrieval wrappers instantiate the model on the current CUDA device, so the examples require CUDA.
 
-Minimal bi-encoder loading and scoring sketch:
+<Warning>
+Set `trust_remote_code=True` only for a local export that you created or otherwise trust. The consolidated Llama
+checkpoint references its exported configuration and model code through Hugging Face `auto_map`. Pass wrapper-only
+settings explicitly when they differ from the defaults because the current export does not preserve all of them.
+</Warning>
+
+The following example loads a bi-encoder and computes one similarity score:
 
 ```python
 import torch
@@ -775,7 +777,13 @@ from nemo_automodel import NeMoAutoModelBiEncoder, NeMoAutoTokenizer
 
 model_path = "./output/llama3_2_1b_encoder/checkpoints/epoch_0_step_499/model/consolidated"
 tokenizer = NeMoAutoTokenizer.from_pretrained(model_path, add_eos_token=False)
-model = NeMoAutoModelBiEncoder.from_pretrained(model_path, use_liger_kernel=False).eval()
+model = NeMoAutoModelBiEncoder.from_pretrained(
+    model_path,
+    pooling="avg",
+    l2_normalize=True,
+    trust_remote_code=True,
+    use_liger_kernel=False,
+).eval()
 device = next(model.parameters()).device
 
 texts = ["query: what does nvlink do?", "passage: NVLink is a high-bandwidth GPU interconnect."]
@@ -788,10 +796,12 @@ with torch.no_grad():
 score = embeddings[0] @ embeddings[1]
 ```
 
+The example produces one scalar tensor named `score`. Its value depends on the fine-tuned checkpoint.
+
 Use a cross-encoder checkpoint to rerank a shortlist from a retriever. Cross-encoders score each query-passage pair
 jointly, so they are usually too expensive for first-stage full-corpus search.
 
-Minimal cross-encoder scoring sketch:
+The following example loads a cross-encoder and ranks two passages:
 
 ```python
 import torch
@@ -800,7 +810,14 @@ from nemo_automodel import NeMoAutoModelCrossEncoder, NeMoAutoTokenizer
 
 model_path = "./output/llama3_2_1b_cross_encoder/checkpoints/epoch_0_step_499/model/consolidated"
 tokenizer = NeMoAutoTokenizer.from_pretrained(model_path, add_eos_token=False)
-model = NeMoAutoModelCrossEncoder.from_pretrained(model_path, use_liger_kernel=False).eval()
+model = NeMoAutoModelCrossEncoder.from_pretrained(
+    model_path,
+    pooling="avg",
+    num_labels=1,
+    temperature=1.0,
+    trust_remote_code=True,
+    use_liger_kernel=False,
+).eval()
 device = next(model.parameters()).device
 
 prompt_template = "question:{query} \n \n passage:{passage}"
@@ -817,27 +834,33 @@ with torch.no_grad():
 ranking = torch.argsort(logits, descending=True)
 ```
 
+For a checkpoint that learned the reranking task, `ranking[0]` is expected to be `0`.
+
 Bi-encoder scores are comparable only within the same model, tokenizer, prefix, max-length, pooling, normalization, and
 indexing setup. Mining scores are raw embedding similarities from that exact setup. Cross-encoder logits are
-uncalibrated reranking signals; do not mix them with bi-encoder scores or use one global threshold across model
+uncalibrated reranking signals. Do not mix them with bi-encoder scores or use one global threshold across model
 versions without calibration.
 
 ## Troubleshooting
+
+Use the following checks to diagnose common retrieval training problems:
 
 | Symptom | Check |
 |---------|-------|
 | Training fails with empty negatives | Ensure every record has `neg_doc` when `n_passages > 1`. |
 | Dataset records fail to load | Check the supported schemas in [Retrieval Dataset](/datasets/retrieval-dataset). |
 | Loss does not move | Verify the positive passage is first and negatives are not duplicates of the positive. |
-| Poor retrieval quality | Mine harder negatives and align train/inference prefixes. |
-| OOM at startup or first batch | Lower `local_batch_size`, `q_max_len`, `p_max_len`, or `rerank_max_length`; use LoRA for larger backbones. |
+| Poor retrieval quality | Mine harder negatives and align training and inference prefixes. |
+| Out of memory (OOM) at startup or first batch | Lower `local_batch_size`, `q_max_len`, `p_max_len`, or `rerank_max_length`. Use LoRA for larger backbones. |
 | Distributed launch times out | Increase `dist_env.timeout_minutes`, especially for first model downloads, slow filesystems, or multi-node runs. |
 | Batch-size assertion fails | Set `global_batch_size` to a multiple of `local_batch_size * data_parallel_size`. |
-| `training.jsonl` does not update during a smoke test | Use stdout/stderr for live monitoring; JSONL metrics are buffered before flush. |
-| Run resumes unexpectedly | Use a new or empty `checkpoint_dir`; AutoModel auto-detects compatible checkpoints when `restore_from` is omitted. |
+| `training.jsonl` does not update during a basic verification test | Use standard output and error for live monitoring. JSONL metrics are buffered before flush. |
+| Run resumes unexpectedly | Use a new or empty `checkpoint_dir`. AutoModel auto-detects compatible checkpoints when `restore_from` is omitted. |
 | Different mining and training behavior | Match tokenizer settings, max lengths, and prefix text including trailing spaces across training and mining. |
 
 ## Related Files
+
+Refer to the following files for implementation and configuration details:
 
 - Bi-encoder recipe:
   [nemo_automodel/recipes/retrieval/train_bi_encoder.py](https://github.com/NVIDIA-NeMo/Automodel/blob/main/nemo_automodel/recipes/retrieval/train_bi_encoder.py)

--- a/docs/guides/llm/retrieval-finetune.mdx
+++ b/docs/guides/llm/retrieval-finetune.mdx
@@ -155,7 +155,7 @@ matches the workflow you need:
 | Data path | Use when | Notes |
 |-----------|----------|-------|
 | `hf://` AutoModel retrieval schema | You want a tutorial run or shared public dataset | Requires an AutoModel-style HF subset with a companion corpus split. |
-| Inline JSONL | You want a small custom run without hard-negative mining | Documents are embedded directly in each record. The loader derives identifiers from document values, but they are not stable corpus IDs. |
+| Inline JSONL | You want a small custom run without hard-negative mining | Documents are embedded directly in each record. Pure inline records do not provide document IDs for same-document masking. |
 | Corpus ID-based JSON | You need hard-negative mining, reusable corpora, or same-document masking | Records reference document IDs in a local corpus that can be loaded by Hugging Face `datasets`. |
 
 The key field requirements differ by source:
@@ -360,9 +360,9 @@ The following settings control bi-encoder behavior:
   additional negatives. Enable it with `model.do_distributed_inbatch_negative: true` or the CLI override
   `--model.do_distributed_inbatch_negative true`. Today it all-gathers over the default process group, so use it only
   for data-parallel FSDP2 retrieval runs (`tp_size: 1`, `cp_size: 1`). Reliable same-document masking requires stable
-  `doc_id` fields from corpus-backed or custom datasets. Inline JSONL derives identifiers from document values, so it can
-  mask exact duplicate inline records but does not provide stable corpus document identity. The collator hashes raw
-  document IDs across the full batch, so make IDs globally unique when a run combines multiple corpora. For
+  `doc_id` fields from corpus-backed or custom datasets. Pure inline JSONL produces empty IDs, and the collator omits
+  same-document masking if any document ID in the batch is missing or incomplete. The collator hashes raw document IDs
+  across the full batch, so make IDs globally unique when a run combines multiple corpora. For
   multi-positive queries expanded into separate rows, keep distributed in-batch negatives disabled unless your sampler
   or masking prevents sibling positives from becoming negatives.
 

--- a/docs/guides/llm/retrieval-finetune.mdx
+++ b/docs/guides/llm/retrieval-finetune.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Retrieval Fine-Tuning (Bi-Encoder and Cross-Encoder)"
-description: "Fine-tune bi-encoder and cross-encoder retrieval models in NeMo AutoModel with distributed training, low-rank adaptation, hard-negative mining, and evaluation."
+description: "Fine-tune bi-encoder and cross-encoder retrieval models in NeMo AutoModel with distributed training, low-rank adaptation (LoRA), hard-negative mining, and evaluation."
 ---
 
 ## Introduction
@@ -155,7 +155,7 @@ matches the workflow you need:
 | Data path | Use when | Notes |
 |-----------|----------|-------|
 | `hf://` AutoModel retrieval schema | You want a tutorial run or shared public dataset | Requires an AutoModel-style HF subset with a companion corpus split. |
-| Inline JSONL | You want a small custom run without hard-negative mining | Documents are embedded directly in each record. No document IDs are available for same-document masking. |
+| Inline JSONL | You want a small custom run without hard-negative mining | Documents are embedded directly in each record. The loader derives identifiers from document values, but they are not stable corpus IDs. |
 | Corpus ID-based JSON | You need hard-negative mining, reusable corpora, or same-document masking | Records reference document IDs in a local corpus that can be loaded by Hugging Face `datasets`. |
 
 The key field requirements differ by source:
@@ -332,7 +332,6 @@ dataset:
   data_type: train
   n_passages: 5
   seed: 42
-  do_shuffle: true
 
 dataloader:
   collate_fn:
@@ -360,8 +359,9 @@ The following settings control bi-encoder behavior:
 - `do_distributed_inbatch_negative`: optional model setting that treats passages from other data-parallel ranks as
   additional negatives. Enable it with `model.do_distributed_inbatch_negative: true` or the CLI override
   `--model.do_distributed_inbatch_negative true`. Today it all-gathers over the default process group, so use it only
-  for data-parallel FSDP2 retrieval runs (`tp_size: 1`, `cp_size: 1`). Same-document masking requires `doc_id` fields from
-  corpus-backed or custom datasets. Inline JSONL does not provide duplicate-document masking. The collator hashes raw
+  for data-parallel FSDP2 retrieval runs (`tp_size: 1`, `cp_size: 1`). Reliable same-document masking requires stable
+  `doc_id` fields from corpus-backed or custom datasets. Inline JSONL derives identifiers from document values, so it can
+  mask exact duplicate inline records but does not provide stable corpus document identity. The collator hashes raw
   document IDs across the full batch, so make IDs globally unique when a run combines multiple corpora. For
   multi-positive queries expanded into separate rows, keep distributed in-batch negatives disabled unless your sampler
   or masking prevents sibling positives from becoming negatives.
@@ -400,7 +400,6 @@ dataset:
   data_type: train
   n_passages: 5
   seed: 42
-  do_shuffle: true
 
 dataloader:
   collate_fn:
@@ -550,7 +549,7 @@ standard output and error showed them.
 The examples include a commented `wandb` block. Enable it when you want remote tracking, and tune
 `step_scheduler.log_remote_every_steps` to control remote logging cadence.
 
-## Enable Low-Rank Adaptation
+## Enable Low-Rank Adaptation (LoRA)
 
 Retrieval recipes support the same parameter-efficient fine-tuning (PEFT) block used by other AutoModel recipes.
 Uncomment or add `peft` to train low-rank adaptation (LoRA) adapters instead of updating every weight:
@@ -558,8 +557,16 @@ Uncomment or add `peft` to train low-rank adaptation (LoRA) adapters instead of 
 ```yaml
 peft:
   _target_: nemo_automodel.components._peft.lora.PeftConfig
+  target_modules:
+    - q_proj
+    - k_proj
+    - v_proj
+    - o_proj
+    - gate_proj
+    - up_proj
+    - down_proj
   exclude_modules: []
-  match_all_linear: true
+  match_all_linear: false
   dim: 16
   alpha: 32
   use_triton: true

--- a/docs/guides/llm/retrieval-finetune.mdx
+++ b/docs/guides/llm/retrieval-finetune.mdx
@@ -175,8 +175,8 @@ The standard bi-encoder and cross-encoder recipes need at least one negative can
 reranking supervision, unless you add a custom strategy such as qrels-aware in-batch negatives.
 </Warning>
 
-For quick custom experiments, inline JSONL is the simplest format. Use the inline dataset factory for these files, and
-switch to corpus ID-based JSON before hard-negative mining or full-corpus evaluation:
+For quick custom experiments, inline JSONL is the simplest format. `RetrievalDatasetConfig` selects the inline loading
+path from the `.jsonl` extension. Switch to corpus ID-based JSON before hard-negative mining or full-corpus evaluation:
 
 ```json
 {"query":"What does NVLink do?","pos_doc":"NVLink is a high-bandwidth GPU interconnect.","neg_doc":["CUDA is a programming model.","Tensor Cores accelerate matrix math."]}
@@ -190,8 +190,8 @@ row uses only the first positive. Otherwise, in-batch negatives and mined hard n
 relevant passage as a negative. The detailed source schemas and conversion rules are in
 [Retrieval Dataset](/datasets/retrieval-dataset).
 
-For larger corpora, use the corpus ID-based JSON format from the dataset guide. Use
-`nemo_automodel.components.datasets.llm.make_retrieval_dataset` for corpus ID-based JSON and for `hf://` sources that
+For larger corpora, use the corpus ID-based JSON format from the dataset guide. The same
+`nemo_automodel.components.datasets.llm.retrieval_dataset.RetrievalDatasetConfig` also loads `hf://` sources that
 already follow the AutoModel retrieval schema, such as:
 
 ```yaml
@@ -201,10 +201,10 @@ data_dir_list:
 ```
 
 `n_passages` controls the size of each query group. For example, `n_passages: 5` means one positive and four negatives.
-Corpus-backed JSON and `hf://` sources use `pos_doc[0]` by default. Set `cycle_positive_docs: true` to rotate the
-supervised positive across epochs when a row has multiple positives. Inline JSONL always uses the first positive.
-Negatives are taken from `neg_doc` in order. If a record has fewer negatives than requested, they are repeated
-cyclically to fill the group. Treat repetition as a fallback for shape compatibility. Prefer enough distinct negatives.
+All supported sources use `pos_doc[0]` by default. Set `cycle_positive_docs: true` to rotate the supervised positive
+across epochs when a record has multiple positives. Negatives are taken from `neg_doc` in order. If a record has fewer
+negatives than requested, they are repeated cyclically to fill the group. Treat repetition as a fallback for shape
+compatibility. Prefer enough distinct negatives.
 
 The training recipe does not load a separate qrels file. Materialize qrels into retrieval records before fine-tuning.
 For mining, keep every known positive for the query in `pos_doc` so the miner can exclude those IDs. It does not read an
@@ -468,9 +468,8 @@ Hugging Face data on each node or use a shared cache, and budget CPU RAM and loc
 ## Add Validation
 
 Both examples include commented `validation_dataset` and `validation_dataloader` blocks. Enable them when you have a
-held-out retrieval file. Use the same dataset family as the validation source: `RetrievalDatasetConfig` for `hf://` or
-corpus ID-based JSON, and `InlineRetrievalDatasetConfig` only for inline JSONL. This corpus-backed example mirrors the
-shipped configs:
+held-out retrieval file. Use `RetrievalDatasetConfig` for every supported source; it selects the loading path from the
+source URI and file extension. This corpus-backed example mirrors the shipped configs:
 
 ```yaml
 validation_dataset:

--- a/docs/guides/llm/retrieval-finetune.mdx
+++ b/docs/guides/llm/retrieval-finetune.mdx
@@ -30,13 +30,6 @@ Prepare retrieval data
   -> Use the consolidated checkpoint for indexing, mining, reranking, or serving
 ```
 
-<Warning>
-The Llama 3.2 quickstart checkpoint cannot currently be used with the built-in hard-negative mining script. Its
-consolidated export requires `trust_remote_code=True`, and the mining CLI does not expose that option. You can complete
-the training and evaluation steps with the quickstart, but use a compatible Hugging Face bi-encoder checkpoint for the
-mining step.
-</Warning>
-
 Start with a bi-encoder when you need embeddings for approximate nearest-neighbor search. Add hard-negative mining after
 the first pass if the model mostly sees easy negatives. Train a cross-encoder when a separate retriever already produces
 a small candidate set and you want a stronger reranking stage.
@@ -617,13 +610,12 @@ the schema and document IDs. The Llama 3.2 quickstarts train from both `FEVER` a
 complete train, mine, and retrain workflow, mine each desired subset separately. Give each output and embedding cache a
 run-specific path, then list all mined JSON files in the next config's `data_dir_list`.
 
-Because of the Llama 3.2 export limitation described in [Workflow Overview](#workflow-overview), the following command
-uses a compatible Hugging Face bi-encoder checkpoint:
+The mining script can load the consolidated checkpoint from the Llama 3.2 quickstart:
 
 ```bash
 uv run torchrun --standalone --nproc-per-node 8 examples/retrieval/data_utils/mine_hard_negatives.py \
   --config examples/retrieval/data_utils/mining_config.yaml \
-  --mining.model_name_or_path /path/to/compatible-hf-bi-encoder \
+  --mining.model_name_or_path ./output/llama3_2_1b_encoder/checkpoints/epoch_0_step_499/model/consolidated/ \
   --mining.train_qa_file_path ./embed_nemotron_dataset_v1/FEVER/FEVER.json \
   --mining.train_file_output_path /path/to/retrieval-data/mined/FEVER/train.json \
   --mining.cache_embeddings_dir /shared/path/to/empty-cache/fever-run-001 \
@@ -737,8 +729,7 @@ symlink, read that file and substitute the resolved checkpoint directory before 
 
 PEFT/LoRA runs save adapter artifacts under the checkpoint `model/` directory instead of the full consolidated export
 path above. Resume LoRA training from the AutoModel checkpoint directory. If you need a standalone checkpoint for
-inference, first produce a Hugging Face-loadable merged encoder with your adapter workflow. The current mining
-limitation for consolidated Llama retrieval exports still applies to that model path.
+inference or mining, first produce a Hugging Face-loadable merged encoder with your adapter workflow.
 
 The `LATEST` symlink points to the most recent checkpoint when it is valid. To resume from the latest resolved
 checkpoint, set:
@@ -768,11 +759,8 @@ Use a bi-encoder checkpoint to encode passages, build an approximate nearest-nei
 the index. Keep the same tokenizer, pooling, normalization, prefixes, and max lengths that you used for training. These
 retrieval wrappers instantiate the model on the current CUDA device, so the examples require CUDA.
 
-<Warning>
-Set `trust_remote_code=True` only for a local export that you created or otherwise trust. The consolidated Llama
-checkpoint references its exported configuration and model code through Hugging Face `auto_map`. Pass wrapper-only
-settings explicitly when they differ from the defaults because the current export does not preserve all of them.
-</Warning>
+Pass wrapper-only settings explicitly when they differ from the defaults because the current export does not preserve
+all of them.
 
 The following example loads a bi-encoder and computes one similarity score:
 
@@ -787,7 +775,6 @@ model = NeMoAutoModelBiEncoder.from_pretrained(
     model_path,
     pooling="avg",
     l2_normalize=True,
-    trust_remote_code=True,
     use_liger_kernel=False,
 ).eval()
 device = next(model.parameters()).device
@@ -821,7 +808,6 @@ model = NeMoAutoModelCrossEncoder.from_pretrained(
     pooling="avg",
     num_labels=1,
     temperature=1.0,
-    trust_remote_code=True,
     use_liger_kernel=False,
 ).eval()
 device = next(model.parameters()).device

--- a/examples/retrieval/bi_encoder/llama3_2_1b.yaml
+++ b/examples/retrieval/bi_encoder/llama3_2_1b.yaml
@@ -59,7 +59,6 @@ dataset:
   data_type: train
   n_passages: 5
   seed: 42
-  do_shuffle: true
 
 dataloader:
   collate_fn:
@@ -80,9 +79,6 @@ dataloader:
 #   data_type: eval
 #   n_passages: 5
 #   seed: 42
-#   do_shuffle: false
-#   max_train_samples: 1000
-#   train_data_select_offset: 0
 #
 # validation_dataloader:
 #   collate_fn:
@@ -110,7 +106,7 @@ dataloader:
 #     - up_proj
 #     - down_proj
 #   exclude_modules: []
-#   match_all_linear: True
+#   match_all_linear: false
 #   dim: 16
 #   alpha: 32
 #   use_triton: true

--- a/examples/retrieval/bi_encoder/llama3_2_1b.yaml
+++ b/examples/retrieval/bi_encoder/llama3_2_1b.yaml
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To run this recipe:
+# From a source checkout, use uv to run with the project dependencies:
+#   uv run automodel examples/retrieval/bi_encoder/llama3_2_1b.yaml --nproc-per-node 8
+# In the NeMo AutoModel container or another environment with dependencies already installed:
 #   automodel examples/retrieval/bi_encoder/llama3_2_1b.yaml --nproc-per-node 8
 # Adjust --nproc-per-node to the number of GPUs available on your machine.
 
@@ -31,7 +33,7 @@ step_scheduler:
 
 dist_env:
   backend: nccl
-  timeout_minutes: 1
+  timeout_minutes: 30
 
 model:
   _target_: nemo_automodel.NeMoAutoModelBiEncoder.from_pretrained

--- a/examples/retrieval/cross_encoder/llama3_2_1b.yaml
+++ b/examples/retrieval/cross_encoder/llama3_2_1b.yaml
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To run this recipe:
+# From a source checkout, use uv to run with the project dependencies:
+#   uv run automodel examples/retrieval/cross_encoder/llama3_2_1b.yaml --nproc-per-node 8
+# In the NeMo AutoModel container or another environment with dependencies already installed:
 #   automodel examples/retrieval/cross_encoder/llama3_2_1b.yaml --nproc-per-node 8
 # Adjust --nproc-per-node to the number of GPUs available on your machine.
 
@@ -29,7 +31,7 @@ step_scheduler:
 
 dist_env:
   backend: nccl
-  timeout_minutes: 1
+  timeout_minutes: 30
 
 model:
   _target_: nemo_automodel.NeMoAutoModelCrossEncoder.from_pretrained
@@ -50,9 +52,8 @@ dataset:
   _target_: nemo_automodel.components.datasets.llm.retrieval_dataset.RetrievalDatasetConfig
   model_type: cross_encoder
   data_dir_list:
-    - retriever_models_research/training_datasets/nqsh_shuffled_50k.json
-    - retriever_models_research/training_datasets/mldr_en_perc95_small.json
-    - retriever_models_research/training_datasets/miracl_train_es_llama3_1b_4m_512len.json
+    - hf://nvidia/embed-nemotron-dataset-v1/FEVER
+    - hf://nvidia/embed-nemotron-dataset-v1/SyntheticClassificationData
   data_type: train
   n_passages: 5
   seed: 42

--- a/examples/retrieval/cross_encoder/llama3_2_1b.yaml
+++ b/examples/retrieval/cross_encoder/llama3_2_1b.yaml
@@ -57,7 +57,6 @@ dataset:
   data_type: train
   n_passages: 5
   seed: 42
-  do_shuffle: true
 
 dataloader:
   _target_: torchdata.stateful_dataloader.StatefulDataLoader
@@ -77,9 +76,6 @@ dataloader:
 #   data_type: eval
 #   n_passages: 5
 #   seed: 42
-#   do_shuffle: false
-#   max_train_samples: 1000
-#   train_data_select_offset: 0
 #
 # validation_dataloader:
 #   _target_: torchdata.stateful_dataloader.StatefulDataLoader
@@ -104,7 +100,7 @@ dataloader:
 #     - up_proj
 #     - down_proj
 #   exclude_modules: []
-#   match_all_linear: True
+#   match_all_linear: false
 #   dim: 16
 #   alpha: 32
 #   use_triton: true

--- a/nemo_automodel/components/datasets/llm/retrieval_collator.py
+++ b/nemo_automodel/components/datasets/llm/retrieval_collator.py
@@ -205,10 +205,10 @@ class BiEncoderCollator:
         # Per-passage corpus doc ids (positive + negatives, flattened in d_input_ids
         # order) for distributed in-batch same-doc negative masking. Top-level key
         # so it bypasses the q_/d_ unpacking in the trainer.
-        if batch and batch[0].get("doc_id") is not None:
-            doc_id_flat: List[str] = []
-            for x in batch:
-                doc_id_flat.extend(x["doc_id"])
+        doc_id_groups = [x.get("doc_id") for x in batch]
+        # Inline records may not provide IDs; incomplete IDs are unsafe for same-doc masking.
+        if doc_id_groups and all(doc_ids and all(doc_ids) for doc_ids in doc_id_groups):
+            doc_id_flat = [doc_id for doc_ids in doc_id_groups for doc_id in doc_ids]
             merged_batch_dict["passage_doc_ids"] = torch.tensor(
                 [_doc_id_str_to_int64(s) for s in doc_id_flat],
                 dtype=torch.long,

--- a/nemo_automodel/components/datasets/llm/retrieval_dataset.py
+++ b/nemo_automodel/components/datasets/llm/retrieval_dataset.py
@@ -648,7 +648,7 @@ def _transform_func(examples, num_neg_docs, corpus_dict, use_dataset_instruction
         cur_corpus_id = corpus_ids[idx_doc]
         for doc in docs:
             if isinstance(doc, dict) and "text" in doc:
-                # Inline-text records (.jsonl/.tsv/.csv) keep document content
+                # Inline-text records keep document content
                 # directly in pos_doc / neg_doc.
                 cur_doc = {
                     "text": "" if doc.get("text") is None else str(doc.get("text", "")),
@@ -683,7 +683,7 @@ def _transform_func(examples, num_neg_docs, corpus_dict, use_dataset_instruction
         cur_pos_neg_text_batch.append(cur_pos_neg_text)
         cur_pos_neg_image_batch.append(cur_pos_neg_image)
 
-        if use_dataset_instruction:
+        if use_dataset_instruction and cur_corpus_id in corpus_dict:
             query_instruction_batch.append(corpus_dict[cur_corpus_id].query_instruction)
             passage_instruction_batch.append(corpus_dict[cur_corpus_id].passage_instruction)
         else:
@@ -781,15 +781,15 @@ def make_retrieval_dataset(
     """
     Load and return dataset in retrieval format for encoder training.
 
-    Entries in *data_dir_list* can be local JSON file paths **or** ``hf://`` URIs
-    pointing to a HuggingFace dataset repository (e.g.
+    Entries in *data_dir_list* can be local corpus JSON or inline JSONL file paths or ``hf://`` URIs
+    pointing to a Hugging Face dataset repository (for example,
     ``hf://nvidia/embed-nemotron-dataset-v1/SciFact``). A source can also be
     provided as ``{"path": path_or_uri, "num_samples": N}`` to sample a fixed
     subset once while loading. Uses ``set_transform()`` for lazy evaluation —
     tokenization is handled by the collator.
 
     Args:
-        data_dir_list: Path(s) to JSON file(s), ``hf://`` URIs, or dictionary entries with path and
+        data_dir_list: Path(s) to corpus JSON or inline JSONL files, ``hf://`` URIs, or dictionary entries with path and
             num_samples.
         model_type: "bi_encoder" (default) or "cross_encoder"
         data_type: Type of data ("train" or "eval")
@@ -922,7 +922,7 @@ class RetrievalDatasetConfig:
     """Construction-time configuration for the retrieval dataset."""
 
     data_dir_list: list[DataEntry] | DataEntry | None = None
-    """Path(s) to JSON file(s), ``hf://`` URIs, or dict entries with path and num_samples."""
+    """Path(s) to corpus JSON or inline JSONL files, ``hf://`` URIs, or dict entries with path and num_samples."""
     model_type: str = "bi_encoder"
     """``bi_encoder`` or ``cross_encoder``."""
     data_type: str = "train"

--- a/nemo_automodel/components/datasets/llm/retrieval_dataset.py
+++ b/nemo_automodel/components/datasets/llm/retrieval_dataset.py
@@ -683,7 +683,7 @@ def _transform_func(examples, num_neg_docs, corpus_dict, use_dataset_instruction
         cur_pos_neg_text_batch.append(cur_pos_neg_text)
         cur_pos_neg_image_batch.append(cur_pos_neg_image)
 
-        if use_dataset_instruction and cur_corpus_id in corpus_dict:
+        if use_dataset_instruction:
             query_instruction_batch.append(corpus_dict[cur_corpus_id].query_instruction)
             passage_instruction_batch.append(corpus_dict[cur_corpus_id].passage_instruction)
         else:

--- a/nemo_automodel/components/datasets/llm/retrieval_dataset.py
+++ b/nemo_automodel/components/datasets/llm/retrieval_dataset.py
@@ -684,6 +684,11 @@ def _transform_func(examples, num_neg_docs, corpus_dict, use_dataset_instruction
         cur_pos_neg_image_batch.append(cur_pos_neg_image)
 
         if use_dataset_instruction:
+            if cur_corpus_id not in corpus_dict:
+                raise ValueError(
+                    "use_dataset_instruction=True requires corpus metadata, but no metadata was found for "
+                    f"corpus_id={cur_corpus_id!r}. Set use_dataset_instruction=False for pure inline sources."
+                )
             query_instruction_batch.append(corpus_dict[cur_corpus_id].query_instruction)
             passage_instruction_batch.append(corpus_dict[cur_corpus_id].passage_instruction)
         else:

--- a/tests/unit_tests/datasets/llm/test_bi_encoder_collator.py
+++ b/tests/unit_tests/datasets/llm/test_bi_encoder_collator.py
@@ -117,6 +117,46 @@ def test_collator_end_to_end_no_prefix():
     assert out["d_input_ids"].shape == out["d_attention_mask"].shape
 
 
+def test_collator_emits_passage_doc_ids_for_complete_nonempty_ids():
+    collator = rc.BiEncoderCollator(tokenizer=FakeTokenizer(), q_max_len=16, p_max_len=16, padding=True)
+    batch = _make_batch(num_examples=2, docs_per_example=2)
+    batch[0]["doc_id"] = ["positive-0", "negative-0"]
+    batch[1]["doc_id"] = ["positive-1", "negative-1"]
+
+    out = collator(batch)
+
+    expected = torch.tensor(
+        [
+            rc._doc_id_str_to_int64("positive-0"),
+            rc._doc_id_str_to_int64("negative-0"),
+            rc._doc_id_str_to_int64("positive-1"),
+            rc._doc_id_str_to_int64("negative-1"),
+        ],
+        dtype=torch.long,
+    )
+    torch.testing.assert_close(out["passage_doc_ids"], expected)
+
+
+@pytest.mark.parametrize(
+    "doc_id_groups",
+    [
+        [["", ""], ["", ""]],
+        [["positive-0", ""], ["positive-1", "negative-1"]],
+        [["positive-0", "negative-0"], None],
+    ],
+)
+def test_collator_omits_passage_doc_ids_when_any_id_is_missing(doc_id_groups):
+    collator = rc.BiEncoderCollator(tokenizer=FakeTokenizer(), q_max_len=16, p_max_len=16, padding=True)
+    batch = _make_batch(num_examples=2, docs_per_example=2)
+    for example, doc_ids in zip(batch, doc_id_groups):
+        if doc_ids is not None:
+            example["doc_id"] = doc_ids
+
+    out = collator(batch)
+
+    assert "passage_doc_ids" not in out
+
+
 def test_collator_with_prefix_and_pad_multiple():
     tok = FakeTokenizer()
     collator = rc.BiEncoderCollator(

--- a/tests/unit_tests/datasets/llm/test_retrieval_dataset.py
+++ b/tests/unit_tests/datasets/llm/test_retrieval_dataset.py
@@ -1026,6 +1026,25 @@ def test_retrieval_dataset_config_builds_inline_jsonl_for_both_model_types(tmp_p
     assert cross_batch["num_labels"] == [1, 1]
 
 
+def test_retrieval_dataset_config_rejects_instructions_without_corpus_metadata(tmp_path):
+    """Pure inline records cannot resolve dataset instructions without corpus metadata."""
+    f = tmp_path / "inline.jsonl"
+    f.write_text(json.dumps({"query": "Q", "pos_doc": "P", "neg_doc": ["N"]}))
+
+    dataset = rd.RetrievalDatasetConfig(
+        data_dir_list=str(f),
+        data_type="train",
+        n_passages=2,
+        use_dataset_instruction=True,
+    ).build()
+
+    with pytest.raises(
+        ValueError,
+        match=r"use_dataset_instruction=True requires corpus metadata.*Set use_dataset_instruction=False",
+    ):
+        dataset[0]
+
+
 def test__load_json_or_jsonl_json_and_jsonl_error_paths(tmp_path):
     # JSON (list)
     f_json = tmp_path / "data.json"

--- a/tests/unit_tests/datasets/llm/test_retrieval_dataset.py
+++ b/tests/unit_tests/datasets/llm/test_retrieval_dataset.py
@@ -989,6 +989,48 @@ def test_make_retrieval_dataset_inline_end_to_end(tmp_path):
     assert ex["doc_image"] == ["", "", ""]
 
 
+def test_retrieval_dataset_config_builds_inline_jsonl_for_both_model_types(tmp_path):
+    """The public retrieval config should route inline JSONL without corpus metadata."""
+    f = tmp_path / "inline.jsonl"
+    f.write_text(
+        json.dumps(
+            {
+                "query": "Q",
+                "pos_doc": ["P1", "P2"],
+                "neg_doc": ["N"],
+            }
+        )
+    )
+
+    dataset = rd.RetrievalDatasetConfig(
+        data_dir_list=str(f),
+        data_type="train",
+        n_passages=2,
+        use_dataset_instruction=True,
+        cycle_positive_docs=True,
+    ).build()
+
+    assert hasattr(dataset, "set_epoch")
+    assert dataset[0]["doc_text"] == ["P1", "N"]
+    assert dataset[0]["query_instruction"] == ""
+    assert dataset[0]["passage_instruction"] == ""
+
+    dataset.set_epoch(1)
+    assert dataset[0]["doc_text"] == ["P2", "N"]
+
+    cross_dataset = rd.RetrievalDatasetConfig(
+        data_dir_list=str(f),
+        model_type="cross_encoder",
+        data_type="train",
+        n_passages=2,
+        use_dataset_instruction=True,
+    ).build()
+    cross_batch = cross_dataset[[0]]
+    assert cross_batch["question"] == ["Q", "Q"]
+    assert cross_batch["doc_text"] == ["P1", "N"]
+    assert cross_batch["num_labels"] == [1, 1]
+
+
 def test__load_json_or_jsonl_json_and_jsonl_error_paths(tmp_path):
     # JSON (list)
     f_json = tmp_path / "data.json"

--- a/tests/unit_tests/datasets/llm/test_retrieval_dataset.py
+++ b/tests/unit_tests/datasets/llm/test_retrieval_dataset.py
@@ -1006,15 +1006,11 @@ def test_retrieval_dataset_config_builds_inline_jsonl_for_both_model_types(tmp_p
         data_dir_list=str(f),
         data_type="train",
         n_passages=2,
-        use_dataset_instruction=True,
         cycle_positive_docs=True,
     ).build()
 
     assert hasattr(dataset, "set_epoch")
     assert dataset[0]["doc_text"] == ["P1", "N"]
-    assert dataset[0]["query_instruction"] == ""
-    assert dataset[0]["passage_instruction"] == ""
-
     dataset.set_epoch(1)
     assert dataset[0]["doc_text"] == ["P2", "N"]
 
@@ -1023,7 +1019,6 @@ def test_retrieval_dataset_config_builds_inline_jsonl_for_both_model_types(tmp_p
         model_type="cross_encoder",
         data_type="train",
         n_passages=2,
-        use_dataset_instruction=True,
     ).build()
     cross_batch = cross_dataset[[0]]
     assert cross_batch["question"] == ["Q", "Q"]


### PR DESCRIPTION
# What does this PR do?

Completes the Fern integration for the retrieval fine-tuning guide and aligns it with the dataset behavior available on current `main`. The change remains documentation-focused.

The main fine-tuning page was carried into Fern by #2391 while this PR was under review. This revision updates that page where current implementation behavior requires it, applies tech-pubs guidance to new or substantively edited retrieval prose, and removes unrelated runtime code, utility scripts, tests, agent guidance, and drive-by copy edits from the original #2306 diff.

# Changelog

- Use `RetrievalDatasetConfig` as the single public configuration for corpus-backed JSON, AutoModel-schema `hf://` sources, and inline JSONL.
- Clarify the runtime one-positive schema, positive cycling, multi-positive expansion, sibling-positive masking, and qrels conversion without duplicating guidance.
- State that qrels are conversion and offline-evaluation inputs, not direct training inputs.
- Clarify that pure inline JSONL has no corpus metadata and must keep `use_dataset_instruction: false`.
- Add retrieval links to the dataset overview, recipe overview, home-page quick links, and guide table.
- Correct the fine-tuning guide for validation group sizing, model support, pure DP/FSDP constraints, distributed masking, LoRA module selection, checkpoint resolution, and trusted local checkpoint loading.
- Document the hard-negative miner as it behaves on current `main`, including cache, overwrite, metadata, score-filtering, and Llama-export limitations.
- Remove commands and guarantees that depend on draft companion PRs.
- Update the bi-encoder and cross-encoder example comments, timeout, public training sources, and source/container command forms needed by the guide.

# Deferred Companion PRs

These follow-ups are intentionally not documented as available in #2306:

- #2905 — preserve and restore bi-encoder export metadata.
- #2906 — harden hard-negative mining cache, scoring, and output behavior.
- #2907 — add HF materialization, positive unrolling, lineage, and mined-output audit utilities.
- Runtime PRD — define the intended behavior when pure inline JSONL sets `use_dataset_instruction: true`: either reject the unsupported configuration with a clear error or return empty instructions. #2306 does not choose or change this behavior.

Unrelated guidance extracted from the original mixed diff:

- #2904 — record reusable, prospective Fern prose-style guidance from the tech-pubs review.
- #2903 — update agent references to the YAML-first CLI.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Kept runtime behavior unchanged and documented the supported pure-inline configuration.
- [x] Ported the documentation to the current Fern MDX layout.
- [x] Included DCO sign-off in all commits.

# Validation

- `ruff format .` and `ruff check --fix .`.
- `tests/unit_tests/datasets/llm/test_retrieval_dataset.py` — 58 passed.
- `tests/unit_tests/datasets/llm/test_typed_dataset_loader.py` — 41 passed.
- `make -C docs/fern docs-check` — 291 MDX files validated; `fern check` found 0 errors and reported the standard single warning.
- `tools/lint_example_yamls.py --automodel-dir .` — 449 YAML files linted.
- Nightly recipe references are valid; all 15 recipe CI groups generated successfully.
- Both modified retrieval YAMLs resolve through `RecipeConfig` to `RetrievalDatasetConfig`.
- `git diff --check`.

# Additional Information

The guide documents only the three verified source forms: corpus-backed JSON, AutoModel-schema `hf://`, and inline JSONL. It does not claim TSV or CSV support because the inline parser currently accepts JSON and JSONL records only.

The original full PR head remains recoverable at commit `dabb437d7537929391b7451a12c4de3b4da7ccd8`. All current inline review threads are resolved.

GPU and multi-node behavior was reviewed against the implementation and existing tests but was not executed locally.