### PR TITLE
fix: qwen3.5 and 3.6 mtp expert checkpoint layout

### DIFF
--- a/nemo_automodel/components/models/qwen3_5_moe/model.py
+++ b/nemo_automodel/components/models/qwen3_5_moe/model.py
@@ -818,6 +818,8 @@ class Qwen3_5MoeForConditionalGeneration(HFCheckpointingMixin, HFQwen3_5MoeForCo
                 self.model.language_model.moe_config,
                 self.backend,
                 dtype=dtype,
+                pretrained_model_name_or_path=getattr(config, "_name_or_path", None)
+                or getattr(config, "name_or_path", None),
             )
 
         # Wrap vision rotary embedding with fp32-safe version

--- a/nemo_automodel/components/models/qwen3_5_moe/state_dict_adapter.py
+++ b/nemo_automodel/components/models/qwen3_5_moe/state_dict_adapter.py
@@ -102,17 +102,53 @@ class Qwen3_5MoeStateDictAdapter(StateDictAdapter):
         moe_config: MoEConfig,
         backend: BackendConfig,
         dtype: torch.dtype = torch.float32,
+        pretrained_model_name_or_path: str | None = None,
+        mtp_expert_hf_layout: str | None = None,
     ):
         self.config = config
         self.moe_config = moe_config
         self.backend = backend
         self.dtype = dtype
+        self.pretrained_model_name_or_path = pretrained_model_name_or_path
+        self.mtp_expert_hf_layout = mtp_expert_hf_layout
         self._uses_model_prefix = True
 
         self.hf_to_internal_map = {
             ".mlp.shared_expert.": ".mlp.shared_experts.",
         }
         self.internal_to_hf_map = {v: k for k, v in self.hf_to_internal_map.items()}
+
+    def _get_mtp_expert_hf_layout(self) -> str:
+        """Return whether MTP experts are stored as split or grouped HF tensors."""
+        layout = self.mtp_expert_hf_layout
+        if layout is None:
+            config_layout = getattr(self.config, "mtp_expert_hf_layout", None)
+            layout = config_layout if isinstance(config_layout, str) else None
+
+        if layout is not None:
+            normalized = layout.lower().replace("_", "-")
+            if normalized in {"split", "per-expert", "per-expert-safetensors"}:
+                return "split"
+            if normalized in {"grouped", "group"}:
+                return "grouped"
+            raise ValueError(f"Unsupported MTP expert HF layout: {layout!r}")
+
+        model_names = [self.pretrained_model_name_or_path]
+        for attr in ("_name_or_path", "name_or_path"):
+            value = getattr(self.config, attr, None)
+            if isinstance(value, str) and value:
+                model_names.append(value)
+
+        for model_name in model_names:
+            if not model_name:
+                continue
+            normalized_name = model_name.lower()
+            if "qwen3.5-35b-a3b" in normalized_name:
+                return "split"
+            if "qwen3.6-35b-a3b" in normalized_name:
+                return "grouped"
+
+        return "grouped"
 
     def _apply_key_mapping(self, state_dict: dict[str, Any], mapping: dict[str, str]) -> dict[str, Any]:
         """Apply key substring mappings to state dict keys."""
@@ -291,13 +327,45 @@ class Qwen3_5MoeStateDictAdapter(StateDictAdapter):
 
         new_fqn = fqn
         value = tensor
