### PR TITLE
fix(vlm): guard validation forward against cuDNN fused-MHA SDPA backend

### DIFF
--- a/nemo_automodel/_transformers/kernel_patches.py
+++ b/nemo_automodel/_transformers/kernel_patches.py
@@ -47,6 +47,34 @@ logger = logging.getLogger(__name__)
 # CPAwareGatedDeltaNet + fp32 SSMGate in their model __init__.)
 _MODEL_RUNTIME_PATCHES = {}
 
+# SDPA backends that are safe for the eval/validation forward. The cuDNN
+# fused-MHA backend is intentionally excluded: on some cuDNN versions it returns
+# ``mha_graph.execute(...).is_good() == false`` for validation-forward shapes
+# (e.g. Qwen3.5 dense VLM full-attention layers use head_dim=256 with an explicit
+# attention mask), crashing ``F.scaled_dot_product_attention``. This mirrors the
+# cuDNN exclusion that ``resolve_sdpa_method`` already applies for activation
+# checkpointing. See NVBugs 6293238.
+_EVAL_SAFE_SDPA_BACKENDS = [
+    SDPBackend.FLASH_ATTENTION,
+    SDPBackend.EFFICIENT_ATTENTION,
+    SDPBackend.MATH,
+]
+
+
+def eval_safe_sdpa_kernel():
+    """Return an ``sdpa_kernel`` context excluding the cuDNN fused-MHA backend.
+
+    Use around eval/validation forwards so SDPA never dispatches to the cuDNN
+    backend, which can fail ``is_good()`` on validation-forward shapes. Custom
+    models (e.g. Qwen3.5) do not go through ``_patch_attention`` and so would
+    otherwise let PyTorch auto-select cuDNN for the eval forward. See NVBugs
+    6293238.
+
+    Returns:
+        A context manager constraining SDPA to flash / mem-efficient / math.
+    """
+    return sdpa_kernel(_EVAL_SAFE_SDPA_BACKENDS)
+
 
 def _assert_same_signature(original, patched):
     """

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -45,6 +45,7 @@ from nemo_automodel._transformers import (
     NeMoAutoModelForImageTextToText,
     NeMoAutoModelForMultimodalLM,
 )
+from nemo_automodel._transformers.kernel_patches import eval_safe_sdpa_kernel
 from nemo_automodel._transformers.utils import apply_cache_compatibility_patches
 from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
 from nemo_automodel.components.datasets.llm.formatting_utils import _resolve_chat_template
@@ -1189,7 +1190,14 @@ class FinetuneRecipeForVLM(BaseRecipe):
 
                 train_ctx, batch = make_cp_batch_and_ctx(self.device_mesh, batch)
                 labels = batch.pop("labels")
-                with train_ctx():
+                # Constrain SDPA to non-cuDNN backends for the validation forward:
+                # the cuDNN fused-MHA backend can fail ``is_good()`` on validation
+                # shapes and custom models (e.g. Qwen3.5) don't go through
+                # ``_patch_attention``. Under CP, ``train_ctx`` already enters a
+                # cuDNN-free sdpa_kernel (flash/efficient only, MATH excluded for
+                # DTensor), so skip the extra guard there. See NVBugs 6293238.
+                sdpa_ctx = nullcontext() if _cp_active else eval_safe_sdpa_kernel()
+                with train_ctx(), sdpa_ctx:
                     batch = filter_forward_kwargs(self.model_parts[0], batch)
                     if isinstance(self.loss_fn, FusedLinearCrossEntropy):
                         out = self.model_parts[0](logits_to_keep=1, **batch)

--- a/tests/unit_tests/_transformers/test_eval_safe_sdpa_kernel.py
+++ b/tests/unit_tests/_transformers/test_eval_safe_sdpa_kernel.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""``eval_safe_sdpa_kernel`` must exclude the cuDNN fused-MHA SDPA backend.
+
+Regression for NVBugs 6293238: the cuDNN fused-MHA backend can fail
+``mha_graph.execute(...).is_good() == false`` on the validation-forward shape,
+so the eval guard must disable it while keeping flash / mem-efficient / math.
+The ``torch.backends.cuda`` SDPA toggles are global flags and do not require a
+GPU, so this runs on CPU-only CI.
+"""
+
+from torch.backends.cuda import (
+    cudnn_sdp_enabled,
+    flash_sdp_enabled,
+    math_sdp_enabled,
+    mem_efficient_sdp_enabled,
+)
+
+from nemo_automodel._transformers.kernel_patches import eval_safe_sdpa_kernel
+
+
+def test_eval_safe_sdpa_kernel_disables_cudnn():
+    """Inside the guard cuDNN SDPA is off and the safe backends stay on."""
+    with eval_safe_sdpa_kernel():
+        assert cudnn_sdp_enabled() is False
+        assert flash_sdp_enabled() is True
+        assert mem_efficient_sdp_enabled() is True
+        assert math_sdp_enabled() is True
+
+
+def test_eval_safe_sdpa_kernel_restores_on_exit():
+    """The context restores the prior cuDNN flag after exiting."""
+    before = cudnn_sdp_enabled()
+    with eval_safe_sdpa_kernel():
+        assert cudnn_sdp_enabled() is False
+    assert cudnn_sdp_enabled() is before


