### PR TITLE
feat(speculative): add Qwen3 dense target support for EAGLE-1/2/3

### DIFF
--- a/examples/speculative/eagle1/qwen3_eagle1_perfectblend.yaml
+++ b/examples/speculative/eagle1/qwen3_eagle1_perfectblend.yaml
@@ -1,0 +1,37 @@
+recipe: TrainEagle1Recipe
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 30
+
+recipe_args:
+  target_model_name_or_path: Qwen/Qwen3-8B
+  train_data_path: /path/to/train.jsonl
+  val_data_path: null
+  train_split: null
+  val_split: null
+  output_dir: ./outputs/eagle1_qwen3_mvp
+  seq_length: 1024
+  micro_batch_size: 1
+  grad_accumulation_steps: 1
+  num_workers: 0
+  num_epochs: 1
+  draft_num_hidden_layers: 1
+  hidden_loss_weight: 1.0
+  token_loss_weight: 0.1
+  freeze_embeddings: true
+  trust_remote_code: false
+  shuffle_seed: 42
+  log_every_steps: 10
+  max_grad_norm: 1.0
+
+optimizer:
+  lr: 1.0e-4
+  betas: [0.9, 0.95]
+  weight_decay: 0.0
+
+checkpoint:
+  enabled: true
+  checkpoint_dir: ./outputs/eagle1_qwen3_mvp/checkpoints
+  model_save_format: safetensors
+  save_consolidated: true

--- a/examples/speculative/eagle2/qwen3_eagle2_perfectblend.yaml
+++ b/examples/speculative/eagle2/qwen3_eagle2_perfectblend.yaml
@@ -1,0 +1,37 @@
+recipe: TrainEagle2Recipe
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 30
+
+recipe_args:
+  target_model_name_or_path: Qwen/Qwen3-8B
+  train_data_path: /path/to/train.jsonl
+  val_data_path: null
+  train_split: null
+  val_split: null
+  output_dir: ./outputs/eagle2_qwen3_mvp
+  seq_length: 1024
+  micro_batch_size: 1
+  grad_accumulation_steps: 1
+  num_workers: 0
+  num_epochs: 1
+  draft_num_hidden_layers: 1
+  hidden_loss_weight: 1.0
+  token_loss_weight: 0.1
+  freeze_embeddings: true
+  trust_remote_code: false
+  shuffle_seed: 42
+  log_every_steps: 10
+  max_grad_norm: 1.0
+
+optimizer:
+  lr: 1.0e-4
+  betas: [0.9, 0.95]
+  weight_decay: 0.0
+
+checkpoint:
+  enabled: true
+  checkpoint_dir: ./outputs/eagle2_qwen3_mvp/checkpoints
+  model_save_format: safetensors
+  save_consolidated: true

--- a/examples/speculative/eagle3/qwen3_eagle3_perfectblend.yaml
+++ b/examples/speculative/eagle3/qwen3_eagle3_perfectblend.yaml
@@ -1,0 +1,36 @@
+recipe: TrainEagle3Recipe
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 30
+
+recipe_args:
+  target_model_name_or_path: Qwen/Qwen3-8B
+  train_data_path: /path/to/train.jsonl
+  val_data_path: null
+  train_split: null
+  val_split: null
+  output_dir: ./outputs/eagle3_qwen3_mvp
+  seq_length: 1024
+  micro_batch_size: 1
+  grad_accumulation_steps: 1
+  num_workers: 0
+  num_epochs: 1
+  ttt_steps: 4
+  draft_vocab_size: 8192
+  freeze_embeddings: true
+  trust_remote_code: false
+  shuffle_seed: 42
+  log_every_steps: 10
+  max_grad_norm: 1.0
+
+optimizer:
+  lr: 1.0e-4
+  betas: [0.9, 0.95]
+  weight_decay: 0.0
+
+checkpoint:
+  enabled: true
+  checkpoint_dir: ./outputs/eagle3_qwen3_mvp/checkpoints
+  model_save_format: safetensors
+  save_consolidated: true

--- a/nemo_automodel/components/speculative/eagle/draft_llama.py
+++ b/nemo_automodel/components/speculative/eagle/draft_llama.py
@@ -18,10 +18,12 @@ The implementation is config-driven and supports any HuggingFace dense
 decoder-only architecture whose layout matches Llama: GQA attention with
 optional Q/K/V/O bias (`config.attention_bias`), SwiGLU MLP with optional
 bias (`config.mlp_bias`), RMSNorm, and rotary position embeddings parameterized
