### PR TITLE
feat(deepseek): DeepSeek-V3 671B no-PP GB200 + fullgraph compile_attn

### DIFF
--- a/examples/llm_benchmark/deepseek/deepseek_v3_sdpa_compile_gb200.yaml
+++ b/examples/llm_benchmark/deepseek/deepseek_v3_sdpa_compile_gb200.yaml
@@ -81,7 +81,7 @@ model:
     linear: torch     # non-TE: TE Linear is @torch.compiler.disable'd → breaks MLA fullgraph
     rms_norm: torch   # non-TE: TE RMSNorm is also compiler-disabled → breaks MLA fullgraph
     rope_fusion: false  # fused RoPE is a TE/compiler-disabled custom op → breaks fullgraph
-    compile_mla: true
+    compile_attn: true
     experts: te  # WAVE 11 winner: TE GroupedLinear bf16 (no fp8) = 28.13% MFU vs gmm 26.48% / torch_mm 24.95%
     dispatcher: hybridep  # GB200: deepep fails EP-buffer init ('invalid resource handle')
     fake_balanced_gate: true

--- a/examples/llm_benchmark/deepseek/deepseek_v3_sdpa_compile_gb200.yaml
+++ b/examples/llm_benchmark/deepseek/deepseek_v3_sdpa_compile_gb200.yaml
@@ -1,0 +1,117 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Benchmarking config for DeepSeek-V3 (671B) attn=sdpa + torch.compile(MLA), GB200 (BF16), NO PP — MLA-MFU experiment.
+#
+# GB200 deltas vs the generic deepseek_v3_te_deepep.yaml:
+#   - peak_tflops: 989 -> 2500  (GB200 BF16 dense peak; generic recipe uses H100 989)
+#   - num_nodes/ci.nodes: 32 -> 16  (16 nodes x 4 GB200 = 64 GPUs)
+#   - pp_size: 4 -> 1  (NO pipeline parallelism) — dropped the pipeline + moe blocks
+#   - ep_size: 64 (shard the 256 routed experts across all 64 GPUs)
+#   - dispatcher: deepep -> hybridep  (GB200: deepep fails EP-buffer init)
+#   - local_batch_size: 8 -> 2, GBS 128 (GA = 128/(64*2) = 1) — 671B no-PP is
+#     memory-tight: ~72GB fixed + ~27.6GB/lbs (lbs1=99.5GB fit, lbs4 OOM'd at 16N),
+#     so lbs=2 (~127GB) is the chosen matched-pair operating point (lbs3~155GB max-fit,
+#     lbs4+ OOMs).
+#
+# Parallelism: ep_size=64 (==world=64), tp=pp=cp=1. seq_len=4096, AC on.
+# DeepSeek-V3 671B fits no-PP on 16 nodes (64 GB200) — PP not needed (lbs1 peak 99.5GB).
+
+recipe: BenchmarkingRecipeForNextTokenPrediction
+
+seed: 1234
+
+benchmark:
+  warmup_steps: 10
+  peak_tflops: 2500  # GB200 BF16 dense peak TFLOPs
+  nsys_start: -1
+  nsys_end: -1
+  nsys_ranks: []
+  num_nodes: 16
+
+step_scheduler:
+  gc_every_steps: 10
+  global_batch_size: 128  # GA = 128/(64*2) = 1 (GA=1 is the no-PP memory ceiling; GA>1 OOMs)
+  local_batch_size: 2
+  ckpt_every_steps: 1000
+  val_every_steps: 1000
+  num_epochs: 1
+  max_steps: 30
+
+distributed:
+  strategy: fsdp2
+  tp_size: 1
+  cp_size: 1
+  pp_size: 1
+  ep_size: 64
+
+  sequence_parallel: false
+  activation_checkpointing: true
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 10
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_config
+  config:
+    _target_: transformers.AutoConfig.from_pretrained
+    pretrained_model_name_or_path: deepseek-ai/DeepSeek-V3
+  trust_remote_code: true
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: sdpa
+    linear: te
+    rms_norm: te
+    rope_fusion: true
+    compile_mla: true
+    experts: gmm
+    dispatcher: hybridep  # GB200: deepep fails EP-buffer init ('invalid resource handle')
+    fake_balanced_gate: true
+    enable_hf_state_dict_adapter: false
+    enable_fsdp_optimizations: true
+
+checkpoint:
+  enabled: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+  fp32_upcast: false
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.mock_iterable_dataset.MockIterableDataset
+  seq_len: 4096
+  num_samples: 100000
+
+dataloader:
+  batch_size: null  # Dataset already yields batches
+  _target_: torch.utils.data.DataLoader
+  num_workers: 0
+
+optimizer:
+  _target_: torch.optim.Adam
+  betas:
+  - 0.9
+  - 0.999
+  eps: 1e-8
+  lr: 0.0001
+  weight_decay: 0
+
+
+ci:
+  time: "04:00:00"
+  nodes: 16
+  ep_size: 64
+  env_vars:
+    RDZV_TIMEOUT: "900"

--- a/examples/llm_benchmark/deepseek/deepseek_v3_sdpa_compile_gb200.yaml
+++ b/examples/llm_benchmark/deepseek/deepseek_v3_sdpa_compile_gb200.yaml
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Benchmarking config for DeepSeek-V3 (671B) attn=sdpa + torch.compile(MLA), GB200 (BF16), NO PP — MLA-MFU experiment.
+# SHIPPING no-PP DeepSeek-V3 (671B) bf16 GB200 config: attn=sdpa + torch.compile(MLA) + experts=te.
+# Best bf16 operating point found: 2.910 s/iter, 28.13% MFU@2500, 107.44 GB (up from the
+# attn:te/gmm baseline 3.437 s / 23.82%). Two wins stacked: (1) fullgraph-compiled SDPA MLA
+# (non-TE linear/norm + non-fused rope) lifted 23.82% -> 26.48%; (2) experts=te TE GroupedLinear
+# (bf16, no fp8) won the expert-backend bake-off (te 28.13% > gmm 26.48% > torch_mm 24.95%),
+# lifting 26.48% -> 28.13%. optimizer.foreach=false handles ep64==world64 (TE experts plain-tensor
+# vs DTensor). NO te_fp8 block => true bf16. See sibling _torchmm_/_te_ variants for the bake-off.
 #
 # GB200 deltas vs the generic deepseek_v3_te_deepep.yaml:
 #   - peak_tflops: 989 -> 2500  (GB200 BF16 dense peak; generic recipe uses H100 989)
@@ -76,7 +82,7 @@ model:
     rms_norm: torch   # non-TE: TE RMSNorm is also compiler-disabled → breaks MLA fullgraph
     rope_fusion: false  # fused RoPE is a TE/compiler-disabled custom op → breaks fullgraph
     compile_mla: true
-    experts: gmm
+    experts: te  # WAVE 11 winner: TE GroupedLinear bf16 (no fp8) = 28.13% MFU vs gmm 26.48% / torch_mm 24.95%
     dispatcher: hybridep  # GB200: deepep fails EP-buffer init ('invalid resource handle')
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: false
@@ -107,6 +113,7 @@ optimizer:
   eps: 1e-8
   lr: 0.0001
   weight_decay: 0
+  foreach: false  # ep64==world64: TE experts plain-tensor vs DTensor; per-param Adam avoids _foreach_lerp_ mix
 
 
 ci:

--- a/examples/llm_benchmark/deepseek/deepseek_v3_sdpa_compile_gb200.yaml
+++ b/examples/llm_benchmark/deepseek/deepseek_v3_sdpa_compile_gb200.yaml
@@ -72,9 +72,9 @@ model:
   backend:
     _target_: nemo_automodel.components.models.common.BackendConfig
     attn: sdpa
-    linear: te
-    rms_norm: te
-    rope_fusion: true
+    linear: torch     # non-TE: TE Linear is @torch.compiler.disable'd → breaks MLA fullgraph
+    rms_norm: torch   # non-TE: TE RMSNorm is also compiler-disabled → breaks MLA fullgraph
+    rope_fusion: false  # fused RoPE is a TE/compiler-disabled custom op → breaks fullgraph
     compile_mla: true
     experts: gmm
     dispatcher: hybridep  # GB200: deepep fails EP-buffer init ('invalid resource handle')

