### PR TITLE
feat(speculative): add tqdm training progress bar to EAGLE and DFlash recipes

### DIFF
--- a/nemo_automodel/recipes/base_recipe.py
+++ b/nemo_automodel/recipes/base_recipe.py
@@ -881,15 +881,23 @@ class BaseRecipe:
             tensor = tensor.cpu()
         return tensor
 
-    def _make_progress_bar(self):
-        """Create a tqdm progress bar on rank 0; returns None on other ranks."""
+    def _make_progress_bar(self, total: int | None = None, initial: int = 0):
+        """Create a tqdm progress bar on rank 0; returns None on other ranks.
+
+        Without arguments the totals come from ``self.step_scheduler``; recipes
+        without a step scheduler (e.g. the EAGLE family) pass ``total`` and
+        ``initial`` explicitly.
+        """
         if not _is_rank_0():
             return None
         from tqdm import tqdm
 
+        if total is None:
+            total = getattr(self.step_scheduler, "max_steps", None)
+            initial = getattr(self.step_scheduler, "step", 0)
         return tqdm(
-            total=getattr(self.step_scheduler, "max_steps", None),
-            initial=getattr(self.step_scheduler, "step", 0),
+            total=total,
+            initial=initial,
             desc="Training",
             unit="step",
             dynamic_ncols=True,

--- a/nemo_automodel/recipes/llm/train_dflash.py
+++ b/nemo_automodel/recipes/llm/train_dflash.py
@@ -561,6 +561,7 @@ class TrainDFlashRecipe(BaseRecipe):
                 logger.info("All %d epochs already completed; nothing to do.", self.num_epochs)
             return
 
+        pbar = self._make_progress_bar(total=self.total_optim_steps, initial=self.runtime.global_step)
         for epoch_idx in range(start_epoch, self.num_epochs):
             if hasattr(self.train_dataloader, "sampler") and hasattr(self.train_dataloader.sampler, "set_epoch"):
                 self.train_dataloader.sampler.set_epoch(epoch_idx)
@@ -628,6 +629,8 @@ class TrainDFlashRecipe(BaseRecipe):
                     self.optimizer.zero_grad(set_to_none=True)
                     self.lr_scheduler.step()
                     self.runtime.global_step += 1
+                    if pbar is not None:
+                        pbar.update(1)
                     completed_steps += 1
                     pending_micro_batches = 0
                     self._maybe_save_step_checkpoint(epoch_idx)
@@ -637,13 +640,22 @@ class TrainDFlashRecipe(BaseRecipe):
                         # log, not over optimizer steps: with grad_accumulation_steps>1
                         # (or skipped short micro-batches) the two differ, and dividing
                         # by log_every_steps would inflate the reported loss/acc.
+                        avg_loss = running_loss / max(1, running_micro)
+                        avg_acc = running_acc / max(1, running_micro)
+                        current_lr = self.lr_scheduler.get_last_lr()[0]
+                        if pbar is not None:
+                            pbar.set_postfix(
+                                loss=f"{avg_loss:.4f}",
+                                acc=f"{avg_acc:.4f}",
+                                lr=f"{current_lr:.2e}",
+                            )
                         logger.info(
                             "epoch=%d step=%d loss=%.4f acc=%.4f lr=%.6g",
                             epoch_idx,
                             self.runtime.global_step,
-                            running_loss / max(1, running_micro),
-                            running_acc / max(1, running_micro),
-                            self.lr_scheduler.get_last_lr()[0],
+                            avg_loss,
+                            avg_acc,
+                            current_lr,
                         )
                         running_loss = 0.0
                         running_acc = 0.0
@@ -661,6 +673,8 @@ class TrainDFlashRecipe(BaseRecipe):
                 self.optimizer.zero_grad(set_to_none=True)
                 self.lr_scheduler.step()
                 self.runtime.global_step += 1
+                if pbar is not None:
+                    pbar.update(1)
                 completed_steps += 1
                 pending_micro_batches = 0
                 self._maybe_save_step_checkpoint(epoch_idx)
@@ -687,6 +701,8 @@ class TrainDFlashRecipe(BaseRecipe):
                 )
                 self._log_saved_checkpoint("epoch", epoch_idx + 1, self.runtime.global_step)
 
+        if pbar is not None:
+            pbar.close()
         self._maybe_save_final_checkpoint(self.num_epochs)
         self._finalize_pending_checkpoint()
 

--- a/nemo_automodel/recipes/llm/train_dflash.py
+++ b/nemo_automodel/recipes/llm/train_dflash.py
@@ -562,68 +562,113 @@ class TrainDFlashRecipe(BaseRecipe):
             return
 
         pbar = self._make_progress_bar(total=self.total_optim_steps, initial=self.runtime.global_step)
-        for epoch_idx in range(start_epoch, self.num_epochs):
-            if hasattr(self.train_dataloader, "sampler") and hasattr(self.train_dataloader.sampler, "set_epoch"):
-                self.train_dataloader.sampler.set_epoch(epoch_idx)
+        try:
+            for epoch_idx in range(start_epoch, self.num_epochs):
+                if hasattr(self.train_dataloader, "sampler") and hasattr(self.train_dataloader.sampler, "set_epoch"):
+                    self.train_dataloader.sampler.set_epoch(epoch_idx)
 
