### PR TITLE
ci: flag RoPE/precision-buffer dtype hazards in automated PR review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -40,6 +40,24 @@ jobs:
           that class's nested `ModelCapabilities` dataclass (static pattern) or
           inside the `get_capabilities(cls, config)` classmethod (dynamic
           dispatch pattern).
+        - Low-precision dtype hazards in RoPE / precision-sensitive buffers. Flag
+          when a module registers a floating-point buffer used to build rotary
+          tables — `inv_freq`, `freqs_cis`, or precomputed `cos`/`sin` — and the
+          model is cast to bf16/fp16 by a model-wide cast
+          (`self.to(config.torch_dtype)`, `model.to(dtype)`, or
+          `cast_model_to_dtype`). `nn.Module.to` rounds floating-point buffers, so
+          the rotary tables then get built from a bf16-rounded frequency, and a
+          later `.float()` / `.to(torch.float32)` on that buffer CANNOT recover the
+          lost bits. This silently degrades RoPE vs HuggingFace (which keeps
+          `inv_freq` in fp32) and surfaces as a large logit/KL divergence when a
+          checkpoint is reloaded in vanilla HF. Require one of: (a) recompute the
+          frequencies in float32 from config at cache-build/forward time, or (b)
+          list the rotary module (`"rotary_emb"`) or buffer
+          (`"inv_freq"`/`"freqs_cis"`) in `_keep_in_fp32_modules`. IMPORTANT: a raw
+          `self.to(dtype)` does NOT honor `_keep_in_fp32_modules` — the cast MUST go
+          through `cast_model_to_dtype(self, dtype)`, so also flag new model code
+          that casts the whole model with a raw `self.to(dtype)` / `model.to(dtype)`
+          instead of `cast_model_to_dtype`.
 
         Do NOT comment on:
         - Style preferences or formatting


### PR DESCRIPTION
Follow-up to #2549.

Adds a review guideline to `.github/workflows/claude-review.yml` so the automated reviewer flags the dtype-hazard class fixed in #2549: a rotary/precision buffer (`inv_freq`, `freqs_cis`, precomputed `cos`/`sin`) registered fp32 but rounded to bf16 by a model-wide cast (`self.to(config.torch_dtype)` / `cast_model_to_dtype`). A later `.float()` cannot recover the lost bits, silently degrading RoPE vs HuggingFace and surfacing as a large logit/KL divergence when a checkpoint is reloaded in vanilla HF.

The guideline asks the reviewer to require one of: (a) recompute frequencies in fp32 from config at cache-build/forward time, or (b) list the rotary module (`"rotary_emb"`) or buffer (`"inv_freq"`/`"freqs_cis"`) in `_keep_in_fp32_modules` — and to flag new model code that casts the whole model with a raw `self.to(dtype)` instead of `cast_model_to_dtype`.

Split out from #2549 because workflow-file changes require a token with `workflow` scope to push.
