### PR TITLE
fix(datasets): tag agent SFT row errors with the example id

### DIFF
--- a/nemo_automodel/components/datasets/llm/agent_chat.py
+++ b/nemo_automodel/components/datasets/llm/agent_chat.py
@@ -260,6 +260,43 @@ def _format_example(
     train_on_last_turn_only: bool = False,
     drop_history_reasoning_content: bool = False,
 ) -> Dict[str, List[int]]:
+    """Render one agent example into tokenized ``input_ids`` / ``labels``.
+
+    Thin wrapper that re-raises any parsing/rendering failure as a ``ValueError``
+    tagged with the example id. Rows are rendered lazily inside the dataloader,
+    so without this a single malformed row surfaces as an opaque
+    ``JSONDecodeError``/``AssertionError`` deep in the stack — with no hint as to
+    which row caused it — and aborts the whole training run.
+    """
+    try:
+        return _format_example_impl(
+            example,
+            tokenizer,
+            eos_token_id,
+            pad_token_id,
+            seq_length=seq_length,
+            padding=padding,
+            truncation=truncation,
+            mask_reasoning_content=mask_reasoning_content,
+            train_on_last_turn_only=train_on_last_turn_only,
+            drop_history_reasoning_content=drop_history_reasoning_content,
+        )
+    except Exception as e:
+        raise ValueError(f"Failed to format agent SFT example (id={example.get('id')!r}): {e}") from e
+
+
+def _format_example_impl(
+    example: Dict[str, Any],
+    tokenizer,
+    eos_token_id: int,
+    pad_token_id: int,
+    seq_length: Optional[int] = None,
+    padding: Union[str, bool] = False,
+    truncation: Union[str, bool] = False,
+    mask_reasoning_content: bool = False,
+    train_on_last_turn_only: bool = False,
+    drop_history_reasoning_content: bool = False,
+) -> Dict[str, List[int]]:
     """Render one agent example into tokenized ``input_ids`` / ``labels``."""
     raw_tools = example.get("tools")
     if isinstance(raw_tools, str) and not raw_tools.strip():

--- a/tests/unit_tests/datasets/llm/test_agent_chat.py
+++ b/tests/unit_tests/datasets/llm/test_agent_chat.py
@@ -620,3 +620,44 @@ def test_format_example_forwards_drop_history_reasoning_content(monkeypatch):
 
     agent_chat._format_example(example, Tok(), 0, 0, drop_history_reasoning_content=True)
     assert captured["drop_history_reasoning_content"] is True
+
+
+def test_format_example_malformed_tools_json_reports_example_id():
+    # A row whose `tools` is malformed JSON must fail with the example id, not an
+    # opaque JSONDecodeError surfacing deep in the lazy dataloader map.
+    class Tok:
+        eos_token_id = 0
+        pad_token_id = 0
+
+    example = {"id": 99, "tools": "{not valid json", "messages": [{"role": "user", "content": "hi"}]}
+    with pytest.raises(ValueError, match="id=99"):
+        agent_chat._format_example(example, Tok(), 0, 0)
+
+
+def test_format_example_malformed_tool_call_reports_example_id():
+    # A malformed tool_call payload must also surface the example id.
+    class Tok:
+        eos_token_id = 0
+        pad_token_id = 0
+
+    example = {
+        "id": "abc",
+        "messages": [
+            {"role": "user", "content": "hi"},
+            {"role": "tool_call", "content": "{bad json"},
+        ],
+    }
+    with pytest.raises(ValueError, match="id='abc'"):
+        agent_chat._format_example(example, Tok(), 0, 0)
+
+
+def test_format_example_wraps_missing_fields_with_example_id():
+    # The existing field-validation errors keep their text but gain the id tag.
+    class Tok:
+        eos_token_id = 0
+        pad_token_id = 0
+
+    with pytest.raises(ValueError, match="missing both `messages` and `conversations`"):
+        agent_chat._format_example({"id": 7}, Tok(), 0, 0)
+    with pytest.raises(ValueError, match="id=7"):
+        agent_chat._format_example({"id": 7}, Tok(), 0, 0)


### PR DESCRIPTION
# What does this PR do ?

`_format_example` renders agent SFT rows lazily inside the dataloader. A single malformed row — bad `tools`/`tool_call` JSON, or missing required fields — surfaced as an opaque `JSONDecodeError`/`AssertionError` deep in the stack with no indication of which row caused it, aborting the whole training run. This re-raises any parse/render failure as a `ValueError` tagged with the example id so the offending row is actionable.

# Changelog

- Wrap `_format_example` so any parsing/rendering failure is re-raised as a `ValueError` tagged with the example `id` (original error chained via `raise ... from e`).
- Move the renderer body into `_format_example_impl`; the public `_format_example` (used by the lazy dataloader map) is the thin error-context wrapper.
- Add unit tests: malformed `tools` JSON and malformed `tool_call` content both report the example id; existing field-validation messages are preserved.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

# Additional Information

- No happy-path behavior change.
- Touches the same `_format_example` as the "reject examples with no supervised tokens" fix (separate PR); whichever merges first, the other needs a trivial rebase.
