### PR TITLE
cp: `fix(examples): enable ac for phi_4_squad (2634)` into `r0.5.0`

### DIFF
--- a/examples/llm_finetune/phi/phi_4_squad.yaml
+++ b/examples/llm_finetune/phi/phi_4_squad.yaml
@@ -49,6 +49,10 @@ checkpoint:
 
 distributed:
   strategy: fsdp2
+  # phi-4 (14B) stores ~60 GiB of activations per training step; without
+  # recomputation a single fwd/bwd peaks at ~74 GiB and OOMs on long batches
+  # (notably the checkpoint-robustness resume phase, which runs extra steps).
+  activation_checkpointing: true
   dp_size: none
   tp_size: 1
   cp_size: 1

--- a/nemo_automodel/_transformers/capabilities.py
+++ b/nemo_automodel/_transformers/capabilities.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import functools
 import inspect
 import logging
+import weakref
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -128,12 +129,23 @@ class ModelSupports:
         model.supports.pp   # ...
     """
 
-    __slots__ = ("_model", "_model_cls", "_mesh")
+    __slots__ = ("_model_ref", "_model_cls", "_mesh")
 
     def __init__(self, model: "nn.Module", mesh: "MeshContext | None" = None) -> None:
-        self._model = model
+        # Hold the model weakly. ``ModelSupports`` is attached back onto the model
+        # as ``model._supports``; a strong reference here would form a
+        # ``model <-> _supports`` cycle, so the capability descriptor must never be
+        # the reason a (multi-GiB) model stays resident after its owner is dropped.
+        self._model_ref = weakref.ref(model)
         self._model_cls = type(model)
         self._mesh = mesh
+
+    @property
+    def _model(self) -> "nn.Module":
+        model = self._model_ref()
+        if model is None:
+            raise ReferenceError("ModelSupports: underlying model has been garbage-collected")
+        return model
 
     def __repr__(self) -> str:
         names = (

--- a/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
+++ b/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
@@ -362,6 +362,36 @@ def _barrier():
         dist.barrier()
 
 
+def _release_recipe_memory(recipe) -> None:
+    """Release a recipe's GPU-resident state between checkpoint-robustness phases.
+
+    Each phase builds a full FSDP2 model + optimizer. A bare ``del`` is not
+    enough: the per-part optimizers are reachable from the model (they are built
+    over ``model.parts``), so the optimizer state (Adam moments are the bulk)
+    lingers. Clear the optimizer state in place and drop the recipe's references,
+    then collect — letting the prior phase's model + optimizer be reclaimed
+    before the next phase allocates its own, keeping the inter-phase baseline low.
+    """
+    if recipe is None:
+        return
+    optimizers = getattr(recipe, "optimizer", None)
+    if not isinstance(optimizers, (list, tuple)):
+        optimizers = [optimizers] if optimizers is not None else []
+    for opt in optimizers:
+        try:
+            opt.state.clear()
+            opt.param_groups.clear()
+        except Exception:
+            pass
+    recipe.model_parts = None
+    recipe.optimizer = None
+    if getattr(recipe, "lr_scheduler", None) is not None:
+        recipe.lr_scheduler = None
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+
 def test_checkpoint_robustness():
     """Train -> checkpoint -> reload automodel from consolidated -> reload vanilla HF, compare logits."""
     custom_args, config_argv = _extract_custom_args(sys.argv[1:])
@@ -438,9 +468,8 @@ def test_checkpoint_robustness():
     else:
         original_quantization_config = _raw_qc
 
+    _release_recipe_memory(trainer)
     del trainer
-    gc.collect()
-    torch.cuda.empty_cache()
 
     # Phantom key check: scan consolidated safetensors for leaked quantization keys
     if check_phantom_keys and _rank0():
@@ -493,9 +522,8 @@ def test_checkpoint_robustness():
     )
 
     # Phase 4: Load into vanilla HF (rank 0 only)
+    _release_recipe_memory(restored_trainer)
     del restored_trainer
-    gc.collect()
-    torch.cuda.empty_cache()
     _barrier()  # ensure all ranks free memory before rank 0 loads HF model
 
     if skip_hf_reload:
@@ -652,9 +680,8 @@ def test_checkpoint_robustness():
             f"max per-token KL = {max_kl_cross_tp:.6e} > threshold {cross_tp_kl_threshold:.6e}"
         )
 
+        _release_recipe_memory(cross_tp_trainer)
         del cross_tp_trainer
-        gc.collect()
-        torch.cuda.empty_cache()
         _barrier()
 
     # Phase 6 (optional): Training resumption — verify loss continuity
@@ -693,9 +720,8 @@ def test_checkpoint_robustness():
                     if entry["step"] >= original_max_steps:
                         baseline_losses[entry["step"]] = entry["loss"]
 
+        _release_recipe_memory(baseline_trainer)
         del baseline_trainer
-        gc.collect()
-        torch.cuda.empty_cache()
         shutil.rmtree(baseline_dir, ignore_errors=True)
 
         # Resume: reload from Phase 1 checkpoint and train to resume_max_steps.
@@ -739,9 +765,8 @@ def test_checkpoint_robustness():
             )
             print(f"[Phase 6] Training resumption verified ({matched_steps} steps compared) ✓")
 
+        _release_recipe_memory(resume_trainer)
         del resume_trainer
-        gc.collect()
-        torch.cuda.empty_cache()
         _barrier()
 
     # Skip the atexit-registered destroy_process_group() call. MoE models with expert


### PR DESCRIPTION
Cherry-pick of #2634 (c75d9cfe) onto `r0.5.0`.

**Release-branch resolution**
- **Dropped** `tests/unit_tests/_transformers/test_capabilities_magi.py`: this PR only *modifies* that test, but the file does not exist on r0.5.0 (the magi test was added main-only after the branch cut), so there is nothing to patch.
- Kept the actual fix: `examples/llm_finetune/phi/phi_4_squad.yaml` (`activation_checkpointing: true` — the OOM fix), the `ModelSupports` weakref change in `_transformers/capabilities.py`, and the `_release_recipe_memory` helper in the checkpoint-robustness functional test. All applied cleanly.

Verified: `py_compile` clean.
