### PR TITLE
fix(retrieval): gate dummy vision forward

### DIFF
--- a/nemo_automodel/_transformers/retrieval.py
+++ b/nemo_automodel/_transformers/retrieval.py
@@ -422,11 +422,16 @@ class BiEncoderModel(nn.Module):
         if not input_dict:
             return None
 
-        if "token_type_ids" not in inspect.getfullargspec(self.model.forward).args and "token_type_ids" in input_dict:
+        forward_args = inspect.getfullargspec(self.model.forward).args
+        if "token_type_ids" not in forward_args and "token_type_ids" in input_dict:
             input_dict = {k: v for k, v in input_dict.items() if k != "token_type_ids"}
 
+        model_inputs = {k: v for k, v in input_dict.items() if k not in ["kd_labels", "run_dummy_vision"]}
+        if "run_dummy_vision" in forward_args and "run_dummy_vision" in input_dict:
+            model_inputs["run_dummy_vision"] = input_dict["run_dummy_vision"]
+
         outputs = self.model(
-            **{k: v for k, v in input_dict.items() if k not in ["kd_labels"]},
+            **model_inputs,
             return_dict=True,
             output_hidden_states=True,
         )

--- a/nemo_automodel/components/models/llama_nemotron_vl/model.py
+++ b/nemo_automodel/components/models/llama_nemotron_vl/model.py
@@ -515,6 +515,7 @@ class LlamaNemotronVLModel(PreTrainedModel):
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         num_patches_list: Optional[List[torch.Tensor]] = None,
+        run_dummy_vision: Optional[bool] = None,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
@@ -550,7 +551,7 @@ class LlamaNemotronVLModel(PreTrainedModel):
 
             input_embeds = input_embeds.reshape(B, N, C)
 
-        elif self.training:
+        elif self.training and run_dummy_vision is not False:
             # If there is no image in the batch, adds a dummy image to the batch
             # to ensure multi-GPU synchronization when there are batches with only text samples and others with image samples
             image_size = self.config.force_image_size or self.config.vision_config.image_size

--- a/nemo_automodel/components/models/llama_nemotron_vl/model.py
+++ b/nemo_automodel/components/models/llama_nemotron_vl/model.py
@@ -219,6 +219,44 @@ def pool(last_hidden_states: torch.Tensor, attention_mask: torch.Tensor, pool_ty
     return emb
 
 
+def _replace_image_token_embeddings(
+    input_embeds: torch.Tensor,
+    input_ids: torch.Tensor,
+    vit_embeds: torch.Tensor,
+    img_context_token_id: int,
+) -> torch.Tensor:
+    """Replace image placeholder token embeddings with vision embeddings."""
+    batch_size, seq_len, hidden_size = input_embeds.shape
+    flat_embeds = input_embeds.reshape(batch_size * seq_len, hidden_size)
+    flat_input_ids = input_ids.reshape(batch_size * seq_len)
+    selected_indices = (flat_input_ids == img_context_token_id).nonzero(as_tuple=False).squeeze(1)
+    vit_embeds = vit_embeds.reshape(-1, hidden_size).to(dtype=flat_embeds.dtype)
+
+    n_token = selected_indices.numel()
+    if n_token != vit_embeds.shape[0]:
+        logger.warning(
+            "image token count mismatch: selected=%s, vit_embeds=%s; truncating vision embeddings",
+            n_token,
+            vit_embeds.shape,
+        )
+        vit_embeds = vit_embeds[:n_token]
+
+    flat_embeds = flat_embeds.index_copy(0, selected_indices, vit_embeds)
+    return flat_embeds.reshape(batch_size, seq_len, hidden_size)
+
+
+def _filter_vision_embeddings_by_image_flags(
+    vit_embeds: torch.Tensor,
+    image_flags: Optional[torch.Tensor],
+) -> torch.Tensor:
+    """Keep only vision embeddings marked as real images."""
+    if image_flags is None or isinstance(image_flags, list):
+        return vit_embeds
+
+    image_flags = image_flags.squeeze(-1)
+    return vit_embeds[image_flags == 1]
+
+
 # ============================================================================
 # Bidirectional LLaMA Model
 # ============================================================================
@@ -524,32 +562,15 @@ class LlamaNemotronVLModel(PreTrainedModel):
 
         # Process and inject vision embeddings if present
         if pixel_values is not None:
-            if image_flags is None:
-                image_flags = torch.ones(pixel_values.shape[0])
-            image_flags = image_flags.squeeze(-1)
             vit_embeds = self.extract_feature(pixel_values).to(device=input_embeds.device)
+            vit_embeds = _filter_vision_embeddings_by_image_flags(vit_embeds, image_flags)
 
-            if not isinstance(image_flags, list):
-                image_flags = image_flags.squeeze(-1)
-                vit_embeds = vit_embeds[image_flags == 1]
-
-            # Inject vision tokens into text embeddings
-            B, N, C = input_embeds.shape
-            input_embeds = input_embeds.reshape(B * N, C)
-            input_ids = input_ids.reshape(B * N)
-            selected = (input_ids == self.config.img_context_token_id).to(input_embeds.device)
-            try:
-                input_embeds[selected] = input_embeds[selected] * 0.0 + vit_embeds.reshape(-1, C)
-            except Exception as e:
-                vit_embeds = vit_embeds.reshape(-1, C)
-                print(
-                    f"warning: {e}, input_embeds[selected].shape={input_embeds[selected].shape}, "
-                    f"vit_embeds.shape={vit_embeds.shape}"
-                )
-                n_token = selected.sum()
-                input_embeds[selected] = input_embeds[selected] * 0.0 + vit_embeds[:n_token]
-
-            input_embeds = input_embeds.reshape(B, N, C)
+            input_embeds = _replace_image_token_embeddings(
+                input_embeds,
+                input_ids,
+                vit_embeds,
+                self.config.img_context_token_id,
+            )
 
         elif self.training and run_dummy_vision is not False:
             # If there is no image in the batch, adds a dummy image to the batch

--- a/nemo_automodel/recipes/retrieval/train_bi_encoder.py
+++ b/nemo_automodel/recipes/retrieval/train_bi_encoder.py
@@ -418,6 +418,11 @@ class TrainBiEncoderRecipe(BaseRecipe):
         )
 
         with train_ctx, sync_ctx:
