### PR TITLE
fix(speculative): validate DFlash mask_token_id on checkpoint resume

### DIFF
--- a/nemo_automodel/recipes/llm/train_dflash.py
+++ b/nemo_automodel/recipes/llm/train_dflash.py
@@ -472,12 +472,28 @@ class TrainDFlashRecipe(BaseRecipe):
         self._load_extra_state(ckpt_dir)
 
     def _load_extra_state(self, ckpt_dir: str) -> None:
-        """Restore DFlash meta: global_step and epoch."""
+        """Restore DFlash meta: global_step and epoch, and validate mask_token_id."""
         meta_path = os.path.join(ckpt_dir, "dflash_meta.pt")
         if os.path.exists(meta_path):
             meta = torch.load(meta_path, weights_only=False, map_location="cpu")
             self.runtime.global_step = int(meta.get("global_step", 0))
             self._resume_epoch = int(meta.get("epoch", 0))
+            # ``mask_token_id`` comes only from the resume YAML (it is not
+            # restored from the checkpoint); the draft's ``embed_tokens`` row at
+            # that id is the learned "predict here" signal and the inference
+            # runtime fills block slots with the same id. A resume YAML whose
+            # ``mask_token_id`` disagrees with the trained one silently points the
+            # mask slots at an untrained embedding row and degrades acceptance
+            # with no error, so fail loudly on a mismatch. Legacy checkpoints
+            # saved before this field existed (``None``) skip the check.
+            saved_mask_token_id = meta.get("mask_token_id", None)
+            if saved_mask_token_id is not None and int(saved_mask_token_id) != int(self.mask_token_id):
+                raise ValueError(
+                    f"mask_token_id mismatch on resume: the checkpoint at {ckpt_dir} was trained with "
+                    f"mask_token_id={int(saved_mask_token_id)}, but recipe_args.mask_token_id="
+                    f"{int(self.mask_token_id)}. The draft's mask-slot embedding was learned at the "
+                    f"checkpoint's id; set recipe_args.mask_token_id={int(saved_mask_token_id)} to resume."
+                )
 
     def _log_saved_checkpoint(self, kind: str, epoch: int, step: int) -> None:
         """Log a saved checkpoint on rank 0 when checkpointing is enabled."""

--- a/tests/unit_tests/recipes/llm/test_train_dflash.py
+++ b/tests/unit_tests/recipes/llm/test_train_dflash.py
@@ -196,3 +196,51 @@ def test_all_ranks_have_valid_ddp_min_reduces_across_ranks(monkeypatch):
     # Every rank valid -> MIN leaves the 1 in place -> all run the backward.
     monkeypatch.setattr(train_dflash.dist, "all_reduce", lambda t, op=None: None)
     assert train_dflash._all_ranks_have_valid(1, is_ddp=True, device="cpu") is True
+
+
+def _load_extra_state_self(mask_token_id=7):
+    return SimpleNamespace(
+        runtime=SimpleNamespace(global_step=0),
+        _resume_epoch=0,
+        mask_token_id=mask_token_id,
+    )
+
+
+def _write_meta(tmp_path, **fields):
+    meta = {"global_step": 5, "epoch": 2, "block_size": 16, "target_layer_ids": [1, 2]}
+    meta.update(fields)
+    torch.save(meta, tmp_path / "dflash_meta.pt")
+    return str(tmp_path)
+
+
+def test_load_extra_state_restores_step_and_epoch(tmp_path):
+    ckpt_dir = _write_meta(tmp_path, mask_token_id=7)
+    obj = _load_extra_state_self(mask_token_id=7)
+    TrainDFlashRecipe._load_extra_state(obj, ckpt_dir)
+    assert obj.runtime.global_step == 5
+    assert obj._resume_epoch == 2
+
+
+def test_load_extra_state_raises_on_mask_token_id_mismatch(tmp_path):
+    """A resume YAML whose mask_token_id disagrees with the checkpoint must fail loudly."""
+    ckpt_dir = _write_meta(tmp_path, mask_token_id=7)
+    obj = _load_extra_state_self(mask_token_id=99)
+    with pytest.raises(ValueError, match="mask_token_id mismatch on resume"):
+        TrainDFlashRecipe._load_extra_state(obj, ckpt_dir)
+
+
+def test_load_extra_state_accepts_legacy_meta_without_mask_token_id(tmp_path):
+    """Checkpoints saved before mask_token_id was persisted skip the check."""
+    meta = {"global_step": 3, "epoch": 1}
+    torch.save(meta, tmp_path / "dflash_meta.pt")
+    obj = _load_extra_state_self(mask_token_id=99)
+    TrainDFlashRecipe._load_extra_state(obj, str(tmp_path))
+    assert obj.runtime.global_step == 3
+    assert obj._resume_epoch == 1
+
+
+def test_load_extra_state_noop_when_meta_missing(tmp_path):
+    obj = _load_extra_state_self(mask_token_id=7)
+    TrainDFlashRecipe._load_extra_state(obj, str(tmp_path))
+    assert obj.runtime.global_step == 0
+    assert obj._resume_epoch == 0


### PR DESCRIPTION
## What

DFlash fills every non-anchor slot of a `[anchor, MASK, MASK, ...]` block with `mask_token_id`, and the draft's `embed_tokens` row at that id becomes the learned "predict here" signal. The inference runtime must fill block slots with the **same** id.

`_save_extra_state` already persists `mask_token_id` into `dflash_meta.pt`, but `_load_extra_state` restored only `global_step` and `epoch`:

```python
self.runtime.global_step = int(meta.get("global_step", 0))
self._resume_epoch = int(meta.get("epoch", 0))
```

On resume `mask_token_id` is re-read solely from the YAML (`_resolve_mask_token_id`). If the resume YAML carries a different `mask_token_id` than the checkpoint was trained with, the mask slots silently point at an untrained embedding row and acceptance degrades with no error.

## Fix

Validate the saved `mask_token_id` against the configured one in `_load_extra_state` and raise on mismatch. Legacy checkpoints saved before this field existed (`None`) skip the check, so older checkpoints still resume.

## Test

Adds four cases to `test_train_dflash.py`: step/epoch restore on match, `ValueError` on mismatch, legacy meta without `mask_token_id` accepted, and no-op when the meta file is absent.

```
tests/unit_tests/recipes/llm/test_train_dflash.py  24 passed
```