### PR TITLE
fix(deepseek_v4): support packed THD document bounds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -200,6 +200,25 @@ RUN git clone --depth 1 --branch v0.17.0 --recurse-submodules --shallow-submodul
         pip install --no-cache-dir --no-build-isolation /tmp/torchao && \
     rm -rf /tmp/torchao
 
+# DeepSeek-V4 TileLang kernels (backend.attn="tilelang": sparse MLA attention,
+# lightning indexer, and the MHC sinkhorn path used by the deepseek_v4_* recipes).
+# Installed AFTER `uv sync` (like torchao above) so the packages are not pruned and
+# so tile_kernels builds/links against the image's final torch. tilelang ships
+# CUDA-agnostic abi3 wheels (x86_64 + aarch64) and JIT-compiles its kernels at
+# RUNTIME via NVRTC, so the CUDA 13.2 -devel base (nvcc/nvrtc/headers) is what is
+# required at runtime; nothing is compiled here. tile_kernels is the external
+# DeepSeek "TileKernels" package (MHC sinkhorn) -- not vendored in AutoModel and not
+# on PyPI -- so it is git-pinned; install it AFTER tilelang with --no-build-isolation
+# so pip does not pull a fresh torch/tilelang over the in-image builds.
+ARG INSTALL_TILELANG=True
+ARG TILELANG_VERSION=0.1.11
+ARG TILEKERNELS_COMMIT=36d9e45d38e204ebb87e6f6e833821eee0482fe5
+RUN if [ "$INSTALL_TILELANG" = "True" ]; then \
+        pip install --no-cache-dir "tilelang==${TILELANG_VERSION}" && \
+        pip install --no-cache-dir --no-build-isolation \
+            "git+https://github.com/deepseek-ai/TileKernels@${TILEKERNELS_COMMIT}"; \
+    fi
+
 COPY . /opt/Automodel
 
 # Re-apply PyTorch overrides after full COPY (which overwrites the modified pyproject.toml/uv.lock)

--- a/docker/common/uv-pytorch.lock
+++ b/docker/common/uv-pytorch.lock
@@ -400,6 +400,41 @@ wheels = [
 ]
 
 [[package]]
+name = "apache-tvm-ffi"
+version = "0.1.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/95/ef83880657e89a0ce0f1ad79cbff11698286d00522dbc290d34a8458e9c2/apache_tvm_ffi-0.1.12.tar.gz", hash = "sha256:2aa5c8ece3144dad11afd6d0f10191d03cdb368bbcd9c92f9fb919f35906223d", size = 2843816, upload-time = "2026-06-09T18:17:31.68Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/60/7e851d0391d3d39acde7620896255eb1dc289a6dec8d0ced9261929328b0/apache_tvm_ffi-0.1.12-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cbdadaf5ce64d4c3114b4366a5b685010ffa178f48f8250974e5f1a9b9c81185", size = 2511255, upload-time = "2026-06-09T18:16:17.258Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/9e17990a0af9bc6f1621fc07b10868e69040d14fbed5767e8a2eab873836/apache_tvm_ffi-0.1.12-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b17d2480eb2d04d4034669e3bba31527cd1d4900f1f51712cd959f9721bb0beb", size = 2687332, upload-time = "2026-06-09T18:16:19.69Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/a2/71eec92ef1a1bc8f993e742f6b1b8d9adfbd0d7396c8549c2473523077e6/apache_tvm_ffi-0.1.12-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f9500fc9b1b3315d02602382d13ac976aa1466b2332ff05f74810a6d48821cd", size = 2821872, upload-time = "2026-06-09T18:16:21.741Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/9c/d770a3610bedcfac40ce918cc90f3ba90199cdb322d4c6babdcb690c7cb2/apache_tvm_ffi-0.1.12-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d0db8594244d4393ff6b4fa1c161eee5e4f79f2b86137547a2e5ad9a4cbf431", size = 2600672, upload-time = "2026-06-09T18:16:24.027Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/e4/d88df0b0157f16b5feaef513ce99a712a13baa5beb0b514fbf6702440646/apache_tvm_ffi-0.1.12-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:de7807573588d8a74aa5897a07252e882a6e9672ba2ad4afcfeafa136142881c", size = 2785316, upload-time = "2026-06-09T18:16:26.092Z" },
+    { url = "https://files.pythonhosted.org/packages/73/eb/fccd0646d28a2d0003625afaa36b9e95fb6b442037d2b49ffc0e4570f7a6/apache_tvm_ffi-0.1.12-cp310-cp310-win_amd64.whl", hash = "sha256:57d75555e6245e20e2eeaef70abaacb80822790ae4651cea747a0621158053a5", size = 2753670, upload-time = "2026-06-09T18:16:28.198Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/4c/720c64fe82121c1b617cc2a63c3a4f9a8a5c32ced22fd448a89644fd675c/apache_tvm_ffi-0.1.12-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e4e22dd0128bd8b671d19b074201e94d39c8a4580822fc153e593741ef7355ff", size = 2508770, upload-time = "2026-06-09T18:16:30.007Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9b/39dbc81718ea7e7adb6e6326675c065bf0b90f4ebba6dde878a77b792cda/apache_tvm_ffi-0.1.12-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9892c39a037bcf0e4ca0da1693f1193ccc2c0f02b899402e88011847980d98f6", size = 2687418, upload-time = "2026-06-09T18:16:32.005Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/9e/bc4fdd679105d0617ebf6e89036967d3560ab7e4422a22df741b493470b2/apache_tvm_ffi-0.1.12-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c418fea49b9146d692af40f0b655df68870a032041dd27c0f468d646eda5f8bc", size = 2821462, upload-time = "2026-06-09T18:16:34.202Z" },
+    { url = "https://files.pythonhosted.org/packages/31/5c/2a311cf5bb49575cec99de45887bc76aefa43a0cd3a3f29cb71e92c8100c/apache_tvm_ffi-0.1.12-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0fec41a0633af57bcae552d662cfd096c57db685b752d1898087ca484f060e9f", size = 2598686, upload-time = "2026-06-09T18:16:36.174Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e9/923843463730aa1add10c26b45110fb6a13a68dfdb48e1cd9e325b04e331/apache_tvm_ffi-0.1.12-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:011e372fb9b169c3bd57f63e03fa1383cee6f1ef47a4932c4ff552f29db281c3", size = 2783994, upload-time = "2026-06-09T18:16:38.13Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d9/de68905c24ea6bc1fbed2021b700b9ca27a2b601fb6db43de37132c21407/apache_tvm_ffi-0.1.12-cp311-cp311-win_amd64.whl", hash = "sha256:06bcc161c020dc83e9db33b63b01c21815eab2cca3ca876748664bacd319cf9c", size = 2755540, upload-time = "2026-06-09T18:16:40.028Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/ef/8f2ea57791e8df55c5a52e20d415c01032ef5fa3761574268201b7cc2c79/apache_tvm_ffi-0.1.12-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:218e55c807d49182710ef2ab0336313ba6becccb7e565f4941d23bded09646d4", size = 2463724, upload-time = "2026-06-09T18:16:41.904Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/c4/34aec1f10353eee555687f3196241457b8e8a06da2014a176f5b022e24bd/apache_tvm_ffi-0.1.12-cp312-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:557d8deb672f2ad7f445399e3fa0c727a6e11472e19c895ee244cbb8cfd99a66", size = 2616513, upload-time = "2026-06-09T18:16:44.115Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/2a/bff8d73841b49f196852edd8460241d3a363e6b0d64c3a9367542658394f/apache_tvm_ffi-0.1.12-cp312-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:817af52916ca9987e019ae9c811406835c7f26c590b2a7bcfa9db0e3809f4228", size = 2757612, upload-time = "2026-06-09T18:16:45.987Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/51d0c31c76bef0f21c11bce0465598d1ea5fdaca22e47a69c29deadeada7/apache_tvm_ffi-0.1.12-cp312-abi3-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a7b08f377ea2663dae10e3045f8d0215f0378ee975096174a8af6381eeb1504", size = 2533956, upload-time = "2026-06-09T18:16:47.891Z" },
+    { url = "https://files.pythonhosted.org/packages/52/f3/fba607d803cb081be2d66ea51865492b42872898bd271d9bcc3e1ced4ef3/apache_tvm_ffi-0.1.12-cp312-abi3-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc0acd7eeb0e451d5e3f686af3ba0b495fdbf97b5b54cf9a0f770cdafe0e691a", size = 2719638, upload-time = "2026-06-09T18:16:50.021Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d7/a25f51156358c631114e16cb09ca91188b3b79677369e111216d6fa7f83d/apache_tvm_ffi-0.1.12-cp312-abi3-win_amd64.whl", hash = "sha256:23eefd1094a41faae2bb7b9cc5816aa938101b624d48ebb724881f1a89b78e99", size = 2725953, upload-time = "2026-06-09T18:16:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/05/d4/5f1a59ebf85c4ea3243766318a50bcec2312bacce9dc9b132db514f7c897/apache_tvm_ffi-0.1.12-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3ee7ebbc4ec8e037364fc1388c081145f790cc97de642348efc39fcda749a8bb", size = 2526890, upload-time = "2026-06-09T18:16:54.547Z" },
+    { url = "https://files.pythonhosted.org/packages/04/4a/428b5bc74a762d62aa5efedc3a72f90e00bae53ab4fb7e5b52206dd9f541/apache_tvm_ffi-0.1.12-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:003027a31011a216295ec8e04ac78bb3d80b8dc47a93f6b602cf242a80676366", size = 2650779, upload-time = "2026-06-09T18:16:56.746Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/c1/550f60d376e7d11cbcfbc2968bd87936beeec91f4c26d16e6c63b60801ee/apache_tvm_ffi-0.1.12-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f69d28a95648c4e864a53f1bfe099b7547dfbc60d520180fc0eb0ec72245151f", size = 2789261, upload-time = "2026-06-09T18:16:59.021Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/6c/34e8bfb495ada6c1d37d5eb84fee17d5c8cfd630e6fa647c8327377bc17e/apache_tvm_ffi-0.1.12-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:02508fef806cfb1a5224aaa69fb121558d60fa56c2fa7d4166fb9f354945509b", size = 2570469, upload-time = "2026-06-09T18:17:01.376Z" },
+    { url = "https://files.pythonhosted.org/packages/33/a9/005a2537fb043aa2d5916bb9c30ee8b6cda258d9e2db343f7dca233407ca/apache_tvm_ffi-0.1.12-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:786b3073a79c025f85b2bf4aa4b6bc1f8a2b1aae186a613181acd6d9661bd3cb", size = 2750777, upload-time = "2026-06-09T18:17:03.333Z" },
+    { url = "https://files.pythonhosted.org/packages/10/d6/5e3199709bef26975ee5f993029999f05edbf5020df8a910f3ef0884acc7/apache_tvm_ffi-0.1.12-cp314-cp314t-win_amd64.whl", hash = "sha256:d015c7ad8e15ee7896ffacb5b30c81fd507375f1b5650078ba382f52a5dc8795", size = 2820788, upload-time = "2026-06-09T18:17:05.424Z" },
+]
+
+[[package]]
 name = "arro3-core"
 version = "0.6.5"
 source = { registry = "https://pypi.org/simple" }
