### PR TITLE
feat(speculative): add Domino online training path on top of DFlash

### DIFF
--- a/examples/speculative/dflash/qwen3_domino.yaml
+++ b/examples/speculative/dflash/qwen3_domino.yaml
@@ -1,0 +1,77 @@
+# Domino draft training for a Qwen3 target (online target hidden-state capture).
+#
+# Domino (sgl-project/SpecForge#571) extends the DFlash parallel draft backbone
+# with a lightweight causal correction head: a GRU encodes a causal state from
+# each block's previous tokens, and a low-rank projection of [backbone hidden |
+# GRU state] adds a correction to the parallel base logits. Training jointly
+# supervises the Domino-refined logits and the backbone-only base logits with a
+# base-anchor curriculum: loss = (1 - lambda_base) * final_loss + lambda_base *
+# base_loss, where lambda_base decays from lambda_base_start to 0.
+#
+# IMPORTANT: regenerate the training responses with the target model before
+# training -- training uses teacher forcing on ground-truth tokens while
+# inference is autoregressive, and the distribution mismatch hurts acceptance
+# length otherwise.
+
+recipe: TrainDominoRecipe
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 30
+
+recipe_args:
+  target_model_name_or_path: Qwen/Qwen3-8B
+  train_data_path: /path/to/perfectblend_qwen3-8b_regen.jsonl   # regenerate responses with the target model first
+  val_data_path: null
+  output_dir: ./outputs/domino_qwen3_8b
+  seq_length: 3072
+  micro_batch_size: 2
+  grad_accumulation_steps: 1
+  num_workers: 4
+  num_epochs: 6
+
+  # --- DFlash backbone (shared with the DFlash recipe) ---
+  draft_num_hidden_layers: 5          # depth of the draft transformer stack
+  block_size: 16                      # tokens drafted in parallel per block
+  num_anchors: 256                    # blocks sampled per sequence per step
+  loss_decay_gamma: 7.0               # block-position loss decay: exp(-(k-offset)/gamma)
+  mask_token_id: 151669               # REQUIRED: token used for non-anchor block positions.
+  #                                   # Pick a reserved / unused token id (do NOT rely on pad:
+  #                                   # pad often aliases eos, which silently degrades quality).
+  # target_layer_ids: [1, 9, 17, 25, 33]   # target layers captured as draft context
+  attention_backend: flex_attention   # "flex_attention" (GPU main path) or "sdpa" (portable fallback)
+
+  # --- Domino head ---
+  emb_dim: 256                        # low-rank bottleneck dim of the logit-correction head
+  gru_hidden_dim: 1024                # hidden size of the causal GRU encoder
+  pure_draft_prefix_len: 1            # leading block positions kept on backbone-only base logits
+  shift_label: true                   # block position k predicts anchor+1+k (Domino default)
+
+  # --- base-anchor curriculum: lambda_base = start * (1 - step / (decay_ratio * total)) ---
+  lambda_base_start: 1.0              # initial weight of the base (backbone-only) loss
+  lambda_base_decay_ratio: 1.0        # fraction of total steps over which lambda_base decays to 0
+
+  trust_remote_code: false
+  # target_attn_implementation: sdpa   # frozen target's attention backend (unset = HF auto-select)
+  shuffle_seed: 42
+  log_every_steps: 10
+  max_grad_norm: 1.0
+  # mask_reasoning_content: true   # exclude <think>...</think> reasoning traces from loss
+
+  # --- checkpoint cadence (independent; the fully-trained model is always saved) ---
+  # ckpt_every_steps: 2000            # also save every N optimizer steps
+  # save_checkpoint_every_epoch: false
+
+optimizer:
+  lr: 6.0e-4
+  betas: [0.9, 0.95]
+  weight_decay: 0.0
+  warmup_ratio: 0.04
+  min_lr_ratio: 0.1
+
+checkpoint:
+  enabled: true
+  checkpoint_dir: ./outputs/domino_qwen3_8b/checkpoints
+  model_save_format: safetensors
+  save_consolidated: true
+  # restore_from: LATEST  # "LATEST", a subdir like "epoch_1_step_1000", or an absolute path

--- a/nemo_automodel/components/speculative/dflash/__init__.py
+++ b/nemo_automodel/components/speculative/dflash/__init__.py
@@ -27,6 +27,12 @@ from nemo_automodel.components.speculative.dflash.core import (
     create_dflash_block_mask,
     create_dflash_sdpa_mask,
 )
