### PR TITLE
fix(checkpoint): materialize lazy Adam optimizer state

### DIFF
--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -542,7 +542,13 @@ class Checkpointer:
         """
         optimizer_path = os.path.join(weights_path, "optim")
         _ensure_dirs(optimizer_path)
-        optimizer_state = OptimizerState(model, optimizer, scheduler, is_peft=self.config.is_peft)
+        optimizer_state = OptimizerState(
+            model,
+            optimizer,
+            scheduler,
+            is_peft=self.config.is_peft,
+            materialize_missing_adam_state=True,
+        )
         state_dict = optimizer_state.state_dict()
         self._optim_ctx.future = self._do_save(state_dict, optimizer_path)
 

--- a/nemo_automodel/components/checkpoint/stateful_wrappers.py
+++ b/nemo_automodel/components/checkpoint/stateful_wrappers.py
@@ -91,6 +91,41 @@ def _has_expert_parallelism(model: torch.nn.Module) -> bool:
     return any(getattr(m, "ep_size", 1) > 1 for m in model.modules())
 
 
+def _zeros_like_param(param: torch.Tensor) -> torch.Tensor:
+    try:
+        return torch.zeros_like(param, memory_format=torch.preserve_format)
+    except TypeError:
+        return torch.zeros_like(param)
+
+
+def _materialize_missing_adam_state(optimizer: torch.optim.Optimizer) -> None:
+    """Create Adam state for optimizer params that have not received gradients yet."""
+    if not isinstance(optimizer, (torch.optim.Adam, torch.optim.AdamW)):
+        return
+
+    for group in optimizer.param_groups:
+        step_dtype = (
+            torch.float32
+            if group.get("fused", False)
+            else torch.float64
+            if torch.get_default_dtype() == torch.float64
+            else torch.float32
+        )
+        for param in group["params"]:
+            state = optimizer.state[param]
+            if "step" not in state:
+                if group.get("capturable", False) or group.get("fused", False):
+                    state["step"] = torch.zeros((), dtype=step_dtype, device=param.device)
+                else:
+                    state["step"] = torch.tensor(0.0, dtype=step_dtype)
+            if "exp_avg" not in state:
+                state["exp_avg"] = _zeros_like_param(param)
+            if "exp_avg_sq" not in state:
+                state["exp_avg_sq"] = _zeros_like_param(param)
+            if group.get("amsgrad", False) and "max_exp_avg_sq" not in state:
+                state["max_exp_avg_sq"] = _zeros_like_param(param)
+
+
 def _get_peft_state_dict(model: torch.nn.Module) -> dict[str, Any]:
     """Extract only trainable PEFT adapter weights, bypassing DCP.
 
@@ -401,6 +436,7 @@ class OptimizerState:
         optimizer: torch.optim.Optimizer,
         scheduler: Optional[Any] = None,
         is_peft: bool = False,
+        materialize_missing_adam_state: bool = False,
     ):
         """
         Initialize an OptimizerState instance.
@@ -419,11 +455,14 @@ class OptimizerState:
             scheduler (Optional[Any], optional): Learning-rate scheduler to track
                 alongside the optimizer. Pass ``None`` if no scheduler is used.
             is_peft (bool): Whether the model uses PEFT adapters (e.g. LoRA/QLoRA).
+            materialize_missing_adam_state (bool): Whether to create zero Adam state for optimizer parameters that
+                have not received gradients yet. This is used on save so DCP metadata is complete.
         """
         self.model = [model] if isinstance(model, torch.nn.Module) else model
         self.optimizer = [optimizer] if isinstance(optimizer, torch.optim.Optimizer) else optimizer
         self.scheduler = [scheduler] if isinstance(scheduler, torch.optim.lr_scheduler.LRScheduler) else scheduler
         self.is_peft = is_peft
+        self.materialize_missing_adam_state = materialize_missing_adam_state
 
     def state_dict(self) -> dict[str, Any]:
         """
@@ -432,6 +471,10 @@ class OptimizerState:
         Returns:
             dict: Dictionary containing the optimizer and scheduler state dicts with CPU offloading enabled.
         """
+        if self.materialize_missing_adam_state:
+            for optimizer in self.optimizer:
+                _materialize_missing_adam_state(optimizer)
+
         # For PEFT models with quantized parameters or expert parallelism, bypass
         # PyTorch DCP's get_optimizer_state_dict() which fails because DCP cannot
         # build a consistent parameter-ID-to-FQN mapping when the model contains

