### PR TITLE
fix(ci): stabilize failed benchmark recipes

### DIFF
--- a/examples/llm_benchmark/deepseek/deepseek_v3_torch.yaml
+++ b/examples/llm_benchmark/deepseek/deepseek_v3_torch.yaml
@@ -33,7 +33,7 @@ benchmark:
 step_scheduler:
   gc_every_steps: 10
   global_batch_size: 512
-  local_batch_size: 4
+  local_batch_size: 2
   ckpt_every_steps: 1000
   val_every_steps: 1000
   num_epochs: 1

--- a/examples/llm_benchmark/deepseek/deepseek_v3_torch.yaml
+++ b/examples/llm_benchmark/deepseek/deepseek_v3_torch.yaml
@@ -109,3 +109,4 @@ ci:
   nodes: 32
   env_vars:
     RDZV_TIMEOUT: "900"
+    PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True"

--- a/examples/llm_benchmark/deepseek/deepseek_v3_torch.yaml
+++ b/examples/llm_benchmark/deepseek/deepseek_v3_torch.yaml
@@ -33,7 +33,7 @@ benchmark:
 step_scheduler:
   gc_every_steps: 10
   global_batch_size: 512
-  local_batch_size: 8
+  local_batch_size: 4
   ckpt_every_steps: 1000
   val_every_steps: 1000
   num_epochs: 1

--- a/examples/llm_benchmark/deepseek/deepseek_v3_torch.yaml
+++ b/examples/llm_benchmark/deepseek/deepseek_v3_torch.yaml
@@ -33,7 +33,7 @@ benchmark:
 step_scheduler:
   gc_every_steps: 10
   global_batch_size: 512
-  local_batch_size: 2
+  local_batch_size: 4
   ckpt_every_steps: 1000
   val_every_steps: 1000
   num_epochs: 1
@@ -47,6 +47,7 @@ distributed:
   ep_size: 64
 
   sequence_parallel: false
+  activation_checkpointing: true
 
   pipeline:
     pp_schedule: interleaved1f1b

--- a/examples/llm_benchmark/glm/glm_4.7_te_deepep.yaml
+++ b/examples/llm_benchmark/glm/glm_4.7_te_deepep.yaml
@@ -33,7 +33,7 @@ benchmark:
 step_scheduler:
   gc_every_steps: 10
   global_batch_size: 2048
-  local_batch_size: 4
+  local_batch_size: 2
   ckpt_every_steps: 1000
   val_every_steps: 1000
   num_epochs: 1

--- a/examples/llm_benchmark/glm/glm_4.7_te_deepep.yaml
+++ b/examples/llm_benchmark/glm/glm_4.7_te_deepep.yaml
@@ -33,7 +33,7 @@ benchmark:
 step_scheduler:
   gc_every_steps: 10
   global_batch_size: 2048
-  local_batch_size: 2
+  local_batch_size: 4
   ckpt_every_steps: 1000
   val_every_steps: 1000
   num_epochs: 1
@@ -59,7 +59,7 @@ distributed:
     layers_per_stage: 2
 
   moe:
-    reshard_after_forward: false
+    reshard_after_forward: true
     wrap_outer_model: false
 
 dist_env:

--- a/examples/llm_benchmark/glm/glm_4.7_te_deepep.yaml
+++ b/examples/llm_benchmark/glm/glm_4.7_te_deepep.yaml
@@ -33,7 +33,7 @@ benchmark:
 step_scheduler:
   gc_every_steps: 10
   global_batch_size: 2048
-  local_batch_size: 8
+  local_batch_size: 4
   ckpt_every_steps: 1000
   val_every_steps: 1000
   num_epochs: 1
@@ -113,3 +113,5 @@ optimizer:
 ci:
   time: "00:45:00"
   nodes: 32
+  env_vars:
+    PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True"

--- a/examples/llm_benchmark/gpt_oss/gptoss_120b_te_deepep.yaml
+++ b/examples/llm_benchmark/gpt_oss/gptoss_120b_te_deepep.yaml
@@ -47,7 +47,7 @@ distributed:
   ep_size: 64
 
   sequence_parallel: false
