### PR TITLE
test: run slow CP unit-test files GPU-only (gemma4, deepseek_v4)

### DIFF
--- a/tests/unit_tests/models/deepseek_v4/test_dsv4_cp_distributed.py
+++ b/tests/unit_tests/models/deepseek_v4/test_dsv4_cp_distributed.py
@@ -36,6 +36,11 @@ from nemo_automodel.components.models.deepseek_v4.layers import (
     build_causal_padding_mask,
 )
 
+# Run only on the GPU job. Each test mp.spawns two gloo worker processes that
+# re-import the full package (~6s/test, ~18s total on the CPU unit-test job).
+# These are context-parallel tests (a multi-GPU feature), so skip them on CPU.
+pytestmark = pytest.mark.run_only_on("GPU")
+
 
 def _free_port() -> int:
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/tests/unit_tests/models/gemma4/test_gemma4_model_cp.py
+++ b/tests/unit_tests/models/gemma4/test_gemma4_model_cp.py
@@ -35,6 +35,20 @@ from nemo_automodel.components.models.gemma4_moe.model import (
     _kv_sharing_active,
 )
 
+# Run only on the GPU job and build everything under the CUDA device context.
+# HF weight init (_init_weights -> torch.Tensor.normal_) on bf16 CPU tensors has a
+# large fixed per-call cost (~12s for even this tiny model, ~150x slower than GPU),
+# which made this file ~149s on the CPU unit-test job. Constructing on-device keeps
+# that init on the GPU.
+pytestmark = pytest.mark.run_only_on("GPU")
+
+
+@pytest.fixture(autouse=True)
+def _build_on_cuda():
+    """Build the models/tensors in these GPU-only tests on CUDA (see note above)."""
+    with torch.device("cuda"):
+        yield
+
 
 def _text_config(**overrides):
     defaults = dict(


### PR DESCRIPTION
Run the two slowest context-parallel coverage files on the **GPU job only**, to cut the CPU unit-test job's runtime (it was passing at 9:13 / 553s with only ~47s of margin under the 10-min limit). Both are multi-GPU-feature tests.

### `models/gemma4/test_gemma4_model_cp.py` (~149s, 27% of the CPU run)
No fixtures; each of ~20 model builds pays HF `_init_weights` → `torch.Tensor.normal_` on **bf16 CPU** tensors (~12s/model — ~150× slower than GPU). Model is built on CPU regardless of job (no `.cuda()`), so the cost hit **both** jobs.
- `pytestmark = run_only_on("GPU")` → skipped on CPU.
- autouse fixture builds under `torch.device("cuda")` → GPU job inits on-device.
- **CPU: skipped (−149s). GPU: ~8s (was ~149s).** Validated: 43 passed (GPU, 8.0s) / 43 skipped (CPU).

### `models/deepseek_v4/test_dsv4_cp_distributed.py` (~18s call / ~46s wall)
Each test `mp.spawn`s two **gloo** worker processes that re-import the full package. The work runs in spawned processes pinned to `torch.device("cpu")`, so a cuda-context fixture wouldn't apply — just skip on CPU.
- `pytestmark = run_only_on("GPU")`.
- **CPU: skipped. GPU: unchanged (still runs).** Validated: 3 passed (GPU) / 3 skipped (CPU).

### Not included: `loss/test_chunked_ce.py` (~12s)
Its cost is `torch.compile` (`chunked_ce.py:100`, tiny 16×8 tensors), which is device-agnostic — GPU-only wouldn't speed up the GPU job, so it's excluded.