### PR TITLE
feat(checkpoint): export torch_save checkpoints to hf

### DIFF
--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -473,6 +473,7 @@ class Checkpointer:
         is_init_step: bool = False,
         use_checkpoint_id: bool = True,
         key_mapping: Optional[dict[str, str]] = None,
+        allow_checkpoint_key_subset: bool = False,
     ) -> None:
         """
         Load model weights from `model_path`.
@@ -489,6 +490,8 @@ class Checkpointer:
             is_init_step: If True, treat load as initialization from a base checkpoint.
             use_checkpoint_id: Pass `checkpoint_id` to DCP if True; disable when using direct HF paths.
             key_mapping: Optional key remapping when reading from HF checkpoints.
+            allow_checkpoint_key_subset: If True, keep the model's current initialization for
+                parameters that are absent from the checkpoint instead of requiring an exact key match.
         """
         # Validate checkpoint directory
         if not os.path.exists(model_path):
@@ -611,6 +614,7 @@ class Checkpointer:
         # renames model keys, producing a mismatch in the DCP planner.
         reader_key_mapping = None if has_state_dict_adapter else key_mapping
         storage_reader = self._get_storage_reader(model_path, reader_key_mapping, is_init_step=is_init_step)
+        checkpoint_metadata_keys: set[str] | None = None
 
         # MoE adapters return views into model storage; DCP writes safetensors
         # data straight through them and from_hf skips the rebuild.
@@ -630,7 +634,8 @@ class Checkpointer:
             and lm_head_param_name in state_dict
         )
         if should_try_tied_lm_head_compat:
-            checkpoint_metadata_keys = _get_checkpoint_metadata_keys(model_path, storage_reader)
+            if checkpoint_metadata_keys is None:
+                checkpoint_metadata_keys = _get_checkpoint_metadata_keys(model_path, storage_reader)
             if lm_head_param_name not in checkpoint_metadata_keys:
                 for source_name in get_tied_lm_head_source_names(model_state.model[0], lm_head_param_name):
                     if source_name not in checkpoint_metadata_keys or source_name in state_dict:
@@ -655,6 +660,22 @@ class Checkpointer:
                     )
                     state_dict.pop(lm_head_param_name, None)
 
+        if allow_checkpoint_key_subset:
+            if checkpoint_metadata_keys is None:
+                checkpoint_metadata_keys = _get_checkpoint_metadata_keys(model_path, storage_reader)
+            missing_checkpoint_keys = sorted(key for key in state_dict if key not in checkpoint_metadata_keys)
+            if missing_checkpoint_keys:
+                for key in missing_checkpoint_keys:
+                    state_dict.pop(key, None)
+                logging.warning(
+                    "Checkpoint %s is missing %d requested model keys. Keeping the current model "
+                    "initialization for those parameters because allow_checkpoint_key_subset=True "
+                    "(examples=%s).",
+                    model_path,
+                    len(missing_checkpoint_keys),
+                    missing_checkpoint_keys[:10],
+                )
+
         state_dict = self._do_load(state_dict, model_path, storage_reader, is_init_step=is_init_step)
 
         if compat_tied_lm_head_source_key is not None and isinstance(lm_head_param_name, str):
@@ -663,6 +684,8 @@ class Checkpointer:
         state_dict = _maybe_adapt_state_dict_from_hf(model_state.model[0], state_dict, moe_mesh=self.moe_mesh)
         expected_keys_for_diff = {k for k in expected_keys if not k.endswith("_extra_state")}
         loaded_keys_for_diff = {k for k in state_dict if not k.endswith("_extra_state")}
+        if allow_checkpoint_key_subset:
+            expected_keys_for_diff = loaded_keys_for_diff.copy()
         key_diff = _summarize_state_dict_key_diff(expected_keys_for_diff, loaded_keys_for_diff)
         if key_diff["missing_count"] or key_diff["unexpected_count"]:
             logging.warning(
@@ -674,7 +697,10 @@ class Checkpointer:
                 key_diff["missing_examples"],
                 key_diff["unexpected_examples"],
             )
-        model_state.load_state_dict(state_dict, strict=not (len(model_state.model) > 1 or has_state_dict_adapter))
+        model_state.load_state_dict(
+            state_dict,
+            strict=not (len(model_state.model) > 1 or has_state_dict_adapter or allow_checkpoint_key_subset),
+        )
 
         del state_dict
         gc.collect()

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -664,17 +664,33 @@ class Checkpointer:
 
         if allow_checkpoint_key_subset:
             missing_checkpoint_keys = sorted(key for key in state_dict if key not in checkpoint_metadata_keys)
+            # A subset load tolerates a few absent keys (e.g. heads excluded at save time);
+            # a checkpoint sharing NO keys with the model is a wrong or unreadable checkpoint
+            # and must not become a silent no-op load.
+            if missing_checkpoint_keys and len(missing_checkpoint_keys) == len(state_dict):
+                raise RuntimeError(
+                    f"Checkpoint {model_path} contains none of the {len(state_dict)} requested model keys "
+                    f"(checkpoint has {len(checkpoint_metadata_keys)} keys, examples="
+                    f"{sorted(checkpoint_metadata_keys)[:5]}). Refusing to continue with "
+                    "allow_checkpoint_key_subset=True because the load would be a no-op."
+                )
+            # Subset loading means the checkpoint keys must be a SUBSET of the model keys
+            # (the model may carry extra heads kept at init). Keys the checkpoint has but the
+            # model lacks signal that the wrong architecture was built (e.g. a VLM checkpoint
+            # loaded into an LLM model would drop the vision tower), so refuse rather than
+            # silently export a partial model. lm_head is never a false positive here: it is
+            # only popped from state_dict when it is also absent from the checkpoint.
+            unmatched_checkpoint_keys = sorted(
+                key for key in checkpoint_metadata_keys if key not in state_dict and not key.endswith("_extra_state")
+            )
+            if unmatched_checkpoint_keys:
+                raise RuntimeError(
+                    f"Checkpoint {model_path} has {len(unmatched_checkpoint_keys)} keys absent from the built "
+                    f"model (examples={unmatched_checkpoint_keys[:5]}). The model was likely constructed with the "
+                    "wrong architecture for this checkpoint (e.g. exporting a VLM checkpoint with an LLM recipe). "
+                    "Rebuild the model with the recipe that produced the checkpoint."
+                )
             if missing_checkpoint_keys:
-                # A subset load tolerates a few absent keys (e.g. heads excluded at save
-                # time); a checkpoint sharing NO keys with the model is a wrong or
-                # unreadable checkpoint and must not become a silent no-op load.
-                if len(missing_checkpoint_keys) == len(state_dict):
-                    raise RuntimeError(
-                        f"Checkpoint {model_path} contains none of the {len(state_dict)} requested model keys "
-                        f"(checkpoint has {len(checkpoint_metadata_keys)} keys, examples="
-                        f"{sorted(checkpoint_metadata_keys)[:5]}). Refusing to continue with "
-                        "allow_checkpoint_key_subset=True because the load would be a no-op."
-                    )
                 for key in missing_checkpoint_keys:
                     state_dict.pop(key, None)
                 logging.warning(

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -613,8 +613,9 @@ class Checkpointer:
         # keys: the storage reader renames checkpoint keys in metadata, and then to_hf also
         # renames model keys, producing a mismatch in the DCP planner.
         reader_key_mapping = None if has_state_dict_adapter else key_mapping
-        storage_reader = self._get_storage_reader(model_path, reader_key_mapping, is_init_step=is_init_step)
-        checkpoint_metadata_keys: set[str] | None = None
+        storage_reader = self._get_storage_reader(
+            model_path, reader_key_mapping, is_init_step=is_init_step, is_safetensors=is_safetensors
+        )
 
         # MoE adapters return views into model storage; DCP writes safetensors
         # data straight through them and from_hf skips the rebuild.
@@ -633,9 +634,10 @@ class Checkpointer:
             and isinstance(lm_head_param_name, str)
             and lm_head_param_name in state_dict
         )
+        checkpoint_metadata_keys: set[str] = set()
+        if should_try_tied_lm_head_compat or allow_checkpoint_key_subset:
+            checkpoint_metadata_keys = _get_checkpoint_metadata_keys(model_path, storage_reader)
         if should_try_tied_lm_head_compat:
-            if checkpoint_metadata_keys is None:
-                checkpoint_metadata_keys = _get_checkpoint_metadata_keys(model_path, storage_reader)
             if lm_head_param_name not in checkpoint_metadata_keys:
                 for source_name in get_tied_lm_head_source_names(model_state.model[0], lm_head_param_name):
                     if source_name not in checkpoint_metadata_keys or source_name in state_dict:
@@ -661,10 +663,18 @@ class Checkpointer:
                     state_dict.pop(lm_head_param_name, None)
 
         if allow_checkpoint_key_subset:
-            if checkpoint_metadata_keys is None:
-                checkpoint_metadata_keys = _get_checkpoint_metadata_keys(model_path, storage_reader)
             missing_checkpoint_keys = sorted(key for key in state_dict if key not in checkpoint_metadata_keys)
             if missing_checkpoint_keys:
