### PR TITLE
fix(models): keep RoPE frequency buffers fp32 under bf16 model cast

### DIFF
--- a/nemo_automodel/components/models/common/utils.py
+++ b/nemo_automodel/components/models/common/utils.py
@@ -550,7 +550,9 @@ def _get_fp32_module_keywords(model: nn.Module) -> list[str]:
     keywords: list[str] = []
     for attr in ("_keep_in_fp32_modules_strict", "_keep_in_fp32_modules"):
         val = getattr(model, attr, None)
-        if isinstance(val, list):
+        # HuggingFace's PreTrainedModel.__init__ normalizes a class-level
+        # list[str] into an instance-level set[str], so accept both (and tuple).
+        if isinstance(val, (list, set, tuple)):
             keywords.extend(val)
 
     # de-duplicate while preserving order

--- a/nemo_automodel/components/models/deepseek_v4/model.py
+++ b/nemo_automodel/components/models/deepseek_v4/model.py
@@ -574,6 +574,10 @@ class DeepseekV4ForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
         "self_attn.compressor.indexer.ape",
         "e_score_correction_bias",
         "lm_head",
+        # RoPE inv_freq (matches rotary_emb + rotary_emb_compress) must stay fp32: the
+        # bf16 cast in initialize_weights would otherwise round it and degrade rotary
+        # precision vs HF (see llama/rope_utils.py).
+        "rotary_emb",
     ]
 
     @dataclass(frozen=True)

--- a/nemo_automodel/components/models/diffusion_gemma/model.py
+++ b/nemo_automodel/components/models/diffusion_gemma/model.py
@@ -75,6 +75,7 @@ except (ModuleNotFoundError, ImportError):
 from nemo_automodel._transformers.model_capabilities import ModelCapabilities
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.models.common.hf_checkpointing_mixin import HFCheckpointingMixin
+from nemo_automodel.components.models.common.utils import cast_model_to_dtype
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
 
