### PR TITLE
fix(speculative): keep DSpark draft RoPE inv_freq in fp32 under bf16

### DIFF
--- a/nemo_automodel/components/speculative/dspark/common.py
+++ b/nemo_automodel/components/speculative/dspark/common.py
@@ -217,6 +217,33 @@ def create_noise_embed(
     return embed_tokens(noise_ids)
 
 
+def pin_rope_inv_freq_fp32(rotary_emb: Optional[nn.Module]) -> None:
+    """Keep a RoPE module's ``inv_freq`` buffer in fp32 after a dtype cast.
+
+    ``module.to(bfloat16)`` (the training build path) rounds the rotary
+    ``inv_freq`` buffer to bf16. The rounded frequencies dephase with absolute
+    position, so the train/inference RoPE diverges (worse with longer context)
+    and draft acceptance erodes, while the serving runtime keeps an fp32 RoPE
+    cache. A bf16 round-trip cannot be undone by upcasting, so recompute fresh
+    fp32 frequencies from the rotary config (the same values HF derives on the
+    fp32 paths). No-op when ``inv_freq`` is already fp32 or on a meta device.
+    """
+    if rotary_emb is None:
+        return
+    inv_freq = getattr(rotary_emb, "inv_freq", None)
+    if inv_freq is None or not inv_freq.is_floating_point() or inv_freq.is_meta or inv_freq.dtype == torch.float32:
+        return
+    rope_init_fn = getattr(rotary_emb, "rope_init_fn", None)
+    config = getattr(rotary_emb, "config", None)
+    if rope_init_fn is None or config is None:
+        return
+    rope_kwargs = getattr(rotary_emb, "rope_kwargs", None) or {}
+    fresh, _ = rope_init_fn(config, inv_freq.device, **rope_kwargs)
+    rotary_emb.inv_freq = fresh.to(device=inv_freq.device, dtype=torch.float32)
+    if getattr(rotary_emb, "original_inv_freq", None) is not None:
+        rotary_emb.original_inv_freq = rotary_emb.inv_freq.clone()
+
+
 __all__ = [
     "DSparkForwardOutput",
     "AcceptRatePredictor",
@@ -227,4 +254,5 @@ __all__ = [
     "build_eval_mask",
     "create_position_ids",
     "create_noise_embed",
+    "pin_rope_inv_freq_fp32",
 ]

--- a/nemo_automodel/components/speculative/dspark/common.py
+++ b/nemo_automodel/components/speculative/dspark/common.py
@@ -218,30 +218,44 @@ def create_noise_embed(
 
 
 def pin_rope_inv_freq_fp32(rotary_emb: Optional[nn.Module]) -> None:
-    """Keep a RoPE module's ``inv_freq`` buffer in fp32 after a dtype cast.
+    """Keep a RoPE module's ``inv_freq`` buffers in fp32 after a dtype cast.
 
     ``module.to(bfloat16)`` (the training build path) rounds the rotary
-    ``inv_freq`` buffer to bf16. The rounded frequencies dephase with absolute
+    ``inv_freq`` buffers to bf16. The rounded frequencies dephase with absolute
     position, so the train/inference RoPE diverges (worse with longer context)
     and draft acceptance erodes, while the serving runtime keeps an fp32 RoPE
     cache. A bf16 round-trip cannot be undone by upcasting, so recompute fresh
-    fp32 frequencies from the rotary config (the same values HF derives on the
-    fp32 paths). No-op when ``inv_freq`` is already fp32 or on a meta device.
+    fp32 frequencies from a fresh rotary module built off the same config (the
+    same values HF derives on the fp32 paths) and copy them back in.
+
+    Works for both the single-buffer layout (``inv_freq`` / ``original_inv_freq``,
+    e.g. Qwen3) and the per-layer-type layout where each frequency buffer is named
+    ``<layer_type>_inv_freq`` (e.g. Gemma4). No-op when every frequency buffer is
+    already fp32 or on a meta device.
     """
     if rotary_emb is None:
         return
-    inv_freq = getattr(rotary_emb, "inv_freq", None)
-    if inv_freq is None or not inv_freq.is_floating_point() or inv_freq.is_meta or inv_freq.dtype == torch.float32:
+    # Match both ``inv_freq``/``original_inv_freq`` and ``<layer_type>_inv_freq``.
+    rounded = {
+        name: buf
+        for name, buf in rotary_emb.named_buffers(recurse=False)
+        if name.endswith("inv_freq")
+        and buf is not None
+        and buf.is_floating_point()
+        and not buf.is_meta
+        and buf.dtype != torch.float32
+    }
+    if not rounded:
         return
-    rope_init_fn = getattr(rotary_emb, "rope_init_fn", None)
     config = getattr(rotary_emb, "config", None)
-    if rope_init_fn is None or config is None:
+    if config is None:
         return
-    rope_kwargs = getattr(rotary_emb, "rope_kwargs", None) or {}
-    fresh, _ = rope_init_fn(config, inv_freq.device, **rope_kwargs)
-    rotary_emb.inv_freq = fresh.to(device=inv_freq.device, dtype=torch.float32)
-    if getattr(rotary_emb, "original_inv_freq", None) is not None:
-        rotary_emb.original_inv_freq = rotary_emb.inv_freq.clone()
+    # Rebuild a fresh module of the same type to recompute the frequencies in
+    # fp32; upcasting the rounded buffers in place cannot recover the lost bits.
+    fresh = type(rotary_emb)(config)
+    for name, fresh_buf in fresh.named_buffers(recurse=False):
+        if name in rounded:
+            setattr(rotary_emb, name, fresh_buf.to(device=rounded[name].device, dtype=torch.float32))
 
 
 __all__ = [

--- a/nemo_automodel/components/speculative/dspark/draft_gemma4.py
+++ b/nemo_automodel/components/speculative/dspark/draft_gemma4.py
@@ -40,6 +40,7 @@ from nemo_automodel.components.speculative.dspark.common import (
     build_eval_mask,
     create_noise_embed,
     create_position_ids,
+    pin_rope_inv_freq_fp32,
     sample_anchor_positions,
 )
 from nemo_automodel.components.speculative.dspark.markov_head import build_markov_head
@@ -317,6 +318,17 @@ class Gemma4DSparkModel(Gemma4PreTrainedModel):
                 input_dim += config.markov_rank
             self.confidence_head = AcceptRatePredictor(input_dim=input_dim)
         self.post_init()
+
+    def _apply(self, fn, recurse: bool = True):
+        """Keep the RoPE ``inv_freq`` buffer in fp32 across dtype casts.
+
+        ``model.to(bfloat16)`` (the training build path) would otherwise round
+        ``inv_freq`` to bf16 and dephase RoPE with absolute position, eroding
+        draft acceptance (see ``pin_rope_inv_freq_fp32``).
+        """
+        module = super()._apply(fn, recurse=recurse)
+        pin_rope_inv_freq_fp32(getattr(self, "rotary_emb", None))
+        return module
 
     def initialize_embeddings_and_head(
         self,

--- a/nemo_automodel/components/speculative/dspark/draft_qwen3.py
+++ b/nemo_automodel/components/speculative/dspark/draft_qwen3.py
@@ -37,6 +37,7 @@ from nemo_automodel.components.speculative.dspark.common import (
     build_eval_mask,
     create_noise_embed,
     create_position_ids,
+    pin_rope_inv_freq_fp32,
     sample_anchor_positions,
 )
 from nemo_automodel.components.speculative.dspark.markov_head import build_markov_head
@@ -248,6 +249,17 @@ class Qwen3DSparkModel(Qwen3PreTrainedModel):
                 input_dim += config.markov_rank
             self.confidence_head = AcceptRatePredictor(input_dim=input_dim)
         self.post_init()
+
+    def _apply(self, fn, recurse: bool = True):
+        """Keep the RoPE ``inv_freq`` buffer in fp32 across dtype casts.
+
+        ``model.to(bfloat16)`` (the training build path) would otherwise round
+        ``inv_freq`` to bf16 and dephase RoPE with absolute position, eroding
+        draft acceptance (see ``pin_rope_inv_freq_fp32``).
+        """
+        module = super()._apply(fn, recurse=recurse)
+        pin_rope_inv_freq_fp32(getattr(self, "rotary_emb", None))
+        return module
 
     def initialize_embeddings_and_head(
         self,

--- a/tests/unit_tests/speculative/test_dspark_draft.py
+++ b/tests/unit_tests/speculative/test_dspark_draft.py
@@ -207,3 +207,32 @@ def test_loss_decreases_on_fixed_batch():
         losses.append(loss.item())
 
     assert losses[-1] < losses[0], f"loss did not decrease: {losses[0]:.4f} -> {losses[-1]:.4f}"
+
+
+def test_rope_inv_freq_stays_fp32_after_bf16_cast():
+    """``model.to(bf16)`` must not round the RoPE frequencies.
+
+    The serving runtime keeps an fp32 RoPE cache; a bf16-rounded ``inv_freq``
+    dephases with absolute position, so the train/inference RoPE would diverge
+    (worse with longer context) and erode draft acceptance. The draft recomputes
+    fresh fp32 frequencies after any cast that would round them.
+    """
+    model = _build_model()  # fp32
+    ref = model.rotary_emb.inv_freq.detach().clone().float()
+
+    model = model.to(torch.bfloat16)
+    inv_freq = model.rotary_emb.inv_freq
+    # Without the fp32 pin this buffer would be bf16 (its frequencies rounded).
+    assert inv_freq.dtype == torch.float32
+    # Recomputed fresh in fp32, not a bf16 round-trip (bf16 rel. error ~1e-2).
+    assert torch.allclose(inv_freq, ref, rtol=1e-6, atol=1e-8)
+    # The pin is rope-only: the rest of the model still casts to bf16.
+    assert next(model.layers[0].parameters()).dtype == torch.bfloat16
+
+
+def test_rope_inv_freq_fp32_survives_chained_casts():
+    model = _build_model()
+    ref = model.rotary_emb.inv_freq.detach().clone().float()
+    model = model.to(torch.float16).to(torch.bfloat16)
+    assert model.rotary_emb.inv_freq.dtype == torch.float32
+    assert torch.allclose(model.rotary_emb.inv_freq, ref, rtol=1e-6, atol=1e-8)

--- a/tests/unit_tests/speculative/test_dspark_gemma4.py
+++ b/tests/unit_tests/speculative/test_dspark_gemma4.py
@@ -90,3 +90,21 @@ def test_gemma4_draft_forward_shapes():
     assert out.draft_logits.shape == (b, anchors, block, VOCAB)
     assert out.confidence_pred.shape == (b, anchors, block)
     assert torch.isfinite(out.draft_logits).all()
+
+
+def test_gemma4_rope_inv_freq_stays_fp32_after_bf16_cast():
+    """``model.to(bf16)`` must keep the Gemma4 RoPE frequencies in fp32.
+
+    A bf16-rounded ``inv_freq`` dephases with absolute position and erodes draft
+    acceptance, so the draft recomputes fresh fp32 frequencies after the cast.
+    """
+    model = _build_gemma4_draft()  # fp32
+    ref = model.rotary_emb.inv_freq.detach().clone().float()
+
+    model = model.to(torch.bfloat16)
+    inv_freq = model.rotary_emb.inv_freq
+    assert inv_freq.dtype == torch.float32
+    # Recomputed fresh in fp32, not a bf16 round-trip (bf16 rel. error ~1e-2).
+    assert torch.allclose(inv_freq, ref, rtol=1e-6, atol=1e-8)
+    # The pin is rope-only: the rest of the model still casts to bf16.
+    assert next(model.layers[0].parameters()).dtype == torch.bfloat16

--- a/tests/unit_tests/speculative/test_dspark_gemma4.py
+++ b/tests/unit_tests/speculative/test_dspark_gemma4.py
@@ -95,16 +95,22 @@ def test_gemma4_draft_forward_shapes():
 def test_gemma4_rope_inv_freq_stays_fp32_after_bf16_cast():
     """``model.to(bf16)`` must keep the Gemma4 RoPE frequencies in fp32.
 
-    A bf16-rounded ``inv_freq`` dephases with absolute position and erodes draft
-    acceptance, so the draft recomputes fresh fp32 frequencies after the cast.
+    A bf16-rounded frequency buffer dephases with absolute position and erodes
+    draft acceptance, so the draft recomputes fresh fp32 frequencies after the
+    cast. ``Gemma4TextRotaryEmbedding`` has no single ``inv_freq``; it registers
+    one ``<layer_type>_inv_freq`` buffer per layer type, so check all of them.
     """
     model = _build_gemma4_draft()  # fp32
-    ref = model.rotary_emb.inv_freq.detach().clone().float()
+    freq_names = [n for n, _ in model.rotary_emb.named_buffers(recurse=False) if n.endswith("inv_freq")]
+    assert freq_names, "expected at least one *_inv_freq buffer on the Gemma4 rotary embedding"
+    ref = {n: getattr(model.rotary_emb, n).detach().clone().float() for n in freq_names}
 
     model = model.to(torch.bfloat16)
-    inv_freq = model.rotary_emb.inv_freq
-    assert inv_freq.dtype == torch.float32
-    # Recomputed fresh in fp32, not a bf16 round-trip (bf16 rel. error ~1e-2).
-    assert torch.allclose(inv_freq, ref, rtol=1e-6, atol=1e-8)
+    for n in freq_names:
+        inv_freq = getattr(model.rotary_emb, n)
+        # Without the fp32 pin this buffer would be bf16 (its frequencies rounded).
+        assert inv_freq.dtype == torch.float32, n
+        # Recomputed fresh in fp32, not a bf16 round-trip (bf16 rel. error ~1e-2).
+        assert torch.allclose(inv_freq, ref[n], rtol=1e-6, atol=1e-8), n
     # The pin is rope-only: the rest of the model still casts to bf16.
     assert next(model.layers[0].parameters()).dtype == torch.bfloat16


### PR DESCRIPTION
## What

The DSpark Qwen3 and Gemma4 draft models are cast to bfloat16 on the training
build path (`train_dspark.py` builds the draft with
`.to(device=..., dtype=compute_dtype)`, and `compute_dtype` is bf16 on CUDA).
That cast rounds the rotary `inv_freq` buffer to bf16, and the rotary forward
only up-casts it (`self.inv_freq.float()`), which cannot recover the lost bits.
The rounded frequencies dephase with absolute position, so the train/inference
RoPE diverges (worse with longer context) and draft acceptance erodes, while the
serving runtime keeps an fp32 RoPE cache.

The sibling DFlash draft already guards against this
(`Qwen3DFlashDraftModel._apply` + `test_rope_inv_freq_stays_fp32_after_bf16_cast`);
the DSpark drafts did not.

## Fix

- Add a shared `pin_rope_inv_freq_fp32` helper in `dspark/common.py` that
  recomputes fresh fp32 frequencies from the rotary config via `rope_init_fn`
  (the same recompute pattern already used in `checkpointing.py` and
  `hf_utils.py`), so it covers both `Qwen3RotaryEmbedding` and
  `Gemma4TextRotaryEmbedding`.
- Call it from an `_apply` override on `Qwen3DSparkModel` and
  `Gemma4DSparkModel`, so any dtype cast keeps `inv_freq` in fp32.

## Tests

- `test_rope_inv_freq_stays_fp32_after_bf16_cast` and
  `test_rope_inv_freq_fp32_survives_chained_casts` (Qwen3) plus
  `test_gemma4_rope_inv_freq_stays_fp32_after_bf16_cast` (Gemma4) assert that
  `inv_freq` stays fp32 and bit-exact against the fp32 reference after a bf16
  cast, while the rest of the model still casts to bf16. They fail before this
  change (the buffer ends up bf16).

Signed-off-by: khazic <khazzz1c@gmail.com>
