### PR TITLE
perf(speculative): add fused Triton soft cross-entropy kernel for EAGLE-3

### DIFF
--- a/nemo_automodel/components/loss/benchmark/ce_loss.py
+++ b/nemo_automodel/components/loss/benchmark/ce_loss.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Benchmark: Triton fused soft CE vs PyTorch baseline.
+
+Usage:
+    python nemo_automodel/components/loss/benchmark/ce_loss.py
+    CUDA_VISIBLE_DEVICES=2 python nemo_automodel/components/loss/benchmark/ce_loss.py
+"""
+
+import time
+
+import torch
+import torch.nn.functional as F
+
+from nemo_automodel.components.loss.triton.soft_cross_entropy import fused_soft_cross_entropy
+
+
+def pytorch_soft_ce(logits, target_probs, mask):
+    """Reference PyTorch soft cross-entropy used as the benchmark baseline."""
+    log_probs = F.log_softmax(logits.float(), dim=-1)
+    per_token_loss = -(target_probs.float() * log_probs).sum(dim=-1)
+    valid_mask = mask.squeeze(-1).float()
+    valid_count = valid_mask.sum().clamp_min(1.0)
+    return (per_token_loss * valid_mask).sum() / valid_count
+
+
+def bench_fn(fn, logits, target_probs, mask, warmup=5, iters=10, backward=True):
+    """Time ``fn`` (optionally including backward) and return seconds per iteration."""
+    for _ in range(warmup):
+        loss = fn(logits, target_probs, mask)
+        if backward:
+            loss.backward()
+            logits.grad = None
+    torch.cuda.synchronize()
+
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        loss = fn(logits, target_probs, mask)
+        if backward:
+            loss.backward()
+            logits.grad = None
+    torch.cuda.synchronize()
+    return (time.perf_counter() - t0) / iters
+
+
+def measure_memory(fn, logits, target_probs, mask, backward=True):
+    """Return peak CUDA memory (bytes) for a single forward/backward of ``fn``."""
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats()
+    loss = fn(logits, target_probs, mask)
+    if backward:
+        loss.backward()
+        logits.grad = None
+    torch.cuda.synchronize()
+    return torch.cuda.max_memory_allocated()
+
+
+def run_shape_benchmark(shapes, mask_ratio=0.8, dtype=torch.bfloat16):
+    """Print a speed/memory/accuracy comparison table across the given tensor shapes."""
+    device = "cuda"
+    print(f"\n{'=' * 110}")
+    print(f" Shape Benchmark | mask_ratio={mask_ratio}, dtype={dtype}")
+    print(f"{'=' * 110}")
+    print(
+        f"{'Shape':<22} | {'PyTorch':>9} | {'Triton':>9} | {'Speedup':>7} "
+        f"| {'PT Mem':>8} | {'Tri Mem':>8} | {'Saved':>8} | {'Loss diff':>10} | {'Grad cos':>10}"
+    )
+    print("-" * 110)
+
+    for B, S, V in shapes:
+        torch.cuda.empty_cache()
+        try:
+            logits = torch.randn(B, S, V, dtype=dtype, device=device, requires_grad=True)
+            logits_ref = logits.detach().clone().requires_grad_(True)
+            target_probs = torch.softmax(torch.randn(B, S, V, device=device), dim=-1).to(dtype)
+            mask = (torch.rand(B, S, device=device) < mask_ratio).unsqueeze(-1).float()
+
+            # Precision
+            ref_loss = pytorch_soft_ce(logits_ref, target_probs, mask)
+            ref_loss.backward()
+            tri_loss = fused_soft_cross_entropy(logits, target_probs, mask)
+            tri_loss.backward()
+            loss_diff = abs(tri_loss.item() - ref_loss.item())
+            grad_cos = F.cosine_similarity(
+                logits.grad.flatten().float(), logits_ref.grad.flatten().float(), dim=0
+            ).item()
+            logits.grad = None
+            logits_ref.grad = None
+            del logits_ref, ref_loss, tri_loss
+
+            # Speed
+            t_pt = bench_fn(pytorch_soft_ce, logits, target_probs, mask)
+            t_tri = bench_fn(fused_soft_cross_entropy, logits, target_probs, mask)
+
+            # Memory
+            mem_pt = measure_memory(pytorch_soft_ce, logits, target_probs, mask)
+            mem_tri = measure_memory(fused_soft_cross_entropy, logits, target_probs, mask)
+
+            speedup = t_pt / t_tri
+            saved = mem_pt - mem_tri
+            tag = f"[{B},{S},{V}]"
+
+            print(
+                f"{tag:<22} | {t_pt * 1000:7.2f}ms | {t_tri * 1000:7.2f}ms | {speedup:5.1f}x  "
+                f"| {mem_pt / 1e9:6.2f}GB | {mem_tri / 1e9:6.2f}GB | {saved / 1e9:6.2f}GB "
+                f"| {loss_diff:10.2e} | {grad_cos:10.8f}"
+            )
+
+            del logits, target_probs, mask
+            torch.cuda.empty_cache()
+
+        except torch.cuda.OutOfMemoryError:
+            print(f"{f'[{B},{S},{V}]':<22} | OOM")
+            torch.cuda.empty_cache()
+
+
+def run_mask_ratio_benchmark(B=1, S=4096, V=32000, dtype=torch.bfloat16):
+    """Print speed/accuracy of the fused kernel as the valid-position mask ratio varies."""
+    device = "cuda"
+    mask_ratios = [1.0, 0.8, 0.5, 0.2, 0.05]
+
+    print(f"\n{'=' * 110}")
+    print(f" Mask Ratio Benchmark | shape=[{B},{S},{V}], dtype={dtype}")
+    print(f"{'=' * 110}")
+    print(
+        f"{'Mask ratio':<12} | {'Valid':>7} | {'PyTorch':>9} | {'Triton':>9} "
+        f"| {'Speedup':>7} | {'Loss diff':>10} | {'Grad cos':>12}"
+    )
+    print("-" * 85)
+
+    for ratio in mask_ratios:
+        torch.cuda.empty_cache()
+
+        logits = torch.randn(B, S, V, dtype=dtype, device=device, requires_grad=True)
+        logits_ref = logits.detach().clone().requires_grad_(True)
+        target_probs = torch.softmax(torch.randn(B, S, V, device=device), dim=-1).to(dtype)
+        mask = (
+            (torch.rand(B, S, device=device) < ratio).unsqueeze(-1).float()
+            if ratio < 1.0
+            else torch.ones(B, S, 1, device=device)
+        )
+        valid = int(mask.sum().item())
+
+        # Precision
+        ref_loss = pytorch_soft_ce(logits_ref, target_probs, mask)
+        ref_loss.backward()
+        tri_loss = fused_soft_cross_entropy(logits, target_probs, mask)
+        tri_loss.backward()
+        loss_diff = abs(tri_loss.item() - ref_loss.item())
+        grad_cos = F.cosine_similarity(logits.grad.flatten().float(), logits_ref.grad.flatten().float(), dim=0).item()
+        logits.grad = None
+        logits_ref.grad = None
+        del logits_ref, ref_loss, tri_loss
+
+        # Speed
+        t_pt = bench_fn(pytorch_soft_ce, logits, target_probs, mask)
+        t_tri = bench_fn(fused_soft_cross_entropy, logits, target_probs, mask)
+
+        print(
+            f"{ratio:<12} | {valid:>7} | {t_pt * 1000:7.2f}ms | {t_tri * 1000:7.2f}ms "
+            f"| {t_pt / t_tri:5.1f}x  | {loss_diff:10.2e} | {grad_cos:12.10f}"
+        )
+
+        del logits, target_probs, mask
+        torch.cuda.empty_cache()
+
+
+def main():
+    """Run the shape and mask-ratio benchmarks on the current CUDA device."""
+    torch.manual_seed(42)
+    device = torch.cuda.get_device_name(0)
+    free, total = torch.cuda.mem_get_info(0)
+    print(f"GPU: {device} | {free / 1e9:.1f}GB free / {total / 1e9:.1f}GB total")
+
+    shapes = [
+        (1, 128, 1024),
+        (1, 256, 8192),
+        (1, 1024, 32000),
+        (1, 2048, 32000),
+        (1, 4096, 32000),
+        (1, 8192, 32000),
+        (1, 16384, 32000),
+        (1, 32768, 32000),
+    ]
+
+    run_shape_benchmark(shapes, mask_ratio=0.8)
+    run_mask_ratio_benchmark(B=1, S=4096, V=32000)
+
+
+if __name__ == "__main__":
+    main()

--- a/nemo_automodel/components/loss/benchmark/soft_ce_loss.py
+++ b/nemo_automodel/components/loss/benchmark/soft_ce_loss.py
@@ -16,8 +16,8 @@
 """Benchmark: Triton fused soft CE vs PyTorch baseline.
 
 Usage:
-    python nemo_automodel/components/loss/benchmark/ce_loss.py
-    CUDA_VISIBLE_DEVICES=2 python nemo_automodel/components/loss/benchmark/ce_loss.py
+    python nemo_automodel/components/loss/benchmark/soft_ce_loss.py
+    CUDA_VISIBLE_DEVICES=2 python nemo_automodel/components/loss/benchmark/soft_ce_loss.py
 """
 
 import time

--- a/nemo_automodel/components/loss/soft_ce.py
+++ b/nemo_automodel/components/loss/soft_ce.py
@@ -19,6 +19,11 @@ from __future__ import annotations
 import torch
 import torch.nn.functional as F
 
+try:
+    from nemo_automodel.components.loss.triton.soft_cross_entropy import HAVE_TRITON, fused_soft_cross_entropy
+except ImportError:
+    HAVE_TRITON = False
+
 
 def masked_soft_cross_entropy(
     logits: torch.Tensor,
@@ -48,6 +53,9 @@ def masked_soft_cross_entropy(
     Returns:
         Scalar loss normalized by the number of valid positions.
     """
+    if HAVE_TRITON and logits.is_cuda:
+        return fused_soft_cross_entropy(logits, target_probs, position_mask)
+
     log_probs = F.log_softmax(logits.float(), dim=-1)
     per_token_loss = -(target_probs * log_probs).sum(dim=-1)
     valid_mask = position_mask.squeeze(-1).to(per_token_loss.dtype)