-        # MTP experts use the SAME grouped layout as the main decoder layers in the
-        # HF checkpoint (e.g. ``mtp.layers.0.mlp.experts.{gate_up_proj,down_proj}``),
-        # so they fall through to the generic grouped handling below. Splitting them
-        # into per-expert keys here produced destinations like
-        # ``mtp.layers.0.mlp.experts.224.down_proj.weight`` that don't exist in the
-        # checkpoint, raising "Missing key in checkpoint state_dict" on load under
-        # expert parallelism (AM-442).
+        mtp_gate_up_match = re.match(r"mtp\.layers\.(\d+)\.mlp\.experts\.gate_and_up_projs$", fqn)
+        mtp_down_match = re.match(r"mtp\.layers\.(\d+)\.mlp\.experts\.down_projs$", fqn)
+        if self._get_mtp_expert_hf_layout() == "split":
+            if mtp_gate_up_match:
+                layer_num = mtp_gate_up_match.group(1)
+                splits, expert_ids = state_dict_utils.split_experts_weights_dtensor_aware(
+                    tensor, self.moe_config.n_routed_experts
+                )
+                result = []
+                inter_dim = self.moe_config.moe_inter_dim
+                for expert_tensor, expert_id in zip(splits, expert_ids):
+                    gate = expert_tensor[:, :inter_dim].transpose(0, 1)
+                    up = expert_tensor[:, inter_dim:].transpose(0, 1)
+                    if not state_dict_utils.is_dtensor(gate):
+                        gate = gate.contiguous()
+                    if not state_dict_utils.is_dtensor(up):
+                        up = up.contiguous()
+                    result.append((f"mtp.layers.{layer_num}.mlp.experts.{expert_id}.gate_proj.weight", gate))
+                    result.append((f"mtp.layers.{layer_num}.mlp.experts.{expert_id}.up_proj.weight", up))
+                if exclude_key_regex:
+                    result = [(key, val) for key, val in result if not re.match(exclude_key_regex, key)]
+                return result
+            if mtp_down_match:
+                layer_num = mtp_down_match.group(1)
+                splits, expert_ids = state_dict_utils.split_experts_weights_dtensor_aware(
+                    tensor, self.moe_config.n_routed_experts
+                )
+                result = []
+                for expert_tensor, expert_id in zip(splits, expert_ids):
+                    down = expert_tensor.transpose(0, 1)
+                    if not state_dict_utils.is_dtensor(down):
+                        down = down.contiguous()
+                    result.append((f"mtp.layers.{layer_num}.mlp.experts.{expert_id}.down_proj.weight", down))
+                if exclude_key_regex:
+                    result = [(key, val) for key, val in result if not re.match(exclude_key_regex, key)]
+                return result
+
+        # Qwen3.6 stores MTP experts in the same grouped layout as decoder experts,
+        # while Qwen3.5 stores MTP experts as per-expert tensors handled above.
         if ".mlp.experts.gate_and_up_projs" in fqn:
             new_fqn = fqn.replace(".mlp.experts.gate_and_up_projs", ".mlp.experts.gate_up_proj")
             value = tensor.transpose(1, 2)

--- a/tests/unit_tests/models/qwen3_5_moe/test_qwen3_5_moe_state_dict_adapter.py
+++ b/tests/unit_tests/models/qwen3_5_moe/test_qwen3_5_moe_state_dict_adapter.py
@@ -35,6 +35,8 @@ def config():
     cfg.num_key_value_heads = 2
     cfg.num_experts = 4
     cfg.num_experts_per_tok = 2
+    cfg._name_or_path = "Qwen/Qwen3.6-35B-A3B"
+    cfg.name_or_path = "Qwen/Qwen3.6-35B-A3B"
     return cfg
 
 
@@ -673,9 +675,9 @@ class TestConvertSingleTensorToHf:
 
         assert result == [("mtp.fc.weight", tensor)]
 
-    def test_mtp_expert_key_conversion(self, adapter):
-        # MTP experts convert to the GROUPED HF layout, identical to the main
-        # decoder layers — not per-expert keys (AM-442).
+    def test_mtp_expert_key_conversion_grouped_layout(self, adapter):
+        # Qwen3.6 MTP experts use the grouped HF layout, identical to the main
+        # decoder layers, not per-expert keys (AM-442).
         tensor = torch.randn(4, 64, 128)
         result = adapter.convert_single_tensor_to_hf("mtp.layers.0.mlp.experts.gate_and_up_projs", tensor)
 
@@ -686,7 +688,7 @@ class TestConvertSingleTensorToHf:
         # No per-expert keys are emitted.
         assert not any(".experts.0." in k for k, _ in result)
 
-    def test_mtp_down_expert_key_conversion(self, adapter):
+    def test_mtp_down_expert_key_conversion_grouped_layout(self, adapter):
         tensor = torch.randn(4, 64, 32)
         result = adapter.convert_single_tensor_to_hf("mtp.layers.0.mlp.experts.down_projs", tensor)
 
