### PR TITLE
feat(moe): add DeepEP v2 dispatcher support

### DIFF
--- a/nemo_automodel/components/_peft/lora_experts.py
+++ b/nemo_automodel/components/_peft/lora_experts.py
@@ -395,6 +395,7 @@ class GroupedExpertsDeepEPLoRA(GroupedExpertsDeepEP):
             orig_module.config,
             dispatcher_backend=orig_module.dispatcher_backend,
             dispatcher_num_sms=orig_module.dispatcher_num_sms,
+            dispatcher_num_qps=orig_module.dispatcher_num_qps,
             dispatcher_share_token_dispatcher=orig_module.dispatcher_share_token_dispatcher,
             dispatcher_async_dispatch=orig_module.dispatcher_async_dispatch,
         )

--- a/nemo_automodel/components/distributed/init_utils.py
+++ b/nemo_automodel/components/distributed/init_utils.py
@@ -172,5 +172,11 @@ def destroy_global_state():
     except Exception:  # pragma: no cover - best effort; deep_ep may be absent
         pass
     if torch.distributed.is_available() and torch.distributed.is_initialized():
+        try:
+            from nemo_automodel.components.moe.megatron.fused_a2a import destroy_deepep_v2_buffer
+
+            destroy_deepep_v2_buffer()
+        except ImportError:
+            pass
         torch.distributed.destroy_process_group()
     signal.signal(signal.SIGINT, signal.SIG_DFL)

--- a/nemo_automodel/components/models/common/utils.py
+++ b/nemo_automodel/components/models/common/utils.py
@@ -173,6 +173,8 @@ class BackendConfig:
             "uccl_ep" uses UCCL-EP for token dispatch across heterogeneous GPUs and NICs.
         dispatcher_num_sms: Communication SM count. Defaults to 6 for DeepEP v2 and 20 for
             the other dispatchers.
+        dispatcher_num_qps: Communication QP count. Defaults to 33 for DeepEP v2 and 0 for
+            the other dispatchers.
         dispatcher_share_token_dispatcher: Whether flex token dispatchers share a communication
             manager instance across MoE layers.
         dispatcher_async_dispatch: Whether DeepEP/UCCL-EP dispatch should return asynchronously
@@ -210,6 +212,7 @@ class BackendConfig:
         else "torch"
     )
     dispatcher_num_sms: int | None = None
+    dispatcher_num_qps: int | None = None
     dispatcher_share_token_dispatcher: bool = True
     dispatcher_async_dispatch: bool = False
     enable_deepep: bool | None = None  # Removed: ignored with a warning; set dispatcher/experts explicitly
@@ -271,6 +274,8 @@ class BackendConfig:
 
         if self.dispatcher_num_sms is None:
             self.dispatcher_num_sms = 6 if self.dispatcher == "deepep_v2" else 20
+        if self.dispatcher_num_qps is None:
+            self.dispatcher_num_qps = 33 if self.dispatcher == "deepep_v2" else 0
 
         # FP8 requires at least one TE backend (applies to all TE modules: Linear, GroupedLinear, RMSNorm)
         if self.te_fp8 is not None and self.linear != "te" and self.experts != "te":

--- a/nemo_automodel/components/models/common/utils.py
+++ b/nemo_automodel/components/models/common/utils.py
@@ -171,6 +171,8 @@ class BackendConfig:
         dispatcher: MoE token dispatcher. "torch" uses DTensor all-gather/reduce-scatter,
             "deepep" uses DeepEP for token dispatch, "deepep_v2" uses DeepEP V2 ElasticBuffer,
             "uccl_ep" uses UCCL-EP for token dispatch across heterogeneous GPUs and NICs.
+        dispatcher_num_sms: Communication SM count. Defaults to 6 for DeepEP v2 and 20 for
+            the other dispatchers.
         dispatcher_share_token_dispatcher: Whether flex token dispatchers share a communication
             manager instance across MoE layers.
         dispatcher_async_dispatch: Whether DeepEP/UCCL-EP dispatch should return asynchronously
@@ -207,7 +209,7 @@ class BackendConfig:
         if HAVE_UCCL_EP and torch.cuda.is_available()
         else "torch"
     )
-    dispatcher_num_sms: int = 20
+    dispatcher_num_sms: int | None = None
     dispatcher_share_token_dispatcher: bool = True
     dispatcher_async_dispatch: bool = False
     enable_deepep: bool | None = None  # Removed: ignored with a warning; set dispatcher/experts explicitly
@@ -266,6 +268,9 @@ class BackendConfig:
                 )
             self.dispatcher = "torch"
             self.experts = "torch_mm"
+
+        if self.dispatcher_num_sms is None:
+            self.dispatcher_num_sms = 6 if self.dispatcher == "deepep_v2" else 20
 
         # FP8 requires at least one TE backend (applies to all TE modules: Linear, GroupedLinear, RMSNorm)
         if self.te_fp8 is not None and self.linear != "te" and self.experts != "te":

--- a/nemo_automodel/components/models/common/utils.py
+++ b/nemo_automodel/components/models/common/utils.py
@@ -169,7 +169,7 @@ class BackendConfig:
             scaled grouped GEMM (training-only; GB200/sm_100+ with torchao installed,
             else falls back to torch._grouped_mm at runtime).
         dispatcher: MoE token dispatcher. "torch" uses DTensor all-gather/reduce-scatter,
-            "deepep" uses DeepEP for token dispatch,
+            "deepep" uses DeepEP for token dispatch, "deepep_v2" uses DeepEP V2 ElasticBuffer,
             "uccl_ep" uses UCCL-EP for token dispatch across heterogeneous GPUs and NICs.
         dispatcher_share_token_dispatcher: Whether flex token dispatchers share a communication
             manager instance across MoE layers.
@@ -200,7 +200,7 @@ class BackendConfig:
     experts: Literal["torch", "te", "gmm", "torch_mm", "torch_mm_mxfp8"] = (
         "torch_mm" if torch.cuda.is_available() else "torch"
     )
-    dispatcher: Literal["torch", "deepep", "hybridep", "uccl_ep"] = (
+    dispatcher: Literal["torch", "deepep", "deepep_v2", "hybridep", "uccl_ep"] = (
         "deepep"
         if HAVE_DEEP_EP and torch.cuda.is_available()
         else "uccl_ep"
@@ -249,12 +249,18 @@ class BackendConfig:
             self.enable_deepep = None
 
         # Backward compatibility
-        if self.experts in ("te", "gmm") and self.dispatcher not in ("deepep", "hybridep", "uccl_ep"):
+        if self.experts in ("te", "gmm") and self.dispatcher not in (
+            "deepep",
+            "deepep_v2",
+            "hybridep",
+            "uccl_ep",
+        ):
             if (
                 torch.distributed.is_initialized() and torch.distributed.get_rank() == 0
             ) or not torch.distributed.is_initialized():
                 logger.info(
-                    f"experts='{self.experts}' requires dispatcher='deepep' or 'uccl_ep', "
+                    f"experts='{self.experts}' requires dispatcher='deepep', 'deepep_v2', "
+                    "'hybridep', or 'uccl_ep', "
                     f"but got dispatcher='{self.dispatcher}'. "
                     "Setting dispatcher to torch and experts to torch_mm."
                 )

--- a/nemo_automodel/components/moe/experts.py
+++ b/nemo_automodel/components/moe/experts.py
@@ -666,6 +666,7 @@ class GroupedExpertsDeepEP(nn.Module):
         backend: Optional["BackendConfig"] = None,
         dispatcher_backend: str = "deepep",
         dispatcher_num_sms: int = 20,
+        dispatcher_num_qps: int = 0,
         dispatcher_share_token_dispatcher: bool = True,
         dispatcher_async_dispatch: bool = False,
     ):
@@ -678,6 +679,7 @@ class GroupedExpertsDeepEP(nn.Module):
                 uses torch._grouped_mm; otherwise uses grouped_gemm.ops.gmm.
             dispatcher_backend: Backend for the flex token dispatcher ("deepep", "deepep_v2", or "hybridep").
             dispatcher_num_sms: Number of SMs to use for the dispatcher backend.
+            dispatcher_num_qps: Number of QPs to use for the dispatcher backend.
             dispatcher_share_token_dispatcher: Whether to share a flex dispatcher communication manager across layers.
             dispatcher_async_dispatch: Whether DeepEP/UCCL-EP dispatch should run asynchronously.
         """
@@ -692,6 +694,7 @@ class GroupedExpertsDeepEP(nn.Module):
         self.is_gated = is_gated_activation(config.expert_activation)
         self.dispatcher_backend = dispatcher_backend
         self.dispatcher_num_sms = dispatcher_num_sms
+        self.dispatcher_num_qps = dispatcher_num_qps
         self.dispatcher_share_token_dispatcher = dispatcher_share_token_dispatcher
         self.dispatcher_async_dispatch = dispatcher_async_dispatch
 
@@ -728,6 +731,7 @@ class GroupedExpertsDeepEP(nn.Module):
             moe_enable_deepep=True,
             moe_flex_dispatcher_backend=self.dispatcher_backend,
             moe_deepep_num_sms=self.dispatcher_num_sms,
+            moe_deepep_num_qps=self.dispatcher_num_qps,
             moe_hybridep_num_sms=self.dispatcher_num_sms,
             moe_share_token_dispatcher=self.dispatcher_share_token_dispatcher,
             moe_deepep_async_dispatch=self.dispatcher_async_dispatch,
@@ -921,6 +925,7 @@ class GroupedExpertsTE(nn.Module):
         backend: Optional["BackendConfig"] = None,
         dispatcher_backend: str = "deepep",
         dispatcher_num_sms: int = 20,
+        dispatcher_num_qps: int = 0,
         dispatcher_share_token_dispatcher: bool = True,
         dispatcher_async_dispatch: bool = False,
     ):
@@ -932,6 +937,7 @@ class GroupedExpertsTE(nn.Module):
             backend: Backend configuration (reserved for future use).
             dispatcher_backend: Backend for the flex token dispatcher ("deepep", "deepep_v2", or "hybridep").
             dispatcher_num_sms: Number of SMs to use for the dispatcher backend.
+            dispatcher_num_qps: Number of QPs to use for the dispatcher backend.
             dispatcher_share_token_dispatcher: Whether to share a flex dispatcher communication manager across layers.
             dispatcher_async_dispatch: Whether DeepEP/UCCL-EP dispatch should run asynchronously.
         """
@@ -951,6 +957,7 @@ class GroupedExpertsTE(nn.Module):
         self.is_gated = is_gated_activation(config.expert_activation)
         self.dispatcher_backend = dispatcher_backend
         self.dispatcher_num_sms = dispatcher_num_sms
+        self.dispatcher_num_qps = dispatcher_num_qps
         self.dispatcher_share_token_dispatcher = dispatcher_share_token_dispatcher
         self.dispatcher_async_dispatch = dispatcher_async_dispatch
 
@@ -1260,6 +1267,7 @@ class GroupedExpertsTE(nn.Module):
             moe_enable_deepep=True,
             moe_flex_dispatcher_backend=self.dispatcher_backend,
             moe_deepep_num_sms=self.dispatcher_num_sms,
+            moe_deepep_num_qps=self.dispatcher_num_qps,
             moe_hybridep_num_sms=self.dispatcher_num_sms,
             moe_share_token_dispatcher=self.dispatcher_share_token_dispatcher,
             moe_deepep_async_dispatch=self.dispatcher_async_dispatch,

--- a/nemo_automodel/components/moe/experts.py
+++ b/nemo_automodel/components/moe/experts.py
@@ -676,7 +676,7 @@ class GroupedExpertsDeepEP(nn.Module):
             config: MoE configuration containing expert parameters.
             backend: Backend configuration. When backend.experts == "torch_mm",
                 uses torch._grouped_mm; otherwise uses grouped_gemm.ops.gmm.
-            dispatcher_backend: Backend for the flex token dispatcher ("deepep" or "hybridep").
+            dispatcher_backend: Backend for the flex token dispatcher ("deepep", "deepep_v2", or "hybridep").
             dispatcher_num_sms: Number of SMs to use for the dispatcher backend.
             dispatcher_share_token_dispatcher: Whether to share a flex dispatcher communication manager across layers.
             dispatcher_async_dispatch: Whether DeepEP/UCCL-EP dispatch should run asynchronously.
@@ -712,7 +712,11 @@ class GroupedExpertsDeepEP(nn.Module):
 
         self.expert_activation = get_expert_activation_for_deepep(config)
 
-    def init_token_dispatcher(self, ep_mesh: DeviceMesh):
+    def init_token_dispatcher(
+        self,
+        ep_mesh: DeviceMesh,
+        num_max_tokens_per_rank: int | None = None,
+    ) -> None:
         self.ep_size = ep_mesh.size()
         self.ep_rank = ep_mesh.get_local_rank()
         ep_group = ep_mesh.get_group()
@@ -744,6 +748,15 @@ class GroupedExpertsDeepEP(nn.Module):
         )
         if self.dispatcher_backend == "deepep":
             self._init_deepep_buffer(ep_group)
