### PR TITLE
fix(precision): dtype contract bug fixes for FSDP2 mixed-dtype loads

### DIFF
--- a/docs/guides/mixed-precision-training.md
+++ b/docs/guides/mixed-precision-training.md
@@ -10,23 +10,23 @@ Precision settings have distinct effects:
 
 | Setting | Controls | Effect on optimizer state |
 | --- | --- | --- |
-| `model.torch_dtype` | Storage dtype of the sharded parameter that PyTorch holds. | The optimizer reads `param.data`, so the EMA buffers (`exp_avg`, `exp_avg_sq` for AdamW) end up in this dtype. |
+| `model.torch_dtype` | Storage dtype of the sharded parameter that PyTorch holds. | For `torch.optim`, the optimizer reads `param.data`, so the EMA buffers (`exp_avg`, `exp_avg_sq` for AdamW) end up in this dtype. (TE FusedAdam keeps fp32 state regardless.) |
 | `mp_policy.param_dtype` | Compute dtype FSDP2 casts to during forward/backward. | None directly; this only affects matmul / activation precision. |
 | `mp_policy.reduce_dtype` | Dtype used for gradient reduce-scatter / all-reduce across DP ranks. | None directly; only affects how gradients are summed. |
 | `mp_policy.output_dtype` | Dtype FSDP2 casts module outputs to. | None directly; this affects activation tensors, including tensors that cross pipeline-parallel boundaries. |
 
 When `model.torch_dtype: bfloat16` is used with `torch.optim.AdamW`, the AdamW EMA buffers (`exp_avg` and `exp_avg_sq`) are also stored in bf16. This is fragile for long full-parameter training runs: bf16 has only a 7-bit mantissa, so small EMA updates can be rounded away even though the values themselves are still in range. Symptoms range from silent degradation - slower convergence, i.e., higher final loss at the same step count, with no visible instability - to overt failure: unstable `grad_norm`, loss bumps, loss spikes, or divergence.
 
-## Recommended fp32 Optimizer-State Patterns
+## Recommended fp32 Master Weight & Optimizer-State Patterns
 
-Use one of these patterns for long pre-training:
+Use one of these patterns for long full-parameter training (pre-training or extended fine-tuning):
 
-| Pattern | Model storage / checkpoint dtype | Optimizer state | When to use |
+| Pattern | Model storage dtype | Optimizer state | When to use |
 | --- | --- | --- | --- |
-| TE FusedAdam with bf16 model storage | bf16 | fp32 master weights + fp32 Adam EMA buffers | Use when the model has a validated TE memory/runtime path and you want training checkpoints to stay bf16. |
-| torch AdamW with `model.torch_dtype: float32` | fp32 | fp32 Adam EMA buffers | Use when the PyTorch optimizer path is the validated lower-memory or more stable path for that model. |
+| TE FusedAdam with bf16 model storage | bf16 | fp32 master weights + fp32 Adam EMA buffers | When TE has a validated memory/runtime path for the model and you want training checkpoints to stay bf16. |
+| torch AdamW with `model.torch_dtype: float32` | fp32 | fp32 master weight (the resident param) + fp32 Adam EMA buffers | Robust starting point for new or precision-sensitive models — params, gradients, and optimizer state are all fp32. Trade-off: writes fp32 training checkpoints. |
 
-Both patterns keep forward/backward compute in bf16 through FSDP2 mixed precision. They differ in where the fp32 master weight lives, how much memory the optimizer uses for a specific model, and what dtype is written to model checkpoints.
+Both patterns keep forward/backward compute in bf16 through FSDP2 mixed precision. They differ in where the fp32 master weight lives, how much peak memory they use for a specific model, and what dtype is written to the training checkpoint.
 
 ### Pattern A: TE FusedAdam + bf16 Model Storage
 
@@ -57,7 +57,11 @@ distributed:
     cast_forward_inputs: true
 ```
 
-TE FusedAdam is the cleanest way to request fp32 optimizer state without making the resident model parameter fp32. It is not a guaranteed memory reduction: depending on model architecture, sharding, and optimizer implementation details, TE can use either less or more memory than torch AdamW with fp32 resident parameters. Validate memory per model before making it the default.
+TE FusedAdam is the cleanest way to request fp32 optimizer state without making the resident model parameter fp32.
+
+It is a common misconception that TE costs extra memory for a second fp32 master. With `store_param_remainders: true` (as above), TE does **not** keep a full extra fp32 master: it stores the bf16 parameter plus a 16-bit remainder that together reconstruct the fp32 master, costing the same ~4 bytes/param as torch AdamW's fp32 resident parameter. The fp32 Adam EMA buffers (`exp_avg`, `exp_avg_sq`) are the same in both patterns, so the two optimizers' steady-state footprints are essentially equal. The practical difference is then simplicity (torch AdamW: no TE dependency, fewer moving parts) vs. keeping model storage and checkpoints in bf16 (TE).
+
+Where the two *can* differ is the gradient buffer: TE keeps the resident parameter in bf16, so its gradients are bf16, whereas torch AdamW with fp32 storage keeps parameters and gradients in fp32 (~2 bytes/param more on the gradient buffer). In practice what we measure is *peak* memory, which is usually dominated by activations rather than the optimizer step, so depending on the model (fraction of intrinsically-fp32 params, fragmentation, where the peak falls) TE can come out lower, equal, or higher. Validate memory per model before making it the default.
 
 ### Pattern B: torch AdamW + fp32 Model Storage
 
@@ -84,7 +88,13 @@ distributed:
 
 This is the PyTorch AdamW version of the master-weights pattern. Forward/backward run in bf16, the all-reduce / reduce-scatter runs in fp32, and the optimizer applies updates against fp32 resident parameters. With `torch.optim.AdamW`, the resident fp32 sharded parameter is the master weight, so there is no separate fp32 master-weight copy.
 
-The main artifact trade-off is checkpoint dtype: because AutoModel checkpoints the resident model parameters, this pattern writes model checkpoints in fp32. Keep those fp32 training checkpoints if you need exact resume. If you need a bf16 checkpoint for inference or release, export a separate model-only bf16 checkpoint after training.
+The trade-off is the dtype of the *training* checkpoint: AutoModel's training (DCP) checkpoint stores the resident model parameters, so this pattern writes them in fp32, which you keep for exact resume. This concerns only the training checkpoint; a consolidated HF checkpoint for inference or release is exported separately and follows the model's intended dtype (for fine-tuning this matches the original HF checkpoint, typically bf16). See [checkpointing](checkpointing.md) for details.
+
+### Precision and Robustness
+
+Both patterns keep the master weights and Adam EMA in fp32, so for most models they converge equivalently. The remaining difference is the gradient: under TE (Pattern A) the resident parameter is bf16, so the gradient feeding the Adam update carries bf16 rounding, while torch AdamW with fp32 storage (Pattern B) keeps the parameter, gradient, and optimizer state all in fp32.
+
+This is usually negligible. When bringing up a new model, fp32 storage (Pattern B) is a robust starting point because every part of the update path is fp32; move to TE (Pattern A) once it is validated for that model and you want bf16 checkpoints.
 
 ## Risky Pattern: torch AdamW with bf16 Model Storage
 
@@ -105,5 +115,5 @@ This keeps the resident model parameters in bf16 instead of fp32, so it can redu
 
 ## Example Configs
 
-- [`examples/llm_pretrain/llama3_70b_pretrain.yaml`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/llm_pretrain/llama3_70b_pretrain.yaml) — TE FusedAdam example. This keeps model storage and training checkpoints in bf16 while using fp32 optimizer state.
+- [`examples/llm_pretrain/llama3_70b_pretrain.yaml`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/llm_pretrain/llama3_70b_pretrain.yaml) — TE FusedAdam example. This keeps model storage and training checkpoints in bf16 while using fp32 master weights + optimizer state.
 - [`examples/llm_pretrain/megatron_pretrain_moonlight_16b_te_slurm.yaml`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/llm_pretrain/megatron_pretrain_moonlight_16b_te_slurm.yaml) — torch AdamW example. This uses `model.torch_dtype: float32` so AdamW state stays fp32 while compute remains bf16 through FSDP2 mixed precision.

--- a/docs/guides/mixed-precision-training.md
+++ b/docs/guides/mixed-precision-training.md
@@ -1,6 +1,6 @@
 # Mixed-Precision Training
 
-NeMo AutoModel uses FSDP2's [`MixedPrecisionPolicy`](https://docs.pytorch.org/docs/stable/distributed.fsdp.fully_shard.html) to control compute precision during forward and backward, and the model's storage dtype (`model.torch_dtype`) to control the precision of the *resident* sharded parameter. Together these decide what numeric precision the optimizer state ends up in, which is the part that determines whether long full-parameter training runs converge cleanly.
+NeMo AutoModel uses FSDP2's [`MixedPrecisionPolicy`](https://docs.pytorch.org/docs/stable/distributed.fsdp.fully_shard.html#torch.distributed.fsdp.MixedPrecisionPolicy) to control compute precision during forward and backward, and the model's storage dtype (`model.torch_dtype`) to control the precision of the *resident* sharded parameter. Together, these decide what numeric precision the optimizer state ends up in, which is the part that determines whether long full-parameter training runs converge cleanly.
 
 This page describes the precision patterns we recommend, and the trap that sits between them. For any long full-parameter training run (pre-training or extended fine-tuning), the key rule is: do not combine `torch.optim.AdamW` with bf16 resident parameters unless you have explicitly accepted bf16 Adam state.
 
@@ -15,20 +15,20 @@ Precision settings have distinct effects:
 | `mp_policy.reduce_dtype` | Dtype used for gradient reduce-scatter / all-reduce across DP ranks. | None directly; only affects how gradients are summed. |
 | `mp_policy.output_dtype` | Dtype FSDP2 casts module outputs to. | None directly; this affects activation tensors, including tensors that cross pipeline-parallel boundaries. |
 
-When `model.torch_dtype: bfloat16` is used with `torch.optim.AdamW`, the AdamW EMA buffers (`exp_avg` and `exp_avg_sq`) are also stored in bf16. This is fragile for long full-parameter training runs: bf16 has only a 7-bit mantissa, so small EMA updates can be rounded away even though the values themselves are still in range. Symptoms range from silent degradation - slower convergence, i.e., higher final loss at the same step count, with no visible instability - to overt failure: unstable `grad_norm`, loss bumps, loss spikes, or divergence.
+When `model.torch_dtype: bfloat16` is used with `torch.optim.AdamW`, the AdamW EMA buffers (`exp_avg` and `exp_avg_sq`) are also stored in bf16. This is fragile for long full-parameter training runs: bf16 has only a 7-bit mantissa, so small EMA updates can be rounded away even though the values themselves are still in range. Symptoms range from silent degradation (slower convergence, i.e., higher final loss at the same step count, with no visible instability) to overt failure: unstable `grad_norm`, loss bumps, loss spikes, or divergence.
 
-## Recommended fp32 Master Weight & Optimizer-State Patterns
+## Recommended fp32 Master Weight and Optimizer-State Patterns
 
 Use one of these patterns for long full-parameter training (pre-training or extended fine-tuning):
 
 | Pattern | Model storage dtype | Optimizer state | When to use |
 | --- | --- | --- | --- |
-| TE FusedAdam with bf16 model storage | bf16 | fp32 master weights + fp32 Adam EMA buffers | When TE has a validated memory/runtime path for the model and you want training checkpoints to stay bf16. |
-| torch AdamW with `model.torch_dtype: float32` | fp32 | fp32 master weight (the resident param) + fp32 Adam EMA buffers | Robust starting point for new or precision-sensitive models — params, gradients, and optimizer state are all fp32. Trade-off: writes fp32 training checkpoints. |
+| TE FusedAdam with bf16 model storage | bf16 | fp32 master weights and fp32 Adam EMA buffers | When TE has a validated memory/runtime path for the model and you want training checkpoints to stay bf16. |
+| torch AdamW with `model.torch_dtype: float32` | fp32 | fp32 master weight (the resident param) and fp32 Adam EMA buffers | Robust starting point for new or precision-sensitive models — params, gradients, and optimizer state are all fp32. Trade-off: writes fp32 training checkpoints. |
 
 Both patterns keep forward/backward compute in bf16 through FSDP2 mixed precision. They differ in where the fp32 master weight lives, how much peak memory they use for a specific model, and what dtype is written to the training checkpoint.
 
-### Pattern A: TE FusedAdam + bf16 Model Storage
+### Pattern A: TE FusedAdam and bf16 Model Storage
 
 Use Transformer Engine FusedAdam when it has been validated for the model. The resident model parameters remain bf16, so model checkpoints can stay bf16, while TE keeps the optimizer's master weights and Adam EMA buffers in fp32.
 
@@ -61,9 +61,9 @@ TE FusedAdam is the cleanest way to request fp32 optimizer state without making 
 
 It is a common misconception that TE costs extra memory for a second fp32 master. With `store_param_remainders: true` (as above), TE does **not** keep a full extra fp32 master: it stores the bf16 parameter plus a 16-bit remainder that together reconstruct the fp32 master, costing the same ~4 bytes/param as torch AdamW's fp32 resident parameter. The fp32 Adam EMA buffers (`exp_avg`, `exp_avg_sq`) are the same in both patterns, so the two optimizers' steady-state footprints are essentially equal. The practical difference is then simplicity (torch AdamW: no TE dependency, fewer moving parts) vs. keeping model storage and checkpoints in bf16 (TE).
 
-Where the two *can* differ is the gradient buffer: TE keeps the resident parameter in bf16, so its gradients are bf16, whereas torch AdamW with fp32 storage keeps parameters and gradients in fp32 (~2 bytes/param more on the gradient buffer). In practice what we measure is *peak* memory, which is usually dominated by activations rather than the optimizer step, so depending on the model (fraction of intrinsically-fp32 params, fragmentation, where the peak falls) TE can come out lower, equal, or higher. Validate memory per model before making it the default.
+Where the two *can* differ is the gradient buffer: TE keeps the resident parameter in bf16, so its gradients are bf16, whereas torch AdamW with fp32 storage keeps parameters and gradients in fp32 (~2 bytes/param more on the gradient buffer). In practice, what we measure is *peak* memory, which is usually dominated by activations rather than the optimizer step, so depending on the model (fraction of intrinsically-fp32 params, fragmentation, where the peak falls), TE can come out lower, equal, or higher. Validate memory per model before making it the default.
 
-### Pattern B: torch AdamW + fp32 Model Storage
+### Pattern B: torch AdamW and fp32 Model Storage
 
 ```yaml
 model:
@@ -88,13 +88,13 @@ distributed:
 
 This is the PyTorch AdamW version of the master-weights pattern. Forward/backward run in bf16, the all-reduce / reduce-scatter runs in fp32, and the optimizer applies updates against fp32 resident parameters. With `torch.optim.AdamW`, the resident fp32 sharded parameter is the master weight, so there is no separate fp32 master-weight copy.
 
-The trade-off is the dtype of the *training* checkpoint: AutoModel's training (DCP) checkpoint stores the resident model parameters, so this pattern writes them in fp32, which you keep for exact resume. This concerns only the training checkpoint; a consolidated HF checkpoint for inference or release is exported separately and follows the model's intended dtype (for fine-tuning this matches the original HF checkpoint, typically bf16). See [checkpointing](checkpointing.md) for details.
+The trade-off is the dtype of the *training* checkpoint: AutoModel's training (DCP) checkpoint stores the resident model parameters, so this pattern writes them in fp32, which you keep for exact resume. This concerns only the training checkpoint; a consolidated HF checkpoint for inference or release is exported separately and follows the model's intended dtype (for fine-tuning, this matches the original HF checkpoint, typically bf16). See [checkpointing](checkpointing.md) for details.
 
 ### Precision and Robustness
 
 Both patterns keep the master weights and Adam EMA in fp32, so for most models they converge equivalently. The remaining difference is the gradient: under TE (Pattern A) the resident parameter is bf16, so the gradient feeding the Adam update carries bf16 rounding, while torch AdamW with fp32 storage (Pattern B) keeps the parameter, gradient, and optimizer state all in fp32.
 
-This is usually negligible. When bringing up a new model, fp32 storage (Pattern B) is a robust starting point because every part of the update path is fp32; move to TE (Pattern A) once it is validated for that model and you want bf16 checkpoints.
+This is usually negligible. When bringing up a new model, fp32 storage (Pattern B) is a robust starting point because every part of the update path is fp32; move to TE (Pattern A) after it is validated for that model and you want bf16 checkpoints.
 
 ## Risky Pattern: torch AdamW with bf16 Model Storage
 
