### PR TITLE
fix(deepseek-v4): avoid bf16 -inf overflow in additive attention mask

### DIFF
--- a/nemo_automodel/components/models/deepseek_v4/layers.py
+++ b/nemo_automodel/components/models/deepseek_v4/layers.py
@@ -501,10 +501,18 @@ def build_causal_padding_mask(
     if attention_mask.dim() == 4:
         return attention_mask.to(dtype)
     if attention_mask.dim() == 2:
-        # 1=valid, 0=padding -> 0 keep, min_value mask, broadcast over query rows
-        pad_add = (1.0 - attention_mask.to(dtype)) * min_value  # [B, S]
-        pad_add = pad_add.unsqueeze(1).unsqueeze(2)  # [B,1,1,S]
-        return (causal + pad_add).to(dtype)
+        # 1=valid, 0=padding.  Overwrite padded key columns with ``min_value``
+        # instead of ADDING a second ``min_value`` plane: a cell that is masked
+        # by BOTH the causal/sliding-window mask AND padding would otherwise sum
+        # two ``min_value`` planes, which overflows to ``-inf`` in low precision
+        # (bf16: -3.39e38 + -3.39e38 -> -inf).  An ``-inf`` logit poisons the
+        # softmax backward (0 * inf -> NaN), producing nan grad_norm at step 0.
+        # Masking via where keeps masked cells at exactly ``min_value`` and
+        # matches the sibling builders (build_packed_causal_padding_mask,
+        # build_dsv4_cp_causal_padding_mask).
+        causal = causal.expand(attention_mask.shape[0], 1, seq_len, seq_len)
+        is_pad_key = (attention_mask == 0).to(device).view(attention_mask.shape[0], 1, 1, seq_len)
+        return torch.where(is_pad_key, torch.full((), min_value, dtype=dtype, device=device), causal).to(dtype)
     raise ValueError(f"Unsupported attention_mask rank: {attention_mask.dim()}")
 
 


### PR DESCRIPTION
**NVBug:** [6317402](https://nvbugswb.nvidia.com/NVBugs5/SWBug.aspx?bugid=6317402) 


## What
In `build_causal_padding_mask` (`nemo_automodel/components/models/deepseek_v4/layers.py`), the dense
2D-padding branch built the 4D additive attention mask by **summing two `torch.finfo(dtype).min`
planes** — the causal/sliding-window plane and the padding plane. For a key position masked by *both*,
this sums `-3.39e38 + -3.39e38`, which **overflows bf16 to `-inf`**. This change composes the mask with
a boolean `torch.where` instead, so masked cells hold a single `finfo.min` (never `-inf`), matching the
existing `build_packed_causal_padding_mask` and `build_dsv4_cp_causal_padding_mask`.

## Why
`deepseek-ai/DeepSeek-V4-Flash` finetune with `--model.backend.attn torch` and a ragged (padded) batch
hits this branch every step (NVBugs 6317402). An `-inf` additive mask is a real numerical hazard: today
the eager attention path appends a finite per-head sink column that keeps softmax well-defined, but an
`-inf` mask is unsafe for any sinkless softmax / SDPA / sparse consumer and for future code, and it is
the reported root cause of the NaN grad_norm at step 0. The two sibling mask builders already avoid
summing saturated planes; this aligns the third.

## How tested
- Isolated bf16 repro of the real builder: unpatched produces 38,675 `-inf` cells (`min=-inf`);
  patched produces 0 (`min=finfo.min`), and the kept/masked cell sets are **byte-identical** to the
  reference causal ∧ sliding-window ∧ not-padding region (no change to which positions are masked).
- Full random-init `DeepseekV4Model` (compress_ratios `[0,128,4,0]`, attn=torch, ragged padded batch,
  masked labels) on 1×H100 with anomaly detection: finite loss + `grad_norm` before and after — no regression.
- `ruff check` passes.

## Caveat (repro scope)
The end-to-end NaN symptom could not be reproduced in single-GPU tiers — the eager attention-sink
column keeps gradients finite even with an `-inf` mask, so the actual NaN appears to require the full
2-node PP2/EP8 DSV4-Flash run (gated model, out of single-GPU budget). This PR removes the confirmed
underlying `-inf` overflow (a genuine hazard) with a semantics-preserving change; a maintainer with the
multi-node setup should confirm it resolves the reported NaN before closing.

## Scope
Single function, single branch. No API or behavior change beyond the masked-cell fill value
(`-inf` → `finfo.min`); 4D-mask and `None` branches untouched. +12/-4, 1 file.
