### PR TITLE
feat(speculative): support target tensor parallelism in EAGLE-1/2

### DIFF
--- a/examples/speculative/eagle1/llama_eagle1_tp.yaml
+++ b/examples/speculative/eagle1/llama_eagle1_tp.yaml
@@ -1,0 +1,56 @@
+recipe: TrainEagle1Recipe
+
+# EAGLE-1 with tensor parallelism on the target.
+#
+# TP shards the frozen target's linears across the "tp" device submesh so a
+# target that does not fit on one GPU can still supply hidden-state supervision.
+# The draft is small and stays replicated: it runs data-parallel over the "dp"
+# axis (which excludes "tp"), so every TP rank in a draft replica sees the same
+# batch. The target's column-parallel lm_head returns vocab-sharded logits; the
+# target wrapper gathers them, and the draft's token-loss projection gathers the
+# (DTensor) lm_head weight. Notes:
+#   * TP requires the fsdp2 strategy and world_size > 1; tp_size must divide the
+#     number of GPUs and the target's attention head count.
+#     dp_size = world_size / (tp_size * pp_size).
+#   * The target must expose a tensor-parallel plan (Llama / Qwen3 dense do).
+#
+# Run (single node, tp_size=2 over 2 GPUs):
+#   automodel examples/speculative/eagle1/llama_eagle1_tp.yaml \
+#       --nproc-per-node 2 --distributed.tp_size=2
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 30
+
+recipe_args:
+  target_model_name_or_path: meta-llama/Llama-3.2-1B
+  train_data_path: /path/to/train.jsonl
+  val_data_path: null
+  train_split: null
+  val_split: null
+  output_dir: ./outputs/eagle1_llama_tp
+  seq_length: 1024
+  micro_batch_size: 1
+  grad_accumulation_steps: 1
+  num_workers: 0
+  num_epochs: 1
+  draft_num_hidden_layers: 1
+  hidden_loss_weight: 1.0
+  token_loss_weight: 0.1
+  freeze_embeddings: true
+  trust_remote_code: false
+  shuffle_seed: 42
+  log_every_steps: 10
+  max_grad_norm: 1.0
+
+distributed:
+  strategy: fsdp2
+  tp_size: 2
+
+optimizer:
+  lr: 1.0e-4
+  betas: [0.9, 0.95]
+  weight_decay: 0.0
+
+checkpoint:
+  enabled: false

--- a/nemo_automodel/components/speculative/eagle/core_v12.py
+++ b/nemo_automodel/components/speculative/eagle/core_v12.py
@@ -69,7 +69,16 @@ class EagleTrainerModule(nn.Module):
 
     def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor:
         """Project predicted hidden states through the frozen target lm_head."""