--- a/examples/llm_benchmark/deepseek/deepseek_v3_sdpa_compile_mxfp8_gb200.yaml
+++ b/examples/llm_benchmark/deepseek/deepseek_v3_sdpa_compile_mxfp8_gb200.yaml
@@ -1,0 +1,123 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DeepSeek-V3 (671B) MXFP8 GB200 no-PP config: attn=sdpa + torch.compile(MLA) + experts=te + te_fp8.recipe=mxfp8.
+# The compiled-MLA op point with MXFP8 expert GEMMs (TE MXFP8BlockScaling). MFU vs FP8 dense peak 5000.
+# Same op point as the bf16 shipping config (deepseek_v3_sdpa_compile_gb200.yaml = 28.13% MFU@2500);
+# this is its MXFP8 partner. mxfp8 adds ~20GB TE fp8 scratch over bf16's 107GB => ~127GB, fits <192GB.
+#
+# GB200 deltas vs the generic deepseek_v3_te_deepep.yaml:
+#   - peak_tflops: 989 -> 2500  (GB200 BF16 dense peak; generic recipe uses H100 989)
+#   - num_nodes/ci.nodes: 32 -> 16  (16 nodes x 4 GB200 = 64 GPUs)
+#   - pp_size: 4 -> 1  (NO pipeline parallelism) — dropped the pipeline + moe blocks
+#   - ep_size: 64 (shard the 256 routed experts across all 64 GPUs)
+#   - dispatcher: deepep -> hybridep  (GB200: deepep fails EP-buffer init)
+#   - local_batch_size: 8 -> 2, GBS 128 (GA = 128/(64*2) = 1) — 671B no-PP is
+#     memory-tight: ~72GB fixed + ~27.6GB/lbs (lbs1=99.5GB fit, lbs4 OOM'd at 16N),
+#     so lbs=2 (~127GB) is the chosen matched-pair operating point (lbs3~155GB max-fit,
+#     lbs4+ OOMs).
+#
+# Parallelism: ep_size=64 (==world=64), tp=pp=cp=1. seq_len=4096, AC on.
+# DeepSeek-V3 671B fits no-PP on 16 nodes (64 GB200) — PP not needed (lbs1 peak 99.5GB).
+
+recipe: BenchmarkingRecipeForNextTokenPrediction
+
+seed: 1234
+
+benchmark:
+  warmup_steps: 10
+  peak_tflops: 5000  # GB200 FP8/MXFP8 dense peak TFLOPs (2x bf16)
+  nsys_start: -1
+  nsys_end: -1
+  nsys_ranks: []
+  num_nodes: 16
+
+step_scheduler:
+  gc_every_steps: 10
+  global_batch_size: 128  # GA = 128/(64*2) = 1 (GA=1 is the no-PP memory ceiling; GA>1 OOMs)
+  local_batch_size: 2
+  ckpt_every_steps: 1000
+  val_every_steps: 1000
+  num_epochs: 1
+  max_steps: 30
+
+distributed:
+  strategy: fsdp2
+  tp_size: 1
+  cp_size: 1
+  pp_size: 1
+  ep_size: 64
+
+  sequence_parallel: false
+  activation_checkpointing: true
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 10
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_config
+  config:
+    _target_: transformers.AutoConfig.from_pretrained
+    pretrained_model_name_or_path: deepseek-ai/DeepSeek-V3
+  trust_remote_code: true
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: sdpa
+    linear: torch     # non-TE: TE Linear is @torch.compiler.disable'd → breaks MLA fullgraph
+    rms_norm: torch   # non-TE: TE RMSNorm is also compiler-disabled → breaks MLA fullgraph
+    rope_fusion: false  # fused RoPE is a TE/compiler-disabled custom op → breaks fullgraph
+    compile_mla: true
+    experts: te  # TE GroupedLinear (MXFP8 via te_fp8.recipe below)
+    dispatcher: hybridep  # GB200: deepep fails EP-buffer init ('invalid resource handle')
+    fake_balanced_gate: true
+    enable_hf_state_dict_adapter: false
+    enable_fsdp_optimizations: true
+    te_fp8:
+      recipe: mxfp8  # TE MXFP8BlockScaling on the expert GEMMs (e4m3 + e8m0 block scale)
+
+checkpoint:
+  enabled: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+  fp32_upcast: false
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.mock_iterable_dataset.MockIterableDataset
+  seq_len: 4096
+  num_samples: 100000
+
+dataloader:
+  batch_size: null  # Dataset already yields batches
+  _target_: torch.utils.data.DataLoader
+  num_workers: 0
+
+optimizer:
+  _target_: torch.optim.Adam
+  betas:
+  - 0.9
+  - 0.999
+  eps: 1e-8
+  lr: 0.0001
+  weight_decay: 0
+  foreach: false  # ep64==world64: TE experts plain-tensor vs DTensor; per-param Adam avoids _foreach_lerp_ mix
+
+
+ci:
+  time: "04:00:00"
+  nodes: 16
+  ep_size: 64
+  env_vars:
+    RDZV_TIMEOUT: "900"

--- a/examples/llm_benchmark/deepseek/deepseek_v3_sdpa_compile_mxfp8_gb200.yaml
+++ b/examples/llm_benchmark/deepseek/deepseek_v3_sdpa_compile_mxfp8_gb200.yaml
@@ -78,7 +78,7 @@ model:
     linear: torch     # non-TE: TE Linear is @torch.compiler.disable'd → breaks MLA fullgraph
     rms_norm: torch   # non-TE: TE RMSNorm is also compiler-disabled → breaks MLA fullgraph
     rope_fusion: false  # fused RoPE is a TE/compiler-disabled custom op → breaks fullgraph
-    compile_mla: true
+    compile_attn: true
     experts: te  # TE GroupedLinear (MXFP8 via te_fp8.recipe below)
     dispatcher: hybridep  # GB200: deepep fails EP-buffer init ('invalid resource handle')
     fake_balanced_gate: true

--- a/examples/llm_benchmark/deepseek/deepseek_v3_sdpa_compile_te_gb200.yaml
+++ b/examples/llm_benchmark/deepseek/deepseek_v3_sdpa_compile_te_gb200.yaml
@@ -16,7 +16,7 @@
 #
 # Single-variable delta vs deepseek_v3_sdpa_compile_gb200.yaml: experts gmm -> te.
 # No te_fp8 block => TE GroupedLinear runs in BF16 (not fp8). Same compiled-MLA op point
-# (attn:sdpa/compile_mla/linear+norm=torch/rope_fusion=false, lbs2/GBS128/GA1/16N/ep64/AC).
+# (attn:sdpa/compile_attn/linear+norm=torch/rope_fusion=false, lbs2/GBS128/GA1/16N/ep64/AC).
 # ep_size=64 == world (16N x 4) => experts:te params NOT FSDP-wrapped (plain tensors) while the
 # rest are DTensor; optimizer.foreach=false avoids aten._foreach_lerp_ batching plain-Tensor +
 # DTensor (same fix as TE-mxfp8 ep==world). Baselines: gmm 26.48% MFU@2500 / 3.091s; torch_mm 24.95% / 3.281s.
@@ -82,7 +82,7 @@ model:
     linear: torch     # non-TE: TE Linear is @torch.compiler.disable'd → breaks MLA fullgraph
     rms_norm: torch   # non-TE: TE RMSNorm is also compiler-disabled → breaks MLA fullgraph
     rope_fusion: false  # fused RoPE is a TE/compiler-disabled custom op → breaks fullgraph
-    compile_mla: true
+    compile_attn: true
     experts: te  # WAVE 11: TE GroupedLinear bf16 (no fp8); vs gmm 26.48% / torch_mm 24.95%
     dispatcher: hybridep  # GB200: deepep fails EP-buffer init ('invalid resource handle')
     fake_balanced_gate: true

--- a/examples/llm_benchmark/deepseek/deepseek_v3_sdpa_compile_te_gb200.yaml
+++ b/examples/llm_benchmark/deepseek/deepseek_v3_sdpa_compile_te_gb200.yaml
@@ -1,0 +1,125 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Benchmarking config for DeepSeek-V3 (671B) attn=sdpa + torch.compile(MLA) + experts=te (TE GroupedLinear, NO fp8), GB200 (BF16), NO PP — WAVE 11 bake-off.
+#
+# Single-variable delta vs deepseek_v3_sdpa_compile_gb200.yaml: experts gmm -> te.
+# No te_fp8 block => TE GroupedLinear runs in BF16 (not fp8). Same compiled-MLA op point
+# (attn:sdpa/compile_mla/linear+norm=torch/rope_fusion=false, lbs2/GBS128/GA1/16N/ep64/AC).
+# ep_size=64 == world (16N x 4) => experts:te params NOT FSDP-wrapped (plain tensors) while the
+# rest are DTensor; optimizer.foreach=false avoids aten._foreach_lerp_ batching plain-Tensor +
+# DTensor (same fix as TE-mxfp8 ep==world). Baselines: gmm 26.48% MFU@2500 / 3.091s; torch_mm 24.95% / 3.281s.
+#
+# GB200 deltas vs the generic deepseek_v3_te_deepep.yaml:
+#   - peak_tflops: 989 -> 2500  (GB200 BF16 dense peak; generic recipe uses H100 989)
+#   - num_nodes/ci.nodes: 32 -> 16  (16 nodes x 4 GB200 = 64 GPUs)
+#   - pp_size: 4 -> 1  (NO pipeline parallelism) — dropped the pipeline + moe blocks
+#   - ep_size: 64 (shard the 256 routed experts across all 64 GPUs)
+#   - dispatcher: deepep -> hybridep  (GB200: deepep fails EP-buffer init)
+#   - local_batch_size: 8 -> 2, GBS 128 (GA = 128/(64*2) = 1) — 671B no-PP is
+#     memory-tight: ~72GB fixed + ~27.6GB/lbs (lbs1=99.5GB fit, lbs4 OOM'd at 16N),
+#     so lbs=2 (~127GB) is the chosen matched-pair operating point (lbs3~155GB max-fit,
+#     lbs4+ OOMs).
+#
+# Parallelism: ep_size=64 (==world=64), tp=pp=cp=1. seq_len=4096, AC on.
+# DeepSeek-V3 671B fits no-PP on 16 nodes (64 GB200) — PP not needed (lbs1 peak 99.5GB).
+
+recipe: BenchmarkingRecipeForNextTokenPrediction
+
+seed: 1234
+
+benchmark:
+  warmup_steps: 10
+  peak_tflops: 2500  # GB200 BF16 dense peak TFLOPs
+  nsys_start: -1
+  nsys_end: -1
+  nsys_ranks: []
+  num_nodes: 16
+
+step_scheduler:
+  gc_every_steps: 10
+  global_batch_size: 128  # GA = 128/(64*2) = 1 (GA=1 is the no-PP memory ceiling; GA>1 OOMs)
+  local_batch_size: 2
+  ckpt_every_steps: 1000
+  val_every_steps: 1000
+  num_epochs: 1
+  max_steps: 30
+
+distributed:
+  strategy: fsdp2
+  tp_size: 1
+  cp_size: 1
+  pp_size: 1
+  ep_size: 64
+
+  sequence_parallel: false
+  activation_checkpointing: true
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 10
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_config
+  config:
+    _target_: transformers.AutoConfig.from_pretrained
+    pretrained_model_name_or_path: deepseek-ai/DeepSeek-V3
+  trust_remote_code: true
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: sdpa
+    linear: torch     # non-TE: TE Linear is @torch.compiler.disable'd → breaks MLA fullgraph
+    rms_norm: torch   # non-TE: TE RMSNorm is also compiler-disabled → breaks MLA fullgraph
+    rope_fusion: false  # fused RoPE is a TE/compiler-disabled custom op → breaks fullgraph
+    compile_mla: true
+    experts: te  # WAVE 11: TE GroupedLinear bf16 (no fp8); vs gmm 26.48% / torch_mm 24.95%
+    dispatcher: hybridep  # GB200: deepep fails EP-buffer init ('invalid resource handle')
+    fake_balanced_gate: true
+    enable_hf_state_dict_adapter: false
+    enable_fsdp_optimizations: true
+
+checkpoint:
+  enabled: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+  fp32_upcast: false
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.mock_iterable_dataset.MockIterableDataset
+  seq_len: 4096
+  num_samples: 100000
+
+dataloader:
+  batch_size: null  # Dataset already yields batches
+  _target_: torch.utils.data.DataLoader
+  num_workers: 0
+
+optimizer:
+  _target_: torch.optim.Adam
+  betas:
+  - 0.9
+  - 0.999
+  eps: 1e-8
+  lr: 0.0001
+  weight_decay: 0
+  foreach: false  # ep==world(64): TE experts plain-tensor vs DTensor; per-param Adam avoids _foreach_lerp_ mix
+
+
+ci:
+  time: "04:00:00"
+  nodes: 16
+  ep_size: 64
+  env_vars:
+    RDZV_TIMEOUT: "900"

