### PR TITLE
fix(training): flag final step when epochs exhaust before max_steps

### DIFF
--- a/nemo_automodel/components/training/step_scheduler.py
+++ b/nemo_automodel/components/training/step_scheduler.py
@@ -246,11 +246,26 @@ class StepScheduler(Stateful):
     @property
     def is_last_step(self):
         """
-        Returns whether the training is finished.
+        Returns whether the current step is the final training step.
+
+        Training stops at whichever comes first: reaching ``max_steps`` or
+        exhausting the configured number of epochs (see ``__iter__`` and
+        ``epochs``). ``max_steps`` alone is therefore not enough to detect the
+        end -- a small dataset can run out of epochs long before ``max_steps``
+        is hit (e.g. ``max_steps=100`` with only 60 steps' worth of data). In
+        that case the last batch of the last epoch is the final step. Detect it
+        so the final checkpoint and consolidated export -- which key off this
+        flag (see ``is_ckpt_step`` and the recipes' ``is_final_checkpoint``) --
+        are still written.
         """
         # we +1 here because the step is incremented after
         # the batch is yielded in the tail handling of __iter__
-        return self.step + 1 >= self.max_steps
+        if self.step + 1 >= self.max_steps:
+            return True
+        # Last batch of the last epoch when epochs are exhausted before max_steps.
+        if self.num_epochs is not None and self.epoch + 1 >= self.num_epochs:
+            return self.is_last_batch
+        return False
 
     @property
     def is_last_batch(self):

--- a/tests/unit_tests/components/training/test_step_scheduler.py
+++ b/tests/unit_tests/components/training/test_step_scheduler.py
@@ -262,9 +262,52 @@ def test_ckpt_every_steps_larger_than_max_steps(
         val = is_ckpt_step.pop(0)
         assert val == scheduler.is_ckpt_step, i
         assert val == scheduler.is_last_batch, i
-        if max_steps is None:
-            assert val == scheduler.is_last_step, i
+        # is_last_step must fire on the final batch regardless of whether the run
+        # ends by hitting max_steps or by exhausting epochs (here max_steps=1000
+        # is never reached; the single epoch runs out first).
+        assert val == scheduler.is_last_step, i
     assert len(is_ckpt_step) == 0
+
+
+def test_is_last_step_when_epochs_exhausted_before_max_steps():
+    """Regression: epochs can run out before max_steps with a small dataset.
+
+    Mirrors the diffusion finetune CI setup that regressed (e.g. hunyuan_t2v_flow):
+    max_steps=100 but only num_epochs * epoch_len = 30 * 2 = 60 steps of data
+    exist, with periodic (ckpt_every_steps=100) and epoch-boundary
+    (save_checkpoint_every_epoch=False) checkpointing both disabled. The final
+    step must still be flagged so the final/consolidated checkpoint is written;
+    otherwise no checkpoint is ever saved.
+    """
+    num_epochs = 30
+    epoch_len = 2
+    max_steps = 100  # never reached: only num_epochs * epoch_len = 60 steps of data
+
+    scheduler = StepScheduler(
+        global_batch_size=1,
+        local_batch_size=1,
+        dp_size=1,
+        ckpt_every_steps=max_steps,  # periodic save never fires (60 < 100)
+        save_checkpoint_every_epoch=False,
+        dataloader=SizedDataLoader(num_batches=epoch_len),
+        num_epochs=num_epochs,
+        max_steps=max_steps,
+    )
+
+    last_step_flags = []
+    ckpt_step_flags = []
+    for _epoch in scheduler.epochs:
+        for _batches in scheduler:
+            last_step_flags.append(scheduler.is_last_step)
+            ckpt_step_flags.append(scheduler.is_ckpt_step)
+
+    # All 60 steps ran (max_steps was never the limiter).
+    assert len(last_step_flags) == num_epochs * epoch_len
+    # is_last_step -- and therefore is_ckpt_step -- fire exactly once, on the final step.
+    assert sum(last_step_flags) == 1
+    assert last_step_flags[-1] is True
+    assert sum(ckpt_step_flags) == 1
+    assert ckpt_step_flags[-1] is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

The diffusion finetune CI job `hunyuan_t2v_flow` (nemo-ci, `diffusion_sft`) fails in its **inference smoke test**:

```
ls: cannot access '.../hunyuan_t2v_flow/checkpoint/epoch_*_step_*': No such file or directory
srun: error: ...: task 0: Exited with exit code 2
```

Training itself runs to completion (loss converges, "Training complete!"), but **no checkpoint is ever written**, so the smoke test's `ls .../epoch_*_step_*` matches nothing. Under the launcher's `set -euo pipefail`, that failing `ls` returns exit code 2 and fails the whole job — the reported "exit code 2" *is* the `ls`, not a training crash.

(Failing job: `gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/344336751`.)

## Root cause

`StepScheduler.is_last_step` only detected the **`max_steps`** termination path:

```python
return self.step + 1 >= self.max_steps
```

But training also stops when the configured **epochs are exhausted** (see `__iter__` / `epochs`). The diffusion launcher runs with `max_steps=100`, `ckpt_every_steps=100`, `save_checkpoint_every_epoch=false`, while the `modal-labs/dissolve` dataset yields only `num_epochs(30) × epoch_len(2) = 60` steps. Training therefore ends by running out of epochs, never reaching `max_steps=100`, so `is_last_step` stays `False` for the entire run.

`is_ckpt_step` and the recipes' `is_final_checkpoint` both key off `is_last_step`, so with it never True:

- the periodic save (`is_ckpt_step`) never fires → **no checkpoint directory is created**, and
- even if one were, the consolidated / diffusers-compatible safetensors that `generate.py` loads (`save_consolidated: final`) are exported **only** when `is_final_checkpoint=True`.

Sibling recipes (wan / flux / qwen) pass only because their datasets reach step 100, tripping `is_last_step` at step 99. The diffusion recipe's `"Saved final checkpoint at step N"` log is misleading — it logs unconditionally and does no saving itself.

## Fix

`is_last_step` now also returns `True` on the **last batch of the last epoch**, so the final checkpoint (and its consolidated export) is written regardless of which termination path ends training:

```python
if self.step + 1 >= self.max_steps:
    return True
# Last batch of the last epoch when epochs are exhausted before max_steps.
if self.num_epochs is not None and self.epoch + 1 >= self.num_epochs:
    return self.is_last_batch
return False
```

`is_last_step` is consumed **only** to trigger checkpoint save / consolidation — never to terminate the training loop (the `__iter__` / `epochs` generators do that independently) — so flagging the genuine final batch cannot end training early.

## Tests

- Added `test_is_last_step_when_epochs_exhausted_before_max_steps`, mirroring the hunyuan setup (`max_steps=100`, 30×2=60 steps, periodic + epoch-boundary saves disabled): asserts the final step — and only it — is flagged.
- Strengthened `test_ckpt_every_steps_larger_than_max_steps` to assert `is_last_step` in **both** parametrized cases. It previously skipped that assertion whenever `max_steps` was set, which had been quietly masking this bug.
- `tests/unit_tests/components/training/` — 43 passed; `ruff format`/`check` clean.