@@ -111,9 +111,9 @@ distributed:
   strategy: fsdp2
 ```
 
-This keeps the resident model parameters in bf16 instead of fp32, so it can reduce memory usage compared with the torch AdamW + `model.torch_dtype: float32` pattern. It is common in existing fine-tuning example configs and is probably acceptable for short fine-tuning runs or LoRA / PEFT. It is **not** recommended for long full-parameter training (pre-training or extended fine-tuning): bf16 EMA quantization can quietly slow convergence (higher final loss at the same step count) and, in worse cases, produce unstable `grad_norm`, loss bumps, loss spikes, or divergence.
+This keeps the resident model parameters in bf16 instead of fp32, so it can reduce memory usage compared with the torch AdamW and `model.torch_dtype: float32` pattern. It is common in existing fine-tuning example configs and is probably acceptable for short fine-tuning runs or LoRA/PEFT. It is **not** recommended for long full-parameter training (pre-training or extended fine-tuning): bf16 EMA quantization can quietly slow convergence (higher final loss at the same step count) and, in worse cases, produce unstable `grad_norm`, loss bumps, loss spikes, or divergence.
 
 ## Example Configs
 
-- [`examples/llm_pretrain/llama3_70b_pretrain.yaml`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/llm_pretrain/llama3_70b_pretrain.yaml) — TE FusedAdam example. This keeps model storage and training checkpoints in bf16 while using fp32 master weights + optimizer state.
-- [`examples/llm_pretrain/megatron_pretrain_moonlight_16b_te_slurm.yaml`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/llm_pretrain/megatron_pretrain_moonlight_16b_te_slurm.yaml) — torch AdamW example. This uses `model.torch_dtype: float32` so AdamW state stays fp32 while compute remains bf16 through FSDP2 mixed precision.
+- [`examples/llm_pretrain/llama3_70b_pretrain.yaml`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/llm_pretrain/llama3_70b_pretrain.yaml): TE FusedAdam example. This keeps model storage and training checkpoints in bf16 while using fp32 master weights and optimizer state.
+- [`examples/llm_pretrain/megatron_pretrain_moonlight_16b_te_slurm.yaml`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/llm_pretrain/megatron_pretrain_moonlight_16b_te_slurm.yaml): torch AdamW example. This uses `model.torch_dtype: float32` so AdamW state stays fp32 while compute remains bf16 through FSDP2 mixed precision.

--- a/docs/guides/mixed-precision-training.md
+++ b/docs/guides/mixed-precision-training.md
@@ -1,6 +1,6 @@
 # Mixed-Precision Training
 
-NeMo AutoModel uses FSDP2's [`MixedPrecisionPolicy`](https://docs.pytorch.org/docs/stable/distributed.fsdp.fully_shard.html#torch.distributed.fsdp.MixedPrecisionPolicy) to control compute precision during forward and backward, and the model's storage dtype (`model.torch_dtype`) to control the precision of the *resident* sharded parameter. Together, these decide what numeric precision the optimizer state ends up in, which is the part that determines whether long full-parameter training runs converge cleanly.
+NeMo AutoModel uses FSDP2's [`MixedPrecisionPolicy`](https://docs.pytorch.org/docs/stable/distributed.fsdp.fully_shard.html) to control compute precision during forward and backward, and the model's storage dtype (`model.torch_dtype`) to control the precision of the *resident* sharded parameter. Together, these decide what numeric precision the optimizer state ends up in, which is the part that determines whether long full-parameter training runs converge cleanly.
 
 This page describes the precision patterns we recommend, and the trap that sits between them. For any long full-parameter training run (pre-training or extended fine-tuning), the key rule is: do not combine `torch.optim.AdamW` with bf16 resident parameters unless you have explicitly accepted bf16 Adam state.
 

--- a/fern/versions/nightly/pages/guides/mixed-precision-training.mdx
+++ b/fern/versions/nightly/pages/guides/mixed-precision-training.mdx
@@ -3,7 +3,7 @@ title: "Mixed-Precision Training"
 description: "Recommended dtype patterns for fp32 master weights and optimizer state, bf16 compute, and FSDP2 mixed precision in NeMo AutoModel."
 ---
 
-NeMo AutoModel uses FSDP2's [`MixedPrecisionPolicy`](https://docs.pytorch.org/docs/stable/distributed.fsdp.fully_shard.html#torch.distributed.fsdp.MixedPrecisionPolicy) to control compute precision during forward and backward, and the model's storage dtype (`model.torch_dtype`) to control the precision of the *resident* sharded parameter. Together, these decide what numeric precision the optimizer state ends up in, which is the part that determines whether long full-parameter training runs converge cleanly.
+NeMo AutoModel uses FSDP2's [`MixedPrecisionPolicy`](https://docs.pytorch.org/docs/stable/distributed.fsdp.fully_shard.html) to control compute precision during forward and backward, and the model's storage dtype (`model.torch_dtype`) to control the precision of the *resident* sharded parameter. Together, these decide what numeric precision the optimizer state ends up in, which is the part that determines whether long full-parameter training runs converge cleanly.
 
 This page describes the precision patterns we recommend, and the trap that sits between them. For any long full-parameter training run (pre-training or extended fine-tuning), the key rule is: do not combine `torch.optim.AdamW` with bf16 resident parameters unless you have explicitly accepted bf16 Adam state.
 

--- a/fern/versions/nightly/pages/guides/mixed-precision-training.mdx
+++ b/fern/versions/nightly/pages/guides/mixed-precision-training.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Mixed-Precision Training"
-description: "Recommended dtype patterns for fp32 optimizer state, bf16 compute, and FSDP2 mixed precision in NeMo AutoModel."
+description: "Recommended dtype patterns for fp32 master weights and optimizer state, bf16 compute, and FSDP2 mixed precision in NeMo AutoModel."
 ---
 
 NeMo AutoModel uses FSDP2's [`MixedPrecisionPolicy`](https://docs.pytorch.org/docs/stable/distributed.fsdp.fully_shard.html) to control compute precision during forward and backward, and the model's storage dtype (`model.torch_dtype`) to control the precision of the *resident* sharded parameter. Together these decide what numeric precision the optimizer state ends up in, which is the part that determines whether long full-parameter training runs converge cleanly.
@@ -13,23 +13,23 @@ Precision settings have distinct effects:
 
 | Setting | Controls | Effect on optimizer state |
 | --- | --- | --- |
-| `model.torch_dtype` | Storage dtype of the sharded parameter that PyTorch holds. | The optimizer reads `param.data`, so the EMA buffers (`exp_avg`, `exp_avg_sq` for AdamW) end up in this dtype. |
+| `model.torch_dtype` | Storage dtype of the sharded parameter that PyTorch holds. | For `torch.optim`, the optimizer reads `param.data`, so the EMA buffers (`exp_avg`, `exp_avg_sq` for AdamW) end up in this dtype. (TE FusedAdam keeps fp32 state regardless.) |
 | `mp_policy.param_dtype` | Compute dtype FSDP2 casts to during forward/backward. | None directly; this only affects matmul / activation precision. |
 | `mp_policy.reduce_dtype` | Dtype used for gradient reduce-scatter / all-reduce across DP ranks. | None directly; only affects how gradients are summed. |
 | `mp_policy.output_dtype` | Dtype FSDP2 casts module outputs to. | None directly; this affects activation tensors, including tensors that cross pipeline-parallel boundaries. |
 
 When `model.torch_dtype: bfloat16` is used with `torch.optim.AdamW`, the AdamW EMA buffers (`exp_avg` and `exp_avg_sq`) are also stored in bf16. This is fragile for long full-parameter training runs: bf16 has only a 7-bit mantissa, so small EMA updates can be rounded away even though the values themselves are still in range. Symptoms range from silent degradation - slower convergence, i.e., higher final loss at the same step count, with no visible instability - to overt failure: unstable `grad_norm`, loss bumps, loss spikes, or divergence.
 
-## Recommended fp32 Optimizer-State Patterns
+## Recommended fp32 Master Weight & Optimizer-State Patterns
 
-Use one of these patterns for long pre-training:
+Use one of these patterns for long full-parameter training (pre-training or extended fine-tuning):
 
-| Pattern | Model storage / checkpoint dtype | Optimizer state | When to use |
+| Pattern | Model storage dtype | Optimizer state | When to use |
 | --- | --- | --- | --- |
-| TE FusedAdam with bf16 model storage | bf16 | fp32 master weights + fp32 Adam EMA buffers | Use when the model has a validated TE memory/runtime path and you want training checkpoints to stay bf16. |
-| torch AdamW with `model.torch_dtype: float32` | fp32 | fp32 Adam EMA buffers | Use when the PyTorch optimizer path is the validated lower-memory or more stable path for that model. |
+| TE FusedAdam with bf16 model storage | bf16 | fp32 master weights + fp32 Adam EMA buffers | When TE has a validated memory/runtime path for the model and you want training checkpoints to stay bf16. |
+| torch AdamW with `model.torch_dtype: float32` | fp32 | fp32 master weight (the resident param) + fp32 Adam EMA buffers | Robust starting point for new or precision-sensitive models — params, gradients, and optimizer state are all fp32. Trade-off: writes fp32 training checkpoints. |
 
-Both patterns keep forward/backward compute in bf16 through FSDP2 mixed precision. They differ in where the fp32 master weight lives, how much memory the optimizer uses for a specific model, and what dtype is written to model checkpoints.
+Both patterns keep forward/backward compute in bf16 through FSDP2 mixed precision. They differ in where the fp32 master weight lives, how much peak memory they use for a specific model, and what dtype is written to the training checkpoint.
 
 ### Pattern A: TE FusedAdam + bf16 Model Storage
 
@@ -60,7 +60,11 @@ distributed:
     cast_forward_inputs: true
 ```
 
-TE FusedAdam is the cleanest way to request fp32 optimizer state without making the resident model parameter fp32. It is not a guaranteed memory reduction: depending on model architecture, sharding, and optimizer implementation details, TE can use either less or more memory than torch AdamW with fp32 resident parameters. Validate memory per model before making it the default.
+TE FusedAdam is the cleanest way to request fp32 optimizer state without making the resident model parameter fp32.
+
+It is a common misconception that TE costs extra memory for a second fp32 master. With `store_param_remainders: true` (as above), TE does **not** keep a full extra fp32 master: it stores the bf16 parameter plus a 16-bit remainder that together reconstruct the fp32 master, costing the same ~4 bytes/param as torch AdamW's fp32 resident parameter. The fp32 Adam EMA buffers (`exp_avg`, `exp_avg_sq`) are the same in both patterns, so the two optimizers' steady-state footprints are essentially equal. The practical difference is then simplicity (torch AdamW: no TE dependency, fewer moving parts) vs. keeping model storage and checkpoints in bf16 (TE).
+
+Where the two *can* differ is the gradient buffer: TE keeps the resident parameter in bf16, so its gradients are bf16, whereas torch AdamW with fp32 storage keeps parameters and gradients in fp32 (~2 bytes/param more on the gradient buffer). In practice what we measure is *peak* memory, which is usually dominated by activations rather than the optimizer step, so depending on the model (fraction of intrinsically-fp32 params, fragmentation, where the peak falls) TE can come out lower, equal, or higher. Validate memory per model before making it the default.
 
 ### Pattern B: torch AdamW + fp32 Model Storage
 
@@ -87,7 +91,13 @@ distributed:
 
 This is the PyTorch AdamW version of the master-weights pattern. Forward/backward run in bf16, the all-reduce / reduce-scatter runs in fp32, and the optimizer applies updates against fp32 resident parameters. With `torch.optim.AdamW`, the resident fp32 sharded parameter is the master weight, so there is no separate fp32 master-weight copy.
 
-The main artifact trade-off is checkpoint dtype: because AutoModel checkpoints the resident model parameters, this pattern writes model checkpoints in fp32. Keep those fp32 training checkpoints if you need exact resume. If you need a bf16 checkpoint for inference or release, export a separate model-only bf16 checkpoint after training.
+The trade-off is the dtype of the *training* checkpoint: AutoModel's training (DCP) checkpoint stores the resident model parameters, so this pattern writes them in fp32, which you keep for exact resume. This concerns only the training checkpoint; a consolidated HF checkpoint for inference or release is exported separately and follows the model's intended dtype (for fine-tuning this matches the original HF checkpoint, typically bf16). See [checkpointing](/development/checkpointing) for details.
+
+### Precision and Robustness
+
+Both patterns keep the master weights and Adam EMA in fp32, so for most models they converge equivalently. The remaining difference is the gradient: under TE (Pattern A) the resident parameter is bf16, so the gradient feeding the Adam update carries bf16 rounding, while torch AdamW with fp32 storage (Pattern B) keeps the parameter, gradient, and optimizer state all in fp32.
+
+This is usually negligible. When bringing up a new model, fp32 storage (Pattern B) is a robust starting point because every part of the update path is fp32; move to TE (Pattern A) once it is validated for that model and you want bf16 checkpoints.
 
 ## Risky Pattern: torch AdamW with bf16 Model Storage
 
@@ -108,5 +118,5 @@ This keeps the resident model parameters in bf16 instead of fp32, so it can redu
 
 ## Example Configs
 
-- [`examples/llm_pretrain/llama3_70b_pretrain.yaml`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/llm_pretrain/llama3_70b_pretrain.yaml) — TE FusedAdam example. This keeps model storage and training checkpoints in bf16 while using fp32 optimizer state.
+- [`examples/llm_pretrain/llama3_70b_pretrain.yaml`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/llm_pretrain/llama3_70b_pretrain.yaml) — TE FusedAdam example. This keeps model storage and training checkpoints in bf16 while using fp32 master weights + optimizer state.
 - [`examples/llm_pretrain/megatron_pretrain_moonlight_16b_te_slurm.yaml`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/llm_pretrain/megatron_pretrain_moonlight_16b_te_slurm.yaml) — torch AdamW example. This uses `model.torch_dtype: float32` so AdamW state stays fp32 while compute remains bf16 through FSDP2 mixed precision.

--- a/fern/versions/nightly/pages/guides/mixed-precision-training.mdx
+++ b/fern/versions/nightly/pages/guides/mixed-precision-training.mdx
@@ -3,7 +3,7 @@ title: "Mixed-Precision Training"
 description: "Recommended dtype patterns for fp32 master weights and optimizer state, bf16 compute, and FSDP2 mixed precision in NeMo AutoModel."
 ---
 
-NeMo AutoModel uses FSDP2's [`MixedPrecisionPolicy`](https://docs.pytorch.org/docs/stable/distributed.fsdp.fully_shard.html) to control compute precision during forward and backward, and the model's storage dtype (`model.torch_dtype`) to control the precision of the *resident* sharded parameter. Together these decide what numeric precision the optimizer state ends up in, which is the part that determines whether long full-parameter training runs converge cleanly.
+NeMo AutoModel uses FSDP2's [`MixedPrecisionPolicy`](https://docs.pytorch.org/docs/stable/distributed.fsdp.fully_shard.html#torch.distributed.fsdp.MixedPrecisionPolicy) to control compute precision during forward and backward, and the model's storage dtype (`model.torch_dtype`) to control the precision of the *resident* sharded parameter. Together, these decide what numeric precision the optimizer state ends up in, which is the part that determines whether long full-parameter training runs converge cleanly.
 
 This page describes the precision patterns we recommend, and the trap that sits between them. For any long full-parameter training run (pre-training or extended fine-tuning), the key rule is: do not combine `torch.optim.AdamW` with bf16 resident parameters unless you have explicitly accepted bf16 Adam state.
 
@@ -18,20 +18,20 @@ Precision settings have distinct effects:
 | `mp_policy.reduce_dtype` | Dtype used for gradient reduce-scatter / all-reduce across DP ranks. | None directly; only affects how gradients are summed. |
 | `mp_policy.output_dtype` | Dtype FSDP2 casts module outputs to. | None directly; this affects activation tensors, including tensors that cross pipeline-parallel boundaries. |
 
-When `model.torch_dtype: bfloat16` is used with `torch.optim.AdamW`, the AdamW EMA buffers (`exp_avg` and `exp_avg_sq`) are also stored in bf16. This is fragile for long full-parameter training runs: bf16 has only a 7-bit mantissa, so small EMA updates can be rounded away even though the values themselves are still in range. Symptoms range from silent degradation - slower convergence, i.e., higher final loss at the same step count, with no visible instability - to overt failure: unstable `grad_norm`, loss bumps, loss spikes, or divergence.
+When `model.torch_dtype: bfloat16` is used with `torch.optim.AdamW`, the AdamW EMA buffers (`exp_avg` and `exp_avg_sq`) are also stored in bf16. This is fragile for long full-parameter training runs: bf16 has only a 7-bit mantissa, so small EMA updates can be rounded away even though the values themselves are still in range. Symptoms range from silent degradation (slower convergence, i.e., higher final loss at the same step count, with no visible instability) to overt failure: unstable `grad_norm`, loss bumps, loss spikes, or divergence.
 
-## Recommended fp32 Master Weight & Optimizer-State Patterns
+## Recommended fp32 Master Weight and Optimizer-State Patterns
 
 Use one of these patterns for long full-parameter training (pre-training or extended fine-tuning):
 
 | Pattern | Model storage dtype | Optimizer state | When to use |
 | --- | --- | --- | --- |
-| TE FusedAdam with bf16 model storage | bf16 | fp32 master weights + fp32 Adam EMA buffers | When TE has a validated memory/runtime path for the model and you want training checkpoints to stay bf16. |
-| torch AdamW with `model.torch_dtype: float32` | fp32 | fp32 master weight (the resident param) + fp32 Adam EMA buffers | Robust starting point for new or precision-sensitive models — params, gradients, and optimizer state are all fp32. Trade-off: writes fp32 training checkpoints. |
+| TE FusedAdam with bf16 model storage | bf16 | fp32 master weights and fp32 Adam EMA buffers | When TE has a validated memory/runtime path for the model and you want training checkpoints to stay bf16. |
+| torch AdamW with `model.torch_dtype: float32` | fp32 | fp32 master weight (the resident param) and fp32 Adam EMA buffers | Robust starting point for new or precision-sensitive models — params, gradients, and optimizer state are all fp32. Trade-off: writes fp32 training checkpoints. |
 
 Both patterns keep forward/backward compute in bf16 through FSDP2 mixed precision. They differ in where the fp32 master weight lives, how much peak memory they use for a specific model, and what dtype is written to the training checkpoint.
 
-### Pattern A: TE FusedAdam + bf16 Model Storage
+### Pattern A: TE FusedAdam and bf16 Model Storage
 
 Use Transformer Engine FusedAdam when it has been validated for the model. The resident model parameters remain bf16, so model checkpoints can stay bf16, while TE keeps the optimizer's master weights and Adam EMA buffers in fp32.
 
