### PR TITLE
fix(benchmark): skip unsupported MTP flops

### DIFF
--- a/nemo_automodel/recipes/llm/benchmark.py
+++ b/nemo_automodel/recipes/llm/benchmark.py
@@ -240,14 +240,24 @@ class BenchmarkingRecipeForNextTokenPrediction(TrainFinetuneRecipeForNextTokenPr
             if mtp_cfg is None or not getattr(mtp_cfg, "enabled", False) or layers is None:
                 continue
             block_types = [getattr(s, "block_type", "moe") for s in layers]
-            flops = _nemotronh_mtp_flops(
-                mp.config,
-                global_batch_size,
-                seq_len,
-                mtp_cfg.num_layers,
-                block_types,
-                mtp_cfg.use_repeated_layer,
-            )
+            try:
+                flops = _nemotronh_mtp_flops(
+                    mp.config,
+                    global_batch_size,
+                    seq_len,
+                    mtp_cfg.num_layers,
+                    block_types,
+                    mtp_cfg.use_repeated_layer,
+                )
+            except AttributeError as exc:
+                if self.dist_env.is_main:
+                    logger.warning(
+                        "Skipping MTP head FLOPs for %s because the Nemotron-H FLOPs formula "
+                        "does not support this config: %s",
+                        type(mp.config).__name__,
+                        exc,
+                    )
+                continue
             if self.dist_env.is_main:
                 logger.info(
                     f"MTP head FLOPs: N={mtp_cfg.num_layers} repeated={mtp_cfg.use_repeated_layer} "


### PR DESCRIPTION
## Summary

Skip optional MTP TFLOPs accounting when the model config is not supported by the Nemotron-H MTP FLOPs formula.

This keeps benchmark setup from failing for configs such as `Qwen3_5MoeConfig`, where the MTP head exists but the FLOPs helper expects Nemotron-H-specific top-level fields like `hidden_size`. Model construction and training behavior are unchanged.

## Links

- Linear issue: https://linear.app/nvidia/issue/AM-525/model-config-num-hidden-layers-mismatch-with-expected-layer-count
- Original failing nemo-ci job: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/347667998
- Automodel-only reference job/template: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/347674289
- First Automodel-only rerun parent pipeline: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/55780852
- First Automodel-only rerun failed leaf: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/347713269
- Latest Automodel-only rerun parent pipeline: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/55785672
- Latest downstream benchmark pipeline: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/55785739
- Latest targeted leaf job: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/347718015

## Verification

- `uv run ruff check nemo_automodel/recipes/llm/benchmark.py`
- `git diff --check`
- Runtime guard check for unsupported MTP config returning `0.0`
- `uv run pytest tests/unit_tests/recipes/llm/test_benchmark.py` (`31 passed`)
- Latest targeted leaf got past the `Qwen3_5MoeConfig` MTP FLOPs `hidden_size` AttributeError; trace shows `Skipping MTP head FLOPs for Qwen3_5MoeConfig` and benchmark setup continued. It later failed with CUDA OOM.