### PR TITLE
feat(speculative): support target tensor parallelism in DFlash

### DIFF
--- a/examples/speculative/dflash/qwen3_dflash_tp.yaml
+++ b/examples/speculative/dflash/qwen3_dflash_tp.yaml
@@ -1,0 +1,59 @@
+# DFlash draft training with tensor parallelism on the target.
+#
+# TP shards the frozen target's linears across the "tp" device submesh so a
+# target that does not fit on one GPU can still supply hidden-state context. The
+# draft is small and stays replicated: it runs data-parallel over the "dp" axis
+# (which excludes "tp"), so every TP rank in a draft replica sees the same batch.
+# The trainer holds the target's lm_head / embed_tokens as non-registered
+# references (DDP sees only the draft) and gathers their vocab-sharded (DTensor)
+# outputs back to plain tensors. Notes:
+#   * TP requires the fsdp2 strategy and world_size > 1; tp_size must divide the
+#     number of GPUs and the target's attention head count.
+#     dp_size = world_size / (tp_size * pp_size).
+#   * The target must expose a tensor-parallel plan (Qwen3 dense does).
+#
+# Run (single node, tp_size=2 over 2 GPUs):
+#   automodel examples/speculative/dflash/qwen3_dflash_tp.yaml \
+#       --nproc-per-node 2 --distributed.tp_size=2
+
+recipe: TrainDFlashRecipe
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 30
+
+recipe_args:
+  target_model_name_or_path: Qwen/Qwen3-8B
+  train_data_path: /path/to/perfectblend_qwen3-8b_regen.jsonl   # regenerate responses with the target model first
+  val_data_path: null
+  output_dir: ./outputs/dflash_qwen3_8b_tp
+  seq_length: 3072
+  micro_batch_size: 4
+  grad_accumulation_steps: 1
+  num_workers: 4
+  num_epochs: 6
+
+  # --- DFlash-specific ---
+  draft_num_hidden_layers: 5
+  block_size: 16
+  num_anchors: 512
+  loss_decay_gamma: 7.0
+  mask_token_id: 151669               # REQUIRED reserved token for non-anchor block positions
+  attention_backend: flex_attention
+
+  trust_remote_code: false
+  shuffle_seed: 42
+  log_every_steps: 10
+  max_grad_norm: 1.0
+
+distributed:
+  strategy: fsdp2
+  tp_size: 2
+
+optimizer:
+  lr: 1.0e-4
+  betas: [0.9, 0.95]
+  weight_decay: 0.0
+
+checkpoint:
+  enabled: false

--- a/nemo_automodel/components/speculative/dflash/core.py
+++ b/nemo_automodel/components/speculative/dflash/core.py
@@ -38,6 +38,17 @@ from nemo_automodel.components.loss.dllm_loss import DFlashDecayLoss
 from nemo_automodel.components.speculative.dflash.draft_qwen3 import Qwen3DFlashDraftModel
 
 
