### PR TITLE
cp: `fix(loss): reuse LM head gather for MTP loss (2694)` into `r0.5.0`

### DIFF
--- a/examples/llm_finetune/nemotron/nemotron_ultra_v3_hellaswag_peft.yaml
+++ b/examples/llm_finetune/nemotron/nemotron_ultra_v3_hellaswag_peft.yaml
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 # Recipe validated on 4 × H100 nodes (32x 80 GB GPUs) under Slurm.
+# Uses gradient accumulation on 32 H100s to leave enough workspace headroom for
+# the Nemotron-Ultra MoE grouped-GEMM backward path.
 #
 # To run on a 4-node Slurm allocation, drive torchrun from inside an
 # ``srun`` step that resolves MASTER_ADDR from the allocation and forwards
@@ -32,7 +34,7 @@ step_scheduler:
   num_epochs: 1
   max_steps: 100
   global_batch_size: 128
-  local_batch_size: 4
+  local_batch_size: 2
   ckpt_every_steps: 20
   val_every_steps: 20
 
@@ -137,4 +139,5 @@ lr_scheduler:
 ci:
   # pp_size(1) * ep_size(32) = 32 GPUs => 4 nodes (8 H100/node).
   recipe_owner: adil-a
+  time: "00:30:00"
   nodes: 4

--- a/examples/llm_finetune/nemotron/nemotron_ultra_v3_squad.yaml
+++ b/examples/llm_finetune/nemotron/nemotron_ultra_v3_squad.yaml
@@ -12,16 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# FULL supervised fine-tune of Nemotron-3-Ultra-550B-A55B across 16 x H100 nodes (128 GPUs, EP=64).
+# FULL supervised fine-tune of Nemotron-3-Ultra-550B-A55B across 32 x H100 nodes
+# (256 GPUs, PP=4, EP=64).
 # Mirrors nemotron_ultra_v3_hellaswag_peft.yaml but trains ALL parameters (no `peft:` block),
-# scaled up for the full-FT memory footprint (16 nodes, EP=64, activation checkpointing, full
-# Adam optimizer state). Real router (fake_balanced_gate=false) and the repeated MTP head are kept.
+# scaled up for the full-FT memory footprint (32 nodes, PP=4, EP=64, activation checkpointing, full
+# Adam optimizer state). Real router (fake_balanced_gate=false), HybridEP dispatch,
+# and the repeated MTP head are kept.
 #
-# To run on a 16-node Slurm allocation, drive torchrun from an srun step:
+# To run on a 32-node Slurm allocation, drive torchrun from an srun step:
 #
 #   MASTER_ADDR=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)
-#   srun --ntasks-per-node=1 --nodes=16 bash -c '
-#     torchrun --nnodes=16 --nproc-per-node=8 \
+#   srun --ntasks-per-node=1 --nodes=32 bash -c '
+#     torchrun --nnodes=32 --nproc-per-node=8 \
 #       --rdzv-backend=c10d --rdzv-endpoint="$MASTER_ADDR":29500 \
 #       --node-rank=$SLURM_NODEID \
 #       examples/llm_finetune/finetune.py \
@@ -30,10 +32,10 @@
 recipe: TrainFinetuneRecipeForNextTokenPrediction
 
 step_scheduler:
-  num_epochs: 3
-  max_steps: 100
-  global_batch_size: 128  # local_batch_size(1) * dp_size(128) -> 1 microbatch/GPU/step
-  local_batch_size: 1
+  num_epochs: 1
+  max_steps: 17
+  global_batch_size: 256  # local_batch_size(4) * dp_size(64) -> no grad accumulation.
+  local_batch_size: 4
   ckpt_every_steps: 50
   val_every_steps: 50
 
@@ -62,7 +64,7 @@ model:
     linear: te
     rms_norm: te
     experts: gmm
-    dispatcher: deepep
+    dispatcher: hybridep
     enable_fsdp_optimizations: false
 
 checkpoint:
@@ -75,11 +77,21 @@ distributed:
   strategy: fsdp2
   tp_size: 1
   cp_size: 1
-  pp_size: 1
+  pp_size: 4
   ep_size: 64
   activation_checkpointing: true