-            running_loss = 0.0
-            running_acc = 0.0
-            running_micro = 0
-            epoch_loss = 0.0
-            micro_step = 0
-            pending_micro_batches = 0
-            completed_steps = 0
-            last_batch_idx = -1
-            num_batches = len(self.train_dataloader)
-            is_ddp = isinstance(self.trainer_module, DistributedDataParallel)
-            for batch_idx, batch in enumerate(self.train_dataloader):
-                last_batch_idx = batch_idx
-                batch = {k: v.to(self.device, non_blocking=True) for k, v in batch.items()}
-                target_batch = self.target_wrapper.generate_batch(
-                    input_ids=batch["input_ids"],
-                    attention_mask=batch["attention_mask"],
-                    loss_mask=batch["loss_mask"],
-                )
-                sync_grads = should_sync_grads(
-                    pending_micro_batches=pending_micro_batches,
-                    grad_accumulation_steps=self.grad_accumulation_steps,
-                    batch_idx=batch_idx,
-                    batches_per_epoch=num_batches,
-                    is_ddp=is_ddp,
-                )
-                sync_ctx = nullcontext() if sync_grads else self.trainer_module.no_sync()
-                with sync_ctx:
-                    local_has_valid = 1
-                    try:
-                        metrics = self.trainer_module(
-                            input_ids=target_batch.input_ids,
-                            hidden_states=target_batch.hidden_states,
-                            loss_mask=target_batch.loss_mask,
-                        )
-                        loss = metrics.loss / self.grad_accumulation_steps
-                    except NoValidAnchorsError:
-                        # Every sample in this micro-batch is too short to form a
-                        # block; nothing to learn from it on this rank.
-                        local_has_valid = 0
-                    # Decide skip-vs-backward in lockstep so a per-rank skip never
-                    # leaves one rank issuing its gradient all-reduce alone (DDP
-                    # hang) or desyncs the accumulation windows: if ANY rank has no
-                    # valid anchors, ALL ranks skip this micro-batch together.
-                    all_have_valid = _all_ranks_have_valid(local_has_valid, is_ddp, self.device)
-                    if all_have_valid:
-                        loss.backward()
-                if not all_have_valid:
-                    self._skipped_micro_batches += 1
-                    continue
+                running_loss = 0.0
+                running_acc = 0.0
+                running_micro = 0
+                epoch_loss = 0.0
+                micro_step = 0
+                pending_micro_batches = 0
+                completed_steps = 0
+                last_batch_idx = -1
+                num_batches = len(self.train_dataloader)
+                is_ddp = isinstance(self.trainer_module, DistributedDataParallel)
+                for batch_idx, batch in enumerate(self.train_dataloader):
+                    last_batch_idx = batch_idx
+                    batch = {k: v.to(self.device, non_blocking=True) for k, v in batch.items()}
+                    target_batch = self.target_wrapper.generate_batch(
+                        input_ids=batch["input_ids"],
+                        attention_mask=batch["attention_mask"],
+                        loss_mask=batch["loss_mask"],
+                    )
+                    sync_grads = should_sync_grads(
+                        pending_micro_batches=pending_micro_batches,
+                        grad_accumulation_steps=self.grad_accumulation_steps,
+                        batch_idx=batch_idx,
+                        batches_per_epoch=num_batches,
+                        is_ddp=is_ddp,
+                    )
+                    sync_ctx = nullcontext() if sync_grads else self.trainer_module.no_sync()
+                    with sync_ctx:
+                        local_has_valid = 1
+                        try:
+                            metrics = self.trainer_module(
+                                input_ids=target_batch.input_ids,
+                                hidden_states=target_batch.hidden_states,
+                                loss_mask=target_batch.loss_mask,
+                            )
+                            loss = metrics.loss / self.grad_accumulation_steps
+                        except NoValidAnchorsError:
+                            # Every sample in this micro-batch is too short to form a
+                            # block; nothing to learn from it on this rank.
+                            local_has_valid = 0
+                        # Decide skip-vs-backward in lockstep so a per-rank skip never
+                        # leaves one rank issuing its gradient all-reduce alone (DDP
+                        # hang) or desyncs the accumulation windows: if ANY rank has no
+                        # valid anchors, ALL ranks skip this micro-batch together.
+                        all_have_valid = _all_ranks_have_valid(local_has_valid, is_ddp, self.device)
+                        if all_have_valid:
+                            loss.backward()
+                    if not all_have_valid:
+                        self._skipped_micro_batches += 1
+                        continue
 
-                running_loss += metrics.loss.detach().item()
-                running_acc += metrics.accuracy.detach().item()
-                running_micro += 1
-                epoch_loss += metrics.loss.detach().item()
-                micro_step += 1
-                pending_micro_batches += 1
+                    running_loss += metrics.loss.detach().item()
+                    running_acc += metrics.accuracy.detach().item()
+                    running_micro += 1
+                    epoch_loss += metrics.loss.detach().item()
+                    micro_step += 1
+                    pending_micro_batches += 1
 
-                if pending_micro_batches == self.grad_accumulation_steps:
+                    if pending_micro_batches == self.grad_accumulation_steps:
+                        torch.nn.utils.clip_grad_norm_(self.trainer_module.parameters(), self.max_grad_norm)
+                        self.optimizer.step()
+                        self.optimizer.zero_grad(set_to_none=True)
+                        self.lr_scheduler.step()
+                        self.runtime.global_step += 1
+                        if pbar is not None:
+                            pbar.update(1)
+                        completed_steps += 1
+                        pending_micro_batches = 0
+                        self._maybe_save_step_checkpoint(epoch_idx)
+
+                        if self.dist_env.is_main and self.runtime.global_step % self.log_every_steps == 0:
+                            # Average over the micro-batches accumulated since the last
+                            # log, not over optimizer steps: with grad_accumulation_steps>1
+                            # (or skipped short micro-batches) the two differ, and dividing
+                            # by log_every_steps would inflate the reported loss/acc.
+                            avg_loss = running_loss / max(1, running_micro)
+                            avg_acc = running_acc / max(1, running_micro)
+                            current_lr = self.lr_scheduler.get_last_lr()[0]
+                            if pbar is not None:
+                                pbar.set_postfix(
+                                    loss=f"{avg_loss:.4f}",
+                                    acc=f"{avg_acc:.4f}",
+                                    lr=f"{current_lr:.2e}",
+                                )
+                            logger.info(
+                                "epoch=%d step=%d loss=%.4f acc=%.4f lr=%.6g",
+                                epoch_idx,
+                                self.runtime.global_step,
+                                avg_loss,
+                                avg_acc,
+                                current_lr,
+                            )
+                            running_loss = 0.0
+                            running_acc = 0.0
+                            running_micro = 0
+
+                # Flush the trailing partial accumulation window (see EAGLE recipes
+                # for the rescale rationale).
+                if pending_micro_batches > 0:
+                    scale = float(self.grad_accumulation_steps) / float(pending_micro_batches)
+                    for p in self.trainer_module.parameters():
+                        if p.grad is not None:
+                            p.grad.mul_(scale)
                     torch.nn.utils.clip_grad_norm_(self.trainer_module.parameters(), self.max_grad_norm)
                     self.optimizer.step()
                     self.optimizer.zero_grad(set_to_none=True)