@@ -695,7 +697,7 @@ class TestConvertSingleTensorToHf:
         assert key == "mtp.layers.0.mlp.experts.down_proj"
         torch.testing.assert_close(value, tensor.transpose(1, 2))
 
-    def test_mtp_experts_emit_no_per_expert_keys(self, adapter):
+    def test_mtp_experts_emit_no_per_expert_keys_for_grouped_layout(self, adapter):
         """AM-442 regression: to_hf must not fabricate per-expert MTP keys that are
         absent from the grouped checkpoint (e.g. ``...experts.224.down_proj.weight``)."""
         for native in ("mtp.layers.0.mlp.experts.gate_and_up_projs", "mtp.layers.0.mlp.experts.down_projs"):
@@ -704,6 +706,45 @@ class TestConvertSingleTensorToHf:
             key = result[0][0]
             assert key in ("mtp.layers.0.mlp.experts.gate_up_proj", "mtp.layers.0.mlp.experts.down_proj")
             assert not re.search(r"\.experts\.\d+\.", key)
+
+    def test_mtp_expert_key_conversion_split_layout_for_qwen35(self, adapter):
+        adapter.pretrained_model_name_or_path = "Qwen/Qwen3.5-35B-A3B"
+        tensor = torch.randn(4, 64, 128)
+
+        result = adapter.convert_single_tensor_to_hf("mtp.layers.0.mlp.experts.gate_and_up_projs", tensor)
+
+        assert len(result) == 8
+        result_by_key = dict(result)
+        expected_keys = set()
+        for expert_id in range(4):
+            expected_keys.add(f"mtp.layers.0.mlp.experts.{expert_id}.gate_proj.weight")
+            expected_keys.add(f"mtp.layers.0.mlp.experts.{expert_id}.up_proj.weight")
+        assert set(result_by_key) == expected_keys
+        for expert_id in range(4):
+            torch.testing.assert_close(
+                result_by_key[f"mtp.layers.0.mlp.experts.{expert_id}.gate_proj.weight"],
+                tensor[expert_id, :, :64].transpose(0, 1),
+            )
+            torch.testing.assert_close(
+                result_by_key[f"mtp.layers.0.mlp.experts.{expert_id}.up_proj.weight"],
+                tensor[expert_id, :, 64:].transpose(0, 1),
+            )
+
+    def test_mtp_down_expert_key_conversion_split_layout_for_qwen35(self, adapter):
+        adapter.pretrained_model_name_or_path = "Qwen/Qwen3.5-35B-A3B"
+        tensor = torch.randn(4, 64, 32)
+
+        result = adapter.convert_single_tensor_to_hf("mtp.layers.0.mlp.experts.down_projs", tensor)
+
+        assert len(result) == 4
+        result_by_key = dict(result)
+        expected_keys = {f"mtp.layers.0.mlp.experts.{expert_id}.down_proj.weight" for expert_id in range(4)}
+        assert set(result_by_key) == expected_keys
+        for expert_id in range(4):
+            torch.testing.assert_close(
+                result_by_key[f"mtp.layers.0.mlp.experts.{expert_id}.down_proj.weight"],
+                tensor[expert_id].transpose(0, 1),
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/models/qwen3_5_moe/test_qwen3_5_moe_state_dict_adapter.py
+++ b/tests/unit_tests/models/qwen3_5_moe/test_qwen3_5_moe_state_dict_adapter.py
@@ -824,7 +824,7 @@ class TestConditionalGenerationStateDictAdapterWiring:
         config = SimpleNamespace(
             text_config=text_config,
             torch_dtype=None,
-            _name_or_path="Qwen/Qwen3.5-35B-A3B",
+            _name_or_path="model-under-test",
             name_or_path=None,
         )
         backend = BackendConfig(enable_hf_state_dict_adapter=True)
@@ -836,14 +836,18 @@ class TestConditionalGenerationStateDictAdapterWiring:
             patch.object(qwen3_5_moe_model, "initialize_linear_module", Mock(return_value=Mock())),
             patch.object(qwen3_5_moe_model, "build_mtp_config_from_hf", Mock(return_value=DummyMTPConfig())),
             patch.object(qwen3_5_moe_model, "Qwen3_5MoeStateDictAdapter", DummyAdapter),
-            patch.object(qwen3_5_moe_model, "Fp32SafeQwen3_5MoeVisionRotaryEmbedding", DummyFp32SafeRotary),
+            patch.object(
+                qwen3_5_moe_model,
+                "Fp32SafeQwen3_5MoeVisionRotaryEmbedding",  # pragma: allowlist secret
+                DummyFp32SafeRotary,
+            ),
         ):
             qwen3_5_moe_model.Qwen3_5MoeForConditionalGeneration(config, backend=backend)
 
         assert len(adapter_calls) == 1
         args, kwargs = adapter_calls[0]
         assert args[0] is text_config