+        elif self.dispatcher_backend == "deepep_v2" and num_max_tokens_per_rank is not None:
+            from nemo_automodel.components.moe.megatron.fused_a2a import init_deepep_v2_buffer
+
+            init_deepep_v2_buffer(
+                ep_group,
+                num_max_tokens_per_rank,
+                self.config.expert_dim,
+                self.config.n_activated_experts,
+            )
 
     def _init_deepep_buffer(self, ep_group: dist.ProcessGroup) -> None:
         """Initialize DeepEP communication buffers before activation checkpointing."""
@@ -917,7 +930,7 @@ class GroupedExpertsTE(nn.Module):
         Args:
             config: MoE configuration containing expert parameters.
             backend: Backend configuration (reserved for future use).
-            dispatcher_backend: Backend for the flex token dispatcher ("deepep" or "hybridep").
+            dispatcher_backend: Backend for the flex token dispatcher ("deepep", "deepep_v2", or "hybridep").
             dispatcher_num_sms: Number of SMs to use for the dispatcher backend.
             dispatcher_share_token_dispatcher: Whether to share a flex dispatcher communication manager across layers.
             dispatcher_async_dispatch: Whether DeepEP/UCCL-EP dispatch should run asynchronously.

--- a/nemo_automodel/components/moe/layers.py
+++ b/nemo_automodel/components/moe/layers.py
@@ -655,6 +655,7 @@ class MoE(nn.Module):
                     backend=backend,
                     dispatcher_backend=backend.dispatcher,
                     dispatcher_num_sms=backend.dispatcher_num_sms,
+                    dispatcher_num_qps=backend.dispatcher_num_qps,
                     dispatcher_share_token_dispatcher=backend.dispatcher_share_token_dispatcher,
                     dispatcher_async_dispatch=backend.dispatcher_async_dispatch,
                 )
@@ -665,6 +666,7 @@ class MoE(nn.Module):
                     backend=backend,
                     dispatcher_backend=backend.dispatcher,
                     dispatcher_num_sms=backend.dispatcher_num_sms,
+                    dispatcher_num_qps=backend.dispatcher_num_qps,
                     dispatcher_share_token_dispatcher=backend.dispatcher_share_token_dispatcher,
                     dispatcher_async_dispatch=backend.dispatcher_async_dispatch,
                 )

--- a/nemo_automodel/components/moe/layers.py
+++ b/nemo_automodel/components/moe/layers.py
@@ -639,7 +639,8 @@ class MoE(nn.Module):
             self.gate = FakeBalancedGate(config, noise=backend.fake_gate_noise)
         else:
             self.gate = Gate(config, gate_precision=backend.gate_precision)
-        if backend.dispatcher in ("deepep", "hybridep", "uccl_ep") and get_world_size_safe() == 1:
+        ep_dispatchers = ("deepep", "deepep_v2", "hybridep", "uccl_ep")
+        if backend.dispatcher in ep_dispatchers and get_world_size_safe() == 1:
             warnings.warn(
                 f"'{backend.dispatcher}' dispatcher is enabled in config, but world size is 1. "
                 "Expert parallelism requires multiple GPUs. Falling back to standard GroupedExperts.",
@@ -647,7 +648,7 @@ class MoE(nn.Module):
                 stacklevel=2,
             )
             self.experts = GroupedExperts(config, backend=backend)
-        elif backend.dispatcher in ("deepep", "hybridep", "uccl_ep"):
+        elif backend.dispatcher in ep_dispatchers:
             if backend.experts in ("gmm", "torch_mm", "torch_mm_mxfp8"):
                 self.experts = GroupedExpertsDeepEP(
                     config,

--- a/nemo_automodel/components/moe/megatron/fused_a2a.py
+++ b/nemo_automodel/components/moe/megatron/fused_a2a.py
@@ -87,10 +87,9 @@ except ImportError:
 _buffer = None
 _deepep_v2_buffer = None
 _deepep_v2_num_sms = 0
+_deepep_v2_num_qps = 0
 _nvshmem_available = None
 _uccl_buffer = None
-
-_DEEPEP_V2_DEFAULT_NUM_QPS = 33
 
 _DEEPEP_V2_HANDLE_TENSOR_FIELDS = (
     "topk_idx",
@@ -428,7 +427,7 @@ class DeepEPV2FusedDispatch(torch.autograd.Function):
             num_experts=num_experts,
             num_max_tokens_per_rank=num_max_tokens_per_rank,
             num_sms=_deepep_v2_num_sms,
-            num_qps=_DEEPEP_V2_DEFAULT_NUM_QPS,
+            num_qps=_deepep_v2_num_qps,
             async_with_compute_stream=async_finish,
             allocate_on_comm_stream=allocate_on_comm_stream,
         )
@@ -457,7 +456,7 @@ class DeepEPV2FusedDispatch(torch.autograd.Function):
             grad_output.contiguous(),
             handle,
             topk_weights=grad_token_probs.float() if grad_token_probs is not None else None,
-            num_qps=_DEEPEP_V2_DEFAULT_NUM_QPS,
+            num_qps=_deepep_v2_num_qps,
             async_with_compute_stream=ctx.async_finish,
             allocate_on_comm_stream=ctx.allocate_on_comm_stream,
         )
@@ -492,7 +491,7 @@ class DeepEPV2FusedCombine(torch.autograd.Function):
             x.contiguous(),
             handle=handle,
             num_sms=_deepep_v2_num_sms,
-            num_qps=_DEEPEP_V2_DEFAULT_NUM_QPS,
+            num_qps=_deepep_v2_num_qps,
             async_with_compute_stream=async_finish,
             allocate_on_comm_stream=allocate_on_comm_stream,
         )
@@ -512,7 +511,7 @@ class DeepEPV2FusedCombine(torch.autograd.Function):
             grad_output.contiguous(),
             handle=handle,
             num_sms=handle.num_sms,
-            num_qps=_DEEPEP_V2_DEFAULT_NUM_QPS,
+            num_qps=_deepep_v2_num_qps,
             async_with_compute_stream=ctx.async_finish,
             allocate_on_comm_stream=ctx.allocate_on_comm_stream,
         )
@@ -584,6 +583,12 @@ def set_deepep_v2_num_sms(num_sms):
     """Set the number of SMs passed to DeepEP V2 ElasticBuffer operations."""
     global _deepep_v2_num_sms
     _deepep_v2_num_sms = num_sms
+
+
+def set_deepep_v2_num_qps(num_qps):
+    """Set the number of QPs passed to DeepEP V2 ElasticBuffer operations."""
+    global _deepep_v2_num_qps
+    _deepep_v2_num_qps = num_qps
 
 
 atexit.register(destroy_deepep_v2_buffer)

--- a/nemo_automodel/components/moe/megatron/fused_a2a.py
+++ b/nemo_automodel/components/moe/megatron/fused_a2a.py
@@ -17,15 +17,57 @@
 # Copyright (c) 2025 DeepSeek
 # Licensed under the MIT License - https://github.com/deepseek-ai/DeepEP/blob/main/LICENSE
 
+import atexit
+import importlib
 import os
 
-try:
-    from deep_ep import Buffer
-    from deep_ep.utils import EventHandle, EventOverlap
+import torch
 
-    HAVE_DEEP_EP = True
-except ImportError:
-    HAVE_DEEP_EP = False
+from nemo_automodel.shared.import_utils import safe_import_from
+
+
+def _safe_import_first_symbol(module_names: tuple[str, ...], symbol: str):
+    """Import the first available symbol from several optional module layouts."""
+    for module_name in module_names:
+        try:
+            module = importlib.import_module(module_name)
+            return True, getattr(module, symbol)
+        except (AttributeError, ImportError):
+            continue
+    return safe_import_from(module_names[-1], symbol)
+
+
+HAVE_DEEP_EP, Buffer = _safe_import_first_symbol(
+    (
+        "deep_ep.legacy",
+        "deep_ep.buffers.legacy",
+        "deep_ep",
+    ),
+    "Buffer",
+)
+HAVE_DEEP_EP_V2, ElasticBuffer = _safe_import_first_symbol(
+    (
+        "deep_ep",
+        "deep_ep.buffers.elastic",
+    ),
+    "ElasticBuffer",
+)
+_, EventHandle = _safe_import_first_symbol(
+    (
+        "deep_ep",
+        "deep_ep.utils",
+        "deep_ep.utils.event",
+    ),
+    "EventHandle",
+)
+_, EventOverlap = _safe_import_first_symbol(
+    (
+        "deep_ep",
+        "deep_ep.utils",
+        "deep_ep.utils.event",
+    ),
+    "EventOverlap",
+)
 
 try:
     import importlib.util
