### PR TITLE
feat(llm_finetune): add DeepSeek-R1 distill fine-tuning examples

### DIFF
--- a/examples/llm_finetune/deepseek_r1/deepseek_r1_7b_squad.yaml
+++ b/examples/llm_finetune/deepseek_r1/deepseek_r1_7b_squad.yaml
@@ -79,6 +79,7 @@ validation_dataset:
   _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
   dataset_name: rajpurkar/squad
   split: validation
+  limit_dataset_samples: 100
 
 validation_dataloader:
   _target_: torchdata.stateful_dataloader.StatefulDataLoader
@@ -99,6 +100,6 @@ optimizer:
 #   save_dir: <your_wandb_save_dir>
 
 ci:
-  recipe_owner: champion1.chen@gmail.com
+  recipe_owner: nemo-automodel-maintainers@nvidia.com
   time: "00:30:00"
   nodes: 1

--- a/examples/llm_finetune/deepseek_r1/deepseek_r1_7b_squad.yaml
+++ b/examples/llm_finetune/deepseek_r1/deepseek_r1_7b_squad.yaml
@@ -1,0 +1,104 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Finetuning config for DeepSeek-R1-Distill-Qwen-7B on SQuAD dataset.
+# DeepSeek-R1-Distill-Qwen-7B is a reasoning model distilled from DeepSeek-R1
+# into a Qwen2.5-7B backbone.
+#
+# To run this recipe:
+#   automodel examples/llm_finetune/deepseek_r1/deepseek_r1_7b_squad.yaml --nproc-per-node 8
+# Adjust --nproc-per-node to the number of GPUs available on your machine.
+
+recipe: TrainFinetuneRecipeForNextTokenPrediction
+
+step_scheduler:
+  global_batch_size: 64
+  local_batch_size: 4
+  ckpt_every_steps: 50
+  val_every_steps: 50  # will run every x number of gradient steps
+  max_steps: 100
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 1
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 42
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: deepseek-ai/DeepSeek-R1-Distill-Qwen-7B
+  torch_dtype: bf16
+  attn_implementation: eager
+
+checkpoint:
+  enabled: false
+  checkpoint_dir: checkpoints/
+  model_save_format: safetensors # torch_save or safetensors
+  save_consolidated: false
+
+distributed:
+  strategy: fsdp2
+  dp_size: none
+  tp_size: 1
+  cp_size: 1
+
+  sequence_parallel: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
+  dataset_name: rajpurkar/squad
+  split: train
+
+packed_sequence:
+  # Set packed_sequence_size > 0 to run with packed sequences
+  packed_sequence_size: 0
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  shuffle: false
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
+  dataset_name: rajpurkar/squad
+  split: validation
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+
+optimizer:
+  _target_: torch.optim.AdamW
+  betas: [0.9, 0.999]
+  eps: 1e-8
+  lr: 1.0e-5
+  weight_decay: 0.01
+
+# Uncomment and configure for W&B logging
+# wandb:
+#   project: <your_wandb_project>
+#   entity: <your_wandb_entity>
+#   name: deepseek_r1_7b_squad
+#   save_dir: <your_wandb_save_dir>
+
+ci:
+  recipe_owner: champion1.chen@gmail.com
+  time: "00:30:00"
+  nodes: 1

