### PR TITLE
fix: use TE attention for gpt_oss packed-sequence recipe (AM-438)

### DIFF
--- a/examples/llm_finetune/gpt_oss/gpt_oss_20b_te_packed_sequence.yaml
+++ b/examples/llm_finetune/gpt_oss/gpt_oss_20b_te_packed_sequence.yaml
@@ -20,7 +20,11 @@ recipe: TrainFinetuneRecipeForNextTokenPrediction
 
 step_scheduler:
   global_batch_size: 32
-  local_batch_size: 4
+  # local_batch_size 1 (not 4): full-FT of the 20B MoE on a single 8xH100-80GB node
+  # OOMs in the MoE experts grouped-GEMM / cross-entropy at lbs=4; lbs=1 (grad-accum
+  # keeps global_batch_size=32) trains within ~35 GiB/GPU. Activation checkpointing is
+  # not usable here (DeepEP token dispatch is non-deterministic -> recompute mismatch).
+  local_batch_size: 1
   ckpt_every_steps: 500
   num_epochs: 2
 

--- a/examples/llm_finetune/gpt_oss/gpt_oss_20b_te_packed_sequence.yaml
+++ b/examples/llm_finetune/gpt_oss/gpt_oss_20b_te_packed_sequence.yaml
@@ -38,7 +38,7 @@ model:
   pretrained_model_name_or_path: openai/gpt-oss-20b
   backend:
     _target_: nemo_automodel.components.models.common.BackendConfig
-    attn: flex
+    attn: te
     linear: te
     rms_norm: te
     experts: te


### PR DESCRIPTION
## Summary

`examples/llm_finetune/gpt_oss/gpt_oss_20b_te_packed_sequence.yaml` paired `model.backend.attn: flex` with THD/packed sequences, but FlexAttention has no THD (3D) support — its sink path unpacks `B, H_q, S_q, D = q.shape` (4D only) and ignores `cu_seqlens` — so the recipe crashed with:

```
ValueError: not enough values to unpack (expected 4, got 3)
```

(surfaced by nemo-ci job 337980493). This `flex` + packed combination was never actually exercised when the recipe was added in #1757: that PR's sequence-packing work was a **TE** feature (its THD unit test *mocks* attention), and this recipe is **not** in the GitHub Actions recipe matrix. TE `DotProductAttention` supports THD/packed natively (`qkv_format=thd` + `cu_seqlens`) and gpt-oss's learnable attention sinks via `softmax_offset` (requires TE ≥ 2.8.0, already required by this recipe's `linear/rms_norm/experts: te`) — the path #1757 validated.

**Two recipe-level changes:**
1. **`model.backend.attn: flex → te`** — the AM-438 crash fix.
2. **`step_scheduler.local_batch_size: 4 → 1`** (`global_batch_size` unchanged at 32) — full fine-tuning of the 20B MoE on a single 8×H100-80GB node OOMs at `lbs=4` (in the MoE experts grouped-GEMM and the vocab-201088 cross-entropy); `lbs=1` trains within ~35 GiB/GPU. Activation checkpointing isn't usable here — DeepEP's non-deterministic token dispatch makes the recompute mismatch the forward.

> A code-level alternative that teaches FlexAttention to support THD packed sequences (per-document block masking) also exists and is verified, but `te` is this recipe's intended/validated backend, so it's not included here.

## Fixes

- Linear [AM-438](https://linear.app/nvidia/issue/AM-438/attention-function-receives-3d-query-tensor-instead-of-expected-4d) — *Attention function receives 3-D query tensor instead of expected 4-D*

## Test plan

Confirmed on cw-dfw (1 node × 8× H100-80GB, ep=8, deepep, packed, `lbs=1`, `max_steps` capped). The AM-438 `ValueError` is gone, TE THD/packed is exercised (`(attn_module): DotProductAttention(...)` — not FlexAttention — and `Packing dataset with size: 1024, strategy: thd`), and there is **no OOM** (peak ~35 GiB/GPU):

```bash
srun -A coreai_dlalgo_llm -p interactive -N1 --ntasks=1 --gpus-per-node=8 \
  --container-image=<nemo-ci image> --container-mounts=/lustre:/lustre,<dir>:<dir> \
  --container-workdir=<dir> --no-container-mount-home \
  bash -lc 'export HF_HOME=<dir>/hf_cache_shared; cd /opt/Automodel && \
            automodel examples/llm_finetune/gpt_oss/gpt_oss_20b_te_packed_sequence.yaml --nproc-per-node 8'
```

> **Training-loss note.** On this PR *alone* the absolute training loss is elevated (step-0 ~8.2, trending down) — but that is a **separate** bug in `GroupedExpertsTE` (the MoE down-projection bias was applied unweighted), **not** this recipe change. It is fixed in **#2591**. With #2591 applied, the same recipe trains correctly: step-0 **5.10 → val 4.19**, matching the HuggingFace reference (~4.5). This PR is orthogonal — it fixes the crash + OOM; #2591 fixes the loss. Together the recipe runs end-to-end and trains correctly.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
