### PR TITLE
fix(docs): catch Fern MDX syntax errors

### DIFF
--- a/.agents/contributor-skills/fern-docs/SKILL.md
+++ b/.agents/contributor-skills/fern-docs/SKILL.md
@@ -213,12 +213,12 @@ For cross-repo references (yaml configs, Python source), use absolute GitHub URL
 ## Validate
 
 ```bash
-make docs-check          # `fern check` — config + MDX validation
+make docs-check          # MDX syntax validation + `fern check`
 ```
 
 Run from `docs/fern/` (`cd docs/fern && make docs-check`) or anywhere with `make -C docs/fern docs-check`.
 
-`fern check` must pass before commit. The dev server's broken-link warnings for version-prefixed routes (e.g. `/latest/get-started/installation` from MDX that uses `/get-started/installation`) are **false positives** — Fern's strict validator doesn't resolve version-agnostic links. The published site renders them correctly. The URLMap-based `validate_fern_internal_links.py` (under the convert-to-fern toolkit) is authoritative.
+`make docs-check` must pass before commit. It runs a no-secret MDX parser before `fern check`, so raw HTML must be valid JSX (for example, use `<img ... />`, not `<img ...>`). The dev server's broken-link warnings for version-prefixed routes (e.g. `/latest/get-started/installation` from MDX that uses `/get-started/installation`) are **false positives** — Fern's strict validator doesn't resolve version-agnostic links. The published site renders them correctly. The URLMap-based `validate_fern_internal_links.py` (under the convert-to-fern toolkit) is authoritative.
 
 To regenerate the autodoc library reference (gitignored under `docs/fern/product-docs/`):
 
@@ -244,7 +244,7 @@ backward-version pages (the `docs-archive` branch) into the working copy — the
 trees are not on `main`.
 
 ```
-                    ┌─ fern-docs-ci.yml                  → stitch → fern check (push to pull-request/<n>)
+                    ┌─ fern-docs-ci.yml                  → stitch → MDX syntax → fern check (push to pull-request/<n>)
 PR (touches docs/) ─┼─ fern-docs-preview-build.yml       → stitch → upload docs/ artifact (no secrets)
                     └─ fern-docs-preview-comment.yml     → 🌿 preview URL comment (consumes artifact)
 

--- a/.github/workflows/fern-docs-ci.yml
+++ b/.github/workflows/fern-docs-ci.yml
@@ -57,6 +57,14 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Validate MDX syntax
+        run: |
+          mdx_lint_dir="${RUNNER_TEMP}/mdx-lint"
+          mkdir -p "$mdx_lint_dir"
+          printf '%s\n' '{"private":true,"type":"module"}' > "$mdx_lint_dir/package.json"
+          npm --prefix "$mdx_lint_dir" install --silent @mdx-js/mdx@3 remark-frontmatter@5 remark-math@6 >/dev/null
+          MDX_LINT_PREFIX="$mdx_lint_dir" node tools/validate_mdx_syntax.mjs docs
+
       - name: Validate Fern configuration
         working-directory: ./docs/fern
         run: |

--- a/docs/fern/Makefile
+++ b/docs/fern/Makefile
@@ -37,6 +37,7 @@ help:
 	@echo "  make docs                   Generate library reference and start Fern dev server"
 	@echo "  make docs-stitch            Restore frozen backward-version pages from the $(ARCHIVE_REF) branch"
 	@echo "  make docs-check             Run 'fern check' (config + MDX validation)"
+	@echo "  make docs-mdx-check         Run MDX syntax validation"
 	@echo "  make docs-preview           Build a shared preview URL on *.docs.buildwithfern.com (needs DOCS_FERN_TOKEN)"
 	@echo "  make docs-publish           Trigger the 'Publish Fern Docs' workflow on origin/main"
 	@echo "  make docs-generate-library  Regenerate the autodoc library reference under product-docs/"
@@ -97,8 +98,15 @@ docs-login:
 docs: docs-stitch docs-generate-library
 	fern docs dev
 
-docs-check: docs-stitch
+docs-check: docs-mdx-check
 	fern check
+
+docs-mdx-check: docs-stitch
+	@tmp_dir="$$(mktemp -d)"; \
+	trap 'rm -rf "$$tmp_dir"' EXIT; \
+	printf '%s\n' '{"private":true,"type":"module"}' > "$$tmp_dir/package.json"; \
+	npm --prefix "$$tmp_dir" install --silent @mdx-js/mdx@3 remark-frontmatter@5 remark-math@6 >/dev/null; \
+	MDX_LINT_PREFIX="$$tmp_dir" MDX_LINT_REPO_ROOT="$(REPO_ROOT)" node "$(REPO_ROOT)/tools/validate_mdx_syntax.mjs" "$(REPO_ROOT)/docs"
 
 # Restore the frozen backward-version page trees into the working copy. They
 # live on the `$(ARCHIVE_REF)` branch (not on main), so a fresh clone has only

--- a/docs/fern/Makefile
+++ b/docs/fern/Makefile
@@ -36,7 +36,7 @@ help:
 	@echo "  make docs-login             FIRST-TIME SETUP — provision Fern account + CLI auth"
 	@echo "  make docs                   Generate library reference and start Fern dev server"
 	@echo "  make docs-stitch            Restore frozen backward-version pages from the $(ARCHIVE_REF) branch"
-	@echo "  make docs-check             Run 'fern check' (config + MDX validation)"
+	@echo "  make docs-check             Run MDX syntax validation + 'fern check'"
 	@echo "  make docs-mdx-check         Run MDX syntax validation"
 	@echo "  make docs-preview           Build a shared preview URL on *.docs.buildwithfern.com (needs DOCS_FERN_TOKEN)"
 	@echo "  make docs-publish           Trigger the 'Publish Fern Docs' workflow on origin/main"

--- a/docs/fern/Makefile
+++ b/docs/fern/Makefile
@@ -23,7 +23,7 @@ REPO_ROOT := $(shell git rev-parse --show-toplevel)
 
 .DEFAULT_GOAL := help
 
-.PHONY: help docs docs-login docs-check docs-preview docs-publish docs-generate-library docs-stitch
+.PHONY: help docs docs-login docs-check docs-preview docs-publish docs-generate-library docs-stitch docs-mdx-check
 
 help:
 	@echo ""

--- a/docs/fern/README.md
+++ b/docs/fern/README.md
@@ -95,7 +95,7 @@ From this directory (`cd docs/fern` first, or use `make -C docs/fern <target>` f
 ```bash
 make docs           # docs-stitch + `fern docs md generate` + `fern docs dev` → http://localhost:3002
 make docs-stitch    # restore frozen backward-version pages from the docs-archive branch
