### PR TITLE
feat(vlm): enable Qwen3.5 dense VLM CP

### DIFF
--- a/examples/vlm_finetune/qwen3_5/qwen3_6_27b_medpix_cp1_2k_2node_100steps.yaml
+++ b/examples/vlm_finetune/qwen3_5/qwen3_6_27b_medpix_cp1_2k_2node_100steps.yaml
@@ -1,0 +1,110 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+
+# Local CP parity run for the DENSE Qwen3.6-27B VLM on MedPix-VQA (real images)
+# at 2k sequence length (2 nodes / 16 GPUs). Pair with qwen3_6_27b_medpix_cp2_2k_2node_100steps.yaml; the
+# two configs differ ONLY in cp_size, so the per-step global batch (and thus the
+# loss curve) must match within numerical tolerance.
+# Run:
+#   automodel finetune -c examples/vlm_finetune/qwen3_5/qwen3_6_27b_medpix_cp1_2k_2node_100steps.yaml --nproc-per-node 8
+
+recipe: FinetuneRecipeForVLM
+
+seed: 1234
+
+step_scheduler:
+  global_batch_size: 8
+  local_batch_size: 1
+  ckpt_every_steps: 1000
+  val_every_steps: 1000
+  log_remote_every_steps: 1
+  gc_every_steps: 5
+  num_epochs: 1
+  max_steps: 100
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 60
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 1234
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained
+  pretrained_model_name_or_path: Qwen/Qwen3.6-27B
+  attn_implementation: sdpa
+  torch_dtype: bfloat16
+  # MTP disabled: its extra full-vocab projection at 2k OOMs the forward pass
+  # on 2 nodes (activation does not shard across DP). Irrelevant to CP parity.
+  num_nextn_predict_layers: 0
+
+processor:
+  _target_: transformers.AutoProcessor.from_pretrained
+  pretrained_model_name_or_path: Qwen/Qwen3.6-27B
+
+checkpoint:
+  enabled: false
+  checkpoint_dir: checkpoints/qwen3_6_27b_medpix_cp1_2k_2node_100steps/
+  model_save_format: safetensors
+  save_consolidated: false
+
+distributed:
+  _target_: nemo_automodel.components.distributed.fsdp2.FSDP2Manager
+  tp_size: 4
+  cp_size: 1
+  pp_size: 1
+  dp_replicate_size: 1
+  ep_size: 1
+  sequence_parallel: false
+  activation_checkpointing: true
+  mp_policy:
+    _target_: torch.distributed.fsdp.MixedPrecisionPolicy
+    param_dtype: bfloat16
+    reduce_dtype: bfloat16
+    output_dtype: bfloat16
+
+freeze_config:
+  freeze_vision_tower: true
+  freeze_audio_tower: true
+  freeze_language_model: false
+
+loss_fn:
+  # FusedLinearCrossEntropy: no materialized [seq,248320] logits. cp2 carries
+  # CP all-gather overhead that OOMs MaskedCE's 2.37 GiB logits at step 2;
+  # the fused path removes that tensor so both cp1 and cp2 fit at 2k.
+  _target_: nemo_automodel.components.loss.linear_ce.FusedLinearCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.vlm.datasets.make_medpix_dataset
+  path_or_dataset: mmoukouba/MedPix-VQA
+  split: train
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  num_workers: 1
+  drop_last: true
+  collate_fn:
+    _target_: nemo_automodel.components.datasets.vlm.collate_fns.default_collate_fn
+    max_length: 2048
+
+optimizer:
+  # torch AdamW: shards optimizer states over the FSDP2 DTensor mesh (/16).
+  # TE FusedAdam was tried but OOMs in initialize_state -- it allocates
+  # exp_avg/exp_avg_sq unsharded (TP-local /4, not FSDP /16).
+  _target_: torch.optim.AdamW
+  betas: [0.9, 0.95]
+  eps: 1e-8
+  lr: 5.0e-6
+  weight_decay: 0.1
+
+lr_scheduler:
+  lr_decay_style: constant
+
+wandb:
+  project: huiyingl_workspace
+  entity: Nemo-automodel
+  name: qwen3_6_27b_medpix_cp1_2k_2node_100steps
+  group: qwen3_6_27b_medpix_dense_cp_parity_2k_2node_100steps
+  tags: [qwen3.6-27b, medpix, dense, cp1, 2k, 2node, parity]
+  dir: logs/qwen3_6_27b_medpix_cp1_2k_2node_100steps/wandb

