### PR TITLE
fix(speculative): make EAGLE recipes complete a checkpoint save end-to-end

### DIFF
--- a/nemo_automodel/recipes/llm/train_eagle1.py
+++ b/nemo_automodel/recipes/llm/train_eagle1.py
@@ -201,6 +201,12 @@ class TrainEagle1Recipe(BaseRecipe):
         """Build the checkpointer using the same plumbing as the standard recipes."""
         ckpt_cfg = self.cfg.get("checkpoint", None)
         default_dir = str(self.output_dir / "checkpoints")
+        # EAGLE recipes construct the draft model directly and bypass
+        # `apply_model_infrastructure`, which is where `_pre_shard_hf_state_dict_keys`
+        # would normally be attached. Capture the pre-shard keys here so the
+        # consolidated-safetensors path in `_maybe_build_consolidated_index`
+        # has something to diff against instead of `None`.
+        draft_state_dict_keys = list(self.draft_model.state_dict().keys())
         ckpt_kwargs = dict(
             enabled=True,
             checkpoint_dir=default_dir,
@@ -209,11 +215,14 @@ class TrainEagle1Recipe(BaseRecipe):
             model_cache_dir=hf_constants.HF_HUB_CACHE,
             save_consolidated=True,
             is_peft=False,
+            model_state_dict_keys=draft_state_dict_keys,
         )
         if ckpt_cfg is not None:
             user_cfg = ckpt_cfg.to_dict() if hasattr(ckpt_cfg, "to_dict") else dict(ckpt_cfg)
             user_cfg.pop("restore_from", None)
             ckpt_kwargs.update(user_cfg)
+        if ckpt_kwargs.get("model_state_dict_keys") is None:
+            ckpt_kwargs["model_state_dict_keys"] = draft_state_dict_keys
 
         self.checkpoint_config = CheckpointingConfig(**ckpt_kwargs)
         dp_rank = dist.get_rank() if dist.is_initialized() else 0

--- a/nemo_automodel/recipes/llm/train_eagle3.py
+++ b/nemo_automodel/recipes/llm/train_eagle3.py
@@ -681,8 +681,6 @@ class TrainEagle3Recipe(BaseRecipe):
 
 def main(config_path=None):
     """Main entry point for the EAGLE-3 recipe."""
-    if config_path is None:
-        raise ValueError("config_path is required for TrainEagle3Recipe")
     cfg = parse_args_and_load_config(config_path)
     trainer = TrainEagle3Recipe(cfg)
     trainer.setup()

--- a/nemo_automodel/recipes/llm/train_eagle3.py
+++ b/nemo_automodel/recipes/llm/train_eagle3.py
@@ -263,6 +263,12 @@ class TrainEagle3Recipe(BaseRecipe):
         """Build the checkpointer using the same plumbing as the standard recipes."""
         ckpt_cfg = self.cfg.get("checkpoint", None)
         default_dir = str(self.output_dir / "checkpoints")
+        # EAGLE recipes construct the draft model directly and bypass
+        # `apply_model_infrastructure`, which is where `_pre_shard_hf_state_dict_keys`
+        # would normally be attached. Capture the pre-shard keys here so the
+        # consolidated-safetensors path in `_maybe_build_consolidated_index`
+        # has something to diff against instead of `None`.
+        draft_state_dict_keys = list(self.draft_model.state_dict().keys())
         ckpt_kwargs = dict(
             enabled=True,
             checkpoint_dir=default_dir,
@@ -271,11 +277,14 @@ class TrainEagle3Recipe(BaseRecipe):
             model_cache_dir=hf_constants.HF_HUB_CACHE,
             save_consolidated=True,
             is_peft=False,
+            model_state_dict_keys=draft_state_dict_keys,
         )
         if ckpt_cfg is not None:
             user_cfg = ckpt_cfg.to_dict() if hasattr(ckpt_cfg, "to_dict") else dict(ckpt_cfg)
             user_cfg.pop("restore_from", None)
             ckpt_kwargs.update(user_cfg)
+        if ckpt_kwargs.get("model_state_dict_keys") is None:
+            ckpt_kwargs["model_state_dict_keys"] = draft_state_dict_keys
 
         self.checkpoint_config = CheckpointingConfig(**ckpt_kwargs)
         dp_rank = dist.get_rank() if dist.is_initialized() else 0