--- a/examples/llm_benchmark/deepseek/deepseek_v3_sdpa_compile_torchmm_gb200.yaml
+++ b/examples/llm_benchmark/deepseek/deepseek_v3_sdpa_compile_torchmm_gb200.yaml
@@ -81,7 +81,7 @@ model:
     linear: torch     # non-TE: TE Linear is @torch.compiler.disable'd → breaks MLA fullgraph
     rms_norm: torch   # non-TE: TE RMSNorm is also compiler-disabled → breaks MLA fullgraph
     rope_fusion: false  # fused RoPE is a TE/compiler-disabled custom op → breaks fullgraph
-    compile_mla: true
+    compile_attn: true
     experts: torch_mm  # torch._grouped_mm bf16 (vs gmm); single-variable swap, hybridep dispatch unchanged
     dispatcher: hybridep  # GB200: deepep fails EP-buffer init ('invalid resource handle')
     fake_balanced_gate: true

--- a/examples/llm_benchmark/deepseek/deepseek_v3_sdpa_compile_torchmm_gb200.yaml
+++ b/examples/llm_benchmark/deepseek/deepseek_v3_sdpa_compile_torchmm_gb200.yaml
@@ -1,0 +1,123 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Benchmarking config for DeepSeek-V3 (671B) attn=sdpa + torch.compile(MLA) + experts=torch_mm, GB200 (BF16), NO PP — expert-kernel MFU experiment.
+#
+# Single-variable delta vs deepseek_v3_sdpa_compile_gb200.yaml: experts gmm -> torch_mm
+# (torch._grouped_mm bf16 path instead of grouped_gemm.ops.gmm). Same hybridep
+# dispatch, same compiled SDPA MLA, same lbs2/GBS128/GA1/16N/ep64/AC. Isolates the
+# expert grouped-GEMM kernel (gmm vs torch_mm) at the compiled-MLA operating point
+# (gmm baseline = 26.48% MFU@2500 / 3.091s).
+#
+# GB200 deltas vs the generic deepseek_v3_te_deepep.yaml:
+#   - peak_tflops: 989 -> 2500  (GB200 BF16 dense peak; generic recipe uses H100 989)
+#   - num_nodes/ci.nodes: 32 -> 16  (16 nodes x 4 GB200 = 64 GPUs)
+#   - pp_size: 4 -> 1  (NO pipeline parallelism) — dropped the pipeline + moe blocks
+#   - ep_size: 64 (shard the 256 routed experts across all 64 GPUs)
+#   - dispatcher: deepep -> hybridep  (GB200: deepep fails EP-buffer init)
+#   - local_batch_size: 8 -> 2, GBS 128 (GA = 128/(64*2) = 1) — 671B no-PP is
+#     memory-tight: ~72GB fixed + ~27.6GB/lbs (lbs1=99.5GB fit, lbs4 OOM'd at 16N),
+#     so lbs=2 (~127GB) is the chosen matched-pair operating point (lbs3~155GB max-fit,
+#     lbs4+ OOMs).
+#
+# Parallelism: ep_size=64 (==world=64), tp=pp=cp=1. seq_len=4096, AC on.
+# DeepSeek-V3 671B fits no-PP on 16 nodes (64 GB200) — PP not needed (lbs1 peak 99.5GB).
+
+recipe: BenchmarkingRecipeForNextTokenPrediction
+
+seed: 1234
+
+benchmark:
+  warmup_steps: 10
+  peak_tflops: 2500  # GB200 BF16 dense peak TFLOPs
+  nsys_start: -1
+  nsys_end: -1
+  nsys_ranks: []
+  num_nodes: 16
+
+step_scheduler:
+  gc_every_steps: 10
+  global_batch_size: 128  # GA = 128/(64*2) = 1 (GA=1 is the no-PP memory ceiling; GA>1 OOMs)
+  local_batch_size: 2
+  ckpt_every_steps: 1000
+  val_every_steps: 1000
+  num_epochs: 1
+  max_steps: 30
+
+distributed:
+  strategy: fsdp2
+  tp_size: 1
+  cp_size: 1
+  pp_size: 1
+  ep_size: 64
+
+  sequence_parallel: false
+  activation_checkpointing: true
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 10
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_config
+  config:
+    _target_: transformers.AutoConfig.from_pretrained
+    pretrained_model_name_or_path: deepseek-ai/DeepSeek-V3
+  trust_remote_code: true
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: sdpa
+    linear: torch     # non-TE: TE Linear is @torch.compiler.disable'd → breaks MLA fullgraph
+    rms_norm: torch   # non-TE: TE RMSNorm is also compiler-disabled → breaks MLA fullgraph
+    rope_fusion: false  # fused RoPE is a TE/compiler-disabled custom op → breaks fullgraph
+    compile_mla: true
+    experts: torch_mm  # torch._grouped_mm bf16 (vs gmm); single-variable swap, hybridep dispatch unchanged
+    dispatcher: hybridep  # GB200: deepep fails EP-buffer init ('invalid resource handle')
+    fake_balanced_gate: true
+    enable_hf_state_dict_adapter: false
+    enable_fsdp_optimizations: true
+
+checkpoint:
+  enabled: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+  fp32_upcast: false
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.mock_iterable_dataset.MockIterableDataset
+  seq_len: 4096
+  num_samples: 100000
+
+dataloader:
+  batch_size: null  # Dataset already yields batches
+  _target_: torch.utils.data.DataLoader
+  num_workers: 0
+
+optimizer:
+  _target_: torch.optim.Adam
+  betas:
+  - 0.9
+  - 0.999
+  eps: 1e-8
+  lr: 0.0001
+  weight_decay: 0
+
+
+ci:
+  time: "04:00:00"
+  nodes: 16
+  ep_size: 64
+  env_vars:
+    RDZV_TIMEOUT: "900"

--- a/examples/llm_benchmark/deepseek/deepseek_v3_te_deepep_gb200.yaml
+++ b/examples/llm_benchmark/deepseek/deepseek_v3_te_deepep_gb200.yaml
@@ -1,0 +1,115 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Benchmarking config for DeepSeek-V3 (671B) Te Deepep, tuned for GB200 (BF16), NO PP.
+#
+# GB200 deltas vs the generic deepseek_v3_te_deepep.yaml:
+#   - peak_tflops: 989 -> 2500  (GB200 BF16 dense peak; generic recipe uses H100 989)
+#   - num_nodes/ci.nodes: 32 -> 16  (16 nodes x 4 GB200 = 64 GPUs)
+#   - pp_size: 4 -> 1  (NO pipeline parallelism) — dropped the pipeline + moe blocks
+#   - ep_size: 64 (shard the 256 routed experts across all 64 GPUs)
+#   - dispatcher: deepep -> hybridep  (GB200: deepep fails EP-buffer init)
+#   - local_batch_size: 8 -> 1, GBS 512 -> 64 (GA = 64/(64*1) = 1) — 671B no-PP is
+#     memory-tight; lbs=1 is the feasibility starting point (sweep up if it fits).
+#
+# Parallelism: ep_size=64 (==world=64), tp=pp=cp=1. seq_len=4096, AC on.
+# This config is the no-PP feasibility test: does DeepSeek-V3 671B fit on 16 nodes
+# (64 GB200) without pipeline parallelism?
+
+recipe: BenchmarkingRecipeForNextTokenPrediction
+
+seed: 1234
+
+benchmark:
+  warmup_steps: 10
+  peak_tflops: 2500  # GB200 BF16 dense peak TFLOPs
+  nsys_start: -1
+  nsys_end: -1
+  nsys_ranks: []
+  num_nodes: 16
+
+step_scheduler:
+  gc_every_steps: 10
+  global_batch_size: 64
+  local_batch_size: 1
+  ckpt_every_steps: 1000
+  val_every_steps: 1000
+  num_epochs: 1
+  max_steps: 30
+
+distributed:
+  strategy: fsdp2
+  tp_size: 1
+  cp_size: 1
+  pp_size: 1
+  ep_size: 64
+
+  sequence_parallel: false
+  activation_checkpointing: true
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 10
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_config
+  config:
+    _target_: transformers.AutoConfig.from_pretrained
+    pretrained_model_name_or_path: deepseek-ai/DeepSeek-V3
+  trust_remote_code: true
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: te
+    linear: te
+    rms_norm: te
+    rope_fusion: true
+    experts: gmm
+    dispatcher: hybridep  # GB200: deepep fails EP-buffer init ('invalid resource handle')
+    fake_balanced_gate: true
+    enable_hf_state_dict_adapter: false
+    enable_fsdp_optimizations: true
+
+checkpoint:
+  enabled: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+  fp32_upcast: false
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.mock_iterable_dataset.MockIterableDataset
+  seq_len: 4096
+  num_samples: 100000
+
+dataloader:
+  batch_size: null  # Dataset already yields batches
+  _target_: torch.utils.data.DataLoader
+  num_workers: 0
+
+optimizer:
+  _target_: torch.optim.Adam
+  betas:
+  - 0.9
+  - 0.999
+  eps: 1e-8
+  lr: 0.0001
+  weight_decay: 0
+
+
+ci:
+  time: "04:00:00"
+  nodes: 16
+  ep_size: 64
+  env_vars:
+    RDZV_TIMEOUT: "900"

