### PR TITLE
feat(speculative): support target tensor parallelism in EAGLE-3 colocated path

### DIFF
--- a/examples/speculative/eagle3/qwen3_eagle3_tp.yaml
+++ b/examples/speculative/eagle3/qwen3_eagle3_tp.yaml
@@ -1,0 +1,66 @@
+recipe: TrainEagle3Recipe
+
+# EAGLE-3 with tensor parallelism on the (colocated) target.
+#
+# TP shards the frozen target's linears (column/row parallel) across the "tp"
+# device submesh, so a target that does not fit on a single GPU (e.g. a large
+# dense Qwen3) can still supply supervision in-process. The draft is small and
+# stays replicated: it runs data-parallel over the "dp" axis (which excludes
+# "tp"), so every TP rank in a draft replica sees the same batch. The target's
+# column-parallel lm_head returns vocab-sharded logits; the target wrapper
+# gathers them to a full tensor before the draft-vocab projection. Notes:
+#   * TP requires the fsdp2 strategy and world_size > 1; tp_size must divide the
+#     number of GPUs and the target's attention head count.
+#     dp_size = world_size / (tp_size * cp_size * pp_size).
+#   * TP only shards the colocated target (not the remote / offline backends).
+#   * Combined TP + CP is not yet supported; keep cp_size: 1.
+#   * The target must expose a tensor-parallel plan (Qwen3 / Llama dense do).
+#
+# Run (single node, tp_size=2 over 2 GPUs):
+#   automodel examples/speculative/eagle3/qwen3_eagle3_tp.yaml \
+#       --nproc-per-node 2 --distributed.tp_size=2
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 30
+
+recipe_args:
+  target_model_name_or_path: Qwen/Qwen3-4B
+  # Pin the target to SDPA to dodge the Qwen3 FA2 s_aux=None crash; TP itself
+  # works with any backend the target supports.
+  target_attn_implementation: sdpa
+  draft_attn_implementation: flash_attention_2
+  train_data_path: ./cache/dataset/perfectblend-messages
+  val_data_path: null
+  train_split: "train[:64]"
+  val_split: null
+  output_dir: ./outputs/eagle3_qwen3_4b_tp
+  seq_length: 2048
+  micro_batch_size: 1
+  grad_accumulation_steps: 1
+  num_workers: 0
+  num_epochs: 1
+  ttt_steps: 7
+  draft_vocab_size: 32000
+  freeze_embeddings: true
+  trust_remote_code: false
+  shuffle_seed: 42
+  log_every_steps: 1
+  max_grad_norm: 1.0
+  packed_sequence_size: 0
+
+rng:
+  seed: 42
+
+distributed:
+  strategy: fsdp2
+  tp_size: 2
+  cp_size: 1
+
+optimizer:
+  lr: 1.0e-4
+  betas: [0.9, 0.95]
+  weight_decay: 0.0
+
+checkpoint:
+  enabled: false

--- a/nemo_automodel/components/speculative/eagle/target.py
+++ b/nemo_automodel/components/speculative/eagle/target.py
@@ -84,6 +84,17 @@ def validate_eagle3_aux_layer_ids(aux_layer_ids: Sequence[int], num_layers: int)
     return aux_layer_ids
 
 
