### PR TITLE
fix(gemma4): avoid DynamicCache OOM on dense E2B/E4B via kv-share holder

### DIFF
--- a/nemo_automodel/components/models/gemma4_moe/model.py
+++ b/nemo_automodel/components/models/gemma4_moe/model.py
@@ -140,6 +140,48 @@ class _FSDPSafeSharedKVStates(MutableMapping):
         return len(self._store)
 
 
+class _Gemma4KVShareHolder:
+    """Cache-free holder that lets HF gemma4 kv-sharing fire under ``use_cache=False``.
+
+    E2B/E4B share K/V across the trailing ``num_kv_shared_layers`` layers: each shared
+    layer reads its source layer's K/V from ``past_key_values.shared_layers`` (see HF
+    ``Gemma4Attention.forward``). HF gates that read on ``past_key_values is not None``,
+    which is ``None`` whenever ``use_cache=False`` -- and ``use_cache`` is forced off by
+    activation checkpointing and the model-owned CP path. The shared layers then fall
+    back to their (frozen, unused) K/V projections and produce garbage, inflating the
+    loss ~4x.
+
+    Passing this lightweight object as ``past_key_values`` satisfies the gate so HF's
+    own kv-sharing logic runs: source layers populate ``shared_layers`` and shared
+    layers read it. ``update`` is a pass-through (no per-token accumulation, so no cache
+    memory growth), and ``get_seq_length`` returns 0 so the causal mask is built with a
+    zero cache offset (correct for a training forward).
+
+    It also avoids the OOM where, under ``use_cache=True`` with no ``past_key_values``
+    supplied, HF builds a real ``DynamicCache`` that accumulates per-layer K/V across the
+    whole training forward -- wasted memory that fragments the allocator and OOMs the
+    FSDP2 gradient reduce-scatter on E4B.
+    """
+
+    def __init__(self) -> None:
+        self.shared_layers: dict = {}
+
+    def get_seq_length(self, *args, **kwargs) -> int:
+        return 0
+
+    def get_mask_sizes(self, query_length: int, layer_idx=None) -> tuple[int, int]:
+        # (kv_length, kv_offset): no cache -> kv spans the current query, zero offset.
+        return query_length, 0
+
+    def update(self, key_states, value_states, layer_idx, *args, **kwargs):
+        return key_states, value_states
+
+
+def _kv_sharing_active(text_config) -> bool:
+    """True if the (dense) text config uses gemma4 kv-sharing (E2B/E4B)."""
+    return int(getattr(text_config, "num_kv_shared_layers", 0) or 0) > 0
+
+
 # ---------------------------------------------------------------------------
 # Gemma4-specific router that outputs NeMo-compatible (weights, indices)
 # ---------------------------------------------------------------------------
@@ -788,6 +830,20 @@ class Gemma4ForConditionalGeneration(HFCheckpointingMixin, HFGemma4ForConditiona
             # the later layers -> KeyError. Pass an _FSDPSafeSharedKVStates
             # instead, which FSDP2 leaves as one shared object. setdefault avoids
             # overwriting a store a caller already provided (e.g. the drafter).
+            # E2B/E4B kv-sharing: pass a cache-free pass-through holder as
+            # past_key_values for kv-sharing variants. Without it, use_cache=True
+            # makes HF build a real DynamicCache that accumulates per-layer K/V
+            # across the training forward -- wasted memory that fragments the
+            # allocator and OOMs the FSDP2 grad reduce-scatter on E4B. The holder
+            # also keeps kv-sharing correct when use_cache is off (activation
+            # checkpointing). Non-kv-sharing variants (e.g. 31B) get None,
+            # preserving prior behavior. See _Gemma4KVShareHolder.
+            kv_share_holder = (
+                _Gemma4KVShareHolder()
+                if (kwargs.get("past_key_values") is None and _kv_sharing_active(text_config))
+                else kwargs.pop("past_key_values", None)
+            )
+            kwargs.pop("past_key_values", None)
             kwargs.setdefault("shared_kv_states", _FSDPSafeSharedKVStates())
             return super().forward(
                 input_ids=input_ids,
@@ -800,6 +856,7 @@ class Gemma4ForConditionalGeneration(HFCheckpointingMixin, HFGemma4ForConditiona
                 mm_token_type_ids=mm_token_type_ids,
                 logits_to_keep=logits_to_keep,
                 output_hidden_states=output_hidden_states,
+                past_key_values=kv_share_holder,
                 **kwargs,
             )
 


### PR DESCRIPTION
# What does this PR do ?

Backports the `_Gemma4KVShareHolder` mechanism from #2621 (on `main`) to the `r0.5.0`
release branch to fix a CUDA OOM on the **HF-direct dense Gemma 4 E2B/E4B** path
(e.g. `examples/vlm_finetune/gemma4/gemma4_4b_mock.yaml`). Only the dense path that
delegates to HF `Gemma4ForConditionalGeneration.forward` is touched; the custom-impl
MoE (26B-A4B) path is unaffected.

# Changelog

- Add `_Gemma4KVShareHolder` (a cache-free, pass-through `past_key_values`) and a
  `_kv_sharing_active()` helper to `components/models/gemma4_moe/model.py`.
- In the dense (non-MoE) branch of `Gemma4ForConditionalGeneration.forward`, pass
  `past_key_values=_Gemma4KVShareHolder()` for kv-sharing variants
  (`num_kv_shared_layers > 0`) instead of letting HF build a `DynamicCache`.
  Non-kv-sharing variants (e.g. 31B) get `None`, preserving prior behavior.

# Root cause

The dense E2B/E4B path runs `text_config.use_cache: true` (kept on for these models).
With no `past_key_values` supplied, HF builds a real `DynamicCache` and the non-shared
layers accumulate per-layer K/V into it across the entire *training* forward. Those
persistent allocations fragment the caching allocator, so the single large contiguous
fp32 gradient **reduce-scatter** buffer cannot be placed during the FSDP2 backward →
`torch.OutOfMemoryError` (E4B on 8×H100: ~15.6 GiB buffer vs ~46 GiB reserved-but-
unallocated). The decode cache is useless during a full-sequence training step.

KV-sharing itself rides the separate `shared_kv_states` dict (unchanged), so passing a
non-`None` pass-through holder suppresses the `DynamicCache` without affecting sharing
or numerics. This is exactly what `main` does via #2621; only the minimal holder subset
is backported here (no context-parallelism or recipe changes).

# Verification

- 8×H100, `gemma4_4b_mock.yaml` (E4B): without the fix it OOMs at step ~3; with the fix
  it runs cleanly with no OOM, and training loss matches `main` to ~3 decimals
  (6.01 → 4.21 over the first 6 steps), confirming kv-sharing correctness is preserved.
- `ruff format` / `ruff check`: clean.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed Contributor guidelines
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

# Additional Information

- Backport of #2621 (`_Gemma4KVShareHolder` subset) to `r0.5.0`.