+
+  pipeline:
+    pp_schedule: interleaved1f1b
+    pp_microbatch_size: 1
+    layers_per_stage: 14  # 108 layers / 8 virtual stages = 2 virtual stages per PP rank.
+    round_virtual_stages_to_pp_multiple: down
+    scale_grads_in_schedule: false
+    patch_inner_model: false
+    patch_causal_lm_model: false
+
   moe:
-    reshard_after_forward: true
+    reshard_after_forward: false
     wrap_outer_model: false
 
 loss_fn:
@@ -122,9 +134,15 @@ lr_scheduler:
   min_lr: 1.0e-6
 
 ci:
-  # pp_size(1) * ep_size(64) = 64 GPUs => 8 nodes (8 H100/node).
+  # pp_size(4) * ep_size(64) = 256 GPUs => 32 nodes (8 H100/node).
   recipe_owner: adil-a
-  nodes: 8
+  nodes: 32
+  time: "00:30:00"
+  max_steps: 17
+  env_vars:
+    PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True"
+    NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN: "8"
+    NUM_OF_STAGES_G2S_COMBINE_API: "4"
 
 # wandb:
 #   project: my-project

--- a/nemo_automodel/components/loss/mtp.py
+++ b/nemo_automodel/components/loss/mtp.py
@@ -19,7 +19,12 @@ import torch
 import torch.nn as nn
 
 from nemo_automodel.components.loss.linear_ce import FusedLinearCrossEntropy
-from nemo_automodel.components.loss.utils import _get_final_hidden_states, _get_lm_head_module, calculate_loss
+from nemo_automodel.components.loss.utils import (
+    _get_final_hidden_states,
+    _get_lm_head_module,
+    _get_lm_head_weight,
+    calculate_loss,
+)
 from nemo_automodel.components.models.common.mtp import get_mtp_loss_scaling_factor, roll_tensor
 
 
