### PR TITLE
ci(fern): run docs check on every /ok to test (drop paths filter)

### DIFF
--- a/.github/workflows/fern-docs-ci.yml
+++ b/.github/workflows/fern-docs-ci.yml
@@ -17,16 +17,21 @@
 
 name: Fern docs (check)
 
-# Triggers on push to mirrored PR branches (`pull-request/<n>`) created by the
-# FW-CI mirror bot. This runs in the trusted base-repo context, so
-# DOCS_FERN_TOKEN is available even for fork PRs.
+# Runs `fern check` on every push to a `pull-request/<n>` branch -- i.e. whenever
+# `/ok to test <sha>` is posted: copy-pr-bot copies the PR onto pull-request/<n>
+# and pushes it, which fires this (exactly like the main `CICD NeMo` pipeline).
+#
+# Deliberately NO `paths:` filter. GitHub evaluates a push `paths:` filter against
+# the branch-creation diff, which is unreliable for the first push copy-pr-bot
+# makes to a brand-new pull-request/<n> branch, so a docs-only PR can skip a
+# path-filtered check entirely -- that is how a malformed nightly.yml slipped past
+# CI and broke the publish on main. cicd-main.yml omits the filter for the same
+# reason. `fern check` is ~25s and needs no secrets, so running it on every mirror
+# push is cheap and safe.
 on:
   push:
     branches:
       - "pull-request/[0-9]+"
-    paths:
-      - 'docs/**'
-      - '.github/workflows/fern-docs-ci.yml'
 
 permissions:
   contents: read

--- a/docs/fern/versions/nightly.yml
+++ b/docs/fern/versions/nightly.yml
@@ -25,18 +25,18 @@ navigation:
       - page: "Repo Structure"
         path: ../../repository-structure.mdx
         slug: repo-structure
-- section: "What's New"
-  slug: whats-new
-  contents:
-    - page: "Announcements"
-      path: ../../announcements.mdx
-      slug: announcements
-    - page: "Release Notes"
-      path: ../../release-notes.mdx
-      slug: release-notes
-    - page: "Model Release Log"
-      path: ../../model-coverage/latest-models.mdx
-      slug: model-release-log
+  - section: "What's New"
+    slug: whats-new
+    contents:
+      - page: "Announcements"
+        path: ../../announcements.mdx
+        slug: announcements
+      - page: "Release Notes"
+        path: ../../release-notes.mdx
+        slug: release-notes
+      - page: "Model Release Log"
+        path: ../../model-coverage/latest-models.mdx
+        slug: model-release-log
   - section: "Performance"
     slug: performance
     contents:
@@ -420,8 +420,9 @@ navigation:
       - page: "MLflow Logging"
         path: ../../guides/mlflow-logging.mdx
         slug: mlflow-logging
-- section: "Reference"
-  slug: reference
-  contents:
-    - page: "API Reference"
-    - folder: ../product-docs/nemo-automodel/Full-Library-Reference
+  - section: "Reference"
+    slug: reference
+    contents:
+      - page: "API Reference"
+        path: ../../api-reference/index.mdx
+      - folder: ../product-docs/nemo-automodel/Full-Library-Reference


### PR DESCRIPTION
## What

`fern check` already existed (`.github/workflows/fern-docs-ci.yml`), but its
`paths: docs/**` filter made GitHub **skip it** on copy-pr-bot's first push to a
new `pull-request/<n>` branch — push `paths:` filters are evaluated against the
branch-creation diff, which is unreliable. So a docs-only PR could merge without
the check ever running.

That is exactly how the malformed `nightly.yml` in #2544 reached `main` and broke
the Fern publish:
https://github.com/NVIDIA-NeMo/Automodel/actions/runs/27443586723/job/81123228884
(`end of the stream or a document separator is expected (28:1)`).

This drops the `paths:` filter so `fern check` runs on **every** `/ok to test`,
exactly like the `CICD NeMo` pipeline (`cicd-main.yml`), which has no filter and
always runs on push to `pull-request/<n>`.

## Verifying the catch

This PR **intentionally leaves `nightly.yml` broken** (the bug is currently on
`main`). The expected result is that **`Fern docs (check)` FAILS** at
`nightly.yml:28` — proving the linter now catches the error pre-merge. The
`nightly.yml` fix lands as a follow-up once the catch is confirmed green→red.

## Changelog

- `fern-docs-ci.yml`: drop the `paths:` filter so the Fern docs check runs on
  every `/ok to test`, closing the gap that let a broken nav YAML reach `main`.
  
 ## Example
https://github.com/NVIDIA-NeMo/Automodel/actions/runs/27444834436/job/81127303133?pr=2547
<img width="1143" height="816" alt="Screenshot 2026-06-12 at 2 47 30 PM" src="https://github.com/user-attachments/assets/46f9c083-193c-472f-8338-2546ce113e17" />
