### PR TITLE
fix(qwen3_moe): disable fused RoPE on packed-sequence recipes (step-0 NaN grad)

### DIFF
--- a/examples/llm_finetune/qwen/qwen3_moe_30b_te_hybridep.yaml
+++ b/examples/llm_finetune/qwen/qwen3_moe_30b_te_hybridep.yaml
@@ -48,6 +48,7 @@ model:
     rms_norm: torch_fp32
     experts: te
     dispatcher: hybridep
+    rope_fusion: false  # fused TE RoPE produces NaN gradients on packed (THD) sequences
     fake_balanced_gate: false
     enable_hf_state_dict_adapter: true
 

--- a/examples/llm_finetune/qwen/qwen3_moe_30b_te_hybridep_mxfp8.yaml
+++ b/examples/llm_finetune/qwen/qwen3_moe_30b_te_hybridep_mxfp8.yaml
@@ -51,6 +51,7 @@ model:
     rms_norm: torch_fp32
     experts: te
     dispatcher: hybridep
+    rope_fusion: false  # fused TE RoPE produces NaN gradients on packed (THD) sequences
     fake_balanced_gate: false
     enable_hf_state_dict_adapter: true
     te_fp8:

--- a/examples/llm_finetune/qwen/qwen3_moe_30b_te_packed_sequence.yaml
+++ b/examples/llm_finetune/qwen/qwen3_moe_30b_te_packed_sequence.yaml
@@ -45,6 +45,7 @@ model:
     rms_norm: torch_fp32
     experts: te
     dispatcher: deepep
+    rope_fusion: false  # fused TE RoPE produces NaN gradients on packed (THD) sequences
     fake_balanced_gate: false
     enable_hf_state_dict_adapter: true
 


### PR DESCRIPTION
## Problem

Fused TransformerEngine RoPE is numerically unstable on THD/packed sequences:
the forward stays finite, but the **backward emits NaN gradients** at step 0
(`grad_norm nan` with a finite loss), which NaNs training from step 1 onward.

The qwen3-moe-30b packed-sequence recipes don't set `rope_fusion`, so they
inherit the default `rope_fusion = HAVE_TE and torch.cuda.is_available()` →
`True` on a GPU+TE build, and hit the bad path.

## Fix

Pin `rope_fusion: false` in the `model.backend` block of the three affected
packed recipes so they use the bounded non-fused RoPE path:

- `qwen3_moe_30b_te_hybridep_mxfp8.yaml`
- `qwen3_moe_30b_te_hybridep.yaml`
- `qwen3_moe_30b_te_packed_sequence.yaml`

This mirrors #2687, which applied the identical one-line fix to the sibling
`qwen3_moe_30b_te_packed_sequence_lora` recipe. See #2674 for the underlying
fused-RoPE-on-THD issue. (The other packed qwen3-moe recipes — `magi_*`,
`flashoptim`, `lora` — already set `rope_fusion: false`.)

## Verification

GB200 Qwen3-MoE-30B (Qwen3-30B-A3B) finetune, `ep_size=8`, packed sequences.
Before: step-0 `grad_norm nan` (bf16) / step-0 `loss nan` (MXFP8). After
`rope_fusion: false`, all of bf16, TE-MXFP8, and torchao-MXFP8 train cleanly
and converge identically:

| precision | step-0 loss | step-0 grad_norm | → step-2 loss |
|---|---|---|---|
| bf16 | 3.04 | 13.88 | 2.23 |
| TE-MXFP8 | 3.04 | 13.81 | 2.22 |
| torchao-MXFP8 | 3.05 | 15.69 | 2.23 |

(bf16 ran the full 50 steps: loss 3.04 → 1.89, grad_norm → ~1.1, zero NaN.)

Refs nvbug 6350293. Companion to #2722 (a separate checkpoint-load bug that
also surfaced on these recipes).
