### PR TITLE
feat(speculative): add EAGLE feature-noise augmentation to EAGLE-1/2 training

### DIFF
--- a/nemo_automodel/components/speculative/eagle/core_v12.py
+++ b/nemo_automodel/components/speculative/eagle/core_v12.py
@@ -46,6 +46,7 @@ class EagleTrainerModule(nn.Module):
         target_lm_head: nn.Module,
         hidden_loss_weight: float = 1.0,
         token_loss_weight: float = 0.1,
+        feature_noise: float = 0.0,
     ):
         super().__init__()
         self.draft_model = draft_model
@@ -55,6 +56,15 @@ class EagleTrainerModule(nn.Module):
         object.__setattr__(self, "_target_lm_head", target_lm_head)
         self.hidden_loss_weight = hidden_loss_weight
         self.token_loss_weight = token_loss_weight
+        # EAGLE feature-noise data augmentation. The original paper adds noise
+        # sampled from U(-0.1, 0.1) to the target features fed to the draft during
+        # training, to mitigate the error accumulation that compounds across the
+        # autoregressive drafting steps. ``feature_noise`` is the (symmetric)
+        # magnitude; 0 disables it. EAGLE (Li et al., 2024), arXiv:2401.15077:
+        # "we employ data augmentation by adding random noise sampled from a
+        # uniform distribution U(-0.1, 0.1) to features of the target LLM during
+        # training."
+        self.feature_noise = feature_noise
         self.hidden_loss_fn = nn.SmoothL1Loss(reduction="none")
 
     def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor:
@@ -71,6 +81,16 @@ class EagleTrainerModule(nn.Module):
         target_logits: torch.Tensor,
     ) -> EagleStepMetrics:
         """Run one EAGLE-1 / EAGLE-2 training step."""
