### PR TITLE
fix(checkpoint): add bounded retention window

### DIFF
--- a/docs/guides/checkpointing.mdx
+++ b/docs/guides/checkpointing.mdx
@@ -58,18 +58,20 @@ These symbolic links eliminate the need to manually track checkpoint names or se
 
 ## Checkpoint Retention
 
-By default, NeMo AutoModel keeps all intermediate checkpoints. To reduce disk growth from frequent checkpoint saves, set a bounded recent checkpoint window:
+By default, NeMo AutoModel keeps all intermediate checkpoints. To limit disk usage when checkpoints are saved frequently, configure a bounded recent-checkpoint window:
 
 ```yaml
 checkpoint:
   max_recent_checkpoints: 2
 ```
 
-`max_recent_checkpoints` controls how many recent checkpoint directories are retained by step. It is not a hard cap on the total number of checkpoint directories. Checkpoint-root pointers, including `LATEST`, `LOWEST_VAL`, other top-level symlinks, and pointer `.txt` fallback files, protect their targets in addition to the recent window. This keeps resume-from-latest behavior reliable and preserves explicitly referenced checkpoints, such as the best validation checkpoint.
+`max_recent_checkpoints` sets the number of checkpoint directories in the recent window, ordered by step. It is not a hard limit on the total number of checkpoint directories.
 
-For example, if `max_recent_checkpoints: 2` and `LOWEST_VAL` points to an older checkpoint outside the most recent two saves, NeMo AutoModel keeps the two most recent checkpoints plus the `LOWEST_VAL` target.
+Checkpoint-root pointers protect their targets in addition to the recent window. These pointers include `LATEST`, `LOWEST_VAL`, other top-level symbolic links, and `.txt` fallback pointer files. This behavior supports reliable resumption from the latest checkpoint and preserves explicitly referenced checkpoints, such as the best validation checkpoint.
 
-Bounded retention currently applies to local filesystem checkpoint directories. Leave `max_recent_checkpoints` unset when `checkpoint.checkpoint_dir` uses `msc://` storage.
+For example, set `max_recent_checkpoints: 2` to retain the two most recent checkpoints. If `LOWEST_VAL` points to an older checkpoint, NeMo AutoModel also retains the `LOWEST_VAL` target.
+
+Bounded retention supports only local file system checkpoint directories. If `checkpoint.checkpoint_dir` uses `msc://` storage, leave `max_recent_checkpoints` unset. Setting it raises `ValueError`.
 
 Leave the value unset, or set it to `null`, to keep all intermediate checkpoints:
 
@@ -341,7 +343,7 @@ NeMo AutoModel can write checkpoints asynchronously to reduce training stalls ca
 - **Enable** (CLI): add `--checkpoint.is_async True` to your run command.
 - **Requirements**: PyTorch ≥ 2.9.0. If an older version is detected, async mode is automatically disabled.
 - **Behavior**: At most one checkpoint is written at a time. The next save waits for the previous write to finish.
-- **Publication**: The `LATEST` symlink is updated after the async save completes, which can be deferred until the next save call for intermediate checkpoints. Before shutdown completes, recipes wait for the final async checkpoint and publish `LATEST` before closing the checkpointer.
+- **Publication**: The `LATEST` symbolic link is updated after the asynchronous save completes. For intermediate checkpoints, publication can be deferred until the next save call. Before shutting down, each recipe waits for the final asynchronous checkpoint and publishes `LATEST` before closing the checkpointer.
 - **PEFT**: Adapter model files are written synchronously on rank 0; optimizer states can still use async.
 
 ## Advanced Usage: Save Additional States

--- a/docs/guides/checkpointing.mdx
+++ b/docs/guides/checkpointing.mdx
@@ -65,7 +65,7 @@ checkpoint:
   max_recent_checkpoints: 2
 ```
 
-`max_recent_checkpoints` controls how many of the most recent checkpoint directories are retained by step. It is not a hard cap on the total number of checkpoint directories: checkpoint-root pointers such as `LATEST`, `LOWEST_VAL`, and other top-level symlinks or symlink-fallback pointer text files protect their targets in addition to the recent window. This keeps resume-from-latest behavior reliable while preserving explicitly referenced checkpoints such as the best validation checkpoint.
+`max_recent_checkpoints` controls how many recent checkpoint directories are retained by step. It is not a hard cap on the total number of checkpoint directories. Checkpoint-root pointers, including `LATEST`, `LOWEST_VAL`, other top-level symlinks, and pointer `.txt` fallback files, protect their targets in addition to the recent window. This keeps resume-from-latest behavior reliable and preserves explicitly referenced checkpoints, such as the best validation checkpoint.
 
 For example, if `max_recent_checkpoints: 2` and `LOWEST_VAL` points to an older checkpoint outside the most recent two saves, NeMo AutoModel keeps the two most recent checkpoints plus the `LOWEST_VAL` target.
 
@@ -340,7 +340,9 @@ NeMo AutoModel can write checkpoints asynchronously to reduce training stalls ca
   ```
 - **Enable** (CLI): add `--checkpoint.is_async True` to your run command.
 - **Requirements**: PyTorch ≥ 2.9.0. If an older version is detected, async mode is automatically disabled.
-- **Behavior**: At most one checkpoint uploads at a time; the next save waits for the previous upload to finish. The `LATEST` symlink is updated after the async save completes, which may be deferred until the next save call for intermediate checkpoints. At shutdown, recipes wait for the final async checkpoint and publish `LATEST` before closing the checkpointer. During PEFT, adapter model files are written synchronously on rank 0; optimizer states can still use async.
+- **Behavior**: At most one checkpoint is written at a time. The next save waits for the previous write to finish.
+- **Publication**: The `LATEST` symlink is updated after the async save completes, which can be deferred until the next save call for intermediate checkpoints. Before shutdown completes, recipes wait for the final async checkpoint and publish `LATEST` before closing the checkpointer.
+- **PEFT**: Adapter model files are written synchronously on rank 0; optimizer states can still use async.
 
 ## Advanced Usage: Save Additional States
 You can also save additional states in NeMo AutoModel. By default, we also automatically checkpoint the `dataloader`, `rng`, and `step_scheduler` states which are necessary to resume training accurately. In full, a Safetensors consolidated checkpoint will look like this:

--- a/docs/guides/checkpointing.mdx
+++ b/docs/guides/checkpointing.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Checkpointing"
+title: "Checkpointing in NeMo Automodel"
 description: ""
 position: 1
 ---
@@ -97,7 +97,7 @@ automodel --nproc-per-node=2 examples/llm_finetune/llama3_2/llama3_2_1b_squad.ya
 ```
 
 <Note>
-In the above command, we used the [`llama3_2_1b_squad.yaml`](https://github.com/NVIDIA-NeMo/Automodel/blob/492add84a2b9d495946fe211c28973cd00051f3e/examples/llm_finetune/llama3_2/llama3_2_1b_squad.yaml) config as a running example; adjust as necessary to your case.
+In the above command we used the [`llama3_2_1b_squad.yaml`](https://github.com/NVIDIA-NeMo/Automodel/blob/492add84a2b9d495946fe211c28973cd00051f3e/examples/llm_finetune/llama3_2/llama3_2_1b_squad.yaml) config as a running example, adjust as necessary to your case.
 More config examples can be found in our [`examples/`](https://github.com/NVIDIA-NeMo/Automodel/tree/main/examples) directory.
 
 </Note>
@@ -143,7 +143,7 @@ bash checkpoints/epoch_0_step_20/model/consolidate.sh
 
 Run the helper from the AutoModel repo root so it can find `tools/offline_hf_consolidation.py`, or set `CONSOLIDATION_TOOL=/path/to/tools/offline_hf_consolidation.py`.
 
-The helper defaults to one CPU worker process with five writer threads, so it is safe on small machines. For large checkpoints, run it on a CPU compute node and increase parallelism:
+The helper defaults to one CPU worker process with five writer threads so it is safe on small machines. For large checkpoints, run it on a CPU compute node and increase parallelism:
 
 ```bash
 NPROC_PER_NODE=16 NUM_THREADS=5 bash checkpoints/epoch_0_step_20/model/consolidate.sh
@@ -165,7 +165,7 @@ CAST_DTYPE=bf16 bash checkpoints/epoch_0_step_20/model/consolidate.sh
 
 Use `CAST_DTYPE` when the consolidated Hugging Face bundle should override the default per-tensor dtype behavior, such as `CAST_DTYPE=bf16` to export ordinary floating-point tensors as BF16 for serving. Supported values include `bf16`, `fp16`, `fp32`, and `fp64`. Only ordinary floating-point tensors with a different source dtype are cast; tensors already in the cast dtype, FP8 tensors, and non-floating tensors are left unchanged.
 
-The helper writes `checkpoints/epoch_0_step_20/model/consolidated/`. You can load and run that consolidated checkpoint using the Hugging Face Transformers API directly:
+The helper writes `checkpoints/epoch_0_step_20/model/consolidated/`. We can load and run that consolidated checkpoint using the Hugging Face Transformers API directly:
 ```python
 import torch
 from transformers import pipeline
@@ -186,7 +186,7 @@ print(pipe("The key to life is"))
 Although this example uses the Hugging Face Transformers API, the `consolidated/` checkpoint is compatible with any Hugging Face-compatible tool, such as vLLM, SGLang, and others.
 
 ## PEFT
-When training with Parameter-Efficient Fine-Tuning (PEFT) techniques, only a small subset of model weights are updated; the rest of the model remains frozen. This dramatically reduces the size of the checkpoint, often to just a few megabytes.
+When training with Parameter-Efficient Fine-Tuning (PEFT) techniques, only a small subset of model weights are updated — the rest of the model remains frozen. This dramatically reduces the size of the checkpoint, often to just a few megabytes.
 
 PEFT checkpoints save adapter files directly under `model/` and do not generate or need `model/consolidate.sh`.
 
@@ -256,7 +256,7 @@ print(tokenizer.batch_decode(outputs.detach().cpu().numpy(), skip_special_tokens
 ## PyTorch DCP
 NeMo AutoModel also offers native PyTorch DCP checkpointing support (`.distcp` extension). Similar to Safetensors, it also provides the same features of load-time resharding and parallel saving.
 
-As a simple example, run the following command to launch the training recipe on two GPUs.
+As a simple example, we can run the following command to launch the training recipe on two GPUs.
 ```bash
 automodel --nproc-per-node=2 examples/llm_finetune/llama3_2/llama3_2_1b_squad.yaml \
     --step_scheduler.ckpt_every_steps 20 \
@@ -309,7 +309,7 @@ docker run --gpus all -it --rm \
   nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
-You can also set a custom checkpoint directory using the YAML config or CLI override:
+You can also set a custom checkpoint directory through the YAML config or CLI override:
 ```yaml
 checkpoint:
   checkpoint_dir: /mnt/shared/my_checkpoints
@@ -338,7 +338,7 @@ NeMo AutoModel can write checkpoints asynchronously to reduce training stalls ca
   ```
 - **Enable** (CLI): add `--checkpoint.is_async True` to your run command.
 - **Requirements**: PyTorch ≥ 2.9.0. If an older version is detected, async mode is automatically disabled.
-- **Behavior**: At most one checkpoint uploads at a time; the next save waits for the previous upload to finish. The `LATEST` symlink is updated after the async save completes (might be deferred until the next save call). During PEFT, adapter model files are written synchronously on rank 0; optimizer states can still use async.
+- **Behavior**: At most one checkpoint uploads at a time; the next save waits for the previous upload to finish. The `LATEST` symlink is updated after the async save completes (may be deferred until the next save call). During PEFT, adapter model files are written synchronously on rank 0; optimizer states can still use async.
 
 ## Advanced Usage: Save Additional States
 You can also save additional states in NeMo AutoModel. By default, we also automatically checkpoint the `dataloader`, `rng`, and `step_scheduler` states which are necessary to resume training accurately. In full, a Safetensors consolidated checkpoint will look like this:

--- a/docs/guides/checkpointing.mdx
+++ b/docs/guides/checkpointing.mdx
@@ -65,9 +65,11 @@ checkpoint:
   max_recent_checkpoints: 2
 ```
 
-`max_recent_checkpoints` controls how many of the most recent checkpoint directories are retained by step. It is not a hard cap on the total number of checkpoint directories: checkpoint-root pointers such as `LATEST`, `LOWEST_VAL`, and other top-level symlinks or pointer text files protect their targets in addition to the recent window. This keeps resume-from-latest behavior reliable while preserving explicitly referenced checkpoints such as the best validation checkpoint.
+`max_recent_checkpoints` controls how many of the most recent checkpoint directories are retained by step. It is not a hard cap on the total number of checkpoint directories: checkpoint-root pointers such as `LATEST`, `LOWEST_VAL`, and other top-level symlinks or symlink-fallback pointer text files protect their targets in addition to the recent window. This keeps resume-from-latest behavior reliable while preserving explicitly referenced checkpoints such as the best validation checkpoint.
 
 For example, if `max_recent_checkpoints: 2` and `LOWEST_VAL` points to an older checkpoint outside the most recent two saves, NeMo AutoModel keeps the two most recent checkpoints plus the `LOWEST_VAL` target.
+
+Bounded retention currently applies to local filesystem checkpoint directories. Leave `max_recent_checkpoints` unset when `checkpoint.checkpoint_dir` uses `msc://` storage.
 
 Leave the value unset, or set it to `null`, to keep all intermediate checkpoints:
 
@@ -338,7 +340,7 @@ NeMo AutoModel can write checkpoints asynchronously to reduce training stalls ca
   ```
 - **Enable** (CLI): add `--checkpoint.is_async True` to your run command.
 - **Requirements**: PyTorch ≥ 2.9.0. If an older version is detected, async mode is automatically disabled.
-- **Behavior**: At most one checkpoint uploads at a time; the next save waits for the previous upload to finish. The `LATEST` symlink is updated after the async save completes (may be deferred until the next save call). During PEFT, adapter model files are written synchronously on rank 0; optimizer states can still use async.
+- **Behavior**: At most one checkpoint uploads at a time; the next save waits for the previous upload to finish. The `LATEST` symlink is updated after the async save completes, which may be deferred until the next save call for intermediate checkpoints. At shutdown, recipes wait for the final async checkpoint and publish `LATEST` before closing the checkpointer. During PEFT, adapter model files are written synchronously on rank 0; optimizer states can still use async.
 
 ## Advanced Usage: Save Additional States
 You can also save additional states in NeMo AutoModel. By default, we also automatically checkpoint the `dataloader`, `rng`, and `step_scheduler` states which are necessary to resume training accurately. In full, a Safetensors consolidated checkpoint will look like this:

--- a/docs/guides/checkpointing.mdx
+++ b/docs/guides/checkpointing.mdx
@@ -56,6 +56,26 @@ NeMo AutoModel automatically creates symbolic links in the checkpoint directory 
 
 These symbolic links eliminate the need to manually track checkpoint names or search through directories to find the best model. When validation is enabled in your training run, both links are automatically maintained and updated as training progresses.
 
+## Checkpoint Retention
+
+By default, NeMo Automodel retains a bounded recent checkpoint window to reduce accidental disk growth from frequent checkpoint saves:
+
+```yaml
+checkpoint:
+  max_recent_checkpoints: 2
+```
+
+`max_recent_checkpoints` controls how many of the most recent checkpoint directories are retained by step. It is not a hard cap on the total number of checkpoint directories: checkpoint-root pointers such as `LATEST`, `LOWEST_VAL`, and other top-level symlinks or pointer text files protect their targets in addition to the recent window. This keeps resume-from-latest behavior reliable while preserving explicitly referenced checkpoints such as the best validation checkpoint.
+
+For example, if `max_recent_checkpoints: 2` and `LOWEST_VAL` points to an older checkpoint outside the most recent two saves, NeMo Automodel keeps the two most recent checkpoints plus the `LOWEST_VAL` target.
+
+Set the value to `null` to disable pruning and keep all intermediate checkpoints:
+
+```yaml
+checkpoint:
+  max_recent_checkpoints: null
+```
+
 ## Safetensors
 To ensure seamless integration with the Hugging Face ecosystem, NeMo AutoModel saves checkpoints in the [Safetensors](https://github.com/safetensors/safetensors) format. Safetensors is a memory-safe, zero-copy alternative to Python's pickle (PyTorch .bin), natively supported by Hugging Face Transformers, offering both safety and performance advantages over Python pickle-based approaches.
 

--- a/docs/guides/checkpointing.mdx
+++ b/docs/guides/checkpointing.mdx
@@ -58,7 +58,7 @@ These symbolic links eliminate the need to manually track checkpoint names or se
 
 ## Checkpoint Retention
 
-By default, NeMo AutoModel retains a bounded recent checkpoint window to reduce accidental disk growth from frequent checkpoint saves:
+By default, NeMo AutoModel keeps all intermediate checkpoints. To reduce disk growth from frequent checkpoint saves, set a bounded recent checkpoint window:
 
 ```yaml
 checkpoint:
@@ -69,7 +69,7 @@ checkpoint:
 
 For example, if `max_recent_checkpoints: 2` and `LOWEST_VAL` points to an older checkpoint outside the most recent two saves, NeMo AutoModel keeps the two most recent checkpoints plus the `LOWEST_VAL` target.
 
-Set the value to `null` to disable pruning and keep all intermediate checkpoints:
+Leave the value unset, or set it to `null`, to keep all intermediate checkpoints:
 
 ```yaml
 checkpoint:

--- a/docs/guides/checkpointing.mdx
+++ b/docs/guides/checkpointing.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Checkpointing in NeMo Automodel"
+title: "Checkpointing"
 description: ""
 position: 1
 ---
@@ -58,7 +58,7 @@ These symbolic links eliminate the need to manually track checkpoint names or se
 
 ## Checkpoint Retention
 
-By default, NeMo Automodel retains a bounded recent checkpoint window to reduce accidental disk growth from frequent checkpoint saves:
+By default, NeMo AutoModel retains a bounded recent checkpoint window to reduce accidental disk growth from frequent checkpoint saves:
 
 ```yaml
 checkpoint:
@@ -67,7 +67,7 @@ checkpoint:
 
 `max_recent_checkpoints` controls how many of the most recent checkpoint directories are retained by step. It is not a hard cap on the total number of checkpoint directories: checkpoint-root pointers such as `LATEST`, `LOWEST_VAL`, and other top-level symlinks or pointer text files protect their targets in addition to the recent window. This keeps resume-from-latest behavior reliable while preserving explicitly referenced checkpoints such as the best validation checkpoint.
 
-For example, if `max_recent_checkpoints: 2` and `LOWEST_VAL` points to an older checkpoint outside the most recent two saves, NeMo Automodel keeps the two most recent checkpoints plus the `LOWEST_VAL` target.
+For example, if `max_recent_checkpoints: 2` and `LOWEST_VAL` points to an older checkpoint outside the most recent two saves, NeMo AutoModel keeps the two most recent checkpoints plus the `LOWEST_VAL` target.
 
 Set the value to `null` to disable pruning and keep all intermediate checkpoints:
 
@@ -97,7 +97,7 @@ automodel --nproc-per-node=2 examples/llm_finetune/llama3_2/llama3_2_1b_squad.ya
 ```
 
 <Note>
-In the above command we used the [`llama3_2_1b_squad.yaml`](https://github.com/NVIDIA-NeMo/Automodel/blob/492add84a2b9d495946fe211c28973cd00051f3e/examples/llm_finetune/llama3_2/llama3_2_1b_squad.yaml) config as a running example, adjust as necessary to your case.
+In the above command, we used the [`llama3_2_1b_squad.yaml`](https://github.com/NVIDIA-NeMo/Automodel/blob/492add84a2b9d495946fe211c28973cd00051f3e/examples/llm_finetune/llama3_2/llama3_2_1b_squad.yaml) config as a running example; adjust as necessary to your case.
 More config examples can be found in our [`examples/`](https://github.com/NVIDIA-NeMo/Automodel/tree/main/examples) directory.
 
 </Note>
@@ -143,7 +143,7 @@ bash checkpoints/epoch_0_step_20/model/consolidate.sh
 
 Run the helper from the AutoModel repo root so it can find `tools/offline_hf_consolidation.py`, or set `CONSOLIDATION_TOOL=/path/to/tools/offline_hf_consolidation.py`.
 
-The helper defaults to one CPU worker process with five writer threads so it is safe on small machines. For large checkpoints, run it on a CPU compute node and increase parallelism:
+The helper defaults to one CPU worker process with five writer threads, so it is safe on small machines. For large checkpoints, run it on a CPU compute node and increase parallelism:
 
 ```bash
 NPROC_PER_NODE=16 NUM_THREADS=5 bash checkpoints/epoch_0_step_20/model/consolidate.sh
@@ -165,7 +165,7 @@ CAST_DTYPE=bf16 bash checkpoints/epoch_0_step_20/model/consolidate.sh
 
 Use `CAST_DTYPE` when the consolidated Hugging Face bundle should override the default per-tensor dtype behavior, such as `CAST_DTYPE=bf16` to export ordinary floating-point tensors as BF16 for serving. Supported values include `bf16`, `fp16`, `fp32`, and `fp64`. Only ordinary floating-point tensors with a different source dtype are cast; tensors already in the cast dtype, FP8 tensors, and non-floating tensors are left unchanged.
 
-The helper writes `checkpoints/epoch_0_step_20/model/consolidated/`. We can load and run that consolidated checkpoint using the Hugging Face Transformers API directly:
+The helper writes `checkpoints/epoch_0_step_20/model/consolidated/`. You can load and run that consolidated checkpoint using the Hugging Face Transformers API directly:
 ```python
 import torch
 from transformers import pipeline
@@ -186,7 +186,7 @@ print(pipe("The key to life is"))
 Although this example uses the Hugging Face Transformers API, the `consolidated/` checkpoint is compatible with any Hugging Face-compatible tool, such as vLLM, SGLang, and others.
 
 ## PEFT
-When training with Parameter-Efficient Fine-Tuning (PEFT) techniques, only a small subset of model weights are updated — the rest of the model remains frozen. This dramatically reduces the size of the checkpoint, often to just a few megabytes.
+When training with Parameter-Efficient Fine-Tuning (PEFT) techniques, only a small subset of model weights are updated; the rest of the model remains frozen. This dramatically reduces the size of the checkpoint, often to just a few megabytes.
 
 PEFT checkpoints save adapter files directly under `model/` and do not generate or need `model/consolidate.sh`.
 
@@ -256,7 +256,7 @@ print(tokenizer.batch_decode(outputs.detach().cpu().numpy(), skip_special_tokens
 ## PyTorch DCP
 NeMo AutoModel also offers native PyTorch DCP checkpointing support (`.distcp` extension). Similar to Safetensors, it also provides the same features of load-time resharding and parallel saving.
 
-As a simple example, we can run the following command to launch the training recipe on two GPUs.
+As a simple example, run the following command to launch the training recipe on two GPUs.
 ```bash
 automodel --nproc-per-node=2 examples/llm_finetune/llama3_2/llama3_2_1b_squad.yaml \
     --step_scheduler.ckpt_every_steps 20 \
@@ -309,7 +309,7 @@ docker run --gpus all -it --rm \
   nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
-You can also set a custom checkpoint directory through the YAML config or CLI override:
+You can also set a custom checkpoint directory using the YAML config or CLI override:
 ```yaml
 checkpoint:
   checkpoint_dir: /mnt/shared/my_checkpoints
@@ -338,7 +338,7 @@ NeMo AutoModel can write checkpoints asynchronously to reduce training stalls ca
   ```
 - **Enable** (CLI): add `--checkpoint.is_async True` to your run command.
 - **Requirements**: PyTorch ≥ 2.9.0. If an older version is detected, async mode is automatically disabled.
-- **Behavior**: At most one checkpoint uploads at a time; the next save waits for the previous upload to finish. The `LATEST` symlink is updated after the async save completes (may be deferred until the next save call). During PEFT, adapter model files are written synchronously on rank 0; optimizer states can still use async.
+- **Behavior**: At most one checkpoint uploads at a time; the next save waits for the previous upload to finish. The `LATEST` symlink is updated after the async save completes (might be deferred until the next save call). During PEFT, adapter model files are written synchronously on rank 0; optimizer states can still use async.
 
 ## Advanced Usage: Save Additional States
 You can also save additional states in NeMo AutoModel. By default, we also automatically checkpoint the `dataloader`, `rng`, and `step_scheduler` states which are necessary to resume training accurately. In full, a Safetensors consolidated checkpoint will look like this:

--- a/docs/guides/checkpointing.mdx
+++ b/docs/guides/checkpointing.mdx
@@ -73,6 +73,8 @@ For example, set `max_recent_checkpoints: 2` to retain the two most recent check
 
 Bounded retention supports only local file system checkpoint directories. If `checkpoint.checkpoint_dir` uses `msc://` storage, leave `max_recent_checkpoints` unset. Setting it raises `ValueError`.
 
