### PR TITLE
fix(checkpoint): keep missing MTP init weights random

### DIFF
--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -264,6 +264,34 @@ def _get_checkpoint_metadata_keys(
     return set(metadata.state_dict_metadata.keys())
 
 
+def _is_mtp_state_key(key: str) -> bool:
+    """Return True when a state-dict key belongs to an MTP module."""
+    return key == "mtp" or key.startswith("mtp.") or key.startswith("model.mtp.")
+
+
+def _pop_missing_init_mtp_keys(
+    state_dict: dict[str, torch.Tensor],
+    checkpoint_metadata_keys: set[str],
+    model_path: str,
+) -> dict[str, torch.Tensor]:
+    """Remove init-only MTP keys absent from the base checkpoint and return their current tensors."""
+    missing_mtp_keys = sorted(
+        key for key in state_dict if _is_mtp_state_key(key) and key not in checkpoint_metadata_keys
+    )
+    if not missing_mtp_keys:
+        return {}
+
+    current_mtp_state = {key: state_dict.pop(key) for key in missing_mtp_keys}
+    logging.warning(
+        "Base checkpoint %s is missing %d requested MTP keys. Keeping the current initialization for those MTP "
+        "parameters (examples=%s).",
+        model_path,
+        len(missing_mtp_keys),
+        missing_mtp_keys[:10],
+    )
+    return current_mtp_state
+
+
 if _is_geq_torch_2_9():
     from torch.distributed.checkpoint.staging import DefaultStager
     from torch.distributed.checkpoint.state_dict_saver import AsyncCheckpointerType, AsyncSaveResponse
@@ -725,6 +753,7 @@ class Checkpointer:
         )
 
         compat_tied_lm_head_source_key: str | None = None
+        init_missing_mtp_state: dict[str, torch.Tensor] = {}
         lm_head_param_name = getattr(model_state, "lm_head_param_name", None)
         should_try_tied_lm_head_compat = (
             getattr(model_state, "uses_tied_lm_head", False)
@@ -734,8 +763,16 @@ class Checkpointer:
         )
         checkpoint_metadata_keys: set[str] = set()
         extra_state_keys = sorted(key for key in state_dict if key.endswith("_extra_state"))
-        if should_try_tied_lm_head_compat or allow_checkpoint_key_subset or extra_state_keys:
+        needs_metadata_for_init_mtp = is_init_step and any(_is_mtp_state_key(key) for key in state_dict)
+        if (
+            should_try_tied_lm_head_compat
+            or allow_checkpoint_key_subset
+            or extra_state_keys
+            or needs_metadata_for_init_mtp
+        ):
             checkpoint_metadata_keys = _get_checkpoint_metadata_keys(model_path, storage_reader)
+        if needs_metadata_for_init_mtp:
+            init_missing_mtp_state = _pop_missing_init_mtp_keys(state_dict, checkpoint_metadata_keys, model_path)
         if extra_state_keys:
             missing_extra_state_keys = [key for key in extra_state_keys if key not in checkpoint_metadata_keys]
             if missing_extra_state_keys:
@@ -814,6 +851,7 @@ class Checkpointer:
                 )
 
         state_dict = self._do_load(state_dict, model_path, storage_reader, is_init_step=is_init_step)
+        state_dict.update(init_missing_mtp_state)
 
         if compat_tied_lm_head_source_key is not None and isinstance(lm_head_param_name, str):
             state_dict[lm_head_param_name] = state_dict.pop(compat_tied_lm_head_source_key)

--- a/tests/unit_tests/checkpoint/test_checkpointing.py
+++ b/tests/unit_tests/checkpoint/test_checkpointing.py
@@ -1275,6 +1275,155 @@ class TestLoadModelCheckpointKeySubset:
         assert "missing=0" in caplog.text
 
 