@@ -349,6 +350,10 @@ class DiffusionGemmaForBlockDiffusion(HFCheckpointingMixin, MoEFSDPSyncMixin, Pr
     config_class = DiffusionGemmaConfig
     base_model_prefix = "model"
     supports_gradient_checkpointing = True
+    # RoPE inv_freq must stay fp32: initialize_weights casts the model to bf16 and
+    # nn.Module.to rounds floating buffers; cast_model_to_dtype restores keep-fp32
+    # modules afterwards (see llama/rope_utils.py).
+    _keep_in_fp32_modules = ["rotary_emb"]
     _no_split_modules = ["DiffusionGemmaMoEDecoderLayer"]
     _tied_weights_keys = ["lm_head.weight"]
 
@@ -503,7 +508,7 @@ class DiffusionGemmaForBlockDiffusion(HFCheckpointingMixin, MoEFSDPSyncMixin, Pr
         with buffer_device:
             for layer in self.model.layers.values():
                 layer.moe.init_weights(buffer_device)
-        self.to(dtype)
+        cast_model_to_dtype(self, dtype)
 
     def _softcap_logits(self, hidden_states: torch.Tensor) -> torch.Tensor:
         logits = self.lm_head(hidden_states).to(torch.float32)

--- a/nemo_automodel/components/models/gemma4_moe/model.py
+++ b/nemo_automodel/components/models/gemma4_moe/model.py
@@ -77,6 +77,7 @@ except (ModuleNotFoundError, ImportError, AttributeError):
 from nemo_automodel._transformers.model_capabilities import ModelCapabilities
 from nemo_automodel.components.models.common import BackendConfig, compute_lm_head_logits
 from nemo_automodel.components.models.common.hf_checkpointing_mixin import HFCheckpointingMixin
+from nemo_automodel.components.models.common.utils import cast_model_to_dtype
 from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
 from nemo_automodel.components.moe.layers import MoE, MoEConfig
 from nemo_automodel.shared.utils import dtype_from_str as get_dtype
@@ -503,6 +504,10 @@ class Gemma4MoEModel(HFGemma4Model):
 # ---------------------------------------------------------------------------
 class Gemma4ForConditionalGeneration(HFCheckpointingMixin, HFGemma4ForConditionalGeneration, MoEFSDPSyncMixin):
     supports_gradient_checkpointing = True
+    # RoPE inv_freq must stay fp32: initialize_weights casts the model to bf16 and
+    # nn.Module.to rounds floating buffers; cast_model_to_dtype restores keep-fp32
+    # modules afterwards (see llama/rope_utils.py).
+    _keep_in_fp32_modules = ["rotary_emb"]
     """Gemma4 VL conditional generation model with NeMo MoE backend.
 
     When the checkpoint has ``enable_moe_block=True`` in its text config,
@@ -759,7 +764,7 @@ class Gemma4ForConditionalGeneration(HFCheckpointingMixin, HFGemma4ForConditiona
         # Needed only when constructing the model directly, doesn't affect when loading a ckpt via from_pretrained().
         language_model = self.model.language_model
         if not isinstance(language_model, Gemma4MoETextModelBackend):
-            self.to(dtype)
+            cast_model_to_dtype(self, dtype)
             return
 
         buffer_device = buffer_device or torch.device(f"cuda:{torch.cuda.current_device()}")
@@ -768,7 +773,7 @@ class Gemma4ForConditionalGeneration(HFCheckpointingMixin, HFGemma4ForConditiona
             for layer in language_model.layers.values():
                 layer.moe.init_weights(buffer_device)
 
-        self.to(dtype)
+        cast_model_to_dtype(self, dtype)
 
 
 if _GEMMA4_HF_AVAILABLE:

--- a/nemo_automodel/components/models/kimi_k25_vl/model.py
+++ b/nemo_automodel/components/models/kimi_k25_vl/model.py
@@ -37,6 +37,7 @@ from transformers.models.deepseek_v3.configuration_deepseek_v3 import DeepseekV3
 from transformers.models.llava.modeling_llava import LlavaCausalLMOutputWithPast
 
 from nemo_automodel.components.models.common.hf_checkpointing_mixin import HFCheckpointingMixin
+from nemo_automodel.components.models.common.utils import cast_model_to_dtype
 
 LOGGER = logging.getLogger(__name__)
 
@@ -881,6 +882,11 @@ class KimiK25VLModel(nn.Module):
 class KimiK25VLForConditionalGeneration(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
     """KimiK25VL model with backend-aware DeepseekV3 language model."""
 
+    # RoPE freqs/inv_freq must stay fp32: from_pretrained casts the model to bf16 and
+    # nn.Module.to rounds floating buffers; routing through cast_model_to_dtype restores
+    # these keep-fp32 buffers afterwards (see llama/rope_utils.py).
+    _keep_in_fp32_modules = ["freqs_cis", "rotary_emb"]
+
     config_class = KimiK25VLConfig
     base_model_prefix = "model"
     main_input_name = "pixel_values"
@@ -937,7 +943,7 @@ class KimiK25VLForConditionalGeneration(HFCheckpointingMixin, nn.Module, MoEFSDP
         config.torch_dtype = torch_dtype
         model = cls.from_config(config, torch_dtype=torch_dtype, *model_args, **kwargs)
         model.name_or_path = pretrained_model_name_or_path
-        model = model.to(dtype=torch_dtype)
+        cast_model_to_dtype(model, torch_dtype)
 
         LOGGER.info(f"Model created with dtype={torch_dtype}. Weights loaded by DCP via adapter.")
         return model

--- a/nemo_automodel/components/models/llama/rope_utils.py
+++ b/nemo_automodel/components/models/llama/rope_utils.py
@@ -183,6 +183,18 @@ class LlamaRotaryEmbedding(nn.Module):
         compute_fn = rope_functions.get(rope_type, _compute_llama3_inv_freq)
         inv_freq, self.attention_scaling = compute_fn(config, device)
 
+        # Keep the config + compute fn so ``_build_cache`` can recompute ``inv_freq``
+        # in float32. ``LlamaForCausalLM.__init__`` casts the whole model via
+        # ``self.to(config.torch_dtype)``, and ``nn.Module.to`` rounds floating-point
+        # buffers -- so the ``inv_freq`` buffer registered below is downcast to bf16.
+        # Building the cos/sin tables from that bf16-rounded buffer degrades RoPE
+        # precision relative to HuggingFace (which keeps ``inv_freq`` in float32) and
+        # surfaces as a large logit divergence when a checkpoint is reloaded in
+        # vanilla HF. Recomputing from config keeps the tables float32-accurate
+        # regardless of the model's parameter dtype.
+        self._rope_config = config
+        self._inv_freq_compute_fn = compute_fn
+
         self.register_buffer("inv_freq", inv_freq, persistent=False)
         self.register_buffer("_cos_cache", None, persistent=False)
         self.register_buffer("_sin_cache", None, persistent=False)
@@ -192,9 +204,14 @@ class LlamaRotaryEmbedding(nn.Module):
         """Build cos/sin cache in config dtype for positions [0, seq_len)."""
         self.max_seq_len_cached = seq_len
 
-        # Compute in float32 for precision, then convert to target dtype
+        # Compute in float32 for precision, then convert to target dtype.
+        # Recompute inv_freq from config instead of reading ``self.inv_freq``: the
+        # registered buffer is rounded to the model dtype (e.g. bf16) by the
+        # model-wide ``.to()`` in ``LlamaForCausalLM.__init__``, and upcasting a
+        # bf16 buffer back to float32 cannot recover the lost precision. See __init__.
         t = torch.arange(seq_len, device=device, dtype=torch.float32)
-        inv_freq = self.inv_freq.to(device=device, dtype=torch.float32)
+        inv_freq, _ = self._inv_freq_compute_fn(self._rope_config, device)
+        inv_freq = inv_freq.to(device=device, dtype=torch.float32)
         freqs = torch.outer(t, inv_freq)
         emb = torch.cat((freqs, freqs), dim=-1)  # [seq, head_dim]
 

--- a/nemo_automodel/components/models/mimo_v2_flash/model.py
+++ b/nemo_automodel/components/models/mimo_v2_flash/model.py
@@ -585,7 +585,10 @@ class MiMoV2FlashModel(nn.Module):
 class MiMoV2FlashForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
     """Causal LM wrapper for MiMo-V2-Flash with Automodel checkpoint adapters."""
 
-    _keep_in_fp32_modules_strict = ["mlp.gate.e_score_correction_bias", "attention_sink_bias"]
+    # "rotary_emb" (matches self.rotary_emb + self.swa_rotary_emb) pins their inv_freq
+    # buffers in fp32: cast_model_to_dtype's bf16 cast would otherwise round inv_freq and
+    # degrade RoPE precision vs HF (see llama/rope_utils.py).
+    _keep_in_fp32_modules_strict = ["mlp.gate.e_score_correction_bias", "attention_sink_bias", "rotary_emb"]
     _pp_keep_self_forward = True
     _skip_init_weights_on_load = True
 

--- a/nemo_automodel/components/models/minimax_m3_vl/model.py
+++ b/nemo_automodel/components/models/minimax_m3_vl/model.py
@@ -363,8 +363,11 @@ class MiniMaxM3SparseForConditionalGeneration(HFCheckpointingMixin, nn.Module, M
     # Pipeline-parallel routing: keep this VLM's own forward (which splices vision
     # features) instead of letting patch_hf_model_for_pp swap in the generic
     # CausalLM forward (which would drop pixel_values). MTP per-depth outputs are
-    # logits (shared lm_head); rotary buffers stay fp32.
-    _keep_in_fp32_modules = ["rotary_emb"]
+    # logits (shared lm_head); rotary buffers stay fp32. "rotary_emb" covers the text
+    # rope; "inv_freq" additionally pins the vision tower's rotary buffer
+    # (vision_encoder.py) fp32 — the bf16 cast would otherwise round it and degrade
+    # vision RoPE (see llama/rope_utils.py).
+    _keep_in_fp32_modules = ["rotary_emb", "inv_freq"]
     _pp_keep_self_forward: bool = True
     mtp_outputs_are_logits = True
     # The state-dict adapter fully populates every tensor from the checkpoint

--- a/tests/unit_tests/models/common/test_cast_model_to_dtype.py
+++ b/tests/unit_tests/models/common/test_cast_model_to_dtype.py
@@ -372,6 +372,63 @@ class TestCastFrozenModulesToComputeDtype:
         assert model.vision.pos.dtype == torch.bfloat16
 
 
+class TestRopeBufferPreserved:
+    """Regression: a model-wide bf16 cast must not round rotary frequency buffers.
+
+    ``nn.Module.to(bf16)`` rounds floating-point buffers, including a rotary
+    embedding's (non-persistent) ``inv_freq`` / ``freqs_cis``. Building cos/sin from a
+    bf16-rounded buffer degrades RoPE precision vs HF (which keeps it fp32) and shows
+    up as a large logit/KL divergence when a checkpoint is reloaded in vanilla HF.
+    Models guard against this by listing the rotary module (or buffer) in
+    ``_keep_in_fp32_modules``; these tests pin that ``cast_model_to_dtype`` honors it
+    for non-persistent rope buffers (the mechanism the per-model fixes rely on).
+    """
+
+    @staticmethod
+    def _rope_model(keep, *, buffer_name="inv_freq", module_name="rotary_emb"):
+        class Rope(nn.Module):
+            def __init__(self):
+                super().__init__()
+                # Non-persistent, exactly like the real rotary frequency buffers.
+                self.register_buffer(buffer_name, torch.arange(0, 8, 2, dtype=torch.float32), persistent=False)
+
+        class M(nn.Module):
+            _keep_in_fp32_modules = keep
+
+            def __init__(self):
+                super().__init__()
+                self.linear = nn.Linear(4, 4)
+                setattr(self, module_name, Rope())
+
+        return M()
+
+    def test_rotary_emb_keyword_keeps_inv_freq_fp32(self):
+        # deepseek_v4 / mimo_v2_flash / gemma4_moe / diffusion_gemma case.
+        model = self._rope_model(["rotary_emb"])
+        cast_model_to_dtype(model, torch.bfloat16)
+        assert model.rotary_emb.inv_freq.dtype == torch.float32  # protected
+        assert model.linear.weight.dtype == torch.bfloat16  # everything else cast
+
+    def test_unprotected_inv_freq_is_rounded(self):
+        # Without the keep-list entry the bug reproduces: inv_freq is rounded to bf16.
+        model = self._rope_model([])
+        cast_model_to_dtype(model, torch.bfloat16)
+        assert model.rotary_emb.inv_freq.dtype == torch.bfloat16
+
+    def test_inv_freq_keyword_protects_non_rotary_named_module(self):
+        # minimax_m3_vl vision tower: inv_freq lives on a module not named "rotary_emb",
+        # so the "inv_freq" buffer-name keyword is what pins it fp32.
+        model = self._rope_model(["inv_freq"], module_name="vision_tower")
+        cast_model_to_dtype(model, torch.bfloat16)
+        assert model.vision_tower.inv_freq.dtype == torch.float32
+
+    def test_freqs_cis_keyword_protects_buffer(self):
+        # deepseek_v3 / kimi_k25_vl: the real-valued frequency buffer is named "freqs_cis".
+        model = self._rope_model(["freqs_cis"], buffer_name="freqs_cis", module_name="model")
+        cast_model_to_dtype(model, torch.bfloat16)
+        assert model.model.freqs_cis.dtype == torch.float32
+
+
 class TestRestoreFp32Buffers:
     def test_buffers_restored_params_untouched(self):
         """_restore_fp32_buffers casts buffers but not parameters."""

--- a/tests/unit_tests/models/common/test_cast_model_to_dtype.py
+++ b/tests/unit_tests/models/common/test_cast_model_to_dtype.py
@@ -136,6 +136,19 @@ class TestGetFp32ModuleKeywords:
         model = Model()
         assert _get_fp32_module_keywords(model) == []
 
+    def test_set_and_tuple_accepted(self):
+        # HuggingFace's PreTrainedModel.__init__ converts a class-level list into an
+        # instance-level set; accept set (and tuple) so keep-fp32 keywords are not
+        # silently dropped (regression: this no-op'd the gemma4_moe/diffusion_gemma fix).
+        class Model(nn.Module):
+            _keep_in_fp32_modules = {"norm"}
+            _keep_in_fp32_modules_strict = ("head",)
+
+            def __init__(self):
+                super().__init__()
+
+        assert set(_get_fp32_module_keywords(Model())) == {"norm", "head"}
+
 
 # ---------------------------------------------------------------------------
 # Tests for _restore_fp32_modules()
@@ -226,6 +239,22 @@ class TestCastModelToDtype:
 
         for p in model.parameters():
             assert p.dtype == torch.float16
+
+    def test_set_valued_keep_in_fp32_preserved(self):
+        # Mirrors HF converting _keep_in_fp32_modules (list) to a set on the instance —
+        # the gemma4_moe/diffusion_gemma case. cast_model_to_dtype must still restore it.
+        class M(nn.Module):
+            _keep_in_fp32_modules = {"norm"}
+
+            def __init__(self):
+                super().__init__()
+                self.linear = nn.Linear(4, 4)
+                self.norm = nn.LayerNorm(4)
+
+        model = M()
+        cast_model_to_dtype(model, torch.bfloat16)
+        assert model.norm.weight.dtype == torch.float32
+        assert model.linear.weight.dtype == torch.bfloat16
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/models/deepseek_v4/test_dsv4_rope_fp32.py
+++ b/tests/unit_tests/models/deepseek_v4/test_dsv4_rope_fp32.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression test: DeepseekV4 RoPE ``inv_freq`` must stay fp32 after bf16 init.
+
+``DeepseekV4RotaryEmbedding`` registers ``inv_freq`` as an fp32 buffer.
+``initialize_weights(dtype=torch.bfloat16)`` casts the whole model to bf16 via
+``cast_model_to_dtype``; ``nn.Module.to`` would round that buffer to bf16 and
+corrupt RoPE precision. The model lists ``"rotary_emb"`` in
+``_keep_in_fp32_modules_strict`` so the rotary buffers (``rotary_emb`` and
+``rotary_emb_compress``) are restored to fp32 afterwards. Runs on CPU.
+"""
+
+import torch
+
+from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.models.deepseek_v4.config import DeepseekV4Config
+from nemo_automodel.components.models.deepseek_v4.model import DeepseekV4ForCausalLM
+
+
+def _tiny_config(**overrides):
+    defaults = dict(
+        vocab_size=256,
+        hidden_size=64,
+        moe_intermediate_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=1,
+        head_dim=16,
+        qk_rope_head_dim=8,
+        q_lora_rank=32,
+        o_lora_rank=32,
+        o_groups=2,
+        n_routed_experts=8,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+        routed_scaling_factor=1.5,
+        norm_topk_prob=True,
+        scoring_func="sqrtsoftplus",
+        topk_method="noaux_tc",
+        max_position_embeddings=128,
+        rope_theta=10000.0,
+        rope_scaling={
+            "type": "yarn",
+            "factor": 16,
+            "original_max_position_embeddings": 64,
+            "beta_fast": 32,
+            "beta_slow": 1,
+        },
+        hc_mult=4,
+        num_hash_layers=0,
+        compress_ratios=[0, 4],  # layer 0 full, layer 1 compressed
+        sliding_window=16,
+        num_nextn_predict_layers=0,  # no MTP
+        rms_norm_eps=1e-6,
+        torch_dtype="float32",
+    )
+    defaults.update(overrides)
+    return DeepseekV4Config(**defaults)
+
+
+def _cpu_backend():
+    return BackendConfig(
+        attn="sdpa",
+        linear="torch",
+        rms_norm="torch",
+        rope_fusion=False,
+        enable_hf_state_dict_adapter=False,
+        dispatcher="torch",
+        experts="torch_mm",
+    )
+
+
+def test_initialize_weights_bf16_keeps_rope_inv_freq_fp32():
+    model = DeepseekV4ForCausalLM(_tiny_config(), backend=_cpu_backend())
+    model.initialize_weights(buffer_device=torch.device("cpu"), dtype=torch.bfloat16)
+
+    rope_buffers = [
+        (name, buf.dtype) for name, buf in model.named_buffers() if "inv_freq" in name or "freqs_cis" in name
+    ]
+    # Both the main and the compressed rotary embeddings expose inv_freq.
+    assert len(rope_buffers) >= 2, f"expected >=2 rotary buffers, found {rope_buffers}"
+    for name, dtype in rope_buffers:
+        assert dtype == torch.float32, f"rotary buffer {name} was cast to {dtype}, expected float32"
+
+    # A regular weight must be bf16 (the cast actually ran).
+    assert model.model.embed_tokens.weight.dtype == torch.bfloat16

--- a/tests/unit_tests/models/diffusion_gemma/test_diffusion_gemma_rope_fp32.py
+++ b/tests/unit_tests/models/diffusion_gemma/test_diffusion_gemma_rope_fp32.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression test: DiffusionGemma RoPE ``inv_freq`` must stay fp32 after bf16 init.
+
+``DiffusionGemmaTextRotaryEmbedding`` (Gemma4-style) registers per-layer-type
+``{type}_inv_freq`` fp32 buffers. ``initialize_weights(dtype=torch.bfloat16)`` casts
+the model to bf16 via ``cast_model_to_dtype``; the model lists ``"rotary_emb"`` in
+``_keep_in_fp32_modules`` so those buffers are restored to fp32. Runs on CPU.
+
+Skipped unless the ``transformers.models.diffusion_gemma`` fork is importable (it
+ships in the NGC container, not on PyPI), matching the other diffusion_gemma tests.
+"""
+
+import importlib.util
+
+import pytest
+import torch
+
+_FORK_AVAILABLE = importlib.util.find_spec("transformers.models.diffusion_gemma") is not None
+_GEMMA4_AVAILABLE = importlib.util.find_spec("transformers.models.gemma4") is not None
+
+pytestmark = pytest.mark.skipif(
+    not (_FORK_AVAILABLE and _GEMMA4_AVAILABLE),
+    reason="requires the transformers diffusion_gemma fork (NGC container only)",
+)
+
+
+def _tiny_text_config_dict():
+    return dict(
+        vocab_size=128,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        global_head_dim=32,
+        num_global_key_value_heads=1,
+        hidden_activation="gelu_pytorch_tanh",
+        max_position_embeddings=512,
+        rms_norm_eps=1e-6,
+        sliding_window=4096,
+        layer_types=["sliding_attention", "full_attention"],
+        num_experts=4,
+        top_k_experts=2,
+        moe_intermediate_size=32,
+        final_logit_softcapping=30.0,
+        use_bidirectional_attention="vision",
+        attention_bias=False,
+        attention_dropout=0.0,
+    )
+
+
+def test_initialize_weights_bf16_keeps_rope_inv_freq_fp32():
+    from transformers.models.diffusion_gemma.configuration_diffusion_gemma import DiffusionGemmaConfig
+
+    from nemo_automodel.components.models.common import BackendConfig
+    from nemo_automodel.components.models.diffusion_gemma.model import DiffusionGemmaForBlockDiffusion
+
+    config = DiffusionGemmaConfig(text_config=_tiny_text_config_dict(), vision_config=None, canvas_length=8)
+    backend = BackendConfig(
+        attn="sdpa",
+        linear="torch",
+        rms_norm="torch_fp32",
+        experts="torch_mm",
+        dispatcher="torch",
+        enable_hf_state_dict_adapter=True,
+    )
+    model = DiffusionGemmaForBlockDiffusion(config, backend=backend, self_conditioning=True, freeze_router=True)
+    model.initialize_weights(dtype=torch.bfloat16, buffer_device=torch.device("cpu"))
+
+    rope_buffers = [
+        (name, buf.dtype) for name, buf in model.named_buffers() if "inv_freq" in name or "freqs_cis" in name
+    ]
+    assert rope_buffers, "no inv_freq/freqs_cis buffers found on the model"
+    for name, dtype in rope_buffers:
+        assert dtype == torch.float32, f"rotary buffer {name} was cast to {dtype}, expected float32"
+
+    assert model.model.layers["0"].self_attn.q_proj.weight.dtype == torch.bfloat16

--- a/tests/unit_tests/models/gemma4_moe/test_gemma4_moe_rope_fp32.py
+++ b/tests/unit_tests/models/gemma4_moe/test_gemma4_moe_rope_fp32.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression test: Gemma4 MoE RoPE ``inv_freq`` must stay fp32 after bf16 init.
+
+HF's ``Gemma4TextRotaryEmbedding`` precomputes ``inv_freq`` as an fp32 buffer.
+``Gemma4ForConditionalGeneration.initialize_weights(dtype=torch.bfloat16)`` casts
+the whole model to bf16 via ``cast_model_to_dtype``; ``nn.Module.to`` would round
+that fp32 buffer to bf16 and corrupt RoPE precision. The model declares
+``_keep_in_fp32_modules = ["rotary_emb"]`` so ``cast_model_to_dtype`` restores the
+rotary buffers to fp32 afterwards. This test builds a tiny MoE model through the
+real ``Gemma4MoETextModelBackend`` path and asserts the invariant holds while a
+regular weight is bf16.
+
+Runs on CPU (no CUDA / TE / DeepEP required).
+"""
+
+import torch
+from transformers.models.gemma4.configuration_gemma4 import Gemma4Config, Gemma4TextConfig
+
+from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.models.gemma4_moe.model import (
+    Gemma4ForConditionalGeneration,
+    Gemma4MoETextModelBackend,
+)
+
+
+def _make_text_config(**overrides):
+    """Tiny Gemma4TextConfig (2 layers, small hidden, tiny vocab, few experts)."""
+    defaults = dict(
+        vocab_size=256,
+        hidden_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        num_hidden_layers=2,
+        intermediate_size=128,
+        rms_norm_eps=1e-6,
+        max_position_embeddings=256,
+        enable_moe_block=True,  # routes construction through the NeMo MoE backend
+        num_experts=4,
+        top_k_experts=2,
+        moe_intermediate_size=64,
+        layer_types=["full_attention", "sliding_attention"],
+        sliding_window=128,
+        hidden_activation="gelu_pytorch_tanh",
+        torch_dtype="bfloat16",
+    )
+    defaults.update(overrides)
+    return Gemma4TextConfig(**defaults)
+
+
+def _make_cpu_backend():
+    """CPU-friendly backend: no TE, no DeepEP, plain torch kernels."""
+    return BackendConfig(
+        linear="torch",
+        attn="sdpa",
+        rms_norm="torch",
+        experts="torch",
+        dispatcher="torch",
+        fake_balanced_gate=False,
+        enable_hf_state_dict_adapter=False,
+    )
+
+
+def test_initialize_weights_bf16_keeps_rope_inv_freq_fp32():
+    """bf16 init must leave rotary ``inv_freq`` in fp32 while regular weights are bf16."""
+    config = Gemma4Config(text_config=_make_text_config())
+    model = Gemma4ForConditionalGeneration(config, backend=_make_cpu_backend())
+
+    # Sanity: construction hit the real NeMo MoE backend, so initialize_weights
+    # runs the cast_model_to_dtype path under test (not the early-return guard).
+    assert isinstance(model.model.language_model, Gemma4MoETextModelBackend)
+
+    model.initialize_weights(dtype=torch.bfloat16, buffer_device=torch.device("cpu"))
+
+    rope_buffers = [
+        (name, buf.dtype) for name, buf in model.named_buffers() if "inv_freq" in name or "freqs_cis" in name
+    ]
+    # The rotary module exposes at least one inv_freq buffer.
+    assert rope_buffers, "no inv_freq/freqs_cis buffers found on the model"
+    for name, dtype in rope_buffers:
+        assert dtype == torch.float32, f"rotary buffer {name} was cast to {dtype}, expected float32"
+
+    # A regular weight must still be bf16 (the cast actually happened).
+    reg_weight = model.model.language_model.layers["0"].self_attn.q_proj.weight
+    assert reg_weight.dtype == torch.bfloat16

--- a/tests/unit_tests/models/kimi_k25_vl/test_kimi_rope_fp32.py
+++ b/tests/unit_tests/models/kimi_k25_vl/test_kimi_rope_fp32.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression test: KimiK25VL RoPE ``freqs_cis`` must stay fp32 after bf16 cast.
+
+The DeepseekV3-based language backbone registers ``freqs_cis`` as a real-valued
+fp32 buffer (inverse frequencies). ``from_pretrained`` casts the model to bf16 via
+``cast_model_to_dtype``; the model lists ``"freqs_cis"`` in ``_keep_in_fp32_modules``
+so the buffer is restored to fp32. This builds via ``from_config`` and applies the
+same ``cast_model_to_dtype`` the fixed ``from_pretrained`` uses (``from_pretrained``
+itself needs a real checkpoint dir for DCP). Runs on CPU.
+"""
+
+import torch
+from transformers.models.deepseek_v3.configuration_deepseek_v3 import DeepseekV3Config
+
+from nemo_automodel.components.models.common.utils import cast_model_to_dtype
+from nemo_automodel.components.models.kimi_k25_vl.model import (
+    KimiK25VLConfig,
+    KimiK25VLForConditionalGeneration,
+    MoonViT3dConfig,
+)
+
+
+def _tiny_text_config():
+    return DeepseekV3Config(
+        vocab_size=128,
+        hidden_size=64,
+        intermediate_size=128,
+        moe_intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        qk_rope_head_dim=16,  # freqs_cis length = qk_rope_head_dim // 2 = 8
+        qk_nope_head_dim=16,
+        v_head_dim=16,
+        kv_lora_rank=16,
+        q_lora_rank=None,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+        n_group=1,
+        topk_group=1,
+        first_k_dense_replace=0,
+        moe_layer_freq=1,
+        max_position_embeddings=64,
+        torch_dtype=torch.bfloat16,
+    )
+
+
+def _tiny_vision_config():
+    return MoonViT3dConfig(
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        patch_size=14,
+        init_pos_emb_height=8,
+        init_pos_emb_width=8,
+        init_pos_emb_time=4,
+        merge_kernel_size=[2, 2],
+        merge_type="sd2_tpool",
+    )
+
+
+def test_bf16_cast_keeps_rope_freqs_cis_fp32():
+    config = KimiK25VLConfig(vision_config=_tiny_vision_config(), text_config=_tiny_text_config())
+    config.torch_dtype = torch.bfloat16
+
+    model = KimiK25VLForConditionalGeneration.from_config(config, torch_dtype=torch.bfloat16)
+    # Mirror the fixed from_pretrained cast (which routes through cast_model_to_dtype).
+    cast_model_to_dtype(model, torch.bfloat16)
+
+    rope_buffers = [
+        (name, buf.dtype) for name, buf in model.named_buffers() if "inv_freq" in name or "freqs_cis" in name
+    ]
+    assert rope_buffers, "no inv_freq/freqs_cis buffers found on the model"
+    for name, dtype in rope_buffers:
+        assert dtype == torch.float32, f"rotary buffer {name} was cast to {dtype}, expected float32"
+
+    assert model.model.language_model.model.embed_tokens.weight.dtype == torch.bfloat16

--- a/tests/unit_tests/models/llama/test_rope_utils.py
+++ b/tests/unit_tests/models/llama/test_rope_utils.py
@@ -148,3 +148,47 @@ def test_rope_fused_path_does_not_sync_on_position_values():
     with patch.object(torch.Tensor, "max", _no_max):
         cos, sin, freqs = rope(x, torch.arange(6).unsqueeze(0))
     assert cos.shape == (1, 6, 8)
+
+
+def test_bf16_model_cast_does_not_degrade_inv_freq():
+    """A model-wide ``.to(bfloat16)`` must not degrade RoPE precision.
+
+    ``LlamaForCausalLM.__init__`` casts the whole model via
+    ``self.to(config.torch_dtype)``, and ``nn.Module.to`` rounds floating-point
+    buffers -- so the ``inv_freq`` buffer is downcast to bf16. Building the cos/sin
+    tables from that bf16-rounded buffer (then upcasting) loses precision relative to
+    HF, which keeps ``inv_freq`` in float32; the gap shows up as a large logit/KL
+    divergence when a checkpoint is reloaded in vanilla HF. The tables must therefore
+    be identical whether or not the module was cast to bf16.
+
+    Uses real Llama-3.2 rope params (``rope_theta=5e5`` + ``llama3`` scaling): the
+    low-frequency components are where the bf16 rounding error is largest.
+    """
+    config = LlamaConfig(
+        hidden_size=2048,
+        num_attention_heads=32,
+        num_key_value_heads=8,
+        head_dim=64,
+        max_position_embeddings=131072,
+        rope_theta=500000.0,
+        rope_scaling={
+            "rope_type": "llama3",
+            "factor": 32.0,
+            "high_freq_factor": 4.0,
+            "low_freq_factor": 1.0,
+            "original_max_position_embeddings": 8192,
+        },
+        torch_dtype=torch.bfloat16,
+    )
+    x = torch.zeros(1, 9, config.hidden_size, dtype=torch.bfloat16)
+    pos = torch.arange(9).unsqueeze(0)
+
+    rope_ref = LlamaRotaryEmbedding(config)  # inv_freq stays float32
+    rope_cast = LlamaRotaryEmbedding(config).to(torch.bfloat16)  # mimics the model-wide cast
+    assert rope_cast.inv_freq.dtype == torch.bfloat16  # buffer is rounded by .to()
+
+    cos_ref, sin_ref = rope_ref(x, pos)
+    cos_cast, sin_cast = rope_cast(x, pos)
+    # Bit-for-bit: the cast module must still build its tables from float32 inv_freq.
+    torch.testing.assert_close(cos_cast, cos_ref, rtol=0, atol=0)
+    torch.testing.assert_close(sin_cast, sin_ref, rtol=0, atol=0)

--- a/tests/unit_tests/models/mimo_v2_flash/test_mimo_rope_fp32.py
+++ b/tests/unit_tests/models/mimo_v2_flash/test_mimo_rope_fp32.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression test: MiMo-V2-Flash RoPE ``inv_freq`` must stay fp32 after bf16 init.
+
+``MiMoV2FlashRotaryEmbedding`` registers ``inv_freq`` as an fp32 buffer (full and
+sliding-window variants). ``initialize_weights(dtype=torch.bfloat16)`` casts the
+model to bf16 via ``cast_model_to_dtype``; the model lists ``"rotary_emb"`` in
+``_keep_in_fp32_modules_strict`` (matches ``rotary_emb`` + ``swa_rotary_emb``) so
+the rotary buffers are restored to fp32. Runs on CPU.
+"""
+
+import torch
+
+from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.models.mimo_v2_flash.config import MiMoV2FlashConfig
+from nemo_automodel.components.models.mimo_v2_flash.model import MiMoV2FlashForCausalLM
+
+
+def _tiny_config(**overrides):
+    defaults = dict(
+        vocab_size=64,
+        hidden_size=32,
+        intermediate_size=64,
+        moe_intermediate_size=16,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        v_head_dim=8,
+        swa_num_attention_heads=4,
+        swa_num_key_value_heads=2,
+        swa_head_dim=8,
+        swa_v_head_dim=8,
+        max_position_embeddings=64,
+        layernorm_epsilon=1e-6,
+        rope_theta=10000.0,
+        swa_rope_theta=10000.0,
+        attention_value_scale=0.707,
+        add_full_attention_sink_bias=False,
+        add_swa_attention_sink_bias=True,
+        partial_rotary_factor=0.5,
+        sliding_window=4,
+        sliding_window_size=4,
+        attention_chunk_size=4,
+        n_routed_experts=4,
+        n_shared_experts=0,
+        num_experts_per_tok=2,
+        scoring_func="sigmoid",
+        n_group=1,
+        topk_group=1,
+        norm_topk_prob=True,
+        routed_scaling_factor=1.0,
+        moe_layer_freq=[0, 1],  # layer 0 dense, layer 1 MoE
+        hybrid_layer_pattern=[0, 1],  # layer 0 full, layer 1 sliding
+        torch_dtype="float32",
+    )
+    defaults.update(overrides)
+    return MiMoV2FlashConfig(**defaults)
+
+
+def _cpu_backend():
+    return BackendConfig(
+        linear="torch",
+        attn="sdpa",
+        rms_norm="torch",
+        experts="torch",
+        dispatcher="torch",
+        rope_fusion=False,
+        fake_balanced_gate=False,
+        enable_hf_state_dict_adapter=False,
+    )
+
+
+def test_initialize_weights_bf16_keeps_rope_inv_freq_fp32():
+    model = MiMoV2FlashForCausalLM(_tiny_config(), backend=_cpu_backend())
+    model.initialize_weights(buffer_device=torch.device("cpu"), dtype=torch.bfloat16)
+
+    rope_buffers = [
+        (name, buf.dtype) for name, buf in model.named_buffers() if "inv_freq" in name or "freqs_cis" in name
+    ]
+    # Full-attention + sliding-window rotary both expose inv_freq.
+    assert len(rope_buffers) >= 2, f"expected >=2 rotary buffers, found {rope_buffers}"
+    for name, dtype in rope_buffers:
+        assert dtype == torch.float32, f"rotary buffer {name} was cast to {dtype}, expected float32"
+
+    assert model.lm_head.weight.dtype == torch.bfloat16

--- a/tests/unit_tests/models/minimax_m3_vl/test_minimax_rope_fp32.py
+++ b/tests/unit_tests/models/minimax_m3_vl/test_minimax_rope_fp32.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression test: MiniMax-M3-VL vision-tower RoPE ``inv_freq`` stays fp32 after bf16 init.
+
+The text backbone uses the recompute-from-config ``gpt_oss`` rope (no buffer), but
+the vision tower (``MiniMaxM3VisionTransformer``) registers ``inv_freq`` as an fp32
+buffer that is NOT under a ``rotary_emb``-named module. ``initialize_weights`` casts
+the model to bf16 via ``cast_model_to_dtype``; the model lists ``"inv_freq"`` in
+``_keep_in_fp32_modules`` (alongside ``"rotary_emb"``) so the vision buffer is
+restored to fp32. Runs on CPU.
+"""
+
+import torch
+
+from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.models.minimax_m3_vl.config import MiniMaxM3VLConfig
+from nemo_automodel.components.models.minimax_m3_vl.model import MiniMaxM3SparseForConditionalGeneration
+
+_TINY_TEXT = dict(
+    hidden_size=64,
+    intermediate_size=32,
+    dense_intermediate_size=48,
+    shared_intermediate_size=32,
+    num_hidden_layers=3,
+    num_attention_heads=4,
+    num_key_value_heads=2,
+    head_dim=16,
+    rotary_dim=8,
+    partial_rotary_factor=0.5,
+    vocab_size=128,
+    max_position_embeddings=256,
+    rms_norm_eps=1e-6,
+    rope_theta=10000.0,
+    num_local_experts=4,
+    num_experts_per_tok=2,
+    n_shared_experts=1,
+    moe_layer_freq=[0, 1, 1],
+    use_gemma_norm=True,
+    use_qk_norm=True,
+    qk_norm_type="per_head",
+    scoring_func="sigmoid",
+    use_routing_bias=True,
+    routed_scaling_factor=2.0,
+    swiglu_alpha=1.702,
+    swiglu_limit=7.0,
+    num_mtp_modules=0,
+)
+_SPARSE_ATTN = dict(
+    use_sparse_attention=True,
+    sparse_index_dim=16,
+    sparse_num_index_heads=2,
+    sparse_topk_blocks=2,
+    sparse_block_size=4,
+    sparse_score_type="max",
+    sparse_init_block=0,
+    sparse_local_block=1,
+    sparse_attention_freq=[0, 1, 1],
+    sparse_disable_index_value=[0, 1, 1],
+)
+_TINY_VISION = dict(
+    hidden_size=32,
+    num_attention_heads=4,
+    num_hidden_layers=2,
+    intermediate_size=64,
+    patch_size=2,
+    num_channels=3,
+    rope_theta=10000.0,
+    hidden_act="gelu",
+    layer_norm_eps=1e-5,
+    img_token_compression_config={"spatial_merge_size": 2, "temporal_patch_size": 2},
+)
+
+
+def _cpu_backend():
+    return BackendConfig(
+        linear="torch",
+        attn="sdpa",
+        rms_norm="torch",
+        rope_fusion=False,
+        enable_deepep=False,
+        fake_balanced_gate=False,
+        enable_hf_state_dict_adapter=True,
+    )
+
+
+def test_initialize_weights_bf16_keeps_vision_inv_freq_fp32():
+    text = {**_TINY_TEXT, "torch_dtype": "float32", "sparse_attention_config": dict(_SPARSE_ATTN)}
+    config = MiniMaxM3VLConfig(
+        vision_config=dict(_TINY_VISION),
+        text_config=text,
+        image_token_index=100,
+        video_token_index=101,
+        projector_hidden_size=_TINY_TEXT["hidden_size"],
+    )
+    model = MiniMaxM3SparseForConditionalGeneration(config, backend=_cpu_backend()).eval()
+    model.initialize_weights(dtype=torch.bfloat16, buffer_device=torch.device("cpu"))
+
+    rope_buffers = [
+        (name, buf.dtype) for name, buf in model.named_buffers() if "inv_freq" in name or "freqs_cis" in name
+    ]
+    # The vision tower contributes the only rotary frequency buffer.
+    assert rope_buffers, "no inv_freq/freqs_cis buffers found on the model"
+    for name, dtype in rope_buffers:
+        assert dtype == torch.float32, f"rotary buffer {name} was cast to {dtype}, expected float32"
+
+    assert model.vision_tower.vision_model.inv_freq.dtype == torch.float32
+    assert model.lm_head.weight.dtype == torch.bfloat16


### PR DESCRIPTION
## What

A rotary embedding's frequency buffer (`inv_freq`, or `freqs_cis`) is registered as **fp32** but gets rounded to **bf16** by a model-wide cast (`self.to(config.torch_dtype)` / `cast_model_to_dtype`). `nn.Module.to` rounds floating-point buffers, so the cos/sin rotary tables are then built from a bf16-rounded frequency — and a later `.float()` can't recover the lost bits. This degrades RoPE vs HuggingFace (which keeps `inv_freq` fp32) and surfaces as a large logit/KL divergence when a checkpoint is reloaded in vanilla HF.

Originally found via the `checkpoint_robustness` failure on `customizer_llama_3_2_1b_full_sft_chat` (nemo-ci job 337980575): Phase 3 (Automodel→Automodel) `max KL = 0`, Phase 4 (Automodel→vanilla HF) `max KL = 1.1e-2 > 5e-3`. A scan of `components/models/` then surfaced the same pattern in 6 more families.

## Fix

**llama** (`rope_utils.py`): recompute `inv_freq` in fp32 from config inside `_build_cache`, so the rotary tables are independent of the model's parameter dtype. Also covers Qwen2 (shares the module).

**6 more families**, fixed via the existing `_keep_in_fp32_modules` mechanism (honored by `cast_model_to_dtype`):

| Model | Fix |
|---|---|
| `deepseek_v4`, `mimo_v2_flash` | add `"rotary_emb"` to `_keep_in_fp32_modules_strict` (matches `rotary_emb` + `rotary_emb_compress`/`swa_rotary_emb`) |
| `minimax_m3_vl` | add `"inv_freq"` — the **vision tower** rope buffer isn't under a `rotary_emb`-named module |
| `gemma4_moe`, `diffusion_gemma` | switch raw `self.to(dtype)` → `cast_model_to_dtype` + `_keep_in_fp32_modules=["rotary_emb"]` (raw `.to` ignores keep-fp32) |
| `kimi_k25_vl` | switch raw `model.to(dtype)` → `cast_model_to_dtype` + `_keep_in_fp32_modules=["freqs_cis","rotary_emb"]` |

Families that were already safe were left alone: the `gpt_oss` rope recomputes `inv_freq` fp32 each forward (used by qwen3*/glm4_moe/hy*/ling/minimax-text), and `step3p5`/`step3p7`/`qwen3_5_moe`/`qwen3_vl_moe` already protect rotary (keep-fp32 list / `Fp32Safe*` wrappers).

## Validation

- **llama**: runtime-verified — AutoModel vs vanilla HF logits become **bit-identical** at realistic scale (16L, vocab 128256, sdpa); `max KL = 0` at every softmax temperature (was up to `1.7e-1`). New `test_rope_utils.py` regression test fails on base (`0.0039` abs / `17%` rel), passes here.
- **6 families**: fixed via the well-tested `cast_model_to_dtype` keep-fp32 path; added `test_cast_model_to_dtype.py` regression tests for non-persistent `inv_freq`/`freqs_cis` preservation (incl. the unprotected-is-rounded repro). Keyword↔module matches verified by code; existing per-model unit/smoke tests pass (deepseek_v4 smoke 17/17 in isolation; mimo/diffusion_gemma/minimax green). The VL fixes (`kimi_k25_vl`, `minimax_m3_vl` vision) are code-reasoned, not runtime-verified locally — flagging for maintainer eyes.

## Follow-up

A `.github/workflows/claude-review.yml` guideline to flag this dtype-hazard class in future reviews is prepared on a separate branch (`akoumpa/ci/claude-review-dtype-guideline`) — workflow files need a `workflow`-scoped token to push, so it lands as its own small PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