+Bounded retention removes only standard `epoch_<E>_step_<S>` checkpoint directories. It does not remove recipe-specific exports, such as retrieval distillation `step_<S>` directories.
+
 Leave the value unset, or set it to `null`, to keep all intermediate checkpoints:
 
 ```yaml
@@ -344,7 +346,7 @@ NeMo AutoModel can write checkpoints asynchronously to reduce training stalls ca
 - **Requirements**: PyTorch ≥ 2.9.0. If an older version is detected, async mode is automatically disabled.
 - **Behavior**: At most one checkpoint is written at a time. The next save waits for the previous write to finish.
 - **Publication**: The `LATEST` symbolic link is updated after the asynchronous save completes. For intermediate checkpoints, publication can be deferred until the next save call. Before shutting down, each recipe waits for the final asynchronous checkpoint and publishes `LATEST` before closing the checkpointer.
-- **PEFT**: Adapter model files are written synchronously on rank 0; optimizer states can still use async.
+- **PEFT**: Adapter model files are written synchronously on rank 0; optimizer states can still be written asynchronously.
 
 ## Advanced Usage: Save Additional States
 You can also save additional states in NeMo AutoModel. By default, we also automatically checkpoint the `dataloader`, `rng`, and `step_scheduler` states which are necessary to resume training accurately. In full, a Safetensors consolidated checkpoint will look like this:

--- a/nemo_automodel/components/checkpoint/config.py
+++ b/nemo_automodel/components/checkpoint/config.py
@@ -121,6 +121,9 @@ class CheckpointingConfig:
     # (diffusion_pytorch_model.safetensors.index.json) so checkpoints are loadable via diffusers from_pretrained().
     best_metric_key: str = "default"  # Validation metric key used to select the best checkpoint.
     consolidation_timeout_minutes: int = 30  # Timeout for inline consolidated-export synchronization.
+    # Retain this many recent checkpoint directories. Checkpoints targeted by checkpoint-root pointers
+    # such as LATEST and LOWEST_VAL are preserved in addition. Set None to disable pruning.
+    max_recent_checkpoints: int | None = 2
 
     def __post_init__(self):
         """Resolve the cache dir, enforce PEFT constraints, and coerce the save format/mode."""
@@ -141,6 +144,14 @@ class CheckpointingConfig:
             )
             self.model_save_format = "safetensors"
             self.save_consolidated = SaveConsolidatedMode.FINAL
+
+        if self.max_recent_checkpoints is not None:
+            if (
+                isinstance(self.max_recent_checkpoints, bool)
+                or not isinstance(self.max_recent_checkpoints, int)
+                or self.max_recent_checkpoints < 1
+            ):
+                raise ValueError("checkpoint.max_recent_checkpoints must be unset or a positive integer")
 
         # Convert a raw string such as "safetensors" into the right Enum.
         formats = [v.value for v in SerializationFormat]

--- a/nemo_automodel/components/checkpoint/config.py
+++ b/nemo_automodel/components/checkpoint/config.py
@@ -121,8 +121,8 @@ class CheckpointingConfig:
     # (diffusion_pytorch_model.safetensors.index.json) so checkpoints are loadable via diffusers from_pretrained().
     best_metric_key: str = "default"  # Validation metric key used to select the best checkpoint.
     consolidation_timeout_minutes: int = 30  # Timeout for inline consolidated-export synchronization.
-    # Retain this many recent checkpoint directories. Checkpoints targeted by checkpoint-root pointers
-    # such as LATEST and LOWEST_VAL are preserved in addition. None keeps all checkpoints.
+    # Retain this many recent checkpoint directories. Preserve checkpoints targeted by checkpoint-root pointers,
+    # such as `LATEST` and `LOWEST_VAL`, in addition to the recent window. `None` keeps all checkpoints.
     max_recent_checkpoints: int | None = None
 
     def __post_init__(self):

--- a/nemo_automodel/components/checkpoint/config.py
+++ b/nemo_automodel/components/checkpoint/config.py
@@ -152,6 +152,11 @@ class CheckpointingConfig:
                 or self.max_recent_checkpoints < 1
             ):
                 raise ValueError("checkpoint.max_recent_checkpoints must be unset or a positive integer")
+            if str(self.checkpoint_dir).startswith("msc://"):
+                raise ValueError(
+                    "checkpoint.max_recent_checkpoints is only supported for local checkpoint directories; "
+                    "unset it when checkpoint.checkpoint_dir uses msc:// storage"
+                )
 
         # Convert a raw string such as "safetensors" into the right Enum.
         formats = [v.value for v in SerializationFormat]

--- a/nemo_automodel/components/checkpoint/config.py
+++ b/nemo_automodel/components/checkpoint/config.py
@@ -122,8 +122,8 @@ class CheckpointingConfig:
     best_metric_key: str = "default"  # Validation metric key used to select the best checkpoint.
     consolidation_timeout_minutes: int = 30  # Timeout for inline consolidated-export synchronization.
     # Retain this many recent checkpoint directories. Checkpoints targeted by checkpoint-root pointers
-    # such as LATEST and LOWEST_VAL are preserved in addition. Set None to disable pruning.
-    max_recent_checkpoints: int | None = 2
+    # such as LATEST and LOWEST_VAL are preserved in addition. None keeps all checkpoints.
+    max_recent_checkpoints: int | None = None
 
     def __post_init__(self):
         """Resolve the cache dir, enforce PEFT constraints, and coerce the save format/mode."""

--- a/nemo_automodel/components/checkpoint/utils.py
+++ b/nemo_automodel/components/checkpoint/utils.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import json
+import logging
 import os
+import re
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -33,6 +35,8 @@ from nemo_automodel.shared.tied_weights import (
 from nemo_automodel.shared.tied_weights import (
     has_local_tied_lm_head as has_local_tied_lm_head,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def get_rank_safe() -> int:
@@ -95,6 +99,198 @@ def format_bytes(num_bytes: int) -> str:
 def format_output_file_count(count: int) -> str:
     """Format the output shard count for user-facing log messages."""
     return f"{count} output {'file' if count == 1 else 'files'}"
+
+
+def _checkpoint_step_num(path: Path) -> int:
+    """Return the trailing checkpoint step number, or -1 when the name is not a checkpoint."""
+    match = re.search(r"step_(\d+)$", path.stem)
+    return int(match.group(1)) if match else -1
+
+
+def _list_existing_checkpoints(ckpt_root: Path) -> list[Path]:
+    """Return existing checkpoint directories under ckpt_root (matching '*step_*')."""
+    if not ckpt_root.exists():
+        return []
+    checkpoints = [path for path in ckpt_root.glob("*step_*") if path.is_dir() and not path.is_symlink()]
+    return sorted((path for path in checkpoints if _checkpoint_step_num(path) >= 0), key=_checkpoint_step_num)
+
+
+def _resolve_checkpoint_pointer_target(ckpt_root: Path, raw_target: str) -> Path | None:
+    """Resolve a checkpoint pointer target relative to ckpt_root."""
+    if not raw_target:
+        return None
+    target = Path(raw_target)
+    if not target.is_absolute():
+        target = ckpt_root / target
+    return Path(os.path.abspath(target))
+
+
+def _read_checkpoint_pointer(ckpt_root: str | Path, link_name: str) -> Path | None:
+    """Resolve a checkpoint pointer symlink or fallback text file."""
+    root = Path(ckpt_root)
+    link_path = root / link_name
+    raw_target = None
+    if os.path.islink(link_path):
+        try:
+            raw_target = os.readlink(link_path)
+        except OSError:
+            pass
+    elif os.path.isfile(f"{link_path}.txt"):
+        try:
+            with open(f"{link_path}.txt", "r") as f:
+                raw_target = f.read().strip()
+        except (OSError, UnicodeError):
+            pass
+
+    return _resolve_checkpoint_pointer_target(root, raw_target) if raw_target else None
+
+
+def _checkpoint_contains_target(checkpoint: Path, target: Path) -> bool:
+    """Return whether target points at or inside checkpoint."""
+    checkpoint_abs = Path(os.path.abspath(checkpoint))
+    target_abs = Path(os.path.abspath(target))
+    return target_abs == checkpoint_abs or checkpoint_abs in target_abs.parents
+
+
+def _read_checkpoint_metric(checkpoint: Path, metric_key: str | None) -> float | None:
+    """Read a validation metric from checkpoint loss metadata."""
+    try:
+        with open(checkpoint / "losses.json", "r") as f:
+            losses = json.load(f)
+    except (OSError, TypeError, json.JSONDecodeError):
+        return None
+
+    candidate_keys = []
+    if metric_key is not None:
+        candidate_keys.append(metric_key)
+    candidate_keys.extend(["val_loss", "default"])
+
+    for key in candidate_keys:
+        if key not in losses:
+            continue
+        try:
+            return float(losses[key])
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def _find_pointer_protected_checkpoints(ckpt_root: Path, checkpoints: list[Path]) -> set[Path]:
+    """Return checkpoints targeted by top-level symlinks or symlink fallback text files."""
+    protected = set()
+    if not ckpt_root.exists():
+        return protected
+
+    try:
+        entries = list(ckpt_root.iterdir())
+    except OSError:
+        logger.warning("Failed to scan checkpoint pointers in %s", ckpt_root, exc_info=True)
+        return protected
+
+    for entry in entries:
+        raw_target = None
+        if os.path.islink(entry):
+            try:
+                raw_target = os.readlink(entry)
+            except OSError:
+                continue
+        elif entry.is_file() and entry.suffix == ".txt":
+            try:
+                raw_target = entry.read_text().strip()
+            except (OSError, UnicodeError):
+                continue
+
+        target = _resolve_checkpoint_pointer_target(ckpt_root, raw_target) if raw_target else None
+        if target is None:
+            continue
+        for checkpoint in checkpoints:
+            if _checkpoint_contains_target(checkpoint, target):
+                protected.add(checkpoint)
+                break
+    return protected
+
+
+def _resolve_restore_from_to_ckpt_dir(checkpoint_dir: str, restore_from: str) -> str | None:
+    """
+    Resolve restore_from to a checkpoint directory.
+
+    Returns:
+        - str: resolved checkpoint directory
+        - None: if restore_from='LATEST' but no checkpoint found (caller should start fresh)
+    """
+    # Handle checkpoint-root pointers such as LATEST and LOWEST_VAL.
+    if os.path.sep not in restore_from and not os.path.isabs(restore_from):
+        pointed_checkpoint = _read_checkpoint_pointer(checkpoint_dir, restore_from)
+        if pointed_checkpoint is not None and pointed_checkpoint.is_dir():
+            return os.fspath(pointed_checkpoint)
+    if restore_from.upper() == "LATEST":
+        return _find_latest_checkpoint(checkpoint_dir)
+
+    # If restore_from is just a directory name (no path separator), treat it as
+    # relative to checkpoint_dir. Otherwise use as-is (absolute or relative path).
+    if os.path.sep not in restore_from and not os.path.isabs(restore_from):
+        return os.path.join(checkpoint_dir, restore_from)
+    return restore_from
+
+
+def _format_missing_checkpoint_dir_error(checkpoint_dir: str, restore_from: str, resolved_ckpt_dir: str) -> str:
+    """Format a helpful error message for a missing checkpoint directory."""
+    error_msg = [
+        f"\n{'=' * 80}",
+        "ERROR: Checkpoint directory does not exist",
+        f"{'=' * 80}",
+        f"Specified: checkpoint.restore_from: '{restore_from}'",
+        f"Resolved to: {resolved_ckpt_dir}",
+        "",
+        "Please check:",
+        "  1. The checkpoint directory exists",
+        f"  2. The path is correct (restore_from: '{restore_from}')",
+        f"  3. Available checkpoints in {checkpoint_dir}:",
+    ]
+
+    ckpt_root = Path(checkpoint_dir)
+    available_ckpts = _list_existing_checkpoints(ckpt_root)
+    if available_ckpts:
+        error_msg += [f"       {', '.join([p.name for p in available_ckpts[:5]])}"]
+        if len(available_ckpts) > 5:
+            error_msg += [f"       ... and {len(available_ckpts) - 5} more"]
+    else:
+        error_msg += (
+            ["       (no checkpoints found)"] if ckpt_root.exists() else ["       (checkpoint_dir does not exist)"]
+        )
+
+    error_msg += [f"{'=' * 80}"]
+    return "\n".join(error_msg)
+
+
+def _find_latest_checkpoint(checkpoint_dir):
+    """
+    Resolve the most recent checkpoint directory.
+
+    Preference order:
+      1) Valid LATEST symlink or txt file under checkpoint_dir
+      2) Highest step directory under checkpoint_dir matching *step_*
+
+    Returns:
+        Path (or str) of the latest checkpoint directory, or None.
+    """
+    root = Path(checkpoint_dir)
+    if not root.exists():
+        return
+
+    latest = _read_checkpoint_pointer(root, "LATEST")
+    if latest is not None and latest.is_dir():
+        return os.fspath(latest)
+
+    checkpoint_files = _list_existing_checkpoints(root)
+    if not checkpoint_files:
+        return
+
+    latest = max(checkpoint_files, key=_checkpoint_step_num)
+    if _checkpoint_step_num(latest) == -1:
+        return
+
+    return latest
 
 
 def resolve_trust_remote_code(pretrained_model_name_or_path):

--- a/nemo_automodel/components/checkpoint/utils.py
+++ b/nemo_automodel/components/checkpoint/utils.py
@@ -134,7 +134,7 @@ def _resolve_checkpoint_pointer_target(ckpt_root: Path, raw_target: str) -> Path
     return Path(os.path.abspath(target))
 
 
-def _read_checkpoint_pointer(ckpt_root: str | Path, link_name: str) -> Path | None:
+def read_checkpoint_pointer(ckpt_root: str | Path, link_name: str) -> Path | None:
     """Resolve a checkpoint pointer symlink or fallback text file."""
     root = Path(ckpt_root)
     link_path = root / link_name
@@ -161,7 +161,7 @@ def _checkpoint_contains_target(checkpoint: Path, target: Path) -> bool:
     return target_abs == checkpoint_abs or checkpoint_abs in target_abs.parents
 
 
-def _read_checkpoint_metric(checkpoint: Path, metric_key: str | None) -> float | None:
+def read_checkpoint_metric(checkpoint: Path, metric_key: str | None) -> float | None:
     """Read a validation metric from checkpoint loss metadata."""
     try:
         with open(checkpoint / "losses.json", "r") as f:
@@ -193,7 +193,7 @@ def _is_checkpoint_pointer_text_file(path: Path, mode: int) -> bool:
     return stat.S_ISREG(mode) and path.suffix == ".txt" and path.stem.isupper()
 
 
-def _find_pointer_protected_checkpoints(ckpt_root: Path, checkpoints: list[Path]) -> set[Path]:
+def find_pointer_protected_checkpoints(ckpt_root: Path, checkpoints: list[Path]) -> set[Path]:
     """Return checkpoints targeted by top-level symlinks or symlink fallback text files."""
     protected = set()
     if not ckpt_root.exists():
@@ -219,7 +219,7 @@ def _find_pointer_protected_checkpoints(ckpt_root: Path, checkpoints: list[Path]
     return protected
 
 
-def _resolve_restore_from_to_ckpt_dir(checkpoint_dir: str, restore_from: str) -> str | None:
+def resolve_restore_from_to_checkpoint_dir(checkpoint_dir: str | Path, restore_from: str) -> str | None:
     """
     Resolve restore_from to a checkpoint directory.
 
@@ -229,11 +229,11 @@ def _resolve_restore_from_to_ckpt_dir(checkpoint_dir: str, restore_from: str) ->
     """
     # Handle checkpoint-root pointers such as LATEST and LOWEST_VAL.
     if os.path.sep not in restore_from and not os.path.isabs(restore_from):
-        pointed_checkpoint = _read_checkpoint_pointer(checkpoint_dir, restore_from)
+        pointed_checkpoint = read_checkpoint_pointer(checkpoint_dir, restore_from)
         if pointed_checkpoint is not None and pointed_checkpoint.is_dir():
             return os.fspath(pointed_checkpoint)
     if restore_from.upper() == "LATEST":
-        return _find_latest_checkpoint(checkpoint_dir)
+        return find_latest_checkpoint(checkpoint_dir)
 
     # If restore_from is just a directory name (no path separator), treat it as
     # relative to checkpoint_dir. Otherwise use as-is (absolute or relative path).
@@ -242,7 +242,7 @@ def _resolve_restore_from_to_ckpt_dir(checkpoint_dir: str, restore_from: str) ->
     return restore_from
 
 
-def _format_missing_checkpoint_dir_error(checkpoint_dir: str, restore_from: str, resolved_ckpt_dir: str) -> str:
+def format_missing_checkpoint_dir_error(checkpoint_dir: str, restore_from: str, resolved_ckpt_dir: str) -> str:
     """Format a helpful error message for a missing checkpoint directory."""
     error_msg = [
         f"\n{'=' * 80}",
@@ -272,7 +272,7 @@ def _format_missing_checkpoint_dir_error(checkpoint_dir: str, restore_from: str,
     return "\n".join(error_msg)
 
 
-def _find_latest_checkpoint(checkpoint_dir):
+def find_latest_checkpoint(checkpoint_dir: str | Path) -> str | Path | None:
     """
     Resolve the most recent checkpoint directory.
 
@@ -287,7 +287,7 @@ def _find_latest_checkpoint(checkpoint_dir):
     if not root.exists():
         return
 
-    latest = _read_checkpoint_pointer(root, "LATEST")
+    latest = read_checkpoint_pointer(root, "LATEST")
     if latest is not None and latest.is_dir():
         return os.fspath(latest)
 

--- a/nemo_automodel/components/checkpoint/utils.py
+++ b/nemo_automodel/components/checkpoint/utils.py
@@ -40,6 +40,7 @@ from nemo_automodel.shared.tied_weights import (
 
 logger = logging.getLogger(__name__)
 _AUTOMODEL_CHECKPOINT_RE = re.compile(r"^epoch_\d+_step_(\d+)$")
+_CHECKPOINT_STEP_RE = re.compile(r"step_(\d+)$")
 
 
 def get_rank_safe() -> int:
@@ -105,17 +106,22 @@ def format_output_file_count(count: int) -> str:
 
 
 def _checkpoint_step_num(path: Path) -> int:
-    """Return the AutoModel checkpoint step number, or -1 when the name is not owned by AutoModel."""
-    match = _AUTOMODEL_CHECKPOINT_RE.fullmatch(path.name)
+    """Return the trailing checkpoint step number, or -1 when the name is not a checkpoint."""
+    match = _CHECKPOINT_STEP_RE.search(path.name)
     return int(match.group(1)) if match else -1
 
 
 def _list_existing_checkpoints(ckpt_root: Path) -> list[Path]:
-    """Return existing AutoModel checkpoint directories under ckpt_root."""
+    """Return existing checkpoint directories whose names end in ``step_<N>``."""
     if not ckpt_root.exists():
         return []
-    checkpoints = [path for path in ckpt_root.glob("epoch_*_step_*") if path.is_dir() and not path.is_symlink()]
+    checkpoints = [path for path in ckpt_root.glob("*step_*") if path.is_dir() and not path.is_symlink()]
     return sorted((path for path in checkpoints if _checkpoint_step_num(path) >= 0), key=_checkpoint_step_num)
+
+
+def list_automodel_checkpoints(ckpt_root: Path) -> list[Path]:
+    """Return canonical AutoModel ``epoch_<E>_step_<S>`` checkpoint directories."""
+    return [path for path in _list_existing_checkpoints(ckpt_root) if _AUTOMODEL_CHECKPOINT_RE.fullmatch(path.name)]
 
 
 def _resolve_checkpoint_pointer_target(ckpt_root: Path, raw_target: str) -> Path | None:
@@ -272,7 +278,7 @@ def _find_latest_checkpoint(checkpoint_dir):
 
     Preference order:
       1) Valid LATEST symlink or txt file under checkpoint_dir
-      2) Highest step directory under checkpoint_dir matching *step_*
+      2) Highest step directory under checkpoint_dir whose name ends in ``step_<N>``
 
     Returns:
         Path (or str) of the latest checkpoint directory, or None.

--- a/nemo_automodel/components/checkpoint/utils.py
+++ b/nemo_automodel/components/checkpoint/utils.py
@@ -160,7 +160,9 @@ def _read_checkpoint_metric(checkpoint: Path, metric_key: str | None) -> float |
     try:
         with open(checkpoint / "losses.json", "r") as f:
             losses = json.load(f)
-    except (OSError, TypeError, json.JSONDecodeError):
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(losses, Mapping):
         return None
 
     candidate_keys = []
@@ -173,7 +175,7 @@ def _read_checkpoint_metric(checkpoint: Path, metric_key: str | None) -> float |
             continue
         try:
             value = float(losses[key])
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, OverflowError):
             continue
         if math.isfinite(value):
             return value

--- a/nemo_automodel/components/checkpoint/utils.py
+++ b/nemo_automodel/components/checkpoint/utils.py
@@ -14,6 +14,7 @@
 
 import json
 import logging
+import math
 import os
 import re
 from collections.abc import Mapping
@@ -170,9 +171,11 @@ def _read_checkpoint_metric(checkpoint: Path, metric_key: str | None) -> float |
         if key not in losses:
             continue
         try:
-            return float(losses[key])
+            value = float(losses[key])
         except (TypeError, ValueError):
             continue
+        if math.isfinite(value):
+            return value
     return None
 
 
@@ -187,23 +190,16 @@ def _find_pointer_protected_checkpoints(ckpt_root: Path, checkpoints: list[Path]
     if not ckpt_root.exists():
         return protected
 
-    try:
-        entries = list(ckpt_root.iterdir())
-    except OSError:
-        logger.warning("Failed to scan checkpoint pointers in %s", ckpt_root, exc_info=True)
-        return protected
+    entries = list(ckpt_root.iterdir())
 
     for entry in entries:
         raw_target = None
         if os.path.islink(entry):
-            try:
-                raw_target = os.readlink(entry)
-            except OSError:
-                continue
+            raw_target = os.readlink(entry)
         elif _is_checkpoint_pointer_text_file(entry):
             try:
                 raw_target = entry.read_text().strip()
-            except (OSError, UnicodeError):
+            except UnicodeError:
                 continue
 
         target = _resolve_checkpoint_pointer_target(ckpt_root, raw_target) if raw_target else None

--- a/nemo_automodel/components/checkpoint/utils.py
+++ b/nemo_automodel/components/checkpoint/utils.py
@@ -37,6 +37,7 @@ from nemo_automodel.shared.tied_weights import (
 )
 
 logger = logging.getLogger(__name__)
+_AUTOMODEL_CHECKPOINT_RE = re.compile(r"^epoch_\d+_step_(\d+)$")
 
 
 def get_rank_safe() -> int:
@@ -102,16 +103,16 @@ def format_output_file_count(count: int) -> str:
 
 
 def _checkpoint_step_num(path: Path) -> int:
-    """Return the trailing checkpoint step number, or -1 when the name is not a checkpoint."""
-    match = re.search(r"step_(\d+)$", path.stem)
+    """Return the AutoModel checkpoint step number, or -1 when the name is not owned by AutoModel."""
+    match = _AUTOMODEL_CHECKPOINT_RE.fullmatch(path.name)
     return int(match.group(1)) if match else -1
 
 
 def _list_existing_checkpoints(ckpt_root: Path) -> list[Path]:
-    """Return existing checkpoint directories under ckpt_root (matching '*step_*')."""
+    """Return existing AutoModel checkpoint directories under ckpt_root."""
     if not ckpt_root.exists():
         return []
-    checkpoints = [path for path in ckpt_root.glob("*step_*") if path.is_dir() and not path.is_symlink()]
+    checkpoints = [path for path in ckpt_root.glob("epoch_*_step_*") if path.is_dir() and not path.is_symlink()]
     return sorted((path for path in checkpoints if _checkpoint_step_num(path) >= 0), key=_checkpoint_step_num)
 
 
@@ -175,6 +176,11 @@ def _read_checkpoint_metric(checkpoint: Path, metric_key: str | None) -> float |
     return None
 
 
+def _is_checkpoint_pointer_text_file(path: Path) -> bool:
+    """Return whether path looks like a symlink fallback checkpoint pointer."""
+    return path.is_file() and path.suffix == ".txt" and path.stem.isupper()
+
+
 def _find_pointer_protected_checkpoints(ckpt_root: Path, checkpoints: list[Path]) -> set[Path]:
     """Return checkpoints targeted by top-level symlinks or symlink fallback text files."""
     protected = set()
@@ -194,7 +200,7 @@ def _find_pointer_protected_checkpoints(ckpt_root: Path, checkpoints: list[Path]
                 raw_target = os.readlink(entry)
             except OSError:
                 continue
-        elif entry.is_file() and entry.suffix == ".txt":
+        elif _is_checkpoint_pointer_text_file(entry):
             try:
                 raw_target = entry.read_text().strip()
             except (OSError, UnicodeError):

--- a/nemo_automodel/components/checkpoint/utils.py
+++ b/nemo_automodel/components/checkpoint/utils.py
@@ -17,6 +17,7 @@ import logging
 import math
 import os
 import re
+import stat
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -179,9 +180,9 @@ def _read_checkpoint_metric(checkpoint: Path, metric_key: str | None) -> float |
     return None
 
 
-def _is_checkpoint_pointer_text_file(path: Path) -> bool:
+def _is_checkpoint_pointer_text_file(path: Path, mode: int) -> bool:
     """Return whether path looks like a symlink fallback checkpoint pointer."""
-    return path.is_file() and path.suffix == ".txt" and path.stem.isupper()
+    return stat.S_ISREG(mode) and path.suffix == ".txt" and path.stem.isupper()
 
 
 def _find_pointer_protected_checkpoints(ckpt_root: Path, checkpoints: list[Path]) -> set[Path]:
@@ -194,13 +195,11 @@ def _find_pointer_protected_checkpoints(ckpt_root: Path, checkpoints: list[Path]
 
     for entry in entries:
         raw_target = None
-        if os.path.islink(entry):
+        entry_mode = entry.lstat().st_mode
+        if stat.S_ISLNK(entry_mode):
             raw_target = os.readlink(entry)
-        elif _is_checkpoint_pointer_text_file(entry):
-            try:
-                raw_target = entry.read_text().strip()
-            except UnicodeError:
-                continue
+        elif _is_checkpoint_pointer_text_file(entry, entry_mode):
+            raw_target = entry.read_text().strip()
 
         target = _resolve_checkpoint_pointer_target(ckpt_root, raw_target) if raw_target else None
         if target is None:

--- a/nemo_automodel/recipes/base_recipe.py
+++ b/nemo_automodel/recipes/base_recipe.py
@@ -484,7 +484,7 @@ class BaseRecipe:
             except OSError:
                 if os.path.lexists(temp_path):
                     os.remove(temp_path)
-                # Fallback: publish a text pointer when symlinks aren't supported.
+                # Fallback: publish a text pointer when symbolic links are not supported.
                 with open(temp_path, "x") as f:
                     f.write(relative_target)
                     f.flush()
@@ -860,8 +860,9 @@ class BaseRecipe:
         max_recent_checkpoints = checkpoint_config.max_recent_checkpoints
         if max_recent_checkpoints is None:
             return "disabled; keeping all checkpoints (checkpoint.max_recent_checkpoints=None)"
+        checkpoint_label = "checkpoint directory" if max_recent_checkpoints == 1 else "checkpoint directories"
         return (
-            f"keeping the most recent {max_recent_checkpoints} checkpoint(s), "
+            f"keeping the most recent {max_recent_checkpoints} {checkpoint_label}, "
             "plus pointer-protected checkpoints "
             f"(checkpoint.max_recent_checkpoints={max_recent_checkpoints})"
         )

--- a/nemo_automodel/recipes/base_recipe.py
+++ b/nemo_automodel/recipes/base_recipe.py
@@ -987,6 +987,19 @@ class BaseRecipe:
             "Validation every steps": step_scheduler.val_every_steps,
             "Max train steps": step_scheduler.max_steps,
         }
+        checkpoint_config = getattr(getattr(self, "checkpointer", None), "config", None)
+        if checkpoint_config is not None and hasattr(checkpoint_config, "max_recent_checkpoints"):
+            max_recent_checkpoints = checkpoint_config.max_recent_checkpoints
+            if max_recent_checkpoints is None:
+                attrs["Checkpoint retention"] = (
+                    "disabled; keeping all checkpoints (checkpoint.max_recent_checkpoints=None)"
+                )
+            else:
+                attrs["Checkpoint retention"] = (
+                    f"keeping the most recent {max_recent_checkpoints} checkpoint(s), "
+                    "plus pointer-protected checkpoints "
+                    f"(checkpoint.max_recent_checkpoints={max_recent_checkpoints})"
+                )
         logging.info("Step scheduler:")
         for k, v in attrs.items():
             logging.info(f"- {k}: {v}")

--- a/nemo_automodel/recipes/base_recipe.py
+++ b/nemo_automodel/recipes/base_recipe.py
@@ -16,7 +16,6 @@ import getpass
 import json
 import logging
 import os
-import re
 import shutil
 import socket
 from datetime import datetime
@@ -43,6 +42,15 @@ except ImportError:
     from transformers.tokenization_utils import PreTrainedTokenizerBase
 
 from nemo_automodel.components.checkpoint.checkpointing import save_config
+from nemo_automodel.components.checkpoint.utils import (
+    _find_latest_checkpoint,
+    _find_pointer_protected_checkpoints,
+    _format_missing_checkpoint_dir_error,
+    _list_existing_checkpoints,
+    _read_checkpoint_metric,
+    _read_checkpoint_pointer,
+    _resolve_restore_from_to_ckpt_dir,
+)
 from nemo_automodel.components.config.loader import ConfigNode, config_to_yaml_str
 from nemo_automodel.components.distributed.mesh_utils import get_flat_mesh
 from nemo_automodel.components.optim.scheduler import OptimizerParamScheduler
@@ -135,168 +143,6 @@ def is_model(object):
     return isinstance(object, nn.Module) or (
         isinstance(object, list) and len(object) > 0 and all(isinstance(item, nn.Module) for item in object)
     )
-
-
-def _checkpoint_step_num(path: Path) -> int:
-    """Return the trailing checkpoint step number, or -1 when the name is not a checkpoint."""
-    match = re.search(r"step_(\d+)$", path.stem)
-    return int(match.group(1)) if match else -1
-
-
-def _list_existing_checkpoints(ckpt_root: Path) -> list[Path]:
-    """Return existing checkpoint directories under ckpt_root (matching '*step_*')."""
-    if not ckpt_root.exists():
-        return []
-    checkpoints = [path for path in ckpt_root.glob("*step_*") if path.is_dir() and not path.is_symlink()]
-    return sorted((path for path in checkpoints if _checkpoint_step_num(path) >= 0), key=_checkpoint_step_num)
-
-
-def _resolve_checkpoint_pointer_target(ckpt_root: Path, raw_target: str) -> Path | None:
-    """Resolve a checkpoint pointer target relative to ckpt_root."""
-    if not raw_target:
-        return None
-    target = Path(raw_target)
-    if not target.is_absolute():
-        target = ckpt_root / target
-    return Path(os.path.abspath(target))
-
-
-def _read_checkpoint_pointer(ckpt_root: str | Path, link_name: str) -> Path | None:
-    """Resolve a checkpoint pointer symlink or fallback text file."""
-    root = Path(ckpt_root)
-    link_path = root / link_name
-    raw_target = None
-    if os.path.islink(link_path):
-        try:
-            raw_target = os.readlink(link_path)
-        except OSError:
-            pass
-    elif os.path.isfile(f"{link_path}.txt"):
-        try:
-            with open(f"{link_path}.txt", "r") as f:
-                raw_target = f.read().strip()
-        except (OSError, UnicodeError):
-            pass
-
-    return _resolve_checkpoint_pointer_target(root, raw_target) if raw_target else None
-
-
-def _checkpoint_contains_target(checkpoint: Path, target: Path) -> bool:
-    """Return whether target points at or inside checkpoint."""
-    checkpoint_abs = Path(os.path.abspath(checkpoint))
-    target_abs = Path(os.path.abspath(target))
-    return target_abs == checkpoint_abs or checkpoint_abs in target_abs.parents
-
-
-def _read_checkpoint_metric(checkpoint: Path, metric_key: str | None) -> float | None:
-    """Read a validation metric from checkpoint loss metadata."""
-    try:
-        with open(checkpoint / "losses.json", "r") as f:
-            losses = json.load(f)
-    except (OSError, TypeError, json.JSONDecodeError):
-        return None
-
-    candidate_keys = []
-    if metric_key is not None:
-        candidate_keys.append(metric_key)
-    candidate_keys.extend(["val_loss", "default"])
-
-    for key in candidate_keys:
-        if key not in losses:
-            continue
-        try:
-            return float(losses[key])
-        except (TypeError, ValueError):
-            continue
-    return None
-
-
-def _find_pointer_protected_checkpoints(ckpt_root: Path, checkpoints: list[Path]) -> set[Path]:
-    """Return checkpoints targeted by top-level symlinks or symlink fallback text files."""
-    protected = set()
-    if not ckpt_root.exists():
-        return protected
-
-    try:
-        entries = list(ckpt_root.iterdir())
-    except OSError:
-        logger.warning("Failed to scan checkpoint pointers in %s", ckpt_root, exc_info=True)
-        return protected
-
-    for entry in entries:
-        raw_target = None
-        if os.path.islink(entry):
-            try:
-                raw_target = os.readlink(entry)
-            except OSError:
-                continue
-        elif entry.is_file() and entry.suffix == ".txt":
-            try:
-                raw_target = entry.read_text().strip()
-            except (OSError, UnicodeError):
-                continue
-
-        target = _resolve_checkpoint_pointer_target(ckpt_root, raw_target) if raw_target else None
-        if target is None:
-            continue
-        for checkpoint in checkpoints:
-            if _checkpoint_contains_target(checkpoint, target):
-                protected.add(checkpoint)
-                break
-    return protected
-
-
-def _resolve_restore_from_to_ckpt_dir(checkpoint_dir: str, restore_from: str) -> str | None:
-    """
-    Resolve restore_from to a checkpoint directory.
-
-    Returns:
-        - str: resolved checkpoint directory
-        - None: if restore_from='LATEST' but no checkpoint found (caller should start fresh)
-    """
-    # Handle checkpoint-root pointers such as LATEST and LOWEST_VAL.
-    if os.path.sep not in restore_from and not os.path.isabs(restore_from):
-        pointed_checkpoint = _read_checkpoint_pointer(checkpoint_dir, restore_from)
-        if pointed_checkpoint is not None and pointed_checkpoint.is_dir():
-            return os.fspath(pointed_checkpoint)
-    if restore_from.upper() == "LATEST":
-        return _find_latest_checkpoint(checkpoint_dir)
-
-    # If restore_from is just a directory name (no path separator), treat it as
-    # relative to checkpoint_dir. Otherwise use as-is (absolute or relative path).
-    if os.path.sep not in restore_from and not os.path.isabs(restore_from):
-        return os.path.join(checkpoint_dir, restore_from)
-    return restore_from
-
-
-def _format_missing_checkpoint_dir_error(checkpoint_dir: str, restore_from: str, resolved_ckpt_dir: str) -> str:
-    """Format a helpful error message for a missing checkpoint directory."""
-    error_msg = [
-        f"\n{'=' * 80}",
-        "ERROR: Checkpoint directory does not exist",
-        f"{'=' * 80}",
-        f"Specified: checkpoint.restore_from: '{restore_from}'",
-        f"Resolved to: {resolved_ckpt_dir}",
-        "",
-        "Please check:",
-        "  1. The checkpoint directory exists",
-        f"  2. The path is correct (restore_from: '{restore_from}')",
-        f"  3. Available checkpoints in {checkpoint_dir}:",
-    ]
-
-    ckpt_root = Path(checkpoint_dir)
-    available_ckpts = _list_existing_checkpoints(ckpt_root)
-    if available_ckpts:
-        error_msg += [f"       {', '.join([p.name for p in available_ckpts[:5]])}"]
-        if len(available_ckpts) > 5:
-            error_msg += [f"       ... and {len(available_ckpts) - 5} more"]
-    else:
-        error_msg += (
-            ["       (no checkpoints found)"] if ckpt_root.exists() else ["       (checkpoint_dir does not exist)"]
-        )
-
-    error_msg += [f"{'=' * 80}"]
-    return "\n".join(error_msg)
 
 
 def _is_rank_0() -> bool:
@@ -714,37 +560,6 @@ class BaseRecipe:
                 f"Updated LOWEST_VAL checkpoint symlink to {os.path.basename(target_dir)} (val_loss={val_loss:.4f})"
             )
 
-    def _finalize_pending_checkpoint(self) -> None:
-        """Wait the final async checkpoint write and flush its deferred symlinks.
-
-        The async ``save_checkpoint`` path defers the ``latest`` / ``best`` symlink
-        update to the *next* save's preamble. After the final checkpoint there is
-        no next save, so the training loop must call this once at the end --
-        otherwise the last async write may be left unfinished and ``latest`` /
-        ``best`` still point at the previous checkpoint. A no-op when checkpointing
-        is disabled or no async save is pending.
-        """
-        checkpointer = getattr(self, "checkpointer", None)
-        if checkpointer is None or not getattr(checkpointer.config, "enabled", False):
-            return
-        checkpointer.async_wait()
-        is_dist_initialized = torch.distributed.is_initialized()
-        is_rank_0 = not is_dist_initialized or torch.distributed.get_rank() == 0
-        prev_pending = getattr(self, "_last_pending_checkpoint_dir", None)
-        if prev_pending is not None:
-            if is_rank_0:
-                self._update_latest_symlink(prev_pending)
-            setattr(self, "_last_pending_checkpoint_dir", None)
-            if is_dist_initialized:
-                _dist_barrier(getattr(getattr(self, "mesh_context", None), "process_group", None))
-        prev_best_pending = getattr(self, "_last_pending_best_checkpoint_info", None)
-        if prev_best_pending is not None:
-            if is_rank_0 and prev_best_pending.get("val") is not None:
-                self._update_best_symlink(prev_best_pending["path"], float(prev_best_pending["val"]))
-            setattr(self, "_last_pending_best_checkpoint_info", None)
-            if is_dist_initialized:
-                _dist_barrier(getattr(getattr(self, "mesh_context", None), "process_group", None))
-
     def _validate_checkpoint_dir_exists(self, ckpt_dir: str, restore_from: str, is_rank_0: bool) -> None:
         """Validate resolved checkpoint directory exists; raise FileNotFoundError with a helpful message."""
         if os.path.exists(ckpt_dir):
@@ -1001,25 +816,38 @@ class BaseRecipe:
             "Validation every steps": step_scheduler.val_every_steps,
             "Max train steps": step_scheduler.max_steps,
         }
-        checkpoint_config = getattr(getattr(self, "checkpointer", None), "config", None)
-        if checkpoint_config is not None:
-            if not getattr(checkpoint_config, "enabled", True):
-                attrs["Checkpoint retention"] = "inactive because checkpointing is disabled"
-            elif hasattr(checkpoint_config, "max_recent_checkpoints"):
-                max_recent_checkpoints = checkpoint_config.max_recent_checkpoints
-                if max_recent_checkpoints is None:
-                    attrs["Checkpoint retention"] = (
-                        "disabled; keeping all checkpoints (checkpoint.max_recent_checkpoints=None)"
-                    )
-                else:
-                    attrs["Checkpoint retention"] = (
-                        f"keeping the most recent {max_recent_checkpoints} checkpoint(s), "
-                        "plus pointer-protected checkpoints "
-                        f"(checkpoint.max_recent_checkpoints={max_recent_checkpoints})"
-                    )
+        retention_policy = self._checkpoint_retention_policy_message()
+        if retention_policy is not None:
+            attrs["Checkpoint retention"] = retention_policy
         logging.info("Step scheduler:")
         for k, v in attrs.items():
             logging.info(f"- {k}: {v}")
+
+    def _checkpoint_retention_policy_message(self, checkpoint_config=None) -> str | None:
+        """Return the user-facing checkpoint retention policy message, if available."""
+        if checkpoint_config is None:
+            checkpoint_config = getattr(getattr(self, "checkpointer", None), "config", None)
+        if checkpoint_config is None:
+            return None
+        if not getattr(checkpoint_config, "enabled", True):
+            return "inactive because checkpointing is disabled"
+        if not hasattr(checkpoint_config, "max_recent_checkpoints"):
+            return None
+
+        max_recent_checkpoints = checkpoint_config.max_recent_checkpoints
+        if max_recent_checkpoints is None:
+            return "disabled; keeping all checkpoints (checkpoint.max_recent_checkpoints=None)"
+        return (
+            f"keeping the most recent {max_recent_checkpoints} checkpoint(s), "
+            "plus pointer-protected checkpoints "
+            f"(checkpoint.max_recent_checkpoints={max_recent_checkpoints})"
+        )
+
+    def _log_checkpoint_retention_policy(self, checkpoint_config=None) -> None:
+        """Log the checkpoint retention policy without requiring a StepScheduler."""
+        retention_policy = self._checkpoint_retention_policy_message(checkpoint_config)
+        if retention_policy is not None:
+            logging.info("Checkpoint retention: %s", retention_policy)
 
     def _setup_garbage_collection(self, step_scheduler: StepScheduler | None = None) -> None:
         """Initialize manual garbage collection based on step scheduler config."""
@@ -1158,54 +986,6 @@ class BaseRecipe:
                 break
         pbar.set_postfix(**postfix)
         pbar.update(1)
-
-
-def _find_latest_checkpoint(checkpoint_dir):
-    """
-    Resolve the most recent checkpoint directory.
-
-    Preference order:
-      1) Valid LATEST symlink or txt file under checkpoint_dir
-      2) Highest step directory under checkpoint_dir matching *step_*
-
-    Returns:
-        Path (or str) of the latest checkpoint directory, or None.
-    """
-    root = Path(checkpoint_dir)
-    if not root.exists():
-        return
-
-    # Try LATEST symlink or txt pointer first
-    latest_link = os.path.join(os.fspath(root), "LATEST")
-    resolved = None
-    if os.path.islink(latest_link):
-        try:
-            resolved = os.readlink(latest_link)
-        except OSError:
-            pass
-    elif os.path.isfile(latest_link + ".txt"):
-        try:
-            with open(latest_link + ".txt", "r") as f:
-                resolved = f.read().strip()
-        except OSError:
-            pass
-
-    if resolved:
-        if not os.path.isabs(resolved):
-            resolved = os.path.abspath(os.path.join(os.fspath(root), resolved))
-        if os.path.isdir(resolved):
-            return resolved
-
-    # Fallback to scanning
-    checkpoint_files = _list_existing_checkpoints(root)
-    if not checkpoint_files:
-        return
-
-    latest = max(checkpoint_files, key=_checkpoint_step_num)
-    if _checkpoint_step_num(latest) == -1:
-        return
-
-    return latest
 
 
 def _extract_model_signature(cfg: dict) -> dict:

--- a/nemo_automodel/recipes/base_recipe.py
+++ b/nemo_automodel/recipes/base_recipe.py
@@ -871,56 +871,62 @@ class BaseRecipe:
         garbage_collector.run(step_scheduler.step)
 
     def _get_dp_group(self, include_cp: bool = False):
-        if not self.device_mesh:
+        device_mesh = getattr(self, "device_mesh", None)
+        if not device_mesh:
             return None
 
-        dp_mesh = get_flat_mesh(self.device_mesh, "dp")
-        if include_cp and self.device_mesh["cp"].size() > 1:
-            dp_mesh = get_flat_mesh(self.device_mesh, "dp_cp")
+        dp_mesh = get_flat_mesh(device_mesh, "dp")
+        if include_cp and device_mesh["cp"].size() > 1:
+            dp_mesh = get_flat_mesh(device_mesh, "dp_cp")
         if dp_mesh.size() == 1:
             return None
         return dp_mesh.get_group()
 
     def _get_dp_group_size(self, include_cp: bool = False):
-        if not self.device_mesh:
+        device_mesh = getattr(self, "device_mesh", None)
+        if not device_mesh:
             if dist.is_initialized():
                 return dist.get_world_size()
             return 1
 
-        dp_mesh = get_flat_mesh(self.device_mesh, "dp")
-        if include_cp and self.device_mesh["cp"].size() > 1:
-            dp_mesh = get_flat_mesh(self.device_mesh, "dp_cp")
+        dp_mesh = get_flat_mesh(device_mesh, "dp")
+        if include_cp and device_mesh["cp"].size() > 1:
+            dp_mesh = get_flat_mesh(device_mesh, "dp_cp")
         return dp_mesh.size()
 
     def _get_cp_group_size(self):
-        if not self.device_mesh or self.device_mesh["cp"].size() == 1:
+        device_mesh = getattr(self, "device_mesh", None)
+        if not device_mesh or device_mesh["cp"].size() == 1:
             return 1
-        return self.device_mesh["cp"].size()
+        return device_mesh["cp"].size()
 
     def _get_dp_rank(self, include_cp: bool = False):
-        if not self.device_mesh:
+        device_mesh = getattr(self, "device_mesh", None)
+        if not device_mesh:
             # For DDP without a device mesh, the global rank is the DP rank.
             if dist.is_initialized():
                 return dist.get_rank()
             return 0
 
-        dp_mesh = get_flat_mesh(self.device_mesh, "dp")
-        if include_cp and self.device_mesh["cp"].size() > 1:
-            dp_mesh = get_flat_mesh(self.device_mesh, "dp_cp")
+        dp_mesh = get_flat_mesh(device_mesh, "dp")
+        if include_cp and device_mesh["cp"].size() > 1:
+            dp_mesh = get_flat_mesh(device_mesh, "dp_cp")
         if dp_mesh.size() == 1:
             return 0
         return dp_mesh.get_local_rank()
 
     def _get_tp_rank(self):
-        if not self.device_mesh or self.device_mesh["tp"].size() == 1:
+        device_mesh = getattr(self, "device_mesh", None)
+        if not device_mesh or device_mesh["tp"].size() == 1:
             return 0
-        return self.device_mesh.get_local_rank("tp")
+        return device_mesh.get_local_rank("tp")
 
     def _get_pp_rank(self):
         # PP is a special case because it'll only be present in the device mesh if pp is enabled
-        if not self.device_mesh or "pp" not in self.device_mesh.mesh_dim_names or self.device_mesh["pp"].size() == 1:
+        device_mesh = getattr(self, "device_mesh", None)
+        if not device_mesh or "pp" not in device_mesh.mesh_dim_names or device_mesh["pp"].size() == 1:
             return 0
-        return self.device_mesh.get_local_rank("pp")
+        return device_mesh.get_local_rank("pp")
 
     def _get_pp_group(self):
         """Return the pipeline-parallel process group, or None when pp is disabled.
@@ -936,7 +942,7 @@ class BaseRecipe:
 
     def _dp_allreduce(self, tensor, op=dist.ReduceOp.SUM, include_cp: bool = False):
         dp_group = self._get_dp_group(include_cp=include_cp)
-        if self.device_mesh and dp_group is None:
+        if getattr(self, "device_mesh", None) and dp_group is None:
             return tensor
         if dp_group is not None or dist.is_initialized():
             if not tensor.is_cuda and torch.cuda.is_available():

--- a/nemo_automodel/recipes/base_recipe.py
+++ b/nemo_automodel/recipes/base_recipe.py
@@ -17,6 +17,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import socket
 from datetime import datetime
 from pathlib import Path
@@ -136,11 +137,113 @@ def is_model(object):
     )
 
 
+def _checkpoint_step_num(path: Path) -> int:
+    """Return the trailing checkpoint step number, or -1 when the name is not a checkpoint."""
+    match = re.search(r"step_(\d+)$", path.stem)
+    return int(match.group(1)) if match else -1
+
+
 def _list_existing_checkpoints(ckpt_root: Path) -> list[Path]:
     """Return existing checkpoint directories under ckpt_root (matching '*step_*')."""
     if not ckpt_root.exists():
         return []
-    return list(ckpt_root.glob("*step_*"))
+    checkpoints = [path for path in ckpt_root.glob("*step_*") if path.is_dir() and not path.is_symlink()]
+    return sorted((path for path in checkpoints if _checkpoint_step_num(path) >= 0), key=_checkpoint_step_num)
+
+
+def _resolve_checkpoint_pointer_target(ckpt_root: Path, raw_target: str) -> Path | None:
+    """Resolve a checkpoint pointer target relative to ckpt_root."""
+    if not raw_target:
+        return None
+    target = Path(raw_target)
+    if not target.is_absolute():
+        target = ckpt_root / target
+    return Path(os.path.abspath(target))
+
+
+def _read_checkpoint_pointer(ckpt_root: str | Path, link_name: str) -> Path | None:
+    """Resolve a checkpoint pointer symlink or fallback text file."""
+    root = Path(ckpt_root)
+    link_path = root / link_name
+    raw_target = None
+    if os.path.islink(link_path):
+        try:
+            raw_target = os.readlink(link_path)
+        except OSError:
+            pass
+    elif os.path.isfile(f"{link_path}.txt"):
+        try:
+            with open(f"{link_path}.txt", "r") as f:
+                raw_target = f.read().strip()
+        except (OSError, UnicodeError):
+            pass
+
+    return _resolve_checkpoint_pointer_target(root, raw_target) if raw_target else None
+
+
+def _checkpoint_contains_target(checkpoint: Path, target: Path) -> bool:
+    """Return whether target points at or inside checkpoint."""
+    checkpoint_abs = Path(os.path.abspath(checkpoint))
+    target_abs = Path(os.path.abspath(target))
+    return target_abs == checkpoint_abs or checkpoint_abs in target_abs.parents
+
+
+def _read_checkpoint_metric(checkpoint: Path, metric_key: str | None) -> float | None:
+    """Read a validation metric from checkpoint loss metadata."""
+    try:
+        with open(checkpoint / "losses.json", "r") as f:
+            losses = json.load(f)
+    except (OSError, TypeError, json.JSONDecodeError):
+        return None
+
+    candidate_keys = []
+    if metric_key is not None:
+        candidate_keys.append(metric_key)
+    candidate_keys.extend(["val_loss", "default"])
+
+    for key in candidate_keys:
+        if key not in losses:
+            continue
+        try:
+            return float(losses[key])
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def _find_pointer_protected_checkpoints(ckpt_root: Path, checkpoints: list[Path]) -> set[Path]:
+    """Return checkpoints targeted by top-level symlinks or symlink fallback text files."""
+    protected = set()
+    if not ckpt_root.exists():
+        return protected
+
+    try:
+        entries = list(ckpt_root.iterdir())
+    except OSError:
+        logger.warning("Failed to scan checkpoint pointers in %s", ckpt_root, exc_info=True)
+        return protected
+
+    for entry in entries:
+        raw_target = None
+        if os.path.islink(entry):
+            try:
+                raw_target = os.readlink(entry)
+            except OSError:
+                continue
+        elif entry.is_file() and entry.suffix == ".txt":
+            try:
+                raw_target = entry.read_text().strip()
+            except (OSError, UnicodeError):
+                continue
+
+        target = _resolve_checkpoint_pointer_target(ckpt_root, raw_target) if raw_target else None
+        if target is None:
+            continue
+        for checkpoint in checkpoints:
+            if _checkpoint_contains_target(checkpoint, target):
+                protected.add(checkpoint)
+                break
+    return protected
 
 
 def _resolve_restore_from_to_ckpt_dir(checkpoint_dir: str, restore_from: str) -> str | None:
@@ -300,6 +403,7 @@ class BaseRecipe:
 
         # Wait for any in-flight checkpoint (async case) to complete
         self.checkpointer.async_wait()
+        self._complete_pending_checkpoint()
 
         # Free GPU caches before DCP's gather-and-write. DCP allocates NCCL
         # workspace and materializes DTensor shards on GPU; with CPU-offloaded
@@ -309,33 +413,13 @@ class BaseRecipe:
             torch.cuda.synchronize()
             torch.cuda.empty_cache()
 
-        # If a previous async checkpoint just finished, update the "latest" symlink now
-        prev_pending = getattr(self, "_last_pending_checkpoint_dir", None)
         is_dist_initialized = torch.distributed.is_initialized()
         is_rank_0 = not is_dist_initialized or torch.distributed.get_rank() == 0
-        if prev_pending is not None:
-            if is_rank_0:
-                self._update_latest_symlink(prev_pending)
-            # clear and remember the last completed path
-            setattr(self, "_last_pending_checkpoint_dir", None)
-            if is_dist_initialized:
-                _dist_barrier(getattr(getattr(self, "mesh_context", None), "process_group", None))
-
-        # If a previous async checkpoint just finished, also update the "best" symlink now (if pending)
-        prev_best_pending = getattr(self, "_last_pending_best_checkpoint_info", None)
-        if prev_best_pending is not None:
-            if is_rank_0 and prev_best_pending.get("val") is not None:
-                self._update_best_symlink(prev_best_pending["path"], float(prev_best_pending["val"]))
-            setattr(self, "_last_pending_best_checkpoint_info", None)
-            if is_dist_initialized:
-                _dist_barrier(getattr(getattr(self, "mesh_context", None), "process_group", None))
-
         path = self.checkpointer.config.checkpoint_dir
         path = os.path.join(path, f"epoch_{epoch}_step_{step}")
 
-        best_val_metric = (
-            val_loss[next(iter(val_loss.keys())) if len(val_loss) == 1 else best_metric_key] if val_loss else None
-        )
+        best_metric_name = next(iter(val_loss.keys())) if val_loss and len(val_loss) == 1 else best_metric_key
+        best_val_metric = val_loss[best_metric_name] if val_loss else None
 
         if is_rank_0:
             if os.path.exists(path):
@@ -456,13 +540,18 @@ class BaseRecipe:
             setattr(self, "_last_pending_checkpoint_dir", path)
             # Defer best symlink update similarly, capturing the metric used for comparison
             if best_val_metric is not None:
-                setattr(self, "_last_pending_best_checkpoint_info", {"path": path, "val": float(best_val_metric)})
+                setattr(
+                    self,
+                    "_last_pending_best_checkpoint_info",
+                    {"path": path, "val": float(best_val_metric), "metric_key": best_metric_name},
+                )
         else:
             # Sync: update immediately
             if is_rank_0:
                 self._update_latest_symlink(path)
                 if best_val_metric is not None:
-                    self._update_best_symlink(path, float(best_val_metric))
+                    self._update_best_symlink(path, float(best_val_metric), best_metric_name)
+                self._prune_old_checkpoints()
             if is_dist_initialized:
                 _dist_barrier(getattr(getattr(self, "mesh_context", None), "process_group", None))
 
@@ -472,6 +561,46 @@ class BaseRecipe:
         if torch.cuda.is_available():
             torch.cuda.synchronize()
             torch.cuda.empty_cache()
+
+    def _complete_pending_checkpoint(self) -> None:
+        """Publish a completed async checkpoint and apply retention."""
+        prev_pending = getattr(self, "_last_pending_checkpoint_dir", None)
+        prev_best_pending = getattr(self, "_last_pending_best_checkpoint_info", None)
+        if prev_pending is None and prev_best_pending is None:
+            return
+
+        is_dist_initialized = torch.distributed.is_initialized()
+        is_rank_0 = not is_dist_initialized or torch.distributed.get_rank() == 0
+        if prev_pending is not None:
+            if is_rank_0:
+                self._update_latest_symlink(prev_pending)
+            setattr(self, "_last_pending_checkpoint_dir", None)
+            if is_dist_initialized:
+                torch.distributed.barrier()
+
+        if prev_best_pending is not None:
+            if is_rank_0 and prev_best_pending.get("val") is not None:
+                self._update_best_symlink(
+                    prev_best_pending["path"],
+                    float(prev_best_pending["val"]),
+                    prev_best_pending.get("metric_key"),
+                )
+            setattr(self, "_last_pending_best_checkpoint_info", None)
+            if is_dist_initialized:
+                torch.distributed.barrier()
+
+        if is_rank_0:
+            self._prune_old_checkpoints()
+        if is_dist_initialized:
+            torch.distributed.barrier()
+
+    def _finalize_pending_checkpoint(self) -> None:
+        """Wait for the final async checkpoint, publish it, and apply retention."""
+        checkpointer = getattr(self, "checkpointer", None)
+        if checkpointer is None or not checkpointer.config.enabled:
+            return
+        checkpointer.async_wait()
+        self._complete_pending_checkpoint()
 
     def _update_checkpoint_symlink(self, link_name: str, target_dir: str) -> None:
         """
@@ -483,6 +612,9 @@ class BaseRecipe:
         link_path = os.path.join(ckpt_root, link_name)
         if os.path.lexists(link_path):
             os.remove(link_path)
+        txt_path = f"{link_path}.txt"
+        if os.path.exists(txt_path):
+            os.remove(txt_path)
 
         ckpt_root_abs = os.path.abspath(ckpt_root)
         target_abs = os.path.abspath(target_dir)
@@ -494,6 +626,57 @@ class BaseRecipe:
             with open(f"{link_path}.txt", "w") as f:
                 f.write(relative_target)
 
+    def _remove_checkpoint_pointer(self, link_name: str) -> None:
+        """Remove a checkpoint pointer symlink and fallback text file."""
+        ckpt_root = self.checkpointer.config.checkpoint_dir
+        link_path = os.path.join(ckpt_root, link_name)
+        if os.path.lexists(link_path):
+            os.remove(link_path)
+        txt_path = f"{link_path}.txt"
+        if os.path.exists(txt_path):
+            os.remove(txt_path)
+
+    def _remove_stale_checkpoint_pointer(self, link_name: str) -> None:
+        """Remove a checkpoint pointer when its target no longer exists."""
+        target = _read_checkpoint_pointer(self.checkpointer.config.checkpoint_dir, link_name)
+        if target is not None and not target.is_dir():
+            self._remove_checkpoint_pointer(link_name)
+
+    def _prune_old_checkpoints(self) -> None:
+        """Prune old checkpoint directories according to checkpoint.max_recent_checkpoints."""
+        max_recent_checkpoints = getattr(self.checkpointer.config, "max_recent_checkpoints", None)
+        if max_recent_checkpoints is None:
+            return
+
+        ckpt_root = Path(self.checkpointer.config.checkpoint_dir)
+        checkpoints = _list_existing_checkpoints(ckpt_root)
+        protected_checkpoints = _find_pointer_protected_checkpoints(ckpt_root, checkpoints)
+        retained_window = set(checkpoints[-max_recent_checkpoints:])
+        checkpoints_to_delete = [
+            checkpoint for checkpoint in checkpoints if checkpoint not in retained_window | protected_checkpoints
+        ]
+        for checkpoint in checkpoints_to_delete:
+            try:
+                shutil.rmtree(checkpoint)
+            except OSError:
+                logger.warning("Failed to prune old checkpoint directory %s", checkpoint, exc_info=True)
+            else:
+                logger.info("Pruned old checkpoint directory %s", checkpoint)
+
+        self._remove_stale_checkpoint_pointer("LATEST")
+        self._remove_stale_checkpoint_pointer("LOWEST_VAL")
+
+    def _initialize_best_val_loss_from_pointer(self, metric_key: str | None) -> None:
+        """Initialize best validation loss from the existing LOWEST_VAL pointer after resume."""
+        if self._best_val_loss != float("inf"):
+            return
+        target = _read_checkpoint_pointer(self.checkpointer.config.checkpoint_dir, "LOWEST_VAL")
+        if target is None or not target.is_dir():
+            return
+        existing_best = _read_checkpoint_metric(target, metric_key)
+        if existing_best is not None:
+            self._best_val_loss = existing_best
+
     def _update_latest_symlink(self, target_dir: str) -> None:
         """
         Create or update a symlink named "latest" under the checkpoint root
@@ -502,12 +685,13 @@ class BaseRecipe:
         """
         self._update_checkpoint_symlink("LATEST", target_dir)
 
-    def _update_best_symlink(self, target_dir: str, val_loss: float) -> None:
+    def _update_best_symlink(self, target_dir: str, val_loss: float, metric_key: str | None = None) -> None:
         """
         Create or update a symlink named "LOWEST_VAL" under the checkpoint root
         that points to the checkpoint with the lowest validation loss.
         Only called on rank 0.
         """
+        self._initialize_best_val_loss_from_pointer(metric_key)
         # Update best checkpoint if this one is better
         if val_loss < self._best_val_loss:
             self._best_val_loss = val_loss
@@ -983,16 +1167,12 @@ def _find_latest_checkpoint(checkpoint_dir):
             return resolved
 
     # Fallback to scanning
-    checkpoint_files = list(root.glob("*step_*"))
+    checkpoint_files = _list_existing_checkpoints(root)
     if not checkpoint_files:
         return
 
-    def _step_num(path: Path):
-        m = re.search(r"step_(\d+)$", path.stem)
-        return int(m.group(1)) if m else -1
-
-    latest = max(checkpoint_files, key=_step_num)
-    if _step_num(latest) == -1:
+    latest = max(checkpoint_files, key=_checkpoint_step_num)
+    if _checkpoint_step_num(latest) == -1:
         return
 
     return latest

--- a/nemo_automodel/recipes/base_recipe.py
+++ b/nemo_automodel/recipes/base_recipe.py
@@ -45,13 +45,13 @@ except ImportError:
 
 from nemo_automodel.components.checkpoint.checkpointing import save_config
 from nemo_automodel.components.checkpoint.utils import (
-    _find_latest_checkpoint,
-    _find_pointer_protected_checkpoints,
-    _format_missing_checkpoint_dir_error,
-    _read_checkpoint_metric,
-    _read_checkpoint_pointer,
-    _resolve_restore_from_to_ckpt_dir,
+    find_latest_checkpoint,
+    find_pointer_protected_checkpoints,
+    format_missing_checkpoint_dir_error,
     list_automodel_checkpoints,
+    read_checkpoint_metric,
+    read_checkpoint_pointer,
+    resolve_restore_from_to_checkpoint_dir,
 )
 from nemo_automodel.components.config.loader import ConfigNode, config_to_yaml_str
 from nemo_automodel.components.distributed.mesh_utils import get_flat_mesh
@@ -465,6 +465,16 @@ class BaseRecipe:
         async_wait()
         self._complete_pending_checkpoint()
 
+    def _finalize_and_close_checkpointer(self) -> None:
+        """Finalize pending checkpoint publication and always close the checkpointer."""
+        checkpointer = getattr(self, "checkpointer", None)
+        if checkpointer is None:
+            return
+        try:
+            self._finalize_pending_checkpoint()
+        finally:
+            checkpointer.close()
+
     def _update_checkpoint_symlink(self, link_name: str, target_dir: str) -> None:
         """
         Create or update a symlink named `link_name` under the checkpoint root
@@ -515,7 +525,7 @@ class BaseRecipe:
 
     def _remove_stale_checkpoint_pointer(self, link_name: str) -> None:
         """Remove a checkpoint pointer when its target no longer exists."""
-        target = _read_checkpoint_pointer(self.checkpointer.config.checkpoint_dir, link_name)
+        target = read_checkpoint_pointer(self.checkpointer.config.checkpoint_dir, link_name)
         if target is not None and not target.is_dir():
             self._remove_checkpoint_pointer(link_name)
 
@@ -528,7 +538,7 @@ class BaseRecipe:
         ckpt_root = Path(self.checkpointer.config.checkpoint_dir)
         checkpoints = list_automodel_checkpoints(ckpt_root)
         try:
-            protected_checkpoints = _find_pointer_protected_checkpoints(ckpt_root, checkpoints)
+            protected_checkpoints = find_pointer_protected_checkpoints(ckpt_root, checkpoints)
         except (OSError, UnicodeError):
             logger.warning("Failed to scan checkpoint pointers in %s; skipping pruning", ckpt_root, exc_info=True)
             return
@@ -551,10 +561,10 @@ class BaseRecipe:
         """Initialize best validation loss from the existing LOWEST_VAL pointer after resume."""
         if self._best_val_loss != float("inf"):
             return
-        target = _read_checkpoint_pointer(self.checkpointer.config.checkpoint_dir, "LOWEST_VAL")
+        target = read_checkpoint_pointer(self.checkpointer.config.checkpoint_dir, "LOWEST_VAL")
         if target is None or not target.is_dir():
             return
-        existing_best = _read_checkpoint_metric(target, metric_key)
+        existing_best = read_checkpoint_metric(target, metric_key)
         if existing_best is not None:
             self._best_val_loss = existing_best
 
@@ -591,7 +601,7 @@ class BaseRecipe:
 
         # Build helpful error message on rank 0
         if is_rank_0:
-            error_msg = _format_missing_checkpoint_dir_error(
+            error_msg = format_missing_checkpoint_dir_error(
                 checkpoint_dir=self.checkpointer.config.checkpoint_dir,
                 restore_from=restore_from,
                 resolved_ckpt_dir=ckpt_dir,
@@ -655,7 +665,7 @@ class BaseRecipe:
         is_rank_0 = _is_rank_0()
 
         if restore_from:
-            ckpt_dir = _resolve_restore_from_to_ckpt_dir(self.checkpointer.config.checkpoint_dir, restore_from)
+            ckpt_dir = resolve_restore_from_to_checkpoint_dir(self.checkpointer.config.checkpoint_dir, restore_from)
             if ckpt_dir is None:
                 # LATEST keyword with no checkpoints found
                 if is_rank_0:
@@ -667,7 +677,7 @@ class BaseRecipe:
             self._validate_checkpoint_dir_exists(ckpt_dir, restore_from=restore_from, is_rank_0=is_rank_0)
         else:
             # Auto-detect latest checkpoint
-            ckpt_dir = _find_latest_checkpoint(self.checkpointer.config.checkpoint_dir)
+            ckpt_dir = find_latest_checkpoint(self.checkpointer.config.checkpoint_dir)
             if ckpt_dir is None:
                 return
             ckpt_dir = str(ckpt_dir)

--- a/nemo_automodel/recipes/base_recipe.py
+++ b/nemo_automodel/recipes/base_recipe.py
@@ -48,10 +48,10 @@ from nemo_automodel.components.checkpoint.utils import (
     _find_latest_checkpoint,
     _find_pointer_protected_checkpoints,
     _format_missing_checkpoint_dir_error,
-    _list_existing_checkpoints,
     _read_checkpoint_metric,
     _read_checkpoint_pointer,
     _resolve_restore_from_to_ckpt_dir,
+    list_automodel_checkpoints,
 )
 from nemo_automodel.components.config.loader import ConfigNode, config_to_yaml_str
 from nemo_automodel.components.distributed.mesh_utils import get_flat_mesh
@@ -526,7 +526,7 @@ class BaseRecipe:
             return
 
         ckpt_root = Path(self.checkpointer.config.checkpoint_dir)
-        checkpoints = _list_existing_checkpoints(ckpt_root)
+        checkpoints = list_automodel_checkpoints(ckpt_root)
         try:
             protected_checkpoints = _find_pointer_protected_checkpoints(ckpt_root, checkpoints)
         except (OSError, UnicodeError):

--- a/nemo_automodel/recipes/base_recipe.py
+++ b/nemo_automodel/recipes/base_recipe.py
@@ -20,6 +20,7 @@ import shutil
 import socket
 from datetime import datetime
 from pathlib import Path
+from uuid import uuid4
 
 import torch
 
@@ -470,21 +471,35 @@ class BaseRecipe:
         """
         ckpt_root = self.checkpointer.config.checkpoint_dir
         link_path = os.path.join(ckpt_root, link_name)
-        if os.path.lexists(link_path):
-            os.remove(link_path)
         txt_path = f"{link_path}.txt"
-        if os.path.exists(txt_path):
-            os.remove(txt_path)
 
         ckpt_root_abs = os.path.abspath(ckpt_root)
         target_abs = os.path.abspath(target_dir)
         relative_target = os.path.relpath(target_abs, start=ckpt_root_abs)
+        temp_path = os.path.join(ckpt_root, f".{link_name}.{uuid4().hex}.tmp")
         try:
-            os.symlink(relative_target, link_path)
-        except OSError:
-            # Fallback: write a text file containing the target path if symlinks aren't supported
-            with open(f"{link_path}.txt", "w") as f:
-                f.write(relative_target)
+            try:
+                os.symlink(relative_target, temp_path)
+            except OSError:
+                if os.path.lexists(temp_path):
+                    os.remove(temp_path)
+                # Fallback: publish a text pointer when symlinks aren't supported.
+                with open(temp_path, "x") as f:
+                    f.write(relative_target)
+                    f.flush()
+                    os.fsync(f.fileno())
+                os.replace(temp_path, txt_path)
+                temp_path = ""
+                if os.path.lexists(link_path):
+                    os.remove(link_path)
+            else:
+                os.replace(temp_path, link_path)
+                temp_path = ""
+                if os.path.exists(txt_path):
+                    os.remove(txt_path)
+        finally:
+            if temp_path and os.path.lexists(temp_path):
+                os.remove(temp_path)
 
     def _remove_checkpoint_pointer(self, link_name: str) -> None:
         """Remove a checkpoint pointer symlink and fallback text file."""
@@ -510,7 +525,11 @@ class BaseRecipe:
 
         ckpt_root = Path(self.checkpointer.config.checkpoint_dir)
         checkpoints = _list_existing_checkpoints(ckpt_root)
-        protected_checkpoints = _find_pointer_protected_checkpoints(ckpt_root, checkpoints)
+        try:
+            protected_checkpoints = _find_pointer_protected_checkpoints(ckpt_root, checkpoints)
+        except OSError:
+            logger.warning("Failed to scan checkpoint pointers in %s; skipping pruning", ckpt_root, exc_info=True)
+            return
         retained_window = set(checkpoints[-max_recent_checkpoints:])
         checkpoints_to_delete = [
             checkpoint for checkpoint in checkpoints if checkpoint not in retained_window | protected_checkpoints

--- a/nemo_automodel/recipes/base_recipe.py
+++ b/nemo_automodel/recipes/base_recipe.py
@@ -15,6 +15,7 @@
 import getpass
 import json
 import logging
+import math
 import os
 import shutil
 import socket
@@ -527,7 +528,7 @@ class BaseRecipe:
         checkpoints = _list_existing_checkpoints(ckpt_root)
         try:
             protected_checkpoints = _find_pointer_protected_checkpoints(ckpt_root, checkpoints)
-        except OSError:
+        except (OSError, UnicodeError):
             logger.warning("Failed to scan checkpoint pointers in %s; skipping pruning", ckpt_root, exc_info=True)
             return
         retained_window = set(checkpoints[-max_recent_checkpoints:])
@@ -570,6 +571,9 @@ class BaseRecipe:
         that points to the checkpoint with the lowest validation loss.
         Only called on rank 0.
         """
+        if not math.isfinite(val_loss):
+            logger.warning("Ignoring non-finite validation metric for checkpoint %s: %s", target_dir, val_loss)
+            return
         self._initialize_best_val_loss_from_pointer(metric_key)
         # Update best checkpoint if this one is better
         if val_loss < self._best_val_loss:

--- a/nemo_automodel/recipes/base_recipe.py
+++ b/nemo_automodel/recipes/base_recipe.py
@@ -254,7 +254,11 @@ def _resolve_restore_from_to_ckpt_dir(checkpoint_dir: str, restore_from: str) ->
         - str: resolved checkpoint directory
         - None: if restore_from='LATEST' but no checkpoint found (caller should start fresh)
     """
-    # Handle "LATEST" keyword for convenience
+    # Handle checkpoint-root pointers such as LATEST and LOWEST_VAL.
+    if os.path.sep not in restore_from and not os.path.isabs(restore_from):
+        pointed_checkpoint = _read_checkpoint_pointer(checkpoint_dir, restore_from)
+        if pointed_checkpoint is not None and pointed_checkpoint.is_dir():
+            return os.fspath(pointed_checkpoint)
     if restore_from.upper() == "LATEST":
         return _find_latest_checkpoint(checkpoint_dir)
 
@@ -536,15 +540,19 @@ class BaseRecipe:
 
         # Update latest symlink according to sync/async behavior
         if getattr(self.checkpointer.config, "is_async", False):
-            # Async: defer symlink until the next call (after async_wait completes)
+            # Async: defer symlink publication until the next call (after async_wait completes).
+            # Store a best-publish record on every rank so _complete_pending_checkpoint has a uniform
+            # barrier sequence even when validation metrics are only present on rank 0.
             setattr(self, "_last_pending_checkpoint_dir", path)
-            # Defer best symlink update similarly, capturing the metric used for comparison
-            if best_val_metric is not None:
-                setattr(
-                    self,
-                    "_last_pending_best_checkpoint_info",
-                    {"path": path, "val": float(best_val_metric), "metric_key": best_metric_name},
-                )
+            setattr(
+                self,
+                "_last_pending_best_checkpoint_info",
+                {
+                    "path": path,
+                    "val": float(best_val_metric) if best_val_metric is not None else None,
+                    "metric_key": best_metric_name,
+                },
+            )
         else:
             # Sync: update immediately
             if is_rank_0:
@@ -597,9 +605,15 @@ class BaseRecipe:
     def _finalize_pending_checkpoint(self) -> None:
         """Wait for the final async checkpoint, publish it, and apply retention."""
         checkpointer = getattr(self, "checkpointer", None)
-        if checkpointer is None or not checkpointer.config.enabled:
+        if checkpointer is None:
             return
-        checkpointer.async_wait()
+        config = getattr(checkpointer, "config", None)
+        if config is not None and not getattr(config, "enabled", True):
+            return
+        async_wait = getattr(checkpointer, "async_wait", None)
+        if async_wait is None:
+            return
+        async_wait()
         self._complete_pending_checkpoint()
 
     def _update_checkpoint_symlink(self, link_name: str, target_dir: str) -> None:
@@ -988,18 +1002,21 @@ class BaseRecipe:
             "Max train steps": step_scheduler.max_steps,
         }
         checkpoint_config = getattr(getattr(self, "checkpointer", None), "config", None)
-        if checkpoint_config is not None and hasattr(checkpoint_config, "max_recent_checkpoints"):
-            max_recent_checkpoints = checkpoint_config.max_recent_checkpoints
-            if max_recent_checkpoints is None:
-                attrs["Checkpoint retention"] = (
-                    "disabled; keeping all checkpoints (checkpoint.max_recent_checkpoints=None)"
-                )
-            else:
-                attrs["Checkpoint retention"] = (
-                    f"keeping the most recent {max_recent_checkpoints} checkpoint(s), "
-                    "plus pointer-protected checkpoints "
-                    f"(checkpoint.max_recent_checkpoints={max_recent_checkpoints})"
-                )
+        if checkpoint_config is not None:
+            if not getattr(checkpoint_config, "enabled", True):
+                attrs["Checkpoint retention"] = "inactive because checkpointing is disabled"
+            elif hasattr(checkpoint_config, "max_recent_checkpoints"):
+                max_recent_checkpoints = checkpoint_config.max_recent_checkpoints
+                if max_recent_checkpoints is None:
+                    attrs["Checkpoint retention"] = (
+                        "disabled; keeping all checkpoints (checkpoint.max_recent_checkpoints=None)"
+                    )
+                else:
+                    attrs["Checkpoint retention"] = (
+                        f"keeping the most recent {max_recent_checkpoints} checkpoint(s), "
+                        "plus pointer-protected checkpoints "
+                        f"(checkpoint.max_recent_checkpoints={max_recent_checkpoints})"
+                    )
         logging.info("Step scheduler:")
         for k, v in attrs.items():
             logging.info(f"- {k}: {v}")

--- a/nemo_automodel/recipes/base_recipe.py
+++ b/nemo_automodel/recipes/base_recipe.py
@@ -427,12 +427,13 @@ class BaseRecipe:
 
         is_dist_initialized = torch.distributed.is_initialized()
         is_rank_0 = not is_dist_initialized or torch.distributed.get_rank() == 0
+        process_group = getattr(getattr(self, "mesh_context", None), "process_group", None)
         if prev_pending is not None:
             if is_rank_0:
                 self._update_latest_symlink(prev_pending)
             setattr(self, "_last_pending_checkpoint_dir", None)
             if is_dist_initialized:
-                torch.distributed.barrier()
+                _dist_barrier(process_group)
 
         if prev_best_pending is not None:
             if is_rank_0 and prev_best_pending.get("val") is not None:
@@ -443,12 +444,12 @@ class BaseRecipe:
                 )
             setattr(self, "_last_pending_best_checkpoint_info", None)
             if is_dist_initialized:
-                torch.distributed.barrier()
+                _dist_barrier(process_group)
 
         if is_rank_0:
             self._prune_old_checkpoints()
         if is_dist_initialized:
-            torch.distributed.barrier()
+            _dist_barrier(process_group)
 
     def _finalize_pending_checkpoint(self) -> None:
         """Wait for the final async checkpoint, publish it, and apply retention."""

--- a/nemo_automodel/recipes/diffusion/train.py
+++ b/nemo_automodel/recipes/diffusion/train.py
@@ -1277,10 +1277,7 @@ class TrainDiffusionRecipe(BaseRecipe):
             if wandb.run is not None:
                 wandb.finish()
 
-        self._finalize_pending_checkpoint()
-        checkpointer = getattr(self, "checkpointer", None)
-        if checkpointer is not None:
-            checkpointer.close()
+        self._finalize_and_close_checkpointer()
         logging.info("[INFO] Training complete!")
 
     def _get_dp_rank(self, include_cp: bool = False) -> int:

--- a/nemo_automodel/recipes/diffusion/train.py
+++ b/nemo_automodel/recipes/diffusion/train.py
@@ -1278,7 +1278,9 @@ class TrainDiffusionRecipe(BaseRecipe):
                 wandb.finish()
 
         self._finalize_pending_checkpoint()
-        self.checkpointer.close()
+        checkpointer = getattr(self, "checkpointer", None)
+        if checkpointer is not None:
+            checkpointer.close()
         logging.info("[INFO] Training complete!")
 
     def _get_dp_rank(self, include_cp: bool = False) -> int:

--- a/nemo_automodel/recipes/diffusion/train.py
+++ b/nemo_automodel/recipes/diffusion/train.py
@@ -29,7 +29,7 @@ from huggingface_hub.constants import HF_HUB_CACHE
 from torch.distributed.fsdp import CPUOffloadPolicy, MixedPrecisionPolicy
 
 from nemo_automodel._diffusers.auto_diffusion_pipeline import NeMoAutoDiffusionPipeline
-from nemo_automodel.components.checkpoint.checkpointing import CheckpointingConfig
+from nemo_automodel.components.checkpoint.config import CheckpointingConfig
 from nemo_automodel.components.config.loader import ConfigNode
 from nemo_automodel.components.distributed.init_utils import initialize_distributed
 from nemo_automodel.components.flow_matching.pipeline import FlowMatchingPipeline, create_adapter

--- a/nemo_automodel/recipes/diffusion/train.py
+++ b/nemo_automodel/recipes/diffusion/train.py
@@ -989,6 +989,7 @@ class TrainDiffusionRecipe(BaseRecipe):
             is_peft=self.peft_cfg is not None,
             model_state_dict_keys=model_state_dict_keys,
             diffusers_compatible=checkpoint_cfg.get("diffusers_compatible", False),
+            max_recent_checkpoints=checkpoint_cfg.get("max_recent_checkpoints", 2),
         )
         self.restore_from = checkpoint_cfg.get("restore_from", None)
         self.checkpointer = self.checkpoint_config.build(
@@ -1274,6 +1275,8 @@ class TrainDiffusionRecipe(BaseRecipe):
             if wandb.run is not None:
                 wandb.finish()
 
+        self._finalize_pending_checkpoint()
+        self.checkpointer.close()
         logging.info("[INFO] Training complete!")
 
     def _get_dp_rank(self, include_cp: bool = False) -> int:

--- a/nemo_automodel/recipes/diffusion/train.py
+++ b/nemo_automodel/recipes/diffusion/train.py
@@ -988,9 +988,11 @@ class TrainDiffusionRecipe(BaseRecipe):
             consolidation_timeout_minutes=checkpoint_cfg.get("consolidation_timeout_minutes", 30),
             is_peft=self.peft_cfg is not None,
             model_state_dict_keys=model_state_dict_keys,
+            is_async=checkpoint_cfg.get("is_async", False),
             diffusers_compatible=checkpoint_cfg.get("diffusers_compatible", False),
             max_recent_checkpoints=checkpoint_cfg.get("max_recent_checkpoints", None),
         )
+        self._log_checkpoint_retention_policy(self.checkpoint_config)
         self.restore_from = checkpoint_cfg.get("restore_from", None)
         self.checkpointer = self.checkpoint_config.build(
             dp_rank=self._get_dp_rank(include_cp=True),

--- a/nemo_automodel/recipes/diffusion/train.py
+++ b/nemo_automodel/recipes/diffusion/train.py
@@ -989,7 +989,7 @@ class TrainDiffusionRecipe(BaseRecipe):
             is_peft=self.peft_cfg is not None,
             model_state_dict_keys=model_state_dict_keys,
             diffusers_compatible=checkpoint_cfg.get("diffusers_compatible", False),
-            max_recent_checkpoints=checkpoint_cfg.get("max_recent_checkpoints", 2),
+            max_recent_checkpoints=checkpoint_cfg.get("max_recent_checkpoints", None),
         )
         self.restore_from = checkpoint_cfg.get("restore_from", None)
         self.checkpointer = self.checkpoint_config.build(

--- a/nemo_automodel/recipes/llm/kd.py
+++ b/nemo_automodel/recipes/llm/kd.py
@@ -1053,8 +1053,7 @@ class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNe
         self.metric_logger_train.close()
         for v in self.metric_logger_valid.values():
             v.close()
-        self._finalize_pending_checkpoint()
-        self.checkpointer.close()
+        self._finalize_and_close_checkpointer()
 
     @torch.no_grad()
     def _run_validation_epoch(self, val_dataloader):

--- a/nemo_automodel/recipes/llm/kd.py
+++ b/nemo_automodel/recipes/llm/kd.py
@@ -1053,6 +1053,7 @@ class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNe
         self.metric_logger_train.close()
         for v in self.metric_logger_valid.values():
             v.close()
+        self._finalize_pending_checkpoint()
         self.checkpointer.close()
 
     @torch.no_grad()

--- a/nemo_automodel/recipes/llm/train_dflash.py
+++ b/nemo_automodel/recipes/llm/train_dflash.py
@@ -611,7 +611,8 @@ class TrainDFlashRecipe(BaseRecipe):
         # (and, being seeded per dp_rank, hold identical rng state), so every peer would
         # torch.save the same rng_dp_rank_N.pt and race on a shared FS; let only the
         # first cp peer write it.
-        if self.cp_mesh is None or self.cp_mesh.get_local_rank() == 0:
+        cp_mesh = getattr(self, "cp_mesh", None)
+        if cp_mesh is None or cp_mesh.get_local_rank() == 0:
             self.checkpointer.save_on_dp_ranks(self.rng, "rng", path)
 
         if is_rank_0:

--- a/nemo_automodel/recipes/llm/train_dflash.py
+++ b/nemo_automodel/recipes/llm/train_dflash.py
@@ -45,6 +45,7 @@ from nemo_automodel.components.checkpoint.checkpointing import (
     CheckpointingConfig,
     save_config,
 )
+from nemo_automodel.components.checkpoint.utils import _find_latest_checkpoint, _resolve_restore_from_to_ckpt_dir
 from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
 from nemo_automodel.components.datasets.llm.eagle3 import build_eagle3_dataloader
 from nemo_automodel.components.distributed.init_utils import initialize_distributed
@@ -57,12 +58,7 @@ from nemo_automodel.components.speculative.dflash.registry import resolve_dflash
 from nemo_automodel.components.speculative.dflash.target import HFDFlashTargetModel
 from nemo_automodel.components.training.rng import StatefulRNG
 from nemo_automodel.recipes._dist_utils import create_distributed_setup_from_config
-from nemo_automodel.recipes.base_recipe import (
-    BaseRecipe,
-    _find_latest_checkpoint,
-    _is_checkpoint_model_config_compatible,
-    _resolve_restore_from_to_ckpt_dir,
-)
+from nemo_automodel.recipes.base_recipe import BaseRecipe, _is_checkpoint_model_config_compatible
 from nemo_automodel.recipes.llm._spec_train_utils import (
     apply_draft_compile,
     apply_draft_fp8,
@@ -554,6 +550,7 @@ class TrainDFlashRecipe(BaseRecipe):
         self.checkpointer = Checkpointer(
             config=self.checkpoint_config, dp_rank=dp_rank, tp_rank=0, pp_rank=0, moe_mesh=None
         )
+        self._log_checkpoint_retention_policy(self.checkpoint_config)
 
     def _module(self):
         return (
@@ -577,29 +574,14 @@ class TrainDFlashRecipe(BaseRecipe):
             return
         self.checkpointer.async_wait()
 
-        prev_pending = getattr(self, "_last_pending_checkpoint_dir", None)
-        prev_best_pending = getattr(self, "_last_pending_best_checkpoint_info", None)
-
         ckpt_root = self.checkpoint_config.checkpoint_dir
         path = os.path.join(str(ckpt_root), f"epoch_{epoch}_step_{step}")
         is_dist_initialized = dist.is_initialized()
         is_rank_0 = (not is_dist_initialized) or dist.get_rank() == 0
-        best_val_metric = (
-            val_loss.get(next(iter(val_loss.keys())) if len(val_loss) == 1 else best_metric_key) if val_loss else None
-        )
+        best_metric_name = next(iter(val_loss.keys())) if val_loss and len(val_loss) == 1 else best_metric_key
+        best_val_metric = val_loss.get(best_metric_name) if val_loss else None
 
-        if prev_pending is not None:
-            if is_rank_0:
-                self._update_latest_symlink(prev_pending)
-            setattr(self, "_last_pending_checkpoint_dir", None)
-            if is_dist_initialized:
-                dist.barrier()
-        if prev_best_pending is not None:
-            if is_rank_0 and prev_best_pending.get("val") is not None:
-                self._update_best_symlink(prev_best_pending["path"], float(prev_best_pending["val"]))
-            setattr(self, "_last_pending_best_checkpoint_info", None)
-            if is_dist_initialized:
-                dist.barrier()
+        self._complete_pending_checkpoint()
 
         if is_rank_0:
             if os.path.exists(path):
@@ -643,13 +625,21 @@ class TrainDFlashRecipe(BaseRecipe):
 
         if getattr(self.checkpointer.config, "is_async", False):
             setattr(self, "_last_pending_checkpoint_dir", path)
-            if best_val_metric is not None:
-                setattr(self, "_last_pending_best_checkpoint_info", {"path": path, "val": float(best_val_metric)})
+            setattr(
+                self,
+                "_last_pending_best_checkpoint_info",
+                {
+                    "path": path,
+                    "val": float(best_val_metric) if best_val_metric is not None else None,
+                    "metric_key": best_metric_name,
+                },
+            )
         else:
             if is_rank_0:
                 self._update_latest_symlink(path)
                 if best_val_metric is not None:
-                    self._update_best_symlink(path, float(best_val_metric))
+                    self._update_best_symlink(path, float(best_val_metric), best_metric_name)
+                self._prune_old_checkpoints()
             if is_dist_initialized:
                 dist.barrier()
 
@@ -991,6 +981,9 @@ class TrainDFlashRecipe(BaseRecipe):
 
             self._maybe_save_final_checkpoint(self.num_epochs)
             self._finalize_pending_checkpoint()
+            checkpointer = getattr(self, "checkpointer", None)
+            if checkpointer is not None:
+                checkpointer.close()
         finally:
             if pbar is not None:
                 pbar.close()

--- a/nemo_automodel/recipes/llm/train_dflash.py
+++ b/nemo_automodel/recipes/llm/train_dflash.py
@@ -45,7 +45,7 @@ from nemo_automodel.components.checkpoint.checkpointing import (
     CheckpointingConfig,
     save_config,
 )
-from nemo_automodel.components.checkpoint.utils import _find_latest_checkpoint, _resolve_restore_from_to_ckpt_dir
+from nemo_automodel.components.checkpoint.utils import find_latest_checkpoint, resolve_restore_from_to_checkpoint_dir
 from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
 from nemo_automodel.components.datasets.llm.eagle3 import build_eagle3_dataloader
 from nemo_automodel.components.distributed.init_utils import initialize_distributed
@@ -666,7 +666,7 @@ class TrainDFlashRecipe(BaseRecipe):
         ckpt_root = self.checkpoint_config.checkpoint_dir
 
         if restore_from:
-            ckpt_dir = _resolve_restore_from_to_ckpt_dir(ckpt_root, restore_from)
+            ckpt_dir = resolve_restore_from_to_checkpoint_dir(ckpt_root, restore_from)
             if ckpt_dir is None:
                 if is_rank_0:
                     logger.warning("restore_from='LATEST' but no checkpoint found in %s", ckpt_root)
@@ -674,7 +674,7 @@ class TrainDFlashRecipe(BaseRecipe):
             if not os.path.isdir(ckpt_dir):
                 raise FileNotFoundError(f"Checkpoint directory does not exist: {ckpt_dir}")
         else:
-            auto = _find_latest_checkpoint(ckpt_root)
+            auto = find_latest_checkpoint(ckpt_root)
             if auto is None:
                 return
             ckpt_dir = str(auto)
@@ -981,10 +981,7 @@ class TrainDFlashRecipe(BaseRecipe):
                     self._log_saved_checkpoint("epoch", epoch_idx + 1, self.runtime.global_step)
 
             self._maybe_save_final_checkpoint(self.num_epochs)
-            self._finalize_pending_checkpoint()
-            checkpointer = getattr(self, "checkpointer", None)
-            if checkpointer is not None:
-                checkpointer.close()
+            self._finalize_and_close_checkpointer()
         finally:
             if pbar is not None:
                 pbar.close()

--- a/nemo_automodel/recipes/llm/train_dspark.py
+++ b/nemo_automodel/recipes/llm/train_dspark.py
@@ -45,7 +45,7 @@ from nemo_automodel.components.checkpoint.checkpointing import (
     CheckpointingConfig,
     save_config,
 )
-from nemo_automodel.components.checkpoint.utils import _find_latest_checkpoint, _resolve_restore_from_to_ckpt_dir
+from nemo_automodel.components.checkpoint.utils import find_latest_checkpoint, resolve_restore_from_to_checkpoint_dir
 from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
 from nemo_automodel.components.datasets.llm.dspark_cache import (
     DTYPE_MAP,
@@ -107,9 +107,7 @@ from nemo_automodel.components.utils.model_utils import VLM_INPUT_KEYS
 from nemo_automodel.recipes._dist_utils import create_distributed_setup_from_config, parse_distributed_section
 from nemo_automodel.recipes.base_recipe import (
     BaseRecipe,
-    _find_latest_checkpoint,
     _is_checkpoint_model_config_compatible,
-    _resolve_restore_from_to_ckpt_dir,
 )
 from nemo_automodel.recipes.llm._dspark_target_build import (
     build_deepseek_v4_target,
@@ -1210,7 +1208,7 @@ class TrainDSparkRecipe(BaseRecipe):
         ckpt_root = self.checkpoint_config.checkpoint_dir
 
         if restore_from:
-            ckpt_dir = _resolve_restore_from_to_ckpt_dir(ckpt_root, restore_from)
+            ckpt_dir = resolve_restore_from_to_checkpoint_dir(ckpt_root, restore_from)
             if ckpt_dir is None:
                 if is_rank_0:
                     logger.warning("restore_from='LATEST' but no checkpoint found in %s", ckpt_root)
@@ -1218,7 +1216,7 @@ class TrainDSparkRecipe(BaseRecipe):
             if not os.path.isdir(ckpt_dir):
                 raise FileNotFoundError(f"Checkpoint directory does not exist: {ckpt_dir}")
         else:
-            auto = _find_latest_checkpoint(ckpt_root)
+            auto = find_latest_checkpoint(ckpt_root)
             if auto is None:
                 return
             ckpt_dir = str(auto)
@@ -1573,10 +1571,7 @@ class TrainDSparkRecipe(BaseRecipe):
                     self._log_saved_checkpoint("epoch", epoch_idx + 1, self.runtime.global_step)
 
             self._maybe_save_final_checkpoint(self.num_epochs)
-            self._finalize_pending_checkpoint()
-            checkpointer = getattr(self, "checkpointer", None)
-            if checkpointer is not None:
-                checkpointer.close()
+            self._finalize_and_close_checkpointer()
         finally:
             if pbar is not None:
                 pbar.close()

--- a/nemo_automodel/recipes/llm/train_dspark.py
+++ b/nemo_automodel/recipes/llm/train_dspark.py
@@ -1154,7 +1154,8 @@ class TrainDSparkRecipe(BaseRecipe):
         # (and, being seeded per dp_rank, hold identical rng state), so every peer would
         # torch.save the same rng_dp_rank_N.pt and race on a shared FS; let only the
         # first cp peer write it.
-        if self.cp_mesh is None or self.cp_mesh.get_local_rank() == 0:
+        cp_mesh = getattr(self, "cp_mesh", None)
+        if cp_mesh is None or cp_mesh.get_local_rank() == 0:
             self.checkpointer.save_on_dp_ranks(self.rng, "rng", path)
 
         if is_rank_0:

--- a/nemo_automodel/recipes/llm/train_dspark.py
+++ b/nemo_automodel/recipes/llm/train_dspark.py
@@ -45,6 +45,7 @@ from nemo_automodel.components.checkpoint.checkpointing import (
     CheckpointingConfig,
     save_config,
 )
+from nemo_automodel.components.checkpoint.utils import _find_latest_checkpoint, _resolve_restore_from_to_ckpt_dir
 from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
 from nemo_automodel.components.datasets.llm.dspark_cache import (
     DTYPE_MAP,
@@ -1086,6 +1087,7 @@ class TrainDSparkRecipe(BaseRecipe):
         self.checkpointer = Checkpointer(
             config=self.checkpoint_config, dp_rank=dp_rank, tp_rank=0, pp_rank=0, moe_mesh=None
         )
+        self._log_checkpoint_retention_policy(self.checkpoint_config)
 
     def _module(self):
         return (
@@ -1115,29 +1117,14 @@ class TrainDSparkRecipe(BaseRecipe):
             return
         self.checkpointer.async_wait()
 
-        prev_pending = getattr(self, "_last_pending_checkpoint_dir", None)
-        prev_best_pending = getattr(self, "_last_pending_best_checkpoint_info", None)
-
         ckpt_root = self.checkpoint_config.checkpoint_dir
         path = os.path.join(str(ckpt_root), f"epoch_{epoch}_step_{step}")
         is_dist_initialized = dist.is_initialized()
         is_rank_0 = (not is_dist_initialized) or dist.get_rank() == 0
-        best_val_metric = (
-            val_loss.get(next(iter(val_loss.keys())) if len(val_loss) == 1 else best_metric_key) if val_loss else None
-        )
+        best_metric_name = next(iter(val_loss.keys())) if val_loss and len(val_loss) == 1 else best_metric_key
+        best_val_metric = val_loss.get(best_metric_name) if val_loss else None
 
-        if prev_pending is not None:
-            if is_rank_0:
-                self._update_latest_symlink(prev_pending)
-            setattr(self, "_last_pending_checkpoint_dir", None)
-            if is_dist_initialized:
-                dist.barrier()
-        if prev_best_pending is not None:
-            if is_rank_0 and prev_best_pending.get("val") is not None:
-                self._update_best_symlink(prev_best_pending["path"], float(prev_best_pending["val"]))
-            setattr(self, "_last_pending_best_checkpoint_info", None)
-            if is_dist_initialized:
-                dist.barrier()
+        self._complete_pending_checkpoint()
 
         if is_rank_0:
             if os.path.exists(path):
@@ -1181,13 +1168,21 @@ class TrainDSparkRecipe(BaseRecipe):
 
         if getattr(self.checkpointer.config, "is_async", False):
             setattr(self, "_last_pending_checkpoint_dir", path)
-            if best_val_metric is not None:
-                setattr(self, "_last_pending_best_checkpoint_info", {"path": path, "val": float(best_val_metric)})
+            setattr(
+                self,
+                "_last_pending_best_checkpoint_info",
+                {
+                    "path": path,
+                    "val": float(best_val_metric) if best_val_metric is not None else None,
+                    "metric_key": best_metric_name,
+                },
+            )
         else:
             if is_rank_0:
                 self._update_latest_symlink(path)
                 if best_val_metric is not None:
-                    self._update_best_symlink(path, float(best_val_metric))
+                    self._update_best_symlink(path, float(best_val_metric), best_metric_name)
+                self._prune_old_checkpoints()
             if is_dist_initialized:
                 dist.barrier()
 
@@ -1578,6 +1573,9 @@ class TrainDSparkRecipe(BaseRecipe):
 
             self._maybe_save_final_checkpoint(self.num_epochs)
             self._finalize_pending_checkpoint()
+            checkpointer = getattr(self, "checkpointer", None)
+            if checkpointer is not None:
+                checkpointer.close()
         finally:
             if pbar is not None:
                 pbar.close()

--- a/nemo_automodel/recipes/llm/train_eagle1.py
+++ b/nemo_automodel/recipes/llm/train_eagle1.py
@@ -868,7 +868,9 @@ class TrainEagle1Recipe(BaseRecipe):
 
             self._maybe_save_final_checkpoint(self.num_epochs)
             self._finalize_pending_checkpoint()
-            self.checkpointer.close()
+            checkpointer = getattr(self, "checkpointer", None)
+            if checkpointer is not None:
+                checkpointer.close()
         finally:
             if pbar is not None:
                 pbar.close()

--- a/nemo_automodel/recipes/llm/train_eagle1.py
+++ b/nemo_automodel/recipes/llm/train_eagle1.py
@@ -35,6 +35,7 @@ from nemo_automodel.components.checkpoint.checkpointing import (
     CheckpointingConfig,
     save_config,
 )
+from nemo_automodel.components.checkpoint.utils import _find_latest_checkpoint, _resolve_restore_from_to_ckpt_dir
 from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
 from nemo_automodel.components.datasets.llm.eagle3 import build_eagle3_dataloader
 from nemo_automodel.components.distributed.init_utils import initialize_distributed
@@ -47,12 +48,7 @@ from nemo_automodel.components.speculative.eagle.target_v12 import HFEagleTarget
 from nemo_automodel.components.training.rng import StatefulRNG
 from nemo_automodel.components.utils.model_utils import print_trainable_parameters
 from nemo_automodel.recipes._dist_utils import create_distributed_setup_from_config
-from nemo_automodel.recipes.base_recipe import (
-    BaseRecipe,
-    _find_latest_checkpoint,
-    _is_checkpoint_model_config_compatible,
-    _resolve_restore_from_to_ckpt_dir,
-)
+from nemo_automodel.recipes.base_recipe import BaseRecipe, _is_checkpoint_model_config_compatible
 from nemo_automodel.recipes.llm._spec_train_utils import (
     apply_draft_compile,
     apply_draft_fp8,
@@ -406,6 +402,7 @@ class TrainEagle1Recipe(BaseRecipe):
             pp_rank=0,
             moe_mesh=None,
         )
+        self._log_checkpoint_retention_policy(self.checkpoint_config)
 
     def _module(self):
         return (

--- a/nemo_automodel/recipes/llm/train_eagle1.py
+++ b/nemo_automodel/recipes/llm/train_eagle1.py
@@ -438,30 +438,14 @@ class TrainEagle1Recipe(BaseRecipe):
             return
         self.checkpointer.async_wait()
 
-        prev_pending = getattr(self, "_last_pending_checkpoint_dir", None)
-        prev_best_pending = getattr(self, "_last_pending_best_checkpoint_info", None)
+        self._complete_pending_checkpoint()
 
         ckpt_root = self.checkpoint_config.checkpoint_dir
         path = os.path.join(str(ckpt_root), f"epoch_{epoch}_step_{step}")
         is_dist_initialized = dist.is_initialized()
         is_rank_0 = (not is_dist_initialized) or dist.get_rank() == 0
-        best_val_metric = (
-            val_loss.get(next(iter(val_loss.keys())) if len(val_loss) == 1 else best_metric_key) if val_loss else None
-        )
-
-        if prev_pending is not None:
-            if is_rank_0:
-                self._update_latest_symlink(prev_pending)
-            setattr(self, "_last_pending_checkpoint_dir", None)
-            if is_dist_initialized:
-                dist.barrier()
-
-        if prev_best_pending is not None:
-            if is_rank_0 and prev_best_pending.get("val") is not None:
-                self._update_best_symlink(prev_best_pending["path"], float(prev_best_pending["val"]))
-            setattr(self, "_last_pending_best_checkpoint_info", None)
-            if is_dist_initialized:
-                dist.barrier()
+        best_metric_name = next(iter(val_loss.keys())) if val_loss and len(val_loss) == 1 else best_metric_key
+        best_val_metric = val_loss.get(best_metric_name) if val_loss else None
 
         if is_rank_0:
             if os.path.exists(path):
@@ -501,12 +485,17 @@ class TrainEagle1Recipe(BaseRecipe):
         if getattr(self.checkpointer.config, "is_async", False):
             setattr(self, "_last_pending_checkpoint_dir", path)
             if best_val_metric is not None:
-                setattr(self, "_last_pending_best_checkpoint_info", {"path": path, "val": float(best_val_metric)})
+                setattr(
+                    self,
+                    "_last_pending_best_checkpoint_info",
+                    {"path": path, "val": float(best_val_metric), "metric_key": best_metric_name},
+                )
         else:
             if is_rank_0:
                 self._update_latest_symlink(path)
                 if best_val_metric is not None:
-                    self._update_best_symlink(path, float(best_val_metric))
+                    self._update_best_symlink(path, float(best_val_metric), best_metric_name)
+                self._prune_old_checkpoints()
             if is_dist_initialized:
                 dist.barrier()
 
@@ -879,6 +868,7 @@ class TrainEagle1Recipe(BaseRecipe):
 
             self._maybe_save_final_checkpoint(self.num_epochs)
             self._finalize_pending_checkpoint()
+            self.checkpointer.close()
         finally:
             if pbar is not None:
                 pbar.close()

--- a/nemo_automodel/recipes/llm/train_eagle1.py
+++ b/nemo_automodel/recipes/llm/train_eagle1.py
@@ -484,12 +484,15 @@ class TrainEagle1Recipe(BaseRecipe):
 
         if getattr(self.checkpointer.config, "is_async", False):
             setattr(self, "_last_pending_checkpoint_dir", path)
-            if best_val_metric is not None:
-                setattr(
-                    self,
-                    "_last_pending_best_checkpoint_info",
-                    {"path": path, "val": float(best_val_metric), "metric_key": best_metric_name},
-                )
+            setattr(
+                self,
+                "_last_pending_best_checkpoint_info",
+                {
+                    "path": path,
+                    "val": float(best_val_metric) if best_val_metric is not None else None,
+                    "metric_key": best_metric_name,
+                },
+            )
         else:
             if is_rank_0:
                 self._update_latest_symlink(path)

--- a/nemo_automodel/recipes/llm/train_eagle1.py
+++ b/nemo_automodel/recipes/llm/train_eagle1.py
@@ -35,7 +35,7 @@ from nemo_automodel.components.checkpoint.checkpointing import (
     CheckpointingConfig,
     save_config,
 )
-from nemo_automodel.components.checkpoint.utils import _find_latest_checkpoint, _resolve_restore_from_to_ckpt_dir
+from nemo_automodel.components.checkpoint.utils import find_latest_checkpoint, resolve_restore_from_to_checkpoint_dir
 from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
 from nemo_automodel.components.datasets.llm.eagle3 import build_eagle3_dataloader
 from nemo_automodel.components.distributed.init_utils import initialize_distributed
@@ -580,7 +580,7 @@ class TrainEagle1Recipe(BaseRecipe):
         ckpt_root = self.checkpoint_config.checkpoint_dir
 
         if restore_from:
-            ckpt_dir = _resolve_restore_from_to_ckpt_dir(ckpt_root, restore_from)
+            ckpt_dir = resolve_restore_from_to_checkpoint_dir(ckpt_root, restore_from)
             if ckpt_dir is None:
                 if is_rank_0:
                     logger.warning("restore_from='LATEST' but no checkpoint found in %s", ckpt_root)
@@ -588,7 +588,7 @@ class TrainEagle1Recipe(BaseRecipe):
             if not os.path.isdir(ckpt_dir):
                 raise FileNotFoundError(f"Checkpoint directory does not exist: {ckpt_dir}")
         else:
-            auto = _find_latest_checkpoint(ckpt_root)
+            auto = find_latest_checkpoint(ckpt_root)
             if auto is None:
                 return
             ckpt_dir = str(auto)
@@ -867,10 +867,7 @@ class TrainEagle1Recipe(BaseRecipe):
                     )
 
             self._maybe_save_final_checkpoint(self.num_epochs)
-            self._finalize_pending_checkpoint()
-            checkpointer = getattr(self, "checkpointer", None)
-            if checkpointer is not None:
-                checkpointer.close()
+            self._finalize_and_close_checkpointer()
         finally:
             if pbar is not None:
                 pbar.close()

--- a/nemo_automodel/recipes/llm/train_eagle3.py
+++ b/nemo_automodel/recipes/llm/train_eagle3.py
@@ -1401,30 +1401,14 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
             return
         self.checkpointer.async_wait()
 
-        prev_pending = getattr(self, "_last_pending_checkpoint_dir", None)
-        prev_best_pending = getattr(self, "_last_pending_best_checkpoint_info", None)
+        self._complete_pending_checkpoint()
 
         ckpt_root = self.checkpoint_config.checkpoint_dir
         path = os.path.join(str(ckpt_root), f"epoch_{epoch}_step_{step}")
         is_dist_initialized = dist.is_initialized()
         is_rank_0 = (not is_dist_initialized) or dist.get_rank() == 0
-        best_val_metric = (
-            val_loss.get(next(iter(val_loss.keys())) if len(val_loss) == 1 else best_metric_key) if val_loss else None
-        )
-
-        if prev_pending is not None:
-            if is_rank_0:
-                self._update_latest_symlink(prev_pending)
-            setattr(self, "_last_pending_checkpoint_dir", None)
-            if is_dist_initialized:
-                dist.barrier()
-
-        if prev_best_pending is not None:
-            if is_rank_0 and prev_best_pending.get("val") is not None:
-                self._update_best_symlink(prev_best_pending["path"], float(prev_best_pending["val"]))
-            setattr(self, "_last_pending_best_checkpoint_info", None)
-            if is_dist_initialized:
-                dist.barrier()
+        best_metric_name = next(iter(val_loss.keys())) if val_loss and len(val_loss) == 1 else best_metric_key
+        best_val_metric = val_loss.get(best_metric_name) if val_loss else None
 
         if is_rank_0:
             if os.path.exists(path):
@@ -1472,12 +1456,17 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
         if getattr(self.checkpointer.config, "is_async", False):
             setattr(self, "_last_pending_checkpoint_dir", path)
             if best_val_metric is not None:
-                setattr(self, "_last_pending_best_checkpoint_info", {"path": path, "val": float(best_val_metric)})
+                setattr(
+                    self,
+                    "_last_pending_best_checkpoint_info",
+                    {"path": path, "val": float(best_val_metric), "metric_key": best_metric_name},
+                )
         else:
             if is_rank_0:
                 self._update_latest_symlink(path)
                 if best_val_metric is not None:
-                    self._update_best_symlink(path, float(best_val_metric))
+                    self._update_best_symlink(path, float(best_val_metric), best_metric_name)
+                self._prune_old_checkpoints()
             if is_dist_initialized:
                 dist.barrier()
 
@@ -1738,6 +1727,9 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
         loop returns, and ``initialize_distributed`` already destroys it at
         process exit.
         """
+        if getattr(self, "checkpointer", None) is not None:
+            _best_effort("finalizing pending checkpoint", self._finalize_pending_checkpoint)
+            _best_effort("closing checkpointer", self.checkpointer.close)
         if getattr(self, "target_wrapper", None) is not None:
             _best_effort("closing target backend", self.target_wrapper.close)
         if getattr(self, "decode_eval_runner", None) is not None:

--- a/nemo_automodel/recipes/llm/train_eagle3.py
+++ b/nemo_automodel/recipes/llm/train_eagle3.py
@@ -38,6 +38,7 @@ from nemo_automodel.components.checkpoint.checkpointing import (
     load_hf_safetensors_state_dict,
     save_config,
 )
+from nemo_automodel.components.checkpoint.utils import _find_latest_checkpoint, _resolve_restore_from_to_ckpt_dir
 from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
 from nemo_automodel.components.datasets.llm.eagle3 import (
     build_eagle3_dataloader,
@@ -63,12 +64,7 @@ from nemo_automodel.components.speculative.regen_loop import RegenRunner, resolv
 from nemo_automodel.components.training.rng import StatefulRNG
 from nemo_automodel.components.utils.model_utils import print_trainable_parameters
 from nemo_automodel.recipes._dist_utils import create_distributed_setup_from_config
-from nemo_automodel.recipes.base_recipe import (
-    BaseRecipe,
-    _find_latest_checkpoint,
-    _is_checkpoint_model_config_compatible,
-    _resolve_restore_from_to_ckpt_dir,
-)
+from nemo_automodel.recipes.base_recipe import BaseRecipe, _is_checkpoint_model_config_compatible
 from nemo_automodel.recipes.llm._spec_train_utils import (
     apply_draft_compile,
     apply_draft_fp8,
@@ -1368,6 +1364,7 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
             pp_rank=0,
             moe_mesh=None,
         )
+        self._log_checkpoint_retention_policy(self.checkpoint_config)
 
     def _module(self):
         return (

--- a/nemo_automodel/recipes/llm/train_eagle3.py
+++ b/nemo_automodel/recipes/llm/train_eagle3.py
@@ -1455,12 +1455,15 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
 
         if getattr(self.checkpointer.config, "is_async", False):
             setattr(self, "_last_pending_checkpoint_dir", path)
-            if best_val_metric is not None:
-                setattr(
-                    self,
-                    "_last_pending_best_checkpoint_info",
-                    {"path": path, "val": float(best_val_metric), "metric_key": best_metric_name},
-                )
+            setattr(
+                self,
+                "_last_pending_best_checkpoint_info",
+                {
+                    "path": path,
+                    "val": float(best_val_metric) if best_val_metric is not None else None,
+                    "metric_key": best_metric_name,
+                },
+            )
         else:
             if is_rank_0:
                 self._update_latest_symlink(path)

--- a/nemo_automodel/recipes/llm/train_eagle3.py
+++ b/nemo_automodel/recipes/llm/train_eagle3.py
@@ -38,7 +38,7 @@ from nemo_automodel.components.checkpoint.checkpointing import (
     load_hf_safetensors_state_dict,
     save_config,
 )
-from nemo_automodel.components.checkpoint.utils import _find_latest_checkpoint, _resolve_restore_from_to_ckpt_dir
+from nemo_automodel.components.checkpoint.utils import find_latest_checkpoint, resolve_restore_from_to_checkpoint_dir
 from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
 from nemo_automodel.components.datasets.llm.eagle3 import (
     build_eagle3_dataloader,
@@ -1556,7 +1556,7 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
         ckpt_root = self.checkpoint_config.checkpoint_dir
 
         if restore_from:
-            ckpt_dir = _resolve_restore_from_to_ckpt_dir(ckpt_root, restore_from)
+            ckpt_dir = resolve_restore_from_to_checkpoint_dir(ckpt_root, restore_from)
             if ckpt_dir is None:
                 if is_rank_0:
                     logger.warning("restore_from='LATEST' but no checkpoint found in %s", ckpt_root)
@@ -1564,7 +1564,7 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
             if not os.path.isdir(ckpt_dir):
                 raise FileNotFoundError(f"Checkpoint directory does not exist: {ckpt_dir}")
         else:
-            auto = _find_latest_checkpoint(ckpt_root)
+            auto = find_latest_checkpoint(ckpt_root)
             if auto is None:
                 return
             ckpt_dir = str(auto)

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -947,8 +947,7 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
         for v in self.metric_logger_valid.values():
             v.close()
 
-        self._finalize_pending_checkpoint()
-        self.checkpointer.close()
+        self._finalize_and_close_checkpointer()
 
         # Mark the MLflow run KILLED if training exited via SIGTERM.
         if self.step_scheduler.sigterm_flag:

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -325,6 +325,7 @@ def build_model(
     return model
 
 
+
 def compute_trust_remote_code_from_model(cfg_model):
     """Compute the value of trust_remote_code based on the model configuration.
 
@@ -947,6 +948,7 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
         for v in self.metric_logger_valid.values():
             v.close()
 
+        self._finalize_pending_checkpoint()
         self.checkpointer.close()
 
         # Mark the MLflow run KILLED if training exited via SIGTERM.

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -325,7 +325,6 @@ def build_model(
     return model
 
 
-
 def compute_trust_remote_code_from_model(cfg_model):
     """Compute the value of trust_remote_code based on the model configuration.
 

--- a/nemo_automodel/recipes/llm/train_seq_cls.py
+++ b/nemo_automodel/recipes/llm/train_seq_cls.py
@@ -210,8 +210,7 @@ class TrainFinetuneRecipeForSequenceClassification(BaseRecipe):
 
         self.metric_logger_train.close()
         self.metric_logger_valid.close()
-        self._finalize_pending_checkpoint()
-        self.checkpointer.close()
+        self._finalize_and_close_checkpointer()
 
     def _run_train_optim_step(self, batches):
         model = self.model_parts[0]

--- a/nemo_automodel/recipes/llm/train_seq_cls.py
+++ b/nemo_automodel/recipes/llm/train_seq_cls.py
@@ -210,6 +210,7 @@ class TrainFinetuneRecipeForSequenceClassification(BaseRecipe):
 
         self.metric_logger_train.close()
         self.metric_logger_valid.close()
+        self._finalize_pending_checkpoint()
         self.checkpointer.close()
 
     def _run_train_optim_step(self, batches):

--- a/nemo_automodel/recipes/multimodal/finetune.py
+++ b/nemo_automodel/recipes/multimodal/finetune.py
@@ -968,6 +968,7 @@ class FinetuneRecipeForMultimodal(BaseRecipe):
         self.metric_logger_train.close()
         self.metric_logger_valid.close()
         if self.checkpointer is not None:
+            self._finalize_pending_checkpoint()
             self.checkpointer.close()
 
     # ------------------------------------------------------------------

--- a/nemo_automodel/recipes/multimodal/finetune.py
+++ b/nemo_automodel/recipes/multimodal/finetune.py
@@ -968,8 +968,7 @@ class FinetuneRecipeForMultimodal(BaseRecipe):
         self.metric_logger_train.close()
         self.metric_logger_valid.close()
         if self.checkpointer is not None:
-            self._finalize_pending_checkpoint()
-            self.checkpointer.close()
+            self._finalize_and_close_checkpointer()
 
     # ------------------------------------------------------------------
     # Logging helpers shared with FinetuneRecipeForVLM so BAGEL can keep its

--- a/nemo_automodel/recipes/retrieval/train_bi_encoder.py
+++ b/nemo_automodel/recipes/retrieval/train_bi_encoder.py
@@ -390,8 +390,7 @@ class TrainBiEncoderRecipe(BaseRecipe):
 
         self.metric_logger_train.close()
         self.metric_logger_valid.close()
-        self._finalize_pending_checkpoint()
-        self.checkpointer.close()
+        self._finalize_and_close_checkpointer()
 
     def _forward_backward_step(self, idx, batch, *, loss_buffer, num_batches, is_train: bool = True):
         """Forward and backward pass for a single micro-batch."""

--- a/nemo_automodel/recipes/retrieval/train_bi_encoder.py
+++ b/nemo_automodel/recipes/retrieval/train_bi_encoder.py
@@ -390,6 +390,7 @@ class TrainBiEncoderRecipe(BaseRecipe):
 
         self.metric_logger_train.close()
         self.metric_logger_valid.close()
+        self._finalize_pending_checkpoint()
         self.checkpointer.close()
 
     def _forward_backward_step(self, idx, batch, *, loss_buffer, num_batches, is_train: bool = True):

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -697,8 +697,7 @@ class FinetuneRecipeForVLM(BaseRecipe):
         self.metric_logger_train.close()
         self.metric_logger_valid.close()
 
-        self._finalize_pending_checkpoint()
-        self.checkpointer.close()
+        self._finalize_and_close_checkpointer()
 
         # Mark the MLflow run KILLED if training exited via SIGTERM.
         if self.step_scheduler.sigterm_flag:

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -697,6 +697,7 @@ class FinetuneRecipeForVLM(BaseRecipe):
         self.metric_logger_train.close()
         self.metric_logger_valid.close()
 
+        self._finalize_pending_checkpoint()
         self.checkpointer.close()
 
         # Mark the MLflow run KILLED if training exited via SIGTERM.

--- a/tests/unit_tests/checkpoint/test_checkpoint_config.py
+++ b/tests/unit_tests/checkpoint/test_checkpoint_config.py
@@ -118,6 +118,19 @@ class TestCheckpointingConfig:
         with pytest.raises(ValueError, match="consolidation_timeout_minutes must be greater than 0"):
             CheckpointingConfig(consolidation_timeout_minutes=timeout_minutes)
 
+    @pytest.mark.parametrize("invalid_value", [0, -1, True, False, 1.5, "2"])
+    def test_max_recent_checkpoints_rejects_invalid_values(self, invalid_value):
+        with pytest.raises(ValueError, match="checkpoint.max_recent_checkpoints must be unset or a positive integer"):
+            CheckpointingConfig(max_recent_checkpoints=invalid_value)
+
+    def test_max_recent_checkpoints_rejects_msc_checkpoint_dir(self):
+        with pytest.raises(ValueError, match="max_recent_checkpoints is only supported for local checkpoint"):
+            CheckpointingConfig(
+                checkpoint_dir="msc://bucket/checkpoints",
+                save_consolidated=False,
+                max_recent_checkpoints=1,
+            )
+
     def test_importable_from_checkpointing(self):
         """Verify backward compat: import from checkpointing.py still works."""
         from nemo_automodel.components.checkpoint.checkpointing import CheckpointingConfig as CkptCfg

--- a/tests/unit_tests/checkpoint/test_checkpoint_config.py
+++ b/tests/unit_tests/checkpoint/test_checkpoint_config.py
@@ -106,6 +106,7 @@ class TestCheckpointingConfig:
         assert cfg.diffusers_compatible is False
         assert cfg.best_metric_key == "default"
         assert cfg.consolidation_timeout_minutes == 30
+        assert cfg.max_recent_checkpoints is None
 
     def test_consolidation_timeout_override(self):
         cfg = CheckpointingConfig(consolidation_timeout_minutes=45)
@@ -137,6 +138,7 @@ class TestCheckpointingConfig:
         assert cfg.model_repo_id is None
         # model_cache_dir falls back to the HF hub cache when None.
         assert str(cfg.model_cache_dir) == str(hf_constants.HF_HUB_CACHE)
+        assert cfg.max_recent_checkpoints is None
 
     def test_explicit_cache_dir_is_kept(self):
         cfg = CheckpointingConfig(model_cache_dir="/tmp/cache")

--- a/tests/unit_tests/recipes/llm/test_eagle_checkpoint_resume.py
+++ b/tests/unit_tests/recipes/llm/test_eagle_checkpoint_resume.py
@@ -453,7 +453,7 @@ def test_eagle_async_checkpoint_retention_prunes_completed_window(tmp_path, reci
 
 
 def test_eagle1_final_checkpoint_saved_before_close(tmp_path):
-    """EAGLE-1 saves the final checkpoint before finalizing/closing async checkpointing."""
+    """EAGLE-1 saves the final checkpoint before finalizing and closing async checkpointing."""
     recipe = _bare_eagle1_recipe(tmp_path)
     recipe.num_epochs = 1
     recipe.grad_accumulation_steps = 1

--- a/tests/unit_tests/recipes/llm/test_eagle_checkpoint_resume.py
+++ b/tests/unit_tests/recipes/llm/test_eagle_checkpoint_resume.py
@@ -430,6 +430,22 @@ def test_eagle1_save_checkpoint_async_stores_best_pending(tmp_path):
     assert recipe._last_pending_best_checkpoint_info["val"] == 0.25
 
 
+@pytest.mark.parametrize("recipe_factory", [_bare_eagle1_recipe, _bare_eagle3_recipe])
+def test_eagle_async_checkpoint_retention_prunes_completed_window(tmp_path, recipe_factory):
+    """EAGLE async saves prune completed checkpoints during long-running jobs."""
+    recipe = recipe_factory(tmp_path)
+    recipe.checkpointer.config.is_async = True
+    recipe.checkpointer.config.max_recent_checkpoints = 1
+
+    for step in [1, 2, 3]:
+        recipe.runtime.global_step = step
+        recipe.save_checkpoint(epoch=0, step=step, train_loss=0.1 * step)
+
+    ckpt_root = Path(recipe.checkpoint_config.checkpoint_dir)
+    checkpoints = sorted(p.name for p in ckpt_root.glob("epoch_*_step_*") if p.is_dir())
+    assert checkpoints == ["epoch_0_step_2", "epoch_0_step_3"]
+
+
 # ---------------------------------------------------------------------------
 # save_checkpoint: FileExistsError when checkpoint dir already exists
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/recipes/llm/test_eagle_checkpoint_resume.py
+++ b/tests/unit_tests/recipes/llm/test_eagle_checkpoint_resume.py
@@ -462,6 +462,8 @@ def test_eagle1_final_checkpoint_saved_before_close(tmp_path):
     recipe.save_checkpoint_every_epoch = False
     recipe.train_dataloader = []
     recipe.runtime.global_step = 1
+    recipe.total_optim_steps = 1
+    recipe._make_progress_bar = lambda **kwargs: None
     events = []
 
     recipe._maybe_save_final_checkpoint = lambda completed_epochs: events.append(("final", completed_epochs)) or True

--- a/tests/unit_tests/recipes/llm/test_eagle_checkpoint_resume.py
+++ b/tests/unit_tests/recipes/llm/test_eagle_checkpoint_resume.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import json
 import os
 from dataclasses import dataclass
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -449,6 +450,28 @@ def test_eagle_async_checkpoint_retention_prunes_completed_window(tmp_path, reci
 # ---------------------------------------------------------------------------
 # save_checkpoint: FileExistsError when checkpoint dir already exists
 # ---------------------------------------------------------------------------
+
+
+def test_eagle1_final_checkpoint_saved_before_close(tmp_path):
+    """EAGLE-1 saves the final checkpoint before finalizing/closing async checkpointing."""
+    recipe = _bare_eagle1_recipe(tmp_path)
+    recipe.num_epochs = 1
+    recipe.grad_accumulation_steps = 1
+    recipe.max_grad_norm = 1.0
+    recipe.ckpt_every_steps = None
+    recipe.save_checkpoint_every_epoch = False
+    recipe.train_dataloader = []
+    recipe.runtime.global_step = 1
+    events = []
+
+    recipe._maybe_save_final_checkpoint = lambda completed_epochs: events.append(("final", completed_epochs)) or True
+    recipe._finalize_pending_checkpoint = lambda: events.append(("finalize", None))
+    recipe.checkpointer.close = lambda: events.append(("close", None))
+    recipe._run_eval = lambda: None
+
+    recipe.run_train_validation_loop()
+
+    assert events == [("final", 1), ("finalize", None), ("close", None)]
 
 
 def test_eagle1_save_checkpoint_raises_on_existing_dir(tmp_path):

--- a/tests/unit_tests/recipes/llm/test_finalize_pending_checkpoint.py
+++ b/tests/unit_tests/recipes/llm/test_finalize_pending_checkpoint.py
@@ -21,6 +21,8 @@ calls this once at the end to wait the write and flush the deferred symlinks.
 
 from types import SimpleNamespace
 
+import torch
+
 from nemo_automodel.recipes.llm.train_dflash import TrainDFlashRecipe
 
 
@@ -61,6 +63,20 @@ def test_finalize_with_no_pending_only_waits():
     assert r._waited == [1]
     assert r._latest == []
     assert r._best == []
+
+
+def test_finalize_uses_recipe_process_group(monkeypatch):
+    process_group = object()
+    barriers = []
+    r = _recipe(pending="/ckpt/epoch_1_step_10", best_pending=None)
+    r.mesh_context = SimpleNamespace(process_group=process_group)
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: 0)
+    monkeypatch.setattr(torch.distributed, "barrier", lambda group=None: barriers.append(group))
+
+    r._finalize_pending_checkpoint()
+
+    assert barriers == [process_group, process_group]
 
 
 def test_finalize_is_noop_when_checkpointing_disabled():

--- a/tests/unit_tests/recipes/llm/test_finalize_pending_checkpoint.py
+++ b/tests/unit_tests/recipes/llm/test_finalize_pending_checkpoint.py
@@ -21,6 +21,7 @@ calls this once at the end to wait the write and flush the deferred symlinks.
 
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 from nemo_automodel.recipes.llm.train_dflash import TrainDFlashRecipe
@@ -92,3 +93,20 @@ def test_finalize_is_noop_without_checkpointer():
     r = TrainDFlashRecipe.__new__(TrainDFlashRecipe)
     # No checkpointer attribute at all (e.g. checkpointing never set up).
     r._finalize_pending_checkpoint()  # must not raise
+
+
+def test_finalize_and_close_closes_checkpointer_when_finalization_fails():
+    events = []
+    r = TrainDFlashRecipe.__new__(TrainDFlashRecipe)
+    r.checkpointer = SimpleNamespace(close=lambda: events.append("close"))
+
+    def fail_finalize():
+        events.append("finalize")
+        raise RuntimeError("publication failed")
+
+    r._finalize_pending_checkpoint = fail_finalize
+
+    with pytest.raises(RuntimeError, match="publication failed"):
+        r._finalize_and_close_checkpointer()
+
+    assert events == ["finalize", "close"]

--- a/tests/unit_tests/recipes/llm/test_finalize_pending_checkpoint.py
+++ b/tests/unit_tests/recipes/llm/test_finalize_pending_checkpoint.py
@@ -36,8 +36,10 @@ def _recipe(enabled=True, pending=None, best_pending=None):
     r._last_pending_best_checkpoint_info = best_pending
     r._latest = []
     r._best = []
+    r._pruned = []
     r._update_latest_symlink = lambda d: r._latest.append(d)
-    r._update_best_symlink = lambda d, v: r._best.append((d, v))
+    r._update_best_symlink = lambda d, v, metric_key=None: r._best.append((d, v, metric_key))
+    r._prune_old_checkpoints = lambda: r._pruned.append(1)
     return r
 
 
@@ -46,7 +48,8 @@ def test_finalize_waits_and_flushes_pending_latest_and_best():
     r._finalize_pending_checkpoint()
     assert r._waited == [1]
     assert r._latest == ["/ckpt/epoch_1_step_10"]
-    assert r._best == [("/ckpt/epoch_1_step_10", 0.5)]
+    assert r._best == [("/ckpt/epoch_1_step_10", 0.5, None)]
+    assert r._pruned == [1]
     # pending cleared so a second finalize is a no-op
     assert r._last_pending_checkpoint_dir is None
     assert r._last_pending_best_checkpoint_info is None

--- a/tests/unit_tests/recipes/llm/test_train_dflash.py
+++ b/tests/unit_tests/recipes/llm/test_train_dflash.py
@@ -220,7 +220,7 @@ def test_build_checkpointer_logs_retention_policy(tmp_path, monkeypatch, caplog)
         TrainDFlashRecipe._build_checkpointer(obj, "target/repo")
 
     assert built
-    assert "Checkpoint retention: keeping the most recent 1 checkpoint(s)" in caplog.text
+    assert "Checkpoint retention: keeping the most recent 1 checkpoint directory" in caplog.text
 
 
 def test_run_train_validation_loop_finalizes_before_close():

--- a/tests/unit_tests/recipes/llm/test_train_dflash.py
+++ b/tests/unit_tests/recipes/llm/test_train_dflash.py
@@ -20,6 +20,7 @@ attributes each helper reads are populated -- mirroring the EAGLE recipe tests.
 
 from __future__ import annotations
 
+import logging
 import pathlib
 from datetime import timedelta
 from types import SimpleNamespace
@@ -126,6 +127,126 @@ def test_maybe_save_final_checkpoint(every, save_epoch, gs, should_fire):
     assert len(calls) == (1 if should_fire else 0)
     if should_fire:
         assert calls[0]["is_final_checkpoint"] is True
+
+
+def test_save_checkpoint_applies_retention_after_sync_save(tmp_path):
+    events = []
+    obj = TrainDFlashRecipe.__new__(TrainDFlashRecipe)
+    obj.checkpoint_config = SimpleNamespace(checkpoint_dir=str(tmp_path))
+    obj.checkpointer = SimpleNamespace(
+        config=SimpleNamespace(enabled=True, is_async=False),
+        async_wait=lambda: events.append("wait"),
+        save_model=lambda *args, **kwargs: events.append("save_model"),
+        save_optimizer=lambda *args, **kwargs: events.append("save_optimizer"),
+        save_on_dp_ranks=lambda *args, **kwargs: events.append("save_rng"),
+    )
+    obj._module = lambda: SimpleNamespace(draft_model=SimpleNamespace())
+    obj.tokenizer = None
+    obj.optimizer = SimpleNamespace()
+    obj.lr_scheduler = SimpleNamespace()
+    obj.rng = SimpleNamespace()
+    obj.runtime = SimpleNamespace(global_step=1)
+    obj.cfg = SimpleNamespace(raw_config={})
+    obj.block_size = 4
+    obj.mask_token_id = 99
+    obj.target_wrapper = SimpleNamespace(target_layer_ids=[0, 1])
+    obj._complete_pending_checkpoint = lambda: events.append("complete_pending")
+    obj._update_latest_symlink = lambda path: events.append(("latest", path))
+    obj._update_best_symlink = lambda path, val, metric_key=None: events.append(("best", path, val, metric_key))
+    obj._prune_old_checkpoints = lambda: events.append("prune")
+
+    TrainDFlashRecipe.save_checkpoint(obj, epoch=0, step=1, val_loss={"val_loss": 0.25})
+
+    assert events[0:2] == ["wait", "complete_pending"]
+    assert any(event[0] == "best" and event[3] == "val_loss" for event in events if isinstance(event, tuple))
+    assert "prune" in events
+
+
+def test_save_checkpoint_records_async_best_pending_info_without_metric(tmp_path):
+    events = []
+    obj = TrainDFlashRecipe.__new__(TrainDFlashRecipe)
+    obj.checkpoint_config = SimpleNamespace(checkpoint_dir=str(tmp_path))
+    obj.checkpointer = SimpleNamespace(
+        config=SimpleNamespace(enabled=True, is_async=True),
+        async_wait=lambda: events.append("wait"),
+        save_model=lambda *args, **kwargs: events.append("save_model"),
+        save_optimizer=lambda *args, **kwargs: events.append("save_optimizer"),
+        save_on_dp_ranks=lambda *args, **kwargs: events.append("save_rng"),
+    )
+    obj._module = lambda: SimpleNamespace(draft_model=SimpleNamespace())
+    obj.tokenizer = None
+    obj.optimizer = SimpleNamespace()
+    obj.lr_scheduler = SimpleNamespace()
+    obj.rng = SimpleNamespace()
+    obj.runtime = SimpleNamespace(global_step=1)
+    obj.cfg = SimpleNamespace(raw_config={})
+    obj.block_size = 4
+    obj.mask_token_id = 99
+    obj.target_wrapper = SimpleNamespace(target_layer_ids=[0, 1])
+    obj._complete_pending_checkpoint = lambda: events.append("complete_pending")
+
+    TrainDFlashRecipe.save_checkpoint(obj, epoch=0, step=1, best_metric_key="val_loss")
+
+    expected_path = str(tmp_path / "epoch_0_step_1")
+    assert events[0:2] == ["wait", "complete_pending"]
+    assert obj._last_pending_checkpoint_dir == expected_path
+    assert obj._last_pending_best_checkpoint_info == {
+        "path": expected_path,
+        "val": None,
+        "metric_key": "val_loss",
+    }
+
+
+def test_build_checkpointer_logs_retention_policy(tmp_path, monkeypatch, caplog):
+    built = []
+
+    class FakeCheckpointer:
+        def __init__(self, config, **kwargs):
+            self.config = config
+            built.append((config, kwargs))
+
+    monkeypatch.setattr(train_dflash, "Checkpointer", FakeCheckpointer)
+    obj = TrainDFlashRecipe.__new__(TrainDFlashRecipe)
+    obj.cfg = SimpleNamespace(
+        get=lambda key, default=None: {"checkpoint_dir": str(tmp_path), "max_recent_checkpoints": 1}
+        if key == "checkpoint"
+        else default
+    )
+    obj.output_dir = tmp_path
+    obj.draft_model = SimpleNamespace(state_dict=lambda: {"weight": torch.zeros(1)})
+    obj.dp_mesh = None
+
+    with caplog.at_level(logging.INFO):
+        TrainDFlashRecipe._build_checkpointer(obj, "target/repo")
+
+    assert built
+    assert "Checkpoint retention: keeping the most recent 1 checkpoint(s)" in caplog.text
+
+
+def test_run_train_validation_loop_finalizes_before_close():
+    events = []
+
+    class FakePbar:
+        def close(self):
+            events.append("pbar_close")
+
+    obj = TrainDFlashRecipe.__new__(TrainDFlashRecipe)
+    obj.trainer_module = SimpleNamespace(train=lambda: None)
+    obj.num_epochs = 1
+    obj._resume_epoch = 0
+    obj.dist_env = SimpleNamespace(is_main=False)
+    obj.total_optim_steps = 1
+    obj.runtime = SimpleNamespace(global_step=1)
+    obj.train_dataloader = []
+    obj._make_progress_bar = lambda **kwargs: FakePbar()
+    obj._run_eval = lambda: None
+    obj._maybe_save_final_checkpoint = lambda completed_epochs: events.append(("final", completed_epochs)) or True
+    obj._finalize_pending_checkpoint = lambda: events.append("finalize")
+    obj.checkpointer = SimpleNamespace(close=lambda: events.append("close"))
+
+    TrainDFlashRecipe.run_train_validation_loop(obj)
+
+    assert events == [("final", 1), "finalize", "close", "pbar_close"]
 
 
 def test_resolve_mask_token_id_prefers_explicit():

--- a/tests/unit_tests/recipes/llm/test_train_dspark_helpers.py
+++ b/tests/unit_tests/recipes/llm/test_train_dspark_helpers.py
@@ -220,7 +220,7 @@ def test_build_checkpointer_logs_retention_policy(tmp_path, monkeypatch, caplog)
         TrainDSparkRecipe._build_checkpointer(obj, "target/repo")
 
     assert built
-    assert "Checkpoint retention: keeping the most recent 1 checkpoint(s)" in caplog.text
+    assert "Checkpoint retention: keeping the most recent 1 checkpoint directory" in caplog.text
 
 
 def test_run_train_validation_loop_finalizes_before_close():

--- a/tests/unit_tests/recipes/llm/test_train_dspark_helpers.py
+++ b/tests/unit_tests/recipes/llm/test_train_dspark_helpers.py
@@ -40,6 +40,7 @@ Covers the recipe-level glue added for the DeepSeek-V4-Flash target:
 
 from __future__ import annotations
 
+import logging
 from types import SimpleNamespace
 
 import pytest
@@ -48,6 +49,7 @@ from transformers import Qwen3Config
 
 from nemo_automodel.components.config.loader import ConfigNode
 from nemo_automodel.components.datasets.llm.dspark_cache import write_manifest, write_shard, write_target_weights
+from nemo_automodel.recipes.llm import train_dspark
 from nemo_automodel.recipes.llm._dspark_target_build import (
     build_deepseek_v4_backend,
     gather_full_weight_module,
@@ -122,6 +124,129 @@ def test_draft_activation_checkpointing_false_is_noop():
     original_attention = draft.layers[0].self_attn
     _apply_draft_activation_checkpointing(draft, False)
     assert draft.layers[0].self_attn is original_attention
+
+
+def test_save_checkpoint_applies_retention_after_sync_save(tmp_path):
+    events = []
+    obj = TrainDSparkRecipe.__new__(TrainDSparkRecipe)
+    obj.checkpoint_config = SimpleNamespace(checkpoint_dir=str(tmp_path))
+    obj.checkpointer = SimpleNamespace(
+        config=SimpleNamespace(enabled=True, is_async=False),
+        async_wait=lambda: events.append("wait"),
+        save_model=lambda *args, **kwargs: events.append("save_model"),
+        save_optimizer=lambda *args, **kwargs: events.append("save_optimizer"),
+        save_on_dp_ranks=lambda *args, **kwargs: events.append("save_rng"),
+    )
+    obj._module = lambda: SimpleNamespace(draft_model=SimpleNamespace())
+    obj.tokenizer = None
+    obj.optimizer = SimpleNamespace()
+    obj.lr_scheduler = SimpleNamespace()
+    obj.rng = SimpleNamespace()
+    obj.runtime = SimpleNamespace(global_step=1)
+    obj.cfg = SimpleNamespace(raw_config={})
+    obj.block_size = 4
+    obj.num_anchors = 2
+    obj.mask_token_id = 99
+    obj.target_wrapper = SimpleNamespace(target_layer_ids=[0, 1])
+    obj._complete_pending_checkpoint = lambda: events.append("complete_pending")
+    obj._update_latest_symlink = lambda path: events.append(("latest", path))
+    obj._update_best_symlink = lambda path, val, metric_key=None: events.append(("best", path, val, metric_key))
+    obj._prune_old_checkpoints = lambda: events.append("prune")
+
+    TrainDSparkRecipe.save_checkpoint(obj, epoch=0, step=1, val_loss={"val_loss": 0.25})
+
+    assert events[0:2] == ["wait", "complete_pending"]
+    assert any(event[0] == "best" and event[3] == "val_loss" for event in events if isinstance(event, tuple))
+    assert "prune" in events
+
+
+def test_save_checkpoint_records_async_best_pending_info_without_metric(tmp_path):
+    events = []
+    obj = TrainDSparkRecipe.__new__(TrainDSparkRecipe)
+    obj.checkpoint_config = SimpleNamespace(checkpoint_dir=str(tmp_path))
+    obj.checkpointer = SimpleNamespace(
+        config=SimpleNamespace(enabled=True, is_async=True),
+        async_wait=lambda: events.append("wait"),
+        save_model=lambda *args, **kwargs: events.append("save_model"),
+        save_optimizer=lambda *args, **kwargs: events.append("save_optimizer"),
+        save_on_dp_ranks=lambda *args, **kwargs: events.append("save_rng"),
+    )
+    obj._module = lambda: SimpleNamespace(draft_model=SimpleNamespace())
+    obj.tokenizer = None
+    obj.optimizer = SimpleNamespace()
+    obj.lr_scheduler = SimpleNamespace()
+    obj.rng = SimpleNamespace()
+    obj.runtime = SimpleNamespace(global_step=1)
+    obj.cfg = SimpleNamespace(raw_config={})
+    obj.block_size = 4
+    obj.num_anchors = 2
+    obj.mask_token_id = 99
+    obj.target_wrapper = SimpleNamespace(target_layer_ids=[0, 1])
+    obj._complete_pending_checkpoint = lambda: events.append("complete_pending")
+
+    TrainDSparkRecipe.save_checkpoint(obj, epoch=0, step=1, best_metric_key="val_loss")
+
+    expected_path = str(tmp_path / "epoch_0_step_1")
+    assert events[0:2] == ["wait", "complete_pending"]
+    assert obj._last_pending_checkpoint_dir == expected_path
+    assert obj._last_pending_best_checkpoint_info == {
+        "path": expected_path,
+        "val": None,
+        "metric_key": "val_loss",
+    }
+
+
+def test_build_checkpointer_logs_retention_policy(tmp_path, monkeypatch, caplog):
+    built = []
+
+    class FakeCheckpointer:
+        def __init__(self, config, **kwargs):
+            self.config = config
+            built.append((config, kwargs))
+
+    monkeypatch.setattr(train_dspark, "Checkpointer", FakeCheckpointer)
+    obj = TrainDSparkRecipe.__new__(TrainDSparkRecipe)
+    obj.cfg = SimpleNamespace(
+        get=lambda key, default=None: {"checkpoint_dir": str(tmp_path), "max_recent_checkpoints": 1}
+        if key == "checkpoint"
+        else default
+    )
+    obj.output_dir = tmp_path
+    obj.draft_model = SimpleNamespace(state_dict=lambda: {"weight": torch.zeros(1)})
+
+    with caplog.at_level(logging.INFO):
+        TrainDSparkRecipe._build_checkpointer(obj, "target/repo")
+
+    assert built
+    assert "Checkpoint retention: keeping the most recent 1 checkpoint(s)" in caplog.text
+
+
+def test_run_train_validation_loop_finalizes_before_close():
+    events = []
+
+    class FakePbar:
+        def close(self):
+            events.append("pbar_close")
+
+    obj = TrainDSparkRecipe.__new__(TrainDSparkRecipe)
+    obj.trainer_module = SimpleNamespace(train=lambda: None)
+    obj.num_epochs = 1
+    obj._resume_epoch = 0
+    obj.dist_env = SimpleNamespace(is_main=False)
+    obj.total_optim_steps = 1
+    obj.runtime = SimpleNamespace(global_step=1)
+    obj.train_dataloader = []
+    obj._make_progress_bar = lambda **kwargs: FakePbar()
+    obj._run_eval = lambda: None
+    obj._maybe_save_final_checkpoint = lambda completed_epochs: events.append(("final", completed_epochs)) or True
+    obj._finalize_pending_checkpoint = lambda: events.append("finalize")
+    obj.checkpointer = SimpleNamespace(close=lambda: events.append("close"))
+    obj.metric_logger = None
+    obj._finish_wandb = lambda: events.append("wandb_finish")
+
+    TrainDSparkRecipe.run_train_validation_loop(obj)
+
+    assert events == [("final", 1), "finalize", "close", "pbar_close", "wandb_finish"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/recipes/llm/test_train_dspark_helpers.py
+++ b/tests/unit_tests/recipes/llm/test_train_dspark_helpers.py
@@ -237,6 +237,8 @@ def test_run_train_validation_loop_finalizes_before_close():
     obj.dist_env = SimpleNamespace(is_main=False)
     obj.total_optim_steps = 1
     obj.runtime = SimpleNamespace(global_step=1)
+    obj.block_size = 1
+    obj.device = torch.device("cpu")
     obj.train_dataloader = []
     obj._make_progress_bar = lambda **kwargs: FakePbar()
     obj._run_eval = lambda: None

--- a/tests/unit_tests/recipes/llm/test_train_dspark_helpers.py
+++ b/tests/unit_tests/recipes/llm/test_train_dspark_helpers.py
@@ -147,6 +147,7 @@ def test_save_checkpoint_applies_retention_after_sync_save(tmp_path):
     obj.block_size = 4
     obj.num_anchors = 2
     obj.mask_token_id = 99
+    obj.target_layer_ids = [0, 1]
     obj.target_wrapper = SimpleNamespace(target_layer_ids=[0, 1])
     obj._complete_pending_checkpoint = lambda: events.append("complete_pending")
     obj._update_latest_symlink = lambda path: events.append(("latest", path))
@@ -181,6 +182,7 @@ def test_save_checkpoint_records_async_best_pending_info_without_metric(tmp_path
     obj.block_size = 4
     obj.num_anchors = 2
     obj.mask_token_id = 99
+    obj.target_layer_ids = [0, 1]
     obj.target_wrapper = SimpleNamespace(target_layer_ids=[0, 1])
     obj._complete_pending_checkpoint = lambda: events.append("complete_pending")
 

--- a/tests/unit_tests/recipes/test_base_recipe.py
+++ b/tests/unit_tests/recipes/test_base_recipe.py
@@ -754,6 +754,15 @@ def test_step_scheduler_log_includes_checkpoint_retention_policy(tmp_path, caplo
     assert "disabled; keeping all checkpoints" in caplog.text
     assert "checkpoint.max_recent_checkpoints=None" in caplog.text
 
+    caplog.clear()
+    recipe_inst = _ToyRecipe(tmp_path, max_recent_checkpoints=2)
+    recipe_inst.checkpointer.config.enabled = False
+    with caplog.at_level(logging.INFO):
+        recipe_inst._log_step_scheduler_details(step_scheduler)
+
+    assert "inactive because checkpointing is disabled" in caplog.text
+    assert "keeping the most recent" not in caplog.text
+
 
 def test_checkpoint_retention_max_recent_one_preserves_latest_resume(tmp_path):
     """checkpoint.max_recent_checkpoints=1 prunes older checkpoints and keeps LATEST resumable."""
@@ -808,6 +817,26 @@ def test_checkpoint_retention_preserves_lowest_val_pointer_target(tmp_path):
     assert _checkpoint_dir_names(tmp_path) == ["epoch_0_step_100", "epoch_0_step_200"]
     assert (tmp_path / "LOWEST_VAL").exists(follow_symlinks=False) or (tmp_path / "LOWEST_VAL.txt").exists()
     assert recipe_inst.load_checkpoint(restore_from="epoch_0_step_100") is None
+
+
+def test_checkpoint_restore_from_lowest_val_text_fallback(tmp_path):
+    """restore_from=LOWEST_VAL resolves text fallback pointers, not only symlinks."""
+    recipe_inst = _ToyRecipe(tmp_path, max_recent_checkpoints=1)
+
+    x = torch.randn(4, 2)
+    loss = recipe_inst.model(x).sum()
+    loss.backward()
+    recipe_inst.optimizer.step()
+    recipe_inst.save_checkpoint(
+        epoch=0,
+        step=100,
+        train_loss=float(loss.item()),
+        val_loss={"val_loss": 0.1},
+    )
+    (tmp_path / "LOWEST_VAL").unlink(missing_ok=True)
+    (tmp_path / "LOWEST_VAL.txt").write_text("epoch_0_step_100")
+
+    assert recipe_inst.load_checkpoint(restore_from="LOWEST_VAL") is None
 
 
 def test_checkpoint_retention_preserves_arbitrary_checkpoint_pointer_target(tmp_path):

--- a/tests/unit_tests/recipes/test_base_recipe.py
+++ b/tests/unit_tests/recipes/test_base_recipe.py
@@ -20,9 +20,10 @@ import pytest
 import torch
 import torch.nn as nn
 
+from nemo_automodel.components.checkpoint.utils import _find_latest_checkpoint
 from nemo_automodel.components.config.loader import ConfigNode
 from nemo_automodel.components.models.common.hf_checkpointing_mixin import HFCheckpointingMixin
-from nemo_automodel.recipes.base_recipe import BaseRecipe, _find_latest_checkpoint, is_distributed_stateful
+from nemo_automodel.recipes.base_recipe import BaseRecipe, is_distributed_stateful
 
 try:
     import expecttest

--- a/tests/unit_tests/recipes/test_base_recipe.py
+++ b/tests/unit_tests/recipes/test_base_recipe.py
@@ -692,8 +692,8 @@ def test_load_checkpoint_multiple_checkpoints_with_latest(tmp_path):
     assert torch.allclose(recipe_inst.model.weight, weight_at_step_200)
 
 
-def test_checkpoint_retention_default_keeps_last_two_checkpoints(tmp_path):
-    """Without checkpoint.max_recent_checkpoints, checkpoint retention defaults to a bounded safety window."""
+def test_checkpoint_retention_default_keeps_all_checkpoints(tmp_path):
+    """Without checkpoint.max_recent_checkpoints, checkpoint retention preserves existing keep-all behavior."""
     recipe_inst = _ToyRecipe(tmp_path)
 
     for step in [50, 100, 75, 200]:
@@ -703,11 +703,16 @@ def test_checkpoint_retention_default_keeps_last_two_checkpoints(tmp_path):
         recipe_inst.optimizer.step()
         recipe_inst.save_checkpoint(epoch=0, step=step, train_loss=float(loss.item()))
 
-    assert recipe_inst.checkpointer.config.max_recent_checkpoints == 2
-    assert _checkpoint_dir_names(tmp_path) == ["epoch_0_step_100", "epoch_0_step_200"]
+    assert recipe_inst.checkpointer.config.max_recent_checkpoints is None
+    assert _checkpoint_dir_names(tmp_path) == [
+        "epoch_0_step_50",
+        "epoch_0_step_75",
+        "epoch_0_step_100",
+        "epoch_0_step_200",
+    ]
 
 
-def test_checkpoint_retention_can_be_disabled(tmp_path):
+def test_checkpoint_retention_explicit_none_keeps_all_checkpoints(tmp_path):
     """checkpoint.max_recent_checkpoints=None keeps all checkpoints for users who need the full history."""
     recipe_inst = _ToyRecipe(tmp_path, max_recent_checkpoints=None)
 

--- a/tests/unit_tests/recipes/test_base_recipe.py
+++ b/tests/unit_tests/recipes/test_base_recipe.py
@@ -175,8 +175,8 @@ class _ToyModel(HFCheckpointingMixin, nn.Linear):
 
 
 def _checkpoint_dir_names(path):
-    """Return checkpoint directory names under path sorted by step."""
-    names = [p.name for p in path.glob("*step_*") if p.is_dir()]
+    """Return AutoModel checkpoint directory names under path sorted by step."""
+    names = [p.name for p in path.glob("epoch_*_step_*") if p.is_dir()]
     return sorted(names, key=lambda name: int(name.rsplit("_", maxsplit=1)[1]))
 
 
@@ -248,19 +248,15 @@ def test_dp_allreduce_uses_world_group_without_device_mesh(tmp_path, monkeypatch
 
 
 def test_find_latest_checkpoint(tmp_path):
-    """
-    Verify that the helper returns the directory whose name contains the
-    largest step number, irrespective of the exact prefix.
-    """
-    # Build a few fake checkpoint directories.
+    """Verify that latest checkpoint discovery uses AutoModel-owned checkpoint directories."""
     (tmp_path / "epoch_0_step_1").mkdir()
-    (tmp_path / "step_20").mkdir()
+    (tmp_path / "step_20").mkdir()  # should be ignored: not an AutoModel checkpoint name
     (tmp_path / "epoch_3_step_5").mkdir()
     (tmp_path / "misc").mkdir()  # should be ignored
 
     latest = _find_latest_checkpoint(tmp_path)
     assert latest is not None
-    assert latest.name == "step_20", "Did not pick the highest step directory"
+    assert latest.name == "epoch_3_step_5", "Did not pick the highest AutoModel checkpoint directory"
 
 
 @pytest.mark.skipif(not HAS_ET, reason="expecttest required")
@@ -802,6 +798,41 @@ def test_checkpoint_retention_max_recent_two_sliding_window(tmp_path):
         recipe_inst.save_checkpoint(epoch=0, step=step, train_loss=float(loss.item()))
 
     assert _checkpoint_dir_names(tmp_path) == ["epoch_0_step_200", "epoch_0_step_300"]
+
+
+def test_checkpoint_retention_ignores_non_automodel_step_directories(tmp_path):
+    """Retention only prunes AutoModel-owned epoch_<n>_step_<n> checkpoint directories."""
+    backup_dir = tmp_path / "backup_step_50"
+    backup_dir.mkdir()
+    (backup_dir / "keep.txt").write_text("not an AutoModel checkpoint")
+    recipe_inst = _ToyRecipe(tmp_path, max_recent_checkpoints=1)
+
+    for step in [100, 200]:
+        x = torch.randn(4, 2)
+        loss = recipe_inst.model(x).sum()
+        loss.backward()
+        recipe_inst.optimizer.step()
+        recipe_inst.save_checkpoint(epoch=0, step=step, train_loss=float(loss.item()))
+
+    assert _checkpoint_dir_names(tmp_path) == ["epoch_0_step_200"]
+    assert (backup_dir / "keep.txt").read_text() == "not an AutoModel checkpoint"
+
+
+def test_checkpoint_retention_ignores_non_pointer_text_files(tmp_path):
+    """Plain text files do not pin old checkpoints unless they look like pointer fallback files."""
+    recipe_inst = _ToyRecipe(tmp_path, max_recent_checkpoints=1)
+
+    for step in [100, 200]:
+        x = torch.randn(4, 2)
+        loss = recipe_inst.model(x).sum()
+        loss.backward()
+        recipe_inst.optimizer.step()
+        recipe_inst.save_checkpoint(epoch=0, step=step, train_loss=float(loss.item()))
+        if step == 100:
+            (tmp_path / "notes.txt").write_text("epoch_0_step_100/losses.json")
+
+    assert _checkpoint_dir_names(tmp_path) == ["epoch_0_step_200"]
+    assert (tmp_path / "notes.txt").exists()
 
 
 def test_checkpoint_retention_preserves_lowest_val_pointer_target(tmp_path):

--- a/tests/unit_tests/recipes/test_base_recipe.py
+++ b/tests/unit_tests/recipes/test_base_recipe.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import os
 from types import SimpleNamespace
 
@@ -722,6 +723,36 @@ def test_checkpoint_retention_can_be_disabled(tmp_path):
         "epoch_0_step_100",
         "epoch_0_step_200",
     ]
+
+
+def test_step_scheduler_log_includes_checkpoint_retention_policy(tmp_path, caplog):
+    """Startup logs should tell users whether checkpoint retention is bounded or disabled."""
+    step_scheduler = SimpleNamespace(
+        grad_acc_steps=1,
+        ckpt_every_steps=5,
+        gc_every_steps=None,
+        epoch=0,
+        num_epochs=1,
+        val_every_steps=10,
+        max_steps=20,
+    )
+
+    recipe_inst = _ToyRecipe(tmp_path, max_recent_checkpoints=2)
+    with caplog.at_level(logging.INFO):
+        recipe_inst._log_step_scheduler_details(step_scheduler)
+
+    assert "Checkpoint retention" in caplog.text
+    assert "keeping the most recent 2 checkpoint(s)" in caplog.text
+    assert "plus pointer-protected checkpoints" in caplog.text
+    assert "checkpoint.max_recent_checkpoints=2" in caplog.text
+
+    caplog.clear()
+    recipe_inst = _ToyRecipe(tmp_path, max_recent_checkpoints=None)
+    with caplog.at_level(logging.INFO):
+        recipe_inst._log_step_scheduler_details(step_scheduler)
+
+    assert "disabled; keeping all checkpoints" in caplog.text
+    assert "checkpoint.max_recent_checkpoints=None" in caplog.text
 
 
 def test_checkpoint_retention_max_recent_one_preserves_latest_resume(tmp_path):

--- a/tests/unit_tests/recipes/test_base_recipe.py
+++ b/tests/unit_tests/recipes/test_base_recipe.py
@@ -989,6 +989,39 @@ def test_non_finite_restored_best_metric_does_not_block_future_best(tmp_path, no
     assert recipe_inst._best_val_loss == 0.5
 
 
+@pytest.mark.parametrize("malformed_losses", ["null", "42", "[]", '{"val_loss": 1' + "0" * 400 + "}"])
+def test_malformed_restored_best_metric_does_not_block_future_best(tmp_path, malformed_losses):
+    """Malformed LOWEST_VAL metadata is ignored when initializing the restored best."""
+    recipe_inst = _ToyRecipe(tmp_path)
+    old_checkpoint = tmp_path / "epoch_0_step_100"
+    new_checkpoint = tmp_path / "epoch_0_step_200"
+    old_checkpoint.mkdir()
+    new_checkpoint.mkdir()
+    (old_checkpoint / "losses.json").write_text(malformed_losses)
+    recipe_inst._update_checkpoint_symlink("LOWEST_VAL", str(old_checkpoint))
+
+    recipe_inst._update_best_symlink(str(new_checkpoint), 0.5, "val_loss")
+
+    assert _read_checkpoint_pointer(tmp_path, "LOWEST_VAL") == new_checkpoint
+    assert recipe_inst._best_val_loss == 0.5
+
+
+def test_non_utf8_restored_best_metric_does_not_block_future_best(tmp_path):
+    """Unreadable LOWEST_VAL metadata is ignored when initializing the restored best."""
+    recipe_inst = _ToyRecipe(tmp_path)
+    old_checkpoint = tmp_path / "epoch_0_step_100"
+    new_checkpoint = tmp_path / "epoch_0_step_200"
+    old_checkpoint.mkdir()
+    new_checkpoint.mkdir()
+    (old_checkpoint / "losses.json").write_bytes(b"\xff")
+    recipe_inst._update_checkpoint_symlink("LOWEST_VAL", str(old_checkpoint))
+
+    recipe_inst._update_best_symlink(str(new_checkpoint), 0.5, "val_loss")
+
+    assert _read_checkpoint_pointer(tmp_path, "LOWEST_VAL") == new_checkpoint
+    assert recipe_inst._best_val_loss == 0.5
+
+
 @pytest.mark.parametrize("non_finite_value", [float("nan"), float("inf"), float("-inf")])
 def test_non_finite_live_metric_does_not_replace_best_pointer(tmp_path, non_finite_value):
     """A live non-finite validation metric is never eligible for LOWEST_VAL."""

--- a/tests/unit_tests/recipes/test_base_recipe.py
+++ b/tests/unit_tests/recipes/test_base_recipe.py
@@ -172,17 +172,23 @@ class _ToyModel(HFCheckpointingMixin, nn.Linear):
         nn.Linear.__init__(self, in_features, out_features, bias=bias)
 
 
+def _checkpoint_dir_names(path):
+    """Return checkpoint directory names under path sorted by step."""
+    names = [p.name for p in path.glob("*step_*") if p.is_dir()]
+    return sorted(names, key=lambda name: int(name.rsplit("_", maxsplit=1)[1]))
+
+
 class _ToyRecipe(BaseRecipe):
     """
     Minimal concrete implementation of BaseRecipe for testing.
     """
 
-    def __init__(self, checkpoint_dir, cfg_dict=None):
+    def __init__(self, checkpoint_dir, cfg_dict=None, max_recent_checkpoints="default"):
         super().__init__()
 
         from nemo_automodel.components.checkpoint.checkpointing import Checkpointer, CheckpointingConfig
 
-        checkpoint_config = CheckpointingConfig(
+        checkpoint_config_kwargs = dict(
             enabled=True,
             checkpoint_dir=str(checkpoint_dir),
             model_save_format="safetensors",
@@ -192,6 +198,9 @@ class _ToyRecipe(BaseRecipe):
             is_peft=False,
             model_state_dict_keys=[],
         )
+        if max_recent_checkpoints != "default":
+            checkpoint_config_kwargs["max_recent_checkpoints"] = max_recent_checkpoints
+        checkpoint_config = CheckpointingConfig(**checkpoint_config_kwargs)
 
         self.checkpointer = Checkpointer(
             config=checkpoint_config,
@@ -679,6 +688,235 @@ def test_load_checkpoint_multiple_checkpoints_with_latest(tmp_path):
 
     # Should restore to step 200 state
     assert torch.allclose(recipe_inst.model.weight, weight_at_step_200)
+
+
+def test_checkpoint_retention_default_keeps_last_two_checkpoints(tmp_path):
+    """Without checkpoint.max_recent_checkpoints, checkpoint retention defaults to a bounded safety window."""
+    recipe_inst = _ToyRecipe(tmp_path)
+
+    for step in [50, 100, 75, 200]:
+        x = torch.randn(4, 2)
+        loss = recipe_inst.model(x).sum()
+        loss.backward()
+        recipe_inst.optimizer.step()
+        recipe_inst.save_checkpoint(epoch=0, step=step, train_loss=float(loss.item()))
+
+    assert recipe_inst.checkpointer.config.max_recent_checkpoints == 2
+    assert _checkpoint_dir_names(tmp_path) == ["epoch_0_step_100", "epoch_0_step_200"]
+
+
+def test_checkpoint_retention_can_be_disabled(tmp_path):
+    """checkpoint.max_recent_checkpoints=None keeps all checkpoints for users who need the full history."""
+    recipe_inst = _ToyRecipe(tmp_path, max_recent_checkpoints=None)
+
+    for step in [50, 100, 75, 200]:
+        x = torch.randn(4, 2)
+        loss = recipe_inst.model(x).sum()
+        loss.backward()
+        recipe_inst.optimizer.step()
+        recipe_inst.save_checkpoint(epoch=0, step=step, train_loss=float(loss.item()))
+
+    assert _checkpoint_dir_names(tmp_path) == [
+        "epoch_0_step_50",
+        "epoch_0_step_75",
+        "epoch_0_step_100",
+        "epoch_0_step_200",
+    ]
+
+
+def test_checkpoint_retention_max_recent_one_preserves_latest_resume(tmp_path):
+    """checkpoint.max_recent_checkpoints=1 prunes older checkpoints and keeps LATEST resumable."""
+    recipe_inst = _ToyRecipe(tmp_path, max_recent_checkpoints=1)
+
+    for step in [50, 100, 200]:
+        x = torch.randn(4, 2)
+        loss = recipe_inst.model(x).sum()
+        loss.backward()
+        recipe_inst.optimizer.step()
+        if step == 200:
+            weight_at_step_200 = recipe_inst.model.weight.clone()
+        recipe_inst.save_checkpoint(epoch=0, step=step, train_loss=float(loss.item()))
+
+    assert _checkpoint_dir_names(tmp_path) == ["epoch_0_step_200"]
+
+    recipe_inst.model.weight.data.add_(42.0)
+    recipe_inst.load_checkpoint(restore_from="LATEST")
+    assert torch.allclose(recipe_inst.model.weight, weight_at_step_200)
+
+
+def test_checkpoint_retention_max_recent_two_sliding_window(tmp_path):
+    """checkpoint.max_recent_checkpoints=2 keeps the two highest-step checkpoint directories, plus pointer targets."""
+    recipe_inst = _ToyRecipe(tmp_path, max_recent_checkpoints=2)
+
+    for step in [50, 200, 100, 300]:
+        x = torch.randn(4, 2)
+        loss = recipe_inst.model(x).sum()
+        loss.backward()
+        recipe_inst.optimizer.step()
+        recipe_inst.save_checkpoint(epoch=0, step=step, train_loss=float(loss.item()))
+
+    assert _checkpoint_dir_names(tmp_path) == ["epoch_0_step_200", "epoch_0_step_300"]
+
+
+def test_checkpoint_retention_preserves_lowest_val_pointer_target(tmp_path):
+    """Retention preserves checkpoints targeted by LOWEST_VAL even outside the latest window."""
+    recipe_inst = _ToyRecipe(tmp_path, max_recent_checkpoints=1)
+
+    for step, val_loss in [(100, 0.1), (200, 0.9)]:
+        x = torch.randn(4, 2)
+        loss = recipe_inst.model(x).sum()
+        loss.backward()
+        recipe_inst.optimizer.step()
+        recipe_inst.save_checkpoint(
+            epoch=0,
+            step=step,
+            train_loss=float(loss.item()),
+            val_loss={"val_loss": val_loss},
+        )
+
+    assert _checkpoint_dir_names(tmp_path) == ["epoch_0_step_100", "epoch_0_step_200"]
+    assert (tmp_path / "LOWEST_VAL").exists(follow_symlinks=False) or (tmp_path / "LOWEST_VAL.txt").exists()
+    assert recipe_inst.load_checkpoint(restore_from="epoch_0_step_100") is None
+
+
+def test_checkpoint_retention_preserves_arbitrary_checkpoint_pointer_target(tmp_path):
+    """Retention preserves checkpoints targeted by any top-level checkpoint pointer."""
+    recipe_inst = _ToyRecipe(tmp_path, max_recent_checkpoints=1)
+
+    for step in [100, 200, 300]:
+        x = torch.randn(4, 2)
+        loss = recipe_inst.model(x).sum()
+        loss.backward()
+        recipe_inst.optimizer.step()
+        recipe_inst.save_checkpoint(epoch=0, step=step, train_loss=float(loss.item()))
+        if step == 100:
+            recipe_inst._update_checkpoint_symlink("PINNED", str(tmp_path / "epoch_0_step_100"))
+
+    assert _checkpoint_dir_names(tmp_path) == ["epoch_0_step_100", "epoch_0_step_300"]
+    assert (tmp_path / "PINNED").exists(follow_symlinks=False) or (tmp_path / "PINNED.txt").exists()
+
+
+def test_checkpoint_retention_preserves_pointer_to_file_inside_checkpoint(tmp_path):
+    """Retention preserves a checkpoint when a top-level pointer targets a file inside it."""
+    recipe_inst = _ToyRecipe(tmp_path, max_recent_checkpoints=1)
+
+    for step in [100, 200, 300]:
+        x = torch.randn(4, 2)
+        loss = recipe_inst.model(x).sum()
+        loss.backward()
+        recipe_inst.optimizer.step()
+        recipe_inst.save_checkpoint(epoch=0, step=step, train_loss=float(loss.item()))
+        if step == 100:
+            recipe_inst._update_checkpoint_symlink("PINNED_FILE", str(tmp_path / "epoch_0_step_100" / "losses.json"))
+
+    assert _checkpoint_dir_names(tmp_path) == ["epoch_0_step_100", "epoch_0_step_300"]
+
+
+def test_checkpoint_retention_preserves_text_fallback_pointer_target(tmp_path):
+    """Retention preserves checkpoints targeted by symlink fallback text files."""
+    recipe_inst = _ToyRecipe(tmp_path, max_recent_checkpoints=1)
+
+    for step in [100, 200, 300]:
+        x = torch.randn(4, 2)
+        loss = recipe_inst.model(x).sum()
+        loss.backward()
+        recipe_inst.optimizer.step()
+        recipe_inst.save_checkpoint(epoch=0, step=step, train_loss=float(loss.item()))
+        if step == 100:
+            (tmp_path / "PINNED.txt").write_text("epoch_0_step_100/losses.json")
+
+    assert _checkpoint_dir_names(tmp_path) == ["epoch_0_step_100", "epoch_0_step_300"]
+
+
+def test_checkpoint_retention_preserves_lowest_val_after_resume(tmp_path):
+    """After resume, a worse validation checkpoint must not replace the previous LOWEST_VAL target."""
+    recipe_a = _ToyRecipe(tmp_path, max_recent_checkpoints=1)
+
+    for step, val_loss in [(100, 0.1), (200, 0.9)]:
+        x = torch.randn(4, 2)
+        loss = recipe_a.model(x).sum()
+        loss.backward()
+        recipe_a.optimizer.step()
+        recipe_a.save_checkpoint(
+            epoch=0,
+            step=step,
+            train_loss=float(loss.item()),
+            val_loss={"val_loss": val_loss},
+        )
+
+    recipe_b = _ToyRecipe(tmp_path, max_recent_checkpoints=1)
+    recipe_b.load_checkpoint(restore_from="LATEST")
+    x = torch.randn(4, 2)
+    loss = recipe_b.model(x).sum()
+    loss.backward()
+    recipe_b.optimizer.step()
+    recipe_b.save_checkpoint(
+        epoch=0,
+        step=300,
+        train_loss=float(loss.item()),
+        val_loss={"val_loss": 0.8},
+    )
+
+    assert _checkpoint_dir_names(tmp_path) == ["epoch_0_step_100", "epoch_0_step_300"]
+
+
+def test_checkpoint_retention_prune_failure_is_nonfatal(tmp_path, monkeypatch):
+    """A failed retention delete leaves extra checkpoints instead of failing the save."""
+    recipe_inst = _ToyRecipe(tmp_path, max_recent_checkpoints=1)
+
+    x = torch.randn(4, 2)
+    loss = recipe_inst.model(x).sum()
+    loss.backward()
+    recipe_inst.optimizer.step()
+    recipe_inst.save_checkpoint(epoch=0, step=100, train_loss=float(loss.item()))
+
+    def fail_rmtree(_path):
+        raise OSError("checkpoint is busy")
+
+    monkeypatch.setattr("nemo_automodel.recipes.base_recipe.shutil.rmtree", fail_rmtree)
+
+    x = torch.randn(4, 2)
+    loss = recipe_inst.model(x).sum()
+    loss.backward()
+    recipe_inst.optimizer.step()
+    recipe_inst.save_checkpoint(epoch=0, step=200, train_loss=float(loss.item()))
+
+    assert _checkpoint_dir_names(tmp_path) == ["epoch_0_step_100", "epoch_0_step_200"]
+
+
+def test_checkpoint_retention_ignores_unreadable_top_level_text_files(tmp_path):
+    """Retention ignores unrelated text files that are not valid checkpoint pointers."""
+    recipe_inst = _ToyRecipe(tmp_path, max_recent_checkpoints=1)
+    (tmp_path / "NOT_A_POINTER.txt").write_bytes(bytes([0xFF, 0xFE]))
+
+    for step in [100, 200]:
+        x = torch.randn(4, 2)
+        loss = recipe_inst.model(x).sum()
+        loss.backward()
+        recipe_inst.optimizer.step()
+        recipe_inst.save_checkpoint(epoch=0, step=step, train_loss=float(loss.item()))
+
+    assert _checkpoint_dir_names(tmp_path) == ["epoch_0_step_200"]
+
+
+def test_checkpoint_retention_async_finalization_prunes_pending_checkpoint(tmp_path):
+    """Async saves prune only after the pending checkpoint has completed and is published."""
+    recipe_inst = _ToyRecipe(tmp_path, max_recent_checkpoints=1)
+    recipe_inst.checkpointer.config.is_async = True
+
+    for step in [100, 200]:
+        x = torch.randn(4, 2)
+        loss = recipe_inst.model(x).sum()
+        loss.backward()
+        recipe_inst.optimizer.step()
+        recipe_inst.save_checkpoint(epoch=0, step=step, train_loss=float(loss.item()))
+
+    assert _checkpoint_dir_names(tmp_path) == ["epoch_0_step_100", "epoch_0_step_200"]
+
+    recipe_inst._finalize_pending_checkpoint()
+
+    assert _checkpoint_dir_names(tmp_path) == ["epoch_0_step_200"]
+    assert (tmp_path / "LATEST").exists(follow_symlinks=False) or (tmp_path / "LATEST.txt").exists()
 
 
 def test_load_checkpoint_path_with_separator_treated_as_full_path(tmp_path):

--- a/tests/unit_tests/recipes/test_base_recipe.py
+++ b/tests/unit_tests/recipes/test_base_recipe.py
@@ -744,7 +744,7 @@ def test_step_scheduler_log_includes_checkpoint_retention_policy(tmp_path, caplo
         recipe_inst._log_step_scheduler_details(step_scheduler)
 
     assert "Checkpoint retention" in caplog.text
-    assert "keeping the most recent 2 checkpoint(s)" in caplog.text
+    assert "keeping the most recent 2 checkpoint directories" in caplog.text
     assert "plus pointer-protected checkpoints" in caplog.text
     assert "checkpoint.max_recent_checkpoints=2" in caplog.text
 
@@ -1030,7 +1030,7 @@ def test_checkpoint_pointer_replace_failure_preserves_existing_target(tmp_path, 
 
 
 def test_checkpoint_retention_preserves_lowest_val_after_resume(tmp_path):
-    """After resume, a worse validation checkpoint must not replace the previous LOWEST_VAL target."""
+    """After resuming, a worse validation checkpoint must not replace the previous LOWEST_VAL target."""
     recipe_a = _ToyRecipe(tmp_path, max_recent_checkpoints=1)
 
     for step, val_loss in [(100, 0.1), (200, 0.9)]:

--- a/tests/unit_tests/recipes/test_base_recipe.py
+++ b/tests/unit_tests/recipes/test_base_recipe.py
@@ -248,15 +248,15 @@ def test_dp_allreduce_uses_world_group_without_device_mesh(tmp_path, monkeypatch
 
 
 def test_find_latest_checkpoint(tmp_path):
-    """Verify that latest checkpoint discovery uses AutoModel-owned checkpoint directories."""
+    """Verify that latest checkpoint discovery supports legacy step-based directory names."""
     (tmp_path / "epoch_0_step_1").mkdir()
-    (tmp_path / "step_20").mkdir()  # should be ignored: not an AutoModel checkpoint name
+    (tmp_path / "step_20").mkdir()
     (tmp_path / "epoch_3_step_5").mkdir()
     (tmp_path / "misc").mkdir()  # should be ignored
 
     latest = _find_latest_checkpoint(tmp_path)
     assert latest is not None
-    assert latest.name == "epoch_3_step_5", "Did not pick the highest AutoModel checkpoint directory"
+    assert latest.name == "step_20", "Did not pick the highest step directory"
 
 
 @pytest.mark.skipif(not HAS_ET, reason="expecttest required")
@@ -805,6 +805,8 @@ def test_checkpoint_retention_ignores_non_automodel_step_directories(tmp_path):
     backup_dir = tmp_path / "backup_step_50"
     backup_dir.mkdir()
     (backup_dir / "keep.txt").write_text("not an AutoModel checkpoint")
+    legacy_checkpoint = tmp_path / "step_300"
+    legacy_checkpoint.mkdir()
     recipe_inst = _ToyRecipe(tmp_path, max_recent_checkpoints=1)
 
     for step in [100, 200]:
@@ -816,6 +818,7 @@ def test_checkpoint_retention_ignores_non_automodel_step_directories(tmp_path):
 
     assert _checkpoint_dir_names(tmp_path) == ["epoch_0_step_200"]
     assert (backup_dir / "keep.txt").read_text() == "not an AutoModel checkpoint"
+    assert legacy_checkpoint.is_dir()
 
 
 def test_checkpoint_retention_ignores_non_pointer_text_files(tmp_path):

--- a/tests/unit_tests/recipes/test_base_recipe.py
+++ b/tests/unit_tests/recipes/test_base_recipe.py
@@ -947,6 +947,31 @@ def test_checkpoint_retention_pointer_scan_failure_skips_pruning(tmp_path, monke
     assert "skipping pruning" in caplog.text
 
 
+def test_checkpoint_retention_pointer_classification_failure_skips_pruning(tmp_path, monkeypatch):
+    """An I/O error while identifying a top-level pointer must fail closed."""
+    recipe_inst = _ToyRecipe(tmp_path, max_recent_checkpoints=1)
+    for step in [100, 200, 300]:
+        (tmp_path / f"epoch_0_step_{step}").mkdir()
+    recipe_inst._update_checkpoint_symlink("PINNED", str(tmp_path / "epoch_0_step_100"))
+    path_type = type(tmp_path)
+    real_lstat = path_type.lstat
+
+    def fail_pinned_lstat(path, *args, **kwargs):
+        if path == tmp_path / "PINNED":
+            raise OSError("cannot classify pointer")
+        return real_lstat(path, *args, **kwargs)
+
+    monkeypatch.setattr(path_type, "lstat", fail_pinned_lstat)
+
+    recipe_inst._prune_old_checkpoints()
+
+    assert _checkpoint_dir_names(tmp_path) == [
+        "epoch_0_step_100",
+        "epoch_0_step_200",
+        "epoch_0_step_300",
+    ]
+
+
 @pytest.mark.parametrize("non_finite_value", ["NaN", "Infinity", "-Infinity"])
 def test_non_finite_restored_best_metric_does_not_block_future_best(tmp_path, non_finite_value):
     """A non-finite metric in LOWEST_VAL metadata is ignored when initializing the restored best."""
@@ -961,6 +986,22 @@ def test_non_finite_restored_best_metric_does_not_block_future_best(tmp_path, no
     recipe_inst._update_best_symlink(str(new_checkpoint), 0.5, "val_loss")
 
     assert _read_checkpoint_pointer(tmp_path, "LOWEST_VAL") == new_checkpoint
+    assert recipe_inst._best_val_loss == 0.5
+
+
+@pytest.mark.parametrize("non_finite_value", [float("nan"), float("inf"), float("-inf")])
+def test_non_finite_live_metric_does_not_replace_best_pointer(tmp_path, non_finite_value):
+    """A live non-finite validation metric is never eligible for LOWEST_VAL."""
+    recipe_inst = _ToyRecipe(tmp_path)
+    old_checkpoint = tmp_path / "epoch_0_step_100"
+    new_checkpoint = tmp_path / "epoch_0_step_200"
+    old_checkpoint.mkdir()
+    new_checkpoint.mkdir()
+    recipe_inst._update_best_symlink(str(old_checkpoint), 0.5, "val_loss")
+
+    recipe_inst._update_best_symlink(str(new_checkpoint), non_finite_value, "val_loss")
+
+    assert _read_checkpoint_pointer(tmp_path, "LOWEST_VAL") == old_checkpoint
     assert recipe_inst._best_val_loss == 0.5
 
 
@@ -1044,10 +1085,10 @@ def test_checkpoint_retention_prune_failure_is_nonfatal(tmp_path, monkeypatch):
     assert _checkpoint_dir_names(tmp_path) == ["epoch_0_step_100", "epoch_0_step_200"]
 
 
-def test_checkpoint_retention_ignores_unreadable_top_level_text_files(tmp_path):
-    """Retention ignores unrelated text files that are not valid checkpoint pointers."""
+def test_checkpoint_retention_unreadable_pointer_text_skips_pruning(tmp_path):
+    """An unreadable pointer-like text file makes pointer discovery fail closed."""
     recipe_inst = _ToyRecipe(tmp_path, max_recent_checkpoints=1)
-    (tmp_path / "NOT_A_POINTER.txt").write_bytes(bytes([0xFF, 0xFE]))
+    (tmp_path / "PINNED.txt").write_bytes(bytes([0xFF, 0xFE]))
 
     for step in [100, 200]:
         x = torch.randn(4, 2)
@@ -1056,7 +1097,7 @@ def test_checkpoint_retention_ignores_unreadable_top_level_text_files(tmp_path):
         recipe_inst.optimizer.step()
         recipe_inst.save_checkpoint(epoch=0, step=step, train_loss=float(loss.item()))
 
-    assert _checkpoint_dir_names(tmp_path) == ["epoch_0_step_200"]
+    assert _checkpoint_dir_names(tmp_path) == ["epoch_0_step_100", "epoch_0_step_200"]
 
 
 def test_checkpoint_retention_async_finalization_prunes_pending_checkpoint(tmp_path):

--- a/tests/unit_tests/recipes/test_base_recipe.py
+++ b/tests/unit_tests/recipes/test_base_recipe.py
@@ -20,7 +20,7 @@ import pytest
 import torch
 import torch.nn as nn
 
-from nemo_automodel.components.checkpoint.utils import _find_latest_checkpoint, _read_checkpoint_pointer
+from nemo_automodel.components.checkpoint.utils import find_latest_checkpoint, read_checkpoint_pointer
 from nemo_automodel.components.config.loader import ConfigNode
 from nemo_automodel.components.models.common.hf_checkpointing_mixin import HFCheckpointingMixin
 from nemo_automodel.recipes.base_recipe import BaseRecipe, is_distributed_stateful
@@ -254,7 +254,7 @@ def test_find_latest_checkpoint(tmp_path):
     (tmp_path / "epoch_3_step_5").mkdir()
     (tmp_path / "misc").mkdir()  # should be ignored
 
-    latest = _find_latest_checkpoint(tmp_path)
+    latest = find_latest_checkpoint(tmp_path)
     assert latest is not None
     assert latest.name == "step_20", "Did not pick the highest step directory"
 
@@ -938,7 +938,7 @@ def test_checkpoint_retention_pointer_scan_failure_skips_pruning(tmp_path, monke
     def fail_pointer_scan(_ckpt_root, _checkpoints):
         raise OSError("pointer scan failed")
 
-    monkeypatch.setattr("nemo_automodel.recipes.base_recipe._find_pointer_protected_checkpoints", fail_pointer_scan)
+    monkeypatch.setattr("nemo_automodel.recipes.base_recipe.find_pointer_protected_checkpoints", fail_pointer_scan)
     with caplog.at_level(logging.WARNING):
         recipe_inst._prune_old_checkpoints()
 
@@ -988,7 +988,7 @@ def test_non_finite_restored_best_metric_does_not_block_future_best(tmp_path, no
 
     recipe_inst._update_best_symlink(str(new_checkpoint), 0.5, "val_loss")
 
-    assert _read_checkpoint_pointer(tmp_path, "LOWEST_VAL") == new_checkpoint
+    assert read_checkpoint_pointer(tmp_path, "LOWEST_VAL") == new_checkpoint
     assert recipe_inst._best_val_loss == 0.5
 
 
@@ -1005,7 +1005,7 @@ def test_malformed_restored_best_metric_does_not_block_future_best(tmp_path, mal
 
     recipe_inst._update_best_symlink(str(new_checkpoint), 0.5, "val_loss")
 
-    assert _read_checkpoint_pointer(tmp_path, "LOWEST_VAL") == new_checkpoint
+    assert read_checkpoint_pointer(tmp_path, "LOWEST_VAL") == new_checkpoint
     assert recipe_inst._best_val_loss == 0.5
 
 
@@ -1021,7 +1021,7 @@ def test_non_utf8_restored_best_metric_does_not_block_future_best(tmp_path):
 
     recipe_inst._update_best_symlink(str(new_checkpoint), 0.5, "val_loss")
 
-    assert _read_checkpoint_pointer(tmp_path, "LOWEST_VAL") == new_checkpoint
+    assert read_checkpoint_pointer(tmp_path, "LOWEST_VAL") == new_checkpoint
     assert recipe_inst._best_val_loss == 0.5
 
 
@@ -1037,7 +1037,7 @@ def test_non_finite_live_metric_does_not_replace_best_pointer(tmp_path, non_fini
 
     recipe_inst._update_best_symlink(str(new_checkpoint), non_finite_value, "val_loss")
 
-    assert _read_checkpoint_pointer(tmp_path, "LOWEST_VAL") == old_checkpoint
+    assert read_checkpoint_pointer(tmp_path, "LOWEST_VAL") == old_checkpoint
     assert recipe_inst._best_val_loss == 0.5
 
 
@@ -1061,7 +1061,7 @@ def test_checkpoint_pointer_replace_failure_preserves_existing_target(tmp_path, 
     with pytest.raises(OSError, match="filesystem full"):
         recipe_inst._update_checkpoint_symlink("LATEST", str(new_checkpoint))
 
-    assert _read_checkpoint_pointer(tmp_path, "LATEST") == old_checkpoint
+    assert read_checkpoint_pointer(tmp_path, "LATEST") == old_checkpoint
     assert not list(tmp_path.glob(".LATEST.*.tmp"))
 
 

--- a/tests/unit_tests/recipes/test_base_recipe.py
+++ b/tests/unit_tests/recipes/test_base_recipe.py
@@ -20,7 +20,7 @@ import pytest
 import torch
 import torch.nn as nn
 
-from nemo_automodel.components.checkpoint.utils import _find_latest_checkpoint
+from nemo_automodel.components.checkpoint.utils import _find_latest_checkpoint, _read_checkpoint_pointer
 from nemo_automodel.components.config.loader import ConfigNode
 from nemo_automodel.components.models.common.hf_checkpointing_mixin import HFCheckpointingMixin
 from nemo_automodel.recipes.base_recipe import BaseRecipe, is_distributed_stateful
@@ -923,6 +923,69 @@ def test_checkpoint_retention_preserves_text_fallback_pointer_target(tmp_path):
             (tmp_path / "PINNED.txt").write_text("epoch_0_step_100/losses.json")
 
     assert _checkpoint_dir_names(tmp_path) == ["epoch_0_step_100", "epoch_0_step_300"]
+
+
+def test_checkpoint_retention_pointer_scan_failure_skips_pruning(tmp_path, monkeypatch, caplog):
+    """Pointer discovery failures preserve every checkpoint rather than risking deletion of a pinned target."""
+    recipe_inst = _ToyRecipe(tmp_path, max_recent_checkpoints=1)
+    for step in [100, 200, 300]:
+        (tmp_path / f"epoch_0_step_{step}").mkdir()
+    recipe_inst._update_checkpoint_symlink("PINNED", str(tmp_path / "epoch_0_step_100"))
+
+    def fail_pointer_scan(_ckpt_root, _checkpoints):
+        raise OSError("pointer scan failed")
+
+    monkeypatch.setattr("nemo_automodel.recipes.base_recipe._find_pointer_protected_checkpoints", fail_pointer_scan)
+    with caplog.at_level(logging.WARNING):
+        recipe_inst._prune_old_checkpoints()
+
+    assert _checkpoint_dir_names(tmp_path) == [
+        "epoch_0_step_100",
+        "epoch_0_step_200",
+        "epoch_0_step_300",
+    ]
+    assert "skipping pruning" in caplog.text
+
+
+@pytest.mark.parametrize("non_finite_value", ["NaN", "Infinity", "-Infinity"])
+def test_non_finite_restored_best_metric_does_not_block_future_best(tmp_path, non_finite_value):
+    """A non-finite metric in LOWEST_VAL metadata is ignored when initializing the restored best."""
+    recipe_inst = _ToyRecipe(tmp_path, max_recent_checkpoints=1)
+    old_checkpoint = tmp_path / "epoch_0_step_100"
+    new_checkpoint = tmp_path / "epoch_0_step_200"
+    old_checkpoint.mkdir()
+    new_checkpoint.mkdir()
+    (old_checkpoint / "losses.json").write_text(f'{{"val_loss": {non_finite_value}}}')
+    recipe_inst._update_checkpoint_symlink("LOWEST_VAL", str(old_checkpoint))
+
+    recipe_inst._update_best_symlink(str(new_checkpoint), 0.5, "val_loss")
+
+    assert _read_checkpoint_pointer(tmp_path, "LOWEST_VAL") == new_checkpoint
+    assert recipe_inst._best_val_loss == 0.5
+
+
+def test_checkpoint_pointer_replace_failure_preserves_existing_target(tmp_path, monkeypatch):
+    """A failed atomic pointer swap leaves the previously published pointer intact."""
+    recipe_inst = _ToyRecipe(tmp_path)
+    old_checkpoint = tmp_path / "epoch_0_step_100"
+    new_checkpoint = tmp_path / "epoch_0_step_200"
+    old_checkpoint.mkdir()
+    new_checkpoint.mkdir()
+    recipe_inst._update_checkpoint_symlink("LATEST", str(old_checkpoint))
+    real_replace = os.replace
+
+    def fail_latest_replace(source, destination):
+        if os.fspath(destination) == os.fspath(tmp_path / "LATEST"):
+            raise OSError("filesystem full")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(os, "replace", fail_latest_replace)
+
+    with pytest.raises(OSError, match="filesystem full"):
+        recipe_inst._update_checkpoint_symlink("LATEST", str(new_checkpoint))
+
+    assert _read_checkpoint_pointer(tmp_path, "LATEST") == old_checkpoint
+    assert not list(tmp_path.glob(".LATEST.*.tmp"))
 
 
 def test_checkpoint_retention_preserves_lowest_val_after_resume(tmp_path):

--- a/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
+++ b/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
@@ -1319,12 +1319,14 @@ class TestBuildCheckpointConfig:
         assert config.model_cache_dir == "/tmp/cache"
         assert config.save_consolidated.value == "final"
         assert config.is_peft is False
+        assert config.max_recent_checkpoints == 2
 
     def test_build_checkpoint_config_with_custom_config(self):
         """Test checkpoint config with custom settings."""
         cfg_ckpt = MagicMock()
         cfg_ckpt.to_dict.return_value = {
             "checkpoint_dir": "/custom/ckpt/",
+            "max_recent_checkpoints": 3,
             "save_consolidated": False,
             "restore_from": "/some/path",  # Should be removed
         }
@@ -1337,6 +1339,7 @@ class TestBuildCheckpointConfig:
         )
 
         assert config.checkpoint_dir == "/custom/ckpt/"
+        assert config.max_recent_checkpoints == 3
         assert config.save_consolidated.value == "false"
         assert config.is_peft is True
 
@@ -1348,6 +1351,7 @@ class TestBuildCheckpointConfig:
         cfg_ckpt.to_dict.return_value = {
             "model_save_format": "torch_save",
             "checkpoint_dir": "/user/ckpt/",
+            "max_recent_checkpoints": 2,
             "save_consolidated": False,
         }
 
@@ -1362,9 +1366,10 @@ class TestBuildCheckpointConfig:
         assert any("falling back" in rec.message.lower() for rec in caplog.records)
         assert config.is_peft is True
         assert config.model_save_format == SerializationFormat.SAFETENSORS
-        # checkpoint_dir is preserved from the user config
+        # checkpoint_dir and max_recent_checkpoints are preserved from the user config
         assert config.checkpoint_dir == "/user/ckpt/"
-        # other user-provided torch_save options are discarded; save_consolidated falls back to the default "final"
+        assert config.max_recent_checkpoints == 2
+        # incompatible torch_save options are coerced; save_consolidated falls back to the default "final"
         assert config.save_consolidated.value == "final"
         assert config.is_async is False
 

--- a/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
+++ b/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
@@ -1319,7 +1319,7 @@ class TestBuildCheckpointConfig:
         assert config.model_cache_dir == "/tmp/cache"
         assert config.save_consolidated.value == "final"
         assert config.is_peft is False
-        assert config.max_recent_checkpoints == 2
+        assert config.max_recent_checkpoints is None
 
     def test_build_checkpoint_config_with_custom_config(self):
         """Test checkpoint config with custom settings."""

--- a/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
+++ b/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
@@ -1366,10 +1366,10 @@ class TestBuildCheckpointConfig:
         assert any("falling back" in rec.message.lower() for rec in caplog.records)
         assert config.is_peft is True
         assert config.model_save_format == SerializationFormat.SAFETENSORS
-        # checkpoint_dir and max_recent_checkpoints are preserved from the user config
+        # The builder preserves `checkpoint_dir` and `max_recent_checkpoints` from the user configuration.
         assert config.checkpoint_dir == "/user/ckpt/"
         assert config.max_recent_checkpoints == 2
-        # incompatible torch_save options are coerced; save_consolidated falls back to the default "final"
+        # The builder coerces incompatible `torch_save` options and restores the default `save_consolidated="final"`.
         assert config.save_consolidated.value == "final"
         assert config.is_async is False
 

--- a/tests/unit_tests/recipes/test_multimodal_finetune.py
+++ b/tests/unit_tests/recipes/test_multimodal_finetune.py
@@ -41,3 +41,23 @@ def test_bagel_auto_model_path_uses_distributed_setup_kwarg():
         }
         & keywords
     )
+
+
+def test_bagel_finalizes_pending_checkpoint_before_closing_checkpointer():
+    """Async BAGEL checkpoints must be published before the checkpointer closes."""
+    from types import SimpleNamespace
+
+    from nemo_automodel.recipes.multimodal.finetune import FinetuneRecipeForMultimodal
+
+    events = []
+    recipe = FinetuneRecipeForMultimodal.__new__(FinetuneRecipeForMultimodal)
+    recipe.model = SimpleNamespace(train=lambda: events.append("train"))
+    recipe.step_scheduler = SimpleNamespace(epochs=[])
+    recipe.metric_logger_train = SimpleNamespace(close=lambda: events.append("train_logger_close"))
+    recipe.metric_logger_valid = SimpleNamespace(close=lambda: events.append("valid_logger_close"))
+    recipe.checkpointer = SimpleNamespace(close=lambda: events.append("checkpointer_close"))
+    recipe._finalize_pending_checkpoint = lambda: events.append("finalize")
+
+    FinetuneRecipeForMultimodal.run_train_validation_loop(recipe)
+
+    assert events == ["train", "train_logger_close", "valid_logger_close", "finalize", "checkpointer_close"]

--- a/tests/unit_tests/recipes/test_train_ft.py
+++ b/tests/unit_tests/recipes/test_train_ft.py
@@ -548,10 +548,10 @@ def test_build_checkpoint_config_peft_torch_save_overrides_to_safetensors(caplog
     assert any("falling back" in rec.message.lower() for rec in caplog.records)
     assert config.is_peft is True
     assert config.model_save_format == SerializationFormat.SAFETENSORS
-    # checkpoint_dir and max_recent_checkpoints are preserved from the user config
+    # The builder preserves `checkpoint_dir` and `max_recent_checkpoints` from the user configuration.
     assert config.checkpoint_dir == "/user/ckpt/"
     assert config.max_recent_checkpoints == 2
-    # incompatible torch_save options are coerced; save_consolidated falls back to the default "final"
+    # The builder coerces incompatible `torch_save` options and restores the default `save_consolidated="final"`.
     assert config.save_consolidated.value == "final"
     assert config.is_async is False
 

--- a/tests/unit_tests/recipes/test_train_ft.py
+++ b/tests/unit_tests/recipes/test_train_ft.py
@@ -533,6 +533,7 @@ def test_build_checkpoint_config_peft_torch_save_overrides_to_safetensors(caplog
     cfg_ckpt.to_dict.return_value = {
         "model_save_format": "torch_save",
         "checkpoint_dir": "/user/ckpt/",
+        "max_recent_checkpoints": 2,
         "save_consolidated": False,
     }
 
@@ -547,9 +548,10 @@ def test_build_checkpoint_config_peft_torch_save_overrides_to_safetensors(caplog
     assert any("falling back" in rec.message.lower() for rec in caplog.records)
     assert config.is_peft is True
     assert config.model_save_format == SerializationFormat.SAFETENSORS
-    # checkpoint_dir is preserved from the user config
+    # checkpoint_dir and max_recent_checkpoints are preserved from the user config
     assert config.checkpoint_dir == "/user/ckpt/"
-    # other user-provided torch_save options are discarded; save_consolidated falls back to the default "final"
+    assert config.max_recent_checkpoints == 2
+    # incompatible torch_save options are coerced; save_consolidated falls back to the default "final"
     assert config.save_consolidated.value == "final"
     assert config.is_async is False
 


### PR DESCRIPTION
# What does this PR do?

Adds opt-in bounded checkpoint retention to prevent frequent checkpointing from filling disks when users configure a retention window. `checkpoint.max_recent_checkpoints` defaults to `None`, preserving the existing behavior of keeping all intermediate checkpoints.

Users can set `checkpoint.max_recent_checkpoints: 2` to keep the two most recent AutoModel checkpoint directories while also preserving checkpoint-root pointer targets such as `LATEST`, `LOWEST_VAL`, and other top-level checkpoint pointers. Users can set `checkpoint.max_recent_checkpoints: 1` for latest-only recent-window retention.

The active retention policy is logged during recipe startup so users can see whether checkpoint pruning is disabled or bounded before training reaches the first checkpoint save.

# Changelog

- Add `checkpoint.max_recent_checkpoints` to `CheckpointingConfig`, with validation for positive integers or `null`.
- Preserve the existing default behavior: unset/`null` keeps all intermediate checkpoints.
- Restrict bounded retention to local filesystem checkpoint directories; leave it unset for `msc://` checkpoint roots.
- Prune whole AutoModel checkpoint directories (`epoch_<n>_step_<n>`) after successful save completion when `checkpoint.max_recent_checkpoints` is set, while keeping `LATEST` resumable.
- Preserve pointer-protected checkpoints, including `LATEST`, `LOWEST_VAL`, and other top-level checkpoint pointers, during retention pruning.
- Clean up stale `LATEST`/`LOWEST_VAL` pointers only when their target no longer exists.
- Move checkpoint pointer/discovery helpers into `nemo_automodel.components.checkpoint.utils`.
- Log the active checkpoint retention policy during recipe startup, including custom speculative recipes and diffusion.
- Finalize async pending checkpoints before recipe shutdown so the final checkpoint is published and retained correctly.
- Wire finalization/retention through LLM, VLM, retrieval, diffusion, sequence classification, KD, EAGLE, DFlash, DSpark, and BAGEL/multimodal recipe paths.
- Update checkpointing docs for opt-in bounded retention, local-filesystem retention scope, pointer-protected checkpoints, and async final checkpoint publication.
- Add CPU unit coverage for default keep-all behavior, explicit retention windows, latest-only retention, sliding-window retention, pointer-protected retention, stale pointer cleanup, startup logging, custom recipe retention, LOWEST_VAL metric-key propagation, config validation, local-only retention validation, AutoModel-owned checkpoint pruning, and async finalization.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed Contributor guidelines
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

