### PR TITLE
cp: `feat(config): disable W&B in example configs (2643)` into `r0.5.0`

### DIFF
--- a/examples/audio_finetune/qwen2_5_omni_asr/ami_sft_3b.yaml
+++ b/examples/audio_finetune/qwen2_5_omni_asr/ami_sft_3b.yaml
@@ -101,6 +101,7 @@ optimizer:
   weight_decay: 0.0
 
 wandb:
+  enable: false
   project: ${oc.env:WANDB_PROJECT,qwen2_5-omni-asr-ami}
   name: ${oc.env:WANDB_NAME,qwen2_5_omni_3b_asr_ami_fullft}
   dir: ${oc.env:WANDB_DIR,result/wandb}

--- a/examples/audio_finetune/qwen2_5_omni_asr/ami_sft_7b.yaml
+++ b/examples/audio_finetune/qwen2_5_omni_asr/ami_sft_7b.yaml
@@ -104,6 +104,7 @@ optimizer:
   weight_decay: 0.0
 
 wandb:
+  enable: false
   project: ${oc.env:WANDB_PROJECT,qwen2_5-omni-asr-ami}
   name: ${oc.env:WANDB_NAME,qwen2_5_omni_7b_asr_ami_fullft}
   dir: ${oc.env:WANDB_DIR,result/wandb}

--- a/examples/audio_finetune/qwen2_5_omni_asr/multi_en_sft_3b.yaml
+++ b/examples/audio_finetune/qwen2_5_omni_asr/multi_en_sft_3b.yaml
@@ -116,6 +116,7 @@ optimizer:
   weight_decay: 0.0
 
 wandb:
+  enable: false
   project: ${oc.env:WANDB_PROJECT,qwen2_5-omni-asr-multi-en}
   name: ${oc.env:WANDB_NAME,qwen2_5_omni_3b_asr_multi_en_fullft}
   dir: ${oc.env:WANDB_DIR,result/wandb}

--- a/examples/audio_finetune/qwen3_omni_asr/ami_sft.yaml
+++ b/examples/audio_finetune/qwen3_omni_asr/ami_sft.yaml
@@ -128,6 +128,7 @@ optimizer:
   weight_decay: 0.0
 
 wandb:
+  enable: false
   project: ${oc.env:WANDB_PROJECT,qwen3-omni-asr-ami}
   name: ${oc.env:WANDB_NAME,qwen3_omni_asr_ami_fullft}
   dir: ${oc.env:WANDB_DIR,result/wandb}

--- a/examples/audio_finetune/qwen3_omni_asr/multi_en_sft.yaml
+++ b/examples/audio_finetune/qwen3_omni_asr/multi_en_sft.yaml
@@ -126,6 +126,7 @@ optimizer:
   weight_decay: 0.0
 
 wandb:
+  enable: false
   project: ${oc.env:WANDB_PROJECT,qwen3-omni-asr-multi-en}
   name: ${oc.env:WANDB_NAME,qwen3_omni_asr_multi_en_fullft}
   dir: ${oc.env:WANDB_DIR,result/wandb}

--- a/examples/diffusion/finetune/flux2_t2i_flow.yaml
+++ b/examples/diffusion/finetune/flux2_t2i_flow.yaml
@@ -1,6 +1,7 @@
 seed: 42
 
 wandb:
+  enable: false
   project: flux2-finetuning
   mode: online
   name: flux2_finetune_run

--- a/examples/diffusion/finetune/flux2_t2i_flow_lora.yaml
+++ b/examples/diffusion/finetune/flux2_t2i_flow_lora.yaml
@@ -1,6 +1,7 @@
 seed: 42
 
 wandb:
+  enable: false
   project: flux2-finetuning
   mode: online
   name: flux2_lora_run

--- a/examples/diffusion/finetune/flux_t2i_flow.yaml
+++ b/examples/diffusion/finetune/flux_t2i_flow.yaml
@@ -85,6 +85,7 @@ checkpoint:
   restore_from: null
 
 wandb:
+  enable: false
   project: flux-finetuning
   mode: online
   name: flux_pretrain_ddp_test_run_1

--- a/examples/diffusion/finetune/flux_t2i_flow_lora.yaml
+++ b/examples/diffusion/finetune/flux_t2i_flow_lora.yaml
@@ -1,6 +1,7 @@
 seed: 42
 
 wandb:
