### PR TITLE
fix(gemma4): FSDP2-safe kv-sharing + skip frozen audio tower on grad-accum

### DIFF
--- a/examples/vlm_finetune/gemma4/gemma4_4b.yaml
+++ b/examples/vlm_finetune/gemma4/gemma4_4b.yaml
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Configuration for fine-tuning Gemma 4 5B with MedPix dataset for image description
-# torchrun --nproc-per-node=2 examples/vlm_finetune/finetune.py -c examples/vlm_finetune/gemma4/gemma4_4b.yaml
+# Configuration for fine-tuning Gemma 4 E4B with MedPix dataset for image description
+# PR 2237 changed the default reduce_dtype from bfloat16 to fp32, which causes OOMs on E4B with 2 GPUs.
+# Although it can be made to run on 2 GPUs by setting reduce_dtype back to bfloat16 and AC=True, its still very 
+# tight. Hence, using 8 GPUs to run this recipe.
+# torchrun --nproc-per-node=8 examples/vlm_finetune/finetune.py -c examples/vlm_finetune/gemma4/gemma4_4b.yaml
 
 recipe: FinetuneRecipeForVLM
 

--- a/examples/vlm_finetune/gemma4/gemma4_4b_te.yaml
+++ b/examples/vlm_finetune/gemma4/gemma4_4b_te.yaml
@@ -15,8 +15,12 @@
 # Fine-tuning Gemma4 E4B with TransformerEngine DotProductAttention (FlashAttention-3).
 # attn_implementation: te  injects TE into all self_attn modules post-init,
 # enabling FA3 kernels without any model-specific code changes.
-#
-# torchrun --nproc-per-node=2 examples/vlm_finetune/finetune.py \
+
+# PR 2237 changed the default reduce_dtype from bfloat16 to fp32, which causes OOMs on E4B with 2 GPUs.
+# Although it can be made to run on 2 GPUs by setting reduce_dtype back to bfloat16 and AC=True, its still very 
+# tight. Hence, using 8 GPUs to run this recipe.
+
+# torchrun --nproc-per-node=8 examples/vlm_finetune/finetune.py \
 #   -c examples/vlm_finetune/gemma4/gemma4_4b_te.yaml
 
 recipe: FinetuneRecipeForVLM

--- a/examples/vlm_finetune/gemma4_joint_drafter/gemma4_4b_joint_drafter_medpix.yaml
+++ b/examples/vlm_finetune/gemma4_joint_drafter/gemma4_4b_joint_drafter_medpix.yaml
@@ -24,7 +24,7 @@
 # ``_shift_labels_left`` already.
 #
 # torchrun --nproc-per-node=8 examples/vlm_finetune/finetune.py \
-#     -c examples/vlm_finetune/gemma4/gemma4_4b_joint_drafter_multi_step.yaml
+#     -c examples/vlm_finetune/gemma4_joint_drafter/gemma4_4b_joint_drafter_medpix.yaml
 #
 # Requires: transformers>=5.8.0.dev
 
@@ -125,7 +125,7 @@ optimizer:
 # you see early base-loss spikes when bumping K, bump warmup to 50 first
 # before lowering drafter_loss_weight.
 lr_scheduler:
-  lr_warmup_steps: 25
+# 10% of max_steps as warmup is used by default which is what we want hence not setting lr_warmup_steps here.
   lr_decay_style: cosine
 
 freeze_config:

--- a/examples/vlm_finetune/gemma4_joint_drafter/gemma4_4b_joint_drafter_tulu_magicoder_mix.yaml
+++ b/examples/vlm_finetune/gemma4_joint_drafter/gemma4_4b_joint_drafter_tulu_magicoder_mix.yaml
@@ -21,8 +21,8 @@
 # turns, ``default_collate_fn`` does not produce a ``pixel_values`` tensor and
 # the base treats the batch as text-only.
 #