-        assert kwargs["pretrained_model_name_or_path"] == "Qwen/Qwen3.5-35B-A3B"
+        assert kwargs["pretrained_model_name_or_path"] == "model-under-test"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/models/qwen3_5_moe/test_qwen3_5_moe_state_dict_adapter.py
+++ b/tests/unit_tests/models/qwen3_5_moe/test_qwen3_5_moe_state_dict_adapter.py
@@ -13,11 +13,13 @@
 # limitations under the License.
 
 import re
-from unittest.mock import Mock
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 import pytest
 import torch
 
+import nemo_automodel.components.models.qwen3_5_moe.model as qwen3_5_moe_model
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.models.qwen3_5_moe.state_dict_adapter import Qwen3_5MoeStateDictAdapter
 from nemo_automodel.components.moe.layers import MoEConfig
@@ -104,6 +106,33 @@ class TestInitialization:
         # reverse mapping should be the inverse
         assert ".mlp.shared_experts." in adapter.internal_to_hf_map
         assert adapter.internal_to_hf_map[".mlp.shared_experts."] == ".mlp.shared_expert."
+
+    def test_mtp_layout_explicit_override(self, config, moe_config, backend_config):
+        adapter = Qwen3_5MoeStateDictAdapter(
+            config=config,
+            moe_config=moe_config,
+            backend=backend_config,
+            mtp_expert_hf_layout="per_expert_safetensors",
+        )
+
+        assert adapter._get_mtp_expert_hf_layout() == "split"
+
+    def test_mtp_layout_config_override(self, config, moe_config, backend_config):
+        config.mtp_expert_hf_layout = "group"
+        adapter = Qwen3_5MoeStateDictAdapter(config=config, moe_config=moe_config, backend=backend_config)
+
+        assert adapter._get_mtp_expert_hf_layout() == "grouped"
+
+    def test_mtp_layout_rejects_unknown_override(self, config, moe_config, backend_config):
+        adapter = Qwen3_5MoeStateDictAdapter(
+            config=config,
+            moe_config=moe_config,
+            backend=backend_config,
+            mtp_expert_hf_layout="packed",
+        )
+
+        with pytest.raises(ValueError, match="Unsupported MTP expert HF layout"):
+            adapter._get_mtp_expert_hf_layout()
 
 
 # ---------------------------------------------------------------------------
@@ -745,6 +774,76 @@ class TestConvertSingleTensorToHf:
                 result_by_key[f"mtp.layers.0.mlp.experts.{expert_id}.down_proj.weight"],
                 tensor[expert_id].transpose(0, 1),
             )
