### PR TITLE
feat(examples): add two-node QLoRA recipe

### DIFF
--- a/examples/llm_finetune/llama3_1/llama3_1_8b_instruct_squad_qlora_2node.yaml
+++ b/examples/llm_finetune/llama3_1/llama3_1_8b_instruct_squad_qlora_2node.yaml
@@ -1,0 +1,108 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# QLoRA configuration for Llama-3.1-8B-Instruct on SQuAD.
+# Target launch shape: 2 nodes x 8 GPUs = 16 ranks, FSDP2 data parallel.
+
+recipe: TrainFinetuneRecipeForNextTokenPrediction
+
+step_scheduler:
+  global_batch_size: 16
+  local_batch_size: 1
+  ckpt_every_steps: 50
+  val_every_steps: 100
+  max_steps: 100
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 30
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 42
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: meta-llama/Llama-3.1-8B-Instruct
+  torch_dtype: bfloat16
+
+peft:
+  _target_: nemo_automodel.components._peft.lora.PeftConfig
+  target_modules: "*_proj"
+  dim: 16
+  alpha: 32
+  dropout: 0.1
+
+distributed:
+  strategy: fsdp2
+  dp_size: none
+  tp_size: 1
+  cp_size: 1
+  pp_size: 1
+
+  sequence_parallel: false
+  activation_checkpointing: false
+
+quantization:
+  load_in_4bit: true
+  load_in_8bit: false
+  bnb_4bit_compute_dtype: bfloat16
+  bnb_4bit_use_double_quant: true
+  bnb_4bit_quant_type: nf4
+  bnb_4bit_quant_storage: bfloat16
+
+checkpoint:
+  enabled: true
+  checkpoint_dir: checkpoints/llama3_1_8b_instruct_squad_qlora_2node/
+  model_save_format: safetensors
+  save_consolidated: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
+  dataset_name: rajpurkar/squad
+  split: train
+
+packed_sequence:
+  packed_sequence_size: 0
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  shuffle: false
+  drop_last: true
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
+  dataset_name: rajpurkar/squad
+  split: validation
+  limit_dataset_samples: 100
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  shuffle: false
+
+optimizer:
+  _target_: torch.optim.AdamW
+  betas: [0.9, 0.999]
+  eps: 1e-8
+  lr: 1.0e-5
+  weight_decay: 0.01
+
+ci:
+  recipe_owner: adil-a


### PR DESCRIPTION
## Summary
- Add a Llama 3.1 8B Instruct SQuAD QLoRA recipe for a 2-node, 16-GPU FSDP2 run.
- Configure 4-bit NF4 quantization, LoRA adapters, validation every 100 steps, and a 100-step run.

## Validation
- Parsed the YAML config with PyYAML.
- Ran `git diff --check` on the new recipe.
- Previously validated the recipe shape with a 2-node Slurm run for 100 steps: job 12099765 completed and logged to W&B: https://wandb.ai/Nemo-automodel/huiyingl_workspace/runs/722ux2w9
<img width="718" height="268" alt="image" src="https://github.com/user-attachments/assets/6311d17b-a6f8-4401-893a-aaf52742ef74" />
