### PR TITLE
fix(moe): include MTP modules in FSDP sync traversal

### DIFF
--- a/nemo_automodel/components/moe/fsdp_mixin.py
+++ b/nemo_automodel/components/moe/fsdp_mixin.py
@@ -54,6 +54,22 @@ def _iter_fsdp_modules(module: torch.nn.Module) -> Iterator[FSDPModule]:
                     if isinstance(experts, FSDPModule):
                         yield experts
 
+    # Check MTP blocks. They are registered on the outer model rather than the
+    # text backbone but participate in the same backward pass and FSDP state
+    # transitions.
+    mtp = getattr(module, "mtp", None)
+    mtp_layers = getattr(mtp, "layers", None)
+    if mtp_layers is not None:
+        for _, block in mtp_layers.named_children():
+            if isinstance(block, FSDPModule):
+                yield block
+            for attr in ("mlp", "moe"):
+                mod = getattr(block, attr, None)
+                if mod is not None and hasattr(mod, "experts"):
+                    experts = mod.experts
+                    if isinstance(experts, FSDPModule):
+                        yield experts
+
 
 def _configure_fsdp_module(
     fsdp_module: FSDPModule,

--- a/tests/unit_tests/moe/test_fsdp_mixin.py
+++ b/tests/unit_tests/moe/test_fsdp_mixin.py
@@ -205,6 +205,42 @@ class TestIterFSDPModules:
         assert moe_model.audio_tower in modules
         assert moe_model.visual in modules
 
+    @patch('nemo_automodel.components.moe.fsdp_mixin.isinstance')
+    def test_iterates_outer_mtp_blocks_and_experts(self, mock_isinstance):
+        def isinstance_side_effect(obj, cls):
+            if cls.__name__ == 'FSDPModule':
+                return isinstance(obj, MockFSDPModule)
+            return isinstance(obj, cls)
+
+        mock_isinstance.side_effect = isinstance_side_effect
+
+        model = MockFSDPModule()
+        moe_model = MockMoEModel(MockBackend(), model)
+
+        mtp_block = MockFSDPModule()
+        mtp_block.mlp = Mock()
+        mtp_block.mlp.experts = MockFSDPModule()
+
+        mtp_moe_block = Mock()
+        mtp_moe_block.moe = Mock()
+        mtp_moe_block.moe.experts = MockFSDPModule()
+
+        moe_model.mtp = Mock()
+        moe_model.mtp.layers = Mock()
+        moe_model.mtp.layers.named_children = Mock(
+            return_value=[
+                ("mtp_layer_0", mtp_block),
+                ("mtp_layer_1", mtp_moe_block),
+            ]
+        )
+
+        modules = list(_iter_fsdp_modules(moe_model))
+
+        assert model in modules
+        assert mtp_block in modules
+        assert mtp_block.mlp.experts in modules
+        assert mtp_moe_block.moe.experts in modules
+
 
 class TestPrepareForGradAccumulation:
     """Test prepare_for_grad_accumulation method."""


### PR DESCRIPTION
## Summary
- include outer `mtp.layers` FSDP modules in MoE FSDP sync traversal
- include MTP block experts under both `mlp.experts` and `moe.experts`
- add focused unit coverage for outer MTP traversal

## Tests
- `pytest -q tests/unit_tests/moe/test_fsdp_mixin.py`