--- a/examples/llm_finetune/deepseek_r1/deepseek_r1_7b_squad_peft.yaml
+++ b/examples/llm_finetune/deepseek_r1/deepseek_r1_7b_squad_peft.yaml
@@ -1,0 +1,110 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# LoRA finetuning config for DeepSeek-R1-Distill-Qwen-7B on SQuAD dataset.
+# Uses LoRA adapters for parameter-efficient fine-tuning of the reasoning model.
+#
+# To run this recipe:
+#   automodel examples/llm_finetune/deepseek_r1/deepseek_r1_7b_squad_peft.yaml --nproc-per-node 8
+# Adjust --nproc-per-node to the number of GPUs available on your machine.
+
+recipe: TrainFinetuneRecipeForNextTokenPrediction
+
+step_scheduler:
+  global_batch_size: 64
+  local_batch_size: 4
+  ckpt_every_steps: 50
+  val_every_steps: 50  # will run every x number of gradient steps
+  max_steps: 100
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 1
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 42
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: deepseek-ai/DeepSeek-R1-Distill-Qwen-7B
+  torch_dtype: bf16
+  attn_implementation: eager
+
+peft:
+  _target_: nemo_automodel.components._peft.lora.PeftConfig
+  target_modules: '*_proj'
+  dim: 8
+  alpha: 32
+  use_triton: True
+
+checkpoint:
+  enabled: false
+  checkpoint_dir: checkpoints/
+  model_save_format: safetensors # torch_save or safetensors
+  save_consolidated: false
+
+distributed:
+  strategy: fsdp2
+  dp_size: none
+  tp_size: 1
+  cp_size: 1
+
+  sequence_parallel: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
+  dataset_name: rajpurkar/squad
+  split: train
+
+packed_sequence:
+  # Set packed_sequence_size > 0 to run with packed sequences
+  packed_sequence_size: 0
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  shuffle: false
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
+  dataset_name: rajpurkar/squad
+  split: validation
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+
+optimizer:
+  _target_: torch.optim.AdamW
+  betas: [0.9, 0.999]
+  eps: 1e-8
+  lr: 1.0e-5
+  weight_decay: 0.01
+
+# Uncomment and configure for W&B logging
+# wandb:
+#   project: <your_wandb_project>
+#   entity: <your_wandb_entity>
+#   name: deepseek_r1_7b_squad_peft
+#   save_dir: <your_wandb_save_dir>
+
+ci:
+  recipe_owner: champion1.chen@gmail.com
+  time: "00:30:00"
+  nodes: 1

--- a/examples/llm_finetune/deepseek_r1/deepseek_r1_7b_squad_peft.yaml
+++ b/examples/llm_finetune/deepseek_r1/deepseek_r1_7b_squad_peft.yaml
@@ -85,6 +85,7 @@ validation_dataset:
   _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
   dataset_name: rajpurkar/squad
   split: validation
+  limit_dataset_samples: 100
 
 validation_dataloader:
   _target_: torchdata.stateful_dataloader.StatefulDataLoader
@@ -105,6 +106,6 @@ optimizer:
 #   save_dir: <your_wandb_save_dir>
 
 ci:
-  recipe_owner: champion1.chen@gmail.com
+  recipe_owner: nemo-automodel-maintainers@nvidia.com
   time: "00:30:00"
   nodes: 1

--- a/examples/llm_finetune/deepseek_r1/deepseek_r1_8b_squad.yaml
+++ b/examples/llm_finetune/deepseek_r1/deepseek_r1_8b_squad.yaml
@@ -99,6 +99,6 @@ optimizer:
 #   save_dir: <your_wandb_save_dir>
 
 ci:
-  recipe_owner: champion1.chen@gmail.com
+  recipe_owner: nemo-automodel-maintainers@nvidia.com
   time: "00:30:00"
   nodes: 1

