### PR TITLE
fix(agent-sft): harden tool-call eval and fix last-turn loss masking

### DIFF
--- a/examples/llm_finetune/agent/qwen2_5_3b_function_calling.yaml
+++ b/examples/llm_finetune/agent/qwen2_5_3b_function_calling.yaml
@@ -110,10 +110,15 @@ validation_dataloader:
   _target_: torchdata.stateful_dataloader.StatefulDataLoader
   collate_fn: nemo_automodel.components.datasets.utils.default_collater
 
-# Generation-based tool-call accuracy eval. Runs at every val step alongside
-# val_loss. Catches the case where loss is decreasing but the model is
-# emitting wrong tool names or malformed argument JSON — a regression
-# loss alone cannot detect. Remove or comment out this block to disable.
+# Generation-based tool-call accuracy eval. Catches the case where loss is
+# decreasing but the model emits wrong tool names or malformed argument JSON —
+# something loss alone cannot detect. Remove or comment out this block to disable.
+#
+# NOTE: this recipe uses `distributed.strategy: fsdp2`, which SKIPS in-loop
+# generation eval by default — running generate() on the sharded training model
+# repeatedly unshards params and can OOM the next step. It runs every val step
+# under DDP. To force it under FSDP2, set `run_on_fsdp2: true` below (slower,
+# higher memory); or run the evaluator offline against a saved checkpoint.
 tool_call_eval:
   _target_: nemo_automodel.components.eval.tool_call_evaluator.ToolCallAccuracyEvaluator
   dataset_name: llamafactory/glaive_toolcall_en
@@ -121,6 +126,7 @@ tool_call_eval:
   max_eval_samples: 128
   max_new_tokens: 256
   max_prompt_tokens: 3584
+  # run_on_fsdp2: true   # opt in to in-loop eval under FSDP2 (otherwise skipped)
 
 optimizer:
   _target_: torch.optim.AdamW

