### PR TITLE
feat(moe): add Rollout Routing Replay (R3) for MoE RL training

### DIFF
--- a/nemo_automodel/components/models/gemma4_moe/model.py
+++ b/nemo_automodel/components/models/gemma4_moe/model.py
@@ -83,6 +83,7 @@ from nemo_automodel.components.models.common.hf_checkpointing_mixin import HFChe
 from nemo_automodel.components.models.common.utils import cast_model_to_dtype
 from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
 from nemo_automodel.components.moe.layers import MoE, MoEConfig
+from nemo_automodel.components.moe.router_replay import RouterReplay, replay_selection
 from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 
 from .cp_attention import attach_gemma4_cp_ring_attention, gemma4_vision_group_ids
@@ -194,12 +195,16 @@ class Gemma4Gate(nn.Module):
     This class reproduces that logic but returns (weights, indices, aux_loss) as expected by GroupedExperts.
     """
 
-    def __init__(self, config: Gemma4TextConfig):
+    def __init__(self, config: Gemma4TextConfig, enable_routing_replay: bool = False):
         super().__init__()
         hidden_size = config.hidden_size
         num_experts = config.num_experts
         self.topk = config.top_k_experts
         self.num_experts = num_experts
+
+        # Rollout Routing Replay (R3): owns a handle only when enabled so the
+        # default routing path stays a no-op.
+        self.router_replay: Optional[RouterReplay] = RouterReplay() if enable_routing_replay else None
 
         # Thread dtype explicitly from config.torch_dtype so the router's own
         # params (proj weight + scale) stay aligned with the rest of the model
@@ -231,6 +236,12 @@ class Gemma4Gate(nn.Module):
         router_probs = F.softmax(expert_scores, dim=-1)
 
         weights, indices = torch.topk(router_probs, k=self.topk, dim=-1)
+        replayed = replay_selection(self.router_replay, indices)
+        if replayed is not indices:
+            # Replay swapped the selection: re-gather the probs for the replayed
+            # experts. Skipped (zero overhead) on the default path.
+            weights = router_probs.gather(-1, replayed)
+            indices = replayed
         weights = weights / weights.sum(dim=-1, keepdim=True).clamp(min=1e-20)
         return weights.to(input_dtype), indices, None
 
@@ -248,8 +259,13 @@ class Gemma4MoE(MoE):
 
     def __init__(self, moe_config: MoEConfig, backend: BackendConfig, text_config: Gemma4TextConfig):
         super().__init__(moe_config, backend)
-        # Replace the gate created by MoE.__init__ with Gemma4-specific gate
-        self.gate = Gemma4Gate(text_config)
+        # Replace the gate created by MoE.__init__ with Gemma4-specific gate.
+        # The shared Gate that MoE.__init__ built registered a RouterReplay handle
+        # when replay is enabled; drop it before the swap so it does not linger as a
+        # dangling, never-driven instance in the global registry.
+        if getattr(self.gate, "router_replay", None) is not None:
+            RouterReplay.instances().remove(self.gate.router_replay)
+        self.gate = Gemma4Gate(text_config, enable_routing_replay=moe_config.enable_routing_replay)
 
     def forward(self, x, padding_mask=None, cp_mesh=None, *, gate_input=None):
         """Forward with optional separate gate input.

--- a/nemo_automodel/components/moe/config.py
+++ b/nemo_automodel/components/moe/config.py
@@ -57,6 +57,10 @@ class MoEConfig:
     shared_expert_activation: str = "swiglu"  # Activation for shared experts ("swiglu" or "relu2")
     force_e_score_correction_bias: bool = False  # Force creation of e_score_correction_bias buffer
     moe_latent_size: int | None = None
+    # Rollout Routing Replay (R3): when True, each gate records/replays its top-k
+    # expert selection so RL training reuses the rollout's routing decisions. See
+    # nemo_automodel.components.moe.router_replay.
+    enable_routing_replay: bool = False
 
     @property
     def expert_dim(self) -> int:

--- a/nemo_automodel/components/moe/layers.py
+++ b/nemo_automodel/components/moe/layers.py
@@ -36,6 +36,7 @@ from nemo_automodel.components.moe.experts import (
 from nemo_automodel.components.moe.megatron.moe_utils import (
     MoEAuxLossAutoScaler,
 )
+from nemo_automodel.components.moe.router_replay import RouterReplay, replay_selection
 
 
 class MLP(nn.Module):
@@ -286,6 +287,12 @@ class Gate(nn.Module):
         self._last_expert_load: Optional[torch.Tensor] = None
         self._last_aux_loss: Optional[torch.Tensor] = None
 
+        # Rollout Routing Replay (R3): owns a handle only when enabled so the
+        # default routing path stays a no-op.
+        self.router_replay: Optional[RouterReplay] = (
+            RouterReplay() if getattr(config, "enable_routing_replay", False) else None
+        )
+
     def forward(
         self,
         x: torch.Tensor,
@@ -323,9 +330,16 @@ class Gate(nn.Module):
                 scores = scores.softmax(dim=-1, dtype=self.gate_precision or torch.float32)
                 original_scores = scores
                 indices = torch.topk(scores, k=self.topk, dim=-1)[1]
+                indices = replay_selection(self.router_replay, indices)
                 weights = scores.gather(1, indices)
             else:
                 values, indices = torch.topk(scores, k=self.topk, dim=-1)
+                replayed = replay_selection(self.router_replay, indices)
+                if replayed is not indices:
+                    # Replay swapped the selection: re-gather the values for the
+                    # replayed experts. Skipped (zero overhead) on the default path.
+                    values = scores.gather(1, replayed)
+                    indices = replayed
                 weights = values.softmax(dim=1, dtype=self.gate_precision or torch.float32)
                 # Use full softmax for aux_loss so P_i represents proper probabilities.
                 # Raw logits can be negative, causing aux_loss to diverge negative.
@@ -351,6 +365,7 @@ class Gate(nn.Module):
                 scores_for_choice = (scores_for_choice * mask.unsqueeze(-1)).flatten(1)
 
             indices = torch.topk(scores_for_choice, self.topk, dim=-1)[1]
+            indices = replay_selection(self.router_replay, indices)
             # Final weights gathered from UNBIASED softmax scores
             weights = original_scores.gather(1, indices)
         elif self.score_func == "sqrtsoftplus":
@@ -362,6 +377,7 @@ class Gate(nn.Module):
                 scores = scores + self.e_score_correction_bias
 
             indices = torch.topk(scores, self.topk, dim=-1)[1]
+            indices = replay_selection(self.router_replay, indices)
             weights = original_scores.gather(1, indices)
         elif self.score_func == "sigmoid_with_bias":
             scores = scores.sigmoid()
@@ -382,6 +398,7 @@ class Gate(nn.Module):
                 )
 
             indices = torch.topk(scores_for_choice, k=self.topk, dim=-1, sorted=False)[1]
+            indices = replay_selection(self.router_replay, indices)
             weights = original_scores.gather(1, indices)
         else:
             scores = scores.sigmoid()
@@ -403,6 +420,7 @@ class Gate(nn.Module):
                 scores = (scores * mask.unsqueeze(-1)).flatten(1)
 
             indices = torch.topk(scores, self.topk, dim=-1)[1]
+            indices = replay_selection(self.router_replay, indices)
             weights = original_scores.gather(1, indices)
 
         if self.norm_topk_prob and self.topk > 1:

--- a/nemo_automodel/components/moe/router_replay.py
+++ b/nemo_automodel/components/moe/router_replay.py
@@ -1,0 +1,231 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rollout Routing Replay (R3) for MoE policy-gradient training.
+
+In on-policy RL on a Mixture-of-Experts model, the rollout (inference) engine and
+the training engine compute the router's top-k expert selection independently.
+Numerical differences between the two backends flip a small fraction of routing
+decisions per layer, which compounds across layers until most tokens are routed to
+a different set of experts than they were during rollout. That mismatch breaks the
+importance-sampling assumption behind GRPO/GSPO and destabilizes training.
+
+Routing replay removes the mismatch by capturing the top-k expert *selection* during
+one forward pass (the rollout-equivalent forward) and replaying that exact selection
+during the training forward. Only the discrete selection is replayed: the router
+logits and their softmax/sigmoid are still recomputed from the live router weights,
+so the gradient continues to flow into the router. This mirrors Megatron-LM's
+``moe_enable_routing_replay`` integration.
+
+Usage::
+
+    from nemo_automodel.components.moe.router_replay import RouterReplay
+
+    # Capture the selection on the rollout-equivalent forward.
+    with RouterReplay.record():
+        model(batch)
+    captured = RouterReplay.collect()  # one tensor per MoE layer, in layer order
+
+    # Replay it on the training forward over the same tokens.
+    with RouterReplay.replay(captured):
+        loss = model(batch)
+    loss.backward()
+
+Each :class:`Gate` constructed with routing replay enabled owns one
+:class:`RouterReplay` instance and registers it in a process-global list at
+construction time. The global order is the construction order, which matches the
+layer order, so ``collect()`` and ``replay()`` line the per-layer tensors up by
+position. This assumes single-threaded model construction (the norm for recipe
+training); call :meth:`RouterReplay.clear_registry` before building a second
+model in the same process.
+"""
+
+from contextlib import contextmanager
+from enum import Enum
+from typing import Iterator, List, Optional
+
+import torch
+
+__all__ = ["RouterReplayMode", "RouterReplay", "replay_selection"]
+
+
+class RouterReplayMode(Enum):
+    """Active mode of a :class:`RouterReplay` instance."""
+
+    RECORD = "record"  # Store the freshly computed top-k selection for later replay.
+    REPLAY = "replay"  # Override the freshly computed selection with the stored one.
+
+
+class RouterReplay:
+    """Per-gate handle that records or replays a single MoE layer's top-k selection.
+
+    Instances register themselves in a process-global list on construction. The
+    static helpers drive every registered instance at once so a caller toggles
+    record/replay for the whole model with a single call (or the ``record`` /
+    ``replay`` context managers).
+    """
+
+    _registry: List["RouterReplay"] = []
+
+    def __init__(self) -> None:
+        """Create a handle and register it in construction (i.e. layer) order."""
+        self.mode: Optional[RouterReplayMode] = None
+        self.recorded_indices: Optional[torch.Tensor] = None
+        self.target_indices: Optional[torch.Tensor] = None
+        RouterReplay._registry.append(self)
+
+    def apply(self, indices: torch.Tensor) -> torch.Tensor:
+        """Record or replay ``indices`` according to the current mode.
+
+        Args:
+            indices: The top-k expert indices the gate just selected, shape
+                ``[num_tokens, topk]``.
+
+        Returns:
+            ``indices`` unchanged when no mode is active or while recording; the
+            stored target indices (moved to ``indices.device``) while replaying.
+        """
+        if self.mode == RouterReplayMode.RECORD:
+            # Indices are integer selection ids carrying no gradient; detach so the
+            # capture never pins the forward graph.
+            self.recorded_indices = indices.detach()
+            return indices
+        if self.mode == RouterReplayMode.REPLAY:
+            if self.target_indices is None:
+                raise RuntimeError(
+                    "RouterReplay is in REPLAY mode but no target indices were set for this layer. "
+                    "Call RouterReplay.replay(indices) / set_replay_indices(...) with one tensor per MoE layer."
+                )
+            target = self.target_indices.to(indices.device)
+            if target.shape != indices.shape:
+                raise ValueError(
+                    f"Replay indices shape {tuple(target.shape)} does not match the current "
+                    f"selection shape {tuple(indices.shape)}; replay must run on the same tokens and topk."
+                )
+            return target
+        return indices
+
+    # -- per-instance state -------------------------------------------------
+
+    def set_target(self, indices: torch.Tensor) -> None:
+        """Set the selection to replay for this layer."""
+        self.target_indices = indices
+
+    def clear(self) -> None:
+        """Drop both the recorded and the target selection for this layer."""
+        self.recorded_indices = None
+        self.target_indices = None
+
+    # -- global control over every registered instance ---------------------
+
+    @staticmethod
+    def instances() -> List["RouterReplay"]:
+        """Return the registered instances in construction (layer) order."""
+        return RouterReplay._registry
+
+    @staticmethod
+    def set_mode(mode: Optional[RouterReplayMode]) -> None:
+        """Set the mode on every registered instance (``None`` disables replay)."""
+        for inst in RouterReplay._registry:
+            inst.mode = mode
+
+    @staticmethod
+    def set_replay_indices(all_layers_indices: List[torch.Tensor]) -> None:
+        """Distribute one selection tensor per layer to the registered instances.
+
+        Args:
+            all_layers_indices: One ``[num_tokens, topk]`` tensor per MoE layer, in
+                the same order the layers were constructed.
+
+        Raises:
+            ValueError: If the number of tensors does not match the number of
+                registered instances.
+        """
+        instances = RouterReplay._registry
+        if len(all_layers_indices) != len(instances):
+            raise ValueError(
+                f"Got {len(all_layers_indices)} replay tensors but there are {len(instances)} "
+                "registered RouterReplay instances (one per MoE layer)."
+            )
+        for inst, indices in zip(instances, all_layers_indices):
+            inst.set_target(indices)
+
+    @staticmethod
+    def collect() -> List[torch.Tensor]:
+        """Collect the recorded selection from every registered instance, in layer order.
+
+        Raises:
+            RuntimeError: If any instance has no recorded selection (i.e. a forward
+                pass was not run under :meth:`record`).
+        """
+        collected: List[torch.Tensor] = []
+        for layer_idx, inst in enumerate(RouterReplay._registry):
+            if inst.recorded_indices is None:
+                raise RuntimeError(
+                    f"RouterReplay instance for layer {layer_idx} has no recorded selection; "
+                    "run a forward pass inside `with RouterReplay.record():` before collecting."
+                )
+            collected.append(inst.recorded_indices)
+        return collected
+
+    @staticmethod
+    def clear_indices() -> None:
+        """Drop recorded and target selections on every registered instance."""
+        for inst in RouterReplay._registry:
+            inst.clear()
+
+    @staticmethod
+    def clear_registry() -> None:
+        """Forget every registered instance (use between independently built models)."""
+        RouterReplay._registry.clear()
+
+    # -- ergonomic context managers ----------------------------------------
+
+    @classmethod
+    @contextmanager
+    def record(cls) -> Iterator[None]:
+        """Record the top-k selection of every gate for the duration of the block."""
+        cls.set_mode(RouterReplayMode.RECORD)
+        try:
+            yield
+        finally:
+            cls.set_mode(None)
+
+    @classmethod
+    @contextmanager
+    def replay(cls, all_layers_indices: List[torch.Tensor]) -> Iterator[None]:
+        """Replay ``all_layers_indices`` (one tensor per layer) for the duration of the block.
+
+        Target selections are cleared on exit so a stale replay never leaks into a
+        later forward pass.
+        """
+        cls.set_replay_indices(all_layers_indices)
+        cls.set_mode(RouterReplayMode.REPLAY)
+        try:
+            yield
+        finally:
+            cls.set_mode(None)
+            for inst in cls._registry:
+                inst.target_indices = None
+
+
+def replay_selection(router_replay: Optional[RouterReplay], indices: torch.Tensor) -> torch.Tensor:
+    """Route ``indices`` through ``router_replay`` when routing replay is enabled.
+
+    Returns ``indices`` unchanged when ``router_replay`` is ``None`` (replay disabled)
+    or when no mode is active, so the gate's default path is a true no-op.
+    """
+    if router_replay is None:
+        return indices
+    return router_replay.apply(indices)

--- a/tests/unit_tests/moe/test_router_replay.py
+++ b/tests/unit_tests/moe/test_router_replay.py
@@ -1,0 +1,386 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for Rollout Routing Replay (R3)."""
+
+import pytest
+import torch
+
+from nemo_automodel.components.moe.config import MoEConfig
+from nemo_automodel.components.moe.layers import Gate
+from nemo_automodel.components.moe.router_replay import (
+    RouterReplay,
+    RouterReplayMode,
+    replay_selection,
+)
+
+# Every score_func branch in Gate.forward selects experts with its own top-k call;
+# routing replay must override the selection identically in all of them.
+SCORE_FUNCS = [
+    "softmax",
+    "softmax_with_bias",
+    "sqrtsoftplus",
+    "sigmoid_with_bias",
+    "sigmoid",
+]
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Isolate the process-global RouterReplay registry across tests."""
+    RouterReplay.clear_registry()
+    yield
+    RouterReplay.clear_registry()
+
+
+def make_config(score_func="softmax", enable_routing_replay=True, **overrides):
+    cfg = dict(
+        n_routed_experts=8,
+        n_shared_experts=0,
+        n_activated_experts=2,
+        n_expert_groups=1,
+        n_limited_groups=1,
+        train_gate=True,
+        gate_bias_update_factor=0.0,
+        aux_loss_coeff=0.0,
+        score_func=score_func,
+        route_scale=1.0,
+        dim=16,
+        inter_dim=32,
+        moe_inter_dim=32,
+        norm_topk_prob=False,
+        dtype=torch.float32,
+        enable_routing_replay=enable_routing_replay,
+    )
+    cfg.update(overrides)
+    return MoEConfig(**cfg)
+
+
+def make_gate(score_func="softmax", enable_routing_replay=True, **overrides):
+    gate = Gate(make_config(score_func, enable_routing_replay, **overrides))
+    # Spread the router weights so two different inputs route differently.
+    with torch.no_grad():
+        gate.weight.normal_(0.0, 1.0)
+    return gate
+
+
+def run(gate, x):
+    token_mask = torch.ones(x.shape[0], dtype=torch.bool)
+    return gate(x, token_mask, None)
+
+
+# --------------------------------------------------------------------------- #
+# Config + helper
+# --------------------------------------------------------------------------- #
+
+
+def test_config_default_off():
+    assert MoEConfig.__dataclass_fields__["enable_routing_replay"].default is False
+    gate = Gate(make_config(enable_routing_replay=False))
+    assert gate.router_replay is None
+    # A disabled gate registers nothing.
+    assert RouterReplay.instances() == []
+
+
+def test_enabled_gate_registers_once():
+    gate = make_gate()
+    assert isinstance(gate.router_replay, RouterReplay)
+    assert RouterReplay.instances() == [gate.router_replay]
+
+
+def test_replay_selection_passthrough_when_disabled():
+    idx = torch.tensor([[0, 1], [2, 3]])
+    assert replay_selection(None, idx) is idx
+
+
+# --------------------------------------------------------------------------- #
+# No-op guarantees: an enabled-but-inactive gate matches a disabled gate
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("score_func", SCORE_FUNCS)
+def test_disabled_path_is_noop(score_func):
+    torch.manual_seed(0)
+    x = torch.randn(6, 16)
+
+    g_off = make_gate(score_func, enable_routing_replay=False)
+    g_on = make_gate(score_func, enable_routing_replay=True)
+    # Same router weights so the only difference would be the replay plumbing.
+    g_on.load_state_dict(g_off.state_dict())
+
+    w_off, i_off, _ = run(g_off, x)
+    w_on, i_on, _ = run(g_on, x)  # enabled but no mode set -> inactive
+
+    torch.testing.assert_close(w_off, w_on)
+    assert torch.equal(i_off, i_on)
+
+
+def test_record_mode_does_not_change_output():
+    torch.manual_seed(0)
+    x = torch.randn(6, 16)
+    gate = make_gate()
+
+    w_plain, i_plain, _ = run(gate, x)
+    with RouterReplay.record():
+        w_rec, i_rec, _ = run(gate, x)
+
+    torch.testing.assert_close(w_plain, w_rec)
+    assert torch.equal(i_plain, i_rec)
+
+
+# --------------------------------------------------------------------------- #
+# Record -> replay roundtrip
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("score_func", SCORE_FUNCS)
+def test_record_replay_roundtrip(score_func):
+    torch.manual_seed(0)
+    gate = make_gate(score_func)
+
+    x_rollout = torch.randn(6, 16)
+    x_train = torch.randn(6, 16)  # different tokens -> different natural routing
+
+    # Sanity: the two inputs route differently without replay.
+    _, i_rollout, _ = run(gate, x_rollout)
+    _, i_train_free, _ = run(gate, x_train)
+    assert not torch.equal(i_rollout, i_train_free)
+
+    # Record on the rollout forward, replay on the training forward.
+    with RouterReplay.record():
+        _, i_recorded, _ = run(gate, x_rollout)
+    captured = RouterReplay.collect()
+    assert len(captured) == 1
+    assert torch.equal(captured[0], i_recorded)
+
+    with RouterReplay.replay(captured):
+        w_replay, i_replay, _ = run(gate, x_train)
+
+    # Replayed selection matches the rollout, not the training input's natural pick.
+    assert torch.equal(i_replay, i_rollout)
+    assert not torch.equal(i_replay, i_train_free)
+
+
+def test_replay_recomputes_weights_from_live_scores():
+    """Weights under replay come from the *current* scores at the replayed indices."""
+    torch.manual_seed(1)
+    gate = make_gate("sigmoid")  # weights = sigmoid(scores).gather(indices), simple to mirror
+
+    x_rollout = torch.randn(5, 16)
+    x_train = torch.randn(5, 16)
+
+    with RouterReplay.record():
+        run(gate, x_rollout)
+    captured = RouterReplay.collect()
+
+    with RouterReplay.replay(captured):
+        w_replay, i_replay, _ = run(gate, x_train)
+
+    # Reference: sigmoid of the live (train) logits gathered at the replayed indices.
+    live_scores = torch.sigmoid(torch.nn.functional.linear(x_train, gate.weight))
+    expected = live_scores.gather(1, i_replay)
+    torch.testing.assert_close(w_replay, expected)
+
+
+def test_replay_keeps_gradient_to_router():
+    torch.manual_seed(2)
+    gate = make_gate("softmax")
+
+    x_rollout = torch.randn(4, 16)
+    x_train = torch.randn(4, 16)
+    with RouterReplay.record():
+        run(gate, x_rollout)
+    captured = RouterReplay.collect()
+
+    with RouterReplay.replay(captured):
+        w_replay, _, _ = run(gate, x_train)
+    w_replay.sum().backward()
+
+    assert gate.weight.grad is not None
+    assert torch.any(gate.weight.grad != 0)
+
+
+# --------------------------------------------------------------------------- #
+# Multi-layer global control
+# --------------------------------------------------------------------------- #
+
+
+def test_multilayer_distribute_and_collect():
+    torch.manual_seed(3)
+    gates = [make_gate("softmax") for _ in range(3)]
+    assert len(RouterReplay.instances()) == 3
+
+    xs = [torch.randn(4, 16) for _ in gates]
+    with RouterReplay.record():
+        recorded = [run(g, x)[1] for g, x in zip(gates, xs)]
+    captured = RouterReplay.collect()
+    assert len(captured) == 3
+    for cap, rec in zip(captured, recorded):
+        assert torch.equal(cap, rec)
+
+    # Replay each layer with its own captured selection on fresh inputs.
+    new_xs = [torch.randn(4, 16) for _ in gates]
+    with RouterReplay.replay(captured):
+        replayed = [run(g, x)[1] for g, x in zip(gates, new_xs)]
+    for rep, rec in zip(replayed, recorded):
+        assert torch.equal(rep, rec)
+
+
+# --------------------------------------------------------------------------- #
+# Error handling + context-manager cleanup
+# --------------------------------------------------------------------------- #
+
+
+def test_collect_before_record_raises():
+    make_gate()
+    with pytest.raises(RuntimeError, match="no recorded selection"):
+        RouterReplay.collect()
+
+
+def test_set_replay_indices_length_mismatch_raises():
+    make_gate()
+    make_gate()
+    with pytest.raises(ValueError, match="replay tensors"):
+        RouterReplay.set_replay_indices([torch.zeros(4, 2, dtype=torch.long)])
+
+
+def test_replay_without_target_raises():
+    gate = make_gate()
+    RouterReplay.set_mode(RouterReplayMode.REPLAY)
+    try:
+        with pytest.raises(RuntimeError, match="no target indices"):
+            run(gate, torch.randn(4, 16))
+    finally:
+        RouterReplay.set_mode(None)
+
+
+def test_replay_shape_mismatch_raises():
+    gate = make_gate()
+    with RouterReplay.record():
+        run(gate, torch.randn(6, 16))
+    captured = RouterReplay.collect()
+    # Replay onto a different token count -> gather/shape guard fires.
+    with pytest.raises(ValueError, match="does not match"):
+        with RouterReplay.replay(captured):
+            run(gate, torch.randn(4, 16))
+
+
+def test_context_managers_clear_state_on_exit():
+    gate = make_gate()
+    with RouterReplay.record():
+        run(gate, torch.randn(4, 16))
+    captured = RouterReplay.collect()
+
+    with RouterReplay.replay(captured):
+        assert gate.router_replay.mode == RouterReplayMode.REPLAY
+        assert gate.router_replay.target_indices is not None
+    # Mode reset and target cleared so a later forward routes normally.
+    assert gate.router_replay.mode is None
+    assert gate.router_replay.target_indices is None
+
+    with RouterReplay.record():
+        assert gate.router_replay.mode == RouterReplayMode.RECORD
+    assert gate.router_replay.mode is None
+
+
+def test_clear_registry_unregisters():
+    make_gate()
+    make_gate()
+    assert len(RouterReplay.instances()) == 2
+    RouterReplay.clear_registry()
+    assert RouterReplay.instances() == []
+
+
+def test_clear_indices_drops_state_but_keeps_registration():
+    gate = make_gate()
+    with RouterReplay.record():
+        run(gate, torch.randn(4, 16))
+    gate.router_replay.set_target(torch.zeros(4, 2, dtype=torch.long))
+    assert gate.router_replay.recorded_indices is not None
+    assert gate.router_replay.target_indices is not None
+
+    RouterReplay.clear_indices()
+    assert gate.router_replay.recorded_indices is None
+    assert gate.router_replay.target_indices is None
+    # Instance is still registered after clearing its indices.
+    assert RouterReplay.instances() == [gate.router_replay]
+
+
+# --------------------------------------------------------------------------- #
+# Gemma4Gate (custom router) honours routing replay too
+# --------------------------------------------------------------------------- #
+
+
+def _gemma4_text_config():
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        hidden_size=16,
+        num_experts=8,
+        top_k_experts=2,
+        rms_norm_eps=1e-6,
+        torch_dtype=torch.float32,
+    )
+
+
+def _make_gemma4_gate(enable_routing_replay=True):
+    from nemo_automodel.components.models.gemma4_moe.model import Gemma4Gate
+
+    gate = Gemma4Gate(_gemma4_text_config(), enable_routing_replay=enable_routing_replay)
+    with torch.no_grad():
+        gate.proj.weight.normal_(0.0, 1.0)
+    return gate
+
+
+def test_gemma4_gate_disabled_has_no_handle():
+    gate = _make_gemma4_gate(enable_routing_replay=False)
+    assert gate.router_replay is None
+    assert RouterReplay.instances() == []
+
+
+def test_gemma4_gate_record_replay_roundtrip():
+    torch.manual_seed(4)
+    gate = _make_gemma4_gate()
+    assert RouterReplay.instances() == [gate.router_replay]
+
+    x_rollout = torch.randn(6, 16)
+    x_train = torch.randn(6, 16)
+
+    _, i_rollout, _ = gate(x_rollout)
+    _, i_train_free, _ = gate(x_train)
+    assert not torch.equal(i_rollout, i_train_free)
+
+    with RouterReplay.record():
+        gate(x_rollout)
+    captured = RouterReplay.collect()
+
+    with RouterReplay.replay(captured):
+        w_replay, i_replay, _ = gate(x_train)
+
+    assert torch.equal(i_replay, i_rollout)
+    # Weights are renormalized probabilities gathered from the live train logits.
+    assert torch.allclose(w_replay.sum(dim=-1), torch.ones(6), atol=1e-5)
+
+
+def test_gemma4_gate_replay_keeps_gradient():
+    torch.manual_seed(5)
+    gate = _make_gemma4_gate()
+    with RouterReplay.record():
+        gate(torch.randn(4, 16))
+    captured = RouterReplay.collect()
+    with RouterReplay.replay(captured):
+        w_replay, _, _ = gate(torch.randn(4, 16))
+    w_replay.sum().backward()
+    assert gate.proj.weight.grad is not None
+    assert torch.any(gate.proj.weight.grad != 0)


### PR DESCRIPTION
## What

Adds opt-in **Rollout Routing Replay (R3)** to the MoE subsystem.

In on-policy RL on a Mixture-of-Experts model, the rollout (inference) engine and the training engine compute the router's top-k expert selection independently. Small numerical differences flip a fraction of routing decisions per layer, and that compounds across layers until most tokens train under a different expert assignment than they were rolled out with. The mismatch breaks the importance-sampling assumption behind GRPO/GSPO and destabilizes training.

R3 removes the mismatch: capture the top-k expert **selection** during the rollout-equivalent forward, then replay that exact selection during the training forward. Only the discrete selection is replayed. The router logits and their softmax/sigmoid are still recomputed from the live router weights, so the gradient continues to flow into the router. This mirrors Megatron-LM's `moe_enable_routing_replay`.

## Changes

- `components/moe/router_replay.py` (new): a `RouterReplay` handle (RECORD / REPLAY modes) with a process-global per-layer registry plus `record()` / `replay()` context managers, and the `replay_selection` helper.
- `MoEConfig.enable_routing_replay` flag (default `False`).
- Hooks in the shared `Gate` (every `score_func` branch) and the custom `Gemma4Gate`, so both record and replay their final expert selection.
- Unit tests at 100% coverage of `router_replay.py`.

## Default path stays a no-op

When `enable_routing_replay=False` (the default), no `RouterReplay` handle is created and the gate forward is unchanged: `replay_selection` returns the original index tensor. The two branches that previously consumed `topk`'s returned values directly re-gather only when replay actually swapped the selection, guarded by an identity check, so the replay-off and record paths add no extra tensor work.

## Usage

```python
from nemo_automodel.components.moe.router_replay import RouterReplay

# Capture the selection on the rollout-equivalent forward.
with RouterReplay.record():
    model(batch)
captured = RouterReplay.collect()      # one tensor per MoE layer, in layer order

# Replay it on the training forward over the same tokens.
with RouterReplay.replay(captured):
    loss = model(batch)
loss.backward()
```

## Testing

Unit tests: `tests/unit_tests/moe/test_router_replay.py`, **27 tests, 100% coverage** of `router_replay.py`. They cover the record/replay roundtrip across every `score_func` branch, the default-path no-op, gradient flow to the router under replay, multi-layer distribute/collect, error handling, and the `Gemma4Gate` path.

Beyond the unit tests, I exercised the real Automodel model classes on GPU (record on batch A, replay on a different batch B):

| Check | Qwen3-MoE (`Qwen3MoeForCausalLM`, 3 MoE layers) | Gemma4-MoE (`Gemma4MoE` + `Gemma4Gate`) |
|---|---|---|
| Natural routing of A and B differs | yes | yes |
| Replay reproduces A's selection across all layers | yes | yes |
| Replay overrides B's natural selection | yes | yes |
| Router weight receives a gradient under replay | yes (CE-loss backward) | yes |

### Test environment

- 1x NVIDIA A800-80GB
- Python 3.12, PyTorch 2.12.0+cu130, Transformers 5.13.0.dev0
- `ruff format` and `ruff check` clean

Addresses #2454.