@@ -64,9 +64,9 @@ TE FusedAdam is the cleanest way to request fp32 optimizer state without making 
 
 It is a common misconception that TE costs extra memory for a second fp32 master. With `store_param_remainders: true` (as above), TE does **not** keep a full extra fp32 master: it stores the bf16 parameter plus a 16-bit remainder that together reconstruct the fp32 master, costing the same ~4 bytes/param as torch AdamW's fp32 resident parameter. The fp32 Adam EMA buffers (`exp_avg`, `exp_avg_sq`) are the same in both patterns, so the two optimizers' steady-state footprints are essentially equal. The practical difference is then simplicity (torch AdamW: no TE dependency, fewer moving parts) vs. keeping model storage and checkpoints in bf16 (TE).
 
-Where the two *can* differ is the gradient buffer: TE keeps the resident parameter in bf16, so its gradients are bf16, whereas torch AdamW with fp32 storage keeps parameters and gradients in fp32 (~2 bytes/param more on the gradient buffer). In practice what we measure is *peak* memory, which is usually dominated by activations rather than the optimizer step, so depending on the model (fraction of intrinsically-fp32 params, fragmentation, where the peak falls) TE can come out lower, equal, or higher. Validate memory per model before making it the default.
+Where the two *can* differ is the gradient buffer: TE keeps the resident parameter in bf16, so its gradients are bf16, whereas torch AdamW with fp32 storage keeps parameters and gradients in fp32 (~2 bytes/param more on the gradient buffer). In practice, what we measure is *peak* memory, which is usually dominated by activations rather than the optimizer step, so depending on the model (fraction of intrinsically-fp32 params, fragmentation, where the peak falls), TE can come out lower, equal, or higher. Validate memory per model before making it the default.
 
-### Pattern B: torch AdamW + fp32 Model Storage
+### Pattern B: torch AdamW and fp32 Model Storage
 
 ```yaml
 model:
@@ -91,13 +91,13 @@ distributed:
 
 This is the PyTorch AdamW version of the master-weights pattern. Forward/backward run in bf16, the all-reduce / reduce-scatter runs in fp32, and the optimizer applies updates against fp32 resident parameters. With `torch.optim.AdamW`, the resident fp32 sharded parameter is the master weight, so there is no separate fp32 master-weight copy.
 
-The trade-off is the dtype of the *training* checkpoint: AutoModel's training (DCP) checkpoint stores the resident model parameters, so this pattern writes them in fp32, which you keep for exact resume. This concerns only the training checkpoint; a consolidated HF checkpoint for inference or release is exported separately and follows the model's intended dtype (for fine-tuning this matches the original HF checkpoint, typically bf16). See [checkpointing](/development/checkpointing) for details.
+The trade-off is the dtype of the *training* checkpoint: AutoModel's training (DCP) checkpoint stores the resident model parameters, so this pattern writes them in fp32, which you keep for exact resume. This concerns only the training checkpoint; a consolidated HF checkpoint for inference or release is exported separately and follows the model's intended dtype (for fine-tuning, this matches the original HF checkpoint, typically bf16). See [checkpointing](/development/checkpointing) for details.
 
 ### Precision and Robustness
 
 Both patterns keep the master weights and Adam EMA in fp32, so for most models they converge equivalently. The remaining difference is the gradient: under TE (Pattern A) the resident parameter is bf16, so the gradient feeding the Adam update carries bf16 rounding, while torch AdamW with fp32 storage (Pattern B) keeps the parameter, gradient, and optimizer state all in fp32.
 
-This is usually negligible. When bringing up a new model, fp32 storage (Pattern B) is a robust starting point because every part of the update path is fp32; move to TE (Pattern A) once it is validated for that model and you want bf16 checkpoints.
+This is usually negligible. When bringing up a new model, fp32 storage (Pattern B) is a robust starting point because every part of the update path is fp32; move to TE (Pattern A) after it is validated for that model and you want bf16 checkpoints.
 
 ## Risky Pattern: torch AdamW with bf16 Model Storage
 
@@ -114,9 +114,9 @@ distributed:
   strategy: fsdp2
 ```
 
-This keeps the resident model parameters in bf16 instead of fp32, so it can reduce memory usage compared with the torch AdamW + `model.torch_dtype: float32` pattern. It is common in existing fine-tuning example configs and is probably acceptable for short fine-tuning runs or LoRA / PEFT. It is **not** recommended for long full-parameter training (pre-training or extended fine-tuning): bf16 EMA quantization can quietly slow convergence (higher final loss at the same step count) and, in worse cases, produce unstable `grad_norm`, loss bumps, loss spikes, or divergence.
+This keeps the resident model parameters in bf16 instead of fp32, so it can reduce memory usage compared with the torch AdamW and `model.torch_dtype: float32` pattern. It is common in existing fine-tuning example configs and is probably acceptable for short fine-tuning runs or LoRA/PEFT. It is **not** recommended for long full-parameter training (pre-training or extended fine-tuning): bf16 EMA quantization can quietly slow convergence (higher final loss at the same step count) and, in worse cases, produce unstable `grad_norm`, loss bumps, loss spikes, or divergence.
 
 ## Example Configs
 
-- [`examples/llm_pretrain/llama3_70b_pretrain.yaml`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/llm_pretrain/llama3_70b_pretrain.yaml) — TE FusedAdam example. This keeps model storage and training checkpoints in bf16 while using fp32 master weights + optimizer state.
-- [`examples/llm_pretrain/megatron_pretrain_moonlight_16b_te_slurm.yaml`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/llm_pretrain/megatron_pretrain_moonlight_16b_te_slurm.yaml) — torch AdamW example. This uses `model.torch_dtype: float32` so AdamW state stays fp32 while compute remains bf16 through FSDP2 mixed precision.
+- [`examples/llm_pretrain/llama3_70b_pretrain.yaml`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/llm_pretrain/llama3_70b_pretrain.yaml): TE FusedAdam example. This keeps model storage and training checkpoints in bf16 while using fp32 master weights and optimizer state.
+- [`examples/llm_pretrain/megatron_pretrain_moonlight_16b_te_slurm.yaml`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/llm_pretrain/megatron_pretrain_moonlight_16b_te_slurm.yaml): torch AdamW example. This uses `model.torch_dtype: float32` so AdamW state stays fp32 while compute remains bf16 through FSDP2 mixed precision.

--- a/nemo_automodel/_transformers/infrastructure.py
+++ b/nemo_automodel/_transformers/infrastructure.py
@@ -52,6 +52,7 @@ from nemo_automodel.components.distributed.mesh import MeshContext
 from nemo_automodel.components.distributed.pipelining.autopipeline import AutoPipeline
 from nemo_automodel.components.distributed.pipelining.config import PipelineConfig
 from nemo_automodel.components.loss.masked_ce import MaskedCrossEntropy
+from nemo_automodel.components.models.common.utils import cast_frozen_modules_to_compute_dtype
 from nemo_automodel.components.moe.config import MoEParallelizerConfig
 from nemo_automodel.components.quantization.fp8 import apply_fp8_to_model
 from nemo_automodel.components.quantization.qat import QATConfig
