### PR TITLE
fix(speculative): compile variable-shape flex callables with dynamic shapes

### DIFF
--- a/nemo_automodel/components/attention/dflash_mask.py
+++ b/nemo_automodel/components/attention/dflash_mask.py
@@ -41,6 +41,10 @@ from torch.nn.attention.flex_attention import BlockMask, create_block_mask
 # changes per step (new anchor positions), but the create_block_mask machinery
 # itself is identical — compiling once and reusing avoids per-step Python
 # overhead of evaluating mask_mod across the BlockMask grid.
+# ``dynamic=True``: the mask shape depends on the per-batch anchor count
+# (``min(num_anchors, valid anchors in the batch)``), so a static compile
+# re-specializes (a full recompile, a multi-second stall mid-training) every
+# time a batch carries a new anchor count. One dynamic compile covers all.
 _compiled_create_block_mask = None
 
 
@@ -48,7 +52,7 @@ def _get_compiled_create_block_mask():
     """Lazy-initialise a compiled ``create_block_mask`` and cache it."""
     global _compiled_create_block_mask
     if _compiled_create_block_mask is None:
-        _compiled_create_block_mask = torch.compile(create_block_mask, dynamic=False)
+        _compiled_create_block_mask = torch.compile(create_block_mask, dynamic=True)
     return _compiled_create_block_mask
 
 

--- a/nemo_automodel/components/speculative/eagle/peagle_draft.py
+++ b/nemo_automodel/components/speculative/eagle/peagle_draft.py
@@ -46,9 +46,15 @@ logger = logging.getLogger(__name__)
 # ``flex_attention`` for unsupported cases -- correct, just slower -- which keeps
 # P-EAGLE unit tests and small CPU/GPU smoke checks runnable. The compiled
 # callable is lazy, so importing this module on CPU costs nothing.
+# ``dynamic=True``: COD subsampling gives every rank/batch a different flat
+# sequence length, so a static-by-default first compile never matches a shared
+# Inductor cache and every fresh process pays a full max-autotune pass
+# (minutes), desyncing multi-node startup. Compiling dynamic from the start
+# lets every rank load the one cached dynamic kernel.
 _peagle_flex_attention_compiled = torch.compile(
     flex_attention,
     mode="max-autotune-no-cudagraphs",
+    dynamic=True,
 )
 _peagle_flex_attention_compile_failed = False
 

--- a/tests/unit_tests/attention/test_dflash_mask.py
+++ b/tests/unit_tests/attention/test_dflash_mask.py
@@ -131,7 +131,8 @@ def test_compiled_create_block_mask_is_cached(monkeypatch):
 
     assert dflash_mask._get_compiled_create_block_mask() is sentinel
     assert dflash_mask._get_compiled_create_block_mask() is sentinel
-    assert calls == [(dflash_mask.create_block_mask, False)]
+    # dynamic=True: rationale at the compile site in dflash_mask.py.
+    assert calls == [(dflash_mask.create_block_mask, True)]
 
 
 def test_block_mask_uncompiled_cpu_smoke():

--- a/tests/unit_tests/speculative/test_peagle.py
+++ b/tests/unit_tests/speculative/test_peagle.py
@@ -746,3 +746,35 @@ def test_gradient_checkpointing_matches_uncheckpointed_forward():
     assert base_grads, "expected non-empty gradients"
     for name in base_grads:
         torch.testing.assert_close(ckpt_grads[name], base_grads[name], rtol=1e-3, atol=1e-4)
+
+
+def test_peagle_flex_attention_compiles_with_dynamic_shapes(monkeypatch):
+    """The module-level flex_attention compile must request dynamic shapes.
+
+    COD subsampling gives every rank/batch a different flat sequence length, so
+    a static-by-default first compile re-specializes (a full max-autotune pass)
+    per new length and never matches a shared Inductor cache across processes.
+    Reloading under a mocked ``torch.compile`` is the only way to observe the
+    kwargs of an import-time compile.
+    """
+    import importlib
+
+    import nemo_automodel.components.speculative.eagle.peagle_draft as peagle_draft
+
+    captured = {}
+
+    def compile_fn(fn, **kwargs):
+        captured["fn"] = fn
+        captured["kwargs"] = kwargs
+        return fn
+
+    monkeypatch.setattr(torch, "compile", compile_fn)
+    try:
+        importlib.reload(peagle_draft)
+        assert captured["fn"] is peagle_draft.flex_attention
+        assert captured["kwargs"] == {"mode": "max-autotune-no-cudagraphs", "dynamic": True}
+    finally:
+        # Re-execute the module under the real torch.compile so later tests see
+        # the production lazy-compiled callable, not the mocked passthrough.
+        monkeypatch.undo()
+        importlib.reload(peagle_draft)


### PR DESCRIPTION
## What does this PR do?

DFlash and P-EAGLE both `torch.compile` flex-attention callables whose shapes are data dependent, and both compiled static. This PR adds `dynamic=True` at both sites.

### Problem

* `dflash_mask.py` compiled `create_block_mask` with `dynamic=False`, but the mask shape follows the per-batch anchor count (`min(num_anchors, valid anchors in the batch)`). Every batch carrying a new anchor count forced a full re-specialization: a multi-second stall in the middle of training.
* `peagle_draft.py` compiled `flex_attention` (max-autotune) without `dynamic`, but COD subsampling gives every rank and batch a unique flat sequence length. Each fresh process paid a full max-autotune pass (minutes) for its first shape and never matched a shared Inductor cache (`TORCHINDUCTOR_CACHE_DIR`). On a 4-node run this desynced startup badly enough that ranks sat in the first collective until the NCCL watchdog fired.

Both observed on real Qwen3-8B training runs (single-node DFlash, 4-node P-EAGLE).

### Fix

`dynamic=True` at both call sites: one shape-generic kernel that every batch, rank, and cache-sharing process reuses. This matches the existing convention for function-level compiles with variable shapes (`chunked_ce.py` compiles `compute_cross_entropy` with `dynamic=True`).

The generic FlexAttention path (`components/attention/flex_attention.py`) is intentionally left static: regular recipes pad to a fixed sequence length, where static specialization is preferable and PyTorch's automatic dynamic fallback covers occasional shape changes.

### Tests

* `test_compiled_create_block_mask_is_cached` updated to pin `dynamic=True`.
* New `test_peagle_flex_attention_compiles_with_dynamic_shapes` reloads `peagle_draft` under a mocked `torch.compile` and pins the kwargs of the import-time compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)