### PR TITLE
fix(distributed): register Falcon-H1 TP plan to fix 34B PEFT OOM

### DIFF
--- a/nemo_automodel/components/distributed/optimized_tp_plans.py
+++ b/nemo_automodel/components/distributed/optimized_tp_plans.py
@@ -668,6 +668,47 @@ def _parallelize_qwen3_5_vlm(
     return get_hf_tp_shard_plan(model)
 
 
+def _parallelize_falcon_h1(
+    model,
+    sequence_parallel: bool = False,
+) -> Dict[str, ParallelStyle]:
+    """Parallelize Falcon-H1 (hybrid Transformer + Mamba2 SSM).
+
+    Every Falcon-H1 decoder layer runs an attention branch (``self_attn``) and a
+    Mamba2 branch (``mamba``) in parallel, followed by an MLP (``feed_forward``).
+    Only the attention and MLP linears are tensor-parallel sharded; the Mamba2
+    mixer stays replicated because its SSM scan / causal conv1d are not
+    TP-shardable with stock kernels (same approach as Qwen3.5's GatedDeltaNet
+    linear-attention branch).
+
+    A dedicated plan is required because HuggingFace ships only
+    ``_tp_plan = {"lm_head": "colwise_gather_output"}`` for FalconH1, and its MLP
+    is named ``feed_forward`` (not ``mlp``). The generic llama-style fallback plan
+    therefore matches neither the HF plan (the ``colwise_gather_output`` style is
+    rejected) nor the MLP module names, leaving the dominant ``feed_forward``
+    weights replicated across TP ranks — which OOMs large variants such as
+    Falcon-H1-34B even under LoRA.
+
+    ``sequence_parallel`` is accepted for signature compatibility but ignored: the
+    parallel Mamba2 branch emits non-sequence-parallel activations that cannot be
+    combined with sequence-parallel attention outputs.
+    """
+    return cast(
+        Dict[str, ParallelStyle],
+        {
+            "model.embed_tokens": VocabParallelEmbedding(input_layouts=Replicate()),
+            "model.layers.*.self_attn.q_proj": ColwiseParallel(),
+            "model.layers.*.self_attn.k_proj": ColwiseParallel(),
+            "model.layers.*.self_attn.v_proj": ColwiseParallel(),
+            "model.layers.*.self_attn.o_proj": RowwiseParallel(),
+            "model.layers.*.feed_forward.gate_proj": ColwiseParallel(),
+            "model.layers.*.feed_forward.up_proj": ColwiseParallel(),
+            "model.layers.*.feed_forward.down_proj": RowwiseParallel(),
+            "lm_head": ColwiseParallel(output_layouts=Replicate()),
+        },
+    )
+
+
 # Keyed by qualified class name — see _get_class_qualname for why.
 PARALLELIZE_FUNCTIONS: Dict[str, Callable[..., Dict[str, ParallelStyle]]] = {
     _get_class_qualname(BaichuanForCausalLM): _parallelize_baichuan,
@@ -680,6 +721,15 @@ PARALLELIZE_FUNCTIONS: Dict[str, Callable[..., Dict[str, ParallelStyle]]] = {
     # MLP, leave the GatedDeltaNet (linear_attn) replicated.
     "nemo_automodel.components.models.qwen3_5.model.Qwen3_5ForConditionalGeneration": _parallelize_qwen3_5_vlm,
     "nemo_automodel.components.models.qwen3_5.model.Qwen3_5ForCausalLM": _parallelize_qwen3_5_vlm,
+    # Falcon-H1 (hybrid Transformer + Mamba2). HF ships only a minimal
+    # _tp_plan ({"lm_head": "colwise_gather_output"}) and names its MLP
+    # "feed_forward", so the generic fallback plan leaves feed_forward replicated
+    # and OOMs Falcon-H1-34B. Shard self_attn + feed_forward; leave the Mamba2
+    # mixer replicated. Hard-coded qualname avoids eagerly importing
+    # transformers.models.falcon_h1; the bare name covers trust_remote_code loads
+    # whose module path carries a snapshot hash.
+    "transformers.models.falcon_h1.modeling_falcon_h1.FalconH1ForCausalLM": _parallelize_falcon_h1,
+    "FalconH1ForCausalLM": _parallelize_falcon_h1,
     _get_class_qualname(LlamaForCausalLM): _parallelize_llama,
     _get_class_qualname(Ministral3ForCausalLM): _parallelize_ministral3,
     # Mistral3 VLM (Pixtral + Ministral3) — native HF class plus the Automodel

--- a/tests/unit_tests/distributed/test_optimized_tp_plans.py
+++ b/tests/unit_tests/distributed/test_optimized_tp_plans.py
@@ -48,6 +48,7 @@ from nemo_automodel.components.distributed.optimized_tp_plans import (
 
 class MockModel:
     """Mock model class for testing."""
+
     def __init__(self, model_type="llama", tie_word_embeddings=False):
         self.config = SimpleNamespace(tie_word_embeddings=tie_word_embeddings)
         self.__class__ = {
@@ -62,6 +63,7 @@ class MockModel:
 
 class MockDeviceMesh:
     """Mock device mesh for testing."""
+
     def __init__(self):
         pass
 
@@ -85,17 +87,15 @@ class TestRotaryEmbedParallel:
         # Mock sequence sharding
         sequence_sharding = [Shard(1)]
 
-        result = RotaryEmbedParallel._prepare_input_fn(
-            sequence_sharding, mod, inputs, device_mesh
-        )
+        result = RotaryEmbedParallel._prepare_input_fn(sequence_sharding, mod, inputs, device_mesh)
 
         # Should return same type with original inputs unchanged
         assert type(result) == type(inputs)
         assert result[0] == mock_dtensor1
         assert result[1] == mock_dtensor2
 
-    @patch('torch.distributed.get_rank')
-    @patch.object(DTensor, 'from_local')
+    @patch("torch.distributed.get_rank")
+    @patch.object(DTensor, "from_local")
     def test_prepare_input_fn_with_tensor(self, mock_from_local, mock_get_rank):
         """Test _prepare_input_fn when input is regular tensor."""
         mock_get_rank.return_value = 0
@@ -114,29 +114,27 @@ class TestRotaryEmbedParallel:
         mod = Mock()
         sequence_sharding = [Shard(1)]
 
-        result = RotaryEmbedParallel._prepare_input_fn(
-            sequence_sharding, mod, inputs, device_mesh
-        )
+        RotaryEmbedParallel._prepare_input_fn(sequence_sharding, mod, inputs, device_mesh)
 
         # Should have called from_local twice
         assert mock_from_local.call_count == 2
 
         # First call should be for sequence parallel sharding
         first_call = mock_from_local.call_args_list[0]
-        assert first_call[1]['local_tensor'] is tensor1
-        assert first_call[1]['device_mesh'] is device_mesh
-        assert first_call[1]['placements'] == sequence_sharding
-        assert first_call[1]['run_check'] is True
+        assert first_call[1]["local_tensor"] is tensor1
+        assert first_call[1]["device_mesh"] is device_mesh
+        assert first_call[1]["placements"] == sequence_sharding
+        assert first_call[1]["run_check"] is True
 
         # Second call should be for replication
         second_call = mock_from_local.call_args_list[1]
-        assert second_call[1]['local_tensor'] is tensor2
-        assert second_call[1]['device_mesh'] is device_mesh
-        assert second_call[1]['placements'] == (Replicate(),)
-        assert second_call[1]['run_check'] is False
+        assert second_call[1]["local_tensor"] is tensor2
+        assert second_call[1]["device_mesh"] is device_mesh
+        assert second_call[1]["placements"] == (Replicate(),)
+        assert second_call[1]["run_check"] is False
 
-    @patch('torch.distributed.get_rank')
-    @patch.object(DTensor, 'from_local')
+    @patch("torch.distributed.get_rank")
+    @patch.object(DTensor, "from_local")
     def test_prepare_input_fn_value_error(self, mock_from_local, mock_get_rank):
         """Test _prepare_input_fn handles ValueError properly."""
         mock_get_rank.return_value = 1
@@ -149,9 +147,7 @@ class TestRotaryEmbedParallel:
         sequence_sharding = [Shard(1)]
 
         with pytest.raises(ValueError) as exc_info:
-            RotaryEmbedParallel._prepare_input_fn(
-                sequence_sharding, mod, inputs, device_mesh
-            )
+            RotaryEmbedParallel._prepare_input_fn(sequence_sharding, mod, inputs, device_mesh)
 
         # Should wrap original error with helpful context
         assert "Failed to shard tensor for sequence parallelism" in str(exc_info.value)
@@ -169,9 +165,7 @@ class TestRotaryEmbedParallel:
         mod = Mock()
         device_mesh = MockDeviceMesh()
 
-        result = RotaryEmbedParallel._prepare_output_fn(
-            True, mod, outputs, device_mesh
-        )
+        result = RotaryEmbedParallel._prepare_output_fn(True, mod, outputs, device_mesh)
 
         # Should call to_local on both outputs
         assert mock_dtensor1.to_local.called
@@ -186,9 +180,7 @@ class TestRotaryEmbedParallel:
         mod = Mock()
         device_mesh = MockDeviceMesh()
 
-        result = RotaryEmbedParallel._prepare_output_fn(
-            False, mod, outputs, device_mesh
-        )
+        result = RotaryEmbedParallel._prepare_output_fn(False, mod, outputs, device_mesh)
 
         # Should not call to_local
         assert not mock_dtensor1.to_local.called
@@ -474,16 +466,12 @@ class TestParallelPlanStructure:
             # Test without sequence parallel
             plan = func(model, sequence_parallel=False)
             for pattern, style in plan.items():
-                assert isinstance(style, valid_styles), (
-                    f"Invalid style {type(style)} for pattern {pattern}"
-                )
+                assert isinstance(style, valid_styles), f"Invalid style {type(style)} for pattern {pattern}"
 
             # Test with sequence parallel
             plan_sp = func(model, sequence_parallel=True)
             for pattern, style in plan_sp.items():
-                assert isinstance(style, valid_styles), (
-                    f"Invalid style {type(style)} for pattern {pattern} with SP"
-                )
+                assert isinstance(style, valid_styles), f"Invalid style {type(style)} for pattern {pattern} with SP"
 
     def test_module_patterns_are_strings(self):
         """Test that all module patterns are strings."""
@@ -519,13 +507,12 @@ class TestParallelPlanStructure:
                 assert pattern in plan_sp
 
 
-
-
 class TestParallelizeMistral3Vlm:
     """_parallelize_mistral3_vlm + PARALLELIZE_FUNCTIONS registration for Mistral3 VLM."""
 
     def test_paths_under_model_language_model_prefix(self):
         from nemo_automodel.components.distributed.optimized_tp_plans import _parallelize_mistral3_vlm
+
         plan = _parallelize_mistral3_vlm(model=None)
         # Every text-decoder rule must be scoped to model.language_model.* —
         # without this prefix scoping (the original bug), MLP weights stayed
@@ -539,6 +526,7 @@ class TestParallelizeMistral3Vlm:
         from torch.distributed.tensor.parallel import ColwiseParallel, RowwiseParallel
 
         from nemo_automodel.components.distributed.optimized_tp_plans import _parallelize_mistral3_vlm
+
         plan = _parallelize_mistral3_vlm(model=None)
         prefix = "model.language_model.layers.*"
         # qkv + gate + up are colwise; o + down are rowwise (Ministral3 GQA pattern).
@@ -560,6 +548,7 @@ class TestParallelizeMistral3Vlm:
         from torch.distributed.tensor.parallel import ColwiseParallel
 
         from nemo_automodel.components.distributed.optimized_tp_plans import _parallelize_mistral3_vlm
+
         plan = _parallelize_mistral3_vlm(model=None)
         # lm_head sits at the top level (not nested under model.language_model)
         # in HF's Mistral3ForConditionalGeneration; sharding it on dim=-1
@@ -582,10 +571,88 @@ class TestParallelizeMistral3Vlm:
         from nemo_automodel.components.models.mistral3_vlm.model import (
             Mistral3FP8VLMForConditionalGeneration,
         )
+
         for cls in (Mistral3ForConditionalGeneration, Mistral3FP8VLMForConditionalGeneration):
             qn = _get_class_qualname(cls)
             assert qn in PARALLELIZE_FUNCTIONS, f"{qn} not registered"
             assert PARALLELIZE_FUNCTIONS[qn] is _parallelize_mistral3_vlm
+
+
+class TestParallelizeFalconH1:
+    """_parallelize_falcon_h1 + PARALLELIZE_FUNCTIONS registration for Falcon-H1.
+
+    Falcon-H1 is a hybrid Transformer + Mamba2 model. HF ships only
+    ``_tp_plan = {"lm_head": "colwise_gather_output"}`` and names its MLP
+    ``feed_forward`` (not ``mlp``), so the generic fallback plan left the
+    dominant feed_forward weights replicated across TP ranks and OOMed
+    Falcon-H1-34B. These tests pin the dedicated plan.
+    """
+
+    def test_attention_and_feed_forward_styles(self):
+        from nemo_automodel.components.distributed.optimized_tp_plans import _parallelize_falcon_h1
+
+        plan = _parallelize_falcon_h1(model=None)
+        prefix = "model.layers.*"
+        # q/k/v + gate/up are colwise; o + down are rowwise (GQA pattern).
+        for k in (
+            f"{prefix}.self_attn.q_proj",
+            f"{prefix}.self_attn.k_proj",
+            f"{prefix}.self_attn.v_proj",
+            f"{prefix}.feed_forward.gate_proj",
+            f"{prefix}.feed_forward.up_proj",
+        ):
+            assert isinstance(plan[k], ColwiseParallel), f"{k} should be colwise"
+        for k in (
+            f"{prefix}.self_attn.o_proj",
+            f"{prefix}.feed_forward.down_proj",
+        ):
+            assert isinstance(plan[k], RowwiseParallel), f"{k} should be rowwise"
+
+    def test_mlp_is_feed_forward_not_mlp(self):
+        """The MLP must be addressed as ``feed_forward`` — the root cause of the
+        OOM was the generic plan targeting ``mlp.*`` (which Falcon-H1 does not
+        have), leaving the dominant MLP weights replicated."""
+        from nemo_automodel.components.distributed.optimized_tp_plans import _parallelize_falcon_h1
+
+        plan = _parallelize_falcon_h1(model=None)
+        assert any(k.startswith("model.layers.*.feed_forward.") for k in plan)
+        assert not any(".mlp." in k for k in plan), "Falcon-H1 has no mlp.* modules"
+
+    def test_mamba_branch_left_replicated(self):
+        """The Mamba2 mixer is not TP-shardable with stock kernels and must be
+        omitted from the plan (left replicated)."""
+        from nemo_automodel.components.distributed.optimized_tp_plans import _parallelize_falcon_h1
+
+        plan = _parallelize_falcon_h1(model=None)
+        assert not any(".mamba" in k for k in plan), "mamba.* must stay replicated"
+
+    def test_sequence_parallel_is_ignored_not_crashing(self):
+        # ParallelStyle objects have no __eq__, so compare structure (keys +
+        # style types) rather than object identity.
+        from nemo_automodel.components.distributed.optimized_tp_plans import _parallelize_falcon_h1
+
+        plan_off = _parallelize_falcon_h1(model=None, sequence_parallel=False)
+        plan_on = _parallelize_falcon_h1(model=None, sequence_parallel=True)
+        assert plan_off.keys() == plan_on.keys()
+        assert {k: type(v) for k, v in plan_off.items()} == {k: type(v) for k, v in plan_on.items()}
+
+    def test_class_registered_by_qualname_and_bare_name(self):
+        """Falcon-H1 may load natively (transformers.models.falcon_h1.*) or via
+        trust_remote_code (transformers_modules.<hash>.*); both must resolve to
+        the dedicated plan, otherwise the parallelizer falls through to the
+        default plan whose paths don't match and weights stay unsharded."""
+        from nemo_automodel.components.distributed.optimized_tp_plans import (
+            PARALLELIZE_FUNCTIONS,
+            _parallelize_falcon_h1,
+        )
+
+        for key in (
+            "transformers.models.falcon_h1.modeling_falcon_h1.FalconH1ForCausalLM",
+            "FalconH1ForCausalLM",
+        ):
+            assert key in PARALLELIZE_FUNCTIONS, f"{key} not registered"
+            assert PARALLELIZE_FUNCTIONS[key] is _parallelize_falcon_h1
+
 
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
## Summary

`falcon_h1_34b_instruct_squad_peft` (8×H100, `tp_size=4`) OOMs during the
first few training steps — each rank reports ~72 GiB allocated and the job is
eventually killed at the Slurm time limit.

Failing CI job: [337980604](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/337980604) (pipeline 54319542, `main`).
Recipe added in #2334.

```
[rank7]: torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 2.09 GiB.
GPU 7 has a total capacity of 79.11 GiB of which 608.56 MiB is free ...
72.41 GiB is allocated by PyTorch ...
```

## Root cause

Falcon-H1 is a **hybrid Transformer + Mamba2 SSM** model. Two things combine to
defeat tensor-parallel sharding:

1. HuggingFace ships only `_tp_plan = {"lm_head": "colwise_gather_output"}` for
   `FalconH1ForCausalLM`. The parallelizer can't translate the
   `colwise_gather_output` style, so it discards the HF plan:
   ```
   HF tp plan not available (Unknown parallel style: colwise_gather_output). Falling back to default base plan.
   No usable tensor-parallel plan is registered for 'FalconH1ForCausalLM'. Falling back to the default base plan at tp_size=4.
   ```
2. It then falls back to the generic **llama-style** base plan, whose MLP
   patterns are `model.layers.*.mlp.*`. But Falcon-H1 names its MLP
   **`feed_forward`**, so those patterns match nothing. The MLP — the dominant
   ~70% of the 34B parameters — is left **replicated** across the TP group, and
   the Mamba2 mixer is unshardable with stock kernels, so each GPU ends up
   holding almost the whole model → OOM.

The attention path (`self_attn.{q,k,v,o}_proj`) *did* shard correctly via the
fallback (the run trained 5–6 steps), so the only missing piece is the MLP.

## Fix

Register a dedicated `FalconH1ForCausalLM` plan in `PARALLELIZE_FUNCTIONS`
(`optimized_tp_plans.py`) that:

- shards `self_attn.{q,k,v,o}_proj` and `feed_forward.{gate,up,down}_proj`
  (the correct module name), plus `embed_tokens` / `lm_head`;
- leaves the **Mamba2 mixer replicated** — its SSM scan / causal conv1d are not
  TP-shardable with stock kernels (same approach as Qwen3.5's GatedDeltaNet
  linear-attention branch, `_parallelize_qwen3_5_vlm`);
- is keyed by both the qualified class name (native `transformers` load) and the
  bare name (`trust_remote_code` loads whose module path carries a snapshot hash).

This shards the dominant `feed_forward` weights across the TP group, cutting
per-GPU resident parameters from ~the full model to roughly `model / (tp·dp)`.
TP sharding is numerically exact, so loss values are unaffected.

`tp_size=4` is reasonable for a 34B on 8 GPUs and is left as-is — this is the
only Falcon-H1 recipe using `tp_size>1`; the 0.5B/1.5B/7B recipes use
`tp_size=1` and are unaffected.

## Testing

- New unit tests in `tests/unit_tests/distributed/test_optimized_tp_plans.py`
  pin the plan: attention + `feed_forward` are sharded (colwise/rowwise), no
  `mlp.*` keys, the Mamba branch stays replicated, and both registration keys
  resolve. Full `test_optimized_tp_plans.py` + `test_get_parallel_plan.py` +
  `test_register_parallel_strategy.py` pass locally (transformers 5.8.1).
- Tested on 8xH100
```
Training:   0%|          | 0/30 2026-06-15 23:46:32 | INFO | root | step 0 | epoch 0 | loss 1.9496 | grad_norm 4.2379 | lr 1.00e-05 | mem 40.01 GiB | num_label_tokens 309
Training:   3%|▎         | 1/30 2026-06-15 23:48:15 | INFO | root | step 1 | epoch 0 | loss 2.2311 | grad_norm 4.0933 | lr 1.00e-05 | mem 44.49 GiB | num_label_tokens 282
Training:   7%|▋         | 2/30 2026-06-15 23:50:12 | INFO | root | step 2 | epoch 0 | loss 2.0807 | grad_norm 3.7598 | lr 1.00e-05 | mem 42.66 GiB | num_label_tokens 289
```
