### PR TITLE
fix(checkpoint): fp8 MoE expert weights silently not loaded at ep_shard=1 (random init → garbage loss)

### DIFF
--- a/examples/llm_finetune/minimax_m2/minimax_m2.1_hellaswag_pp.yaml
+++ b/examples/llm_finetune/minimax_m2/minimax_m2.1_hellaswag_pp.yaml
@@ -35,6 +35,7 @@ distributed:
   dp_replicate_size: 1
   ep_size: 32
   sequence_parallel: false
+  activation_checkpointing: true
 
   pipeline:
     pp_schedule: interleaved1f1b
@@ -46,6 +47,7 @@ distributed:
     layers_per_stage: 2
 
   moe:
+    ignore_router_for_ac: true
     reshard_after_forward: false
     wrap_outer_model: false
 
@@ -80,6 +82,7 @@ dataset:
   _target_: nemo_automodel.components.datasets.llm.hellaswag.HellaSwag
   path_or_dataset: rowan/hellaswag
   split: train
+  pad_to_max_length: true
 
 packed_sequence:
   packed_sequence_size: 0
@@ -95,6 +98,7 @@ validation_dataset:
   _target_: nemo_automodel.components.datasets.llm.hellaswag.HellaSwag
   path_or_dataset: rowan/hellaswag
   split: train
+  pad_to_max_length: true
 
 validation_dataloader:
   _target_: torchdata.stateful_dataloader.StatefulDataLoader

--- a/examples/llm_finetune/minimax_m2/minimax_m2.7_hellaswag_pp.yaml
+++ b/examples/llm_finetune/minimax_m2/minimax_m2.7_hellaswag_pp.yaml
@@ -37,6 +37,7 @@ distributed:
   dp_replicate_size: 1
   ep_size: 16
   sequence_parallel: false
+  activation_checkpointing: true
 
   pipeline:
     pp_schedule: interleaved1f1b
@@ -48,6 +49,7 @@ distributed:
     layers_per_stage: 2
 
   moe:
+    ignore_router_for_ac: true
     reshard_after_forward: false
     wrap_outer_model: false
 
@@ -82,6 +84,7 @@ dataset:
   _target_: nemo_automodel.components.datasets.llm.hellaswag.HellaSwag
   path_or_dataset: rowan/hellaswag
   split: train
+  pad_to_max_length: true
 
 packed_sequence:
   packed_sequence_size: 0
@@ -97,6 +100,7 @@ validation_dataset:
   _target_: nemo_automodel.components.datasets.llm.hellaswag.HellaSwag
   path_or_dataset: rowan/hellaswag
   split: train
+  pad_to_max_length: true
 
 validation_dataloader:
   _target_: torchdata.stateful_dataloader.StatefulDataLoader

--- a/nemo_automodel/components/moe/state_dict_mixin.py
+++ b/nemo_automodel/components/moe/state_dict_mixin.py
@@ -637,6 +637,12 @@ class MoESplitExpertsStateDictMixin:
         inter_dim = self.moe_config.moe_inter_dim
         prefix = prefix_override if prefix_override is not None else self._hf_prefix
         expert_segment = self._expert_path_segment
