### PR TITLE
ci: cap MAX_STEPS to 10 for slow vlm_finetune recipes

### DIFF
--- a/examples/vlm_finetune/gemma4/gemma4_26b_a4b_moe_packing.yaml
+++ b/examples/vlm_finetune/gemma4/gemma4_26b_a4b_moe_packing.yaml
@@ -101,6 +101,10 @@ freeze_config:
   freeze_audio_tower: true
   freeze_language_model: false
 
+ci:
+  env_vars:
+    MAX_STEPS: 10
+
 # wandb:
 #   project: <your-project>
 #   entity: <your-entity>

--- a/examples/vlm_finetune/qwen3_5/qwen3_5_27b_tp4pp4.yaml
+++ b/examples/vlm_finetune/qwen3_5/qwen3_5_27b_tp4pp4.yaml
@@ -105,3 +105,5 @@ ci:
   recipe_owner: HuiyingLi
   nodes: 2                          # TP=4 * PP=4 = 16 GPUs = 2 nodes x 8 GPUs
   time: "00:30:00"
+  env_vars:
+    MAX_STEPS: 10

--- a/examples/vlm_finetune/qwen3_5/qwen3_6_27b.yaml
+++ b/examples/vlm_finetune/qwen3_5/qwen3_6_27b.yaml
@@ -114,6 +114,10 @@ optimizer:
   lr: 1.0e-5
   weight_decay: 0.1
 
+ci:
+  env_vars:
+    MAX_STEPS: 10
+
 # wandb:
 #   project: your_wandb_project
 #   entity: your_wandb_entity

--- a/examples/vlm_finetune/qwen3_5/qwen3_6_27b_lora.yaml
+++ b/examples/vlm_finetune/qwen3_5/qwen3_6_27b_lora.yaml
@@ -127,6 +127,10 @@ optimizer:
   lr: 1.0e-4
   weight_decay: 0.01
 
+ci:
+  env_vars:
+    MAX_STEPS: 10
+
 # wandb:
 #   project: <your_wandb_project>
 #   entity: <your_wandb_entity>

--- a/examples/vlm_finetune/qwen3_5_moe/qwen3_5_35b_neat_packing.yaml
+++ b/examples/vlm_finetune/qwen3_5_moe/qwen3_5_35b_neat_packing.yaml
@@ -130,6 +130,8 @@ optimizer:
 
 ci:
   time: "00:15:00"
+  env_vars:
+    MAX_STEPS: 10
 
 # wandb:
 #   project: <your_wandb_project>


### PR DESCRIPTION
# What does this PR do ?

Caps the CI run to **10 steps** for five `vlm_finetune` recipes that were cancelled by the Slurm `TIME LIMIT` **mid-training** (actively progressing — not hangs/OOM/bugs), via each recipe's `ci:` block.

# Changelog

Adds `ci.env_vars.MAX_STEPS: 10` to:
- `qwen3_5/qwen3_6_27b_lora.yaml`
- `qwen3_5/qwen3_6_27b.yaml`
- `gemma4/gemma4_26b_a4b_moe_packing.yaml`
- `qwen3_5_moe/qwen3_5_35b_neat_packing.yaml`
- `qwen3_5/qwen3_5_27b_tp4pp4.yaml`

## Why / mechanism

In pipeline 55200226 (downstream child of [55200212](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/55200212), `main-mirror`, eos/H100) these were `CANCELLED ... DUE TO TIME LIMIT` while still advancing. Rather than only stretching the wall clock, cap the step count.

There is **no direct `ci.max_steps` key** — the supported path is `ci.env_vars`:
- `tests/ci_tests/utils/generate_ci_tests.py` injects `ci.env_vars` entries as CI job variables.
- `MAX_STEPS` maps to `step_scheduler.max_steps` in the `nightly`/`release`/`performance` phases (`tests/ci_tests/scripts/config_templates/ci_config.yaml`), overriding the default `50`.

Progress at the timeout (50-step default):
| recipe | progress | per-step |
|---|---|---|
| qwen3_6_27b_lora | 29/50 | 5.9 s |
| qwen3_6_27b | 21/50 | 7.7 s |
| gemma4_26b_a4b_moe_packing | 34/50 | 1.2 s (load-bound) |
| qwen3_5_35b_neat_packing | 5/50 | 53.8 s |
| qwen3_5_27b_tp4pp4 | 10/50 | 122.6 s (tps=73) |

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests? (N/A — CI recipe metadata)
- [ ] Did you add or update any necessary documentation? (N/A)

# Additional Information

- `qwen3_5_35b_neat_packing` (53.8 s/step) and `qwen3_5_27b_tp4pp4` (122.6 s/step, tps=73) are **pathologically slow** per step — even 10 steps leans on their existing `ci.time` (15 m / 30 m), so the underlying perf issue is worth a separate look.
- Sibling PR for the slow `llm_finetune` recipes (wall-clock approach): #2637.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
