### PR TITLE
fix(model): honor yarn/linear/dynamic RoPE in LlamaRotaryEmbedding

### DIFF
--- a/nemo_automodel/components/models/llama/rope_utils.py
+++ b/nemo_automodel/components/models/llama/rope_utils.py
@@ -169,7 +169,10 @@ class LlamaRotaryEmbedding(nn.Module):
         self.rope_fusion = rope_fusion
         self.dtype = getattr(config, "torch_dtype", None) or torch.float32
 
-        # Map rope types to their respective computation functions
+        # ``default`` and ``llama3`` have local fast-path implementations. Every
+        # other schedule (``yarn``, ``linear``, ``dynamic``, ``longrope``, ...)
+        # is delegated to transformers' canonical ``ROPE_INIT_FUNCTIONS`` so the
+        # frequencies and attention scaling match HuggingFace exactly.
         rope_functions = {
             "default": _compute_default_inv_freq,
             "llama3": _compute_llama3_inv_freq,
@@ -179,8 +182,19 @@ class LlamaRotaryEmbedding(nn.Module):
         _, rope_scaling = _get_rope_config(config)
         rope_type = rope_scaling.get("rope_type", rope_scaling.get("type", "default"))
 
-        # Fallback to llama3 as the robust default if type is not in our map
-        compute_fn = rope_functions.get(rope_type, _compute_llama3_inv_freq)
+        # Resolve the compute function. An unrecognised ``rope_type`` previously
+        # fell back silently to the llama3 NTK schedule, which yields wrong
+        # frequencies for YaRN/linear/dynamic configs -- a latent bug, e.g. for
+        # an EAGLE dense draft that inherits a YaRN target's ``rope_scaling``.
+        # Delegate such types to transformers instead of guessing.
+        compute_fn = rope_functions.get(rope_type)
+        if compute_fn is None:
+            from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
+
+            compute_fn = ROPE_INIT_FUNCTIONS.get(rope_type)
+            if compute_fn is None:
+                supported = sorted(set(rope_functions) | set(ROPE_INIT_FUNCTIONS))
+                raise ValueError(f"Unsupported RoPE rope_type={rope_type!r}; expected one of {supported}.")
         inv_freq, self.attention_scaling = compute_fn(config, device)
 
         # Keep the config + compute fn so ``_build_cache`` can recompute ``inv_freq``

--- a/tests/unit_tests/models/llama/test_rope_utils.py
+++ b/tests/unit_tests/models/llama/test_rope_utils.py
@@ -22,6 +22,7 @@ parallelism -- silently receive the wrong rotary phase.
 
 from unittest.mock import patch
 
+import pytest
 import torch
 from transformers import LlamaConfig
 
@@ -192,3 +193,62 @@ def test_bf16_model_cast_does_not_degrade_inv_freq():
     # Bit-for-bit: the cast module must still build its tables from float32 inv_freq.
     torch.testing.assert_close(cos_cast, cos_ref, rtol=0, atol=0)
     torch.testing.assert_close(sin_cast, sin_ref, rtol=0, atol=0)
+
+
+def _config_with_rope_scaling(rope_scaling: dict) -> LlamaConfig:
+    """Build a config carrying ``rope_scaling``, mirroring how the EAGLE recipe
+    seeds the draft config from ``target_config.to_dict()``."""
+    base = LlamaConfig(
+        hidden_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        num_hidden_layers=2,
+        max_position_embeddings=2048,
+    )
+    config_dict = base.to_dict()
+    config_dict["rope_scaling"] = rope_scaling
+    return LlamaConfig.from_dict(config_dict)
+
+
+def test_rope_yarn_matches_transformers_not_llama3_fallback():
+    """A ``yarn`` rope_type must use transformers' YaRN schedule, not silently
+    fall back to llama3 (the latent bug an EAGLE dense draft inherited from a
+    YaRN target's ``rope_scaling``)."""
+    from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
+
+    from nemo_automodel.components.models.llama.rope_utils import _compute_llama3_inv_freq
+
+    config = _config_with_rope_scaling({"rope_type": "yarn", "factor": 4.0, "original_max_position_embeddings": 2048})
+    rope = LlamaRotaryEmbedding(config)
+
+    ref_inv_freq, ref_scaling = ROPE_INIT_FUNCTIONS["yarn"](config, torch.device("cpu"))
+    torch.testing.assert_close(rope.inv_freq, ref_inv_freq)
+    assert rope.attention_scaling == ref_scaling
+    assert rope.attention_scaling != 1.0  # YaRN applies an mscale; proves it ran
+
+    # The old behavior fell back to the llama3 NTK schedule; the fix must differ.
+    llama3_inv_freq, _ = _compute_llama3_inv_freq(config, torch.device("cpu"))
+    assert not torch.allclose(rope.inv_freq, llama3_inv_freq)
+
+
+def test_rope_linear_and_dynamic_resolve_via_transformers():
+    """``linear`` and ``dynamic`` schedules resolve through transformers without error."""
+    from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
+
+    for rope_type in ("linear", "dynamic"):
+        config = _config_with_rope_scaling({"rope_type": rope_type, "factor": 4.0})
+        rope = LlamaRotaryEmbedding(config)
+        ref_inv_freq, _ = ROPE_INIT_FUNCTIONS[rope_type](config, torch.device("cpu"))
+        torch.testing.assert_close(rope.inv_freq, ref_inv_freq)
+
+
+def test_rope_unknown_type_raises():
+    """An unrecognised rope_type fails loudly instead of guessing a schedule."""
+    config = _config_with_rope_scaling({"rope_type": "default", "rope_theta": 10000.0})
+    # Inject a bogus type after construction to bypass HF config validation and
+    # reach the resolver. ``_get_rope_config`` reads ``rope_parameters`` first.
+    bogus = {"rope_type": "does_not_exist"}
+    config.rope_parameters = bogus
+    config.rope_scaling = bogus
+    with pytest.raises(ValueError, match="Unsupported RoPE rope_type"):
+        LlamaRotaryEmbedding(config)


### PR DESCRIPTION
## What

`LlamaRotaryEmbedding` mapped only `rope_type` `default` and `llama3` to a compute function and **silently fell back to the llama3 NTK schedule** for everything else:

```python
compute_fn = rope_functions.get(rope_type, _compute_llama3_inv_freq)
```

So a `yarn` / `linear` / `dynamic` / `longrope` config received the wrong rotary frequencies.

This is most damaging for the **EAGLE dense draft**. `TrainEagle3Recipe` / `TrainEagle1Recipe` seed the draft config from `target_config.to_dict()`, so a YaRN target's `rope_scaling` flows verbatim into the Llama-style draft. The draft then trains and serves with a RoPE inconsistent with the target at long positions, degrading acceptance. The gpt-oss draft already works around the exact same gap with a dedicated `GptOssDraftRotaryEmbedding` (its docstring calls the dense fallback "a latent bug masked by short-context training"); the dense path had no such guard.

## Fix

Resolve the compute function explicitly: keep the local `default` / `llama3` fast paths, delegate any other `rope_type` to transformers' canonical `ROPE_INIT_FUNCTIONS` (already used in `checkpointing.py`), and raise a clear `ValueError` on a genuinely unknown type instead of guessing.

```python
compute_fn = rope_functions.get(rope_type)
if compute_fn is None:
    from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
    compute_fn = ROPE_INIT_FUNCTIONS.get(rope_type)
    if compute_fn is None:
        raise ValueError(...)
```

The fix lives in the shared `LlamaRotaryEmbedding`, so every Llama/Qwen2-style model with a non-llama3 scaling benefits, not just the draft.

### Behavior change

Models that previously ran with the (incorrect) llama3 fallback for a YaRN/linear/dynamic config will now use the correct schedule, so their rotary frequencies change. This is a correctness fix; `default` and `llama3` configs (the common path) are byte-for-byte unchanged.

## Test

Adds to `test_rope_utils.py`: YaRN `inv_freq` and `attention_scaling` match `transformers` and differ from the old llama3 fallback; `linear`/`dynamic` resolve via transformers; an unknown `rope_type` raises.

```
tests/unit_tests/models/llama/test_rope_utils.py  10 passed
# regression: tests/unit_tests/models/llama + eagle draft tests  49 passed, 8 skipped
```