--- a/examples/llm_finetune/deepseek_r1/deepseek_r1_8b_squad.yaml
+++ b/examples/llm_finetune/deepseek_r1/deepseek_r1_8b_squad.yaml
@@ -1,0 +1,104 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Finetuning config for DeepSeek-R1-Distill-Llama-8B on SQuAD dataset.
+# DeepSeek-R1-Distill-Llama-8B is a reasoning model distilled from DeepSeek-R1
+# into a Llama-3.1-8B backbone.
+#
+# To run this recipe:
+#   automodel examples/llm_finetune/deepseek_r1/deepseek_r1_8b_squad.yaml --nproc-per-node 8
+# Adjust --nproc-per-node to the number of GPUs available on your machine.
+
+recipe: TrainFinetuneRecipeForNextTokenPrediction
+
+step_scheduler:
+  global_batch_size: 64
+  local_batch_size: 4
+  ckpt_every_steps: 50
+  val_every_steps: 50  # will run every x number of gradient steps
+  max_steps: 100
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 1
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 42
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: deepseek-ai/DeepSeek-R1-Distill-Llama-8B
+  torch_dtype: bfloat16
+
+checkpoint:
+  enabled: false
+  checkpoint_dir: checkpoints/
+  model_save_format: safetensors # torch_save or safetensors
+  save_consolidated: false
+
+distributed:
+  strategy: fsdp2
+  dp_size: none
+  tp_size: 1
+  cp_size: 1
+
+  sequence_parallel: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
+  dataset_name: rajpurkar/squad
+  split: train
+
+packed_sequence:
+  # Set packed_sequence_size > 0 to run with packed sequences
+  packed_sequence_size: 0
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  shuffle: false
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
+  dataset_name: rajpurkar/squad
+  split: validation
+  limit_dataset_samples: 100
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+
+optimizer:
+  _target_: torch.optim.AdamW
+  betas: [0.9, 0.999]
+  eps: 1e-8
+  lr: 1.0e-5
+  weight_decay: 0.01
+
+# Uncomment and configure for W&B logging
+# wandb:
+#   project: <your_wandb_project>
+#   entity: <your_wandb_entity>
+#   name: deepseek_r1_8b_squad
+#   save_dir: <your_wandb_save_dir>
+
+ci:
+  recipe_owner: champion1.chen@gmail.com
+  time: "00:30:00"
+  nodes: 1

--- a/examples/llm_finetune/deepseek_r1/deepseek_r1_8b_squad_peft.yaml
+++ b/examples/llm_finetune/deepseek_r1/deepseek_r1_8b_squad_peft.yaml
@@ -113,6 +113,6 @@ optimizer:
 #   save_dir: <your_wandb_save_dir>
 
 ci:
-  recipe_owner: champion1.chen@gmail.com
+  recipe_owner: nemo-automodel-maintainers@nvidia.com
   time: "00:30:00"
   nodes: 1

--- a/examples/llm_finetune/deepseek_r1/deepseek_r1_8b_squad_peft.yaml
+++ b/examples/llm_finetune/deepseek_r1/deepseek_r1_8b_squad_peft.yaml
@@ -1,0 +1,118 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# QLoRA finetuning config for DeepSeek-R1-Distill-Llama-8B on SQuAD dataset.
+# Uses 4-bit quantization with LoRA adapters for memory-efficient fine-tuning.
+#
+# To run this recipe:
+#   automodel examples/llm_finetune/deepseek_r1/deepseek_r1_8b_squad_peft.yaml --nproc-per-node 8
+# Adjust --nproc-per-node to the number of GPUs available on your machine.
+
+recipe: TrainFinetuneRecipeForNextTokenPrediction
+
+step_scheduler:
+  global_batch_size: 32
+  local_batch_size: 4
+  ckpt_every_steps: 100
+  val_every_steps: 600
+  max_steps: 500
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 1
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 42
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: deepseek-ai/DeepSeek-R1-Distill-Llama-8B
+  torch_dtype: bfloat16
+
+peft:
+  _target_: nemo_automodel.components._peft.lora.PeftConfig
+  target_modules: '*_proj'
+  dim: 16
+  alpha: 32
+  dropout: 0.1
+
+distributed:
+  strategy: fsdp2
+  dp_size: none
+  tp_size: 1
+  cp_size: 1
+
+  sequence_parallel: false
+
+quantization:
+  load_in_4bit: True
+  load_in_8bit: False
+  bnb_4bit_compute_dtype: bfloat16
+  bnb_4bit_use_double_quant: True
+  bnb_4bit_quant_type: nf4
+  bnb_4bit_quant_storage: bfloat16
+
+checkpoint:
+  enabled: false
+  checkpoint_dir: checkpoints/
+  model_save_format: safetensors # torch_save or safetensors
+  save_consolidated: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
+  dataset_name: rajpurkar/squad
+  split: train
+
+packed_sequence:
+  # Set packed_sequence_size > 0 to run with packed sequences
+  packed_sequence_size: 0
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  shuffle: false
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
+  dataset_name: rajpurkar/squad
+  split: validation
+  limit_dataset_samples: 100
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+
+optimizer:
+  _target_: torch.optim.AdamW
+  betas: [0.9, 0.999]
+  eps: 1e-8
+  lr: 1.0e-5
+  weight_decay: 0.01
+
+# Uncomment and configure for W&B logging
+# wandb:
+#   project: <your_wandb_project>
+#   entity: <your_wandb_entity>
+#   name: deepseek_r1_8b_squad_peft
+#   save_dir: <your_wandb_save_dir>
+
+ci:
+  recipe_owner: champion1.chen@gmail.com
+  time: "00:30:00"
+  nodes: 1