--- a/examples/vlm_finetune/qwen3_5/qwen3_6_27b_medpix_cp2_2k_2node_100steps.yaml
+++ b/examples/vlm_finetune/qwen3_5/qwen3_6_27b_medpix_cp2_2k_2node_100steps.yaml
@@ -1,0 +1,110 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+
+# Local CP parity run for the DENSE Qwen3.6-27B VLM on MedPix-VQA (real images)
+# at 2k sequence length (2 nodes / 16 GPUs). Pair with qwen3_6_27b_medpix_cp2_2k_2node_100steps.yaml; the
+# two configs differ ONLY in cp_size, so the per-step global batch (and thus the
+# loss curve) must match within numerical tolerance.
+# Run:
+#   automodel finetune -c examples/vlm_finetune/qwen3_5/qwen3_6_27b_medpix_cp2_2k_2node_100steps.yaml --nproc-per-node 8
+
+recipe: FinetuneRecipeForVLM
+
+seed: 1234
+
+step_scheduler:
+  global_batch_size: 8
+  local_batch_size: 1
+  ckpt_every_steps: 1000
+  val_every_steps: 1000
+  log_remote_every_steps: 1
+  gc_every_steps: 5
+  num_epochs: 1
+  max_steps: 100
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 60
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 1234
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained
+  pretrained_model_name_or_path: Qwen/Qwen3.6-27B
+  attn_implementation: sdpa
+  torch_dtype: bfloat16
+  # MTP disabled: its extra full-vocab projection at 2k OOMs the forward pass
+  # on 2 nodes (activation does not shard across DP). Irrelevant to CP parity.
+  num_nextn_predict_layers: 0
+
+processor:
+  _target_: transformers.AutoProcessor.from_pretrained
+  pretrained_model_name_or_path: Qwen/Qwen3.6-27B
+
+checkpoint:
+  enabled: false
+  checkpoint_dir: checkpoints/qwen3_6_27b_medpix_cp2_2k_2node_100steps/
+  model_save_format: safetensors
+  save_consolidated: false
+
+distributed:
+  _target_: nemo_automodel.components.distributed.fsdp2.FSDP2Manager
+  tp_size: 4
+  cp_size: 2
+  pp_size: 1
+  dp_replicate_size: 1
+  ep_size: 1
+  sequence_parallel: false
+  activation_checkpointing: true
+  mp_policy:
+    _target_: torch.distributed.fsdp.MixedPrecisionPolicy
+    param_dtype: bfloat16
+    reduce_dtype: bfloat16
+    output_dtype: bfloat16
+
+freeze_config:
+  freeze_vision_tower: true
+  freeze_audio_tower: true
+  freeze_language_model: false
+
+loss_fn:
+  # FusedLinearCrossEntropy: no materialized [seq,248320] logits. cp2 carries
+  # CP all-gather overhead that OOMs MaskedCE's 2.37 GiB logits at step 2;
+  # the fused path removes that tensor so both cp1 and cp2 fit at 2k.
+  _target_: nemo_automodel.components.loss.linear_ce.FusedLinearCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.vlm.datasets.make_medpix_dataset
+  path_or_dataset: mmoukouba/MedPix-VQA
+  split: train
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  num_workers: 1
+  drop_last: true
+  collate_fn:
+    _target_: nemo_automodel.components.datasets.vlm.collate_fns.default_collate_fn
+    max_length: 2048
+
+optimizer:
+  # torch AdamW: shards optimizer states over the FSDP2 DTensor mesh (/16).
+  # TE FusedAdam was tried but OOMs in initialize_state -- it allocates
+  # exp_avg/exp_avg_sq unsharded (TP-local /4, not FSDP /16).
+  _target_: torch.optim.AdamW
+  betas: [0.9, 0.95]
+  eps: 1e-8
+  lr: 5.0e-6
+  weight_decay: 0.1
+
+lr_scheduler:
+  lr_decay_style: constant
+
+wandb:
+  project: huiyingl_workspace
+  entity: Nemo-automodel
+  name: qwen3_6_27b_medpix_cp2_2k_2node_100steps
+  group: qwen3_6_27b_medpix_dense_cp_parity_2k_2node_100steps
+  tags: [qwen3.6-27b, medpix, dense, cp2, 2k, 2node, parity]
+  dir: logs/qwen3_6_27b_medpix_cp2_2k_2node_100steps/wandb

