### PR TITLE
feat(datasets): add train_on_last_turn_only to agent chat SFT dataset

### DIFF
--- a/nemo_automodel/components/datasets/llm/agent_chat.py
+++ b/nemo_automodel/components/datasets/llm/agent_chat.py
@@ -187,6 +187,38 @@ def _convert_messages(
     return out
 
 
+def _mask_labels_to_last_turn(labels: List[int], ignore_index: int = -100) -> List[int]:
+    """Restrict the loss to the final assistant turn (``mask_history``).
+
+    ``labels`` come from :func:`format_chat_template` with every assistant
+    turn supervised; non-assistant tokens are already ``ignore_index``.
+    Because the chat template renders each assistant message as a single
+    contiguous span, supervised tokens form one maximal run per assistant
+    turn separated by ``ignore_index`` runs. This keeps only the last such
+    run and masks every earlier supervised token in place.
+
+    Args:
+        labels: per-token labels (``ignore_index`` marks unsupervised tokens).
+        ignore_index: the value marking unsupervised tokens.
+
+    Returns:
+        The same list, mutated so only the final supervised run is kept.
+    """
+    last = -1
+    for i in range(len(labels) - 1, -1, -1):
+        if labels[i] != ignore_index:
+            last = i
+            break
+    if last < 0:
+        return labels
+    start = last
+    while start - 1 >= 0 and labels[start - 1] != ignore_index:
+        start -= 1
+    for i in range(start):
+        labels[i] = ignore_index
+    return labels
+
+
 def _format_example(
     example: Dict[str, Any],
     tokenizer,
@@ -195,6 +227,7 @@ def _format_example(
     seq_length: Optional[int] = None,
     padding: Union[str, bool] = False,
     truncation: Union[str, bool] = False,
+    train_on_last_turn_only: bool = False,
 ) -> Dict[str, List[int]]:
     """Render one agent example into tokenized ``input_ids`` / ``labels``."""
     raw_tools = example.get("tools")
@@ -219,7 +252,7 @@ def _format_example(
 
     formatted = _convert_messages(raw_messages, example_id=example.get("id"))
 
-    return format_chat_template(
+    tokenized = format_chat_template(
         tokenizer=tokenizer,
         formatted_text=formatted,
         tools=tools,
@@ -230,6 +263,9 @@ def _format_example(
         truncation=truncation,
         answer_only_loss_mask=True,
     )
+    if train_on_last_turn_only:
+        _mask_labels_to_last_turn(tokenized["labels"])
+    return tokenized
 
 
 def make_agent_chat_dataset(
@@ -242,6 +278,7 @@ def make_agent_chat_dataset(
     limit_dataset_samples: Optional[int] = None,
     padding: Union[str, bool] = False,
     truncation: Union[str, bool] = False,
+    train_on_last_turn_only: bool = False,
 ) -> LazyMappedDataset:
     """Load a multi-turn function-calling SFT dataset.
 
@@ -259,6 +296,10 @@ def make_agent_chat_dataset(
         limit_dataset_samples: If set, keep only the first N examples.
         padding: Padding strategy forwarded to the tokenizer.
         truncation: Truncation strategy forwarded to the tokenizer.
+        train_on_last_turn_only: If True, supervise only the final assistant
+            turn of each dialogue (``mask_history``); all earlier assistant
+            turns are excluded from the loss. Defaults to False, which
+            supervises every assistant turn.
 
     Returns:
         A ``LazyMappedDataset`` yielding dicts with ``input_ids``, ``labels``
@@ -293,5 +334,6 @@ def make_agent_chat_dataset(
         seq_length,
         padding,
         truncation,
+        train_on_last_turn_only,
     )
     return LazyMappedDataset(dataset, fmt_fn)

--- a/tests/unit_tests/datasets/llm/test_agent_chat.py
+++ b/tests/unit_tests/datasets/llm/test_agent_chat.py
@@ -334,3 +334,43 @@ def test_format_example_accepts_empty_tools_string(monkeypatch):
         pad_token_id=0,
     )
     assert captured["tools"] is None
+
+
+def test_mask_labels_to_last_turn_keeps_only_final_run():
+    # Two supervised assistant runs separated by an ignored (user/tool) run.
+    labels = [-100, 1, 2, -100, -100, 3, 4, -100]
+    agent_chat._mask_labels_to_last_turn(labels)
+    assert labels == [-100, -100, -100, -100, -100, 3, 4, -100]
+
+
+def test_mask_labels_to_last_turn_single_run_unchanged():
+    labels = [-100, -100, 5, 6, 7]
+    agent_chat._mask_labels_to_last_turn(labels)
+    assert labels == [-100, -100, 5, 6, 7]
+
+
+def test_mask_labels_to_last_turn_no_supervised_tokens_is_noop():
+    labels = [-100, -100, -100]
+    agent_chat._mask_labels_to_last_turn(labels)
+    assert labels == [-100, -100, -100]
+
+
+def test_format_example_train_on_last_turn_only_masks_earlier_turns(monkeypatch):
+    # ``labels`` carry two supervised assistant runs; with the flag set only
+    # the final run survives. Without it, both runs stay supervised.
+    def fake_format_chat_template(**kwargs):
+        return {"input_ids": [10, 11, 12, 13, 14, 15], "labels": [-100, 1, -100, -100, 2, 3]}
+
+    monkeypatch.setattr(agent_chat, "format_chat_template", fake_format_chat_template)
+
+    class Tok:
+        eos_token_id = 0
+        pad_token_id = 0
+
+    example = {"messages": [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "x"}]}
+
+    kept = agent_chat._format_example(example, Tok(), 0, 0)
+    assert kept["labels"] == [-100, 1, -100, -100, 2, 3]
+
+    masked = agent_chat._format_example(example, Tok(), 0, 0, train_on_last_turn_only=True)
+    assert masked["labels"] == [-100, -100, -100, -100, 2, 3]


### PR DESCRIPTION
## What

Adds an opt-in `train_on_last_turn_only` (mask_history) mode to `make_agent_chat_dataset`. When enabled, only the **final assistant turn** of each multi-turn agent dialogue is supervised; all earlier assistant turns are excluded from the loss. Default is `False`, which preserves the existing all-turn supervision behavior.

This mirrors the `mask_history` / `train_only_last_turn` option found in LLaMA-Factory, ms-swift, SpecForge, and Megatron-Bridge, which is a common requirement for multi-turn agent SFT.

## How

- New pure helper `_mask_labels_to_last_turn(labels)`: keeps only the last contiguous supervised run of `labels` (the final assistant message, since the chat template renders each assistant message — including tool_calls — as one contiguous span) and masks every earlier supervised token in place.
- `_format_example` / `make_agent_chat_dataset` gain a `train_on_last_turn_only: bool = False` flag, threaded through.
- The change is contained to the agent-chat dataset; it post-processes the labels returned by `format_chat_template` and does not touch the shared chat-template utilities.

## Changelog

- `make_agent_chat_dataset(..., train_on_last_turn_only=True)` supervises only the last assistant turn of each dialogue.

## Usage

```yaml
dataset:
  _target_: nemo_automodel.components.datasets.llm.agent_chat.make_agent_chat_dataset
  dataset_name: llamafactory/glaive_toolcall_en
  train_on_last_turn_only: true
```

## Pre-checks

- `ruff format` + `ruff check`: clean
- `pytest tests/unit_tests/datasets/llm/test_agent_chat.py`: 22 passed (4 new tests covering the helper and the flag)
- Sign-off: included (DCO)