### PR TITLE
feat(diffusion): support Hugging Face datasets

### DIFF
--- a/tests/unit_tests/diffusion_processors/test_hf_dataset_export.py
+++ b/tests/unit_tests/diffusion_processors/test_hf_dataset_export.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for Hugging Face diffusion dataset materialization."""
+
+import json
+
+import pytest
+from PIL import Image
+
+from tools.diffusion.data import hf_dataset_export
+
+
+class FakeDataset:
+    """Small dataset-like object for materialization tests."""
+
+    def __init__(self, rows):
+        self.rows = rows
+        self.column_names = list(rows[0]) if rows else []
+        self.features = {}
+
+    def __iter__(self):
+        return iter(self.rows)
+
+
+def test_materialize_hf_image_dataset_writes_jsonl_captions(tmp_path, monkeypatch):
+    rows = [
+        {"image": Image.new("RGB", (8, 8), color="red"), "text": "red square"},
+        {"image": Image.new("RGB", (8, 8), color="blue"), "text": "blue square"},
+    ]
+    monkeypatch.setattr(hf_dataset_export, "_load_hf_dataset", lambda *args, **kwargs: FakeDataset(rows))
+
+    export = hf_dataset_export.materialize_hf_dataset(
+        "org/images",
+        tmp_path,
+        media_type="image",
+        caption_field="internvl",
+        max_items=1,
+    )
+
+    assert export.total_items == 1
+    assert export.media_column == "image"
+    assert export.caption_column == "text"
+    assert (tmp_path / "hf_sample_00000000.png").exists()
+
+    caption_lines = (tmp_path / "hf_internvl.json").read_text(encoding="utf-8").splitlines()
+    assert len(caption_lines) == 1
+    assert json.loads(caption_lines[0]) == {
+        "file_name": "hf_sample_00000000.png",
+        "internvl": "red square",
+    }
+
+
+def test_materialize_hf_video_dataset_writes_sidecar_captions(tmp_path, monkeypatch):
+    rows = [{"video": {"bytes": b"fake-video", "path": "source.mov"}, "caption": "a short clip"}]
+    monkeypatch.setattr(hf_dataset_export, "_load_hf_dataset", lambda *args, **kwargs: FakeDataset(rows))
+
+    export = hf_dataset_export.materialize_hf_dataset(
+        "org/videos",
+        tmp_path,
+        media_type="video",
+        caption_field="caption",
+    )
+
+    assert export.total_items == 1
+    assert export.media_column == "video"
+    assert export.caption_column == "caption"
+    assert (tmp_path / "hf_sample_00000000.mov").read_bytes() == b"fake-video"
+    assert json.loads((tmp_path / "hf_sample_00000000.json").read_text(encoding="utf-8")) == {"caption": "a short clip"}
+
+
+def test_materialize_hf_video_dataset_accepts_url_mapping(tmp_path, monkeypatch):
+    source_path = tmp_path / "source.mov"
+    source_path.write_bytes(b"fake-video")
+    rows = [{"video": {"url": str(source_path)}, "caption": "a local clip"}]
+    monkeypatch.setattr(hf_dataset_export, "_load_hf_dataset", lambda *args, **kwargs: FakeDataset(rows))
+
+    export_dir = tmp_path / "export"
+    export = hf_dataset_export.materialize_hf_dataset("org/videos", export_dir, media_type="video")
+
+    assert export.total_items == 1
+    assert (export_dir / "hf_sample_00000000.mov").read_bytes() == b"fake-video"
+
+
+def test_materialize_hf_dataset_rejects_existing_export(tmp_path, monkeypatch):
+    rows = [{"image": Image.new("RGB", (8, 8), color="red"), "text": "red square"}]
+    monkeypatch.setattr(hf_dataset_export, "_load_hf_dataset", lambda *args, **kwargs: FakeDataset(rows))
+
+    hf_dataset_export.materialize_hf_dataset("org/images", tmp_path, media_type="image")
+    media_path = tmp_path / "hf_sample_00000000.png"
+    caption_path = tmp_path / "hf_internvl.json"
+    original_media = media_path.read_bytes()
+    original_captions = caption_path.read_text(encoding="utf-8")
+
+    with pytest.raises(ValueError, match="HF materialization directory is not empty; choose a new directory"):
+        hf_dataset_export.materialize_hf_dataset("org/images", tmp_path, media_type="image")
+
+    assert media_path.read_bytes() == original_media
+    assert caption_path.read_text(encoding="utf-8") == original_captions
+
+
+def test_materialize_hf_dataset_errors_when_media_column_cannot_be_inferred(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        hf_dataset_export,
+        "_load_hf_dataset",
+        lambda *args, **kwargs: FakeDataset([{"text": "caption only"}]),
+    )
+
+    with pytest.raises(ValueError, match="Pass --dataset_media_column"):
+        hf_dataset_export.materialize_hf_dataset("org/images", tmp_path, media_type="image")

--- a/tools/diffusion/data/hf_dataset_export.py
+++ b/tools/diffusion/data/hf_dataset_export.py
@@ -1,0 +1,431 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Materialize Hugging Face media datasets for diffusion preprocessing."""
+
+import json
+import logging
+import shutil
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+IMAGE_COLUMN_CANDIDATES = ("image", "jpg", "jpeg", "png", "webp")
+VIDEO_COLUMN_CANDIDATES = ("video", "mp4", "file", "video_path", "path")
+CAPTION_COLUMN_CANDIDATES = ("caption", "text", "prompt", "description")
+
+IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".webp", ".bmp"}
+VIDEO_EXTENSIONS = {".mp4", ".avi", ".mov", ".mkv", ".webm"}
+
+
+@dataclass(frozen=True)
+class HFDatasetExport:
+    """Summary of a materialized Hugging Face dataset split."""
+
+    media_dir: Path
+    total_items: int
+    media_column: str
+    caption_column: str | None
+    caption_file: Path | None = None
+
+
+def materialize_hf_dataset(
+    dataset_name: str,
+    output_dir: str | Path,
+    *,
+    media_type: str,
+    split: str = "train",
+    config_name: str | None = None,
+    media_column: str | None = None,
+    caption_column: str | None = None,
+    caption_field: str = "caption",
+    max_items: int | None = None,
+    streaming: bool = False,
+    trust_remote_code: bool | None = None,
+    download_timeout: int = 60,
+) -> HFDatasetExport:
+    """Download a Hugging Face split and export media plus captions locally.
+
+    The diffusion preprocessors operate on local image/video paths. This helper
+    adapts Hugging Face rows to that shape while preserving the existing
+    processor, bucketing, multiprocessing, and cache-writing paths.
+
+    Args:
+        dataset_name: Hugging Face dataset ID or local dataset path accepted by
+            ``datasets.load_dataset``.
+        output_dir: Directory where media files and caption metadata are written.
+        media_type: Either ``"image"`` or ``"video"``.
+        split: Dataset split to load.
+        config_name: Optional dataset config/subset name.
+        media_column: Optional source media column. If omitted, common names are
+            inferred from features or the first row.
+        caption_column: Optional source caption column. If omitted, common text
+            column names are inferred from features or the first row.
+        caption_field: Caption key to write in generated metadata.
+        max_items: Optional maximum number of rows to export.
+        streaming: Whether to stream the dataset from Hugging Face.
+        trust_remote_code: Optional value forwarded to ``load_dataset``.
+        download_timeout: Timeout in seconds for URL-backed media cells.
+
+    Returns:
+        Metadata describing the exported dataset.
+
+    Raises:
+        ValueError: If columns cannot be resolved or media cells use an
+            unsupported shape.
+    """
+    if media_type not in {"image", "video"}:
+        raise ValueError(f"media_type must be 'image' or 'video', got {media_type!r}")
+
+    output_path = Path(output_dir)
+    has_exported_samples = output_path.exists() and (
+        (output_path / "hf_internvl.json").exists() or any(output_path.glob("hf_sample_*"))
+    )
+    if has_exported_samples:
+        raise ValueError("HF materialization directory is not empty; choose a new directory")
+
+    dataset = _load_hf_dataset(
+        dataset_name,
+        split=split,
+        config_name=config_name,
+        streaming=streaming,
+        trust_remote_code=trust_remote_code,
+    )
+
+    available = _available_columns_from_dataset(dataset)
+    if available:
+        media_column = _resolve_media_column(available, media_type, media_column)
+        caption_column = _resolve_caption_column(available, caption_column)
+        dataset = _maybe_cast_decode_false(dataset, media_type, media_column)
+        row_iter = iter(dataset)
+        try:
+            first_row = next(row_iter)
+        except StopIteration as exc:
+            raise ValueError(f"Dataset {dataset_name!r} split {split!r} is empty") from exc
+    else:
+        row_iter = iter(dataset)
+        try:
+            first_row = next(row_iter)
+        except StopIteration as exc:
+            raise ValueError(f"Dataset {dataset_name!r} split {split!r} is empty") from exc
+
+        available = set(first_row.keys())
+        media_column = _resolve_media_column(available, media_type, media_column)
+        caption_column = _resolve_caption_column(available, caption_column)
+        dataset = _maybe_cast_decode_false(dataset, media_type, media_column)
+
+        # Re-create the iterator after an optional cast so rows reflect decode=False.
+        row_iter = iter(dataset)
+        try:
+            first_row = next(row_iter)
+        except StopIteration as exc:
+            raise ValueError(f"Dataset {dataset_name!r} split {split!r} is empty after media casting") from exc
+
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    caption_file = output_path / "hf_internvl.json" if media_type == "image" else None
+    if caption_file is not None:
+        caption_file.write_text("", encoding="utf-8")
+
+    total_items = 0
+    for index, row in enumerate(_chain_first(first_row, row_iter)):
+        if max_items is not None and index >= max_items:
+            break
+
+        media_value = row[media_column]
+        caption = _get_caption(row, caption_column, fallback=f"hf sample {index:08d}")
+
+        if media_type == "image":
+            file_name = f"hf_sample_{index:08d}{_media_suffix(media_value, default='.png', allowed=IMAGE_EXTENSIONS)}"
+            media_path = output_path / file_name
+            _write_image(media_value, media_path, download_timeout)
+            _append_jsonl_caption(caption_file, file_name, caption, caption_field)
+        else:
+            suffix = _media_suffix(media_value, default=".mp4", allowed=VIDEO_EXTENSIONS)
+            media_path = output_path / f"hf_sample_{index:08d}{suffix}"
+            _write_binary_or_path(media_value, media_path, download_timeout)
+            _write_sidecar_caption(media_path.with_suffix(".json"), caption, caption_field)
+
+        total_items += 1
+
+    return HFDatasetExport(
+        media_dir=output_path,
+        total_items=total_items,
+        media_column=media_column,
+        caption_column=caption_column,
+        caption_file=caption_file,
+    )
+
+
+def _load_hf_dataset(
+    dataset_name: str,
+    *,
+    split: str,
+    config_name: str | None,
+    streaming: bool,
+    trust_remote_code: bool | None,
+):
+    """Load a Hugging Face dataset split."""
+    from datasets import load_dataset
+
+    kwargs: dict[str, Any] = {"split": split, "streaming": streaming}
+    if config_name is not None:
+        kwargs["name"] = config_name
+    if trust_remote_code is not None:
+        kwargs["trust_remote_code"] = trust_remote_code
+
+    return load_dataset(dataset_name, **kwargs)
+
+
+def _chain_first(first_row: dict[str, Any], rows):
+    """Yield a consumed first row followed by the remaining iterator."""
+    yield first_row
+    yield from rows
+
+
+def _resolve_media_column(available: set[str], media_type: str, requested: str | None) -> str:
+    """Resolve the media column name."""
+    if requested is not None:
+        if requested not in available:
+            raise ValueError(f"media column {requested!r} not found. Available columns: {sorted(available)}")
+        return requested
+
+    candidates = IMAGE_COLUMN_CANDIDATES if media_type == "image" else VIDEO_COLUMN_CANDIDATES
+    for candidate in candidates:
+        if candidate in available:
+            return candidate
+
+    raise ValueError(
+        f"Could not infer {media_type} column. Pass --dataset_media_column. Available columns: {sorted(available)}"
+    )
+
+
+def _resolve_caption_column(available: set[str], requested: str | None) -> str | None:
+    """Resolve the caption column name."""
+    if requested is not None:
+        if requested not in available:
+            raise ValueError(f"caption column {requested!r} not found. Available columns: {sorted(available)}")
+        return requested
+
+    for candidate in CAPTION_COLUMN_CANDIDATES:
+        if candidate in available:
+            return candidate
+
+    return None
+
+
+def _available_columns_from_dataset(dataset) -> set[str]:
+    """Return dataset column names from metadata without reading rows."""
+    column_names = getattr(dataset, "column_names", None)
+    if column_names:
+        return set(column_names)
+    features = getattr(dataset, "features", None)
+    if features:
+        return set(features.keys())
+    return set()
+
+
+def _maybe_cast_decode_false(dataset, media_type: str, media_column: str):
+    """Prefer path/bytes cells for HF media features when available."""
+    features = getattr(dataset, "features", None)
+    if not features or media_column not in features:
+        return dataset
+
+    try:
+        if media_type == "image":
+            from datasets import Image
+
+            if isinstance(features[media_column], Image):
+                return dataset.cast_column(media_column, Image(decode=False))
+        else:
+            from datasets import Video
+
+            if isinstance(features[media_column], Video):
+                return dataset.cast_column(media_column, Video(decode=False))
+    except (ImportError, AttributeError, TypeError, ValueError) as exc:
+        logger.debug("Could not cast %s column %s to decode=False: %s", media_type, media_column, exc)
+
+    return dataset
+
+
+def _get_caption(row: dict[str, Any], caption_column: str | None, fallback: str) -> str:
+    """Read a caption from a row."""
+    if caption_column is None:
+        return fallback
+
+    caption = row.get(caption_column)
+    if caption is None:
+        return fallback
+    if isinstance(caption, list):
+        return " ".join(str(part) for part in caption if part is not None).strip() or fallback
+    return str(caption).strip() or fallback
+
+
+def _append_jsonl_caption(caption_file: Path, file_name: str, caption: str, caption_field: str) -> None:
+    """Append one image caption in the existing JSONL convention."""
+    with caption_file.open("a", encoding="utf-8") as f:
+        f.write(json.dumps({"file_name": file_name, caption_field: caption}) + "\n")
+
+
+def _write_sidecar_caption(caption_file: Path, caption: str, caption_field: str) -> None:
+    """Write one video sidecar caption."""
+    caption_file.write_text(json.dumps({caption_field: caption}, indent=2), encoding="utf-8")
+
+
+def _write_image(media_value: Any, output_path: Path, download_timeout: int) -> None:
+    """Write an image-like HF cell to disk."""
+    from PIL import Image
+
+    if isinstance(media_value, Image.Image):
+        media_value.convert("RGB").save(output_path)
+        return
+
+    if isinstance(media_value, dict):
+        raw_bytes = media_value.get("bytes")
+        raw_path = media_value.get("path") or media_value.get("url")
+        if raw_bytes is not None:
+            with Image.open(_bytes_io(raw_bytes)) as image:
+                image.convert("RGB").save(output_path)
+            return
+        if raw_path:
+            _copy_or_download(raw_path, output_path, download_timeout)
+            return
+
+    if isinstance(media_value, (bytes, bytearray, memoryview)):
+        with Image.open(_bytes_io(media_value)) as image:
+            image.convert("RGB").save(output_path)
+        return
+
+    if isinstance(media_value, (str, Path)):
+        _copy_or_download(media_value, output_path, download_timeout)
+        return
+
+    if hasattr(media_value, "__array__"):
+        import numpy as np
+
+        Image.fromarray(np.asarray(media_value)).convert("RGB").save(output_path)
+        return
+
+    raise ValueError(f"Unsupported image cell type: {type(media_value).__name__}")
+
+
+def _write_binary_or_path(media_value: Any, output_path: Path, download_timeout: int) -> None:
+    """Write a binary/path-like video HF cell to disk."""
+    if isinstance(media_value, dict):
+        raw_bytes = media_value.get("bytes")
+        raw_path = media_value.get("path") or media_value.get("url")
+        if raw_bytes is not None:
+            output_path.write_bytes(bytes(raw_bytes))
+            return
+        if raw_path:
+            _copy_or_download(raw_path, output_path, download_timeout)
+            return
+
+    if isinstance(media_value, (bytes, bytearray, memoryview)):
+        output_path.write_bytes(bytes(media_value))
+        return
+
+    if isinstance(media_value, (str, Path)):
+        _copy_or_download(media_value, output_path, download_timeout)
+        return
+
+    raise ValueError(
+        f"Unsupported video cell type: {type(media_value).__name__}. "
+        "Use a path, URL, bytes-backed cell, or cast the HF video column with decode=False."
+    )
+
+
+def _copy_or_download(source: str | Path, output_path: Path, timeout: int) -> None:
+    """Copy a local file or download an HTTP(S) URL."""
+    source_str = str(source)
+    if _is_http_url(source_str):
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with urllib.request.urlopen(source_str, timeout=timeout) as response:
+            output_path.write_bytes(response.read())
+        return
+    if _is_hf_url(source_str):
+        downloaded_path = _download_hf_url(source_str)
+        _copy_or_download(downloaded_path, output_path, timeout)
+        return
+
+    source_path = Path(source_str)
+    if not source_path.exists():
+        raise ValueError(f"Media path does not exist locally: {source_path}")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        output_path.hardlink_to(source_path)
+    except OSError:
+        shutil.copy2(source_path, output_path)
+
+
+def _media_suffix(media_value: Any, *, default: str, allowed: set[str]) -> str:
+    """Infer an output suffix from a path/URL cell."""
+    source_path = None
+    if isinstance(media_value, dict):
+        source_path = media_value.get("path") or media_value.get("url")
+    elif isinstance(media_value, (str, Path)):
+        source_path = media_value
+
+    if source_path:
+        parsed_path = urlparse(str(source_path)).path
+        suffix = Path(parsed_path).suffix.lower()
+        if suffix in allowed:
+            return suffix
+
+    return default
+
+
+def _is_http_url(value: str) -> bool:
+    """Return whether a string is an HTTP(S) URL."""
+    parsed = urlparse(value)
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+
+
+def _is_hf_url(value: str) -> bool:
+    """Return whether a string is a Hugging Face filesystem URL."""
+    return urlparse(value).scheme == "hf"
+
+
+def _download_hf_url(value: str) -> str:
+    """Download a Hugging Face filesystem URL and return the local cache path."""
+    from huggingface_hub import hf_hub_download
+
+    parsed = urlparse(value)
+    if parsed.netloc == "datasets":
+        path = parsed.path.lstrip("/")
+    else:
+        path = parsed.path.lstrip("/")
+        if path.startswith("datasets/"):
+            path = path.removeprefix("datasets/")
+
+    if "@" not in path:
+        raise ValueError(f"Unsupported Hugging Face media URL without revision: {value}")
+
+    repo_id, revision_and_file = path.split("@", 1)
+    if "/" not in revision_and_file:
+        raise ValueError(f"Unsupported Hugging Face media URL without file path: {value}")
+
+    revision, filename = revision_and_file.split("/", 1)
+    return hf_hub_download(repo_id=repo_id, filename=filename, revision=revision, repo_type="dataset")
+
+
+def _bytes_io(raw_bytes: bytes | bytearray | memoryview):
+    """Wrap raw bytes as a file-like object."""
+    import io
+
+    return io.BytesIO(bytes(raw_bytes))

