### PR TITLE
feat: support Qwen2.5-Omni model

### DIFF
--- a/docs/model-coverage/omni/index.md
+++ b/docs/model-coverage/omni/index.md
@@ -17,6 +17,7 @@ For other installation options, see our [NeMo AutoModel Installation Guide](../.
 | Owner | Model | Modalities | Architecture |
 |---|---|---|---|
 | Qwen / Alibaba Cloud | [Qwen3-Omni](qwen/qwen3-omni.md) | Text · Image · Audio · Video | `Qwen3OmniForConditionalGeneration` |
+| Qwen / Alibaba Cloud | [Qwen2.5-Omni](qwen/qwen2-5-omni.md) | Text · Image · Audio · Video | `Qwen2_5OmniForConditionalGeneration` |
 | Microsoft | [Phi-4-multimodal](microsoft/phi4-multimodal.md) | Text · Image · Audio | `Phi4MultimodalForCausalLM` |
 | NVIDIA | [Nemotron-3-Nano-Omni](nvidia/nemotron-omni.md) | Text · Image · Audio | `NemotronH_Nano_Omni_Reasoning_V3` |
 
@@ -28,6 +29,7 @@ All supported omni models can be fine-tuned using full SFT or PEFT (LoRA) approa
 :hidden:
 
 qwen/qwen3-omni
+qwen/qwen2-5-omni
 microsoft/phi4-multimodal
 nvidia/nemotron-omni
 ```

--- a/docs/model-coverage/omni/qwen/qwen2-5-omni.md
+++ b/docs/model-coverage/omni/qwen/qwen2-5-omni.md
@@ -1,0 +1,95 @@
+# Qwen2.5-Omni
+
+[Qwen2.5-Omni](https://qwenlm.github.io/blog/qwen2.5-omni/) is Alibaba Cloud's omnimodal model supporting text, image, audio, and video inputs in a single unified architecture with a dense language backbone. NeMo AutoModel onboards the **Thinker** stack for audio understanding tasks such as automatic speech recognition (ASR).
+
+:::{card}
+| | |
+|---|---|
+| **Task** | Omnimodal (Text·Image·Audio·Video) |
+| **Architecture** | `Qwen2_5OmniForConditionalGeneration` |
+| **Parameters** | 3B / 7B (dense) |
+| **HF Org** | [Qwen](https://huggingface.co/Qwen) |
+:::
+
+## Available Models
+
+- **Qwen2.5-Omni-3B**: 3B dense backbone
+- **Qwen2.5-Omni-7B**: 7B dense backbone
+
+## Architecture
+
+The registry wires the Qwen2.5-Omni Thinker backbone under the following architecture keys:
+
+- `Qwen2_5OmniForConditionalGeneration`
+- `Qwen2_5OmniModel`
+- `Qwen2_5OmniThinkerForConditionalGeneration`
+
+## Example HF Models
+
+| Model | HF ID |
+|---|---|
+| Qwen2.5-Omni 3B | [`Qwen/Qwen2.5-Omni-3B`](https://huggingface.co/Qwen/Qwen2.5-Omni-3B) |
+| Qwen2.5-Omni 7B | [`Qwen/Qwen2.5-Omni-7B`](https://huggingface.co/Qwen/Qwen2.5-Omni-7B) |
+
+## Example Recipes
+
+| Recipe | Dataset | Description |
+|---|---|---|
+| {download}`ami_sft_3b.yaml <../../../../examples/audio_finetune/qwen2_5_omni_asr/ami_sft_3b.yaml>` | AMI | ASR SFT — Qwen2.5-Omni 3B on the AMI meeting corpus |
+| {download}`ami_sft_7b.yaml <../../../../examples/audio_finetune/qwen2_5_omni_asr/ami_sft_7b.yaml>` | AMI | ASR SFT — Qwen2.5-Omni 7B on the AMI meeting corpus |
+
+
+## Try with NeMo AutoModel
+
+**1. Install** ([full instructions](../../../guides/installation.md)):
+
+```bash
+pip install nemo-automodel
+```
+
+**2. Clone the repo** to get the example recipes:
+
+```bash
+git clone https://github.com/NVIDIA-NeMo/Automodel.git
+cd Automodel
+```
+
+**3. Run the recipe** from inside the repo:
+
+```bash
+automodel --nproc-per-node=8 examples/audio_finetune/qwen2_5_omni_asr/ami_sft_3b.yaml
+```
+
+:::{dropdown} Run with Docker
+**1. Pull the container** and mount a checkpoint directory:
+
+```bash
+docker run --gpus all -it --rm \
+  --shm-size=8g \
+  -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
+  nvcr.io/nvidia/nemo-automodel:26.02.00
+```
+
+**2.** Navigate to the AutoModel directory (where the recipes are):
+
+```bash
+cd /opt/Automodel
+```
+
+**3. Run the recipe**:
+
+```bash
+automodel --nproc-per-node=8 examples/audio_finetune/qwen2_5_omni_asr/ami_sft_3b.yaml
+```
+:::
+
+See the [Installation Guide](../../../guides/installation.md) and [Omni Fine-Tuning Guide](../../../guides/omni/gemma3-3n.md).
+
+## Fine-Tuning
+
+See the [VLM / Omni Fine-Tuning Guide](../../../guides/omni/gemma3-3n.md).
+
+## Hugging Face Model Cards
+
+- [Qwen/Qwen2.5-Omni-3B](https://huggingface.co/Qwen/Qwen2.5-Omni-3B)
+- [Qwen/Qwen2.5-Omni-7B](https://huggingface.co/Qwen/Qwen2.5-Omni-7B)

--- a/examples/audio_finetune/qwen2_5_omni_asr/ami_sft_3b.yaml
+++ b/examples/audio_finetune/qwen2_5_omni_asr/ami_sft_3b.yaml
@@ -1,0 +1,110 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Full-FT English ASR of Qwen/Qwen2.5-Omni-3B on the AMI meeting corpus.
+
+recipe: FinetuneRecipeForVLM
+
+step_scheduler:
+  global_batch_size: 64
+  local_batch_size: 8
+  ckpt_every_steps: 200
+  num_epochs: 1
+  max_steps: 2000             # safety cap; epoch typically exhausts first
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 10
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 1111
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForMultimodalLM.from_pretrained
+  pretrained_model_name_or_path: Qwen/Qwen2.5-Omni-3B
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: sdpa
+    linear: te
+    rms_norm: torch_fp32
+    rope_fusion: false
+    enable_hf_state_dict_adapter: true
+
+checkpoint:
+  enabled: true
+  checkpoint_dir: result/checkpoints/qwen2_5_omni_asr_ami
+  model_save_format: safetensors
+  save_consolidated: true
+
+distributed:
+  strategy: fsdp2
+  tp_size: 1
+  cp_size: 1
+  pp_size: 1
+  sequence_parallel: false
+
+# Full fine-tune: audio tower + language model trainable; vision tower frozen
+# (we never feed images on AMI).
+freeze_config:
+  freeze_embeddings: false
+  freeze_vision_tower: true
+  freeze_audio_tower: false
+  freeze_language_model: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+# Conversation shape (per sample):
+#   user(  text=user_prompt + audio=<waveform>  )
+#   assistant(  text=<transcript>  )
+dataset:
+  _target_: nemo_automodel.components.datasets.vlm.datasets.make_hf_audio_asr_dataset
+  path_or_dataset: edinburghcstr/ami
+  name: ihm
+  split: train
+  audio_column: audio
+  text_column: text
+  sampling_rate: 16000
+  system_prompt: null
+  user_prompt: >-
+    Transcribe the following English meeting audio verbatim. Output only the
+    raw transcript text with no leading or trailing commentary.
+  # Qwen-Omni's Whisper feature extractor has a known off-by-one between
+  # ``input_features`` and ``feature_attention_mask`` on sub-second clips.
+  # Filtering at 1.0 s costs only the header-only sf.info probe per sample.
+  min_audio_duration_seconds: 1.0
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  num_workers: 2
+  collate_fn:
+    _target_: nemo_automodel.components.datasets.vlm.collate_fns.qwen2_5_omni_asr_collate_fn
+
+optimizer:
+  _target_: torch.optim.AdamW
+  betas: [0.9, 0.95]
+  eps: 1e-8
+  lr: 2.0e-5
+  weight_decay: 0.0
+
+wandb:
+  project: ${oc.env:WANDB_PROJECT,qwen2_5-omni-asr-ami}
+  name: ${oc.env:WANDB_NAME,qwen2_5_omni_3b_asr_ami_fullft}
+  dir: ${oc.env:WANDB_DIR,result/wandb}
+
+ci:
+  recipe_owner: yuekaizhang
+  time: "00:30:00"

--- a/examples/audio_finetune/qwen2_5_omni_asr/ami_sft_7b.yaml
+++ b/examples/audio_finetune/qwen2_5_omni_asr/ami_sft_7b.yaml
@@ -1,0 +1,113 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Full-FT English ASR of Qwen/Qwen2.5-Omni-7B on the AMI meeting corpus.
+
+recipe: FinetuneRecipeForVLM
+
+step_scheduler:
+  global_batch_size: 64
+  local_batch_size: 8
+  ckpt_every_steps: 200
+  num_epochs: 1
+  max_steps: 2000             # safety cap; epoch typically exhausts first
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 10
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 1111
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForMultimodalLM.from_pretrained
+  pretrained_model_name_or_path: Qwen/Qwen2.5-Omni-7B
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: sdpa
+    linear: te
+    rms_norm: torch_fp32
+    rope_fusion: false
+    enable_hf_state_dict_adapter: true
+
+checkpoint:
+  enabled: true
+  checkpoint_dir: result/checkpoints/qwen2_5_omni_asr_ami_7b
+  model_save_format: safetensors
+  save_consolidated: true
+
+distributed:
+  strategy: fsdp2
+  tp_size: 1
+  cp_size: 1
+  pp_size: 1
+  sequence_parallel: false
+  # Recomputes activations on backward to halve activation memory at ~30%
+  # compute cost. Required for 7B at local_batch_size=8 on AMI's longest clips.
+  activation_checkpointing: true
+
+# Full fine-tune: audio tower + language model trainable; vision tower frozen
+# (we never feed images on AMI).
+freeze_config:
+  freeze_embeddings: false
+  freeze_vision_tower: true
+  freeze_audio_tower: false
+  freeze_language_model: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+# Conversation shape (per sample):
+#   user(  text=user_prompt + audio=<waveform>  )
+#   assistant(  text=<transcript>  )
+dataset:
+  _target_: nemo_automodel.components.datasets.vlm.datasets.make_hf_audio_asr_dataset
+  path_or_dataset: edinburghcstr/ami
+  name: ihm
+  split: train
+  audio_column: audio
+  text_column: text
+  sampling_rate: 16000
+  system_prompt: null
+  user_prompt: >-
+    Transcribe the following English meeting audio verbatim. Output only the
+    raw transcript text with no leading or trailing commentary.
+  # Qwen-Omni's Whisper feature
+  # extractor has a known off-by-one between input_features and
+  # feature_attention_mask on sub-second clips.
+  min_audio_duration_seconds: 1.0
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  num_workers: 2
+  collate_fn:
+    _target_: nemo_automodel.components.datasets.vlm.collate_fns.qwen2_5_omni_asr_collate_fn
+
+optimizer:
+  _target_: torch.optim.AdamW
+  betas: [0.9, 0.95]
+  eps: 1e-8
+  lr: 2.0e-5
+  weight_decay: 0.0
+
+wandb:
+  project: ${oc.env:WANDB_PROJECT,qwen2_5-omni-asr-ami}
+  name: ${oc.env:WANDB_NAME,qwen2_5_omni_7b_asr_ami_fullft}
+  dir: ${oc.env:WANDB_DIR,result/wandb}
+
+ci:
+  recipe_owner: yuekaizhang
+  time: "00:30:00"

--- a/examples/audio_finetune/qwen3_omni_asr/ami_sft.yaml
+++ b/examples/audio_finetune/qwen3_omni_asr/ami_sft.yaml
@@ -133,5 +133,5 @@ wandb:
   dir: ${oc.env:WANDB_DIR,result/wandb}
 
 ci:
-  recipe_owner: yuekaiz
+  recipe_owner: yuekaizhang
   time: "00:30:00"

--- a/nemo_automodel/_transformers/registry.py
+++ b/nemo_automodel/_transformers/registry.py
@@ -173,6 +173,27 @@ MODEL_ARCH_MAPPING = OrderedDict(
             ("nemo_automodel.components.models.qwen2.model", "Qwen2ForCausalLM"),
         ),
         (
+            "Qwen2_5OmniModel",
+            (
+                "nemo_automodel.components.models.qwen2_5_omni.model",
+                "Qwen2_5OmniThinkerForConditionalGeneration",
+            ),
+        ),
+        (
+            "Qwen2_5OmniForConditionalGeneration",
+            (
+                "nemo_automodel.components.models.qwen2_5_omni.model",
+                "Qwen2_5OmniThinkerForConditionalGeneration",
+            ),
+        ),
+        (
+            "Qwen2_5OmniThinkerForConditionalGeneration",
+            (
+                "nemo_automodel.components.models.qwen2_5_omni.model",
+                "Qwen2_5OmniThinkerForConditionalGeneration",
+            ),
+        ),
+        (
             "Qwen3MoeForCausalLM",
             ("nemo_automodel.components.models.qwen3_moe.model", "Qwen3MoeForCausalLM"),
         ),

--- a/nemo_automodel/components/datasets/vlm/collate_fns.py
+++ b/nemo_automodel/components/datasets/vlm/collate_fns.py
@@ -257,6 +257,7 @@ _IMSTART_TEMPLATE_PROCESSORS = frozenset(
     {
         "Qwen2VLProcessor",
         "Qwen2_5_VLProcessor",
+        "Qwen2_5OmniProcessor",
         "Qwen3VLProcessor",
         "Qwen3VLMoeProcessor",
         "Qwen3OmniMoeProcessor",
@@ -866,6 +867,22 @@ def qwen3_omni_asr_collate_fn(
             batch[key] = value[:, :-1]
 
     return batch
+
+
+def qwen2_5_omni_asr_collate_fn(
+    examples: Sequence[Dict[str, Any]],
+    processor,
+) -> Dict[str, torch.Tensor]:
+    """Collate Qwen2.5-Omni ASR conversations.
+
+    Thin alias over :func:`qwen3_omni_asr_collate_fn`: the body is processor-
+    agnostic (it only depends on the processor exposing ``apply_chat_template``
+    and the ``audio=`` kwarg, both of which ``Qwen2_5OmniProcessor`` provides),
+    so the entire Qwen3-Omni-ASR path works unchanged here. We expose a
+    separate symbol so YAML configs can pick the right collate via
+    ``_target_`` without users having to know about the Qwen3-Omni name.
+    """
+    return qwen3_omni_asr_collate_fn(examples, processor)
 
 
 def kimi_vl_collate_fn(
@@ -2161,6 +2178,7 @@ def llava_onevision_collate_fn(
 # Mapping of processor types to their collate functions
 COLLATE_FNS = {
     "Qwen2_5_VLProcessor": qwen2_5_collate_fn,
+    "Qwen2_5OmniProcessor": qwen2_5_omni_asr_collate_fn,
     "Qwen3OmniMoeProcessor": qwen3_omni_collate_fn,
     "KimiVLProcessor": kimi_vl_collate_fn,
     "KimiK25Processor": kimi_k25_vl_collate_fn,

--- a/nemo_automodel/components/models/qwen2_5_omni/__init__.py
+++ b/nemo_automodel/components/models/qwen2_5_omni/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/nemo_automodel/components/models/qwen2_5_omni/model.py
+++ b/nemo_automodel/components/models/qwen2_5_omni/model.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Qwen2.5-Omni Thinker for ASR / multimodal text generation.
+
+Qwen2.5-Omni is the dense predecessor of Qwen3-Omni-Moe. For NeMo
+AutoModel we only train the Thinker (audio + image + video + text); the
+talker and token2wav components are dropped from the loaded checkpoint by
+:class:`Qwen2_5OmniStateDictAdapter`.
+
+Compared with :mod:`nemo_automodel.components.models.qwen3_omni_moe.model`,
+this module is intentionally minimal:
+
+- inherits HF's ``Qwen2_5OmniThinkerForConditionalGeneration`` directly
+  (the text backbone is a standard dense Qwen2 transformer with MRoPE, so
+  no custom rewrite is needed);
+- adds :class:`HFCheckpointingMixin` for NeMo-compatible save/load;
+- attaches :class:`Qwen2_5OmniStateDictAdapter` for ``thinker.*`` prefix
+  handling;
+- does NOT inherit ``MoEFSDPSyncMixin`` (dense, no experts).
+"""
+
+from typing import Any
+
+import torch
+from transformers.models.qwen2_5_omni.configuration_qwen2_5_omni import (
+    Qwen2_5OmniConfig,
+    Qwen2_5OmniThinkerConfig,
+)
+from transformers.models.qwen2_5_omni.modeling_qwen2_5_omni import (
+    Qwen2_5OmniThinkerForConditionalGeneration as HFQwen2_5OmniThinkerForConditionalGeneration,
+)
+
+from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.models.common.hf_checkpointing_mixin import HFCheckpointingMixin
+from nemo_automodel.components.models.qwen2_5_omni.state_dict_adapter import Qwen2_5OmniStateDictAdapter
+from nemo_automodel.shared.utils import dtype_from_str as get_dtype
+
+
+def _resolve_thinker_config(config: Qwen2_5OmniConfig | Qwen2_5OmniThinkerConfig) -> Qwen2_5OmniThinkerConfig:
+    """Return the thinker sub-config regardless of whether a full Omni or
+    Thinker-only config was passed in."""
+    if hasattr(config, "thinker_config") and config.thinker_config is not None:
+        return config.thinker_config
+    return config
+
+
+class Qwen2_5OmniThinkerForConditionalGeneration(
+    HFCheckpointingMixin,
+    HFQwen2_5OmniThinkerForConditionalGeneration,
+):
+    """Qwen2.5-Omni Thinker (audio + image + video + text → text)."""
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str,
+        *model_args,
+        backend: BackendConfig | None = None,
+        **kwargs,
+    ):
+        config = Qwen2_5OmniConfig.from_pretrained(pretrained_model_name_or_path)
+        thinker_config = _resolve_thinker_config(config)
+        return cls(thinker_config, backend=backend, **kwargs)
+
+    @classmethod
+    def from_config(
+        cls,
+        config: Qwen2_5OmniConfig | Qwen2_5OmniThinkerConfig,
+        backend: BackendConfig | None = None,
+        **kwargs,
+    ):
+        return cls(_resolve_thinker_config(config), backend=backend, **kwargs)
+
+    def __init__(
+        self,
+        config: Qwen2_5OmniConfig | Qwen2_5OmniThinkerConfig,
+        backend: BackendConfig | None = None,
+        **kwargs,
+    ):
+        thinker_config = _resolve_thinker_config(config)
+        super().__init__(thinker_config)
+
+        # HF Qwen2.5-Omni declares ``audio_tower.audio_bos_eos_token`` as an
+        # ``nn.Embedding(2, output_dim)`` (modeling_qwen2_5_omni.py:751) but it
+        # is never indexed in any forward (audio BOS/EOS are routed through the
+        # text tokenizer's ``embed_tokens`` instead). The unused parameter
+        # still has ``requires_grad=True``, so it ends up in the AdamW
+        # ``param_groups`` and gets no gradients during training -> its AdamW
+        # state stays empty -> DCP save omits its ``step``/``exp_avg`` keys ->
+        # DCP load template expects them -> ``RuntimeError("Missing key in
+        # checkpoint state_dict: …audio_bos_eos_token.weight.step")`` which is
+        # masked as ``TypeError: cannot pickle code objects`` by DCP's
+        # exception-propagation tuple. Delete the dead embedding here so it
+        # never enters the optimizer; ``Qwen2_5OmniStateDictAdapter.from_hf``
+        # also strips the matching HF checkpoint key.
+        if hasattr(self, "audio_tower") and hasattr(self.audio_tower, "audio_bos_eos_token"):
+            del self.audio_tower.audio_bos_eos_token
+
+        self.backend = backend or BackendConfig()
+        text_config = thinker_config.text_config if hasattr(thinker_config, "text_config") else thinker_config
+        torch_dtype = getattr(text_config, "torch_dtype", None) or getattr(thinker_config, "torch_dtype", None)
+        dtype = get_dtype(torch_dtype, torch.bfloat16) if torch_dtype is not None else torch.bfloat16
+
+        if self.backend.enable_hf_state_dict_adapter:
+            self.state_dict_adapter = Qwen2_5OmniStateDictAdapter(
+                thinker_config,
+                backend=self.backend,
+                dtype=dtype,
+            )
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        input_features: torch.FloatTensor | None = None,
+        feature_attention_mask: torch.LongTensor | None = None,
+        audio_feature_lengths: torch.LongTensor | None = None,
+        pixel_values: torch.FloatTensor | None = None,
+        pixel_values_videos: torch.FloatTensor | None = None,
+        image_grid_thw: torch.LongTensor | None = None,
+        video_grid_thw: torch.LongTensor | None = None,
+        video_second_per_grid: torch.Tensor | None = None,
+        use_audio_in_video: bool | None = None,
+        position_ids: torch.Tensor | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        labels: torch.LongTensor | None = None,
+        **kwargs: Any,
+    ):
+        """Delegate to HF Thinker forward, passing all multimodal inputs through.
+
+        The forward signature mirrors HF's
+        ``Qwen2_5OmniThinkerForConditionalGeneration.forward``; we override
+        only to make the call site uniform with the rest of NeMo AutoModel.
+        Audio is mandatory for ASR; image / video paths are kept enabled so
+        the same class supports the full Thinker modality set.
+        """
+        outputs = super().forward(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            input_features=input_features,
+            feature_attention_mask=feature_attention_mask,
+            audio_feature_lengths=audio_feature_lengths,
+            pixel_values=pixel_values,
+            pixel_values_videos=pixel_values_videos,
+            image_grid_thw=image_grid_thw,
+            video_grid_thw=video_grid_thw,
+            video_second_per_grid=video_second_per_grid,
+            use_audio_in_video=use_audio_in_video,
+            position_ids=position_ids,
+            inputs_embeds=inputs_embeds,
+            labels=labels,
+            **kwargs,
+        )
+        if labels is not None:
+            return {"logits": outputs.logits, "loss": outputs.loss}
+        return outputs.logits if hasattr(outputs, "logits") else outputs
+
+
+ModelClass = Qwen2_5OmniThinkerForConditionalGeneration

--- a/nemo_automodel/components/models/qwen2_5_omni/state_dict_adapter.py
+++ b/nemo_automodel/components/models/qwen2_5_omni/state_dict_adapter.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import re
+from typing import Any, Optional
+
+import torch
+
+from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.models.common import BackendConfig
+
+logger = logging.getLogger(__name__)
+
+
+_THINKER_PREFIX = "thinker."
+_DROP_PREFIXES = ("talker.", "token2wav.")
+
+# Keys the NeMo Thinker class deletes at __init__ time (so the HF base
+# checkpoint must not be allowed to repopulate them, otherwise load_state_dict
+# would either raise on an unexpected key or silently re-insert the dead
+# parameter). Matched as substrings against the post-prefix-strip key.
+_DROP_THINKER_KEY_SUBSTRINGS = ("audio_tower.audio_bos_eos_token",)
+
+
+class Qwen2_5OmniStateDictAdapter(StateDictAdapter):
+    """HF Qwen2.5-Omni checkpoint adapter (thinker-only path).
+
+    HF Qwen/Qwen2.5-Omni-* checkpoints store keys under three top-level
+    prefixes: ``thinker.*``, ``talker.*``, ``token2wav.*``. For ASR/text
+    fine-tuning we only train the Thinker, so this adapter:
+
+    - on ``from_hf``: drops ``talker.*`` and ``token2wav.*`` keys and strips
+      the ``thinker.`` prefix so keys align with our NeMo Thinker class.
+    - on ``to_hf``: re-adds the ``thinker.`` prefix so the saved checkpoint
+      can be merged back with the original talker/token2wav shards.
+
+    Qwen2.5-Omni-3B is dense (no MoE), so no expert grouping logic is
+    needed — this is a thin key-renaming adapter.
+    """
+
+    def __init__(
+        self,
+        config: Any,
+        backend: BackendConfig | None = None,
+        dtype: torch.dtype = torch.float32,
+    ):
+        self.config = config
+        self.backend = backend or BackendConfig()
+        self.dtype = dtype
+        self._uses_thinker_prefix = True
+
+    def to_hf(
+        self,
+        state_dict: dict[str, Any],
+        exclude_key_regex: Optional[str] = None,
+        quantization: bool = False,
+        **kwargs,
+    ) -> dict[str, Any]:
+        if self._uses_thinker_prefix:
+            hf_state_dict = {_THINKER_PREFIX + k: v for k, v in state_dict.items()}
+        else:
+            hf_state_dict = dict(state_dict)
+
+        if exclude_key_regex:
+            pattern = re.compile(exclude_key_regex)
+            hf_state_dict = {k: v for k, v in hf_state_dict.items() if not pattern.match(k)}
+        return hf_state_dict
+
+    def from_hf(
+        self,
+        hf_state_dict: dict[str, Any],
+        device_mesh: Optional[Any] = None,
+        **kwargs,
+    ) -> dict[str, Any]:
+        out: dict[str, Any] = {}
+        saw_thinker = False
+        for key, value in hf_state_dict.items():
+            if key.startswith(_DROP_PREFIXES):
+                continue
+            stripped = key[len(_THINKER_PREFIX) :] if key.startswith(_THINKER_PREFIX) else key
+            # Drop keys for parameters the NeMo Thinker deletes at __init__.
+            if any(sub in stripped for sub in _DROP_THINKER_KEY_SUBSTRINGS):
+                continue
+            if key.startswith(_THINKER_PREFIX):
+                saw_thinker = True
+            out[stripped] = value
+        self._uses_thinker_prefix = saw_thinker or self._uses_thinker_prefix
+        return out
+
+    def convert_single_tensor_to_hf(self, fqn: str, tensor: Any, **kwargs) -> list[tuple[str, Any]]:
+        exclude_key_regex = kwargs.get("exclude_key_regex", None)
+        key = _THINKER_PREFIX + fqn if self._uses_thinker_prefix else fqn
+        if exclude_key_regex:
+            if re.match(exclude_key_regex, key):
+                return []
+        return [(key, tensor)]

--- a/tests/unit_tests/models/qwen2_5_omni/test_qwen2_5_omni_model.py
+++ b/tests/unit_tests/models/qwen2_5_omni/test_qwen2_5_omni_model.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Smoke tests for Qwen2.5-Omni Thinker model module.
+
+These do NOT load real HF checkpoints (parity tests under
+``tests/functional_tests/qwen2_5_omni/`` cover that). The point here is to
+catch wiring regressions cheaply: imports, MRO, registry resolution, and the
+state-dict adapter attachment.
+"""
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+
+def test_imports():
+    from nemo_automodel.components.models.qwen2_5_omni.model import (
+        ModelClass,
+        Qwen2_5OmniThinkerForConditionalGeneration,
+    )
+
+    assert ModelClass is Qwen2_5OmniThinkerForConditionalGeneration
+
+
+def test_mro_includes_hf_checkpointing_mixin():
+    from nemo_automodel.components.models.common.hf_checkpointing_mixin import HFCheckpointingMixin
+    from nemo_automodel.components.models.qwen2_5_omni.model import (
+        Qwen2_5OmniThinkerForConditionalGeneration,
+    )
+
+    mro_names = {c.__name__ for c in Qwen2_5OmniThinkerForConditionalGeneration.__mro__}
+    assert "HFCheckpointingMixin" in mro_names
+    # And no MoE FSDP sync mixin should be present (dense model).
+    assert "MoEFSDPSyncMixin" not in mro_names
+    # Sanity: must still inherit the HF Thinker class.
+    assert "Qwen2_5OmniThinkerForConditionalGeneration" in mro_names
+    assert any("Qwen2_5OmniPreTrainedModel" in n for n in mro_names)
+    assert HFCheckpointingMixin in Qwen2_5OmniThinkerForConditionalGeneration.__mro__
+
+
+def test_registry_resolves_to_thinker_class():
+    from nemo_automodel._transformers.registry import ModelRegistry
+    from nemo_automodel.components.models.qwen2_5_omni.model import (
+        Qwen2_5OmniThinkerForConditionalGeneration,
+    )
+
+    for arch in (
+        "Qwen2_5OmniModel",
+        "Qwen2_5OmniForConditionalGeneration",
+        "Qwen2_5OmniThinkerForConditionalGeneration",
+    ):
+        cls = ModelRegistry.get_model_cls_from_model_arch(arch)
+        assert cls is Qwen2_5OmniThinkerForConditionalGeneration, (
+            f"Registry maps {arch!r} to {cls.__name__}, expected the NeMo Thinker class"
+        )
+
+
+def test_resolve_thinker_config_unwraps_full_omni_config():
+    """``_resolve_thinker_config`` returns the thinker sub-config when given the full Omni config."""
+    from nemo_automodel.components.models.qwen2_5_omni.model import _resolve_thinker_config
+
+    class FakeThinker:
+        torch_dtype = None
+
+    class FakeOmni:
+        thinker_config = FakeThinker()
+
+    assert _resolve_thinker_config(FakeOmni()) is FakeOmni().thinker_config.__class__ or isinstance(
+        _resolve_thinker_config(FakeOmni()), FakeThinker
+    )
+
+    # If a thinker config is passed directly, it should be returned untouched.
+    thinker_only = FakeThinker()
+    assert _resolve_thinker_config(thinker_only) is thinker_only
+
+
+@pytest.mark.parametrize(
+    "processor_name",
+    ["Qwen2_5OmniProcessor"],
+)
+def test_marker_processor_set_includes_qwen2_5_omni(processor_name):
+    from nemo_automodel.components.datasets.vlm.collate_fns import _IMSTART_TEMPLATE_PROCESSORS
+
+    assert processor_name in _IMSTART_TEMPLATE_PROCESSORS
+
+
+def test_collate_fn_dispatch_includes_qwen2_5_omni():
+    from nemo_automodel.components.datasets.vlm.collate_fns import (
+        COLLATE_FNS,
+        qwen2_5_omni_asr_collate_fn,
+    )
+
+    assert COLLATE_FNS.get("Qwen2_5OmniProcessor") is qwen2_5_omni_asr_collate_fn
+
+
+def test_collate_fn_is_alias_of_qwen3_omni_asr():
+    """``qwen2_5_omni_asr_collate_fn`` must delegate to ``qwen3_omni_asr_collate_fn`` for processor-agnostic logic."""
+    from unittest.mock import MagicMock
+
+    from nemo_automodel.components.datasets.vlm import collate_fns as cf
+
+    sentinel = object()
+    captured = {}
+
+    def fake_qwen3_asr(examples, processor):
+        captured["examples"] = examples
+        captured["processor"] = processor
+        return sentinel
+
+    real = cf.qwen3_omni_asr_collate_fn
+    cf.qwen3_omni_asr_collate_fn = fake_qwen3_asr
+    try:
+        out = cf.qwen2_5_omni_asr_collate_fn([{"x": 1}], processor=MagicMock())
+    finally:
+        cf.qwen3_omni_asr_collate_fn = real
+
+    assert out is sentinel
+    assert captured["examples"] == [{"x": 1}]

--- a/tests/unit_tests/models/qwen2_5_omni/test_qwen2_5_omni_state_dict_adapter.py
+++ b/tests/unit_tests/models/qwen2_5_omni/test_qwen2_5_omni_state_dict_adapter.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Qwen2.5-Omni state dict adapter."""
+
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.models.qwen2_5_omni.state_dict_adapter import (
+    Qwen2_5OmniStateDictAdapter,
+)
+
+
+@pytest.fixture
+def config():
+    cfg = Mock()
+    cfg.num_hidden_layers = 2
+    cfg.hidden_size = 32
+    return cfg
+
+
+@pytest.fixture
+def backend_config():
+    return BackendConfig(
+        linear="torch",
+        attn="sdpa",
+        rms_norm="torch",
+        enable_hf_state_dict_adapter=False,
+    )
+
+
+@pytest.fixture
+def adapter(config, backend_config):
+    return Qwen2_5OmniStateDictAdapter(config=config, backend=backend_config, dtype=torch.float32)
+
+
+class TestInitialization:
+    def test_defaults(self, adapter, config, backend_config):
+        assert adapter.config is config
+        assert adapter.backend is backend_config
+        assert adapter.dtype == torch.float32
+        assert adapter._uses_thinker_prefix is True
+
+
+class TestFromHF:
+    def test_strips_thinker_prefix(self, adapter):
+        hf_state = {
+            "thinker.model.embed_tokens.weight": torch.randn(4, 4),
+            "thinker.audio_tower.conv1.weight": torch.randn(2, 2),
+            "thinker.visual.blocks.0.attn.q.weight": torch.randn(2, 2),
+            "thinker.lm_head.weight": torch.randn(4, 4),
+        }
+        out = adapter.from_hf(hf_state)
+        # All thinker.* keys must be stripped of the prefix
+        assert "model.embed_tokens.weight" in out
+        assert "audio_tower.conv1.weight" in out
+        assert "visual.blocks.0.attn.q.weight" in out
+        assert "lm_head.weight" in out
+        assert all(not k.startswith("thinker.") for k in out)
+        # Flag should remain True so to_hf re-adds the prefix
+        assert adapter._uses_thinker_prefix is True
+
+    def test_drops_talker_and_token2wav(self, adapter):
+        hf_state = {
+            "thinker.model.embed_tokens.weight": torch.randn(2, 2),
+            "talker.model.embed_tokens.weight": torch.randn(2, 2),
+            "talker.codec_head.weight": torch.randn(2, 2),
+            "token2wav.code2wav_bigvgan_model.layers.0.weight": torch.randn(2, 2),
+            "token2wav.code2wav_dit_model.layers.0.weight": torch.randn(2, 2),
+        }
+        out = adapter.from_hf(hf_state)
+        assert "model.embed_tokens.weight" in out
+        for key in out:
+            assert not key.startswith("talker."), f"talker key leaked through: {key}"
+            assert not key.startswith("token2wav."), f"token2wav key leaked through: {key}"
+
+    def test_handles_state_without_thinker_prefix(self, adapter):
+        # If a checkpoint already lacks the thinker prefix (e.g. a NeMo-saved one),
+        # keys pass through unchanged.
+        hf_state = {"model.embed_tokens.weight": torch.randn(2, 2)}
+        out = adapter.from_hf(hf_state)
+        assert "model.embed_tokens.weight" in out
+
+
+class TestToHF:
+    def test_adds_thinker_prefix(self, adapter):
+        nemo_state = {
+            "model.embed_tokens.weight": torch.randn(2, 2),
+            "audio_tower.conv1.weight": torch.randn(2, 2),
+            "lm_head.weight": torch.randn(2, 2),
+        }
+        out = adapter.to_hf(nemo_state)
+        assert all(k.startswith("thinker.") for k in out.keys())
+        assert "thinker.model.embed_tokens.weight" in out
+        assert "thinker.audio_tower.conv1.weight" in out
+        assert "thinker.lm_head.weight" in out
+
+    def test_respects_exclude_regex(self, adapter):
+        nemo_state = {"keep.me": torch.ones(1), "drop.me": torch.ones(1)}
+        out = adapter.to_hf(nemo_state, exclude_key_regex=r"^thinker\.drop")
+        assert "thinker.drop.me" not in out
+        assert "thinker.keep.me" in out
+
+    def test_round_trip(self, adapter):
+        nemo_state = {
+            "model.embed_tokens.weight": torch.randn(4, 4),
+            "audio_tower.conv1.weight": torch.randn(2, 2),
+            "visual.blocks.0.attn.q.weight": torch.randn(2, 2),
+            "lm_head.weight": torch.randn(4, 4),
+        }
+        # nemo → hf
+        hf_state = adapter.to_hf(nemo_state)
+        # hf → nemo
+        restored = adapter.from_hf(hf_state)
+        for key, value in nemo_state.items():
+            assert key in restored, f"missing key after round-trip: {key}"
+            assert torch.equal(restored[key], value), f"value mismatch for {key}"
+
+
+class TestSingleTensorConversion:
+    def test_prefixes_key(self, adapter):
+        out = adapter.convert_single_tensor_to_hf("model.embed_tokens.weight", torch.zeros(2, 2))
+        assert out == [("thinker.model.embed_tokens.weight", out[0][1])]
+
+    def test_respects_exclude_regex(self, adapter):
+        out = adapter.convert_single_tensor_to_hf("drop.me", torch.zeros(1), exclude_key_regex=r"^thinker\.drop")
+        assert out == []

--- a/tools/wrap_thinker_ckpt_as_omni.py
+++ b/tools/wrap_thinker_ckpt_as_omni.py
@@ -140,10 +140,18 @@ def wrap(ckpt_dir: Path, base_dir: Path, out_dir: Path) -> None:
     base_weight_map = _read_index(base_dir)
     base_prefixes = _classify_keys(list(base_weight_map.keys()))
     logger.info("base key counts: %s", {k: len(v) for k, v in base_prefixes.items()})
-    needed_base_prefixes = ("code2wav", "talker")
-    for p in needed_base_prefixes:
-        if p not in base_prefixes:
-            raise ValueError(f"base model has no '{p}.*' keys; cannot wrap")
+    # Auto-detect every non-thinker top-level prefix in the base snapshot.
+    # For Qwen3-Omni-Moe this resolves to {"code2wav", "talker"}; for
+    # Qwen2.5-Omni it resolves to {"talker", "token2wav"}. The rule "carry
+    # over anything in the base that is not in the ckpt" is forward-compatible
+    # with any future Omni layout.
+    needed_base_prefixes = tuple(sorted(p for p in base_prefixes if p != "thinker"))
+    if not needed_base_prefixes:
+        raise ValueError(
+            f"base model at {base_dir} has no non-thinker prefixes; nothing to wrap "
+            f"(found prefixes: {sorted(base_prefixes)})"
+        )
+    logger.info("will carry over non-thinker prefixes from base: %s", needed_base_prefixes)
 
     # ---- 3. Re-bucket each ckpt shard's content into the output dir ----
     new_index: Dict[str, str] = {}
@@ -154,30 +162,26 @@ def wrap(ckpt_dir: Path, base_dir: Path, out_dir: Path) -> None:
     # the standard ``model-XXXXX-of-YYYYY.safetensors`` format), since the
     # tensors and keys are already correctly prefixed.
     ckpt_thinker_shards = list(ckpt_shards.items())
-    base_code2wav_shards: Dict[str, list[str]] = {}
-    base_talker_shards: Dict[str, list[str]] = {}
-    for shard_name, full_map_keys in base_weight_map.items():
-        # weight_map maps key -> shard filename; we need the reverse
-        pass
 
-    # Re-derive base shards by prefix bucket.
+    # Re-derive base shards by prefix bucket. ``base_shards_per_prefix`` maps
+    # each non-thinker prefix -> {shard_filename: [keys]} (a base shard can
+    # mix prefixes, so we filter per-key when writing it out).
     base_shards_by_file: Dict[str, list[str]] = {}
     for key, shard in base_weight_map.items():
         base_shards_by_file.setdefault(shard, []).append(key)
+    base_shards_per_prefix: Dict[str, Dict[str, list[str]]] = {p: {} for p in needed_base_prefixes}
     for shard_name, keys_in_shard in base_shards_by_file.items():
         ks_by_prefix = _classify_keys(keys_in_shard)
-        if "code2wav" in ks_by_prefix:
-            base_code2wav_shards.setdefault(shard_name, []).extend(ks_by_prefix["code2wav"])
-        if "talker" in ks_by_prefix:
-            base_talker_shards.setdefault(shard_name, []).extend(ks_by_prefix["talker"])
+        for prefix in needed_base_prefixes:
+            if prefix in ks_by_prefix:
+                base_shards_per_prefix[prefix].setdefault(shard_name, []).extend(ks_by_prefix[prefix])
 
-    total_shards = len(ckpt_thinker_shards) + len(base_code2wav_shards) + len(base_talker_shards)
+    total_shards = len(ckpt_thinker_shards) + sum(len(v) for v in base_shards_per_prefix.values())
     logger.info(
-        "output plan: %d shards (ckpt thinker=%d, base code2wav=%d, base talker=%d)",
+        "output plan: %d shards (ckpt thinker=%d; %s)",
         total_shards,
         len(ckpt_thinker_shards),
-        len(base_code2wav_shards),
-        len(base_talker_shards),
+        ", ".join(f"base {p}={len(base_shards_per_prefix[p])}" for p in needed_base_prefixes),
     )
 
     def _shard_filename(idx: int) -> str:
@@ -197,9 +201,10 @@ def wrap(ckpt_dir: Path, base_dir: Path, out_dir: Path) -> None:
             "wrote thinker shard %s (%d keys, %.2f GB)", out_name, len(keys), (out_dir / out_name).stat().st_size / 1e9
         )
 
-    # 3c. Copy code2wav + talker shards from base; filter to only those keys
-    # (some base shards mix prefixes).
-    for src_kind, src_shards in (("code2wav", base_code2wav_shards), ("talker", base_talker_shards)):
+    # 3c. Copy every non-thinker prefix's shards from base; filter to only
+    # those keys (some base shards mix prefixes).
+    for src_kind in needed_base_prefixes:
+        src_shards = base_shards_per_prefix[src_kind]
         for shard_name, keys in sorted(src_shards.items()):
             out_name = _shard_filename(next_index)
             next_index += 1


### PR DESCRIPTION
The PR supports ASR SFT for qwen2.5 omni 3B & 7B models.

#### Qwen2.5-Omni ASR on AMI IHM `test`

| Model | Word Error Rate |
|---|---:|
| Qwen/Qwen2.5-Omni-3B baseline (zero-shot) | 40.01% |
| Qwen2.5-Omni-3B + 1 epoch SFT (step 1080) |  9.49% |
| Qwen/Qwen2.5-Omni-7B baseline (zero-shot) | 35.70% |
| Qwen2.5-Omni-7B + 1 epoch SFT (step 1080) |  9.04% |

Note: Basline models contain a lot of `the english audio is …` boilerplate prefix insertion errors.


<img width="570" height="426" alt="image" src="https://github.com/user-attachments/assets/0d853c2c-f282-49dd-8639-1f762e1125d8" />
