### PR TITLE
ci: add cluster_tag for reserved-cluster opt-in

### DIFF
--- a/examples/llm_finetune/gpt_oss/gpt_oss_20b_single_gpu.yaml
+++ b/examples/llm_finetune/gpt_oss/gpt_oss_20b_single_gpu.yaml
@@ -98,4 +98,4 @@ optimizer:
 ci:
   recipe_owner: akoumpa
   nproc_per_node: 1
-  known_issue_id: AM-159
+  cluster_tag: digits

--- a/examples/llm_finetune/gpt_oss/gpt_oss_20b_single_gpu_peft.yaml
+++ b/examples/llm_finetune/gpt_oss/gpt_oss_20b_single_gpu_peft.yaml
@@ -111,3 +111,4 @@ optimizer:
 ci:
   recipe_owner: adil-a
   nproc_per_node: 1
+  cluster_tag: digits

--- a/tests/ci_tests/utils/generate_ci_tests.py
+++ b/tests/ci_tests/utils/generate_ci_tests.py
@@ -121,6 +121,7 @@ CI_KEY_TO_VAR = {
     "local_batch_size": "LOCAL_BATCH_SIZE",
     "recipe_owner": "RECIPE_OWNER",
     "nproc_per_node": "CONFIG_NPROC_PER_NODE",
+    "cluster_tag": "RESERVED_CLUSTER_TAG",
 }
 
 
@@ -176,6 +177,8 @@ def _enrich_base_job(job: Dict[str, Any], ci_config: Dict[str, Any], scope: str)
             job["variables"][ci_var] = DQ(str(value))
         elif ci_var == "NODE_MULTIPLIER":
             job["variables"][ci_var] = str(value).lower()
+        elif ci_var == "RESERVED_CLUSTER_TAG":
+            job["variables"][ci_var] = f"/{value}/"
         else:
             job["variables"][ci_var] = value
 


### PR DESCRIPTION
# What does this PR do ?

- Add a general `ci.cluster_tag` recipe key; the test generator emits it as RESERVED_CLUSTER_TAG so a recipe can opt into a reserved CI cluster while still running on its normal clusters.
- Opt both single-GPU gpt_oss recipes into `digits`, and re-enable gpt_oss_20b_single_gpu by dropping its known_issue_id (AM-159).

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
