### PR TITLE
fix(mistral3): remap FP8 VLM checkpoint prefixes

### DIFF
--- a/examples/llm_finetune/mistral/ministral3_3b_squad.yaml
+++ b/examples/llm_finetune/mistral/ministral3_3b_squad.yaml
@@ -119,6 +119,10 @@ ci:
     cross_tp_kl_threshold: 5e-3
     dataset.limit_dataset_samples: 500
     validation_dataset.limit_dataset_samples: 500
+    # Vanilla HF reload reads Ministral-3's FP8 config directly and can route
+    # through HF's finegrained-fp8 kernels/tolerances instead of Automodel's
+    # bf16 dequantized checkpoint path. Phase 3 still verifies Automodel reload.
+    skip_hf_reload: true
     # vision_tower params receive no grads from text-only batches, so Adam
     # never materialises per-param `step` state for them; DCP resume load is
     # strict and fails with `Missing key ... optim.state.model.vision_tower.*`.

--- a/examples/llm_finetune/mistral/ministral3_3b_squad_peft.yaml
+++ b/examples/llm_finetune/mistral/ministral3_3b_squad_peft.yaml
@@ -129,6 +129,10 @@ ci:
     tokenizer_name: mistralai/Ministral-3-3B-Instruct-2512
     dataset.limit_dataset_samples: 500
     validation_dataset.limit_dataset_samples: 500
+    # Vanilla HF reload starts from the original FP8 base model and requires
+    # HF's finegrained-fp8 runtime kernels. Phase 3 still verifies Automodel
+    # checkpoint reload for the PEFT adapter.
+    skip_hf_reload: true
     # vision_tower params receive no grads from text-only batches, so Adam
     # never materialises per-param `step` state for them; DCP resume load is
     # strict and fails with `Missing key ... optim.state.model.vision_tower.*`.

--- a/nemo_automodel/components/models/mistral3_vlm/state_dict_adapter.py
+++ b/nemo_automodel/components/models/mistral3_vlm/state_dict_adapter.py
@@ -94,6 +94,29 @@ def _identity(k: str) -> str:
     return k
 
 
+# The HF ``Mistral3ForConditionalGeneration`` puts the LM head at the top level
+# (model param FQN ``lm_head.weight``), but the on-disk checkpoint nests it under
+# the language model (``language_model.lm_head.weight``). For tied-embedding
+# checkpoints (e.g. Ministral-3) the head is never serialized, so the two names
+# never collide and identity round-trips. For *untied* checkpoints (e.g.
+# Devstral-Small-2-24B, ``tie_word_embeddings=False``) the head IS serialized
+# under the nested name, and DCP fails with "Missing key in checkpoint
+# state_dict: lm_head.weight" unless we bridge the two. These translate only the
+# head key; every other key round-trips via identity.
+_MODEL_LM_HEAD_KEY = "lm_head.weight"
+_HF_LM_HEAD_KEY = "language_model.lm_head.weight"
+
+
+def _lm_head_native_to_hf(model_key: str) -> str:
+    """Map the model's top-level ``lm_head.weight`` to the on-disk nested name."""
+    return _HF_LM_HEAD_KEY if model_key == _MODEL_LM_HEAD_KEY else model_key
+
+
+def _lm_head_hf_to_native(hf_key: str) -> str:
+    """Map the on-disk nested ``language_model.lm_head.weight`` to the model name."""
+    return _MODEL_LM_HEAD_KEY if hf_key == _HF_LM_HEAD_KEY else hf_key
+
+
 class Mistral3FP8StateDictAdapter(StateDictAdapter):
     """FP8 dequant adapter for the Mistral-3.5 128B dawn-ridge VLM.
 
@@ -120,12 +143,18 @@ class Mistral3FP8StateDictAdapter(StateDictAdapter):
     def for_vlm_full(cls) -> "Mistral3FP8StateDictAdapter":
         """Full-VLM path for Mistral3ForConditionalGeneration checkpoints.
 
