### PR TITLE
feat(speculative): add activation checkpointing for P-EAGLE draft layers

### DIFF
--- a/nemo_automodel/components/speculative/eagle/draft_llama.py
+++ b/nemo_automodel/components/speculative/eagle/draft_llama.py
@@ -665,6 +665,10 @@ class LlamaEagle3DraftModel(_PeagleDraftMixin, PreTrainedModel):
         self.config = config
         self.target_hidden_size = getattr(config, "target_hidden_size", config.hidden_size)
         self.draft_vocab_size = getattr(config, "draft_vocab_size", config.vocab_size)
+        # Activation checkpointing for the P-EAGLE draft layers (training-only
+        # memory knob; toggled via ``gradient_checkpointing_enable`` and read by
+        # ``_PeagleDraftMixin.forward_peagle``). Off by default; never serialized.
+        self.gradient_checkpointing = False
 
         self.model = Eagle3LlamaModel(config)
         self.lm_head = nn.Linear(config.hidden_size, self.draft_vocab_size, bias=False)
@@ -741,6 +745,21 @@ class LlamaEagle3DraftModel(_PeagleDraftMixin, PreTrainedModel):
     def freeze_embeddings(self) -> None:
         """Freeze draft input embeddings."""
         self.model.embed_tokens.weight.requires_grad_(False)
+
+    def gradient_checkpointing_enable(self, gradient_checkpointing_kwargs=None) -> None:
+        """Enable activation checkpointing for the P-EAGLE draft layers.
+
+        Training-only memory knob: recomputes each ``forward_peagle`` layer in the
+        backward instead of storing its activations (the EAGLE-3 TTT ``forward``
+        path is unaffected). ``gradient_checkpointing_kwargs`` is accepted for
+        HF-API parity but ignored -- recompute is always non-reentrant, the only
+        mode compatible with the non-tensor ``block_mask``.
+        """
+        self.gradient_checkpointing = True
+
+    def gradient_checkpointing_disable(self) -> None:
+        """Disable activation checkpointing for the P-EAGLE draft layers."""
+        self.gradient_checkpointing = False
 
     def project_hidden_states(self, aux_hidden_states: torch.Tensor) -> torch.Tensor:
         """Project concatenated target aux states from ``num_aux * H_target`` to draft hidden size.

--- a/nemo_automodel/components/speculative/eagle/peagle_draft.py
+++ b/nemo_automodel/components/speculative/eagle/peagle_draft.py
@@ -33,6 +33,7 @@ import logging
 import torch
 import torch.nn as nn
 from torch.nn.attention.flex_attention import create_block_mask, flex_attention
+from torch.utils.checkpoint import checkpoint
 
 from nemo_automodel.components.models.llama.rope_utils import apply_rotary_pos_emb
 from nemo_automodel.components.speculative.eagle.peagle_attention import create_peagle_mask_mod
@@ -177,6 +178,22 @@ class _PeagleDraftMixin:
         """
         return self.project_hidden_states(self.mask_hidden.view(1, -1))
 
