### PR TITLE
fix(speculative): make EAGLE dataloader CUDA-fork-safe

### DIFF
--- a/nemo_automodel/components/datasets/llm/eagle3.py
+++ b/nemo_automodel/components/datasets/llm/eagle3.py
@@ -58,6 +58,26 @@ def build_eagle3_dataloader(
         unshifted=True,
     )
     sampler = DistributedSampler(dataset, shuffle=shuffle) if distributed else None
+
+    # The EAGLE recipes load the target model onto CUDA before iterating, so the
+    # CUDA context is already initialized by the time these workers spawn. Two
+    # defaults are unsafe in that state and must be overridden when
+    # ``num_workers > 0``:
+    #   * ``fork`` (the Linux default start method) hands each worker a copy of
+    #     the parent's live CUDA context, which is invalid in the child and
+    #     aborts the worker with ``cudaErrorInitializationError`` -> SIGABRT.
+    #     ``forkserver`` starts workers from a clean process with no inherited
+    #     CUDA context.
+    #   * Without ``persistent_workers`` the pool is torn down and re-forked at
+    #     every epoch boundary -- exactly when the abort surfaced (the first
+    #     epoch ran fine). Keeping workers alive across epochs removes that
+    #     re-fork entirely.
+    worker_kwargs: dict[str, Any] = {}
+    if num_workers > 0:
+        worker_kwargs["persistent_workers"] = True
+        if torch.cuda.is_available():
+            worker_kwargs["multiprocessing_context"] = "forkserver"
+
     return DataLoader(
         dataset,
         batch_size=batch_size,
@@ -67,6 +87,7 @@ def build_eagle3_dataloader(
         pin_memory=torch.cuda.is_available(),
         collate_fn=_stack_batch,
         drop_last=False,
+        **worker_kwargs,
     )
 
 

--- a/tests/unit_tests/datasets/llm/test_eagle3_dataloader.py
+++ b/tests/unit_tests/datasets/llm/test_eagle3_dataloader.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ``build_eagle3_dataloader`` worker configuration.
+
+The EAGLE recipes initialize CUDA (the target model) before iterating the
+dataloader. With ``num_workers > 0`` the workers must therefore (a) not inherit
+the parent's live CUDA context -- ``fork`` does, and aborts the worker with
+``cudaErrorInitializationError`` -- and (b) stay alive across epochs so the pool
+is not re-forked at every epoch boundary. These tests pin both behaviors.
+"""
+
+from __future__ import annotations
+
+from nemo_automodel.components.datasets.llm import eagle3
+
+
+def _patch_dataset(monkeypatch, n: int = 4):
+    """Replace ChatDataset with a tiny in-memory map-style dataset (no I/O)."""
+    rows = [{"input_ids": [0], "loss_mask": [0], "attention_mask": [1]} for _ in range(n)]
+    monkeypatch.setattr(eagle3, "ChatDataset", lambda *a, **k: rows)
+
+
+def _build(**over):
+    kwargs = dict(data_path="x", tokenizer=None, seq_length=8, batch_size=2, shuffle=False)
+    kwargs.update(over)
+    return eagle3.build_eagle3_dataloader(**kwargs)
+
+
+def test_no_workers_keeps_defaults(monkeypatch):
+    _patch_dataset(monkeypatch)
+    monkeypatch.setattr(eagle3.torch.cuda, "is_available", lambda: False)
+    dl = _build(num_workers=0)
+    assert dl.num_workers == 0
+    # persistent_workers / multiprocessing_context must NOT be forced on when
+    # there are no worker processes (DataLoader rejects persistent_workers with
+    # num_workers == 0).
+    assert dl.persistent_workers is False
+    assert dl.multiprocessing_context is None
+
+
+def test_workers_are_persistent(monkeypatch):
+    _patch_dataset(monkeypatch)
+    monkeypatch.setattr(eagle3.torch.cuda, "is_available", lambda: False)
+    dl = _build(num_workers=4)
+    assert dl.num_workers == 4
+    # Persistent across epochs -> no re-fork at the epoch boundary.
+    assert dl.persistent_workers is True
+    # No CUDA -> no need to override the start method.
+    assert dl.multiprocessing_context is None
+
+
+def test_workers_use_forkserver_when_cuda_available(monkeypatch):
+    _patch_dataset(monkeypatch)
+    monkeypatch.setattr(eagle3.torch.cuda, "is_available", lambda: True)
+    dl = _build(num_workers=4)
+    assert dl.persistent_workers is True
+    # forkserver -> workers start clean, without the parent's CUDA context.
+    assert dl.multiprocessing_context.get_start_method() == "forkserver"


### PR DESCRIPTION
## What

EAGLE training aborts at the **first epoch boundary** with:

```
CUDA error: initialization error
...
RuntimeError: DataLoader worker (pid ...) is killed by signal: Aborted.
```

when `recipe_args.num_workers` is large (observed at 16 / 32; lowering to 4 is a
stopgap that only reduces the probability).

## Root cause

The EAGLE recipes (`train_eagle{1,2,3}.py`) load the **target model onto CUDA**
and run forwards (`generate_batch`) before iterating the dataloader, so the CUDA
context is already initialized when `build_eagle3_dataloader` spawns its workers.
Two `DataLoader` defaults are unsafe in that state:

- **`fork`** (the Linux default start method) hands each worker a copy of the
  parent's live CUDA context, which is invalid in the child and aborts the
  worker with `cudaErrorInitializationError` → SIGABRT.
- Without **`persistent_workers`**, the worker pool is torn down and **re-forked
  at every epoch boundary** — exactly when the abort surfaces (the first epoch
  runs fine, the crash hits as epoch 1 starts).

## Fix

In `build_eagle3_dataloader`, when `num_workers > 0`:

- set `persistent_workers=True` so the pool survives epoch boundaries (no
  re-fork), and
- set `multiprocessing_context="forkserver"` when CUDA is available so workers
  start from a clean process with no inherited CUDA context.

`num_workers == 0` is unchanged. This builder backs **EAGLE-1/2/3**, so all three
recipes are fixed in one place. Users can keep high `num_workers` for throughput.

## Changelog

- `components/datasets/llm/eagle3.py`: CUDA-fork-safe worker config in
  `build_eagle3_dataloader` (persistent workers + forkserver when CUDA).
- Tests: `tests/unit_tests/datasets/llm/test_eagle3_dataloader.py` pinning the
  worker config across no-workers / workers-no-cuda / workers-with-cuda.

## Pre-checks

- [x] `ruff format` / `ruff check` clean.
- [x] `pytest tests/unit_tests/datasets/llm/test_eagle3_dataloader.py tests/unit_tests/speculative/test_eagle3.py` → 31 passed, 2 skipped (GPU-gated).
- [x] `/simplify` run over the diff (no changes needed).
- [x] DCO sign-off present.