### PR TITLE
fix(datasets): warn when agent SFT seq_length has no effect

### DIFF
--- a/examples/llm_finetune/agent/qwen2_5_3b_function_calling.yaml
+++ b/examples/llm_finetune/agent/qwen2_5_3b_function_calling.yaml
@@ -82,6 +82,9 @@ dataset:
   _target_: nemo_automodel.components.datasets.llm.agent_chat.make_agent_chat_dataset
   dataset_name: llamafactory/glaive_toolcall_en
   split: train
+  # NOTE: seq_length only caps length when truncation is enabled (or pads when
+  # padding: max_length). With the defaults it does NOT truncate, so long
+  # dialogues pass through uncapped. Add `truncation: true` to enforce the cap.
   seq_length: 4096
   tokenizer:
     pretrained_model_name_or_path: Qwen/Qwen2.5-3B

--- a/examples/llm_finetune/agent/qwen2_5_3b_function_calling_lora.yaml
+++ b/examples/llm_finetune/agent/qwen2_5_3b_function_calling_lora.yaml
@@ -78,6 +78,9 @@ dataset:
   _target_: nemo_automodel.components.datasets.llm.agent_chat.make_agent_chat_dataset
   dataset_name: llamafactory/glaive_toolcall_en
   split: train
+  # NOTE: seq_length only caps length when truncation is enabled (or pads when
+  # padding: max_length). With the defaults it does NOT truncate, so long
+  # dialogues pass through uncapped. Add `truncation: true` to enforce the cap.
   seq_length: 4096
   tokenizer:
     pretrained_model_name_or_path: Qwen/Qwen2.5-3B

--- a/nemo_automodel/components/datasets/llm/agent_chat.py
+++ b/nemo_automodel/components/datasets/llm/agent_chat.py
@@ -543,6 +543,22 @@ def make_agent_chat_dataset(
     if (dataset_name is None) == (path is None):
         raise ValueError("Exactly one of `dataset_name` or `path` must be provided")
 
+    # ``seq_length`` is forwarded to ``apply_chat_template(max_length=...)``, which
+    # the tokenizer only honors when truncation is enabled (to cap the length) or
+    # when ``padding="max_length"`` (to pad up to it). With the defaults
+    # (``truncation=False``, ``padding=False``) ``max_length`` is ignored, so
+    # ``seq_length`` silently has no effect and over-long dialogues pass through
+    # uncapped. Warn rather than silently dropping tokens by flipping truncation on.
+    truncation_active = bool(truncation) and truncation != "do_not_truncate"
+    if seq_length is not None and not truncation_active and padding != "max_length":
+        logger.warning(
+            "`seq_length=%s` has no effect: truncation is disabled and `padding` is not "
+            "'max_length', so the tokenizer ignores `max_length` and dialogues are not "
+            "capped. Set `truncation=True` to cap long dialogues, or `padding='max_length'` "
+            "to pad to `seq_length`.",
+            seq_length,
+        )
+
     if dataset_name is not None:
         if limit_dataset_samples is not None:
             assert isinstance(limit_dataset_samples, int), "Expected limit_dataset_samples to be an int"

--- a/tests/unit_tests/datasets/llm/test_agent_chat.py
+++ b/tests/unit_tests/datasets/llm/test_agent_chat.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 import json
+import logging
 
 import pytest
 
@@ -661,3 +662,64 @@ def test_format_example_wraps_missing_fields_with_example_id():
         agent_chat._format_example({"id": 7}, Tok(), 0, 0)
     with pytest.raises(ValueError, match="id=7"):
         agent_chat._format_example({"id": 7}, Tok(), 0, 0)
+
+
+def _patch_minimal_loader(monkeypatch):
+    """Patch load_dataset / pad-token / formatter so dataset build does no real work."""
+
+    class DummyDataset:
+        def __init__(self, items):
+            self.items = items
+
+        def __getitem__(self, idx):
+            return self.items[idx]
+
+        def __len__(self):
+            return len(self.items)
+
+    monkeypatch.setattr(
+        agent_chat, "load_dataset", lambda *a, **k: DummyDataset([{"id": 0, "messages": [], "tools": []}])
+    )
+    monkeypatch.setattr(agent_chat, "_add_pad_token", lambda tok: 0)
+    monkeypatch.setattr(agent_chat, "_format_example", lambda ex, *a, **kw: {"formatted": ex["id"]})
+
+
+def test_make_agent_chat_dataset_warns_when_seq_length_inert(monkeypatch, caplog):
+    # seq_length is forwarded to apply_chat_template(max_length=...), which the
+    # tokenizer ignores unless truncation is on or padding == "max_length". With
+    # the defaults the cap silently does nothing, so the builder must warn.
+    _patch_minimal_loader(monkeypatch)
+
+    class Tok:
+        eos_token_id = 0
+
+    with caplog.at_level(logging.WARNING, logger="nemo_automodel.components.datasets.llm.agent_chat"):
+        agent_chat.make_agent_chat_dataset(tokenizer=Tok(), dataset_name="dummy/agent", seq_length=4096)
+    assert any("has no effect" in r.getMessage() for r in caplog.records)
+
+
+def test_make_agent_chat_dataset_no_warning_when_seq_length_used(monkeypatch, caplog):
+    # When truncation is enabled (or padding == "max_length") the cap is real, so
+    # there must be no spurious warning.
+    _patch_minimal_loader(monkeypatch)
+
+    class Tok:
+        eos_token_id = 0
+
+    with caplog.at_level(logging.WARNING, logger="nemo_automodel.components.datasets.llm.agent_chat"):
+        agent_chat.make_agent_chat_dataset(
+            tokenizer=Tok(), dataset_name="dummy/agent", seq_length=4096, truncation=True
+        )
+    assert not any("has no effect" in r.getMessage() for r in caplog.records)
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="nemo_automodel.components.datasets.llm.agent_chat"):
+        agent_chat.make_agent_chat_dataset(
+            tokenizer=Tok(), dataset_name="dummy/agent", seq_length=4096, padding="max_length"
+        )
+    assert not any("has no effect" in r.getMessage() for r in caplog.records)
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="nemo_automodel.components.datasets.llm.agent_chat"):
+        agent_chat.make_agent_chat_dataset(tokenizer=Tok(), dataset_name="dummy/agent")
+    assert not any("has no effect" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
# What does this PR do ?

`make_agent_chat_dataset` forwards `seq_length` to `apply_chat_template(max_length=...)`, which the tokenizer only honors when truncation is enabled (to cap) or when `padding="max_length"` (to pad). With the dataset defaults (`truncation=False`, `padding=False`) — and the shipped agent example configs — `max_length` is ignored, so `seq_length` silently has no effect and over-long dialogues pass through uncapped (misleading config + OOM risk). This warns instead of failing silently, and documents the requirement in the example configs.

# Changelog

- Warn in `make_agent_chat_dataset` when `seq_length` is set but neither truncation nor `padding="max_length"` will apply it.
- Add a clarifying comment next to `seq_length` in both `examples/llm_finetune/agent/qwen2_5_3b_function_calling*.yaml` configs.
- Add unit tests for the warning case and the no-warning cases (truncation on / `padding="max_length"` / `seq_length` unset).

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

# Additional Information

- No behavior change: warning only — it does not enable truncation or drop any tokens.