### PR DESCRIPTION
**NVBug:** [6293238](https://nvbugswb.nvidia.com/NVBugs5/SWBug.aspx?bugid=6293238) 


## What
Constrain the VLM validation forward to non-cuDNN SDPA backends so it cannot dispatch to the cuDNN
fused-MHA kernel that can fail `mha_graph.execute(...).is_good() == false`.
- New `eval_safe_sdpa_kernel()` in `nemo_automodel/_transformers/kernel_patches.py` —
  `sdpa_kernel([FLASH_ATTENTION, EFFICIENT_ATTENTION, MATH])` (cuDNN excluded), mirroring the cuDNN
  exclusion `resolve_sdpa_method` already applies under activation checkpointing.
- `FinetuneRecipeForVLM._run_validation_epoch` wraps the eval forward in `eval_safe_sdpa_kernel()`
  (skipped under context parallelism, where `train_ctx` already enters a cuDNN-free context).
- Unit tests for the new helper.

## Why
Qwen3.6-27B dense VLM MTP finetune trains 10/10 steps cleanly, then crashes in the end-of-training
validation forward:
```
RuntimeError: Expected mha_graph.execute(...).is_good() to be true, but got false.
```
inside `F.scaled_dot_product_attention`. Root cause is a cuDNN fused-MHA backend defect surfaced by the
validation-forward shape (Qwen3.5 full-attention layers use head_dim=256 and the eval batch carries an
explicit attention mask). The Qwen3.5 VLM is a **custom** model, so it bypasses `_patch_attention`
(`auto_model.py:543`) and never receives the cuDNN-excluding SDPA backend list that HF models get —
leaving the eval forward free to select cuDNN. Training takes the maskless `is_causal=True` path that
cuDNN handles, so only validation crashes. This keeps the published recipe's validation enabled
end-to-end (the POR test currently masks the bug by stripping validation), as recommended in the bug's
"Suggested next steps".

## How tested
On cw-dfw (1× H100, container with torch 2.12 / cuDNN 9.21):
- `eval_safe_sdpa_kernel()` disables cuDNN SDPA (flash/mem-efficient/math remain enabled) and restores
  the flag on exit.
- A downsized **real** `Qwen3_5ForConditionalGeneration` validation forward (eval/no_grad + activation
  checkpointing + MTP + image, multiple seqlens) runs green under the guard with finite logits.
- `pytest tests/unit_tests/_transformers/test_eval_safe_sdpa_kernel.py` + existing kernel_patches tests:
  10 passed. `ruff check` / `ruff format --check` clean.

Note: the kernel-level crash no longer reproduces on cuDNN 9.21 (the kernel defect was fixed in a newer
cuDNN than the bug's original `nemo-automodel:nightly` image); this change removes the code-level
fragility so older-cuDNN users are protected and the backend choice is explicit.

## Scope / risk
Eval-only; training behavior unchanged. CP path unchanged (guard skipped — CP's context already excludes
cuDNN). Low risk: flash/mem-efficient/math are already the AC-time default for HF models. +83/-1, 3 files.
