### PR TITLE
fix(datasets): warn on agent SFT rows with no supervised tokens

### DIFF
--- a/nemo_automodel/components/datasets/llm/agent_chat.py
+++ b/nemo_automodel/components/datasets/llm/agent_chat.py
@@ -338,6 +338,23 @@ def _format_example_impl(
     )
     if train_on_last_turn_only:
         _mask_labels_to_last_turn(tokenized["labels"])
+
+    # Truncation (or over-aggressive last-turn masking) can leave a sample with no
+    # supervised tokens at all — every label is ``ignore_index`` (-100). A single
+    # such sample is harmless: the loss normalizes by the batch's supervised-token
+    # count, so it just contributes nothing (a NaN only arises if a *whole* step is
+    # empty, which signals a misconfigured seq_length/truncation). Rather than
+    # hard-failing the run on one example, warn (with the id) and let it through — it
+    # is already effectively skipped from the gradient, and the map-style
+    # dataset/collator cannot drop a row in place at this stage.
+    labels = tokenized.get("labels")
+    if labels is not None and all(label == -100 for label in labels):
+        logger.warning(
+            "Agent SFT example (id=%r) has no supervised tokens (all labels masked); it "
+            "contributes nothing to the loss. This usually means truncation dropped every "
+            "assistant turn — increase seq_length or disable truncation.",
+            example.get("id"),
+        )
     return tokenized
 
 

--- a/tests/unit_tests/datasets/llm/test_agent_chat.py
+++ b/tests/unit_tests/datasets/llm/test_agent_chat.py
@@ -723,3 +723,44 @@ def test_make_agent_chat_dataset_no_warning_when_seq_length_used(monkeypatch, ca
     with caplog.at_level(logging.WARNING, logger="nemo_automodel.components.datasets.llm.agent_chat"):
         agent_chat.make_agent_chat_dataset(tokenizer=Tok(), dataset_name="dummy/agent")
     assert not any("has no effect" in r.getMessage() for r in caplog.records)
+
+
+def test_format_example_warns_and_keeps_when_all_labels_masked(monkeypatch, caplog):
+    # If truncation drops every assistant token the loss mask is all-ignore. A
+    # single such sample is harmless (it contributes nothing to the batch-normalized
+    # loss), so the renderer warns with the id and returns the sample as-is rather
+    # than hard-failing the run.
+    monkeypatch.setattr(
+        agent_chat,
+        "format_chat_template",
+        lambda **kw: {"input_ids": [1, 2, 3], "labels": [-100, -100, -100]},
+    )
+
+    class Tok:
+        eos_token_id = 0
+        pad_token_id = 0
+
+    example = {"id": 123, "messages": [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "x"}]}
+    with caplog.at_level(logging.WARNING, logger="nemo_automodel.components.datasets.llm.agent_chat"):
+        result = agent_chat._format_example(example, Tok(), 0, 0)
+    # Sample is kept unchanged (not dropped, not raised on).
+    assert result["labels"] == [-100, -100, -100]
+    # Warning fired and names the offending example id.
+    warnings = [r.getMessage() for r in caplog.records if "no supervised tokens" in r.getMessage()]
+    assert warnings and "123" in warnings[0]
+
+
+def test_format_example_ok_when_some_label_supervised(monkeypatch):
+    # A sample with at least one supervised label passes through unchanged.
+    monkeypatch.setattr(
+        agent_chat,
+        "format_chat_template",
+        lambda **kw: {"input_ids": [1, 2, 3], "labels": [-100, 2, 3]},
+    )
+
+    class Tok:
+        eos_token_id = 0
+        pad_token_id = 0
+
+    example = {"id": 1, "messages": [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "x"}]}
+    assert agent_chat._format_example(example, Tok(), 0, 0)["labels"] == [-100, 2, 3]


### PR DESCRIPTION
# What does this PR do ?

When truncation drops every assistant turn (or last-turn masking leaves
nothing), `_format_example` produces an agent SFT sample whose `labels` are all
`ignore_index` (-100). The pre-existing guard only catches "no assistant message
present", not "assistant tokens truncated away".

A *single* such sample is harmless: the loss normalizes by the batch's
supervised-token count, so an all-masked example contributes nothing to the
gradient. A NaN only arises if a *whole* step is empty, which signals a
misconfigured `seq_length`/`truncation`. So rather than hard-failing the run on
one example, this detects the all-masked case and **warns** with the example id
(pointing at `seq_length`/`truncation`) while **keeping** the sample — it is
already effectively skipped from the gradient, and the map-style
dataset/collator cannot drop a row in place at this stage.

# Changelog

- After rendering (and after optional last-turn masking), emit a warning tagged
  with the example `id` when a sample has no supervised tokens (all labels
  masked), pointing at `seq_length`/`truncation` as the likely cause. The sample
  is kept, not dropped or raised on.
- Add unit tests for the all-masked (warns, kept) and partially-supervised
  (passes through) cases.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

# Additional Information

- Rebased onto current `main` (after #2361 moved the renderer body into
  `_format_example_impl` and #2360 added the `seq_length`-inert warning); both
  warnings coexist in `agent_chat.py`.
