### PR TITLE
fix(qwen3_moe): disable fused RoPE for the packed-sequence LoRA recipe

### DIFF
--- a/examples/llm_finetune/qwen/qwen3_moe_30b_te_packed_sequence_lora.yaml
+++ b/examples/llm_finetune/qwen/qwen3_moe_30b_te_packed_sequence_lora.yaml
@@ -47,6 +47,12 @@ model:
     dispatcher: deepep
     fake_balanced_gate: false
     enable_hf_state_dict_adapter: true
+    # Fused TE RoPE emits NaN/Inf on the query in THD (packed-sequence) mode, which
+    # NaNs the step-0 gradient, corrupts all weights through the optimizer step, and
+    # collapses MoE routing onto a single EP rank at step 1 -- surfacing as a CUDA OOM
+    # in the DeepEP token-permute (the OOM is a symptom, not the cause). Use the bounded
+    # fp32 non-fused RoPE path instead. Same root cause/fix as #2675 (Moonlight, GLM-4.7).
+    rope_fusion: false
 
 peft:
   _target_: nemo_automodel.components._peft.lora.PeftConfig


### PR DESCRIPTION
## Problem

`qwen3_moe_30b_te_packed_sequence_lora` (nemo-ci `peft`, eos) fails at step 1 with a per-rank **CUDA OOM** in the DeepEP token-permute + a `DeepEP error: CPU recv timeout` cascade. The OOM is a **symptom, not the cause**.

## Root cause

**Fused TE RoPE emits NaN/Inf on the query under THD (packed-sequence) mode.** The chain:
1. Step 0: the fused-RoPE backward produces a non-finite **query** gradient (`grad_norm=nan` while `loss` is finite ~3.38).
2. `clip_grad_norm` (global norm = NaN) smears it across **all** LoRA grads; the unconditional optimizer step writes NaN into every LoRA weight.
3. Step 1: NaN weights → routing collapses onto a single EP rank → that rank floods → **OOM** in the token-permute; other ranks hang at the DeepEP combine barrier → recv timeout.

This is the **same root cause and fix as #2675** ("disable fused RoPE for MLA packed-sequence MoE recipes", which fixed Moonlight-16B and GLM-4.7-Flash). qwen3_moe was not covered there, and its recipe doesn't set `rope_fusion`, so it defaults to `True` (TE present).

### How it was localized
Per-parameter and per-module **backward grad-finiteness** traces on eos (8×H100):
- First non-finite grad = `model.layers.N.self_attn.q_proj.lora_A` — **q-only** (`k_proj`/`v_proj`/`o_proj` and the MoE experts all finite); origin layer varies run-to-run (non-determinism).
- `q_proj`/`q_norm` forward inputs, outputs, and weights are all **finite**; only the **grad-input** (gradient arriving from the upstream RoPE backward) is NaN — so the NaN is manufactured upstream of `q_norm`, in RoPE.
- Independent of the GEMM kernel (`gmm` == `torch_mm`), the EP dispatcher (`deepep` == `hybridep`), and the SDPA backend (forcing `NVTE_FUSED_ATTN`/`NVTE_FLASH_ATTN` left it unchanged) — i.e. **not** the MoE/dispatcher and **not** the attention kernel.

## Fix

Set `rope_fusion: false` on this recipe → the bounded fp32 non-fused RoPE path.

## Validation (eos, 8×H100)

Before: step 0 `grad_norm nan`, step 1 OOM + DeepEP recv timeout → job fails.
After: trains cleanly — `step 0 loss 3.04 grad_norm 2.03`, decreasing to `step 14 loss 1.88`, finite grad_norm throughout, **no OOM / no timeout**, job **passes**.

## Follow-up (not in this PR)

The other `attn: te` + packed/THD qwen3_moe recipes almost certainly share this bug and should get the same `rope_fusion: false` (not CI-validated here): `qwen3_moe_30b_te_packed_sequence`, `..._flashoptim`, `..._te_deepep`, `..._te_hybridep{,_mxfp8}`, `..._te_chat_thd`. The deeper fix is to make fused TE RoPE finite on THD.