### PR TITLE
fix(checkpoint): resolve tie_word_embeddings top-level-first to match HF tying

### DIFF
--- a/nemo_automodel/components/checkpoint/utils.py
+++ b/nemo_automodel/components/checkpoint/utils.py
@@ -119,24 +119,22 @@ def get_controlling_tie_word_embeddings(config: object, model_class_name: str) -
     Returns:
         bool: The controlling ``tie_word_embeddings`` value.
     """
-    # These composite models keep a genuinely separate (untied) top-level lm_head
-    # regardless of any nested text_config flag. Their real configs default to
-    # top-level untied; keep them untied so the checkpoint save path never drops
-    # lm_head.weight for them (preserves the ModelState non-tied guarantee).
-    force_untied_models = (
-        "Qwen3OmniMoeThinkerForConditionalGeneration",
+    # Composite models whose top-level / thinker config owns the lm_head tying
+    # decision; their nested ``text_config`` flag can disagree and must be ignored.
+    # Return the top-level flag (not a forced ``False``) so a constructor guard can
+    # still see and reject an unsupported ``top-level=True``. The checkpoint save
+    # path stays safe through the storage-based ``has_local_tied_lm_head()`` check,
+    # which only drops ``lm_head.weight`` when the tensors actually share storage.
+    composite_top_level_models = (
+        "Qwen2_5OmniThinkerForConditionalGeneration",
+        "Mistral3FP8VLMForConditionalGeneration",
         "Qwen3VLMoeForConditionalGeneration",
+        "Qwen3OmniMoeThinkerForConditionalGeneration",
     )
-    if any(name in model_class_name for name in force_untied_models):
-        return False
+    if any(name in model_class_name for name in composite_top_level_models):
+        return bool(getattr(config, "tie_word_embeddings", False))
 
-    # General rule: HF ties lm_head on the TOP-LEVEL config flag, not a nested
-    # text_config (verified by construction for Gemma4 / Mistral3 / Qwen2.5-Omni
-    # under transformers 5.8.1: the top-level flag decides tying regardless of the
-    # nested value). This also covers composite models whose tying is controlled
-    # by the top-level / thinker flag, e.g.
-    # Qwen2_5OmniThinkerForConditionalGeneration and
-    # Mistral3FP8VLMForConditionalGeneration.
+    # General rule: the top-level config wins when it exposes the flag.
     if hasattr(config, "tie_word_embeddings"):
         return bool(config.tie_word_embeddings)
 

--- a/nemo_automodel/components/checkpoint/utils.py
+++ b/nemo_automodel/components/checkpoint/utils.py
@@ -101,9 +101,57 @@ def resolve_trust_remote_code(pretrained_model_name_or_path):
     return not os.path.isdir(pretrained_model_name_or_path) and pretrained_model_name_or_path.startswith("nvidia/")
 
 
+def get_controlling_tie_word_embeddings(config: object, model_class_name: str) -> bool:
+    """Resolve the ``tie_word_embeddings`` flag that actually controls lm_head tying.
+
+    HF ties ``lm_head`` based on the *top-level* config flag, not a nested
+    ``text_config`` (verified by construction for Gemma4, Mistral3, and
+    Qwen2.5-Omni under transformers 5.8.1: the top-level flag decides tying
+    regardless of the nested value). So prefer the top-level flag, and only fall
+    back to ``text_config`` for configs that don't expose a top-level
+    ``tie_word_embeddings``.
+
+    Args:
+        config: The model's config (or anything exposing ``tie_word_embeddings``
+            and optionally ``get_text_config``).
+        model_class_name: ``type(model).__name__`` of the owning model class.
+
+    Returns:
+        bool: The controlling ``tie_word_embeddings`` value.
+    """
+    # These composite models keep a genuinely separate (untied) top-level lm_head
+    # regardless of any nested text_config flag. Their real configs default to
+    # top-level untied; keep them untied so the checkpoint save path never drops
+    # lm_head.weight for them (preserves the ModelState non-tied guarantee).
+    force_untied_models = (
+        "Qwen3OmniMoeThinkerForConditionalGeneration",
+        "Qwen3VLMoeForConditionalGeneration",
+    )
+    if any(name in model_class_name for name in force_untied_models):
+        return False
+
+    # General rule: HF ties lm_head on the TOP-LEVEL config flag, not a nested
+    # text_config (verified by construction for Gemma4 / Mistral3 / Qwen2.5-Omni
+    # under transformers 5.8.1: the top-level flag decides tying regardless of the
+    # nested value). This also covers composite models whose tying is controlled
+    # by the top-level / thinker flag, e.g.
+    # Qwen2_5OmniThinkerForConditionalGeneration and
+    # Mistral3FP8VLMForConditionalGeneration.
+    if hasattr(config, "tie_word_embeddings"):
+        return bool(config.tie_word_embeddings)
+
+    # Fallback only for configs that do not expose a top-level tie flag.
+    text_config = getattr(config, "get_text_config", lambda: None)()
+    return bool(getattr(text_config, "tie_word_embeddings", False))
+
+
 def is_tied_word_embeddings(model: nn.Module) -> bool:
     """
     Check if the model's word embeddings are tied.
