### PR TITLE
fix(datasets): decode MedPix images on demand instead of up front

### DIFF
--- a/nemo_automodel/components/datasets/vlm/datasets.py
+++ b/nemo_automodel/components/datasets/vlm/datasets.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
 import json
 import logging
 import math
@@ -22,6 +23,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 
 import torch.utils.data
+from datasets import Image as HfImage
 from datasets import load_dataset
 from PIL import Image
 
@@ -111,24 +113,46 @@ def make_cord_v2_dataset(
 
 
 def make_medpix_dataset(path_or_dataset="medpix-dataset/medpix-dataset", split="train", **kwargs):
-    """Load and preprocess the MedPix dataset for image-to-text fine-tuning."""
-    dataset = load_dataset(path_or_dataset, split=split)
+    """Load and preprocess the MedPix dataset for image-to-text fine-tuning.
 
-    def format(example):
+    Formatting is deferred to ``__getitem__`` via ``with_transform`` so the
+    dataset stays Arrow-backed (no Python-side copy of every image). Images are
+    loaded undecoded (``Image(decode=False)``) and wrapped as lazy ``PIL``
+    handles (``Image.open`` reads only the header); the actual pixel decode then
+    happens on demand in the DataLoader workers, rather than eagerly decoding the
+    whole split up front.
+    """
+    dataset = load_dataset(path_or_dataset, split=split)
+    if "image_id" in getattr(dataset, "features", {}):
+        dataset = dataset.cast_column("image_id", HfImage(decode=False))
+
+    def lazy_image(value):
+        # ``Image(decode=False)`` yields a ``{"bytes": ..., "path": ...}`` dict.
+        if isinstance(value, dict):
+            if value.get("bytes") is not None:
+                return Image.open(io.BytesIO(value["bytes"]))
+            if value.get("path"):
+                return value["path"]
+        return value
+
+    def transform(batch):
         return {
             "conversation": [
-                {
-                    "role": "user",
-                    "content": [
-                        {"type": "image", "image": example["image_id"]},
-                        {"type": "text", "text": example["question"]},
-                    ],
-                },
-                {"role": "assistant", "content": [{"type": "text", "text": example["answer"]}]},
-            ],
+                [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "image", "image": lazy_image(image)},
+                            {"type": "text", "text": question},
+                        ],
+                    },
+                    {"role": "assistant", "content": [{"type": "text", "text": answer}]},
+                ]
+                for image, question, answer in zip(batch["image_id"], batch["question"], batch["answer"])
+            ]
         }
 
