### PR TITLE
feat(speculative): compress EAGLE-3 offline cache target_probs via top-k

### DIFF
--- a/nemo_automodel/components/datasets/llm/eagle3_cache.py
+++ b/nemo_automodel/components/datasets/llm/eagle3_cache.py
@@ -35,11 +35,18 @@ agree on one schema):
 * ``<cache_dir>/shard-000000.safetensors`` -- one shard holds a contiguous block
   of samples, each field stacked along dim 0:
   ``input_ids[n,S]``, ``attention_mask[n,S]``, ``loss_mask[n,S]`` (int64),
-  ``aux_hidden_states[n,S,3H]``, ``target_probs[n,S,draft_vocab]`` (float),
-  ``position_mask[n,S,1]`` (bool).
+  ``aux_hidden_states[n,S,3H]`` (float), ``position_mask[n,S,1]`` (bool), and the
+  draft-vocab target distribution. The distribution is stored in full as
+  ``target_probs[n,S,draft_vocab]`` (float) by default, or -- when the manifest's
+  ``target_probs_topk`` enables it -- as the top-k factorization
+  ``target_probs_values[n,S,k]`` (float) + ``target_probs_indices[n,S,k]`` (int32),
+  which the reader scatters back to full width. Top-k bounds the dominant field's
+  footprint at the cost of the dropped tail mass (a disk/fidelity trade-off, off by
+  default; see ``precompute_eagle3``).
 
 Each ``CachedEagle3Dataset`` item is exactly the keyword arguments
