### PR TITLE
fix(moe): default ignore_router_for_ac=True for activation checkpointing

### DIFF
--- a/nemo_automodel/components/distributed/config.py
+++ b/nemo_automodel/components/distributed/config.py
@@ -125,7 +125,11 @@ class DistributedSetup:
 class MoEParallelizerConfig:
     """Configuration for MoE model parallelization (EP + FSDP settings)."""
 
-    ignore_router_for_ac: bool = False
+    # Default True: under activation checkpointing the MoE router output must be saved
+    # rather than recomputed. Recomputing the router can route a different number of tokens
+    # per expert than the forward pass, which makes torch.utils.checkpoint raise a
+    # CheckpointError on the backward recompute.
+    ignore_router_for_ac: bool = True
     reshard_after_forward: bool = False
     lm_head_precision: Optional[Union[str, torch.dtype]] = None
     wrap_outer_model: bool = True

--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -210,7 +210,7 @@ def apply_ep(model: nn.Module, ep_mesh: DeviceMesh, moe_mesh: DeviceMesh | None 
 
 def apply_ac(
     model: nn.Module,
-    ignore_router: bool = False,
+    ignore_router: bool = True,
     hidden_size: int | None = None,
     num_experts: int | None = None,
     selective: bool = False,
@@ -219,7 +219,9 @@ def apply_ac(
 
     Args:
         model: The model to apply activation checkpointing to.
-        ignore_router: If True, uses selective checkpointing that saves router outputs.
+        ignore_router: If True (the default), saves the MoE router output so the dispatch
+            is not recomputed under activation checkpointing (avoids a CheckpointError from
+            non-deterministic re-routing on recompute). If False, a warning is emitted.
         hidden_size: Hidden dimension size. If None, derived from model.config.hidden_size.
         num_experts: Number of routed experts. If None, derived from moe_config.n_routed_experts
             first, then falls back to model.config attributes.
@@ -228,6 +230,16 @@ def apply_ac(
             ``ignore_router``; the shared policy already saves expert-parallel communication
             collectives and ``topk``, so it composes with expert parallelism.
     """
+    if not selective and not ignore_router:
+        logger.warning(
+            "Activation checkpointing is enabled with ignore_router_for_ac=False. The MoE "
+            "router/dispatch will be recomputed in the backward pass, which can route a "
+            "different number of tokens per expert than the forward pass and crash with "
+            "torch.utils.checkpoint.CheckpointError ('Recomputed values ... have different "
+            "metadata'). Set ignore_router_for_ac=True (the default) to save the router "
+            "output and keep routing consistent across recompute."
+        )
+
     if selective:
         # Reuse the dense FSDP2 selective policy so the save-op set (attention,
         # matmuls, comm collectives, topk, D2H copies) stays single-sourced.
@@ -630,7 +642,7 @@ def parallelize_model(
     ep_axis_name: str | None = None,
     ep_shard_axis_names: tuple[str, ...] | None = None,
     activation_checkpointing: bool | str = False,
-    ignore_router_for_ac: bool = False,
+    ignore_router_for_ac: bool = True,
     reshard_after_forward: bool = False,
     lm_head_precision: str | torch.dtype | None = None,
     wrap_outer_model: bool = True,

--- a/tests/unit_tests/moe/test_parallelizer.py
+++ b/tests/unit_tests/moe/test_parallelizer.py
@@ -522,6 +522,24 @@ def test_apply_ac_wraps_blocks_with_and_without_context(monkeypatch):
     assert len(model.layers.registered) == 2
 
 
+def test_apply_ac_warns_when_router_is_recomputed(monkeypatch):
+    P = _import_parallelizer_with_stubs(monkeypatch)
+    monkeypatch.setattr(P, "ptd_checkpoint_wrapper", MagicMock(side_effect=lambda block, **kw: block))
+    monkeypatch.setattr(P, "create_selective_checkpoint_contexts", MagicMock(return_value="CTX"))
+    logger_mock = MagicMock()
+    monkeypatch.setattr(P, "logger", logger_mock)
+
+    # ignore_router=False under (non-selective) AC recomputes the router -> warn.
+    P.apply_ac(DummyModel([DummyBlock()]), ignore_router=False, hidden_size=7168, num_experts=256)
+    assert logger_mock.warning.call_count == 1
+    assert "ignore_router_for_ac" in logger_mock.warning.call_args[0][0]
+
+    # ignore_router=True (the default) saves the router output -> no warning.
+    logger_mock.reset_mock()
+    P.apply_ac(DummyModel([DummyBlock()]), ignore_router=True, hidden_size=7168, num_experts=256)
+    logger_mock.warning.assert_not_called()
+
+
 def test_apply_ac_uses_block_local_checkpointing_when_available(monkeypatch):
     P = _import_parallelizer_with_stubs(monkeypatch)
 
@@ -912,7 +930,7 @@ def test_parallelize_model_calls_subsystems_and_validates(monkeypatch):
     )
     apply_ep_mock.assert_called_once()
     # AC enabled
-    apply_ac_mock.assert_called_once_with(model, ignore_router=False, selective=False)
+    apply_ac_mock.assert_called_once_with(model, ignore_router=True, selective=False)
     # FSDP called with combined flags and derived meshes
     args, kwargs = apply_fsdp_mock.call_args
     # handle positional or keyword invocations
@@ -1789,8 +1807,8 @@ def test_parallelize_model_passes_ignore_router_for_ac_to_apply_ac(monkeypatch):
     assert kwargs.get("ignore_router") is True
 
 
-def test_parallelize_model_ignore_router_for_ac_defaults_to_false(monkeypatch):
-    """Test that parallelize_model defaults ignore_router_for_ac to False."""
+def test_parallelize_model_ignore_router_for_ac_defaults_to_true(monkeypatch):
+    """Test that parallelize_model defaults ignore_router_for_ac to True."""
     P = _import_parallelizer_with_stubs(monkeypatch)
     apply_ac_mock = MagicMock()
     monkeypatch.setattr(P, "apply_ac", apply_ac_mock)
@@ -1818,10 +1836,10 @@ def test_parallelize_model_ignore_router_for_ac_defaults_to_false(monkeypatch):
         activation_checkpointing=True,
     )
 
-    # Verify apply_ac was called with ignore_router=False (default)
+    # Verify apply_ac was called with ignore_router=True (default)
     apply_ac_mock.assert_called_once()
     args, kwargs = apply_ac_mock.call_args
-    assert kwargs.get("ignore_router") is False
+    assert kwargs.get("ignore_router") is True
     # Full (True) AC is not selective.
     assert kwargs.get("selective") is False
 
@@ -1857,7 +1875,7 @@ def test_parallelize_model_passes_selective_to_apply_ac(monkeypatch):
     apply_ac_mock.assert_called_once()
     _, kwargs = apply_ac_mock.call_args
     assert kwargs.get("selective") is True
-    assert kwargs.get("ignore_router") is False
+    assert kwargs.get("ignore_router") is True
 
 
 def test_apply_ac_selective_wraps_blocks_with_shared_policy(monkeypatch):

--- a/tests/unit_tests/recipes/test_dist_utils.py
+++ b/tests/unit_tests/recipes/test_dist_utils.py
@@ -245,7 +245,7 @@ class TestMoE:
     def test_empty_moe_dict_uses_defaults(self):
         result = parse_distributed_section({"ep_size": 2, "moe": {}})
         assert isinstance(result["moe_parallel_config"], MoEParallelizerConfig)
-        assert result["moe_parallel_config"].ignore_router_for_ac is False
+        assert result["moe_parallel_config"].ignore_router_for_ac is True
 
     def test_mp_policy_none_when_omitted(self):
         result = parse_distributed_section({"ep_size": 2, "moe": {}})


### PR DESCRIPTION
# What does this PR do ?

Makes `ignore_router_for_ac=True` the default so custom MoE models train correctly under activation checkpointing, and warns when it is explicitly disabled.

# Changelog

- `MoEParallelizerConfig.ignore_router_for_ac`, `parallelize_model(...)`, and `apply_ac(...)` now default to `True`.
- `apply_ac` emits a warning when activation checkpointing is enabled with `ignore_router_for_ac=False` (and selective AC is not in use), explaining the `CheckpointError` risk.
- Updated unit tests for the new default and added a test for the warning.

## Why

Under activation checkpointing the MoE block (router + token dispatch) is recomputed in the backward pass. Recomputing the router can route a **different number of tokens per expert** than the original forward, so TE's token-permutation buffers (`row_id_map`, per-expert grouped-GEMM inputs) change shape and `torch.utils.checkpoint` raises:

```
torch.utils.checkpoint.CheckpointError: Recomputed values for the following tensors
have different metadata than during the forward pass.
  row_id_map [18187,16] -> [18201,16];  per-expert buffers [34,2048] -> [35,2048]
```

This reliably breaks `qwen3_moe_30b_te_*` finetune tests on the **first training step** (also seen on `qwen3_moe_30b_te_hybridep`). Saving the router output (`ignore_router_for_ac=True`) pins the routing decision across the recompute so the permutation shapes match. The `deepseek_v4` recipes already set this explicitly; this makes it the safe default for all custom MoE models.

## Stack
```
[rank6]: Traceback (most recent call last):
[rank6]:   File "/opt/Automodel/examples/llm_finetune/finetune.py", line 44, in <module>
[rank6]:     main()
[rank6]:   File "/opt/Automodel/examples/llm_finetune/finetune.py", line 40, in main
[rank6]:     recipe.run_train_validation_loop()
[rank6]:   File "/opt/Automodel/nemo_automodel/recipes/llm/train_ft.py", line 1074, in run_train_validation_loop
[rank6]:     train_log_data = self._run_train_optim_step(batches, self.max_grad_norm)
[rank6]:                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank6]:   File "/opt/Automodel/nemo_automodel/recipes/llm/train_ft.py", line 1339, in _run_train_optim_step
[rank6]:     self._forward_backward_step(
[rank6]:   File "/opt/Automodel/nemo_automodel/recipes/llm/train_ft.py", line 1281, in _forward_backward_step
[rank6]:     (local_loss * self._get_dp_group_size(include_cp=True)).backward()
[rank6]:   File "/usr/local/lib/python3.12/dist-packages/torch/_tensor.py", line 631, in backward
[rank6]:     torch.autograd.backward(
[rank6]:   File "/usr/local/lib/python3.12/dist-packages/torch/autograd/__init__.py", line 379, in backward
[rank6]:     _engine_run_backward(
[rank6]:   File "/usr/local/lib/python3.12/dist-packages/torch/autograd/graph.py", line 877, in _engine_run_backward
[rank6]:     return Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
[rank6]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank6]:   File "/usr/local/lib/python3.12/dist-packages/torch/autograd/function.py", line 317, in apply
[rank6]:     return user_fn(self, *args)
[rank6]:            ^^^^^^^^^^^^^^^^^^^^
[rank6]:   File "/usr/local/lib/python3.12/dist-packages/transformer_engine/pytorch/permutation.py", line 457, in backward
[rank6]:     row_id_map, pad_offsets = ctx.saved_tensors
[rank6]:                               ^^^^^^^^^^^^^^^^^
[rank6]:   File "/usr/local/lib/python3.12/dist-packages/torch/utils/checkpoint.py", line 1154, in unpack_hook
[rank6]:     frame.check_recomputed_tensors_match(gid)
[rank6]:   File "/usr/local/lib/python3.12/dist-packages/torch/utils/checkpoint.py", line 900, in check_recomputed_tensors_match
[rank6]:     raise CheckpointError(
[rank6]: torch.utils.checkpoint.CheckpointError: torch.utils.checkpoint: Recomputed values for the following tensors have different metadata than during the forward pass.
[rank6]: tensor at position 52:
[rank6]: saved metadata: {'shape': torch.Size([18187, 16]), 'dtype': torch.int32, 'device': device(type='cuda', index=6)}
[rank6]: recomputed metadata: {'shape': torch.Size([18201, 16]), 'dtype': torch.int32, 'device': device(type='cuda', index=6)}
[rank6]: tensor at position 53:
``` 


# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? (`test_parallelizer.py` + `test_dist_utils.py`, 136 passing; added `test_apply_ac_warns_when_router_is_recomputed`)
- [x] Did you add or update any necessary documentation? (updated `apply_ac` docstring)

# Additional Information

- Failing job: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/343744157 (pipeline 55200281, `main-mirror`, eos/H100)
- Behavior note: with the default now `True`, `apply_ac` derives `hidden_size`/`num_experts` for **every** MoE model (previously only when the flag was set). A model that doesn't expose these raises a clear `ValueError`; selective AC (`activation_checkpointing: selective`) remains an alternative that also saves the router/topk.