@@ -42,11 +84,21 @@ try:
 except ImportError:
     HAVE_UCCL_EP = False
 
-import torch
-
 _buffer = None
+_deepep_v2_buffer = None
+_deepep_v2_num_sms = 0
 _nvshmem_available = None
 _uccl_buffer = None
+
+_DEEPEP_V2_HANDLE_TENSOR_FIELDS = (
+    "topk_idx",
+    "psum_num_recv_tokens_per_scaleup_rank",
+    "psum_num_recv_tokens_per_expert",
+    "recv_src_metadata",
+    "dst_buffer_slot_idx",
+    "token_metadata_at_forward",
+    "channel_linked_list",
+)
 
 
 def _is_nvshmem_available() -> bool:
@@ -134,6 +186,67 @@ def free_buffer() -> None:
         except Exception:  # pragma: no cover - best effort
             pass
         _buffer = None
+
+
+def destroy_deepep_v2_buffer(ignore_errors: bool = True) -> None:
+    """Explicitly destroy the DeepEP V2 ElasticBuffer if one is allocated."""
+    global _deepep_v2_buffer
+
+    if _deepep_v2_buffer is not None:
+        try:
+            _deepep_v2_buffer.destroy()
+        except Exception:
+            if not ignore_errors:
+                raise
+    _deepep_v2_buffer = None
+
+
+def _warmup_deepep_v2_group(group: torch.distributed.ProcessGroup) -> None:
+    """Materialize the EP group's NCCL communicator before ElasticBuffer reads it."""
+    warmup = torch.empty(1, device=torch.cuda.current_device())
+    work = torch.distributed.all_reduce(warmup, group=group, async_op=True)
+    work.wait()
+
+
+def init_deepep_v2_buffer(
+    group: torch.distributed.ProcessGroup,
+    num_max_tokens_per_rank: int,
+    hidden: int,
+    num_topk: int,
+) -> None:
+    """Initialize the process-global DeepEP V2 ElasticBuffer."""
+    global _deepep_v2_buffer
+
+    if hidden % 256 != 0:
+        raise ValueError(f"DeepEP V2 requires a hidden dimension divisible by 256, got {hidden}.")
+    if _deepep_v2_buffer is not None:
+        return
+
+    _warmup_deepep_v2_group(group)
+    _deepep_v2_buffer = ElasticBuffer(
+        group,
+        num_max_tokens_per_rank=num_max_tokens_per_rank,
+        hidden=hidden,
+        num_topk=num_topk,
+        num_gpu_timeout_secs=300,
+        explicitly_destroy=True,
+    )
+
+
+def _save_deepep_v2_handle(ctx, handle) -> None:
+    """Save ElasticBuffer handle tensors for non-reentrant checkpoint replay."""
+    ctx.handle = handle
+    ctx.handle_tensor_fields = tuple(
+        field for field in _DEEPEP_V2_HANDLE_TENSOR_FIELDS if getattr(handle, field) is not None
+    )
+    ctx.save_for_backward(*(getattr(handle, field) for field in ctx.handle_tensor_fields))
+
+
+def _restore_deepep_v2_handle(ctx):
+    """Restore checkpoint-recomputed tensors onto the original ElasticBuffer handle."""
+    for field, tensor in zip(ctx.handle_tensor_fields, ctx.saved_tensors, strict=True):
+        setattr(ctx.handle, field, tensor)
+    return ctx.handle
 
 
 class FusedDispatch(torch.autograd.Function):
@@ -282,6 +395,126 @@ class FusedCombine(torch.autograd.Function):
         return grad_x, None, None, None, None
 
 