-``Eagle3TrainerModule.forward`` consumes on its precomputed-distribution path.
+``Eagle3TrainerModule.forward`` consumes on its precomputed-distribution path
+(``target_probs`` always yielded at full width).
 """
 
 from __future__ import annotations
@@ -58,17 +65,53 @@ from nemo_automodel.shared.import_utils import safe_import_from
 _MANIFEST_NAME = "manifest.json"
 _EMBEDDINGS_NAME = "target_embeddings.safetensors"
 _SHARD_RE = re.compile(r"^shard-(\d{6})\.safetensors$")
-_FORMAT_VERSION = 1
+_FORMAT_VERSION = 2
 
-# Fields stored per sample. The float fields are cast to the cache dtype; the id /
-# mask fields stay int64 / bool. This key set is exactly what the trainer's
-# precomputed-distribution path consumes.
-_FLOAT_KEYS = ("aux_hidden_states", "target_probs")
-_INT_KEYS = ("input_ids", "attention_mask", "loss_mask")
-_BOOL_KEYS = ("position_mask",)
-CACHE_KEYS = _FLOAT_KEYS + _INT_KEYS + _BOOL_KEYS
+# Fields the trainer's precomputed-distribution path consumes (what each
+# ``CachedEagle3Dataset`` item yields). ``target_probs`` is the full draft-vocab
+# distribution; under top-k compression the reader reconstructs it from the
+# stored factorization, otherwise it is read back as-is.
+_COMMON_KEYS = ("input_ids", "attention_mask", "loss_mask", "aux_hidden_states", "position_mask")
+_LOSSLESS_PROBS_KEYS = ("target_probs",)
+CACHE_KEYS = _COMMON_KEYS + _LOSSLESS_PROBS_KEYS
+
+# A shard stores the draft-vocab ``target_probs`` either in full (lossless, the
+# default) or, to bound the dominant field's footprint, as the top-k
+# ``(values, indices)`` factorization the reader scatters back to full width.
+# Which layout is in use is recorded by ``target_probs_topk`` in the manifest.
+_TARGET_PROBS_VALUES = "target_probs_values"
+_TARGET_PROBS_INDICES = "target_probs_indices"
+_TOPK_PROBS_KEYS = (_TARGET_PROBS_VALUES, _TARGET_PROBS_INDICES)
 
 DTYPE_MAP = {"bf16": torch.bfloat16, "fp16": torch.float16, "fp32": torch.float32}
+
+
+def is_compressed(target_probs_topk: int | None, draft_vocab_size: int) -> bool:
+    """True when ``target_probs_topk`` actually compresses (a positive k below the vocab width)."""
+    return target_probs_topk is not None and 0 < int(target_probs_topk) < draft_vocab_size
+
+
+def compress_target_probs(target_probs: torch.Tensor, topk: int) -> tuple[torch.Tensor, torch.Tensor]:
+    """Factor a draft-vocab distribution into its top-``topk`` ``(values, indices)``.
+
+    ``target_probs`` is ``[..., draft_vocab]``. The kept values are renormalized to
+    sum to 1 so the reconstructed distribution stays a proper distribution for soft
+    cross-entropy. The dropped tail mass is a disk/fidelity trade-off that grows with
+    how diffuse the target is (it is *not* negligible for a real LLM: top-64 of a
+    Qwen3-8B next-token distribution keeps only ~0.92 of the mass), so callers choose
+    ``topk`` deliberately; see ``precompute_eagle3``. ``topk`` is clamped to the vocab
+    width.
+    """
+    k = min(topk, target_probs.shape[-1])
+    values, indices = torch.topk(target_probs, k, dim=-1)
+    values = values / values.sum(dim=-1, keepdim=True).clamp_min(torch.finfo(target_probs.dtype).tiny)
+    return values, indices.to(torch.int32)
+
+
+def reconstruct_target_probs(values: torch.Tensor, indices: torch.Tensor, draft_vocab_size: int) -> torch.Tensor:
+    """Scatter stored top-k ``(values, indices)`` back into a full ``[..., draft_vocab]`` distribution."""
+    full = torch.zeros((*values.shape[:-1], draft_vocab_size), dtype=values.dtype, device=values.device)
+    return full.scatter_(-1, indices.to(torch.long), values)
 
 
 def _load_safetensors():
@@ -170,12 +213,25 @@ def read_target_embeddings(cache_dir: str) -> torch.Tensor:
 
 
 def write_shard(cache_dir: str, shard_index: int, samples: dict[str, torch.Tensor]) -> str:
-    """Write one shard atomically. ``samples`` maps each ``CACHE_KEYS`` field to a stacked tensor."""
+    """Write one shard atomically.
+
+    ``samples`` carries the ``_COMMON_KEYS`` plus exactly one ``target_probs``
+    representation: the full ``target_probs`` (lossless) or the top-k pair
+    ``target_probs_values`` + ``target_probs_indices``.
+    """
     save_file, _ = _load_safetensors()
-    missing = [k for k in CACHE_KEYS if k not in samples]
+    has_full = "target_probs" in samples
+    has_topk = all(k in samples for k in _TOPK_PROBS_KEYS)
+    if int(has_full) + int(has_topk) != 1:
+        raise ValueError(
+            "write_shard needs exactly one target_probs representation: the full 'target_probs', "
+            "or the top-k 'target_probs_values' + 'target_probs_indices'."
+        )
+    keys = _COMMON_KEYS + (_LOSSLESS_PROBS_KEYS if has_full else _TOPK_PROBS_KEYS)
+    missing = [k for k in keys if k not in samples]
     if missing:
         raise ValueError(f"write_shard is missing required cache fields: {missing}")
-    tensors = {k: samples[k].contiguous() for k in CACHE_KEYS}
+    tensors = {k: samples[k].contiguous() for k in keys}
     return _atomic_write(shard_path(cache_dir, shard_index), lambda tmp: save_file(tensors, tmp))
 
 
@@ -192,6 +248,11 @@ class CachedEagle3Dataset(Dataset):
         self.manifest = read_manifest(cache_dir)
         self.shard_size = int(self.manifest["shard_size"])
         self.num_samples = int(self.manifest["num_samples"])
+        # A cache stores target_probs either in full or as its top-k factorization;
+        # the reader yields the full distribution either way.
+        self.draft_vocab_size = int(self.manifest["draft_vocab_size"])
+        self._compressed = is_compressed(self.manifest.get("target_probs_topk"), self.draft_vocab_size)
+        self._disk_keys = _COMMON_KEYS + (_TOPK_PROBS_KEYS if self._compressed else _LOSSLESS_PROBS_KEYS)
         indices = sorted(existing_shard_indices(cache_dir))
         expected = (self.num_samples + self.shard_size - 1) // self.shard_size
         if len(indices) != expected:
@@ -221,7 +282,14 @@ class CachedEagle3Dataset(Dataset):
         shard_index = index // self.shard_size
         offset = index % self.shard_size
         handle = self._handle(shard_index)
-        return {key: handle.get_slice(key)[offset] for key in CACHE_KEYS}
+        sample = {key: handle.get_slice(key)[offset] for key in self._disk_keys}
+        if self._compressed:
+            sample["target_probs"] = reconstruct_target_probs(
+                sample.pop(_TARGET_PROBS_VALUES),
+                sample.pop(_TARGET_PROBS_INDICES),
+                self.draft_vocab_size,
+            )
+        return sample
 
 
 def _collate_cached(features: list[dict[str, torch.Tensor]]) -> dict[str, torch.Tensor]:

--- a/nemo_automodel/components/speculative/precompute_eagle3.py
+++ b/nemo_automodel/components/speculative/precompute_eagle3.py
@@ -21,19 +21,20 @@ reads it back via ``cached_target_path`` instead of loading or running the
 target at all.
 
 ==============================  READ THIS  =================================
-This is the SpecForge **offline** training path. It is **extremely disk
-intensive** -- ``aux_hidden_states`` alone is ``3 * target_hidden_size`` wide,
-so an 8B target at seq-len 2048 costs ~80 MB *per sample* (tens of TB for a
-large corpus). Modern practice trains **online**, where the target forward is
-cheap next to that I/O, so this path is largely **deprecated**. It is provided
-for completeness / reproducing the SpecForge offline recipe and for the niche
-case of repeatedly re-training a draft on a fixed, bounded dataset. Prefer the
-online recipe (no ``cached_target_path``) unless you specifically need this.
+This is the SpecForge **offline** training path. It is **disk intensive** -- the
+draft-vocab ``target_probs`` (``draft_vocab`` wide) and ``aux_hidden_states``
+(``3 * target_hidden_size`` wide) together cost on the order of 100+ MB per
+sample for an 8B target at seq-len 2048, i.e. multiple TB for a large corpus.
+Modern practice trains **online**, where the target forward is cheap next to that
+I/O; prefer the online recipe unless you re-train a draft repeatedly on a fixed,
+bounded dataset. ``--target-probs-topk`` can shrink the ``target_probs`` field by
+storing only its top-k mass, but that is a real disk/fidelity trade-off (a real
+LLM distribution has a fat tail), so it is **off by default** -- see the flag's
+help.
 ===========================================================================
 
 Only EAGLE-3 is supported. EAGLE-1/2 supervise on the *full*-vocab target
-distribution (no draft-vocab compression), which is ~0.5 GB per sample -- not
-worth caching -- so they keep the online path only.
+distribution, which the recipe keeps on the online path only.
 
 Typical usage (single device; large MoE targets that need sharding must use the
 online path instead):
@@ -62,9 +63,10 @@ from nemo_automodel._transformers import NeMoAutoModelForCausalLM
 from nemo_automodel._transformers.auto_tokenizer import NeMoAutoTokenizer
 from nemo_automodel.components.datasets.llm.eagle3 import build_eagle3_dataloader, build_eagle3_token_mapping
 from nemo_automodel.components.datasets.llm.eagle3_cache import (
-    CACHE_KEYS,
     DTYPE_MAP,
+    compress_target_probs,
     existing_shard_indices,
+    is_compressed,
     manifest_path,
     read_manifest,
     write_manifest,
@@ -82,12 +84,15 @@ def _compute_batch_cache(
     selected_token_ids: torch.Tensor,
     selected_token_mask: torch.Tensor,
     cache_dtype: torch.dtype,
+    target_probs_topk: int,
 ) -> dict[str, torch.Tensor]:
     """Turn one target-model batch into the per-sample tensors the trainer caches.
 
     Reuses ``_compute_target_distribution`` -- the exact function the online