-  activation_checkpointing: false
+  activation_checkpointing: true
 
   pipeline:
     pp_schedule: interleaved1f1b
@@ -114,3 +114,5 @@ ci:
   time: "00:30:00"
   nodes: 8
   ep_size: 16
+  env_vars:
+    PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True"

--- a/examples/llm_benchmark/gpt_oss/gptoss_120b_te_deepep_gb200.yaml
+++ b/examples/llm_benchmark/gpt_oss/gptoss_120b_te_deepep_gb200.yaml
@@ -124,3 +124,5 @@ ci:
   nodes: 8
   cluster_tag: gb200
   ep_size: 16
+  env_vars:
+    PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True"

--- a/examples/llm_benchmark/gpt_oss/gptoss_20b_torch.yaml
+++ b/examples/llm_benchmark/gpt_oss/gptoss_20b_torch.yaml
@@ -33,7 +33,7 @@ benchmark:
 step_scheduler:
   gc_every_steps: 10
   global_batch_size: 256
-  local_batch_size: 2
+  local_batch_size: 1
   ckpt_every_steps: 1000
   val_every_steps: 1000
   num_epochs: 1

--- a/examples/llm_benchmark/llama3_3/custom_llama3_1_70b_pretrain_benchmark_8nodes.yaml
+++ b/examples/llm_benchmark/llama3_3/custom_llama3_1_70b_pretrain_benchmark_8nodes.yaml
@@ -94,3 +94,9 @@ distributed:
   reshard_after_forward: True
   patch_is_packed_sequence: True  # Patch transformers._is_packed_sequence to always return False: removes CPU-GPU sync per attention layer and ensures static shapes for torch.compile. Safe for non-packed (standard) training only.
   defer_fsdp_grad_sync: False   # Must be False with GA>1: True → delayed resharding → OOM
+
+ci:
+  nodes: 8
+  time: "00:30:00"
+  env_vars:
+    PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True"

--- a/examples/llm_benchmark/llama3_3/custom_llama3_1_70b_pretrain_benchmark_8nodes.yaml
+++ b/examples/llm_benchmark/llama3_3/custom_llama3_1_70b_pretrain_benchmark_8nodes.yaml
@@ -89,5 +89,8 @@ distributed:
   enable_async_tensor_parallel: False
   enable_fsdp2_prefetch: True
   enable_compile: True
+  # Keep the 8k benchmark shape but release each layer's full parameters before
+  # moving to the next one; the prior default retained enough all-gathers to OOM.
+  reshard_after_forward: True
   patch_is_packed_sequence: True  # Patch transformers._is_packed_sequence to always return False: removes CPU-GPU sync per attention layer and ensures static shapes for torch.compile. Safe for non-packed (standard) training only.
   defer_fsdp_grad_sync: False   # Must be False with GA>1: True → delayed resharding → OOM

--- a/examples/llm_benchmark/qwen/qwen3.5_moe_te_deepep.yaml
+++ b/examples/llm_benchmark/qwen/qwen3.5_moe_te_deepep.yaml
@@ -110,5 +110,5 @@ optimizer:
   weight_decay: 0
 
 ci:
-  time: "00:15:00"
+  time: "00:25:00"
   nodes: 1

--- a/examples/llm_benchmark/qwen/qwen3.5_moe_te_deepep.yaml
+++ b/examples/llm_benchmark/qwen/qwen3.5_moe_te_deepep.yaml
@@ -33,7 +33,7 @@ benchmark:
 step_scheduler:
   gc_every_steps: 10
   global_batch_size: 256
-  local_batch_size: 2
+  local_batch_size: 1
   ckpt_every_steps: 1000
   val_every_steps: 1000
   num_epochs: 1

--- a/nemo_automodel/_transformers/tokenization/nemo_auto_tokenizer.py
+++ b/nemo_automodel/_transformers/tokenization/nemo_auto_tokenizer.py
@@ -386,6 +386,24 @@ class NeMoAutoTokenizerWithBosEosEnforced(AutoTokenizer):
                     raise
             else:
                 raise
