### PR TITLE
perf(diffusion): optimize Wan2.1 finetuning recipes

### DIFF
--- a/examples/diffusion/finetune/wan2_1_t2v_flow.yaml
+++ b/examples/diffusion/finetune/wan2_1_t2v_flow.yaml
@@ -10,7 +10,7 @@ dist_env:
   timeout_minutes: 30
 
 model:
-  pretrained_model_name_or_path: Wan-AI/Wan2.1-T2V-1.3B-Diffusers
+  pretrained_model_name_or_path: Wan-AI/Wan2.1-T2V-14B-Diffusers
   mode: finetune  # "finetune" loads pretrained weights, "pretrain" initializes random weights
 
 step_scheduler:
@@ -72,6 +72,7 @@ fsdp:
   pp_size: 1
   dp_replicate_size: 1
   dp_size: 8
+  activation_checkpointing: false
   defer_fsdp_grad_sync: true
   enable_fsdp2_prefetch: true
   fsdp2_backward_prefetch_depth: 2

--- a/examples/diffusion/finetune/wan2_1_t2v_flow.yaml
+++ b/examples/diffusion/finetune/wan2_1_t2v_flow.yaml
@@ -12,6 +12,8 @@ dist_env:
 model:
   pretrained_model_name_or_path: Wan-AI/Wan2.1-T2V-14B-Diffusers
   mode: finetune  # "finetune" loads pretrained weights, "pretrain" initializes random weights
+  torch_dtype: float32
+  compute_dtype: bfloat16
 
 step_scheduler:
   global_batch_size: 8
@@ -74,7 +76,9 @@ fsdp:
   dp_size: 8
   activation_checkpointing: false
   defer_fsdp_grad_sync: true
-  enable_fsdp2_prefetch: true
+  reduce_dtype: bfloat16
+  enable_fsdp2_prefetch: false
+  enable_compile: true
   fsdp2_backward_prefetch_depth: 2
   fsdp2_forward_prefetch_depth: 1
 

--- a/examples/diffusion/finetune/wan2_1_t2v_flow_lora.yaml
+++ b/examples/diffusion/finetune/wan2_1_t2v_flow_lora.yaml
@@ -32,8 +32,15 @@ peft:
 optim:
   learning_rate: 5e-6
   optimizer:
+    _target_: transformer_engine.pytorch.optimizers.fused_adam.FusedAdam
     weight_decay: 0.01
     betas: [0.9, 0.999]
+    master_weights: true
+    store_param_remainders: true
+    exp_avg_dtype: float32
+    exp_avg_sq_dtype: float32
+    adam_w_mode: true
+    bias_correction: true
 
 lr_scheduler:
   lr_decay_style: cosine
@@ -50,6 +57,10 @@ fsdp:
   dp_replicate_size: 1
   dp_size: 8
   activation_checkpointing: false
+  defer_fsdp_grad_sync: true
+  reduce_dtype: bfloat16
+  enable_fsdp2_prefetch: false
+  enable_compile: true
 
 flow_matching:
   adapter_type: "simple"
@@ -68,8 +79,8 @@ flow_matching:
   summary_log_interval: 10
 
 step_scheduler:
-  global_batch_size: 8
-  local_batch_size: 1
+  global_batch_size: 16
+  local_batch_size: 2
   ckpt_every_steps: 1000
   num_epochs: 100
   log_every: 2

--- a/examples/diffusion/finetune/wan2_1_t2v_flow_lora.yaml
+++ b/examples/diffusion/finetune/wan2_1_t2v_flow_lora.yaml
@@ -10,7 +10,7 @@ dist_env:
   timeout_minutes: 30
 
 model:
-  pretrained_model_name_or_path: Wan-AI/Wan2.1-T2V-1.3B-Diffusers
+  pretrained_model_name_or_path: Wan-AI/Wan2.1-T2V-14B-Diffusers
   # Required when peft block is present — triggers QKV unfuse before injection
   # and is passed to auto_diffusion_pipeline for model-specific setup.
   model_type: "wan"
@@ -27,9 +27,7 @@ peft:
   dropout: 0.0
   target_modules:
     - "*.to_q"
-    - "*.to_k"
     - "*.to_v"
-    - "*.to_out.0"
 
 optim:
   learning_rate: 5e-6
@@ -51,6 +49,7 @@ fsdp:
   pp_size: 1
   dp_replicate_size: 1
   dp_size: 8
+  activation_checkpointing: false
 
 flow_matching:
   adapter_type: "simple"

--- a/nemo_automodel/recipes/diffusion/train.py
+++ b/nemo_automodel/recipes/diffusion/train.py
@@ -454,6 +454,8 @@ def build_model_and_optimizer(
                 )
             dp_size = world_size // denom
 
