### PR TITLE
docs(contributing): fix perk typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,22 +168,22 @@ ruff format .
 
 ## Pre-commit
 
-We recommand to use [perk](https://github.com/j178/prek) to ensure code quality. It is a faster and more modern alternative to [pre-commit](https://github.com/pre-commit/pre-commit).
+We recommand to use [prek](https://github.com/j178/prek) to ensure code quality. It is a faster and more modern alternative to [pre-commit](https://github.com/pre-commit/pre-commit).
 
 Installation:
 
 ```bash
-uv tool install perk
+uv tool install prek
 ```
 
 Usage:
 
 ```bash
 # Install git hooks
-perk install
+prek install
 
 # Run manually on all files
-perk run --all-files
+prek run --all-files
 ```
 
 After installing the git hooks, `git commit` will automatically run incremental checks.


### PR DESCRIPTION
# What does this PR do ?

documentation typo fix: `perk` -> `prek`

# Changelog
  - Fixed typo: `perk` → `prek` in Pre-commit section of CONTRIBUTING.md (link text, install command, and usage commands)

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? (Not needed)
- [x] Did you add or update any necessary documentation?