### PR TITLE
ci(linting): free disk space before installing toolchain

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -59,6 +59,12 @@ jobs:
         uses: astral-sh/setup-uv@v1
         with:
           version: 0.8.22
+      - name: Free up disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf /usr/local/.ghcup || true
+          sudo rm -rf /usr/local/lib/node_modules || true
+          pip cache purge || true
       - name: Install ruff
         env:
           UV_PROJECT_ENVIRONMENT: ./venv
@@ -69,12 +75,6 @@ jobs:
           export PATH="./bin/:$PATH"
 
           uv sync --link-mode copy --locked --group linting
-      - name: Free up disk space
-        run: |
-          sudo rm -rf /usr/local/lib/android || true
-          sudo rm -rf /usr/local/.ghcup || true
-          sudo rm -rf /usr/local/lib/node_modules || true
-          pip cache purge || true
       - name: Run ruff
         run: |
           source ./venv/bin/activate
@@ -130,6 +130,12 @@ jobs:
         uses: astral-sh/setup-uv@v1
         with:
           version: 0.8.22
+      - name: Free up disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf /usr/local/.ghcup || true
+          sudo rm -rf /usr/local/lib/node_modules || true
+          pip cache purge || true
       - name: Install ty
         env:
           UV_PROJECT_ENVIRONMENT: ./venv


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Background / motivation

- Linting jobs on the `ubuntu-latest` runner (~14 GB free) are failing with `os error 28: No space left on device` while `uv sync` pulls `torch==2.9.0+cu129` and the bundled NVIDIA CUDA wheels.
- The `Free up disk space` step exists but is positioned **after** `Install ruff` in the `linting` job — by the time it runs, the install has already crashed.
- The `type_checking` job runs the same heavy `uv sync` (`Install ty`) but has no cleanup step at all, so it is one wheel away from the same failure.

Reference failure: https://github.com/NVIDIA-NeMo/Automodel/actions/runs/26763621681/job/78883766198

```text
error: Failed to install: torch-2.9.0+cu129-cp312-cp312-manylinux_2_28_x86_64.whl (torch==2.9.0+cu129)
  Caused by: failed to copy file from /tmp/setup-uv-cache/.../torch/lib/libtorch_cuda.so
             to /home/runner/work/.../venv/lib/python3.12/site-packages/torch/lib/libtorch_cuda.so:
             No space left on device (os error 28)
```

## What changed

- `linting` job: moved `Free up disk space` to **before** `Install ruff`.
- `type_checking` job: added the same `Free up disk space` step before `Install ty`.
- `import_linting` already had the correct order — left untouched.

## Details

- `.github/workflows/cicd-main.yml` — three jobs share the heavy `uv sync --group linting` install. After this change all three perform cleanup before the install.
  - `linting` (lines ~62–67): cleanup now precedes `Install ruff`.
  - `type_checking` (lines ~133–138): new cleanup block, identical to the other two jobs.
- Cleanup commands target the largest preinstalled trees on `ubuntu-latest`: `/usr/local/lib/android`, `/usr/local/.ghcup`, `/usr/local/lib/node_modules`, plus `pip cache purge` — together typically ~10 GB.

## Tested

- Local diff verified: `git diff --stat` → `1 file changed, 12 insertions(+), 6 deletions(-)`.
- CI on this PR will rerun the `linting` and `type_checking` jobs against the same `uv.lock` (which still resolves torch+CUDA) — green run is the real signal.
</details>
