### PR TITLE
fix(diffusion): raise qwen-image dist timeout for checkpoint consolidation

### DIFF
--- a/examples/diffusion/finetune/qwen_image_t2i_flow.yaml
+++ b/examples/diffusion/finetune/qwen_image_t2i_flow.yaml
@@ -80,6 +80,7 @@ wandb:
 dist_env:
   backend: "nccl"
   init_method: "env://"
+  timeout_minutes: 30
 
 seed: 42
 


### PR DESCRIPTION
# What does this PR do ?

Fixes the `qwen_image_t2i_flow` diffusion CI job, which fails during the final checkpoint save with a NCCL collective (`barrier`) timeout — not during training.

**Root cause:** the diffusion recipe initializes the process group with `dist_env.timeout_minutes` defaulting to `1` (60s). Training completes all 10 epochs fine, but at the final checkpoint, `consolidate_safetensors_files_on_every_rank` distributes shard consolidation across ranks and ends with a `dist.barrier()`. The work is imbalanced: rank 0 alone writes the overall metadata file (reading across all shards of the 20.4B-param Qwen-Image transformer), taking ~98s, while ranks 1–7 finish quickly and park on the barrier. The barrier's 60s timeout fires before rank 0 completes, and the watchdog tears every rank down.

`examples/diffusion/finetune/qwen_image_t2i_flow.yaml` never set `timeout_minutes`, so it inherited the 60s default. The sibling full-finetune diffusion configs (`flux2_t2i_flow`, `wan2_1_t2v_flow`, `wan2_2_t2v_flow`, `hunyuan_t2v_flow_lora`) already set `timeout_minutes: 30` — Qwen-Image was simply missed. Large LLM configs (e.g. `ling_1t_sft`, `gpt_oss_20b`) follow the same per-config override pattern.

# Changelog

- Add `timeout_minutes: 30` to the `dist_env` block of `examples/diffusion/finetune/qwen_image_t2i_flow.yaml`, matching the convention used by the other large diffusion finetune configs.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests? — N/A (config-only change)
- [ ] Did you add or update any necessary documentation? — N/A

# Additional Information

- The 60s process-group default is intentionally short to fail fast on genuine NCCL hangs during the training loop; only the consolidation barrier legitimately needs a longer window. A per-config override (this PR) keeps that blast radius small rather than inflating the global default in `recipes/diffusion/train.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
