### PR TITLE
fix(datasets): serialize dict tool arguments to JSON string in xlam

### DIFF
--- a/nemo_automodel/components/datasets/llm/xlam.py
+++ b/nemo_automodel/components/datasets/llm/xlam.py
@@ -102,6 +102,12 @@ def _convert_tool_calls(raw_calls: List[Dict], example_id: Optional[int] = None)
             logger.warning("Skipping call without name: %s", call)
             continue
         arguments = call.get("arguments", "")
+        if not isinstance(arguments, str):
+            # OpenAI tool calling format requires `function.arguments` to be a
+            # JSON-encoded string. Upstream xLAM uses string arguments, but
+            # derivative datasets may store them as dicts; serialize so the
+            # rendered chat template emits a consistent, valid JSON payload.
+            arguments = json.dumps(arguments, ensure_ascii=False)
 
         call_id = f"call_{example_id}_{idx}" if example_id is not None else f"call_{idx}"
         tool_calls.append(
@@ -110,7 +116,6 @@ def _convert_tool_calls(raw_calls: List[Dict], example_id: Optional[int] = None)
                 "type": "function",
                 "function": {
                     "name": name,
-                    # Keep arguments as JSON string per OpenAI tool calling format.
                     "arguments": arguments,
                 },
             }

--- a/tests/unit_tests/datasets/llm/test_xlam.py
+++ b/tests/unit_tests/datasets/llm/test_xlam.py
@@ -65,6 +65,28 @@ def test_convert_tool_calls_preserves_arguments_and_ids():
     assert converted[0]["function"]["arguments"] == '{"x":1}'
 
 
+def test_convert_tool_calls_serializes_dict_arguments_to_json_string():
+    # OpenAI tool calling format requires `function.arguments` to be a string.
+    # Derivative xLAM-style datasets may carry it as a dict; the adapter must
+    # serialize so chat templates render a valid JSON payload.
+    raw_calls = [
+        {"name": "weather", "arguments": {"city": "Beijing", "days": 3}},
+        {"name": "echo", "arguments": ["a", "b"]},
+    ]
+
+    converted = xlam._convert_tool_calls(raw_calls)
+    assert isinstance(converted[0]["function"]["arguments"], str)
+    assert json.loads(converted[0]["function"]["arguments"]) == {"city": "Beijing", "days": 3}
+    assert json.loads(converted[1]["function"]["arguments"]) == ["a", "b"]
+
+
+def test_convert_tool_calls_preserves_unicode_in_dict_arguments():
+    raw_calls = [{"name": "search", "arguments": {"query": "北京天气"}}]
+    converted = xlam._convert_tool_calls(raw_calls)
+    # ensure_ascii=False keeps CJK characters readable in the rendered chat.
+    assert "北京天气" in converted[0]["function"]["arguments"]
+
+
 def test_format_example_builds_chat_payload(monkeypatch):
     captured = {}
 


### PR DESCRIPTION
## Summary

OpenAI tool calling format requires `function.arguments` to be a JSON
string, but `xlam._convert_tool_calls` passed `call["arguments"]`
through verbatim. Upstream `Salesforce/xlam-function-calling-60k`
happens to store arguments as JSON strings so this worked in practice,
but derivative xLAM-style datasets (Chinese variants,
instruction-rewritten splits) often emit a dict and were either
rendered as Python repr by lenient chat templates or rejected by
stricter ones.

Match the sibling `agent_chat` adapter: when `arguments` is not already
a string, call `json.dumps(arguments, ensure_ascii=False)`. The
`ensure_ascii=False` flag keeps CJK characters readable in the rendered
chat instead of escaping them to `\uXXXX`.

## Files

| File | Change |
|---|---|
| `nemo_automodel/components/datasets/llm/xlam.py` | +6 / -1 |
| `tests/unit_tests/datasets/llm/test_xlam.py` | +22 / -0, two new cases |

## Test plan

- [x] `pytest tests/unit_tests/datasets/llm/test_xlam.py` — 7/7 pass
  (5 existing + 2 new: dict args serialize, unicode preserved)
- [x] No behavior change for the upstream xLAM dataset path (string args
      are passed through unchanged, covered by the existing
      `test_convert_tool_calls_preserves_arguments_and_ids` test)