--- a/examples/llm_benchmark/deepseek/deepseek_v3_te_deepep_gb200.yaml
+++ b/examples/llm_benchmark/deepseek/deepseek_v3_te_deepep_gb200.yaml
@@ -20,7 +20,7 @@
 #   - pp_size: 4 -> 1  (NO pipeline parallelism) — dropped the pipeline + moe blocks
 #   - ep_size: 64 (shard the 256 routed experts across all 64 GPUs)
 #   - dispatcher: deepep -> hybridep  (GB200: deepep fails EP-buffer init)
-#   - local_batch_size: 8 -> 2, GBS 512 (GA = 512/(64*2) = 4) — 671B no-PP is
+#   - local_batch_size: 8 -> 2, GBS 128 (GA = 128/(64*2) = 1) — 671B no-PP is
 #     memory-tight: ~72GB fixed + ~27.6GB/lbs (lbs1=99.5GB fit, lbs4 OOM'd at 16N),
 #     so lbs=2 (~127GB) is the chosen matched-pair operating point (lbs3~155GB max-fit,
 #     lbs4+ OOMs).
@@ -42,7 +42,7 @@ benchmark:
 
 step_scheduler:
   gc_every_steps: 10
-  global_batch_size: 512
+  global_batch_size: 128  # GA = 128/(64*2) = 1 (GA=1 is the no-PP memory ceiling; GA>1 OOMs)
   local_batch_size: 2
   ckpt_every_steps: 1000
   val_every_steps: 1000

--- a/examples/llm_benchmark/deepseek/deepseek_v3_te_deepep_gb200.yaml
+++ b/examples/llm_benchmark/deepseek/deepseek_v3_te_deepep_gb200.yaml
@@ -20,12 +20,13 @@
 #   - pp_size: 4 -> 1  (NO pipeline parallelism) — dropped the pipeline + moe blocks
 #   - ep_size: 64 (shard the 256 routed experts across all 64 GPUs)
 #   - dispatcher: deepep -> hybridep  (GB200: deepep fails EP-buffer init)
-#   - local_batch_size: 8 -> 1, GBS 512 -> 64 (GA = 64/(64*1) = 1) — 671B no-PP is
-#     memory-tight; lbs=1 is the feasibility starting point (sweep up if it fits).
+#   - local_batch_size: 8 -> 2, GBS 512 (GA = 512/(64*2) = 4) — 671B no-PP is
+#     memory-tight: ~72GB fixed + ~27.6GB/lbs (lbs1=99.5GB fit, lbs4 OOM'd at 16N),
+#     so lbs=2 (~127GB) is the chosen matched-pair operating point (lbs3~155GB max-fit,
+#     lbs4+ OOMs).
 #
 # Parallelism: ep_size=64 (==world=64), tp=pp=cp=1. seq_len=4096, AC on.
-# This config is the no-PP feasibility test: does DeepSeek-V3 671B fit on 16 nodes
-# (64 GB200) without pipeline parallelism?
+# DeepSeek-V3 671B fits no-PP on 16 nodes (64 GB200) — PP not needed (lbs1 peak 99.5GB).
 
 recipe: BenchmarkingRecipeForNextTokenPrediction
 
@@ -41,8 +42,8 @@ benchmark:
 
 step_scheduler:
   gc_every_steps: 10
-  global_batch_size: 64
-  local_batch_size: 1
+  global_batch_size: 512
+  local_batch_size: 2
   ckpt_every_steps: 1000
   val_every_steps: 1000
   num_epochs: 1

--- a/examples/llm_benchmark/deepseek/deepseek_v3_te_mxfp8_gb200.yaml
+++ b/examples/llm_benchmark/deepseek/deepseek_v3_te_mxfp8_gb200.yaml
@@ -23,7 +23,7 @@
 #   - pp_size: 4 -> 1  (NO pipeline parallelism) — dropped the pipeline + moe blocks
 #   - ep_size: 64 (shard the 256 routed experts across all 64 GPUs)
 #   - dispatcher: deepep -> hybridep  (GB200: deepep fails EP-buffer init)
-#   - local_batch_size: 8 -> 2, GBS 512 (GA = 512/(64*2) = 4) — lbs=2 matched pair
+#   - local_batch_size: 8 -> 2, GBS 128 (GA = 128/(64*2) = 1) — lbs=2 matched pair
 #     with the bf16 config (~127GB bf16 / ~147GB mxfp8 with TE fp8 buffers, both fit).
 #
 # Parallelism: ep_size=64 (==world=64), tp=pp=cp=1. seq_len=4096, AC on.
@@ -44,7 +44,7 @@ benchmark:
 
 step_scheduler:
   gc_every_steps: 10
-  global_batch_size: 512
+  global_batch_size: 128  # GA = 128/(64*2) = 1 (GA=1 is the no-PP memory ceiling; GA>1 OOMs)
   local_batch_size: 2
   ckpt_every_steps: 1000
   val_every_steps: 1000

--- a/examples/llm_benchmark/deepseek/deepseek_v3_te_mxfp8_gb200.yaml
+++ b/examples/llm_benchmark/deepseek/deepseek_v3_te_mxfp8_gb200.yaml
@@ -1,0 +1,121 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Benchmarking config for DeepSeek-V3 (671B) Te, tuned for GB200 (MXFP8), NO PP.
+#
+# MXFP8 variant of deepseek_v3_te_deepep_gb200.yaml — same no-PP layout, deltas:
+#   - experts: gmm -> te; te_fp8.recipe: mxfp8; optimizer.foreach: false
+#   - peak_tflops: 2500 -> 5000 (GB200 MXFP8/FP8 dense peak)
+# GB200 deltas vs the generic deepseek_v3_te_deepep.yaml:
+#   - peak_tflops: 989 -> 2500  (GB200 BF16 dense peak; generic recipe uses H100 989)
+#   - num_nodes/ci.nodes: 32 -> 16  (16 nodes x 4 GB200 = 64 GPUs)
+#   - pp_size: 4 -> 1  (NO pipeline parallelism) — dropped the pipeline + moe blocks
+#   - ep_size: 64 (shard the 256 routed experts across all 64 GPUs)
+#   - dispatcher: deepep -> hybridep  (GB200: deepep fails EP-buffer init)
+#   - local_batch_size: 8 -> 1, GBS 512 -> 64 (GA = 64/(64*1) = 1) — 671B no-PP is
+#     memory-tight; lbs=1 is the feasibility starting point (sweep up if it fits).
+#
+# Parallelism: ep_size=64 (==world=64), tp=pp=cp=1. seq_len=4096, AC on.
+# This config is the no-PP feasibility test: does DeepSeek-V3 671B fit on 16 nodes
+# (64 GB200) without pipeline parallelism?
+
+recipe: BenchmarkingRecipeForNextTokenPrediction
+
+seed: 1234
+
+benchmark:
+  warmup_steps: 10
+  peak_tflops: 5000  # GB200 MXFP8/FP8 dense peak TFLOPs
+  nsys_start: -1
+  nsys_end: -1
+  nsys_ranks: []
+  num_nodes: 16
+
+step_scheduler:
+  gc_every_steps: 10
+  global_batch_size: 64
+  local_batch_size: 1
+  ckpt_every_steps: 1000
+  val_every_steps: 1000
+  num_epochs: 1
+  max_steps: 30
+
+distributed:
+  strategy: fsdp2
+  tp_size: 1
+  cp_size: 1
+  pp_size: 1
+  ep_size: 64
+
+  sequence_parallel: false
+  activation_checkpointing: true
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 10
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_config
+  config:
+    _target_: transformers.AutoConfig.from_pretrained
+    pretrained_model_name_or_path: deepseek-ai/DeepSeek-V3
+  trust_remote_code: true
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: te
+    linear: te
+    rms_norm: te
+    rope_fusion: true
+    experts: te
+    dispatcher: hybridep  # GB200: deepep fails EP-buffer init ('invalid resource handle')
+    fake_balanced_gate: true
+    enable_hf_state_dict_adapter: false
+    enable_fsdp_optimizations: true
+    te_fp8:
+      recipe: mxfp8
+
+checkpoint:
+  enabled: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+  fp32_upcast: false
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.mock_iterable_dataset.MockIterableDataset
+  seq_len: 4096
+  num_samples: 100000
+
+dataloader:
+  batch_size: null  # Dataset already yields batches
+  _target_: torch.utils.data.DataLoader
+  num_workers: 0
+
+optimizer:
+  _target_: torch.optim.Adam
+  betas:
+  - 0.9
+  - 0.999
+  eps: 1e-8
+  lr: 0.0001
+  weight_decay: 0
+  foreach: false  # ep==world experts=te: per-param Adam avoids Tensor/DTensor _foreach_lerp_ mix
+
+
+ci:
+  time: "04:00:00"
+  nodes: 16
+  ep_size: 64
+  env_vars:
+    RDZV_TIMEOUT: "900"

