### PR TITLE
fix(sdpa): apply resolved backend constraints to custom models

### DIFF
--- a/nemo_automodel/_transformers/auto_model.py
+++ b/nemo_automodel/_transformers/auto_model.py
@@ -540,7 +540,7 @@ class _BaseNeMoAutoModelClass(_BaseAutoModelClass):
             return _retry(use_liger_kernel=False)
 
         try:
-            if use_sdpa_patching and not is_custom_model:
+            if use_sdpa_patching and (not is_custom_model or sdpa_method is not None):
                 model = _patch_attention(model, sdpa_method)  # noqa: F821
         except Exception:
             logger.warning("Retrying without SDPA patching.")

--- a/nemo_automodel/_transformers/kernel_patches.py
+++ b/nemo_automodel/_transformers/kernel_patches.py
@@ -48,6 +48,26 @@ logger = logging.getLogger(__name__)
 _MODEL_RUNTIME_PATCHES = {}
 
 
+def _set_global_sdpa_backends(sdpa_method):
+    """Apply resolved SDPA backend constraints process-wide for checkpoint recompute."""
+    if sdpa_method is None:
+        return
+
+    enabled = {getattr(backend, "name", str(backend)) for backend in sdpa_method}
+    backend_setters = {
+        "FLASH_ATTENTION": "enable_flash_sdp",
+        "EFFICIENT_ATTENTION": "enable_mem_efficient_sdp",
+        "MATH": "enable_math_sdp",
+        "CUDNN_ATTENTION": "enable_cudnn_sdp",
+    }
+    for backend_name, setter_name in backend_setters.items():
+        setter = getattr(torch.backends.cuda, setter_name, None)
+        if setter is not None:
+            setter(backend_name in enabled)
+
+    logger.info("Set global SDPA backends to %s", sdpa_method)
+
+
 def _assert_same_signature(original, patched):
     """
     Raise AssertionError if the two call signatures differ.
@@ -79,6 +99,8 @@ def _patch_attention(obj, sdpa_method=None):
             SDPBackend.EFFICIENT_ATTENTION,
             SDPBackend.MATH,
         ]
+    else:
+        _set_global_sdpa_backends(sdpa_method)
     orig_forward = obj.forward
 
     def patch_method(method):

--- a/tests/unit_tests/_transformers/test_auto_model.py
+++ b/tests/unit_tests/_transformers/test_auto_model.py
@@ -247,7 +247,10 @@ class TestPatchAttention:
         obj = DummyModule()
         custom_sdpa_method = [SDPBackend.FLASH_ATTENTION]
 
-        with patch("nemo_automodel._transformers.kernel_patches.sdpa_kernel") as mock_sdpa_kernel:
+        with (
+            patch("nemo_automodel._transformers.kernel_patches.sdpa_kernel") as mock_sdpa_kernel,
+            patch("nemo_automodel._transformers.kernel_patches._set_global_sdpa_backends") as mock_global_sdpa,
+        ):
             result = _patch_attention(obj, custom_sdpa_method)
 
             assert result is obj
@@ -257,6 +260,7 @@ class TestPatchAttention:
             # Call forward and verify sdpa_kernel was called with the custom method
             output = obj.forward(5)
             assert output == 6  # Original forward logic still works
+            mock_global_sdpa.assert_called_once_with(custom_sdpa_method)
             mock_sdpa_kernel.assert_called_once_with(custom_sdpa_method)
 
 
@@ -1560,6 +1564,51 @@ class TestBuildModelRetryDepth:
 
         assert result is sentinel_model
         assert order == ["runtime_patches", "infrastructure"]
+
+    def test_custom_model_gets_sdpa_patch_when_method_resolved(self):
+        """Custom models need resolved SDPA method constraints too, e.g. to exclude cuDNN under AC."""
+        build_kwargs, mock_config = self._make_build_kwargs()
+        sentinel_model = MagicMock()
+        sdpa_method = [object()]
+        build_kwargs.update(is_hf_model=False, use_sdpa_patching=True, sdpa_method=sdpa_method)
+
+        with (
+            patch("nemo_automodel._transformers.auto_model._apply_preload_overrides", return_value=("sdpa", False)),
+            patch("nemo_automodel._transformers.auto_model._init_model", return_value=(True, sentinel_model)),
+            patch("nemo_automodel._transformers.auto_model.get_world_size_safe", return_value=1),
+            patch(
+                "nemo_automodel._transformers.auto_model._patch_attention", return_value=sentinel_model
+            ) as mock_patch,
+            patch("nemo_automodel._transformers.capabilities.attach_capabilities_and_validate"),
+            patch("nemo_automodel._transformers.auto_model.apply_model_infrastructure", return_value=sentinel_model),
+            patch("torch.cuda.current_device", return_value=0),
+        ):
+            result = _BaseNeMoAutoModelClass._build_model(mock_config, **build_kwargs)
+
+        assert result is sentinel_model
+        mock_patch.assert_called_once_with(sentinel_model, sdpa_method)
+
+    def test_custom_model_skips_sdpa_patch_when_method_is_default(self):
+        """Keep the custom-model default path unchanged when no SDPA method was resolved."""
+        build_kwargs, mock_config = self._make_build_kwargs()
+        sentinel_model = MagicMock()
+        build_kwargs.update(is_hf_model=False, use_sdpa_patching=True, sdpa_method=None)
+
+        with (
+            patch("nemo_automodel._transformers.auto_model._apply_preload_overrides", return_value=("sdpa", False)),
+            patch("nemo_automodel._transformers.auto_model._init_model", return_value=(True, sentinel_model)),
+            patch("nemo_automodel._transformers.auto_model.get_world_size_safe", return_value=1),
+            patch(
+                "nemo_automodel._transformers.auto_model._patch_attention", return_value=sentinel_model
+            ) as mock_patch,
+            patch("nemo_automodel._transformers.capabilities.attach_capabilities_and_validate"),
+            patch("nemo_automodel._transformers.auto_model.apply_model_infrastructure", return_value=sentinel_model),
+            patch("torch.cuda.current_device", return_value=0),
+        ):
+            result = _BaseNeMoAutoModelClass._build_model(mock_config, **build_kwargs)
+
+        assert result is sentinel_model
+        mock_patch.assert_not_called()
 
     def test_meta_tensor_runtime_error_retries_without_meta_device(self):
         """RuntimeError with 'meta tensors' triggers retry without meta device."""


### PR DESCRIPTION
## Summary
- apply resolved SDPA backend constraints to custom Automodel implementations when `sdpa_method` is resolved
- set the resolved SDPA backend flags process-wide so activation-checkpoint recompute uses the same backend eligibility as forward
- add focused unit coverage for explicit SDPA backend constraints and custom-model patching behavior

## Root cause / findings
The failing `qwen3_6_27b` VLM release job uses the custom Qwen3.5/Qwen3Next model path with activation checkpointing. Automodel already resolves SDPA methods under activation checkpointing to exclude cuDNN, but custom models were skipped by the SDPA patching path. That let PyTorch select cuDNN SDPA and fail in validation with:

```text
RuntimeError: Expected mha_graph.execute(handle, variant_pack, workspace_ptr.get()).is_good() to be true, but got false.
```

A first debug patch that only wrapped the top-level custom model forward removed the cuDNN `mha_graph.execute` error, but failed during backward with a checkpoint metadata mismatch because checkpoint recompute happened outside that top-level `sdpa_kernel` context. The final fix also applies the resolved backend list through process-level SDPA backend flags, so recompute sees the same backend constraints.

## Evidence
- Original failed job: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/346789255
- Same-SHA repro at `84e85792`: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/347083170
- Previous-commit repro at `b5aa1320`: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/347102618
- Intermediate top-level-context-only debug failure: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/347286644
- Final fixed scoped qwen job success: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/347305613
- Final fixed parent pipeline: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/55733942

The final run logs:

```text
nemo_automodel: 0.5.0+86e41e1b
Set global SDPA backends to [FLASH_ATTENTION, EFFICIENT_ATTENTION, MATH]
Patched model with SDPA method= [FLASH_ATTENTION, EFFICIENT_ATTENTION, MATH]
[val] step 9 | epoch 0 | loss 1.5970
Finished job with name qwen3_6_27b
```

## Tests
- `uv run pytest tests/unit_tests/_transformers/test_auto_model.py -q`