### PR TITLE
feat(speculative): log the draft model summary in EAGLE training

### DIFF
--- a/nemo_automodel/components/utils/model_utils.py
+++ b/nemo_automodel/components/utils/model_utils.py
@@ -251,11 +251,13 @@ def count_model_parameters(model: nn.Module) -> tuple[int, int]:
 
 
 @torch.no_grad()
-def print_trainable_parameters(model: nn.Module) -> tuple[int, int]:
+def print_trainable_parameters(model: nn.Module, name: str = "Model") -> tuple[int, int]:
     """Print the number of trainable parameters in the model.
 
     Args:
         model: Model to analyze
+        name: Label for the summary header (e.g. ``"Draft"`` to distinguish the
+            draft model from the target in speculative-decoding training).
 
     Returns:
         trainable_params: int
@@ -268,7 +270,7 @@ def print_trainable_parameters(model: nn.Module) -> tuple[int, int]:
         local_sq_norm = float(local_sq_norm**0.5)
         trainable_pct = (100.0 * trainable_params / total_params) if total_params > 0 else 0.0
 
-        logging.info("Model summary:")
+        logging.info(f"{name} summary:")
         logging.info("--------------------------------")
         logging.info(f"Trainable parameters: {trainable_params:,}")
         logging.info(f"Total parameters: {total_params:,}")
@@ -276,7 +278,7 @@ def print_trainable_parameters(model: nn.Module) -> tuple[int, int]:
         logging.info(f"Param L2 norm: {local_sq_norm:.4f}")
         logging.info("--------------------------------")
     except Exception:
-        logging.info("Model summary: <unavailable>")
+        logging.info(f"{name} summary: <unavailable>")
 
     return trainable_params, total_params
 

--- a/nemo_automodel/recipes/llm/train_eagle1.py
+++ b/nemo_automodel/recipes/llm/train_eagle1.py
@@ -45,6 +45,7 @@ from nemo_automodel.components.speculative.eagle.core_v12 import EagleTrainerMod
 from nemo_automodel.components.speculative.eagle.registry import resolve_eagle1_draft_spec
 from nemo_automodel.components.speculative.eagle.target_v12 import HFEagleTargetModel
 from nemo_automodel.components.training.rng import StatefulRNG
+from nemo_automodel.components.utils.model_utils import print_trainable_parameters
 from nemo_automodel.recipes._dist_setup import setup_distributed
 from nemo_automodel.recipes.base_recipe import (
     BaseRecipe,
@@ -210,6 +211,9 @@ class TrainEagle1Recipe(BaseRecipe):
         self.draft_model.copy_embeddings_from_target(self.target_wrapper.get_input_embeddings())
         if recipe_cfg.get("freeze_embeddings", True):
             self.draft_model.freeze_embeddings()
+        # The target's "Model summary" is logged by apply_model_infrastructure when it
+        # loads; the draft is built directly, so log its (trainable) summary here too.
+        print_trainable_parameters(self.draft_model, name="Draft")
 
         trainer_module = EagleTrainerModule(
             self.draft_model,

--- a/nemo_automodel/recipes/llm/train_eagle3.py
+++ b/nemo_automodel/recipes/llm/train_eagle3.py
@@ -54,6 +54,7 @@ from nemo_automodel.components.speculative.eagle import (
 )
 from nemo_automodel.components.speculative.eagle.registry import resolve_eagle3_draft_spec
 from nemo_automodel.components.training.rng import StatefulRNG
+from nemo_automodel.components.utils.model_utils import print_trainable_parameters
 from nemo_automodel.recipes._dist_setup import setup_distributed
 from nemo_automodel.recipes.base_recipe import (
     BaseRecipe,
@@ -200,6 +201,9 @@ class TrainEagle3Recipe(BaseRecipe):
         self.draft_model.copy_embeddings_from_target(embed_source)
         if recipe_cfg.get("freeze_embeddings", True):
             self.draft_model.freeze_embeddings()
+        # The target's "Model summary" is logged by apply_model_infrastructure when it
+        # loads; the draft is built directly, so log its (trainable) summary here too.
+        print_trainable_parameters(self.draft_model, name="Draft")
 
         trainer_module = Eagle3TrainerModule(
             self.draft_model,

--- a/tests/unit_tests/utils/test_model_utils.py
+++ b/tests/unit_tests/utils/test_model_utils.py
@@ -76,6 +76,19 @@ def test_print_trainable_parameters_counts(dummy_model, caplog, monkeypatch):
     # Check logging output
     assert "Trainable parameters" in caplog.text
     assert "Total parameters" in caplog.text
+    # Default header label
+    assert "Model summary:" in caplog.text
+
+
+def test_print_trainable_parameters_custom_name(dummy_model, caplog):
+    """The ``name`` label customizes the summary header (e.g. the draft model
+    in speculative-decoding training)."""
+    import logging
+
+    caplog.set_level(logging.DEBUG)
+    model_utils.print_trainable_parameters(dummy_model, name="Draft")
+    assert "Draft summary:" in caplog.text
+    assert "Model summary:" not in caplog.text
 
 
 def test_print_trainable_parameters_non_zero_rank(dummy_model, capsys, monkeypatch):


### PR DESCRIPTION
## Problem

In speculative-decoding training the `Model summary` block (trainable/total params, L2 norm) is logged by `apply_model_infrastructure` when the **target** model loads. The target is frozen, and the EAGLE **draft** model — the one actually being trained — is built directly and bypasses that path, so its summary is never shown. The logs report the target's size and give no visibility into the draft.

Example (current): the summary prints `Trainable parameters: 4,022,468,096 ... 100.00%`, which is the Qwen3-4B target, not the draft.

## Change

- Add an optional `name` label to `print_trainable_parameters(model, name="Model")` (backward compatible — default unchanged).
- In the EAGLE-1/2 and EAGLE-3 recipes, log a labeled `Draft summary:` for the draft model right after it is built and frozen.

Now both appear in the log: the target's `Model summary:` and the draft's `Draft summary:`.

## Validation

Server run, EAGLE-1 with a Qwen3-4B target. Both summaries now print at setup — the draft summary correctly shows it is much smaller than the target, and that its copied-from-target embeddings are frozen (trainable 114M of 503M = 22.67%), which the target's `100.00%` line never conveyed:

```
Model summary:
--------------------------------
Trainable parameters: 4,022,468,096
Total parameters: 4,022,468,096
Trainable parameters percentage: 100.00%
Param L2 norm: 1578.0900
--------------------------------
...
Draft summary:
--------------------------------
Trainable parameters: 114,040,320
Total parameters: 502,996,480
Trainable parameters percentage: 22.67%
Param L2 norm: 488.4588
--------------------------------
```

## Tests

Added a unit test for the `name` label; existing `print_trainable_parameters` tests still pass. `ruff` + format clean; EAGLE recipe unit tests pass.