### PR TITLE
fix(speculative): gather sharded target lm_head in EAGLE-1/2 token loss

### DIFF
--- a/nemo_automodel/components/speculative/eagle/core_v12.py
+++ b/nemo_automodel/components/speculative/eagle/core_v12.py
@@ -69,7 +69,16 @@ class EagleTrainerModule(nn.Module):
 
     def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor:
         """Project predicted hidden states through the frozen target lm_head."""
-        return F.linear(hidden_states, self._target_lm_head.weight)
+        weight = self._target_lm_head.weight
+        # The target may be FSDP2-sharded (the EAGLE-1/2 recipe's optional
+        # ``distributed:`` path, used for targets that do not fit on one GPU),
+        # which makes ``weight`` a ``DTensor``. The draft runs under DDP, so
+        # ``hidden_states`` is a plain tensor and ``F.linear`` cannot mix the
+        # two. Gather the frozen weight to a local full tensor first -- mirrors
+        # ``copy_embeddings_from_target``. No-op when the target is unsharded.
+        if hasattr(weight, "full_tensor"):
+            weight = weight.full_tensor()
+        return F.linear(hidden_states, weight)
 
     def forward(
         self,

--- a/tests/unit_tests/speculative/test_eagle12.py
+++ b/tests/unit_tests/speculative/test_eagle12.py
@@ -127,3 +127,51 @@ def test_eagle_trainer_runs_and_backprops():
         if p.requires_grad
     )
     assert has_grad, "expected at least one parameter to receive a non-zero gradient"
+
+
+def test_compute_logits_gathers_sharded_dtensor_target_lm_head():
+    """The token-loss head must work when the target lm_head is an FSDP2 ``DTensor``.
+
+    The EAGLE-1/2 recipe can FSDP2-shard the target (its ``distributed:`` path for
+    targets that do not fit on one GPU), making ``lm_head.weight`` a ``DTensor``
+    while the DDP draft produces plain ``hidden_states``. ``compute_logits`` must
+    gather the weight first; otherwise ``F.linear`` raises a mixed Tensor/DTensor
+    error.
+    """
+    import torch.distributed as dist
+    import torch.nn as nn
+    from torch.distributed.device_mesh import init_device_mesh
+    from torch.distributed.tensor import Shard, distribute_tensor
+
+    if not dist.is_available():
+        import pytest
+
+        pytest.skip("torch.distributed is not available")
+
+    already_initialized = dist.is_initialized()
+    if not already_initialized:
+        dist.init_process_group(backend="gloo", rank=0, world_size=1, store=dist.HashStore())
+    try:
+        torch.manual_seed(0)
+        target_model = _build_tiny_target()
+        target_model.requires_grad_(False)
+        draft_model = _build_tiny_draft_model()
+
+        mesh = init_device_mesh("cpu", (1,))
+        full_weight = target_model.lm_head.weight.detach().clone()
+        sharded_weight = distribute_tensor(target_model.lm_head.weight.detach(), mesh, [Shard(0)])
+        # A ``DTensor`` is a ``torch.Tensor`` subclass, so it can back a Parameter;
+        # this reproduces what FSDP2 leaves on ``lm_head.weight`` after sharding.
+        target_model.lm_head.weight = nn.Parameter(sharded_weight, requires_grad=False)
+        assert hasattr(target_model.lm_head.weight, "full_tensor")
+
+        trainer = EagleTrainerModule(draft_model, target_lm_head=target_model.lm_head)
+
+        hidden_states = torch.randn(2, 6, draft_model.config.hidden_size)
+        logits = trainer.compute_logits(hidden_states)
+
+        assert torch.isfinite(logits).all()
+        torch.testing.assert_close(logits, torch.nn.functional.linear(hidden_states, full_weight))
+    finally:
+        if not already_initialized:
+            dist.destroy_process_group()


### PR DESCRIPTION
## What

`EagleTrainerModule.compute_logits` projects the predicted draft hidden states through the **target** `lm_head`:

```python
return F.linear(hidden_states, self._target_lm_head.weight)
```

When the EAGLE-1/2 recipe shards the target via its optional `distributed:` path (the documented route for targets that do not fit on a single GPU, e.g. a Qwen3-30B-A3B MoE target), `lm_head.weight` becomes a `DTensor`. The draft runs under DDP, so `hidden_states` is a plain tensor, and the projection fails with:

```
RuntimeError: aten.mm.default got mixed torch.Tensor and DTensor, need to convert all torch.Tensor to DTensor
```

The EAGLE-3 path already handles the analogous case in `copy_embeddings_from_target` by gathering with `.full_tensor()`; the EAGLE-1/2 token-loss head was missing the same guard.

## Fix

Gather the frozen target weight to a local full tensor before `F.linear`:

```python
weight = self._target_lm_head.weight
if hasattr(weight, "full_tensor"):
    weight = weight.full_tensor()
return F.linear(hidden_states, weight)
```

It is a no-op when the target is unsharded, so the common single-GPU-per-rank dense path is unaffected.

## Test

Adds `test_compute_logits_gathers_sharded_dtensor_target_lm_head`: inits a single-rank gloo group, shards the tiny target's `lm_head.weight` into a `DTensor`, and asserts `compute_logits` returns finite logits equal to the dense `F.linear` reference. Verified the test fails on the old code path (the mixed Tensor/DTensor error above) and passes with the fix.

```
tests/unit_tests/speculative/test_eagle12.py ....  4 passed
```