### PR TITLE
fix(qwen3_5_moe): convert MTP experts as grouped tensors (AM-442)

### DIFF
--- a/nemo_automodel/components/models/qwen3_5_moe/state_dict_adapter.py
+++ b/nemo_automodel/components/models/qwen3_5_moe/state_dict_adapter.py
@@ -287,41 +287,13 @@ class Qwen3_5MoeStateDictAdapter(StateDictAdapter):
 
         new_fqn = fqn
         value = tensor
-        mtp_gate_up_match = re.match(r"mtp\.layers\.(\d+)\.mlp\.experts\.gate_and_up_projs$", fqn)
-        mtp_down_match = re.match(r"mtp\.layers\.(\d+)\.mlp\.experts\.down_projs$", fqn)
-        if mtp_gate_up_match:
-            layer_num = mtp_gate_up_match.group(1)
-            splits, expert_ids = state_dict_utils.split_experts_weights_dtensor_aware(
-                tensor, self.moe_config.n_routed_experts
-            )
-            result = []
-            inter_dim = self.moe_config.moe_inter_dim
-            for expert_tensor, expert_id in zip(splits, expert_ids):
-                gate = expert_tensor[:, :inter_dim].transpose(0, 1)
-                up = expert_tensor[:, inter_dim:].transpose(0, 1)
-                if not state_dict_utils.is_dtensor(gate):
-                    gate = gate.contiguous()
-                if not state_dict_utils.is_dtensor(up):
-                    up = up.contiguous()
-                result.append((f"mtp.layers.{layer_num}.mlp.experts.{expert_id}.gate_proj.weight", gate))
-                result.append((f"mtp.layers.{layer_num}.mlp.experts.{expert_id}.up_proj.weight", up))
-            if exclude_key_regex:
-                result = [(key, val) for key, val in result if not re.match(exclude_key_regex, key)]
-            return result
-        if mtp_down_match:
-            layer_num = mtp_down_match.group(1)
-            splits, expert_ids = state_dict_utils.split_experts_weights_dtensor_aware(
-                tensor, self.moe_config.n_routed_experts
-            )
-            result = []
-            for expert_tensor, expert_id in zip(splits, expert_ids):
-                down = expert_tensor.transpose(0, 1)
-                if not state_dict_utils.is_dtensor(down):
-                    down = down.contiguous()
-                result.append((f"mtp.layers.{layer_num}.mlp.experts.{expert_id}.down_proj.weight", down))
-            if exclude_key_regex:
-                result = [(key, val) for key, val in result if not re.match(exclude_key_regex, key)]
-            return result
+        # MTP experts use the SAME grouped layout as the main decoder layers in the
+        # HF checkpoint (e.g. ``mtp.layers.0.mlp.experts.{gate_up_proj,down_proj}``),
+        # so they fall through to the generic grouped handling below. Splitting them
+        # into per-expert keys here produced destinations like
+        # ``mtp.layers.0.mlp.experts.224.down_proj.weight`` that don't exist in the
+        # checkpoint, raising "Missing key in checkpoint state_dict" on load under
+        # expert parallelism (AM-442).
         if ".mlp.experts.gate_and_up_projs" in fqn:
             new_fqn = fqn.replace(".mlp.experts.gate_and_up_projs", ".mlp.experts.gate_up_proj")
             value = tensor.transpose(1, 2)

--- a/tests/unit_tests/models/qwen3_5_moe/test_qwen3_5_moe_state_dict_adapter.py
+++ b/tests/unit_tests/models/qwen3_5_moe/test_qwen3_5_moe_state_dict_adapter.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
 from unittest.mock import Mock
 
 import pytest
@@ -673,24 +674,36 @@ class TestConvertSingleTensorToHf:
         assert result == [("mtp.fc.weight", tensor)]
 
     def test_mtp_expert_key_conversion(self, adapter):
+        # MTP experts convert to the GROUPED HF layout, identical to the main
+        # decoder layers — not per-expert keys (AM-442).
         tensor = torch.randn(4, 64, 128)
         result = adapter.convert_single_tensor_to_hf("mtp.layers.0.mlp.experts.gate_and_up_projs", tensor)
 
-        assert len(result) == 8
-        out = dict(result)
-        assert "mtp.layers.0.mlp.experts.0.gate_proj.weight" in out
-        assert "mtp.layers.0.mlp.experts.0.up_proj.weight" in out
-        torch.testing.assert_close(out["mtp.layers.0.mlp.experts.0.gate_proj.weight"], tensor[0, :, :64].T)
-        torch.testing.assert_close(out["mtp.layers.0.mlp.experts.0.up_proj.weight"], tensor[0, :, 64:].T)
+        assert len(result) == 1
+        key, value = result[0]
+        assert key == "mtp.layers.0.mlp.experts.gate_up_proj"
+        torch.testing.assert_close(value, tensor.transpose(1, 2))
+        # No per-expert keys are emitted.
+        assert not any(".experts.0." in k for k, _ in result)
 
     def test_mtp_down_expert_key_conversion(self, adapter):
         tensor = torch.randn(4, 64, 32)
         result = adapter.convert_single_tensor_to_hf("mtp.layers.0.mlp.experts.down_projs", tensor)
 