+def _to_full_tensor(tensor: torch.Tensor) -> torch.Tensor:
+    """Materialise a (possibly tensor-parallel) tensor as a plain local tensor.
+
+    Under tensor parallelism the target's column-parallel ``lm_head`` and
+    vocab-parallel ``embed_tokens`` return ``DTensor`` outputs. The draft and the
+    block-wise loss consume plain tensors, so gather the full tensor. A no-op for
+    an already-plain (unsharded / replicated) tensor.
+    """
+    return tensor.full_tensor() if hasattr(tensor, "full_tensor") else tensor
+
+
 class NoValidAnchorsError(ValueError):
     """Raised when a batch has no sample long enough to form a DFlash block.
 
@@ -73,8 +84,14 @@ class DFlashTrainerModule(nn.Module):
     ):
         super().__init__()
         self.draft_model = draft_model
-        self.lm_head = target_lm_head
-        self.embed_tokens = target_embed_tokens
+        # Keep the frozen target lm_head / embed_tokens as NON-registered
+        # references. Under tensor parallelism their weights are DTensors; a
+        # registered (DDP-wrapped) sharded param would break DDP's parameter
+        # broadcast/bucketing. Non-registering keeps the DDP-wrapped trainer to
+        # the plain draft params only, while ``self.lm_head`` / ``self.embed_tokens``
+        # attribute access still works. (Mirrors EAGLE core_v12's _target_lm_head.)
+        object.__setattr__(self, "lm_head", target_lm_head)
+        object.__setattr__(self, "embed_tokens", target_embed_tokens)
         self.block_size = block_size
         self.mask_token_id = mask_token_id
         self.attention_backend = attention_backend
@@ -151,7 +168,9 @@ class DFlashTrainerModule(nn.Module):
             anchor_tokens,
             torch.tensor(self.mask_token_id, dtype=torch.long, device=device),
         )
-        return self.embed_tokens(noise_ids)
+        # A tensor-parallel target's embed_tokens is vocab-parallel and returns a
+        # DTensor; gather it so the (plain) draft can consume the noise embedding.
+        return _to_full_tensor(self.embed_tokens(noise_ids))
 
     def forward(
         self,
@@ -185,7 +204,9 @@ class DFlashTrainerModule(nn.Module):
             target_hidden=hidden_states,
             attention_mask=dflash_attn_mask,
         )
-        logits = self.lm_head(output_hidden)
+        # A tensor-parallel target's lm_head is column-parallel and returns
+        # vocab-sharded (DTensor) logits; gather to a full tensor for the loss.
+        logits = _to_full_tensor(self.lm_head(output_hidden))
 
         n = anchor_positions.size(1)
         bs = self.block_size

--- a/nemo_automodel/recipes/llm/train_dflash.py
+++ b/nemo_automodel/recipes/llm/train_dflash.py
@@ -48,12 +48,14 @@ from nemo_automodel.components.checkpoint.checkpointing import (
 from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
 from nemo_automodel.components.datasets.llm.eagle3 import build_eagle3_dataloader
 from nemo_automodel.components.distributed.init_utils import initialize_distributed
+from nemo_automodel.components.distributed.mesh_utils import get_flat_mesh
 from nemo_automodel.components.loggers.log_utils import setup_logging
 from nemo_automodel.components.speculative.dflash.core import DFlashTrainerModule, NoValidAnchorsError
 from nemo_automodel.components.speculative.dflash.draft_qwen3 import build_target_layer_ids
 from nemo_automodel.components.speculative.dflash.registry import resolve_dflash_draft_spec
 from nemo_automodel.components.speculative.dflash.target import HFDFlashTargetModel
 from nemo_automodel.components.training.rng import StatefulRNG
+from nemo_automodel.recipes._dist_utils import create_distributed_setup_from_config
 from nemo_automodel.recipes.base_recipe import (
     BaseRecipe,
     _find_latest_checkpoint,
@@ -94,6 +96,23 @@ def _all_ranks_have_valid(local_has_valid: int, is_ddp: bool, device) -> bool:
     return bool(flag.item())
 
 
+def _submesh_or_none(device_mesh, name: str):
+    """Return the named (flattened) submesh, or None if absent / no mesh.
+
+    Uses ``get_flat_mesh`` so ``_flatten()``-created axes ("dp") resolve across
+    torch versions. The "dp" axis excludes "tp", so keying the draft DDP group,
+    the dataloader sampler, and the checkpointer dp_rank on it replicates the
+    draft across tensor-parallel ranks (every TP rank in a draft replica sees the
+    same batch).
+    """
+    if device_mesh is None:
+        return None
+    try:
+        return get_flat_mesh(device_mesh, name)
+    except KeyError:
+        return None
+
+
 class TrainDFlashRecipe(BaseRecipe):
     """Recipe for DFlash draft-model training on Qwen3-style dense / MoE targets."""
 
@@ -123,19 +142,7 @@ class TrainDFlashRecipe(BaseRecipe):
         )
         self.compute_dtype = torch.bfloat16 if self.device.type == "cuda" else torch.float32
 
-        target_attn_implementation = recipe_cfg.get("target_attn_implementation", None)
-        target_kwargs = {}
-        if target_attn_implementation is not None:
-            target_kwargs["attn_implementation"] = target_attn_implementation
-        self.target_model = NeMoAutoModelForCausalLM.from_pretrained(
-            target_path,
-            trust_remote_code=recipe_cfg.get("trust_remote_code", False),
-            torch_dtype=self.compute_dtype,
-            force_hf=bool(recipe_cfg.get("target_force_hf", False)),
-            **target_kwargs,
-        )
-        self.target_model.to(self.device)
-        self.target_model.requires_grad_(False)
+        self.target_model = self._build_target_model(recipe_cfg, target_path)
 
         # Resolve the captured target layers once and share them between the
         # target wrapper (what to capture) and the draft config (the ``fc`` input
@@ -162,6 +169,7 @@ class TrainDFlashRecipe(BaseRecipe):
             distributed=self.dist_env.world_size > 1,
             shuffle_seed=recipe_cfg.get("shuffle_seed", 42),
             mask_reasoning_content=recipe_cfg.get("mask_reasoning_content", False),
+            dp_mesh=self.dp_mesh,
         )
         self.val_dataloader = None
         if recipe_cfg.get("val_data_path", None):
@@ -176,6 +184,7 @@ class TrainDFlashRecipe(BaseRecipe):
                 distributed=self.dist_env.world_size > 1,
                 shuffle_seed=recipe_cfg.get("shuffle_seed", 42),
                 mask_reasoning_content=recipe_cfg.get("mask_reasoning_content", False),
+                dp_mesh=self.dp_mesh,
             )
 
         # DFlash draft config: a small non-causal Qwen3 stack that reuses the
@@ -201,12 +210,18 @@ class TrainDFlashRecipe(BaseRecipe):
 
         trainer_module = self._build_trainer_module(attention_backend, recipe_cfg).to(self.device)
         if self.dist_env.world_size > 1:
+            # The frozen target lm_head / embed_tokens are held as non-registered
+            # references on the trainer, so DDP only sees the plain draft params
+            # (no sharded DTensor params to broadcast). The draft's gradient
+            # all-reduce is restricted to the "dp" sub-axis (see
+            # ``_draft_ddp_process_group``).
             trainer_module = DistributedDataParallel(
                 trainer_module,
                 device_ids=[self.device.index] if self.device.type == "cuda" else None,
                 output_device=self.device.index if self.device.type == "cuda" else None,
                 broadcast_buffers=False,
                 find_unused_parameters=False,
+                process_group=self._draft_ddp_process_group(),
             )
         self.trainer_module = trainer_module
 
@@ -251,6 +266,54 @@ class TrainDFlashRecipe(BaseRecipe):
         self.rng = StatefulRNG(seed=int(recipe_cfg.get("shuffle_seed", 42)), ranked=self.dist_env.world_size > 1)
         self._build_checkpointer(target_path)
         self.load_checkpoint(self.cfg.get("checkpoint.restore_from", None))
+
+    def _build_target_model(self, recipe_cfg, target_path: str) -> torch.nn.Module:
+        """Load the frozen (optionally tensor-parallel) target model.
+
+        With a ``distributed:`` section and ``tp_size>1`` the target is sharded
+        in place by ``from_pretrained`` (its FSDP2 parallelize plan); the small
+        draft stays replicated and runs DDP over the "dp" axis (which excludes
+        "tp"), and the trainer module gathers the target's vocab-sharded lm_head
+        / embed_tokens outputs. Absent, the original single-GPU-per-rank DP path
+        is used. Sets ``self.dist_setup`` / ``self.device_mesh`` / ``self.dp_mesh``
+        as a side effect and returns the (grad-disabled) target.
+        """
+        target_attn_implementation = recipe_cfg.get("target_attn_implementation", None)
+        target_kwargs = dict(
+            trust_remote_code=recipe_cfg.get("trust_remote_code", False),
+            torch_dtype=self.compute_dtype,
+            force_hf=bool(recipe_cfg.get("target_force_hf", False)),
+        )
+        if target_attn_implementation is not None:
+            target_kwargs["attn_implementation"] = target_attn_implementation
+        self.dist_setup = None
+        self.device_mesh = None
+        self.dp_mesh = None
+        if self.cfg.get("distributed", None) is not None:
+            self.dist_setup = create_distributed_setup_from_config(self.cfg, world_size=self.dist_env.world_size)
+            self.device_mesh = self.dist_setup.mesh_context.device_mesh
+            self.dp_mesh = _submesh_or_none(self.device_mesh, "dp")
+            target_kwargs["distributed_setup"] = self.dist_setup
+        target_model = NeMoAutoModelForCausalLM.from_pretrained(target_path, **target_kwargs)
+        if self.dist_setup is None:
+            # ``nn.Module.to`` is in-place; the sharded path is already placed by
+            # ``from_pretrained``.
+            target_model.to(self.device)
+        target_model.requires_grad_(False)
+        return target_model
+
+    def _draft_ddp_process_group(self):
+        """Process group for the draft's gradient all-reduce.
+
+        With tensor parallelism the draft is replicated across tp ranks, so a
+        full-world all-reduce would average duplicate gradients; restrict it to
+        the "dp" sub-axis (which excludes tp) so it reduces only across real data
+        replicas. Without a mesh (tp_size=1) ``dp_mesh`` is None -> return None ->
+        the default full-world group, unchanged.
+        """
+        if self.dp_mesh is not None and self.dp_mesh.size() < self.dist_env.world_size:
+            return self.dp_mesh.get_group()
+        return None
 
     def _build_dflash_config(self, recipe_cfg, target_layer_ids: list[int]) -> dict:
         """Build the draft ``dflash_config`` block. Subclasses extend it (e.g. Domino)."""
@@ -337,7 +400,15 @@ class TrainDFlashRecipe(BaseRecipe):
             ckpt_kwargs["model_state_dict_keys"] = draft_state_dict_keys
 
         self.checkpoint_config = CheckpointingConfig(**ckpt_kwargs)
-        dp_rank = dist.get_rank() if dist.is_initialized() else 0
+        # The draft is replicated (never TP-sharded), so key the checkpoint shard
+        # on the dp coordinate -- identical for every tp rank in a replica --
+        # rather than the global rank. dp_mesh is None without a mesh (tp_size=1)
+        # -> global rank, unchanged. tp_rank stays 0 (the draft is not sharded).
+        dp_rank = (
+            self.dp_mesh.get_local_rank()
+            if getattr(self, "dp_mesh", None) is not None
+            else (dist.get_rank() if dist.is_initialized() else 0)
+        )
         self.checkpointer = Checkpointer(
             config=self.checkpoint_config, dp_rank=dp_rank, tp_rank=0, pp_rank=0, moe_mesh=None
         )

--- a/tests/unit_tests/speculative/test_dflash_tp.py
+++ b/tests/unit_tests/speculative/test_dflash_tp.py
@@ -1,0 +1,322 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU unit tests for DFlash target-model tensor parallelism.
+
+Covers the pieces verifiable without multiple GPUs: the trainer keeps the frozen
+target lm_head / embed_tokens as non-registered references (so a DDP-wrapped
+trainer only sees the plain draft params), it gathers their tensor-parallel
+(DTensor) outputs to plain tensors, and the recipe resolves the ``dp`` submesh it
+keys the draft DDP group / sampler / checkpointer on. Real multi-rank TP is
+validated on the server.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+from transformers.models.qwen3.configuration_qwen3 import Qwen3Config
+
+import nemo_automodel.recipes.llm.train_dflash as train_dflash
+from nemo_automodel.components.speculative.dflash.core import DFlashStepMetrics, DFlashTrainerModule, _to_full_tensor
+from nemo_automodel.components.speculative.dflash.draft_qwen3 import Qwen3DFlashDraftModel
+from nemo_automodel.recipes.llm.train_dflash import TrainDFlashRecipe
+
+VOCAB = 64
+HIDDEN = 32
+NUM_TARGET_LAYERS = 8
+TARGET_LAYER_IDS = [1, 3, 5]
+BLOCK_SIZE = 4
+MASK_ID = VOCAB - 1
+
+
+@pytest.fixture
+def single_rank_pg():
+    import torch.distributed as dist
+
+    if not dist.is_available():
+        pytest.skip("torch.distributed is not available")
+    already = dist.is_initialized()
+    if not already:
+        dist.init_process_group(backend="gloo", rank=0, world_size=1, store=dist.HashStore())
+    try:
+        yield
+    finally:
+        if not already:
+            dist.destroy_process_group()
+
+
+def _draft_model():
+    cfg = Qwen3Config(
+        vocab_size=VOCAB,
+        hidden_size=HIDDEN,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        max_position_embeddings=64,
+        attention_bias=False,
+        attention_dropout=0.0,
+        tie_word_embeddings=False,
+    )
+    cfg.num_target_layers = NUM_TARGET_LAYERS
+    cfg.block_size = BLOCK_SIZE
+    cfg.dflash_config = {"mask_token_id": MASK_ID, "target_layer_ids": TARGET_LAYER_IDS}
+    cfg._attn_implementation = "sdpa"
+    return Qwen3DFlashDraftModel(cfg)
+
+
+# --------------------------------------------------------------------------- #
+# _to_full_tensor
+# --------------------------------------------------------------------------- #
+def test_to_full_tensor_is_noop_on_plain_tensor():
+    plain = torch.randn(2, 3)
+    assert _to_full_tensor(plain) is plain
+
+
+def test_to_full_tensor_gathers_vocab_sharded_dtensor(single_rank_pg):
+    from torch.distributed.device_mesh import init_device_mesh
+    from torch.distributed.tensor import Shard, distribute_tensor
+
+    full = torch.randn(2, 4, 6)
+    mesh = init_device_mesh("cpu", (1,), mesh_dim_names=("tp",))
+    sharded = distribute_tensor(full, mesh, [Shard(-1)])
+    assert hasattr(sharded, "full_tensor")
+
+    out = _to_full_tensor(sharded)
+    assert not hasattr(out, "full_tensor")
+    torch.testing.assert_close(out, full)
+
+
+# --------------------------------------------------------------------------- #
+# Trainer with a tensor-parallel target lm_head + embed_tokens
+# --------------------------------------------------------------------------- #
+def test_trainer_runs_with_tensor_parallel_target(single_rank_pg):
+    """A column-parallel lm_head and vocab-parallel embed_tokens return DTensors;
+    the trainer must gather them, keep them non-registered (so DDP sees only the
+    draft), run a finite forward, and flow gradients to the draft."""
+    from torch.distributed.device_mesh import init_device_mesh
+    from torch.distributed.tensor import Replicate, Shard
+    from torch.distributed.tensor.parallel import ColwiseParallel, RowwiseParallel, parallelize_module
+
+    torch.manual_seed(0)
+    draft = _draft_model()
+    lm_head = nn.Linear(HIDDEN, VOCAB, bias=False)
+    embed = nn.Embedding(VOCAB, HIDDEN)
+    mesh = init_device_mesh("cpu", (1,), mesh_dim_names=("tp",))
+    parallelize_module(lm_head, mesh, ColwiseParallel(output_layouts=Shard(-1), use_local_output=False))
+    parallelize_module(
+        embed, mesh, RowwiseParallel(input_layouts=Replicate(), output_layouts=Replicate(), use_local_output=False)
+    )
+
+    trainer = DFlashTrainerModule(
+        draft_model=draft,
+        target_lm_head=lm_head,
+        target_embed_tokens=embed,
+        mask_token_id=MASK_ID,
+        block_size=BLOCK_SIZE,
+        attention_backend="sdpa",
+        num_anchors=8,
+        loss_decay_gamma=7.0,
+    )
+
+    # The frozen target modules are non-registered: a DDP-wrapped trainer must
+    # only see the plain draft params (no sharded DTensor params to broadcast).
+    trainer_param_ids = {id(p) for p in trainer.parameters()}
+    assert all(id(p) not in trainer_param_ids for p in lm_head.parameters())
+    assert all(id(p) not in trainer_param_ids for p in embed.parameters())
+    assert trainer_param_ids == {id(p) for p in draft.parameters()}
+
+    input_ids = torch.randint(0, VOCAB - 1, (2, 24))
+    hidden = torch.randn(2, 24, len(TARGET_LAYER_IDS) * HIDDEN)
+    loss_mask = torch.ones(2, 24)
+    out = trainer(input_ids=input_ids, hidden_states=hidden, loss_mask=loss_mask)
+
+    assert isinstance(out, DFlashStepMetrics)
+    assert torch.isfinite(out.loss) and out.loss.item() > 0
+
+    out.loss.backward()
+    assert all(torch.isfinite(p.grad).all() for p in draft.parameters() if p.grad is not None)
+    grad = sum(p.grad.abs().sum().item() for p in draft.parameters() if p.grad is not None)
+    assert grad > 0
+
+
+# --------------------------------------------------------------------------- #
+# _submesh_or_none
+# --------------------------------------------------------------------------- #
+def test_submesh_or_none_handles_none_present_and_missing(monkeypatch):
+    assert train_dflash._submesh_or_none(None, "dp") is None
+
+    monkeypatch.setattr(train_dflash, "get_flat_mesh", lambda mesh, name: ("submesh", name))
+    assert train_dflash._submesh_or_none(object(), "dp") == ("submesh", "dp")
+
+    def _raise(mesh, name):
+        raise KeyError(name)
+
+    monkeypatch.setattr(train_dflash, "get_flat_mesh", _raise)
+    assert train_dflash._submesh_or_none(object(), "dp") is None
+
+
+# --------------------------------------------------------------------------- #
+# TrainDFlashRecipe seams: target build / DDP group / checkpoint dp_rank
+# --------------------------------------------------------------------------- #
+def _bare_recipe(**attrs):
+    """A recipe instance with ``setup()`` bypassed and only the attrs under test set."""
+    recipe = TrainDFlashRecipe.__new__(TrainDFlashRecipe)
+    for name, value in attrs.items():
+        setattr(recipe, name, value)
+    return recipe
+
+
+class _TargetStub:
+    """Stand-in for a loaded target model; records ``.to`` / ``requires_grad_``."""
+
+    def __init__(self):
+        self.to_calls = []
+        self.requires_grad_calls = []
+
+    def to(self, device):
+        self.to_calls.append(device)
+        return self
+
+    def requires_grad_(self, flag):
+        self.requires_grad_calls.append(flag)
+        return self
+
+
+def test_build_target_model_single_gpu_path(monkeypatch):
+    """No ``distributed:`` section: no mesh is built, ``from_pretrained`` is called
+    without ``distributed_setup``, and ``.to(device)`` places the target."""
+    captured = {}
+    stub = _TargetStub()
+
+    def _fake_from_pretrained(path, **kwargs):
+        captured["path"] = path
+        captured["kwargs"] = kwargs
+        return stub
+
+    monkeypatch.setattr(
+        train_dflash, "NeMoAutoModelForCausalLM", SimpleNamespace(from_pretrained=_fake_from_pretrained)
+    )
+
+    recipe = _bare_recipe(
+        cfg={},  # no "distributed" key
+        dist_env=SimpleNamespace(world_size=1),
+        device=torch.device("cpu"),
+        compute_dtype=torch.float32,
+    )
+    out = recipe._build_target_model({"target_attn_implementation": "sdpa"}, "target/path")
+
+    assert out is stub
+    assert recipe.dist_setup is None and recipe.device_mesh is None and recipe.dp_mesh is None
+    assert "distributed_setup" not in captured["kwargs"]
+    assert captured["kwargs"]["attn_implementation"] == "sdpa"
+    assert captured["path"] == "target/path"
+    assert stub.to_calls == [recipe.device]  # placed by .to on the single-GPU path
+    assert stub.requires_grad_calls == [False]
+
+
+def test_build_target_model_tensor_parallel_path(monkeypatch):
+    """A ``distributed:`` section resolves the mesh + dp submesh, passes
+    ``distributed_setup`` to ``from_pretrained`` (sharded in place), and skips ``.to``."""
+    captured = {}
+    stub = _TargetStub()
+
+    def _fake_from_pretrained(path, **kwargs):
+        captured["kwargs"] = kwargs
+        return stub
+
+    sentinel_mesh = object()
+    sentinel_dp = object()
+    dist_setup = SimpleNamespace(mesh_context=SimpleNamespace(device_mesh=sentinel_mesh))
+    monkeypatch.setattr(
+        train_dflash, "NeMoAutoModelForCausalLM", SimpleNamespace(from_pretrained=_fake_from_pretrained)
+    )
+    monkeypatch.setattr(train_dflash, "create_distributed_setup_from_config", lambda cfg, world_size: dist_setup)
+    monkeypatch.setattr(train_dflash, "_submesh_or_none", lambda mesh, name: sentinel_dp)
+
+    recipe = _bare_recipe(
+        cfg={"distributed": {"tp_size": 2}},
+        dist_env=SimpleNamespace(world_size=2),
+        device=torch.device("cpu"),
+        compute_dtype=torch.bfloat16,
+    )
+    out = recipe._build_target_model({}, "target/path")
+
+    assert out is stub
+    assert recipe.dist_setup is dist_setup
+    assert recipe.device_mesh is sentinel_mesh
+    assert recipe.dp_mesh is sentinel_dp
+    assert captured["kwargs"]["distributed_setup"] is dist_setup
+    assert stub.to_calls == []  # sharded in place by from_pretrained, never moved
+    assert stub.requires_grad_calls == [False]
+
+
+def test_draft_ddp_process_group_no_mesh():
+    # tp_size=1 -> no mesh -> default full-world group (None).
+    recipe = _bare_recipe(dp_mesh=None, dist_env=SimpleNamespace(world_size=2))
+    assert recipe._draft_ddp_process_group() is None
+
+
+def test_draft_ddp_process_group_full_world_when_dp_spans_world():
+    # dp spans the whole world (no tp) -> default full-world group (None).
+    dp_mesh = SimpleNamespace(size=lambda: 2, get_group=lambda: "DP_GROUP")
+    recipe = _bare_recipe(dp_mesh=dp_mesh, dist_env=SimpleNamespace(world_size=2))
+    assert recipe._draft_ddp_process_group() is None
+
+
+def test_draft_ddp_process_group_restricts_to_dp_axis():
+    # dp smaller than world (tp>1) -> reduce only over the dp sub-group.
+    dp_mesh = SimpleNamespace(size=lambda: 1, get_group=lambda: "DP_GROUP")
+    recipe = _bare_recipe(dp_mesh=dp_mesh, dist_env=SimpleNamespace(world_size=2))
+    assert recipe._draft_ddp_process_group() == "DP_GROUP"
+
+
+def test_build_checkpointer_keys_dp_rank_on_dp_mesh(monkeypatch, tmp_path):
+    """The checkpoint shard is keyed on the dp coordinate (identical across tp
+    ranks of a replica), and tp_rank stays 0 (the draft is never tp-sharded)."""
+    captured = {}
+    monkeypatch.setattr(train_dflash, "CheckpointingConfig", lambda **kw: SimpleNamespace(**kw))
+    monkeypatch.setattr(train_dflash, "Checkpointer", lambda **kw: captured.update(kw) or SimpleNamespace(**kw))
+
+    recipe = _bare_recipe(
+        cfg={},  # no "checkpoint" section
+        output_dir=tmp_path,
+        draft_model=torch.nn.Linear(2, 2),
+        dp_mesh=SimpleNamespace(get_local_rank=lambda: 3),
+    )
+    recipe._build_checkpointer("target/path")
+
+    assert captured["dp_rank"] == 3
+    assert captured["tp_rank"] == 0
+
+
+def test_build_checkpointer_falls_back_to_global_rank(monkeypatch, tmp_path):
+    # tp_size=1 -> dp_mesh None -> key on the global rank (0 here, no dist init).
+    captured = {}
+    monkeypatch.setattr(train_dflash, "CheckpointingConfig", lambda **kw: SimpleNamespace(**kw))
+    monkeypatch.setattr(train_dflash, "Checkpointer", lambda **kw: captured.update(kw) or SimpleNamespace(**kw))
+    monkeypatch.setattr(train_dflash.dist, "is_initialized", lambda: False)
+
+    recipe = _bare_recipe(
+        cfg={},
+        output_dir=tmp_path,
+        draft_model=torch.nn.Linear(2, 2),
+        dp_mesh=None,
+    )
+    recipe._build_checkpointer("target/path")
+
+    assert captured["dp_rank"] == 0


### PR DESCRIPTION
## What

DFlash had no `distributed:` section at all -- it was single-GPU-per-rank data parallel only, so a target that does not fit on one GPU could not feed the draft online. This adds colocated target **tensor parallelism**, reusing the distributed infrastructure (device mesh + `from_pretrained`'s FSDP2 parallelize plan) the EAGLE recipes already use.

## Why DFlash needs more than EAGLE

Unlike EAGLE-3 (which gives the draft its own lm_head), the DFlash trainer **reuses the target's `lm_head` and `embed_tokens` directly** in its forward (the noise embedding and the draft logits). Under TP those become `DTensor`s, and a registered sharded param also breaks DDP. So:

- **`core`**: hold the frozen target `lm_head` / `embed_tokens` as **non-registered** references (`object.__setattr__`), so a DDP-wrapped trainer only sees the plain draft params (no sharded DTensor params to broadcast/bucket). Gather their vocab-sharded (`DTensor`) outputs with `_to_full_tensor` before the draft / loss consume them. No-op without TP. (Mirrors EAGLE `core_v12`'s `_target_lm_head` handling.)
- **`train_dflash`**: add the distributed scaffold -- build the mesh, TP-shard the target via `from_pretrained(distributed_setup=...)`, capture the flattened `dp` submesh (which excludes `tp`), and key the draft DDP group, the `DistributedSampler`, and the checkpointer `dp_rank` on it. Without a `distributed:` section the original single-GPU-per-rank DP behavior is unchanged.
- **Example** `examples/speculative/dflash/qwen3_dflash_tp.yaml`.

## Usage

```
automodel examples/speculative/dflash/qwen3_dflash_tp.yaml --nproc-per-node 2 --distributed.tp_size=2
```

## Test

`tests/unit_tests/speculative/test_dflash_tp.py`: the `DTensor`->full-tensor gather, and a forward+backward with a tensor-parallel (`DTensor`) `lm_head` and `embed_tokens` that stays finite, flows gradients to the draft, and keeps the target modules out of the trainer's `parameters()`. Single-rank gloo on CPU; real multi-rank TP is validated on GPU.

```
test_dflash_tp.py + test_dflash_core + test_dflash_target + test_train_dflash  35 passed
```

Completes target TP across the speculative recipes (EAGLE-3 #2827, EAGLE-1/2 #2829, DFlash here). Independent of those PRs.