+class DeepEPV2FusedDispatch(torch.autograd.Function):
+    """Fused dispatch operation using DeepEP V2 ElasticBuffer."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        x,
+        token_indices,
+        token_probs,
+        num_experts,
+        group,
+        async_finish=False,
+        allocate_on_comm_stream=False,
+    ):
+        """Forward pass of DeepEP V2 fused dispatch."""
+        num_topk = token_indices.shape[1]
+        num_max_tokens_per_rank = x.size(0)
+        if _deepep_v2_buffer is None:
+            init_deepep_v2_buffer(
+                group,
+                num_max_tokens_per_rank,
+                x.size(1),
+                num_topk,
+            )
+        recv_x, recv_token_indices, recv_token_probs, handle, after_event = _deepep_v2_buffer.dispatch(
+            x,
+            topk_idx=token_indices,
+            topk_weights=token_probs,
+            num_experts=num_experts,
+            num_max_tokens_per_rank=num_max_tokens_per_rank,
+            num_sms=_deepep_v2_num_sms,
+            async_with_compute_stream=async_finish,
+            allocate_on_comm_stream=allocate_on_comm_stream,
+        )
+        if async_finish:
+            after_event.current_stream_wait()
+
+        ctx.async_finish = async_finish
+        ctx.allocate_on_comm_stream = allocate_on_comm_stream
+        _save_deepep_v2_handle(ctx, handle)
+        tokens_per_expert = torch.as_tensor(handle.num_recv_tokens_per_expert_list, dtype=torch.int64)
+
+        return (recv_x, recv_token_indices, recv_token_probs, tokens_per_expert, handle)
+
+    @staticmethod
+    def backward(
+        ctx,
+        grad_output,
+        grad_token_indices,
+        grad_token_probs,
+        grad_tokens_per_expert,
+        grad_handle,
+    ):
+        """Backward pass of DeepEP V2 fused dispatch."""
+        handle = _restore_deepep_v2_handle(ctx)
+        grad_x, grad_token_probs, after_event = _deepep_v2_buffer.combine(
+            grad_output.contiguous(),
+            handle,
+            topk_weights=grad_token_probs.float() if grad_token_probs is not None else None,
+            async_with_compute_stream=ctx.async_finish,
+            allocate_on_comm_stream=ctx.allocate_on_comm_stream,
+        )
+        if ctx.async_finish:
+            after_event.current_stream_wait()
+        return (
+            grad_x,
+            None,
+            grad_token_probs,
+            None,
+            None,
+            None,
+            None,
+        )
+
+
+class DeepEPV2FusedCombine(torch.autograd.Function):
+    """Fused combine operation using DeepEP V2 ElasticBuffer."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        x,
+        group,
+        handle,
+        async_finish=False,
+        allocate_on_comm_stream=False,
+    ):
+        """Forward pass of DeepEP V2 fused combine."""
+        del group
+        combined_x, _, after_event = _deepep_v2_buffer.combine(
+            x.contiguous(),
+            handle=handle,
+            num_sms=_deepep_v2_num_sms,
+            async_with_compute_stream=async_finish,
+            allocate_on_comm_stream=allocate_on_comm_stream,
+        )
+        if async_finish:
+            after_event.current_stream_wait()
+
+        ctx.async_finish = async_finish
+        ctx.allocate_on_comm_stream = allocate_on_comm_stream
+        _save_deepep_v2_handle(ctx, handle)
+        return combined_x, None
+
+    @staticmethod
+    def backward(ctx, grad_output, _grad_event=None):
+        """Backward pass of DeepEP V2 fused combine."""
+        handle = _restore_deepep_v2_handle(ctx)
+        grad_x, _, _, _, after_event = _deepep_v2_buffer.dispatch(
+            grad_output.contiguous(),
+            handle=handle,
+            num_sms=handle.num_sms,
+            async_with_compute_stream=ctx.async_finish,
+            allocate_on_comm_stream=ctx.allocate_on_comm_stream,
+        )
+        if ctx.async_finish:
+            after_event.current_stream_wait()
+        return grad_x, None, None, None, None
+
+
 if HAVE_DEEP_EP:
 
     def fused_dispatch(
@@ -330,14 +563,67 @@ if HAVE_DEEP_EP:
         """
         return FusedCombine.apply(x, group, handle, async_finish, allocate_on_comm_stream)
 
-    def set_deepep_num_sms(num_sms):
-        """Sets the number of SMs to use for DeepEP."""
-        Buffer.set_num_sms(num_sms)
-
 else:
     fused_dispatch = None
     fused_combine = None
-    set_deepep_num_sms = None
+
+
+def set_deepep_num_sms(num_sms):
+    """Set the number of SMs used by the legacy DeepEP Buffer."""
+    if HAVE_DEEP_EP:
+        Buffer.set_num_sms(num_sms)
+
+
+def set_deepep_v2_num_sms(num_sms):
+    """Set the number of SMs passed to DeepEP V2 ElasticBuffer operations."""
+    global _deepep_v2_num_sms
+    _deepep_v2_num_sms = num_sms
+
+
+atexit.register(destroy_deepep_v2_buffer)
+
+
+if HAVE_DEEP_EP_V2:
+
+    def deepep_v2_fused_dispatch(
+        x,
+        token_indices,
+        token_probs,
+        num_experts,
+        group,
+        async_finish=False,
+        allocate_on_comm_stream=False,
+    ):
+        """Perform fused dispatch with DeepEP V2 ElasticBuffer."""
+        return DeepEPV2FusedDispatch.apply(
+            x.contiguous(),
+            token_indices,
+            token_probs,
+            num_experts,
+            group,
+            async_finish,
+            allocate_on_comm_stream,
+        )
+
+    def deepep_v2_fused_combine(
+        x,
+        group,
+        handle,
+        async_finish=False,
+        allocate_on_comm_stream=False,
+    ):
+        """Perform fused combine with DeepEP V2 ElasticBuffer."""
+        return DeepEPV2FusedCombine.apply(
+            x,
+            group,
+            handle,
+            async_finish,
+            allocate_on_comm_stream,
+        )
+
+else:
+    deepep_v2_fused_dispatch = None
+    deepep_v2_fused_combine = None
 
 
 # HybridEP support
@@ -456,7 +742,10 @@ class HybridEPDispatch(torch.autograd.Function):
         """Backward pass of fused dispatch of the HybridEP backend."""
         handle = ctx.handle
         combined_hidden, combined_probs = _hybrid_ep_buffer.combine_with_unpermute(
-            hidden=grad_x, probs=grad_probs, handle=handle, pad_multiple=ctx.pad_multiple
+            hidden=grad_x,
+            probs=grad_probs,
+            handle=handle,
+            pad_multiple=ctx.pad_multiple,
         )
         return combined_hidden, None, combined_probs, None, None, None, None, None, None
 
@@ -468,7 +757,9 @@ class HybridEPCombine(torch.autograd.Function):
     def forward(ctx, x, handle, num_permuted_tokens=None, pad_multiple=None):
         """Forward pass of fused combine of the HybridEP backend."""
         combined_hidden, _ = _hybrid_ep_buffer.combine_with_unpermute(
-            hidden=x, handle=handle, pad_multiple=pad_multiple
+            hidden=x,
+            handle=handle,
+            pad_multiple=pad_multiple,
         )
         ctx.handle = handle
         ctx.pad_multiple = pad_multiple
@@ -486,7 +777,7 @@ class HybridEPCombine(torch.autograd.Function):
             pad_multiple=ctx.pad_multiple,
             num_permuted_tokens=ctx.num_permuted_tokens,
         )
-        return dispatched_hidden, None, None, None
+        return dispatched_hidden, None, None, None, None
 
 
 if HAVE_HYBRIDEP:

--- a/nemo_automodel/components/moe/megatron/fused_a2a.py
+++ b/nemo_automodel/components/moe/megatron/fused_a2a.py
@@ -456,6 +456,7 @@ class DeepEPV2FusedDispatch(torch.autograd.Function):
             grad_output.contiguous(),
             handle,
             topk_weights=grad_token_probs.float() if grad_token_probs is not None else None,
+            num_sms=_deepep_v2_num_sms,
             num_qps=_deepep_v2_num_qps,
             async_with_compute_stream=ctx.async_finish,
             allocate_on_comm_stream=ctx.allocate_on_comm_stream,

--- a/nemo_automodel/components/moe/megatron/fused_a2a.py
+++ b/nemo_automodel/components/moe/megatron/fused_a2a.py
@@ -90,6 +90,8 @@ _deepep_v2_num_sms = 0
 _nvshmem_available = None
 _uccl_buffer = None
 
+_DEEPEP_V2_DEFAULT_NUM_QPS = 33
+
 _DEEPEP_V2_HANDLE_TENSOR_FIELDS = (
     "topk_idx",
     "psum_num_recv_tokens_per_scaleup_rank",
@@ -426,6 +428,7 @@ class DeepEPV2FusedDispatch(torch.autograd.Function):
             num_experts=num_experts,
             num_max_tokens_per_rank=num_max_tokens_per_rank,
             num_sms=_deepep_v2_num_sms,
+            num_qps=_DEEPEP_V2_DEFAULT_NUM_QPS,
             async_with_compute_stream=async_finish,
             allocate_on_comm_stream=allocate_on_comm_stream,
         )
@@ -454,6 +457,7 @@ class DeepEPV2FusedDispatch(torch.autograd.Function):
             grad_output.contiguous(),
             handle,
             topk_weights=grad_token_probs.float() if grad_token_probs is not None else None,
+            num_qps=_DEEPEP_V2_DEFAULT_NUM_QPS,
             async_with_compute_stream=ctx.async_finish,
             allocate_on_comm_stream=ctx.allocate_on_comm_stream,
         )
@@ -488,6 +492,7 @@ class DeepEPV2FusedCombine(torch.autograd.Function):
             x.contiguous(),
             handle=handle,
             num_sms=_deepep_v2_num_sms,
+            num_qps=_DEEPEP_V2_DEFAULT_NUM_QPS,
             async_with_compute_stream=async_finish,
             allocate_on_comm_stream=allocate_on_comm_stream,
         )
@@ -507,6 +512,7 @@ class DeepEPV2FusedCombine(torch.autograd.Function):
             grad_output.contiguous(),
             handle=handle,
             num_sms=handle.num_sms,
+            num_qps=_DEEPEP_V2_DEFAULT_NUM_QPS,
             async_with_compute_stream=ctx.async_finish,
             allocate_on_comm_stream=ctx.allocate_on_comm_stream,
         )

--- a/nemo_automodel/components/moe/megatron/token_dispatcher.py
+++ b/nemo_automodel/components/moe/megatron/token_dispatcher.py
@@ -27,6 +27,7 @@ from .fused_a2a import (
     hybrid_ep_combine,
     hybrid_ep_dispatch,
     set_deepep_num_sms,
+    set_deepep_v2_num_qps,
     set_deepep_v2_num_sms,
     set_uccl_num_sms,
     uccl_fused_combine,
@@ -494,6 +495,9 @@ class TokenDispatcherConfig:
     moe_deepep_num_sms: int = 20
     """Number of SMs to use for DeepEP backend."""
 
+    moe_deepep_num_qps: int = 0
+    """Number of QPs to use for DeepEP v2."""
+
     moe_hybridep_num_sms: int = 24
     """Number of SMs to use for HybridEP dispatch and combine APIs."""
 
@@ -572,6 +576,7 @@ class MoEFlexTokenDispatcher:
                 set_deepep_num_sms(self.config.moe_deepep_num_sms)
             else:
                 set_deepep_v2_num_sms(self.config.moe_deepep_num_sms)
+                set_deepep_v2_num_qps(self.config.moe_deepep_num_qps)
             if backend == "deepep_v2" and deepep_v2_fused_dispatch is None:
                 raise ImportError("DeepEP V2 is not installed. Install a deep_ep package that exports ElasticBuffer.")
 

--- a/nemo_automodel/components/moe/megatron/token_dispatcher.py
+++ b/nemo_automodel/components/moe/megatron/token_dispatcher.py
@@ -20,11 +20,14 @@ from typing import List, Literal, Optional, Tuple
 import torch
 
 from .fused_a2a import (
+    deepep_v2_fused_combine,
+    deepep_v2_fused_dispatch,
     fused_combine,
     fused_dispatch,
     hybrid_ep_combine,
     hybrid_ep_dispatch,
     set_deepep_num_sms,
+    set_deepep_v2_num_sms,
     set_uccl_num_sms,
     uccl_fused_combine,
     uccl_fused_dispatch,
@@ -485,8 +488,8 @@ class TokenDispatcherConfig:
     improve stability especially when the number of experts is large (e.g. finegrained-moe).
     None means no changes for dtype."""
 
-    moe_flex_dispatcher_backend: Literal["deepep", "hybridep", "uccl_ep"] = "deepep"
-    """Backend for the flex token dispatcher. Options: 'deepep', 'hybridep', or 'uccl_ep'."""
+    moe_flex_dispatcher_backend: Literal["deepep", "deepep_v2", "hybridep", "uccl_ep"] = "deepep"
+    """Backend for the flex token dispatcher. Options: 'deepep', 'deepep_v2', 'hybridep', or 'uccl_ep'."""
 
     moe_deepep_num_sms: int = 20
     """Number of SMs to use for DeepEP backend."""
@@ -507,6 +510,7 @@ class MoEFlexTokenDispatcher:
     """
 
     shared_deepep_manager: _DeepepManager = None
+    shared_deepep_v2_manager: _DeepepManager = None
     shared_hybridep_manager: _HybridEPManager = None
     shared_uccl_manager: _DeepepManager = None
 
@@ -563,33 +567,41 @@ class MoEFlexTokenDispatcher:
                 self._comm_manager = MoEFlexTokenDispatcher.shared_uccl_manager
             else:
                 self._comm_manager = _DeepepManager(**manager_kwargs)
-        elif backend == "deepep":
-            if set_deepep_num_sms is not None:
+        elif backend in ("deepep", "deepep_v2"):
+            if backend == "deepep":
                 set_deepep_num_sms(self.config.moe_deepep_num_sms)
-            if self.config.moe_share_token_dispatcher:
-                if MoEFlexTokenDispatcher.shared_deepep_manager is None:
-                    MoEFlexTokenDispatcher.shared_deepep_manager = _DeepepManager(
-                        group=ep_group,
-                        router_topk=self.tp_size * self.config.moe_router_topk,
-                        permute_fusion=self.config.moe_permute_fusion,
-                        capacity_factor=self.config.moe_expert_capacity_factor,
-                        num_experts=self.tp_size * self.config.num_moe_experts,
-                        num_local_experts=self.num_local_experts,
-                        router_dtype=self.config.moe_router_dtype,
-                        moe_router_expert_pad_multiple=self.config.moe_router_expert_pad_multiple,
-                    )
-                self._comm_manager = MoEFlexTokenDispatcher.shared_deepep_manager
             else:
-                self._comm_manager = _DeepepManager(
-                    group=ep_group,
-                    router_topk=self.tp_size * self.config.moe_router_topk,
-                    permute_fusion=self.config.moe_permute_fusion,
-                    capacity_factor=self.config.moe_expert_capacity_factor,
-                    num_experts=self.tp_size * self.config.num_moe_experts,
-                    num_local_experts=self.num_local_experts,
-                    router_dtype=self.config.moe_router_dtype,
-                    moe_router_expert_pad_multiple=self.config.moe_router_expert_pad_multiple,
+                set_deepep_v2_num_sms(self.config.moe_deepep_num_sms)
+            if backend == "deepep_v2" and deepep_v2_fused_dispatch is None:
+                raise ImportError("DeepEP V2 is not installed. Install a deep_ep package that exports ElasticBuffer.")
+
+            manager_kwargs = dict(
+                group=ep_group,
+                router_topk=self.tp_size * self.config.moe_router_topk,
+                permute_fusion=self.config.moe_permute_fusion,
+                capacity_factor=self.config.moe_expert_capacity_factor,
+                num_experts=self.tp_size * self.config.num_moe_experts,
+                num_local_experts=self.num_local_experts,
+                router_dtype=self.config.moe_router_dtype,
+                moe_router_expert_pad_multiple=self.config.moe_router_expert_pad_multiple,
+            )
+            if backend == "deepep_v2":
+                manager_kwargs.update(
+                    _dispatch_fn=deepep_v2_fused_dispatch,
+                    _combine_fn=deepep_v2_fused_combine,
                 )
+
+            if self.config.moe_share_token_dispatcher:
+                if backend == "deepep":
+                    if MoEFlexTokenDispatcher.shared_deepep_manager is None:
+                        MoEFlexTokenDispatcher.shared_deepep_manager = _DeepepManager(**manager_kwargs)
+                    self._comm_manager = MoEFlexTokenDispatcher.shared_deepep_manager
+                else:
+                    if MoEFlexTokenDispatcher.shared_deepep_v2_manager is None:
+                        MoEFlexTokenDispatcher.shared_deepep_v2_manager = _DeepepManager(**manager_kwargs)
+                    self._comm_manager = MoEFlexTokenDispatcher.shared_deepep_v2_manager
+            else:
+                self._comm_manager = _DeepepManager(**manager_kwargs)
         elif backend == "hybridep":
             if self.config.moe_share_token_dispatcher:
                 if MoEFlexTokenDispatcher.shared_hybridep_manager is None:
@@ -613,7 +625,8 @@ class MoEFlexTokenDispatcher:
                 )
         else:
             raise ValueError(
-                f"Invalid backend: {backend}. Please set moe_flex_dispatcher_backend='deepep', 'hybridep', or 'uccl_ep'"
+                f"Invalid backend: {backend}. Please set moe_flex_dispatcher_backend='deepep', "
+                "'deepep_v2', 'hybridep', or 'uccl_ep'"
             )
 
     def _initialize_metadata(self, num_local_tokens: int, probs: torch.Tensor) -> torch.Tensor:
@@ -703,6 +716,9 @@ class MoEFlexTokenDispatcher:
         tokens_per_expert = self._comm_manager.get_number_of_tokens_per_expert()
         return global_input_tokens, tokens_per_expert, permuted_probs
 
+    def _uses_deepep_async_dispatch(self) -> bool:
+        return isinstance(self._comm_manager, _DeepepManager) and self.config.moe_deepep_async_dispatch
+
     def token_permutation(
         self, hidden_states: torch.Tensor, num_local_tokens: int, probs: torch.Tensor
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -717,7 +733,7 @@ class MoEFlexTokenDispatcher:
         hidden_states, _ = self.dispatch_preprocess(
             hidden_states=hidden_states, num_local_tokens=num_local_tokens, probs=probs
         )
-        async_dispatch = isinstance(self._comm_manager, _DeepepManager) and self.config.moe_deepep_async_dispatch
+        async_dispatch = self._uses_deepep_async_dispatch()
         hidden_states, _ = self.dispatch_all_to_all(
             hidden_states,
             async_finish=async_dispatch,
@@ -748,7 +764,7 @@ class MoEFlexTokenDispatcher:
             token_probs=token_probs,
             token_indices=token_indices,
         )
-        async_dispatch = isinstance(self._comm_manager, _DeepepManager) and self.config.moe_deepep_async_dispatch
+        async_dispatch = self._uses_deepep_async_dispatch()
         hidden_states, _ = self.dispatch_all_to_all(
             hidden_states,
             async_finish=async_dispatch,
@@ -797,7 +813,12 @@ class MoEFlexTokenDispatcher:
         3. Post-process the combined tokens to match the original input shape
         """
         hidden_states = self.combine_preprocess(hidden_states)
-        hidden_states = self.combine_all_to_all(hidden_states, False, False)
+        async_dispatch = self._uses_deepep_async_dispatch()
+        hidden_states = self.combine_all_to_all(
+            hidden_states,
+            async_finish=async_dispatch,
+            allocate_on_comm_stream=async_dispatch,
+        )
         hidden_states = self.combine_postprocess(hidden_states)
 
         return hidden_states

--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -138,6 +138,9 @@ class ExpertParallel(ParallelStyle):
     Dim `0` of each parameter is sharded since that is the expert dimension.
     """
 
+    def __init__(self, num_max_tokens_per_rank: int | None = None):
+        self.num_max_tokens_per_rank = num_max_tokens_per_rank
+
     def _partition_fn(self, name, module, device_mesh):
         # shard on the expert dimension
         assert device_mesh.ndim == 1
@@ -148,7 +151,10 @@ class ExpertParallel(ParallelStyle):
             module.register_parameter(name, dist_param)
 
         if isinstance(module, GroupedExpertsDeepEP):
-            module.init_token_dispatcher(ep_mesh=device_mesh)
+            module.init_token_dispatcher(
+                ep_mesh=device_mesh,
+                num_max_tokens_per_rank=self.num_max_tokens_per_rank,
+            )
 
     def _apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
         return distribute_module(
@@ -180,7 +186,12 @@ def _iter_moe_blocks(model_wrapper: nn.Module, backbone: nn.Module):
         yield from mtp_module.layers.children()
 
 
-def apply_ep(model: nn.Module, ep_mesh: DeviceMesh, moe_mesh: DeviceMesh | None = None):
+def apply_ep(
+    model: nn.Module,
+    ep_mesh: DeviceMesh,
+    moe_mesh: DeviceMesh | None = None,
+    num_max_tokens_per_rank: int | None = None,
+):
     """Applies EP to MoE module."""
     assert ep_mesh.size() > 1
 
@@ -204,7 +215,7 @@ def apply_ep(model: nn.Module, ep_mesh: DeviceMesh, moe_mesh: DeviceMesh | None 
             parallelize_module(
                 module=moe_module.experts,
                 device_mesh=ep_mesh,
-                parallelize_plan=ExpertParallel(),
+                parallelize_plan=ExpertParallel(num_max_tokens_per_rank),
             )
 
 
@@ -647,6 +658,7 @@ def parallelize_model(
     lm_head_precision: str | torch.dtype | None = None,
     wrap_outer_model: bool = True,
     mp_policy: MixedPrecisionPolicy | None = None,
+    num_max_tokens_per_rank: int | None = None,
 ):
     """Apply context, expert, activation-checkpointing, and FSDP parallelism."""
 
@@ -666,7 +678,12 @@ def parallelize_model(
             f"expert_parallel_degree {moe_mesh[ep_axis_name].size()}"
         )
 
-        apply_ep(model, moe_mesh[ep_axis_name], moe_mesh=moe_mesh)
+        apply_ep(
+            model,
+            moe_mesh[ep_axis_name],
+            moe_mesh=moe_mesh,
+            num_max_tokens_per_rank=num_max_tokens_per_rank,
+        )
 
     if activation_checkpointing:
         apply_ac(

--- a/tests/unit_tests/_peft/test_lora_experts.py
+++ b/tests/unit_tests/_peft/test_lora_experts.py
@@ -178,6 +178,7 @@ def test_grouped_experts_deepep_lora_preserves_dispatcher_settings(moe_config):
         moe_config,
         dispatcher_backend="hybridep",
         dispatcher_num_sms=24,
+        dispatcher_num_qps=33,
         dispatcher_share_token_dispatcher=False,
         dispatcher_async_dispatch=True,
     )
@@ -188,6 +189,7 @@ def test_grouped_experts_deepep_lora_preserves_dispatcher_settings(moe_config):
 
     assert lora_experts.dispatcher_backend == "hybridep"
     assert lora_experts.dispatcher_num_sms == 24
+    assert lora_experts.dispatcher_num_qps == 33
     assert lora_experts.dispatcher_share_token_dispatcher is False
     assert lora_experts.dispatcher_async_dispatch is True
     assert lora_experts.use_torch_mm is True

--- a/tests/unit_tests/distributed/test_destroy_global_state.py
+++ b/tests/unit_tests/distributed/test_destroy_global_state.py
@@ -21,6 +21,11 @@ import nemo_automodel.components.moe.megatron.fused_a2a as fused_a2a
 def _patch_common(monkeypatch, calls, *, initialized: bool):
     monkeypatch.setattr(init_utils.signal, "signal", lambda *a, **k: None)
     monkeypatch.setattr(fused_a2a, "free_buffer", lambda: calls.append("free_buffer"))
+    monkeypatch.setattr(
+        fused_a2a,
+        "destroy_deepep_v2_buffer",
+        lambda: calls.append("destroy_deepep_v2_buffer"),
+    )
     monkeypatch.setattr(init_utils.torch.cuda, "is_available", lambda: False)
     monkeypatch.setattr(init_utils.torch.distributed, "is_available", lambda: True)
     monkeypatch.setattr(init_utils.torch.distributed, "is_initialized", lambda: initialized)
@@ -35,7 +40,7 @@ def test_frees_deepep_buffer_before_destroying_process_group(monkeypatch):
 
     init_utils.destroy_global_state()
 
-    assert calls == ["free_buffer", "destroy_pg"]
+    assert calls == ["free_buffer", "destroy_deepep_v2_buffer", "destroy_pg"]
 
 
 def test_frees_buffer_even_without_process_group(monkeypatch):
@@ -61,4 +66,4 @@ def test_buffer_free_failure_does_not_block_pg_destroy(monkeypatch):
 
     init_utils.destroy_global_state()
 
-    assert calls == ["destroy_pg"]
+    assert calls == ["destroy_deepep_v2_buffer", "destroy_pg"]

--- a/tests/unit_tests/moe/test_backend_config.py
+++ b/tests/unit_tests/moe/test_backend_config.py
@@ -196,6 +196,21 @@ class TestBackendConfigHybridEP:
         config = BackendConfig(dispatcher="deepep_v2", dispatcher_num_sms=20)
         assert config.dispatcher_num_sms == 20
 
+    def test_deepep_v2_dispatcher_num_qps_default(self):
+        """DeepEP v2 defaults to the measured EP64 QP count."""
+        config = BackendConfig(dispatcher="deepep_v2")
+        assert config.dispatcher_num_qps == 33
+
+    def test_deepep_v2_dispatcher_num_qps_custom(self):
+        """An explicit DeepEP v2 QP count overrides the tuned default."""
+        config = BackendConfig(dispatcher="deepep_v2", dispatcher_num_qps=65)
+        assert config.dispatcher_num_qps == 65
+
+    def test_legacy_dispatcher_num_qps_default(self):
+        """Other dispatchers retain the API's automatic QP selection."""
+        config = BackendConfig(dispatcher="deepep")
+        assert config.dispatcher_num_qps == 0
+
     def test_dispatcher_share_token_dispatcher_default(self):
         """Test that dispatcher_share_token_dispatcher defaults to enabled."""
         config = BackendConfig(dispatcher="deepep")

--- a/tests/unit_tests/moe/test_backend_config.py
+++ b/tests/unit_tests/moe/test_backend_config.py
@@ -186,6 +186,16 @@ class TestBackendConfigHybridEP:
         config = BackendConfig(dispatcher="hybridep", dispatcher_num_sms=24)
         assert config.dispatcher_num_sms == 24
 
+    def test_deepep_v2_dispatcher_num_sms_default(self):
+        """DeepEP v2 defaults to the measured EP64 optimum."""
+        config = BackendConfig(dispatcher="deepep_v2")
+        assert config.dispatcher_num_sms == 6
+
+    def test_deepep_v2_dispatcher_num_sms_custom(self):
+        """An explicit DeepEP v2 SM count overrides the tuned default."""
+        config = BackendConfig(dispatcher="deepep_v2", dispatcher_num_sms=20)
+        assert config.dispatcher_num_sms == 20
+
     def test_dispatcher_share_token_dispatcher_default(self):
         """Test that dispatcher_share_token_dispatcher defaults to enabled."""
         config = BackendConfig(dispatcher="deepep")

--- a/tests/unit_tests/moe/test_deepep_v2_fused_a2a.py
+++ b/tests/unit_tests/moe/test_deepep_v2_fused_a2a.py
@@ -1,0 +1,313 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch.utils.checkpoint import checkpoint
+
+from nemo_automodel.components.moe.megatron import fused_a2a
+
+
+class _FakeGroup:
+    def __init__(self, size: int = 1):
+        self._size = size
+
+    def size(self) -> int:
+        return self._size
+
+    def rank(self) -> int:
+        return 0
+
+
+class _FakeEvent:
+    def current_stream_wait(self) -> None:
+        pass
+
+
+class _FakeHandle:
+    def __init__(self, topk_idx: torch.Tensor, num_max_tokens_per_rank: int | None = None):
+        self.num_max_tokens_per_rank = (
+            num_max_tokens_per_rank if num_max_tokens_per_rank is not None else topk_idx.size(0)
+        )
+        self.num_recv_tokens_per_expert_list = [2, 0]
+        self.num_sms = 7
+        self.topk_idx = topk_idx
+        self.psum_num_recv_tokens_per_scaleup_rank = torch.tensor([topk_idx.size(0)], dtype=torch.int32)
+        self.psum_num_recv_tokens_per_expert = torch.tensor([2, 2], dtype=torch.int32)
+        self.recv_src_metadata = topk_idx.clone()
+        self.dst_buffer_slot_idx = topk_idx.to(torch.int32).clone()
+        self.token_metadata_at_forward = None
+        self.channel_linked_list = None
+
+
+class _FakeElasticBuffer:
+    def __init__(self, _group, **kwargs):
+        self.constructed_with_num_bytes = "num_bytes" in kwargs
+        self.allow_hybrid_mode = kwargs.get("allow_hybrid_mode", True)
+        self.allow_multiple_reduction = kwargs.get("allow_multiple_reduction", True)
+        self.prefer_overlap_with_compute = kwargs.get("prefer_overlap_with_compute", True)
+        self.num_gpu_timeout_secs = kwargs.get("num_gpu_timeout_secs")
+        self.destroyed = False
+        self.dispatch_handles = []
+        self.combine_handles = []
+
+    def dispatch(self, x, topk_idx=None, topk_weights=None, handle=None, **kwargs):
+        if handle is None:
+            handle = _FakeHandle(topk_idx, kwargs["num_max_tokens_per_rank"])
+            self.dispatch_handles.append(handle)
+            return x + 1, topk_idx, topk_weights, handle, _FakeEvent()
+        self.dispatch_handles.append(handle)
+        return x + 2, None, None, handle, _FakeEvent()
+
+    def combine(self, x, handle, topk_weights=None, **kwargs):
+        self.combine_handles.append(handle)
+        return x + 3, topk_weights, _FakeEvent()
+
+    def destroy(self) -> None:
+        self.destroyed = True
+
+
+def _reset_fake_state(monkeypatch) -> None:
+    monkeypatch.setattr(fused_a2a, "ElasticBuffer", _FakeElasticBuffer)
+    monkeypatch.setattr(fused_a2a, "_warmup_deepep_v2_group", lambda _group: None)
+    monkeypatch.setattr(fused_a2a, "_deepep_v2_buffer", None)
+
+
+def _init_test_deepep_v2_buffer(*args, **kwargs):
+    fused_a2a.init_deepep_v2_buffer(*args, **kwargs)
+    return fused_a2a._deepep_v2_buffer
+
+
+def test_legacy_buffer_resolver_prefers_latest_legacy_module(monkeypatch):
+    legacy_buffer = object()
+    root_buffer = object()
+
+    def import_module(module_name):
+        if module_name == "deep_ep.legacy":
+            raise ImportError(module_name)
+        if module_name == "deep_ep.buffers.legacy":
+            return SimpleNamespace(Buffer=legacy_buffer)
+        if module_name == "deep_ep":
+            return SimpleNamespace(Buffer=root_buffer)
+        raise AssertionError(module_name)
+
+    monkeypatch.setattr(fused_a2a.importlib, "import_module", import_module)
+
+    available, buffer = fused_a2a._safe_import_first_symbol(
+        ("deep_ep.legacy", "deep_ep.buffers.legacy", "deep_ep"),
+        "Buffer",
+    )
+
+    assert available is True
+    assert buffer is legacy_buffer
+
+
+def test_legacy_buffer_resolver_falls_back_to_previous_root_buffer(monkeypatch):
+    root_buffer = object()
+
+    def import_module(module_name):
+        if module_name == "deep_ep":
+            return SimpleNamespace(Buffer=root_buffer)
+        raise ImportError(module_name)
+
+    monkeypatch.setattr(fused_a2a.importlib, "import_module", import_module)
+
+    available, buffer = fused_a2a._safe_import_first_symbol(
+        ("deep_ep.legacy", "deep_ep.buffers.legacy", "deep_ep"),
+        "Buffer",
+    )
+
+    assert available is True
+    assert buffer is root_buffer
+
+
+def test_deepep_v2_num_sms_does_not_mutate_legacy_buffer(monkeypatch):
+    legacy_calls = []
+    monkeypatch.setattr(fused_a2a, "HAVE_DEEP_EP", True)
+    monkeypatch.setattr(fused_a2a, "Buffer", SimpleNamespace(set_num_sms=legacy_calls.append))
+    monkeypatch.setattr(fused_a2a, "_deepep_v2_num_sms", 0)
+
+    fused_a2a.set_deepep_v2_num_sms(20)
+
+    assert fused_a2a._deepep_v2_num_sms == 20
+    assert legacy_calls == []
+
+    fused_a2a.set_deepep_num_sms(17)
+
+    assert legacy_calls == [17]
+    assert fused_a2a._deepep_v2_num_sms == 20
+
+
+def test_deepep_v2_dispatch_uses_legacy_return_contract(monkeypatch):
+    _reset_fake_state(monkeypatch)
+
+    x = torch.zeros(5, 256)
+    token_indices = torch.tensor([[0], [1], [0], [1], [0]], dtype=torch.int64)
+    token_probs = torch.ones(5, 1)
+
+    recv_x, recv_indices, recv_probs, tokens_per_expert, handle = fused_a2a.DeepEPV2FusedDispatch.apply(
+        x,
+        token_indices,
+        token_probs,
+        2,
+        _FakeGroup(),
+        False,
+        False,
+    )
+
+    assert torch.equal(recv_x, x + 1)
+    assert torch.equal(recv_indices, token_indices)
+    assert torch.equal(recv_probs, token_probs)
+    assert torch.equal(tokens_per_expert, torch.tensor([2, 0], dtype=torch.int64))
+    assert torch.equal(handle.topk_idx, token_indices)
+    assert handle.num_max_tokens_per_rank == 5
+
+
+def test_deepep_v2_handle_restore_uses_saved_tensor_fields():
+    class _FakeCtx:
+        def save_for_backward(self, *tensors):
+            self.saved_tensors = tensors
+
+    original_handle = _FakeHandle(torch.tensor([[0]], dtype=torch.int64))
+    recomputed_handle = _FakeHandle(torch.tensor([[1]], dtype=torch.int64))
+    ctx = _FakeCtx()
+
+    fused_a2a._save_deepep_v2_handle(ctx, original_handle)
+    ctx.saved_tensors = tuple(getattr(recomputed_handle, field) for field in ctx.handle_tensor_fields)
+    restored_handle = fused_a2a._restore_deepep_v2_handle(ctx)
+
+    assert restored_handle is original_handle
+    assert torch.equal(restored_handle.topk_idx, recomputed_handle.topk_idx)
+    assert torch.equal(restored_handle.recv_src_metadata, recomputed_handle.recv_src_metadata)
+
+
+def test_deepep_v2_handle_tensors_track_nonreentrant_recompute():
+    handles = []
+    backward_handles = []
+
+    class _CheckpointedFunction(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, x):
+            handle = _FakeHandle(torch.tensor([[len(handles)]], dtype=torch.int64))
+            handles.append(handle)
+            fused_a2a._save_deepep_v2_handle(ctx, handle)
+            return x * 2
+
+        @staticmethod
+        def backward(ctx, grad_output):
+            backward_handles.append(fused_a2a._restore_deepep_v2_handle(ctx))
+            return grad_output * 2
+
+    x = torch.ones(1, requires_grad=True)
+    checkpoint(_CheckpointedFunction.apply, x, use_reentrant=False).backward()
+
+    assert len(handles) == 2
+    assert backward_handles == [handles[0]]
+    assert torch.equal(backward_handles[0].topk_idx, handles[-1].topk_idx)
+
+
+def test_deepep_v2_buffer_validates_hidden_alignment(monkeypatch):
+    _reset_fake_state(monkeypatch)
+    group = _FakeGroup()
+
+    hybrid_buffer = _init_test_deepep_v2_buffer(group, num_max_tokens_per_rank=4, hidden=2560, num_topk=2)
+
+    assert hybrid_buffer.allow_hybrid_mode is True
+    with pytest.raises(ValueError, match="hidden dimension divisible by 256"):
+        _init_test_deepep_v2_buffer(group, num_max_tokens_per_rank=4, hidden=2880, num_topk=2)
+
+
+def test_deepep_v2_buffer_initialization_is_idempotent(monkeypatch):
+    _reset_fake_state(monkeypatch)
+    group = _FakeGroup()
+
+    buffer = _init_test_deepep_v2_buffer(group, num_max_tokens_per_rank=4096, hidden=256, num_topk=2)
+    same_buffer = _init_test_deepep_v2_buffer(group, num_max_tokens_per_rank=4096, hidden=256, num_topk=2)
+
+    assert same_buffer is buffer
+
+
+def test_deepep_v2_dispatch_reuses_process_global_buffer(monkeypatch):
+    _reset_fake_state(monkeypatch)
+    group = _FakeGroup()
+    token_indices = torch.tensor([[0], [1]], dtype=torch.int64)
+    token_probs = torch.ones(2, 1)
+    init_order = []
+
+    class _OrderedFakeElasticBuffer(_FakeElasticBuffer):
+        def __init__(self, buffer_group, **kwargs):
+            init_order.append(("buffer", buffer_group))
+            super().__init__(buffer_group, **kwargs)
+
+    monkeypatch.setattr(fused_a2a, "ElasticBuffer", _OrderedFakeElasticBuffer)
+    monkeypatch.setattr(
+        fused_a2a,
+        "_warmup_deepep_v2_group",
+        lambda warmup_group: init_order.append(("warmup", warmup_group)),
+    )
+
+    fused_a2a.DeepEPV2FusedDispatch.apply(torch.zeros(2, 256), token_indices, token_probs, 2, group, False, False)
+    buffer = fused_a2a._deepep_v2_buffer
+    fused_a2a.DeepEPV2FusedDispatch.apply(torch.zeros(2, 256), token_indices, token_probs, 2, group, False, False)
+
+    assert init_order == [("warmup", group), ("buffer", group)]
+    assert fused_a2a._deepep_v2_buffer is buffer
+    assert len(buffer.dispatch_handles) == 2
+    assert buffer.constructed_with_num_bytes is False
+    assert buffer.allow_multiple_reduction is True
+    assert buffer.prefer_overlap_with_compute is True
+    assert buffer.num_gpu_timeout_secs == 300
+
+
+def test_deepep_v2_combine_uses_process_global_buffer(monkeypatch):
+    _reset_fake_state(monkeypatch)
+    group = _FakeGroup()
+    token_indices = torch.tensor([[0], [1]], dtype=torch.int64)
+    token_probs = torch.ones(2, 1)
+
+    _, _, _, _, handle = fused_a2a.DeepEPV2FusedDispatch.apply(
+        torch.zeros(2, 256),
+        token_indices,
+        token_probs,
+        2,
+        group,
+        False,
+        False,
+    )
+    buffer = fused_a2a._deepep_v2_buffer
+
+    combined_x, _ = fused_a2a.DeepEPV2FusedCombine.apply(
+        torch.zeros(2, 256),
+        group,
+        handle,
+        False,
+        False,
+    )
+
+    assert torch.equal(combined_x, torch.full((2, 256), 3.0))
+    assert buffer.combine_handles == [handle]
+
+
+def test_destroy_deepep_v2_buffer_clears_process_global_buffer(monkeypatch):
+    _reset_fake_state(monkeypatch)
+    group = _FakeGroup()
+
+    buffer = _init_test_deepep_v2_buffer(group, num_max_tokens_per_rank=4, hidden=256, num_topk=2)
+
+    fused_a2a.destroy_deepep_v2_buffer()
+
+    assert buffer.destroyed is True
+    assert fused_a2a._deepep_v2_buffer is None

--- a/tests/unit_tests/moe/test_deepep_v2_fused_a2a.py
+++ b/tests/unit_tests/moe/test_deepep_v2_fused_a2a.py
@@ -38,12 +38,17 @@ class _FakeEvent:
 
 
 class _FakeHandle:
-    def __init__(self, topk_idx: torch.Tensor, num_max_tokens_per_rank: int | None = None):
+    def __init__(
+        self,
+        topk_idx: torch.Tensor,
+        num_max_tokens_per_rank: int | None = None,
+        num_sms: int = 7,
+    ):
         self.num_max_tokens_per_rank = (
             num_max_tokens_per_rank if num_max_tokens_per_rank is not None else topk_idx.size(0)
         )
         self.num_recv_tokens_per_expert_list = [2, 0]
-        self.num_sms = 7
+        self.num_sms = num_sms
         self.topk_idx = topk_idx
         self.psum_num_recv_tokens_per_scaleup_rank = torch.tensor([topk_idx.size(0)], dtype=torch.int32)
         self.psum_num_recv_tokens_per_expert = torch.tensor([2, 2], dtype=torch.int32)
@@ -69,7 +74,11 @@ class _FakeElasticBuffer:
     def dispatch(self, x, topk_idx=None, topk_weights=None, handle=None, **kwargs):
         self.dispatch_kwargs.append(kwargs)
         if handle is None:
-            handle = _FakeHandle(topk_idx, kwargs["num_max_tokens_per_rank"])
+            handle = _FakeHandle(
+                topk_idx,
+                kwargs["num_max_tokens_per_rank"],
+                kwargs["num_sms"],
+            )
             self.dispatch_handles.append(handle)
             return x + 1, topk_idx, topk_weights, handle, _FakeEvent()
         self.dispatch_handles.append(handle)
@@ -313,8 +322,9 @@ def test_deepep_v2_combine_uses_process_global_buffer(monkeypatch):
     assert buffer.combine_handles == [handle]
 
 
-def test_deepep_v2_uses_tuned_qp_count_in_forward_and_backward(monkeypatch):
+def test_deepep_v2_uses_tuned_resources_in_forward_and_backward(monkeypatch):
     _reset_fake_state(monkeypatch)
+    monkeypatch.setattr(fused_a2a, "_deepep_v2_num_sms", 20)
     monkeypatch.setattr(fused_a2a, "_deepep_v2_num_qps", 65)
     group = _FakeGroup()
     x = torch.zeros(2, 256, requires_grad=True)
@@ -334,6 +344,8 @@ def test_deepep_v2_uses_tuned_qp_count_in_forward_and_backward(monkeypatch):
     combined_x.sum().backward()
 
     buffer = fused_a2a._deepep_v2_buffer
+    assert [kwargs["num_sms"] for kwargs in buffer.dispatch_kwargs] == [20, 20]
+    assert [kwargs["num_sms"] for kwargs in buffer.combine_kwargs] == [20, 20]
     assert [kwargs["num_qps"] for kwargs in buffer.dispatch_kwargs] == [65, 65]
     assert [kwargs["num_qps"] for kwargs in buffer.combine_kwargs] == [65, 65]
 

--- a/tests/unit_tests/moe/test_deepep_v2_fused_a2a.py
+++ b/tests/unit_tests/moe/test_deepep_v2_fused_a2a.py
@@ -155,6 +155,14 @@ def test_deepep_v2_num_sms_does_not_mutate_legacy_buffer(monkeypatch):
     assert fused_a2a._deepep_v2_num_sms == 20
 
 
+def test_deepep_v2_num_qps_is_configurable(monkeypatch):
+    monkeypatch.setattr(fused_a2a, "_deepep_v2_num_qps", 0)
+
+    fused_a2a.set_deepep_v2_num_qps(65)
+
+    assert fused_a2a._deepep_v2_num_qps == 65
+
+
 def test_deepep_v2_dispatch_uses_legacy_return_contract(monkeypatch):
     _reset_fake_state(monkeypatch)
 
@@ -307,6 +315,7 @@ def test_deepep_v2_combine_uses_process_global_buffer(monkeypatch):
 
 def test_deepep_v2_uses_tuned_qp_count_in_forward_and_backward(monkeypatch):
     _reset_fake_state(monkeypatch)
+    monkeypatch.setattr(fused_a2a, "_deepep_v2_num_qps", 65)
     group = _FakeGroup()
     x = torch.zeros(2, 256, requires_grad=True)
     token_indices = torch.tensor([[0], [1]], dtype=torch.int64)
@@ -325,8 +334,8 @@ def test_deepep_v2_uses_tuned_qp_count_in_forward_and_backward(monkeypatch):
     combined_x.sum().backward()
 
     buffer = fused_a2a._deepep_v2_buffer
-    assert [kwargs["num_qps"] for kwargs in buffer.dispatch_kwargs] == [33, 33]
-    assert [kwargs["num_qps"] for kwargs in buffer.combine_kwargs] == [33, 33]
+    assert [kwargs["num_qps"] for kwargs in buffer.dispatch_kwargs] == [65, 65]
+    assert [kwargs["num_qps"] for kwargs in buffer.combine_kwargs] == [65, 65]
 
 
 def test_destroy_deepep_v2_buffer_clears_process_global_buffer(monkeypatch):

--- a/tests/unit_tests/moe/test_deepep_v2_fused_a2a.py
+++ b/tests/unit_tests/moe/test_deepep_v2_fused_a2a.py
@@ -63,8 +63,11 @@ class _FakeElasticBuffer:
         self.destroyed = False
         self.dispatch_handles = []
         self.combine_handles = []
+        self.dispatch_kwargs = []
+        self.combine_kwargs = []
 
     def dispatch(self, x, topk_idx=None, topk_weights=None, handle=None, **kwargs):
+        self.dispatch_kwargs.append(kwargs)
         if handle is None:
             handle = _FakeHandle(topk_idx, kwargs["num_max_tokens_per_rank"])
             self.dispatch_handles.append(handle)
@@ -73,6 +76,7 @@ class _FakeElasticBuffer:
         return x + 2, None, None, handle, _FakeEvent()
 
     def combine(self, x, handle, topk_weights=None, **kwargs):
+        self.combine_kwargs.append(kwargs)
         self.combine_handles.append(handle)
         return x + 3, topk_weights, _FakeEvent()
 
@@ -299,6 +303,30 @@ def test_deepep_v2_combine_uses_process_global_buffer(monkeypatch):
 
     assert torch.equal(combined_x, torch.full((2, 256), 3.0))
     assert buffer.combine_handles == [handle]
+
+
+def test_deepep_v2_uses_tuned_qp_count_in_forward_and_backward(monkeypatch):
+    _reset_fake_state(monkeypatch)
+    group = _FakeGroup()
+    x = torch.zeros(2, 256, requires_grad=True)
+    token_indices = torch.tensor([[0], [1]], dtype=torch.int64)
+    token_probs = torch.ones(2, 1)
+
+    recv_x, _, _, _, handle = fused_a2a.DeepEPV2FusedDispatch.apply(
+        x,
+        token_indices,
+        token_probs,
+        2,
+        group,
+        False,
+        False,
+    )
+    combined_x, _ = fused_a2a.DeepEPV2FusedCombine.apply(recv_x, group, handle, False, False)
+    combined_x.sum().backward()
+
+    buffer = fused_a2a._deepep_v2_buffer
+    assert [kwargs["num_qps"] for kwargs in buffer.dispatch_kwargs] == [33, 33]
+    assert [kwargs["num_qps"] for kwargs in buffer.combine_kwargs] == [33, 33]
 
 
 def test_destroy_deepep_v2_buffer_clears_process_global_buffer(monkeypatch):

--- a/tests/unit_tests/moe/test_experts.py
+++ b/tests/unit_tests/moe/test_experts.py
@@ -830,12 +830,14 @@ class TestGroupedExpertsDeepEP:
             moe_config,
             dispatcher_backend="hybridep",
             dispatcher_num_sms=24,
+            dispatcher_num_qps=33,
             dispatcher_share_token_dispatcher=False,
             dispatcher_async_dispatch=True,
         )
 
         assert experts.dispatcher_backend == "hybridep"
         assert experts.dispatcher_num_sms == 24
