### PR TITLE
fix(speculative): make regenerate clobber guard see existing shards

### DIFF
--- a/nemo_automodel/components/speculative/regenerate.py
+++ b/nemo_automodel/components/speculative/regenerate.py
@@ -378,7 +378,11 @@ async def _run(args: argparse.Namespace) -> int:
     _validate_args(args)
     output_dir = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
-    existing = _existing_shard_indices(output_dir) if args.resume else set()
+    # Always scan for existing shards: without --resume, a non-empty set must
+    # trip the clobber guard below (gating the scan on args.resume would feed
+    # the guard an always-empty set and let a fresh run silently overwrite and
+    # interleave shards from a previous run).
+    existing = _existing_shard_indices(output_dir)
     _ensure_manifest_compatible(
         output_dir,
         _build_manifest(args),

--- a/tests/unit_tests/speculative/test_regenerate.py
+++ b/tests/unit_tests/speculative/test_regenerate.py
@@ -496,6 +496,28 @@ def test_run_resume_skips_already_written_shards(tmp_path: Path, monkeypatch):
     assert (tmp_path / "shard-000000.parquet").stat().st_mtime_ns == shard0_mtime_before
 
 
+def test_run_fresh_into_nonempty_dir_refuses_to_clobber(tmp_path: Path, monkeypatch):
+    """End-to-end: a fresh run (no --resume) against a dir with shards must abort
+    before rewriting the manifest or touching any shard. Guards the _run wiring:
+    the shard scan must not be gated on --resume, or the guard sees an empty set."""
+    from nemo_automodel.components.speculative import regenerate as regen
+
+    (tmp_path / "shard-000000.parquet").write_bytes(b"previous-run-data")
+    monkeypatch.setattr(
+        regen,
+        "_import_aiohttp",
+        lambda: SimpleNamespace(ClientSession=None, ClientTimeout=lambda total=None: None),
+    )
+
+    args = _run_args(tmp_path, resume=False)
+    with pytest.raises(ValueError, match="already contains"):
+        asyncio.run(regen._run(args))
+
+    # Nothing was clobbered: the old shard is intact and no manifest was written.
+    assert (tmp_path / "shard-000000.parquet").read_bytes() == b"previous-run-data"
+    assert not (tmp_path / "manifest.json").exists()
+
+
 class _SequentialSession:
     """Returns a pre-defined sequence of _FakeResponse objects, one per POST call."""
 


### PR DESCRIPTION
# What does this PR do ?

Fixes a data-integrity hole in the EAGLE-3 dataset regeneration CLI: the refuse-to-clobber guard in `_ensure_manifest_compatible` was dead code, because `_run` only scanned for existing shards when `--resume` was passed and therefore always handed the fresh-run branch an empty set.

Consequences before this fix: a fresh run pointed at a non-empty output directory silently rewrote the manifest and overwrote shards by index. If the new run produced fewer shards than the old one, stale high-index shards survived and `ChatDataset`'s directory glob silently mixed samples from two different generation configs, and a later `--resume` considered the leftovers legitimate because the manifest had been rewritten.

The fix scans unconditionally. After the guard passes, a fresh run implies the set is empty, so the downstream resume-skip logic is unchanged.

# Changelog

- `nemo_automodel/components/speculative/regenerate.py`: compute `_existing_shard_indices(output_dir)` unconditionally in `_run` so the fresh-run clobber guard actually fires.
- `tests/unit_tests/speculative/test_regenerate.py`: add an end-to-end test through `_run` asserting a fresh run into a non-empty directory aborts before writing a manifest or touching shards. The existing unit test called `_ensure_manifest_compatible` directly with a hand-built set, which is exactly how the broken wiring stayed green.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

# Additional Information

- Found while reviewing the speculative-decoding components for correctness.