### PR TITLE
docs(moe): clarify the GroupedExpertsTE in-place-load comment

### DIFF
--- a/nemo_automodel/components/moe/state_dict_mixin.py
+++ b/nemo_automodel/components/moe/state_dict_mixin.py
@@ -644,11 +644,11 @@ class MoESplitExpertsStateDictMixin:
         # rebuild path: never mark these keys in-place-loaded when ``quantization`` is set.
         quantization = kwargs.get("quantization", False)
 
-        # GroupedExpertsTE (backend.experts == "te") exposes gate_and_up_projs/down_projs as a
-        # torch.stack COPY of TE's per-expert weight{i} params; it does not alias the model's
-        # grouped storage, so an in-place copy_ would write that throwaway buffer and leave the TE
-        # experts at their initial values. Force the rebuild path for it. Other expert backends
-        # keep a real aliasing stacked Parameter and are unaffected.
+        # Same hazard for the "te" backend, independent of quantization: GroupedExpertsTE returns
+        # gate_and_up_projs/down_projs as a fresh torch.stack of TE's per-expert weights — a copy
+        # that no longer aliases the model's grouped storage. An in-place copy_ into that copy
+        # never reaches the real weights (experts stay at init -> garbage/NaN loss), so "te" must
+        # take the rebuild path too. Other backends keep the real aliasing tensor and load in place.
         experts_alias_grouped_storage = getattr(getattr(self, "backend", None), "experts", None) != "te"
 
         from nemo_automodel.components.moe.state_dict_utils import (


### PR DESCRIPTION
Follow-up to #2722 (already merged). Rewords the comment on the `experts_alias_grouped_storage` guard in `state_dict_mixin.py` so it reads as a clear parallel to the `quantization` hazard comment directly above it — stating why the TE grouped tensor is a non-aliasing copy, what an in-place `copy_` into it would do, and that only the `te` backend needs the rebuild path.

Comment-only; no behavior change.