--- a/nemo_automodel/components/datasets/llm/agent_chat.py
+++ b/nemo_automodel/components/datasets/llm/agent_chat.py
@@ -216,38 +216,6 @@ def _convert_messages(
     return out
 
 
-def _mask_labels_to_last_turn(labels: List[int], ignore_index: int = -100) -> List[int]:
-    """Restrict the loss to the final assistant turn (``mask_history``).
-
-    ``labels`` come from :func:`format_chat_template` with every assistant
-    turn supervised; non-assistant tokens are already ``ignore_index``.
-    Because the chat template renders each assistant message as a single
-    contiguous span, supervised tokens form one maximal run per assistant
-    turn separated by ``ignore_index`` runs. This keeps only the last such
-    run and masks every earlier supervised token in place.
-
-    Args:
-        labels: per-token labels (``ignore_index`` marks unsupervised tokens).
-        ignore_index: the value marking unsupervised tokens.
-
-    Returns:
-        The same list, mutated so only the final supervised run is kept.
-    """
-    last = -1
-    for i in range(len(labels) - 1, -1, -1):
-        if labels[i] != ignore_index:
-            last = i
-            break
-    if last < 0:
-        return labels
-    start = last
-    while start - 1 >= 0 and labels[start - 1] != ignore_index:
-        start -= 1
-    for i in range(start):
-        labels[i] = ignore_index
-    return labels
-
-
 def _format_example(
     example: Dict[str, Any],
     tokenizer,
@@ -335,10 +303,8 @@ def _format_example_impl(
         truncation=truncation,
         answer_only_loss_mask=True,
         mask_reasoning_content=mask_reasoning_content,
+        train_on_last_turn_only=train_on_last_turn_only,
     )
-    if train_on_last_turn_only:
-        _mask_labels_to_last_turn(tokenized["labels"])
-
     # Truncation (or over-aggressive last-turn masking) can leave a sample with no
     # supervised tokens at all — every label is ``ignore_index`` (-100). A single
     # such sample is harmless: the loss normalizes by the batch's supervised-token

--- a/nemo_automodel/components/datasets/llm/formatting_utils.py
+++ b/nemo_automodel/components/datasets/llm/formatting_utils.py
@@ -279,6 +279,41 @@ def _build_reasoning_mask(
     return reasoning_mask
 
 
+def _mask_labels_to_last_turn(mask: List[int], ignore_index: int = -100) -> List[int]:
+    """Restrict supervision to the final assistant turn (``mask_history``).
+
+    Operates on any per-token sequence where ``ignore_index`` marks
+    unsupervised positions: a label list (``ignore_index=-100``) or a 0/1
+    assistant mask (``ignore_index=0``). Each assistant turn renders as a
+    single contiguous supervised span, so this keeps only the last such run
+    and rewrites every earlier supervised position to ``ignore_index``.
+
+    Apply this to the assistant mask **before** any reasoning_content holes are
+    punched into it; running it on already-holed labels would treat the
+    reasoning gap as a turn boundary and drop in-turn content before the hole.
+
+    Args:
+        mask: per-token labels or 0/1 mask (``ignore_index`` marks unsupervised).
+        ignore_index: the value marking unsupervised positions.
+
+    Returns:
+        The same list, mutated so only the final supervised run is kept.
+    """
+    last = -1
+    for i in range(len(mask) - 1, -1, -1):
+        if mask[i] != ignore_index:
+            last = i
+            break
+    if last < 0:
+        return mask
+    start = last
+    while start - 1 >= 0 and mask[start - 1] != ignore_index:
+        start -= 1
+    for i in range(start):
+        mask[i] = ignore_index
+    return mask
+
+
 @torch.no_grad()
 def _get_right_trailing_pad_mask(
     sequence: torch.Tensor,
@@ -583,6 +618,7 @@ def format_chat_template(
     tools: Optional[List[Dict]] = None,
     answer_only_loss_mask: bool = True,
     mask_reasoning_content: bool = False,
+    train_on_last_turn_only: bool = False,
     unshifted: bool = False,
 ) -> Dict[str, List[int]]:
     """
@@ -597,6 +633,9 @@ def format_chat_template(
         tools: Optional list of tool definitions for function calling.
         answer_only_loss_mask: Whether to compute the loss mask only on the answer tokens.
         mask_reasoning_content: Whether to exclude rendered reasoning_content tokens from loss.
+        train_on_last_turn_only: Whether to supervise only the final assistant turn,
+            masking every earlier assistant turn (``mask_history``). Applied to the
+            assistant mask before reasoning_content is masked out.
 
     Returns:
         A dictionary with the formatted example.
@@ -666,6 +705,11 @@ def format_chat_template(
         for i in range(min(len(mask), len(tokenizer_attn_mask))):
             if not tokenizer_attn_mask[i]:
                 mask[i] = 0
+
+    # Restrict to the last assistant turn before reasoning is masked, so the
+    # contiguous-run heuristic sees a hole-free mask (one run per turn).
+    if train_on_last_turn_only:
+        _mask_labels_to_last_turn(mask, ignore_index=0)
 
     if mask_reasoning_content and has_reasoning_content:
         reasoning_mask = _build_reasoning_mask(

--- a/nemo_automodel/components/distributed/utils.py
+++ b/nemo_automodel/components/distributed/utils.py
@@ -16,11 +16,13 @@
 import logging
 from contextlib import ContextDecorator, nullcontext
 from datetime import datetime, timedelta
-from typing import Optional
+from typing import Any, Optional
 
 import torch
 import torch.distributed
 import torch.distributed as dist
+
+from nemo_automodel.components.distributed.config import DDPConfig
 
 logger = logging.getLogger(__name__)
 
@@ -245,3 +247,17 @@ def get_sync_ctx(model, is_optim_step, defer_fsdp_grad_sync: bool):
     elif isinstance(model, torch.nn.parallel.DistributedDataParallel) and not is_optim_step:
         sync_ctx = model.no_sync()
     return sync_ctx
+
+
+def dp_eval_sample_shard(distributed_config: Any, dp_rank: int, dp_size: int) -> tuple | None:
+    """Return ``(dp_rank, dp_size)`` to shard eval samples across DP ranks, else ``None``.
+
+    Only DDP replicates the full model on every rank, so only there can each rank
+    score a disjoint subset independently. Under FSDP2 / MegatronFSDP the model is
+    sharded and ``generate()`` issues per-layer all-gather collectives that must
+    stay in lockstep across the group — different samples per rank would desync
+    them and hang — so every rank scores the same samples (``None``).
+    """
+    if isinstance(distributed_config, DDPConfig) and dp_size > 1:
+        return (dp_rank, dp_size)
+    return None

--- a/nemo_automodel/components/eval/tool_call_evaluator.py
+++ b/nemo_automodel/components/eval/tool_call_evaluator.py
@@ -46,16 +46,6 @@ from nemo_automodel.components.eval.tool_call_parser import (
 logger = logging.getLogger(__name__)
 
 
-_METRIC_KEYS = (
-    "has_call",
-    "name_correct",
-    "args_json_valid",
-    "args_field_recall",
-    "args_field_precision",
-    "args_exact_match",
-)
-
-
 class ToolCallAccuracyEvaluator:
     """Generation-based tool-call accuracy evaluator for agent SFT.
 
@@ -85,6 +75,19 @@ class ToolCallAccuracyEvaluator:
             processed; the caller is responsible for all-reducing the
             returned ``_count`` and weighted-summed metrics.
     """
+
+    #: Fixed metric names returned by :meth:`evaluate` (one mean each). Exposed
+    #: so a caller can all-reduce a stable key set across ranks instead of the
+    #: data-dependent ``_skip_<reason>`` diagnostics, which differ per rank and
+    #: would desync collectives.
+    METRIC_KEYS = (
+        "has_call",
+        "name_correct",
+        "args_json_valid",
+        "args_field_recall",
+        "args_field_precision",
+        "args_exact_match",
+    )
 
     def __init__(
         self,
@@ -278,7 +281,7 @@ class ToolCallAccuracyEvaluator:
             samples actually scored on this rank.
         """
         samples = self._iter_my_samples()
-        sums = {k: 0.0 for k in _METRIC_KEYS}
+        sums = {k: 0.0 for k in self.METRIC_KEYS}
         n_scored = 0
         skip_reasons: Dict[str, int] = {}
 
@@ -369,7 +372,7 @@ class ToolCallAccuracyEvaluator:
             decoded = tokenizer.decode(new_tokens, skip_special_tokens=False)
             pred_calls = parse_tool_calls(decoded)
             metrics = compute_sample_metrics(pred_calls, sample["gt_tool_calls"])
-            for k in _METRIC_KEYS:
+            for k in self.METRIC_KEYS:
                 sums[k] += metrics[k]
             n_scored += 1
             del input_ids, attention_mask, output
@@ -389,10 +392,10 @@ class ToolCallAccuracyEvaluator:
 
         result: Dict[str, float] = {}
         if n_scored > 0:
-            for k in _METRIC_KEYS:
+            for k in self.METRIC_KEYS:
                 result[f"{self.metric_prefix}/{k}"] = sums[k] / n_scored
         else:
-            for k in _METRIC_KEYS:
+            for k in self.METRIC_KEYS:
                 result[f"{self.metric_prefix}/{k}"] = 0.0
         result[f"{self.metric_prefix}/_count"] = float(n_scored)
         result[f"{self.metric_prefix}/_skipped"] = float(n_skipped)

--- a/nemo_automodel/components/eval/tool_call_evaluator.py
+++ b/nemo_automodel/components/eval/tool_call_evaluator.py
@@ -123,6 +123,20 @@ class ToolCallAccuracyEvaluator:
 
         self._samples_cache: Optional[List[Dict[str, Any]]] = None
 
+    @property
+    def sample_shard(self) -> Optional[tuple]:
+        """``(rank, world_size)`` shard, or ``None`` to score every sample.
+
+        The training recipe sets this so each data-parallel rank scores a
+        disjoint subset, but only when the model is replicated per rank (DDP);
+        sharded strategies must keep every rank on the same samples.
+        """
+        return self._sample_shard
+
+    @sample_shard.setter
+    def sample_shard(self, value: Optional[tuple]) -> None:
+        self._sample_shard = value
+
     def _cleanup_cuda(self) -> None:
         gc.collect()
         if torch.cuda.is_available():

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -61,7 +61,7 @@ from nemo_automodel.components.config._arg_parser import parse_args_and_load_con
 from nemo_automodel.components.datasets.llm.megatron.sampler import create_megatron_sampler
 from nemo_automodel.components.datasets.llm.megatron_dataset import MegatronPretraining
 from nemo_automodel.components.datasets.llm.packed_sequence import pack_dataset
-from nemo_automodel.components.distributed.config import DDPConfig, FSDP2Config, MegatronFSDPConfig
+from nemo_automodel.components.distributed.config import FSDP2Config, MegatronFSDPConfig
 from nemo_automodel.components.distributed.cp_utils import make_cp_batch_and_ctx
 from nemo_automodel.components.distributed.init_utils import (
     initialize_distributed,
@@ -69,7 +69,7 @@ from nemo_automodel.components.distributed.init_utils import (
 from nemo_automodel.components.distributed.megatron_fsdp import fully_shard_optimizer
 from nemo_automodel.components.distributed.mesh import MeshContext
 from nemo_automodel.components.distributed.pipelining import AutoPipeline
-from nemo_automodel.components.distributed.utils import FirstRankPerNode, get_sync_ctx
+from nemo_automodel.components.distributed.utils import FirstRankPerNode, dp_eval_sample_shard, get_sync_ctx
 from nemo_automodel.components.loggers.comet_utils import build_comet
 from nemo_automodel.components.loggers.log_utils import setup_logging
 from nemo_automodel.components.loggers.metric_logger import MetricsSample, build_metric_logger
@@ -172,20 +172,6 @@ def _get_num_thd_chunks(pp_enabled, cfg):
     if pp_enabled:
         return cfg.step_scheduler.local_batch_size // cfg.get("distributed.pipeline.pp_microbatch_size", 1)
     return 1
-
-
-def _dp_eval_sample_shard(distributed_config: Any, dp_rank: int, dp_size: int) -> tuple | None:
-    """Return ``(dp_rank, dp_size)`` to shard tool-call eval across DP ranks, else ``None``.
-
-    Only DDP replicates the full model on every rank, so only there can each rank
-    score a disjoint subset independently. Under FSDP2 / MegatronFSDP the model is
-    sharded and ``generate()`` issues per-layer all-gather collectives that must
-    stay in lockstep across the group — different samples per rank would desync
-    them and hang — so every rank scores the same samples (``None``).
-    """
-    if isinstance(distributed_config, DDPConfig) and dp_size > 1:
-        return (dp_rank, dp_size)
-    return None
 
 
 def build_model(
@@ -918,18 +904,6 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
         """
         self.cfg = cfg
 
-    def _shard_tool_call_eval_across_dp(self):
-        """Shard tool-call eval samples across DP ranks when it is safe to do so.
-
-        Each DP rank then scores a disjoint subset instead of every rank
-        redundantly scoring the full set. Only safe when the model is replicated
-        per rank (DDP); a ``sample_shard`` already set from YAML is left untouched.
-        """
-        if self.tool_call_evaluator.sample_shard is None:
-            self.tool_call_evaluator.sample_shard = _dp_eval_sample_shard(
-                self.distributed_config, self._get_dp_rank(), self._get_dp_group_size()
-            )
-
     # ------------------ build phase ------------------
     def setup(self):
         """Builds all components needed for training/validation/logging/checkpointing/etc.
@@ -1152,7 +1126,12 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
         tool_call_eval_cfg = self.cfg.get("tool_call_eval", None)
         if tool_call_eval_cfg is not None:
             self.tool_call_evaluator = tool_call_eval_cfg.instantiate()
-            self._shard_tool_call_eval_across_dp()
+            # Shard eval samples across DP ranks only when safe (DDP); never
+            # override a ``sample_shard`` already set from YAML.
+            if self.tool_call_evaluator.sample_shard is None:
+                self.tool_call_evaluator.sample_shard = dp_eval_sample_shard(
+                    self.distributed_config, self._get_dp_rank(), self._get_dp_group_size()
+                )
         self._warned_tool_call_eval_skipped = False
         self.best_metric_key = self.cfg.get("checkpoint.best_metric_key", "default")
         # Scheduler

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -61,7 +61,7 @@ from nemo_automodel.components.config._arg_parser import parse_args_and_load_con
 from nemo_automodel.components.datasets.llm.megatron.sampler import create_megatron_sampler
 from nemo_automodel.components.datasets.llm.megatron_dataset import MegatronPretraining
 from nemo_automodel.components.datasets.llm.packed_sequence import pack_dataset
-from nemo_automodel.components.distributed.config import FSDP2Config, MegatronFSDPConfig
+from nemo_automodel.components.distributed.config import DDPConfig, FSDP2Config, MegatronFSDPConfig
 from nemo_automodel.components.distributed.cp_utils import make_cp_batch_and_ctx
 from nemo_automodel.components.distributed.init_utils import (
     initialize_distributed,
@@ -172,6 +172,20 @@ def _get_num_thd_chunks(pp_enabled, cfg):
     if pp_enabled:
         return cfg.step_scheduler.local_batch_size // cfg.get("distributed.pipeline.pp_microbatch_size", 1)
     return 1
+
+
+def _dp_eval_sample_shard(distributed_config: Any, dp_rank: int, dp_size: int) -> tuple | None:
+    """Return ``(dp_rank, dp_size)`` to shard tool-call eval across DP ranks, else ``None``.
+
+    Only DDP replicates the full model on every rank, so only there can each rank
+    score a disjoint subset independently. Under FSDP2 / MegatronFSDP the model is
+    sharded and ``generate()`` issues per-layer all-gather collectives that must
+    stay in lockstep across the group — different samples per rank would desync
+    them and hang — so every rank scores the same samples (``None``).
+    """
+    if isinstance(distributed_config, DDPConfig) and dp_size > 1:
+        return (dp_rank, dp_size)
+    return None
 
 
 def build_model(
@@ -1126,6 +1140,14 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
         tool_call_eval_cfg = self.cfg.get("tool_call_eval", None)
         if tool_call_eval_cfg is not None:
             self.tool_call_evaluator = tool_call_eval_cfg.instantiate()
+            # Shard eval samples across DP ranks so each scores a disjoint subset
+            # instead of every rank redundantly scoring the full set. Only safe
+            # when the model is replicated per rank (DDP); a YAML-set sample_shard
+            # is left untouched.
+            if self.tool_call_evaluator.sample_shard is None:
+                self.tool_call_evaluator.sample_shard = _dp_eval_sample_shard(
+                    self.distributed_config, self._get_dp_rank(), self._get_dp_group_size()
+                )
         self._warned_tool_call_eval_skipped = False
         self.best_metric_key = self.cfg.get("checkpoint.best_metric_key", "default")
         # Scheduler
@@ -1709,14 +1731,13 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
                     self._warned_tool_call_eval_skipped = True
                 metrics[f"{prefix}/_disabled_fsdp2"] = 1.0
             else:
-                # Every DP rank must issue the SAME collective here, whatever its
-                # local eval produced. A rank whose evaluate() raised (e.g. a
-                # divergent generate() OOM) or that hit different skip reasons must
-                # not skip or add an all-reduce, or it desyncs the collective and
-                # deadlocks the others. So: treat a local failure as an empty
-                # result, and reduce a FIXED vector (the stable means plus
-                # _count/_skipped, never the per-rank _skip_<reason> keys) in one
-                # packed all-reduce.
+                # sample_shard is set (identically) on every rank only for DDP,
+                # where each rank scored a DISJOINT subset → all-reduce. When it
+                # is None (FSDP2 in-loop, or single rank) every rank scored the
+                # SAME set in lockstep and holds identical results → use them
+                # directly with no collective. The branch is taken identically on
+                # all ranks, so the collectives below stay in sync.
+                sharded = self.tool_call_evaluator.sample_shard is not None
                 try:
                     local_metrics = self.tool_call_evaluator.evaluate(self.model_parts[0], self.tokenizer)
                 except Exception as exc:
@@ -1725,22 +1746,35 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
 
                 metric_keys = list(self.tool_call_evaluator.METRIC_KEYS)
                 local_count = float(local_metrics.get(count_key, 0.0))
-                # Pack [count, mean_0 * count, ..., mean_n * count, skipped] so the
-                # count-weighted means and the diagnostics reduce in one collective.
-                packed = torch.tensor(
-                    [local_count]
-                    + [float(local_metrics.get(f"{prefix}/{k}", 0.0)) * local_count for k in metric_keys]
-                    + [float(local_metrics.get(f"{prefix}/_skipped", 0.0))],
-                    dtype=torch.float32,
-                    device=self.dist_env.device,
-                )
-                reduced = self._dp_allreduce(packed).tolist()
-
-                total_count = reduced[0]
-                for i, k in enumerate(metric_keys, start=1):
-                    metrics[f"{prefix}/{k}"] = reduced[i] / total_count if total_count > 0 else 0.0
-                metrics[f"{prefix}/_skipped"] = reduced[-1]
-                metrics[count_key] = total_count
+                if sharded:
+                    # Every DP rank must issue the SAME collective here, whatever
+                    # its local eval produced. A rank whose evaluate() raised (e.g.
+                    # a divergent generate() OOM) or that hit different skip reasons
+                    # must not skip or add an all-reduce, or it desyncs the
+                    # collective and deadlocks the others. So reduce a FIXED vector
+                    # (count, count-weighted means, skipped — never the per-rank
+                    # _skip_<reason> keys) in one packed all-reduce; a local failure
+                    # contributes zeros but still participates.
+                    packed = torch.tensor(
+                        [local_count]
+                        + [float(local_metrics.get(f"{prefix}/{k}", 0.0)) * local_count for k in metric_keys]
+                        + [float(local_metrics.get(f"{prefix}/_skipped", 0.0))],
+                        dtype=torch.float32,
+                        device=self.dist_env.device,
+                    )
+                    reduced = self._dp_allreduce(packed).tolist()
+                    total_count = reduced[0]
+                    for i, k in enumerate(metric_keys, start=1):
+                        metrics[f"{prefix}/{k}"] = reduced[i] / total_count if total_count > 0 else 0.0
+                    metrics[f"{prefix}/_skipped"] = reduced[-1]
+                    metrics[count_key] = total_count
+                else:
+                    # Replicated: identical on every rank, so report the local
+                    # values directly (no collective, _count is the true count).
+                    for k in metric_keys:
+                        metrics[f"{prefix}/{k}"] = float(local_metrics.get(f"{prefix}/{k}", 0.0))
+                    metrics[f"{prefix}/_skipped"] = float(local_metrics.get(f"{prefix}/_skipped", 0.0))
+                    metrics[count_key] = local_count
 
                 gc.collect()
                 if torch.cuda.is_available():

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -918,6 +918,18 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
         """
         self.cfg = cfg
 
+    def _shard_tool_call_eval_across_dp(self):
+        """Shard tool-call eval samples across DP ranks when it is safe to do so.
+
+        Each DP rank then scores a disjoint subset instead of every rank
+        redundantly scoring the full set. Only safe when the model is replicated
+        per rank (DDP); a ``sample_shard`` already set from YAML is left untouched.
+        """
+        if self.tool_call_evaluator.sample_shard is None:
+            self.tool_call_evaluator.sample_shard = _dp_eval_sample_shard(
+                self.distributed_config, self._get_dp_rank(), self._get_dp_group_size()
+            )
+
     # ------------------ build phase ------------------
     def setup(self):
         """Builds all components needed for training/validation/logging/checkpointing/etc.
@@ -1140,14 +1152,7 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
         tool_call_eval_cfg = self.cfg.get("tool_call_eval", None)
         if tool_call_eval_cfg is not None:
             self.tool_call_evaluator = tool_call_eval_cfg.instantiate()
-            # Shard eval samples across DP ranks so each scores a disjoint subset
-            # instead of every rank redundantly scoring the full set. Only safe
-            # when the model is replicated per rank (DDP); a YAML-set sample_shard
-            # is left untouched.
-            if self.tool_call_evaluator.sample_shard is None:
-                self.tool_call_evaluator.sample_shard = _dp_eval_sample_shard(
-                    self.distributed_config, self._get_dp_rank(), self._get_dp_group_size()
-                )
+            self._shard_tool_call_eval_across_dp()
         self._warned_tool_call_eval_skipped = False
         self.best_metric_key = self.cfg.get("checkpoint.best_metric_key", "default")
         # Scheduler

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -1695,7 +1695,8 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
         # generate() repeatedly unshards parameters and can leave enough
         # allocator pressure to OOM the next backward pass.
         if getattr(self, "tool_call_evaluator", None) is not None:
-            count_key = f"{self.tool_call_evaluator.metric_prefix}/_count"
+            prefix = self.tool_call_evaluator.metric_prefix
+            count_key = f"{prefix}/_count"
             if isinstance(self.distributed_config, FSDP2Config) and not getattr(
                 self.tool_call_evaluator, "run_on_fsdp2", False
             ):
@@ -1706,44 +1707,44 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
                         "or run the evaluator offline from a checkpoint."
                     )
                     self._warned_tool_call_eval_skipped = True
-                metrics[f"{self.tool_call_evaluator.metric_prefix}/_disabled_fsdp2"] = 1.0
+                metrics[f"{prefix}/_disabled_fsdp2"] = 1.0
             else:
+                # Every DP rank must issue the SAME collective here, whatever its
+                # local eval produced. A rank whose evaluate() raised (e.g. a
+                # divergent generate() OOM) or that hit different skip reasons must
+                # not skip or add an all-reduce, or it desyncs the collective and
+                # deadlocks the others. So: treat a local failure as an empty
+                # result, and reduce a FIXED vector (the stable means plus
+                # _count/_skipped, never the per-rank _skip_<reason> keys) in one
+                # packed all-reduce.
                 try:
-                    tool_metrics = self.tool_call_evaluator.evaluate(self.model_parts[0], self.tokenizer)
-                    # The evaluator returns per-rank means and count-like
-                    # diagnostics. Weighted all-reduce the means by scored
-                    # sample count, and sum diagnostics directly.
-                    local_count = float(tool_metrics.pop(count_key, 0.0))
-                    device = self.dist_env.device
-                    count_t = torch.tensor(local_count, dtype=torch.float32, device=device)
-                    total_count = self._dp_allreduce(count_t).item()
-
-                    count_like_metrics = {
-                        k: v
-                        for k, v in list(tool_metrics.items())
-                        if k.startswith(f"{self.tool_call_evaluator.metric_prefix}/_")
-                    }
-                    for k in count_like_metrics:
-                        tool_metrics.pop(k, None)
-
-                    if total_count > 0:
-                        for k, v in list(tool_metrics.items()):
-                            local_sum = torch.tensor(float(v) * local_count, dtype=torch.float32, device=device)
-                            total_sum = self._dp_allreduce(local_sum).item()
-                            tool_metrics[k] = total_sum / total_count
-
-                    for k, v in count_like_metrics.items():
-                        local_total = torch.tensor(float(v), dtype=torch.float32, device=device)
-                        tool_metrics[k] = self._dp_allreduce(local_total).item()
-
-                    tool_metrics[count_key] = total_count
-                    metrics.update(tool_metrics)
+                    local_metrics = self.tool_call_evaluator.evaluate(self.model_parts[0], self.tokenizer)
                 except Exception as exc:
                     logging.warning("tool_call_evaluator.evaluate failed: %s", exc)
-                finally:
-                    gc.collect()
-                    if torch.cuda.is_available():
-                        torch.cuda.empty_cache()
+                    local_metrics = {}
+
+                metric_keys = list(self.tool_call_evaluator.METRIC_KEYS)
+                local_count = float(local_metrics.get(count_key, 0.0))
+                # Pack [count, mean_0 * count, ..., mean_n * count, skipped] so the
+                # count-weighted means and the diagnostics reduce in one collective.
+                packed = torch.tensor(
+                    [local_count]
+                    + [float(local_metrics.get(f"{prefix}/{k}", 0.0)) * local_count for k in metric_keys]
+                    + [float(local_metrics.get(f"{prefix}/_skipped", 0.0))],
+                    dtype=torch.float32,
+                    device=self.dist_env.device,
+                )
+                reduced = self._dp_allreduce(packed).tolist()
+
+                total_count = reduced[0]
+                for i, k in enumerate(metric_keys, start=1):
+                    metrics[f"{prefix}/{k}"] = reduced[i] / total_count if total_count > 0 else 0.0
+                metrics[f"{prefix}/_skipped"] = reduced[-1]
+                metrics[count_key] = total_count
+
+                gc.collect()
+                if torch.cuda.is_available():
+                    torch.cuda.empty_cache()
 
         return MetricsSample(
             step=self.step_scheduler.step,

--- a/tests/unit_tests/datasets/llm/test_agent_chat.py
+++ b/tests/unit_tests/datasets/llm/test_agent_chat.py
@@ -462,30 +462,15 @@ def test_extract_eval_samples_args_already_dict():
     assert samples[0]["gt_tool_calls"] == [{"name": "f", "arguments": {"a": 1}}]
 
 
-def test_mask_labels_to_last_turn_keeps_only_final_run():
-    # Two supervised assistant runs separated by an ignored (user/tool) run.
-    labels = [-100, 1, 2, -100, -100, 3, 4, -100]
-    agent_chat._mask_labels_to_last_turn(labels)
-    assert labels == [-100, -100, -100, -100, -100, 3, 4, -100]
+def test_format_example_forwards_train_on_last_turn_only(monkeypatch):
+    # The last-turn restriction now lives in ``format_chat_template`` so it acts
+    # on the hole-free assistant mask before reasoning_content is masked.
+    # ``_format_example`` must forward the flag rather than post-process labels.
+    captured = {}
 
-
-def test_mask_labels_to_last_turn_single_run_unchanged():
-    labels = [-100, -100, 5, 6, 7]
-    agent_chat._mask_labels_to_last_turn(labels)
-    assert labels == [-100, -100, 5, 6, 7]
-
-
-def test_mask_labels_to_last_turn_no_supervised_tokens_is_noop():
-    labels = [-100, -100, -100]
-    agent_chat._mask_labels_to_last_turn(labels)
-    assert labels == [-100, -100, -100]
-
-
-def test_format_example_train_on_last_turn_only_masks_earlier_turns(monkeypatch):
-    # ``labels`` carry two supervised assistant runs; with the flag set only
-    # the final run survives. Without it, both runs stay supervised.
     def fake_format_chat_template(**kwargs):
-        return {"input_ids": [10, 11, 12, 13, 14, 15], "labels": [-100, 1, -100, -100, 2, 3]}
+        captured.update(kwargs)
+        return {"input_ids": [10, 11], "labels": [-100, 1]}
 
     monkeypatch.setattr(agent_chat, "format_chat_template", fake_format_chat_template)
 
@@ -495,11 +480,11 @@ def test_format_example_train_on_last_turn_only_masks_earlier_turns(monkeypatch)
 
     example = {"messages": [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "x"}]}
 
-    kept = agent_chat._format_example(example, Tok(), 0, 0)
-    assert kept["labels"] == [-100, 1, -100, -100, 2, 3]
+    agent_chat._format_example(example, Tok(), 0, 0)
+    assert captured["train_on_last_turn_only"] is False
 
-    masked = agent_chat._format_example(example, Tok(), 0, 0, train_on_last_turn_only=True)
-    assert masked["labels"] == [-100, -100, -100, -100, 2, 3]
+    agent_chat._format_example(example, Tok(), 0, 0, train_on_last_turn_only=True)
+    assert captured["train_on_last_turn_only"] is True
 
 
 def test_convert_messages_preserves_assistant_reasoning_content():

--- a/tests/unit_tests/datasets/llm/test_formatting_utils.py
+++ b/tests/unit_tests/datasets/llm/test_formatting_utils.py
@@ -85,3 +85,29 @@ def test_multiturn_mask_requires_assistant():
     formatted = [{"role": "user", "content": "a"}]
     with pytest.raises(AssertionError, match="At least one assistant message"):
         formatting_utils._build_multiturn_assistant_mask(_CountingTokenizer(), formatted, [0, 1])
+
+
+def test_mask_labels_to_last_turn_keeps_only_final_run():
+    # Two supervised runs separated by an ignored run; only the last survives.
+    labels = [-100, 1, 2, -100, -100, 3, 4, -100]
+    formatting_utils._mask_labels_to_last_turn(labels)
+    assert labels == [-100, -100, -100, -100, -100, 3, 4, -100]
+
+
+def test_mask_labels_to_last_turn_single_run_unchanged():
+    labels = [-100, -100, 5, 6, 7]
+    formatting_utils._mask_labels_to_last_turn(labels)
+    assert labels == [-100, -100, 5, 6, 7]
+
+
+def test_mask_labels_to_last_turn_no_supervised_tokens_is_noop():
+    labels = [-100, -100, -100]
+    formatting_utils._mask_labels_to_last_turn(labels)
+    assert labels == [-100, -100, -100]
+
+
+def test_mask_labels_to_last_turn_on_binary_mask():
+    # On a 0/1 assistant mask (ignore_index=0): keep only the last run of 1s.
+    mask = [0, 1, 1, 0, 1, 1, 1, 0]
+    formatting_utils._mask_labels_to_last_turn(mask, ignore_index=0)
+    assert mask == [0, 0, 0, 0, 1, 1, 1, 0]

--- a/tests/unit_tests/datasets/llm/test_tokenizer_apply_functions.py
+++ b/tests/unit_tests/datasets/llm/test_tokenizer_apply_functions.py
@@ -586,6 +586,95 @@ def test_apply_chat_template_can_mask_reasoning_content_without_generation_kwd()
     assert masked["labels"][masked["input_ids"].index(answer_id)] != -100
 
 
+def test_format_chat_template_train_on_last_turn_only_masks_earlier_turns():
+    # Only the final assistant turn stays supervised; earlier turns are dropped.
+    tok = _StubTokenizerChatNoGenMultiTurn()
+    messages = [
+        {"role": "user", "content": "q1"},
+        {"role": "assistant", "content": "alpha beta"},
+        {"role": "user", "content": "q2"},
+        {"role": "assistant", "content": "gamma delta"},
+    ]
+    common = dict(eos_token_id=tok.eos_token_id, pad_token_id=tok.eos_token_id, answer_only_loss_mask=True)
+
+    all_turns = format_chat_template(tok, formatted_text=[m.copy() for m in messages], **common)
+    last_only = format_chat_template(
+        tok, formatted_text=[m.copy() for m in messages], train_on_last_turn_only=True, **common
+    )
+
+    all_supervised = {v for v in all_turns["labels"] if v != -100}
+    last_supervised = {v for v in last_only["labels"] if v != -100}
+
+    for word in ("alpha", "beta", "gamma", "delta"):
+        assert tok._id_for_token(word) in all_supervised
+    assert tok._id_for_token("gamma") in last_supervised
+    assert tok._id_for_token("delta") in last_supervised
+    assert tok._id_for_token("alpha") not in last_supervised
+    assert tok._id_for_token("beta") not in last_supervised
+
+
+class _StubTokenizerChatNoGenReasoningSplitsContent(_StubTokenizerChatNoGen):
+    """Assistant content renders both BEFORE and AFTER the reasoning block.
+
+    Mirrors templates that emit text, then a ``<think>`` block, then more text
+    (or a tool call), so a masked reasoning span sits between two supervised
+    content spans within the same turn.
+    """
+
+    chat_template = "<dummy reasoning_content template>"
+
+    def apply_chat_template(self, messages, **kwargs):  # type: ignore[override]
+        ids: List[int] = [self._start_of_turn_token_id]
+        for msg in messages:
+            ids.append(self._id_for_token(f"<{msg['role']}>"))
+            if msg["role"] == "assistant" and msg.get("reasoning_content"):
+                words = str(msg["content"]).split()
+                head, tail = words[:1], words[1:]
+                ids.extend(self._id_for_token(t) for t in head)
+                ids.append(self._id_for_token("<think>"))
+                ids.extend(self._id_for_token(t) for t in str(msg["reasoning_content"]).split())
+                ids.append(self._id_for_token("</think>"))
+                ids.extend(self._id_for_token(t) for t in tail)
+            else:
+                ids.extend(self._id_for_token(t) for t in str(msg["content"]).split())
+        ids.append(self.eos_token_id)
+        if kwargs.get("return_dict", False):
+            return {"input_ids": ids}
+        return ids
+
+
+def test_format_chat_template_last_turn_only_keeps_content_around_masked_reasoning():
+    # Regression: the final turn renders as [head][<think>why</think>][tail].
+    # The last-turn restriction must run on the hole-free mask, so masking the
+    # reasoning hole does not also drop the supervised "head" before it (the old
+    # order kept only the last contiguous run, i.e. just "tail").
+    tok = _StubTokenizerChatNoGenReasoningSplitsContent()
+    messages = [
+        {"role": "user", "content": "q1"},
+        {"role": "assistant", "content": "earlierturn"},
+        {"role": "user", "content": "q2"},
+        {"role": "assistant", "content": "head tail", "reasoning_content": "why"},
+    ]
+
+    out = format_chat_template(
+        tok,
+        formatted_text=[m.copy() for m in messages],
+        eos_token_id=tok.eos_token_id,
+        pad_token_id=tok.eos_token_id,
+        answer_only_loss_mask=True,
+        mask_reasoning_content=True,
+        train_on_last_turn_only=True,
+    )
+
+    supervised = {v for v in out["labels"] if v != -100}
+    # Both content spans of the last turn stay supervised.
+    assert tok._id_for_token("head") in supervised
+    assert tok._id_for_token("tail") in supervised
+    # The reasoning hole is masked, and the earlier assistant turn is dropped.
+    assert tok._id_for_token("why") not in supervised
+    assert tok._id_for_token("earlierturn") not in supervised
+
+
 # pad_token_id == eos_token_id overlap tests
 
 
@@ -1017,9 +1106,9 @@ class TestFormatChatTemplateNoEosAfterTruncation:
         # All labels must be exactly seq_length
         assert len(out["labels"]) == seq_length
         # The last label must be -100 (padding), NOT eos_token_id
-        assert (
-            out["labels"][-1] == -100
-        ), f"Last label should be -100 (padding) after truncation, got {out['labels'][-1]}"
+        assert out["labels"][-1] == -100, (
+            f"Last label should be -100 (padding) after truncation, got {out['labels'][-1]}"
+        )
 
     def test_eos_still_appended_when_not_truncated(self):
         tok = _StubTokenizerChatTruncating()

--- a/tests/unit_tests/eval/test_tool_call_evaluator.py
+++ b/tests/unit_tests/eval/test_tool_call_evaluator.py
@@ -294,3 +294,16 @@ def test_metric_keys_match_evaluate_mean_metrics(monkeypatch):
     mean_keys = {k for k in metrics if not k.rsplit("/", 1)[-1].startswith("_")}
     expected = {f"{prefix}/{name}" for name in ToolCallAccuracyEvaluator.METRIC_KEYS}
     assert mean_keys == expected
+
+
+def test_sample_shard_property_round_trips_and_drives_sharding(monkeypatch):
+    # The recipe injects the shard after construction via the public property;
+    # it must round-trip and actually drive _iter_my_samples partitioning.
+    evaluator = _make_evaluator(monkeypatch)
+    assert evaluator.sample_shard is None
+
+    evaluator.sample_shard = (1, 4)
+    assert evaluator.sample_shard == (1, 4)
+
+    evaluator._samples_cache = [{"i": i} for i in range(8)]
+    assert evaluator._iter_my_samples() == [{"i": 1}, {"i": 5}]

--- a/tests/unit_tests/eval/test_tool_call_evaluator.py
+++ b/tests/unit_tests/eval/test_tool_call_evaluator.py
@@ -20,7 +20,6 @@ import torch
 from nemo_automodel.components.eval import tool_call_evaluator as ev_mod
 from nemo_automodel.components.eval.tool_call_evaluator import ToolCallAccuracyEvaluator
 
-
 # ---------- fakes ----------
 
 
@@ -75,9 +74,7 @@ class FakeModel:
         self.generate_calls += 1
         # Append max_new_tokens zeros so the evaluator can slice off the
         # new portion; the decoded text is scripted in the tokenizer.
-        new = torch.zeros(
-            (input_ids.shape[0], max_new_tokens), dtype=input_ids.dtype, device=input_ids.device
-        )
+        new = torch.zeros((input_ids.shape[0], max_new_tokens), dtype=input_ids.dtype, device=input_ids.device)
         return torch.cat([input_ids, new], dim=1)
 
 
@@ -173,7 +170,7 @@ def test_evaluate_malformed_json(monkeypatch):
     evaluator = _make_evaluator(monkeypatch)
     tok = FakeTokenizer()
     tok.responses = [
-        '<tool_call>not json at all</tool_call>',
+        "<tool_call>not json at all</tool_call>",
         '<tool_call>{"name": "calc", "arguments": {"a": 1, "b": 2}}</tool_call>',
     ]
     model = FakeModel()
@@ -281,3 +278,19 @@ def test_metric_prefix_is_applied(monkeypatch):
     metrics = evaluator.evaluate(FakeModel(), tok)
     assert "eval/agent/_count" in metrics
     assert "eval/agent/name_correct" in metrics
+
+
+def test_metric_keys_match_evaluate_mean_metrics(monkeypatch):
+    # The recipe all-reduces a FIXED key set (``METRIC_KEYS``) across DP ranks to
+    # avoid collective desync from the data-dependent ``_skip_<reason>`` keys.
+    # Guard that METRIC_KEYS matches the mean-metrics evaluate() actually emits,
+    # so a newly added metric cannot silently escape the reduction.
+    evaluator = _make_evaluator(monkeypatch)
+    tok = FakeTokenizer()
+    tok.responses = ["", ""]
+    metrics = evaluator.evaluate(FakeModel(), tok)
+
+    prefix = evaluator.metric_prefix
+    mean_keys = {k for k in metrics if not k.rsplit("/", 1)[-1].startswith("_")}
+    expected = {f"{prefix}/{name}" for name in ToolCallAccuracyEvaluator.METRIC_KEYS}
+    assert mean_keys == expected

--- a/tests/unit_tests/recipes/test_train_ft.py
+++ b/tests/unit_tests/recipes/test_train_ft.py
@@ -34,6 +34,7 @@ from nemo_automodel._transformers.model_init import resolve_sdpa_method
 from nemo_automodel.recipes.llm.train_ft import (
     PipelineCausalLMLoss,
     TrainFinetuneRecipeForNextTokenPrediction,
+    _dp_eval_sample_shard,
     build_dataloader,
     build_model,
     build_optimizer,
@@ -1983,3 +1984,29 @@ class TestResolveSdpaMethod:
 
         result = resolve_sdpa_method([SDPBackend.FLASH_ATTENTION, "efficient_attention"])
         assert result == [SDPBackend.FLASH_ATTENTION, SDPBackend.EFFICIENT_ATTENTION]
+
+
+class TestDpEvalSampleShard:
+    """`_dp_eval_sample_shard` shards tool-call eval only when the model is
+    replicated per DP rank (DDP); sharded strategies must stay in lockstep."""
+
+    def test_ddp_multi_rank_shards(self):
+        from nemo_automodel.components.distributed.config import DDPConfig
+
+        assert _dp_eval_sample_shard(DDPConfig(), 1, 4) == (1, 4)
+
+    def test_ddp_single_rank_no_shard(self):
+        from nemo_automodel.components.distributed.config import DDPConfig
+
+        assert _dp_eval_sample_shard(DDPConfig(), 0, 1) is None
+
+    def test_fsdp2_never_shards(self):
+        # Sharding under FSDP2 would desync generate()'s per-layer all-gathers.
+        from nemo_automodel.components.distributed.config import FSDP2Config
+
+        assert _dp_eval_sample_shard(FSDP2Config(), 1, 4) is None
+
+    def test_megatron_fsdp_never_shards(self):
+        from nemo_automodel.components.distributed.config import MegatronFSDPConfig
+
+        assert _dp_eval_sample_shard(MegatronFSDPConfig(), 1, 4) is None

--- a/tests/unit_tests/recipes/test_train_ft.py
+++ b/tests/unit_tests/recipes/test_train_ft.py
@@ -2012,6 +2012,40 @@ class TestDpEvalSampleShard:
         assert _dp_eval_sample_shard(MegatronFSDPConfig(), 1, 4) is None
 
 
+class TestShardToolCallEvalAcrossDp:
+    """`_shard_tool_call_eval_across_dp` wires the DP shard onto the evaluator
+    during setup: injected only for DDP, and never overriding a YAML-set shard."""
+
+    def _recipe(self, distributed_config, evaluator, dp_rank=1, dp_size=4):
+        recipe = TrainFinetuneRecipeForNextTokenPrediction.__new__(TrainFinetuneRecipeForNextTokenPrediction)
+        recipe.tool_call_evaluator = evaluator
+        recipe.distributed_config = distributed_config
+        recipe._get_dp_rank = lambda: dp_rank
+        recipe._get_dp_group_size = lambda: dp_size
+        return recipe
+
+    def test_ddp_injects_shard(self):
+        from nemo_automodel.components.distributed.config import DDPConfig
+
+        ev = _FakeToolCallEvaluator(sample_shard=None)
+        self._recipe(DDPConfig(), ev, dp_rank=1, dp_size=4)._shard_tool_call_eval_across_dp()
+        assert ev.sample_shard == (1, 4)
+
+    def test_fsdp2_leaves_shard_none(self):
+        from nemo_automodel.components.distributed.config import FSDP2Config
+
+        ev = _FakeToolCallEvaluator(sample_shard=None)
+        self._recipe(FSDP2Config(), ev)._shard_tool_call_eval_across_dp()
+        assert ev.sample_shard is None
+
+    def test_yaml_set_shard_is_untouched(self):
+        from nemo_automodel.components.distributed.config import DDPConfig
+
+        ev = _FakeToolCallEvaluator(sample_shard=(0, 2))
+        self._recipe(DDPConfig(), ev, dp_rank=1, dp_size=4)._shard_tool_call_eval_across_dp()
+        assert ev.sample_shard == (0, 2)  # explicit YAML shard preserved
+
+
 class _FakeToolCallEvaluator:
     """Stand-in for ToolCallAccuracyEvaluator: returns canned metrics (or raises)
     so ``_run_validation_epoch``'s reduction can be tested without generation."""

--- a/tests/unit_tests/recipes/test_train_ft.py
+++ b/tests/unit_tests/recipes/test_train_ft.py
@@ -2010,3 +2010,123 @@ class TestDpEvalSampleShard:
         from nemo_automodel.components.distributed.config import MegatronFSDPConfig
 
         assert _dp_eval_sample_shard(MegatronFSDPConfig(), 1, 4) is None
+
+
+class _FakeToolCallEvaluator:
+    """Stand-in for ToolCallAccuracyEvaluator: returns canned metrics (or raises)
+    so ``_run_validation_epoch``'s reduction can be tested without generation."""
+
+    metric_prefix = "tool_call"
+    METRIC_KEYS = (
+        "has_call",
+        "name_correct",
+        "args_json_valid",
+        "args_field_recall",
+        "args_field_precision",
+        "args_exact_match",
+    )
+
+    def __init__(self, *, sample_shard=None, run_on_fsdp2=False, result=None, raises=False):
+        self.sample_shard = sample_shard
+        self.run_on_fsdp2 = run_on_fsdp2
+        self._result = result if result is not None else {}
+        self._raises = raises
+        self.eval_calls = 0
+
+    def evaluate(self, model, tokenizer):
+        self.eval_calls += 1
+        if self._raises:
+            raise RuntimeError("boom")
+        return dict(self._result)
+
+
+def _make_eval_recipe(distributed_config, evaluator):
+    """Minimal recipe wired for ``_run_validation_epoch`` with an empty val loader.
+
+    Single-rank: ``_dp_allreduce`` is the identity, so the packed all-reduce
+    recovers the per-rank means directly.
+    """
+    recipe = TrainFinetuneRecipeForNextTokenPrediction.__new__(TrainFinetuneRecipeForNextTokenPrediction)
+    recipe.model_parts = [SimpleNamespace(eval=lambda: None)]
+    recipe.dist_env = SimpleNamespace(device=torch.device("cpu"), is_main=True)
+    recipe.optimizer = [SimpleNamespace(param_groups=[{"lr": 0.01}])]
+    recipe.pp_enabled = False
+    recipe.distributed_config = distributed_config
+    recipe.tool_call_evaluator = evaluator
+    recipe.tokenizer = object()
+    recipe.step_scheduler = SimpleNamespace(step=3, epoch=1)
+    recipe._warned_tool_call_eval_skipped = False
+    recipe._dp_allreduce = lambda tensor, *args, **kwargs: tensor
+    return recipe
+
+
+class TestRunValidationToolCallEval:
+    """Cover the tool-call eval reduction branches in ``_run_validation_epoch``
+    (FSDP2 skip / DDP packed all-reduce / replicated / evaluate failure) without a
+    real model or process group."""
+
+    def _run(self, recipe, monkeypatch):
+        # max_memory_allocated() is CUDA-only; stub it so the CPU metrics build works.
+        monkeypatch.setattr(torch.cuda, "max_memory_allocated", lambda *a, **k: 0)
+        return recipe._run_validation_epoch([])  # empty loader -> straight to the eval block
+
+    def test_fsdp2_skips_in_loop_eval(self, monkeypatch):
+        from nemo_automodel.components.distributed.config import FSDP2Config
+
+        ev = _FakeToolCallEvaluator(run_on_fsdp2=False)
+        recipe = _make_eval_recipe(FSDP2Config(), ev)
+        out = self._run(recipe, monkeypatch)
+        assert out.metrics["tool_call/_disabled_fsdp2"] == 1.0
+        assert ev.eval_calls == 0  # generation never ran
+        assert recipe._warned_tool_call_eval_skipped is True
+
+    def test_ddp_sharded_packed_allreduce(self, monkeypatch):
+        from nemo_automodel.components.distributed.config import DDPConfig
+
+        result = {
+            "tool_call/has_call": 1.0,
+            "tool_call/name_correct": 0.5,
+            "tool_call/args_json_valid": 1.0,
+            "tool_call/args_field_recall": 0.0,
+            "tool_call/args_field_precision": 0.0,
+            "tool_call/args_exact_match": 0.0,
+            "tool_call/_count": 2.0,
+            "tool_call/_skipped": 1.0,
+        }
+        ev = _FakeToolCallEvaluator(sample_shard=(0, 1), result=result)
+        out = self._run(_make_eval_recipe(DDPConfig(), ev), monkeypatch)
+        # Identity all-reduce on one rank: count-weighted sum / count recovers the mean.
+        assert out.metrics["tool_call/has_call"] == 1.0
+        assert out.metrics["tool_call/name_correct"] == 0.5
+        assert out.metrics["tool_call/_count"] == 2.0
+        assert out.metrics["tool_call/_skipped"] == 1.0
+        assert ev.eval_calls == 1
+
+    def test_replicated_reports_local_without_collective(self, monkeypatch):
+        from nemo_automodel.components.distributed.config import FSDP2Config
+
+        result = {
+            "tool_call/has_call": 0.75,
+            "tool_call/name_correct": 0.25,
+            "tool_call/args_json_valid": 0.5,
+            "tool_call/args_field_recall": 0.1,
+            "tool_call/args_field_precision": 0.2,
+            "tool_call/args_exact_match": 0.0,
+            "tool_call/_count": 4.0,
+            "tool_call/_skipped": 0.0,
+        }
+        # FSDP2 + run_on_fsdp2 -> not skipped; sample_shard None -> replicated branch.
+        ev = _FakeToolCallEvaluator(sample_shard=None, run_on_fsdp2=True, result=result)
+        out = self._run(_make_eval_recipe(FSDP2Config(), ev), monkeypatch)
+        assert out.metrics["tool_call/has_call"] == 0.75
+        assert out.metrics["tool_call/_count"] == 4.0
+        assert out.metrics["tool_call/_skipped"] == 0.0
+
+    def test_evaluate_failure_is_tolerated(self, monkeypatch):
+        from nemo_automodel.components.distributed.config import DDPConfig
+
+        ev = _FakeToolCallEvaluator(sample_shard=(0, 1), raises=True)
+        out = self._run(_make_eval_recipe(DDPConfig(), ev), monkeypatch)
+        # An evaluate() that raised contributes an empty result -> zeros, count 0.
+        assert out.metrics["tool_call/_count"] == 0.0
+        assert out.metrics["tool_call/has_call"] == 0.0

--- a/tests/unit_tests/recipes/test_train_ft.py
+++ b/tests/unit_tests/recipes/test_train_ft.py
@@ -31,10 +31,11 @@ requires_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA n
 from torch.utils.data import IterableDataset
 
 from nemo_automodel._transformers.model_init import resolve_sdpa_method
+from nemo_automodel.components.distributed.utils import dp_eval_sample_shard
+from nemo_automodel.components.eval.tool_call_evaluator import ToolCallAccuracyEvaluator
 from nemo_automodel.recipes.llm.train_ft import (
     PipelineCausalLMLoss,
     TrainFinetuneRecipeForNextTokenPrediction,
-    _dp_eval_sample_shard,
     build_dataloader,
     build_model,
     build_optimizer,
@@ -1987,63 +1988,29 @@ class TestResolveSdpaMethod:
 
 
 class TestDpEvalSampleShard:
-    """`_dp_eval_sample_shard` shards tool-call eval only when the model is
+    """`dp_eval_sample_shard` shards eval samples only when the model is
     replicated per DP rank (DDP); sharded strategies must stay in lockstep."""
 
     def test_ddp_multi_rank_shards(self):
         from nemo_automodel.components.distributed.config import DDPConfig
 
-        assert _dp_eval_sample_shard(DDPConfig(), 1, 4) == (1, 4)
+        assert dp_eval_sample_shard(DDPConfig(), 1, 4) == (1, 4)
 
     def test_ddp_single_rank_no_shard(self):
         from nemo_automodel.components.distributed.config import DDPConfig
 
-        assert _dp_eval_sample_shard(DDPConfig(), 0, 1) is None
+        assert dp_eval_sample_shard(DDPConfig(), 0, 1) is None
 
     def test_fsdp2_never_shards(self):
         # Sharding under FSDP2 would desync generate()'s per-layer all-gathers.
         from nemo_automodel.components.distributed.config import FSDP2Config
 
-        assert _dp_eval_sample_shard(FSDP2Config(), 1, 4) is None
+        assert dp_eval_sample_shard(FSDP2Config(), 1, 4) is None
 
     def test_megatron_fsdp_never_shards(self):
         from nemo_automodel.components.distributed.config import MegatronFSDPConfig
 
-        assert _dp_eval_sample_shard(MegatronFSDPConfig(), 1, 4) is None
-
-
-class TestShardToolCallEvalAcrossDp:
-    """`_shard_tool_call_eval_across_dp` wires the DP shard onto the evaluator
-    during setup: injected only for DDP, and never overriding a YAML-set shard."""
-
-    def _recipe(self, distributed_config, evaluator, dp_rank=1, dp_size=4):
-        recipe = TrainFinetuneRecipeForNextTokenPrediction.__new__(TrainFinetuneRecipeForNextTokenPrediction)
-        recipe.tool_call_evaluator = evaluator
-        recipe.distributed_config = distributed_config
-        recipe._get_dp_rank = lambda: dp_rank
-        recipe._get_dp_group_size = lambda: dp_size
-        return recipe
-
-    def test_ddp_injects_shard(self):
-        from nemo_automodel.components.distributed.config import DDPConfig
-
-        ev = _FakeToolCallEvaluator(sample_shard=None)
-        self._recipe(DDPConfig(), ev, dp_rank=1, dp_size=4)._shard_tool_call_eval_across_dp()
-        assert ev.sample_shard == (1, 4)
-
-    def test_fsdp2_leaves_shard_none(self):
-        from nemo_automodel.components.distributed.config import FSDP2Config
-
-        ev = _FakeToolCallEvaluator(sample_shard=None)
-        self._recipe(FSDP2Config(), ev)._shard_tool_call_eval_across_dp()
-        assert ev.sample_shard is None
-
-    def test_yaml_set_shard_is_untouched(self):
-        from nemo_automodel.components.distributed.config import DDPConfig
-
-        ev = _FakeToolCallEvaluator(sample_shard=(0, 2))
-        self._recipe(DDPConfig(), ev, dp_rank=1, dp_size=4)._shard_tool_call_eval_across_dp()
-        assert ev.sample_shard == (0, 2)  # explicit YAML shard preserved
+        assert dp_eval_sample_shard(MegatronFSDPConfig(), 1, 4) is None
 
 
 class _FakeToolCallEvaluator:
@@ -2051,14 +2018,8 @@ class _FakeToolCallEvaluator:
     so ``_run_validation_epoch``'s reduction can be tested without generation."""
 
     metric_prefix = "tool_call"
-    METRIC_KEYS = (
-        "has_call",
-        "name_correct",
-        "args_json_valid",
-        "args_field_recall",
-        "args_field_precision",
-        "args_exact_match",
-    )
+    # Reuse the real evaluator's keys so this fake can never silently diverge.
+    METRIC_KEYS = ToolCallAccuracyEvaluator.METRIC_KEYS
 
     def __init__(self, *, sample_shard=None, run_on_fsdp2=False, result=None, raises=False):
         self.sample_shard = sample_shard


### PR DESCRIPTION
# What does this PR do ?

Correctness fixes for multi-turn agent (tool-calling) SFT, all on that path.

## Tool-call eval: deadlock-safe, honestly documented, and DP-sharded

**Deadlock.** `_run_validation` reduced `ToolCallAccuracyEvaluator` metrics with one DP all-reduce per metric key, inside a `try`. Two rank-divergent conditions desynced the collectives and hung surviving ranks: (a) `evaluate()` raising on a subset of ranks (e.g. a divergent `generate()` CUDA OOM) skipped that rank's all-reduces while peers blocked; (b) the per-key loop iterated a **data-dependent** key set (`_skip_<reason>` differs per rank). Now reduced as a single packed all-reduce over a **fixed** vector, with a local `evaluate()` failure tolerated as an empty result that still participates.

**Honest docs + actually running.** The example YAML claimed the eval "Runs at every val step", but the recipe is FSDP2, which **skips** in-loop generation eval unless `run_on_fsdp2: true` (running `generate()` on the sharded training model repeatedly unshards params and can OOM the next step). The comment now says so, with a commented opt-in. (The default-skip is intentional and unchanged.)

**DP sharding.** The recipe never set `sample_shard`, so every DP rank redundantly scored the full set and `_count` was summed into `dp_size * n`. Now `sample_shard=(dp_rank, dp_size)` is injected **only under DDP** (model replicated per rank → each can generate a disjoint subset). Under FSDP2/MegatronFSDP the sharded model's `generate()` issues per-layer all-gathers that must stay in lockstep, so sharding there would desync and hang — those keep scoring the full set. The reduction sums across ranks only when sharded; when replicated it uses the identical local result (true `_count`, no needless collective).

## Last-turn loss mask: apply before reasoning is masked

`train_on_last_turn_only` post-processed labels with a "keep the last contiguous supervised run" heuristic. With `mask_reasoning_content=True`, masking reasoning punched a hole into the final assistant turn, so the heuristic dropped supervised content before it. The restriction now runs inside `format_chat_template`, on the hole-free assistant mask, before reasoning is masked.

# Changelog

- Reduce agent SFT tool-call eval metrics with one packed, failure-tolerant all-reduce over a fixed key set (fixes a multi-GPU deadlock); expose `ToolCallAccuracyEvaluator.METRIC_KEYS`.
- Inject `sample_shard` for DDP eval (disjoint per-rank scoring, correct `_count`); keep FSDP2/MegatronFSDP replicated in lockstep. New `_dp_eval_sample_shard` helper + public `sample_shard` property.
- Make the example YAML's tool-call eval comment honest (FSDP2 default-skip + `run_on_fsdp2` opt-in).
- Fix `train_on_last_turn_only` dropping in-turn content before a masked reasoning span; move the restriction into `format_chat_template`. `_mask_labels_to_last_turn` moved to `formatting_utils`, generalized over `ignore_index`.
- Tests: fixed-key reduction contract, `sample_shard` property + DDP-shard decision, last-turn mask (multi-turn + content-around-masked-reasoning regression).

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] New tests added
- [ ] Docs: example YAML comment updated; no public API doc change

# Additional Information

- DCO signed-off. `ruff format` + `ruff check` clean; affected unit tests pass locally.
- The DP-sharding builds directly on the deadlock-safe reduction (sharded per-rank subsets are only safe to all-reduce once the key set is fixed), which is why both land here together.