-make docs-check     # docs-stitch + `fern check` (config + MDX validation)
+make docs-check     # docs-stitch + MDX syntax validation + `fern check`
 make docs-preview   # docs-stitch + shared preview URL on *.docs.buildwithfern.com (needs DOCS_FERN_TOKEN)
 make docs-publish   # trigger the `Publish Fern Docs` workflow on origin/main
 ```
@@ -180,7 +180,7 @@ When the next GA cuts (e.g. `v0.5`):
 
 | Workflow | Trigger | Purpose |
 |---|---|---|
-| `fern-docs-ci.yml` | `push: pull-request/[0-9]+` (FW-CI mirror) | `fern check` on PRs |
+| `fern-docs-ci.yml` | `push: pull-request/[0-9]+` (FW-CI mirror) | MDX syntax validation + `fern check` on PRs |
 | `fern-docs-preview-build.yml` | `pull_request` | Untrusted half: collect `docs/fern/` artifact (no secrets) |
 | `fern-docs-preview-comment.yml` | `workflow_run` after build | Trusted half: build preview with `DOCS_FERN_TOKEN`, post 🌿 comment |
 | `publish-fern-docs.yml` | push to `main` (`docs/**`), `docs/v*` tag, or manual | Publish to docs.nvidia.com/nemo/automodel |
@@ -206,6 +206,7 @@ PR titles follow Conventional Commits (e.g., `docs(fern): add gemma4 fine-tuning
 | `fern check` YAML error | 2-space indent; `- page:` inside `contents:`; `path:` is relative to the version YAML (so nightly paths reach back up via `../../`) |
 | Page 404 in preview | `slug:` collision in the same section, or missing `slug:` override (default slugifies the long display title) |
 | `Folder not found: ./product-docs/...` in `fern docs dev` | Run `make docs` once; library generation populates `product-docs/` |
+| `Unexpected closing tag`, especially after raw HTML such as `<img>` | Use valid MDX/JSX syntax, for example self-close void elements as `<img ... />`; `make docs-check` catches this before publish |
 | `[ERR_PNPM_IGNORED_BUILDS]` on first `fern docs dev` | pnpm 10+ blocks esbuild's postinstall — `pnpm config set onlyBuiltDependencies '["esbuild"]' --location global`, then `rm -rf ~/.fern/app-preview` and retry |
 | Broken-link warning for version-agnostic path | `fern docs broken-links` false-positives on links without a version slug; the URLMap-based `validate_fern_internal_links.py` is authoritative |
 | `JSX expressions must have one parent element` | Wrap multi-element JSX in `<>...</>` or a `<div>` |

--- a/docs/guides/dllm/diffusiongemma.mdx
+++ b/docs/guides/dllm/diffusiongemma.mdx
@@ -89,13 +89,13 @@ The SFT and LoRA training curves on GSM8K (first 200 steps) are shown below.
 **SFT**
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/NVIDIA-NeMo/Automodel/main/docs/guides/dllm/diffusiongemma_sft.png" alt="DiffusionGemma SFT training curves" width="900">
+  <img src="https://raw.githubusercontent.com/NVIDIA-NeMo/Automodel/main/docs/guides/dllm/diffusiongemma_sft.png" alt="DiffusionGemma SFT training curves" width="900" />
 </p>
 
 **LoRA**
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/NVIDIA-NeMo/Automodel/main/docs/guides/dllm/diffusiongemma_lora.png" alt="DiffusionGemma LoRA training curves" width="900">
+  <img src="https://raw.githubusercontent.com/NVIDIA-NeMo/Automodel/main/docs/guides/dllm/diffusiongemma_lora.png" alt="DiffusionGemma LoRA training curves" width="900" />
 </p>
 
 

--- a/docs/guides/vlm/minimax-m3.mdx
+++ b/docs/guides/vlm/minimax-m3.mdx
@@ -75,11 +75,11 @@ The SFT and LoRA fine-tuning loss curves are shown below.
 **SFT**
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/NVIDIA-NeMo/Automodel/main/docs/guides/vlm/minimax_m3_sft.png" alt="Minimax-M3 SFT training loss curve" width="700">
+  <img src="https://raw.githubusercontent.com/NVIDIA-NeMo/Automodel/main/docs/guides/vlm/minimax_m3_sft.png" alt="Minimax-M3 SFT training loss curve" width="700" />
 </p>
 
 **LoRA**
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/NVIDIA-NeMo/Automodel/main/docs/guides/vlm/minimax_m3_lora.png" alt="Minimax-M3 LoRA training loss curve" width="700">
+  <img src="https://raw.githubusercontent.com/NVIDIA-NeMo/Automodel/main/docs/guides/vlm/minimax_m3_lora.png" alt="Minimax-M3 LoRA training loss curve" width="700" />
 </p>

--- a/tools/validate_mdx_syntax.mjs
+++ b/tools/validate_mdx_syntax.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { pathToFileURL } from "node:url";
+
+const repoRoot = path.resolve(process.env.MDX_LINT_REPO_ROOT ?? process.cwd());
+const roots = process.argv.slice(2);
+const rootsToCheck = roots.length > 0 ? roots : ["docs"];
+
+const dependencyRequire = process.env.MDX_LINT_PREFIX
+  ? createRequire(path.join(process.env.MDX_LINT_PREFIX, "package.json"))
+  : createRequire(import.meta.url);
+
+const { compile } = await import(pathToFileURL(dependencyRequire.resolve("@mdx-js/mdx")).href);
+const remarkFrontmatter = (await import(pathToFileURL(dependencyRequire.resolve("remark-frontmatter")).href)).default;
+const remarkMath = (await import(pathToFileURL(dependencyRequire.resolve("remark-math")).href)).default;
+
+function isGeneratedDocsPath(filePath) {
+  const relativePath = path.relative(repoRoot, filePath).split(path.sep).join("/");
+  return relativePath === "docs/fern/product-docs" || relativePath.startsWith("docs/fern/product-docs/");
+}
+
+async function collectMdxFiles(inputPath, files) {
+  const stat = await fs.stat(inputPath);
+  if (stat.isDirectory()) {
+    if (isGeneratedDocsPath(inputPath)) {
+      return;
+    }
+
+    const entries = await fs.readdir(inputPath, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.name === "node_modules" || entry.name === ".git") {
+        continue;
+      }
+      await collectMdxFiles(path.join(inputPath, entry.name), files);
+    }
+    return;
+  }
+
+  if (stat.isFile() && inputPath.endsWith(".mdx")) {
+    files.push(inputPath);
+  }
+}
+
+function formatError(filePath, error) {
+  const relativePath = path.relative(repoRoot, filePath);
+  const line = error.line ?? error.position?.start?.line;
+  const column = error.column ?? error.position?.start?.column;
+  const location = line && column ? `${relativePath}:${line}:${column}` : relativePath;
+  return `${location}: ${error.message}`;
+}
+
+const files = [];
+for (const root of rootsToCheck) {
+  await collectMdxFiles(path.resolve(root), files);
+}
+files.sort();
+
+let failures = 0;
+for (const file of files) {
+  try {
+    await compile(await fs.readFile(file, "utf8"), {
+      jsx: true,
+      remarkPlugins: [remarkFrontmatter, remarkMath],
+    });
+  } catch (error) {
+    failures += 1;
+    console.error(formatError(file, error));
+  }
+}
+
+if (failures > 0) {
+  console.error(`Found ${failures} MDX syntax error(s).`);
+  process.exit(1);
+}
+
+console.log(`Validated ${files.length} MDX files.`);


### PR DESCRIPTION
## Summary
- add a no-secret MDX syntax validation step to the Fern docs PR check
- wire the same validation into `make docs-check`
- self-close raw `<img>` tags that broke the publish job, plus the same latent issue in DiffusionGemma docs

## Evidence
- Failing publish job: https://github.com/NVIDIA-NeMo/Automodel/actions/runs/28267737434/job/83758291397
- Verified locally: `make -C docs/fern docs-check`
- Verified locally: `git diff --check`