### PR TITLE
fix(optim): align Dion mesh with FSDP sharding

### DIFF
--- a/nemo_automodel/components/optim/dion.py
+++ b/nemo_automodel/components/optim/dion.py
@@ -20,6 +20,8 @@ from typing import Any, Optional, Protocol
 
 import torch.nn as nn
 
+from nemo_automodel.components.distributed.mesh_utils import get_fsdp_dp_mesh
+
 
 class _DionFamilyConfig(Protocol):
     """Structural type for the dion-family optimizer configs build_dion_optimizer reads."""
@@ -147,14 +149,11 @@ def _get_dion_mesh(device_mesh: Any) -> Any:
     if not hasattr(device_mesh, "ndim") or device_mesh.ndim == 1:
         return device_mesh
     try:
-        logger.info(f"[Dion] Extracting dp_shard_cp 1D submesh from device_mesh: {device_mesh}")
-        dp_mesh_2d = device_mesh[("dp_replicate", "dp_shard_cp")]
-        submesh = dp_mesh_2d["dp_shard_cp"]
-        if hasattr(submesh, "ndim") and submesh.ndim == 1:
-            logger.info(f"[Dion] Extracted dp_shard_cp 1D submesh via 2D mesh: {submesh}")
-            return submesh
-    except (KeyError, RuntimeError, TypeError) as e:
-        logger.debug(f"[Dion] Could not access via (dp_replicate, dp_shard_cp): {e}")
+        dion_mesh = get_fsdp_dp_mesh(device_mesh)
+        logger.info(f"[Dion] Resolved FSDP DP mesh from device_mesh: {dion_mesh}")
+        return dion_mesh
+    except (AttributeError, KeyError, RuntimeError, TypeError) as e:
+        logger.debug(f"[Dion] Could not resolve FSDP DP mesh: {e}")
     return device_mesh
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -465,6 +465,8 @@ modules = [
     "nemo_automodel.components.utils",
 ]
 ignore_imports = [
+    # Dion needs the FSDP DP mesh resolver so its optimizer mesh matches parameter sharding.
+    "nemo_automodel.components.optim.dion -> nemo_automodel.components.distributed.mesh_utils",
     "nemo_automodel.components.distributed.optimized_tp_plans -> nemo_automodel.components.models.llama.model",
     "nemo_automodel.components.distributed.optimized_tp_plans -> nemo_automodel.components.models.gemma4_moe.model",
     "nemo_automodel.components.distributed.optimized_tp_plans -> nemo_automodel.components.models.mistral3_vlm.model",

--- a/tests/unit_tests/optim/test_dion_optimizer_utils.py
+++ b/tests/unit_tests/optim/test_dion_optimizer_utils.py
@@ -34,9 +34,11 @@ class TinyModel(nn.Module):
 class FakeMesh:
     """Simple stand-in for a named DeviceMesh-like object."""
 
-    def __init__(self, mapping: dict, ndim: int = 1):
+    def __init__(self, mapping: dict, ndim: int = 1, mesh_dim_names: tuple = (), flatten_mapping: dict | None = None):
         self._mapping = dict(mapping)
         self.ndim = ndim
+        self.mesh_dim_names = mesh_dim_names
+        self._flatten_mapping = flatten_mapping or {}
 
     def __getitem__(self, key):
         if key not in self._mapping:
@@ -47,14 +49,18 @@ class FakeMesh:
 class FakeSubmesh:
     """A 1-D submesh stub returned from a 2-D mesh lookup."""
 
-    def __init__(self, mapping: dict | None = None):
+    def __init__(self, mapping: dict | None = None, size: int = 1):
         self.ndim = 1
         self._mapping = mapping or {}
+        self._size = size
 
     def __getitem__(self, key):
         if key not in self._mapping:
             raise KeyError(key)
         return self._mapping[key]
+
+    def size(self):
+        return self._size
 
 
 # ---------------------------------------------------------------------------
@@ -217,13 +223,44 @@ class TestGetDionMesh:
         mesh = object()  # no ndim attribute
         assert self._call(mesh) is mesh
 
-    def test_multidim_mesh_extracts_submesh(self):
-        inner_submesh = FakeSubmesh()
-        inner_submesh.ndim = 1
-        dp_2d = FakeSubmesh({"dp_shard_cp": inner_submesh})
-        mesh = FakeMesh({("dp_replicate", "dp_shard_cp"): dp_2d}, ndim=2)
+    def test_multidim_cp1_mesh_uses_native_dp_shard(self):
+        dp_shard = FakeSubmesh(size=8)
+        mesh = FakeMesh(
+            {
+                "dp_replicate": FakeSubmesh(size=1),
+                "dp_shard": dp_shard,
+                "cp": FakeSubmesh(size=1),
+            },
+            ndim=5,
+            mesh_dim_names=("dp_replicate", "dp_shard", "cp"),
+        )
         result = self._call(mesh)
-        assert result is inner_submesh
+        assert result is dp_shard
+
+    def test_multidim_cp_mesh_uses_flattened_dp_shard_cp(self):
+        dp_shard_cp = FakeSubmesh(size=16)
+        mesh = FakeMesh(
+            {
+                "dp_replicate": FakeSubmesh(size=1),
+                "dp_shard": FakeSubmesh(size=8),
+                "cp": FakeSubmesh(size=2),
+            },
+            ndim=5,
+            mesh_dim_names=("dp_replicate", "dp_shard", "cp"),
+            flatten_mapping={"dp_shard_cp": dp_shard_cp},
+        )
+        result = self._call(mesh)
+        assert result is dp_shard_cp
+
+    def test_multidim_mesh_uses_legacy_composed_dp_mesh(self):
+        dp_mesh = FakeSubmesh()
+        mesh = FakeMesh(
+            {("dp_replicate", "dp_shard_cp"): dp_mesh},
+            ndim=2,
+            mesh_dim_names=("dp_replicate", "dp_shard_cp"),
+        )
+        result = self._call(mesh)
+        assert result is dp_mesh
 
     def test_multidim_mesh_fallback_on_key_error(self):
         mesh = FakeMesh({}, ndim=2)
@@ -307,14 +344,20 @@ class TestBuildDionOptimizer:
         _, mesh_kwargs = self._build(monkeypatch, FakeDionConfig(), mesh=mesh, mesh_kwarg=None)
         assert mesh_kwargs == {}
 
-    def test_resolves_submesh_from_multidim(self, monkeypatch):
-        """A multi-dim mesh is reduced to its 1-D dp_shard_cp submesh."""
-        inner = FakeSubmesh()
-        inner.ndim = 1
-        dp_2d = FakeSubmesh({"dp_shard_cp": inner})
-        mesh = FakeMesh({("dp_replicate", "dp_shard_cp"): dp_2d}, ndim=2)
+    def test_resolves_native_dp_shard_from_cp1_multidim(self, monkeypatch):
+        """A cp=1 multi-dim mesh is reduced to its native 1-D dp_shard submesh."""
+        dp_shard = FakeSubmesh(size=8)
+        mesh = FakeMesh(
+            {
+                "dp_replicate": FakeSubmesh(size=1),
+                "dp_shard": dp_shard,
+                "cp": FakeSubmesh(size=1),
+            },
+            ndim=5,
+            mesh_dim_names=("dp_replicate", "dp_shard", "cp"),
+        )
         _, mesh_kwargs = self._build(monkeypatch, FakeDionConfig(), mesh=mesh)
-        assert mesh_kwargs == {"distributed_mesh": inner}
+        assert mesh_kwargs == {"distributed_mesh": dp_shard}
 
     def test_none_mesh_returns_empty(self, monkeypatch):
         """device_mesh=None yields no mesh kwargs."""


### PR DESCRIPTION
## Summary

- Keep the Dion/Muon mesh fix inside `_get_dion_mesh`.
- Delegate multi-dimensional mesh selection to `get_fsdp_dp_mesh`, so Dion uses the same FSDP DP mesh resolver as parameter sharding.
- Add a narrow import-linter exception for `nemo_automodel.components.optim.dion -> nemo_automodel.components.distributed.mesh_utils`, with a comment explaining the intentional resolver import.
- Preserve the fallback behavior of returning the original mesh if the shared resolver cannot resolve a DP mesh.

## Context

The failing release job created the optimizer with `DeviceMesh((dp_shard_cp=8), ...)`, while the DTensor parameters were sharded over `DeviceMesh((MeshAxisName.DP_SHARD=8), ...)` for a `cp_size=1` Qwen2.5 Muon recipe. That produced:

```text
Got DTensor sharded over mesh dimension 0 different from the optimizer's device mesh.
```

This patch makes Dion resolve the optimizer mesh through the shared FSDP DP mesh helper while keeping the import-linter allowance limited to this one direct module edge.

## Validation

Current PR head (`1a78ce402b8b024fc890f08e0ddcf0e8b410fba8`):

- `uv run pytest tests/unit_tests/optim/test_dion_optimizer_utils.py tests/unit_tests/distributed/test_mesh_utils.py -q` -> `62 passed`
- `uv run lint-imports --verbose --no-cache` -> `Contracts: 1 kept, 0 broken`
- `uv run ruff format --check nemo_automodel/components/optim/dion.py tests/unit_tests/optim/test_dion_optimizer_utils.py pyproject.toml`
- `uv run ruff check nemo_automodel/components/optim/dion.py tests/unit_tests/optim/test_dion_optimizer_utils.py`
- Current-head scoped nemo-ci rerun: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/56018859
  - Automodel child pipeline: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/56019743
  - Leaf pipeline: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/56019760
  - Target job: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/349457015

Note: parent pipeline https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/56018692 failed before tests due to a runner checkout/auth failure on `.claude/external/e2etrain-skills`; the current rerun uses `GIT_SUBMODULE_PATHS=dlfw-ci` to avoid that unrelated submodule checkout.

Earlier scoped nemo-ci run for the same mesh-selection behavior before the final import-linter exception cleanup (`4f357c173756e9f941149b2d12bff518525e62fd`):

- Parent pipeline: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/55990062
- Automodel child pipeline: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/55993140
- Leaf pipeline: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/55993194
- Passing target job: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/349295219

The passing trace showed `nemo_automodel: 0.5.0+4f357c17`, Dion resolving `DeviceMesh((MeshAxisName.DP_SHARD=8), ...)`, and no recurrence of the DTensor mesh mismatch.

Original failing job: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/348871690