--- a/examples/llm_benchmark/deepseek/deepseek_v3_te_mxfp8_gb200.yaml
+++ b/examples/llm_benchmark/deepseek/deepseek_v3_te_mxfp8_gb200.yaml
@@ -23,8 +23,8 @@
 #   - pp_size: 4 -> 1  (NO pipeline parallelism) — dropped the pipeline + moe blocks
 #   - ep_size: 64 (shard the 256 routed experts across all 64 GPUs)
 #   - dispatcher: deepep -> hybridep  (GB200: deepep fails EP-buffer init)
-#   - local_batch_size: 8 -> 1, GBS 512 -> 64 (GA = 64/(64*1) = 1) — 671B no-PP is
-#     memory-tight; lbs=1 is the feasibility starting point (sweep up if it fits).
+#   - local_batch_size: 8 -> 2, GBS 512 (GA = 512/(64*2) = 4) — lbs=2 matched pair
+#     with the bf16 config (~127GB bf16 / ~147GB mxfp8 with TE fp8 buffers, both fit).
 #
 # Parallelism: ep_size=64 (==world=64), tp=pp=cp=1. seq_len=4096, AC on.
 # This config is the no-PP feasibility test: does DeepSeek-V3 671B fit on 16 nodes
@@ -44,8 +44,8 @@ benchmark:
 
 step_scheduler:
   gc_every_steps: 10
-  global_batch_size: 64
-  local_batch_size: 1
+  global_batch_size: 512
+  local_batch_size: 2
   ckpt_every_steps: 1000
   val_every_steps: 1000
   num_epochs: 1

--- a/examples/llm_benchmark/qwen/qwen3_moe_30b_compile_attn_gb200.yaml
+++ b/examples/llm_benchmark/qwen/qwen3_moe_30b_compile_attn_gb200.yaml
@@ -1,0 +1,128 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Benchmarking config for Qwen3 MoE 30B (A3B) bf16, attn=sdpa + torch.compile(attention) + experts=te, GB200.
+#
+# WAVE 13: generalizes the DeepSeek MLA compile win to standard GQA attention. Single-variable
+# delta vs qwen3_moe_30b_te_deepep_gb200.yaml (attn:te/experts:te, 9.183 s / 26.27% MFU@2500):
+# switch the attention path to attn:sdpa + compile_attn:true (+ linear/rms_norm:torch,
+# rope_fusion:false so no TE submodules inside the compiled region). experts:te kept (the
+# shipping bf16 expert backend) — only the attention module changes. Expect a SMALL win or
+# wash (GQA is far fewer ops than MLA, and the MoE experts dominate compute).
+#
+# GB200 deltas vs the generic qwen3_moe_30b_te_deepep.yaml:
+#   - peak_tflops: 2500  (GB200 BF16 dense peak; generic recipe uses H100 989)
+#   - num_nodes/ci.nodes: 1 -> 2  (2 nodes x 4 GB200 = 8 GPUs)
+#   - local_batch_size: 4 -> 16
+#
+# Parallelism: ep_size=8, tp=pp=cp=1. With dp_size=8 (world=8) and
+# global_batch_size=512, lbs=16 gives 512 / (8 * 16) = 4 gradient-accumulation
+# micro-batches. seq_len=4096. lbs=16 matches the qwen3_moe_30b_te_mxfp8_gb200
+# operating point so the bf16 vs mxfp8 comparison is a precision-only delta.
+
+recipe: BenchmarkingRecipeForNextTokenPrediction
+
+seed: 1234
+
+benchmark:
+  warmup_steps: 10
+  peak_tflops: 2500  # GB200 BF16 dense peak TFLOPs
+  nsys_start: -1
+  nsys_end: -1
+  nsys_ranks: []
+  num_nodes: 2
+
+step_scheduler:
+  gc_every_steps: 10
+  global_batch_size: 512
+  local_batch_size: 16
+  ckpt_every_steps: 1000
+  val_every_steps: 1000
+  num_epochs: 1
+  max_steps: 30
+
+distributed:
+  strategy: fsdp2
+  tp_size: 1
+  cp_size: 1
+  pp_size: 1
+  ep_size: 8
+
+  sequence_parallel: false
+  activation_checkpointing: true
+
+  pipeline:
+    pp_schedule: interleaved1f1b
+    pp_microbatch_size: 2
+    round_virtual_stages_to_pp_multiple: down
+    scale_grads_in_schedule: false
+    patch_inner_model: false
+    patch_causal_lm_model: false
+    layers_per_stage: 2
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 10
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_config
+  config:
+    _target_: transformers.AutoConfig.from_pretrained
+    pretrained_model_name_or_path: Qwen/Qwen3-30B-A3B
+  trust_remote_code: true
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: sdpa     # WAVE 13: compilable attention backend (TE attn not fullgraph-traceable)
+    linear: torch  # WAVE 13: TE Linear is @torch.compiler.disable'd -> breaks attn fullgraph
+    rms_norm: torch  # WAVE 13: TE RMSNorm also compiler-disabled
+    rope_fusion: false  # WAVE 13: fused RoPE is a TE compiler-disabled op
+    compile_attn: true  # WAVE 13: torch.compile(fullgraph) the GQA attention forward
+    experts: te  # TE GroupedLinear bf16 (no fp8) — fastest bf16 expert backend (bake-off: te 26.27% > gmm 26.12% > torch_mm 25.45%)
+    dispatcher: hybridep  # GB200: deepep fails EP-buffer init ('invalid resource handle')
+    fake_balanced_gate: true
+    enable_hf_state_dict_adapter: true
+    enable_fsdp_optimizations: true
+
+checkpoint:
+  enabled: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+  fp32_upcast: false
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.mock_iterable_dataset.MockIterableDataset
+  seq_len: 4096
+  num_samples: 100000
+
+dataloader:
+  batch_size: null  # Dataset already yields batches
+  _target_: torch.utils.data.DataLoader
+  num_workers: 0
+
+optimizer:
+  _target_: torch.optim.Adam
+  betas:
+  - 0.9
+  - 0.999
+  eps: 1e-8
+  lr: 0.0001
+  weight_decay: 0
+  foreach: false  # ep8==world8: TE experts plain-tensor vs DTensor; per-param Adam avoids _foreach_lerp_ mix
+
+
+ci:
+  time: "00:40:00"
+  nodes: 2
+  ep_size: 8

--- a/examples/llm_benchmark/qwen/qwen3_moe_30b_te_bf16_gb200.yaml
+++ b/examples/llm_benchmark/qwen/qwen3_moe_30b_te_bf16_gb200.yaml
@@ -1,0 +1,126 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Benchmarking config for Qwen3 MoE 30B (A3B) bf16, experts=te (TE GroupedLinear, NO fp8), GB200 (WAVE 11 bake-off).
+#
+# Single-variable delta vs qwen3_moe_30b_te_deepep_gb200.yaml: experts gmm -> te.
+# No te_fp8 block => TE GroupedLinear runs in BF16 (not fp8). Same lbs16/GBS512/ep8/2N op point.
+# ep_size=8 == world (2N x 4) => experts:te params are NOT FSDP-wrapped (plain tensors) while the
+# rest are DTensor; optimizer.foreach=false avoids aten._foreach_lerp_ batching a plain-Tensor +
+# DTensor together (same fix as the TE-mxfp8 ep==world configs). gmm baseline = 26.12% MFU@2500 / 9.237s.
+#
+# GB200 deltas vs the generic qwen3_moe_30b_te_deepep.yaml:
+#   - peak_tflops: 2500  (GB200 BF16 dense peak; generic recipe uses H100 989)
+#   - num_nodes/ci.nodes: 1 -> 2  (2 nodes x 4 GB200 = 8 GPUs)
+#   - local_batch_size: 4 -> 16
+#
+# Parallelism: ep_size=8, tp=pp=cp=1. With dp_size=8 (world=8) and
+# global_batch_size=512, lbs=16 gives 512 / (8 * 16) = 4 gradient-accumulation
+# micro-batches. seq_len=4096. lbs=16 matches the qwen3_moe_30b_te_mxfp8_gb200
+# operating point so the bf16 vs mxfp8 comparison is a precision-only delta.
+
+recipe: BenchmarkingRecipeForNextTokenPrediction
+
+seed: 1234
+
+benchmark:
+  warmup_steps: 10
+  peak_tflops: 2500  # GB200 BF16 dense peak TFLOPs
+  nsys_start: -1
+  nsys_end: -1
+  nsys_ranks: []
+  num_nodes: 2
+
+step_scheduler:
+  gc_every_steps: 10
+  global_batch_size: 512
+  local_batch_size: 16
+  ckpt_every_steps: 1000
+  val_every_steps: 1000
+  num_epochs: 1
+  max_steps: 30
+
+distributed:
+  strategy: fsdp2
+  tp_size: 1
+  cp_size: 1
+  pp_size: 1
+  ep_size: 8
+
+  sequence_parallel: false
+  activation_checkpointing: true
+
+  pipeline:
+    pp_schedule: interleaved1f1b
+    pp_microbatch_size: 2
+    round_virtual_stages_to_pp_multiple: down
+    scale_grads_in_schedule: false
+    patch_inner_model: false
+    patch_causal_lm_model: false
+    layers_per_stage: 2
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 10
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_config
+  config:
+    _target_: transformers.AutoConfig.from_pretrained
+    pretrained_model_name_or_path: Qwen/Qwen3-30B-A3B
+  trust_remote_code: true
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: te
+    linear: te
+    rms_norm: te
+    rope_fusion: true
+    experts: te  # WAVE 11: TE GroupedLinear bf16 (no fp8); vs gmm
+    dispatcher: hybridep  # GB200: deepep fails EP-buffer init ('invalid resource handle')
+    fake_balanced_gate: true
+    enable_hf_state_dict_adapter: true
+    enable_fsdp_optimizations: true
+
+checkpoint:
+  enabled: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+  fp32_upcast: false
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.mock_iterable_dataset.MockIterableDataset
+  seq_len: 4096
+  num_samples: 100000
+
+dataloader:
+  batch_size: null  # Dataset already yields batches
+  _target_: torch.utils.data.DataLoader
+  num_workers: 0
+
+optimizer:
+  _target_: torch.optim.Adam
+  betas:
+  - 0.9
+  - 0.999
+  eps: 1e-8
+  lr: 0.0001
+  weight_decay: 0
+  foreach: false  # ep==world: TE experts plain-tensor vs DTensor; per-param Adam avoids _foreach_lerp_ mix
+
+
+ci:
+  time: "00:40:00"
+  nodes: 2
+  ep_size: 8

