### PR TITLE
fix(speculative): release the EAGLE-3 target/W&B on any training exit

### DIFF
--- a/nemo_automodel/recipes/llm/train_eagle3.py
+++ b/nemo_automodel/recipes/llm/train_eagle3.py
@@ -119,6 +119,15 @@ def _all_reduce_mean(value: torch.Tensor) -> torch.Tensor:
     return value
 
 
+def _best_effort(label: str, fn) -> None:
+    """Run a teardown step, logging (never raising) on failure so one failed step
+    does not abort the rest of cleanup."""
+    try:
+        fn()
+    except Exception:
+        logger.exception("error %s during cleanup", label)
+
+
 class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
     """Recipe for EAGLE-3 training on Llama-style dense LLMs (Llama, Phi-3, Qwen3) and MoE backbones (Qwen3-MoE)."""
 
@@ -934,6 +943,7 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
         if start_epoch >= self.num_epochs:
             if self.dist_env.is_main:
                 logger.info("All %d epochs already completed; nothing to do.", self.num_epochs)
+            self._finalize_training()
             return
         if self.dist_env.is_main:
             logger.info(
@@ -950,6 +960,36 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
                 self.min_lr_ratio,
             )
 
+        try:
+            self._train_epochs(start_epoch, batches_per_epoch, is_ddp)
+            self._maybe_save_final_checkpoint(self.num_epochs)
+            if self.dist_env.is_main:
+                logger.info("Training complete: global_step=%s", self.runtime.global_step)
+        finally:
+            self._finalize_training()
+
+    def _finalize_training(self) -> None:
+        """Release training resources on any exit path (normal, early-return, or
+        exception). Best-effort: each step is guarded so a failure in one does not
+        block the others.
+
+        The high-value step is disconnecting the remote target. Without it a
+        mid-training crash leaves the long-lived target server with a stale
+        client-idle state and a half-open NCCL transport, so the next run cannot
+        connect. ``close()`` is a no-op for the co-located backend. The process
+        group is intentionally left alone -- it is a framework-global resource
+        that direct callers (tests, the interactive launcher) reuse after the
+        loop returns, and ``initialize_distributed`` already destroys it at
+        process exit.
+        """
+        if getattr(self, "target_wrapper", None) is not None:
+            _best_effort("closing target backend", self.target_wrapper.close)
+        if getattr(self, "wandb_run", None) is not None:
+            _best_effort("finishing W&B run", self.wandb_run.finish)
+
+    def _train_epochs(self, start_epoch, batches_per_epoch, is_ddp):
+        """Run the epoch loop (extracted so :meth:`run_train_validation_loop` can
+        wrap it in ``try/finally`` and guarantee teardown on any exit path)."""
         for epoch in range(start_epoch, self.num_epochs):
             if hasattr(self.train_dataloader.sampler, "set_epoch"):
                 self.train_dataloader.sampler.set_epoch(epoch)
@@ -1120,19 +1160,6 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
                     best_metric_key="val_loss",
                 )
                 self._log_saved_checkpoint("epoch", epoch + 1, self.runtime.global_step)
-
-        self._maybe_save_final_checkpoint(self.num_epochs)
-
-        if self.target_wrapper is not None:
-            # Release remote connections / shut down the target server's
-            # client-idle watchdog. A no-op for the co-located backend.
-            self.target_wrapper.close()
-
-        if getattr(self, "wandb_run", None) is not None:
-            self.wandb_run.finish()
-
-        if self.dist_env.is_main:
-            logger.info("Training complete: global_step=%s", self.runtime.global_step)
 
 
 def main(config_path=None):

