### PR TITLE
perf(datasets): skip full-conversation re-tokenization in chat loss mask

### DIFF
--- a/nemo_automodel/components/datasets/llm/formatting_utils.py
+++ b/nemo_automodel/components/datasets/llm/formatting_utils.py
@@ -137,30 +137,50 @@ def _build_multiturn_assistant_mask(
     tools: Optional[List[Dict]] = None,
     truncation: Union[str, bool] = "do_not_truncate",
     seq_length: Optional[int] = None,
+    full_length: Optional[int] = None,
 ) -> List[int]:
-    """Build a fallback loss mask that supervises every assistant turn."""
+    """Build a fallback loss mask that supervises every assistant turn.
+
+    Each assistant span is located by tokenizing the conversation prefixes
+    before and after the turn, which is O(turns) ``apply_chat_template`` calls.
+    Two reductions keep that from re-doing work:
+
+    - ``full_length`` is the caller's already-known unpadded token count for the
+      whole conversation (``sum(attention_mask)``). When the dialogue ends on an
+      assistant turn its closing boundary is the full conversation, so passing
+      ``full_length`` skips re-tokenizing the entire prefix — the single most
+      expensive call in the loop.
+    - Prefix lengths are memoized so a boundary shared by adjacent turns (a
+      turn's end and the next turn's start) is tokenized at most once.
+
+    Both are exact: ``full_length`` and the memoized values equal what
+    :func:`_tokenized_chat_length` would return, so the mask is unchanged.
+    """
     assistant_mask = [0] * len(input_ids)
     found_assistant = False
+
+    length_cache: Dict[int, int] = {}
+    if full_length is not None:
+        length_cache[len(formatted_text)] = full_length
+
+    def prefix_length(k: int) -> int:
+        if k not in length_cache:
+            length_cache[k] = _tokenized_chat_length(
+                tokenizer,
+                formatted_text[:k],
+                tools=tools,
+                truncation=truncation,
+                seq_length=seq_length,
+            )
+        return length_cache[k]
 
     for idx, message in enumerate(formatted_text):
         if message["role"] != "assistant":
             continue
 
         found_assistant = True
-        start = _tokenized_chat_length(
-            tokenizer,
-            formatted_text[:idx],
-            tools=tools,
-            truncation=truncation,
-            seq_length=seq_length,
-        )
-        end = _tokenized_chat_length(
-            tokenizer,
-            formatted_text[: idx + 1],
-            tools=tools,
-            truncation=truncation,
-            seq_length=seq_length,
-        )
+        start = prefix_length(idx)
+        end = prefix_length(idx + 1)
         for pos in range(min(start, len(assistant_mask)), min(end, len(assistant_mask))):
             assistant_mask[pos] = 1
 
