### PR TITLE
test(models): speed up qwen3.5 moe/vl-moe from_pretrained unit tests

### DIFF
--- a/tests/unit_tests/models/qwen3_5_moe/test_qwen3_5_moe_model.py
+++ b/tests/unit_tests/models/qwen3_5_moe/test_qwen3_5_moe_model.py
@@ -656,8 +656,12 @@ class TestQwen3_5MoeForConditionalGeneration:
 # from_pretrained / ModelClass export tests
 # ---------------------------------------------------------------------------
 class TestQwen3_5MoeFromPretrainedAndModelClass:
-    def test_from_pretrained_classmethod(self):
-        cfg = Qwen3_5MoeConfig()
+    def test_from_pretrained_classmethod(self, vl_config):
+        # Use the tiny `vl_config` fixture instead of the default ``Qwen3_5MoeConfig()``,
+        # which describes the full ~30B model (40 layers, 256 experts, 248K vocab) and
+        # takes minutes to materialize on GPU. The classmethod's delegation behaviour is
+        # identical regardless of model size.
+        cfg = vl_config
         cfg.text_config.pad_token_id = 0
 
         with (

--- a/tests/unit_tests/models/qwen3_vl_moe/test_qwen3_vl_moe_model.py
+++ b/tests/unit_tests/models/qwen3_vl_moe/test_qwen3_vl_moe_model.py
@@ -861,16 +861,15 @@ class TestQwen3VLMoeForConditionalGenerationPPGuard:
 
 @_requires_cuda
 class TestQwen3VLMoeFromPretrainedAndModelClass:
-    def test_from_pretrained_classmethod(self):
-        cfg = Qwen3VLMoeConfig()
-        cfg.text_config.rope_parameters = {
-            "rope_theta": 10000.0,
-            "rope_type": "default",
-            "mrope_section": [1, 1, 1],
-            "partial_rotary_factor": 1.0,
-        }
-        # Add pad_token_id required by transformers v5
-        cfg.text_config.pad_token_id = 0
+    def test_from_pretrained_classmethod(self, vl_config):
+        # Use the tiny `vl_config` fixture instead of the default ``Qwen3VLMoeConfig()``,
+        # which describes the full model (24 layers, 60 experts, 151K vocab) and takes
+        # ~100s to materialize on GPU. The classmethod's delegation behaviour is
+        # independent of model size.
+        # `vl_config` already carries a valid tiny rope/pad setup (it is the same
+        # config every other test in this module builds and runs forward with), so no
+        # extra rope_parameters/pad_token_id massaging is required here.
+        cfg = vl_config
 
         with (
             patch(


### PR DESCRIPTION
## Summary

Two GPU unit tests in `L0_Unit_Tests_GPU` were dominating CI time by building the **full production HF model** from the default config purely to verify that `from_pretrained` delegates to `from_config(cfg)`:

| Test | Default config it built | Time |
|---|---|---|
| `qwen3_5_moe::TestQwen3_5MoeFromPretrainedAndModelClass::test_from_pretrained_classmethod` | 40 layers, hidden 2048, 256 experts, vocab 248K (~30B params) | ~235s |
| `qwen3_vl_moe::TestQwen3VLMoeFromPretrainedAndModelClass::test_from_pretrained_classmethod` | 24 layers, hidden 2048, 60 experts, vocab 152K | ~100s |

The assertion under test (delegation to `from_config`) is independent of model size. This PR switches both tests to the existing tiny `vl_config` fixture (2 layers / 4 experts / 128 vocab), which materializes near-instantly. For the VL test, the now-unneeded `rope_parameters`/`pad_token_id` massaging is dropped, since the tiny fixture already carries a valid rope/pad setup that the rest of the module builds and runs forward with.

**Expected savings: ~335s combined → ~1-2s**, with identical delegation assertions.

### Out of scope (note)

The third slow test, `qwen3_5/test_qwen3_5_dense_backbone.py::TestDenseTextBackbone::test_forward_shape_mixed_layers` (~70s), is **not** a config-size problem — it already uses a tiny config. Its cost is one-time FLA/Triton kernel JIT + autotune for the `linear_attention` path (`chunk_gated_delta_rule` + `causal_conv1d`), which is process-global and shared with the rest of the linear-attention test family. Trimming this one test would just shift the compile cost to the next linear-attention test. The effective lever is a persistent `TRITON_CACHE_DIR` at the CI level (the job currently recompiles from scratch on each of its retry attempts), which is better addressed separately.

## Test plan

- These tests are CUDA-only (`pytest.mark.skipif(not torch.cuda.is_available())` / `@_requires_cuda`), and no GPU is available in the dev environment used to prepare this change.
- Verified statically: both files still collect cleanly (`pytest --collect-only`), the tiny-config fixtures resolve, and the `from_pretrained -> from_config(cfg)` delegation path / assertions are unchanged.
- Full GPU verification will run in `L0_Unit_Tests_GPU` CI.