### PR TITLE
fix(datasets): nest processing kwargs under processor_kwargs in default_collate_fn

### DIFF
--- a/nemo_automodel/components/datasets/vlm/collate_fns.py
+++ b/nemo_automodel/components/datasets/vlm/collate_fns.py
@@ -1266,19 +1266,24 @@ def default_collate_fn(
         conversations, kept = _drop_overlong_samples(conversations, processor, max_length)
         examples = [examples[i] for i in kept]
 
-    processor_kwargs = {
-        "tokenize": True,
-        "padding": True,
-        "truncation": True,
-        "return_tensors": "pt",
-        "return_dict": True,
-    }
+    # transformers>=5 expects processing kwargs (padding/truncation/max_length) to be
+    # nested under `processor_kwargs`; only apply_chat_template's own controls
+    # (tokenize/return_dict/return_tensors) stay top-level. Passing them flat still
+    # works but logs, once per sample: "Kwargs passed to `processor.__call__` have to
+    # be in `processor_kwargs` dict, not in `**kwargs`".
+    processing_kwargs = {"padding": True, "truncation": True}
     if max_length is not None:
-        processor_kwargs["max_length"] = max_length
-        processor_kwargs["padding"] = "max_length"
+        processing_kwargs["max_length"] = max_length
+        processing_kwargs["padding"] = "max_length"
         if drop_overlong:
-            processor_kwargs["truncation"] = False  # Pre-filtering guarantees samples fit
-    batch = processor.apply_chat_template(conversations, **processor_kwargs)
+            processing_kwargs["truncation"] = False  # Pre-filtering guarantees samples fit
+    batch = processor.apply_chat_template(
+        conversations,
+        tokenize=True,
+        return_dict=True,
+        return_tensors="pt",
+        processor_kwargs=processing_kwargs,
+    )
 
     if _post_tokenize_hook is not None:
         batch = _post_tokenize_hook(batch, processor)

--- a/tests/unit_tests/datasets/vlm/test_collate_fns.py
+++ b/tests/unit_tests/datasets/vlm/test_collate_fns.py
@@ -73,6 +73,7 @@ class DummyDefaultProcessor:
         truncation=False,
         return_tensors,
         return_dict=True,
+        processor_kwargs=None,
     ):
         assert tokenize and return_tensors == "pt" and return_dict
         batch_size = len(conv_list)
@@ -694,9 +695,11 @@ def test_default_collate_fn_with_max_length(collate_mod, fake_qwen_utils, monkey
     processor = MaxLengthProcessor()
     collate_mod.default_collate_fn([{"conversation": CONVERSATION}], processor, max_length=512)
 
-    assert captured_kwargs.get("max_length") == 512
-    assert captured_kwargs.get("padding") == "max_length"
-    assert captured_kwargs.get("truncation") is True
+    # processing kwargs are now nested under processor_kwargs (transformers>=5)
+    proc_kwargs = captured_kwargs.get("processor_kwargs", {})
+    assert proc_kwargs.get("max_length") == 512
+    assert proc_kwargs.get("padding") == "max_length"
+    assert proc_kwargs.get("truncation") is True
 
 
 def test_default_collate_fn_without_max_length(collate_mod, fake_qwen_utils, monkeypatch):
@@ -718,8 +721,9 @@ def test_default_collate_fn_without_max_length(collate_mod, fake_qwen_utils, mon
     processor = NoMaxLengthProcessor()
     collate_mod.default_collate_fn([{"conversation": CONVERSATION}], processor)
 
-    assert "max_length" not in captured_kwargs
-    assert captured_kwargs.get("padding") is True
+    proc_kwargs = captured_kwargs.get("processor_kwargs", {})
+    assert "max_length" not in proc_kwargs
+    assert proc_kwargs.get("padding") is True
 
 
 def test_kimi_vl_collate_fn_registered(collate_mod):
@@ -2712,9 +2716,10 @@ def test_default_collate_fn_truncation_by_default(collate_mod, fake_qwen_utils, 
         max_length=512,
     )
 
-    assert captured_kwargs.get("truncation") is True
-    assert captured_kwargs.get("max_length") == 512
-    assert captured_kwargs.get("padding") == "max_length"
+    proc_kwargs = captured_kwargs.get("processor_kwargs", {})
+    assert proc_kwargs.get("truncation") is True
+    assert proc_kwargs.get("max_length") == 512
+    assert proc_kwargs.get("padding") == "max_length"
 
 
 def test_default_collate_fn_no_truncation_with_drop_overlong(collate_mod, fake_qwen_utils, monkeypatch):
@@ -2745,9 +2750,10 @@ def test_default_collate_fn_no_truncation_with_drop_overlong(collate_mod, fake_q
         drop_overlong=True,
     )
 
-    assert captured_kwargs.get("truncation") is False
-    assert captured_kwargs.get("max_length") == 512
-    assert captured_kwargs.get("padding") == "max_length"
+    proc_kwargs = captured_kwargs.get("processor_kwargs", {})
+    assert proc_kwargs.get("truncation") is False
+    assert proc_kwargs.get("max_length") == 512
+    assert proc_kwargs.get("padding") == "max_length"
 
 
 def test_estimate_media_tokens_with_pil_image(collate_mod):


### PR DESCRIPTION
## Problem

`default_collate_fn` (the VLM validation collate) flattens processing kwargs into `apply_chat_template`:

```python
processor_kwargs = {"tokenize": True, "padding": True, "truncation": True,
                    "return_tensors": "pt", "return_dict": True, ...}
batch = processor.apply_chat_template(conversations, **processor_kwargs)
```

With `transformers==5.8.1` this logs **once per sample**, flooding validation:

> `WARNING | transformers.processing_utils | Kwargs passed to `processor.__call__` have to be in `processor_kwargs` dict, not in `**kwargs``

Bisected on the real Qwen3.5 processor: **`padding`, `truncation`, and `max_length` each independently** trip it (they're processing kwargs forwarded to `processor.__call__`); `tokenize` / `return_dict` / `return_tensors` are real `apply_chat_template` parameters and are fine.

## Fix

Nest the processing kwargs under `processor_kwargs=`; keep `apply_chat_template`'s own controls top-level. Verified `warned=False` with the same processor.

## Behavior

Unchanged — in 5.x the flat form is applied anyway (the warning branch assigns the leftover `**kwargs` to `processor_kwargs` and uses them), so this only silences the log. `pyproject.toml` pins `transformers==5.8.1`, where the `processor_kwargs=` argument is supported.

`default_collate_fn` is the only `apply_chat_template` call site that flattens processing kwargs — the other VLM collates use `tokenize=False` plus a separate `processor(...)` call.