+        assert experts.dispatcher_num_qps == 33
         assert experts.dispatcher_share_token_dispatcher is False
         assert experts.dispatcher_async_dispatch is True
         assert experts.config == moe_config
@@ -846,6 +848,7 @@ class TestGroupedExpertsDeepEP:
             moe_config,
             dispatcher_backend="hybridep",
             dispatcher_num_sms=24,
+            dispatcher_num_qps=33,
             dispatcher_share_token_dispatcher=False,
             dispatcher_async_dispatch=True,
         )
@@ -868,6 +871,7 @@ class TestGroupedExpertsDeepEP:
             assert config_arg.moe_flex_dispatcher_backend == "hybridep"
             assert config_arg.moe_hybridep_num_sms == 24
             assert config_arg.moe_deepep_num_sms == 24
+            assert config_arg.moe_deepep_num_qps == 33
             assert config_arg.moe_share_token_dispatcher is False
             assert config_arg.moe_deepep_async_dispatch is True
 

--- a/tests/unit_tests/moe/test_experts.py
+++ b/tests/unit_tests/moe/test_experts.py
@@ -761,6 +761,27 @@ class TestGroupedExpertsDeepEP:
             assert experts.ep_rank == 0
             mock_init_buffer.assert_called_once_with(mock_mesh.get_group.return_value)
 
