### PR TITLE
feat(examples): add MiniCPM5-1B fine-tuning recipes

### DIFF
--- a/docs/model-coverage/llm/index.md
+++ b/docs/model-coverage/llm/index.md
@@ -5,7 +5,7 @@ Large Language Models (LLMs) power a variety of tasks such as dialogue systems, 
 NeMo AutoModel provides a simple interface for loading and fine-tuning LLMs hosted on the Hugging Face Hub.
 
 ## Run LLMs with NeMo AutoModel
-To run LLMs with NeMo AutoModel, make sure you're using NeMo container version [`25.11.00`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-automodel?version=25.11.00) or later. If the model you intend to fine-tune requires a newer version of Transformers, you may need to upgrade to the latest version of NeMo AutoModel by using:
+To run LLMs with NeMo AutoModel, make sure you're using NeMo container version [`25.11.00`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-automodel?version=25.11.00) or later. If the model you intend to fine-tune requires a newer version of Transformers, you may need to upgrade to the latest version of NeMo AutoModel by running:
 
 ```bash
 pip3 install --upgrade git+git@github.com:NVIDIA-NeMo/AutoModel.git

--- a/docs/model-coverage/llm/index.md
+++ b/docs/model-coverage/llm/index.md
@@ -64,7 +64,7 @@ NeMo AutoModel supports the [AutoModelForCausalLM](https://huggingface.co/transf
 | InternLM | [InternLM](internlm/internlm.md) | `InternLMForCausalLM`, `InternLM2ForCausalLM`, `InternLM3ForCausalLM` |
 | Inception AI | [Jais](inceptionai/jais.md) | `JAISLMHeadModel` |
 | MiniMax | [MiniMax-M2](minimax/minimax-m2.md) | `MiniMaxM2ForCausalLM` |
-| OpenBMB | [MiniCPM](openbmb/minicpm.md) | `MiniCPMForCausalLM`, `MiniCPM3ForCausalLM` |
+| OpenBMB | [MiniCPM](openbmb/minicpm.md) | `MiniCPMForCausalLM`, `MiniCPM3ForCausalLM`, `MiniCPM5ForCausalLM` |
 | Moonshot AI | [Moonlight](moonshotai/moonlight.md) | `DeepseekV3ForCausalLM` |
 | ByteDance Seed | [Seed](bytedance-seed/seed.md) | `Qwen2ForCausalLM` |
 | Upstage | [Solar](upstage/solar.md) | `SolarForCausalLM` |

--- a/docs/model-coverage/llm/index.md
+++ b/docs/model-coverage/llm/index.md
@@ -79,7 +79,7 @@ NeMo AutoModel supports the [AutoModelForCausalLM](https://huggingface.co/transf
 
 ## Fine-Tune LLMs with NeMo AutoModel
 
-The models listed above can be fine-tuned using NeMo AutoModel. We support two primary fine-tuning approaches:
+The models listed above can be fine-tuned using NeMo AutoModel. NeMo AutoModel supports two primary fine-tuning approaches:
 
 1. **Parameter-Efficient Fine-Tuning (PEFT)**: Updates only a small subset of parameters (typically <1%) using techniques like Low-Rank Adaptation (LoRA).
 2. **Supervised Fine-Tuning (SFT)**: Updates all or most model parameters for deeper adaptation.

--- a/docs/model-coverage/llm/index.md
+++ b/docs/model-coverage/llm/index.md
@@ -15,7 +15,7 @@ For other installation options (for example, uv), refer to the [NeMo AutoModel I
 
 ## Supported Models
 
-NeMo AutoModel supports the [AutoModelForCausalLM](https://huggingface.co/transformers/v3.5.1/model_doc/auto.html#automodelforcausallm) in the [Text Generation](https://huggingface.co/models?pipeline_tag=text-generation&sort=trending) category. During preprocessing, it uses `transformers.AutoTokenizer`, which is sufficient for most LLM cases. If your model requires custom text handling, override the tokenizer in your recipe YAML or provide a custom dataset `_target_`. See [LLM datasets](../../guides/llm/dataset.md) and [dataset overview](../../guides/dataset-overview.md).
+NeMo AutoModel supports the [AutoModelForCausalLM](https://huggingface.co/transformers/v3.5.1/model_doc/auto.html#automodelforcausallm) in the [Text Generation](https://huggingface.co/models?pipeline_tag=text-generation&sort=trending) category. During preprocessing, it uses `transformers.AutoTokenizer`, which is sufficient for most LLM cases. If your model requires custom text handling, override the tokenizer in your recipe YAML or provide a custom dataset `_target_`. Refer to [LLM datasets](../../guides/llm/dataset.md) and [dataset overview](../../guides/dataset-overview.md).
 
 | Owner | Model Family | Architectures |
 |---|---|---|

--- a/docs/model-coverage/llm/openbmb/minicpm.md
+++ b/docs/model-coverage/llm/openbmb/minicpm.md
@@ -84,7 +84,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/minicpm/minicpm5_1b_squad.yam
 ```
 :::
 