-        return F.linear(hidden_states, self._target_lm_head.weight)
+        weight = self._target_lm_head.weight
+        # The target may be FSDP2-sharded (the EAGLE-1/2 recipe's optional
+        # ``distributed:`` path, used for targets that do not fit on one GPU),
+        # which makes ``weight`` a ``DTensor``. The draft runs under DDP, so
+        # ``hidden_states`` is a plain tensor and ``F.linear`` cannot mix the
+        # two. Gather the frozen weight to a local full tensor first -- mirrors
+        # ``copy_embeddings_from_target``. No-op when the target is unsharded.
+        if hasattr(weight, "full_tensor"):
+            weight = weight.full_tensor()
+        return F.linear(hidden_states, weight)
 
     def forward(
         self,

--- a/nemo_automodel/components/speculative/eagle/target_v12.py
+++ b/nemo_automodel/components/speculative/eagle/target_v12.py
@@ -29,6 +29,17 @@ def _shift_left_with_zero(tensor: torch.Tensor) -> torch.Tensor:
     return torch.cat((tensor[:, 1:], tail), dim=1)
 
 
+def _to_full_tensor(tensor: torch.Tensor) -> torch.Tensor:
+    """Materialise a (possibly tensor-parallel) tensor as a plain local tensor.
+
+    With a tensor-parallel target the lm_head is column-parallel, so its logits
+    come back as a vocab-sharded ``DTensor``. The draft consumes plain tensors,
+    so gather the full tensor before handing it on. A no-op for an already-plain
+    (unsharded or pure-FSDP-replicated) tensor.
+    """
+    return tensor.full_tensor() if hasattr(tensor, "full_tensor") else tensor
+
+
 @dataclass
 class EagleTargetBatch:
     """Target-model outputs needed by the EAGLE-1 / EAGLE-2 trainer."""
@@ -83,7 +94,11 @@ class HFEagleTargetModel:
         # ``last_hidden_state``; AutoModel custom backbones return the
         # bare hidden tensor.
         hidden_states = outputs if isinstance(outputs, torch.Tensor) else outputs[0]
-        logits = self.model.lm_head(hidden_states)
+        # A tensor-parallel target has a column-parallel lm_head, so its logits
+        # are a vocab-sharded DTensor; gather to a full tensor for the draft. The
+        # hidden states stay replicated under the default (non sequence-parallel)
+        # plan, so they need no gather. No-op without TP.
+        logits = _to_full_tensor(self.model.lm_head(hidden_states))
         return EagleTargetBatch(
             input_hidden_states=hidden_states,
             target_hidden_states=_shift_left_with_zero(hidden_states),

--- a/nemo_automodel/recipes/llm/train_eagle1.py
+++ b/nemo_automodel/recipes/llm/train_eagle1.py
@@ -38,6 +38,7 @@ from nemo_automodel.components.checkpoint.checkpointing import (
 from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
 from nemo_automodel.components.datasets.llm.eagle3 import build_eagle3_dataloader
 from nemo_automodel.components.distributed.init_utils import initialize_distributed
+from nemo_automodel.components.distributed.mesh_utils import get_flat_mesh
 from nemo_automodel.components.loggers.log_utils import setup_logging
 from nemo_automodel.components.loggers.wandb_utils import init_wandb_run, suppress_wandb_log_messages
 from nemo_automodel.components.speculative.eagle.core_v12 import EagleTrainerModule
@@ -66,6 +67,22 @@ def _all_reduce_mean(value: torch.Tensor) -> torch.Tensor:
         dist.all_reduce(value, op=dist.ReduceOp.SUM)
         value = value / dist.get_world_size()
     return value
+
+
+def _submesh_or_none(device_mesh, name: str):
+    """Return the named (flattened) submesh, or None if absent / no mesh.
+
+    Uses ``get_flat_mesh`` so ``_flatten()``-created axes ("dp") resolve across
+    torch versions. The "dp" axis excludes "tp", so keying the draft DDP group
+    and the dataloader sampler on it replicates the draft across tensor-parallel
+    ranks (every TP rank in a draft replica sees the same batch).
+    """
+    if device_mesh is None:
+        return None
+    try:
+        return get_flat_mesh(device_mesh, name)
+    except KeyError:
+        return None
 
 
 class TrainEagle1Recipe(BaseRecipe):
@@ -115,11 +132,19 @@ class TrainEagle1Recipe(BaseRecipe):
         self.distributed_config = None
         self.device_mesh = None
         self.moe_mesh = None
+        self.dp_mesh = None
         if self.cfg.get("distributed", None) is not None:
             self.dist_setup = create_distributed_setup_from_config(self.cfg, world_size=self.dist_env.world_size)
             self.distributed_config = self.dist_setup.strategy_config
             self.device_mesh = self.dist_setup.mesh_context.device_mesh
             self.moe_mesh = self.dist_setup.mesh_context.moe_mesh
+            # Tensor parallelism (distributed.tp_size>1) shards the target's
+            # linears in place via ``from_pretrained`` below; the draft is small
+            # and stays replicated. The flattened "dp" axis excludes "tp", so the
+            # draft DDP group and the dataloader sampler key on it to replicate
+            # across TP ranks (the target wrapper gathers the vocab-sharded
+            # logits). EAGLE-1/2 has no context parallelism, so only "dp" matters.
+            self.dp_mesh = _submesh_or_none(self.device_mesh, "dp")
             target_kwargs.update(
                 distributed_setup=self.dist_setup,
             )
@@ -143,6 +168,7 @@ class TrainEagle1Recipe(BaseRecipe):
             distributed=self.dist_env.world_size > 1,
             shuffle_seed=recipe_cfg.get("shuffle_seed", 42),
             mask_reasoning_content=recipe_cfg.get("mask_reasoning_content", False),
+            dp_mesh=self.dp_mesh,
         )
         self.val_dataloader = None
         if recipe_cfg.get("val_data_path", None):
@@ -157,6 +183,7 @@ class TrainEagle1Recipe(BaseRecipe):
                 distributed=self.dist_env.world_size > 1,
                 shuffle_seed=recipe_cfg.get("shuffle_seed", 42),
                 mask_reasoning_content=recipe_cfg.get("mask_reasoning_content", False),
+                dp_mesh=self.dp_mesh,
             )
 
         draft_config = target_config.to_dict()
@@ -183,12 +210,24 @@ class TrainEagle1Recipe(BaseRecipe):
             feature_noise=float(recipe_cfg.get("feature_noise", 0.1)),
         ).to(self.device)
         if self.dist_env.world_size > 1:
+            # Restrict the draft's gradient all-reduce to the "dp" sub-axis. With
+            # tensor parallelism the draft is replicated across tp ranks, so a
+            # full-world all-reduce would average duplicate gradients; the dp
+            # group (which excludes tp) reduces only across real data replicas.
+            # Without a mesh (tp_size=1) dp_mesh is None -> full-world DDP,
+            # unchanged.
+            dp_process_group = (
+                self.dp_mesh.get_group()
+                if self.dp_mesh is not None and self.dp_mesh.size() < self.dist_env.world_size
+                else None
+            )
             trainer_module = DistributedDataParallel(
                 trainer_module,
                 device_ids=[self.device.index] if self.device.type == "cuda" else None,
                 output_device=self.device.index if self.device.type == "cuda" else None,
                 broadcast_buffers=False,
                 find_unused_parameters=False,
+                process_group=dp_process_group,
             )
         self.trainer_module = trainer_module
 
@@ -287,7 +326,15 @@ class TrainEagle1Recipe(BaseRecipe):
             ckpt_kwargs["model_state_dict_keys"] = draft_state_dict_keys
 
         self.checkpoint_config = CheckpointingConfig(**ckpt_kwargs)
-        dp_rank = dist.get_rank() if dist.is_initialized() else 0
+        # The draft is replicated (never TP-sharded), so key the checkpoint shard
+        # on the dp coordinate -- identical for every tp rank in a replica --
+        # rather than the global rank. dp_mesh is None without a mesh (tp_size=1)
+        # -> global rank, unchanged. tp_rank stays 0 (the draft is not sharded).
+        dp_rank = (
+            self.dp_mesh.get_local_rank()
+            if getattr(self, "dp_mesh", None) is not None
+            else (dist.get_rank() if dist.is_initialized() else 0)
+        )
         self.checkpointer = self.checkpoint_config.build(
             dp_rank=dp_rank,
             tp_rank=0,

--- a/tests/unit_tests/speculative/test_eagle12.py
+++ b/tests/unit_tests/speculative/test_eagle12.py
@@ -127,3 +127,51 @@ def test_eagle_trainer_runs_and_backprops():
         if p.requires_grad
     )
     assert has_grad, "expected at least one parameter to receive a non-zero gradient"
+
+
+def test_compute_logits_gathers_sharded_dtensor_target_lm_head():
+    """The token-loss head must work when the target lm_head is an FSDP2 ``DTensor``.
+
+    The EAGLE-1/2 recipe can FSDP2-shard the target (its ``distributed:`` path for
+    targets that do not fit on one GPU), making ``lm_head.weight`` a ``DTensor``
+    while the DDP draft produces plain ``hidden_states``. ``compute_logits`` must
+    gather the weight first; otherwise ``F.linear`` raises a mixed Tensor/DTensor
+    error.
+    """
+    import torch.distributed as dist
+    import torch.nn as nn
+    from torch.distributed.device_mesh import init_device_mesh
+    from torch.distributed.tensor import Shard, distribute_tensor
+
+    if not dist.is_available():
+        import pytest
+
+        pytest.skip("torch.distributed is not available")
+
+    already_initialized = dist.is_initialized()
+    if not already_initialized:
+        dist.init_process_group(backend="gloo", rank=0, world_size=1, store=dist.HashStore())
+    try:
+        torch.manual_seed(0)
+        target_model = _build_tiny_target()
+        target_model.requires_grad_(False)
+        draft_model = _build_tiny_draft_model()
+
+        mesh = init_device_mesh("cpu", (1,))
+        full_weight = target_model.lm_head.weight.detach().clone()
+        sharded_weight = distribute_tensor(target_model.lm_head.weight.detach(), mesh, [Shard(0)])
+        # A ``DTensor`` is a ``torch.Tensor`` subclass, so it can back a Parameter;
+        # this reproduces what FSDP2 leaves on ``lm_head.weight`` after sharding.
+        target_model.lm_head.weight = nn.Parameter(sharded_weight, requires_grad=False)
+        assert hasattr(target_model.lm_head.weight, "full_tensor")
+
+        trainer = EagleTrainerModule(draft_model, target_lm_head=target_model.lm_head)
+
+        hidden_states = torch.randn(2, 6, draft_model.config.hidden_size)
+        logits = trainer.compute_logits(hidden_states)
+
+        assert torch.isfinite(logits).all()
+        torch.testing.assert_close(logits, torch.nn.functional.linear(hidden_states, full_weight))
+    finally:
+        if not already_initialized:
+            dist.destroy_process_group()

