### PR TITLE
feat(speculative): add step-based and final checkpointing to EAGLE recipes

### DIFF
--- a/examples/speculative/eagle3/llama_eagle3_mvp.yaml
+++ b/examples/speculative/eagle3/llama_eagle3_mvp.yaml
@@ -50,6 +50,14 @@ recipe_args:
   shuffle_seed: 42
   log_every_steps: 10
   max_grad_norm: 1.0
+  # Checkpoint cadence (two independent knobs). The fully-trained model is always
+  # saved when the run completes; these only add intermediate checkpoints. Set
+  # ckpt_every_steps to save every N optimizer steps, and/or
+  # save_checkpoint_every_epoch to save at each epoch boundary; setting both
+  # stacks them. With neither set, only the end-of-run checkpoint is written.
+  # Directories are named epoch_{epoch}_step_{global_step}.
+  # ckpt_every_steps: 500
+  # save_checkpoint_every_epoch: false
 
 optimizer:
   # TTT loss is a weighted mean (``Σ 0.8^i * L_i / Σ 0.8^i``), so LR is

--- a/nemo_automodel/recipes/llm/train_eagle1.py
+++ b/nemo_automodel/recipes/llm/train_eagle1.py
@@ -239,6 +239,17 @@ class TrainEagle1Recipe(BaseRecipe):
         self.max_grad_norm = recipe_cfg.get("max_grad_norm", 1.0)
         self.num_epochs = recipe_cfg.num_epochs
         self.log_every_steps = recipe_cfg.get("log_every_steps", 10)
+        # Checkpoint cadence. The two knobs are independent:
+        #   * ``ckpt_every_steps``            -- save every N optimizer steps (None/<=0 = off).
+        #   * ``save_checkpoint_every_epoch`` -- save at each epoch boundary (off by default).
+        # The fully-trained model is always saved once the run completes; these
+        # only add intermediate checkpoints (and stack when both are set). With
+        # both off, the end-of-run checkpoint is the only one written.
+        # NOTE: field names mirror StepScheduler (components/training/step_scheduler.py),
+        # which the SFT recipe uses for the same cadence; EAGLE hand-rolls its own
+        # loop, so a future refactor could adopt StepScheduler here too.
+        self.ckpt_every_steps = recipe_cfg.get("ckpt_every_steps", None)
+        self.save_checkpoint_every_epoch = recipe_cfg.get("save_checkpoint_every_epoch", False)
         self.output_dir = pathlib.Path(recipe_cfg.output_dir)
         self.output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -416,6 +427,62 @@ class TrainEagle1Recipe(BaseRecipe):
                     self._update_best_symlink(path, float(best_val_metric))
             if is_dist_initialized:
                 dist.barrier()
