### PR TITLE
feat: vision biencoder finetuning + Nemotron VL 1B finetuning support

### DIFF
--- a/examples/retrieval/bi_encoder/nemotron_vl_1b/README.md
+++ b/examples/retrieval/bi_encoder/nemotron_vl_1b/README.md
@@ -1,0 +1,72 @@
+# Finetuning Llama Nemotron VL 1B embedding model
+
+This example shows how to finetune an embedding model for visual document retrieval: [nvidia/llama-nemotron-embed-vl-1b-v2](https://huggingface.co/nvidia/llama-nemotron-embed-vl-1b-v2).  The model can embed document pages in the form of image, text, or combined image–text inputs. Documents can be retrieved given a user query in text form. The model supports page images containing text, tables, charts, and infographics. You can check the performance of the model on vision document retrieval and text retrieval benchmarks [here](https://huggingface.co/nvidia/llama-nemotron-embed-vl-1b-v2#evaluation-results).
+
+
+## Finetuning for domain adaptation
+You might want to further finetune the [nvidia/llama-nemotron-embed-vl-1b-v2](https://huggingface.co/nvidia/llama-nemotron-embed-vl-1b-v2) open multimodal embedding modal for a specific domain adaptation. 
+
+The Nemo Automodel Retrieval recipe expects a train set with a Corpus ID-Based JSON schema as presented below, and also documented [here](https://docs.nvidia.com/nemo/automodel/latest/guides/llm/retrieval-dataset.html#corpus-id-based-json-merlin-nemo-retriever-style).
+
+```json
+{
+  "corpus": {
+    "path": "/path/to/corpus/colpali_train_set"
+  },
+  "data": [
+    {
+      "question_id": "q2",
+      "question": "What is the primary purpose of the PTC in lithium batteries?",
+      "corpus_id": "colpali_train_set",
+      "pos_doc": [
+        {"id": "2"}
+      ],
+      "neg_doc": [
+        {"id": "69560"},
+        {"id": "112685"},
+        {"id": "5132"}, ...
+    }, ...
+  ]
+}
+```
+
+The "corpus" path points to a directory with the corpus in parquet format containing a field with the document id.  
+The "data" contains the list of training samples for contrastive learning, in particular the question, positive samples (pos_doc) and negative samples (neg_doc), which are document ids from the corpus. Positive and negative samples can be document page images or chunks of text (passages). 
+
+### Preparing the vision retrieval train set
+We provide for this example a notebook to prepare the a vision retrieval train set based on [ColPali](https://huggingface.co/datasets/vidore/colpali_train_set): [prepare_dataset_for_vdr/convert_colpali_dataset_for_training.ipynb]([prepare_dataset_for_vdr/convert_colpali_dataset_for_training.ipynb]). It performs the following steps:
+1. Downloads a [train set](https://huggingface.co/datasets/Tevatron/colpali) that includes mined hard-negatives (for faster contrastive learning) and the corresponding [corpus](https://huggingface.co/datasets/Tevatron/colpali-corpus)
+2. Converts and saves that data into the Corpus ID-Based JSON schema expected for training biencoder models with Nemo Automodel.
+
+After running the notebook, open [nemotron_vl_1b_example.yaml](nemotron_vl_1b_example.yaml) and modify inside `data_dir_list` the path of ColPali dataset with the one you set when running the notebook above, as in below example. 
+Notice that in this example there is a second dataset in `data_dir_list`, where the positive/negative samples are text passages (from [MIRACL train set](https://huggingface.co/datasets/nvidia/embed-nemotron-dataset-v1/viewer/MIRACL), focused on multi-lingual text retrieval). You can also set the number of samples per dataset as in the following example.
+
+```yaml
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  dataset:
+    _target_: nemo_automodel.components.datasets.llm.make_retrieval_dataset
+    model_type: bi_encoder
+    data_dir_list:
+      - path: /path/to/trainset/colpali_train.json 
+        num_samples: 5000
+      - path: hf://nvidia/embed-nemotron-dataset-v1/MIRACL
+        num_samples: 5000
+```
+
+Also set the YAML config to log train metrics to W&B if you have an account.
+```
+wandb:
+  project: YOUR_WANDB_PROJECT
+  entity: YOUR_WANDB_ENTITY
+  name: nemotron_vl_1b_embedding_example
+```
+
+### Fine-tuning with Automodel
+
+Here is an example on how to fine-tune the [nvidia/llama-nemotron-embed-vl-1b-v2](https://huggingface.co/nvidia/llama-nemotron-embed-vl-1b-v2) embedding model, distributed to 8x A100 GPUs in a single instance. If you have less GPUs available, you can set `--nproc-per-node` accordingly. For multi-node training, you can use `sbatch` command for Slurm clusters.
+
+```bash
+torchrun --nproc-per-node=8 examples/retrieval/bi_encoder/finetune.py --config examples/retrieval/bi_encoder/nemotron_vl_1b/nemotron_vl_1b_example.yaml
+```
+

--- a/examples/retrieval/bi_encoder/nemotron_vl_1b/README.md
+++ b/examples/retrieval/bi_encoder/nemotron_vl_1b/README.md
@@ -38,7 +38,7 @@ We provide for this example a notebook to prepare the a vision retrieval train s
 1. Downloads a [train set](https://huggingface.co/datasets/Tevatron/colpali) that includes mined hard-negatives (for faster contrastive learning) and the corresponding [corpus](https://huggingface.co/datasets/Tevatron/colpali-corpus)
 2. Converts and saves that data into the Corpus ID-Based JSON schema expected for training biencoder models with Nemo Automodel.
 
-After running the notebook, open [nemotron_vl_1b_example.yaml](nemotron_vl_1b_example.yaml) and modify inside `data_dir_list` the path of ColPali dataset with the one you set when running the notebook above, as in below example. 
+After running the notebook, open [nemotron_vl_1b_example.yaml](nemotron_vl_1b_example.yaml) and modify inside `data_dir_list` the path of ColPali dataset (`colpali_train.json`) with the one you set when running the notebook above, as in below example. 
 Notice that in this example there is a second dataset in `data_dir_list`, where the positive/negative samples are text passages (from [MIRACL train set](https://huggingface.co/datasets/nvidia/embed-nemotron-dataset-v1/viewer/MIRACL), focused on multi-lingual text retrieval). You can also set the number of samples per dataset as in the following example.
 
 ```yaml

--- a/examples/retrieval/bi_encoder/nemotron_vl_1b/README.md
+++ b/examples/retrieval/bi_encoder/nemotron_vl_1b/README.md
@@ -4,7 +4,7 @@ This example shows how to finetune an embedding model for visual document retrie
 
 
 ## Finetuning for domain adaptation
-You might want to further finetune the [nvidia/llama-nemotron-embed-vl-1b-v2](https://huggingface.co/nvidia/llama-nemotron-embed-vl-1b-v2) open multimodal embedding modal for a specific domain adaptation. 
+You might want to further finetune the [nvidia/llama-nemotron-embed-vl-1b-v2](https://huggingface.co/nvidia/llama-nemotron-embed-vl-1b-v2) open multimodal embedding model for a specific domain adaptation. 
 
 The Nemo Automodel Retrieval recipe expects a train set with a Corpus ID-Based JSON schema as presented below, and also documented [here](https://docs.nvidia.com/nemo/automodel/latest/guides/llm/retrieval-dataset.html#corpus-id-based-json-merlin-nemo-retriever-style).
 
@@ -34,7 +34,7 @@ The "corpus" path points to a directory with the corpus in parquet format contai
 The "data" contains the list of training samples for contrastive learning, in particular the question, positive samples (pos_doc) and negative samples (neg_doc), which are document ids from the corpus. Positive and negative samples can be document page images or chunks of text (passages). 
 
 ### Preparing the vision retrieval train set
-We provide for this example a notebook to prepare the a vision retrieval train set based on [ColPali](https://huggingface.co/datasets/vidore/colpali_train_set): [prepare_dataset_for_vdr/convert_colpali_dataset_for_training.ipynb]([prepare_dataset_for_vdr/convert_colpali_dataset_for_training.ipynb]). It performs the following steps:
+This example includes a notebook that demonstrates how to prepare a vision retrieval training dataset using [ColPali](https://huggingface.co/datasets/vidore/colpali_train_set): [prepare_dataset_for_vdr/convert_colpali_dataset_for_training.ipynb]([prepare_dataset_for_vdr/convert_colpali_dataset_for_training.ipynb]). It performs the following steps:
 1. Downloads a [train set](https://huggingface.co/datasets/Tevatron/colpali) that includes mined hard-negatives (for faster contrastive learning) and the corresponding [corpus](https://huggingface.co/datasets/Tevatron/colpali-corpus)
 2. Converts and saves that data into the Corpus ID-Based JSON schema expected for training biencoder models with Nemo Automodel.
 
@@ -54,7 +54,7 @@ dataloader:
         num_samples: 5000
 ```
 
-Also set the YAML config to log train metrics to W&B if you have an account.
+Also, if you have a Weights & Biases (W&B) account, you can configure the YAML file to log training metrics during training.
 ```
 wandb:
   project: YOUR_WANDB_PROJECT

--- a/examples/retrieval/bi_encoder/nemotron_vl_1b/nemotron_vl_1b_example.yaml
+++ b/examples/retrieval/bi_encoder/nemotron_vl_1b/nemotron_vl_1b_example.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # To run this recipe:
-#   automodel examples/retrieval/bi_encoder/llama3_2_1b.yaml --nproc-per-node 8
+#   automodel examples/retrieval/bi_encoder/nemotron_vl_1b/nemotron_vl_1b_example.yaml --nproc-per-node 8
 # Adjust --nproc-per-node to the number of GPUs available on your machine.
 
 recipe: TrainBiEncoderRecipe
@@ -49,8 +49,8 @@ model:
 tokenizer:
   _target_: nemo_automodel.components.models.llama_nemotron_vl.processor.LlamaNemotronVLProcessor.from_pretrained
   pretrained_model_name_or_path: nvidia/llama-nemotron-embed-vl-1b-v2
-  q_max_len: 512
-  p_max_len: 4096
+  q_max_length: 512
+  p_max_length: 4096
   query_prefix: "query:"
   passage_prefix: "passage:"
   max_input_tiles: 2

--- a/examples/retrieval/bi_encoder/nemotron_vl_1b/nemotron_vl_1b_example.yaml
+++ b/examples/retrieval/bi_encoder/nemotron_vl_1b/nemotron_vl_1b_example.yaml
@@ -62,7 +62,7 @@ dataloader:
     _target_: nemo_automodel.components.datasets.llm.make_retrieval_dataset
     model_type: bi_encoder
     data_dir_list:
-      - path: /lustre/fsw/portfolios/datascience/users/gmoreira/automodel_colpali/training_datasets/colpali_train.json 
+      - path: <DATASETS_PATH>/automodel_colpali/training_datasets/colpali_train.json 
         num_samples: 5000
       - path: hf://nvidia/embed-nemotron-dataset-v1/MIRACL
         num_samples: 5000

--- a/examples/retrieval/bi_encoder/nemotron_vl_1b/nemotron_vl_1b_example.yaml
+++ b/examples/retrieval/bi_encoder/nemotron_vl_1b/nemotron_vl_1b_example.yaml
@@ -1,0 +1,110 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# To run this recipe:
+#   automodel examples/retrieval/bi_encoder/llama3_2_1b.yaml --nproc-per-node 8
+# Adjust --nproc-per-node to the number of GPUs available on your machine.
+
+recipe: TrainBiEncoderRecipe
+
+seed: 0
+
+temperature: 0.02
+
+step_scheduler:
+  global_batch_size: 8
+  local_batch_size: 1
+  ckpt_every_steps: 5000
+  val_every_steps: 500
+  num_epochs: 1
+  log_remote_every_steps: 50
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 10
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelBiEncoder.from_pretrained
+  pretrained_model_name_or_path: nvidia/llama-nemotron-embed-vl-1b-v2
+  pooling: avg
+  l2_normalize: true
+  use_liger_kernel: true
+  use_sdpa_patching: true
+  torch_dtype: bfloat16
+  attn_implementation: flash_attention_2
+  do_distributed_inbatch_negative: true
+  detach_distributed_inbatch_negatives: false
+
+tokenizer:
+  _target_: nemo_automodel.components.models.llama_nemotron_vl.processor.LlamaNemotronVLProcessor.from_pretrained
+  pretrained_model_name_or_path: nvidia/llama-nemotron-embed-vl-1b-v2
+  q_max_len: 512
+  p_max_len: 4096
+  query_prefix: "query:"
+  passage_prefix: "passage:"
+  max_input_tiles: 2
+
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  dataset:
+    _target_: nemo_automodel.components.datasets.llm.make_retrieval_dataset
+    model_type: bi_encoder
+    data_dir_list:
+      - path: /lustre/fsw/portfolios/datascience/users/gmoreira/automodel_colpali/training_datasets/colpali_train.json 
+        num_samples: 5000
+      - path: hf://nvidia/embed-nemotron-dataset-v1/MIRACL
+        num_samples: 5000
+    data_type: train
+    n_passages: 5
+    seed: 42
+    do_shuffle: true
+  collate_fn:
+    _target_: nemo_automodel.components.datasets.llm.make_vision_collator_from_processor_method
+    collator_fn_name: process_queries_documents_biencoder
+  shuffle: true
+  num_workers: 4
+  pin_memory: true
+
+optimizer:
+  _target_: transformer_engine.pytorch.optimizers.fused_adam.FusedAdam
+  lr: 1e-6
+  weight_decay: 0.1
+  adam_w_mode: true
+  bias_correction: true
+  master_weights: true
+
+lr_scheduler:
+  lr_warmup_steps: 100
+  lr_decay_style: linear
+
+checkpoint:
+  enabled: true
+  checkpoint_dir: ./output/nemotron_vl_1b_example/checkpoints
+  model_save_format: safetensors
+  save_consolidated: true
+
+distributed:
+  strategy: ddp
+  find_unused_parameters: false
+  static_graph: true
+  bucket_cap_mb: 400
+  gradient_as_bucket_view: true
+
+# Uncomment and configure for W&B logging
+wandb:
+  project: YOUR_WANDB_PROJECT
+  entity: YOUR_WANDB_ENTITY
+  name: nemotron_vl_1b_embedding_example
+  #save_dir: <your_wandb_save_dir> 

--- a/examples/retrieval/bi_encoder/nemotron_vl_1b/nemotron_vl_1b_example.yaml
+++ b/examples/retrieval/bi_encoder/nemotron_vl_1b/nemotron_vl_1b_example.yaml
@@ -107,4 +107,5 @@ wandb:
   project: YOUR_WANDB_PROJECT
   entity: YOUR_WANDB_ENTITY
   name: nemotron_vl_1b_embedding_example
+  enable: false
   #save_dir: <your_wandb_save_dir> 

--- a/examples/retrieval/bi_encoder/prepare_dataset_for_vdr/convert_colpali_dataset_for_training.ipynb
+++ b/examples/retrieval/bi_encoder/prepare_dataset_for_vdr/convert_colpali_dataset_for_training.ipynb
@@ -1,6 +1,16 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "debce5fc",
+   "metadata": {},
+   "source": [
+    "### Example conversion notebook to Automodel's image retrieval dataset format\n",
+    "\n",
+    "This notebook is provided as an example of how to create a training dataset to start training of embedding models for visual document retrieval. Users are responsible for validating the quality of the generated dataset samples."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "2e18b373",

--- a/nemo_automodel/_transformers/registry.py
+++ b/nemo_automodel/_transformers/registry.py
@@ -122,6 +122,10 @@ MODEL_ARCH_MAPPING = OrderedDict(
             ("nemo_automodel.components.models.llama_bidirectional.model", "LlamaBidirectionalModel", {"retrieval"}),
         ),
         (
+            "LlamaNemotronVLModel",
+            ("nemo_automodel.components.models.llama_nemotron_vl.model", "LlamaNemotronVLModel", {"retrieval"}),
+        ),
+        (
             "LlamaForCausalLM",
             ("nemo_automodel.components.models.llama.model", "LlamaForCausalLM"),
         ),

--- a/nemo_automodel/_transformers/retrieval.py
+++ b/nemo_automodel/_transformers/retrieval.py
@@ -422,11 +422,16 @@ class BiEncoderModel(nn.Module):
         if not input_dict:
             return None
 
-        if "token_type_ids" not in inspect.getfullargspec(self.model.forward).args and "token_type_ids" in input_dict:
+        forward_args = inspect.getfullargspec(self.model.forward).args
+        if "token_type_ids" not in forward_args and "token_type_ids" in input_dict:
             input_dict = {k: v for k, v in input_dict.items() if k != "token_type_ids"}
 
+        model_inputs = {k: v for k, v in input_dict.items() if k not in ["kd_labels", "run_dummy_vision"]}
+        if "run_dummy_vision" in forward_args and "run_dummy_vision" in input_dict:
+            model_inputs["run_dummy_vision"] = input_dict["run_dummy_vision"]
+
         outputs = self.model(
-            **{k: v for k, v in input_dict.items() if k not in ["kd_labels"]},
+            **model_inputs,
             return_dict=True,
             output_hidden_states=True,
         )

--- a/nemo_automodel/_transformers/retrieval.py
+++ b/nemo_automodel/_transformers/retrieval.py
@@ -332,11 +332,15 @@ _LLAMA_TASKS = {
 _MINISTRAL3_BIDIREC_TASKS = {
     "embedding": "Ministral3BidirectionalModel",
 }
+_LLAMA_NEMOTRON_VL_TASKS = {
+    "embedding": "LlamaNemotronVLModel",
+}
 SUPPORTED_BACKBONES = {
     "llama": _LLAMA_TASKS,
     "llama_bidirec": _LLAMA_TASKS,
     "ministral3": _MINISTRAL3_BIDIREC_TASKS,
     "ministral3_bidirec": _MINISTRAL3_BIDIREC_TASKS,
+    "llama_nemotron_vl": _LLAMA_NEMOTRON_VL_TASKS,
 }
 
 

--- a/nemo_automodel/components/datasets/llm/__init__.py
+++ b/nemo_automodel/components/datasets/llm/__init__.py
@@ -22,7 +22,11 @@ from .delta_lake_dataset import (  # noqa: F401
 )
 from .nanogpt_dataset import NanogptDataset  # noqa: F401
 from .neat_packing import neat_pack_dataset  # noqa: F401
-from .retrieval_collator import BiEncoderCollator, CrossEncoderCollator  # noqa: F401
+from .retrieval_collator import (  # noqa: F401
+    BiEncoderCollator,
+    CrossEncoderCollator,
+    make_vision_retrieval_collator_from_processor,
+)
 from .retrieval_dataset import make_retrieval_dataset  # noqa: F401
 from .squad import make_squad_dataset  # noqa: F401
 from .xlam import make_xlam_dataset  # noqa: F401
@@ -35,6 +39,7 @@ __all__ = [
     "make_agent_chat_dataset",
     "BiEncoderCollator",
     "CrossEncoderCollator",
+    "make_vision_retrieval_collator_from_processor",
     "ColumnMappedTextInstructionDataset",
     "ColumnMappedTextInstructionIterableDataset",
     "ChatDataset",

--- a/nemo_automodel/components/datasets/llm/__init__.py
+++ b/nemo_automodel/components/datasets/llm/__init__.py
@@ -25,7 +25,7 @@ from .neat_packing import neat_pack_dataset  # noqa: F401
 from .retrieval_collator import (  # noqa: F401
     BiEncoderCollator,
     CrossEncoderCollator,
-    make_vision_retrieval_collator_from_processor,
+    make_vision_collator_from_processor_method,
 )
 from .retrieval_dataset import make_retrieval_dataset  # noqa: F401
 from .squad import make_squad_dataset  # noqa: F401
@@ -39,7 +39,7 @@ __all__ = [
     "make_agent_chat_dataset",
     "BiEncoderCollator",
     "CrossEncoderCollator",
-    "make_vision_retrieval_collator_from_processor",
+    "make_vision_collator_from_processor_method",
     "ColumnMappedTextInstructionDataset",
     "ColumnMappedTextInstructionIterableDataset",
     "ChatDataset",

--- a/nemo_automodel/components/datasets/llm/retrieval_collator.py
+++ b/nemo_automodel/components/datasets/llm/retrieval_collator.py
@@ -16,7 +16,7 @@ import hashlib
 from typing import TYPE_CHECKING, Any, Dict, List, Union
 
 import torch
-from transformers import AutoConfig, AutoProcessor, DataCollatorWithPadding, PreTrainedTokenizerBase, ProcessorMixin
+from transformers import DataCollatorWithPadding, PreTrainedTokenizerBase, ProcessorMixin
 from transformers.file_utils import PaddingStrategy
 
 from nemo_automodel.components.models.llama_nemotron_vl import LlamaNemotronVLProcessor

--- a/nemo_automodel/components/datasets/llm/retrieval_collator.py
+++ b/nemo_automodel/components/datasets/llm/retrieval_collator.py
@@ -16,7 +16,7 @@ import hashlib
 from typing import TYPE_CHECKING, Any, Dict, List, Union
 
 import torch
-from transformers import AutoConfig, AutoProcessor, DataCollatorWithPadding, PreTrainedTokenizerBase
+from transformers import AutoConfig, AutoProcessor, DataCollatorWithPadding, PreTrainedTokenizerBase, ProcessorMixin
 from transformers.file_utils import PaddingStrategy
 
 from nemo_automodel.components.models.llama_nemotron_vl import LlamaNemotronVLProcessor
@@ -310,7 +310,22 @@ class CrossEncoderCollator(DataCollatorWithPadding):
         return batch_dict
 
 
-def make_vision_retrieval_collator_from_processor(model_name_or_path: str, **kwargs):
+def make_vision_collator_from_processor_method(tokenizer: ProcessorMixin, collator_fn_name: str):
+    """
+    Turns a method of a processor into a collator function.
+
+    Args:
+        tokenizer: The processor instance.
+        collator_fn_name: The name of the proceessor method to turn into a collator function.
+
+    Returns:
+        A collator for vision/multimodal retrieval datasets.
+    """
+    return getattr(tokenizer, collator_fn_name)
+
+
+# Deprecated: To be replaced by make_vision_collator_from_processor_method()
+def make_vision_retrieval_collator_from_processor_path(model_name_or_path: str, **kwargs):
     """ "
     Make a vision retrieval collator from a processor.
 

--- a/nemo_automodel/components/datasets/llm/retrieval_collator.py
+++ b/nemo_automodel/components/datasets/llm/retrieval_collator.py
@@ -19,6 +19,7 @@ import torch
 from transformers import DataCollatorWithPadding, PreTrainedTokenizerBase, ProcessorMixin
 from transformers.file_utils import PaddingStrategy
 
+
 def _doc_id_str_to_int64(doc_id: str) -> int:
     """Stable 63-bit int for corpus doc id strings (for in-batch duplicate masking)."""
     h = hashlib.md5(doc_id.encode("utf-8")).digest()[:8]

--- a/nemo_automodel/components/datasets/llm/retrieval_collator.py
+++ b/nemo_automodel/components/datasets/llm/retrieval_collator.py
@@ -16,8 +16,14 @@ import hashlib
 from typing import TYPE_CHECKING, Any, Dict, List, Union
 
 import torch
-from transformers import DataCollatorWithPadding, PreTrainedTokenizerBase
+from transformers import AutoConfig, AutoProcessor, DataCollatorWithPadding, PreTrainedTokenizerBase
 from transformers.file_utils import PaddingStrategy
+
+from nemo_automodel.components.models.llama_nemotron_vl import LlamaNemotronVLProcessor
+
+MODELS_WITH_PROCESSOR = {
+    "llama_nemotron_vl": LlamaNemotronVLProcessor,
+}
 
 
 def _doc_id_str_to_int64(doc_id: str) -> int:
@@ -302,3 +308,26 @@ class CrossEncoderCollator(DataCollatorWithPadding):
             batch_dict["labels"] = torch.zeros(num_labels, dtype=torch.long)
 
         return batch_dict
+
+
+def make_vision_retrieval_collator_from_processor(model_name_or_path: str, **kwargs):
+    """ "
+    Make a vision retrieval collator from a processor.
+
+    Args:
+        model_name_or_path: The name or path of the model to use, where the processor is defined.
+        **kwargs: Additional arguments to pass to the processor.
+
+    Returns:
+        A collator for vision/multimodal retrieval datasets.
+    """
+    if "tokenizer" in kwargs:
+        del kwargs["tokenizer"]
+    config = AutoConfig.from_pretrained(model_name_or_path, trust_remote_code=True)
+    if config.model_type in MODELS_WITH_PROCESSOR:
+        processor = MODELS_WITH_PROCESSOR[config.model_type].from_pretrained(
+            model_name_or_path, trust_remote_code=True, **kwargs
+        )
+    else:
+        processor = AutoProcessor.from_pretrained(model_name_or_path, trust_remote_code=True, **kwargs)
+    return processor.process_queries_documents_biencoder

--- a/nemo_automodel/components/datasets/llm/retrieval_collator.py
+++ b/nemo_automodel/components/datasets/llm/retrieval_collator.py
@@ -322,27 +322,3 @@ def make_vision_collator_from_processor_method(tokenizer: ProcessorMixin, collat
         A collator for vision/multimodal retrieval datasets.
     """
     return getattr(tokenizer, collator_fn_name)
-
-
-# Deprecated: To be replaced by make_vision_collator_from_processor_method()
-def make_vision_retrieval_collator_from_processor_path(model_name_or_path: str, **kwargs):
-    """ "
-    Make a vision retrieval collator from a processor.
-
-    Args:
-        model_name_or_path: The name or path of the model to use, where the processor is defined.
-        **kwargs: Additional arguments to pass to the processor.
-
-    Returns:
-        A collator for vision/multimodal retrieval datasets.
-    """
-    if "tokenizer" in kwargs:
-        del kwargs["tokenizer"]
-    config = AutoConfig.from_pretrained(model_name_or_path, trust_remote_code=True)
-    if config.model_type in MODELS_WITH_PROCESSOR:
-        processor = MODELS_WITH_PROCESSOR[config.model_type].from_pretrained(
-            model_name_or_path, trust_remote_code=True, **kwargs
-        )
-    else:
-        processor = AutoProcessor.from_pretrained(model_name_or_path, trust_remote_code=True, **kwargs)
-    return processor.process_queries_documents_biencoder

--- a/nemo_automodel/components/datasets/llm/retrieval_collator.py
+++ b/nemo_automodel/components/datasets/llm/retrieval_collator.py
@@ -19,13 +19,6 @@ import torch
 from transformers import DataCollatorWithPadding, PreTrainedTokenizerBase, ProcessorMixin
 from transformers.file_utils import PaddingStrategy
 
-from nemo_automodel.components.models.llama_nemotron_vl import LlamaNemotronVLProcessor
-
-MODELS_WITH_PROCESSOR = {
-    "llama_nemotron_vl": LlamaNemotronVLProcessor,
-}
-
-
 def _doc_id_str_to_int64(doc_id: str) -> int:
     """Stable 63-bit int for corpus doc id strings (for in-batch duplicate masking)."""
     h = hashlib.md5(doc_id.encode("utf-8")).digest()[:8]

--- a/nemo_automodel/components/datasets/llm/retrieval_dataset.py
+++ b/nemo_automodel/components/datasets/llm/retrieval_dataset.py
@@ -88,6 +88,43 @@ class ColPaliDataset(AbstractDataset):
         return sorted(list(self.docid2idx.keys()))
 
 
+class WikiSSNQDataset(AbstractDataset):
+    def __init__(self, path):
+        self.path = path
+        self.data = load_dataset(path)['train']
+        docid2idx = {}
+        for idx, docid in enumerate(self.data['docid']):
+            docid2idx[str(docid)] = idx
+        self.docid2idx = docid2idx
+
+    def get_document_by_id(self, id):
+        example = deepcopy(EXAMPLE_TEMPLATE)
+        doc = self.data[self.docid2idx[id]]
+        example['image'] = doc['image']
+        if 'nr_ocr' in doc:
+            example['nr_ocr'] = doc['nr_ocr']
+        if 'complex_ocr' in doc:
+            example['complex_ocr'] = doc['complex_ocr']
+        return(example)
+    
+    def get_all_ids(self):
+        return(sorted(list(self.docid2idx.keys())))
+
+class DocMatixDataset(AbstractDataset):
+    def __init__(self, path):
+        self.path = path
+        self.data = load_dataset(path, 'images')['train']
+
+    def get_document_by_id(self, id):
+        example = deepcopy(EXAMPLE_TEMPLATE)
+        example_idx, image_idx = id.split('_')
+        example['image'] = self.data[int(example_idx)]['images'][int(image_idx)]
+        return(example)
+    
+    def get_all_ids(self):
+        return([str(x) + '_' + str(0) for x in list(range(len(self.data)))])
+
+
 class HFCorpusDataset(AbstractDataset):
     """Wraps an already-loaded HuggingFace Dataset as a corpus (in-memory, no local Parquet)."""
 
@@ -108,6 +145,8 @@ class HFCorpusDataset(AbstractDataset):
 DATASETS = {
     "TextQADataset": TextQADataset,
     "ColPaliDataset": ColPaliDataset,
+    "WikiSSNQDataset": WikiSSNQDataset,
+    "DocMatixDataset": DocMatixDataset,
 }
 
 

--- a/nemo_automodel/components/datasets/llm/retrieval_dataset.py
+++ b/nemo_automodel/components/datasets/llm/retrieval_dataset.py
@@ -63,6 +63,31 @@ class TextQADataset(AbstractDataset):
         return sorted(list(self.docid2idx.keys()))
 
 
+class ColPaliDataset(AbstractDataset):
+    """Load ColPali corpus documents from a dataset path."""
+
+    def __init__(self, path):
+        self.path = path
+        self.data = load_dataset(path)["train"]
+        docid2idx = {}
+        for idx, docid in enumerate(self.data["image_filename"]):
+            docid2idx[str(docid)] = idx
+        self.docid2idx = docid2idx
+
+    def get_document_by_id(self, id):
+        example = deepcopy(EXAMPLE_TEMPLATE)
+        doc = self.data[self.docid2idx[id]]
+        example["image"] = doc["image"]
+        if "nr_ocr" in doc:
+            example["nr_ocr"] = doc["nr_ocr"]
+        if "complex_ocr" in doc:
+            example["complex_ocr"] = doc["complex_ocr"]
+        return example
+
+    def get_all_ids(self):
+        return sorted(list(self.docid2idx.keys()))
+
+
 class HFCorpusDataset(AbstractDataset):
     """Wraps an already-loaded HuggingFace Dataset as a corpus (in-memory, no local Parquet)."""
 
@@ -82,6 +107,7 @@ class HFCorpusDataset(AbstractDataset):
 
 DATASETS = {
     "TextQADataset": TextQADataset,
+    "ColPaliDataset": ColPaliDataset,
 }
 
 

--- a/nemo_automodel/components/datasets/llm/retrieval_dataset.py
+++ b/nemo_automodel/components/datasets/llm/retrieval_dataset.py
@@ -89,40 +89,45 @@ class ColPaliDataset(AbstractDataset):
 
 
 class WikiSSNQDataset(AbstractDataset):
+    """Load Wiki-SS corpus documents from a dataset path."""
+
     def __init__(self, path):
         self.path = path
-        self.data = load_dataset(path)['train']
+        self.data = load_dataset(path)["train"]
         docid2idx = {}
-        for idx, docid in enumerate(self.data['docid']):
+        for idx, docid in enumerate(self.data["docid"]):
             docid2idx[str(docid)] = idx
         self.docid2idx = docid2idx
 
     def get_document_by_id(self, id):
         example = deepcopy(EXAMPLE_TEMPLATE)
         doc = self.data[self.docid2idx[id]]
-        example['image'] = doc['image']
-        if 'nr_ocr' in doc:
-            example['nr_ocr'] = doc['nr_ocr']
-        if 'complex_ocr' in doc:
-            example['complex_ocr'] = doc['complex_ocr']
-        return(example)
-    
+        example["image"] = doc["image"]
+        if "nr_ocr" in doc:
+            example["nr_ocr"] = doc["nr_ocr"]
+        if "complex_ocr" in doc:
+            example["complex_ocr"] = doc["complex_ocr"]
+        return example
+
     def get_all_ids(self):
-        return(sorted(list(self.docid2idx.keys())))
+        return sorted(list(self.docid2idx.keys()))
+
 
 class DocMatixDataset(AbstractDataset):
+    """Load DocMatix corpus documents from a dataset path."""
+
     def __init__(self, path):
         self.path = path
-        self.data = load_dataset(path, 'images')['train']
+        self.data = load_dataset(path, "images")["train"]
 
     def get_document_by_id(self, id):
         example = deepcopy(EXAMPLE_TEMPLATE)
-        example_idx, image_idx = id.split('_')
-        example['image'] = self.data[int(example_idx)]['images'][int(image_idx)]
-        return(example)
-    
+        example_idx, image_idx = id.split("_")
+        example["image"] = self.data[int(example_idx)]["images"][int(image_idx)]
+        return example
+
     def get_all_ids(self):
-        return([str(x) + '_' + str(0) for x in list(range(len(self.data)))])
+        return [str(x) + "_" + str(0) for x in list(range(len(self.data)))]
 
 
 class HFCorpusDataset(AbstractDataset):

--- a/nemo_automodel/components/models/llama_nemotron_vl/__init__.py
+++ b/nemo_automodel/components/models/llama_nemotron_vl/__init__.py
@@ -1,0 +1,13 @@
+"""Eagle Llama Bidirectional model for embedding and retrieval tasks."""
+
+from nemo_automodel.components.models.llama_nemotron_vl.model import (
+    LlamaNemotronVLConfig,
+    LlamaNemotronVLModel,
+)
+from nemo_automodel.components.models.llama_nemotron_vl.processor import LlamaNemotronVLProcessor
+
+__all__ = [
+    "LlamaNemotronVLModel",
+    "LlamaNemotronVLConfig",
+    "LlamaNemotronVLProcessor",
+]

--- a/nemo_automodel/components/models/llama_nemotron_vl/__init__.py
+++ b/nemo_automodel/components/models/llama_nemotron_vl/__init__.py
@@ -1,4 +1,4 @@
-"""Eagle Llama Bidirectional model for embedding and retrieval tasks."""
+"""Llama Nemotron VL model for multimodal embedding and retrieval tasks."""
 
 from nemo_automodel.components.models.llama_nemotron_vl.model import (
     LlamaNemotronVLConfig,

--- a/nemo_automodel/components/models/llama_nemotron_vl/model.py
+++ b/nemo_automodel/components/models/llama_nemotron_vl/model.py
@@ -551,7 +551,7 @@ class LlamaNemotronVLModel(PreTrainedModel):
             input_embeds = input_embeds.reshape(B, N, C)
 
         elif self.training:
-            # If there is no image in the batch, adds a dummy image to the batch 
+            # If there is no image in the batch, adds a dummy image to the batch
             # to ensure multi-GPU synchronization when there are batches with only text samples and others with image samples
             image_size = self.config.force_image_size or self.config.vision_config.image_size
             dtype = next(self.vision_model.parameters()).dtype

--- a/nemo_automodel/components/models/llama_nemotron_vl/model.py
+++ b/nemo_automodel/components/models/llama_nemotron_vl/model.py
@@ -62,13 +62,6 @@ class LlamaNemotronVLConfig(PretrainedConfig):
     This serves as the foundation for LlamaNemotronVL configurations.
     """
 
-    @dataclass(frozen=True)
-    class ModelCapabilities:
-        supports_tp: bool = False
-        supports_cp: bool = False
-        supports_pp: bool = False
-        supports_ep: bool = False
-
     model_type = "llama_nemotron_vl"
     is_composition = True
     # is_composition was renamed to has_no_defaults_at_init in transformers 4.52.1
@@ -391,6 +384,15 @@ class LlamaNemotronVLModel(PreTrainedModel):
     Combines a vision encoder (SigLIP) with a bidirectional language model (LLaMA)
     for cross-modal reranking tasks.
     """
+
+    @dataclass(frozen=True)
+    class ModelCapabilities:
+        """Declared parallelism capabilities for this model class."""
+
+        supports_tp: bool = False
+        supports_cp: bool = False
+        supports_pp: bool = False
+        supports_ep: bool = False
 
     config_class = LlamaNemotronVLConfig
     main_input_name = "pixel_values"

--- a/nemo_automodel/components/models/llama_nemotron_vl/model.py
+++ b/nemo_automodel/components/models/llama_nemotron_vl/model.py
@@ -3,6 +3,7 @@
 
 import inspect
 import math
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
@@ -61,6 +62,13 @@ class LlamaNemotronVLConfig(PretrainedConfig):
     This serves as the foundation for LlamaNemotronVL configurations.
     """
 
+    @dataclass(frozen=True)
+    class ModelCapabilities:
+        supports_tp: bool = False
+        supports_cp: bool = False
+        supports_pp: bool = False
+        supports_ep: bool = False
+
     model_type = "llama_nemotron_vl"
     is_composition = True
     # is_composition was renamed to has_no_defaults_at_init in transformers 4.52.1
@@ -98,19 +106,13 @@ class LlamaNemotronVLConfig(PretrainedConfig):
         img_context_token_id: int = 128258,  # tokenizer.convert_tokens_to_ids("<IMG_CONTEXT>")
         **kwargs,
     ):
-        if vision_config is None:
-            vision_config = {}
-            logger.info("vision_config is None. Initializing Vision Encoders with default values.")
-        else:
+        if vision_config is not None:
             if vision_config["model_type"] == "siglip_vision_model":
                 self.vision_config = SiglipVisionConfig(**vision_config)
             else:
                 raise ValueError("Unsupported model_type: {}".format(vision_config["model_type"]))
 
-        if llm_config is None:
-            llm_config = {}
-            logger.info("llm_config is None. Initializing the LLM config with default values")
-        else:
+        if llm_config is not None:
             if llm_config["architectures"][0] in {
                 "LlamaBidirectionalModel",
                 "LlamaBidirectionalForSequenceClassification",

--- a/nemo_automodel/components/models/llama_nemotron_vl/model.py
+++ b/nemo_automodel/components/models/llama_nemotron_vl/model.py
@@ -1,0 +1,682 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0.
+
+import inspect
+import math
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import torch
+import torch.nn as nn
+import transformers
+from torch.nn import CrossEntropyLoss
+from transformers import AutoConfig, AutoProcessor, PreTrainedModel
+from transformers.cache_utils import Cache, DynamicCache
+from transformers.configuration_utils import PretrainedConfig
+from transformers.modeling_outputs import (
+    BaseModelOutputWithPast,
+    CausalLMOutputWithPast,
+)
+from transformers.models.llama.configuration_llama import LlamaConfig
+from transformers.models.llama.modeling_llama import (
+    LlamaDecoderLayer,
+    LlamaModel,
+)
+from transformers.models.siglip.configuration_siglip import SiglipVisionConfig
+from transformers.models.siglip.modeling_siglip import SiglipVisionModel
+from transformers.utils import logging
+
+logger = logging.get_logger(__name__)
+
+# ============================================================================
+# Bidirectional LLaMA Configuration
+# ============================================================================
+
+
+class LlamaBidirectionalConfig(LlamaConfig):
+    """Configuration for bidirectional (non-causal) LLaMA model."""
+
+    model_type = "llama_bidirec"
+
+    def __init__(
+        self,
+        pooling="avg",
+        temperature=1.0,
+        **kwargs,
+    ):
+        self.pooling = pooling
+        self.temperature = temperature
+        super().__init__(
+            **kwargs,
+        )
+
+
+# ============================================================================
+# LlamaNemotronVL Configuration Classes
+# ============================================================================
+
+
+class LlamaNemotronVLConfig(PretrainedConfig):
+    """
+    Base configuration for vision-language models combining vision and language components.
+    This serves as the foundation for LlamaNemotronVL configurations.
+    """
+
+    model_type = "llama_nemotron_vl"
+    is_composition = True
+    # is_composition was renamed to has_no_defaults_at_init in transformers 4.52.1
+    # In PR https://github.com/huggingface/transformers/pull/36263
+    has_no_defaults_at_init = True
+    # Declare sub-configs so transformers can propagate per-backbone attn_implementation
+    # e.g. from_pretrained(attn_implementation={"vision_config": "sdpa", "llm_config": "flash_attention_2"})
+    sub_configs = {"vision_config": SiglipVisionConfig, "llm_config": LlamaBidirectionalConfig}
+
+    def __init__(
+        self,
+        vision_config=None,
+        llm_config=None,
+        use_backbone_lora=0,
+        use_llm_lora=0,
+        select_layer=-1,
+        force_image_size=None,
+        downsample_ratio=0.5,
+        template=None,
+        dynamic_image_size=False,
+        use_thumbnail=False,
+        min_dynamic_patch=1,
+        max_dynamic_patch=6,
+        mlp_checkpoint=True,
+        pre_feature_reduction=False,
+        keep_aspect_ratio=False,
+        vocab_size=-1,
+        q_max_length: Optional[int] = 512,
+        p_max_length: Optional[int] = 10240,
+        query_prefix: str = "query:",
+        passage_prefix: str = "passage:",
+        pooling: str = "last",
+        bidirectional_attention: bool = False,
+        max_input_tiles: int = 2,
+        img_context_token_id: int = 128258,  # tokenizer.convert_tokens_to_ids("<IMG_CONTEXT>")
+        **kwargs,
+    ):
+        if vision_config is None:
+            vision_config = {}
+            logger.info("vision_config is None. Initializing Vision Encoders with default values.")
+        else:
+            if vision_config["model_type"] == "siglip_vision_model":
+                self.vision_config = SiglipVisionConfig(**vision_config)
+            else:
+                raise ValueError("Unsupported model_type: {}".format(vision_config["model_type"]))
+
+        if llm_config is None:
+            llm_config = {}
+            logger.info("llm_config is None. Initializing the LLM config with default values")
+        else:
+            if llm_config["architectures"][0] in {
+                "LlamaBidirectionalModel",
+                "LlamaBidirectionalForSequenceClassification",
+            }:
+                self.llm_config = LlamaBidirectionalConfig(**llm_config)
+            else:
+                raise ValueError("Unsupported architecture: {}".format(llm_config["architectures"][0]))
+            self.vocab_size = self.llm_config.vocab_size
+        self.use_backbone_lora = use_backbone_lora
+        self.use_llm_lora = use_llm_lora
+        self.select_layer = select_layer
+        self.force_image_size = force_image_size
+        self.downsample_ratio = downsample_ratio
+        self.template = template
+        self.dynamic_image_size = dynamic_image_size
+        self.use_thumbnail = use_thumbnail
+        self.min_dynamic_patch = min_dynamic_patch
+        self.max_dynamic_patch = max_dynamic_patch
+        self.mlp_checkpoint = mlp_checkpoint
+        self.pre_feature_reduction = pre_feature_reduction
+        self.keep_aspect_ratio = keep_aspect_ratio
+
+        self.q_max_length = q_max_length
+        self.p_max_length = p_max_length
+        self.query_prefix = query_prefix
+        self.passage_prefix = passage_prefix
+        self.pooling = pooling
+        self.bidirectional_attention = bidirectional_attention
+        self.img_context_token_id = img_context_token_id
+        self.max_input_tiles = max_input_tiles
+        super().__init__(**kwargs)
+
+
+# Check if native create_bidirectional_mask exists (transformers >= 5.0)
+try:
+    from transformers.masking_utils import create_bidirectional_mask
+
+    _HAS_NATIVE_BIDIRECTIONAL_MASK = True
+except ImportError:
+    from transformers.modeling_attn_mask_utils import _prepare_4d_attention_mask
+
+    _HAS_NATIVE_BIDIRECTIONAL_MASK = False
+
+# Detect API differences via introspection
+_decoder_forward_params = inspect.signature(LlamaDecoderLayer.forward).parameters
+_dynamic_cache_init_params = inspect.signature(DynamicCache.__init__).parameters
+
+# past_key_value (singular) in < 4.56, past_key_values (plural) in >= 4.56
+_USE_PLURAL_CACHE_PARAM = "past_key_values" in _decoder_forward_params
+# DynamicCache accepts config parameter in >= 4.56
+_DYNAMIC_CACHE_ACCEPTS_CONFIG = "config" in _dynamic_cache_init_params
+
+
+def split_model(model_path, device):
+    device_map = {}
+    world_size = torch.cuda.device_count()
+    config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
+    num_layers = config.llm_config.num_hidden_layers
+
+    print("world_size", world_size)
+    num_layers_per_gpu_ = math.floor(num_layers / (world_size - 1))
+    num_layers_per_gpu = [num_layers_per_gpu_] * world_size
+    num_layers_per_gpu[device] = num_layers - num_layers_per_gpu_ * (world_size - 1)
+    print(num_layers_per_gpu)
+    layer_cnt = 0
+    for i, num_layer in enumerate(num_layers_per_gpu):
+        for j in range(num_layer):
+            device_map[f"language_model.model.layers.{layer_cnt}"] = i
+            layer_cnt += 1
+    device_map["vision_model"] = device
+    device_map["mlp1"] = device
+    device_map["language_model.model.tok_embeddings"] = device
+    device_map["language_model.model.embed_tokens"] = device
+    device_map["language_model.output"] = device
+    device_map["language_model.model.norm"] = device
+    device_map["language_model.lm_head"] = device
+    device_map["language_model.model.rotary_emb"] = device
+    device_map[f"language_model.model.layers.{num_layers - 1}"] = device
+    return device_map
+
+
+def pool(last_hidden_states: torch.Tensor, attention_mask: torch.Tensor, pool_type: str) -> torch.Tensor:
+    last_hidden = last_hidden_states.masked_fill(~attention_mask[..., None].bool(), 0.0)
+
+    if pool_type == "avg":
+        emb = last_hidden.sum(dim=1) / attention_mask.sum(dim=1)[..., None]
+    elif pool_type == "weighted_avg":
+        emb = last_hidden.sum(dim=1)
+    elif pool_type == "cls":
+        emb = last_hidden[:, 0]
+    elif pool_type == "last":
+        left_padding = attention_mask[:, -1].sum() == attention_mask.shape[0]
+        if left_padding:
+            emb = last_hidden[:, -1]
+        else:
+            sequence_lengths = attention_mask.sum(dim=1) - 1
+            batch_size = last_hidden.shape[0]
+            emb = last_hidden[torch.arange(batch_size, device=last_hidden.device), sequence_lengths]
+    elif pool_type == "cls_last":
+        emb = last_hidden[:, 0]
+    elif pool_type == "colbert":
+        emb = last_hidden
+    else:
+        raise ValueError(f"pool_type {pool_type} not supported")
+
+    return emb
+
+
+# ============================================================================
+# Bidirectional LLaMA Model
+# ============================================================================
+
+
+class LlamaBidirectionalModel(LlamaModel):
+    """
+    LlamaModel modified to use bidirectional (non-causal) attention.
+    Supports transformers 4.44+ through 5.x with a unified forward() implementation.
+    See https://huggingface.co/nvidia/llama-nemotron-embed-1b-v2 for version notes.
+    """
+
+    config_class = LlamaBidirectionalConfig
+
+    def __init__(self, config: LlamaBidirectionalConfig):
+        super().__init__(config)
+        for layer in self.layers:
+            layer.self_attn.is_causal = False
+
+    def _create_bidirectional_mask(
+        self,
+        input_embeds: torch.Tensor,
+        attention_mask: torch.Tensor | None,
+    ) -> torch.Tensor | None:
+        if attention_mask is None:
+            return None
+
+        if _HAS_NATIVE_BIDIRECTIONAL_MASK:
+            return create_bidirectional_mask(
+                self.config,
+                input_embeds,
+                attention_mask=attention_mask,
+            )
+
+        # Fallback for transformers < 5.0
+        if getattr(self.config, "_attn_implementation", None) == "flash_attention_2":
+            has_masked_tokens = (attention_mask == 0).any()
+            return attention_mask if has_masked_tokens else None
+
+        return _prepare_4d_attention_mask(attention_mask, input_embeds.dtype)
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        past_key_values: Cache | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        cache_position: torch.LongTensor | None = None,
+        use_cache: bool | None = None,
+        output_hidden_states: bool | None = None,
+        **kwargs,
+    ) -> BaseModelOutputWithPast:
+        if (input_ids is None) ^ (inputs_embeds is not None):
+            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        # Initialize cache if needed
+        if use_cache and past_key_values is None:
+            if _DYNAMIC_CACHE_ACCEPTS_CONFIG:
+                past_key_values = DynamicCache(config=self.config)
+            else:
+                past_key_values = DynamicCache()
+
+        if cache_position is None:
+            past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
+            cache_position = torch.arange(
+                past_seen_tokens,
+                past_seen_tokens + inputs_embeds.shape[1],
+                device=inputs_embeds.device,
+            )
+
+        if position_ids is None:
+            position_ids = cache_position.unsqueeze(0)
+
+        bidirectional_mask = self._create_bidirectional_mask(inputs_embeds, attention_mask)
+
+        hidden_states = inputs_embeds
+        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+
+        all_hidden_states = () if output_hidden_states else None
+
+        # Build decoder layer kwargs with correct cache parameter name
+        layer_kwargs = {
+            "attention_mask": bidirectional_mask,
+            "position_ids": position_ids,
+            "use_cache": use_cache,
+            "cache_position": cache_position,
+            "position_embeddings": position_embeddings,
+        }
+        if _USE_PLURAL_CACHE_PARAM:
+            layer_kwargs["past_key_values"] = past_key_values
+        else:
+            layer_kwargs["past_key_value"] = past_key_values
+
+        for decoder_layer in self.layers[: self.config.num_hidden_layers]:
+            if output_hidden_states:
+                all_hidden_states += (hidden_states,)
+
+            layer_outputs = decoder_layer(hidden_states, **layer_kwargs)
+
+            # Decoder returns tuple in < 4.54, tensor in >= 4.54
+            if isinstance(layer_outputs, tuple):
+                hidden_states = layer_outputs[0]
+            else:
+                hidden_states = layer_outputs
+
+        hidden_states = self.norm(hidden_states)
+
+        if output_hidden_states:
+            all_hidden_states += (hidden_states,)
+
+        return BaseModelOutputWithPast(
+            last_hidden_state=hidden_states,
+            past_key_values=past_key_values,
+            hidden_states=all_hidden_states,
+        )
+
+
+# ============================================================================
+# LlamaNemotronVL Model Classes
+# ============================================================================
+
+
+class LlamaNemotronVLModel(PreTrainedModel):
+    """
+    LlamaNemotron VL model for vision-language reranking.
+    Combines a vision encoder (SigLIP) with a bidirectional language model (LLaMA)
+    for cross-modal reranking tasks.
+    """
+
+    config_class = LlamaNemotronVLConfig
+    main_input_name = "pixel_values"
+    _no_split_modules = ["LlamaDecoderLayer"]
+    _supports_flash_attn_2 = True  # transformers < 4.54
+    _supports_flash_attn = True  # transformers >= 4.54
+    _supports_sdpa = True
+
+    def __init__(
+        self,
+        config: LlamaNemotronVLConfig,
+        vision_model: Optional[PreTrainedModel] = None,
+        language_model: Optional[PreTrainedModel] = None,
+    ):
+        super().__init__(config)
+
+        # Propagate attn_implementation to sub-configs for transformers < 4.56
+        # which lacks set_attn_implementation. In 4.56+, set_attn_implementation
+        # handles this automatically using the sub_configs declared on the config class.
+        if not hasattr(PreTrainedModel, "set_attn_implementation"):
+            parent_attn = getattr(config, "_attn_implementation", None)
+            if parent_attn is not None:
+                for sub_config in (config.vision_config, config.llm_config):
+                    if getattr(sub_config, "_attn_implementation_autoset", False):
+                        sub_config._attn_implementation = parent_attn
+                        sub_config._attn_implementation_autoset = False
+
+        # Calculate image token count
+        image_size = config.force_image_size or config.vision_config.image_size
+        if hasattr(config.vision_config, "grid_size"):
+            grid_size = config.vision_config.grid_size
+            self.patch_size = 14
+            self.num_image_token = int((grid_size * config.downsample_ratio) ** 2)
+        else:
+            patch_size = config.vision_config.patch_size
+            self.patch_size = patch_size
+            self.num_image_token = int((image_size // patch_size) ** 2 * (config.downsample_ratio**2))
+
+        self.select_layer = config.select_layer
+        self.template = config.template
+        self.downsample_ratio = config.downsample_ratio
+
+        logger.info(f"num_image_token: {self.num_image_token}")
+        if vision_model is not None:
+            self.vision_model = vision_model
+        else:
+            if config.vision_config.model_type == "siglip_vision_model":
+                self.vision_model = SiglipVisionModel(config.vision_config)
+            else:
+                raise NotImplementedError(f"Unsupported vision model type: {config.vision_config.model_type}")
+
+        if language_model is not None:
+            self.language_model = language_model
+        else:
+            if config.llm_config.architectures[0] == "LlamaBidirectionalModel":
+                self.language_model = LlamaBidirectionalModel(config.llm_config)
+            else:
+                raise NotImplementedError(f"{config.llm_config.architectures[0]} is not implemented.")
+
+        # Vision-to-language projection
+        vit_hidden_size = config.vision_config.hidden_size
+        llm_hidden_size = config.llm_config.hidden_size
+        self.mlp1 = nn.Sequential(
+            nn.LayerNorm(vit_hidden_size * int(1 / self.downsample_ratio) ** 2),
+            nn.Linear(
+                vit_hidden_size * int(1 / self.downsample_ratio) ** 2,
+                llm_hidden_size,
+            ),
+            nn.GELU(),
+            nn.Linear(llm_hidden_size, llm_hidden_size),
+        )
+        self.img_context_token_id = None
+
+        # Initialize processor
+        self.processor = AutoProcessor.from_pretrained(config.name_or_path, trust_remote_code=True)
+
+        self.post_init()
+
+        # transformers 4.54.0-4.55.x have a bug in the flash attention
+        # infrastructure where a parameter name mismatch ('implementation' vs
+        # 'attn_implementation') in _flash_attention_forward causes FA3 pad/unpad
+        # functions to be used with FA2 attention kernels, producing nondeterministic
+        # and numerically different results for batched vision+text sequences.
+        # This was fixed in 4.56.0.
+        from packaging.version import Version
+
+        _tv = Version(transformers.__version__)
+        if Version("4.54.0") <= _tv < Version("4.56.0"):
+            raise RuntimeError(
+                f"transformers {transformers.__version__} is not supported by this model. "
+                f"Versions 4.54.0-4.55.x have a flash attention bug that produces "
+                f"nondeterministic and incorrect image embeddings. "
+                f"Please use transformers <=4.53.x or >=4.56.0."
+            )
+
+    def _embed_batch(self, inputs: Dict[str, Any], pool_type: Optional[str] = None):
+        """
+        Encodes the inputs into a tensor of embeddings.
+        Args:
+            inputs: A dictionary of inputs to the model. You can prepare the inputs using the processor.process_queries and processor.process_documents methods.
+            pool_type: The type of pooling to use. If None, the pooling type is set to the pooling type configured in the model.
+        Returns:
+            A tensor of embeddings.
+        """
+        inputs = {k: v.to(self.device) if isinstance(v, torch.Tensor) else v for k, v in inputs.items()}
+
+        outputs = self.forward(**inputs, output_hidden_states=True, return_dict=True)
+        if not pool_type:
+            pool_type = self.config.pooling
+        embeddings = pool(
+            last_hidden_states=outputs.hidden_states[-1], attention_mask=inputs["attention_mask"], pool_type=pool_type
+        )
+        return embeddings
+
+    def encode_queries(self, queries: List[str], **kwargs):
+        """
+        Encodes the input queries into a tensor of embeddings.
+        Args:
+            queries: A list of queries.
+        Returns:
+            A tensor of embeddings.
+        """
+        queries_dict = self.processor.process_queries(queries)
+        queries_embeddings = self._embed_batch(inputs=queries_dict, **kwargs)
+        return queries_embeddings
+
+    def encode_documents(self, images: Optional[List[Any]] = None, texts: Optional[List[str]] = None, **kwargs):
+        """
+        Encodes the input document images and texts into a tensor of embeddings.
+        Args:
+            images: A list of PIL.Image of document pages images.
+            texts: A list of document page texts.
+        Returns:
+            A tensor of embeddings.
+        """
+        if images and texts:
+            examples = [{"image": image, "text": doc_text} for image, doc_text in zip(images, texts)]
+
+        elif images:
+            examples = [{"image": image, "text": ""} for image in images]
+
+        elif texts:
+            examples = [{"image": "", "text": doc_text} for doc_text in texts]
+        else:
+            raise ValueError("At least docs_images or docs_texts need to be provided")
+
+        docs_dict = self.processor.process_documents(examples)
+        docs_embeddings = self._embed_batch(inputs=docs_dict, **kwargs)
+        return docs_embeddings
+
+    def forward(
+        self,
+        pixel_values: torch.FloatTensor = None,
+        input_ids: torch.LongTensor = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        image_flags: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[List[torch.FloatTensor]] = None,
+        labels: Optional[torch.LongTensor] = None,
+        use_cache: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+        num_patches_list: Optional[List[torch.Tensor]] = None,
+    ) -> Union[Tuple, CausalLMOutputWithPast]:
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+        # Get text embeddings
+        input_embeds = self.language_model.get_input_embeddings()(input_ids)
+
+        # Process and inject vision embeddings if present
+        if pixel_values is not None:
+            if image_flags is None:
+                image_flags = torch.ones(pixel_values.shape[0])
+            image_flags = image_flags.squeeze(-1)
+            vit_embeds = self.extract_feature(pixel_values).to(device=input_embeds.device)
+
+            if not isinstance(image_flags, list):
+                image_flags = image_flags.squeeze(-1)
+                vit_embeds = vit_embeds[image_flags == 1]
+
+            # Inject vision tokens into text embeddings
+            B, N, C = input_embeds.shape
+            input_embeds = input_embeds.reshape(B * N, C)
+            input_ids = input_ids.reshape(B * N)
+            selected = (input_ids == self.config.img_context_token_id).to(input_embeds.device)
+            try:
+                input_embeds[selected] = input_embeds[selected] * 0.0 + vit_embeds.reshape(-1, C)
+            except Exception as e:
+                vit_embeds = vit_embeds.reshape(-1, C)
+                print(
+                    f"warning: {e}, input_embeds[selected].shape={input_embeds[selected].shape}, "
+                    f"vit_embeds.shape={vit_embeds.shape}"
+                )
+                n_token = selected.sum()
+                input_embeds[selected] = input_embeds[selected] * 0.0 + vit_embeds[:n_token]
+
+            input_embeds = input_embeds.reshape(B, N, C)
+
+        # Forward through language model
+        outputs = self.language_model(
+            inputs_embeds=input_embeds,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+        )
+        logits = None
+        loss = None
+
+        if hasattr(outputs, "logits"):
+            logits = outputs.logits
+            if labels is not None:
+                # Shift so that tokens < n predict n
+                shift_logits = logits[..., :-1, :].contiguous()
+                shift_labels = labels[..., 1:].contiguous()
+                # Flatten the tokens
+                loss_fct = CrossEntropyLoss()
+                shift_logits = shift_logits.view(-1, self.language_model.config.vocab_size)
+                shift_labels = shift_labels.view(-1)
+                # Enable model parallelism
+                shift_labels = shift_labels.to(shift_logits.device)
+                loss = loss_fct(shift_logits, shift_labels)
+
+        if not return_dict:
+            output = (logits,) + outputs[1:]
+            return (loss,) + output if loss is not None else output
+
+        return CausalLMOutputWithPast(
+            loss=loss,
+            logits=logits,
+            past_key_values=outputs.past_key_values,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+        )
+
+    def pixel_shuffle(self, x, scale_factor=0.5):
+        n, w, h, c = x.shape
+        # N, W, H, C --> N, W, H * scale, C // scale
+        x = x.view(n, w, int(h * scale_factor), int(c / scale_factor))
+        # N, W, H * scale, C // scale --> N, H * scale, W, C // scale
+        x = x.permute(0, 2, 1, 3).contiguous()
+        # N, H * scale, W, C // scale --> N, H * scale, W * scale, C // (scale ** 2)
+        x = x.view(
+            n,
+            int(h * scale_factor),
+            int(w * scale_factor),
+            int(c / (scale_factor * scale_factor)),
+        )
+        x = x.permute(0, 2, 1, 3).contiguous()
+        return x
+
+    def extract_feature(self, pixel_values):
+        """Extract and project vision features to language model space."""
+        # Extract features from vision encoder
+        if self.select_layer == -1:
+            vit_embeds = self.vision_model(pixel_values=pixel_values, output_hidden_states=False, return_dict=True)
+            if hasattr(vit_embeds, "last_hidden_state"):
+                vit_embeds = vit_embeds.last_hidden_state
+        else:
+            vit_embeds = self.vision_model(
+                pixel_values=pixel_values, output_hidden_states=True, return_dict=True
+            ).hidden_states[self.select_layer]
+
+        # Remove CLS token if not using SigLIP
+        if not isinstance(self.vision_model, SiglipVisionModel):
+            vit_embeds = vit_embeds[:, 1:, :]
+
+        # Apply pixel shuffle and MLP projection
+        _, n, c = vit_embeds.shape
+        h = w = int(n**0.5)
+        vit_embeds = vit_embeds.reshape(-1, h, w, c)  # (B, H, W, C)
+        vit_embeds = self.pixel_shuffle(vit_embeds, scale_factor=self.downsample_ratio)  # (B, H/s, W/s, C*s*s)
+        _, h_s, w_s, c_s = vit_embeds.shape
+        vit_embeds = vit_embeds.reshape(-1, h_s * w_s, c_s)  # (B, (H/s)*(W/s), C*s*s)
+        vit_embeds = self.mlp1(vit_embeds)
+
+        return vit_embeds
+
+    def get_input_embeddings(self):
+        return self.language_model.get_input_embeddings()
+
+    def get_output_embeddings(self):
+        return self.language_model.get_output_embeddings()
+
+    def build_collator(self, processor=None, **kwargs):
+        return processor or self.processor
+
+    def post_loss(self, loss, inputs):
+        # Add Dummy Gradients for Vision Encoder to ensure multi-GPU synchronization when there are batches with only text samples
+        # and other batches with images.
+        if "pixel_values" in inputs and inputs["pixel_values"] is None:
+            dummy_pixels = torch.zeros(1, 3, 512, 512, device=loss.device, dtype=self.vision_model.dtype)
+            dummy_output = self.extract_feature(dummy_pixels)
+            loss = loss + dummy_output.sum() * 0.0
+        return loss
+
+
+# Export for ModelRegistry auto-discovery
+ModelClass = [LlamaNemotronVLModel]
+
+
+def _register_with_hf_auto_classes():
+    """Register bidirectional models with HuggingFace Auto classes.
+
+    This is needed so that AutoModel.from_config(LlamaBidirectionalConfig)
+    works inside LlamaForSequenceClassification.__init__.
+    """
+    from transformers import AutoConfig, AutoModel
+
+    try:
+        AutoConfig.register(LlamaNemotronVLConfig.model_type, LlamaNemotronVLConfig)
+    except ValueError:
+        pass  # Already registered
+    try:
+        AutoModel.register(LlamaNemotronVLConfig, LlamaNemotronVLModel)
+    except ValueError:
+        pass  # Already registered
+
+
+_register_with_hf_auto_classes()
+
+__all__ = [
+    "LlamaNemotronVLModel",
+    "LlamaNemotronVLConfig",
+    "ModelClass",
+]

--- a/nemo_automodel/components/models/llama_nemotron_vl/model.py
+++ b/nemo_automodel/components/models/llama_nemotron_vl/model.py
@@ -550,6 +550,15 @@ class LlamaNemotronVLModel(PreTrainedModel):
 
             input_embeds = input_embeds.reshape(B, N, C)
 
+        elif self.training:
+            # If there is no image in the batch, adds a dummy image to the batch 
+            # to ensure multi-GPU synchronization when there are batches with only text samples and others with image samples
+            image_size = self.config.force_image_size or self.config.vision_config.image_size
+            dtype = next(self.vision_model.parameters()).dtype
+            dummy_pixels = torch.zeros(1, 3, image_size, image_size, device=input_embeds.device, dtype=dtype)
+            dummy_output = self.extract_feature(dummy_pixels)
+            input_embeds = input_embeds + dummy_output.sum().to(input_embeds.dtype) * 0.0
+
         # Forward through language model
         outputs = self.language_model(
             inputs_embeds=input_embeds,

--- a/nemo_automodel/components/models/llama_nemotron_vl/model.py
+++ b/nemo_automodel/components/models/llama_nemotron_vl/model.py
@@ -219,6 +219,44 @@ def pool(last_hidden_states: torch.Tensor, attention_mask: torch.Tensor, pool_ty
     return emb
 
 
+def _replace_image_token_embeddings(
+    input_embeds: torch.Tensor,
+    input_ids: torch.Tensor,
+    vit_embeds: torch.Tensor,
+    img_context_token_id: int,
+) -> torch.Tensor:
+    """Replace image placeholder token embeddings with vision embeddings."""
+    batch_size, seq_len, hidden_size = input_embeds.shape
+    flat_embeds = input_embeds.reshape(batch_size * seq_len, hidden_size)
+    flat_input_ids = input_ids.reshape(batch_size * seq_len)
+    selected_indices = (flat_input_ids == img_context_token_id).nonzero(as_tuple=False).squeeze(1)
+    vit_embeds = vit_embeds.reshape(-1, hidden_size).to(dtype=flat_embeds.dtype)
+
+    n_token = selected_indices.numel()
+    if n_token != vit_embeds.shape[0]:
+        logger.warning(
+            "image token count mismatch: selected=%s, vit_embeds=%s; truncating vision embeddings",
+            n_token,
+            vit_embeds.shape,
+        )
+        vit_embeds = vit_embeds[:n_token]
+
+    flat_embeds = flat_embeds.index_copy(0, selected_indices, vit_embeds)
+    return flat_embeds.reshape(batch_size, seq_len, hidden_size)
+
+
+def _filter_vision_embeddings_by_image_flags(
+    vit_embeds: torch.Tensor,
+    image_flags: Optional[torch.Tensor],
+) -> torch.Tensor:
+    """Keep only vision embeddings marked as real images."""
+    if image_flags is None or isinstance(image_flags, list):
+        return vit_embeds
+
+    image_flags = image_flags.squeeze(-1)
+    return vit_embeds[image_flags == 1]
+
+
 # ============================================================================
 # Bidirectional LLaMA Model
 # ============================================================================
@@ -515,6 +553,7 @@ class LlamaNemotronVLModel(PreTrainedModel):
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         num_patches_list: Optional[List[torch.Tensor]] = None,
+        run_dummy_vision: Optional[bool] = None,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
@@ -523,34 +562,17 @@ class LlamaNemotronVLModel(PreTrainedModel):
 
         # Process and inject vision embeddings if present
         if pixel_values is not None:
-            if image_flags is None:
-                image_flags = torch.ones(pixel_values.shape[0])
-            image_flags = image_flags.squeeze(-1)
             vit_embeds = self.extract_feature(pixel_values).to(device=input_embeds.device)
+            vit_embeds = _filter_vision_embeddings_by_image_flags(vit_embeds, image_flags)
 
-            if not isinstance(image_flags, list):
-                image_flags = image_flags.squeeze(-1)
-                vit_embeds = vit_embeds[image_flags == 1]
+            input_embeds = _replace_image_token_embeddings(
+                input_embeds,
+                input_ids,
+                vit_embeds,
+                self.config.img_context_token_id,
+            )
 
-            # Inject vision tokens into text embeddings
-            B, N, C = input_embeds.shape
-            input_embeds = input_embeds.reshape(B * N, C)
-            input_ids = input_ids.reshape(B * N)
-            selected = (input_ids == self.config.img_context_token_id).to(input_embeds.device)
-            try:
-                input_embeds[selected] = input_embeds[selected] * 0.0 + vit_embeds.reshape(-1, C)
-            except Exception as e:
-                vit_embeds = vit_embeds.reshape(-1, C)
-                print(
-                    f"warning: {e}, input_embeds[selected].shape={input_embeds[selected].shape}, "
-                    f"vit_embeds.shape={vit_embeds.shape}"
-                )
-                n_token = selected.sum()
-                input_embeds[selected] = input_embeds[selected] * 0.0 + vit_embeds[:n_token]
-
-            input_embeds = input_embeds.reshape(B, N, C)
-
-        elif self.training:
+        elif self.training and run_dummy_vision is not False:
             # If there is no image in the batch, adds a dummy image to the batch
             # to ensure multi-GPU synchronization when there are batches with only text samples and others with image samples
             image_size = self.config.force_image_size or self.config.vision_config.image_size

--- a/nemo_automodel/components/models/llama_nemotron_vl/processor.py
+++ b/nemo_automodel/components/models/llama_nemotron_vl/processor.py
@@ -1,0 +1,530 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0.
+
+import base64
+import dataclasses
+import os
+from dataclasses import field
+from io import BytesIO
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
+
+import requests
+import torch
+import torchvision.transforms as T
+from PIL import Image
+from torchvision.transforms.functional import InterpolationMode
+from transformers import BatchEncoding, ProcessorMixin
+
+IMAGENET_MEAN = (0.485, 0.456, 0.406)
+IMAGENET_STD = (0.229, 0.224, 0.225)
+
+SIGLIP_MEAN = (0.5, 0.5, 0.5)
+SIGLIP_STD = (0.5, 0.5, 0.5)
+
+
+@dataclasses.dataclass
+class Conversation:
+    """Manages prompt construction with system messages and multi-turn dialogues."""
+
+    # System instruction prepended to prompts
+    system_message: str = ""
+    # Role identifiers for dialogue turns
+    roles: Tuple[str, str] = ("", "")
+    # Message history as (role, content) pairs
+    messages: List[List[str]] = field(default_factory=list)
+    # Separator token between messages
+    sep: str = ""
+    # Token IDs that trigger generation stopping
+    stop_token_ids: List[int] = None
+
+    def get_prompt(self) -> str:
+        """Construct the formatted prompt string from system message and dialogue history."""
+        ret = self.system_message + self.sep
+        for role, message in self.messages:
+            if message:
+                ret += role + message + self.sep
+            else:
+                ret += role
+        return ret
+
+    def append_message(self, role: str, message: str):
+        """Add a message turn to the dialogue history."""
+        self.messages.append([role, message])
+
+
+def get_conv_template(name: str) -> Conversation:
+    """Initialize a conversation instance with default configuration."""
+    return Conversation(
+        stop_token_ids=[128259, 128001],
+    )
+
+
+def load_image(image):
+    """Load an image from a file, a URL, a base64 string, or a bytes object."""
+    if isinstance(image, Image.Image):
+        return image
+    elif isinstance(image, str) and os.path.exists(image):
+        return Image.open(image)
+    elif isinstance(image, dict):
+        if "disk_path" in image:
+            return Image.open(image["disk_path"])
+        elif "base64" in image:
+            return Image.open(BytesIO(base64.b64decode(image["base64"])))
+        elif "url" in image:
+            response = requests.get(image["url"])
+            return Image.open(BytesIO(response.content))
+        elif "bytes" in image:
+            return Image.open(BytesIO(image["bytes"]))
+        else:
+            raise ValueError(f"Invalid image: {image}")
+    else:
+        raise ValueError(f"Invalid image: {image}")
+
+
+def build_transform(input_size, norm_type="imagenet"):
+    """Build a transform for an image."""
+    if norm_type == "imagenet":
+        MEAN, STD = IMAGENET_MEAN, IMAGENET_STD
+    elif norm_type == "siglip":
+        MEAN, STD = SIGLIP_MEAN, SIGLIP_STD
+
+    transform = T.Compose(
+        [
+            T.Lambda(lambda img: img.convert("RGB") if img.mode != "RGB" else img),
+            T.Resize((input_size, input_size), interpolation=InterpolationMode.BICUBIC),
+            T.ToTensor(),
+            T.Normalize(mean=MEAN, std=STD),
+        ]
+    )
+    return transform
+
+
+def find_closest_aspect_ratio(aspect_ratio, target_ratios, width, height, image_size):
+    """
+    previous version mainly foucs on ratio.
+    We also consider area ratio here.
+    """
+    best_factor = float("-inf")
+    best_ratio = (1, 1)
+    area = width * height
+    for ratio in target_ratios:
+        target_aspect_ratio = ratio[0] / ratio[1]
+        area_ratio = (ratio[0] * ratio[1] * image_size * image_size) / area
+        # new area > 60% of original image area is enough.
+        factor_based_on_area_n_ratio = min(area_ratio, 0.6) * min(
+            target_aspect_ratio / aspect_ratio, aspect_ratio / target_aspect_ratio
+        )
+
+        if factor_based_on_area_n_ratio > best_factor:
+            best_factor = factor_based_on_area_n_ratio
+            best_ratio = ratio
+
+    return best_ratio
+
+
+def dynamic_preprocess(image, min_num=1, max_num=6, image_size=448, use_thumbnail=False):
+    """Dynamically preprocess an image into a list of image tiles, with a thumbnail if needed."""
+    orig_width, orig_height = image.size
+    aspect_ratio = orig_width / orig_height
+
+    # calculate the existing image aspect ratio
+    target_ratios = set(
+        (i, j)
+        for n in range(min_num, max_num + 1)
+        for i in range(1, n + 1)
+        for j in range(1, n + 1)
+        if i * j <= max_num and i * j >= min_num
+    )
+    target_ratios = sorted(target_ratios, key=lambda x: x[0] * x[1])
+
+    # find the closest aspect ratio to the target
+    target_aspect_ratio = find_closest_aspect_ratio(aspect_ratio, target_ratios, orig_width, orig_height, image_size)
+
+    # calculate the target width and height
+    target_width = image_size * target_aspect_ratio[0]
+    target_height = image_size * target_aspect_ratio[1]
+    blocks = target_aspect_ratio[0] * target_aspect_ratio[1]
+
+    # resize the image
+    resized_img = image.resize((target_width, target_height))
+    processed_images = []
+    for i in range(blocks):
+        box = (
+            (i % (target_width // image_size)) * image_size,
+            (i // (target_width // image_size)) * image_size,
+            ((i % (target_width // image_size)) + 1) * image_size,
+            ((i // (target_width // image_size)) + 1) * image_size,
+        )
+        # split the image
+        split_img = resized_img.crop(box)
+        processed_images.append(split_img)
+    assert len(processed_images) == blocks
+    if use_thumbnail and len(processed_images) != 1:
+        thumbnail_img = image.resize((image_size, image_size))
+        processed_images.append(thumbnail_img)
+    return processed_images
+
+
+class LlamaNemotronVLProcessor(ProcessorMixin):
+    """Processor for LlamaNemotronVL model."""
+
+    attributes = ["tokenizer"]
+    tokenizer_class = "AutoTokenizer"
+
+    def __init__(
+        self,
+        tokenizer: Any,
+        q_max_length: Optional[int] = None,
+        p_max_length: Optional[int] = None,
+        pad_to_multiple_of: Optional[int] = None,
+        query_prefix: str = "query:",
+        passage_prefix: str = "passage:",
+        max_input_tiles: int = 6,
+        num_image_token: int = 128258,
+        dynamic_image_size: bool = True,
+        image_size: int = 512,
+        use_thumbnail: bool = True,
+        template: str = "bidirectional-llama-retriever",
+        num_channels: int = 3,
+        norm_type: str = "siglip",
+        system_message: str = "",
+        padding: Union[bool, str] = True,
+        **kwargs,
+    ):
+        tokenizer.padding_side = "left"
+        tokenizer.model_input_names = tokenizer.model_input_names + ["pixel_values"]
+        self.tokenizer = tokenizer
+
+        self.q_max_length = q_max_length
+        self.p_max_length = p_max_length
+        self.pad_to_multiple_of = pad_to_multiple_of
+        self.query_prefix = query_prefix
+        self.passage_prefix = passage_prefix
+        self.max_input_tiles = max_input_tiles
+        self.num_image_token = num_image_token
+        self.dynamic_image_size = dynamic_image_size
+        self.image_size = image_size
+        self.use_thumbnail = use_thumbnail
+        self.template = template
+        self.num_channels = num_channels
+        self.norm_type = norm_type
+        self.system_message = system_message
+        self.padding = padding
+
+        super().__init__(self.tokenizer)
+
+    def __call__(
+        self,
+        text: Optional[List[str]] = None,
+        images: Optional[List[Any]] = None,
+        text_kwargs: Optional[Dict[str, Any]] = None,
+        images_kwargs: Optional[Dict[str, Any]] = None,
+        common_kwargs: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> Dict[str, Any]:
+        """Process text and/or image inputs into model-ready features.
+        This method provides compatibility with the standard HuggingFace processor interface
+        used by Sentence Transformers. For image inputs, it delegates to process_documents.
+        For text-only inputs, it tokenizes directly (assuming any task prefix has already been
+        applied by the caller).
+        Args:
+            text: List of text strings. For text-only inputs, these should already include
+                any task prefix (e.g. "query: " or "passage: ").
+            images: List of PIL Images for document encoding.
+            text_kwargs: Keyword arguments for text processing (e.g. padding, truncation).
+            images_kwargs: Keyword arguments for image processing (unused, for API compat).
+            common_kwargs: Common keyword arguments (e.g. return_tensors).
+            **kwargs: Additional keyword arguments (ignored).
+        Returns:
+            Dict with "input_ids", "attention_mask", and optionally "pixel_values".
+        """
+        text_kwargs = text_kwargs or {}
+        common_kwargs = common_kwargs or {}
+        tokenizer_kwargs = {**common_kwargs, **text_kwargs}
+        return_tensors = tokenizer_kwargs.pop("return_tensors", "pt")
+        padding = tokenizer_kwargs.pop("padding", self.padding)
+        truncation = tokenizer_kwargs.pop("truncation", True)
+
+        if images is not None:
+            # Image or image+text: delegate to process_documents which handles
+            # image tiling, image token creation, and the passage prefix.
+            if text is not None:
+                documents = [{"image": img, "text": t} for img, t in zip(images, text)]
+            else:
+                documents = [{"image": img, "text": ""} for img in images]
+            return self.process_documents(
+                documents,
+                return_tensors=return_tensors,
+                padding=padding,
+                truncation=truncation,
+            )
+
+        # Text-only: just tokenize (the caller has already applied any prompt prefix)
+        max_length = None
+        if truncation:
+            max_length = self.p_max_length or self.tokenizer.model_max_length
+        return self.tokenizer(
+            text,
+            padding=padding,
+            truncation=truncation,
+            max_length=max_length,
+            pad_to_multiple_of=self.pad_to_multiple_of,
+            return_tensors=return_tensors,
+        )
+
+    def process_documents(
+        self,
+        documents: Union[Dict, List[Dict]],
+        return_tensors: Literal["pt", "np"] = "pt",
+        padding: bool | str | None = None,
+        truncation: bool = True,
+        pixel_values_layout: Literal["per_image", "flat_tiles"] = "flat_tiles",
+        **kwargs,
+    ) -> Dict[str, Any]:
+        """Process documents into model inputs with tokenized text and pixel values.
+        Args:
+            documents: Either a dict with "images" and "texts" lists, or a list of
+                dicts each with "image" and "text" keys. Images can be PIL Images,
+                file paths, or None/empty string for text-only documents.
+            return_tensors: Output format — "pt" for PyTorch tensors, "np" for numpy arrays.
+            padding: Padding strategy passed to the tokenizer. Defaults to the value
+                set in the processor constructor.
+            truncation: Whether to truncate sequences to p_max_length.
+            pixel_values_layout: How to structure the pixel values output:
+                - "flat_tiles": All image tiles concatenated into a single tensor of shape
+                  (total_tiles, C, H, W). Different images may contribute different numbers
+                  of tiles. None if no images are present. This is the format expected by
+                  the model's forward() method.
+                - "per_image": A list aligned with the input documents, where each entry
+                  is either a tensor of shape (num_tiles, C, H, W) or None.
+        Returns:
+            Dict with "input_ids", "attention_mask", and "pixel_values".
+        """
+        if return_tensors not in ("pt", "np"):
+            raise ValueError(f"Invalid return_tensors: {return_tensors!r}. Must be 'pt' or 'np'.")
+
+        if isinstance(documents, dict):
+            images = documents["images"]
+            texts = documents["texts"]
+            assert len(texts) == len(images)
+        elif isinstance(documents, list):
+            images = [pair["image"] for pair in documents]
+            texts = [pair["text"] for pair in documents]
+        else:
+            raise ValueError("The documents need to be a dict or list of dicts")
+
+        contents = []
+        pil_images_by_idx = {}
+        max_input_tile_by_idx = {}
+        for idx, (image, text) in enumerate(zip(images, texts)):
+            prefix = ""
+            if image is not None and image != "":
+                pil_images_by_idx[idx] = load_image(image)
+                prefix = "<image>"
+                max_input_tile_by_idx[idx] = self.max_input_tiles
+
+            # ToDo: Order is hardcoded and different than before. No \n after <image>
+            content = text
+            if prefix != "":
+                content = prefix + " " + content
+            if self.passage_prefix:
+                content = self.passage_prefix + " " + content
+            contents.append(content)
+
+        assert len(max_input_tile_by_idx) == len(pil_images_by_idx), (
+            "The number of max_input_tile_by_idx and pil_images_by_idx should be the same."
+        )
+
+        transform = build_transform(input_size=self.image_size, norm_type=self.norm_type)
+
+        template = get_conv_template(self.template)
+        template.system_message = self.system_message
+
+        IMG_START_TOKEN = "<img>"
+        IMG_END_TOKEN = "</img>"
+        IMG_CONTEXT_TOKEN = "<IMG_CONTEXT>"
+
+        content_prompts = []
+        pixel_values_list = []
+        for i, content in enumerate(contents):
+            pil_image = pil_images_by_idx.get(i)
+            max_input_tiles = max_input_tile_by_idx.get(i)
+            if pil_image is not None:
+                if self.dynamic_image_size:
+                    image_tiles = dynamic_preprocess(
+                        pil_image,
+                        image_size=self.image_size,
+                        max_num=max_input_tiles,
+                        use_thumbnail=self.use_thumbnail,
+                    )
+                else:
+                    image_tiles = [pil_image]
+
+                pixel_values = [transform(item) for item in image_tiles]
+                pixel_values = torch.stack(pixel_values).to(dtype=torch.bfloat16)
+            else:
+                pixel_values = None
+            pixel_values_list.append(pixel_values)
+
+            if pixel_values is not None and "<image>" not in content:
+                content = "<image> " + content
+
+            # Reseting conversation messages
+            template.messages.clear()
+
+            # TODO: do we need this template?
+            template.append_message(template.roles[0], content)  # user
+            template.append_message(template.roles[1], None)  # assistant
+            content_prompt = template.get_prompt()
+
+            if pixel_values is not None:
+                num_patches = pixel_values.shape[0]
+                image_tokens = IMG_START_TOKEN + IMG_CONTEXT_TOKEN * self.num_image_token * num_patches + IMG_END_TOKEN
+                content_prompt = content_prompt.replace("<image>", image_tokens, 1)
+            else:
+                content_prompt = content_prompt.replace("<image>", "", 1)
+
+            content_prompts.append(content_prompt)
+
+        max_length = None
+        if truncation:
+            max_length = self.p_max_length or self.tokenizer.model_max_length
+
+        if padding is None:
+            padding = self.padding
+
+        model_inputs = self.tokenizer(
+            content_prompts,
+            truncation=truncation,
+            max_length=max_length,
+            padding=padding,
+            pad_to_multiple_of=self.pad_to_multiple_of,
+            return_tensors=return_tensors,
+        )
+
+        if pixel_values_layout == "flat_tiles":
+            pixel_values_list = [pv for pv in pixel_values_list if pv is not None]
+            if len(pixel_values_list) > 1:
+                pixel_values_squeezed = torch.concat(pixel_values_list, axis=0)
+            elif len(pixel_values_list) == 1:
+                pixel_values_squeezed = pixel_values_list[0]
+            else:
+                pixel_values_squeezed = None
+
+            if pixel_values_squeezed is not None and return_tensors == "np":
+                pixel_values_return_value = pixel_values_squeezed.to(dtype=torch.float16).cpu().numpy()
+            else:
+                pixel_values_return_value = pixel_values_squeezed
+        elif pixel_values_layout == "per_image":
+            if return_tensors == "np":
+                pixel_values_return_value = [
+                    pv.to(dtype=torch.float16).cpu().numpy() if pv is not None else None for pv in pixel_values_list
+                ]
+            else:
+                pixel_values_return_value = pixel_values_list
+        else:
+            raise ValueError(
+                f"Invalid pixel_values_layout: {pixel_values_layout!r}. Must be 'squeezed' or 'per_image'."
+            )
+
+        batch_docs = {
+            "input_ids": model_inputs["input_ids"],
+            "attention_mask": model_inputs["attention_mask"],
+            "pixel_values": pixel_values_return_value,
+        }
+
+        return batch_docs
+
+    def process_queries(
+        self,
+        queries: List[str],
+        return_tensors: Literal["pt", "np"] = "pt",
+        padding: bool | str | None = None,
+        truncation: bool = True,
+        **kwargs,
+    ) -> BatchEncoding:
+        """Process queries into model inputs with tokenized text.
+        Args:
+            queries: List of query strings.
+            return_tensors: Output format — "pt" for PyTorch tensors, "np" for numpy arrays.
+            padding: Padding strategy passed to the tokenizer. Defaults to the value
+                set in the processor constructor.
+            truncation: Whether to truncate sequences to q_max_length.
+        Returns:
+            Dict with "input_ids" and "attention_mask".
+        """
+        if return_tensors not in ("pt", "np"):
+            raise ValueError(f"Invalid return_tensors: {return_tensors!r}. Must be 'pt' or 'np'.")
+
+        template = get_conv_template(self.template)
+        template.system_message = self.system_message
+
+        query_prompts = []
+        for query in queries:
+            if self.query_prefix:
+                query = f"{self.query_prefix} {query}"
+
+            # Reseting conversation messages
+            template.messages.clear()
+
+            template.append_message(template.roles[0], query)  # user
+            template.append_message(template.roles[1], None)  # assistant
+            query_prompt = template.get_prompt()
+
+            query_prompts.append(query_prompt)
+
+        max_length = None
+        if truncation:
+            max_length = self.q_max_length or self.tokenizer.model_max_length
+
+        if padding is None:
+            padding = self.padding
+
+        batch_query = self.tokenizer(
+            query_prompts,
+            truncation=truncation,
+            max_length=max_length,
+            padding=padding,
+            pad_to_multiple_of=self.pad_to_multiple_of,
+            return_tensors=return_tensors,
+        )
+
+        return batch_query
+
+    def process_queries_documents_biencoder(self, features: Dict, **kwargs) -> Dict[str, Any]:
+        """
+        (Pdb) features
+        [{'image': [<PIL.Image.Image image mode=RGB size=1275x1650 at 0x155059A5C3A0>, <PIL.Image.Image image mode=RGB size=1275x1650 at 0x155059A5C580>, <PIL.Image.Image image mode=RGB size=1275x1650 at 0x155059A5C940>], 'text': ['passage: ', 'passage: ', 'passage: '], 'question': "query: What change did Carl Rey suggest for the Strategic Plan's website objective deadline?"}, {'image': [<PIL.Image.Image image mode=RGB size=1275x1650 at 0x155059A5C0D0>, <PIL.Image.Image image mode=RGB size=1275x1650 at 0x155059A5DC00>, <PIL.Image.Image image mode=RGB size=1275x1650 at 0x155059A5EBF0>], 'text': ['passage: ', 'passage: ', 'passage: '], 'question': 'query: What are the name and TIN requirements for individuals with real estate transactions?'}, {'image': [<PIL.Image.Image image mode=RGB size=1275x1650 at 0x155059A5D390>, <PIL.Image.Image image mode=RGB size=1275x1650 at 0x155059A5C850>, <PIL.Image.Image image mode=RGB size=1275x1650 at 0x155059A5C070>], 'text': ['passage: ', 'passage: ', 'passage: '], 'question': 'query: How does Richard Hooker view human inclinations?'}]
+        """
+        queries = []
+        pos_neg_text_batch = []
+        pos_neg_image_batch = []
+        for feature in features:
+            queries.append(feature["question"])
+            pos_neg_text_batch.extend(feature["doc_text"])
+            pos_neg_image_batch.extend(feature["doc_image"])
+
+        query_batch_dict = self.process_queries(queries, **kwargs)
+        doc_batch_dict = self.process_documents({"images": pos_neg_image_batch, "texts": pos_neg_text_batch}, **kwargs)
+
+        merged_batch_dict = self.merge_batch_dict(query_batch_dict, doc_batch_dict)
+        merged_batch_dict = self.add_dummy_labels(queries, merged_batch_dict)
+        return merged_batch_dict
+
+    def merge_batch_dict(self, query_batch_dict, doc_batch_dict):
+        q_prefix, d_prefix = "q_", "d_"
+        # merge into a single BatchEncoding by adding prefix
+        merged_batch_dict = {}
+        for k in list(query_batch_dict.keys()):
+            merged_batch_dict[q_prefix + k] = query_batch_dict[k]
+            del query_batch_dict[k]
+        for k in list(doc_batch_dict.keys()):
+            merged_batch_dict[d_prefix + k] = doc_batch_dict[k]
+            del doc_batch_dict[k]
+        return merged_batch_dict
+
+    def add_dummy_labels(self, questions, merged_batch_dict):
+        # dummy placeholder for field "labels", won't use it to compute loss
+        labels = torch.zeros(len(questions), dtype=torch.long)
+        merged_batch_dict["labels"] = labels
+        return merged_batch_dict

--- a/nemo_automodel/components/models/llama_nemotron_vl/processor.py
+++ b/nemo_automodel/components/models/llama_nemotron_vl/processor.py
@@ -10,10 +10,19 @@ from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 import requests
 import torch
-import torchvision.transforms as T
 from PIL import Image
-from torchvision.transforms.functional import InterpolationMode
 from transformers import BatchEncoding, PretrainedConfig, ProcessorMixin
+from transformers.image_processing_base import BatchFeature
+from transformers.image_processing_utils_fast import BaseImageProcessorFast, divide_to_patches
+from transformers.image_utils import (
+    ChannelDimension,
+    ImageInput,
+    PILImageResampling,
+    SizeDict,
+    get_image_size,
+    make_list_of_images,
+)
+from transformers.utils import TensorType
 
 IMAGENET_MEAN = (0.485, 0.456, 0.406)
 IMAGENET_STD = (0.229, 0.224, 0.225)
@@ -79,24 +88,6 @@ def load_image(image):
             raise ValueError(f"Invalid image: {image}")
     else:
         raise ValueError(f"Invalid image: {image}")
-
-
-def build_transform(input_size, norm_type="imagenet"):
-    """Build a transform for an image."""
-    if norm_type == "imagenet":
-        MEAN, STD = IMAGENET_MEAN, IMAGENET_STD
-    elif norm_type == "siglip":
-        MEAN, STD = SIGLIP_MEAN, SIGLIP_STD
-
-    transform = T.Compose(
-        [
-            T.Lambda(lambda img: img.convert("RGB") if img.mode != "RGB" else img),
-            T.Resize((input_size, input_size), interpolation=InterpolationMode.BICUBIC),
-            T.ToTensor(),
-            T.Normalize(mean=MEAN, std=STD),
-        ]
-    )
-    return transform
 
 
 def find_closest_aspect_ratio(aspect_ratio, target_ratios, width, height, image_size):
@@ -165,6 +156,130 @@ def dynamic_preprocess(image, min_num=1, max_num=6, image_size=448, use_thumbnai
     return processed_images
 
 
+class LlamaNemotronVLImageProcessor(BaseImageProcessorFast):
+    """Fast batched image processor for Llama Nemotron VL retrieval inputs."""
+
+    model_input_names = ["pixel_values"]
+
+    def __init__(
+        self,
+        image_size: int = 512,
+        max_num_tiles: int = 6,
+        use_thumbnail: bool = True,
+        dynamic_image_size: bool = True,
+        norm_type: str = "siglip",
+        resample: Optional[Union[PILImageResampling, int]] = None,
+        **kwargs,
+    ):
+        if norm_type == "imagenet":
+            image_mean, image_std = IMAGENET_MEAN, IMAGENET_STD
+        elif norm_type == "siglip":
+            image_mean, image_std = SIGLIP_MEAN, SIGLIP_STD
+        else:
+            raise ValueError(f"Invalid norm_type: {norm_type!r}. Must be 'imagenet' or 'siglip'.")
+
+        kwargs.setdefault("do_rescale", True)
+        kwargs.setdefault("rescale_factor", 1 / 255)
+        kwargs.setdefault("do_normalize", True)
+        kwargs.setdefault("image_mean", image_mean)
+        kwargs.setdefault("image_std", image_std)
+        kwargs.setdefault("resample", resample if resample is not None else PILImageResampling.BICUBIC)
+
+        super().__init__(**kwargs)
+        self.image_size = image_size
+        self.max_num_tiles = max_num_tiles
+        self.use_thumbnail = use_thumbnail
+        self.dynamic_image_size = dynamic_image_size
+        self.norm_type = norm_type
+
+    def dynamic_preprocess(
+        self,
+        image: torch.Tensor,
+        image_size: int = 512,
+        max_num_tiles: int = 6,
+        use_thumbnail: bool = True,
+        resample: Optional[Union[PILImageResampling, int]] = None,
+    ) -> List[torch.Tensor]:
+        """Split one channel-first image tensor into dynamically sized square tiles."""
+        resample = resample if resample is not None else self.resample
+        orig_height, orig_width = get_image_size(image, channel_dim=ChannelDimension.FIRST)
+        aspect_ratio = orig_width / orig_height
+
+        target_ratios = set(
+            (i, j)
+            for n in range(1, max_num_tiles + 1)
+            for i in range(1, n + 1)
+            for j in range(1, n + 1)
+            if i * j <= max_num_tiles and i * j >= 1
+        )
+        target_ratios = sorted(target_ratios, key=lambda x: x[0] * x[1])
+        target_aspect_ratio = find_closest_aspect_ratio(
+            aspect_ratio,
+            target_ratios,
+            orig_width,
+            orig_height,
+            image_size,
+        )
+
+        target_width = image_size * target_aspect_ratio[0]
+        target_height = image_size * target_aspect_ratio[1]
+        resized_img = self.resize(image, SizeDict(height=target_height, width=target_width), resample=resample)
+        patches = divide_to_patches(resized_img, image_size)
+        if use_thumbnail and len(patches) != 1:
+            patches.append(self.resize(image, SizeDict(height=image_size, width=image_size), resample=resample))
+
+        return patches
+
+    def _preprocess(
+        self,
+        images: ImageInput,
+        image_size: Optional[int] = None,
+        max_num_tiles: Optional[int] = None,
+        use_thumbnail: Optional[bool] = None,
+        dynamic_image_size: Optional[bool] = None,
+        do_rescale: Optional[bool] = None,
+        rescale_factor: Optional[float] = None,
+        do_normalize: Optional[bool] = None,
+        image_mean: Optional[Union[float, List[float]]] = None,
+        image_std: Optional[Union[float, List[float]]] = None,
+        resample: Optional[Union[PILImageResampling, int]] = None,
+        return_tensors: Optional[Union[str, TensorType]] = None,
+        **kwargs,
+    ) -> BatchFeature:
+        image_size = image_size if image_size is not None else self.image_size
+        max_num_tiles = max_num_tiles if max_num_tiles is not None else self.max_num_tiles
+        use_thumbnail = use_thumbnail if use_thumbnail is not None else self.use_thumbnail
+        dynamic_image_size = dynamic_image_size if dynamic_image_size is not None else self.dynamic_image_size
+        do_rescale = do_rescale if do_rescale is not None else self.do_rescale
+        rescale_factor = rescale_factor if rescale_factor is not None else self.rescale_factor
+        do_normalize = do_normalize if do_normalize is not None else self.do_normalize
+        image_mean = image_mean if image_mean is not None else self.image_mean
+        image_std = image_std if image_std is not None else self.image_std
+        resample = resample if resample is not None else self.resample
+
+        all_patches = []
+        num_patches = []
+        for image in make_list_of_images(images):
+            if dynamic_image_size:
+                patches = self.dynamic_preprocess(image, image_size, max_num_tiles, use_thumbnail, resample=resample)
+            else:
+                patches = [self.resize(image, SizeDict(height=image_size, width=image_size), resample=resample)]
+            all_patches.extend(patches)
+            num_patches.append(len(patches))
+
+        pixel_values = torch.stack(all_patches, dim=0)
+        pixel_values = self.rescale_and_normalize(
+            pixel_values,
+            do_rescale,
+            rescale_factor,
+            do_normalize=do_normalize,
+            image_mean=image_mean,
+            image_std=image_std,
+        )
+
+        return BatchFeature(data={"pixel_values": pixel_values, "num_patches": num_patches}, tensor_type=return_tensors)
+
+
 class LlamaNemotronVLProcessorConfig(PretrainedConfig):
     """Dummy Configuration for LlamaNemotronVLProcessor,
     just to register the processor with AutoProcessor."""
@@ -218,6 +333,13 @@ class LlamaNemotronVLProcessor(ProcessorMixin):
         self.norm_type = norm_type
         self.system_message = system_message
         self.padding = padding
+        self.image_processor = LlamaNemotronVLImageProcessor(
+            image_size=image_size,
+            max_num_tiles=max_input_tiles,
+            use_thumbnail=use_thumbnail,
+            dynamic_image_size=dynamic_image_size,
+            norm_type=norm_type,
+        )
 
         super().__init__(self.tokenizer)
 
@@ -327,7 +449,8 @@ class LlamaNemotronVLProcessor(ProcessorMixin):
         for idx, (image, text) in enumerate(zip(images, texts)):
             prefix = ""
             if image is not None and image != "":
-                pil_images_by_idx[idx] = load_image(image)
+                pil_image = load_image(image)
+                pil_images_by_idx[idx] = pil_image.convert("RGB") if pil_image.mode != "RGB" else pil_image
                 prefix = "<image>"
                 max_input_tile_by_idx[idx] = self.max_input_tiles
 
@@ -343,7 +466,26 @@ class LlamaNemotronVLProcessor(ProcessorMixin):
             "The number of max_input_tile_by_idx and pil_images_by_idx should be the same."
         )
 
-        transform = build_transform(input_size=self.image_size, norm_type=self.norm_type)
+        pixel_values_by_idx = {}
+        if pil_images_by_idx:
+            image_indices = list(pil_images_by_idx.keys())
+            self.image_processor.image_size = self.image_size
+            self.image_processor.max_num_tiles = self.max_input_tiles
+            self.image_processor.use_thumbnail = self.use_thumbnail
+            self.image_processor.dynamic_image_size = self.dynamic_image_size
+            image_features = self.image_processor(
+                [pil_images_by_idx[idx] for idx in image_indices], return_tensors="pt"
+            )
+            pixel_values = image_features["pixel_values"].to(dtype=torch.bfloat16)
+            num_patches = image_features["num_patches"]
+            if isinstance(num_patches, torch.Tensor):
+                num_patches = num_patches.tolist()
+
+            offset = 0
+            for idx, patch_count in zip(image_indices, num_patches):
+                patch_count = int(patch_count)
+                pixel_values_by_idx[idx] = pixel_values[offset : offset + patch_count]
+                offset += patch_count
 
         template = get_conv_template(self.template)
         template.system_message = self.system_message
@@ -355,23 +497,7 @@ class LlamaNemotronVLProcessor(ProcessorMixin):
         content_prompts = []
         pixel_values_list = []
         for i, content in enumerate(contents):
-            pil_image = pil_images_by_idx.get(i)
-            max_input_tiles = max_input_tile_by_idx.get(i)
-            if pil_image is not None:
-                if self.dynamic_image_size:
-                    image_tiles = dynamic_preprocess(
-                        pil_image,
-                        image_size=self.image_size,
-                        max_num=max_input_tiles,
-                        use_thumbnail=self.use_thumbnail,
-                    )
-                else:
-                    image_tiles = [pil_image]
-
-                pixel_values = [transform(item) for item in image_tiles]
-                pixel_values = torch.stack(pixel_values).to(dtype=torch.bfloat16)
-            else:
-                pixel_values = None
+            pixel_values = pixel_values_by_idx.get(i)
             pixel_values_list.append(pixel_values)
 
             if pixel_values is not None and "<image>" not in content:

--- a/nemo_automodel/components/models/llama_nemotron_vl/processor.py
+++ b/nemo_automodel/components/models/llama_nemotron_vl/processor.py
@@ -13,7 +13,7 @@ import torch
 import torchvision.transforms as T
 from PIL import Image
 from torchvision.transforms.functional import InterpolationMode
-from transformers import AutoProcessor, BatchEncoding, PretrainedConfig, ProcessorMixin
+from transformers import BatchEncoding, PretrainedConfig, ProcessorMixin
 
 IMAGENET_MEAN = (0.485, 0.456, 0.406)
 IMAGENET_STD = (0.229, 0.224, 0.225)
@@ -537,7 +537,9 @@ class LlamaNemotronVLProcessor(ProcessorMixin):
         merged_batch_dict["labels"] = labels
         return merged_batch_dict
 
+
 def _register_with_hf_auto_classes():
     LlamaNemotronVLProcessor.register_for_auto_class("AutoProcessor")
+
 
 _register_with_hf_auto_classes()

--- a/nemo_automodel/components/models/llama_nemotron_vl/processor.py
+++ b/nemo_automodel/components/models/llama_nemotron_vl/processor.py
@@ -303,7 +303,7 @@ class LlamaNemotronVLProcessor(ProcessorMixin):
         query_prefix: str = "query:",
         passage_prefix: str = "passage:",
         max_input_tiles: int = 6,
-        num_image_token: int = 128258,
+        num_image_token: int = 256,
         dynamic_image_size: bool = True,
         image_size: int = 512,
         use_thumbnail: bool = True,
@@ -558,7 +558,7 @@ class LlamaNemotronVLProcessor(ProcessorMixin):
                 pixel_values_return_value = pixel_values_list
         else:
             raise ValueError(
-                f"Invalid pixel_values_layout: {pixel_values_layout!r}. Must be 'squeezed' or 'per_image'."
+                f"Invalid pixel_values_layout: {pixel_values_layout!r}. Must be 'flat_tiles' or 'per_image'."
             )
 
         batch_docs = {

--- a/nemo_automodel/components/models/llama_nemotron_vl/processor.py
+++ b/nemo_automodel/components/models/llama_nemotron_vl/processor.py
@@ -13,7 +13,7 @@ import torch
 import torchvision.transforms as T
 from PIL import Image
 from torchvision.transforms.functional import InterpolationMode
-from transformers import BatchEncoding, ProcessorMixin
+from transformers import AutoProcessor, BatchEncoding, PretrainedConfig, ProcessorMixin
 
 IMAGENET_MEAN = (0.485, 0.456, 0.406)
 IMAGENET_STD = (0.229, 0.224, 0.225)
@@ -165,6 +165,13 @@ def dynamic_preprocess(image, min_num=1, max_num=6, image_size=448, use_thumbnai
     return processed_images
 
 
+class LlamaNemotronVLProcessorConfig(PretrainedConfig):
+    """Dummy Configuration for LlamaNemotronVLProcessor,
+    just to register the processor with AutoProcessor."""
+
+    pass
+
+
 class LlamaNemotronVLProcessor(ProcessorMixin):
     """Processor for LlamaNemotronVL model."""
 
@@ -174,6 +181,7 @@ class LlamaNemotronVLProcessor(ProcessorMixin):
     def __init__(
         self,
         tokenizer: Any,
+        config: Optional[LlamaNemotronVLProcessorConfig] = None,
         q_max_length: Optional[int] = None,
         p_max_length: Optional[int] = None,
         pad_to_multiple_of: Optional[int] = None,
@@ -528,3 +536,8 @@ class LlamaNemotronVLProcessor(ProcessorMixin):
         labels = torch.zeros(len(questions), dtype=torch.long)
         merged_batch_dict["labels"] = labels
         return merged_batch_dict
+
+def _register_with_hf_auto_classes():
+    LlamaNemotronVLProcessor.register_for_auto_class("AutoProcessor")
+
+_register_with_hf_auto_classes()

--- a/nemo_automodel/recipes/base_recipe.py
+++ b/nemo_automodel/recipes/base_recipe.py
@@ -89,9 +89,9 @@ def is_tokenizer(object):
         object (any): the object to check.
 
     Returns:
-        bool: returns True if object is a tokenizer or VLM processor.
+        bool: returns True if object is a VLM processor or tokenizer.
     """
-    return isinstance(object, (PreTrainedTokenizerBase, ProcessorMixin))
+    return isinstance(object, (ProcessorMixin, PreTrainedTokenizerBase))
 
 
 def is_lr_scheduler(object):

--- a/nemo_automodel/recipes/retrieval/train_bi_encoder.py
+++ b/nemo_automodel/recipes/retrieval/train_bi_encoder.py
@@ -25,6 +25,7 @@ import torch.nn.functional as F
 import wandb
 from torch.utils.data import IterableDataset
 from torchdata.stateful_dataloader.sampler import StatefulDistributedSampler
+from transformers import ProcessorMixin
 
 from nemo_automodel._transformers.utils import apply_cache_compatibility_patches
 from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
@@ -324,10 +325,12 @@ class TrainBiEncoderRecipe(BaseRecipe):
             logger=logger,
         )
 
+        # Might be tokenizer or processor (for VLMs)
         self.tokenizer = self.cfg.tokenizer.instantiate()
-        if self.tokenizer.pad_token is None:
-            self.tokenizer.pad_token = self.tokenizer.eos_token
-            self.tokenizer.padding_side = "left"
+        tokenizer = self.tokenizer.tokenizer if isinstance(self.tokenizer, ProcessorMixin) else self.tokenizer
+        if tokenizer.pad_token is None:
+            tokenizer.pad_token = self.tokenizer.eos_token
+            tokenizer.padding_side = "left"
 
         self.dataloader = build_dataloader(
             self.cfg.dataloader,

--- a/nemo_automodel/recipes/retrieval/train_bi_encoder.py
+++ b/nemo_automodel/recipes/retrieval/train_bi_encoder.py
@@ -448,6 +448,11 @@ class TrainBiEncoderRecipe(BaseRecipe):
         )
 
         with train_ctx, sync_ctx:
+            if is_train:
+                if query is not None:
+                    query["run_dummy_vision"] = False
+                if passage is not None:
+                    passage["run_dummy_vision"] = True
             q_reps = model(query)
             p_reps = model(passage)
             attr_model = _unwrap_model_for_attrs(model)

--- a/tests/unit_tests/_transformers/test_doc_coverage.py
+++ b/tests/unit_tests/_transformers/test_doc_coverage.py
@@ -45,6 +45,8 @@ _DOC_ARCH_ALIASES = {
     # Retrieval/bi-encoder variants of Llama, covered on the GritLM page.
     "LlamaBidirectionalForSequenceClassification": "GritLM",
     "LlamaBidirectionalModel": "GritLM",
+    # Multimodal retrieval variant covered by the existing NVIDIA Llama Nemotron embedding page.
+    "LlamaNemotronVLModel": "llama-nemotron-embed-1b-v2",
     # HF ships ``LlavaOnevisionForConditionalGeneration`` (lowercase "n");
     # registry uses ``LlavaOneVisionForConditionalGeneration`` (the NVIDIA
     # re-impl for LLaVA-OneVision-1.5 with RICE ViT).

--- a/tests/unit_tests/_transformers/test_registry.py
+++ b/tests/unit_tests/_transformers/test_registry.py
@@ -172,6 +172,18 @@ def test_default_registry_has_static_entries():
         assert arch_name in inst.model_arch_name_to_cls.keys()
 
 
+def test_llama_nemotron_vl_registry_entry_is_retrieval_model():
+    """Llama Nemotron VL should be registered as a retrieval architecture."""
+    from nemo_automodel._transformers.registry import MODEL_ARCH_MAPPING, ModelRegistry
+
+    assert MODEL_ARCH_MAPPING["LlamaNemotronVLModel"] == (
+        "nemo_automodel.components.models.llama_nemotron_vl.model",
+        "LlamaNemotronVLModel",
+        {"retrieval"},
+    )
+    assert ModelRegistry.has_retrieval_model("LlamaNemotronVLModel")
+
+
 def test_step3p7_registry_and_custom_config_registration():
     """Step3p7 VLM support is available through the lazy registry and AutoConfig."""
     from transformers.models.auto.configuration_auto import CONFIG_MAPPING

--- a/tests/unit_tests/_transformers/test_retrieval.py
+++ b/tests/unit_tests/_transformers/test_retrieval.py
@@ -29,6 +29,12 @@ from nemo_automodel.components.models.llama_bidirectional.model import (
 from nemo_automodel.components.models.ministral_bidirectional.model import Ministral3BidirectionalModel
 
 
+def test_llama_nemotron_vl_supported_backbone_for_embedding():
+    from nemo_automodel._transformers.retrieval import SUPPORTED_BACKBONES
+
+    assert SUPPORTED_BACKBONES["llama_nemotron_vl"]["embedding"] == "LlamaNemotronVLModel"
+
+
 def _tiny_mistral3_vlm_config(text_model_type: str) -> Mistral3Config:
     """Build a tiny Mistral3 VLM config with a selectable text backbone."""
     text_config = {

--- a/tests/unit_tests/datasets/llm/test_bi_encoder_collator.py
+++ b/tests/unit_tests/datasets/llm/test_bi_encoder_collator.py
@@ -120,12 +120,22 @@ def test_collator_end_to_end_no_prefix():
 def test_collator_with_prefix_and_pad_multiple():
     tok = FakeTokenizer()
     collator = rc.BiEncoderCollator(
-        tokenizer=tok, q_max_len=32, p_max_len=32, query_prefix="Q:", passage_prefix="D:", padding=True, pad_to_multiple_of=4
+        tokenizer=tok,
+        q_max_len=32,
+        p_max_len=32,
+        query_prefix="Q:",
+        passage_prefix="D:",
+        padding=True,
+        pad_to_multiple_of=4,
     )
     # Make varying lengths so padding is exercised and rounded to multiple-of 4
     batch = [
         {"question": "short", "doc_text": ["tiny", "a bit longer"], "doc_image": ["", ""]},
-        {"question": "this is a somewhat longer question", "doc_text": ["short doc", "this is a longish doc text"], "doc_image": ["", ""]},
+        {
+            "question": "this is a somewhat longer question",
+            "doc_text": ["short doc", "this is a longish doc text"],
+            "doc_image": ["", ""],
+        },
     ]
     out = collator(batch)
     # Verify padding rounded to multiple of 4
@@ -220,3 +230,27 @@ def test_collator_with_dataset_instruction():
     # The instruction adds 12 words, so we should see significantly more tokens
     assert with_instruction_tokens > without_instruction_tokens
     assert with_instruction_tokens - without_instruction_tokens > 10  # At least 10 more tokens from instruction
+
+
+def test_make_vision_collator_from_processor_method_returns_bound_method():
+    class FakeProcessor:
+        def process_queries_documents_biencoder(self, features):
+            return {"features": features}
+
+    processor = FakeProcessor()
+    collator = rc.make_vision_collator_from_processor_method(processor, "process_queries_documents_biencoder")
+
+    assert collator.__self__ is processor
+    assert collator.__func__ is FakeProcessor.process_queries_documents_biencoder
+    assert collator([{"question": "Q"}]) == {"features": [{"question": "Q"}]}
+
+
+def test_make_vision_collator_from_processor_method_missing_method_raises():
+    with pytest.raises(AttributeError):
+        rc.make_vision_collator_from_processor_method(object(), "missing_collator")
+
+
+def test_models_with_processor_includes_llama_nemotron_vl():
+    from nemo_automodel.components.models.llama_nemotron_vl import LlamaNemotronVLProcessor
+
+    assert rc.MODELS_WITH_PROCESSOR["llama_nemotron_vl"] is LlamaNemotronVLProcessor

--- a/tests/unit_tests/datasets/llm/test_bi_encoder_collator.py
+++ b/tests/unit_tests/datasets/llm/test_bi_encoder_collator.py
@@ -248,9 +248,3 @@ def test_make_vision_collator_from_processor_method_returns_bound_method():
 def test_make_vision_collator_from_processor_method_missing_method_raises():
     with pytest.raises(AttributeError):
         rc.make_vision_collator_from_processor_method(object(), "missing_collator")
-
-
-def test_models_with_processor_includes_llama_nemotron_vl():
-    from nemo_automodel.components.models.llama_nemotron_vl import LlamaNemotronVLProcessor
-
-    assert rc.MODELS_WITH_PROCESSOR["llama_nemotron_vl"] is LlamaNemotronVLProcessor

--- a/tests/unit_tests/datasets/llm/test_retrieval_dataset.py
+++ b/tests/unit_tests/datasets/llm/test_retrieval_dataset.py
@@ -353,6 +353,100 @@ def test_textqa_get_all_ids(tmp_path, monkeypatch):
     assert corpus.get_all_ids() == ["1", "2"]
 
 
+def test_colpali_dataset_uses_image_filename_ids(monkeypatch):
+    """ColPaliDataset should expose image documents keyed by image_filename."""
+    monkeypatch.setattr(
+        rd,
+        "load_dataset",
+        _mock_hf_load_dataset_returning(
+            [
+                {
+                    "image_filename": "z-page.png",
+                    "image": "image-z",
+                    "nr_ocr": "ocr-z",
+                    "complex_ocr": "complex-z",
+                },
+                {
+                    "image_filename": "a-page.png",
+                    "image": "image-a",
+                    "nr_ocr": "ocr-a",
+                    "complex_ocr": "complex-a",
+                },
+            ]
+        ),
+    )
+
+    corpus = rd.ColPaliDataset("colpali-path")
+
+    assert corpus.path == "colpali-path"
+    assert corpus.get_all_ids() == ["a-page.png", "z-page.png"]
+    assert corpus.get_document_by_id("z-page.png") == {
+        "text": "",
+        "image": "image-z",
+        "nr_ocr": "ocr-z",
+        "complex_ocr": "complex-z",
+    }
+
+
+def test_wikissnq_dataset_uses_docid_ids(monkeypatch):
+    """WikiSSNQDataset should expose image documents keyed by docid."""
+    monkeypatch.setattr(
+        rd,
+        "load_dataset",
+        _mock_hf_load_dataset_returning(
+            [
+                {
+                    "docid": "doc-b",
+                    "image": "image-b",
+                    "nr_ocr": "ocr-b",
+                    "complex_ocr": "complex-b",
+                },
+                {
+                    "docid": "doc-a",
+                    "image": "image-a",
+                    "nr_ocr": "ocr-a",
+                    "complex_ocr": "complex-a",
+                },
+            ]
+        ),
+    )
+
+    corpus = rd.WikiSSNQDataset("wikissnq-path")
+
+    assert corpus.path == "wikissnq-path"
+    assert corpus.get_all_ids() == ["doc-a", "doc-b"]
+    assert corpus.get_document_by_id("doc-a") == {
+        "text": "",
+        "image": "image-a",
+        "nr_ocr": "ocr-a",
+        "complex_ocr": "complex-a",
+    }
+
+
+def test_docmatix_dataset_loads_images_config_and_row_image_ids(monkeypatch):
+    """DocMatixDataset should read the images config and resolve row_image IDs."""
+    calls = []
+    backing_dataset = Dataset.from_list(
+        [
+            {"images": ["image-0-0", "image-0-1"]},
+            {"images": ["image-1-0"]},
+        ]
+    )
+
+    def fake_load_dataset(path, config):
+        calls.append((path, config))
+        return {"train": backing_dataset}
+
+    monkeypatch.setattr(rd, "load_dataset", fake_load_dataset)
+
+    corpus = rd.DocMatixDataset("docmatix-path")
+
+    assert calls == [("docmatix-path", "images")]
+    assert corpus.path == "docmatix-path"
+    assert corpus.get_all_ids() == ["0_0", "1_0"]
+    assert corpus.get_document_by_id("0_1") == {"text": "", "image": "image-0-1", "nr_ocr": ""}
+
+
 def test_load_corpus_metadata_missing_file(tmp_path):
     empty_dir = tmp_path / "empty_corpus"
     empty_dir.mkdir()

--- a/tests/unit_tests/models/bi_encoder/test_bi_encoder_model.py
+++ b/tests/unit_tests/models/bi_encoder/test_bi_encoder_model.py
@@ -45,9 +45,50 @@ class _ToyMultiVectorBiEncoder(torch.nn.Module):
     def __init__(self):
         super().__init__()
         self.scale = torch.nn.Parameter(torch.tensor(1.0))
+        self.run_dummy_vision_flags = []
 
     def forward(self, batch):
+        self.run_dummy_vision_flags.append(batch.get("run_dummy_vision"))
         return batch["input_ids"].float() * self.scale
+
+
+class _ToyBackboneOutput:
+    def __init__(self, hidden_state):
+        self.last_hidden_state = hidden_state
+
+
+class _ToyBackboneWithDummyFlag(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.config = SimpleNamespace(name_or_path="")
+        self.run_dummy_vision = None
+
+    def forward(
+        self,
+        input_ids,
+        attention_mask,
+        return_dict=True,
+        output_hidden_states=True,
+        run_dummy_vision=None,
+    ):
+        self.run_dummy_vision = run_dummy_vision
+        hidden_state = input_ids.float().unsqueeze(-1).expand(*input_ids.shape, 2)
+        return _ToyBackboneOutput(hidden_state)
+
+
+class _ToyBackboneWithoutDummyFlag(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.config = SimpleNamespace(name_or_path="")
+        self.received_kwargs = None
+
+    def forward(self, input_ids, attention_mask, return_dict=True, output_hidden_states=True):
+        self.received_kwargs = {
+            "return_dict": return_dict,
+            "output_hidden_states": output_hidden_states,
+        }
+        hidden_state = input_ids.float().unsqueeze(-1).expand(*input_ids.shape, 2)
+        return _ToyBackboneOutput(hidden_state)
 
 
 def _apply_common_mocks(monkeypatch):
@@ -211,6 +252,38 @@ def test_cross_encoder_retries_without_sdpa(monkeypatch):
     _assert_retries_without_sdpa(monkeypatch, CrossEncoderModel, am.NeMoAutoModelCrossEncoder)
 
 
+def test_bi_encoder_forwards_run_dummy_vision_when_backbone_supports_it():
+    backbone = _ToyBackboneWithDummyFlag()
+    model = BiEncoderModel(backbone, pooling="avg", l2_normalize=False)
+
+    embeddings = model(
+        {
+            "input_ids": torch.tensor([[1, 2]]),
+            "attention_mask": torch.tensor([[1, 1]]),
+            "run_dummy_vision": False,
+        }
+    )
+
+    assert backbone.run_dummy_vision is False
+    assert embeddings.shape == (1, 2)
+
+
+def test_bi_encoder_drops_run_dummy_vision_when_backbone_does_not_support_it():
+    backbone = _ToyBackboneWithoutDummyFlag()
+    model = BiEncoderModel(backbone, pooling="avg", l2_normalize=False)
+
+    embeddings = model(
+        {
+            "input_ids": torch.tensor([[1, 2]]),
+            "attention_mask": torch.tensor([[1, 1]]),
+            "run_dummy_vision": True,
+        }
+    )
+
+    assert backbone.received_kwargs == {"return_dict": True, "output_hidden_states": True}
+    assert embeddings.shape == (1, 2)
+
+
 def test_maxsim_scores_and_labels_masks_padding_before_maxsim():
     query = torch.tensor(
         [
@@ -320,6 +393,32 @@ def test_forward_backward_step_supports_local_multi_vector_pooling():
     assert len(loss_buffer) == 1
     assert torch.isfinite(loss_buffer[0])
     assert recipe.model_parts[0].scale.grad is not None
+
+
+def test_forward_backward_step_disables_query_dummy_vision_but_keeps_passage_dummy_vision():
+    recipe = TrainBiEncoderRecipe.__new__(TrainBiEncoderRecipe)
+    recipe.dist_env = SimpleNamespace(device="cpu")
+    recipe.distributed_config = SimpleNamespace(defer_fsdp_grad_sync=True)
+    model = _ToyMultiVectorBiEncoder()
+    recipe.model_parts = [model]
+    recipe.temperature = 1.0
+    recipe.train_n_passages = 2
+
+    batch = {
+        "q_input_ids": torch.tensor([[[1.0, 0.0], [0.0, 1.0]]]),
+        "q_attention_mask": torch.tensor([[1, 1]]),
+        "d_input_ids": torch.tensor(
+            [
+                [[1.0, 0.0], [0.0, 1.0]],
+                [[0.0, 1.0], [0.0, 0.0]],
+            ]
+        ),
+        "d_attention_mask": torch.tensor([[1, 1], [1, 0]]),
+    }
+
+    recipe._forward_backward_step(0, batch, loss_buffer=[], num_batches=1, is_train=True)
+
+    assert model.run_dummy_vision_flags == [False, True]
 
 
 def test_validation_epoch_supports_multi_vector_pooling():

--- a/tests/unit_tests/models/llama_nemotron_vl/test_image_embedding_insert.py
+++ b/tests/unit_tests/models/llama_nemotron_vl/test_image_embedding_insert.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+from pathlib import Path
+
+import torch
+
+_MODEL_PATH = (
+    Path(__file__).resolve().parents[4] / "nemo_automodel/components/models/llama_nemotron_vl/model.py"
+)
+_MODEL_SPEC = importlib.util.spec_from_file_location("_llama_nemotron_vl_model_for_test", _MODEL_PATH)
+_MODEL_MODULE = importlib.util.module_from_spec(_MODEL_SPEC)
+assert _MODEL_SPEC.loader is not None
+_MODEL_SPEC.loader.exec_module(_MODEL_MODULE)
+
+_filter_vision_embeddings_by_image_flags = _MODEL_MODULE._filter_vision_embeddings_by_image_flags
+_replace_image_token_embeddings = _MODEL_MODULE._replace_image_token_embeddings
+
+IMG_TOKEN_ID = 128258
+
+
+def _old_boolean_index_replace(
+    input_embeds: torch.Tensor,
+    input_ids: torch.Tensor,
+    vit_embeds: torch.Tensor,
+) -> torch.Tensor:
+    batch_size, seq_len, hidden_size = input_embeds.shape
+    flat_embeds = input_embeds.reshape(batch_size * seq_len, hidden_size)
+    flat_input_ids = input_ids.reshape(batch_size * seq_len)
+    selected = flat_input_ids == IMG_TOKEN_ID
+    flat_embeds = flat_embeds.clone()
+    flat_embeds[selected] = flat_embeds[selected] * 0.0 + vit_embeds.reshape(-1, hidden_size)
+    return flat_embeds.reshape(batch_size, seq_len, hidden_size)
+
+
+def test_replace_image_token_embeddings_matches_boolean_index_outputs_and_grads():
+    input_ids = torch.tensor(
+        [
+            [1, IMG_TOKEN_ID, IMG_TOKEN_ID, 2, 3],
+            [4, 5, IMG_TOKEN_ID, IMG_TOKEN_ID, 6],
+        ],
+        dtype=torch.long,
+    )
+    input_embeds = torch.randn(2, 5, 4, requires_grad=True)
+    vit_embeds = torch.randn(4, 4, requires_grad=True)
+
+    old_input = input_embeds.detach().clone().requires_grad_(True)
+    old_vit = vit_embeds.detach().clone().requires_grad_(True)
+    old_out = _old_boolean_index_replace(old_input, input_ids, old_vit)
+    old_out.square().sum().backward()
+
+    new_input = input_embeds.detach().clone().requires_grad_(True)
+    new_vit = vit_embeds.detach().clone().requires_grad_(True)
+    new_out = _replace_image_token_embeddings(new_input, input_ids, new_vit, IMG_TOKEN_ID)
+    new_out.square().sum().backward()
+
+    torch.testing.assert_close(new_out, old_out)
+    torch.testing.assert_close(new_input.grad, old_input.grad)
+    torch.testing.assert_close(new_vit.grad, old_vit.grad)
+
+
+def test_filter_vision_embeddings_skips_filter_when_image_flags_absent():
+    vit_embeds = torch.randn(3, 2, 4)
+
+    filtered = _filter_vision_embeddings_by_image_flags(vit_embeds, None)
+
+    assert filtered is vit_embeds
+
+
+def test_filter_vision_embeddings_keeps_flagged_rows():
+    vit_embeds = torch.arange(4 * 2 * 3, dtype=torch.float32).reshape(4, 2, 3)
+    image_flags = torch.tensor([[1], [0], [1], [0]], dtype=torch.long)
+
+    filtered = _filter_vision_embeddings_by_image_flags(vit_embeds, image_flags)
+
+    torch.testing.assert_close(filtered, vit_embeds[[0, 2]])

--- a/tests/unit_tests/models/llama_nemotron_vl/test_llama_nemotron_vl.py
+++ b/tests/unit_tests/models/llama_nemotron_vl/test_llama_nemotron_vl.py
@@ -16,6 +16,7 @@ import pytest
 import torch
 import torch.nn as nn
 from PIL import Image
+from transformers.image_utils import PILImageResampling
 from transformers.modeling_outputs import CausalLMOutputWithPast
 from transformers.models.siglip.configuration_siglip import SiglipVisionConfig
 from transformers.processing_utils import ProcessorMixin
@@ -26,6 +27,7 @@ from nemo_automodel.components.models.llama_nemotron_vl.model import (
     LlamaNemotronVLModel,
 )
 from nemo_automodel.components.models.llama_nemotron_vl.processor import (
+    LlamaNemotronVLImageProcessor,
     LlamaNemotronVLProcessor,
     dynamic_preprocess,
     find_closest_aspect_ratio,
@@ -449,6 +451,70 @@ def test_dynamic_preprocess_adds_thumbnail_only_for_multi_tile_images():
     assert len(square_tiles) == 1
     assert len(wide_tiles) == 3
     assert [tile.size for tile in wide_tiles] == [(4, 4), (4, 4), (4, 4)]
+
+
+def test_fast_image_processor_uses_bicubic_resize_by_default(monkeypatch):
+    image_processor = LlamaNemotronVLImageProcessor(image_size=4, max_num_tiles=2)
+    seen_resample = []
+
+    def fake_resize(image, size, resample=None, **kwargs):
+        seen_resample.append(resample)
+        return torch.zeros((3, size.height, size.width), dtype=image.dtype)
+
+    monkeypatch.setattr(image_processor, "resize", fake_resize)
+
+    patches = image_processor.dynamic_preprocess(
+        torch.zeros((3, 4, 8)),
+        image_size=4,
+        max_num_tiles=2,
+        use_thumbnail=True,
+    )
+
+    assert len(patches) == 3
+    assert seen_resample == [PILImageResampling.BICUBIC, PILImageResampling.BICUBIC]
+
+
+def test_fast_image_processor_preprocess_honors_image_kwargs(monkeypatch):
+    image_processor = LlamaNemotronVLImageProcessor(image_size=4)
+    captured = {}
+
+    def fake_resize(image, size, resample=None, **kwargs):
+        captured["resample"] = resample
+        return torch.ones((3, size.height, size.width), dtype=image.dtype)
+
+    def fake_rescale_and_normalize(pixel_values, do_rescale, rescale_factor, do_normalize, image_mean, image_std):
+        captured["do_rescale"] = do_rescale
+        captured["rescale_factor"] = rescale_factor
+        captured["do_normalize"] = do_normalize
+        captured["image_mean"] = image_mean
+        captured["image_std"] = image_std
+        return pixel_values
+
+    monkeypatch.setattr(image_processor, "resize", fake_resize)
+    monkeypatch.setattr(image_processor, "rescale_and_normalize", fake_rescale_and_normalize)
+
+    output = image_processor._preprocess(
+        [torch.zeros((3, 4, 4))],
+        image_size=4,
+        dynamic_image_size=False,
+        do_rescale=False,
+        rescale_factor=0.5,
+        do_normalize=False,
+        image_mean=[0.1, 0.2, 0.3],
+        image_std=[0.4, 0.5, 0.6],
+        resample=PILImageResampling.NEAREST,
+        return_tensors="pt",
+    )
+
+    assert output["pixel_values"].shape == (1, 3, 4, 4)
+    assert captured == {
+        "resample": PILImageResampling.NEAREST,
+        "do_rescale": False,
+        "rescale_factor": 0.5,
+        "do_normalize": False,
+        "image_mean": [0.1, 0.2, 0.3],
+        "image_std": [0.4, 0.5, 0.6],
+    }
 
 
 def test_llama_nemotron_vl_config_builds_composed_subconfigs():

--- a/tests/unit_tests/models/llama_nemotron_vl/test_llama_nemotron_vl.py
+++ b/tests/unit_tests/models/llama_nemotron_vl/test_llama_nemotron_vl.py
@@ -1,0 +1,485 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+import torch.nn as nn
+from PIL import Image
+from transformers.modeling_outputs import CausalLMOutputWithPast
+from transformers.models.siglip.configuration_siglip import SiglipVisionConfig
+from transformers.processing_utils import ProcessorMixin
+
+from nemo_automodel.components.models.llama_nemotron_vl.model import (
+    LlamaBidirectionalConfig,
+    LlamaNemotronVLConfig,
+    LlamaNemotronVLModel,
+)
+from nemo_automodel.components.models.llama_nemotron_vl.processor import (
+    LlamaNemotronVLProcessor,
+    dynamic_preprocess,
+    find_closest_aspect_ratio,
+)
+
+IMG_CONTEXT_TOKEN_ID = 99
+
+
+class FakeTokenizer:
+    def __init__(self):
+        self.model_input_names = ["input_ids", "attention_mask"]
+        self.model_max_length = 99
+        self.padding_side = "right"
+        self.calls = []
+
+    def __call__(self, texts, **kwargs):
+        if isinstance(texts, str):
+            texts = [texts]
+        self.calls.append({"texts": list(texts), "kwargs": kwargs})
+        input_ids = []
+        attention_mask = []
+        for text in texts:
+            num_image_tokens = text.count("<IMG_CONTEXT>")
+            ids = [1] + [IMG_CONTEXT_TOKEN_ID] * num_image_tokens + [2]
+            input_ids.append(ids)
+        max_length = max(len(ids) for ids in input_ids)
+        for ids in input_ids:
+            pad_length = max_length - len(ids)
+            attention_mask.append([1] * len(ids) + [0] * pad_length)
+            ids.extend([0] * pad_length)
+        return {
+            "input_ids": torch.tensor(input_ids, dtype=torch.long),
+            "attention_mask": torch.tensor(attention_mask, dtype=torch.long),
+        }
+
+
+class FakeVisionModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(1))
+
+
+class FakeLanguageModel(nn.Module):
+    def __init__(self, vocab_size=128, hidden_size=8):
+        super().__init__()
+        self.config = type("FakeLanguageConfig", (), {"vocab_size": vocab_size})()
+        self.embedding = nn.Embedding(vocab_size, hidden_size)
+        self.lm_head = nn.Linear(hidden_size, vocab_size, bias=False)
+        self.forward_calls = []
+        with torch.no_grad():
+            token_values = torch.arange(vocab_size, dtype=torch.float32).unsqueeze(1)
+            self.embedding.weight.copy_(token_values.repeat(1, hidden_size))
+
+    def get_input_embeddings(self):
+        return self.embedding
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def forward(
+        self,
+        inputs_embeds,
+        attention_mask=None,
+        position_ids=None,
+        past_key_values=None,
+        use_cache=None,
+        output_attentions=None,
+        output_hidden_states=None,
+    ):
+        self.forward_calls.append(
+            {
+                "inputs_embeds": inputs_embeds.detach().clone(),
+                "attention_mask": attention_mask.detach().clone() if attention_mask is not None else None,
+                "position_ids": position_ids,
+                "past_key_values": past_key_values,
+                "use_cache": use_cache,
+                "output_attentions": output_attentions,
+                "output_hidden_states": output_hidden_states,
+            }
+        )
+        hidden_states = (inputs_embeds, inputs_embeds + 1.0)
+        return CausalLMOutputWithPast(
+            logits=self.lm_head(inputs_embeds),
+            past_key_values=past_key_values,
+            hidden_states=hidden_states,
+            attentions=None,
+        )
+
+
+@pytest.fixture
+def processor(monkeypatch):
+    monkeypatch.setattr(ProcessorMixin, "check_argument_for_proper_class", lambda *args, **kwargs: None)
+    return LlamaNemotronVLProcessor(
+        tokenizer=FakeTokenizer(),
+        q_max_length=7,
+        p_max_length=11,
+        pad_to_multiple_of=4,
+        query_prefix="query:",
+        passage_prefix="passage:",
+        image_size=4,
+        num_image_token=2,
+    )
+
+
+@pytest.fixture
+def tiny_model(monkeypatch, processor):
+    import nemo_automodel.components.models.llama_nemotron_vl.model as model_module
+
+    monkeypatch.setattr(model_module.AutoProcessor, "from_pretrained", lambda *args, **kwargs: processor)
+    config = LlamaNemotronVLConfig(
+        vision_config=_tiny_vision_config(),
+        llm_config=_tiny_llm_config(),
+        pooling="avg",
+        img_context_token_id=IMG_CONTEXT_TOKEN_ID,
+    )
+    model = LlamaNemotronVLModel(
+        config,
+        vision_model=FakeVisionModel(),
+        language_model=FakeLanguageModel(
+            vocab_size=128,
+            hidden_size=config.llm_config.hidden_size,
+        ),
+    )
+    with torch.no_grad():
+        token_values = torch.arange(128, dtype=torch.float32).unsqueeze(1)
+        model.language_model.embedding.weight.copy_(token_values.repeat(1, config.llm_config.hidden_size))
+    model.eval()
+    return model
+
+
+def _tiny_vision_config():
+    return {
+        "model_type": "siglip_vision_model",
+        "hidden_size": 8,
+        "image_size": 4,
+        "patch_size": 2,
+        "num_hidden_layers": 1,
+        "num_attention_heads": 1,
+        "intermediate_size": 16,
+    }
+
+
+def _tiny_llm_config():
+    return {
+        "architectures": ["LlamaBidirectionalModel"],
+        "model_type": "llama",
+        "vocab_size": 32,
+        "hidden_size": 8,
+        "intermediate_size": 16,
+        "num_hidden_layers": 1,
+        "num_attention_heads": 1,
+        "num_key_value_heads": 1,
+    }
+
+
+def test_processor_initializes_tokenizer_for_pixel_values(processor):
+    assert processor.tokenizer.padding_side == "left"
+    assert processor.tokenizer.model_input_names == ["input_ids", "attention_mask", "pixel_values"]
+
+
+def test_processor_process_queries_prefixes_and_tokenizes(processor):
+    output = processor.process_queries(["What is shown?"])
+
+    assert set(output) == {"input_ids", "attention_mask"}
+    call = processor.tokenizer.calls[-1]
+    assert call["texts"] == ["query: What is shown?"]
+    assert call["kwargs"] == {
+        "truncation": True,
+        "max_length": 7,
+        "padding": True,
+        "pad_to_multiple_of": 4,
+        "return_tensors": "pt",
+    }
+
+
+def test_processor_process_queries_handles_multiple_queries_and_options(processor):
+    processor.process_queries(["First query", "Second query"], return_tensors="np", padding=False, truncation=False)
+
+    call = processor.tokenizer.calls[-1]
+    assert call["texts"] == ["query: First query", "query: Second query"]
+    assert call["kwargs"] == {
+        "truncation": False,
+        "max_length": None,
+        "padding": False,
+        "pad_to_multiple_of": 4,
+        "return_tensors": "np",
+    }
+
+
+def test_processor_process_documents_supports_text_only_inputs(processor):
+    output = processor.process_documents({"images": ["", None], "texts": ["Document A", "Document B"]})
+
+    assert set(output) == {"input_ids", "attention_mask", "pixel_values"}
+    assert output["pixel_values"] is None
+    call = processor.tokenizer.calls[-1]
+    assert call["texts"] == ["passage: Document A", "passage: Document B"]
+    assert call["kwargs"] == {
+        "truncation": True,
+        "max_length": 11,
+        "padding": True,
+        "pad_to_multiple_of": 4,
+        "return_tensors": "pt",
+    }
+
+
+def test_processor_process_documents_supports_pil_images_and_text(processor):
+    images = [
+        Image.new("RGB", (4, 4), (255, 0, 0)),
+        Image.new("RGB", (8, 4), (0, 255, 0)),
+    ]
+
+    output = processor.process_documents({"images": images, "texts": ["text 1", "text 2"]})
+
+    assert set(output) == {"input_ids", "attention_mask", "pixel_values"}
+    assert output["pixel_values"].shape == (4, 3, 4, 4)
+    assert output["pixel_values"].dtype == torch.bfloat16
+
+    call = processor.tokenizer.calls[-1]
+    assert call["texts"][0].startswith("passage: <img>")
+    assert call["texts"][0].count("<IMG_CONTEXT>") == 2
+    assert call["texts"][0].endswith("</img> text 1")
+    assert call["texts"][1].startswith("passage: <img>")
+    assert call["texts"][1].count("<IMG_CONTEXT>") == 6
+    assert call["texts"][1].endswith("</img> text 2")
+    assert call["kwargs"] == {
+        "truncation": True,
+        "max_length": 11,
+        "padding": True,
+        "pad_to_multiple_of": 4,
+        "return_tensors": "pt",
+    }
+
+
+def test_processor_process_documents_can_return_per_image_tiles(processor):
+    images = [
+        Image.new("RGB", (4, 4), (255, 0, 0)),
+        Image.new("RGB", (8, 4), (0, 255, 0)),
+    ]
+
+    output = processor.process_documents(
+        {"images": images, "texts": ["text 1", "text 2"]},
+        pixel_values_layout="per_image",
+    )
+
+    assert len(output["pixel_values"]) == 2
+    assert output["pixel_values"][0].shape == (1, 3, 4, 4)
+    assert output["pixel_values"][1].shape == (3, 3, 4, 4)
+
+
+def test_processor_biencoder_collator_merges_query_document_batches(processor):
+    features = [
+        {"question": "Question 0", "doc_text": ["Doc 0", "Doc 1"], "doc_image": ["", ""]},
+        {"question": "Question 1", "doc_text": ["Doc 2", "Doc 3"], "doc_image": ["", ""]},
+    ]
+
+    output = processor.process_queries_documents_biencoder(features)
+
+    assert set(output) == {
+        "q_input_ids",
+        "q_attention_mask",
+        "d_input_ids",
+        "d_attention_mask",
+        "d_pixel_values",
+        "labels",
+    }
+    assert output["q_input_ids"].shape[0] == 2
+    assert output["d_input_ids"].shape[0] == 4
+    assert output["d_pixel_values"] is None
+    assert output["labels"].dtype == torch.long
+    assert torch.equal(output["labels"], torch.zeros(2, dtype=torch.long))
+
+
+def test_model_encode_queries_uses_processor_and_pools_text_embeddings(tiny_model):
+    embeddings = tiny_model.encode_queries(["First query", "Second query"])
+
+    assert embeddings.shape == (2, tiny_model.config.llm_config.hidden_size)
+    assert torch.allclose(embeddings, torch.full_like(embeddings, 2.5))
+    assert tiny_model.processor.tokenizer.calls[-1]["texts"] == ["query: First query", "query: Second query"]
+    forward_call = tiny_model.language_model.forward_calls[-1]
+    assert forward_call["inputs_embeds"].shape == (2, 2, tiny_model.config.llm_config.hidden_size)
+    assert forward_call["output_hidden_states"] is True
+
+
+def test_model_encode_documents_with_images_and_text_uses_vision_embeddings(tiny_model, monkeypatch):
+    captured = {}
+
+    def fake_extract_feature(pixel_values):
+        captured["pixel_values_shape"] = tuple(pixel_values.shape)
+        hidden_size = tiny_model.config.llm_config.hidden_size
+        vision_features = torch.arange(pixel_values.shape[0] * 2 * hidden_size, dtype=torch.float32).reshape(
+            pixel_values.shape[0],
+            2,
+            hidden_size,
+        )
+        captured["vision_features"] = vision_features
+        return vision_features
+
+    monkeypatch.setattr(tiny_model, "extract_feature", fake_extract_feature)
+    images = [
+        Image.new("RGB", (4, 4), (255, 0, 0)),
+        Image.new("RGB", (8, 4), (0, 255, 0)),
+    ]
+
+    embeddings = tiny_model.encode_documents(images=images, texts=["text 1", "text 2"])
+
+    assert embeddings.shape == (2, tiny_model.config.llm_config.hidden_size)
+    assert captured["pixel_values_shape"] == (4, 3, 4, 4)
+    assert tiny_model.processor.tokenizer.calls[-1]["texts"][0].endswith("</img> text 1")
+    assert tiny_model.processor.tokenizer.calls[-1]["texts"][1].endswith("</img> text 2")
+
+    forward_call = tiny_model.language_model.forward_calls[-1]
+    input_embeds = forward_call["inputs_embeds"]
+    attention_mask = forward_call["attention_mask"]
+    assert input_embeds.shape[:2] == attention_mask.shape == (2, 8)
+    assert attention_mask.tolist() == [[1, 1, 1, 1, 0, 0, 0, 0], [1, 1, 1, 1, 1, 1, 1, 1]]
+    vision_features = captured["vision_features"].reshape(-1, tiny_model.config.llm_config.hidden_size)
+    assert torch.allclose(input_embeds[0, 1:3], vision_features[:2])
+    assert torch.allclose(input_embeds[1, 1:7], vision_features[2:8])
+
+
+def test_model_forward_injects_image_embeddings_into_text_sequence(tiny_model, monkeypatch):
+    hidden_size = tiny_model.config.llm_config.hidden_size
+    vision_features = torch.stack(
+        [
+            torch.full((hidden_size,), -3.0),
+            torch.full((hidden_size,), -7.0),
+        ]
+    ).reshape(2, 1, hidden_size)
+
+    def fake_extract_feature(pixel_values):
+        assert tuple(pixel_values.shape) == (2, 3, 4, 4)
+        return vision_features
+
+    monkeypatch.setattr(tiny_model, "extract_feature", fake_extract_feature)
+    input_ids = torch.tensor([[1, IMG_CONTEXT_TOKEN_ID, IMG_CONTEXT_TOKEN_ID, 2]])
+    attention_mask = torch.ones_like(input_ids)
+    pixel_values = torch.ones((2, 3, 4, 4))
+
+    output = tiny_model.forward(
+        pixel_values=pixel_values,
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        output_hidden_states=True,
+        return_dict=True,
+    )
+
+    injected_embeds = tiny_model.language_model.forward_calls[-1]["inputs_embeds"]
+    assert torch.allclose(injected_embeds[0, 0], torch.full((hidden_size,), 1.0))
+    assert torch.allclose(injected_embeds[0, 1], vision_features[0, 0])
+    assert torch.allclose(injected_embeds[0, 2], vision_features[1, 0])
+    assert torch.allclose(injected_embeds[0, 3], torch.full((hidden_size,), 2.0))
+    assert output.logits.shape == (1, 4, tiny_model.language_model.config.vocab_size)
+    assert torch.allclose(output.hidden_states[-1], injected_embeds + 1.0)
+
+
+def _target_ratios(max_num=6):
+    return sorted(
+        {
+            (i, j)
+            for n in range(1, max_num + 1)
+            for i in range(1, n + 1)
+            for j in range(1, n + 1)
+            if 1 <= i * j <= max_num
+        },
+        key=lambda ratio: ratio[0] * ratio[1],
+    )
+
+
+@pytest.mark.parametrize(
+    ("size", "expected_ratio", "expected_tiles"),
+    [
+        ((4, 4), (1, 1), 1),
+        ((8, 4), (2, 1), 2),
+        ((4, 8), (1, 2), 2),
+        ((12, 4), (3, 1), 3),
+        ((4, 12), (1, 3), 3),
+        ((16, 8), (3, 2), 6),
+        ((8, 16), (2, 3), 6),
+        ((20, 4), (5, 1), 5),
+        ((4, 20), (1, 5), 5),
+    ],
+)
+def test_find_closest_aspect_ratio_for_image_shapes(size, expected_ratio, expected_tiles):
+    ratio = find_closest_aspect_ratio(
+        aspect_ratio=size[0] / size[1],
+        target_ratios=_target_ratios(),
+        width=size[0],
+        height=size[1],
+        image_size=4,
+    )
+
+    assert ratio == expected_ratio
+    assert ratio[0] * ratio[1] == expected_tiles
+
+
+@pytest.mark.parametrize(
+    ("size", "expected_tiles"),
+    [
+        ((4, 4), 1),
+        ((8, 4), 2),
+        ((4, 8), 2),
+        ((12, 4), 3),
+        ((4, 12), 3),
+        ((16, 8), 6),
+        ((8, 16), 6),
+        ((20, 4), 5),
+        ((4, 20), 5),
+    ],
+)
+def test_dynamic_preprocess_tile_counts_for_image_shapes(size, expected_tiles):
+    tiles = dynamic_preprocess(Image.new("RGB", size), image_size=4, max_num=6, use_thumbnail=False)
+
+    assert len(tiles) == expected_tiles
+    assert [tile.size for tile in tiles] == [(4, 4)] * expected_tiles
+
+
+def test_dynamic_preprocess_adds_thumbnail_only_for_multi_tile_images():
+    square_tiles = dynamic_preprocess(Image.new("RGB", (4, 4)), image_size=4, max_num=6, use_thumbnail=True)
+    wide_tiles = dynamic_preprocess(Image.new("RGB", (8, 4)), image_size=4, max_num=6, use_thumbnail=True)
+
+    assert len(square_tiles) == 1
+    assert len(wide_tiles) == 3
+    assert [tile.size for tile in wide_tiles] == [(4, 4), (4, 4), (4, 4)]
+
+
+def test_llama_nemotron_vl_config_builds_composed_subconfigs():
+    config = LlamaNemotronVLConfig(
+        vision_config=_tiny_vision_config(),
+        llm_config=_tiny_llm_config(),
+        q_max_length=13,
+        p_max_length=21,
+        pooling="avg",
+    )
+
+    assert config.model_type == "llama_nemotron_vl"
+    assert isinstance(config.vision_config, SiglipVisionConfig)
+    assert isinstance(config.llm_config, LlamaBidirectionalConfig)
+    assert config.llm_config.architectures == ["LlamaBidirectionalModel"]
+    assert config.q_max_length == 13
+    assert config.p_max_length == 21
+    assert config.pooling == "avg"
+
+
+def test_llama_nemotron_vl_config_rejects_unsupported_vision_model():
+    vision_config = _tiny_vision_config()
+    vision_config["model_type"] = "unsupported_vision"
+
+    with pytest.raises(ValueError, match="Unsupported model_type"):
+        LlamaNemotronVLConfig(vision_config=vision_config, llm_config=_tiny_llm_config())
+
+
+def test_llama_nemotron_vl_config_rejects_unsupported_llm_architecture():
+    llm_config = _tiny_llm_config()
+    llm_config["architectures"] = ["UnsupportedArchitecture"]
+
+    with pytest.raises(ValueError, match="Unsupported architecture"):
+        LlamaNemotronVLConfig(vision_config=_tiny_vision_config(), llm_config=llm_config)


### PR DESCRIPTION
# What does this PR do ?

Adds support to VLM finetuning as multimodal biencoder models for visual document retrieval + adds Nemotron VL 1B multimodal embedding model finetuning

# Changelog

- Adds support to finetuning a VLM as a biencoder / embedding models for visual (document) retrieval 
- Adds Nemotron VL 1B biencoder finetuning, that supports retrieving both doc page images and texts
- Adds an example YAML and readme on how to finetune Nemotron VL 1B on domain-specific data

# Before your PR is "Ready for review"

**Pre checks**:

- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.
