### PR TITLE
fix(config): validate pp_size against distributed.pipeline

### DIFF
--- a/nemo_automodel/recipes/_dist_utils.py
+++ b/nemo_automodel/recipes/_dist_utils.py
@@ -160,11 +160,22 @@ def parse_distributed_section(cfg_dict: dict) -> dict:
     if activation_checkpointing == "selective" and strategy_name != "fsdp2":
         raise ValueError("selective activation checkpointing is supported only for FSDP2 configs.")
 
-    # YAML-level sanity: silently discard sub-configs that don't apply to the
-    # current parallelism sizes (e.g. pipeline section present but pp_size=1,
-    # which is common when a YAML template is overridden via CLI).
+    # `distributed.pipeline` and `pp_size` are validated asymmetrically:
+    #   * pipeline block with pp_size<=1 -> WARN (inert; block ignored). This is
+    #     often intentional -- a recipe keeps the pipeline section as a reference
+    #     and toggles pp_size via CLI (e.g. ep8/pp1 vs ep4/pp2 parity debugging),
+    #     and tests load such configs with `--distributed.pp_size 1`. A hard error
+    #     can't be fixed by a static YAML edit when pp_size is overridden at launch.
+    #   * pp_size>1 with no pipeline block -> ERROR. This is an unambiguous
+    #     misconfiguration: PP is requested but the schedule/microbatch size are
+    #     unspecified. (An explicit empty `pipeline: {}` opts into defaults.)
     pp_size: int = parallelism.get("pp_size") or 1
     if pipeline_dict is not None and pp_size <= 1:
+        logger.warning(
+            "`distributed.pipeline` is set but pp_size=%d (<= 1): pipeline parallelism "
+            "is disabled and the pipeline settings are ignored. Set pp_size > 1 to enable it.",
+            pp_size,
+        )
         pipeline_dict = None
     if moe_dict is not None and ep_size <= 1:
         moe_dict = None
@@ -177,7 +188,12 @@ def parse_distributed_section(cfg_dict: dict) -> dict:
             pipeline_dict["dtype"] = dtype_from_str(pipeline_dict["dtype"])
         pipeline_config = PipelineConfig(**pipeline_dict)
     elif pp_size > 1:
-        pipeline_config = PipelineConfig()
+        raise ValueError(
+            f"`pp_size={pp_size}` (> 1) enables pipeline parallelism but no "
+            "`distributed.pipeline` block was provided. Add a `distributed.pipeline` "
+            "section (e.g. `pp_schedule`, `pp_microbatch_size`); an empty "
+            "`pipeline: {}` selects defaults."
+        )
     else:
         pipeline_config = None
 

--- a/tests/unit_tests/recipes/test_dist_utils.py
+++ b/tests/unit_tests/recipes/test_dist_utils.py
@@ -116,6 +116,7 @@ class TestParsing:
             "cp_size": 2,
             "ep_size": 2,
             "dp_replicate_size": 2,
+            "pipeline": {},  # pp_size>1 requires a pipeline block (empty = defaults)
         }
         result = parse_distributed_section(cfg)
         assert result["dp_size"] == 4
@@ -172,21 +173,32 @@ class TestPipeline:
         assert result["pipeline_config"].pp_schedule == "1f1b"
 
     def test_pp_enabled_true_when_pp_gt_1(self):
-        assert parse_distributed_section({"pp_size": 2})["pp_enabled"] is True
+        assert parse_distributed_section({"pp_size": 2, "pipeline": {}})["pp_enabled"] is True
 
-    def test_default_pipeline_config_created_when_pp_gt_1_and_no_pipeline_dict(self):
-        """pp_size > 1 without a pipeline section must still yield a PipelineConfig."""
-        result = parse_distributed_section({"pp_size": 4})
-        assert result["pp_enabled"] is True
-        assert isinstance(result["pipeline_config"], PipelineConfig)
-        assert result["pipeline_config"].pp_schedule == "1f1b"
+    def test_pp_gt_1_without_pipeline_raises(self):
+        """pp_size > 1 with no pipeline section is an unambiguous misconfiguration
+        (PP requested but schedule/microbatch unspecified), so it must raise. An
+        explicit empty `pipeline: {}` opts into defaults instead."""
+        with pytest.raises(ValueError, match="pipeline"):
+            parse_distributed_section({"pp_size": 4})
 
     def test_pp_enabled_false_when_pp_eq_1(self):
         assert parse_distributed_section({"pp_size": 1})["pp_enabled"] is False
 
