### PR TITLE
feat(gemma4): context parallelism for dense 31B

### DIFF
--- a/examples/vlm_finetune/gemma4/gemma4_31b_tulu3_text_cp8_16k.yaml
+++ b/examples/vlm_finetune/gemma4/gemma4_31b_tulu3_text_cp8_16k.yaml
@@ -1,0 +1,107 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Gemma 4 31B (dense) text-only SFT on Tulu-3, sequence-packed to 16k, single node.
+# Context parallelism cp8 shards the 16k sequence to 2k local/rank so the full
+# 60-layer model fits on one 8-GPU node (~54 GiB steady).
+# Dense CP requires attn_implementation=sdpa (the model-owned p2p ring swaps
+# F.scaled_dot_product_attention) and no TE-attention backend so the dense CP
+# install path runs.
+
+recipe: FinetuneRecipeForVLM
+
+step_scheduler:
+  global_batch_size: 1
+  local_batch_size: 1
+  ckpt_every_steps: 999999
+  val_every_steps: 999999
+  max_steps: 50
+  num_epochs: 1
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 60
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 42
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained
+  pretrained_model_name_or_path: google/gemma-4-31B-it
+  torch_dtype: torch.bfloat16
+  attn_implementation: sdpa
+  use_liger_kernel: false
+  use_sdpa_patching: false
+  text_config:
+    use_cache: false
+
+processor:
+  padding_side: right
+
+checkpoint:
+  enabled: false
+
+distributed:
+  strategy: fsdp2
+  dp_size: none
+  tp_size: 1
+  cp_size: 8
+  sequence_parallel: false
+  activation_checkpointing: true
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.vlm.datasets.make_meta_dataset
+  path_or_dataset: logs/gemma4_tulu3_seqpack_cp/data/tulu3_train_meta.json
+  split: train
+  truncate: false
+
+packed_sequence:
+  pretokenize: true
+  max_length: 16384
+  pack_size: 16384
+  collate_max_length: 16384
+  packing_ratio: 0.9
+  drop_long_samples: true
+  post_tokenize_hook_fn: nemo_automodel.components.datasets.vlm.collate_fns.gemma4_inject_thinking_prefix
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  num_workers: 4
+  persistent_workers: true
+  pin_memory: true
+
+optimizer:
+  _target_: torch.optim.AdamW
+  lr: 2e-5
+  weight_decay: 0.01
+  betas: [0.9, 0.95]
+
+freeze_config:
+  freeze_embeddings: true
+  freeze_vision_tower: true
+  freeze_audio_tower: true
+  freeze_language_model: false
+
+wandb:
+  project: huiyingl_workspace
+  entity: Nemo-automodel
+  name: gemma4_31b_tulu3_text_cp8_16k
+  group: gemma4_31b_tulu3_text_cp8_16k
+  tags: [gemma4-31b, tulu3, text-only, dense, cp8, 16k, single-node]
+  dir: logs/gemma4_31b_tulu3_text_cp8_16k/wandb

--- a/nemo_automodel/components/models/gemma4_moe/cp_attention.py
+++ b/nemo_automodel/components/models/gemma4_moe/cp_attention.py
@@ -29,6 +29,36 @@ logger = logging.getLogger(__name__)
 _GEMMA4_CP_FLEX_RING_OK_LOGGED = False
 
 
