### PR TITLE
fix(ci): reduce mixtral release smoke batch

### DIFF
--- a/examples/llm_finetune/mistral/mixtral-8x7b-v0-1_squad.yaml
+++ b/examples/llm_finetune/mistral/mixtral-8x7b-v0-1_squad.yaml
@@ -102,5 +102,10 @@ lr_scheduler:
 
 ci:
   recipe_owner: HuiyingLi
-  time: "00:20:00"
+  time: "00:30:00"
   nodes: 2
+  release:
+    step_scheduler.global_batch_size: 64
+    step_scheduler.local_batch_size: 8
+    step_scheduler.max_steps: 5
+    distributed.pipeline.pp_microbatch_size: 1

--- a/examples/llm_finetune/mistral/mixtral-8x7b-v0-1_squad.yaml
+++ b/examples/llm_finetune/mistral/mixtral-8x7b-v0-1_squad.yaml
@@ -20,11 +20,11 @@
 recipe: TrainFinetuneRecipeForNextTokenPrediction
 
 step_scheduler:
-  global_batch_size: 256
-  local_batch_size: 32
+  global_batch_size: 64
+  local_batch_size: 8
   ckpt_every_steps: 50
   val_every_steps: 1000
-  max_steps: 100
+  max_steps: 5
 
 dist_env:
   backend: nccl
@@ -58,7 +58,7 @@ distributed:
 
   pipeline:
     pp_schedule: interleaved1f1b
-    pp_microbatch_size: 4
+    pp_microbatch_size: 1
     scale_grads_in_schedule: false
 
 loss_fn:
@@ -71,12 +71,14 @@ dataset:
   split: train
 
 packed_sequence:
+  # Set packed_sequence_size > 0 to run with packed sequences
   packed_sequence_size: 1024
+  packing_strategy: thd
 
-# StatefulDataLoader with default collate
+# StatefulDataLoader with packed-sequence collate
 dataloader:
   _target_: torchdata.stateful_dataloader.StatefulDataLoader
-  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  collate_fn: nemo_automodel.components.datasets.utils.packed_sequence_thd_collater
   shuffle: true
 
 validation_dataset:
@@ -86,7 +88,7 @@ validation_dataset:
 
 validation_dataloader:
   _target_: torchdata.stateful_dataloader.StatefulDataLoader
-  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  collate_fn: nemo_automodel.components.datasets.utils.packed_sequence_thd_collater
 
 optimizer:
   _target_: torch.optim.Adam
@@ -105,7 +107,4 @@ ci:
   time: "00:30:00"
   nodes: 2
   release:
-    step_scheduler.global_batch_size: 64
-    step_scheduler.local_batch_size: 8
     step_scheduler.max_steps: 5