+  enable: false
   project: flux-finetuning
   mode: online
   name: flux_lora_run

--- a/examples/diffusion/finetune/hunyuan_t2v_flow.yaml
+++ b/examples/diffusion/finetune/hunyuan_t2v_flow.yaml
@@ -76,6 +76,7 @@ checkpoint:
   restore_from: null
 
 wandb:
+  enable: false
   project: hunyuan-video-training
   mode: online
   name: 720p_t2v_run

--- a/examples/diffusion/finetune/hunyuan_t2v_flow_lora.yaml
+++ b/examples/diffusion/finetune/hunyuan_t2v_flow_lora.yaml
@@ -1,6 +1,7 @@
 seed: 42
 
 wandb:
+  enable: false
   project: hunyuan-video-training
   mode: online
   name: hunyuan_lora_run

--- a/examples/diffusion/finetune/qwen_image_t2i_flow.yaml
+++ b/examples/diffusion/finetune/qwen_image_t2i_flow.yaml
@@ -72,6 +72,7 @@ checkpoint:
   restore_from: null
 
 wandb:
+  enable: false
   project: qwen-image-finetuning
   mode: online
   name: qwen_image_finetune_run_1

--- a/examples/diffusion/finetune/qwen_image_t2i_flow_lora.yaml
+++ b/examples/diffusion/finetune/qwen_image_t2i_flow_lora.yaml
@@ -1,6 +1,7 @@
 seed: 42
 
 wandb:
+  enable: false
   project: qwen-image-lora-finetuning
   mode: online
   name: qwen_image_lora_run_1

--- a/examples/diffusion/finetune/wan2_1_t2v_flow.yaml
+++ b/examples/diffusion/finetune/wan2_1_t2v_flow.yaml
@@ -1,6 +1,7 @@
 seed: 42
 
 wandb:
+  enable: false
   project: wan-t2v-flow-matching
   mode: online
   name: wan2_1_t2v_fm_v2

--- a/examples/diffusion/finetune/wan2_1_t2v_flow_lora.yaml
+++ b/examples/diffusion/finetune/wan2_1_t2v_flow_lora.yaml
@@ -1,6 +1,7 @@
 seed: 42
 
 wandb:
+  enable: false
   project: wan-t2v-flow-matching
   mode: online
   name: wan2_1_lora_run

--- a/examples/diffusion/finetune/wan2_1_t2v_flow_multinode.yaml
+++ b/examples/diffusion/finetune/wan2_1_t2v_flow_multinode.yaml
@@ -1,6 +1,7 @@
 seed: 42
 
 wandb:
+  enable: false
   project: wan-t2v-flow-matching
   mode: online
   name: wan2_1_t2v_fm_multinode_v2

--- a/examples/diffusion/finetune/wan2_2_t2v_flow.yaml
+++ b/examples/diffusion/finetune/wan2_2_t2v_flow.yaml
@@ -1,6 +1,7 @@
 seed: 42
 
 wandb:
+  enable: false
   project: wan-t2v-flow-matching
   mode: online
   # Stage name is auto-appended (e.g. wan2_2_t2v_fm_high_noise) when model.stage is set.

--- a/examples/diffusion/pretrain/flux_t2i_flow.yaml
+++ b/examples/diffusion/pretrain/flux_t2i_flow.yaml
@@ -84,6 +84,7 @@ checkpoint:
   restore_from:
 
 wandb:
+  enable: false
   project: flux-pretraining
   mode: online
   name: flux_pretrain_ddp_test_run_1

--- a/examples/diffusion/pretrain/qwen_image_t2i_flow.yaml
+++ b/examples/diffusion/pretrain/qwen_image_t2i_flow.yaml
@@ -79,6 +79,7 @@ checkpoint:
   restore_from:
 
 wandb:
+  enable: false
   project: qwen-image-pretraining
   mode: online
   name: qwen_image_pretrain_run_1

--- a/examples/diffusion/pretrain/wan2_1_t2v_flow.yaml
+++ b/examples/diffusion/pretrain/wan2_1_t2v_flow.yaml
@@ -1,6 +1,7 @@
 seed: 42
 
 wandb:
+  enable: false
   project: wan-t2v-flow-matching-pretrain
   mode: online
   name: wan2_1_t2v_fm_pretrain

