### PR TITLE
feat(vlm): wire BitsAndBytes QLoRA quantization into VLM finetune recipe

### DIFF
--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -126,6 +126,7 @@ def build_model(
     pipeline_config=None,
     cfg_moe=None,
     activation_checkpointing=False,
+    cfg_quantization=None,
 ) -> tuple[nn.Module | AutoPipeline, list["Optimizer"]]:  # noqa: F821
     """Build and initialize a model for VLM.
 
@@ -161,6 +162,11 @@ def build_model(
             kwargs["fp8_config"] = fp8_config
         if cfg_compile is not None:
             kwargs["compile_config"] = build_compile_config(cfg_compile)
+        if cfg_quantization is not None:
+            logger.info("Model weight quantization enabled with BitsAndBytes")
+            from nemo_automodel.components.quantization.qlora import create_bnb_config
+
+            kwargs["quantization_config"] = create_bnb_config(cfg_quantization)
 
         # Check if using NeMoAutoModel
         is_nemo_auto_model = cfg_model.get("_target_", None) in (
@@ -829,6 +835,7 @@ class FinetuneRecipeForVLM(BaseRecipe):
             seed=self.cfg.get("seed", 42),
             cfg_fp8=self.cfg.get("fp8", None),
             cfg_compile=self.cfg.get("compile", None),
+            cfg_quantization=self.cfg.get("quantization", None),
             device_mesh=self.device_mesh,
             moe_mesh=self.moe_mesh,
             distributed_config=self.distributed_config,

--- a/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
+++ b/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
@@ -290,6 +290,77 @@ def test_build_model_no_moe_config_when_cfg_moe_is_none():
     assert "activation_checkpointing" not in captured_kwargs
 
 
+def test_build_model_passes_quantization_config():
+    """cfg_quantization is converted via create_bnb_config and forwarded as quantization_config."""
+    from nemo_automodel._transformers import NeMoAutoModelForImageTextToText
+
+    captured_kwargs = {}
+
+    class CapturingModelConfig:
+        def __init__(self):
+            self._target_ = NeMoAutoModelForImageTextToText.from_pretrained
+
+        def instantiate(self, **kwargs):
+            captured_kwargs.update(kwargs)
+            return DummyModel()
+
+        def get(self, key, default=None):
+            return getattr(self, key, default)
+
+    cfg_model = CapturingModelConfig()
+    cfg_quantization = SimpleNamespace(load_in_4bit=True)
+    sentinel_bnb = object()
+
+    with (
+        patch("nemo_automodel.recipes.vlm.finetune._supports_logits_to_keep", return_value=True),
+        patch(
+            "nemo_automodel.components.quantization.qlora.create_bnb_config",
+            return_value=sentinel_bnb,
+        ) as mock_create,
+    ):
+        build_model(
+            cfg_model=cfg_model,
+            cfg_freeze=None,
+            cfg_peft=None,
+            seed=123,
+            cfg_quantization=cfg_quantization,
+        )
+
+    # Wiring: cfg_quantization -> create_bnb_config(...) -> kwargs["quantization_config"]
+    mock_create.assert_called_once_with(cfg_quantization)
+    assert captured_kwargs.get("quantization_config") is sentinel_bnb
+
+
+def test_build_model_no_quantization_config_when_none():
+    """No quantization_config kwarg when cfg_quantization is None (the default)."""
+    from nemo_automodel._transformers import NeMoAutoModelForImageTextToText
+
+    captured_kwargs = {}
+
+    class CapturingModelConfig:
+        def __init__(self):
+            self._target_ = NeMoAutoModelForImageTextToText.from_pretrained
+
+        def instantiate(self, **kwargs):
+            captured_kwargs.update(kwargs)
+            return DummyModel()
+
+        def get(self, key, default=None):
+            return getattr(self, key, default)
+
+    cfg_model = CapturingModelConfig()
+
+    with patch("nemo_automodel.recipes.vlm.finetune._supports_logits_to_keep", return_value=True):
+        build_model(
+            cfg_model=cfg_model,
+            cfg_freeze=None,
+            cfg_peft=None,
+            seed=123,
+        )
+
+    assert "quantization_config" not in captured_kwargs
+
+
 # -----------------------------------------------------------------------------
 # FinetuneRecipeForVLM helpers
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## What

Thread a `quantization:` config block through the VLM finetune recipe so QLoRA (4-bit base + LoRA) works for image-text-to-text models. The LLM recipe (`train_ft.py`) already supported this; the VLM recipe (`recipes/vlm/finetune.py`) silently ignored the block.

The change mirrors the existing `fp8`/`compile` wiring exactly:
- `build_model(...)` gains a `cfg_quantization` parameter; when set, it builds a `BitsAndBytesConfig` via `create_bnb_config` and adds it to the kwargs passed to `NeMoAutoModel*.from_pretrained` (which already accepts `quantization_config`).
- The recipe build call site passes `cfg_quantization=self.cfg.get("quantization", None)`.

LoRA-over-4bit needs no new code — `apply_lora_to_linear_modules` already handles the QLoRA case (adapter dtype from `bnb_4bit_compute_dtype`, frozen `Linear4bit` base via `LinearLoRA.super_fwd`).

## Usage

Add to any VLM finetune config:

```yaml
quantization:
  load_in_4bit: true
  bnb_4bit_compute_dtype: bfloat16
  bnb_4bit_use_double_quant: true
  bnb_4bit_quant_type: nf4
  bnb_4bit_quant_storage: bfloat16
```

## Verification

Dense VLM (Qwen3.5-27B), single GPU, MedPix, 100 steps:

| | bf16 LoRA | QLoRA (4-bit) |
|---|---|---|
| peak GPU mem | 66.9 GiB | **31.8 GiB** |
| `Linear4bit` modules | 0 | 111 |
| train-loss curve | — | corr **0.995** vs LoRA |

## Scope / limitations

- Works for **dense** VLMs (weights are `nn.Linear` → bnb quantizes natively).
- **Custom MoE** models (fused 3D expert `nn.Parameter`s) are out of scope: bitsandbytes only quantizes `nn.Linear`, so experts stay bf16 and there's no memory benefit. Supporting MoE QLoRA needs separate model-layer work (per-expert 4-bit storage + dequant-in-grouped-GEMM) and is left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)