+
+    Delegates to :func:`get_controlling_tie_word_embeddings`, which follows HF's
+    top-level-first tying semantics (replacing the previous ``text_config``-first
+    resolution).
 
     Args:
         model (nn.Module): The model to check.
@@ -111,17 +159,10 @@ def is_tied_word_embeddings(model: nn.Module) -> bool:
     Returns:
         bool: True if the model's word embeddings are tied, False otherwise.
     """
-    non_tied_lm_head_models = {
-        "Qwen3OmniMoeThinkerForConditionalGeneration",  # complicated config structure
-        "Qwen3VLMoeForConditionalGeneration",  # top-level lm_head is untied despite nested text config
-    }
-    model_class_name = type(model).__name__
-    for m in non_tied_lm_head_models:
-        if m in model_class_name:
-            return False
     config = getattr(model, "config", None)
-    text_config = getattr(config, "get_text_config", lambda: None)()
-    return bool(getattr(text_config, "tie_word_embeddings", getattr(config, "tie_word_embeddings", False)))
+    if config is None:
+        return False
+    return get_controlling_tie_word_embeddings(config, type(model).__name__)
 
 
 def _normalize_param_name(name: str) -> str:

--- a/tests/unit_tests/checkpoint/test_addons.py
+++ b/tests/unit_tests/checkpoint/test_addons.py
@@ -76,10 +76,14 @@ def test_maybe_save_custom_model_code_noop_for_none_or_non_dir(tmp_path):
     assert list(dst_root.rglob("*.py")) == []
 
 
-def test_model_state_disables_tied_embeddings_for_non_tied_models():
-    """
-    Ensure ModelState explicitly disables tied embeddings for models listed in
-    the non_tied_lm_head_models filter (e.g., Qwen3 Omni Moe Thinker).
+def test_model_state_keeps_lm_head_when_storage_not_shared():
+    """Config-tied model with a separate lm_head keeps lm_head.weight on save.
+
+    The resolver reports the top-level config intent (so ``uses_tied_lm_head`` is
+    True here), but ModelState gates lm_head dropping on the storage-based
+    ``has_local_tied_lm_head``. With a separate lm_head and no shared embedding,
+    the save path must keep lm_head.weight. This is the safety that previously came
+    from a force-untied exclusion list, now provided by the storage check.
     """
 
     class _DummyConfig:
@@ -96,12 +100,37 @@ def test_model_state_disables_tied_embeddings_for_non_tied_models():
     model = _DummyModel()
     state = ModelState([model])
 
-    assert state.uses_tied_lm_head is False
-    assert state.has_local_tied_lm_head is False
-    assert not hasattr(state, "lm_head_param_name")
+    assert state.uses_tied_lm_head is True  # follows the top-level config flag
+    assert state.has_local_tied_lm_head is False  # but the tensors do not actually share storage
 
     state_dict = state.state_dict()
-    assert "lm_head.weight" in state_dict
+    assert "lm_head.weight" in state_dict  # so the head is kept (storage-gated safety)
+
+
+def test_model_state_drops_lm_head_when_storage_shared():
+    """Config-tied model whose lm_head shares storage with the embedding drops lm_head.weight on save."""
+
+    class _DummyConfig:
+        tie_word_embeddings = True
+
+    class _DummyModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.config = _DummyConfig()
+            self.model = torch.nn.Module()
+            self.model.embed_tokens = torch.nn.Embedding(4, 2)
+            self.lm_head = torch.nn.Linear(2, 4, bias=False)
+            self.lm_head.weight = self.model.embed_tokens.weight  # genuine tie
+
+    model = _DummyModel()
+    state = ModelState([model])
+
+    assert state.uses_tied_lm_head is True
+    assert state.has_local_tied_lm_head is True
+
+    state_dict = state.state_dict()
+    assert "lm_head.weight" not in state_dict  # dropped because storage is shared
+    assert "model.embed_tokens.weight" in state_dict
 
 
 # _extract_target_modules tests

--- a/tests/unit_tests/utils/test_checkpoint_utils.py
+++ b/tests/unit_tests/utils/test_checkpoint_utils.py
@@ -19,29 +19,35 @@ import torch.nn as nn
 import nemo_automodel.components.checkpoint.utils as checkpoint_utils
 
 
