### PR TITLE
fix(diffusion): resolve flux nightly CI failures

### DIFF
--- a/nemo_automodel/recipes/diffusion/train.py
+++ b/nemo_automodel/recipes/diffusion/train.py
@@ -232,6 +232,12 @@ def _build_diffusion_parallel_manager_args(
     if compute_dtype is None:
         compute_dtype = dtype
 
+    # The recipe passes ConfigNode sections, which support .to_dict() but not dict().
+    if hasattr(fsdp_cfg, "to_dict"):
+        fsdp_cfg = fsdp_cfg.to_dict()
+    if hasattr(ddp_cfg, "to_dict"):
+        ddp_cfg = ddp_cfg.to_dict()
+
     if fsdp_cfg is not None and ddp_cfg is not None:
         raise ValueError(
             "Cannot specify both 'fsdp' and 'ddp' configurations. "

--- a/tests/ci_tests/scripts/diffusion_finetune_launcher.sh
+++ b/tests/ci_tests/scripts/diffusion_finetune_launcher.sh
@@ -144,13 +144,21 @@ fi
 echo "============================================"
 echo "[finetune] Running finetuning..."
 echo "============================================"
+# The recipe rejects configs that contain both 'fsdp' and 'ddp' sections, and
+# a --fsdp.* CLI override injects an 'fsdp' section. Only pass it for FSDP
+# recipes; DDP replicates across all ranks and needs no dp_size.
+DIST_OVERRIDE="--fsdp.dp_size ${NPROC_PER_NODE}"
+if grep -qE '^ddp:' "/opt/Automodel/${CONFIG_PATH}"; then
+    DIST_OVERRIDE=""
+fi
+
 CONFIG="--config /opt/Automodel/${CONFIG_PATH} \
     --data.dataloader.cache_dir $DATA_DIR/cache \
     --checkpoint.checkpoint_dir $CKPT_DIR \
     --step_scheduler.max_steps ${MAX_STEPS:-100} \
     --step_scheduler.ckpt_every_steps 100 \
     --step_scheduler.save_checkpoint_every_epoch false \
-    --fsdp.dp_size ${NPROC_PER_NODE} \
+    ${DIST_OVERRIDE} \
     --wandb.mode disabled"
 
 CMD="uv run --extra diffusion torchrun --nproc-per-node=${NPROC_PER_NODE} \

--- a/tests/unit_tests/recipes/test_diffusion_train_metrics.py
+++ b/tests/unit_tests/recipes/test_diffusion_train_metrics.py
@@ -464,6 +464,36 @@ def test_build_diffusion_parallel_manager_args_parses_ddp_config():
     }
 
 
+def test_build_diffusion_parallel_manager_args_accepts_confignode_fsdp_config():
+    manager_args = _build_diffusion_parallel_manager_args(
+        fsdp_cfg=ConfigNode({"dp_size": 8, "cpu_offload": False}),
+        ddp_cfg=None,
+        world_size=8,
+        dtype=torch.bfloat16,
+        lora_enabled=False,
+    )
+
+    assert manager_args["_manager_type"] == "fsdp2"
+    assert manager_args["dp_size"] == 8
+
+
+def test_build_diffusion_parallel_manager_args_accepts_confignode_ddp_config():
+    manager_args = _build_diffusion_parallel_manager_args(
+        fsdp_cfg=None,
+        ddp_cfg=ConfigNode({"backend": "nccl", "activation_checkpointing": False}),
+        world_size=4,
+        dtype=torch.bfloat16,
+        lora_enabled=False,
+    )
+
+    assert manager_args == {
+        "_manager_type": "ddp",
+        "world_size": 4,
+        "activation_checkpointing": False,
+        "find_unused_parameters": False,
+    }
+
+
 def test_build_model_and_optimizer_forwards_perf_options_and_optimizer_kwargs(monkeypatch):
     pipe = SimpleNamespace(transformer=_TinyTransformer())
     manager = SimpleNamespace(device_mesh="mesh")


### PR DESCRIPTION
# What does this PR do ?

Fixes two startup failures in the diffusion nightly functional tests (`flux_t2i_flow_lora` and `flux_t2i_flow`).

# Changelog

- `tests/ci_tests/scripts/diffusion_finetune_launcher.sh`: the launcher unconditionally passed `--fsdp.dp_size` to every recipe. Since #2251 switched the Flux LoRA config to a `ddp:` section, that CLI override injected a conflicting `fsdp` section and the recipe raised `ValueError: Cannot specify both 'fsdp' and 'ddp' configurations`. The launcher now greps the recipe YAML for a top-level `ddp:` section and skips the override for DDP-based recipes (DDP replicates across all ranks and needs no dp_size). This also pre-empts the same failure for `qwen_image_t2i_flow_lora` if it is added to the nightly list.
- `nemo_automodel/recipes/diffusion/train.py`: `_build_diffusion_parallel_manager_args` (introduced in #2266) called `dict()` on the `fsdp`/`ddp` config sections, but the recipe passes `ConfigNode` objects which support `.to_dict()` but not `dict()` conversion, crashing `flux_t2i_flow` with `TypeError: 'ConfigNode' object is not iterable`. The sections are now normalized via `.to_dict()` at the top of the function, fixing both the FSDP branch and the identical latent bug in the DDP branch.
- `tests/unit_tests/recipes/test_diffusion_train_metrics.py`: added unit tests that pass `ConfigNode` sections to `_build_diffusion_parallel_manager_args` the way the recipe does (the existing tests only covered plain dicts, which is why the regression slipped through to the nightly).

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

# Additional Information

- Failing nightly jobs: `flux_t2i_flow_lora` (Slurm job 5422723) and `flux_t2i_flow` (Slurm job 5422718) on pipeline 54319513.

🤖 Generated with [Claude Code](https://claude.com/claude-code)