### PR TITLE
feat(nemotron_v3): run MTP heads under eval for validation acceptance metrics

### DIFF
--- a/nemo_automodel/components/models/nemotron_v3/model.py
+++ b/nemo_automodel/components/models/nemotron_v3/model.py
@@ -441,6 +441,12 @@ class NemotronHForCausalLM(HFCheckpointingMixin, GenerationMixin, nn.Module, MoE
         else:
             self.mtp = None
 
+        # When True, the MTP heads also run under eval mode (``self.training``
+        # False) so validation can measure per-head token acceptance. Defaults
+        # to False so generation/decoding never pays the MTP cost; the training
+        # harness toggles it around the validation forward only.
+        self.compute_mtp_in_eval = False
+
         if self.backend.enable_hf_state_dict_adapter:
             self.state_dict_adapter = NemotronV3StateDictAdapter(
                 config=config,
@@ -808,7 +814,11 @@ class NemotronHForCausalLM(HFCheckpointingMixin, GenerationMixin, nn.Module, MoE
         # MTP head: last PP stage in training only. Other stages / eval emit
         # placeholder empties below so the tuple arity stays 1 + D.
         mtp_per_depth_h: list[torch.Tensor] | None = None
-        if self.mtp is not None and self.training:
+        # Run the MTP heads in training, or in eval when explicitly requested for
+        # validation acceptance metrics. Never on the cached generation path —
+        # decoding feeds one token at a time and must not pay the MTP cost.
+        mtp_active = self.mtp is not None and (self.training or (self.compute_mtp_in_eval and not use_cache))
+        if mtp_active:
             mtp_attention_mask = (
                 causal_mask_mapping.get("full_attention") if causal_mask_mapping is not None else attention_mask
             )

--- a/tests/unit_tests/models/nemotron_v3/test_nemotron_v3_mtp.py
+++ b/tests/unit_tests/models/nemotron_v3/test_nemotron_v3_mtp.py
@@ -326,6 +326,48 @@ class TestMTPEnabled:
         assert model.mtp.layers[1].final_layernorm.weight.grad is not None
 
 
+class TestMTPComputeInEval:
+    """The ``compute_mtp_in_eval`` flag lets validation run the MTP heads to
+    measure per-head token acceptance, while the cached generation/decoding
+    path (``use_cache``) never pays the MTP cost. The flag defaults to False so
+    behavior is unchanged unless a harness explicitly opts in."""
+
+    def test_flag_defaults_false(self, backend):
+        """A freshly built model must not run MTP in eval by default."""
+        model, _ = _make_model(backend, mtp_layers=1, mtp_pattern="*E")
+        assert model.compute_mtp_in_eval is False
+
+    @pytest.mark.run_only_on("GPU")
+    def test_eval_runs_mtp_when_flag_enabled(self, backend):
+        """With the flag on and no KV cache, eval must emit per-depth hidden
+        states even though ``self.training`` is False."""
+        model, config = _make_model(backend, mtp_layers=1, mtp_pattern="*E")
+        model.eval()
+        model.compute_mtp_in_eval = True
+        input_ids = torch.randint(0, config.vocab_size, (2, 8))
+        out = model(input_ids, labels=input_ids.clone())
+        assert out.mtp_per_depth_h is not None
+        # D=1 in this fixture.
+        assert len(out.mtp_per_depth_h) == 1
+        assert out.mtp_loss_scaling_factor == 0.1
+
+    @pytest.mark.run_only_on("GPU")
+    def test_eval_skips_mtp_on_cached_decode_path(self, backend):
+        """Even with the flag on, the cached generation path (``use_cache``)
+        must skip MTP — decoding feeds one token at a time and must not pay
+        the MTP cost."""
+        from nemo_automodel.components.models.nemotron_v3.cache import NemotronHybridCache
+
+        model, config = _make_model(backend, mtp_layers=1, mtp_pattern="*E")
+        model.eval()
+        model.compute_mtp_in_eval = True
+        cache = NemotronHybridCache(config, batch_size=2, dtype=torch.bfloat16, device=torch.device("cuda"))
+        input_ids = torch.randint(0, config.vocab_size, (2, 8), device="cuda")
+        out = model.to("cuda")(input_ids, past_key_values=cache, use_cache=True)
+        assert out.mtp_per_depth_h is None
+        assert out.mtp_loss_scaling_factor is None
+
+
 # ---------------------------------------------------------------------------
 # State-dict adapter MTP key handling
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/models/nemotron_v3/test_nemotron_v3_mtp.py
+++ b/tests/unit_tests/models/nemotron_v3/test_nemotron_v3_mtp.py
@@ -242,6 +242,20 @@ def _make_model(backend, *, mtp_layers=0, mtp_pattern="", **cfg_overrides):
 
 
 class TestMTPDisabled:
+    def test_constructor_override_disables_native_mtp_config(self, backend):
+        """SpeechLM can skip a checkpoint-provided MTP head at load time."""
+        from nemo_automodel.components.models.nemotron_v3.model import NemotronHForCausalLM
+
+        config = MockNemotronV3Config(
+            num_nextn_predict_layers=1,
+            mtp_hybrid_override_pattern=None,
+            mtp_layers_block_type=["attention", "moe"],
+        )
+        model = NemotronHForCausalLM(config, backend=backend, num_nextn_predict_layers=0)
+
+        assert model.mtp is None
+        assert not model.mtp_config.enabled
+
     @pytest.mark.run_only_on("GPU")
     def test_no_mtp_when_config_omits_fields(self, backend):
         """When num_nextn_predict_layers is 0, self.mtp must be None and

--- a/tests/unit_tests/models/nemotron_v3/test_nemotron_v3_state_dict_adapter.py
+++ b/tests/unit_tests/models/nemotron_v3/test_nemotron_v3_state_dict_adapter.py
@@ -162,6 +162,53 @@ class TestNemotronV3AdapterDense:
         assert set(back.keys()) == set(hf_sd.keys())
 
 
+class TestNemotronV3AdapterMTP:
+    """MTP checkpoint namespace regressions."""
+
+    def test_view_loaded_mtp_experts_keep_native_namespace(self):
+        config = MockNemotronV3Config()
+        moe_config = MoEConfig(
+            n_routed_experts=2,
+            n_shared_experts=1,
+            n_activated_experts=1,
+            n_expert_groups=1,
+            n_limited_groups=1,
+            train_gate=True,
+            gate_bias_update_factor=0.0,
+            aux_loss_coeff=0.0,
+            score_func="sigmoid",
+            route_scale=1.0,
+            dim=256,
+            inter_dim=512,
+            moe_inter_dim=128,
+            norm_topk_prob=False,
+            expert_bias=False,
+            expert_activation="relu2",
+            dtype=torch.bfloat16,
+        )
+        adapter = NemotronV3StateDictAdapter(config, moe_config, BackendConfig(), dtype=torch.bfloat16)
+
+        # DCP writes these split tensors through views into the native grouped
+        # parameters. The merge therefore returns no tensor for them and uses
+        # view_loaded_native_keys to tell the loader they were loaded.
+        adapter._inplace_loaded_native_keys = {
+            "layers.1.mixer.experts.gate_and_up_projs",
+            "layers.1.mixer.experts.down_projs",
+        }
+        hf_state = {}
+        for expert_id in range(2):
+            hf_state[f"mtp.layers.1.mixer.experts.{expert_id}.up_proj.weight"] = torch.randn(128, 256)
+            hf_state[f"mtp.layers.1.mixer.experts.{expert_id}.down_proj.weight"] = torch.randn(256, 128)
+
+        native = adapter.from_hf(hf_state)
+
+        assert not native
+        assert adapter.view_loaded_native_keys == {
+            "mtp.layers.1.mixer.experts.gate_and_up_projs",
+            "mtp.layers.1.mixer.experts.down_projs",
+        }
+
+
 class TestNemotronV3AdapterToHf:
     """Test to_hf conversion."""
 


### PR DESCRIPTION

# What does this PR do ?

Adds a `compute_mtp_in_eval` flag to `NemotronHForCausalLM` so the MTP heads can optionally run during validation to measure per-head token acceptance, without adding any MTP cost to the cached generation/decoding path.

# Changelog

- Add `compute_mtp_in_eval` attribute (default `False`) to `NemotronHForCausalLM`.
- Gate the MTP forward on `self.training or (self.compute_mtp_in_eval and not use_cache)`, so MTP heads run in training as before, or in eval only when explicitly requested — and never on the cached generation path.
- The flag is toggled by the validation harness in NeMo around the validation forward; AutoModel only exposes the mechanism.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