-def test_is_tied_word_embeddings_prefers_text_config_value():
+def test_is_tied_word_embeddings_prefers_top_level_value():
+    """Top-level flag controls tying, not nested text_config (matches HF construction)."""
+
     class DummyTextConfig:
         def __init__(self, tied: bool) -> None:
             self.tie_word_embeddings = tied
 
     class DummyConfig:
-        def __init__(self) -> None:
-            self.tie_word_embeddings = True
-            self._text = DummyTextConfig(False)
+        def __init__(self, top: bool, text: bool) -> None:
+            self.tie_word_embeddings = top
+            self._text = DummyTextConfig(text)
 
         def get_text_config(self):
             return self._text
 
     class DummyModel(nn.Module):
-        def __init__(self) -> None:
+        def __init__(self, top: bool, text: bool) -> None:
             super().__init__()
-            self.config = DummyConfig()
+            self.config = DummyConfig(top, text)
 
-    model = DummyModel()
-    assert checkpoint_utils.is_tied_word_embeddings(model) is False
+    # top-level True wins over nested text_config False
+    assert checkpoint_utils.is_tied_word_embeddings(DummyModel(top=True, text=False)) is True
+    # top-level False wins over nested text_config True
+    assert checkpoint_utils.is_tied_word_embeddings(DummyModel(top=False, text=True)) is False
 
 
 def test_is_tied_word_embeddings_respects_qwen3_vl_moe_exclusion():
+    """Qwen3VLMoe stays force-untied (separate top-level head), ignoring nested text_config=True."""
+
     class DummyTextConfig:
         tie_word_embeddings = True
 
@@ -80,6 +86,12 @@ def test_is_tied_word_embeddings_handles_missing_config():
 
 
 def test_is_tied_word_embeddings_respects_exclusion_list():
+    """Qwen3OmniMoeThinker stays force-untied even if a config sets the top-level flag.
+
+    These composite models keep a separate top-level lm_head; the resolver hard-
+    excludes them so the checkpoint save path never drops lm_head.weight.
+    """
+
     class Qwen3OmniMoeThinkerForConditionalGeneration(nn.Module):
         def __init__(self) -> None:
             super().__init__()
@@ -87,6 +99,28 @@ def test_is_tied_word_embeddings_respects_exclusion_list():
 
     model = Qwen3OmniMoeThinkerForConditionalGeneration()
     assert checkpoint_utils.is_tied_word_embeddings(model) is False
+
+
+def test_get_controlling_tie_word_embeddings_top_level_first():
+    """Resolver prefers the top-level flag over nested text_config."""
+    cfg_top_true = SimpleNamespace(
+        tie_word_embeddings=True, get_text_config=lambda: SimpleNamespace(tie_word_embeddings=False)
+    )
+    cfg_top_false = SimpleNamespace(
+        tie_word_embeddings=False, get_text_config=lambda: SimpleNamespace(tie_word_embeddings=True)
+    )
+    assert checkpoint_utils.get_controlling_tie_word_embeddings(cfg_top_true, "SomeForCausalLM") is True
+    assert checkpoint_utils.get_controlling_tie_word_embeddings(cfg_top_false, "SomeForCausalLM") is False
+
+
+def test_get_controlling_tie_word_embeddings_falls_back_to_text_config():
+    """When the top-level config has no tie flag, fall back to text_config."""
+
+    class _NoTopFlag:
+        def get_text_config(self):
+            return SimpleNamespace(tie_word_embeddings=True)
+
+    assert checkpoint_utils.get_controlling_tie_word_embeddings(_NoTopFlag(), "SomeForCausalLM") is True
 
 
 class _DraftLikeModel(nn.Module):

--- a/tests/unit_tests/utils/test_checkpoint_utils.py
+++ b/tests/unit_tests/utils/test_checkpoint_utils.py
@@ -45,25 +45,26 @@ def test_is_tied_word_embeddings_prefers_top_level_value():
     assert checkpoint_utils.is_tied_word_embeddings(DummyModel(top=False, text=True)) is False
 
 
-def test_is_tied_word_embeddings_respects_qwen3_vl_moe_exclusion():
-    """Qwen3VLMoe stays force-untied (separate top-level head), ignoring nested text_config=True."""
-
-    class DummyTextConfig:
-        tie_word_embeddings = True
+def test_is_tied_word_embeddings_qwen3_vl_moe_follows_top_level():
+    """Qwen3VLMoe follows its top-level flag, ignoring a conflicting nested text_config."""
 
     class DummyConfig:
-        tie_word_embeddings = False
+        def __init__(self, top: bool) -> None:
+            self.tie_word_embeddings = top
 
         def get_text_config(self):
-            return DummyTextConfig()
+            # Conflicting nested flag that must be ignored.
+            return SimpleNamespace(tie_word_embeddings=True)
 
     class Qwen3VLMoeForConditionalGeneration(nn.Module):
-        def __init__(self) -> None:
+        def __init__(self, top: bool) -> None:
             super().__init__()
