### PR TITLE
docs: update v0.4 container references to 26.04 and fix mount instructions

### DIFF
--- a/docs/fern/versions/v0.4/pages/guides/checkpointing.mdx
+++ b/docs/fern/versions/v0.4/pages/guides/checkpointing.mdx
@@ -252,7 +252,7 @@ When training inside a Docker container (see [Installation Guide](/get-started/i
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v "$(pwd)"/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:25.11.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 You can also set a custom checkpoint directory via the YAML config or CLI override:

--- a/docs/fern/versions/v0.4/pages/guides/diffusion/finetune.mdx
+++ b/docs/fern/versions/v0.4/pages/guides/diffusion/finetune.mdx
@@ -50,8 +50,8 @@ pip3 install nemo-automodel
 Alternatively, if you run into dependency or driver issues, use the pre-built Docker container:
 
 ```bash
-docker pull nvcr.io/nvidia/nemo-automodel:26.02.00
-docker run --gpus all -it --rm --shm-size=8g nvcr.io/nvidia/nemo-automodel:26.02.00
+docker pull nvcr.io/nvidia/nemo-automodel:26.04.00
+docker run --gpus all -it --rm --shm-size=8g nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 <Info>

--- a/docs/fern/versions/v0.4/pages/guides/dllm/finetune.mdx
+++ b/docs/fern/versions/v0.4/pages/guides/dllm/finetune.mdx
@@ -46,8 +46,8 @@ pip3 install nemo-automodel
 Alternatively, use the pre-built Docker container:
 
 ```bash
-docker pull nvcr.io/nvidia/nemo-automodel:26.02.00
-docker run --gpus all -it --rm --shm-size=8g nvcr.io/nvidia/nemo-automodel:26.02.00
+docker pull nvcr.io/nvidia/nemo-automodel:26.04.00
+docker run --gpus all -it --rm --shm-size=8g nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 For the full set of installation methods, see the [installation guide](/get-started/installation).

--- a/docs/fern/versions/v0.4/pages/guides/installation.mdx
+++ b/docs/fern/versions/v0.4/pages/guides/installation.mdx
@@ -55,8 +55,8 @@ Use virtualenv (PyPI, Git, or editable install) when you need:
 Debian-based systems can have dependency conflicts with system packages. Containers provide isolation and consistency.
 
 ```bash
-docker pull nvcr.io/nvidia/nemo-automodel:25.11.00
-docker run --gpus all -it --rm --shm-size=8g nvcr.io/nvidia/nemo-automodel:25.11.00
+docker pull nvcr.io/nvidia/nemo-automodel:26.04.00
+docker run --gpus all -it --rm --shm-size=8g nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **Alternative: virtualenv** (if Docker is not available)
@@ -163,10 +163,10 @@ To verify the install, run `python -c "import nemo_automodel; print(nemo_automod
 ### Install with NeMo Docker Container
 You can use NeMo AutoModel with the NeMo Docker container. Pull the container by running:
 ```bash
-docker pull nvcr.io/nvidia/nemo-automodel:25.11.00
+docker pull nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 <Note>
-The above `docker` command uses the [`25.11.00`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-automodel?version=25.11.00) container. Use the [most recent container](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-automodel) version to ensure you get the latest version of AutoModel and its dependencies like PyTorch, Transformers, etc.
+The above `docker` command uses the [`26.04.00`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-automodel?version=26.04.00) container. Use the [most recent container](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-automodel) version to ensure you get the latest version of AutoModel and its dependencies like PyTorch, Transformers, etc.
 
 </Note>
 
@@ -175,7 +175,7 @@ Then you can enter the container using:
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v "$(pwd)"/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:25.11.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 <Info>
@@ -186,7 +186,7 @@ docker run --gpus all -it --rm \
   -v /path/to/your/checkpoints:/opt/Automodel/checkpoints \
   -v /path/to/your/datasets:/datasets \
   -v /path/to/your/hf_cache:/root/.cache/huggingface \
-  nvcr.io/nvidia/nemo-automodel:25.11.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 </Info>
@@ -240,7 +240,7 @@ This installs AutoModel in editable mode, so changes to the code are immediately
 
 ### Mount the Repo into a NeMo Docker Container
 
-To run `Automodel` inside a NeMo container while **mounting your local repo**, follow these steps:
+To develop against your local checkout while reusing the container's pre-built dependencies, bind-mount your local `Automodel` directory over `/opt/Automodel`, overriding the source installed in the image:
 
 ```bash
 # Step 1: Clone the AutoModel repository.
@@ -248,22 +248,23 @@ git clone https://github.com/NVIDIA-NeMo/Automodel.git
 cd Automodel
 
 # Step 2: Pull a compatible container image (replace the tag as needed).
-docker pull nvcr.io/nvidia/nemo-automodel:25.11.00
+docker pull nvcr.io/nvidia/nemo-automodel:26.04.00
 
-# Step 3: Run the container, mount the repo, and run a quick sanity check.
-docker run --gpus all -it --rm \
-  -v $(pwd):/workspace/Automodel \         # Mount repo into container workspace
-  -v $(pwd)/Automodel:/opt/Automodel \     # Optional: Mount Automodel under /opt for flexibility
-  --shm-size=8g \                           # Increase shared memory for PyTorch/data loading
-  nvcr.io/nvidia/nemo-automodel:25.11.00 /bin/bash -c "\
-    cd /workspace/Automodel && \           # Enter the mounted repo
-    pip install -e . && \                  # Install Automodel in editable mode
-    automodel examples/llm_finetune/llama3_2/llama3_2_1b_squad.yaml" # Run a usage example
+# Step 3: Run the container, sync the mounted checkout, and run a usage example.
+docker run --gpus all --network=host -it --rm \
+  --shm-size=32g \
+  -v "$(pwd)":/opt/Automodel \
+  nvcr.io/nvidia/nemo-automodel:26.04.00 /bin/bash -c "\
+    cd /opt/Automodel && \
+    bash docker/common/update_pyproject_pytorch.sh /opt/Automodel && \
+    uv sync --locked --extra all --all-groups && \
+    automodel examples/llm_finetune/llama3_2/llama3_2_1b_squad.yaml"
 ```
-<Note>
-The above `docker` command mounts your local `Automodel` directory into the container at `/workspace/Automodel`.
 
-</Note>
+<Warning>
+The `update_pyproject_pytorch.sh` step is required. Without it, `uv sync` tries to reinstall `torch`, which causes CUDA version mismatches and TransformerEngine import failures, because `uv` cannot recognize the torch baked into the PyTorch base container.
+
+</Warning>
 
 ## Install Profiles
 

--- a/docs/fern/versions/v0.4/pages/guides/llm/finetune.mdx
+++ b/docs/fern/versions/v0.4/pages/guides/llm/finetune.mdx
@@ -43,8 +43,8 @@ pip3 install nemo-automodel
 Alternatively, if you run into dependency or driver issues, use the pre-built Docker container:
 
 ```bash
-docker pull nvcr.io/nvidia/nemo-automodel:26.02.00
-docker run --gpus all -it --rm --shm-size=8g -v $(pwd)/checkpoints:/tmp/checkpoints/ nvcr.io/nvidia/nemo-automodel:26.02.00
+docker pull nvcr.io/nvidia/nemo-automodel:26.04.00
+docker run --gpus all -it --rm --shm-size=8g -v $(pwd)/checkpoints:/tmp/checkpoints/ nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 <Info>

--- a/docs/fern/versions/v0.4/pages/guides/vlm/gemma4.mdx
+++ b/docs/fern/versions/v0.4/pages/guides/vlm/gemma4.mdx
@@ -61,7 +61,7 @@ This guide runs **inside** the NeMo Automodel Docker container:
 ```bash
 docker run -it --rm --gpus all --ipc=host --network host \
     -v $(pwd):/workspace \
-    nvcr.io/nvidia/nemo-automodel:26.02
+    nvcr.io/nvidia/nemo-automodel:26.04.00
 
 # Inside the container:
 huggingface-cli login          # needed for gated model access

--- a/docs/fern/versions/v0.4/pages/guides/vlm/qwen3-5.mdx
+++ b/docs/fern/versions/v0.4/pages/guides/vlm/qwen3-5.mdx
@@ -43,7 +43,7 @@ export WANDB_API_KEY=your_wandb_key
 
 srun --output=output.out \
      --error=output.err \
-     --container-image /your/path/to/automodel26.02.image.sqsh --no-container-mount-home bash -c "
+     --container-image /your/path/to/automodel26.04.image.sqsh --no-container-mount-home bash -c "
   CUDA_DEVICE_MAX_CONNECTIONS=1 automodel \
   examples/vlm_finetune/qwen3_5_moe/qwen3_5_moe_medpix.yaml \
   --nproc-per-node=8 \

--- a/docs/fern/versions/v0.4/pages/launcher/nemo-run.mdx
+++ b/docs/fern/versions/v0.4/pages/launcher/nemo-run.mdx
@@ -51,7 +51,7 @@ def my_slurm_cluster():
         exclusive=True,
         packager=run.Packager(),
     )
-    executor.container_image = "nvcr.io/nvidia/nemo-automodel:26.02"
+    executor.container_image = "nvcr.io/nvidia/nemo-automodel:26.04.00"
     executor.container_mounts = ["/data:/data", "/checkpoints:/checkpoints"]
     executor.env_vars = {"HF_HOME": "/data/hf_cache"}
     executor.time = "04:00:00"
@@ -70,7 +70,7 @@ import nemo_run as run
 def my_k8s_cluster():
     return run.KubeflowExecutor(
         namespace="training",
-        image="nvcr.io/nvidia/nemo-automodel:26.02",
+        image="nvcr.io/nvidia/nemo-automodel:26.04.00",
         num_nodes=1,
         nprocs_per_node=8,
         gpus_per_node=8,

--- a/docs/fern/versions/v0.4/pages/model-coverage/diffusion/black-forest-labs/flux.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/diffusion/black-forest-labs/flux.mdx
@@ -66,7 +66,7 @@ torchrun --nproc-per-node=8 \
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/diffusion/hunyuanvideo-community/hunyuanvideo.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/diffusion/hunyuanvideo-community/hunyuanvideo.mdx
@@ -65,7 +65,7 @@ torchrun --nproc-per-node=8 \
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/diffusion/qwen/qwen-image.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/diffusion/qwen/qwen-image.mdx
@@ -65,7 +65,7 @@ torchrun --nproc-per-node=8 \
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/diffusion/wan-ai/wan2-1-t2v.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/diffusion/wan-ai/wan2-1-t2v.mdx
@@ -66,7 +66,7 @@ torchrun --nproc-per-node=8 \
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/allenai/olmo.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/allenai/olmo.mdx
@@ -64,7 +64,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/allenai/olmo2.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/allenai/olmo2.mdx
@@ -67,7 +67,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/olmo/olmo_2_0425_1b_instruct_
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/allenai/olmoe.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/allenai/olmoe.mdx
@@ -64,7 +64,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/baai/aquila.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/baai/aquila.mdx
@@ -65,7 +65,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/baichuan-inc/baichuan.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/baichuan-inc/baichuan.mdx
@@ -67,7 +67,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/baichuan/baichuan_2_7b_squad.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/bigcode/starcoder.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/bigcode/starcoder.mdx
@@ -66,7 +66,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/bigcode/starcoder2.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/bigcode/starcoder2.mdx
@@ -68,7 +68,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/starcoder/starcoder_2_7b_squa
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/bytedance-seed/seed.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/bytedance-seed/seed.mdx
@@ -68,7 +68,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/seed/seed_coder_8b_instruct_s
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/cohere/command-r.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/cohere/command-r.mdx
@@ -68,7 +68,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/cohere/cohere_command_r_7b_sq
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/deepseek-ai/deepseek-v3.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/deepseek-ai/deepseek-v3.mdx
@@ -78,7 +78,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/deepseek_v32/deepseek_v32_hel
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/deepseek-ai/deepseek.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/deepseek-ai/deepseek.mdx
@@ -65,7 +65,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/deepseek-ai/dsv4-flash.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/deepseek-ai/dsv4-flash.mdx
@@ -68,7 +68,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/deepseek_v4/deepseek_v4_flash
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/eleutherai/gpt-j.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/eleutherai/gpt-j.mdx
@@ -64,7 +64,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/eleutherai/gpt-neox.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/eleutherai/gpt-neox.mdx
@@ -70,7 +70,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/google/gemma.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/google/gemma.mdx
@@ -76,7 +76,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/gemma/gemma_2_9b_it_squad.yam
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/ibm/bamba.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/ibm/bamba.mdx
@@ -62,7 +62,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/ibm/granite-moe.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/ibm/granite-moe.mdx
@@ -68,7 +68,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/ibm/granite.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/ibm/granite.mdx
@@ -69,7 +69,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/granite/granite_3_3_2b_instru
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/inceptionai/jais.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/inceptionai/jais.mdx
@@ -68,7 +68,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/index.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/index.mdx
@@ -8,7 +8,7 @@ Large Language Models (LLMs) power a variety of tasks such as dialogue systems, 
 NeMo AutoModel provides a simple interface for loading and fine-tuning LLMs hosted on the Hugging Face Hub.
 
 ## Run LLMs with NeMo AutoModel
-To run LLMs with NeMo AutoModel, make sure you're using NeMo container version [`25.11.00`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-automodel?version=25.11.00) or later. If the model you intend to fine-tune requires a newer version of Transformers, you may need to upgrade to the latest version of NeMo AutoModel by using:
+To run LLMs with NeMo AutoModel, make sure you're using NeMo container version [`26.04.00`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-automodel?version=26.04.00) or later. If the model you intend to fine-tune requires a newer version of Transformers, you may need to upgrade to the latest version of NeMo AutoModel by using:
 
 ```bash
 pip3 install --upgrade git+git@github.com:NVIDIA-NeMo/AutoModel.git

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/internlm/internlm.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/internlm/internlm.mdx
@@ -68,7 +68,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/lgai-exaone/exaone.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/lgai-exaone/exaone.mdx
@@ -63,7 +63,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/meta/llama.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/meta/llama.mdx
@@ -77,7 +77,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/llama3_2/llama3_2_1b_squad.ya
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/microsoft/phi.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/microsoft/phi.mdx
@@ -66,7 +66,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/phi/phi_2_squad.yaml
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/microsoft/phi3-small.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/microsoft/phi3-small.mdx
@@ -64,7 +64,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/microsoft/phi3.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/microsoft/phi3.mdx
@@ -75,7 +75,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/phi/phi_4_squad.yaml
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/minimax/minimax-m2.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/minimax/minimax-m2.mdx
@@ -73,7 +73,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/minimax_m2/minimax_m2.1_hella
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/mistralai/ministral3.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/mistralai/ministral3.mdx
@@ -68,7 +68,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/devstral/devstral2_small_2512
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/mistralai/mistral.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/mistralai/mistral.mdx
@@ -70,7 +70,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/mistral/mistral_7b_squad.yaml
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/mistralai/mixtral.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/mistralai/mixtral.mdx
@@ -67,7 +67,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/mistral/mixtral-8x7b-v0-1_squ
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/moonshotai/moonlight.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/moonshotai/moonlight.mdx
@@ -64,7 +64,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/moonlight/moonlight_16b_te.ya
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/nvidia/nemotron-flash.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/nvidia/nemotron-flash.mdx
@@ -69,7 +69,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/nemotron_flash/nemotron_flash
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/nvidia/nemotron-h.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/nvidia/nemotron-h.mdx
@@ -70,7 +70,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/nemotron/nemotron_nano_9b_squ
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/nvidia/nemotron-super.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/nvidia/nemotron-super.mdx
@@ -62,7 +62,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/nvidia/nemotron.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/nvidia/nemotron.mdx
@@ -62,7 +62,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/openai/gpt-oss.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/openai/gpt-oss.mdx
@@ -66,7 +66,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/gpt_oss/gpt_oss_20b.yaml
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/openbmb/minicpm.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/openbmb/minicpm.mdx
@@ -66,7 +66,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/orionstar/orion.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/orionstar/orion.mdx
@@ -64,7 +64,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/parasail-ai/gritlm.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/parasail-ai/gritlm.mdx
@@ -62,7 +62,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/qwen/qwen2-moe.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/qwen/qwen2-moe.mdx
@@ -64,7 +64,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/qwen/qwen1_5_moe_a2_7b_qlora.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/qwen/qwen2.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/qwen/qwen2.mdx
@@ -69,7 +69,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/qwen/qwen2_5_7b_squad.yaml
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/qwen/qwen3-moe.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/qwen/qwen3-moe.mdx
@@ -66,7 +66,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/qwen/qwen3_moe_30b_te_deepep.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/qwen/qwen3-next.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/qwen/qwen3-next.mdx
@@ -68,7 +68,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/qwen/qwen3_next_te_deepep.yam
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/qwen/qwen3.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/qwen/qwen3.mdx
@@ -66,7 +66,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/qwen/qwen3_0p6b_hellaswag.yam
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/stabilityai/stablelm.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/stabilityai/stablelm.mdx
@@ -64,7 +64,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/stepfun-ai/step-3-5.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/stepfun-ai/step-3-5.mdx
@@ -68,7 +68,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/stepfun/step_3.5_flash_hellas
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/thudm/chatglm.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/thudm/chatglm.mdx
@@ -64,7 +64,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/thudm/glm4-moe.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/thudm/glm4-moe.mdx
@@ -76,7 +76,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/glm/glm_4.5_air_te_deepep.yam
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/thudm/glm4.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/thudm/glm4.mdx
@@ -67,7 +67,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/glm/glm_4_9b_chat_hf_squad.ya
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/thudm/glm5-moe-dsa.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/thudm/glm5-moe-dsa.mdx
@@ -100,7 +100,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/glm/glm_5_hellaswag_pp.yaml
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/tiiuae/falcon.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/tiiuae/falcon.mdx
@@ -69,7 +69,7 @@ automodel --nproc-per-node=8 examples/llm_finetune/falcon/falcon3_7b_instruct_sq
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/llm/upstage/solar.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/llm/upstage/solar.mdx
@@ -62,7 +62,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/fern/versions/v0.4/pages/model-coverage/omni/index.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/omni/index.mdx
@@ -7,7 +7,7 @@ Omni models go beyond image-text understanding to support additional modalities 
 
 ## Run Omni Models with NeMo AutoModel
 
-To run omni models with NeMo AutoModel, use NeMo container version [`25.11.00`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-automodel?version=25.11.00) or later. If the model you want to fine-tune requires a newer version of Transformers, you may need to upgrade:
+To run omni models with NeMo AutoModel, use NeMo container version [`26.04.00`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-automodel?version=26.04.00) or later. If the model you want to fine-tune requires a newer version of Transformers, you may need to upgrade:
 
 ```bash
 pip3 install --upgrade git+git@github.com:NVIDIA-NeMo/AutoModel.git

--- a/docs/fern/versions/v0.4/pages/model-coverage/omni/microsoft/phi4-multimodal.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/omni/microsoft/phi4-multimodal.mdx
@@ -63,7 +63,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/phi4/phi4_mm_cv17.yaml
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/omni/qwen/qwen3-omni.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/omni/qwen/qwen3-omni.mdx
@@ -63,7 +63,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/qwen3/qwen3_omni_moe_30b_te_d
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/vlm/google/gemma3-vl.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/vlm/google/gemma3-vl.mdx
@@ -71,7 +71,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/gemma3/gemma3_vl_4b_cord_v2.y
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/vlm/google/gemma4.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/vlm/google/gemma4.mdx
@@ -79,7 +79,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/gemma4/gemma4_4b.yaml
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/vlm/huggingface/smolvlm.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/vlm/huggingface/smolvlm.mdx
@@ -64,7 +64,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/fern/versions/v0.4/pages/model-coverage/vlm/index.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/vlm/index.mdx
@@ -11,7 +11,7 @@ NeMo AutoModel LLM APIs can be easily extended to support VLM tasks. While most 
 
 ## Run VLMs with NeMo AutoModel
 
-To run VLMs with NeMo AutoModel, use NeMo container version [`25.11.00`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-automodel?version=25.11.00) or later. If the model you want to fine-tune requires a newer version of Transformers, you may need to upgrade:
+To run VLMs with NeMo AutoModel, use NeMo container version [`26.04.00`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-automodel?version=26.04.00) or later. If the model you want to fine-tune requires a newer version of Transformers, you may need to upgrade:
 
 ```bash
 pip3 install --upgrade git+git@github.com:NVIDIA-NeMo/AutoModel.git

--- a/docs/fern/versions/v0.4/pages/model-coverage/vlm/internlm/internvl.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/vlm/internlm/internvl.mdx
@@ -64,7 +64,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/internvl/internvl_3_5_4b.yaml
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/vlm/llava-hf/llava.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/vlm/llava-hf/llava.mdx
@@ -73,7 +73,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/fern/versions/v0.4/pages/model-coverage/vlm/lmms-lab/llava-onevision.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/vlm/lmms-lab/llava-onevision.mdx
@@ -68,7 +68,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/llava_onevision/llava_ov_1_5_
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/vlm/meta/llama4.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/vlm/meta/llama4.mdx
@@ -64,7 +64,7 @@ Replace `<MODEL_HF_ID>` with the model ID from **Example HF Models** above.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** The recipes are at `/opt/Automodel/examples/` — navigate there:

--- a/docs/fern/versions/v0.4/pages/model-coverage/vlm/mistralai/ministral3-vl.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/vlm/mistralai/ministral3-vl.mdx
@@ -69,7 +69,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/mistral/ministral3_3b_medpix.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/vlm/mistralai/mistral-medium-3-5.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/vlm/mistralai/mistral-medium-3-5.mdx
@@ -133,7 +133,7 @@ sbatch your_slurm_script.sub
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/vlm/mistralai/mistral-small-4.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/vlm/mistralai/mistral-small-4.mdx
@@ -68,7 +68,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/mistral4/mistral4_medpix.yaml
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/vlm/moonshotai/kimi-vl.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/vlm/moonshotai/kimi-vl.mdx
@@ -65,7 +65,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/kimi/kimi2vl_cordv2.yaml
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/vlm/nvidia/nemotron-parse.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/vlm/nvidia/nemotron-parse.mdx
@@ -63,7 +63,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/nemotron/nemotron_parse_v1_1.
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/vlm/qwen/qwen2-5-vl.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/vlm/qwen/qwen2-5-vl.mdx
@@ -70,7 +70,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/qwen2_5/qwen2_5_vl_3b_rdr.yam
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/vlm/qwen/qwen3-5-vl.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/vlm/qwen/qwen3-5-vl.mdx
@@ -67,7 +67,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/qwen3_5/qwen3_5_4b.yaml
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):

--- a/docs/fern/versions/v0.4/pages/model-coverage/vlm/qwen/qwen3-vl.mdx
+++ b/docs/fern/versions/v0.4/pages/model-coverage/vlm/qwen/qwen3-vl.mdx
@@ -70,7 +70,7 @@ automodel --nproc-per-node=8 examples/vlm_finetune/qwen3/qwen3_vl_4b_instruct_rd
 docker run --gpus all -it --rm \
   --shm-size=8g \
   -v $(pwd)/checkpoints:/opt/Automodel/checkpoints \
-  nvcr.io/nvidia/nemo-automodel:26.02.00
+  nvcr.io/nvidia/nemo-automodel:26.04.00
 ```
 
 **2.** Navigate to the AutoModel directory (where the recipes are):


### PR DESCRIPTION
## What

Back-ports the container-version fix to the **frozen v0.4 GA docs** (`docs/fern/versions/v0.4/pages/`), targeting **`26.04.00`** — the container that 0.4.0 actually shipped with (`breaking-changes.mdx: 0.4.0 · 26.04`). This is the v0.4 counterpart to #2716, which targets the nightly `main` tree at `26.06`.

### Container tag bumps (→ `26.04.00`) — 83 files
- Installation guide, checkpointing guide, model-coverage index + per-model pages, and the LLM / VLM / dLLM / diffusion / speculative guides (the stale `25.11.00` and `26.02.00` tags).
- `launcher/nemo-run.mdx` is **included** here (unlike #2716): the `test_nemo_run_config.py` that pins `:26.02` does not exist on `docs-archive`, so the frozen v0.4 site can be fully consistent on its 26.04 GA container.
- The 1 `automodel26.02.image.sqsh` example filename → `automodel26.04.image.sqsh`.

### Installation guide mount fix
Same back-port as #2716: rewrote `guides/installation.mdx` → **"Mount the Repo into a NeMo Docker Container"** to bind-mount the local checkout over `/opt/Automodel`, run `docker/common/update_pyproject_pytorch.sh` + `uv sync`, then a usage-example run, with a `<Warning>` about the `update_pyproject_pytorch.sh` step. This replaces the old broken `/workspace/Automodel` mount + `pip install -e .`.

## Intentionally NOT changed
- `performance-summary.mdx` benchmark-environment labels `(26.02)` — the numbers were measured on the 26.02 container.
- `breaking-changes.mdx` (`0.4.0 · 26.04`) and `guides/vlm/nemotron-omni.mdx` (`26.04+`) — already correct / historical.
- `CONTRIBUTING.md` and `release-notes.mdx` do not exist on `docs-archive`.

## Notes
- This is a deliberate back-port onto the `docs-archive` branch (the sanctioned mechanism for editing frozen version pages). **Base = `docs-archive`**, not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
