### PR TITLE
feat(speculative): add Qwen3-MoE target support to EAGLE-1/2/3

### DIFF
--- a/examples/speculative/eagle1/qwen3_moe_eagle1_perfectblend.yaml
+++ b/examples/speculative/eagle1/qwen3_moe_eagle1_perfectblend.yaml
@@ -4,6 +4,16 @@ dist_env:
   backend: nccl
   timeout_minutes: 30
 
+# FSDP2 sharding for the target. Qwen3-30B-A3B is ~60GB in bf16; without
+# sharding every rank would replicate the full target and OOM on 80GB.
+distributed:
+  strategy: fsdp2
+  tp_size: 1
+  pp_size: 1
+  cp_size: 1
+  ep_size: 1
+  activation_checkpointing: true
+
 recipe_args:
   target_model_name_or_path: Qwen/Qwen3-30B-A3B
   train_data_path: /path/to/train.jsonl

--- a/examples/speculative/eagle1/qwen3_moe_eagle1_perfectblend.yaml
+++ b/examples/speculative/eagle1/qwen3_moe_eagle1_perfectblend.yaml
@@ -1,0 +1,37 @@
+recipe: TrainEagle1Recipe
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 30
+
+recipe_args:
+  target_model_name_or_path: Qwen/Qwen3-30B-A3B
+  train_data_path: /path/to/train.jsonl
+  val_data_path: null
+  train_split: null
+  val_split: null
+  output_dir: ./outputs/eagle1_qwen3_moe_mvp
+  seq_length: 1024
+  micro_batch_size: 1
+  grad_accumulation_steps: 1
+  num_workers: 0
+  num_epochs: 1
+  draft_num_hidden_layers: 1
+  hidden_loss_weight: 1.0
+  token_loss_weight: 0.1
+  freeze_embeddings: true
+  trust_remote_code: false
+  shuffle_seed: 42
+  log_every_steps: 10
+  max_grad_norm: 1.0
+
+optimizer:
+  lr: 1.0e-4
+  betas: [0.9, 0.95]
+  weight_decay: 0.0
+
+checkpoint:
+  enabled: true
+  checkpoint_dir: ./outputs/eagle1_qwen3_moe_mvp/checkpoints
+  model_save_format: safetensors
+  save_consolidated: true

--- a/examples/speculative/eagle1/qwen3_moe_eagle1_perfectblend.yaml
+++ b/examples/speculative/eagle1/qwen3_moe_eagle1_perfectblend.yaml
@@ -6,12 +6,15 @@ dist_env:
 
 # FSDP2 sharding for the target. Qwen3-30B-A3B is ~60GB in bf16; without
 # sharding every rank would replicate the full target and OOM on 80GB.
+# ``ep_size: 8`` splits the 128 experts across 8 ranks (16 experts each);
+# the remaining non-expert weights are FSDP-sharded across the
+# ``world_size // ep_size`` DP ranks.
 distributed:
   strategy: fsdp2
   tp_size: 1
   pp_size: 1
   cp_size: 1
-  ep_size: 1
+  ep_size: 8
   activation_checkpointing: true
 
 recipe_args:

--- a/examples/speculative/eagle2/qwen3_moe_eagle2_perfectblend.yaml
+++ b/examples/speculative/eagle2/qwen3_moe_eagle2_perfectblend.yaml
@@ -4,6 +4,16 @@ dist_env:
   backend: nccl
   timeout_minutes: 30
 
+# FSDP2 sharding for the target. Qwen3-30B-A3B is ~60GB in bf16; without
+# sharding every rank would replicate the full target and OOM on 80GB.
+distributed:
+  strategy: fsdp2
+  tp_size: 1
+  pp_size: 1
+  cp_size: 1
+  ep_size: 1
+  activation_checkpointing: true
+
 recipe_args:
   target_model_name_or_path: Qwen/Qwen3-30B-A3B
   train_data_path: /path/to/train.jsonl

--- a/examples/speculative/eagle2/qwen3_moe_eagle2_perfectblend.yaml
+++ b/examples/speculative/eagle2/qwen3_moe_eagle2_perfectblend.yaml
@@ -1,0 +1,37 @@
+recipe: TrainEagle2Recipe
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 30
+
+recipe_args:
+  target_model_name_or_path: Qwen/Qwen3-30B-A3B
+  train_data_path: /path/to/train.jsonl
+  val_data_path: null
+  train_split: null
+  val_split: null
+  output_dir: ./outputs/eagle2_qwen3_moe_mvp
+  seq_length: 1024
+  micro_batch_size: 1
+  grad_accumulation_steps: 1
+  num_workers: 0
+  num_epochs: 1
+  draft_num_hidden_layers: 1
+  hidden_loss_weight: 1.0
+  token_loss_weight: 0.1
+  freeze_embeddings: true
+  trust_remote_code: false
+  shuffle_seed: 42
+  log_every_steps: 10
+  max_grad_norm: 1.0
+
+optimizer:
+  lr: 1.0e-4
+  betas: [0.9, 0.95]
+  weight_decay: 0.0
+
+checkpoint:
+  enabled: true
+  checkpoint_dir: ./outputs/eagle2_qwen3_moe_mvp/checkpoints
+  model_save_format: safetensors
+  save_consolidated: true

--- a/examples/speculative/eagle2/qwen3_moe_eagle2_perfectblend.yaml
+++ b/examples/speculative/eagle2/qwen3_moe_eagle2_perfectblend.yaml
@@ -6,12 +6,15 @@ dist_env:
 
 # FSDP2 sharding for the target. Qwen3-30B-A3B is ~60GB in bf16; without
 # sharding every rank would replicate the full target and OOM on 80GB.
+# ``ep_size: 8`` splits the 128 experts across 8 ranks (16 experts each);
+# the remaining non-expert weights are FSDP-sharded across the
+# ``world_size // ep_size`` DP ranks.
 distributed:
   strategy: fsdp2
   tp_size: 1
   pp_size: 1
   cp_size: 1
-  ep_size: 1
+  ep_size: 8
   activation_checkpointing: true
 
 recipe_args:

--- a/examples/speculative/eagle3/qwen3_moe_eagle3_perfectblend.yaml
+++ b/examples/speculative/eagle3/qwen3_moe_eagle3_perfectblend.yaml
@@ -1,0 +1,36 @@
+recipe: TrainEagle3Recipe
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 30
+
+recipe_args:
+  target_model_name_or_path: Qwen/Qwen3-30B-A3B
+  train_data_path: /path/to/train.jsonl
+  val_data_path: null
+  train_split: null
+  val_split: null
+  output_dir: ./outputs/eagle3_qwen3_moe_mvp
+  seq_length: 1024
+  micro_batch_size: 1
+  grad_accumulation_steps: 1
+  num_workers: 0
+  num_epochs: 1
+  ttt_steps: 4
+  draft_vocab_size: 8192
+  freeze_embeddings: true
+  trust_remote_code: false
+  shuffle_seed: 42
+  log_every_steps: 10
+  max_grad_norm: 1.0
+
+optimizer:
+  lr: 1.0e-4
+  betas: [0.9, 0.95]
+  weight_decay: 0.0
+
+checkpoint:
+  enabled: true
+  checkpoint_dir: ./outputs/eagle3_qwen3_moe_mvp/checkpoints
+  model_save_format: safetensors
+  save_consolidated: true

--- a/examples/speculative/eagle3/qwen3_moe_eagle3_perfectblend.yaml
+++ b/examples/speculative/eagle3/qwen3_moe_eagle3_perfectblend.yaml
@@ -4,6 +4,21 @@ dist_env:
   backend: nccl
   timeout_minutes: 30
 
+# FSDP2 sharding for the target. Qwen3-30B-A3B is ~60GB in bf16, which
+# does not fit on a single 80GB GPU once the draft, activations, and
+# optimizer state are added. With ``strategy: fsdp2`` and the default
+# ``dp_size`` (= world_size), each rank holds 1/N of the target weights;
+# the forward pass gathers per layer and immediately reshards.
+# ``activation_checkpointing: true`` keeps memory headroom for the
+# TTT-unrolled draft forwards on top of the target forward.
+distributed:
+  strategy: fsdp2
+  tp_size: 1
+  pp_size: 1
+  cp_size: 1
+  ep_size: 1
+  activation_checkpointing: true
+
 recipe_args:
   target_model_name_or_path: Qwen/Qwen3-30B-A3B
   train_data_path: /path/to/train.jsonl

--- a/examples/speculative/eagle3/qwen3_moe_eagle3_perfectblend.yaml
+++ b/examples/speculative/eagle3/qwen3_moe_eagle3_perfectblend.yaml
@@ -6,17 +6,19 @@ dist_env:
 
 # FSDP2 sharding for the target. Qwen3-30B-A3B is ~60GB in bf16, which
 # does not fit on a single 80GB GPU once the draft, activations, and
-# optimizer state are added. With ``strategy: fsdp2`` and the default
-# ``dp_size`` (= world_size), each rank holds 1/N of the target weights;
-# the forward pass gathers per layer and immediately reshards.
-# ``activation_checkpointing: true`` keeps memory headroom for the
-# TTT-unrolled draft forwards on top of the target forward.
+# optimizer state are added. ``ep_size: 8`` splits the 128 experts across
+# 8 ranks (16 experts per rank), and ``dp_size`` defaults to
+# ``world_size // ep_size`` -- each DP rank holds 1/dp_size of the
+# non-expert target weights, gathered per layer and immediately reshared
+# in the forward pass. ``activation_checkpointing: true`` keeps memory
+# headroom for the TTT-unrolled draft forwards on top of the target
+# forward. EP8 was validated end-to-end on an 8xH100 node.
 distributed:
   strategy: fsdp2
   tp_size: 1
   pp_size: 1
   cp_size: 1
-  ep_size: 1
+  ep_size: 8
   activation_checkpointing: true
 
 recipe_args:

--- a/nemo_automodel/components/speculative/eagle/draft_llama.py
+++ b/nemo_automodel/components/speculative/eagle/draft_llama.py
@@ -478,9 +478,19 @@ class LlamaEagle3DraftModel(PreTrainedModel):
         self.post_init()
 
     def copy_embeddings_from_target(self, target_embedding: nn.Embedding) -> None:
-        """Initialize draft embeddings from the target model embeddings."""
+        """Initialize draft embeddings from the target model embeddings.
+
+        When the target model is wrapped with FSDP2, ``target_embedding.weight``
+        is a ``DTensor`` sharded across ranks.  The draft embedding is a plain
+        ``nn.Parameter`` (the draft is not FSDP-wrapped), so a direct
+        ``copy_`` of a DTensor into a regular tensor raises a mixed-type
+        distributed-operator error.  Gather to a full local tensor first.
+        """
+        target_weight = target_embedding.weight
+        if hasattr(target_weight, "full_tensor"):
+            target_weight = target_weight.full_tensor()
         with torch.no_grad():
-            self.model.embed_tokens.weight.copy_(target_embedding.weight)
+            self.model.embed_tokens.weight.copy_(target_weight)
 
     def freeze_embeddings(self) -> None:
         """Freeze draft input embeddings."""

--- a/nemo_automodel/components/speculative/eagle/draft_llama_v12.py
+++ b/nemo_automodel/components/speculative/eagle/draft_llama_v12.py
@@ -175,9 +175,18 @@ class LlamaEagleDraftModel(PreTrainedModel):
         self.post_init()
 
     def copy_embeddings_from_target(self, target_embeddings: nn.Embedding) -> None:
-        """Copy the target model token embeddings into the draft embeddings."""
+        """Copy the target model token embeddings into the draft embeddings.
+
+        When the target is wrapped with FSDP2, its ``embed_tokens.weight`` is
+        a ``DTensor`` sharded across ranks.  Gather to a local full tensor
+        before copying into the (unsharded) draft parameter -- otherwise
+        ``aten.copy_`` raises a mixed Tensor/DTensor error.
+        """
+        target_weight = target_embeddings.weight
+        if hasattr(target_weight, "full_tensor"):
+            target_weight = target_weight.full_tensor()
         with torch.no_grad():
-            self.embed_tokens.weight.copy_(target_embeddings.weight.to(self.embed_tokens.weight.device))
+            self.embed_tokens.weight.copy_(target_weight.to(self.embed_tokens.weight.device))
 
     def freeze_embeddings(self) -> None:
         """Freeze draft token embeddings."""