+        except AttributeError as e:
+            # DeepSeek-V3.2's remote config is intentionally loaded through
+            # Automodel's local config class, but AutoTokenizer independently
+            # creates a generic config only to discover the tokenizer.  Recent
+            # Transformers validates RoPE during that generic construction and
+            # requires this otherwise irrelevant field.  Supply a minimal config
+            # for tokenizer discovery; model construction still uses the recipe's
+            # DeepseekV32Config.
+            if "max_position_embeddings" not in str(e):
+                raise
+            from transformers import PretrainedConfig
+
+            tokenizer = super().from_pretrained(
+                pretrained_model_name_or_path,
+                *args,
+                config=PretrainedConfig(max_position_embeddings=1),
+                **kwargs,
+            )
 
         # Convert TikToken-based tokenizers to fast (Rust-backed) tokenizers so that
         # char_to_token() works natively for {% generation %} mask computation.

--- a/nemo_automodel/recipes/llm/benchmark.py
+++ b/nemo_automodel/recipes/llm/benchmark.py
@@ -72,9 +72,24 @@ def _infer_vocab_size(model_cfg):
         model_config = config_cls.from_pretrained(config_section.pretrained_model_name_or_path)
 
     if model_config is None:
-        model_config = AutoConfig.from_pretrained(
-            config_section.pretrained_model_name_or_path, trust_remote_code=trust_remote_code
-        )
+        try:
+            model_config = AutoConfig.from_pretrained(
+                config_section.pretrained_model_name_or_path, trust_remote_code=trust_remote_code
+            )
+        except Exception as exc:
+            # Step-3.5 publishes MTP layer metadata in ``layer_types`` in addition
+            # to its transformer-layer count.  Newer Transformers validates those
+            # lengths while loading a config even though benchmark setup only needs
+            # ``vocab_size``.  Reuse the tokenizer compatibility patch, then retry.
+            message = str(exc)
+            if "num_hidden_layers" not in message or "layer_types" not in message:
+                raise
+            from nemo_automodel._transformers.v4_patches.layer_types import relax_layer_types_validator
+
+            relax_layer_types_validator()
+            model_config = AutoConfig.from_pretrained(
+                config_section.pretrained_model_name_or_path, trust_remote_code=trust_remote_code
+            )
 
     if hasattr(model_config, "vocab_size"):
         return model_config.vocab_size

--- a/tests/unit_tests/recipes/llm/test_benchmark.py
+++ b/tests/unit_tests/recipes/llm/test_benchmark.py
@@ -180,7 +180,7 @@ class TestBenchmarkingRecipeInitialization:
 
         with patch("nemo_automodel.recipes.llm.benchmark.TrainFinetuneRecipeForNextTokenPrediction.__init__"):
             with patch("transformers.AutoConfig.from_pretrained", return_value=mock_model_config):
-                recipe = BenchmarkingRecipeForNextTokenPrediction(mock_config)
+                BenchmarkingRecipeForNextTokenPrediction(mock_config)
 
                 assert mock_config.dataset.vocab_size == 50257
 
@@ -225,6 +225,31 @@ class TestBenchmarkingRecipeInitialization:
             assert vocab_size == 163840
             mock_autoconfig.assert_called_once_with("moonshotai/Kimi-K2-Base", trust_remote_code=True)
 
+    def test_infer_vocab_size_retries_layer_type_validation_error(self, mock_config):
+        """Step-style MTP metadata should not prevent benchmark vocab inference."""
+        model_cfg = ConfigNamespace(
+            trust_remote_code=True,
+            config=ConfigNamespace(
+                _target_="transformers.AutoConfig.from_pretrained",
+                pretrained_model_name_or_path="stepfun-ai/Step-3.5-Flash",
+            ),
+        )
+        model_config = MagicMock(spec=["vocab_size"])
+        model_config.vocab_size = 151936
+        validation_error = ValueError("num_hidden_layers must equal layer_types")
+
+        with (
+            patch(
+                "transformers.AutoConfig.from_pretrained",
+                side_effect=[validation_error, model_config],
+            ) as mock_autoconfig,
+            patch("nemo_automodel._transformers.v4_patches.layer_types.relax_layer_types_validator") as relax,
+        ):
+            assert _infer_vocab_size(model_cfg) == 151936
+
+        relax.assert_called_once()
+        assert mock_autoconfig.call_count == 2
+
     def test_infer_vocab_size_method_target(self, mock_config):
         """`_target_` resolved to a classmethod (e.g. `Class.from_pretrained`) should be invoked directly."""
         mock_model_config = MagicMock(spec=["vocab_size"])
