### PR TITLE
fix(speculative): validate config on precompute_eagle3 --resume

### DIFF
--- a/nemo_automodel/components/speculative/precompute_eagle3.py
+++ b/nemo_automodel/components/speculative/precompute_eagle3.py
@@ -52,7 +52,9 @@ from __future__ import annotations
 
 import argparse
 import logging
+import os
 import sys
+from typing import Any
 
 import torch
 
@@ -63,6 +65,8 @@ from nemo_automodel.components.datasets.llm.eagle3_cache import (
     CACHE_KEYS,
     DTYPE_MAP,
     existing_shard_indices,
+    manifest_path,
+    read_manifest,
     write_manifest,
     write_shard,
     write_target_embeddings,
@@ -119,6 +123,38 @@ def _validate_args(args: argparse.Namespace) -> None:
         raise ValueError(f"--dtype must be one of {sorted(DTYPE_MAP)}, got {args.dtype!r}")
 
 
+def _ensure_resume_compatible(cache_dir: str, manifest: dict[str, Any], existing_shards: set[int]) -> None:
+    """Refuse to ``--resume`` into a cache produced with a different configuration.
+
+    Every manifest field shapes the shard contents or their addressing: the
+    ``target_probs`` columns follow ``selected_token_ids`` (which moves with the
+    dataset, shuffle seed, and draft vocab size), sample order follows the
+    dataset, and tensor shapes follow ``seq_length`` / ``dtype``. Shards from a
+    mismatched run are indistinguishable by shape alone, so without this check a
+    resume after changing e.g. ``--input-data`` or ``--shuffle-seed`` would keep
+    the old shards and bless them with the new manifest, silently corrupting the
+    supervision that training reads back.
+    """
+    if not os.path.exists(manifest_path(cache_dir)):
+        if existing_shards:
+            raise ValueError(
+                f"--resume was requested for {cache_dir}, but its manifest is missing, so the existing "
+                "shards cannot be verified against the current configuration. Delete the directory and "
+                "start fresh."
+            )
+        return
+    recorded = read_manifest(cache_dir)
+    recorded.pop("format_version", None)
+    if recorded != manifest:
+        mismatched = sorted(k for k in recorded.keys() | manifest.keys() if recorded.get(k) != manifest.get(k))
+        raise ValueError(
+            f"--resume was requested for {cache_dir}, but the recorded manifest does not match the current "
+            f"run configuration (mismatched fields: {mismatched}). Existing shards would be silently "
+            "inconsistent with newly written ones. Re-run with the original settings, or delete the "
+            "directory and start fresh."
+        )
+
+
 def _run(args: argparse.Namespace) -> int:
     """Load the target, scan the dataset once, and write the sharded cache. Returns an exit code."""
     _validate_args(args)
@@ -173,6 +209,26 @@ def _run(args: argparse.Namespace) -> int:
     selected_token_ids = selected_token_ids.to(device)
     selected_token_mask = selected_token_mask.to(device)
 
+    manifest = {
+        "target_model": args.target_model,
+        "target_vocab_size": target_vocab_size,
+        "draft_vocab_size": int(selected_token_ids.numel()),
+        "seq_length": args.seq_length,
+        "dtype": args.dtype,
+        "num_samples": num_samples,
+        "shard_size": args.shard_size,
+        "aux_hidden_dim": int(target_model.config.hidden_size) * len(target_wrapper.aux_layer_ids),
+        "aux_layer_ids": list(target_wrapper.aux_layer_ids),
+        "selected_token_ids": selected_token_ids.cpu().tolist(),
+    }
+    if args.resume:
+        _ensure_resume_compatible(args.output_dir, manifest, existing)
+    # Written before the shard loop (every field is already known here) so an
+    # interrupted run leaves a manifest behind for the resume check above. An
+    # incomplete cache still cannot be trained on: CachedEagle3Dataset verifies
+    # the shard count against ``num_samples`` before serving any sample.
+    write_manifest(args.output_dir, manifest)
+
     logger.info(
         "Precomputing EAGLE-3 cache: %d samples, shard_size=%d, draft_vocab=%d, dtype=%s -> %s",
         num_samples,
@@ -225,21 +281,6 @@ def _run(args: argparse.Namespace) -> int:
 
     _flush()  # trailing partial shard
 
-    write_manifest(
-        args.output_dir,
-        {
-            "target_model": args.target_model,
-            "target_vocab_size": target_vocab_size,
-            "draft_vocab_size": int(selected_token_ids.numel()),
-            "seq_length": args.seq_length,
-            "dtype": args.dtype,
-            "num_samples": num_samples,
-            "shard_size": args.shard_size,
-            "aux_hidden_dim": int(target_model.config.hidden_size) * len(target_wrapper.aux_layer_ids),
-            "aux_layer_ids": list(target_wrapper.aux_layer_ids),
-            "selected_token_ids": selected_token_ids.cpu().tolist(),
-        },
-    )
     logger.info("Done. Cache written to %s", args.output_dir)
     return 0
 

--- a/tests/unit_tests/speculative/test_eagle3_offline_cache.py
+++ b/tests/unit_tests/speculative/test_eagle3_offline_cache.py
@@ -443,6 +443,52 @@ def test_producer_main_resume_skips_existing_shards(monkeypatch, tmp_path):
     assert os.path.getmtime(shard0) == mtime_before
 
 
+def test_producer_main_resume_rejects_changed_config(monkeypatch, tmp_path):
+    """--resume with a config that no longer matches the recorded manifest must
+    refuse: old shards encode the old selected_token_ids / seq_length and would
+    be silently mixed with shards from the new configuration."""
+    _patch_producer(monkeypatch, num_samples=5, batch_size=2)
+    assert pe.main(_producer_argv(tmp_path)) == 0
+    manifest_before = read_manifest(str(tmp_path))
+
+    # Same data, different seq_length: shard contents would no longer line up.
+    _patch_producer(monkeypatch, num_samples=5, batch_size=2, seq_len=8)
+    argv = [a if a != "6" else "8" for a in _producer_argv(tmp_path, extra=["--resume"])]
+    with pytest.raises(ValueError, match="mismatched fields.*seq_length"):
+        pe.main(argv)
+
+    # The recorded manifest must be untouched by the refused run.
+    assert read_manifest(str(tmp_path)) == manifest_before
+
+
+def test_producer_main_resume_rejects_shards_without_manifest(monkeypatch, tmp_path):
+    """--resume against shards whose manifest is gone cannot verify compatibility."""
+    _patch_producer(monkeypatch, num_samples=5, batch_size=2)
+    assert pe.main(_producer_argv(tmp_path)) == 0
+    os.remove(os.path.join(str(tmp_path), "manifest.json"))
+
+    _patch_producer(monkeypatch, num_samples=5, batch_size=2)
+    with pytest.raises(ValueError, match="manifest is missing"):
+        pe.main(_producer_argv(tmp_path, extra=["--resume"]))
+
+
+def test_producer_writes_manifest_before_shards(monkeypatch, tmp_path):
+    """The manifest must exist before the first shard is written, so a crashed
+    run can be resumed with the compatibility check above."""
+    _patch_producer(monkeypatch, num_samples=5, batch_size=2)
+
+    real_write_shard = pe.write_shard
+    seen = []
+
+    def _spy_write_shard(cache_dir, shard_index, samples):
+        seen.append(os.path.exists(os.path.join(cache_dir, "manifest.json")))
+        return real_write_shard(cache_dir, shard_index, samples)
+
+    monkeypatch.setattr(pe, "write_shard", _spy_write_shard)
+    assert pe.main(_producer_argv(tmp_path)) == 0
+    assert seen and all(seen)
+
+
 # ---------------------------------------------------------------------------
 # Error / edge branches in eagle3_cache and the trainer module.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this PR do ?

Closes a silent-corruption hole in the EAGLE-3 offline cache producer. `--resume` skipped already-present shards but never verified that the current configuration matches the run that produced them, and the manifest was only written at the very end. Resuming after changing `--input-data`, `--shuffle-seed`, `--draft-vocab-size`, `--seq-length`, or `--dtype` therefore kept the old shards and stamped a manifest recording the new configuration over all of them.

This is fully silent: `target_probs` columns follow `selected_token_ids` (which move with the dataset, seed, and vocab size), every tensor shape still matches, and the training recipe trusts only the manifest's `selected_token_ids`. The drafter trains on supervision whose vocabulary mapping is wrong for part of the cache.

# Changelog

- `nemo_automodel/components/speculative/precompute_eagle3.py`: build the full manifest before the shard loop (all fields, including the derived `selected_token_ids`, are already known there); on `--resume`, refuse when it does not match the recorded manifest or when shards exist with no manifest to verify against; write the manifest before the first shard so an interrupted run resumes safely. Training on an incomplete cache still fails fast because `CachedEagle3Dataset` checks the shard count against `num_samples` before serving samples.
- `tests/unit_tests/speculative/test_eagle3_offline_cache.py`: end-to-end tests for the changed-config refusal (recorded manifest left untouched), the shards-without-manifest refusal, and the manifest-before-shards ordering.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

# Additional Information

- Same class of guard that `regenerate.py` already has for its parquet shards; found while reviewing the speculative-decoding components for correctness.