--- a/examples/llm_benchmark/qwen/qwen3_moe_30b_torchmm_gb200.yaml
+++ b/examples/llm_benchmark/qwen/qwen3_moe_30b_torchmm_gb200.yaml
@@ -1,0 +1,122 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Benchmarking config for Qwen3 MoE 30B (A3B) bf16, experts=torch_mm, GB200 (WAVE 11 bake-off).
+#
+# Single-variable delta vs qwen3_moe_30b_te_deepep_gb200.yaml: experts gmm -> torch_mm
+# (torch._grouped_mm bf16). Same lbs16/GBS512/ep8/2N/attn:te op point. gmm baseline = 26.12% MFU@2500 / 9.237s.
+#
+# GB200 deltas vs the generic qwen3_moe_30b_te_deepep.yaml:
+#   - peak_tflops: 2500  (GB200 BF16 dense peak; generic recipe uses H100 989)
+#   - num_nodes/ci.nodes: 1 -> 2  (2 nodes x 4 GB200 = 8 GPUs)
+#   - local_batch_size: 4 -> 16
+#
+# Parallelism: ep_size=8, tp=pp=cp=1. With dp_size=8 (world=8) and
+# global_batch_size=512, lbs=16 gives 512 / (8 * 16) = 4 gradient-accumulation
+# micro-batches. seq_len=4096. lbs=16 matches the qwen3_moe_30b_te_mxfp8_gb200
+# operating point so the bf16 vs mxfp8 comparison is a precision-only delta.
+
+recipe: BenchmarkingRecipeForNextTokenPrediction
+
+seed: 1234
+
+benchmark:
+  warmup_steps: 10
+  peak_tflops: 2500  # GB200 BF16 dense peak TFLOPs
+  nsys_start: -1
+  nsys_end: -1
+  nsys_ranks: []
+  num_nodes: 2
+
+step_scheduler:
+  gc_every_steps: 10
+  global_batch_size: 512
+  local_batch_size: 16
+  ckpt_every_steps: 1000
+  val_every_steps: 1000
+  num_epochs: 1
+  max_steps: 30
+
+distributed:
+  strategy: fsdp2
+  tp_size: 1
+  cp_size: 1
+  pp_size: 1
+  ep_size: 8
+
+  sequence_parallel: false
+  activation_checkpointing: true
+
+  pipeline:
+    pp_schedule: interleaved1f1b
+    pp_microbatch_size: 2
+    round_virtual_stages_to_pp_multiple: down
+    scale_grads_in_schedule: false
+    patch_inner_model: false
+    patch_causal_lm_model: false
+    layers_per_stage: 2
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 10
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_config
+  config:
+    _target_: transformers.AutoConfig.from_pretrained
+    pretrained_model_name_or_path: Qwen/Qwen3-30B-A3B
+  trust_remote_code: true
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: te
+    linear: te
+    rms_norm: te
+    rope_fusion: true
+    experts: torch_mm  # WAVE 11: torch._grouped_mm bf16 (vs gmm); single-variable swap
+    dispatcher: hybridep  # GB200: deepep fails EP-buffer init ('invalid resource handle')
+    fake_balanced_gate: true
+    enable_hf_state_dict_adapter: true
+    enable_fsdp_optimizations: true
+
+checkpoint:
+  enabled: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+  fp32_upcast: false
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.mock_iterable_dataset.MockIterableDataset
+  seq_len: 4096
+  num_samples: 100000
+
+dataloader:
+  batch_size: null  # Dataset already yields batches
+  _target_: torch.utils.data.DataLoader
+  num_workers: 0
+
+optimizer:
+  _target_: torch.optim.Adam
+  betas:
+  - 0.9
+  - 0.999
+  eps: 1e-8
+  lr: 0.0001
+  weight_decay: 0
+
+
+ci:
+  time: "00:40:00"
+  nodes: 2
+  ep_size: 8

--- a/nemo_automodel/components/models/common/utils.py
+++ b/nemo_automodel/components/models/common/utils.py
@@ -191,6 +191,11 @@ class BackendConfig:
         enable_fsdp_optimizations: Whether to enable FSDP2 optimizations.
         gate_precision: Optional dtype override for the gate computation. Accepts
             torch.dtype or string (e.g., "torch.float32", "float32").
+        compile_mla: torch.compile(fullgraph) the DeepSeek MLA forward (requires attn="sdpa"
+            + all-torch submodules). See the field comment below.
+        compile_attn: generic version of compile_mla for standard GQA attention (e.g.
+            Qwen3-MoE). MLA also honors it. Requires attn="sdpa", linear="torch",
+            rms_norm="torch", rope_fusion=False.
     """
 
     attn: Literal["te", "sdpa", "flex", "eager", "tilelang"] = "te" if HAVE_TE and torch.cuda.is_available() else "sdpa"
@@ -225,6 +230,11 @@ class BackendConfig:
     # reshapes, SDPA). Requires a compilable attention backend (attn="sdpa"); TE's fused
     # attention is a custom-autograd black box that fullgraph can't trace. Default False.
     compile_mla: bool = False
+    # Generic version of compile_mla for standard (GQA) attention modules (e.g. Qwen3-MoE).
+    # Same constraint: the compiled region must contain no TE custom-autograd submodules, so
+    # it requires attn="sdpa", linear="torch", rms_norm="torch", rope_fusion=False. MLA also
+    # honors this flag (compile_mla stays as a backward-compatible alias). Default False.
+    compile_attn: bool = False
 
     def __post_init__(self):
         # Normalize te_fp8: dict -> TEFp8Config, None stays None

--- a/nemo_automodel/components/models/common/utils.py
+++ b/nemo_automodel/components/models/common/utils.py
@@ -220,6 +220,11 @@ class BackendConfig:
     enable_fsdp_optimizations: bool = False
     te_fp8: TEFp8Config | None = None
     gate_precision: str | torch.dtype | None = None
+    # When True, torch.compile(fullgraph=True) the attention module's forward (e.g. the
+    # DeepSeek-V3 MLA) to fuse its many small ops (lora down/up projections, RoPE, latent
+    # reshapes, SDPA). Requires a compilable attention backend (attn="sdpa"); TE's fused
+    # attention is a custom-autograd black box that fullgraph can't trace. Default False.
+    compile_mla: bool = False
 
     def __post_init__(self):
         # Normalize te_fp8: dict -> TEFp8Config, None stays None

--- a/nemo_automodel/components/models/common/utils.py
+++ b/nemo_automodel/components/models/common/utils.py
@@ -191,11 +191,9 @@ class BackendConfig:
         enable_fsdp_optimizations: Whether to enable FSDP2 optimizations.
         gate_precision: Optional dtype override for the gate computation. Accepts
             torch.dtype or string (e.g., "torch.float32", "float32").
-        compile_mla: torch.compile(fullgraph) the DeepSeek MLA forward (requires attn="sdpa"
-            + all-torch submodules). See the field comment below.
-        compile_attn: generic version of compile_mla for standard GQA attention (e.g.
-            Qwen3-MoE). MLA also honors it. Requires attn="sdpa", linear="torch",
-            rms_norm="torch", rope_fusion=False.
+        compile_attn: torch.compile(fullgraph) the attention module's forward — both the
+            DeepSeek-V3 MLA and standard GQA attention (e.g. Qwen3-MoE) honor it. Requires
+            attn="sdpa", linear="torch", rms_norm="torch", rope_fusion=False.
     """
 
     attn: Literal["te", "sdpa", "flex", "eager", "tilelang"] = "te" if HAVE_TE and torch.cuda.is_available() else "sdpa"
@@ -225,15 +223,12 @@ class BackendConfig:
     enable_fsdp_optimizations: bool = False
     te_fp8: TEFp8Config | None = None
     gate_precision: str | torch.dtype | None = None
-    # When True, torch.compile(fullgraph=True) the attention module's forward (e.g. the
-    # DeepSeek-V3 MLA) to fuse its many small ops (lora down/up projections, RoPE, latent
-    # reshapes, SDPA). Requires a compilable attention backend (attn="sdpa"); TE's fused
-    # attention is a custom-autograd black box that fullgraph can't trace. Default False.
-    compile_mla: bool = False
-    # Generic version of compile_mla for standard (GQA) attention modules (e.g. Qwen3-MoE).
-    # Same constraint: the compiled region must contain no TE custom-autograd submodules, so
-    # it requires attn="sdpa", linear="torch", rms_norm="torch", rope_fusion=False. MLA also
-    # honors this flag (compile_mla stays as a backward-compatible alias). Default False.
+    # When True, torch.compile(fullgraph=True) the attention module's forward to fuse its many
+    # small ops (projections, RoPE, reshapes, SDPA). Applies to both the DeepSeek-V3 MLA and
+    # standard GQA attention (e.g. Qwen3-MoE). The compiled region must contain no TE
+    # custom-autograd submodules (TE's fused attention/Linear/RMSNorm are black boxes that
+    # fullgraph can't trace), so it requires attn="sdpa", linear="torch", rms_norm="torch",
+    # rope_fusion=False. Default False.
     compile_attn: bool = False
 
     def __post_init__(self):