--- a/nemo_automodel/components/speculative/eagle/registry.py
+++ b/nemo_automodel/components/speculative/eagle/registry.py
@@ -49,12 +49,15 @@ class DraftSpec:
 
 # Llama-style dense LLMs. The dense draft works for any architecture in this
 # tuple as long as the target supports HuggingFace's
-# ``output_hidden_states=True`` mechanism (all standard causal-LM HF models do,
-# including MoE backbones -- the draft only consumes the post-block hidden
-# states, not the per-expert routing internals).
+# ``output_hidden_states=True`` mechanism. This includes MoE backbones
+# (e.g. ``Qwen3MoeForCausalLM``): the draft only consumes the post-block
+# hidden states emitted by ``register_forward_hook`` on each decoder layer,
+# not the per-expert routing internals -- so an MoE target is treated
+# identically to a dense target end-to-end.
 _DENSE_ARCHITECTURES: tuple[str, ...] = (
     "LlamaForCausalLM",
     "Phi3ForCausalLM",
+    "Qwen3MoeForCausalLM",
 )
 
 

--- a/nemo_automodel/components/speculative/eagle/target.py
+++ b/nemo_automodel/components/speculative/eagle/target.py
@@ -16,8 +16,9 @@
 
 from __future__ import annotations
 
+import inspect
 from dataclasses import dataclass
-from typing import Iterable, Sequence
+from typing import Sequence
 
 import torch
 import torch.nn as nn
@@ -95,18 +96,31 @@ class HFEagle3TargetModel:
                 raise ValueError(f"aux layer id {layer_id} is out of bounds for model with {num_layers} layers")
         return aux_layer_ids
 
-    def _get_transformer_layers(self) -> Iterable[nn.Module]:
+    def _get_transformer_layers(self) -> list[nn.Module]:
+        """Return decoder layers as an ordered list indexable by integer.
+
+        Supports both the HuggingFace layouts (where ``layers`` is a
+        ``ModuleList``) and AutoModel's custom-impl layouts (where
+        ``layers`` is a ``ModuleDict`` keyed by ``str(i)``). Returning a
+        plain list normalizes the access pattern for downstream
+        ``register_forward_hook`` calls.
+        """
         # Common HF causal-LM layouts:
         #   model.model.layers              (Llama, Qwen, Mistral, Gemma, Phi, ...)
         #   model.layers                    (some VLM text backbones exposed directly)
         #   model.transformer.h             (GPT2 / Falcon-style)
         if hasattr(self.model, "model") and hasattr(self.model.model, "layers"):
-            return self.model.model.layers
-        if hasattr(self.model, "layers"):
-            return self.model.layers
-        if hasattr(self.model, "transformer") and hasattr(self.model.transformer, "h"):
-            return self.model.transformer.h
-        raise ValueError("Unsupported model structure for EAGLE-3 aux-layer capture")
+            container = self.model.model.layers
+        elif hasattr(self.model, "layers"):
+            container = self.model.layers
+        elif hasattr(self.model, "transformer") and hasattr(self.model.transformer, "h"):
+            container = self.model.transformer.h
+        else:
+            raise ValueError("Unsupported model structure for EAGLE-3 aux-layer capture")
+        if isinstance(container, nn.ModuleDict):
+            # AutoModel custom impls use ModuleDict keyed by ``str(i)``.
+            return [container[str(i)] for i in range(len(container))]
+        return list(container)
 
     def get_input_embeddings(self) -> nn.Embedding:
         """Return the target model input embeddings."""
@@ -135,13 +149,20 @@ class HFEagle3TargetModel:
                 raise ValueError(f"aux layer id {layer_id} is out of bounds for model with {len(layers)} layers")
             handles.append(layers[layer_id].register_forward_hook(_make_hook(layer_id)))
 
+        # AutoModel's custom causal LMs only declare ``input_ids``,
+        # ``attention_mask``, ``position_ids``, ``padding_mask`` and a
+        # ``**attn_kwargs`` catch-all; the HF flags below mean nothing to
+        # them and are dropped to keep the call site honest.
+        forward_params = inspect.signature(self.model.forward).parameters
+        extra_kwargs = {
+            name: False for name in ("output_hidden_states", "output_attentions", "use_cache") if name in forward_params
+        }
+
         try:
             outputs = self.model(
                 input_ids=input_ids,
                 attention_mask=attention_mask,
-                output_hidden_states=False,
-                output_attentions=False,
-                use_cache=False,
+                **extra_kwargs,
             )
         finally:
             for handle in handles:
@@ -153,7 +174,10 @@ class HFEagle3TargetModel:
             )
 
         aux_hidden_states = torch.cat([captured[layer_id] for layer_id in self.aux_layer_ids], dim=-1)
-        shifted_logits = _shift_left_with_zero(outputs.logits)
+        # HF causal LM outputs wrap logits in a dataclass; AutoModel's
+        # custom causal LM returns the logits tensor directly.
+        target_logits = outputs.logits if hasattr(outputs, "logits") else outputs
+        shifted_logits = _shift_left_with_zero(target_logits)
         shifted_input_ids = _shift_left_with_zero(input_ids)
         shifted_loss_mask = _shift_left_with_zero(loss_mask)
         return Eagle3TargetBatch(

--- a/nemo_automodel/components/speculative/eagle/target_v12.py
+++ b/nemo_automodel/components/speculative/eagle/target_v12.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import inspect
 from dataclasses import dataclass
 
 import torch
@@ -62,14 +63,26 @@ class HFEagleTargetModel:
         loss_mask: torch.Tensor,
     ) -> EagleTargetBatch:
         """Run the target transformer and prepare shifted supervision tensors."""
