### PR TITLE
fix(config): replace assert-based runtime validation

### DIFF
--- a/nemo_automodel/components/checkpoint/config.py
+++ b/nemo_automodel/components/checkpoint/config.py
@@ -131,9 +131,8 @@ class CheckpointingConfig:
 
         # Convert a raw string such as "safetensors" into the right Enum.
         formats = [v.value for v in SerializationFormat]
-        assert self.model_save_format in formats, (
-            f"Unsupported model save format: {self.model_save_format}. Supported formats: {formats}"
-        )
+        if self.model_save_format not in formats:
+            raise ValueError(f"Unsupported model save format: {self.model_save_format}. Supported formats: {formats}")
         self.model_save_format = SerializationFormat[self.model_save_format.upper()]
 
         # Normalize legacy bools and string aliases to a consolidated export mode.

--- a/nemo_automodel/components/optim/optimizer.py
+++ b/nemo_automodel/components/optim/optimizer.py
@@ -67,6 +67,26 @@ _DTYPE_FIELDS = ("master_weight_dtype", "exp_avg_dtype", "exp_avg_sq_dtype")
 # ---------------------------------------------------------------------------
 
 
+def _get_trainable_params_or_raise(part: torch.nn.Module) -> list[torch.nn.Parameter]:
+    trainable_params = [p for p in part.parameters() if p.requires_grad]
+    if not trainable_params:
+        raise ValueError("No trainable parameters found for optimizer build; expected at least one parameter.")
+    return trainable_params
+
+
+def _require_callable_factory(
+    factory: Callable[..., torch.optim.Optimizer] | None,
+) -> Callable[..., torch.optim.Optimizer]:
+    if not callable(factory):
+        raise TypeError("OptimizerFromFactoryConfig.factory must be a callable")
+    return factory
+
+
+# ---------------------------------------------------------------------------
+# Typed optimizer configs
+# ---------------------------------------------------------------------------
+
+
 @dataclass
 class OptimizerConfig:
     """Base optimizer config.
@@ -110,8 +130,7 @@ class OptimizerConfig:
         foreach = _foreach_for_mesh(device_mesh)
         optimizers: list[torch.optim.Optimizer] = []
         for part in getattr(model, "parts", [model]):
-            trainable_params = [p for p in part.parameters() if p.requires_grad]
-            assert len(trainable_params) > 0, "trainable_params cannot be empty"
+            trainable_params = _get_trainable_params_or_raise(part)
             optimizers.append(self._build_optimizer(trainable_params, foreach=foreach))
         warn_if_torch_adam_with_bf16_params(optimizer=optimizers, is_peft=is_peft, context="optim", logger=logger)
         return optimizers
@@ -368,7 +387,7 @@ class OptimizerFromFactoryConfig(OptimizerConfig):
         device_mesh: DeviceMesh | None = None,
         is_peft: bool = False,
     ) -> list[torch.optim.Optimizer]:
-        assert callable(self.factory), "OptimizerFromFactoryConfig.factory must be a callable"
+        factory = _require_callable_factory(self.factory)
         foreach = _foreach_for_mesh(device_mesh)
 
         kwargs = dict(self.kwargs)
@@ -379,14 +398,13 @@ class OptimizerFromFactoryConfig(OptimizerConfig):
         # Only inject ``foreach`` for factories that actually accept it. The TP>1 path sets
         # ``foreach=False`` via ``_foreach_for_mesh``; passing it to a factory that does not take
         # ``foreach`` (e.g. TE ``FusedAdam``) would raise.  Honour an explicit user-provided value.
-        if foreach is not None and "foreach" not in kwargs and _factory_accepts_foreach(self.factory):
+        if foreach is not None and "foreach" not in kwargs and _factory_accepts_foreach(factory):
             kwargs["foreach"] = foreach
 
         optimizers: list[torch.optim.Optimizer] = []
         for part in getattr(model, "parts", [model]):
-            trainable_params = [p for p in part.parameters() if p.requires_grad]
-            assert len(trainable_params) > 0, "trainable_params cannot be empty"
-            optimizers.append(self.factory(params=trainable_params, **kwargs))
+            trainable_params = _get_trainable_params_or_raise(part)
+            optimizers.append(factory(params=trainable_params, **kwargs))
         warn_if_torch_adam_with_bf16_params(optimizer=optimizers, is_peft=is_peft, context="optim", logger=logger)
         return optimizers
 
@@ -396,7 +414,7 @@ class OptimizerFromFactoryConfig(OptimizerConfig):
         *,
         device_mesh: DeviceMesh | None = None,
     ) -> torch.optim.Optimizer:
-        assert callable(self.factory), "OptimizerFromFactoryConfig.factory must be a callable"
+        factory = _require_callable_factory(self.factory)
         foreach = _foreach_for_mesh(device_mesh)
 
         kwargs = dict(self.kwargs)
@@ -404,10 +422,10 @@ class OptimizerFromFactoryConfig(OptimizerConfig):
             val = kwargs.get(attr, None)
             if isinstance(val, str):
                 kwargs[attr] = dtype_from_str(val)
-        if foreach is not None and "foreach" not in kwargs and _factory_accepts_foreach(self.factory):
+        if foreach is not None and "foreach" not in kwargs and _factory_accepts_foreach(factory):
             kwargs["foreach"] = foreach
 
-        return self.factory(params=param_groups, **kwargs)
+        return factory(params=param_groups, **kwargs)
 
 
 # ---------------------------------------------------------------------------

--- a/nemo_automodel/components/optim/scheduler.py
+++ b/nemo_automodel/components/optim/scheduler.py
@@ -87,33 +87,49 @@ class OptimizerParamScheduler:
         self.init_lr = init_lr
         self.max_lr = float(max_lr)
         self.min_lr = min_lr
-        assert self.min_lr >= 0.0
-        assert self.max_lr >= self.min_lr
-        assert self.init_lr <= self.max_lr
+        if self.min_lr < 0.0:
+            raise ValueError(f"min_lr must be >= 0.0, got {self.min_lr}")
+        if self.max_lr < self.min_lr:
+            raise ValueError(f"max_lr must be >= min_lr, got max_lr={self.max_lr}, min_lr={self.min_lr}")
+        if self.init_lr > self.max_lr:
+            raise ValueError(f"init_lr must be <= max_lr, got init_lr={self.init_lr}, max_lr={self.max_lr}")
 
         self.lr_warmup_steps = lr_warmup_steps
         self.num_steps = 0
         self.lr_decay_steps = lr_decay_steps
         self.wsd_decay_steps = wsd_decay_steps
         self.lr_wsd_decay_style = lr_wsd_decay_style
-        assert self.lr_decay_steps > 0
-        assert self.lr_warmup_steps < self.lr_decay_steps
+        if self.lr_decay_steps <= 0:
+            raise ValueError(f"lr_decay_steps must be > 0, got {self.lr_decay_steps}")
+        if self.lr_warmup_steps >= self.lr_decay_steps:
+            raise ValueError(
+                f"lr_warmup_steps must be < lr_decay_steps, got warmup={self.lr_warmup_steps}, decay={self.lr_decay_steps}"
+            )
 
         self.lr_decay_style = lr_decay_style
         if self.lr_decay_style == "WSD":
-            assert self.wsd_decay_steps is not None
+            if self.wsd_decay_steps is None:
+                raise ValueError("wsd_decay_steps must be set when lr_decay_style='WSD'")
 
         self.start_wd = start_wd
         self.end_wd = end_wd
-        assert self.start_wd >= 0.0
-        assert self.end_wd >= self.start_wd
+        if self.start_wd < 0.0:
+            raise ValueError(f"start_wd must be >= 0.0, got {self.start_wd}")
+        if self.end_wd < self.start_wd:
+            raise ValueError(f"end_wd must be >= start_wd, got start_wd={self.start_wd}, end_wd={self.end_wd}")
         self.wd_incr_steps = wd_incr_steps
         self.wd_incr_style = wd_incr_style
+        if self.wd_incr_style == "constant" and self.start_wd != self.end_wd:
+            raise ValueError(
+                "start_wd must equal end_wd when wd_incr_style='constant', "
+                f"got start_wd={self.start_wd}, end_wd={self.end_wd}"
+            )
 
         self.override_opt_param_scheduler = override_opt_param_scheduler
         self.use_checkpoint_opt_param_scheduler = use_checkpoint_opt_param_scheduler
         if self.override_opt_param_scheduler:
-            assert not self.use_checkpoint_opt_param_scheduler, "both override and use-checkpoint are set."
+            if self.use_checkpoint_opt_param_scheduler:
+                raise ValueError("both override and use-checkpoint are set.")
 
         # Set the learning rate
         self.step(0)
@@ -292,10 +308,11 @@ class OptimizerParamScheduler:
             return cls_value
 
         if not self.use_checkpoint_opt_param_scheduler:
-            assert cls_value == sd_value, (
-                f"OptimizerParamScheduler: class input value {cls_value} and checkpoint"
-                f"value {sd_value} for {name} do not match"
-            )
+            if cls_value != sd_value:
+                raise ValueError(
+                    f"OptimizerParamScheduler: class input value {cls_value} and checkpoint "
+                    f"value {sd_value} for {name} do not match"
+                )
 
         logger.info("using checkpoint value {} for {}".format(sd_value, name))
         return sd_value

--- a/tests/unit_tests/checkpoint/test_checkpoint_config.py
+++ b/tests/unit_tests/checkpoint/test_checkpoint_config.py
@@ -72,7 +72,7 @@ class TestCheckpointingConfig:
         assert str(cfg.checkpoint_dir) == "/tmp/ckpt"
 
     def test_invalid_format_raises(self):
-        with pytest.raises(AssertionError, match="Unsupported model save format"):
+        with pytest.raises(ValueError, match="Unsupported model save format"):
             CheckpointingConfig(
                 enabled=True,
                 checkpoint_dir="/tmp/ckpt",

--- a/tests/unit_tests/optim/test_optim_config.py
+++ b/tests/unit_tests/optim/test_optim_config.py
@@ -177,8 +177,28 @@ class TestOptimizerFromFactoryConfig:
         assert captured["master_weight_dtype"] is torch.bfloat16
 
     def test_build_requires_callable_factory(self):
-        with pytest.raises(AssertionError, match="must be a callable"):
+        with pytest.raises(TypeError, match="must be a callable"):
             OptimizerFromFactoryConfig(factory=None).build(_model())
+
+    def test_build_from_param_groups_requires_callable_factory(self):
+        with pytest.raises(TypeError, match="must be a callable"):
+            OptimizerFromFactoryConfig(factory=None).build_from_param_groups([])
+
+    def test_build_rejects_empty_trainable_params(self):
+        model = _model()
+        for param in model.parameters():
+            param.requires_grad = False
+
+        with pytest.raises(ValueError, match="No trainable parameters found"):
+            AdamWConfig().build(model)
+
+    def test_factory_build_rejects_empty_trainable_params(self):
+        model = _model()
+        for param in model.parameters():
+            param.requires_grad = False
+
+        with pytest.raises(ValueError, match="No trainable parameters found"):
+            OptimizerFromFactoryConfig(factory=torch.optim.SGD, kwargs={"lr": 0.01}).build(model)
 
     def test_build_from_param_groups_uses_factory(self):
         cfg = OptimizerFromFactoryConfig(

--- a/tests/unit_tests/optim/test_scheduler.py
+++ b/tests/unit_tests/optim/test_scheduler.py
@@ -65,9 +65,9 @@ def test_optimizer_param_scheduler_init_valid_params(dummy_optimizer):
 
 def test_optimizer_param_scheduler_init_invalid_lr_ranges(dummy_optimizer):
     """