--- a/tests/unit_tests/speculative/test_eagle12_tp.py
+++ b/tests/unit_tests/speculative/test_eagle12_tp.py
@@ -1,0 +1,129 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU unit tests for EAGLE-1 / EAGLE-2 target-model tensor parallelism.
+
+Covers the pieces verifiable without multiple GPUs: the target wrapper's gather
+of a tensor-parallel (vocab-sharded ``DTensor``) logits output back to a plain
+tensor, and the ``dp`` submesh resolution the recipe keys its draft DDP group /
+dataloader sampler on. The real multi-rank TP sharding is validated on the server.
+"""
+
+import pytest
+import torch
+from transformers import LlamaConfig, LlamaForCausalLM
+
+import nemo_automodel.recipes.llm.train_eagle1 as train_eagle1
+from nemo_automodel.components.speculative.eagle.target_v12 import HFEagleTargetModel, _to_full_tensor
+
+
+def _tiny_target(num_hidden_layers: int = 4) -> LlamaForCausalLM:
+    config = LlamaConfig(
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=num_hidden_layers,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        vocab_size=64,
+        max_position_embeddings=32,
+    )
+    config.torch_dtype = torch.float32
+    return LlamaForCausalLM(config).to(torch.float32).eval()
+
+
+@pytest.fixture
+def single_rank_pg():
+    """A single-rank gloo process group so DTensor / TP primitives run on CPU."""
+    import torch.distributed as dist
+
+    if not dist.is_available():
+        pytest.skip("torch.distributed is not available")
+    already = dist.is_initialized()
+    if not already:
+        dist.init_process_group(backend="gloo", rank=0, world_size=1, store=dist.HashStore())
+    try:
+        yield
+    finally:
+        if not already:
+            dist.destroy_process_group()
+
+
+# --------------------------------------------------------------------------- #
+# _to_full_tensor
+# --------------------------------------------------------------------------- #
+def test_to_full_tensor_is_noop_on_plain_tensor():
+    plain = torch.randn(2, 3)
+    assert _to_full_tensor(plain) is plain
+
+
+def test_to_full_tensor_gathers_vocab_sharded_dtensor(single_rank_pg):
+    from torch.distributed.device_mesh import init_device_mesh
+    from torch.distributed.tensor import Shard, distribute_tensor
+
+    full = torch.randn(2, 4, 6)
+    mesh = init_device_mesh("cpu", (1,), mesh_dim_names=("tp",))
+    sharded = distribute_tensor(full, mesh, [Shard(-1)])
+    assert hasattr(sharded, "full_tensor")
+
+    out = _to_full_tensor(sharded)
+    assert not hasattr(out, "full_tensor")
+    torch.testing.assert_close(out, full)
+
+
+# --------------------------------------------------------------------------- #
+# generate_batch under a tensor-parallel (DTensor) lm_head
+# --------------------------------------------------------------------------- #
+def test_generate_batch_gathers_tp_sharded_logits(single_rank_pg):
+    """A column-parallel lm_head yields vocab-sharded DTensor logits; the wrapper
+    must hand the draft a plain (gathered) tensor. Hidden states stay plain."""
+    from torch.distributed.device_mesh import init_device_mesh
+    from torch.distributed.tensor import Shard
+    from torch.distributed.tensor.parallel import ColwiseParallel, parallelize_module
+
+    torch.manual_seed(0)
+    model = _tiny_target(num_hidden_layers=4)
+    mesh = init_device_mesh("cpu", (1,), mesh_dim_names=("tp",))
+    parallelize_module(model, mesh, {"lm_head": ColwiseParallel(output_layouts=Shard(-1), use_local_output=False)})
+    assert hasattr(model(input_ids=torch.randint(0, 64, (1, 8))).logits, "full_tensor")
+
+    wrapper = HFEagleTargetModel(model)
+    b, t = 1, 8
+    batch = wrapper.generate_batch(
+        input_ids=torch.randint(0, 64, (b, t)),
+        attention_mask=torch.ones(b, t, dtype=torch.long),
+        loss_mask=torch.ones(b, t, dtype=torch.long),
+    )
+
+    assert not hasattr(batch.target_logits, "full_tensor")  # gathered to plain
+    assert torch.isfinite(batch.target_logits).all()
+    assert batch.target_logits.shape[:2] == (b, t)
+    # Hidden states are replicated under the default plan -> plain tensors.
+    assert not hasattr(batch.input_hidden_states, "full_tensor")
+    assert not hasattr(batch.target_hidden_states, "full_tensor")
+
+
+# --------------------------------------------------------------------------- #
+# _submesh_or_none: None mesh, present axis, missing axis (KeyError -> None)
+# --------------------------------------------------------------------------- #
+def test_submesh_or_none_handles_none_present_and_missing(monkeypatch):
+    assert train_eagle1._submesh_or_none(None, "dp") is None
+
+    monkeypatch.setattr(train_eagle1, "get_flat_mesh", lambda mesh, name: ("submesh", name))
+    assert train_eagle1._submesh_or_none(object(), "dp") == ("submesh", "dp")
+
+    def _raise(mesh, name):
+        raise KeyError(name)
+
+    monkeypatch.setattr(train_eagle1, "get_flat_mesh", _raise)
+    assert train_eagle1._submesh_or_none(object(), "dp") is None


### PR DESCRIPTION
## What

Extends colocated target tensor parallelism (added for EAGLE-3 in #2827) to the EAGLE-1/2 recipe, so a target that does not fit on one GPU can still supply hidden-state supervision online.

The recipe already loads the target via `NeMoAutoModelForCausalLM.from_pretrained(distributed_setup=...)`, so `distributed.tp_size>1` already TP-shards it. This wires up the downstream handling:

- **`target_v12`**: the column-parallel lm_head returns vocab-sharded (`DTensor`) logits; `generate_batch` now gathers them to a full tensor (`_to_full_tensor`) for the draft. Hidden states stay replicated under the default (non sequence-parallel) plan, so they need no gather. No-op without TP.
- **`train_eagle1`**: capture the flattened `dp` submesh (which excludes `tp`) and key the draft DDP group, the `DistributedSampler`, and the checkpointer `dp_rank` on it. The replicated draft then averages gradients only across real data replicas and every TP rank in a replica sees the same batch. Without a mesh (`tp_size=1`) these fall back to full-world DDP / global rank, unchanged.
- **Example** `examples/speculative/eagle1/llama_eagle1_tp.yaml`.

## Dependency

Stacked on **#2823** (`fix(speculative): gather sharded target lm_head in EAGLE-1/2 token loss`): under TP the target lm_head **weight** is also a `DTensor`, and the draft's token-loss projection `compute_logits` needs the `.full_tensor()` gather that #2823 adds. Until #2823 merges, this PR's diff includes that commit.

## Usage

```
automodel examples/speculative/eagle1/llama_eagle1_tp.yaml --nproc-per-node 2 --distributed.tp_size=2
```

## Test

`tests/unit_tests/speculative/test_eagle12_tp.py`: the `DTensor`->full-tensor gather, a `generate_batch` whose tensor-parallel (`DTensor`) lm_head logits come back plain, and `dp` submesh resolution. Single-rank gloo on CPU; real multi-rank TP is validated on GPU.

```
test_eagle12_tp.py + test_eagle12 + test_eagle12_coverage  37 passed
```

Scope: EAGLE-1/2 colocated. DFlash TP is a separate follow-up (it lacks a `distributed:` section entirely).