### PR TITLE
[codex] Enable Fern multi-source

### DIFF
--- a/docs/fern/docs.yml
+++ b/docs/fern/docs.yml
@@ -2,6 +2,7 @@ instances:
 - url: https://nemo-automodel.docs.buildwithfern.com/nemo/automodel
   custom-domain: docs.nvidia.com/nemo/automodel
 title: NVIDIA NeMo AutoModel
+multi-source: true
 
 # Version-root landing: each version YAML's first nav entry is the index page
 # mounted with slug: "" (e.g. docs/index.mdx for nightly), so /nemo/automodel/v0.4,

--- a/docs/fern/docs.yml
+++ b/docs/fern/docs.yml
@@ -1,8 +1,8 @@
 instances:
 - url: https://nemo-automodel.docs.buildwithfern.com/nemo/automodel
   custom-domain: docs.nvidia.com/nemo/automodel
+  multi-source: true
 title: NVIDIA NeMo AutoModel
-multi-source: true
 
 # Version-root landing: each version YAML's first nav entry is the index page
 # mounted with slug: "" (e.g. docs/index.mdx for nightly), so /nemo/automodel/v0.4,


### PR DESCRIPTION
## Summary

Sets `multi-source: true` on the Fern `instances` entry.

## Validation

- Parsed the updated `docs/fern/docs.yml` with Ruby YAML after applying the change.
- Verified the PR only changes `docs/fern/docs.yml`.