### PR TITLE
fix(recipe): reshard MoE experts after forward in nemotron_nano_v3_cp_test

### DIFF
--- a/examples/llm_finetune/nemotron/nemotron_nano_v3_cp_test.yaml
+++ b/examples/llm_finetune/nemotron/nemotron_nano_v3_cp_test.yaml
@@ -44,6 +44,13 @@ distributed:
   pp_size: 1
   ep_size: 4
   sequence_parallel: false
+  moe:
+    # cp=2/ep=4 puts experts on a 2-wide ep_shard FSDP dim; with the default
+    # reshard_after_forward=False the all-gathered experts stay resident across the
+    # whole forward (~11.5 GB/rank), OOMing this 30B model on 8xH100 at step 1 once
+    # Adam state is allocated. Resharding after forward is numerically transparent
+    # (CP-parity is unaffected) and frees that headroom.
+    reshard_after_forward: true
 
 loss_fn:
   _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy


### PR DESCRIPTION
## Problem

`nemotron_nano_v3_cp_test` (cp=2 / ep=4) OOMs on 8×H100 at step 1 — e.g. nemo-ci job [337980528](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/337980528). The CI log shows step 0 completing at **62.45 GiB**, then `torch.OutOfMemoryError` in step 1's forward while FSDP all-gathers the MoE expert weights (`moe/layers.py` `self.experts(...)` → `foreach_all_gather_copy_out`).

## Root cause

With `cp_size=2, ep_size=4` the non-PP mesh is 8, so `ep_shard_size = 8 // 4 = 2` (`distributed/mesh_utils.py`). Experts are therefore sharded across **both** EP (4-way) **and** a 2-wide `ep_shard` FSDP dimension (`moe/parallelizer.py::apply_fsdp`). FSDP-sharded experts must be all-gathered before the grouped GEMM, and with the default `reshard_after_forward=False` those gathered weights stay resident for the entire forward (~11.5 GB/rank). Once Adam state is allocated on step 0's `optimizer.step()`, step 1's forward crosses the 80 GiB budget.

This is a memory/throughput tradeoff, not a bug: the sibling `cp=1 / ep=8` config has `ep_shard=1` (pure EP, no all-gather) and fits. `reshard_after_forward=True` frees the gathered experts per layer and only re-gathers them in backward — numerically transparent, so the CP-parity comparison this recipe performs is unaffected.

## Fix

Set `distributed.moe.reshard_after_forward: true` in the recipe.

## Verification — 8×H100 (cw-dfw), identical container/source/model, only `reshard_after_forward` differs

| `reshard_after_forward` | step 0 | step 1–4 peak | result |
|---|---|---|---|
| `false` (baseline) | 62.45 GiB | — | **OOM in step 1**, same expert all-gather as job 337980528 |
| `true` (this PR) | 45.35 GiB | 60.05 GiB | **all 5 steps, exit 0** |

The baseline reproduces the CI OOM exactly (same 62.45 GiB at step 0, same OOM site); the fix holds peak at ~60 GiB, comfortably under budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)