### PR TITLE
[model][perf] feat: FFPA D=512 attention backend for Gemma4 (3× fwd / 6× bwd vs SDPA)

### DIFF
--- a/examples/vlm_finetune/gemma4/gemma4_31b_ffpa.yaml
+++ b/examples/vlm_finetune/gemma4/gemma4_31b_ffpa.yaml
@@ -1,0 +1,124 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Configuration for fine-tuning Gemma 4 31B (dense) on the MMLongBench summ-multi
+# corpus (gov-report + multi-lexsum, K in {4,8,16}, summarization + claims-extraction).
+# See scripts/prepare_mmlongbench_summ_multi.py for data preparation.
+# torchrun --nproc-per-node=8 examples/vlm_finetune/finetune.py -c examples/vlm_finetune/gemma4/gemma4_31b_ffpa.yaml
+
+recipe: FinetuneRecipeForVLM
+
+step_scheduler:
+  global_batch_size: 8
+  local_batch_size: 1
+  ckpt_every_steps: 500
+  val_every_steps: 500
+  num_epochs: 2
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 60
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 42
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained
+  pretrained_model_name_or_path: google/gemma-4-31B-it
+  torch_dtype: torch.bfloat16
+  use_liger_kernel: true
+  use_sdpa_patching: false
+  attn_implementation: ffpa
+  # 31B does not use kv_shared layers (only used in 2B, 4B), hence use_cache: false.
+  text_config:
+    use_cache: false
+
+processor:
+  padding_side: right
+
+checkpoint:
+  enabled: false
+  checkpoint_dir: vlm_checkpoints/gemma4_31b_it/
+  model_save_format: torch_save
+  save_consolidated: false
+
+distributed:
+  strategy: fsdp2
+  dp_size: none
+  tp_size: 1
+  cp_size: 1
+
+  sequence_parallel: false
+  # Activation checkpointing is required for Gemma4 31B to fit in memory; fsdp alone leads to OOM.
+  activation_checkpointing: true
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.vlm.datasets.make_meta_dataset
+  path_or_dataset: /data/vllm_serve_bench/mmlongbench/meta_train_summ_multi.json
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.vlm.datasets.make_meta_dataset
+  path_or_dataset: /data/vllm_serve_bench/mmlongbench/meta_val_summ_multi.json
+
+# Gemma4 training does not support sequence packing, so seqlen is controlled
+# exclusively via collate_fn.max_length (forwarded to the HF processor with
+# padding="max_length" + truncation=True for deterministic activation memory).
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  num_workers: 4
+  pin_memory: true
+  collate_fn:
+    _target_: nemo_automodel.components.datasets.vlm.collate_fns.gemma4_prefix_collate_fn
+    max_length: 8192
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  num_workers: 1
+  collate_fn:
+    _target_: nemo_automodel.components.datasets.vlm.collate_fns.gemma4_prefix_collate_fn
+    max_length: 8192
+
+optimizer:
+  _target_: torch.optim.AdamW
+  lr: 1e-5
+  weight_decay: 0.01
+  betas: [0.9, 0.95]
+
+lr_scheduler:
+  lr_decay_style: cosine
+
+freeze_config:
+  freeze_embeddings: true
+  freeze_vision_tower: true
+  freeze_audio_tower: true
+  freeze_language_model: false
+
+wandb:
+  project: gemma4-31b-ffpa-fix-mem
+  name: ""
+  group: "gemma4-31b-medpix"
+  tags:
+    - gemma4-31b
+    - medpix-vqa
+    - fsdp2
+    - ffpa
+
+ci:
+  recipe_owner: athitten
+  time: "00:20:00"

--- a/nemo_automodel/_transformers/auto_model.py
+++ b/nemo_automodel/_transformers/auto_model.py
@@ -391,6 +391,18 @@ class _BaseNeMoAutoModelClass(_BaseAutoModelClass):
             logger.info("attn_implementation='te' requested: using 'sdpa' for model init and will inject TE post-init.")
             attn_implementation = "sdpa"
 
