### PR TITLE
chore(models): add 26.10 deprecation warnings for custom model classes

### DIFF
--- a/nemo_automodel/components/models/baichuan/model.py
+++ b/nemo_automodel/components/models/baichuan/model.py
@@ -50,6 +50,7 @@ from transformers.utils import logging
 from nemo_automodel.components.models.baichuan.configuration import BaichuanConfig
 from nemo_automodel.components.models.common.hf_checkpointing_mixin import HFCheckpointingMixin
 from nemo_automodel.components.models.common.utils import compute_lm_head_logits
+from nemo_automodel.components.models.deprecation import warn_deprecated_model_class
 
 logger = logging.get_logger(__name__)
 
@@ -486,6 +487,7 @@ class BaichuanForCausalLM(HFCheckpointingMixin, BaichuanPreTrainedModel, Generat
         supports_ep: bool = False
 
     def __init__(self, config: BaichuanConfig, **model_kwargs):
+        warn_deprecated_model_class("BaichuanForCausalLM")
         super().__init__(config)
         self.model = BaichuanModel(config)
         self.lm_head = NormHead(config.hidden_size, config.vocab_size, bias=False)

--- a/nemo_automodel/components/models/deprecation.py
+++ b/nemo_automodel/components/models/deprecation.py
@@ -1,0 +1,129 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Deprecation warnings for custom model classes scheduled for removal."""
+
+from __future__ import annotations
+
+import warnings
+
+_DEPRECATED_MODEL_YAMLS: dict[str, tuple[str, ...]] = {
+    "BaichuanForCausalLM": (
+        "examples/llm_finetune/baichuan/baichuan_2_7b_mock_fp8.yaml",
+        "examples/llm_finetune/baichuan/baichuan_2_7b_squad_peft.yaml",
+        "examples/llm_finetune/baichuan/baichuan_2_7b_squad.yaml",
+    ),
+    "Qwen2ForCausalLM": (
+        "examples/llm_benchmark/qwen/custom_qwen2_5_32b_peft_benchmark.yaml",
+        "examples/llm_benchmark/qwen/custom_qwen2_5_32b_peft_benchmark_2nodes.yaml",
+        "examples/llm_benchmark/qwen/qwen2_5_7b_peft_benchmark.yaml",
+        "examples/llm_finetune/agent/qwen2_5_3b_function_calling.yaml",
+        "examples/llm_finetune/agent/qwen2_5_3b_function_calling_lora.yaml",
+        "examples/llm_finetune/qwen/qwen2_5_0p5b_instruct_fineproofs_chat.yaml",
+        "examples/llm_finetune/qwen/qwen2_5_32b_peft_benchmark.yaml",
+        "examples/llm_finetune/qwen/qwen2_5_7b_hellaswag_fp8.yaml",
+        "examples/llm_finetune/qwen/qwen2_5_7b_instruct_chat.yaml",
+        "examples/llm_finetune/qwen/qwen2_5_7b_squad.yaml",
+        "examples/llm_finetune/qwen/qwen2_5_7b_squad_muon.yaml",
+        "examples/llm_finetune/qwen/qwen2_5_7b_squad_peft.yaml",
+        "examples/llm_finetune/qwen/qwen25_magi_prefix_tree_rollouts.yaml",
+        "examples/llm_finetune/seed/seed_coder_8b_instruct_hellaswag_fp8.yaml",
+        "examples/llm_finetune/seed/seed_coder_8b_instruct_squad.yaml",
+        "examples/llm_finetune/seed/seed_coder_8b_instruct_squad_peft.yaml",
+        "examples/llm_finetune/seed/seed_oss_36B_hellaswag.yaml",
+        "examples/llm_finetune/seed/seed_oss_36B_hellaswag_peft.yaml",
+    ),
+    "LlamaForCausalLM": (
+        "examples/llm_benchmark/llama3_1/llama3_1_8b_peft_benchmark.yaml",
+        "examples/llm_benchmark/llama3_3/custom_llama3_1_70b_pretrain_benchmark_8nodes.yaml",
+        "examples/llm_benchmark/llama3_3/custom_llama3_3_70b_instruct_peft_benchmark.yaml",
+        "examples/llm_benchmark/llama3_3/custom_llama3_3_70b_instruct_peft_benchmark_2nodes.yaml",
+        "examples/llm_benchmark/llama3_3/llama3_3_70b_instruct_peft_benchmark.yaml",
+        "examples/llm_benchmark/llama3_3/llama_3_3_70b_instruct_squad_peft_pp.yaml",
+        "examples/llm_finetune/llama3_1/customizer_llama_3_1_8b_full_sft_tp.yaml",
+        "examples/llm_finetune/llama3_1/llama3_1_8b_columnmapped_lora.yaml",
+        "examples/llm_finetune/llama3_1/llama3_1_8b_hellaswag_fp8.yaml",
+        "examples/llm_finetune/llama3_1/llama3_1_8b_hellaswag_pp.yaml",
+        "examples/llm_finetune/llama3_1/llama3_1_8b_hellaswag_pp_dynamic_seq_len.yaml",
+        "examples/llm_finetune/llama3_1/llama3_1_8b_instruct_squad_qlora_2node.yaml",
+        "examples/llm_finetune/llama3_1/llama3_1_8b_squad_qlora.yaml",
+        "examples/llm_finetune/llama3_2/customizer_llama_3_2_1b_full_sft.yaml",
+        "examples/llm_finetune/llama3_2/customizer_llama_3_2_1b_full_sft_chat.yaml",
+        "examples/llm_finetune/llama3_2/customizer_llama_3_2_1b_peft.yaml",
+        "examples/llm_finetune/llama3_2/customizer_llama_3_2_1b_peft_packing.yaml",
+        "examples/llm_finetune/llama3_2/llama3_2_1b_hellaswag.yaml",
+        "examples/llm_finetune/llama3_2/llama3_2_1b_hellaswag_hsdp.yaml",
+        "examples/llm_finetune/llama3_2/llama3_2_1b_hellaswag_megatron_fsdp.yaml",
+        "examples/llm_finetune/llama3_2/llama3_2_1b_hellaswag_peft.yaml",
+        "examples/llm_finetune/llama3_2/llama3_2_1b_squad.yaml",
+        "examples/llm_finetune/llama3_2/llama3_2_1b_squad_flashoptim.yaml",
+        "examples/llm_finetune/llama3_2/llama3_2_1b_squad_megatron_fsdp.yaml",
+        "examples/llm_finetune/llama3_2/llama3_2_1b_squad_neftune.yaml",
+        "examples/llm_finetune/llama3_2/llama3_2_1b_squad_peft.yaml",
+        "examples/llm_finetune/llama3_2/llama3_2_1b_squad_qat.yaml",
+        "examples/llm_finetune/llama3_2/llama3_2_1b_squad_skypilot.yaml",
+        "examples/llm_finetune/llama3_2/llama3_2_1b_squad_skypilot_kubernetes.yaml",
+        "examples/llm_finetune/llama3_2/llama3_2_1b_squad_skypilot_kubernetes_2nodes.yaml",
+        "examples/llm_finetune/llama3_2/llama_3_2_3b_instruct_squad.yaml",
+        "examples/llm_finetune/llama3_2/llama_3_2_3b_instruct_squad_peft.yaml",
+        "examples/llm_finetune/llama3_3/llama_3_3_70b_instruct_squad.yaml",
+        "examples/llm_finetune/llama3_3/llama_3_3_70b_instruct_squad_peft.yaml",
+        "examples/llm_finetune/llama3_3/llama_3_3_70b_instruct_squad_peft_qlora_spark.yaml",
+        "examples/llm_kd/llama3_2/llama3_2_1b_kd.yaml",
+        "examples/llm_pretrain/llama3_70b_pretrain.yaml",
+        "examples/speculative/eagle1/llama_eagle1_perfectblend.yaml",
+        "examples/speculative/eagle2/llama_eagle2_perfectblend.yaml",
+        "examples/speculative/eagle3/llama_eagle3_mvp.yaml",
+        "examples/speculative/eagle3/llama_eagle3_mvp_flash_attn.yaml",
+        "examples/speculative/eagle3/llama_eagle3_perfectblend.yaml",
+        "examples/speculative/eagle3/llama_eagle3_remote.yaml",
+        "examples/speculative/eagle3_1/llama_eagle3_1_mvp.yaml",
+        "examples/speculative/eagle3_1/llama_eagle3_1_perfectblend.yaml",
+        "examples/speculative/p-eagle/llama_peagle_mvp.yaml",
+    ),
+    "Glm4MoeForCausalLM": (
+        "examples/llm_benchmark/glm/glm_4.5_air_te_deepep.yaml",
+        "examples/llm_benchmark/glm/glm_4.7_te_deepep.yaml",
+        "examples/llm_benchmark/glm/glm47_lora.yaml",
+        "examples/llm_finetune/glm/glm_4.5_air_te_deepep.yaml",
+        "examples/llm_finetune/glm/glm_4.7_te_deepep.yaml",
+    ),
+    "Glm4MoeLiteForCausalLM": (
+        "examples/llm_benchmark/glm/glm_4.7_flash_lora.yaml",
+        "examples/llm_benchmark/glm/glm_4.7_flash_te_deepep.yaml",
+        "examples/llm_benchmark/glm/glm_4.7_flash_te_deepep_lora.yaml",
+        "examples/llm_finetune/glm/glm_4.7_flash_te_deepep.yaml",
+        "examples/llm_finetune/glm/glm_4.7_flash_te_packed_sequence.yaml",
+    ),
+    "KimiVLForConditionalGeneration": ("examples/vlm_finetune/kimi/kimi2vl_cordv2.yaml",),
+}
+
+
+def warn_deprecated_model_class(model_cls_name: str) -> None:
+    """Emit a deprecation warning for custom model classes removed in 26.10.
+
+    Args:
+        model_cls_name: Name of the model class being instantiated.
+    """
+    yaml_paths = _DEPRECATED_MODEL_YAMLS.get(model_cls_name)
+    if yaml_paths is None:
+        return
+
+    yaml_list = ", ".join(yaml_paths)
+    warnings.warn(
+        f"{model_cls_name} is deprecated and will be removed in NeMo AutoModel 26.10. "
+        f"Associated example configs: {yaml_list}",
+        category=FutureWarning,
+        stacklevel=3,
+    )

--- a/nemo_automodel/components/models/deprecation.py
+++ b/nemo_automodel/components/models/deprecation.py
@@ -122,7 +122,7 @@ def warn_deprecated_model_class(model_cls_name: str) -> None:
 
     yaml_list = ", ".join(yaml_paths)
     warnings.warn(
-        f"{model_cls_name} is deprecated and will be removed in NeMo AutoModel 26.10. "
+        f"{model_cls_name} is deprecated and will be removed in NeMo AutoModel 26.10 container release and NeMo-Automodel v0.7.0. "
         f"Associated example configs: {yaml_list}",
         category=FutureWarning,
         stacklevel=3,

--- a/nemo_automodel/components/models/glm4_moe/model.py
+++ b/nemo_automodel/components/models/glm4_moe/model.py
@@ -28,6 +28,7 @@ from nemo_automodel.components.models.common import (
 )
 from nemo_automodel.components.models.common.hf_checkpointing_mixin import HFCheckpointingMixin
 from nemo_automodel.components.models.common.utils import cast_model_to_dtype, compute_lm_head_logits
+from nemo_automodel.components.models.deprecation import warn_deprecated_model_class
 from nemo_automodel.components.models.glm4_moe.layers import Glm4MoeAttention
 from nemo_automodel.components.models.glm4_moe.state_dict_adapter import Glm4MoeStateDictAdapter
 from nemo_automodel.components.models.gpt_oss.rope_utils import RotaryEmbedding, position_ids_to_freqs_cis
@@ -270,6 +271,7 @@ class Glm4MoeForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
         backend: BackendConfig | None = None,
         **kwargs,
     ):
+        warn_deprecated_model_class("Glm4MoeForCausalLM")
         super().__init__()
         self.config = config
         self.backend = backend or BackendConfig()

--- a/nemo_automodel/components/models/glm4_moe_lite/model.py
+++ b/nemo_automodel/components/models/glm4_moe_lite/model.py
@@ -33,6 +33,7 @@ from nemo_automodel.components.models.deepseek_v3.rope_utils import (
     freqs_cis_from_position_ids,
     precompute_freqs_cis,
 )
+from nemo_automodel.components.models.deprecation import warn_deprecated_model_class
 from nemo_automodel.components.models.glm4_moe.state_dict_adapter import Glm4MoeStateDictAdapter
 from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
 from nemo_automodel.components.moe.layers import MLP, MoE, MoEConfig
@@ -272,6 +273,7 @@ class Glm4MoeLiteForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
         backend: BackendConfig | None = None,
         **kwargs,
     ):
+        warn_deprecated_model_class("Glm4MoeLiteForCausalLM")
         super().__init__()
         self.config = config
         self.backend = backend or BackendConfig()

--- a/nemo_automodel/components/models/kimivl/model.py
+++ b/nemo_automodel/components/models/kimivl/model.py
@@ -27,6 +27,7 @@ from transformers.models.deepseek_v3.configuration_deepseek_v3 import DeepseekV3
 from transformers.models.llava.modeling_llava import LlavaCausalLMOutputWithPast
 
 from nemo_automodel.components.models.common.hf_checkpointing_mixin import HFCheckpointingMixin
+from nemo_automodel.components.models.deprecation import warn_deprecated_model_class
 
 LOGGER = logging.getLogger(__name__)
 
@@ -655,6 +656,7 @@ class KimiVLForConditionalGeneration(HFCheckpointingMixin, nn.Module, MoEFSDPSyn
         return cls.from_config(config, *model_args, **kwargs)
 
     def __init__(self, config, moe_config: MoEConfig | None = None, backend: BackendConfig | None = None, **kwargs):
+        warn_deprecated_model_class("KimiVLForConditionalGeneration")
         super().__init__()
         self.config = config
         self.backend = backend or BackendConfig()

--- a/nemo_automodel/components/models/llama/model.py
+++ b/nemo_automodel/components/models/llama/model.py
@@ -51,6 +51,7 @@ from nemo_automodel.components.models.common import (
     initialize_rms_norm_module,
 )
 from nemo_automodel.components.models.common.hf_checkpointing_mixin import HFCheckpointingMixin
+from nemo_automodel.components.models.deprecation import warn_deprecated_model_class
 from nemo_automodel.components.models.llama.rope_utils import (
     LlamaRotaryEmbedding,
     apply_rotary_pos_emb,
@@ -420,6 +421,7 @@ class LlamaForCausalLM(HFCheckpointingMixin, LlamaPreTrainedModel):
         config: LlamaConfig,
         backend: Optional[BackendConfig] = None,
     ):
+        warn_deprecated_model_class("LlamaForCausalLM")
         super().__init__(config)
         self.config = config
         self.backend = backend or BackendConfig()

--- a/nemo_automodel/components/models/qwen2/model.py
+++ b/nemo_automodel/components/models/qwen2/model.py
@@ -49,6 +49,7 @@ from nemo_automodel.components.models.common import (
     initialize_rms_norm_module,
 )
 from nemo_automodel.components.models.common.hf_checkpointing_mixin import HFCheckpointingMixin
+from nemo_automodel.components.models.deprecation import warn_deprecated_model_class
 
 # Use shared rope_utils (same implementation as Llama, supports both config formats)
 from nemo_automodel.components.models.llama.rope_utils import (
@@ -392,6 +393,7 @@ class Qwen2ForCausalLM(HFCheckpointingMixin, Qwen2PreTrainedModel):
         config: Qwen2Config,
         backend: Optional[BackendConfig] = None,
     ):
+        warn_deprecated_model_class("Qwen2ForCausalLM")
         super().__init__(config)
         self.backend = backend or BackendConfig()
         self.model = Qwen2Model(config=config, backend=self.backend)


### PR DESCRIPTION
Emit FutureWarning on init for Baichuan, Qwen2, Llama, GLM-4 MoE, and Kimi-VL custom implementations, listing associated example YAML configs.

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