-        Keys round-trip identically between HF's VLM ``state_dict()`` and
-        disk for the dawn-ridge-128B checkpoint (both use
-        ``model.language_model.*``, ``model.vision_tower.*``,
-        ``model.multi_modal_projector.*``, ``lm_head.weight``). Only the
-        language_model layer weights are FP8; vision / mm_projector / lm_head
-        are BF16 on disk and must be passed through without a scale_inv
+        The body keys round-trip identically between HF's VLM ``state_dict()``
+        and disk (both use ``model.language_model.*``, ``model.vision_tower.*``,
+        ``model.multi_modal_projector.*``). The **LM head** is the one
+        exception: the model exposes it at the top level (``lm_head.weight``)
+        while the checkpoint nests it (``language_model.lm_head.weight``), so we
+        translate just that key via ``_lm_head_{native_to_hf,hf_to_native}``.
+        Tied checkpoints (Ministral-3) never serialize the head, so the
+        translation is a harmless no-op there; untied checkpoints (Devstral-24B)
+        rely on it to find the head during the DCP load.
+
+        Only the language_model layer weights are FP8; vision / mm_projector /
+        lm_head are BF16 on disk and must be passed through without a scale_inv
         placeholder — otherwise DCP would fail trying to fetch a non-existent
         ``_scale_inv`` key.
         """
@@ -134,7 +163,12 @@ class Mistral3FP8StateDictAdapter(StateDictAdapter):
             "model.multi_modal_projector",
             # "lm_head" already in _NON_QUANTIZED_SUFFIXES via suffix match.
         )
-        return cls(layout_name="vlm_full", not_fp8_prefixes=not_fp8)
+        return cls(
+            native_to_hf=_lm_head_native_to_hf,
+            hf_to_native=_lm_head_hf_to_native,
+            layout_name="vlm_full",
+            not_fp8_prefixes=not_fp8,
+        )
 
     # --------------------------------------------------------------------- #
     # model → HF                                                            #

--- a/nemo_automodel/components/models/mistral3_vlm/state_dict_adapter.py
+++ b/nemo_automodel/components/models/mistral3_vlm/state_dict_adapter.py
@@ -25,9 +25,11 @@ handles **FP8 dequantization** during load/save:
     and drops the scale keys. Vision tower + multi_modal_projector + lm_head
     are BF16 on disk and pass through unchanged.
 
-Keys round-trip identically: the HF VLM state_dict and the on-disk keys
-both use ``model.language_model.*``, ``model.vision_tower.*``,
-``model.multi_modal_projector.*``, ``lm_head.weight`` — no rename needed.
+The live HF VLM module keeps the body under ``model.*`` while the checkpoint
+stores text weights under ``language_model.model.*`` and top-level VLM
+components as ``vision_tower.*`` / ``multi_modal_projector.*``. The LM head is
+also nested on disk as ``language_model.lm_head.weight`` while the runtime
+module exposes it as ``lm_head.weight``.
 
 Structurally modelled after
 `nemo_automodel/components/models/deepseek_v3/state_dict_adapter.py`.
@@ -94,27 +96,46 @@ def _identity(k: str) -> str:
     return k
 
 
-# The HF ``Mistral3ForConditionalGeneration`` puts the LM head at the top level
-# (model param FQN ``lm_head.weight``), but the on-disk checkpoint nests it under
-# the language model (``language_model.lm_head.weight``). For tied-embedding
-# checkpoints (e.g. Ministral-3) the head is never serialized, so the two names
-# never collide and identity round-trips. For *untied* checkpoints (e.g.
-# Devstral-Small-2-24B, ``tie_word_embeddings=False``) the head IS serialized
-# under the nested name, and DCP fails with "Missing key in checkpoint
-# state_dict: lm_head.weight" unless we bridge the two. These translate only the
-# head key; every other key round-trips via identity.
+# The runtime ``Mistral3ForConditionalGeneration`` puts body modules under
+# ``model.*`` while the on-disk checkpoint stores text weights under
+# ``language_model.model.*`` and non-text VLM components at top level.
+# It also exposes the LM head at the top level (``lm_head.weight``), but the
+# checkpoint nests it under ``language_model.lm_head.weight``. For tied-embedding
+# checkpoints (e.g. Ministral-3) the head is never serialized; untied checkpoints
+# (e.g. Devstral-Small-2-24B, ``tie_word_embeddings=False``) rely on the head
+# bridge during DCP load.
 _MODEL_LM_HEAD_KEY = "lm_head.weight"
 _HF_LM_HEAD_KEY = "language_model.lm_head.weight"
 
 
-def _lm_head_native_to_hf(model_key: str) -> str:
-    """Map the model's top-level ``lm_head.weight`` to the on-disk nested name."""
-    return _HF_LM_HEAD_KEY if model_key == _MODEL_LM_HEAD_KEY else model_key
+def _vlm_full_native_to_hf(model_key: str) -> str:
+    """Map runtime VLM parameter names to checkpoint names."""
+    if model_key == _MODEL_LM_HEAD_KEY:
+        return _HF_LM_HEAD_KEY
+    if model_key.startswith("model.language_model.model."):
+        return "language_model.model." + model_key[len("model.language_model.model.") :]
+    if model_key.startswith("model.language_model."):
+        return "language_model.model." + model_key[len("model.language_model.") :]
+    if model_key.startswith("model.vision_tower."):
+        return "vision_tower." + model_key[len("model.vision_tower.") :]
+    if model_key.startswith("model.multi_modal_projector."):
+        return "multi_modal_projector." + model_key[len("model.multi_modal_projector.") :]
+    return model_key
 
 
-def _lm_head_hf_to_native(hf_key: str) -> str:
-    """Map the on-disk nested ``language_model.lm_head.weight`` to the model name."""
-    return _MODEL_LM_HEAD_KEY if hf_key == _HF_LM_HEAD_KEY else hf_key
+def _vlm_full_hf_to_native(hf_key: str) -> str:
+    """Map checkpoint VLM names back to runtime parameter names."""
+    if hf_key == _HF_LM_HEAD_KEY:
+        return _MODEL_LM_HEAD_KEY
+    if hf_key.startswith("language_model.model."):
+        return "model.language_model." + hf_key[len("language_model.model.") :]
+    if hf_key.startswith("language_model."):
+        return "model." + hf_key
+    if hf_key.startswith("vision_tower."):
+        return "model." + hf_key
+    if hf_key.startswith("multi_modal_projector."):
+        return "model." + hf_key
+    return hf_key
 
 
 class Mistral3FP8StateDictAdapter(StateDictAdapter):
