### PR TITLE
docs: enable Fern multi-source

### DIFF
--- a/docs/fern/docs.yml
+++ b/docs/fern/docs.yml
@@ -1,6 +1,7 @@
 instances:
 - url: https://nemo-automodel.docs.buildwithfern.com/nemo/automodel
   custom-domain: docs.nvidia.com/nemo/automodel
+  multi-source: true
 title: NVIDIA NeMo AutoModel
 
 # Version-root landing: each version YAML's first nav entry is the index page

--- a/docs/fern/docs.yml
+++ b/docs/fern/docs.yml
@@ -38,7 +38,6 @@ libraries:
 experimental:
   mdx-components:
   - ./components
-  basepath-aware: true
 
 versions:
   - display-name: Nightly


### PR DESCRIPTION
## Summary

Sets `multi-source: true` on the Fern `instances` entry.

Supersedes #2844 with a clean single signed-off commit so DCO passes.

## Validation

- Parsed the updated `docs/fern/docs.yml` as YAML before creating the branch.
- Verified the config has `instances[].multi-source: true` and no top-level `multi-source`.