+                # A subset load tolerates a few absent keys (e.g. heads excluded at save
+                # time); a checkpoint sharing NO keys with the model is a wrong or
+                # unreadable checkpoint and must not become a silent no-op load.
+                if len(missing_checkpoint_keys) == len(state_dict):
+                    raise RuntimeError(
+                        f"Checkpoint {model_path} contains none of the {len(state_dict)} requested model keys "
+                        f"(checkpoint has {len(checkpoint_metadata_keys)} keys, examples="
+                        f"{sorted(checkpoint_metadata_keys)[:5]}). Refusing to continue with "
+                        "allow_checkpoint_key_subset=True because the load would be a no-op."
+                    )
                 for key in missing_checkpoint_keys:
                     state_dict.pop(key, None)
                 logging.warning(
@@ -685,7 +695,9 @@ class Checkpointer:
         expected_keys_for_diff = {k for k in expected_keys if not k.endswith("_extra_state")}
         loaded_keys_for_diff = {k for k in state_dict if not k.endswith("_extra_state")}
         if allow_checkpoint_key_subset:
-            expected_keys_for_diff = loaded_keys_for_diff.copy()
+            # Keys deliberately kept at init were already warned about above; keep
+            # reporting unexpected keys, which nothing else surfaces.
+            expected_keys_for_diff &= loaded_keys_for_diff
         key_diff = _summarize_state_dict_key_diff(expected_keys_for_diff, loaded_keys_for_diff)
         if key_diff["missing_count"] or key_diff["unexpected_count"]:
             logging.warning(
@@ -1260,7 +1272,11 @@ fi
             )
 
     def _get_storage_reader(
-        self, model_path: str, key_mapping: Optional[dict[str, str]], is_init_step: bool = False
+        self,
+        model_path: str,
+        key_mapping: Optional[dict[str, str]],
+        is_init_step: bool = False,
+        is_safetensors: bool | None = None,
     ) -> Optional[_HuggingFaceStorageReader]:
         """
         Construct a Hugging Face storage reader when loading safetensors or during init.
@@ -1275,29 +1291,38 @@ fi
             model_path: Path to the model checkpoint directory or HF snapshot.
             key_mapping: Optional key remapping for conversion.
             is_init_step: If True, always produce a reader for base HF load.
+            is_safetensors: Whether `model_path` holds a safetensors checkpoint; computed
+                from the directory contents when not supplied.
 
         Returns:
-            Configured storage reader or None for other formats.
+            Configured storage reader, or None for the default DCP FileSystemReader.
         """
-        if self.config.model_save_format == SerializationFormat.SAFETENSORS or is_init_step:
-            # The upstream HuggingFaceStorageReader delegates dtype decoding to
-            # safetensors.torch._TYPES, which does not yet recognize the FP8
-            # scale dtypes emitted by some quantized HF checkpoints (e.g.
-            # DeepSeek V4's F8_E8M0 scales → KeyError('F8_E8M0') inside
-            # read_metadata → DCP ends up with metadata=None on every rank).
-            # The in-tree backport's DTYPE_MAP was extended for F8_E8M0/F8_E5M2,
-            # so prefer it for base-model HF loads. Mid-training DCP loads may
-            # still use the faster upstream reader.
-            if key_mapping is None and not is_init_step:
-                try:
-                    from torch.distributed.checkpoint.hf_storage import (
-                        HuggingFaceStorageReader as _UpstreamHFReader,
-                    )
+        # The configured save format does not always match what is on disk at `model_path`
+        # (e.g. exporting a torch_save DCP checkpoint with a safetensors-configured
+        # checkpointer). A safetensors reader on a non-safetensors directory returns EMPTY
+        # metadata instead of raising, so trust the directory contents for non-init loads.
+        if is_safetensors is None:
+            is_safetensors = _is_safetensors_checkpoint(model_path)
+        if not is_init_step and not is_safetensors:
+            return None
+        # The upstream HuggingFaceStorageReader delegates dtype decoding to
+        # safetensors.torch._TYPES, which does not yet recognize the FP8
+        # scale dtypes emitted by some quantized HF checkpoints (e.g.
+        # DeepSeek V4's F8_E8M0 scales → KeyError('F8_E8M0') inside
+        # read_metadata → DCP ends up with metadata=None on every rank).
+        # The in-tree backport's DTYPE_MAP was extended for F8_E8M0/F8_E5M2,
+        # so prefer it for base-model HF loads. Mid-training DCP loads may
+        # still use the faster upstream reader.
+        if key_mapping is None and not is_init_step:
+            try:
+                from torch.distributed.checkpoint.hf_storage import (
+                    HuggingFaceStorageReader as _UpstreamHFReader,
+                )
 
-                    return _UpstreamHFReader(path=model_path)
-                except ImportError:
-                    pass
-            return _HuggingFaceStorageReader(path=model_path, key_mapping=key_mapping)
+                return _UpstreamHFReader(path=model_path)
+            except ImportError:
+                pass
+        return _HuggingFaceStorageReader(path=model_path, key_mapping=key_mapping)
 
     def _get_original_model_path(self, model_state: ModelState) -> str | None:
         """

--- a/nemo_automodel/components/checkpoint/config.py
+++ b/nemo_automodel/components/checkpoint/config.py
@@ -138,6 +138,18 @@ class CheckpointingConfig:
 
         # Normalize legacy bools and string aliases to a consolidated export mode.
         self.save_consolidated = _normalize_save_consolidated(self.save_consolidated)
+        if (
+            self.model_save_format != SerializationFormat.SAFETENSORS
+            and self.save_consolidated != SaveConsolidatedMode.FALSE
+            and not self.is_peft
+        ):
+            logging.warning(
+                "checkpoint.save_consolidated=%s is ignored when checkpoint.model_save_format=%s. "
+                "Export sharded torch_save checkpoints back to Hugging Face safetensors after training with "
+                "scripts/export_llm_dcp_to_hf.py.",
+                self.save_consolidated.value,
+                self.model_save_format.value,
+            )
         if self.save_consolidated != SaveConsolidatedMode.FALSE and not self.is_peft:
             if not self.v4_compatible:
                 logging.warning(

--- a/nemo_automodel/components/checkpoint/config.py
+++ b/nemo_automodel/components/checkpoint/config.py
@@ -138,20 +138,16 @@ class CheckpointingConfig:
 
         # Normalize legacy bools and string aliases to a consolidated export mode.
         self.save_consolidated = _normalize_save_consolidated(self.save_consolidated)
-        if (
-            self.model_save_format != SerializationFormat.SAFETENSORS
-            and self.save_consolidated != SaveConsolidatedMode.FALSE
-            and not self.is_peft
-        ):
-            logging.warning(
-                "checkpoint.save_consolidated=%s is ignored when checkpoint.model_save_format=%s. "
-                "Export sharded torch_save checkpoints back to Hugging Face safetensors after training with "
-                "scripts/export_llm_dcp_to_hf.py.",
-                self.save_consolidated.value,
-                self.model_save_format.value,
-            )
         if self.save_consolidated != SaveConsolidatedMode.FALSE and not self.is_peft:
-            if not self.v4_compatible:
+            if self.model_save_format != SerializationFormat.SAFETENSORS:
+                logging.warning(
+                    "checkpoint.save_consolidated=%s is ignored when checkpoint.model_save_format=%s. "
+                    "Export sharded torch_save checkpoints back to Hugging Face safetensors after training with "
+                    "scripts/export_llm_dcp_to_hf.py.",
+                    self.save_consolidated.value,
+                    self.model_save_format.value,
+                )
+            elif not self.v4_compatible:
                 logging.warning(
                     "save_consolidated=%s but v4_compatible=False; "
                     "checkpoint assets may be not compatible with transformers v4; "

--- a/scripts/export_llm_dcp_to_hf.py
+++ b/scripts/export_llm_dcp_to_hf.py
@@ -35,13 +35,12 @@ import torch
 from torch.nn.parallel import DistributedDataParallel
 
 from nemo_automodel.components.checkpoint.checkpointing import save_config
+from nemo_automodel.components.checkpoint.utils import is_rank_0
 from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
 from nemo_automodel.components.config.loader import ConfigNode
 from nemo_automodel.recipes.llm.train_ft import TrainFinetuneRecipeForNextTokenPrediction
 
 _CHECKPOINT_DIR_RE = re.compile(r"epoch_(\d+)_step_(\d+)$")
-_TRACKING_KEYS = ("wandb", "mlflow", "comet")
-_EXPORT_WORKDIR_NAME = ".export_workdir"
 
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
@@ -82,18 +81,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         default=None,
         help="Explicit step number for the exported checkpoint directory name. Defaults to the source checkpoint.",
     )
-    parser.add_argument(
-        "--save-consolidated",
-        choices=("every", "final"),
-        default="final",
-        help="Consolidated export mode to record in the saved config. Default: final.",
-    )
     return parser.parse_args(argv)
-
-
-def infer_config_path(checkpoint_dir: str) -> Path:
-    """Return the default config.yaml path for a checkpoint directory."""
-    return Path(checkpoint_dir) / "config.yaml"
 
 
 def infer_epoch_step(checkpoint_dir: str) -> tuple[int, int]:
@@ -108,6 +96,8 @@ def infer_epoch_step(checkpoint_dir: str) -> tuple[int, int]:
 
 def resolve_epoch_step(checkpoint_dir: str, epoch: int | None, step: int | None) -> tuple[int, int]:
     """Resolve exported epoch and step from explicit flags or the source checkpoint name."""
+    if epoch is not None and step is not None:
+        return epoch, step
     inferred_epoch, inferred_step = infer_epoch_step(checkpoint_dir)
     return (
         inferred_epoch if epoch is None else epoch,
@@ -115,42 +105,38 @@ def resolve_epoch_step(checkpoint_dir: str, epoch: int | None, step: int | None)
     )
 
 
-def infer_export_root(output_dir: str, epoch: int, step: int) -> Path:
-    """Return the final exported checkpoint directory."""
-    return Path(output_dir) / f"epoch_{epoch}_step_{step}"
-
-
-def infer_export_workdir(output_dir: str) -> Path:
-    """Return a hidden work directory used only for recipe setup side effects."""
-    return Path(output_dir) / _EXPORT_WORKDIR_NAME
-
-
-def disable_tracking_loggers(cfg: ConfigNode) -> None:
-    """Remove remote experiment trackers from the loaded config."""
-    for key in _TRACKING_KEYS:
-        cfg.__dict__.pop(key, None)
-
-
 def build_export_config(args: argparse.Namespace) -> ConfigNode:
     """Load config.yaml and apply export-specific overrides."""
-    config_path = Path(args.config) if args.config is not None else infer_config_path(args.checkpoint_dir)
-    export_workdir = infer_export_workdir(args.output_dir)
+    config_path = Path(args.config) if args.config is not None else Path(args.checkpoint_dir) / "config.yaml"
     cfg = parse_args_and_load_config(
         str(config_path),
         argv=[
             "--checkpoint.restore_from",
             "None",
+            # Hidden directory that absorbs recipe-setup side effects (metric JSONL
+            # logs, auto-resume scan) without touching the user-facing export root.
             "--checkpoint.checkpoint_dir",
-            str(export_workdir),
+            str(Path(args.output_dir) / ".export_workdir"),
             "--checkpoint.model_save_format",
             "safetensors",
             "--checkpoint.save_consolidated",
-            args.save_consolidated,
+            "final",
+            # An offline export must not log to remote experiment trackers.
+            "--wandb",
+            "None",
+            "--mlflow",
+            "None",
+            "--comet",
+            "None",
         ],
     )
+    if cfg.get("peft", None) is not None:
+        raise ValueError(
+            "PEFT checkpoints are saved as a single consolidated adapter_model.safetensors already; "
+            "this exporter only supports full-model torch_save checkpoints."
+        )
     if args.model_name_or_path is not None:
         cfg.set_by_dotted("model.pretrained_model_name_or_path", args.model_name_or_path)
-    disable_tracking_loggers(cfg)
     return cfg
 
 
@@ -158,40 +144,19 @@ def resolve_model_for_export(
     trainer: TrainFinetuneRecipeForNextTokenPrediction,
 ) -> torch.nn.Module | list[torch.nn.Module]:
     """Return the model object that should be passed to the checkpointer."""
-    model = getattr(trainer, "model_parts", None)
-    if model is None:
-        model = getattr(trainer, "model", None)
-    if model is None:
-        raise ValueError("Trainer did not expose a model for export.")
-    if isinstance(model, list):
-        if len(model) == 0:
-            raise ValueError("Trainer exposed an empty model_parts list.")
-        if len(model) > 1:
-            return model
-        model = model[0]
+    model_parts = trainer.model_parts
+    if len(model_parts) > 1:
+        return model_parts
+    model = model_parts[0]
     if isinstance(model, DistributedDataParallel):
         model = model.module
     return model
-
-
-def is_main_process() -> bool:
-    """Return True for rank 0 or when torch.distributed is not initialized."""
-    return not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0
 
 
 def barrier() -> None:
     """Synchronize across ranks when torch.distributed is initialized."""
     if torch.distributed.is_initialized():
         torch.distributed.barrier()
-
-
-def prepare_export_root(export_root: Path) -> None:
-    """Create the export directory once and fail fast on accidental overwrite."""
-    if is_main_process():
-        if export_root.exists():
-            raise FileExistsError(f"Export directory already exists: {export_root}")
-        export_root.mkdir(parents=True, exist_ok=False)
-    barrier()
 
 
 def close_trainer(trainer: TrainFinetuneRecipeForNextTokenPrediction | None) -> None:
@@ -211,7 +176,11 @@ def main(argv: Sequence[str] | None = None) -> None:
     """Restore a DCP checkpoint and re-save it as Hugging Face safetensors."""
     args = parse_args(argv)
     export_epoch, export_step = resolve_epoch_step(args.checkpoint_dir, args.epoch, args.step)
-    export_root = infer_export_root(args.output_dir, export_epoch, export_step)
+    export_root = Path(args.output_dir) / f"epoch_{export_epoch}_step_{export_step}"
+    # Fail fast on every rank, before the expensive recipe setup and before
+    # torch.distributed is initialized.
+    if export_root.exists():
+        raise FileExistsError(f"Export directory already exists: {export_root}")
     cfg = build_export_config(args)
 
     trainer: TrainFinetuneRecipeForNextTokenPrediction | None = None
@@ -219,14 +188,19 @@ def main(argv: Sequence[str] | None = None) -> None:
         trainer = TrainFinetuneRecipeForNextTokenPrediction(cfg)
         trainer.setup()
         export_model = resolve_model_for_export(trainer)
-        prepare_export_root(export_root)
+        # Idempotent on every rank, so a filesystem failure raises everywhere
+        # instead of stranding the other ranks in a collective.
+        export_root.mkdir(parents=True, exist_ok=True)
         trainer.checkpointer.load_model(
             export_model,
             model_path=str(Path(args.checkpoint_dir) / "model"),
             allow_checkpoint_key_subset=True,
         )
-        if is_main_process():
-            save_config(cfg.to_dict(), str(export_root))
+        if is_rank_0():
+            # to_yaml_dict() keeps _target_/*_fn entries as dotted-path strings so the
+            # exported config.yaml stays loadable; to_dict() would serialize the
+            # resolved Python objects as !!python/name tags that safe_load rejects.
+            save_config(cfg.to_yaml_dict(), str(export_root))
         barrier()
         trainer.checkpointer.save_model(
             model=export_model,
@@ -237,7 +211,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     finally:
         close_trainer(trainer)
 
-    if is_main_process():
+    if is_rank_0():
         output_dir = export_root / "model" / "consolidated"
         print(f"HF export is ready under: {output_dir}")
 

--- a/scripts/export_llm_dcp_to_hf.py
+++ b/scripts/export_llm_dcp_to_hf.py
@@ -1,0 +1,246 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Export an LLM DCP checkpoint to consolidated Hugging Face safetensors.
+
+This tool rebuilds the original distributed model topology from ``config.yaml``,
+loads only the model weights from a sharded ``torch_save`` checkpoint, and saves
+them back out as Hugging Face-compatible safetensors.
+
+Example:
+    torchrun --nproc-per-node=8 scripts/export_llm_dcp_to_hf.py \
+        --checkpoint-dir /path/to/checkpoints/epoch_0_step_17999 \
+        --output-dir /path/to/hf_export
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from typing import Sequence
+
+import torch
+from torch.nn.parallel import DistributedDataParallel
+
+from nemo_automodel.components.checkpoint.checkpointing import save_config
+from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
+from nemo_automodel.components.config.loader import ConfigNode
+from nemo_automodel.recipes.llm.train_ft import TrainFinetuneRecipeForNextTokenPrediction
+
+_CHECKPOINT_DIR_RE = re.compile(r"epoch_(\d+)_step_(\d+)$")
+_TRACKING_KEYS = ("wandb", "mlflow", "comet")
+_EXPORT_WORKDIR_NAME = ".export_workdir"
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments for DCP to HF export."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--checkpoint-dir",
+        required=True,
+        help="Path to the saved training checkpoint directory, for example epoch_0_step_17999.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        help="Directory that will receive the exported checkpoint root.",
+    )
+    parser.add_argument(
+        "--config",
+        default=None,
+        help="Optional config.yaml path. Defaults to <checkpoint-dir>/config.yaml.",
+    )
+    parser.add_argument(
+        "--model-name-or-path",
+        default=None,
+        help=(
+            "Optional override for model.pretrained_model_name_or_path. Use this when the recorded base "
+            "model path in config.yaml is no longer valid."
+        ),
+    )
+    parser.add_argument(
+        "--epoch",
+        type=int,
+        default=None,
+        help="Explicit epoch number for the exported checkpoint directory name. Defaults to the source checkpoint.",
+    )
+    parser.add_argument(
+        "--step",
+        type=int,
+        default=None,
+        help="Explicit step number for the exported checkpoint directory name. Defaults to the source checkpoint.",
+    )
+    parser.add_argument(
+        "--save-consolidated",
+        choices=("every", "final"),
+        default="final",
+        help="Consolidated export mode to record in the saved config. Default: final.",
+    )
+    return parser.parse_args(argv)
+
+
+def infer_config_path(checkpoint_dir: str) -> Path:
+    """Return the default config.yaml path for a checkpoint directory."""
+    return Path(checkpoint_dir) / "config.yaml"
+
+
+def infer_epoch_step(checkpoint_dir: str) -> tuple[int, int]:
+    """Parse epoch and step numbers from a checkpoint directory name."""
+    match = _CHECKPOINT_DIR_RE.search(Path(checkpoint_dir).name)
+    if match is None:
+        raise ValueError(
+            "Could not infer epoch/step from checkpoint directory name. Pass both --epoch and --step explicitly."
+        )
+    return int(match.group(1)), int(match.group(2))
+
+
+def resolve_epoch_step(checkpoint_dir: str, epoch: int | None, step: int | None) -> tuple[int, int]:
+    """Resolve exported epoch and step from explicit flags or the source checkpoint name."""
+    inferred_epoch, inferred_step = infer_epoch_step(checkpoint_dir)
+    return (
+        inferred_epoch if epoch is None else epoch,
+        inferred_step if step is None else step,
+    )
+
+
+def infer_export_root(output_dir: str, epoch: int, step: int) -> Path:
+    """Return the final exported checkpoint directory."""
+    return Path(output_dir) / f"epoch_{epoch}_step_{step}"
+
+
+def infer_export_workdir(output_dir: str) -> Path:
+    """Return a hidden work directory used only for recipe setup side effects."""
+    return Path(output_dir) / _EXPORT_WORKDIR_NAME
+
+
+def disable_tracking_loggers(cfg: ConfigNode) -> None:
+    """Remove remote experiment trackers from the loaded config."""
+    for key in _TRACKING_KEYS:
+        cfg.__dict__.pop(key, None)
+
+
+def build_export_config(args: argparse.Namespace) -> ConfigNode:
+    """Load config.yaml and apply export-specific overrides."""
+    config_path = Path(args.config) if args.config is not None else infer_config_path(args.checkpoint_dir)
+    export_workdir = infer_export_workdir(args.output_dir)
+    cfg = parse_args_and_load_config(
+        str(config_path),
+        argv=[
+            "--checkpoint.restore_from",
+            "None",
+            "--checkpoint.checkpoint_dir",
+            str(export_workdir),
+            "--checkpoint.model_save_format",
+            "safetensors",
+            "--checkpoint.save_consolidated",
+            args.save_consolidated,
+        ],
+    )
+    if args.model_name_or_path is not None:
+        cfg.set_by_dotted("model.pretrained_model_name_or_path", args.model_name_or_path)
+    disable_tracking_loggers(cfg)
+    return cfg
+
+
+def resolve_model_for_export(
+    trainer: TrainFinetuneRecipeForNextTokenPrediction,
+) -> torch.nn.Module | list[torch.nn.Module]:
+    """Return the model object that should be passed to the checkpointer."""
+    model = getattr(trainer, "model_parts", None)
+    if model is None:
+        model = getattr(trainer, "model", None)
+    if model is None:
+        raise ValueError("Trainer did not expose a model for export.")
+    if isinstance(model, list):
+        if len(model) == 0:
+            raise ValueError("Trainer exposed an empty model_parts list.")
+        if len(model) > 1:
+            return model
+        model = model[0]
+    if isinstance(model, DistributedDataParallel):
+        model = model.module
+    return model
+
+
+def is_main_process() -> bool:
+    """Return True for rank 0 or when torch.distributed is not initialized."""
+    return not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0
+
+
+def barrier() -> None:
+    """Synchronize across ranks when torch.distributed is initialized."""
+    if torch.distributed.is_initialized():
+        torch.distributed.barrier()
+
+
+def prepare_export_root(export_root: Path) -> None:
+    """Create the export directory once and fail fast on accidental overwrite."""
+    if is_main_process():
+        if export_root.exists():
+            raise FileExistsError(f"Export directory already exists: {export_root}")
+        export_root.mkdir(parents=True, exist_ok=False)
+    barrier()
+
+
+def close_trainer(trainer: TrainFinetuneRecipeForNextTokenPrediction | None) -> None:
+    """Best-effort cleanup for recipe-owned resources."""
+    if trainer is None:
+        return
+    if hasattr(trainer, "metric_logger_train"):
+        trainer.metric_logger_train.close()
+    if hasattr(trainer, "metric_logger_valid"):
+        for logger in trainer.metric_logger_valid.values():
+            logger.close()
+    if hasattr(trainer, "checkpointer"):
+        trainer.checkpointer.close()
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Restore a DCP checkpoint and re-save it as Hugging Face safetensors."""
+    args = parse_args(argv)
+    export_epoch, export_step = resolve_epoch_step(args.checkpoint_dir, args.epoch, args.step)
+    export_root = infer_export_root(args.output_dir, export_epoch, export_step)
+    cfg = build_export_config(args)
+
+    trainer: TrainFinetuneRecipeForNextTokenPrediction | None = None
+    try:
+        trainer = TrainFinetuneRecipeForNextTokenPrediction(cfg)
+        trainer.setup()
+        export_model = resolve_model_for_export(trainer)
+        prepare_export_root(export_root)
+        trainer.checkpointer.load_model(
+            export_model,
+            model_path=str(Path(args.checkpoint_dir) / "model"),
+            allow_checkpoint_key_subset=True,
+        )
+        if is_main_process():
+            save_config(cfg.to_dict(), str(export_root))
+        barrier()
+        trainer.checkpointer.save_model(
+            model=export_model,
+            weights_path=str(export_root),
+            tokenizer=trainer.tokenizer,
+            is_final_checkpoint=True,
+        )
+    finally:
+        close_trainer(trainer)
+
+    if is_main_process():
+        output_dir = export_root / "model" / "consolidated"
+        print(f"HF export is ready under: {output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/export_llm_dcp_to_hf.py
+++ b/scripts/export_llm_dcp_to_hf.py
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Export an LLM DCP checkpoint to consolidated Hugging Face safetensors.
+"""Export an LLM or VLM DCP checkpoint to consolidated Hugging Face safetensors.
 
-This tool rebuilds the original distributed model topology from ``config.yaml``,
-loads only the model weights from a sharded ``torch_save`` checkpoint, and saves
-them back out as Hugging Face-compatible safetensors.
+This tool rebuilds the original distributed model topology from ``config.yaml``
+using the recipe recorded in that config (LLM or VLM), loads only the model
+weights from a sharded ``torch_save`` checkpoint, and saves them back out as
+Hugging Face-compatible safetensors. Because the model is rebuilt with the same
+recipe that produced the checkpoint, a VLM checkpoint keeps its vision tower
+instead of being silently exported as a text-only model.
 
 Example:
     torchrun --nproc-per-node=8 scripts/export_llm_dcp_to_hf.py \
@@ -27,6 +30,7 @@ Example:
 from __future__ import annotations
 
 import argparse
+import importlib
 import re
 from pathlib import Path
 from typing import Sequence
@@ -34,11 +38,12 @@ from typing import Sequence
 import torch
 from torch.nn.parallel import DistributedDataParallel
 
+from nemo_automodel.cli.utils import resolve_recipe_name
 from nemo_automodel.components.checkpoint.checkpointing import save_config
 from nemo_automodel.components.checkpoint.utils import is_rank_0
 from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
 from nemo_automodel.components.config.loader import ConfigNode
-from nemo_automodel.recipes.llm.train_ft import TrainFinetuneRecipeForNextTokenPrediction
+from nemo_automodel.recipes.base_recipe import BaseRecipe
 
 _CHECKPOINT_DIR_RE = re.compile(r"epoch_(\d+)_step_(\d+)$")
 
@@ -140,8 +145,29 @@ def build_export_config(args: argparse.Namespace) -> ConfigNode:
     return cfg
 
 
+def build_recipe(cfg: ConfigNode) -> BaseRecipe:
+    """Instantiate the recipe class recorded in ``cfg.recipe`` (LLM or VLM).
+
+    The model topology must be rebuilt with the same recipe that wrote the
+    checkpoint; otherwise an LLM recipe would construct a text-only model for a
+    VLM checkpoint and drop its vision tower. ``allow_checkpoint_key_subset`` then
+    raises on the unmatched keys instead of silently exporting a partial model.
+    """
+    raw = cfg.get("recipe", None)
+    if raw is None:
+        raise ValueError("config.yaml has no 'recipe' field, so the model architecture cannot be rebuilt for export.")
+    module_name, _, class_name = resolve_recipe_name(raw).rpartition(".")
+    recipe_cls = getattr(importlib.import_module(module_name), class_name)
+    return recipe_cls(cfg)
+
+
+def resolve_export_tokenizer(trainer: BaseRecipe):
+    """Return the tokenizer (LLM) or processor (VLM) to persist with the export."""
+    return getattr(trainer, "tokenizer", None) or getattr(trainer, "processor", None)
+
+
 def resolve_model_for_export(
-    trainer: TrainFinetuneRecipeForNextTokenPrediction,
+    trainer: BaseRecipe,
 ) -> torch.nn.Module | list[torch.nn.Module]:
     """Return the model object that should be passed to the checkpointer."""
     model_parts = trainer.model_parts
@@ -159,15 +185,21 @@ def barrier() -> None:
         torch.distributed.barrier()
 
 
-def close_trainer(trainer: TrainFinetuneRecipeForNextTokenPrediction | None) -> None:
+def close_trainer(trainer: BaseRecipe | None) -> None:
     """Best-effort cleanup for recipe-owned resources."""
     if trainer is None:
         return
-    if hasattr(trainer, "metric_logger_train"):
-        trainer.metric_logger_train.close()
-    if hasattr(trainer, "metric_logger_valid"):
-        for logger in trainer.metric_logger_valid.values():
-            logger.close()
+    # The LLM recipe keeps validation loggers in a dict (one per val set); the VLM
+    # recipe keeps a single logger. Handle both without assuming the shape.
+    for attr in ("metric_logger_train", "metric_logger_valid"):
+        logger_obj = getattr(trainer, attr, None)
+        if logger_obj is None:
+            continue
+        loggers = logger_obj.values() if isinstance(logger_obj, dict) else [logger_obj]
+        for logger in loggers:
+            close = getattr(logger, "close", None)
+            if close is not None:
+                close()
     if hasattr(trainer, "checkpointer"):
         trainer.checkpointer.close()
 
@@ -183,9 +215,9 @@ def main(argv: Sequence[str] | None = None) -> None:
         raise FileExistsError(f"Export directory already exists: {export_root}")
     cfg = build_export_config(args)
 
-    trainer: TrainFinetuneRecipeForNextTokenPrediction | None = None
+    trainer: BaseRecipe | None = None
     try:
-        trainer = TrainFinetuneRecipeForNextTokenPrediction(cfg)
+        trainer = build_recipe(cfg)
         trainer.setup()
         export_model = resolve_model_for_export(trainer)
         # Idempotent on every rank, so a filesystem failure raises everywhere
@@ -205,7 +237,7 @@ def main(argv: Sequence[str] | None = None) -> None:
         trainer.checkpointer.save_model(
             model=export_model,
             weights_path=str(export_root),
-            tokenizer=trainer.tokenizer,
+            tokenizer=resolve_export_tokenizer(trainer),
             is_final_checkpoint=True,
         )
     finally:

--- a/tests/unit_tests/checkpoint/test_checkpointing.py
+++ b/tests/unit_tests/checkpoint/test_checkpointing.py
@@ -1050,6 +1050,37 @@ class TestLoadModelCheckpointKeySubset:
                     allow_checkpoint_key_subset=True,
                 )
 
+    def test_allow_checkpoint_key_subset_raises_on_keys_absent_from_model(self):
+        """A checkpoint carrying keys the built model lacks (e.g. a VLM checkpoint
+        loaded into an LLM model) must raise instead of silently dropping them."""
+        checkpointer = self._make_checkpointer()
+        model = torch.nn.Module()
+        initial_state_dict = {"language_model.layer.weight": torch.zeros(2, 2)}
+
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("nemo_automodel.components.checkpoint.checkpointing.ModelState") as mock_model_state_cls,
+            patch.object(checkpointer, "_get_storage_reader", return_value=object()),
+            patch(
+                "nemo_automodel.components.checkpoint.checkpointing._maybe_adapt_state_dict_to_hf",
+                side_effect=lambda module, state_dict, **kwargs: state_dict,
+            ),
+            patch(
+                "nemo_automodel.components.checkpoint.checkpointing._get_checkpoint_metadata_keys",
+                return_value={"language_model.layer.weight", "vision_tower.block.weight"},
+            ),
+        ):
+            mock_model_state = mock_model_state_cls.return_value
+            mock_model_state.model = [model]
+            mock_model_state.state_dict.return_value = initial_state_dict.copy()
+
+            with pytest.raises(RuntimeError, match="keys absent from the built model"):
+                checkpointer.load_model(
+                    model,
+                    model_path="/fake/path",
+                    allow_checkpoint_key_subset=True,
+                )
+
     def test_allow_checkpoint_key_subset_still_warns_on_unexpected_keys(self, caplog):
         checkpointer = self._make_checkpointer()
         model = torch.nn.Module()

--- a/tests/unit_tests/checkpoint/test_checkpointing.py
+++ b/tests/unit_tests/checkpoint/test_checkpointing.py
@@ -1018,6 +1018,79 @@ class TestLoadModelCheckpointKeySubset:
         assert set(mock_model_state.load_state_dict.call_args.args[0]) == {"layer.weight"}
         assert mock_model_state.load_state_dict.call_args.kwargs["strict"] is False
 
+    def test_allow_checkpoint_key_subset_raises_when_no_keys_match(self):
+        checkpointer = self._make_checkpointer()
+        model = torch.nn.Module()
+        initial_state_dict = {
+            "layer.weight": torch.zeros(2, 2),
+            "other.weight": torch.zeros(2, 2),
+        }
+
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("nemo_automodel.components.checkpoint.checkpointing.ModelState") as mock_model_state_cls,
+            patch.object(checkpointer, "_get_storage_reader", return_value=object()),
+            patch(
+                "nemo_automodel.components.checkpoint.checkpointing._maybe_adapt_state_dict_to_hf",
+                side_effect=lambda module, state_dict, **kwargs: state_dict,
+            ),
+            patch(
+                "nemo_automodel.components.checkpoint.checkpointing._get_checkpoint_metadata_keys",
+                return_value={"unrelated.weight"},
+            ),
+        ):
+            mock_model_state = mock_model_state_cls.return_value
+            mock_model_state.model = [model]
+            mock_model_state.state_dict.return_value = initial_state_dict.copy()
+
+            with pytest.raises(RuntimeError, match="contains none of the .* requested model keys"):
+                checkpointer.load_model(
+                    model,
+                    model_path="/fake/path",
+                    allow_checkpoint_key_subset=True,
+                )
+
+    def test_allow_checkpoint_key_subset_still_warns_on_unexpected_keys(self, caplog):
+        checkpointer = self._make_checkpointer()
+        model = torch.nn.Module()
+        initial_state_dict = {
+            "layer.weight": torch.zeros(2, 2),
+            "model.embed_vision.embedding_projection.weight": torch.zeros(2, 2),
+        }
+
+        caplog.set_level(logging.WARNING)
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("nemo_automodel.components.checkpoint.checkpointing.ModelState") as mock_model_state_cls,
+            patch.object(checkpointer, "_get_storage_reader", return_value=object()),
+            patch(
+                "nemo_automodel.components.checkpoint.checkpointing._maybe_adapt_state_dict_to_hf",
+                side_effect=lambda module, state_dict, **kwargs: state_dict,
+            ),
+            patch(
+                "nemo_automodel.components.checkpoint.checkpointing._maybe_adapt_state_dict_from_hf",
+                side_effect=lambda module, state_dict, **kwargs: {**state_dict, "stray.weight": torch.ones(1)},
+            ),
+            patch(
+                "nemo_automodel.components.checkpoint.checkpointing._get_checkpoint_metadata_keys",
+                return_value={"layer.weight"},
+            ),
+            patch.object(checkpointer, "_do_load", side_effect=lambda state_dict, *args, **kwargs: state_dict),
+        ):
+            mock_model_state = mock_model_state_cls.return_value
+            mock_model_state.model = [model]
+            mock_model_state.state_dict.return_value = initial_state_dict.copy()
+
+            checkpointer.load_model(
+                model,
+                model_path="/fake/path",
+                allow_checkpoint_key_subset=True,
+            )
+
+        assert "Checkpoint key mismatch" in caplog.text
+        assert "unexpected=1" in caplog.text
+        assert "missing=0" in caplog.text
+
 
 # =============================================================================
 # Tests for Checkpointer.initialize_model_weights
@@ -1463,6 +1536,9 @@ class TestOfflineConsolidationScriptAndWarnings:
             caplog.text
         )
         assert "scripts/export_llm_dcp_to_hf.py" in caplog.text
+        # The v4_compatible advice concerns consolidated output, which was just
+        # declared ignored; it must not fire for non-safetensors formats.
+        assert "v4_compatible" not in caplog.text
 
     def test_torch_save_never_writes_consolidated_safetensors(self, tmp_path):
         checkpointer = self._make_checkpointer(
@@ -1771,12 +1847,30 @@ class TestGetStorageReaderInitStep:
                 "nemo_automodel.components.checkpoint.checkpointing._HuggingFaceStorageReader",
                 backport_marker,
             ),
+            patch(
+                "nemo_automodel.components.checkpoint.checkpointing._is_safetensors_checkpoint",
+                return_value=True,
+            ),
         ):
             reader = checkpointer._get_storage_reader(model_path="/fake/path", key_mapping=None, is_init_step=False)
 
         upstream_marker.assert_called_once_with(path="/fake/path")
         backport_marker.assert_not_called()
         assert reader is upstream_marker.return_value
+
+    def test_non_init_step_non_safetensors_dir_returns_none(self):
+        """A safetensors-configured checkpointer pointed at a torch_save DCP directory
+        must fall back to the default DCP FileSystemReader (None), not the HF reader,
+        which would return empty metadata for such a directory."""
+        checkpointer = self._make_checkpointer()
+
+        with patch(
+            "nemo_automodel.components.checkpoint.checkpointing._is_safetensors_checkpoint",
+            return_value=False,
+        ):
+            reader = checkpointer._get_storage_reader(model_path="/fake/path", key_mapping=None, is_init_step=False)
+
+        assert reader is None
 
     def test_keymap_always_uses_backport(self):
         """When a key_mapping is supplied, the backport reader is always used (regardless of is_init_step)."""
@@ -1793,6 +1887,10 @@ class TestGetStorageReaderInitStep:
             patch(
                 "nemo_automodel.components.checkpoint.checkpointing._HuggingFaceStorageReader",
                 backport_marker,
+            ),
+            patch(
+                "nemo_automodel.components.checkpoint.checkpointing._is_safetensors_checkpoint",
+                return_value=True,
             ),
         ):
             mapping = {"old.key": "new.key"}

--- a/tests/unit_tests/checkpoint/test_checkpointing.py
+++ b/tests/unit_tests/checkpoint/test_checkpointing.py
@@ -953,6 +953,72 @@ class TestLoadModelCustomModelGuard:
         mock_dcp_load.assert_not_called()
 
 
+class TestLoadModelCheckpointKeySubset:
+    """Test allow_checkpoint_key_subset support for torch_save exports."""
+
+    def _make_checkpointer(self):
+        config = CheckpointingConfig(
+            enabled=True,
+            checkpoint_dir="/tmp/test",
+            model_save_format="safetensors",
+            model_cache_dir="/tmp/cache",
+            model_repo_id="test/model",
+            save_consolidated=False,
+            is_peft=False,
+        )
+        with patch("torch.distributed.is_initialized", return_value=False):
+            return Checkpointer(config, dp_rank=0, tp_rank=0, pp_rank=0, moe_mesh=None)
+
+    def test_allow_checkpoint_key_subset_drops_missing_destination_keys(self, caplog):
+        checkpointer = self._make_checkpointer()
+        model = torch.nn.Module()
+        initial_state_dict = {
+            "layer.weight": torch.zeros(2, 2),
+            "model.embed_vision.embedding_projection.weight": torch.zeros(2, 2),
+        }
+        captured = {}
+
+        def fake_do_load(state_dict, *args, **kwargs):
+            captured["requested_keys"] = set(state_dict)
+            return {key: torch.ones_like(value) for key, value in state_dict.items()}
+
+        caplog.set_level(logging.WARNING)
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("nemo_automodel.components.checkpoint.checkpointing.ModelState") as mock_model_state_cls,
+            patch.object(checkpointer, "_get_storage_reader", return_value=object()),
+            patch(
+                "nemo_automodel.components.checkpoint.checkpointing._maybe_adapt_state_dict_to_hf",
+                side_effect=lambda module, state_dict, **kwargs: state_dict,
+            ),
+            patch(
+                "nemo_automodel.components.checkpoint.checkpointing._maybe_adapt_state_dict_from_hf",
+                side_effect=lambda module, state_dict, **kwargs: state_dict,
+            ),
+            patch(
+                "nemo_automodel.components.checkpoint.checkpointing._get_checkpoint_metadata_keys",
+                return_value={"layer.weight"},
+            ),
+            patch.object(checkpointer, "_do_load", side_effect=fake_do_load),
+        ):
+            mock_model_state = mock_model_state_cls.return_value
+            mock_model_state.model = [model]
+            mock_model_state.state_dict.return_value = initial_state_dict.copy()
+
+            checkpointer.load_model(
+                model,
+                model_path="/fake/path",
+                allow_checkpoint_key_subset=True,
+            )
+
+        assert captured["requested_keys"] == {"layer.weight"}
+        assert "allow_checkpoint_key_subset=True" in caplog.text
+        assert "model.embed_vision.embedding_projection.weight" in caplog.text
+        mock_model_state.load_state_dict.assert_called_once()
+        assert set(mock_model_state.load_state_dict.call_args.args[0]) == {"layer.weight"}
+        assert mock_model_state.load_state_dict.call_args.kwargs["strict"] is False
+
+
 # =============================================================================
 # Tests for Checkpointer.initialize_model_weights
 # =============================================================================
@@ -1244,11 +1310,17 @@ class TestCheckpointerSaveModelDiffusersRename:
 class TestOfflineConsolidationScriptAndWarnings:
     """Focused tests for offline consolidation helper generation and warnings."""
 
-    def _make_checkpointer(self, tmp_path, save_consolidated=False, diffusers_compatible=False):
+    def _make_checkpointer(
+        self,
+        tmp_path,
+        save_consolidated=False,
+        diffusers_compatible=False,
+        model_save_format="safetensors",
+    ):
         config = CheckpointingConfig(
             enabled=True,
             checkpoint_dir=str(tmp_path),
-            model_save_format="safetensors",
+            model_save_format=model_save_format,
             model_cache_dir=str(tmp_path / "cache"),
             model_repo_id="test/model",
             save_consolidated=save_consolidated,
@@ -1381,6 +1453,26 @@ class TestOfflineConsolidationScriptAndWarnings:
 
         assert _should_write_consolidated_safetensors(checkpointer.config, is_final_checkpoint=False) is False
         assert _should_write_consolidated_safetensors(checkpointer.config, is_final_checkpoint=True) is True
+
+    def test_torch_save_warns_that_save_consolidated_is_ignored(self, tmp_path, caplog):
+        caplog.set_level(logging.WARNING)
+
+        self._make_checkpointer(tmp_path, save_consolidated="final", model_save_format="torch_save")
+
+        assert "checkpoint.save_consolidated=final is ignored when checkpoint.model_save_format=torch_save" in (
+            caplog.text
+        )
+        assert "scripts/export_llm_dcp_to_hf.py" in caplog.text
+
+    def test_torch_save_never_writes_consolidated_safetensors(self, tmp_path):
+        checkpointer = self._make_checkpointer(
+            tmp_path,
+            save_consolidated="final",
+            model_save_format="torch_save",
+        )
+
+        assert _should_write_consolidated_safetensors(checkpointer.config, is_final_checkpoint=False) is False
+        assert _should_write_consolidated_safetensors(checkpointer.config, is_final_checkpoint=True) is False
 
     def test_setup_warns_for_inline_consolidation(self, tmp_path, monkeypatch, caplog):
         monkeypatch.setenv("WORLD_SIZE", "1")

--- a/tests/unit_tests/scripts/test_export_llm_dcp_to_hf.py
+++ b/tests/unit_tests/scripts/test_export_llm_dcp_to_hf.py
@@ -243,7 +243,7 @@ def test_main_exports_checkpoint_end_to_end(monkeypatch, tmp_path):
     model = object()
     exported_yaml = {"checkpoint": {"model_save_format": "safetensors"}}
     monkeypatch.setattr(script, "build_export_config", lambda args: MagicMock(to_yaml_dict=lambda: exported_yaml))
-    monkeypatch.setattr(script, "TrainFinetuneRecipeForNextTokenPrediction", lambda cfg: trainer)
+    monkeypatch.setattr(script, "build_recipe", lambda cfg: trainer)
     monkeypatch.setattr(script, "resolve_model_for_export", lambda t: model)
     save_config_calls = {}
     monkeypatch.setattr(
@@ -301,9 +301,66 @@ def test_main_closes_trainer_even_when_setup_fails(monkeypatch, tmp_path):
     trainer = MagicMock()
     trainer.setup.side_effect = RuntimeError("boom")
     monkeypatch.setattr(script, "build_export_config", lambda args: MagicMock(to_yaml_dict=lambda: {}))
-    monkeypatch.setattr(script, "TrainFinetuneRecipeForNextTokenPrediction", lambda cfg: trainer)
+    monkeypatch.setattr(script, "build_recipe", lambda cfg: trainer)
 
     with pytest.raises(RuntimeError, match="boom"):
         script.main(["--checkpoint-dir", str(checkpoint_dir), "--output-dir", str(output_dir)])
 
+    trainer.checkpointer.close.assert_called_once()
+
+
+def test_build_recipe_dispatches_on_config_recipe_field(monkeypatch):
+    from scripts import export_llm_dcp_to_hf as script
+
+    captured = {}
+
+    class _FakeVLMRecipe:
+        def __init__(self, cfg):
+            captured["cfg"] = cfg
+
+    monkeypatch.setattr(script, "resolve_recipe_name", lambda raw: "pkg.mod.FinetuneRecipeForVLM")
+    monkeypatch.setattr(script.importlib, "import_module", lambda name: Namespace(FinetuneRecipeForVLM=_FakeVLMRecipe))
+    cfg = MagicMock()
+    cfg.get.return_value = "FinetuneRecipeForVLM"
+
+    recipe = script.build_recipe(cfg)
+
+    assert isinstance(recipe, _FakeVLMRecipe)
+    assert captured["cfg"] is cfg
+
+
+def test_build_recipe_requires_recipe_field():
+    from scripts.export_llm_dcp_to_hf import build_recipe
+
+    cfg = MagicMock()
+    cfg.get.return_value = None
+    with pytest.raises(ValueError, match="no 'recipe' field"):
+        build_recipe(cfg)
+
+
+def test_resolve_export_tokenizer_prefers_tokenizer_then_processor():
+    from scripts.export_llm_dcp_to_hf import resolve_export_tokenizer
+
+    tok, proc = object(), object()
+    assert resolve_export_tokenizer(Namespace(tokenizer=tok, processor=proc)) is tok
+    # VLM recipe exposes ``processor`` and no ``tokenizer``.
+    assert resolve_export_tokenizer(Namespace(processor=proc)) is proc
+    assert resolve_export_tokenizer(Namespace()) is None
+
+
+def test_close_trainer_handles_single_metric_logger():
+    from scripts.export_llm_dcp_to_hf import close_trainer
+
+    train_logger, valid_logger = MagicMock(), MagicMock()
+    # VLM recipe keeps a single validation logger rather than a dict.
+    trainer = Namespace(
+        metric_logger_train=train_logger,
+        metric_logger_valid=valid_logger,
+        checkpointer=MagicMock(),
+    )
+
+    close_trainer(trainer)
+
+    train_logger.close.assert_called_once()
+    valid_logger.close.assert_called_once()
     trainer.checkpointer.close.assert_called_once()

--- a/tests/unit_tests/scripts/test_export_llm_dcp_to_hf.py
+++ b/tests/unit_tests/scripts/test_export_llm_dcp_to_hf.py
@@ -1,0 +1,129 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from argparse import Namespace
+
+import pytest
+
+
+def test_infer_config_path_uses_checkpoint_dir():
+    from scripts.export_llm_dcp_to_hf import infer_config_path
+
+    config_path = infer_config_path("/tmp/run/checkpoints/epoch_1_step_23")
+
+    assert str(config_path) == "/tmp/run/checkpoints/epoch_1_step_23/config.yaml"
+
+
+def test_infer_epoch_step_parses_checkpoint_name():
+    from scripts.export_llm_dcp_to_hf import infer_epoch_step
+
+    assert infer_epoch_step("/tmp/run/checkpoints/epoch_3_step_456") == (3, 456)
+
+
+def test_infer_epoch_step_requires_standard_checkpoint_name():
+    from scripts.export_llm_dcp_to_hf import infer_epoch_step
+
+    with pytest.raises(ValueError):
+        infer_epoch_step("/tmp/run/checkpoints/latest")
+
+
+def test_resolve_epoch_step_prefers_explicit_values():
+    from scripts.export_llm_dcp_to_hf import resolve_epoch_step
+
+    assert resolve_epoch_step("/tmp/run/checkpoints/epoch_3_step_456", 9, 10) == (9, 10)
+
+
+def test_infer_export_root_uses_epoch_and_step():
+    from scripts.export_llm_dcp_to_hf import infer_export_root
+
+    export_root = infer_export_root("/tmp/export", 7, 99)
+
+    assert str(export_root) == "/tmp/export/epoch_7_step_99"
+
+
+def test_disable_tracking_loggers_strips_remote_logger_sections():
+    from nemo_automodel.components.config.loader import ConfigNode
+    from scripts.export_llm_dcp_to_hf import disable_tracking_loggers
+
+    cfg = ConfigNode(
+        {
+            "wandb": {"project": "demo"},
+            "mlflow": {"experiment": "demo"},
+            "comet": {"project": "demo"},
+            "checkpoint": {"enabled": True},
+        }
+    )
+
+    disable_tracking_loggers(cfg)
+
+    assert not hasattr(cfg, "wandb")
+    assert not hasattr(cfg, "mlflow")
+    assert not hasattr(cfg, "comet")
+    assert cfg.checkpoint.enabled is True
+
+
+def test_build_export_config_applies_export_overrides(monkeypatch):
+    from nemo_automodel.components.config.loader import ConfigNode
+    from scripts import export_llm_dcp_to_hf as script
+
+    captured = {}
+
+    def fake_parse_args_and_load_config(config_path, argv):
+        captured["config_path"] = config_path
+        captured["argv"] = argv
+        return ConfigNode({"checkpoint": {"enabled": True}, "wandb": {"project": "demo"}})
+
+    monkeypatch.setattr(script, "parse_args_and_load_config", fake_parse_args_and_load_config)
+
+    cfg = script.build_export_config(
+        Namespace(
+            checkpoint_dir="/tmp/run/checkpoints/epoch_0_step_42",
+            output_dir="/tmp/export",
+            config=None,
+            model_name_or_path="/models/gemma4",
+            save_consolidated="final",
+            epoch=None,
+            step=None,
+        )
+    )
+
+    assert captured["config_path"] == "/tmp/run/checkpoints/epoch_0_step_42/config.yaml"
+    assert captured["argv"] == [
+        "--checkpoint.restore_from",
+        "None",
+        "--checkpoint.checkpoint_dir",
+        "/tmp/export/.export_workdir",
+        "--checkpoint.model_save_format",
+        "safetensors",
+        "--checkpoint.save_consolidated",
+        "final",
+    ]
+    assert cfg.model.pretrained_model_name_or_path == "/models/gemma4"
+    assert not hasattr(cfg, "wandb")
+
+
+def test_resolve_model_for_export_unwraps_single_ddp(monkeypatch):
+    from scripts import export_llm_dcp_to_hf as script
+
+    model = object()
+
+    class FakeDDP:
+        def __init__(self, wrapped_module):
+            self.module = wrapped_module
+
+    monkeypatch.setattr(script, "DistributedDataParallel", FakeDDP)
+
+    trainer = Namespace(model_parts=[FakeDDP(model)])
+
+    assert script.resolve_model_for_export(trainer) is model

--- a/tests/unit_tests/scripts/test_export_llm_dcp_to_hf.py
+++ b/tests/unit_tests/scripts/test_export_llm_dcp_to_hf.py
@@ -29,15 +29,6 @@ def test_parse_args_uses_defaults_for_optional_flags():
     assert args.model_name_or_path is None
     assert args.epoch is None
     assert args.step is None
-    assert args.save_consolidated == "final"
-
-
-def test_infer_config_path_uses_checkpoint_dir():
-    from scripts.export_llm_dcp_to_hf import infer_config_path
-
-    config_path = infer_config_path("/tmp/run/checkpoints/epoch_1_step_23")
-
-    assert str(config_path) == "/tmp/run/checkpoints/epoch_1_step_23/config.yaml"
 
 
 def test_infer_epoch_step_parses_checkpoint_name():
@@ -59,46 +50,19 @@ def test_resolve_epoch_step_prefers_explicit_values():
     assert resolve_epoch_step("/tmp/run/checkpoints/epoch_3_step_456", 9, 10) == (9, 10)
 
 
+def test_resolve_epoch_step_with_explicit_values_skips_name_parsing():
+    from scripts.export_llm_dcp_to_hf import resolve_epoch_step
+
+    # A non-standard directory name must be fine when both flags are given,
+    # which is exactly the workaround the infer_epoch_step error suggests.
+    assert resolve_epoch_step("/tmp/run/checkpoints/latest", 0, 500) == (0, 500)
+
+
 def test_resolve_epoch_step_falls_back_to_inferred_values():
     from scripts.export_llm_dcp_to_hf import resolve_epoch_step
 
     assert resolve_epoch_step("/tmp/run/checkpoints/epoch_3_step_456", None, None) == (3, 456)
     assert resolve_epoch_step("/tmp/run/checkpoints/epoch_3_step_456", 9, None) == (9, 456)
-
-
-def test_infer_export_workdir_uses_hidden_directory():
-    from scripts.export_llm_dcp_to_hf import infer_export_workdir
-
-    assert str(infer_export_workdir("/tmp/export")) == "/tmp/export/.export_workdir"
-
-
-def test_infer_export_root_uses_epoch_and_step():
-    from scripts.export_llm_dcp_to_hf import infer_export_root
-
-    export_root = infer_export_root("/tmp/export", 7, 99)
-
-    assert str(export_root) == "/tmp/export/epoch_7_step_99"
-
-
-def test_disable_tracking_loggers_strips_remote_logger_sections():
-    from nemo_automodel.components.config.loader import ConfigNode
-    from scripts.export_llm_dcp_to_hf import disable_tracking_loggers
-
-    cfg = ConfigNode(
-        {
-            "wandb": {"project": "demo"},
-            "mlflow": {"experiment": "demo"},
-            "comet": {"project": "demo"},
-            "checkpoint": {"enabled": True},
-        }
-    )
-
-    disable_tracking_loggers(cfg)
-
-    assert not hasattr(cfg, "wandb")
-    assert not hasattr(cfg, "mlflow")
-    assert not hasattr(cfg, "comet")
-    assert cfg.checkpoint.enabled is True
 
 
 def test_build_export_config_applies_export_overrides(monkeypatch):
@@ -120,7 +84,6 @@ def test_build_export_config_applies_export_overrides(monkeypatch):
             output_dir="/tmp/export",
             config=None,
             model_name_or_path="/models/gemma4",
-            save_consolidated="final",
             epoch=None,
             step=None,
         )
@@ -136,9 +99,14 @@ def test_build_export_config_applies_export_overrides(monkeypatch):
         "safetensors",
         "--checkpoint.save_consolidated",
         "final",
+        "--wandb",
+        "None",
+        "--mlflow",
+        "None",
+        "--comet",
+        "None",
     ]
     assert cfg.model.pretrained_model_name_or_path == "/models/gemma4"
-    assert not hasattr(cfg, "wandb")
 
 
 def test_build_export_config_uses_explicit_config_path_without_model_override(monkeypatch):
@@ -159,7 +127,6 @@ def test_build_export_config_uses_explicit_config_path_without_model_override(mo
             output_dir="/tmp/export",
             config="/custom/config.yaml",
             model_name_or_path=None,
-            save_consolidated="every",
             epoch=None,
             step=None,
         )
@@ -168,6 +135,29 @@ def test_build_export_config_uses_explicit_config_path_without_model_override(mo
     assert captured["config_path"] == "/custom/config.yaml"
     # No --model-name-or-path override, so the recorded base model path is untouched.
     assert cfg.model.pretrained_model_name_or_path == "/orig"
+
+
+def test_build_export_config_rejects_peft_configs(monkeypatch):
+    from nemo_automodel.components.config.loader import ConfigNode
+    from scripts import export_llm_dcp_to_hf as script
+
+    monkeypatch.setattr(
+        script,
+        "parse_args_and_load_config",
+        lambda config_path, argv: ConfigNode({"checkpoint": {"enabled": True}, "peft": {"match_all_linear": True}}),
+    )
+
+    with pytest.raises(ValueError, match="PEFT checkpoints"):
+        script.build_export_config(
+            Namespace(
+                checkpoint_dir="/tmp/run/checkpoints/epoch_0_step_42",
+                output_dir="/tmp/export",
+                config=None,
+                model_name_or_path=None,
+                epoch=None,
+                step=None,
+            )
+        )
 
 
 def test_resolve_model_for_export_unwraps_single_ddp(monkeypatch):
@@ -204,56 +194,6 @@ def test_resolve_model_for_export_returns_multipart_list_unchanged():
     assert script.resolve_model_for_export(trainer) is parts
 
 
-def test_resolve_model_for_export_falls_back_to_model_attribute():
-    from scripts import export_llm_dcp_to_hf as script
-
-    model = object()
-    trainer = Namespace(model_parts=None, model=model)
-
-    assert script.resolve_model_for_export(trainer) is model
-
-
-def test_resolve_model_for_export_raises_when_no_model():
-    from scripts import export_llm_dcp_to_hf as script
-
-    trainer = Namespace(model_parts=None, model=None)
-
-    with pytest.raises(ValueError, match="did not expose a model"):
-        script.resolve_model_for_export(trainer)
-
-
-def test_resolve_model_for_export_raises_on_empty_model_parts():
-    from scripts import export_llm_dcp_to_hf as script
-
-    trainer = Namespace(model_parts=[])
-
-    with pytest.raises(ValueError, match="empty model_parts"):
-        script.resolve_model_for_export(trainer)
-
-
-def test_is_main_process_true_when_distributed_not_initialized(monkeypatch):
-    import torch.distributed as dist
-
-    from scripts import export_llm_dcp_to_hf as script
-
-    monkeypatch.setattr(dist, "is_initialized", lambda: False)
-
-    assert script.is_main_process() is True
-
-
-def test_is_main_process_respects_rank_when_distributed(monkeypatch):
-    import torch.distributed as dist
-
-    from scripts import export_llm_dcp_to_hf as script
-
-    monkeypatch.setattr(dist, "is_initialized", lambda: True)
-    monkeypatch.setattr(dist, "get_rank", lambda: 0)
-    assert script.is_main_process() is True
-
-    monkeypatch.setattr(dist, "get_rank", lambda: 1)
-    assert script.is_main_process() is False
-
-
 def test_barrier_invokes_distributed_barrier_only_when_initialized(monkeypatch):
     import torch.distributed as dist
 
@@ -269,42 +209,6 @@ def test_barrier_invokes_distributed_barrier_only_when_initialized(monkeypatch):
     monkeypatch.setattr(dist, "is_initialized", lambda: True)
     script.barrier()
     assert mock_barrier.call_count == 1
-
-
-def test_prepare_export_root_creates_directory_on_main(monkeypatch, tmp_path):
-    from scripts import export_llm_dcp_to_hf as script
-
-    monkeypatch.setattr(script, "is_main_process", lambda: True)
-    monkeypatch.setattr(script, "barrier", lambda: None)
-    export_root = tmp_path / "epoch_0_step_1"
-
-    script.prepare_export_root(export_root)
-
-    assert export_root.is_dir()
-
-
-def test_prepare_export_root_raises_when_directory_exists(monkeypatch, tmp_path):
-    from scripts import export_llm_dcp_to_hf as script
-
-    monkeypatch.setattr(script, "is_main_process", lambda: True)
-    monkeypatch.setattr(script, "barrier", lambda: None)
-    export_root = tmp_path / "epoch_0_step_1"
-    export_root.mkdir()
-
-    with pytest.raises(FileExistsError):
-        script.prepare_export_root(export_root)
-
-
-def test_prepare_export_root_skips_creation_on_non_main(monkeypatch, tmp_path):
-    from scripts import export_llm_dcp_to_hf as script
-
-    monkeypatch.setattr(script, "is_main_process", lambda: False)
-    monkeypatch.setattr(script, "barrier", lambda: None)
-    export_root = tmp_path / "epoch_0_step_1"
-
-    script.prepare_export_root(export_root)
-
-    assert not export_root.exists()
 
 
 def test_close_trainer_is_noop_for_none():
@@ -337,7 +241,8 @@ def test_main_exports_checkpoint_end_to_end(monkeypatch, tmp_path):
 
     trainer = MagicMock()
     model = object()
-    monkeypatch.setattr(script, "build_export_config", lambda args: MagicMock(to_dict=lambda: {"checkpoint": {}}))
+    exported_yaml = {"checkpoint": {"model_save_format": "safetensors"}}
+    monkeypatch.setattr(script, "build_export_config", lambda args: MagicMock(to_yaml_dict=lambda: exported_yaml))
     monkeypatch.setattr(script, "TrainFinetuneRecipeForNextTokenPrediction", lambda cfg: trainer)
     monkeypatch.setattr(script, "resolve_model_for_export", lambda t: model)
     save_config_calls = {}
@@ -361,8 +266,29 @@ def test_main_exports_checkpoint_end_to_end(monkeypatch, tmp_path):
     assert save_kwargs["is_final_checkpoint"] is True
     assert save_kwargs["tokenizer"] is trainer.tokenizer
 
+    # The exported config must come from to_yaml_dict(): to_dict() would serialize
+    # resolved _target_ objects as !!python tags that yaml.safe_load rejects.
+    assert save_config_calls["config"] is exported_yaml
     assert save_config_calls["path"] == str(export_root)
     trainer.checkpointer.close.assert_called_once()
+
+
+def test_main_fails_fast_when_export_root_exists(monkeypatch, tmp_path):
+    from scripts import export_llm_dcp_to_hf as script
+
+    checkpoint_dir = tmp_path / "checkpoints" / "epoch_2_step_7"
+    checkpoint_dir.mkdir(parents=True)
+    export_root = tmp_path / "export" / "epoch_2_step_7"
+    export_root.mkdir(parents=True)
+
+    build_config = MagicMock()
+    monkeypatch.setattr(script, "build_export_config", build_config)
+
+    with pytest.raises(FileExistsError, match="already exists"):
+        script.main(["--checkpoint-dir", str(checkpoint_dir), "--output-dir", str(tmp_path / "export")])
+
+    # The check runs before any expensive recipe construction.
+    build_config.assert_not_called()
 
 
 def test_main_closes_trainer_even_when_setup_fails(monkeypatch, tmp_path):
@@ -374,7 +300,7 @@ def test_main_closes_trainer_even_when_setup_fails(monkeypatch, tmp_path):
 
     trainer = MagicMock()
     trainer.setup.side_effect = RuntimeError("boom")
-    monkeypatch.setattr(script, "build_export_config", lambda args: MagicMock(to_dict=lambda: {}))
+    monkeypatch.setattr(script, "build_export_config", lambda args: MagicMock(to_yaml_dict=lambda: {}))
     monkeypatch.setattr(script, "TrainFinetuneRecipeForNextTokenPrediction", lambda cfg: trainer)
 
     with pytest.raises(RuntimeError, match="boom"):

--- a/tests/unit_tests/scripts/test_export_llm_dcp_to_hf.py
+++ b/tests/unit_tests/scripts/test_export_llm_dcp_to_hf.py
@@ -13,8 +13,23 @@
 # limitations under the License.
 
 from argparse import Namespace
+from unittest.mock import MagicMock
 
 import pytest
+
+
+def test_parse_args_uses_defaults_for_optional_flags():
+    from scripts.export_llm_dcp_to_hf import parse_args
+
+    args = parse_args(["--checkpoint-dir", "/tmp/ckpt/epoch_0_step_1", "--output-dir", "/tmp/export"])
+
+    assert args.checkpoint_dir == "/tmp/ckpt/epoch_0_step_1"
+    assert args.output_dir == "/tmp/export"
+    assert args.config is None
+    assert args.model_name_or_path is None
+    assert args.epoch is None
+    assert args.step is None
+    assert args.save_consolidated == "final"
 
 
 def test_infer_config_path_uses_checkpoint_dir():
@@ -42,6 +57,19 @@ def test_resolve_epoch_step_prefers_explicit_values():
     from scripts.export_llm_dcp_to_hf import resolve_epoch_step
 
     assert resolve_epoch_step("/tmp/run/checkpoints/epoch_3_step_456", 9, 10) == (9, 10)
+
+
+def test_resolve_epoch_step_falls_back_to_inferred_values():
+    from scripts.export_llm_dcp_to_hf import resolve_epoch_step
+
+    assert resolve_epoch_step("/tmp/run/checkpoints/epoch_3_step_456", None, None) == (3, 456)
+    assert resolve_epoch_step("/tmp/run/checkpoints/epoch_3_step_456", 9, None) == (9, 456)
+
+
+def test_infer_export_workdir_uses_hidden_directory():
+    from scripts.export_llm_dcp_to_hf import infer_export_workdir
+
+    assert str(infer_export_workdir("/tmp/export")) == "/tmp/export/.export_workdir"
 
 
 def test_infer_export_root_uses_epoch_and_step():
@@ -113,6 +141,35 @@ def test_build_export_config_applies_export_overrides(monkeypatch):
     assert not hasattr(cfg, "wandb")
 
 
+def test_build_export_config_uses_explicit_config_path_without_model_override(monkeypatch):
+    from nemo_automodel.components.config.loader import ConfigNode
+    from scripts import export_llm_dcp_to_hf as script
+
+    captured = {}
+
+    def fake_parse_args_and_load_config(config_path, argv):
+        captured["config_path"] = config_path
+        return ConfigNode({"checkpoint": {"enabled": True}, "model": {"pretrained_model_name_or_path": "/orig"}})
+
+    monkeypatch.setattr(script, "parse_args_and_load_config", fake_parse_args_and_load_config)
+
+    cfg = script.build_export_config(
+        Namespace(
+            checkpoint_dir="/tmp/run/checkpoints/epoch_0_step_42",
+            output_dir="/tmp/export",
+            config="/custom/config.yaml",
+            model_name_or_path=None,
+            save_consolidated="every",
+            epoch=None,
+            step=None,
+        )
+    )
+
+    assert captured["config_path"] == "/custom/config.yaml"
+    # No --model-name-or-path override, so the recorded base model path is untouched.
+    assert cfg.model.pretrained_model_name_or_path == "/orig"
+
+
 def test_resolve_model_for_export_unwraps_single_ddp(monkeypatch):
     from scripts import export_llm_dcp_to_hf as script
 
@@ -127,3 +184,200 @@ def test_resolve_model_for_export_unwraps_single_ddp(monkeypatch):
     trainer = Namespace(model_parts=[FakeDDP(model)])
 
     assert script.resolve_model_for_export(trainer) is model
+
+
+def test_resolve_model_for_export_returns_single_non_ddp_model():
+    from scripts import export_llm_dcp_to_hf as script
+
+    model = object()
+    trainer = Namespace(model_parts=[model])
+
+    assert script.resolve_model_for_export(trainer) is model
+
+
+def test_resolve_model_for_export_returns_multipart_list_unchanged():
+    from scripts import export_llm_dcp_to_hf as script
+
+    parts = [object(), object()]
+    trainer = Namespace(model_parts=parts)
+
+    assert script.resolve_model_for_export(trainer) is parts
+
+
+def test_resolve_model_for_export_falls_back_to_model_attribute():
+    from scripts import export_llm_dcp_to_hf as script
+
+    model = object()
+    trainer = Namespace(model_parts=None, model=model)
+
+    assert script.resolve_model_for_export(trainer) is model
+
+
+def test_resolve_model_for_export_raises_when_no_model():
+    from scripts import export_llm_dcp_to_hf as script
+
+    trainer = Namespace(model_parts=None, model=None)
+
+    with pytest.raises(ValueError, match="did not expose a model"):
+        script.resolve_model_for_export(trainer)
+
+
+def test_resolve_model_for_export_raises_on_empty_model_parts():
+    from scripts import export_llm_dcp_to_hf as script
+
+    trainer = Namespace(model_parts=[])
+
+    with pytest.raises(ValueError, match="empty model_parts"):
+        script.resolve_model_for_export(trainer)
+
+
+def test_is_main_process_true_when_distributed_not_initialized(monkeypatch):
+    import torch.distributed as dist
+
+    from scripts import export_llm_dcp_to_hf as script
+
+    monkeypatch.setattr(dist, "is_initialized", lambda: False)
+
+    assert script.is_main_process() is True
+
+
+def test_is_main_process_respects_rank_when_distributed(monkeypatch):
+    import torch.distributed as dist
+
+    from scripts import export_llm_dcp_to_hf as script
+
+    monkeypatch.setattr(dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(dist, "get_rank", lambda: 0)
+    assert script.is_main_process() is True
+
+    monkeypatch.setattr(dist, "get_rank", lambda: 1)
+    assert script.is_main_process() is False
+
+
+def test_barrier_invokes_distributed_barrier_only_when_initialized(monkeypatch):
+    import torch.distributed as dist
+
+    from scripts import export_llm_dcp_to_hf as script
+
+    mock_barrier = MagicMock()
+    monkeypatch.setattr(dist, "barrier", mock_barrier)
+
+    monkeypatch.setattr(dist, "is_initialized", lambda: False)
+    script.barrier()
+    assert mock_barrier.call_count == 0
+
+    monkeypatch.setattr(dist, "is_initialized", lambda: True)
+    script.barrier()
+    assert mock_barrier.call_count == 1
+
+
+def test_prepare_export_root_creates_directory_on_main(monkeypatch, tmp_path):
+    from scripts import export_llm_dcp_to_hf as script
+
+    monkeypatch.setattr(script, "is_main_process", lambda: True)
+    monkeypatch.setattr(script, "barrier", lambda: None)
+    export_root = tmp_path / "epoch_0_step_1"
+
+    script.prepare_export_root(export_root)
+
+    assert export_root.is_dir()
+
+
+def test_prepare_export_root_raises_when_directory_exists(monkeypatch, tmp_path):
+    from scripts import export_llm_dcp_to_hf as script
+
+    monkeypatch.setattr(script, "is_main_process", lambda: True)
+    monkeypatch.setattr(script, "barrier", lambda: None)
+    export_root = tmp_path / "epoch_0_step_1"
+    export_root.mkdir()
+
+    with pytest.raises(FileExistsError):
+        script.prepare_export_root(export_root)
+
+
+def test_prepare_export_root_skips_creation_on_non_main(monkeypatch, tmp_path):
+    from scripts import export_llm_dcp_to_hf as script
+
+    monkeypatch.setattr(script, "is_main_process", lambda: False)
+    monkeypatch.setattr(script, "barrier", lambda: None)
+    export_root = tmp_path / "epoch_0_step_1"
+
+    script.prepare_export_root(export_root)
+
+    assert not export_root.exists()
+
+
+def test_close_trainer_is_noop_for_none():
+    from scripts.export_llm_dcp_to_hf import close_trainer
+
+    # Should not raise.
+    close_trainer(None)
+
+
+def test_close_trainer_closes_all_recipe_resources():
+    from scripts.export_llm_dcp_to_hf import close_trainer
+
+    trainer = MagicMock()
+    valid_logger = MagicMock()
+    trainer.metric_logger_valid = {"val": valid_logger}
+
+    close_trainer(trainer)
+
+    trainer.metric_logger_train.close.assert_called_once()
+    valid_logger.close.assert_called_once()
+    trainer.checkpointer.close.assert_called_once()
+
+
+def test_main_exports_checkpoint_end_to_end(monkeypatch, tmp_path):
+    from scripts import export_llm_dcp_to_hf as script
+
+    checkpoint_dir = tmp_path / "checkpoints" / "epoch_2_step_7"
+    checkpoint_dir.mkdir(parents=True)
+    output_dir = tmp_path / "export"
+
+    trainer = MagicMock()
+    model = object()
+    monkeypatch.setattr(script, "build_export_config", lambda args: MagicMock(to_dict=lambda: {"checkpoint": {}}))
+    monkeypatch.setattr(script, "TrainFinetuneRecipeForNextTokenPrediction", lambda cfg: trainer)
+    monkeypatch.setattr(script, "resolve_model_for_export", lambda t: model)
+    save_config_calls = {}
+    monkeypatch.setattr(
+        script, "save_config", lambda config, path: save_config_calls.update({"config": config, "path": path})
+    )
+
+    script.main(["--checkpoint-dir", str(checkpoint_dir), "--output-dir", str(output_dir)])
+
+    export_root = output_dir / "epoch_2_step_7"
+    assert export_root.is_dir()
+
+    load_kwargs = trainer.checkpointer.load_model.call_args.kwargs
+    assert load_kwargs["model_path"] == str(checkpoint_dir / "model")
+    assert load_kwargs["allow_checkpoint_key_subset"] is True
+    assert trainer.checkpointer.load_model.call_args.args[0] is model
+
+    save_kwargs = trainer.checkpointer.save_model.call_args.kwargs
+    assert save_kwargs["model"] is model
+    assert save_kwargs["weights_path"] == str(export_root)
+    assert save_kwargs["is_final_checkpoint"] is True
+    assert save_kwargs["tokenizer"] is trainer.tokenizer
+
+    assert save_config_calls["path"] == str(export_root)
+    trainer.checkpointer.close.assert_called_once()
+
+
+def test_main_closes_trainer_even_when_setup_fails(monkeypatch, tmp_path):
+    from scripts import export_llm_dcp_to_hf as script
+
+    checkpoint_dir = tmp_path / "checkpoints" / "epoch_0_step_1"
+    checkpoint_dir.mkdir(parents=True)
+    output_dir = tmp_path / "export"
+
+    trainer = MagicMock()
+    trainer.setup.side_effect = RuntimeError("boom")
+    monkeypatch.setattr(script, "build_export_config", lambda args: MagicMock(to_dict=lambda: {}))
+    monkeypatch.setattr(script, "TrainFinetuneRecipeForNextTokenPrediction", lambda cfg: trainer)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        script.main(["--checkpoint-dir", str(checkpoint_dir), "--output-dir", str(output_dir)])
+
+    trainer.checkpointer.close.assert_called_once()


### PR DESCRIPTION
## What
- add a dedicated export flow for sharded torch_save checkpoints back to Hugging Face safetensors
- allow DCP model loads to keep current parameter initialization for keys that are absent from the checkpoint during export
- document the offline export flow and cover it with unit tests

## Changelog
- move the export helper from tools to scripts
- add partial-key checkpoint loading support for export cases like Gemma4 torch_save checkpoints
- warn when checkpoint.save_consolidated is set together with checkpoint.model_save_format=torch_save

## Pre-checks
- ran ruff format on changed Python files
- ran ruff check --fix on changed Python files
- ran uv run --group test python -m pytest tests/unit_tests/scripts/test_export_llm_dcp_to_hf.py tests/unit_tests/checkpoint/test_checkpointing.py -q with 103 passed and 2 skipped
- simplify was not available in this environment