+
+    def _log_saved_checkpoint(self, kind: str, epoch: int, step: int) -> None:
+        """Log a saved checkpoint on rank 0 when checkpointing is enabled."""
+        ckpt_cfg = getattr(self, "checkpoint_config", None)
+        if self.dist_env.is_main and ckpt_cfg is not None and ckpt_cfg.enabled:
+            logger.info("Saved %s checkpoint to %s/epoch_%d_step_%d", kind, ckpt_cfg.checkpoint_dir, epoch, step)
+
+    def _maybe_save_step_checkpoint(self, epoch: int) -> bool:
+        """Save a checkpoint mid-epoch when ``ckpt_every_steps`` is configured.
+
+        Called after every optimizer step. Saves whenever ``ckpt_every_steps`` is
+        a positive integer and the current ``global_step`` is a multiple of it.
+        Returns True if a checkpoint was written. The checkpoint directory is
+        named ``epoch_{epoch}_step_{global_step}`` so it never collides with the
+        end-of-epoch checkpoint (which uses ``epoch + 1``).
+        """
+        every = getattr(self, "ckpt_every_steps", None)
+        if every is None or every <= 0 or self.runtime.global_step % every != 0:
+            return False
+        self.save_checkpoint(
+            epoch=epoch,
+            step=self.runtime.global_step,
+            train_loss=None,
+            val_loss=None,
+            best_metric_key="val_loss",
+        )
+        self._log_saved_checkpoint("step", epoch, self.runtime.global_step)
+        return True
+
+    def _maybe_save_final_checkpoint(self, completed_epochs: int) -> bool:
+        """Always save the fully-trained model at the end of a completed run,
+        unless a periodic checkpoint already captured the final step.
+
+        The end-of-run state is otherwise easy to lose: with no cadence nothing is
+        saved at all, and with a pure step cadence the final step is skipped
+        whenever the total step count is not a multiple of ``ckpt_every_steps``.
+        This is a no-op only when a step or epoch checkpoint already landed on the
+        final step, so it never duplicates or collides with one.
+        """
+        gs = self.runtime.global_step
+        if gs <= 0:
+            return False
+        every = getattr(self, "ckpt_every_steps", None)
+        saved_by_step = bool(every and every > 0 and gs % every == 0)
+        saved_by_epoch = bool(getattr(self, "save_checkpoint_every_epoch", False))
+        if saved_by_step or saved_by_epoch:
+            return False
+        self.save_checkpoint(
+            epoch=completed_epochs,
+            step=gs,
+            train_loss=None,
+            val_loss=None,
+            best_metric_key="val_loss",
+        )
+        self._log_saved_checkpoint("final", completed_epochs, gs)
+        return True
 
     def _save_extra_state(self, path: str, epoch: int) -> None:
         """Persist EAGLE-recipe-specific scalars. Subclasses extend this."""
@@ -599,6 +666,7 @@ class TrainEagle1Recipe(BaseRecipe):
                     self.runtime.global_step += 1
                     completed_steps += 1
                     pending_micro_batches = 0
+                    self._maybe_save_step_checkpoint(epoch_idx)
 
                     if self.dist_env.is_main and self.runtime.global_step % self.log_every_steps == 0:
                         avg_loss = running_loss / self.log_every_steps
@@ -650,6 +718,7 @@ class TrainEagle1Recipe(BaseRecipe):
                 self.runtime.global_step += 1
                 completed_steps += 1
                 pending_micro_batches = 0
+                self._maybe_save_step_checkpoint(epoch_idx)
 
             eval_metrics = self._run_eval()
             if self.dist_env.is_main:
@@ -658,7 +727,7 @@ class TrainEagle1Recipe(BaseRecipe):
                     msg += f" val_loss={eval_metrics['val_loss']:.4f} val_accuracy={eval_metrics['val_accuracy']:.4f}"
                 logger.info(msg)
 
-            if last_batch_idx >= 0:
+            if getattr(self, "save_checkpoint_every_epoch", False) and last_batch_idx >= 0:
                 avg_loss = epoch_loss / max(1, micro_step) if micro_step else None
                 self.save_checkpoint(
                     epoch=epoch_idx + 1,
@@ -667,6 +736,8 @@ class TrainEagle1Recipe(BaseRecipe):
                     val_loss=eval_metrics,
                     best_metric_key="val_loss",
                 )
+
+        self._maybe_save_final_checkpoint(self.num_epochs)
 
 
 def main(config_path: str | None = None):

--- a/nemo_automodel/recipes/llm/train_eagle3.py
+++ b/nemo_automodel/recipes/llm/train_eagle3.py
@@ -229,6 +229,17 @@ class TrainEagle3Recipe(BaseRecipe):
         self.max_grad_norm = recipe_cfg.get("max_grad_norm", 1.0)
         self.num_epochs = recipe_cfg.num_epochs
         self.log_every_steps = recipe_cfg.get("log_every_steps", 10)
