### PR TITLE
docs: align nightly navigation routes

### DIFF
--- a/docs/fern/README.md
+++ b/docs/fern/README.md
@@ -6,7 +6,7 @@ This directory holds the Fern build infrastructure (config, repo-specific compon
 
 NVIDIA branding (logos, favicon, footer, fonts, NVIDIA-green CSS, OneTrust JS) comes from the central control repo at **[NVIDIA/fern-components](https://github.com/NVIDIA/fern-components)** via `global-theme: nvidia` in `docs.yml` — no logos or theme CSS are vendored locally.
 
-## Quick links
+## Quick Links
 
 | What | Where |
 |---|---|
@@ -42,7 +42,7 @@ make docs-check
 
 **`make docs-login` is load-bearing.** Skip it and `fern docs md generate` returns `HTTP 403: User does not belong to organization` — the CLI's `fern login` flow alone is *not* enough; Fern requires that you sign in to the dashboard first so your account record exists in Fern's user DB. See [NeMo Gym #1185](https://github.com/NVIDIA-NeMo/Gym/issues/1185) for the ugly version of that bug.
 
-### Fern CLI + docs reference
+### Fern CLI and Docs Reference
 
 | Resource | Link |
 |---|---|
@@ -88,7 +88,7 @@ The **`docs/` top-level tree IS the nightly tree** — every PR lands there. The
 
 **Only the nightly tree is on `main`.** The frozen `v0.4/pages/` snapshot lives on the **`docs-archive` branch** and is restored into the working copy before any Fern build — by `make docs-stitch` locally, or the `.github/actions/stitch-fern-versions` composite action in CI (publish, `fern check`, and preview all run it first). Fern reads one local tree and publishes a full-site snapshot, so the archived pages must be physically present at build time; they can't be sourced from another branch natively. The restore path is gitignored on `main`. To pull a version from an immutable tag instead of the branch: `make docs-check ARCHIVE_REF=docs/v0.4.0`.
 
-## Local development
+## Local Development
 
 From this directory (`cd docs/fern` first, or use `make -C docs/fern <target>` from anywhere):
 
@@ -104,13 +104,13 @@ For first-time-on-this-machine setup, see the [Quickstart](#quickstart) above �
 
 `fern docs md generate` (run by `make docs`) populates `docs/fern/product-docs/` from the `nemo_automodel` package source declared in the `libraries:` block of `docs.yml`. Without it, a cold `fern docs dev` will fail with `Folder not found: ./product-docs/...`. Re-run only when the upstream Python source changes — for prose-only iteration, `cd docs/fern && fern docs dev` alone is enough.
 
-## Sidebar fidelity rule
+## Sidebar Fidelity Rule
 
 **The published v0.4.0 sidebar at docs.nvidia.com/nemo/automodel/latest is the source of truth for section captions, page titles, and Model Coverage child ordering.** Don't silently shorten "Install NeMo AutoModel" to "Installation" or rename a section caption — engineers and the docs PM diff this site against the published one and any drift looks like a content regression.
 
 If you want a shorter or different sidebar label, change the toctree-derived display name in the source — never just retitle in the converted MDX.
 
-## Authoring conventions
+## Authoring Conventions
 
 ### Frontmatter
 
@@ -137,7 +137,7 @@ The shared NVIDIA `<CustomFooter />` (privacy / Do Not Sell / etc.) ships from t
 
 Standard Fern components are also available — `<Note>`, `<Tip>`, `<Info>`, `<Warning>`, `<Cards>` / `<Card>`, etc. Don't use GitHub `> [!NOTE]` syntax — it does not render in MDX.
 
-### Internal links
+### Internal Links
 
 Use **version-agnostic paths** (no `/latest/`, `/v0.4/`, or `/nightly/` prefix):
 
@@ -148,7 +148,7 @@ Use **version-agnostic paths** (no `/latest/`, `/v0.4/`, or `/nightly/` prefix):
 
 The same MDX backs every version slug — a hard-coded prefix would jump readers across versions. Page slugs come from explicit `slug:` overrides in the version YAML, not from the (often verbose) display title — so `Install NeMo AutoModel` is at `/get-started/installation`, not `/get-started/install-nemo-automodel`.
 
-### Cross-repo references (yaml configs, source files)
+### Cross-Repo References (YAML Configs, Source Files)
 
 Repository source paths like `examples/llm_finetune/foo.yaml` or `nemo_automodel/components/...` are not part of the docs site. Link to them as **absolute GitHub URLs**:
 
@@ -176,7 +176,7 @@ When the next GA cuts (e.g. `v0.5`):
 4. Add the new frozen-pin entry to `docs.yml` `versions:` (`display-name: "0.5.0"`, `slug: v0.5`, `availability: stable`); keep `v0.4` per support policy
 5. `docs/` keeps moving forward as the nightly tree; `versions/v0.4/pages/` and `versions/v0.5/pages/` are both frozen
 
-## CI and publishing
+## CI and Publishing
 
 | Workflow | Trigger | Purpose |
 |---|---|---|
@@ -197,7 +197,7 @@ DCO sign-off is required:
 git commit -s -m "docs: <add|update|remove> <page-title>"
 ```
 
-PR titles follow Conventional Commits (e.g. `docs(fern): add gemma4 fine-tuning guide`) — see [`AGENTS.md`](../../AGENTS.md) for the full convention.
+PR titles follow Conventional Commits (e.g., `docs(fern): add gemma4 fine-tuning guide`) — see [`AGENTS.md`](../../AGENTS.md) for the full convention.
 
 ## Troubleshooting
 

--- a/docs/fern/README.md
+++ b/docs/fern/README.md
@@ -57,7 +57,7 @@ make docs-check
 
 ## Layout
 
-```
+```text
 docs/                            ← nightly MDX lives here (sibling of fern/)
 ├── index.mdx, breaking-changes.mdx, release-notes.mdx, ...
 ├── about/, guides/, model-coverage/, launcher/, api-reference/
@@ -76,7 +76,7 @@ docs/                            ← nightly MDX lives here (sibling of fern/)
     └── product-docs/            # GENERATED Python API reference (gitignored — `make docs` regenerates)
 ```
 
-```
+```text
 File path                                                  Published URL
 ─────────────────────────────────────────────────────────  ─────────────────────────────────────────────────
 docs/get-started/installation.mdx                          docs.nvidia.com/nemo/automodel/nightly/get-started/installation

--- a/docs/fern/versions/nightly.yml
+++ b/docs/fern/versions/nightly.yml
@@ -51,6 +51,9 @@ navigation:
       - page: "Release Log"
         path: ../../model-coverage/latest-models.mdx
         slug: release-log
+      - page: "Troubleshooting Models and First Runs"
+        path: ../../model-coverage/troubleshooting.mdx
+        slug: troubleshooting
       - section: "Large Language Models"
         slug: large-language-models
         contents:
@@ -73,6 +76,7 @@ navigation:
             path: ../../model-coverage/llm/qwen/qwen3-next.mdx
           - page: "ERNIE 4.5"
             path: ../../model-coverage/llm/baidu/ernie4-5.mdx
+            slug: ernie-4-5
           - page: "DeepSeek"
             path: ../../model-coverage/llm/deepseek-ai/deepseek.mdx
           - page: "DeepSeek-V3"
@@ -85,26 +89,31 @@ navigation:
             path: ../../model-coverage/llm/mistralai/mixtral.mdx
           - page: "Ministral3 / Devstral"
             path: ../../model-coverage/llm/mistralai/ministral3.mdx
+            slug: ministral3-devstral
           - page: "Phi"
             path: ../../model-coverage/llm/microsoft/phi.mdx
           - page: "Phi-3 / Phi-4"
             path: ../../model-coverage/llm/microsoft/phi3.mdx
+            slug: phi-3-phi-4
           - page: "Phi-3-Small"
             path: ../../model-coverage/llm/microsoft/phi3-small.mdx
           - page: "Nemotron / Minitron"
             path: ../../model-coverage/llm/nvidia/nemotron.mdx
+            slug: nemotron-minitron
           - page: "Nemotron-H"
             path: ../../model-coverage/llm/nvidia/nemotron-h.mdx
           - page: "Nemotron-Flash"
             path: ../../model-coverage/llm/nvidia/nemotron-flash.mdx
           - page: "Nemotron-Super (Llama-3.3-Nemotron-Super-49B)"
             path: ../../model-coverage/llm/nvidia/nemotron-super.mdx
+            slug: nemotron-super-llama-3-3-nemotron-super-49b
           - page: "ChatGLM"
             path: ../../model-coverage/llm/thudm/chatglm.mdx
           - page: "GLM-4"
             path: ../../model-coverage/llm/thudm/glm4.mdx
           - page: "GLM-4 MoE (GLM-4.5 / GLM-4.7)"
             path: ../../model-coverage/llm/thudm/glm4-moe.mdx
+            slug: glm-4-moe-glm-4-5-glm-4-7
           - page: "GLM-5 MoE (DSA)"
             path: ../../model-coverage/llm/thudm/glm5-moe-dsa.mdx
           - page: "Granite"
@@ -127,14 +136,17 @@ navigation:
             path: ../../model-coverage/llm/eleutherai/gpt-j.mdx
           - page: "GPT-NeoX / Pythia"
             path: ../../model-coverage/llm/eleutherai/gpt-neox.mdx
+            slug: gpt-neox-pythia
           - page: "StarCoder"
             path: ../../model-coverage/llm/bigcode/starcoder.mdx
           - page: "StarCoder2"
             path: ../../model-coverage/llm/bigcode/starcoder2.mdx
           - page: "Aquila / Aquila2"
             path: ../../model-coverage/llm/baai/aquila.mdx
+            slug: aquila-aquila2
           - page: "Baichuan / Baichuan2"
             path: ../../model-coverage/llm/baichuan-inc/baichuan.mdx
+            slug: baichuan-baichuan2
           - page: "Command-R"
             path: ../../model-coverage/llm/cohere/command-r.mdx
           - page: "Falcon"
@@ -146,7 +158,7 @@ navigation:
           - page: "Jais"
             path: ../../model-coverage/llm/inceptionai/jais.mdx
           - page: "MiniMax-M2"
-            path: ../../model-coverage/llm/minimax/minimax-m2.md
+            path: ../../model-coverage/llm/minimax/minimax-m2.mdx
           - page: "MiniCPM"
             path: ../../model-coverage/llm/openbmb/minicpm.mdx
           - page: "Moonlight"
@@ -161,6 +173,7 @@ navigation:
             path: ../../model-coverage/llm/stabilityai/stablelm.mdx
           - page: "Step-3.5"
             path: ../../model-coverage/llm/stepfun-ai/step-3-5.mdx
+            slug: step-3-5
           - page: "GritLM"
             path: ../../model-coverage/llm/parasail-ai/gritlm.mdx
           - page: "Hy3-preview"
@@ -171,6 +184,7 @@ navigation:
             path: ../../model-coverage/llm/xiaomimimo/mimo-v2-flash.mdx
           - page: "Ling 2.0"
             path: ../../model-coverage/llm/inclusionai/ling-2.mdx
+            slug: ling-2-0
       - section: "Vision Language Models"
         slug: vision-language-models
         contents:
@@ -181,20 +195,25 @@ navigation:
             path: ../../model-coverage/vlm/moonshotai/kimi-vl.mdx
           - page: "Gemma 3 VL / Gemma 3n"
             path: ../../model-coverage/vlm/google/gemma3-vl.mdx
+            slug: gemma-3-vl-gemma-3n
           - page: "Gemma 4"
             path: ../../model-coverage/vlm/google/gemma4.mdx
           - page: "Qwen2.5-VL"
             path: ../../model-coverage/vlm/qwen/qwen2-5-vl.mdx
+            slug: qwen2-5-vl
           - page: "Qwen3-VL / Qwen3-VL-MoE"
             path: ../../model-coverage/vlm/qwen/qwen3-vl.mdx
+            slug: qwen3-vl-qwen3-vl-moe
           - page: "Qwen3.5-VL"
             path: ../../model-coverage/vlm/qwen/qwen3-5-vl.mdx
+            slug: qwen3-5-vl
           - page: "Nemotron-Parse"
             path: ../../model-coverage/vlm/nvidia/nemotron-parse.mdx
           - page: "Ministral3 VL"
             path: ../../model-coverage/vlm/mistralai/ministral3-vl.mdx
           - page: "Mistral Medium 3.5"
             path: ../../model-coverage/vlm/mistralai/mistral-medium-3-5.mdx
+            slug: mistral-medium-3-5
           - page: "Mistral-Small-4"
             path: ../../model-coverage/vlm/mistralai/mistral-small-4.mdx
           - page: "InternVL"
@@ -208,7 +227,11 @@ navigation:
           - page: "LLaVA"
             path: ../../model-coverage/vlm/llava-hf/llava.mdx
           - page: "Step-3.7-Flash"
-            path: ../../model-coverage/vlm/stepfun-ai/step-3-7.md
+            path: ../../model-coverage/vlm/stepfun-ai/step-3-7.mdx
+            slug: step-3-7-flash
+          - page: "MiniMax-M3"
+            path: ../../model-coverage/vlm/minimax/minimax-m3.mdx
+            slug: minimax-m3
       - section: "Multimodal"
         slug: multimodal
         contents:
@@ -227,6 +250,7 @@ navigation:
             path: ../../model-coverage/omni/qwen/qwen3-omni.mdx
           - page: "Qwen2.5-Omni"
             path: ../../model-coverage/omni/qwen/qwen2-5-omni.mdx
+            slug: qwen2-5-omni
           - page: "Phi-4-multimodal"
             path: ../../model-coverage/omni/microsoft/phi4-multimodal.mdx
           - page: "Nemotron-Omni"
@@ -247,12 +271,16 @@ navigation:
             slug: overview
           - page: "Wan 2.1 T2V"
             path: ../../model-coverage/diffusion/wan-ai/wan2-1-t2v.mdx
+            slug: wan-2-1-t2v
           - page: "Wan 2.2 T2V-A14B"
             path: ../../model-coverage/diffusion/wan-ai/wan2-2-t2v.mdx
+            slug: wan-2-2-t2v-a14b
           - page: "FLUX.1-dev"
             path: ../../model-coverage/diffusion/black-forest-labs/flux.mdx
+            slug: flux-1-dev
           - page: "HunyuanVideo 1.5"
             path: ../../model-coverage/diffusion/hunyuanvideo-community/hunyuanvideo.mdx
+            slug: hunyuanvideo-1-5
           - page: "Qwen-Image"
             path: ../../model-coverage/diffusion/qwen/qwen-image.mdx
       - section: "Embedding Models"
@@ -286,7 +314,7 @@ navigation:
         path: ../../guides/llm/finetune.mdx
         slug: sft-peft
       - page: "Function Calling with FunctionGemma"
-        path: ../../guides/llm/toolcalling.md
+        path: ../../guides/llm/toolcalling.mdx
         slug: function-calling
       - page: "Multi-Turn Agent (Tool-Calling) SFT"
         path: ../../guides/llm/agent-sft.mdx
@@ -298,13 +326,13 @@ navigation:
         path: ../../guides/llm/large-moe-finetune.mdx
         slug: large-moe-fine-tuning
       - page: "DeepSeek V4 Flash"
-        path: ../../guides/llm/dsv4-flash.md
+        path: ../../guides/llm/dsv4-flash.mdx
         slug: deepseek-v4-flash
       - page: "Hy3-preview"
-        path: ../../guides/llm/hy3.md
+        path: ../../guides/llm/hy3.mdx
         slug: hy3-preview
       - page: "Nemotron-3-Ultra-550B"
-        path: ../../guides/llm/nemotron-3-ultra.md
+        path: ../../guides/llm/nemotron-3-ultra.mdx
         slug: nemotron-3-ultra
       - page: "Pretraining"
         path: ../../guides/llm/pretraining.mdx
@@ -319,31 +347,34 @@ navigation:
         path: ../../guides/llm/retrieval-finetune.mdx
         slug: retrieval-finetune
       - page: "Gemma 3 / 3n"
-        path: ../../guides/omni/gemma3-3n.md
+        path: ../../guides/omni/gemma3-3n.mdx
         slug: gemma-3-3n
       - page: "Gemma 4 31B"
-        path: ../../guides/vlm/gemma4.md
+        path: ../../guides/vlm/gemma4.mdx
         slug: gemma-4
       - page: "Qwen3.5-VL"
-        path: ../../guides/vlm/qwen3-5.md
+        path: ../../guides/vlm/qwen3-5.mdx
         slug: qwen3-5-vl
       - page: "Nemotron-Omni"
-        path: ../../guides/vlm/nemotron-omni.md
+        path: ../../guides/vlm/nemotron-omni.mdx
         slug: nemotron-omni
       - page: "Mistral Medium 3.5 VL"
-        path: ../../guides/vlm/mistral-medium-3-5.md
+        path: ../../guides/vlm/mistral-medium-3-5.mdx
         slug: mistral-medium-3-5
+      - page: "MiniMax-M3"
+        path: ../../guides/vlm/minimax-m3.mdx
+        slug: minimax-m3
       - page: "Fine-Tune Step-3.7-Flash"
-        path: ../../guides/vlm/step-3-7.md
+        path: ../../guides/vlm/step-3-7.mdx
         slug: step-3-7
       - page: "ASR with Qwen3-Omni"
-        path: ../../guides/audio/qwen3-omni-asr.md
+        path: ../../guides/audio/qwen3-omni-asr.mdx
         slug: qwen3-omni-asr
       - page: "Wan2.1-T2V Fine-Tuning"
         path: ../../guides/diffusion/finetune.mdx
         slug: diffusion-fine-tuning
       - page: "Fine-Tuning DiffusionGemma"
-        path: ../../guides/dllm/diffusiongemma.md
+        path: ../../guides/dllm/diffusiongemma.mdx
         slug: diffusiongemma
       - page: "Train an EAGLE Drafter for Speculative Decoding"
         path: ../../guides/speculative/eagle.mdx
@@ -358,6 +389,7 @@ navigation:
         path: ../../guides/llm/databricks.mdx
         slug: databricks
   - section: "Data"
+    slug: datasets
     contents:
       - page: "Overview"
         path: ../../guides/dataset-overview.mdx
@@ -381,6 +413,7 @@ navigation:
         path: ../../guides/diffusion/dataset.mdx
         slug: diffusion-dataset
   - section: "Run Jobs"
+    slug: job-launchers
     contents:
       - page: "Overview"
         path: ../../launcher/overview.mdx
@@ -401,6 +434,7 @@ navigation:
         path: ../../launcher/skypilot-kubernetes.mdx
         slug: skypilot-k8s
   - section: "Advanced Training"
+    slug: development
     contents:
       - page: "Checkpointing"
         path: ../../guides/checkpointing.mdx
@@ -423,6 +457,9 @@ navigation:
       - page: "MLflow Logging"
         path: ../../guides/mlflow-logging.mdx
         slug: mlflow-logging
+      - page: "Breaking Changes"
+        path: ../../breaking-changes.mdx
+        slug: breaking-changes
   - section: "Reference"
     slug: reference
     contents:


### PR DESCRIPTION
Summary:
- Updates nightly Fern navigation to prefer canonical .mdx routes for mirrored pages.
- Adds explicit slugs for model coverage, launcher, data, and advanced-training routes that need stable generated URLs.
- Adds the model troubleshooting and MiniMax-M3 routes to the nightly navigation.

Validation:
- git diff --check origin/main..akoumpa/docs-quality-foundation

Stack:
- 1/4 akoumpa/docs-quality-foundation
- 2/4 akoumpa/docs-quality-entrypoints
- 3/4 akoumpa/docs-quality-recipes
- 4/4 akoumpa/docs-quality-model-coverage