@@ -35,6 +40,7 @@ def calculate_mtp_loss(
     ignore_index: int = -100,
     cu_seqlens: Optional[torch.Tensor] = None,
     seq_idx: Optional[torch.Tensor] = None,
+    lm_weight: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """Compute the DeepSeek-V3 Multi-Token Prediction auxiliary loss.
 
@@ -63,6 +69,9 @@ def calculate_mtp_loss(
             Equality classes are what matter; absolute values can be any
             ints. Takes precedence over ``cu_seqlens``. Used to mask label
             rolls whose source position lies in a different sub-sequence.
+        lm_weight: Optional caller-materialized LM-head weight. Supplying this
+            lets the main loss and all MTP depths share one DTensor
+            ``full_tensor()`` gather on the FusedLinearCrossEntropy path.
 
     Returns:
         Scalar MTP loss with autograd graph.
@@ -84,6 +93,15 @@ def calculate_mtp_loss(
     D = len(mtp_outputs)
     cur_labels = labels
     total = mtp_outputs[0].new_zeros(())
+
+    # Materialize the (possibly DTensor-sharded) LM head ONCE for all depths
+    # under FusedLinearCrossEntropy. calculate_loss would otherwise re-gather it
+    # (full_tensor) per depth; each gathered copy is retained for backward and
+    # they accumulate on-device -> OOM for large-vocab MoE. One shared gather is
+    # numerically identical (same weight); grads from every depth accumulate into
+    # it and collapse to a single reduce-scatter on the sharded parameter.
+    if isinstance(loss_fn, FusedLinearCrossEntropy) and lm_weight is None:
+        lm_weight = _get_lm_head_weight(model)
 
     if seq_idx is None and cu_seqlens is not None:
         cs = cu_seqlens
@@ -143,6 +161,7 @@ def calculate_mtp_loss(
                 hidden_states=mtp_output,
                 labels=masked,
                 model=model,
+                lm_weight=lm_weight,
                 num_label_tokens=num_label_tokens,
             )
         else:
@@ -222,12 +241,18 @@ class PipelineCausalLMLoss(nn.Module):
             mtp_per_depth_logits = getattr(output, "mtp_per_depth_logits", None)
             model_scaling_factor = getattr(output, "mtp_loss_scaling_factor", get_mtp_loss_scaling_factor(self.model))
 
+        # Gather the LM head at most once and thread it through the main loss and
+        # every MTP depth (avoids redundant per-call full_tensor() gathers).
+        shared_lm_weight = (
+            _get_lm_head_weight(self.model) if isinstance(self.loss_fn, FusedLinearCrossEntropy) else None
+        )
         loss = calculate_loss(
             self.loss_fn,
             logits=logits,
             labels=labels,
             model=self.model,
             hidden_states=hidden_states,
+            lm_weight=shared_lm_weight,
         )
         if (mtp_per_depth_h is not None or mtp_per_depth_logits is not None) and self.model.training:
             scaling_factor = self.scaling_factor if self.scaling_factor is not None else model_scaling_factor
@@ -241,6 +266,7 @@ class PipelineCausalLMLoss(nn.Module):
                 ignore_index=self.ignore_index,
                 cu_seqlens=self.cu_seqlens,
                 seq_idx=seq_idx_mb,
+                lm_weight=shared_lm_weight,
             )
         return loss
 

--- a/nemo_automodel/components/loss/utils.py
+++ b/nemo_automodel/components/loss/utils.py
@@ -85,7 +85,14 @@ def calculate_loss(loss_fn, **kwargs) -> torch.Tensor:
     if isinstance(loss_fn, FusedLinearCrossEntropy):
         model = kwargs.pop("model")
         labels = kwargs.pop("labels")
-        lm_head = _get_lm_head_weight(model)
+        # Reuse a caller-materialized LM head when provided so a single
+        # full_tensor() all-gather is shared across the main loss and every MTP
+        # depth (see calculate_mtp_loss). Re-gathering the (vocab x hidden) head
+        # per call leaves a copy retained for backward each time; they accumulate
+        # on-device and OOM large-vocab MoE (e.g. Nemotron-Ultra, 256k vocab).
+        lm_head = kwargs.pop("lm_weight", None)
+        if lm_head is None:
+            lm_head = _get_lm_head_weight(model)
         loss_fn_kwargs.update(
             {
                 "hidden_states": kwargs.pop("hidden_states"),
@@ -94,6 +101,7 @@ def calculate_loss(loss_fn, **kwargs) -> torch.Tensor:
             }
         )
     else:
+        kwargs.pop("lm_weight", None)  # logit-based losses do not need the LM head
         loss_fn_kwargs.update(
             {
                 "logits": kwargs.pop("logits"),

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -72,7 +72,7 @@ from nemo_automodel.components.loggers.wandb_utils import suppress_wandb_log_mes
 from nemo_automodel.components.loss.linear_ce import FusedLinearCrossEntropy
 from nemo_automodel.components.loss.masked_ce import MaskedCrossEntropy
 from nemo_automodel.components.loss.mtp import calculate_mtp_loss
-from nemo_automodel.components.loss.utils import calculate_loss
+from nemo_automodel.components.loss.utils import _get_lm_head_weight, calculate_loss
 from nemo_automodel.components.moe.megatron.moe_utils import MoEAuxLossAutoScaler
 from nemo_automodel.components.quantization.fp8 import build_fp8_config
 from nemo_automodel.components.training.model_output_utils import get_final_hidden_states
@@ -1198,12 +1198,19 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
                 else:
                     out = model(**batch)
 
+                # Gather the LM head once and share it across the main loss and
+                # all MTP depths (FusedLinearCrossEntropy path) to avoid redundant
+                # full_tensor() gathers that accumulate on-device and OOM.
+                shared_lm_weight = (
+                    _get_lm_head_weight(model) if isinstance(self.loss_fn, FusedLinearCrossEntropy) else None
+                )
                 local_loss = calculate_loss(
                     self.loss_fn,
                     logits=getattr(out, "logits", out),
                     labels=labels,
                     model=model,
                     hidden_states=get_final_hidden_states(out),
+                    lm_weight=shared_lm_weight,
                     num_label_tokens=num_label_tokens,
                 )
                 mtp_per_depth_h = getattr(out, "mtp_per_depth_h", None)
@@ -1224,6 +1231,7 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
                         ignore_index=mtp_cfg.ignore_index,
                         # mask cross-boundary MTP label rolls in THD packing (matches the PP path)
                         cu_seqlens=batch.get("cu_seqlens"),
+                        lm_weight=shared_lm_weight,
                     )
                 loss_buffer.append(local_loss.clone().detach())
                 if is_train:

--- a/tests/ci_tests/README.md
+++ b/tests/ci_tests/README.md
@@ -49,6 +49,7 @@ ci:
   time: "00:25:00"                # Required. SLURM wall time (HH:MM:SS)
   nodes: 2                        # Optional. SLURM node count (default: 1)
   node_multiplier: true           # Optional. Dynamic node scaling
+  max_steps: 50                   # Optional. Override max training steps for CI
   local_batch_size: 2             # Optional. Override batch size for CI
   nproc_per_node: 1               # Optional. GPUs per node, overrides cluster default (CI var: CONFIG_NPROC_PER_NODE)
   vllm_deploy: true               # Optional. Enable vLLM deployment test

--- a/tests/ci_tests/utils/generate_ci_tests.py
+++ b/tests/ci_tests/utils/generate_ci_tests.py
@@ -120,6 +120,7 @@ CI_KEY_TO_VAR = {
     "time": "TIME",
     "nodes": "TEST_NODE_COUNT",
     "node_multiplier": "NODE_MULTIPLIER",
+    "max_steps": "MAX_STEPS",
     "local_batch_size": "LOCAL_BATCH_SIZE",
     "ep_size": "EP_SIZE",
     "recipe_owner": "RECIPE_OWNER",

--- a/tests/unit_tests/loss/test_mtp_lm_head_gather.py
+++ b/tests/unit_tests/loss/test_mtp_lm_head_gather.py
@@ -1,0 +1,275 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the MTP-loss LM-head gather-once optimization.
+
+``calculate_mtp_loss`` dispatches each MTP depth through ``calculate_loss``.
+On the ``FusedLinearCrossEntropy`` path, ``calculate_loss`` materializes the LM
+head via ``DTensor.full_tensor()`` (an all-gather) because cut_cross_entropy
+needs the dense ``[vocab, hidden]`` weight. Re-gathering it for the main loss
+*and* every MTP depth left ``1 + D`` gathered copies retained for backward,
+which accumulate on-device and OOM large-vocab MoE (e.g. Nemotron-Ultra,
+256k vocab; eos job 344476745). The fix gathers the head ONCE and threads it
+through the main loss and all depths via the new ``lm_weight`` argument.
+
+These tests assert the change is (a) numerically identical to gathering per
+depth, (b) gathers the head exactly once, (c) is a no-op gather when the weight
+is supplied, (d) preserves gradients, and (e) still works for the sharded
+DTensor LM head where the OOM occurred.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+import nemo_automodel.components.loss.linear_ce as _lce
+import nemo_automodel.components.loss.mtp as _mtp
+import nemo_automodel.components.loss.utils as _lutils
+from nemo_automodel.components.loss.linear_ce import FusedLinearCrossEntropy
+from nemo_automodel.components.loss.mtp import calculate_mtp_loss
+from nemo_automodel.components.models.common.mtp import roll_tensor
+
+H, V, B, S, D = 8, 32, 2, 6, 2
+IGN, SF, NLT = -100, 0.1, 20
+
+
+@pytest.fixture
+def ref_cce(monkeypatch):
+    """Run the FusedLinearCrossEntropy path on CPU with a reference torch CE.
+
+    We are validating the LM-head gather threading, not the cut_cross_entropy
+    kernel, so a dense reference matmul+CE (matching cut_cross_entropy's
+    sum-reduction / shift=False contract) is the right oracle and keeps the
+    test CPU-only.
+    """
+
+    def _ref(
+        hidden, lm_weight, targets, ignore_index=-100, softcap=None, reduction="sum", shift=False, filter_eps=None
+    ):
+        logits = hidden.float() @ lm_weight.float().t()
+        return F.cross_entropy(
+            logits.reshape(-1, logits.shape[-1]),
+            targets.reshape(-1).long(),
+            ignore_index=ignore_index,
+            reduction=reduction,
+        )
+
+    monkeypatch.setattr(_lce, "linear_cross_entropy", _ref, raising=False)
+    monkeypatch.setattr(_lce, "HAVE_CUT_CROSS_ENTROPY", True, raising=False)
+
+
+class _TinyModel(nn.Module):
+    def __init__(self, weight: torch.Tensor | None = None):
+        super().__init__()
+        self.lm_head = nn.Linear(H, V, bias=False)
+        if weight is not None:
+            self.lm_head.weight = nn.Parameter(weight)
+        self.training = True
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+
+def _reference_mtp_loss(hs, labels, W):
+    """Independent MTP loss: per-depth roll/mask + dense CE, summed and scaled."""
+    cur = labels.clone()
+    total = torch.zeros(())
+    for k, h in enumerate(hs):
+        cur = roll_tensor(cur, shifts=-1, dim=-1)
+        masked = cur.clone()
+        masked[..., -min(k + 1, labels.shape[-1]) :] = IGN
+        logits = h.float() @ W.float().t()
+        total = (
+            total
+            + F.cross_entropy(logits.reshape(-1, V), masked.reshape(-1).long(), ignore_index=IGN, reduction="sum") / NLT
+        )
+    return total * (SF / D)
+
+
+def _inputs(requires_grad=False, seed=0):
+    torch.manual_seed(seed)
+    hs = [torch.randn(B, S, H, requires_grad=requires_grad) for _ in range(D)]
+    labels = torch.randint(0, V, (B, S))
+    return hs, labels
+
+
+def _count_gathers():
+    """Patch _get_lm_head_weight in both namespaces with a counting wrapper."""
+    n = {"c": 0}
+    real = _lutils._get_lm_head_weight
+
+    def spy(model):
+        n["c"] += 1
+        return real(model)
+
+    return (
+        n,
+        mock.patch.object(_mtp, "_get_lm_head_weight", side_effect=spy),
+        mock.patch.object(_lutils, "_get_lm_head_weight", side_effect=spy),
+    )
+
+
+def test_mtp_loss_matches_reference(ref_cce):
+    torch.manual_seed(1)
+    m = _TinyModel()
+    hs, labels = _inputs()
+    got = calculate_mtp_loss(
+        FusedLinearCrossEntropy(reduction="sum"),
+        mtp_per_depth_h=[h.clone() for h in hs],
+        labels=labels,
+        model=m,
+        scaling_factor=SF,
+        num_label_tokens=NLT,
+        ignore_index=IGN,
+    )
+    expected = _reference_mtp_loss(hs, labels, m.lm_head.weight.detach())
+    torch.testing.assert_close(got, expected, rtol=1e-5, atol=1e-6)
+
+
+def test_lm_head_gathered_once(ref_cce):
+    torch.manual_seed(1)
+    m = _TinyModel()
+    hs, labels = _inputs()
+    n, p1, p2 = _count_gathers()
+    with p1, p2:
+        calculate_mtp_loss(
+            FusedLinearCrossEntropy(reduction="sum"),
+            mtp_per_depth_h=[h.clone() for h in hs],
+            labels=labels,
+            model=m,
+            scaling_factor=SF,
+            num_label_tokens=NLT,
+            ignore_index=IGN,
+        )
+    assert n["c"] == 1, f"expected exactly 1 LM-head gather, got {n['c']} (pre-fix == 1+D up the stack)"
+
+
+def test_lm_weight_passthrough_skips_gather(ref_cce):
+    torch.manual_seed(1)
+    m = _TinyModel()
+    hs, labels = _inputs()
+    n, p1, p2 = _count_gathers()
+    with p1, p2:
+        calculate_mtp_loss(
+            FusedLinearCrossEntropy(reduction="sum"),
+            mtp_per_depth_h=[h.clone() for h in hs],
+            labels=labels,
+            model=m,
+            scaling_factor=SF,
+            num_label_tokens=NLT,
+            ignore_index=IGN,
+            lm_weight=m.lm_head.weight.detach(),
+        )
+    assert n["c"] == 0, f"caller-supplied lm_weight must avoid any gather, got {n['c']}"
+
+
+def test_mtp_loss_grads_match_reference(ref_cce):
+    hs1, labels = _inputs(requires_grad=True)
+    m = _TinyModel()
+    W2 = m.lm_head.weight.detach().clone().requires_grad_(True)
+    hs2 = [h.detach().clone().requires_grad_(True) for h in hs1]
+    calculate_mtp_loss(
+        FusedLinearCrossEntropy(reduction="sum"),
+        mtp_per_depth_h=hs1,
+        labels=labels,
+        model=m,
+        scaling_factor=SF,
+        num_label_tokens=NLT,
+        ignore_index=IGN,
+    ).backward()
+    _reference_mtp_loss(hs2, labels, W2).backward()
+    torch.testing.assert_close(m.lm_head.weight.grad, W2.grad, rtol=1e-4, atol=1e-6)
+    for a, b in zip(hs1, hs2):
+        torch.testing.assert_close(a.grad, b.grad, rtol=1e-4, atol=1e-6)
+
+
+def test_non_fused_path_does_not_gather_lm_head():
+    """Logit-based losses (non-Fused) must not trigger the LM-head weight gather."""
+    hs, labels = _inputs()
+
+    def fake_calc(loss_fn, **kw):  # avoid invoking a real loss
+        return torch.zeros((), requires_grad=True)
+
+    class _LogitLoss(nn.Module):
+        pass
+
+    m = _TinyModel()
+    with (
+        mock.patch.object(_mtp, "calculate_loss", side_effect=fake_calc),
+        mock.patch.object(
+            _mtp, "_get_lm_head_weight", side_effect=AssertionError("non-fused path must not gather the LM head")
+        ),
+    ):
+        calculate_mtp_loss(
+            _LogitLoss(),
+            mtp_per_depth_h=[h.clone() for h in hs],
+            labels=labels,
+            model=m,
+            scaling_factor=SF,
+            ignore_index=IGN,
+        )
+
+
+def test_sharded_lm_head_gathers_once_and_matches(ref_cce):
+    """Sharded DTensor LM head (the OOM scenario): exactly one all-gather, and
+    loss + grads match the unsharded reference."""
+    from torch.distributed import Backend
+
+    if "threaded" not in getattr(Backend, "backend_type_map", {}):
+        pytest.skip("threaded c10d backend unavailable in this torch build")
+    try:
+        from tests.unit_tests.distributed.test_grad_utils import spawn_threads_and_init_comms
+    except Exception as e:  # pragma: no cover
+        pytest.skip(f"threaded dist harness unavailable: {e}")
+
+    from torch.distributed.device_mesh import init_device_mesh
+    from torch.distributed.tensor import Shard, distribute_tensor
+
+    @spawn_threads_and_init_comms(world_size=2)
+    def _body(self=None):
+        mesh = init_device_mesh("cpu", (2,), mesh_dim_names=("tp",))
+        torch.manual_seed(0)
+        W_full = torch.randn(V, H)
+        hs = [torch.randn(B, S, H, requires_grad=True) for _ in range(D)]
+        labels = torch.randint(0, V, (B, S))
+        m = _TinyModel(weight=distribute_tensor(W_full.clone(), mesh, [Shard(0)]))
+
+        n, p1, p2 = _count_gathers()
+        with p1, p2:
+            loss = calculate_mtp_loss(
+                FusedLinearCrossEntropy(reduction="sum"),
+                mtp_per_depth_h=hs,
+                labels=labels,
+                model=m,
+                scaling_factor=SF,
+                num_label_tokens=NLT,
+                ignore_index=IGN,
+            )
+        loss.backward()
+        assert n["c"] == 1, f"sharded head must gather once, got {n['c']}"
+
+        W2 = W_full.clone().requires_grad_(True)
+        hs2 = [h.detach().clone().requires_grad_(True) for h in hs]
+        _reference_mtp_loss(hs2, labels, W2).backward()
+        torch.testing.assert_close(
+            loss, _reference_mtp_loss([h.detach() for h in hs], labels, W_full), rtol=1e-5, atol=1e-6
+        )
+        torch.testing.assert_close(m.lm_head.weight.grad.full_tensor(), W2.grad, rtol=1e-4, atol=1e-6)
+
+    _body()


### PR DESCRIPTION
Cherry-pick of #2694 into `r0.5.0`.

Source workflow job: https://github.com/NVIDIA-NeMo/Automodel/actions/runs/27966487585/job/82761531511

Conflict resolution:
- Resolved the conflict in `tests/unit_tests/recipes/test_train_ft.py` by dropping the main-only CP-hook test hunk. The source merge commit only adjusted that pre-existing main test's mock signature, and `r0.5.0` does not contain the underlying CP-hook behavior.

Validation:
- `git diff --check origin/r0.5.0...HEAD`
- `uv run ruff check nemo_automodel/components/loss/mtp.py nemo_automodel/components/loss/utils.py nemo_automodel/recipes/llm/train_ft.py tests/unit_tests/loss/test_mtp_lm_head_gather.py`
- `uv run pytest -q tests/unit_tests/loss/test_mtp_cross_boundary.py tests/unit_tests/loss/test_mtp_lm_head_gather.py` (14 passed, 1 skipped)