@@ -635,76 +680,35 @@ class TrainDFlashRecipe(BaseRecipe):
                     pending_micro_batches = 0
                     self._maybe_save_step_checkpoint(epoch_idx)
 
-                    if self.dist_env.is_main and self.runtime.global_step % self.log_every_steps == 0:
-                        # Average over the micro-batches accumulated since the last
-                        # log, not over optimizer steps: with grad_accumulation_steps>1
-                        # (or skipped short micro-batches) the two differ, and dividing
-                        # by log_every_steps would inflate the reported loss/acc.
-                        avg_loss = running_loss / max(1, running_micro)
-                        avg_acc = running_acc / max(1, running_micro)
-                        current_lr = self.lr_scheduler.get_last_lr()[0]
-                        if pbar is not None:
-                            pbar.set_postfix(
-                                loss=f"{avg_loss:.4f}",
-                                acc=f"{avg_acc:.4f}",
-                                lr=f"{current_lr:.2e}",
-                            )
-                        logger.info(
-                            "epoch=%d step=%d loss=%.4f acc=%.4f lr=%.6g",
-                            epoch_idx,
-                            self.runtime.global_step,
-                            avg_loss,
-                            avg_acc,
-                            current_lr,
+                eval_metrics = self._run_eval()
+                if self.dist_env.is_main:
+                    msg = (
+                        f"Finished epoch {epoch_idx + 1}/{self.num_epochs} completed_steps={completed_steps} "
+                        f"skipped_short_micro_batches={self._skipped_micro_batches}"
+                    )
+                    if eval_metrics is not None:
+                        msg += (
+                            f" val_loss={eval_metrics['val_loss']:.4f} val_accuracy={eval_metrics['val_accuracy']:.4f}"
                         )
-                        running_loss = 0.0
-                        running_acc = 0.0
-                        running_micro = 0
+                    logger.info(msg)
 
-            # Flush the trailing partial accumulation window (see EAGLE recipes
-            # for the rescale rationale).
-            if pending_micro_batches > 0:
-                scale = float(self.grad_accumulation_steps) / float(pending_micro_batches)
-                for p in self.trainer_module.parameters():
-                    if p.grad is not None:
-                        p.grad.mul_(scale)
-                torch.nn.utils.clip_grad_norm_(self.trainer_module.parameters(), self.max_grad_norm)
-                self.optimizer.step()
-                self.optimizer.zero_grad(set_to_none=True)
-                self.lr_scheduler.step()
-                self.runtime.global_step += 1
-                if pbar is not None:
-                    pbar.update(1)
-                completed_steps += 1
-                pending_micro_batches = 0
-                self._maybe_save_step_checkpoint(epoch_idx)
+                if getattr(self, "save_checkpoint_every_epoch", False) and last_batch_idx >= 0:
+                    avg_loss = epoch_loss / max(1, micro_step) if micro_step else None
+                    self.save_checkpoint(
+                        epoch=epoch_idx + 1,
+                        step=self.runtime.global_step,
+                        train_loss=avg_loss,
+                        val_loss=eval_metrics,
+                        best_metric_key="val_loss",
+                        is_final_checkpoint=epoch_idx + 1 >= self.num_epochs,
+                    )
+                    self._log_saved_checkpoint("epoch", epoch_idx + 1, self.runtime.global_step)
 
-            eval_metrics = self._run_eval()
-            if self.dist_env.is_main:
-                msg = (
-                    f"Finished epoch {epoch_idx + 1}/{self.num_epochs} completed_steps={completed_steps} "
-                    f"skipped_short_micro_batches={self._skipped_micro_batches}"
-                )
-                if eval_metrics is not None:
-                    msg += f" val_loss={eval_metrics['val_loss']:.4f} val_accuracy={eval_metrics['val_accuracy']:.4f}"
-                logger.info(msg)
-
-            if getattr(self, "save_checkpoint_every_epoch", False) and last_batch_idx >= 0:
-                avg_loss = epoch_loss / max(1, micro_step) if micro_step else None
-                self.save_checkpoint(
-                    epoch=epoch_idx + 1,
-                    step=self.runtime.global_step,
-                    train_loss=avg_loss,
-                    val_loss=eval_metrics,
-                    best_metric_key="val_loss",
-                    is_final_checkpoint=epoch_idx + 1 >= self.num_epochs,
-                )
-                self._log_saved_checkpoint("epoch", epoch_idx + 1, self.runtime.global_step)
-
-        if pbar is not None:
-            pbar.close()
-        self._maybe_save_final_checkpoint(self.num_epochs)
-        self._finalize_pending_checkpoint()
+            self._maybe_save_final_checkpoint(self.num_epochs)
+            self._finalize_pending_checkpoint()
+        finally:
+            if pbar is not None:
+                pbar.close()
 
 
 def main(config_path: str | None = None):

--- a/nemo_automodel/recipes/llm/train_eagle1.py
+++ b/nemo_automodel/recipes/llm/train_eagle1.py
@@ -583,6 +583,7 @@ class TrainEagle1Recipe(BaseRecipe):
         except TypeError:
             batches_per_epoch = None
         is_ddp = isinstance(self.trainer_module, DistributedDataParallel)
+        pbar = self._make_progress_bar(total=self.total_optim_steps, initial=self.runtime.global_step)
         for epoch_idx in range(start_epoch, self.num_epochs):
             if hasattr(self.train_dataloader, "sampler") and hasattr(self.train_dataloader.sampler, "set_epoch"):
                 self.train_dataloader.sampler.set_epoch(epoch_idx)
@@ -641,6 +642,8 @@ class TrainEagle1Recipe(BaseRecipe):
                     self.optimizer.zero_grad(set_to_none=True)
                     self.lr_scheduler.step()
                     self.runtime.global_step += 1
+                    if pbar is not None:
+                        pbar.update(1)
                     completed_steps += 1
                     pending_micro_batches = 0
                     self._maybe_save_step_checkpoint(epoch_idx)
@@ -650,6 +653,12 @@ class TrainEagle1Recipe(BaseRecipe):
                         avg_loss = running_loss / n
                         avg_acc = running_acc / n
                         current_lr = self.lr_scheduler.get_last_lr()[0]
+                        if pbar is not None:
+                            pbar.set_postfix(
+                                loss=f"{avg_loss:.4f}",
+                                acc=f"{avg_acc:.4f}",
+                                lr=f"{current_lr:.2e}",
+                            )
                         logger.info(
                             "epoch=%d step=%d loss=%.4f acc=%.4f lr=%.6g",
                             epoch_idx,
@@ -709,6 +718,8 @@ class TrainEagle1Recipe(BaseRecipe):
                 self.optimizer.zero_grad(set_to_none=True)
                 self.lr_scheduler.step()
                 self.runtime.global_step += 1
+                if pbar is not None:
+                    pbar.update(1)
                 completed_steps += 1
                 pending_micro_batches = 0
                 self._maybe_save_step_checkpoint(epoch_idx)
@@ -735,6 +746,8 @@ class TrainEagle1Recipe(BaseRecipe):
                     best_metric_key="val_loss",
                 )
 
+        if pbar is not None:
+            pbar.close()
         self._maybe_save_final_checkpoint(self.num_epochs)
         self._finalize_pending_checkpoint()
 

--- a/nemo_automodel/recipes/llm/train_eagle1.py
+++ b/nemo_automodel/recipes/llm/train_eagle1.py
@@ -584,60 +584,137 @@ class TrainEagle1Recipe(BaseRecipe):
             batches_per_epoch = None
         is_ddp = isinstance(self.trainer_module, DistributedDataParallel)
         pbar = self._make_progress_bar(total=self.total_optim_steps, initial=self.runtime.global_step)
-        for epoch_idx in range(start_epoch, self.num_epochs):
-            if hasattr(self.train_dataloader, "sampler") and hasattr(self.train_dataloader.sampler, "set_epoch"):
-                self.train_dataloader.sampler.set_epoch(epoch_idx)
+        try:
+            for epoch_idx in range(start_epoch, self.num_epochs):
+                if hasattr(self.train_dataloader, "sampler") and hasattr(self.train_dataloader.sampler, "set_epoch"):
+                    self.train_dataloader.sampler.set_epoch(epoch_idx)
 
-            running_loss = 0.0
-            running_acc = 0.0
-            running_hidden_loss = 0.0
-            running_token_loss = 0.0
-            epoch_loss = 0.0
-            micro_step = 0
-            pending_micro_batches = 0
-            completed_steps = 0
-            last_batch_idx = -1
-            for batch_idx, batch in enumerate(self.train_dataloader):
-                last_batch_idx = batch_idx
-                batch = {k: v.to(self.device, non_blocking=True) for k, v in batch.items()}
-                target_batch = self.target_wrapper.generate_batch(
-                    input_ids=batch["input_ids"],
-                    attention_mask=batch["attention_mask"],
-                    loss_mask=batch["loss_mask"],
-                )
-                # Skip DDP's per-micro-batch all-reduce on every micro-batch
-                # except the one an optimizer step immediately follows; that
-                # step's all-reduce covers the whole locally-accumulated window.
-                sync_grads = should_sync_grads(
-                    pending_micro_batches=pending_micro_batches,
-                    grad_accumulation_steps=self.grad_accumulation_steps,
-                    batch_idx=batch_idx,
-                    batches_per_epoch=batches_per_epoch,
-                    is_ddp=is_ddp,
-                )
-                sync_ctx = nullcontext() if sync_grads else self.trainer_module.no_sync()
-                with sync_ctx:
-                    metrics = self.trainer_module(
-                        input_ids=target_batch.input_ids,
-                        attention_mask=target_batch.attention_mask,
-                        loss_mask=target_batch.loss_mask,
-                        input_hidden_states=target_batch.input_hidden_states,
-                        target_hidden_states=target_batch.target_hidden_states,
-                        target_logits=target_batch.target_logits,
+                running_loss = 0.0
+                running_acc = 0.0
+                running_hidden_loss = 0.0
+                running_token_loss = 0.0
+                epoch_loss = 0.0
+                micro_step = 0
+                pending_micro_batches = 0
+                completed_steps = 0
+                last_batch_idx = -1
+                for batch_idx, batch in enumerate(self.train_dataloader):
+                    last_batch_idx = batch_idx
+                    batch = {k: v.to(self.device, non_blocking=True) for k, v in batch.items()}
+                    target_batch = self.target_wrapper.generate_batch(
+                        input_ids=batch["input_ids"],
+                        attention_mask=batch["attention_mask"],
+                        loss_mask=batch["loss_mask"],
                     )
-                    loss = metrics.loss / self.grad_accumulation_steps
-                    loss.backward()
+                    # Skip DDP's per-micro-batch all-reduce on every micro-batch
+                    # except the one an optimizer step immediately follows; that
+                    # step's all-reduce covers the whole locally-accumulated window.
+                    sync_grads = should_sync_grads(
+                        pending_micro_batches=pending_micro_batches,
+                        grad_accumulation_steps=self.grad_accumulation_steps,
+                        batch_idx=batch_idx,
+                        batches_per_epoch=batches_per_epoch,
+                        is_ddp=is_ddp,
+                    )
+                    sync_ctx = nullcontext() if sync_grads else self.trainer_module.no_sync()
+                    with sync_ctx:
+                        metrics = self.trainer_module(
+                            input_ids=target_batch.input_ids,
+                            attention_mask=target_batch.attention_mask,
+                            loss_mask=target_batch.loss_mask,
+                            input_hidden_states=target_batch.input_hidden_states,
+                            target_hidden_states=target_batch.target_hidden_states,
+                            target_logits=target_batch.target_logits,
+                        )
+                        loss = metrics.loss / self.grad_accumulation_steps
+                        loss.backward()
 
-                running_loss += metrics.loss.detach().item()
-                running_acc += metrics.accuracy.detach().item()
-                running_hidden_loss += metrics.hidden_loss.detach().item()
-                running_token_loss += metrics.token_loss.detach().item()
-                epoch_loss += metrics.loss.detach().item()
-                micro_step += 1
-                pending_micro_batches += 1
+                    running_loss += metrics.loss.detach().item()
+                    running_acc += metrics.accuracy.detach().item()
+                    running_hidden_loss += metrics.hidden_loss.detach().item()
+                    running_token_loss += metrics.token_loss.detach().item()
+                    epoch_loss += metrics.loss.detach().item()
+                    micro_step += 1
+                    pending_micro_batches += 1
 
-                if pending_micro_batches == self.grad_accumulation_steps:
-                    grad_norm = torch.nn.utils.clip_grad_norm_(self.trainer_module.parameters(), self.max_grad_norm)
+                    if pending_micro_batches == self.grad_accumulation_steps:
+                        grad_norm = torch.nn.utils.clip_grad_norm_(self.trainer_module.parameters(), self.max_grad_norm)
+                        self.optimizer.step()
+                        self.optimizer.zero_grad(set_to_none=True)
+                        self.lr_scheduler.step()
+                        self.runtime.global_step += 1
+                        if pbar is not None:
+                            pbar.update(1)
+                        completed_steps += 1
+                        pending_micro_batches = 0
+                        self._maybe_save_step_checkpoint(epoch_idx)
+
+                        if self.dist_env.is_main and self.runtime.global_step % self.log_every_steps == 0:
+                            n = self.log_every_steps
+                            avg_loss = running_loss / n
+                            avg_acc = running_acc / n
+                            current_lr = self.lr_scheduler.get_last_lr()[0]
+                            if pbar is not None:
+                                pbar.set_postfix(
+                                    loss=f"{avg_loss:.4f}",
+                                    acc=f"{avg_acc:.4f}",
+                                    lr=f"{current_lr:.2e}",
+                                )
+                            logger.info(
+                                "epoch=%d step=%d loss=%.4f acc=%.4f lr=%.6g",
+                                epoch_idx,
+                                self.runtime.global_step,
+                                avg_loss,
+                                avg_acc,
+                                current_lr,
+                            )
+                            self._wandb_log(
+                                {
+                                    "train/loss": avg_loss,
+                                    "train/accuracy": avg_acc,
+                                    "train/hidden_loss": running_hidden_loss / n,
+                                    "train/token_loss": running_token_loss / n,
+                                    "train/lr": current_lr,
+                                    "train/grad_norm": float(grad_norm),
+                                    "train/epoch": epoch_idx,
+                                },
+                                step=self.runtime.global_step,
+                            )
+                            running_loss = 0.0
+                            running_acc = 0.0
+                            running_hidden_loss = 0.0
+                            running_token_loss = 0.0
+
+                # Flush the trailing partial accumulation window. When
+                # ``batches_per_epoch`` is not a multiple of ``grad_accumulation_steps``,
+                # up to ``grad_accumulation_steps - 1`` micro-batches have run
+                # ``backward()`` but never reached an ``optimizer.step()`` -- those
+                # gradients would otherwise be wiped by the next epoch's
+                # ``zero_grad`` and the samples wasted.
+                #
+                # Each micro-batch divided its loss by ``grad_accumulation_steps``
+                # in anticipation of a full window. With only ``pending_micro_batches``
+                # contributors, the accumulated gradient magnitude is
+                # ``pending_micro_batches / grad_accumulation_steps`` of a normal
+                # step; rescale by the inverse so the trailing step's gradient is on
+                # the same scale as every other step.
+                #
+                # Assumption: every data-parallel rank reaches this flush with the
+                # same ``pending_micro_batches``. That holds here because the loader
+                # uses ``DistributedSampler`` with ``drop_last=False`` (and the
+                # DataLoader likewise), which pads every rank to an equal sample
+                # count -> equal batches per epoch -> equal trailing windows. If a
+                # non-padding / variable-length sampler is ever introduced, revisit
+                # this: a divergent per-rank ``scale`` would desync parameters, and
+                # a rank that lands on ``pending_micro_batches == 0`` would skip the
+                # flush (and the ``clip_grad_norm_`` collective inside it) while its
+                # peers step, hanging on the mismatched collective.
+                if pending_micro_batches > 0:
+                    scale = float(self.grad_accumulation_steps) / float(pending_micro_batches)
+                    for p in self.trainer_module.parameters():
+                        if p.grad is not None:
+                            p.grad.mul_(scale)
+                    torch.nn.utils.clip_grad_norm_(self.trainer_module.parameters(), self.max_grad_norm)
                     self.optimizer.step()
                     self.optimizer.zero_grad(set_to_none=True)
                     self.lr_scheduler.step()
@@ -648,108 +725,35 @@ class TrainEagle1Recipe(BaseRecipe):
                     pending_micro_batches = 0
                     self._maybe_save_step_checkpoint(epoch_idx)
 
-                    if self.dist_env.is_main and self.runtime.global_step % self.log_every_steps == 0:
-                        n = self.log_every_steps
-                        avg_loss = running_loss / n
-                        avg_acc = running_acc / n
-                        current_lr = self.lr_scheduler.get_last_lr()[0]
-                        if pbar is not None:
-                            pbar.set_postfix(
-                                loss=f"{avg_loss:.4f}",
-                                acc=f"{avg_acc:.4f}",
-                                lr=f"{current_lr:.2e}",
-                            )
-                        logger.info(
-                            "epoch=%d step=%d loss=%.4f acc=%.4f lr=%.6g",
-                            epoch_idx,
-                            self.runtime.global_step,
-                            avg_loss,
-                            avg_acc,
-                            current_lr,
+                eval_metrics = self._run_eval()
+                if self.dist_env.is_main:
+                    msg = f"Finished epoch {epoch_idx + 1}/{self.num_epochs} completed_steps={completed_steps}"
+                    if eval_metrics is not None:
+                        msg += (
+                            f" val_loss={eval_metrics['val_loss']:.4f} val_accuracy={eval_metrics['val_accuracy']:.4f}"
                         )
-                        self._wandb_log(
-                            {
-                                "train/loss": avg_loss,
-                                "train/accuracy": avg_acc,
-                                "train/hidden_loss": running_hidden_loss / n,
-                                "train/token_loss": running_token_loss / n,
-                                "train/lr": current_lr,
-                                "train/grad_norm": float(grad_norm),
-                                "train/epoch": epoch_idx,
-                            },
-                            step=self.runtime.global_step,
-                        )
-                        running_loss = 0.0
-                        running_acc = 0.0
-                        running_hidden_loss = 0.0
-                        running_token_loss = 0.0
-
-            # Flush the trailing partial accumulation window. When
-            # ``batches_per_epoch`` is not a multiple of ``grad_accumulation_steps``,
-            # up to ``grad_accumulation_steps - 1`` micro-batches have run
-            # ``backward()`` but never reached an ``optimizer.step()`` -- those
-            # gradients would otherwise be wiped by the next epoch's
-            # ``zero_grad`` and the samples wasted.
-            #
-            # Each micro-batch divided its loss by ``grad_accumulation_steps``
-            # in anticipation of a full window. With only ``pending_micro_batches``
-            # contributors, the accumulated gradient magnitude is
-            # ``pending_micro_batches / grad_accumulation_steps`` of a normal
-            # step; rescale by the inverse so the trailing step's gradient is on
-            # the same scale as every other step.
-            #
-            # Assumption: every data-parallel rank reaches this flush with the
-            # same ``pending_micro_batches``. That holds here because the loader
-            # uses ``DistributedSampler`` with ``drop_last=False`` (and the
-            # DataLoader likewise), which pads every rank to an equal sample
-            # count -> equal batches per epoch -> equal trailing windows. If a
-            # non-padding / variable-length sampler is ever introduced, revisit
-            # this: a divergent per-rank ``scale`` would desync parameters, and
-            # a rank that lands on ``pending_micro_batches == 0`` would skip the
-            # flush (and the ``clip_grad_norm_`` collective inside it) while its
-            # peers step, hanging on the mismatched collective.
-            if pending_micro_batches > 0:
-                scale = float(self.grad_accumulation_steps) / float(pending_micro_batches)
-                for p in self.trainer_module.parameters():
-                    if p.grad is not None:
-                        p.grad.mul_(scale)
-                torch.nn.utils.clip_grad_norm_(self.trainer_module.parameters(), self.max_grad_norm)
-                self.optimizer.step()
-                self.optimizer.zero_grad(set_to_none=True)
-                self.lr_scheduler.step()
-                self.runtime.global_step += 1
-                if pbar is not None:
-                    pbar.update(1)
-                completed_steps += 1
-                pending_micro_batches = 0
-                self._maybe_save_step_checkpoint(epoch_idx)
-
-            eval_metrics = self._run_eval()
-            if self.dist_env.is_main:
-                msg = f"Finished epoch {epoch_idx + 1}/{self.num_epochs} completed_steps={completed_steps}"
+                    logger.info(msg)
                 if eval_metrics is not None:
-                    msg += f" val_loss={eval_metrics['val_loss']:.4f} val_accuracy={eval_metrics['val_accuracy']:.4f}"
-                logger.info(msg)
-            if eval_metrics is not None:
-                self._wandb_log(
-                    {"val/loss": eval_metrics["val_loss"], "val/accuracy": eval_metrics["val_accuracy"]},
-                    step=self.runtime.global_step,
-                )
+                    self._wandb_log(
+                        {"val/loss": eval_metrics["val_loss"], "val/accuracy": eval_metrics["val_accuracy"]},
+                        step=self.runtime.global_step,
+                    )
 
-            if getattr(self, "save_checkpoint_every_epoch", False) and last_batch_idx >= 0:
-                avg_loss = epoch_loss / max(1, micro_step) if micro_step else None
-                self.save_checkpoint(
-                    epoch=epoch_idx + 1,
-                    step=self.runtime.global_step,
-                    train_loss=avg_loss,
-                    val_loss=eval_metrics,
-                    best_metric_key="val_loss",
-                )
+                if getattr(self, "save_checkpoint_every_epoch", False) and last_batch_idx >= 0:
+                    avg_loss = epoch_loss / max(1, micro_step) if micro_step else None
+                    self.save_checkpoint(
+                        epoch=epoch_idx + 1,
+                        step=self.runtime.global_step,
+                        train_loss=avg_loss,
+                        val_loss=eval_metrics,
+                        best_metric_key="val_loss",
+                    )
 
-        if pbar is not None:
-            pbar.close()
-        self._maybe_save_final_checkpoint(self.num_epochs)
-        self._finalize_pending_checkpoint()
+            self._maybe_save_final_checkpoint(self.num_epochs)
+            self._finalize_pending_checkpoint()
+        finally:
+            if pbar is not None:
+                pbar.close()
 
         if getattr(self, "wandb_run", None) is not None:
             self.wandb_run.finish()

--- a/nemo_automodel/recipes/llm/train_eagle3.py
+++ b/nemo_automodel/recipes/llm/train_eagle3.py
@@ -973,13 +973,16 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
                 self.min_lr_ratio,
             )
 
+        pbar = self._make_progress_bar(total=self.total_optim_steps, initial=self.runtime.global_step)
         try:
-            self._train_epochs(start_epoch, batches_per_epoch, is_ddp)
+            self._train_epochs(start_epoch, batches_per_epoch, is_ddp, pbar)
             self._maybe_save_final_checkpoint(self.num_epochs)
             self._finalize_pending_checkpoint()
             if self.dist_env.is_main:
                 logger.info("Training complete: global_step=%s", self.runtime.global_step)
         finally:
+            if pbar is not None:
+                pbar.close()
             self._finalize_training()
 
     def _finalize_training(self) -> None:
@@ -1001,7 +1004,7 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
         if getattr(self, "wandb_run", None) is not None:
             _best_effort("finishing W&B run", self.wandb_run.finish)
 
-    def _train_epochs(self, start_epoch, batches_per_epoch, is_ddp):
+    def _train_epochs(self, start_epoch, batches_per_epoch, is_ddp, pbar=None):
         """Run the epoch loop (extracted so :meth:`run_train_validation_loop` can
         wrap it in ``try/finally`` and guarantee teardown on any exit path)."""
         for epoch in range(start_epoch, self.num_epochs):
@@ -1056,6 +1059,8 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
                     self.lr_scheduler.step()
                     self.optimizer.zero_grad(set_to_none=True)
                     self.runtime.global_step += 1
+                    if pbar is not None:
+                        pbar.update(1)
                     pending_micro_batches = 0
                     self._maybe_save_step_checkpoint(epoch)
 
@@ -1064,6 +1069,12 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
                         mean_acc = _all_reduce_mean(running_acc / max(running_steps, 1))
                         current_lr = self.lr_scheduler.get_last_lr()[0]
                         if self.dist_env.is_main:
+                            if pbar is not None:
+                                pbar.set_postfix(
+                                    loss=f"{mean_loss.item():.4f}",
+                                    acc=f"{mean_acc.item():.4f}",
+                                    lr=f"{current_lr:.2e}",
+                                )
                             logger.info(
                                 "epoch=%s step=%s train_loss=%.6f train_acc=%.6f lr=%.3e",
                                 epoch,
@@ -1109,6 +1120,8 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
                 self.lr_scheduler.step()
                 self.optimizer.zero_grad(set_to_none=True)
                 self.runtime.global_step += 1
+                if pbar is not None:
+                    pbar.update(1)
                 pending_micro_batches = 0
                 self._maybe_save_step_checkpoint(epoch)
 

--- a/tests/unit_tests/recipes/llm/test_eagle_step_checkpoint.py
+++ b/tests/unit_tests/recipes/llm/test_eagle_step_checkpoint.py
@@ -197,6 +197,7 @@ def _build_eagle1_recipe(num_batches, grad_accum, num_epochs, ckpt_every_steps, 
     recipe.max_grad_norm = 1e9
     recipe.num_epochs = num_epochs
     recipe.log_every_steps = 1
+    recipe.total_optim_steps = num_epochs * -(-num_batches // grad_accum)
     recipe.ckpt_every_steps = ckpt_every_steps
     recipe.save_checkpoint_every_epoch = save_every_epoch
     recipe.optimizer = torch.optim.SGD(recipe.trainer_module.parameters(), lr=0.0)

--- a/tests/unit_tests/recipes/llm/test_train_dflash_noanchor_skip.py
+++ b/tests/unit_tests/recipes/llm/test_train_dflash_noanchor_skip.py
@@ -79,6 +79,7 @@ def _build_recipe(raise_on, num_batches=3, grad_accum=1):
     recipe.max_grad_norm = 1.0
     recipe.num_epochs = 1
     recipe.log_every_steps = 1
+    recipe.total_optim_steps = -(-num_batches // grad_accum)
     recipe._skipped_micro_batches = 0
     recipe.save_checkpoint_every_epoch = False
     recipe.ckpt_every_steps = None
@@ -103,3 +104,34 @@ def test_no_skip_when_all_micro_batches_valid():
     recipe.run_train_validation_loop()
     assert recipe._skipped_micro_batches == 0
     assert recipe.runtime.global_step == 3
+
+
+# ---------------------------------------------------------------------------
+# Progress bar: one update per optimizer step, postfix at log points, closed
+# ---------------------------------------------------------------------------
+
+
+class _FakeProgressBar:
+    def __init__(self):
+        self.n = 0
+        self.postfix = None
+        self.closed = False
+
+    def update(self, count=1):
+        self.n += count
+
+    def set_postfix(self, **kwargs):
+        self.postfix = kwargs
+
+    def close(self):
+        self.closed = True
+
+
+def test_progress_bar_advances_per_optim_step(monkeypatch):
+    fake = _FakeProgressBar()
+    monkeypatch.setattr(TrainDFlashRecipe, "_make_progress_bar", lambda self, **kwargs: fake)
+    recipe = _build_recipe(raise_on=set(), num_batches=3, grad_accum=1)
+    recipe.run_train_validation_loop()
+    assert fake.n == recipe.runtime.global_step == 3
+    assert fake.closed
+    assert set(fake.postfix) == {"loss", "acc", "lr"}

--- a/tests/unit_tests/recipes/llm/test_train_dflash_noanchor_skip.py
+++ b/tests/unit_tests/recipes/llm/test_train_dflash_noanchor_skip.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
 import torch
 import torch.nn as nn
 
@@ -135,3 +136,18 @@ def test_progress_bar_advances_per_optim_step(monkeypatch):
     assert fake.n == recipe.runtime.global_step == 3
     assert fake.closed
     assert set(fake.postfix) == {"loss", "acc", "lr"}
+
+
+def test_progress_bar_closed_when_loop_raises(monkeypatch):
+    """The bar is closed even when the training loop raises (try/finally)."""
+    fake = _FakeProgressBar()
+    monkeypatch.setattr(TrainDFlashRecipe, "_make_progress_bar", lambda self, **kwargs: fake)
+
+    def _boom(self, **kwargs):
+        raise RuntimeError("boom")
+
+    recipe = _build_recipe(raise_on=set(), num_batches=2, grad_accum=1)
+    monkeypatch.setattr(type(recipe.trainer_module), "forward", _boom)
+    with pytest.raises(RuntimeError, match="boom"):
+        recipe.run_train_validation_loop()
+    assert fake.closed

--- a/tests/unit_tests/recipes/llm/test_train_eagle1_grad_accum.py
+++ b/tests/unit_tests/recipes/llm/test_train_eagle1_grad_accum.py
@@ -223,3 +223,22 @@ def test_progress_bar_advances_per_optim_step(monkeypatch):
     assert fake.n == recipe.runtime.global_step == 2
     assert fake.closed
     assert set(fake.postfix) == {"loss", "acc", "lr"}
+
+
+class _RaisingModule(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.w = nn.Parameter(torch.zeros(4))
+
+    def forward(self, **kwargs):
+        raise RuntimeError("boom")
+
+
+def test_progress_bar_closed_when_loop_raises(monkeypatch):
+    """The bar is closed even when the training loop raises (try/finally)."""
+    fake = _FakeProgressBar()
+    monkeypatch.setattr(TrainEagle1Recipe, "_make_progress_bar", lambda self, **kwargs: fake)
+    recipe = _build_recipe(num_batches=2, grad_accum=1, trainer_module=_RaisingModule())
+    with pytest.raises(RuntimeError, match="boom"):
+        recipe.run_train_validation_loop()
+    assert fake.closed

--- a/tests/unit_tests/recipes/llm/test_train_eagle1_grad_accum.py
+++ b/tests/unit_tests/recipes/llm/test_train_eagle1_grad_accum.py
@@ -117,6 +117,7 @@ def _build_recipe(num_batches: int, grad_accum: int, trainer_module: nn.Module |
     recipe.max_grad_norm = 1e9
     recipe.num_epochs = 1
     recipe.log_every_steps = 1
+    recipe.total_optim_steps = -(-num_batches // grad_accum)
     recipe.optimizer = torch.optim.SGD(recipe.trainer_module.parameters(), lr=0.0)
     recipe.lr_scheduler = torch.optim.lr_scheduler.LambdaLR(recipe.optimizer, lambda s: 1.0)
     return recipe
@@ -190,3 +191,35 @@ def test_no_sync_entered_for_interior_microbatches_under_ddp(tmp_path):
         assert recipe.runtime.global_step == 2
     finally:
         dist.destroy_process_group()
+
+
+# ---------------------------------------------------------------------------
+# Progress bar: one update per optimizer step (incl. trailing flush), closed
+# ---------------------------------------------------------------------------
+
+
+class _FakeProgressBar:
+    def __init__(self):
+        self.n = 0
+        self.postfix = None
+        self.closed = False
+
+    def update(self, count=1):
+        self.n += count
+
+    def set_postfix(self, **kwargs):
+        self.postfix = kwargs
+
+    def close(self):
+        self.closed = True
+
+
+def test_progress_bar_advances_per_optim_step(monkeypatch):
+    fake = _FakeProgressBar()
+    monkeypatch.setattr(TrainEagle1Recipe, "_make_progress_bar", lambda self, **kwargs: fake)
+    # 4 batches / accum 3 -> one full window + one trailing flush = 2 steps.
+    recipe = _build_recipe(num_batches=4, grad_accum=3)
+    recipe.run_train_validation_loop()
+    assert fake.n == recipe.runtime.global_step == 2
+    assert fake.closed
+    assert set(fake.postfix) == {"loss", "acc", "lr"}

--- a/tests/unit_tests/recipes/llm/test_train_eagle3_flush.py
+++ b/tests/unit_tests/recipes/llm/test_train_eagle3_flush.py
@@ -259,3 +259,35 @@ def test_logging_path_is_exercised(tmp_path):
     recipe = _build_recipe(tmp_path, num_samples=4, grad_accum=2, log_every=1)
     recipe.run_train_validation_loop()
     assert recipe.runtime.global_step == 2
+
+
+# ---------------------------------------------------------------------------
+# Progress bar: one update per optimizer step, postfix at log points, closed
+# ---------------------------------------------------------------------------
+
+
+class _FakeProgressBar:
+    def __init__(self):
+        self.n = 0
+        self.postfix = None
+        self.closed = False
+
+    def update(self, count=1):
+        self.n += count
+
+    def set_postfix(self, **kwargs):
+        self.postfix = kwargs
+
+    def close(self):
+        self.closed = True
+
+
+def test_progress_bar_advances_per_optim_step(tmp_path, monkeypatch):
+    fake = _FakeProgressBar()
+    monkeypatch.setattr(TrainEagle3Recipe, "_make_progress_bar", lambda self, **kwargs: fake)
+    # 5 samples / accum 3 -> one full window + one trailing flush = 2 steps.
+    recipe = _build_recipe(tmp_path, num_samples=5, grad_accum=3, log_every=1)
+    recipe.run_train_validation_loop()
+    assert fake.n == recipe.runtime.global_step == 2
+    assert fake.closed
+    assert set(fake.postfix) == {"loss", "acc", "lr"}

--- a/tests/unit_tests/recipes/test_base_recipe.py
+++ b/tests/unit_tests/recipes/test_base_recipe.py
@@ -728,6 +728,15 @@ class TestMakeProgressBar:
         assert pbar.total is None
         pbar.close()
 
+    def test_explicit_total_and_initial_skip_step_scheduler(self, monkeypatch):
+        monkeypatch.setattr(torch.distributed, "is_initialized", lambda: False)
+        r = _FakeRecipe()  # deliberately no step_scheduler attribute
+        pbar = r._make_progress_bar(total=40, initial=7)
+        assert pbar is not None
+        assert pbar.total == 40
+        assert pbar.n == 7
+        pbar.close()
+
 
 class TestUpdateProgressBar:
     def _make_pbar(self):

--- a/tests/unit_tests/speculative/test_eagle12_coverage.py
+++ b/tests/unit_tests/speculative/test_eagle12_coverage.py
@@ -356,6 +356,7 @@ class TestRecipeInternals:
         recipe.num_epochs = 1
         recipe.log_every_steps = 1
         recipe.peak_lr = 1e-4
+        recipe.total_optim_steps = 4
 
         recipe.optimizer = torch.optim.AdamW([p for p in trainer_module.parameters() if p.requires_grad], lr=1e-4)
         recipe.lr_scheduler = torch.optim.lr_scheduler.LambdaLR(recipe.optimizer, lambda s: 1.0)


### PR DESCRIPTION
## What

The speculative-decoding training loops (EAGLE-1/2, EAGLE-3 / P-EAGLE, and DFlash) only emit a log line every `log_every_steps` optimizer steps. There is no view of overall progress: no step/total, no percentage, and no time estimate, so a long run looks stalled between log lines.

This PR adds a rank-0 tqdm progress bar to every speculative recipe, showing `step/total`, percentage, elapsed time, ETA, and seconds per step, with loss/accuracy/lr attached as the bar postfix at each logging interval.

## How

- Generalize `BaseRecipe._make_progress_bar` to accept explicit `total`/`initial` arguments. These recipes hand-roll their training loop and have no `step_scheduler`; they pass `total_optim_steps` and the resumed `runtime.global_step` instead. Without arguments the helper behaves exactly as before (reads `step_scheduler`), so the existing `train_ft`/`kd`/`seq_cls`/VLM/retrieval callers are unchanged.
- `train_eagle1.py`, `train_eagle3.py`, and `train_dflash.py`: create the bar at loop start, advance it once per optimizer step (including the trailing grad-accum flush step), set the postfix at each `log_every_steps` interval, and close it on exit (EAGLE-3 closes in its existing `try/finally`).
- Coverage: EAGLE-2 inherits EAGLE-1's loop unchanged; P-EAGLE runs through the EAGLE-3 loop. So EAGLE-1/2/3, P-EAGLE, and DFlash are all covered.
- Periodic `logger.info` lines and W&B logging are unchanged.

## Tests

- `TestMakeProgressBar::test_explicit_total_and_initial_skip_step_scheduler`: explicit args bypass `step_scheduler` entirely.
- `test_progress_bar_advances_per_optim_step` (eagle1, eagle3, dflash): the bar advances once per optimizer step including the trailing flush, receives a loss/acc/lr postfix, and is closed.
- Bare test-harness recipes now set `total_optim_steps` like the real `setup()` does.

`pytest` over the EAGLE/DFlash recipe suites, `test_base_recipe.py`, and `test_train_ft.py`: 230 passed. ruff clean.

## Notes

`main` currently has two failing `TestFormatLoad` checkpoint unit tests (fixed by #2519 / #2520); if L0 shows those two failures here, they are pre-existing and unrelated to this change.