### PR TITLE
fix(ci): HybridEP for multi-node MoE benchmarks + LoRA OOM fixes

### DIFF
--- a/examples/llm_benchmark/deepseek/deepseek_v3_te_deepep.yaml
+++ b/examples/llm_benchmark/deepseek/deepseek_v3_te_deepep.yaml
@@ -79,7 +79,7 @@ model:
     rms_norm: te
     rope_fusion: true
     experts: gmm
-    dispatcher: deepep
+    dispatcher: hybridep
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: false
     enable_fsdp_optimizations: true

--- a/examples/llm_benchmark/deepseek/deepseek_v3_te_deepep.yaml
+++ b/examples/llm_benchmark/deepseek/deepseek_v3_te_deepep.yaml
@@ -23,7 +23,7 @@ recipe: BenchmarkingRecipeForNextTokenPrediction
 seed: 1234
 
 benchmark:
-  warmup_steps: 10
+  warmup_steps: 2
   peak_tflops: 989  # H100 peak TFLOPs
   nsys_start: -1
   nsys_end: -1
@@ -32,12 +32,12 @@ benchmark:
 
 step_scheduler:
   gc_every_steps: 10
-  global_batch_size: 512
-  local_batch_size: 8
+  global_batch_size: 256
+  local_batch_size: 4
   ckpt_every_steps: 1000
   val_every_steps: 1000
   num_epochs: 1
-  max_steps: 30
+  max_steps: 12
 
 distributed:
   strategy: fsdp2

--- a/examples/llm_benchmark/deepseek/deepseek_v3_te_deepep.yaml
+++ b/examples/llm_benchmark/deepseek/deepseek_v3_te_deepep.yaml
@@ -78,7 +78,7 @@ model:
     linear: te
     rms_norm: te
     rope_fusion: true
-    experts: gmm
+    experts: torch_mm
     dispatcher: hybridep
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: false

--- a/examples/llm_benchmark/deepseek/deepseek_v3_te_deepep_1024.yaml
+++ b/examples/llm_benchmark/deepseek/deepseek_v3_te_deepep_1024.yaml
@@ -56,7 +56,7 @@ model:
     rms_norm: te
     rope_fusion: true
     experts: gmm
-    dispatcher: deepep
+    dispatcher: hybridep
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: false
     enable_fsdp_optimizations: true

--- a/examples/llm_benchmark/deepseek/deepseek_v3_te_deepep_1024.yaml
+++ b/examples/llm_benchmark/deepseek/deepseek_v3_te_deepep_1024.yaml
@@ -55,7 +55,7 @@ model:
     linear: te
     rms_norm: te
     rope_fusion: true
-    experts: gmm
+    experts: torch_mm
     dispatcher: hybridep
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: false

--- a/examples/llm_benchmark/deepseek/deepseek_v3_te_deepep_1024.yaml
+++ b/examples/llm_benchmark/deepseek/deepseek_v3_te_deepep_1024.yaml
@@ -23,7 +23,7 @@ recipe: BenchmarkingRecipeForNextTokenPrediction
 seed: 1234
 
 benchmark:
-  warmup_steps: 10
+  warmup_steps: 2
   peak_tflops: 989  # H100 peak TFLOPs
   nsys_start: -1
   nsys_end: -1
@@ -32,12 +32,12 @@ benchmark:
 
 step_scheduler:
   gc_every_steps: 10
-  global_batch_size: 8192
-  local_batch_size: 8
+  global_batch_size: 4096
+  local_batch_size: 4
   ckpt_every_steps: 1000
   val_every_steps: 1000
   num_epochs: 1
-  max_steps: 30
+  max_steps: 12
 
 dist_env:
   backend: nccl

--- a/examples/llm_benchmark/glm/glm47_lora.yaml
+++ b/examples/llm_benchmark/glm/glm47_lora.yaml
@@ -71,8 +71,8 @@ model:
     linear: te
     rms_norm: te
     rope_fusion: true
-    experts: torch_mm
-    dispatcher: hybridep
+    experts: torch
+    dispatcher: torch
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true
     enable_fsdp_optimizations: true

--- a/examples/llm_benchmark/glm/glm47_lora.yaml
+++ b/examples/llm_benchmark/glm/glm47_lora.yaml
@@ -72,7 +72,7 @@ model:
     rms_norm: te
     rope_fusion: true
     experts: gmm
-    dispatcher: deepep
+    dispatcher: hybridep
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true
     enable_fsdp_optimizations: true

--- a/examples/llm_benchmark/glm/glm47_lora.yaml
+++ b/examples/llm_benchmark/glm/glm47_lora.yaml
@@ -71,7 +71,7 @@ model:
     linear: te
     rms_norm: te
     rope_fusion: true
-    experts: gmm
+    experts: torch_mm
     dispatcher: hybridep
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true

--- a/examples/llm_benchmark/glm/glm47_lora.yaml
+++ b/examples/llm_benchmark/glm/glm47_lora.yaml
@@ -71,8 +71,8 @@ model:
     linear: te
     rms_norm: te
     rope_fusion: true
-    experts: torch
-    dispatcher: torch
+    experts: gmm
+    dispatcher: hybridep
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true
     enable_fsdp_optimizations: true

--- a/examples/llm_benchmark/glm/glm5_lora.yaml
+++ b/examples/llm_benchmark/glm/glm5_lora.yaml
@@ -71,8 +71,8 @@ model:
     linear: te
     rms_norm: te
     rope_fusion: false
-    experts: torch
-    dispatcher: torch
+    experts: torch_mm
+    dispatcher: hybridep
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true
     enable_fsdp_optimizations: true

--- a/examples/llm_benchmark/glm/glm5_lora.yaml
+++ b/examples/llm_benchmark/glm/glm5_lora.yaml
@@ -71,8 +71,8 @@ model:
     linear: te
     rms_norm: te
     rope_fusion: false
-    experts: torch_mm
-    dispatcher: hybridep
+    experts: torch
+    dispatcher: torch
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true
     enable_fsdp_optimizations: true

--- a/examples/llm_benchmark/glm/glm5_lora.yaml
+++ b/examples/llm_benchmark/glm/glm5_lora.yaml
@@ -71,7 +71,7 @@ model:
     linear: te
     rms_norm: te
     rope_fusion: false
-    experts: gmm
+    experts: torch_mm
     dispatcher: hybridep
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true

--- a/examples/llm_benchmark/glm/glm5_lora.yaml
+++ b/examples/llm_benchmark/glm/glm5_lora.yaml
@@ -72,7 +72,7 @@ model:
     rms_norm: te
     rope_fusion: false
     experts: gmm
-    dispatcher: deepep
+    dispatcher: hybridep
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true
     enable_fsdp_optimizations: true

--- a/examples/llm_benchmark/glm/glm5_lora.yaml
+++ b/examples/llm_benchmark/glm/glm5_lora.yaml
@@ -104,5 +104,5 @@ optimizer:
   weight_decay: 0
 
 ci:
-  time: "00:30:00"
+  time: "00:45:00"
   nodes: 16

--- a/examples/llm_benchmark/glm/glm_4.5_air_te_deepep.yaml
+++ b/examples/llm_benchmark/glm/glm_4.5_air_te_deepep.yaml
@@ -77,7 +77,7 @@ model:
     rms_norm: te
     rope_fusion: true
     experts: gmm
-    dispatcher: deepep
+    dispatcher: hybridep
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true
     enable_fsdp_optimizations: true

--- a/examples/llm_benchmark/glm/glm_4.5_air_te_deepep.yaml
+++ b/examples/llm_benchmark/glm/glm_4.5_air_te_deepep.yaml
@@ -76,7 +76,7 @@ model:
     linear: te
     rms_norm: te
     rope_fusion: true
-    experts: gmm
+    experts: torch_mm
     dispatcher: hybridep
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true

--- a/examples/llm_benchmark/glm/glm_5_te_deepep.yaml
+++ b/examples/llm_benchmark/glm/glm_5_te_deepep.yaml
@@ -28,7 +28,7 @@ benchmark:
   nsys_start: -1
   nsys_end: -1
   nsys_ranks: []
-  num_nodes: 64
+  num_nodes: 128
 
 step_scheduler:
   gc_every_steps: 10
@@ -112,6 +112,6 @@ optimizer:
 
 ci:
   time: "00:45:00"
-  nodes: 64
+  nodes: 128
   env_vars:
     PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True"

--- a/examples/llm_benchmark/glm/glm_5_te_deepep.yaml
+++ b/examples/llm_benchmark/glm/glm_5_te_deepep.yaml
@@ -23,7 +23,7 @@ recipe: BenchmarkingRecipeForNextTokenPrediction
 seed: 1234
 
 benchmark:
-  warmup_steps: 10
+  warmup_steps: 2
   peak_tflops: 989  # H100 peak TFLOPs
   nsys_start: -1
   nsys_end: -1
@@ -32,12 +32,12 @@ benchmark:
 
 step_scheduler:
   gc_every_steps: 10
-  global_batch_size: 512
-  local_batch_size: 4
+  global_batch_size: 256
+  local_batch_size: 2
   ckpt_every_steps: 1000
   val_every_steps: 1000
   num_epochs: 1
-  max_steps: 30
+  max_steps: 12
 
 distributed:
   strategy: fsdp2

--- a/examples/llm_benchmark/glm/glm_5_te_deepep.yaml
+++ b/examples/llm_benchmark/glm/glm_5_te_deepep.yaml
@@ -28,12 +28,12 @@ benchmark:
   nsys_start: -1
   nsys_end: -1
   nsys_ranks: []
-  num_nodes: 32
+  num_nodes: 64
 
 step_scheduler:
   gc_every_steps: 10
-  global_batch_size: 256
-  local_batch_size: 2
+  global_batch_size: 1024
+  local_batch_size: 4
   ckpt_every_steps: 1000
   val_every_steps: 1000
   num_epochs: 1
@@ -112,6 +112,6 @@ optimizer:
 
 ci:
   time: "00:45:00"
-  nodes: 32
+  nodes: 64
   env_vars:
     PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True"

--- a/examples/llm_benchmark/glm/glm_5_te_deepep.yaml
+++ b/examples/llm_benchmark/glm/glm_5_te_deepep.yaml
@@ -78,7 +78,7 @@ model:
     linear: te
     rms_norm: te
     rope_fusion: false
-    experts: gmm
+    experts: torch_mm
     dispatcher: hybridep
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true

--- a/examples/llm_benchmark/glm/glm_5_te_deepep.yaml
+++ b/examples/llm_benchmark/glm/glm_5_te_deepep.yaml
@@ -79,7 +79,7 @@ model:
     rms_norm: te
     rope_fusion: false
     experts: gmm
-    dispatcher: deepep
+    dispatcher: hybridep
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true
     enable_fsdp_optimizations: true

--- a/examples/llm_benchmark/minimax/minimax_m2.5_te_deepep.yaml
+++ b/examples/llm_benchmark/minimax/minimax_m2.5_te_deepep.yaml
@@ -79,7 +79,7 @@ model:
     rms_norm: te
     rope_fusion: true
     experts: torch_mm
-    dispatcher: deepep
+    dispatcher: hybridep
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true
     enable_fsdp_optimizations: true

--- a/examples/llm_benchmark/minimax/minimax_m25_lora.yaml
+++ b/examples/llm_benchmark/minimax/minimax_m25_lora.yaml
@@ -70,7 +70,7 @@ model:
     rms_norm: te
     rope_fusion: true
     experts: torch_mm
-    dispatcher: hybridep
+    dispatcher: torch
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true
     enable_fsdp_optimizations: true

--- a/examples/llm_benchmark/minimax/minimax_m25_lora.yaml
+++ b/examples/llm_benchmark/minimax/minimax_m25_lora.yaml
@@ -69,8 +69,8 @@ model:
     linear: te
     rms_norm: te
     rope_fusion: true
-    experts: torch
-    dispatcher: torch
+    experts: torch_mm
+    dispatcher: hybridep
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true
     enable_fsdp_optimizations: true

--- a/examples/llm_benchmark/minimax/minimax_m25_lora.yaml
+++ b/examples/llm_benchmark/minimax/minimax_m25_lora.yaml
@@ -69,7 +69,7 @@ model:
     linear: te
     rms_norm: te
     rope_fusion: true
-    experts: torch_mm
+    experts: torch
     dispatcher: torch
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true

--- a/examples/llm_benchmark/minimax/minimax_m25_lora.yaml
+++ b/examples/llm_benchmark/minimax/minimax_m25_lora.yaml
@@ -70,7 +70,7 @@ model:
     rms_norm: te
     rope_fusion: true
     experts: gmm
-    dispatcher: deepep
+    dispatcher: hybridep
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true
     enable_fsdp_optimizations: true

--- a/examples/llm_benchmark/minimax/minimax_m25_lora.yaml
+++ b/examples/llm_benchmark/minimax/minimax_m25_lora.yaml
@@ -34,8 +34,8 @@ benchmark:
 
 step_scheduler:
   gc_every_steps: 10
-  global_batch_size: 256
-  local_batch_size: 2
+  global_batch_size: 128
+  local_batch_size: 1
   ckpt_every_steps: 1000
   val_every_steps: 1000
   num_epochs: 1

--- a/examples/llm_benchmark/minimax/minimax_m25_lora.yaml
+++ b/examples/llm_benchmark/minimax/minimax_m25_lora.yaml
@@ -34,8 +34,8 @@ benchmark:
 
 step_scheduler:
   gc_every_steps: 10
-  global_batch_size: 128
-  local_batch_size: 1
+  global_batch_size: 512
+  local_batch_size: 4
   ckpt_every_steps: 1000
   val_every_steps: 1000
   num_epochs: 1
@@ -45,8 +45,8 @@ distributed:
   strategy: fsdp2
   tp_size: 1
   cp_size: 1
-  pp_size: 1
-  ep_size: 8
+  pp_size: 2
+  ep_size: 32
   sequence_parallel: false
   activation_checkpointing: true
   moe:
@@ -70,7 +70,7 @@ model:
     rms_norm: te
     rope_fusion: true
     experts: torch_mm
-    dispatcher: deepep
+    dispatcher: hybridep
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true
     enable_fsdp_optimizations: true

