### PR TITLE
fix(model): apply dict config overrides with custom dispatch

### DIFF
--- a/nemo_automodel/_transformers/model_init.py
+++ b/nemo_automodel/_transformers/model_init.py
@@ -251,6 +251,18 @@ def get_hf_config(pretrained_model_name_or_path, attn_implementation, **kwargs):
     kwargs = kwargs.copy()
     trust_remote_code = kwargs.pop("trust_remote_code", resolve_trust_remote_code(pretrained_model_name_or_path))
     hf_config = kwargs.get("config", None)
+    # A plain-dict ``config`` (e.g. from CLI ``--model.config.num_hidden_layers 16``,
+    # which the config loader materializes as a dict, not a PretrainedConfig) is a set
+    # of config *overrides*, not a finished config object. Treat it as such: drop it
+    # from ``config`` and fold its keys into the kwargs that AutoConfig.from_pretrained
+    # applies as overrides. Returning the raw dict instead would break every downstream
+    # consumer that expects a config object (e.g. get_architectures -> the custom-model
+    # resolver, which would then mis-dispatch to the stock-HF path and reject custom
+    # kwargs like ``backend``).
+    if isinstance(hf_config, dict):
+        kwargs.pop("config", None)
+        kwargs.update(hf_config)
+        hf_config = None
     if hf_config is None:
         # Filter out nested dict kwargs before passing to AutoConfig.from_pretrained.
         # Nested dicts (e.g. text_config={"key": val}) would replace entire sub-configs
