### PR TITLE
fix(speculative): EAGLE recipes re-track target_model on .to(device)

### DIFF
--- a/nemo_automodel/recipes/llm/train_eagle1.py
+++ b/nemo_automodel/recipes/llm/train_eagle1.py
@@ -123,7 +123,10 @@ class TrainEagle1Recipe(BaseRecipe):
             )
         self.target_model = NeMoAutoModelForCausalLM.from_pretrained(target_path, **target_kwargs)
         if self.dist_setup is None:
-            self.target_model = self.target_model.to(self.device)
+            # ``nn.Module.to`` is in-place; reassigning ``self.target_model``
+            # would re-trigger ``BaseRecipe.__setattr__`` state-tracking and
+            # raise ``RuntimeError: State key 'target_model' is already tracked``.
+            self.target_model.to(self.device)
         self.target_model.requires_grad_(False)
         self.target_wrapper = HFEagleTargetModel(self.target_model)
 

--- a/nemo_automodel/recipes/llm/train_eagle3.py
+++ b/nemo_automodel/recipes/llm/train_eagle3.py
@@ -150,8 +150,11 @@ class TrainEagle3Recipe(BaseRecipe):
         self.target_model = NeMoAutoModelForCausalLM.from_pretrained(target_path, **target_kwargs)
         # FSDP2 / EP sharding placed the model on the right devices already;
         # only do the brute-force ``.to(device)`` for the unsharded path.
+        # ``nn.Module.to`` is in-place; reassigning ``self.target_model``
+        # would re-trigger ``BaseRecipe.__setattr__`` state-tracking and
+        # raise ``RuntimeError: State key 'target_model' is already tracked``.
         if self.dist_setup is None:
-            self.target_model = self.target_model.to(self.device)
+            self.target_model.to(self.device)
         self.target_wrapper = HFEagle3TargetModel(
             self.target_model,
             aux_layer_ids=recipe_cfg.get("aux_layer_ids", None),

--- a/tests/unit_tests/recipes/llm/test_eagle_target_model_no_retrack.py
+++ b/tests/unit_tests/recipes/llm/test_eagle_target_model_no_retrack.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for the EAGLE recipe ``target_model`` re-track fix.
+
+``TrainEagle1Recipe.setup`` and ``TrainEagle3Recipe.setup`` used to do::
+
+    self.target_model = self.target_model.to(self.device)
+
+on the unsharded path.  ``nn.Module.to`` is in-place, so the reassignment is
+redundant -- and it re-triggers ``BaseRecipe.__setattr__`` state tracking,
+which raises ``RuntimeError: State key 'target_model' is already tracked``
+since the duplicate-key guard was hardened from ``assert`` to ``raise``.
+
+The fix drops the reassignment and keeps the in-place ``.to(self.device)``
+call.  These tests pin that behavior on both EAGLE-1 (which EAGLE-2
+inherits from) and EAGLE-3 by driving ``setup()`` up to the patched line
+with stubs and asserting (1) no ``RuntimeError`` from ``__setattr__`` and
+(2) ``target_model`` is tracked exactly once.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+from torch import nn
+
+
+class _SetupReachedTarget(Exception):
+    """Sentinel raised by the wrapper stub once ``setup()`` has executed
+    past the patched ``self.target_model.to(self.device)`` line."""
+
+
+def _tiny_target_module() -> nn.Module:
+    """A real ``nn.Module`` so ``BaseRecipe.is_model`` flags it for tracking
+    and so ``.to(device)`` is a real in-place no-op rather than a Mock call."""
+
+    class _T(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.lin = nn.Linear(2, 2)
+
+        def requires_grad_(self, mode: bool = True):  # noqa: D401 - mirror nn.Module API
+            for p in self.parameters():
+                p.requires_grad_(mode)
+            return self
+
+    return _T()
+
+
+def _fake_dist_env() -> SimpleNamespace:
+    return SimpleNamespace(
+        device=torch.device("cpu"),
+        world_size=1,
+        is_main=True,
+        rank=0,
+        local_rank=0,
+    )
+
+
+def _fake_target_config() -> MagicMock:
+    cfg = MagicMock()
+    cfg.architectures = ["LlamaForCausalLM"]
+    return cfg
+
+
+def _make_cfg() -> MagicMock:
+    """Build a minimal ``cfg`` mock matching the attribute access in
+    ``setup()`` up to and including the patched line.
+
+    No ``distributed:`` block -> ``self.dist_setup`` stays ``None`` ->
+    the unsharded branch (the line under test) executes.
+    """
+
+    cfg = MagicMock()
+    # ``self.cfg.get("distributed", None)`` -> None drives the unsharded path.
+    cfg.get = MagicMock(side_effect=lambda key, default=None: default)
+    cfg.recipe_args = SimpleNamespace(
+        target_model_name_or_path="ignored/path",
+        get=lambda key, default=None: default,
+    )
+    # ``recipe_cfg.get("trust_remote_code", False)`` style calls go through
+    # ``recipe_args.get``; SimpleNamespace doesn't expose ``get`` by default,
+    # so we attach one explicitly below.
+    cfg.recipe_args.get = lambda key, default=None: default
+    return cfg
+
+
+@pytest.mark.parametrize(
+    "recipe_module, recipe_cls_name, target_wrapper_attr, draft_spec_attr",
+    [
+        (
+            "nemo_automodel.recipes.llm.train_eagle1",
+            "TrainEagle1Recipe",
+            "HFEagleTargetModel",
+            "resolve_eagle1_draft_spec",
+        ),
+        (
+            "nemo_automodel.recipes.llm.train_eagle3",
+            "TrainEagle3Recipe",
+            "HFEagle3TargetModel",
+            "resolve_eagle3_draft_spec",
+        ),
+    ],
+)
+def test_setup_unsharded_does_not_retrack_target_model(
+    recipe_module, recipe_cls_name, target_wrapper_attr, draft_spec_attr
+):
+    """Regression: ``setup()`` on the unsharded path must run
+    ``self.target_model.to(self.device)`` in place, without re-triggering
+    ``BaseRecipe.__setattr__`` state tracking on ``target_model``.
+    """
+    import importlib
+
+    mod = importlib.import_module(recipe_module)
+    recipe_cls = getattr(mod, recipe_cls_name)
+
+    target_module = _tiny_target_module()
+
+    # The wrapper is the first call site that runs *after* the patched line.
+    # Raising a sentinel here both (a) confirms we got past the patched line
+    # and (b) short-circuits the rest of ``setup()`` (which depends on real
+    # data files / HF downloads we don't want in a unit test).
+    def _wrapper_sentinel(*_args, **_kwargs):
+        raise _SetupReachedTarget()
+
+    cfg = _make_cfg()
+    recipe = recipe_cls(cfg)
+
+    with (
+        patch.object(mod, "initialize_distributed", return_value=_fake_dist_env()),
+        patch.object(mod, "setup_logging"),
+        patch.object(mod, "AutoConfig") as mock_auto_config,
+        patch.object(mod, "NeMoAutoTokenizer") as mock_tok,
+        patch.object(mod, draft_spec_attr, return_value=MagicMock()),
+        patch.object(mod, "NeMoAutoModelForCausalLM") as mock_auto_model,
+        patch.object(mod, target_wrapper_attr, side_effect=_wrapper_sentinel),
+    ):
+        mock_auto_config.from_pretrained.return_value = _fake_target_config()
+        mock_tok.from_pretrained.return_value = MagicMock()
+        mock_auto_model.from_pretrained.return_value = target_module
+
+        with pytest.raises(_SetupReachedTarget):
+            recipe.setup()
+
+    # Recipe must hold the same module object (in-place ``.to``, no rebind).
+    assert recipe.target_model is target_module
+
+    # ``target_model`` must be tracked exactly once. The buggy reassignment
+    # would have raised ``RuntimeError`` before reaching the wrapper sentinel.
+    tracked = recipe.__dict__["__state_tracked"]
+    assert "target_model" in tracked
+
+
+def test_eagle2_inherits_eagle1_fix():
+    """``TrainEagle2Recipe`` inherits ``setup`` from ``TrainEagle1Recipe``,
+    so the same fix applies. Pin the inheritance and method identity so a
+    future override has to consciously re-establish the contract.
+    """
+    from nemo_automodel.recipes.llm.train_eagle1 import TrainEagle1Recipe
+    from nemo_automodel.recipes.llm.train_eagle2 import TrainEagle2Recipe
+
+    assert issubclass(TrainEagle2Recipe, TrainEagle1Recipe)
+    assert TrainEagle2Recipe.setup is TrainEagle1Recipe.setup


### PR DESCRIPTION
## Summary

`TrainEagle1Recipe.setup` and `TrainEagle3Recipe.setup` reassigned
`self.target_model = self.target_model.to(self.device)` on the unsharded
path. `nn.Module.to` is in-place, so the reassignment is redundant — and it
re-triggers `BaseRecipe.__setattr__` state tracking, which, since #2219
hardened the duplicate-key check from `assert` to `raise`, crashes the
recipe before any training step runs:

```
File ".../nemo_automodel/recipes/llm/train_eagle3.py", line 154, in setup
    self.target_model = self.target_model.to(self.device)
File ".../nemo_automodel/recipes/base_recipe.py", line 242, in __setattr__
    raise RuntimeError(f"State key {key!r} is already tracked")
RuntimeError: State key 'target_model' is already tracked
```

The fix drops the reassignment and keeps the in-place `.to(self.device)`.

```diff
 self.target_model = NeMoAutoModelForCausalLM.from_pretrained(target_path, **target_kwargs)
 if self.dist_setup is None:
-    self.target_model = self.target_model.to(self.device)
+    self.target_model.to(self.device)
```

`TrainEagle2Recipe` inherits from `TrainEagle1Recipe`, so all three EAGLE
recipes are covered.

## Root cause

`BaseRecipe.__setattr__` (`nemo_automodel/recipes/base_recipe.py:230-244`)
auto-tracks any attribute that is a model / tokenizer / optimizer /
dataloader / `ConfigNode` etc. for checkpointing. It enforces single
assignment per key:

```python
if should_track and not any(substr in key.lower() for substr in ("val", "eval", "test", "loss")):
    if key in self.__dict__["__state_tracked"]:
        raise RuntimeError(f"State key {key!r} is already tracked")
    self.__dict__["__state_tracked"].add(key)
```

The original `assert` here was silent under `python -O`; #2219 (May 13)
replaced it with a `RuntimeError`, exposing the latent bug in the EAGLE
recipes.

The unsharded branch is taken whenever the recipe YAML has no
`distributed:` block. `examples/speculative/eagle3/llama_eagle3_mvp.yaml`
ships without one, so any multi-rank `torchrun` invocation of that recipe
hits the crash inside `setup()` — well before EAGLE-3's vocab-shrink or
checkpoint-resume logic gets a chance to run.

## Why the existing test did not catch this

There is no in-tree CI test that exercises `train_eagle{1,3}.py:setup` on
a config that lacks `distributed:`. The two test paths I checked were the
EAGLE checkpoint-save (#2310) and EAGLE-3 vocab-shrunk resume (#2319)
PRs, both of which ship their own configs with explicit FSDP setup.

## Repro (before fix)

Container: `nvcr.io/nvidia/nemo-automodel:25.07.rc7` (or any container
with `main` as of 2026-05-27, commit `d0908fe6`). Two H100 GPUs.

```bash
cd /opt/Automodel
cat > /tmp/train.jsonl <<'JSONL'
{"messages":[{"role":"user","content":"What is 2 plus 2?"},{"role":"assistant","content":"4."}]}
JSONL
torchrun --nproc-per-node=2 -m nemo_automodel.cli.app \
  examples/speculative/eagle3/llama_eagle3_mvp.yaml \
  --recipe_args.train_data_path /tmp/train.jsonl \
  --recipe_args.val_data_path null \
  --recipe_args.seq_length 128 \
  --recipe_args.ttt_steps 2 \
  --recipe_args.draft_vocab_size 4096 \
  --recipe_args.num_epochs 1 \
  --checkpoint.enabled true
```

Observed (crashes ~5s into `setup()` on both ranks):

```
[rank0]:   File "/opt/Automodel/nemo_automodel/recipes/llm/train_eagle3.py", line 154, in setup
[rank0]:     self.target_model = self.target_model.to(self.device)
[rank0]:   File "/opt/Automodel/nemo_automodel/recipes/base_recipe.py", line 242, in __setattr__
[rank0]:     raise RuntimeError(f"State key {key!r} is already tracked")
[rank0]: RuntimeError: State key 'target_model' is already tracked
torch.distributed.elastic.multiprocessing.errors.ChildFailedError
```

Same error reproduces with `examples/speculative/eagle1/...` recipes.

## After fix — observed

Verified end-to-end on EOS, job `5335209`, 2× H100, container
`nemo-automodel-nightly-20260527.sqsh`. Procedure: overlay the patched
`train_eagle1.py` and `train_eagle3.py` into `/opt/Automodel/...` inside
the daily-PR Automodel container, then run `llama_eagle3_mvp.yaml`
end-to-end (save → resume) with `meta-llama/Llama-3.2-1B-Instruct` as
the target model and `--recipe_args.val_data_path None` (capital N).

Full log (`after_fix.5335209.log`):

```
[overlay] copying patched recipes into /opt/Automodel
'/lustre/fsw/coreai_dlalgo_ci/qiaochuz/eagle_fix_patches/train_eagle1.py' -> '/opt/Automodel/nemo_automodel/recipes/llm/train_eagle1.py'
'/lustre/fsw/coreai_dlalgo_ci/qiaochuz/eagle_fix_patches/train_eagle3.py' -> '/opt/Automodel/nemo_automodel/recipes/llm/train_eagle3.py'
[overlay] grep for the buggy assignment (must be empty):
(empty — patch applied)
[run1] save
W0527 11:07:02.016000 4065244 torch/distributed/run.py:862] 
W0527 11:07:02.016000 4065244 torch/distributed/run.py:862] *****************************************
W0527 11:07:02.016000 4065244 torch/distributed/run.py:862] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
W0527 11:07:02.016000 4065244 torch/distributed/run.py:862] *****************************************
cfg-path: /opt/Automodel/examples/speculative/eagle3/llama_eagle3_mvp.yaml
cfg-path: /opt/Automodel/examples/speculative/eagle3/llama_eagle3_mvp.yaml
> initializing torch distributed with 2 workers.
2026-05-27 11:07:13 | INFO | nemo_automodel.components.loggers.log_utils | Setting logging level to 20
2026-05-27 11:07:14 | WARNING | nemo_automodel._transformers.tokenization.nemo_auto_tokenizer | Tokenizer 'meta-llama/Llama-3.2-1B-Instruct' has pad_token_id=None; defaulting to 0. This can cause incorrect MoE auxiliary loss calculations if valid tokens share token ID 0. Set pad_token_id explicitly in your tokenizer config to avoid this.
2026-05-27 11:07:14 | INFO | nemo_automodel._transformers.model_init | HF_HUB_OFFLINE=1: skipping weight download for meta-llama/Llama-3.2-1B-Instruct (using cached weights)
2026-05-27 11:07:14 | INFO | nemo_automodel._transformers.model_init | Using custom model implementation for LlamaForCausalLM
[LlamaForCausalLM] Attention implementation: flash_attention_2
[LlamaForCausalLM] torch_dtype: torch.bfloat16
2026-05-27 11:07:17 | INFO | nemo_automodel.components.models.llama.state_dict_adapter | Tying lm_head.weight to model.embed_tokens.weight (HuggingFace checkpoint has tied weights)
2026-05-27 11:07:17 | INFO | root | Model summary:
2026-05-27 11:07:17 | INFO | root | --------------------------------
2026-05-27 11:07:17 | INFO | root | Trainable parameters: 1,235,814,400
2026-05-27 11:07:17 | INFO | root | Total parameters: 1,235,814,400
2026-05-27 11:07:17 | INFO | root | Trainable parameters percentage: 100.00%
2026-05-27 11:07:17 | INFO | root | Param L2 norm: 690.7851
2026-05-27 11:07:17 | INFO | root | --------------------------------
2026-05-27 11:07:20 | INFO | nemo_automodel.recipes.llm.train_eagle3 | Training start: start_epoch=0 num_epochs=1 batches_per_epoch=1 grad_accum=1 log_every=1 total_optim_steps=1 warmup_steps=1 peak_lr=1.000e-04 min_lr_ratio=0.1
/usr/local/lib/python3.12/dist-packages/torch/utils/_config_module.py:540: FutureWarning: torch._dynamo.config.skip_code_recursive_on_recompile_limit_hit is deprecated and does not do anything. It will be removed in a future version of PyTorch.
  config[key] = copy.deepcopy(getattr(self, key))
/usr/local/lib/python3.12/dist-packages/torch/utils/_config_module.py:540: FutureWarning: torch._dynamo.config.skip_code_recursive_on_recompile_limit_hit is deprecated and does not do anything. It will be removed in a future version of PyTorch.
  config[key] = copy.deepcopy(getattr(self, key))
2026-05-27 11:07:22 | INFO | nemo_automodel.recipes.llm.train_eagle3 | epoch=0 step=1 train_loss=8.631310 train_acc=0.000000 lr=1.000e-04
2026-05-27 11:07:22 | INFO | nemo_automodel.recipes.llm.train_eagle3 | Epoch 0 done: total_batches_seen=1 global_step=1
/usr/local/lib/python3.12/dist-packages/torch/distributed/c10d_logger.py:83: UserWarning: barrier(): using the device under current context. You can specify `device_id` in `init_process_group` to mute this warning.
  return func(*args, **kwargs)
2026-05-27 11:07:23 | INFO | nemo_automodel.components.checkpoint._backports.consolidate_hf_safetensors | Rank 0/2: Consolidating safetensors files from /tmp/automodel_eagle3_fixtest_5335209_4063884/checkpoints/epoch_1_step_1/model to /tmp/automodel_eagle3_fixtest_5335209_4063884/checkpoints/epoch_1_step_1/model/consolidated
2026-05-27 11:07:23 | INFO | nemo_automodel.components.checkpoint._backports.consolidate_hf_safetensors | Rank 0: Assigned 0 output files out of 1 total files
2026-05-27 11:07:23 | INFO | nemo_automodel.components.checkpoint._backports.consolidate_hf_safetensors | Rank 0: Done consolidating. Processed 0 unique indices in 0.00 secs.
2026-05-27 11:07:23 | INFO | nemo_automodel.components.checkpoint._backports.consolidate_hf_safetensors | Rank 0: Waiting for all ranks to complete...
2026-05-27 11:07:23 | INFO | nemo_automodel.components.checkpoint._backports.consolidate_hf_safetensors | Rank 0: All ranks have completed.
2026-05-27 11:07:23 | INFO | nemo_automodel.components.checkpoint._backports.consolidate_hf_safetensors | Total time taken: 0.90 secs.
2026-05-27 11:07:24 | INFO | nemo_automodel.recipes.llm.train_eagle3 | Saved checkpoint to /tmp/automodel_eagle3_fixtest_5335209_4063884/checkpoints/epoch_1_step_1
2026-05-27 11:07:24 | INFO | nemo_automodel.recipes.llm.train_eagle3 | Training complete: global_step=1
[run2] resume
W0527 11:07:28.527000 4066341 torch/distributed/run.py:862] 
W0527 11:07:28.527000 4066341 torch/distributed/run.py:862] *****************************************
W0527 11:07:28.527000 4066341 torch/distributed/run.py:862] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
W0527 11:07:28.527000 4066341 torch/distributed/run.py:862] *****************************************
cfg-path: /opt/Automodel/examples/speculative/eagle3/llama_eagle3_mvp.yaml
cfg-path: /opt/Automodel/examples/speculative/eagle3/llama_eagle3_mvp.yaml
> initializing torch distributed with 2 workers.
2026-05-27 11:07:39 | INFO | nemo_automodel.components.loggers.log_utils | Setting logging level to 20
2026-05-27 11:07:40 | WARNING | nemo_automodel._transformers.tokenization.nemo_auto_tokenizer | Tokenizer 'meta-llama/Llama-3.2-1B-Instruct' has pad_token_id=None; defaulting to 0. This can cause incorrect MoE auxiliary loss calculations if valid tokens share token ID 0. Set pad_token_id explicitly in your tokenizer config to avoid this.
2026-05-27 11:07:40 | INFO | nemo_automodel._transformers.model_init | HF_HUB_OFFLINE=1: skipping weight download for meta-llama/Llama-3.2-1B-Instruct (using cached weights)
2026-05-27 11:07:40 | INFO | nemo_automodel._transformers.model_init | Using custom model implementation for LlamaForCausalLM
[LlamaForCausalLM] Attention implementation: flash_attention_2
[LlamaForCausalLM] torch_dtype: torch.bfloat16
2026-05-27 11:07:43 | INFO | nemo_automodel.components.models.llama.state_dict_adapter | Tying lm_head.weight to model.embed_tokens.weight (HuggingFace checkpoint has tied weights)
2026-05-27 11:07:43 | INFO | root | Model summary:
2026-05-27 11:07:43 | INFO | root | --------------------------------
2026-05-27 11:07:43 | INFO | root | Trainable parameters: 1,235,814,400
2026-05-27 11:07:43 | INFO | root | Total parameters: 1,235,814,400
2026-05-27 11:07:43 | INFO | root | Trainable parameters percentage: 100.00%
2026-05-27 11:07:43 | INFO | root | Param L2 norm: 690.7851
2026-05-27 11:07:43 | INFO | root | --------------------------------
2026-05-27 11:07:46 | INFO | nemo_automodel.recipes.llm.train_eagle3 | Resuming from checkpoint: /tmp/automodel_eagle3_fixtest_5335209_4063884/checkpoints/epoch_1_step_1
2026-05-27 11:07:47 | INFO | nemo_automodel.recipes.llm.train_eagle3 | All 1 epochs already completed; nothing to do.
PASS: EAGLE-3 vocab-shrunk checkpoint save and resume completed (after fix)
```

Run 1 reaches `Training complete: global_step=1` and writes a checkpoint;
run 2 resumes from `LATEST` and exits cleanly. Final stdout is
`PASS: EAGLE-3 vocab-shrunk checkpoint save and resume completed (after fix)`.

Two preexisting testcase-side issues had to be worked around to get a
clean PASS once `setup()` no longer crashed at line 154 — both are
independent of this fix:

1. The original daily-PR script passed `--recipe_args.val_data_path null`.
   Automodel's CLI parser maps `null` to the literal Python string
   `"null"`; only `None`/`none` map to Python `None`. Use `None` instead.
2. `examples/speculative/eagle3/llama_eagle3_mvp.yaml` defaults to
   `meta-llama/Llama-3.2-1B`, which has no chat template, but the recipe
   builds a `ChatDataset`. Override to `Llama-3.2-1B-Instruct`.

Both only become visible *after* this PR lets `setup()` advance past the
`target_model` reassignment — i.e. exactly the boundary this fix moves
past. Will follow up to fix the daily-PR gap testcase separately.


## Detected by

NeMo daily-PR impact pipeline gap test
`test_automodel_eagle3_vocab_shrunk_resume_daily_pr_test` (run
`20260527T111037Z-5b469c1e`, automodel suite). Failure is a hard 18-second
crash inside `setup()`; daily-PR cron flagged it this morning.

## Test plan

- [x] EAGLE-3 mvp YAML + `torchrun --nproc-per-node=2` reaches first
  training step (was crashing in `setup()`).
- [x] Unsharded path still moves the target model to `self.device`
  (relying on `nn.Module.to` being in-place).
- [x] No behavior change for any recipe that defines a `distributed:`
  block — that branch wasn't touched.
- [x] `TrainEagle2Recipe` inherits from `TrainEagle1Recipe`, so the same
  fix applies.
