### PR TITLE
fix: Qwen3.5 MedPix EP32 NCCL timeout

### DIFF
--- a/examples/vlm_finetune/qwen3_5_moe/qwen3_5_moe_medpix.yaml
+++ b/examples/vlm_finetune/qwen3_5_moe/qwen3_5_moe_medpix.yaml
@@ -29,7 +29,9 @@ step_scheduler:
 
 dist_env:
   backend: nccl
-  timeout_minutes: 10
+  # The first interleaved PP backward pass can spend more than 10 minutes in
+  # downstream compile/compute before rank 0 receives gradients.
+  timeout_minutes: 30
 
 rng:
   _target_: nemo_automodel.components.training.rng.StatefulRNG

--- a/nemo_automodel/components/distributed/config.py
+++ b/nemo_automodel/components/distributed/config.py
@@ -73,6 +73,7 @@ class DistributedSetup:
         moe_parallel_config: "MoEParallelizerConfig | dict | None" = None,
         activation_checkpointing: ActivationCheckpointingMode = False,
         world_size: int | None = None,
+        timeout_minutes: int | None = None,
     ) -> "DistributedSetup":
         """Create a resolved distributed setup from sizes and policy configs.
 
@@ -110,6 +111,7 @@ class DistributedSetup:
             strategy_config,
             parallelism_sizes=parallelism_sizes,
             world_size=world_size,
+            timeout_minutes=timeout_minutes,
         )
 
         return cls(

--- a/nemo_automodel/components/distributed/mesh.py
+++ b/nemo_automodel/components/distributed/mesh.py
@@ -190,6 +190,7 @@ class MeshContext:
         parallelism_sizes: ParallelismSizes | None = None,
         *,
         world_size: int | None = None,
+        timeout_minutes: int | None = None,
     ) -> "MeshContext":
         """Build a topology-only :class:`MeshContext` from parallelism sizes.
 
@@ -200,6 +201,8 @@ class MeshContext:
                 DP inferred from ``world_size``.
             world_size: Total process count. If ``None``, inferred from the
                 distributed environment.
