### PR TITLE
ci: raise ci.time for slow finetune recipes hitting 10-min default

### DIFF
--- a/examples/llm_finetune/deepseek_v4/deepseek_v4_flash_hellaswag_lora.yaml
+++ b/examples/llm_finetune/deepseek_v4/deepseek_v4_flash_hellaswag_lora.yaml
@@ -130,4 +130,5 @@ optimizer:
 ci:
   # pp_size(1) * ep_size(32) = 32 GPUs => 4 nodes (8 H100/node).
   recipe_owner: hemildesai
+  time: "00:20:00"
   nodes: 4

--- a/examples/llm_finetune/falcon/falcon_h1_34b_instruct_squad_peft.yaml
+++ b/examples/llm_finetune/falcon/falcon_h1_34b_instruct_squad_peft.yaml
@@ -106,5 +106,5 @@ optimizer:
 
 ci:
   recipe_owner: HuiyingLi
-  time: "00:15:00"
+  time: "00:25:00"
   nodes: 1

--- a/examples/llm_finetune/hy_v3/hy3_preview_deepep.yaml
+++ b/examples/llm_finetune/hy_v3/hy3_preview_deepep.yaml
@@ -138,4 +138,5 @@ ci:
   # Verified on cw (H100-80GB): trains at ~42 GiB/GPU. Note pp4*ep8=32 (4 nodes) OOMs
   # at the first optimizer.step, and dp does not shard the experts (only pp*ep does),
   # so the fix is more pp, not more dp; ep stays 8 to keep DeepEP intra-node.
+  time: "00:20:00"
   nodes: 8

--- a/examples/llm_finetune/llama3_3/llama_3_3_70b_instruct_squad_peft_qlora_spark.yaml
+++ b/examples/llm_finetune/llama3_3/llama_3_3_70b_instruct_squad_peft_qlora_spark.yaml
@@ -106,5 +106,6 @@ optimizer:
 
 ci:
   recipe_owner: akoumpa
+  time: "00:30:00"
   nproc_per_node: 1
   cluster_tag: digits

--- a/examples/llm_finetune/qwen/qwen3_8b_squad_spark.yaml
+++ b/examples/llm_finetune/qwen/qwen3_8b_squad_spark.yaml
@@ -98,5 +98,6 @@ lr_scheduler:
 
 ci:
   recipe_owner: akoumpa
+  time: "00:20:00"
   nproc_per_node: 1
   cluster_tag: digits


### PR DESCRIPTION
# What does this PR do ?

Raises the per-recipe CI wall clock (`ci.time`) for five finetune recipes that were cancelled by the Slurm `TIME LIMIT` **mid-training** (actively progressing — not hangs, OOM, or bugs) because they omit `ci.time` and inherit the 10-min default (falcon set it slightly too low).

# Changelog

- `deepseek_v4_flash_hellaswag_lora`: add `ci.time: "00:20:00"` (reached **49/50** under the 10-min default)
- `hy3_preview_deepep`: add `ci.time: "00:20:00"` (**33/50**, 8-node DeepEP)
- `qwen3_8b_squad_spark`: add `ci.time: "00:20:00"` (**50/50** done, killed during checkpoint consolidation)
- `llama_3_3_70b_instruct_squad_peft_qlora_spark`: add `ci.time: "00:30:00"` (**14/50** @ 25.6 s/step)
- `falcon_h1_34b_instruct_squad_peft`: bump `ci.time` `00:15:00` → `"00:25:00"` (**11/50** @ 18.4 s/step)

## Why

In pipeline [55200281](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/55200281) (main-mirror, eos/H100) these jobs were `CANCELLED ... DUE TO TIME LIMIT` while training was still advancing. `ci.time` **is** piped to the nemo-ci `sbatch --time` (falcon's `00:15:00` produced `--time 00:15:00`); recipes without it inherit the 10-min default, which is too short for these models. (`dist_env.timeout_minutes` is unrelated — it is only the `torch.distributed` init timeout.)

Evidence (genuine mid-work timeouts):
- deepseek_v4_flash_hellaswag_lora — https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/343744219
- hy3_preview_deepep — https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/343744102
- qwen3_8b_squad_spark — https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/343744150
- llama_3_3_70b…_qlora_spark — https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/343744261
- falcon_h1_34b_instruct_squad_peft — https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/343744224

Not included: `glm_5.1_hellaswag_pp` and `nemotron_ultra_v3_squad` also hit `TIME LIMIT`, but at **0/50** (pipeline-init stall / 550B setup) — hangs/setup, not mid-work; more wall time won't fix them.

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests? (N/A — CI metadata only)
- [ ] Did you add or update any necessary documentation? (N/A)

# Additional Information

- The two `_spark` recipes carry `cluster_tag: digits` / `nproc_per_node: 1` but ran on eos/H100 in this pipeline — the time bump helps regardless, but the cluster-tag mismatch may warrant a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
