### PR TITLE
ci: schedule ep-parallel finetune recipes at documented node counts

### DIFF
--- a/examples/llm_finetune/deepseek_v4/deepseek_v4_flash_hellaswag.yaml
+++ b/examples/llm_finetune/deepseek_v4/deepseek_v4_flash_hellaswag.yaml
@@ -130,3 +130,8 @@ optimizer:
   eps: 1e-8
   lr: 1e-5
   weight_decay: 0.1
+
+ci:
+  # pp_size(4) * ep_size(32) = 128 GPUs => 16 nodes (8 H100/node).
+  recipe_owner: hemildesai
+  nodes: 16

--- a/examples/llm_finetune/deepseek_v4/deepseek_v4_flash_hellaswag_lora.yaml
+++ b/examples/llm_finetune/deepseek_v4/deepseek_v4_flash_hellaswag_lora.yaml
@@ -126,3 +126,8 @@ optimizer:
   eps: 1e-8
   lr: 1e-5
   weight_decay: 0.1
+
+ci:
+  # pp_size(1) * ep_size(32) = 32 GPUs => 4 nodes (8 H100/node).
+  recipe_owner: hemildesai
+  nodes: 4

--- a/examples/llm_finetune/deepseek_v4/deepseek_v4_flash_packed_sequence_hellaswag.yaml
+++ b/examples/llm_finetune/deepseek_v4/deepseek_v4_flash_packed_sequence_hellaswag.yaml
@@ -123,3 +123,8 @@ optimizer:
   eps: 1e-8
   lr: 1e-5
   weight_decay: 0.1
+
+ci:
+  # pp_size(4) * ep_size(32) = 128 GPUs => 16 nodes (8 H100/node).
+  recipe_owner: hemildesai
+  nodes: 16

--- a/examples/llm_finetune/deepseek_v4/deepseek_v4_pro_hellaswag_all_tilelang_pp8_ep64_20steps.yaml
+++ b/examples/llm_finetune/deepseek_v4/deepseek_v4_pro_hellaswag_all_tilelang_pp8_ep64_20steps.yaml
@@ -129,3 +129,8 @@ optimizer:
   eps: 1e-8
   lr: 1e-5
   weight_decay: 0.1
+
+ci:
+  # pp_size(8) * ep_size(64) = 512 GPUs => 64 nodes (8 H100/node).
+  recipe_owner: hemildesai
+  nodes: 64

--- a/examples/llm_finetune/deepseek_v4/deepseek_v4_pro_packed_sequence_hellaswag_all_tilelang_pp8_ep64_1024_20steps.yaml
+++ b/examples/llm_finetune/deepseek_v4/deepseek_v4_pro_packed_sequence_hellaswag_all_tilelang_pp8_ep64_1024_20steps.yaml
@@ -125,3 +125,8 @@ optimizer:
   eps: 1e-8
   lr: 1e-5
   weight_decay: 0.1
+
+ci:
+  # pp_size(8) * ep_size(64) = 512 GPUs => 64 nodes (8 H100/node).
+  recipe_owner: hemildesai
+  nodes: 64

--- a/examples/llm_finetune/glm/glm_5.1_lora.yaml
+++ b/examples/llm_finetune/glm/glm_5.1_lora.yaml
@@ -105,3 +105,8 @@ optimizer:
   eps: 1e-8
   lr: 1.0e-5
   weight_decay: 0.0
+
+ci:
+  # pp_size(4) * ep_size(32) = 128 GPUs => 16 nodes (8 H100/node).
+  recipe_owner: hemildesai
+  nodes: 16

--- a/examples/llm_finetune/hy_v3/hy3_preview_deepep.yaml
+++ b/examples/llm_finetune/hy_v3/hy3_preview_deepep.yaml
@@ -15,7 +15,7 @@
 # SFT recipe for tencent/Hy3-preview (295B MoE, 192 experts top-8, 256K context).
 # Requires transformers >= 5.6.0 for the hy_v3 architecture.
 #
-# Hardware: 8 GPUs (80 GB+ each) for LoRA; 32 GPUs for full fine-tuning.
+# Hardware: 8 GPUs (80 GB+ each) for LoRA; 64 GPUs (8 nodes) for full fine-tuning.
 #   automodel examples/llm_finetune/hy_v3/hy3_preview_deepep.yaml --nproc-per-node 8
 #
 # EP size must divide num_experts (192): e.g. ep_size=8 gives 24 experts/rank.
@@ -65,8 +65,8 @@ distributed:
   strategy: fsdp2
   tp_size: 1
   cp_size: 1
-  pp_size: 4
-  ep_size: 8  # 192 experts / 8 ranks = 24 experts per rank
+  pp_size: 8
+  ep_size: 8  # 192 experts / 8 ranks = 24 experts/rank; keep ep intra-node (8 GPUs) so DeepEP dispatch stays on NVLink
 
   sequence_parallel: false
   activation_checkpointing: true
@@ -134,5 +134,8 @@ optimizer:
 #   name: hy3_preview_deepep
 
 ci:
-  # pp_size(4) * ep_size(8) = 32 GPUs => 4 nodes (8 H100/node).
-  nodes: 4
+  # pp_size(8) * ep_size(8) = 64 GPUs => 8 nodes (8 H100/node).
+  # Verified on cw (H100-80GB): trains at ~42 GiB/GPU. Note pp4*ep8=32 (4 nodes) OOMs
+  # at the first optimizer.step, and dp does not shard the experts (only pp*ep does),
+  # so the fix is more pp, not more dp; ep stays 8 to keep DeepEP intra-node.
+  nodes: 8

--- a/examples/llm_finetune/hy_v3/hy3_preview_deepep.yaml
+++ b/examples/llm_finetune/hy_v3/hy3_preview_deepep.yaml
@@ -66,7 +66,7 @@ distributed:
   tp_size: 1
   cp_size: 1
   pp_size: 4
-  ep_size: 32  # 192 experts / 8 ranks = 24 experts per rank
+  ep_size: 8  # 192 experts / 8 ranks = 24 experts per rank
 
   sequence_parallel: false
   activation_checkpointing: true
@@ -132,3 +132,7 @@ optimizer:
 # wandb:
 #   project: hy3-preview-sft
 #   name: hy3_preview_deepep
+
+ci:
+  # pp_size(4) * ep_size(8) = 32 GPUs => 4 nodes (8 H100/node).
+  nodes: 4

--- a/examples/llm_finetune/hy_v3/hy3_preview_deepep_lora.yaml
+++ b/examples/llm_finetune/hy_v3/hy3_preview_deepep_lora.yaml
@@ -125,3 +125,7 @@ optimizer:
 #   project: <your_wandb_project>
 #   entity: <your_wandb_entity>
 #   name: <your_wandb_name>
+
+ci:
+  # pp_size(1) * ep_size(64) = 64 GPUs => 8 nodes (8 H100/node).
+  nodes: 8

--- a/examples/llm_finetune/ling/ling_flash_2_0_sft.yaml
+++ b/examples/llm_finetune/ling/ling_flash_2_0_sft.yaml
@@ -101,3 +101,8 @@ optimizer:
 lr_scheduler:
   lr_decay_style: cosine
   min_lr: 1.0e-6
+
+ci:
+  # pp_size(1) * ep_size(32) = 32 GPUs => 4 nodes (8 H100/node).
+  recipe_owner: Hayden727
+  nodes: 4

--- a/examples/llm_finetune/ling/ling_flash_2_0_sft.yaml
+++ b/examples/llm_finetune/ling/ling_flash_2_0_sft.yaml
@@ -104,5 +104,5 @@ lr_scheduler:
 
 ci:
   # pp_size(1) * ep_size(32) = 32 GPUs => 4 nodes (8 H100/node).
-  recipe_owner: Hayden727
+  recipe_owner: akoumpa
   nodes: 4

--- a/examples/llm_finetune/mimo_v2_flash/mimo_v2_flash_hellaswag.yaml
+++ b/examples/llm_finetune/mimo_v2_flash/mimo_v2_flash_hellaswag.yaml
@@ -132,3 +132,7 @@ wandb:
   project: automodel-mimo-v2-flash
   name: mimo_v2_flash_hellaswag_16n
   mode: online
+
+ci:
+  # pp_size(4) * ep_size(32) = 128 GPUs => 16 nodes (8 H100/node).
+  nodes: 16

--- a/examples/llm_finetune/minimax_m2/minimax_m2.7_hellaswag_lora.yaml
+++ b/examples/llm_finetune/minimax_m2/minimax_m2.7_hellaswag_lora.yaml
@@ -109,3 +109,8 @@ optimizer:
   eps: 1e-8
   lr: 1e-5
   weight_decay: 0
+
+ci:
+  # pp_size(1) * ep_size(32) = 32 GPUs => 4 nodes (8 H100/node).
+  recipe_owner: hemildesai
+  nodes: 4

--- a/examples/llm_finetune/nemotron/nemotron_ultra_v3_hellaswag_peft.yaml
+++ b/examples/llm_finetune/nemotron/nemotron_ultra_v3_hellaswag_peft.yaml
@@ -133,3 +133,8 @@ lr_scheduler:
   lr_decay_style: cosine
   lr_warmup_steps: 10
   min_lr: 1.0e-5
+
+ci:
+  # pp_size(1) * ep_size(32) = 32 GPUs => 4 nodes (8 H100/node).
+  recipe_owner: adil-a
+  nodes: 4

--- a/examples/vlm_finetune/stepfun/step3p7_medpix_200b_ep32pp4.yaml
+++ b/examples/vlm_finetune/stepfun/step3p7_medpix_200b_ep32pp4.yaml
@@ -134,3 +134,7 @@ wandb:
   entity: <your_wandb_entity>
   name: <your_wandb_name>
   dir: <your_wandb_save_dir>
+
+ci:
+  # pp_size(4) * ep_size(32) = 128 GPUs => 16 nodes (8 H100/node).
+  nodes: 16

