### PR TITLE
feat(datasets): drop history reasoning_content from agent SFT prompt

### DIFF
--- a/nemo_automodel/components/datasets/llm/agent_chat.py
+++ b/nemo_automodel/components/datasets/llm/agent_chat.py
@@ -95,7 +95,12 @@ def _sharegpt_to_chatml(conversations: List[Dict[str, Any]]) -> List[Dict[str, A
         src_role = turn.get("from")
         if src_role not in _SHAREGPT_ROLE_MAP:
             raise ValueError(f"Unsupported sharegpt role: {src_role!r}")
-        out.append({"role": _SHAREGPT_ROLE_MAP[src_role], "content": turn.get("value", "")})
+        chatml_turn = {"role": _SHAREGPT_ROLE_MAP[src_role], "content": turn.get("value", "")}
+        # Carry an explicit reasoning/thinking field through if the export
+        # stores it alongside the turn (e.g. ``reasoning_content``).
+        if turn.get("reasoning_content"):
+            chatml_turn["reasoning_content"] = turn["reasoning_content"]
+        out.append(chatml_turn)
     return out
 
 
@@ -181,7 +186,17 @@ def _convert_messages(
             content = messages[i].get("content", "")
             if not isinstance(content, str):
                 content = "" if content is None else str(content)
-            out.append({"role": role, "content": content})
+            msg: Dict[str, Any] = {"role": role, "content": content}
+            # Preserve an assistant turn's reasoning/thinking trace so it
+            # survives into the rendered chat (chat templates that reference
+            # ``reasoning_content`` will emit it; otherwise it is dropped with
+            # a warning by ``format_chat_template``). Carried through here so a
+            # following tool_call group can merge onto this same turn.
+            if role == "assistant":
+                reasoning = messages[i].get("reasoning_content")
+                if reasoning:
+                    msg["reasoning_content"] = reasoning if isinstance(reasoning, str) else str(reasoning)
+            out.append(msg)
             i += 1
 
     return out
@@ -195,6 +210,7 @@ def _format_example(
     seq_length: Optional[int] = None,
     padding: Union[str, bool] = False,
     truncation: Union[str, bool] = False,
+    mask_reasoning_content: bool = False,
 ) -> Dict[str, List[int]]:
     """Render one agent example into tokenized ``input_ids`` / ``labels``."""
     raw_tools = example.get("tools")
@@ -229,6 +245,7 @@ def _format_example(
         padding=padding,
         truncation=truncation,
         answer_only_loss_mask=True,
+        mask_reasoning_content=mask_reasoning_content,
     )
 
 
@@ -242,6 +259,7 @@ def make_agent_chat_dataset(
     limit_dataset_samples: Optional[int] = None,
     padding: Union[str, bool] = False,
     truncation: Union[str, bool] = False,
+    mask_reasoning_content: bool = False,
 ) -> LazyMappedDataset:
     """Load a multi-turn function-calling SFT dataset.
 
@@ -259,6 +277,11 @@ def make_agent_chat_dataset(
         limit_dataset_samples: If set, keep only the first N examples.
         padding: Padding strategy forwarded to the tokenizer.
         truncation: Truncation strategy forwarded to the tokenizer.
+        mask_reasoning_content: If True, exclude assistant ``reasoning_content``
+            (thinking) tokens from the loss while still rendering them into the
+            prompt. Requires a chat template that emits ``reasoning_content``.
+            Defaults to False, which trains on reasoning tokens like any other
+            assistant content.
 
     Returns:
         A ``LazyMappedDataset`` yielding dicts with ``input_ids``, ``labels``
@@ -293,5 +316,6 @@ def make_agent_chat_dataset(
         seq_length,
         padding,
         truncation,
+        mask_reasoning_content,
     )
     return LazyMappedDataset(dataset, fmt_fn)

--- a/nemo_automodel/components/datasets/llm/agent_chat.py
+++ b/nemo_automodel/components/datasets/llm/agent_chat.py
@@ -205,10 +205,10 @@ def _convert_messages(
             i += 1
 
     if drop_history_reasoning_content:
-        last_assistant = -1
-        for idx, m in enumerate(out):
-            if m.get("role") == "assistant":
-                last_assistant = idx
+        last_assistant = max(
+            (idx for idx, m in enumerate(out) if m.get("role") == "assistant"),
+            default=-1,
+        )
         for idx, m in enumerate(out):
             if idx != last_assistant and m.get("role") == "assistant":
                 m.pop("reasoning_content", None)
@@ -340,10 +340,10 @@ def make_agent_chat_dataset(
         tokenizer,
         eos_token_id,
         pad_token_id,
-        seq_length,
-        padding,
-        truncation,
-        mask_reasoning_content,
-        drop_history_reasoning_content,
+        seq_length=seq_length,
+        padding=padding,
+        truncation=truncation,
+        mask_reasoning_content=mask_reasoning_content,
+        drop_history_reasoning_content=drop_history_reasoning_content,
     )
     return LazyMappedDataset(dataset, fmt_fn)

--- a/nemo_automodel/components/datasets/llm/agent_chat.py
+++ b/nemo_automodel/components/datasets/llm/agent_chat.py
@@ -107,6 +107,7 @@ def _sharegpt_to_chatml(conversations: List[Dict[str, Any]]) -> List[Dict[str, A
 def _convert_messages(
     messages: List[Dict[str, Any]],
     example_id: Optional[Union[int, str]] = None,
+    drop_history_reasoning_content: bool = False,
 ) -> List[Dict[str, Any]]:
     """Convert chatml-style agent messages to OpenAI chat-completions format.
 
@@ -122,6 +123,10 @@ def _convert_messages(
     Args:
         messages: chatml-style turns with roles in ``_VALID_MESSAGE_ROLES``.
         example_id: Optional identifier used to derive unique tool_call ids.
+        drop_history_reasoning_content: If True, strip ``reasoning_content``
+            from every assistant turn except the final one, so historical
+            thinking traces are not rendered into the prompt. This matches
+            inference, where the model never sees its own prior-turn thinking.
 
     Returns:
         A list of OpenAI-format messages suitable for ``apply_chat_template``.
@@ -199,6 +204,15 @@ def _convert_messages(
             out.append(msg)
             i += 1
 
+    if drop_history_reasoning_content:
+        last_assistant = -1
+        for idx, m in enumerate(out):
+            if m.get("role") == "assistant":
+                last_assistant = idx
+        for idx, m in enumerate(out):
+            if idx != last_assistant and m.get("role") == "assistant":
+                m.pop("reasoning_content", None)
+
     return out
 
 
@@ -211,6 +225,7 @@ def _format_example(
     padding: Union[str, bool] = False,
     truncation: Union[str, bool] = False,
     mask_reasoning_content: bool = False,
+    drop_history_reasoning_content: bool = False,
 ) -> Dict[str, List[int]]:
     """Render one agent example into tokenized ``input_ids`` / ``labels``."""
     raw_tools = example.get("tools")
@@ -233,7 +248,11 @@ def _format_example(
     elif not isinstance(raw_messages, list):
         raise ValueError(f"`messages` must be a list, got {type(raw_messages).__name__}")
 
-    formatted = _convert_messages(raw_messages, example_id=example.get("id"))
+    formatted = _convert_messages(
+        raw_messages,
+        example_id=example.get("id"),
+        drop_history_reasoning_content=drop_history_reasoning_content,
+    )
 
     return format_chat_template(
         tokenizer=tokenizer,
@@ -260,6 +279,7 @@ def make_agent_chat_dataset(
     padding: Union[str, bool] = False,
     truncation: Union[str, bool] = False,
     mask_reasoning_content: bool = False,
+    drop_history_reasoning_content: bool = False,
 ) -> LazyMappedDataset:
     """Load a multi-turn function-calling SFT dataset.
 
@@ -282,6 +302,13 @@ def make_agent_chat_dataset(
             prompt. Requires a chat template that emits ``reasoning_content``.
             Defaults to False, which trains on reasoning tokens like any other
             assistant content.
+        drop_history_reasoning_content: If True, strip ``reasoning_content``
+            from all but the final assistant turn so historical thinking is not
+            rendered into the prompt (matching inference, where prior-turn
+            thinking is not visible). Orthogonal to ``mask_reasoning_content``:
+            this controls whether history thinking appears in the prompt at all,
+            the latter controls whether rendered thinking contributes to loss.
+            Defaults to False, which keeps every turn's reasoning_content.
 
     Returns:
         A ``LazyMappedDataset`` yielding dicts with ``input_ids``, ``labels``
@@ -317,5 +344,6 @@ def make_agent_chat_dataset(
         padding,
         truncation,
         mask_reasoning_content,
+        drop_history_reasoning_content,
     )
     return LazyMappedDataset(dataset, fmt_fn)

--- a/tests/unit_tests/datasets/llm/test_agent_chat.py
+++ b/tests/unit_tests/datasets/llm/test_agent_chat.py
@@ -385,3 +385,73 @@ def test_format_example_forwards_mask_reasoning_content(monkeypatch):
 
     agent_chat._format_example(example, Tok(), 0, 0, mask_reasoning_content=True)
     assert captured["mask_reasoning_content"] is True
+
+
+def test_convert_messages_drops_history_reasoning_keeps_last():
+    # Two assistant turns each carry reasoning; only the final one should keep it.
+    messages = [
+        {"role": "user", "content": "weather BJ?"},
+        {"role": "assistant", "content": "Beijing is sunny", "reasoning_content": "first thought"},
+        {"role": "user", "content": "and SH?"},
+        {"role": "assistant", "content": "Shanghai is rainy", "reasoning_content": "second thought"},
+    ]
+    out = agent_chat._convert_messages(messages, drop_history_reasoning_content=True)
+    assistants = [m for m in out if m["role"] == "assistant"]
+    assert "reasoning_content" not in assistants[0]
+    assert assistants[1]["reasoning_content"] == "second thought"
+
+
+def test_convert_messages_keeps_all_reasoning_by_default():
+    messages = [
+        {"role": "user", "content": "weather BJ?"},
+        {"role": "assistant", "content": "Beijing is sunny", "reasoning_content": "first thought"},
+        {"role": "user", "content": "and SH?"},
+        {"role": "assistant", "content": "Shanghai is rainy", "reasoning_content": "second thought"},
+    ]
+    out = agent_chat._convert_messages(messages)
+    assistants = [m for m in out if m["role"] == "assistant"]
+    assert assistants[0]["reasoning_content"] == "first thought"
+    assert assistants[1]["reasoning_content"] == "second thought"
+
+
+def test_convert_messages_drop_history_reasoning_handles_tool_call_turn():
+    # The final assistant turn is a tool_call merge; its reasoning must survive
+    # while an earlier assistant turn's reasoning is dropped.
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello", "reasoning_content": "greet back"},
+        {"role": "user", "content": "weather?"},
+        {"role": "assistant", "content": "", "reasoning_content": "call the tool"},
+        {"role": "tool_call", "content": '{"name":"aqi","arguments":{"city":"BJ"}}'},
+    ]
+    out = agent_chat._convert_messages(messages, example_id=1, drop_history_reasoning_content=True)
+    assistants = [m for m in out if m["role"] == "assistant"]
+    assert "reasoning_content" not in assistants[0]
+    assert assistants[1]["reasoning_content"] == "call the tool"
+    assert assistants[1]["tool_calls"][0]["function"]["name"] == "aqi"
+
+
+def test_format_example_forwards_drop_history_reasoning_content(monkeypatch):
+    captured = {}
+
+    def fake_convert_messages(messages, example_id=None, drop_history_reasoning_content=False):
+        captured["drop_history_reasoning_content"] = drop_history_reasoning_content
+        return [{"role": "user", "content": "hi"}]
+
+    def fake_format_chat_template(**kwargs):
+        return {"ok": True}
+
+    monkeypatch.setattr(agent_chat, "_convert_messages", fake_convert_messages)
+    monkeypatch.setattr(agent_chat, "format_chat_template", fake_format_chat_template)
+
+    class Tok:
+        eos_token_id = 0
+        pad_token_id = 0
+
+    example = {"messages": [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "yo"}]}
+
+    agent_chat._format_example(example, Tok(), 0, 0)
+    assert captured["drop_history_reasoning_content"] is False
+
+    agent_chat._format_example(example, Tok(), 0, 0, drop_history_reasoning_content=True)
+    assert captured["drop_history_reasoning_content"] is True

--- a/tests/unit_tests/datasets/llm/test_agent_chat.py
+++ b/tests/unit_tests/datasets/llm/test_agent_chat.py
@@ -334,3 +334,54 @@ def test_format_example_accepts_empty_tools_string(monkeypatch):
         pad_token_id=0,
     )
     assert captured["tools"] is None
+
+
+def test_convert_messages_preserves_assistant_reasoning_content():
+    messages = [
+        {"role": "user", "content": "2+2?"},
+        {"role": "assistant", "content": "4", "reasoning_content": "add two and two"},
+    ]
+    out = agent_chat._convert_messages(messages)
+    assert out[1]["content"] == "4"
+    assert out[1]["reasoning_content"] == "add two and two"
+
+
+def test_convert_messages_reasoning_survives_tool_call_merge():
+    # An assistant reasoning turn immediately followed by a tool_call group
+    # merges into one assistant message that keeps the reasoning trace.
+    messages = [
+        {"role": "user", "content": "weather?"},
+        {"role": "assistant", "content": "", "reasoning_content": "I should call the weather tool"},
+        {"role": "tool_call", "content": '{"name":"aqi","arguments":{"city":"BJ"}}'},
+    ]
+    out = agent_chat._convert_messages(messages, example_id=1)
+    assert [m["role"] for m in out] == ["user", "assistant"]
+    assert out[1]["reasoning_content"] == "I should call the weather tool"
+    assert out[1]["tool_calls"][0]["function"]["name"] == "aqi"
+
+
+def test_sharegpt_to_chatml_passes_reasoning_content_through():
+    out = agent_chat._sharegpt_to_chatml([{"from": "gpt", "value": "hi", "reasoning_content": "be polite"}])
+    assert out[0] == {"role": "assistant", "content": "hi", "reasoning_content": "be polite"}
+
+
+def test_format_example_forwards_mask_reasoning_content(monkeypatch):
+    captured = {}
+
+    def fake_format_chat_template(**kwargs):
+        captured.update(kwargs)
+        return {"ok": True}
+
+    monkeypatch.setattr(agent_chat, "format_chat_template", fake_format_chat_template)
+
+    class Tok:
+        eos_token_id = 0
+        pad_token_id = 0
+
+    example = {"messages": [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "yo"}]}
+
+    agent_chat._format_example(example, Tok(), 0, 0)
+    assert captured["mask_reasoning_content"] is False
+
+    agent_chat._format_example(example, Tok(), 0, 0, mask_reasoning_content=True)
+    assert captured["mask_reasoning_content"] is True


### PR DESCRIPTION
## What

Add a `drop_history_reasoning_content` option to the agent chat SFT dataset
(`agent_chat.py`) that strips `reasoning_content` from every assistant turn
except the final one, so historical thinking traces are not rendered into the
prompt. This matches inference — the model never sees its own prior-turn
thinking — and avoids the train/inference mismatch (and wasted context) caused
by leaving stale thinking in the rendered chat.

It is **orthogonal** to the existing `mask_reasoning_content`:

| | history thinking in prompt? | thinking counted in loss? |
|---|---|---|
| default | yes | yes |
| `mask_reasoning_content` | yes (still rendered) | no |
| `drop_history_reasoning_content` (this PR) | no (dropped from history) | — |

## Changelog

- `make_agent_chat_dataset` / `_format_example` / `_convert_messages` accept
  `drop_history_reasoning_content` (default `False`, fully backward compatible).
- When enabled, only the final assistant turn keeps its `reasoning_content`;
  earlier turns are pruned. Post-loop processing so the tool_call-merge case is
  handled correctly.
- 4 new unit tests; full `test_agent_chat.py` suite is 26 passed.

## Dependency

> **Stacked on #2348** (`feat(datasets): preserve and optionally mask
> reasoning_content in agent SFT`). That PR adds the `reasoning_content`
> carry-through this feature prunes — without it there is nothing to drop.
> Please merge #2348 first; once it lands, this PR's diff collapses to the
> single drop-history commit.

## Pre-checks

- [x] `ruff format` + `ruff check` clean
- [x] unit tests pass locally (26 passed)
- [x] DCO sign-off
