### PR TITLE
fix(config): glm4.7 yaml

### DIFF
--- a/examples/llm_finetune/glm/glm_4.7_flash_te_packed_sequence.yaml
+++ b/examples/llm_finetune/glm/glm_4.7_flash_te_packed_sequence.yaml
@@ -33,10 +33,6 @@ rng:
   seed: 1111
   ranked: true
 
-moe_config:
-  _target_: nemo_automodel.components.moe.config.MoEParallelizerConfig
-  activation_checkpointing: false
-
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: zai-org/GLM-4.7-Flash
@@ -71,6 +67,7 @@ distributed:
   cp_size: 1
   pp_size: 1
   ep_size: 8
+  activation_checkpointing: false
 
 distributed_config:
   _target_: nemo_automodel.components.distributed.config.FSDP2Config


### PR DESCRIPTION
The glm_4.7_flash_te_packed_sequence recipe used a top-level `moe_config:` block with `_target_: nemo_automodel.components.moe.config.MoEParallelizerConfig`, but that class lives at `nemo_automodel.components.distributed.config` (moe.config has no such attribute). The config loader eagerly resolves every `_target_`, so this raised at config-load time, before training started:

  AttributeError: module 'nemo_automodel.components.moe.config'
                  has no attribute 'MoEParallelizerConfig'

The top-level `moe_config:` block is not a supported recipe key: MoE parallelizer settings are read from `distributed.moe` and activation checkpointing from `distributed.activation_checkpointing` (see recipes/_dist_utils.py:parse_distributed_section). Every other MoE recipe (e.g. glm_4.7_flash_te_deepep.yaml) already uses the distributed.* form.

Fix: drop the top-level moe_config block and move `activation_checkpointing: false` under `distributed:`. With ep_size>1 the loader builds a default MoEParallelizerConfig, preserving the original intent (activation checkpointing off).

Verified against current source: the recipe now loads without the AttributeError, and parse_distributed_section yields the correct default MoEParallelizerConfig with activation_checkpointing=False.

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