--- a/tools/diffusion/preprocessing_multiprocess.py
+++ b/tools/diffusion/preprocessing_multiprocess.py
@@ -26,6 +26,14 @@ Usage:
         --output_dir /path/to/cache \\
         --processor flux
 
+    # Image preprocessing from a Hugging Face dataset
+    python -m tools.diffusion.preprocessing_multiprocess image \\
+        --dataset_name lambdalabs/naruto-blip-captions \\
+        --dataset_media_column image \\
+        --dataset_caption_column text \\
+        --output_dir /path/to/cache \\
+        --processor flux
+
     # Video preprocessing
     python -m tools.diffusion.preprocessing_multiprocess video \\
         --video_dir /path/to/videos \\
@@ -56,6 +64,7 @@ from PIL import Image
 from tqdm import tqdm
 
 from nemo_automodel.components.datasets.diffusion.multi_tier_bucketing import MultiTierBucketCalculator
+from tools.diffusion.data.hf_dataset_export import materialize_hf_dataset
 from tools.diffusion.processors import (
     BaseModelProcessor,
     BaseVideoProcessor,
@@ -274,7 +283,7 @@ def _process_shard_on_gpu(
 
 
 def preprocess_dataset(
-    image_dir: str,
+    image_dir: Optional[str],
     output_dir: str,
     processor_name: str,
     model_name: Optional[str] = None,
@@ -283,12 +292,21 @@ def preprocess_dataset(
     caption_field: str = "internvl",
     max_images: Optional[int] = None,
     max_pixels: int = 256 * 256,
+    *,
+    dataset_name: Optional[str] = None,
+    dataset_split: str = "train",
+    dataset_config_name: Optional[str] = None,
+    dataset_media_column: Optional[str] = None,
+    dataset_caption_column: Optional[str] = None,
+    dataset_dir: Optional[str] = None,
+    dataset_streaming: bool = False,
+    dataset_trust_remote_code: Optional[bool] = None,
 ):
     """
     Preprocess image dataset with one process per GPU.
 
     Args:
-        image_dir: Directory containing images
+        image_dir: Directory containing images. Required unless dataset_name is provided.
         output_dir: Output directory for cache
         processor_name: Name of processor to use (e.g., 'flux', 'sdxl')
         model_name: HuggingFace model name (uses processor default if None)
@@ -297,10 +315,49 @@ def preprocess_dataset(
         caption_field: Field to use from JSON captions ('internvl' or 'usr')
         max_images: Maximum number of images to process
         max_pixels: Maximum pixels per image
+        dataset_name: Optional Hugging Face dataset ID to materialize before preprocessing.
+        dataset_split: Hugging Face dataset split.
+        dataset_config_name: Optional Hugging Face dataset config/subset name.
+        dataset_media_column: Optional image column name.
+        dataset_caption_column: Optional caption/text column name.
+        dataset_dir: Optional directory for materialized HF media.
+        dataset_streaming: Whether to stream the HF dataset.
+        dataset_trust_remote_code: Optional trust_remote_code value for HF datasets.
     """
-    image_dir = Path(image_dir)
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
+
+    if dataset_name:
+        if image_dir is not None:
+            raise ValueError("Specify either image_dir or dataset_name, not both")
+        export_dir = dataset_dir or str(output_dir / "_hf_dataset" / "images")
+        export = materialize_hf_dataset(
+            dataset_name,
+            export_dir,
+            media_type="image",
+            split=dataset_split,
+            config_name=dataset_config_name,
+            media_column=dataset_media_column,
+            caption_column=dataset_caption_column,
+            caption_field=caption_field,
+            max_items=max_images,
+            streaming=dataset_streaming,
+            trust_remote_code=dataset_trust_remote_code,
+        )
+        logger.info(
+            "Materialized %d HF image samples from %s split %s to %s (media_column=%s, caption_column=%s)",
+            export.total_items,
+            dataset_name,
+            dataset_split,
+            export.media_dir,
+            export.media_column,
+            export.caption_column,
+        )
+        image_dir = str(export.media_dir)
+    elif image_dir is None:
+        raise ValueError("image_dir is required unless dataset_name is provided")
+
+    image_dir = Path(image_dir)
 
     # Get processor and resolve model name
     processor = ProcessorRegistry.get(processor_name)
@@ -818,7 +875,7 @@ def _process_video_shard_on_gpu(
 
 
 def preprocess_video_dataset(
-    video_dir: str,
+    video_dir: Optional[str],
     output_dir: str,
     processor_name: str,
     model_name: Optional[str] = None,
@@ -837,12 +894,21 @@ def preprocess_video_dataset(
     caption_field: str = "caption",
     shard_size: int = 10000,
     max_videos: Optional[int] = None,
+    *,
+    dataset_name: Optional[str] = None,
+    dataset_split: str = "train",
+    dataset_config_name: Optional[str] = None,
+    dataset_media_column: Optional[str] = None,
+    dataset_caption_column: Optional[str] = None,
+    dataset_dir: Optional[str] = None,
+    dataset_streaming: bool = False,
+    dataset_trust_remote_code: Optional[bool] = None,
 ):
     """
     Preprocess video dataset with one process per GPU.
 
     Args:
-        video_dir: Directory containing videos
+        video_dir: Directory containing videos. Required unless dataset_name is provided.
         output_dir: Output directory for cache
         processor_name: Name of processor ('wan', 'hunyuan')
         model_name: HuggingFace model name (uses processor default if None)
@@ -861,10 +927,50 @@ def preprocess_video_dataset(
         caption_field: Field name for captions
         shard_size: Number of videos per metadata shard
         max_videos: Maximum number of videos to process
+        dataset_name: Optional Hugging Face dataset ID to materialize before preprocessing.
+        dataset_split: Hugging Face dataset split.
+        dataset_config_name: Optional Hugging Face dataset config/subset name.
+        dataset_media_column: Optional video column name.
+        dataset_caption_column: Optional caption/text column name.
+        dataset_dir: Optional directory for materialized HF media.
+        dataset_streaming: Whether to stream the HF dataset.
+        dataset_trust_remote_code: Optional trust_remote_code value for HF datasets.
     """
-    video_dir = Path(video_dir)
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
+
+    if dataset_name:
+        if video_dir is not None:
+            raise ValueError("Specify either video_dir or dataset_name, not both")
+        export_dir = dataset_dir or str(output_dir / "_hf_dataset" / "videos")
+        export = materialize_hf_dataset(
+            dataset_name,
+            export_dir,
+            media_type="video",
+            split=dataset_split,
+            config_name=dataset_config_name,
+            media_column=dataset_media_column,
+            caption_column=dataset_caption_column,
+            caption_field=caption_field,
+            max_items=max_videos,
+            streaming=dataset_streaming,
+            trust_remote_code=dataset_trust_remote_code,
+        )
+        logger.info(
+            "Materialized %d HF video samples from %s split %s to %s (media_column=%s, caption_column=%s)",
+            export.total_items,
+            dataset_name,
+            dataset_split,
+            export.media_dir,
+            export.media_column,
+            export.caption_column,
+        )
+        video_dir = str(export.media_dir)
+        caption_format = "sidecar"
+    elif video_dir is None:
+        raise ValueError("video_dir is required unless dataset_name is provided")
+
+    video_dir = Path(video_dir)
 
     # Get processor and resolve model name
     processor = ProcessorRegistry.get(processor_name)
@@ -1003,6 +1109,12 @@ Examples:
   python -m tools.diffusion.preprocessing_multiprocess image \\
       --image_dir /data/images --output_dir /cache --processor flux
 
+  # Image preprocessing from a Hugging Face dataset
+  python -m tools.diffusion.preprocessing_multiprocess image \\
+      --dataset_name lambdalabs/naruto-blip-captions \\
+      --dataset_media_column image --dataset_caption_column text \\
+      --output_dir /cache --processor flux
+
   # Video preprocessing with Wan2.1
   python -m tools.diffusion.preprocessing_multiprocess video \\
       --video_dir /data/videos --output_dir /cache --processor wan \\
@@ -1023,7 +1135,20 @@ Examples:
     # Image subcommand
     # ===================
     image_parser = subparsers.add_parser("image", help="Preprocess images")
-    image_parser.add_argument("--image_dir", type=str, required=True, help="Input image directory")
+    image_parser.add_argument("--image_dir", type=str, default=None, help="Input image directory")
+    image_parser.add_argument("--dataset_name", type=str, default=None, help="Hugging Face dataset ID to materialize")
+    image_parser.add_argument("--dataset_split", type=str, default="train", help="HF dataset split")
+    image_parser.add_argument("--dataset_config_name", type=str, default=None, help="HF dataset config/subset name")
+    image_parser.add_argument("--dataset_media_column", type=str, default=None, help="HF image column name")
+    image_parser.add_argument("--dataset_caption_column", type=str, default=None, help="HF caption/text column name")
+    image_parser.add_argument("--dataset_dir", type=str, default=None, help="Directory for materialized HF media")
+    image_parser.add_argument("--dataset_streaming", action="store_true", help="Stream the HF dataset")
+    image_parser.add_argument(
+        "--dataset_trust_remote_code",
+        action="store_true",
+        default=None,
+        help="Pass trust_remote_code=True to datasets.load_dataset",
+    )
     image_parser.add_argument("--output_dir", type=str, required=True, help="Output cache directory")
     image_parser.add_argument("--processor", type=str, default="flux", help="Processor name (default: flux)")
     image_parser.add_argument("--model_name", type=str, default=None, help="Model name (uses processor default)")
@@ -1048,7 +1173,20 @@ Examples:
     # Video subcommand
     # ===================
     video_parser = subparsers.add_parser("video", help="Preprocess videos")
-    video_parser.add_argument("--video_dir", type=str, required=True, help="Input video directory")
+    video_parser.add_argument("--video_dir", type=str, default=None, help="Input video directory")
+    video_parser.add_argument("--dataset_name", type=str, default=None, help="Hugging Face dataset ID to materialize")
+    video_parser.add_argument("--dataset_split", type=str, default="train", help="HF dataset split")
+    video_parser.add_argument("--dataset_config_name", type=str, default=None, help="HF dataset config/subset name")
+    video_parser.add_argument("--dataset_media_column", type=str, default=None, help="HF video column name")
+    video_parser.add_argument("--dataset_caption_column", type=str, default=None, help="HF caption/text column name")
+    video_parser.add_argument("--dataset_dir", type=str, default=None, help="Directory for materialized HF media")
+    video_parser.add_argument("--dataset_streaming", action="store_true", help="Stream the HF dataset")
+    video_parser.add_argument(
+        "--dataset_trust_remote_code",
+        action="store_true",
+        default=None,
+        help="Pass trust_remote_code=True to datasets.load_dataset",
+    )
     video_parser.add_argument("--output_dir", type=str, required=True, help="Output cache directory")
     video_parser.add_argument(
         "--processor",
@@ -1126,6 +1264,9 @@ Examples:
 
     # Handle subcommands
     if args.command == "image":
+        if (args.image_dir is None) == (args.dataset_name is None):
+            parser.error("image requires exactly one of --image_dir or --dataset_name")
+
         if args.resolution_preset:
             max_pixels = MultiTierBucketCalculator.RESOLUTION_PRESETS[args.resolution_preset]
         elif args.max_pixels:
@@ -1143,9 +1284,20 @@ Examples:
             args.caption_field,
             args.max_images,
             max_pixels,
+            dataset_name=args.dataset_name,
+            dataset_split=args.dataset_split,
+            dataset_config_name=args.dataset_config_name,
+            dataset_media_column=args.dataset_media_column,
+            dataset_caption_column=args.dataset_caption_column,
+            dataset_dir=args.dataset_dir,
+            dataset_streaming=args.dataset_streaming,
+            dataset_trust_remote_code=args.dataset_trust_remote_code,
         )
 
     elif args.command == "video":
+        if (args.video_dir is None) == (args.dataset_name is None):
+            parser.error("video requires exactly one of --video_dir or --dataset_name")
+
         # Validate explicit size args
         if (args.height is None) != (args.width is None):
             parser.error("Both --height and --width must be specified together")
@@ -1170,6 +1322,14 @@ Examples:
             caption_field=args.caption_field,
             shard_size=args.shard_size,
             max_videos=args.max_videos,
+            dataset_name=args.dataset_name,
+            dataset_split=args.dataset_split,
+            dataset_config_name=args.dataset_config_name,
+            dataset_media_column=args.dataset_media_column,
+            dataset_caption_column=args.dataset_caption_column,
+            dataset_dir=args.dataset_dir,
+            dataset_streaming=args.dataset_streaming,
+            dataset_trust_remote_code=args.dataset_trust_remote_code,
         )
     else:
         parser.print_help()


### PR DESCRIPTION
# What does this PR do ?

Adds Hugging Face datasets as an input source for diffusion image and video preprocessing while retaining the existing local-media processing paths.

# Changelog

- Materialize image and video dataset cells from PIL images, arrays, bytes, local paths, HTTP(S) URLs, and Hugging Face URLs.
- Infer or accept explicit media and caption columns, dataset configs, splits, streaming, and remote-code trust settings.
- Export captions into the existing image JSONL and video sidecar formats before running the standard preprocessing pipeline.
- Add CLI validation requiring exactly one local directory or Hugging Face dataset source.
- Add unit coverage for image and video export, URL mappings, overwrite protection, and media-column validation.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed Contributor guidelines
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation? Documentation changes were intentionally excluded from this PR.

# Additional Information

Validation:
- `ruff format` and `ruff check` passed for all changed Python files.
- `pytest -q --confcutdir=tests/unit_tests/diffusion_processors tests/unit_tests/diffusion_processors/test_hf_dataset_export.py`: 5 passed.
