### PR TITLE
fix(docker): bump DeepEP to `42144303` to pad HybridEP token capacity

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -78,9 +78,12 @@ RUN if [ "$INSTALL_TE" = "True" ]; then \
 # Install HybridEP / DeepEP. Build with apt rdma-core v60 (so build==runtime libibverbs)
 # and RDMA_CORE_HOME symlinked to the system install; create the libnvshmem_host.so->.so.3
 # symlink required for DeepEP fabric handle ops; use the nvshmem wheel 3.6.5 and pin
-# DEEPEP_COMMIT to 17cfb817.
+# DEEPEP_COMMIT to 42144303 (== 17cfb817 + DeepEP #638), which pads the HybridEP
+# max_num_of_tokens_per_rank up to the combine-kernel chunk size so a per-rank token
+# count that is not a multiple of 64 (e.g. 672) no longer fails the combine-kernel
+# static_assert (MAX_NUM_OF_TOKENS_PER_RANK % NUM_OF_TOKENS_PER_CHUNK == 0).
 COPY docker/common/deepep.patch /opt/deepep.patch
-ARG DEEPEP_COMMIT=17cfb817bccec3a9c247013360cc550c2bac441e
+ARG DEEPEP_COMMIT=42144303752422ade37f24bca9e2dde12df70e09
 ENV HYBRID_EP_MULTINODE=1
 ENV RDMA_CORE_HOME=/opt/rdma-core/build
 ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64/:$LD_LIBRARY_PATH


### PR DESCRIPTION
## What

Bump `DEEPEP_COMMIT` from `17cfb817` to `42144303` (deepseek-ai/DeepEP **[#638](https://github.com/deepseek-ai/DeepEP/pull/638)**, "Handle token padding & Add check for inter-node case").

`42144303` is exactly **one commit on top of the currently pinned `17cfb817`** (`ahead_by: 1, behind_by: 0`), so this adds only the padding fix and cannot regress the internode behavior that `17cfb817` was pinned for. `docker/common/deepep.patch` only touches `setup.py`, so it still applies cleanly.

## Why

HybridEP MoE recipes (e.g. `ling_flash_2_0_sft`) crash at DeepEP JIT time:

```
hybrid_ep_backend.cuh: static assertion failed:
"MAX_NUM_OF_TOKENS_PER_RANK must be multiple of NUM_OF_TOKENS_PER_CHUNK"
  MAX_NUM_OF_TOKENS_PER_RANK=672, NUM_OF_TOKENS_PER_CHUNK=64   (672 = 64 * 10.5)
```

```
/usr/local/lib/python3.12/dist-packages/torch/utils/_config_module.py:540: FutureWarning: torch._dynamo.config.skip_code_recursive_on_recompile_limit_hit is deprecated and does not do anything. It will be removed in a future version of PyTorch.
  config[key] = copy.deepcopy(getattr(self, key))
/usr/local/lib/python3.12/dist-packages/torch/utils/_config_module.py:540: FutureWarning: torch._dynamo.config.skip_code_recursive_on_recompile_limit_hit is deprecated and does not do anything. It will be removed in a future version of PyTorch.
  config[key] = copy.deepcopy(getattr(self, key))
/usr/local/lib/python3.12/dist-packages/torch/utils/_config_module.py:540: FutureWarning: torch._dynamo.config.skip_code_recursive_on_recompile_limit_hit is deprecated and does not do anything. It will be removed in a future version of PyTorch.
  config[key] = copy.deepcopy(getattr(self, key))
/usr/local/lib/python3.12/dist-packages/torch/utils/_config_module.py:540: FutureWarning: torch._dynamo.config.skip_code_recursive_on_recompile_limit_hit is deprecated and does not do anything. It will be removed in a future version of PyTorch.
  config[key] = copy.deepcopy(getattr(self, key))
/usr/local/lib/python3.12/dist-packages/torch/utils/_config_module.py:540: FutureWarning: torch._dynamo.config.skip_code_recursive_on_recompile_limit_hit is deprecated and does not do anything. It will be removed in a future version of PyTorch.
  config[key] = copy.deepcopy(getattr(self, key))
/usr/local/lib/python3.12/dist-packages/torch/utils/_config_module.py:540: FutureWarning: torch._dynamo.config.skip_code_recursive_on_recompile_limit_hit is deprecated and does not do anything. It will be removed in a future version of PyTorch.
  config[key] = copy.deepcopy(getattr(self, key))
/usr/local/lib/python3.12/dist-packages/torch/utils/_config_module.py:540: FutureWarning: torch._dynamo.config.skip_code_recursive_on_recompile_limit_hit is deprecated and does not do anything. It will be removed in a future version of PyTorch.
  config[key] = copy.deepcopy(getattr(self, key))
/usr/local/lib/python3.12/dist-packages/torch/utils/_config_module.py:540: FutureWarning: torch._dynamo.config.skip_code_recursive_on_recompile_limit_hit is deprecated and does not do anything. It will be removed in a future version of PyTorch.
  config[key] = copy.deepcopy(getattr(self, key))
/usr/local/lib/python3.12/dist-packages/torch/utils/_config_module.py:540: FutureWarning: torch._dynamo.config.skip_code_recursive_on_recompile_limit_hit is deprecated and does not do anything. It will be removed in a future version of PyTorch.
  config[key] = copy.deepcopy(getattr(self, key))
/usr/local/lib/python3.12/dist-packages/torch/utils/_config_module.py:540: FutureWarning: torch._dynamo.config.skip_code_recursive_on_recompile_limit_hit is deprecated and does not do anything. It will be removed in a future version of PyTorch.
  config[key] = copy.deepcopy(getattr(self, key))
/usr/local/lib/python3.12/dist-packages/deep_ep/backend/hybrid_ep_backend.cuh(4552): error: static assertion failed with "MAX_NUM_OF_TOKENS_PER_RANK must be multiple of NUM_OF_TOKENS_PER_CHUNK."
    static_assert(MAX_NUM_OF_TOKENS_PER_RANK % NUM_OF_TOKENS_PER_CHUNK == 0, "MAX_NUM_OF_TOKENS_PER_RANK must be multiple of NUM_OF_TOKENS_PER_CHUNK.");
```

Failing pipeline: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/344336823
Working pipeline: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/344439748

The HybridEP combine kernel processes tokens in fixed 64-token chunks, so the per-rank buffer capacity must be a multiple of 64. The pinned DeepEP only aligned the per-rank token count up to a multiple of **16** (and only in the dispatch path), so a per-rank token count such as `672` (a valid multiple of 16, not of 64) fails to compile the combine kernel. DeepEP [#638](https://github.com/deepseek-ai/DeepEP/pull/638) adds `hybrid_ep_pad_num_of_tokens_per_rank()` in the C++ `Configurer` that pads `max_num_of_tokens_per_rank` up to `num_of_tokens_per_chunk_combine_api` (64) at buffer construction (covering `__init__`, dispatch, and `adjust_template`), and adds an inter-node IB QP tx-depth capacity check.


## Changelog

- `docker/Dockerfile`: `DEEPEP_COMMIT` `17cfb817` → `42144303`.

## Test plan

- nemo-ci: rebuild the container and re-run `ling_flash_2_0_sft` (previously failed with the combine-kernel static_assert at `MAX_NUM_OF_TOKENS_PER_RANK=672`).

## Pre-checks

- [x] DCO sign-off present.
- [x] No code changes (Dockerfile dependency pin only); lint/unit unaffected.