+            timeout_minutes: Optional timeout for process groups created by
+                ``DeviceMesh`` axes.
         """
         if world_size is None:
             world_size = get_world_size_safe()
@@ -212,6 +215,7 @@ class MeshContext:
             strategy_config,
             parallelism_sizes,
             world_size=world_size,
+            timeout_minutes=timeout_minutes,
         )
         return cls.from_meshes(device_mesh, moe_mesh)
 

--- a/nemo_automodel/components/distributed/mesh_utils.py
+++ b/nemo_automodel/components/distributed/mesh_utils.py
@@ -14,6 +14,7 @@
 
 """Device mesh construction and access utilities for distributed training."""
 
+import datetime
 from dataclasses import dataclass, field
 
 import torch
@@ -62,6 +63,7 @@ def _create_device_meshes(
     parallelism: ParallelismSizes,
     *,
     world_size: int,
+    timeout_minutes: int | None = None,
 ) -> tuple[DeviceMesh | None, DeviceMesh | None]:
     """Create raw device meshes based on distributed config type."""
     if (
@@ -75,6 +77,7 @@ def _create_device_meshes(
         return _create_fsdp2_device_mesh(
             parallelism,
             world_size=world_size,
+            timeout_minutes=timeout_minutes,
         )
     elif isinstance(strategy_config, MegatronFSDPConfig):
         _require_size_one("megatron_fsdp", parallelism.pp_size, "pipeline parallelism")
@@ -82,6 +85,7 @@ def _create_device_meshes(
         mesh = _create_megatron_fsdp_device_mesh(
             parallelism,
             world_size=world_size,
+            timeout_minutes=timeout_minutes,
         )
         return mesh, None
     elif isinstance(strategy_config, DDPConfig):
@@ -120,15 +124,41 @@ def _mesh_device_type() -> str:
     return "cuda" if torch.cuda.is_available() else "cpu"
 
 
-def _init_named_mesh(spec: _MeshSpec) -> DeviceMesh:
+def _init_named_mesh(spec: _MeshSpec, *, timeout_minutes: int | None = None) -> DeviceMesh:
     _validate_mesh_spec(spec)
+    device_type = _mesh_device_type()
     device_mesh = init_device_mesh(
-        device_type=_mesh_device_type(),
+        device_type=device_type,
         mesh_shape=spec.shape,
         mesh_dim_names=spec.axes,
+        backend_override=_nccl_backend_override(spec.axes, device_type=device_type, timeout_minutes=timeout_minutes),
     )
     _register_flattened_axes(device_mesh, spec.flattened_axes)
     return device_mesh
+
+
+def _nccl_backend_override(
+    axes: tuple[MeshAxisName, ...],
+    *,
+    device_type: str,
+    timeout_minutes: int | None,
+):
+    """Create per-axis NCCL options for DeviceMesh subgroups.
+
+    ``init_process_group(timeout=...)`` configures the default process group, but
+    ``init_device_mesh`` creates additional per-axis process groups. Without a
+    backend override those groups keep PyTorch's default NCCL timeout.
+    """
+    if timeout_minutes is None or device_type != "cuda":
+        return None
+
+    timeout = datetime.timedelta(minutes=timeout_minutes)
+    override = {}
+    for axis in axes:
+        options = dist.ProcessGroupNCCL.Options()
+        options._timeout = timeout
+        override[axis] = ("nccl", options)
+    return override
 
 
 def _validate_mesh_spec(spec: _MeshSpec) -> None:
@@ -153,6 +183,7 @@ def _create_fsdp2_device_mesh(
     parallelism: ParallelismSizes,
     *,
     world_size: int,
+    timeout_minutes: int | None = None,
 ) -> tuple[DeviceMesh, DeviceMesh | None]:
     """Create the FSDP2 root mesh and optional MoE mesh."""
     tp_size = _degree(parallelism.tp_size)
@@ -198,6 +229,7 @@ def _create_fsdp2_device_mesh(
                 MeshAxisName.DP_CP: (MeshAxisName.DP_REPLICATE, MeshAxisName.DP_SHARD, MeshAxisName.CP),
             },
         ),
+        timeout_minutes=timeout_minutes,
     )
 
     moe_mesh = None
@@ -211,6 +243,7 @@ def _create_megatron_fsdp_device_mesh(
     parallelism: ParallelismSizes,
     *,
     world_size: int,
+    timeout_minutes: int | None = None,
 ) -> DeviceMesh:
     """Create the Megatron FSDP mesh."""
     tp_size = _degree(parallelism.tp_size)
@@ -229,6 +262,7 @@ def _create_megatron_fsdp_device_mesh(
             axes=(MeshAxisName.DP, MeshAxisName.CP, MeshAxisName.TP),
             flattened_axes={MeshAxisName.DP_CP: (MeshAxisName.DP, MeshAxisName.CP)} if cp_size > 1 else {},
         ),
+        timeout_minutes=timeout_minutes,
     )
 
 

--- a/nemo_automodel/recipes/_dist_utils.py
+++ b/nemo_automodel/recipes/_dist_utils.py
@@ -250,15 +250,41 @@ def _distributed_cfg_to_dict(cfg: Any | None) -> dict:
     if cfg is None:
         return {}
     if isinstance(cfg, dict):
+        distributed_cfg = cfg.get("distributed")
+        if isinstance(distributed_cfg, dict):
+            return distributed_cfg.copy()
         return cfg.copy()
     distributed_cfg = cfg.distributed
     return distributed_cfg.to_dict() if hasattr(distributed_cfg, "to_dict") else dict(distributed_cfg)
+
+
+def _dist_env_timeout_minutes(cfg: Any | None) -> int | None:
+    """Return top-level ``dist_env.timeout_minutes`` when available."""
+    if cfg is None:
+        return None
+    if isinstance(cfg, dict):
+        dist_env = cfg.get("dist_env")
+        if isinstance(dist_env, dict):
+            return dist_env.get("timeout_minutes")
+        return None
+
+    getter = getattr(cfg, "get", None)
+    if callable(getter):
+        return getter("dist_env.timeout_minutes", None)
+
+    dist_env = getattr(cfg, "dist_env", None)
+    if dist_env is None:
+        return None
+    if isinstance(dist_env, dict):
+        return dist_env.get("timeout_minutes")
+    return getattr(dist_env, "timeout_minutes", None)
 
 
 def create_distributed_setup_from_config(
     cfg: Any | None = None,
     world_size: Optional[int] = None,
     *,
+    timeout_minutes: int | None = None,
     strategy: str | None = None,
     dp_size: int | None = None,
     dp_replicate_size: int | None = None,
@@ -286,6 +312,9 @@ def create_distributed_setup_from_config(
         world_size: Total number of processes in the job. If ``None`` (default),
             the value is auto-detected from ``torch.distributed`` if initialized,
             or from the ``WORLD_SIZE`` environment variable, falling back to ``1``.
+        timeout_minutes: Optional timeout for process groups created by
+            ``DeviceMesh`` axes. If omitted and ``cfg`` is a top-level recipe
+            config, ``dist_env.timeout_minutes`` is used.
         strategy: Distributed strategy name (``fsdp2``, ``megatron_fsdp``,
             ``megatron-fsdp``, ``mfsdp``, or ``ddp``).
         dp_size: Data-parallel size. If ``None``, inferred by mesh creation.
@@ -326,6 +355,7 @@ def create_distributed_setup_from_config(
         if value is not None:
             cfg_dict[key] = value
 
+    mesh_timeout_minutes = timeout_minutes if timeout_minutes is not None else _dist_env_timeout_minutes(cfg)
     parsed = parse_distributed_section(cfg_dict)
     return DistributedSetup.build(
         strategy=parsed["strategy_config"],
@@ -334,6 +364,7 @@ def create_distributed_setup_from_config(
         moe_parallel_config=parsed["moe_parallel_config"],
         activation_checkpointing=parsed["activation_checkpointing"],
         world_size=world_size,
+        timeout_minutes=mesh_timeout_minutes,
     )
 
 

--- a/tests/ci_tests/utils/generate_ci_tests.py
+++ b/tests/ci_tests/utils/generate_ci_tests.py
@@ -15,6 +15,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import os
 import sys
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -305,6 +306,7 @@ def generate_pipeline(automodel_dir: str, scope: str, test_folder: str) -> Dict[
     exempt_configs = set(config_override.get("exempt_configs") or [])
 
     pipeline: Dict[str, Any] = {"include": ["automodel/automodel_ci_template.yml"]}
+    job_name_suffix = os.environ.get("AUTOMODEL_CI_JOB_NAME_SUFFIX", "")
 
     for config in yml_configs:
         # Skip missing recipes so one bad reference doesn't abort the whole pipeline.
@@ -319,7 +321,7 @@ def generate_pipeline(automodel_dir: str, scope: str, test_folder: str) -> Dict[
 
         for suffix, job in generate_job(config, config_override, scope, test_folder, automodel_dir):
             job["variables"]["MODEL_FAMILY"] = model_name
-            pipeline[f"{config_name}{suffix}"] = job
+            pipeline[f"{config_name}{suffix}{job_name_suffix}"] = job
 
     return pipeline
 

--- a/tests/unit_tests/distributed/test_device_mesh.py
+++ b/tests/unit_tests/distributed/test_device_mesh.py
@@ -108,6 +108,12 @@ def test_mesh_context_build_passes_parallelism_to_raw_mesh_builder(captured_raw_
     assert parallelism.ep_size == 1
 
 
+def test_mesh_context_build_passes_timeout_to_raw_mesh_builder(captured_raw_mesh_call):
+    MeshContext.build(FSDP2Config(), world_size=4, timeout_minutes=30)
+
+    assert captured_raw_mesh_call["timeout_minutes"] == 30
+
+
 def test_mesh_context_build_requires_strategy_config():
     with pytest.raises(ValueError, match="Unknown distributed strategy config type"):
         MeshContext.build("ddp", world_size=1)  # type: ignore[arg-type]

--- a/tests/unit_tests/distributed/test_mesh_utils.py
+++ b/tests/unit_tests/distributed/test_mesh_utils.py
@@ -14,12 +14,17 @@
 
 """Tests for mesh_utils: get_flat_mesh, get_submesh, _unflatten_compat utilities."""
 
+import datetime
 from unittest.mock import Mock, patch
 
 import pytest
 import torch
 
+import nemo_automodel.components.distributed.mesh_utils as mesh_utils
+from nemo_automodel.components.distributed.mesh import MeshAxisName
 from nemo_automodel.components.distributed.mesh_utils import (
+    _init_named_mesh,
+    _MeshSpec,
     _unflatten_compat,
     get_flat_mesh,
     get_fsdp_dp_mesh,
@@ -48,6 +53,41 @@ def test_distributed_package_exports_user_entrypoints():
     assert distributed.MeshContext is MeshContext
     assert distributed.ParallelismSizes is ParallelismSizes
     assert distributed.initialize_distributed is initialize_distributed
+
+
+def test_init_named_mesh_sets_nccl_timeout_backend_override(monkeypatch):
+    captured: dict = {}
+    fake_mesh = Mock()
+
+    def fake_init_device_mesh(**kwargs):
+        captured.update(kwargs)
+        return fake_mesh
+
+    monkeypatch.setattr(mesh_utils, "init_device_mesh", fake_init_device_mesh)
+    monkeypatch.setattr(mesh_utils, "_mesh_device_type", lambda: "cuda")
+
+    result = _init_named_mesh(_MeshSpec(shape=(2,), axes=(MeshAxisName.PP,)), timeout_minutes=30)
+
+    assert result is fake_mesh
+    backend, options = captured["backend_override"][MeshAxisName.PP]
+    assert backend == "nccl"
+    assert options._timeout == datetime.timedelta(minutes=30)
+
+
+def test_init_named_mesh_omits_backend_override_for_cpu(monkeypatch):
+    captured: dict = {}
+    fake_mesh = Mock()
+
+    def fake_init_device_mesh(**kwargs):
+        captured.update(kwargs)
+        return fake_mesh
+
+    monkeypatch.setattr(mesh_utils, "init_device_mesh", fake_init_device_mesh)
+    monkeypatch.setattr(mesh_utils, "_mesh_device_type", lambda: "cpu")
+
+    _init_named_mesh(_MeshSpec(shape=(2,), axes=(MeshAxisName.PP,)), timeout_minutes=30)
+
+    assert captured["backend_override"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/recipes/test_dist_utils.py
+++ b/tests/unit_tests/recipes/test_dist_utils.py
@@ -621,6 +621,33 @@ class TestCreateDistributedSetupFromConfigWorldSizeAutoDetect:
         assert result.strategy_config.activation_checkpointing is False
         assert result.activation_checkpointing is True
 
+    def test_top_level_dist_env_timeout_passed_to_mesh(self, patched_mesh):
+        create_distributed_setup_from_config(
+            {
+                "distributed": {
+                    "strategy": "fsdp2",
+                    "pp_size": 2,
+                    "pipeline": {},
+                },
+                "dist_env": {"timeout_minutes": 30},
+            },
+            world_size=4,
+        )
+
+        assert patched_mesh["timeout_minutes"] == 30
+
+    def test_explicit_timeout_overrides_cfg_timeout(self, patched_mesh):
+        create_distributed_setup_from_config(
+            {
+                "distributed": {"strategy": "fsdp2"},
+                "dist_env": {"timeout_minutes": 10},
+            },
+            timeout_minutes=45,
+            world_size=4,
+        )
+
+        assert patched_mesh["timeout_minutes"] == 45
+
     @pytest.mark.parametrize("strategy", ["megatron_fsdp", "megatron-fsdp", "mfsdp"])
     def test_programmatic_megatron_fsdp_names(self, strategy, patched_mesh):
         result = create_distributed_setup_from_config(strategy=strategy, world_size=1)


### PR DESCRIPTION
## Summary
- propagate `dist_env.timeout_minutes` into DeviceMesh-created NCCL process groups
- increase the Qwen3.5 MoE MedPix recipe timeout to 30 minutes
- allow generated Automodel CI job names to carry a suffix, used for the EP32 validation target

## Why
AM-540 was a PP receive timeout: the default process group timeout was configured, but the per-axis DeviceMesh NCCL groups kept the default timeout. This wires the recipe timeout through the mesh construction path so PP receive groups get the intended longer timeout.

## Validation
- `pytest -q tests/unit_tests/distributed/test_device_mesh.py tests/unit_tests/distributed/test_mesh_utils.py tests/unit_tests/recipes/test_dist_utils.py` -> 115 passed
- `ruff check nemo_automodel/components/distributed/config.py nemo_automodel/components/distributed/mesh.py nemo_automodel/components/distributed/mesh_utils.py nemo_automodel/recipes/_dist_utils.py tests/ci_tests/utils/generate_ci_tests.py tests/unit_tests/distributed/test_device_mesh.py tests/unit_tests/distributed/test_mesh_utils.py tests/unit_tests/recipes/test_dist_utils.py`
- nemo-ci `qwen3_5_moe_medpix_ep32`, `MAX_STEPS=2`: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/347899288

The PR targets `main`; the `r0.5.0` label requests the release-branch auto-cherry-pick after merge.