+            if is_train:
+                if query is not None:
+                    query["run_dummy_vision"] = False
+                if passage is not None:
+                    passage["run_dummy_vision"] = True
             q_reps = model(query)
             p_reps = model(passage)
 

--- a/tests/unit_tests/models/bi_encoder/test_bi_encoder_model.py
+++ b/tests/unit_tests/models/bi_encoder/test_bi_encoder_model.py
@@ -45,9 +45,50 @@ class _ToyMultiVectorBiEncoder(torch.nn.Module):
     def __init__(self):
         super().__init__()
         self.scale = torch.nn.Parameter(torch.tensor(1.0))
+        self.run_dummy_vision_flags = []
 
     def forward(self, batch):
+        self.run_dummy_vision_flags.append(batch.get("run_dummy_vision"))
         return batch["input_ids"].float() * self.scale
+
+
+class _ToyBackboneOutput:
+    def __init__(self, hidden_state):
+        self.last_hidden_state = hidden_state
+
+
+class _ToyBackboneWithDummyFlag(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.config = SimpleNamespace(name_or_path="")
+        self.run_dummy_vision = None
+
+    def forward(
+        self,
+        input_ids,
+        attention_mask,
+        return_dict=True,
+        output_hidden_states=True,
+        run_dummy_vision=None,
+    ):
+        self.run_dummy_vision = run_dummy_vision
+        hidden_state = input_ids.float().unsqueeze(-1).expand(*input_ids.shape, 2)
+        return _ToyBackboneOutput(hidden_state)
+
+
+class _ToyBackboneWithoutDummyFlag(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.config = SimpleNamespace(name_or_path="")
+        self.received_kwargs = None
+
+    def forward(self, input_ids, attention_mask, return_dict=True, output_hidden_states=True):
+        self.received_kwargs = {
+            "return_dict": return_dict,
+            "output_hidden_states": output_hidden_states,
+        }
+        hidden_state = input_ids.float().unsqueeze(-1).expand(*input_ids.shape, 2)
+        return _ToyBackboneOutput(hidden_state)
 
 
 def _apply_common_mocks(monkeypatch):
@@ -211,6 +252,38 @@ def test_cross_encoder_retries_without_sdpa(monkeypatch):
     _assert_retries_without_sdpa(monkeypatch, CrossEncoderModel, am.NeMoAutoModelCrossEncoder)
 
 
+def test_bi_encoder_forwards_run_dummy_vision_when_backbone_supports_it():
+    backbone = _ToyBackboneWithDummyFlag()
+    model = BiEncoderModel(backbone, pooling="avg", l2_normalize=False)
+
+    embeddings = model(
+        {
+            "input_ids": torch.tensor([[1, 2]]),
+            "attention_mask": torch.tensor([[1, 1]]),
+            "run_dummy_vision": False,
+        }
+    )
+
+    assert backbone.run_dummy_vision is False
+    assert embeddings.shape == (1, 2)
+
+
+def test_bi_encoder_drops_run_dummy_vision_when_backbone_does_not_support_it():
+    backbone = _ToyBackboneWithoutDummyFlag()
+    model = BiEncoderModel(backbone, pooling="avg", l2_normalize=False)
+
+    embeddings = model(
+        {
+            "input_ids": torch.tensor([[1, 2]]),
+            "attention_mask": torch.tensor([[1, 1]]),
+            "run_dummy_vision": True,
+        }
+    )
+
+    assert backbone.received_kwargs == {"return_dict": True, "output_hidden_states": True}
+    assert embeddings.shape == (1, 2)
+
+
 def test_maxsim_scores_and_labels_masks_padding_before_maxsim():
     query = torch.tensor(
         [
@@ -320,6 +393,32 @@ def test_forward_backward_step_supports_local_multi_vector_pooling():
     assert len(loss_buffer) == 1
     assert torch.isfinite(loss_buffer[0])
     assert recipe.model_parts[0].scale.grad is not None
+
+
+def test_forward_backward_step_disables_query_dummy_vision_but_keeps_passage_dummy_vision():
+    recipe = TrainBiEncoderRecipe.__new__(TrainBiEncoderRecipe)
+    recipe.dist_env = SimpleNamespace(device="cpu")
+    recipe.distributed_config = SimpleNamespace(defer_fsdp_grad_sync=True)
+    model = _ToyMultiVectorBiEncoder()
+    recipe.model_parts = [model]
+    recipe.temperature = 1.0
+    recipe.train_n_passages = 2
+
+    batch = {
+        "q_input_ids": torch.tensor([[[1.0, 0.0], [0.0, 1.0]]]),
+        "q_attention_mask": torch.tensor([[1, 1]]),
+        "d_input_ids": torch.tensor(
+            [
+                [[1.0, 0.0], [0.0, 1.0]],
+                [[0.0, 1.0], [0.0, 0.0]],
+            ]
+        ),
+        "d_attention_mask": torch.tensor([[1, 1], [1, 0]]),
+    }
+
+    recipe._forward_backward_step(0, batch, loss_buffer=[], num_batches=1, is_train=True)
+
+    assert model.run_dummy_vision_flags == [False, True]
 
 
 def test_validation_epoch_supports_multi_vector_pooling():

--- a/tests/unit_tests/models/llama_nemotron_vl/test_image_embedding_insert.py
+++ b/tests/unit_tests/models/llama_nemotron_vl/test_image_embedding_insert.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+from pathlib import Path
+
+import torch
+
+_MODEL_PATH = (
+    Path(__file__).resolve().parents[4] / "nemo_automodel/components/models/llama_nemotron_vl/model.py"
+)
+_MODEL_SPEC = importlib.util.spec_from_file_location("_llama_nemotron_vl_model_for_test", _MODEL_PATH)
+_MODEL_MODULE = importlib.util.module_from_spec(_MODEL_SPEC)
+assert _MODEL_SPEC.loader is not None
+_MODEL_SPEC.loader.exec_module(_MODEL_MODULE)
+
+_filter_vision_embeddings_by_image_flags = _MODEL_MODULE._filter_vision_embeddings_by_image_flags
+_replace_image_token_embeddings = _MODEL_MODULE._replace_image_token_embeddings
+
+IMG_TOKEN_ID = 128258
+
+
+def _old_boolean_index_replace(
+    input_embeds: torch.Tensor,
+    input_ids: torch.Tensor,
+    vit_embeds: torch.Tensor,
+) -> torch.Tensor:
+    batch_size, seq_len, hidden_size = input_embeds.shape
+    flat_embeds = input_embeds.reshape(batch_size * seq_len, hidden_size)
+    flat_input_ids = input_ids.reshape(batch_size * seq_len)
+    selected = flat_input_ids == IMG_TOKEN_ID
+    flat_embeds = flat_embeds.clone()
+    flat_embeds[selected] = flat_embeds[selected] * 0.0 + vit_embeds.reshape(-1, hidden_size)
+    return flat_embeds.reshape(batch_size, seq_len, hidden_size)
+
+
+def test_replace_image_token_embeddings_matches_boolean_index_outputs_and_grads():
+    input_ids = torch.tensor(
+        [
+            [1, IMG_TOKEN_ID, IMG_TOKEN_ID, 2, 3],
+            [4, 5, IMG_TOKEN_ID, IMG_TOKEN_ID, 6],
+        ],
+        dtype=torch.long,
+    )
+    input_embeds = torch.randn(2, 5, 4, requires_grad=True)
+    vit_embeds = torch.randn(4, 4, requires_grad=True)
+
+    old_input = input_embeds.detach().clone().requires_grad_(True)
+    old_vit = vit_embeds.detach().clone().requires_grad_(True)
+    old_out = _old_boolean_index_replace(old_input, input_ids, old_vit)
+    old_out.square().sum().backward()
+
+    new_input = input_embeds.detach().clone().requires_grad_(True)
+    new_vit = vit_embeds.detach().clone().requires_grad_(True)
+    new_out = _replace_image_token_embeddings(new_input, input_ids, new_vit, IMG_TOKEN_ID)
+    new_out.square().sum().backward()
+
+    torch.testing.assert_close(new_out, old_out)
+    torch.testing.assert_close(new_input.grad, old_input.grad)
+    torch.testing.assert_close(new_vit.grad, old_vit.grad)
+
+
+def test_filter_vision_embeddings_skips_filter_when_image_flags_absent():
+    vit_embeds = torch.randn(3, 2, 4)
+
+    filtered = _filter_vision_embeddings_by_image_flags(vit_embeds, None)
+
+    assert filtered is vit_embeds
+
+
+def test_filter_vision_embeddings_keeps_flagged_rows():
+    vit_embeds = torch.arange(4 * 2 * 3, dtype=torch.float32).reshape(4, 2, 3)
+    image_flags = torch.tensor([[1], [0], [1], [0]], dtype=torch.long)
+
+    filtered = _filter_vision_embeddings_by_image_flags(vit_embeds, image_flags)
+
+    torch.testing.assert_close(filtered, vit_embeds[[0, 2]])


### PR DESCRIPTION
# What does this PR do ?

Gate the Nemotron VL dummy vision forward path so retrieval training only runs it where it is needed for FSDP-style synchronization.

# Changelog

- Add an optional `run_dummy_vision` argument to `LlamaNemotronVLModel.forward()` while preserving the existing default behavior.
- Thread `run_dummy_vision` through `BiEncoderModel.encode()` only when the wrapped backbone supports that argument.
- Set `run_dummy_vision: false` for query forwards in the bi-encoder trainer.
- Set `run_dummy_vision: true` for passage forwards only under FSDP2 or Megatron FSDP, where rank-aligned module entry can be required.
- Add CPU unit coverage for wrapper argument forwarding/filtering and strategy-specific trainer routing.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If any of the above items are unfinished, this PR can remain as Draft.

# Additional Information

Validation:

- `uv run ruff format nemo_automodel/_transformers/retrieval.py nemo_automodel/components/models/llama_nemotron_vl/model.py nemo_automodel/recipes/retrieval/train_bi_encoder.py tests/unit_tests/models/bi_encoder/test_bi_encoder_model.py`
- `uv run ruff check nemo_automodel/_transformers/retrieval.py nemo_automodel/components/models/llama_nemotron_vl/model.py nemo_automodel/recipes/retrieval/train_bi_encoder.py tests/unit_tests/models/bi_encoder/test_bi_encoder_model.py`
- `srun -A coreai_dlalgo_genai ... uv run --extra vlm pytest tests/unit_tests/models/bi_encoder/test_bi_encoder_model.py -q` (`18 passed`)

- Related to # (issue)

## Latest Update (2026-06-13)

- Optimized Nemotron VL image-token embedding insertion by replacing boolean indexed assignment with `index_copy`.
- Added CPU unit coverage for output/gradient parity with the previous insertion path and image-flag filtering.

Additional validation:

- `uv run pytest tests/unit_tests/models/llama_nemotron_vl/test_image_embedding_insert.py -q` (`3 passed`)
- `uv run ruff check nemo_automodel/components/models/llama_nemotron_vl/model.py tests/unit_tests/models/llama_nemotron_vl/test_image_embedding_insert.py`