### PR TITLE
feat(speculative): add serve_vllm for EAGLE-3 / P-EAGLE drafts

### DIFF
--- a/nemo_automodel/components/speculative/serve_vllm.py
+++ b/nemo_automodel/components/speculative/serve_vllm.py
@@ -1,0 +1,542 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Serve an Automodel-trained EAGLE-3 / P-EAGLE drafter with vLLM.
+
+This is the vLLM companion to ``serve_sglang``. It exists because the
+parallel-drafting (P-EAGLE) head produced by the EAGLE-3 recipe with
+``parallel_drafting: true`` is *not* servable by SGLang today (``serve_sglang``
+rejects it); its inference runtime is vLLM's parallel-drafting path
+(vLLM >= 0.16, https://github.com/vllm-project/speculators/pull/480). The same
+entry point also serves a plain (non-parallel) EAGLE-3 draft under vLLM.
+
+The EAGLE drafter checkpoints produced by the recipes are written by the
+consolidated checkpointer as an HF-style ``model/`` directory
+(``model.safetensors`` + ``config.json``), optionally nested one level deeper in
+a ``consolidated/`` subdir. The draft already stores the ``d2t`` / ``t2d``
+vocab-remap buffers inside its weights in the exact offset form vLLM expects
+(``target_id = draft_id + d2t[draft_id]``), so -- unlike the SGLang path -- no
+separate speculative-token-map file is emitted.
+
+Three fixups bridge the Automodel on-disk format to what vLLM loads:
+
+* ``architectures``: the recipe writes ``["LlamaEagle3DraftModel"]`` (the
+  Automodel class name), which is not in vLLM's model registry. vLLM routes
+  every EAGLE-3 draft on ``LlamaForCausalLMEagle3`` (``PEagleDraftModel`` /
+  ``Eagle3LlamaForCausalLM`` are registered aliases), so the field is rewritten.
+* ``pard_token`` (P-EAGLE only): vLLM's parallel-drafting proposer reads the
+  masked-slot token id from ``pard_token`` / ``ptd_token_id`` /
+  ``dflash_config.mask_token_id``, but the recipe only writes the top-level
+  ``mask_token_id``. The value is copied to ``pard_token`` (mirroring vLLM's own
+  speculators ``update_peagle`` mapping).
+* weight keys: Automodel wraps the draft as ``self.model``, so its weights are
+  saved with a leading ``model.`` (``model.embed_tokens.weight``). vLLM's loader
+  re-adds ``model.`` to every non-top-level weight, so the prefix is stripped
+  during a one-time export into a ``vllm_export/`` subdir (the source checkpoint
+  is left untouched). A draft whose weights are already vLLM-standard skips the
+  export and only gets the config fixups in place.
+
+The script then shells out to ``python -m vllm.entrypoints.openai.api_server``
+with the right ``--speculative-config``.
+
+NOTE -- vLLM is NOT bundled with the NeMo-AutoModel container image and is
+intentionally NOT declared in ``pyproject.toml``. To use this entry point,
+install it yourself into the same environment:
+
+    uv pip install "vllm>=0.16"
+
+Refer to https://github.com/vllm-project/vllm for the version matching your
+CUDA / PyTorch stack. If vLLM is missing this script exits with a clear install
+hint rather than crashing on import.
+
+Typical usage (after training produces a P-EAGLE checkpoint at
+``./outputs/peagle/checkpoints/epoch_2_step_44326``):
+
+    python -m nemo_automodel.components.speculative.serve_vllm \\
+        --target Qwen/Qwen3-8B \\
+        --draft ./outputs/peagle/checkpoints/epoch_2_step_44326 \\
+        --num-speculative-tokens 8
+
+``--num-speculative-tokens`` defaults to the draft config's ``num_depths`` (K),
+so for a P-EAGLE head it can be omitted. Pass ``--print-only`` to inspect the
+command without launching it; in that mode the on-disk ``architectures`` rewrite
+is skipped and the printed paths reflect what a real launch would produce.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from nemo_automodel.shared.import_utils import safe_import, safe_import_from
+
+logger = logging.getLogger(__name__)
+
+_VLLM_INSTALL_HINT = (
+    "vllm is not installed in this environment. Install it manually with "
+    '`uv pip install "vllm>=0.16"` (the parallel-drafting / P-EAGLE runtime landed in 0.16; '
+    "see https://github.com/vllm-project/vllm for CUDA / PyTorch compatibility) and re-run "
+    "this script. vLLM is intentionally not bundled with the NeMo-AutoModel container."
+)
+_SAFETENSORS_INSTALL_HINT = (
+    "safetensors is required to remap an Automodel drafter checkpoint for vLLM. "
+    "Install it with `uv pip install safetensors` and re-run this script."
+)
+
+# Automodel wraps the draft as ``self.model = LlamaModel(...)`` so its weights are
+# saved with a leading ``model.`` (e.g. ``model.embed_tokens.weight``). vLLM's
+# ``Eagle3LlamaForCausalLM`` loader re-adds ``model.`` to every non-top-level
+# weight, so an Automodel draft becomes ``model.model.embed_tokens.weight`` and
+# fails to load. We strip the wrapper prefix during export so vLLM resolves it.
+_MODEL_PREFIX = "model."
+_VLLM_EXPORT_DIRNAME = "vllm_export"
+
+# The EAGLE recipes write ``architectures=["LlamaEagle3DraftModel"]`` (the
+# Automodel class name) into the drafter config, but vLLM's model registry
+# routes every EAGLE-3 draft on ``LlamaForCausalLMEagle3`` (``PEagleDraftModel``
+# and ``Eagle3LlamaForCausalLM`` are registered aliases). We rewrite during
+# resolution so the drafter directory is consumable by vLLM unchanged.
+_AUTOMODEL_DRAFT_ARCHITECTURE = "LlamaEagle3DraftModel"
+_VLLM_DRAFT_ARCHITECTURE = "LlamaForCausalLMEagle3"
+
+
+def _check_vllm_available() -> None:
+    """Verify the ``vllm`` package can actually be imported, else exit (code 2)."""
+    ok, _ = safe_import("vllm")
+    if not ok:
+        logger.error(_VLLM_INSTALL_HINT)
+        raise SystemExit(2)
+
+
+def _has_hf_weight_file(path: Path) -> bool:
+    """Return True if ``path`` contains an HF-style weight artifact."""
+    return any(
+        (path / name).exists() for name in ("model.safetensors", "model.safetensors.index.json", "pytorch_model.bin")
+    )
+
+
+def _load_config(config_path: Path) -> dict[str, Any]:
+    """Load a drafter ``config.json`` into a dict."""
+    with config_path.open("r") as f:
+        return json.load(f)
+
+
+def _vllm_config_updates(config: dict[str, Any]) -> dict[str, Any]:
+    """Return the ``config.json`` key changes needed for vLLM to load this draft.
+
+    Two fixups bridge the Automodel on-disk format to what vLLM reads:
+
+    * ``architectures`` -> the vLLM-canonical ``LlamaForCausalLMEagle3`` (the
+      recipe writes the Automodel class name ``LlamaEagle3DraftModel``, which
+      vLLM's registry does not know).
+    * for a P-EAGLE head, ``pard_token`` (= ``mask_token_id``). This mirrors
+      vLLM's own speculators ``update_peagle`` mapping; the parallel-drafting
+      proposer reads ``pard_token`` / ``ptd_token_id`` /
+      ``dflash_config.mask_token_id``, none of which the recipe writes -- it
+      only writes the top-level ``mask_token_id``.
+
+    Returns an empty dict when the config already satisfies vLLM.
+    """
+    updates: dict[str, Any] = {}
+    if config.get("architectures") != [_VLLM_DRAFT_ARCHITECTURE]:
+        updates["architectures"] = [_VLLM_DRAFT_ARCHITECTURE]
+    if config.get("parallel_drafting"):
+        has_mask_key = (
+            "pard_token" in config or "ptd_token_id" in config or "mask_token_id" in (config.get("dflash_config") or {})
+        )
+        if not has_mask_key:
+            mask_token_id = config.get("mask_token_id")
+            if mask_token_id is None:
+                raise ValueError(
+                    "draft config has parallel_drafting=true but no mask_token_id, so the "
+                    "pard_token that vLLM's parallel-drafting proposer requires cannot be derived."
+                )
+            updates["pard_token"] = mask_token_id
+    return updates
+
+
+def _rewrite_config_for_vllm(config_path: Path, config: dict[str, Any]) -> None:
+    """Patch ``config_path`` in place with the keys vLLM needs (architectures, pard_token).
+
+    Takes the already-parsed ``config`` so the caller's read is not repeated.
+    No-op when the config already satisfies vLLM. The write is staged through a
+    sibling ``.tmp`` file and finalized with ``os.replace`` so an interrupted
+    write cannot leave the destination half-truncated.
+    """
+    updates = _vllm_config_updates(config)
+    if not updates:
+        return
+    logger.info("Patching draft config for vLLM: %s", updates)
+    tmp_path = config_path.with_suffix(config_path.suffix + ".tmp")
+    with tmp_path.open("w") as f:
+        json.dump({**config, **updates}, f, indent=2)
+    os.replace(tmp_path, config_path)
+
+
+def _draft_weight_keys(draft_dir: Path) -> list[str]:
+    """Return the weight tensor names in ``draft_dir``.
+
+    Reads the names from ``model.safetensors.index.json`` when sharded, otherwise
+    from the single ``model.safetensors`` header (no tensor data is loaded).
+    Returns an empty list when neither is present / readable.
+    """
+    index_path = draft_dir / "model.safetensors.index.json"
+    if index_path.exists():
+        return list(_load_config(index_path).get("weight_map", {}).keys())
+    single = draft_dir / "model.safetensors"
+    if single.exists():
+        ok, safe_open = safe_import_from("safetensors", "safe_open")
+        if ok:
+            with safe_open(str(single), framework="pt") as f:
+                return list(f.keys())
+    return []
+
+
+def _needs_weight_remap(weight_keys: list[str]) -> bool:
+    """True when any weight carries the Automodel ``self.model`` wrapper prefix."""
+    return any(k.startswith(_MODEL_PREFIX) for k in weight_keys)
+
+
+def _remap_key_for_vllm(key: str) -> str:
+    """Strip the ``self.model`` wrapper prefix so vLLM's loader (which re-adds it) resolves it.
+
+    Top-level tensors (``lm_head.weight``, ``d2t``, ``t2d``, ``mask_hidden``) do
+    not carry the prefix and are returned unchanged.
+    """
+    return key[len(_MODEL_PREFIX) :] if key.startswith(_MODEL_PREFIX) else key
+
+
+def _load_safetensors_io():
+    """Return ``(load_file, save_file)`` from ``safetensors.torch`` or exit with a hint."""
+    ok_load, load_file = safe_import_from("safetensors.torch", "load_file")
+    ok_save, save_file = safe_import_from("safetensors.torch", "save_file")
+    if not (ok_load and ok_save):
+        logger.error(_SAFETENSORS_INSTALL_HINT)
+        raise SystemExit(2)
+    return load_file, save_file
+
+
+def _export_is_fresh(draft_dir: Path, export_dir: Path) -> bool:
+    """True when ``export_dir`` holds a complete config + weights newer than the source."""
+    exported_config = export_dir / "config.json"
+    if not exported_config.exists() or not _has_hf_weight_file(export_dir):
+        return False
+    src_weights = [*draft_dir.glob("model-*.safetensors"), draft_dir / "model.safetensors"]
+    src_mtime = max((w.stat().st_mtime_ns for w in src_weights if w.exists()), default=0)
+    return exported_config.stat().st_mtime_ns >= src_mtime
+
+
+def _export_for_vllm(draft_dir: Path, config: dict[str, Any]) -> Path:
+    """Materialize a vLLM-loadable copy of ``draft_dir`` in a ``vllm_export/`` subdir.
+
+    The safetensors keys are remapped to strip the Automodel ``self.model``
+    wrapper prefix, the config receives the architectures / pard_token fixups, and
+    the tokenizer assets are copied alongside. The source checkpoint is left
+    untouched. The export is cached and rebuilt only when stale.
+    """
+    export_dir = draft_dir / _VLLM_EXPORT_DIRNAME
+    if _export_is_fresh(draft_dir, export_dir):
+        logger.info("Reusing fresh vLLM export at %s", export_dir)
+        return export_dir
+
+    # Validate the config fixups up front so a bad draft fails before any writes.
+    config_updates = _vllm_config_updates(config)
+    load_file, save_file = _load_safetensors_io()
+    export_dir.mkdir(parents=True, exist_ok=True)
+
+    shards = sorted(draft_dir.glob("model-*.safetensors")) or [draft_dir / "model.safetensors"]
+    for shard in shards:
+        if not shard.exists():
+            continue
+        remapped = {_remap_key_for_vllm(k): v for k, v in load_file(str(shard)).items()}
+        save_file(remapped, str(export_dir / shard.name), metadata={"format": "pt"})
+
+    index_path = draft_dir / "model.safetensors.index.json"
+    if index_path.exists():
+        index = _load_config(index_path)
+        index["weight_map"] = {_remap_key_for_vllm(k): v for k, v in index["weight_map"].items()}
+        with (export_dir / "model.safetensors.index.json").open("w") as f:
+            json.dump(index, f, indent=2)
+
+    exported_config = dict(config)
+    exported_config.update(config_updates)
+    with (export_dir / "config.json").open("w") as f:
+        json.dump(exported_config, f, indent=2)
+
+    # Copy tokenizer / chat-template assets so vLLM can load the draft standalone.
+    for asset in draft_dir.iterdir():
+        if (
+            asset.is_file()
+            and asset.suffix in (".json", ".jinja", ".txt", ".model")
+            and not asset.name.startswith("model-")
+            and asset.name not in ("config.json", "model.safetensors.index.json")
+        ):
+            shutil.copy2(asset, export_dir / asset.name)
+
+    logger.info("Exported vLLM-compatible draft to %s", export_dir)
+    return export_dir
+
+
+def _find_draft_dir(draft_path: Path) -> Path | None:
+    """Return the HF-style drafter directory under ``draft_path``, if present.
+
+    Accepts the outer ``epoch_<E>_step_<S>`` directory, its ``model/`` subdir, or
+    the consolidated checkpointer's ``model/consolidated/`` (and a bare
+    ``consolidated/``) layout, as well as a directory that is already the HF
+    model dir. Returns the first candidate holding ``config.json`` + a weight
+    file, else ``None``.
+    """
+    candidates = [
+        draft_path,
+        draft_path / "model",
+        draft_path / "model" / "consolidated",
+        draft_path / "consolidated",
+    ]
+    for candidate in candidates:
+        if candidate.is_dir() and (candidate / "config.json").exists() and _has_hf_weight_file(candidate):
+            return candidate
+    return None
+
+
+def resolve_draft_artifacts(draft: str, *, dry_run: bool = False) -> tuple[str, dict[str, Any]]:
+    """Resolve a user-supplied drafter path to the directory and config vLLM expects.
+
+    Args:
+        draft: A local path to a recipe checkpoint (the ``epoch_*`` dir, its
+            ``model/`` / ``model/consolidated/`` subdir, or the HF model dir
+            itself) or a Hugging Face Hub repo id.
+        dry_run: When True, no on-disk ``architectures`` rewrite is performed and
+            the returned paths reflect what a real launch would produce.
+
+    Returns:
+        ``(draft_path, config)`` where ``draft_path`` is what vLLM's
+        ``--speculative-config`` ``model`` field should point at and ``config``
+        is the parsed drafter ``config.json`` (empty for a passed-through Hub
+        repo id, which cannot be introspected locally).
+    """
+    p = Path(draft)
+    if not p.exists():
+        # Treat a non-existent path as a Hugging Face Hub repo id and pass it
+        # through untouched; vLLM resolves and downloads it at launch.
+        return draft, {}
+
+    draft_dir = _find_draft_dir(p)
+    if draft_dir is None:
+        raise ValueError(
+            f"--draft {draft!r} exists but no config.json + weights were found under it "
+            "(looked in ./, model/, model/consolidated/, consolidated/). Point --draft at the "
+            "checkpoint directory produced by an EAGLE-3 / P-EAGLE recipe."
+        )
+
+    config_path = draft_dir / "config.json"
+    config = _load_config(config_path)
+
+    # Automodel drafts carry a ``self.model`` wrapper prefix on their weights that
+    # vLLM cannot load; those need a remapped export. A draft whose weights are
+    # already vLLM-standard only needs the in-place config fixups.
+    if _needs_weight_remap(_draft_weight_keys(draft_dir)):
+        export_dir = draft_dir / _VLLM_EXPORT_DIRNAME
+        if dry_run:
+            return str(export_dir), config
+        return str(_export_for_vllm(draft_dir, config)), config
+
+    if not dry_run:
+        _rewrite_config_for_vllm(config_path, config)
+    return str(draft_dir), config
+
+
+def _resolve_num_speculative_tokens(cli_value: int | None, config: dict[str, Any]) -> int:
+    """Resolve K (number of speculative tokens), defaulting to the draft's ``num_depths``."""
+    if cli_value is not None:
+        return cli_value
+    num_depths = config.get("num_depths")
+    if num_depths is None:
+        raise ValueError(
+            "--num-speculative-tokens is required: the draft config has no ``num_depths`` to "
+            "derive it from (only P-EAGLE / parallel-drafting heads carry it). Pass the value "
+            "explicitly, e.g. --num-speculative-tokens 4."
+        )
+    return int(num_depths)
+
+
+def _build_speculative_config(args: argparse.Namespace, draft_path: str, config: dict[str, Any]) -> dict[str, Any]:
+    """Build the vLLM ``--speculative-config`` dict for a resolved draft.
+
+    ``parallel_drafting`` is a SpeculativeConfig field that vLLM defaults to
+    False; it must be set here for a P-EAGLE head (the draft's own
+    ``config.json`` flag is not auto-promoted to the speculative config).
+    """
+    speculative_config: dict[str, Any] = {
+        "method": args.method,
+        "model": draft_path,
+        "num_speculative_tokens": _resolve_num_speculative_tokens(args.num_speculative_tokens, config),
+        "draft_tensor_parallel_size": args.draft_tp_size,
+    }
+    if config.get("parallel_drafting"):
+        speculative_config["parallel_drafting"] = True
+    return speculative_config
+
+
+def build_vllm_argv(args: argparse.Namespace) -> list[str]:
+    """Build the ``python -m vllm.entrypoints.openai.api_server`` argv for a config."""
+    draft_path, config = resolve_draft_artifacts(args.draft, dry_run=args.print_only)
+    speculative_config = _build_speculative_config(args, draft_path, config)
+
+    argv: list[str] = [
+        sys.executable,
+        "-m",
+        "vllm.entrypoints.openai.api_server",
+        "--model",
+        args.target,
+        "--speculative-config",
+        json.dumps(speculative_config),
+        "--host",
+        args.host,
+        "--port",
+        str(args.port),
+        "--tensor-parallel-size",
+        str(args.tp_size),
+        "--gpu-memory-utilization",
+        str(args.gpu_memory_utilization),
+        "--dtype",
+        args.dtype,
+    ]
+    if args.max_model_len is not None:
+        argv += ["--max-model-len", str(args.max_model_len)]
+    if args.trust_remote_code:
+        argv.append("--trust-remote-code")
+    if args.extra:
+        argv += list(args.extra)
+    return argv
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments for the vLLM serve helper."""
+    parser = argparse.ArgumentParser(
+        prog="serve_vllm",
+        description=(
+            "Launch vLLM with an Automodel-trained EAGLE-3 / P-EAGLE drafter. "
+            "Requires `uv pip install vllm` in the current environment; vLLM is not "
+            "bundled with the Automodel container."
+        ),
+    )
+    parser.add_argument(
+        "--target",
+        required=True,
+        help="Target (base) model path or HuggingFace repo id, e.g. Qwen/Qwen3-8B.",
+    )
+    parser.add_argument(
+        "--draft",
+        required=True,
+        help=(
+            "Path to the drafter checkpoint directory produced by an EAGLE-3 / P-EAGLE recipe "
+            "(e.g. outputs/peagle/checkpoints/epoch_2_step_44326). The ``model/`` and "
+            "``model/consolidated/`` subdirs are auto-selected."
+        ),
+    )
+    parser.add_argument(
+        "--method",
+        default="eagle3",
+        choices=["eagle", "eagle3"],
+        help="Speculative method passed to vLLM (P-EAGLE uses eagle3 + parallel_drafting).",
+    )
+    parser.add_argument(
+        "--num-speculative-tokens",
+        type=int,
+        default=None,
+        help="K, number of speculative tokens. Defaults to the draft config's num_depths.",
+    )
+    parser.add_argument("--host", default="0.0.0.0", help="Server bind host.")
+    parser.add_argument("--port", type=int, default=8000, help="Server port.")
+    parser.add_argument("--tp-size", type=int, default=1, help="Tensor-parallel size for the target model.")
+    parser.add_argument(
+        "--draft-tp-size",
+        type=int,
+        default=1,
+        help="--speculative-config draft_tensor_parallel_size (draft model TP).",
+    )
+    parser.add_argument(
+        "--gpu-memory-utilization",
+        type=float,
+        default=0.8,
+        help="--gpu-memory-utilization passed through to vLLM.",
+    )
+    parser.add_argument(
+        "--dtype",
+        default="bfloat16",
+        help="Inference dtype (must match the dtype used during EAGLE training).",
+    )
+    parser.add_argument(
+        "--max-model-len",
+        type=int,
+        default=None,
+        help="--max-model-len passed through to vLLM (default: model config).",
+    )
+    parser.add_argument(
+        "--trust-remote-code",
+        action="store_true",
+        help="Forward --trust-remote-code to vLLM (needed for custom target architectures).",
+    )
+    parser.add_argument(
+        "--print-only",
+        action="store_true",
+        help=(
+            "Print the resolved vLLM command and exit without launching it. "
+            "Skips the on-disk architectures rewrite; the printed paths reflect "
+            "what would be produced on a real launch."
+        ),
+    )
+    parser.add_argument(
+        "extra",
+        nargs=argparse.REMAINDER,
+        help="Additional arguments forwarded verbatim to vLLM (prefix with `--`).",
+    )
+    parsed = parser.parse_args(argv)
+    if parsed.extra and parsed.extra[0] == "--":
+        parsed.extra = parsed.extra[1:]
+    return parsed
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Validate the environment, resolve the drafter ckpt, then exec vLLM.
+
+    Returns the vLLM server's exit code, or ``2`` if vLLM is missing.
+    """
+    logging.basicConfig(
+        level=os.environ.get("NEMO_AUTOMODEL_LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = _parse_args(argv)
+    if not args.print_only:
+        # Fail fast before any expensive config resolution / rewrite work.
+        _check_vllm_available()
+    cmd = build_vllm_argv(args)
+    logger.info("vLLM command: %s", " ".join(cmd))
+    if args.print_only:
+        print(" ".join(cmd))
+        return 0
+    if hasattr(os, "execv") and Path(cmd[0]).is_absolute() and Path(cmd[0]).is_file():
+        os.execv(cmd[0], cmd)
+    return subprocess.call(cmd)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/nemo_automodel/components/speculative/serve_vllm.py
+++ b/nemo_automodel/components/speculative/serve_vllm.py
@@ -235,12 +235,16 @@ def _load_safetensors_io():
 
 
 def _export_is_fresh(draft_dir: Path, export_dir: Path) -> bool:
-    """True when ``export_dir`` holds a complete config + weights newer than the source."""
+    """True when ``export_dir`` holds a complete config + weights newer than the source weights or config."""
     exported_config = export_dir / "config.json"
     if not exported_config.exists() or not _has_hf_weight_file(export_dir):
         return False
-    src_weights = [*draft_dir.glob("model-*.safetensors"), draft_dir / "model.safetensors"]
-    src_mtime = max((w.stat().st_mtime_ns for w in src_weights if w.exists()), default=0)
+    src_files = [
+        *draft_dir.glob("model-*.safetensors"),
+        draft_dir / "model.safetensors",
+        draft_dir / "config.json",
+    ]
+    src_mtime = max((f.stat().st_mtime_ns for f in src_files if f.exists()), default=0)
     return exported_config.stat().st_mtime_ns >= src_mtime
 
 

--- a/tests/unit_tests/speculative/test_serve_vllm.py
+++ b/tests/unit_tests/speculative/test_serve_vllm.py
@@ -1,0 +1,386 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+from nemo_automodel.components.speculative import serve_vllm
+from nemo_automodel.components.speculative.serve_vllm import (
+    build_vllm_argv,
+    main,
+    resolve_draft_artifacts,
+)
+
+
+def _build_args(
+    draft: str,
+    *,
+    method: str = "eagle3",
+    num_speculative_tokens: int | None = None,
+    print_only: bool = False,
+    trust_remote_code: bool = False,
+    max_model_len: int | None = None,
+    extra: list[str] | None = None,
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        target="Qwen/Qwen3-8B",
+        draft=draft,
+        method=method,
+        num_speculative_tokens=num_speculative_tokens,
+        host="0.0.0.0",
+        port=8000,
+        tp_size=1,
+        draft_tp_size=1,
+        gpu_memory_utilization=0.8,
+        dtype="bfloat16",
+        max_model_len=max_model_len,
+        trust_remote_code=trust_remote_code,
+        print_only=print_only,
+        extra=extra or [],
+    )
+
+
+def _write_draft_checkpoint(
+    model_dir: Path,
+    *,
+    architectures: list[str],
+    parallel: bool = True,
+    prefixed: bool = True,
+) -> Path:
+    """Write a tiny real HF-style draft checkpoint and return the config path.
+
+    ``prefixed=True`` mirrors the Automodel ``self.model`` wrapper (weights named
+    ``model.*``); ``prefixed=False`` mirrors an already-vLLM-standard draft.
+    """
+    model_dir.mkdir(parents=True, exist_ok=True)
+    pre = "model." if prefixed else ""
+    tensors = {
+        f"{pre}embed_tokens.weight": torch.zeros(4, 2),
+        f"{pre}layers.0.self_attn.q_proj.weight": torch.zeros(2, 2),
+        f"{pre}norm.weight": torch.zeros(2),
+        "lm_head.weight": torch.zeros(4, 2),
+        "d2t": torch.zeros(4, dtype=torch.long),
+        "t2d": torch.zeros(4, dtype=torch.bool),
+    }
+    if parallel:
+        tensors["mask_hidden"] = torch.zeros(1, 1, 6)
+    save_file(tensors, str(model_dir / "model.safetensors"), metadata={"format": "pt"})
+
+    config = {"architectures": architectures, "model_type": "qwen3", "draft_vocab_size": 4}
+    if parallel:
+        config.update({"parallel_drafting": True, "mask_token_id": 151669, "num_depths": 8})
+    config_path = model_dir / "config.json"
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    # A tokenizer-ish asset that the export should carry along.
+    (model_dir / "tokenizer_config.json").write_text("{}", encoding="utf-8")
+    return config_path
+
+
+def _safetensors_keys(path: Path) -> set[str]:
+    with safe_open(str(path), framework="pt") as f:
+        return set(f.keys())
+
+
+def _speculative_config_from_argv(argv: list[str]) -> dict:
+    return json.loads(argv[argv.index("--speculative-config") + 1])
+
+
+# --------------------------------------------------------------------------- #
+# Automodel draft (model.* prefixed weights) -> remapped vllm_export/ dir.
+# --------------------------------------------------------------------------- #
+def test_resolve_exports_remapped_weights(tmp_path: Path):
+    """An Automodel draft is exported with the ``model.`` prefix stripped and config fixed."""
+    model_dir = tmp_path / "epoch_0_step_2000" / "model" / "consolidated"
+    src_config = _write_draft_checkpoint(model_dir, architectures=["LlamaEagle3DraftModel"])
+
+    draft_path, config = resolve_draft_artifacts(str(tmp_path / "epoch_0_step_2000"))
+
+    export_dir = model_dir / "vllm_export"
+    assert draft_path == str(export_dir)
+    # Weight keys are de-prefixed; top-level tensors are untouched.
+    assert _safetensors_keys(export_dir / "model.safetensors") == {
+        "embed_tokens.weight",
+        "layers.0.self_attn.q_proj.weight",
+        "norm.weight",
+        "lm_head.weight",
+        "d2t",
+        "t2d",
+        "mask_hidden",
+    }
+    # Exported config carries both fixups.
+    exported = json.loads((export_dir / "config.json").read_text(encoding="utf-8"))
+    assert exported["architectures"] == ["LlamaForCausalLMEagle3"]
+    assert exported["pard_token"] == 151669
+    # Tokenizer asset travels with the export.
+    assert (export_dir / "tokenizer_config.json").exists()
+    # The source checkpoint is left untouched (non-destructive).
+    assert json.loads(src_config.read_text(encoding="utf-8"))["architectures"] == ["LlamaEagle3DraftModel"]
+    assert config["parallel_drafting"] is True
+
+
+def test_resolve_reads_keys_and_remaps_index(tmp_path: Path):
+    """A sharded draft: keys are read from the index and the exported index is de-prefixed."""
+    model_dir = tmp_path / "model"
+    _write_draft_checkpoint(model_dir, architectures=["LlamaEagle3DraftModel"])
+    # Add a safetensors index so resolution reads keys from it (the real sharded layout).
+    index = {
+        "metadata": {"total_size": 0},
+        "weight_map": {
+            "model.embed_tokens.weight": "model.safetensors",
+            "lm_head.weight": "model.safetensors",
+            "d2t": "model.safetensors",
+        },
+    }
+    (model_dir / "model.safetensors.index.json").write_text(json.dumps(index), encoding="utf-8")
+
+    draft_path, _ = resolve_draft_artifacts(str(model_dir))
+
+    exported_index = json.loads((Path(draft_path) / "model.safetensors.index.json").read_text(encoding="utf-8"))
+    assert set(exported_index["weight_map"]) == {"embed_tokens.weight", "lm_head.weight", "d2t"}
+
+
+def test_export_is_cached_until_source_changes(tmp_path: Path):
+    """A second resolve reuses the export; touching the source weights rebuilds it."""
+    model_dir = tmp_path / "model"
+    _write_draft_checkpoint(model_dir, architectures=["LlamaEagle3DraftModel"])
+    export_config = model_dir / "vllm_export" / "config.json"
+
+    resolve_draft_artifacts(str(model_dir))
+    first_mtime = export_config.stat().st_mtime_ns
+    resolve_draft_artifacts(str(model_dir))
+    assert export_config.stat().st_mtime_ns == first_mtime, "fresh export must be reused, not rebuilt"
+
+
+def test_resolve_dry_run_returns_export_path_without_writing(tmp_path: Path):
+    """dry_run returns the would-be export path but creates nothing and touches nothing."""
+    model_dir = tmp_path / "model"
+    src_config = _write_draft_checkpoint(model_dir, architectures=["LlamaEagle3DraftModel"])
+    content_before = src_config.read_text(encoding="utf-8")
+
+    draft_path, _ = resolve_draft_artifacts(str(model_dir), dry_run=True)
+
+    assert draft_path == str(model_dir / "vllm_export")
+    assert not (model_dir / "vllm_export").exists()
+    assert src_config.read_text(encoding="utf-8") == content_before
+
+
+def test_resolve_peagle_without_mask_token_raises_before_writing(tmp_path: Path):
+    """parallel_drafting with no mask_token_id fails, and no partial export is left behind."""
+    model_dir = tmp_path / "model"
+    model_dir.mkdir(parents=True)
+    save_file(
+        {"model.embed_tokens.weight": torch.zeros(4, 2), "lm_head.weight": torch.zeros(4, 2)},
+        str(model_dir / "model.safetensors"),
+        metadata={"format": "pt"},
+    )
+    (model_dir / "config.json").write_text(
+        json.dumps({"architectures": ["LlamaEagle3DraftModel"], "parallel_drafting": True}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="no mask_token_id"):
+        resolve_draft_artifacts(str(model_dir))
+    assert not (model_dir / "vllm_export" / "model.safetensors").exists()
+
+
+# --------------------------------------------------------------------------- #
+# vLLM-standard draft (no model. prefix) -> in-place config rewrite, no export.
+# --------------------------------------------------------------------------- #
+def test_resolve_vllm_standard_draft_rewrites_in_place(tmp_path: Path):
+    """A draft whose weights are already vLLM-standard only gets the config fixups."""
+    model_dir = tmp_path / "model"
+    config_path = _write_draft_checkpoint(model_dir, architectures=["LlamaEagle3DraftModel"], prefixed=False)
+
+    draft_path, _ = resolve_draft_artifacts(str(model_dir))
+
+    assert draft_path == str(model_dir)
+    assert not (model_dir / "vllm_export").exists()
+    rewritten = json.loads(config_path.read_text(encoding="utf-8"))
+    assert rewritten["architectures"] == ["LlamaForCausalLMEagle3"]
+    assert rewritten["pard_token"] == 151669
+
+
+def test_resolve_vllm_standard_already_correct_is_untouched(tmp_path: Path):
+    """A vLLM-standard config already carrying arch + pard_token is not rewritten."""
+    model_dir = tmp_path / "model"
+    config_path = _write_draft_checkpoint(model_dir, architectures=["LlamaForCausalLMEagle3"], prefixed=False)
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    config["pard_token"] = config["mask_token_id"]
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    mtime_before = config_path.stat().st_mtime_ns
+
+    resolve_draft_artifacts(str(model_dir))
+
+    assert config_path.stat().st_mtime_ns == mtime_before
+
+
+def test_resolve_passes_through_hf_repo_id(tmp_path: Path):
+    """A non-existent path is treated as a Hub repo id and passed through with an empty config."""
+    draft_path, config = resolve_draft_artifacts("khazic/peagle-qwen3-8b")
+
+    assert draft_path == "khazic/peagle-qwen3-8b"
+    assert config == {}
+
+
+def test_resolve_existing_dir_without_weights_raises(tmp_path: Path):
+    """A real directory with no config/weights is a user error, not a Hub id."""
+    (tmp_path / "config.json").write_text("{}", encoding="utf-8")  # config but no weights
+
+    with pytest.raises(ValueError, match="no config.json \\+ weights"):
+        resolve_draft_artifacts(str(tmp_path))
+
+
+# --------------------------------------------------------------------------- #
+# build_vllm_argv / speculative-config.
+# --------------------------------------------------------------------------- #
+def test_build_argv_peagle_sets_parallel_drafting_and_points_at_export(tmp_path: Path):
+    """A P-EAGLE head: speculative-config carries parallel_drafting, K=num_depths, export path."""
+    model_dir = tmp_path / "model"
+    _write_draft_checkpoint(model_dir, architectures=["LlamaEagle3DraftModel"])
+
+    argv = build_vllm_argv(_build_args(str(model_dir)))
+
+    spec = _speculative_config_from_argv(argv)
+    assert spec["method"] == "eagle3"
+    assert spec["model"] == str(model_dir / "vllm_export")
+    assert spec["num_speculative_tokens"] == 8  # derived from num_depths
+    assert spec["parallel_drafting"] is True
+    assert spec["draft_tensor_parallel_size"] == 1
+    assert argv[argv.index("--model") + 1] == "Qwen/Qwen3-8B"
+    assert "vllm.entrypoints.openai.api_server" in argv
+
+
+def test_build_argv_plain_eagle3_omits_parallel_drafting(tmp_path: Path):
+    """A non-parallel EAGLE-3 head: no parallel_drafting key, K must be given explicitly."""
+    model_dir = tmp_path / "model"
+    _write_draft_checkpoint(model_dir, architectures=["LlamaEagle3DraftModel"], parallel=False)
+
+    argv = build_vllm_argv(_build_args(str(model_dir), num_speculative_tokens=3))
+
+    spec = _speculative_config_from_argv(argv)
+    assert spec["num_speculative_tokens"] == 3
+    assert "parallel_drafting" not in spec
+
+
+def test_build_argv_plain_eagle3_without_k_raises(tmp_path: Path):
+    """A non-parallel head with no num_depths and no CLI K is a hard error."""
+    model_dir = tmp_path / "model"
+    _write_draft_checkpoint(model_dir, architectures=["LlamaForCausalLMEagle3"], parallel=False, prefixed=False)
+
+    with pytest.raises(ValueError, match="num-speculative-tokens is required"):
+        build_vllm_argv(_build_args(str(model_dir)))
+
+
+def test_build_argv_passes_through_optional_flags(tmp_path: Path):
+    """max-model-len, trust-remote-code and trailing extras are forwarded."""
+    model_dir = tmp_path / "model"
+    _write_draft_checkpoint(model_dir, architectures=["LlamaEagle3DraftModel"])
+
+    argv = build_vllm_argv(
+        _build_args(
+            str(model_dir),
+            trust_remote_code=True,
+            max_model_len=4096,
+            extra=["--enable-chunked-prefill"],
+        )
+    )
+
+    assert argv[argv.index("--max-model-len") + 1] == "4096"
+    assert "--trust-remote-code" in argv
+    assert "--enable-chunked-prefill" in argv
+
+
+def test_parse_args_strips_leading_double_dash():
+    """A leading ``--`` separator before extras is stripped."""
+    args = serve_vllm._parse_args(["--target", "Qwen/Qwen3-8B", "--draft", "/tmp/d", "--", "--enable-chunked-prefill"])
+    assert args.extra == ["--enable-chunked-prefill"]
+
+
+# --------------------------------------------------------------------------- #
+# main() dispatch.
+# --------------------------------------------------------------------------- #
+def test_main_print_only_prints_command(tmp_path: Path, capsys):
+    """--print-only prints the resolved command, exits 0, and writes nothing."""
+    model_dir = tmp_path / "model"
+    _write_draft_checkpoint(model_dir, architectures=["LlamaEagle3DraftModel"])
+
+    rc = main(["--target", "Qwen/Qwen3-8B", "--draft", str(model_dir), "--print-only"])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "vllm.entrypoints.openai.api_server" in out
+    assert not (model_dir / "vllm_export").exists()
+
+
+def test_main_exits_when_vllm_missing(tmp_path: Path, monkeypatch):
+    """Without --print-only a missing vLLM exits with code 2 before launching."""
+    model_dir = tmp_path / "model"
+    _write_draft_checkpoint(model_dir, architectures=["LlamaEagle3DraftModel"])
+    monkeypatch.setattr(serve_vllm, "safe_import", lambda name: (False, None))
+
+    with pytest.raises(SystemExit) as exc:
+        main(["--target", "Qwen/Qwen3-8B", "--draft", str(model_dir)])
+    assert exc.value.code == 2
+
+
+def test_main_launches_via_subprocess(tmp_path: Path, monkeypatch):
+    """When vLLM is present and not print-only, the built argv is dispatched."""
+    model_dir = tmp_path / "model"
+    _write_draft_checkpoint(model_dir, architectures=["LlamaEagle3DraftModel"])
+    monkeypatch.setattr(serve_vllm, "safe_import", lambda name: (True, object()))
+    monkeypatch.delattr(serve_vllm.os, "execv", raising=False)
+    captured = {}
+
+    def _fake_call(cmd):
+        captured["cmd"] = cmd
+        return 0
+
+    monkeypatch.setattr(serve_vllm.subprocess, "call", _fake_call)
+
+    rc = main(["--target", "Qwen/Qwen3-8B", "--draft", str(model_dir)])
+
+    assert rc == 0
+    assert "vllm.entrypoints.openai.api_server" in captured["cmd"]
+
+
+def test_main_execv_path_replaces_process(tmp_path: Path, monkeypatch):
+    """With os.execv available the command is dispatched via execv (process replacement)."""
+    model_dir = tmp_path / "model"
+    _write_draft_checkpoint(model_dir, architectures=["LlamaEagle3DraftModel"])
+    monkeypatch.setattr(serve_vllm, "safe_import", lambda name: (True, object()))
+    captured = {}
+
+    class _Execv(Exception):
+        pass
+
+    def _fake_execv(path, cmd):
+        captured["path"] = path
+        captured["cmd"] = cmd
+        raise _Execv  # execv never returns; raise to hand control back to the test
+
+    monkeypatch.setattr(serve_vllm.os, "execv", _fake_execv)
+
+    with pytest.raises(_Execv):
+        main(["--target", "Qwen/Qwen3-8B", "--draft", str(model_dir)])
+
+    assert captured["path"] == captured["cmd"][0]
+    assert "vllm.entrypoints.openai.api_server" in captured["cmd"]

--- a/tests/unit_tests/speculative/test_serve_vllm.py
+++ b/tests/unit_tests/speculative/test_serve_vllm.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -158,8 +159,8 @@ def test_resolve_reads_keys_and_remaps_index(tmp_path: Path):
     assert set(exported_index["weight_map"]) == {"embed_tokens.weight", "lm_head.weight", "d2t"}
 
 
-def test_export_is_cached_until_source_changes(tmp_path: Path):
-    """A second resolve reuses the export; touching the source weights rebuilds it."""
+def test_export_is_cached_when_source_unchanged(tmp_path: Path):
+    """A second resolve over an unchanged source reuses the export instead of rebuilding."""
     model_dir = tmp_path / "model"
     _write_draft_checkpoint(model_dir, architectures=["LlamaEagle3DraftModel"])
     export_config = model_dir / "vllm_export" / "config.json"
@@ -168,6 +169,42 @@ def test_export_is_cached_until_source_changes(tmp_path: Path):
     first_mtime = export_config.stat().st_mtime_ns
     resolve_draft_artifacts(str(model_dir))
     assert export_config.stat().st_mtime_ns == first_mtime, "fresh export must be reused, not rebuilt"
+
+
+def test_export_rebuilt_when_source_weights_or_config_change(tmp_path: Path):
+    """A stale export is rebuilt when either the source weights or the source config change.
+
+    The config alone drives the architectures / pard_token fixups, so a config-only
+    edit (e.g. toggling ``parallel_drafting`` or changing ``mask_token_id``) must
+    invalidate the export even when the weights are untouched.
+    """
+    model_dir = tmp_path / "model"
+    src_config = _write_draft_checkpoint(model_dir, architectures=["LlamaEagle3DraftModel"])
+    src_weights = model_dir / "model.safetensors"
+    export_config = model_dir / "vllm_export" / "config.json"
+
+    def _stamp_sentinel_then_age_source(source: Path) -> None:
+        # Tag the current export so a rebuild is detectable, then make ``source``
+        # strictly newer than the export to force a rebuild on the next resolve.
+        marked = json.loads(export_config.read_text(encoding="utf-8"))
+        marked["_sentinel"] = True
+        export_config.write_text(json.dumps(marked), encoding="utf-8")
+        newer_ns = export_config.stat().st_mtime_ns + 1_000_000_000
+        os.utime(source, ns=(newer_ns, newer_ns))
+
+    resolve_draft_artifacts(str(model_dir))
+
+    _stamp_sentinel_then_age_source(src_config)
+    resolve_draft_artifacts(str(model_dir))
+    assert "_sentinel" not in json.loads(export_config.read_text(encoding="utf-8")), (
+        "a source config change must rebuild the export"
+    )
+
+    _stamp_sentinel_then_age_source(src_weights)
+    resolve_draft_artifacts(str(model_dir))
+    assert "_sentinel" not in json.loads(export_config.read_text(encoding="utf-8")), (
+        "a source weight change must rebuild the export"
+    )
 
 
 def test_resolve_dry_run_returns_export_path_without_writing(tmp_path: Path):


### PR DESCRIPTION
## What

Adds `nemo_automodel/components/speculative/serve_vllm.py`, the vLLM companion to
`serve_sglang`. It serves an Automodel-trained EAGLE-3 / P-EAGLE drafter under
vLLM's parallel-drafting runtime.

## Why

The P-EAGLE recipe (`parallel_drafting: true`) produces a head that SGLang cannot
serve today, so `serve_sglang` rejects it and points at vLLM. There was no vLLM
entry point, so a trained P-EAGLE draft could not actually be served or
benchmarked (the `qwen_peagle_perfectblend.yaml` recipe comment already notes
that acceptance can only be measured by running the head under vLLM). This closes
that gap.

## How

`serve_vllm` resolves a recipe checkpoint (`epoch_*/model[/consolidated]`),
applies three fixups so vLLM can load the draft, then shells out to
`vllm.entrypoints.openai.api_server` with the right `--speculative-config`:

1. `architectures`: rewrite Automodel's `LlamaEagle3DraftModel` to vLLM's
   registered `LlamaForCausalLMEagle3`.
2. `pard_token` (P-EAGLE): vLLM's parallel-drafting proposer reads the masked-slot
   id from `pard_token` / `ptd_token_id` / `dflash_config.mask_token_id`, but the
   recipe writes only the top-level `mask_token_id`. The value is copied over,
   mirroring vLLM's own speculators `update_peagle` mapping.
3. weight keys: Automodel wraps the draft as `self.model`, so weights are saved as
   `model.*`; vLLM re-adds `model.` to every non-top-level weight, double-prefixing
   them. The prefix is stripped into a one-time `vllm_export/` copy, leaving the
   source checkpoint untouched. A draft whose weights are already vLLM-standard
   skips the export and gets the config fixups in place.

The draft already stores the `d2t` / `t2d` vocab-remap buffers in the offset form
vLLM expects, so (unlike the SGLang path) no separate speculative-token-map file
is emitted.

## Validation

Trained a standard P-EAGLE Qwen3-8B draft and served it through `serve_vllm` on
vLLM's parallel-drafting runtime: the draft loads and parallel drafting runs,
producing a measurable acceptance length end to end. New unit tests cover artifact
resolution, all three fixups, the export vs in-place split, export caching, and
CLI dispatch (`--print-only`, missing-vLLM exit, subprocess / execv dispatch).

## Notes

- vLLM is intentionally not bundled with the container and not declared in
  `pyproject.toml`; the script exits with an install hint when it is missing.
- P-EAGLE inference requires vLLM >= 0.16 (parallel-drafting runtime).