+class TestLoadModelInitMTPKeys:
+    """Test MTP key handling for base initialization and checkpoint restoration."""
+
+    def _make_checkpointer(self):
+        config = CheckpointingConfig(
+            enabled=True,
+            checkpoint_dir="/tmp/test",
+            model_save_format="safetensors",
+            model_cache_dir="/tmp/cache",
+            model_repo_id="test/model",
+            save_consolidated=False,
+            is_peft=False,
+        )
+        with patch("torch.distributed.is_initialized", return_value=False):
+            return Checkpointer(config, dp_rank=0, tp_rank=0, pp_rank=0, moe_mesh=None)
+
+    def test_base_init_keeps_missing_mtp_random_initialized(self, caplog):
+        checkpointer = self._make_checkpointer()
+        model = torch.nn.Module()
+        initial_state_dict = {
+            "layer.weight": torch.zeros(2, 2),
+            "mtp.layers.0.block.weight": torch.full((2, 2), 7.0),
+        }
+        captured = {}
+
+        def fake_do_load(state_dict, *args, **kwargs):
+            captured["requested_keys"] = set(state_dict)
+            return {key: torch.ones_like(value) for key, value in state_dict.items()}
+
+        caplog.set_level(logging.WARNING)
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("nemo_automodel.components.checkpoint.checkpointing.ModelState") as mock_model_state_cls,
+            patch.object(checkpointer, "_get_storage_reader", return_value=object()),
+            patch(
+                "nemo_automodel.components.checkpoint.checkpointing._maybe_adapt_state_dict_to_hf",
+                side_effect=lambda module, state_dict, **kwargs: state_dict,
+            ),
+            patch(
+                "nemo_automodel.components.checkpoint.checkpointing._maybe_adapt_state_dict_from_hf",
+                side_effect=lambda module, state_dict, **kwargs: state_dict,
+            ),
+            patch(
+                "nemo_automodel.components.checkpoint.checkpointing._get_checkpoint_metadata_keys",
+                return_value={"layer.weight"},
+            ),
+            patch.object(checkpointer, "_do_load", side_effect=fake_do_load),
+        ):
+            mock_model_state = mock_model_state_cls.return_value
+            mock_model_state.model = [model]
+            mock_model_state.state_dict.return_value = initial_state_dict.copy()
+
+            checkpointer.load_model(model, model_path="/fake/path", is_init_step=True)
+
+        assert captured["requested_keys"] == {"layer.weight"}
+        loaded_state_dict = mock_model_state.load_state_dict.call_args.args[0]
+        assert set(loaded_state_dict) == {"layer.weight", "mtp.layers.0.block.weight"}
+        assert torch.equal(loaded_state_dict["layer.weight"], torch.ones(2, 2))
+        assert torch.equal(
+            loaded_state_dict["mtp.layers.0.block.weight"], initial_state_dict["mtp.layers.0.block.weight"]
+        )
+        assert mock_model_state.load_state_dict.call_args.kwargs["strict"] is True
+        assert "requested MTP keys" in caplog.text
+
+    def test_base_init_loads_mtp_keys_when_checkpoint_has_them(self, caplog):
+        checkpointer = self._make_checkpointer()
+        model = torch.nn.Module()
+        initial_state_dict = {
+            "layer.weight": torch.zeros(2, 2),
+            "mtp.layers.0.block.weight": torch.zeros(2, 2),
+        }
+        captured = {}
+
+        def fake_do_load(state_dict, *args, **kwargs):
+            captured["requested_keys"] = set(state_dict)
+            return {key: torch.ones_like(value) for key, value in state_dict.items()}
+
+        caplog.set_level(logging.WARNING)
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("nemo_automodel.components.checkpoint.checkpointing.ModelState") as mock_model_state_cls,
+            patch.object(checkpointer, "_get_storage_reader", return_value=object()),
+            patch(
+                "nemo_automodel.components.checkpoint.checkpointing._maybe_adapt_state_dict_to_hf",
+                side_effect=lambda module, state_dict, **kwargs: state_dict,
+            ),
+            patch(
+                "nemo_automodel.components.checkpoint.checkpointing._maybe_adapt_state_dict_from_hf",
+                side_effect=lambda module, state_dict, **kwargs: state_dict,
+            ),
+            patch(
+                "nemo_automodel.components.checkpoint.checkpointing._get_checkpoint_metadata_keys",
+                return_value={"layer.weight", "mtp.layers.0.block.weight"},
+            ),
+            patch.object(checkpointer, "_do_load", side_effect=fake_do_load),
+        ):
+            mock_model_state = mock_model_state_cls.return_value
+            mock_model_state.model = [model]
+            mock_model_state.state_dict.return_value = initial_state_dict.copy()
+
+            checkpointer.load_model(model, model_path="/fake/path", is_init_step=True)
+
+        assert captured["requested_keys"] == {"layer.weight", "mtp.layers.0.block.weight"}
+        loaded_state_dict = mock_model_state.load_state_dict.call_args.args[0]
+        assert set(loaded_state_dict) == {"layer.weight", "mtp.layers.0.block.weight"}
+        assert torch.equal(loaded_state_dict["mtp.layers.0.block.weight"], torch.ones(2, 2))
+        assert "requested MTP keys" not in caplog.text
+
+    def test_checkpoint_restore_keeps_mtp_keys_strict(self):
+        checkpointer = self._make_checkpointer()
+        model = torch.nn.Module()
+        initial_state_dict = {
+            "layer.weight": torch.zeros(2, 2),
+            "mtp.layers.0.block.weight": torch.zeros(2, 2),
+        }
+        captured = {}
+
+        def fake_do_load(state_dict, *args, **kwargs):
+            captured["requested_keys"] = set(state_dict)
+            return {key: torch.ones_like(value) for key, value in state_dict.items()}
+
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("nemo_automodel.components.checkpoint.checkpointing.ModelState") as mock_model_state_cls,
+            patch.object(checkpointer, "_get_storage_reader", return_value=object()),
+            patch(
+                "nemo_automodel.components.checkpoint.checkpointing._maybe_adapt_state_dict_to_hf",
+                side_effect=lambda module, state_dict, **kwargs: state_dict,
+            ),
+            patch(
+                "nemo_automodel.components.checkpoint.checkpointing._maybe_adapt_state_dict_from_hf",
+                side_effect=lambda module, state_dict, **kwargs: state_dict,
+            ),
+            patch(
+                "nemo_automodel.components.checkpoint.checkpointing._get_checkpoint_metadata_keys",
+            ) as mock_get_metadata,
+            patch.object(checkpointer, "_do_load", side_effect=fake_do_load),
+        ):
+            mock_model_state = mock_model_state_cls.return_value
+            mock_model_state.model = [model]
+            mock_model_state.state_dict.return_value = initial_state_dict.copy()
+
+            checkpointer.load_model(model, model_path="/fake/path")
+
+        assert captured["requested_keys"] == {"layer.weight", "mtp.layers.0.block.weight"}
+        mock_get_metadata.assert_not_called()
+        assert mock_model_state.load_state_dict.call_args.kwargs["strict"] is True
+
+
 class TestLoadModelExtraState:
     """Test checkpoint load compatibility for module extra-state keys."""
 