--- a/examples/llm_benchmark/minimax/minimax_m25_lora.yaml
+++ b/examples/llm_benchmark/minimax/minimax_m25_lora.yaml
@@ -46,7 +46,7 @@ distributed:
   tp_size: 1
   cp_size: 1
   pp_size: 1
-  ep_size: 32
+  ep_size: 8
   sequence_parallel: false
   activation_checkpointing: true
   moe:
@@ -70,7 +70,7 @@ model:
     rms_norm: te
     rope_fusion: true
     experts: torch_mm
-    dispatcher: hybridep
+    dispatcher: deepep
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true
     enable_fsdp_optimizations: true

--- a/examples/llm_benchmark/minimax/minimax_m25_lora.yaml
+++ b/examples/llm_benchmark/minimax/minimax_m25_lora.yaml
@@ -34,8 +34,8 @@ benchmark:
 
 step_scheduler:
   gc_every_steps: 10
-  global_batch_size: 512
-  local_batch_size: 4
+  global_batch_size: 256
+  local_batch_size: 2
   ckpt_every_steps: 1000
   val_every_steps: 1000
   num_epochs: 1

--- a/examples/llm_benchmark/minimax/minimax_m25_lora.yaml
+++ b/examples/llm_benchmark/minimax/minimax_m25_lora.yaml
@@ -108,5 +108,5 @@ optimizer:
   weight_decay: 0
 
 ci:
-  time: "00:20:00"
+  time: "00:45:00"
   nodes: 4

--- a/examples/llm_benchmark/minimax/minimax_m25_lora.yaml
+++ b/examples/llm_benchmark/minimax/minimax_m25_lora.yaml
@@ -30,7 +30,7 @@ benchmark:
   nsys_start: -1
   nsys_end: -1
   nsys_ranks: []
-  num_nodes: 4
+  num_nodes: 8
 
 step_scheduler:
   gc_every_steps: 10
@@ -109,4 +109,4 @@ optimizer:
 
 ci:
   time: "00:45:00"
-  nodes: 4
+  nodes: 8

--- a/examples/llm_benchmark/minimax/minimax_m25_lora.yaml
+++ b/examples/llm_benchmark/minimax/minimax_m25_lora.yaml
@@ -78,8 +78,8 @@ model:
 peft:
   _target_: nemo_automodel.components._peft.lora.PeftConfig
   target_modules: ["*"]
-  dim: 32
-  alpha: 32
+  dim: 64
+  alpha: 64
   dropout: 0.0
   moe_rank_scaling: true
 

--- a/examples/llm_benchmark/minimax/minimax_m25_lora.yaml
+++ b/examples/llm_benchmark/minimax/minimax_m25_lora.yaml
@@ -49,6 +49,14 @@ distributed:
   ep_size: 32
   sequence_parallel: false
   activation_checkpointing: true
+  pipeline:
+    pp_schedule: interleaved1f1b
+    pp_microbatch_size: 1
+    round_virtual_stages_to_pp_multiple: down
+    scale_grads_in_schedule: false
+    patch_inner_model: false
+    patch_causal_lm_model: false
+    layers_per_stage: 2
   moe:
     reshard_after_forward: false
     wrap_outer_model: false

--- a/examples/llm_benchmark/minimax/minimax_m25_lora.yaml
+++ b/examples/llm_benchmark/minimax/minimax_m25_lora.yaml
@@ -69,7 +69,7 @@ model:
     linear: te
     rms_norm: te
     rope_fusion: true
-    experts: gmm
+    experts: torch_mm
     dispatcher: hybridep
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true

--- a/examples/llm_benchmark/mistral/mistral_small_4_te_deepep.yaml
+++ b/examples/llm_benchmark/mistral/mistral_small_4_te_deepep.yaml
@@ -78,7 +78,7 @@ model:
     linear: te
     rms_norm: te
     rope_fusion: true
-    experts: gmm
+    experts: torch_mm
     dispatcher: hybridep
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true

--- a/examples/llm_benchmark/mistral/mistral_small_4_te_deepep.yaml
+++ b/examples/llm_benchmark/mistral/mistral_small_4_te_deepep.yaml
@@ -79,7 +79,7 @@ model:
     rms_norm: te
     rope_fusion: true
     experts: gmm
-    dispatcher: deepep
+    dispatcher: hybridep
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true
     enable_fsdp_optimizations: true

--- a/examples/llm_benchmark/nemotron/nemotron_super_v3_lora.yaml
+++ b/examples/llm_benchmark/nemotron/nemotron_super_v3_lora.yaml
@@ -68,7 +68,7 @@ model:
     rms_norm: te
     rope_fusion: false
     experts: gmm
-    dispatcher: deepep
+    dispatcher: hybridep
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true
     enable_fsdp_optimizations: true

--- a/examples/llm_benchmark/nemotron/nemotron_super_v3_lora.yaml
+++ b/examples/llm_benchmark/nemotron/nemotron_super_v3_lora.yaml
@@ -67,7 +67,7 @@ model:
     linear: te
     rms_norm: te
     rope_fusion: false
-    experts: torch_mm
+    experts: torch
     dispatcher: torch
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true

--- a/examples/llm_benchmark/nemotron/nemotron_super_v3_lora.yaml
+++ b/examples/llm_benchmark/nemotron/nemotron_super_v3_lora.yaml
@@ -67,8 +67,8 @@ model:
     linear: te
     rms_norm: te
     rope_fusion: false
-    experts: torch
-    dispatcher: torch
+    experts: torch_mm
+    dispatcher: hybridep
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true
     enable_fsdp_optimizations: true

--- a/examples/llm_benchmark/nemotron/nemotron_super_v3_lora.yaml
+++ b/examples/llm_benchmark/nemotron/nemotron_super_v3_lora.yaml
@@ -68,7 +68,7 @@ model:
     rms_norm: te
     rope_fusion: false
     experts: torch_mm
-    dispatcher: hybridep
+    dispatcher: torch
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true
     enable_fsdp_optimizations: true

--- a/examples/llm_benchmark/nemotron/nemotron_super_v3_lora.yaml
+++ b/examples/llm_benchmark/nemotron/nemotron_super_v3_lora.yaml
@@ -67,7 +67,7 @@ model:
     linear: te
     rms_norm: te
     rope_fusion: false
-    experts: gmm
+    experts: torch_mm
     dispatcher: hybridep
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true

--- a/examples/llm_benchmark/nemotron/nemotron_super_v3_lora.yaml
+++ b/examples/llm_benchmark/nemotron/nemotron_super_v3_lora.yaml
@@ -46,7 +46,7 @@ distributed:
   tp_size: 1
   cp_size: 1
   pp_size: 1
-  ep_size: 32
+  ep_size: 8
   sequence_parallel: false
   activation_checkpointing: true
   moe:
@@ -68,7 +68,7 @@ model:
     rms_norm: te
     rope_fusion: false
     experts: torch_mm
-    dispatcher: hybridep
+    dispatcher: deepep
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true
     enable_fsdp_optimizations: true

--- a/examples/llm_benchmark/nemotron/nemotron_super_v3_lora.yaml
+++ b/examples/llm_benchmark/nemotron/nemotron_super_v3_lora.yaml
@@ -34,8 +34,8 @@ benchmark:
 
 step_scheduler:
   gc_every_steps: 10
-  global_batch_size: 512
-  local_batch_size: 4
+  global_batch_size: 256
+  local_batch_size: 2
   ckpt_every_steps: 1000
   val_every_steps: 1000
   num_epochs: 1

--- a/examples/llm_benchmark/nemotron/nemotron_super_v3_lora.yaml
+++ b/examples/llm_benchmark/nemotron/nemotron_super_v3_lora.yaml
@@ -30,11 +30,11 @@ benchmark:
   nsys_start: -1
   nsys_end: -1
   nsys_ranks: []
-  num_nodes: 4
+  num_nodes: 8
 
 step_scheduler:
   gc_every_steps: 10
-  global_batch_size: 256
+  global_batch_size: 512
   local_batch_size: 2
   ckpt_every_steps: 1000
   val_every_steps: 1000
@@ -46,11 +46,11 @@ distributed:
   tp_size: 1
   cp_size: 1
   pp_size: 1
-  ep_size: 8
+  ep_size: 64
   sequence_parallel: false
   activation_checkpointing: true
   moe:
-    reshard_after_forward: false
+    reshard_after_forward: true
 
 dist_env:
   backend: nccl
@@ -68,7 +68,7 @@ model:
     rms_norm: te
     rope_fusion: false
     experts: torch_mm
-    dispatcher: deepep
+    dispatcher: hybridep
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true
     enable_fsdp_optimizations: true
@@ -106,5 +106,5 @@ optimizer:
   weight_decay: 0
 
 ci:
-  time: "00:20:00"
-  nodes: 4
+  time: "00:30:00"
+  nodes: 8

--- a/examples/llm_benchmark/nemotron/nemotron_super_v3_te_deepep.yaml
+++ b/examples/llm_benchmark/nemotron/nemotron_super_v3_te_deepep.yaml
@@ -61,7 +61,7 @@ model:
     _target_: nemo_automodel.components.models.common.BackendConfig
     linear: te
     rms_norm: te
-    experts: gmm
+    experts: torch_mm
     dispatcher: hybridep
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true

--- a/examples/llm_benchmark/nemotron/nemotron_super_v3_te_deepep.yaml
+++ b/examples/llm_benchmark/nemotron/nemotron_super_v3_te_deepep.yaml
@@ -62,7 +62,7 @@ model:
     linear: te
     rms_norm: te
     experts: gmm
-    dispatcher: deepep
+    dispatcher: hybridep
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true
 

--- a/examples/llm_benchmark/nemotron/nemotron_ultra_v3_te_deepep.yaml
+++ b/examples/llm_benchmark/nemotron/nemotron_ultra_v3_te_deepep.yaml
@@ -82,7 +82,7 @@ model:
     linear: te
     rms_norm: te
     experts: torch_mm
-    dispatcher: deepep
+    dispatcher: hybridep
     fake_balanced_gate: true
     enable_fsdp_optimizations: false
 

--- a/examples/llm_benchmark/nemotron/nemotron_ultra_v3_te_deepep.yaml
+++ b/examples/llm_benchmark/nemotron/nemotron_ultra_v3_te_deepep.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Nemotron-3-Ultra-550B-A55B throughput benchmark (16 nodes / 128x H100, EP=64):
-# torch_mm experts, balanced gate, EP=64, local batch size 2, seq 4096, activation checkpointing,
+# torch_mm experts, balanced gate, EP=64, local batch size 1, seq 4096, activation checkpointing,
 # fused linear cross-entropy, and the repeated MTP head (num_nextn_predict_layers=2 +
 # mtp_use_repeated_layer=true; one physical MTP layer reused across both depths). Run via the
 # recipe (nemo_automodel/recipes/llm/benchmark.py) to get MFU / TFLOPs.
@@ -31,7 +31,7 @@ recipe: BenchmarkingRecipeForNextTokenPrediction
 seed: 1234
 
 benchmark:
-  warmup_steps: 10
+  warmup_steps: 2
   peak_tflops: 989  # H100 dense bf16 peak TFLOPs
   nsys_start: -1
   nsys_end: -1
@@ -40,12 +40,12 @@ benchmark:
 
 step_scheduler:
   gc_every_steps: 10
-  global_batch_size: 256  # local_batch_size(2) * dp_size(128) -> 1 microbatch/GPU/step (no grad accum)
-  local_batch_size: 2
+  global_batch_size: 128  # local_batch_size(1) * dp_size(128) -> 1 microbatch/GPU/step (no grad accum)
+  local_batch_size: 1
   ckpt_every_steps: 1000
   val_every_steps: 1000
   num_epochs: 1
-  max_steps: 30
+  max_steps: 12
 
 distributed:
   strategy: fsdp2
@@ -112,5 +112,5 @@ optimizer:
   weight_decay: 0
 
 ci:
-  time: "00:30:00"
+  time: "00:45:00"
   nodes: 16

--- a/examples/vlm_benchmark/qwen/qwen3_vl_235b_te_deepep.yaml
+++ b/examples/vlm_benchmark/qwen/qwen3_vl_235b_te_deepep.yaml
@@ -78,7 +78,7 @@ model:
     linear: te
     rms_norm: te
     rope_fusion: false
-    experts: gmm
+    experts: torch_mm
     dispatcher: hybridep
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true

--- a/examples/vlm_benchmark/qwen/qwen3_vl_235b_te_deepep.yaml
+++ b/examples/vlm_benchmark/qwen/qwen3_vl_235b_te_deepep.yaml
@@ -79,7 +79,7 @@ model:
     rms_norm: te
     rope_fusion: false
     experts: gmm
-    dispatcher: deepep
+    dispatcher: hybridep
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true
     enable_fsdp_optimizations: true

--- a/examples/vlm_benchmark/qwen/qwen3vl235b_lora.yaml
+++ b/examples/vlm_benchmark/qwen/qwen3vl235b_lora.yaml
@@ -78,8 +78,8 @@ model:
     linear: te
     rms_norm: te
     rope_fusion: false
-    experts: torch
-    dispatcher: torch
+    experts: torch_mm
+    dispatcher: hybridep
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true
     enable_fsdp_optimizations: true

--- a/examples/vlm_benchmark/qwen/qwen3vl235b_lora.yaml
+++ b/examples/vlm_benchmark/qwen/qwen3vl235b_lora.yaml
@@ -78,8 +78,8 @@ model:
     linear: te
     rms_norm: te
     rope_fusion: false
-    experts: torch_mm
-    dispatcher: hybridep
+    experts: torch
+    dispatcher: torch
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true
     enable_fsdp_optimizations: true

--- a/examples/vlm_benchmark/qwen/qwen3vl235b_lora.yaml
+++ b/examples/vlm_benchmark/qwen/qwen3vl235b_lora.yaml
@@ -78,7 +78,7 @@ model:
     linear: te
     rms_norm: te
     rope_fusion: false
-    experts: gmm
+    experts: torch_mm
     dispatcher: hybridep
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true

--- a/examples/vlm_benchmark/qwen/qwen3vl235b_lora.yaml
+++ b/examples/vlm_benchmark/qwen/qwen3vl235b_lora.yaml
@@ -79,7 +79,7 @@ model:
     rms_norm: te
     rope_fusion: false
     experts: gmm