-    return [format(example) for example in dataset]
+    return dataset.with_transform(transform)
 
 
 def make_llava_onevision_dataset(

--- a/tests/unit_tests/datasets/vlm/test_datasets.py
+++ b/tests/unit_tests/datasets/vlm/test_datasets.py
@@ -139,19 +139,25 @@ def test_make_cord_v2_dataset(monkeypatch, stub_json2token, ground_key, wrapper)
 
 
 def test_make_medpix_dataset(monkeypatch):
-    """End-to-end sanity check for `make_medpix_dataset`."""
-    fake_ds = [
-        {
-            "image_id": "medpix_001.jpg",
-            "question": "What is shown in this medical image?",
-            "answer": "This is a chest X-ray showing normal lung fields.",
-        },
-        {
-            "image_id": "medpix_002.jpg",
-            "question": "Describe the findings in this image.",
-            "answer": "The image shows a fracture in the left femur.",
-        },
+    """End-to-end sanity check for `make_medpix_dataset`.
+
+    ``make_medpix_dataset`` defers formatting via ``with_transform`` and decodes
+    images lazily, so ``load_dataset`` is mocked with a real HF ``Dataset`` whose
+    ``image_id`` is an ``Image`` column (matching the production dataset).
+    """
+    from datasets import Dataset, Features, Value
+    from datasets import Image as HFImage
+
+    images = [Image.new("RGB", (8, 8), (255, 0, 0)), Image.new("RGB", (8, 8), (0, 255, 0))]
+    questions = ["What is shown in this medical image?", "Describe the findings in this image."]
+    answers = [
+        "This is a chest X-ray showing normal lung fields.",
+        "The image shows a fracture in the left femur.",
     ]
+    fake_ds = Dataset.from_dict(
+        {"image_id": images, "question": questions, "answer": answers},
+        features=Features({"image_id": HFImage(), "question": Value("string"), "answer": Value("string")}),
+    )
 
     # Patch `load_dataset` so no network call is issued.
     monkeypatch.setattr(ds, "load_dataset", lambda *a, **k: fake_ds)
@@ -159,23 +165,25 @@ def test_make_medpix_dataset(monkeypatch):
     result = ds.make_medpix_dataset()
 
     assert len(result) == len(fake_ds)
-    for sample, src in zip(result, fake_ds, strict=True):
+    for i in range(len(result)):
+        sample = result[i]
         assert list(sample) == ["conversation"]
 
         conversation = sample["conversation"]
         assert len(conversation) == 2
 
-        # user turn
+        # user turn -- image decode is deferred, so it surfaces as a lazy PIL handle
         user_turn = conversation[0]
         assert user_turn["role"] == "user"
-        assert user_turn["content"][0] == {"type": "image", "image": src["image_id"]}
-        assert user_turn["content"][1] == {"type": "text", "text": src["question"]}
+        image_item = user_turn["content"][0]
+        assert image_item["type"] == "image"
+        assert isinstance(image_item["image"], Image.Image)
+        assert user_turn["content"][1] == {"type": "text", "text": questions[i]}
 
         # assistant turn
         assistant_turn = conversation[1]
         assert assistant_turn["role"] == "assistant"
-        assistant_payload = assistant_turn["content"][0]
-        assert assistant_payload == {"type": "text", "text": src["answer"]}
+        assert assistant_turn["content"][0] == {"type": "text", "text": answers[i]}
 
 
 class _FakeHFDataset:


### PR DESCRIPTION
## What

`make_medpix_dataset` built its conversation list with `[format(ex) for ex in dataset]`, and `format` referenced `example["image_id"]` (an HF `Image` feature). Iterating therefore **decoded every image in the split up front** and held all 17,420 decoded images in memory before training started.

For short runs this is pure overhead: a 50-step `qwen3_5_4b_neat_packing` job on 8×H100 spent ~160 s in a GPU-idle dataset-build phase decoding the whole split, even though only ~50×GBS samples are consumed.

## Change (`datasets.py` only)

- Defer formatting to `__getitem__` via `dataset.with_transform(...)` — the dataset stays Arrow-backed, so images are **not** copied into a Python list.
- Load images undecoded (`cast_column("image_id", Image(decode=False))`) and wrap the bytes in a **lazy** `PIL.Image.open(BytesIO(...))` (header-only read). The pixel decode then happens on demand in the DataLoader workers; the existing `_preload_media` calls `.convert("RGB")` per sample.
- A lazy `PIL` handle is the form every consumer already accepts (training collate via `_preload_media`, and the validation collate/processor), so **no other files change**.

## Validation (qwen3_5_4b_neat_packing, Qwen3.5-4B, neat-packing, FSDP2, 8×H100, full dataset)

|  | dataset-build | end-to-end | result |
|---|---|---|---|
| before (eager) | ~160 s (0% GPU) | 11:53 | 50 steps + val + consolidated ckpt |
| after (this PR) | ~12 s | 7:51 | 50 steps + val + consolidated ckpt |

Loss unchanged (full before/after in the comment below). fd-safe: `BytesIO` holds no OS file descriptor — measured open-fd count stays flat (8) whether 0 or all 17,420 lazy handles are built.

## Note

The same eager-decode pattern exists in the other `make_*` VLM dataset builders (e.g. `make_cord_v2_dataset`); this PR fixes `make_medpix_dataset` (the one exercised by the timing-sensitive CI recipe). Happy to generalize.
