### PR TITLE
fix(data): allow text collate without Qwen VL utilities

### DIFF
--- a/nemo_automodel/components/datasets/vlm/collate_fns.py
+++ b/nemo_automodel/components/datasets/vlm/collate_fns.py
@@ -19,15 +19,12 @@ from unittest.mock import MagicMock
 import torch
 from PIL import Image as PILImage
 
-from nemo_automodel.shared.import_utils import MISSING_QWEN_VL_UTILS_MSG
-
 try:
-    from qwen_vl_utils import process_vision_info
+    import qwen_vl_utils  # noqa: F401
 
     HAVE_QWEN_VL_UTILS = True
 except ImportError:
     HAVE_QWEN_VL_UTILS = False
-    process_vision_info = MagicMock()
 
 try:
     from qwen_omni_utils import process_mm_info
@@ -1256,9 +1253,6 @@ def default_collate_fn(
             (e.g. Gemma4 thinking-channel injection) to transform the
             tokenized batch and the prefix tokens without duplicating the rest of the pipeline.
     """
-    if not HAVE_QWEN_VL_UTILS:
-        raise ImportError(MISSING_QWEN_VL_UTILS_MSG)
-
     conversations = _ensure_rgb([example["conversation"] for example in examples])
 
     # Optionally drop overlong samples before processing

--- a/tests/unit_tests/datasets/vlm/test_collate_fns.py
+++ b/tests/unit_tests/datasets/vlm/test_collate_fns.py
@@ -666,14 +666,23 @@ def test_nemotron_parse_collate_shifts_and_casts(collate_mod, monkeypatch):
     assert torch.equal(batch["decoder_attention_mask"], torch.tensor([[1, 1, 1]]))
 
 
-@pytest.mark.parametrize("fn_name", ["default_collate_fn", "qwen3_omni_collate_fn"])
-def test_import_error_when_qwen_utils_missing(collate_mod, fn_name, monkeypatch):
+def test_qwen3_omni_collate_fn_import_error_when_qwen_utils_missing(collate_mod, monkeypatch):
     monkeypatch.setattr(collate_mod, "HAVE_QWEN_VL_UTILS", False, raising=True)
     monkeypatch.setattr(collate_mod, "HAVE_QWEN_OMNI_UTILS", False, raising=True)
-    func = getattr(collate_mod, fn_name)
 
     with pytest.raises(ImportError):
-        func([], None)
+        collate_mod.qwen3_omni_collate_fn([], None)
+
+
+def test_default_collate_fn_without_qwen_vl_utils(collate_mod, monkeypatch):
+    monkeypatch.setattr(collate_mod, "HAVE_QWEN_VL_UTILS", False, raising=True)
+
+    processor = DummyDefaultProcessor()
+    batch = collate_mod.default_collate_fn([{"conversation": CONVERSATION}], processor)
+
+    assert batch["input_ids"].shape == (1, 3)
+    assert batch["labels"].shape == (1, 3)
+    assert batch["pixel_values"].dtype == torch.bfloat16
 
 
 def test_default_collate_fn_with_max_length(collate_mod, fake_qwen_utils, monkeypatch):


### PR DESCRIPTION
## Stack

4 of 7. Previous: #2851. Next: #2853.

## Summary

- Removes the Qwen VL utility requirement from the generic text-capable VLM collator.
- Keeps Qwen Omni-specific utility validation on the path that actually needs it.
- Adds coverage for text collation when `qwen_vl_utils` is absent.

## Validation

- `tests/unit_tests/datasets/vlm/test_collate_fns.py`: `127 passed`
- Commit hooks and `git diff --check`