### PR TITLE
fix(oom): use FusedLinearCrossEntropy in qwen3 tulu3 configs to avoid OOM

### DIFF
--- a/examples/convergence/tulu3/models/qwen3-4b/qwen3_4b_cp1_flashoptim.yaml
+++ b/examples/convergence/tulu3/models/qwen3-4b/qwen3_4b_cp1_flashoptim.yaml
@@ -6,7 +6,9 @@
 
 step_scheduler:
   global_batch_size: 128
-  local_batch_size: 8
+  # lb 8 backward-OOMs once FLCE removes the logits bottleneck (cp1, unbounded
+  # seqs); 4 keeps global_batch_size via grad-accum. cp2 keeps 8 (CP halves it).
+  local_batch_size: 4
   ckpt_every_steps: 500
   gc_every_steps: 10
   max_steps: 1000
@@ -23,6 +25,9 @@ rng:
 
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  # FusedLinearCrossEntropy fuses the lm_head projection with cross-entropy and
+  # needs the final hidden state instead of the full [bsz, seq, vocab] logits.
+  output_hidden_states: true
   pretrained_model_name_or_path: Qwen/Qwen3-4B-Base
   force_hf: true
 
@@ -51,7 +56,9 @@ distributed:
     layers_per_stage: 2
 
 loss_fn:
-  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+  # Avoids the full bf16->fp32 logit upcast that OOMs MaskedCrossEntropy on long
+  # tulu3 samples (truncation: false) on 8xH100-80GB. See PR #1554.
+  _target_: nemo_automodel.components.loss.linear_ce.FusedLinearCrossEntropy
 
 dataset:
   _target_: nemo_automodel.components.datasets.llm.chat_dataset.ChatDataset

--- a/examples/convergence/tulu3/models/qwen3-4b/qwen3_4b_cp1_te_fusedadam.yaml
+++ b/examples/convergence/tulu3/models/qwen3-4b/qwen3_4b_cp1_te_fusedadam.yaml
@@ -23,6 +23,9 @@ rng:
 
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  # FusedLinearCrossEntropy fuses the lm_head projection with cross-entropy and
+  # needs the final hidden state instead of the full [bsz, seq, vocab] logits.
+  output_hidden_states: true
   pretrained_model_name_or_path: Qwen/Qwen3-4B-Base
   force_hf: true
 
@@ -51,7 +54,9 @@ distributed:
     layers_per_stage: 2
 
 loss_fn:
-  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+  # Avoids the full bf16->fp32 logit upcast that OOMs MaskedCrossEntropy on long
+  # tulu3 samples (truncation: false) on 8xH100-80GB. See PR #1554.
+  _target_: nemo_automodel.components.loss.linear_ce.FusedLinearCrossEntropy
 
 dataset:
   _target_: nemo_automodel.components.datasets.llm.chat_dataset.ChatDataset

--- a/examples/convergence/tulu3/models/qwen3-4b/qwen3_4b_cp2_flashoptim.yaml
+++ b/examples/convergence/tulu3/models/qwen3-4b/qwen3_4b_cp2_flashoptim.yaml
@@ -23,6 +23,9 @@ rng:
 
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  # FusedLinearCrossEntropy fuses the lm_head projection with cross-entropy and
+  # needs the final hidden state instead of the full [bsz, seq, vocab] logits.
+  output_hidden_states: true
   pretrained_model_name_or_path: Qwen/Qwen3-4B-Base
   force_hf: true
 
@@ -55,7 +58,9 @@ autocast:
   dtype: bfloat16
 
 loss_fn:
-  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+  # Avoids the full bf16->fp32 logit upcast that OOMs MaskedCrossEntropy on long
+  # tulu3 samples (truncation: false) on 8xH100-80GB. See PR #1554.
+  _target_: nemo_automodel.components.loss.linear_ce.FusedLinearCrossEntropy
 
 dataset:
   _target_: nemo_automodel.components.datasets.llm.chat_dataset.ChatDataset

--- a/examples/convergence/tulu3/models/qwen3-moe-30b/qwen3_moe_30b_ep8_flashoptim.yaml
+++ b/examples/convergence/tulu3/models/qwen3-moe-30b/qwen3_moe_30b_ep8_flashoptim.yaml
@@ -20,6 +20,9 @@ rng:
 
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  # FusedLinearCrossEntropy fuses the lm_head projection with cross-entropy and
+  # needs the final hidden state instead of the full [bsz, seq, vocab] logits.
+  output_hidden_states: true
   pretrained_model_name_or_path: Qwen/Qwen3-30B-A3B-Base
   backend:
     _target_: nemo_automodel.components.models.common.BackendConfig
@@ -57,7 +60,9 @@ distributed:
     layers_per_stage: 2
 
 loss_fn:
-  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+  # Avoids the full bf16->fp32 logit upcast that OOMs MaskedCrossEntropy on long
+  # tulu3 samples (truncation: false) on 8xH100-80GB. See PR #1554.
+  _target_: nemo_automodel.components.loss.linear_ce.FusedLinearCrossEntropy
 
 dataset:
   _target_: nemo_automodel.components.datasets.llm.chat_dataset.ChatDataset

