### PR TITLE
test(moe): add DeepEP v2 benchmark and finetuning recipes

### DIFF
--- a/examples/llm_benchmark/deepseek/deepseek_v3_te_deepep.yaml
+++ b/examples/llm_benchmark/deepseek/deepseek_v3_te_deepep.yaml
@@ -45,6 +45,11 @@ distributed:
   cp_size: 1
   pp_size: 4
   ep_size: 64
+  mp_policy:
+    param_dtype: bfloat16
+    reduce_dtype: bfloat16
+    output_dtype: bfloat16
+    cast_forward_inputs: true
 
   sequence_parallel: false
   activation_checkpointing: true
@@ -56,7 +61,7 @@ distributed:
     scale_grads_in_schedule: false
     patch_inner_model: false
     patch_causal_lm_model: false
-    layers_per_stage: 2
+    layers_per_stage: 4
 
   moe:
     reshard_after_forward: false
@@ -116,3 +121,13 @@ ci:
   nodes: 32
   env_vars:
     RDZV_TIMEOUT: "900"
+    NVTE_FUSED_ATTN: "1"
+    NVTE_UNFUSED_ATTN: "0"
+    NVTE_FLASH_ATTN: "0"
+    NVTE_ALLOW_NONDETERMINISTIC_ALGO: "1"
+    NVTE_NORM_FWD_USE_CUDNN: "1"
+    NVTE_NORM_BWD_USE_CUDNN: "1"
+    NVTE_FWD_LAYERNORM_SM_MARGIN: "16"
+    NVTE_BWD_LAYERNORM_SM_MARGIN: "16"
+    TORCH_NCCL_AVOID_RECORD_STREAMS: "0"
+    NCCL_P2P_NET_CHUNKSIZE: "2097152"

--- a/examples/llm_benchmark/qwen/qwen3_moe_235b_te_deepep.yaml
+++ b/examples/llm_benchmark/qwen/qwen3_moe_235b_te_deepep.yaml
@@ -77,7 +77,7 @@ model:
     attn: te
     linear: te
     rms_norm: te
-    rope_fusion: true
+    rope_fusion: false
     experts: gmm
     dispatcher: deepep
     fake_balanced_gate: true

--- a/examples/llm_benchmark/qwen/qwen3_moe_30b_te_deepep.yaml
+++ b/examples/llm_benchmark/qwen/qwen3_moe_30b_te_deepep.yaml
@@ -76,6 +76,7 @@ model:
     rope_fusion: true
     experts: gmm
     dispatcher: deepep
+    dispatcher_num_sms: 20
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true
     enable_fsdp_optimizations: true

--- a/examples/llm_finetune/qwen/qwen3_moe_235b_te_deepep.yaml
+++ b/examples/llm_finetune/qwen/qwen3_moe_235b_te_deepep.yaml
@@ -13,18 +13,19 @@
 # limitations under the License.
 
 # To run this recipe:
-#   automodel examples/llm_finetune/qwen/qwen3_moe_30b_te_deepep.yaml --nproc-per-node 8
+#   automodel examples/llm_finetune/qwen/qwen3_moe_235b_te_deepep.yaml --nproc-per-node 8
 # Adjust --nproc-per-node to the number of GPUs available on your machine.
 
 recipe: TrainFinetuneRecipeForNextTokenPrediction
 
 step_scheduler:
   global_batch_size: 512
-  local_batch_size: 32
+  local_batch_size: 8
   ckpt_every_steps: 500
-  val_every_steps: 100  # will run every x number of gradient steps
+  val_every_steps: 500
   num_epochs: 2
-  # max_steps: 5
+  max_steps: 100
+  gc_every_steps: 10
 
 dist_env:
   backend: nccl
@@ -37,7 +38,7 @@ rng:
 
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
-  pretrained_model_name_or_path: Qwen/Qwen3-30B-A3B
+  pretrained_model_name_or_path: Qwen/Qwen3-235B-A22B
   trust_remote_code: true
   torch_dtype: bfloat16
   backend:
@@ -45,6 +46,7 @@ model:
     attn: te
     linear: torch
     rms_norm: torch_fp32
+    rope_fusion: false
     experts: torch_mm
     dispatcher: deepep_v2
     dispatcher_share_token_dispatcher: false
@@ -53,29 +55,33 @@ model:
     enable_fsdp_optimizations: true
 
 checkpoint:
-  enabled: true
+  enabled: false
   checkpoint_dir: /tmp/checkpoints/
-  model_save_format: safetensors # torch_save or safetensors
+  model_save_format: safetensors
   save_consolidated: final
 
 distributed:
   strategy: fsdp2
   tp_size: 1
   cp_size: 1
-  pp_size: 1
-  ep_size: 8
+  pp_size: 4
+  ep_size: 32
 
   sequence_parallel: false
   activation_checkpointing: true
 
   pipeline:
     pp_schedule: interleaved1f1b
-    pp_microbatch_size: 8
+    pp_microbatch_size: 1
     round_virtual_stages_to_pp_multiple: up
     scale_grads_in_schedule: false
+    layers_per_stage: 2
     patch_inner_model: false
     patch_causal_lm_model: false
 
+  moe:
+    reshard_after_forward: false
+    wrap_outer_model: false
 
 loss_fn:
   _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
@@ -86,7 +92,6 @@ dataset:
   split: train
 
 packed_sequence:
-  # Set packed_sequence_size > 0 to run with packed sequences
   packed_sequence_size: 0
 
 dataloader:
@@ -109,25 +114,15 @@ optimizer:
   _target_: torch.optim.Adam
   betas: [0.9, 0.95]
   eps: 1e-7
-  lr: 1.0e-4
+  lr: 1.0e-5
   weight_decay: 0.0
-  # min_lr: 1.0e-5
-
-# Uncomment and configure for W&B logging
-# wandb:
-#   project: <your_wandb_project>
-#   entity: <your_wandb_entity>
-#   name: <your_wandb_exp_name>
-#   save_dir: <your_wandb_save_dir>
 
 ci:
   recipe_owner: hemildesai
-  node_multiplier: true
-  time: "00:15:00"
-  vllm_deploy: true
-  vllm_smoke_test: true
+  nodes: 32
+  time: "01:00:00"
   checkpoint_robustness:
     hf_kl_threshold: 1e-2
-    tokenizer_name: Qwen/Qwen3-30B-A3B
+    tokenizer_name: Qwen/Qwen3-235B-A22B
     no_check_resume: true
     dataset.num_samples_limit: 500


### PR DESCRIPTION
**Consolidated into #2850.**

This PR was one layer of the DeepEP v2 upgrade stack. The stack has been collapsed
into a single PR against `main` — see **#2850**, which contains all of these commits
(signed off). This PR is closed for history only; there is no longer a stack.
