### PR TITLE
docs: update container references to 26.06 and fix mount instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ The latest Automodel container can be found: [here](https://catalog.ngc.nvidia.c
 The container can be run with the following docker command:
 
 ```bash
-docker run --gpus all --network=host -it --rm --shm-size=32g nvcr.io/nvidia/nemo-automodel:26.04.00 /bin/bash
+docker run --gpus all --network=host -it --rm --shm-size=32g nvcr.io/nvidia/nemo-automodel:26.06.00 /bin/bash
 ```
 
 #### Mounting local Automodel directory into the container
@@ -24,7 +24,7 @@ To sync local Automodel directory into the container, mount the local directory 
 Example docker command:
 
 ```bash
-docker run --gpus all --network=host -it --rm -v <local-Automodel-path>:/opt/Automodel --shm-size=32g nvcr.io/nvidia/nemo-automodel:26.04.00 /bin/bash
+docker run --gpus all --network=host -it --rm -v <local-Automodel-path>:/opt/Automodel --shm-size=32g nvcr.io/nvidia/nemo-automodel:26.06.00 /bin/bash
 ```
 
 Within the container, cd into `/opt/Automodel/` and update the pyproject.toml and uv.lock file by running the following command:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ The latest Automodel container can be found: [here](https://catalog.ngc.nvidia.c
 The container can be run with the following docker command:
 
 ```bash
-docker run --gpus all --network=host -it --rm --shm-size=32g nvcr.io/nvidia/nemo-automodel:25.11.00 /bin/bash
+docker run --gpus all --network=host -it --rm --shm-size=32g nvcr.io/nvidia/nemo-automodel:26.04.00 /bin/bash
 ```
 
 #### Mounting local Automodel directory into the container
@@ -24,7 +24,7 @@ To sync local Automodel directory into the container, mount the local directory 
 Example docker command:
 
 ```bash
-docker run --gpus all --network=host -it --rm -v <local-Automodel-path>:/opt/Automodel --shm-size=32g nvcr.io/nvidia/nemo-automodel:25.11.00 /bin/bash
+docker run --gpus all --network=host -it --rm -v <local-Automodel-path>:/opt/Automodel --shm-size=32g nvcr.io/nvidia/nemo-automodel:26.04.00 /bin/bash
 ```
 
 Within the container, cd into `/opt/Automodel/` and update the pyproject.toml and uv.lock file by running the following command:

--- a/docs/guides/checkpointing.mdx
+++ b/docs/guides/checkpointing.mdx
@@ -283,7 +283,7 @@ When training inside a Docker container (see [Installation Guide](/get-started/i
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v "$(pwd)"/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 You can also set a custom checkpoint directory through the YAML config or CLI override:

--- a/docs/guides/checkpointing.mdx
+++ b/docs/guides/checkpointing.mdx
@@ -283,7 +283,7 @@ When training inside a Docker container (see [Installation Guide](/get-started/i
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v "$(pwd)"/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:25.11.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 You can also set a custom checkpoint directory through the YAML config or CLI override:

--- a/docs/guides/diffusion/finetune.mdx
+++ b/docs/guides/diffusion/finetune.mdx
@@ -51,8 +51,8 @@ pip3 install nemo-automodel
 Alternatively, if you run into dependency or driver issues, use the pre-built Docker container:
 
 ```bash
-docker pull nvcr.io/nvidia/nemo-automodel:26.02.00
-docker run --gpus all -it --rm --shm-size=8g nvcr.io/nvidia/nemo-automodel:26.02.00
+docker pull nvcr.io/nvidia/nemo-automodel:26.04.00
+docker run --gpus all -it --rm --shm-size=8g nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 <Info>

--- a/docs/guides/diffusion/finetune.mdx
+++ b/docs/guides/diffusion/finetune.mdx
@@ -51,8 +51,8 @@ pip3 install nemo-automodel
 Alternatively, if you run into dependency or driver issues, use the pre-built Docker container:
 
 ```bash
-docker pull nvcr.io/nvidia/nemo-automodel:26.04.00
-docker run --gpus all -it --rm --shm-size=8g nvcr.io/nvidia/nemo-automodel:26.04.00
+docker pull nvcr.io/nvidia/nemo-automodel:26.06.00
+docker run --gpus all -it --rm --shm-size=8g nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 <Info>

--- a/docs/guides/dllm/finetune.mdx
+++ b/docs/guides/dllm/finetune.mdx
@@ -50,8 +50,8 @@ pip3 install nemo-automodel
 Alternatively, use the pre-built Docker container:
 
 ```bash
-docker pull nvcr.io/nvidia/nemo-automodel:26.02.00
-docker run --gpus all -it --rm --shm-size=8g nvcr.io/nvidia/nemo-automodel:26.02.00
+docker pull nvcr.io/nvidia/nemo-automodel:26.04.00
+docker run --gpus all -it --rm --shm-size=8g nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 For the full set of installation methods, see the [installation guide](/get-started/installation).

--- a/docs/guides/dllm/finetune.mdx
+++ b/docs/guides/dllm/finetune.mdx
@@ -50,8 +50,8 @@ pip3 install nemo-automodel
 Alternatively, use the pre-built Docker container:
 
 ```bash
-docker pull nvcr.io/nvidia/nemo-automodel:26.04.00
-docker run --gpus all -it --rm --shm-size=8g nvcr.io/nvidia/nemo-automodel:26.04.00
+docker pull nvcr.io/nvidia/nemo-automodel:26.06.00
+docker run --gpus all -it --rm --shm-size=8g nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 For the full set of installation methods, see the [installation guide](/get-started/installation).

--- a/docs/guides/installation.mdx
+++ b/docs/guides/installation.mdx
@@ -250,19 +250,15 @@ cd Automodel
 # Step 2: Pull a compatible container image (replace the tag as needed).
 docker pull nvcr.io/nvidia/nemo-automodel:26.04.00
 
-# Step 3: Run the container with your local checkout mounted over /opt/Automodel.
+# Step 3: Run the container, sync the mounted checkout, and run a usage example.
 docker run --gpus all --network=host -it --rm \
   --shm-size=32g \
   -v "$(pwd)":/opt/Automodel \
-  nvcr.io/nvidia/nemo-automodel:26.04.00 /bin/bash
-```
-
-Inside the container, patch `pyproject.toml` / `uv.lock` for the PyTorch base image, then re-sync the environment:
-
-```bash
-cd /opt/Automodel
-bash docker/common/update_pyproject_pytorch.sh /opt/Automodel
-uv sync --locked --extra all --all-groups
+  nvcr.io/nvidia/nemo-automodel:26.04.00 /bin/bash -c "\
+    cd /opt/Automodel && \
+    bash docker/common/update_pyproject_pytorch.sh /opt/Automodel && \
+    uv sync --locked --extra all --all-groups && \
+    automodel examples/llm_finetune/llama3_2/llama3_2_1b_squad.yaml"
 ```
 
 <Warning>

--- a/docs/guides/installation.mdx
+++ b/docs/guides/installation.mdx
@@ -55,8 +55,8 @@ Use virtualenv (PyPI, Git, or editable install) when you need:
 Debian-based systems can have dependency conflicts with system packages. Containers provide isolation and consistency.
 
 ```bash
-docker pull nvcr.io/nvidia/nemo-automodel:26.04.00
-docker run --gpus all -it --rm --shm-size=8g nvcr.io/nvidia/nemo-automodel:26.04.00
+docker pull nvcr.io/nvidia/nemo-automodel:26.06.00
+docker run --gpus all -it --rm --shm-size=8g nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **Alternative: virtualenv** (if Docker is not available)
@@ -163,10 +163,10 @@ To verify the install, run `python -c "import nemo_automodel; print(nemo_automod
 ### Install with NeMo Docker Container
 You can use NeMo AutoModel with the NeMo Docker container. Pull the container by running:
 ```bash
-docker pull nvcr.io/nvidia/nemo-automodel:26.04.00
+docker pull nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 <Note>
-The above `docker` command uses the [`26.04.00`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-automodel?version=26.04.00) container. Use the [most recent container](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-automodel) version to ensure you get the latest version of AutoModel and its dependencies like PyTorch, Transformers, etc.
+The above `docker` command uses the [`26.06.00`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-automodel?version=26.06.00) container. Use the [most recent container](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-automodel) version to ensure you get the latest version of AutoModel and its dependencies like PyTorch, Transformers, etc.
 
 </Note>
 
@@ -175,7 +175,7 @@ Then you can enter the container using:
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v "$(pwd)"/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 <Info>
@@ -186,7 +186,7 @@ docker run --gpus all -it --rm \
   -v /path/to/your/checkpoints:/opt/Automodel/checkpoints \
   -v /path/to/your/datasets:/datasets \
   -v /path/to/your/hf_cache:/root/.cache/huggingface \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 </Info>
@@ -248,13 +248,13 @@ git clone https://github.com/NVIDIA-NeMo/Automodel.git
 cd Automodel
 
 # Step 2: Pull a compatible container image (replace the tag as needed).
-docker pull nvcr.io/nvidia/nemo-automodel:26.04.00
+docker pull nvcr.io/nvidia/nemo-automodel:26.06.00
 
 # Step 3: Run the container, sync the mounted checkout, and run a usage example.
 docker run --gpus all --network=host -it --rm \
   --shm-size=32g \
   -v "$(pwd)":/opt/Automodel \
-  nvcr.io/nvidia/nemo-automodel:26.04.00 /bin/bash -c "\
+  nvcr.io/nvidia/nemo-automodel:26.06.00 /bin/bash -c "\
     cd /opt/Automodel && \
     bash docker/common/update_pyproject_pytorch.sh /opt/Automodel && \
     uv sync --locked --extra all --all-groups && \

--- a/docs/guides/installation.mdx
+++ b/docs/guides/installation.mdx
@@ -55,8 +55,8 @@ Use virtualenv (PyPI, Git, or editable install) when you need:
 Debian-based systems can have dependency conflicts with system packages. Containers provide isolation and consistency.
 
 ```bash
-docker pull nvcr.io/nvidia/nemo-automodel:25.11.00
-docker run --gpus all -it --rm --shm-size=8g nvcr.io/nvidia/nemo-automodel:25.11.00
+docker pull nvcr.io/nvidia/nemo-automodel:26.04.00
+docker run --gpus all -it --rm --shm-size=8g nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **Alternative: virtualenv** (if Docker is not available)
@@ -163,10 +163,10 @@ To verify the install, run `python -c "import nemo_automodel; print(nemo_automod
 ### Install with NeMo Docker Container
 You can use NeMo AutoModel with the NeMo Docker container. Pull the container by running:
 ```bash
-docker pull nvcr.io/nvidia/nemo-automodel:25.11.00
+docker pull nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 <Note>
-The above `docker` command uses the [`25.11.00`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-automodel?version=25.11.00) container. Use the [most recent container](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-automodel) version to ensure you get the latest version of AutoModel and its dependencies like PyTorch, Transformers, etc.
+The above `docker` command uses the [`26.04.00`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-automodel?version=26.04.00) container. Use the [most recent container](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-automodel) version to ensure you get the latest version of AutoModel and its dependencies like PyTorch, Transformers, etc.
 
 </Note>
 
@@ -175,7 +175,7 @@ Then you can enter the container using:
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v "$(pwd)"/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:25.11.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 <Info>
@@ -186,7 +186,7 @@ docker run --gpus all -it --rm \
   -v /path/to/your/checkpoints:/opt/Automodel/checkpoints \
   -v /path/to/your/datasets:/datasets \
   -v /path/to/your/hf_cache:/root/.cache/huggingface \
-  nvcr.io/nvidia/nemo-automodel:25.11.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 </Info>
@@ -240,7 +240,7 @@ This installs AutoModel in editable mode, so changes to the code are immediately
 
 ### Mount the Repo into a NeMo Docker Container
 
-To run `Automodel` inside a NeMo container while **mounting your local repo**, follow these steps:
+To develop against your local checkout while reusing the container's pre-built dependencies, bind-mount your local `Automodel` directory over `/opt/Automodel`, overriding the source installed in the image:
 
 ```bash
 # Step 1: Clone the AutoModel repository.
@@ -248,22 +248,27 @@ git clone https://github.com/NVIDIA-NeMo/Automodel.git
 cd Automodel
 
 # Step 2: Pull a compatible container image (replace the tag as needed).
-docker pull nvcr.io/nvidia/nemo-automodel:25.11.00
+docker pull nvcr.io/nvidia/nemo-automodel:26.04.00
 
-# Step 3: Run the container, mount the repo, and run a quick sanity check.
-docker run --gpus all -it --rm \
-  -v $(pwd):/workspace/Automodel \         # Mount repo into container workspace
-  -v $(pwd)/Automodel:/opt/Automodel \     # Optional: Mount Automodel under /opt for flexibility
-  --shm-size=8g \                           # Increase shared memory for PyTorch/data loading
-  nvcr.io/nvidia/nemo-automodel:25.11.00 /bin/bash -c "\
-    cd /workspace/Automodel && \           # Enter the mounted repo
-    pip install -e . && \                  # Install Automodel in editable mode
-    automodel examples/llm_finetune/llama3_2/llama3_2_1b_squad.yaml" # Run a usage example
+# Step 3: Run the container with your local checkout mounted over /opt/Automodel.
+docker run --gpus all --network=host -it --rm \
+  --shm-size=32g \
+  -v "$(pwd)":/opt/Automodel \
+  nvcr.io/nvidia/nemo-automodel:26.04.00 /bin/bash
 ```
-<Note>
-The above `docker` command mounts your local `Automodel` directory into the container at `/workspace/Automodel`.
 
-</Note>
+Inside the container, patch `pyproject.toml` / `uv.lock` for the PyTorch base image, then re-sync the environment:
+
+```bash
+cd /opt/Automodel
+bash docker/common/update_pyproject_pytorch.sh /opt/Automodel
+uv sync --locked --extra all --all-groups
+```
+
+<Warning>
+The `update_pyproject_pytorch.sh` step is required. Without it, `uv sync` tries to reinstall `torch`, which causes CUDA version mismatches and TransformerEngine import failures, because `uv` cannot recognize the torch baked into the PyTorch base container.
+
+</Warning>
 
 ## Install Profiles
 

--- a/docs/guides/llm/agent-sft.mdx
+++ b/docs/guides/llm/agent-sft.mdx
@@ -55,7 +55,7 @@ We fine-tune on the [llamafactory/glaive_toolcall_en](https://huggingface.co/dat
 This guide runs **inside** the NeMo AutoModel Docker container:
 
 ```bash
-docker run -it --rm --gpus all --ipc=host --network host -v $(pwd):/workspace nvcr.io/nvidia/nemo-automodel:26.04.00
+docker run -it --rm --gpus all --ipc=host --network host -v $(pwd):/workspace nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 ```bash

--- a/docs/guides/llm/agent-sft.mdx
+++ b/docs/guides/llm/agent-sft.mdx
@@ -55,7 +55,7 @@ We fine-tune on the [llamafactory/glaive_toolcall_en](https://huggingface.co/dat
 This guide runs **inside** the NeMo AutoModel Docker container:
 
 ```bash
-docker run -it --rm --gpus all --ipc=host --network host -v $(pwd):/workspace nvcr.io/nvidia/nemo-automodel:26.02
+docker run -it --rm --gpus all --ipc=host --network host -v $(pwd):/workspace nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 ```bash

--- a/docs/guides/llm/finetune.mdx
+++ b/docs/guides/llm/finetune.mdx
@@ -43,8 +43,8 @@ pip3 install nemo-automodel
 Alternatively, if you run into dependency or driver issues, use the pre-built Docker container:
 
 ```bash
-docker pull nvcr.io/nvidia/nemo-automodel:26.04.00
-docker run --gpus all -it --rm --shm-size=8g -v $(pwd)/checkpoints:/tmp/checkpoints/ nvcr.io/nvidia/nemo-automodel:26.04.00
+docker pull nvcr.io/nvidia/nemo-automodel:26.06.00
+docker run --gpus all -it --rm --shm-size=8g -v $(pwd)/checkpoints:/tmp/checkpoints/ nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 <Info>

--- a/docs/guides/llm/finetune.mdx
+++ b/docs/guides/llm/finetune.mdx
@@ -43,8 +43,8 @@ pip3 install nemo-automodel
 Alternatively, if you run into dependency or driver issues, use the pre-built Docker container:
 
 ```bash
-docker pull nvcr.io/nvidia/nemo-automodel:26.02.00
-docker run --gpus all -it --rm --shm-size=8g -v $(pwd)/checkpoints:/tmp/checkpoints/ nvcr.io/nvidia/nemo-automodel:26.02.00
+docker pull nvcr.io/nvidia/nemo-automodel:26.04.00
+docker run --gpus all -it --rm --shm-size=8g -v $(pwd)/checkpoints:/tmp/checkpoints/ nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 <Info>

--- a/docs/guides/speculative/eagle.mdx
+++ b/docs/guides/speculative/eagle.mdx
@@ -72,7 +72,7 @@ This guide runs **inside** the NeMo AutoModel Docker container:
 ```bash
 docker run -it --rm --gpus all --ipc=host --network host \
     -v $(pwd):/workspace \
-    nvcr.io/nvidia/nemo-automodel:26.04.00
+    nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 ```bash

--- a/docs/guides/speculative/eagle.mdx
+++ b/docs/guides/speculative/eagle.mdx
@@ -72,7 +72,7 @@ This guide runs **inside** the NeMo AutoModel Docker container:
 ```bash
 docker run -it --rm --gpus all --ipc=host --network host \
     -v $(pwd):/workspace \
-    nvcr.io/nvidia/nemo-automodel:26.02
+    nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 ```bash

--- a/docs/guides/vlm/gemma4.md
+++ b/docs/guides/vlm/gemma4.md
@@ -58,7 +58,7 @@ This guide runs **inside** the NeMo AutoModel Docker container:
 ```bash
 docker run -it --rm --gpus all --ipc=host --network host \
     -v $(pwd):/workspace \
-    nvcr.io/nvidia/nemo-automodel:26.02
+    nvcr.io/nvidia/nemo-automodel:26.04.00
 
 # Inside the container:
 huggingface-cli login          # needed for gated model access

--- a/docs/guides/vlm/gemma4.md
+++ b/docs/guides/vlm/gemma4.md
@@ -58,7 +58,7 @@ This guide runs **inside** the NeMo AutoModel Docker container:
 ```bash
 docker run -it --rm --gpus all --ipc=host --network host \
     -v $(pwd):/workspace \
-    nvcr.io/nvidia/nemo-automodel:26.04.00
+    nvcr.io/nvidia/nemo-automodel:26.06.00
 
 # Inside the container:
 huggingface-cli login          # needed for gated model access

--- a/docs/guides/vlm/gemma4.mdx
+++ b/docs/guides/vlm/gemma4.mdx
@@ -61,7 +61,7 @@ This guide runs **inside** the NeMo AutoModel Docker container:
 ```bash
 docker run -it --rm --gpus all --ipc=host --network host \
     -v $(pwd):/workspace \
-    nvcr.io/nvidia/nemo-automodel:26.04.00
+    nvcr.io/nvidia/nemo-automodel:26.06.00
 
 # Inside the container:
 huggingface-cli login          # needed for gated model access

--- a/docs/guides/vlm/gemma4.mdx
+++ b/docs/guides/vlm/gemma4.mdx
@@ -61,7 +61,7 @@ This guide runs **inside** the NeMo AutoModel Docker container:
 ```bash
 docker run -it --rm --gpus all --ipc=host --network host \
     -v $(pwd):/workspace \
-    nvcr.io/nvidia/nemo-automodel:26.02
+    nvcr.io/nvidia/nemo-automodel:26.04.00
 
 # Inside the container:
 huggingface-cli login          # needed for gated model access

--- a/docs/guides/vlm/qwen3-5.md
+++ b/docs/guides/vlm/qwen3-5.md
@@ -40,7 +40,7 @@ export WANDB_API_KEY=your_wandb_key
 
 srun --output=output.out \
      --error=output.err \
-     --container-image /your/path/to/automodel26.02.image.sqsh --no-container-mount-home bash -c "
+     --container-image /your/path/to/automodel26.04.image.sqsh --no-container-mount-home bash -c "
   CUDA_DEVICE_MAX_CONNECTIONS=1 automodel \
   examples/vlm_finetune/qwen3_5_moe/qwen3_5_moe_medpix.yaml \
   --nproc-per-node=8 \

--- a/docs/guides/vlm/qwen3-5.md
+++ b/docs/guides/vlm/qwen3-5.md
@@ -40,7 +40,7 @@ export WANDB_API_KEY=your_wandb_key
 
 srun --output=output.out \
      --error=output.err \
-     --container-image /your/path/to/automodel26.04.image.sqsh --no-container-mount-home bash -c "
+     --container-image /your/path/to/automodel26.06.image.sqsh --no-container-mount-home bash -c "
   CUDA_DEVICE_MAX_CONNECTIONS=1 automodel \
   examples/vlm_finetune/qwen3_5_moe/qwen3_5_moe_medpix.yaml \
   --nproc-per-node=8 \

--- a/docs/guides/vlm/qwen3-5.mdx
+++ b/docs/guides/vlm/qwen3-5.mdx
@@ -43,7 +43,7 @@ export WANDB_API_KEY=your_wandb_key
 
 srun --output=output.out \
      --error=output.err \
-     --container-image /your/path/to/automodel26.04.image.sqsh --no-container-mount-home bash -c "
+     --container-image /your/path/to/automodel26.06.image.sqsh --no-container-mount-home bash -c "
   CUDA_DEVICE_MAX_CONNECTIONS=1 automodel \
   examples/vlm_finetune/qwen3_5_moe/qwen3_5_moe_medpix.yaml \
   --nproc-per-node=8 \

--- a/docs/guides/vlm/qwen3-5.mdx
+++ b/docs/guides/vlm/qwen3-5.mdx
@@ -43,7 +43,7 @@ export WANDB_API_KEY=your_wandb_key
 
 srun --output=output.out \
      --error=output.err \
-     --container-image /your/path/to/automodel26.02.image.sqsh --no-container-mount-home bash -c "
+     --container-image /your/path/to/automodel26.04.image.sqsh --no-container-mount-home bash -c "
   CUDA_DEVICE_MAX_CONNECTIONS=1 automodel \
   examples/vlm_finetune/qwen3_5_moe/qwen3_5_moe_medpix.yaml \
   --nproc-per-node=8 \

--- a/docs/guides/vlm/step-3-7.md
+++ b/docs/guides/vlm/step-3-7.md
@@ -53,7 +53,7 @@ export WANDB_API_KEY=your_wandb_key
 
 srun --output=output.out \
      --error=output.err \
-     --container-image /path/to/automodel26.04.image.sqsh \
+     --container-image /path/to/automodel26.06.image.sqsh \
      --no-container-mount-home bash -c "
   CUDA_DEVICE_MAX_CONNECTIONS=1 automodel \
   /path/to/step_3_7_flash_recipe.yaml \

--- a/docs/guides/vlm/step-3-7.md
+++ b/docs/guides/vlm/step-3-7.md
@@ -53,7 +53,7 @@ export WANDB_API_KEY=your_wandb_key
 
 srun --output=output.out \
      --error=output.err \
-     --container-image /path/to/automodel26.02.image.sqsh \
+     --container-image /path/to/automodel26.04.image.sqsh \
      --no-container-mount-home bash -c "
   CUDA_DEVICE_MAX_CONNECTIONS=1 automodel \
   /path/to/step_3_7_flash_recipe.yaml \

--- a/docs/guides/vlm/step-3-7.mdx
+++ b/docs/guides/vlm/step-3-7.mdx
@@ -56,7 +56,7 @@ export WANDB_API_KEY=your_wandb_key
 
 srun --output=output.out \
      --error=output.err \
-     --container-image /path/to/automodel26.02.image.sqsh \
+     --container-image /path/to/automodel26.04.image.sqsh \
      --no-container-mount-home bash -c "
   CUDA_DEVICE_MAX_CONNECTIONS=1 automodel \
   /path/to/step_3_7_flash_recipe.yaml \

--- a/docs/guides/vlm/step-3-7.mdx
+++ b/docs/guides/vlm/step-3-7.mdx
@@ -56,7 +56,7 @@ export WANDB_API_KEY=your_wandb_key
 
 srun --output=output.out \
      --error=output.err \
-     --container-image /path/to/automodel26.04.image.sqsh \
+     --container-image /path/to/automodel26.06.image.sqsh \
      --no-container-mount-home bash -c "
   CUDA_DEVICE_MAX_CONNECTIONS=1 automodel \
   /path/to/step_3_7_flash_recipe.yaml \

--- a/docs/model-coverage/diffusion/black-forest-labs/flux.mdx
+++ b/docs/model-coverage/diffusion/black-forest-labs/flux.mdx
@@ -66,7 +66,7 @@ torchrun --nproc-per-node=8 \
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/diffusion/black-forest-labs/flux.mdx
+++ b/docs/model-coverage/diffusion/black-forest-labs/flux.mdx
@@ -66,7 +66,7 @@ torchrun --nproc-per-node=8 \
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/diffusion/hunyuanvideo-community/hunyuanvideo.mdx
+++ b/docs/model-coverage/diffusion/hunyuanvideo-community/hunyuanvideo.mdx
@@ -65,7 +65,7 @@ torchrun --nproc-per-node=8 \
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/diffusion/hunyuanvideo-community/hunyuanvideo.mdx
+++ b/docs/model-coverage/diffusion/hunyuanvideo-community/hunyuanvideo.mdx
@@ -65,7 +65,7 @@ torchrun --nproc-per-node=8 \
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/diffusion/qwen/qwen-image.mdx
+++ b/docs/model-coverage/diffusion/qwen/qwen-image.mdx
@@ -65,7 +65,7 @@ torchrun --nproc-per-node=8 \
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/diffusion/qwen/qwen-image.mdx
+++ b/docs/model-coverage/diffusion/qwen/qwen-image.mdx
@@ -65,7 +65,7 @@ torchrun --nproc-per-node=8 \
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/diffusion/wan-ai/wan2-1-t2v.mdx
+++ b/docs/model-coverage/diffusion/wan-ai/wan2-1-t2v.mdx
@@ -66,7 +66,7 @@ torchrun --nproc-per-node=8 \
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/diffusion/wan-ai/wan2-1-t2v.mdx
+++ b/docs/model-coverage/diffusion/wan-ai/wan2-1-t2v.mdx
@@ -66,7 +66,7 @@ torchrun --nproc-per-node=8 \
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/diffusion/wan-ai/wan2-2-t2v.mdx
+++ b/docs/model-coverage/diffusion/wan-ai/wan2-2-t2v.mdx
@@ -118,7 +118,7 @@ torchrun --nproc-per-node=8 \
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/diffusion/wan-ai/wan2-2-t2v.mdx
+++ b/docs/model-coverage/diffusion/wan-ai/wan2-2-t2v.mdx
@@ -118,7 +118,7 @@ torchrun --nproc-per-node=8 \
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/allenai/olmo.mdx
+++ b/docs/model-coverage/llm/allenai/olmo.mdx
@@ -64,7 +64,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/allenai/olmo.mdx
+++ b/docs/model-coverage/llm/allenai/olmo.mdx
@@ -64,7 +64,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/allenai/olmo2.mdx
+++ b/docs/model-coverage/llm/allenai/olmo2.mdx
@@ -67,7 +67,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/olmo/olmo_2_0425_1b_instruct_
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/allenai/olmo2.mdx
+++ b/docs/model-coverage/llm/allenai/olmo2.mdx
@@ -67,7 +67,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/olmo/olmo_2_0425_1b_instruct_
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/allenai/olmoe.mdx
+++ b/docs/model-coverage/llm/allenai/olmoe.mdx
@@ -64,7 +64,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/allenai/olmoe.mdx
+++ b/docs/model-coverage/llm/allenai/olmoe.mdx
@@ -64,7 +64,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/baai/aquila.mdx
+++ b/docs/model-coverage/llm/baai/aquila.mdx
@@ -65,7 +65,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/baai/aquila.mdx
+++ b/docs/model-coverage/llm/baai/aquila.mdx
@@ -65,7 +65,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/baichuan-inc/baichuan.mdx
+++ b/docs/model-coverage/llm/baichuan-inc/baichuan.mdx
@@ -67,7 +67,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/baichuan/baichuan_2_7b_squad.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/baichuan-inc/baichuan.mdx
+++ b/docs/model-coverage/llm/baichuan-inc/baichuan.mdx
@@ -67,7 +67,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/baichuan/baichuan_2_7b_squad.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/baidu/ernie4-5.mdx
+++ b/docs/model-coverage/llm/baidu/ernie4-5.mdx
@@ -74,7 +74,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/ernie4_5/ernie4_5_21b_a3b_hel
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2. Navigate to the AutoModel directory**:

--- a/docs/model-coverage/llm/baidu/ernie4-5.mdx
+++ b/docs/model-coverage/llm/baidu/ernie4-5.mdx
@@ -74,7 +74,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/ernie4_5/ernie4_5_21b_a3b_hel
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2. Navigate to the AutoModel directory**:

--- a/docs/model-coverage/llm/bigcode/starcoder.mdx
+++ b/docs/model-coverage/llm/bigcode/starcoder.mdx
@@ -66,7 +66,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/bigcode/starcoder.mdx
+++ b/docs/model-coverage/llm/bigcode/starcoder.mdx
@@ -66,7 +66,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/bigcode/starcoder2.mdx
+++ b/docs/model-coverage/llm/bigcode/starcoder2.mdx
@@ -68,7 +68,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/starcoder/starcoder_2_7b_squa
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/bigcode/starcoder2.mdx
+++ b/docs/model-coverage/llm/bigcode/starcoder2.mdx
@@ -68,7 +68,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/starcoder/starcoder_2_7b_squa
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/bytedance-seed/seed.mdx
+++ b/docs/model-coverage/llm/bytedance-seed/seed.mdx
@@ -68,7 +68,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/seed/seed_coder_8b_instruct_s
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/bytedance-seed/seed.mdx
+++ b/docs/model-coverage/llm/bytedance-seed/seed.mdx
@@ -68,7 +68,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/seed/seed_coder_8b_instruct_s
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/cohere/command-r.mdx
+++ b/docs/model-coverage/llm/cohere/command-r.mdx
@@ -68,7 +68,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/cohere/cohere_command_r_7b_sq
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/cohere/command-r.mdx
+++ b/docs/model-coverage/llm/cohere/command-r.mdx
@@ -68,7 +68,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/cohere/cohere_command_r_7b_sq
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/deepseek-ai/deepseek-v3.mdx
+++ b/docs/model-coverage/llm/deepseek-ai/deepseek-v3.mdx
@@ -78,7 +78,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/deepseek_v32/deepseek_v32_hel
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/deepseek-ai/deepseek-v3.mdx
+++ b/docs/model-coverage/llm/deepseek-ai/deepseek-v3.mdx
@@ -78,7 +78,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/deepseek_v32/deepseek_v32_hel
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/deepseek-ai/deepseek.mdx
+++ b/docs/model-coverage/llm/deepseek-ai/deepseek.mdx
@@ -65,7 +65,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/deepseek-ai/deepseek.mdx
+++ b/docs/model-coverage/llm/deepseek-ai/deepseek.mdx
@@ -65,7 +65,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/deepseek-ai/dsv4-flash.mdx
+++ b/docs/model-coverage/llm/deepseek-ai/dsv4-flash.mdx
@@ -68,7 +68,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/deepseek_v4/deepseek_v4_flash
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/deepseek-ai/dsv4-flash.mdx
+++ b/docs/model-coverage/llm/deepseek-ai/dsv4-flash.mdx
@@ -68,7 +68,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/deepseek_v4/deepseek_v4_flash
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/eleutherai/gpt-j.mdx
+++ b/docs/model-coverage/llm/eleutherai/gpt-j.mdx
@@ -64,7 +64,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/eleutherai/gpt-j.mdx
+++ b/docs/model-coverage/llm/eleutherai/gpt-j.mdx
@@ -64,7 +64,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/eleutherai/gpt-neox.mdx
+++ b/docs/model-coverage/llm/eleutherai/gpt-neox.mdx
@@ -70,7 +70,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/eleutherai/gpt-neox.mdx
+++ b/docs/model-coverage/llm/eleutherai/gpt-neox.mdx
@@ -70,7 +70,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/google/gemma.mdx
+++ b/docs/model-coverage/llm/google/gemma.mdx
@@ -80,7 +80,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/gemma/gemma_2_9b_it_squad.yam
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/google/gemma.mdx
+++ b/docs/model-coverage/llm/google/gemma.mdx
@@ -80,7 +80,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/gemma/gemma_2_9b_it_squad.yam
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/ibm/bamba.mdx
+++ b/docs/model-coverage/llm/ibm/bamba.mdx
@@ -62,7 +62,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/ibm/bamba.mdx
+++ b/docs/model-coverage/llm/ibm/bamba.mdx
@@ -62,7 +62,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/ibm/granite-moe.mdx
+++ b/docs/model-coverage/llm/ibm/granite-moe.mdx
@@ -68,7 +68,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/ibm/granite-moe.mdx
+++ b/docs/model-coverage/llm/ibm/granite-moe.mdx
@@ -68,7 +68,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/ibm/granite.mdx
+++ b/docs/model-coverage/llm/ibm/granite.mdx
@@ -69,7 +69,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/granite/granite_3_3_2b_instru
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/ibm/granite.mdx
+++ b/docs/model-coverage/llm/ibm/granite.mdx
@@ -69,7 +69,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/granite/granite_3_3_2b_instru
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/inceptionai/jais.mdx
+++ b/docs/model-coverage/llm/inceptionai/jais.mdx
@@ -68,7 +68,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/inceptionai/jais.mdx
+++ b/docs/model-coverage/llm/inceptionai/jais.mdx
@@ -68,7 +68,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/index.mdx
+++ b/docs/model-coverage/llm/index.mdx
@@ -8,7 +8,7 @@ Large Language Models (LLMs) power a variety of tasks such as dialogue systems, 
 NeMo AutoModel provides a simple interface for loading and fine-tuning LLMs hosted on the Hugging Face Hub.
 
 ## Run LLMs with NeMo AutoModel
-To run LLMs with NeMo AutoModel, make sure you're using NeMo container version [`26.04.00`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-automodel?version=26.04.00) or later. If the model you intend to fine-tune requires a newer version of Transformers, you may need to upgrade to the latest version of NeMo AutoModel by running:
+To run LLMs with NeMo AutoModel, make sure you're using NeMo container version [`26.06.00`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-automodel?version=26.06.00) or later. If the model you intend to fine-tune requires a newer version of Transformers, you may need to upgrade to the latest version of NeMo AutoModel by running:
 
 ```bash
 pip3 install --upgrade git+git@github.com:NVIDIA-NeMo/AutoModel.git

--- a/docs/model-coverage/llm/index.mdx
+++ b/docs/model-coverage/llm/index.mdx
@@ -8,7 +8,7 @@ Large Language Models (LLMs) power a variety of tasks such as dialogue systems, 
 NeMo AutoModel provides a simple interface for loading and fine-tuning LLMs hosted on the Hugging Face Hub.
 
 ## Run LLMs with NeMo AutoModel
-To run LLMs with NeMo AutoModel, make sure you're using NeMo container version [`25.11.00`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-automodel?version=25.11.00) or later. If the model you intend to fine-tune requires a newer version of Transformers, you may need to upgrade to the latest version of NeMo AutoModel by running:
+To run LLMs with NeMo AutoModel, make sure you're using NeMo container version [`26.04.00`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-automodel?version=26.04.00) or later. If the model you intend to fine-tune requires a newer version of Transformers, you may need to upgrade to the latest version of NeMo AutoModel by running:
 
 ```bash
 pip3 install --upgrade git+git@github.com:NVIDIA-NeMo/AutoModel.git

--- a/docs/model-coverage/llm/internlm/internlm.mdx
+++ b/docs/model-coverage/llm/internlm/internlm.mdx
@@ -68,7 +68,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/internlm/internlm.mdx
+++ b/docs/model-coverage/llm/internlm/internlm.mdx
@@ -68,7 +68,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/lgai-exaone/exaone.mdx
+++ b/docs/model-coverage/llm/lgai-exaone/exaone.mdx
@@ -63,7 +63,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/lgai-exaone/exaone.mdx
+++ b/docs/model-coverage/llm/lgai-exaone/exaone.mdx
@@ -63,7 +63,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/meta/llama.mdx
+++ b/docs/model-coverage/llm/meta/llama.mdx
@@ -77,7 +77,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/llama3_2/llama3_2_1b_squad.ya
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/meta/llama.mdx
+++ b/docs/model-coverage/llm/meta/llama.mdx
@@ -77,7 +77,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/llama3_2/llama3_2_1b_squad.ya
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/microsoft/phi.mdx
+++ b/docs/model-coverage/llm/microsoft/phi.mdx
@@ -66,7 +66,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/phi/phi_2_squad.yaml
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/microsoft/phi.mdx
+++ b/docs/model-coverage/llm/microsoft/phi.mdx
@@ -66,7 +66,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/phi/phi_2_squad.yaml
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/microsoft/phi3-small.mdx
+++ b/docs/model-coverage/llm/microsoft/phi3-small.mdx
@@ -64,7 +64,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/microsoft/phi3-small.mdx
+++ b/docs/model-coverage/llm/microsoft/phi3-small.mdx
@@ -64,7 +64,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/microsoft/phi3.mdx
+++ b/docs/model-coverage/llm/microsoft/phi3.mdx
@@ -75,7 +75,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/phi/phi_4_squad.yaml
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/microsoft/phi3.mdx
+++ b/docs/model-coverage/llm/microsoft/phi3.mdx
@@ -75,7 +75,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/phi/phi_4_squad.yaml
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/minimax/minimax-m2.md
+++ b/docs/model-coverage/llm/minimax/minimax-m2.md
@@ -72,7 +72,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/minimax_m2/minimax_m2.1_hella
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/minimax/minimax-m2.md
+++ b/docs/model-coverage/llm/minimax/minimax-m2.md
@@ -72,7 +72,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/minimax_m2/minimax_m2.1_hella
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/minimax/minimax-m2.mdx
+++ b/docs/model-coverage/llm/minimax/minimax-m2.mdx
@@ -73,7 +73,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/minimax_m2/minimax_m2.1_hella
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/minimax/minimax-m2.mdx
+++ b/docs/model-coverage/llm/minimax/minimax-m2.mdx
@@ -73,7 +73,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/minimax_m2/minimax_m2.1_hella
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/mistralai/ministral3.mdx
+++ b/docs/model-coverage/llm/mistralai/ministral3.mdx
@@ -68,7 +68,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/devstral/devstral2_small_2512
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/mistralai/ministral3.mdx
+++ b/docs/model-coverage/llm/mistralai/ministral3.mdx
@@ -68,7 +68,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/devstral/devstral2_small_2512
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/mistralai/mistral.mdx
+++ b/docs/model-coverage/llm/mistralai/mistral.mdx
@@ -70,7 +70,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/mistral/mistral_7b_squad.yaml
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/mistralai/mistral.mdx
+++ b/docs/model-coverage/llm/mistralai/mistral.mdx
@@ -70,7 +70,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/mistral/mistral_7b_squad.yaml
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/mistralai/mixtral.mdx
+++ b/docs/model-coverage/llm/mistralai/mixtral.mdx
@@ -67,7 +67,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/mistral/mixtral-8x7b-v0-1_squ
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/mistralai/mixtral.mdx
+++ b/docs/model-coverage/llm/mistralai/mixtral.mdx
@@ -67,7 +67,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/mistral/mixtral-8x7b-v0-1_squ
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/moonshotai/moonlight.mdx
+++ b/docs/model-coverage/llm/moonshotai/moonlight.mdx
@@ -64,7 +64,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/moonlight/moonlight_16b_te.ya
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/moonshotai/moonlight.mdx
+++ b/docs/model-coverage/llm/moonshotai/moonlight.mdx
@@ -64,7 +64,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/moonlight/moonlight_16b_te.ya
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/nvidia/nemotron-flash.mdx
+++ b/docs/model-coverage/llm/nvidia/nemotron-flash.mdx
@@ -69,7 +69,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/nemotron_flash/nemotron_flash
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/nvidia/nemotron-flash.mdx
+++ b/docs/model-coverage/llm/nvidia/nemotron-flash.mdx
@@ -69,7 +69,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/nemotron_flash/nemotron_flash
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/nvidia/nemotron-h.mdx
+++ b/docs/model-coverage/llm/nvidia/nemotron-h.mdx
@@ -70,7 +70,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/nemotron/nemotron_nano_9b_squ
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/nvidia/nemotron-h.mdx
+++ b/docs/model-coverage/llm/nvidia/nemotron-h.mdx
@@ -70,7 +70,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/nemotron/nemotron_nano_9b_squ
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/nvidia/nemotron-super.mdx
+++ b/docs/model-coverage/llm/nvidia/nemotron-super.mdx
@@ -62,7 +62,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/nvidia/nemotron-super.mdx
+++ b/docs/model-coverage/llm/nvidia/nemotron-super.mdx
@@ -62,7 +62,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/nvidia/nemotron.mdx
+++ b/docs/model-coverage/llm/nvidia/nemotron.mdx
@@ -62,7 +62,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/nvidia/nemotron.mdx
+++ b/docs/model-coverage/llm/nvidia/nemotron.mdx
@@ -62,7 +62,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/openai/gpt-oss.mdx
+++ b/docs/model-coverage/llm/openai/gpt-oss.mdx
@@ -66,7 +66,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/gpt_oss/gpt_oss_20b.yaml
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/openai/gpt-oss.mdx
+++ b/docs/model-coverage/llm/openai/gpt-oss.mdx
@@ -66,7 +66,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/gpt_oss/gpt_oss_20b.yaml
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/openbmb/minicpm.mdx
+++ b/docs/model-coverage/llm/openbmb/minicpm.mdx
@@ -70,7 +70,7 @@ automodel examples/llm_finetune/minicpm/minicpm5_1b_squad_peft.yaml --nproc-per-
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/openbmb/minicpm.mdx
+++ b/docs/model-coverage/llm/openbmb/minicpm.mdx
@@ -70,7 +70,7 @@ automodel examples/llm_finetune/minicpm/minicpm5_1b_squad_peft.yaml --nproc-per-
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/orionstar/orion.mdx
+++ b/docs/model-coverage/llm/orionstar/orion.mdx
@@ -64,7 +64,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/orionstar/orion.mdx
+++ b/docs/model-coverage/llm/orionstar/orion.mdx
@@ -64,7 +64,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/parasail-ai/gritlm.mdx
+++ b/docs/model-coverage/llm/parasail-ai/gritlm.mdx
@@ -62,7 +62,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/parasail-ai/gritlm.mdx
+++ b/docs/model-coverage/llm/parasail-ai/gritlm.mdx
@@ -62,7 +62,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/qwen/qwen2-moe.mdx
+++ b/docs/model-coverage/llm/qwen/qwen2-moe.mdx
@@ -64,7 +64,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/qwen/qwen1_5_moe_a2_7b_qlora.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/qwen/qwen2-moe.mdx
+++ b/docs/model-coverage/llm/qwen/qwen2-moe.mdx
@@ -64,7 +64,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/qwen/qwen1_5_moe_a2_7b_qlora.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/qwen/qwen2.mdx
+++ b/docs/model-coverage/llm/qwen/qwen2.mdx
@@ -69,7 +69,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/qwen/qwen2_5_7b_squad.yaml
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/qwen/qwen2.mdx
+++ b/docs/model-coverage/llm/qwen/qwen2.mdx
@@ -69,7 +69,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/qwen/qwen2_5_7b_squad.yaml
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/qwen/qwen3-moe.mdx
+++ b/docs/model-coverage/llm/qwen/qwen3-moe.mdx
@@ -66,7 +66,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/qwen/qwen3_moe_30b_te_deepep.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/qwen/qwen3-moe.mdx
+++ b/docs/model-coverage/llm/qwen/qwen3-moe.mdx
@@ -66,7 +66,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/qwen/qwen3_moe_30b_te_deepep.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/qwen/qwen3-next.mdx
+++ b/docs/model-coverage/llm/qwen/qwen3-next.mdx
@@ -68,7 +68,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/qwen/qwen3_next_te_deepep.yam
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/qwen/qwen3-next.mdx
+++ b/docs/model-coverage/llm/qwen/qwen3-next.mdx
@@ -68,7 +68,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/qwen/qwen3_next_te_deepep.yam
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/qwen/qwen3.mdx
+++ b/docs/model-coverage/llm/qwen/qwen3.mdx
@@ -66,7 +66,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/qwen/qwen3_0p6b_hellaswag.yam
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/qwen/qwen3.mdx
+++ b/docs/model-coverage/llm/qwen/qwen3.mdx
@@ -66,7 +66,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/qwen/qwen3_0p6b_hellaswag.yam
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/stabilityai/stablelm.mdx
+++ b/docs/model-coverage/llm/stabilityai/stablelm.mdx
@@ -64,7 +64,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/stabilityai/stablelm.mdx
+++ b/docs/model-coverage/llm/stabilityai/stablelm.mdx
@@ -64,7 +64,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/stepfun-ai/step-3-5.mdx
+++ b/docs/model-coverage/llm/stepfun-ai/step-3-5.mdx
@@ -68,7 +68,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/stepfun/step_3.5_flash_hellas
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/stepfun-ai/step-3-5.mdx
+++ b/docs/model-coverage/llm/stepfun-ai/step-3-5.mdx
@@ -68,7 +68,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/stepfun/step_3.5_flash_hellas
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/thudm/chatglm.mdx
+++ b/docs/model-coverage/llm/thudm/chatglm.mdx
@@ -64,7 +64,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/thudm/chatglm.mdx
+++ b/docs/model-coverage/llm/thudm/chatglm.mdx
@@ -64,7 +64,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/thudm/glm4-moe.mdx
+++ b/docs/model-coverage/llm/thudm/glm4-moe.mdx
@@ -76,7 +76,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/glm/glm_4.5_air_te_deepep.yam
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/thudm/glm4-moe.mdx
+++ b/docs/model-coverage/llm/thudm/glm4-moe.mdx
@@ -76,7 +76,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/glm/glm_4.5_air_te_deepep.yam
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/thudm/glm4.mdx
+++ b/docs/model-coverage/llm/thudm/glm4.mdx
@@ -67,7 +67,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/glm/glm_4_9b_chat_hf_squad.ya
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/thudm/glm4.mdx
+++ b/docs/model-coverage/llm/thudm/glm4.mdx
@@ -67,7 +67,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/glm/glm_4_9b_chat_hf_squad.ya
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/thudm/glm5-moe-dsa.mdx
+++ b/docs/model-coverage/llm/thudm/glm5-moe-dsa.mdx
@@ -100,7 +100,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/glm/glm_5_hellaswag_pp.yaml
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/thudm/glm5-moe-dsa.mdx
+++ b/docs/model-coverage/llm/thudm/glm5-moe-dsa.mdx
@@ -100,7 +100,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/glm/glm_5_hellaswag_pp.yaml
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/tiiuae/falcon.mdx
+++ b/docs/model-coverage/llm/tiiuae/falcon.mdx
@@ -69,7 +69,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/falcon/falcon3_7b_instruct_sq
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/tiiuae/falcon.mdx
+++ b/docs/model-coverage/llm/tiiuae/falcon.mdx
@@ -69,7 +69,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/falcon/falcon3_7b_instruct_sq
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/llm/upstage/solar.mdx
+++ b/docs/model-coverage/llm/upstage/solar.mdx
@@ -62,7 +62,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/upstage/solar.mdx
+++ b/docs/model-coverage/llm/upstage/solar.mdx
@@ -62,7 +62,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/llm/xiaomimimo/mimo-v2-flash.mdx
+++ b/docs/model-coverage/llm/xiaomimimo/mimo-v2-flash.mdx
@@ -66,7 +66,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/mimo_v2_flash/mimo_v2_flash_h
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2. Navigate to the AutoModel directory**:

--- a/docs/model-coverage/llm/xiaomimimo/mimo-v2-flash.mdx
+++ b/docs/model-coverage/llm/xiaomimimo/mimo-v2-flash.mdx
@@ -66,7 +66,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/mimo_v2_flash/mimo_v2_flash_h
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2. Navigate to the AutoModel directory**:

--- a/docs/model-coverage/omni/index.mdx
+++ b/docs/model-coverage/omni/index.mdx
@@ -7,7 +7,7 @@ Omni models go beyond image-text understanding to support additional modalities 
 
 ## Run Omni Models with NeMo AutoModel
 
-To run omni models with NeMo AutoModel, use NeMo container version [`26.04.00`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-automodel?version=26.04.00) or later. If the model you want to fine-tune requires a newer version of Transformers, you may need to upgrade:
+To run omni models with NeMo AutoModel, use NeMo container version [`26.06.00`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-automodel?version=26.06.00) or later. If the model you want to fine-tune requires a newer version of Transformers, you may need to upgrade:
 
 ```bash
 pip3 install --upgrade git+git@github.com:NVIDIA-NeMo/AutoModel.git

--- a/docs/model-coverage/omni/index.mdx
+++ b/docs/model-coverage/omni/index.mdx
@@ -7,7 +7,7 @@ Omni models go beyond image-text understanding to support additional modalities 
 
 ## Run Omni Models with NeMo AutoModel
 
-To run omni models with NeMo AutoModel, use NeMo container version [`25.11.00`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-automodel?version=25.11.00) or later. If the model you want to fine-tune requires a newer version of Transformers, you may need to upgrade:
+To run omni models with NeMo AutoModel, use NeMo container version [`26.04.00`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-automodel?version=26.04.00) or later. If the model you want to fine-tune requires a newer version of Transformers, you may need to upgrade:
 
 ```bash
 pip3 install --upgrade git+git@github.com:NVIDIA-NeMo/AutoModel.git

--- a/docs/model-coverage/omni/microsoft/phi4-multimodal.mdx
+++ b/docs/model-coverage/omni/microsoft/phi4-multimodal.mdx
@@ -63,7 +63,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/phi4/phi4_mm_cv17.yaml
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/omni/microsoft/phi4-multimodal.mdx
+++ b/docs/model-coverage/omni/microsoft/phi4-multimodal.mdx
@@ -63,7 +63,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/phi4/phi4_mm_cv17.yaml
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/omni/qwen/qwen2-5-omni.mdx
+++ b/docs/model-coverage/omni/qwen/qwen2-5-omni.mdx
@@ -67,7 +67,7 @@ automodel --nproc-per-node=8 examples/audio_finetune/qwen2_5_omni_asr/ami_sft_3b
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2. Navigate to the AutoModel directory** (where the recipes are):

--- a/docs/model-coverage/omni/qwen/qwen2-5-omni.mdx
+++ b/docs/model-coverage/omni/qwen/qwen2-5-omni.mdx
@@ -67,7 +67,7 @@ automodel --nproc-per-node=8 examples/audio_finetune/qwen2_5_omni_asr/ami_sft_3b
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2. Navigate to the AutoModel directory** (where the recipes are):

--- a/docs/model-coverage/omni/qwen/qwen3-omni.mdx
+++ b/docs/model-coverage/omni/qwen/qwen3-omni.mdx
@@ -63,7 +63,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/qwen3/qwen3_omni_moe_30b_te_d
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/omni/qwen/qwen3-omni.mdx
+++ b/docs/model-coverage/omni/qwen/qwen3-omni.mdx
@@ -63,7 +63,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/qwen3/qwen3_omni_moe_30b_te_d
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/vlm/google/gemma3-vl.mdx
+++ b/docs/model-coverage/vlm/google/gemma3-vl.mdx
@@ -71,7 +71,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/gemma3/gemma3_vl_4b_cord_v2.y
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/vlm/google/gemma3-vl.mdx
+++ b/docs/model-coverage/vlm/google/gemma3-vl.mdx
@@ -71,7 +71,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/gemma3/gemma3_vl_4b_cord_v2.y
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/vlm/google/gemma4.mdx
+++ b/docs/model-coverage/vlm/google/gemma4.mdx
@@ -80,7 +80,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/gemma4/gemma4_4b.yaml
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2. Navigate to the AutoModel directory** (where the recipes are):

--- a/docs/model-coverage/vlm/google/gemma4.mdx
+++ b/docs/model-coverage/vlm/google/gemma4.mdx
@@ -80,7 +80,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/gemma4/gemma4_4b.yaml
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2. Navigate to the AutoModel directory** (where the recipes are):

--- a/docs/model-coverage/vlm/huggingface/smolvlm.mdx
+++ b/docs/model-coverage/vlm/huggingface/smolvlm.mdx
@@ -64,7 +64,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/vlm/huggingface/smolvlm.mdx
+++ b/docs/model-coverage/vlm/huggingface/smolvlm.mdx
@@ -64,7 +64,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/vlm/index.mdx
+++ b/docs/model-coverage/vlm/index.mdx
@@ -11,7 +11,7 @@ NeMo AutoModel LLM APIs can be easily extended to support VLM tasks. While most 
 
 ## Run VLMs with NeMo AutoModel
 
-To run VLMs with NeMo AutoModel, use NeMo container version [`25.11.00`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-automodel?version=25.11.00) or later. If the model you want to fine-tune requires a newer version of Transformers, you may need to upgrade:
+To run VLMs with NeMo AutoModel, use NeMo container version [`26.04.00`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-automodel?version=26.04.00) or later. If the model you want to fine-tune requires a newer version of Transformers, you may need to upgrade:
 
 ```bash
 pip3 install --upgrade git+git@github.com:NVIDIA-NeMo/AutoModel.git

--- a/docs/model-coverage/vlm/index.mdx
+++ b/docs/model-coverage/vlm/index.mdx
@@ -11,7 +11,7 @@ NeMo AutoModel LLM APIs can be easily extended to support VLM tasks. While most 
 
 ## Run VLMs with NeMo AutoModel
 
-To run VLMs with NeMo AutoModel, use NeMo container version [`26.04.00`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-automodel?version=26.04.00) or later. If the model you want to fine-tune requires a newer version of Transformers, you may need to upgrade:
+To run VLMs with NeMo AutoModel, use NeMo container version [`26.06.00`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-automodel?version=26.06.00) or later. If the model you want to fine-tune requires a newer version of Transformers, you may need to upgrade:
 
 ```bash
 pip3 install --upgrade git+git@github.com:NVIDIA-NeMo/AutoModel.git

--- a/docs/model-coverage/vlm/internlm/internvl.mdx
+++ b/docs/model-coverage/vlm/internlm/internvl.mdx
@@ -64,7 +64,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/internvl/internvl_3_5_4b.yaml
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/vlm/internlm/internvl.mdx
+++ b/docs/model-coverage/vlm/internlm/internvl.mdx
@@ -64,7 +64,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/internvl/internvl_3_5_4b.yaml
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/vlm/llava-hf/llava.mdx
+++ b/docs/model-coverage/vlm/llava-hf/llava.mdx
@@ -73,7 +73,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/vlm/llava-hf/llava.mdx
+++ b/docs/model-coverage/vlm/llava-hf/llava.mdx
@@ -73,7 +73,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/vlm/lmms-lab/llava-onevision.mdx
+++ b/docs/model-coverage/vlm/lmms-lab/llava-onevision.mdx
@@ -68,7 +68,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/llava_onevision/llava_ov_1_5_
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/vlm/lmms-lab/llava-onevision.mdx
+++ b/docs/model-coverage/vlm/lmms-lab/llava-onevision.mdx
@@ -68,7 +68,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/llava_onevision/llava_ov_1_5_
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/vlm/meta/llama4.mdx
+++ b/docs/model-coverage/vlm/meta/llama4.mdx
@@ -64,7 +64,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/vlm/meta/llama4.mdx
+++ b/docs/model-coverage/vlm/meta/llama4.mdx
@@ -64,7 +64,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/model-coverage/vlm/mistralai/ministral3-vl.mdx
+++ b/docs/model-coverage/vlm/mistralai/ministral3-vl.mdx
@@ -69,7 +69,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/mistral/ministral3_3b_medpix.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/vlm/mistralai/ministral3-vl.mdx
+++ b/docs/model-coverage/vlm/mistralai/ministral3-vl.mdx
@@ -69,7 +69,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/mistral/ministral3_3b_medpix.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/vlm/mistralai/mistral-medium-3-5.mdx
+++ b/docs/model-coverage/vlm/mistralai/mistral-medium-3-5.mdx
@@ -133,7 +133,7 @@ sbatch your_slurm_script.sub
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/vlm/mistralai/mistral-medium-3-5.mdx
+++ b/docs/model-coverage/vlm/mistralai/mistral-medium-3-5.mdx
@@ -133,7 +133,7 @@ sbatch your_slurm_script.sub
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/vlm/mistralai/mistral-small-4.mdx
+++ b/docs/model-coverage/vlm/mistralai/mistral-small-4.mdx
@@ -68,7 +68,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/mistral4/mistral4_medpix.yaml
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/vlm/mistralai/mistral-small-4.mdx
+++ b/docs/model-coverage/vlm/mistralai/mistral-small-4.mdx
@@ -68,7 +68,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/mistral4/mistral4_medpix.yaml
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/vlm/moonshotai/kimi-vl.mdx
+++ b/docs/model-coverage/vlm/moonshotai/kimi-vl.mdx
@@ -65,7 +65,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/kimi/kimi2vl_cordv2.yaml
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/vlm/moonshotai/kimi-vl.mdx
+++ b/docs/model-coverage/vlm/moonshotai/kimi-vl.mdx
@@ -65,7 +65,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/kimi/kimi2vl_cordv2.yaml
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/vlm/nvidia/nemotron-parse.mdx
+++ b/docs/model-coverage/vlm/nvidia/nemotron-parse.mdx
@@ -63,7 +63,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/nemotron/nemotron_parse_v1_1.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/vlm/nvidia/nemotron-parse.mdx
+++ b/docs/model-coverage/vlm/nvidia/nemotron-parse.mdx
@@ -63,7 +63,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/nemotron/nemotron_parse_v1_1.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/vlm/qwen/qwen2-5-vl.mdx
+++ b/docs/model-coverage/vlm/qwen/qwen2-5-vl.mdx
@@ -70,7 +70,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/qwen2_5/qwen2_5_vl_3b_rdr.yam
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/vlm/qwen/qwen2-5-vl.mdx
+++ b/docs/model-coverage/vlm/qwen/qwen2-5-vl.mdx
@@ -70,7 +70,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/qwen2_5/qwen2_5_vl_3b_rdr.yam
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/vlm/qwen/qwen3-5-vl.mdx
+++ b/docs/model-coverage/vlm/qwen/qwen3-5-vl.mdx
@@ -67,7 +67,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/qwen3_5/qwen3_5_4b.yaml
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/vlm/qwen/qwen3-5-vl.mdx
+++ b/docs/model-coverage/vlm/qwen/qwen3-5-vl.mdx
@@ -67,7 +67,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/qwen3_5/qwen3_5_4b.yaml
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/vlm/qwen/qwen3-vl.mdx
+++ b/docs/model-coverage/vlm/qwen/qwen3-vl.mdx
@@ -70,7 +70,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/qwen3/qwen3_vl_4b_instruct_rd
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/model-coverage/vlm/qwen/qwen3-vl.mdx
+++ b/docs/model-coverage/vlm/qwen/qwen3-vl.mdx
@@ -70,7 +70,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/qwen3/qwen3_vl_4b_instruct_rd
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.04.00
+  nvcr.io/nvidia/nemo-automodel:26.06.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):


### PR DESCRIPTION
## What

Updates every "use this container" reference for NeMo AutoModel to the current **`26.04.00`** NGC container, and fixes the installation guide's repo-mount instructions.

### Container tag bumps
- `CONTRIBUTING.md` — both `docker run` commands (`25.11.00` → `26.04.00`).
- Docs site — bumped all `25.11.00` and `26.02.00` `nemo-automodel` references to `26.04.00` across the installation guide, checkpointing guide, model-coverage index + per-model pages, and the LLM / VLM / dLLM / diffusion / speculative guides. **94 files total.**

### Installation guide mount fix
Rewrote `docs/guides/installation.mdx` → **"Mount the Repo into a NeMo Docker Container"** to match the canonical flow in `CONTRIBUTING.md`. The old version was incorrect:
- It mounted to `/workspace/Automodel` and included a broken `-v $(pwd)/Automodel:/opt/Automodel` (after `cd Automodel`, `$(pwd)/Automodel` does not exist).
- It used `pip install -e .`, which breaks against the PyTorch base container.

The new version bind-mounts the local checkout over `/opt/Automodel`, runs `docker/common/update_pyproject_pytorch.sh` + `uv sync --locked --extra all --all-groups`, and adds a `<Warning>` explaining why the `update_pyproject_pytorch.sh` step is required.

## Intentionally NOT changed
- Historical `release-notes.mdx` entries (`0.2.0 · 25.11`, `0.3.0 · 26.02`).
- `performance-summary.mdx` benchmark-environment labels `(26.02)` — they record the container the numbers were measured on; bumping would misstate the benchmark environment.
- `docs/launcher/nemo-run.mdx` `:26.02` tag — coupled to `tests/unit_tests/launcher/test_nemo_run_config.py`, which asserts `:26.02`. Bumping the doc would require updating that test in lockstep (a code change, out of scope).
- `nemo_automodel/shared/torch_patches.py` `nv25.11` — a PyTorch base-image version check, not the AutoModel container tag.

## Notes
- **Tag format:** used the full `26.04.00` patch tag to match existing docs and the `0.4.0` NGC tag recorded in `release-notes.mdx`. (The README badge and the `build-and-dependency` contributor skill use the short `26.04` form.)
- **Validation:** `fern check` runs in CI (`fern-docs-ci.yml`); it is not runnable locally here (`fern`/`node` not installed). No nav / slug / redirect changes were made, so link structure is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