+    def test_grouped_experts_deepep_v2_preinitializes_buffer(self, moe_config):
+        """Test that a known PP token capacity initializes ElasticBuffer during sharding."""
+        experts = GroupedExpertsDeepEP(moe_config, dispatcher_backend="deepep_v2")
+        mock_mesh = Mock()
+        mock_mesh.size.return_value = 2
+        mock_mesh.get_local_rank.return_value = 0
+        mock_mesh.get_group.return_value = Mock()
+
+        with (
+            patch("nemo_automodel.components.moe.experts.MoEFlexTokenDispatcher", return_value=Mock()),
+            patch("nemo_automodel.components.moe.megatron.fused_a2a.init_deepep_v2_buffer") as mock_init_buffer,
+        ):
+            experts.init_token_dispatcher(mock_mesh, num_max_tokens_per_rank=4096)
+
+        mock_init_buffer.assert_called_once_with(
+            mock_mesh.get_group.return_value,
+            4096,
+            moe_config.expert_dim,
+            moe_config.n_activated_experts,
+        )
+
     def test_grouped_experts_deepep_apply_bias_no_bias(self, moe_config):
         """Test _apply_bias method with no bias."""
         _ = GroupedExpertsDeepEP(moe_config)

--- a/tests/unit_tests/moe/test_layers.py
+++ b/tests/unit_tests/moe/test_layers.py
@@ -1333,6 +1333,7 @@ class TestMoE:
         backend_config.experts = "torch_mm"
         backend_config.dispatcher = "deepep_v2"
         backend_config.dispatcher_num_sms = 12