-    Tests initialization with invalid learning rate ranges, expecting AssertionError.
+    Tests initialization with invalid learning rate ranges, expecting ValueError.
     """
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError, match="min_lr must be >= 0.0"):
         OptimizerParamScheduler(
             optimizer=dummy_optimizer,
             init_lr=1e-3,
@@ -81,7 +81,7 @@ def test_optimizer_param_scheduler_init_invalid_lr_ranges(dummy_optimizer):
             wd_incr_steps=500,
             wd_incr_style="linear",
         )
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError, match="max_lr must be >= min_lr"):
         OptimizerParamScheduler(
             optimizer=dummy_optimizer,
             init_lr=1e-3,
@@ -95,7 +95,7 @@ def test_optimizer_param_scheduler_init_invalid_lr_ranges(dummy_optimizer):
             wd_incr_steps=500,
             wd_incr_style="linear",
         )
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError, match="init_lr must be <= max_lr"):
         OptimizerParamScheduler(
             optimizer=dummy_optimizer,
             init_lr=1e-2,
@@ -113,9 +113,9 @@ def test_optimizer_param_scheduler_init_invalid_lr_ranges(dummy_optimizer):
 
 def test_optimizer_param_scheduler_init_invalid_warmup_decay_steps(dummy_optimizer):
     """
