### PR TITLE
fix(models): default yarn original_max_position_embeddings

### DIFF
--- a/nemo_automodel/components/models/step3p7/configuration_step3p7.py
+++ b/nemo_automodel/components/models/step3p7/configuration_step3p7.py
@@ -323,7 +323,11 @@ class Step3p7Config(PretrainedConfig):
 
         rope_scaling = kwargs.get("rope_scaling")
         if isinstance(rope_scaling, dict):
-            kwargs["rope_scaling"] = dict(rope_scaling)
+            rope_scaling = dict(rope_scaling)
+            rope_type = rope_scaling.get("rope_type", rope_scaling.get("type"))
+            if rope_type == "yarn" and "original_max_position_embeddings" not in rope_scaling:
+                rope_scaling["original_max_position_embeddings"] = text_config.max_position_embeddings
+            kwargs["rope_scaling"] = rope_scaling
 
         self.understand_projector_stride = understand_projector_stride
         self.projector_bias = projector_bias

--- a/tests/unit_tests/models/step3p7/test_configuration_step3p7.py
+++ b/tests/unit_tests/models/step3p7/test_configuration_step3p7.py
@@ -156,3 +156,16 @@ def test_step3p7_config_accepts_dicts_and_existing_text_config():
     assert reused.text_config is text_config
     assert text_config.rope_scaling["type"] == "linear"
     assert text_config.rope_scaling["factor"] == 2.0
+
+
+def test_step3p7_config_yarn_without_original_max_position_embeddings():
+    """Regression for NVBug 6333464: a minimal yarn rope_scaling (no
+    ``original_max_position_embeddings``) must still construct, with the key
+    defaulted from the text config's ``max_position_embeddings``."""
+    config = Step3p7Config(
+        text_config={"hidden_size": 16, "max_position_embeddings": 4096},
+        rope_scaling={"rope_type": "yarn", "factor": 2.0},
+    )
+    assert config.rope_scaling["rope_type"] == "yarn"
+    assert config.rope_scaling["factor"] == 2.0
+    assert config.rope_scaling["original_max_position_embeddings"] == 4096


### PR DESCRIPTION
**NVBug:** [6333464](https://nvbugswb.nvidia.com/NVBugs5/SWBug.aspx?bugid=6333464) 


## What

`Step3p7Config(..., rope_scaling={"rope_type": "yarn", "factor": 2.0})` raised:

```
KeyError: "Missing required keys in `rope_parameters` for 'rope_type'='yarn': {'original_max_position_embeddings'}"
```

so Step3.7 (StepFun 3.7) could not be configured with a valid-but-minimal yarn RoPE
scaling. This fixes the top-level config to default the HF-required key.

# Why

`Step3p7Config.__init__` forwards `rope_scaling` to HF `PretrainedConfig` unchanged.
HF's yarn validator (`transformers.modeling_rope_utils._validate_yarn_rope_parameters`)
requires `original_max_position_embeddings`. HF auto-injects this default via
`standardize_rope_params()`, but that path only runs for the config when
`self.rope_parameters`/`rope_theta` is set before `super().__init__` — which the top-level
`Step3p7Config` does not do (unlike `Step3p7TextConfig`, which is why only the top-level
config crashed). Result: any yarn `rope_scaling` omitting the key made the model
unconfigurable. NVBug 6333464; surfaced by
`test_automodel_stepfun3p7_components_daily_pr_test`.

# How

In `Step3p7Config.__init__`, before `super().__init__(**kwargs)`, when `rope_scaling` is a
yarn dict missing `original_max_position_embeddings`, default it to
`text_config.max_position_embeddings`. This mirrors HF's own default and the existing
in-repo pattern in `mistral3/model.py`; supplying the value is preferable to ignoring it,
because the yarn scaling math consumes it. Both `rope_type` and `type` spellings are
accepted.

# How tested

- Repro (CPU-only, weightless) from the bug report:
  `Step3p7Config(text_config=..., vision_config=..., rope_scaling={"rope_type":"yarn","factor":2.0})`
  fails before the change, succeeds after (top-level `rope_scaling` now carries
  `original_max_position_embeddings`).
- New regression unit test
  `tests/unit_tests/models/step3p7/test_configuration_step3p7.py::test_step3p7_config_yarn_without_original_max_position_embeddings`:
  fails on `main` with the reported `KeyError`, passes with the fix.
- Full `test_configuration_step3p7.py`: 8 passed before (existing) + new test => 9 passed
  after the fix.
- `ruff format --check` and `ruff check` pass (line length 120).
- Verified in the rc6 container (transformers 5.8.1) on cw-dfw against latest `main`.
