### PR TITLE
docs(dllm): use absolute image URLs in the DiffusionGemma guide

### DIFF
--- a/docs/guides/dllm/diffusiongemma.mdx
+++ b/docs/guides/dllm/diffusiongemma.mdx
@@ -1,7 +1,5 @@
----
-title: "Fine-Tuning DiffusionGemma with NeMo AutoModel"
-description: ""
----
+# Fine-Tuning DiffusionGemma with NeMo AutoModel
+
 ## Introduction
 
 **DiffusionGemma** is a block-diffusion language model. Unlike an autoregressive (AR)
@@ -90,11 +88,15 @@ The SFT and LoRA training curves on GSM8K (first 200 steps) are shown below.
 
 **SFT**
 
-![DiffusionGemma SFT training curves](./diffusiongemma_sft.png)
+<p align="center">
+  <img src="https://raw.githubusercontent.com/NVIDIA-NeMo/Automodel/main/docs/guides/dllm/diffusiongemma_sft.png" alt="DiffusionGemma SFT training curves" width="900">
+</p>
 
 **LoRA**
 
-![DiffusionGemma LoRA training curves](./diffusiongemma_lora.png)
+<p align="center">
+  <img src="https://raw.githubusercontent.com/NVIDIA-NeMo/Automodel/main/docs/guides/dllm/diffusiongemma_lora.png" alt="DiffusionGemma LoRA training curves" width="900">
+</p>
 
 
 ## Requirements


### PR DESCRIPTION
Relative ./diffusiongemma_*.png paths don't render on the published docs site / build.nvidia.com; switch to the raw.githubusercontent.com/.../main URLs used by the other guides (the PNGs are already on main).

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