@@ -625,6 +626,17 @@ def apply_model_infrastructure(
             attach_context_parallel_hooks(mp)
             if is_compile_enabled:
                 attach_cp_sdpa_hooks(mp, cp_mesh)
+
+    # Frozen submodules (e.g. a frozen vision tower) are excluded from FSDP wrapping
+    # (see apply_fsdp tower skipping) and so never receive the FSDP param_dtype cast.
+    # Under fp32 master weights + bf16 mixed-precision compute that leaves a frozen
+    # fp32 module feeding bf16 trainable modules -> dtype-mismatch matmul at the seam.
+    # Cast those frozen modules to the compute dtype so the whole forward runs uniformly.
+    # No-op for pure-fp32 / pure-bf16 runs and when no mp_policy is available (DDP/PP).
+    compute_dtype = getattr(getattr(model_wrapper, "mp_policy", None), "param_dtype", None)
+    if compute_dtype is not None:
+        for mp in model.parts if hasattr(model, "parts") else [model]:
+            cast_frozen_modules_to_compute_dtype(mp, compute_dtype)
 
     model = _apply_runtime_compatibility_fixes(model)
     return model

--- a/nemo_automodel/_transformers/infrastructure.py
+++ b/nemo_automodel/_transformers/infrastructure.py
@@ -627,12 +627,14 @@ def apply_model_infrastructure(
             if is_compile_enabled:
                 attach_cp_sdpa_hooks(mp, cp_mesh)
 
-    # Frozen submodules (e.g. a frozen vision tower) are excluded from FSDP wrapping
-    # (see apply_fsdp tower skipping) and so never receive the FSDP param_dtype cast.
-    # Under fp32 master weights + bf16 mixed-precision compute that leaves a frozen
-    # fp32 module feeding bf16 trainable modules -> dtype-mismatch matmul at the seam.
-    # Cast those frozen modules to the compute dtype so the whole forward runs uniformly.
-    # No-op for pure-fp32 / pure-bf16 runs and when no mp_policy is available (DDP/PP).
+    # Frozen submodules (e.g. a frozen vision tower) either land in the root FSDP unit
+    # (sharded) or are excluded from wrapping, depending on the model/parallelizer. In
+    # both cases FSDP mixed precision never casts their buffers, and an excluded frozen
+    # module also keeps its storage-dtype params. Under fp32 master weights + bf16 compute
+    # that leaves frozen fp32 tensors feeding bf16 trainable modules -> dtype-mismatch
+    # matmul at the seam. Cast frozen params/buffers to the compute dtype so the whole
+    # forward runs uniformly. No-op for pure-fp32 / pure-bf16 runs and when no mp_policy
+    # is available (DDP/PP).
     compute_dtype = getattr(getattr(model_wrapper, "mp_policy", None), "param_dtype", None)
     if compute_dtype is not None:
         for mp in model.parts if hasattr(model, "parts") else [model]:

--- a/nemo_automodel/_transformers/model_init.py
+++ b/nemo_automodel/_transformers/model_init.py
@@ -620,15 +620,29 @@ def _get_model_tensor(model, name: str):
 
 
 def _restore_loaded_model_dtype(
-    model, pretrained_model_name_or_path, hf_config, quantization_config, load_kwargs
+    model, pretrained_model_name_or_path, hf_config, quantization_config, load_kwargs, requested_dtype=None
 ) -> None:
-    """Restore each loaded tensor to the exact dtype stored in the checkpoint.
+    """Unify each loaded tensor's dtype after HuggingFace's mixed-dtype load.
 
     Some modules allocate parameters in a wider dtype than the checkpoint.
     HuggingFace then copies the checkpoint tensor into that existing tensor,
-    which upcasts the loaded value. We fix that by re-inspecting checkpoint
-    tensor dtypes per key and restoring each loaded parameter/buffer to the
-    dtype that was actually stored in the file.
+    which upcasts the loaded value, leaving the model with a mix of dtypes that
+    trips FSDP2's uniform-original-dtype check. We fix that by re-inspecting the
+    checkpoint tensor dtypes per key and unifying each loaded parameter/buffer.
+
+    The unification target depends on ``requested_dtype``:
+
+      * ``None`` (the user passed ``torch_dtype="auto"``): restore each tensor to
+        the exact dtype stored in the checkpoint -- faithfully mirror the file.
+      * an explicit ``torch.dtype``: restore each floating tensor to the *wider*
+        of (checkpoint dtype, requested dtype). This honors an explicit fp32
+        request (so parameters can serve as fp32 master weights) while preserving
+        intrinsically-fp32 checkpoint params (e.g. ``A_log``) even under a bf16
+        request, and is a no-op for the common bf16/auto case.
+
+    Args:
+        requested_dtype: The resolved ``torch_dtype`` the caller requested, or
+            None when ``"auto"`` was requested.
     """
     if quantization_config is not None or getattr(hf_config, "quantization_config", None) is not None:
         return
@@ -652,26 +666,38 @@ def _restore_loaded_model_dtype(
     restored_count = 0
     for name, checkpoint_dtype in checkpoint_dtypes.items():
         tensor = _get_model_tensor(model, name)
-        if tensor is None or tensor.dtype == checkpoint_dtype:
+        if tensor is None:
+            continue
+
+        # Pick the unification target. For an explicit floating request, take the
+        # wider of (checkpoint, requested) so explicit fp32 is honored as master
+        # weights while intrinsically-fp32 checkpoint params survive a bf16 request.
+        # For "auto" (requested_dtype is None) or non-floating tensors, mirror the
+        # checkpoint dtype exactly (preserves today's behavior).
+        target_dtype = checkpoint_dtype
+        if requested_dtype is not None and checkpoint_dtype.is_floating_point and tensor.dtype.is_floating_point:
+            target_dtype = torch.promote_types(checkpoint_dtype, requested_dtype)
+
+        if tensor.dtype == target_dtype:
             continue
 
         seen_dtype = restored_dtype_by_tensor_id.get(id(tensor))
-        if seen_dtype is not None and seen_dtype != checkpoint_dtype:
+        if seen_dtype is not None and seen_dtype != target_dtype:
             logger.warning(
                 "Skipping conflicting checkpoint dtypes for aliased tensor %s: %s vs %s",
                 name,
                 seen_dtype,
-                checkpoint_dtype,
+                target_dtype,
             )
             continue
 
         try:
-            tensor.data = tensor.data.to(dtype=checkpoint_dtype)
+            tensor.data = tensor.data.to(dtype=target_dtype)
         except (RuntimeError, TypeError) as exc:
-            logger.warning("Failed to restore checkpoint dtype for %s to %s: %s", name, checkpoint_dtype, exc)
+            logger.warning("Failed to restore checkpoint dtype for %s to %s: %s", name, target_dtype, exc)
             continue
 
-        restored_dtype_by_tensor_id[id(tensor)] = checkpoint_dtype
+        restored_dtype_by_tensor_id[id(tensor)] = target_dtype
         restored_count += 1
 
     if restored_count > 0:
@@ -759,7 +785,12 @@ def __init_model(
                 )
             if restore_loaded_dtype:
                 _restore_loaded_model_dtype(
-                    model, pretrained_model_name_or_path, hf_config, quantization_config, kwargs
+                    model,
+                    pretrained_model_name_or_path,
+                    hf_config,
+                    quantization_config,
+                    kwargs,
+                    requested_dtype=(torch_dtype if torch_dtype != "auto" else None),
                 )
         else:
             model = cls._from_config_parent_class(
@@ -842,7 +873,14 @@ def __init_model(
                 **kwargs,
             )
         if restore_loaded_dtype:
-            _restore_loaded_model_dtype(model, pretrained_model_name_or_path, hf_config, quantization_config, kwargs)
+            _restore_loaded_model_dtype(
+                model,
+                pretrained_model_name_or_path,
+                hf_config,
+                quantization_config,
+                kwargs,
+                requested_dtype=(torch_dtype if torch_dtype != "auto" else None),
+            )
     else:
         model = cls._from_config_parent_class(
             hf_config,

--- a/nemo_automodel/_transformers/model_init.py
+++ b/nemo_automodel/_transformers/model_init.py
@@ -669,6 +669,14 @@ def _restore_loaded_model_dtype(
         if tensor is None:
             continue
 
+        # Record the checkpoint's original dtype on the tensor as the compute-dtype
+        # hint. Storage may be upcast below (fp32 master weights), which erases the
+        # dtype HF intended for compute; downstream sharding (fully_shard_by_dtype)
+        # reads ``_hf_compute_dtype`` to keep intrinsically-fp32 params (e.g. ``A_log``)
+        # computing in fp32 while the bulk computes in mp_policy.param_dtype.
+        if checkpoint_dtype.is_floating_point and tensor.dtype.is_floating_point:
+            tensor._hf_compute_dtype = checkpoint_dtype
+
         # Pick the unification target. For an explicit floating request, take the
         # wider of (checkpoint, requested) so explicit fp32 is honored as master
         # weights while intrinsically-fp32 checkpoint params survive a bf16 request.

--- a/nemo_automodel/components/distributed/parallelizer.py
+++ b/nemo_automodel/components/distributed/parallelizer.py
@@ -476,9 +476,15 @@ class NemotronHParallelizationStrategy(ParallelizationStrategy):
 
         dp_mesh = get_fsdp_dp_mesh(device_mesh, dp_replicate_mesh_name, dp_shard_cp_mesh_name)
 
+        fp32_compute_module_names = tuple(getattr(model, "_keep_in_fp32_modules_strict", None) or ())
+
         for layer in layers:
             parallelizer_utils.fully_shard_by_dtype(
-                layer, mesh=dp_mesh, mp_policy=mp_policy, offload_policy=offload_policy
+                layer,
+                mesh=dp_mesh,
+                mp_policy=mp_policy,
+                offload_policy=offload_policy,
+                fp32_compute_module_names=fp32_compute_module_names,
             )
 
         # do not reshard after forward for root model
@@ -508,6 +514,10 @@ class Qwen3_5ParallelizationStrategy(DefaultParallelizationStrategy):
         cp_enabled = cp_mesh_name in device_mesh.mesh_dim_names and device_mesh[cp_mesh_name].size() > 1
         patch_hf_model(model, cp_enabled=cp_enabled)
 
+        # Submodules that must compute in fp32 even under fp32 master weights (bf16
+        # compute). patch_hf_model declares ``_fp32_params`` on the model.
+        fp32_compute_module_names = tuple(getattr(model, "_keep_in_fp32_modules_strict", None) or ())
+
         # Delegate TP, AC, mixed precision to the default strategy, but
         # override the FSDP sharding to use fully_shard_by_dtype.
         # Temporarily swap the global — safe because model init is single-threaded
@@ -527,6 +537,7 @@ class Qwen3_5ParallelizationStrategy(DefaultParallelizationStrategy):
                             mesh,
                             mp_policy,
                             offload_policy,
+                            fp32_compute_module_names=fp32_compute_module_names,
                         )
             else:
                 for _, sub in module.named_children():

--- a/nemo_automodel/components/distributed/parallelizer_utils.py
+++ b/nemo_automodel/components/distributed/parallelizer_utils.py
@@ -32,6 +32,7 @@ def iter_maximal_uniform_dtype_subtrees(
     *,
     include_buffers: bool = True,
     tensor_pred: Optional[Callable[[torch.Tensor], bool]] = None,
+    dtype_of: Optional[Callable[[torch.Tensor], torch.dtype]] = None,
     return_paths: bool = False,
 ) -> Iterator[UniformSubtreeItem]:
     """
@@ -40,6 +41,9 @@ def iter_maximal_uniform_dtype_subtrees(
     - include_buffers: include buffers in dtype unification checks.
     - tensor_pred: predicate to choose which tensors to consider (default: all).
                    Example: tensor_pred=torch.is_floating_point  (to consider only FP tensors)
+    - dtype_of: maps a tensor to the dtype used for unification (default: its storage
+                dtype ``t.dtype``). Pass a custom function to group by *compute* dtype
+                rather than storage dtype.
     - return_paths: if True, yields (qualified_name, module, dtype); else (module, dtype).
 
     Notes:
@@ -48,16 +52,18 @@ def iter_maximal_uniform_dtype_subtrees(
     """
     if tensor_pred is None:
         tensor_pred = lambda t: True
+    if dtype_of is None:
+        dtype_of = lambda t: t.dtype
 
     def _local_dtype_set(m: nn.Module) -> Set[torch.dtype]:
         ds: Set[torch.dtype] = set()
         for p in m.parameters(recurse=False):
             if tensor_pred(p):
-                ds.add(p.dtype)
+                ds.add(dtype_of(p))
         if include_buffers:
             for b in m.buffers(recurse=False):
                 if tensor_pred(b):
-                    ds.add(b.dtype)
+                    ds.add(dtype_of(b))
         return ds
 
     def _visit(m: nn.Module, path: Tuple[str, ...]) -> Tuple[Set[torch.dtype], List[UniformSubtreeItem]]:
@@ -90,12 +96,18 @@ def iter_maximal_uniform_dtype_subtrees(
         yield it
 
 
-def _group_params_by_dtype(layer: nn.Module) -> Dict[torch.dtype, List[nn.Parameter]]:
+def _group_params_by_dtype(
+    layer: nn.Module,
+    dtype_of: Optional[Callable[[torch.Tensor], torch.dtype]] = None,
+) -> Dict[torch.dtype, List[nn.Parameter]]:
+    if dtype_of is None:
+        dtype_of = lambda t: t.dtype
     ans: Dict[torch.dtype, List[nn.Parameter]] = {}
     for name, param in layer.named_parameters():
-        if param.dtype not in ans:
-            ans[param.dtype] = []
-        ans[param.dtype].append(param)
+        dtype = dtype_of(param)
+        if dtype not in ans:
+            ans[dtype] = []
+        ans[dtype].append(param)
     return ans
 
 
@@ -129,16 +141,84 @@ def _mp_policy_with_param_dtype(
     return mp_policy_copy
 
 
+def _make_compute_dtype_fn(
+    module: nn.Module,
+    mp_policy: Optional[MixedPrecisionPolicy],
+    fp32_compute_module_names: Tuple[str, ...],
+) -> Callable[[torch.Tensor], torch.dtype]:
+    """Build the per-parameter *compute* dtype resolver used to group FSDP units.
+
+    The compute dtype of a floating tensor is resolved by precedence:
+
+      1. Pinned fp32 -- the tensor's name matches ``fp32_compute_module_names``
+         (from the model's ``_keep_in_fp32_modules_strict``). Authoritative, works
+         even from-scratch / quantized where there is no checkpoint to read.
+      2. HF-recorded dtype -- ``tensor._hf_compute_dtype``, the checkpoint's original
+         dtype recorded at load time (see ``_restore_loaded_model_dtype``). This makes
+         any checkpoint-loaded model keep its intrinsically-fp32 params in fp32 compute
+         automatically, even after storage was upcast for fp32 master weights.
+      3. Fallback -- ``mp_policy.param_dtype`` (the requested mixed-precision compute
+         dtype, typically bf16), or the storage dtype when no policy is given.
+
+    Non-floating tensors always keep their storage dtype.
+    """
+    policy_dtype = getattr(mp_policy, "param_dtype", None)
+
+    pinned_ids: Set[int] = set()
+    if fp32_compute_module_names:
+        for name, tensor in (*module.named_parameters(), *module.named_buffers()):
+            if any(token in name for token in fp32_compute_module_names):
+                pinned_ids.add(id(tensor))
+
+    def compute_dtype_of(t: torch.Tensor) -> torch.dtype:
+        if not t.dtype.is_floating_point:
+            return t.dtype
+        if id(t) in pinned_ids:
+            return torch.float32
+        recorded = getattr(t, "_hf_compute_dtype", None)
+        if recorded is not None and recorded.is_floating_point:
+            return recorded
+        return policy_dtype if policy_dtype is not None else t.dtype
+
+    return compute_dtype_of
+
+
 def fully_shard_by_dtype(
     module: nn.Module,
     mesh: DeviceMesh,
     mp_policy: Optional[MixedPrecisionPolicy],
     offload_policy: Optional[OffloadPolicy],
+    fp32_compute_module_names: Tuple[str, ...] = (),
 ) -> None:
-    """Fully shard a module, splitting mixed-dtype subtrees when needed."""
+    """Fully shard a module so every parameter computes in its required dtype.
+
+    The intent is simple: compute everything in ``mp_policy.param_dtype`` (e.g. bf16)
+    except parameters that must stay in fp32 -- their FSDP unit gets ``param_dtype=fp32``
+    while the rest of the module computes in the policy dtype. A parameter "must stay
+    fp32" if it is pinned via ``fp32_compute_module_names`` or HF stored it in fp32 (see
+    ``_make_compute_dtype_fn`` for the full precedence). This decouples *compute* dtype
+    from *storage* dtype, so fp32 master weights (uniform fp32 storage) still compute in
+    bf16 for the bulk.
+
+    Implementation: group the module's parameters by their resolved compute dtype and
+    shard so each FSDP unit is compute-dtype-uniform. The three cases below differ only
+    in sharding granularity:
+
+      * 1 compute dtype  -> shard the whole module once.
+      * 2 compute dtypes -> shard the minority-dtype subtrees on their own, then shard
+        the parent with the majority dtype (keeps the bulk as one FSDP unit).
+      * 3+ compute dtypes -> shard every maximal compute-dtype-uniform subtree on its own.
+
+    Args:
+        fp32_compute_module_names: Parameter/buffer name substrings that must compute in
+            fp32 (e.g. ``("_fp32_params",)`` for Qwen3.5's GatedDeltaNet fp32 holder).
+            Sourced from the model's ``_keep_in_fp32_modules_strict``.
+    """
+    compute_dtype_of = _make_compute_dtype_fn(module, mp_policy, fp32_compute_module_names)
+
     # calling _group_params_by_dtype is not optimal here, because we may
     # end up with two traversals over the module, but this code is not in the hot path.
-    grouped_params = _group_params_by_dtype(module)
+    grouped_params = _group_params_by_dtype(module, dtype_of=compute_dtype_of)
     if len(grouped_params) == 0:
         return
     elif len(grouped_params) == 1:
@@ -154,6 +234,7 @@ def fully_shard_by_dtype(
         for path, mod, dtype in iter_maximal_uniform_dtype_subtrees(
             module,
             tensor_pred=torch.is_floating_point,
+            dtype_of=compute_dtype_of,
             return_paths=True,
         ):
             if (len(grouped_params) == 2 and dtype == least_items_dtype) or len(grouped_params) > 2:

--- a/nemo_automodel/components/distributed/pipelining/hf_utils.py
+++ b/nemo_automodel/components/distributed/pipelining/hf_utils.py
@@ -402,15 +402,8 @@ def create_pipeline_forward_gemma4_vlm() -> Callable:
 
             vision_tower = getattr(self.model, "vision_tower", None)
             if vision_tower is not None and pixel_values is not None:
-                # Dynamic import to keep a ``distributed -> checkpoint`` edge out
-                # of the static import graph: gemma4_moe.model -> state_dict_adapter
-                # -> components.checkpoint would otherwise break the import-linter
-                # ``independence`` contract. Mirrors qwen3_5_moe/cp_linear_attn.py.
-                import importlib
-
-                gemma4_model_module = importlib.import_module("nemo_automodel.components.models.gemma4_moe.model")
-                image_features = gemma4_model_module.get_gemma4_image_features_with_projector_dtype(
-                    self.model, pixel_values, image_position_ids=image_position_ids
+                image_features = self.model.get_image_features(
+                    pixel_values, image_position_ids=image_position_ids, return_dict=True
                 ).pooler_output
                 image_features = image_features.to(inputs_embeds.device, inputs_embeds.dtype)
 

--- a/nemo_automodel/components/models/common/utils.py
+++ b/nemo_automodel/components/models/common/utils.py
@@ -669,28 +669,30 @@ def compute_lm_head_logits(
 
 
 def cast_frozen_modules_to_compute_dtype(model: nn.Module, compute_dtype: torch.dtype | None) -> None:
-    """Cast frozen, FSDP-excluded modules to the FSDP compute dtype.
+    """Cast the floating-point tensors of frozen submodules to ``compute_dtype``.
 
-    FSDP2 mixed precision only casts FSDP-managed (trainable) parameters to the
-    compute ``param_dtype`` at all-gather time. Fully frozen submodules (for example a
-    frozen vision tower) are deliberately excluded from FSDP wrapping, so they keep
-    their storage dtype. Under the fp32-master-weights pattern (fp32 storage + bf16
-    compute) this leaves a frozen fp32 module feeding bf16 trainable modules, which
-    raises a dtype-mismatch error in the first matmul across the seam.
+    When parameters are stored in fp32 (the fp32-master-weights pattern) while compute runs
+    in bf16, a fully frozen submodule -- such as a frozen vision tower -- can still produce
+    fp32 values that flow into bf16 trainable modules and raise a dtype mismatch in the next
+    matmul. This walks each maximal fully-frozen submodule and casts its parameters and
+    buffers to ``compute_dtype``, handling the two tensor kinds differently:
 
-    This casts each maximal fully-frozen, non-sharded submodule to ``compute_dtype`` so
-    every forward-participating module computes in the same dtype, while keeping
-    ``_keep_in_fp32_modules`` / ``_keep_in_fp32_modules_strict`` params and buffers in
-    fp32. It is a no-op when ``compute_dtype`` is None, for sharded (DTensor) params
-    (FSDP casts those itself), and for params already in ``compute_dtype`` (pure-fp32 or
-    pure-bf16 runs, where ``module.to`` is a cheap no-op).
+    * **Parameters** are cast only when they are plain (unsharded) tensors. Sharded (DTensor)
+      params are left as-is: FSDP all-gathers them to the compute dtype during forward, and
+      changing a sharded param's dtype in place would desync FSDP's flat-parameter and
+      ``orig_dtype`` bookkeeping.
+    * **Buffers** are always cast. Buffers are never sharded, so they stay in their stored
+      dtype regardless of the wrapper; an fp32 buffer (for example a standardization
+      constant) used in a forward op promotes the surrounding bf16 activations to fp32.
 
-    Frozen modules are never updated, so the compute-dtype storage costs no
-    training accuracy and removes the only fp32/bf16 boundary in the forward.
+    Tensors whose qualified name matches ``_keep_in_fp32_modules`` or
+    ``_keep_in_fp32_modules_strict`` are left in fp32. The function is a no-op when
+    ``compute_dtype`` is None and for tensors already in ``compute_dtype``. Frozen modules are
+    never updated, so casting them does not affect training accuracy.
 
     Args:
         model: The model, already materialized, checkpoint-loaded, and sharded.
-        compute_dtype: The FSDP compute dtype (``mp_policy.param_dtype``); None disables.
+        compute_dtype: The compute dtype (``mp_policy.param_dtype``); None disables the cast.
     """
     if compute_dtype is None:
         return
@@ -702,17 +704,17 @@ def cast_frozen_modules_to_compute_dtype(model: nn.Module, compute_dtype: torch.
 
     fp32_keywords = _get_fp32_module_keywords(model)
 
-    # ``named_modules`` yields parents before children, so the first frozen subtree we
-    # accept is always maximal; descendants are skipped via the ancestor check below.
+    def _is_fp32_pinned(name: str) -> bool:
+        return any(kw in name for kw in fp32_keywords)
+
+    # ``named_modules`` yields parents before children, so the first fully-frozen subtree
+    # we accept is always maximal; descendants are skipped via the ancestor check below.
+    # Sharded subtrees are included so their buffers get cast; their params are skipped per-tensor.
     selected: list[str] = []
     for name, module in model.named_modules():
         params = list(module.parameters(recurse=True))
         if not params:
             continue
-        # Sharded (FSDP-managed) subtrees are cast by FSDP itself; leave them alone.
-        if DTensor and any(isinstance(p, DTensor) for p in params):
-            continue
-        # Only fully-frozen subtrees are excluded from FSDP wrapping.
         if any(p.requires_grad for p in params):
             continue
         if any(name == anc or name.startswith(anc + ".") for anc in selected):
@@ -721,10 +723,25 @@ def cast_frozen_modules_to_compute_dtype(model: nn.Module, compute_dtype: torch.
 
     for name in selected:
         module = model.get_submodule(name) if name else model
-        module.to(compute_dtype)
-        if fp32_keywords:
-            # Safe here: ``module`` holds plain tensors (we skipped DTensor subtrees).
-            _restore_fp32_modules(module, fp32_keywords)
+        prefix = f"{name}." if name else ""
+        # Parameters: cast plain (unsharded) floats; leave sharded (DTensor) params to FSDP.
+        for param_name, param in module.named_parameters():
+            full_name = prefix + param_name
+            if _is_fp32_pinned(full_name):
+                continue
+            if DTensor and isinstance(param, DTensor):
+                continue
+            if param.is_floating_point() and param.dtype != compute_dtype:
+                param.data = param.data.to(compute_dtype)
+        # Buffers: never FSDP-managed (always plain tensors), so always safe to cast.
+        for buffer_name, buf in module.named_buffers():
+            full_name = prefix + buffer_name
+            if _is_fp32_pinned(full_name):
+                continue
+            if buf.is_floating_point() and buf.dtype != compute_dtype:
+                owner_name, _, leaf = buffer_name.rpartition(".")
+                owner = module.get_submodule(owner_name) if owner_name else module
+                owner._buffers[leaf] = buf.to(compute_dtype)
 
 
 __all__ = [

--- a/nemo_automodel/components/models/common/utils.py
+++ b/nemo_automodel/components/models/common/utils.py
@@ -668,10 +668,70 @@ def compute_lm_head_logits(
     return CausalLMOutputWithPast(logits=logits, hidden_states=hidden_out)
 
 
+def cast_frozen_modules_to_compute_dtype(model: nn.Module, compute_dtype: torch.dtype | None) -> None:
+    """Cast frozen, FSDP-excluded modules to the FSDP compute dtype.
+
+    FSDP2 mixed precision only casts FSDP-managed (trainable) parameters to the
+    compute ``param_dtype`` at all-gather time. Fully frozen submodules (for example a
+    frozen vision tower) are deliberately excluded from FSDP wrapping, so they keep
+    their storage dtype. Under the fp32-master-weights pattern (fp32 storage + bf16
+    compute) this leaves a frozen fp32 module feeding bf16 trainable modules, which
+    raises a dtype-mismatch error in the first matmul across the seam.
+
+    This casts each maximal fully-frozen, non-sharded submodule to ``compute_dtype`` so
+    every forward-participating module computes in the same dtype, while keeping
+    ``_keep_in_fp32_modules`` / ``_keep_in_fp32_modules_strict`` params and buffers in
+    fp32. It is a no-op when ``compute_dtype`` is None, for sharded (DTensor) params
+    (FSDP casts those itself), and for params already in ``compute_dtype`` (pure-fp32 or
+    pure-bf16 runs, where ``module.to`` is a cheap no-op).
+
+    Frozen modules are never updated, so the compute-dtype storage costs no
+    training accuracy and removes the only fp32/bf16 boundary in the forward.
+
+    Args:
+        model: The model, already materialized, checkpoint-loaded, and sharded.
+        compute_dtype: The FSDP compute dtype (``mp_policy.param_dtype``); None disables.
+    """
+    if compute_dtype is None:
+        return
+
+    try:
+        from torch.distributed.tensor import DTensor
+    except ImportError:
+        DTensor = ()
+
+    fp32_keywords = _get_fp32_module_keywords(model)
+
+    # ``named_modules`` yields parents before children, so the first frozen subtree we
+    # accept is always maximal; descendants are skipped via the ancestor check below.
+    selected: list[str] = []
+    for name, module in model.named_modules():
+        params = list(module.parameters(recurse=True))
+        if not params:
+            continue
+        # Sharded (FSDP-managed) subtrees are cast by FSDP itself; leave them alone.
+        if DTensor and any(isinstance(p, DTensor) for p in params):
+            continue
+        # Only fully-frozen subtrees are excluded from FSDP wrapping.
+        if any(p.requires_grad for p in params):
+            continue
+        if any(name == anc or name.startswith(anc + ".") for anc in selected):
+            continue
+        selected.append(name)
+
+    for name in selected:
+        module = model.get_submodule(name) if name else model
+        module.to(compute_dtype)
+        if fp32_keywords:
+            # Safe here: ``module`` holds plain tensors (we skipped DTensor subtrees).
+            _restore_fp32_modules(module, fp32_keywords)
+
+
 __all__ = [
     "BackendConfig",
     "Float32RMSNorm",
     "TEFp8Config",
+    "cast_frozen_modules_to_compute_dtype",
     "cast_model_to_dtype",
     "compute_lm_head_logits",
     "get_is_first_microbatch",

--- a/nemo_automodel/components/models/gemma4_moe/model.py
+++ b/nemo_automodel/components/models/gemma4_moe/model.py
@@ -19,8 +19,7 @@ GroupedExperts backend, enabling Expert Parallelism (EP) via the standard
 MoE parallelizer.
 """
 
-from contextlib import contextmanager
-from typing import Any, Iterator, Optional, Union
+from typing import Any, Optional, Union
 
 import torch
 import torch.nn as nn
@@ -82,66 +81,6 @@ from nemo_automodel.components.moe.layers import MoE, MoEConfig
 from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 
 from .state_dict_adapter import Gemma4MoEStateDictAdapter
-
-
-def _first_floating_param_dtype(module: nn.Module | None) -> torch.dtype | None:
-    """Return the dtype of the first floating parameter in ``module``."""
-    if module is None:
-        return None
-    for param in module.parameters(recurse=True):
-        if param.is_floating_point():
-            return param.dtype
-    return None
-
-
-def _cast_floating_tensor(value: Any, dtype: torch.dtype) -> Any:
-    if isinstance(value, torch.Tensor) and value.is_floating_point() and value.dtype != dtype:
-        return value.to(dtype)
-    return value
-
-
-@contextmanager
-def _cast_gemma4_embedder_inputs_to_param_dtype(embedder: nn.Module | None) -> Iterator[None]:
-    """Cast transient multimodal embedder activations to the current param dtype.
-
-    FSDP2 mixed precision keeps resident parameters in fp32 for AdamW master
-    weights, but all-gathers them as bf16 for forward compute. HF Gemma4's
-    vision pooler intentionally emits float32 before the multimodal projector,
-    so the projector input must be recast to its current compute parameter dtype
-    without changing the resident parameter dtype.
-    """
-    target_dtype = _first_floating_param_dtype(embedder)
-    if embedder is None or target_dtype is None:
-        yield
-        return
-
-    def hook(
-        _module: nn.Module, args: tuple[Any, ...], kwargs: dict[str, Any]
-    ) -> tuple[tuple[Any, ...], dict[str, Any]]:
-        if "inputs_embeds" in kwargs:
-            kwargs = dict(kwargs)
-            kwargs["inputs_embeds"] = _cast_floating_tensor(kwargs["inputs_embeds"], target_dtype)
-            return args, kwargs
-        if args:
-            args = (_cast_floating_tensor(args[0], target_dtype), *args[1:])
-        return args, kwargs
-
-    handle = embedder.register_forward_pre_hook(hook, with_kwargs=True)
-    try:
-        yield
-    finally:
-        handle.remove()
-
-
-def get_gemma4_image_features_with_projector_dtype(
-    gemma4_model: nn.Module,
-    pixel_values: torch.Tensor,
-    *,
-    image_position_ids: torch.Tensor | None = None,
-) -> Any:
-    """Run HF Gemma4 image features with a dtype-safe projector boundary."""
-    with _cast_gemma4_embedder_inputs_to_param_dtype(getattr(gemma4_model, "embed_vision", None)):
-        return gemma4_model.get_image_features(pixel_values, image_position_ids=image_position_ids, return_dict=True)
 
 
 # ---------------------------------------------------------------------------
@@ -718,8 +657,8 @@ class Gemma4ForConditionalGeneration(HFCheckpointingMixin, HFGemma4ForConditiona
 
         # Handle vision tokens
         if pixel_values is not None:
-            image_features = get_gemma4_image_features_with_projector_dtype(
-                self.model, pixel_values, image_position_ids=image_position_ids
+            image_features = self.model.get_image_features(
+                pixel_values, image_position_ids=image_position_ids, return_dict=True
             ).pooler_output
             image_features = image_features.to(inputs_embeds.device, inputs_embeds.dtype)
 

--- a/nemo_automodel/components/models/qwen3_5_moe/cp_linear_attn.py
+++ b/nemo_automodel/components/models/qwen3_5_moe/cp_linear_attn.py
@@ -671,6 +671,14 @@ def patch_hf_model(model, cp_enabled=False):
             cp_enabled,
         )
 
+        # Declare the fp32-compute submodules so fully_shard_by_dtype keeps them in
+        # fp32 compute even under fp32 master weights (bf16 compute for the bulk). The
+        # ``_fp32_params`` holder created above is the authoritative marker; the
+        # GatedDeltaNet forward uses those params directly without re-upcasting.
+        existing = tuple(getattr(model, "_keep_in_fp32_modules_strict", None) or ())
+        if "_fp32_params" not in existing:
+            model._keep_in_fp32_modules_strict = existing + ("_fp32_params",)
+
         # Attach a Qwen3.5 state_dict_adapter so saved checkpoints hide the
         # ``_fp32_params`` wrapping and remain HF-loadable directly.  Keep
         # ``from_hf`` in bare-key mode: adapter-mediated DCP loads operate in

--- a/nemo_automodel/components/optim/precision_warnings.py
+++ b/nemo_automodel/components/optim/precision_warnings.py
@@ -16,17 +16,87 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Iterable
+from typing import Any
 
 import torch
 import torch.distributed as dist
 from torch.optim import Optimizer
 
 _WARNED_CONTEXTS: set[str] = set()
+_DTYPE_RESOLVED_CONTEXTS: set[str] = set()
+_TORCH_ADAM_TARGETS = {
+    "torch.optim.Adam",
+    "torch.optim.AdamW",
+    "torch.optim.adam.Adam",
+    "torch.optim.adamw.AdamW",
+}
+
+
+def resolve_storage_dtype(
+    cfg_model: Any | None,
+    cfg_opt: Any | None,
+    *,
+    is_peft: bool = False,
+    context: str = "recipe",
+    logger: logging.Logger | None = None,
+) -> None:
+    """Default model storage dtype to float32 for full-parameter ``torch.optim`` training.
+
+    Built-in ``torch.optim`` optimizers update the resident parameter in place and keep
+    no internal fp32 master copy, so the model parameters *are* the master copy. Storing
+    them in bf16 therefore makes optimizer updates and state bf16, which degrades training
+    precision relative to frameworks that keep an fp32 master. To avoid that, when the user
+    has not explicitly chosen a storage dtype we default ``cfg_model.torch_dtype`` to
+    ``float32`` so the parameters act as the fp32 master copy. fp32 storage is never
+    numerically worse than bf16 for these optimizers; the only cost is memory, which an
+    explicit ``model.torch_dtype=bfloat16`` opts out of.
+
+    No-ops (leaving the dtype unchanged) when:
+      * ``is_peft`` is True (base weights are frozen; only small adapters train), or
+      * the optimizer is not a ``torch.optim`` optimizer (e.g. TE ``FusedAdam``, DeepSpeed,
+        or bitsandbytes optimizers, which manage their own master / state precision and so
+        live outside the ``torch.optim`` namespace), or
+      * ``model.torch_dtype`` is already set to a concrete (non-``auto``) value.
+
+    The decision is mutated on every rank (so all ranks agree) but logged only on rank
+    zero. It is idempotent: once set, a second call sees the explicit value and returns.
+
+    Args:
+        cfg_model: The model config node/dict (must expose/accept ``torch_dtype``).
+        cfg_opt: The optimizer config node/dict (read for ``_target_``).
+        is_peft: Whether this is a PEFT/LoRA run.
+        context: Short label used for log de-duplication.
+        logger: Optional logger; defaults to this module's logger.
+    """
+    if cfg_model is None or is_peft:
+        return
+    if not _is_torch_optim_config(cfg_opt):
+        return
+
+    current = _get_cfg_attr(cfg_model, "torch_dtype")
+    if current is not None and not (isinstance(current, str) and current == "auto"):
+        # User explicitly chose a storage dtype; always honor it.
+        return
+
+    _set_cfg_attr(cfg_model, "torch_dtype", "float32")
+
+    if _is_rank_zero() and context not in _DTYPE_RESOLVED_CONTEXTS:
+        log = logger if logger is not None else logging.getLogger(__name__)
+        log.info(
+            "No explicit model.torch_dtype set for full-parameter training with a "
+            "torch.optim optimizer (which keeps no fp32 master copy). Defaulting "
+            "model.torch_dtype=float32 so model parameters act as the fp32 master copy. "
+            "Set model.torch_dtype=bfloat16 to keep bf16 storage, or use Transformer "
+            "Engine FusedAdam with master_weights=True. See "
+            "docs/guides/mixed-precision-training.md."
+        )
+        _DTYPE_RESOLVED_CONTEXTS.add(context)
 
 
 def warn_if_torch_adam_with_bf16_params(
     *,
     optimizer: Optimizer | Iterable[Optimizer] | None = None,
+    optimizer_cfg: Any | None = None,
     parameters: Iterable[torch.nn.Parameter] | None = None,
     is_peft: bool = False,
     context: str = "recipe",
@@ -36,7 +106,7 @@ def warn_if_torch_adam_with_bf16_params(
     if is_peft or not _is_rank_zero() or context in _WARNED_CONTEXTS:
         return
 
-    if not _is_torch_adam_optimizer(optimizer):
+    if not (_is_torch_adam_optimizer(optimizer) or _is_torch_adam_config(optimizer_cfg)):
         return
 
     params = parameters if parameters is not None else _iter_optimizer_params(optimizer)
@@ -54,6 +124,23 @@ def warn_if_torch_adam_with_bf16_params(
     _WARNED_CONTEXTS.add(context)
 
 
+def _get_cfg_attr(cfg: Any, key: str) -> Any:
+    """Read ``key`` from a config node or dict, returning None when absent."""
+    if cfg is None:
+        return None
+    if isinstance(cfg, dict):
+        return cfg.get(key, None)
+    return getattr(cfg, key, None)
+
+
+def _set_cfg_attr(cfg: Any, key: str, value: Any) -> None:
+    """Set ``key`` on a config node or dict."""
+    if isinstance(cfg, dict):
+        cfg[key] = value
+    else:
+        setattr(cfg, key, value)
+
+
 def _is_rank_zero() -> bool:
     return not dist.is_available() or not dist.is_initialized() or dist.get_rank() == 0
 
@@ -63,6 +150,41 @@ def _is_torch_adam_optimizer(optimizer: Optimizer | Iterable[Optimizer] | None) 
         return False
     optimizers = optimizer if isinstance(optimizer, Iterable) else [optimizer]
     return any(isinstance(opt, (torch.optim.Adam, torch.optim.AdamW)) for opt in optimizers)
+
+
+def _is_torch_adam_config(optimizer_cfg: Any | None) -> bool:
+    target = getattr(optimizer_cfg, "_target_", None)
+    if target is None and isinstance(optimizer_cfg, dict):
+        target = optimizer_cfg.get("_target_", None)
+    if target is None:
+        return False
+    if isinstance(target, str):
+        return target in _TORCH_ADAM_TARGETS
+    if target in (torch.optim.Adam, torch.optim.AdamW):
+        return True
+    module = getattr(target, "__module__", "")
+    qualname = getattr(target, "__qualname__", "")
+    return f"{module}.{qualname}" in _TORCH_ADAM_TARGETS
+
+
+def _is_torch_optim_config(optimizer_cfg: Any | None) -> bool:
+    """True when the optimizer ``_target_`` is a built-in ``torch.optim`` optimizer.
+
+    These optimizers update the resident parameter in place and keep no internal fp32
+    master copy, so the storage dtype *is* the master-weight dtype and fp32 storage is
+    always safe. Optimizers outside the ``torch.optim`` namespace (TE ``FusedAdam``,
+    DeepSpeed, bitsandbytes 8-bit, Muon, ...) manage their own master / state precision
+    and are deliberately excluded.
+    """
+    target = getattr(optimizer_cfg, "_target_", None)
+    if target is None and isinstance(optimizer_cfg, dict):
+        target = optimizer_cfg.get("_target_", None)
+    if target is None:
+        return False
+    if isinstance(target, str):
+        return target.startswith("torch.optim.")
+    module = getattr(target, "__module__", "") or ""
+    return module == "torch.optim" or module.startswith("torch.optim.")
 
 
 def _iter_optimizer_params(optimizer: Optimizer | Iterable[Optimizer] | None) -> Iterable[torch.nn.Parameter]:

--- a/nemo_automodel/recipes/_dist_setup.py
+++ b/nemo_automodel/recipes/_dist_setup.py
@@ -20,6 +20,7 @@ All dict handling lives here; the component layer (``mesh``) stays purely typed.
 """
 
 import dataclasses
+import logging
 from typing import Any, Dict, Optional
 
 from nemo_automodel.components.distributed.mesh import (
@@ -29,6 +30,8 @@ from nemo_automodel.components.distributed.mesh import (
 from nemo_automodel.components.distributed.pipelining.config import PipelineConfig
 from nemo_automodel.components.moe.config import MoEParallelizerConfig
 from nemo_automodel.shared.utils import dtype_from_str
+
+logger = logging.getLogger(__name__)
 
 _PARALLELISM_DEFAULTS: Dict[str, Any] = {
     "tp_size": 1,
@@ -172,6 +175,30 @@ def parse_distributed_section(cfg_dict: dict) -> dict:
         pipeline_config = PipelineConfig()
     else:
         pipeline_config = None
+
+    # Default the pipeline communication dtype to the FSDP mixed-precision activation
+    # dtype (the dtype of tensors crossing pipeline stage boundaries) so PP stage
+    # shape inference matches the real activation dtype (e.g. bf16 compute under fp32
+    # master weights). Deriving it from mp_policy.output_dtype is silent and correct;
+    # an explicit mismatch is honored but warned, since it can corrupt inter-stage
+    # recv buffers.
+    if pipeline_config is not None and pp_size > 1:
+        mp_policy = getattr(strategy_config, "mp_policy", None)
+        activation_dtype = None
+        if mp_policy is not None:
+            activation_dtype = getattr(mp_policy, "output_dtype", None) or getattr(mp_policy, "param_dtype", None)
+        if activation_dtype is not None:
+            if pipeline_config.dtype is None:
+                pipeline_config.dtype = activation_dtype
+            elif pipeline_config.dtype != activation_dtype:
+                logger.warning(
+                    "pipeline.dtype=%s does not match the FSDP activation dtype "
+                    "(mp_policy.output_dtype=%s) used for inter-stage communication; "
+                    "this can corrupt pipeline stage shape inference. Leave pipeline.dtype "
+                    "unset to derive it automatically.",
+                    pipeline_config.dtype,
+                    activation_dtype,
+                )
 
     # Instantiate nested _target_ configs (e.g. mp_policy) before constructing MoEParallelizerConfig
     if moe_dict is not None and "mp_policy" in moe_dict:

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -773,6 +773,8 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
             logging.info("Disabling rope_fusion because cp_size=%d > 1", self.dist_setup.cp_size)
             self.cfg.model.backend.rope_fusion = False
 
+        # fp32 master-weight default planned to be enabled in follow-up PR (resolve_storage_dtype).
+
         model = build_model(
             self.cfg.model,
             self.peft_config,

--- a/nemo_automodel/recipes/llm/train_seq_cls.py
+++ b/nemo_automodel/recipes/llm/train_seq_cls.py
@@ -97,6 +97,7 @@ class TrainFinetuneRecipeForSequenceClassification(BaseRecipe):
         )
 
         self.peft_config = self.cfg.instantiate_path("peft")
+        # fp32 master-weight default planned to be enabled in follow-up PR (resolve_storage_dtype).
         model = build_model(
             cfg_model=self.cfg.model,
             cfg_peft=self.peft_config,

--- a/nemo_automodel/recipes/retrieval/train_bi_encoder.py
+++ b/nemo_automodel/recipes/retrieval/train_bi_encoder.py
@@ -233,6 +233,8 @@ class TrainBiEncoderRecipe(BaseRecipe):
         if self.cfg.get("peft", None) is not None:
             self.peft_config = self.cfg.peft.instantiate()
 
+        # fp32 master-weight default planned to be enabled in follow-up PR (resolve_storage_dtype).
+
         checkpoint_config = self.cfg.checkpoint
 
         if self.cfg.get("clip_grad_norm.max_norm", None) is not None:

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -613,6 +613,8 @@ class FinetuneRecipeForVLM(BaseRecipe):
             logging.info("Disabling rope_fusion because cp_size=%d > 1", self.dist_setup.cp_size)
             self.cfg.model.backend.rope_fusion = False
 
+        # fp32 master-weight default planned to be enabled in follow-up PR (resolve_storage_dtype).
+
         model = build_model(
             self.cfg.model,
             self.cfg.get("freeze_config", None),

--- a/skills/nemo-automodel-model-onboarding/SKILL.md
+++ b/skills/nemo-automodel-model-onboarding/SKILL.md
@@ -271,13 +271,27 @@ param's original HF dtype and uses it as a fallback, but that recording is skipp
 quantized, from-scratch, and odd-checkpoint paths — so the explicit pin is the only signal
 that holds across every path.
 
-**Frozen submodules** (e.g. a frozen vision tower in a VLM) are excluded from FSDP wrapping
-and therefore never receive the FSDP compute-dtype cast. To avoid a frozen-fp32 module
-feeding bf16 trainable modules (a dtype-mismatch matmul at the seam), every maximal
-fully-frozen, non-sharded submodule is automatically cast to `mp_policy.param_dtype` (bf16)
-after materialization and checkpoint loading. This is safe because frozen modules are never
-updated. If a *frozen* part is also numerically sensitive and must compute in fp32, list it
-in `_keep_in_fp32_modules_strict` — the cast honors those keywords and leaves them fp32.
+**Frozen submodules** (e.g. a frozen vision tower in a VLM) are a dtype-mismatch hazard under
+the fp32-master pattern: a frozen part that stays fp32 feeds bf16 trainable modules and trips
+a matmul at the seam. There are two distinct fp32 sources, and both are handled automatically
+(after materialization, checkpoint load, and sharding) by casting each maximal fully-frozen
+submodule toward `mp_policy.param_dtype` (bf16):
+
+- **Parameters** — a frozen submodule *excluded* from FSDP keeps fp32 (plain tensors) and is
+  cast; a frozen submodule that *is* sharded holds DTensor params, which are left to FSDP's
+  all-gather cast (re-casting sharded storage in place would desync FSDP bookkeeping).
+- **Buffers** — FSDP never casts buffers, so a frozen module's fp32 buffers (e.g.
+  standardization constants) would promote bf16 activations back to fp32 via type promotion.
+  Buffers are always plain tensors, so they are cast unconditionally — including inside sharded
+  frozen towers whose params FSDP already handles.
+
+This is safe because frozen modules are never updated. If a *frozen* part is also numerically
+sensitive and must compute in fp32, list it in `_keep_in_fp32_modules_strict` — the cast honors
+those keywords and leaves matching params and buffers in fp32.
+
+A model whose vision path forces fp32 *inside* a forward op that isn't a parameter or buffer
+(e.g. HF Gemma4's `get_image_features` feeding an fp32 activation into a bf16 projector) needs
+a per-model activation cast at that seam, since no parameter/buffer cast can reach it.
 
 ---
 

--- a/skills/nemo-automodel-model-onboarding/SKILL.md
+++ b/skills/nemo-automodel-model-onboarding/SKILL.md
@@ -249,6 +249,28 @@ _CUSTOM_CONFIG_REGISTRATIONS: Dict[str, Tuple[str, str]] = {
 }
 ```
 
+### 2.6 Keep intrinsically-fp32 params in fp32 compute
+
+Some parameters are numerically unstable in low precision and must be **computed** in fp32
+even when the rest of the model computes in bf16 — e.g. SSM/Mamba `A_log`, `dt_bias`, `D`;
+MoE sigmoid-gate bias (`e_score_correction_bias`); attention-sink bias; per-head `scale`.
+If your model has any such params, declare them in `_keep_in_fp32_modules_strict` as
+parameter-name substrings; sharding (`fully_shard_by_dtype`) reads this list and gives those
+params an fp32 compute dtype while everything else uses `mp_policy.param_dtype` (bf16). A
+plain dense LLM with no precision-sensitive params needs nothing here.
+
+Where to declare it:
+
+- **NeMo-native model class** (you own `model.py`): a class attribute, e.g.
+  `_keep_in_fp32_modules_strict = ["e_score_correction_bias"]` (see `deepseek_v4`, `ling_v2`).
+- **HF model you only patch** (e.g. Qwen3.5): set it on the instance inside `patch_hf_model`,
+  e.g. `model._keep_in_fp32_modules_strict = existing + ("_fp32_params",)`.
+
+Always declare the pin for these params. A normal checkpoint load also auto-records each
+param's original HF dtype and uses it as a fallback, but that recording is skipped on the
+quantized, from-scratch, and odd-checkpoint paths — so the explicit pin is the only signal
+that holds across every path.
+
 ---
 
 ## Phase 3: Onboarding Example Config
@@ -374,6 +396,7 @@ that only surface in a full parity comparison.
 - [ ] Created example YAML config
 - [ ] Verified model loads via `NeMoAutoModelForCausalLM.from_pretrained()`
 - [ ] Created unit tests (forward shape, state_dict round-trip)
+- [ ] Declared `_keep_in_fp32_modules_strict` for every intrinsically-fp32 param (SSM `A_log`/`dt_bias`/`D`, MoE gate bias, attention-sink bias, `scale`, …) — see §2.6
 - [ ] Created layer equivalence tests for every rewritten layer (matching model dtype)
 - [ ] Created functional tests (training loss decreases)
 - [ ] Updated docs/model-coverage page

--- a/skills/nemo-automodel-model-onboarding/SKILL.md
+++ b/skills/nemo-automodel-model-onboarding/SKILL.md
@@ -271,6 +271,14 @@ param's original HF dtype and uses it as a fallback, but that recording is skipp
 quantized, from-scratch, and odd-checkpoint paths — so the explicit pin is the only signal
 that holds across every path.
 
+**Frozen submodules** (e.g. a frozen vision tower in a VLM) are excluded from FSDP wrapping
+and therefore never receive the FSDP compute-dtype cast. To avoid a frozen-fp32 module
+feeding bf16 trainable modules (a dtype-mismatch matmul at the seam), every maximal
+fully-frozen, non-sharded submodule is automatically cast to `mp_policy.param_dtype` (bf16)
+after materialization and checkpoint loading. This is safe because frozen modules are never
+updated. If a *frozen* part is also numerically sensitive and must compute in fp32, list it
+in `_keep_in_fp32_modules_strict` — the cast honors those keywords and leaves them fp32.
+
 ---
 
 ## Phase 3: Onboarding Example Config

--- a/skills/nemo-automodel-model-onboarding/moe-patterns.md
+++ b/skills/nemo-automodel-model-onboarding/moe-patterns.md
@@ -246,7 +246,10 @@ def update_moe_gate_bias(self) -> None:
 
 ```python
 class NewMoEForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
-    _keep_in_fp32_modules_strict = ["e_score_correction_bias"]  # If using sigmoid routing
+    # Pin every intrinsically-fp32 param (sigmoid-gate bias here; add SSM A_log/dt_bias,
+    # attention-sink bias, scale, etc. as applicable). See SKILL.md §2.6 -- this keeps
+    # them in fp32 compute even under fp32 master weights.
+    _keep_in_fp32_modules_strict = ["e_score_correction_bias"]  # if using sigmoid routing
 
     @classmethod
     def from_config(cls, config, moe_config=None, backend=None, **kwargs):
@@ -441,4 +444,4 @@ In addition to the standard checklist in SKILL.md:
 - [ ] Forward handles `thd` format via `squeeze_input_for_thd`
 - [ ] Forward passes `padding_mask` to MoE layers
 - [ ] State dict adapter handles expert weight stacking/unstacking
-- [ ] `_keep_in_fp32_modules_strict` set for gate bias if using sigmoid routing
+- [ ] `_keep_in_fp32_modules_strict` set for every intrinsically-fp32 param (sigmoid-gate bias `e_score_correction_bias`, and any others) — see SKILL.md §2.6

--- a/tests/unit_tests/_transformers/test_auto_model.py
+++ b/tests/unit_tests/_transformers/test_auto_model.py
@@ -927,6 +927,96 @@ class TestModelMappingKeyErrorFallback:
         assert fake_model.norm.weight.dtype == torch.float32
         mock_wrap.assert_called_once_with(FakeModel)
 
+    def test_force_hf_pretrained_explicit_fp32_promotes_all_to_fp32(self):
+        """Explicit fp32 request unifies every floating tensor to fp32 (master weights)."""
+
+        class FakeConfig:
+            name_or_path = "test-model"
+
+        class FakeModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(2, 2, bias=False)
+                self.norm = torch.nn.LayerNorm(2)
+
+        fake_config = FakeConfig()
+        # Simulate HF's mixed-dtype load: most params bf16, a stray param fp32.
+        fake_model = FakeModel()
+        fake_model.linear.to(torch.bfloat16)
+        fake_model.norm.to(torch.float32)
+
+        cls = self._make_cls({})
+        cls._from_pretrained_parent_class = MagicMock(return_value=fake_model)
+
+        with (
+            patch("nemo_automodel._transformers.model_init.get_hf_config", return_value=fake_config),
+            patch(
+                "nemo_automodel.components.checkpoint.utils._get_checkpoint_tensor_dtypes",
+                return_value={
+                    "linear.weight": torch.bfloat16,
+                    "norm.weight": torch.float32,
+                },
+            ),
+            patch("nemo_automodel._transformers.model_init._get_mixin_wrapped_class") as mock_wrap,
+        ):
+            mock_wrap.return_value = type("WrappedModel", (HFCheckpointingMixin, FakeModel), {})
+            _init_model(
+                cls,
+                "test-model",
+                attn_implementation="eager",
+                torch_dtype=torch.float32,
+                quantization_config=None,
+                force_hf=True,
+            )
+
+        assert fake_model.linear.weight.dtype == torch.float32
+        assert fake_model.norm.weight.dtype == torch.float32
+
+    def test_force_hf_pretrained_explicit_bf16_preserves_intrinsic_fp32(self):
+        """Explicit bf16 request keeps bf16 params bf16 but preserves intrinsically-fp32 params."""
+
+        class FakeConfig:
+            name_or_path = "test-model"
+
+        class FakeModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(2, 2, bias=False)
+                self.norm = torch.nn.LayerNorm(2)
+
+        fake_config = FakeConfig()
+        fake_model = FakeModel()
+        fake_model.linear.to(torch.bfloat16)
+        fake_model.norm.to(torch.float32)
+
+        cls = self._make_cls({})
+        cls._from_pretrained_parent_class = MagicMock(return_value=fake_model)
+
+        with (
+            patch("nemo_automodel._transformers.model_init.get_hf_config", return_value=fake_config),
+            patch(
+                "nemo_automodel.components.checkpoint.utils._get_checkpoint_tensor_dtypes",
+                return_value={
+                    "linear.weight": torch.bfloat16,
+                    "norm.weight": torch.float32,
+                },
+            ),
+            patch("nemo_automodel._transformers.model_init._get_mixin_wrapped_class") as mock_wrap,
+        ):
+            mock_wrap.return_value = type("WrappedModel", (HFCheckpointingMixin, FakeModel), {})
+            _init_model(
+                cls,
+                "test-model",
+                attn_implementation="eager",
+                torch_dtype=torch.bfloat16,
+                quantization_config=None,
+                force_hf=True,
+            )
+
+        assert fake_model.linear.weight.dtype == torch.bfloat16
+        # promote(fp32, bf16) == fp32 -> intrinsically-fp32 checkpoint param survives.
+        assert fake_model.norm.weight.dtype == torch.float32
+
     def test_fallback_path_known_config_type(self):
         """Fallback (non-force_hf, no custom model) path: _model_mapping succeeds."""
 

--- a/tests/unit_tests/_transformers/test_auto_model.py
+++ b/tests/unit_tests/_transformers/test_auto_model.py
@@ -971,6 +971,10 @@ class TestModelMappingKeyErrorFallback:
 
         assert fake_model.linear.weight.dtype == torch.float32
         assert fake_model.norm.weight.dtype == torch.float32
+        # Storage was upcast to fp32, but the checkpoint's original (compute) dtype is
+        # recorded so downstream sharding can keep the bulk in bf16 compute.
+        assert fake_model.linear.weight._hf_compute_dtype == torch.bfloat16
+        assert fake_model.norm.weight._hf_compute_dtype == torch.float32
 
     def test_force_hf_pretrained_explicit_bf16_preserves_intrinsic_fp32(self):
         """Explicit bf16 request keeps bf16 params bf16 but preserves intrinsically-fp32 params."""

--- a/tests/unit_tests/components/optim/test_precision_warnings.py
+++ b/tests/unit_tests/components/optim/test_precision_warnings.py
@@ -13,17 +13,23 @@
 # limitations under the License.
 
 import logging
+from types import SimpleNamespace
 
 import torch
 
 from nemo_automodel.components.optim import precision_warnings
-from nemo_automodel.components.optim.precision_warnings import warn_if_torch_adam_with_bf16_params
+from nemo_automodel.components.optim.precision_warnings import (
+    resolve_storage_dtype,
+    warn_if_torch_adam_with_bf16_params,
+)
 
 _WARNING_PREFIX = "Detected torch.optim.Adam/AdamW with trainable bf16 model parameters"
+_RESOLVE_PREFIX = "Defaulting model.torch_dtype=float32"
 
 
 def setup_function():
     precision_warnings._WARNED_CONTEXTS.clear()
+    precision_warnings._DTYPE_RESOLVED_CONTEXTS.clear()
 
 
 def test_warns_once_for_full_bf16_training_with_torch_adamw(caplog):
@@ -36,26 +42,6 @@ def test_warns_once_for_full_bf16_training_with_torch_adamw(caplog):
 
     assert caplog.text.count(_WARNING_PREFIX) == 1
     assert "docs/guides/mixed-precision-training.md" in caplog.text
-
-
-def test_warns_for_torch_adam(caplog):
-    param = torch.nn.Parameter(torch.ones(1, dtype=torch.bfloat16))
-    optimizer = torch.optim.Adam([param], lr=1.0e-4)
-
-    with caplog.at_level(logging.WARNING):
-        warn_if_torch_adam_with_bf16_params(optimizer=optimizer, context="unit-test")
-
-    assert _WARNING_PREFIX in caplog.text
-
-
-def test_skips_non_adam_optimizer(caplog):
-    param = torch.nn.Parameter(torch.ones(1, dtype=torch.bfloat16))
-    optimizer = torch.optim.SGD([param], lr=1.0e-4)
-
-    with caplog.at_level(logging.WARNING):
-        warn_if_torch_adam_with_bf16_params(optimizer=optimizer, context="unit-test")
-
-    assert _WARNING_PREFIX not in caplog.text
 
 
 def test_skips_peft_bf16_training(caplog):
@@ -76,3 +62,98 @@ def test_skips_full_fp32_training(caplog):
         warn_if_torch_adam_with_bf16_params(optimizer=optimizer, context="unit-test")
 
     assert _WARNING_PREFIX not in caplog.text
+
+
+def test_warns_from_optimizer_config_target_and_parameters(caplog):
+    param = torch.nn.Parameter(torch.ones(1, dtype=torch.bfloat16))
+    optimizer_cfg = SimpleNamespace(_target_="torch.optim.AdamW")
+
+    with caplog.at_level(logging.WARNING):
+        warn_if_torch_adam_with_bf16_params(
+            optimizer_cfg=optimizer_cfg,
+            parameters=[param],
+            context="unit-test",
+        )
+
+    assert _WARNING_PREFIX in caplog.text
+
+
+def test_resolve_defaults_fp32_for_full_param_torch_adamw(caplog):
+    cfg_model = SimpleNamespace()
+    cfg_opt = SimpleNamespace(_target_="torch.optim.AdamW")
+
+    with caplog.at_level(logging.INFO):
+        resolve_storage_dtype(cfg_model, cfg_opt, is_peft=False, context="unit-test")
+
+    assert cfg_model.torch_dtype == "float32"
+    assert _RESOLVE_PREFIX in caplog.text
+
+
+def test_resolve_treats_auto_as_unset(caplog):
+    cfg_model = SimpleNamespace(torch_dtype="auto")
+    cfg_opt = SimpleNamespace(_target_="torch.optim.AdamW")
+
+    resolve_storage_dtype(cfg_model, cfg_opt, is_peft=False, context="unit-test")
+
+    assert cfg_model.torch_dtype == "float32"
+
+
+def test_resolve_honors_explicit_dtype():
+    cfg_model = SimpleNamespace(torch_dtype="bfloat16")
+    cfg_opt = SimpleNamespace(_target_="torch.optim.AdamW")
+
+    resolve_storage_dtype(cfg_model, cfg_opt, is_peft=False, context="unit-test")
+
+    assert cfg_model.torch_dtype == "bfloat16"
+
+
+def test_resolve_skips_peft():
+    cfg_model = SimpleNamespace()
+    cfg_opt = SimpleNamespace(_target_="torch.optim.AdamW")
+
+    resolve_storage_dtype(cfg_model, cfg_opt, is_peft=True, context="unit-test")
+
+    assert getattr(cfg_model, "torch_dtype", None) is None
+
+
+def test_resolve_defaults_fp32_for_full_param_torch_sgd(caplog):
+    # The fp32-master rationale generalizes to any in-place torch.optim optimizer,
+    # not just Adam/AdamW.
+    cfg_model = SimpleNamespace()
+    cfg_opt = SimpleNamespace(_target_="torch.optim.SGD")
+
+    with caplog.at_level(logging.INFO):
+        resolve_storage_dtype(cfg_model, cfg_opt, is_peft=False, context="unit-test")
+
+    assert cfg_model.torch_dtype == "float32"
+    assert _RESOLVE_PREFIX in caplog.text
+
+
+def test_resolve_skips_non_torch_optimizer():
+    # Optimizers outside the torch.optim namespace (TE FusedAdam, DeepSpeed,
+    # bitsandbytes, ...) manage their own master / state precision.
+    cfg_model = SimpleNamespace()
+    cfg_opt = SimpleNamespace(_target_="transformer_engine.pytorch.optimizers.FusedAdam")
+
+    resolve_storage_dtype(cfg_model, cfg_opt, is_peft=False, context="unit-test")
+
+    assert getattr(cfg_model, "torch_dtype", None) is None
+
+
+def test_resolve_works_with_dict_configs():
+    cfg_model = {}
+    cfg_opt = {"_target_": "torch.optim.Adam"}
+
+    resolve_storage_dtype(cfg_model, cfg_opt, is_peft=False, context="unit-test")
+
+    assert cfg_model["torch_dtype"] == "float32"
+
+
+def test_resolve_logs_once_per_context(caplog):
+    cfg_opt = SimpleNamespace(_target_="torch.optim.AdamW")
+
+    with caplog.at_level(logging.INFO):
+        resolve_storage_dtype(SimpleNamespace(), cfg_opt, is_peft=False, context="unit-test")
+        resolve_storage_dtype(SimpleNamespace(), cfg_opt, is_peft=False, context="unit-test")
+
+    assert caplog.text.count(_RESOLVE_PREFIX) == 1

--- a/tests/unit_tests/distributed/test_fp32_compute_contract.py
+++ b/tests/unit_tests/distributed/test_fp32_compute_contract.py
@@ -1,0 +1,225 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end contract: every trainable parameter ends up in an FSDP unit whose
+*compute* dtype matches what precision correctness requires.
+
+These are CPU unit tests (no real FSDP): we run the production
+``fully_shard_by_dtype`` with ``fully_shard`` mocked to record each unit's module
+and ``param_dtype``, then map every parameter to the compute dtype of the most
+specific FSDP unit that owns it. This exercises the full resolution path
+(pinned -> HF-recorded -> mp_policy.param_dtype) across the model archetypes that
+actually use ``fully_shard_by_dtype`` (NemotronH dense layers, Qwen3.5 hybrid
+mixer), under fp32 master weights and ordinary loads.
+"""
+
+import torch
+import torch.nn as nn
+from torch.distributed.fsdp import MixedPrecisionPolicy
+
+import nemo_automodel.components.distributed.parallelizer_utils as parallelizer_utils
+from nemo_automodel.components.distributed.parallelizer_utils import fully_shard_by_dtype
+
+
+def _mp_policy(param_dtype=torch.bfloat16):
+    return MixedPrecisionPolicy(param_dtype=param_dtype, reduce_dtype=torch.float32, output_dtype=torch.float32)
+
+
+def _resident_compute_dtypes(model, mp_policy, fp32_compute_module_names, monkeypatch):
+    """Shard ``model`` (mocked) and return {param_name: resident compute dtype}.
+
+    The resident compute dtype of a parameter is the ``param_dtype`` of the most
+    specific (deepest / fewest-params) FSDP unit that owns it -- which is the unit
+    FSDP would actually use for that parameter.
+    """
+    calls: list[tuple[nn.Module, torch.dtype]] = []
+
+    def fake_fully_shard(mod, *, mesh, mp_policy, offload_policy):
+        calls.append((mod, mp_policy.param_dtype if mp_policy is not None else None))
+
+    # Patch only fully_shard; the real _fully_shard (incl. ModuleList expansion)
+    # still routes every leaf shard through the mock.
+    monkeypatch.setattr(parallelizer_utils, "fully_shard", fake_fully_shard, raising=True)
+
+    fully_shard_by_dtype(
+        model,
+        mesh=object(),
+        mp_policy=mp_policy,
+        offload_policy=object(),
+        fp32_compute_module_names=fp32_compute_module_names,
+    )
+
+    owned = [({id(p) for p in mod.parameters()}, dtype) for mod, dtype in calls]
+    resolved: dict[str, torch.dtype] = {}
+    for name, param in model.named_parameters():
+        candidates = [(len(ids), dtype) for ids, dtype in owned if id(param) in ids]
+        assert candidates, f"parameter {name!r} was not covered by any FSDP unit"
+        chosen = min(candidates, key=lambda c: c[0])[1]
+        # No mixed-precision policy -> FSDP computes in the storage dtype.
+        resolved[name] = chosen if chosen is not None else param.dtype
+    return resolved
+
+
+def _tag_hf(tensor, dtype):
+    tensor._hf_compute_dtype = dtype
+
+
+# --------------------------------------------------------------------------- #
+# Model archetypes (tiny) that use fully_shard_by_dtype in production.
+# --------------------------------------------------------------------------- #
+
+
+class DenseLayer(nn.Module):
+    """NemotronH-style dense layer: only ordinary projection weights."""
+
+    def __init__(self, dtype=torch.float32):
+        super().__init__()
+        self.attn = nn.Linear(8, 8, bias=False).to(dtype)
+        self.mlp = nn.Linear(8, 8, bias=False).to(dtype)
+
+
+class Fp32Holder(nn.Module):
+    """Qwen3.5-style holder isolating an intrinsically-fp32 param (e.g. A_log)."""
+
+    def __init__(self, n=4):
+        super().__init__()
+        self.A_log = nn.Parameter(torch.zeros(n, dtype=torch.float32))
+
+
+class HybridLayer(nn.Module):
+    """Qwen3.5-style GatedDeltaNet layer: bulk projections + fp32 holder."""
+
+    def __init__(self, dtype=torch.float32):
+        super().__init__()
+        self.in_proj = nn.Linear(8, 8, bias=False).to(dtype)
+        self.out_proj = nn.Linear(8, 8, bias=False).to(dtype)
+        self._fp32_params = Fp32Holder()
+
+
+# --------------------------------------------------------------------------- #
+# Dense archetype
+# --------------------------------------------------------------------------- #
+
+
+def test_dense_master_weights_compute_bf16(monkeypatch):
+    """fp32 master weights, no fp32 params -> the whole dense layer computes bf16."""
+    layer = DenseLayer(dtype=torch.float32)  # uniform fp32 storage (master weights)
+    resolved = _resident_compute_dtypes(layer, _mp_policy(torch.bfloat16), (), monkeypatch)
+
+    assert resolved == {
+        "attn.weight": torch.bfloat16,
+        "mlp.weight": torch.bfloat16,
+    }
+
+
+def test_dense_genuine_fp32_policy_computes_fp32(monkeypatch):
+    """An explicit fp32 compute policy keeps the dense layer in fp32."""
+    layer = DenseLayer(dtype=torch.float32)
+    resolved = _resident_compute_dtypes(layer, _mp_policy(torch.float32), (), monkeypatch)
+
+    assert resolved == {
+        "attn.weight": torch.float32,
+        "mlp.weight": torch.float32,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Hybrid archetype -- the three dtype-source scenarios
+# --------------------------------------------------------------------------- #
+
+
+def test_hybrid_master_weights_pinned_keeps_holder_fp32(monkeypatch):
+    """From-scratch master weights: the pin keeps A_log fp32, bulk computes bf16."""
+    layer = HybridLayer(dtype=torch.float32)  # uniform fp32 storage, no HF records
+    resolved = _resident_compute_dtypes(layer, _mp_policy(torch.bfloat16), ("_fp32_params",), monkeypatch)
+
+    assert resolved == {
+        "in_proj.weight": torch.bfloat16,
+        "out_proj.weight": torch.bfloat16,
+        "_fp32_params.A_log": torch.float32,
+    }
+
+
+def test_hybrid_master_weights_hf_recorded_keeps_holder_fp32(monkeypatch):
+    """Loaded-from-checkpoint master weights: HF records keep A_log fp32 with no pin."""
+    layer = HybridLayer(dtype=torch.float32)  # storage upcast to fp32 (master weights)
+    # Simulate _restore_loaded_model_dtype recording the checkpoint's original dtypes.
+    _tag_hf(layer.in_proj.weight, torch.bfloat16)
+    _tag_hf(layer.out_proj.weight, torch.bfloat16)
+    _tag_hf(layer._fp32_params.A_log, torch.float32)
+
+    resolved = _resident_compute_dtypes(layer, _mp_policy(torch.bfloat16), (), monkeypatch)
+
+    assert resolved == {
+        "in_proj.weight": torch.bfloat16,
+        "out_proj.weight": torch.bfloat16,
+        "_fp32_params.A_log": torch.float32,
+    }
+
+
+def test_hybrid_non_master_load_mirrors_storage(monkeypatch):
+    """Ordinary bf16 load: bulk stored bf16, holder fp32; records mirror storage."""
+    layer = HybridLayer(dtype=torch.bfloat16)  # bulk bf16 storage, holder fp32 storage
+    _tag_hf(layer.in_proj.weight, torch.bfloat16)
+    _tag_hf(layer.out_proj.weight, torch.bfloat16)
+    _tag_hf(layer._fp32_params.A_log, torch.float32)
+
+    resolved = _resident_compute_dtypes(layer, _mp_policy(torch.bfloat16), (), monkeypatch)
+
+    assert resolved == {
+        "in_proj.weight": torch.bfloat16,
+        "out_proj.weight": torch.bfloat16,
+        "_fp32_params.A_log": torch.float32,
+    }
+
+
+def test_hybrid_pin_overrides_hf_recorded_dtype(monkeypatch):
+    """The pin wins even when an HF record would say bf16."""
+    layer = HybridLayer(dtype=torch.float32)
+    # Record A_log as bf16 (wrong on purpose); the pin must still force fp32.
+    _tag_hf(layer.in_proj.weight, torch.bfloat16)
+    _tag_hf(layer.out_proj.weight, torch.bfloat16)
+    _tag_hf(layer._fp32_params.A_log, torch.bfloat16)
+
+    resolved = _resident_compute_dtypes(layer, _mp_policy(torch.bfloat16), ("_fp32_params",), monkeypatch)
+
+    assert resolved["_fp32_params.A_log"] == torch.float32
+    assert resolved["in_proj.weight"] == torch.bfloat16
+
+
+def test_hybrid_stack_of_layers_master_weights(monkeypatch):
+    """A ModuleList of hybrid layers: every A_log fp32, every projection bf16."""
+    stack = nn.ModuleList([HybridLayer(dtype=torch.float32) for _ in range(3)])
+    # fully_shard_by_dtype is called per-layer by the strategies; mirror that.
+    resolved: dict[str, torch.dtype] = {}
+    for i, layer in enumerate(stack):
+        layer_resolved = _resident_compute_dtypes(layer, _mp_policy(torch.bfloat16), ("_fp32_params",), monkeypatch)
+        for name, dtype in layer_resolved.items():
+            resolved[f"{i}.{name}"] = dtype
+
+    for i in range(3):
+        assert resolved[f"{i}._fp32_params.A_log"] == torch.float32
+        assert resolved[f"{i}.in_proj.weight"] == torch.bfloat16
+        assert resolved[f"{i}.out_proj.weight"] == torch.bfloat16
+
+
+def test_no_mixed_precision_policy_falls_back_to_storage(monkeypatch):
+    """Without a policy, compute dtype falls back to storage dtype (no downcast)."""
+    layer = HybridLayer(dtype=torch.float32)
+    resolved = _resident_compute_dtypes(layer, None, ("_fp32_params",), monkeypatch)
+
+    # No policy -> non-pinned params keep their storage dtype (fp32 here).
+    assert resolved["in_proj.weight"] == torch.float32
+    assert resolved["out_proj.weight"] == torch.float32
+    assert resolved["_fp32_params.A_log"] == torch.float32

--- a/tests/unit_tests/distributed/test_parallelizer_utils.py
+++ b/tests/unit_tests/distributed/test_parallelizer_utils.py
@@ -22,10 +22,22 @@ from nemo_automodel.components.distributed.parallelizer_utils import (
     _fully_shard,
     _get_module_from_path,
     _group_params_by_dtype,
+    _make_compute_dtype_fn,
     _mp_policy_with_param_dtype,
     fully_shard_by_dtype,
     iter_maximal_uniform_dtype_subtrees,
 )
+
+
+def _tag_hf_compute_dtype(model: nn.Module) -> None:
+    """Simulate an HF checkpoint load by recording each float tensor's dtype.
+
+    ``_restore_loaded_model_dtype`` does this in production; tagging here lets the
+    compute-dtype grouping mirror storage dtype (as it would for a loaded model).
+    """
+    for tensor in (*model.parameters(), *model.buffers()):
+        if tensor.dtype.is_floating_point:
+            tensor._hf_compute_dtype = tensor.dtype
 
 
 class Block(nn.Module):
@@ -260,18 +272,184 @@ def test_fully_shard_by_dtype_single_dtype(monkeypatch):
         "nemo_automodel.components.distributed.parallelizer_utils._fully_shard", fake__fully_shard, raising=True
     )
 
-    # All parameters are float32
+    # All parameters are float32 storage, but the policy requests bf16 compute
+    # (fp32 master weights). Compute dtype is decoupled from storage: the bulk
+    # computes in mp_policy.param_dtype (bf16), NOT the fp32 storage dtype.
     model = ToyModel(a_dtype=torch.float32, b_dtype_l1=torch.float32, b_dtype_l2=torch.float32)
     mp_policy = _make_mp_policy()
     fully_shard_by_dtype(model, mesh=object(), mp_policy=mp_policy, offload_policy=object())
 
     assert [mod for mod, _ in fully_calls] == [model]  # whole module sharded once
     assert fully_calls[0][1] is not mp_policy
-    assert fully_calls[0][1].param_dtype == torch.float32
+    assert fully_calls[0][1].param_dtype == torch.bfloat16
     assert fully_calls[0][1].reduce_dtype == mp_policy.reduce_dtype
     assert fully_calls[0][1].output_dtype == mp_policy.output_dtype
     assert mp_policy.param_dtype == torch.bfloat16
-    assert sub_calls == []  # no subtree calls
+    assert sub_calls == []  # no fp32-compute carve-outs declared
+
+
+def test_fully_shard_by_dtype_storage_equals_compute_keeps_storage_dtype(monkeypatch):
+    """Uniform storage that matches the requested compute dtype shards as before."""
+    fully_calls: list[tuple[nn.Module, MixedPrecisionPolicy]] = []
+
+    def fake_fully_shard(mod, *, mesh, mp_policy, offload_policy):
+        fully_calls.append((mod, mp_policy))
+
+    monkeypatch.setattr(
+        "nemo_automodel.components.distributed.parallelizer_utils.fully_shard", fake_fully_shard, raising=True
+    )
+
+    # bf16 storage and bf16 compute -> param_dtype stays bf16 (no decoupling needed).
+    model = ToyModel(a_dtype=torch.bfloat16, b_dtype_l1=torch.bfloat16, b_dtype_l2=torch.bfloat16)
+    mp_policy = _make_mp_policy()
+    fully_shard_by_dtype(model, mesh=object(), mp_policy=mp_policy, offload_policy=object())
+
+    assert [mod for mod, _ in fully_calls] == [model]
+    assert fully_calls[0][1].param_dtype == torch.bfloat16
+
+
+def test_fully_shard_by_dtype_genuine_fp32_compute_unchanged(monkeypatch):
+    """Uniform fp32 storage with an fp32-compute policy keeps fp32 compute."""
+    fully_calls: list[tuple[nn.Module, MixedPrecisionPolicy]] = []
+
+    def fake_fully_shard(mod, *, mesh, mp_policy, offload_policy):
+        fully_calls.append((mod, mp_policy))
+
+    monkeypatch.setattr(
+        "nemo_automodel.components.distributed.parallelizer_utils.fully_shard", fake_fully_shard, raising=True
+    )
+
+    model = ToyModel(a_dtype=torch.float32, b_dtype_l1=torch.float32, b_dtype_l2=torch.float32)
+    mp_policy = MixedPrecisionPolicy(param_dtype=torch.float32, reduce_dtype=torch.float32, output_dtype=torch.float32)
+    fully_shard_by_dtype(model, mesh=object(), mp_policy=mp_policy, offload_policy=object())
+
+    assert [mod for mod, _ in fully_calls] == [model]
+    assert fully_calls[0][1].param_dtype == torch.float32
+
+
+def test_make_compute_dtype_fn_precedence():
+    """Resolver precedence: pinned fp32 > HF-recorded > mp_policy.param_dtype."""
+
+    class Holder(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = nn.Parameter(torch.zeros(2, dtype=torch.float32))
+
+    class Mixer(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.in_proj = nn.Linear(4, 4, bias=False).to(torch.float32)  # master-weight fp32 storage
+            self.recorded_fp32 = nn.Linear(4, 4, bias=False).to(torch.float32)
+            self.recorded_bf16 = nn.Linear(4, 4, bias=False).to(torch.float32)
+            self._fp32_params = Holder()
+
+    mixer = Mixer()
+    # Simulate HF load: in_proj had bf16 in the checkpoint, the others fp32/bf16.
+    mixer.in_proj.weight._hf_compute_dtype = torch.bfloat16
+    mixer.recorded_fp32.weight._hf_compute_dtype = torch.float32
+    mixer.recorded_bf16.weight._hf_compute_dtype = torch.bfloat16
+
+    fn = _make_compute_dtype_fn(mixer, _make_mp_policy(), ("_fp32_params",))
+
+    # Pinned wins even though storage is fp32 and nothing was recorded.
+    assert fn(mixer._fp32_params.weight) == torch.float32
+    # HF-recorded bf16 beats the fp32 master storage.
+    assert fn(mixer.in_proj.weight) == torch.bfloat16
+    assert fn(mixer.recorded_bf16.weight) == torch.bfloat16
+    # HF-recorded fp32 is honored.
+    assert fn(mixer.recorded_fp32.weight) == torch.float32
+
+
+def test_make_compute_dtype_fn_fallback_to_policy_then_storage():
+    model = ToyModel(a_dtype=torch.float32, b_dtype_l1=torch.float32, b_dtype_l2=torch.float32)
+
+    # No record, no pin, bf16 policy -> fall back to policy (bf16) despite fp32 storage.
+    fn = _make_compute_dtype_fn(model, _make_mp_policy(), ())
+    assert fn(model.a.weight) == torch.bfloat16
+
+    # No policy -> fall back to storage dtype.
+    fn_no_policy = _make_compute_dtype_fn(model, None, ())
+    assert fn_no_policy(model.a.weight) == torch.float32
+
+
+def test_fully_shard_by_dtype_fp32_master_pins_compute(monkeypatch):
+    """fp32 master weights (uniform fp32 storage): pinned param keeps fp32, bulk gets bf16."""
+    fully_calls: list[tuple[nn.Module, MixedPrecisionPolicy]] = []
+    sub_calls: list[tuple[nn.Module, MixedPrecisionPolicy]] = []
+
+    def fake_fully_shard(mod, *, mesh, mp_policy, offload_policy):
+        fully_calls.append((mod, mp_policy))
+
+    def fake__fully_shard(mod, *, mesh, mp_policy, offload_policy):
+        sub_calls.append((mod, mp_policy))
+
+    monkeypatch.setattr(
+        "nemo_automodel.components.distributed.parallelizer_utils.fully_shard", fake_fully_shard, raising=True
+    )
+    monkeypatch.setattr(
+        "nemo_automodel.components.distributed.parallelizer_utils._fully_shard", fake__fully_shard, raising=True
+    )
+
+    class Fp32Holder(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = nn.Parameter(torch.zeros(2, dtype=torch.float32))
+
+    class Mixer(nn.Module):
+        def __init__(self):
+            super().__init__()
+            # Two bulk linears so the bf16-compute group is the strict majority.
+            self.in_proj = nn.Linear(4, 4, bias=False).to(torch.float32)
+            self.out_proj = nn.Linear(4, 4, bias=False).to(torch.float32)
+            self._fp32_params = Fp32Holder()
+
+    mixer = Mixer()
+    fully_shard_by_dtype(
+        mixer,
+        mesh=object(),
+        mp_policy=_make_mp_policy(),
+        offload_policy=object(),
+        fp32_compute_module_names=("_fp32_params",),
+    )
+
+    # Minority fp32 holder sharded on its own; the bf16 bulk is the parent unit.
+    assert [mod for mod, _ in sub_calls] == [mixer._fp32_params]
+    assert sub_calls[0][1].param_dtype == torch.float32
+    assert [mod for mod, _ in fully_calls] == [mixer]
+    assert fully_calls[0][1].param_dtype == torch.bfloat16
+
+
+def test_fully_shard_by_dtype_fp32_master_hf_recorded_compute(monkeypatch):
+    """fp32 master weights with HF-recorded dtypes: recorded-fp32 param stays fp32, no pin needed."""
+    fully_calls: list[tuple[nn.Module, MixedPrecisionPolicy]] = []
+    sub_calls: list[tuple[nn.Module, MixedPrecisionPolicy]] = []
+
+    def fake_fully_shard(mod, *, mesh, mp_policy, offload_policy):
+        fully_calls.append((mod, mp_policy))
+
+    def fake__fully_shard(mod, *, mesh, mp_policy, offload_policy):
+        sub_calls.append((mod, mp_policy))
+
+    monkeypatch.setattr(
+        "nemo_automodel.components.distributed.parallelizer_utils.fully_shard", fake_fully_shard, raising=True
+    )
+    monkeypatch.setattr(
+        "nemo_automodel.components.distributed.parallelizer_utils._fully_shard", fake__fully_shard, raising=True
+    )
+
+    # Uniform fp32 storage (master weights), but the checkpoint recorded 'a' as fp32
+    # and the rest as bf16 -> 'a' computes fp32 automatically, bulk computes bf16.
+    model = ToyModel(a_dtype=torch.float32, b_dtype_l1=torch.float32, b_dtype_l2=torch.float32)
+    model.a.weight._hf_compute_dtype = torch.float32
+    model.b.l1.weight._hf_compute_dtype = torch.bfloat16
+    model.b.l2.weight._hf_compute_dtype = torch.bfloat16
+
+    fully_shard_by_dtype(model, mesh=object(), mp_policy=_make_mp_policy(), offload_policy=object())
+
+    assert [mod for mod, _ in sub_calls] == [model.a]
+    assert sub_calls[0][1].param_dtype == torch.float32
+    assert [mod for mod, _ in fully_calls] == [model]
+    assert fully_calls[0][1].param_dtype == torch.bfloat16
 
 
 def test_fully_shard_by_dtype_two_dtypes(monkeypatch):
@@ -293,6 +471,7 @@ def test_fully_shard_by_dtype_two_dtypes(monkeypatch):
 
     # Make float32 the least common (1 param) vs float16 (2 params)
     model = ToyModel(a_dtype=torch.float32, b_dtype_l1=torch.float16, b_dtype_l2=torch.float16)
+    _tag_hf_compute_dtype(model)  # compute dtype mirrors storage (as for a loaded checkpoint)
     fully_shard_by_dtype(model, mesh=object(), mp_policy=_make_mp_policy(), offload_policy=object())
 
     # Expect subtree sharding for the least common dtype subtree(s) and full sharding once
@@ -327,6 +506,7 @@ def test_fully_shard_by_dtype_three_dtypes(monkeypatch):
         b_dtype_l2=torch.float16,
         c_dtype=torch.bfloat16,
     )
+    _tag_hf_compute_dtype(model)  # compute dtype mirrors storage (as for a loaded checkpoint)
     fully_shard_by_dtype(model, mesh=object(), mp_policy=_make_mp_policy(), offload_policy=object())
 
     # For >2 dtypes: only subtree sharding, no whole-module sharding

--- a/tests/unit_tests/models/common/test_cast_model_to_dtype.py
+++ b/tests/unit_tests/models/common/test_cast_model_to_dtype.py
@@ -342,6 +342,35 @@ class TestCastFrozenModulesToComputeDtype:
         for p in model.parameters():
             assert p.dtype == torch.float32
 
+    def test_sharded_frozen_param_skipped_but_buffer_cast(self, monkeypatch):
+        """A sharded (DTensor) frozen param is left to FSDP, but its fp32 buffers are still cast.
+
+        This mirrors the sharded frozen-tower case (e.g. gemma4 vision tower in the root
+        FSDP unit): FSDP all-gathers the params to the compute dtype itself, but never casts
+        buffers, so an fp32 buffer would promote bf16 activations back to fp32. We simulate a
+        DTensor param with a ``nn.Parameter`` subclass and patch the ``DTensor`` symbol the
+        function imports at call time.
+        """
+        import torch.distributed.tensor as dt_mod
+
+        class _FakeDTensor(nn.Parameter):
+            pass
+
+        monkeypatch.setattr(dt_mod, "DTensor", _FakeDTensor, raising=False)
+
+        model = _VLMLike()
+        # Mark the frozen proj weight as a "sharded" param (DTensor-like instance).
+        model.vision.proj.weight = _FakeDTensor(model.vision.proj.weight.data, requires_grad=False)
+
+        cast_frozen_modules_to_compute_dtype(model, torch.bfloat16)
+
+        # Sharded param is left untouched (FSDP would down-cast it at all-gather).
+        assert model.vision.proj.weight.dtype == torch.float32
+        # Plain frozen param in the same subtree is still cast.
+        assert model.vision.norm.weight.dtype == torch.bfloat16
+        # Frozen buffer is always cast (never FSDP-managed) -- the actual fix.
+        assert model.vision.pos.dtype == torch.bfloat16
+
 
 class TestRestoreFp32Buffers:
     def test_buffers_restored_params_untouched(self):

--- a/tests/unit_tests/models/common/test_cast_model_to_dtype.py
+++ b/tests/unit_tests/models/common/test_cast_model_to_dtype.py
@@ -22,6 +22,7 @@ from nemo_automodel.components.models.common.utils import (
     _has_dtensor_params,
     _restore_fp32_buffers,
     _restore_fp32_modules,
+    cast_frozen_modules_to_compute_dtype,
     cast_model_to_dtype,
 )
 
@@ -280,6 +281,66 @@ class TestDTensorAwareCasting:
 
         assert model.norm.weight.dtype == torch.float32
         assert model.linear.weight.dtype == torch.bfloat16
+
+
+class _VLMLike(nn.Module):
+    """A frozen tower + trainable backbone, mirroring the VLM finetune layout."""
+
+    def __init__(self, keep_fp32=None):
+        super().__init__()
+        if keep_fp32 is not None:
+            self._keep_in_fp32_modules = keep_fp32
+        # Frozen vision tower (excluded from FSDP) with a norm submodule.
+        self.vision = nn.Module()
+        self.vision.proj = nn.Linear(4, 4)
+        self.vision.norm = nn.LayerNorm(4)
+        self.vision.register_buffer("pos", torch.zeros(4))
+        for p in self.vision.parameters():
+            p.requires_grad_(False)
+        # Trainable language backbone.
+        self.language = nn.Linear(4, 2)
+
+
+class TestCastFrozenModulesToComputeDtype:
+    def test_frozen_tower_cast_trainable_untouched(self):
+        model = _VLMLike()
+        # Whole model starts fp32.
+        assert model.vision.proj.weight.dtype == torch.float32
+        assert model.language.weight.dtype == torch.float32
+
+        cast_frozen_modules_to_compute_dtype(model, torch.bfloat16)
+
+        # Frozen tower (params + buffers) cast to the compute dtype.
+        assert model.vision.proj.weight.dtype == torch.bfloat16
+        assert model.vision.norm.weight.dtype == torch.bfloat16
+        assert model.vision.pos.dtype == torch.bfloat16
+        # Trainable backbone is left for FSDP to cast.
+        assert model.language.weight.dtype == torch.float32
+
+    def test_none_compute_dtype_is_noop(self):
+        model = _VLMLike()
+        cast_frozen_modules_to_compute_dtype(model, None)
+        assert model.vision.proj.weight.dtype == torch.float32
+
+    def test_respects_keep_in_fp32_modules(self):
+        model = _VLMLike(keep_fp32=["norm"])
+        cast_frozen_modules_to_compute_dtype(model, torch.bfloat16)
+
+        assert model.vision.proj.weight.dtype == torch.bfloat16
+        # Frozen norm is pinned to fp32 even though the rest of the tower is bf16.
+        assert model.vision.norm.weight.dtype == torch.float32
+
+    def test_already_compute_dtype_noop(self):
+        model = _VLMLike()
+        model.vision.to(torch.bfloat16)
+        cast_frozen_modules_to_compute_dtype(model, torch.bfloat16)
+        assert model.vision.proj.weight.dtype == torch.bfloat16
+
+    def test_fully_trainable_model_untouched(self):
+        model = SimpleModel()  # all params require grad
+        cast_frozen_modules_to_compute_dtype(model, torch.bfloat16)
+        for p in model.parameters():
+            assert p.dtype == torch.float32
 
 
 class TestRestoreFp32Buffers:

--- a/tests/unit_tests/models/gemma4/test_gemma4_model.py
+++ b/tests/unit_tests/models/gemma4/test_gemma4_model.py
@@ -605,52 +605,6 @@ class TestGemma4ForConditionalGeneration:
             torch.arange(seq, device=device),
         )
 
-    def test_forward_casts_pooled_image_features_to_projector_dtype(self, gemma4_config, backend_config, device):
-        class DtypeCheckingVisionEmbedder(torch.nn.Module):
-            def __init__(self, hidden_size):
-                super().__init__()
-                self.proj = torch.nn.Linear(hidden_size, hidden_size, bias=False)
-                self.seen_dtype = None
-
-            def forward(self, *, inputs_embeds):
-                self.seen_dtype = inputs_embeds.dtype
-                return self.proj(inputs_embeds)
-
-        model = Gemma4ForConditionalGeneration(gemma4_config, backend=backend_config)
-        model = model.to(device).to(torch.float32)
-
-        hidden_size = gemma4_config.text_config.hidden_size
-        embedder = DtypeCheckingVisionEmbedder(hidden_size).to(device).to(torch.bfloat16)
-        model.model.embed_vision = embedder
-
-        batch, seq = 1, 3
-        inputs_embeds = torch.randn(batch, seq, hidden_size, device=device, dtype=torch.float32)
-        pixel_values = torch.randn(batch, 1, device=device, dtype=torch.bfloat16)
-        mm_token_type_ids = torch.tensor([[1, 0, 0]], device=device)
-
-        def fake_get_image_features(pixel_values, image_position_ids=None, return_dict=True):
-            pooled = torch.randn(batch, 1, hidden_size, device=device, dtype=torch.float32)
-            return MagicMock(pooler_output=model.model.embed_vision(inputs_embeds=pooled))
-
-        captured = {}
-
-        def fake_language_model_forward(**kwargs):
-            captured["inputs_embeds"] = kwargs["inputs_embeds"]
-            return MagicMock(last_hidden_state=kwargs["inputs_embeds"])
-
-        with (
-            patch.object(model.model, "get_image_features", side_effect=fake_get_image_features),
-            patch.object(model.model.language_model, "forward", side_effect=fake_language_model_forward),
-        ):
-            model(
-                inputs_embeds=inputs_embeds,
-                pixel_values=pixel_values,
-                mm_token_type_ids=mm_token_type_ids,
-            )
-
-        assert embedder.seen_dtype == torch.bfloat16
-        assert captured["inputs_embeds"].dtype == torch.float32
-
     def test_initialize_weights_dense_only_casts_dtype(self, dense_config, backend_config):
         model = Gemma4ForConditionalGeneration(dense_config, backend=backend_config)
         model.initialize_weights(dtype=torch.float32)

--- a/tests/unit_tests/recipes/test_dist_setup.py
+++ b/tests/unit_tests/recipes/test_dist_setup.py
@@ -18,6 +18,7 @@ Typed validation tests live in ``tests/unit_tests/distributed/test_mesh.py``.
 """
 
 import pytest
+import torch
 
 from nemo_automodel.components.distributed.config import DDPConfig, FSDP2Config, MegatronFSDPConfig
 from nemo_automodel.components.distributed.pipelining.config import PipelineConfig
@@ -137,6 +138,30 @@ class TestPipeline:
 
     def test_pp_enabled_false_when_pp_eq_1(self):
         assert parse_distributed_section({"pp_size": 1})["pp_enabled"] is False
+
+    def test_pipeline_dtype_defaults_to_mp_policy_output_dtype(self):
+        """Unset pipeline.dtype is derived from the FSDP mp_policy output dtype (bf16 default)."""
+        result = parse_distributed_section({"pp_size": 2})
+        assert result["pipeline_config"].dtype == torch.bfloat16
+
+    def test_pipeline_dtype_explicit_match_kept(self, caplog):
+        cfg = {"pp_size": 2, "pipeline": {"dtype": "bfloat16"}}
+        with caplog.at_level("WARNING"):
+            result = parse_distributed_section(cfg)
+        assert result["pipeline_config"].dtype == torch.bfloat16
+        assert "does not match" not in caplog.text
+
+    def test_pipeline_dtype_explicit_mismatch_warns_and_kept(self, caplog):
+        cfg = {"pp_size": 2, "pipeline": {"dtype": "float32"}}
+        with caplog.at_level("WARNING"):
+            result = parse_distributed_section(cfg)
+        # Explicit value is honored (not overridden) but a mismatch warning fires.
+        assert result["pipeline_config"].dtype == torch.float32
+        assert "does not match" in caplog.text
+
+    def test_pipeline_dtype_not_set_when_pp_eq_1(self):
+        result = parse_distributed_section({"pp_size": 1})
+        assert result["pipeline_config"] is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Split out of #2379 (the broader fp32-master-weight effort) so the **bug-fix** portion can merge soon, separate from the **default-dtype behavior change** (which needs broad OOM/config validation and will follow up).

This PR contains only changes that are **no-ops for existing example configs** (no config sets `model.torch_dtype: float32`, so there is no memory/perf regression). It fixes correctness issues in how dtypes are loaded, propagated, and sharded.

### Bug fixes / refactors
- **`_restore_loaded_model_dtype` is now dtype-aware** (`model_init.py`): unifies each floating tensor to `promote_types(checkpoint, requested)` instead of always restoring the checkpoint dtype. Honors an explicit fp32 request while preserving intrinsically-fp32 checkpoint params (e.g. `A_log`) under bf16; no-op for the bf16/auto path. Fixes FSDP2 uniform-dtype tripping on HF mixed-dtype loads.
- **FSDP compute dtype resolved per-param, decoupled from storage** (`parallelizer_utils.py`, `parallelizer.py`): `fully_shard_by_dtype` groups params by resolved compute dtype with clear precedence (pinned fp32 → HF-recorded `_hf_compute_dtype` → fallback).
- **Frozen modules cast to compute dtype** (`models/common/utils.py`, `infrastructure.py`): general `cast_frozen_modules_to_compute_dtype` casts fully-frozen, non-sharded submodules to the FSDP compute dtype, respecting `_keep_in_fp32_modules(_strict)`. Removes the now-redundant gemma4-specific projector hook.
- **Pipeline dtype defaults to FSDP activation dtype** (`_dist_setup.py`) instead of falling back incorrectly.
- **Qwen3.5** declares `_keep_in_fp32_modules_strict` for its `_fp32_params` holder.

### Dormant helper (not wired)
- `resolve_storage_dtype()` is added and unit-tested in `precision_warnings.py` but **not called** from any recipe. The four call sites carry a breadcrumb comment; wiring (the actual default-behavior change) lands in the follow-up PR.

### Docs
- Model-onboarding skill documents the `_keep_in_fp32_modules_strict` contract.

## Test plan
- [x] `tests/unit_tests/_transformers/test_auto_model.py`
- [x] `tests/unit_tests/distributed/test_fp32_compute_contract.py`
- [x] `tests/unit_tests/distributed/test_parallelizer_utils.py`
- [x] `tests/unit_tests/models/common/test_cast_model_to_dtype.py`
- [x] `tests/unit_tests/recipes/test_dist_setup.py`
- [x] `tests/unit_tests/components/training/test_precision_warnings.py`
- [x] `ruff check` clean
- [x] GitLab CI (memory/perf sanity across touched models)

Nightly CI run: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/53813531
Verified any failure cases are the same as main. No new failed tests.

## Notes
- Base branch is `zpqiu/fp32-master-weights-custom-moe`.
- Follow-up PR (default fp32 master-weight behavior + EAGLE/diffusion configs + docs) will rebase onto this once merged.