### PR TITLE
fix(datasets): align reasoning + assistant loss masks for left padding

### DIFF
--- a/nemo_automodel/components/datasets/llm/formatting_utils.py
+++ b/nemo_automodel/components/datasets/llm/formatting_utils.py
@@ -639,7 +639,9 @@ def format_chat_template(
             seq_length=seq_length,
         )
         # _build_reasoning_mask also computes from unpadded lengths.
-        reasoning_mask = _maybe_shift_mask_for_left_padding(reasoning_mask, tokenizer, tokenized_chat.get("attention_mask"))
+        reasoning_mask = _maybe_shift_mask_for_left_padding(
+            reasoning_mask, tokenizer, tokenized_chat.get("attention_mask")
+        )
         mask = [assistant if not reasoning else 0 for assistant, reasoning in zip(mask, reasoning_mask)]
 
     return _package_tokenized_example(

--- a/nemo_automodel/components/datasets/llm/formatting_utils.py
+++ b/nemo_automodel/components/datasets/llm/formatting_utils.py
@@ -104,6 +104,31 @@ def _tokenize_chat(
     return tokenized_chat.get("input_ids", [])
 
 
+def _maybe_shift_mask_for_left_padding(
+    mask: List[int],
+    tokenizer: "PreTrainedTokenizer",
+    attention_mask: Optional[List[int]],
+) -> List[int]:
+    """Shift a token-level mask right when the tokenizer uses left padding.
+
+    ``_build_multiturn_assistant_mask`` and ``_build_reasoning_mask`` compute
+    span indices from **unpadded** (left-aligned) tokenizations.  When the
+    tokenizer pads on the left, actual content is right-aligned in
+    ``input_ids``, so the mask must be shifted right by the padding offset to
+    keep positions aligned.
+
+    For right-padding tokenizers (the majority) this is a no-op.
+    """
+    if getattr(tokenizer, "padding_side", "right") != "left":
+        return mask
+    if attention_mask is None:
+        return mask
+    pad_len = len(mask) - sum(attention_mask)
+    if pad_len <= 0:
+        return mask
+    return [0] * pad_len + mask[: len(mask) - pad_len]
+
+
 def _build_multiturn_assistant_mask(
     tokenizer: "PreTrainedTokenizer",
     formatted_text: List[Dict[str, Any]],
@@ -590,14 +615,9 @@ def format_chat_template(
             truncation=truncation,
             seq_length=seq_length,
         )
-        # _build_multiturn_assistant_mask computes indices from unpadded (left-aligned)
-        # lengths. Left-padding tokenizers right-align content — shift mask to match.
-        if getattr(tokenizer, "padding_side", "right") == "left":
-            attn_mask = tokenized_chat.get("attention_mask")
-            if attn_mask is not None:
-                pad_len = len(input_ids) - sum(attn_mask)
-                if pad_len > 0:
-                    mask = [0] * pad_len + mask[: len(mask) - pad_len]
+        # _build_multiturn_assistant_mask computes indices from unpadded
+        # lengths — shift for left-padding tokenizers.
+        mask = _maybe_shift_mask_for_left_padding(mask, tokenizer, tokenized_chat.get("attention_mask"))
     else:
         mask = [1] * len(input_ids)
 
@@ -618,6 +638,8 @@ def format_chat_template(
             truncation=truncation,
             seq_length=seq_length,
         )
+        # _build_reasoning_mask also computes from unpadded lengths.
+        reasoning_mask = _maybe_shift_mask_for_left_padding(reasoning_mask, tokenizer, tokenized_chat.get("attention_mask"))
         mask = [assistant if not reasoning else 0 for assistant, reasoning in zip(mask, reasoning_mask)]
 
     return _package_tokenized_example(

--- a/tests/unit_tests/datasets/llm/test_shift_mask_left_padding.py
+++ b/tests/unit_tests/datasets/llm/test_shift_mask_left_padding.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for _maybe_shift_mask_for_left_padding in formatting_utils."""
+
+from types import SimpleNamespace
+
+from nemo_automodel.components.datasets.llm.formatting_utils import _maybe_shift_mask_for_left_padding
+
+
+def _make_tokenizer(padding_side: str) -> SimpleNamespace:
+    return SimpleNamespace(padding_side=padding_side)
+
+
+# ── Right-padding tokenizer: no-op ──────────────────────────────────────
+
+
+def test_right_padding_is_noop():
+    tok = _make_tokenizer("right")
+    mask = [0, 0, 1, 1, 1, 0, 0, 0]
+    attn = [1, 1, 1, 1, 1, 0, 0, 0]
+    result = _maybe_shift_mask_for_left_padding(mask, tok, attn)
+    assert result is mask, "Should return the exact same list object (no copy)"
+
+
+# ── Left-padding tokenizer: shift right by pad_len ──────────────────────
+
+
+def test_left_padding_shifts_mask_right():
+    tok = _make_tokenizer("left")
+    # 3 pad tokens on the left, content at positions 3-7
+    attn = [0, 0, 0, 1, 1, 1, 1, 1]
+    # mask built from unpadded positions: 1s at indices 2-4
+    mask = [0, 0, 1, 1, 1, 0, 0, 0]
+    result = _maybe_shift_mask_for_left_padding(mask, tok, attn)
+    # pad_len=3 → shift right by 3: 1s should be at indices 5-7
+    assert result == [0, 0, 0, 0, 0, 1, 1, 1]
+
+
+def test_left_padding_preserves_length():
+    tok = _make_tokenizer("left")
+    mask = [0, 1, 1, 0, 0]
+    attn = [0, 0, 1, 1, 1]
+    result = _maybe_shift_mask_for_left_padding(mask, tok, attn)
+    assert len(result) == len(mask)
+
+
+def test_left_padding_zero_pad_is_noop():
+    tok = _make_tokenizer("left")
+    # No actual padding — all tokens are content
+    mask = [0, 1, 1, 0]
+    attn = [1, 1, 1, 1]
+    result = _maybe_shift_mask_for_left_padding(mask, tok, attn)
+    assert result is mask, "pad_len=0 → should return original list"
+
+
+# ── Edge cases ───────────────────────────────────────────────────────────
+
+
+def test_attention_mask_none_returns_original():
+    tok = _make_tokenizer("left")
+    mask = [0, 1, 1, 0]
+    result = _maybe_shift_mask_for_left_padding(mask, tok, None)
+    assert result is mask
+
+
+def test_no_padding_side_attr_defaults_to_right():
+    tok = SimpleNamespace()  # no padding_side attribute
+    mask = [0, 1, 1, 0, 0]
+    attn = [0, 0, 1, 1, 1]
+    result = _maybe_shift_mask_for_left_padding(mask, tok, attn)
+    assert result is mask, "Missing padding_side should default to right (no-op)"
+
+
+def test_all_padding_shifts_entire_mask():
+    tok = _make_tokenizer("left")
+    # Entire sequence is padding
+    mask = [1, 1, 0, 0]
+    attn = [0, 0, 0, 0]
+    result = _maybe_shift_mask_for_left_padding(mask, tok, attn)
+    assert result == [0, 0, 0, 0]
+
+
+def test_single_token_content():
+    tok = _make_tokenizer("left")
+    mask = [1, 0, 0]
+    attn = [0, 0, 1]
+    result = _maybe_shift_mask_for_left_padding(mask, tok, attn)
+    # pad_len=2, shift right by 2: mask[0]=1 → position 2
+    assert result == [0, 0, 1]


### PR DESCRIPTION
# What does this PR do?

Fix loss-mask misalignment for left-padding tokenizers in
``format_chat_template``. Affects both the assistant mask and the
reasoning mask paths.

## Background

``_build_multiturn_assistant_mask`` and ``_build_reasoning_mask`` compute
their span indices from **unpadded** (``padding=False``) tokenizations
because they walk the formatted text to find role boundaries. The mask
arrays they return are sized to the *padded* ``input_ids``, however --
and when ``tokenizer.padding_side == "left"`` (e.g. Phi-3,
some Qwen-VL configs) the actual content is right-aligned in
``input_ids``. The mask positions then fall in the left-padding region,
the subsequent ``attention_mask``-based zeroing wipes them, and training
silently learns from an all-zero loss mask for ~80% of samples.

## Relationship to #2312

#2312 fixes this for the **assistant mask** path with an inline shift.
This PR is a strict superset of that fix:

1. Extracts the shift into a reusable ``_maybe_shift_mask_for_left_padding``
   helper.
2. Applies it to **both** the assistant mask path (same site as #2312)
   **and** the reasoning mask path (which #2312 missed).
3. Adds unit tests for the helper (8 cases covering happy / no-op /
   edge paths).

#2312 has since landed; the rebase conflict at the assistant-mask site has
been resolved by replacing the inline shift with the helper call.

## Changelog

- ``components/datasets/llm/formatting_utils.py``:
  - Add ``_maybe_shift_mask_for_left_padding(mask, tokenizer, attention_mask)``
    helper. Three short-circuit guards make it a no-op for
    right-padding tokenizers, missing ``attention_mask``, and
    ``pad_len == 0``.
  - Replace the inline shift from #2312 with a call to the helper after
    ``_build_multiturn_assistant_mask``.
  - Call it after ``_build_reasoning_mask`` (the bug #2312 missed).
- ``tests/unit_tests/datasets/llm/test_shift_mask_left_padding.py``:
  8 unit tests using a ``SimpleNamespace`` fake tokenizer (no HF
  dependency), covering right-padding no-op, left-padding shift,
  zero ``pad_len`` no-op, ``attention_mask=None``, missing
  ``padding_side`` attribute (default right), all-padding,
  single-content-token.

## Verification

Unit tests pass locally:

```
pytest tests/unit_tests/datasets/llm/test_shift_mask_left_padding.py -v
```

For right-padding tokenizers (Llama / Qwen / Mistral / ...) the helper
returns the original list object unchanged -- no behavioural change.

For left-padding tokenizers (Phi-3, ...) the previously-silent
all-zero loss_mask is now correctly aligned with content positions.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Contributor guidelines followed
- [x] Unit tests added (``test_shift_mask_left_padding.py``)
- [x] No documentation changes needed -- internal helper.