### PR TITLE
fix(checkpoint): map BOOL in the safetensors backport DTYPE_MAP

### DIFF
--- a/nemo_automodel/components/checkpoint/_backports/hf_utils.py
+++ b/nemo_automodel/components/checkpoint/_backports/hf_utils.py
@@ -52,6 +52,9 @@ DTYPE_MAP = {
     "F8_E4M3": torch.float8_e4m3fn,
     "F8_E5M2": torch.float8_e5m2,
     "F8_E8M0": torch.float8_e8m0fnu,
+    # Standard safetensors dtype; without it, bool buffers (e.g. EAGLE-3's
+    # draft-vocab masks) crash the safetensors checkpoint save.
+    "BOOL": torch.bool,
 }
 
 HF_DCP_VERSION: float = 1.0

--- a/tests/unit_tests/checkpoint/_backports/test_hf_utils_dtypes.py
+++ b/tests/unit_tests/checkpoint/_backports/test_hf_utils_dtypes.py
@@ -12,12 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for ``_backports/hf_utils.DTYPE_MAP`` FP8-scale extensions.
+"""Tests for ``_backports/hf_utils.DTYPE_MAP`` extensions.
 
 DeepSeek V4 (and other quantized HF checkpoints) emit FP8-scale tensors with
 dtype tags ``F8_E5M2`` and ``F8_E8M0`` that the upstream
 ``safetensors.torch._TYPES`` map does not yet recognize.  The in-tree backport
 extends ``DTYPE_MAP`` so the in-tree HF storage reader can decode them.
+
+``BOOL`` is a standard safetensors dtype but was missing from the map, so
+saving a state dict with a bool buffer (e.g. the EAGLE-3 draft-vocab
+``selected_token_mask``) in safetensors format crashed the final checkpoint
+save of a finished training run.
 """
 
 import pytest
@@ -32,10 +37,11 @@ from nemo_automodel.components.checkpoint._backports.hf_utils import DTYPE_MAP
         ("F8_E4M3", torch.float8_e4m3fn),
         ("F8_E5M2", torch.float8_e5m2),
         ("F8_E8M0", torch.float8_e8m0fnu),
+        ("BOOL", torch.bool),
     ],
 )
-def test_dtype_map_contains_fp8_dtypes(key, expected_dtype):
-    """All three FP8 variants emitted by DSV4-style checkpoints must be mapped."""
+def test_dtype_map_contains_extended_dtypes(key, expected_dtype):
+    """FP8 variants (DSV4-style checkpoints) and BOOL (bool buffers) must be mapped."""
     assert key in DTYPE_MAP, f"{key} missing from DTYPE_MAP"
     assert DTYPE_MAP[key] is expected_dtype
 
@@ -55,3 +61,10 @@ def test_dtype_map_preserves_existing_entries():
     }
     for key, dtype in expected.items():
         assert DTYPE_MAP.get(key) is dtype, f"DTYPE_MAP[{key!r}] regressed"
+
+
+def test_write_path_maps_torch_bool():
+    """Pin the crash site: the safetensors writer's dtype-str lookup."""
+    from nemo_automodel.components.checkpoint._backports.filesystem import _to_safetensors_dtype_str
+
+    assert _to_safetensors_dtype_str(torch.bool) == "BOOL"


### PR DESCRIPTION
## What does this PR do?

Adds `"BOOL": torch.bool` to the in-tree safetensors backport's `DTYPE_MAP` (`_backports/hf_utils.py`).

### Problem

BOOL is a standard safetensors dtype (`safetensors.torch._TYPES` maps it to `torch.bool`), but the backport's hand-maintained `DTYPE_MAP` did not carry it. Any state dict containing a bool tensor therefore could not be saved in safetensors format:

```
File "nemo_automodel/components/checkpoint/_backports/filesystem.py", line 135, in _to_safetensors_dtype_str
ValueError: Unsupported dtype for safetensors serialization: torch.bool
```

EAGLE-3 hits this in practice: with a compressed draft vocab the trainer registers persistent bool buffers (`selected_token_mask`, `t2d`), so a Qwen3-8B EAGLE-3 run with `model_save_format: safetensors` trained to completion and then crashed at the final checkpoint save, losing the export.

### Fix

One map entry. The write path (`_to_safetensors_dtype_str`), the read path (`_get_dtype`), and the consolidation reverse map all derive from `DTYPE_MAP`, so the single entry covers save, load, and consolidation.

Note for maintainers: the map is still missing the (rarer) standard dtypes `U16`/`U32`/`U64`. This PR intentionally adds only the dtype hit by real training, keeping the backport close to its upstream source (pytorch/pytorch#155707); deriving the map from `safetensors.torch._TYPES` would close the gap for good but couples the backport to a private safetensors API.

### Tests

* `BOOL` added to the extended-dtypes parametrization in `test_hf_utils_dtypes.py`.
* New `test_write_path_maps_torch_bool` pins `_to_safetensors_dtype_str(torch.bool) == "BOOL"`, the exact call site that raised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)