### PR TITLE
fix(datasets): parse JSON-encoded tools field in ChatDataset

### DIFF
--- a/nemo_automodel/components/datasets/llm/chat_dataset.py
+++ b/nemo_automodel/components/datasets/llm/chat_dataset.py
@@ -360,7 +360,18 @@ class ChatDataset(Dataset):
 
         normalized = _normalize_messages(messages)
         tools = row.get("tools")
+        if isinstance(tools, str):
+            # JSONL-stored datasets often serialize the `tools` field as a JSON
+            # string. Parse it so the chat template receives the tool defs;
+            # silently dropping them would leave the assistant tool_calls
+            # without a matching schema and corrupt the training signal.
+            try:
+                tools = json.loads(tools)
+            except json.JSONDecodeError as e:
+                raise ValueError(f"`tools` is a string but not valid JSON: {e}") from e
         if tools is not None and not isinstance(tools, list):
+            raise ValueError(f"`tools` must be a list or JSON-encoded list, got {type(tools).__name__}")
+        if isinstance(tools, list) and len(tools) == 0:
             tools = None
 
         eos_token_id = getattr(self.tokenizer, "eos_token_id", 0)

--- a/tests/unit_tests/datasets/llm/test_chat_dataset.py
+++ b/tests/unit_tests/datasets/llm/test_chat_dataset.py
@@ -296,7 +296,11 @@ def test_tool_calling_chat_dataset_happy_path_and_edge_cases(monkeypatch):
 
     monkeypatch.setattr(tcd, "format_chat_template", fake_format)
 
-    # Two rows: one with valid tools list, one with invalid tools type that should be nulled
+    # Three rows exercising the supported `tools` shapes:
+    #  - native list (passes through)
+    #  - JSON-encoded string (parsed back to a list — common JSONL layout)
+    #  - empty list (normalized to None)
+    tools_list = [{"type": "function", "function": {"name": "t"}}]
     dataset_rows = [
         {
             "messages": [
@@ -304,14 +308,21 @@ def test_tool_calling_chat_dataset_happy_path_and_edge_cases(monkeypatch):
                 {"role": "user", "content": "q"},
                 {"role": "assistant", "content": "a"},
             ],
-            "tools": [{"type": "function", "function": {"name": "t"}}],
+            "tools": tools_list,
         },
         {
             "messages": [
                 {"role": "user", "content": 7},
                 {"role": "assistant", "content": 8},
             ],
-            "tools": {"not": "alist"},
+            "tools": json.dumps(tools_list),
+        },
+        {
+            "messages": [
+                {"role": "user", "content": "noop"},
+                {"role": "assistant", "content": "ok"},
+            ],
+            "tools": [],
         },
     ]
 
@@ -329,15 +340,21 @@ def test_tool_calling_chat_dataset_happy_path_and_edge_cases(monkeypatch):
     # init effects
     assert ds.pad_token_id == 3  # from _add_pad_token
     assert tok.chat_template == "OVERRIDE"
-    assert len(ds) == 2
+    assert len(ds) == 3
 
     item0 = ds[0]
     item1 = ds[1]
+    item2 = ds[2]
     assert item0["input_ids"] == [1, 2] and item1["attention_mask"] == [1, 1]
+    assert item2["input_ids"] == [1, 2]
 
-    # Verify calls captured the tools argument behavior
-    assert calls[0]["kwargs"]["tools"] == dataset_rows[0]["tools"]
-    assert calls[1]["kwargs"]["tools"] is None
+    # tools shapes flow through correctly:
+    #  - row 0: list passed verbatim
+    #  - row 1: JSON string parsed back to the same list
+    #  - row 2: empty list normalized to None
+    assert calls[0]["kwargs"]["tools"] == tools_list
+    assert calls[1]["kwargs"]["tools"] == tools_list
+    assert calls[2]["kwargs"]["tools"] is None
     assert calls[0]["kwargs"]["mask_reasoning_content"] is True
 
     # Bad row: messages not a list → ValueError