--- a/tests/unit_tests/checkpoint/test_optimizer_lazy_state.py
+++ b/tests/unit_tests/checkpoint/test_optimizer_lazy_state.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+import torch
+
+from nemo_automodel.components.checkpoint.checkpointing import Checkpointer, CheckpointingConfig
+
+
+class _SparseOptimizerStateModel(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.active = torch.nn.Linear(2, 2, bias=False)
+        self.inactive = torch.nn.Linear(2, 2, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.active(x).sum()
+
+
+def _make_checkpointer(path: Path) -> Checkpointer:
+    config = CheckpointingConfig(
+        enabled=True,
+        checkpoint_dir=str(path),
+        model_save_format="safetensors",
+        model_cache_dir=str(path / "cache"),
+        model_repo_id="test/model",
+        save_consolidated=False,
+        is_peft=False,
+    )
+    return Checkpointer(config, dp_rank=0, tp_rank=0, pp_rank=0, moe_mesh=None)
+
+
+def _step_active_only(model: _SparseOptimizerStateModel, optimizer: torch.optim.Optimizer) -> None:
+    optimizer.zero_grad(set_to_none=True)
+    model(torch.ones(1, 2)).backward()
+    optimizer.step()
+    optimizer.zero_grad(set_to_none=True)
+
+
+def _prime_all_optimizer_state(model: torch.nn.Module, optimizer: torch.optim.Optimizer) -> None:
+    optimizer.zero_grad(set_to_none=True)
+    for param in model.parameters():
+        param.grad = torch.zeros_like(param)
+    optimizer.step()
+    optimizer.zero_grad(set_to_none=True)
+
+
+def test_optimizer_save_materializes_missing_adam_state_for_dcp_load(tmp_path: Path) -> None:
+    source_model = _SparseOptimizerStateModel()
+    source_optimizer = torch.optim.AdamW(source_model.parameters(), lr=1e-3)
+    _step_active_only(source_model, source_optimizer)
+    assert source_model.inactive.weight not in source_optimizer.state
+
+    checkpointer = _make_checkpointer(tmp_path)
+    checkpointer.save_optimizer(source_optimizer, source_model, str(tmp_path))
+    assert "step" in source_optimizer.state[source_model.inactive.weight]
+
+    target_model = _SparseOptimizerStateModel()
+    target_optimizer = torch.optim.AdamW(target_model.parameters(), lr=1e-3)
+    _prime_all_optimizer_state(target_model, target_optimizer)
+
+    checkpointer.load_optimizer(target_optimizer, target_model, str(tmp_path))
+
+    inactive_state = target_optimizer.state[target_model.inactive.weight]
+    assert inactive_state["step"].item() == 0
+    torch.testing.assert_close(inactive_state["exp_avg"], torch.zeros_like(target_model.inactive.weight))
+    torch.testing.assert_close(inactive_state["exp_avg_sq"], torch.zeros_like(target_model.inactive.weight))


### PR DESCRIPTION
# What does this PR do ?

Materializes zero Adam/AdamW optimizer state for parameters that have not received gradients before saving DCP optimizer checkpoints. This keeps DCP optimizer metadata complete and prevents resume from failing when the load-side optimizer expects `optim.state.<param>.step`.

# Changelog

- Add save-side Adam state materialization for missing `step`, `exp_avg`, `exp_avg_sq`, and AMSGrad `max_exp_avg_sq`.
- Keep optimizer load behavior unchanged.
- Add a CPU DCP unit repro for sparse optimizer state save/load.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation? Not needed for this checkpoint bug fix.

# Additional Information

Repro against `origin/main` (`903077a`): a CPU DCP harness where one AdamW parameter has no state at save time and the target optimizer expects all parameter state fails with:

`RuntimeError: Missing key in checkpoint state_dict: optim.state.inactive.weight.step.`

The same harness on this branch loads successfully:

`FIXED_BRANCH_LOAD inactive.step=0.0`

Local checks:

- `uv run ruff format nemo_automodel/components/checkpoint/stateful_wrappers.py nemo_automodel/components/checkpoint/checkpointing.py tests/unit_tests/checkpoint/test_optimizer_lazy_state.py`
- `uv run ruff check --fix nemo_automodel/components/checkpoint/stateful_wrappers.py nemo_automodel/components/checkpoint/checkpointing.py tests/unit_tests/checkpoint/test_optimizer_lazy_state.py`
- `uv run pytest -q tests/unit_tests/checkpoint/test_optimizer_lazy_state.py`
- `uv run pytest -q tests/unit_tests/checkpoint/test_checkpointing.py`
