### PR TITLE
fix(docker): build DeepEP against the NVSHMEM wheel matching the apt runtime

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -75,29 +75,37 @@ RUN if [ "$INSTALL_TE" = "True" ]; then \
     cd ../ && rm -rf TransformerEngine; \
     fi
 
-# Install HybridEP
-## Dependency: RDMA Core
-RUN git clone https://github.com/linux-rdma/rdma-core.git && \
-    cd rdma-core && git checkout tags/v60.0 && sh build.sh
-ENV RDMA_CORE_HOME=/opt/rdma-core/build
-## Use stub of libnvidia-ml-dev during build only
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends libnvidia-ml-dev
+# Install HybridEP / DeepEP. Build with apt rdma-core v60 (so build==runtime libibverbs)
+# and RDMA_CORE_HOME symlinked to the system install; create the libnvshmem_host.so->.so.3
+# symlink required for DeepEP fabric handle ops; use the nvshmem wheel 3.6.5 and pin
+# DEEPEP_COMMIT to 17cfb817.
 COPY docker/common/deepep.patch /opt/deepep.patch
-ARG DEEPEP_COMMIT=7febc6e25660af0f54d95dd781ecdcd62265ecca
-RUN git clone -b hybrid-ep https://github.com/deepseek-ai/DeepEP.git
+ARG DEEPEP_COMMIT=17cfb817bccec3a9c247013360cc550c2bac441e
 ENV HYBRID_EP_MULTINODE=1
-RUN cd DeepEP && \
+ENV RDMA_CORE_HOME=/opt/rdma-core/build
+ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64/:$LD_LIBRARY_PATH
+RUN apt-get update && apt-get install -y --allow-change-held-packages \
+        rdma-core libibverbs-dev && \
+    apt-get clean && \
+    ARCH_LIB=$(dpkg-architecture -qDEB_HOST_MULTIARCH) && \
+    test -f /usr/lib/${ARCH_LIB}/libmlx5.so || \
+        ln -sf /usr/lib/${ARCH_LIB}/libmlx5.so.1 /usr/lib/${ARCH_LIB}/libmlx5.so && \
+    mkdir -p ${RDMA_CORE_HOME} && \
+    ln -sfn /usr/include ${RDMA_CORE_HOME}/include && \
+    ln -sfn /usr/lib/${ARCH_LIB} ${RDMA_CORE_HOME}/lib && \
+    git clone https://github.com/deepseek-ai/DeepEP.git && \
+    cd DeepEP && \
     git fetch origin $DEEPEP_COMMIT && \
     git checkout FETCH_HEAD && \
     patch -p1 < /opt/deepep.patch && \
