### PR TITLE
fix(speculative): serialize remote EAGLE-3 /generate end to end

### DIFF
--- a/nemo_automodel/components/speculative/eagle/remote/client.py
+++ b/nemo_automodel/components/speculative/eagle/remote/client.py
@@ -66,6 +66,10 @@ class _ServerClient:
         self._nccl: Optional[NCCLTransport] = None
         self._nccl_attempted = False
         self._nccl_lock = threading.Lock()
+        # Serializes generate() per server; see its docstring. The executor in
+        # RemoteEagle3TargetModel has more workers than servers, so this lock,
+        # not the pool size, enforces the one-in-flight invariant.
+        self._generate_lock = threading.Lock()
 
     def _host(self) -> str:
         return self.url.split("://", 1)[-1].split(":", 1)[0].split("/", 1)[0]
@@ -129,20 +133,27 @@ class _ServerClient:
             return True
 
     def generate(self, payload: bytes) -> dict[str, Optional[torch.Tensor]]:
-        """POST /generate and return the supervision tensors (NCCL or wire)."""
-        if self._nccl_enabled and not self._nccl_attempted:
-            self._init_nccl()
-        headers = {"Content-Type": "application/octet-stream"}
-        use_nccl = self._nccl is not None and self._nccl.is_initialized
-        if use_nccl:
-            headers[protocol.NCCL_HEADER] = "1"
-        url = f"{self.url}/{protocol.EP_GENERATE}"
-        resp = self._session.post(url, data=payload, timeout=self.timeout, headers=headers)
-        resp.raise_for_status()
-        if resp.headers.get(protocol.NCCL_HEADER) == "1" and use_nccl:
-            keys_order, metadata = protocol.decode_nccl_metadata(resp.content)
-            return self._nccl.recv_tensors(metadata, keys_order)
-        return wire.decode(resp.content, map_location="cpu")
+        """POST /generate and return the supervision tensors (NCCL or wire).
+
+        Serialized on ``_generate_lock`` so this process never has two
+        /generate requests in flight against the same server: the NCCL recv
+        posted here must pair with this request's send, and the server's
+        hook-based aux capture is not reentrant.
+        """
+        with self._generate_lock:
+            if self._nccl_enabled and not self._nccl_attempted:
+                self._init_nccl()
+            headers = {"Content-Type": "application/octet-stream"}
+            use_nccl = self._nccl is not None and self._nccl.is_initialized
+            if use_nccl:
+                headers[protocol.NCCL_HEADER] = "1"
+            url = f"{self.url}/{protocol.EP_GENERATE}"
+            resp = self._session.post(url, data=payload, timeout=self.timeout, headers=headers)
+            resp.raise_for_status()
+            if resp.headers.get(protocol.NCCL_HEADER) == "1" and use_nccl:
+                keys_order, metadata = protocol.decode_nccl_metadata(resp.content)
+                return self._nccl.recv_tensors(metadata, keys_order)
+            return wire.decode(resp.content, map_location="cpu")
 
     def close(self) -> None:
         try:

--- a/nemo_automodel/components/speculative/eagle/remote/server.py
+++ b/nemo_automodel/components/speculative/eagle/remote/server.py
@@ -100,6 +100,16 @@ class TargetModelServer:
         self._nccl_enabled = os.environ.get("NEMO_EAGLE_ENABLE_NCCL", "1") == "1"
         self._nccl: Optional[NCCLTransport] = None
         self._pending_nccl_send: Optional[tuple[dict, list[str]]] = None
+        # ``ThreadingHTTPServer`` handles requests concurrently, but /generate
+        # is not reentrant: the supervision forward captures aux hidden states
+        # through hooks registered on the shared model, and the NCCL path
+        # stages tensors in the single ``_pending_nccl_send`` slot above.
+        # Concurrent requests (multiple training ranks, or a client whose
+        # prefetcher overlaps) would silently receive each other's tensors,
+        # so the HTTP handler serializes the whole generate-and-flush sequence
+        # on this lock. ``set_vocab_mapping`` shares it because it swaps the
+        # tensors the generate forward reads.
+        self._generate_lock = threading.Lock()
         # Lifecycle: a watchdog shuts the server down once the client goes away
         # so a finished training run does not leave a GPU-pinned server process.
         self._shutdown_event = threading.Event()
