### PR TITLE
ci: add cluster_tag to gb200 benchmarks

### DIFF
--- a/examples/llm_benchmark/deepseek/deepseek_v3_sdpa_compile_gb200.yaml
+++ b/examples/llm_benchmark/deepseek/deepseek_v3_sdpa_compile_gb200.yaml
@@ -119,6 +119,7 @@ optimizer:
 ci:
   time: "04:00:00"
   nodes: 16
+  cluster_tag: gb200
   ep_size: 64
   env_vars:
     RDZV_TIMEOUT: "900"

--- a/examples/llm_benchmark/deepseek/deepseek_v3_sdpa_compile_mxfp8_gb200.yaml
+++ b/examples/llm_benchmark/deepseek/deepseek_v3_sdpa_compile_mxfp8_gb200.yaml
@@ -118,6 +118,7 @@ optimizer:
 ci:
   time: "04:00:00"
   nodes: 16
+  cluster_tag: gb200
   ep_size: 64
   env_vars:
     RDZV_TIMEOUT: "900"

--- a/examples/llm_benchmark/deepseek/deepseek_v3_sdpa_compile_te_gb200.yaml
+++ b/examples/llm_benchmark/deepseek/deepseek_v3_sdpa_compile_te_gb200.yaml
@@ -120,6 +120,7 @@ optimizer:
 ci:
   time: "04:00:00"
   nodes: 16
+  cluster_tag: gb200
   ep_size: 64
   env_vars:
     RDZV_TIMEOUT: "900"

--- a/examples/llm_benchmark/deepseek/deepseek_v3_sdpa_compile_torchmm_gb200.yaml
+++ b/examples/llm_benchmark/deepseek/deepseek_v3_sdpa_compile_torchmm_gb200.yaml
@@ -118,6 +118,7 @@ optimizer:
 ci:
   time: "04:00:00"
   nodes: 16
+  cluster_tag: gb200
   ep_size: 64
   env_vars:
     RDZV_TIMEOUT: "900"

--- a/examples/llm_benchmark/deepseek/deepseek_v3_te_deepep_gb200.yaml
+++ b/examples/llm_benchmark/deepseek/deepseek_v3_te_deepep_gb200.yaml
@@ -111,6 +111,7 @@ optimizer:
 ci:
   time: "04:00:00"
   nodes: 16
+  cluster_tag: gb200
   ep_size: 64
   env_vars:
     RDZV_TIMEOUT: "900"

--- a/examples/llm_benchmark/deepseek/deepseek_v3_te_mxfp8_gb200.yaml
+++ b/examples/llm_benchmark/deepseek/deepseek_v3_te_mxfp8_gb200.yaml
@@ -116,6 +116,7 @@ optimizer:
 ci:
   time: "04:00:00"
   nodes: 16
+  cluster_tag: gb200
   ep_size: 64
   env_vars:
     RDZV_TIMEOUT: "900"

--- a/examples/llm_benchmark/gpt_oss/gptoss_120b_te_deepep_gb200.yaml
+++ b/examples/llm_benchmark/gpt_oss/gptoss_120b_te_deepep_gb200.yaml
@@ -122,4 +122,5 @@ optimizer:
 ci:
   time: "00:40:00"
   nodes: 8
+  cluster_tag: gb200
   ep_size: 16

--- a/examples/llm_benchmark/gpt_oss/gptoss_120b_te_mxfp8_gb200.yaml
+++ b/examples/llm_benchmark/gpt_oss/gptoss_120b_te_mxfp8_gb200.yaml
@@ -140,4 +140,5 @@ optimizer:
 ci:
   time: "00:40:00"
   nodes: 8
+  cluster_tag: gb200
   ep_size: 16

--- a/examples/llm_benchmark/qwen/qwen3_moe_235b_te_deepep_gb200.yaml
+++ b/examples/llm_benchmark/qwen/qwen3_moe_235b_te_deepep_gb200.yaml
@@ -111,4 +111,5 @@ optimizer:
 ci:
   time: "01:00:00"
   nodes: 8
+  cluster_tag: gb200
   ep_size: 32

--- a/examples/llm_benchmark/qwen/qwen3_moe_235b_te_mxfp8_gb200.yaml
+++ b/examples/llm_benchmark/qwen/qwen3_moe_235b_te_mxfp8_gb200.yaml
@@ -113,4 +113,5 @@ optimizer:
 ci:
   time: "01:00:00"
   nodes: 8
+  cluster_tag: gb200
   ep_size: 32

--- a/examples/llm_benchmark/qwen/qwen3_moe_30b_compile_attn_gb200.yaml
+++ b/examples/llm_benchmark/qwen/qwen3_moe_30b_compile_attn_gb200.yaml
@@ -125,4 +125,5 @@ optimizer:
 ci:
   time: "00:40:00"
   nodes: 2
+  cluster_tag: gb200
   ep_size: 8

--- a/examples/llm_benchmark/qwen/qwen3_moe_30b_te_bf16_gb200.yaml
+++ b/examples/llm_benchmark/qwen/qwen3_moe_30b_te_bf16_gb200.yaml
@@ -123,4 +123,5 @@ optimizer:
 ci:
   time: "00:40:00"
   nodes: 2
+  cluster_tag: gb200
   ep_size: 8

--- a/examples/llm_benchmark/qwen/qwen3_moe_30b_te_deepep_gb200.yaml
+++ b/examples/llm_benchmark/qwen/qwen3_moe_30b_te_deepep_gb200.yaml
@@ -117,4 +117,5 @@ optimizer:
 ci:
   time: "00:40:00"
   nodes: 2
+  cluster_tag: gb200
   ep_size: 8

--- a/examples/llm_benchmark/qwen/qwen3_moe_30b_te_mxfp8_gb200.yaml
+++ b/examples/llm_benchmark/qwen/qwen3_moe_30b_te_mxfp8_gb200.yaml
@@ -135,4 +135,5 @@ optimizer:
 ci:
   time: "00:40:00"
   nodes: 2
+  cluster_tag: gb200
   ep_size: 8

--- a/examples/llm_benchmark/qwen/qwen3_moe_30b_torchmm_gb200.yaml
+++ b/examples/llm_benchmark/qwen/qwen3_moe_30b_torchmm_gb200.yaml
@@ -119,4 +119,5 @@ optimizer:
 ci:
   time: "00:40:00"
   nodes: 2
+  cluster_tag: gb200
   ep_size: 8


### PR DESCRIPTION
# What does this PR do ?

Add cluster_tag: gb200 to all 15 _gb200 benchmark configs (deepseek, gpt_oss, qwen) so they route to GB200 clusters under the new generic routing rule.

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
