### PR TITLE
fix(speculative): drop position 0 from P-EAGLE depth-1 candidate pool

### DIFF
--- a/nemo_automodel/components/speculative/eagle/peagle_data.py
+++ b/nemo_automodel/components/speculative/eagle/peagle_data.py
@@ -48,8 +48,10 @@ def generate_cod_sample_indices(
         num_depths: Number of parallel prediction depths ``K``.
         down_sample_ratio: Geometric decay ratio ``r in (0, 1]``.
         down_sample_ratio_min: Minimum retention ratio floor.
-        filter_position_zero: Drop position 0 from the deeper-depth candidate pool
-            (it has no preceding token to predict).
+        filter_position_zero: Drop position 0 from every depth>=1 candidate pool
+            (it has no preceding token to predict, so its chain-start anchor
+            would be negative). Keep True unless the caller guarantees
+            ``loss_mask[0] == 0``.
 
     Returns:
         Tuple of:
@@ -66,6 +68,16 @@ def generate_cod_sample_indices(
     sample_indices = [torch.arange(seq_length, device=device)]
     n_per_depth = [seq_length]
     prev_indices = all_valid_indices
+    if filter_position_zero:
+        # Position 0 has no preceding token, so it cannot be a meaningful
+        # depth>=1 reference: its chain start ``anchor_pos = sampled_idx - d``
+        # would be negative. The deeper-depth pool already drops it below (the
+        # ``next_candidates`` filter), but the initial depth-1 pool is seeded
+        # straight from ``all_valid_indices`` -- so without this a supervised
+        # position 0 (``loss_mask[0] == 1``) leaks ``anchor_pos == -1`` into the
+        # output, and the mask later indexes ``document_ids[-1]`` via Python's
+        # negative wraparound, silently breaking cross-document isolation.
+        prev_indices = prev_indices[prev_indices != 0]
 
     for d in range(1, num_depths):
         valid_length = max(0, all_valid_indices.shape[0] - d)

--- a/tests/unit_tests/speculative/test_peagle.py
+++ b/tests/unit_tests/speculative/test_peagle.py
@@ -156,6 +156,29 @@ def test_cod_filters_unsupervised_positions_from_deeper_depths():
     assert torch.all(orig[depth >= 1] < 8)
 
 
+def test_cod_supervised_position_zero_does_not_leak_negative_anchor():
+    """A supervised position 0 must not produce ``anchor_pos == -1``.
+
+    The depth-1 pool is seeded straight from ``all_valid_indices``; if position 0
+    is supervised it could be sampled, and its chain start ``anchor_pos = 0 - 1``
+    is negative. The mask then indexes ``document_ids[-1]`` via Python's negative
+    wraparound, silently breaking cross-document isolation. ``filter_position_zero``
+    (default) must drop it from every depth>=1 pool, not just the deeper ones.
+    """
+    seq_len, num_depths = 16, 8
+    loss_mask = torch.ones(1, seq_len, dtype=torch.long)  # position 0 IS supervised
+    # Stress several seeds: with the bug, any draw that picks position 0 at
+    # depth 1 leaks anchor_pos == -1. The fix makes min >= 0 a hard invariant.
+    for seed in range(8):
+        torch.manual_seed(seed)
+        anchor_pos, depth = generate_cod_sample_indices(
+            seq_length=seq_len, loss_mask=loss_mask, num_depths=num_depths, down_sample_ratio=0.9
+        )
+        assert int(anchor_pos.min()) >= 0
+        # Depth 0 still spans the full sequence (the filter only touches depth>=1).
+        assert int((depth == 0).sum()) == seq_len
+
+
 # --------------------------------------------------------------------------- #
 # Sequence partitioning (Algorithm 1)
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Problem

`generate_cod_sample_indices` seeds the depth-1 candidate pool straight from `all_valid_indices`. When position 0 is a supervised token (`loss_mask[0] == 1`) it can be sampled at depth 1, and its chain start `anchor_pos = sampled_idx - 1` becomes `-1`.

`create_peagle_mask_mod` then evaluates `document_ids[q_anchor_pos]` with that `-1`, which Python resolves via negative wraparound to the last position's document id. Queries can attend across document boundaries, silently breaking the P-EAGLE cross-document isolation the mask is meant to enforce.

## Root cause

`filter_position_zero` is meant to drop position 0 (it has no preceding token to predict), but the implementation only filtered the deeper-depth `next_candidates` pool. The initial depth-1 pool was seeded directly from `all_valid_indices` and never filtered, so a supervised position 0 leaked through.

## Fix

Apply `filter_position_zero` to the initial pool too, so `anchor_pos >= 0` becomes a hard invariant whenever the flag is set (the default). Depth 0 is unaffected: it spans the full sequence and anchors on the position itself, so `document_ids[0]` is always valid.

## Test

Adds `test_cod_supervised_position_zero_does_not_leak_negative_anchor`: with `loss_mask[0] == 1` and the default `filter_position_zero`, it asserts `anchor_pos.min() >= 0` across several seeds. The bug produced `-1`; the test was confirmed to fail without the fix and pass with it. The rest of `test_peagle.py` stays green.