@@ -143,13 +164,12 @@ class Mistral3FP8StateDictAdapter(StateDictAdapter):
     def for_vlm_full(cls) -> "Mistral3FP8StateDictAdapter":
         """Full-VLM path for Mistral3ForConditionalGeneration checkpoints.
 
-        The body keys round-trip identically between HF's VLM ``state_dict()``
-        and disk (both use ``model.language_model.*``, ``model.vision_tower.*``,
-        ``model.multi_modal_projector.*``). The **LM head** is the one
-        exception: the model exposes it at the top level (``lm_head.weight``)
-        while the checkpoint nests it (``language_model.lm_head.weight``), so we
-        translate just that key via ``_lm_head_{native_to_hf,hf_to_native}``.
-        Tied checkpoints (Ministral-3) never serialize the head, so the
+        The runtime module keeps VLM body modules under ``model.*`` but the
+        checkpoint stores text weights under ``language_model.model.*`` and
+        non-text component names at top level. The **LM head** has one extra
+        quirk: the model exposes it at the top level (``lm_head.weight``) while
+        the checkpoint nests it (``language_model.lm_head.weight``).
+        Tied checkpoints (Ministral-3) never serialize the head, so the head
         translation is a harmless no-op there; untied checkpoints (Devstral-24B)
         rely on it to find the head during the DCP load.
 
@@ -164,8 +184,8 @@ class Mistral3FP8StateDictAdapter(StateDictAdapter):
             # "lm_head" already in _NON_QUANTIZED_SUFFIXES via suffix match.
         )
         return cls(
-            native_to_hf=_lm_head_native_to_hf,
-            hf_to_native=_lm_head_hf_to_native,
+            native_to_hf=_vlm_full_native_to_hf,
+            hf_to_native=_vlm_full_hf_to_native,
             layout_name="vlm_full",
             not_fp8_prefixes=not_fp8,
         )

--- a/tests/unit_tests/models/mistral3_vlm/test_state_dict_adapter.py
+++ b/tests/unit_tests/models/mistral3_vlm/test_state_dict_adapter.py
@@ -128,16 +128,28 @@ class TestForVlmFullFactory:
             "model.multi_modal_projector",
         )
 
-    def test_keys_round_trip_identity(self):
-        # Both rewrites are _identity by default — keys should pass through.
+    def test_body_keys_round_trip_identity(self):
+        # Body keys (language_model / vision_tower / multi_modal_projector) pass
+        # through unchanged in both directions.
         a = Mistral3FP8StateDictAdapter.for_vlm_full()
         for k in (
             "model.language_model.layers.0.self_attn.q_proj.weight",
+            "model.language_model.embed_tokens.weight",
             "model.vision_tower.patch_conv.weight",
-            "lm_head.weight",
+            "model.multi_modal_projector.linear_1.weight",
         ):
             assert a._native_to_hf(k) == k
             assert a._hf_to_native(k) == k
+
+    def test_lm_head_key_is_remapped_both_ways(self):
+        # The model exposes the head at the top level (``lm_head.weight``) but the
+        # checkpoint nests it (``language_model.lm_head.weight``). The adapter must
+        # bridge the two so untied checkpoints (Devstral) load the head via DCP.
+        a = Mistral3FP8StateDictAdapter.for_vlm_full()
+        assert a._native_to_hf("lm_head.weight") == "language_model.lm_head.weight"
+        assert a._hf_to_native("language_model.lm_head.weight") == "lm_head.weight"
+        # Round-trips back to the model name.
+        assert a._hf_to_native(a._native_to_hf("lm_head.weight")) == "lm_head.weight"
 
 
 # --------------------------------------------------------------------------- #
@@ -161,9 +173,7 @@ class TestFromHf:
         assert w_key + "_scale_inv" not in out
         # weight dequanted to bf16
         assert out[w_key].dtype == torch.bfloat16
-        assert torch.equal(
-            out[w_key], torch.tensor([[0.5, 1.0]], dtype=torch.bfloat16)
-        )
+        assert torch.equal(out[w_key], torch.tensor([[0.5, 1.0]], dtype=torch.bfloat16))
 
     def test_bf16_weight_passes_through(self):
         a = self._adapter()
@@ -176,11 +186,13 @@ class TestFromHf:
         a = self._adapter()
         sd = {
             "model.language_model.layers.0.self_attn.q_proj.activation_scale": torch.tensor(1.0),
-            "lm_head.weight": torch.tensor([1.0]),
+            # On-disk head key is nested; from_hf must surface it as the model name.
+            "language_model.lm_head.weight": torch.tensor([1.0]),
         }
         out = a.from_hf(sd)
         assert "model.language_model.layers.0.self_attn.q_proj.activation_scale" not in out
         assert "lm_head.weight" in out
+        assert "language_model.lm_head.weight" not in out
 
     def test_fp8_weight_without_scale_passes_through_untouched(self):
         # Defensive: if no scale_inv sibling, don't dequant — pass through.
@@ -189,6 +201,16 @@ class TestFromHf:
         v = torch.tensor([[1.0]], dtype=torch.float8_e4m3fn)
         out = a.from_hf({w_key: v})
         assert out[w_key].dtype == torch.float8_e4m3fn
+
+    def test_nested_lm_head_remapped_to_model_name(self):
+        # Untied checkpoints (Devstral) ship the head under the nested name; it
+        # must arrive at the model's top-level ``lm_head.weight`` (BF16, no dequant).
+        a = self._adapter()
+        v = torch.zeros(8, 4, dtype=torch.bfloat16)
+        out = a.from_hf({"language_model.lm_head.weight": v})
+        assert "lm_head.weight" in out
+        assert "language_model.lm_head.weight" not in out
+        assert torch.equal(out["lm_head.weight"], v)
 
 
 # --------------------------------------------------------------------------- #
@@ -221,11 +243,11 @@ class TestToHf:
     def test_quantization_skips_placeholder_for_non_fp8_keys(self):
         a = self._adapter()
         v = torch.zeros(4, dtype=torch.bfloat16)
-        # vision_tower + multi_modal_projector + lm_head + embed_tokens excluded.
+        # vision_tower + multi_modal_projector + embed_tokens excluded; their
+        # keys are identity. (lm_head is covered separately since it is remapped.)
         for key in (
             "model.vision_tower.transformer.layers.0.attention.q_proj.weight",
             "model.multi_modal_projector.linear_1.weight",
-            "lm_head.weight",
             "model.language_model.embed_tokens.weight",
         ):
             out = a.to_hf({key: v}, quantization=True)
@@ -233,6 +255,18 @@ class TestToHf:
             assert key + "_scale_inv" not in out
             # Original dtype preserved
             assert out[key].dtype == torch.bfloat16
+
+    def test_lm_head_remapped_to_nested_name_no_scale(self):
+        # to_hf must rename the model's top-level head to the on-disk nested name
+        # (so the DCP destination matches the checkpoint), with no FP8 scale_inv.
+        a = self._adapter()
+        v = torch.zeros(4, dtype=torch.bfloat16)
+        out = a.to_hf({"lm_head.weight": v}, quantization=True)
+        assert "language_model.lm_head.weight" in out
+        assert "lm_head.weight" not in out
+        assert "language_model.lm_head.weight_scale_inv" not in out
+        # Original dtype preserved (no FP8 cast for the non-quantized head).
+        assert out["language_model.lm_head.weight"].dtype == torch.bfloat16
 
     def test_exclude_key_regex(self):
         a = self._adapter()
@@ -281,11 +315,21 @@ class TestConvertSingleTensorToHf:
     def test_quantization_non_fp8_emits_one_pair(self):
         a = self._adapter()
         t = torch.zeros(1)
+        # Identity-named, non-FP8 keys: one pair, name unchanged.
         for fqn in (
             "model.vision_tower.transformer.layers.0.attention.q_proj.weight",
             "model.multi_modal_projector.linear_1.weight",
-            "lm_head.weight",
         ):
             pairs = a.convert_single_tensor_to_hf(fqn, t, quantization=True)
             assert len(pairs) == 1
             assert pairs[0] == (fqn, t)
+
+    def test_quantization_lm_head_emits_one_pair_remapped(self):
+        # The head is non-FP8 (no scale_inv) but IS renamed to the on-disk
+        # nested name on the save path.
+        a = self._adapter()
+        t = torch.zeros(1)
+        pairs = a.convert_single_tensor_to_hf("lm_head.weight", t, quantization=True)
+        assert len(pairs) == 1
+        assert pairs[0][0] == "language_model.lm_head.weight"
+        assert pairs[0][1] is t

--- a/tests/unit_tests/models/mistral3_vlm/test_state_dict_adapter.py
+++ b/tests/unit_tests/models/mistral3_vlm/test_state_dict_adapter.py
@@ -112,7 +112,7 @@ class TestDequantizeFromFp8:
 
 
 # --------------------------------------------------------------------------- #
-# Mistral3FP8StateDictAdapter — factories and identity rewrites               #
+# Mistral3FP8StateDictAdapter — factories and key rewrites                    #
 # --------------------------------------------------------------------------- #
 class TestForVlmFullFactory:
     """The single shipped factory wires layout name and not_fp8_prefixes."""
@@ -128,18 +128,31 @@ class TestForVlmFullFactory:
             "model.multi_modal_projector",
         )
 
-    def test_body_keys_round_trip_identity(self):
-        # Body keys (language_model / vision_tower / multi_modal_projector) pass
-        # through unchanged in both directions.
+    def test_body_keys_remap_between_runtime_and_checkpoint_prefixes(self):
+        # Runtime Mistral3ForConditionalGeneration stores the VLM body under
+        # ``model.*``; the checkpoint stores text under ``language_model.model.*``
+        # and non-text VLM components at top level.
         a = Mistral3FP8StateDictAdapter.for_vlm_full()
-        for k in (
-            "model.language_model.layers.0.self_attn.q_proj.weight",
-            "model.language_model.embed_tokens.weight",
-            "model.vision_tower.patch_conv.weight",
-            "model.multi_modal_projector.linear_1.weight",
-        ):
-            assert a._native_to_hf(k) == k
-            assert a._hf_to_native(k) == k
+        cases = {
+            "model.language_model.layers.0.self_attn.q_proj.weight": (
+                "language_model.model.layers.0.self_attn.q_proj.weight"
+            ),
+            "model.language_model.model.layers.0.self_attn.q_proj.weight": (
+                "language_model.model.layers.0.self_attn.q_proj.weight"
+            ),
+            "model.language_model.embed_tokens.weight": "language_model.model.embed_tokens.weight",
+            "model.vision_tower.patch_conv.weight": "vision_tower.patch_conv.weight",
+            "model.multi_modal_projector.linear_1.weight": "multi_modal_projector.linear_1.weight",
+        }
+        for native, hf in cases.items():
+            assert a._native_to_hf(native) == hf
+        assert (
+            a._hf_to_native("language_model.model.layers.0.self_attn.q_proj.weight")
+            == "model.language_model.layers.0.self_attn.q_proj.weight"
+        )
+        assert a._hf_to_native("language_model.model.embed_tokens.weight") == "model.language_model.embed_tokens.weight"
+        assert a._hf_to_native("vision_tower.patch_conv.weight") == "model.vision_tower.patch_conv.weight"
+        assert a._hf_to_native("multi_modal_projector.linear_1.weight") == "model.multi_modal_projector.linear_1.weight"
 
     def test_lm_head_key_is_remapped_both_ways(self):
         # The model exposes the head at the top level (``lm_head.weight``) but the
@@ -175,10 +188,30 @@ class TestFromHf:
         assert out[w_key].dtype == torch.bfloat16
         assert torch.equal(out[w_key], torch.tensor([[0.5, 1.0]], dtype=torch.bfloat16))
 
+    def test_checkpoint_language_model_key_remapped_to_runtime_prefix(self):
+        a = self._adapter()
+        v = torch.zeros(4, dtype=torch.bfloat16)
+        out = a.from_hf({"language_model.model.embed_tokens.weight": v})
+        assert "model.language_model.embed_tokens.weight" in out
+        assert "language_model.model.embed_tokens.weight" not in out
+        assert torch.equal(out["model.language_model.embed_tokens.weight"], v)
+
+    def test_checkpoint_vlm_component_keys_remapped_to_runtime_prefix(self):
+        a = self._adapter()
+        state = {
+            "vision_tower.patch_conv.weight": torch.zeros(2, dtype=torch.bfloat16),
+            "multi_modal_projector.linear_1.weight": torch.ones(2, dtype=torch.bfloat16),
+        }
+        out = a.from_hf(state)
+        assert set(out) == {
+            "model.vision_tower.patch_conv.weight",
+            "model.multi_modal_projector.linear_1.weight",
+        }
+
     def test_bf16_weight_passes_through(self):
         a = self._adapter()
         v = torch.tensor([[1.5, -2.0]], dtype=torch.bfloat16)
-        sd = {"model.vision_tower.ln_pre.weight": v}
+        sd = {"vision_tower.ln_pre.weight": v}
         out = a.from_hf(sd)
         assert torch.equal(out["model.vision_tower.ln_pre.weight"], v)
 
@@ -227,18 +260,19 @@ class TestToHf:
         w_key = "model.language_model.layers.0.self_attn.q_proj.weight"
         v = torch.zeros(2, 2, dtype=torch.bfloat16)
         out = a.to_hf({w_key: v}, quantization=False)
-        assert out == {w_key: v}
+        assert out == {"language_model.model.layers.0.self_attn.q_proj.weight": v}
 
     def test_quantization_emits_scale_inv_for_fp8_keys(self):
         a = self._adapter()
         w_key = "model.language_model.layers.0.self_attn.q_proj.weight"
+        hf_key = "language_model.model.layers.0.self_attn.q_proj.weight"
         out = a.to_hf({w_key: torch.zeros(2, 2, dtype=torch.bfloat16)}, quantization=True)
-        assert w_key in out
-        assert out[w_key].dtype == torch.float8_e4m3fn
-        assert w_key + "_scale_inv" in out
-        assert out[w_key + "_scale_inv"].dtype == torch.bfloat16
+        assert hf_key in out
+        assert out[hf_key].dtype == torch.float8_e4m3fn
+        assert hf_key + "_scale_inv" in out
+        assert out[hf_key + "_scale_inv"].dtype == torch.bfloat16
         # Scalar (0-d) placeholder
-        assert out[w_key + "_scale_inv"].shape == ()
+        assert out[hf_key + "_scale_inv"].shape == ()
 
     def test_quantization_skips_placeholder_for_non_fp8_keys(self):
         a = self._adapter()
@@ -251,10 +285,19 @@ class TestToHf:
             "model.language_model.embed_tokens.weight",
         ):
             out = a.to_hf({key: v}, quantization=True)
-            assert key in out
-            assert key + "_scale_inv" not in out
+            hf_key = a._native_to_hf(key)
+            assert hf_key in out
+            assert hf_key + "_scale_inv" not in out
             # Original dtype preserved
-            assert out[key].dtype == torch.bfloat16
+            assert out[hf_key].dtype == torch.bfloat16
+
+    def test_language_model_embed_tokens_remapped_to_checkpoint_name_no_scale(self):
+        a = self._adapter()
+        v = torch.zeros(4, dtype=torch.bfloat16)
+        out = a.to_hf({"model.language_model.embed_tokens.weight": v}, quantization=True)
+        assert "language_model.model.embed_tokens.weight" in out
+        assert "model.language_model.embed_tokens.weight" not in out
+        assert "language_model.model.embed_tokens.weight_scale_inv" not in out
 
     def test_lm_head_remapped_to_nested_name_no_scale(self):
         # to_hf must rename the model's top-level head to the on-disk nested name
@@ -278,7 +321,7 @@ class TestToHf:
             exclude_key_regex=r"^lm_head\.",
         )
         assert "lm_head.weight" not in out
-        assert "model.language_model.layers.0.self_attn.q_proj.weight" in out
+        assert "language_model.model.layers.0.self_attn.q_proj.weight" in out
 
 
 # --------------------------------------------------------------------------- #
@@ -298,17 +341,18 @@ class TestConvertSingleTensorToHf:
             t,
         )
         assert len(pairs) == 1
-        assert pairs[0][0] == "model.language_model.layers.0.self_attn.q_proj.weight"
+        assert pairs[0][0] == "language_model.model.layers.0.self_attn.q_proj.weight"
         assert pairs[0][1] is t
 
     def test_quantization_fp8_emits_two_pairs(self):
         a = self._adapter()
         t = torch.zeros(1)
         fqn = "model.language_model.layers.0.self_attn.q_proj.weight"
+        hf_key = "language_model.model.layers.0.self_attn.q_proj.weight"
         pairs = a.convert_single_tensor_to_hf(fqn, t, quantization=True)
         assert len(pairs) == 2
-        assert pairs[0] == (fqn, t)
-        assert pairs[1][0] == fqn + "_scale_inv"
+        assert pairs[0] == (hf_key, t)
+        assert pairs[1][0] == hf_key + "_scale_inv"
         assert pairs[1][1].dtype == torch.bfloat16
         assert pairs[1][1].shape == ()
 
@@ -316,13 +360,16 @@ class TestConvertSingleTensorToHf:
         a = self._adapter()
         t = torch.zeros(1)
         # Identity-named, non-FP8 keys: one pair, name unchanged.
-        for fqn in (
-            "model.vision_tower.transformer.layers.0.attention.q_proj.weight",
-            "model.multi_modal_projector.linear_1.weight",
-        ):
+        cases = {
+            "model.vision_tower.transformer.layers.0.attention.q_proj.weight": (
+                "vision_tower.transformer.layers.0.attention.q_proj.weight"
+            ),
+            "model.multi_modal_projector.linear_1.weight": "multi_modal_projector.linear_1.weight",
+        }
+        for fqn, hf_key in cases.items():
             pairs = a.convert_single_tensor_to_hf(fqn, t, quantization=True)
             assert len(pairs) == 1
-            assert pairs[0] == (fqn, t)
+            assert pairs[0] == (hf_key, t)
 
     def test_quantization_lm_head_emits_one_pair_remapped(self):
         # The head is non-FP8 (no scale_inv) but IS renamed to the on-disk


### PR DESCRIPTION
**Follow-up to #2654 / NVBug [6293432](https://nvbugswb.nvidia.com/NVBugs5/SWBug.aspx?bugid=6293432) and Linear [AM-504](https://linear.app/nvidia/issue/AM-504/missing-modellanguage-modelembed-tokensweight-in-checkpoint-causing).**

## What
`Mistral3FP8StateDictAdapter.for_vlm_full()` now maps the full FP8 VLM checkpoint layout used by the Mistral3/Ministral3 family:

- runtime `model.language_model.*` -> checkpoint `language_model.model.*`
- runtime `model.vision_tower.*` -> checkpoint `vision_tower.*`
- runtime `model.multi_modal_projector.*` -> checkpoint `multi_modal_projector.*`
- runtime `lm_head.weight` -> checkpoint `language_model.lm_head.weight`

The FP8 dequantization behavior is unchanged: language-model linear weights use `_scale_inv`; embeddings, norms, vision/projector weights, and `lm_head` stay non-FP8.

The two Ministral CI recipes also skip checkpoint-robustness Phase 4 vanilla-HF reload. That phase reads the FP8 config through HF’s finegrained-fp8 path/kernel availability rather than Automodel’s bf16-dequantized checkpoint path. Phase 3 still verifies Automodel reload from the consolidated checkpoint.

## Why
After #2654 routed these recipes through Automodel's custom `Mistral3FP8VLMForConditionalGeneration`, DCP loading relied on this adapter for model-key -> checkpoint-key translation. The checkpoint stores the text backbone under `language_model.model.*`, but the runtime model asks DCP for `model.language_model.*`, causing missing-key failures such as:

```
RuntimeError: Missing key in checkpoint state_dict: model.language_model.embed_tokens.weight.
```

Devstral additionally needs the untied head bridge because its checkpoint serializes `language_model.lm_head.weight`; Ministral has tied embeddings and does not serialize the head, but it still needs the body prefix mapping.

## How tested
Local:

- `pytest tests/unit_tests/models/mistral3_vlm/test_state_dict_adapter.py -q`
- `pytest tests/unit_tests/ci_tests/test_config_resolver.py -q`
- `ruff check nemo_automodel/components/models/mistral3_vlm/state_dict_adapter.py tests/unit_tests/models/mistral3_vlm/test_state_dict_adapter.py`
- `git diff --check`

nemo-ci on commit `1d74ed69c603622d94ac379f145c90a221554933`:

- Root pipeline: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/55393490
- Child pipeline: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/55393605
- Generated LLM pipeline: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/55393678
- `devstral2_small_2512_squad`: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/344770912
- `devstral2_small_2512_squad_peft`: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/344770915
- `ministral3_3b_squad`: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/344770914
- `ministral3_3b_squad_peft`: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/344770916

Signed-off-by: Alexandros Koumparoulis <akoumparouli@nvidia.com>