-by `config.rope_theta` / `config.rope_scaling`. This currently covers Llama
-and Phi-3 dense (Phi-3 omits `attention_bias` / `mlp_bias`, which the
-attention and MLP layers already read via
-`getattr(config, "<field>", False)`).
+by `config.rope_theta` / `config.rope_scaling`. This currently covers Llama,
+Phi-3, and Qwen3 dense (Phi-3 omits `attention_bias` / `mlp_bias`, which
+the attention and MLP layers already read via
+`getattr(config, "<field>", False)`; Qwen3 decouples `head_dim` from
+`hidden_size / num_attention_heads`, which the attention layer reads via
+`getattr(config, "head_dim", ...)`).
 
 Class names and the public `architectures` string remain ``LlamaEagle3*`` for
 backward compatibility with already-trained checkpoints and with SGLang's
@@ -442,7 +444,7 @@ class Eagle3LlamaModel(nn.Module):
 
 
 class LlamaEagle3DraftModel(PreTrainedModel):
-    """Llama-style dense EAGLE-3 draft model (Llama, Phi-3).
+    """Llama-style dense EAGLE-3 draft model (Llama, Phi-3, Qwen3).
 
     State dict keys match SGLang's ``LlamaForCausalLMEagle3`` so the saved
     checkpoint can be loaded by SGLang's inference engine without any

--- a/nemo_automodel/components/speculative/eagle/draft_llama_v12.py
+++ b/nemo_automodel/components/speculative/eagle/draft_llama_v12.py
@@ -14,7 +14,7 @@
 
 """Llama-style dense LLM draft model for EAGLE-1 / EAGLE-2 training.
 
-Config-driven; supports Llama and Phi-3 dense via standard HF config
+Config-driven; supports Llama, Phi-3, and Qwen3 dense via standard HF config
 fields (``attention_bias``, ``mlp_bias``, ``rope_theta``/``rope_scaling``,
 ``rms_norm_eps``). Class names are retained for checkpoint-architectures
 compatibility.
@@ -158,7 +158,7 @@ class EagleLlamaDecoderLayer(nn.Module):
 class LlamaEagleDraftModel(PreTrainedModel):
     """Llama-style dense draft that predicts next-step hidden states.
 
-    Works with Llama and Phi-3 dense configs. The class name is
+    Works with Llama, Phi-3, and Qwen3 dense configs. The class name is
     retained for backward compatibility with already-trained checkpoints.
     """
 

--- a/nemo_automodel/components/speculative/eagle/draft_llama_v12.py
+++ b/nemo_automodel/components/speculative/eagle/draft_llama_v12.py
@@ -122,7 +122,9 @@ class EagleLlamaMLP(nn.Module):
         self.down_proj = nn.Linear(
             config.intermediate_size, config.hidden_size, bias=getattr(config, "mlp_bias", False)
         )
-        self.act_fn = nn.SiLU()
+        from transformers.activations import ACT2FN
+
+        self.act_fn = ACT2FN[config.hidden_act]
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         return self.down_proj(self.act_fn(self.gate_proj(hidden_states)) * self.up_proj(hidden_states))

--- a/nemo_automodel/components/speculative/eagle/registry.py
+++ b/nemo_automodel/components/speculative/eagle/registry.py
@@ -55,6 +55,7 @@ class DraftSpec:
 _DENSE_ARCHITECTURES: tuple[str, ...] = (
     "LlamaForCausalLM",
     "Phi3ForCausalLM",
+    "Qwen3ForCausalLM",
 )
 
 

--- a/nemo_automodel/recipes/llm/train_eagle1.py
+++ b/nemo_automodel/recipes/llm/train_eagle1.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""EAGLE-1 / EAGLE-2 training recipe for Llama-style dense LLMs (Llama, Phi-3)."""
+"""EAGLE-1 / EAGLE-2 training recipe for Llama-style dense LLMs (Llama, Phi-3, Qwen3)."""
 
 from __future__ import annotations
 
@@ -62,7 +62,7 @@ def _all_reduce_mean(value: torch.Tensor) -> torch.Tensor:
 
 
 class TrainEagle1Recipe(BaseRecipe):