-        assert len(result) == 4
-        out = dict(result)
-        assert "mtp.layers.0.mlp.experts.0.down_proj.weight" in out
-        torch.testing.assert_close(out["mtp.layers.0.mlp.experts.0.down_proj.weight"], tensor[0].T)
+        assert len(result) == 1
+        key, value = result[0]
+        assert key == "mtp.layers.0.mlp.experts.down_proj"
+        torch.testing.assert_close(value, tensor.transpose(1, 2))
+
+    def test_mtp_experts_emit_no_per_expert_keys(self, adapter):
+        """AM-442 regression: to_hf must not fabricate per-expert MTP keys that are
+        absent from the grouped checkpoint (e.g. ``...experts.224.down_proj.weight``)."""
+        for native in ("mtp.layers.0.mlp.experts.gate_and_up_projs", "mtp.layers.0.mlp.experts.down_projs"):
+            result = adapter.convert_single_tensor_to_hf(native, torch.randn(4, 64, 32))
+            assert len(result) == 1
+            key = result[0][0]
+            assert key in ("mtp.layers.0.mlp.experts.gate_up_proj", "mtp.layers.0.mlp.experts.down_proj")
+            assert not re.search(r"\.experts\.\d+\.", key)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes **AM-442**: `RuntimeError: Missing key in checkpoint state_dict: mtp.layers.0.mlp.experts.224.down_proj.weight` when loading the Qwen3.6-35B-A3B MoE checkpoint under expert parallelism (recipes `qwen3_6_35b`, `qwen3_6_35b_lora`, `qwen3_6_35b_medpix_ep8cp2_4k`; Automodel main + transformers 5.8.1).

## Root cause

The MTP block's MoE experts are stored in the HF checkpoint in the **same grouped layout** as the main decoder layers — confirmed against the real checkpoint index (`Qwen/Qwen3.6-35B-A3B/model.safetensors.index.json`):

```
mtp.layers.0.mlp.experts.down_proj        # grouped 3-D tensor
mtp.layers.0.mlp.experts.gate_up_proj
```
(zero per-expert keys.)

But `Qwen3_5MoeStateDictAdapter.convert_single_tensor_to_hf` (the `to_hf` direction) **split the MTP experts into per-expert keys** (`mtp.layers.0.mlp.experts.{id}.down_proj.weight`), while leaving the main decoder layers grouped. When the checkpoint loader builds its load destinations by running the model state-dict through `to_hf`, it asked DCP to load into per-expert MTP keys that don't exist in the grouped checkpoint → missing-key error.

Under EP=8 with 256 experts, each rank owns 32 experts; rank 7 owns 224–255, so `split_experts_weights_dtensor_aware` emits expert **224** first on that rank — which is why 224 is the first key to fail.

## Fix

Remove the per-expert MTP branches in `convert_single_tensor_to_hf` so MTP experts fall through to the **generic grouped** rename+transpose already used for the main decoder layers, producing `mtp.layers.0.mlp.experts.{gate_up_proj,down_proj}` — exactly matching the on-disk keys. The grouped `from_hf` path already handles loading these (including EP-shard slicing).

## Testing

- `tests/unit_tests/models/qwen3_5_moe/test_qwen3_5_moe_state_dict_adapter.py` — updated the two `to_hf` MTP tests to assert the grouped output, and added `test_mtp_experts_emit_no_per_expert_keys` (AM-442 regression: `to_hf` must not fabricate `...experts.<id>....` keys). **47/47 pass**; `ruff` clean.
- Root cause byte-confirmed against the real checkpoint's safetensors index and against the transformers 5.8.1 `Qwen3_5MoeExperts` grouped-parameter definition.

## W&B validation run (end-to-end on the real 35B checkpoint)

Ran the exact failing recipe — `qwen3_6_35b` (Qwen3.6-35B-A3B, **EP=8 + MTP enabled**, `num_nextn_predict_layers: 1`) — on **8 GPUs** with transformers 5.8.1 and the fixed adapter, loading the grouped HF-hub checkpoint:

🔗 https://wandb.ai/Nemo-automodel/huiyingl_workspace/runs/amkgnw1h

- The 72 GB checkpoint **loads cleanly** — previously this exact path raised `RuntimeError: Missing key in checkpoint state_dict: mtp.layers.0.mlp.experts.224.down_proj.weight` on the EP rank that owns expert 224.
- **100/100 steps completed, 0 `Missing key` / 0 `KeyError`**; loss 2.06 → ~1.5 (decreasing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

