### PR TITLE
docs(speculative): fix EAGLE drafter layer count and EAGLE-1 loss

### DIFF
--- a/docs/guides/speculative/eagle.mdx
+++ b/docs/guides/speculative/eagle.mdx
@@ -102,7 +102,7 @@ next, using a technique called **test-time training (TTT) unroll**:
 ```text
 Target (frozen)          Drafter (trainable)
 ┌──────────────┐         ┌──────────────┐
-│ Llama 3.1 8B │ ──────> │  2-layer     │
+│ Llama 3.1 8B │ ──────> │  1-layer     │
 │              │ hidden  │  transformer │
 │ Full model   │ states  │  + fc fusion │
 │ (frozen)     │         │  + lm_head   │
@@ -116,7 +116,7 @@ Key components:
 
 - **Target model**: The full LLM (e.g., Llama 3.1 8B), completely frozen. Provides
   hidden states from selected intermediate layers as auxiliary inputs to the drafter.
-- **Draft model**: A shallow transformer (typically 2 layers) with:
+- **Draft model**: A shallow transformer (a single fused decoder layer) with:
   - A **fusion layer** (`fc`) that combines auxiliary hidden states from 3 target layers
   - Its own attention layers, MLP, and layer norm
   - A smaller **output vocabulary** (e.g., 8192 or 32000 tokens instead of 128k) to reduce compute
@@ -156,7 +156,7 @@ recipe_args:
 ### How EAGLE-1 Differs
 
 EAGLE-1 is simpler: it uses a single transformer layer, predicts the full
-vocabulary, and trains with a combined loss of MSE on hidden states
+vocabulary, and trains with a combined loss of SmoothL1 (Huber) on hidden states
 (`hidden_loss_weight`) and cross-entropy on tokens (`token_loss_weight`).
 No TTT unroll, no vocabulary mapping.
 
@@ -583,7 +583,7 @@ recipe_args:
 
   # EAGLE-1 specific
   draft_num_hidden_layers: 1    # number of draft transformer layers
-  hidden_loss_weight: 1.0       # MSE loss on hidden states
+  hidden_loss_weight: 1.0       # SmoothL1 (Huber) loss on hidden states
   token_loss_weight: 0.1        # cross-entropy loss on tokens
 
   freeze_embeddings: true


### PR DESCRIPTION
## What

The EAGLE architecture guide (`docs/guides/speculative/eagle.mdx`) describes the drafter in two ways that contradict the code it documents. This corrects both.

## 1. EAGLE-3 drafter depth: "2 layers" -> a single fused layer

The diagram and the "Draft model" bullet say the EAGLE-3 drafter is a "2-layer" / "typically 2 layers" transformer. The EAGLE-3 and EAGLE-3.1 drafter is built as a single fused decoder layer:

```python
# nemo_automodel/components/speculative/eagle/draft_llama.py
layers: list[nn.Module] = [Eagle3LlamaDecoderLayer(config, layer_id=0)]
if getattr(config, "parallel_drafting", False):   # only P-EAGLE stacks more
    ...
```

The same file's comment ("EAGLE-3 / EAGLE-3.1 TTT uses a single fused first layer") and the class docstring ("single draft decoder layer") agree. Extra layers exist only for the P-EAGLE (`parallel_drafting`) path, not for the standard EAGLE-3 / EAGLE-3.1 path this section describes. Updated the diagram (`2-layer` to `1-layer`) and the bullet to "a single fused decoder layer".

## 2. EAGLE-1 hidden-state loss: "MSE" -> SmoothL1 (Huber)

The prose and the EAGLE-1 YAML comment call the hidden-state loss "MSE". The implementation uses SmoothL1:

```python
# nemo_automodel/components/speculative/eagle/core_v12.py
self.hidden_loss_fn = nn.SmoothL1Loss(reduction="none")
```

`examples/speculative/README.md` already documents this correctly as "SmoothL1 hidden-state loss". Updated both mentions in the guide to "SmoothL1 (Huber)".

## Notes

Docs-only change, no behavior change. Verified against the current `main`.
