### PR TITLE
fix: skip fused LoRA MLP install for meta weights

### DIFF
--- a/nemo_automodel/components/_peft/lora_mlp.py
+++ b/nemo_automodel/components/_peft/lora_mlp.py
@@ -215,7 +215,7 @@ class LoRASwiGLUMLPFunction(torch.autograd.Function):
 
 
 def _fusible(module) -> bool:
-    """A LoRA linear is fusible when it is a plain (non-DoRA, dropout-free, non-DTensor) adapter."""
+    """A LoRA linear is fusible when it is a plain materialized adapter."""
     lora_A = getattr(module, "lora_A", None)
     lora_B = getattr(module, "lora_B", None)
     if lora_A is None or lora_B is None:
@@ -238,6 +238,8 @@ def _fusible(module) -> bool:
         return False
     for w in (base_w, lora_A.weight, lora_B.weight):
         if isinstance(w, DTensor):
+            return False
+        if getattr(w, "is_meta", False):
             return False
     return True
 
@@ -410,8 +412,8 @@ def _is_relu2_mlp(module) -> bool:
     return getattr(module, "activation", None) == "relu2"
 
 
-def _projs_are_lora(module, projs) -> bool:
-    return all(getattr(getattr(module, proj), "lora_A", None) is not None for proj in projs)
+def _projs_are_fusible(module, projs) -> bool:
+    return all(_fusible(getattr(module, proj)) for proj in projs)
 
 
 def _swiglu_forward(mod, orig_forward):
@@ -435,11 +437,12 @@ def install_fused_lora_mlp(model) -> int:
 
     Intended to be called by the LoRA matcher after the projections have been patched to
     ``LinearLoRA``. Handles SiLU-SwiGLU MLPs (gate/up/down) via :func:`fused_lora_swiglu_mlp` and
-    non-gated ReLU² MLPs (up/down) via :func:`fused_lora_relu2_mlp`. The installed ``forward`` falls
-    back to the module's original per-linear ``forward`` whenever fusion does not apply at runtime —
-    notably once the projections become ``DTensor`` under tensor/expert parallelism, or for DoRA /
-    active dropout. This keeps the fused memory win on single-GPU and pure-DP while staying correct
-    (and identical to the unfused path) under sharding.
+    non-gated ReLU² MLPs (up/down) via :func:`fused_lora_relu2_mlp`. A wrapper is installed only when
+    the projections are fusible and materialized at install time. The installed ``forward`` still
+    falls back to the module's original per-linear ``forward`` whenever fusion stops applying at
+    runtime, for example once projections become ``DTensor`` under tensor/expert parallelism, or for
+    DoRA / active dropout. This keeps the fused memory win on single-GPU and pure-DP while staying
+    correct (and identical to the unfused path) under sharding and PP/meta construction.
 
     Returns the number of MLP modules whose ``forward`` was swapped. Idempotent.
     """
@@ -447,9 +450,9 @@ def install_fused_lora_mlp(model) -> int:
     for mlp in model.modules():
         if getattr(mlp, "_lora_mlp_fused", False):
             continue
-        if _is_silu_swiglu_mlp(mlp) and _projs_are_lora(mlp, ("gate_proj", "up_proj", "down_proj")):
+        if _is_silu_swiglu_mlp(mlp) and _projs_are_fusible(mlp, ("gate_proj", "up_proj", "down_proj")):
             mlp.forward = _swiglu_forward(mlp, mlp.forward)
-        elif _is_relu2_mlp(mlp) and _projs_are_lora(mlp, ("up_proj", "down_proj")):
+        elif _is_relu2_mlp(mlp) and _projs_are_fusible(mlp, ("up_proj", "down_proj")):
             mlp.forward = _relu2_forward(mlp, mlp.forward)
         else:
             continue

--- a/tests/unit_tests/_peft/test_lora_mlp.py
+++ b/tests/unit_tests/_peft/test_lora_mlp.py
@@ -14,6 +14,8 @@
 
 """Parity tests for the fused LoRA SwiGLU MLP autograd function."""
 
+# ruff: noqa: E741
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -181,6 +183,28 @@ def test_fused_helper_declines_on_quantized_base():
     gate_qs = _make_lora(H, I, R)
     gate_qs.quant_state = object()
     assert fused_lora_swiglu_mlp(gate_qs, up, down, x) is None
+
+
+def test_fused_helper_declines_on_meta_weights():
+    """FSDP/PP graph construction can leave projection params on meta; direct F.linear must not run."""
+    H, I, R = 64, 96, 8
+    gate, up, down = _make_lora(H, I, R), _make_lora(H, I, R), _make_lora(I, H, R)
+    x = torch.randn(2, 16, H)
+
+    gate.weight = nn.Parameter(torch.empty_like(gate.weight, device="meta"), requires_grad=False)
+    assert fused_lora_swiglu_mlp(gate, up, down, x) is None
+
+
+def test_install_skips_meta_weight_mlp():
+    """Do not install a fused MLP wrapper when any projection weight is still on meta."""
+    from nemo_automodel.components._peft.lora_mlp import install_fused_lora_mlp
+
+    H, I, R = 64, 96, 8
+    mlp = _lora_swiglu_mlp(H, I, R)
+    mlp.gate_proj.weight = nn.Parameter(torch.empty_like(mlp.gate_proj.weight, device="meta"), requires_grad=False)
+
+    assert install_fused_lora_mlp(mlp) == 0
+    assert not getattr(mlp, "_lora_mlp_fused", False)
 
 
 def _lora_swiglu_mlp(H, I, R):


### PR DESCRIPTION
## Summary
- skip fused LoRA MLP wrapper installation when any projection weight is still on `meta`
- keep the runtime fusion guard for `meta` weights so direct fused `F.linear` is not used on unmaterialized params
- add regression coverage for helper fallback and install-time skip with meta projection weights

## Why
`glm_5.1_lora` under PP/FSDP can construct LoRA MLP projections on `meta`. The fused wrapper bypasses the normal module materialization path and directly calls `F.linear` on projection parameters, which produced non-finite loss. Skipping wrapper installation for meta projections keeps this path on the original per-linear forward.

## Testing
- `pytest -q tests/unit_tests/_peft/test_lora_mlp.py tests/unit_tests/_peft/test_lora.py` -> 32 passed, 4 skipped
- `ruff check nemo_automodel/components/_peft/lora_mlp.py tests/unit_tests/_peft/test_lora_mlp.py`
- nemo-ci `glm_5.1_lora` with `MAX_STEPS=2`: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/347847218

Final nemo-ci trace had finite losses for steps 0 and 1, no `loss nan`, and no traceback.