-See the [Installation Guide](../../../guides/installation.md) and [LLM Fine-Tuning Guide](../../../guides/llm/finetune.md).
+Refer to the [Installation Guide](../../../guides/installation.md) and [LLM Fine-Tuning Guide](../../../guides/llm/finetune.md).
 
 ## Fine-Tuning
 

--- a/docs/model-coverage/llm/openbmb/minicpm.md
+++ b/docs/model-coverage/llm/openbmb/minicpm.md
@@ -79,7 +79,7 @@ cd /opt/Automodel
 **3. Fine-tune**:
 
 ```bash
-automodel --nproc-per-node=8 examples/llm_finetune/llama3_2/llama3_2_1b_squad.yaml \
+automodel --nproc-per-node=8 examples/llm_finetune/minicpm/minicpm5_1b_squad.yaml \
   --model.pretrained_model_name_or_path <MODEL_HF_ID>
 ```
 :::

--- a/docs/model-coverage/llm/openbmb/minicpm.md
+++ b/docs/model-coverage/llm/openbmb/minicpm.md
@@ -1,6 +1,6 @@
 # MiniCPM
 
-[MiniCPM](https://github.com/OpenBMB/MiniCPM) is a compact language model series from OpenBMB / Tsinghua University, designed to deliver strong performance at small parameter counts using model merging and continuous training techniques.
+[MiniCPM](https://github.com/OpenBMB/MiniCPM) is a compact language model series from OpenBMB and Tsinghua University, designed to deliver strong performance at small parameter counts using model merging and continuous training techniques.
 
 :::{card}
 | | |

--- a/docs/model-coverage/llm/openbmb/minicpm.md
+++ b/docs/model-coverage/llm/openbmb/minicpm.md
@@ -86,9 +86,9 @@ automodel --nproc-per-node=8 examples/llm_finetune/minicpm/minicpm5_1b_squad.yam
 
 Refer to the [Installation Guide](../../../guides/installation.md) and [LLM Fine-Tuning Guide](../../../guides/llm/finetune.md).
 
-## Fine-Tuning
+## Fine-Tune
 
-See the [LLM Fine-Tuning Guide](../../../guides/llm/finetune.md).
+Refer to the [LLM Fine-Tuning Guide](../../../guides/llm/finetune.md).
 
 ## Hugging Face Model Cards
 

--- a/docs/model-coverage/llm/openbmb/minicpm.md
+++ b/docs/model-coverage/llm/openbmb/minicpm.md
@@ -6,13 +6,14 @@
 | | |
 |---|---|
 | **Task** | Text Generation |
-| **Architecture** | `MiniCPMForCausalLM` / `MiniCPM3ForCausalLM` |
-| **Parameters** | 2B – 4B |
+| **Architecture** | `MiniCPMForCausalLM` / `MiniCPM3ForCausalLM` / `MiniCPM5ForCausalLM` |
+| **Parameters** | 1B – 4B |
 | **HF Org** | [openbmb](https://huggingface.co/openbmb) |
 :::
 
 ## Available Models
 
+- **MiniCPM5-1B** (`MiniCPM5ForCausalLM`): 1B
 - **MiniCPM3-4B** (`MiniCPM3ForCausalLM`): 4B
 - **MiniCPM-2B-sft-bf16** (`MiniCPMForCausalLM`): 2B, SFT
 - **MiniCPM-2B-dpo-bf16** (`MiniCPMForCausalLM`): 2B, DPO
@@ -21,11 +22,13 @@
 
 - `MiniCPMForCausalLM` — MiniCPM v1/v2
 - `MiniCPM3ForCausalLM` — MiniCPM3
+- `MiniCPM5ForCausalLM` — MiniCPM5
 
 ## Example HF Models
 
 | Model | HF ID |
 |---|---|
+| MiniCPM5 1B | [`openbmb/MiniCPM5-1B`](https://huggingface.co/openbmb/MiniCPM5-1B) |
 | MiniCPM 2B SFT | [`openbmb/MiniCPM-2B-sft-bf16`](https://huggingface.co/openbmb/MiniCPM-2B-sft-bf16) |
 | MiniCPM3 4B | [`openbmb/MiniCPM3-4B`](https://huggingface.co/openbmb/MiniCPM3-4B) |
 
@@ -47,14 +50,15 @@ git clone https://github.com/NVIDIA-NeMo/Automodel.git
 cd Automodel
 ```
 
-**3. Fine-tune** by adapting a base LLM recipe — override the model ID on the CLI:
+**3. Fine-tune** using one of the provided MiniCPM5 recipes:
 
 ```bash
-automodel --nproc-per-node=8 examples/llm_finetune/llama3_2/llama3_2_1b_squad.yaml \
-  --model.pretrained_model_name_or_path <MODEL_HF_ID>
-```
+# Full fine-tuning
+automodel examples/llm_finetune/minicpm/minicpm5_1b_squad.yaml --nproc-per-node 8
 
-Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
+# LoRA fine-tuning
+automodel examples/llm_finetune/minicpm/minicpm5_1b_squad_peft.yaml --nproc-per-node 8
+```
 
 :::{dropdown} Run with Docker
 **1. Pull the container** and mount a checkpoint directory:
@@ -88,5 +92,6 @@ See the [LLM Fine-Tuning Guide](../../../guides/llm/finetune.md).
 
 ## Hugging Face Model Cards
 
+- [openbmb/MiniCPM5-1B](https://huggingface.co/openbmb/MiniCPM5-1B)
 - [openbmb/MiniCPM-2B-sft-bf16](https://huggingface.co/openbmb/MiniCPM-2B-sft-bf16)
 - [openbmb/MiniCPM3-4B](https://huggingface.co/openbmb/MiniCPM3-4B)

--- a/examples/llm_finetune/minicpm/minicpm5_1b_hellaswag_peft.yaml
+++ b/examples/llm_finetune/minicpm/minicpm5_1b_hellaswag_peft.yaml
@@ -1,0 +1,109 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# LoRA finetuning config for MiniCPM5-1B on HellaSwag dataset.
+#
+# To run this recipe:
+#   automodel examples/llm_finetune/minicpm/minicpm5_1b_hellaswag_peft.yaml --nproc-per-node 8
+# Adjust --nproc-per-node to the number of GPUs available on your machine.
+
+recipe: TrainFinetuneRecipeForNextTokenPrediction
+
+step_scheduler:
+  global_batch_size: 64
+  local_batch_size: 8
+  ckpt_every_steps: 50
+  val_every_steps: 50
+  max_steps: 100
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 1
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 1111
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: openbmb/MiniCPM5-1B
+  torch_dtype: bf16
+  trust_remote_code: true
+
+checkpoint:
+  enabled: false
+  checkpoint_dir: checkpoints/
+  model_save_format: safetensors
+  save_consolidated: false
+
+peft:
+  _target_: nemo_automodel.components._peft.lora.PeftConfig
+  target_modules: '*_proj'
+  dim: 8
+  alpha: 32
+  use_triton: True
+
+distributed:
+  strategy: fsdp2
+  dp_size: none
+  tp_size: 1
+  cp_size: 1
+
+  sequence_parallel: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.hellaswag.HellaSwag
+  path_or_dataset: rowan/hellaswag
+  split: train
+
+packed_sequence:
+  packed_sequence_size: 0
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  shuffle: false
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.llm.hellaswag.HellaSwag
+  path_or_dataset: rowan/hellaswag
+  split: validation
+  num_samples_limit: 64
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+
+optimizer:
+  _target_: torch.optim.Adam
+  betas: [0.9, 0.999]
+  eps: 1e-8
+  lr: 1.0e-5
+  weight_decay: 0
+
+# Uncomment and configure for W&B logging
+# wandb:
+#   project: <your_wandb_project>
+#   entity: <your_wandb_entity>
+#   name: minicpm5_1b_hellaswag_peft
+#   save_dir: <your_wandb_save_dir>
+
+ci:
+  recipe_owner: HuiyingLi
+  time: "00:10:00"
+  nodes: 1

--- a/examples/llm_finetune/minicpm/minicpm5_1b_squad.yaml
+++ b/examples/llm_finetune/minicpm/minicpm5_1b_squad.yaml
@@ -91,6 +91,6 @@ optimizer:
 #   save_dir: <your_wandb_save_dir>
 
 ci:
-  recipe_owner: nemo-automodel-maintainers@nvidia.com
-  time: "00:30:00"
+  recipe_owner: HuiyingLi
+  time: "00:10:00"
   nodes: 1

--- a/examples/llm_finetune/minicpm/minicpm5_1b_squad.yaml
+++ b/examples/llm_finetune/minicpm/minicpm5_1b_squad.yaml
@@ -1,0 +1,96 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Finetuning config for MiniCPM5-1B on SQuAD dataset.
+#
+# To run this recipe:
+#   automodel examples/llm_finetune/minicpm/minicpm5_1b_squad.yaml --nproc-per-node 8
+# Adjust --nproc-per-node to the number of GPUs available on your machine.
+
+recipe: TrainFinetuneRecipeForNextTokenPrediction
+
+step_scheduler:
+  global_batch_size: 64
+  local_batch_size: 8
+  ckpt_every_steps: 50
+  val_every_steps: 50
+  max_steps: 100
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 1
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 1111
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: openbmb/MiniCPM5-1B
+  torch_dtype: bf16
+  trust_remote_code: true
+
+distributed:
+  strategy: fsdp2
+  dp_size: none
+  tp_size: 1
+  cp_size: 1
+
+  sequence_parallel: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
+  dataset_name: rajpurkar/squad
+  split: train
+
+packed_sequence:
+  packed_sequence_size: 0
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  shuffle: false
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
+  dataset_name: rajpurkar/squad
+  split: validation
+  limit_dataset_samples: 64
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+
+optimizer:
+  _target_: torch.optim.Adam
+  betas: [0.9, 0.999]
+  eps: 1e-8
+  lr: 1.0e-5
+  weight_decay: 0
+
+# Uncomment and configure for W&B logging
+# wandb:
+#   project: <your_wandb_project>
+#   entity: <your_wandb_entity>
+#   name: minicpm5_1b_squad
+#   save_dir: <your_wandb_save_dir>
+
+ci:
+  recipe_owner: nemo-automodel-maintainers@nvidia.com
+  time: "00:30:00"
+  nodes: 1

--- a/examples/llm_finetune/minicpm/minicpm5_1b_squad_peft.yaml
+++ b/examples/llm_finetune/minicpm/minicpm5_1b_squad_peft.yaml
@@ -104,6 +104,6 @@ optimizer:
 #   save_dir: <your_wandb_save_dir>
 
 ci:
-  recipe_owner: nemo-automodel-maintainers@nvidia.com
-  time: "00:30:00"
+  recipe_owner: HuiyingLi
+  time: "00:10:00"
   nodes: 1

--- a/examples/llm_finetune/minicpm/minicpm5_1b_squad_peft.yaml
+++ b/examples/llm_finetune/minicpm/minicpm5_1b_squad_peft.yaml
@@ -1,0 +1,109 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# LoRA finetuning config for MiniCPM5-1B on SQuAD dataset.
+#
+# To run this recipe:
+#   automodel examples/llm_finetune/minicpm/minicpm5_1b_squad_peft.yaml --nproc-per-node 8
+# Adjust --nproc-per-node to the number of GPUs available on your machine.
+
+recipe: TrainFinetuneRecipeForNextTokenPrediction
+
+step_scheduler:
+  global_batch_size: 64
+  local_batch_size: 8
+  ckpt_every_steps: 50
+  val_every_steps: 50
+  max_steps: 100
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 1
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 1111
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: openbmb/MiniCPM5-1B
+  torch_dtype: bf16
+  trust_remote_code: true
+
+checkpoint:
+  enabled: false
+  checkpoint_dir: checkpoints/
+  model_save_format: safetensors
+  save_consolidated: false
+
+peft:
+  _target_: nemo_automodel.components._peft.lora.PeftConfig
+  target_modules: '*_proj'
+  dim: 8
+  alpha: 32
+  use_triton: True
+
+distributed:
+  strategy: fsdp2
+  dp_size: none
+  tp_size: 1
+  cp_size: 1
+
+  sequence_parallel: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
+  dataset_name: rajpurkar/squad
+  split: train
+
+packed_sequence:
+  packed_sequence_size: 0
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  shuffle: false
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
+  dataset_name: rajpurkar/squad
+  split: validation
+  limit_dataset_samples: 64
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+
+optimizer:
+  _target_: torch.optim.Adam
+  betas: [0.9, 0.999]
+  eps: 1e-8
+  lr: 1.0e-5
+  weight_decay: 0
+
+# Uncomment and configure for W&B logging
+# wandb:
+#   project: <your_wandb_project>
+#   entity: <your_wandb_entity>
+#   name: minicpm5_1b_squad_peft
+#   save_dir: <your_wandb_save_dir>
+
+ci:
+  recipe_owner: nemo-automodel-maintainers@nvidia.com
+  time: "00:30:00"
+  nodes: 1

--- a/tests/ci_tests/configs/llm_finetune/test_recipes.yml
+++ b/tests/ci_tests/configs/llm_finetune/test_recipes.yml
@@ -30,6 +30,7 @@ configs:
   - mistral/ministral3_3b_squad_peft.yaml
   - mistral/mixtral-8x7b-v0-1_squad.yaml
   - mistral/mixtral-8x7b-v0-1_squad_peft.yaml
+  - minicpm/minicpm5_1b_hellaswag_peft.yaml
   - minicpm/minicpm5_1b_squad.yaml
   - minicpm/minicpm5_1b_squad_peft.yaml
   - moonlight/moonlight_16b_te.yaml

--- a/tests/ci_tests/configs/llm_finetune/test_recipes.yml
+++ b/tests/ci_tests/configs/llm_finetune/test_recipes.yml
@@ -30,6 +30,8 @@ configs:
   - mistral/ministral3_3b_squad_peft.yaml
   - mistral/mixtral-8x7b-v0-1_squad.yaml
   - mistral/mixtral-8x7b-v0-1_squad_peft.yaml
+  - minicpm/minicpm5_1b_squad.yaml
+  - minicpm/minicpm5_1b_squad_peft.yaml
   - moonlight/moonlight_16b_te.yaml
   - moonlight/moonlight_16b_te_packed_sequence.yaml
   - nemotron/llama3_3_nemotron_super_49B_squad.yaml


### PR DESCRIPTION
  Add SFT and LoRA fine-tuning recipes for openbmb/MiniCPM5-1B on the SQuAD dataset. Update model coverage docs to
  include MiniCPM5.

  Closes #2337

  # What does this PR do ?

  Add fine-tuning recipe YAMLs for MiniCPM5-1B (full SFT and LoRA) and update the model coverage documentation to
  reflect MiniCPM5 support.

  # Changelog

  - Add `examples/llm_finetune/minicpm/minicpm5_1b_squad.yaml`: full SFT recipe for openbmb/MiniCPM5-1B on SQuAD
  - Add `examples/llm_finetune/minicpm/minicpm5_1b_squad_peft.yaml`: LoRA fine-tuning recipe (dim=8, alpha=32) for
  openbmb/MiniCPM5-1B on SQuAD
  - Update `tests/ci_tests/configs/llm_finetune/test_recipes.yml`: register both recipes in CI
  - Update `docs/model-coverage/llm/index.md` and `docs/model-coverage/llm/openbmb/minicpm.md`: add MiniCPM5-1B to
  supported models

  # Before your PR is "Ready for review"

  **Pre checks**:

  - [x] Make sure you read and followed [Contributor
  guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
  - [x] Did you write any new necessary tests?
  - [x] Did you add or update any necessary documentation?

  # Additional Information

  - Related to #2337