### PR TITLE
ci: avoid remote config load for Nemotron Nano test

### DIFF
--- a/tests/functional_tests/hf_transformer_finetune/nemotron_nano_v3_4layer_custom.yaml
+++ b/tests/functional_tests/hf_transformer_finetune/nemotron_nano_v3_4layer_custom.yaml
@@ -33,7 +33,7 @@ model:
   config:
     _target_: transformers.AutoConfig.from_pretrained
     pretrained_model_name_or_path: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
-    trust_remote_code: true
+    trust_remote_code: false
   backend:
     _target_: nemo_automodel.components.models.common.BackendConfig
     dispatcher: torch


### PR DESCRIPTION
## Summary
- avoid remote-code `AutoConfig` loading in the Nemotron Nano v3 4-layer HF Transformer finetune test
- use the Transformers-native `nemotron_h` config path while keeping Automodel's custom Nemotron v3 model resolver path

## Context
Debugged failed Actions job: https://github.com/NVIDIA-NeMo/Automodel/actions/runs/28133351739/job/83325122353

The first actionable failure is rank 0 failing during `AutoConfig.from_pretrained(..., trust_remote_code=True)` for `/home/TestData/automodel/hf_nemotron_nano_v3_4l/`:

```text
AttributeError: module 'transformers_modules.hf_nemotron_nano_v3_4l....configuration_nemotron_h' has no attribute 'NemotronHConfig'
```

The later NCCL watchdog timeout is fallout after rank 0 exits.

## Validation
- `AutoConfig.from_pretrained('/home/TestData/automodel/hf_nemotron_nano_v3_4l/', trust_remote_code=False)` resolves `transformers.models.nemotron_h.configuration_nemotron_h.NemotronHConfig`
- `NeMoAutoTokenizer.from_pretrained('/home/TestData/automodel/hf_nemotron_nano_v3_4l/', trust_remote_code=False)` loads successfully
- Automodel custom-model resolver still selects `nemo_automodel.components.models.nemotron_v3.model.NemotronHForCausalLM`
- `git diff --check`

Full 2-GPU local finetune was not runnable on this host because the installed PyTorch CUDA build rejects the local NVIDIA driver.
