### PR TITLE
fix(datasets): merge tool_calls into prior assistant turn in agent_chat

### DIFF
--- a/nemo_automodel/components/datasets/llm/agent_chat.py
+++ b/nemo_automodel/components/datasets/llm/agent_chat.py
@@ -106,8 +106,13 @@ def _convert_messages(
     """Convert chatml-style agent messages to OpenAI chat-completions format.
 
     Consecutive ``tool_call`` entries collapse into one assistant message
-    with parallel ``tool_calls``. ``tool_response`` (or ``tool``) entries
-    that follow are paired with those tool_call ids in order.
+    with parallel ``tool_calls``. When the preceding emitted turn is an
+    assistant message without tool_calls (e.g. an assistant ``content``
+    that reasons before calling tools), the tool_calls attach to that
+    message instead of creating a second consecutive assistant turn —
+    this preserves the natural single-turn shape the model produces at
+    inference. ``tool_response`` (or ``tool``) entries that follow are
+    paired with those tool_call ids in order.
 
     Args:
         messages: chatml-style turns with roles in ``_VALID_MESSAGE_ROLES``.
@@ -149,7 +154,13 @@ def _convert_messages(
                     }
                 )
                 i += 1
-            out.append({"role": "assistant", "content": "", "tool_calls": tool_calls})
+            if out and out[-1].get("role") == "assistant" and "tool_calls" not in out[-1]:
+                # Attach tool_calls to the prior assistant text turn so the
+                # rendered chat keeps a single assistant message (matching
+                # what the model emits at inference: think/text + tool_call).
+                out[-1]["tool_calls"] = tool_calls
+            else:
+                out.append({"role": "assistant", "content": "", "tool_calls": tool_calls})
         elif role in ("tool_response", "tool"):
             local_idx = 0
             while i < len(messages) and messages[i].get("role") in ("tool_response", "tool"):

--- a/tests/unit_tests/datasets/llm/test_agent_chat.py
+++ b/tests/unit_tests/datasets/llm/test_agent_chat.py
@@ -82,6 +82,48 @@ def test_convert_messages_passes_string_arguments_through_unchanged():
     assert out[1]["tool_calls"][0]["function"]["arguments"] == raw_args
 
 
+def test_convert_messages_merges_tool_calls_into_prior_assistant_turn():
+    # Datasets like Swift's agent traces emit an assistant "think/text" turn
+    # immediately followed by tool_call turns. Logically they are one
+    # assistant message; emitting two consecutive assistant turns would
+    # diverge from what the model produces at inference and may render as
+    # two separate `<|im_start|>assistant` blocks under some chat templates.
+    messages = [
+        {"role": "user", "content": "click button"},
+        {"role": "assistant", "content": "<think>I should click at (1, 2).</think>"},
+        {"role": "tool_call", "content": '{"name":"click","arguments":{"x":1,"y":2}}'},
+        {"role": "tool_response", "content": "ok"},
+        {"role": "assistant", "content": "done"},
+    ]
+    out = agent_chat._convert_messages(messages, example_id="abc")
+
+    # user / assistant(think + tool_calls) / tool / assistant — not 5 turns
+    assert [m["role"] for m in out] == ["user", "assistant", "tool", "assistant"]
+
+    merged = out[1]
+    assert merged["content"] == "<think>I should click at (1, 2).</think>"
+    assert len(merged["tool_calls"]) == 1
+    assert merged["tool_calls"][0]["function"]["name"] == "click"
+    assert merged["tool_calls"][0]["id"] == "call_abc_0"
+    assert out[2]["tool_call_id"] == "call_abc_0"
+
+
+def test_convert_messages_does_not_merge_when_prior_assistant_already_has_tool_calls():
+    # Two distinct rounds of tool calls separated by a tool_response must
+    # stay as two assistant turns; merging would conflate independent calls.
+    messages = [
+        {"role": "user", "content": "?"},
+        {"role": "tool_call", "content": '{"name":"a","arguments":{}}'},
+        {"role": "tool_response", "content": "ra"},
+        {"role": "tool_call", "content": '{"name":"b","arguments":{}}'},
+        {"role": "tool_response", "content": "rb"},
+    ]
+    out = agent_chat._convert_messages(messages)
+    assert [m["role"] for m in out] == ["user", "assistant", "tool", "assistant", "tool"]
+    assert out[1]["tool_calls"][0]["function"]["name"] == "a"
+    assert out[3]["tool_calls"][0]["function"]["name"] == "b"
+
+
 def test_convert_messages_rejects_unknown_role():
     with pytest.raises(ValueError, match="Unsupported role"):
         agent_chat._convert_messages([{"role": "narrator", "content": "x"}])


### PR DESCRIPTION
## ⚠️ Stacked on #2321

This PR contains the commits from #2321 plus one follow-up fix. Please
merge #2321 first; once that lands, this PR will rebase down to a
single commit. Review focus is the latest commit only:

> [`c773a6c0`](../commit/c773a6c0) — fix: merge tool_calls into prior assistant turn

## Summary

`_convert_messages` always emits a fresh assistant message with empty
content for any `tool_call` block. Datasets such as Swift-style agent
traces emit a `<think>...</think>` assistant turn immediately followed
by tool_call turns, intending a single assistant message:

```python
{"role": "assistant", "content": "<think>I should click at (1, 2).</think>"}
{"role": "tool_call",  "content": '{"name":"click","arguments":{"x":1,"y":2}}'}
```

The current code produces two consecutive assistant turns. After
`apply_chat_template`, Qwen2.5 / Llama 3.1 templates render this as
two independent `<|im_start|>assistant ... <|im_end|>` blocks, which
diverges from the single-turn shape the model produces at inference
and creates train/serve skew on the tool-call format.

This PR attaches the collected `tool_calls` to the prior emitted
assistant turn whenever that turn does not already carry `tool_calls`.
Distinct tool_call rounds separated by a `tool_response` stay as
separate assistant turns (covered by a regression test).

## Files

| File | Change |
|---|---|
| `nemo_automodel/components/datasets/llm/agent_chat.py` | +10 / -3 (docstring + merge logic) |
| `tests/unit_tests/datasets/llm/test_agent_chat.py` | +46 / -0, two new cases |

## Test plan

- [x] `pytest tests/unit_tests/datasets/llm/test_agent_chat.py` — 15/15 pass
  (13 existing + 2 new)
- [x] `test_convert_messages_merges_tool_calls_into_prior_assistant_turn`
      verifies the `<think>` + tool_call merge case
- [x] `test_convert_messages_does_not_merge_when_prior_assistant_already_has_tool_calls`
      verifies distinct rounds remain separate
- [x] No change to existing parallel tool_calls / pairing behavior
      (existing tests still pass unchanged)