--- a/tests/unit_tests/recipes/llm/test_train_eagle3_cleanup.py
+++ b/tests/unit_tests/recipes/llm/test_train_eagle3_cleanup.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Teardown guarantees for the EAGLE-3 training loop.
+
+``run_train_validation_loop`` must release training resources (disconnect the
+remote target, finish the W&B run, destroy the process group) on *any* exit
+path, not just normal completion. A mid-training exception that skipped the
+remote-target ``close()`` would otherwise leave the long-lived target server
+with a stale client-idle state and a half-open NCCL transport.
+"""
+
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from nemo_automodel.recipes.llm.train_eagle3 import TrainEagle3Recipe
+
+
+def _make_recipe(**overrides) -> TrainEagle3Recipe:
+    """A minimal recipe with just the attributes the train loop reads (no setup)."""
+    r = TrainEagle3Recipe.__new__(TrainEagle3Recipe)
+    r.trainer_module = mock.MagicMock()
+    dataloader = mock.MagicMock()
+    dataloader.__len__.return_value = 4
+    r.train_dataloader = dataloader
+    r.num_epochs = 1
+    r._resume_epoch = 0
+    r.dist_env = SimpleNamespace(is_main=True)
+    r.target_wrapper = mock.MagicMock()
+    r.wandb_run = mock.MagicMock()
+    r.runtime = SimpleNamespace(global_step=0)
+    r.grad_accumulation_steps = 1
+    r.log_every_steps = 1
+    r.total_optim_steps = 4
+    r.warmup_steps = 0
+    r.peak_lr = 1e-4
+    r.min_lr_ratio = 0.1
+    r._maybe_save_final_checkpoint = mock.MagicMock()
+    for key, value in overrides.items():
+        setattr(r, key, value)
+    return r
+
+
+def test_run_loop_finalizes_on_exception():
+    """A mid-training exception still releases the target/W&B (and re-raises)."""
+    recipe = _make_recipe()
+    recipe._train_epochs = mock.MagicMock(side_effect=RuntimeError("boom"))
+    with pytest.raises(RuntimeError, match="boom"):
+        recipe.run_train_validation_loop()
+    recipe.target_wrapper.close.assert_called_once()
+    recipe.wandb_run.finish.assert_called_once()
+    # The final checkpoint is success-only and must NOT be written after a crash.
+    recipe._maybe_save_final_checkpoint.assert_not_called()
+
+
+def test_run_loop_finalizes_on_success():
+    """Normal completion saves the final checkpoint and releases resources."""
+    recipe = _make_recipe()
+    recipe._train_epochs = mock.MagicMock()
+    recipe.run_train_validation_loop()
+    recipe._train_epochs.assert_called_once()
+    recipe._maybe_save_final_checkpoint.assert_called_once_with(1)
+    recipe.target_wrapper.close.assert_called_once()
+    recipe.wandb_run.finish.assert_called_once()
+
+
+def test_early_return_finalizes():
+    """The 'all epochs already completed' resume path also releases resources."""
+    recipe = _make_recipe(_resume_epoch=5, num_epochs=1)
+    recipe._train_epochs = mock.MagicMock()
+    recipe.run_train_validation_loop()
+    recipe._train_epochs.assert_not_called()
+    recipe.target_wrapper.close.assert_called_once()
+    recipe.wandb_run.finish.assert_called_once()
+
+
+def test_finalize_is_best_effort():
+    """A failure in one teardown step does not block the others."""
+    recipe = _make_recipe()
+    recipe.target_wrapper.close.side_effect = RuntimeError("server gone")
+    recipe._finalize_training()  # must not raise
+    recipe.wandb_run.finish.assert_called_once()
+
+
+def test_finalize_handles_missing_backends():
+    """The cached backend has no target_wrapper and W&B may be disabled (None)."""
+    recipe = _make_recipe(target_wrapper=None, wandb_run=None)
+    recipe._finalize_training()  # no error, no calls to make

--- a/tests/unit_tests/recipes/llm/test_train_eagle3_cleanup.py
+++ b/tests/unit_tests/recipes/llm/test_train_eagle3_cleanup.py
@@ -15,8 +15,8 @@
 """Teardown guarantees for the EAGLE-3 training loop.
 
 ``run_train_validation_loop`` must release training resources (disconnect the
-remote target, finish the W&B run, destroy the process group) on *any* exit
-path, not just normal completion. A mid-training exception that skipped the
+remote target, finish the W&B run) on *any* exit path, not just normal
+completion. A mid-training exception that skipped the
 remote-target ``close()`` would otherwise leave the long-lived target server
 with a stale client-idle state and a half-open NCCL transport.
 """


### PR DESCRIPTION
## Problem

`TrainEagle3Recipe.run_train_validation_loop` released the remote target (`target_wrapper.close()`) and finished the W&B run **only after the epoch loop completed normally** ([train_eagle3.py](nemo_automodel/recipes/llm/train_eagle3.py)). Any mid-training exception (a step, backward, eval, or checkpoint failure) propagated out and skipped that cleanup. Nothing higher up catches it (`_AsyncHandle.result()` re-raises).

For the **remote target backend** this has real teeth: `close()` sends the disconnect that resets the server's client-idle watchdog and destroys the client NCCL transport. Skipping it leaves the long-lived target server with a stale client-connected state and a half-open NCCL group, so the next run cannot connect (or hangs) until the server is manually restarted. For the co-located backend `close()` is a no-op.

## Fix

Extract the epoch loop into `_train_epochs()` and wrap its call in `try/finally`. A best-effort `_finalize_training()` runs on every exit path (normal completion, the resume early-return, and exceptions):

* `target_wrapper.close()` (the high-value step: disconnect the remote target).
* `wandb_run.finish()`.

Each step is guarded (`_best_effort`) so a failure in one does not block the others. The success-only `_maybe_save_final_checkpoint` stays inside the `try` so it is not written after a crash.

### Deliberately out of scope

* **Process group teardown.** `_finalize_training` does **not** call `dist.destroy_process_group()`. The process group is a framework-global resource that direct callers (the unit-test suites and the interactive launcher) reuse after `run_train_validation_loop` returns, and `initialize_distributed` already destroys it via an atexit handler. Destroying it here would be redundant and could break those callers.
* **Sibling recipes.** The same latent gap exists in other recipes (e.g. `train_ft` only guards its progress bar). A base-class teardown hook is the right generalization but is a larger, riskier change across five recipes; this PR keeps to the acute EAGLE-3 remote-target case.

## Tests

`tests/unit_tests/recipes/llm/test_train_eagle3_cleanup.py` (CPU, hand-built minimal recipe):

* `test_run_loop_finalizes_on_exception`: a mid-training exception still closes the target and finishes W&B, re-raises, and does **not** write the final checkpoint.
* `test_run_loop_finalizes_on_success`: normal completion saves the final checkpoint and releases resources.
* `test_early_return_finalizes`: the "all epochs already completed" resume path also releases resources.
* `test_finalize_is_best_effort`: a failing `close()` does not block `wandb finish()`.
* `test_finalize_handles_missing_backends`: cached backend (no target_wrapper) / W&B disabled (None) is a no-op.

Existing EAGLE-3 recipe suites (resume, step-checkpoint, flush) stay green; ruff clean; `/simplify` applied.

Signed-off-by: khazic <khazzz1c@gmail.com>