### PR TITLE
fix(distributed): use flattened CP FSDP mesh

### DIFF
--- a/nemo_automodel/components/distributed/mesh_utils.py
+++ b/nemo_automodel/components/distributed/mesh_utils.py
@@ -350,7 +350,7 @@ def get_fsdp_dp_mesh(
     Prefer native dimensions whenever possible:
     - cp=1, dp_replicate=1  -> ``device_mesh["dp_shard"]``
     - cp=1, dp_replicate>1  -> ``device_mesh[("dp_replicate", "dp_shard")]``
-    - cp>1, dp_replicate=1  -> ``device_mesh[("dp_shard", "cp")]``
+    - cp>1, dp_replicate=1  -> ``device_mesh["dp_shard_cp"]``
 
     When both CP and replicated DP are active we fall back to ``get_submesh()``
     because the composed mesh is genuinely multi-level.
@@ -373,7 +373,7 @@ def get_fsdp_dp_mesh(
         elif dp_replicate_size > 1:
             return device_mesh[(dp_replicate_name, dp_shard_name)]
         elif cp_size > 1:
-            return device_mesh[(dp_shard_name, cp_name)]
+            return get_flat_mesh(device_mesh, dp_shard_cp_name)
         else:
             return device_mesh[dp_shard_name]
 

--- a/tests/unit_tests/distributed/test_mesh_utils.py
+++ b/tests/unit_tests/distributed/test_mesh_utils.py
@@ -408,15 +408,16 @@ class TestGetFsdpDpMesh:
     # Branch 3 – dp_replicate = 1, cp > 1
     # ------------------------------------------------------------------
 
-    def test_cp_only_returns_shard_cp_tuple_slice(self):
-        """dp_replicate=1, cp>1 → device_mesh[("dp_shard","cp")]."""
+    def test_cp_only_returns_flattened_shard_cp_mesh(self):
+        """dp_replicate=1, cp>1 → device_mesh["dp_shard_cp"]."""
         mesh = self._make_mesh(self._ALL_NATIVE_DIMS, {"dp_replicate": 1, "cp": 4})
+        shard_cp_mesh = Mock()
+        mesh._get_root_mesh = Mock(return_value=mesh)
+        mesh._flatten_mapping = {"dp_shard_cp": shard_cp_mesh}
 
         result = get_fsdp_dp_mesh(mesh)
 
-        mesh.__getitem__.assert_any_call(("dp_shard", "cp"))
-        assert result._key == ("dp_shard", "cp")
-        assert result._mesh is mesh
+        assert result is shard_cp_mesh
 
     # ------------------------------------------------------------------
     # Branch 4 – dp_replicate > 1 AND cp > 1 → get_submesh fallback


### PR DESCRIPTION
## Summary

Fix the FSDP2 mesh selected when context parallelism is enabled without HSDP replication.

- Return the flattened `dp_shard_cp` mesh from `get_fsdp_dp_mesh()` for `cp_size > 1` and `dp_replicate_size == 1`.
- Keep the existing HSDP path unchanged for `dp_replicate_size > 1`.
- Update `test_mesh_utils.py` to assert that CP-only FSDP uses the flattened shard mesh instead of a native 2D mesh slice.

## Root cause / findings

The FSDP2 mesh builder already registers `dp_shard_cp` as the flattened `(dp_shard, cp)` axis. However, `get_fsdp_dp_mesh()` returned the native 2D slice `device_mesh[("dp_shard", "cp")]` when CP was enabled.

PyTorch `fully_shard()` does not interpret a 2D `DeviceMesh` as "flatten both axes and shard across all ranks". It interprets 2D meshes as HSDP: dim 0 is the replicate dimension and dim 1 is the shard dimension. In the installed PyTorch source this is documented in `fully_shard()` and implemented by `_get_mesh_info()` returning `HSDPMeshInfo(mesh, shard_mesh_dim=1, replicate_mesh_dim=0)`.

For a topology like `world=8, cp=2, dp=4`, the old mesh had shape `(dp_shard=4, cp=2)`, so FSDP only sharded over the CP dimension and replicated across the DP-shard dimension. The intended behavior is to shard over all `dp_shard * cp` ranks, which requires the 1D flattened `dp_shard_cp` mesh.

## Validation

- `/opt/venv/bin/python -m pytest tests/unit_tests/distributed/test_mesh_utils.py -q` (`24 passed`)
- `/opt/venv/bin/ruff format nemo_automodel/components/distributed/mesh_utils.py tests/unit_tests/distributed/test_mesh_utils.py`
- `/opt/venv/bin/ruff check --fix nemo_automodel/components/distributed/mesh_utils.py tests/unit_tests/distributed/test_mesh_utils.py`