@@ -345,6 +362,48 @@ def test_tool_calling_chat_dataset_happy_path_and_edge_cases(monkeypatch):
     ds_bad = tcd.ChatDataset("ignored", tok)
     with pytest.raises(ValueError):
         _ = ds_bad[0]
+
+
+def test_chat_dataset_rejects_invalid_tools_field(monkeypatch):
+    class Tok:
+        eos_token_id = 1
+        chat_template = "{{ default }}"
+
+    tok = Tok()
+    monkeypatch.setattr(tcd, "_has_chat_template", lambda _tok: True)
+    monkeypatch.setattr(tcd, "_add_pad_token", lambda _tok: 0)
+    monkeypatch.setattr(
+        tcd,
+        "format_chat_template",
+        lambda *a, **k: {"input_ids": [], "labels": [], "attention_mask": []},
+    )
+
+    base_messages = [
+        {"role": "user", "content": "q"},
+        {"role": "assistant", "content": "a"},
+    ]
+
+    # Non-string, non-list `tools` (e.g. a dict) used to be silently nulled,
+    # which left tool_calls in messages without a matching schema. Now it
+    # surfaces a ValueError so misconfigured datasets fail loudly.
+    monkeypatch.setattr(
+        tcd,
+        "_load_openai_messages",
+        lambda *a, **k: [{"messages": base_messages, "tools": {"not": "alist"}}],
+    )
+    ds = tcd.ChatDataset("ignored", tok)
+    with pytest.raises(ValueError, match="`tools` must be a list"):
+        _ = ds[0]
+
+    # Malformed JSON string is also surfaced rather than dropped.
+    monkeypatch.setattr(
+        tcd,
+        "_load_openai_messages",
+        lambda *a, **k: [{"messages": base_messages, "tools": "[not json"}],
+    )
+    ds_bad_json = tcd.ChatDataset("ignored", tok)
+    with pytest.raises(ValueError, match="not valid JSON"):
+        _ = ds_bad_json[0]
 
 
 def test_chat_dataset_skip_invalid_samples_does_not_filter_structured_bad_rows(monkeypatch):


### PR DESCRIPTION
## Summary

JSONL-stored chat datasets commonly serialize the `tools` field as a
JSON string. `ChatDataset.__getitem__` only accepted a Python list and
silently set anything else to `None`, which produced a broken training
signal: assistant messages still carried `tool_calls`, but the chat
template was rendered with no matching tool schema, so the model
learned to invoke functions it had never been shown.

This PR parses JSON-encoded `tools` up front and raises on truly
invalid shapes (dicts, ints, malformed JSON). An empty list is
normalized to `None` so downstream chat templates skip the tools block
entirely. This brings `ChatDataset` in line with the validation the
sibling `agent_chat` adapter already does.

## Behavior changes

| Input `tools` | Before | After |
|---|---|---|
| `[{...}]` (list)         | passes through | passes through (unchanged) |
| `'[{...}]'` (JSON string)| **silently nulled — bug** | parsed to list |
| `[]` (empty list)        | passes through | normalized to `None` |
| `{...}` (dict)           | silently nulled | `ValueError` |
| `'[not json'` (bad JSON) | silently nulled | `ValueError` |
| `None` / missing         | `None` | `None` (unchanged) |

## Files

| File | Change |
|---|---|
| `nemo_automodel/components/datasets/llm/chat_dataset.py` | +13 / -2 |
| `tests/unit_tests/datasets/llm/test_chat_dataset.py` | +65 / -7 |

## Test plan

- [x] `pytest tests/unit_tests/datasets/llm/test_chat_dataset.py -k tool` — 12/12 pass
- [x] Existing `test_tool_calling_chat_dataset_happy_path_and_edge_cases`
      updated to exercise list / JSON-string / empty-list shapes
- [x] New `test_chat_dataset_rejects_invalid_tools_field` covers the
      ValueError paths for dict tools and malformed JSON strings
- [x] Three pre-existing `TestParquetLoading` failures observed locally
      are environment-specific (`/home/TestData` hard-coded path,
      unrelated to this change)