### PR TITLE
fix(distributed): propagate NCCL timeout to derived device meshes

### DIFF
--- a/nemo_automodel/components/distributed/mesh_utils.py
+++ b/nemo_automodel/components/distributed/mesh_utils.py
@@ -133,12 +133,12 @@ def _init_named_mesh(spec: _MeshSpec, *, timeout_minutes: int | None = None) -> 
         mesh_dim_names=spec.axes,
         backend_override=_nccl_backend_override(spec.axes, device_type=device_type, timeout_minutes=timeout_minutes),
     )
-    _register_flattened_axes(device_mesh, spec.flattened_axes)
+    _register_flattened_axes(device_mesh, spec.flattened_axes, timeout_minutes=timeout_minutes)
     return device_mesh
 
 
 def _nccl_backend_override(
-    axes: tuple[MeshAxisName, ...],
+    axes: tuple[str, ...],
     *,
     device_type: str,
     timeout_minutes: int | None,
@@ -168,14 +168,25 @@ def _validate_mesh_spec(spec: _MeshSpec) -> None:
 
 
 def _register_flattened_axes(
-    device_mesh: DeviceMesh, flattened_axes: dict[MeshAxisName, tuple[MeshAxisName, ...]]
+    device_mesh: DeviceMesh,
+    flattened_axes: dict[MeshAxisName, tuple[MeshAxisName, ...]],
+    *,
+    timeout_minutes: int | None = None,
 ) -> None:
     if not flattened_axes:
         return
     if not hasattr(device_mesh, "_flatten_mapping"):
         device_mesh._flatten_mapping = {}
+    backend_overrides = _nccl_backend_override(
+        tuple(flattened_axes),
+        device_type=device_mesh.device_type,
+        timeout_minutes=timeout_minutes,
+    )
     for flattened_axis, source_axes in flattened_axes.items():
-        flattened_mesh = device_mesh[source_axes]._flatten(mesh_dim_name=flattened_axis)
+        flattened_mesh = device_mesh[source_axes]._flatten(
+            mesh_dim_name=flattened_axis,
+            backend_override=backend_overrides.get(flattened_axis) if backend_overrides else None,
+        )
         device_mesh._flatten_mapping.setdefault(flattened_axis, flattened_mesh)
 
 
@@ -234,7 +245,12 @@ def _create_fsdp2_device_mesh(
 
     moe_mesh = None
     if ep_size > 1:
-        moe_mesh = _create_moe_mesh(device_mesh, ep_shard_size=ep_shard_size, ep_size=ep_size)
+        moe_mesh = _create_moe_mesh(
+            device_mesh,
+            ep_shard_size=ep_shard_size,
+            ep_size=ep_size,
+            timeout_minutes=timeout_minutes,
+        )
 
     return device_mesh, moe_mesh
 
@@ -266,19 +282,44 @@ def _create_megatron_fsdp_device_mesh(
     )
 
 
-def _create_moe_mesh(device_mesh: DeviceMesh, *, ep_shard_size: int, ep_size: int) -> DeviceMesh:
+def _create_moe_mesh(
+    device_mesh: DeviceMesh,
+    *,
+    ep_shard_size: int,
+    ep_size: int,
+    timeout_minutes: int | None = None,
+) -> DeviceMesh:
     non_pp_axes = (MeshAxisName.DP_REPLICATE, MeshAxisName.DP_SHARD, MeshAxisName.CP, MeshAxisName.TP)
     return _unflatten_compat(
         device_mesh[non_pp_axes]._flatten(),
-        0,
-        (ep_shard_size, ep_size),
-        (MeshAxisName.EP_SHARD, MeshAxisName.EP),
+        axis=0,
+        sizes=(ep_shard_size, ep_size),
+        names=(MeshAxisName.EP_SHARD, MeshAxisName.EP),
+        timeout_minutes=timeout_minutes,
     )
 
 
-def _unflatten_compat(flat_mesh: DeviceMesh, axis: int, sizes: tuple, names: tuple) -> DeviceMesh:
-    """Compatibility shim for DeviceMesh._unflatten(), added in PyTorch 2.10."""
+def _unflatten_compat(
+    flat_mesh: DeviceMesh,
+    axis: int,
+    sizes: tuple,
+    names: tuple,
+    *,
+    timeout_minutes: int | None = None,
+) -> DeviceMesh:
+    """Unflatten a mesh with its NCCL timeout, including the PyTorch 2.9 fallback."""
     if hasattr(flat_mesh, "_unflatten"):
+        if timeout_minutes is not None and flat_mesh.device_type == "cuda":
+            return flat_mesh._unflatten(
+                axis,
+                sizes,
+                names,
+                backend_override=_nccl_backend_override(
+                    names,
+                    device_type=flat_mesh.device_type,
+                    timeout_minutes=timeout_minutes,
+                ),
+            )
         return flat_mesh._unflatten(axis, sizes, names)
     new_mesh_tensor = flat_mesh.mesh.reshape(sizes)
     from torch.distributed.device_mesh import DeviceMesh as _DeviceMesh

--- a/tests/unit_tests/distributed/test_mesh_utils.py
+++ b/tests/unit_tests/distributed/test_mesh_utils.py
@@ -21,8 +21,9 @@ import pytest
 import torch
 
 import nemo_automodel.components.distributed.mesh_utils as mesh_utils
-from nemo_automodel.components.distributed.mesh import MeshAxisName
+from nemo_automodel.components.distributed.mesh import MeshAxisName, ParallelismSizes
 from nemo_automodel.components.distributed.mesh_utils import (
+    _create_fsdp2_device_mesh,
     _create_moe_mesh,
     _init_named_mesh,
     _MeshSpec,
@@ -112,6 +113,43 @@ def test_flattened_axes_inherit_nccl_timeout():
     assert backend == "nccl"
     assert options._timeout == datetime.timedelta(minutes=30)
     assert device_mesh._flatten_mapping[MeshAxisName.DP_CP] is flattened_mesh
+
+
+def test_flattened_axes_omit_nccl_timeout_when_unconfigured():
+    source_mesh = Mock()
+    device_mesh = Mock()
+    device_mesh.device_type = "cuda"
+    device_mesh._flatten_mapping = {}
+    device_mesh.__getitem__ = Mock(return_value=source_mesh)
+
+    _register_flattened_axes(
+        device_mesh,
+        {MeshAxisName.DP_CP: (MeshAxisName.DP_SHARD, MeshAxisName.CP)},
+    )
+
+    assert source_mesh._flatten.call_args.kwargs["backend_override"] is None
+
+
+def test_fsdp2_forwards_nccl_timeout_to_moe_mesh(monkeypatch):
+    device_mesh = Mock()
+    moe_mesh = Mock()
+    monkeypatch.setattr(mesh_utils, "_init_named_mesh", Mock(return_value=device_mesh))
+    create_moe_mesh = Mock(return_value=moe_mesh)
+    monkeypatch.setattr(mesh_utils, "_create_moe_mesh", create_moe_mesh)
+
+    result = _create_fsdp2_device_mesh(
+        ParallelismSizes(dp_size=8, ep_size=2),
+        world_size=8,
+        timeout_minutes=30,
+    )
+
+    assert result == (device_mesh, moe_mesh)
+    create_moe_mesh.assert_called_once_with(
+        device_mesh,
+        ep_shard_size=4,
+        ep_size=2,
+        timeout_minutes=30,
+    )
 
 
 def test_moe_ep_groups_inherit_nccl_timeout():
@@ -324,6 +362,23 @@ class TestUnflattenCompat:
         for backend, options in backend_override.values():
             assert backend == "nccl"
             assert options._timeout == datetime.timedelta(minutes=30)
+        assert result is expected
+
+    def test_native_unflatten_omits_backend_override_for_cpu(self):
+        expected = Mock()
+        flat_mesh = Mock()
+        flat_mesh.device_type = "cpu"
+        flat_mesh._unflatten = Mock(return_value=expected)
+
+        result = _unflatten_compat(
+            flat_mesh,
+            0,
+            (4, 32),
+            ("ep_shard", "ep"),
+            timeout_minutes=30,
+        )
+
+        flat_mesh._unflatten.assert_called_once_with(0, (4, 32), ("ep_shard", "ep"))
         assert result is expected
 
     def test_fallback_when_unflatten_missing(self):

--- a/tests/unit_tests/distributed/test_mesh_utils.py
+++ b/tests/unit_tests/distributed/test_mesh_utils.py
@@ -23,8 +23,10 @@ import torch
 import nemo_automodel.components.distributed.mesh_utils as mesh_utils
 from nemo_automodel.components.distributed.mesh import MeshAxisName
 from nemo_automodel.components.distributed.mesh_utils import (
+    _create_moe_mesh,
     _init_named_mesh,
     _MeshSpec,
+    _register_flattened_axes,
     _unflatten_compat,
     get_flat_mesh,
     get_fsdp_dp_mesh,
@@ -88,6 +90,50 @@ def test_init_named_mesh_omits_backend_override_for_cpu(monkeypatch):
     _init_named_mesh(_MeshSpec(shape=(2,), axes=(MeshAxisName.PP,)), timeout_minutes=30)
 
     assert captured["backend_override"] is None
+
+
+def test_flattened_axes_inherit_nccl_timeout():
+    flattened_mesh = Mock()
+    source_mesh = Mock()
+    source_mesh.device_type = "cuda"
+    source_mesh._flatten = Mock(return_value=flattened_mesh)
+    device_mesh = Mock()
+    device_mesh.device_type = "cuda"
+    device_mesh._flatten_mapping = {}
+    device_mesh.__getitem__ = Mock(return_value=source_mesh)
+
+    _register_flattened_axes(
+        device_mesh,
+        {MeshAxisName.DP_CP: (MeshAxisName.DP_SHARD, MeshAxisName.CP)},
+        timeout_minutes=30,
+    )
+
+    backend, options = source_mesh._flatten.call_args.kwargs["backend_override"]
+    assert backend == "nccl"
+    assert options._timeout == datetime.timedelta(minutes=30)
+    assert device_mesh._flatten_mapping[MeshAxisName.DP_CP] is flattened_mesh
+
+
+def test_moe_ep_groups_inherit_nccl_timeout():
+    moe_mesh = Mock()
+    flat_mesh = Mock()
+    flat_mesh.device_type = "cuda"
+    flat_mesh._unflatten = Mock(return_value=moe_mesh)
+    source_mesh = Mock()
+    source_mesh._flatten = Mock(return_value=flat_mesh)
+    device_mesh = Mock()
+    device_mesh.device_type = "cuda"
+    device_mesh.__getitem__ = Mock(return_value=source_mesh)
+
+    result = _create_moe_mesh(device_mesh, ep_shard_size=4, ep_size=32, timeout_minutes=30)
+
+    source_mesh._flatten.assert_called_once_with()
+    unflatten_override = flat_mesh._unflatten.call_args.kwargs["backend_override"]
+    for axis in (MeshAxisName.EP_SHARD, MeshAxisName.EP):
+        backend, options = unflatten_override[axis]
+        assert backend == "nccl"
+        assert options._timeout == datetime.timedelta(minutes=30)
+    assert result is moe_mesh
 
 
 # ---------------------------------------------------------------------------
@@ -258,6 +304,26 @@ class TestUnflattenCompat:
         result = _unflatten_compat(flat_mesh, 0, (2, 4), ("dp_replicate", "dp_shard_cp"))
 
         flat_mesh._unflatten.assert_called_once_with(0, (2, 4), ("dp_replicate", "dp_shard_cp"))
+        assert result is expected
+
+    def test_native_unflatten_receives_backend_override(self):
+        expected = Mock()
+        flat_mesh = Mock()
+        flat_mesh.device_type = "cuda"
+        flat_mesh._unflatten = Mock(return_value=expected)
+
+        result = _unflatten_compat(
+            flat_mesh,
+            0,
+            (4, 32),
+            ("ep_shard", "ep"),
+            timeout_minutes=30,
+        )
+
+        backend_override = flat_mesh._unflatten.call_args.kwargs["backend_override"]
+        for backend, options in backend_override.values():
+            assert backend == "nccl"
+            assert options._timeout == datetime.timedelta(minutes=30)
         assert result is expected
 
     def test_fallback_when_unflatten_missing(self):


### PR DESCRIPTION
## Summary

Propagate the configured NCCL timeout to process groups created from derived `DeviceMesh` instances.

- Pass the timeout to flattened DP/CP groups registered by `_register_flattened_axes()`.
- Pass the timeout to the reconstructed `ep_shard` and `ep` groups created for the MoE mesh.
- Preserve the existing CPU, no-timeout, and PyTorch 2.9 compatibility paths.
- Add unit coverage for flattened and MoE process-group timeout propagation.

## Root cause / findings

This is a follow-up to #2777, which propagates `dist_env.timeout_minutes` to the named per-axis groups created by `init_device_mesh()`.

`DeviceMesh._flatten()` and `DeviceMesh._unflatten()` create additional process groups after the initial mesh is constructed. Those derived groups do not inherit the NCCL options from the default process group or their parent mesh, so flattened `dp`/`dp_shard_cp`/`dp_cp` groups and reconstructed `ep_shard`/`ep` groups continued to use the default NCCL timeout.

The intermediate flattened MoE mesh is used only to define the rank layout. The configured timeout is applied when that mesh is unflattened into the final EP process groups that run collectives.

## Validation

- `python -m pytest -q tests/unit_tests/distributed/test_device_mesh.py tests/unit_tests/distributed/test_mesh_utils.py`
  - `48 passed`
- `ruff format --check nemo_automodel/components/distributed/mesh_utils.py tests/unit_tests/distributed/test_mesh_utils.py`
- `ruff check nemo_automodel/components/distributed/mesh_utils.py tests/unit_tests/distributed/test_mesh_utils.py`