-    dispatcher: deepep
+    dispatcher: hybridep
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true
     enable_fsdp_optimizations: true

--- a/nemo_automodel/components/_peft/lora_experts.py
+++ b/nemo_automodel/components/_peft/lora_experts.py
@@ -370,7 +370,13 @@ class GroupedExpertsDeepEPLoRA(GroupedExpertsDeepEP):
     def __init__(
         self, orig_module: GroupedExpertsDeepEP, lora_dim=8, alpha=32, lora_A_init_method="xavier", lora_dtype=None
     ):
-        super().__init__(orig_module.config)
+        super().__init__(
+            orig_module.config,
+            dispatcher_backend=orig_module.dispatcher_backend,
+            dispatcher_num_sms=orig_module.dispatcher_num_sms,
+            dispatcher_share_token_dispatcher=orig_module.dispatcher_share_token_dispatcher,
+            dispatcher_async_dispatch=orig_module.dispatcher_async_dispatch,
+        )
 
         self.gate_and_up_projs.data.copy_(orig_module.gate_and_up_projs.data)
         self.down_projs.data.copy_(orig_module.down_projs.data)
@@ -385,6 +391,7 @@ class GroupedExpertsDeepEPLoRA(GroupedExpertsDeepEP):
         self.ep_rank = getattr(orig_module, "ep_rank", 0)
         self.token_dispatcher = getattr(orig_module, "token_dispatcher", None)
         self.use_torch_mm = getattr(orig_module, "use_torch_mm", False)