+        reduce_dtype = dtype_from_str(fsdp_cfg.get("reduce_dtype", None), default=torch.float32)
+
         manager_args: Dict[str, Any] = {
             "_manager_type": "fsdp2",
             "dp_size": dp_size,
@@ -476,7 +478,7 @@ def build_model_and_optimizer(
             "fsdp2_forward_prefetch_depth": fsdp_cfg.get("fsdp2_forward_prefetch_depth", 1),
             "mp_policy": MixedPrecisionPolicy(
                 param_dtype=param_dtype,
-                reduce_dtype=torch.float32,
+                reduce_dtype=reduce_dtype,
                 output_dtype=compute_dtype,
             ),
         }

--- a/tests/unit_tests/recipes/test_diffusion_train_metrics.py
+++ b/tests/unit_tests/recipes/test_diffusion_train_metrics.py
@@ -442,6 +442,7 @@ def test_build_model_and_optimizer_forwards_perf_options_and_optimizer_kwargs(mo
             "enable_fsdp2_prefetch": False,
             "fsdp2_backward_prefetch_depth": 4,
             "fsdp2_forward_prefetch_depth": 3,
+            "reduce_dtype": "bfloat16",
         },
         attention_backend="flash",
         transformer_engine_linear=True,
@@ -468,6 +469,7 @@ def test_build_model_and_optimizer_forwards_perf_options_and_optimizer_kwargs(mo
     assert manager_args["enable_fsdp2_prefetch"] is False
     assert manager_args["fsdp2_backward_prefetch_depth"] == 4
     assert manager_args["fsdp2_forward_prefetch_depth"] == 3
+    assert manager_args["mp_policy"].reduce_dtype is torch.bfloat16
     assert calls["transformer_engine_linear"] is True
     assert calls["transformer_engine_fp8_safe_only"] is True
     assert calls["fuse_qkv_projections"] is True


### PR DESCRIPTION
# What does this PR do ?

Optimizes the Wan2.1-T2V-14B full finetuning and LoRA example recipes based on the local Wan performance and correctness experiment runs.

# Changelog

- Add configurable `fsdp.reduce_dtype` support to the diffusion training recipe mixed precision policy.
- Update `examples/diffusion/finetune/wan2_1_t2v_flow.yaml` to use the Wan2.1-T2V-14B Diffusers model with FP32 model storage, BF16 compute/reduce, disabled FSDP2 prefetch, and per-layer compile.
- Update `examples/diffusion/finetune/wan2_1_t2v_flow_lora.yaml` to use the Wan2.1-T2V-14B Diffusers model with the selected LoRA target modules, batch size, BF16 reduction, compile, and TE FusedAdam optimizer-state settings.
- Extend the diffusion recipe unit test to verify the forwarded FSDP reduce dtype.

# Experiment Summary

Reference experiment directories from the development workspace:

- `experiments/wan_perf/`
- `experiments/wan_correctness/`

Wan full finetuning performance experiments:

- Baseline clean throughput, `E001`: `0.893s/step`, `8.96 samples/sec`, `48.98 GiB`.
- BF16 FSDP reduction, `E010`: improved to `0.839s/step`, `9.53 samples/sec`, `47.83 GiB`.
- Per-layer compile on top of BF16 reduction, `E014`: raw performance winner at `0.693s/step`, `11.54 samples/sec`, `38.62 GiB`.
- Safety recommendation retained in the recipe: FP32 model storage plus BF16 compute/reduce, no FSDP2 prefetch, and per-layer compile. The safety run completed at `0.715s/step`, `11.19 samples/sec`, `48.55 GiB`.
- Rejected alternatives included fused AdamW, deeper/prefetch-enabled FSDP2, Diffusers QKV fusion, flash attention, TE FP8, TE BF16 linear, and local batch 2 full finetuning due to regressions or OOM.

Wan LoRA performance experiments:

- Clean LoRA baseline, `L001`: `0.607s/step`, `13.18 samples/sec`, `29.26 GiB`.
- Local/global batch `2/16`, `L002`: improved sample throughput to `14.99 samples/sec`, but used `52.31 GiB`.
- Batch `2/16` plus BF16 reduction, disabled FSDP2 prefetch, and per-layer compile, `L003`: winner at `0.792s/step`, `20.21 samples/sec`, `45.13 GiB`.
- Local/global batch `3/24`, `L004`, fit but regressed to `19.12 samples/sec` and `64.61 GiB`.
- Re-enabling FSDP2 prefetch, `L005`, tied throughput at `20.20 samples/sec` but used slightly more memory.
- Safety recommendation retained in the recipe: L003 runtime settings plus TE FusedAdam with FP32 master/state settings; the safety run completed at `20.10 samples/sec`, effectively tied with L003.

Correctness runs:

- Ran correctness coverage for the updated full-finetune and LoRA recipes.
- Full finetune completed 500 optimizer steps with final `train_loss=0.705226`, steady throughput after step 100 of `10.912 samples/sec`, and peak memory `38.67 GB`.
- LoRA finetune completed 500 optimizer steps with final `train_loss=0.492492`, steady throughput after step 100 of `18.538 samples/sec`, and peak memory `45.14 GB`.
- Generated base, full-finetuned, and LoRA outputs for visual comparison; middle-frame visual checks were saved under `experiments/wan_correctness/generated/frames`.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed Contributor guidelines.
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

Validation:

- `UV_CACHE_DIR=/tmp/uv_cache uv run --extra diffusion pytest tests/unit_tests/recipes/test_diffusion_train_metrics.py -q` passed during the experiment workflow.

# Additional Information

- Branch contains signed-off commits.
