### PR TITLE
fix(speculative): declare flash_attention_2 support on EAGLE-3 draft

### DIFF
--- a/nemo_automodel/components/speculative/eagle/draft_llama.py
+++ b/nemo_automodel/components/speculative/eagle/draft_llama.py
@@ -508,6 +508,12 @@ class LlamaEagle3DraftModel(PreTrainedModel):
 
     config_class = PretrainedConfig
     base_model_prefix = "model"
+    # Declare the attention backends this draft actually implements so
+    # ``PreTrainedModel.__init__`` allows them. ``Eagle3LlamaAttention`` supports
+    # ``eager`` and ``flash_attention_2`` (see ``_SUPPORTED_ATTN_IMPLEMENTATIONS``)
+    # but NOT SDPA; without this flag transformers defaults ``_supports_flash_attn``
+    # to ``False`` and rejects ``attn_implementation="flash_attention_2"``.
+    _supports_flash_attn = True
 
     def __init__(self, config: PretrainedConfig):
         super().__init__(config)

--- a/tests/unit_tests/speculative/test_eagle_draft_attn_support.py
+++ b/tests/unit_tests/speculative/test_eagle_draft_attn_support.py
@@ -70,5 +70,9 @@ def test_eagle3_draft_constructs_with_flash_attention_2():
 
 def test_eagle1_2_draft_does_not_claim_flash_attn():
     # EAGLE-1/2 attention is eager-only; advertising FA2 would let transformers
-    # dispatch a backend the layer cannot run.
-    assert LlamaEagleDraftModel._supports_flash_attn is False
+    # dispatch a backend the layer cannot run. EAGLE-3 opts in via a class-level
+    # override; EAGLE-1/2 must not declare its own override (it inherits the base
+    # PreTrainedModel default, which is a property in current transformers and so
+    # cannot be compared by value at the class level).
+    assert LlamaEagle3DraftModel.__dict__.get("_supports_flash_attn") is True
+    assert "_supports_flash_attn" not in LlamaEagleDraftModel.__dict__

--- a/tests/unit_tests/speculative/test_eagle_draft_attn_support.py
+++ b/tests/unit_tests/speculative/test_eagle_draft_attn_support.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Attention-backend capability flags for the EAGLE draft models.
+
+``transformers`` gates ``attn_implementation="flash_attention_2"`` on the
+class-level ``_supports_flash_attn`` flag (default ``False`` on
+``PreTrainedModel``). The EAGLE-3 draft attention implements eager + FA2, so it
+must advertise FA2; the EAGLE-1/2 draft attention is eager-only and must not.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from transformers import LlamaConfig
+
+from nemo_automodel.components.speculative.eagle.draft_llama import _HAS_FA, LlamaEagle3DraftModel
+from nemo_automodel.components.speculative.eagle.draft_llama_v12 import LlamaEagleDraftModel
+
+
+def _tiny_config() -> LlamaConfig:
+    config = LlamaConfig(
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        vocab_size=64,
+        max_position_embeddings=64,
+    )
+    config.draft_vocab_size = 16
+    config.target_hidden_size = 32
+    return config
+
+
+def test_eagle3_draft_declares_flash_attn_support():
+    # This flag is exactly what transformers' _flash_attn_can_dispatch checks;
+    # without it, attn_implementation="flash_attention_2" is rejected at init.
+    assert LlamaEagle3DraftModel._supports_flash_attn is True
+    # The draft attention implements eager + FA2 but NOT SDPA, so SDPA stays off.
+    assert LlamaEagle3DraftModel._supports_sdpa is False
+
+
+def test_eagle3_draft_eager_construction_unchanged():
+    # The default (eager) path must keep working.
+    model = LlamaEagle3DraftModel(_tiny_config()).to(torch.float32)
+    assert model is not None
+
+
+@pytest.mark.skipif(not _HAS_FA, reason="flash-attn not installed")
+def test_eagle3_draft_constructs_with_flash_attention_2():
+    config = _tiny_config()
+    config.attn_implementation = "flash_attention_2"
+    # Must not raise transformers' "does not support Flash Attention 2 yet".
+    model = LlamaEagle3DraftModel(config)
+    assert model is not None
+
+
+def test_eagle1_2_draft_does_not_claim_flash_attn():
+    # EAGLE-1/2 attention is eager-only; advertising FA2 would let transformers
+    # dispatch a backend the layer cannot run.
+    assert LlamaEagleDraftModel._supports_flash_attn is False


### PR DESCRIPTION
## What

Training an EAGLE-3 draft with `attn_implementation="flash_attention_2"` aborts at
model construction:

```
ValueError: LlamaEagle3DraftModel does not support Flash Attention 2 yet.
```

## Root cause

transformers 5.x gates `flash_attention_2` on the class-level
`_supports_flash_attn` flag, which `PreTrainedModel` defaults to `False`
(`modeling_utils.py`: `_flash_attn_can_dispatch` -> `if not self._supports_flash_attn: raise`).
`LlamaEagle3DraftModel` never declared it — even though its
`Eagle3LlamaAttention` already implements both `eager` **and**
`flash_attention_2` (`_SUPPORTED_ATTN_IMPLEMENTATIONS = ("eager", "flash_attention_2")`).
So FA2 was rejected at `__init__` before the layer's own working FA2 path could run.

## Fix

Set `_supports_flash_attn = True` on `LlamaEagle3DraftModel`.

- `_supports_sdpa` is left at its `False` default — the draft attention implements
  eager + FA2 but **not** SDPA, so advertising SDPA would let transformers dispatch
  a backend the layer can't run.
- The EAGLE-1/2 draft (`LlamaEagleDraftModel`, `draft_llama_v12.py`) is **eager-only**
  and is deliberately left without the flag.

## Changelog

- `components/speculative/eagle/draft_llama.py`: declare `_supports_flash_attn = True`
  on `LlamaEagle3DraftModel`.
- Tests: `tests/unit_tests/speculative/test_eagle_draft_attn_support.py` — EAGLE-3
  advertises FA2 (and not SDPA), EAGLE-1/2 does not, eager construction still works,
  and FA2 construction succeeds when flash-attn is installed (skipped otherwise).

## Pre-checks

- [x] `ruff format` / `ruff check` clean.
- [x] `pytest tests/unit_tests/speculative/test_eagle_draft_attn_support.py tests/unit_tests/speculative/test_eagle3.py` → 31 passed, 3 skipped (FA2/GPU-gated).
- [x] `/simplify` run over the diff (no changes needed).
- [x] DCO sign-off present.