@@ -3914,6 +3949,9 @@ msc = [
 s3 = [
     { name = "boto3" },
 ]
+tilelang = [
+    { name = "tilelang" },
+]
 vlm = [
     { name = "albumentations" },
     { name = "backoff" },
@@ -4025,6 +4063,7 @@ requires-dist = [
     { name = "sentencepiece", marker = "extra == 'extra'" },
     { name = "soundfile", marker = "extra == 'vlm'" },
     { name = "tiktoken" },
+    { name = "tilelang", marker = "extra == 'tilelang'", specifier = ">=0.1.11" },
     { name = "timm", marker = "extra == 'vlm'", specifier = "<=1.0.22" },
     { name = "torch", marker = "sys_platform != 'darwin' and sys_platform != 'linux'", specifier = ">=2.6.0", index = "https://download.pytorch.org/whl/cpu" },
     { name = "torch", marker = "sys_platform == 'darwin'", specifier = ">=2.6.0", index = "https://pypi.org/simple" },
@@ -4039,7 +4078,7 @@ requires-dist = [
     { name = "transformers", specifier = "==5.8.1" },
     { name = "wandb", specifier = ">=0.26.1" },
 ]
-provides-extras = ["diffusion", "diffusion-kernels", "cuda", "cuda-source", "extra", "fa", "fla", "delta-databricks", "moe", "vlm", "cli", "s3", "msc", "all"]
+provides-extras = ["diffusion", "diffusion-kernels", "cuda", "cuda-source", "tilelang", "extra", "fa", "fla", "delta-databricks", "moe", "vlm", "cli", "s3", "msc", "all"]
 
 [package.metadata.requires-dev]
 build = [
@@ -7378,6 +7417,32 @@ wheels = [
 ]
 
 [[package]]
+name = "tilelang"
+version = "0.1.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "apache-tvm-ffi" },
+    { name = "cloudpickle" },
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "psutil" },
+    { name = "setuptools", marker = "sys_platform == 'darwin'" },
+    { name = "torch", marker = "sys_platform == 'never'" },
+    { name = "torch-c-dlpack-ext", marker = "python_full_version < '3.14'" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+    { name = "z3-solver" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/2b/ea36e371296155b662dfc0ce987b6e1c6f4017714e13824050370a0fd4f1/tilelang-0.1.11.tar.gz", hash = "sha256:ac9d03e67caadeebd4d7f3ac5e2318011db8d3e23f7179f7dd3ba2a249354d47", size = 93229382, upload-time = "2026-06-08T08:37:26.87Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/ad/7f33bc7aea74d2e27ea3e3dcb6d8773c1d8026d1cfe2fd09db119c19493e/tilelang-0.1.11-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:1be1f0643322419e66618093c69d3e45408ac3fcc04564413372916b2a9a716c", size = 38305998, upload-time = "2026-06-08T08:37:12.571Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/0e/ed59fb66606b6e51349793d9db209d01a41487008bd6d4a984249d70eb4b/tilelang-0.1.11-cp38-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90d78f093d2bd46660633133982cd715cf9b7d0c379d463f136748efcfa55a9c", size = 50054335, upload-time = "2026-06-08T08:37:15.93Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/bd/6060f90ca4d063c22a8dbeaa5f14489a59706c0304dce5006e89907950ff/tilelang-0.1.11-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:c7b0dedc0a181486b7fa137d04eaf793271a7573ebd30e77838c18321a3206db", size = 45875401, upload-time = "2026-06-08T08:37:19.213Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b4/517c706798a159236a57d4aa1d4a448b2f8288808cd8fb8d7d2eb465a2af/tilelang-0.1.11-cp38-abi3-win_amd64.whl", hash = "sha256:d58ed14cdc6050b8454e5dbd53f6d0904d46f149f25d158621d8f874e775b5f8", size = 33740387, upload-time = "2026-06-08T08:37:22.929Z" },
+]
+
+[[package]]
 name = "timm"
 version = "1.0.22"
 source = { registry = "https://pypi.org/simple" }
@@ -7498,6 +7563,37 @@ dependencies = [
     { name = "setuptools", marker = "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux'" },
     { name = "sympy", marker = "sys_platform != 'darwin' and sys_platform != 'linux'" },
     { name = "typing-extensions", marker = "sys_platform != 'darwin' and sys_platform != 'linux'" },
+]
+
+[[package]]
+name = "torch-c-dlpack-ext"
+version = "0.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "torch", marker = "python_full_version < '3.14' and sys_platform == 'never'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/de/921b6491efce5c389a5ef9bbed3d2d6660005840dae488124173180859ab/torch_c_dlpack_ext-0.1.5.tar.gz", hash = "sha256:d06f0357d575d22a168cc77acb9020fc4bae30968ceb6718a055dcbe92bacabe", size = 12913, upload-time = "2026-01-12T11:25:08.484Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/49/67a66932ab2fcdda3c5a4dcf606e713d86883a4a9a99a3bb832815b52b8e/torch_c_dlpack_ext-0.1.5-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:e0f6c197d5293884898b9ebf13d07501de39cb94799b374ed43f91731087d557", size = 7056755, upload-time = "2026-01-12T11:24:31.817Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/28/d2d6bf90e01a1f4da3277c9a56d9ecac648b6d6adaa8e20c17f802deb7fb/torch_c_dlpack_ext-0.1.5-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba3d88f0f7d5e1d9c3d4a3179037fc8e261c3b77ac1fad23edc0d3a9214ef193", size = 432066, upload-time = "2026-01-12T11:24:33.619Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/e9/a1f9584a3af4ac6ae5ad5cf86927d8c3a9b6bb50d54e54d19313411216a0/torch_c_dlpack_ext-0.1.5-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c7468df84ec152d930fbc3acf460c44a60b3462b95af3d3a676d133629c7e176", size = 879488, upload-time = "2026-01-12T11:24:34.837Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/08/478cfcb5814e29f9b720111bdef315fc2fbc8b276e4b1183c8b9c9414a4f/torch_c_dlpack_ext-0.1.5-cp310-cp310-win_amd64.whl", hash = "sha256:78dd4904bd26170a2dd7c0eab56367756ee0a15672ce9b84146169e68f0c6ddc", size = 1461437, upload-time = "2026-01-12T11:24:36.385Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/c12a9bb3a5ddc0962c00467891bf1ffdda39a4d4780bf0fbbf54523ff34e/torch_c_dlpack_ext-0.1.5-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:56bd25a2af19280bf8a06aa62cff5510106f43235b9327d8561b3e9a659c4d84", size = 5076782, upload-time = "2026-01-12T11:24:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e1/64e1e579d107064785549e70758e38a42376ab7e73d86897ed4beab10e74/torch_c_dlpack_ext-0.1.5-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fba674110e1fab0b176bb5a28223e157db65c90767d4ba74abdbee9f537b0e9d", size = 440949, upload-time = "2026-01-12T11:24:39.716Z" },
+    { url = "https://files.pythonhosted.org/packages/64/5c/3e1382a620824f92920ab3fae132d8fb4e85898284c99e0c6a7764e452ce/torch_c_dlpack_ext-0.1.5-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3448c4f0d64104d0b2e58080a7efa72304a04960c18f338024b80b13cd3eca26", size = 897768, upload-time = "2026-01-12T11:24:41.209Z" },
+    { url = "https://files.pythonhosted.org/packages/54/4f/76ea1006b9038b496d01e916c91efd17cb782abde2491a261cf203f57e30/torch_c_dlpack_ext-0.1.5-cp311-cp311-win_amd64.whl", hash = "sha256:74676474e0afa9a4216c4755ea7cf05e8158be1d168f6bda669ba91097c263f2", size = 1479088, upload-time = "2026-01-12T11:24:42.436Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/67/10d236698525d7b7db4d74ec0a4b01f5b2db33968995fdd9ac6b4635e327/torch_c_dlpack_ext-0.1.5-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:c0f2bd51fcd99c0e5b50314e1985f2728c4941bfa821f065e6c30951d1f995ca", size = 5291237, upload-time = "2026-01-12T11:24:44.011Z" },
+    { url = "https://files.pythonhosted.org/packages/87/06/8d760997307a5c3be4384424667bf31aae0a42060838c532c7d846516175/torch_c_dlpack_ext-0.1.5-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3562ee411258676f9c38b8ad39306d1c8d027b6a86f6a87c920d2d009a9d1510", size = 443069, upload-time = "2026-01-12T11:24:45.451Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/79/a914539b4785f3e44f891aa012a886edb8bc10fe081c440981c57543ce21/torch_c_dlpack_ext-0.1.5-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e6f9da4bb9af70e27facc777458be62e10dbbbddda7672d16138db0553c5a524", size = 897846, upload-time = "2026-01-12T11:24:48.168Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/e6/7d7a97a3953208d6d6ce749180c34d1dab48464ded9a76cecabe9d021ce6/torch_c_dlpack_ext-0.1.5-cp312-cp312-win_amd64.whl", hash = "sha256:670fbbab70123cc228bed41693a3720757af57a0ad22669063c9db25321e8f55", size = 1482855, upload-time = "2026-01-12T11:24:49.581Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/c6/65346a201d921b616731311fc9941f15137672b444cebdad702cb52ccee0/torch_c_dlpack_ext-0.1.5-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:74acea2ed395cadda63342845b9e9ee7cd4537846223dacfb4431b4610109265", size = 1993243, upload-time = "2026-01-12T11:24:51.079Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/ec/faf10be09a5812b1c5ec9922b53fb5def5fc4080b81a653b9347bb169ebb/torch_c_dlpack_ext-0.1.5-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49f1e99d13c64e22dac0a34a1560e9e5a398a49a9fa81df83053e04fde6ec5bd", size = 443798, upload-time = "2026-01-12T11:24:52.754Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/68/f434b48700f3e04f33882f54d8d3910327b935f55e14ec49da7d607bf470/torch_c_dlpack_ext-0.1.5-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:debe62e5ef93e631065d6b9f6e60d3d39bae6b89fa1b25d9523f40b3efbf8aba", size = 755004, upload-time = "2026-01-12T11:24:54.004Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a8/cc64e563f05ea99bd79bdb43f71f0f46452d3acd734da4843ede5fc73a35/torch_c_dlpack_ext-0.1.5-cp313-cp313-win_amd64.whl", hash = "sha256:30e3eab616dbc81dfdb7492aca557be551a9163ba9b585f97394a42b336b113a", size = 999126, upload-time = "2026-01-12T11:24:55.44Z" },
+    { url = "https://files.pythonhosted.org/packages/96/5e/449324ca8e81573e650b6851fc31c1038f750d1de85d0b185d788e1c7a3a/torch_c_dlpack_ext-0.1.5-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:cac94a4905d391889e679a8da31e46dc325af5d55d13b7c70c0ce3d71d1ced6d", size = 1982154, upload-time = "2026-01-12T11:24:58.038Z" },
+    { url = "https://files.pythonhosted.org/packages/20/62/11c05b99f69aa5152bca0313e0dfa6d125a020cf890dc888ef009aa7891c/torch_c_dlpack_ext-0.1.5-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a58fdf45fb0bda7bc459632cec891570f31c11636d5851c825cf308ec8b73c2", size = 163825, upload-time = "2026-01-12T11:24:59.474Z" },
+    { url = "https://files.pythonhosted.org/packages/15/b5/be613cd8e71c9982bd07af530f86c5a7f30df7831d14cec5414857af7149/torch_c_dlpack_ext-0.1.5-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b985a324c68241cf83a9474b28015524b66775b12a91930dd4c0760aa628d01", size = 171740, upload-time = "2026-01-12T11:25:00.776Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/11/52e291f1659e2ec70a09f5ca4ad27e015eb4f0a1371ae68d23a9fbd1c704/torch_c_dlpack_ext-0.1.5-cp314-cp314-win_amd64.whl", hash = "sha256:d794e19fa3f330ab7a29987c07e031fc08e4953aec516d35701d0827863e356b", size = 277086, upload-time = "2026-01-12T11:25:01.901Z" },
 ]
 
 [[package]]
@@ -8356,6 +8452,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/86/0f0dccb6e59a9e7f122c5afd43568b1d31b8ab7dda5f1b01fb5c7025c9a9/yarl-1.22.0-cp314-cp314t-win_amd64.whl", hash = "sha256:9fb17ea16e972c63d25d4a97f016d235c78dd2344820eb35bc034bc32012ee27", size = 96292, upload-time = "2025-10-06T14:12:15.398Z" },
     { url = "https://files.pythonhosted.org/packages/48/b7/503c98092fb3b344a179579f55814b613c1fbb1c23b3ec14a7b008a66a6e/yarl-1.22.0-cp314-cp314t-win_arm64.whl", hash = "sha256:9f6d73c1436b934e3f01df1e1b21ff765cd1d28c77dfb9ace207f746d4610ee1", size = 85171, upload-time = "2025-10-06T14:12:16.935Z" },
     { url = "https://files.pythonhosted.org/packages/73/ae/b48f95715333080afb75a4504487cbe142cae1268afc482d06692d605ae6/yarl-1.22.0-py3-none-any.whl", hash = "sha256:1380560bdba02b6b6c90de54133c81c9f2a453dee9912fe58c1dcced1edb7cff", size = 46814, upload-time = "2025-10-06T14:12:53.872Z" },
+]
+
+[[package]]
+name = "z3-solver"
+version = "4.15.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/8e/0c8f17309549d2e5cde9a3ccefa6365437f1e7bafe71878eaf9478e47b18/z3_solver-4.15.4.0.tar.gz", hash = "sha256:928c29b58c4eb62106da51c1914f6a4a55d0441f8f48a81b9da07950434a8946", size = 5018600, upload-time = "2025-10-29T18:12:03.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/33/a3d5d2eaeb0f7b3174d57d405437eabb2075d4d50bd9ea0957696c435c7b/z3_solver-4.15.4.0-py3-none-macosx_13_0_arm64.whl", hash = "sha256:407e825cc9211f95ef46bdc8d151bf630e7ab2d62a21d24cd74c09cc5b73f3aa", size = 37052538, upload-time = "2025-10-29T18:11:46.233Z" },
+    { url = "https://files.pythonhosted.org/packages/47/84/fd7ffac1551cd9f8d44fe41358f738be670fc4c24dfd514fab503f2cf3e7/z3_solver-4.15.4.0-py3-none-macosx_13_0_x86_64.whl", hash = "sha256:00bd10c5a6a5f6112d3a9a810d0799227e52f76caa860dafa5e00966bb47eb13", size = 39807925, upload-time = "2025-10-29T18:11:49.81Z" },
+    { url = "https://files.pythonhosted.org/packages/21/c9/bb51a96af0091324c81b803f16c49f719f9f6ea0b0bb52200f5c97ec4892/z3_solver-4.15.4.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e103a6f203f505b8b8b8e5c931cc407c95b61556512d4921c1ddc0b3f41b08e", size = 29268352, upload-time = "2025-10-29T18:11:53.032Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/2e/0b49f7e4e53817cfb09a0f6585012b782dfe0b666e8abefcb4fac0570606/z3_solver-4.15.4.0-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:62c7e9cbdd711932301f29919ad9158de9b2f58b4d281dd259bbcd0a2f408ba1", size = 27226534, upload-time = "2025-10-29T18:11:55.59Z" },
+    { url = "https://files.pythonhosted.org/packages/26/91/33de49538444d4aafbe47415c450c2f9abab1733e1226f276b496672f46c/z3_solver-4.15.4.0-py3-none-win32.whl", hash = "sha256:be3bc916545c96ffbf89e00d07104ff14f78336e55db069177a1bfbcc01b269d", size = 13191672, upload-time = "2025-10-29T18:11:58.424Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d6/a0b135e4419df475177ae78fc93c422430b0fd8875649486f9a5989772e6/z3_solver-4.15.4.0-py3-none-win_amd64.whl", hash = "sha256:00e35b02632ed085ea8199fb230f6015e6fc40554a6680c097bd5f060e827431", size = 16259597, upload-time = "2025-10-29T18:12:01.14Z" },
 ]
 
 [[package]]