+        # When quantizing, the adapter casts each split with ``value.to(float8_e4m3fn)``,
+        # which ALLOCATES a new tensor that no longer aliases the model's grouped storage.
+        # An in-place DCP ``copy_`` into that throwaway buffer would silently never reach the
+        # model (experts stay at random init -> garbage loss). So fp8 loads must take the
+        # rebuild path: never mark these keys in-place-loaded when ``quantization`` is set.
+        quantization = kwargs.get("quantization", False)
 
         from nemo_automodel.components.moe.state_dict_utils import (
             is_dtensor,
@@ -652,7 +658,7 @@ class MoESplitExpertsStateDictMixin:
             splits = self._split_experts_weights(tensor, n_experts)
 
             # In-place views only engage when splits are plain (ep_shard==1).
-            inplace_ok = is_dtensor(tensor) and len(splits) > 0 and not is_dtensor(splits[0])
+            inplace_ok = is_dtensor(tensor) and len(splits) > 0 and not is_dtensor(splits[0]) and not quantization
             if inplace_ok:
                 self._register_inplace_loaded_key(fqn, prefix_override)
 
@@ -694,7 +700,7 @@ class MoESplitExpertsStateDictMixin:
                 validate_dtensor_expert_sharding(tensor, n_experts, f"down_projs (DeepEP) layer {layer_num}")
 
             splits = self._split_experts_weights(tensor, n_experts)
-            inplace_ok = is_dtensor(tensor) and len(splits) > 0 and not is_dtensor(splits[0])
+            inplace_ok = is_dtensor(tensor) and len(splits) > 0 and not is_dtensor(splits[0]) and not quantization
             if inplace_ok:
                 self._register_inplace_loaded_key(fqn, prefix_override)
 


### PR DESCRIPTION
## Summary
Fixes a **silent** weight-loading bug: fp8 (block-quantized) MoE expert weights are never loaded from the checkpoint when `ep_shard == 1`, so the experts keep their random initialization. This produces a garbage starting loss — e.g. **MiniMax-M2 at `ep_size=32`: step-0 loss ~15 instead of ~3** — with **no error or warning** (the in-place view tracking marks the keys "loaded", suppressing the missing-key diff).

## Root cause
The fp8 base-checkpoint load path is `to_hf(quantization=True)` → `dcp.load` (in-place `copy_`) → `from_hf` (skips the rebuild for keys marked in-place-loaded).

In `_convert_single_merged_expert_to_hf_split_experts` (`state_dict_mixin.py`), when the per-expert split is a plain tensor (`ep_shard == 1`) it marks the key in-place-loaded and returns per-expert tensors that are **views aliasing the model's grouped expert storage**, expecting DCP to write straight through them. But the fp8 adapters then cast each split with `value.to(torch.float8_e4m3fn)` — a dtype cast **always allocates a new tensor**, which no longer aliases model storage. DCP copies the checkpoint bytes into that throwaway buffer, `from_hf` skips the rebuild (the key is marked in-place-loaded), and the model silently retains its `normal_(0, 0.02)` init.

Why it only triggers at `ep_shard == 1 + quantization=True`:
- **`ep_shard > 1`** (e.g. ep16): the per-expert split stays a DTensor → not marked in-place → takes the **rebuild** path (dequantize → stack → redistribute) → loads correctly.
- **bf16 / `quantization=False`** (e.g. `ling_flash`): the views are not cast, so they still alias model storage → the in-place DCP write reaches the model.

## Fix
Gate `inplace_ok` on `not quantization` so fp8 loads always take the rebuild path (the path that already works at `ep_shard>1` and for bf16). Two lines; fixes **all** fp8 MoE adapters at `ep_shard=1` (deepseek_v3/v32, glm_moe_dsa, minimax_m2/m3, mistral3/4, …).

## Verification (8-node eos, same MiniMax-M2.7 checkpoint, `ep_size=32`)
| | rank-0 expert `absmax` | step-0 loss |
|---|---|---|
| before | ~0.11 (= random init, std 0.02) | 14.97 |
| **after** | ~0.35 (= correctly loaded, matches ep16) | **3.19** |

After the fix the ep32-loaded expert weights are **byte-identical** to the ep16 load (confirmed via a per-expert weight dump), and training descends normally (3.19 → 1.97).

## Recipe configs
Also enables `activation_checkpointing` + `ignore_router_for_ac` (memory; `ignore_router_for_ac` avoids the MoE router recompute mismatch) and `pad_to_max_length` (static-shape PP) on the `minimax_m2.1` and `minimax_m2.7` hellaswag PP recipes. `m2.7` (ep16 = 16 experts/GPU) needs AC to avoid a backward-pass OOM.

## End-to-end verification (8-node eos)
All three MiniMax recipes now start at the correct loss and train cleanly (previously stuck at random-init ~15, or OOM):

| recipe | config | step-0 loss → | status |
|---|---|---|---|
| `minimax_m2.1` | ep32 + AC | 3.10 → 1.72 | ✅ trains |
| `minimax_m2.5` | ep32 | 3.22 → 1.73 | ✅ full run |
| `minimax_m2.7` | ep16 + AC | 3.18 → 1.93 | ✅ no OOM |

(`glm_5.1` is fp8 + `ep_shard=1` so it benefits from the same fix, but is tracked separately — it needs a larger `ci.time` for the 32-node load and is still being verified.)