--- a/nemo_automodel/components/models/deepseek_v3/layers.py
+++ b/nemo_automodel/components/models/deepseek_v3/layers.py
@@ -135,7 +135,7 @@ class MLA(nn.Module):
                     "TE fused attention is not fullgraph-compilable.",
                     attn_impl,
                 )
-            else:
+            else:  # pragma: no cover - torch.compile path exercised on GPU benchmark runs only
                 logger.warning("compile MLA forward: torch.compile(fullgraph=True) the MLA forward (attn=sdpa).")
                 self._compiled_forward = torch.compile(self._forward_impl, fullgraph=True, dynamic=False)
 
@@ -146,7 +146,7 @@ class MLA(nn.Module):
         attention_mask: torch.Tensor | None = None,
         **attn_kwargs: Any,
     ):
-        if self._compiled_forward is not None:
+        if self._compiled_forward is not None:  # pragma: no cover - compiled path only on GPU benchmark runs
             return self._compiled_forward(x, freqs_cis, attention_mask, **attn_kwargs)
         return self._forward_impl(x, freqs_cis, attention_mask, **attn_kwargs)
 

--- a/nemo_automodel/components/models/deepseek_v3/layers.py
+++ b/nemo_automodel/components/models/deepseek_v3/layers.py
@@ -126,16 +126,17 @@ class MLA(nn.Module):
         # RoPE, latent reshapes, SDPA) with torch.compile(fullgraph=True). Only valid
         # with a compilable attention backend — TE's fused attention is a custom-autograd
         # black box that fullgraph can't trace. seq_len is fixed here so dynamic=False.
+        # Honors compile_mla (MLA-specific) or compile_attn (generic attention-compile flag).
         self._compiled_forward = None
-        if backend.compile_mla:
+        if backend.compile_mla or backend.compile_attn:
             if attn_impl != "sdpa":
                 logger.warning(
-                    "backend.compile_mla=True ignored: requires attn='sdpa' (got attn='%s'); "
+                    "backend.compile_mla/compile_attn ignored: requires attn='sdpa' (got attn='%s'); "
                     "TE fused attention is not fullgraph-compilable.",
                     attn_impl,
                 )
             else:
-                logger.warning("backend.compile_mla=True: torch.compile(fullgraph=True) the MLA forward (attn=sdpa).")
+                logger.warning("compile MLA forward: torch.compile(fullgraph=True) the MLA forward (attn=sdpa).")
                 self._compiled_forward = torch.compile(self._forward_impl, fullgraph=True, dynamic=False)
 
     def forward(

--- a/nemo_automodel/components/models/deepseek_v3/layers.py
+++ b/nemo_automodel/components/models/deepseek_v3/layers.py
@@ -126,12 +126,12 @@ class MLA(nn.Module):
         # RoPE, latent reshapes, SDPA) with torch.compile(fullgraph=True). Only valid
         # with a compilable attention backend — TE's fused attention is a custom-autograd
         # black box that fullgraph can't trace. seq_len is fixed here so dynamic=False.
-        # Honors compile_mla (MLA-specific) or compile_attn (generic attention-compile flag).
+        # Driven by the generic backend.compile_attn flag (the MLA is one attention module).
         self._compiled_forward = None
-        if backend.compile_mla or backend.compile_attn:
+        if backend.compile_attn:
             if attn_impl != "sdpa":
                 logger.warning(
-                    "backend.compile_mla/compile_attn ignored: requires attn='sdpa' (got attn='%s'); "
+                    "backend.compile_attn ignored: requires attn='sdpa' (got attn='%s'); "
                     "TE fused attention is not fullgraph-compilable.",
                     attn_impl,
                 )

--- a/nemo_automodel/components/models/deepseek_v3/layers.py
+++ b/nemo_automodel/components/models/deepseek_v3/layers.py
@@ -12,11 +12,14 @@
 # See the License for the specific governing permissions and
 # limitations under the License.
 
+import logging
 from typing import Any
 
 import torch
 from torch import nn
 from transformers.models.deepseek_v3.configuration_deepseek_v3 import DeepseekV3Config
+
+logger = logging.getLogger(__name__)
 
 from nemo_automodel.components.attention.utils import (
     initialize_attn_module_and_func,
@@ -119,7 +122,34 @@ class MLA(nn.Module):
             softmax_scale=self.softmax_scale,
         )
 
+        # Optionally fuse the MLA forward's many small ops (lora down/up projections,
+        # RoPE, latent reshapes, SDPA) with torch.compile(fullgraph=True). Only valid
+        # with a compilable attention backend — TE's fused attention is a custom-autograd
+        # black box that fullgraph can't trace. seq_len is fixed here so dynamic=False.
+        self._compiled_forward = None
+        if backend.compile_mla:
+            if attn_impl != "sdpa":
+                logger.warning(
+                    "backend.compile_mla=True ignored: requires attn='sdpa' (got attn='%s'); "
+                    "TE fused attention is not fullgraph-compilable.",
+                    attn_impl,
+                )
+            else:
+                logger.warning("backend.compile_mla=True: torch.compile(fullgraph=True) the MLA forward (attn=sdpa).")
+                self._compiled_forward = torch.compile(self._forward_impl, fullgraph=True, dynamic=False)
+
     def forward(
+        self,
+        x: torch.Tensor,
+        freqs_cis: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        **attn_kwargs: Any,
+    ):
+        if self._compiled_forward is not None:
+            return self._compiled_forward(x, freqs_cis, attention_mask, **attn_kwargs)
+        return self._forward_impl(x, freqs_cis, attention_mask, **attn_kwargs)
+
+    def _forward_impl(
         self,
         x: torch.Tensor,
         freqs_cis: torch.Tensor,

--- a/nemo_automodel/components/models/qwen3_moe/layers.py
+++ b/nemo_automodel/components/models/qwen3_moe/layers.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from typing import Any
 
 import torch
@@ -29,6 +30,8 @@ from nemo_automodel.components.models.common import (
     initialize_rms_norm_module,
 )
 from nemo_automodel.components.models.gpt_oss.rope_utils import apply_rotary_emb_qk
+
+logger = logging.getLogger(__name__)
 
 
 class Qwen3MoeAttention(nn.Module):
@@ -80,7 +83,38 @@ class Qwen3MoeAttention(nn.Module):
             num_gqa_groups=self.num_kv_heads,
         )
 
+        # Optionally fuse the attention forward's many small ops (q/k/v projections, per-head
+        # RMSNorm, RoPE, SDPA) with torch.compile(fullgraph=True). Only valid with a compilable
+        # attention backend — TE's fused attention is a custom-autograd black box that fullgraph
+        # can't trace, and TE Linear/RMSNorm are @torch.compiler.disable'd. seq_len is fixed so
+        # dynamic=False.
+        self._compiled_forward = None
+        if backend.compile_attn:
+            if backend.attn != "sdpa":
+                logger.warning(
+                    "backend.compile_attn=True ignored: requires attn='sdpa' (got attn='%s'); "
+                    "TE fused attention is not fullgraph-compilable.",
+                    backend.attn,
+                )
+            else:
+                logger.warning(
+                    "backend.compile_attn=True: torch.compile(fullgraph=True) the Qwen3-MoE attention (attn=sdpa)."
+                )
+                self._compiled_forward = torch.compile(self._forward_impl, fullgraph=True, dynamic=False)
+
     def forward(
+        self,
+        x: torch.Tensor,
+        *,
+        freqs_cis: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        **attn_kwargs: Any,
+    ) -> torch.Tensor:
+        if self._compiled_forward is not None:
+            return self._compiled_forward(x, freqs_cis=freqs_cis, attention_mask=attention_mask, **attn_kwargs)
+        return self._forward_impl(x, freqs_cis=freqs_cis, attention_mask=attention_mask, **attn_kwargs)
+
+    def _forward_impl(
         self,
         x: torch.Tensor,
         *,

--- a/nemo_automodel/components/models/qwen3_moe/layers.py
+++ b/nemo_automodel/components/models/qwen3_moe/layers.py
@@ -96,7 +96,7 @@ class Qwen3MoeAttention(nn.Module):
                     "TE fused attention is not fullgraph-compilable.",
                     backend.attn,
                 )
-            else:
+            else:  # pragma: no cover - torch.compile path exercised on GPU benchmark runs only
                 logger.warning(
                     "backend.compile_attn=True: torch.compile(fullgraph=True) the Qwen3-MoE attention (attn=sdpa)."
                 )
@@ -110,7 +110,7 @@ class Qwen3MoeAttention(nn.Module):
         attention_mask: torch.Tensor | None = None,
         **attn_kwargs: Any,
     ) -> torch.Tensor:
-        if self._compiled_forward is not None:
+        if self._compiled_forward is not None:  # pragma: no cover - compiled path only on GPU benchmark runs
             return self._compiled_forward(x, freqs_cis=freqs_cis, attention_mask=attention_mask, **attn_kwargs)
         return self._forward_impl(x, freqs_cis=freqs_cis, attention_mask=attention_mask, **attn_kwargs)
 

