### PR TITLE
feat(datasets): add multi-turn agent SFT dataset adapter

### DIFF
--- a/examples/llm_finetune/agent/qwen2_5_3b_function_calling.yaml
+++ b/examples/llm_finetune/agent/qwen2_5_3b_function_calling.yaml
@@ -1,0 +1,112 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Multi-turn agent SFT (full-parameter) on Qwen2.5-3B with the
+# llamafactory/glaive_toolcall_en function-calling dataset.
+#
+# To run this recipe:
+#   automodel examples/llm_finetune/agent/qwen2_5_3b_function_calling.yaml --nproc-per-node 8
+# Adjust --nproc-per-node to the number of GPUs available on your machine.
+#
+# The dataset adapter also accepts the swift / chatml `messages` schema
+# (e.g. AI-ModelScope/function-calling-chatml). To use it, download the
+# dataset locally and switch the dataset block to:
+#   dataset:
+#     _target_: nemo_automodel.components.datasets.llm.agent_chat.make_agent_chat_dataset
+#     path: /path/to/function_calling_chatml.jsonl
+
+recipe: TrainFinetuneRecipeForNextTokenPrediction
+
+step_scheduler:
+  global_batch_size: 32
+  local_batch_size: 1
+  ckpt_every_steps: 500
+  val_every_steps: 500
+  max_steps: 2000
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 1
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 1111
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: Qwen/Qwen2.5-3B
+  attn_implementation: flash_attention_2
+
+compile:
+  enabled: false
+  mode: "default"
+  fullgraph: false
+  dynamic: true
+  backend: null
+
+clip_grad_norm:
+  max_norm: 1.0
+
+distributed:
+  strategy: fsdp2
+  dp_size: none
+  cp_size: 1
+  sequence_parallel: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.agent_chat.make_agent_chat_dataset
+  dataset_name: llamafactory/glaive_toolcall_en
+  split: train
+  seq_length: 4096
+  tokenizer:
+    pretrained_model_name_or_path: Qwen/Qwen2.5-3B
+
+packed_sequence:
+  packed_sequence_size: 0
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  shuffle: true
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.llm.agent_chat.make_agent_chat_dataset
+  dataset_name: llamafactory/glaive_toolcall_en
+  split: train[:256]
+  limit_dataset_samples: 256
+  seq_length: 4096
+  tokenizer:
+    pretrained_model_name_or_path: Qwen/Qwen2.5-3B
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+
+optimizer:
+  _target_: torch.optim.AdamW
+  betas: [0.9, 0.95]
+  eps: 1.0e-8
+  lr: 1.0e-5
+  weight_decay: 0.01
+
+lr_scheduler:
+  lr_decay_style: cosine
+  min_lr: 1.0e-6
+
+nvtx: false

--- a/examples/llm_finetune/agent/qwen2_5_3b_function_calling.yaml
+++ b/examples/llm_finetune/agent/qwen2_5_3b_function_calling.yaml
@@ -48,7 +48,7 @@ rng:
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: Qwen/Qwen2.5-3B
-  attn_implementation: flash_attention_2
+  attn_implementation: sdpa
 
 compile:
   enabled: false

--- a/examples/llm_finetune/agent/qwen2_5_3b_function_calling_lora.yaml
+++ b/examples/llm_finetune/agent/qwen2_5_3b_function_calling_lora.yaml
@@ -1,0 +1,112 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Multi-turn agent SFT (LoRA) on Qwen2.5-3B with the
+# llamafactory/glaive_toolcall_en function-calling dataset.
+#
+# To run this recipe:
+#   automodel examples/llm_finetune/agent/qwen2_5_3b_function_calling_lora.yaml --nproc-per-node 1
+# A single 24GB GPU should fit this configuration.
+
+recipe: TrainFinetuneRecipeForNextTokenPrediction
+
+step_scheduler:
+  global_batch_size: 16
+  local_batch_size: 1
+  ckpt_every_steps: 500
+  val_every_steps: 500
+  max_steps: 2000
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 1
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 1111
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: Qwen/Qwen2.5-3B
+  attn_implementation: flash_attention_2
+
+peft:
+  _target_: nemo_automodel.components._peft.lora.PeftConfig
+  match_all_linear: True
+  dim: 16
+  alpha: 16
+  use_triton: True
+
+compile:
+  enabled: false
+  mode: "default"
+  fullgraph: false
+  dynamic: true
+  backend: null
+
+clip_grad_norm:
+  max_norm: 1.0
+
+distributed:
+  strategy: fsdp2
+  dp_size: none
+  cp_size: 1
+  sequence_parallel: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.agent_chat.make_agent_chat_dataset
+  dataset_name: llamafactory/glaive_toolcall_en
+  split: train
+  seq_length: 4096
+  tokenizer:
+    pretrained_model_name_or_path: Qwen/Qwen2.5-3B
+
+packed_sequence:
+  packed_sequence_size: 0
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  shuffle: true
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.llm.agent_chat.make_agent_chat_dataset
+  dataset_name: llamafactory/glaive_toolcall_en
+  split: train[:256]
+  limit_dataset_samples: 256
+  seq_length: 4096
+  tokenizer:
+    pretrained_model_name_or_path: Qwen/Qwen2.5-3B
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+
+optimizer:
+  _target_: torch.optim.AdamW
+  betas: [0.9, 0.95]
+  eps: 1.0e-8
+  lr: 2.0e-4
+  weight_decay: 0.0
+
+lr_scheduler:
+  lr_decay_style: cosine
+  min_lr: 1.0e-6
+
+nvtx: false

