### PR TITLE
fix: TP config for nemotron-flash-1b + super-49B vllm_deploy cascade

### DIFF
--- a/examples/llm_finetune/nemotron/llama3_3_nemotron_super_49B_squad.yaml
+++ b/examples/llm_finetune/nemotron/llama3_3_nemotron_super_49B_squad.yaml
@@ -54,6 +54,7 @@ distributed:
   strategy: fsdp2
   dp_size: none
   tp_size: 4
+  tp_plan: llama_nemotron_super_tp_plan  # registered DeciLM/nemotron-nas TP plan; custom-code arch has no default plan
   cp_size: 1
   ep_size: 1
   pipeline:

--- a/examples/llm_finetune/nemotron_flash/nemotron_flash_1b_squad_peft.yaml
+++ b/examples/llm_finetune/nemotron_flash/nemotron_flash_1b_squad_peft.yaml
@@ -113,11 +113,9 @@ ci:
   time: "00:15:00"
   checkpoint_robustness:
     hf_kl_threshold: 5e-3
-    # tp_size=2 with bf16 row-parallel all-reduces produces ULP-level drift
-    # (~1e-3) between trainer and restored logits even with bit-identical
-    # weights; relax the Phase-3 threshold accordingly.
     kl_threshold: 5e-3
-    distributed.tp_size: 2
+    # NemotronFlash (hybrid mamba/deltanet, custom code) has no TP plan; reload at tp=1.
+    distributed.tp_size: 1
     tokenizer_name: nvidia/Nemotron-Flash-1B
     trust_remote_code: true
     check_fused_qkv_keys: true


### PR DESCRIPTION
## What
Fixes two `*_vllm_deploy` CI tests that **cascade from a missing checkpoint**:
- nemotron-flash-1b PEFT ([job 337980668](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/337980668))
- llama-3.3-nemotron-super-49B SFT ([job 337980592](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/337980592))

## Root cause
Both deploys error `No checkpoint found under .../robustness_checkpoint` because the upstream finetune/robustness producer dies first: a custom-code (`trust_remote_code`) architecture with **no registered TP plan** now hard-errors at `tp_size>1` (newer torch DTensor `shard_order` assert; the #2244 fail-fast in `parallelizer.py`). These previously rode AutoModel's default base plan on older torch.

## Fixes
- **nemotron-flash-1b** (`nemotron_flash_1b_squad_peft.yaml`): `NemotronFlash` (hybrid mamba2/deltanet) has **no** TP plan in any transformers version (verified 5.5.0 and latest 5.12.1), in the model's Hub code, or in AutoModel — and its hybrid SSM/conv layers aren't expressible with the standard colwise/rowwise TP styles. The robustness cross-TP phase ran at `tp_size=2` and aborted at setup, before the checkpoint was saved. It's a 1B model that doesn't need TP → set the robustness reload to `tp_size: 1`. (Train→save→AutoModel-reload→HF-reload still validate; only cross-TP-at-2, which never had a real plan, is dropped.)
- **super-49B / DeciLM-nemotron-nas** (`llama3_3_nemotron_super_49B_squad.yaml`): AutoModel already ships `get_decilm_nemotron_tp_plan` (named `llama_nemotron_super_tp_plan`, since #1487); the recipe never selected it, so the finetune fell through to the broken default plan at `tp_size=4`. Wire `distributed.tp_plan: llama_nemotron_super_tp_plan`. (All 49 real-attention blocks have 8 KV heads → divisible by tp=4 finetune and tp=8 robustness; the 31 no-op attention blocks stay replicated.)

## Validation
- Targeted GitLab pipeline (both recipes + their `_vllm_deploy`, on this commit): https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/54962684 _(running)_

## Pre-checks
- YAML parses; DCO signed off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
