### PR TITLE
ci: bump unit-test timeouts to capture --durations report

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -377,10 +377,16 @@ jobs:
           - test-name: L0_Unit_Tests_CPU
             runner: ${{ needs.pre-flight.outputs.runner_prefix }}
             cpu-only: true
+            # Diagnostic bump: the suite was timing out at the default 10 min before
+            # pytest could emit its --durations report. Raised so the run completes and
+            # we can read per-test timings. Revert to the default once slow tests are fixed.
+            timeout: 20
           - test-name: L0_Unit_Tests_GPU
             runner: ${{ needs.pre-flight.outputs.runner_prefix }}
             cpu-only: false
-            timeout: 30
+            # Diagnostic bump: GPU unit suite never finished within 30 min, so --durations
+            # was never emitted. Raised to capture per-test timings. Revert after fixing.
+            timeout: 60
     needs: [pre-flight, cicd-wait-in-queue, cicd-container-build]
     runs-on: ${{ matrix.runner }}
     name: ${{ matrix.test-name }}


### PR DESCRIPTION
## What

Temporarily raise the L0 unit-test job timeouts so the suite runs to completion and pytest emits its `--durations` report:

- `L0_Unit_Tests_CPU`: 10 → 20 min
- `L0_Unit_Tests_GPU`: 30 → 60 min

## Why

Both jobs are currently failing by **hitting the per-attempt wall-clock limit** (CPU `600000ms`, GPU `1800000ms`), retried 3× via `nick-fields/retry` (`retry_on: timeout`). They die **before** pytest reaches the end-of-run `--durations` table, so we have **no per-test timing data** to target the slow tests — and the **GPU job has never once completed** within 30 min.

This bump lets the suite finish so we can read `--durations 32` from the CI logs and fix the actual slow tests (e.g. on the CPU job, `models/gemma4/test_gemma4_model_cp.py` alone is ~149s / 27% of a 553s run — bf16 CPU random-init in `_init_weights`).

## Note

This is a **diagnostic, temporary** change — inline comments say to revert once the slow tests are fixed. It does not fix the root cause; it's the instrument to find it.

Heavy CI does not auto-run on PR branches; it needs `/ok to test <sha>`.