-    pip install --no-cache-dir nvidia-nvshmem-cu13==3.4.5 && \
-    TORCH_CUDA_ARCH_LIST="9.0 10.0 12.0" MAX_JOBS=8 pip install --no-build-isolation . && \
-    apt-get purge -y libnvidia-ml-dev && \
-    apt-get autoremove -y && \
-    rm -rf /var/lib/apt/lists/* && \
-    rm -rf /opt/deepep.patch && \
-    cd / && rm -rf DeepEP rdma-core
+    pip install --no-cache-dir nvidia-nvshmem-cu13==3.6.5 && \
+    NVSHMEM_LIB_PATH=$(pip show nvidia-nvshmem-cu13 | grep "Location:" | cut -d' ' -f2)/nvidia/nvshmem/lib && \
+    ln -sf ${NVSHMEM_LIB_PATH}/libnvshmem_host.so.3 ${NVSHMEM_LIB_PATH}/libnvshmem_host.so && \
+    apt-get update && apt-get install -y --no-install-recommends libnvidia-ml-dev && \
+    TORCH_CUDA_ARCH_LIST="9.0 10.0 12.0" pip install --no-cache-dir --no-build-isolation -v . && \
+    apt-get purge -y libnvidia-ml-dev && apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/* /opt/deepep.patch && \
+    cd / && rm -rf DeepEP
 
 # Install Bitsandbytes
 ARG INSTALL_BITSANDBYTES=True

--- a/examples/llm_finetune/glm/glm_4.5_air_te_deepep.yaml
+++ b/examples/llm_finetune/glm/glm_4.5_air_te_deepep.yaml
@@ -38,6 +38,9 @@ rng:
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: zai-org/GLM-4.5-Air
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    dispatcher: hybridep
 
 checkpoint:
   enabled: false


### PR DESCRIPTION
## What

`glm_4.5_air_te_deepep` (8-node, ep32) hangs in DeepEP **internode** dispatch. Debugging surfaced two independent DeepEP build/runtime problems on the image; this PR fixes both.

## 1. NVSHMEM device/host version mismatch (`docker/Dockerfile`)

The image shipped a single `deep_ep_cpp.so` whose two halves linked **different** NVSHMEM versions:

- the **device** kernels were statically linked against the **3.4.5** `nvidia-nvshmem-cu13` pip wheel — DeepEP's `setup.py` leaves `NVSHMEM_DIR` unset and falls back to `find_spec("nvidia.nvshmem")`, so it baked the installed wheel's `libnvshmem_device.a` (3.4.5) straight into the `.so`;
- the **host** side links the soname `libnvshmem_host.so.3`, which at runtime resolves to the system **apt** `libnvshmem3-cuda-13` **3.6.5** (torch's `libtorch_nvshmem.so` loads it first — the failing job logs `NVSHMEM v3.6.5`).

So one library ran **device NVSHMEM 3.4.5 + host NVSHMEM 3.6.5** — an unintended split across the device/host boundary, with no guarantee the two builds' device-state ABI agree. This was image-global: it affected every DeepEP/MoE workload on the image, not just this recipe.

Fix: pin **`nvidia-nvshmem-cu13==3.6.5`** so the device side matches the 3.6.5 apt host runtime, and add the `libnvshmem_host.so` → `.so.3` symlink (required for the DeepEP host link + fabric handle ops). Also switch to apt `rdma-core` v60 + `libibverbs-dev` (so build==runtime libibverbs) with `RDMA_CORE_HOME` pointed at the system install, set `LD_LIBRARY_PATH=/usr/local/cuda/lib64`, and pin `DEEPEP_COMMIT=17cfb817`.

## 2. Internode MoE dispatcher backend — the actual hang (`glm_4.5_air_te_deepep.yaml`)

Matching the NVSHMEM version is necessary but **not** sufficient: even with device==host==3.6.5, the default **`deepep`** dispatcher (`Buffer.internode_dispatch`) still faults internode with an illegal memory access at `csrc/kernels/internode.cu:346` (recv counters stuck at `-1` → `RuntimeError: DeepEP error: timeout (dispatch CPU)`). The **`hybridep`** path (`HybridEPBuffer`) does not.

Fix: set `model.backend.dispatcher: hybridep` so MoE dispatch goes through `HybridEPBuffer`, matching the other internode deepep recipes (`gpt_oss_120b`, `ling_1t_sft`, `qwen3_moe_*_gb200`, `deepseek_v3_*_gb200`).

## Why both changes ship together

An earlier attempt to enable `hybridep` on the **prior** image via a config override (job [343337035](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/343337035)) did **not** take effect: with `TEST_IMAGE` set, CI uses the image's *baked* config, so the override was dropped and the job re-ran the `deepep` path — faulting again at `internode.cu:346` (`recv -1`). `hybridep` was therefore never exercised on the old DeepEP build (`7febc6e`) in isolation, so config-alone on that image is unverified. The validated configuration is the Dockerfile build change **and** the `hybridep` config together (below).

## Validation

`glm_4.5_air_te_deepep` passes internode (8-node, eos) on a build carrying both changes:
- pipeline: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/55134157
- glm test job: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/343356317 (succeeded)

Standalone DeepEP `test_hybrid_ep.py` (2-node, eos) also passes (correctness for BF16 and FP8 + real RDMA throughput) where the normal `internode_dispatch` faults.