+def _patch_fsdp_accumulated_grad_guard() -> None:
+    """Guard ``FSDPParam.to_accumulated_grad_if_needed`` against uninitialized params.
+
+    On some torch builds that method reads ``self._unsharded_param`` (the lazily
+    set unsharded tensor) without first checking it exists. In FSDP2 post-backward
+    under fp32 grad-reduce, frozen / never-unsharded params (e.g. the frozen Gemma4
+    vision tower and embeddings) have no ``_unsharded_param`` yet and it raises
+    ``AttributeError``. Such params carry no grad to upcast anyway, so wrap the
+    method to skip them when uninitialized. No-op once applied / on fixed builds.
+    """
+    try:
+        from torch.distributed.fsdp._fully_shard._fsdp_param import FSDPParam
+    except Exception:
+        return
+    orig = FSDPParam.to_accumulated_grad_if_needed
+    if getattr(orig, "_gemma4_guarded", False):
+        return
+
+    def guarded(self):
+        if not hasattr(self, "_unsharded_param"):
+            return
+        return orig(self)
+
+    guarded._gemma4_guarded = True
+    FSDPParam.to_accumulated_grad_if_needed = guarded
+
+
+_patch_fsdp_accumulated_grad_guard()
+
+
 @dataclass(frozen=True)
 class CPRingAttentionContext:
     """Inputs for Gemma4 manual ring CP attention (built by the run_cp_manual_attention seam)."""
@@ -576,7 +606,19 @@ def _install_gemma4_cp_ring_sdpa(attention_module: torch.nn.Module, cp_mesh) -> 
         )
 
     def _pre_hook(module, args, kwargs):
-        module._cp_manual_metadata = {name: kwargs.pop(name, None) for name in metadata_keys}
+        captured = {name: kwargs.pop(name, None) for name in metadata_keys}
+        # Dense Gemma4 routes through HF's decoder layers, which do not thread the
+        # CP/vision metadata down to self_attn kwargs (the MoE backend does). The
+        # dense forward stashes it on the module as ``_cp_dense_metadata``; fall
+        # back to that for any key the caller didn't pass so the ring can still
+        # build the vision-bidirectional / packed masks. Persisted across the step
+        # (not cleared by the post-hook) so it survives activation-checkpoint recompute.
+        fallback = getattr(module, "_cp_dense_metadata", None)
+        if fallback:
+            for name in metadata_keys:
+                if captured.get(name) is None:
+                    captured[name] = fallback.get(name)
+        module._cp_manual_metadata = captured
         # Own the CP mask handling (instead of relying on the generic
         # attach_context_parallel_hooks mask-strip): drop any full-sequence 4D
         # attention_mask -- invalid once the sequence is CP-sharded -- and force

--- a/nemo_automodel/components/models/gemma4_moe/model.py
+++ b/nemo_automodel/components/models/gemma4_moe/model.py
@@ -711,12 +711,14 @@ class Gemma4ForConditionalGeneration(HFCheckpointingMixin, HFGemma4ForConditiona
                 supports_ep=True,
             )
         if getattr(config, "audio_config", None) is not None:
-            # Dense + audio variant: gemma-4-E2B-it, gemma-4-E4B-it
+            # Dense + audio variant: gemma-4-E2B-it, gemma-4-E4B-it.
+            # CP not yet supported here: kv-sharing + per-layer-inputs are not
+            # wired through the p2p ring. Tracked separately from this 31B PR.
             return ModelCapabilities()
         # Plain dense variant: gemma-4-31B-it
         return ModelCapabilities(
             supports_tp=True,
-            supports_cp=False,
+            supports_cp=True,
             supports_pp=True,
             supports_ep=False,
         )