--- a/tests/ci_tests/configs/llm_finetune/test_recipes.yml
+++ b/tests/ci_tests/configs/llm_finetune/test_recipes.yml
@@ -16,6 +16,10 @@ configs:
   - baichuan/baichuan_2_7b_squad.yaml
   - baichuan/baichuan_2_7b_squad_peft.yaml
   - cohere/cohere_command_r_7b_hellaswag_fp8.yaml
+  - deepseek_r1/deepseek_r1_7b_squad.yaml
+  - deepseek_r1/deepseek_r1_7b_squad_peft.yaml
+  - deepseek_r1/deepseek_r1_8b_squad.yaml
+  - deepseek_r1/deepseek_r1_8b_squad_peft.yaml
   - deepseek_v32/deepseek_v32_hellaswag_pp.yaml
   - gemma/gemma_3_270m_squad.yaml
   - gemma/gemma_3_270m_squad_peft.yaml


### PR DESCRIPTION
  Add fine-tuning recipes for DeepSeek-R1 distilled models:
  - deepseek_r1_7b_squad.yaml: full SFT for DeepSeek-R1-Distill-Qwen-7B
  - deepseek_r1_7b_squad_peft.yaml: LoRA for DeepSeek-R1-Distill-Qwen-7B
  - deepseek_r1_8b_squad.yaml: full SFT for DeepSeek-R1-Distill-Llama-8B
  - deepseek_r1_8b_squad_peft.yaml: QLoRA (4-bit) for DeepSeek-R1-Distill-Llama-8B

  Both distilled variants (Qwen2.5-based and Llama-3.1-based) use
  NeMoAutoModelForCausalLM.from_pretrained with fsdp2 and are registered
  in the CI test recipe list.

  # What does this PR do ?

  Adds four fine-tuning recipe configs for DeepSeek-R1 distilled models —
  covering both the Qwen2.5-based (7B) and Llama-3.1-based (8B) distill
  variants, each with a full SFT and a parameter-efficient (LoRA/QLoRA) option.

  # Changelog

  - Add `examples/llm_finetune/deepseek_r1/deepseek_r1_7b_squad.yaml`: full SFT for
  `deepseek-ai/DeepSeek-R1-Distill-Qwen-7B` on SQuAD
  - Add `examples/llm_finetune/deepseek_r1/deepseek_r1_7b_squad_peft.yaml`: LoRA fine-tuning for the same model
  - Add `examples/llm_finetune/deepseek_r1/deepseek_r1_8b_squad.yaml`: full SFT for
  `deepseek-ai/DeepSeek-R1-Distill-Llama-8B` on SQuAD
  - Add `examples/llm_finetune/deepseek_r1/deepseek_r1_8b_squad_peft.yaml`: QLoRA (4-bit NF4) fine-tuning for the same
  model
  - Register all four configs in `tests/ci_tests/configs/llm_finetune/test_recipes.yml`

  # Before your PR is "Ready for review"

  **Pre checks**:

  - [V] Make sure you read and followed [Contributor
  guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
  - [V] Did you write any new necessary tests?
  - [V] Did you add or update any necessary documentation?

  # Additional Information

  - Related to # (issue)