+def _to_full_tensor(tensor: torch.Tensor) -> torch.Tensor:
+    """Materialise a (possibly tensor-parallel) tensor as a plain local tensor.
+
+    With a tensor-parallel target the lm_head is column-parallel, so its logits
+    come back as a vocab-sharded ``DTensor``. The draft consumes plain tensors,
+    so gather the full tensor before handing it on. A no-op for an already-plain
+    (unsharded or pure-FSDP-replicated) tensor.
+    """
+    return tensor.full_tensor() if hasattr(tensor, "full_tensor") else tensor
+
+
 @dataclass
 class Eagle3TargetBatch:
     """Target-model supervision for one draft-training batch.
@@ -339,6 +350,11 @@ class HFEagle3TargetModel(Eagle3TargetBackend):
         finally:
             for handle in handles:
                 handle.remove()
+        # A tensor-parallel target returns vocab-sharded (DTensor) logits from its
+        # column-parallel lm_head; gather to a full tensor before the draft-vocab
+        # projection and shift. No-op without TP. (TP is gated off with CP for now,
+        # so the CP branch above never produces a TP-sharded logits tensor.)
+        target_logits = _to_full_tensor(target_logits)
         shifted_logits = _shift_left_with_zero(target_logits)
         shifted_input_ids = _shift_left_with_zero(input_ids)
         shifted_loss_mask = _shift_left_with_zero(loss_mask)

--- a/nemo_automodel/recipes/llm/train_eagle3.py
+++ b/nemo_automodel/recipes/llm/train_eagle3.py
@@ -117,6 +117,28 @@ def _validate_cp_gates(cp_size: int, backend: str, packed_sequence_size: int) ->
         )
 
 
+def _validate_tp_gates(tp_size: int, backend: str, cp_size: int) -> None:
+    """Reject tensor-parallel combinations the EAGLE-3 target path cannot honor.
+
+    TP shards only the colocated target (the FSDP2 parallelize plan column/row
+    shards its linears and makes the lm_head logits a vocab-sharded ``DTensor``,
+    which the target wrapper gathers). It is therefore meaningless with the remote
+    backend (the target runs out-of-process), and combined TP+CP is not yet wired:
+    the CP gather path does not handle a TP-sharded (DTensor) sequence.
+    """
+    if tp_size > 1 and backend != "colocated":
+        raise NotImplementedError(
+            "Tensor parallelism (tp_size>1) is only supported with the colocated target backend; "
+            f"the {backend!r} backend runs the target out-of-process."
+        )
+    if tp_size > 1 and cp_size > 1:
+        raise NotImplementedError(
+            "Tensor parallelism (tp_size>1) combined with context parallelism (cp_size>1) is not "
+            "yet supported; the CP sequence gather does not handle a TP-sharded target output. "
+            "Set tp_size=1 or cp_size=1."
+        )
+
+
 def _best_effort(label: str, fn) -> None:
     """Run a teardown step, logging (never raising) on failure so one failed step
     does not abort the rest of cleanup."""
@@ -430,10 +452,12 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
                 "packed_sequence_size > 0 is only supported with the colocated target backend; "
                 f"the {backend!r} backend does not propagate per-document masking."
             )
-        # Context parallelism gates (read from config: the cp submesh is only
-        # built later, inside the colocated path).
+        # Context- and tensor-parallel gates (read from config: the cp/tp
+        # submeshes are only built later, inside the colocated path).
         cp_size = int(self.cfg.get("distributed.cp_size", 1) or 1)
+        tp_size = int(self.cfg.get("distributed.tp_size", 1) or 1)
         _validate_cp_gates(cp_size, backend, packed_sequence_size)
+        _validate_tp_gates(tp_size, backend, cp_size)
         if backend == "remote":
             self._setup_remote_target(recipe_cfg)
         elif backend == "sglang":
@@ -522,6 +546,11 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
             # Capture the cp/dp submeshes: the target forward runs CP on "cp",
             # while the draft DDP group, dataloader sampler, and checkpointer key
             # on "dp" (cp ranks within a dp group share data and draft weights).
+            # Tensor parallelism (distributed.tp_size>1) needs no submesh here: the
+            # target's linears are sharded in place by ``from_pretrained`` below
+            # (its FSDP2 parallelize plan), the wrapper gathers the resulting
+            # vocab-sharded logits, and the flattened "dp" axis already excludes
+            # the "tp" axis so the draft and sampler replicate across TP ranks.
             self.cp_mesh = _submesh_or_none(self.device_mesh, "cp")
             self.dp_mesh = _submesh_or_none(self.device_mesh, "dp")
             target_kwargs.update(

--- a/tests/unit_tests/speculative/test_eagle3_target_tp.py
+++ b/tests/unit_tests/speculative/test_eagle3_target_tp.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU unit tests for EAGLE-3 target-model tensor parallelism.
+
+Covers the pieces verifiable without multiple GPUs: the recipe-level TP gates and
+the target wrapper's gather of a tensor-parallel (vocab-sharded ``DTensor``)
+logits output back to a plain tensor for the draft. The real multi-rank TP
+sharding is validated on the server.
+"""
+
+import pytest
+import torch
+from transformers import LlamaConfig, LlamaForCausalLM
+
+from nemo_automodel.components.speculative.eagle.target import HFEagle3TargetModel, _to_full_tensor
+from nemo_automodel.recipes.llm.train_eagle3 import _validate_tp_gates
+
+
+def _tiny_target(num_hidden_layers: int = 4) -> LlamaForCausalLM:
+    config = LlamaConfig(
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=num_hidden_layers,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        vocab_size=64,
+        max_position_embeddings=32,
+    )
+    config.torch_dtype = torch.float32
+    return LlamaForCausalLM(config).to(torch.float32).eval()
+
+
+@pytest.fixture
+def single_rank_pg():
+    """A single-rank gloo process group so DTensor / TP primitives run on CPU."""
+    import torch.distributed as dist
+
+    if not dist.is_available():
+        pytest.skip("torch.distributed is not available")
+    already = dist.is_initialized()
+    if not already:
+        dist.init_process_group(backend="gloo", rank=0, world_size=1, store=dist.HashStore())
+    try:
+        yield
+    finally:
+        if not already:
+            dist.destroy_process_group()
+
+
+# --------------------------------------------------------------------------- #
+# Recipe TP gates
+# --------------------------------------------------------------------------- #
+def test_tp_gate_allows_tp_size_one():
+    # tp_size==1 must never raise, regardless of backend or cp_size.
+    _validate_tp_gates(tp_size=1, backend="remote", cp_size=4)
+    _validate_tp_gates(tp_size=1, backend="colocated", cp_size=1)
+
+
+def test_tp_gate_allows_colocated():
+    _validate_tp_gates(tp_size=2, backend="colocated", cp_size=1)
+
+
+def test_tp_gate_rejects_remote_backend():
+    with pytest.raises(NotImplementedError, match="only supported with the colocated target backend"):
+        _validate_tp_gates(tp_size=2, backend="remote", cp_size=1)
+
+
+def test_tp_gate_rejects_combined_with_cp():
+    with pytest.raises(NotImplementedError, match="context parallelism"):
+        _validate_tp_gates(tp_size=2, backend="colocated", cp_size=2)
+
+
+# --------------------------------------------------------------------------- #
+# _to_full_tensor: gather a TP-sharded DTensor, no-op on a plain tensor
+# --------------------------------------------------------------------------- #
+def test_to_full_tensor_is_noop_on_plain_tensor():
+    plain = torch.randn(2, 3)
+    assert _to_full_tensor(plain) is plain
+
+
+def test_to_full_tensor_gathers_vocab_sharded_dtensor(single_rank_pg):
+    from torch.distributed.device_mesh import init_device_mesh
+    from torch.distributed.tensor import Shard, distribute_tensor
+
+    full = torch.randn(2, 4, 6)
+    mesh = init_device_mesh("cpu", (1,), mesh_dim_names=("tp",))
+    sharded = distribute_tensor(full, mesh, [Shard(-1)])  # mimics a column-parallel lm_head
+    assert hasattr(sharded, "full_tensor")
+
+    out = _to_full_tensor(sharded)
+    assert not hasattr(out, "full_tensor")  # now a plain tensor
+    torch.testing.assert_close(out, full)
+
+
+# --------------------------------------------------------------------------- #
+# generate_batch under a tensor-parallel (DTensor) lm_head
+# --------------------------------------------------------------------------- #
+def test_generate_batch_gathers_tp_sharded_logits(single_rank_pg):
+    """A column-parallel lm_head yields vocab-sharded DTensor logits; the wrapper
+    must hand the draft a plain (gathered) tensor, not a DTensor."""
+    from torch.distributed.device_mesh import init_device_mesh
+    from torch.distributed.tensor import Shard
+    from torch.distributed.tensor.parallel import ColwiseParallel, parallelize_module
+
+    torch.manual_seed(0)
+    model = _tiny_target(num_hidden_layers=4)
+    mesh = init_device_mesh("cpu", (1,), mesh_dim_names=("tp",))
+    # Tensor-parallel only the lm_head -> vocab-sharded DTensor logits (the TP plan
+    # leaves the decoder residual stream replicated, so aux hidden states stay plain).
+    parallelize_module(model, mesh, {"lm_head": ColwiseParallel(output_layouts=Shard(-1), use_local_output=False)})
+    assert hasattr(model(input_ids=torch.randint(0, 64, (1, 8))).logits, "full_tensor")
+
+    wrapper = HFEagle3TargetModel(model, aux_layer_ids=[1, 2, 3])
+    b, t = 1, 8
+    batch = wrapper.generate_batch(
+        input_ids=torch.randint(0, 64, (b, t)),
+        attention_mask=torch.ones(b, t, dtype=torch.long),
+        loss_mask=torch.ones(b, t, dtype=torch.long),
+    )
+
+    assert not hasattr(batch.logits, "full_tensor")  # gathered to a plain tensor
+    assert batch.logits.shape[:2] == (b, t)
+    assert torch.isfinite(batch.logits).all()
+    # aux hidden states are 3 concatenated layers of hidden_size 16 -> 48.
+    assert batch.aux_hidden_states.shape == (b, t, 48)


