### PR TITLE
feat(distributed): enable selective checkpointing for DDP

### DIFF
--- a/docs/guides/distributed-setup.mdx
+++ b/docs/guides/distributed-setup.mdx
@@ -56,7 +56,7 @@ configs accept either a dataclass or a plain dict.
 | `parallelism_sizes` | `ParallelismSizes \| None` | `None` | Requested parallel dimensions (`tp_size`, `pp_size`, `cp_size`, `ep_size`, `dp_size`, `dp_replicate_size`). `dp_replicate_size` is FSDP2-only. |
 | `pipeline_config` | `PipelineConfig \| dict \| None` | `None` | Pipeline-parallel options; **requires `pp_size > 1`**. |
 | `moe_parallel_config` | `MoEParallelizerConfig \| dict \| None` | `None` | Expert-parallel options; **requires `ep_size > 1`**. |
-| `activation_checkpointing` | `bool \| "selective"` | `False` | `True` enables full activation checkpointing; `"selective"` enables FSDP2 selective AC. |
+| `activation_checkpointing` | `bool \| "full" \| "selective"` | `False` | `True` or `"full"` enables full activation checkpointing; `"selective"` enables selective AC for FSDP2 or DDP. |
 | `world_size` | `int \| None` | `None` | Total ranks; auto-detected from the process group when omitted. |
 
 `ParallelismSizes` is durable user intent (what you requested). The resolved

--- a/docs/guides/gradient-checkpointing.mdx
+++ b/docs/guides/gradient-checkpointing.mdx
@@ -26,7 +26,7 @@ distributed:
   ...
 ```
 
-For FSDP2, `activation_checkpointing` also accepts explicit policy strings:
+For FSDP2 and DDP, `activation_checkpointing` also accepts explicit policy strings:
 
 ```yaml
 distributed:
@@ -34,10 +34,16 @@ distributed:
   activation_checkpointing: selective
 ```
 
-Use `true` or `full` for full activation checkpointing. Use `selective` for PyTorch selective activation checkpointing on FSDP2 configs. Selective checkpointing saves expensive operations such as attention, collectives, and part of the matrix multiplications while recomputing cheaper operations during backward.
+```yaml
+distributed:
+  strategy: ddp
+  activation_checkpointing: selective
+```
+
+Use `true` or `full` for full activation checkpointing. Use `selective` for PyTorch selective activation checkpointing on FSDP2 or DDP configs. Selective checkpointing saves expensive operations such as attention, collectives, and part of the matrix multiplications while recomputing cheaper operations during backward.
 
 <Note>
-`selective` requires the FSDP2 strategy. Non-FSDP2 strategies (`ddp`, `megatron_fsdp`) raise an error when `selective` is requested. KV-sharing models (e.g., Gemma4) automatically fall back to sub-module checkpointing, because attention cannot be recomputed through the KV cache.
+`selective` is supported for FSDP2 and DDP. Megatron-FSDP raises an error when `selective` is requested. KV-sharing models (e.g., Gemma4) automatically fall back to sub-module checkpointing, because attention cannot be recomputed through the KV cache.
 </Note>
 
 <Tip>
@@ -49,7 +55,7 @@ Selective AC only speeds things up when the model's expensive operations are the
 </Note>
 
 <Note>
-**MoE/expert parallelism:** Selective AC is designed for dense transformers and generally does **not** help Mixture-of-Experts models with expert parallelism. In an MoE block the experts dominate the cost (they are cheap to recompute but expensive to store), and the expert-parallel dispatch/communication is opaque to the selective policy, so it is recomputed regardless. As a result, selective AC tends to add activation memory without a corresponding speedup for MoE, matching what reference implementations such as TorchTitan observe. Prefer **full** activation checkpointing (`true`/`full`) for MoE; selective remains supported for MoE and FSDP2 as an opt-in.
+**MoE/expert parallelism:** Selective AC is designed for dense transformers and generally does **not** help Mixture-of-Experts models with expert parallelism. In an MoE block the experts dominate the cost (they are cheap to recompute but expensive to store), and the expert-parallel dispatch/communication is opaque to the selective policy, so it is recomputed regardless. As a result, selective AC tends to add activation memory without a corresponding speedup for MoE, matching what reference implementations such as TorchTitan observe. Prefer **full** activation checkpointing (`true`/`full`) for MoE; selective remains available as an opt-in for FSDP2, including MoE configs, and for DDP.
 </Note>
 
 ### Configure Programmatically
@@ -57,10 +63,10 @@ Selective AC only speeds things up when the model's expensive operations are the
 from nemo_automodel import NeMoAutoModelForCausalLM
 from nemo_automodel.components.distributed.config import DistributedSetup
 
-# Use activation_checkpointing="selective" for FSDP2 selective checkpointing.
+# Use activation_checkpointing="selective" for FSDP2 or DDP selective checkpointing.
 distributed_setup = DistributedSetup.build(
     strategy="fsdp2",
-    activation_checkpointing=True,
+    activation_checkpointing="selective",
 )
 
 model = NeMoAutoModelForCausalLM.from_pretrained(

--- a/nemo_automodel/components/distributed/config.py
+++ b/nemo_automodel/components/distributed/config.py
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
     from nemo_automodel.components.distributed.pipelining.config import PipelineConfig
 
 # Type aliases for API signatures.
-ActivationCheckpointingMode = Union[bool, Literal["selective"]]
+ActivationCheckpointingMode = Union[bool, Literal["full", "selective"]]
 DistributedStrategyConfig = Union["FSDP2Config", "MegatronFSDPConfig", "DDPConfig"]
 # Backwards-compatible alias for external / type-checking references.
 DistributedConfig = DistributedStrategyConfig
@@ -176,9 +176,9 @@ class FSDP2Config:
             ``output_dtype=float32`` in mp_policy to keep the residual stream in fp32
             while running matmuls in lower precision.  Set to ``None`` to disable.
             Can be set from YAML as a string (e.g. ``autocast_dtype: bfloat16``).
-        activation_checkpointing (bool | "selective"): Enable activation checkpointing. ``True`` keeps the existing
-            full activation checkpointing behavior. ``"selective"`` wraps transformer blocks with PyTorch selective
-            activation checkpointing.
+        activation_checkpointing (bool | "full" | "selective"): Enable activation checkpointing. ``True`` or
+            ``"full"`` keeps the existing full activation checkpointing behavior. ``"selective"`` wraps transformer
+            blocks with PyTorch selective activation checkpointing.
         defer_fsdp_grad_sync (bool): Defer FSDP gradient sync to final micro-batch.
         reshard_after_forward (Optional[bool]): Override layer-level FSDP2 resharding.
             ``None`` preserves AutoModel's heuristic: pipeline-parallel layers do
@@ -305,10 +305,12 @@ class DDPConfig:
     Only dp_size is relevant (inferred from world_size).
 
     Attributes:
-        activation_checkpointing (bool): Enable activation checkpointing if True.
+        activation_checkpointing (bool | "full" | "selective"): Enable activation checkpointing. ``True`` or
+            ``"full"`` keeps the existing full activation checkpointing behavior. ``"selective"`` wraps transformer
+            blocks with PyTorch selective activation checkpointing.
+        broadcast_buffers (bool): Synchronize module buffers before each forward.
         find_unused_parameters (bool): Forwarded to PyTorch DDP for models with
             conditionally unused trainable parameters.
-        broadcast_buffers (bool): Synchronize module buffers before each forward.
         static_graph (bool): Tell DDP the used/unused parameter set is stable.
         bucket_cap_mb (Optional[float]): DDP gradient bucket size in MiB. ``None`` uses PyTorch's default.
         gradient_as_bucket_view (bool): Make gradients views into DDP buckets after the first iteration.
@@ -317,7 +319,7 @@ class DDPConfig:
             Can be set from YAML as a string (e.g. ``autocast_dtype: bfloat16``).
     """
 
-    activation_checkpointing: bool = False
+    activation_checkpointing: ActivationCheckpointingMode = False
     broadcast_buffers: bool = False
     find_unused_parameters: bool = False
     static_graph: bool = False

--- a/nemo_automodel/components/distributed/ddp.py
+++ b/nemo_automodel/components/distributed/ddp.py
@@ -21,8 +21,14 @@ from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
 )
 from torch.nn.parallel import DistributedDataParallel as DDP
 
+from nemo_automodel.components.distributed.activation_checkpointing import (
+    is_selective_activation_checkpointing,
+)
 from nemo_automodel.components.distributed.config import DDPConfig
-from nemo_automodel.components.distributed.parallelizer import _extract_model_layers
+from nemo_automodel.components.distributed.parallelizer import (
+    _extract_model_layers,
+    apply_selective_activation_checkpointing,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -101,7 +107,9 @@ class DDPManager:
             if self.device.type == "cuda":
                 model = model.to(torch.bfloat16)
             if self.activation_checkpointing:
-                if hasattr(model, "gradient_checkpointing_enable"):
+                if is_selective_activation_checkpointing(self.activation_checkpointing):
+                    apply_selective_activation_checkpointing(model)
+                elif hasattr(model, "gradient_checkpointing_enable"):
                     model.gradient_checkpointing_enable()
                 else:
                     logger.error("Model does not support gradient checkpointing. Skipping.")
@@ -116,18 +124,21 @@ class DDPManager:
                 except Exception:
                     pass
 
-            layers = _extract_model_layers(model)
-            for i, layer in enumerate(layers):
-                if hasattr(layer, "mlp"):
-                    layers[i].mlp = checkpoint_wrapper(layer.mlp)
-                if hasattr(layer, "self_attn"):
-                    layers[i].self_attn = checkpoint_wrapper(layers[i].self_attn)
+            if is_selective_activation_checkpointing(self.activation_checkpointing):
+                apply_selective_activation_checkpointing(model)
+            else:
+                layers = _extract_model_layers(model)
+                for i, layer in enumerate(layers):
+                    if hasattr(layer, "mlp"):
+                        layers[i].mlp = checkpoint_wrapper(layer.mlp)
+                    if hasattr(layer, "self_attn"):
+                        layers[i].self_attn = checkpoint_wrapper(layers[i].self_attn)
 
-                if hasattr(layer, "input_layernorm"):
-                    layers[i].input_layernorm = checkpoint_wrapper(layers[i].input_layernorm)
+                    if hasattr(layer, "input_layernorm"):
+                        layers[i].input_layernorm = checkpoint_wrapper(layers[i].input_layernorm)
 
-                if hasattr(layer, "post_attention_layernorm"):
-                    layers[i].post_attention_layernorm = checkpoint_wrapper(layers[i].post_attention_layernorm)
+                    if hasattr(layer, "post_attention_layernorm"):
+                        layers[i].post_attention_layernorm = checkpoint_wrapper(layers[i].post_attention_layernorm)
 
         ddp_kwargs = {
             "device_ids": [self.device] if self.device.type == "cuda" else None,

--- a/nemo_automodel/recipes/_dist_utils.py
+++ b/nemo_automodel/recipes/_dist_utils.py
@@ -49,8 +49,7 @@ def _normalize_activation_checkpointing(value: Any) -> bool | str:
     """Normalize YAML activation checkpointing values.
 
     ``True`` keeps the existing full checkpointing behavior. ``"selective"``
-    enables PyTorch selective activation checkpointing for supported FSDP2
-    paths.
+    enables PyTorch selective activation checkpointing for supported paths.
     """
     if value is None:
         return False
@@ -157,8 +156,8 @@ def parse_distributed_section(cfg_dict: dict) -> dict:
             strategy_kwargs["autocast_dtype"] = dtype_from_str(val)
 
     ep_size: int = parallelism.get("ep_size") or 1
-    if activation_checkpointing == "selective" and strategy_name != "fsdp2":
-        raise ValueError("selective activation checkpointing is supported only for FSDP2 configs.")
+    if activation_checkpointing == "selective" and strategy_name not in {"fsdp2", "ddp"}:
+        raise ValueError("selective activation checkpointing is supported only for FSDP2 and DDP configs.")
 
     # `distributed.pipeline` and `pp_size` are validated asymmetrically:
     #   * pipeline block with pp_size<=1 -> WARN (inert; block ignored). This is

--- a/tests/unit_tests/distributed/test_ddp_manager.py
+++ b/tests/unit_tests/distributed/test_ddp_manager.py
@@ -51,3 +51,27 @@ def test_ddp_manager_forwards_ddp_constructor_flags(monkeypatch):
     assert ddp_ctor.call_args.kwargs["static_graph"] is True
     assert ddp_ctor.call_args.kwargs["bucket_cap_mb"] == 64
     assert ddp_ctor.call_args.kwargs["gradient_as_bucket_view"] is True
+
+
+def test_ddp_manager_applies_selective_activation_checkpointing(monkeypatch):
+    monkeypatch.setattr(ddp_mod.dist, "is_available", lambda: True, raising=True)
+    monkeypatch.setattr(ddp_mod.dist, "is_initialized", lambda: True, raising=True)
+    monkeypatch.setattr(ddp_mod.dist, "get_rank", lambda: 0, raising=True)
+    monkeypatch.setattr(ddp_mod.dist, "get_world_size", lambda: 2, raising=True)
+    monkeypatch.setattr(ddp_mod.dist, "get_backend", lambda: "gloo", raising=True)
+
+    ddp_ctor = MagicMock(return_value="wrapped")
+    apply_selective_ac = MagicMock()
+    checkpoint_wrapper = MagicMock()
+    monkeypatch.setattr(ddp_mod, "DDP", ddp_ctor, raising=True)
+    monkeypatch.setattr(ddp_mod, "apply_selective_activation_checkpointing", apply_selective_ac, raising=True)
+    monkeypatch.setattr(ddp_mod, "checkpoint_wrapper", checkpoint_wrapper, raising=True)
+
+    manager = ddp_mod.DDPManager(DDPConfig(activation_checkpointing="selective"))
+
+    model = nn.Linear(2, 2)
+    assert manager.parallelize(model) == "wrapped"
+
+    apply_selective_ac.assert_called_once_with(model)
+    checkpoint_wrapper.assert_not_called()
+    ddp_ctor.assert_called_once()

--- a/tests/unit_tests/recipes/test_dist_utils.py
+++ b/tests/unit_tests/recipes/test_dist_utils.py
@@ -345,6 +345,11 @@ class TestActivationCheckpointingParsing:
         assert result["strategy_config"].activation_checkpointing is False
         assert result["activation_checkpointing"] is True
 
+    def test_full_string_normalized_to_true_for_ddp(self):
+        result = parse_distributed_section({"strategy": "ddp", "activation_checkpointing": "full"})
+        assert result["strategy_config"].activation_checkpointing is False
+        assert result["activation_checkpointing"] is True
+
     def test_selective_allowed_for_ep(self):
         # Selective AC is now supported with expert parallelism via the MoE
         # parallelizer. For EP it is kept off the strategy config and carried on
@@ -355,9 +360,10 @@ class TestActivationCheckpointingParsing:
         assert result["strategy_config"].activation_checkpointing is False
         assert result["activation_checkpointing"] == "selective"
 
-    def test_selective_rejected_for_non_fsdp2(self):
-        with pytest.raises(ValueError, match="FSDP2"):
-            parse_distributed_section({"strategy": "ddp", "activation_checkpointing": "selective"})
+    def test_selective_allowed_for_ddp(self):
+        result = parse_distributed_section({"strategy": "ddp", "activation_checkpointing": "selective"})
+        assert result["strategy_config"].activation_checkpointing is False
+        assert result["activation_checkpointing"] == "selective"
 
     def test_unknown_activation_checkpointing_mode_rejected(self):
         with pytest.raises(ValueError, match="activation_checkpointing"):
@@ -370,24 +376,6 @@ class TestActivationCheckpointingParsing:
         # infrastructure._with_activation_checkpointing, not here.
         assert result["strategy_config"].activation_checkpointing is False
         assert result["activation_checkpointing"] == "selective"
-
-    def test_selective_allowed_for_ep(self):
-        # Selective AC is now supported with expert parallelism via the MoE
-        # parallelizer. For EP it is kept off the strategy config and carried on
-        # the parsed value (consumed by parallelize_model -> apply_ac).
-        result = parse_distributed_section(
-            {"strategy": "fsdp2", "activation_checkpointing": "selective", "ep_size": 2, "moe": {}}
-        )
-        assert result["strategy_config"].activation_checkpointing is False
-        assert result["activation_checkpointing"] == "selective"
-
-    def test_selective_rejected_for_non_fsdp2(self):
-        with pytest.raises(ValueError, match="FSDP2"):
-            parse_distributed_section({"strategy": "ddp", "activation_checkpointing": "selective"})
-
-    def test_unknown_activation_checkpointing_mode_rejected(self):
-        with pytest.raises(ValueError, match="activation_checkpointing"):
-            parse_distributed_section({"strategy": "fsdp2", "activation_checkpointing": "sometimes"})
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this PR do ?

Enables selective activation checkpointing for DDP by routing `distributed.activation_checkpointing: selective` through the existing selective checkpointing implementation.

This was added while investigating AutoModel retrieval training speed for the Nemotron VL 1B image-retrieval workload. DDP local batch size 2 did not fit cleanly without activation checkpointing. Full activation checkpointing fit, but added more recompute. In real retrieval runs, DDP with selective activation checkpointing was about 5% faster than DDP with full activation checkpointing while still fitting local batch size 2.

# Changelog

- Allow `distributed.activation_checkpointing: selective` for DDP configs in the distributed config parser.
- Update activation-checkpointing typing/docs to explicitly include `"full"` and `"selective"` policy strings.
- Apply `apply_selective_activation_checkpointing()` in `DDPManager` when DDP activation checkpointing is set to `selective`.
- Preserve existing DDP behavior for `activation_checkpointing: true`, which continues to use the current full checkpointing path.
- Add unit-test coverage for parsing DDP `full` and `selective` activation checkpointing.
- Add unit-test coverage that `DDPManager` calls the selective checkpointing helper and skips the full checkpoint-wrapper path when `activation_checkpointing="selective"`.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
- Motivation / experiment context:
  - This came from Nemotron VL retrieval speed exploration.
  - The goal was to test whether DDP can fit a larger local batch size without paying the full recompute cost of full activation checkpointing.
  - In the real retrieval experiment, selective activation checkpointing improved throughput by roughly 5% compared with full activation checkpointing.
  - The PR does not change the default DDP behavior; users must opt in with `distributed.activation_checkpointing: selective`.
- Documentation:
  - Updated `docs/guides/gradient-checkpointing.mdx` to document selective AC support for DDP.
  - Updated `docs/guides/distributed-setup.mdx` to reflect that `"selective"` applies to FSDP2 or DDP.
- Validation:
  - `python -m ruff check nemo_automodel/components/distributed/config.py nemo_automodel/components/distributed/ddp.py nemo_automodel/recipes/_dist_utils.py tests/unit_tests/recipes/test_dist_utils.py tests/unit_tests/distributed/test_ddp_manager.py`
  - `python -m ruff format --check nemo_automodel/components/distributed/config.py nemo_automodel/components/distributed/ddp.py nemo_automodel/recipes/_dist_utils.py tests/unit_tests/recipes/test_dist_utils.py tests/unit_tests/distributed/test_ddp_manager.py`
- Focused pytest was not run in the login shell because `pytest` and `uv` were unavailable there.