-    Tests initialization with invalid warmup and decay steps, expecting AssertionError.
+    Tests initialization with invalid warmup and decay steps, expecting ValueError.
     """
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError, match="lr_decay_steps must be > 0"):
         OptimizerParamScheduler(
             optimizer=dummy_optimizer,
             init_lr=1e-5,
@@ -129,7 +129,7 @@ def test_optimizer_param_scheduler_init_invalid_warmup_decay_steps(dummy_optimiz
             wd_incr_steps=500,
             wd_incr_style="linear",
         )
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError, match="lr_warmup_steps must be < lr_decay_steps"):
         OptimizerParamScheduler(
             optimizer=dummy_optimizer,
             init_lr=1e-5,
@@ -148,9 +148,9 @@ def test_optimizer_param_scheduler_init_invalid_warmup_decay_steps(dummy_optimiz
 def test_optimizer_param_scheduler_init_wsd_without_wsd_decay_steps(dummy_optimizer):
     """
     Tests initialization with 'WSD' decay style but missing `wsd_decay_steps`,
-    expecting AssertionError.
+    expecting ValueError.
     """
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError, match="wsd_decay_steps must be set"):
         OptimizerParamScheduler(
             optimizer=dummy_optimizer,
             init_lr=1e-5,
@@ -170,9 +170,9 @@ def test_optimizer_param_scheduler_init_wsd_without_wsd_decay_steps(dummy_optimi
 def test_optimizer_param_scheduler_init_override_and_use_checkpoint_error(dummy_optimizer):
     """
     Tests initialization when both `override_opt_param_scheduler` and
