### PR TITLE
fix(speculative): keep DFlash padding blocks self-attending to avoid NaN

### DIFF
--- a/nemo_automodel/components/attention/dflash_mask.py
+++ b/nemo_automodel/components/attention/dflash_mask.py
@@ -96,7 +96,12 @@ def create_dflash_sdpa_mask(
     noise_visible = is_noise & (q_block == kv_block)
 
     keep = block_keep_mask.view(B, 1, N, 1).repeat_interleave(block_size, dim=2)
-    bool_mask = (ctx_visible | noise_visible) & keep
+    # A padding block (``keep`` False) keeps only its in-block (noise) attention,
+    # so its query rows are never fully masked. A fully-masked row makes the dense
+    # softmax (the sdpa/eager backends) return NaN, which then contaminates the
+    # rest of the sample through the next layer's ``0 * NaN`` value aggregation.
+    # The block's output is discarded downstream by the loss block mask anyway.
+    bool_mask = (ctx_visible & keep) | noise_visible
 
     neg_inf = torch.tensor(float("-inf"), device=device, dtype=dtype)
     zero = torch.tensor(0.0, device=device, dtype=dtype)
@@ -151,7 +156,10 @@ def create_dflash_block_mask(
 
         keep = block_keep_mask[b, safe_q_block]
         in_bounds = q_block < N
-        return (ctx_visible | noise_visible) & keep & in_bounds
+        # Padding blocks keep in-block attention so no query row is fully masked
+        # (see create_dflash_sdpa_mask; kept consistent across backends, and the
+        # output is dropped by the loss block mask anyway).
+        return ((ctx_visible & keep) | noise_visible) & in_bounds
 
     # ``BLOCK_SIZE`` is left at the default (128). It MUST be a multiple of the
     # underlying flex_attention kernel's BLOCK_M / BLOCK_N (128 on H100); setting

--- a/tests/unit_tests/attention/test_dflash_mask.py
+++ b/tests/unit_tests/attention/test_dflash_mask.py
@@ -29,7 +29,10 @@ def _reference_dflash_mask(anchor_positions, block_keep_mask, ctx_len, block_siz
     Mirrors the rules from the DFlash paper §4.2:
     - Block b attends to context positions ``< anchor[b]`` (causal prefix).
     - Block b attends to its own noise positions (bidirectional).
-    - Different blocks invisible; padded-anchor slots see nothing.
+    - Different blocks invisible. A padded-anchor block (keep=False) drops its
+      context attention but keeps its in-block noise attention, so its query
+      rows are never fully masked (a fully-masked row NaNs the dense softmax);
+      its output is discarded by the loss block mask.
     """
     B, N = anchor_positions.shape
     Q_LEN = N * block_size
@@ -38,12 +41,11 @@ def _reference_dflash_mask(anchor_positions, block_keep_mask, ctx_len, block_siz
     for b in range(B):
         for q in range(Q_LEN):
             block_id = q // block_size
-            if not bool(block_keep_mask[b, block_id]):
-                continue
+            keep = bool(block_keep_mask[b, block_id])
             anchor = int(anchor_positions[b, block_id])
             for k in range(KV_LEN):
                 is_ctx = k < ctx_len
-                ctx_ok = is_ctx and (k < anchor)
+                ctx_ok = is_ctx and (k < anchor) and keep
                 is_noise = k >= ctx_len
                 kv_block = (k - ctx_len) // block_size if is_noise else -1
                 noise_ok = is_noise and (kv_block == block_id)
@@ -77,8 +79,14 @@ def test_sdpa_mask_matches_reference():
     assert sdpa.shape == (2, 1, 2 * 4, 8 + 2 * 4)
 
 
-def test_sdpa_mask_respects_block_keep():
-    """Padded anchor slots (keep=False) must attend to nothing."""
+def test_sdpa_mask_padding_block_keeps_in_block_attention():
+    """A padded anchor block (keep=False) drops context but keeps in-block noise.
+
+    A fully-masked query row would NaN the dense softmax (sdpa/eager) and, via the
+    next layer's ``0 * NaN`` value aggregation, poison the whole sample. The
+    padded block must therefore stay self-attending (its output is dropped by the
+    loss block mask), never fully masked.
+    """
     block_size = 4
     ctx_len = 6
     anchor_positions = torch.tensor([[2, 4, 0]], dtype=torch.long)
@@ -93,9 +101,15 @@ def test_sdpa_mask_respects_block_keep():
         dtype=torch.float32,
     )
 
-    # Rows for block 2 (q_idx in [8, 12)) must all be -inf — sees nothing.
     pad_rows = sdpa[0, 0, 2 * block_size : 3 * block_size, :]
-    assert torch.all(torch.isinf(pad_rows) & (pad_rows < 0))
+    # No padded-block row is fully masked (every row has at least one 0 entry).
+    assert not torch.any(torch.all(torch.isinf(pad_rows) & (pad_rows < 0), dim=-1))
+    # Padded block sees only its own block's noise (kv in [ctx + 2*bs, ctx + 3*bs)).
+    own_noise = slice(ctx_len + 2 * block_size, ctx_len + 3 * block_size)
+    assert torch.all(pad_rows[:, own_noise] == 0.0)
+    # ...and nothing in the context or the other blocks' noise.
+    assert torch.all(torch.isinf(pad_rows[:, :ctx_len]) & (pad_rows[:, :ctx_len] < 0))
+    assert torch.all(torch.isinf(pad_rows[:, ctx_len : ctx_len + 2 * block_size]))
 
 
 def test_sdpa_mask_overlapping_anchors():

--- a/tests/unit_tests/speculative/test_dflash_core.py
+++ b/tests/unit_tests/speculative/test_dflash_core.py
@@ -31,7 +31,7 @@ BLOCK_SIZE = 4
 MASK_ID = VOCAB - 1
 
 
-def _build_trainer(num_anchors=8, loss_decay_gamma=None):
+def _build_trainer(num_anchors=8, loss_decay_gamma=None, attention_backend="sdpa"):
     cfg = Qwen3Config(
         vocab_size=VOCAB,
         hidden_size=HIDDEN,
@@ -48,7 +48,7 @@ def _build_trainer(num_anchors=8, loss_decay_gamma=None):
     cfg.num_target_layers = NUM_TARGET_LAYERS
     cfg.block_size = BLOCK_SIZE
     cfg.dflash_config = {"mask_token_id": MASK_ID, "target_layer_ids": TARGET_LAYER_IDS}
-    cfg._attn_implementation = "sdpa"
+    cfg._attn_implementation = attention_backend
     draft = Qwen3DFlashDraftModel(cfg)
     lm_head = torch.nn.Linear(HIDDEN, VOCAB, bias=False)
     embed = torch.nn.Embedding(VOCAB, HIDDEN)
@@ -58,7 +58,7 @@ def _build_trainer(num_anchors=8, loss_decay_gamma=None):
         target_embed_tokens=embed,
         mask_token_id=MASK_ID,
         block_size=BLOCK_SIZE,
-        attention_backend="sdpa",
+        attention_backend=attention_backend,
         num_anchors=num_anchors,
         loss_decay_gamma=loss_decay_gamma,
     )
@@ -81,6 +81,28 @@ def test_forward_returns_finite_loss_and_grads_flow_to_draft():
     assert 0.0 <= out.accuracy.item() <= 1.0
     assert out.valid_tokens.item() > 0
     out.loss.backward()
+    grad = sum(p.grad.abs().sum().item() for p in trainer.draft_model.parameters() if p.grad is not None)
+    assert grad > 0
+
+
+@pytest.mark.parametrize("attention_backend", ["eager", "sdpa"])
+def test_padding_blocks_do_not_nan_loss_or_grads(attention_backend):
+    """A batch mixing sequence lengths produces padding blocks (block_keep_mask
+    has False entries). Those blocks must not NaN the loss or gradients on the
+    dense (eager/sdpa) backends: a fully-masked attention row NaNs the softmax,
+    and that NaN spreads across the whole sample via the next layer's
+    ``0 * NaN`` value aggregation. Regression for that contamination."""
+    trainer = _build_trainer(loss_decay_gamma=7.0, attention_backend=attention_backend)
+    input_ids, hidden, loss_mask = _inputs(bsz=2, seq_len=24)
+    # Sample 0 keeps only the first 5 positions valid -> fewer anchors than
+    # sample 1 -> trailing padding blocks for sample 0.
+    loss_mask[0, 5:] = 0.0
+
+    out = trainer(input_ids=input_ids, hidden_states=hidden, loss_mask=loss_mask)
+    assert torch.isfinite(out.loss) and out.loss.item() > 0
+
+    out.loss.backward()
+    assert all(torch.isfinite(p.grad).all() for p in trainer.draft_model.parameters() if p.grad is not None)
     grad = sum(p.grad.abs().sum().item() for p in trainer.draft_model.parameters() if p.grad is not None)
     assert grad > 0
 


### PR DESCRIPTION
## What

A batch that mixes sequence lengths yields padding blocks: `block_keep_mask` has `False` entries for the trailing anchors of shorter samples. The DFlash masks dropped those blocks by masking their query rows **entirely** (all `-inf`):

```python
bool_mask = (ctx_visible | noise_visible) & keep   # keep=False -> whole row -inf
```

A fully-masked row makes the dense softmax return NaN. On the **eager** backend that NaN then spreads across the *whole sample* through the next layer's `0 * NaN` value aggregation (a valid query weights a padding block's NaN key value with attention weight 0, and `0 * NaN = NaN`), so the loss and all gradients become NaN.

The default `flex_attention` backend returns 0 for fully-masked rows, and torch's fused SDPA kernel also handles them, so only the **eager** backend was actually broken. But eager is a selectable backend (`attention_backend=eager`) and it silently NaNs training on any variable-length batch.

## Fix

Keep a padding block's in-block (noise) attention so its query rows are never fully masked. The block's output is discarded downstream by the loss block mask regardless, so this changes nothing observable except removing the NaN:

```python
bool_mask = (ctx_visible & keep) | noise_visible
```

Applied to both the SDPA additive mask and the `flex_attention` `BlockMask` (and the element-level test reference) so the backends stay consistent. For batches with no padding blocks (all `keep=True`) the mask is byte-for-byte unchanged, so the common path and uniform-length batches are unaffected.

## Test

Adds a parametrized `eager`/`sdpa` regression in `test_dflash_core.py` that trains on a mixed-length batch (forcing padding blocks) and asserts finite loss and gradients. Verified it fails on `eager` before the fix (NaN loss + NaN grads) and passes after. Updates the mask reference + block-keep test to the self-attending semantics.

```
tests/unit_tests/attention/test_dflash_mask.py + speculative/test_dflash_core.py  49 passed, 1 skipped
```