--- a/examples/llm_finetune/deepseek_v4/deepseek_v4_flash_cp_tulu3.yaml
+++ b/examples/llm_finetune/deepseek_v4/deepseek_v4_flash_cp_tulu3.yaml
@@ -150,3 +150,5 @@ ci:
   # multiply the mesh.
   recipe_owner: huiyingl
   nodes: 16
+  # Cold multi-node start + TileLang JIT runs past the 00:10:00 default.
+  time: "00:30:00"

--- a/examples/llm_finetune/deepseek_v4/deepseek_v4_flash_hellaswag.yaml
+++ b/examples/llm_finetune/deepseek_v4/deepseek_v4_flash_hellaswag.yaml
@@ -135,3 +135,5 @@ ci:
   # pp_size(4) * ep_size(32) = 128 GPUs => 16 nodes (8 H100/node).
   recipe_owner: hemildesai
   nodes: 16
+  # Cold multi-node start + TileLang JIT runs past the 00:10:00 default.
+  time: "00:30:00"

--- a/examples/llm_finetune/deepseek_v4/deepseek_v4_flash_packed_sequence_hellaswag.yaml
+++ b/examples/llm_finetune/deepseek_v4/deepseek_v4_flash_packed_sequence_hellaswag.yaml
@@ -128,3 +128,5 @@ ci:
   # pp_size(4) * ep_size(32) = 128 GPUs => 16 nodes (8 H100/node).
   recipe_owner: hemildesai
   nodes: 16
+  # Cold multi-node start + TileLang JIT runs past the 00:10:00 default.
+  time: "00:30:00"

--- a/examples/llm_finetune/deepseek_v4/deepseek_v4_pro_hellaswag_all_tilelang_pp8_ep64_20steps.yaml
+++ b/examples/llm_finetune/deepseek_v4/deepseek_v4_pro_hellaswag_all_tilelang_pp8_ep64_20steps.yaml
@@ -134,3 +134,5 @@ ci:
   # pp_size(8) * ep_size(64) = 512 GPUs => 64 nodes (8 H100/node).
   recipe_owner: hemildesai
   nodes: 64
+  # Cold multi-node start + TileLang JIT runs past the 00:10:00 default.
+  time: "00:30:00"

--- a/examples/llm_finetune/deepseek_v4/deepseek_v4_pro_packed_sequence_hellaswag_all_tilelang_pp8_ep64_1024_20steps.yaml
+++ b/examples/llm_finetune/deepseek_v4/deepseek_v4_pro_packed_sequence_hellaswag_all_tilelang_pp8_ep64_1024_20steps.yaml
@@ -130,3 +130,5 @@ ci:
   # pp_size(8) * ep_size(64) = 512 GPUs => 64 nodes (8 H100/node).
   recipe_owner: hemildesai
   nodes: 64
+  # Cold multi-node start + TileLang JIT runs past the 00:10:00 default.
+  time: "00:30:00"

