### PR TITLE
fix(loss): localize DTensor labels before KD masking

### DIFF
--- a/nemo_automodel/components/loss/kd_loss.py
+++ b/nemo_automodel/components/loss/kd_loss.py
@@ -182,18 +182,10 @@ class KDLoss(nn.Module):
         Returns:
             Scalar KD loss.
         """
-        # Exclude padding / ignored tokens from the loss.
-        valid_mask = (labels != self.ignore_index).view(-1)
-        if valid_mask.sum() == 0:
-            # Entire batch contains only padding - return zero to keep gradients finite.
-            return student_logits.new_tensor(0.0)
-
         if student_logits.ndim > 2:
             student_logits = student_logits.view(-1, student_logits.shape[-1])
         if teacher_logits.ndim > 2:
             teacher_logits = teacher_logits.view(-1, teacher_logits.shape[-1])
-        if labels.ndim > 1:
-            labels = labels.view(-1)
 
         # Determine TP group: prefer explicit argument, then auto-detect from DTensor.
         tp_group = self.tp_group
@@ -206,6 +198,8 @@ class KDLoss(nn.Module):
                 student_logits = student_logits.to_local()
             if _HAVE_DTENSOR and isinstance(teacher_logits, DTensor):
                 teacher_logits = teacher_logits.to_local()
+            if _HAVE_DTENSOR and isinstance(labels, DTensor):
+                labels = labels.to_local()
         else:
             # Non-TP path: materialise full tensors.
             if _HAVE_DTENSOR and isinstance(student_logits, DTensor):
@@ -214,6 +208,16 @@ class KDLoss(nn.Module):
                 teacher_logits = teacher_logits.full_tensor()
             if _HAVE_DTENSOR and isinstance(labels, DTensor):
                 labels = labels.full_tensor()
+
+        if labels.ndim > 1:
+            labels = labels.view(-1)
+
+        # Exclude padding / ignored tokens from the loss after labels have been
+        # localized/materialized so the boolean mask matches the logits layout.
+        valid_mask = (labels != self.ignore_index).view(-1)
+        if valid_mask.sum() == 0:
+            # Entire batch contains only padding - return zero to keep gradients finite.
+            return student_logits.new_tensor(0.0)
 
         t_logits = teacher_logits[valid_mask]
         s_logits = student_logits[valid_mask]

--- a/tests/unit_tests/loss/test_kd_loss.py
+++ b/tests/unit_tests/loss/test_kd_loss.py
@@ -29,6 +29,17 @@ from nemo_automodel.components.loss.kd_loss import (
     _kl_forward_tp,
 )
 
+try:
+    from torch.distributed.device_mesh import init_device_mesh
+    from torch.distributed.tensor import DTensor, Replicate
+
+    HAVE_DTENSOR = True
+except Exception:  # pragma: no cover
+    DTensor = None  # type: ignore[assignment]
+    Replicate = None  # type: ignore[assignment]
+    init_device_mesh = None  # type: ignore[assignment]
+    HAVE_DTENSOR = False
+
 # ---------------------------------------------------------------------------
 # Reference implementation (no TP, no T² scaling applied yet)
 # ---------------------------------------------------------------------------
@@ -587,3 +598,33 @@ def test_kd_loss_tp_path_with_temperature(trivial_pg):
     assert torch.allclose(loss_no_tp, loss_tp, atol=1e-5), (
         f"Non-TP loss {loss_no_tp.item():.6f} != TP loss {loss_tp.item():.6f}"
     )
+
+
+@pytest.mark.skipif(not HAVE_DTENSOR, reason="DTensor not available")
+def test_kd_loss_materializes_dtensor_labels_before_masking():
+    """DTensor labels should be materialized before building the boolean mask."""
+    mesh = init_device_mesh("cpu", (1,), mesh_dim_names=("tp",))
+    student_logits = torch.randn(4, 8, dtype=torch.float32)
+    teacher_logits = torch.randn(4, 8, dtype=torch.float32)
+    labels_local = torch.tensor([0, -100, 1, 2])
+    labels = DTensor.from_local(labels_local, mesh, [Replicate()])
+
+    loss = KDLoss()(student_logits, teacher_logits, labels)
+    ref = _reference_kd_loss(student_logits, teacher_logits, labels_local)
+
+    assert torch.allclose(loss, ref, atol=1e-6), f"Expected {ref}, got {loss}"
+
+
+@pytest.mark.skipif(not HAVE_DTENSOR, reason="DTensor not available")
+def test_kd_loss_tp_path_localizes_dtensor_labels_before_masking(trivial_pg):
+    """Explicit TP path should localize DTensor labels before applying the mask."""
+    mesh = init_device_mesh("cpu", (1,), mesh_dim_names=("tp",))
+    student_logits = torch.randn(4, 8, dtype=torch.float32)
+    teacher_logits = torch.randn(4, 8, dtype=torch.float32)
+    labels_local = torch.tensor([0, -100, 1, 2])
+    labels = DTensor.from_local(labels_local, mesh, [Replicate()])
+
+    loss = KDLoss(tp_group=trivial_pg)(student_logits, teacher_logits, labels)
+    ref = _reference_kd_loss(student_logits, teacher_logits, labels_local)
+
+    assert torch.allclose(loss, ref, atol=1e-6), f"Expected {ref}, got {loss}"


### PR DESCRIPTION
## Summary
- localize or materialize `labels` before building the KD valid-token mask
- keep the mask aligned with the local/full logits layout in both TP and non-TP paths
- add DTensor regression coverage for both code paths

## Why
`KDLoss.forward()` built `valid_mask` from `labels` before handling DTensor inputs. When `student_logits` and `teacher_logits` were later converted to local or full tensors, the mask could still be a DTensor, which breaks boolean indexing or leaves the mask on a mismatched layout.

## Testing
- `uv run pytest tests/unit_tests/loss/test_kd_loss.py -v`
- `uv run --group linting ruff check nemo_automodel/components/loss/kd_loss.py tests/unit_tests/loss/test_kd_loss.py`
