### PR TITLE
fix(merge_lora): save tokenizer faithfully via NeMoAutoTokenizer

### DIFF
--- a/tools/merge_lora.py
+++ b/tools/merge_lora.py
@@ -262,7 +262,20 @@ def merge_lora(
 
     if save_tokenizer:
         try:
-            tokenizer = AutoTokenizer.from_pretrained(base_model, trust_remote_code=trust_remote_code)
+            # Prefer NeMoAutoTokenizer: on transformers>=5 a plain
+            # AutoTokenizer.save_pretrained re-serializes the tokenizer and
+            # mutates tokenizer_config.json (e.g. extra_special_tokens
+            # becomes a list, added_tokens_decoder / additional_special_tokens
+            # / chat_template are dropped, stray backend / is_local keys
+            # are added), which downstream tools such as vLLM reject. NeMoAutoTokenizer
+            # restores the original config faithfully on save. Fall back to the plain
+            # HF tokenizer if Automodel is unavailable.
+            try:
+                from nemo_automodel._transformers.auto_tokenizer import NeMoAutoTokenizer
+
+                tokenizer = NeMoAutoTokenizer.from_pretrained(base_model, trust_remote_code=trust_remote_code)
+            except Exception:
+                tokenizer = AutoTokenizer.from_pretrained(base_model, trust_remote_code=trust_remote_code)
             tokenizer.save_pretrained(output_dir)
             logger.info("Tokenizer saved to %s", output_dir)
         except Exception as e:


### PR DESCRIPTION
**NVBug:** [6260766](https://nvbugswb.nvidia.com/NVBugs5/SWBug.aspx?bugid=6260766) [6260758](https://nvbugswb.nvidia.com/NVBugs5/SWBug.aspx?bugid=6260758) [6258125](https://nvbugswb.nvidia.com/NVBugs5/SWBug.aspx?bugid=6258125) 


## Title
`fix(merge_lora): save base tokenizer faithfully so vLLM can load merged model`

## What
`tools/merge_lora.py` now saves the tokenizer through `NeMoAutoTokenizer`
instead of a plain `transformers.AutoTokenizer`, with a `try/except` fallback to
the plain HF tokenizer when `nemo_automodel` is unavailable.

## Why
On transformers v5, `AutoTokenizer.save_pretrained()` re-serializes the tokenizer
into the new v5 on-disk schema. For Qwen2.5 (and similar fast tokenizers) the
resulting `tokenizer_config.json` is "very different" from the base model's:

- `extra_special_tokens` becomes a **list** of empty strings (downstream tools
  such as vLLM expect a dict / its absence);
- stray `backend` / `is_local` keys are injected;
- `added_tokens_decoder`, `additional_special_tokens` and `chat_template` are
  dropped.

vLLM then fails to load the merged model. Customers hit this after running
`merge_lora.py` on a LoRA-finetuned Qwen2.5-0.5B-Instruct
(NVBugs 6260766 / 6260758 / 6258125).

`NeMoAutoTokenizer` (via `NeMoAutoTokenizerWithBosEosEnforced.save_pretrained`)
captures the original `tokenizer_config.json` at load time and restores it
faithfully on save — the same mechanism the training/checkpoint save path already
uses (added in #1465). This change brings `merge_lora.py` in line with that path.

## How tested
On cw-dfw inside the rc container (transformers 5.8.1, peft 0.18.1) with real
`Qwen/Qwen2.5-0.5B-Instruct` weights, running the real `merge_lora.merge_lora(...)`
on a tiny LoRA adapter and diffing the merged `tokenizer_config.json` vs base:

- **Before:** merged config has `extra_special_tokens` = list, `backend`/`is_local`
  injected, `added_tokens_decoder` = 0, `additional_special_tokens` = 0, no
  `chat_template` (reproduces the customer's broken file).
- **After:** merged config matches the base — `extra_special_tokens` absent,
  `added_tokens_decoder` = 22, `additional_special_tokens` = 13, `chat_template`
  present, no `backend`/`is_local`. vLLM-loadable.

Existing `tests/unit_tests/tools/test_merge_lora.py` is unaffected (the new import
lives only in the `save_tokenizer=True` branch; those tests use
`save_tokenizer=False` and mock `transformers`).

## Notes for reviewers
- The plain `AutoTokenizer` path is kept as a fallback so the tool still runs
  outside an Automodel install.
- The training/adapter checkpoint save path (`PeftAddon`/`ConsolidatedHFAddon` in
  `components/checkpoint/addons.py`) already saves faithfully via
  `NeMoAutoTokenizer`; only `merge_lora.py` still used plain HF. Customers should
  also use a container newer than `26.04` so the adapter checkpoint itself is
  faithful.