--- a/tests/unit_tests/models/qwen3_moe/test_qwen3_moe_compile_attn.py
+++ b/tests/unit_tests/models/qwen3_moe/test_qwen3_moe_compile_attn.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU unit tests for the Qwen3-MoE compile_attn (fullgraph attention compile) wiring.
+
+These mock the submodule initializers so Qwen3MoeAttention constructs without a GPU or
+TransformerEngine. They cover the compile_attn gating in __init__ (default off, and the
+warn/no-op path when attn != 'sdpa'); the actual torch.compile call (attn='sdpa' + GPU)
+is pragma-excluded as it only runs on the GPU benchmark.
+"""
+
+from unittest.mock import Mock, patch
+
+from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.models.qwen3_moe.layers import Qwen3MoeAttention
+
+
+def _config():
+    from transformers.models.qwen3_moe.configuration_qwen3_moe import Qwen3MoeConfig
+
+    cfg = Qwen3MoeConfig(
+        vocab_size=128,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        max_position_embeddings=256,
+        rms_norm_eps=1e-6,
+        moe_intermediate_size=64,
+        num_experts=0,
+        num_experts_per_tok=1,
+    )
+    cfg.head_dim = 16
+    return cfg
+
+
+@patch("nemo_automodel.components.models.qwen3_moe.layers.initialize_attn_module_and_func")
+@patch("nemo_automodel.components.models.qwen3_moe.layers.initialize_rms_norm_module")
+@patch("nemo_automodel.components.models.qwen3_moe.layers.initialize_linear_module")
+class TestQwen3MoeCompileAttn:
+    """compile_attn gating in Qwen3MoeAttention.__init__."""
+
+    def _build(self, mock_lin, mock_rms, mock_attn, backend):
+        mock_lin.return_value = Mock()
+        mock_rms.return_value = Mock()
+        mock_attn.return_value = (Mock(), Mock())
+        return Qwen3MoeAttention(_config(), backend)
+
+    def test_compile_attn_off_leaves_uncompiled(self, mock_lin, mock_rms, mock_attn):
+        backend = BackendConfig(attn="sdpa", linear="torch", rms_norm="torch", rope_fusion=False, compile_attn=False)
+        attn = self._build(mock_lin, mock_rms, mock_attn, backend)
+        assert attn._compiled_forward is None
+
+    def test_compile_attn_on_non_sdpa_warns_and_noops(self, mock_lin, mock_rms, mock_attn):
+        # compile_attn=True but attn != 'sdpa' → warn and leave the forward uncompiled.
+        backend = BackendConfig(attn="te", linear="torch", rms_norm="torch", rope_fusion=False, compile_attn=True)
+        attn = self._build(mock_lin, mock_rms, mock_attn, backend)
+        assert attn._compiled_forward is None

--- a/tests/unit_tests/moe/test_backend_config.py
+++ b/tests/unit_tests/moe/test_backend_config.py
@@ -401,3 +401,19 @@ class TestTEFp8ConfigRecipe:
             pytest.skip("transformer_engine not importable")
         sentinel = object()
         assert TEFp8Config(recipe=sentinel).build_recipe() is sentinel
+
+
+class TestBackendConfigCompileAttn:
+    """BackendConfig.compile_attn / compile_mla fullgraph-compile flags."""
+
+    def test_compile_attn_default_false(self):
+        assert BackendConfig().compile_attn is False
+
+    def test_compile_attn_explicit_true(self):
+        assert BackendConfig(compile_attn=True).compile_attn is True
+
+    def test_compile_mla_default_false(self):
+        assert BackendConfig().compile_mla is False
+
+    def test_compile_mla_explicit_true(self):
+        assert BackendConfig(compile_mla=True).compile_mla is True

--- a/tests/unit_tests/moe/test_backend_config.py
+++ b/tests/unit_tests/moe/test_backend_config.py
@@ -404,7 +404,7 @@ class TestTEFp8ConfigRecipe:
 
 
 class TestBackendConfigCompileAttn:
-    """BackendConfig.compile_attn / compile_mla fullgraph-compile flags."""
+    """BackendConfig.compile_attn fullgraph-compile flag (drives both MLA and GQA attention)."""
 
     def test_compile_attn_default_false(self):
         assert BackendConfig().compile_attn is False
@@ -412,8 +412,7 @@ class TestBackendConfigCompileAttn:
     def test_compile_attn_explicit_true(self):
         assert BackendConfig(compile_attn=True).compile_attn is True
 
-    def test_compile_mla_default_false(self):
-        assert BackendConfig().compile_mla is False
-
-    def test_compile_mla_explicit_true(self):
-        assert BackendConfig(compile_mla=True).compile_mla is True
+    def test_compile_mla_removed(self):
+        # compile_mla was consolidated into the generic compile_attn flag.
+        with pytest.raises(TypeError):
+            BackendConfig(compile_mla=True)


### PR DESCRIPTION
## Summary

Adds **DeepSeek-V3 671B no-pipeline-parallel** GB200 support and a generic **fullgraph `torch.compile` for attention** (`compile_attn`, drives both MLA + GQA).

- **DeepSeek-V3 671B fits no-PP** at 16 nodes / ep=64 (fsdp2 full-shard + full activation checkpointing, pp=1/tp=1/cp=1). PP is not required on GB200. The no-PP memory ceiling is **grad-accum** (the hybridep MoE dispatcher buffers scale with microbatches), so the configs use GA=1 / small GBS.
- **`compile_attn`** — fullgraph `torch.compile` of the MLA attention under `attn: sdpa` lifts DeepSeek-V3 bf16 from **23.82% → 26.48%** MFU@2500; with `experts: te` it reaches **28.13%** (+18% relative over the attn:te/gmm starting point). The compiled region must contain no TE submodules (TE Linear/RMSNorm/fused-RoPE are `@no_torch_dynamo`-disabled), so it uses `linear: torch` + `rms_norm: torch` + `rope_fusion: false`.
- **`compile_attn`** — the same mechanism generalized to standard GQA attention (Qwen3-MoE). **Measured opt-in**: it does *not* help GQA (qwen30B sdpa+compiled = 25.83% vs uncompiled `attn: te` = 26.27%), because TE's fused attention already beats SDPA by more than fusing the few surrounding ops recovers. The win is MLA-specific (many small q/kv-lora ops). Defaults off; Qwen3-MoE/GPT-OSS stay on `attn: te`. (GPT-OSS can't use the sdpa path at all — attention sinks + alternating sliding-window don't express as plain SDPA.)

> **Stacked on #2394** (`hemil/mxfp8-moe`). The DeepSeek mxfp8 config depends on that PR's `TEFp8Config` mxfp8 recipe, so this targets the #2394 branch and will auto-retarget to `main` once #2394 merges. Review/merge #2394 first.

## Changes

- **`components/models/common/utils.py`** — `BackendConfig` gains a single generic `compile_attn` flag (default off) that compiles both the MLA and GQA attention.
- **`components/models/deepseek_v3/layers.py`** — MLA forward split into dispatcher + `_forward_impl`; `torch.compile(fullgraph=True, dynamic=False)` when `compile_attn` + `attn: sdpa`.
- **`components/models/qwen3_moe/layers.py`** — Qwen3MoeAttention forward split + fullgraph-compile under `compile_attn` + `attn: sdpa` (warns/no-ops otherwise).
- **Configs (GB200):** DeepSeek-V3 no-PP — shipping bf16 (`deepseek_v3_sdpa_compile_gb200.yaml`, compiled-MLA + te) and mxfp8 (`deepseek_v3_sdpa_compile_mxfp8_gb200.yaml`), plus expert-backend bake-off variants (`te_deepep`, `te_mxfp8`, `sdpa_compile_te`, `sdpa_compile_torchmm`). Qwen3-MoE-30B `compile_attn` config + bf16 expert-backend bake-off variants (`te_bf16`, `torchmm`).
- **Tests** — `tests/unit_tests/models/qwen3_moe/test_qwen3_moe_compile_attn.py` (CPU-runnable: default-off leaves forward uncompiled; `compile_attn=True` + non-sdpa warns/no-ops) and `compile_attn` field coverage in `test_backend_config.py`. GPU-only `torch.compile` call + compiled-forward dispatch are `# pragma: no cover`.

## Tests done (GB200, 16N=64 GPU = one NVL72 domain)

mock-data benchmark; MFU vs the GB200 dense peak per precision (bf16 → 2500 TFLOP/s, MXFP8 → 5000 TFLOP/s).

| DeepSeek-V3 671B (no-PP, lbs2/GBS128/GA1/ep64, full AC) | iter | MFU | peak mem |
|---|---|---|---|
| bf16 — compiled-MLA + `experts: te` | 2.910 s | 28.13%@2500 | 107.4 GB |
| MXFP8 — compiled-MLA + `experts: te` + `te_fp8.recipe: mxfp8` | 2.594 s | 15.78%@5000 | 127.8 GB |

- **MXFP8 is ~10.9% faster** than bf16 wall-clock (2.594 vs 2.910 s), +20.4 GB (comfortably <192 GB). Mock-data loss tracks bf16 (11.94 ≈ 11.94 — no divergence on the MLA + mxfp8 path).
- **Expert-backend bake-off (bf16, compiled-MLA):** `experts: te` 28.13% > `gmm` 26.48% > `torch_mm` 24.95% — te is the fastest expert backend (consistent with #2394's bake-off).
- **`compile_attn` (Qwen3-MoE-30B, 2N):** sdpa+compiled-attn 25.83% < uncompiled `attn: te` 26.27% → kept opt-in (see Summary).

## Test plan

- [x] DeepSeek-V3 bf16 no-PP benchmark passes (28.13% MFU@2500, 16N).
- [x] DeepSeek-V3 mxfp8 no-PP benchmark passes (15.78% MFU@5000, ~11% faster than bf16).
- [x] `compile_attn` engages cleanly on Qwen3-MoE (fullgraph, no graph break) — measured, kept opt-in.
- [x] CPU unit tests for `compile_attn` gating.
- [ ] CI green on the stacked branch (after #2394).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


