### PR TITLE
cp: DeciLM Nemotron TP plan (#2703) to r0.5.0

### DIFF
--- a/examples/llm_finetune/nemotron/llama3_3_nemotron_super_49B_squad.yaml
+++ b/examples/llm_finetune/nemotron/llama3_3_nemotron_super_49B_squad.yaml
@@ -54,7 +54,6 @@ distributed:
   strategy: fsdp2
   dp_size: none
   tp_size: 4
-  tp_plan: llama_nemotron_super_tp_plan  # registered DeciLM/nemotron-nas TP plan; custom-code arch has no default plan
   cp_size: 1
   ep_size: 1
   pipeline:
@@ -119,7 +118,7 @@ lr_scheduler:
 ci:
   recipe_owner: akoumpa
   nodes: 2
-  time: "00:55:00"  # 49B robustness (Phase 1-4 reloads of a 49B on 2 nodes) needs >45min
+  time: "01:15:00"  # 49B finetune+robustness runs ~51-55min wall-clock; 55min is too tight (a run hit 55.1min)
   vllm_deploy: true
   vllm_smoke_test: true  # 49B exceeds 1 GPU; use vLLM's native nemotron-nas backend (no HF reference load)
   vllm_deploy_gpus: 4  # expose 4 of the node's 8 GPUs for tensor-parallel vLLM load

--- a/nemo_automodel/components/distributed/optimized_tp_plans.py
+++ b/nemo_automodel/components/distributed/optimized_tp_plans.py
@@ -307,6 +307,15 @@ def get_decilm_nemotron_tp_plan(
     return cast(dict[str, ParallelStyle], base_model_tp_plan)
 
 
+def _parallelize_decilm_nemotron(
+    model,
+    sequence_parallel: bool = False,
+) -> dict[str, ParallelStyle]:
+    if getattr(getattr(model, "config", None), "model_type", None) != "nemotron-nas":
+        raise ValueError("DeciLM TP plan is only registered for Nemotron-NAS checkpoints")
+    return get_decilm_nemotron_tp_plan(sequence_parallel=sequence_parallel)
+
+
 def _parallelize_baichuan(
     model: BaichuanForCausalLM | None,
     sequence_parallel: bool = False,
@@ -747,5 +756,6 @@ PARALLELIZE_FUNCTIONS: Dict[str, Callable[..., Dict[str, ParallelStyle]]] = {
     _get_class_qualname(CustomQwen2ForCausalLM): _parallelize_qwen,
     # trust_remote_code models — matched by bare class __name__ in parallelizer
     # because their qualname includes a snapshot-hash-bearing module path.
+    "DeciLMForCausalLM": _parallelize_decilm_nemotron,
     "NemotronLabsDiffusionModel": _parallelize_nemotron_labs_diffusion,
 }

--- a/tests/unit_tests/distributed/test_get_parallel_plan.py
+++ b/tests/unit_tests/distributed/test_get_parallel_plan.py
@@ -479,3 +479,14 @@ def test_named_plan_decilm_with_sequence_parallel():
     )
     assert "model.norm" in result
     assert "model.layers.*.self_attn.q_proj" in result
+
+
+def test_decilm_remote_code_class_auto_selects_nemotron_plan():
+    class DeciLMForCausalLM:
+        config = SimpleNamespace(model_type="nemotron-nas")
+
+    result = _get_parallel_plan(DeciLMForCausalLM(), sequence_parallel=False, tp_size=2)
+    assert "model.layers.*.self_attn.q_proj" in result
+    assert "model.layers.*.self_attn.k_proj" in result
+    assert "model.layers.*.self_attn.v_proj" in result
+    assert "model.layers.*.self_attn.qkv_proj" not in result


### PR DESCRIPTION
## Summary
- Cherry-picks #2703 into `r0.5.0`.
- Registers the remote-code `DeciLMForCausalLM` class name for the existing Nemotron-NAS TP plan.
- Keeps the release recipe aligned with the merged main change.

## Validation
- `git diff --check origin/r0.5.0..HEAD`
- `uv run pytest -q tests/unit_tests/distributed/test_get_parallel_plan.py`
- `uv run ruff check nemo_automodel/components/distributed/optimized_tp_plans.py tests/unit_tests/distributed/test_get_parallel_plan.py`