### PR TITLE
fix(moe): handle non-EP expert weight DTensors

### DIFF
--- a/examples/llm_finetune/nemotron/nemotron_nano_v3_singlegpu_lora.yaml
+++ b/examples/llm_finetune/nemotron/nemotron_nano_v3_singlegpu_lora.yaml
@@ -33,6 +33,7 @@ model:
     _target_: nemo_automodel.components.models.common.BackendConfig
     rms_norm: torch_fp32
     linear: torch
+    dispatcher: torch
 
 compile:
   enabled: false

--- a/nemo_automodel/components/distributed/fsdp2.py
+++ b/nemo_automodel/components/distributed/fsdp2.py
@@ -116,8 +116,8 @@ class FSDP2Manager:
         Returns:
             The parallelized model.
         """
-        if get_world_size_safe() == 1:
-            logger.info("World size is 1, skipping parallelization.")
+        if get_world_size_safe() == 1 or self.device_mesh.size() == 1:
+            logger.info("World size or FSDP mesh size is 1, skipping parallelization.")
             if self.activation_checkpointing:
                 if is_selective_activation_checkpointing(self.activation_checkpointing):
                     # Selective AC works on a plain model (no FSDP required), so

--- a/nemo_automodel/components/moe/state_dict_mixin.py
+++ b/nemo_automodel/components/moe/state_dict_mixin.py
@@ -657,8 +657,12 @@ class MoESplitExpertsStateDictMixin:
 
             splits = self._split_experts_weights(tensor, n_experts)
 
-            # In-place views only engage when splits are plain (ep_shard==1).
-            inplace_ok = is_dtensor(tensor) and len(splits) > 0 and not is_dtensor(splits[0]) and not quantization
+            inplace_ok = (
+                (is_dtensor(tensor) or (isinstance(tensor, torch.Tensor) and tensor.is_cuda and not tensor.is_meta))
+                and len(splits) > 0
+                and not is_dtensor(splits[0])
+                and not quantization
+            )
             if inplace_ok:
                 self._register_inplace_loaded_key(fqn, prefix_override)
 
@@ -700,7 +704,12 @@ class MoESplitExpertsStateDictMixin:
                 validate_dtensor_expert_sharding(tensor, n_experts, f"down_projs (DeepEP) layer {layer_num}")
 
             splits = self._split_experts_weights(tensor, n_experts)
-            inplace_ok = is_dtensor(tensor) and len(splits) > 0 and not is_dtensor(splits[0]) and not quantization
+            inplace_ok = (
+                (is_dtensor(tensor) or (isinstance(tensor, torch.Tensor) and tensor.is_cuda and not tensor.is_meta))
+                and len(splits) > 0
+                and not is_dtensor(splits[0])
+                and not quantization
+            )
             if inplace_ok:
                 self._register_inplace_loaded_key(fqn, prefix_override)
 

--- a/nemo_automodel/recipes/base_recipe.py
+++ b/nemo_automodel/recipes/base_recipe.py
@@ -832,19 +832,23 @@ class BaseRecipe:
         if not self.device_mesh:
             return None
 
+        dp_mesh = get_flat_mesh(self.device_mesh, "dp")
         if include_cp and self.device_mesh["cp"].size() > 1:
-            return get_flat_mesh(self.device_mesh, "dp_cp").get_group()
-        return get_flat_mesh(self.device_mesh, "dp").get_group()
+            dp_mesh = get_flat_mesh(self.device_mesh, "dp_cp")
+        if dp_mesh.size() == 1:
+            return None
+        return dp_mesh.get_group()
 
     def _get_dp_group_size(self, include_cp: bool = False):
-        dp_group = self._get_dp_group(include_cp=include_cp)
-        if dp_group is None:
-            # For DDP without a device mesh, all ranks form a single
-            # data-parallel group whose size equals the world size.
+        if not self.device_mesh:
             if dist.is_initialized():
                 return dist.get_world_size()
             return 1
-        return dp_group.size()
+
+        dp_mesh = get_flat_mesh(self.device_mesh, "dp")
+        if include_cp and self.device_mesh["cp"].size() > 1:
+            dp_mesh = get_flat_mesh(self.device_mesh, "dp_cp")
+        return dp_mesh.size()
 
     def _get_cp_group_size(self):
         if not self.device_mesh or self.device_mesh["cp"].size() == 1:
@@ -858,9 +862,12 @@ class BaseRecipe:
                 return dist.get_rank()
             return 0
 
+        dp_mesh = get_flat_mesh(self.device_mesh, "dp")
         if include_cp and self.device_mesh["cp"].size() > 1:
-            return get_flat_mesh(self.device_mesh, "dp_cp").get_local_rank()
-        return get_flat_mesh(self.device_mesh, "dp").get_local_rank()
+            dp_mesh = get_flat_mesh(self.device_mesh, "dp_cp")
+        if dp_mesh.size() == 1:
+            return 0
+        return dp_mesh.get_local_rank()
 
     def _get_tp_rank(self):
         if not self.device_mesh or self.device_mesh["tp"].size() == 1:
@@ -875,6 +882,8 @@ class BaseRecipe:
 
     def _dp_allreduce(self, tensor, op=dist.ReduceOp.SUM, include_cp: bool = False):
         dp_group = self._get_dp_group(include_cp=include_cp)
+        if self.device_mesh and dp_group is None:
+            return tensor
         if dp_group is not None or dist.is_initialized():
             if not tensor.is_cuda and torch.cuda.is_available():
                 tensor = tensor.cuda()


### PR DESCRIPTION
## Summary

- avoid singleton DP/FSDP mesh process-group calls for the no-parallelism FSDP2 recipe
- keep the single-GPU Nemotron Nano v3 LoRA config on the local torch MoE dispatcher
- use non-contiguous expert views for CUDA checkpoint target tensors to avoid extra contiguous copies during load

## Testing

- `pytest tests/unit_tests/moe/test_state_dict_mixin.py::TestInplaceLoadViews tests/unit_tests/moe/test_layers.py::TestMoE::test_moe_init_with_gmm_experts_with_deepep tests/unit_tests/moe/test_layers.py::TestMoE::test_moe_init_with_hybridep_multi_device tests/unit_tests/moe/test_layers.py::TestMoE::test_moe_init_with_deepep_single_device tests/unit_tests/moe/test_experts.py::TestGroupedExpertsDeepEP tests/unit_tests/recipes/test_base_recipe.py::test_dp_allreduce_uses_world_group_without_device_mesh -q`
- `ruff check nemo_automodel/components/distributed/fsdp2.py nemo_automodel/components/moe/state_dict_mixin.py nemo_automodel/recipes/base_recipe.py`
- YAML parse check for `examples/llm_finetune/nemotron/nemotron_nano_v3_singlegpu_lora.yaml`
- `git diff --check`
- nemo-ci: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/344729569