+from nemo_automodel.components.speculative.dflash.domino_core import (
+    DominoStepMetrics,
+    DominoTrainerModule,
+    compute_accept_len,
+    get_lambda_base,
+)
 from nemo_automodel.components.speculative.dflash.draft_qwen3 import (
     Qwen3DFlashDraftModel,
     build_target_layer_ids,
@@ -45,6 +51,10 @@ __all__ = [
     "NoValidAnchorsError",
     "create_dflash_block_mask",
     "create_dflash_sdpa_mask",
+    "DominoTrainerModule",
+    "DominoStepMetrics",
+    "compute_accept_len",
+    "get_lambda_base",
     "Qwen3DFlashDraftModel",
     "build_target_layer_ids",
     "extract_context_feature",

--- a/nemo_automodel/components/speculative/dflash/domino_core.py
+++ b/nemo_automodel/components/speculative/dflash/domino_core.py
@@ -1,0 +1,390 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Domino online training wrapper.
+
+Ported from SpecForge's ``specforge/core/domino.py`` (sgl-project/SpecForge#571).
+
+Domino extends the parallel DFlash draft backbone with a lightweight *causal*
+correction head. DFlash drafts a whole block in a single non-causal forward, so
+each predicted position is blind to the (drafted) tokens earlier in its own
+block. The Domino head fixes that: a GRU encodes a causal state from the block's
+previous tokens, and a low-rank projection of ``[backbone hidden | GRU state]``
+produces a logit delta that is *added* to the parallel base logits.
+
+Training jointly supervises two logits with a base-anchor curriculum::
+
+    loss = (1 - lambda_base) * final_loss + lambda_base * base_loss
+
+``final_loss`` is the CE on the Domino-refined logits and ``base_loss`` the CE on
+the backbone-only base logits. ``lambda_base`` decays from its start value to 0
+over the first ``decay_ratio`` fraction of training, so early steps keep the
+parallel backbone strong and later steps let the correction head take over.
+
+``DominoTrainerModule`` reuses the DFlash anchor sampling, noise-block
+construction, and block attention mask (it subclasses ``DFlashTrainerModule``);
+only the head, the dual-logit loss, and the metrics are Domino-specific. The
+Domino head parameters (``prefix_gru``, ``embed_proj``) live on the DFlash draft
+model and are enabled via ``dflash_config.projector_type='domino'``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from nemo_automodel.components.attention.dflash_mask import (
+    create_dflash_block_mask,
+    create_dflash_sdpa_mask,
+)
+from nemo_automodel.components.speculative.dflash.core import DFlashTrainerModule
+from nemo_automodel.components.speculative.dflash.draft_qwen3 import Qwen3DFlashDraftModel
+
+
+def get_lambda_base(
+    global_step: int,
+    total_steps: int,
+    lambda_start: float = 1.0,
+    decay_ratio: float = 0.5,
+) -> float:
+    """Base-anchor curriculum weight at ``global_step``.
+
+    ``lambda_base`` starts at ``lambda_start`` and decays linearly to 0 over the
+    first ``decay_ratio`` fraction of ``total_steps``, then stays at 0. The result
+    is clamped to ``[0, 1]``.
+    """
+    decay_steps = max(1, int(total_steps * decay_ratio))
+    progress = min(global_step / decay_steps, 1.0)
+    lambda_base = lambda_start * (1.0 - progress)
+    return max(0.0, min(1.0, lambda_base))
+
+
+def compute_accept_len(
+    pred_ids_4d: torch.Tensor,
+    target_ids_4d: torch.Tensor,
+    valid_mask_4d: torch.Tensor,
+) -> torch.Tensor:
+    """Per-block acceptance length: consecutive correct predictions from position 0.
+
+    Invalid (masked-out) positions count as correct so they never truncate a block
+    prematurely; the trailing valid mask then zeros their contribution.
+    """
+    correct = (pred_ids_4d == target_ids_4d) | (~valid_mask_4d)
+    accept_prefix = correct.long().cumprod(dim=2) * valid_mask_4d.long()
+    return accept_prefix.sum(dim=2).float()
+
+
+@dataclass
+class DominoStepMetrics:
+    """Per-step training outputs for the Domino draft.
+
+    ``loss``/``accuracy``/``valid_tokens`` mirror ``DFlashStepMetrics`` so the
+    DFlash training loop consumes them unchanged. The remaining fields are
+    diagnostics for the two supervised logits and the curriculum weight.
+    """
+
+    loss: torch.Tensor
+    accuracy: torch.Tensor
+    valid_tokens: torch.Tensor
+    final_loss: torch.Tensor
+    base_loss: torch.Tensor
+    base_accuracy: torch.Tensor
+    accept_len: torch.Tensor
+    base_accept_len: torch.Tensor
+    lambda_base: torch.Tensor
+
+
+class DominoTrainerModule(DFlashTrainerModule):
+    """Domino online training wrapper: DFlash backbone + causal correction head."""
+
+    def __init__(
+        self,
+        draft_model: Qwen3DFlashDraftModel,
+        target_lm_head: nn.Module,
+        target_embed_tokens: nn.Module,
+        mask_token_id: int,
+        block_size: int = 16,
+        attention_backend: str = "flex_attention",
+        num_anchors: int = 512,
+        loss_decay_gamma: Optional[float] = None,
+        shift_label: bool = False,
+    ):
+        super().__init__(
+            draft_model=draft_model,
+            target_lm_head=target_lm_head,
+            target_embed_tokens=target_embed_tokens,
+            mask_token_id=mask_token_id,
+            block_size=block_size,
+            attention_backend=attention_backend,
+            num_anchors=num_anchors,
+            loss_decay_gamma=loss_decay_gamma,
+        )
+        if getattr(draft_model, "projector_type", None) != "domino":
+            raise ValueError(
+                "DominoTrainerModule requires a draft model built with "
+                "dflash_config.projector_type='domino' (so prefix_gru / embed_proj exist)."
+            )
+        self.shift_label = shift_label
+
+    @property
+    def _suffix_start(self) -> int:
+        """First block position that receives the Domino correction.
+
+        With ``shift_label`` the block predicts ``anchor+1+k``, so position 0 is
+        already a real next-token prediction; otherwise position 0 is the clean
+        anchor and is excluded. ``pure_draft_prefix_len`` reserves additional
+        leading positions for the backbone-only (uncorrected) base logits.
+        """
+        pure_prefix = getattr(self.draft_model, "pure_draft_prefix_len", 0)
+        return pure_prefix if self.shift_label else (1 + pure_prefix)
+
+    def _build_domino_head_inputs(
+        self,
+        input_ids: torch.Tensor,
+        anchor_positions: torch.Tensor,
+        target_ids: torch.Tensor,
+        output_hidden: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Reshape backbone hidden states and gather the block's previous tokens.
+
+        ``prev_ids[..., k]`` is the token that precedes block-position ``k``'s
+        target -- the input token at ``anchor+k`` when ``shift_label`` (the GRU
+        consumes ground-truth context), else the target sequence itself.
+        """
+        bsz, n, bs = target_ids.shape
+        hidden4d = output_hidden.reshape(bsz, n, bs, output_hidden.shape[-1])
+
+        prev_ids = target_ids
+        if self.shift_label:
+            prev_offsets = torch.arange(0, self.block_size, device=input_ids.device).view(1, 1, -1)
+            prev_indices = (anchor_positions.unsqueeze(-1) + prev_offsets).clamp(max=input_ids.size(1) - 1)
+            prev_ids = torch.gather(
+                input_ids.unsqueeze(1).expand(-1, anchor_positions.size(1), -1),
+                2,
+                prev_indices,
+            )
+        return hidden4d, prev_ids
+
+    def _apply_domino_head(
+        self,
+        base_logits4d: torch.Tensor,
+        hidden4d: torch.Tensor,
+        prev_ids: torch.Tensor,
+        target_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        """Add the GRU-conditioned low-rank correction to the suffix base logits."""
+        bsz, n, bs = target_ids.shape
+        if self.shift_label:
+            block_emb = self.embed_tokens(prev_ids)
+            gru_inputs = block_emb.reshape(bsz * n, bs, -1)
+            gru_out, _ = self.draft_model.prefix_gru(gru_inputs)
+            gru_out = gru_out.reshape(bsz, n, bs, -1)
+            prefix_states = gru_out[:, :, self._suffix_start :, :]
+        else:
+            block_emb = self.embed_tokens(target_ids)
+            gru_inputs = block_emb[:, :, : bs - 1, :].reshape(bsz * n, bs - 1, -1)
+            gru_out, _ = self.draft_model.prefix_gru(gru_inputs)
+            gru_out = gru_out.reshape(bsz, n, bs - 1, -1)
+            prefix_states = gru_out[:, :, self._suffix_start - 1 :, :]
+        z_n = hidden4d[:, :, self._suffix_start :, :]
+        concat_features = torch.cat([z_n, prefix_states], dim=-1)
+        logits_e = self.draft_model.embed_proj(concat_features)
+
+        prefix_logits = base_logits4d[:, :, : self._suffix_start, :]
+        suffix_logits = base_logits4d[:, :, self._suffix_start :, :] + logits_e
+        return torch.cat([prefix_logits, suffix_logits], dim=2)
+
+    def _compute_weighted_losses(
+        self,
+        final_logits: torch.Tensor,
+        base_logits: torch.Tensor,
+        target_ids: torch.Tensor,
+        weight_mask: torch.Tensor,
+        lambda_base: float,
+    ) -> Tuple[torch.Tensor, ...]:
+        """Decay-weighted CE on both logits, mixed by the curriculum weight."""
+        flat_logits = final_logits.reshape(-1, final_logits.size(-1))
+        flat_base_logits = base_logits.reshape(-1, base_logits.size(-1))
+        flat_targets = target_ids.reshape(-1)
+        flat_weights = weight_mask.reshape(-1)
+
+        valid_token_count = flat_weights.sum() + 1e-6
+
+        final_loss_per_token = F.cross_entropy(flat_logits, flat_targets, reduction="none")
+        final_loss = (final_loss_per_token * flat_weights).sum() / valid_token_count
+
+        base_loss_per_token = F.cross_entropy(flat_base_logits, flat_targets, reduction="none")
+        base_loss = (base_loss_per_token * flat_weights).sum() / valid_token_count
+
+        loss = (1.0 - lambda_base) * final_loss + lambda_base * base_loss
+        return loss, final_loss, base_loss, flat_logits, flat_base_logits, flat_targets
+
+    def _compute_extra_metrics(
+        self,
+        pred_ids: torch.Tensor,
+        flat_base_logits: torch.Tensor,
+        flat_targets: torch.Tensor,
+        binary_eval_mask: torch.Tensor,
+        actual_token_count: torch.Tensor,
+        target_ids: torch.Tensor,
+        eval_weight_mask: torch.Tensor,
+        final_loss: torch.Tensor,
+        base_loss: torch.Tensor,
+        lambda_base: float,
+    ) -> Dict[str, torch.Tensor]:
+        """Diagnostics for both heads (acceptance length, base accuracy). No gradient."""
+        bsz, n, bs = target_ids.shape
+
+        base_pred_ids = torch.argmax(flat_base_logits, dim=-1)
+        base_correct = (base_pred_ids == flat_targets) & (binary_eval_mask > 0.5)
+        base_accuracy = base_correct.sum().float() / actual_token_count
+
+        valid_mask_4d = (eval_weight_mask > 0).bool()
+        pred_accept_len = compute_accept_len(pred_ids.view(bsz, n, bs), target_ids, valid_mask_4d)
+        base_accept_len = compute_accept_len(base_pred_ids.view(bsz, n, bs), target_ids, valid_mask_4d)
+
+        valid_block_mask = valid_mask_4d.any(dim=2)
+        num_valid_blocks = valid_block_mask.sum().float() + 1e-6
+        avg_accept_len = ((pred_accept_len + 1.0) * valid_block_mask.float()).sum() / num_valid_blocks
+        base_avg_accept_len = ((base_accept_len + 1.0) * valid_block_mask.float()).sum() / num_valid_blocks
+
+        return {
+            "final_loss": final_loss.detach(),
+            "base_loss": base_loss.detach(),
+            "base_accuracy": base_accuracy.detach(),
+            "accept_len": avg_accept_len.detach(),
+            "base_accept_len": base_avg_accept_len.detach(),
+            "lambda_base": torch.tensor(float(lambda_base), device=final_loss.device),
+        }
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        hidden_states: torch.Tensor,
+        loss_mask: torch.Tensor,
+        lambda_base: float = 0.0,
+    ) -> DominoStepMetrics:
+        """Parallel block-wise training forward with the Domino correction head."""
+        bsz, seq_len = input_ids.shape
+        device = input_ids.device
+
+        anchor_positions, block_keep_mask = self._sample_anchor_positions(seq_len, loss_mask, device)
+        noise_embedding = self._create_noise_embed(input_ids, anchor_positions, block_keep_mask)
+
+        context_position_ids = torch.arange(seq_len, device=device).unsqueeze(0).expand(bsz, -1)
+        draft_position_ids = self._create_position_ids(anchor_positions)
+        full_position_ids = torch.cat([context_position_ids, draft_position_ids], dim=1)
+
+        if self.attention_backend == "flex_attention":
+            dflash_attn_mask = create_dflash_block_mask(
+                anchor_positions, block_keep_mask, seq_len, self.block_size, device
+            )
+        else:
+            dflash_attn_mask = create_dflash_sdpa_mask(
+                anchor_positions, block_keep_mask, seq_len, self.block_size, device, dtype=noise_embedding.dtype
+            )
+
+        output_hidden = self.draft_model(
+            position_ids=full_position_ids,
+            noise_embedding=noise_embedding,
+            target_hidden=hidden_states,
+            attention_mask=dflash_attn_mask,
+        )
+
+        # --- Labels: block position k predicts anchor + label_start + k ---
+        label_start = 1 if self.shift_label else 0
+        label_offsets = torch.arange(label_start, label_start + self.block_size, device=device).view(1, 1, -1)
+        label_indices = anchor_positions.unsqueeze(-1) + label_offsets
+        valid_label_mask = label_indices < seq_len
+        safe_target_indices = label_indices.clamp(max=seq_len - 1)
+        n = anchor_positions.size(1)
+        target_ids = torch.gather(input_ids.unsqueeze(1).expand(-1, n, -1), 2, safe_target_indices)
+
+        bsz, n, bs = target_ids.shape
+        base_logits = self.lm_head(output_hidden)
+        hidden4d, prev_ids = self._build_domino_head_inputs(
+            input_ids=input_ids,
+            anchor_positions=anchor_positions,
+            target_ids=target_ids,
+            output_hidden=output_hidden,
+        )
+        base_logits4d = base_logits.reshape(bsz, n, bs, -1)
+        final_logits = self._apply_domino_head(
+            base_logits4d=base_logits4d,
+            hidden4d=hidden4d,
+            prev_ids=prev_ids,
+            target_ids=target_ids,
+        ).reshape(bsz, n * bs, -1)
+
+        # --- Weight mask: block validity * bounds * (exclude anchor) * loss_mask ---
+        weight_mask = block_keep_mask.unsqueeze(-1).expand(-1, -1, self.block_size).float()
+        weight_mask = weight_mask * valid_label_mask.float()
+        if not self.shift_label:
+            pos_in_block = torch.arange(self.block_size, device=device).view(1, 1, -1)
+            weight_mask = weight_mask * (pos_in_block > 0).float()
+        gathered_loss_mask = torch.gather(loss_mask.unsqueeze(1).expand(-1, n, -1), 2, safe_target_indices)
+        weight_mask = weight_mask * gathered_loss_mask
+
+        # Binary eval mask (pre-decay) for accuracy / acceptance-length stats.
+        eval_weight_mask = weight_mask.clone()
+        binary_eval_mask = weight_mask.view(-1)
+
+        # --- Block-position loss decay: first valid position keeps weight 1.0 ---
+        if self.loss_decay_gamma is not None and self.loss_decay_gamma > 0:
+            k = torch.arange(self.block_size, device=device).view(1, 1, -1)
+            offset = 0 if self.shift_label else 1
+            decay_weights = torch.exp(-(k - offset).clamp(min=0).float() / self.loss_decay_gamma)
+            weight_mask = weight_mask * decay_weights
+
+        loss, final_loss, base_loss, flat_logits, flat_base_logits, flat_targets = self._compute_weighted_losses(
+            final_logits=final_logits,
+            base_logits=base_logits,
+            target_ids=target_ids,
+            weight_mask=weight_mask,
+            lambda_base=lambda_base,
+        )
+
+        with torch.no_grad():
+            pred_ids = torch.argmax(flat_logits, dim=-1)
+            correct = (pred_ids == flat_targets) & (binary_eval_mask > 0.5)
+            actual_token_count = binary_eval_mask.sum() + 1e-6
+            accuracy = correct.sum().float() / actual_token_count
+            metrics = self._compute_extra_metrics(
+                pred_ids=pred_ids,
+                flat_base_logits=flat_base_logits,
+                flat_targets=flat_targets,
+                binary_eval_mask=binary_eval_mask,
+                actual_token_count=actual_token_count,
+                target_ids=target_ids,
+                eval_weight_mask=eval_weight_mask,
+                final_loss=final_loss,
+                base_loss=base_loss,
+                lambda_base=lambda_base,
+            )
+
+        return DominoStepMetrics(
+            loss=loss,
+            accuracy=accuracy.detach(),
+            valid_tokens=binary_eval_mask.sum().detach(),
+            final_loss=metrics["final_loss"],
+            base_loss=metrics["base_loss"],
+            base_accuracy=metrics["base_accuracy"],
+            accept_len=metrics["accept_len"],
+            base_accept_len=metrics["base_accept_len"],
+            lambda_base=metrics["lambda_base"],
+        )

--- a/nemo_automodel/components/speculative/dflash/domino_core.py
+++ b/nemo_automodel/components/speculative/dflash/domino_core.py
@@ -216,23 +216,24 @@ class DominoTrainerModule(DFlashTrainerModule):
         target_ids: torch.Tensor,
         weight_mask: torch.Tensor,
         lambda_base: float,
-    ) -> Tuple[torch.Tensor, ...]:
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Decay-weighted CE on both logits, mixed by the curriculum weight."""
-        flat_logits = final_logits.reshape(-1, final_logits.size(-1))
-        flat_base_logits = base_logits.reshape(-1, base_logits.size(-1))
         flat_targets = target_ids.reshape(-1)
         flat_weights = weight_mask.reshape(-1)
-
         valid_token_count = flat_weights.sum() + 1e-6
 
-        final_loss_per_token = F.cross_entropy(flat_logits, flat_targets, reduction="none")
+        final_loss_per_token = F.cross_entropy(
+            final_logits.reshape(-1, final_logits.size(-1)), flat_targets, reduction="none"
+        )
         final_loss = (final_loss_per_token * flat_weights).sum() / valid_token_count
 
-        base_loss_per_token = F.cross_entropy(flat_base_logits, flat_targets, reduction="none")
+        base_loss_per_token = F.cross_entropy(
+            base_logits.reshape(-1, base_logits.size(-1)), flat_targets, reduction="none"
+        )
         base_loss = (base_loss_per_token * flat_weights).sum() / valid_token_count
 
         loss = (1.0 - lambda_base) * final_loss + lambda_base * base_loss
-        return loss, final_loss, base_loss, flat_logits, flat_base_logits, flat_targets
+        return loss, final_loss, base_loss
 
     def _compute_extra_metrics(
         self,
@@ -340,8 +341,10 @@ class DominoTrainerModule(DFlashTrainerModule):
         gathered_loss_mask = torch.gather(loss_mask.unsqueeze(1).expand(-1, n, -1), 2, safe_target_indices)
         weight_mask = weight_mask * gathered_loss_mask
 
-        # Binary eval mask (pre-decay) for accuracy / acceptance-length stats.
-        eval_weight_mask = weight_mask.clone()
+        # Binary eval mask (pre-decay) for accuracy / acceptance-length stats. The
+        # decay below rebinds weight_mask to a fresh tensor (out-of-place), so these
+        # keep referencing the pre-decay mask without a clone.
+        eval_weight_mask = weight_mask
         binary_eval_mask = weight_mask.view(-1)
 
         # --- Block-position loss decay: first valid position keeps weight 1.0 ---
@@ -351,7 +354,7 @@ class DominoTrainerModule(DFlashTrainerModule):
             decay_weights = torch.exp(-(k - offset).clamp(min=0).float() / self.loss_decay_gamma)
             weight_mask = weight_mask * decay_weights
 
-        loss, final_loss, base_loss, flat_logits, flat_base_logits, flat_targets = self._compute_weighted_losses(
+        loss, final_loss, base_loss = self._compute_weighted_losses(
             final_logits=final_logits,
             base_logits=base_logits,
             target_ids=target_ids,
@@ -360,6 +363,9 @@ class DominoTrainerModule(DFlashTrainerModule):
         )
 
         with torch.no_grad():
+            flat_logits = final_logits.reshape(-1, final_logits.size(-1))
+            flat_base_logits = base_logits.reshape(-1, base_logits.size(-1))
+            flat_targets = target_ids.reshape(-1)
             pred_ids = torch.argmax(flat_logits, dim=-1)
             correct = (pred_ids == flat_targets) & (binary_eval_mask > 0.5)
             actual_token_count = binary_eval_mask.sum() + 1e-6

--- a/nemo_automodel/components/speculative/dflash/draft_qwen3.py
+++ b/nemo_automodel/components/speculative/dflash/draft_qwen3.py
@@ -263,6 +263,36 @@ class Qwen3DFlashDraftModel(Qwen3PreTrainedModel):
             raise ValueError(f"Unknown draft projector_type: {self.projector_type}")
         self.post_init()
 
+    def _apply(self, fn, recurse=True):
+        """Keep the RoPE ``inv_freq`` buffer in fp32 across dtype casts.
+
+        ``Qwen3RotaryEmbedding`` computes the rotary angles in fp32 but reads the
+        frequencies from a stored ``inv_freq`` buffer. ``model.to(bfloat16)`` -- the
+        training build path -- rounds that buffer to bf16, whereas the serving
+        runtime (SGLang keeps an fp32 RoPE cache) and HF's ``from_pretrained`` reload
+        keep it in fp32. The resulting train/inference RoPE mismatch grows with
+        absolute position (the bf16 frequencies dephase) and erodes draft
+        acceptance, so ``inv_freq`` must stay fp32 on both the training and reload
+        paths. A bf16 round-trip cannot be undone by upcasting, so when a cast
+        rounds the buffer we recompute fresh fp32 frequencies from the rotary
+        config (the same values HF derives on the fp32 paths) instead of upcasting
+        the corrupted ones.
+        """
+        module = super()._apply(fn, recurse=recurse)
+        rotary_emb = getattr(self, "rotary_emb", None)
+        inv_freq = getattr(rotary_emb, "inv_freq", None) if rotary_emb is not None else None
+        if (
+            inv_freq is not None
+            and inv_freq.is_floating_point()
+            and not inv_freq.is_meta
+            and inv_freq.dtype != torch.float32
+        ):
+            fresh = type(rotary_emb)(rotary_emb.config).inv_freq.to(device=inv_freq.device)
+            rotary_emb.inv_freq = fresh
+            if hasattr(rotary_emb, "original_inv_freq"):
+                rotary_emb.original_inv_freq = fresh.clone()
+        return module
+
     def forward(
         self,
         position_ids: torch.LongTensor,

--- a/nemo_automodel/components/speculative/dflash/draft_qwen3.py
+++ b/nemo_automodel/components/speculative/dflash/draft_qwen3.py
@@ -236,6 +236,31 @@ class Qwen3DFlashDraftModel(Qwen3PreTrainedModel):
         self.hidden_norm = Qwen3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.block_size = config.block_size
         self.mask_token_id = dflash_config.get("mask_token_id", None)
+        # Optional Domino correction head (ported from SpecForge#571). DFlash drafts
+        # a block in parallel and is non-causal; the Domino head adds a *causal*
+        # low-rank logit correction conditioned on a GRU state built from the
+        # block's previous tokens. ``projector_type=None`` leaves DFlash untouched.
+        self.projector_type = dflash_config.get("projector_type", None)
+        self.pure_draft_prefix_len = dflash_config.get("pure_draft_prefix_len", 0)
+        self.shift_label = dflash_config.get("shift_label", False)
+        if self.projector_type == "domino":
+            self.emb_dim = dflash_config["emb_dim"]
+            self.gru_hidden_dim = dflash_config["gru_hidden_dim"]
+            self.prefix_gru = nn.GRU(
+                input_size=config.hidden_size,
+                hidden_size=self.gru_hidden_dim,
+                num_layers=1,
+                batch_first=True,
+                bias=False,
+            )
+            in_dim = config.hidden_size + self.gru_hidden_dim
+            self.embed_proj = nn.Sequential(
+                nn.Linear(in_dim, self.emb_dim, bias=False),
+                nn.SiLU(),
+                nn.Linear(self.emb_dim, config.vocab_size, bias=False),
+            )
+        elif self.projector_type is not None:
+            raise ValueError(f"Unknown draft projector_type: {self.projector_type}")
         self.post_init()
 
     def forward(

--- a/nemo_automodel/recipes/llm/train_dflash.py
+++ b/nemo_automodel/recipes/llm/train_dflash.py
@@ -190,10 +190,7 @@ class TrainDFlashRecipe(BaseRecipe):
         draft_config["max_window_layers"] = draft_num_hidden_layers
         draft_config["num_target_layers"] = num_target_layers
         draft_config["block_size"] = self.block_size
-        draft_config["dflash_config"] = {
-            "mask_token_id": self.mask_token_id,
-            "target_layer_ids": target_layer_ids,
-        }
+        draft_config["dflash_config"] = self._build_dflash_config(recipe_cfg, target_layer_ids)
         # A single knob drives both the trainer's mask format and the draft's
         # attention function -- they must agree (a flex BlockMask only works with
         # the flex attention fn, a dense bool mask only with sdpa/eager).
@@ -202,16 +199,7 @@ class TrainDFlashRecipe(BaseRecipe):
         draft_config_obj._attn_implementation = attention_backend
         self.draft_model = draft_spec.draft_cls(draft_config_obj).to(device=self.device, dtype=self.compute_dtype)
 
-        trainer_module = DFlashTrainerModule(
-            draft_model=self.draft_model,
-            target_lm_head=self.target_model.get_output_embeddings(),
-            target_embed_tokens=self.target_model.get_input_embeddings(),
-            mask_token_id=self.mask_token_id,
-            block_size=self.block_size,
-            attention_backend=attention_backend,
-            num_anchors=int(recipe_cfg.get("num_anchors", 512)),
-            loss_decay_gamma=recipe_cfg.get("loss_decay_gamma", None),
-        ).to(self.device)
+        trainer_module = self._build_trainer_module(attention_backend, recipe_cfg).to(self.device)
         if self.dist_env.world_size > 1:
             trainer_module = DistributedDataParallel(
                 trainer_module,
@@ -263,6 +251,37 @@ class TrainDFlashRecipe(BaseRecipe):
         self.rng = StatefulRNG(seed=int(recipe_cfg.get("shuffle_seed", 42)), ranked=self.dist_env.world_size > 1)
         self._build_checkpointer(target_path)
         self.load_checkpoint(self.cfg.get("checkpoint.restore_from", None))
+
+    def _build_dflash_config(self, recipe_cfg, target_layer_ids: list[int]) -> dict:
+        """Build the draft ``dflash_config`` block. Subclasses extend it (e.g. Domino)."""
+        return {
+            "mask_token_id": self.mask_token_id,
+            "target_layer_ids": target_layer_ids,
+        }
+
+    def _build_trainer_module(self, attention_backend: str, recipe_cfg):
+        """Build the trainer wrapper. Subclasses override to swap the wrapper (e.g. Domino)."""
+        return DFlashTrainerModule(
+            draft_model=self.draft_model,
+            target_lm_head=self.target_model.get_output_embeddings(),
+            target_embed_tokens=self.target_model.get_input_embeddings(),
+            mask_token_id=self.mask_token_id,
+            block_size=self.block_size,
+            attention_backend=attention_backend,
+            num_anchors=int(recipe_cfg.get("num_anchors", 512)),
+            loss_decay_gamma=recipe_cfg.get("loss_decay_gamma", None),
+        )
+
+    def _run_trainer_step(self, target_batch):
+        """Run one trainer-module forward. Subclasses override to inject extra inputs (e.g. lambda_base)."""
+        return self.trainer_module(
+            input_ids=target_batch.input_ids,
+            hidden_states=target_batch.hidden_states,
+            loss_mask=target_batch.loss_mask,
+        )
+
+    def _log_extra_train_metrics(self, epoch_idx: int) -> None:
+        """Hook for subclasses to log extra per-step metrics at a log point (no-op here)."""
 
     @staticmethod
     def _resolve_mask_token_id(recipe_cfg, vocab_size: int) -> int:
@@ -596,11 +615,7 @@ class TrainDFlashRecipe(BaseRecipe):
                     with sync_ctx:
                         local_has_valid = 1
                         try:
-                            metrics = self.trainer_module(
-                                input_ids=target_batch.input_ids,
-                                hidden_states=target_batch.hidden_states,
-                                loss_mask=target_batch.loss_mask,
-                            )
+                            metrics = self._run_trainer_step(target_batch)
                             loss = metrics.loss / self.grad_accumulation_steps
                         except NoValidAnchorsError:
                             # Every sample in this micro-batch is too short to form a
@@ -658,6 +673,7 @@ class TrainDFlashRecipe(BaseRecipe):
                                 avg_acc,
                                 current_lr,
                             )
+                            self._log_extra_train_metrics(epoch_idx)
                             running_loss = 0.0
                             running_acc = 0.0
                             running_micro = 0

--- a/nemo_automodel/recipes/llm/train_domino.py
+++ b/nemo_automodel/recipes/llm/train_domino.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Domino draft-model training recipe (Qwen3-style targets).
+
+Domino (sgl-project/SpecForge#571) extends the DFlash parallel draft backbone
+with a lightweight causal correction head (a GRU state plus a low-rank logit
+correction; see ``nemo_automodel.components.speculative.dflash.domino_core``).
+This recipe reuses every piece of the DFlash recipe -- online target hidden-state
+capture, anchor sampling, the block attention mask, gradient accumulation, and
+checkpointing -- and only swaps in the Domino trainer wrapper, enables the Domino
+head on the draft via ``dflash_config``, and drives the base-anchor ``lambda_base``
+curriculum.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
+from nemo_automodel.components.speculative.dflash.domino_core import DominoTrainerModule, get_lambda_base
+from nemo_automodel.recipes.llm.train_dflash import TrainDFlashRecipe
+
+logger = logging.getLogger(__name__)
+
+
+class TrainDominoRecipe(TrainDFlashRecipe):
+    """Recipe for Domino draft-model training: DFlash backbone + causal correction head."""
+
+    def _build_dflash_config(self, recipe_cfg, target_layer_ids: list[int]) -> dict:
+        """Extend the DFlash draft config with the Domino head fields."""
+        cfg = super()._build_dflash_config(recipe_cfg, target_layer_ids)
+        cfg.update(
+            {
+                "projector_type": "domino",
+                "emb_dim": int(recipe_cfg.get("emb_dim", 256)),
+                "gru_hidden_dim": int(recipe_cfg.get("gru_hidden_dim", 1024)),
+                "pure_draft_prefix_len": int(recipe_cfg.get("pure_draft_prefix_len", 1)),
+                "shift_label": bool(recipe_cfg.get("shift_label", True)),
+            }
+        )
+        return cfg
+
+    def _build_trainer_module(self, attention_backend: str, recipe_cfg):
+        """Build the Domino trainer wrapper on the (Domino-head-enabled) DFlash draft."""
+        return DominoTrainerModule(
+            draft_model=self.draft_model,
+            target_lm_head=self.target_model.get_output_embeddings(),
+            target_embed_tokens=self.target_model.get_input_embeddings(),
+            mask_token_id=self.mask_token_id,
+            block_size=self.block_size,
+            attention_backend=attention_backend,
+            num_anchors=int(recipe_cfg.get("num_anchors", 512)),
+            loss_decay_gamma=recipe_cfg.get("loss_decay_gamma", None),
+            shift_label=self.draft_model.shift_label,
+        )
+
+    def setup(self):
+        """Build everything via the DFlash recipe, then read the lambda_base schedule."""
+        super().setup()
+        recipe_cfg = self.cfg.recipe_args
+        self.lambda_base_start = float(recipe_cfg.get("lambda_base_start", 1.0))
+        self.lambda_base_decay_ratio = float(recipe_cfg.get("lambda_base_decay_ratio", 0.5))
+        self._last_domino_metrics = None
+
+    def _run_trainer_step(self, target_batch):
+        """Forward through the Domino wrapper, injecting the current curriculum weight."""
+        lambda_base = get_lambda_base(
+            global_step=self.runtime.global_step,
+            total_steps=self.total_optim_steps,
+            lambda_start=self.lambda_base_start,
+            decay_ratio=self.lambda_base_decay_ratio,
+        )
+        metrics = self.trainer_module(
+            input_ids=target_batch.input_ids,
+            hidden_states=target_batch.hidden_states,
+            loss_mask=target_batch.loss_mask,
+            lambda_base=lambda_base,
+        )
+        self._last_domino_metrics = metrics
+        return metrics
+
+    def _log_extra_train_metrics(self, epoch_idx: int) -> None:
+        """Log the Domino-specific diagnostics for the most recent step (rank-0 local)."""
+        m = getattr(self, "_last_domino_metrics", None)
+        if m is None:
+            return
+        logger.info(
+            "  domino: final_loss=%.4f base_loss=%.4f base_acc=%.4f "
+            "accept_len=%.3f base_accept_len=%.3f lambda_base=%.3f",
+            float(m.final_loss),
+            float(m.base_loss),
+            float(m.base_accuracy),
+            float(m.accept_len),
+            float(m.base_accept_len),
+            float(m.lambda_base),
+        )
+
+
+def main(config_path: str | None = None):
+    """Entrypoint for ``TrainDominoRecipe``."""
+    cfg = parse_args_and_load_config(config_path)
+    trainer = TrainDominoRecipe(cfg)
+    trainer.setup()
+    trainer.run_train_validation_loop()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit_tests/recipes/llm/test_train_domino.py
+++ b/tests/unit_tests/recipes/llm/test_train_domino.py
@@ -1,0 +1,183 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Domino recipe seams over the DFlash recipe.
+
+The recipe is constructed via ``__new__`` (bypassing ``setup()``), so only the
+overridden seams are exercised: the draft config extension, the trainer-module
+swap, the lambda_base injection, and the extra-metrics logging.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+from transformers.models.qwen3.configuration_qwen3 import Qwen3Config
+
+from nemo_automodel.components.speculative.dflash.domino_core import DominoStepMetrics, DominoTrainerModule
+from nemo_automodel.components.speculative.dflash.draft_qwen3 import Qwen3DFlashDraftModel
+from nemo_automodel.recipes.llm.train_domino import TrainDominoRecipe
+
+VOCAB = 64
+HIDDEN = 32
+BLOCK_SIZE = 4
+MASK_ID = VOCAB - 1
+TARGET_LAYER_IDS = [1, 3, 5]
+
+
+def _domino_draft(shift_label=True, pure_prefix=1):
+    cfg = Qwen3Config(
+        vocab_size=VOCAB,
+        hidden_size=HIDDEN,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        max_position_embeddings=64,
+        attention_bias=False,
+        attention_dropout=0.0,
+        tie_word_embeddings=False,
+    )
+    cfg.num_target_layers = 8
+    cfg.block_size = BLOCK_SIZE
+    cfg.dflash_config = {
+        "mask_token_id": MASK_ID,
+        "target_layer_ids": TARGET_LAYER_IDS,
+        "projector_type": "domino",
+        "emb_dim": 16,
+        "gru_hidden_dim": 24,
+        "pure_draft_prefix_len": pure_prefix,
+        "shift_label": shift_label,
+    }
+    cfg._attn_implementation = "sdpa"
+    return Qwen3DFlashDraftModel(cfg)
+
+
+def _recipe():
+    return TrainDominoRecipe.__new__(TrainDominoRecipe)
+
+
+def test_build_dflash_config_adds_domino_fields():
+    recipe = _recipe()
+    recipe.mask_token_id = MASK_ID
+    cfg = {"emb_dim": 128, "gru_hidden_dim": 512, "pure_draft_prefix_len": 2, "shift_label": False}
+    out = recipe._build_dflash_config(cfg, TARGET_LAYER_IDS)
+    assert out["mask_token_id"] == MASK_ID
+    assert out["target_layer_ids"] == TARGET_LAYER_IDS
+    assert out["projector_type"] == "domino"
+    assert out["emb_dim"] == 128
+    assert out["gru_hidden_dim"] == 512
+    assert out["pure_draft_prefix_len"] == 2
+    assert out["shift_label"] is False
+
+
+def test_build_dflash_config_defaults():
+    recipe = _recipe()
+    recipe.mask_token_id = MASK_ID
+    out = recipe._build_dflash_config({}, TARGET_LAYER_IDS)
+    assert out["emb_dim"] == 256
+    assert out["gru_hidden_dim"] == 1024
+    assert out["pure_draft_prefix_len"] == 1
+    assert out["shift_label"] is True
+
+
+def test_build_trainer_module_is_domino():
+    recipe = _recipe()
+    recipe.draft_model = _domino_draft(shift_label=True)
+    recipe.mask_token_id = MASK_ID
+    recipe.block_size = BLOCK_SIZE
+    recipe.target_model = SimpleNamespace(
+        get_output_embeddings=lambda: torch.nn.Linear(HIDDEN, VOCAB, bias=False),
+        get_input_embeddings=lambda: torch.nn.Embedding(VOCAB, HIDDEN),
+    )
+    module = recipe._build_trainer_module("sdpa", {"num_anchors": 7, "loss_decay_gamma": 5.0})
+    assert isinstance(module, DominoTrainerModule)
+    assert module.num_anchors == 7
+    assert module.loss_decay_gamma == 5.0
+    assert module.shift_label is True
+
+
+def test_run_trainer_step_injects_lambda_base():
+    recipe = _recipe()
+    recipe.runtime = SimpleNamespace(global_step=50)
+    recipe.total_optim_steps = 100
+    recipe.lambda_base_start = 1.0
+    recipe.lambda_base_decay_ratio = 1.0
+
+    seen = {}
+
+    def _fake_module(**kwargs):
+        seen.update(kwargs)
+        return SimpleNamespace(loss=torch.tensor(1.0), accuracy=torch.tensor(0.5))
+
+    recipe.trainer_module = _fake_module
+    target_batch = SimpleNamespace(
+        input_ids=torch.zeros(1, 4, dtype=torch.long),
+        hidden_states=torch.zeros(1, 4, 8),
+        loss_mask=torch.ones(1, 4),
+    )
+    out = recipe._run_trainer_step(target_batch)
+    # global_step 50 / (100 * 1.0) -> lambda_base 0.5.
+    assert seen["lambda_base"] == 0.5
+    assert recipe._last_domino_metrics is out
+
+
+def test_log_extra_train_metrics(caplog):
+    recipe = _recipe()
+    recipe._last_domino_metrics = DominoStepMetrics(
+        loss=torch.tensor(1.0),
+        accuracy=torch.tensor(0.5),
+        valid_tokens=torch.tensor(10.0),
+        final_loss=torch.tensor(0.9),
+        base_loss=torch.tensor(2.3),
+        base_accuracy=torch.tensor(0.4),
+        accept_len=torch.tensor(6.9),
+        base_accept_len=torch.tensor(4.0),
+        lambda_base=torch.tensor(0.5),
+    )
+    with caplog.at_level("INFO"):
+        recipe._log_extra_train_metrics(epoch_idx=0)
+    assert "domino:" in caplog.text
+    assert "base_loss=2.3" in caplog.text
+
+
+def test_log_extra_train_metrics_noop_without_metrics():
+    recipe = _recipe()
+    recipe._last_domino_metrics = None
+    # Must not raise when no step has run yet.
+    recipe._log_extra_train_metrics(epoch_idx=0)
+
+
+def test_setup_reads_lambda_base_schedule(monkeypatch):
+    recipe = _recipe()
+    recipe.cfg = SimpleNamespace(recipe_args={"lambda_base_start": 0.8, "lambda_base_decay_ratio": 0.25})
+    # Bypass the heavy DFlash setup (super().setup()); only the schedule read is under test.
+    monkeypatch.setattr("nemo_automodel.recipes.llm.train_dflash.TrainDFlashRecipe.setup", lambda self: None)
+    recipe.setup()
+    assert recipe.lambda_base_start == 0.8
+    assert recipe.lambda_base_decay_ratio == 0.25
+    assert recipe._last_domino_metrics is None
+
+
+def test_main_runs_setup_then_loop(monkeypatch):
+    from nemo_automodel.recipes.llm import train_domino
+
+    calls = []
+    monkeypatch.setattr(train_domino, "parse_args_and_load_config", lambda p: SimpleNamespace())
+    monkeypatch.setattr(TrainDominoRecipe, "setup", lambda self: calls.append("setup"))
+    monkeypatch.setattr(TrainDominoRecipe, "run_train_validation_loop", lambda self: calls.append("loop"))
+    train_domino.main("cfg.yaml")
+    assert calls == ["setup", "loop"]

--- a/tests/unit_tests/speculative/test_dflash_draft.py
+++ b/tests/unit_tests/speculative/test_dflash_draft.py
@@ -46,6 +46,56 @@ def test_extract_context_feature_uses_offset_one():
     assert torch.allclose(out[..., 3:], torch.full((1, 2, 3), 4.0))
 
 
+def _draft_cfg(bs=4):
+    cfg = Qwen3Config(
+        vocab_size=64,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        max_position_embeddings=64,
+        rope_theta=1000000,
+        tie_word_embeddings=False,
+    )
+    cfg.num_target_layers = 8
+    cfg.block_size = bs
+    cfg.dflash_config = {"mask_token_id": 63, "target_layer_ids": [1, 3, 5]}
+    cfg._attn_implementation = "sdpa"
+    return cfg
+
+
+def _rope_relerr(inv_freq):
+    # Reference fp32 default-rope frequencies for head_dim=8, theta=1e6.
+    ref = 1.0 / (1000000 ** (torch.arange(0, 8, 2).float() / 8))
+    return ((inv_freq.float() - ref).abs() / ref).max().item()
+
+
+def test_rope_inv_freq_stays_fp32_after_bf16_cast():
+    """``model.to(bf16)`` must not round the RoPE frequencies.
+
+    The serving runtime keeps an fp32 RoPE cache; if the draft trained with a
+    bf16-rounded ``inv_freq`` the train/inference RoPE would diverge (worse with
+    longer context) and erode acceptance. The draft pins ``inv_freq`` to fp32.
+    """
+    draft = Qwen3DFlashDraftModel(_draft_cfg()).to(torch.bfloat16)
+    inv_freq = draft.rotary_emb.inv_freq
+    assert inv_freq.dtype == torch.float32
+    # Recomputed fresh, so the values are exact fp32 (not a bf16 round-trip).
+    assert _rope_relerr(inv_freq) < 1e-6
+    # original_inv_freq (used by dynamic-rope resets) is pinned too.
+    assert draft.rotary_emb.original_inv_freq.dtype == torch.float32
+    # The rest of the model is still bf16 (the pin is rope-only).
+    assert next(draft.layers[0].parameters()).dtype == torch.bfloat16
+
+
+def test_rope_inv_freq_fp32_survives_chained_casts():
+    draft = Qwen3DFlashDraftModel(_draft_cfg()).to(torch.float16).to(torch.bfloat16)
+    assert draft.rotary_emb.inv_freq.dtype == torch.float32
+    assert _rope_relerr(draft.rotary_emb.inv_freq) < 1e-6
+
+
 def test_draft_forward_output_shape():
     H, n_layers_target, tli, bs = 32, 8, [1, 3, 5], 4
     cfg = Qwen3Config(

--- a/tests/unit_tests/speculative/test_domino_core.py
+++ b/tests/unit_tests/speculative/test_domino_core.py
@@ -1,0 +1,218 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Domino trainer module (causal head, dual-logit loss, curriculum)."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from transformers.models.qwen3.configuration_qwen3 import Qwen3Config
+
+from nemo_automodel.components.speculative.dflash.domino_core import (
+    DominoStepMetrics,
+    DominoTrainerModule,
+    compute_accept_len,
+    get_lambda_base,
+)
+from nemo_automodel.components.speculative.dflash.draft_qwen3 import Qwen3DFlashDraftModel
+
+VOCAB = 64
+HIDDEN = 32
+NUM_TARGET_LAYERS = 8
+TARGET_LAYER_IDS = [1, 3, 5]
+BLOCK_SIZE = 4
+MASK_ID = VOCAB - 1
+EMB_DIM = 16
+GRU_HIDDEN = 24
+
+
+def _draft_config(projector_type="domino", pure_prefix=1, shift_label=True):
+    cfg = Qwen3Config(
+        vocab_size=VOCAB,
+        hidden_size=HIDDEN,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        max_position_embeddings=64,
+        attention_bias=False,
+        attention_dropout=0.0,
+        tie_word_embeddings=False,
+    )
+    cfg.num_target_layers = NUM_TARGET_LAYERS
+    cfg.block_size = BLOCK_SIZE
+    dflash_config = {"mask_token_id": MASK_ID, "target_layer_ids": TARGET_LAYER_IDS}
+    if projector_type is not None:
+        dflash_config.update(
+            {
+                "projector_type": projector_type,
+                "emb_dim": EMB_DIM,
+                "gru_hidden_dim": GRU_HIDDEN,
+                "pure_draft_prefix_len": pure_prefix,
+                "shift_label": shift_label,
+            }
+        )
+    cfg.dflash_config = dflash_config
+    cfg._attn_implementation = "sdpa"
+    return cfg
+
+
+def _build_trainer(num_anchors=8, loss_decay_gamma=None, pure_prefix=1, shift_label=True):
+    draft = Qwen3DFlashDraftModel(_draft_config(pure_prefix=pure_prefix, shift_label=shift_label))
+    lm_head = torch.nn.Linear(HIDDEN, VOCAB, bias=False)
+    embed = torch.nn.Embedding(VOCAB, HIDDEN)
+    return DominoTrainerModule(
+        draft_model=draft,
+        target_lm_head=lm_head,
+        target_embed_tokens=embed,
+        mask_token_id=MASK_ID,
+        block_size=BLOCK_SIZE,
+        attention_backend="sdpa",
+        num_anchors=num_anchors,
+        loss_decay_gamma=loss_decay_gamma,
+        shift_label=shift_label,
+    )
+
+
+def _inputs(bsz=2, seq_len=24):
+    torch.manual_seed(0)
+    input_ids = torch.randint(0, VOCAB - 1, (bsz, seq_len))
+    loss_mask = torch.ones(bsz, seq_len)
+    hidden = torch.randn(bsz, seq_len, len(TARGET_LAYER_IDS) * HIDDEN)
+    return input_ids, hidden, loss_mask
+
+
+# --------------------------------------------------------------------------- #
+# Draft head construction
+# --------------------------------------------------------------------------- #
+
+
+def test_draft_builds_domino_head():
+    draft = Qwen3DFlashDraftModel(_draft_config())
+    assert isinstance(draft.prefix_gru, torch.nn.GRU)
+    assert draft.prefix_gru.input_size == HIDDEN
+    assert draft.prefix_gru.hidden_size == GRU_HIDDEN
+    # embed_proj projects [hidden | gru] -> emb_dim -> vocab.
+    assert draft.embed_proj[0].in_features == HIDDEN + GRU_HIDDEN
+    assert draft.embed_proj[-1].out_features == VOCAB
+    assert draft.shift_label is True
+    assert draft.pure_draft_prefix_len == 1
+
+
+def test_draft_without_projector_has_no_head():
+    draft = Qwen3DFlashDraftModel(_draft_config(projector_type=None))
+    assert draft.projector_type is None
+    assert not hasattr(draft, "prefix_gru")
+
+
+def test_draft_unknown_projector_raises():
+    with pytest.raises(ValueError, match="Unknown draft projector_type"):
+        Qwen3DFlashDraftModel(_draft_config(projector_type="mystery"))
+
+
+def test_trainer_requires_domino_draft():
+    draft = Qwen3DFlashDraftModel(_draft_config(projector_type=None))
+    with pytest.raises(ValueError, match="projector_type='domino'"):
+        DominoTrainerModule(
+            draft_model=draft,
+            target_lm_head=torch.nn.Linear(HIDDEN, VOCAB, bias=False),
+            target_embed_tokens=torch.nn.Embedding(VOCAB, HIDDEN),
+            mask_token_id=MASK_ID,
+            block_size=BLOCK_SIZE,
+            attention_backend="sdpa",
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Forward pass
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("shift_label", [True, False])
+def test_forward_returns_metrics_and_grads_flow_to_head(shift_label):
+    trainer = _build_trainer(loss_decay_gamma=7.0, shift_label=shift_label)
+    input_ids, hidden, loss_mask = _inputs()
+    out = trainer(input_ids=input_ids, hidden_states=hidden, loss_mask=loss_mask, lambda_base=0.3)
+    assert isinstance(out, DominoStepMetrics)
+    assert torch.isfinite(out.loss) and out.loss.item() > 0
+    assert 0.0 <= out.accuracy.item() <= 1.0
+    assert 0.0 <= out.base_accuracy.item() <= 1.0
+    assert out.valid_tokens.item() > 0
+    assert torch.isfinite(out.final_loss) and torch.isfinite(out.base_loss)
+    # Accept length is at least the always-accepted anchor (>= ~1.0; the 1e-6
+    # denominator term keeps it a hair under 1.0 for an all-miss untrained model).
+    assert out.accept_len.item() > 0.99 and out.base_accept_len.item() > 0.99
+    assert out.lambda_base.item() == pytest.approx(0.3)
+
+    out.loss.backward()
+    gru_grad = sum(p.grad.abs().sum().item() for p in trainer.draft_model.prefix_gru.parameters() if p.grad is not None)
+    proj_grad = sum(
+        p.grad.abs().sum().item() for p in trainer.draft_model.embed_proj.parameters() if p.grad is not None
+    )
+    assert gru_grad > 0
+    assert proj_grad > 0
+
+
+def test_lambda_base_one_equals_base_loss():
+    trainer = _build_trainer()
+    input_ids, hidden, loss_mask = _inputs()
+    out = trainer(input_ids=input_ids, hidden_states=hidden, loss_mask=loss_mask, lambda_base=1.0)
+    assert out.loss.item() == pytest.approx(out.base_loss.item(), rel=1e-5)
+
+
+def test_lambda_base_zero_equals_final_loss():
+    trainer = _build_trainer()
+    input_ids, hidden, loss_mask = _inputs()
+    out = trainer(input_ids=input_ids, hidden_states=hidden, loss_mask=loss_mask, lambda_base=0.0)
+    assert out.loss.item() == pytest.approx(out.final_loss.item(), rel=1e-5)
+
+
+def test_suffix_start_depends_on_shift_label():
+    # shift_label=True -> pure_prefix; shift_label=False -> 1 + pure_prefix.
+    assert _build_trainer(pure_prefix=1, shift_label=True)._suffix_start == 1
+    assert _build_trainer(pure_prefix=1, shift_label=False)._suffix_start == 2
+    assert _build_trainer(pure_prefix=2, shift_label=True)._suffix_start == 2
+
+
+# --------------------------------------------------------------------------- #
+# Curriculum schedule + acceptance length
+# --------------------------------------------------------------------------- #
+
+
+def test_get_lambda_base_schedule():
+    # Linear decay from start to 0 over decay_ratio * total steps, then clamps at 0.
+    assert get_lambda_base(0, 100, lambda_start=1.0, decay_ratio=1.0) == pytest.approx(1.0)
+    assert get_lambda_base(50, 100, lambda_start=1.0, decay_ratio=1.0) == pytest.approx(0.5)
+    assert get_lambda_base(100, 100, lambda_start=1.0, decay_ratio=1.0) == pytest.approx(0.0)
+    assert get_lambda_base(200, 100, lambda_start=1.0, decay_ratio=1.0) == pytest.approx(0.0)
+    # Half-decay: lambda_base hits 0 at the midpoint.
+    assert get_lambda_base(50, 100, lambda_start=1.0, decay_ratio=0.5) == pytest.approx(0.0)
+    assert get_lambda_base(0, 0, lambda_start=1.0, decay_ratio=0.5) == pytest.approx(1.0)
+
+
+def test_compute_accept_len():
+    # block 0: first two predictions correct then a miss -> accept_len 2.
+    # block 1: first prediction wrong -> accept_len 0.
+    pred = torch.tensor([[[1, 2, 9, 4], [9, 2, 3, 4]]])
+    target = torch.tensor([[[1, 2, 3, 4], [1, 2, 3, 4]]])
+    valid = torch.ones(1, 2, 4, dtype=torch.bool)
+    accept = compute_accept_len(pred, target, valid)
+    assert accept.tolist() == [[2.0, 0.0]]
+    # An invalid trailing position never truncates the accepted prefix.
+    valid2 = torch.tensor([[[True, True, False, True], [True, True, True, True]]])
+    pred2 = torch.tensor([[[1, 2, 0, 4], [1, 2, 3, 4]]])
+    accept2 = compute_accept_len(pred2, target, valid2)
+    assert accept2.tolist() == [[3.0, 4.0]]


### PR DESCRIPTION
## Objective

Add a **Domino** online training path on top of the existing DFlash speculative-decoding stack, ported from SpecForge ([sgl-project/SpecForge#571](https://github.com/sgl-project/SpecForge/pull/571)). The existing DFlash path is left unchanged.

Domino extends the parallel DFlash draft backbone with a lightweight *causal* correction head. DFlash drafts a whole block in a single non-causal forward, so each predicted position is blind to the (drafted) tokens earlier in its own block. The Domino head fixes that: a GRU encodes a causal state from the block's previous tokens, and a low-rank projection of `[backbone hidden | GRU state]` produces a logit delta that is added to the parallel base logits.

## Design

Training jointly supervises two logits with a base-anchor curriculum:

```
loss = (1 - lambda_base) * final_loss + lambda_base * base_loss
```

`final_loss` is the CE on the Domino-refined logits, `base_loss` the CE on the backbone-only base logits. `lambda_base` decays linearly to 0 over the first `lambda_base_decay_ratio` fraction of training, so early steps keep the parallel backbone strong and later steps let the correction head take over.

The integration reuses DFlash end to end:

- `DominoTrainerModule` subclasses `DFlashTrainerModule`, reusing anchor sampling, the noise-block construction, and the block attention mask. Only the head, the dual-logit loss, and the metrics are Domino-specific.
- `TrainDominoRecipe` subclasses `TrainDFlashRecipe` through four behavior-preserving seam methods added to the DFlash recipe (`_build_dflash_config`, `_build_trainer_module`, `_run_trainer_step`, `_log_extra_train_metrics`). The DFlash recipe behavior is unchanged.
- The Domino head (`prefix_gru`, `embed_proj`) lives on the DFlash draft model, gated by `dflash_config.projector_type='domino'`, so a pure-DFlash draft has no extra parameters.

### RoPE precision fix

While validating, I found that `model.to(bfloat16)` rounds the Qwen3 rotary `inv_freq` buffer to bf16, whereas HF `from_pretrained` and the SGLang serving runtime keep it in fp32. That train/inference RoPE mismatch grows with absolute position and erodes draft acceptance. The draft now recomputes fresh fp32 frequencies from the rotary config after any low-precision cast (a bf16 round-trip cannot be undone by upcasting), covering the training build and reload paths. This benefits DFlash and Domino alike.

## Files

| File | Change |
|---|---|
| `nemo_automodel/components/speculative/dflash/domino_core.py` | New `DominoTrainerModule`, dual-logit loss, metrics, `get_lambda_base` |
| `nemo_automodel/components/speculative/dflash/draft_qwen3.py` | Optional Domino head + fp32 RoPE pin |
| `nemo_automodel/recipes/llm/train_dflash.py` | Four behavior-preserving seams |
| `nemo_automodel/recipes/llm/train_domino.py` | New `TrainDominoRecipe` |
| `examples/speculative/dflash/qwen3_domino.yaml` | Example config |
| `tests/unit_tests/...` | `test_domino_core.py`, `test_train_domino.py`, RoPE-fp32 regression tests |

## Validation

Unit tests (full DFlash + Domino + speculative suite): 393 passed, 1 skipped on an A800 (including new RoPE-fp32 regression tests).

End-to-end smoke (Qwen3-0.6B target, ShareGPT-style data, `sdpa` backend): a full run to the final checkpoint. Loss trends down, `final_loss` separates below `base_loss`, `lambda_base` decays on schedule, and the saved consolidated safetensors carries the Domino head (`prefix_gru.*`, `embed_proj.*`) with `projector_type: domino` in the config.

## Usage

```bash
automodel examples/speculative/dflash/qwen3_domino.yaml --nproc-per-node 8
```

The example expects the same target-model and dataset setup as the DFlash online-training examples, with the Domino architecture and curriculum parameters read from the YAML.

## References

- Domino reference (SpecForge): https://github.com/sgl-project/SpecForge/pull/571