@@ -737,6 +739,40 @@ class Gemma4ForConditionalGeneration(HFCheckpointingMixin, HFGemma4ForConditiona
             raise UnavailableError("transformers.models.gemma4 is not available.")
         config = Gemma4Config.from_pretrained(pretrained_model_name_or_path)
         return cls.from_config(config, *model_args, **kwargs)
+
+    def setup_cp_attention(self, cp_mesh) -> None:
+        """Install Gemma4's model-owned p2p ring CP attention (dense path).
+
+        Idempotent: flips the ``_cp_enabled`` flag the forward reads and installs
+        the ring on every self-attn module (each was given a per-module
+        ``setup_cp_attention`` by ``attach_gemma4_cp_ring_attention`` at
+        construction). Invoked from Gemma4's own batch-sharding callable
+        (``_cp_shard_batch``) the first time the recipe hands it the CP submesh, so
+        the install is fully model-owned -- no framework dispatch is required.
+        """
+        if getattr(self, "_cp_enabled", False):
+            return
+        self._cp_enabled = True
+        for module in self.modules():
+            if module is self:
+                continue
+            module_setup = getattr(module, "setup_cp_attention", None)
+            if callable(module_setup):
+                module_setup(cp_mesh)
+
+    def _cp_shard_batch(self, cp_mesh, tp_mesh, batch, *, loss_mask=None, padding_token_id=0):
+        """Gemma4-owned CP batch sharder that also self-installs the ring.
+
+        Attached to the batch as ``_cp_make_batch_fn`` by
+        ``prepare_model_inputs_for_cp``. ``cp_utils.make_cp_batch_and_ctx`` calls it
+        with the CP submesh, which is the one place Gemma4 receives ``cp_mesh`` on a
+        model-owned path -- so install the ring here (idempotent) before sharding,
+        rather than depending on the framework to call ``setup_cp_attention``.
+        """
+        self.setup_cp_attention(cp_mesh)
+        return make_contiguous_shard_cp_batch_and_ctx(
+            cp_mesh, tp_mesh, batch, loss_mask=loss_mask, padding_token_id=padding_token_id
+        )
 
     def __init__(
         self,
@@ -793,7 +829,12 @@ class Gemma4ForConditionalGeneration(HFCheckpointingMixin, HFGemma4ForConditiona
         self.pad_token_id = pad_token_id if pad_token_id is not None else -1
 
         if not enable_moe:
-            # Dense Gemma4 — keep vanilla HF model, nothing else to do.
+            # Dense Gemma4 — keep vanilla HF model. Attach the model-owned p2p ring
+            # CP attention to each HF self-attn so setup_cp_attention can install it
+            # when CP is enabled. (The MoE path attaches it per Gemma4MoEDecoderLayer.)
+            for module in self.modules():
+                if isinstance(module, Gemma4Attention):
+                    attach_gemma4_cp_ring_attention(module)
             return
 
         # --- MoE path: replace the text model ---
@@ -881,6 +922,23 @@ class Gemma4ForConditionalGeneration(HFCheckpointingMixin, HFGemma4ForConditiona
                 past_key_values = kwargs.pop("past_key_values", None)
                 logits_to_keep = kwargs.pop("logits_to_keep", logits_to_keep)
                 kwargs.pop("labels", None)
+
+                # Dense Gemma4 rides HF's decoder layers, which don't thread the
+                # CP/vision metadata down to self_attn (the MoE backend passes it via
+                # kwargs). Stash the CP-sharded metadata on each ring-hooked attention
+                # module so the ring builds the vision-bidirectional / packed masks
+                # rather than a plain causal mask (which corrupts multimodal attention).
+                cp_meta = {
+                    "mm_token_type_ids": mm_token_type_ids,
+                    "padding_mask": padding_mask,
+                    "_packed_seq_ids": kwargs.get("_packed_seq_ids"),
+                    "_gemma4_vision_group_ids": kwargs.get("_gemma4_vision_group_ids"),
+                }
+                # Left set (not cleared) so the activation-checkpoint recompute in
+                # backward sees the same metadata; each CP forward overwrites it.
+                for _mod in self.modules():
+                    if getattr(_mod, "_cp_uses_attention_hook", False):
+                        _mod._cp_dense_metadata = cp_meta
 
                 text_outputs = self.model.language_model(
                     input_ids=None,
@@ -1049,7 +1107,7 @@ class Gemma4ForConditionalGeneration(HFCheckpointingMixin, HFGemma4ForConditiona
             "mm_token_type_ids": mm_token_type_ids
             if mm_token_type_ids is not None
             else special_image_mask.to(torch.long),
-            "_cp_make_batch_fn": make_contiguous_shard_cp_batch_and_ctx,
+            "_cp_make_batch_fn": self._cp_shard_batch,
             "_gemma4_vision_group_ids": gemma4_vision_group_ids(
                 mm_token_type_ids if mm_token_type_ids is not None else special_image_mask.to(torch.long)
             ),

--- a/tests/unit_tests/models/gemma4/test_cp_attention.py
+++ b/tests/unit_tests/models/gemma4/test_cp_attention.py
@@ -727,3 +727,115 @@ def test_manual_attention_entry_sets_gqa_when_head_counts_differ(monkeypatch):
         kwargs={},
     )
     assert out.shape == q.shape
+
+
+# ---------------------------------------------------------------------------
+# _patch_fsdp_accumulated_grad_guard
+# ---------------------------------------------------------------------------
+def test_fsdp_guard_skips_uninitialized_and_runs_orig_and_is_idempotent(monkeypatch):
+    """The guard wraps FSDPParam.to_accumulated_grad_if_needed so it skips params
+    with no _unsharded_param (returns None) and otherwise calls the original."""
+    import sys
+    import types
+
+    calls = {"n": 0}
+
+    class FakeFSDPParam:
+        def to_accumulated_grad_if_needed(self):
+            calls["n"] += 1
+            return "ran"
+
+    fake_mod = types.ModuleType("torch.distributed.fsdp._fully_shard._fsdp_param")
+    fake_mod.FSDPParam = FakeFSDPParam
+    monkeypatch.setitem(sys.modules, "torch.distributed.fsdp._fully_shard._fsdp_param", fake_mod)
+
+    cpa._patch_fsdp_accumulated_grad_guard()
+
+    p = FakeFSDPParam()
+    # No _unsharded_param -> guarded wrapper returns None without calling orig.
+    assert p.to_accumulated_grad_if_needed() is None
+    assert calls["n"] == 0
+    # With _unsharded_param -> original runs.
+    p._unsharded_param = object()
+    assert p.to_accumulated_grad_if_needed() == "ran"
+    assert calls["n"] == 1
+    # Marked guarded; a second patch is a no-op (does not double-wrap).
+    assert FakeFSDPParam.to_accumulated_grad_if_needed._gemma4_guarded is True
+    wrapped = FakeFSDPParam.to_accumulated_grad_if_needed
+    cpa._patch_fsdp_accumulated_grad_guard()
+    assert FakeFSDPParam.to_accumulated_grad_if_needed is wrapped
+
+
+def test_fsdp_guard_noop_when_import_unavailable(monkeypatch):
+    """If the FSDP internal module can't be imported, the patch returns quietly."""
+    import sys
+
+    # Setting the module to None makes `from ... import FSDPParam` raise ImportError,
+    # which the guard swallows.
+    monkeypatch.setitem(sys.modules, "torch.distributed.fsdp._fully_shard._fsdp_param", None)
+    cpa._patch_fsdp_accumulated_grad_guard()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# _install_gemma4_cp_ring_sdpa: dense _cp_dense_metadata fallback in the pre-hook
+# ---------------------------------------------------------------------------
+def test_pre_hook_falls_back_to_dense_metadata(monkeypatch):
+    """Dense Gemma4 doesn't thread metadata to self_attn kwargs; the pre-hook must
+    fall back to module._cp_dense_metadata for keys the caller didn't pass."""
+    import torch.nn.functional as F
+
+    captured = {}
+
+    def fake_ring(module, query, key, value, *, cp_mesh, attn_mask, dropout_p, is_causal, scale, enable_gqa, kwargs):
+        captured["meta"] = dict(module._cp_manual_metadata)
+        return torch.zeros_like(query)
+
+    monkeypatch.setattr(cpa, "_gemma4_cp_manual_attention", fake_ring)
+
+    class _Attn(torch.nn.Module):
+        def forward(self, q, k, v, **kw):
+            return F.scaled_dot_product_attention(q, k, v)
+
+    attn = _Attn()
+    cpa.attach_gemma4_cp_ring_attention(attn)
+    attn.setup_cp_attention(object())
+
+    packed = torch.tensor([[1, 1, 2, 2]])
+    # Dense forward stashes metadata on the module; the call passes no metadata kwargs.
+    attn._cp_dense_metadata = {
+        "_packed_seq_ids": packed,
+        "mm_token_type_ids": None,
+        "padding_mask": None,
+        "_gemma4_vision_group_ids": None,
+    }
+    q = torch.randn(1, 2, 4, 8)
+    attn(q, q.clone(), q.clone())
+    assert torch.equal(captured["meta"]["_packed_seq_ids"], packed)
+
+
+def test_pre_hook_kwarg_takes_precedence_over_dense_fallback(monkeypatch):
+    """An explicit kwarg value must not be overwritten by the _cp_dense_metadata fallback."""
+    import torch.nn.functional as F
+
+    captured = {}
+
+    def fake_ring(module, query, key, value, *, cp_mesh, attn_mask, dropout_p, is_causal, scale, enable_gqa, kwargs):
+        captured["meta"] = dict(module._cp_manual_metadata)
+        return torch.zeros_like(query)
+
+    monkeypatch.setattr(cpa, "_gemma4_cp_manual_attention", fake_ring)
+
+    class _Attn(torch.nn.Module):
+        def forward(self, q, k, v, **kw):
+            return F.scaled_dot_product_attention(q, k, v)
+
+    attn = _Attn()
+    cpa.attach_gemma4_cp_ring_attention(attn)
+    attn.setup_cp_attention(object())
+
+    kwarg_packed = torch.tensor([[3, 3, 3, 3]])
+    stale_fallback = torch.tensor([[9, 9, 9, 9]])
+    attn._cp_dense_metadata = {"_packed_seq_ids": stale_fallback}
+    q = torch.randn(1, 2, 4, 8)
+    attn(q, q.clone(), q.clone(), _packed_seq_ids=kwarg_packed)
+    assert torch.equal(captured["meta"]["_packed_seq_ids"], kwarg_packed)

--- a/tests/unit_tests/models/gemma4/test_gemma4_model_cp.py
+++ b/tests/unit_tests/models/gemma4/test_gemma4_model_cp.py
@@ -459,3 +459,153 @@ def test_prepare_model_inputs_threads_per_layer_inputs(monkeypatch):
     prepared = model.prepare_model_inputs_for_cp(input_ids=torch.tensor([[1, 42, 3, 4]]))
     assert "per_layer_inputs" in prepared
     assert prepared["per_layer_inputs"].shape == (1, 4, 8)
+
+
+# ---------------------------------------------------------------------------
+# get_capabilities: dense 31B supports CP; E2B/E4B (audio) does not; MoE does
+# ---------------------------------------------------------------------------
+def test_get_capabilities_plain_dense_supports_cp():
+    caps = Gemma4ForConditionalGeneration.get_capabilities(_cfg(enable_moe_block=False))
+    assert caps.supports_cp is True
+    assert caps.supports_tp is True
+    assert caps.supports_pp is True
+    assert caps.supports_ep is False
+
+
+def test_get_capabilities_dense_audio_variant_no_cp():
+    # E2B/E4B: dense + audio_config present -> CP intentionally unsupported
+    # (kv-sharing + per-layer-inputs not yet wired through the ring).
+    cfg = _cfg(enable_moe_block=False)
+    cfg.audio_config = {}  # non-None marks the dense+audio variant (E2B/E4B)
+    caps = Gemma4ForConditionalGeneration.get_capabilities(cfg)
+    assert caps.supports_cp is False
+
+
+def test_get_capabilities_moe_supports_cp_and_ep():
+    caps = Gemma4ForConditionalGeneration.get_capabilities(_cfg(enable_moe_block=True))
+    assert caps.supports_cp is True
+    assert caps.supports_ep is True
+    assert caps.supports_tp is False
+
+
+# ---------------------------------------------------------------------------
+# Dense __init__ attaches the model-owned ring to each self-attention module
+# ---------------------------------------------------------------------------
+def test_dense_init_attaches_ring_to_self_attention():
+    model = Gemma4ForConditionalGeneration(_cfg(enable_moe_block=False), backend=_backend())
+    hooked = [m for m in model.modules() if getattr(m, "_cp_manual_metadata_keys", None)]
+    # one per dense decoder layer
+    assert len(hooked) == model.config.text_config.num_hidden_layers
+    for m in hooked:
+        assert m._cp_manual_metadata_keys == (
+            "mm_token_type_ids",
+            "_packed_seq_ids",
+            "padding_mask",
+            "_gemma4_vision_group_ids",
+        )
+        assert callable(m.setup_cp_attention)
+
+
+# ---------------------------------------------------------------------------
+# setup_cp_attention: model-level seam, idempotent, fans out to submodules
+# ---------------------------------------------------------------------------
+def test_setup_cp_attention_sets_flag_and_calls_submodules():
+    model = Gemma4ForConditionalGeneration(_cfg(enable_moe_block=False), backend=_backend())
+    calls = {"n": 0}
+    seen_mesh = []
+    for m in model.modules():
+        if m is model:
+            continue
+        if hasattr(m, "setup_cp_attention"):
+
+            def _stub(mesh, _calls=calls, _seen=seen_mesh):
+                _calls["n"] += 1
+                _seen.append(mesh)
+
+            m.setup_cp_attention = _stub
+    mesh = object()
+    model.setup_cp_attention(mesh)
+    assert model._cp_enabled is True
+    assert calls["n"] == model.config.text_config.num_hidden_layers
+    assert all(s is mesh for s in seen_mesh)
+
+
+def test_setup_cp_attention_idempotent():
+    model = Gemma4ForConditionalGeneration(_cfg(enable_moe_block=False), backend=_backend())
+    calls = {"n": 0}
+    for m in model.modules():
+        if m is model:
+            continue
+        if hasattr(m, "setup_cp_attention"):
+            m.setup_cp_attention = lambda mesh, _c=calls: _c.__setitem__("n", _c["n"] + 1)
+    model.setup_cp_attention(object())
+    first = calls["n"]
+    assert first > 0
+    # second call returns early via the _cp_enabled guard -> no extra submodule calls
+    model.setup_cp_attention(object())
+    assert calls["n"] == first
+
+
+# ---------------------------------------------------------------------------
+# _cp_shard_batch: installs the ring (idempotent) then delegates to the sharder
+# ---------------------------------------------------------------------------
+def test_cp_shard_batch_installs_ring_then_delegates(monkeypatch):
+    model = Gemma4ForConditionalGeneration(_cfg(enable_moe_block=False), backend=_backend())
+    installed = {"mesh": None}
+    monkeypatch.setattr(model, "setup_cp_attention", lambda mesh: installed.__setitem__("mesh", mesh))
+
+    sentinel = ("ctx", {"sharded": True})
+    seen = {}
+
+    def fake_shard(cp_mesh, tp_mesh, batch, *, loss_mask=None, padding_token_id=0):
+        seen.update(
+            cp_mesh=cp_mesh, tp_mesh=tp_mesh, batch=batch, loss_mask=loss_mask, padding_token_id=padding_token_id
+        )
+        return sentinel
+
+    monkeypatch.setattr(
+        "nemo_automodel.components.models.gemma4_moe.model.make_contiguous_shard_cp_batch_and_ctx",
+        fake_shard,
+    )
+
+    cp_mesh, tp_mesh, batch = object(), object(), {"input_ids": torch.tensor([[1, 2]])}
+    out = model._cp_shard_batch(cp_mesh, tp_mesh, batch, loss_mask="lm", padding_token_id=7)
+    assert out is sentinel
+    assert installed["mesh"] is cp_mesh  # ring installed with the CP submesh
+    assert seen["cp_mesh"] is cp_mesh and seen["tp_mesh"] is tp_mesh
+    assert seen["loss_mask"] == "lm" and seen["padding_token_id"] == 7
+
+
+def test_prepare_model_inputs_attaches_cp_shard_batch_fn():
+    model = Gemma4ForConditionalGeneration(_cfg(enable_moe_block=False), backend=_backend()).to(torch.bfloat16)
+    prepared = model.prepare_model_inputs_for_cp(input_ids=torch.tensor([[1, 2, 3, 4]]))
+    # The model attaches its own bound batch-sharding callable (model-owned install seam).
+    assert prepared["_cp_make_batch_fn"] == model._cp_shard_batch
+
+
+# ---------------------------------------------------------------------------
+# Dense CP forward stashes CP-sharded metadata on the ring-hooked self_attn modules
+# ---------------------------------------------------------------------------
+def test_forward_dense_cp_stashes_metadata_on_ring_modules():
+    cfg = _cfg(enable_moe_block=False, final_logit_softcapping=30.0)
+    model = Gemma4ForConditionalGeneration(cfg, backend=_backend()).to(torch.bfloat16)
+    model.setup_cp_attention(object())  # installs ring -> _cp_uses_attention_hook on self_attn
+
+    batch, seq = 1, 4
+    hidden = torch.randn(batch, seq, cfg.text_config.hidden_size, dtype=torch.bfloat16)
+    packed = torch.tensor([[1, 1, 2, 2]])
+    with mock.patch.object(
+        model.model.language_model,
+        "forward",
+        return_value=SimpleNamespace(
+            last_hidden_state=hidden, past_key_values=None, hidden_states=None, attentions=None
+        ),
+    ):
+        model(input_ids=torch.tensor([[1, 2, 3, 4]]), _packed_seq_ids=packed)
+
+    hooked = [m for m in model.modules() if getattr(m, "_cp_uses_attention_hook", False)]
+    assert hooked, "expected ring-hooked self_attn modules"
+    for m in hooked:
+        meta = m._cp_dense_metadata
+        assert set(meta) == {"mm_token_type_ids", "padding_mask", "_packed_seq_ids", "_gemma4_vision_group_ids"}
+        assert torch.equal(meta["_packed_seq_ids"], packed)


### PR DESCRIPTION
## What

Wire context parallelism into the plain-dense **Gemma4 31B** (`google/gemma-4-31B-it`) using the model-owned p2p ring flex_attention already used by the 26B MoE path.

## How

- `prepare_model_inputs_for_cp` attaches Gemma4's own `_cp_shard_batch` as the batch's `_cp_make_batch_fn`.
- `cp_utils.make_cp_batch_and_ctx` calls it with the CP submesh — the one place the model receives `cp_mesh` on a model-owned path — where it idempotently installs the ring (`setup_cp_attention`) and then shards the batch.
- `get_capabilities`: plain-dense 31B now `supports_cp=True`. **E2B/E4B** (dense+audio) are intentionally left unsupported — kv-sharing + per-layer-inputs are not yet wired through the ring (tracked separately).
- Dense forward stashes the CP-sharded vision/packed metadata on the ring-hooked `self_attn` modules so the ring builds the correct bidirectional/packed mask instead of a plain causal one.

## Scope

Limited to **31B**. Footprint: `gemma4_moe/model.py`, `gemma4_moe/cp_attention.py`, plus one 31B recipe (tulu3 text 16k cp8).

## Validation

- **cp1 vs cp2 SFT parity** (full 60-layer, TP4, medpix):
  - cp1: https://wandb.ai/Nemo-automodel/huiyingl_workspace/runs/ut16tjpi
  - cp2: https://wandb.ai/Nemo-automodel/huiyingl_workspace/runs/o16pd8bw
  
<img width="386" height="252" alt="image" src="https://github.com/user-attachments/assets/2265047e-dad5-4913-b03e-5a924a8e5c46" />

- **tulu3 text-only, 16k, cp8, single node, 50 steps:** https://wandb.ai/Nemo-automodel/huiyingl_workspace/runs/nc7jkb2r

<img width="974" height="504" alt="image" src="https://github.com/user-attachments/assets/d44ef4cc-2d4e-4473-b2ad-cd329c2f7d3f" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