--- a/examples/dllm_sft/dflash_sft.yaml
+++ b/examples/dllm_sft/dflash_sft.yaml
@@ -39,6 +39,7 @@ dist_env:
 seed: 42
 
 wandb:
+  enable: false
   project: dflash-sft
   name: dflash-qwen3-4b-run
 

--- a/examples/dllm_sft/llada2_sft.yaml
+++ b/examples/dllm_sft/llada2_sft.yaml
@@ -42,6 +42,7 @@ dist_env:
 seed: 42
 
 wandb:
+  enable: false
   project: llada2-sft
   name: llada2-mini-tulu3-run
 

--- a/examples/dllm_sft/llada_sft.yaml
+++ b/examples/dllm_sft/llada_sft.yaml
@@ -29,6 +29,7 @@ dist_env:
 seed: 42
 
 wandb:
+  enable: false
   project: dllm-baseline
   name: am-llada-tulu3_run
 

--- a/examples/dllm_sft/nemotron_labs_diffusion_sft.yaml
+++ b/examples/dllm_sft/nemotron_labs_diffusion_sft.yaml
@@ -29,6 +29,7 @@ dist_env:
 seed: 42
 
 wandb:
+  enable: false
   project: dllm-baseline
   name: am-nemotron-labs-diffusion-sft
 

--- a/examples/dllm_sft/nemotron_nano30b_dflash.yaml
+++ b/examples/dllm_sft/nemotron_nano30b_dflash.yaml
@@ -46,6 +46,7 @@ dist_env:
 seed: 42
 
 wandb:
+  enable: false
   entity: joc
   project: dflash-sft
   name: dflash-nemotron-nano-30b-run

--- a/examples/dllm_sft/qwen3_4b_dflash.yaml
+++ b/examples/dllm_sft/qwen3_4b_dflash.yaml
@@ -42,6 +42,7 @@ dist_env:
 seed: 42
 
 wandb:
+  enable: false
   entity: joc
   project: dflash-sft
   name: dflash-qwen3-4b-run

--- a/examples/llm_finetune/devstral/devstral2_small_2512_squad.yaml
+++ b/examples/llm_finetune/devstral/devstral2_small_2512_squad.yaml
@@ -103,6 +103,7 @@ lr_scheduler:
   min_lr: 1.0e-6
 
 wandb:
+  enable: false
   project: huiyingl_workspace
   entity: Nemo-automodel
   name: devstral_24b_squad

--- a/examples/llm_finetune/devstral/devstral2_small_2512_squad_peft.yaml
+++ b/examples/llm_finetune/devstral/devstral2_small_2512_squad_peft.yaml
@@ -112,6 +112,7 @@ lr_scheduler:
   min_lr: 1.0e-6
 
 wandb:
+  enable: false
   project: huiyingl_workspace
   entity: Nemo-automodel
   name: devstral_24b_squad_peft

--- a/examples/llm_finetune/mimo_v2_flash/mimo_v2_flash_hellaswag.yaml
+++ b/examples/llm_finetune/mimo_v2_flash/mimo_v2_flash_hellaswag.yaml
@@ -129,6 +129,7 @@ optimizer:
   weight_decay: 0.1
 
 wandb:
+  enable: false
   project: automodel-mimo-v2-flash
   name: mimo_v2_flash_hellaswag_16n
   mode: online

--- a/examples/multimodal_finetune/bagel/bagel_sft.yaml
+++ b/examples/multimodal_finetune/bagel/bagel_sft.yaml
@@ -165,6 +165,7 @@ ema:
   decay: 0.9999
 
 wandb:
+  enable: false
   project: bagel-finetuning
   mode: disabled
   name: bagel_7b_mot_sft

--- a/examples/multimodal_pretrain/bagel/bagel_pretrain.yaml
+++ b/examples/multimodal_pretrain/bagel/bagel_pretrain.yaml
@@ -166,6 +166,7 @@ ema:
   implementation: auto
 
 wandb:
+  enable: false
   project: bagel-pretraining
   mode: disabled
   name: bagel_mot_pretrain

--- a/examples/vlm_finetune/mistral3p5/mistral3p5_128b_medpix.yaml
+++ b/examples/vlm_finetune/mistral3p5/mistral3p5_128b_medpix.yaml
@@ -124,6 +124,7 @@ lr_scheduler:
   min_lr: 1.0e-6
 
 wandb:
