### PR TITLE
perf(DSV4): use generic checkpoint wrapper for activation checkpointing

### DIFF
--- a/nemo_automodel/components/models/deepseek_v4/model.py
+++ b/nemo_automodel/components/models/deepseek_v4/model.py
@@ -47,7 +47,6 @@ from typing import Any, Optional, Union
 
 import torch
 import torch.nn as nn
-from torch.utils.checkpoint import checkpoint
 from transformers.modeling_outputs import CausalLMOutputWithPast
 
 from nemo_automodel.components.models.common import (
@@ -164,11 +163,6 @@ class DeepseekV4Block(nn.Module):
         )
         self.attn_hc = DeepseekV4HyperConnection(**hc_kwargs)
         self.ffn_hc = DeepseekV4HyperConnection(**hc_kwargs)
-        self.activation_checkpointing = False
-
-    def set_activation_checkpointing(self, enabled: bool = True) -> None:
-        """Enable block-local checkpointing that avoids replaying MoE dispatch."""
-        self.activation_checkpointing = enabled
 
     def forward(
         self,
@@ -213,12 +207,8 @@ class DeepseekV4Block(nn.Module):
             collapsed = (pre.unsqueeze(-1) * hidden_streams).sum(dim=2).to(hidden_streams.dtype)
             return collapsed, post, comb
 
-        if self.activation_checkpointing and torch.is_grad_enabled():
-            x = checkpoint(attention_site, x, use_reentrant=False)
-            collapsed, post, comb = checkpoint(ffn_prepare, x, use_reentrant=False)
-        else:
-            x = attention_site(x)
-            collapsed, post, comb = ffn_prepare(x)
+        x = attention_site(x)
+        collapsed, post, comb = ffn_prepare(x)
 
         # Hash-routing layers need the current batch's input_ids to do the
         # tid2eid lookup; stash it on the gate just before the MoE call.

--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -328,9 +328,7 @@ def apply_ac(
     for parent_layers, layer_id, block in _iter_transformer_and_mtp_blocks(model):
         if mtp_repeated and id(block) in mtp_block_ids:
             continue
-        if ignore_router and hasattr(block, "set_activation_checkpointing"):
-            block.set_activation_checkpointing(True)
-        elif ignore_router:
+        if ignore_router:
             block = ptd_checkpoint_wrapper(
                 block,
                 preserve_rng_state=True,

--- a/tests/unit_tests/moe/test_parallelizer.py
+++ b/tests/unit_tests/moe/test_parallelizer.py
@@ -540,7 +540,7 @@ def test_apply_ac_warns_when_router_is_recomputed(monkeypatch):
     logger_mock.warning.assert_not_called()
 
 
-def test_apply_ac_uses_block_local_checkpointing_when_available(monkeypatch):
+def test_apply_ac_uses_generic_wrapper_even_when_block_local_checkpointing_is_available(monkeypatch):
     P = _import_parallelizer_with_stubs(monkeypatch)
 
     class BlockWithLocalAC(DummyBlock):
@@ -553,14 +553,17 @@ def test_apply_ac_uses_block_local_checkpointing_when_available(monkeypatch):
 
     block = BlockWithLocalAC()
     model = DummyModel([block])
-    wrapper_mock = MagicMock()
+    wrapped = object()
+    wrapper_mock = MagicMock(return_value=wrapped)
     monkeypatch.setattr(P, "ptd_checkpoint_wrapper", wrapper_mock)
 
     P.apply_ac(model, ignore_router=True, hidden_size=7168, num_experts=256)
 
-    wrapper_mock.assert_not_called()
-    assert block.activation_checkpointing is True
-    assert model.layers.registered["0"] is block
+    wrapper_mock.assert_called_once()
+    assert wrapper_mock.call_args.kwargs["preserve_rng_state"] is True
+    assert callable(wrapper_mock.call_args.kwargs["context_fn"])
+    assert block.activation_checkpointing is False
+    assert model.layers.registered["0"] is wrapped
 
 
 def test_apply_ac_custom_policy_respects_hidden_and_expert_dims(monkeypatch):


### PR DESCRIPTION
## What

Route MoE activation checkpointing through the generic PyTorch checkpoint wrapper even when a block exposes `set_activation_checkpointing`.

This replaces the previous DeepSeek V4 routed-expert checkpointing implementation in this PR. With `ignore_router_for_ac=True`, `apply_ac` now always uses `ptd_checkpoint_wrapper(..., context_fn=selective_checkpointing_context_fn)` instead of calling a model-specific block-local AC hook.

## Why

This is a narrower experiment for the full-block AC behavior: it removes the DSV4-specific AC path and lets the existing MoE parallelizer policy decide which ops are saved vs recomputed.

## Validation

- `python -m pytest -q tests/unit_tests/moe/test_parallelizer.py -k 'activation or checkpoint or ignore_router or apply_ac'`
  - `22 passed, 43 deselected`
- `ruff check nemo_automodel/components/models/deepseek_v4/model.py nemo_automodel/components/moe/parallelizer.py tests/unit_tests/moe/test_parallelizer.py`
  - `All checks passed`
- `python -m compileall -q nemo_automodel/components/models/deepseek_v4/model.py`

### DSV4 4k non-packed run

- Run: https://wandb.ai/Nemo-automodel/huiyingl_workspace/runs/9dao4gol
- Slurm: `13064157`, completed `30/30`, exit `0:0`, elapsed `00:10:09`
- Config shape: `seq_length=4096`, `packed_sequence_size=0`, `cp=1`, `pp=4`, `ep=32`, 16 nodes
- Memory:
  - step 0: `32.46 GiB`
  - steps 1-29: `40.96-40.97 GiB`
  - peak logged: `40.97 GiB`
- Compared against the earlier matching run https://wandb.ai/Nemo-automodel/huiyingl_workspace/runs/u4mrj2fi, whose steady memory was about `56.19 GiB`; this run is about `15.2 GiB` lower at steady state.

<img width="589" height="503" alt="image" src="https://github.com/user-attachments/assets/a28c358e-6cf5-4420-b6ea-5469e38bd1ff" />