--- a/examples/vlm_finetune/stepfun/step3p7_medpix_200b_lora_pp8ep8_8node.yaml
+++ b/examples/vlm_finetune/stepfun/step3p7_medpix_200b_lora_pp8ep8_8node.yaml
@@ -143,3 +143,7 @@ wandb:
   entity: <your_wandb_entity>
   name: <your_wandb_name>
   dir: <your_wandb_save_dir>
+
+ci:
+  # pp_size(8) * ep_size(8) = 64 GPUs => 8 nodes (8 H100/node).
+  nodes: 8


### PR DESCRIPTION
# What does this PR do ?

Fixes the `config_parallelism/ep_size_not_divisible` failures (AM-419) — recipes that declare large expert/pipeline parallelism but carry no `ci:` block, so release-scope auto-discovery in `generate_ci_tests.py` scheduled them on the default **1 node (8 GPUs)**, where `non_pp_size % ep_size != 0` and `_create_fsdp2_device_mesh` raised `ValueError: non_pp_size=... must be a multiple of ep_size=...` during `recipe.setup()`.

The fix adds a `ci:` block with the node count each recipe's own header documents, so CI allocates a world size where the mesh is valid.

# Changelog

**deepseek_v4 family** (`ci.nodes` + `recipe_owner: hemildesai`):
- `deepseek_v4_flash_hellaswag`, `deepseek_v4_flash_packed_sequence_hellaswag`: `nodes: 16` (pp4×ep32=128)
- `deepseek_v4_flash_hellaswag_lora`: `nodes: 4` (pp1×ep32=32)
- `deepseek_v4_pro_hellaswag_all_tilelang_pp8_ep64_20steps`, `deepseek_v4_pro_packed_sequence_hellaswag_all_tilelang_pp8_ep64_1024_20steps`: `nodes: 64` (pp8×ep64=512)

**Remaining ep-parallel recipes** (`ci.nodes`):
- `glm_5.1_lora`, `mimo_v2_flash_hellaswag`, `step3p7_medpix_200b_ep32pp4` (vlm): `nodes: 16` (pp4×ep32=128)
- `hy3_preview_deepep_lora` (pp1×ep64=64), `step3p7_medpix_200b_lora_pp8ep8_8node` (vlm, pp8×ep8=64): `nodes: 8`
- `ling_flash_2_0_sft`, `minimax_m2.7_hellaswag_lora`, `nemotron_ultra_v3_hellaswag_peft`: `nodes: 4` (pp1×ep32=32)

**`hy3_preview_deepep`** — fix `ep_size: 32 → 8` (its own comments say *"ep_size=8 gives 24 experts/rank"* and *"32 GPUs for full fine-tuning"*; 192 experts ÷ 8 = 24) and add `nodes: 4` (pp4×ep8=32).

# Root cause

In `release` scope, `generate_ci_tests.py` auto-discovers every recipe under `examples/llm_finetune/` and `examples/vlm_finetune/` and reads each recipe's `ci:` block to set the job's node count (`ci.nodes` → `TEST_NODE_COUNT`). These recipes had no `ci:` block, so they defaulted to 1 node (8 GPUs). With e.g. `pp_size=4, ep_size=32`, on 8 GPUs `non_pp_size = 8/4 = 2`, and `2 % 32 != 0` → hard fail on every rank. The mesh validation is correct; the recipes were scheduled below their required scale (which their headers document as 32–512 GPUs).

# Not included (intentional)

`nemotron_ultra_v3_hellaswag_peft_gb200` is **left unchanged** and will continue to fail. It is a GB200-only recipe (4 GPUs/node, 184 GB), and nemo-ci has **no per-recipe GB200 routing** for the eos functional pipeline: `RESERVED_CLUSTER_TAG` (set by `ci.cluster_tag`) only gates the `dlcluster_digits` cluster — there is no rule for the GB200 clusters (`lyris`/`pretyche`/`oci_hsg`), and cluster scope is set pipeline-wide by `TEST_CLUSTER_REGEX` (eos). Routing it to GB200 would require a nemo-ci infra change, so it stays a known failure for now.

# Verification

- Re-ran `generate_ci_tests.py --scope release` for `llm_finetune` and `vlm_finetune`: all 14 fixed recipes now emit the expected `TEST_NODE_COUNT` (16/4/64 and 16/8/4), previously unset.
- Mesh math holds for each: `world = nodes×8` gives `pp | world` and `(world/pp) % ep == 0`.
- Confirmed `.llm_finetune_test` / `.vlm_finetune_test` job templates exist, so the generated pipeline YAML is valid.
- Not functionally validated — these need 4–64 real nodes (32–512 GPUs); end-to-end training success can only be confirmed by the multinode CI run.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the Contributor guidelines
- [ ] New tests — N/A (CI recipe metadata only)
- [ ] Docs — N/A

# Additional Information

- Covers the `config_parallelism/ep_size_not_divisible` row of AM-419 (14 of 15 jobs; the 15th, the gb200 recipe, is intentionally left failing per above).
- Cost note: the two deepseek `pro` recipes are 64-node/512-GPU jobs per release pipeline; the 16-node jobs likewise need that capacity free on eos.