--- a/nemo_automodel/components/loss/triton/soft_cross_entropy.py
+++ b/nemo_automodel/components/loss/triton/soft_cross_entropy.py
@@ -1,0 +1,233 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fused soft-target cross-entropy Triton kernel for EAGLE-3 training."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import torch
+
+from nemo_automodel.components.loss.triton.te_cross_entropy import MAX_FUSED_SIZE, element_mul_kernel
+from nemo_automodel.shared.import_utils import MISSING_TRITON_MSG, null_decorator
+
+try:
+    import triton
+    import triton.language as tl
+
+    HAVE_TRITON = True
+except ImportError:
+    HAVE_TRITON = False
+
+if not HAVE_TRITON:
+    triton = MagicMock()
+    triton.jit = null_decorator
+    triton.autotune = null_decorator
+    triton.heuristics = null_decorator
+    tl = MagicMock()
+
+
+@triton.jit
+def _soft_ce_forward_kernel(
+    X_ptr,
+    X_stride,
+    P_ptr,
+    P_stride,
+    Loss_ptr,
+    LSE_ptr,
+    Mask_ptr,
+    n_cols,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """CE = -dot(p, x) + (max + log(sum_exp)) * sum(p), single-pass online softmax."""
+    row_id = tl.program_id(0).to(tl.int64)
+
+    if tl.load(Mask_ptr + row_id) == 0.0:
+        tl.store(Loss_ptr + row_id, 0.0)
+        tl.store(LSE_ptr + row_id, 0.0)
+        return
+
+    X_row_ptr = X_ptr + row_id * X_stride
+    P_row_ptr = P_ptr + row_id * P_stride
+
+    m = float("-inf")
+    d = 0.0
+    dot_px = 0.0
+    sum_p = 0.0
+
+    for i in range(0, n_cols, BLOCK_SIZE):
+        offsets = i + tl.arange(0, BLOCK_SIZE)
+        valid = offsets < n_cols
+
+        x_block = tl.load(X_row_ptr + offsets, mask=valid, other=float("-inf")).to(tl.float32)
+        p_block = tl.load(P_row_ptr + offsets, mask=valid, other=0.0).to(tl.float32)
+
+        # Online softmax: rescale running sum when max updates
+        block_max = tl.max(x_block)
+        m_new = tl.maximum(m, block_max)
+        d = d * tl.exp(m - m_new) + tl.sum(tl.exp(x_block - m_new))
+        m = m_new
+
+        # tl.where avoids 0 * (-inf) = NaN at padding positions
+        dot_px += tl.sum(tl.where(valid, p_block * x_block, 0.0))
+        sum_p += tl.sum(p_block)
+
+    lse = m + tl.log(d)
+    tl.store(Loss_ptr + row_id, -dot_px + lse * sum_p)
+    tl.store(LSE_ptr + row_id, lse)
+
+
+@triton.jit
+def _soft_ce_backward_kernel(
+    X_ptr,
+    X_stride,
+    P_ptr,
+    P_stride,
+    LSE_ptr,
+    Mask_ptr,
+    InvCount_ptr,
+    n_cols,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """grad = (softmax(x) - p) / valid_count, single-pass using saved lse."""
+    row_id = tl.program_id(0).to(tl.int64)
+
+    if tl.load(Mask_ptr + row_id) == 0.0:
+        X_row_ptr = X_ptr + row_id * X_stride
+        for i in range(0, n_cols, BLOCK_SIZE):
+            offsets = i + tl.arange(0, BLOCK_SIZE)
+            tl.store(X_row_ptr + offsets, 0.0, mask=offsets < n_cols)
+        return
+
+    X_row_ptr = X_ptr + row_id * X_stride
+    P_row_ptr = P_ptr + row_id * P_stride
+    lse = tl.load(LSE_ptr + row_id).to(tl.float32)
+    inv_count = tl.load(InvCount_ptr).to(tl.float32)
+
+    for i in range(0, n_cols, BLOCK_SIZE):
+        offsets = i + tl.arange(0, BLOCK_SIZE)
+        valid = offsets < n_cols
+        x_block = tl.load(X_row_ptr + offsets, mask=valid, other=float("-inf"))
+        out_dtype = x_block.dtype
+        x_block = x_block.to(tl.float32)
+        p_block = tl.load(P_row_ptr + offsets, mask=valid, other=0.0).to(tl.float32)
+
+        grad_block = (tl.exp(x_block - lse) - p_block) * inv_count
+        tl.store(X_row_ptr + offsets, grad_block.to(out_dtype), mask=valid)
+
+
+def _select_num_warps(V: int) -> int:
+    if V <= 1024:
+        return 4
+    elif V <= 4096:
+        return 8
+    elif V <= 16384:
+        return 16
+    return 32
+
+
+def _launch_config(V: int) -> tuple[int, int]:
+    """Return the (BLOCK_SIZE, num_warps) launch config for a vocab size of ``V``."""
+    return min(MAX_FUSED_SIZE, triton.next_power_of_2(V)), _select_num_warps(V)
+
+
+class SoftCrossEntropyFunction(torch.autograd.Function):
+    """Autograd wrapper around the fused Triton soft cross-entropy kernels."""
+
+    @staticmethod
+    def forward(ctx, logits, target_probs, valid_mask, valid_count):
+        B, S, V = logits.shape
+        n_rows = B * S
+
+        logits_2d = logits.view(n_rows, V)
+        if logits_2d.stride(-1) != 1:
+            logits_2d = logits_2d.contiguous()
+        target_probs_2d = target_probs.view(n_rows, V)
+        if target_probs_2d.stride(-1) != 1:
+            target_probs_2d = target_probs_2d.contiguous()
+
+        mask_1d = valid_mask.view(n_rows)
+        loss_1d = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse_1d = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        BLOCK_SIZE, num_warps = _launch_config(V)
+
+        _soft_ce_forward_kernel[(n_rows,)](
+            logits_2d,
+            logits_2d.stride(0),
+            target_probs_2d,
+            target_probs_2d.stride(0),
+            loss_1d,
+            lse_1d,
+            mask_1d,
+            V,
+            BLOCK_SIZE=BLOCK_SIZE,
+            num_warps=num_warps,
+        )
+
+        scalar_loss = loss_1d.sum() / valid_count
+        inv_valid_count = torch.reciprocal(valid_count)
+
+        ctx.save_for_backward(logits_2d.detach(), target_probs_2d, mask_1d, lse_1d, inv_valid_count)
+        ctx.shape = (B, S, V)
+        return scalar_loss
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits_2d, target_probs_2d, mask_1d, lse_1d, inv_valid_count = ctx.saved_tensors
+        B, S, V = ctx.shape
+        n_rows = B * S
+
+        BLOCK_SIZE, num_warps = _launch_config(V)
+
+        _soft_ce_backward_kernel[(n_rows,)](
+            logits_2d,
+            logits_2d.stride(0),
+            target_probs_2d,
+            target_probs_2d.stride(0),
+            lse_1d,
+            mask_1d,
+            inv_valid_count,
+            V,
+            BLOCK_SIZE=BLOCK_SIZE,
+            num_warps=num_warps,
+        )
+
+        # Scale the in-place gradient by the incoming grad_output. Launched
+        # unconditionally: the elementwise multiply is cheap and reading
+        # grad_output on-device avoids a per-step ``.item()`` host sync.
+        element_mul_kernel[(n_rows,)](
+            logits_2d,
+            logits_2d.stride(0),
+            grad_output,
+            V,
+            BLOCK_SIZE=BLOCK_SIZE,
+            num_warps=num_warps,
+        )
+
+        return logits_2d.view(B, S, V), None, None, None
+
+
+def fused_soft_cross_entropy(
+    logits: torch.Tensor,
+    target_probs: torch.Tensor,
+    position_mask: torch.Tensor,
+) -> torch.Tensor:
+    """Fused Triton soft cross-entropy, drop-in replacement for the PyTorch path."""
+    if not HAVE_TRITON:
+        raise ImportError(MISSING_TRITON_MSG)
+    valid_mask = position_mask.squeeze(-1).float()
+    valid_count = valid_mask.sum().clamp_min(1.0)
+    return SoftCrossEntropyFunction.apply(logits, target_probs, valid_mask, valid_count)

--- a/nemo_automodel/components/loss/triton/soft_cross_entropy.py
+++ b/nemo_automodel/components/loss/triton/soft_cross_entropy.py
@@ -47,16 +47,22 @@ def _soft_ce_forward_kernel(
     P_stride,
     Loss_ptr,
     LSE_ptr,
+    Sump_ptr,
     Mask_ptr,
     n_cols,
     BLOCK_SIZE: tl.constexpr,
 ):
-    """CE = -dot(p, x) + (max + log(sum_exp)) * sum(p), single-pass online softmax."""
+    """CE = -dot(p, x) + (max + log(sum_exp)) * sum(p), single-pass online softmax.
+
+    ``sum(p)`` is saved per row so the backward can form the exact gradient
+    ``sum(p) * softmax(x) - p`` for arbitrary (not necessarily normalized) targets.
+    """
     row_id = tl.program_id(0).to(tl.int64)
 
     if tl.load(Mask_ptr + row_id) == 0.0:
         tl.store(Loss_ptr + row_id, 0.0)
         tl.store(LSE_ptr + row_id, 0.0)
+        tl.store(Sump_ptr + row_id, 0.0)
         return
 
     X_row_ptr = X_ptr + row_id * X_stride
@@ -87,6 +93,7 @@ def _soft_ce_forward_kernel(
     lse = m + tl.log(d)
     tl.store(Loss_ptr + row_id, -dot_px + lse * sum_p)
     tl.store(LSE_ptr + row_id, lse)
+    tl.store(Sump_ptr + row_id, sum_p)
 
 
 @triton.jit
@@ -96,12 +103,18 @@ def _soft_ce_backward_kernel(
     P_ptr,
     P_stride,
     LSE_ptr,
+    Sump_ptr,
     Mask_ptr,
     InvCount_ptr,
     n_cols,
     BLOCK_SIZE: tl.constexpr,
 ):
-    """grad = (softmax(x) - p) / valid_count, single-pass using saved lse."""
+    """grad = (sum_p * softmax(x) - p) / valid_count, single-pass using saved lse / sum_p.
+
+    ``sum_p`` (the per-row target mass, == 1 for a normalized distribution) is the
+    derivative of the forward's ``lse * sum(p)`` term and keeps the gradient exact
+    for arbitrary targets.
+    """
     row_id = tl.program_id(0).to(tl.int64)
 
     if tl.load(Mask_ptr + row_id) == 0.0:
@@ -114,6 +127,7 @@ def _soft_ce_backward_kernel(
     X_row_ptr = X_ptr + row_id * X_stride
     P_row_ptr = P_ptr + row_id * P_stride
     lse = tl.load(LSE_ptr + row_id).to(tl.float32)
+    sum_p = tl.load(Sump_ptr + row_id).to(tl.float32)
     inv_count = tl.load(InvCount_ptr).to(tl.float32)
 
     for i in range(0, n_cols, BLOCK_SIZE):
@@ -124,7 +138,7 @@ def _soft_ce_backward_kernel(
         x_block = x_block.to(tl.float32)
         p_block = tl.load(P_row_ptr + offsets, mask=valid, other=0.0).to(tl.float32)
 
-        grad_block = (tl.exp(x_block - lse) - p_block) * inv_count
+        grad_block = (sum_p * tl.exp(x_block - lse) - p_block) * inv_count
         tl.store(X_row_ptr + offsets, grad_block.to(out_dtype), mask=valid)
 
 
@@ -161,6 +175,7 @@ class SoftCrossEntropyFunction(torch.autograd.Function):
         mask_1d = valid_mask.view(n_rows)
         loss_1d = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
         lse_1d = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        sump_1d = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
 
         BLOCK_SIZE, num_warps = _launch_config(V)
 
@@ -171,6 +186,7 @@ class SoftCrossEntropyFunction(torch.autograd.Function):
             target_probs_2d.stride(0),
             loss_1d,
             lse_1d,
+            sump_1d,
             mask_1d,
             V,
             BLOCK_SIZE=BLOCK_SIZE,
@@ -180,13 +196,13 @@ class SoftCrossEntropyFunction(torch.autograd.Function):
         scalar_loss = loss_1d.sum() / valid_count
         inv_valid_count = torch.reciprocal(valid_count)
 
-        ctx.save_for_backward(logits_2d.detach(), target_probs_2d, mask_1d, lse_1d, inv_valid_count)
+        ctx.save_for_backward(logits_2d.detach(), target_probs_2d, mask_1d, lse_1d, sump_1d, inv_valid_count)
         ctx.shape = (B, S, V)
         return scalar_loss
 
     @staticmethod
     def backward(ctx, grad_output):
-        logits_2d, target_probs_2d, mask_1d, lse_1d, inv_valid_count = ctx.saved_tensors
+        logits_2d, target_probs_2d, mask_1d, lse_1d, sump_1d, inv_valid_count = ctx.saved_tensors
         B, S, V = ctx.shape
         n_rows = B * S
 
@@ -198,6 +214,7 @@ class SoftCrossEntropyFunction(torch.autograd.Function):
             target_probs_2d,
             target_probs_2d.stride(0),
             lse_1d,
+            sump_1d,
             mask_1d,
             inv_valid_count,
             V,

--- a/tests/unit_tests/loss/test_soft_ce_triton.py
+++ b/tests/unit_tests/loss/test_soft_ce_triton.py
@@ -133,3 +133,26 @@ def test_one_hot_target():
     triton_loss = fused_soft_cross_entropy(logits, target_probs, mask)
 
     torch.testing.assert_close(triton_loss, ref_loss, rtol=1e-4, atol=1e-4)
+
+
+def test_unnormalized_target_forward_and_backward():
+    """Targets whose rows do not sum to 1 still match the PyTorch reference.
+
+    Pins the per-row ``sum(p)`` factor in the backward (``sum_p * softmax(x) - p``):
+    with a normalized target ``sum_p == 1`` and the factor is invisible, so this
+    uses raw non-negative weights (``sum_p != 1``) to exercise it.
+    """
+    B, S, V = 1, 256, 4096
+    logits_ref = torch.randn(B, S, V, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+    logits_tri = logits_ref.detach().clone().requires_grad_(True)
+    # Raw non-negative weights, deliberately NOT renormalized to sum to 1.
+    target_probs = torch.rand(B, S, V, dtype=torch.bfloat16, device="cuda")
+    mask = torch.ones(B, S, 1, device="cuda")
+
+    ref_loss = _pytorch_reference(logits_ref, target_probs, mask)
+    ref_loss.backward()
+    tri_loss = fused_soft_cross_entropy(logits_tri, target_probs, mask)
+    tri_loss.backward()
+
+    torch.testing.assert_close(tri_loss, ref_loss, rtol=1e-4, atol=1e-4)
+    torch.testing.assert_close(logits_tri.grad, logits_ref.grad, rtol=1e-3, atol=1e-3)

--- a/tests/unit_tests/loss/test_soft_ce_triton.py
+++ b/tests/unit_tests/loss/test_soft_ce_triton.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the fused Triton soft cross-entropy kernel."""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from nemo_automodel.components.loss.triton.soft_cross_entropy import HAVE_TRITON, fused_soft_cross_entropy
+
+pytestmark = [
+    pytest.mark.skipif(not HAVE_TRITON, reason="Triton not installed"),
+    pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available"),
+]
+
+# (batch, seq_len, vocab) shapes exercised by the forward/backward parity tests.
+_PARITY_SHAPES = [
+    (1, 128, 1024),
+    (1, 256, 8192),
+    (1, 1024, 32000),
+    (1, 2048, 32000),
+    (1, 4096, 32000),
+    (1, 8192, 32000),
+    (1, 16384, 32000),
+    (1, 32768, 32000),
+]
+
+
+def _pytorch_reference(logits, target_probs, position_mask):
+    """Reference PyTorch implementation."""
+    log_probs = F.log_softmax(logits.float(), dim=-1)
+    per_token_loss = -(target_probs.float() * log_probs).sum(dim=-1)
+    valid_mask = position_mask.squeeze(-1).float()
+    valid_count = valid_mask.sum().clamp_min(1.0)
+    return (per_token_loss * valid_mask).sum() / valid_count
+
+
+def _make_inputs(batch, seq_len, vocab, dtype=torch.bfloat16, mask_ratio=0.8, device="cuda"):
+    """Generate random test inputs."""
+    logits = torch.randn(batch, seq_len, vocab, dtype=dtype, device=device)
+    target_logits = torch.randn(batch, seq_len, vocab, dtype=torch.float32, device=device)
+    target_probs = torch.softmax(target_logits, dim=-1).to(dtype)
+    mask = (torch.rand(batch, seq_len, device=device) < mask_ratio).unsqueeze(-1).float()
+    return logits, target_probs, mask
+
+
+@pytest.mark.parametrize("batch,seq_len,vocab", _PARITY_SHAPES)
+def test_forward_matches_pytorch(batch, seq_len, vocab):
+    """Triton forward output matches PyTorch reference within tolerance."""
+    logits, target_probs, mask = _make_inputs(batch, seq_len, vocab)
+
+    ref_loss = _pytorch_reference(logits, target_probs, mask)
+    triton_loss = fused_soft_cross_entropy(logits, target_probs, mask)
+
+    torch.testing.assert_close(triton_loss, ref_loss, rtol=1e-4, atol=1e-4)
+
+
+@pytest.mark.parametrize("batch,seq_len,vocab", _PARITY_SHAPES)
+def test_backward_matches_pytorch(batch, seq_len, vocab):
+    """Triton backward gradients match PyTorch autograd."""
+    logits_ref, target_probs, mask = _make_inputs(batch, seq_len, vocab)
+    logits_ref.requires_grad_(True)
+
+    logits_tri = logits_ref.detach().clone().requires_grad_(True)
+
+    ref_loss = _pytorch_reference(logits_ref, target_probs, mask)
+    ref_loss.backward()
+
+    triton_loss = fused_soft_cross_entropy(logits_tri, target_probs, mask)
+    triton_loss.backward()
+
+    torch.testing.assert_close(logits_tri.grad, logits_ref.grad, rtol=1e-3, atol=1e-3)
+
+
+def test_all_masked():
+    """All positions masked produces zero loss and zero gradients."""
+    logits, target_probs, _ = _make_inputs(1, 64, 1024)
+    mask = torch.zeros(1, 64, 1, device="cuda")
+    logits.requires_grad_(True)
+
+    loss = fused_soft_cross_entropy(logits, target_probs, mask)
+    loss.backward()
+
+    assert loss.item() == 0.0
+    assert logits.grad.abs().max().item() == 0.0
+
+
+def test_single_valid_position():
+    """Single valid position produces correct loss."""
+    logits, target_probs, _ = _make_inputs(1, 64, 1024)
+    mask = torch.zeros(1, 64, 1, device="cuda")
+    mask[0, 7, 0] = 1.0
+
+    ref_loss = _pytorch_reference(logits, target_probs, mask)
+    triton_loss = fused_soft_cross_entropy(logits, target_probs, mask)
+
+    torch.testing.assert_close(triton_loss, ref_loss, rtol=1e-4, atol=1e-4)
+
+
+def test_fp32_target_probs():
+    """Works with fp32 target_probs (live training path)."""
+    logits = torch.randn(1, 256, 8192, dtype=torch.bfloat16, device="cuda")
+    target_probs = torch.softmax(torch.randn(1, 256, 8192, device="cuda"), dim=-1)  # fp32
+    mask = torch.ones(1, 256, 1, device="cuda")
+
+    ref_loss = _pytorch_reference(logits, target_probs, mask)
+    triton_loss = fused_soft_cross_entropy(logits, target_probs, mask)
+
+    torch.testing.assert_close(triton_loss, ref_loss, rtol=1e-4, atol=1e-4)
+
+
+def test_one_hot_target():
+    """One-hot targets (degenerate case) match standard CE."""
+    B, S, V = 1, 128, 1024
+    logits = torch.randn(B, S, V, dtype=torch.bfloat16, device="cuda")
+    labels = torch.randint(0, V, (B, S), device="cuda")
+    target_probs = F.one_hot(labels, V).float()
+    mask = torch.ones(B, S, 1, device="cuda")
+
+    ref_loss = _pytorch_reference(logits, target_probs, mask)
+    triton_loss = fused_soft_cross_entropy(logits, target_probs, mask)
+
+    torch.testing.assert_close(triton_loss, ref_loss, rtol=1e-4, atol=1e-4)


### PR DESCRIPTION
# What does this PR do ?

Add a fused Triton soft-target cross-entropy kernel for EAGLE-3 / P-EAGLE draft training. The primary motivation is memory: the PyTorch `F.log_softmax` + elementwise multiply + sum path in `masked_soft_cross_entropy` materializes a full `[B, S, vocab]` float32 log-probs tensor, which is the dominant peak-memory term in draft training. The fused kernel computes the loss with a single-pass online softmax and never materializes that tensor, cutting the loss peak memory to roughly the inputs alone.

Measured savings scale with sequence length, e.g. ~12.6 GB saved at `[1, 32768, 32000]` (4x less peak memory for this op), with a speedup on top (memory-bound, so it varies by GPU bandwidth). See the benchmark comments below for A6000 and A100 numbers.

## Impact on P-EAGLE

This should let P-EAGLE train at sequence length 4096 without OOM, and without needing to enable sequence partitioning to fit. Sequence partitioning stays available for longer sequences, but it should no longer be required just to make 4096 fit.

# Changelog

- Add `nemo_automodel/components/loss/triton/soft_cross_entropy.py`: `fused_soft_cross_entropy` plus `SoftCrossEntropyFunction` (forward computes loss with a single-pass online softmax and saves `lse`; backward reuses `lse` to compute `softmax(x) - p` in one pass; masked rows early-return).
- `masked_soft_cross_entropy` (`soft_ce.py`) dispatches to the fused kernel when Triton is available and the input is on CUDA, and otherwise keeps the existing PyTorch path.
- Reuse `MAX_FUSED_SIZE` and `element_mul_kernel` from the sibling `te_cross_entropy.py` instead of redefining them.
- Add CUDA parity tests (`tests/unit_tests/loss/test_soft_ce_triton.py`) covering forward loss, backward gradients, all-masked, single-valid-position, fp32 targets, and one-hot targets against the PyTorch reference.
- Add a standalone microbenchmark (`benchmark/ce_loss.py`).

# Note for reviewers

`masked_soft_cross_entropy` selects the fused kernel transparently via `if HAVE_TRITON and logits.is_cuda`, rather than as an explicitly-constructed loss object the way `FusedLinearCrossEntropy` / `TEParallelCrossEntropy` are selected. This keeps it a drop-in for existing callers, but differs from the explicit-selection convention used elsewhere. Happy to switch to explicit selection (threaded through the EAGLE recipe) if preferred.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

# Additional Information

- Numerical parity with the PyTorch path is covered by the new tests (the kernel keeps fp32 accumulation).
- The speedup is memory-bound, so the relative speedup is lower on higher-bandwidth GPUs while the memory savings stay the same across GPUs.
