### PR TITLE
fix(peft): LoRA MLP QLoRA/PP/gemma3n fixes (AM-435, AM-447, AM-453)

### DIFF
--- a/nemo_automodel/components/_peft/lora.py
+++ b/nemo_automodel/components/_peft/lora.py
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import functools
 import logging
 import math
-import types
 from dataclasses import dataclass, field
 from typing import Any, Literal, Optional
 
@@ -302,12 +300,10 @@ class LinearLoRA(nn.Linear):
             use_memory_efficient_lora = self._should_use_memory_efficient_lora(x)
             if use_memory_efficient_lora:
                 if self.dropout_position == "pre" or not self.training or self.dropout_p == 0.0:
-                    return LoRATritonFunction.apply(
-                        x, self.lora_A.weight, self.lora_B.weight, self.scale, x.dtype, False, res
+                    return apply_memory_efficient_lora(
+                        x, self.lora_A.weight, self.lora_B.weight, self.scale, False, res
                     )
-                lora_res = LoRATritonFunction.apply(
-                    x, self.lora_A.weight, self.lora_B.weight, self.scale, x.dtype, False
-                )
+                lora_res = apply_memory_efficient_lora(x, self.lora_A.weight, self.lora_B.weight, self.scale, False)
             else:
                 lora_res = self.lora_B(self.lora_A(x) * self.scale)
             if self.dropout_position == "post":
@@ -395,10 +391,8 @@ class TritonLinearLoRA(LinearLoRA):
             x = F.dropout(x, p=self.dropout_p, training=self.training)
         if self.use_memory_efficient_lora:
             if self.dropout_position == "pre" or not self.training or self.dropout_p == 0.0:
-                return LoRATritonFunction.apply(
-                    x, self.lora_A.weight, self.lora_B.weight, self.scale, x.dtype, True, res
-                )
-            lora_res = LoRATritonFunction.apply(x, self.lora_A.weight, self.lora_B.weight, self.scale, x.dtype, True)
+                return apply_memory_efficient_lora(x, self.lora_A.weight, self.lora_B.weight, self.scale, True, res)
+            lora_res = apply_memory_efficient_lora(x, self.lora_A.weight, self.lora_B.weight, self.scale, True)
         else:
             lora_res = self.lora_B(self.lora_A(x) * self.scale)
         if self.dropout_position == "post":
@@ -674,71 +668,7 @@ def apply_lora_to_linear_modules(
     if n_fused_mlps:
         logger.info("Fused %d LoRA SwiGLU/ReLU2 MLP module(s) for memory-efficient backward.", n_fused_mlps)
 
-    patch_gemma3n_inplace_lora_views(model)
-
     return num_modules_matched
-
-
-def patch_gemma3n_inplace_lora_views(model: nn.Module) -> int:
-    """Make gemma3n's ``per_layer_model_projection`` LoRA output safe to mutate in place.
-
-    transformers gemma3n ``Gemma3nTextModel.project_per_layer_inputs`` mutates the output of
-    ``self.per_layer_model_projection(inputs_embeds)`` in place (``per_layer_projection *= ...``).
-    When that projection is a LoRA-patched linear using the memory-efficient
-    :class:`LoRATritonFunction`, the returned tensor is a view of the custom autograd Function's
-    output. Some torch versions flag such a view and forbid the in-place op with
-    ``RuntimeError: Output 0 of LoRATritonFunctionBackward is a view and is being modified inplace``.
-
-    This wraps the (single) ``per_layer_model_projection`` module's ``forward`` so it returns a
-    fresh, non-view tensor via :meth:`~torch.Tensor.clone`. ``clone`` is an identity in the autograd
-    graph (gradients pass straight through), so numerics and gradients are unchanged; it only
-    detaches the output from the Function's view so the downstream in-place op is legal. The clone
-    is scoped to this one gemma3n module, so non-gemma3n LoRA pays nothing.
-
-    Detection is structural (a module that owns both a ``per_layer_model_projection`` submodule and
-    a ``project_per_layer_inputs`` method) rather than class-name based, so it keeps working across
-    transformers renames and applies wherever the text backbone is nested inside a VLM wrapper. It
-    is a no-op when the projection is not a LoRA module (e.g. it was excluded from ``target_modules``),
-    when it was already wrapped, or when transformers lacks these attributes.
-
-    Args:
-        model: The (already LoRA-patched) model to scan and wrap in place.
-
-    Returns:
-        int: Number of ``per_layer_model_projection`` modules wrapped.
-    """
-    n_wrapped = 0
-    for module in model.modules():
-        proj = getattr(module, "per_layer_model_projection", None)
-        if proj is None or not callable(getattr(module, "project_per_layer_inputs", None)):
-            continue
-        # Only the memory-efficient LoRA path returns a view; a plain Linear or the non-efficient
-        # LoRA path (res + lora_res) already returns a fresh tensor, so wrapping is unnecessary.
-        if not isinstance(proj, LinearLoRA) or not getattr(proj, "use_memory_efficient_lora", False):
-            continue
-        if getattr(proj, "_nemo_inplace_view_safe", False):
-            continue
-
-        orig_forward = proj.forward
-
-        @functools.wraps(orig_forward.__func__ if hasattr(orig_forward, "__func__") else orig_forward)
-        def _clone_forward(self, x, _orig=orig_forward):
-            out = _orig(x)
-            # ``clone`` only matters when the output is a view of a custom-Function output; it is a
-            # cheap autograd identity otherwise. Guard on tensor-ness to stay robust to odd returns.
-            return out.clone() if isinstance(out, torch.Tensor) else out
-
-        proj.forward = types.MethodType(_clone_forward, proj)
-        proj._nemo_inplace_view_safe = True
-        n_wrapped += 1
-
-    if n_wrapped:
-        logger.info(
-            "Patched %d gemma3n per_layer_model_projection LoRA module(s) to return a non-view "
-            "tensor (project_per_layer_inputs mutates it in place).",
-            n_wrapped,
-        )
-    return n_wrapped
 
 
 class LoRATritonFunction(torch.autograd.Function):
@@ -770,11 +700,14 @@ class LoRATritonFunction(torch.autograd.Function):
 
         Reshapes 3D tensors into 2D and then calls either Triton kernels or PyTorch matmuls. When ``res`` is
         provided, the residual is added in-place into the LoRA output to avoid allocating a separate add result.
+
+        Always returns a **2D** tensor; the caller restores the original leading dimensions. Keeping the
+        ``(N, out) -> (bs, seq, out)`` reshape *outside* this ``autograd.Function`` means the Function's output
+        is never a view, so a downstream consumer may safely mutate the LoRA output in place (the reshape done
+        by the caller is an ordinary autograd view, which supports in-place ops).
         """
-        reshape = x.dim() == 3
-        if reshape:
-            bs, seq_len, d = x.shape
-            x = x.reshape(-1, d)
+        if x.dim() == 3:
+            x = x.reshape(-1, x.shape[-1])
             if res is not None:
                 res = res.reshape(-1, res.shape[-1])
 
@@ -786,8 +719,6 @@ class LoRATritonFunction(torch.autograd.Function):
         if res is not None:
             lora_res.add_(res)
 
-        if reshape:
-            return lora_res.view(bs, seq_len, -1)
         return lora_res
 
     @staticmethod
@@ -800,11 +731,16 @@ class LoRATritonFunction(torch.autograd.Function):
         """
         x, lora_A, lora_B = ctx.saved_tensors
         scale = ctx.scale
-        d_res = d_y if ctx.has_residual and ctx.needs_input_grad[6] else None
 
         reshape = x.dim() == 3
         if reshape:
             bs, seq_len, d = x.shape
+        # forward now returns a 2D output, so d_y arrives 2D; the residual input kept its original
+        # (possibly 3D) shape, so its gradient must be reshaped back to match that input.
+        d_res = None
+        if ctx.has_residual and ctx.needs_input_grad[6]:
+            d_res = d_y.reshape(bs, seq_len, -1) if reshape else d_y
+        if reshape:
             d_y = d_y.reshape(-1, d_y.shape[-1])
             x = x.reshape(-1, d)
 
@@ -836,3 +772,17 @@ class LoRATritonFunction(torch.autograd.Function):
         if ctx.num_inputs == 6:
             return gradients + (None,)
         return gradients
+
+
+def apply_memory_efficient_lora(x, lora_A, lora_B, scale, use_triton_kernel, res=None):
+    """Run :class:`LoRATritonFunction` and restore the input's leading dimensions.
+
+    ``LoRATritonFunction.forward`` returns a 2D tensor (its reshape is intentionally kept outside the
+    autograd Function so the output is never a view). Reshape back to the input rank here; the result
+    is an ordinary autograd view, which — unlike a custom-Function output view — a downstream consumer
+    may mutate in place (e.g. transformers' gemma3n ``project_per_layer_inputs``).
+    """
+    out = LoRATritonFunction.apply(x, lora_A, lora_B, scale, x.dtype, use_triton_kernel, res)
+    if x.dim() == 3:
+        out = out.reshape(*x.shape[:-1], -1)
+    return out

--- a/nemo_automodel/components/_peft/lora.py
+++ b/nemo_automodel/components/_peft/lora.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
 import logging
 import math
+import types
 from dataclasses import dataclass, field
 from typing import Any, Literal, Optional
 
@@ -672,7 +674,71 @@ def apply_lora_to_linear_modules(
     if n_fused_mlps:
         logger.info("Fused %d LoRA SwiGLU/ReLU2 MLP module(s) for memory-efficient backward.", n_fused_mlps)
 
+    patch_gemma3n_inplace_lora_views(model)
+
     return num_modules_matched
+
+
+def patch_gemma3n_inplace_lora_views(model: nn.Module) -> int:
+    """Make gemma3n's ``per_layer_model_projection`` LoRA output safe to mutate in place.
+
+    transformers gemma3n ``Gemma3nTextModel.project_per_layer_inputs`` mutates the output of
+    ``self.per_layer_model_projection(inputs_embeds)`` in place (``per_layer_projection *= ...``).
+    When that projection is a LoRA-patched linear using the memory-efficient
+    :class:`LoRATritonFunction`, the returned tensor is a view of the custom autograd Function's
+    output. Some torch versions flag such a view and forbid the in-place op with
+    ``RuntimeError: Output 0 of LoRATritonFunctionBackward is a view and is being modified inplace``.
+
+    This wraps the (single) ``per_layer_model_projection`` module's ``forward`` so it returns a
+    fresh, non-view tensor via :meth:`~torch.Tensor.clone`. ``clone`` is an identity in the autograd
+    graph (gradients pass straight through), so numerics and gradients are unchanged; it only
+    detaches the output from the Function's view so the downstream in-place op is legal. The clone
+    is scoped to this one gemma3n module, so non-gemma3n LoRA pays nothing.
+
+    Detection is structural (a module that owns both a ``per_layer_model_projection`` submodule and
+    a ``project_per_layer_inputs`` method) rather than class-name based, so it keeps working across
+    transformers renames and applies wherever the text backbone is nested inside a VLM wrapper. It
+    is a no-op when the projection is not a LoRA module (e.g. it was excluded from ``target_modules``),
+    when it was already wrapped, or when transformers lacks these attributes.
+
+    Args:
+        model: The (already LoRA-patched) model to scan and wrap in place.
+
+    Returns:
+        int: Number of ``per_layer_model_projection`` modules wrapped.
+    """
+    n_wrapped = 0
+    for module in model.modules():
+        proj = getattr(module, "per_layer_model_projection", None)
+        if proj is None or not callable(getattr(module, "project_per_layer_inputs", None)):
+            continue
+        # Only the memory-efficient LoRA path returns a view; a plain Linear or the non-efficient
+        # LoRA path (res + lora_res) already returns a fresh tensor, so wrapping is unnecessary.
+        if not isinstance(proj, LinearLoRA) or not getattr(proj, "use_memory_efficient_lora", False):
+            continue
+        if getattr(proj, "_nemo_inplace_view_safe", False):
+            continue
+
+        orig_forward = proj.forward
+
+        @functools.wraps(orig_forward.__func__ if hasattr(orig_forward, "__func__") else orig_forward)
+        def _clone_forward(self, x, _orig=orig_forward):
+            out = _orig(x)
+            # ``clone`` only matters when the output is a view of a custom-Function output; it is a
+            # cheap autograd identity otherwise. Guard on tensor-ness to stay robust to odd returns.
+            return out.clone() if isinstance(out, torch.Tensor) else out
+
+        proj.forward = types.MethodType(_clone_forward, proj)
+        proj._nemo_inplace_view_safe = True
+        n_wrapped += 1
+
+    if n_wrapped:
+        logger.info(
+            "Patched %d gemma3n per_layer_model_projection LoRA module(s) to return a non-view "
+            "tensor (project_per_layer_inputs mutates it in place).",
+            n_wrapped,
+        )
+    return n_wrapped
 
 
 class LoRATritonFunction(torch.autograd.Function):

--- a/nemo_automodel/components/_peft/lora_mlp.py
+++ b/nemo_automodel/components/_peft/lora_mlp.py
@@ -212,7 +212,19 @@ def _fusible(module) -> bool:
         return False
     if getattr(module, "dropout_p", 0.0) and module.training:
         return False
-    for w in (module.weight, lora_A.weight, lora_B.weight):
+    # QLoRA / quantized base weights are stored as packed buffers (e.g. bitsandbytes 4-bit
+    # carries a ``quant_state`` and a flattened weight shaped like ``(1, out*in/2)`` rather than
+    # a 2D ``(out_features, in_features)`` matrix). The fused path calls ``F.linear(x, base_weight)``
+    # directly, which fails for a packed buffer ("mat1 and mat2 shapes cannot be multiplied"); bail
+    # so the per-linear ``LinearLoRA.forward`` path (which dequantizes the base) handles it instead.
+    base_w = module.weight
+    if getattr(base_w, "quant_state", None) is not None or getattr(module, "quant_state", None) is not None:
+        return False
+    out_features = getattr(module, "out_features", None)
+    in_features = getattr(module, "in_features", None)
+    if out_features is not None and in_features is not None and tuple(base_w.shape) != (out_features, in_features):
+        return False
+    for w in (base_w, lora_A.weight, lora_B.weight):
         if isinstance(w, DTensor):
             return False
     return True

--- a/nemo_automodel/components/_peft/lora_mlp.py
+++ b/nemo_automodel/components/_peft/lora_mlp.py
@@ -198,6 +198,18 @@ class LoRASwiGLUMLPFunction(torch.autograd.Function):
             d_x = torch.addmm(d_e @ gW, d_R, gA)
             d_x = d_x.addmm_(d_g, uW).addmm_(d_Q, uA).view(ctx.orig_shape)
 
+        # Each returned gradient must live on the same device as its corresponding input. Under
+        # pipeline-parallel graph construction torch tracks the LoRA parameters on the meta device
+        # while the activations (and the grads computed from them) are on cuda, so it rejected the
+        # cuda grads ("invalid gradient ... expected device meta but got cuda"). Move each LoRA grad
+        # onto its parameter's device: a no-op in normal single-device training, and correct in the
+        # PP/meta graph pass (the real gradients still flow on the cuda execution passes).
+        d_gA, d_gB = d_gA.to(gA.device), d_gB.to(gB.device)
+        d_uA, d_uB = d_uA.to(uA.device), d_uB.to(uB.device)
+        d_dA, d_dB = d_dA.to(dA.device), d_dB.to(dB.device)
+        if d_x is not None:
+            d_x = d_x.to(x.device)
+
         # order matches forward(x, gW, gA, gB, gS, uW, uA, uB, uS, dW, dA, dB, dS)
         return (d_x, None, d_gA, d_gB, None, None, d_uA, d_uB, None, None, d_dA, d_dB, None)
 
@@ -316,6 +328,14 @@ class LoRAReLU2MLPFunction(torch.autograd.Function):
         d_x = None
         if needs_x:
             d_x = torch.addmm(d_e @ uW, d_Q, uA).view(ctx.orig_shape)
+
+        # See LoRASwiGLUMLPFunction.backward: return each LoRA grad on its parameter's device so the
+        # pipeline-parallel meta graph pass (params on meta, activations on cuda) doesn't reject the
+        # cuda grads. No-op in normal single-device training.
+        d_uA, d_uB = d_uA.to(uA.device), d_uB.to(uB.device)
+        d_dA, d_dB = d_dA.to(dA.device), d_dB.to(dB.device)
+        if d_x is not None:
+            d_x = d_x.to(x.device)
 
         # order matches forward(x, uW, uA, uB, uS, dW, dA, dB, dS)
         return (d_x, None, d_uA, d_uB, None, None, d_dA, d_dB, None)

--- a/tests/unit_tests/_peft/test_lora.py
+++ b/tests/unit_tests/_peft/test_lora.py
@@ -429,3 +429,120 @@ class TestTELinearLoRA:
         assert patched.lora_B.weight.grad is not None, "lora_B should have gradients"
         assert torch.isfinite(patched.lora_A.weight.grad).all(), "lora_A gradients should be finite"
         assert torch.isfinite(patched.lora_B.weight.grad).all(), "lora_B gradients should be finite"
+
+
+class _Gemma3nTextModelMini(nn.Module):
+    """Minimal stand-in for transformers ``Gemma3nTextModel`` exercising the bug.
+
+    Owns a ``per_layer_model_projection`` linear and a ``project_per_layer_inputs`` method whose
+    first op mutates the projection output in place (``*=``), exactly like the real HF method.
+    """
+
+    class _Cfg:
+        num_hidden_layers = 3
+
+    class _Norm(nn.Module):
+        def __init__(self, d):
+            super().__init__()
+            self.weight = nn.Parameter(torch.zeros(d))
+
+        def forward(self, x):
+            var = x.float().pow(2).mean(-1, keepdim=True)
+            return (x * torch.rsqrt(var + 1e-6).to(x.dtype)) * (1.0 + self.weight)
+
+    def __init__(self, p=8, d=5, nlayers=3):
+        super().__init__()
+        self.config = self._Cfg()
+        self.config.num_hidden_layers = nlayers
+        self.hidden_size_per_layer_input = d
+        self.per_layer_model_projection = nn.Linear(p, d * nlayers, bias=False)
+        self.per_layer_projection_norm = self._Norm(d)
+        self.register_buffer("per_layer_projection_scale", torch.tensor(d**-0.5))
+        self.register_buffer("per_layer_input_scale", torch.tensor(2.0**0.5))
+
+    def project_per_layer_inputs(self, inputs_embeds, per_layer_inputs=None, inplace=True):
+        per_layer_projection = self.per_layer_model_projection(inputs_embeds)
+        scale = self.per_layer_projection_scale.to(dtype=inputs_embeds.dtype, device=per_layer_projection.device)
+        if inplace:
+            per_layer_projection *= scale  # the offending in-place op (HF parity)
+        else:
+            per_layer_projection = per_layer_projection * scale
+        per_layer_projection = per_layer_projection.reshape(
+            *inputs_embeds.shape[:-1], self.config.num_hidden_layers, self.hidden_size_per_layer_input
+        )
+        per_layer_projection = self.per_layer_projection_norm(per_layer_projection)
+        if per_layer_inputs is None:
+            return per_layer_projection
+        if per_layer_projection.shape != per_layer_inputs.shape:
+            per_layer_inputs = per_layer_inputs[..., : self.config.num_hidden_layers, :]
+        return (per_layer_projection + per_layer_inputs) * self.per_layer_input_scale.to(
+            dtype=inputs_embeds.dtype, device=per_layer_projection.device
+        )
+
+
+def test_patch_gemma3n_inplace_lora_views_wraps_and_preserves_numerics():
+    """The gemma3n patch makes the in-place projection legal without changing numerics or grads."""
+    from nemo_automodel.components._peft.lora import patch_gemma3n_inplace_lora_views
+
+    p, d, nlayers = 8, 5, 3
+    torch.manual_seed(0)
+    patched_model = _Gemma3nTextModelMini(p, d, nlayers)
+    patch_linear_module(
+        patched_model.per_layer_model_projection, dim=4, alpha=8, use_triton=False, use_memory_efficient_lora=True
+    )
+
+    # Reference: identical weights, out-of-place consumer, no model-side patch.
+    torch.manual_seed(0)
+    ref_model = _Gemma3nTextModelMini(p, d, nlayers)
+    patch_linear_module(
+        ref_model.per_layer_model_projection, dim=4, alpha=8, use_triton=False, use_memory_efficient_lora=True
+    )
+
+    assert patch_gemma3n_inplace_lora_views(patched_model) == 1
+    # Idempotent: a second call wraps nothing.
+    assert patch_gemma3n_inplace_lora_views(patched_model) == 0
+
+    inputs_embeds = torch.randn(2, 3, p)
+    per_layer_inputs = torch.randn(2, 3, nlayers, d)
+
+    for with_pli in (False, True):
+        pli = per_layer_inputs if with_pli else None
+
+        for m in (patched_model, ref_model):
+            m.per_layer_model_projection.lora_A.weight.grad = None
+            m.per_layer_model_projection.lora_B.weight.grad = None
+
+        x_patched = inputs_embeds.detach().clone().requires_grad_(True)
+        # With the patch, the in-place consumer must NOT raise.
+        out_patched = patched_model.project_per_layer_inputs(
+            x_patched, pli.detach().clone() if with_pli else None, inplace=True
+        )
+        out_patched.sum().backward()
+
+        x_ref = inputs_embeds.detach().clone().requires_grad_(True)
+        out_ref = ref_model.project_per_layer_inputs(x_ref, pli.detach().clone() if with_pli else None, inplace=False)
+        out_ref.sum().backward()
+
+        assert torch.allclose(out_patched, out_ref, atol=1e-6)
+        assert torch.allclose(x_patched.grad, x_ref.grad, atol=1e-6)
+        assert torch.allclose(
+            patched_model.per_layer_model_projection.lora_A.weight.grad,
+            ref_model.per_layer_model_projection.lora_A.weight.grad,
+            atol=1e-6,
+        )
+        assert torch.allclose(
+            patched_model.per_layer_model_projection.lora_B.weight.grad,
+            ref_model.per_layer_model_projection.lora_B.weight.grad,
+            atol=1e-6,
+        )
+
+
+def test_patch_gemma3n_inplace_lora_views_noop_without_lora():
+    """The patch is a no-op when per_layer_model_projection was not LoRA-patched."""
+    from nemo_automodel.components._peft.lora import patch_gemma3n_inplace_lora_views
+
+    model = _Gemma3nTextModelMini()
+    # Plain nn.Linear projection (e.g. excluded from target_modules) -> nothing to wrap.
+    assert patch_gemma3n_inplace_lora_views(model) == 0
+    # A non-gemma3n model (no per_layer_model_projection) is also a no-op.
+    assert patch_gemma3n_inplace_lora_views(DummyModel()) == 0

--- a/tests/unit_tests/_peft/test_lora.py
+++ b/tests/unit_tests/_peft/test_lora.py
@@ -23,6 +23,7 @@ from nemo_automodel.components._peft.lora import (
     LoRATritonFunction,
     PeftConfig,
     apply_lora_to_linear_modules,
+    apply_memory_efficient_lora,
     patch_linear_module,
 )
 from nemo_automodel.shared.import_utils import safe_import_te
@@ -173,7 +174,7 @@ def test_memory_efficient_lora_matches_legacy_forward_and_backward(input_shape):
     lora_A_ref = lora_A.detach().clone().requires_grad_(True)
     lora_B_ref = lora_B.detach().clone().requires_grad_(True)
 
-    efficient = LoRATritonFunction.apply(x, lora_A, lora_B, scale, x.dtype, False)
+    efficient = apply_memory_efficient_lora(x, lora_A, lora_B, scale, False)
     legacy = F.linear(F.linear(x_ref, lora_A_ref) * scale, lora_B_ref)
 
     grad = torch.randn_like(legacy)
@@ -204,7 +205,7 @@ def test_memory_efficient_lora_with_residual_matches_legacy_forward_and_backward
     lora_B_ref = lora_B.detach().clone().requires_grad_(True)
     res_ref = res.detach().clone().requires_grad_(True)
 
-    efficient = LoRATritonFunction.apply(x, lora_A, lora_B, scale, x.dtype, False, res)
+    efficient = apply_memory_efficient_lora(x, lora_A, lora_B, scale, False, res)
     legacy = res_ref + F.linear(F.linear(x_ref, lora_A_ref) * scale, lora_B_ref)
 
     grad = torch.randn_like(legacy)
@@ -480,27 +481,29 @@ class _Gemma3nTextModelMini(nn.Module):
         )
 
 
-def test_patch_gemma3n_inplace_lora_views_wraps_and_preserves_numerics():
-    """The gemma3n patch makes the in-place projection legal without changing numerics or grads."""
-    from nemo_automodel.components._peft.lora import patch_gemma3n_inplace_lora_views
+def test_memory_efficient_lora_output_is_inplace_safe():
+    """A consumer may mutate the memory-efficient LoRA output in place, with no model-specific patch.
 
+    Regression for AM-453: transformers gemma3n ``project_per_layer_inputs`` does
+    ``per_layer_projection *= scale`` on the projection output. Previously the memory-efficient LoRA
+    returned a *view of a custom-autograd-Function output*, so the in-place op raised
+    "Output 0 of LoRATritonFunctionBackward is a view and is being modified inplace". The
+    ``(N, out) -> (bs, seq, out)`` reshape now happens outside the Function, so its output is an
+    ordinary (in-place-safe) view -- fixing the bug class generically (no gemma3n-specific code).
+    """
     p, d, nlayers = 8, 5, 3
     torch.manual_seed(0)
-    patched_model = _Gemma3nTextModelMini(p, d, nlayers)
+    model = _Gemma3nTextModelMini(p, d, nlayers)
     patch_linear_module(
-        patched_model.per_layer_model_projection, dim=4, alpha=8, use_triton=False, use_memory_efficient_lora=True
+        model.per_layer_model_projection, dim=4, alpha=8, use_triton=False, use_memory_efficient_lora=True
     )
 
-    # Reference: identical weights, out-of-place consumer, no model-side patch.
+    # Reference: identical weights, out-of-place consumer.
     torch.manual_seed(0)
     ref_model = _Gemma3nTextModelMini(p, d, nlayers)
     patch_linear_module(
         ref_model.per_layer_model_projection, dim=4, alpha=8, use_triton=False, use_memory_efficient_lora=True
     )
-
-    assert patch_gemma3n_inplace_lora_views(patched_model) == 1
-    # Idempotent: a second call wraps nothing.
-    assert patch_gemma3n_inplace_lora_views(patched_model) == 0
 
     inputs_embeds = torch.randn(2, 3, p)
     per_layer_inputs = torch.randn(2, 3, nlayers, d)
@@ -508,41 +511,28 @@ def test_patch_gemma3n_inplace_lora_views_wraps_and_preserves_numerics():
     for with_pli in (False, True):
         pli = per_layer_inputs if with_pli else None
 
-        for m in (patched_model, ref_model):
+        for m in (model, ref_model):
             m.per_layer_model_projection.lora_A.weight.grad = None
             m.per_layer_model_projection.lora_B.weight.grad = None
 
-        x_patched = inputs_embeds.detach().clone().requires_grad_(True)
-        # With the patch, the in-place consumer must NOT raise.
-        out_patched = patched_model.project_per_layer_inputs(
-            x_patched, pli.detach().clone() if with_pli else None, inplace=True
-        )
-        out_patched.sum().backward()
+        x_in = inputs_embeds.detach().clone().requires_grad_(True)
+        # The in-place consumer must NOT raise -- this is the regression.
+        out = model.project_per_layer_inputs(x_in, pli.detach().clone() if with_pli else None, inplace=True)
+        out.sum().backward()
 
         x_ref = inputs_embeds.detach().clone().requires_grad_(True)
         out_ref = ref_model.project_per_layer_inputs(x_ref, pli.detach().clone() if with_pli else None, inplace=False)
         out_ref.sum().backward()
 
-        assert torch.allclose(out_patched, out_ref, atol=1e-6)
-        assert torch.allclose(x_patched.grad, x_ref.grad, atol=1e-6)
+        assert torch.allclose(out, out_ref, atol=1e-6)
+        assert torch.allclose(x_in.grad, x_ref.grad, atol=1e-6)
         assert torch.allclose(
-            patched_model.per_layer_model_projection.lora_A.weight.grad,
+            model.per_layer_model_projection.lora_A.weight.grad,
             ref_model.per_layer_model_projection.lora_A.weight.grad,
             atol=1e-6,
         )
         assert torch.allclose(
-            patched_model.per_layer_model_projection.lora_B.weight.grad,
+            model.per_layer_model_projection.lora_B.weight.grad,
             ref_model.per_layer_model_projection.lora_B.weight.grad,
             atol=1e-6,
         )
-
-
-def test_patch_gemma3n_inplace_lora_views_noop_without_lora():
-    """The patch is a no-op when per_layer_model_projection was not LoRA-patched."""
-    from nemo_automodel.components._peft.lora import patch_gemma3n_inplace_lora_views
-
-    model = _Gemma3nTextModelMini()
-    # Plain nn.Linear projection (e.g. excluded from target_modules) -> nothing to wrap.
-    assert patch_gemma3n_inplace_lora_views(model) == 0
-    # A non-gemma3n model (no per_layer_model_projection) is also a no-op.
-    assert patch_gemma3n_inplace_lora_views(DummyModel()) == 0

--- a/tests/unit_tests/_peft/test_lora_mlp.py
+++ b/tests/unit_tests/_peft/test_lora_mlp.py
@@ -46,8 +46,12 @@ def test_fused_lora_mlp_matches_reference_fp32():
     # reference
     xr = x0.clone().requires_grad_(True)
     ref_p = {k: v.clone().requires_grad_(True) for k, v in dict(gA=gA, gB=gB, uA=uA, uB=uB, dA=dA, dB=dB).items()}
-    (_ref_mlp(xr, gW, ref_p["gA"], ref_p["gB"], gS, uW, ref_p["uA"], ref_p["uB"], uS,
-              dW, ref_p["dA"], ref_p["dB"], dS) * gout).sum().backward()
+    (
+        _ref_mlp(
+            xr, gW, ref_p["gA"], ref_p["gB"], gS, uW, ref_p["uA"], ref_p["uB"], uS, dW, ref_p["dA"], ref_p["dB"], dS
+        )
+        * gout
+    ).sum().backward()
 
     # fused
     xf = x0.clone().requires_grad_(True)
@@ -155,6 +159,28 @@ def test_fused_helper_declines_on_dropout_and_dora():
     gate = _make_lora(H, I, R)
     gate.use_dora = True
     assert fused_lora_swiglu_mlp(gate, up, down, x) is None
+
+
+def test_fused_helper_declines_on_quantized_base():
+    """QLoRA/quantized base weights are packed buffers, not a 2D (out, in) matrix; the fused path
+    must decline so the per-linear (dequantizing) path handles them.
+
+    Regression for AM-435: with a 4-bit-packed base, ``F.linear(x, base_weight)`` in the fused
+    forward failed with "mat1 and mat2 shapes cannot be multiplied (Nx4096 and 1x14680064)".
+    """
+    H, I, R = 64, 96, 8
+    up, down = _make_lora(H, I, R), _make_lora(I, H, R)
+    x = torch.randn(2, 16, H)
+
+    # (a) packed/flattened base weight (shape != (out_features, in_features))
+    gate_packed = _make_lora(H, I, R)
+    gate_packed.weight = nn.Parameter(torch.zeros(1, I * H // 2), requires_grad=False)
+    assert fused_lora_swiglu_mlp(gate_packed, up, down, x) is None
+
+    # (b) bitsandbytes-style quant_state marker on the module
+    gate_qs = _make_lora(H, I, R)
+    gate_qs.quant_state = object()
+    assert fused_lora_swiglu_mlp(gate_qs, up, down, x) is None
 
 
 def _lora_swiglu_mlp(H, I, R):


### PR DESCRIPTION
# What does this PR do?

Splits the three **LoRA MLP** fixes out of #2482 (nightly-CI grab-bag) into a focused PR, and implements the two that weren't yet in #2482. All three are `_peft` LoRA fixes from the AM 26.06 Release Testing project:

| Issue | Fix |
|---|---|
| **AM-435** | LoRA-SwiGLU MLP weight shape incompatible with activation (matmul failure under **QLoRA**) |
| **AM-447** | `LoRASwiGLUMLPFunctionBackward` returns a gradient on cuda instead of meta under **pipeline parallelism** |
| **AM-453** | In-place modification of the view returned by `LoRATritonFunctionBackward` (gemma3n) |

# Changelog

- **AM-435** (`lora_mlp.py`): `_fusible()` now declines QLoRA/quantized base weights (bitsandbytes `quant_state` marker, or a packed weight whose shape ≠ `(out_features, in_features)`), so they fall back to the per-linear `LinearLoRA` path that dequantizes the base — instead of `F.linear(x, packed_weight)` blowing up with `mat1 and mat2 shapes cannot be multiplied (N×4096 and 1×14680064)`. + regression test.
- **AM-447** (`lora_mlp.py`): the fused `LoRASwiGLUMLPFunction` / `LoRAReLU2MLPFunction` backward now returns each LoRA gradient on its **parameter's** device. Under PP, torch builds the backward graph with the LoRA params on `meta` while activations are on cuda; returning cuda grads tripped `returned an invalid gradient at index 2 - expected device meta but got cuda`. The cast is a no-op in single-device training.
- **AM-453** (`lora.py`, cherry-picked from #2482): `patch_gemma3n_inplace_lora_views()` makes gemma3n's `per_layer_model_projection` LoRA output a fresh (non-view) tensor so `project_per_layer_inputs`'s in-place op is legal. + tests.

# Verification

- **AM-447** verified end-to-end on 2-GPU **pipeline parallelism** (Qwen3 + fused SwiGLU LoRA): the prior crash is gone (`invalid-gradient` count: 0) and the step runs. The fused LoRA path itself trains with finite loss at `pp=1` (3.86 → 4.01 → 3.52).
- **AM-435** covered by a new unit test (fused path declines quantized base); the fix is a guard that routes to the already-working per-linear path.
- **AM-453** covered by the cherry-picked unit tests.
- Unit tests: `tests/unit_tests/_peft/test_lora_mlp.py` + `test_lora.py` pass on CPU.

> Note (separate issue, **not** in scope here): once AM-447's crash is removed, the `qwen3_8b_hellaswag_pp_peft` recipe surfaces a **NaN loss under PP** that also occurs without the fused LoRA path — it originates in the PP-split forward (`hf_utils`), not in these LoRA fixes (the fused path is finite at `pp=1`). Worth a separate ticket.

# Before your PR is "Ready for review"

- [x] New tests added (AM-435 regression; AM-453 via cherry-pick)
- [x] Ran linting (`ruff`) and unit tests
- [x] DCO sign-off on all commits
