### PR TITLE
fix(vlm): bump mistral3p5_128b_medpix max_length 1024->2048

### DIFF
--- a/examples/vlm_finetune/mistral3p5/mistral3p5_128b_medpix.yaml
+++ b/examples/vlm_finetune/mistral3p5/mistral3p5_128b_medpix.yaml
@@ -97,7 +97,7 @@ dataloader:
   pin_memory: true
   collate_fn:
     _target_: nemo_automodel.components.datasets.vlm.collate_fns.default_collate_fn
-    max_length: 1024
+    max_length: 2048
   drop_last: true
 
 validation_dataset:
@@ -110,7 +110,7 @@ validation_dataloader:
   num_workers: 1
   collate_fn:
     _target_: nemo_automodel.components.datasets.vlm.collate_fns.default_collate_fn
-    max_length: 1024
+    max_length: 2048
 
 optimizer:
   _target_: torch.optim.Adam


### PR DESCRIPTION
# What does this PR do ?

Raises `max_length` from **1024 → 2048** in the Mistral-Medium-3.5 128B MedPix VLM SFT recipe so MedPix samples (which expand to up to ~665 image placeholder tokens plus text) fit without truncation.

# Changelog

- `examples/vlm_finetune/mistral3p5/mistral3p5_128b_medpix.yaml`: set `max_length: 2048` (was `1024`) on both the train and validation `default_collate_fn`.

## Root cause

With `max_length: 1024` (the smallest of any VLM recipe), `default_collate_fn` runs the HF processor with `truncation=True` + `padding="max_length"`. A MedPix sample expands to ~665 image placeholder tokens plus text, exceeding 1024, so truncation clips the image-token block. transformers >=5 then raises in `_check_special_mm_tokens`:

```
ValueError: Mismatch in `image` token count between text and `input_ids`.
Got ids=[..., 629] and text=[..., 665]. Likely due to `truncation='max_length'`.
```

Under pipeline parallelism a fixed `seq_len` is required (so truncation can't simply be disabled), and dropping overlong samples risks NCCL hangs on an empty batch — so raising `max_length` is the correct fix. The LoRA sibling (`mistral3p5_128b_medpix_lora`) and `mistral4_medpix` already use 2048.

## Verification

Ran this recipe from this branch on eos (8x H100, TP8/PP8) via nemo-ci:

- Pipeline (passed): https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/55350072
- Job (passed): https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/344547487

Completed all 100 steps; healthy loss (~1.0-1.6), peak memory **~33 GiB / 80 GiB per GPU** (no OOM). The original image-token-mismatch crash is gone.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests? — N/A (config-only change)
- [ ] Did you add or update any necessary documentation? — N/A

# Additional Information

- Surfaced by the `r0.5.0-automodel-release` pipeline (failing job 344336711). The same `max_length: 1024` is present on the `r0.5.0` branch, so this likely warrants a cherry-pick to the release branch.
