### PR TITLE
fix(qwen3_moe): step-0 NaN in MXFP8 packed finetune — expert unload + fused RoPE

### DIFF
--- a/examples/llm_finetune/qwen/qwen3_moe_30b_te_hybridep.yaml
+++ b/examples/llm_finetune/qwen/qwen3_moe_30b_te_hybridep.yaml
@@ -48,6 +48,7 @@ model:
     rms_norm: torch_fp32
     experts: te
     dispatcher: hybridep
+    rope_fusion: false  # fused TE RoPE produces NaN gradients on packed (THD) sequences
     fake_balanced_gate: false
     enable_hf_state_dict_adapter: true
 

--- a/examples/llm_finetune/qwen/qwen3_moe_30b_te_hybridep_mxfp8.yaml
+++ b/examples/llm_finetune/qwen/qwen3_moe_30b_te_hybridep_mxfp8.yaml
@@ -51,6 +51,7 @@ model:
     rms_norm: torch_fp32
     experts: te
     dispatcher: hybridep
+    rope_fusion: false  # fused TE RoPE produces NaN gradients on packed (THD) sequences
     fake_balanced_gate: false
     enable_hf_state_dict_adapter: true
     te_fp8:

--- a/examples/llm_finetune/qwen/qwen3_moe_30b_te_packed_sequence.yaml
+++ b/examples/llm_finetune/qwen/qwen3_moe_30b_te_packed_sequence.yaml
@@ -45,6 +45,7 @@ model:
     rms_norm: torch_fp32
     experts: te
     dispatcher: deepep
+    rope_fusion: false  # fused TE RoPE produces NaN gradients on packed (THD) sequences
     fake_balanced_gate: false
     enable_hf_state_dict_adapter: true
 

--- a/nemo_automodel/components/moe/state_dict_mixin.py
+++ b/nemo_automodel/components/moe/state_dict_mixin.py
@@ -644,6 +644,13 @@ class MoESplitExpertsStateDictMixin:
         # rebuild path: never mark these keys in-place-loaded when ``quantization`` is set.
         quantization = kwargs.get("quantization", False)
 
+        # GroupedExpertsTE (backend.experts == "te") exposes gate_and_up_projs/down_projs as a
+        # torch.stack COPY of TE's per-expert weight{i} params; it does not alias the model's
+        # grouped storage, so an in-place copy_ would write that throwaway buffer and leave the TE
+        # experts at their initial values. Force the rebuild path for it. Other expert backends
+        # keep a real aliasing stacked Parameter and are unaffected.
+        experts_alias_grouped_storage = getattr(getattr(self, "backend", None), "experts", None) != "te"
+
         from nemo_automodel.components.moe.state_dict_utils import (
             is_dtensor,
             validate_dtensor_expert_sharding,
@@ -662,6 +669,7 @@ class MoESplitExpertsStateDictMixin:
                 and len(splits) > 0
                 and not is_dtensor(splits[0])
                 and not quantization
+                and experts_alias_grouped_storage
             )
             if inplace_ok:
                 self._register_inplace_loaded_key(fqn, prefix_override)
@@ -709,6 +717,7 @@ class MoESplitExpertsStateDictMixin:
                 and len(splits) > 0
                 and not is_dtensor(splits[0])
                 and not quantization
+                and experts_alias_grouped_storage
             )
             if inplace_ok:
                 self._register_inplace_loaded_key(fqn, prefix_override)

--- a/tests/unit_tests/moe/test_state_dict_mixin.py
+++ b/tests/unit_tests/moe/test_state_dict_mixin.py
@@ -895,3 +895,45 @@ class TestInplaceLoadViews:
         assert "model.layers.0.mlp.experts.gate_and_up_projs" not in out
         assert "model.layers.0.mlp.experts.down_projs" not in out
         assert mixin._inplace_loaded_native_keys == set()
