### PR TITLE
perf(moe): reuse HybridEP JIT cache

### DIFF
--- a/nemo_automodel/components/moe/megatron/fused_a2a.py
+++ b/nemo_automodel/components/moe/megatron/fused_a2a.py
@@ -20,6 +20,8 @@
 import atexit
 import importlib
 import os
+import shutil
+from pathlib import Path
 
 import torch
 
@@ -189,16 +191,15 @@ def free_buffer() -> None:
         _buffer = None
 
 
-def destroy_deepep_v2_buffer(ignore_errors: bool = True) -> None:
+def destroy_deepep_v2_buffer() -> None:
     """Explicitly destroy the DeepEP V2 ElasticBuffer if one is allocated."""
     global _deepep_v2_buffer
 
     if _deepep_v2_buffer is not None:
         try:
             _deepep_v2_buffer.destroy()
-        except Exception:
-            if not ignore_errors:
-                raise
+        except Exception:  # pragma: no cover - best effort
+            pass
     _deepep_v2_buffer = None
 
 
@@ -649,6 +650,34 @@ except ImportError:
 _hybrid_ep_buffer = None
 
 
+def _sync_hybridep_jit_cache(*, persist: bool) -> None:
+    """Bridge HybridEP's process-local JIT directory to a persistent cache.
+
+    ``load_cached_kernels`` only scans ``proc-<pid>``, so a new process cannot
+    reuse kernels from an earlier launch without staging them into that directory.
+    """
+    cache_root = os.environ.get("HYBRID_EP_CACHE_DIR")
+    if not cache_root:
+        return
+
+    jit_dir = Path(cache_root).expanduser() / ".deepep" / "hybrid_ep" / "jit"
+    stable_dir, process_dir = jit_dir / "kernel-cache", jit_dir / f"proc-{os.getpid()}"
+    source_dir, destination_dir = (process_dir, stable_dir) if persist else (stable_dir, process_dir)
+    if source_dir.is_dir():
+        destination_dir.mkdir(parents=True, exist_ok=True)
+        for kernel in source_dir.glob("*.so"):
+            try:
+                os.link(kernel, destination_dir / kernel.name)
+            except OSError:
+                # Cache reuse is an optimization and must not prevent training.
+                pass
+    if persist:
+        shutil.rmtree(process_dir, ignore_errors=True)
+
+
+atexit.register(_sync_hybridep_jit_cache, persist=True)
+
+
 def init_hybrid_ep_buffer(
     group: torch.distributed.ProcessGroup,
     hidden_dim: int,
@@ -675,6 +704,7 @@ def init_hybrid_ep_buffer(
     """
     assert not fp8_dispatch, "HybridEP dispatcher does not support fp8 dispatch now"
     global _hybrid_ep_buffer
+    _sync_hybridep_jit_cache(persist=False)
     _hybrid_ep_buffer = HybridEPBuffer(
         group=group,
         hidden_dim=hidden_dim,
@@ -683,6 +713,7 @@ def init_hybrid_ep_buffer(
         use_fp8=fp8_dispatch,
         num_sms_dispatch_api=num_sms_dispatch_api,
         num_sms_combine_api=num_sms_combine_api,
+        load_cached_kernels=True,
     )
 
 
@@ -789,7 +820,7 @@ class HybridEPCombine(torch.autograd.Function):
             pad_multiple=ctx.pad_multiple,
             num_permuted_tokens=ctx.num_permuted_tokens,
         )
-        return dispatched_hidden, None, None, None, None
+        return dispatched_hidden, None, None, None
 
 
 if HAVE_HYBRIDEP:

--- a/tests/unit_tests/moe/test_fused_a2a.py
+++ b/tests/unit_tests/moe/test_fused_a2a.py
@@ -12,23 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for DeepEP buffer teardown (``fused_a2a.free_buffer``)."""
+"""Unit tests for fused all-to-all teardown and autograd wrappers."""
 
+import os
 from unittest import mock
 
 import pytest
+import torch
 
 import nemo_automodel.components.moe.megatron.fused_a2a as fused_a2a
 
 
 @pytest.fixture(autouse=True)
-def _restore_buffer():
-    """Save/restore the module-global ``_buffer`` so tests don't leak state."""
-    saved = fused_a2a._buffer
+def _restore_buffers():
+    """Save and restore process-global communication buffers."""
+    saved_buffer = fused_a2a._buffer
+    saved_hybrid_ep_buffer = fused_a2a._hybrid_ep_buffer
     try:
         yield
     finally:
-        fused_a2a._buffer = saved
+        fused_a2a._buffer = saved_buffer
+        fused_a2a._hybrid_ep_buffer = saved_hybrid_ep_buffer
 
 
 def test_free_buffer_destroys_and_clears():
@@ -60,3 +64,71 @@ def test_free_buffer_swallows_destroy_errors():
 
     boom.destroy.assert_called_once_with()
     assert fused_a2a._buffer is None
+
+
+def test_hybridep_combine_backward_returns_one_gradient_per_input(monkeypatch):
+    class _FakeHybridEPBuffer:
+        @staticmethod
+        def combine_with_unpermute(*, hidden, **_kwargs):
+            return hidden.clone(), None
+
+        @staticmethod
+        def dispatch_with_permute(*, hidden, **_kwargs):
+            return hidden.clone(), None, None, None, None
+
+    monkeypatch.setattr(fused_a2a, "_hybrid_ep_buffer", _FakeHybridEPBuffer())
+    x = torch.ones(2, 3, requires_grad=True)
+
+    fused_a2a.HybridEPCombine.apply(x, object(), None, None).sum().backward()
+
+    torch.testing.assert_close(x.grad, torch.ones_like(x))
+
+
+def test_hybridep_jit_cache_reuses_and_persists_kernels(monkeypatch, tmp_path):
+    monkeypatch.setenv("HYBRID_EP_CACHE_DIR", str(tmp_path))
+    jit_dir = tmp_path / ".deepep" / "hybrid_ep" / "jit"
+    stable_dir, process_dir = jit_dir / "kernel-cache", jit_dir / f"proc-{os.getpid()}"
+    os.makedirs(stable_dir)
+    cached_kernel = os.path.join(stable_dir, "cached.so")
+    with open(cached_kernel, "wb") as kernel_file:
+        kernel_file.write(b"cached")
+
+    fused_a2a._sync_hybridep_jit_cache(persist=False)
+    assert os.path.samefile(cached_kernel, os.path.join(process_dir, "cached.so"))
+
+    compiled_kernel = os.path.join(process_dir, "compiled.so")
+    with open(compiled_kernel, "wb") as kernel_file:
+        kernel_file.write(b"compiled")
+    fused_a2a._sync_hybridep_jit_cache(persist=True)
+
+    assert os.path.isfile(os.path.join(stable_dir, "compiled.so"))
+    assert not os.path.exists(process_dir)
+
+
+def test_init_hybridep_buffer_always_loads_cached_kernels(monkeypatch):
+    buffer = mock.MagicMock()
+    hybrid_ep_buffer = mock.MagicMock(return_value=buffer)
+    monkeypatch.setattr(fused_a2a, "HybridEPBuffer", hybrid_ep_buffer, raising=False)
+    monkeypatch.delenv("HYBRID_EP_CACHE_DIR", raising=False)
+
+    fused_a2a.init_hybrid_ep_buffer(
+        group=mock.MagicMock(),
+        hidden_dim=4096,
+        seq_len=4096,
+        num_local_experts=4,
+        num_sms_dispatch_api=20,
+        num_sms_combine_api=20,
+        fp8_dispatch=False,
+    )
+
+    hybrid_ep_buffer.assert_called_once_with(
+        group=mock.ANY,
+        hidden_dim=4096,
+        max_num_of_tokens_per_rank=4096,
+        num_local_experts=4,
+        use_fp8=False,
+        num_sms_dispatch_api=20,
+        num_sms_combine_api=20,
+        load_cached_kernels=True,
+    )
+    assert fused_a2a._hybrid_ep_buffer is buffer


### PR DESCRIPTION
**Consolidated into #2850.**

This PR was one layer of the DeepEP v2 upgrade stack. The stack has been collapsed
into a single PR against `main` — see **#2850**, which contains all of these commits
(signed off). This PR is closed for history only; there is no longer a stack.