@@ -114,6 +124,10 @@ class TargetModelServer:
     @property
     def shutdown_event(self) -> threading.Event:
         return self._shutdown_event
+
+    @property
+    def generate_lock(self) -> threading.Lock:
+        return self._generate_lock
 
     # -- handlers (return the HTTP response body as bytes) --
 
@@ -239,17 +253,30 @@ def _make_request_handler(server_logic: TargetModelServer):
             try:
                 if endpoint == protocol.EP_GENERATE:
                     wants_nccl = self.headers.get(protocol.NCCL_HEADER) == "1"
-                    body, used_nccl = server_logic.handle_generate(raw, client_wants_nccl=wants_nccl)
-                    headers = {protocol.NCCL_HEADER: "1"} if used_nccl else None
-                    ctype = "application/json" if used_nccl else "application/octet-stream"
-                    self._send(body, content_type=ctype, extra_headers=headers)
-                    if used_nccl:
-                        # Send tensors only after the HTTP response is flushed so
-                        # the client has the metadata and can post its recv.
-                        self.wfile.flush()
-                        server_logic.flush_nccl_send()
+                    # Exclusive end-to-end: see the ``_generate_lock`` comment in
+                    # ``TargetModelServer.__init__``.
+                    with server_logic.generate_lock:
+                        body, used_nccl = server_logic.handle_generate(raw, client_wants_nccl=wants_nccl)
+                        headers = {protocol.NCCL_HEADER: "1"} if used_nccl else None
+                        ctype = "application/json" if used_nccl else "application/octet-stream"
+                        self._send(body, content_type=ctype, extra_headers=headers)
+                        if used_nccl:
+                            # Send tensors only after the HTTP response is flushed so
+                            # the client has the metadata and can post its recv.
+                            self.wfile.flush()
+                            try:
+                                server_logic.flush_nccl_send()
+                            except Exception:
+                                # The 200 response is already on the wire; writing a
+                                # 500 now would be parsed as the response to the NEXT
+                                # request on this keep-alive connection. Drop the
+                                # connection instead (flush_nccl_send already logged
+                                # and disabled NCCL for subsequent requests).
+                                self.close_connection = True
                 elif endpoint == protocol.EP_SET_VOCAB_MAPPING:
-                    self._send(server_logic.handle_set_vocab_mapping(raw), content_type="application/json")
+                    with server_logic.generate_lock:
+                        body = server_logic.handle_set_vocab_mapping(raw)
+                    self._send(body, content_type="application/json")
                 elif endpoint == protocol.EP_MODEL_INFO:
                     self._send(server_logic.handle_model_info(raw), content_type="application/json")
                 elif endpoint == protocol.EP_INPUT_EMBEDDINGS:

--- a/nemo_automodel/recipes/llm/train_eagle3.py
+++ b/nemo_automodel/recipes/llm/train_eagle3.py
@@ -609,8 +609,14 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
         fill()
         while queue:
             batch, handle = queue.popleft()
-            fill()  # refill before blocking on the result to keep the pipe full
-            yield batch, handle.result()
+            target_batch = handle.result()
+            # Refill only after the popped request completed: round-robin makes
+            # its server the next dispatch target, so refilling before the
+            # result would put a second request in flight on a busy server and
+            # break the one-in-flight-per-server invariant that NCCL recv
+            # ordering and the server's hook-based aux capture rely on.
+            fill()
+            yield batch, target_batch
 
     def _build_checkpointer(self, target_path: str) -> None:
         """Build the checkpointer using the same plumbing as the standard recipes."""

--- a/tests/unit_tests/speculative/test_eagle3_remote.py
+++ b/tests/unit_tests/speculative/test_eagle3_remote.py
@@ -266,3 +266,154 @@ def test_prefetched_batches_preserves_order_and_prefetches_ahead():
         seen.append(target_batch)
 
     assert seen == [0, 1, 2, 3, 4]  # consumed strictly in dataloader order