-# torchrun --nproc-per-node=8 examples/vlm_finetune/finetune.py \
-#     -c examples/vlm_finetune/gemma4/gemma4_4b_joint_drafter_text_mix.yaml
+# torchrun --nproc-per-node=8 examples/vlm_finetune/finetune.py -c \
+# examples/vlm_finetune/gemma4_joint_drafter/gemma4_4b_joint_drafter_tulu_magicoder_mix.yaml
 #
 # Requires: transformers>=5.8.0.dev
 
@@ -121,9 +121,8 @@ optimizer:
   weight_decay: 0.01
   betas: [0.9, 0.95]
 
-# 10% of max_steps as warmup
 lr_scheduler:
-  lr_warmup_steps: 200
+# 10% of max_steps as warmup is used by default which is what we want hence not setting lr_warmup_steps here.
   lr_decay_style: cosine
 
 freeze_config:

--- a/nemo_automodel/components/distributed/parallelizer.py
+++ b/nemo_automodel/components/distributed/parallelizer.py
@@ -886,6 +886,17 @@ def _apply_per_layer_compile(model: nn.Module) -> None:
     logger.info("Per-layer torch.compile applied to %d decoder layers", compiled_count)
 
 
+def _subtree_all_frozen(module: nn.Module) -> bool:
+    """Return True if ``module`` owns parameters and none of them require grad.
+
+    Used to skip FSDP-wrapping a frozen submodule that never runs in the forward
+    (e.g. the audio tower on image/text-only data); see
+    ``apply_fsdp2_sharding_recursively``.
+    """
+    params = list(module.parameters())
+    return len(params) > 0 and not any(p.requires_grad for p in params)
+
+
 def apply_fsdp2_sharding_recursively(
     module: nn.Module,
     mesh: DeviceMesh,
@@ -989,6 +1000,17 @@ def apply_fsdp2_sharding_recursively(
                     fsdp_units[i].set_modules_to_backward_prefetch(targets)
     else:
         for name, sub_module in module.named_children():
+            # A frozen audio tower never runs in the forward on image/text-only
+            # data, so wrapping its layers as their own FSDP units leaves those
+            # units never all-gathered. Under gradient accumulation FSDP's
+            # deferred post-backward then dereferences their (never-created)
+            # ``_unsharded_param`` and raises ``AttributeError``. Skip it so its
+            # params stay with the always-run root FSDP unit (which is still
+            # sharded, and whose frozen params have ``grad is None`` so the
+            # accumulate path is a no-op). Mirrors the audio_tower guard in
+            # ``components/moe/parallelizer.py``.
+            if name == "audio_tower" and _subtree_all_frozen(sub_module):
+                continue
             apply_fsdp2_sharding_recursively(
                 sub_module,
                 mesh,

--- a/nemo_automodel/components/distributed/parallelizer.py
+++ b/nemo_automodel/components/distributed/parallelizer.py
@@ -1001,7 +1001,7 @@ def apply_fsdp2_sharding_recursively(
     else:
         for name, sub_module in module.named_children():
             # A frozen audio tower never runs in the forward on image/text-only
-            # data, so wrapping its layers as their own FSDP units leaves those
+            # data (in gemma E4B and E2B models), so wrapping its layers as their own FSDP units leaves those
             # units never all-gathered. Under gradient accumulation FSDP's
             # deferred post-backward then dereferences their (never-created)
             # ``_unsharded_param`` and raises ``AttributeError``. Skip it so its

--- a/nemo_automodel/components/distributed/pipelining/hf_utils.py
+++ b/nemo_automodel/components/distributed/pipelining/hf_utils.py
@@ -318,6 +318,15 @@ def create_pipeline_forward_gemma4_text() -> Callable:
 
         hidden_states = inputs_embeds
         config_layer_types = getattr(self.config, "layer_types", None)
+        # HF transfomers v5.8.1+ Gemma4 attention threads a single mutable mapping through every decoder
+        # layer for kv-sharing: "full-length" layers (store_full_length_kv) write their
+        # keys/values into it and kv-shared layers (is_kv_shared_layer) read them back.
+        # The decoder-layer kwarg defaults to None, so a store layer would execute
+        # ``None[layer_type] = ...`` -> TypeError. Create one per stage and thread it,
+        # mirroring HF's Gemma4TextModel.forward. gemma-4-31B, 26B-A4B have num_kv_shared_layers=0
+        # (no readers, store is a harmless no-op write); for a kv-sharing model split
+        # across PP stages only within-stage sharing would work here.
+        shared_kv_states: dict = {}
         if hasattr(self, "layers") and self.layers is not None:
             layer_iter = self.layers.values() if hasattr(self.layers, "values") else self.layers
             for decoder_layer in layer_iter:
@@ -340,6 +349,7 @@ def create_pipeline_forward_gemma4_text() -> Callable:
                     cache_position=cache_position,
                     position_embeddings=position_embeddings,
                     padding_mask=padding_mask,
+                    shared_kv_states=shared_kv_states,
                 )
                 hidden_states = layer_outputs[0] if isinstance(layer_outputs, tuple) else layer_outputs
 

--- a/nemo_automodel/components/models/gemma4_moe/model.py
+++ b/nemo_automodel/components/models/gemma4_moe/model.py
@@ -19,7 +19,8 @@ GroupedExperts backend, enabling Expert Parallelism (EP) via the standard
 MoE parallelizer.
 """
 
-from typing import Any, Optional, Union
+from collections.abc import MutableMapping
+from typing import Any, Iterator, Optional, Union
 
 import torch
 import torch.nn as nn
@@ -87,6 +88,60 @@ from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 from .cp_attention import attach_gemma4_cp_ring_attention, gemma4_vision_group_ids
 from .cp_batch import make_contiguous_shard_cp_batch_and_ctx
 from .state_dict_adapter import Gemma4MoEStateDictAdapter
+
+
+class _FSDPSafeSharedKVStates(MutableMapping):
+    """A dict-like store for Gemma4 key/value sharing that is safe to pass through FSDP2.
+
+    What Gemma4 needs:
+        In Gemma4, the later "kv-shared" attention layers do not compute their
+        own keys/values -- they reuse the keys/values produced by an earlier
+        layer. HuggingFace implements this by passing ONE shared key/value store
+        into every decoder layer's ``forward()``: the earlier layer writes its
+        keys/values into the store, and the later layers read them back out. This
+        only works if every layer is handed the *same* store object.
+
+    Why a plain ``dict`` breaks under FSDP2:
+        With FSDP2 each decoder layer is wrapped as its own unit, and the default
+        mixed-precision setting (``cast_forward_inputs=True``) makes FSDP2 look at
+        every argument passed to a layer and cast its float tensors to bf16. It
+        does this with torch's ``_apply_to_tensors``, which, whenever it sees a
+        ``dict`` (or ``list``/``tuple``/``set``/...), builds a brand-new copy of
+        it. So if the shared store is a plain ``dict``, each layer receives its
+        own private copy: the earlier layer's writes land in a copy that is thrown
+        away, and the later layers read from an empty copy -- which raises
+        ``KeyError: 'sliding_attention'``.
+
+    Why this class fixes it:
+        ``_apply_to_tensors`` only copies the specific types it knows about
+        (``dict``, ``OrderedDict``, ``list``, ``tuple``, ``set``, namedtuples,
+        dataclasses, ``PackedSequence``); any other object it leaves alone and
+        passes straight through. This class behaves like a dict (it implements
+        ``MutableMapping``) but is deliberately NOT a ``dict`` subclass, so FSDP2
+        hands the SAME instance to every layer and the writes are preserved.
+
+        Note: this dict-based sharing is how transformers 5.8.x works. In 5.5 the
+        shared keys/values were stored on the ``Cache`` object instead (which
+        FSDP2 also passes through untouched), so this problem did not exist there.
+    """
+
+    def __init__(self) -> None:
+        self._store: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
+
+    def __getitem__(self, key: str) -> tuple[torch.Tensor, torch.Tensor]:
+        return self._store[key]
+
+    def __setitem__(self, key: str, value: tuple[torch.Tensor, torch.Tensor]) -> None:
+        self._store[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self._store[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._store)
+
+    def __len__(self) -> int:
+        return len(self._store)
 
 
 # ---------------------------------------------------------------------------
@@ -615,9 +670,13 @@ class Gemma4MoETextModelBackend(nn.Module):
         for layer_type in set(self.config.layer_types):
             position_embeddings[layer_type] = self.rotary_emb(hidden_states, position_ids, layer_type)
 
-        # Single dict shared across all layers so kv-sharing layers can reuse the
-        # full-length keys/values cached by earlier layers (HF contract).
-        shared_kv_states: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
+        # One shared key/value store passed to every layer: the later kv-shared
+        # layers reuse the keys/values that earlier layers write here. It must be
+        # an _FSDPSafeSharedKVStates and NOT a plain dict -- under FSDP2 each
+        # layer is wrapped separately and FSDP2's input casting makes a fresh copy
+        # of any plain dict per layer, so the writes would be lost. See
+        # _FSDPSafeSharedKVStates for the full explanation.
+        shared_kv_states = _FSDPSafeSharedKVStates()
         for decoder_layer in self.layers.values():
             hidden_states = decoder_layer(
                 hidden_states,
@@ -922,6 +981,20 @@ class Gemma4ForConditionalGeneration(HFCheckpointingMixin, HFGemma4ForConditiona
             # Dense path — delegate to HF forward (which already supports
             # logits_to_keep + output_hidden_states and returns a ModelOutput
             # carrying logits and hidden_states).
+            #
+            # Gemma4 HF transformers shares keys/values between attention layers by passing
+            # one shared key/value store into every decoder layer (earlier layers
+            # write it, later "kv-shared" layers read it). NOTE: this dict-based
+            # design is new in transformers 5.8.x; 5.5 stored the shared
+            # keys/values on the Cache object instead.
+            #
+            # Under FSDP2 each layer is wrapped separately and the input-casting
+            # step (cast_forward_inputs) makes a fresh copy of any plain dict
+            # before each layer runs, so the earlier layer's writes never reach
+            # the later layers -> KeyError. Pass an _FSDPSafeSharedKVStates
+            # instead, which FSDP2 leaves as one shared object. setdefault avoids
+            # overwriting a store a caller already provided (e.g. the drafter).
+            kwargs.setdefault("shared_kv_states", _FSDPSafeSharedKVStates())
             return super().forward(
                 input_ids=input_ids,
                 position_ids=position_ids,


### PR DESCRIPTION
# What does this PR do ?

1. HF transformers 5.8 threads a mutable shared_kv_states dict through decoder layers; FSDP2's cast_forward_inputs deep-copies it per layer → KeyError: 'sliding_attention'. Fixed with a non-dict MutableMapping holder FSDP2 passes by reference.
2. A frozen, never-run audio_tower wrapped as its own FSDP unit crashes the deferred grad-accum backward (FSDPParam has no _unsharded_param); skip wrapping it so its params live on the always-run root unit (mirrors the MoE parallelizer's existing guard).
3. Add empty shared_kv_states through gemma4 pipeline-parallel forward (its a no-op, since shared_kv_states are used only by E2B and E4B) and pipeline-parallel forward is for 31B model
4. Updates gemma_4b.yaml and gemma_4b_te.yaml to use 8 GPUs. #2237  changed the default reduce_dtype from bfloat16 to fp32, which causes OOMs on E4B with 2 GPUs.
Although it can be made to run on 2 GPUs by setting reduce_dtype back to bfloat16 and AC=True, its still very tight. Hence updated to use 8 GPUs

Loss curves for both of these comparing with the previous 2 GPU run:

<img width="1002" height="640" alt="Screenshot 2026-06-15 at 8 57 05 PM" src="https://github.com/user-attachments/assets/35bea43e-5d2a-4292-98c6-496084d919ea" />


# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
