### PR TITLE
fix(devstral2,ministral3): load FP8 checkpoints via custom mistral3_vlm path (drop HF FineGrainedFP8)

### DIFF
--- a/examples/llm_finetune/devstral/devstral2_small_2512_squad.yaml
+++ b/examples/llm_finetune/devstral/devstral2_small_2512_squad.yaml
@@ -17,10 +17,13 @@
 #   automodel examples/llm_finetune/devstral/devstral2_small_2512_squad.yaml --nproc-per-node 8
 # Adjust --nproc-per-node to the number of GPUs available on your machine.
 #
-# This recipe uses the stock HF Mistral3ForConditionalGeneration loader
-# (force_hf: true). The custom Devstral FP8 path was removed in the
-# mistral3_vlm refactor; the FP8 checkpoint is dequantized on load via
-# transformers.FineGrainedFP8Config(dequantize=true).
+# Devstral-Small-2-24B-Instruct-2512 is a per-tensor FP8 checkpoint
+# (Mistral3ForConditionalGeneration / ministral3 text backbone, same family as
+# Ministral-3). Automodel's custom Mistral3FP8VLMForConditionalGeneration claims
+# it via the mistral3_vlm resolver hook and dequantizes FP8 -> bf16 inside the
+# DCP load via its state_dict_adapter. This avoids HF's FineGrainedFP8 loader,
+# which breaks on per-tensor (scalar) scales under transformers 5.8.1. Single-
+# node FSDP2 materializes ~46 GB/rank in bf16, which fits on an 80 GB H100.
 
 recipe: TrainFinetuneRecipeForNextTokenPrediction
 
@@ -43,10 +46,6 @@ rng:
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: mistralai/Devstral-Small-2-24B-Instruct-2512
-  force_hf: true
-  quantization_config:
-    _target_: transformers.FineGrainedFP8Config
-    dequantize: true
 
 checkpoint:
   enabled: true

--- a/examples/llm_finetune/devstral/devstral2_small_2512_squad_peft.yaml
+++ b/examples/llm_finetune/devstral/devstral2_small_2512_squad_peft.yaml
@@ -17,10 +17,13 @@
 #   automodel examples/llm_finetune/devstral/devstral2_small_2512_squad_peft.yaml --nproc-per-node 8
 # Adjust --nproc-per-node to the number of GPUs available on your machine.
 #
-# This recipe uses the stock HF Mistral3ForConditionalGeneration loader
-# (force_hf: true). The custom Devstral FP8 path was removed in the
-# mistral3_vlm refactor; the FP8 checkpoint is dequantized on load via
-# transformers.FineGrainedFP8Config(dequantize=true).
+# Devstral-Small-2-24B-Instruct-2512 is a per-tensor FP8 checkpoint
+# (Mistral3ForConditionalGeneration / ministral3 text backbone, same family as
+# Ministral-3). Automodel's custom Mistral3FP8VLMForConditionalGeneration claims
+# it via the mistral3_vlm resolver hook and dequantizes FP8 -> bf16 inside the
+# DCP load via its state_dict_adapter; LoRA then attaches to the resulting bf16
+# Linears. This avoids HF's FineGrainedFP8 loader, which breaks on per-tensor
+# (scalar) scales under transformers 5.8.1.
 
 recipe: TrainFinetuneRecipeForNextTokenPrediction
 
@@ -43,10 +46,6 @@ rng:
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: mistralai/Devstral-Small-2-24B-Instruct-2512
-  force_hf: true
-  quantization_config:
-    _target_: transformers.FineGrainedFP8Config
-    dequantize: true
 
 peft:
   _target_: nemo_automodel.components._peft.lora.PeftConfig

--- a/examples/llm_finetune/mistral/ministral3_3b_squad.yaml
+++ b/examples/llm_finetune/mistral/ministral3_3b_squad.yaml
@@ -37,11 +37,15 @@ rng:
   ranked: true
 
 model:
+  # mistralai/Ministral-3-3B-Instruct-2512 is a per-tensor FP8 checkpoint
+  # (Mistral3ForConditionalGeneration / ministral3 text backbone). Automodel's
+  # custom Mistral3FP8VLMForConditionalGeneration claims it via the mistral3_vlm
+  # resolver hook and dequantizes FP8 -> bf16 inside the DCP load via its
+  # state_dict_adapter. No explicit quantization_config is needed -- passing one
+  # would force HF's FineGrainedFP8 loader, which breaks on per-tensor (scalar)
+  # scales under transformers 5.8.1.
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: mistralai/Ministral-3-3B-Instruct-2512
-  quantization_config:
-    _target_: transformers.FineGrainedFP8Config
-    dequantize: true
 
 checkpoint:
   enabled: true

--- a/examples/llm_finetune/mistral/ministral3_3b_squad_peft.yaml
+++ b/examples/llm_finetune/mistral/ministral3_3b_squad_peft.yaml
@@ -37,12 +37,17 @@ rng:
   ranked: true
 
 model:
+  # mistralai/Ministral-3-3B-Instruct-2512 is a per-tensor FP8 checkpoint
+  # (Mistral3ForConditionalGeneration / ministral3 text backbone). Automodel's
+  # custom Mistral3FP8VLMForConditionalGeneration claims it via the mistral3_vlm
+  # resolver hook and dequantizes FP8 -> bf16 inside the DCP load via its
+  # state_dict_adapter; LoRA then attaches to the resulting bf16 Linears. No
+  # explicit quantization_config is needed -- passing one would force HF's
+  # FineGrainedFP8 loader, which breaks on per-tensor (scalar) scales under
+  # transformers 5.8.1.
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: mistralai/Ministral-3-3B-Instruct-2512
   torch_dtype: bf16
-  quantization_config:
-    _target_: transformers.FineGrainedFP8Config
-    dequantize: true
 
 checkpoint:
   enabled: true


### PR DESCRIPTION
**NVBug:** [6293432](https://nvbugswb.nvidia.com/NVBugs5/SWBug.aspx?bugid=6293432)


## What
Pure-YAML fix across the four Mistral3 per-tensor-FP8 SQuAD recipes. In each,
remove `quantization_config: { _target_: transformers.FineGrainedFP8Config,
dequantize: true }` from the `model:` section (devstral2 additionally drops
`force_hf: true`), and update the comment. No Python changes.

- `examples/llm_finetune/devstral/devstral2_small_2512_squad.yaml`
- `examples/llm_finetune/devstral/devstral2_small_2512_squad_peft.yaml`
- `examples/llm_finetune/mistral/ministral3_3b_squad.yaml`
- `examples/llm_finetune/mistral/ministral3_3b_squad_peft.yaml`

## Why
`mistralai/Devstral-Small-2-24B-Instruct-2512` and
`mistralai/Ministral-3-3B-Instruct-2512` are **per-tensor** FP8 checkpoints
(`weight_block_size: null`), so each weight's `weight_scale_inv` is a 0-d scalar.
With `FineGrainedFP8Config(dequantize=true)` (and, for devstral2, `force_hf: true`)
the load goes through stock HF's FP8 dequant-on-load, and transformers 5.8.1's
`Fp8Dequantize._dequantize_one` assumes a 2-D per-block scale grid:
```
scale_rows, scale_cols = scales.shape[-2:]
ValueError: not enough values to unpack (expected 2, got 0)
```
so the model fails to load on every Linear weight, before step 0 (NVBug 6293432).
transformers is hard-pinned (`transformers==5.8.1`).

Both checkpoints share the same config shape: an outer `Mistral3Config` VLM with
a `ministral3` text backbone and `quant_method == 'fp8'`. Automodel already ships
a correct per-tensor FP8 path for exactly this:
`Mistral3FP8VLMForConditionalGeneration` (`components/models/mistral3_vlm/`). Its
`mistral3_vlm` resolver hook claims such configs and dequantizes FP8 → bf16 inside
its `state_dict_adapter` during the DCP load. The only reason the recipes weren't
using it was the `quantization_config` (+ `force_hf`) override, which bypassed the
custom class and forced HF's broken loader. Removing those keys lets the models
route to the custom FP8 VLM path, which never touches HF's per-tensor dequant.
This mirrors the devstral2 + ministral3 fix in #2482.

The resolver hook is installed eagerly: importing `NeMoAutoModelForCausalLM` pulls
in `components/distributed/optimized_tp_plans.py`, which imports `mistral3_vlm.model`
and thereby runs the package's `_install_resolver_hook()` — so routing does not
depend on import order, and no extra wiring is needed.

## How tested
- cw-dfw, container with transformers 5.8.1, 1×H100, this branch mounted via `PYTHONPATH`.
  Loaded each real model exactly as the new recipe does — `from_pretrained(...)`
  with **no** `force_hf` and **no** `quantization_config`:

  - `Devstral-Small-2-24B-Instruct-2512`:
    - `mistral3_vlm resolver hook installed at import time: True`
    - model class = `Mistral3FP8VLMForConditionalGeneration` (custom path claimed it)
    - `model.language_model.layers.0.mlp.gate_proj.weight` = `(32768, 5120) torch.bfloat16`, all-finite
    - 24.0B params, `RESULT: PASS` — no HF FineGrainedFP8 crash.

  - `Ministral-3-3B-Instruct-2512`:
    - `mistral3_vlm resolver hook installed at import time: True`
    - model class = `Mistral3FP8VLMForConditionalGeneration` (custom path claimed it)
    - `model.language_model.layers.0.mlp.gate_proj.weight` = `(9216, 3072) torch.bfloat16`, all-finite
    - 3.8B params, `RESULT: PASS` — no HF FineGrainedFP8 crash.
