### PR TITLE
ci: Add gemma4 e4b to nightly test

### DIFF
--- a/tests/ci_tests/configs/vlm_finetune/nightly_recipes.yml
+++ b/tests/ci_tests/configs/vlm_finetune/nightly_recipes.yml
@@ -16,6 +16,7 @@ configs:
   # SFT
   - gemma3/gemma3_vl_4b_cord_v2.yaml
   - gemma3n/gemma3n_vl_4b_medpix.yaml
+  - gemma4/gemma4_4b.yaml
   - gemma4/gemma4_26b_a4b_moe.yaml
   - internvl/internvl_3_5_4b.yaml
   - kimi/kimi2vl_cordv2.yaml


### PR DESCRIPTION
# What does this PR do ?

Would like to add one more gemma4 model to the nightly test so that we have one MoE (already there) and one dense getting run nightly. Both of them differ in architecture quite a bit and there are sometimes new errors specific to the dense model that dont surface with the MoE model run. This leads to bugs getting  discovered late, adding this to avoid such a situation in the future.

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
