### PR TITLE
cp: `feat(moe): MTP FLOPs accounting fix (2486)` into `r0.5.0`

### DIFF
--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -663,6 +663,12 @@ class Checkpointer:
         state_dict = _maybe_adapt_state_dict_from_hf(model_state.model[0], state_dict, moe_mesh=self.moe_mesh)
         expected_keys_for_diff = {k for k in expected_keys if not k.endswith("_extra_state")}
         loaded_keys_for_diff = {k for k in state_dict if not k.endswith("_extra_state")}
+        # MoE experts load in-place via strided views into model storage (DCP writes through
+        # them), so they are absent from the returned state_dict but ARE loaded. The adapter
+        # tracks them (reset + populated entirely inside from_hf); count them as loaded for the
+        # diff to avoid false "missing" warnings while genuinely unloaded params are still flagged.
+        _adapter = getattr(model_state.model[0], "state_dict_adapter", None)
+        loaded_keys_for_diff |= getattr(_adapter, "view_loaded_native_keys", None) or set()
         key_diff = _summarize_state_dict_key_diff(expected_keys_for_diff, loaded_keys_for_diff)
         if key_diff["missing_count"] or key_diff["unexpected_count"]:
             logging.warning(

--- a/nemo_automodel/components/models/nemotron_v3/state_dict_adapter.py
+++ b/nemo_automodel/components/models/nemotron_v3/state_dict_adapter.py
@@ -184,7 +184,9 @@ class NemotronV3StateDictAdapter(MoESplitExpertsStateDictMixin, StateDictAdapter
             for key, value in mtp_state_dict.items():
                 stripped_key = key[len("mtp.") :] if key.startswith("mtp.") else key
                 stripped[stripped_key] = value
-            merged_mtp = self._from_hf_w_merged_experts(stripped, device_mesh)
+            # reset_view_loaded_keys=False: this is the second merge of a single from_hf (after the
+            # backbone merge above), so accumulate MTP view-loaded keys onto the backbone's record.
+            merged_mtp = self._from_hf_w_merged_experts(stripped, device_mesh, reset_view_loaded_keys=False)
             for key, value in merged_mtp.items():
                 merged[f"mtp.{key}"] = value
 

--- a/nemo_automodel/components/moe/layers.py
+++ b/nemo_automodel/components/moe/layers.py
@@ -37,79 +37,6 @@ from nemo_automodel.components.moe.megatron.moe_utils import (
     MoEAuxLossAutoScaler,
 )
 
-_shared_experts_stream: Optional[torch.cuda.Stream] = None
-
-
-def _record_stream_safe(t: torch.Tensor, stream: Optional[torch.cuda.Stream]) -> None:
-    """Tell the caching allocator that ``stream`` uses ``t``'s storage.
-
-    Required whenever a tensor allocated on one CUDA stream is read/written on
-    another stream: without it the allocator may recycle the block while
-    ``stream`` is still using it (cross-stream use-after-free -> corrupted
-    values). No-op for non-CUDA tensors; handles DTensor by recording on the
-    local shard.
-    """
-    if stream is None or not isinstance(t, torch.Tensor):
-        return
-    local = t.to_local() if hasattr(t, "to_local") else t
-    if local.is_cuda:
-        local.record_stream(stream)
-
-
-class _SharedExpertStreamFork(torch.autograd.Function):
-    """Fork the shared-expert input ``x`` into the side stream.
-
-    Data-identity op; it only enforces cross-stream ordering + allocator safety
-    so the side-stream overlap is correct in BOTH passes. A raw ``wait_stream``
-    is forward-only and has no backward mirror, which (together with missing
-    ``record_stream``) is the cross-stream race that corrupts gradients.
-
-    * forward (main stream): the side stream waits for main so it observes ``x``.
-    * backward (main stream): ``grad_x`` was produced by the shared-expert
-      subgraph on the side stream, so main waits for side before that gradient
-      is accumulated into ``x``'s ``.grad`` alongside the main-stream branches.
-    """
-
-    @staticmethod
-    def forward(ctx, x, side_stream):
-        ctx.main_stream = torch.cuda.current_stream()
-        ctx.side_stream = side_stream
-        side_stream.wait_stream(ctx.main_stream)
-        _record_stream_safe(x, side_stream)
-        return x
-
-    @staticmethod
-    def backward(ctx, grad_x):
-        ctx.main_stream.wait_stream(ctx.side_stream)
-        _record_stream_safe(grad_x, ctx.main_stream)
-        return grad_x, None
-
-
-class _SharedExpertStreamJoin(torch.autograd.Function):
-    """Join the shared-expert output ``z`` back to the main stream.
-
-    * forward (main stream): main waits for the side stream so ``z`` is ready
-      before it is added to the routed output. Applied AFTER ``experts()`` is
-      launched so the shared-expert compute overlaps the dispatch comm.
-    * backward (main stream): ``grad_z`` is produced on the main stream by the
-      ``y + z`` add; the side stream waits for main before the shared-expert
-      subgraph (replayed on the side stream) consumes it.
-    """
-
-    @staticmethod
-    def forward(ctx, z, side_stream):
-        ctx.main_stream = torch.cuda.current_stream()
-        ctx.side_stream = side_stream
-        ctx.main_stream.wait_stream(side_stream)
-        _record_stream_safe(z, ctx.main_stream)
-        return z
-
-    @staticmethod
-    def backward(ctx, grad_z):
-        ctx.side_stream.wait_stream(ctx.main_stream)
-        _record_stream_safe(grad_z, ctx.side_stream)
-        return grad_z, None
-
 
 class MLP(nn.Module):
     """
@@ -795,37 +722,15 @@ class MoE(nn.Module):
 
         weights, indices, aux_loss = self.gate(x, token_mask, cp_mesh)
 
-        # Shared-expert output (optionally gated).  Run on a side CUDA stream to
-        # overlap with the grouped-expert dispatch comm.  The fork/join autograd
-        # fences (_SharedExpertStreamFork / _SharedExpertStreamJoin) make the
-        # overlap correct in BOTH forward and backward: a raw wait_stream is
-        # forward-only, and its missing backward mirror plus the missing
-        # record_stream is a cross-stream race that corrupts gradients (grad-norm
-        # explosion at high tokens/microbatch on some hardware).  shared_experts
-        # stays in the normal autograd graph, so FSDP2's post-backward
-        # reduce-scatter hooks and gradient accumulation are unaffected; expert
-        # parallelism only touches the routed ``experts`` path on the main stream.
+        # Shared-expert output (optionally gated), computed inline on the main stream.
         z = None
-        side_stream = None
         if self.shared_experts is not None:
-            global _shared_experts_stream
-            if _shared_experts_stream is None:
-                _shared_experts_stream = torch.cuda.Stream()
-            side_stream = _shared_experts_stream
+            z = self.shared_experts(x)
+            if self.shared_expert_gate is not None:
+                z = torch.nn.functional.sigmoid(self.shared_expert_gate(x)) * z
 
-            # Fork into the side stream (fences main->side fwd, side->main bwd).
-            x_se = _SharedExpertStreamFork.apply(x, side_stream)
-            with torch.cuda.stream(side_stream):
-                z = self.shared_experts(x_se)
-                if self.shared_expert_gate is not None:
-                    z = torch.nn.functional.sigmoid(self.shared_expert_gate(x_se)) * z
-
-        # Routed experts on the main stream — runs concurrently with the
-        # shared-expert side stream above; the join below waits for it.
+        # Routed experts on the main stream.
         y = self.experts(x_latent, token_mask, weights, indices)
-        if side_stream is not None:
-            # Join back to the main stream (fences side->main fwd, main->side bwd).
-            z = _SharedExpertStreamJoin.apply(z, side_stream)
 
         if self.fc2_latent_proj is not None:
             y = self.fc2_latent_proj(y)

--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -279,7 +279,27 @@ def apply_ac(
     def selective_checkpointing_context_fn():
         return create_selective_checkpoint_contexts(_custom_policy)
 
+    # Weight-tied (use_repeated_layer) MTP head blocks must NOT be activation
+    # checkpointed: the single physical block is recomputed once per MTP depth in
+    # backward, and FSDP2 cannot re-unshard the *shared* EP-sharded experts param
+    # group on the 2nd+ recompute (the 1st recompute's post_backward reshards it, and
+    # the 2nd recompute's pre_forward unshard does not re-gather it) -> the experts
+    # weight is read in the resharded Shard(1) state and grouped_gemm raises
+    # "Expected hidden_in == a.size(1)". The MTP head is tiny (1 physical block), so
+    # skipping its recompute costs negligible activation memory. Non-tied MTP heads
+    # (each physical block recomputed exactly once) are unaffected and keep AC.
+    mtp_module = getattr(model, "mtp", None)
+    mtp_block_ids: set[int] = set()
+    mtp_repeated = False
+    if mtp_module is not None and hasattr(mtp_module, "layers"):
+        mtp_block_ids = {id(b) for b in mtp_module.layers.children()}
+        mtp_repeated = bool(getattr(getattr(mtp_module, "mtp_config", None), "use_repeated_layer", False))
+    if mtp_repeated and mtp_block_ids:
+        logger.info("Skipping activation checkpointing on %d weight-tied MTP head block(s)", len(mtp_block_ids))
+
     for parent_layers, layer_id, block in _iter_transformer_and_mtp_blocks(model):
+        if mtp_repeated and id(block) in mtp_block_ids:
+            continue
         if ignore_router and hasattr(block, "set_activation_checkpointing"):
             block.set_activation_checkpointing(True)
         elif ignore_router:
@@ -340,8 +360,21 @@ def apply_fsdp(
     # Prefer nested text modules when present (VLM models)
     _model = get_text_module(_model)
 
+    # MTP auxiliary-head blocks keep their EP-sharded experts un-resharded
+    # (reshard_after_forward=False) even when the backbone reshards. The MTP head is
+    # tiny (1-2 MoE sublayers) so keeping its experts gathered costs negligible resident
+    # memory, while it removes FSDP2 unshard fragility for the weight-tied head whose
+    # single physical experts param group is used multiple times per step (see apply_ac,
+    # which skips AC on these blocks for the same reason). Bulk backbone experts keep the
+    # configured reshard_after_forward.
+    mtp_module = getattr(model, "mtp", None)
+    mtp_block_ids = set()
+    if mtp_module is not None and hasattr(mtp_module, "layers"):
+        mtp_block_ids = {id(b) for b in mtp_module.layers.children()}
+
     for block in _iter_moe_blocks(model, _model):
         moe_module = _get_moe_module(block)
+        experts_reshard_after_forward = False if id(block) in mtp_block_ids else reshard_after_forward
         if isinstance(moe_module, MoE) and ep_shard_enabled:
             # Apply FSDP on dim=1 for grouped experts since we may have more
             # shards than experts (dim=0).
@@ -353,7 +386,7 @@ def apply_fsdp(
                 moe_module.experts,
                 mesh=ep_shard_mesh,
                 shard_placement_fn=_moe_shard_placement,
-                reshard_after_forward=reshard_after_forward,
+                reshard_after_forward=experts_reshard_after_forward,
                 mp_policy=mp_policy,
             )
         # If FSDP is disabled for grouped experts because the parameters are already

--- a/nemo_automodel/components/moe/state_dict_mixin.py
+++ b/nemo_automodel/components/moe/state_dict_mixin.py
@@ -74,6 +74,19 @@ class MoESplitExpertsStateDictMixin:
         self._inplace_loaded_native_keys.add(tracked)
 
     @property
+    def view_loaded_native_keys(self) -> set[str]:
+        """Native keys loaded in-place via strided views during the most recent ``from_hf``.
+
+        MoE experts with a plain local split are loaded by DCP writing the checkpoint tensors
+        straight through non-contiguous strided views into the model's grouped expert storage.
+        Such keys are intentionally absent from the dict ``from_hf`` returns (the data is already
+        in the model) but are NOT missing. ``_from_hf_w_merged_experts`` records them here so the
+        checkpoint loader can exclude them from false "missing" key-diff warnings. The record is
+        reset at the start of each load by ``_from_hf_w_merged_experts(reset_view_loaded_keys=True)``.
+        """
+        return getattr(self, "_view_loaded_native_keys", None) or set()
+
+    @property
     def _hf_prefix(self) -> str:
         """Prefix for HuggingFace format keys. Override in subclass."""
         return "model." if self._uses_model_prefix else ""
@@ -384,6 +397,7 @@ class MoESplitExpertsStateDictMixin:
         self,
         hf_state_dict: dict[str, Any],
         device_mesh: Optional["DeviceMesh"] = None,
+        reset_view_loaded_keys: bool = True,
     ) -> dict[str, Any]:
         """Convert HF checkpoint to native format.
 
@@ -393,7 +407,17 @@ class MoESplitExpertsStateDictMixin:
 
         For non-gated activations (ReLU²):
             Creates gate_and_up_projs [n_experts, dim, inter_dim] and transposed down_projs tensors.
+
+        Args:
+            reset_view_loaded_keys: Clear the in-place (strided-view) loaded-key record at the
+                start of this call. A single ``from_hf`` may invoke this method more than once
+                (e.g. backbone then MTP merge); the later call(s) pass ``False`` so the view-loaded
+                keys accumulate across one logical load. Resetting here (rather than in the loader)
+                keeps the whole view-key lifecycle inside the adapter and ensures each load starts
+                clean (no leak from a prior load such as an init-time partial load).
         """
+        if reset_view_loaded_keys:
+            self._view_loaded_native_keys = set()
 
         n_experts = self.moe_config.n_routed_experts
         is_gated = self._is_gated_moe
@@ -559,6 +583,13 @@ class MoESplitExpertsStateDictMixin:
         # Drop consumed entries so a subsequent from_hf (e.g. MTP merge after backbone) starts clean.
         if consumed_inplace_keys:
             self._inplace_loaded_native_keys -= consumed_inplace_keys
+            # These native keys were loaded in-place via strided views into model storage (DCP
+            # writes the checkpoint tensors straight through them), so they are intentionally
+            # absent from the returned state_dict but are NOT missing. Record them so the
+            # checkpoint loader's key-diff can exclude them and only flag genuinely unloaded params.
+            self._view_loaded_native_keys = (
+                getattr(self, "_view_loaded_native_keys", None) or set()
+            ) | consumed_inplace_keys
 
         # Recombine any per-expert HF LoRA keys back to grouped format
         state_dict = self._recombine_lora_expert_keys(state_dict)

--- a/nemo_automodel/components/utils/flops_utils.py
+++ b/nemo_automodel/components/utils/flops_utils.py
@@ -574,6 +574,55 @@ def _nemotronh_moe_layer_flops(config, gbs, seq_len):
     return routed_expert_flops + shared_expert_flops + gate_flops + latent_proj_flops
 
 
+def _nemotronh_mtp_flops(config, gbs, seq_len, num_mtp_layers, mtp_block_types, use_repeated_layer):
+    """Model FLOPs for the Multi-Token-Prediction (MTP) head of Nemotron-3 Super/Ultra.
+
+    The head predicts ``num_mtp_layers`` (N) additional tokens. Each of the N depths runs
+    the MTP block pattern once, plus a depth-fusion projection (``eh_proj``: cat[enorm(embed),
+    hnorm(hidden)] of size 2*hidden -> hidden) and a vocab projection (weight-tied lm_head).
+
+    Repeated layer: when ``use_repeated_layer`` is True the model builds a SINGLE physical
+    depth (``mtp_block_types`` lists its sublayers) and reuses it across all N depths -- but
+    it still EXECUTES once per depth, so the block compute is N x the physical sublayers.
+    That N x is the repeated layer's FLOPs. When False, ``mtp_block_types`` already spans all
+    N physical depths, so the block runs once.
+
+    These settings are NOT fully recoverable from the HF config (it retains only the physical
+    depth count and omits the block pattern), so callers pass the effective values read from
+    the built model: ``num_mtp_layers = model.mtp_config.num_layers`` and
+    ``mtp_block_types = [s.block_type for s in model.mtp.layers]``.
+
+    Args:
+        num_mtp_layers: effective MTP depths actually run (model.mtp_config.num_layers).
+        mtp_block_types: block types ("mamba"/"attention"/"mlp"/"moe") of the physical MTP
+            sublayers (model.mtp.layers).
+        use_repeated_layer: True if the physical depth is reused across the N depths.
+    """
+    if not num_mtp_layers or not mtp_block_types:
+        return 0
+
+    hs = config.hidden_size
+    vocab_size = config.vocab_size
+    num_tokens = gbs * seq_len
+
+    per_block_fn = {
+        "mamba": _mamba_layer_flops,
+        "attention": _non_mla_attn_layer_flops,
+        "mlp": _nemotronh_mlp_layer_flops,
+        "moe": _nemotronh_moe_layer_flops,
+    }
+    physical_block_flops = sum(per_block_fn[bt](config, gbs, seq_len) for bt in mtp_block_types if bt in per_block_fn)
+    # Repeated: physical sublayers execute once per depth -> N x. Non-repeated: mtp_block_types
+    # already spans all N depths, so the listed blocks run once.
+    block_flops = physical_block_flops * (num_mtp_layers if use_repeated_layer else 1)
+
+    # Per-depth depth-fusion (eh_proj: 2H -> H) and weight-tied vocab projection (lm_head).
+    eh_proj_flops = num_mtp_layers * 6 * num_tokens * (2 * hs) * hs
+    lm_head_flops = num_mtp_layers * 6 * num_tokens * hs * vocab_size
+
+    return block_flops + eh_proj_flops + lm_head_flops
+
+
 def _non_mla_attn_layer_flops(config, gbs, seq_len):
     """Model FLOPs for attention layer"""
     hs = config.hidden_size

--- a/nemo_automodel/recipes/llm/benchmark.py
+++ b/nemo_automodel/recipes/llm/benchmark.py
@@ -159,6 +159,16 @@ class BenchmarkingRecipeForNextTokenPrediction(TrainFinetuneRecipeForNextTokenPr
         flops = flops_formula(self.model_parts[0].config, gbs=global_batch_size, seq_len=seq_len)
         self.tflops = flops / (10**12)
 
+        # Add Multi-Token-Prediction (MTP) head FLOPs (e.g. Nemotron-3 Ultra). The backbone
+        # FLOPs formula omits the MTP head, and the HF config retains only the physical depth
+        # count, so read the effective settings (depths run, repeated-layer flag, per-depth
+        # block types) from the built model.
+        backbone_tflops = self.tflops
+        mtp_tflops = self._mtp_tflops(global_batch_size, seq_len)
+        self.tflops += mtp_tflops
+        if self.dist_env.is_main:
+            logger.info(f"MTP TFLOPs/GPU: {mtp_tflops:.6f} (backbone {backbone_tflops:.6f}, total {self.tflops:.6f})")
+
         if hasattr(self.cfg, "peft"):
             # Calculate trainable vs non-trainable parameters
             # Need to get these before autopipeline splits the model across PP ranks
@@ -211,6 +221,40 @@ class BenchmarkingRecipeForNextTokenPrediction(TrainFinetuneRecipeForNextTokenPr
             reset=True,
             barrier=True,
         )
+
+    def _mtp_tflops(self, global_batch_size, seq_len):
+        """TFLOPs added by a Multi-Token-Prediction (MTP) head, if the model has one.
+
+        The backbone FLOPs formula omits the MTP head, and the HF config retains only the
+        physical depth count (and no per-depth block pattern). So read the EFFECTIVE settings
+        from the built model: ``mtp_config.num_layers`` (depths actually run),
+        ``mtp_config.use_repeated_layer``, and the per-sublayer ``block_type`` from
+        ``mtp.layers``. Returns 0.0 when the model has no enabled MTP head.
+        """
+        from nemo_automodel.components.utils.flops_utils import _nemotronh_mtp_flops
+
+        for mp in self.model_parts:
+            mtp_cfg = getattr(mp, "mtp_config", None)
+            mtp = getattr(mp, "mtp", None)
+            layers = getattr(mtp, "layers", None) if mtp is not None else None
+            if mtp_cfg is None or not getattr(mtp_cfg, "enabled", False) or layers is None:
+                continue
+            block_types = [getattr(s, "block_type", "moe") for s in layers]
+            flops = _nemotronh_mtp_flops(
+                mp.config,
+                global_batch_size,
+                seq_len,
+                mtp_cfg.num_layers,
+                block_types,
+                mtp_cfg.use_repeated_layer,
+            )
+            if self.dist_env.is_main:
+                logger.info(
+                    f"MTP head FLOPs: N={mtp_cfg.num_layers} repeated={mtp_cfg.use_repeated_layer} "
+                    f"blocks={block_types} -> +{flops / (10**12):.6f} TFLOPs"
+                )
+            return flops / (10**12)
+        return 0.0
 
     def run_benchmark(self):
         """Run the benchmarking loop.

--- a/tests/unit_tests/moe/test_latent_projection.py
+++ b/tests/unit_tests/moe/test_latent_projection.py
@@ -15,7 +15,7 @@
 """Tests for MoE latent projection layers (fc1_latent_proj, fc2_latent_proj)."""
 
 from functools import partial
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 import torch
@@ -230,34 +230,18 @@ class TestMoELatentProjectionForward:
                 batch_size * seq_len, moe_config.dim, dtype=torch.bfloat16, device=device
             )
 
-            with (
-                patch("torch.cuda.Stream") as mock_stream_class,
-                patch("torch.cuda.current_stream") as mock_current_stream,
-                patch("torch.cuda.stream") as mock_stream_context,
-                # The shared-expert fork/join calls Tensor.record_stream with the
-                # mocked stream; no-op the helper so the mock isn't passed to it.
-                patch("nemo_automodel.components.moe.layers._record_stream_safe"),
-            ):
-                mock_stream = Mock()
-                mock_stream.wait_stream = Mock()
-                mock_stream_class.return_value = mock_stream
-                mock_current_stream.return_value = Mock()
-                mock_context = Mock()
-                mock_context.__enter__ = Mock(return_value=None)
-                mock_context.__exit__ = Mock(return_value=None)
-                mock_stream_context.return_value = mock_context
+            # Shared experts run inline on the main stream (no side-stream overlap).
+            output = moe(x)
 
-                output = moe(x)
+            assert output.shape == x.shape
 
-                assert output.shape == x.shape
+            # Routed experts should get latent-dim input
+            experts_input = mock_experts.call_args[0][0]
+            assert experts_input.shape[-1] == moe_config.moe_latent_size
 
-                # Routed experts should get latent-dim input
-                experts_input = mock_experts.call_args[0][0]
-                assert experts_input.shape[-1] == moe_config.moe_latent_size
-
-                # Shared experts should get original-dim input
-                shared_input = mock_shared.call_args[0][0]
-                assert shared_input.shape[-1] == moe_config.dim
+            # Shared experts should get original-dim input
+            shared_input = mock_shared.call_args[0][0]
+            assert shared_input.shape[-1] == moe_config.dim
 
     def test_forward_no_latent_experts_receive_original_dim(self, moe_config, backend_config, device):
         """Test that without latent projections, experts receive original dim input."""

--- a/tests/unit_tests/moe/test_layers.py
+++ b/tests/unit_tests/moe/test_layers.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import importlib.util
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 import torch
@@ -1417,30 +1417,11 @@ class TestMoE:
             mock_experts.return_value = torch.randn(batch_size * seq_len, moe_config.dim, device=device)
             mock_shared.return_value = torch.randn(batch_size * seq_len, moe_config.dim, device=device)
 
-            # Patch at the module level to avoid CUDA stream issues on CPU
-            with (
-                patch("torch.cuda.Stream") as mock_stream_class,
-                patch("torch.cuda.current_stream") as mock_current_stream,
-                patch("torch.cuda.stream") as mock_stream_context,
-                # The shared-expert fork/join calls Tensor.record_stream with the
-                # mocked stream; no-op the helper so the mock isn't passed to it.
-                patch("nemo_automodel.components.moe.layers._record_stream_safe"),
-            ):
-                mock_stream = Mock()
-                mock_stream.wait_stream = Mock()
-                mock_stream_class.return_value = mock_stream
-                mock_current_stream.return_value = Mock()
+            # Shared experts run inline on the main stream (no side-stream overlap).
+            output = moe(x)
 
-                # Create a context manager that just yields
-                mock_context = Mock()
-                mock_context.__enter__ = Mock(return_value=None)
-                mock_context.__exit__ = Mock(return_value=None)
-                mock_stream_context.return_value = mock_context
-
-                output = moe(x)
-
-                assert output.shape == x.shape
-                assert output.device == device
+            assert output.shape == x.shape
+            assert output.device == device
 
     def test_moe_forward_with_padding_mask(self, moe_config, backend_config, device):
         """Test MoE forward pass with padding mask."""

--- a/tests/unit_tests/utils/test_mtp_flops.py
+++ b/tests/unit_tests/utils/test_mtp_flops.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the Multi-Token-Prediction (MTP) FLOPs helper used in MFU.
+
+Expected values are hand-derived from the FLOPs definitions below (independent of the
+implementation), so the tests assert what is *correct*, not merely what the code emits.
+
+Fixtures use ``gbs=2, seq=4`` -> ``num_tokens = gbs * seq = 8``, ``hidden_size H = 8``,
+``vocab_size V = 32``. From the formulas in ``flops_utils``:
+
+  * one MLP block      = 6 * gbs * seq * H * intermediate * 3   (intermediate=16)  = 18432
+  * eh_proj / depth    = 6 * num_tokens * (2H) * H              = 6*8*16*8          = 6144
+  * lm_head / depth    = 6 * num_tokens * H * V                 = 6*8*8*32          = 12288
+
+``_nemotronh_mtp_flops`` returns, for N depths:
+    block * (N if use_repeated_layer else 1) + N * eh_proj + N * lm_head
+where ``block`` is the summed per-sublayer FLOPs of ``mtp_block_types``.
+"""
+
+import types
+
+from nemo_automodel.components.utils.flops_utils import (
+    _nemotronh_mlp_layer_flops,
+    _nemotronh_moe_layer_flops,
+    _nemotronh_mtp_flops,
+)
+
+GBS, SEQ = 2, 4  # num_tokens = 8
+
+_ONE_MLP = 18432  # 6*2*4*8*16*3
+_EH_PER_DEPTH = 6144  # 6*8*(2*8)*8
+_LM_PER_DEPTH = 12288  # 6*8*8*32
+
+
+def _mlp_cfg():
+    return types.SimpleNamespace(hidden_size=8, intermediate_size=16, vocab_size=32)
+
+
+def _moe_cfg():
+    # Latent MoE (Ultra/Super-V3): experts operate in moe_latent_size space + fc1/fc2 latent proj.
+    return types.SimpleNamespace(
+        hidden_size=8,
+        vocab_size=32,
+        moe_latent_size=4,
+        moe_intermediate_size=6,
+        num_experts_per_tok=2,
+        moe_shared_expert_intermediate_size=10,
+        n_routed_experts=16,
+    )
+
+
+def test_per_block_and_fusion_baselines():
+    """Sanity-check the building blocks the hand-derivation relies on."""
+    assert _nemotronh_mlp_layer_flops(_mlp_cfg(), GBS, SEQ) == _ONE_MLP
+
+
+def test_mtp_repeated_single_block():
+    # ['mlp'], N=2, repeated: block = 18432*2 = 36864; +eh*2 (12288) +lm*2 (24576) = 73728
+    cfg = _mlp_cfg()
+    assert _nemotronh_mtp_flops(cfg, GBS, SEQ, 2, ["mlp"], True) == 73728
+
+
+def test_repeated_equals_unrolled():
+    """The repeated layer's compute is N x: 1 physical depth run N times == N physical depths run once."""
+    cfg = _mlp_cfg()
+    repeated = _nemotronh_mtp_flops(cfg, GBS, SEQ, 2, ["mlp"], True)
+    unrolled = _nemotronh_mtp_flops(cfg, GBS, SEQ, 2, ["mlp", "mlp"], False)
+    assert repeated == unrolled == 73728
+
+
+def test_mtp_repeated_two_sublayer_depth():
+    # ['mlp','mlp'] (2 sublayers/depth), N=2, repeated: block = (2*18432)*2 = 73728; +eh*2 +lm*2 = 110592
+    cfg = _mlp_cfg()
+    assert _nemotronh_mtp_flops(cfg, GBS, SEQ, 2, ["mlp", "mlp"], True) == 110592
+
+
+def test_eh_proj_and_lm_head_scale_with_n():
+    """eh_proj + lm_head are per-depth: dropping the block isolates them at N*(eh+lm)."""
+    cfg = _mlp_cfg()
+    # N=1, no block (empty) -> 0 (guarded); use a zero-flop check via difference instead:
+    n1 = _nemotronh_mtp_flops(cfg, GBS, SEQ, 1, ["mlp"], True)
+    n2 = _nemotronh_mtp_flops(cfg, GBS, SEQ, 2, ["mlp"], True)
+    # going 1 -> 2 depths (repeated) adds exactly one more (block + eh + lm)
+    assert n2 - n1 == _ONE_MLP + _EH_PER_DEPTH + _LM_PER_DEPTH
+
+
+def test_mtp_moe_block_counts_latent():
+    cfg = _moe_cfg()
+    # latent MoE block (hand-derived): routed 4608 + shared 7680 + gate 6144 + latent_proj 3072 = 21504
+    assert _nemotronh_moe_layer_flops(cfg, GBS, SEQ) == 21504
+    # ['moe'], N=2, repeated: 21504*2 + eh*2 + lm*2 = 43008 + 12288 + 24576 = 79872
+    assert _nemotronh_mtp_flops(cfg, GBS, SEQ, 2, ["moe"], True) == 79872
+
+
+def test_mtp_disabled_returns_zero():
+    cfg = _mlp_cfg()
+    assert _nemotronh_mtp_flops(cfg, GBS, SEQ, 0, ["mlp"], True) == 0
+    assert _nemotronh_mtp_flops(cfg, GBS, SEQ, 2, [], True) == 0


### PR DESCRIPTION
Cherry-pick of #2486 (c2571088) onto `r0.5.0`.

**Release-branch resolution**
- `checkpointing.py`: kept this PR's actual change (count view-loaded native MoE expert keys as loaded via the new `adapter.view_loaded_native_keys` property, which this PR adds in `moe/state_dict_mixin.py`), but **dropped the `if allow_checkpoint_key_subset:` block** — that flag/feature does not exist on r0.5.0 (added on `main` after the branch cut) and would raise `NameError`.
- All other files (`moe/layers.py`, `moe/parallelizer.py`, `utils/flops_utils.py`, `nemotron_v3` adapter, benchmark recipe, unit tests) applied cleanly.

Verified: `py_compile` clean on all touched Python files.
