### PR TITLE
fix(qwen3_moe): keep native forward under PP so CP+THD works

### DIFF
--- a/examples/llm_finetune/qwen/qwen3_moe_30b_te_chat_thd.yaml
+++ b/examples/llm_finetune/qwen/qwen3_moe_30b_te_chat_thd.yaml
@@ -65,7 +65,7 @@ distributed:
   strategy: fsdp2
   tp_size: 1
   cp_size: 2
-  pp_size: 1
+  pp_size: 2
   ep_size: 4
 
   sequence_parallel: false
@@ -73,7 +73,7 @@ distributed:
 
   pipeline:
     pp_schedule: interleaved1f1b
-    pp_microbatch_size: 4
+    pp_microbatch_size: 1
     round_virtual_stages_to_pp_multiple: down
     scale_grads_in_schedule: false
     patch_inner_model: false
@@ -131,3 +131,7 @@ optimizer:
 
 ci:
   recipe_owner: hemildesai
+  # pp_size=2 splits the model across 2 pipeline stages; needs 2 nodes (16xH100)
+  # so each stage's shard fits in 80GB (pp=2 on a single node is memory-neutral
+  # vs pp=1 and still OOMs). Verified at ~19 GiB/GPU on cw-dfw.
+  nodes: 2

--- a/nemo_automodel/components/models/qwen3_moe/model.py
+++ b/nemo_automodel/components/models/qwen3_moe/model.py
@@ -232,6 +232,16 @@ class Qwen3MoeModel(nn.Module):
 
 
 class Qwen3MoeForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
+    # Skip patch_hf_model_for_pp: this model's own forward already handles
+    # pipeline-parallel stage routing (embed_tokens/norm/lm_head are None off the
+    # owning stage; hidden states arrive in the input_ids slot) AND context
+    # parallelism + THD via the native freqs_cis path
+    # (position_ids_to_freqs_cis + apply_rotary_emb_qk with cu_seqlens/cp_*).
+    # The generic HF pipeline forward assumes the HF rotary API
+    # (rotary_emb(x, position_ids) -> cos/sin) and crashes on the freqs_cis /
+    # THD / CP path, so it must not clobber our forward.
+    _pp_keep_self_forward: bool = True
+
     @dataclass(frozen=True)
     class ModelCapabilities:
         """Declared parallelism capabilities for this model class."""

--- a/tests/unit_tests/models/qwen3_moe/test_qwen3_moe_pp.py
+++ b/tests/unit_tests/models/qwen3_moe/test_qwen3_moe_pp.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU-only checks for Qwen3-MoE pipeline-parallel compatibility."""
+
+from nemo_automodel.components.distributed.pipelining.hf_utils import model_keeps_self_forward
+from nemo_automodel.components.models.qwen3_moe.model import Qwen3MoeForCausalLM
+
+
+def test_pp_keep_self_forward_is_declared():
+    """Pipeline parallelism must preserve Qwen3-MoE's own forward.
+
+    Qwen3-MoE uses the gpt_oss-style RoPE (``position_ids_to_freqs_cis`` +
+    ``apply_rotary_emb_qk`` with ``cu_seqlens``/``cp_size``/``cp_rank``) and a
+    ``freqs_cis`` decoder-layer API. Without ``_pp_keep_self_forward = True`` the
+    PP builder replaces the forward with the generic HF one that calls
+    ``rotary_emb(hidden_states, position_ids)`` and crashes inside
+    ``apply_rotary_emb`` under THD + context parallelism
+    (``RuntimeError: Sizes of tensors must match ... at torch.cat``). The model's
+    own forward already handles PP stage routing (``embed_tokens``/``norm``/
+    ``lm_head`` are ``None`` off the owning stage; hidden states arrive in the
+    ``input_ids`` slot) and CP + THD.
+    """
+    assert getattr(Qwen3MoeForCausalLM, "_pp_keep_self_forward", False) is True
+    # The pipeline build call site keys off model_keeps_self_forward(...).
+    model = Qwen3MoeForCausalLM.__new__(Qwen3MoeForCausalLM)
+    assert model_keeps_self_forward(model) is True


### PR DESCRIPTION
## Summary

`Qwen3MoeForCausalLM` crashed under pipeline parallelism whenever it was combined
with context parallelism + THD packed sequences (e.g.
`qwen3_moe_30b_te_chat_thd` at `pp_size>1`):

```
RuntimeError: Sizes of tensors must match except in dimension 2.
              Expected size 512 but got size 1     (apply_rotary_emb → torch.cat)
```

**Root cause:** the model didn't declare `_pp_keep_self_forward = True`, so the PP
builder replaced its forward with the **generic HF pipeline forward**. That
forward assumes the HF rotary API (`rotary_emb(x, position_ids) -> (cos, sin)`
and `layer(hidden, position_ids, position_embeddings)`). But Qwen3-MoE uses the
gpt_oss-style rope — `position_ids_to_freqs_cis(...)` + per-layer
`apply_rotary_emb_qk(q, k, freqs_cis, qkv_format, cu_seqlens, cp_size, cp_rank)` —
so the generic forward fed `position_ids` where a tensor was expected and crashed
in RoPE under THD/CP.

## Fix

Declare `_pp_keep_self_forward = True` on `Qwen3MoeForCausalLM` (one line), matching
the sibling native MoE models (`nemotron_v3`, `qwen3_5_moe`, `ling_v2`). The
model's own forward is **already PP-stage-aware** — `embed_tokens`/`norm`/`lm_head`
are `None` off the owning stage (`compute_lm_head_logits` passes hidden through),
hidden states arrive in the `input_ids` slot (`squeeze_input_for_thd` handles the
`[1, T, hidden]` case), and CP is handled inside TE attention via
`cp_size`/`cp_rank`. The stage wrapper (`_wrap_stage_forward_to_emit_tensor`)
unwraps the returned `CausalLMOutputWithPast` to a tensor. No framework changes
needed — just stop clobbering the good forward.

## Verification (16×H100, cw-dfw)

`qwen3_moe_30b_te_chat_thd` at **`pp_size=2`, `cp_size=2`, THD** on 2 nodes:
- RoPE crash gone; **trained 20/20 steps**, `torchrun exit 0` on both nodes.
- Loss healthy (~0.7–1.4); **~19 GiB/GPU, no OOM** (PP splits the model across the
  two nodes — vs 58 GiB at `pp=1` and the original 79 GiB OOM).

Adds a CPU unit test asserting the opt-in flag is declared and recognized by
`model_keeps_self_forward`.