+
+    def test_inplace_load_skips_when_backend_experts_is_te_gate_and_up(self):
+        # GroupedExpertsTE (backend.experts == "te") exposes gate_and_up_projs as a
+        # torch.stack copy of per-expert weights that does not alias the model's grouped
+        # storage. Even for a DTensor source the in-place path must not engage, otherwise
+        # the copy_ would write the throwaway and the experts would never be loaded.
+        mixin = MockMoEStateDictMixin(n_experts=2, inter_dim=512)
+        mixin.backend.experts = "te"
+        local_storage = torch.randn(2, 1024, 1024)
+        splits = [local_storage[i] for i in range(2)]
+        mock_dtensor = Mock()
+
+        result = self._run_inplace_conversion(
+            mixin, "model.layers.0.mlp.experts.gate_and_up_projs", mock_dtensor, splits
+        )
+
+        assert result is not None
+        for _, v in result:
+            assert v.is_contiguous(), "experts=='te' must emit contiguous copies, not in-place views"
+        assert not hasattr(mixin, "_inplace_loaded_native_keys") or (
+            "model.layers.0.mlp.experts.gate_and_up_projs" not in (mixin._inplace_loaded_native_keys or set())
+        )
+
+    def test_inplace_load_skips_when_backend_experts_is_te_down_projs(self):
+        # Same non-aliasing reason as the gate_and_up case, for the down_projs branch.
+        mixin = MockMoEStateDictMixin(n_experts=2, inter_dim=512)
+        mixin.backend.experts = "te"
+        local_storage = torch.randn(2, 512, 1024)
+        splits = [local_storage[i] for i in range(2)]
+        mock_dtensor = Mock(spec=["ndim", "shape", "is_meta"])
+        mock_dtensor.ndim = 3
+        mock_dtensor.shape = (2, 512, 1024)
+        mock_dtensor.is_meta = False
+
+        result = self._run_inplace_conversion(mixin, "model.layers.3.mlp.experts.down_projs", mock_dtensor, splits)
+
+        assert result is not None and len(result) == 2
+        for _, v in result:
+            assert v.is_contiguous(), "experts=='te' must emit contiguous copies, not in-place views"
+        assert not hasattr(mixin, "_inplace_loaded_native_keys") or (
+            "model.layers.3.mlp.experts.down_projs" not in (mixin._inplace_loaded_native_keys or set())
+        )


### PR DESCRIPTION
Two independent bugs make the Qwen3-MoE-30B MXFP8/packed-sequence finetune produce NaN at step 0 (and garbage loss in bf16). Both are fixed here.

## Bug 1 — GroupedExpertsTE experts silently unloaded (`state_dict_mixin.py`)

`GroupedExpertsTE` (`backend.experts == "te"`) exposes `gate_and_up_projs` / `down_projs` as a **`torch.stack` COPY** of TransformerEngine's per-expert `weight{i}` params — it does **not** alias the model's grouped expert storage.

At `ep_shard == 1` (`ep_size == world_size`), the merged-expert state-dict conversion marks the key as in-place-loadable, so DCP does `target.copy_(source)` through strided views. For the TE backend those views point at the throwaway `torch.stack`, so the data never reaches TE's real `weight{i}` params — the experts stay at **random init**, **silently** (`strict=False`). bf16 → garbage loss (~15.8); MXFP8 → NaN.

Fix: exclude `experts == "te"` from the in-place path so it rebuilds via `_set_stacked_weight`. Other backends (`GroupedExperts`, `GroupedExpertsDeepEP`) keep a real aliasing `nn.Parameter` and are unaffected. #2682 closed only the **quantization** sub-case of this same hazard; a plain **bf16** checkpoint still slipped through.

## Bug 2 — fused TE RoPE NaNs the backward on packed (THD) sequences (3 configs)

Fused TransformerEngine RoPE is numerically unstable on THD/packed sequences: the forward stays finite, but the **backward emits NaN gradients** at step 0 (`grad_norm nan`), which NaNs training from step 1; under MXFP8 it surfaces as a step-0 forward NaN. The packed recipes don't set `rope_fusion`, so they inherit the default (`HAVE_TE and cuda` → `True`) and hit the bad path.

Fix: pin `rope_fusion: false` in the `model.backend` block of the three affected packed recipes (`qwen3_moe_30b_te_hybridep_mxfp8`, `qwen3_moe_30b_te_hybridep`, `qwen3_moe_30b_te_packed_sequence`). Mirrors #2687, which applied the identical one-line fix to the sibling `qwen3_moe_30b_te_packed_sequence_lora` recipe; see #2674. (The other packed qwen3-moe recipes — `magi_*`, `flashoptim`, `lora` — already set it.)

## Verification

GB200 Qwen3-MoE-30B (Qwen3-30B-A3B) finetune, `ep_size=8`, packed sequences. With both fixes, bf16, TE-MXFP8, and torchao-MXFP8 all train cleanly and converge identically:

| precision | step-0 loss | step-0 grad_norm | → step-2 loss |
|---|---|---|---|
| bf16 | 3.04 | 13.88 | 2.23 |
| TE-MXFP8 | 3.04 | 13.81 | 2.22 |
| torchao-MXFP8 | 3.05 | 15.69 | 2.23 |

bf16 ran the full 50 steps (loss 3.04 → 1.89, grad_norm → ~1.1, zero NaN). The MXFP8 forward-NaN was downstream of the fused-RoPE corruption — there is no separate MXFP8 kernel/block-scaling issue.

Refs nvbug 6350293.