+        backend_config.dispatcher_num_qps = 65
         backend_config.dispatcher_share_token_dispatcher = False
         backend_config.dispatcher_async_dispatch = True
         with patch("nemo_automodel.components.moe.layers.get_world_size_safe", return_value=2):
@@ -1341,6 +1342,7 @@ class TestMoE:
         assert isinstance(moe.experts, GroupedExpertsDeepEP)
         assert moe.experts.dispatcher_backend == "deepep_v2"
         assert moe.experts.dispatcher_num_sms == 12
+        assert moe.experts.dispatcher_num_qps == 65
         assert moe.experts.dispatcher_share_token_dispatcher is False
         assert moe.experts.dispatcher_async_dispatch is True
 

--- a/tests/unit_tests/moe/test_layers.py
+++ b/tests/unit_tests/moe/test_layers.py
@@ -1331,7 +1331,7 @@ class TestMoE:
     def test_moe_forwards_dispatcher_config_to_experts(self, moe_config, backend_config):
         """MoE should pass BackendConfig dispatcher knobs to flex dispatcher experts."""
         backend_config.experts = "torch_mm"
-        backend_config.dispatcher = "deepep"
+        backend_config.dispatcher = "deepep_v2"
         backend_config.dispatcher_num_sms = 12
         backend_config.dispatcher_share_token_dispatcher = False
         backend_config.dispatcher_async_dispatch = True