--- a/nemo_automodel/components/models/deepseek_v4/layers.py
+++ b/nemo_automodel/components/models/deepseek_v4/layers.py
@@ -546,7 +546,10 @@ def _pool_windows_packed(
     pos_per_batch: list[torch.Tensor] = []
     doc_per_batch: list[torch.Tensor] = []
     local_per_batch: list[torch.Tensor] = []
-    max_pooled = 0
+    # Keep the compressed sequence length static for TileLang. Values from
+    # incomplete per-document tails are omitted, then represented by masked
+    # zero slots at the end of the packed pool.
+    max_pooled = kv.shape[1] // ratio
     for batch_idx in range(batch):
         offset = 0
         pooled_docs: list[torch.Tensor] = []
@@ -590,7 +593,8 @@ def _pool_windows_packed(
         pos_per_batch.append(pos_b)
         doc_per_batch.append(doc_b)
         local_per_batch.append(local_b)
-        max_pooled = max(max_pooled, pooled_b.shape[0])
+        if pooled_b.shape[0] > max_pooled:
+            raise ValueError(f"Packed pooled windows ({pooled_b.shape[0]}) exceed static capacity ({max_pooled})")
 
     pooled = kv.new_zeros((batch, max_pooled, head_dim))
     pool_positions = torch.zeros((batch, max_pooled), device=kv.device, dtype=torch.long)

--- a/nemo_automodel/components/models/deepseek_v4/layers.py
+++ b/nemo_automodel/components/models/deepseek_v4/layers.py
@@ -451,6 +451,161 @@ def _pool_windows(
     return (kv_w * gate_w.softmax(dim=2)).sum(dim=2)
 
 
+def _normalize_packed_seq_lens(
+    packed_seq_lens: torch.Tensor,
+    *,
+    batch: int,
+    device: torch.device,
+) -> torch.Tensor:
+    if packed_seq_lens.dim() == 1:
+        packed_seq_lens = packed_seq_lens.unsqueeze(0)
+    packed_seq_lens = packed_seq_lens.to(device=device, dtype=torch.long)
+    if packed_seq_lens.shape[0] == 1 and batch > 1:
+        packed_seq_lens = packed_seq_lens.expand(batch, -1)
+    if packed_seq_lens.shape[0] != batch:
+        raise ValueError(
+            f"Packed sequence lengths batch ({packed_seq_lens.shape[0]}) must match hidden batch ({batch})"
+        )
+    return torch.where(
+        packed_seq_lens > 0,
+        packed_seq_lens,
+        torch.zeros((), device=device, dtype=torch.long),
+    )
+
+
+def _packed_doc_bounds(
+    packed_seq_lens: torch.Tensor,
+    *,
+    seq_len: int,
+    batch: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    seq_lens = _normalize_packed_seq_lens(packed_seq_lens, batch=batch, device=device)
+    positions = torch.arange(seq_len, device=device, dtype=torch.long).expand(batch, -1)
+    ends = seq_lens.cumsum(dim=-1)
+    starts = ends - seq_lens
+    total = ends[:, -1:]
+    doc_ids = torch.searchsorted(ends.contiguous(), positions.contiguous(), right=True)
+    valid = positions < total
+    safe_doc_ids = doc_ids.clamp(max=max(seq_lens.shape[1] - 1, 0))
+    doc_starts = torch.gather(starts, dim=-1, index=safe_doc_ids)
+    doc_ends = torch.gather(ends, dim=-1, index=safe_doc_ids)
+    local_pos = positions - doc_starts
+    doc_ids = torch.where(valid, doc_ids, torch.full_like(doc_ids, -1))
+    doc_starts = torch.where(valid, doc_starts, torch.zeros_like(doc_starts))
+    doc_ends = torch.where(valid, doc_ends, torch.zeros_like(doc_ends))
+    local_pos = torch.where(valid, local_pos, torch.zeros_like(local_pos))
+    return doc_ids, doc_starts, doc_ends, local_pos
+
+
+def _packed_compressed_bounds(
+    packed_seq_lens: torch.Tensor,
+    *,
+    seq_len: int,
+    batch: int,
+    ratio: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    seq_lens = _normalize_packed_seq_lens(packed_seq_lens, batch=batch, device=device)
+    doc_ids, _, _, local_pos = _packed_doc_bounds(seq_lens, seq_len=seq_len, batch=batch, device=device)
+    doc_windows = seq_lens // ratio
+    comp_ends_by_doc = doc_windows.cumsum(dim=-1)
+    comp_starts_by_doc = comp_ends_by_doc - doc_windows
+    safe_doc_ids = doc_ids.clamp(min=0, max=max(seq_lens.shape[1] - 1, 0))
+    comp_starts = torch.gather(comp_starts_by_doc, dim=-1, index=safe_doc_ids)
+    doc_window_counts = torch.gather(doc_windows, dim=-1, index=safe_doc_ids)
+    comp_ends = comp_starts + ((local_pos + 1) // ratio).clamp(max=doc_window_counts)
+    invalid = doc_ids < 0
+    comp_starts = torch.where(invalid, torch.zeros_like(comp_starts), comp_starts)
+    comp_ends = torch.where(invalid, torch.zeros_like(comp_ends), comp_ends)
+    return comp_starts, comp_ends, doc_ids, local_pos
+
+
+def _pool_windows_packed(
+    kv: torch.Tensor,
+    gate: torch.Tensor,
+    ape: torch.Tensor,
+    ratio: int,
+    head_dim: int,
+    packed_seq_lens: torch.Tensor,
+    *,
+    overlap: bool = False,
+    position_ids: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Pool complete windows independently inside each packed document."""
+    batch, _, _ = kv.shape
+    seq_lens = _normalize_packed_seq_lens(packed_seq_lens, batch=batch, device=kv.device)
+    if position_ids is not None:
+        if position_ids.dim() == 1:
+            position_ids = position_ids.unsqueeze(0)
+        position_ids = position_ids.to(device=kv.device, dtype=torch.long)
+        if position_ids.shape[0] == 1 and batch > 1:
+            position_ids = position_ids.expand(batch, -1)
+
+    pooled_per_batch: list[torch.Tensor] = []
+    pos_per_batch: list[torch.Tensor] = []
+    doc_per_batch: list[torch.Tensor] = []
+    local_per_batch: list[torch.Tensor] = []
+    max_pooled = 0
+    for batch_idx in range(batch):
+        offset = 0
+        pooled_docs: list[torch.Tensor] = []
+        pos_docs: list[torch.Tensor] = []
+        doc_docs: list[torch.Tensor] = []
+        local_docs: list[torch.Tensor] = []
+        for doc_idx, length_t in enumerate(seq_lens[batch_idx]):
+            length = int(length_t.item())
+            usable = (length // ratio) * ratio
+            if usable > 0:
+                doc_pooled = _pool_windows(
+                    kv[batch_idx : batch_idx + 1, offset : offset + usable],
+                    gate[batch_idx : batch_idx + 1, offset : offset + usable],
+                    ape,
+                    ratio,
+                    head_dim,
+                    overlap=overlap,
+                ).squeeze(0)
+                pooled_docs.append(doc_pooled)
+                n_doc_pooled = doc_pooled.shape[0]
+                if position_ids is not None:
+                    pool_positions = position_ids[batch_idx, offset : offset + usable : ratio][:n_doc_pooled]
+                else:
+                    pool_positions = torch.arange(0, usable, ratio, device=kv.device, dtype=torch.long)
+                pos_docs.append(pool_positions)
+                doc_docs.append(torch.full((n_doc_pooled,), doc_idx, device=kv.device, dtype=torch.long))
+                local_docs.append(torch.arange(n_doc_pooled, device=kv.device, dtype=torch.long))
+            offset += length
+
+        if pooled_docs:
+            pooled_b = torch.cat(pooled_docs, dim=0)
+            pos_b = torch.cat(pos_docs, dim=0)
+            doc_b = torch.cat(doc_docs, dim=0)
+            local_b = torch.cat(local_docs, dim=0)
+        else:
+            pooled_b = kv.new_zeros((0, head_dim))
+            pos_b = torch.empty((0,), device=kv.device, dtype=torch.long)
+            doc_b = torch.empty((0,), device=kv.device, dtype=torch.long)
+            local_b = torch.empty((0,), device=kv.device, dtype=torch.long)
+        pooled_per_batch.append(pooled_b)
+        pos_per_batch.append(pos_b)
+        doc_per_batch.append(doc_b)
+        local_per_batch.append(local_b)
+        max_pooled = max(max_pooled, pooled_b.shape[0])
+
+    pooled = kv.new_zeros((batch, max_pooled, head_dim))
+    pool_positions = torch.zeros((batch, max_pooled), device=kv.device, dtype=torch.long)
+    pool_doc_ids = torch.full((batch, max_pooled), -1, device=kv.device, dtype=torch.long)
+    pool_local_idxs = torch.full((batch, max_pooled), -1, device=kv.device, dtype=torch.long)
+    for batch_idx, pooled_b in enumerate(pooled_per_batch):
+        n_pooled = pooled_b.shape[0]
+        if n_pooled:
+            pooled[batch_idx, :n_pooled] = pooled_b
+            pool_positions[batch_idx, :n_pooled] = pos_per_batch[batch_idx]
+            pool_doc_ids[batch_idx, :n_pooled] = doc_per_batch[batch_idx]
+            pool_local_idxs[batch_idx, :n_pooled] = local_per_batch[batch_idx]
+    return pooled, pool_positions, pool_doc_ids, pool_local_idxs
+
+
 def _rope_pool_positions(
     pool_length: int, pool_base: int, ratio: int, device: torch.device, batch: int
 ) -> torch.Tensor:
@@ -655,6 +810,7 @@ class DeepseekV4Indexer(nn.Module):
         start_pos: int,
         position_ids: torch.Tensor | None = None,
         cp_group=None,
+        packed_seq_lens: torch.Tensor | None = None,
     ) -> torch.LongTensor:
         input_dtype = hidden_states.dtype
         batch, seq_len, _ = hidden_states.shape
@@ -662,29 +818,50 @@ class DeepseekV4Indexer(nn.Module):
         hidden_states_fp32 = hidden_states.float()
         kv = self.wkv(hidden_states_fp32)
         gate = self.wgate(hidden_states_fp32)
-        ready_kv, ready_gate, pool_base = cache.accumulate_windows(
-            kv, gate, layer_idx, "indexer_state", self.compress_ratio, start_pos
-        )
-        new_pooled = self.kv_norm(
-            _pool_windows(
-                ready_kv,
-                ready_gate,
+        if packed_seq_lens is not None:
+            if cp_active:
+                raise NotImplementedError("DeepSeek V4 packed THD indexer does not support context parallelism.")
+            pooled_raw, pool_positions, _, _ = _pool_windows_packed(
+                kv,
+                gate,
                 self.ape_param(hidden_states_fp32),
                 self.compress_ratio,
                 self.head_dim,
+                packed_seq_lens,
                 overlap=self.overlap,
-                cp_group=cp_group,
-            ).to(input_dtype)
-        )
-        if new_pooled.shape[1] > 0:
-            positions = _rope_pool_positions(
-                new_pooled.shape[1], pool_base, self.compress_ratio, new_pooled.device, new_pooled.shape[0]
+                position_ids=position_ids,
             )
-            cos, sin = rotary(new_pooled, positions)
-            new_pooled = _apply_partial_rope(new_pooled.unsqueeze(1), cos, sin, self.rope_head_dim).squeeze(1)
-        pooled_kv = cache.update_pool(new_pooled, layer_idx, "indexer_state")
-        if cp_active:
-            pooled_kv = dsv4_cp_all_gather(pooled_kv, dim=1, cp_group=cp_group)
+            new_pooled = self.kv_norm(pooled_raw.to(input_dtype))
+            if new_pooled.shape[1] > 0:
+                cos, sin = rotary(new_pooled, pool_positions)
+                new_pooled = _apply_partial_rope(new_pooled.unsqueeze(1), cos, sin, self.rope_head_dim).squeeze(1)
+            pooled_kv = new_pooled
+        else:
+            ready_kv, ready_gate, pool_base = cache.accumulate_windows(
+                kv, gate, layer_idx, "indexer_state", self.compress_ratio, start_pos
+            )
+            new_pooled = self.kv_norm(
+                _pool_windows(
+                    ready_kv,
+                    ready_gate,
+                    self.ape_param(hidden_states_fp32),
+                    self.compress_ratio,
+                    self.head_dim,
+                    overlap=self.overlap,
+                    cp_group=cp_group,
+                ).to(input_dtype)
+            )
+            if new_pooled.shape[1] > 0:
+                positions = _rope_pool_positions(
+                    new_pooled.shape[1], pool_base, self.compress_ratio, new_pooled.device, new_pooled.shape[0]
+                )
+                cos, sin = rotary(new_pooled, positions)
+                new_pooled = _apply_partial_rope(new_pooled.unsqueeze(1), cos, sin, self.rope_head_dim).squeeze(1)
+            pooled_kv = cache.update_pool(new_pooled, layer_idx, "indexer_state")
+            if cp_active:
+                pooled_kv = dsv4_cp_all_gather(pooled_kv, dim=1, cp_group=cp_group)
+        if pooled_kv.shape[1] == 0:
+            return torch.empty((batch, seq_len, 0), device=hidden_states.device, dtype=torch.long)
 
         cos, sin = position_embeddings
         q = self.wq_b(q_residual).view(batch, seq_len, self.n_heads, self.head_dim).transpose(1, 2)
@@ -702,13 +879,25 @@ class DeepseekV4Indexer(nn.Module):
             query_start=query_start,
             query_total_len=query_total_len,
         )
-        q_positions = _query_positions(
-            position_ids, batch=batch, seq_len=seq_len, device=hidden_states.device, cp_group=cp_group
-        )
-        valid_end = ((q_positions + 1) // self.compress_ratio).unsqueeze(-1)
         pooled_pos = torch.arange(pooled_kv.shape[1], device=hidden_states.device).view(1, 1, -1)
+        if packed_seq_lens is not None:
+            valid_start, valid_end, _, _ = _packed_compressed_bounds(
+                packed_seq_lens,
+                seq_len=seq_len,
+                batch=batch,
+                ratio=self.compress_ratio,
+                device=hidden_states.device,
+            )
+            valid_start = valid_start.unsqueeze(-1)
+            valid_end = valid_end.unsqueeze(-1)
+            valid = (pooled_pos >= valid_start) & (pooled_pos < valid_end)
+        else:
+            q_positions = _query_positions(
+                position_ids, batch=batch, seq_len=seq_len, device=hidden_states.device, cp_group=cp_group
+            )
+            valid = pooled_pos < ((q_positions + 1) // self.compress_ratio).unsqueeze(-1)
         index_scores = torch.where(
-            pooled_pos < valid_end,
+            valid,
             index_scores,
             torch.full((), float("-inf"), dtype=index_scores.dtype, device=index_scores.device),
         )
@@ -788,57 +977,79 @@ class DeepseekV4Compressor(nn.Module):
         enable_hca_fsdp_graph_alignment: bool = False,
         position_ids: torch.Tensor | None = None,
         cp_group=None,
-    ) -> torch.Tensor:
+        packed_seq_lens: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.LongTensor | None]:
         input_dtype = hidden_states.dtype
         batch, seq_len, _ = hidden_states.shape
         cp_active = dsv4_cp_enabled(cp_group)
         hidden_states_fp32 = hidden_states.float()
         kv = self.wkv(hidden_states_fp32)
         gate = self.wgate(hidden_states_fp32)
-        ready_kv, ready_gate, pool_base = cache.accumulate_windows(
-            kv, gate, layer_idx, "compressor_state", self.compress_ratio, start_pos
-        )
-        local_has_complete_hca_window = ready_kv.shape[1] > 0
-        fsdp_group_has_complete_hca_window = (
-            self._compute_fsdp_group_has_complete_hca_window(local_has_complete_hca_window, kv.device)
-            if enable_hca_fsdp_graph_alignment
-            else local_has_complete_hca_window
-        )
-        needs_masked_synthetic_hca_window = (
-            enable_hca_fsdp_graph_alignment
-            and self.indexer is None
-            and fsdp_group_has_complete_hca_window
-            and not local_has_complete_hca_window
-            and 0 < kv.shape[1] < self.compress_ratio
-        )
-        if needs_masked_synthetic_hca_window:
-            # A mixed short/long HCA parameter sync group needs every rank to
-            # create the same compressor autograd edges. All-short groups keep
-            # the original no-HCA path so optimizer semantics stay at
-            # grad=None. Zero-length local HCA inputs are outside this narrow
-            # training fix.
-            pad_len = self.compress_ratio - kv.shape[1]
-            pad_shape = (batch, pad_len, kv.shape[-1])
-            ready_kv = torch.cat([kv, kv.new_zeros(pad_shape)], dim=1)
-            ready_gate = torch.cat([gate, gate.new_zeros(pad_shape)], dim=1)
-            pool_base = max(0, start_pos)
-        new_pooled = self.kv_norm(
-            _pool_windows(
-                ready_kv,
-                ready_gate,
+        if packed_seq_lens is not None:
+            if cp_active:
+                raise NotImplementedError("DeepSeek V4 packed THD compressor does not support context parallelism.")
+            pooled_raw, pool_positions, _, _ = _pool_windows_packed(
+                kv,
+                gate,
                 self.ape_param(hidden_states_fp32),
                 self.compress_ratio,
                 self.head_dim,
+                packed_seq_lens,
                 overlap=self.overlap,
-                cp_group=cp_group,
-            ).to(input_dtype)
-        )
-        positions = _rope_pool_positions(new_pooled.shape[1], pool_base, self.compress_ratio, new_pooled.device, batch)
-        cos, sin = rotary(new_pooled, positions)
-        new_pooled = _apply_partial_rope(new_pooled.unsqueeze(1), cos, sin, self.rope_head_dim).squeeze(1)
-        pooled = cache.update_pool(new_pooled, layer_idx, "compressor_state").unsqueeze(1)
-        if cp_active:
-            pooled = dsv4_cp_all_gather(pooled, dim=2, cp_group=cp_group)
+                position_ids=position_ids,
+            )
+            new_pooled = self.kv_norm(pooled_raw.to(input_dtype))
+            if new_pooled.shape[1] > 0:
+                cos, sin = rotary(new_pooled, pool_positions)
+                new_pooled = _apply_partial_rope(new_pooled.unsqueeze(1), cos, sin, self.rope_head_dim).squeeze(1)
+            pooled = new_pooled.unsqueeze(1)
+        else:
+            ready_kv, ready_gate, pool_base = cache.accumulate_windows(
+                kv, gate, layer_idx, "compressor_state", self.compress_ratio, start_pos
+            )
+            local_has_complete_hca_window = ready_kv.shape[1] > 0
+            fsdp_group_has_complete_hca_window = (
+                self._compute_fsdp_group_has_complete_hca_window(local_has_complete_hca_window, kv.device)
+                if enable_hca_fsdp_graph_alignment
+                else local_has_complete_hca_window
+            )
+            needs_masked_synthetic_hca_window = (
+                enable_hca_fsdp_graph_alignment
+                and self.indexer is None
+                and fsdp_group_has_complete_hca_window
+                and not local_has_complete_hca_window
+                and 0 < kv.shape[1] < self.compress_ratio
+            )
+            if needs_masked_synthetic_hca_window:
+                # A mixed short/long HCA parameter sync group needs every rank to
+                # create the same compressor autograd edges. All-short groups keep
+                # the original no-HCA path so optimizer semantics stay at
+                # grad=None. Zero-length local HCA inputs are outside this narrow
+                # training fix.
+                pad_len = self.compress_ratio - kv.shape[1]
+                pad_shape = (batch, pad_len, kv.shape[-1])
+                ready_kv = torch.cat([kv, kv.new_zeros(pad_shape)], dim=1)
+                ready_gate = torch.cat([gate, gate.new_zeros(pad_shape)], dim=1)
+                pool_base = max(0, start_pos)
+            new_pooled = self.kv_norm(
+                _pool_windows(
+                    ready_kv,
+                    ready_gate,
+                    self.ape_param(hidden_states_fp32),
+                    self.compress_ratio,
+                    self.head_dim,
+                    overlap=self.overlap,
+                    cp_group=cp_group,
+                ).to(input_dtype)
+            )
+            positions = _rope_pool_positions(
+                new_pooled.shape[1], pool_base, self.compress_ratio, new_pooled.device, batch
+            )
+            cos, sin = rotary(new_pooled, positions)
+            new_pooled = _apply_partial_rope(new_pooled.unsqueeze(1), cos, sin, self.rope_head_dim).squeeze(1)
+            pooled = cache.update_pool(new_pooled, layer_idx, "compressor_state").unsqueeze(1)
+            if cp_active:
+                pooled = dsv4_cp_all_gather(pooled, dim=2, cp_group=cp_group)
 
         # Indexer narrows the attended compressed positions per query.  The
         # caller (DSV4Attention) is responsible for turning ``indexer_topk``
@@ -867,12 +1078,25 @@ class DeepseekV4Compressor(nn.Module):
                 start_pos,
                 position_ids=position_ids,
                 cp_group=cp_group,
+                packed_seq_lens=packed_seq_lens,
             )
-            q_positions = _query_positions(
-                position_ids, batch=batch, seq_len=seq_len, device=raw_topk.device, cp_group=cp_group
-            )
-            threshold = ((q_positions + 1) // self.compress_ratio).unsqueeze(-1)
-            causal_invalid = raw_topk >= threshold
+            if packed_seq_lens is not None:
+                valid_start, valid_end, _, _ = _packed_compressed_bounds(
+                    packed_seq_lens,
+                    seq_len=seq_len,
+                    batch=batch,
+                    ratio=self.compress_ratio,
+                    device=raw_topk.device,
+                )
+                valid_start = valid_start.unsqueeze(-1)
+                valid_end = valid_end.unsqueeze(-1)
+                causal_invalid = (raw_topk < valid_start) | (raw_topk >= valid_end)
+            else:
+                q_positions = _query_positions(
+                    position_ids, batch=batch, seq_len=seq_len, device=raw_topk.device, cp_group=cp_group
+                )
+                threshold = ((q_positions + 1) // self.compress_ratio).unsqueeze(-1)
+                causal_invalid = raw_topk >= threshold
             indexer_topk = torch.where(causal_invalid, torch.full_like(raw_topk, -1), raw_topk)
         return pooled, indexer_topk
 
@@ -1092,6 +1316,13 @@ class DeepseekV4Attention(nn.Module):
             device=hidden_states.device,
             cp_group=cp_group,
         )
+        packed_seq_lens = kwargs.get("_dsv4_packed_seq_lens")
+        if packed_seq_lens is not None:
+            flat_query_positions = (
+                torch.arange(seq_len, device=hidden_states.device, dtype=torch.long).unsqueeze(0).expand(batch, -1)
+            )
+        else:
+            flat_query_positions = query_positions
         # IMPORTANT: for compress_ratio>0 layers the released DSV4-Flash uses
         # the compress-rope (theta=160000 + YaRN) for the MAIN attention Q/KV
         # too, NOT just for the compressor sub-module.  Reference at
@@ -1145,6 +1376,7 @@ class DeepseekV4Attention(nn.Module):
                 ),
                 position_ids=position_ids,
                 cp_group=cp_group,
+                packed_seq_lens=packed_seq_lens,
             )
             n_pooled = pooled.shape[2]
             full_kv = torch.cat([full_kv, pooled], dim=2)
@@ -1169,10 +1401,38 @@ class DeepseekV4Attention(nn.Module):
                     # with valid index 0, and scatter_'s duplicate-index order
                     # is unspecified, so use count-then-threshold instead.
                     compressed_mask = _build_indexer_topk_compressed_mask(attention_mask, indexer_topk, n_pooled)
+                    if packed_seq_lens is not None:
+                        valid_start, valid_end, _, _ = _packed_compressed_bounds(
+                            packed_seq_lens,
+                            seq_len=seq_len,
+                            batch=batch,
+                            ratio=self.compress_ratio,
+                            device=full_kv.device,
+                        )
+                        p_pos = torch.arange(n_pooled, device=full_kv.device).view(1, 1, n_pooled)
+                        allowed = (p_pos >= valid_start.unsqueeze(-1)) & (p_pos < valid_end.unsqueeze(-1))
+                        range_mask = torch.where(
+                            allowed,
+                            torch.zeros((), dtype=attention_mask.dtype, device=full_kv.device),
+                            torch.full((), min_val, dtype=attention_mask.dtype, device=full_kv.device),
+                        )
+                        compressed_mask = torch.minimum(compressed_mask, range_mask)
                 else:
                     p_pos = torch.arange(n_pooled, device=full_kv.device)
-                    threshold = (query_positions + 1) // self.compress_ratio
-                    allowed = p_pos.view(1, 1, n_pooled) < threshold.unsqueeze(-1)  # [B, S, P]
+                    if packed_seq_lens is not None:
+                        valid_start, valid_end, _, _ = _packed_compressed_bounds(
+                            packed_seq_lens,
+                            seq_len=seq_len,
+                            batch=batch,
+                            ratio=self.compress_ratio,
+                            device=full_kv.device,
+                        )
+                        allowed = (p_pos.view(1, 1, n_pooled) >= valid_start.unsqueeze(-1)) & (
+                            p_pos.view(1, 1, n_pooled) < valid_end.unsqueeze(-1)
+                        )
+                    else:
+                        threshold = (query_positions + 1) // self.compress_ratio
+                        allowed = p_pos.view(1, 1, n_pooled) < threshold.unsqueeze(-1)  # [B, S, P]
                     compressed_mask = torch.where(
                         allowed,
                         torch.zeros((), dtype=attention_mask.dtype, device=full_kv.device),
@@ -1199,7 +1459,7 @@ class DeepseekV4Attention(nn.Module):
                 compressed_topk=indexer_topk,
                 n_pooled=n_pooled,
                 vanilla_key_len=vanilla_key_len,
-                q_positions=query_positions,
+                q_positions=flat_query_positions,
             )
             attn_output = dsv4_sparse_attention(
                 q.transpose(1, 2).contiguous(),

--- a/nemo_automodel/components/models/deepseek_v4/model.py
+++ b/nemo_automodel/components/models/deepseek_v4/model.py
@@ -111,6 +111,35 @@ class DeepseekV4CausalLMOutput(CausalLMOutputWithPast):
     mtp_loss_scaling_factor: Optional[float] = None
 
 
+def _packed_seq_lens_from_attn_kwargs(attn_kwargs: dict[str, Any], *, device: torch.device) -> torch.Tensor:
+    """Return padded per-document lengths for DSV4 packed THD attention."""
+    seq_lens = attn_kwargs.get("seq_lens_padded")
+    if seq_lens is None:
+        seq_lens = attn_kwargs.get("seq_lens")
+    if seq_lens is not None:
+        seq_lens = seq_lens.to(device=device, dtype=torch.long)
+        return torch.where(seq_lens > 0, seq_lens, torch.zeros((), device=device, dtype=torch.long))
+
+    cu_seqlens = attn_kwargs.get("cu_seqlens_padded")
+    if cu_seqlens is None:
+        cu_seqlens = attn_kwargs.get("cu_seqlens")
+    if cu_seqlens is None:
+        raise ValueError("DeepSeek V4 THD packed attention requires cu_seqlens or seq_lens boundaries.")
+
+    cu_seqlens = cu_seqlens.to(device=device, dtype=torch.long)
+    if cu_seqlens.dim() == 1:
+        valid = cu_seqlens[cu_seqlens >= 0]
+        if valid.numel() < 2:
+            raise ValueError("DeepSeek V4 THD packed attention received fewer than two cu_seqlens boundaries.")
+        return (valid[1:] - valid[:-1]).unsqueeze(0)
+    if cu_seqlens.dim() == 2:
+        starts = cu_seqlens[:, :-1]
+        ends = cu_seqlens[:, 1:]
+        valid = (starts >= 0) & (ends >= 0)
+        return torch.where(valid, ends - starts, torch.zeros_like(starts))
+    raise ValueError(f"Unsupported cu_seqlens rank for DeepSeek V4 THD attention: {cu_seqlens.dim()}")
+
+
 class DeepseekV4Block(nn.Module):
     """Single transformer block for DeepSeek V4.
 
@@ -478,12 +507,12 @@ class DeepseekV4Model(nn.Module):
         sliding_window = int(getattr(self.config, "sliding_window", 0) or 0) or None
         packed_seq_lens = None
         if attn_kwargs.get("qkv_format") == "thd":
-            # THD packing uses seq_lens_padded to keep pack/CP padding inside a
-            # valid block. Using only seq_lens leaves trailing pad query rows
-            # with no legal keys, which the sparse TileLang path cannot execute.
-            packed_seq_lens = attn_kwargs.get("seq_lens_padded")
-            if packed_seq_lens is None:
-                packed_seq_lens = attn_kwargs.get("seq_lens")
+            # THD packing uses padded sequence lengths to keep pack/CP padding
+            # inside a valid block. The THD preprocessing path emits cumulative
+            # ``cu_seqlens*`` boundaries, so derive lengths from those instead
+            # of silently falling back to one global causal sequence.
+            packed_seq_lens = _packed_seq_lens_from_attn_kwargs(attn_kwargs, device=shape_ref.device)
+            attn_kwargs["_dsv4_packed_seq_lens"] = packed_seq_lens
         cp_group = attn_kwargs.get("_dsv4_cp_group")
         cp_active = dsv4_cp_enabled(cp_group)
         if cp_active and packed_seq_lens is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,14 @@ cuda = [
 cuda_source = [
     "bitsandbytes",
 ]
+# DeepSeek-V4 TileLang kernels (enable backend.attn="tilelang": sparse MLA
+# attention, lightning indexer, and the MHC sinkhorn path). Installed into the
+# container by docker/Dockerfile. The external DeepSeek ``tile_kernels`` package
+# (MHC sinkhorn) is git-pinned and installed there too; it is not resolvable from
+# PyPI, so like ``deep_ep`` it is not declared as a resolvable dependency here.
+tilelang = [
+    "tilelang>=0.1.11",
+]
 extra = ["perceptron", "sentencepiece"]
 fa = ["flash-attn<=2.8.3"]
 fla = [

--- a/tests/unit_tests/models/deepseek_v4/test_dsv4_layers.py
+++ b/tests/unit_tests/models/deepseek_v4/test_dsv4_layers.py
@@ -55,6 +55,8 @@ from nemo_automodel.components.models.deepseek_v4.optimized_kernels import (
     sinkhorn_normalize_torch,
 )
 
+_REQUIRES_CUDA = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+
 
 def _miles_q_positions(seqlen_local: int, cp_rank: int, device: torch.device) -> torch.Tensor:
     start = cp_rank * seqlen_local
@@ -308,6 +310,134 @@ class TestDeepseekV4AttentionMask:
 
         assert (real_topk[0, 5:] >= 0).sum(dim=-1).eq(0).all()
         assert (padded_topk[0, 5:] >= 0).sum(dim=-1).gt(0).all()
+
+    @_REQUIRES_CUDA
+    def test_packed_pool_windows_overlap_is_doc_local_cuda(self):
+        device = torch.device("cuda")
+        ratio, head_dim = 4, 8
+        kv = torch.arange(1 * 16 * 2 * head_dim, device=device, dtype=torch.float32).view(1, 16, 2 * head_dim)
+        gate = torch.zeros_like(kv)
+        ape = torch.zeros(ratio, 2 * head_dim, device=device)
+        seq_lens = torch.tensor([[8, 8]], device=device)
+        position_ids = torch.tensor([[0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7]], device=device)
+
+        actual, pool_positions, pool_doc_ids, pool_local_idxs = dsv4_layers._pool_windows_packed(
+            kv,
+            gate,
+            ape,
+            ratio,
+            head_dim,
+            seq_lens,
+            overlap=True,
+            position_ids=position_ids,
+        )
+        expected = torch.cat(
+            [
+                dsv4_layers._pool_windows(kv[:, :8], gate[:, :8], ape, ratio, head_dim, overlap=True),
+                dsv4_layers._pool_windows(kv[:, 8:], gate[:, 8:], ape, ratio, head_dim, overlap=True),
+            ],
+            dim=1,
+        )
+        global_pooled = dsv4_layers._pool_windows(kv, gate, ape, ratio, head_dim, overlap=True)
+
+        torch.testing.assert_close(actual, expected)
+        assert not torch.allclose(actual[:, 2], global_pooled[:, 2])
+        torch.testing.assert_close(pool_positions.cpu(), torch.tensor([[0, 4, 0, 4]]))
+        torch.testing.assert_close(pool_doc_ids.cpu(), torch.tensor([[0, 0, 1, 1]]))
+        torch.testing.assert_close(pool_local_idxs.cpu(), torch.tensor([[0, 1, 0, 1]]))
+
+    @_REQUIRES_CUDA
+    def test_packed_sparse_topk_compressed_range_is_doc_local_cuda(self):
+        device = torch.device("cuda")
+        seq_lens = torch.tensor([[8, 8]], device=device)
+        seq_len, ratio, n_pooled = 16, 4, 4
+        base_mask = build_packed_causal_padding_mask(
+            seq_lens,
+            seq_len=seq_len,
+            dtype=torch.float32,
+            device=device,
+            sliding_window=4,
+        )
+        valid_start, valid_end, _, _ = dsv4_layers._packed_compressed_bounds(
+            seq_lens,
+            seq_len=seq_len,
+            batch=1,
+            ratio=ratio,
+            device=device,
+        )
+        p_pos = torch.arange(n_pooled, device=device).view(1, 1, n_pooled)
+        min_val = torch.finfo(torch.float32).min
+        compressed_mask = torch.where(
+            (p_pos >= valid_start.unsqueeze(-1)) & (p_pos < valid_end.unsqueeze(-1)),
+            torch.zeros((), device=device),
+            torch.full((), min_val, device=device),
+        )
+        attention_mask = torch.cat([base_mask, compressed_mask.unsqueeze(1)], dim=-1)
+
+        topk = build_dsv4_sparse_topk_indices(
+            batch_size=1,
+            seq_len=seq_len,
+            key_len=seq_len + n_pooled,
+            window_size=4,
+            device=device,
+            attention_mask=attention_mask,
+            compress_ratio=ratio,
+            n_pooled=n_pooled,
+            vanilla_key_len=seq_len,
+            q_positions=torch.arange(seq_len, device=device).unsqueeze(0),
+        )
+
+        assert (topk[0, 8, 4:] >= 0).sum().item() == 0
+        assert (seq_len + 2) in topk[0, 12, 4:].tolist()
+        assert (seq_len + 0) not in topk[0, 12, 4:].tolist()
+        assert (seq_len + 1) not in topk[0, 12, 4:].tolist()
+
+    @_REQUIRES_CUDA
+    def test_packed_indexer_topk_mask_intersects_doc_local_range_cuda(self):
+        device = torch.device("cuda")
+        seq_lens = torch.tensor([[8, 8]], device=device)
+        seq_len, ratio, n_pooled = 16, 4, 4
+        base_mask = build_packed_causal_padding_mask(
+            seq_lens,
+            seq_len=seq_len,
+            dtype=torch.float32,
+            device=device,
+            sliding_window=4,
+        )
+        valid_start, valid_end, _, _ = dsv4_layers._packed_compressed_bounds(
+            seq_lens,
+            seq_len=seq_len,
+            batch=1,
+            ratio=ratio,
+            device=device,
+        )
+        p_pos = torch.arange(n_pooled, device=device).view(1, 1, n_pooled)
+        min_val = torch.finfo(torch.float32).min
+        compressed_mask = torch.where(
+            (p_pos >= valid_start.unsqueeze(-1)) & (p_pos < valid_end.unsqueeze(-1)),
+            torch.zeros((), device=device),
+            torch.full((), min_val, device=device),
+        )
+        attention_mask = torch.cat([base_mask, compressed_mask.unsqueeze(1)], dim=-1)
+        compressed_topk = torch.full((1, seq_len, 2), -1, device=device, dtype=torch.long)
+        compressed_topk[0, 12] = torch.tensor([0, 2], device=device)
+
+        topk = build_dsv4_sparse_topk_indices(
+            batch_size=1,
+            seq_len=seq_len,
+            key_len=seq_len + n_pooled,
+            window_size=4,
+            device=device,
+            attention_mask=attention_mask,
+            compress_ratio=ratio,
+            compressed_topk=compressed_topk,
+            n_pooled=n_pooled,
+            vanilla_key_len=seq_len,
+            q_positions=torch.arange(seq_len, device=device).unsqueeze(0),
+        )
+
+        assert (seq_len + 0) not in topk[0, 12, -2:].tolist()
+        assert (seq_len + 2) in topk[0, 12, -2:].tolist()
 
     def test_short_hca_training_window_stays_disabled_without_group_hca(self):
         """All-short groups should keep the original no-HCA path and grad=None semantics."""

--- a/tests/unit_tests/models/deepseek_v4/test_dsv4_layers.py
+++ b/tests/unit_tests/models/deepseek_v4/test_dsv4_layers.py
@@ -347,6 +347,33 @@ class TestDeepseekV4AttentionMask:
         torch.testing.assert_close(pool_local_idxs.cpu(), torch.tensor([[0, 1, 0, 1]]))
 
     @_REQUIRES_CUDA
+    def test_packed_pool_windows_keeps_static_compressed_capacity_cuda(self):
+        device = torch.device("cuda")
+        ratio, head_dim = 4, 8
+        kv = torch.arange(1 * 12 * head_dim, device=device, dtype=torch.float32).view(1, 12, head_dim)
+        gate = torch.zeros_like(kv)
+        ape = torch.zeros(ratio, head_dim, device=device)
+        seq_lens = torch.tensor([[6, 6]], device=device)
+        position_ids = torch.tensor([[0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5]], device=device)
+
+        actual, pool_positions, pool_doc_ids, pool_local_idxs = dsv4_layers._pool_windows_packed(
+            kv,
+            gate,
+            ape,
+            ratio,
+            head_dim,
+            seq_lens,
+            overlap=False,
+            position_ids=position_ids,
+        )
+
+        assert actual.shape == (1, 3, head_dim)
+        torch.testing.assert_close(pool_positions.cpu(), torch.tensor([[0, 0, 0]]))
+        torch.testing.assert_close(pool_doc_ids.cpu(), torch.tensor([[0, 1, -1]]))
+        torch.testing.assert_close(pool_local_idxs.cpu(), torch.tensor([[0, 0, -1]]))
+        torch.testing.assert_close(actual[:, 2], torch.zeros_like(actual[:, 2]))
+
+    @_REQUIRES_CUDA
     def test_packed_sparse_topk_compressed_range_is_doc_local_cuda(self):
         device = torch.device("cuda")
         seq_lens = torch.tensor([[8, 8]], device=device)

--- a/tests/unit_tests/models/deepseek_v4/test_dsv4_model_smoke.py
+++ b/tests/unit_tests/models/deepseek_v4/test_dsv4_model_smoke.py
@@ -542,6 +542,56 @@ class TestDeepseekV4ModelSmoke:
         assert out.logits.shape == (1, 8, cfg.vocab_size)
 
     @_REQUIRES_CUDA
+    def test_thd_mask_prefers_cu_seqlens_padded(self, monkeypatch):
+        """THD preprocessing emits cu_seqlens, not seq_lens, so DSV4 must derive lengths."""
+        cfg = _tiny_config(num_hidden_layers=0, compress_ratios=[])
+        model = _make_model(cfg).cuda()
+        captured = {}
+        original = dsv4_model_module.build_packed_causal_padding_mask
+
+        def record_packed_mask(seq_lens, *args, **kwargs):
+            captured["seq_lens"] = seq_lens.detach().cpu()
+            return original(seq_lens, *args, **kwargs)
+
+        monkeypatch.setattr(dsv4_model_module, "build_packed_causal_padding_mask", record_packed_mask)
+
+        input_ids = torch.ones(1, 8, dtype=torch.long, device="cuda")
+        position_ids = torch.arange(8, dtype=torch.long, device="cuda").unsqueeze(0)
+
+        with torch.no_grad():
+            out = model(
+                input_ids,
+                position_ids=position_ids,
+                qkv_format="thd",
+                cu_seqlens=torch.tensor([0, 3, 5], dtype=torch.int32, device="cuda"),
+                cu_seqlens_padded=torch.tensor([0, 4, 8], dtype=torch.int32, device="cuda"),
+            )
+
+        assert out.logits.shape == (1, 8, cfg.vocab_size)
+        torch.testing.assert_close(captured["seq_lens"], torch.tensor([[4, 4]]))
+
+    @_REQUIRES_CUDA
+    def test_thd_compressed_layer_forward_cuda(self):
+        cfg = _tiny_config(num_hidden_layers=1, compress_ratios=[4], sliding_window=4)
+        model = _make_model(cfg).cuda()
+
+        input_ids = torch.randint(0, cfg.vocab_size, (1, 16), device="cuda")
+        position_ids = torch.tensor([[0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7]], device="cuda")
+
+        with torch.no_grad():
+            out = model(
+                input_ids,
+                position_ids=position_ids,
+                qkv_format="thd",
+                cu_seqlens=torch.tensor([0, 8, 16], dtype=torch.int32, device="cuda"),
+                cu_seqlens_padded=torch.tensor([0, 8, 16], dtype=torch.int32, device="cuda"),
+            )
+
+        assert out.logits.shape == (1, 16, cfg.vocab_size)
+        assert torch.isfinite(out.logits).all()
+        torch._dynamo.reset()
+
+    @_REQUIRES_CUDA
     def test_forward_shape(self):
         """Forward pass produces logits of the right shape."""
         cfg = _tiny_config()

--- a/uv.lock
+++ b/uv.lock
@@ -377,6 +377,41 @@ wheels = [
 ]
 
 [[package]]
+name = "apache-tvm-ffi"
+version = "0.1.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/95/ef83880657e89a0ce0f1ad79cbff11698286d00522dbc290d34a8458e9c2/apache_tvm_ffi-0.1.12.tar.gz", hash = "sha256:2aa5c8ece3144dad11afd6d0f10191d03cdb368bbcd9c92f9fb919f35906223d", size = 2843816, upload-time = "2026-06-09T18:17:31.68Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/60/7e851d0391d3d39acde7620896255eb1dc289a6dec8d0ced9261929328b0/apache_tvm_ffi-0.1.12-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cbdadaf5ce64d4c3114b4366a5b685010ffa178f48f8250974e5f1a9b9c81185", size = 2511255, upload-time = "2026-06-09T18:16:17.258Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/9e17990a0af9bc6f1621fc07b10868e69040d14fbed5767e8a2eab873836/apache_tvm_ffi-0.1.12-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b17d2480eb2d04d4034669e3bba31527cd1d4900f1f51712cd959f9721bb0beb", size = 2687332, upload-time = "2026-06-09T18:16:19.69Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/a2/71eec92ef1a1bc8f993e742f6b1b8d9adfbd0d7396c8549c2473523077e6/apache_tvm_ffi-0.1.12-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f9500fc9b1b3315d02602382d13ac976aa1466b2332ff05f74810a6d48821cd", size = 2821872, upload-time = "2026-06-09T18:16:21.741Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/9c/d770a3610bedcfac40ce918cc90f3ba90199cdb322d4c6babdcb690c7cb2/apache_tvm_ffi-0.1.12-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d0db8594244d4393ff6b4fa1c161eee5e4f79f2b86137547a2e5ad9a4cbf431", size = 2600672, upload-time = "2026-06-09T18:16:24.027Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/e4/d88df0b0157f16b5feaef513ce99a712a13baa5beb0b514fbf6702440646/apache_tvm_ffi-0.1.12-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:de7807573588d8a74aa5897a07252e882a6e9672ba2ad4afcfeafa136142881c", size = 2785316, upload-time = "2026-06-09T18:16:26.092Z" },
+    { url = "https://files.pythonhosted.org/packages/73/eb/fccd0646d28a2d0003625afaa36b9e95fb6b442037d2b49ffc0e4570f7a6/apache_tvm_ffi-0.1.12-cp310-cp310-win_amd64.whl", hash = "sha256:57d75555e6245e20e2eeaef70abaacb80822790ae4651cea747a0621158053a5", size = 2753670, upload-time = "2026-06-09T18:16:28.198Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/4c/720c64fe82121c1b617cc2a63c3a4f9a8a5c32ced22fd448a89644fd675c/apache_tvm_ffi-0.1.12-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e4e22dd0128bd8b671d19b074201e94d39c8a4580822fc153e593741ef7355ff", size = 2508770, upload-time = "2026-06-09T18:16:30.007Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9b/39dbc81718ea7e7adb6e6326675c065bf0b90f4ebba6dde878a77b792cda/apache_tvm_ffi-0.1.12-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9892c39a037bcf0e4ca0da1693f1193ccc2c0f02b899402e88011847980d98f6", size = 2687418, upload-time = "2026-06-09T18:16:32.005Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/9e/bc4fdd679105d0617ebf6e89036967d3560ab7e4422a22df741b493470b2/apache_tvm_ffi-0.1.12-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c418fea49b9146d692af40f0b655df68870a032041dd27c0f468d646eda5f8bc", size = 2821462, upload-time = "2026-06-09T18:16:34.202Z" },
+    { url = "https://files.pythonhosted.org/packages/31/5c/2a311cf5bb49575cec99de45887bc76aefa43a0cd3a3f29cb71e92c8100c/apache_tvm_ffi-0.1.12-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0fec41a0633af57bcae552d662cfd096c57db685b752d1898087ca484f060e9f", size = 2598686, upload-time = "2026-06-09T18:16:36.174Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e9/923843463730aa1add10c26b45110fb6a13a68dfdb48e1cd9e325b04e331/apache_tvm_ffi-0.1.12-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:011e372fb9b169c3bd57f63e03fa1383cee6f1ef47a4932c4ff552f29db281c3", size = 2783994, upload-time = "2026-06-09T18:16:38.13Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d9/de68905c24ea6bc1fbed2021b700b9ca27a2b601fb6db43de37132c21407/apache_tvm_ffi-0.1.12-cp311-cp311-win_amd64.whl", hash = "sha256:06bcc161c020dc83e9db33b63b01c21815eab2cca3ca876748664bacd319cf9c", size = 2755540, upload-time = "2026-06-09T18:16:40.028Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/ef/8f2ea57791e8df55c5a52e20d415c01032ef5fa3761574268201b7cc2c79/apache_tvm_ffi-0.1.12-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:218e55c807d49182710ef2ab0336313ba6becccb7e565f4941d23bded09646d4", size = 2463724, upload-time = "2026-06-09T18:16:41.904Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/c4/34aec1f10353eee555687f3196241457b8e8a06da2014a176f5b022e24bd/apache_tvm_ffi-0.1.12-cp312-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:557d8deb672f2ad7f445399e3fa0c727a6e11472e19c895ee244cbb8cfd99a66", size = 2616513, upload-time = "2026-06-09T18:16:44.115Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/2a/bff8d73841b49f196852edd8460241d3a363e6b0d64c3a9367542658394f/apache_tvm_ffi-0.1.12-cp312-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:817af52916ca9987e019ae9c811406835c7f26c590b2a7bcfa9db0e3809f4228", size = 2757612, upload-time = "2026-06-09T18:16:45.987Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/51d0c31c76bef0f21c11bce0465598d1ea5fdaca22e47a69c29deadeada7/apache_tvm_ffi-0.1.12-cp312-abi3-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a7b08f377ea2663dae10e3045f8d0215f0378ee975096174a8af6381eeb1504", size = 2533956, upload-time = "2026-06-09T18:16:47.891Z" },
+    { url = "https://files.pythonhosted.org/packages/52/f3/fba607d803cb081be2d66ea51865492b42872898bd271d9bcc3e1ced4ef3/apache_tvm_ffi-0.1.12-cp312-abi3-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc0acd7eeb0e451d5e3f686af3ba0b495fdbf97b5b54cf9a0f770cdafe0e691a", size = 2719638, upload-time = "2026-06-09T18:16:50.021Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d7/a25f51156358c631114e16cb09ca91188b3b79677369e111216d6fa7f83d/apache_tvm_ffi-0.1.12-cp312-abi3-win_amd64.whl", hash = "sha256:23eefd1094a41faae2bb7b9cc5816aa938101b624d48ebb724881f1a89b78e99", size = 2725953, upload-time = "2026-06-09T18:16:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/05/d4/5f1a59ebf85c4ea3243766318a50bcec2312bacce9dc9b132db514f7c897/apache_tvm_ffi-0.1.12-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3ee7ebbc4ec8e037364fc1388c081145f790cc97de642348efc39fcda749a8bb", size = 2526890, upload-time = "2026-06-09T18:16:54.547Z" },
+    { url = "https://files.pythonhosted.org/packages/04/4a/428b5bc74a762d62aa5efedc3a72f90e00bae53ab4fb7e5b52206dd9f541/apache_tvm_ffi-0.1.12-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:003027a31011a216295ec8e04ac78bb3d80b8dc47a93f6b602cf242a80676366", size = 2650779, upload-time = "2026-06-09T18:16:56.746Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/c1/550f60d376e7d11cbcfbc2968bd87936beeec91f4c26d16e6c63b60801ee/apache_tvm_ffi-0.1.12-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f69d28a95648c4e864a53f1bfe099b7547dfbc60d520180fc0eb0ec72245151f", size = 2789261, upload-time = "2026-06-09T18:16:59.021Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/6c/34e8bfb495ada6c1d37d5eb84fee17d5c8cfd630e6fa647c8327377bc17e/apache_tvm_ffi-0.1.12-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:02508fef806cfb1a5224aaa69fb121558d60fa56c2fa7d4166fb9f354945509b", size = 2570469, upload-time = "2026-06-09T18:17:01.376Z" },
+    { url = "https://files.pythonhosted.org/packages/33/a9/005a2537fb043aa2d5916bb9c30ee8b6cda258d9e2db343f7dca233407ca/apache_tvm_ffi-0.1.12-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:786b3073a79c025f85b2bf4aa4b6bc1f8a2b1aae186a613181acd6d9661bd3cb", size = 2750777, upload-time = "2026-06-09T18:17:03.333Z" },
+    { url = "https://files.pythonhosted.org/packages/10/d6/5e3199709bef26975ee5f993029999f05edbf5020df8a910f3ef0884acc7/apache_tvm_ffi-0.1.12-cp314-cp314t-win_amd64.whl", hash = "sha256:d015c7ad8e15ee7896ffacb5b30c81fd507375f1b5650078ba382f52a5dc8795", size = 2820788, upload-time = "2026-06-09T18:17:05.424Z" },
+]
+
+[[package]]
 name = "arro3-core"
 version = "0.6.5"
 source = { registry = "https://pypi.org/simple" }
@@ -2156,7 +2191,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/ed/6bfa4109fcb23a58819600392564fea69cdc6551ffd5e69ccf1d52a40cbc/greenlet-3.2.4-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:8c68325b0d0acf8d91dde4e6f930967dd52a5302cd4062932a6b2e7c2969f47c", size = 271061, upload-time = "2025-08-07T13:17:15.373Z" },
     { url = "https://files.pythonhosted.org/packages/2a/fc/102ec1a2fc015b3a7652abab7acf3541d58c04d3d17a8d3d6a44adae1eb1/greenlet-3.2.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:94385f101946790ae13da500603491f04a76b6e4c059dab271b3ce2e283b2590", size = 629475, upload-time = "2025-08-07T13:42:54.009Z" },
     { url = "https://files.pythonhosted.org/packages/c5/26/80383131d55a4ac0fb08d71660fd77e7660b9db6bdb4e8884f46d9f2cc04/greenlet-3.2.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f10fd42b5ee276335863712fa3da6608e93f70629c631bf77145021600abc23c", size = 640802, upload-time = "2025-08-07T13:45:25.52Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/7c/e7833dbcd8f376f3326bd728c845d31dcde4c84268d3921afcae77d90d08/greenlet-3.2.4-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c8c9e331e58180d0d83c5b7999255721b725913ff6bc6cf39fa2a45841a4fd4b", size = 636703, upload-time = "2025-08-07T13:53:12.622Z" },
     { url = "https://files.pythonhosted.org/packages/e9/49/547b93b7c0428ede7b3f309bc965986874759f7d89e4e04aeddbc9699acb/greenlet-3.2.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:58b97143c9cc7b86fc458f215bd0932f1757ce649e05b640fea2e79b54cedb31", size = 635417, upload-time = "2025-08-07T13:18:25.189Z" },
     { url = "https://files.pythonhosted.org/packages/7f/91/ae2eb6b7979e2f9b035a9f612cf70f1bf54aad4e1d125129bef1eae96f19/greenlet-3.2.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c2ca18a03a8cfb5b25bc1cbe20f3d9a4c80d8c3b13ba3df49ac3961af0b1018d", size = 584358, upload-time = "2025-08-07T13:18:23.708Z" },
     { url = "https://files.pythonhosted.org/packages/f7/85/433de0c9c0252b22b16d413c9407e6cb3b41df7389afc366ca204dbc1393/greenlet-3.2.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:9fe0a28a7b952a21e2c062cd5756d34354117796c6d9215a87f55e38d15402c5", size = 1113550, upload-time = "2025-08-07T13:42:37.467Z" },
@@ -2167,7 +2201,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/de/f28ced0a67749cac23fecb02b694f6473f47686dff6afaa211d186e2ef9c/greenlet-3.2.4-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:96378df1de302bc38e99c3a9aa311967b7dc80ced1dcc6f171e99842987882a2", size = 272305, upload-time = "2025-08-07T13:15:41.288Z" },
     { url = "https://files.pythonhosted.org/packages/09/16/2c3792cba130000bf2a31c5272999113f4764fd9d874fb257ff588ac779a/greenlet-3.2.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1ee8fae0519a337f2329cb78bd7a8e128ec0f881073d43f023c7b8d4831d5246", size = 632472, upload-time = "2025-08-07T13:42:55.044Z" },
     { url = "https://files.pythonhosted.org/packages/ae/8f/95d48d7e3d433e6dae5b1682e4292242a53f22df82e6d3dda81b1701a960/greenlet-3.2.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94abf90142c2a18151632371140b3dba4dee031633fe614cb592dbb6c9e17bc3", size = 644646, upload-time = "2025-08-07T13:45:26.523Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/5e/405965351aef8c76b8ef7ad370e5da58d57ef6068df197548b015464001a/greenlet-3.2.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:4d1378601b85e2e5171b99be8d2dc85f594c79967599328f95c1dc1a40f1c633", size = 640519, upload-time = "2025-08-07T13:53:13.928Z" },
     { url = "https://files.pythonhosted.org/packages/25/5d/382753b52006ce0218297ec1b628e048c4e64b155379331f25a7316eb749/greenlet-3.2.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0db5594dce18db94f7d1650d7489909b57afde4c580806b8d9203b6e79cdc079", size = 639707, upload-time = "2025-08-07T13:18:27.146Z" },
     { url = "https://files.pythonhosted.org/packages/1f/8e/abdd3f14d735b2929290a018ecf133c901be4874b858dd1c604b9319f064/greenlet-3.2.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2523e5246274f54fdadbce8494458a2ebdcdbc7b802318466ac5606d3cded1f8", size = 587684, upload-time = "2025-08-07T13:18:25.164Z" },
     { url = "https://files.pythonhosted.org/packages/5d/65/deb2a69c3e5996439b0176f6651e0052542bb6c8f8ec2e3fba97c9768805/greenlet-3.2.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1987de92fec508535687fb807a5cea1560f6196285a4cde35c100b8cd632cc52", size = 1116647, upload-time = "2025-08-07T13:42:38.655Z" },
@@ -2178,7 +2211,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
     { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
-    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
     { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
@@ -2189,7 +2221,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
     { url = "https://files.pythonhosted.org/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
     { url = "https://files.pythonhosted.org/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
@@ -2200,7 +2231,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
     { url = "https://files.pythonhosted.org/packages/c0/aa/687d6b12ffb505a4447567d1f3abea23bd20e73a5bed63871178e0831b7a/greenlet-3.2.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c17b6b34111ea72fc5a4e4beec9711d2226285f0386ea83477cbb97c30a3f3a5", size = 699218, upload-time = "2025-08-07T13:45:30.969Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
     { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },
@@ -3955,6 +3985,9 @@ msc = [
 s3 = [
     { name = "boto3" },
 ]
+tilelang = [
+    { name = "tilelang" },
+]
 vlm = [
     { name = "albumentations" },
     { name = "backoff" },
@@ -4068,6 +4101,7 @@ requires-dist = [
     { name = "sentencepiece", marker = "extra == 'extra'" },
     { name = "soundfile", marker = "extra == 'vlm'" },
     { name = "tiktoken" },
+    { name = "tilelang", marker = "extra == 'tilelang'", specifier = ">=0.1.11" },
     { name = "timm", marker = "extra == 'vlm'", specifier = "<=1.0.22" },
     { name = "torch", marker = "sys_platform != 'darwin' and sys_platform != 'linux'", specifier = ">=2.6.0", index = "https://download.pytorch.org/whl/cpu" },
     { name = "torch", marker = "sys_platform == 'darwin'", specifier = ">=2.6.0", index = "https://pypi.org/simple" },
@@ -4082,7 +4116,7 @@ requires-dist = [
     { name = "transformers", specifier = "==5.8.1" },
     { name = "wandb", specifier = ">=0.26.1" },
 ]
-provides-extras = ["diffusion", "diffusion-kernels", "cuda", "cuda-source", "extra", "fa", "fla", "delta-databricks", "moe", "vlm", "cli", "s3", "msc", "all"]
+provides-extras = ["diffusion", "diffusion-kernels", "cuda", "cuda-source", "tilelang", "extra", "fa", "fla", "delta-databricks", "moe", "vlm", "cli", "s3", "msc", "all"]
 
 [package.metadata.requires-dev]
 build = [
@@ -7595,6 +7629,34 @@ wheels = [
 ]
 
 [[package]]
+name = "tilelang"
+version = "0.1.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "apache-tvm-ffi" },
+    { name = "cloudpickle" },
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "psutil" },
+    { name = "setuptools", marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.10.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin' and sys_platform != 'linux'" },
+    { name = "torch", version = "2.10.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux'" },
+    { name = "torch-c-dlpack-ext", marker = "python_full_version < '3.14'" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+    { name = "z3-solver" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/2b/ea36e371296155b662dfc0ce987b6e1c6f4017714e13824050370a0fd4f1/tilelang-0.1.11.tar.gz", hash = "sha256:ac9d03e67caadeebd4d7f3ac5e2318011db8d3e23f7179f7dd3ba2a249354d47", size = 93229382, upload-time = "2026-06-08T08:37:26.87Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/ad/7f33bc7aea74d2e27ea3e3dcb6d8773c1d8026d1cfe2fd09db119c19493e/tilelang-0.1.11-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:1be1f0643322419e66618093c69d3e45408ac3fcc04564413372916b2a9a716c", size = 38305998, upload-time = "2026-06-08T08:37:12.571Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/0e/ed59fb66606b6e51349793d9db209d01a41487008bd6d4a984249d70eb4b/tilelang-0.1.11-cp38-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90d78f093d2bd46660633133982cd715cf9b7d0c379d463f136748efcfa55a9c", size = 50054335, upload-time = "2026-06-08T08:37:15.93Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/bd/6060f90ca4d063c22a8dbeaa5f14489a59706c0304dce5006e89907950ff/tilelang-0.1.11-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:c7b0dedc0a181486b7fa137d04eaf793271a7573ebd30e77838c18321a3206db", size = 45875401, upload-time = "2026-06-08T08:37:19.213Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b4/517c706798a159236a57d4aa1d4a448b2f8288808cd8fb8d7d2eb465a2af/tilelang-0.1.11-cp38-abi3-win_amd64.whl", hash = "sha256:d58ed14cdc6050b8454e5dbd53f6d0904d46f149f25d158621d8f874e775b5f8", size = 33740387, upload-time = "2026-06-08T08:37:22.929Z" },
+]
+
+[[package]]
 name = "timm"
 version = "1.0.22"
 source = { registry = "https://pypi.org/simple" }
@@ -7858,6 +7920,39 @@ wheels = [
     { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:db5a61791b7da3c1aa5a496e64cd72dbd4ef3ef2cbb69680fd45dc255b0da2f3", upload-time = "2026-01-21T19:02:42Z" },
     { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:7781235583ea06b214075c10fa95f83b9805f06af44efc6e9946808413cff94f", upload-time = "2026-01-21T19:01:59Z" },
     { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.10.0%2Bcu130-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:526b737db11d632281795484ec729baae5f193a5a0d76a1f7d822f7897c8b4f5", upload-time = "2026-01-21T19:02:44Z" },
+]
+
+[[package]]
+name = "torch-c-dlpack-ext"
+version = "0.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and sys_platform == 'darwin'" },
+    { name = "torch", version = "2.10.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux'" },
+    { name = "torch", version = "2.10.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "python_full_version < '3.14' and sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/de/921b6491efce5c389a5ef9bbed3d2d6660005840dae488124173180859ab/torch_c_dlpack_ext-0.1.5.tar.gz", hash = "sha256:d06f0357d575d22a168cc77acb9020fc4bae30968ceb6718a055dcbe92bacabe", size = 12913, upload-time = "2026-01-12T11:25:08.484Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/49/67a66932ab2fcdda3c5a4dcf606e713d86883a4a9a99a3bb832815b52b8e/torch_c_dlpack_ext-0.1.5-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:e0f6c197d5293884898b9ebf13d07501de39cb94799b374ed43f91731087d557", size = 7056755, upload-time = "2026-01-12T11:24:31.817Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/28/d2d6bf90e01a1f4da3277c9a56d9ecac648b6d6adaa8e20c17f802deb7fb/torch_c_dlpack_ext-0.1.5-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba3d88f0f7d5e1d9c3d4a3179037fc8e261c3b77ac1fad23edc0d3a9214ef193", size = 432066, upload-time = "2026-01-12T11:24:33.619Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/e9/a1f9584a3af4ac6ae5ad5cf86927d8c3a9b6bb50d54e54d19313411216a0/torch_c_dlpack_ext-0.1.5-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c7468df84ec152d930fbc3acf460c44a60b3462b95af3d3a676d133629c7e176", size = 879488, upload-time = "2026-01-12T11:24:34.837Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/08/478cfcb5814e29f9b720111bdef315fc2fbc8b276e4b1183c8b9c9414a4f/torch_c_dlpack_ext-0.1.5-cp310-cp310-win_amd64.whl", hash = "sha256:78dd4904bd26170a2dd7c0eab56367756ee0a15672ce9b84146169e68f0c6ddc", size = 1461437, upload-time = "2026-01-12T11:24:36.385Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/c12a9bb3a5ddc0962c00467891bf1ffdda39a4d4780bf0fbbf54523ff34e/torch_c_dlpack_ext-0.1.5-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:56bd25a2af19280bf8a06aa62cff5510106f43235b9327d8561b3e9a659c4d84", size = 5076782, upload-time = "2026-01-12T11:24:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e1/64e1e579d107064785549e70758e38a42376ab7e73d86897ed4beab10e74/torch_c_dlpack_ext-0.1.5-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fba674110e1fab0b176bb5a28223e157db65c90767d4ba74abdbee9f537b0e9d", size = 440949, upload-time = "2026-01-12T11:24:39.716Z" },
+    { url = "https://files.pythonhosted.org/packages/64/5c/3e1382a620824f92920ab3fae132d8fb4e85898284c99e0c6a7764e452ce/torch_c_dlpack_ext-0.1.5-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3448c4f0d64104d0b2e58080a7efa72304a04960c18f338024b80b13cd3eca26", size = 897768, upload-time = "2026-01-12T11:24:41.209Z" },
+    { url = "https://files.pythonhosted.org/packages/54/4f/76ea1006b9038b496d01e916c91efd17cb782abde2491a261cf203f57e30/torch_c_dlpack_ext-0.1.5-cp311-cp311-win_amd64.whl", hash = "sha256:74676474e0afa9a4216c4755ea7cf05e8158be1d168f6bda669ba91097c263f2", size = 1479088, upload-time = "2026-01-12T11:24:42.436Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/67/10d236698525d7b7db4d74ec0a4b01f5b2db33968995fdd9ac6b4635e327/torch_c_dlpack_ext-0.1.5-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:c0f2bd51fcd99c0e5b50314e1985f2728c4941bfa821f065e6c30951d1f995ca", size = 5291237, upload-time = "2026-01-12T11:24:44.011Z" },
+    { url = "https://files.pythonhosted.org/packages/87/06/8d760997307a5c3be4384424667bf31aae0a42060838c532c7d846516175/torch_c_dlpack_ext-0.1.5-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3562ee411258676f9c38b8ad39306d1c8d027b6a86f6a87c920d2d009a9d1510", size = 443069, upload-time = "2026-01-12T11:24:45.451Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/79/a914539b4785f3e44f891aa012a886edb8bc10fe081c440981c57543ce21/torch_c_dlpack_ext-0.1.5-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e6f9da4bb9af70e27facc777458be62e10dbbbddda7672d16138db0553c5a524", size = 897846, upload-time = "2026-01-12T11:24:48.168Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/e6/7d7a97a3953208d6d6ce749180c34d1dab48464ded9a76cecabe9d021ce6/torch_c_dlpack_ext-0.1.5-cp312-cp312-win_amd64.whl", hash = "sha256:670fbbab70123cc228bed41693a3720757af57a0ad22669063c9db25321e8f55", size = 1482855, upload-time = "2026-01-12T11:24:49.581Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/c6/65346a201d921b616731311fc9941f15137672b444cebdad702cb52ccee0/torch_c_dlpack_ext-0.1.5-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:74acea2ed395cadda63342845b9e9ee7cd4537846223dacfb4431b4610109265", size = 1993243, upload-time = "2026-01-12T11:24:51.079Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/ec/faf10be09a5812b1c5ec9922b53fb5def5fc4080b81a653b9347bb169ebb/torch_c_dlpack_ext-0.1.5-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49f1e99d13c64e22dac0a34a1560e9e5a398a49a9fa81df83053e04fde6ec5bd", size = 443798, upload-time = "2026-01-12T11:24:52.754Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/68/f434b48700f3e04f33882f54d8d3910327b935f55e14ec49da7d607bf470/torch_c_dlpack_ext-0.1.5-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:debe62e5ef93e631065d6b9f6e60d3d39bae6b89fa1b25d9523f40b3efbf8aba", size = 755004, upload-time = "2026-01-12T11:24:54.004Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a8/cc64e563f05ea99bd79bdb43f71f0f46452d3acd734da4843ede5fc73a35/torch_c_dlpack_ext-0.1.5-cp313-cp313-win_amd64.whl", hash = "sha256:30e3eab616dbc81dfdb7492aca557be551a9163ba9b585f97394a42b336b113a", size = 999126, upload-time = "2026-01-12T11:24:55.44Z" },
+    { url = "https://files.pythonhosted.org/packages/96/5e/449324ca8e81573e650b6851fc31c1038f750d1de85d0b185d788e1c7a3a/torch_c_dlpack_ext-0.1.5-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:cac94a4905d391889e679a8da31e46dc325af5d55d13b7c70c0ce3d71d1ced6d", size = 1982154, upload-time = "2026-01-12T11:24:58.038Z" },
+    { url = "https://files.pythonhosted.org/packages/20/62/11c05b99f69aa5152bca0313e0dfa6d125a020cf890dc888ef009aa7891c/torch_c_dlpack_ext-0.1.5-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a58fdf45fb0bda7bc459632cec891570f31c11636d5851c825cf308ec8b73c2", size = 163825, upload-time = "2026-01-12T11:24:59.474Z" },
+    { url = "https://files.pythonhosted.org/packages/15/b5/be613cd8e71c9982bd07af530f86c5a7f30df7831d14cec5414857af7149/torch_c_dlpack_ext-0.1.5-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b985a324c68241cf83a9474b28015524b66775b12a91930dd4c0760aa628d01", size = 171740, upload-time = "2026-01-12T11:25:00.776Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/11/52e291f1659e2ec70a09f5ca4ad27e015eb4f0a1371ae68d23a9fbd1c704/torch_c_dlpack_ext-0.1.5-cp314-cp314-win_amd64.whl", hash = "sha256:d794e19fa3f330ab7a29987c07e031fc08e4953aec516d35701d0827863e356b", size = 277086, upload-time = "2026-01-12T11:25:01.901Z" },
 ]
 
 [[package]]
@@ -8943,6 +9038,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/86/0f0dccb6e59a9e7f122c5afd43568b1d31b8ab7dda5f1b01fb5c7025c9a9/yarl-1.22.0-cp314-cp314t-win_amd64.whl", hash = "sha256:9fb17ea16e972c63d25d4a97f016d235c78dd2344820eb35bc034bc32012ee27", size = 96292, upload-time = "2025-10-06T14:12:15.398Z" },
     { url = "https://files.pythonhosted.org/packages/48/b7/503c98092fb3b344a179579f55814b613c1fbb1c23b3ec14a7b008a66a6e/yarl-1.22.0-cp314-cp314t-win_arm64.whl", hash = "sha256:9f6d73c1436b934e3f01df1e1b21ff765cd1d28c77dfb9ace207f746d4610ee1", size = 85171, upload-time = "2025-10-06T14:12:16.935Z" },
     { url = "https://files.pythonhosted.org/packages/73/ae/b48f95715333080afb75a4504487cbe142cae1268afc482d06692d605ae6/yarl-1.22.0-py3-none-any.whl", hash = "sha256:1380560bdba02b6b6c90de54133c81c9f2a453dee9912fe58c1dcced1edb7cff", size = 46814, upload-time = "2025-10-06T14:12:53.872Z" },
+]
+
+[[package]]
+name = "z3-solver"
+version = "4.15.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/8e/0c8f17309549d2e5cde9a3ccefa6365437f1e7bafe71878eaf9478e47b18/z3_solver-4.15.4.0.tar.gz", hash = "sha256:928c29b58c4eb62106da51c1914f6a4a55d0441f8f48a81b9da07950434a8946", size = 5018600, upload-time = "2025-10-29T18:12:03.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/33/a3d5d2eaeb0f7b3174d57d405437eabb2075d4d50bd9ea0957696c435c7b/z3_solver-4.15.4.0-py3-none-macosx_13_0_arm64.whl", hash = "sha256:407e825cc9211f95ef46bdc8d151bf630e7ab2d62a21d24cd74c09cc5b73f3aa", size = 37052538, upload-time = "2025-10-29T18:11:46.233Z" },
+    { url = "https://files.pythonhosted.org/packages/47/84/fd7ffac1551cd9f8d44fe41358f738be670fc4c24dfd514fab503f2cf3e7/z3_solver-4.15.4.0-py3-none-macosx_13_0_x86_64.whl", hash = "sha256:00bd10c5a6a5f6112d3a9a810d0799227e52f76caa860dafa5e00966bb47eb13", size = 39807925, upload-time = "2025-10-29T18:11:49.81Z" },
+    { url = "https://files.pythonhosted.org/packages/21/c9/bb51a96af0091324c81b803f16c49f719f9f6ea0b0bb52200f5c97ec4892/z3_solver-4.15.4.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e103a6f203f505b8b8b8e5c931cc407c95b61556512d4921c1ddc0b3f41b08e", size = 29268352, upload-time = "2025-10-29T18:11:53.032Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/2e/0b49f7e4e53817cfb09a0f6585012b782dfe0b666e8abefcb4fac0570606/z3_solver-4.15.4.0-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:62c7e9cbdd711932301f29919ad9158de9b2f58b4d281dd259bbcd0a2f408ba1", size = 27226534, upload-time = "2025-10-29T18:11:55.59Z" },
+    { url = "https://files.pythonhosted.org/packages/26/91/33de49538444d4aafbe47415c450c2f9abab1733e1226f276b496672f46c/z3_solver-4.15.4.0-py3-none-win32.whl", hash = "sha256:be3bc916545c96ffbf89e00d07104ff14f78336e55db069177a1bfbcc01b269d", size = 13191672, upload-time = "2025-10-29T18:11:58.424Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d6/a0b135e4419df475177ae78fc93c422430b0fd8875649486f9a5989772e6/z3_solver-4.15.4.0-py3-none-win_amd64.whl", hash = "sha256:00e35b02632ed085ea8199fb230f6015e6fc40554a6680c097bd5f060e827431", size = 16259597, upload-time = "2025-10-29T18:12:01.14Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Stacked on #2683. This is the model/test portion split out of the original #2683 diff.

## What

- Derive DeepSeek V4 packed THD document lengths from `seq_lens_padded` / `cu_seqlens_padded` and pass them through the model.
- Make compressed pooling and compressed sparse-attention bounds document-local for packed THD.
- Use flat packed key positions for TileLang sparse top-k while keeping RoPE positions doc-local.
- Add CUDA-only regression coverage for packed THD masks, compressed pooling, compressed sparse top-k bounds, indexer bounds, and a compressed-layer forward smoke test.

## Validation

- `CUDA_VISIBLE_DEVICES=0 python -m pytest tests/unit_tests/models/deepseek_v4/test_dsv4_model_smoke.py -q`
- `CUDA_VISIBLE_DEVICES=0 python -m pytest tests/unit_tests/models/deepseek_v4/test_dsv4_layers.py -k "not tilelang" -q`
- `ruff check tests/unit_tests/models/deepseek_v4/test_dsv4_model_smoke.py tests/unit_tests/models/deepseek_v4/test_dsv4_layers.py nemo_automodel/components/models/deepseek_v4/model.py nemo_automodel/components/models/deepseek_v4/layers.py`
- `git diff --check akoumpa/build/tilelang-tile-kernels-dsv4..HEAD`

Signed-off-by: Alexandros Koumparoulis <akoumparouli@nvidia.com>