+        # Checkpoint cadence. The two knobs are independent:
+        #   * ``ckpt_every_steps``            -- save every N optimizer steps (None/<=0 = off).
+        #   * ``save_checkpoint_every_epoch`` -- save at each epoch boundary (off by default).
+        # The fully-trained model is always saved once the run completes; these
+        # only add intermediate checkpoints (and stack when both are set). With
+        # both off, the end-of-run checkpoint is the only one written.
+        # NOTE: field names mirror StepScheduler (components/training/step_scheduler.py),
+        # which the SFT recipe uses for the same cadence; EAGLE hand-rolls its own
+        # loop, so a future refactor could adopt StepScheduler here too.
+        self.ckpt_every_steps = recipe_cfg.get("ckpt_every_steps", None)
+        self.save_checkpoint_every_epoch = recipe_cfg.get("save_checkpoint_every_epoch", False)
         self.output_dir = pathlib.Path(recipe_cfg.output_dir)
         self.output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -579,6 +590,62 @@ class TrainEagle3Recipe(BaseRecipe):
             if is_dist_initialized:
                 dist.barrier()
 
+    def _log_saved_checkpoint(self, kind: str, epoch: int, step: int) -> None:
+        """Log a saved checkpoint on rank 0 when checkpointing is enabled."""
+        ckpt_cfg = getattr(self, "checkpoint_config", None)
+        if self.dist_env.is_main and ckpt_cfg is not None and ckpt_cfg.enabled:
+            logger.info("Saved %s checkpoint to %s/epoch_%d_step_%d", kind, ckpt_cfg.checkpoint_dir, epoch, step)
+
+    def _maybe_save_step_checkpoint(self, epoch: int) -> bool:
+        """Save a checkpoint mid-epoch when ``ckpt_every_steps`` is configured.
+
+        Called after every optimizer step. Saves whenever ``ckpt_every_steps`` is
+        a positive integer and the current ``global_step`` is a multiple of it.
+        Returns True if a checkpoint was written. The checkpoint directory is
+        named ``epoch_{epoch}_step_{global_step}`` so it never collides with the
+        end-of-epoch checkpoint (which uses ``epoch + 1``).
+        """
+        every = getattr(self, "ckpt_every_steps", None)
+        if every is None or every <= 0 or self.runtime.global_step % every != 0:
+            return False
+        self.save_checkpoint(
+            epoch=epoch,
+            step=self.runtime.global_step,
+            train_loss=None,
+            val_loss=None,
+            best_metric_key="val_loss",
+        )
+        self._log_saved_checkpoint("step", epoch, self.runtime.global_step)
+        return True
+
+    def _maybe_save_final_checkpoint(self, completed_epochs: int) -> bool:
+        """Always save the fully-trained model at the end of a completed run,
+        unless a periodic checkpoint already captured the final step.
+
+        The end-of-run state is otherwise easy to lose: with no cadence nothing is
+        saved at all, and with a pure step cadence the final step is skipped
+        whenever the total step count is not a multiple of ``ckpt_every_steps``.
+        This is a no-op only when a step or epoch checkpoint already landed on the
+        final step, so it never duplicates or collides with one.
+        """
+        gs = self.runtime.global_step
+        if gs <= 0:
+            return False
+        every = getattr(self, "ckpt_every_steps", None)
+        saved_by_step = bool(every and every > 0 and gs % every == 0)
+        saved_by_epoch = bool(getattr(self, "save_checkpoint_every_epoch", False))
+        if saved_by_step or saved_by_epoch:
+            return False
+        self.save_checkpoint(
+            epoch=completed_epochs,
+            step=gs,
+            train_loss=None,
+            val_loss=None,
+            best_metric_key="val_loss",
+        )
+        self._log_saved_checkpoint("final", completed_epochs, gs)
+        return True
+
     def _save_extra_state(self, path: str, epoch: int) -> None:
         """Persist EAGLE-3 meta: global_step, epoch, and vocab mapping tensors."""
         torch.save(
@@ -755,6 +822,7 @@ class TrainEagle3Recipe(BaseRecipe):
                     self.optimizer.zero_grad(set_to_none=True)
                     self.runtime.global_step += 1
                     pending_micro_batches = 0
+                    self._maybe_save_step_checkpoint(epoch)
 
                     if self.runtime.global_step % self.log_every_steps == 0:
                         mean_loss = _all_reduce_mean(running_loss / max(running_steps, 1))
@@ -797,6 +865,7 @@ class TrainEagle3Recipe(BaseRecipe):
                 self.optimizer.zero_grad(set_to_none=True)
                 self.runtime.global_step += 1
                 pending_micro_batches = 0
+                self._maybe_save_step_checkpoint(epoch)
 
                 if running_steps > 0:
                     mean_loss = _all_reduce_mean(running_loss / max(running_steps, 1))
@@ -837,21 +906,17 @@ class TrainEagle3Recipe(BaseRecipe):
                         val_loss_dict["val_loss"],
                         val_loss_dict["val_accuracy"],
                     )