--- a/examples/convergence/tulu3/models/qwen3-moe-30b/qwen3_moe_30b_ep8_te_fusedadam.yaml
+++ b/examples/convergence/tulu3/models/qwen3-moe-30b/qwen3_moe_30b_ep8_te_fusedadam.yaml
@@ -20,6 +20,9 @@ rng:
 
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  # FusedLinearCrossEntropy fuses the lm_head projection with cross-entropy and
+  # needs the final hidden state instead of the full [bsz, seq, vocab] logits.
+  output_hidden_states: true
   pretrained_model_name_or_path: Qwen/Qwen3-30B-A3B-Base
   backend:
     _target_: nemo_automodel.components.models.common.BackendConfig
@@ -57,7 +60,9 @@ distributed:
     layers_per_stage: 2
 
 loss_fn:
-  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+  # Avoids the full bf16->fp32 logit upcast that OOMs MaskedCrossEntropy on long
+  # tulu3 samples (truncation: false) on 8xH100-80GB. See PR #1554.
+  _target_: nemo_automodel.components.loss.linear_ce.FusedLinearCrossEntropy
 
 dataset:
   _target_: nemo_automodel.components.datasets.llm.chat_dataset.ChatDataset


### PR DESCRIPTION
# What does this PR do ?
nvbug:6069279

Fixes the CUDA OOM in the `qwen3-4b` and `qwen3-moe-30b` tulu3 convergence configs (added in #1554) on 8×H100-80GB.

With `loss_fn: MaskedCrossEntropy` + `truncation: false`, a batch containing a long tulu3 sample builds the full `[tokens, vocab]` logit tensor that `masked_ce.py`'s `logits.float()` upcast must allocate contiguously in fp32 — **48 GiB** (4B, lb8) / **18.6 GiB** (30B). Switching to `FusedLinearCrossEntropy` + `output_hidden_states: true` makes the recipe take its `logits_to_keep=1` path, so the full logit matrix is never materialized (same fix as #2603 for the VLM recipe).

For `qwen3_4b_cp1_flashoptim`, removing the logits bottleneck then exposed a second, smaller backward-pass activation OOM at `local_batch_size: 8` with unbounded sequences, so that one config drops to `local_batch_size: 4` (global batch unchanged via grad accumulation). `cp2` keeps lb8 — context parallelism halves per-GPU sequence — and the `te_fusedadam`/30B configs already use lb2.

Related: #1554

# Changelog

- `qwen3-4b/qwen3_4b_cp1_flashoptim.yaml`: FusedLinearCrossEntropy + `output_hidden_states: true` + `local_batch_size` 8→4
- `qwen3-4b/qwen3_4b_cp1_te_fusedadam.yaml`: FusedLinearCrossEntropy + `output_hidden_states: true`
- `qwen3-4b/qwen3_4b_cp2_flashoptim.yaml`: FusedLinearCrossEntropy + `output_hidden_states: true`
- `qwen3-moe-30b/qwen3_moe_30b_ep8_flashoptim.yaml`: FusedLinearCrossEntropy + `output_hidden_states: true`
- `qwen3-moe-30b/qwen3_moe_30b_ep8_te_fusedadam.yaml`: FusedLinearCrossEntropy + `output_hidden_states: true`

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed Contributor guidelines
- [ ] Did you write any new necessary tests? — config-only; the convergence recipes are themselves the test
- [ ] Did you add or update any necessary documentation? — n/a

# Additional Information

Verified on a single node × 8×H100-80GB (`torchrun --standalone --nproc-per-node=8 … --step_scheduler.max_steps 10`):

| config | before (current) | after (this PR) |
|--------|------------------|-----------------|
| `qwen3_4b_cp1_flashoptim` | OOM **48.21 GiB** at `masked_ce.py` `logits.float()` | ✅ 10 steps + val, no OOM (FLCE + lb4) |
| `qwen3_moe_30b_ep8_flashoptim` | OOM **18.57 GiB** at `logits.float()` | ✅ 10 steps + val, no OOM (FLCE) |
| `qwen3_4b_cp2_flashoptim` | OOM (lb8, cp2) | ✅ 10 steps, no OOM (FLCE, lb8) |

The `te_fusedadam` variants (4B + 30B) take the same loss fix; their `local_batch_size: 2` already matches the confirmed-passing 30B config, and the loss OOM is optimizer-independent, so they follow the same verified pattern.

**Training loss is healthy with the fix** (per-step training loss; the baseline OOM'd before producing a usable series):

| step | `qwen3_4b_cp1` (FLCE+lb4) | `qwen3_4b_cp2` (FLCE) | `qwen3_moe_30b` (FLCE) |
|-----:|-------------------------:|----------------------:|-----------------------:|
| 0 | 0.6662 | 0.6663 | 0.9907 |
| 1 | 0.7060 | 0.7060 | 1.2140 |
| 2 | 0.6644 | 0.6645 | 0.9050 |
| 3 | 0.8198 | 0.8198 | 1.1948 |
| 4 | 0.8518 | 0.8518 | 1.0627 |
| 5 | 0.6910 | 0.6915 | 0.8153 |
| 6 | 0.6772 | 0.6775 | 0.8553 |
| 7 | 0.7120 | 0.7121 | 0.9920 |
| 8 | 0.6513 | 0.6513 | 0.8158 |
| 9 | 0.6414 | 0.6414 | 0.8868 |

(4B `cp1` and `cp2` track to ~1e-3 — same model/data/global batch, differing only in micro-batch × CP — confirming the `local_batch_size` and CP differences don't perturb training.)