-    `use_checkpoint_opt_param_scheduler` are true, expecting AssertionError.
+    `use_checkpoint_opt_param_scheduler` are true, expecting ValueError.
     """
-    with pytest.raises(AssertionError, match="both override and use-checkpoint are set."):
+    with pytest.raises(ValueError, match="both override and use-checkpoint are set."):
         OptimizerParamScheduler(
             optimizer=dummy_optimizer,
             init_lr=1e-5,
@@ -273,7 +273,7 @@ def test_get_wd_constant(dummy_optimizer):
     scheduler.num_steps = 600
     assert scheduler.get_wd() == 0.05
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError, match="start_wd must equal end_wd"):
         OptimizerParamScheduler(
             optimizer=dummy_optimizer,
             init_lr=1e-5,
@@ -760,7 +760,7 @@ def test_load_state_dict_use_checkpoint_true(dummy_optimizer, caplog):
 def test_load_state_dict_use_checkpoint_false_mismatch(dummy_optimizer, caplog):
     """
     Tests `load_state_dict` when `use_checkpoint_opt_param_scheduler` is False
-    and parameters mismatch, expecting an AssertionError.
+    and parameters mismatch, expecting a ValueError.
     """
     caplog.set_level(logging.INFO)
 
@@ -795,8 +795,8 @@ def test_load_state_dict_use_checkpoint_false_mismatch(dummy_optimizer, caplog):
     }
 
     with pytest.raises(
-        AssertionError,
-        match="OptimizerParamScheduler: class input value 0.001 and checkpointvalue 0.002 for learning rate do not match",
+        ValueError,
+        match="OptimizerParamScheduler: class input value 0.001 and checkpoint value 0.002 for learning rate do not match",
     ):
         scheduler.load_state_dict(checkpoint_state)
 
@@ -808,7 +808,7 @@ def test_load_state_dict_override_true(dummy_optimizer, caplog):
     """
     caplog.set_level(logging.INFO)
 
-    with pytest.raises(AssertionError, match="both override and use-checkpoint are set"):
+    with pytest.raises(ValueError, match="both override and use-checkpoint are set"):
         scheduler = OptimizerParamScheduler(  # noqa: F841
             optimizer=dummy_optimizer,
             init_lr=1e-5,


### PR DESCRIPTION
# What does this PR do ?

Replaces assert-based runtime validation in the scheduler, checkpoint config, and optimizer build paths with explicit exceptions that still fire under `python -O`.

# Changelog

- replace scheduler constructor and checkpoint-mismatch asserts with explicit `ValueError`s
- replace checkpoint save-format assertion with an explicit `ValueError`
- replace empty-trainable-parameter and non-callable-factory asserts with explicit `ValueError` / `TypeError`
- update unit tests to validate the public exception types and add coverage for empty-trainable-parameter cases

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

# Additional Information

Root cause: several user-facing validation paths relied on `assert`, so running with optimized Python could strip the validation entirely. In practice that allowed invalid scheduler configs to construct, let scheduler checkpoint mismatches load silently, and downgraded some optimizer/checkpoint failures into less clear downstream exceptions.

Validation:
- `uv run pytest tests/unit_tests/optim/test_scheduler.py tests/unit_tests/optim/test_optim_config.py tests/unit_tests/checkpoint/test_checkpoint_config.py -v`
- `uv run --group linting ruff format nemo_automodel/components/optim/scheduler.py nemo_automodel/components/optim/optimizer.py nemo_automodel/components/checkpoint/config.py tests/unit_tests/optim/test_scheduler.py tests/unit_tests/optim/test_optim_config.py tests/unit_tests/checkpoint/test_checkpoint_config.py`
- `uv run --group linting ruff check nemo_automodel/components/optim/scheduler.py nemo_automodel/components/optim/optimizer.py nemo_automodel/components/checkpoint/config.py tests/unit_tests/optim/test_scheduler.py tests/unit_tests/optim/test_optim_config.py tests/unit_tests/checkpoint/test_checkpoint_config.py`
- `uv run python -O` smoke checks confirming invalid scheduler configs, checkpoint format, empty trainable parameter sets, and non-callable factories still fail explicitly
