### PR TITLE
ci: add time budgets for 12 new timeout failures

### DIFF
--- a/examples/llm_finetune/glm/glm_5.1_hellaswag_pp.yaml
+++ b/examples/llm_finetune/glm/glm_5.1_hellaswag_pp.yaml
@@ -100,4 +100,5 @@ optimizer:
   weight_decay: 0
 
 ci:
+  time: "00:30:00"
   nodes: 32

--- a/examples/llm_finetune/mimo_v2_flash/mimo_v2_flash_hellaswag.yaml
+++ b/examples/llm_finetune/mimo_v2_flash/mimo_v2_flash_hellaswag.yaml
@@ -135,5 +135,6 @@ wandb:
   mode: online
 
 ci:
+  time: "00:15:00"
   # pp_size(4) * ep_size(32) = 128 GPUs => 16 nodes (8 H100/node).
   nodes: 16

--- a/examples/vlm_finetune/gemma3/gemma3_vl_4b_cord_v2.yaml
+++ b/examples/vlm_finetune/gemma3/gemma3_vl_4b_cord_v2.yaml
@@ -100,4 +100,5 @@ freeze_config:
 #   wandb_save_dir:
 
 ci:
+  time: "00:15:00"
   recipe_owner: akoumpa

--- a/examples/vlm_finetune/gemma4/gemma4_26b_a4b_moe_packing.yaml
+++ b/examples/vlm_finetune/gemma4/gemma4_26b_a4b_moe_packing.yaml
@@ -102,6 +102,7 @@ freeze_config:
   freeze_language_model: false
 
 ci:
+  time: "00:20:00"
   env_vars:
     MAX_STEPS: 10
 

--- a/examples/vlm_finetune/gemma4/gemma4_31b_te.yaml
+++ b/examples/vlm_finetune/gemma4/gemma4_31b_te.yaml
@@ -115,4 +115,5 @@ freeze_config:
 #   name: <your-run-name>
 
 ci:
+  time: "00:15:00"
   recipe_owner: khazic

--- a/examples/vlm_finetune/gemma4/gemma4_4b_te.yaml
+++ b/examples/vlm_finetune/gemma4/gemma4_4b_te.yaml
@@ -111,4 +111,5 @@ freeze_config:
 #   name: <your-run-name>
 
 ci:
+  time: "00:15:00"
   recipe_owner: khazic

--- a/examples/vlm_finetune/mistral/ministral3_14b_medpix.yaml
+++ b/examples/vlm_finetune/mistral/ministral3_14b_medpix.yaml
@@ -102,4 +102,5 @@ freeze_config:
 #   save_dir:
 
 ci:
+  time: "00:15:00"
   recipe_owner: akoumpa

--- a/examples/vlm_finetune/mistral/ministral3_8b_medpix.yaml
+++ b/examples/vlm_finetune/mistral/ministral3_8b_medpix.yaml
@@ -102,4 +102,5 @@ freeze_config:
 #   save_dir:
 
 ci:
+  time: "00:15:00"
   recipe_owner: akoumpa

--- a/examples/vlm_finetune/qwen3_5/qwen3_6_27b.yaml
+++ b/examples/vlm_finetune/qwen3_5/qwen3_6_27b.yaml
@@ -115,6 +115,7 @@ optimizer:
   weight_decay: 0.1
 
 ci:
+  time: "00:15:00"
   env_vars:
     MAX_STEPS: 10
 

--- a/examples/vlm_finetune/qwen3_5/qwen3_6_27b_lora.yaml
+++ b/examples/vlm_finetune/qwen3_5/qwen3_6_27b_lora.yaml
@@ -128,6 +128,7 @@ optimizer:
   weight_decay: 0.01
 
 ci:
+  time: "00:15:00"
   env_vars:
     MAX_STEPS: 10
 

--- a/examples/vlm_finetune/qwen3_5_moe/qwen3_6_35b_medpix_ep8cp2_4k.yaml
+++ b/examples/vlm_finetune/qwen3_5_moe/qwen3_6_35b_medpix_ep8cp2_4k.yaml
@@ -120,3 +120,6 @@ wandb:
   group: qwen3_6_35b_medpix_ep8cp_parity_4k_100steps
   tags: [qwen3.6-35b, medpix, ep8, cp2, 4k, parity]
   dir: logs/qwen3_6_35b_medpix_ep8cp2_4k_100steps/wandb  # pragma: allowlist secret
+
+ci:
+  time: "00:15:00"

--- a/examples/vlm_finetune/stepfun/step3p7_medpix_200b_ep32pp4.yaml
+++ b/examples/vlm_finetune/stepfun/step3p7_medpix_200b_ep32pp4.yaml
@@ -137,5 +137,6 @@ wandb:
   dir: <your_wandb_save_dir>
 
 ci:
+  time: "00:30:00"
   # pp_size(4) * ep_size(32) = 128 GPUs => 16 nodes (8 H100/node).
   nodes: 16


### PR DESCRIPTION
# What does this PR do ?

9 tests set to 00:15:00 (training completed within 10 min, just need ckpt time), gemma4_26b_a4b_moe_packing set to 00:20:00 (setup never finished in 10 min, 1 node), glm_5.1_hellaswag_pp and step3p7_medpix_200b_ep32pp4 set to 00:30:00 (multi-node setup also never finished; sibling glm_5 at same 32 nodes uses 00:45:00)

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