+        self.use_mxfp8 = getattr(orig_module, "use_mxfp8", False)
 
         GroupedExpertsDeepEPLoRA._init_adapter(
             self,

--- a/nemo_automodel/components/_peft/lora_experts.py
+++ b/nemo_automodel/components/_peft/lora_experts.py
@@ -16,7 +16,6 @@ import math
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 from torch.distributed.tensor import DTensor, Partial, Shard
 
 from nemo_automodel.components.moe.experts import (
@@ -36,21 +35,6 @@ except ImportError:
 def _to_local(proj):
     """Convert DTensor to local tensor, or return as-is."""
     return proj.to_local() if isinstance(proj, DTensor) else proj
-
-
-def _to_grouped_mm_operand(proj, dtype: torch.dtype):
-    """Convert a projection tensor to the dtype/layout expected by grouped MM."""
-    return _to_local(proj).to(dtype).contiguous()
-
-
-def _pad_lora_rank_for_grouped_mm(lora_A: torch.Tensor, lora_B: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-    """Pad LoRA rank tensors so grouped-mm strides are 16-byte aligned."""
-    rank = lora_A.size(-1)
-    alignment = max(1, 16 // lora_A.element_size())
-    padding = (-rank) % alignment
-    if padding == 0:
-        return lora_A, lora_B
-    return F.pad(lora_A, (0, padding)), F.pad(lora_B, (0, 0, 0, padding))
 
 
 class GroupedExpertsLoRA(GroupedExperts):
@@ -172,13 +156,12 @@ class GroupedExpertsLoRA(GroupedExperts):
 
         assert self.n_routed_experts % ep_size == 0
 
-        compute_dtype = x.dtype
-        gate_and_up_projs = _to_grouped_mm_operand(self.gate_and_up_projs, compute_dtype)
-        down_projs = _to_grouped_mm_operand(self.down_projs, compute_dtype)
-        lora_gate_and_up_A = _to_grouped_mm_operand(self.lora_gate_and_up_A, compute_dtype)
-        lora_gate_and_up_B = _to_grouped_mm_operand(self.lora_gate_and_up_B, compute_dtype)
-        lora_down_A = _to_grouped_mm_operand(self.lora_down_A, compute_dtype)
-        lora_down_B = _to_grouped_mm_operand(self.lora_down_B, compute_dtype)
+        gate_and_up_projs = _to_local(self.gate_and_up_projs)
+        down_projs = _to_local(self.down_projs)
+        lora_gate_and_up_A = _to_local(self.lora_gate_and_up_A)
+        lora_gate_and_up_B = _to_local(self.lora_gate_and_up_B)
+        lora_down_A = _to_local(self.lora_down_A)
+        lora_down_B = _to_local(self.lora_down_B)
 
         if ep_size > 1:
             x = DTensor.from_local(x, device_mesh=ep_mesh, placements=[Shard(0)]).full_tensor(
@@ -195,10 +178,6 @@ class GroupedExpertsLoRA(GroupedExperts):
         experts_end_idx = experts_start_idx + n_local_experts
 
         if self.use_torch_mm:
-            lora_gate_and_up_A, lora_gate_and_up_B = _pad_lora_rank_for_grouped_mm(
-                lora_gate_and_up_A, lora_gate_and_up_B
-            )
-            lora_down_A, lora_down_B = _pad_lora_rank_for_grouped_mm(lora_down_A, lora_down_B)
             y = self._forward_grouped_mm(
                 x,
                 token_mask,
@@ -391,13 +370,7 @@ class GroupedExpertsDeepEPLoRA(GroupedExpertsDeepEP):
     def __init__(
         self, orig_module: GroupedExpertsDeepEP, lora_dim=8, alpha=32, lora_A_init_method="xavier", lora_dtype=None
     ):
-        super().__init__(
-            orig_module.config,
-            dispatcher_backend=orig_module.dispatcher_backend,
-            dispatcher_num_sms=orig_module.dispatcher_num_sms,
-            dispatcher_share_token_dispatcher=orig_module.dispatcher_share_token_dispatcher,
-            dispatcher_async_dispatch=orig_module.dispatcher_async_dispatch,
-        )
+        super().__init__(orig_module.config)
 
         self.gate_and_up_projs.data.copy_(orig_module.gate_and_up_projs.data)
         self.down_projs.data.copy_(orig_module.down_projs.data)
@@ -412,7 +385,6 @@ class GroupedExpertsDeepEPLoRA(GroupedExpertsDeepEP):
         self.ep_rank = getattr(orig_module, "ep_rank", 0)
         self.token_dispatcher = getattr(orig_module, "token_dispatcher", None)
         self.use_torch_mm = getattr(orig_module, "use_torch_mm", False)
-        self.use_mxfp8 = getattr(orig_module, "use_mxfp8", False)
 
         GroupedExpertsDeepEPLoRA._init_adapter(
             self,
@@ -505,20 +477,15 @@ class GroupedExpertsDeepEPLoRA(GroupedExpertsDeepEP):
         )
         permuted_probs = permuted_probs.unsqueeze(-1)
 
-        compute_dtype = x.dtype
-        gate_and_up_projs = _to_grouped_mm_operand(self.gate_and_up_projs, compute_dtype)
-        down_projs = _to_grouped_mm_operand(self.down_projs, compute_dtype)
-        lora_gate_and_up_A = _to_grouped_mm_operand(self.lora_gate_and_up_A, compute_dtype)
-        lora_gate_and_up_B = _to_grouped_mm_operand(self.lora_gate_and_up_B, compute_dtype)
-        lora_down_A = _to_grouped_mm_operand(self.lora_down_A, compute_dtype)
-        lora_down_B = _to_grouped_mm_operand(self.lora_down_B, compute_dtype)
+        gate_and_up_projs = _to_local(self.gate_and_up_projs)
+        down_projs = _to_local(self.down_projs)
+        lora_gate_and_up_A = _to_local(self.lora_gate_and_up_A)
+        lora_gate_and_up_B = _to_local(self.lora_gate_and_up_B)
+        lora_down_A = _to_local(self.lora_down_A)
+        lora_down_B = _to_local(self.lora_down_B)
 
         if torch.count_nonzero(tokens_per_expert) > 0:
             if self.use_torch_mm:
-                lora_gate_and_up_A, lora_gate_and_up_B = _pad_lora_rank_for_grouped_mm(
-                    lora_gate_and_up_A, lora_gate_and_up_B
-                )
-                lora_down_A, lora_down_B = _pad_lora_rank_for_grouped_mm(lora_down_A, lora_down_B)
                 tokens_per_expert_gpu = tokens_per_expert.to(
                     device=permuted_local_hidden_states.device, non_blocking=True
                 )

--- a/nemo_automodel/components/_peft/lora_experts.py
+++ b/nemo_automodel/components/_peft/lora_experts.py
@@ -37,6 +37,11 @@ def _to_local(proj):
     return proj.to_local() if isinstance(proj, DTensor) else proj
 
 
+def _to_grouped_mm_operand(proj, dtype: torch.dtype):
+    """Convert a projection tensor to the dtype/layout expected by grouped MM."""
+    return _to_local(proj).to(dtype).contiguous()
+
+
 class GroupedExpertsLoRA(GroupedExperts):
     """
     GroupedExperts + LoRA.
@@ -156,12 +161,13 @@ class GroupedExpertsLoRA(GroupedExperts):
 
         assert self.n_routed_experts % ep_size == 0
 
-        gate_and_up_projs = _to_local(self.gate_and_up_projs)
-        down_projs = _to_local(self.down_projs)
-        lora_gate_and_up_A = _to_local(self.lora_gate_and_up_A)
-        lora_gate_and_up_B = _to_local(self.lora_gate_and_up_B)
-        lora_down_A = _to_local(self.lora_down_A)
-        lora_down_B = _to_local(self.lora_down_B)
+        compute_dtype = x.dtype
+        gate_and_up_projs = _to_grouped_mm_operand(self.gate_and_up_projs, compute_dtype)
+        down_projs = _to_grouped_mm_operand(self.down_projs, compute_dtype)
+        lora_gate_and_up_A = _to_grouped_mm_operand(self.lora_gate_and_up_A, compute_dtype)
+        lora_gate_and_up_B = _to_grouped_mm_operand(self.lora_gate_and_up_B, compute_dtype)
+        lora_down_A = _to_grouped_mm_operand(self.lora_down_A, compute_dtype)
+        lora_down_B = _to_grouped_mm_operand(self.lora_down_B, compute_dtype)
 
         if ep_size > 1:
             x = DTensor.from_local(x, device_mesh=ep_mesh, placements=[Shard(0)]).full_tensor(
@@ -484,12 +490,13 @@ class GroupedExpertsDeepEPLoRA(GroupedExpertsDeepEP):
         )
         permuted_probs = permuted_probs.unsqueeze(-1)
 
-        gate_and_up_projs = _to_local(self.gate_and_up_projs)
-        down_projs = _to_local(self.down_projs)
-        lora_gate_and_up_A = _to_local(self.lora_gate_and_up_A)
-        lora_gate_and_up_B = _to_local(self.lora_gate_and_up_B)
-        lora_down_A = _to_local(self.lora_down_A)
-        lora_down_B = _to_local(self.lora_down_B)
+        compute_dtype = x.dtype
+        gate_and_up_projs = _to_grouped_mm_operand(self.gate_and_up_projs, compute_dtype)
+        down_projs = _to_grouped_mm_operand(self.down_projs, compute_dtype)
+        lora_gate_and_up_A = _to_grouped_mm_operand(self.lora_gate_and_up_A, compute_dtype)
+        lora_gate_and_up_B = _to_grouped_mm_operand(self.lora_gate_and_up_B, compute_dtype)
+        lora_down_A = _to_grouped_mm_operand(self.lora_down_A, compute_dtype)
+        lora_down_B = _to_grouped_mm_operand(self.lora_down_B, compute_dtype)
 
         if torch.count_nonzero(tokens_per_expert) > 0:
             if self.use_torch_mm:

--- a/nemo_automodel/components/_peft/lora_experts.py
+++ b/nemo_automodel/components/_peft/lora_experts.py
@@ -16,6 +16,7 @@ import math
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 from torch.distributed.tensor import DTensor, Partial, Shard
 
 from nemo_automodel.components.moe.experts import (
@@ -35,6 +36,21 @@ except ImportError:
 def _to_local(proj):
     """Convert DTensor to local tensor, or return as-is."""
     return proj.to_local() if isinstance(proj, DTensor) else proj
+
+
+def _to_grouped_mm_operand(proj, dtype: torch.dtype):
+    """Convert a projection tensor to the dtype/layout expected by grouped MM."""
+    return _to_local(proj).to(dtype).contiguous()
+
+
+def _pad_lora_rank_for_grouped_mm(lora_A: torch.Tensor, lora_B: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Pad LoRA rank tensors so grouped-mm strides are 16-byte aligned."""
+    rank = lora_A.size(-1)
+    alignment = max(1, 16 // lora_A.element_size())
+    padding = (-rank) % alignment
+    if padding == 0:
+        return lora_A, lora_B
+    return F.pad(lora_A, (0, padding)), F.pad(lora_B, (0, 0, 0, padding))
 
 
 class GroupedExpertsLoRA(GroupedExperts):
@@ -156,12 +172,13 @@ class GroupedExpertsLoRA(GroupedExperts):
 
         assert self.n_routed_experts % ep_size == 0
 
-        gate_and_up_projs = _to_local(self.gate_and_up_projs)
-        down_projs = _to_local(self.down_projs)
-        lora_gate_and_up_A = _to_local(self.lora_gate_and_up_A)
-        lora_gate_and_up_B = _to_local(self.lora_gate_and_up_B)
-        lora_down_A = _to_local(self.lora_down_A)
-        lora_down_B = _to_local(self.lora_down_B)
+        compute_dtype = x.dtype
+        gate_and_up_projs = _to_grouped_mm_operand(self.gate_and_up_projs, compute_dtype)
+        down_projs = _to_grouped_mm_operand(self.down_projs, compute_dtype)
+        lora_gate_and_up_A = _to_grouped_mm_operand(self.lora_gate_and_up_A, compute_dtype)
+        lora_gate_and_up_B = _to_grouped_mm_operand(self.lora_gate_and_up_B, compute_dtype)
+        lora_down_A = _to_grouped_mm_operand(self.lora_down_A, compute_dtype)
+        lora_down_B = _to_grouped_mm_operand(self.lora_down_B, compute_dtype)
 
         if ep_size > 1:
             x = DTensor.from_local(x, device_mesh=ep_mesh, placements=[Shard(0)]).full_tensor(
@@ -178,6 +195,10 @@ class GroupedExpertsLoRA(GroupedExperts):
         experts_end_idx = experts_start_idx + n_local_experts
 
         if self.use_torch_mm:
+            lora_gate_and_up_A, lora_gate_and_up_B = _pad_lora_rank_for_grouped_mm(
+                lora_gate_and_up_A, lora_gate_and_up_B
+            )
+            lora_down_A, lora_down_B = _pad_lora_rank_for_grouped_mm(lora_down_A, lora_down_B)
             y = self._forward_grouped_mm(
                 x,
                 token_mask,
@@ -370,7 +391,13 @@ class GroupedExpertsDeepEPLoRA(GroupedExpertsDeepEP):
     def __init__(
         self, orig_module: GroupedExpertsDeepEP, lora_dim=8, alpha=32, lora_A_init_method="xavier", lora_dtype=None
     ):
-        super().__init__(orig_module.config)
+        super().__init__(
+            orig_module.config,
+            dispatcher_backend=orig_module.dispatcher_backend,
+            dispatcher_num_sms=orig_module.dispatcher_num_sms,
+            dispatcher_share_token_dispatcher=orig_module.dispatcher_share_token_dispatcher,
+            dispatcher_async_dispatch=orig_module.dispatcher_async_dispatch,
+        )
 
         self.gate_and_up_projs.data.copy_(orig_module.gate_and_up_projs.data)
         self.down_projs.data.copy_(orig_module.down_projs.data)
@@ -385,6 +412,7 @@ class GroupedExpertsDeepEPLoRA(GroupedExpertsDeepEP):
         self.ep_rank = getattr(orig_module, "ep_rank", 0)
         self.token_dispatcher = getattr(orig_module, "token_dispatcher", None)
         self.use_torch_mm = getattr(orig_module, "use_torch_mm", False)
+        self.use_mxfp8 = getattr(orig_module, "use_mxfp8", False)
 
         GroupedExpertsDeepEPLoRA._init_adapter(
             self,
@@ -477,15 +505,20 @@ class GroupedExpertsDeepEPLoRA(GroupedExpertsDeepEP):
         )
         permuted_probs = permuted_probs.unsqueeze(-1)
 
-        gate_and_up_projs = _to_local(self.gate_and_up_projs)
-        down_projs = _to_local(self.down_projs)
-        lora_gate_and_up_A = _to_local(self.lora_gate_and_up_A)
-        lora_gate_and_up_B = _to_local(self.lora_gate_and_up_B)
-        lora_down_A = _to_local(self.lora_down_A)
-        lora_down_B = _to_local(self.lora_down_B)
+        compute_dtype = x.dtype
+        gate_and_up_projs = _to_grouped_mm_operand(self.gate_and_up_projs, compute_dtype)
+        down_projs = _to_grouped_mm_operand(self.down_projs, compute_dtype)
+        lora_gate_and_up_A = _to_grouped_mm_operand(self.lora_gate_and_up_A, compute_dtype)
+        lora_gate_and_up_B = _to_grouped_mm_operand(self.lora_gate_and_up_B, compute_dtype)
+        lora_down_A = _to_grouped_mm_operand(self.lora_down_A, compute_dtype)
+        lora_down_B = _to_grouped_mm_operand(self.lora_down_B, compute_dtype)
 
         if torch.count_nonzero(tokens_per_expert) > 0:
             if self.use_torch_mm:
+                lora_gate_and_up_A, lora_gate_and_up_B = _pad_lora_rank_for_grouped_mm(
+                    lora_gate_and_up_A, lora_gate_and_up_B
+                )
+                lora_down_A, lora_down_B = _pad_lora_rank_for_grouped_mm(lora_down_A, lora_down_B)
                 tokens_per_expert_gpu = tokens_per_expert.to(
                     device=permuted_local_hidden_states.device, non_blocking=True
                 )

--- a/nemo_automodel/components/_peft/lora_experts.py
+++ b/nemo_automodel/components/_peft/lora_experts.py
@@ -16,6 +16,7 @@ import math
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 from torch.distributed.tensor import DTensor, Partial, Shard
 
 from nemo_automodel.components.moe.experts import (
@@ -40,6 +41,16 @@ def _to_local(proj):
 def _to_grouped_mm_operand(proj, dtype: torch.dtype):
     """Convert a projection tensor to the dtype/layout expected by grouped MM."""
     return _to_local(proj).to(dtype).contiguous()
+
+
+def _pad_lora_rank_for_grouped_mm(lora_A: torch.Tensor, lora_B: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Pad LoRA rank tensors so grouped-mm strides are 16-byte aligned."""
+    rank = lora_A.size(-1)
+    alignment = max(1, 16 // lora_A.element_size())
+    padding = (-rank) % alignment
+    if padding == 0:
+        return lora_A, lora_B
+    return F.pad(lora_A, (0, padding)), F.pad(lora_B, (0, 0, 0, padding))
 
 
 class GroupedExpertsLoRA(GroupedExperts):
@@ -184,6 +195,10 @@ class GroupedExpertsLoRA(GroupedExperts):
         experts_end_idx = experts_start_idx + n_local_experts
 
         if self.use_torch_mm:
+            lora_gate_and_up_A, lora_gate_and_up_B = _pad_lora_rank_for_grouped_mm(
+                lora_gate_and_up_A, lora_gate_and_up_B
+            )
+            lora_down_A, lora_down_B = _pad_lora_rank_for_grouped_mm(lora_down_A, lora_down_B)
             y = self._forward_grouped_mm(
                 x,
                 token_mask,
@@ -500,6 +515,10 @@ class GroupedExpertsDeepEPLoRA(GroupedExpertsDeepEP):
 
         if torch.count_nonzero(tokens_per_expert) > 0:
             if self.use_torch_mm:
+                lora_gate_and_up_A, lora_gate_and_up_B = _pad_lora_rank_for_grouped_mm(
+                    lora_gate_and_up_A, lora_gate_and_up_B
+                )
+                lora_down_A, lora_down_B = _pad_lora_rank_for_grouped_mm(lora_down_A, lora_down_B)
                 tokens_per_expert_gpu = tokens_per_expert.to(
                     device=permuted_local_hidden_states.device, non_blocking=True
                 )

--- a/tests/unit_tests/_peft/test_lora_experts.py
+++ b/tests/unit_tests/_peft/test_lora_experts.py
@@ -31,7 +31,11 @@ except ImportError:
     HAS_TE = False
 
 from nemo_automodel.components._peft.lora import PeftConfig, apply_lora_to_linear_modules, patch_moe_module
-from nemo_automodel.components._peft.lora_experts import GroupedExpertsDeepEPLoRA, GroupedExpertsLoRA
+from nemo_automodel.components._peft.lora_experts import (
+    GroupedExpertsDeepEPLoRA,
+    GroupedExpertsLoRA,
+    _pad_lora_rank_for_grouped_mm,
+)
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.layers import GroupedExperts, GroupedExpertsDeepEP, GroupedExpertsTE
 
@@ -188,6 +192,21 @@ def test_grouped_experts_deepep_lora_preserves_dispatcher_settings(moe_config):
     assert lora_experts.dispatcher_async_dispatch is True
     assert lora_experts.use_torch_mm is True
     assert lora_experts.use_mxfp8 is True
+
+
+def test_pad_lora_rank_for_grouped_mm_aligns_bf16_rank():
+    """Test rank padding for torch._grouped_mm stride alignment."""
+    lora_A = torch.randn(2, 16, 4, dtype=torch.bfloat16)
+    lora_B = torch.randn(2, 4, 32, dtype=torch.bfloat16)
+
+    padded_A, padded_B = _pad_lora_rank_for_grouped_mm(lora_A, lora_B)
+
+    assert padded_A.shape == (2, 16, 8)
+    assert padded_B.shape == (2, 8, 32)
+    assert torch.equal(padded_A[..., :4], lora_A)
+    assert torch.equal(padded_B[:, :4], lora_B)
+    assert torch.count_nonzero(padded_A[..., 4:]) == 0
+    assert torch.count_nonzero(padded_B[:, 4:]) == 0
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")

--- a/tests/unit_tests/_peft/test_lora_experts.py
+++ b/tests/unit_tests/_peft/test_lora_experts.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 import torch
 import torch.nn as nn
-from unittest.mock import MagicMock, patch
+
 try:
     import grouped_gemm
 except ImportError:
@@ -23,14 +25,15 @@ except ImportError:
 
 try:
     import transformer_engine  # noqa: F401
+
     HAS_TE = True
 except ImportError:
     HAS_TE = False
 
+from nemo_automodel.components._peft.lora import PeftConfig, apply_lora_to_linear_modules, patch_moe_module
+from nemo_automodel.components._peft.lora_experts import GroupedExpertsDeepEPLoRA, GroupedExpertsLoRA
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.layers import GroupedExperts, GroupedExpertsDeepEP, GroupedExpertsTE
-from nemo_automodel.components._peft.lora_experts import GroupedExpertsLoRA, GroupedExpertsDeepEPLoRA
-from nemo_automodel.components._peft.lora import patch_moe_module, apply_lora_to_linear_modules, PeftConfig
 
 
 @pytest.fixture
@@ -58,7 +61,7 @@ def moe_config():
         moe_inter_dim=32,
         norm_topk_prob=False,
         expert_activation="swiglu",
-        dtype=torch.float32
+        dtype=torch.float32,
     )
 
 
@@ -80,7 +83,7 @@ def test_grouped_experts_lora_init(moe_config, device):
     # lora_gate_and_up_A: [n_experts, in_dim, lora_dim] -> [4, 16, 4]
     assert lora_experts.lora_gate_and_up_A.shape == (4, 16, 4)
     # lora_gate_and_up_B: [n_experts, lora_dim, out_dim] -> [4, 4, 64]
-    assert lora_experts.lora_gate_and_up_B.shape == (4, 4, 64) # 32 * 2
+    assert lora_experts.lora_gate_and_up_B.shape == (4, 4, 64)  # 32 * 2
     # lora_down_A: [n_experts, inter_dim, lora_dim] -> [4, 32, 4]
     assert lora_experts.lora_down_A.shape == (4, 32, 4)
     # lora_down_B: [n_experts, lora_dim, out_dim] -> [4, 4, 16]
@@ -96,6 +99,7 @@ def test_grouped_experts_lora_init(moe_config, device):
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_apply_lora_equivalence(moe_config, device):
     """Test that applying LoRA to a model maintains output equivalence upon initialization."""
+
     class MockModel(nn.Module):
         def __init__(self):
             super().__init__()
@@ -127,10 +131,7 @@ def test_apply_lora_equivalence(moe_config, device):
         out_orig = model(x, token_mask, weights, indices)
 
     # Apply LoRA
-    peft_config = PeftConfig(
-        target_modules=["*experts*"],
-        dim=4
-    )
+    peft_config = PeftConfig(target_modules=["*experts*"], dim=4)
     apply_lora_to_linear_modules(model, peft_config)
     model = model.to(device)
     # LoRA output
@@ -167,6 +168,28 @@ def test_grouped_experts_deepep_lora_init(moe_config, device):
     assert lora_experts.lora_gate_and_up_B.requires_grad
 
 
+def test_grouped_experts_deepep_lora_preserves_dispatcher_settings(moe_config):
+    """Test that LoRA wrapping preserves the source expert dispatcher backend."""
+    orig_experts = GroupedExpertsDeepEP(
+        moe_config,
+        dispatcher_backend="hybridep",
+        dispatcher_num_sms=24,
+        dispatcher_share_token_dispatcher=False,
+        dispatcher_async_dispatch=True,
+    )
+    orig_experts.use_torch_mm = True
+    orig_experts.use_mxfp8 = True
+
+    lora_experts = GroupedExpertsDeepEPLoRA(orig_experts, lora_dim=4, alpha=8)
+
+    assert lora_experts.dispatcher_backend == "hybridep"
+    assert lora_experts.dispatcher_num_sms == 24
+    assert lora_experts.dispatcher_share_token_dispatcher is False
+    assert lora_experts.dispatcher_async_dispatch is True
+    assert lora_experts.use_torch_mm is True
+    assert lora_experts.use_mxfp8 is True
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_patch_moe_module(moe_config, device):
     """Test that patch_moe_module correctly wraps the original experts with the appropriate LoRA class."""
@@ -188,6 +211,7 @@ def test_apply_lora_patching_logic(moe_config, device):
     2. Wildcard matching works for MoE modules.
     3. Non-target modules (e.g., standard Linear layers not in target list) are NOT patched.
     """
+
     class MockModel(nn.Module):
         def __init__(self):
             super().__init__()
@@ -195,30 +219,25 @@ def test_apply_lora_patching_logic(moe_config, device):
             self.linear = nn.Linear(16, 16)
 
     model = MockModel().to(device)
-    peft_config = PeftConfig(
-        target_modules=["experts"],
-        dim=4
-    )
+    peft_config = PeftConfig(target_modules=["experts"], dim=4)
 
     count = apply_lora_to_linear_modules(model, peft_config)
     assert count == 1
     assert isinstance(model.experts, GroupedExpertsLoRA)
-    assert isinstance(model.linear, nn.Linear) # Should not be patched
+    assert isinstance(model.linear, nn.Linear)  # Should not be patched
 
     # Test wildcard matching
     model = MockModel().to(device)
-    peft_config = PeftConfig(
-        target_modules=["*experts*"],
-        dim=4
-    )
+    peft_config = PeftConfig(target_modules=["*experts*"], dim=4)
     count = apply_lora_to_linear_modules(model, peft_config)
     assert count == 1
     assert isinstance(model.experts, GroupedExpertsLoRA)
-    assert isinstance(model.linear, nn.Linear) # Should not be patched
+    assert isinstance(model.linear, nn.Linear)  # Should not be patched
 
 
 class MockDeepEPDispatcher:
     """Mock dispatcher that simulates DeepEP's token permutation locally."""
+
     def token_permutation2(self, hidden_states, num_local_tokens, token_probs, token_indices):
         # Simply return the hidden states as if it was a single expert local dispatch
         # To make it compatible with ops.gmm, we need a tokens_per_expert tensor
@@ -229,10 +248,7 @@ class MockDeepEPDispatcher:
         return hidden_states
 
 
-@pytest.mark.skipif(
-    grouped_gemm is None or not torch.cuda.is_available(),
-    reason="Requires grouped_gemm and CUDA"
-)
+@pytest.mark.skipif(grouped_gemm is None or not torch.cuda.is_available(), reason="Requires grouped_gemm and CUDA")
 def test_grouped_experts_deepep_lora_forward_mocked(moe_config, device):
     """
     Test Forward pass of GroupedExpertsDeepEPLoRA using a Mock Dispatcher.
@@ -270,9 +286,7 @@ def test_grouped_experts_deepep_lora_forward_mocked(moe_config, device):
     permuted_probs = torch.ones(num_tokens, device=device).to(dtype)
 
     # Set the same mock on both modules to ensure they see the same "dispatched" data
-    mock_dispatcher.token_permutation2 = MagicMock(
-        return_value=(permuted_x, tokens_per_expert, permuted_probs)
-    )
+    mock_dispatcher.token_permutation2 = MagicMock(return_value=(permuted_x, tokens_per_expert, permuted_probs))
     lora_module.token_dispatcher = mock_dispatcher
     orig_experts.token_dispatcher = mock_dispatcher
 
@@ -452,7 +466,7 @@ def test_lora_with_expert_bias(device):
         norm_topk_prob=False,
         expert_activation="swiglu",
         dtype=torch.float32,
-        expert_bias=True  # Enable bias
+        expert_bias=True,  # Enable bias
     )
 
     orig_experts = GroupedExperts(moe_config).to(device)
@@ -462,8 +476,8 @@ def test_lora_with_expert_bias(device):
     lora_experts = GroupedExpertsLoRA(orig_experts, lora_dim=4, alpha=8).to(device)
 
     # Check that bias parameters exist and are frozen
-    assert hasattr(lora_experts, 'gate_up_proj_bias')
-    assert hasattr(lora_experts, 'down_proj_bias')
+    assert hasattr(lora_experts, "gate_up_proj_bias")
+    assert hasattr(lora_experts, "down_proj_bias")
     assert not lora_experts.gate_up_proj_bias.requires_grad
     assert not lora_experts.down_proj_bias.requires_grad
 
@@ -499,7 +513,7 @@ def test_quick_geglu_activation_with_lora(device):
         expert_activation="quick_geglu",  # Use QuickGEGLU
         activation_alpha=1.702,
         activation_limit=7.0,
-        dtype=torch.float32
+        dtype=torch.float32,
     )
 
     orig_experts = GroupedExperts(moe_config).to(device)
@@ -528,7 +542,7 @@ def test_lora_dtype_conversion(moe_config, device):
         orig_experts.init_weights(buffer_device=device)
 
     # Create LoRA with explicit bfloat16 dtype
-    if device.type == 'cuda' and torch.cuda.is_bf16_supported():
+    if device.type == "cuda" and torch.cuda.is_bf16_supported():
         lora_experts = GroupedExpertsLoRA(orig_experts, lora_dim=4, alpha=8, lora_dtype="bfloat16").to(device)
 
         # Check that LoRA weights have the correct dtype
@@ -565,14 +579,15 @@ def test_lora_backward_pass_values(moe_config, device):
     loss.backward()
 
     # Check that gradients are non-zero
-    assert not torch.allclose(lora_experts.lora_gate_and_up_A.grad, torch.zeros_like(lora_experts.lora_gate_and_up_A.grad))
-    assert not torch.allclose(lora_experts.lora_gate_and_up_B.grad, torch.zeros_like(lora_experts.lora_gate_and_up_B.grad))
+    assert not torch.allclose(
+        lora_experts.lora_gate_and_up_A.grad, torch.zeros_like(lora_experts.lora_gate_and_up_A.grad)
+    )
+    assert not torch.allclose(
+        lora_experts.lora_gate_and_up_B.grad, torch.zeros_like(lora_experts.lora_gate_and_up_B.grad)
+    )
 
 
-@pytest.mark.skipif(
-    grouped_gemm is None or not torch.cuda.is_available(),
-    reason="Requires grouped_gemm and CUDA"
-)
+@pytest.mark.skipif(grouped_gemm is None or not torch.cuda.is_available(), reason="Requires grouped_gemm and CUDA")
 def test_deepep_lora_zero_tokens(moe_config, device):
     """Test DeepEP LoRA forward pass with zero tokens routed to experts."""
     moe_config.n_routed_experts = 4
@@ -598,9 +613,7 @@ def test_deepep_lora_zero_tokens(moe_config, device):
     permuted_x = torch.randn(num_tokens, 16, device=device).to(dtype)
     permuted_probs = torch.ones(num_tokens, device=device).to(dtype)
 
-    mock_dispatcher.token_permutation2 = MagicMock(
-        return_value=(permuted_x, tokens_per_expert, permuted_probs)
-    )
+    mock_dispatcher.token_permutation2 = MagicMock(return_value=(permuted_x, tokens_per_expert, permuted_probs))
     lora_module.token_dispatcher = mock_dispatcher
 
     x = torch.randn(num_tokens, 16, device=device).to(dtype)
@@ -628,6 +641,7 @@ def test_patch_moe_module_rejects_te_experts(moe_config, device):
 @pytest.mark.skipif(not HAS_TE, reason="Transformer Engine required")
 def test_apply_lora_rejects_te_experts(moe_config, device):
     """Test that apply_lora_to_linear_modules raises NotImplementedError for GroupedExpertsTE."""
+
     class MockModel(nn.Module):
         def __init__(self):
             super().__init__()
@@ -881,10 +895,7 @@ def test_grouped_experts_lora_forward_torch_mm_with_bias(device):
     assert not torch.isnan(out).any()
 
 
-@pytest.mark.skipif(
-    grouped_gemm is None or not torch.cuda.is_available(),
-    reason="Requires grouped_gemm and CUDA"
-)
+@pytest.mark.skipif(grouped_gemm is None or not torch.cuda.is_available(), reason="Requires grouped_gemm and CUDA")
 def test_deepep_lora_forward_torch_mm(moe_config, device):
     """Test DeepEP LoRA forward with use_torch_mm=True via mock dispatcher."""
     moe_config.n_routed_experts = 4
@@ -913,9 +924,7 @@ def test_deepep_lora_forward_torch_mm(moe_config, device):
     permuted_x = torch.randn(num_tokens, 16, device=device).to(dtype)
     permuted_probs = torch.ones(num_tokens, device=device).to(dtype)
 
-    mock_dispatcher.token_permutation2 = MagicMock(
-        return_value=(permuted_x, tokens_per_expert, permuted_probs)
-    )
+    mock_dispatcher.token_permutation2 = MagicMock(return_value=(permuted_x, tokens_per_expert, permuted_probs))
     lora_module.token_dispatcher = mock_dispatcher
 
     x = torch.randn(num_tokens, 16, device=device).to(dtype)
@@ -928,10 +937,7 @@ def test_deepep_lora_forward_torch_mm(moe_config, device):
     assert not torch.isnan(out).any()
 
 
-@pytest.mark.skipif(
-    grouped_gemm is None or not torch.cuda.is_available(),
-    reason="Requires grouped_gemm and CUDA"
-)
+@pytest.mark.skipif(grouped_gemm is None or not torch.cuda.is_available(), reason="Requires grouped_gemm and CUDA")
 def test_deepep_lora_forward_torch_mm_equivalence(moe_config, device):
     """With zero-init B, torch_mm and grouped_gemm paths should match for DeepEP LoRA."""
     moe_config.n_routed_experts = 4
@@ -967,13 +973,9 @@ def test_deepep_lora_forward_torch_mm_equivalence(moe_config, device):
     permuted_probs = torch.ones(num_tokens, device=device).to(dtype)
 
     mock_dispatcher_gg = MockDeepEPDispatcher()
-    mock_dispatcher_gg.token_permutation2 = MagicMock(
-        return_value=(permuted_x, tokens_per_expert, permuted_probs)
-    )
+    mock_dispatcher_gg.token_permutation2 = MagicMock(return_value=(permuted_x, tokens_per_expert, permuted_probs))
     mock_dispatcher_mm = MockDeepEPDispatcher()
-    mock_dispatcher_mm.token_permutation2 = MagicMock(
-        return_value=(permuted_x, tokens_per_expert, permuted_probs)
-    )
+    mock_dispatcher_mm.token_permutation2 = MagicMock(return_value=(permuted_x, tokens_per_expert, permuted_probs))
     lora_gg.token_dispatcher = mock_dispatcher_gg
     lora_mm.token_dispatcher = mock_dispatcher_mm
 
@@ -996,7 +998,7 @@ def test_lora_dtype_string(moe_config, device):
     with torch.no_grad():
         orig_experts.init_weights(buffer_device=device)
 
-    if device.type == 'cuda' and torch.cuda.is_bf16_supported():
+    if device.type == "cuda" and torch.cuda.is_bf16_supported():
         lora_experts = GroupedExpertsLoRA(orig_experts, lora_dim=4, alpha=8, lora_dtype="bfloat16").to(device)
         assert lora_experts.lora_gate_and_up_A.dtype == torch.bfloat16
 
@@ -1010,7 +1012,7 @@ def test_deepep_lora_dtype_string(moe_config, device):
     orig_experts.n_routed_experts = 4
     orig_experts.ep_size = 1
 
-    if device.type == 'cuda' and torch.cuda.is_bf16_supported():
+    if device.type == "cuda" and torch.cuda.is_bf16_supported():
         lora_module = GroupedExpertsDeepEPLoRA(orig_experts, lora_dim=4, lora_dtype="bfloat16").to(device)
         assert lora_module.lora_gate_and_up_A.dtype == torch.bfloat16
 
@@ -1035,10 +1037,7 @@ def test_deepep_lora_kaiming_init(moe_config, device):
     assert not torch.allclose(lora_module.lora_down_A, torch.zeros_like(lora_module.lora_down_A))
 
 
-@pytest.mark.skipif(
-    grouped_gemm is None or not torch.cuda.is_available(),
-    reason="Requires grouped_gemm and CUDA"
-)
+@pytest.mark.skipif(grouped_gemm is None or not torch.cuda.is_available(), reason="Requires grouped_gemm and CUDA")
 def test_deepep_lora_forward_torch_mm_with_bias(device):
     """Test DeepEP LoRA forward with use_torch_mm=True and expert_bias=True."""
     config = MoEConfig(
@@ -1078,9 +1077,7 @@ def test_deepep_lora_forward_torch_mm_with_bias(device):
     permuted_x = torch.randn(num_tokens, 16, device=device).to(dtype)
     permuted_probs = torch.ones(num_tokens, device=device).to(dtype)
 
-    mock_dispatcher.token_permutation2 = MagicMock(
-        return_value=(permuted_x, tokens_per_expert, permuted_probs)
-    )
+    mock_dispatcher.token_permutation2 = MagicMock(return_value=(permuted_x, tokens_per_expert, permuted_probs))
     lora_module.token_dispatcher = mock_dispatcher
 
     x = torch.randn(num_tokens, 16, device=device).to(dtype)
@@ -1093,10 +1090,7 @@ def test_deepep_lora_forward_torch_mm_with_bias(device):
     assert not torch.isnan(out).any()
 
 
-@pytest.mark.skipif(
-    grouped_gemm is None or not torch.cuda.is_available(),
-    reason="Requires grouped_gemm and CUDA"
-)
+@pytest.mark.skipif(grouped_gemm is None or not torch.cuda.is_available(), reason="Requires grouped_gemm and CUDA")
 def test_deepep_lora_forward_grouped_gemm_with_bias(device):
     """Test DeepEP LoRA forward with use_torch_mm=False (grouped_gemm) and expert_bias=True."""
     config = MoEConfig(
@@ -1135,9 +1129,7 @@ def test_deepep_lora_forward_grouped_gemm_with_bias(device):
     permuted_x = torch.randn(num_tokens, 16, device=device).to(dtype)
     permuted_probs = torch.ones(num_tokens, device=device).to(dtype)
 
-    mock_dispatcher.token_permutation2 = MagicMock(
-        return_value=(permuted_x, tokens_per_expert, permuted_probs)
-    )
+    mock_dispatcher.token_permutation2 = MagicMock(return_value=(permuted_x, tokens_per_expert, permuted_probs))
     lora_module.token_dispatcher = mock_dispatcher
 
     x = torch.randn(num_tokens, 16, device=device).to(dtype)
@@ -1156,6 +1148,7 @@ def test_deepep_lora_forward_grouped_gemm_with_bias(device):
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_moe_rank_scaling_basic(moe_config, device):
     """MoE experts get dim // n_activated_experts; Linear keeps full dim."""
+
     class MockModel(nn.Module):
         def __init__(self):
             super().__init__()
@@ -1185,6 +1178,7 @@ def test_moe_rank_scaling_basic(moe_config, device):
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_moe_rank_scaling_default_off(moe_config, device):
     """With moe_rank_scaling=False (default), both get the full dim."""
+
     class MockModel(nn.Module):
         def __init__(self):
             super().__init__()
@@ -1257,6 +1251,7 @@ def test_moe_rank_scaling_floor_division_warning(device):
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_moe_rank_scaling_dim_too_small(moe_config, device):
     """When dim < n_activated_experts, raise ValueError."""
+
     class MockModel(nn.Module):
         def __init__(self):
             super().__init__()
@@ -1279,6 +1274,7 @@ def test_moe_rank_scaling_dim_too_small(moe_config, device):
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_moe_rank_scaling_output_equivalence(moe_config, device):
     """With zero-init B, scaled-rank MoE LoRA should produce the same output as the original model."""
+
     class MockModel(nn.Module):
         def __init__(self):
             super().__init__()

--- a/tests/unit_tests/_peft/test_lora_experts.py
+++ b/tests/unit_tests/_peft/test_lora_experts.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import MagicMock, patch
-
 import pytest
 import torch
 import torch.nn as nn
-
+from unittest.mock import MagicMock, patch
 try:
     import grouped_gemm
 except ImportError:
@@ -25,19 +23,14 @@ except ImportError:
 
 try:
     import transformer_engine  # noqa: F401
-
     HAS_TE = True
 except ImportError:
     HAS_TE = False
 
-from nemo_automodel.components._peft.lora import PeftConfig, apply_lora_to_linear_modules, patch_moe_module
-from nemo_automodel.components._peft.lora_experts import (
-    GroupedExpertsDeepEPLoRA,
-    GroupedExpertsLoRA,
-    _pad_lora_rank_for_grouped_mm,
-)
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.layers import GroupedExperts, GroupedExpertsDeepEP, GroupedExpertsTE
+from nemo_automodel.components._peft.lora_experts import GroupedExpertsLoRA, GroupedExpertsDeepEPLoRA
+from nemo_automodel.components._peft.lora import patch_moe_module, apply_lora_to_linear_modules, PeftConfig
 
 
 @pytest.fixture
@@ -65,7 +58,7 @@ def moe_config():
         moe_inter_dim=32,
         norm_topk_prob=False,
         expert_activation="swiglu",
-        dtype=torch.float32,
+        dtype=torch.float32
     )
 
 
@@ -87,7 +80,7 @@ def test_grouped_experts_lora_init(moe_config, device):
     # lora_gate_and_up_A: [n_experts, in_dim, lora_dim] -> [4, 16, 4]
     assert lora_experts.lora_gate_and_up_A.shape == (4, 16, 4)
     # lora_gate_and_up_B: [n_experts, lora_dim, out_dim] -> [4, 4, 64]
-    assert lora_experts.lora_gate_and_up_B.shape == (4, 4, 64)  # 32 * 2
+    assert lora_experts.lora_gate_and_up_B.shape == (4, 4, 64) # 32 * 2
     # lora_down_A: [n_experts, inter_dim, lora_dim] -> [4, 32, 4]
     assert lora_experts.lora_down_A.shape == (4, 32, 4)
     # lora_down_B: [n_experts, lora_dim, out_dim] -> [4, 4, 16]
@@ -103,7 +96,6 @@ def test_grouped_experts_lora_init(moe_config, device):
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_apply_lora_equivalence(moe_config, device):
     """Test that applying LoRA to a model maintains output equivalence upon initialization."""
-
     class MockModel(nn.Module):
         def __init__(self):
             super().__init__()
@@ -135,7 +127,10 @@ def test_apply_lora_equivalence(moe_config, device):
         out_orig = model(x, token_mask, weights, indices)
 
     # Apply LoRA
-    peft_config = PeftConfig(target_modules=["*experts*"], dim=4)
+    peft_config = PeftConfig(
+        target_modules=["*experts*"],
+        dim=4
+    )
     apply_lora_to_linear_modules(model, peft_config)
     model = model.to(device)
     # LoRA output
@@ -172,43 +167,6 @@ def test_grouped_experts_deepep_lora_init(moe_config, device):
     assert lora_experts.lora_gate_and_up_B.requires_grad
 
 
-def test_grouped_experts_deepep_lora_preserves_dispatcher_settings(moe_config):
-    """Test that LoRA wrapping preserves the source expert dispatcher backend."""
-    orig_experts = GroupedExpertsDeepEP(
-        moe_config,
-        dispatcher_backend="hybridep",
-        dispatcher_num_sms=24,
-        dispatcher_share_token_dispatcher=False,
-        dispatcher_async_dispatch=True,
-    )
-    orig_experts.use_torch_mm = True
-    orig_experts.use_mxfp8 = True
-
-    lora_experts = GroupedExpertsDeepEPLoRA(orig_experts, lora_dim=4, alpha=8)
-
-    assert lora_experts.dispatcher_backend == "hybridep"
-    assert lora_experts.dispatcher_num_sms == 24
-    assert lora_experts.dispatcher_share_token_dispatcher is False
-    assert lora_experts.dispatcher_async_dispatch is True
-    assert lora_experts.use_torch_mm is True
-    assert lora_experts.use_mxfp8 is True
-
-
-def test_pad_lora_rank_for_grouped_mm_aligns_bf16_rank():
-    """Test rank padding for torch._grouped_mm stride alignment."""
-    lora_A = torch.randn(2, 16, 4, dtype=torch.bfloat16)
-    lora_B = torch.randn(2, 4, 32, dtype=torch.bfloat16)
-
-    padded_A, padded_B = _pad_lora_rank_for_grouped_mm(lora_A, lora_B)
-
-    assert padded_A.shape == (2, 16, 8)
-    assert padded_B.shape == (2, 8, 32)
-    assert torch.equal(padded_A[..., :4], lora_A)
-    assert torch.equal(padded_B[:, :4], lora_B)
-    assert torch.count_nonzero(padded_A[..., 4:]) == 0
-    assert torch.count_nonzero(padded_B[:, 4:]) == 0
-
-
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_patch_moe_module(moe_config, device):
     """Test that patch_moe_module correctly wraps the original experts with the appropriate LoRA class."""
@@ -230,7 +188,6 @@ def test_apply_lora_patching_logic(moe_config, device):
     2. Wildcard matching works for MoE modules.
     3. Non-target modules (e.g., standard Linear layers not in target list) are NOT patched.
     """
-
     class MockModel(nn.Module):
         def __init__(self):
             super().__init__()
@@ -238,25 +195,30 @@ def test_apply_lora_patching_logic(moe_config, device):
             self.linear = nn.Linear(16, 16)
 
     model = MockModel().to(device)
-    peft_config = PeftConfig(target_modules=["experts"], dim=4)
+    peft_config = PeftConfig(
+        target_modules=["experts"],
+        dim=4
+    )
 
     count = apply_lora_to_linear_modules(model, peft_config)
     assert count == 1
     assert isinstance(model.experts, GroupedExpertsLoRA)
-    assert isinstance(model.linear, nn.Linear)  # Should not be patched
+    assert isinstance(model.linear, nn.Linear) # Should not be patched
 
     # Test wildcard matching
     model = MockModel().to(device)
-    peft_config = PeftConfig(target_modules=["*experts*"], dim=4)
+    peft_config = PeftConfig(
+        target_modules=["*experts*"],
+        dim=4
+    )
     count = apply_lora_to_linear_modules(model, peft_config)
     assert count == 1
     assert isinstance(model.experts, GroupedExpertsLoRA)
-    assert isinstance(model.linear, nn.Linear)  # Should not be patched
+    assert isinstance(model.linear, nn.Linear) # Should not be patched
 
 
 class MockDeepEPDispatcher:
     """Mock dispatcher that simulates DeepEP's token permutation locally."""
-
     def token_permutation2(self, hidden_states, num_local_tokens, token_probs, token_indices):
         # Simply return the hidden states as if it was a single expert local dispatch
         # To make it compatible with ops.gmm, we need a tokens_per_expert tensor
@@ -267,7 +229,10 @@ class MockDeepEPDispatcher:
         return hidden_states
 
 
-@pytest.mark.skipif(grouped_gemm is None or not torch.cuda.is_available(), reason="Requires grouped_gemm and CUDA")
+@pytest.mark.skipif(
+    grouped_gemm is None or not torch.cuda.is_available(),
+    reason="Requires grouped_gemm and CUDA"
+)
 def test_grouped_experts_deepep_lora_forward_mocked(moe_config, device):
     """
     Test Forward pass of GroupedExpertsDeepEPLoRA using a Mock Dispatcher.
@@ -305,7 +270,9 @@ def test_grouped_experts_deepep_lora_forward_mocked(moe_config, device):
     permuted_probs = torch.ones(num_tokens, device=device).to(dtype)
 
     # Set the same mock on both modules to ensure they see the same "dispatched" data
-    mock_dispatcher.token_permutation2 = MagicMock(return_value=(permuted_x, tokens_per_expert, permuted_probs))
+    mock_dispatcher.token_permutation2 = MagicMock(
+        return_value=(permuted_x, tokens_per_expert, permuted_probs)
+    )
     lora_module.token_dispatcher = mock_dispatcher
     orig_experts.token_dispatcher = mock_dispatcher
 
@@ -485,7 +452,7 @@ def test_lora_with_expert_bias(device):
         norm_topk_prob=False,
         expert_activation="swiglu",
         dtype=torch.float32,
-        expert_bias=True,  # Enable bias
+        expert_bias=True  # Enable bias
     )
 
     orig_experts = GroupedExperts(moe_config).to(device)
@@ -495,8 +462,8 @@ def test_lora_with_expert_bias(device):
     lora_experts = GroupedExpertsLoRA(orig_experts, lora_dim=4, alpha=8).to(device)
 
     # Check that bias parameters exist and are frozen
-    assert hasattr(lora_experts, "gate_up_proj_bias")
-    assert hasattr(lora_experts, "down_proj_bias")
+    assert hasattr(lora_experts, 'gate_up_proj_bias')
+    assert hasattr(lora_experts, 'down_proj_bias')
     assert not lora_experts.gate_up_proj_bias.requires_grad
     assert not lora_experts.down_proj_bias.requires_grad
 
@@ -532,7 +499,7 @@ def test_quick_geglu_activation_with_lora(device):
         expert_activation="quick_geglu",  # Use QuickGEGLU
         activation_alpha=1.702,
         activation_limit=7.0,
-        dtype=torch.float32,
+        dtype=torch.float32
     )
 
     orig_experts = GroupedExperts(moe_config).to(device)
@@ -561,7 +528,7 @@ def test_lora_dtype_conversion(moe_config, device):
         orig_experts.init_weights(buffer_device=device)
 
     # Create LoRA with explicit bfloat16 dtype
-    if device.type == "cuda" and torch.cuda.is_bf16_supported():
+    if device.type == 'cuda' and torch.cuda.is_bf16_supported():
         lora_experts = GroupedExpertsLoRA(orig_experts, lora_dim=4, alpha=8, lora_dtype="bfloat16").to(device)
 
         # Check that LoRA weights have the correct dtype
@@ -598,15 +565,14 @@ def test_lora_backward_pass_values(moe_config, device):
     loss.backward()
 
     # Check that gradients are non-zero
-    assert not torch.allclose(
-        lora_experts.lora_gate_and_up_A.grad, torch.zeros_like(lora_experts.lora_gate_and_up_A.grad)
-    )
-    assert not torch.allclose(
-        lora_experts.lora_gate_and_up_B.grad, torch.zeros_like(lora_experts.lora_gate_and_up_B.grad)
-    )
+    assert not torch.allclose(lora_experts.lora_gate_and_up_A.grad, torch.zeros_like(lora_experts.lora_gate_and_up_A.grad))
+    assert not torch.allclose(lora_experts.lora_gate_and_up_B.grad, torch.zeros_like(lora_experts.lora_gate_and_up_B.grad))
 
 
-@pytest.mark.skipif(grouped_gemm is None or not torch.cuda.is_available(), reason="Requires grouped_gemm and CUDA")
+@pytest.mark.skipif(
+    grouped_gemm is None or not torch.cuda.is_available(),
+    reason="Requires grouped_gemm and CUDA"
+)
 def test_deepep_lora_zero_tokens(moe_config, device):
     """Test DeepEP LoRA forward pass with zero tokens routed to experts."""
     moe_config.n_routed_experts = 4
@@ -632,7 +598,9 @@ def test_deepep_lora_zero_tokens(moe_config, device):
     permuted_x = torch.randn(num_tokens, 16, device=device).to(dtype)
     permuted_probs = torch.ones(num_tokens, device=device).to(dtype)
 
-    mock_dispatcher.token_permutation2 = MagicMock(return_value=(permuted_x, tokens_per_expert, permuted_probs))
+    mock_dispatcher.token_permutation2 = MagicMock(
+        return_value=(permuted_x, tokens_per_expert, permuted_probs)
+    )
     lora_module.token_dispatcher = mock_dispatcher
 
     x = torch.randn(num_tokens, 16, device=device).to(dtype)
@@ -660,7 +628,6 @@ def test_patch_moe_module_rejects_te_experts(moe_config, device):
 @pytest.mark.skipif(not HAS_TE, reason="Transformer Engine required")
 def test_apply_lora_rejects_te_experts(moe_config, device):
     """Test that apply_lora_to_linear_modules raises NotImplementedError for GroupedExpertsTE."""
-
     class MockModel(nn.Module):
         def __init__(self):
             super().__init__()
@@ -914,7 +881,10 @@ def test_grouped_experts_lora_forward_torch_mm_with_bias(device):
     assert not torch.isnan(out).any()
 
 
-@pytest.mark.skipif(grouped_gemm is None or not torch.cuda.is_available(), reason="Requires grouped_gemm and CUDA")
+@pytest.mark.skipif(
+    grouped_gemm is None or not torch.cuda.is_available(),
+    reason="Requires grouped_gemm and CUDA"
+)
 def test_deepep_lora_forward_torch_mm(moe_config, device):
     """Test DeepEP LoRA forward with use_torch_mm=True via mock dispatcher."""
     moe_config.n_routed_experts = 4
@@ -943,7 +913,9 @@ def test_deepep_lora_forward_torch_mm(moe_config, device):
     permuted_x = torch.randn(num_tokens, 16, device=device).to(dtype)
     permuted_probs = torch.ones(num_tokens, device=device).to(dtype)
 
-    mock_dispatcher.token_permutation2 = MagicMock(return_value=(permuted_x, tokens_per_expert, permuted_probs))
+    mock_dispatcher.token_permutation2 = MagicMock(
+        return_value=(permuted_x, tokens_per_expert, permuted_probs)
+    )
     lora_module.token_dispatcher = mock_dispatcher
 
     x = torch.randn(num_tokens, 16, device=device).to(dtype)
@@ -956,7 +928,10 @@ def test_deepep_lora_forward_torch_mm(moe_config, device):
     assert not torch.isnan(out).any()
 
 
-@pytest.mark.skipif(grouped_gemm is None or not torch.cuda.is_available(), reason="Requires grouped_gemm and CUDA")
+@pytest.mark.skipif(
+    grouped_gemm is None or not torch.cuda.is_available(),
+    reason="Requires grouped_gemm and CUDA"
+)
 def test_deepep_lora_forward_torch_mm_equivalence(moe_config, device):
     """With zero-init B, torch_mm and grouped_gemm paths should match for DeepEP LoRA."""
     moe_config.n_routed_experts = 4
@@ -992,9 +967,13 @@ def test_deepep_lora_forward_torch_mm_equivalence(moe_config, device):
     permuted_probs = torch.ones(num_tokens, device=device).to(dtype)
 
     mock_dispatcher_gg = MockDeepEPDispatcher()
-    mock_dispatcher_gg.token_permutation2 = MagicMock(return_value=(permuted_x, tokens_per_expert, permuted_probs))
+    mock_dispatcher_gg.token_permutation2 = MagicMock(
+        return_value=(permuted_x, tokens_per_expert, permuted_probs)
+    )
     mock_dispatcher_mm = MockDeepEPDispatcher()
-    mock_dispatcher_mm.token_permutation2 = MagicMock(return_value=(permuted_x, tokens_per_expert, permuted_probs))
+    mock_dispatcher_mm.token_permutation2 = MagicMock(
+        return_value=(permuted_x, tokens_per_expert, permuted_probs)
+    )
     lora_gg.token_dispatcher = mock_dispatcher_gg
     lora_mm.token_dispatcher = mock_dispatcher_mm
 
@@ -1017,7 +996,7 @@ def test_lora_dtype_string(moe_config, device):
     with torch.no_grad():
         orig_experts.init_weights(buffer_device=device)
 
-    if device.type == "cuda" and torch.cuda.is_bf16_supported():
+    if device.type == 'cuda' and torch.cuda.is_bf16_supported():
         lora_experts = GroupedExpertsLoRA(orig_experts, lora_dim=4, alpha=8, lora_dtype="bfloat16").to(device)
         assert lora_experts.lora_gate_and_up_A.dtype == torch.bfloat16
 
@@ -1031,7 +1010,7 @@ def test_deepep_lora_dtype_string(moe_config, device):
     orig_experts.n_routed_experts = 4
     orig_experts.ep_size = 1
 
-    if device.type == "cuda" and torch.cuda.is_bf16_supported():
+    if device.type == 'cuda' and torch.cuda.is_bf16_supported():
         lora_module = GroupedExpertsDeepEPLoRA(orig_experts, lora_dim=4, lora_dtype="bfloat16").to(device)
         assert lora_module.lora_gate_and_up_A.dtype == torch.bfloat16
 
@@ -1056,7 +1035,10 @@ def test_deepep_lora_kaiming_init(moe_config, device):
     assert not torch.allclose(lora_module.lora_down_A, torch.zeros_like(lora_module.lora_down_A))
 
 
-@pytest.mark.skipif(grouped_gemm is None or not torch.cuda.is_available(), reason="Requires grouped_gemm and CUDA")
+@pytest.mark.skipif(
+    grouped_gemm is None or not torch.cuda.is_available(),
+    reason="Requires grouped_gemm and CUDA"
+)
 def test_deepep_lora_forward_torch_mm_with_bias(device):
     """Test DeepEP LoRA forward with use_torch_mm=True and expert_bias=True."""
     config = MoEConfig(
@@ -1096,7 +1078,9 @@ def test_deepep_lora_forward_torch_mm_with_bias(device):
     permuted_x = torch.randn(num_tokens, 16, device=device).to(dtype)
     permuted_probs = torch.ones(num_tokens, device=device).to(dtype)
 
-    mock_dispatcher.token_permutation2 = MagicMock(return_value=(permuted_x, tokens_per_expert, permuted_probs))
+    mock_dispatcher.token_permutation2 = MagicMock(
+        return_value=(permuted_x, tokens_per_expert, permuted_probs)
+    )
     lora_module.token_dispatcher = mock_dispatcher
 
     x = torch.randn(num_tokens, 16, device=device).to(dtype)
@@ -1109,7 +1093,10 @@ def test_deepep_lora_forward_torch_mm_with_bias(device):
     assert not torch.isnan(out).any()
 
 
-@pytest.mark.skipif(grouped_gemm is None or not torch.cuda.is_available(), reason="Requires grouped_gemm and CUDA")
+@pytest.mark.skipif(
+    grouped_gemm is None or not torch.cuda.is_available(),
+    reason="Requires grouped_gemm and CUDA"
+)
 def test_deepep_lora_forward_grouped_gemm_with_bias(device):
     """Test DeepEP LoRA forward with use_torch_mm=False (grouped_gemm) and expert_bias=True."""
     config = MoEConfig(
@@ -1148,7 +1135,9 @@ def test_deepep_lora_forward_grouped_gemm_with_bias(device):
     permuted_x = torch.randn(num_tokens, 16, device=device).to(dtype)
     permuted_probs = torch.ones(num_tokens, device=device).to(dtype)
 
-    mock_dispatcher.token_permutation2 = MagicMock(return_value=(permuted_x, tokens_per_expert, permuted_probs))
+    mock_dispatcher.token_permutation2 = MagicMock(
+        return_value=(permuted_x, tokens_per_expert, permuted_probs)
+    )
     lora_module.token_dispatcher = mock_dispatcher
 
     x = torch.randn(num_tokens, 16, device=device).to(dtype)
@@ -1167,7 +1156,6 @@ def test_deepep_lora_forward_grouped_gemm_with_bias(device):
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_moe_rank_scaling_basic(moe_config, device):
     """MoE experts get dim // n_activated_experts; Linear keeps full dim."""
-
     class MockModel(nn.Module):
         def __init__(self):
             super().__init__()
@@ -1197,7 +1185,6 @@ def test_moe_rank_scaling_basic(moe_config, device):
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_moe_rank_scaling_default_off(moe_config, device):
     """With moe_rank_scaling=False (default), both get the full dim."""
-
     class MockModel(nn.Module):
         def __init__(self):
             super().__init__()
@@ -1270,7 +1257,6 @@ def test_moe_rank_scaling_floor_division_warning(device):
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_moe_rank_scaling_dim_too_small(moe_config, device):
     """When dim < n_activated_experts, raise ValueError."""
-
     class MockModel(nn.Module):
         def __init__(self):
             super().__init__()
@@ -1293,7 +1279,6 @@ def test_moe_rank_scaling_dim_too_small(moe_config, device):
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_moe_rank_scaling_output_equivalence(moe_config, device):
     """With zero-init B, scaled-rank MoE LoRA should produce the same output as the original model."""
-
     class MockModel(nn.Module):
         def __init__(self):
             super().__init__()

--- a/tests/unit_tests/_peft/test_lora_experts.py
+++ b/tests/unit_tests/_peft/test_lora_experts.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 import torch
 import torch.nn as nn
-from unittest.mock import MagicMock, patch
+
 try:
     import grouped_gemm
 except ImportError:
@@ -23,14 +25,19 @@ except ImportError:
 
 try:
     import transformer_engine  # noqa: F401
+
     HAS_TE = True
 except ImportError:
     HAS_TE = False
 
+from nemo_automodel.components._peft.lora import PeftConfig, apply_lora_to_linear_modules, patch_moe_module
+from nemo_automodel.components._peft.lora_experts import (
+    GroupedExpertsDeepEPLoRA,
+    GroupedExpertsLoRA,
+    _pad_lora_rank_for_grouped_mm,
+)
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.layers import GroupedExperts, GroupedExpertsDeepEP, GroupedExpertsTE
-from nemo_automodel.components._peft.lora_experts import GroupedExpertsLoRA, GroupedExpertsDeepEPLoRA
-from nemo_automodel.components._peft.lora import patch_moe_module, apply_lora_to_linear_modules, PeftConfig
 
 
 @pytest.fixture
@@ -58,7 +65,7 @@ def moe_config():
         moe_inter_dim=32,
         norm_topk_prob=False,
         expert_activation="swiglu",
-        dtype=torch.float32
+        dtype=torch.float32,
     )
 
 
@@ -80,7 +87,7 @@ def test_grouped_experts_lora_init(moe_config, device):
     # lora_gate_and_up_A: [n_experts, in_dim, lora_dim] -> [4, 16, 4]
     assert lora_experts.lora_gate_and_up_A.shape == (4, 16, 4)
     # lora_gate_and_up_B: [n_experts, lora_dim, out_dim] -> [4, 4, 64]
-    assert lora_experts.lora_gate_and_up_B.shape == (4, 4, 64) # 32 * 2
+    assert lora_experts.lora_gate_and_up_B.shape == (4, 4, 64)  # 32 * 2
     # lora_down_A: [n_experts, inter_dim, lora_dim] -> [4, 32, 4]
     assert lora_experts.lora_down_A.shape == (4, 32, 4)
     # lora_down_B: [n_experts, lora_dim, out_dim] -> [4, 4, 16]
@@ -96,6 +103,7 @@ def test_grouped_experts_lora_init(moe_config, device):
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_apply_lora_equivalence(moe_config, device):
     """Test that applying LoRA to a model maintains output equivalence upon initialization."""
+
     class MockModel(nn.Module):
         def __init__(self):
             super().__init__()
@@ -127,10 +135,7 @@ def test_apply_lora_equivalence(moe_config, device):
         out_orig = model(x, token_mask, weights, indices)
 
     # Apply LoRA
-    peft_config = PeftConfig(
-        target_modules=["*experts*"],
-        dim=4
-    )
+    peft_config = PeftConfig(target_modules=["*experts*"], dim=4)
     apply_lora_to_linear_modules(model, peft_config)
     model = model.to(device)
     # LoRA output
@@ -167,6 +172,43 @@ def test_grouped_experts_deepep_lora_init(moe_config, device):
     assert lora_experts.lora_gate_and_up_B.requires_grad
 
 
+def test_grouped_experts_deepep_lora_preserves_dispatcher_settings(moe_config):
+    """Test that LoRA wrapping preserves the source expert dispatcher backend."""
+    orig_experts = GroupedExpertsDeepEP(
+        moe_config,
+        dispatcher_backend="hybridep",
+        dispatcher_num_sms=24,
+        dispatcher_share_token_dispatcher=False,
+        dispatcher_async_dispatch=True,
+    )
+    orig_experts.use_torch_mm = True
+    orig_experts.use_mxfp8 = True
+
+    lora_experts = GroupedExpertsDeepEPLoRA(orig_experts, lora_dim=4, alpha=8)
+
+    assert lora_experts.dispatcher_backend == "hybridep"
+    assert lora_experts.dispatcher_num_sms == 24
+    assert lora_experts.dispatcher_share_token_dispatcher is False
+    assert lora_experts.dispatcher_async_dispatch is True
+    assert lora_experts.use_torch_mm is True
+    assert lora_experts.use_mxfp8 is True
+
+
+def test_pad_lora_rank_for_grouped_mm_aligns_bf16_rank():
+    """Test rank padding for torch._grouped_mm stride alignment."""
+    lora_A = torch.randn(2, 16, 4, dtype=torch.bfloat16)
+    lora_B = torch.randn(2, 4, 32, dtype=torch.bfloat16)
+
+    padded_A, padded_B = _pad_lora_rank_for_grouped_mm(lora_A, lora_B)
+
+    assert padded_A.shape == (2, 16, 8)
+    assert padded_B.shape == (2, 8, 32)
+    assert torch.equal(padded_A[..., :4], lora_A)
+    assert torch.equal(padded_B[:, :4], lora_B)
+    assert torch.count_nonzero(padded_A[..., 4:]) == 0
+    assert torch.count_nonzero(padded_B[:, 4:]) == 0
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_patch_moe_module(moe_config, device):
     """Test that patch_moe_module correctly wraps the original experts with the appropriate LoRA class."""
@@ -188,6 +230,7 @@ def test_apply_lora_patching_logic(moe_config, device):
     2. Wildcard matching works for MoE modules.
     3. Non-target modules (e.g., standard Linear layers not in target list) are NOT patched.
     """
+
     class MockModel(nn.Module):
         def __init__(self):
             super().__init__()
@@ -195,30 +238,25 @@ def test_apply_lora_patching_logic(moe_config, device):
             self.linear = nn.Linear(16, 16)
 
     model = MockModel().to(device)
-    peft_config = PeftConfig(
-        target_modules=["experts"],
-        dim=4
-    )
+    peft_config = PeftConfig(target_modules=["experts"], dim=4)
 
     count = apply_lora_to_linear_modules(model, peft_config)
     assert count == 1
     assert isinstance(model.experts, GroupedExpertsLoRA)
-    assert isinstance(model.linear, nn.Linear) # Should not be patched
+    assert isinstance(model.linear, nn.Linear)  # Should not be patched
 
     # Test wildcard matching
     model = MockModel().to(device)
-    peft_config = PeftConfig(
-        target_modules=["*experts*"],
-        dim=4
-    )
+    peft_config = PeftConfig(target_modules=["*experts*"], dim=4)
     count = apply_lora_to_linear_modules(model, peft_config)
     assert count == 1
     assert isinstance(model.experts, GroupedExpertsLoRA)
-    assert isinstance(model.linear, nn.Linear) # Should not be patched
+    assert isinstance(model.linear, nn.Linear)  # Should not be patched
 
 
 class MockDeepEPDispatcher:
     """Mock dispatcher that simulates DeepEP's token permutation locally."""
+
     def token_permutation2(self, hidden_states, num_local_tokens, token_probs, token_indices):
         # Simply return the hidden states as if it was a single expert local dispatch
         # To make it compatible with ops.gmm, we need a tokens_per_expert tensor
@@ -229,10 +267,7 @@ class MockDeepEPDispatcher:
         return hidden_states
 
 
-@pytest.mark.skipif(
-    grouped_gemm is None or not torch.cuda.is_available(),
-    reason="Requires grouped_gemm and CUDA"
-)
+@pytest.mark.skipif(grouped_gemm is None or not torch.cuda.is_available(), reason="Requires grouped_gemm and CUDA")
 def test_grouped_experts_deepep_lora_forward_mocked(moe_config, device):
     """
     Test Forward pass of GroupedExpertsDeepEPLoRA using a Mock Dispatcher.
@@ -270,9 +305,7 @@ def test_grouped_experts_deepep_lora_forward_mocked(moe_config, device):
     permuted_probs = torch.ones(num_tokens, device=device).to(dtype)
 
     # Set the same mock on both modules to ensure they see the same "dispatched" data
-    mock_dispatcher.token_permutation2 = MagicMock(
-        return_value=(permuted_x, tokens_per_expert, permuted_probs)
-    )
+    mock_dispatcher.token_permutation2 = MagicMock(return_value=(permuted_x, tokens_per_expert, permuted_probs))
     lora_module.token_dispatcher = mock_dispatcher
     orig_experts.token_dispatcher = mock_dispatcher
 
@@ -452,7 +485,7 @@ def test_lora_with_expert_bias(device):
         norm_topk_prob=False,
         expert_activation="swiglu",
         dtype=torch.float32,
-        expert_bias=True  # Enable bias
+        expert_bias=True,  # Enable bias
     )
 
     orig_experts = GroupedExperts(moe_config).to(device)
@@ -462,8 +495,8 @@ def test_lora_with_expert_bias(device):
     lora_experts = GroupedExpertsLoRA(orig_experts, lora_dim=4, alpha=8).to(device)
 
     # Check that bias parameters exist and are frozen
-    assert hasattr(lora_experts, 'gate_up_proj_bias')
-    assert hasattr(lora_experts, 'down_proj_bias')
+    assert hasattr(lora_experts, "gate_up_proj_bias")
+    assert hasattr(lora_experts, "down_proj_bias")
     assert not lora_experts.gate_up_proj_bias.requires_grad
     assert not lora_experts.down_proj_bias.requires_grad
 
@@ -499,7 +532,7 @@ def test_quick_geglu_activation_with_lora(device):
         expert_activation="quick_geglu",  # Use QuickGEGLU
         activation_alpha=1.702,
         activation_limit=7.0,
-        dtype=torch.float32
+        dtype=torch.float32,
     )
 
     orig_experts = GroupedExperts(moe_config).to(device)
@@ -528,7 +561,7 @@ def test_lora_dtype_conversion(moe_config, device):
         orig_experts.init_weights(buffer_device=device)
 
     # Create LoRA with explicit bfloat16 dtype
-    if device.type == 'cuda' and torch.cuda.is_bf16_supported():
+    if device.type == "cuda" and torch.cuda.is_bf16_supported():
         lora_experts = GroupedExpertsLoRA(orig_experts, lora_dim=4, alpha=8, lora_dtype="bfloat16").to(device)
 
         # Check that LoRA weights have the correct dtype
@@ -565,14 +598,15 @@ def test_lora_backward_pass_values(moe_config, device):
     loss.backward()
 
     # Check that gradients are non-zero
-    assert not torch.allclose(lora_experts.lora_gate_and_up_A.grad, torch.zeros_like(lora_experts.lora_gate_and_up_A.grad))
-    assert not torch.allclose(lora_experts.lora_gate_and_up_B.grad, torch.zeros_like(lora_experts.lora_gate_and_up_B.grad))
+    assert not torch.allclose(
+        lora_experts.lora_gate_and_up_A.grad, torch.zeros_like(lora_experts.lora_gate_and_up_A.grad)
+    )
+    assert not torch.allclose(
+        lora_experts.lora_gate_and_up_B.grad, torch.zeros_like(lora_experts.lora_gate_and_up_B.grad)
+    )
 
 
-@pytest.mark.skipif(
-    grouped_gemm is None or not torch.cuda.is_available(),
-    reason="Requires grouped_gemm and CUDA"
-)
+@pytest.mark.skipif(grouped_gemm is None or not torch.cuda.is_available(), reason="Requires grouped_gemm and CUDA")
 def test_deepep_lora_zero_tokens(moe_config, device):
     """Test DeepEP LoRA forward pass with zero tokens routed to experts."""
     moe_config.n_routed_experts = 4
@@ -598,9 +632,7 @@ def test_deepep_lora_zero_tokens(moe_config, device):
     permuted_x = torch.randn(num_tokens, 16, device=device).to(dtype)
     permuted_probs = torch.ones(num_tokens, device=device).to(dtype)
 
-    mock_dispatcher.token_permutation2 = MagicMock(
-        return_value=(permuted_x, tokens_per_expert, permuted_probs)
-    )
+    mock_dispatcher.token_permutation2 = MagicMock(return_value=(permuted_x, tokens_per_expert, permuted_probs))
     lora_module.token_dispatcher = mock_dispatcher
 
     x = torch.randn(num_tokens, 16, device=device).to(dtype)
@@ -628,6 +660,7 @@ def test_patch_moe_module_rejects_te_experts(moe_config, device):
 @pytest.mark.skipif(not HAS_TE, reason="Transformer Engine required")
 def test_apply_lora_rejects_te_experts(moe_config, device):
     """Test that apply_lora_to_linear_modules raises NotImplementedError for GroupedExpertsTE."""
+
     class MockModel(nn.Module):
         def __init__(self):
             super().__init__()
@@ -881,10 +914,7 @@ def test_grouped_experts_lora_forward_torch_mm_with_bias(device):
     assert not torch.isnan(out).any()
 
 
-@pytest.mark.skipif(
-    grouped_gemm is None or not torch.cuda.is_available(),
-    reason="Requires grouped_gemm and CUDA"
-)
+@pytest.mark.skipif(grouped_gemm is None or not torch.cuda.is_available(), reason="Requires grouped_gemm and CUDA")
 def test_deepep_lora_forward_torch_mm(moe_config, device):
     """Test DeepEP LoRA forward with use_torch_mm=True via mock dispatcher."""
     moe_config.n_routed_experts = 4
@@ -913,9 +943,7 @@ def test_deepep_lora_forward_torch_mm(moe_config, device):
     permuted_x = torch.randn(num_tokens, 16, device=device).to(dtype)
     permuted_probs = torch.ones(num_tokens, device=device).to(dtype)
 
-    mock_dispatcher.token_permutation2 = MagicMock(
-        return_value=(permuted_x, tokens_per_expert, permuted_probs)
-    )
+    mock_dispatcher.token_permutation2 = MagicMock(return_value=(permuted_x, tokens_per_expert, permuted_probs))
     lora_module.token_dispatcher = mock_dispatcher
 
     x = torch.randn(num_tokens, 16, device=device).to(dtype)
@@ -928,10 +956,7 @@ def test_deepep_lora_forward_torch_mm(moe_config, device):
     assert not torch.isnan(out).any()
 
 
-@pytest.mark.skipif(
-    grouped_gemm is None or not torch.cuda.is_available(),
-    reason="Requires grouped_gemm and CUDA"
-)
+@pytest.mark.skipif(grouped_gemm is None or not torch.cuda.is_available(), reason="Requires grouped_gemm and CUDA")
 def test_deepep_lora_forward_torch_mm_equivalence(moe_config, device):
     """With zero-init B, torch_mm and grouped_gemm paths should match for DeepEP LoRA."""
     moe_config.n_routed_experts = 4
@@ -967,13 +992,9 @@ def test_deepep_lora_forward_torch_mm_equivalence(moe_config, device):
     permuted_probs = torch.ones(num_tokens, device=device).to(dtype)
 
     mock_dispatcher_gg = MockDeepEPDispatcher()
-    mock_dispatcher_gg.token_permutation2 = MagicMock(
-        return_value=(permuted_x, tokens_per_expert, permuted_probs)
-    )
+    mock_dispatcher_gg.token_permutation2 = MagicMock(return_value=(permuted_x, tokens_per_expert, permuted_probs))
     mock_dispatcher_mm = MockDeepEPDispatcher()
-    mock_dispatcher_mm.token_permutation2 = MagicMock(
-        return_value=(permuted_x, tokens_per_expert, permuted_probs)
-    )
+    mock_dispatcher_mm.token_permutation2 = MagicMock(return_value=(permuted_x, tokens_per_expert, permuted_probs))
     lora_gg.token_dispatcher = mock_dispatcher_gg
     lora_mm.token_dispatcher = mock_dispatcher_mm
 
@@ -996,7 +1017,7 @@ def test_lora_dtype_string(moe_config, device):
     with torch.no_grad():
         orig_experts.init_weights(buffer_device=device)
 
-    if device.type == 'cuda' and torch.cuda.is_bf16_supported():
+    if device.type == "cuda" and torch.cuda.is_bf16_supported():
         lora_experts = GroupedExpertsLoRA(orig_experts, lora_dim=4, alpha=8, lora_dtype="bfloat16").to(device)
         assert lora_experts.lora_gate_and_up_A.dtype == torch.bfloat16
 
@@ -1010,7 +1031,7 @@ def test_deepep_lora_dtype_string(moe_config, device):
     orig_experts.n_routed_experts = 4
     orig_experts.ep_size = 1
 
-    if device.type == 'cuda' and torch.cuda.is_bf16_supported():
+    if device.type == "cuda" and torch.cuda.is_bf16_supported():
         lora_module = GroupedExpertsDeepEPLoRA(orig_experts, lora_dim=4, lora_dtype="bfloat16").to(device)
         assert lora_module.lora_gate_and_up_A.dtype == torch.bfloat16
 
@@ -1035,10 +1056,7 @@ def test_deepep_lora_kaiming_init(moe_config, device):
     assert not torch.allclose(lora_module.lora_down_A, torch.zeros_like(lora_module.lora_down_A))
 
 
-@pytest.mark.skipif(
-    grouped_gemm is None or not torch.cuda.is_available(),
-    reason="Requires grouped_gemm and CUDA"
-)
+@pytest.mark.skipif(grouped_gemm is None or not torch.cuda.is_available(), reason="Requires grouped_gemm and CUDA")
 def test_deepep_lora_forward_torch_mm_with_bias(device):
     """Test DeepEP LoRA forward with use_torch_mm=True and expert_bias=True."""
     config = MoEConfig(
@@ -1078,9 +1096,7 @@ def test_deepep_lora_forward_torch_mm_with_bias(device):
     permuted_x = torch.randn(num_tokens, 16, device=device).to(dtype)
     permuted_probs = torch.ones(num_tokens, device=device).to(dtype)
 
-    mock_dispatcher.token_permutation2 = MagicMock(
-        return_value=(permuted_x, tokens_per_expert, permuted_probs)
-    )
+    mock_dispatcher.token_permutation2 = MagicMock(return_value=(permuted_x, tokens_per_expert, permuted_probs))
     lora_module.token_dispatcher = mock_dispatcher
 
     x = torch.randn(num_tokens, 16, device=device).to(dtype)
@@ -1093,10 +1109,7 @@ def test_deepep_lora_forward_torch_mm_with_bias(device):
     assert not torch.isnan(out).any()
 
 
-@pytest.mark.skipif(
-    grouped_gemm is None or not torch.cuda.is_available(),
-    reason="Requires grouped_gemm and CUDA"
-)
+@pytest.mark.skipif(grouped_gemm is None or not torch.cuda.is_available(), reason="Requires grouped_gemm and CUDA")
 def test_deepep_lora_forward_grouped_gemm_with_bias(device):
     """Test DeepEP LoRA forward with use_torch_mm=False (grouped_gemm) and expert_bias=True."""
     config = MoEConfig(
@@ -1135,9 +1148,7 @@ def test_deepep_lora_forward_grouped_gemm_with_bias(device):
     permuted_x = torch.randn(num_tokens, 16, device=device).to(dtype)
     permuted_probs = torch.ones(num_tokens, device=device).to(dtype)
 
-    mock_dispatcher.token_permutation2 = MagicMock(
-        return_value=(permuted_x, tokens_per_expert, permuted_probs)
-    )
+    mock_dispatcher.token_permutation2 = MagicMock(return_value=(permuted_x, tokens_per_expert, permuted_probs))
     lora_module.token_dispatcher = mock_dispatcher
 
     x = torch.randn(num_tokens, 16, device=device).to(dtype)
@@ -1156,6 +1167,7 @@ def test_deepep_lora_forward_grouped_gemm_with_bias(device):
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_moe_rank_scaling_basic(moe_config, device):
     """MoE experts get dim // n_activated_experts; Linear keeps full dim."""
+
     class MockModel(nn.Module):
         def __init__(self):
             super().__init__()
@@ -1185,6 +1197,7 @@ def test_moe_rank_scaling_basic(moe_config, device):
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_moe_rank_scaling_default_off(moe_config, device):
     """With moe_rank_scaling=False (default), both get the full dim."""
+
     class MockModel(nn.Module):
         def __init__(self):
             super().__init__()
@@ -1257,6 +1270,7 @@ def test_moe_rank_scaling_floor_division_warning(device):
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_moe_rank_scaling_dim_too_small(moe_config, device):
     """When dim < n_activated_experts, raise ValueError."""
+
     class MockModel(nn.Module):
         def __init__(self):
             super().__init__()
@@ -1279,6 +1293,7 @@ def test_moe_rank_scaling_dim_too_small(moe_config, device):
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_moe_rank_scaling_output_equivalence(moe_config, device):
     """With zero-init B, scaled-rank MoE LoRA should produce the same output as the original model."""
+
     class MockModel(nn.Module):
         def __init__(self):
             super().__init__()


### PR DESCRIPTION
## Summary

Stabilizes the Automodel MoE **performance benchmarks** that were failing on DeepEP CPU-dispatch timeouts (`moe_recv_expert_counter` → -1) — Linear **AM-524** and its mislabeled siblings (AM-527/528/529) — by switching multi-node MoE dispatch from DeepEP to **HybridEP**, and fixing the two LoRA recipes that then hit CUDA OOM.

> **Attribution:** the bulk of this PR — the HybridEP switch and the `lora_experts.py` fixes — is @akoumparouli's work from `akoumpa/fix/am-moe-benchmark-hybridep`. This branch adds the final two LoRA recipe conformance fixes on top and consolidates onto `main`.

## Changes

**HybridEP switch (akoumparouli):**
- MoE token dispatcher DeepEP → **HybridEP for multi-node** (rule: `hybridep` when `ep_size > 8`, else `deepep`); experts → `torch_mm`.
- `lora_experts.py`: preserve the dispatcher backend in `GroupedExpertsDeepEPLoRA` (else `hybridep` silently falls back to `deepep` under LoRA), and pad LoRA-rank operands for `torch._grouped_mm` (`torch_mm` experts).
- Per-recipe sizing/node-count adjustments.

**LoRA OOM conformance (this branch):** the two recipes that OOM'd after being dropped to `ep=8`/`deepep`/`pp=1`, conformed to their passing same-model siblings:
- `minimax_m25_lora` → `ep=32`/`pp=2`/`hybridep` + `distributed.pipeline` block (mirrors `minimax_m2.5_te_deepep`)
- `nemotron_super_v3_lora` → `ep=64`/`hybridep`/`reshard`, 8 nodes (mirrors `nemotron_super_v3_te_deepep`)

## Verification (EOS, HF-enabled)
- ✅ `nemotron_super_v3_lora` — [348252172](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/348252172), 27.88 GB peak, no OOM
- ✅ `minimax_m25_lora` — [348456837](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/348456837), 18.85 GB peak, no OOM, 30 steps
- ✅ `*_te_deepep` recipes — akoumparouli's earlier passing runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)