--- a/nemo_automodel/components/models/qwen3_5/model.py
+++ b/nemo_automodel/components/models/qwen3_5/model.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import copy
+import inspect
 from dataclasses import dataclass
 from typing import Any
 
@@ -417,7 +418,7 @@ class Qwen3_5ForConditionalGeneration(HFCheckpointingMixin, HFQwen3_5ForConditio
         """Declared parallelism capabilities for this model class."""
 
         supports_tp: bool = True
-        supports_cp: bool = False
+        supports_cp: bool = True
         supports_pp: bool = True
         supports_ep: bool = False
 
@@ -526,6 +527,88 @@ class Qwen3_5ForConditionalGeneration(HFCheckpointingMixin, HFQwen3_5ForConditio
 
         return pixel_values, pixel_values_videos, image_grid_thw, video_grid_thw
 
+    def prepare_model_inputs_for_cp(
+        self,
+        input_ids: torch.Tensor,
+        *,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        pixel_values: torch.Tensor | None = None,
+        pixel_values_videos: torch.Tensor | None = None,
+        image_grid_thw: torch.Tensor | None = None,
+        image_grid_hws: torch.Tensor | None = None,
+        video_grid_thw: torch.Tensor | None = None,
+        mm_token_type_ids: torch.Tensor | None = None,
+        **kwargs: Any,
+    ) -> dict[str, torch.Tensor]:
+        """Build full-sequence multimodal embeddings and mRoPE positions before CP sharding.
+
+        The VLM->LM multimodal scatter and mRoPE ``get_rope_index`` must run on the
+        *full* (unsharded) sequence; context-parallel sharding then happens on the
+        returned ``inputs_embeds`` / ``position_ids`` via ``make_cp_batch_and_ctx``.
+        """
+        if input_ids is None:
+            raise ValueError("Qwen3.5 dense CP pre-embedding requires input_ids.")
+
+        if image_grid_thw is None and image_grid_hws is not None and image_grid_hws.numel() > 0:
+            if image_grid_hws.shape[-1] == 2:
+                ones = torch.ones(
+                    image_grid_hws.shape[0],
+                    1,
+                    dtype=image_grid_hws.dtype,
+                    device=image_grid_hws.device,
+                )
+                image_grid_thw = torch.cat([ones, image_grid_hws], dim=-1)
+            else:
+                image_grid_thw = image_grid_hws
+
+        inputs_embeds = self.get_input_embeddings()(input_ids)
+
+        if pixel_values is not None:
+            if hasattr(self.model.visual, "rotary_pos_emb"):
+                self.model.visual.rotary_pos_emb.to(pixel_values.device)
+            image_outputs = self.model.get_image_features(pixel_values, image_grid_thw, return_dict=True)
+            image_embeds = torch.cat(image_outputs.pooler_output, dim=0).to(inputs_embeds.device, inputs_embeds.dtype)
+            image_mask, _ = self.model.get_placeholder_mask(
+                input_ids,
+                inputs_embeds=inputs_embeds,
+                image_features=image_embeds,
+            )
+            inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_embeds)
+
+        if pixel_values_videos is not None:
+            if hasattr(self.model.visual, "rotary_pos_emb"):
+                self.model.visual.rotary_pos_emb.to(pixel_values_videos.device)
+            video_outputs = self.model.get_video_features(pixel_values_videos, video_grid_thw, return_dict=True)
+            video_embeds = torch.cat(video_outputs.pooler_output, dim=0).to(inputs_embeds.device, inputs_embeds.dtype)
+            _, video_mask = self.model.get_placeholder_mask(
+                input_ids,
+                inputs_embeds=inputs_embeds,
+                video_features=video_embeds,
+            )
+            inputs_embeds = inputs_embeds.masked_scatter(video_mask, video_embeds)
+
+        if position_ids is None:
+            rope_kwargs = {
+                "image_grid_thw": image_grid_thw,
+                "video_grid_thw": video_grid_thw,
+                "attention_mask": attention_mask,
+            }
+            if "mm_token_type_ids" in inspect.signature(self.model.get_rope_index).parameters:
+                if mm_token_type_ids is None:
+                    mm_token_type_ids = torch.zeros_like(input_ids, dtype=torch.long)
+                    image_token_id = getattr(self.config, "image_token_id", None)
+                    video_token_id = getattr(self.config, "video_token_id", None)
+                    if image_token_id is not None:
+                        mm_token_type_ids = mm_token_type_ids.masked_fill(input_ids == image_token_id, 1)
+                    if video_token_id is not None:
+                        mm_token_type_ids = mm_token_type_ids.masked_fill(input_ids == video_token_id, 2)
+                rope_kwargs["mm_token_type_ids"] = mm_token_type_ids.to(device=input_ids.device)
+            position_ids, rope_deltas = self.model.get_rope_index(input_ids, **rope_kwargs)
+            self.model.rope_deltas = rope_deltas
+
+        return {"inputs_embeds": inputs_embeds, "position_ids": position_ids}
+
     def forward(
         self,
         input_ids: torch.LongTensor | None = None,
@@ -544,6 +627,19 @@ class Qwen3_5ForConditionalGeneration(HFCheckpointingMixin, HFQwen3_5ForConditio
         padding_mask: torch.Tensor | None = None,
         **kwargs: Any,
     ) -> Qwen3_5CausalLMOutputWithPast:
+        if kwargs.pop("_pre_embed_only", False):
+            return self.prepare_model_inputs_for_cp(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                pixel_values=pixel_values,
+                pixel_values_videos=pixel_values_videos,
+                image_grid_thw=image_grid_thw,
+                video_grid_thw=video_grid_thw,
+                mm_token_type_ids=mm_token_type_ids,
+                **kwargs,
+            )
+
         effective_use_cache = False if use_cache is None and self.training else use_cache
         kwargs = dict(kwargs)
         if effective_use_cache is not None:

--- a/tests/unit_tests/models/qwen3_5/test_qwen3_5_cp_preembed.py
+++ b/tests/unit_tests/models/qwen3_5/test_qwen3_5_cp_preembed.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU-only tests for Qwen3.5 dense VLM CP pre-embedding.
+
+``Qwen3_5ForConditionalGeneration.prepare_model_inputs_for_cp`` builds
+full-sequence multimodal embeddings and mRoPE positions *before* context-parallel
+sharding (the CP linear-attention layers recover the dense token order
+internally via the DualChunkSwap layout, so no seq_index is threaded here).
+
+Instantiating the full VL model is expensive, so we build a barebones instance
+via ``__new__`` and stub the heavy submodules (visual encoder, rope-index helper,
+embedding table).
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+import torch
+import torch.nn as nn
+
+pytest.importorskip("transformers.models.qwen3_5")
+
+from nemo_automodel.components.models.qwen3_5.model import Qwen3_5ForConditionalGeneration
+
+
+def _build_model(*, rope_index=None, image_token_id=None, video_token_id=None):
+    """Build a barebones Qwen3_5ForConditionalGeneration with stubbed deps."""
+    model = Qwen3_5ForConditionalGeneration.__new__(Qwen3_5ForConditionalGeneration)
+    nn.Module.__init__(model)
+
+    hidden = 4
+
+    def _embed(input_ids):
+        # Deterministic embeddings: [B, S, H] where each value mirrors the token id.
+        return input_ids.unsqueeze(-1).expand(*input_ids.shape, hidden).float()
+
+    # Instance attribute shadows the class method.
+    model.get_input_embeddings = lambda: _embed
+
+    inner = types.SimpleNamespace()
+    inner.visual = None  # no rotary_pos_emb attribute -> hasattr() is False
+
+    def _default_rope_index(input_ids, **kwargs):
+        # [3, B, S] mRoPE positions + a rope_delta per row.
+        b, s = input_ids.shape
+        pos = torch.arange(s).view(1, 1, s).expand(3, b, s).contiguous()
+        return pos, torch.zeros(b, 1)
+
+    inner.get_rope_index = rope_index or _default_rope_index
+    inner.rope_deltas = None
+    model.model = inner
+
+    model.config = types.SimpleNamespace(
+        image_token_id=image_token_id,
+        video_token_id=video_token_id,
+    )
+    return model
+
+
+class TestPrepareModelInputsForCP:
+    def test_requires_input_ids(self):
+        model = _build_model()
+        with pytest.raises(ValueError, match="requires input_ids"):
+            model.prepare_model_inputs_for_cp(input_ids=None)
+
+    def test_text_only_builds_embeds_and_positions(self):
+        model = _build_model()
+        input_ids = torch.tensor([[5, 6, 7, 8]])
+
+        out = model.prepare_model_inputs_for_cp(input_ids=input_ids)
+
+        # CP linear-attn recovers token order internally; only embeds + positions here.
+        assert set(out) == {"inputs_embeds", "position_ids"}
+        assert out["inputs_embeds"].shape == (1, 4, 4)
+        # position_ids came from get_rope_index (mRoPE [3, B, S]).
+        assert out["position_ids"].shape == (3, 1, 4)
+        # rope_deltas stashed back onto the inner model.
+        assert model.model.rope_deltas is not None
+
+    def test_existing_position_ids_not_recomputed(self):
+        called = {"count": 0}
+
+        def _rope(input_ids, **kwargs):
+            called["count"] += 1
+            return torch.zeros(3, 1, input_ids.shape[1]), torch.zeros(1, 1)
+
+        model = _build_model(rope_index=_rope)
+        pos = torch.arange(4).view(1, 4)
+        out = model.prepare_model_inputs_for_cp(input_ids=torch.tensor([[5, 6, 7, 8]]), position_ids=pos)
+
+        assert called["count"] == 0, "get_rope_index must not run when position_ids provided"
+        assert out["position_ids"] is pos
+
+    def test_image_grid_hws_promoted_to_thw(self):
+        """image_grid_hws of shape [N, 2] is promoted to [N, 3] by prepending a temporal=1 column."""
+        captured = {}
+
+        def _rope(input_ids, **kwargs):
+            captured.update(kwargs)
+            return torch.zeros(3, 1, input_ids.shape[1]), torch.zeros(1, 1)
+
+        model = _build_model(rope_index=_rope)
+        image_grid_hws = torch.tensor([[2, 2]])  # [N, 2]
+        model.prepare_model_inputs_for_cp(
+            input_ids=torch.tensor([[5, 6, 7, 8]]),
+            image_grid_hws=image_grid_hws,
+        )
+        assert captured["image_grid_thw"].tolist() == [[1, 2, 2]]
+
+    def test_mm_token_type_ids_synthesized_from_token_ids(self):
+        """When get_rope_index accepts mm_token_type_ids, it is built from image/video token ids."""
+        captured = {}
+
+        def _rope(input_ids, *, image_grid_thw=None, video_grid_thw=None, attention_mask=None, mm_token_type_ids=None):
+            captured["mm_token_type_ids"] = mm_token_type_ids
+            return torch.zeros(3, 1, input_ids.shape[1]), torch.zeros(1, 1)
+
+        model = _build_model(rope_index=_rope, image_token_id=6, video_token_id=8)
+        model.prepare_model_inputs_for_cp(input_ids=torch.tensor([[5, 6, 7, 8]]))
+
+        # token 6 -> image (1), token 8 -> video (2), others 0.
+        assert captured["mm_token_type_ids"].tolist() == [[0, 1, 0, 2]]
+
+
+class TestForwardPreEmbedDispatch:
+    def test_pre_embed_only_dispatches_to_prepare(self):
+        model = _build_model()
+        sentinel = {"inputs_embeds": torch.zeros(1, 4, 4)}
+
+        captured = {}
+
+        def _fake_prepare(*, input_ids, attention_mask=None, position_ids=None, pixel_values=None, **kwargs):
+            captured["input_ids"] = input_ids
+            captured["pixel_values"] = pixel_values
+            captured["kwargs"] = kwargs
+            return sentinel
+
+        model.prepare_model_inputs_for_cp = _fake_prepare
+
+        input_ids = torch.tensor([[5, 6, 7, 8]])
+        pixel_values = torch.randn(4, 8)
+        # image_grid_hws is not a named forward param, so it rides in **kwargs.
+        out = model.forward(
+            input_ids=input_ids,
+            _pre_embed_only=True,
+            pixel_values=pixel_values,
+            image_grid_hws=torch.tensor([[2, 2]]),
+        )
+
+        assert out is sentinel
+        assert torch.equal(captured["input_ids"], input_ids)
+        assert captured["pixel_values"] is pixel_values
+        assert "image_grid_hws" in captured["kwargs"]

--- a/tests/unit_tests/models/qwen3_5/test_qwen3_5_cp_preembed.py
+++ b/tests/unit_tests/models/qwen3_5/test_qwen3_5_cp_preembed.py
@@ -110,6 +110,22 @@ class TestPrepareModelInputsForCP:
         )
         assert captured["image_grid_thw"].tolist() == [[1, 2, 2]]
 
+    def test_image_grid_hws_already_thw_passes_through(self):
+        """image_grid_hws already shaped [N, 3] is used as-is (no temporal column prepended)."""
+        captured = {}
+
+        def _rope(input_ids, **kwargs):
+            captured.update(kwargs)
+            return torch.zeros(3, 1, input_ids.shape[1]), torch.zeros(1, 1)
+
+        model = _build_model(rope_index=_rope)
+        image_grid_hws = torch.tensor([[1, 2, 2]])  # [N, 3]
+        model.prepare_model_inputs_for_cp(
+            input_ids=torch.tensor([[5, 6, 7, 8]]),
+            image_grid_hws=image_grid_hws,
+        )
+        assert captured["image_grid_thw"].tolist() == [[1, 2, 2]]
+
     def test_mm_token_type_ids_synthesized_from_token_ids(self):
         """When get_rope_index accepts mm_token_type_ids, it is built from image/video token ids."""
         captured = {}
@@ -123,6 +139,70 @@ class TestPrepareModelInputsForCP:
 
         # token 6 -> image (1), token 8 -> video (2), others 0.
         assert captured["mm_token_type_ids"].tolist() == [[0, 1, 0, 2]]
+
+    def test_image_features_scattered_into_embeds(self):
+        """pixel_values path: image features replace image-token embeddings via masked_scatter."""
+        model = _build_model(image_token_id=99)
+
+        # Visual with a rotary_pos_emb so the device-move branch is exercised.
+        moved = {}
+        model.model.visual = types.SimpleNamespace(
+            rotary_pos_emb=types.SimpleNamespace(to=lambda dev: moved.setdefault("dev", dev))
+        )
+
+        feat = torch.full((1, 4), 8.0)  # one image token, hidden=4
+        model.model.get_image_features = (
+            lambda pixel_values, image_grid_thw=None, return_dict=True: types.SimpleNamespace(pooler_output=[feat])
+        )
+
+        def _mask(input_ids, *, inputs_embeds=None, image_features=None, video_features=None):
+            image_mask = (input_ids == 99).unsqueeze(-1).expand_as(inputs_embeds)
+            return image_mask, torch.zeros_like(image_mask)
+
+        model.model.get_placeholder_mask = _mask
+
+        ids = torch.tensor([[5, 99, 7]])
+        # Pass position_ids so the rope path (covered elsewhere) is skipped here.
+        out = model.prepare_model_inputs_for_cp(
+            input_ids=ids,
+            pixel_values=torch.zeros(1, 3, 2, 2),
+            image_grid_thw=torch.tensor([[1, 2, 2]]),
+            position_ids=torch.zeros(3, 1, 3, dtype=torch.long),
+        )
+
+        emb = out["inputs_embeds"]
+        assert torch.allclose(emb[0, 1], torch.full((4,), 8.0))  # image token overwritten
+        assert torch.allclose(emb[0, 0], torch.full((4,), 5.0))  # text token untouched
+        assert moved["dev"] is not None  # visual.rotary_pos_emb.to(...) ran
+
+    def test_video_features_scattered_into_embeds(self):
+        """pixel_values_videos path: video features replace video-token embeddings."""
+        model = _build_model(video_token_id=88)
+
+        feat = torch.full((1, 4), 3.0)  # one video token, hidden=4
+        model.model.get_video_features = (
+            lambda pixel_values_videos, video_grid_thw=None, return_dict=True: types.SimpleNamespace(
+                pooler_output=[feat]
+            )
+        )
+
+        def _mask(input_ids, *, inputs_embeds=None, image_features=None, video_features=None):
+            video_mask = (input_ids == 88).unsqueeze(-1).expand_as(inputs_embeds)
+            return torch.zeros_like(video_mask), video_mask
+
+        model.model.get_placeholder_mask = _mask
+
+        ids = torch.tensor([[5, 88, 7]])
+        out = model.prepare_model_inputs_for_cp(
+            input_ids=ids,
+            pixel_values_videos=torch.zeros(1, 3, 2, 2),
+            video_grid_thw=torch.tensor([[1, 2, 2]]),
+            position_ids=torch.zeros(3, 1, 3, dtype=torch.long),
+        )
+
+        emb = out["inputs_embeds"]
+        assert torch.allclose(emb[0, 1], torch.full((4,), 3.0))  # video token overwritten
+        assert torch.allclose(emb[0, 2], torch.full((4,), 7.0))  # text token untouched
 
 
 class TestForwardPreEmbedDispatch:


### PR DESCRIPTION
## What

Enables context parallelism for the **dense** Qwen3.5/Qwen3.6-27B VLM training (the MoE path landed in #2432; this is the dense analogue). The VLM forward now pre-runs the media encoders on the full sequence before CP sharding, scatters image/video embeddings into `inputs_embeds`, and builds mRoPE `position_ids`, then hands the batch to the existing CP utilities.

## Why

Text CP already worked for the dense model, but VLM CP needs full-sequence multimodal preprocessing before the sequence is partitioned — sharding raw media inputs leaves the language-model path without correctly aligned media embeddings and mRoPE positions. The recipe's CP path is already generic (`hasattr(model, "prepare_model_inputs_for_cp")`), so the model only needs to expose that hook.

## Changelog

- Add `prepare_model_inputs_for_cp` and a `_pre_embed_only` forward hook to dense `Qwen3_5ForConditionalGeneration` (mirrors the MoE model).
- Flip `supports_cp = True` on the dense conditional-generation `ModelCapabilities`.
- No `seq_index` threading needed: the shared `CPAwareGatedDeltaNet` (attached by `Qwen3_5ParallelizationStrategy`) recovers dense token order from the DualChunkSwap CP layout. Recipe, `cp_utils`, registry, and parallelizer are unchanged.
- Add CPU unit tests for the pre-embed path (`tests/unit_tests/models/qwen3_5/test_qwen3_5_cp_preembed.py`).
- Add MedPix cp1/cp2 2k parity recipes (`examples/vlm_finetune/qwen3_5/qwen3_6_27b_medpix_cp{1,2}_2k_2node_100steps.yaml`).

## Validation

- `ruff check` / `ruff format --check` clean on changed files.
- Unit tests: `pytest tests/unit_tests/models/qwen3_5/test_qwen3_5_cp_preembed.py` — 6/6 pass (CPU).
- Local MedPix 2k 100-step parity, dense 27B VLM, 2 nodes x 8 H100 (tp4, FusedLinearCE, torch AdamW, MTP off), container `transformers==5.5.0`:
  - 100/100 matched train steps, 0 OOM.
  - Train loss abs diff over all 100 steps: **max `0.0146`, mean `0.0025` (0.16% rel), final `0.0001`** (cp1 `1.6615` vs cp2 `1.6614`).
 
<img width="353" height="258" alt="image" src="https://github.com/user-attachments/assets/334b3856-1c14-4370-96fc-c9a895a47af4" />


### Notes / limitations
- 4k OOMs for cp1 on 2 nodes (cp=1 holds the full-sequence activation, which does not shard across DP); 2k is used for the parity.
- CP needs perf optimization.

Signed-off-by: Huiying Li <huiyingl@nvidia.com>
