### PR TITLE
fix(fsdp2): guard uninitialized accumulated grads

### DIFF
--- a/nemo_automodel/components/distributed/parallelizer.py
+++ b/nemo_automodel/components/distributed/parallelizer.py
@@ -128,6 +128,46 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
+def _patch_fsdp_accumulated_grad_guard() -> None:
+    """Guard FSDP2 post-backward against params that were never unsharded.
+
+    This is needed for text-only configs that still instantiate and shard a
+    full VLM model, e.g.
+    ``examples/llm_finetune/mistral/ministral3_3b_squad.yaml`` when
+    ``ci.checkpoint_robustness.distributed.tp_size: 2`` reruns the recipe.
+    Ministral3 FP8 is loaded through ``Mistral3FP8VLMForConditionalGeneration``
+    so the vision tower remains separately FSDP-sharded, but SQuAD batches do
+    not execute that tower. Those FSDP params never create PyTorch's lazy
+    ``_unsharded_param`` field, and the fp32 grad-reduce post-backward helper
+    dereferences it unconditionally. If the field is absent, there is no
+    unsharded grad to upcast, so returning early preserves the no-grad case.
+    The wrapper still calls PyTorch first and only handles the exact
+    ``AttributeError`` from the missing lazy field.
+    Permalinks:
+    - Trigger YAML: https://github.com/NVIDIA-NeMo/Automodel/blob/0990cb2c047496bae50e2035dac7b8c509316076/examples/llm_finetune/mistral/ministral3_3b_squad.yaml#L114-L128
+    - Mistral3 layer extraction: https://github.com/NVIDIA-NeMo/Automodel/blob/0990cb2c047496bae50e2035dac7b8c509316076/nemo_automodel/components/distributed/parallelizer.py#L1522-L1530
+    """
+    try:
+        from torch.distributed.fsdp._fully_shard._fsdp_param import FSDPParam
+    except Exception:
+        return
+
+    orig = FSDPParam.to_accumulated_grad_if_needed
+    if getattr(orig, "_nemo_automodel_guarded", False):
+        return
+
+    def guarded(self: Any) -> Any:
+        try:
+            return orig(self)
+        except AttributeError as exc:
+            if "_unsharded_param" not in str(exc) or hasattr(self, "_unsharded_param"):
+                raise
+            return None
+
+    setattr(guarded, "_nemo_automodel_guarded", True)
+    FSDPParam.to_accumulated_grad_if_needed = guarded
+
+
 def apply_selective_activation_checkpointing(model: nn.Module, *, enable_compile: bool = False) -> None:
     """Apply selective activation checkpointing to ``model`` end to end.
 
@@ -352,6 +392,9 @@ class DefaultParallelizationStrategy(ParallelizationStrategy):
                 reduce_dtype=torch.float32,
                 output_dtype=torch.float32,
             )
+
+        # Install this only when NeMo actually enters FSDP2 sharding.
+        _patch_fsdp_accumulated_grad_guard()
 
         # Find transformer layers and apply parallelisms
         apply_fsdp2_sharding_recursively(

--- a/tests/unit_tests/distributed/test_parallelizer.py
+++ b/tests/unit_tests/distributed/test_parallelizer.py
@@ -42,6 +42,45 @@ from nemo_automodel.components.distributed.parallelizer import (
 )
 
 
+def test_fsdp_accumulated_grad_guard_only_handles_missing_unsharded_param(monkeypatch):
+    """The FSDP2 guard only handles the exact missing lazy unsharded tensor case."""
+    calls = {"count": 0}
+
+    class FakeFSDPParam:
+        def __init__(self, mode="ok"):
+            self.mode = mode
+
+        def to_accumulated_grad_if_needed(self):
+            calls["count"] += 1
+            if self.mode == "missing":
+                return self._unsharded_param.grad
+            if self.mode == "other":
+                raise AttributeError("different attribute")
+            return "called"
+
+    fake_module = SimpleNamespace(FSDPParam=FakeFSDPParam)
+    monkeypatch.setitem(sys.modules, "torch.distributed.fsdp._fully_shard._fsdp_param", fake_module)
+
+    parallelizer._patch_fsdp_accumulated_grad_guard()
+
+    param = FakeFSDPParam()
+    assert param.to_accumulated_grad_if_needed() == "called"
+    assert calls["count"] == 1
+
+    param.mode = "missing"
+    assert param.to_accumulated_grad_if_needed() is None
+    assert calls["count"] == 2
+
+    param.mode = "other"
+    with pytest.raises(AttributeError, match="different attribute"):
+        param.to_accumulated_grad_if_needed()
+    assert calls["count"] == 3
+
+    wrapped = FakeFSDPParam.to_accumulated_grad_if_needed
+    parallelizer._patch_fsdp_accumulated_grad_guard()
+    assert FakeFSDPParam.to_accumulated_grad_if_needed is wrapped
+
+
 class MockModel(nn.Module):
     """Mock model for testing purposes."""
 


### PR DESCRIPTION
# What does this PR do ?

Adds a common FSDP2 guard so post-backward skips params whose lazy unsharded tensor was never created.

This fixes checkpoint robustness crashes for text-only Ministral3 runs that load through the VLM implementation and leave modality towers unused during backward.

# Changelog

- Guard `FSDPParam.to_accumulated_grad_if_needed()` when `_unsharded_param` is absent.
- Add a focused unit test for the guard behavior and idempotence.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation? N/A

# Additional Information

Short stack trace segment from the failing nemo-ci job:

```text
/usr/local/lib/python3.12/dist-packages/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py:504: in post_backward
    fsdp_param.to_accumulated_grad_if_needed()
/usr/local/lib/python3.12/dist-packages/torch/distributed/fsdp/_fully_shard/_fsdp_param.py:600: in to_accumulated_grad_if_needed
    or self._unsharded_param.grad is None
E   AttributeError: 'FSDPParam' object has no attribute '_unsharded_param'
```

Verification:

- `pytest -q tests/unit_tests/distributed/test_parallelizer.py::test_fsdp_accumulated_grad_guard_skips_uninitialized_params`
- Scoped nemo-ci passed: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/346201724
- Generated pipeline: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/55591672
