### PR TITLE
fix(ci): set node counts for multi-node VLM finetune recipes

### DIFF
--- a/examples/vlm_finetune/mistral3p5/mistral3p5_128b_medpix.yaml
+++ b/examples/vlm_finetune/mistral3p5/mistral3p5_128b_medpix.yaml
@@ -127,3 +127,8 @@ wandb:
   project: huiyingl_workspace
   entity: Nemo-automodel
   name: mistral3p5_128b_medpix
+
+ci:
+  recipe_owner: akoumpa
+  nodes: 8                          # TP=8 * PP=8 = 64 GPUs = 8 nodes x 8 GPUs
+  time: "00:30:00"

--- a/examples/vlm_finetune/mistral3p5/mistral3p5_128b_medpix_lora.yaml
+++ b/examples/vlm_finetune/mistral3p5/mistral3p5_128b_medpix_lora.yaml
@@ -125,3 +125,8 @@ lr_scheduler:
 #   project: <your_wandb_project>
 #   entity: <your_wandb_entity>
 #   name: <your_wandb_name>
+
+ci:
+  recipe_owner: akoumpa
+  nodes: 8                          # TP=8 * PP=8 = 64 GPUs = 8 nodes x 8 GPUs
+  time: "00:30:00"

--- a/examples/vlm_finetune/qwen3_5/qwen3_5_27b_tp4pp4.yaml
+++ b/examples/vlm_finetune/qwen3_5/qwen3_5_27b_tp4pp4.yaml
@@ -102,6 +102,6 @@ optimizer:
 #   name: <your-run-name>
 
 ci:
-  recipe_owner: akoumpa
+  recipe_owner: HuiyingLi
   nodes: 2                          # TP=4 * PP=4 = 16 GPUs = 2 nodes x 8 GPUs
   time: "00:30:00"

--- a/examples/vlm_finetune/qwen3_5/qwen3_5_27b_tp4pp4.yaml
+++ b/examples/vlm_finetune/qwen3_5/qwen3_5_27b_tp4pp4.yaml
@@ -100,3 +100,8 @@ optimizer:
 #   project: <your-project>
 #   entity: <your-entity>
 #   name: <your-run-name>
+
+ci:
+  recipe_owner: akoumpa
+  nodes: 2                          # TP=4 * PP=4 = 16 GPUs = 2 nodes x 8 GPUs
+  time: "00:30:00"


### PR DESCRIPTION
## What does this PR do?

Three `examples/vlm_finetune` recipes fail in release-scope CI with:

```
ValueError: world_size (8) must be divisible by (tp_size * cp_size * pp_size)
```

Release CI auto-discovers every `examples/vlm_finetune/**/*.yaml` and runs each on a single 8-GPU node unless the recipe's `ci:` section requests more nodes. These three recipes had **no `ci:` section**, so they ran with `world_size=8` while their parallelism requires more GPUs, and `_infer_dp_size` raised.

This adds a `ci:` section to each recipe requesting the node count its TP×CP×PP product needs, so the device mesh builds with `dp_size=1`:

| Recipe | TP×CP×PP | GPUs needed | `ci.nodes` (×8 GPUs) |
|---|---|---|---|
| `mistral3p5_128b_medpix` | 8×1×8 = 64 | 64 | 8 |
| `mistral3p5_128b_medpix_lora` | 8×1×8 = 64 | 64 | 8 |
| `qwen3_5_27b_tp4pp4` | 4×1×4 = 16 | 16 | 2 |

## Changelog

- Add a `ci:` section (`recipe_owner`, `nodes`, `time`) to the three VLM finetune recipes above so release CI allocates enough nodes for their TP/PP product instead of failing on the world-size divisibility check.

## Linear

Fixes [AM-434](https://linear.app/nvidia/issue/AM-434/world-size-not-divisible-by-tensor-context-and-pipeline-parallel).

## Pre-checks

- [x] DCO sign-off present.
- [x] YAML validated; `world_size` now divisible by `tp_size * cp_size * pp_size` for all three (`dp_size=1`).
- [ ] Heavy CI pipeline still needs a `/ok to test <sha>` trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