+    def _run_draft_layer(self, layer_fn, *args, **kwargs):
+        """Run one P-EAGLE draft layer, optionally under activation checkpointing.
+
+        When ``gradient_checkpointing`` is enabled (training only), the layer's
+        activations are freed after the forward and recomputed during the
+        backward (``torch.utils.checkpoint``), trading one extra forward per
+        layer for a lower activation-memory peak on the long flattened COD
+        sequence. ``use_reentrant=False`` is required so the non-tensor P-EAGLE
+        argument (``block_mask``) passes through and so the recompute composes
+        with the flex-attention path. With the flag off (the default, and in
+        eval) the layer runs directly with no overhead.
+        """
+        if self.gradient_checkpointing and self.training:
+            return checkpoint(layer_fn, *args, use_reentrant=False, **kwargs)
+        return layer_fn(*args, **kwargs)
+
     def forward_peagle(
         self,
         sampled_input_ids: torch.Tensor,
@@ -201,14 +218,15 @@ class _PeagleDraftMixin:
         """
         draft_input_embeds = self.embed_input_ids(sampled_input_ids)
         # Layer 0 fuses ``[embed, hidden]`` (2H); deeper layers refine plain H.
-        hidden_states = self.model.layers[0].forward_peagle(
+        hidden_states = self._run_draft_layer(
+            self.model.layers[0].forward_peagle,
             input_embeds=draft_input_embeds,
             hidden_states=sampled_projected_hidden,
             position_ids=position_ids,
             block_mask=block_mask,
         )
         for layer in self.model.layers[1:]:
-            hidden_states = layer.forward_peagle(hidden_states, position_ids, block_mask)
+            hidden_states = self._run_draft_layer(layer.forward_peagle, hidden_states, position_ids, block_mask)
         if getattr(self.config, "norm_output", False):
             hidden_states = self.model.norm(hidden_states)
         return hidden_states

--- a/nemo_automodel/recipes/llm/train_eagle3.py
+++ b/nemo_automodel/recipes/llm/train_eagle3.py
@@ -225,6 +225,12 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
         freeze_embeddings_default = not parallel_drafting
         if recipe_cfg.get("freeze_embeddings", freeze_embeddings_default):
             self.draft_model.freeze_embeddings()
+        # P-EAGLE memory knob: recompute the draft layers' activations in the
+        # backward instead of storing them, lowering the activation peak of the
+        # long flattened COD sequence (complements ``sequence_partitions``).
+        # Off by default; only affects the parallel-drafting forward.
+        if recipe_cfg.get("draft_gradient_checkpointing", False):
+            self.draft_model.gradient_checkpointing_enable()
         # The target's "Model summary" is logged by apply_model_infrastructure when it
         # loads; the draft is built directly, so log its (trainable) summary here too.
         print_trainable_parameters(self.draft_model, name="Draft")

--- a/tests/unit_tests/speculative/test_peagle.py
+++ b/tests/unit_tests/speculative/test_peagle.py
@@ -593,3 +593,133 @@ def test_peagle_checkpoint_save_round_trip(tmp_path):
     assert mask_keys, f"mask_hidden missing from saved weights: {sorted(sd)}"
     num_aux = getattr(draft.config, "num_aux_hidden_states", 3)
     assert tuple(sd[mask_keys[0]].shape) == (1, 1, num_aux * draft.config.target_hidden_size)
+
+
+# --------------------------------------------------------------------------- #
+# Activation (gradient) checkpointing for the P-EAGLE draft layers
+# --------------------------------------------------------------------------- #
+def test_gradient_checkpointing_default_off_and_toggle():
+    """The draft ships with checkpointing off; enable/disable flip the flag."""
+    draft = _build_tiny_draft_model(parallel_drafting=True, device="cpu")
+    assert draft.gradient_checkpointing is False
+    draft.gradient_checkpointing_enable()
+    assert draft.gradient_checkpointing is True
+    # ``gradient_checkpointing_kwargs`` is accepted for HF-API parity but ignored
+    # (recompute is always non-reentrant); the flag stays on.
+    draft.gradient_checkpointing_enable(gradient_checkpointing_kwargs={"use_reentrant": True})
+    assert draft.gradient_checkpointing is True
+    draft.gradient_checkpointing_disable()
+    assert draft.gradient_checkpointing is False
+
+
+def test_run_draft_layer_checkpoints_only_when_enabled_and_training():
+    """``_run_draft_layer`` recomputes (calls the layer twice: forward + backward
+    recompute) only when checkpointing is on AND the module is training; otherwise
+    it runs the layer exactly once."""
+    draft = _build_tiny_draft_model(parallel_drafting=True, device="cpu")
+    lin = torch.nn.Linear(4, 4)
+    calls = {"n": 0}
+
+    def fn(x):
+        calls["n"] += 1
+        return lin(x)
+
+    def _count(enabled: bool, training: bool) -> int:
+        draft.gradient_checkpointing = enabled
+        draft.train(training)
+        calls["n"] = 0
+        out = draft._run_draft_layer(fn, torch.randn(2, 4, requires_grad=True))
+        out.sum().backward()
+        return calls["n"]
+
+    assert _count(enabled=False, training=True) == 1  # disabled: forward only
+    assert _count(enabled=True, training=True) == 2  # enabled + train: + recompute
+    assert _count(enabled=True, training=False) == 1  # eval: no recompute
+
+
+def test_run_draft_layer_matches_direct_numerically():
+    """Checkpointed and direct execution of a draft layer are bit-for-bit equal in
+    output and input gradient."""
+    draft = _build_tiny_draft_model(parallel_drafting=True, device="cpu")
+    draft.train()
+    lin = torch.nn.Linear(4, 4)
+    x = torch.randn(2, 4)
+    xa, xb = x.clone().requires_grad_(True), x.clone().requires_grad_(True)
+
+    draft.gradient_checkpointing = False
+    out_direct = draft._run_draft_layer(lin, xa)
+    out_direct.sum().backward()
+    draft.gradient_checkpointing = True
+    out_ckpt = draft._run_draft_layer(lin, xb)
+    out_ckpt.sum().backward()
+
+    torch.testing.assert_close(out_ckpt, out_direct)
+    torch.testing.assert_close(xb.grad, xa.grad)
+
+
+def test_forward_peagle_routes_every_layer_through_checkpoint_helper(monkeypatch):
+    """``forward_peagle`` dispatches every draft layer (the fused layer 0 and the
+    deeper vanilla layers) through ``_run_draft_layer``, so enabling checkpointing
+    recomputes each one. Layer forwards are stubbed with a flex-free CPU op so the
+    routing is exercised without the CUDA-only flex-attention kernel."""
+    draft = _build_tiny_draft_model(parallel_drafting=True, mask_token_id=3, device="cpu")
+    draft.train()
+    draft.gradient_checkpointing_enable()
+
+    hidden_size = draft.config.hidden_size
+    calls: list[int] = []
+
+    def _make_stub(idx, lin):
+        def _fp(*args, **kwargs):
+            calls.append(idx)
+            hidden = kwargs.get("hidden_states", args[0] if args else None)
+            return lin(hidden)
+
+        return _fp
+
+    for i, layer in enumerate(draft.model.layers):
+        monkeypatch.setattr(layer, "forward_peagle", _make_stub(i, torch.nn.Linear(hidden_size, hidden_size)))
+
+    n = 5
+    ids = torch.zeros(1, n, dtype=torch.long)
+    hidden = torch.randn(1, n, hidden_size, requires_grad=True)
+    position_ids = torch.arange(n).unsqueeze(0)
+    out = draft.forward_peagle(ids, hidden, position_ids, block_mask=None)
+    out.sum().backward()
+
+    # Two draft layers, each called twice (forward + checkpoint recompute).
+    assert calls.count(0) == 2
+    assert calls.count(1) == 2
+
+
+@_gpu_only
+def test_gradient_checkpointing_matches_uncheckpointed_forward():
+    """Enabling activation checkpointing on the real flex-attention P-EAGLE forward
+    is numerically exact: identical loss and valid-token count, and (up to float
+    summation order) identical gradients on every draft parameter."""
+    torch.manual_seed(0)
+    mask_id = 20
+    draft = _build_tiny_draft_model(parallel_drafting=True, mask_token_id=mask_id)
+    trainer = _make_trainer(draft, num_depths=6, mask_token_id=mask_id)
+    batch = _random_batch(draft.config, batch_size=2, seq_len=16)
+
+    draft.zero_grad(set_to_none=True)
+    draft.gradient_checkpointing_disable()
+    torch.manual_seed(123)
+    base = trainer(**batch)
+    base.loss.backward()
+    base_grads = {n: p.grad.detach().clone() for n, p in draft.named_parameters() if p.grad is not None}
+
+    draft.zero_grad(set_to_none=True)
+    draft.gradient_checkpointing_enable()
+    torch.manual_seed(123)
+    ckpt = trainer(**batch)
+    ckpt.loss.backward()
+    ckpt_grads = {n: p.grad.detach().clone() for n, p in draft.named_parameters() if p.grad is not None}
+
+    torch.testing.assert_close(ckpt.loss, base.loss, rtol=1e-4, atol=1e-5)
+    assert ckpt.valid_tokens.item() == base.valid_tokens.item()
+    assert set(ckpt_grads) == set(base_grads)
+    assert base_grads, "expected non-empty gradients"
+    for name in base_grads:
+        torch.testing.assert_close(ckpt_grads[name], base_grads[name], rtol=1e-3, atol=1e-4)


### PR DESCRIPTION
## What

Adds an opt-in activation (gradient) checkpointing knob to the EAGLE-3 draft model. When enabled, each P-EAGLE draft layer is recomputed in the backward pass instead of keeping its activations resident, lowering the activation-memory peak of the long flattened COD (chain-of-draft) sequence. It complements `sequence_partitions`: that knob slices the sequence in time (one segment resident at a time), this one trades a recompute for the per-layer activation storage along depth. The two stack.

## Why

P-EAGLE flattens all `num_depths` COD depths into one long parallel-drafting sequence, so the draft forward's activation footprint grows with depth and sequence length. On larger targets / longer sequences this is the memory wall (the draft itself is small; it is the activations that OOM). `sequence_partitions` alone is a single-rank time-slice; activation checkpointing is the orthogonal depth-axis lever and the standard tool for exactly this.

## How

* `LlamaEagle3DraftModel` gains `gradient_checkpointing_enable()` / `gradient_checkpointing_disable()` and a `gradient_checkpointing` flag (off by default, training-only, never serialized into the draft `config.json`, mirroring how `sequence_partitions` is treated).
* `_PeagleDraftMixin.forward_peagle` routes every draft layer through a small `_run_draft_layer` helper that wraps the call in `torch.utils.checkpoint.checkpoint(..., use_reentrant=False)` when the flag is set and the module is training. `use_reentrant=False` is required so the non-tensor `block_mask` passes through and the recompute composes with the flex-attention path.
* Scope: only the parallel-drafting `forward_peagle` path. The standard EAGLE-3 single-layer TTT `forward()` is intentionally left unchanged (one layer is little benefit, and its stateful `cache_hidden` recurrence does not compose with recompute).
* Recipe arg `draft_gradient_checkpointing` wires it through `train_eagle3`.

## Usage

```yaml
recipe_args:
  parallel_drafting: true
  draft_gradient_checkpointing: true   # off by default
```

## Tests

`tests/unit_tests/speculative/test_peagle.py`:
* CPU: flag default/toggle; `_run_draft_layer` recomputes only when enabled AND training (call-count), and is numerically equal (output + input grad) to the direct path; `forward_peagle` routes every layer through the helper (flex-free stubbed layers).
* CUDA-gated: on the real flex-attention forward, checkpointing reproduces the uncheckpointed loss, valid-token count, and per-parameter gradients exactly (up to float summation order).

ruff lint/format clean; `/simplify` applied.

Signed-off-by: khazic <khazzz1c@gmail.com>