### PR DESCRIPTION
## Summary
- Fixes base checkpoint loads when the runtime model has MTP enabled but the source checkpoint does not contain MTP tensors.
- Reads checkpoint metadata before DCP planning and removes only checkpoint-absent MTP destinations from init-time loads, then restores the model's current initialized tensors so MTP stays initialized instead of being searched in the base checkpoint.
- Keeps MTP checkpoint restoration strict: non-init restore still requests MTP keys, and base init from checkpoints that contain MTP still loads those tensors.

Original nemo-ci failure: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/347786556

## Validation
- `uv run pytest -q tests/unit_tests/checkpoint/test_checkpointing.py::TestLoadModelInitMTPKeys tests/unit_tests/checkpoint/test_checkpointing.py::TestLoadModelCheckpointKeySubset tests/unit_tests/checkpoint/test_checkpointing.py::TestLoadModelExtraState`
- `uv run pytest -q tests/unit_tests/models/qwen3_5/test_qwen3_5_mtp.py tests/unit_tests/models/qwen3_5_moe/test_qwen3_5_moe_mtp.py`
- `uv run ruff check nemo_automodel/components/checkpoint/checkpointing.py tests/unit_tests/checkpoint/test_checkpointing.py`
- `uv run ruff format --check nemo_automodel/components/checkpoint/checkpointing.py tests/unit_tests/checkpoint/test_checkpointing.py`
- Scoped nemo-ci rerun started: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/55827327 (`qwen3_5_35b`, VLM nightly on eos; parent build running, `automodel_test` bridge created)