--- a/tests/unit_tests/recipes/llm/test_eagle_build_checkpointer.py
+++ b/tests/unit_tests/recipes/llm/test_eagle_build_checkpointer.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for EAGLE recipe _build_checkpointer and eagle3 main().
+
+Covers the fix where EAGLE recipes pass ``model_state_dict_keys`` from the
+draft model to ``CheckpointingConfig``, preventing ``TypeError: 'NoneType'
+object is not iterable`` at consolidated checkpoint save time.
+
+Also verifies that ``train_eagle3.main(None)`` no longer raises ``ValueError``
+before ``parse_args_and_load_config`` has a chance to read ``sys.argv``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch.nn as nn
+
+from nemo_automodel.recipes.llm.train_eagle1 import TrainEagle1Recipe
+from nemo_automodel.recipes.llm.train_eagle3 import TrainEagle3Recipe
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeDraftModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc = nn.Linear(4, 4)
+        self.norm = nn.LayerNorm(4)
+
+
+def _bare_recipe_for_checkpointer(cls, tmp_path):
+    """Create a minimal recipe instance with just enough state for _build_checkpointer."""
+    recipe = cls.__new__(cls)
+    recipe.cfg = SimpleNamespace(get=lambda *_args, **_kw: None)
+    recipe.output_dir = Path(tmp_path) / "output"
+    recipe.output_dir.mkdir(parents=True, exist_ok=True)
+    recipe.draft_model = _FakeDraftModel()
+    return recipe
+
+
+# ---------------------------------------------------------------------------
+# EAGLE-1: _build_checkpointer sets model_state_dict_keys
+# ---------------------------------------------------------------------------
+
+
+@patch("nemo_automodel.recipes.llm.train_eagle1.Checkpointer")
+def test_eagle1_build_checkpointer_sets_model_state_dict_keys(mock_checkpointer, tmp_path):
+    """_build_checkpointer must populate model_state_dict_keys from the draft model."""
+    recipe = _bare_recipe_for_checkpointer(TrainEagle1Recipe, tmp_path)
+
+    recipe._build_checkpointer(target_path="/fake/target")
+
+    expected_keys = list(recipe.draft_model.state_dict().keys())
+    assert recipe.checkpoint_config.model_state_dict_keys is not None
+    assert recipe.checkpoint_config.model_state_dict_keys == expected_keys
+
+
+@patch("nemo_automodel.recipes.llm.train_eagle1.Checkpointer")
+def test_eagle1_build_checkpointer_user_none_override_falls_back(mock_checkpointer, tmp_path):
+    """If user config explicitly sets model_state_dict_keys=None, the fallback restores draft keys."""
+    user_ckpt_cfg = SimpleNamespace(
+        to_dict=lambda: {"model_state_dict_keys": None, "checkpoint_dir": str(tmp_path / "user_ckpt")},
+    )
+    recipe = _bare_recipe_for_checkpointer(TrainEagle1Recipe, tmp_path)
+    recipe.cfg = SimpleNamespace(get=lambda key, default=None: user_ckpt_cfg if key == "checkpoint" else default)
+
+    recipe._build_checkpointer(target_path="/fake/target")
+
+    expected_keys = list(recipe.draft_model.state_dict().keys())
+    assert recipe.checkpoint_config.model_state_dict_keys == expected_keys
+
+
+# ---------------------------------------------------------------------------
+# EAGLE-3: _build_checkpointer sets model_state_dict_keys
+# ---------------------------------------------------------------------------
+
+
+@patch("nemo_automodel.recipes.llm.train_eagle3.Checkpointer")
+def test_eagle3_build_checkpointer_sets_model_state_dict_keys(mock_checkpointer, tmp_path):
+    """EAGLE-3 _build_checkpointer must also populate model_state_dict_keys."""
+    recipe = _bare_recipe_for_checkpointer(TrainEagle3Recipe, tmp_path)
+
+    recipe._build_checkpointer(target_path="/fake/target")
+
+    expected_keys = list(recipe.draft_model.state_dict().keys())
+    assert recipe.checkpoint_config.model_state_dict_keys is not None
+    assert recipe.checkpoint_config.model_state_dict_keys == expected_keys
+
+
+@patch("nemo_automodel.recipes.llm.train_eagle3.Checkpointer")
+def test_eagle3_build_checkpointer_user_none_override_falls_back(mock_checkpointer, tmp_path):
+    """EAGLE-3: user config model_state_dict_keys=None triggers fallback to draft keys."""
+    user_ckpt_cfg = SimpleNamespace(
+        to_dict=lambda: {"model_state_dict_keys": None, "checkpoint_dir": str(tmp_path / "user_ckpt")},
+    )
+    recipe = _bare_recipe_for_checkpointer(TrainEagle3Recipe, tmp_path)
+    recipe.cfg = SimpleNamespace(get=lambda key, default=None: user_ckpt_cfg if key == "checkpoint" else default)
+
+    recipe._build_checkpointer(target_path="/fake/target")
+
+    expected_keys = list(recipe.draft_model.state_dict().keys())
+    assert recipe.checkpoint_config.model_state_dict_keys == expected_keys
+
+
+# ---------------------------------------------------------------------------
+# EAGLE-3: main(None) no longer raises ValueError
+# ---------------------------------------------------------------------------
+
+
+def test_eagle3_main_none_does_not_raise_valueerror():
+    """main(None) must not raise ValueError; it should reach parse_args_and_load_config."""
+    with patch("nemo_automodel.recipes.llm.train_eagle3.parse_args_and_load_config") as mock_parse:
+        mock_parse.side_effect = SystemExit(2)
+        with pytest.raises(SystemExit):
+            from nemo_automodel.recipes.llm.train_eagle3 import main
+
+            main(None)
+    # The key assertion: no ValueError was raised before parse_args_and_load_config.
+    mock_parse.assert_called_once_with(None)


