### PR TITLE
ci: Enable activation checkpointing for gemma_2_9b_it_squad (AM-464)

### DIFF
--- a/examples/llm_finetune/gemma/gemma_2_9b_it_squad.yaml
+++ b/examples/llm_finetune/gemma/gemma_2_9b_it_squad.yaml
@@ -49,6 +49,7 @@ checkpoint:
 
 distributed:
   strategy: fsdp2
+  activation_checkpointing: true
   dp_size: none
   tp_size: 1
   cp_size: 1


### PR DESCRIPTION
## What
Enable `distributed.activation_checkpointing: true` for the `gemma_2_9b_it_squad` finetune recipe.

## Why — AM-464 / nemo-ci job 337980482
`gemma_2_9b_it_squad` CUDA-OOMs on 8×H100-80GB in the backward pass at training step ~10/50.

Root cause is **configuration, not code**:
- `google/gemma-2-9b-it` runs with `attn_implementation: eager`, so every one of the 42 decoder layers materializes a full `[B, heads, S, S]` attention-score tensor and keeps it for backward (the liger/SDPA kernel patch is inert under `eager`).
- No activation checkpointing → all 42 layers' activations are resident simultaneously.
- SQuAD is unpacked and padded to the longest sample per micro-batch with **no length cap**, so the first long batch (~step 10, deterministic under `shuffle: false`) spikes past 80 GB. A second OOM site is the full `[B, S, 256000]` logits + fp32 upcast in `MaskedCrossEntropy`.

## Fix
`activation_checkpointing: true` recomputes per-layer activations during backward, so only one layer's eager attention scores are resident at a time instead of all 42 — the dominant `O(S²)` term for this recipe.

## Verification (cw-dfw, 8×H100-80GB, CI image `automodel:pipe.54318163`, same commit as the failing job)
| | baseline (`main`) | + `activation_checkpointing: true` |
|---|---|---|
| step 10 | **CUDA OOM** — all 8 GPUs pegged ~80.3–81 GB | 57 GiB, continues |
| result | crash at step 10/50 | **20/20 steps + full validation pass, rc=0**; peak 71–79 GB |
| loss curve | — | **identical** to baseline through the steps it survived (activation checkpointing is loss-neutral) |

The baseline reproduced job 337980482 bit-for-bit (same loss + per-step memory; byte-identical OOM line). Because the loss curve is unchanged, the `gemma_2_9b_it_squad_h100` golden values are expected to still match — CI will confirm.

Closes AM-464.