@@ -264,7 +289,7 @@ class TestBenchmarkingRecipeInitialization:
     def test_init_sets_batch_size_from_scheduler(self, mock_config):
         """Test that batch_size is set from step_scheduler."""
         with patch("nemo_automodel.recipes.llm.benchmark.TrainFinetuneRecipeForNextTokenPrediction.__init__"):
-            recipe = BenchmarkingRecipeForNextTokenPrediction(mock_config)
+            BenchmarkingRecipeForNextTokenPrediction(mock_config)
 
             assert mock_config.dataset.batch_size == 4
 
@@ -537,7 +562,7 @@ class TestBenchmarkingRecipeHelpers:
 
         with patch("nemo_automodel.recipes.llm.benchmark.TrainFinetuneRecipeForNextTokenPrediction.__init__"):
             with pytest.raises(AttributeError):
-                recipe = BenchmarkingRecipeForNextTokenPrediction(config_without_benchmark)
+                BenchmarkingRecipeForNextTokenPrediction(config_without_benchmark)
 
 
 @pytest.mark.usefixtures("patch_torch_distributed_for_benchmark")
@@ -611,7 +636,14 @@ class TestBenchmarkingRecipeWandBIntegration:
             mock_recipe._log_iteration_metrics("iteration", ga_steps=4, peak_tflops=989, rank=0, iteration=10)
 
             # Verify wandb logging was called with correct parameters
-            expected_timer_names = ["iteration", "optimizer", "forward_backward_0", "forward_backward_1", "forward_backward_2", "forward_backward_3"]
+            expected_timer_names = [
+                "iteration",
+                "optimizer",
+                "forward_backward_0",
+                "forward_backward_1",
+                "forward_backward_2",
+                "forward_backward_3",
+            ]
             mock_recipe.timers.write_to_wandb.assert_called_once_with(
                 names=expected_timer_names,
                 writer=mock_recipe.wandb_run,


### PR DESCRIPTION
## Summary

Stabilizes the seven failed LLM benchmark recipes from nemo-ci pipeline 55935723.

- Reduces per-rank memory pressure while preserving every recipe's global batch size and sequence length.
- Adds allocator settings, activation checkpointing, MoE re-sharding, and an appropriate Qwen CI time budget.
- Adds resilient benchmark tokenizer/vocabulary setup coverage for the affected DeepSeek path.

## Validation

All selected jobs passed. The final narrowed leaf ran only the last two unresolved recipes; already-green recipes were excluded from follow-up reruns.

- [DeepSeek V3 Torch](https://nv/nemoci/-/jobs/349682387) — passed
- [GLM 4.7 TE DeepEP](https://nv/nemoci/-/jobs/349682388) — passed
- [GPT-OSS 120B](https://nv/nemoci/-/jobs/349654663) — passed
- [GPT-OSS 120B GB200](https://nv/nemoci/-/jobs/349654664) — passed
- [GPT-OSS 20B Torch](https://nv/nemoci/-/jobs/349654665) — passed
- [Llama 3.1 70B 8-node](https://nv/nemoci/-/jobs/349669733) — passed
- [Qwen 3.5 MoE](https://nv/nemoci/-/jobs/349669734) — passed

The final two-job leaf is [pipeline 56066543](https://nv/nemoci/-/pipelines/56066543).

Local checks:

- `tests/unit_tests/recipes/llm/test_benchmark.py` — 32 passed
- Benchmark YAML parsing and CI test generation