--- a/examples/llm_finetune/agent/qwen2_5_3b_function_calling_lora.yaml
+++ b/examples/llm_finetune/agent/qwen2_5_3b_function_calling_lora.yaml
@@ -41,7 +41,7 @@ rng:
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: Qwen/Qwen2.5-3B
-  attn_implementation: flash_attention_2
+  attn_implementation: sdpa
 
 peft:
   _target_: nemo_automodel.components._peft.lora.PeftConfig

--- a/nemo_automodel/components/datasets/llm/__init__.py
+++ b/nemo_automodel/components/datasets/llm/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from .agent_chat import make_agent_chat_dataset  # noqa: F401
 from .chat_dataset import ChatDataset  # noqa: F401
 from .column_mapped_text_instruction_dataset import ColumnMappedTextInstructionDataset  # noqa: F401
 from .column_mapped_text_instruction_iterable_dataset import ColumnMappedTextInstructionIterableDataset  # noqa: F401
@@ -31,6 +32,7 @@ __all__ = [
     "make_squad_dataset",
     "make_retrieval_dataset",
     "make_xlam_dataset",
+    "make_agent_chat_dataset",
     "BiEncoderCollator",
     "CrossEncoderCollator",
     "ColumnMappedTextInstructionDataset",

--- a/nemo_automodel/components/datasets/llm/agent_chat.py
+++ b/nemo_automodel/components/datasets/llm/agent_chat.py
@@ -1,0 +1,280 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Multi-turn agent SFT dataset adapter.
+
+Loads function-calling chat datasets where each example contains tool
+definitions and a multi-turn message list that includes tool calls and
+tool responses, then renders them through the tokenizer's chat template
+with ``answer_only_loss_mask=True`` so that ``user`` and ``tool`` tokens
+are excluded from the loss.
+
+Two input schemas are accepted:
+
+1. Swift / chatml ``messages`` schema (used by
+   ``AI-ModelScope/function-calling-chatml``)::
+
+       {
+           "tools": "[{...openai tool schema...}]",
+           "messages": [
+               {"role": "user",          "content": "..."},
+               {"role": "tool_call",     "content": "{\\"name\\": ..., \\"arguments\\": ...}"},
+               {"role": "tool_response", "content": "..."},
+               {"role": "assistant",     "content": "..."}
+           ]
+       }
+
+2. ShareGPT ``conversations`` schema (used by
+   ``llamafactory/glaive_toolcall_en`` and similar)::
+
+       {
+           "tools": "[...]",
+           "conversations": [
+               {"from": "human",         "value": "..."},
+               {"from": "function_call", "value": "..."},
+               {"from": "observation",   "value": "..."},
+               {"from": "gpt",           "value": "..."}
+           ]
+       }
+
+Consecutive ``tool_call`` entries are merged into a single assistant
+message with parallel ``tool_calls``; the following ``tool_response``
+entries are paired with those calls in order.
+"""
+
+import json
+import logging
+from typing import Any, Dict, List, Optional, Union
+
+from datasets import load_dataset
+
+from nemo_automodel.components.datasets.lazy_mapped_dataset import LazyMappedDataset
+from nemo_automodel.components.datasets.llm.formatting_utils import _add_pad_token, format_chat_template
+
+logger = logging.getLogger(__name__)
+
+
+_VALID_MESSAGE_ROLES = {"system", "user", "assistant", "tool_call", "tool_response", "tool"}
+
+# ShareGPT ``from`` -> chatml ``role`` mapping.
+_SHAREGPT_ROLE_MAP = {
+    "system": "system",
+    "human": "user",
+    "user": "user",
+    "gpt": "assistant",
+    "assistant": "assistant",
+    "function_call": "tool_call",
+    "tool_call": "tool_call",
+    "observation": "tool_response",
+    "tool_response": "tool_response",
+    "tool": "tool_response",
+}
+
+
+def _json_load_if_str(value: Any) -> Any:
+    """Parse ``value`` as JSON if it is a string, otherwise return as-is."""
+    if isinstance(value, str):
+        return json.loads(value)
+    return value
+
+
+def _sharegpt_to_chatml(conversations: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Convert ShareGPT ``{from, value}`` turns to chatml ``{role, content}``."""
+    out: List[Dict[str, Any]] = []
+    for turn in conversations:
+        src_role = turn.get("from")
+        if src_role not in _SHAREGPT_ROLE_MAP:
+            raise ValueError(f"Unsupported sharegpt role: {src_role!r}")
+        out.append({"role": _SHAREGPT_ROLE_MAP[src_role], "content": turn.get("value", "")})
+    return out
+
+
+def _convert_messages(
+    messages: List[Dict[str, Any]],
+    example_id: Optional[Union[int, str]] = None,
+) -> List[Dict[str, Any]]:
+    """Convert chatml-style agent messages to OpenAI chat-completions format.
+
+    Consecutive ``tool_call`` entries collapse into one assistant message
+    with parallel ``tool_calls``. ``tool_response`` (or ``tool``) entries
+    that follow are paired with those tool_call ids in order.
+
+    Args:
+        messages: chatml-style turns with roles in ``_VALID_MESSAGE_ROLES``.
+        example_id: Optional identifier used to derive unique tool_call ids.
+
+    Returns:
+        A list of OpenAI-format messages suitable for ``apply_chat_template``.
+    """
+    out: List[Dict[str, Any]] = []
+    pending_call_ids: List[str] = []
+    call_counter = 0
+    id_prefix = f"call_{example_id}" if example_id is not None else "call"
+
+    i = 0
+    while i < len(messages):
+        role = messages[i].get("role")
+        if role not in _VALID_MESSAGE_ROLES:
+            raise ValueError(f"Unsupported role in agent messages: {role!r}")
+
+        if role == "tool_call":
+            tool_calls: List[Dict[str, Any]] = []
+            pending_call_ids = []
+            while i < len(messages) and messages[i].get("role") == "tool_call":
+                call = _json_load_if_str(messages[i].get("content", "{}"))
+                name = call.get("name")
+                if not isinstance(name, str) or not name:
+                    raise ValueError(f"tool_call missing `name`: {messages[i]!r}")
+                args = call.get("arguments", "")
+                if not isinstance(args, str):
+                    args = json.dumps(args, ensure_ascii=False)
+                cid = f"{id_prefix}_{call_counter}"
+                call_counter += 1
+                pending_call_ids.append(cid)
+                tool_calls.append(
+                    {
+                        "id": cid,
+                        "type": "function",
+                        "function": {"name": name, "arguments": args},
+                    }
+                )
+                i += 1
+            out.append({"role": "assistant", "content": "", "tool_calls": tool_calls})
+        elif role in ("tool_response", "tool"):
+            local_idx = 0
+            while i < len(messages) and messages[i].get("role") in ("tool_response", "tool"):
+                if local_idx < len(pending_call_ids):
+                    tool_call_id = pending_call_ids[local_idx]
+                else:
+                    tool_call_id = f"{id_prefix}_response_{call_counter}_{local_idx}"
+                content = messages[i].get("content", "")
+                if not isinstance(content, str):
+                    content = json.dumps(content, ensure_ascii=False)
+                out.append({"role": "tool", "content": content, "tool_call_id": tool_call_id})
+                i += 1
+                local_idx += 1
+        else:
+            content = messages[i].get("content", "")
+            if not isinstance(content, str):
+                content = "" if content is None else str(content)
+            out.append({"role": role, "content": content})
+            i += 1
+
+    return out
+
+
+def _format_example(
+    example: Dict[str, Any],
+    tokenizer,
+    eos_token_id: int,
+    pad_token_id: int,
+    seq_length: Optional[int] = None,
+    padding: Union[str, bool] = False,
+    truncation: Union[str, bool] = False,
+) -> Dict[str, List[int]]:
+    """Render one agent example into tokenized ``input_ids`` / ``labels``."""
+    tools = _json_load_if_str(example.get("tools"))
+    if tools is not None and not isinstance(tools, list):
+        raise ValueError(f"`tools` must be a list or JSON-encoded list, got {type(tools).__name__}")
+    if tools is not None and len(tools) == 0:
+        tools = None
+
+    raw_messages = example.get("messages")
+    if raw_messages is None:
+        sharegpt = example.get("conversations")
+        if sharegpt is None:
+            raise ValueError("Example missing both `messages` and `conversations` fields")
+        if not isinstance(sharegpt, list):
+            raise ValueError(f"`conversations` must be a list, got {type(sharegpt).__name__}")
+        raw_messages = _sharegpt_to_chatml(sharegpt)
+    elif not isinstance(raw_messages, list):
+        raise ValueError(f"`messages` must be a list, got {type(raw_messages).__name__}")
+
+    formatted = _convert_messages(raw_messages, example_id=example.get("id"))
+
+    return format_chat_template(
+        tokenizer=tokenizer,
+        formatted_text=formatted,
+        tools=tools,
+        eos_token_id=eos_token_id,
+        pad_token_id=pad_token_id,
+        seq_length=seq_length,
+        padding=padding,
+        truncation=truncation,
+        answer_only_loss_mask=True,
+    )
+
+
+def make_agent_chat_dataset(
+    tokenizer,
+    *,
+    dataset_name: Optional[str] = None,
+    path: Optional[Union[str, List[str]]] = None,
+    split: str = "train",
+    seq_length: Optional[int] = None,
+    limit_dataset_samples: Optional[int] = None,
+    padding: Union[str, bool] = False,
+    truncation: Union[str, bool] = False,
+) -> LazyMappedDataset:
+    """Load a multi-turn function-calling SFT dataset.
+
+    Exactly one of ``dataset_name`` (HuggingFace Hub id) or ``path`` (local
+    JSON/JSONL file or list of files) must be provided. The loaded examples
+    are lazily rendered through the tokenizer's chat template; tool/user
+    tokens are excluded from the loss via ``answer_only_loss_mask=True``.
+
+    Args:
+        tokenizer: HuggingFace tokenizer with a chat template.
+        dataset_name: HF Hub dataset id, e.g. ``llamafactory/glaive_toolcall_en``.
+        path: Local JSON/JSONL file path or list of paths.
+        split: Dataset split (only used with ``dataset_name``).
+        seq_length: Optional max sequence length for the tokenizer.
+        limit_dataset_samples: If set, keep only the first N examples.
+        padding: Padding strategy forwarded to the tokenizer.
+        truncation: Truncation strategy forwarded to the tokenizer.
+
+    Returns:
+        A ``LazyMappedDataset`` yielding dicts with ``input_ids``, ``labels``
+        and ``attention_mask`` ready for the trainer collator.
+    """
+    if (dataset_name is None) == (path is None):
+        raise ValueError("Exactly one of `dataset_name` or `path` must be provided")
+
+    if dataset_name is not None:
+        if limit_dataset_samples is not None:
+            assert isinstance(limit_dataset_samples, int), "Expected limit_dataset_samples to be an int"
+            if "[" not in split:
+                split = f"{split}[:{limit_dataset_samples}]"
+            else:
+                logger.warning("Dataset split %s already contains slice, skipping limit_dataset_samples", split)
+        dataset = load_dataset(dataset_name, split=split)
+    else:
+        data_files = [str(p) for p in (path if isinstance(path, list) else [path])]
+        dataset = load_dataset("json", data_files=data_files, split="train")
+        if limit_dataset_samples is not None:
+            assert isinstance(limit_dataset_samples, int), "Expected limit_dataset_samples to be an int"
+            dataset = dataset.select(range(min(limit_dataset_samples, len(dataset))))
+
+    eos_token_id = getattr(tokenizer, "eos_token_id", 0)
+    pad_token_id = _add_pad_token(tokenizer) or eos_token_id
+
+    fmt_fn = lambda x: _format_example(  # noqa: E731
+        x,
+        tokenizer,
+        eos_token_id,
+        pad_token_id,
+        seq_length,
+        padding,
+        truncation,
+    )
+    return LazyMappedDataset(dataset, fmt_fn)

--- a/nemo_automodel/components/datasets/llm/agent_chat.py
+++ b/nemo_automodel/components/datasets/llm/agent_chat.py
@@ -131,7 +131,7 @@ def _convert_messages(
             tool_calls: List[Dict[str, Any]] = []
             pending_call_ids = []
             while i < len(messages) and messages[i].get("role") == "tool_call":
-                call = _json_load_if_str(messages[i].get("content", "{}"))
+                call = _json_load_if_str(messages[i].get("content") or "{}")
                 name = call.get("name")
                 if not isinstance(name, str) or not name:
                     raise ValueError(f"tool_call missing `name`: {messages[i]!r}")
@@ -164,6 +164,9 @@ def _convert_messages(
                 i += 1
                 local_idx += 1
         else:
+            # Reset pending_call_ids so a later orphan tool_response does not
+            # silently reuse stale IDs from the previous tool_call group.
+            pending_call_ids = []
             content = messages[i].get("content", "")
             if not isinstance(content, str):
                 content = "" if content is None else str(content)
@@ -183,7 +186,10 @@ def _format_example(
     truncation: Union[str, bool] = False,
 ) -> Dict[str, List[int]]:
     """Render one agent example into tokenized ``input_ids`` / ``labels``."""
-    tools = _json_load_if_str(example.get("tools"))
+    raw_tools = example.get("tools")
+    if isinstance(raw_tools, str) and not raw_tools.strip():
+        raw_tools = None
+    tools = _json_load_if_str(raw_tools)
     if tools is not None and not isinstance(tools, list):
         raise ValueError(f"`tools` must be a list or JSON-encoded list, got {type(tools).__name__}")
     if tools is not None and len(tools) == 0:

--- a/tests/unit_tests/datasets/llm/test_agent_chat.py
+++ b/tests/unit_tests/datasets/llm/test_agent_chat.py
@@ -238,3 +238,57 @@ def test_make_agent_chat_dataset_loads_hub_split_with_limit(monkeypatch):
     assert captured_load["name"] == "dummy/agent"
     assert captured_load["split"] == "train[:2]"
     assert [ds[i] for i in range(len(ds))] == [{"formatted": 0}, {"formatted": 1}]
+
+
+def test_convert_messages_orphan_tool_response_gets_synthetic_id():
+    # tool_response that does not follow a tool_call group must fall back to a
+    # synthetic tool_call_id rather than silently reusing IDs from an earlier
+    # tool_call group.
+    messages = [
+        {"role": "tool_call", "content": '{"name":"f","arguments":{}}'},
+        {"role": "tool_response", "content": "ok"},
+        {"role": "assistant", "content": "done"},
+        {"role": "tool_response", "content": "orphan"},
+    ]
+    out = agent_chat._convert_messages(messages, example_id=7)
+
+    paired_id = out[1]["tool_call_id"]
+    orphan_id = out[3]["tool_call_id"]
+    assert paired_id == out[0]["tool_calls"][0]["id"]
+    assert orphan_id != paired_id
+    assert "response" in orphan_id
+
+
+def test_convert_messages_tool_call_with_none_content_is_rejected():
+    # A tool_call dict with ``content: None`` must surface as a clear
+    # ValueError about the missing ``name`` rather than an AttributeError.
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "tool_call", "content": None},
+    ]
+    with pytest.raises(ValueError, match="tool_call missing `name`"):
+        agent_chat._convert_messages(messages)
+
+
+def test_format_example_accepts_empty_tools_string(monkeypatch):
+    # ``tools: ""`` (used by some on-disk ShareGPT exports to mean "no tools")
+    # must be normalized to ``None`` rather than crashing ``json.loads("")``.
+    captured = {}
+
+    def fake_format_chat_template(**kwargs):
+        captured.update(kwargs)
+        return {"ok": True}
+
+    monkeypatch.setattr(agent_chat, "format_chat_template", fake_format_chat_template)
+
+    class Tok:
+        eos_token_id = 5
+        pad_token_id = 0
+
+    agent_chat._format_example(
+        {"tools": "", "messages": [{"role": "user", "content": "hi"}]},
+        Tok(),
+        eos_token_id=5,
+        pad_token_id=0,
+    )
+    assert captured["tools"] is None

--- a/tests/unit_tests/datasets/llm/test_agent_chat.py
+++ b/tests/unit_tests/datasets/llm/test_agent_chat.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+import pytest
+
+from nemo_automodel.components.datasets.llm import agent_chat
+
+
+def test_json_load_if_str_roundtrip_and_passthrough():
+    payload = {"a": 1, "b": "two"}
+    assert agent_chat._json_load_if_str(json.dumps(payload)) == payload
+    assert agent_chat._json_load_if_str(payload) is payload
+
+
+def test_sharegpt_to_chatml_maps_all_roles():
+    conversations = [
+        {"from": "system", "value": "sys"},
+        {"from": "human", "value": "hi"},
+        {"from": "gpt", "value": "hello"},
+        {"from": "function_call", "value": '{"name":"f","arguments":{}}'},
+        {"from": "observation", "value": "obs"},
+    ]
+    out = agent_chat._sharegpt_to_chatml(conversations)
+    assert [m["role"] for m in out] == ["system", "user", "assistant", "tool_call", "tool_response"]
+    assert out[1]["content"] == "hi"
+    assert out[3]["content"] == '{"name":"f","arguments":{}}'
+
+
+def test_sharegpt_to_chatml_rejects_unknown_role():
+    with pytest.raises(ValueError, match="Unsupported sharegpt role"):
+        agent_chat._sharegpt_to_chatml([{"from": "narrator", "value": "x"}])
+
+
+def test_convert_messages_collapses_parallel_tool_calls_and_pairs_responses():
+    messages = [
+        {"role": "user", "content": "weather in BJ and SH?"},
+        {"role": "tool_call", "content": '{"name":"aqi","arguments":{"city":"BJ"}}'},
+        {"role": "tool_call", "content": '{"name":"aqi","arguments":{"city":"SH"}}'},
+        {"role": "tool_response", "content": "BJ=10"},
+        {"role": "tool_response", "content": "SH=72"},
+        {"role": "assistant", "content": "BJ good, SH mild."},
+    ]
+    out = agent_chat._convert_messages(messages, example_id=42)
+
+    # user / assistant(2 tool_calls) / tool / tool / assistant
+    assert [m["role"] for m in out] == ["user", "assistant", "tool", "tool", "assistant"]
+
+    assistant_call = out[1]
+    assert assistant_call["content"] == ""
+    assert len(assistant_call["tool_calls"]) == 2
+    assert [c["function"]["name"] for c in assistant_call["tool_calls"]] == ["aqi", "aqi"]
+    assert [c["id"] for c in assistant_call["tool_calls"]] == ["call_42_0", "call_42_1"]
+    # arguments stay as JSON strings when input was a dict
+    assert assistant_call["tool_calls"][0]["function"]["arguments"] == '{"city": "BJ"}'
+
+    # tool_response pairs in order with the prior tool_call ids
+    assert out[2]["tool_call_id"] == "call_42_0" and out[2]["content"] == "BJ=10"
+    assert out[3]["tool_call_id"] == "call_42_1" and out[3]["content"] == "SH=72"
+
+    assert out[4]["role"] == "assistant" and out[4]["content"] == "BJ good, SH mild."
+
+
+def test_convert_messages_passes_string_arguments_through_unchanged():
+    raw_args = '{"city":"BJ"}'
+    messages = [
+        {"role": "user", "content": "?"},
+        {"role": "tool_call", "content": json.dumps({"name": "aqi", "arguments": raw_args})},
+    ]
+    out = agent_chat._convert_messages(messages)
+    assert out[1]["tool_calls"][0]["function"]["arguments"] == raw_args
+
+
+def test_convert_messages_rejects_unknown_role():
+    with pytest.raises(ValueError, match="Unsupported role"):
+        agent_chat._convert_messages([{"role": "narrator", "content": "x"}])
+
+
+def test_convert_messages_requires_tool_call_name():
+    with pytest.raises(ValueError, match="tool_call missing `name`"):
+        agent_chat._convert_messages([{"role": "tool_call", "content": "{}"}])
+
+
+def test_format_example_builds_chat_payload_for_chatml(monkeypatch):
+    captured = {}
+
+    def fake_format_chat_template(**kwargs):
+        captured.update(kwargs)
+        return {"ok": True}
+
+    monkeypatch.setattr(agent_chat, "format_chat_template", fake_format_chat_template)
+
+    class Tok:
+        eos_token_id = 7
+        pad_token_id = 3
+
+    tok = Tok()
+    example = {
+        "id": 5,
+        "tools": '[{"type":"function","function":{"name":"aqi","parameters":{}}}]',
+        "messages": [
+            {"role": "user", "content": "weather?"},
+            {"role": "tool_call", "content": '{"name":"aqi","arguments":{"city":"BJ"}}'},
+            {"role": "tool_response", "content": "ok"},
+            {"role": "assistant", "content": "done"},
+        ],
+    }
+
+    result = agent_chat._format_example(
+        example,
+        tok,
+        eos_token_id=tok.eos_token_id,
+        pad_token_id=tok.pad_token_id,
+        seq_length=16,
+        padding=False,
+        truncation=False,
+    )
+
+    assert result == {"ok": True}
+    assert captured["tokenizer"] is tok
+    assert captured["seq_length"] == 16
+    assert captured["answer_only_loss_mask"] is True
+
+    tools = captured["tools"]
+    assert tools[0]["function"]["name"] == "aqi"
+
+    formatted = captured["formatted_text"]
+    assert [m["role"] for m in formatted] == ["user", "assistant", "tool", "assistant"]
+    assert formatted[1]["tool_calls"][0]["id"] == "call_5_0"
+    assert formatted[2]["tool_call_id"] == "call_5_0"
+
+
+def test_format_example_supports_sharegpt_input(monkeypatch):
+    captured = {}
+
+    def fake_format_chat_template(**kwargs):
+        captured.update(kwargs)
+        return {}
+
+    monkeypatch.setattr(agent_chat, "format_chat_template", fake_format_chat_template)
+
+    class Tok:
+        eos_token_id = 0
+        pad_token_id = 0
+
+    example = {
+        "tools": [],  # empty list should normalize to None
+        "conversations": [
+            {"from": "human", "value": "hi"},
+            {"from": "gpt", "value": "hello"},
+        ],
+    }
+
+    agent_chat._format_example(example, Tok(), 0, 0)
+
+    assert captured["tools"] is None
+    assert [m["role"] for m in captured["formatted_text"]] == ["user", "assistant"]
+
+
+def test_format_example_rejects_missing_messages_and_conversations():
+    class Tok:
+        eos_token_id = 0
+        pad_token_id = 0
+
+    with pytest.raises(ValueError, match="missing both `messages` and `conversations`"):
+        agent_chat._format_example({}, Tok(), 0, 0)
+
+
+def test_format_example_rejects_non_list_tools():
+    class Tok:
+        eos_token_id = 0
+        pad_token_id = 0
+
+    example = {"tools": '{"not": "a list"}', "messages": [{"role": "user", "content": "x"}]}
+    with pytest.raises(ValueError, match="`tools` must be a list"):
+        agent_chat._format_example(example, Tok(), 0, 0)
+
+
+def test_make_agent_chat_dataset_requires_exactly_one_source():
+    class Tok:
+        eos_token_id = 0
+        pad_token_id = 0
+
+    with pytest.raises(ValueError, match="Exactly one of"):
+        agent_chat.make_agent_chat_dataset(Tok())
+    with pytest.raises(ValueError, match="Exactly one of"):
+        agent_chat.make_agent_chat_dataset(Tok(), dataset_name="foo", path="bar.json")
+
+
+def test_make_agent_chat_dataset_loads_hub_split_with_limit(monkeypatch):
+    rows = [
+        {"id": 0, "messages": [{"role": "user", "content": "q0"}], "tools": []},
+        {"id": 1, "messages": [{"role": "user", "content": "q1"}], "tools": []},
+    ]
+    captured_load = {}
+
+    class DummyDataset:
+        def __init__(self, items):
+            self.items = items
+
+        def __getitem__(self, idx):
+            return self.items[idx]
+
+        def __len__(self):
+            return len(self.items)
+
+    def fake_load_dataset(name_or_loader, split=None, data_files=None):
+        captured_load["name"] = name_or_loader
+        captured_load["split"] = split
+        captured_load["data_files"] = data_files
+        return DummyDataset(rows)
+
+    monkeypatch.setattr(agent_chat, "load_dataset", fake_load_dataset)
+    monkeypatch.setattr(agent_chat, "_add_pad_token", lambda tok: 13)
+    monkeypatch.setattr(agent_chat, "_format_example", lambda ex, *a, **kw: {"formatted": ex["id"]})
+
+    class Tok:
+        eos_token_id = 5
+
+    ds = agent_chat.make_agent_chat_dataset(
+        tokenizer=Tok(),
+        dataset_name="dummy/agent",
+        split="train",
+        limit_dataset_samples=2,
+    )
+
+    assert captured_load["name"] == "dummy/agent"
+    assert captured_load["split"] == "train[:2]"
+    assert [ds[i] for i in range(len(ds))] == [{"formatted": 0}, {"formatted": 1}]


### PR DESCRIPTION
## Summary

Add a multi-turn agent SFT dataset adapter so NeMo AutoModel can train on
function-calling chat datasets (e.g. `llamafactory/glaive_toolcall_en`,
swift-style `AI-ModelScope/function-calling-chatml`) where each example
interleaves user / assistant / tool_call / tool_response turns.

The existing `xlam` dataset only handles single-turn `user → tool_call`
samples and does not learn the assistant's behavior after observing a
tool response. This PR closes that gap by reusing the LLM dataset's
`format_chat_template` machinery with `answer_only_loss_mask=True`, so
`tool_response` and `user` tokens are excluded from the loss while
`assistant` content and `tool_call` arguments are supervised.

- New adapter `make_agent_chat_dataset` accepts two on-disk schemas:
  - chatml `messages` with roles in {user, assistant, tool_call, tool_response, system}
  - ShareGPT `conversations` with `from` ∈ {human, gpt, function_call, observation, system}
- Consecutive `tool_call` turns collapse into a single assistant message with
  parallel `tool_calls`; following `tool_response` turns are paired with
  those tool_call ids in order.
- Two ready recipes on Qwen2.5-3B + `llamafactory/glaive_toolcall_en`
  (full SFT and LoRA), using `attn_implementation: sdpa` so the recipes
  run without an extra flash-attn dependency.

## Files

| File | Change |
|---|---|
| `nemo_automodel/components/datasets/llm/agent_chat.py` | new, 280 lines |
| `nemo_automodel/components/datasets/llm/__init__.py` | +2 (register `make_agent_chat_dataset`) |
| `tests/unit_tests/datasets/llm/test_agent_chat.py` | new, 240 lines, 13 cases |
| `examples/llm_finetune/agent/qwen2_5_3b_function_calling.yaml` | new, full SFT |
| `examples/llm_finetune/agent/qwen2_5_3b_function_calling_lora.yaml` | new, LoRA |

## Test plan

- [x] `ruff format` / `ruff check --fix` clean on new files
- [x] `pytest tests/unit_tests/datasets/llm/test_agent_chat.py` — 13/13 pass
- [x] `pytest tests/unit_tests/datasets/llm/test_xlam.py` — 5/5 pass (no regression)
- [x] Smoke render one multi-turn example through a real tokenizer's chat
      template; verify `input_ids` / `labels` shapes and assistant-token
      mask are well-formed
- [x] End-to-end FSDP2 + LoRA run on 8x A100 80GB with Qwen2.5-3B (see logs below)
- [ ] Reviewer to confirm naming / registry placement
- [ ] CI green

## End-to-end training verification (8x A100 80GB, FSDP2 + LoRA, Qwen2.5-3B, `llamafactory/glaive_toolcall_en`)

\`\`\`
step  0 | loss 1.0391 | grad_norm 0.89 | lr 2.29e-05 | mem  7.75 GiB
step 10 | loss 0.8623 | grad_norm 0.63 | lr 5.19e-05 | mem  6.60 GiB
step 20 | loss 0.8352 | grad_norm 0.68 | lr 8.10e-05 | mem  8.14 GiB
step 30 | loss 0.7878 | grad_norm 0.93 | lr 1.10e-04 | mem  4.86 GiB
step 40 | loss 0.6688 | grad_norm 0.74 | lr 1.39e-04 | mem  8.82 GiB
step 50 | loss 0.5420 | grad_norm 1.30 | lr 1.68e-04 | mem  5.47 GiB
step 60 | loss 0.5602 | grad_norm 0.66 | lr 1.97e-04 | mem  6.55 GiB

[val] step 62 | loss 0.4908 | num_label_tokens 71686
checkpoint saved to checkpoints/epoch_0_step_62 (LOWEST_VAL)

step 70 | loss 0.4428 | grad_norm 0.54 | lr 2.00e-04 | mem  7.51 GiB
step 80 | loss 0.4845 | grad_norm 0.50 | lr 1.99e-04 | mem  4.68 GiB
step 85 | loss 0.4676 | grad_norm 0.49 | lr 1.99e-04 | mem  5.99 GiB

throughput   ~13k tokens/s total (~1.6-2.0k/gpu)
peak memory  ~15 GiB/gpu (well under 80 GB)
\`\`\`

Training loss falls from **1.04 → 0.47 in 85 steps** (≈55% reduction);
validation at step 62 reports **val_loss 0.4908**, consistent with the
training trend; checkpoint serialization and `LOWEST_VAL` symlink update
also succeed. No NaNs, no OOMs.

## Out of scope (deferred follow-ups)

- Role-weighted loss (swift-style `loss_scale react / hermes`) — separate PR
- Additional model recipes (DeepSeek, GLM4, Llama 3) — separate PR
- Documentation page under `docs/guides/llm/agent_sft.md` — separate PR