### PR TITLE
test(checkpoint): fix TestFormatLoad directory-based reader selection

### DIFF
--- a/tests/unit_tests/checkpoint/test_checkpointing.py
+++ b/tests/unit_tests/checkpoint/test_checkpointing.py
@@ -2780,10 +2780,28 @@ class TestFormatLoad:
             return Checkpointer(config, dp_rank=0, tp_rank=0, pp_rank=0)
 
     def test_safetensors_format_produces_hf_reader(self):
-        """safetensors format: _get_storage_reader returns an HF reader."""
+        """safetensors checkpoint: _get_storage_reader returns an HF reader.
+
+        Reader selection is driven by whether the checkpoint is safetensors
+        (``is_safetensors``), which the production caller passes explicitly, so the
+        path need not exist on disk.
+        """
         ckptr = self._make_checkpointer("safetensors")
-        reader = ckptr._get_storage_reader("/tmp/model", key_mapping=None)
+        reader = ckptr._get_storage_reader("/tmp/model", key_mapping=None, is_safetensors=True)
         assert reader is not None
+
+    def test_get_storage_reader_infers_safetensors_from_directory(self, tmp_path):
+        """When ``is_safetensors`` is not supplied, reader choice follows the on-disk
+        contents (regression for #2487): a safetensors directory yields a reader, a
+        non-safetensors directory yields None for a non-init load."""
+        ckptr = self._make_checkpointer("safetensors")
+        st_dir = tmp_path / "st"
+        st_dir.mkdir()
+        (st_dir / "model.safetensors.index.json").write_text("{}")
+        assert ckptr._get_storage_reader(str(st_dir), key_mapping=None) is not None
+        other = tmp_path / "dcp"
+        other.mkdir()
+        assert ckptr._get_storage_reader(str(other), key_mapping=None) is None
 
     def test_dcp_format_produces_no_reader(self):
         """torch_save (DCP) format: _get_storage_reader returns None."""
@@ -2795,7 +2813,7 @@ class TestFormatLoad:
         """safetensors + cloud: HF reader passed to dcp.load, MSC reader never created."""
         ckptr = self._make_checkpointer("safetensors")
         sd = {"w": torch.zeros(4)}
-        hf_reader = ckptr._get_storage_reader("/tmp/model", key_mapping=None)
+        hf_reader = ckptr._get_storage_reader("/tmp/model", key_mapping=None, is_safetensors=True)
         assert hf_reader is not None
 
         with _cloud_patches():
@@ -2831,7 +2849,7 @@ class TestFormatLoad:
         """safetensors + local: HF reader used, MSC never involved."""
         ckptr = self._make_checkpointer("safetensors")
         sd = {"w": torch.zeros(4)}
-        hf_reader = ckptr._get_storage_reader("/tmp/model", key_mapping=None)
+        hf_reader = ckptr._get_storage_reader("/tmp/model", key_mapping=None, is_safetensors=True)
 
         with (
             patch("nemo_automodel.components.checkpoint.checkpointing.msc") as mock_msc,


### PR DESCRIPTION
## What

Fixes the two failing `tests/unit_tests/checkpoint/test_checkpointing.py::TestFormatLoad` tests on `main` (currently red in `L0_Unit_Tests`):

- `test_safetensors_format_produces_hf_reader`
- `test_safetensors_cloud_load_uses_hf_reader_not_msc`

Both fail with `assert None is not None`.

## Root cause

PR #2487 (`feat(checkpoint): export torch_save checkpoints to hf`, the current `main` HEAD) changed `Checkpointer._get_storage_reader` to decide the reader from whether the checkpoint is safetensors (the `is_safetensors` argument, which the production caller passes explicitly, otherwise inferred from the on-disk directory contents via `_is_safetensors_checkpoint`) instead of from the configured `model_save_format`:

```python
if is_safetensors is None:
    is_safetensors = _is_safetensors_checkpoint(model_path)
if not is_init_step and not is_safetensors:
    return None
```

The `TestFormatLoad` safetensors cases (added by #1709) still call `_get_storage_reader("/tmp/model", key_mapping=None)` on a non-existent path with no `is_safetensors`, so the new gate sees a non-safetensors directory and returns `None`, tripping `assert reader is not None`. The tests pass at #2487's parent (`90e76b41`) and fail at #2487 (`86d39d7f`); #2487 changed the behavior without updating them.

## Fix

- Pass `is_safetensors=True` to `_get_storage_reader` in the safetensors reader cases. This mirrors the production call signature (which passes the flag explicitly) and asserts the safetensors to HF-reader contract without depending on a real on-disk path.
- Add `test_get_storage_reader_infers_safetensors_from_directory` to lock in the new inference behavior: with `is_safetensors` unset, a safetensors directory yields a reader and a non-safetensors directory yields `None`.

The DCP and `torch_save` cases are unchanged (they correctly expect `None`).

## Test

`pytest tests/unit_tests/checkpoint/test_checkpointing.py::TestFormatLoad`: 7 passed. ruff clean.