### PR DESCRIPTION
# What does this PR do?

Make the EAGLE-1 / EAGLE-3 training recipes actually reach and complete the
end-of-epoch consolidated safetensors checkpoint save. Two related bugs were
blocking it.

## Bug 1 — `TypeError: 'NoneType' object is not iterable` at checkpoint save

On an 8-rank EAGLE-3 / EAGLE-1 run with the default
`--checkpoint.model_save_format safetensors --checkpoint.save_consolidated True`,
training completes ~16 optimizer steps and then crashes at the first
checkpoint save:

```
File ".../components/checkpoint/checkpointing.py", line 924, in _maybe_build_consolidated_index
    keys_to_remove = list(set(fqn_to_file_index_mapping.keys()) - set(pre_shard_hf_state_dict_keys))
TypeError: 'NoneType' object is not iterable
```

Root cause:

- `_maybe_build_consolidated_index` reads
  `model._pre_shard_hf_state_dict_keys` (set by `apply_model_infrastructure`)
  with fallback to `CheckpointingConfig.model_state_dict_keys`.
- EAGLE recipes build the draft model directly (`LlamaEagle*DraftModel(...).to(device)`)
  and bypass `apply_model_infrastructure`, so the attribute is never set.
- The recipes also never passed `model_state_dict_keys` to
  `CheckpointingConfig`, so the fallback is `None` too.
- `set(None)` raises.

Fix: in `_build_checkpointer`, capture
`list(self.draft_model.state_dict().keys())` and pass it as
`model_state_dict_keys` on `CheckpointingConfig`. Mirrors what
`recipes/diffusion/train.py:561` already does.

## Bug 2 — EAGLE-3 `main()` raised before `-c` could be parsed

`train_eagle3.py:main(config_path=None)` rejected `config_path is None`
before calling `parse_args_and_load_config`, but that helper is what reads
`-c <config.yaml>` from `sys.argv`. As a result
`torchrun -m nemo_automodel.recipes.llm.train_eagle3 -c <config>` was
unusable; only the direct-python-import call path worked.

Fix: remove the premature `ValueError` so argv parsing can resolve
`config_path` itself.

# Changelog

- `recipes/llm/train_eagle1.py`: pass `model_state_dict_keys` from the draft
  model to `CheckpointingConfig` in `_build_checkpointer`. EAGLE-2 inherits
  via `TrainEagle1Recipe` so it is covered automatically.
- `recipes/llm/train_eagle3.py`: same fix; additionally remove the premature
  `ValueError` in `main()` so `torchrun -m ... -c <yaml>` works.

# Verification

End-to-end run on 8x H100 with the user-reported repro config (target
`Llama-3.1-8B-Instruct`, PerfectBlend-Regenerated dataset, sliced to 200
samples, 1 epoch):

```
2026-05-25 15:11:44 | INFO | __main__ | Epoch 0 done: total_batches_seen=25 global_step=25
2026-05-25 15:11:48 | INFO | ...consolidate_hf_safetensors | Rank 0/8: Consolidating safetensors files ...
2026-05-25 15:11:50 | INFO | ...consolidate_hf_safetensors | Total time taken: 2.41 secs.
2026-05-25 15:11:52 | INFO | __main__ | Saved checkpoint to outputs/verify_eagle3_fix/checkpoints/epoch_1_step_25
2026-05-25 15:11:52 | INFO | __main__ | Training complete: global_step=25
```

Checks against the verification log:

- `grep -nE "TypeError|NoneType.* not iterable" "$LOG"` -> empty
  (`PASS: no TypeError`).
- `grep -n "Saved checkpoint to" "$LOG"` -> the line above.
- Consolidated output directory contents:

```
$ ls -la outputs/verify_eagle3_fix/checkpoints/epoch_1_step_25/model/consolidated/
config.json
chat_template.jinja
model-00001-of-00004.safetensors  (1.5 GB)
model-00004-of-00004.safetensors  (363 MB)
model.safetensors.index.json
special_tokens_map.json
tokenizer.json
tokenizer_config.json
```

Before this fix, the same command crashed at the first save and the output
directory contained only partial files (no `model.safetensors*` written).

## Known cosmetic follow-up

The two shard files are numbered `00001-of-00004` and `00004-of-00004`
(no `00002` / `00003`). This is because the consolidated-index path still
reads the **target** model's safetensors index (target has 4 shards) and
maps the draft's keys onto shards 1 and 4 (the target's `max(shard)` is used
as `default_index` for any key the target index does not cover). The
`model.safetensors.index.json` correctly points every key to an existing
file, so this loads fine via standard HF safetensors loaders — just a
slightly ugly shard layout. Worth a follow-up to either set
`model_repo_id=None` for EAGLE or build the consolidated index from the
draft's keys directly, but out of scope for this fix.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Contributor guidelines followed
- [ ] Did you write any new necessary tests? No — bug repro requires a real
  multi-GPU run with consolidated safetensors save; not feasible as a unit
  test. End-to-end repro + verification log attached above.
- [ ] Did you add or update any necessary documentation? No — behavior of
  the public API is unchanged; only a crash on a previously-broken path is
  removed.