### PR TITLE
ci: raise super-49B robustness time limit to 1h15m

### DIFF
--- a/examples/llm_finetune/nemotron/llama3_3_nemotron_super_49B_squad.yaml
+++ b/examples/llm_finetune/nemotron/llama3_3_nemotron_super_49B_squad.yaml
@@ -119,7 +119,7 @@ lr_scheduler:
 ci:
   recipe_owner: akoumpa
   nodes: 2
-  time: "00:55:00"  # 49B robustness (Phase 1-4 reloads of a 49B on 2 nodes) needs >45min
+  time: "01:15:00"  # 49B finetune+robustness runs ~51-55min wall-clock; 55min is too tight (a run hit 55.1min)
   vllm_deploy: true
   vllm_smoke_test: true  # 49B exceeds 1 GPU; use vLLM's native nemotron-nas backend (no HF reference load)
   vllm_deploy_gpus: 4  # expose 4 of the node's 8 GPUs for tensor-parallel vLLM load


### PR DESCRIPTION
## What

Raise the `ci.time` limit for the `llama3_3_nemotron_super_49B_squad` checkpoint-robustness recipe from `00:55:00` to `01:15:00`.

**Targets #2703** (`akoumpa/am-436-llama33-super`) so this rides along with the DeciLM Nemotron TP-plan work rather than as a standalone change. (The original 49B fix landed in #2626, which merged with `ci.time` set to `00:55:00`.)

## Why

`00:55:00` is **too tight**: the finetune + robustness producer runs **~51–55 min wall-clock** across measured runs:
- pipeline 55194011 (the run behind #2626): ~51 min
- pipeline 55467887 (1h-limit experiment): **55.1 min**

A 55-min limit risks SLURM-cancelling the job right at the finish line (the 55.1-min run would have been killed at 55:00). `01:15:00` gives ~20 min of headroom for Lustre/queue variance while staying far tighter than a blanket 2h.

`ci.time` only sets the SLURM wall-clock ceiling — it does not change test behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
