### PR TITLE
fix(vlm): use FusedLinearCrossEntropy for qwen3_5_9b to avoid logits OOM

### DIFF
--- a/examples/vlm_finetune/qwen3_5/qwen3_5_9b.yaml
+++ b/examples/vlm_finetune/qwen3_5/qwen3_5_9b.yaml
@@ -71,7 +71,11 @@ freeze_config:
   freeze_language_model: false
 
 loss_fn:
-  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+  # FusedLinearCrossEntropy fuses the lm_head projection with cross-entropy and
+  # computes it in chunks, so the full [num_tokens, vocab] logits tensor is never
+  # materialized. MaskedCrossEntropy fp32-upcasts the full logits and OOMs at the
+  # F.cross_entropy call on large VLM batches (AM-457). Matches qwen3_6_27b_medpix.
+  _target_: nemo_automodel.components.loss.linear_ce.FusedLinearCrossEntropy
 
 dataset:
   _target_: nemo_automodel.components.datasets.vlm.datasets.make_medpix_dataset


### PR DESCRIPTION
# What does this PR do ?

Switches the `qwen3_5_9b` VLM fine-tune recipe to `FusedLinearCrossEntropy` so it stops CUDA-OOMing in the loss.

`MaskedCrossEntropy` fp32-upcasts the full `[num_tokens, vocab]` logits tensor and then calls `F.cross_entropy`, which spikes ~45 GiB on large vision-token batches (steady ~30 GiB → 77+ GiB) and OOMs at `masked_ce.py:84`. `FusedLinearCrossEntropy` fuses the lm_head projection with cross-entropy and computes it in chunks — with the recipe's `logits_to_keep=1` path the full logits matrix is never materialized. The sibling `qwen3_6_27b_medpix` recipes already use it for exactly this reason.

Fixes AM-457.

# Changelog

- `examples/vlm_finetune/qwen3_5/qwen3_5_9b.yaml`: switch `loss_fn` from `MaskedCrossEntropy` to `FusedLinearCrossEntropy`.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed Contributor guidelines
- [ ] Did you write any new necessary tests? — config-only change; covered by the existing nightly recipe test
- [ ] Did you add or update any necessary documentation? — n/a

# Additional Information

Verified on a single node × 8×H100-80GB (same container, model `Qwen/Qwen3.5-9B`, nightly config; 50 steps):

| `loss_fn` | peak mem | result |
|------|----------|--------|
| `MaskedCrossEntropy` (current) | — | OOM at step 31 in `cross_entropy` (`masked_ce.py:84`), exit 1 |
| `FusedLinearCrossEntropy` (this PR) | 37.7 GiB | all 50 steps + validation, no OOM |

No `output_hidden_states` flag was needed — the `loss_fn` swap is sufficient on its own.

**Training is numerically unaffected.** Loss tracks `MaskedCrossEntropy` within ~0.02 at every overlapping step (small fused-chunked-vs-full-CE fp-accumulation difference):

| step | MaskedCE loss | FLCE loss |
|-----:|--------------:|----------:|
| 0  | 2.0619 | 2.0616 |
| 5  | 1.6869 | 1.6895 |
| 10 | 1.8668 | 1.8632 |
| 15 | 1.7659 | 1.7502 |
| 20 | 1.8549 | 1.8505 |
| 25 | 1.8458 | 1.8430 |
| 31 | 1.6053 | 1.6113 |
| 40 | OOM    | 1.8815 |
| 49 | OOM    | 1.8947 |

FLCE validation loss at step 49: **1.5703**.
