### PR TITLE
fix(recipe): disable fused RoPE for MLA packed-sequence MoE recipes

### DIFF
--- a/examples/llm_finetune/glm/glm_4.7_flash_te_packed_sequence.yaml
+++ b/examples/llm_finetune/glm/glm_4.7_flash_te_packed_sequence.yaml
@@ -45,6 +45,11 @@ model:
     dispatcher: deepep
     fake_balanced_gate: false
     enable_hf_state_dict_adapter: true
+    # WAR for https://github.com/NVIDIA-NeMo/Automodel/issues/2674:
+    # fused TE RoPE emits NaN/Inf on the MLA single-head k_pe in THD (packed-sequence)
+    # mode, NaN-ing step-0 loss/grad and collapsing MoE routing -> OOM.
+    # Non-fused RoPE (fp32 unit-magnitude complex multiply) is bounded.
+    rope_fusion: false
 
 autopipeline:
   _target_: nemo_automodel.components.distributed.pipelining.config.PipelineConfig

--- a/examples/llm_finetune/moonlight/moonlight_16b_te_packed_sequence.yaml
+++ b/examples/llm_finetune/moonlight/moonlight_16b_te_packed_sequence.yaml
@@ -47,6 +47,11 @@ model:
     dispatcher: deepep
     fake_balanced_gate: false
     enable_hf_state_dict_adapter: true
+    # WAR for https://github.com/NVIDIA-NeMo/Automodel/issues/2674:
+    # fused TE RoPE emits NaN/Inf on the MLA single-head k_pe in THD (packed-sequence)
+    # mode, NaN-ing step-0 loss/grad and collapsing MoE routing -> OOM.
+    # Non-fused RoPE (fp32 unit-magnitude complex multiply) is bounded.
+    rope_fusion: false
 
 checkpoint:
   enabled: false

--- a/tests/ci_tests/configs/llm_finetune/test_recipes.yml
+++ b/tests/ci_tests/configs/llm_finetune/test_recipes.yml
@@ -25,6 +25,7 @@ configs:
   - falcon/falcon_h1_34b_instruct_squad_peft.yaml
   - gemma/gemma_3_270m_squad.yaml
   - gemma/gemma_3_270m_squad_peft.yaml
+  - glm/glm_4.7_flash_te_packed_sequence.yaml
   - glm/glm_4_9b_chat_hf_hellaswag_fp8.yaml
   - gpt_oss/gpt_oss_120b.yaml
   - gpt_oss/gpt_oss_20b.yaml


### PR DESCRIPTION
## What

Disable fused RoPE (`model.backend.rope_fusion: false`) in the two **MLA + TE + packed-sequence** MoE finetune recipes:

- `examples/llm_finetune/moonlight/moonlight_16b_te_packed_sequence.yaml`
- `examples/llm_finetune/glm/glm_4.7_flash_te_packed_sequence.yaml`

## Why

In THD (packed-sequence) mode the fused Transformer-Engine RoPE path emits **NaN/Inf on the MLA single-head `k_pe`** at the first forward (`q_pe`, multi-head, is fine under the identical `freqs`). That NaN-s step-0 loss/grad, the optimizer step then corrupts every weight, and at step 1 the all-`NaN` router collapses MoE routing onto a single EP rank — which surfaces as a **CUDA OOM** in the token-permute. The OOM is a symptom, not the cause; weights load 100% clean.

Repro evidence (instrumented, exact CI commit `d94e9110`, 8×H100, `ep_size=8`):
```
ROPE OUT  q_pe[nan=0 finmax=1.0e1]  k_pe[nan=30 finmax=3.390e38]   # bf16 max + NaN
```

The non-fused RoPE path does the rotation as a unit-magnitude complex multiply in fp32, so it is bounded.

## Validation (8×H100)

| Recipe | before (`rope_fusion: true` default) | after (this PR) |
|---|---|---|
| Moonlight-16B | `loss nan` → step-1 OOM | loss 2.57 → 2.47 → 2.16, val 2.07, no NaN, balanced routing, no OOM |
| GLM-4.7-Flash | `loss nan` → step-1 OOM | loss 3.03 → 2.84 → 2.67, val 2.50, no NaN, balanced routing, no OOM |

## Notes

- Workaround for #2674 — the proper TE-side fix (fused RoPE on single-head `k_pe` in THD, and/or per-sequence positions from `cu_seqlens`) is tracked there. This PR only flips a recipe flag to unblock these CI configs.
- Other MLA + packed recipes (e.g. `glm_moe_dsa`, DeepSeek-V3.2) likely need the same guard once their configs run.
