### PR TITLE
fix(test): load checkpoint-robustness HF reference via device_map

### DIFF
--- a/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
+++ b/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
@@ -534,12 +534,22 @@ def test_checkpoint_robustness():
             hf_kwargs["device_map"] = "auto"
         if original_quantization_config is not None:
             hf_kwargs["quantization_config"] = original_quantization_config
+        # Load the reference model straight onto the target GPU. Materialising a
+        # 14B checkpoint on CPU and then ``.to(device)`` costs ~50-225s, and that
+        # rank-0-only stall trips the NCCL watchdog while the other ranks idle at
+        # the post-phase ``_barrier()`` below (the failure mode this test hit on
+        # large models). ``device_map`` places weights on the GPU directly (~12s).
+        # trust_remote_code models need the ``_no_meta`` real-device init, which is
+        # incompatible with device_map's meta dispatch, and the auto/quantized
+        # paths set ``device_map`` themselves -- so restrict this to standard-HF loads.
+        if "device_map" not in hf_kwargs and not trust_remote_code and original_quantization_config is None:
+            hf_kwargs["device_map"] = {"": device}
 
         if is_peft:
             from peft import PeftModel
 
             with _no_meta:
-                if hf_device_map_auto:
+                if "device_map" in hf_kwargs:
                     base_model = AutoModelForCausalLM.from_pretrained(original_pretrained_path, **hf_kwargs)
                 else:
                     base_model = _fix_meta_rotary_embeddings(
@@ -586,7 +596,7 @@ def test_checkpoint_robustness():
         else:
             _prepopulate_hf_dynamic_modules_cache(consolidated_dir)
             with _no_meta:
-                if hf_device_map_auto:
+                if "device_map" in hf_kwargs:
                     hf_model = AutoModelForCausalLM.from_pretrained(str(consolidated_dir), **hf_kwargs)
                 else:
                     hf_model = _fix_meta_rotary_embeddings(


### PR DESCRIPTION
## What

`phi_4_squad` / `phi_4_squad_peft` checkpoint-robustness CI failures reported as `Signal/OOM-Kill` (e.g. [job 337980585](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/337980585)) are **not** host-RAM OOMs — they are misclassified **NCCL watchdog timeouts**.

The test's Phase 4 loads a vanilla-HF reference model on **rank 0 only** (`AutoModelForCausalLM.from_pretrained` → CPU → `.to(device)`); for a 14B checkpoint that is ~50 s warm / ~225 s cold. The other 7 ranks idle at the post-phase `_barrier()`, so the rank-0 stall overruns the watchdog (`dist_env.timeout_minutes`) → peers abort (SIGABRT), rank 0 is SIGKILL'd in teardown → nemo-ci's extractor stamps the rank-0 SIGKILL as `Signal/OOM-Kill`.

## Changelog

- Load the checkpoint-robustness HF reference model **straight onto the GPU via `device_map={"": device}`** (~12 s vs 50-225 s) for standard-HF loads. `low_cpu_mem_usage=True` does not help (still ~48 s). `trust_remote_code` (needs `_no_meta`), quantized, and `device_map=auto` paths are unchanged.

## Verification

Reproduced and validated on **8×H100** (offline, full `check_resume`, matching CI). Unfixed code fails identically to CI (rank 0 SIGKILL / peers SIGABRT at the Phase-4 barrier; confirmed it is a watchdog timeout, not a host OOM — a `--mem=160G` cap *survived* by reclaiming page cache, and an uncapped run used only 260 GB of 2 TB). With the fix:

| `timeout_minutes` | Phase 3 KL | Phase 4 HF KL (thr 2e-3) | Phase 6 resume | result |
|---|---|---|---|---|
| **2** | 0.0 | 3.17e-4 | verified ✓ | **rc=0** ✅ |
| **1** | 0.0 | 6.21e-4 | verified ✓ | **rc=0** ✅ |

Passes end-to-end through Phase 6 (the exact phase CI died at), KL asserts green, **no NCCL timeout** — while keeping `dist_env.timeout_minutes` at the usual 1-2.

> `phi_4_squad` validated directly; `phi_4_squad_peft` (also in AM-468) goes through the same modified branch — the PR pipeline will confirm it.

## Pre-checks

- [x] `ruff check` / `ruff format` clean
- [x] DCO sign-off

Linear: [AM-468](https://linear.app/nvidia/issue/AM-468/tests-terminated-by-sigkill-due-to-oom-with-no-specific-codelevel)