+    def test_pipeline_with_pp_le_1_warns_and_is_dropped(self, caplog):
+        """A pipeline block with pp_size<=1 is inert: it is dropped (not an error) and a
+        warning is logged. Recipes legitimately keep the section as a reference and toggle
+        pp_size via CLI (e.g. ep8/pp1 vs ep4/pp2 parity debugging)."""
+        cfg = {"pp_size": 1, "pipeline": {"pp_schedule": "1f1b", "pp_microbatch_size": 4}}
+        with caplog.at_level("WARNING"):
+            result = parse_distributed_section(cfg)
+        assert result["pipeline_config"] is None
+        assert result["pp_enabled"] is False
+        assert "pipeline parallelism is disabled" in caplog.text
+
     def test_pipeline_dtype_defaults_to_mp_policy_output_dtype(self):
         """Unset pipeline.dtype is derived from the FSDP mp_policy output dtype (bf16 default)."""
-        result = parse_distributed_section({"pp_size": 2})
+        result = parse_distributed_section({"pp_size": 2, "pipeline": {}})
         assert result["pipeline_config"].dtype == torch.bfloat16
 
     def test_pipeline_dtype_explicit_match_kept(self, caplog):
@@ -391,14 +403,14 @@ class TestValidation:
             parse_distributed_section({"strategy": "unknown"})
 
     def test_pipeline_requires_pp_gt_1(self):
-        """Pipeline section is silently discarded when pp_size <= 1
+        """Pipeline section is discarded (with a warning) when pp_size <= 1
         (common when a YAML template is overridden via CLI)."""
         result = parse_distributed_section({"pp_size": 1, "pipeline": {"pp_schedule": "1f1b"}})
         assert result["pipeline_config"] is None
         assert result["pp_enabled"] is False
 
     def test_pipeline_rejects_default_pp_size(self):
-        """Pipeline section is silently discarded when pp_size defaults to 1."""
+        """Pipeline section is discarded (with a warning) when pp_size defaults to 1."""
         result = parse_distributed_section({"pipeline": {"pp_schedule": "1f1b"}})
         assert result["pipeline_config"] is None
         assert result["pp_enabled"] is False


### PR DESCRIPTION
## Summary

Validate `distributed.pipeline` against `pp_size` **asymmetrically** — warn on
the recoverable mismatch, hard-error on the unambiguous one:

- a `pipeline:` block with `pp_size <= 1` → inert (PP disabled); the block is
  dropped and a **warning** is logged.
- `pp_size > 1` with no `pipeline:` block → **`ValueError`**. PP is requested
  but the schedule / microbatch size are unspecified. An explicit empty
  `pipeline: {}` opts into defaults.

## Why the split

Keeping a `pipeline:` section at `pp_size=1` is intentional and useful: it's a
ready reference for enabling PP, and handy for `ep8/pp1` vs `ep4/pp2` parity
debugging (re-adding the section by hand is a pain). The L2 finetune tests also
load such configs and set `--distributed.pp_size 1` on the CLI — a hard error
there can't be fixed by a static YAML edit when `pp_size` is overridden at
launch. So that direction only warns.

The reverse — `pp_size > 1` with no `pipeline:` block — is an unambiguous
misconfiguration (PP requested, but the schedule is never specified), so it
fails fast instead of silently running with `PipelineConfig` defaults.

**No recipe changes** — earlier `pp_size` bumps were dropped; every config keeps
its pipeline section at `pp_size=1`. Verified across all example +
functional-test configs with a `distributed` section: **0 trip the new error**,
and the 38 `pipeline:`+`pp_size:1` template recipes only warn.

## Testing

`tests/unit_tests/recipes/test_dist_utils.py`: **71 passed.** Covers both
directions — warn-and-drop for `pipeline:`+`pp<=1`, and
`pytest.raises(ValueError)` for `pp>1` with no block (empty `pipeline: {}` still
opts into defaults).