-        outputs = self.model.model(
+        # Strip HF-only flags when the base model doesn't declare them.
+        # AutoModel's custom backbones expose a ``**attn_kwargs`` catch-all
+        # and silently ignore ``output_*`` / ``use_cache``; HF backbones
+        # declare them and care.
+        base_model = self.model.model
+        base_forward_params = inspect.signature(base_model.forward).parameters
+        extra_kwargs = {
+            name: False
+            for name in ("output_hidden_states", "output_attentions", "use_cache")
+            if name in base_forward_params
+        }
+        outputs = base_model(
             input_ids=input_ids,
             attention_mask=attention_mask,
-            output_attentions=False,
-            output_hidden_states=False,
-            use_cache=False,
+            **extra_kwargs,
         )
-        hidden_states = outputs[0]
+        # HF base models return a dataclass whose first item is
+        # ``last_hidden_state``; AutoModel custom backbones return the
+        # bare hidden tensor.
+        hidden_states = outputs if isinstance(outputs, torch.Tensor) else outputs[0]
         logits = self.model.lm_head(hidden_states)
         return EagleTargetBatch(
             input_hidden_states=hidden_states,

--- a/nemo_automodel/recipes/llm/train_eagle1.py
+++ b/nemo_automodel/recipes/llm/train_eagle1.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""EAGLE-1 / EAGLE-2 training recipe for Llama-style dense LLMs (Llama, Phi-3)."""
+"""EAGLE-1 / EAGLE-2 training recipe for Llama-style dense LLMs (Llama, Phi-3) and MoE backbones (Qwen3-MoE)."""
 
 from __future__ import annotations
 
@@ -62,7 +62,7 @@ def _all_reduce_mean(value: torch.Tensor) -> torch.Tensor:
 
 
 class TrainEagle1Recipe(BaseRecipe):
-    """Recipe for EAGLE-1 training on Llama-style dense LLMs (Llama, Phi-3)."""
+    """Recipe for EAGLE-1 training on Llama-style dense LLMs (Llama, Phi-3) and MoE backbones (Qwen3-MoE)."""
 
     def __init__(self, cfg):
         self.cfg = cfg

--- a/nemo_automodel/recipes/llm/train_eagle1.py
+++ b/nemo_automodel/recipes/llm/train_eagle1.py
@@ -44,6 +44,7 @@ from nemo_automodel.components.speculative.eagle.core_v12 import EagleTrainerMod
 from nemo_automodel.components.speculative.eagle.registry import resolve_eagle1_draft_spec
 from nemo_automodel.components.speculative.eagle.target_v12 import HFEagleTargetModel
 from nemo_automodel.components.training.rng import StatefulRNG
+from nemo_automodel.recipes._dist_setup import setup_distributed
 from nemo_automodel.recipes.base_recipe import (
     BaseRecipe,
     _find_latest_checkpoint,
@@ -94,12 +95,34 @@ class TrainEagle1Recipe(BaseRecipe):
             trust_remote_code=recipe_cfg.get("trust_remote_code", False),
         )
         self.compute_dtype = torch.bfloat16 if self.device.type == "cuda" else torch.float32
-        self.target_model = NeMoAutoModelForCausalLM.from_pretrained(
-            target_path,
+
+        # Optional ``distributed:`` YAML section. Required for targets that
+        # do not fit on a single GPU (e.g. Qwen3-30B-A3B MoE). Absent =>
+        # original single-GPU-per-rank behavior, preserved for 8B-class dense.
+        target_kwargs = dict(
             trust_remote_code=recipe_cfg.get("trust_remote_code", False),
             torch_dtype=self.compute_dtype,
             force_hf=True,
-        ).to(self.device)
+        )
+        self.dist_setup = None
+        self.distributed_config = None
+        self.device_mesh = None
+        self.moe_mesh = None
+        if self.cfg.get("distributed", None) is not None:
+            self.dist_setup = setup_distributed(self.cfg, world_size=self.dist_env.world_size)
+            self.distributed_config = self.dist_setup.strategy_config
+            self.device_mesh = self.dist_setup.device_mesh
+            self.moe_mesh = self.dist_setup.moe_mesh
+            target_kwargs.update(
+                distributed_config=self.distributed_config,
+                device_mesh=self.device_mesh,
+                moe_mesh=self.moe_mesh,
+                moe_config=self.dist_setup.moe_config,
+                activation_checkpointing=self.dist_setup.activation_checkpointing,
+            )
+        self.target_model = NeMoAutoModelForCausalLM.from_pretrained(target_path, **target_kwargs)
+        if self.dist_setup is None:
+            self.target_model = self.target_model.to(self.device)
         self.target_model.requires_grad_(False)
         self.target_wrapper = HFEagleTargetModel(self.target_model)
 

--- a/nemo_automodel/recipes/llm/train_eagle1.py
+++ b/nemo_automodel/recipes/llm/train_eagle1.py
@@ -99,10 +99,11 @@ class TrainEagle1Recipe(BaseRecipe):
         # Optional ``distributed:`` YAML section. Required for targets that
         # do not fit on a single GPU (e.g. Qwen3-30B-A3B MoE). Absent =>
         # original single-GPU-per-rank behavior, preserved for 8B-class dense.
+        # ``force_hf`` opt-in; see the train_eagle3 recipe for rationale.
         target_kwargs = dict(
             trust_remote_code=recipe_cfg.get("trust_remote_code", False),
             torch_dtype=self.compute_dtype,
-            force_hf=True,
+            force_hf=bool(recipe_cfg.get("target_force_hf", False)),
         )
         self.dist_setup = None
         self.distributed_config = None

--- a/nemo_automodel/recipes/llm/train_eagle3.py
+++ b/nemo_automodel/recipes/llm/train_eagle3.py
@@ -49,6 +49,7 @@ from nemo_automodel.components.speculative.eagle import (
 )
 from nemo_automodel.components.speculative.eagle.registry import resolve_eagle3_draft_spec
 from nemo_automodel.components.training.rng import StatefulRNG
+from nemo_automodel.recipes._dist_setup import setup_distributed
 from nemo_automodel.recipes.base_recipe import (
     BaseRecipe,
     _find_latest_checkpoint,
@@ -113,12 +114,38 @@ class TrainEagle3Recipe(BaseRecipe):
             trust_remote_code=recipe_cfg.get("trust_remote_code", False),
         )
         self.compute_dtype = torch.bfloat16 if self.device.type == "cuda" else torch.float32
-        self.target_model = NeMoAutoModelForCausalLM.from_pretrained(
-            target_path,
+
+        # Optional ``distributed:`` YAML section. Required for targets that
+        # do not fit on a single GPU (e.g. Qwen3-30B-A3B MoE): without it,
+        # ``from_pretrained`` loads the full target on every rank and OOMs.
+        # When absent, the recipe keeps the original single-GPU-per-rank
+        # behavior so existing 8B-class dense recipes are unaffected.
+        target_kwargs = dict(
             trust_remote_code=recipe_cfg.get("trust_remote_code", False),
             torch_dtype=self.compute_dtype,
             force_hf=True,
-        ).to(self.device)
+        )
+        self.dist_setup = None
+        self.distributed_config = None
+        self.device_mesh = None
+        self.moe_mesh = None
+        if self.cfg.get("distributed", None) is not None:
+            self.dist_setup = setup_distributed(self.cfg, world_size=self.dist_env.world_size)
+            self.distributed_config = self.dist_setup.strategy_config
+            self.device_mesh = self.dist_setup.device_mesh
+            self.moe_mesh = self.dist_setup.moe_mesh
+            target_kwargs.update(
+                distributed_config=self.distributed_config,
+                device_mesh=self.device_mesh,
+                moe_mesh=self.moe_mesh,
+                moe_config=self.dist_setup.moe_config,
+                activation_checkpointing=self.dist_setup.activation_checkpointing,
+            )
+        self.target_model = NeMoAutoModelForCausalLM.from_pretrained(target_path, **target_kwargs)
+        # FSDP2 / EP sharding placed the model on the right devices already;
+        # only do the brute-force ``.to(device)`` for the unsharded path.
+        if self.dist_setup is None:
+            self.target_model = self.target_model.to(self.device)
         self.target_wrapper = HFEagle3TargetModel(
             self.target_model,
             aux_layer_ids=recipe_cfg.get("aux_layer_ids", None),

--- a/nemo_automodel/recipes/llm/train_eagle3.py
+++ b/nemo_automodel/recipes/llm/train_eagle3.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""EAGLE-3 training recipe for Llama-style dense LLMs (Llama, Phi-3)."""
+"""EAGLE-3 training recipe for Llama-style dense LLMs (Llama, Phi-3) and MoE backbones (Qwen3-MoE)."""
 
 from __future__ import annotations
 
@@ -81,7 +81,7 @@ def _all_reduce_mean(value: torch.Tensor) -> torch.Tensor:
 
 
 class TrainEagle3Recipe(BaseRecipe):
-    """Recipe for EAGLE-3 training on Llama-style dense LLMs (Llama, Phi-3)."""
+    """Recipe for EAGLE-3 training on Llama-style dense LLMs (Llama, Phi-3) and MoE backbones (Qwen3-MoE)."""
 
     def __init__(self, cfg):
         self.cfg = cfg

--- a/nemo_automodel/recipes/llm/train_eagle3.py
+++ b/nemo_automodel/recipes/llm/train_eagle3.py
@@ -120,10 +120,16 @@ class TrainEagle3Recipe(BaseRecipe):
         # ``from_pretrained`` loads the full target on every rank and OOMs.
         # When absent, the recipe keeps the original single-GPU-per-rank
         # behavior so existing 8B-class dense recipes are unaffected.
+        # ``force_hf`` is opt-in. Default ``False`` so HF architectures
+        # with an AutoModel custom impl (e.g. ``Qwen3MoeForCausalLM``,
+        # ``LlamaForCausalLM``) take the custom path, which unlocks the
+        # MoE infra (EP, ``GroupedExperts``, DeepEP). Set
+        # ``recipe_args.target_force_hf: true`` in YAML to force the
+        # plain HF implementation.
         target_kwargs = dict(
             trust_remote_code=recipe_cfg.get("trust_remote_code", False),
             torch_dtype=self.compute_dtype,
-            force_hf=True,
+            force_hf=bool(recipe_cfg.get("target_force_hf", False)),
         )
         self.dist_setup = None
         self.distributed_config = None

--- a/tests/unit_tests/speculative/test_draft_embedding_copy.py
+++ b/tests/unit_tests/speculative/test_draft_embedding_copy.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the EAGLE draft ``copy_embeddings_from_target`` DTensor branch.
+
+Covers the FSDP2-target compatibility patch on both the EAGLE-3 draft
+(``LlamaEagle3DraftModel`` in ``draft_llama.py``) and the EAGLE-1/2 draft
+(``LlamaEagleDraftModel`` in ``draft_llama_v12.py``). When the target
+embedding weight is a ``DTensor`` (sharded across ranks under FSDP2), the
+copy path must gather it via ``.full_tensor()`` before writing into the
+(un-sharded) draft parameter. A plain ``nn.Embedding.weight`` (single
+rank or pre-sharding) must pass through unchanged.
+
+Pure-CPU, no distributed init: the DTensor branch is exercised with a
+mock object that exposes ``full_tensor()``. The test verifies branch
+selection and call-count without requiring a multi-rank harness.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import torch
+import torch.nn as nn
+
+from nemo_automodel.components.speculative.eagle.draft_llama import LlamaEagle3DraftModel
+from nemo_automodel.components.speculative.eagle.draft_llama_v12 import LlamaEagleDraftModel
+
+_VOCAB = 32
+_HIDDEN = 16
+
+
+class _MinimalDraftEagle3:
+    """Stand-in exposing ``self.model.embed_tokens`` for the method under test."""
+
+    copy_embeddings_from_target = LlamaEagle3DraftModel.copy_embeddings_from_target
+
+    def __init__(self) -> None:
+        inner = nn.Module()
+        inner.embed_tokens = nn.Embedding(_VOCAB, _HIDDEN)
+        self.model = inner
+
+
+class _MinimalDraftEagle1:
+    """Stand-in exposing ``self.embed_tokens`` for the method under test."""
+
+    copy_embeddings_from_target = LlamaEagleDraftModel.copy_embeddings_from_target
+
+    def __init__(self) -> None:
+        self.embed_tokens = nn.Embedding(_VOCAB, _HIDDEN)
+
+
+def _fake_dtensor_embedding(full: torch.Tensor) -> MagicMock:
+    """Return an ``nn.Embedding``-like mock whose ``.weight`` is a DTensor stand-in."""
+    fake_weight = MagicMock()
+    fake_weight.full_tensor = MagicMock(return_value=full)
+    fake_emb = MagicMock()
+    fake_emb.weight = fake_weight
+    return fake_emb
+
+
+def test_eagle3_copy_plain_tensor() -> None:
+    draft = _MinimalDraftEagle3()
+    target = nn.Embedding(_VOCAB, _HIDDEN)
+    expected = target.weight.detach().clone()
+    draft.copy_embeddings_from_target(target)
+    assert torch.equal(draft.model.embed_tokens.weight, expected)
+
+
+def test_eagle3_copy_dtensor_invokes_full_tensor() -> None:
+    draft = _MinimalDraftEagle3()
+    full = torch.randn(_VOCAB, _HIDDEN)
+    fake_emb = _fake_dtensor_embedding(full)
+    draft.copy_embeddings_from_target(fake_emb)
+    fake_emb.weight.full_tensor.assert_called_once()
+    assert torch.equal(draft.model.embed_tokens.weight, full)
+
+
+def test_eagle1_copy_plain_tensor() -> None:
+    draft = _MinimalDraftEagle1()
+    target = nn.Embedding(_VOCAB, _HIDDEN)
+    expected = target.weight.detach().clone()
+    draft.copy_embeddings_from_target(target)
+    assert torch.equal(draft.embed_tokens.weight, expected)
+
+
+def test_eagle1_copy_dtensor_invokes_full_tensor() -> None:
+    draft = _MinimalDraftEagle1()
+    full = torch.randn(_VOCAB, _HIDDEN)
+    fake_emb = _fake_dtensor_embedding(full)
+    draft.copy_embeddings_from_target(fake_emb)
+    fake_emb.weight.full_tensor.assert_called_once()
+    assert torch.equal(draft.embed_tokens.weight, full)

--- a/tests/unit_tests/speculative/test_eagle_registry.py
+++ b/tests/unit_tests/speculative/test_eagle_registry.py
@@ -62,6 +62,16 @@ def test_eagle1_registry_contains_phi3():
     assert "Phi3ForCausalLM" in EAGLE1_DRAFT_REGISTRY
 
 
+def test_eagle3_registry_contains_qwen3_moe():
+    assert "Qwen3MoeForCausalLM" in EAGLE3_DRAFT_REGISTRY
+    assert EAGLE3_DRAFT_REGISTRY["Qwen3MoeForCausalLM"].draft_cls is LlamaEagle3DraftModel
+
+
+def test_eagle1_registry_contains_qwen3_moe():
+    assert "Qwen3MoeForCausalLM" in EAGLE1_DRAFT_REGISTRY
+    assert EAGLE1_DRAFT_REGISTRY["Qwen3MoeForCausalLM"].draft_cls is LlamaEagleDraftModel
+
+
 # ── resolve_eagle3_draft_spec ────────────────────────────────────────────
 
 
@@ -88,8 +98,20 @@ def test_resolve_eagle3_empty_raises():
 # ── resolve_eagle1_draft_spec ────────────────────────────────────────────
 
 
+def test_resolve_eagle3_qwen3_moe():
+    # MoE backbones share the dense Llama-style draft because the draft only
+    # consumes post-block hidden states, not the per-expert routing internals.
+    spec = resolve_eagle3_draft_spec(["Qwen3MoeForCausalLM"])
+    assert spec.draft_cls is LlamaEagle3DraftModel
+
+
 def test_resolve_eagle1_llama():
     spec = resolve_eagle1_draft_spec(["LlamaForCausalLM"])
+    assert spec.draft_cls is LlamaEagleDraftModel
+
+
+def test_resolve_eagle1_qwen3_moe():
+    spec = resolve_eagle1_draft_spec(["Qwen3MoeForCausalLM"])
     assert spec.draft_cls is LlamaEagleDraftModel
 
 

--- a/tests/unit_tests/speculative/test_eagle_target_wrappers.py
+++ b/tests/unit_tests/speculative/test_eagle_target_wrappers.py
@@ -1,0 +1,207 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for EAGLE target-model wrappers' custom-impl path.
+
+Covers the branch exercised when ``target_force_hf=False`` and the loaded
+target model is the AutoModel custom implementation (e.g. the custom
+``Qwen3MoeForCausalLM`` under ``components/models/qwen3_moe``) rather than
+the stock HuggingFace class. Verifies:
+
+1. ``_get_transformer_layers`` normalizes both ``nn.ModuleDict`` (custom
+   impl, str-keyed) and ``nn.ModuleList`` (HF) into an ordered layer list.
+2. ``generate_batch`` does not forward ``output_hidden_states`` /
+   ``output_attentions`` / ``use_cache`` to a custom backbone whose
+   ``forward`` does not declare them.
+3. ``generate_batch`` handles a bare-tensor return value (custom backbone)
+   as well as a HF dataclass return with a ``.logits`` attribute.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+from transformers.modeling_outputs import CausalLMOutput
+
+from nemo_automodel.components.speculative.eagle.target import HFEagle3TargetModel
+from nemo_automodel.components.speculative.eagle.target_v12 import HFEagleTargetModel
+
+_FORBIDDEN_HF_FLAGS = {"output_hidden_states", "output_attentions", "use_cache"}
+
+
+class _FakeAutoModelBackbone(nn.Module):
+    """Mimics an AutoModel custom-impl backbone: ``ModuleDict`` layers and
+    a ``**attn_kwargs`` catch-all in ``forward``."""
+
+    def __init__(self, num_layers: int, hidden: int, embed: nn.Embedding) -> None:
+        super().__init__()
+        self.layers = nn.ModuleDict({str(i): nn.Linear(hidden, hidden) for i in range(num_layers)})
+        self._embed = embed
+
+    def forward(self, input_ids, attention_mask=None, position_ids=None, **attn_kwargs):
+        leaked = _FORBIDDEN_HF_FLAGS & set(attn_kwargs)
+        if leaked:
+            raise AssertionError(f"HF flag leaked to custom backbone: {leaked}")
+        h = self._embed(input_ids)
+        for layer in self.layers.values():
+            h = layer(h)
+        return h
+
+
+class _FakeAutoModelCausalLM(nn.Module):
+    """Outer wrapper matching the AutoModel custom-impl surface used by
+    EAGLE-3 (``self.model.model.layers`` is a ``ModuleDict``) and EAGLE-1/2
+    (``self.model.model`` exposes a bare-tensor forward)."""
+
+    def __init__(self, num_layers: int = 4, hidden: int = 16, vocab: int = 32) -> None:
+        super().__init__()
+        self.config = type("Cfg", (), {"num_hidden_layers": num_layers})
+        self.embed_tokens = nn.Embedding(vocab, hidden)
+        self.model = _FakeAutoModelBackbone(num_layers, hidden, self.embed_tokens)
+        self.lm_head = nn.Linear(hidden, vocab, bias=False)
+
+    def get_input_embeddings(self) -> nn.Embedding:
+        return self.embed_tokens
+
+    def forward(self, input_ids, attention_mask=None, **attn_kwargs):
+        h = self.model(input_ids, attention_mask=attention_mask, **attn_kwargs)
+        return self.lm_head(h)
+
+
+class _FakeHFBackbone(nn.Module):
+    """Mimics a HuggingFace backbone: ``ModuleList`` layers, explicit HF
+    flags in ``forward`` signature, and a tuple-style return."""
+
+    def __init__(self, num_layers: int, hidden: int, embed: nn.Embedding) -> None:
+        super().__init__()
+        self.layers = nn.ModuleList([nn.Linear(hidden, hidden) for _ in range(num_layers)])
+        self._embed = embed
+
+    def forward(
+        self,
+        input_ids,
+        attention_mask=None,
+        output_hidden_states: bool = False,
+        output_attentions: bool = False,
+        use_cache: bool = False,
+    ):
+        h = self._embed(input_ids)
+        for layer in self.layers:
+            h = layer(h)
+        return (h,)
+
+
+class _FakeHFCausalLM(nn.Module):
+    """HF causal-LM stand-in returning ``CausalLMOutput`` with ``.logits``."""
+
+    def __init__(self, num_layers: int = 4, hidden: int = 16, vocab: int = 32) -> None:
+        super().__init__()
+        self.config = type("Cfg", (), {"num_hidden_layers": num_layers})
+        self.embed_tokens = nn.Embedding(vocab, hidden)
+        self.model = _FakeHFBackbone(num_layers, hidden, self.embed_tokens)
+        self.lm_head = nn.Linear(hidden, vocab, bias=False)
+
+    def get_input_embeddings(self) -> nn.Embedding:
+        return self.embed_tokens
+
+    def forward(
+        self,
+        input_ids,
+        attention_mask=None,
+        output_hidden_states: bool = False,
+        output_attentions: bool = False,
+        use_cache: bool = False,
+    ):
+        h = self.model(
+            input_ids,
+            attention_mask=attention_mask,
+            output_hidden_states=output_hidden_states,
+            output_attentions=output_attentions,
+            use_cache=use_cache,
+        )[0]
+        return CausalLMOutput(logits=self.lm_head(h))
+
+
+def _tiny_batch(batch: int = 2, seq: int = 8, vocab: int = 32):
+    input_ids = torch.randint(0, vocab, (batch, seq))
+    attn = torch.ones(batch, seq, dtype=torch.long)
+    loss = torch.ones(batch, seq, dtype=torch.long)
+    return input_ids, attn, loss
+
+
+def test_eagle3_get_layers_normalizes_moduledict() -> None:
+    fake = _FakeAutoModelCausalLM(num_layers=4)
+    wrapper = HFEagle3TargetModel(fake, aux_layer_ids=[0, 1, 3])
+    layers = wrapper._get_transformer_layers()
+    assert len(layers) == 4
+    for i, layer in enumerate(layers):
+        assert layer is fake.model.layers[str(i)]
+
+
+def test_eagle3_get_layers_normalizes_modulelist() -> None:
+    fake = _FakeHFCausalLM(num_layers=4)
+    wrapper = HFEagle3TargetModel(fake, aux_layer_ids=[0, 1, 3])
+    layers = wrapper._get_transformer_layers()
+    assert len(layers) == 4
+    for i, layer in enumerate(layers):
+        assert layer is fake.model.layers[i]
+
+
+def test_eagle3_drops_hf_flags_for_custom_backbone() -> None:
+    fake = _FakeAutoModelCausalLM(num_layers=4)
+    wrapper = HFEagle3TargetModel(fake, aux_layer_ids=[0, 1, 3])
+    input_ids, attn, loss = _tiny_batch()
+    batch = wrapper.generate_batch(input_ids, attn, loss)
+    assert batch.logits.shape == (2, 8, 32)
+
+
+def test_eagle3_handles_bare_tensor_return() -> None:
+    fake = _FakeAutoModelCausalLM(num_layers=4)
+    wrapper = HFEagle3TargetModel(fake, aux_layer_ids=[0, 1, 3])
+    input_ids, attn, loss = _tiny_batch()
+    batch = wrapper.generate_batch(input_ids, attn, loss)
+    assert isinstance(batch.logits, torch.Tensor)
+
+
+def test_eagle3_handles_hf_dataclass_return() -> None:
+    fake = _FakeHFCausalLM(num_layers=4)
+    wrapper = HFEagle3TargetModel(fake, aux_layer_ids=[0, 1, 3])
+    input_ids, attn, loss = _tiny_batch()
+    batch = wrapper.generate_batch(input_ids, attn, loss)
+    assert batch.logits.shape == (2, 8, 32)
+
+
+def test_eagle1_drops_hf_flags_for_custom_backbone() -> None:
+    fake = _FakeAutoModelCausalLM(num_layers=2)
+    wrapper = HFEagleTargetModel(fake)
+    input_ids, attn, loss = _tiny_batch()
+    batch = wrapper.generate_batch(input_ids, attn, loss)
+    assert batch.target_logits.shape == (2, 8, 32)
+
+
+def test_eagle1_handles_bare_tensor_return() -> None:
+    fake = _FakeAutoModelCausalLM(num_layers=2)
+    wrapper = HFEagleTargetModel(fake)
+    input_ids, attn, loss = _tiny_batch()
+    batch = wrapper.generate_batch(input_ids, attn, loss)
+    assert isinstance(batch.input_hidden_states, torch.Tensor)
+    assert isinstance(batch.target_hidden_states, torch.Tensor)
+
+
+def test_eagle1_handles_hf_dataclass_return() -> None:
+    fake = _FakeHFCausalLM(num_layers=2)
+    wrapper = HFEagleTargetModel(fake)
+    input_ids, attn, loss = _tiny_batch()
+    batch = wrapper.generate_batch(input_ids, attn, loss)
+    assert batch.target_logits.shape == (2, 8, 32)


### PR DESCRIPTION
# What does this PR do?

Add ``Qwen3MoeForCausalLM`` (Qwen3-MoE family) as a supported target for
EAGLE-1 / EAGLE-2 / EAGLE-3 training, alongside the existing dense
Llama / Phi-3 paths. Also wires the EAGLE recipes to AutoModel's existing
FSDP2 sharding so 30B-class MoE targets actually fit on standard 80GB
multi-GPU nodes -- the previous code replicated the full target per rank
and OOMed on anything bigger than ~13B.

## Changelog

**Qwen3-MoE target support:**

- ``components/speculative/eagle/registry.py``: append
  ``Qwen3MoeForCausalLM`` to ``_DENSE_ARCHITECTURES``. The dense draft
  works as-is for MoE backbones because the EAGLE draft only consumes
  post-block hidden states emitted by ``register_forward_hook`` on each
  decoder layer -- per-expert routing internals are not part of the
  draft's input.
- ``recipes/llm/train_eagle{1,3}.py``: docstrings extended from
  "Llama, Phi-3" to mention Qwen3-MoE.
- Example YAMLs: ``examples/speculative/eagle{1,2,3}/qwen3_moe_*_perfectblend.yaml``.
- ``tests/unit_tests/speculative/test_eagle_registry.py``: add four
  tests covering EAGLE-1 / EAGLE-3 registry containment and dispatch
  resolution for ``Qwen3MoeForCausalLM`` -> ``LlamaEagle*DraftModel``.

**FSDP2 target sharding for the EAGLE recipes:**

- ``recipes/llm/train_eagle{1,3}.py``: when a ``distributed:`` section
  is present in the YAML, call ``setup_distributed`` and thread
  ``device_mesh`` / ``moe_mesh`` / ``distributed_config`` / ``moe_config`` /
  ``activation_checkpointing`` into ``NeMoAutoModelForCausalLM.from_pretrained``.
  The infrastructure layer then shards the target with FSDP2 (and EP
  when ``ep_size > 1``); the brute-force ``.to(self.device)`` is skipped
  in the sharded path because the infra has already placed the
  parameters.
- The draft model keeps its existing ``DistributedDataParallel`` wrap.
  FSDP2 on the target and DDP on the draft coexist on the same world,
  each using its own communication scheme.
- When ``distributed:`` is absent the recipes fall back to the original
  single-GPU-per-rank behavior, so existing Llama / Phi-3 / Qwen3-dense
  recipes are unaffected.
- New Qwen3-MoE example YAMLs ship with ``strategy: fsdp2`` and
  ``activation_checkpointing: true`` to leave headroom for the
  TTT-unrolled draft forwards. ``ep_size`` can be raised in YAML for
  larger MoEs; the recipe forwards ``moe_config`` already.

**DTensor copy fix:**

- ``components/speculative/eagle/draft_llama.py`` and
  ``draft_llama_v12.py``: in ``copy_embeddings_from_target``, gather a
  DTensor target weight via ``.full_tensor()`` before copying into the
  unsharded draft parameter. Without this, FSDP2-wrapped targets raise
  ``RuntimeError: aten.copy_.default got mixed torch.Tensor and DTensor``.
  The ``hasattr`` guard makes the existing unsharded path a no-op.

## Verification

End-to-end smoke test on 8 x A800 80GB, ``Qwen3-30B-A3B-Instruct-2507``
(non-thinking variant) as target, EAGLE-3 recipe, FSDP2 strategy
(``dp_size=8``, ``activation_checkpointing=true``):

- Target weights sharded across ranks (~16 GB per rank instead of full
  60 GB), no OOM.
- Draft training enters the loop and converges over a 250-step sanity
  run: training loss decreases monotonically, draft accuracy rises from
  near-zero to ~0.31, LR follows the cosine schedule.
- Each 10-step window completes in ~6 s end-to-end.

Training-loop log excerpt (step 10 -> 250, every 10 steps):

```
epoch=0 step=10  train_loss=9.065207 train_acc=0.006130 lr=3.548e-05
epoch=0 step=20  train_loss=7.670224 train_acc=0.062447 lr=6.774e-05
epoch=0 step=30  train_loss=6.768910 train_acc=0.068292 lr=1.000e-04
epoch=0 step=40  train_loss=6.126582 train_acc=0.109515 lr=9.995e-05
epoch=0 step=50  train_loss=5.978342 train_acc=0.113623 lr=9.977e-05
epoch=0 step=60  train_loss=5.815319 train_acc=0.135431 lr=9.947e-05
epoch=0 step=70  train_loss=5.840969 train_acc=0.145151 lr=9.905e-05
epoch=0 step=80  train_loss=5.370955 train_acc=0.180499 lr=9.850e-05
epoch=0 step=90  train_loss=5.316124 train_acc=0.202069 lr=9.783e-05
epoch=0 step=100 train_loss=5.357407 train_acc=0.205463 lr=9.704e-05
epoch=0 step=110 train_loss=5.378894 train_acc=0.200543 lr=9.613e-05
epoch=0 step=120 train_loss=4.823973 train_acc=0.251581 lr=9.511e-05
epoch=0 step=130 train_loss=4.989300 train_acc=0.237234 lr=9.397e-05
epoch=0 step=140 train_loss=4.670279 train_acc=0.273315 lr=9.273e-05
epoch=0 step=150 train_loss=4.925109 train_acc=0.246173 lr=9.138e-05
epoch=0 step=160 train_loss=4.756421 train_acc=0.264386 lr=8.993e-05
epoch=0 step=170 train_loss=4.565536 train_acc=0.270532 lr=8.838e-05
epoch=0 step=180 train_loss=4.455242 train_acc=0.286340 lr=8.674e-05
epoch=0 step=190 train_loss=4.445095 train_acc=0.273486 lr=8.500e-05
epoch=0 step=200 train_loss=4.605785 train_acc=0.260287 lr=8.319e-05
epoch=0 step=210 train_loss=4.307686 train_acc=0.307715 lr=8.130e-05
epoch=0 step=220 train_loss=4.183267 train_acc=0.310303 lr=7.933e-05
epoch=0 step=230 train_loss=4.380021 train_acc=0.307971 lr=7.729e-05
epoch=0 step=240 train_loss=4.345554 train_acc=0.283203 lr=7.520e-05
epoch=0 step=250 train_loss=4.174419 train_acc=0.306598 lr=7.304e-05
```

The verification path exercises every change in this PR: the registry
entry (otherwise dispatch raises), the FSDP2 sharding (otherwise OOM at
load), the DTensor copy fix (otherwise crash at
``copy_embeddings_from_target`` before the first step).

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Contributor guidelines followed
- [x] Unit tests added (``test_eagle_registry.py`` -- 4 new tests)
- [x] Example configs added under ``examples/speculative/eagle{1,2,3}/``
- [x] DCO sign-off on every commit