+
+
+# ---------------------------------------------------------------------------
+# Qwen3_5MoeForConditionalGeneration state dict adapter wiring
+# ---------------------------------------------------------------------------
+class TestConditionalGenerationStateDictAdapterWiring:
+    def test_passes_top_level_model_name_to_state_dict_adapter(self):
+        class DummyRotary:
+            inv_freq = torch.ones(4)
+
+        class DummyVisual:
+            def __init__(self):
+                self.rotary_pos_emb = DummyRotary()
+
+        class DummyParentModel:
+            def __init__(self):
+                self.visual = DummyVisual()
+                self.language_model = SimpleNamespace()
+
+        class DummyTextBackend:
+            def __init__(self, *args, **kwargs):
+                self.moe_config = Mock(name="moe_config")
+
+        class DummyMTPConfig:
+            enabled = False
+
+        class DummyFp32SafeRotary:
+            def __init__(self, dim):
+                self.dim = dim
+
+            def register_buffer(self, *args, **kwargs):
+                pass
+
+            def to(self, *args, **kwargs):
+                return self
+
+        adapter_calls = []
+
+        class DummyAdapter:
+            def __init__(self, *args, **kwargs):
+                adapter_calls.append((args, kwargs))
+
+        def fake_hf_init(self, config):
+            self.model = DummyParentModel()
+            self.lm_head = None
+
+        text_config = SimpleNamespace(torch_dtype=None, hidden_size=8, vocab_size=16, pad_token_id=None)
+        config = SimpleNamespace(
+            text_config=text_config,
+            torch_dtype=None,
+            _name_or_path="Qwen/Qwen3.5-35B-A3B",
+            name_or_path=None,
+        )
+        backend = BackendConfig(enable_hf_state_dict_adapter=True)
+
+        with (
+            patch.object(qwen3_5_moe_model.HFQwen3_5MoeForConditionalGeneration, "__init__", fake_hf_init),
+            patch.object(qwen3_5_moe_model, "Qwen3_5MoeModel", DummyParentModel),
+            patch.object(qwen3_5_moe_model, "Qwen3_5MoeTextModelBackend", DummyTextBackend),
+            patch.object(qwen3_5_moe_model, "initialize_linear_module", Mock(return_value=Mock())),
+            patch.object(qwen3_5_moe_model, "build_mtp_config_from_hf", Mock(return_value=DummyMTPConfig())),
+            patch.object(qwen3_5_moe_model, "Qwen3_5MoeStateDictAdapter", DummyAdapter),
+            patch.object(qwen3_5_moe_model, "Fp32SafeQwen3_5MoeVisionRotaryEmbedding", DummyFp32SafeRotary),
+        ):
+            qwen3_5_moe_model.Qwen3_5MoeForConditionalGeneration(config, backend=backend)
+
+        assert len(adapter_calls) == 1
+        args, kwargs = adapter_calls[0]
+        assert args[0] is text_config
+        assert kwargs["pretrained_model_name_or_path"] == "Qwen/Qwen3.5-35B-A3B"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

* Restore split per-expert HF key emission for Qwen3.5 MTP expert tensors.
* Preserve grouped MTP expert keys for Qwen3.6 checkpoints.
* Pass the top-level pretrained model id into the Qwen3.5-MoE state dict adapter so it can select the correct checkpoint layout.

## Regression

PR NVIDIA-NeMo/Automodel#2595 / cherry-pick NVIDIA-NeMo/Automodel#2618 changed MTP expert export to always use grouped keys for [AMINT-118](https://linear.app/nvidia/issue/AMINT-118/checkpoint-missing-weight-tensor-for-mtplayers0mlpexperts224down-proj). That matches Qwen/Qwen3.6-35B-A3B, but Qwen/Qwen3.5-35B-A3B checkpoints store MTP experts as per-expert safetensors keys such as `mtp.layers.0.mlp.experts.0.down_proj.weight`. With grouped export, DCP load looks for `mtp.layers.0.mlp.experts.down_proj` and fails with:

`RuntimeError: Missing key in checkpoint state_dict: mtp.layers.0.mlp.experts.down_proj.`

## Validation

* `PYTHONPATH=$PWD python -m pytest tests/unit_tests/models/qwen3_5_moe/test_qwen3_5_moe_state_dict_adapter.py -q` -> 61 passed
* Probe confirmed `Qwen/Qwen3.5-35B-A3B` emits split `...experts.0.down_proj.weight` keys while `Qwen/Qwen3.6-35B-A3B` emits grouped `...experts.down_proj` keys.
* NeMo-CI release VLM MTP pair passed:
  * root pipeline: [https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/55837816](<https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/55837816>)
  * VLM finetune leaf pipeline: [https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/55842527](<https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/55842527>)
  * `qwen3_5_35b`: [https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/348153547](<https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/348153547>)
  * `qwen3_6_35b`: [https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/348153548](<https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/348153548>)