### PR TITLE
fix(ci): stabilize diffusion finetune smoke tests

### DIFF
--- a/examples/diffusion/finetune/flux_t2i_flow.yaml
+++ b/examples/diffusion/finetune/flux_t2i_flow.yaml
@@ -93,6 +93,7 @@ wandb:
 dist_env:
   backend: "nccl"
   init_method: "env://"
+  timeout_minutes: 30
 
 seed: 42
 

--- a/examples/diffusion/finetune/flux_t2i_flow_lora.yaml
+++ b/examples/diffusion/finetune/flux_t2i_flow_lora.yaml
@@ -9,6 +9,7 @@ wandb:
 dist_env:
   backend: "nccl"
   init_method: "env://"
+  timeout_minutes: 30
 
 model:
   pretrained_model_name_or_path: "black-forest-labs/FLUX.1-dev"

--- a/tests/ci_tests/scripts/diffusion_finetune_launcher.sh
+++ b/tests/ci_tests/scripts/diffusion_finetune_launcher.sh
@@ -33,7 +33,7 @@ case "$RECIPE_NAME" in
         MEDIA_TYPE="video"
         PROCESSOR="wan"
         GENERATE_CONFIG="examples/diffusion/generate/configs/generate_wan.yaml"
-        MODEL_NAME="Wan-AI/Wan2.1-T2V-1.3B-Diffusers"
+        MODEL_NAME="Wan-AI/Wan2.1-T2V-14B-Diffusers"
         INFER_NUM_FRAMES=9
         PREPROCESS_EXTRA_ARGS=""
         ;;
@@ -153,6 +153,7 @@ if grep -qE '^ddp:' "/opt/Automodel/${CONFIG_PATH}"; then
 fi
 
 CONFIG="--config /opt/Automodel/${CONFIG_PATH} \
+    --model.pretrained_model_name_or_path $MODEL_NAME \
     --data.dataloader.cache_dir $DATA_DIR/cache \
     --checkpoint.checkpoint_dir $CKPT_DIR \
     --step_scheduler.max_steps ${MAX_STEPS:-100} \


### PR DESCRIPTION
# What does this PR do ?

Fix two diffusion finetune CI failures by aligning the model used across Wan2.1 training/inference and increasing the Flux distributed timeout used during checkpoint consolidation.

For Wan2.1 LoRA, the CI launcher derived `MODEL_NAME` as `Wan-AI/Wan2.1-T2V-1.3B-Diffusers`, while the Wan2.1 finetune configs train against `Wan-AI/Wan2.1-T2V-14B-Diffusers`. That can produce a LoRA checkpoint with 14B transformer dimensions and then run the inference smoke test against the 1.3B base pipeline, causing parameter shape mismatches while loading LoRA weights.

For Flux full finetune, the diffusion recipe defaulted to a one-minute distributed timeout when `dist_env.timeout_minutes` was unset. Flux checkpoint consolidation can exceed that default and trigger NCCL ALLREDUCE watchdog timeouts, so the Flux recipe now uses the same 30 minute timeout used by the other diffusion finetune recipes.

# Changelog

- Set the Wan2.1 launcher model ID to `Wan-AI/Wan2.1-T2V-14B-Diffusers`.
- Pass `--model.pretrained_model_name_or_path $MODEL_NAME` into finetune so Wan training and inference use the same launcher-derived model.
- Add `dist_env.timeout_minutes: 30` to `flux_t2i_flow.yaml`.
- Add `dist_env.timeout_minutes: 30` to `flux_t2i_flow_lora.yaml` for consistency with the Flux CI recipe family.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed Contributor guidelines.
- [x] Did you write any new necessary tests? No new test needed; this updates CI recipe configuration and launcher wiring.
- [x] Did you add or update any necessary documentation? Not needed.

# Additional Information

- Branch diff excludes `pyproject.toml` and `uv.lock` changes.
- Local validation: `bash -n tests/ci_tests/scripts/diffusion_finetune_launcher.sh`
- Local validation: `git diff --check --cached` before commit and `git diff --check -- examples/diffusion/finetune/flux_t2i_flow.yaml examples/diffusion/finetune/flux_t2i_flow_lora.yaml`
- Local validation: parsed the updated Flux YAML files with `yaml.safe_load`.