# Additional Information

Validation after rebasing onto latest `main`:

- `git diff --check origin/main..HEAD` -> clean
- `rg -n "^(<<<<<<< .+|=======$|>>>>>>> .+)" nemo_automodel tests docs` -> no conflict markers
- `uv run ruff format --check <changed Python files>` -> `23 files already formatted`
- `uv run ruff check <changed Python files>` -> `All checks passed!`
- `uv run pytest tests/unit_tests/checkpoint/test_checkpoint_config.py tests/unit_tests/recipes/test_base_recipe.py tests/unit_tests/recipes/llm/test_finalize_pending_checkpoint.py tests/unit_tests/recipes/llm/test_train_dflash.py tests/unit_tests/recipes/llm/test_train_dspark_helpers.py tests/unit_tests/recipes/llm/test_eagle_checkpoint_resume.py tests/unit_tests/recipes/llm/test_eagle_step_checkpoint.py tests/unit_tests/recipes/llm/test_train_eagle1_grad_accum.py tests/unit_tests/recipes/llm/test_train_eagle3_cleanup.py tests/unit_tests/recipes/llm/test_train_eagle3_flush.py tests/unit_tests/recipes/llm/test_train_eagle3_regen.py tests/unit_tests/recipes/llm/test_train_eagle3_tau.py tests/unit_tests/recipes/llm/test_eagle3_resume_vocab_mapping.py tests/unit_tests/speculative/test_eagle12_coverage.py tests/unit_tests/recipes/test_diffusion_train_metrics.py tests/unit_tests/recipes/test_multimodal_finetune.py tests/unit_tests/recipes/test_finetune_vlm_helpers.py::TestBuildCheckpointConfig tests/unit_tests/recipes/test_train_ft.py::test_build_checkpoint_config_peft_torch_save_overrides_to_safetensors -q` -> `405 passed, 2 skipped`
