### PR TITLE
fix(distributed): keep FSDP2 dtype groups storage-uniform

### DIFF
--- a/nemo_automodel/components/distributed/parallelizer_utils.py
+++ b/nemo_automodel/components/distributed/parallelizer_utils.py
@@ -157,12 +157,27 @@ def _make_compute_dtype_fn(
          dtype recorded at load time (see ``_restore_loaded_model_dtype``). This makes
          any checkpoint-loaded model keep its intrinsically-fp32 params in fp32 compute
          automatically, even after storage was upcast for fp32 master weights.
-      3. Fallback -- ``mp_policy.param_dtype`` (the requested mixed-precision compute
-         dtype, typically bf16), or the storage dtype when no policy is given.
+      3. Fallback -- when the tensor carries no compute hint, the result depends on
+         whether the module's floating-point *storage* is uniform:
+           * uniform storage -- ``mp_policy.param_dtype`` (the requested mixed-precision
+             compute dtype, typically bf16). This is the fp32-master-weights case: the
+             uniform-fp32 storage is artificially widened and should compute in the
+             policy dtype. Falls back to the storage dtype when no policy is given.
+           * mixed storage -- the tensor's own storage dtype. A param whose storage
+             differs from its peers is intrinsically that dtype (not a master weight),
+             so it must compute in it. Applying the policy here would force differently
+             stored params into one compute dtype and re-introduce the mixed *original*
+             dtype that stock FSDP2 rejects (``_init_mp_dtypes``).
 
     Non-floating tensors always keep their storage dtype.
     """
     policy_dtype = getattr(mp_policy, "param_dtype", None)
+
+    # The policy fallback only represents "fp32 master weights -> compute in policy
+    # dtype" when the module's floating storage is uniform. If storage is already
+    # mixed, unhinted params keep their storage dtype instead (see precedence above).
+    floating_storage_dtypes = {t.dtype for t in (*module.parameters(), *module.buffers()) if t.dtype.is_floating_point}
+    storage_is_uniform = len(floating_storage_dtypes) <= 1
 
     pinned_ids: Set[int] = set()
     if fp32_compute_module_names:
@@ -178,7 +193,9 @@ def _make_compute_dtype_fn(
         recorded = getattr(t, "_hf_compute_dtype", None)
         if recorded is not None and recorded.is_floating_point:
             return recorded
-        return policy_dtype if policy_dtype is not None else t.dtype
+        if policy_dtype is not None and storage_is_uniform:
+            return policy_dtype
+        return t.dtype
 
     return compute_dtype_of
 
@@ -216,39 +233,48 @@ def fully_shard_by_dtype(
     """
     compute_dtype_of = _make_compute_dtype_fn(module, mp_policy, fp32_compute_module_names)
 
+    # FSDP2 requires every param group to be uniform in *storage* (original) dtype
+    # -- ``_init_mp_dtypes`` asserts ``{p.orig_dtype}`` is a singleton -- while a group's
+    # ``param_dtype`` controls *compute* dtype. These are independent axes, so we group by
+    # the (storage, compute) pair: this keeps each FSDP unit storage-uniform (satisfying the
+    # assertion even when two different storage dtypes share one compute dtype, e.g. bf16 and
+    # fp32 weights both computing in bf16) while still splitting params that need a different
+    # compute dtype. ``key[1]`` is the compute dtype used as the unit's ``param_dtype``.
+    group_key_of = lambda t: (t.dtype, compute_dtype_of(t))
+
     # calling _group_params_by_dtype is not optimal here, because we may
     # end up with two traversals over the module, but this code is not in the hot path.
-    grouped_params = _group_params_by_dtype(module, dtype_of=compute_dtype_of)
+    grouped_params = _group_params_by_dtype(module, dtype_of=group_key_of)
     if len(grouped_params) == 0:
         return
     elif len(grouped_params) == 1:
-        dtype = next(iter(grouped_params))
+        key = next(iter(grouped_params))
         fully_shard(
             module,
             mesh=mesh,
-            mp_policy=_mp_policy_with_param_dtype(mp_policy, dtype),
+            mp_policy=_mp_policy_with_param_dtype(mp_policy, key[1]),
             offload_policy=offload_policy,
         )
     else:
-        least_items_dtype = min(grouped_params.items(), key=lambda x: len(x[1]))[0]
-        for path, mod, dtype in iter_maximal_uniform_dtype_subtrees(
+        least_items_key = min(grouped_params.items(), key=lambda x: len(x[1]))[0]
+        for path, mod, key in iter_maximal_uniform_dtype_subtrees(
             module,
             tensor_pred=torch.is_floating_point,
-            dtype_of=compute_dtype_of,
+            dtype_of=group_key_of,
             return_paths=True,
         ):
-            if (len(grouped_params) == 2 and dtype == least_items_dtype) or len(grouped_params) > 2:
+            if (len(grouped_params) == 2 and key == least_items_key) or len(grouped_params) > 2:
                 _fully_shard(
                     _get_module_from_path(module, path),
                     mesh=mesh,
-                    mp_policy=_mp_policy_with_param_dtype(mp_policy, dtype),
+                    mp_policy=_mp_policy_with_param_dtype(mp_policy, key[1]),
                     offload_policy=offload_policy,
                 )
         if len(grouped_params) == 2:
-            parent_dtype = next(dtype for dtype in grouped_params if dtype != least_items_dtype)
+            parent_key = next(key for key in grouped_params if key != least_items_key)
             fully_shard(
                 module,
                 mesh=mesh,
-                mp_policy=_mp_policy_with_param_dtype(mp_policy, parent_dtype),
+                mp_policy=_mp_policy_with_param_dtype(mp_policy, parent_key[1]),
                 offload_policy=offload_policy,
             )


### PR DESCRIPTION
**NVBug:** [6329869](https://nvbugswb.nvidia.com/NVBugs5/SWBug.aspx?bugid=6329869) 


## What
`fully_shard_by_dtype` could place parameters with different **storage** dtypes (e.g. bf16 + fp32) into a
single FSDP2 unit, which stock FSDP2 rejects at lazy-init:
```
AssertionError: FSDP expects uniform original parameter dtype but got {torch.bfloat16, torch.float32}
```
This is a regression of the feature guarded by
`tests/functional_tests/llm_pretrain_and_kd/run_fully_shard_by_dtype_param_dtype.py` (originally #2271),
reintroduced by #2419 when grouping switched from storage dtype to compute dtype.

## Why
FSDP2 enforces two independent invariants per param group: **storage (original) dtype** must be uniform
(`_init_mp_dtypes` asserts `{p.orig_dtype}` is a singleton); **compute dtype** (`param_dtype`) is per-unit
and may differ. #2419 grouped only by compute dtype to let uniform-fp32 master weights compute in bf16. But
for a mixed-**storage** module with no checkpoint compute hints (the guard's from-scratch bf16+fp32 model,
and any from-scratch mixed-dtype model), `_make_compute_dtype_fn` resolves every unhinted param to the
policy dtype (fp16), so all params collapse into one group with mixed storage → FSDP2 asserts.

## How
`nemo_automodel/components/distributed/parallelizer_utils.py` (single file):
1. Group FSDP units by the composite `(storage_dtype, compute_dtype)` key, so each unit is uniform in
   **both** axes. The unit's `param_dtype` is the compute component.
2. In `_make_compute_dtype_fn`, apply the "fp32 master weights → compute in policy dtype" fallback **only
   when the module's floating storage is uniform**. When storage is already mixed, an unhinted param keeps
   its own storage dtype as its compute dtype.

The existing precedence (pinned fp32 > HF-recorded `_hf_compute_dtype` > policy/storage fallback) and the
1/2/3+ dtype sharding structure are unchanged, so the master-weights and HF-loaded behaviors from #2419 are
preserved.

## How tested
- Canonical guard `run_fully_shard_by_dtype_param_dtype.py` (2 GPU): PASS (was: AssertionError).
- `tests/unit_tests/distributed/test_parallelizer_utils.py` + `test_fp32_compute_contract.py`: 25 passed.
- `ruff format --check` and `ruff check` clean. 2× H100, torch 2.12 container. +39/−13, single file.