-            self.save_checkpoint(
-                epoch=epoch + 1,
-                step=self.runtime.global_step,
-                train_loss=None,
-                val_loss=val_loss_dict,
-                best_metric_key="val_loss",
-            )
-            ckpt_cfg = getattr(self, "checkpoint_config", None)
-            if self.dist_env.is_main and ckpt_cfg is not None and ckpt_cfg.enabled:
-                logger.info(
-                    "Saved checkpoint to %s/epoch_%d_step_%d",
-                    ckpt_cfg.checkpoint_dir,
-                    epoch + 1,
-                    self.runtime.global_step,
+            if getattr(self, "save_checkpoint_every_epoch", False):
+                self.save_checkpoint(
+                    epoch=epoch + 1,
+                    step=self.runtime.global_step,
+                    train_loss=None,
+                    val_loss=val_loss_dict,
+                    best_metric_key="val_loss",
                 )
+                self._log_saved_checkpoint("epoch", epoch + 1, self.runtime.global_step)
+
+        self._maybe_save_final_checkpoint(self.num_epochs)
 
         if self.dist_env.is_main:
             logger.info("Training complete: global_step=%s", self.runtime.global_step)

--- a/tests/unit_tests/recipes/llm/test_eagle_step_checkpoint.py
+++ b/tests/unit_tests/recipes/llm/test_eagle_step_checkpoint.py
@@ -1,0 +1,269 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for step-based checkpointing in the EAGLE-1/2 and EAGLE-3 recipes.
+
+The EAGLE recipes run their own training loop (they do not use ``StepScheduler``)
+and historically only saved a checkpoint at each epoch boundary. These tests guard
+the added ``ckpt_every_steps`` (save every N optimizer steps) and
+``save_checkpoint_every_epoch`` (toggle the end-of-epoch save) behavior:
+
+1. ``_maybe_save_step_checkpoint`` fires exactly on ``global_step`` multiples of
+   ``ckpt_every_steps`` and is a no-op when it is unset / non-positive.
+2. Driven through the real EAGLE-1 training loop, mid-epoch step checkpoints are
+   written at the right steps and the epoch save can be turned off independently.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+from nemo_automodel.recipes.llm.train_eagle1 import TrainEagle1Recipe
+from nemo_automodel.recipes.llm.train_eagle3 import TrainEagle3Recipe
+
+RECIPE_CLASSES = [TrainEagle1Recipe, TrainEagle3Recipe]
+
+
+# ---------------------------------------------------------------------------
+# _maybe_save_step_checkpoint in isolation (both recipes share the same logic)
+# ---------------------------------------------------------------------------
+
+
+def _helper_self(ckpt_every_steps, global_step):
+    """A minimal stand-in carrying just the attributes the helper reads."""
+    calls = []
+    return (
+        SimpleNamespace(
+            ckpt_every_steps=ckpt_every_steps,
+            runtime=SimpleNamespace(global_step=global_step),
+            dist_env=SimpleNamespace(is_main=True),
+            checkpoint_config=None,
+            save_checkpoint=lambda **kw: calls.append(kw),
+            _log_saved_checkpoint=lambda *a, **k: None,
+        ),
+        calls,
+    )
+
+
+@pytest.mark.parametrize("recipe_cls", RECIPE_CLASSES)
+@pytest.mark.parametrize(
+    "every,step,should_fire",
+    [
+        (2, 1, False),
+        (2, 2, True),
+        (2, 3, False),
+        (2, 4, True),
+        (3, 6, True),
+        (1, 7, True),
+    ],
+)
+def test_maybe_save_step_checkpoint_fires_on_multiples(recipe_cls, every, step, should_fire):
+    obj, calls = _helper_self(every, step)
+    fired = recipe_cls._maybe_save_step_checkpoint(obj, epoch=0)
+    assert fired is should_fire
+    assert len(calls) == (1 if should_fire else 0)
+    if should_fire:
+        assert calls[0]["step"] == step
+        assert calls[0]["epoch"] == 0
+        assert calls[0]["val_loss"] is None
+
+
+@pytest.mark.parametrize("recipe_cls", RECIPE_CLASSES)
+@pytest.mark.parametrize("every", [None, 0, -1])
+def test_maybe_save_step_checkpoint_disabled(recipe_cls, every):
+    obj, calls = _helper_self(every, 10)
+    assert recipe_cls._maybe_save_step_checkpoint(obj, epoch=0) is False
+    assert calls == []
+
+
+@pytest.mark.parametrize("recipe_cls", RECIPE_CLASSES)
+def test_maybe_save_step_checkpoint_missing_attr_is_noop(recipe_cls):
+    """A partially-constructed recipe (no ``ckpt_every_steps`` attr) must not crash."""
+    obj = SimpleNamespace(runtime=SimpleNamespace(global_step=4))
+    assert recipe_cls._maybe_save_step_checkpoint(obj, epoch=0) is False
+
+
+def _final_self(ckpt_every_steps, save_every_epoch, global_step):
+    calls = []
+    return (
+        SimpleNamespace(
+            ckpt_every_steps=ckpt_every_steps,
+            save_checkpoint_every_epoch=save_every_epoch,
+            runtime=SimpleNamespace(global_step=global_step),
+            dist_env=SimpleNamespace(is_main=True),
+            checkpoint_config=None,
+            save_checkpoint=lambda **kw: calls.append(kw),
+            _log_saved_checkpoint=lambda *a, **k: None,
+        ),
+        calls,
+    )
+
+
+@pytest.mark.parametrize("recipe_cls", RECIPE_CLASSES)
+@pytest.mark.parametrize(
+    "every,save_epoch,gs,should_fire",
+    [
+        (None, False, 7, True),  # no cadence -> final is the only checkpoint
+        (2, False, 7, True),  # step cadence misses the final step (7 % 2 != 0) -> safety net
+        (2, False, 8, False),  # step cadence already saved the final step (8 % 2 == 0)
+        (None, True, 7, False),  # epoch cadence already saved the final step
+        (2, True, 7, False),  # epoch cadence covers the final step
+        (None, False, 0, False),  # nothing trained yet
+    ],
+)
+def test_final_checkpoint_fires_unless_final_step_already_saved(recipe_cls, every, save_epoch, gs, should_fire):
+    obj, calls = _final_self(ckpt_every_steps=every, save_every_epoch=save_epoch, global_step=gs)
+    assert recipe_cls._maybe_save_final_checkpoint(obj, completed_epochs=3) is should_fire
+    assert len(calls) == (1 if should_fire else 0)
+    if should_fire:
+        assert calls[0]["epoch"] == 3
+        assert calls[0]["step"] == gs
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through the real EAGLE-1 training loop
+# ---------------------------------------------------------------------------
+
+
+class _ConstantGradModule(nn.Module):
+    def __init__(self, n: int = 4):
+        super().__init__()
+        self.w = nn.Parameter(torch.zeros(n))
+
+    def forward(self, **kwargs):
+        return SimpleNamespace(loss=self.w.sum(), accuracy=torch.tensor(0.5))
+
+
+class _FakeTargetWrapper:
+    def generate_batch(self, input_ids, attention_mask, loss_mask):
+        return SimpleNamespace(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            loss_mask=loss_mask,
+            input_hidden_states=None,
+            target_hidden_states=None,
+            target_logits=None,
+        )
+
+
+class _ListLoader:
+    def __init__(self, num_batches: int):
+        one = torch.ones(1, 4, dtype=torch.long)
+        self._batches = [
+            {"input_ids": one.clone(), "attention_mask": one.clone(), "loss_mask": one.clone()}
+            for _ in range(num_batches)
+        ]
+
+    def __iter__(self):
+        return iter(self._batches)
+
+    def __len__(self):
+        return len(self._batches)
+
+
+def _build_eagle1_recipe(num_batches, grad_accum, num_epochs, ckpt_every_steps, save_every_epoch):
+    recipe = TrainEagle1Recipe.__new__(TrainEagle1Recipe)
+    recipe.device = torch.device("cpu")
+    recipe.dist_env = SimpleNamespace(is_main=True, world_size=1)
+    recipe.trainer_module = _ConstantGradModule()
+    recipe.target_wrapper = _FakeTargetWrapper()
+    recipe.train_dataloader = _ListLoader(num_batches)
+    recipe.val_dataloader = None
+    recipe.runtime = SimpleNamespace(global_step=0)
+    recipe.grad_accumulation_steps = grad_accum
+    recipe.max_grad_norm = 1e9
+    recipe.num_epochs = num_epochs
+    recipe.log_every_steps = 1
+    recipe.ckpt_every_steps = ckpt_every_steps
+    recipe.save_checkpoint_every_epoch = save_every_epoch
+    recipe.optimizer = torch.optim.SGD(recipe.trainer_module.parameters(), lr=0.0)
+    recipe.lr_scheduler = torch.optim.lr_scheduler.LambdaLR(recipe.optimizer, lambda s: 1.0)
+
+    saves = []
+    recipe.save_checkpoint = lambda **kw: saves.append((kw["epoch"], kw["step"], kw["val_loss"] is not None))
+    return recipe, saves
+
+
+def test_step_checkpoints_written_during_loop():
+    # 6 batches, accum 2 -> 3 optimizer steps; ckpt every 2 steps -> saves at step 2.
+    recipe, saves = _build_eagle1_recipe(
+        num_batches=6, grad_accum=2, num_epochs=1, ckpt_every_steps=2, save_every_epoch=True
+    )
+    recipe.run_train_validation_loop()
+    assert recipe.runtime.global_step == 3
+    # mid-epoch step checkpoint at global_step 2, labeled with the current (0-based) epoch
+    assert any(e == 0 and s == 2 for (e, s, _) in saves)
+    # end-of-epoch checkpoint at the final step, labeled epoch + 1
+    assert any(e == 1 and s == 3 for (e, s, _) in saves)
+
+
+def test_save_checkpoint_every_epoch_false_skips_epoch_save():
+    recipe, saves = _build_eagle1_recipe(
+        num_batches=6, grad_accum=2, num_epochs=1, ckpt_every_steps=1, save_every_epoch=False
+    )
+    recipe.run_train_validation_loop()
+    assert recipe.runtime.global_step == 3
+    # Only per-step saves (epoch labels 0,0,0), none labeled epoch+1 (==1).
+    assert [s for (e, s, _) in saves] == [1, 2, 3]
+    assert all(e == 0 for (e, s, _) in saves)
+
+
+def test_only_final_checkpoint_when_both_unset():
+    # Neither cadence set -> exactly one save, at the end of the whole run,
+    # labeled with num_epochs and the final global_step.
+    recipe, saves = _build_eagle1_recipe(
+        num_batches=6, grad_accum=2, num_epochs=2, ckpt_every_steps=None, save_every_epoch=False
+    )
+    recipe.run_train_validation_loop()
+    assert recipe.runtime.global_step == 6
+    assert saves == [(2, 6, False)]
+
+
+def test_step_only_saves_final_when_last_step_off_cadence():
+    # 3 optimizer steps, ckpt every 2 -> step save at gs=2 only. gs=3 (the final
+    # fully-trained step) is not a multiple of 2, so the safety net writes it,
+    # labeled with num_epochs.
+    recipe, saves = _build_eagle1_recipe(
+        num_batches=6, grad_accum=2, num_epochs=1, ckpt_every_steps=2, save_every_epoch=False
+    )
+    recipe.run_train_validation_loop()
+    assert recipe.runtime.global_step == 3
+    assert [(e, s) for (e, s, _) in saves] == [(0, 2), (1, 3)]
+
+
+def test_step_only_no_final_duplicate_when_last_step_on_cadence():
+    # 3 optimizer steps, ckpt every 3 -> step save lands exactly on gs=3, so the
+    # safety net must not add a duplicate final checkpoint.
+    recipe, saves = _build_eagle1_recipe(
+        num_batches=6, grad_accum=2, num_epochs=1, ckpt_every_steps=3, save_every_epoch=False
+    )
+    recipe.run_train_validation_loop()
+    assert recipe.runtime.global_step == 3
+    assert [(e, s) for (e, s, _) in saves] == [(0, 3)]
+
+
+def test_only_epoch_checkpoints_no_final_duplicate():
+    # Epoch cadence on, step off -> per-epoch saves only; the final-checkpoint
+    # fallback must NOT add a duplicate.
+    recipe, saves = _build_eagle1_recipe(
+        num_batches=6, grad_accum=2, num_epochs=2, ckpt_every_steps=None, save_every_epoch=True
+    )
+    recipe.run_train_validation_loop()
+    assert recipe.runtime.global_step == 6
+    # one save per epoch boundary, labeled epoch+1, never a num_epochs final extra
+    assert [(e, s) for (e, s, _) in saves] == [(1, 3), (2, 6)]


### PR DESCRIPTION
## What

The EAGLE-1/2 and EAGLE-3 recipes run their own training loop (they do not use `StepScheduler`) and previously saved a checkpoint **only at each epoch boundary**. This adds two independent, `StepScheduler`-aligned knobs under `recipe_args`:

| knob | effect | default |
|---|---|---|
| `ckpt_every_steps` | save every N optimizer steps | `None` (off) |
| `save_checkpoint_every_epoch` | save at each epoch boundary | `false` |

## Behavior

The fully-trained model is **always** saved when the run completes: a final checkpoint is written unless a step- or epoch-cadence save already captured the last optimizer step (so it never duplicates or collides).

| config | result |
|---|---|
| neither set | only the end-of-run (final) checkpoint |
| only `ckpt_every_steps` | per-step saves **+** a final safety-net save if the last step isn't on cadence |
| only `save_checkpoint_every_epoch` | per-epoch saves (the last epoch is the final) |
| both set | both, stacked |

Checkpoint directories keep the existing `epoch_{epoch}_step_{global_step}` naming and never collide (mid-epoch step saves use the current epoch; epoch-boundary saves use `epoch + 1`; the final save uses `num_epochs`).

## Notes

- Both recipes hand-roll their training loop, so the new knobs mirror `StepScheduler`'s names (`ckpt_every_steps`, `save_checkpoint_every_epoch`); a `NOTE` in each `__init__` points there so a future unification is straightforward.
- Behavior change for existing configs: a config that sets neither knob now writes a single final checkpoint instead of one per epoch.

## Tests

New `tests/unit_tests/recipes/llm/test_eagle_step_checkpoint.py` covers the cadence decision logic for both recipes and drives the real EAGLE-1 loop end-to-end (per-step saves, final safety net, no-duplicate at boundary, only-epoch, both-unset). Local run: EAGLE recipe unit set **120 passed**, `ruff` clean.