+  enable: false
   project: huiyingl_workspace
   entity: Nemo-automodel
   name: mistral3p5_128b_medpix

--- a/examples/vlm_finetune/mistral4/mistral4_medpix.yaml
+++ b/examples/vlm_finetune/mistral4/mistral4_medpix.yaml
@@ -111,6 +111,7 @@ optimizer:
   weight_decay: 0.0
 
 wandb:
+  enable: false
   project: huiyingl_workspace
   entity: Nemo-automodel
   name: mistral4-medpix

--- a/examples/vlm_finetune/nemotron_omni/nemotron_omni_cord_v2_peft.yaml
+++ b/examples/vlm_finetune/nemotron_omni/nemotron_omni_cord_v2_peft.yaml
@@ -106,6 +106,7 @@ validation_dataloader:
     max_length: 4096
 
 wandb:
+  enable: false
   entity: Nemo-automodel
   project: huiyingl_workspace
   name: nemotron_omni_cordv2_v2_lora_400steps

--- a/examples/vlm_finetune/nemotron_omni/nemotron_omni_v3_cord_v2_ep8cp2.yaml
+++ b/examples/vlm_finetune/nemotron_omni/nemotron_omni_v3_cord_v2_ep8cp2.yaml
@@ -88,6 +88,7 @@ validation_dataloader:
     max_length: 4096
 
 wandb:
+  enable: false
   entity: Nemo-automodel
   project: huiyingl_workspace
   name: nomni_v3_medpix_ep8cp2_te

--- a/examples/vlm_finetune/qwen3_5_moe/qwen3_6_35b_medpix_ep8cp2_4k.yaml
+++ b/examples/vlm_finetune/qwen3_5_moe/qwen3_6_35b_medpix_ep8cp2_4k.yaml
@@ -113,6 +113,7 @@ lr_scheduler:
   lr_decay_style: constant
 
 wandb:
+  enable: false
   project: huiyingl_workspace
   entity: Nemo-automodel
   name: qwen3_6_35b_medpix_ep8cp2_4k_100steps

--- a/examples/vlm_finetune/stepfun/step3p7_medpix_200b_ep32pp4.yaml
+++ b/examples/vlm_finetune/stepfun/step3p7_medpix_200b_ep32pp4.yaml
@@ -130,6 +130,7 @@ lr_scheduler:
   min_lr: 1.0e-6
 
 wandb:
+  enable: false
   project: <your_wandb_project>
   entity: <your_wandb_entity>
   name: <your_wandb_name>

--- a/examples/vlm_finetune/stepfun/step3p7_medpix_200b_lora_pp8ep8_8node.yaml
+++ b/examples/vlm_finetune/stepfun/step3p7_medpix_200b_lora_pp8ep8_8node.yaml
@@ -139,6 +139,7 @@ lr_scheduler:
   min_lr: 1.0e-6
 
 wandb:
+  enable: false
   project: <your_wandb_project>
   entity: <your_wandb_entity>
   name: <your_wandb_name>