@@ -1339,7 +1339,7 @@ class TestMoE:
             moe = MoE(moe_config, backend_config)
 
         assert isinstance(moe.experts, GroupedExpertsDeepEP)
-        assert moe.experts.dispatcher_backend == "deepep"
+        assert moe.experts.dispatcher_backend == "deepep_v2"
         assert moe.experts.dispatcher_num_sms == 12
         assert moe.experts.dispatcher_share_token_dispatcher is False
         assert moe.experts.dispatcher_async_dispatch is True

--- a/tests/unit_tests/moe/test_parallelizer.py
+++ b/tests/unit_tests/moe/test_parallelizer.py
@@ -352,8 +352,8 @@ def test_expert_parallel_partition_fn_shards_and_dispatcher(monkeypatch):
             super().__init__()
             self.dispatch_called_with = None
 
-        def init_token_dispatcher(self, ep_mesh):
-            self.dispatch_called_with = ep_mesh
+        def init_token_dispatcher(self, ep_mesh, num_max_tokens_per_rank=None):
+            self.dispatch_called_with = (ep_mesh, num_max_tokens_per_rank)
 
         # override register_parameter to avoid strict type checks
         def register_parameter(self, name, param):
@@ -374,7 +374,7 @@ def test_expert_parallel_partition_fn_shards_and_dispatcher(monkeypatch):
     monkeypatch.setattr(P, "Shard", fake_shard)
     monkeypatch.setattr(P, "distribute_tensor", distribute_tensor_mock)
 
-    ep = P.ExpertParallel()
+    ep = P.ExpertParallel(num_max_tokens_per_rank=4096)
     module = DummyGrouped()
     device_mesh = type("Mesh", (), {"ndim": 1})()
 
@@ -392,7 +392,7 @@ def test_expert_parallel_partition_fn_shards_and_dispatcher(monkeypatch):
         assert isinstance(args[2], list) and args[2][0] is shard_sentinel
 
     # dispatcher must be initialized
-    assert module.dispatch_called_with is device_mesh
+    assert module.dispatch_called_with == (device_mesh, 4096)
 
 
 def test_expert_parallel_partition_fn_preserves_requires_grad(monkeypatch):

--- a/tests/unit_tests/moe/test_token_dispatcher.py
+++ b/tests/unit_tests/moe/test_token_dispatcher.py
@@ -120,6 +120,7 @@ def reset_deepep_dispatcher_state(monkeypatch):
 
     v2_dispatch = object()
     v2_combine = object()
+    v2_num_qps = []
     monkeypatch.setattr(MoEFlexTokenDispatcher, "shared_deepep_manager", None)
     monkeypatch.setattr(MoEFlexTokenDispatcher, "shared_deepep_v2_manager", None)
     monkeypatch.setattr(token_dispatcher, "_DeepepManager", _FakeDeepepManager)
@@ -127,7 +128,8 @@ def reset_deepep_dispatcher_state(monkeypatch):
     monkeypatch.setattr(token_dispatcher, "deepep_v2_fused_combine", v2_combine)
     monkeypatch.setattr(token_dispatcher, "set_deepep_num_sms", lambda _num_sms: None)
     monkeypatch.setattr(token_dispatcher, "set_deepep_v2_num_sms", lambda _num_sms: None)
-    return v2_dispatch, v2_combine
+    monkeypatch.setattr(token_dispatcher, "set_deepep_v2_num_qps", v2_num_qps.append)
+    return v2_dispatch, v2_combine, v2_num_qps
 
 
 def _build_dispatcher(backend: str) -> MoEFlexTokenDispatcher:
@@ -135,6 +137,7 @@ def _build_dispatcher(backend: str) -> MoEFlexTokenDispatcher:
         moe_flex_dispatcher_backend=backend,
         moe_router_topk=2,
         num_moe_experts=8,
+        moe_deepep_num_qps=33,
         moe_share_token_dispatcher=False,
     )
     return MoEFlexTokenDispatcher(
@@ -153,9 +156,10 @@ class TestMoEFlexTokenDispatcherDeepEPSelection:
         assert "_dispatch_fn" not in dispatcher._comm_manager.kwargs
 
     def test_deepep_v2_uses_elastic_manager(self, reset_deepep_dispatcher_state):
-        v2_dispatch, v2_combine = reset_deepep_dispatcher_state
+        v2_dispatch, v2_combine, v2_num_qps = reset_deepep_dispatcher_state
         dispatcher = _build_dispatcher("deepep_v2")
 
         assert isinstance(dispatcher._comm_manager, _FakeDeepepManager)
         assert dispatcher._comm_manager.kwargs["_dispatch_fn"] is v2_dispatch
         assert dispatcher._comm_manager.kwargs["_combine_fn"] is v2_combine
+        assert v2_num_qps == [33]

--- a/tests/unit_tests/moe/test_token_dispatcher.py
+++ b/tests/unit_tests/moe/test_token_dispatcher.py
@@ -17,7 +17,11 @@ from unittest.mock import patch
 import pytest
 import torch
 
-from nemo_automodel.components.moe.megatron.token_dispatcher import _HybridEPManager
+from nemo_automodel.components.moe.megatron.token_dispatcher import (
+    MoEFlexTokenDispatcher,
+    TokenDispatcherConfig,
+    _HybridEPManager,
+)
 
 
 @pytest.fixture
@@ -98,3 +102,60 @@ class TestIndicesToMultihot:
         assert routing_map.shape == (1, 8)
         assert routing_map.sum() == 2
         assert routing_map[0, 0] and routing_map[0, 7]
+
+
+class _FakeGroup:
+    def size(self):
+        return 2
+
+
+class _FakeDeepepManager:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+@pytest.fixture
+def reset_deepep_dispatcher_state(monkeypatch):
+    from nemo_automodel.components.moe.megatron import token_dispatcher
+
+    v2_dispatch = object()
+    v2_combine = object()
+    monkeypatch.setattr(MoEFlexTokenDispatcher, "shared_deepep_manager", None)
+    monkeypatch.setattr(MoEFlexTokenDispatcher, "shared_deepep_v2_manager", None)
+    monkeypatch.setattr(token_dispatcher, "_DeepepManager", _FakeDeepepManager)
+    monkeypatch.setattr(token_dispatcher, "deepep_v2_fused_dispatch", v2_dispatch)
+    monkeypatch.setattr(token_dispatcher, "deepep_v2_fused_combine", v2_combine)
+    monkeypatch.setattr(token_dispatcher, "set_deepep_num_sms", lambda _num_sms: None)
+    monkeypatch.setattr(token_dispatcher, "set_deepep_v2_num_sms", lambda _num_sms: None)
+    return v2_dispatch, v2_combine
+
+
+def _build_dispatcher(backend: str) -> MoEFlexTokenDispatcher:
+    config = TokenDispatcherConfig(
+        moe_flex_dispatcher_backend=backend,
+        moe_router_topk=2,
+        num_moe_experts=8,
+        moe_share_token_dispatcher=False,
+    )
+    return MoEFlexTokenDispatcher(
+        num_local_experts=4,
+        local_expert_indices=[0, 1, 2, 3],
+        config=config,
+        ep_group=_FakeGroup(),
+    )
+
+
+class TestMoEFlexTokenDispatcherDeepEPSelection:
+    def test_deepep_uses_legacy_manager(self, reset_deepep_dispatcher_state):
+        dispatcher = _build_dispatcher("deepep")
+
+        assert isinstance(dispatcher._comm_manager, _FakeDeepepManager)
+        assert "_dispatch_fn" not in dispatcher._comm_manager.kwargs
+
+    def test_deepep_v2_uses_elastic_manager(self, reset_deepep_dispatcher_state):
+        v2_dispatch, v2_combine = reset_deepep_dispatcher_state
+        dispatcher = _build_dispatcher("deepep_v2")
+
+        assert isinstance(dispatcher._comm_manager, _FakeDeepepManager)
+        assert dispatcher._comm_manager.kwargs["_dispatch_fn"] is v2_dispatch
+        assert dispatcher._comm_manager.kwargs["_combine_fn"] is v2_combine


### PR DESCRIPTION
**Consolidated into #2850.**

This PR was one layer of the DeepEP v2 upgrade stack. The stack has been collapsed
into a single PR against `main` — see **#2850**, which contains all of these commits
(signed off). This PR is closed for history only; there is no longer a stack.
