### PR TITLE
feat(vlm): add Nemotron-Omni RADIO post-load patches

### DIFF
--- a/nemo_automodel/_transformers/infrastructure.py
+++ b/nemo_automodel/_transformers/infrastructure.py
@@ -60,6 +60,7 @@ from nemo_automodel.components.utils.model_utils import (
     _supports_logits_to_keep,
     apply_parameter_freezing,
     count_model_parameters,
+    enable_radio_vit_fused_attn,
     freeze_deepseek_v4_indexer_params,
     freeze_unused_kv_sharing_params,
     init_empty_weights,
@@ -497,6 +498,9 @@ def apply_model_infrastructure(
     # so the optimizer never tracks them and checkpoint save/resume stay consistent.
     freeze_unused_kv_sharing_params(model)
     freeze_deepseek_v4_indexer_params(model)
+
+    # NemotronOmni RADIO: opt into the fused SDPA path on ViT attention blocks.
+    enable_radio_vit_fused_attn(model)
 
     # Loss function check
     if not _supports_logits_to_keep(model) and not isinstance(loss_fn, MaskedCrossEntropy):

--- a/nemo_automodel/components/utils/model_utils.py
+++ b/nemo_automodel/components/utils/model_utils.py
@@ -301,6 +301,40 @@ def _freeze_module_by_attribute_and_patterns(model, attribute_name, name_pattern
                 param.requires_grad = False
 
 
+def enable_radio_vit_fused_attn(model):
+    """Route RADIO ViT attention through ``F.scaled_dot_product_attention``.
+
+    RADIO's timm Attention blocks default to ``fused_attn=False``, which
+    materializes the full ``(B, H, seq, seq)`` attention tensor (~5 GiB per
+    block at RADIO-v2-H + dynamic-resolution patch counts). Flipping
+    ``fused_attn=True`` matches the Megatron-Bridge path which sets
+    ``vision_config.use_flash_attn=True`` via
+    ``attn_implementation="flash_attention_2"``.
+
+    No-op when the model has no RADIO vision tower.
+
+    Args:
+        model: The model to patch in place.
+    """
+    vision_model = getattr(model, "vision_model", None) or getattr(getattr(model, "model", None), "vision_model", None)
+    vit_blocks = getattr(
+        getattr(getattr(vision_model, "radio_model", None), "model", None),
+        "blocks",
+        None,
+    )
+    if vit_blocks is None:
+        return
+
+    flipped = 0
+    for block in vit_blocks:
+        attn = getattr(block, "attn", None)
+        if attn is not None:
+            attn.fused_attn = True
+            flipped += 1
+    if flipped:
+        logger.info("Enabled fused_attn on %d RADIO ViT blocks", flipped)
+
+
 def apply_parameter_freezing(model, freeze_config):
     """Apply parameter freezing based on configuration.
 
@@ -312,10 +346,12 @@ def apply_parameter_freezing(model, freeze_config):
         - freeze_vision_tower: bool (default True)
         - freeze_audio_tower: bool (default False)
         - freeze_language_model: bool (default False)
+        - freeze_video_embedder: bool (default False)
     """
     freeze_vision_tower = freeze_config.get("freeze_vision_tower", True)
     freeze_audio_tower = freeze_config.get("freeze_audio_tower", False)
     freeze_language_model = freeze_config.get("freeze_language_model", False)
+    freeze_video_embedder = freeze_config.get("freeze_video_embedder", False)
 
     # Freeze vision tower
     if freeze_vision_tower:
@@ -328,6 +364,21 @@ def apply_parameter_freezing(model, freeze_config):
     # Freeze language model backbone
     if freeze_language_model:
         _freeze_module_by_attribute_and_patterns(model, "language_model", ["language", "text", "llm"])
+
+    # NemotronOmni RADIO: patch_generator.video_embedder is only exercised on
+    # video inputs; on image-only training it sits in the optimizer without
+    # state (no grad → no lazy init), so dcp.load on resume raises
+    # "Missing key in checkpoint state_dict: optim.state.<...>.video_embedder.weight.step".
+    # Independent of freeze_vision_tower so the image encoder can stay trainable
+    # while the video branch is frozen out.
+    if freeze_video_embedder:
+        frozen = 0
+        for name, param in model.named_parameters():
+            if "patch_generator.video_embedder" in name:
+                param.requires_grad_(False)
+                frozen += 1
+        if frozen:
+            logger.info("Froze %d patch_generator.video_embedder params", frozen)
 
     # Phi4MM: cast internal fp32 LoRA adapters to bf16 for FSDP2 compatibility,
     # and disable KV cache (remote code uses legacy DynamicCache.key_cache

--- a/tests/unit_tests/utils/test_model_utils.py
+++ b/tests/unit_tests/utils/test_model_utils.py
@@ -543,3 +543,131 @@ class TestSqueezeInputForThd:
 
         assert kw["cu_seqlens"].tolist() == [0, 3, 5]
         assert kw["cu_seqlens_padded"].tolist() == [0, 4, 6]
+
+
+# =============================================================================
+# Tests for enable_radio_vit_fused_attn
+# =============================================================================
+
+
+def _build_radio_model(num_blocks: int = 3, attach_via_nested_model: bool = False, attn_present: bool = True):
+    """Build a stub mirroring ``model.[model.]vision_model.radio_model.model.blocks[*].attn.fused_attn``."""
+
+    class Attn(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.fused_attn = False
+
+    class Block(nn.Module):
+        def __init__(self, with_attn: bool):
+            super().__init__()
+            if with_attn:
+                self.attn = Attn()
+            # else: no `attn` attribute at all → exercises the `attn is None` skip
+
+    class RadioInner(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.blocks = nn.ModuleList([Block(attn_present) for _ in range(num_blocks)])
+
+    class RadioModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.model = RadioInner()
+
+    class VisionModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.radio_model = RadioModel()
+
+    class Outer(nn.Module):
+        def __init__(self):
+            super().__init__()
+            if attach_via_nested_model:
+
+                class Inner(nn.Module):
+                    def __init__(self):
+                        super().__init__()
+                        self.vision_model = VisionModel()
+
+                self.model = Inner()
+            else:
+                self.vision_model = VisionModel()
+
+    return Outer()
+
+
+def test_enable_radio_vit_fused_attn_flips_blocks_top_level():
+    """All blocks reachable via ``model.vision_model.radio_model.model.blocks`` flip to fused_attn=True."""
+    model = _build_radio_model(num_blocks=3)
+    model_utils.enable_radio_vit_fused_attn(model)
+
+    for block in model.vision_model.radio_model.model.blocks:
+        assert block.attn.fused_attn is True
+
+
+def test_enable_radio_vit_fused_attn_flips_blocks_nested_model():
+    """Resolves vision_model via the ``model.model.vision_model`` path used by HF wrappers."""
+    model = _build_radio_model(num_blocks=2, attach_via_nested_model=True)
+    model_utils.enable_radio_vit_fused_attn(model)
+
+    for block in model.model.vision_model.radio_model.model.blocks:
+        assert block.attn.fused_attn is True
+
+
+def test_enable_radio_vit_fused_attn_noop_without_radio():
+    """No vision tower → silent no-op (does not raise)."""
+    model = nn.Linear(4, 4)
+    model_utils.enable_radio_vit_fused_attn(model)
+
+
+def test_enable_radio_vit_fused_attn_skips_blocks_without_attn():
+    """Blocks without an ``attn`` attribute are skipped, not crashed on."""
+    model = _build_radio_model(num_blocks=2, attn_present=False)
+    model_utils.enable_radio_vit_fused_attn(model)  # must not raise
+
+
+# =============================================================================
+# Tests for freeze_video_embedder branch in apply_parameter_freezing
+# =============================================================================
+
+
+@pytest.fixture()
+def video_embedder_model() -> nn.Module:
+    """Model exposing a ``patch_generator.video_embedder`` parameter."""
+
+    class PatchGenerator(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.video_embedder = nn.Linear(4, 4)
+            self.image_embedder = nn.Linear(4, 4)
+
+    class Model(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.patch_generator = PatchGenerator()
+            self.language_head = nn.Linear(4, 4)
+
+    return Model()
+
+
+def test_freeze_video_embedder_true_freezes_only_video_embedder(video_embedder_model):
+    """``freeze_video_embedder=True`` freezes ``patch_generator.video_embedder.*`` only."""
+    model_utils.apply_parameter_freezing(
+        video_embedder_model,
+        {"freeze_vision_tower": False, "freeze_video_embedder": True},
+    )
+
+    assert not _any_requires_grad(video_embedder_model.patch_generator.video_embedder)
+    assert _all_requires_grad(video_embedder_model.patch_generator.image_embedder)
+    assert _all_requires_grad(video_embedder_model.language_head)
+
+
+def test_freeze_video_embedder_false_keeps_video_embedder_trainable(video_embedder_model):
+    """Default ``freeze_video_embedder=False`` leaves the video embedder trainable."""
+    model_utils.apply_parameter_freezing(
+        video_embedder_model,
+        {"freeze_vision_tower": False, "freeze_video_embedder": False},
+    )
+
+    assert _all_requires_grad(video_embedder_model.patch_generator.video_embedder)


### PR DESCRIPTION
This PR improves nemotron-3-omni:
- enable_radio_vit_fused_attn(): route RADIO timm ViT attention through F.scaled_dot_product_attention so the (B, H, seq, seq) attention tensor (~5 GiB per block at RADIO-v2-H + dynamic-resolution patch counts) is not materialized. 
- apply_parameter_freezing(): new freeze_video_embedder knob (default False). patch_generator.video_embedder is only exercised on video inputs; on image-only training it sits in the optimizer without state (no grad → no lazy init), so dcp.load on resume raises a missing-key error. Independent of freeze_vision_tower so the image encoder can stay trainable while the video branch is frozen out.