--- a/nemo_automodel/components/config/_arg_parser.py
+++ b/nemo_automodel/components/config/_arg_parser.py
@@ -94,4 +94,30 @@ def parse_args_and_load_config(default_cfg_path: str | None = None, argv: list[s
         dotted, val_str = kv.split("=", 1)
         cfg.set_by_dotted(dotted, translate_value(val_str))
 
+    # Resolve the optional `wandb.enable` toggle after overrides, so that
+    # `wandb.enable=true` passed on the CLI is honored.
+    _resolve_wandb_enable(cfg)
+
     return cfg
+
+
+def _resolve_wandb_enable(cfg: ConfigNode) -> None:
+    """Apply the optional ``wandb.enable`` toggle in place.
+
+    A present ``wandb:`` block enables Weights & Biases logging by default
+    (backward compatible). Setting ``enable: false`` disables it: the whole
+    ``wandb`` section is dropped so every downstream presence check
+    (``cfg.wandb``, ``cfg.get("wandb")``, ``hasattr(cfg, "wandb")``) consistently
+    sees it as absent. The flag itself is always stripped so it is never
+    forwarded to ``wandb.init()`` as an unknown keyword argument.
+
+    Args:
+        cfg: The loaded recipe configuration. Mutated in place.
+    """
+    node = cfg.get("wandb", None)
+    if not isinstance(node, ConfigNode):
+        return
+    enabled = bool(node.get("enable", True))
+    node.__dict__.pop("enable", None)
+    if not enabled:
+        cfg.__dict__.pop("wandb", None)

--- a/tests/unit_tests/config/test_cli.py
+++ b/tests/unit_tests/config/test_cli.py
@@ -29,6 +29,11 @@ class DummyConfig:
     def set_by_dotted(self, dotted, value):
         self._calls.append((dotted, value))
 
+    def get(self, key, default=None):
+        # Mirror ConfigNode.get: missing keys (e.g. the optional `wandb`
+        # section resolved by parse_args_and_load_config) return the default.
+        return default
+
     # allow direct attribute access in case caller relies on it later
     def __getattr__(self, item):
         raise AttributeError(item)

--- a/tests/unit_tests/config/test_example_yaml_linter.py
+++ b/tests/unit_tests/config/test_example_yaml_linter.py
@@ -20,14 +20,16 @@ from tools.lint_example_yamls import lint_yaml_text
 
 def test_linter_accepts_valid_example_recipe():
     errors = lint_yaml_text(
-        "\n".join([
-            "recipe: TrainFinetuneRecipeForNextTokenPrediction",
-            "model:",
-            "  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained",
-            "ci:",
-            "  recipe_owner: test",
-            "",
-        ]),
+        "\n".join(
+            [
+                "recipe: TrainFinetuneRecipeForNextTokenPrediction",
+                "model:",
+                "  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained",
+                "ci:",
+                "  recipe_owner: test",
+                "",
+            ]
+        ),
         Path("examples/llm_finetune/valid.yaml"),
         Path.cwd(),
     )
@@ -60,6 +62,49 @@ def test_linter_requires_ci_last():
     )
 
     assert any("`ci` section must be the last" in error.message for error in errors)
+
+
+def test_linter_rejects_wandb_without_enable_false():
+    errors = lint_yaml_text(
+        "\n".join(
+            [
+                "recipe: TrainFinetuneRecipeForNextTokenPrediction",
+                "model:",
+                "  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained",
+                "wandb:",
+                "  project: my-project",
+                "ci:",
+                "  recipe_owner: test",
+                "",
+            ]
+        ),
+        Path("examples/llm_finetune/with_wandb.yaml"),
+        Path.cwd(),
+    )
+
+    assert any("must set `enable: false`" in error.message for error in errors)
+
+
+def test_linter_accepts_wandb_with_enable_false():
+    errors = lint_yaml_text(
+        "\n".join(
+            [
+                "recipe: TrainFinetuneRecipeForNextTokenPrediction",
+                "model:",
+                "  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained",
+                "wandb:",
+                "  enable: false",
+                "  project: my-project",
+                "ci:",
+                "  recipe_owner: test",
+                "",
+            ]
+        ),
+        Path("examples/llm_finetune/with_wandb.yaml"),
+        Path.cwd(),
+    )
+
+    assert not any("wandb" in error.message for error in errors)
 
 
 def test_linter_rejects_duplicate_top_level_keys():

--- a/tests/unit_tests/config/test_wandb_enable.py
+++ b/tests/unit_tests/config/test_wandb_enable.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+from nemo_automodel.components.config._arg_parser import _resolve_wandb_enable
+from nemo_automodel.components.config.loader import ConfigNode
+
+
+def test_wandb_enable_false_drops_section():
+    """`enable: false` removes the wandb section so it reads as absent everywhere."""
+    cfg = ConfigNode({"wandb": {"enable": False, "project": "p"}})
+
+    _resolve_wandb_enable(cfg)
+
+    assert "wandb" not in cfg
+    assert cfg.get("wandb", None) is None
+    assert not hasattr(cfg, "wandb")
+
+
+def test_wandb_enable_true_keeps_section_and_strips_flag():
+    """`enable: true` keeps the section but drops the flag (not a wandb.init kwarg)."""
+    cfg = ConfigNode({"wandb": {"enable": True, "project": "p"}})
+
+    _resolve_wandb_enable(cfg)
+
+    assert cfg.get("wandb", None) is not None
+    assert cfg.wandb.to_dict() == {"project": "p"}
+
+
+def test_wandb_missing_enable_defaults_to_on():
+    """A present block with no `enable` key logs by default (backward compatible)."""
+    cfg = ConfigNode({"wandb": {"project": "p"}})
+
+    _resolve_wandb_enable(cfg)
+
+    assert cfg.get("wandb", None) is not None
+    assert cfg.wandb.to_dict() == {"project": "p"}
+
+
+def test_wandb_absent_is_noop():
+    """No wandb block stays absent."""
+    cfg = ConfigNode({"model": {}})
+
+    _resolve_wandb_enable(cfg)
+
+    assert "wandb" not in cfg

--- a/tools/lint_example_yamls.py
+++ b/tools/lint_example_yamls.py
@@ -86,6 +86,7 @@ def lint_yaml_text(text: str, path: Path, automodel_dir: Path) -> list[LintError
 
     key_lines = _top_level_key_lines(document)
     errors = _lint_top_level_keys(path, key_lines)
+    errors.extend(_lint_wandb_disabled(path, data, key_lines))
     if _should_require_recipe(path, automodel_dir):
         errors.extend(_lint_recipe_target(path, data, key_lines, automodel_dir))
     return errors
@@ -121,6 +122,41 @@ def _lint_top_level_keys(path: Path, key_lines: list[tuple[str, int]]) -> list[L
         errors.append(LintError(path, ci_line, "Top-level `ci` section must be the last section."))
 
     return errors
+
+
+def _lint_wandb_disabled(path: Path, data: dict, key_lines: list[tuple[str, int]]) -> list[LintError]:
+    """Require an example ``wandb:`` block to set ``enable: false``.
+
+    Weights & Biases logging is opt-in for examples: a present ``wandb:`` block
+    logs by default, which fails or noisily logs for anyone who runs the example
+    without W&B credentials. Example configs ship the block with ``enable: false``
+    so users opt in by flipping it to ``true`` (no need to comment/uncomment the
+    block). A config with no ``wandb:`` block is fine.
+
+    Args:
+        path: Path of the YAML file being linted.
+        data: The parsed YAML mapping.
+        key_lines: ``(key, line)`` pairs for the document's top-level keys.
+
+    Returns:
+        A lint error if a top-level ``wandb`` block is present without
+        ``enable: false``.
+    """
+    if "wandb" not in data:
+        return []
+    wandb_line = dict(key_lines).get("wandb", 1)
+    block = data.get("wandb")
+    enable = block.get("enable") if isinstance(block, dict) else None
+    if enable is False:
+        return []
+    return [
+        LintError(
+            path,
+            wandb_line,
+            "Example `wandb:` block must set `enable: false` (W&B logging is opt-in); "
+            "add `enable: false` so users opt in by flipping it to `true`.",
+        )
+    ]
 
 
 def _lint_recipe_target(

--- a/tutorials/llama-peft/llama_peft_config.yaml
+++ b/tutorials/llama-peft/llama_peft_config.yaml
@@ -79,5 +79,6 @@ packed_sequence:
   packed_sequence_size: 1024
 
 wandb:
+  enable: false
   project: peft-llama
   name: bs8-lr1e-4-warmup207-clip0.8


### PR DESCRIPTION
Cherry-pick of #2643 (8e649e11) onto `r0.5.0`.

**Release-branch resolution**
- **Dropped 8 example configs** modified by this PR that do not exist on r0.5.0 (added on `main` after the branch cut): `examples/dllm_sft/diffusion_gemma_{lora,sft}.yaml`, `examples/vlm_finetune/gemma4/gemma4_{31b_tulu3_text_cp8_16k,e4b_tulu3_text_cp16_64k}.yaml`, `examples/vlm_finetune/minimax_m3/minimax_m3_vl_{lora_pp4ep8_8node,sft_ep32pp4}.yaml`, `examples/vlm_finetune/qwen3_5/qwen3_6_27b_medpix_cp{1,2}_2k_2node_100steps.yaml`.
- Everything else applied cleanly: the `wandb.enable` arg-parser support, the `tools/lint_example_yamls.py` linter + its unit test, `test_wandb_enable.py`, and the `wandb: {enable: false}` block added to every example config present on r0.5.0 (~45 files).

Verified: `python tools/lint_example_yamls.py` passes (394 files linted, exit 0).
