### PR TITLE
perf(diffusion): improve wan2.1 finetuning defaults

### DIFF
--- a/examples/diffusion/finetune/wan2_1_t2v_flow.yaml
+++ b/examples/diffusion/finetune/wan2_1_t2v_flow.yaml
@@ -10,7 +10,7 @@ dist_env:
   timeout_minutes: 30
 
 model:
-  pretrained_model_name_or_path: Wan-AI/Wan2.1-T2V-1.3B-Diffusers
+  pretrained_model_name_or_path: Wan-AI/Wan2.1-T2V-14B-Diffusers
   mode: finetune  # "finetune" loads pretrained weights, "pretrain" initializes random weights
 
 step_scheduler:
@@ -72,6 +72,7 @@ fsdp:
   pp_size: 1
   dp_replicate_size: 1
   dp_size: 8
+  activation_checkpointing: false
   defer_fsdp_grad_sync: true
   enable_fsdp2_prefetch: true
   fsdp2_backward_prefetch_depth: 2

--- a/examples/diffusion/finetune/wan2_1_t2v_flow_lora.yaml
+++ b/examples/diffusion/finetune/wan2_1_t2v_flow_lora.yaml
@@ -10,7 +10,7 @@ dist_env:
   timeout_minutes: 30
 
 model:
-  pretrained_model_name_or_path: Wan-AI/Wan2.1-T2V-1.3B-Diffusers
+  pretrained_model_name_or_path: Wan-AI/Wan2.1-T2V-14B-Diffusers
   # Required when peft block is present — triggers QKV unfuse before injection
   # and is passed to auto_diffusion_pipeline for model-specific setup.
   model_type: "wan"
@@ -27,9 +27,7 @@ peft:
   dropout: 0.0
   target_modules:
     - "*.to_q"
-    - "*.to_k"
     - "*.to_v"
-    - "*.to_out.0"
 
 optim:
   learning_rate: 5e-6
@@ -51,6 +49,7 @@ fsdp:
   pp_size: 1
   dp_replicate_size: 1
   dp_size: 8
+  activation_checkpointing: false
 
 flow_matching:
   adapter_type: "simple"


### PR DESCRIPTION
# What does this PR do ?

Update the Wan 2.1 T2V finetuning example defaults to the best-performing 14B full finetuning and LoRA configurations from the local performance sweep.

# Changelog

- Switch `wan2_1_t2v_flow.yaml` and `wan2_1_t2v_flow_lora.yaml` to `Wan-AI/Wan2.1-T2V-14B-Diffusers`.
- Disable FSDP activation checkpointing for the Wan 2.1 full finetuning and LoRA example defaults.
- Narrow the LoRA target modules to q/v projections for the speed-focused rank-64 LoRA default.

# Experiment summary

Full finetuning:

- Baseline/control: E010 foreach AdamW control averaged `0.897s/step` over steps 2-23.
- Adopted: E013 no activation checkpointing confirmation averaged `0.893s/step`, about `8.96 samples/s`, with `48.98 GB` peak memory.
- Effectiveness: the adopted full finetuning default is a small but confirmed improvement over the control, about `0.4%` lower step time. Gradient accumulation x2 reached `9.34 samples/s`, but was not adopted because it changes effective global batch size to 16.
- Rejected paths: fused AdamW was unstable over a longer run, FP8 Transformer Engine was slower and used more memory, explicit attention backend overrides were slower than the default path, and TP2 was runnable after fixes but slower due to reduced DP and extra collectives.

LoRA:

- Baseline: L001 LoRA 14B throughput baseline averaged `0.789s/step` with `29.71 GB` peak memory.
- Adopted: L006 q/v-only rank-64 LoRA averaged `0.610s/step`, about `13.1 samples/s`, with `29.26 GB` peak memory.
- Effectiveness: the adopted LoRA default reduces step time by about `23%` and improves throughput by about `29%` versus the LoRA baseline, while slightly reducing peak memory.
- Alternates considered: q/v-only rank32 was similar speed with lower capacity, q/k/v-only rank64 was a coverage/speed compromise at `0.625s/step`, and q/v-only grad accumulation x2 gave only a tiny throughput gain while changing effective global batch size.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

No new tests were added because this PR only updates example YAML defaults. The performance sweep is recorded in the local untracked `experiments/wan_perf/EXPERIMENTS.md` notes used to prepare this summary.

# Additional Information

- Related to Wan 2.1 T2V 14B finetuning performance.
