### PR TITLE
fix(transformers): keep gemma3n KV sharing working under FSDP2 (AM-454)

### DIFF
--- a/nemo_automodel/_transformers/infrastructure.py
+++ b/nemo_automodel/_transformers/infrastructure.py
@@ -32,6 +32,10 @@ from typing import TYPE_CHECKING, Optional, Union
 import torch
 
 from nemo_automodel._transformers.utils import _should_load_before_shard
+from nemo_automodel._transformers.v4_patches.kv_sharing import (
+    install_kv_sharing_holder,
+    should_install_kv_sharing_holder,
+)
 from nemo_automodel._transformers.v4_patches.rotary import fix_rotary_embeddings, should_fix_rotary_embeddings
 from nemo_automodel.components._peft.lora import apply_lora_to_linear_modules
 from nemo_automodel.components.checkpoint.checkpointing import (
@@ -123,6 +127,11 @@ def _apply_runtime_compatibility_fixes(model):
     model_parts = model.parts if hasattr(model, "parts") else [model]
     if should_fix_rotary_embeddings(model_parts):
         fix_rotary_embeddings(model_parts)
+    # HF cross-layer KV sharing (e.g. gemma3n) threads a mutable shared_kv_states
+    # dict through layers; FSDP2 cast_forward_inputs rebuilds it per layer and
+    # breaks sharing (AM-454). Swap in a pytree-opaque holder shared by reference.
+    if should_install_kv_sharing_holder(model_parts):
+        install_kv_sharing_holder(model_parts)
     return model
 
 

--- a/nemo_automodel/_transformers/v4_patches/__init__.py
+++ b/nemo_automodel/_transformers/v4_patches/__init__.py
@@ -14,6 +14,10 @@
 
 """Compatibility patches for legacy v4-style transformer models."""
 
+from nemo_automodel._transformers.v4_patches.kv_sharing import (
+    install_kv_sharing_holder,
+    should_install_kv_sharing_holder,
+)
 from nemo_automodel._transformers.v4_patches.layer_types import (
     install_layer_types_patch_hook,
     patch_allowed_layer_types,
@@ -25,7 +29,9 @@ from nemo_automodel._transformers.v4_patches.rotary import (
 
 __all__ = [
     "fix_rotary_embeddings",
+    "install_kv_sharing_holder",
     "install_layer_types_patch_hook",
     "patch_allowed_layer_types",
     "should_fix_rotary_embeddings",
+    "should_install_kv_sharing_holder",
 ]

--- a/nemo_automodel/_transformers/v4_patches/kv_sharing.py
+++ b/nemo_automodel/_transformers/v4_patches/kv_sharing.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Runtime fix for HF cross-layer KV sharing under FSDP2.
+
+Some HF models (e.g. gemma3n) implement cross-layer KV sharing by threading a
+single mutable ``shared_kv_states`` dict through every decoder layer as a forward
+kwarg: the last full-length layer of each attention type writes its K/V into the
+dict, and the later "shared" layers read them back.
+
+Under FSDP2 with ``MixedPrecisionPolicy(cast_forward_inputs=True)``, the per-layer
+``fully_shard`` pre-forward casts forward inputs by running ``tree_map`` over
+``(args, kwargs)``. ``tree_map`` *reconstructs* every container it understands —
+including a plain ``dict`` — so each wrapped layer receives a fresh, empty copy of
+``shared_kv_states``. The writing layer fills its throwaway copy and the reading
+layer sees an empty one, raising ``KeyError`` (e.g. ``KeyError: 18``) on the first
+forward. This only triggers once ``fully_shard`` is active (dp_shard > 1).
+
+The fix swaps the dict for a :class:`_SharedKVStates` instance: it behaves like the
+dict the model expects but, because it is not a type pytree knows how to flatten,
+``tree_map`` treats it as a leaf and passes the *same* instance to every layer, so
+in-place writes are visible to the readers. See AM-454.
+"""
+
+import logging
+from functools import partial
+
+logger = logging.getLogger(__name__)
+
+
+class _SharedKVStates:
+    """Pytree-opaque, dict-like holder for HF cross-layer KV sharing.
+
+    Implements just enough of the mapping protocol for HF attention
+    (``__getitem__`` / ``__setitem__`` / ``__contains__``). Crucially it is *not*
+    a ``dict``/``list``/``tuple``, so ``torch.utils._pytree`` treats it as a leaf
+    and FSDP2's forward-input cast does not reconstruct it.
+    """
+
+    __slots__ = ("_d",)
+
+    def __init__(self):
+        self._d = {}
+
+    def __getitem__(self, key):
+        return self._d[key]
+
+    def __setitem__(self, key, value):
+        self._d[key] = value
+
+    def __contains__(self, key):
+        return key in self._d
+
+    def __len__(self):
+        return len(self._d)
+
+    def get(self, key, default=None):
+        return self._d.get(key, default)
+
+    def keys(self):
+        return self._d.keys()
+
+    def clear(self):
+        self._d.clear()
+
+
+def _kv_sharing_stacks(model):
+    """Yield (module, layers) for each decoder stack that uses KV sharing."""
+    for module in model.modules():
+        layers = getattr(module, "layers", None)
+        cfg = getattr(module, "config", None)
+        text_cfg = getattr(cfg, "text_config", None) or cfg
+        if layers is None or getattr(text_cfg, "num_kv_shared_layers", 0) <= 0:
+            continue
+        try:
+            layer_list = list(layers)
+        except TypeError:
+            continue
+        if layer_list:
+            yield module, layer_list
+
+
+def should_install_kv_sharing_holder(model_parts):
+    """True if any model part has a decoder stack that uses HF KV sharing."""
+    for mp in model_parts:
+        for _ in _kv_sharing_stacks(mp):
+            return True
+    return False
+
+
+def install_kv_sharing_holder(model_parts):
+    """Inject a pytree-opaque ``shared_kv_states`` holder so KV sharing survives FSDP2.
+
+    Registers a per-layer ``forward_pre_hook`` that swaps the ``shared_kv_states``
+    kwarg for a single :class:`_SharedKVStates` instance shared across the stack.
+    The holder is reset at the first layer of every forward so stale tensors are
+    not retained across steps. No-op for models without KV sharing.
+    """
+    hooked = 0
+    for mp in model_parts:
+        for _module, layer_list in _kv_sharing_stacks(mp):
+            # A wrapper may re-expose the same ``.layers``; only hook a stack once.
+            if getattr(layer_list[0], "_kv_sharing_holder_installed", False):
+                continue
+
+            holder = _SharedKVStates()
+
+            def _pre_hook(_mod, args, kwargs, _holder=holder, _is_first=False):
+                # Reset on the first layer so we don't carry K/V across forwards.
+                if _is_first:
+                    _holder.clear()
+                kwargs["shared_kv_states"] = _holder
+                return args, kwargs
+
+            for idx, layer in enumerate(layer_list):
+                layer.register_forward_pre_hook(
+                    partial(_pre_hook, _is_first=(idx == 0)),
+                    with_kwargs=True,
+                )
+                layer._kv_sharing_holder_installed = True
+                hooked += 1
+
+    if hooked:
+        logger.info("Installed shared-KV-states holder on %d decoder layers (FSDP2 KV-sharing fix).", hooked)
+    return hooked

--- a/nemo_automodel/_transformers/v4_patches/kv_sharing.py
+++ b/nemo_automodel/_transformers/v4_patches/kv_sharing.py
@@ -46,6 +46,10 @@ class _SharedKVStates:
     (``__getitem__`` / ``__setitem__`` / ``__contains__``). Crucially it is *not*
     a ``dict``/``list``/``tuple``, so ``torch.utils._pytree`` treats it as a leaf
     and FSDP2's forward-input cast does not reconstruct it.
+
+    Mirrors ``gemma4_moe._FSDPSafeSharedKVStates`` (#2566), which solves the same
+    problem in-model for gemma4; gemma3n is native HF so we inject the holder via
+    a forward pre-hook instead (see ``install_kv_sharing_holder``).
     """
 
     __slots__ = ("_d",)
@@ -76,12 +80,24 @@ class _SharedKVStates:
 
 
 def _kv_sharing_stacks(model):
-    """Yield (module, layers) for each decoder stack that uses KV sharing."""
+    """Yield (module, layers) for each gemma3n decoder stack that uses KV sharing.
+
+    Scoped to gemma3n on purpose. gemma3n is a native HF model whose
+    ``Gemma3nTextModel.forward`` builds a plain ``shared_kv_states`` dict that we
+    cannot edit in place, so we swap in an FSDP2-safe holder via a forward
+    pre-hook. Other kv-sharing models (e.g. gemma4) already make their own
+    shared store FSDP2-safe in-model (``gemma4_moe`` model.py, #2566) and may
+    thread a caller-supplied store (the speculative drafter via
+    ``gemma4_drafter`` composite); injecting our holder onto their layers would
+    clobber it and break that path, so we leave them alone.
+    """
     for module in model.modules():
         layers = getattr(module, "layers", None)
         cfg = getattr(module, "config", None)
         text_cfg = getattr(cfg, "text_config", None) or cfg
         if layers is None or getattr(text_cfg, "num_kv_shared_layers", 0) <= 0:
+            continue
+        if not str(getattr(text_cfg, "model_type", "")).startswith("gemma3n"):
             continue
         try:
             layer_list = list(layers)

--- a/tests/unit_tests/_transformers/v4_patches/test_kv_sharing.py
+++ b/tests/unit_tests/_transformers/v4_patches/test_kv_sharing.py
@@ -174,3 +174,24 @@ def test_install_is_idempotent_per_stack():
     second = install_kv_sharing_holder([model])
     assert first == 3
     assert second == 0  # already installed -> skipped
+
+
+def test_apply_runtime_compatibility_fixes_installs_holder():
+    """The fix is wired into _apply_runtime_compatibility_fixes (the prod path)."""
+    from nemo_automodel._transformers.infrastructure import _apply_runtime_compatibility_fixes
+
+    model = _TextModel()
+    _simulate_fsdp_cast(model)
+    returned = _apply_runtime_compatibility_fixes(model)
+    assert returned is model
+    # Holder is installed -> sharing works despite the simulated FSDP cast.
+    out = model(torch.zeros(2))
+    assert torch.allclose(out, torch.zeros(2))
+
+
+def test_apply_runtime_compatibility_fixes_noop_without_kv_sharing():
+    from nemo_automodel._transformers.infrastructure import _apply_runtime_compatibility_fixes
+
+    model = _TextModel(num_kv_shared_layers=0)
+    _apply_runtime_compatibility_fixes(model)
+    assert not getattr(model.layers[0], "_kv_sharing_holder_installed", False)

--- a/tests/unit_tests/_transformers/v4_patches/test_kv_sharing.py
+++ b/tests/unit_tests/_transformers/v4_patches/test_kv_sharing.py
@@ -1,0 +1,176 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``nemo_automodel._transformers.v4_patches.kv_sharing``.
+
+These exercise the AM-454 fix on CPU (no GPU/FSDP needed) by simulating the
+behaviour that breaks HF cross-layer KV sharing: FSDP2's forward-input cast runs
+``tree_map`` over the per-layer kwargs, which reconstructs a plain ``dict`` and
+therefore hands each layer its own empty copy of ``shared_kv_states``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+import torch.utils._pytree as pytree
+
+from nemo_automodel._transformers.v4_patches.kv_sharing import (
+    _SharedKVStates,
+    install_kv_sharing_holder,
+    should_install_kv_sharing_holder,
+)
+
+
+class _Attn(nn.Module):
+    """Mimics the HF gemma3n KV-sharing contract for one layer."""
+
+    def __init__(self, layer_idx, is_shared, kv_idx, store_full):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.is_kv_shared_layer = is_shared
+        self.kv_shared_layer_index = kv_idx
+        self.store_full_length_kv = store_full
+
+    def forward(self, x, shared_kv_states):
+        if self.is_kv_shared_layer:
+            # Reads K/V written by an earlier layer -> KeyError if dict not shared.
+            k, v = shared_kv_states[self.kv_shared_layer_index]
+            return x + k + v
+        k = v = x
+        if self.store_full_length_kv:
+            shared_kv_states[self.layer_idx] = (k, v)
+        return x
+
+
+class _Layer(nn.Module):
+    def __init__(self, attn):
+        super().__init__()
+        self.self_attn = attn
+
+    def forward(self, x, shared_kv_states=None):
+        return self.self_attn(x, shared_kv_states)
+
+
+class _TextModel(nn.Module):
+    """Tiny stand-in for Gemma3nTextModel: stores K/V at layer 1, reads at 2."""
+
+    def __init__(self, num_kv_shared_layers=2):
+        super().__init__()
+        self.config = SimpleNamespace(num_hidden_layers=3, num_kv_shared_layers=num_kv_shared_layers)
+        self.layers = nn.ModuleList(
+            [
+                _Layer(_Attn(0, is_shared=False, kv_idx=None, store_full=False)),
+                _Layer(_Attn(1, is_shared=False, kv_idx=None, store_full=True)),
+                _Layer(_Attn(2, is_shared=True, kv_idx=1, store_full=False)),
+            ]
+        )
+
+    def forward(self, x):
+        # The model owns a single dict, exactly like HF gemma3n.
+        shared_kv_states = {}
+        for layer in self.layers:
+            x = layer(x, shared_kv_states=shared_kv_states)
+        return x
+
+
+def _simulate_fsdp_cast(model):
+    """Register a pre-hook on each layer that copies kwargs via ``tree_map``.
+
+    This reproduces FSDP2's ``cast_forward_inputs`` behaviour, which reconstructs
+    the ``shared_kv_states`` dict per layer and breaks the sharing.
+    """
+
+    def _hook(_mod, args, kwargs):
+        return pytree.tree_map(lambda t: t, args), pytree.tree_map(lambda t: t, kwargs)
+
+    for layer in model.layers:
+        layer.register_forward_pre_hook(_hook, with_kwargs=True)
+
+
+def test_shared_kv_states_is_dict_like():
+    holder = _SharedKVStates()
+    assert 1 not in holder
+    holder[1] = ("k", "v")
+    assert 1 in holder
+    assert holder[1] == ("k", "v")
+    assert list(holder.keys()) == [1]
+    assert len(holder) == 1
+    assert holder.get(2) is None
+    holder.clear()
+    assert len(holder) == 0
+
+
+def test_holder_is_pytree_opaque():
+    """tree_map must return the *same* instance (a dict would be rebuilt)."""
+    holder = _SharedKVStates()
+    holder[1] = ("k", "v")
+    mapped = pytree.tree_map(lambda t: t, {"shared_kv_states": holder})
+    assert mapped["shared_kv_states"] is holder
+
+    plain = {1: ("k", "v")}
+    mapped_plain = pytree.tree_map(lambda t: t, {"shared_kv_states": plain})
+    assert mapped_plain["shared_kv_states"] is not plain  # demonstrates the bug
+
+
+def test_fsdp_cast_breaks_sharing_without_fix():
+    model = _TextModel()
+    _simulate_fsdp_cast(model)
+    with pytest.raises(KeyError):
+        model(torch.zeros(2))
+
+
+def test_install_kv_sharing_holder_restores_sharing():
+    model = _TextModel()
+    _simulate_fsdp_cast(model)
+
+    n = install_kv_sharing_holder([model])
+    assert n == 3  # all three layers hooked
+
+    # No KeyError, and the shared K/V (zeros) flow through.
+    out = model(torch.zeros(2))
+    assert torch.allclose(out, torch.zeros(2))
+
+
+def test_holder_resets_between_forwards():
+    model = _TextModel()
+    install_kv_sharing_holder([model])
+    model(torch.zeros(2))
+    # Layer 0 (first) clears the holder each forward, so no stale keys leak in.
+    holder = model.layers[0]._forward_pre_hooks  # presence check only
+    assert holder is not None
+    # A second forward must still succeed (holder reset, then re-populated).
+    out = model(torch.ones(2))
+    assert out.shape == (2,)
+
+
+def test_should_install_detects_kv_sharing():
+    assert should_install_kv_sharing_holder([_TextModel(num_kv_shared_layers=2)]) is True
+
+
+def test_should_install_false_without_kv_sharing():
+    model = _TextModel(num_kv_shared_layers=0)
+    assert should_install_kv_sharing_holder([model]) is False
+    assert install_kv_sharing_holder([model]) == 0
+
+
+def test_install_is_idempotent_per_stack():
+    model = _TextModel()
+    first = install_kv_sharing_holder([model])
+    second = install_kv_sharing_holder([model])
+    assert first == 3
+    assert second == 0  # already installed -> skipped

--- a/tests/unit_tests/_transformers/v4_patches/test_kv_sharing.py
+++ b/tests/unit_tests/_transformers/v4_patches/test_kv_sharing.py
@@ -69,9 +69,11 @@ class _Layer(nn.Module):
 class _TextModel(nn.Module):
     """Tiny stand-in for Gemma3nTextModel: stores K/V at layer 1, reads at 2."""
 
-    def __init__(self, num_kv_shared_layers=2):
+    def __init__(self, num_kv_shared_layers=2, model_type="gemma3n_text"):
         super().__init__()
-        self.config = SimpleNamespace(num_hidden_layers=3, num_kv_shared_layers=num_kv_shared_layers)
+        self.config = SimpleNamespace(
+            num_hidden_layers=3, num_kv_shared_layers=num_kv_shared_layers, model_type=model_type
+        )
         self.layers = nn.ModuleList(
             [
                 _Layer(_Attn(0, is_shared=False, kv_idx=None, store_full=False)),
@@ -166,6 +168,18 @@ def test_should_install_false_without_kv_sharing():
     model = _TextModel(num_kv_shared_layers=0)
     assert should_install_kv_sharing_holder([model]) is False
     assert install_kv_sharing_holder([model]) == 0
+
+
+def test_skips_non_gemma3n_kv_sharing_models():
+    """Other kv-sharing models (e.g. gemma4) manage their own FSDP2-safe store
+    in-model and may thread a caller-supplied store (the drafter). Injecting our
+    holder there would clobber it (regressed test_..._gemma4_joint_drafter), so
+    such models must be skipped."""
+    model = _TextModel(num_kv_shared_layers=2, model_type="gemma4_text")
+    assert should_install_kv_sharing_holder([model]) is False
+    assert install_kv_sharing_holder([model]) == 0
+    # Layers are untouched: the caller-supplied dict still flows through.
+    assert not getattr(model.layers[0], "_kv_sharing_holder_installed", False)
 
 
 def test_install_is_idempotent_per_stack():


### PR DESCRIPTION
## Summary

Fixes **AM-454**: `KeyError: 18` (cross-layer KV sharing) when fine-tuning **gemma3n** (`gemma3n_vl_4b_medpix`) on multiple GPUs with FSDP2 and transformers that use the `shared_kv_states` dict API (e.g. 5.8.x).

```
File ".../transformers/models/gemma3n/modeling_gemma3n.py", line 1241, in forward
    key_states, value_states = shared_kv_states[self.kv_shared_layer_index]
KeyError: 18
```

## Root cause

HF gemma3n implements cross-layer KV sharing by threading a single **mutable `shared_kv_states` dict** through every decoder layer as a forward kwarg: the last full-length layer of each attention type (e.g. layers 18/19 for `gemma-3n-e4b`) writes its K/V into the dict, and the later "shared" layers (20–34) read it back.

Automodel's FSDP2 path wraps each decoder layer with `fully_shard` using `MixedPrecisionPolicy(cast_forward_inputs=True)`. That pre-forward casts inputs by running `tree_map` over `(args, kwargs)`, and `tree_map` **reconstructs every container it understands — including a plain `dict`** — so each wrapped layer receives a *fresh, empty copy* of `shared_kv_states`. The writer fills its throwaway copy; the reader sees an empty one → `KeyError`. Only triggers once `fully_shard` is active (`dp_shard > 1`, i.e. multi-GPU); single-GPU skips sharding and works. transformers 5.5.0 was immune because it routed sharing through the `Cache` object (`past_key_values.shared_layers`), which pytree treats as an opaque leaf.

## Fix

`nemo_automodel/_transformers/v4_patches/kv_sharing.py` — a pytree-opaque, dict-like `_SharedKVStates` holder. Because it is not a type pytree flattens, `tree_map` passes the *same instance* to every layer, so in-place writes are visible to the readers. `install_kv_sharing_holder()` registers a per-layer `forward_pre_hook` that swaps in one shared holder (reset on the first layer each forward); it is applied from `_apply_runtime_compatibility_fixes` (alongside the rotary fix, post-shard) and is a no-op for models without KV sharing. Lives with the other HF-model compat patches — the common parallelizer is untouched.

## Testing

- **Unit** (`tests/unit_tests/_transformers/v4_patches/test_kv_sharing.py`, CPU, 8 tests): reproduces the FSDP `tree_map` dict-copy bug on a tiny stand-in (KeyError without the fix), proves the holder restores sharing, is pytree-opaque, resets per forward, gates correctly, and is idempotent per stack.
- **End-to-end**: `gemma3n_vl_4b_medpix` on 2 GPUs (transformers 5.8.1) — previously `KeyError: 18` at the first forward, now trains cleanly (`Installed shared-KV-states holder on 35 decoder layers`; loss 3.19 → 2.82 → …). 8-GPU confirmation: trains cleanly to step 399/epoch 3 (0 KeyErrors).

## W&B validation run

Validated end-to-end with a 100-step tracked run on **8 GPUs** (transformers 5.8.1, fixed code from this branch, MedPix recipe):

🔗 https://wandb.ai/Nemo-automodel/huiyingl_workspace/runs/h1v5it6b

- `Installed shared-KV-states holder on 35 decoder layers` — the fix is active.
- **100/100 steps completed, 0 KeyErrors**; loss 3.19 → ~2.2 (decreasing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

