### PR TITLE
fix(examples): switch agent SFT loss to FusedLinearCrossEntropy to avoid OOM

### DIFF
--- a/examples/llm_finetune/agent/qwen2_5_3b_function_calling.yaml
+++ b/examples/llm_finetune/agent/qwen2_5_3b_function_calling.yaml
@@ -49,6 +49,9 @@ model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: Qwen/Qwen2.5-3B
   attn_implementation: sdpa
+  # Required by FusedLinearCrossEntropy below, which consumes hidden states
+  # directly instead of materializing the full [bsz, seq_len, vocab] logits.
+  output_hidden_states: true
 
 compile:
   enabled: false
@@ -67,7 +70,13 @@ distributed:
   sequence_parallel: false
 
 loss_fn:
-  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+  # FusedLinearCrossEntropy avoids materializing the full
+  # [bsz, seq_len, vocab_size] logits tensor (~2.5 GiB / rank for Qwen2.5
+  # at seq_length=4096 in fp32). The naive ``MaskedCrossEntropy`` peaks at
+  # roughly 5-7 GiB per forward and, combined with grad_accum and FSDP2
+  # unshard, OOMs around step 20 on 8x80GB A100. The fused linear path
+  # consumes hidden states directly and stays well under the budget.
+  _target_: nemo_automodel.components.loss.linear_ce.FusedLinearCrossEntropy
 
 dataset:
   _target_: nemo_automodel.components.datasets.llm.agent_chat.make_agent_chat_dataset

--- a/examples/llm_finetune/agent/qwen2_5_3b_function_calling_lora.yaml
+++ b/examples/llm_finetune/agent/qwen2_5_3b_function_calling_lora.yaml
@@ -42,6 +42,9 @@ model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: Qwen/Qwen2.5-3B
   attn_implementation: sdpa
+  # Required by FusedLinearCrossEntropy below, which consumes hidden states
+  # directly instead of materializing the full [bsz, seq_len, vocab] logits.
+  output_hidden_states: true
 
 peft:
   _target_: nemo_automodel.components._peft.lora.PeftConfig
@@ -67,7 +70,9 @@ distributed:
   sequence_parallel: false
 
 loss_fn:
-  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+  # See companion full-SFT yaml for rationale; MaskedCrossEntropy OOMs on
+  # Qwen2.5 vocab=151936 with seq_length=4096 even on 8x80GB.
+  _target_: nemo_automodel.components.loss.linear_ce.FusedLinearCrossEntropy
 
 dataset:
   _target_: nemo_automodel.components.datasets.llm.agent_chat.make_agent_chat_dataset


### PR DESCRIPTION
## Summary

Both agent SFT example YAMLs added in #2321 use `MaskedCrossEntropy`, which materializes the full `[bsz, seq_len, vocab]` logits tensor and upcasts to fp32. On Qwen2.5 (vocab=151936) at the shipped `seq_length=4096` with `grad_accum=4` under FSDP2, the CE call peaks at ~5-7 GiB per forward and the accumulated allocator pressure deterministically OOMs around step 21 on 8x80GB A100 — far before the 3B model itself would saturate memory.

## Fix

- Switch both agent example YAMLs to `FusedLinearCrossEntropy` (the loss used by the existing deepseekv3 / moonlight pretrain recipes). It consumes hidden states directly and skips full-logits materialization.
- Set `model.output_hidden_states: true`, which the fused loss requires.

## Test plan

- [x] Reproduced OOM on 8x80GB A100 with the existing yaml at step 21 (73 GiB/rank, trying to allocate 6.54 GiB in `F.cross_entropy`).
- [x] Same yaml + this fix runs to completion at the same `seq_length=4096` / `local_batch_size=1` / `global_batch_size=32`.
- [ ] CI green