+
+
+class _InflightBackend:
+    """Async backend stub tracking how many requests are in flight at once."""
+
+    def __init__(self):
+        self.inflight = 0
+        self.max_inflight = 0
+
+    def generate_batch_async(self, input_ids, attention_mask, loss_mask):
+        self.inflight += 1
+        self.max_inflight = max(self.max_inflight, self.inflight)
+        backend = self
+
+        class _H:
+            def result(self_inner, timeout=None):
+                backend.inflight -= 1
+                return int(input_ids[0, 0].item())
+
+        return _H()
+
+
+def test_prefetched_batches_never_exceeds_depth_in_flight():
+    """The prefetcher must hold at most ``depth`` requests in flight. With depth
+    capped to the server count, one extra request means some server runs two
+    concurrent /generate forwards, which corrupts the hook-captured supervision."""
+    from nemo_automodel.recipes.llm.train_eagle3 import TrainEagle3Recipe
+
+    recipe = TrainEagle3Recipe.__new__(TrainEagle3Recipe)
+    recipe.target_wrapper = _InflightBackend()
+    recipe.target_prefetch_depth = 2
+
+    loader = [{"input_ids": torch.full((1, 4), i), "attention_mask": None, "loss_mask": None} for i in range(6)]
+    seen = [target_batch for _b, target_batch in recipe._prefetched_batches(loader)]
+
+    assert seen == list(range(6))
+    assert recipe.target_wrapper.max_inflight == recipe.target_prefetch_depth
+
+
+# --- 6. /generate concurrency ----------------------------------------------
+
+
+class _ConcurrencyProbe:
+    """Records the maximum number of threads inside a guarded section."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self.active = 0
+        self.max_active = 0
+
+    def __enter__(self):
+        with self._lock:
+            self.active += 1
+            self.max_active = max(self.max_active, self.active)
+        return self
+
+    def __exit__(self, *exc):
+        with self._lock:
+            self.active -= 1
+        return False
+
+
+def test_server_serializes_concurrent_generate_requests():
+    """Two /generate requests racing on the threaded HTTP server must run the
+    supervision forward one at a time: the aux-capture hooks live on the shared
+    model, so overlapping forwards hand each request the other's tensors."""
+    import time
+
+    target = _make_target_wrapper()
+    probe = _ConcurrencyProbe()
+    original_generate_batch = target.generate_batch
+
+    def _slow_generate_batch(**kwargs):
+        with probe:
+            time.sleep(0.05)
+            return original_generate_batch(**kwargs)
+
+    target.generate_batch = _slow_generate_batch
+
+    port = _free_port()
+    logic = TargetModelServer(target, nccl_port=port + 100, host="127.0.0.1")
+    httpd = ThreadingHTTPServer(("127.0.0.1", port), _make_request_handler(logic))
+    httpd.daemon_threads = True
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    backend = RemoteEagle3TargetModel.from_urls([f"http://127.0.0.1:{port}"], device="cpu", max_retries=0)
+    try:
+        backend.set_vocab_mapping(*_vocab_mapping())
+        inputs = [_batch() for _ in range(4)]
+        # Distinct sessions per thread so the requests really race on the server.
+        import requests as _requests
+
+        results = [None] * len(inputs)
+
+        def _post(i):
+            payload = wire.encode_to_bytes(
+                {"input_ids": inputs[i][0], "attention_mask": inputs[i][1], "loss_mask": inputs[i][2]}
+            )
+            resp = _requests.post(f"http://127.0.0.1:{port}/{protocol.EP_GENERATE}", data=payload, timeout=30)
+            resp.raise_for_status()
+            results[i] = wire.decode(resp.content, map_location="cpu")
+
+        threads = [threading.Thread(target=_post, args=(i,)) for i in range(len(inputs))]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=60)
+
+        assert probe.max_active == 1, "concurrent /generate forwards ran on the shared target model"
+        # Each request got the supervision for ITS OWN inputs.
+        ids, mask = _vocab_mapping()
+        for i, result in enumerate(results):
+            ref = compute_supervision(target, ids, mask, *inputs[i])
+            torch.testing.assert_close(result["target_probs"], ref["target_probs"], rtol=0, atol=0)
+    finally:
+        backend.close()
+        httpd.shutdown()
+        httpd.server_close()
+
+
+def test_client_serializes_generate_per_server(monkeypatch):
+    """_ServerClient.generate must never have two requests in flight on one
+    server from this process (NCCL recv pairing relies on it)."""
+    import time
+
+    from nemo_automodel.components.speculative.eagle.remote.client import _ServerClient
+
+    monkeypatch.setenv("NEMO_EAGLE_ENABLE_NCCL", "0")
+    client = _ServerClient("http://127.0.0.1:9", timeout=5, max_retries=0)
+    probe = _ConcurrencyProbe()
+
+    class _Resp:
+        content = wire.encode_to_bytes({"x": torch.zeros(1)})
+        headers = {}
+
+        def raise_for_status(self):
+            return None
+
+    def _fake_post(url, **kwargs):
+        with probe:
+            time.sleep(0.02)
+            return _Resp()
+
+    monkeypatch.setattr(client._session, "post", _fake_post)
+
+    threads = [threading.Thread(target=client.generate, args=(b"",)) for _ in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    assert probe.max_active == 1


### PR DESCRIPTION
# What does this PR do ?

Fixes a silent supervision-corruption race in the remote EAGLE-3 target path (train-inference disaggregation). Three pieces interacted:

1. `_prefetched_batches` refilled the queue **before** awaiting the popped request, so with the prefetch depth capped to the server count there were `depth + 1` requests in flight, and round-robin dispatch sent the extra request to exactly the server still busy with the popped one.
2. The client's thread pool has `max(2, num_servers)` workers, so both requests genuinely ran concurrently against that server.
3. The server handles requests on `ThreadingHTTPServer` threads, but `/generate` is not reentrant: aux hidden states are captured via forward hooks registered on the shared model, so a concurrent forward fires this request's hooks too and overwrites the captured tensors; and the NCCL path stages tensors in a single shared pending-send slot consumed after the HTTP flush, so an overwrite sends one client the other's tensors and leaves the other blocked forever in `dist.recv`.

Tensor shapes usually match across batches, so nothing crashes: the draft silently trains on supervision computed from a different batch. Multiple training ranks talking to one server hit the same race even at depth 1.

The race is closed at all three layers because each guards a hazard the others cannot reach: no client-side fix can coordinate independent training ranks (server lock), and no server-side fix can keep a racing client's NCCL recv paired with the right send (client lock).

# Changelog

- `nemo_automodel/recipes/llm/train_eagle3.py`: `_prefetched_batches` awaits the popped result before refilling, restoring the one-in-flight-per-server invariant the prefetch cap promises.
- `nemo_automodel/components/speculative/eagle/remote/client.py`: `_ServerClient.generate` is serialized per server so the NCCL recv always pairs with this request's send regardless of executor sizing.
- `nemo_automodel/components/speculative/eagle/remote/server.py`: the handler serializes the whole generate-and-flush sequence on a lock; `set_vocab_mapping` shares it because it swaps tensors the generate forward reads. When the NCCL flush fails after the 200 response is already on the wire, drop the connection instead of writing a second response that would desync the keep-alive stream.
- `tests/unit_tests/speculative/test_eagle3_remote.py`: tests pinning the max-in-flight invariant of the prefetcher, mutual exclusion of concurrent `/generate` requests through the real threaded HTTP server (each request gets its own batch's supervision back), and per-server serialization in the client.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

# Additional Information

- Known follow-ups deliberately out of scope: per-rank server assignment for multi-rank jobs (the `nccl_rank_offset` is currently the URL index, not the training rank), NCCL buffer device placement in worker threads, and a heartbeat-based server watchdog.
- Found while reviewing the speculative-decoding components for correctness.