+        # Check before _apply_preload_overrides, which would otherwise rewrite ffpa → sdpa/flash_attention_2.
+        if attn_implementation == "ffpa":
+            if mesh.cp_size > 1:
+                raise ValueError(
+                    f"attn_implementation='ffpa' is incompatible with cp_size>1 (got cp_size={mesh.cp_size})."
+                )
+            if has_packed_sequence:
+                raise ValueError("attn_implementation='ffpa' is incompatible with packed sequences.")
+            from nemo_automodel._transformers.ffpa_attention import register_ffpa_attention
+
+            register_ffpa_attention()
+
         if is_hf_model:
             attn_implementation, use_liger_kernel = _apply_preload_overrides(
                 mesh.tp_size,
@@ -1026,6 +1038,11 @@ class _NeMoAutoModelForRetrievalBase:
         from nemo_automodel._transformers import retrieval as _enc_mod
 
         encoder_cls = getattr(_enc_mod, cls._ENCODER_CLS_NAME)
+
+        if attn_implementation == "ffpa":
+            from nemo_automodel._transformers.ffpa_attention import register_ffpa_attention
+
+            register_ffpa_attention()
 
         logger.info(f"Loading {cls.__name__} from {pretrained_model_name_or_path}")
 

--- a/nemo_automodel/_transformers/ffpa_attention.py
+++ b/nemo_automodel/_transformers/ffpa_attention.py
@@ -1,0 +1,300 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""FFPA attention bindings for HF ``ALL_ATTENTION_FUNCTIONS`` / ``ALL_MASK_ATTENTION_FUNCTIONS``.
+
+Routes ``head_dim=512`` bf16/fp16 layers through the CuTeDSL FFPA kernel and
+falls back to SDPA (or eager for softcap) for unsupported configurations.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable
+
+import torch
+from torch import nn
+
+logger = logging.getLogger(__name__)
+
+_FFPA_HEAD_DIM = 512
+_REGISTERED: bool = False
+_FALLBACK_WARNED: set[str] = set()
+
+# Sentinel "no window" for the varlen custom op (matches ffpa_attn).
+_VARLEN_WIN_NONE = -(2**31)
+
+_SDPA_FN: Callable | None = None
+_EAGER_FN: Callable | None = None
+_FFPA_FN: Callable | None = None
+_CUTEDSL_BACKEND: Any = None
+_FFPA_LOW_LEVEL_READY: bool | None = None
+
+
+def _warn_once(reason: str, message: str, *, target: str = "sdpa") -> None:
+    if reason in _FALLBACK_WARNED:
+        return
+    _FALLBACK_WARNED.add(reason)
+    logger.warning("ffpa fallback to %s: %s (reason=%r)", target, message, reason)
+
+
+def _get_sdpa() -> Callable | None:
+    global _SDPA_FN
+    if _SDPA_FN is None:
+        try:
+            from transformers.integrations.sdpa_attention import sdpa_attention_forward
+
+            _SDPA_FN = sdpa_attention_forward
+        except Exception:
+            return None
+    return _SDPA_FN
+
+
+def _get_eager() -> Callable | None:
+    global _EAGER_FN
+    if _EAGER_FN is None:
+        try:
+            from transformers.models.gemma4.modeling_gemma4 import eager_attention_forward
+
+            _EAGER_FN = eager_attention_forward
+        except Exception:
+            return None
+    return _EAGER_FN
+
+
+def _ffpa_low_level_ready() -> bool:
+    global _FFPA_LOW_LEVEL_READY
+    if _FFPA_LOW_LEVEL_READY is None:
+        try:
+            import ffpa_attn.cute  # noqa: F401
+
+            _ = torch.ops.ffpa_attn._fwd_cute
+            _ = torch.ops.ffpa_attn._bwd_cute
+            _FFPA_LOW_LEVEL_READY = True
+        except Exception:
+            _FFPA_LOW_LEVEL_READY = False
+    return _FFPA_LOW_LEVEL_READY
+
+
+def _get_ffpa_high_level() -> tuple[Callable | None, Any]:
+    global _FFPA_FN, _CUTEDSL_BACKEND
+    if _FFPA_FN is None:
+        try:
+            from ffpa_attn import ffpa_attn_func
+            from ffpa_attn.functional import CuTeDSLBackend
+
+            _FFPA_FN = ffpa_attn_func
+            _CUTEDSL_BACKEND = CuTeDSLBackend()
+        except Exception:
+            return None, None
+    return _FFPA_FN, _CUTEDSL_BACKEND
+
+
+def ffpa_selective_checkpoint_policy():
+    """Return a ``context_fn`` factory marking FFPA forward ops as ``MUST_SAVE``."""
+    from torch.utils.checkpoint import CheckpointPolicy, create_selective_checkpoint_contexts
+
+    _ffpa_low_level_ready()
+    must_save_ops = set()
+    for name in ("_fwd_cute", "_varlen_fwd_cute"):
+        try:
+            must_save_ops.add(getattr(torch.ops.ffpa_attn, name).default)
+        except Exception:
+            pass
+
+    def _policy_fn(ctx, op, *args, **kwargs):
+        if op in must_save_ops:
+            return CheckpointPolicy.MUST_SAVE
+        return CheckpointPolicy.PREFER_RECOMPUTE
+
+    return lambda: create_selective_checkpoint_contexts(_policy_fn)
+
+
+def ffpa_mask(
+    batch_size: int,
+    q_length: int,
+    kv_length: int,
+    q_offset: int = 0,
+    kv_offset: int = 0,
+    mask_function: Callable | None = None,
+    attention_mask: torch.Tensor | None = None,
+    dtype: torch.dtype = torch.float32,
+    **kwargs: Any,
+) -> torch.Tensor | None:
+    """Mask factory for ``ALL_MASK_ATTENTION_FUNCTIONS["ffpa"]``."""
+    # Vision / audio sub-encoders share this registry but need 4D float masks.
+    cfg = kwargs.get("config")
+    if cfg is not None:
+        model_type = getattr(cfg, "model_type", "") or ""
+        if "vision" in model_type or "audio" in model_type:
+            return None
+
+    if mask_function is not None:
+        from transformers.masking_utils import causal_mask_function, eager_mask
+
+        if mask_function is not causal_mask_function:
+            return eager_mask(
+                batch_size=batch_size,
+                q_length=q_length,
+                kv_length=kv_length,
+                q_offset=q_offset,
+                kv_offset=kv_offset,
+                mask_function=mask_function,
+                attention_mask=attention_mask,
+                dtype=dtype,
+                **kwargs,
+            )
+
+    if attention_mask is None:
+        return None
+    if attention_mask.dtype != torch.bool:
+        attention_mask = attention_mask.to(dtype=torch.bool)
+    if attention_mask.shape[-1] != kv_length:
+        attention_mask = attention_mask[:, -kv_length:]
+    if bool(attention_mask.all()):
+        return None
+    return attention_mask
+
+
+def ffpa_attention_forward(
+    module: nn.Module,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attention_mask: torch.Tensor | None,
+    dropout: float | int = 0.0,
+    scaling: float | None = None,
+    softcap: float | None = None,
+    **kwargs: Any,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """HF attention-interface forward backed by ``torch.ops.ffpa_attn._fwd_cute``."""
+    # softcap must go to eager: SDPA silently drops the kwarg.
+    use_sdpa = softcap is None
+
+    def _fallback():
+        if use_sdpa:
+            sdpa = _get_sdpa()
+            if sdpa is not None:
+                return sdpa(module, query, key, value, attention_mask, dropout=dropout, scaling=scaling, **kwargs)
+        eager = _get_eager()
+        if eager is None:
+            raise RuntimeError("ffpa_attention_forward: no SDPA/eager fallback importable from transformers")
+        return eager(
+            module, query, key, value, attention_mask, dropout=dropout, scaling=scaling, softcap=softcap, **kwargs
+        )
+
+    if getattr(module, "head_dim", None) != _FFPA_HEAD_DIM:
+        return _fallback()
+    if query.dtype not in (torch.float16, torch.bfloat16):
+        _warn_once("dtype", f"need bf16/fp16, got {query.dtype}")
+        return _fallback()
+    if softcap is not None:
+        _warn_once("softcap", f"CuTeDSL backend does not support softcap (got {softcap})", target="eager")
+        return _fallback()
+    if module.training and float(dropout) > 0.0:
+        _warn_once("dropout", f"CuTeDSL backend rejects dropout={float(dropout):.4f}")
+        return _fallback()
+    # Refuse silent default to 1/sqrt(head_dim): Gemma4 full-attn uses 1/sqrt(256), not 1/sqrt(512).
+    if scaling is None:
+        _warn_once("scaling", "module.scaling is None — refusing ffpa default scale")
+        return _fallback()
+    if not _ffpa_low_level_ready():
+        _warn_once("ffpa_unavailable", "ffpa_attn or torch.ops.ffpa_attn._fwd_cute not importable")
+        return _fallback()
+
+    if attention_mask is not None:
+        if isinstance(attention_mask, torch.Tensor) and attention_mask.dim() == 4:
+            return _fallback()
+        if not (
+            isinstance(attention_mask, torch.Tensor)
+            and attention_mask.dim() == 2
+            and attention_mask.dtype == torch.bool
+        ):
+            _warn_once(
+                "unsupported_mask",
+                f"ffpa expects 2D bool pad mask or 4D additive float; got "
+                f"shape={tuple(attention_mask.shape) if isinstance(attention_mask, torch.Tensor) else type(attention_mask).__name__} "
+                f"dtype={getattr(attention_mask, 'dtype', None)}",
+            )
+            return _fallback()
+        from transformers.modeling_flash_attention_utils import _pad_input, _unpad_input, _upad_input
+
+        B, _, S, _ = query.shape
+        q_pack, k_pack, v_pack, indices_q, (cu_q, cu_k), (max_q, max_k) = _upad_input(
+            query.transpose(1, 2), key.transpose(1, 2), value.transpose(1, 2), attention_mask, S, _unpad_input
+        )
+        out_pack, _ = torch.ops.ffpa_attn._varlen_fwd_cute(
+            q_pack.contiguous(),
+            k_pack.contiguous(),
+            v_pack.contiguous(),
+            cu_q,
+            cu_k,
+            int(max_q),
+            int(max_k),
+            float(scaling),
+            True,
+            _VARLEN_WIN_NONE,
+            _VARLEN_WIN_NONE,
+            0.0,
+            False,
+        )
+        return _pad_input(out_pack, indices_q, B, S), None
+
+    ffpa_fn, backend = _get_ffpa_high_level()
+    if ffpa_fn is None:
+        _warn_once("ffpa_attn_func_unavailable", "ffpa_attn.ffpa_attn_func not importable")
+        return _fallback()
+    # ffpa returns [B, H_q, N_q, D]; HF caller expects [B, S, H_q, D].
+    out_bhnd = ffpa_fn(
+        query,
+        key,
+        value,
+        attn_mask=None,
+        dropout_p=0.0,
+        is_causal=True,
+        scale=float(scaling),
+        enable_gqa=True,
+        backend=backend,
+    )
+    return out_bhnd.transpose(1, 2).contiguous(), None
+
+
+def register_ffpa_attention() -> bool:
+    """Register ``"ffpa"`` in HF attention/mask registries. Idempotent."""
+    global _REGISTERED
+    if _REGISTERED:
+        return False
+    try:
+        from transformers.masking_utils import ALL_MASK_ATTENTION_FUNCTIONS
+        from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+    except Exception as exc:
+        logger.debug("transformers not importable: %s", exc)
+        return False
+    try:
+        ALL_ATTENTION_FUNCTIONS.register("ffpa", ffpa_attention_forward)
+        ALL_MASK_ATTENTION_FUNCTIONS.register("ffpa", ffpa_mask)
+    except Exception as exc:
+        logger.warning("failed to register 'ffpa': %s", exc)
+        return False
+    _REGISTERED = True
+    logger.info("registered ALL_ATTENTION_FUNCTIONS['ffpa'] + ALL_MASK_ATTENTION_FUNCTIONS['ffpa']")
+    return True
+
+
+__all__ = [
+    "ffpa_attention_forward",
+    "ffpa_mask",
+    "ffpa_selective_checkpoint_policy",
+    "register_ffpa_attention",
+]

--- a/nemo_automodel/components/distributed/parallelizer.py
+++ b/nemo_automodel/components/distributed/parallelizer.py
@@ -112,6 +112,17 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
+def _detect_ffpa_impl(model) -> bool:
+    """Return True iff ``model`` (or its ``text_config``) sets ``_attn_implementation="ffpa"``."""
+    cfg = getattr(model, "config", None)
+    if cfg is None:
+        return False
+    for sub in (cfg, getattr(cfg, "text_config", None)):
+        if sub is not None and getattr(sub, "_attn_implementation", None) == "ffpa":
+            return True
+    return False
+
+
 class ParallelizationStrategy(ABC):
     """Abstract base class for model parallelization strategies."""
 
@@ -234,7 +245,27 @@ class DefaultParallelizationStrategy(ParallelizationStrategy):
                     except Exception:
                         pass
 
-            if enable_compile:
+            if _detect_ffpa_impl(model):
+                # Selective AC: mark FFPA fwd ops MUST_SAVE so CuTeDSL kernels aren't replayed in backward.
+                from functools import partial
+
+                from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
+                    apply_activation_checkpointing,
+                )
+
+                from nemo_automodel._transformers.ffpa_attention import ffpa_selective_checkpoint_policy
+
+                layer_classes = tuple({type(layer) for layer in layers})
+                apply_activation_checkpointing(
+                    model,
+                    checkpoint_wrapper_fn=partial(
+                        checkpoint_wrapper,
+                        checkpoint_impl=CheckpointImpl.NO_REENTRANT,
+                        context_fn=ffpa_selective_checkpoint_policy(),
+                    ),
+                    check_fn=lambda submodule: isinstance(submodule, layer_classes),
+                )
+            elif enable_compile:
                 # NO_REENTRANT is required for compile: REENTRANT's first forward runs under
                 # no_grad, causing AOT autograd to trace a forward-only graph that drops LoRA
                 # (and other trainable) weight gradients.  Wrapping must happen BEFORE FSDP2


### PR DESCRIPTION
# What does this PR do ?

Introduces `attn_implementation="ffpa"` for the Gemma4 family: full-attention layers with `head_dim=512` are routed to the
[ffpa-attn](https://github.com/xlite-dev/ffpa-attn) CuTeDSL kernel (both dense and varlen, fwd + bwd). All other layers automatically fall back to the SDPA flash backend.

# Changelog

### 1. `_transformers/ffpa_attention.py` (New Module)
Core implementation for the FFPA attention interface:

* **`ffpa_attention_forward`**: Implements the HF attention interface.
  * The dense path dispatches to `torch.ops.ffpa_attn._fwd_cute`.
  * When a 2D bool padding mask is supplied, it routes through `_varlen_fwd_cute`, reusing transformers' `_upad_input` / `_pad_input` to share the flash-varlen protocol.
* **`ffpa_mask`**: Registered under `ALL_MASK_ATTENTION_FUNCTIONS["ffpa"]`.
  * No padding → `None` (dense fast path).
  * With padding → 2D bool (varlen path).
  * Sliding / prefix-LM and other non-pure-causal patterns → 4D additive float (drops into the fallback branch).
  * Vision / audio sub-encoders → `None` (ensures the shared registry is not polluted).
* **Fallback Priority**:
  1. **SDPA (Default)**: O(L) memory, dispatches to the flash backend on H100 / H200 / B200. *Note: This is critical for Gemma4-31B as 50 of its 60 layers are sliding (`head_dim=256`) and permanently land in fallback; materializing `(B, H, L, L)` scores there is not affordable.*
  2. **Eager**: Triggered only when `softcap is not None`. Since SDPA lacks a `softcap` entry point and silently swallows the value via `**kwargs`, Gemma2 / 3 softcap layers must use eager for numerical correctness.
  3. **Eager (Safety Net)**: Degrades to eager when SDPA is not importable.
  * *Trigger Conditions:* `head_dim ≠ 512`, `fp32`, `softcap`, `training and dropout > 0`, `scaling is None`, 4D additive mask, or any mask that is neither 2D bool nor 4D.
* **`ffpa_selective_checkpoint_policy()`**: Returns a `context_fn` marking `_fwd_cute` / `_varlen_fwd_cute` as `MUST_SAVE`. This prevents the non-reentrant CuTeDSL kernel from being replayed during the backward pass of `NO_REENTRANT` activation checkpointing (as a replay would not recover the saved tensors).
* **`register_ffpa_attention()`**: Idempotently injects `"ffpa"` into both HF global registries.

### 2. `_transformers/auto_model.py`
Updates to model building pipelines:

* Modified `_build_model` to include an `attn_implementation == "ffpa"` branch placed **before** `_apply_preload_overrides`. 
  * It hard-raises a `ValueError` for `cp_size > 1` or `has_packed_sequence` (preventing `_apply_preload_overrides` from silently rewriting them to `sdpa` / `flash_attention_2` and hiding issues until mid-training).
  * Calls `register_ffpa_attention()`.
* `_NeMoAutoModelForRetrievalBase.from_pretrained` now picks up the same registration hook at its entry point, ensuring BiEncoder / CrossEncoder share the same path.

### 3. `components/distributed/parallelizer.py`
Adjustments for distributed training and checkpointing:

* **`_detect_ffpa_impl(model)`**: Added checks for both `config._attn_implementation` and `text_config._attn_implementation` to ensure VLM top-level configs do not miss the FFPA signal.
* **`DefaultParallelizationStrategy`**: Added an FFPA-specific AC branch where every transformer layer is wrapped with `checkpoint_wrapper(NO_REENTRANT, context_fn=ffpa_selective_checkpoint_policy())`.

### 4. `examples/vlm_finetune/gemma4/gemma4_31b.yaml`
* Exposes a minimal `attn_implementation: ffpa` enablement example.
* Includes inline notes regarding memory footprint and topology options specifically for 8×H200 / `L=8192`.

# Before your PR is "Ready for review"

**Pre checks**:

- [✔] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ✔] Did you write any new necessary tests?
- [ ✔] Did you add or update any necessary documentation?


# Test Results

## 1. Unit Tests (`test_ffpa_attention.py`)
Passed all **11 test cases** successfully:

* **Fallback Matrix**: Includes 8 specialized routing test cases:
  * **6 × *routes-to-sdpa*** cases: Validates fallback triggers (`head_dim ≠ 512`, `fp32`, 4D mask, `training and dropout > 0`, `scaling = None`, or when the `ffpa` kernel is unavailable).
  * **1 × *routes-to-eager*** case: Verified that `softcap` strictly forces the eager path, preventing SDPA from silently swallowing the keyword argument.
  * **1 × *degrades-to-eager*** case: Graceful degradation safety net when SDPA import fails.
* **Warning Deduplication**: Confirmed the specific fallback reason is injected into `_FALLBACK_WARNED` exactly once across repeated calls to prevent spamming training logs.
* **CuTeDSL Dense Dispatch**: Verified it correctly receives the HF shape `[B, H, S, D]` and returns `[B, S, H, D]` via `ffpa_attn_func`. Assertions on `is_causal=True`, `enable_gqa=True`, and `scale` pass-through successfully match the kernel contract.
* **Idempotent Registration**: `register_ffpa_attention()` runs idempotently and correctly populates `ALL_ATTENTION_FUNCTIONS["ffpa"]`.

---

## 2. Kernel Micro-Benchmark (Upstream `ffpa-attn` Repo)
* **Environment**: H200 GPU
* **Workload**: Gemma4-31B full-attention shape (`B=1`, `H=32`, `D=512`)
* **Baseline**: SDPA

| Sequence Length ($N$) | Forward Speedup | Backward Speedup |
| :--- | :--- | :--- |
| 8192 | **≈ 3×** | **≈ 6×** |
| 16384 | **≈ 3×** | **≈ 6×** |


<img width="4800" height="3600" alt="image" src="https://github.com/user-attachments/assets/bafc5ab3-4867-4606-9348-6d038e82112d" />


<img width="4800" height="3600" alt="image" src="https://github.com/user-attachments/assets/4c121b5e-6522-4b2b-8f0c-27e731369a5c" />



> **Accuracy Note:** Numerical outputs are fully aligned with SDPA within standard `bf16` precision tolerance.

---

## 3. End-to-End (E2E) Training (`gemma4_31b_ffpa.yaml`)

> **TL;DR:** At the exact same memory footprint, **Throughput (TPS) improves by 40–50%** while the loss curve perfectly overlaps the baseline.

#### Environment & Hyperparameters
* **Hardware**: 1 Node × 8×H200
* **Strategy**: FSDP2 + Activation Checkpointing (AC)
* **Config**: `DP=8`, `GBS=8`, `local_bs=1`, `grad-accum=4`, `L=8192`

#### Core Metrics Comparison
| Backend | Peak Memory | Tokens/s/GPU | Loss |
| :--- | :--- | :--- | :--- |
| `sdpa` (Baseline) | ~65 GiB | 1.00× | Reference |
| `ffpa` (Candidate) | ~65 GiB | **1.4–1.5×** | Overlaps `sdpa` within `bf16` noise |


<img width="1182" height="1026" alt="image" src="https://github.com/user-attachments/assets/67c0c7c1-7c6f-4b53-8bb3-9594f3db15cf" />



#### Execution Command
```bash
torchrun --nproc-per-node=8 examples/vlm_finetune/finetune.py \
    -c examples/vlm_finetune/gemma4/gemma4_31b_ffpa.yaml \
    model.attn_implementation=sdpa     # Run baseline
#   model.attn_implementation=ffpa     # Run candidate
