### PR TITLE
fix(vlm): enable activation checkpointing for 35B Qwen3.5/3.6 VLM recipes

### DIFF
--- a/examples/vlm_finetune/qwen3_5_moe/qwen3_5_35b.yaml
+++ b/examples/vlm_finetune/qwen3_5_moe/qwen3_5_35b.yaml
@@ -67,6 +67,10 @@ distributed:
   ep_size: 8
 
   sequence_parallel: false
+  # Recompute transformer-block activations in backward so the fp32 master weights
+  # (restored for custom MoE under FSDP2 in #1896) fit within 80GB; without this the
+  # 35B-A3B run OOMs intermittently at its ~67 GiB steady-state peak on 8xH100.
+  activation_checkpointing: true
 
 freeze_config:
   freeze_vision_tower: true

--- a/examples/vlm_finetune/qwen3_5_moe/qwen3_6_35b.yaml
+++ b/examples/vlm_finetune/qwen3_5_moe/qwen3_6_35b.yaml
@@ -71,6 +71,10 @@ distributed:
   ep_size: 8
 
   sequence_parallel: false
+  # Recompute transformer-block activations in backward so the fp32 master weights
+  # (restored for custom MoE under FSDP2 in #1896) fit within 80GB; without this the
+  # 35B-A3B run OOMs intermittently at its ~67 GiB steady-state peak on 8xH100.
+  activation_checkpointing: true
 
 freeze_config:
   freeze_vision_tower: true


### PR DESCRIPTION
# What does this PR do ?

Enables activation checkpointing on the two full fine-tune 35B-A3B VLM recipes (`qwen3_5_35b`, `qwen3_6_35b`) so they stop OOMing on 8×H100-80GB.

Since #1896 restored fp32 master weights for custom MoE models under FSDP2 (a convergence fix), these recipes' steady-state peak memory rose ~3 GiB to ~67 GiB, leaving only ~2 GiB of headroom on 80 GB GPUs. With variable VLM/MoE batch sizes the backward pass intermittently exceeds the limit, so the nightly `qwen3_5_35b` job OOMs on some runs and passes on others at the same ~67 GiB peak. Reverting #1896 isn't an option (it fixes convergence), so this restores headroom by recomputing transformer-block activations in backward.

# Changelog

- `examples/vlm_finetune/qwen3_5_moe/qwen3_5_35b.yaml`: set `distributed.activation_checkpointing: true`.
- `examples/vlm_finetune/qwen3_5_moe/qwen3_6_35b.yaml`: same (identical pp1/ep8 full-FT layout).

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed Contributor guidelines
- [ ] Did you write any new necessary tests? — config-only change; covered by the existing nightly recipe tests
- [ ] Did you add or update any necessary documentation? — n/a

# Additional Information

Verified `qwen3_5_35b` on a single node × 8×H100-80GB (same container, model `Qwen/Qwen3.5-35B-A3B`, and nightly config as the failing job; 50 steps):

| `activation_checkpointing` | peak mem | result |
|------|----------|--------|
| off (current) | 67.2 GiB | OOM at step 31 (`Tried to allocate 1.89 GiB`), exit 1 |
| true (this PR) | 56.3 GiB | all 50 steps + validation, no OOM |

`qwen3_6_35b` is the identical pp1/ep8 full-FT analog, and its own `qwen3_6_35b_medpix_ep8cp2_4k` sibling already sets `activation_checkpointing: true`.

Other 35B configs were checked and intentionally left unchanged:
- `qwen3_5_35b_neat_packing` (pp2/ep4): verified on the same hardware — peaks at ~48 GiB and completes 50 steps **without** AC, so it doesn't need it.
- `qwen3_6_35b_lora` (LoRA): base weights frozen → low memory.
- `qwen3_6_35b_medpix_ep8cp2_4k`: already enables AC.