-    distributed.pipeline.pp_microbatch_size: 1

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -584,10 +584,8 @@ def build_validation_dataloader(cfg, dp_world_size, dp_rank, pp_enabled, model: 
             val_ds_name = "default"
         return val_ds_name
 
-    # Pack the validation set the same way as training when the attention backend
-    # consumes a THD/cu_seqlens layout. Besides TE, the magi backend also packs (and,
-    # at cp>1, shards) THD sequences; leaving validation unpacked would feed magi tiny
-    # per-example sequences that cp-sharding splits degenerately, inflating val loss.
+    # Pack validation when it explicitly consumes THD/cu_seqlens metadata, or
+    # when a backend/model requires validation to follow training's THD layout.
     _magi_backend = (
         str(cfg.get("model.backend.attn", "")) == "magi" or str(cfg.get("model.attn_implementation", "")) == "magi"
     )
@@ -596,9 +594,12 @@ def build_validation_dataloader(cfg, dp_world_size, dp_rank, pp_enabled, model: 
         and callable(getattr(model, "should_pack_validation_with_training", None))
         and model.should_pack_validation_with_training()
     )
-    _pack_val = (
-        _uses_te_dot_product_attention(cfg.model) or _magi_backend or _model_packs_validation
-    ) and _uses_thd_collater(cfg.dataloader)
+    _backend_packs_validation = _uses_te_dot_product_attention(cfg.model) or _magi_backend or _model_packs_validation
+    _validation_uses_thd = _uses_thd_collater(cfg.validation_dataloader)
+    _training_uses_thd = _uses_thd_collater(cfg.get("dataloader", None))
+    _pack_val = cfg.get("packed_sequence.packed_sequence_size", 0) > 0 and (
+        _validation_uses_thd or (_backend_packs_validation and _training_uses_thd)
+    )
 
     # Build validation dataloader if the config provides it
     val_dataloaders = {}

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -595,7 +595,8 @@ def build_validation_dataloader(cfg, dp_world_size, dp_rank, pp_enabled, model: 
         and model.should_pack_validation_with_training()
     )
     _backend_packs_validation = _uses_te_dot_product_attention(cfg.model) or _magi_backend or _model_packs_validation
-    _validation_uses_thd = _uses_thd_collater(cfg.validation_dataloader)
+    cfg_validation_dataloader = cfg.get("validation_dataloader", None)
+    _validation_uses_thd = _uses_thd_collater(cfg_validation_dataloader)
     _training_uses_thd = _uses_thd_collater(cfg.get("dataloader", None))
     _pack_val = cfg.get("packed_sequence.packed_sequence_size", 0) > 0 and (
         _validation_uses_thd or (_backend_packs_validation and _training_uses_thd)
@@ -608,7 +609,7 @@ def build_validation_dataloader(cfg, dp_world_size, dp_rank, pp_enabled, model: 
         val_ds_name = _prepare_val_ds_name(val_ds_name)
         val_dataloaders[val_ds_name] = build_dataloader(
             val_ds_cfg,
-            cfg.validation_dataloader,
+            cfg_validation_dataloader,
             cfg.model,
             cfg_ps=cfg.get("packed_sequence", None) if _pack_val else None,
             seed=cfg.get("seed", 42),

--- a/tests/unit_tests/recipes/test_train_ft.py
+++ b/tests/unit_tests/recipes/test_train_ft.py
@@ -233,15 +233,15 @@ def test_build_validation_dataloader_no_validation_keys():
     mock_build.assert_not_called()
 
 
-@pytest.mark.parametrize("attn,expect_packed", [("magi", True), ("te", True), ("sdpa", False)])
-def test_build_validation_dataloader_packs_val_for_thd_backends(monkeypatch, attn, expect_packed):
-    """The validation set is packed (cfg_ps passed) for THD-consuming backends.
+@pytest.mark.parametrize("attn", ["magi", "te", "sdpa"])
+def test_build_validation_dataloader_packs_val_for_thd_collater(monkeypatch, attn):
+    """The validation set is packed (cfg_ps passed) when using the THD collater.
 
-    Regression: previously only TE triggered val packing; the magi backend left
-    validation unpacked, so at cp>1 magi sharded tiny per-example sequences
-    degenerately and inflated the val loss.
+    Regression: validation packing was previously gated by backend, so FA2/SDPA
+    configs with a THD collater left validation unpacked and repeatedly rebuilt
+    pipeline shapes for variable-length examples.
     """
-    # Pretend the (training) dataloader uses the THD packed collater.
+    # Pretend the validation dataloader uses the THD packed collater.
     monkeypatch.setattr("nemo_automodel.recipes.llm.train_ft._uses_thd_collater", lambda _cfg: True)
     cfg = ConfigNode(
         {
@@ -263,7 +263,32 @@ def test_build_validation_dataloader_packs_val_for_thd_backends(monkeypatch, att
     with patch("nemo_automodel.recipes.llm.train_ft.build_dataloader", return_value=("dl", "tok")) as mock_build:
         build_validation_dataloader(cfg, dp_world_size=1, dp_rank=0, pp_enabled=False)
     _, kwargs = mock_build.call_args
-    assert (kwargs["cfg_ps"] is not None) is expect_packed
+    assert kwargs["cfg_ps"] is not None
+
+
+def test_build_validation_dataloader_skips_val_packing_without_pack_size(monkeypatch):
+    monkeypatch.setattr("nemo_automodel.recipes.llm.train_ft._uses_thd_collater", lambda _cfg: True)
+    cfg = ConfigNode(
+        {
+            "model": {"backend": {"attn": "sdpa"}},
+            "dataloader": {},
+            "validation_dataloader": {},
+            "packed_sequence": {"packed_sequence_size": 0},
+            "distributed": {"cp_size": 1},
+            "step_scheduler": {
+                "local_batch_size": 1,
+                "global_batch_size": 8,
+                "max_steps": 5,
+                "val_every_steps": 1,
+            },
+            "seed": 42,
+            "validation_dataset": {"some": "cfg"},
+        }
+    )
+    with patch("nemo_automodel.recipes.llm.train_ft.build_dataloader", return_value=("dl", "tok")) as mock_build:
+        build_validation_dataloader(cfg, dp_world_size=1, dp_rank=0, pp_enabled=False)
+    _, kwargs = mock_build.call_args
+    assert kwargs["cfg_ps"] is None
 
 
 def test_build_validation_dataloader_packs_val_when_model_requires_thd(monkeypatch):

--- a/tests/unit_tests/recipes/test_train_ft.py
+++ b/tests/unit_tests/recipes/test_train_ft.py
@@ -233,6 +233,21 @@ def test_build_validation_dataloader_no_validation_keys():
     mock_build.assert_not_called()
 
 
+def test_build_validation_dataloader_no_validation_config():
+    cfg = ConfigNode(
+        {
+            "model": {},
+            "dataloader": {},
+        }
+    )
+
+    with patch("nemo_automodel.recipes.llm.train_ft.build_dataloader") as mock_build:
+        result = build_validation_dataloader(cfg, dp_world_size=1, dp_rank=0, pp_enabled=False)
+
+    assert result == {}
+    mock_build.assert_not_called()
+
+
 @pytest.mark.parametrize("attn", ["magi", "te", "sdpa"])
 def test_build_validation_dataloader_packs_val_for_thd_collater(monkeypatch, attn):
     """The validation set is packed (cfg_ps passed) when using the THD collater.


### PR DESCRIPTION
# What does this PR do ?

Reduce the Mixtral 8x7B SQuAD release CI smoke workload so the job no longer OOMs during the optimizer gradient-clipping all-reduce, and use THD packed-sequence collation for the recipe to keep pipeline sequence shapes fixed at the packed size.

# Changelog

- Increase the Mixtral SQuAD CI timeout from `00:20:00` to `00:30:00` to account for model setup plus the smoke run.
- Move the memory-reduction settings into their recipe sections: `step_scheduler.global_batch_size=64`, `step_scheduler.local_batch_size=8`, and `distributed.pipeline.pp_microbatch_size=1`.
- Keep `ci.release.step_scheduler.max_steps=5` because release defaults otherwise override recipe `max_steps` to 50.
- Enable THD packed-sequence collation for train and validation with `packed_sequence_size=1024`.
- Pack validation when the validation dataloader uses the THD collater and packed sequences are enabled, while preserving main's backend/model opt-in path for THD validation packing.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? Added focused validation-dataloader tests for THD validation packing.
- [x] Did you add or update any necessary documentation? Not needed for CI recipe/runtime behavior.

# Additional Information

Latest PR head after rebasing on `origin/main`: `8b0a5c6d`.

Local validation on commit `8b0a5c6d`:

- `uv run pytest -q tests/unit_tests/recipes/test_train_ft.py -k 'build_validation_dataloader'`
- `uv run ruff check nemo_automodel/recipes/llm/train_ft.py tests/unit_tests/recipes/test_train_ft.py`
- `uv run ruff format --check nemo_automodel/recipes/llm/train_ft.py tests/unit_tests/recipes/test_train_ft.py`

nemo-ci validation before the rebase, on equivalent pre-rebase commit `90063926`:

- nemo-ci root pipeline: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/55521454
- AutoModel child pipeline: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/55522027
- LLM child pipeline: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/55522191
- Target Mixtral job: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/345692983
- Result: success. Slurm completed with `SLURM_STATE=COMPLETED` and `SLURM_EXITCODE=0`.
- Trace check: only two `Precomputed pipeline stage shapes` messages, both `seq_len=1024`; no variable validation sequence-shape spam.

Earlier validation:

- Commit `2df24c4d` nemo-ci target job passed but exposed validation still using variable sequence lengths: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/345669255
- Commit `a143805d` initial memory-reduction validation: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/345494195