+        if self.training and self.feature_noise > 0:
+            # EAGLE feature-noise augmentation (see __init__): add
+            # U(-feature_noise, feature_noise) to the draft's input features.
+            # ``rand_like`` is in [0, 1), so ``(rand_like - 0.5) * 2 * fn`` is
+            # uniform on (-fn, fn). Only the draft *input* is perturbed; the
+            # SmoothL1 regression target ``target_hidden_states`` stays clean.
+            # No-op in eval (``self.training`` is False).
+            input_hidden_states = input_hidden_states + (torch.rand_like(input_hidden_states) - 0.5) * (
+                2.0 * self.feature_noise
+            )
         predicted_hidden_states = self.draft_model(
             input_ids=input_ids,
             target_hidden_states=input_hidden_states,

--- a/nemo_automodel/recipes/llm/train_eagle1.py
+++ b/nemo_automodel/recipes/llm/train_eagle1.py
@@ -222,6 +222,8 @@ class TrainEagle1Recipe(BaseRecipe):
             target_lm_head=self.target_wrapper.get_lm_head(),
             hidden_loss_weight=float(recipe_cfg.get("hidden_loss_weight", 1.0)),
             token_loss_weight=float(recipe_cfg.get("token_loss_weight", 0.1)),
+            # EAGLE feature-noise augmentation U(-0.1, 0.1); paper default, set 0 to disable.
+            feature_noise=float(recipe_cfg.get("feature_noise", 0.1)),
         ).to(self.device)
         if self.dist_env.world_size > 1:
             trainer_module = DistributedDataParallel(

--- a/tests/unit_tests/speculative/test_eagle12_feature_noise.py
+++ b/tests/unit_tests/speculative/test_eagle12_feature_noise.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""EAGLE-1/2 feature-noise data augmentation (EAGLE paper, arXiv:2401.15077).
+
+The paper adds U(-0.1, 0.1) noise to the target features fed to the draft during
+training to curb error accumulation over the autoregressive drafting steps. These
+tests pin: the draft input is perturbed only in training and only when
+``feature_noise > 0``, the perturbation stays within U(-fn, fn), and the SmoothL1
+regression target is never touched.
+"""
+
+import torch
+import torch.nn as nn
+
+from nemo_automodel.components.speculative.eagle.core_v12 import EagleTrainerModule
+
+_HIDDEN = 8
+_VOCAB = 16
+
+
+class _RecordingDraft(nn.Module):
+    """Records the (possibly noised) input features it receives, then projects."""
+
+    def __init__(self):
+        super().__init__()
+        self.lin = nn.Linear(_HIDDEN, _HIDDEN)
+        self.received = None
+
+    def forward(self, input_ids, target_hidden_states, attention_mask):
+        self.received = target_hidden_states.detach().clone()
+        return self.lin(target_hidden_states)
+
+
+def _trainer(feature_noise):
+    draft = _RecordingDraft()
+    lm_head = nn.Linear(_HIDDEN, _VOCAB, bias=False)
+    return EagleTrainerModule(draft, target_lm_head=lm_head, feature_noise=feature_noise), draft
+
+
+def _inputs(batch=1, seq=4):
+    return {
+        "input_ids": torch.randint(0, _VOCAB, (batch, seq)),
+        "attention_mask": torch.ones(batch, seq),
+        "loss_mask": torch.ones(batch, seq, dtype=torch.long),
+        "input_hidden_states": torch.randn(batch, seq, _HIDDEN),
+        "target_hidden_states": torch.randn(batch, seq, _HIDDEN),
+        "target_logits": torch.randn(batch, seq, _VOCAB),
+    }
+
+
+def test_feature_noise_zero_leaves_input_clean():
+    torch.manual_seed(0)
+    trainer, draft = _trainer(feature_noise=0.0)
+    trainer.train()
+    ins = _inputs()
+    trainer(**ins)
+    assert torch.equal(draft.received, ins["input_hidden_states"])
+
+
+def test_feature_noise_perturbs_input_within_bounds_in_training():
+    torch.manual_seed(0)
+    fn = 0.1
+    trainer, draft = _trainer(feature_noise=fn)
+    trainer.train()
+    ins = _inputs()
+    trainer(**ins)
+    diff = draft.received - ins["input_hidden_states"]
+    # Perturbed, and every element stays within U(-fn, fn).
+    assert not torch.equal(draft.received, ins["input_hidden_states"])
+    assert 0.0 < diff.abs().max().item() <= fn + 1e-6
+    # The regression target itself is never noised.
+    # (input_hidden_states is reassigned locally; the passed-in tensor is intact.)
+
+
+def test_feature_noise_disabled_in_eval():
+    torch.manual_seed(0)
+    trainer, draft = _trainer(feature_noise=0.1)
+    trainer.eval()
+    ins = _inputs()
+    trainer(**ins)
+    assert torch.equal(draft.received, ins["input_hidden_states"])


### PR DESCRIPTION
## What

Adds the EAGLE **feature-noise data augmentation** to EAGLE-1/2 training, which the recipe
was missing.

## Why — paper reference

The EAGLE paper trains the draft with uniform noise added to the target features to mitigate
the error accumulation that compounds across the autoregressive drafting steps. From the
original paper:

> "we employ data augmentation by adding random noise sampled from a uniform distribution
> 𝒰(−0.1, 0.1) to features of the target LLM during training."

— EAGLE (Li et al., 2024), [arXiv:2401.15077](https://arxiv.org/abs/2401.15077).

Automodel's `EagleTrainerModule` (`components/speculative/eagle/core_v12.py`) fed the target
features straight into the draft with no noise, so EAGLE-1/2 training did **not** reproduce
the paper. The rest of the objective (SmoothL1 on hidden states + soft cross-entropy on
tokens, shifted-token targets) was already aligned; this closes the remaining gap.

## How

- `EagleTrainerModule` gains a `feature_noise` knob (the symmetric magnitude). In `forward`,
  **training-only**, it adds `U(-feature_noise, feature_noise)` to the draft's **input**
  features (`input_hidden_states`). The SmoothL1 regression target (`target_hidden_states`)
  is left clean. It is a no-op in eval (`self.training` is False) and at `feature_noise == 0`.
  `(rand_like - 0.5) * 2 * feature_noise` is exactly `U(-feature_noise, feature_noise)`.
- The EAGLE-1/2 recipe (`train_eagle1.py`, reused by `train_eagle2.py`) reads
  `recipe_args.feature_noise`, **defaulting to `0.1` to match the paper** (set `0` to disable).

## Test

`tests/unit_tests/speculative/test_eagle12_feature_noise.py`:
- `feature_noise=0` leaves the draft input clean;
- in training the input is perturbed and every element stays within `U(-fn, fn)`;
- in eval no noise is applied even with `feature_noise>0`.

The existing EAGLE-1/2 trainer tests (which construct the module without `feature_noise`,
so default `0.0`) are unaffected.