### PR DESCRIPTION
## What

A large dense target that does not fit on a single GPU (e.g. a big Qwen3) could not feed the online (**colocated**) EAGLE-3 draft: the recipe built only a context-parallel (`cp`) submesh, never tensor-parallel. The remote / offline-cache backends were the only way to train against such a target.

The distributed infrastructure already supports TP, so this reuses it rather than adding new machinery:
- the device mesh always carries a `tp` axis sized from `distributed.tp_size`;
- `NeMoAutoModelForCausalLM.from_pretrained(distributed_setup=...)` already applies the model's FSDP2 tensor-parallel plan when `tp_size>1`.

So with `distributed.tp_size>1` the frozen target was in fact already being TP-sharded; the missing piece was downstream handling.

## Changes (no change to `components/distributed/*`)

- **Gather TP-sharded logits.** A column-parallel `lm_head` returns vocab-sharded (`DTensor`) logits. `HFEagle3TargetModel.generate_batch` now gathers them to a full tensor (`_to_full_tensor`) before the draft-vocab projection / shift. No-op without TP. Aux hidden states stay replicated under the default (non sequence-parallel) plan, so they are unchanged.
- **Gates.** `_validate_tp_gates`: TP only shards the colocated target (not the remote backend, which runs out-of-process), and TP+CP is rejected for now (the CP sequence gather does not yet handle a TP-sharded output).
- **Draft / data sharding need no change.** The draft DDP group and the `DistributedSampler` already key on the flattened `dp` axis, which excludes `tp`, so the small draft replicates across TP ranks and every TP rank in a replica sees the same batch.
- **Example config** `examples/speculative/eagle3/qwen3_eagle3_tp.yaml`.

## Usage

```
automodel examples/speculative/eagle3/qwen3_eagle3_tp.yaml --nproc-per-node 2 --distributed.tp_size=2
```

## Test

`tests/unit_tests/speculative/test_eagle3_target_tp.py`: TP gates; the `DTensor`->full-tensor gather; and a colocated `generate_batch` whose tensor-parallel (`DTensor`) lm_head logits come back as a plain tensor for the draft. Single-rank gloo on CPU; real multi-rank TP is validated on GPU.

```
tests/unit_tests/speculative/test_eagle3_target_tp.py  7 passed
# regression: eagle3 target / cp / gates  40 passed
```

Scope: EAGLE-3 colocated path. EAGLE-1/2 and DFlash (which lack the `dp_mesh` / sampler wiring) are follow-ups.