@@ -755,6 +767,13 @@ def __init_model(
     pretrained_model_name_or_path = (
         pretrained_model_name_or_path_or_config if is_pretrained_init else getattr(hf_config, "name_or_path")
     )
+    # A plain-dict ``config`` override (e.g. from ``--model.config.num_hidden_layers``)
+    # has already been folded into ``hf_config`` by ``get_hf_config`` above. Drop it from
+    # kwargs so it is not also forwarded into the model constructor / HF from_pretrained
+    # (custom path passes ``hf_config`` positionally as ``config`` -> would collide;
+    # stock-HF path does not accept a dict ``config``).
+    if isinstance(kwargs.get("config"), dict):
+        kwargs.pop("config", None)
     architectures = get_architectures(hf_config)
 
     # Propagate the user-requested dtype to the top-level config and every nested

--- a/tests/unit_tests/_transformers/test_model_init.py
+++ b/tests/unit_tests/_transformers/test_model_init.py
@@ -214,6 +214,77 @@ class TestGetHfConfigNestedKwargs:
         assert "text_config" not in call_kwargs
         assert call_kwargs["output_hidden_states"] is True
 
+    @patch("nemo_automodel._transformers.model_init.resolve_trust_remote_code", return_value=False)
+    @patch("nemo_automodel._transformers.model_init.AutoConfig.from_pretrained")
+    def test_dict_config_override_folded_into_auto_config(self, mock_from_pretrained, mock_trust):
+        """A plain-dict ``config`` (from --model.config.*) must be applied as overrides,
+        not returned verbatim. Regression for NVBugs 6259955 Defect 2: a dict config flipped
+        custom-model dispatch to the stock-HF path (get_architectures(dict) -> None)."""
+        built = MagicMock()
+        mock_from_pretrained.return_value = built
+
+        result = get_hf_config(
+            "fake/model",
+            attn_implementation="eager",
+            config={"num_hidden_layers": 16},
+        )
+
+        # The dict must NOT be returned as-is; a real config object is built instead.
+        assert result is built
+        call_kwargs = mock_from_pretrained.call_args[1]
+        # The override keys are folded into the AutoConfig.from_pretrained call ...
+        assert call_kwargs["num_hidden_layers"] == 16
+        # ... and the raw ``config`` dict is not forwarded as a kwarg.
+        assert "config" not in call_kwargs
+
+
+class TestDictConfigOverrideKeepsCustomPath:
+    """NVBugs 6259955 Defect 2: --model.config.* overrides must not flip dispatch off the
+    custom model path, and the dict ``config`` must not reach the model constructor."""
+
+    def _make_config(self):
+        config = MagicMock()
+        config.architectures = ["SomeModel"]
+        config.torch_dtype = "bfloat16"
+        config.name_or_path = "fake/model"
+        return config
+
+    @patch("nemo_automodel._transformers.model_init._download_model_weights")
+    @patch("nemo_automodel._transformers.model_init.get_hf_config")
+    @patch("nemo_automodel._transformers.model_init._resolve_custom_model_cls_for_config")
+    def test_dict_config_not_forwarded_to_custom_init(self, mock_resolve_cls, mock_get_hf_config, _mock_download):
+        hf_config = self._make_config()
+        mock_get_hf_config.return_value = hf_config
+
+        captured_kwargs = {}
+        captured_args = {}
+
+        def fake_model_cls(config, **kwargs):
+            captured_args["config"] = config
+            captured_kwargs.update(kwargs)
+            return MagicMock()
+
+        fake_model_cls.__module__ = "nemo_automodel.components.models.fake"
+        mock_resolve_cls.return_value = fake_model_cls
+
+        is_custom, _ = _init_model(
+            cls=MagicMock(),
+            pretrained_model_name_or_path_or_config="fake/model",
+            attn_implementation="flash_attention_2",
+            torch_dtype="auto",
+            quantization_config=None,
+            force_hf=False,
+            backend={"attn": "sdpa"},
+            config={"num_hidden_layers": 16},
+        )
+
+        # Custom path stays selected (dispatch did not flip to stock-HF) ...
+        assert is_custom is True
+        assert captured_args["config"] is hf_config
+        # ... and the dict ``config`` override never reaches the constructor (would
+        # otherwise collide with the positional config and/or raise TypeError).
+        assert "config" not in captured_kwargs
+
 
 class TestSetupBnbLoadingKwargs:
     """_setup_bnb_loading_kwargs sets a per-GPU device_map and disables HF async weight loading."""


### PR DESCRIPTION
**NVBug:** [6259955](https://nvbugswb.nvidia.com/NVBugs5/SWBug.aspx?bugid=6259955) 


## What
`get_hf_config` / `__init_model` (`nemo_automodel/_transformers/model_init.py`) now treat a plain-dict
`config` kwarg — how the config loader materializes `--model.config.*` CLI overrides (and YAML
`model.config:` maps) — as config **overrides** rather than a finished config object.
- `get_hf_config`: a `dict` `config` is popped and its keys folded into the kwargs `AutoConfig.from_pretrained`
  applies as overrides, so a real config (e.g. `GlmMoeDsaConfig` with `num_hidden_layers=N`) is built. Its
  `architectures` survive, so custom-model dispatch is preserved.
- `__init_model`: the now-consumed dict `config` is dropped from kwargs so it isn't forwarded into the model
  constructor (which receives the config positionally).
Adds two regression tests in `tests/unit_tests/_transformers/test_model_init.py`.

## Why
Fixes NVBugs 6259955 Defect 2. Passing `--model.config.num_hidden_layers 16` (the natural shrink knob for
GLM-5.1 / `GlmMoeDsaForCausalLM`) crashed with:
```
TypeError: GlmMoeDsaForCausalLM.__init__() got an unexpected keyword argument 'backend'
```
Root cause: the override was materialized as a dict and returned verbatim by `get_hf_config`.
`get_architectures(dict)` returns `[]`, so `_resolve_custom_model_cls_for_config` returned `None` and
dispatch flipped from the custom GlmMoeDsa implementation to the stock-HF path — which forwards the
custom-only `backend` kwarg into the built-in transformers `GlmMoeDsaForCausalLM.__init__` and rejects it.
(PR #1784 coerced dict→BackendConfig only on the custom path, so it didn't cover this stock-HF fallback.)
This made it impossible to shrink GLM-5.1 below its 256-H100 footprint via the supported CLI. The fix is
the report's preferred remedy: `--model.config.*` overrides no longer change which implementation is
dispatched, and they are correctly applied. Affects every registered custom model that accepts custom-only
constructor kwargs, not just GlmMoeDsa.

## How tested
On cw-dfw (H100) in the rc6 container, latest main `2b96596a`, transformers 5.8.1:
- Weightless repro driving `NeMoAutoModelForCausalLM.from_pretrained` on a tiny GlmMoeDsa config (no
  GLM-5.1 download): before → control custom path OK, override → `TypeError: ... 'backend'` (exact bug
  traceback); after → control unchanged, override keeps the custom path and applies the override (1 layer
  built vs the file's 2), exit 0.
- `pytest tests/unit_tests/_transformers/test_model_init.py` → 39 passed (37 existing + 2 new), 0 regressions.

## Notes
- Defect 3 of the same bug (DeepEP internode dispatch timeout at ep>8) is already fixed on main by #2630
  (recipe switched deepep→hybridep); no change needed here.
- Defect 1 (ep8/4-node OOM) is expected under-provisioning, not a code bug; this fix unblocks shrinking
  GLM-5.1 for a small-footprint smoke.