-    trainer calls -- so the cached ``target_probs`` / ``position_mask`` are
-    numerically identical to the live path. Float fields are downcast to
+    trainer calls -- so the cached supervision is numerically identical to the
+    live path. The draft-vocab ``target_probs`` is stored in full, or -- when
+    ``target_probs_topk`` compresses (a positive k below the draft vocab) -- as
+    its top-k ``(values, indices)`` factorization. Float fields are downcast to
     ``cache_dtype``; everything is moved to CPU for writing.
     """
     target_probs, position_mask = _compute_target_distribution(
@@ -96,14 +101,20 @@ def _compute_batch_cache(
         selected_token_mask=selected_token_mask,
         loss_mask=target_batch.loss_mask,
     )
-    return {
+    sample = {
         "input_ids": target_batch.input_ids.to(torch.long).cpu(),
         "attention_mask": target_batch.attention_mask.to(torch.long).cpu(),
         "loss_mask": target_batch.loss_mask.to(torch.long).cpu(),
         "aux_hidden_states": target_batch.aux_hidden_states.to(cache_dtype).cpu(),
-        "target_probs": target_probs.to(cache_dtype).cpu(),
         "position_mask": position_mask.to(torch.bool).cpu(),
     }
+    if is_compressed(target_probs_topk, target_probs.shape[-1]):
+        topk_values, topk_indices = compress_target_probs(target_probs, target_probs_topk)
+        sample["target_probs_values"] = topk_values.to(cache_dtype).cpu()
+        sample["target_probs_indices"] = topk_indices.cpu()
+    else:
+        sample["target_probs"] = target_probs.to(cache_dtype).cpu()
+    return sample
 
 
 def _validate_args(args: argparse.Namespace) -> None:
@@ -119,6 +130,8 @@ def _validate_args(args: argparse.Namespace) -> None:
         )
     if args.draft_vocab_size is not None and args.draft_vocab_size < 1:
         raise ValueError(f"--draft-vocab-size must be >= 1 or omitted, got {args.draft_vocab_size}")
+    if args.target_probs_topk < 0:
+        raise ValueError(f"--target-probs-topk must be >= 0 (0 = lossless), got {args.target_probs_topk}")
     if args.dtype not in DTYPE_MAP:
         raise ValueError(f"--dtype must be one of {sorted(DTYPE_MAP)}, got {args.dtype!r}")
 
@@ -217,6 +230,7 @@ def _run(args: argparse.Namespace) -> int:
         "dtype": args.dtype,
         "num_samples": num_samples,
         "shard_size": args.shard_size,
+        "target_probs_topk": args.target_probs_topk,
         "aux_hidden_dim": int(target_model.config.hidden_size) * len(target_wrapper.aux_layer_ids),
         "aux_layer_ids": list(target_wrapper.aux_layer_ids),
         "selected_token_ids": selected_token_ids.cpu().tolist(),
@@ -249,7 +263,9 @@ def _run(args: argparse.Namespace) -> int:
         if buffered == 0:
             return
         if shard_index not in existing:
-            merged = {k: torch.cat([c[k] for c in chunks], dim=0)[: args.shard_size] for k in CACHE_KEYS}
+            # Every chunk came from _compute_batch_cache with the same topk, so they
+            # share one key set (full vs top-k) -- merge whatever that batch produced.
+            merged = {k: torch.cat([c[k] for c in chunks], dim=0)[: args.shard_size] for k in chunks[0]}
             path = write_shard(args.output_dir, shard_index, merged)
             logger.info("Wrote %s (%d samples)", path, merged["input_ids"].shape[0])
         chunks = []
@@ -274,7 +290,11 @@ def _run(args: argparse.Namespace) -> int:
                 attention_mask=batch["attention_mask"],
                 loss_mask=batch["loss_mask"],
             )
-            chunks.append(_compute_batch_cache(target_batch, selected_token_ids, selected_token_mask, cache_dtype))
+            chunks.append(
+                _compute_batch_cache(
+                    target_batch, selected_token_ids, selected_token_mask, cache_dtype, args.target_probs_topk
+                )
+            )
             buffered += batch_size
             if buffered >= args.shard_size:
                 _flush()
@@ -298,6 +318,16 @@ def _build_parser() -> argparse.ArgumentParser:
         type=int,
         default=None,
         help="Draft vocabulary size (None = full target vocab; defeats most of the storage saving).",
+    )
+    parser.add_argument(
+        "--target-probs-topk",
+        type=int,
+        default=0,
+        help="Compress the dominant cache field by storing only the top-k of each token's "
+        "draft-vocab target distribution (0 = off = store it in full, the default and exact). "
+        "This is a real disk/fidelity trade-off, NOT free: a real LLM next-token distribution has "
+        "a fat tail (top-64 of a Qwen3-8B distribution keeps only ~0.92 of the mass, KL ~1.3), so "
+        "small k distorts the soft-CE target. Use a large k (or leave it off) for fidelity.",
     )
     parser.add_argument("--batch-size", type=int, default=4, help="Target forward batch size.")
     parser.add_argument(

--- a/tests/unit_tests/speculative/test_eagle3_offline_cache.py
+++ b/tests/unit_tests/speculative/test_eagle3_offline_cache.py
@@ -35,10 +35,12 @@ from nemo_automodel.components.datasets.llm.eagle3_cache import (
     CACHE_KEYS,
     CachedEagle3Dataset,
     build_cached_eagle3_dataloader,
+    compress_target_probs,
     existing_shard_indices,
     manifest_path,
     read_manifest,
     read_target_embeddings,
+    reconstruct_target_probs,
     write_manifest,
     write_shard,
     write_target_embeddings,
@@ -157,10 +159,11 @@ def test_forward_rejects_both_supervision_sources():
 # ---------------------------------------------------------------------------
 
 
-def test_compute_batch_cache_matches_compute_target_distribution():
+def test_compute_batch_cache_lossless_matches_compute_target_distribution():
     _, ids, mask = _build_module()
     tb = _fake_target_batch()
-    cache = _compute_batch_cache(tb, ids, mask, cache_dtype=torch.float32)
+    # topk=0 (the default) stores the full distribution -- exact, no factorization.
+    cache = _compute_batch_cache(tb, ids, mask, cache_dtype=torch.float32, target_probs_topk=0)
 
     assert set(cache) == set(CACHE_KEYS)
     target_probs, position_mask = _compute_target_distribution(
@@ -173,13 +176,58 @@ def test_compute_batch_cache_matches_compute_target_distribution():
     assert cache["position_mask"].dtype == torch.bool
 
 
+def test_compute_batch_cache_compressed_stores_topk():
+    _, ids, mask = _build_module()
+    tb = _fake_target_batch()
+    # A positive k below the draft vocab switches to the top-k factorization.
+    cache = _compute_batch_cache(tb, ids, mask, cache_dtype=torch.float32, target_probs_topk=4)
+
+    assert "target_probs" not in cache
+    assert cache["target_probs_values"].shape[-1] == 4
+    assert cache["target_probs_indices"].dtype == torch.int32
+    target_probs, _ = _compute_target_distribution(
+        target_logits=tb.logits, selected_token_ids=ids, selected_token_mask=mask, loss_mask=tb.loss_mask
+    )
+    reconstructed = reconstruct_target_probs(cache["target_probs_values"], cache["target_probs_indices"], _DRAFT_VOCAB)
+    # The kept top tokens carry the same argmax as the live distribution.
+    assert (reconstructed.argmax(-1) == target_probs.argmax(-1)).all()
+
+
 def test_compute_batch_cache_downcasts_floats():
     _, ids, mask = _build_module()
     tb = _fake_target_batch()
-    cache = _compute_batch_cache(tb, ids, mask, cache_dtype=torch.bfloat16)
+    cache = _compute_batch_cache(tb, ids, mask, cache_dtype=torch.bfloat16, target_probs_topk=4)
     assert cache["aux_hidden_states"].dtype == torch.bfloat16
-    assert cache["target_probs"].dtype == torch.bfloat16
+    assert cache["target_probs_values"].dtype == torch.bfloat16
+    assert cache["target_probs_indices"].dtype == torch.int32  # indices stay exact
     assert cache["input_ids"].dtype == torch.long  # ids/masks stay exact
+
+
+# ---------------------------------------------------------------------------
+# target_probs top-k compression / reconstruction
+# ---------------------------------------------------------------------------
+
+
+def test_compress_reconstruct_preserves_peaked_mass():
+    torch.manual_seed(0)
+    target_probs = torch.softmax(torch.randn(3, 5, _DRAFT_VOCAB) * 6.0, dim=-1)
+    values, indices = compress_target_probs(target_probs, topk=4)
+
+    assert values.shape[-1] == 4 and indices.dtype == torch.int32
+    # The kept mass is renormalized to a proper distribution.
+    torch.testing.assert_close(values.sum(-1), torch.ones(3, 5))
+    reconstructed = reconstruct_target_probs(values, indices, _DRAFT_VOCAB)
+    # The argmax (the always-supervised top token) is never dropped.
+    assert (reconstructed.argmax(-1) == target_probs.argmax(-1)).all()
+
+
+def test_compress_lossless_when_topk_at_least_vocab():
+    target_probs = torch.softmax(torch.randn(2, 4, _DRAFT_VOCAB), dim=-1)
+    values, indices = compress_target_probs(target_probs, topk=_DRAFT_VOCAB + 10)
+
+    assert values.shape[-1] == _DRAFT_VOCAB  # clamped to the vocab width
+    reconstructed = reconstruct_target_probs(values, indices, _DRAFT_VOCAB)
+    torch.testing.assert_close(reconstructed, target_probs)
 
 
 # ---------------------------------------------------------------------------
@@ -187,15 +235,29 @@ def test_compute_batch_cache_downcasts_floats():
 # ---------------------------------------------------------------------------
 
 
-def _write_tiny_cache(cache_dir, num_samples=3, shard_size=2, seq_len=4):
+def _write_tiny_cache(cache_dir, num_samples=3, shard_size=2, seq_len=4, topk=0):
+    """Write a tiny cache (lossless by default, top-k when ``topk`` compresses).
+
+    Returns ``(disk_samples, expected_target_probs)`` where the expectation is what
+    the reader yields for ``target_probs`` (reconstructed under compression).
+    """
+    target_probs = torch.softmax(torch.randn(num_samples, seq_len, _DRAFT_VOCAB), dim=-1)
     samples = {
         "input_ids": torch.randint(0, _VOCAB, (num_samples, seq_len), dtype=torch.long),
         "attention_mask": torch.ones(num_samples, seq_len, dtype=torch.long),
         "loss_mask": torch.ones(num_samples, seq_len, dtype=torch.long),
         "aux_hidden_states": torch.randn(num_samples, seq_len, _HIDDEN * 3),
-        "target_probs": torch.rand(num_samples, seq_len, _DRAFT_VOCAB),
         "position_mask": torch.ones(num_samples, seq_len, 1, dtype=torch.bool),
     }
+    if 0 < topk < _DRAFT_VOCAB:
+        values, indices = compress_target_probs(target_probs, topk)
+        samples["target_probs_values"] = values
+        samples["target_probs_indices"] = indices
+        expected = reconstruct_target_probs(values, indices, _DRAFT_VOCAB)
+    else:
+        samples["target_probs"] = target_probs
+        expected = target_probs
+
     shard_index = 0
     for start in range(0, num_samples, shard_size):
         chunk = {k: v[start : start + shard_size] for k, v in samples.items()}
@@ -211,25 +273,58 @@ def _write_tiny_cache(cache_dir, num_samples=3, shard_size=2, seq_len=4):
             "dtype": "fp32",
             "num_samples": num_samples,
             "shard_size": shard_size,
+            "target_probs_topk": topk,
             "aux_hidden_dim": _HIDDEN * 3,
             "aux_layer_ids": [1, 2, 3],
             "selected_token_ids": list(range(_DRAFT_VOCAB)),
         },
     )
-    return samples
+    return samples, expected
 
 
-def test_cache_dataset_round_trip(tmp_path):
+def test_cache_dataset_round_trip_lossless(tmp_path):
     cache_dir = str(tmp_path / "cache")
-    samples = _write_tiny_cache(cache_dir, num_samples=3, shard_size=2, seq_len=4)
+    samples, expected_target_probs = _write_tiny_cache(cache_dir, num_samples=3, shard_size=2, seq_len=4)
 
     dataset = CachedEagle3Dataset(cache_dir)
     assert len(dataset) == 3
     item = dataset[2]  # last sample lives in the trailing partial shard
     assert set(item) == set(CACHE_KEYS)
     torch.testing.assert_close(item["aux_hidden_states"], samples["aux_hidden_states"][2])
-    torch.testing.assert_close(item["target_probs"], samples["target_probs"][2])
+    torch.testing.assert_close(item["target_probs"], expected_target_probs[2])
     assert int(item["input_ids"][0]) == int(samples["input_ids"][2][0])
+
+
+def test_cache_dataset_round_trip_compressed(tmp_path):
+    cache_dir = str(tmp_path / "cache")
+    _, expected_target_probs = _write_tiny_cache(cache_dir, num_samples=3, shard_size=2, seq_len=4, topk=4)
+
+    dataset = CachedEagle3Dataset(cache_dir)
+    item = dataset[2]
+    # The reader yields full-width target_probs (reconstructed), not the disk keys.
+    assert set(item) == set(CACHE_KEYS)
+    assert item["target_probs"].shape == (4, _DRAFT_VOCAB)
+    torch.testing.assert_close(item["target_probs"], expected_target_probs[2])
+
+
+def test_write_shard_rejects_ambiguous_target_probs(tmp_path):
+    cache_dir = str(tmp_path / "cache")
+    base = {
+        "input_ids": torch.zeros(1, 4, dtype=torch.long),
+        "attention_mask": torch.ones(1, 4, dtype=torch.long),
+        "loss_mask": torch.ones(1, 4, dtype=torch.long),
+        "aux_hidden_states": torch.zeros(1, 4, _HIDDEN * 3),
+        "position_mask": torch.ones(1, 4, 1, dtype=torch.bool),
+    }
+    # Neither representation present.
+    with pytest.raises(ValueError, match="exactly one target_probs"):
+        write_shard(cache_dir, 0, dict(base))
+    # Both representations present.
+    both = dict(base, target_probs=torch.rand(1, 4, _DRAFT_VOCAB))
+    both["target_probs_values"] = torch.rand(1, 4, 2)
+    both["target_probs_indices"] = torch.zeros(1, 4, 2, dtype=torch.int32)
+    with pytest.raises(ValueError, match="exactly one target_probs"):
+        write_shard(cache_dir, 0, both)
 
 
 def test_cache_dataloader_batches(tmp_path):
@@ -273,7 +368,7 @@ def test_read_target_embeddings_missing_raises(tmp_path):
 
 
 def _args(**overrides):
-    base = dict(batch_size=4, shard_size=256, draft_vocab_size=8192, dtype="bf16")
+    base = dict(batch_size=4, shard_size=256, draft_vocab_size=8192, target_probs_topk=64, dtype="bf16")
     base.update(overrides)
     return SimpleNamespace(**base)
 
@@ -285,6 +380,7 @@ def _args(**overrides):
         ({"shard_size": 0}, "shard-size"),
         ({"shard_size": 100, "batch_size": 8}, "multiple of"),  # 100 % 8 != 0
         ({"draft_vocab_size": 0}, "draft-vocab-size"),
+        ({"target_probs_topk": -1}, "target-probs-topk"),
         ({"dtype": "int4"}, "dtype"),
     ],
 )
@@ -520,8 +616,16 @@ def test_read_manifest_wrong_format_version_raises(tmp_path):
 
 
 def test_write_shard_missing_fields_raises(tmp_path):
+    # A valid target_probs representation but missing the common fields.
     with pytest.raises(ValueError, match="missing required cache fields"):
-        write_shard(str(tmp_path), 0, {"input_ids": torch.zeros(1, 1, dtype=torch.long)})
+        write_shard(
+            str(tmp_path),
+            0,
+            {
+                "input_ids": torch.zeros(1, 1, dtype=torch.long),
+                "target_probs": torch.rand(1, 1, _DRAFT_VOCAB),
+            },
+        )
 
 
 def test_load_safetensors_missing_raises(monkeypatch):


### PR DESCRIPTION
## What

Adds an **opt-in** top-k compression for the EAGLE-3 offline target-output cache
(`precompute_eagle3` / `eagle3_cache`). A new `--target-probs-topk K` stores only
the top-k mass of each token's draft-vocab `target_probs` distribution as a
`(values, indices)` factorization, which the reader scatters back to full width.

## Why

`target_probs` is the cache's dominant field: `draft_vocab` wide per token, on the
order of ~131 MB/sample for an 8B target at `draft_vocab=32000`, seq 2048. Storing
only its top-k mass shrinks that field by roughly the `k / draft_vocab` ratio.

## Design

* **Off by default (the cache stays exact).** `--target-probs-topk` defaults to
  `0` = store the full distribution, so existing behavior is unchanged.
* **Honest disk/fidelity trade-off, not free.** A real LLM next-token distribution
  has a fat tail, so top-k is lossy: measured on a Qwen3-8B distribution, top-64
  keeps only **~0.92** of the mass (KL ~1.3 vs the full distribution). The flag
  help and module docstring spell this out; pick a large `k` (or leave it off) for
  fidelity. The kept values are renormalized so the reconstruction is still a
  proper distribution for soft cross-entropy.
* **The trainer is untouched.** `CachedEagle3Dataset` always yields full-width
  `target_probs`; whether a shard stored it in full or as top-k is recorded by the
  manifest's `target_probs_topk` and handled entirely in the reader.
* Cache `format_version` bumped to 2; the reader handles both the full and top-k
  shard layouts.

## Tests

`tests/unit_tests/speculative/test_eagle3_offline_cache.py`: lossless and
compressed `_compute_batch_cache`, `compress` / `reconstruct` round-trips
(renormalization + argmax preserved, lossless when `k >= draft_vocab`), both
on-disk round-trips through `CachedEagle3Dataset`, `write_shard`'s
exactly-one-representation guard, and the new arg validation.