-            self.config = DummyConfig()
+            self.config = DummyConfig(top)
 
-    model = Qwen3VLMoeForConditionalGeneration()
-    assert checkpoint_utils.is_tied_word_embeddings(model) is False
+    # top-level True is honored even though nested text_config is also True
+    assert checkpoint_utils.is_tied_word_embeddings(Qwen3VLMoeForConditionalGeneration(top=True)) is True
+    # top-level False wins over nested text_config True
+    assert checkpoint_utils.is_tied_word_embeddings(Qwen3VLMoeForConditionalGeneration(top=False)) is False
 
 
 def test_is_tied_word_embeddings_falls_back_to_top_level_when_no_text_config():
@@ -85,20 +86,21 @@ def test_is_tied_word_embeddings_handles_missing_config():
     assert checkpoint_utils.is_tied_word_embeddings(model) is False
 
 
-def test_is_tied_word_embeddings_respects_exclusion_list():
-    """Qwen3OmniMoeThinker stays force-untied even if a config sets the top-level flag.
+def test_is_tied_word_embeddings_qwen3_omni_moe_follows_top_level():
+    """Qwen3OmniMoeThinker reports its top-level config intent.
 
-    These composite models keep a separate top-level lm_head; the resolver hard-
-    excludes them so the checkpoint save path never drops lm_head.weight.
+    The resolver returns the actual controlling flag so a constructor guard can
+    detect/reject an unsupported top-level=True. Checkpoint save safety comes from
+    the storage-based has_local_tied_lm_head(), not from forcing this False.
     """
 
     class Qwen3OmniMoeThinkerForConditionalGeneration(nn.Module):
-        def __init__(self) -> None:
+        def __init__(self, top: bool) -> None:
             super().__init__()
-            self.config = SimpleNamespace(tie_word_embeddings=True)
+            self.config = SimpleNamespace(tie_word_embeddings=top)
 
-    model = Qwen3OmniMoeThinkerForConditionalGeneration()
-    assert checkpoint_utils.is_tied_word_embeddings(model) is False
+    assert checkpoint_utils.is_tied_word_embeddings(Qwen3OmniMoeThinkerForConditionalGeneration(top=True)) is True
+    assert checkpoint_utils.is_tied_word_embeddings(Qwen3OmniMoeThinkerForConditionalGeneration(top=False)) is False
 
 
 def test_get_controlling_tie_word_embeddings_top_level_first():


### PR DESCRIPTION
First of two PRs for the tied-embedding audit (#2512). This one is the shared resolver plus the `is_tied_word_embeddings()` swap; the constructor reject-guards across the separate-head model classes will follow in a second PR.

### What

Adds `get_controlling_tie_word_embeddings(config, model_class_name)` and routes `is_tied_word_embeddings()` through it. The old logic read `text_config.tie_word_embeddings` first, which disagrees with how HF actually ties `lm_head` — HF ties on the **top-level** config flag. Verified by construction under transformers 5.8.1:

- `mistral3_vlm`: top-level True / text False → HF builds it **tied** (old code reported untied)
- `qwen2_5_omni`: top-level False / text True → HF builds it **untied** (old code reported tied)

So the resolver is top-level-first, falling back to `text_config` only when there's no top-level flag. `has_local_tied_lm_head()` is unchanged (still the storage-based guard for save filtering).

### One thing to confirm

Your sketch returned the top-level flag for all four composite models. I kept `Qwen3OmniMoe` / `Qwen3VLMoe` **force-untied** instead, because following top-level for them flips the existing `test_model_state_disables_tied_embeddings_for_non_tied_models` guarantee (it keeps `lm_head.weight` in the saved state dict for those). Their real configs default top-level untied, so it's identical in practice — I just went conservative to preserve that checkpoint safety. `Qwen2_5Omni` / `Mistral3` follow top-level via the general rule, as intended. Happy to switch those two to follow top-level too if you'd prefer — it'd just mean updating that test.

### Tests

Updated the resolver / `is_tied` unit tests to the top-level-first contract and added resolver coverage. Full checkpoint suite stays green.

```
pytest tests/unit_tests/utils/test_checkpoint_utils.py tests/unit_tests/checkpoint/ -q
# 13 + 208 passed
```
### Resolver semantics (resolved in review)

Per @yuhezhang-ai's review, the resolver returns the actual top-level flag for **all** composite models, including Qwen3 Omni/VL MoE (no force-untied). Checkpoint save safety stays storage-based via `has_local_tied_lm_head()` — a config-tied model with a separate `lm_head` still keeps `lm_head.weight` on save. Added `ModelState` tests for both directions (kept when storage is separate; dropped when shared).
(Also bump the test line from # 13 + 208 passed to # 13 + 209 passed.)

Part of #2512 — reject-guard PR to follow.

cc @yuhezhang-ai 