@@ -618,6 +638,12 @@ def format_chat_template(
     if template_has_generation_kwd:
         mask = tokenized_chat["assistant_masks"]
     elif not template_has_generation_kwd and answer_only_loss_mask:
+        # The unpadded token count of the whole conversation is already known
+        # from this tokenization; pass it so the mask builder need not
+        # re-tokenize the full prefix. Fall back to None (recompute) when no
+        # attention_mask is available.
+        attn_for_len = tokenized_chat.get("attention_mask")
+        full_length = sum(attn_for_len) if attn_for_len is not None else None
         mask = _build_multiturn_assistant_mask(
             tokenizer,
             formatted_text,
@@ -625,6 +651,7 @@ def format_chat_template(
             tools=tools,
             truncation=truncation,
             seq_length=seq_length,
+            full_length=full_length,
         )
         # _build_multiturn_assistant_mask computes indices from unpadded
         # lengths — shift for left-padding tokenizers.

--- a/tests/unit_tests/datasets/llm/test_formatting_utils.py
+++ b/tests/unit_tests/datasets/llm/test_formatting_utils.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from nemo_automodel.components.datasets.llm import formatting_utils
+
+
+class _CountingTokenizer:
+    """Minimal tokenizer stub: each message renders to a fixed token count.
+
+    Records how many times ``apply_chat_template`` is called so a test can
+    assert the mask builder skips the full-conversation re-tokenization.
+    """
+
+    def __init__(self, tokens_per_message=2):
+        self.calls = 0
+        self.tokens_per_message = tokens_per_message
+
+    def apply_chat_template(
+        self,
+        messages,
+        tools=None,
+        tokenize=True,
+        return_dict=True,
+        return_assistant_tokens_mask=False,
+        padding=False,
+        truncation=None,
+        max_length=None,
+    ):
+        self.calls += 1
+        n = len(messages) * self.tokens_per_message
+        return {"input_ids": list(range(n)), "attention_mask": [1] * n}
+
+
+def _conversation():
+    return [
+        {"role": "user", "content": "a"},
+        {"role": "assistant", "content": "b"},
+        {"role": "user", "content": "c"},
+        {"role": "assistant", "content": "d"},
+    ]
+
+
+def test_multiturn_mask_full_length_matches_recompute():
+    # Passing full_length must produce a byte-identical mask to the recompute path.
+    formatted = _conversation()
+    input_ids = list(range(2 * len(formatted)))
+
+    baseline = formatting_utils._build_multiturn_assistant_mask(_CountingTokenizer(), formatted, input_ids)
+    optimized = formatting_utils._build_multiturn_assistant_mask(
+        _CountingTokenizer(), formatted, input_ids, full_length=len(input_ids)
+    )
+    assert optimized == baseline
+    # assistant turns at idx 1 (tokens [2, 4)) and idx 3 (tokens [6, 8))
+    assert baseline == [0, 0, 1, 1, 0, 0, 1, 1]
+
+
+def test_multiturn_mask_full_length_skips_full_retokenize():
+    # When the dialogue ends on an assistant turn, the closing boundary is the
+    # full conversation and must be served from full_length, not a fresh call.
+    formatted = _conversation()
+    input_ids = list(range(2 * len(formatted)))
+
+    baseline_tok = _CountingTokenizer()
+    formatting_utils._build_multiturn_assistant_mask(baseline_tok, formatted, input_ids)
+
+    optimized_tok = _CountingTokenizer()
+    formatting_utils._build_multiturn_assistant_mask(optimized_tok, formatted, input_ids, full_length=len(input_ids))
+    assert optimized_tok.calls == baseline_tok.calls - 1
+
+
+def test_multiturn_mask_requires_assistant():
+    # The no-assistant guard is preserved.
+    formatted = [{"role": "user", "content": "a"}]
+    with pytest.raises(AssertionError, match="At least one assistant message"):
+        formatting_utils._build_multiturn_assistant_mask(_CountingTokenizer(), formatted, [0, 1])


### PR DESCRIPTION
# What does this PR do ?

For chat templates without a `{% generation %}` block (e.g. Qwen2.5), the answer-only loss mask is built by `_build_multiturn_assistant_mask`, which locates each assistant span by tokenizing the conversation prefix before and after the turn. The closing boundary of the final assistant turn re-tokenized the **entire** conversation — the single most expensive `apply_chat_template` call in the loop, repeated per example every epoch in the dataloader. This serves that boundary from the already-known unpadded length instead.

# Changelog

- `format_chat_template` passes the conversation's unpadded token count (`sum(attention_mask)`) to `_build_multiturn_assistant_mask` as `full_length`; the mask builder uses it for the final boundary instead of re-tokenizing the whole prefix, and memoizes prefix lengths shared by adjacent turns.
- Add `tests/unit_tests/datasets/llm/test_formatting_utils.py`: a parity test (mask byte-identical to the recompute path) and a call-count test (one fewer tokenization when the dialogue ends on an assistant turn).

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

# Additional Information

- Provably behavior-preserving: `full_length` equals `_tokenized_chat_length(formatted_text)`; falls back to recompute when no `attention_mask` is available.
- This is a conservative, safe reduction. A full O(N^2)->O(N) rewrite (offset-mapping based, and sharing prefix tokenizations with the reasoning-mask builder) is a larger follow-up that warrants dedicated parity testing.
- Touches shared `formatting_utils` used by all chat/agent SFT datasets, hence its own PR.
