### PR TITLE
fix(speculative): re-sync the target vocab mapping on EAGLE-3 resume

### DIFF
--- a/nemo_automodel/recipes/llm/train_eagle3.py
+++ b/nemo_automodel/recipes/llm/train_eagle3.py
@@ -896,6 +896,16 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
                 module = self._module()
                 module.selected_token_ids.copy_(ids.to(module.selected_token_ids.device))
                 module.selected_token_mask.copy_(mask.to(module.selected_token_mask.device))
+                # set_vocab_mapping was already called at setup() with the
+                # freshly-scanned mapping, but resume can restore a different one
+                # (the checkpoint's, e.g. when the data / split / cache changed).
+                # Re-apply it so the draft's d2t/t2d tables and -- the actual bug
+                # -- the remote target server (which projects to the draft vocab
+                # itself) match the checkpoint, not the setup-time scan. Colocated
+                # set_vocab_mapping is a no-op; the cached path has no target.
+                self.draft_model.set_vocab_mapping(module.selected_token_ids)
+                if getattr(self, "target_wrapper", None) is not None:
+                    self.target_wrapper.set_vocab_mapping(module.selected_token_ids, module.selected_token_mask)
 
     def _run_eval(self):
         if self.val_dataloader is None:

--- a/tests/unit_tests/recipes/llm/test_eagle3_resume_vocab_mapping.py
+++ b/tests/unit_tests/recipes/llm/test_eagle3_resume_vocab_mapping.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``_load_extra_state`` must re-apply the restored vocab mapping on resume.
+
+setup() pushes the freshly-scanned draft-vocab mapping to the draft and (for a
+remote target) the server. A resumed checkpoint may carry a different mapping;
+after restoring it onto the trainer module, the recipe must re-push it so the
+draft d2t/t2d tables and the remote server match the checkpoint, not the stale
+setup-time scan. Otherwise the server keeps projecting full-vocab logits with
+the old mapping while the draft trains against the new one -- a silent mismatch.
+"""
+
+from types import SimpleNamespace
+
+import torch
+
+from nemo_automodel.recipes.llm.train_eagle3 import TrainEagle3Recipe
+
+
+def _write_meta(tmp_path, ids, mask):
+    torch.save(
+        {"global_step": 7, "epoch": 2, "selected_token_ids": ids, "selected_token_mask": mask},
+        tmp_path / "eagle_meta.pt",
+    )
+
+
+def _bare_recipe(module, draft_model, target_wrapper):
+    recipe = TrainEagle3Recipe.__new__(TrainEagle3Recipe)
+    recipe._module = lambda: module
+    recipe.runtime = SimpleNamespace(global_step=0)
+    recipe.draft_model = draft_model
+    recipe.target_wrapper = target_wrapper
+    return recipe
+
+
+def test_resume_reapplies_vocab_mapping_to_draft_and_target(tmp_path):
+    ids = torch.tensor([1, 3, 5], dtype=torch.long)
+    mask = torch.zeros(8, dtype=torch.bool)
+    mask[ids] = True
+    _write_meta(tmp_path, ids, mask)
+
+    module = SimpleNamespace(
+        selected_token_ids=torch.zeros(3, dtype=torch.long),
+        selected_token_mask=torch.zeros(8, dtype=torch.bool),
+    )
+    draft_calls = []
+    target_calls = []
+    draft_model = SimpleNamespace(set_vocab_mapping=lambda i: draft_calls.append(i))
+    target_wrapper = SimpleNamespace(set_vocab_mapping=lambda i, m: target_calls.append((i, m)))
+    recipe = _bare_recipe(module, draft_model, target_wrapper)
+
+    recipe._load_extra_state(str(tmp_path))
+
+    # meta restored onto the trainer module
+    assert recipe.runtime.global_step == 7
+    assert recipe._resume_epoch == 2
+    assert torch.equal(module.selected_token_ids, ids)
+    # and re-pushed to both the draft and the (remote) target, with the restored ids
+    assert len(draft_calls) == 1 and torch.equal(draft_calls[0], ids)
+    assert len(target_calls) == 1
+    assert torch.equal(target_calls[0][0], ids) and torch.equal(target_calls[0][1], mask)
+
+
+def test_resume_without_target_wrapper_does_not_crash(tmp_path):
+    """The cached/offline path has target_wrapper=None; re-applying must be safe."""
+    ids = torch.tensor([2, 4, 6], dtype=torch.long)
+    mask = torch.zeros(8, dtype=torch.bool)
+    mask[ids] = True
+    _write_meta(tmp_path, ids, mask)
+
+    module = SimpleNamespace(
+        selected_token_ids=torch.zeros(3, dtype=torch.long),
+        selected_token_mask=torch.zeros(8, dtype=torch.bool),
+    )
+    draft_calls = []
+    draft_model = SimpleNamespace(set_vocab_mapping=lambda i: draft_calls.append(i))
+    recipe = _bare_recipe(module, draft_model, target_wrapper=None)
+
+    recipe._load_extra_state(str(tmp_path))  # must not raise
+
+    assert torch.equal(module.selected_token_ids, ids)
+    assert len(draft_calls) == 1

--- a/tests/unit_tests/recipes/llm/test_eagle_checkpoint_resume.py
+++ b/tests/unit_tests/recipes/llm/test_eagle_checkpoint_resume.py
@@ -65,6 +65,9 @@ class _FakeDraftModel(nn.Module):
         super().__init__()
         self.layer = nn.Linear(4, 4)
 
+    def set_vocab_mapping(self, selected_token_ids):
+        pass
+
 
 class _FakeEagle1TrainerModule(nn.Module):
     def __init__(self):
@@ -104,6 +107,8 @@ def _bare_eagle3_recipe(tmp_path) -> TrainEagle3Recipe:
     recipe.tokenizer = None
     recipe.dist_env = SimpleNamespace(is_main=True, world_size=1)
     recipe.trainer_module = _FakeEagle3TrainerModule()
+    recipe.draft_model = recipe.trainer_module.draft_model
+    recipe.target_wrapper = None
     recipe.optimizer = torch.optim.AdamW(recipe.trainer_module.parameters(), lr=1e-4)
     recipe.lr_scheduler = torch.optim.lr_scheduler.LambdaLR(recipe.optimizer, lambda s: 1.0)
     recipe.runtime = SimpleNamespace(global_step=0)


### PR DESCRIPTION
## Problem

EAGLE-3 `setup()` pushes the freshly-scanned draft-vocab mapping to the draft and, for a
remote target, to the server via `set_vocab_mapping` (`train_eagle3.py:221` / `:416`).
`load_checkpoint()` then runs `_load_extra_state`, which overwrites the trainer module's
`selected_token_ids`/`selected_token_mask` with the checkpoint's, **but never re-pushed that
mapping**.

So on resume the trainer/draft use the checkpoint mapping while the **remote server keeps
the setup-time scan**. With the same data/config the scan is deterministic, so they agree;
but if the data, split, or `selected_token_ids` cache changed at resume, the server projects
full-vocab logits to the draft vocab with the *stale* mapping while the draft trains against
the *new* one. That is a silent supervision mismatch (no error, just wrong gradients).

Colocated is unaffected: it returns full-vocab logits and the trainer projects them with its
own (already-restored) `selected_token_ids`.

## Fix

After `_load_extra_state` restores `selected_token_ids`/`selected_token_mask`, re-apply
`set_vocab_mapping` to the draft and (when present) the target wrapper:

```python
self.draft_model.set_vocab_mapping(module.selected_token_ids)
if getattr(self, "target_wrapper", None) is not None:
    self.target_wrapper.set_vocab_mapping(module.selected_token_ids, module.selected_token_mask)
```

Colocated `set_vocab_mapping` is a no-op; the remote backend re-syncs the server to the
checkpoint mapping; the cached/offline path has no `target_wrapper` and is guarded.

## Test

`tests/unit_tests/recipes/llm/test_eagle3_resume_vocab_mapping.py` asserts resume re-pushes
the restored mapping to both the draft and the target, and that a `None` target wrapper (the
cached path) does not crash. The existing resume tests are updated to wire a `draft_model` /
`target_wrapper` onto the bare recipe. CPU-only.
