### PR TITLE
perf(diffusion): improve Hunyuan training throughput

### DIFF
--- a/examples/diffusion/finetune/hunyuan_t2v_flow.yaml
+++ b/examples/diffusion/finetune/hunyuan_t2v_flow.yaml
@@ -2,7 +2,10 @@ model:
   pretrained_model_name_or_path: "hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-720p_t2v"
   mode: "finetune"
   cache_dir: null
-  attention_backend: "flash"
+  # Hunyuan passes attention masks into transformer blocks. flash_varlen plus
+  # the mask optimization is the fastest validated full fine-tuning setup.
+  attention_backend: "flash_varlen"
+  optimize_hunyuan_flash_varlen_mask: true
 
 optim:
   learning_rate: 5e-6

--- a/examples/diffusion/finetune/hunyuan_t2v_flow_lora.yaml
+++ b/examples/diffusion/finetune/hunyuan_t2v_flow_lora.yaml
@@ -16,9 +16,10 @@ model:
   model_type: "hunyuan"
   mode: "finetune"
   # Hunyuan's attention processor passes attn_mask to dispatch_attention_fn,
-  # which flash-attn 2 rejects ("`attn_mask` is not supported for flash-attn 2.").
-  # Use diffusers' native (PyTorch SDPA) backend, which handles attn_mask correctly.
-  attention_backend: "native"
+  # which plain flash-attn 2 rejects. flash_varlen plus the mask optimization
+  # keeps the packed-mask path correct and is the fastest validated LoRA setup.
+  attention_backend: "flash_varlen"
+  optimize_hunyuan_flash_varlen_mask: true
 
 # ── LoRA / PEFT configuration ─────────────────────────────────────────────────
 # Remove this section for full fine-tune.

