### PR TITLE
ci: override ep size for benchmark gptoss 120b

### DIFF
--- a/examples/llm_benchmark/gpt_oss/gptoss_120b_te_deepep.yaml
+++ b/examples/llm_benchmark/gpt_oss/gptoss_120b_te_deepep.yaml
@@ -113,3 +113,4 @@ optimizer:
 ci:
   time: "00:30:00"
   nodes: 8
+  ep_size: 16

--- a/tests/ci_tests/scripts/config_templates/ci_config.yaml
+++ b/tests/ci_tests/scripts/config_templates/ci_config.yaml
@@ -86,6 +86,9 @@ env:
   LOCAL_BATCH_SIZE:
     target: step_scheduler.local_batch_size
     phases: [nightly, release, convergence, performance]
+  EP_SIZE:
+    target: distributed.ep_size
+    phases: [nightly, release, convergence, performance]
 
 # Computed dynamic overrides. `format` is str.format() over env vars + built-in `date`.
 computed:

--- a/tests/ci_tests/utils/generate_ci_tests.py
+++ b/tests/ci_tests/utils/generate_ci_tests.py
@@ -119,6 +119,7 @@ CI_KEY_TO_VAR = {
     "nodes": "TEST_NODE_COUNT",
     "node_multiplier": "NODE_MULTIPLIER",
     "local_batch_size": "LOCAL_BATCH_SIZE",
+    "ep_size": "EP_SIZE",
     "recipe_owner": "RECIPE_OWNER",
     "nproc_per_node": "CONFIG_NPROC_PER_NODE",
 }


### PR DESCRIPTION
# What does this PR do ?

- Update benchmark gptoss 120b ep size
- Allow ci tests to override default ep size

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