-    """Recipe for EAGLE-1 training on Llama-style dense LLMs (Llama, Phi-3)."""
+    """Recipe for EAGLE-1 training on Llama-style dense LLMs (Llama, Phi-3, Qwen3)."""
 
     def __init__(self, cfg):
         self.cfg = cfg

--- a/nemo_automodel/recipes/llm/train_eagle3.py
+++ b/nemo_automodel/recipes/llm/train_eagle3.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""EAGLE-3 training recipe for Llama-style dense LLMs (Llama, Phi-3)."""
+"""EAGLE-3 training recipe for Llama-style dense LLMs (Llama, Phi-3, Qwen3)."""
 
 from __future__ import annotations
 
@@ -81,7 +81,7 @@ def _all_reduce_mean(value: torch.Tensor) -> torch.Tensor:
 
 
 class TrainEagle3Recipe(BaseRecipe):
-    """Recipe for EAGLE-3 training on Llama-style dense LLMs (Llama, Phi-3)."""
+    """Recipe for EAGLE-3 training on Llama-style dense LLMs (Llama, Phi-3, Qwen3)."""
 
     def __init__(self, cfg):
         self.cfg = cfg


### PR DESCRIPTION
# What does this PR do?

Add Qwen3 (``Qwen3ForCausalLM``) as a supported target for EAGLE-1 /
EAGLE-2 / EAGLE-3 training. Stacked on top of #2312 (Phi-3 support);
the actual Qwen3-specific delta is one registry entry + three example
configs + docstring updates.

> **Depends on #2312.** Until #2312 lands, the diff shown here also
> includes the Phi-3 PR's commits as a prefix. After #2312 merges this
> branch will rebase onto main and become a 3-line incremental PR.
> The Qwen3-specific commit is `b3d018c8`.

## Changelog (Qwen3 delta only)

- ``components/speculative/eagle/registry.py``: append
  ``Qwen3ForCausalLM`` to ``_DENSE_ARCHITECTURES``. Qwen3 already works
  through the existing config-driven draft path -- it decouples
  ``head_dim`` from ``hidden_size / num_attention_heads``, which the
  attention layer already reads via
  ``getattr(config, "head_dim", ...)``; ``attention_bias`` and
  ``mlp_bias`` are exposed on ``Qwen3Config`` so they are read normally.
- Add example YAMLs:
  ``examples/speculative/eagle{1,2,3}/qwen3_eagle{1,2,3}_perfectblend.yaml``.
- Update draft / recipe docstrings to mention Qwen3 alongside Llama and Phi-3.

No code-path changes were required. The registry dispatch already
exists from #2312.

## Verification

End-to-end smoke test on 8 x H100:

- Target: ``Qwen/Qwen3-8B`` (15.26 GB, 8.19 B params, ``model_type=qwen3``).
- Dataset: PerfectBlend (200-sample slice).
- EAGLE-3 over 25 optimizer steps:

```
2026-05-25 20:34:04 INFO Training start: start_epoch=0 num_epochs=1 batches_per_epoch=25
2026-05-25 20:34:06 INFO epoch=0 step=1  train_loss=9.846308  train_acc=0.000000
2026-05-25 20:34:06 INFO epoch=0 step=2  train_loss=8.477696  train_acc=0.029953
2026-05-25 20:34:07 INFO epoch=0 step=3  train_loss=8.218086  train_acc=0.053741
...
2026-05-25 20:34:13 INFO epoch=0 step=23 train_loss=6.182835  train_acc=0.113525
2026-05-25 20:34:13 INFO epoch=0 step=24 train_loss=6.219086  train_acc=0.098724
2026-05-25 20:34:14 INFO epoch=0 step=25 train_loss=6.175844  train_acc=0.093933
2026-05-25 20:34:14 INFO Epoch 0 done: total_batches_seen=25 global_step=25
```

Loss decreases ``9.85 -> 6.18`` over 25 steps (~37% drop), accuracy ticks
up from ``0`` to ``~0.09``. No ``TypeError`` / ``AttributeError`` at
draft construction, target load (Liger applied to ``model type: qwen3``
without complaint), or training step.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Contributor guidelines followed
- [ ] Did you write any new necessary tests? No -- end-to-end repro needs
  multi-GPU + a real Qwen3 target; smoke-test evidence above.
- [x] Example configs added under ``examples/speculative/eagle{1,2,3}/``.