--- a/nemo_automodel/components/flow_matching/adapters/hunyuan.py
+++ b/nemo_automodel/components/flow_matching/adapters/hunyuan.py
@@ -19,12 +19,135 @@ This adapter supports HunyuanVideo 1.5 style models with dual text encoders
 and image embeddings for image-to-video conditioning.
 """
 
+import logging
 from typing import Any, Dict, Tuple
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
+
+from nemo_automodel.shared.import_utils import safe_import_from
 
 from .base import FlowMatchingContext, ModelAdapter
+
+logger = logging.getLogger(__name__)
+
+
+def _is_flash_varlen_attention_backend(backend: Any) -> bool:
+    backend_name = getattr(backend, "value", backend)
+    return backend_name == "flash_varlen"
+
+
+def enable_hunyuan_flash_varlen_mask_optimization() -> bool:
+    """Patch Diffusers Hunyuan attention to avoid dense mask construction for flash-varlen attention."""
+    has_processor, processor_cls = safe_import_from(
+        "diffusers.models.transformers.transformer_hunyuan_video15",
+        "HunyuanVideo15AttnProcessor2_0",
+    )
+    has_dispatch, dispatch_attention_fn = safe_import_from(
+        "diffusers.models.attention_dispatch",
+        "dispatch_attention_fn",
+    )
+    has_rope, apply_rotary_emb = safe_import_from(
+        "diffusers.models.embeddings",
+        "apply_rotary_emb",
+    )
+    if not (has_processor and has_dispatch and has_rope):
+        logger.warning("Could not enable Hunyuan flash_varlen mask optimization because Diffusers imports failed.")
+        return False
+
+    if getattr(processor_cls, "_nemo_flash_varlen_mask_optimized", False):
+        return True
+
+    original_call = processor_cls.__call__
+
+    def _flash_varlen_mask_optimized_call(
+        self: Any,
+        attn: nn.Module,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        image_rotary_emb: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        if attention_mask is None or not _is_flash_varlen_attention_backend(getattr(self, "_attention_backend", None)):
+            return original_call(
+                self,
+                attn,
+                hidden_states,
+                encoder_hidden_states=encoder_hidden_states,
+                attention_mask=attention_mask,
+                image_rotary_emb=image_rotary_emb,
+            )
+
+        query = attn.to_q(hidden_states)
+        key = attn.to_k(hidden_states)
+        value = attn.to_v(hidden_states)
+
+        query = query.unflatten(2, (attn.heads, -1))
+        key = key.unflatten(2, (attn.heads, -1))
+        value = value.unflatten(2, (attn.heads, -1))
+
+        query = attn.norm_q(query)
+        key = attn.norm_k(key)
+
+        if image_rotary_emb is not None:
+            query = apply_rotary_emb(query, image_rotary_emb, sequence_dim=1)
+            key = apply_rotary_emb(key, image_rotary_emb, sequence_dim=1)
+
+        if encoder_hidden_states is not None:
+            encoder_query = attn.add_q_proj(encoder_hidden_states)
+            encoder_key = attn.add_k_proj(encoder_hidden_states)
+            encoder_value = attn.add_v_proj(encoder_hidden_states)
+
+            encoder_query = encoder_query.unflatten(2, (attn.heads, -1))
+            encoder_key = encoder_key.unflatten(2, (attn.heads, -1))
+            encoder_value = encoder_value.unflatten(2, (attn.heads, -1))
+
+            if attn.norm_added_q is not None:
+                encoder_query = attn.norm_added_q(encoder_query)
+            if attn.norm_added_k is not None:
+                encoder_key = attn.norm_added_k(encoder_key)
+
+            query = torch.cat([query, encoder_query], dim=1)
+            key = torch.cat([key, encoder_key], dim=1)
+            value = torch.cat([value, encoder_value], dim=1)
+
+        _, seq_len, _, _ = query.shape
+        attention_mask = F.pad(attention_mask, (seq_len - attention_mask.shape[1], 0), value=True).bool()
+
+        hidden_states = dispatch_attention_fn(
+            query,
+            key,
+            value,
+            attn_mask=attention_mask,
+            dropout_p=0.0,
+            is_causal=False,
+            backend=self._attention_backend,
+            parallel_config=self._parallel_config,
+        )
+
+        hidden_states = hidden_states.flatten(2, 3)
+        hidden_states = hidden_states.to(query.dtype)
+
+        if encoder_hidden_states is not None:
+            hidden_states, encoder_hidden_states = (
+                hidden_states[:, : -encoder_hidden_states.shape[1]],
+                hidden_states[:, -encoder_hidden_states.shape[1] :],
+            )
+
+            if getattr(attn, "to_out", None) is not None:
+                hidden_states = attn.to_out[0](hidden_states)
+                hidden_states = attn.to_out[1](hidden_states)
+
+            if getattr(attn, "to_add_out", None) is not None:
+                encoder_hidden_states = attn.to_add_out(encoder_hidden_states)
+
+        return hidden_states, encoder_hidden_states
+
+    processor_cls._nemo_original_call = original_call
+    processor_cls.__call__ = _flash_varlen_mask_optimized_call
+    processor_cls._nemo_flash_varlen_mask_optimized = True
+    return True
 
 
 class HunyuanAdapter(ModelAdapter):

--- a/nemo_automodel/recipes/diffusion/train.py
+++ b/nemo_automodel/recipes/diffusion/train.py
@@ -697,6 +697,7 @@ class TrainDiffusionRecipe(BaseRecipe):
         )
         self.fuse_qkv_projections = bool(self.cfg.get("model.fuse_qkv_projections", False))
         self.compact_fused_qkv_projections = bool(self.cfg.get("model.compact_fused_qkv_projections", False))
+        self.optimize_hunyuan_flash_varlen_mask = bool(self.cfg.get("model.optimize_hunyuan_flash_varlen_mask", False))
         if self.transformer_engine_fp8:
             self.transformer_engine_linear = True
         if self.compact_fused_qkv_projections and not self.fuse_qkv_projections:
@@ -747,6 +748,7 @@ class TrainDiffusionRecipe(BaseRecipe):
         )
         logging.info("[INFO] Fuse QKV projections: %s", self.fuse_qkv_projections)
         logging.info("[INFO] Compact fused QKV projections: %s", self.compact_fused_qkv_projections)
+        logging.info("[INFO] Optimize Hunyuan flash-varlen mask: %s", self.optimize_hunyuan_flash_varlen_mask)
         logging.info("[INFO] Precision: model_dtype=%s, compute_dtype=%s", self.model_dtype, self.compute_dtype)
         logging.info(
             "[INFO] Performance config: check_loss=%s, grad_clip_foreach=%s",
@@ -791,6 +793,15 @@ class TrainDiffusionRecipe(BaseRecipe):
         self.adapter_kwargs = (
             adapter_kwargs.to_dict() if hasattr(adapter_kwargs, "to_dict") else dict(adapter_kwargs or {})
         )
+        if self.optimize_hunyuan_flash_varlen_mask:
+            if self.adapter_type != "hunyuan":
+                raise ValueError(
+                    "model.optimize_hunyuan_flash_varlen_mask=true requires flow_matching.adapter_type=hunyuan"
+                )
+            if self.attention_backend != "flash_varlen":
+                raise ValueError(
+                    "model.optimize_hunyuan_flash_varlen_mask=true requires model.attention_backend=flash_varlen"
+                )
 
         logging.info("[INFO] Flow Matching V2 Pipeline")
         logging.info(f"[INFO]   - Adapter type: {self.adapter_type}")
@@ -850,6 +861,15 @@ class TrainDiffusionRecipe(BaseRecipe):
         )
 
         self.model = self.pipe.transformer
+        if self.optimize_hunyuan_flash_varlen_mask:
+            from nemo_automodel.components.flow_matching.adapters.hunyuan import (
+                enable_hunyuan_flash_varlen_mask_optimization,
+            )
+
+            if not enable_hunyuan_flash_varlen_mask_optimization():
+                raise RuntimeError("Failed to enable Hunyuan flash-varlen mask optimization")
+            logging.info("[INFO] Enabled Hunyuan flash-varlen 2D mask optimization")
+
         self.peft_config = getattr(self.pipe, "_peft_config", None)
 
         checkpoint_cfg = self.cfg.get("checkpoint", None)

--- a/tests/unit_tests/flow_matching/adapters/test_hunyuan_adapter.py
+++ b/tests/unit_tests/flow_matching/adapters/test_hunyuan_adapter.py
@@ -36,6 +36,7 @@ from nemo_automodel.components.flow_matching.adapters import (
     FlowMatchingContext,
     HunyuanAdapter,
 )
+from nemo_automodel.components.flow_matching.adapters import hunyuan as hunyuan_module
 from nemo_automodel.components.flow_matching.adapters.hunyuan import _is_flash_varlen_attention_backend
 
 # =============================================================================
@@ -95,6 +96,144 @@ class TestHunyuanFlashVarlenMaskOptimization:
         assert _is_flash_varlen_attention_backend("flash_varlen")
         assert _is_flash_varlen_attention_backend(Backend())
         assert not _is_flash_varlen_attention_backend("flash")
+
+    def test_enable_flash_varlen_mask_optimization_returns_false_when_diffusers_imports_fail(self, monkeypatch):
+        monkeypatch.setattr(hunyuan_module, "safe_import_from", lambda *_args: (False, None))
+
+        assert not hunyuan_module.enable_hunyuan_flash_varlen_mask_optimization()
+
+    def test_enable_flash_varlen_mask_optimization_is_idempotent_and_preserves_fallback(self, monkeypatch):
+        class FakeProcessor:
+            def __call__(
+                self,
+                attn,
+                hidden_states,
+                encoder_hidden_states=None,
+                attention_mask=None,
+                image_rotary_emb=None,
+            ):
+                self.original_call_count = getattr(self, "original_call_count", 0) + 1
+                return hidden_states + 1, encoder_hidden_states
+
+        def fake_dispatch_attention_fn(*_args, **_kwargs):
+            raise AssertionError("dispatch_attention_fn should not be called for fallback paths")
+
+        def fake_apply_rotary_emb(tensor, *_args, **_kwargs):
+            return tensor
+
+        def fake_safe_import_from(module_name, symbol_name):
+            symbols = {
+                (
+                    "diffusers.models.transformers.transformer_hunyuan_video15",
+                    "HunyuanVideo15AttnProcessor2_0",
+                ): FakeProcessor,
+                ("diffusers.models.attention_dispatch", "dispatch_attention_fn"): fake_dispatch_attention_fn,
+                ("diffusers.models.embeddings", "apply_rotary_emb"): fake_apply_rotary_emb,
+            }
+            return True, symbols[(module_name, symbol_name)]
+
+        monkeypatch.setattr(hunyuan_module, "safe_import_from", fake_safe_import_from)
+
+        assert hunyuan_module.enable_hunyuan_flash_varlen_mask_optimization()
+        original_call = FakeProcessor._nemo_original_call
+        patched_call = FakeProcessor.__call__
+        assert hunyuan_module.enable_hunyuan_flash_varlen_mask_optimization()
+        assert FakeProcessor._nemo_original_call is original_call
+        assert FakeProcessor.__call__ is patched_call
+
+        processor = FakeProcessor()
+        processor._attention_backend = "flash"
+        hidden_states = torch.zeros(1, 2, 4)
+
+        out, _ = processor(None, hidden_states, attention_mask=torch.ones(1, 2, dtype=torch.bool))
+        assert torch.equal(out, hidden_states + 1)
+        assert processor.original_call_count == 1
+
+        processor._attention_backend = "flash_varlen"
+        out, _ = processor(None, hidden_states, attention_mask=None)
+        assert torch.equal(out, hidden_states + 1)
+        assert processor.original_call_count == 2
+
+    def test_flash_varlen_mask_optimized_call_dispatches_with_padded_mask(self, monkeypatch):
+        class FakeProcessor:
+            def __call__(self, *_args, **_kwargs):
+                raise AssertionError("original call should not run for flash_varlen with an attention mask")
+
+        class FakeAttention(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.heads = 2
+                self.to_q = nn.Linear(4, 4, bias=False)
+                self.to_k = nn.Linear(4, 4, bias=False)
+                self.to_v = nn.Linear(4, 4, bias=False)
+                self.add_q_proj = nn.Linear(4, 4, bias=False)
+                self.add_k_proj = nn.Linear(4, 4, bias=False)
+                self.add_v_proj = nn.Linear(4, 4, bias=False)
+                self.norm_q = nn.Identity()
+                self.norm_k = nn.Identity()
+                self.norm_added_q = nn.Identity()
+                self.norm_added_k = nn.Identity()
+                self.to_out = nn.ModuleList([nn.Identity(), nn.Identity()])
+                self.to_add_out = nn.Identity()
+
+        dispatch_calls = {}
+        rotary_calls = []
+
+        def fake_dispatch_attention_fn(query, key, value, **kwargs):
+            dispatch_calls["query_shape"] = query.shape
+            dispatch_calls["key_shape"] = key.shape
+            dispatch_calls["value_shape"] = value.shape
+            dispatch_calls.update(kwargs)
+            return value
+
+        def fake_apply_rotary_emb(tensor, image_rotary_emb, sequence_dim):
+            rotary_calls.append((image_rotary_emb, sequence_dim))
+            return tensor
+
+        def fake_safe_import_from(module_name, symbol_name):
+            symbols = {
+                (
+                    "diffusers.models.transformers.transformer_hunyuan_video15",
+                    "HunyuanVideo15AttnProcessor2_0",
+                ): FakeProcessor,
+                ("diffusers.models.attention_dispatch", "dispatch_attention_fn"): fake_dispatch_attention_fn,
+                ("diffusers.models.embeddings", "apply_rotary_emb"): fake_apply_rotary_emb,
+            }
+            return True, symbols[(module_name, symbol_name)]
+
+        monkeypatch.setattr(hunyuan_module, "safe_import_from", fake_safe_import_from)
+        assert hunyuan_module.enable_hunyuan_flash_varlen_mask_optimization()
+
+        processor = FakeProcessor()
+        processor._attention_backend = "flash_varlen"
+        processor._parallel_config = "parallel-config"
+        hidden_states = torch.randn(2, 3, 4)
+        encoder_hidden_states = torch.randn(2, 2, 4)
+        attention_mask = torch.tensor([[True, False, True], [False, True, True]])
+        image_rotary_emb = object()
+
+        hidden_out, encoder_out = processor(
+            FakeAttention(),
+            hidden_states,
+            encoder_hidden_states=encoder_hidden_states,
+            attention_mask=attention_mask,
+            image_rotary_emb=image_rotary_emb,
+        )
+
+        assert hidden_out.shape == hidden_states.shape
+        assert encoder_out.shape == encoder_hidden_states.shape
+        assert dispatch_calls["query_shape"] == (2, 5, 2, 2)
+        assert dispatch_calls["key_shape"] == (2, 5, 2, 2)
+        assert dispatch_calls["value_shape"] == (2, 5, 2, 2)
+        assert dispatch_calls["attn_mask"].dtype is torch.bool
+        assert dispatch_calls["attn_mask"].shape == (2, 5)
+        assert dispatch_calls["attn_mask"][:, :2].all()
+        assert torch.equal(dispatch_calls["attn_mask"][:, 2:], attention_mask)
+        assert dispatch_calls["dropout_p"] == 0.0
+        assert dispatch_calls["is_causal"] is False
+        assert dispatch_calls["backend"] == "flash_varlen"
+        assert dispatch_calls["parallel_config"] == "parallel-config"
+        assert rotary_calls == [(image_rotary_emb, 1), (image_rotary_emb, 1)]
 
 
 # =============================================================================

--- a/tests/unit_tests/flow_matching/adapters/test_hunyuan_adapter.py
+++ b/tests/unit_tests/flow_matching/adapters/test_hunyuan_adapter.py
@@ -36,6 +36,7 @@ from nemo_automodel.components.flow_matching.adapters import (
     FlowMatchingContext,
     HunyuanAdapter,
 )
+from nemo_automodel.components.flow_matching.adapters.hunyuan import _is_flash_varlen_attention_backend
 
 # =============================================================================
 # Mock Model
@@ -82,6 +83,18 @@ class MockHunyuanModel(nn.Module):
         else:
             output = torch.randn_like(latents)
         return (output,)
+
+
+class TestHunyuanFlashVarlenMaskOptimization:
+    """Test helpers for the Hunyuan flash-varlen mask optimization."""
+
+    def test_flash_varlen_backend_detection(self):
+        class Backend:
+            value = "flash_varlen"
+
+        assert _is_flash_varlen_attention_backend("flash_varlen")
+        assert _is_flash_varlen_attention_backend(Backend())
+        assert not _is_flash_varlen_attention_backend("flash")
 
 
 # =============================================================================

--- a/tests/unit_tests/recipes/test_diffusion_train_metrics.py
+++ b/tests/unit_tests/recipes/test_diffusion_train_metrics.py
@@ -20,6 +20,7 @@ import pytest
 import torch
 import torch.nn as nn
 
+from nemo_automodel.components.config.loader import ConfigNode
 from nemo_automodel.recipes.diffusion import train as diffusion_train
 from nemo_automodel.recipes.diffusion.train import (
     TrainDiffusionRecipe,
@@ -292,6 +293,109 @@ def test_transformer_engine_fp8_context_calls_transformer_engine_autocast():
         recipe="recipe",
         amax_reduction_group="group",
     )
+
+
+def _minimal_diffusion_recipe_cfg(
+    *,
+    adapter_type="hunyuan",
+    attention_backend="flash_varlen",
+    optimize_hunyuan_flash_varlen_mask=True,
+):
+    return ConfigNode(
+        {
+            "model": {
+                "pretrained_model_name_or_path": "dummy-model",
+                "attention_backend": attention_backend,
+                "optimize_hunyuan_flash_varlen_mask": optimize_hunyuan_flash_varlen_mask,
+            },
+            "flow_matching": {"adapter_type": adapter_type},
+            "optim": {"learning_rate": 1.0e-4},
+            "performance": {},
+            "step_scheduler": {
+                "num_epochs": 1,
+                "local_batch_size": 1,
+                "global_batch_size": 1,
+                "ckpt_every_steps": 1,
+            },
+        }
+    )
+
+
+def _patch_lightweight_diffusion_recipe_setup(monkeypatch):
+    monkeypatch.setattr(diffusion_train, "build_distributed", lambda _cfg: SimpleNamespace(is_main=False))
+    monkeypatch.setattr(diffusion_train, "setup_logging", lambda: None)
+    monkeypatch.setattr(diffusion_train, "StatefulRNG", lambda *args, **kwargs: SimpleNamespace())
+    monkeypatch.setattr(diffusion_train.dist, "is_initialized", lambda: False)
+    monkeypatch.setattr(diffusion_train.torch.cuda, "is_available", lambda: False)
+
+
+@pytest.mark.parametrize(
+    ("adapter_type", "attention_backend", "expected_error"),
+    [
+        ("simple", "flash_varlen", "adapter_type=hunyuan"),
+        ("hunyuan", "flash", "attention_backend=flash_varlen"),
+    ],
+)
+def test_diffusion_recipe_validates_hunyuan_flash_varlen_mask_requirements(
+    monkeypatch,
+    adapter_type,
+    attention_backend,
+    expected_error,
+):
+    _patch_lightweight_diffusion_recipe_setup(monkeypatch)
+    build_model_and_optimizer_mock = MagicMock()
+    monkeypatch.setattr(diffusion_train, "build_model_and_optimizer", build_model_and_optimizer_mock)
+
+    recipe = TrainDiffusionRecipe(
+        _minimal_diffusion_recipe_cfg(adapter_type=adapter_type, attention_backend=attention_backend)
+    )
+
+    with pytest.raises(ValueError, match=expected_error):
+        recipe.setup()
+
+    build_model_and_optimizer_mock.assert_not_called()
+
+
+def test_diffusion_recipe_raises_when_hunyuan_flash_varlen_mask_optimization_fails(monkeypatch):
+    _patch_lightweight_diffusion_recipe_setup(monkeypatch)
+    monkeypatch.setattr(
+        diffusion_train,
+        "build_model_and_optimizer",
+        MagicMock(return_value=(SimpleNamespace(transformer=nn.Linear(1, 1)), object(), None)),
+    )
+
+    from nemo_automodel.components.flow_matching.adapters import hunyuan as hunyuan_module
+
+    enable_optimization = MagicMock(return_value=False)
+    monkeypatch.setattr(hunyuan_module, "enable_hunyuan_flash_varlen_mask_optimization", enable_optimization)
+
+    recipe = TrainDiffusionRecipe(_minimal_diffusion_recipe_cfg())
+
+    with pytest.raises(RuntimeError, match="Failed to enable Hunyuan flash-varlen mask optimization"):
+        recipe.setup()
+
+    enable_optimization.assert_called_once_with()
+
+
+def test_diffusion_recipe_enables_hunyuan_flash_varlen_mask_optimization_before_checkpoint_setup(monkeypatch):
+    _patch_lightweight_diffusion_recipe_setup(monkeypatch)
+    monkeypatch.setattr(
+        diffusion_train,
+        "build_model_and_optimizer",
+        MagicMock(return_value=(SimpleNamespace(transformer=nn.Linear(1, 1)), object(), None)),
+    )
+
+    from nemo_automodel.components.flow_matching.adapters import hunyuan as hunyuan_module
+
+    enable_optimization = MagicMock(return_value=True)
+    monkeypatch.setattr(hunyuan_module, "enable_hunyuan_flash_varlen_mask_optimization", enable_optimization)
+
+    recipe = TrainDiffusionRecipe(_minimal_diffusion_recipe_cfg())
+
+    with pytest.raises(ValueError, match="checkpoint config is required"):
+        recipe.setup()
+
+    enable_optimization.assert_called_once_with()
 
 
 class _TinyTransformer(nn.Module):


### PR DESCRIPTION
# What does this PR do ?

Improves HunyuanVideo training throughput by enabling the validated `flash_varlen` attention path and adding an opt-in Hunyuan mask optimization that avoids avoidable dense mask work in Diffusers attention.

# Changelog

- Add `model.optimize_hunyuan_flash_varlen_mask` to the diffusion training recipe and validate it is only used with the Hunyuan adapter and `flash_varlen` attention.
- Patch Diffusers Hunyuan attention at setup time to preserve the flash-varlen mask path while avoiding dense 2D mask construction overhead.
- Update Hunyuan full fine-tuning and LoRA recipes to use the best validated defaults: `attention_backend: flash_varlen` plus `optimize_hunyuan_flash_varlen_mask: true`.
- Add focused unit coverage for flash-varlen backend detection.

# Performance Summary

Full fine-tuning runs were executed on 8x H100 with FSDP2 DP=8, activation checkpointing enabled, and local/global batch 1/8.

- Baseline E002 (`flash_varlen`, no mask optimization): completed 24 optimizer steps, `24.758s/step`, `0.32-0.33 samples/s`, `28.78 GB` peak memory, final avg loss `0.064749`.
- Accepted E004 (`flash_varlen` + mask optimization): completed 24 optimizer steps, `21.700s/step`, `26.31 GB` peak memory, final avg loss `0.064336`.
- Result: `12.4%` lower step time, about `14.1%` higher throughput, and about `2.47 GB` lower peak memory with similar loss behavior.

LoRA runs were executed on 8x H100 with FSDP2 DP=8 unless otherwise noted.

- L001 native-attention profile: healthy 5-step run; non-profile steps were around `37-41s/step`, with attention and FSDP2 collectives dominating the profile.
- Accepted L002 (`flash_varlen` + mask optimization): completed 12 optimizer steps, `21.333s/step`, `19.63 GB` peak memory, final avg loss `0.079166`.
- L004 DDP with `find_unused_parameters=true`: completed 12 optimizer steps and was slightly faster at `20.984s/step`, but used `32.72 GB`, so it was not retained.
- L005 FSDP2 without activation checkpointing: rejected due to OOM before step 0.
- L006 Triton LoRA: completed 12 optimizer steps but was neutral at `21.334s/step`, so it was not retained.

# Validation Runs

Training-health validation:

- E002 completed with stable finite losses and finite grad norms.
- E004 completed with finite losses and finite grad norms. Final avg loss stayed close to E002 (`0.064336` vs `0.064749`), and the same late grad-norm spike recovered on the next step.
- E006 FSDP2 prefetch tuning and E008 Transformer Engine Linear were healthy but not retained because the speed difference was neutral or slightly worse than E004.
- E007 larger-batch run produced finite losses/grad norms but did not improve throughput enough to justify the memory increase and changed batch semantics.
- SSTA and FlexAttention alternatives were analyzed but not retained because they were not loss-preserving and/or did not show a speed win.

LoRA validation:

- L002 completed 12 optimizer steps without non-finite loss or grad norm using the retained settings.
- L007 validated the edited LoRA YAML defaults directly, without CLI attention overrides. It completed 3 steps with finite loss/grad norm and logged `Optimize Hunyuan flash-varlen mask: True`, `Setting attention backend to flash_varlen`, and `Enabled Hunyuan flash-varlen 2D mask optimization`.
- L007 step times were `23.426s`, `21.191s`, and `21.017s`; peak memory was `19.62 GB`.

Recipe/checkpoint/inference validation:

- LoRA validation ran `examples/diffusion/finetune/hunyuan_t2v_flow_lora.yaml` for 500 optimizer steps with FSDP2 DP=8, activation checkpointing enabled, `flash_varlen`, and `optimize_hunyuan_flash_varlen_mask=true`.
- Full fine-tune validation ran `examples/diffusion/finetune/hunyuan_t2v_flow.yaml` for 100 optimizer steps with FSDP2 DP=8, activation checkpointing enabled, `flash_varlen`, and `optimize_hunyuan_flash_varlen_mask=true`.
- Full fine-tuning reached final checkpoint save at `epoch_19_step_99`. The run exited nonzero during post-save NCCL synchronization after consolidation started, but the consolidated safetensors file was written and validated.
- Full checkpoint validation opened the consolidated safetensors checkpoint successfully with 1801 tensor keys.
- Full-finetuned inference loaded the consolidated checkpoint successfully and generated an MP4.
- Exact-prompt comparison videos were generated for original, LoRA-finetuned, and full-finetuned checkpoints using the same seed and inference settings.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed Contributor guidelines
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation? Recipe comments/defaults were updated; no separate docs page needed.

# Local Validation

- `python -m py_compile nemo_automodel/components/flow_matching/adapters/hunyuan.py nemo_automodel/recipes/diffusion/train.py`
- `UV_CACHE_DIR=/tmp/pthombre-uv-cache uv run --no-sync ruff format --check nemo_automodel/components/flow_matching/adapters/hunyuan.py nemo_automodel/recipes/diffusion/train.py tests/unit_tests/flow_matching/adapters/test_hunyuan_adapter.py`
- `UV_CACHE_DIR=/tmp/pthombre-uv-cache uv run --no-sync ruff check nemo_automodel/components/flow_matching/adapters/hunyuan.py nemo_automodel/recipes/diffusion/train.py tests/unit_tests/flow_matching/adapters/test_hunyuan_adapter.py`
- `git diff --check`

Focused pytest was attempted but this local checkout's `uv --no-sync` environment does not include `torch`, so test collection failed before running tests with `ModuleNotFoundError: No module named 'torch'`.

# Additional Information

The local `experiments/` directory with run notes is intentionally not included in this PR.
