### PR TITLE
ci(automodel): set AM-576 release timeouts

### DIFF
--- a/examples/llm_finetune/deepseek_v4/deepseek_v4_pro_hellaswag_all_tilelang_pp8_ep64_20steps.yaml
+++ b/examples/llm_finetune/deepseek_v4/deepseek_v4_pro_hellaswag_all_tilelang_pp8_ep64_20steps.yaml
@@ -134,6 +134,5 @@ ci:
   # pp_size(8) * ep_size(64) = 512 GPUs => 64 nodes (8 H100/node).
   recipe_owner: hemildesai
   nodes: 64
-  max_steps: 20
   # Cold multi-node start + TileLang JIT runs past the 00:10:00 default.
   time: "00:35:00"

--- a/examples/llm_finetune/deepseek_v4/deepseek_v4_pro_hellaswag_all_tilelang_pp8_ep64_20steps.yaml
+++ b/examples/llm_finetune/deepseek_v4/deepseek_v4_pro_hellaswag_all_tilelang_pp8_ep64_20steps.yaml
@@ -136,4 +136,4 @@ ci:
   nodes: 64
   max_steps: 20
   # Cold multi-node start + TileLang JIT runs past the 00:10:00 default.
-  time: "00:30:00"
+  time: "00:35:00"

--- a/examples/llm_finetune/deepseek_v4/deepseek_v4_pro_hellaswag_all_tilelang_pp8_ep64_20steps.yaml
+++ b/examples/llm_finetune/deepseek_v4/deepseek_v4_pro_hellaswag_all_tilelang_pp8_ep64_20steps.yaml
@@ -134,5 +134,6 @@ ci:
   # pp_size(8) * ep_size(64) = 512 GPUs => 64 nodes (8 H100/node).
   recipe_owner: hemildesai
   nodes: 64
+  max_steps: 20
   # Cold multi-node start + TileLang JIT runs past the 00:10:00 default.
   time: "00:30:00"

--- a/examples/llm_finetune/glm/glm_5.1_lora.yaml
+++ b/examples/llm_finetune/glm/glm_5.1_lora.yaml
@@ -110,3 +110,4 @@ ci:
   # pp_size(4) * ep_size(32) = 128 GPUs => 16 nodes (8 H100/node).
   recipe_owner: hemildesai
   nodes: 16
+  time: "00:30:00"

--- a/examples/llm_finetune/glm/glm_5.1_lora.yaml
+++ b/examples/llm_finetune/glm/glm_5.1_lora.yaml
@@ -110,4 +110,4 @@ ci:
   # pp_size(4) * ep_size(32) = 128 GPUs => 16 nodes (8 H100/node).
   recipe_owner: hemildesai
   nodes: 16
-  time: "00:30:00"
+  time: "00:20:00"

--- a/examples/llm_finetune/ling/ling_flash_2_0_sft.yaml
+++ b/examples/llm_finetune/ling/ling_flash_2_0_sft.yaml
@@ -106,3 +106,4 @@ ci:
   # pp_size(1) * ep_size(32) = 32 GPUs => 4 nodes (8 H100/node).
   recipe_owner: akoumpa
   nodes: 4
+  time: "00:30:00"

--- a/examples/llm_finetune/ling/ling_flash_2_0_sft.yaml
+++ b/examples/llm_finetune/ling/ling_flash_2_0_sft.yaml
@@ -106,4 +106,4 @@ ci:
   # pp_size(1) * ep_size(32) = 32 GPUs => 4 nodes (8 H100/node).
   recipe_owner: akoumpa
   nodes: 4
-  time: "00:30:00"
+  time: "00:15:00"

--- a/examples/llm_finetune/mistral/mistral_7b_hellaswag_fp8.yaml
+++ b/examples/llm_finetune/mistral/mistral_7b_hellaswag_fp8.yaml
@@ -118,3 +118,4 @@ optimizer:
 
 ci:
   recipe_owner: HuiyingLi
+  time: "00:20:00"

--- a/examples/llm_finetune/mistral/mistral_7b_hellaswag_fp8.yaml
+++ b/examples/llm_finetune/mistral/mistral_7b_hellaswag_fp8.yaml
@@ -118,4 +118,4 @@ optimizer:
 
 ci:
   recipe_owner: HuiyingLi
-  time: "00:20:00"
+  time: "00:15:00"

--- a/examples/vlm_finetune/gemma3n/gemma3n_vl_4b_medpix_peft.yaml
+++ b/examples/vlm_finetune/gemma3n/gemma3n_vl_4b_medpix_peft.yaml
@@ -117,3 +117,4 @@ freeze_config:
 
 ci:
   recipe_owner: akoumpa
+  time: "00:15:00"

--- a/examples/vlm_finetune/gemma4/gemma4_26b_a4b_moe_mock.yaml
+++ b/examples/vlm_finetune/gemma4/gemma4_26b_a4b_moe_mock.yaml
@@ -96,3 +96,7 @@ freeze_config:
   freeze_vision_tower: true
   freeze_audio_tower: true
   freeze_language_model: false
+
+ci:
+  recipe_owner: athitten
+  time: "00:20:00"

--- a/examples/vlm_finetune/gemma4/gemma4_26b_a4b_moe_mock.yaml
+++ b/examples/vlm_finetune/gemma4/gemma4_26b_a4b_moe_mock.yaml
@@ -99,4 +99,4 @@ freeze_config:
 
 ci:
   recipe_owner: athitten
-  time: "00:20:00"
+  time: "00:15:00"

--- a/examples/vlm_finetune/gemma4/gemma4_31b_peft.yaml
+++ b/examples/vlm_finetune/gemma4/gemma4_31b_peft.yaml
@@ -121,3 +121,4 @@ freeze_config:
 
 ci:
   recipe_owner: athitten
+  time: "00:20:00"

--- a/examples/vlm_finetune/gemma4/gemma4_31b_peft.yaml
+++ b/examples/vlm_finetune/gemma4/gemma4_31b_peft.yaml
@@ -121,4 +121,4 @@ freeze_config:
 
 ci:
   recipe_owner: athitten
-  time: "00:20:00"
+  time: "00:15:00"

--- a/examples/vlm_finetune/gemma4_joint_drafter/gemma4_4b_joint_drafter_medpix.yaml
+++ b/examples/vlm_finetune/gemma4_joint_drafter/gemma4_4b_joint_drafter_medpix.yaml
@@ -144,3 +144,4 @@ freeze_config:
 
 ci:
   recipe_owner: athitten
+  time: "00:15:00"

--- a/examples/vlm_finetune/kimi/kimi2vl_cordv2.yaml
+++ b/examples/vlm_finetune/kimi/kimi2vl_cordv2.yaml
@@ -123,3 +123,4 @@ freeze_config:
 
 ci:
   recipe_owner: akoumpa
+  time: "00:15:00"

--- a/examples/vlm_finetune/mistral/ministral3_3b_medpix.yaml
+++ b/examples/vlm_finetune/mistral/ministral3_3b_medpix.yaml
@@ -103,3 +103,4 @@ freeze_config:
 
 ci:
   recipe_owner: akoumpa
+  time: "00:15:00"

--- a/examples/vlm_finetune/nemotron_omni/nemotron_omni_cord_v2_peft.yaml
+++ b/examples/vlm_finetune/nemotron_omni/nemotron_omni_cord_v2_peft.yaml
@@ -116,3 +116,7 @@ optimizer:
   lr: 1e-3
   weight_decay: 0.01
   betas: [0.9, 0.95]
+
+ci:
+  recipe_owner: HuiyingLi
+  time: "00:30:00"

--- a/examples/vlm_finetune/nemotron_omni/nemotron_omni_cord_v2_peft.yaml
+++ b/examples/vlm_finetune/nemotron_omni/nemotron_omni_cord_v2_peft.yaml
@@ -119,4 +119,4 @@ optimizer:
 
 ci:
   recipe_owner: HuiyingLi
-  time: "00:30:00"
+  time: "00:15:00"

--- a/examples/vlm_finetune/qwen3/qwen3_vl_4b_neat_packing.yaml
+++ b/examples/vlm_finetune/qwen3/qwen3_vl_4b_neat_packing.yaml
@@ -103,4 +103,4 @@ freeze_config:
 
 ci:
   recipe_owner: HuiyingLi
-  time: "00:30:00"
+  time: "00:15:00"

--- a/examples/vlm_finetune/qwen3/qwen3_vl_4b_neat_packing.yaml
+++ b/examples/vlm_finetune/qwen3/qwen3_vl_4b_neat_packing.yaml
@@ -103,3 +103,4 @@ freeze_config:
 
 ci:
   recipe_owner: HuiyingLi
+  time: "00:30:00"

--- a/examples/vlm_finetune/qwen3_5_moe/qwen3_5_35b_neat_packing.yaml
+++ b/examples/vlm_finetune/qwen3_5_moe/qwen3_5_35b_neat_packing.yaml
@@ -130,9 +130,9 @@ optimizer:
   weight_decay: 0.1
 
 ci:
-  time: "00:15:00"
-  env_vars:
-    MAX_STEPS: 10
+  recipe_owner: HuiyingLi
+  max_steps: 10
+  time: "00:30:00"
 
 # wandb:
 #   project: <your_wandb_project>

--- a/examples/vlm_finetune/qwen3_5_moe/qwen3_5_35b_neat_packing.yaml
+++ b/examples/vlm_finetune/qwen3_5_moe/qwen3_5_35b_neat_packing.yaml
@@ -132,7 +132,7 @@ optimizer:
 ci:
   recipe_owner: HuiyingLi
   max_steps: 10
-  time: "00:30:00"
+  time: "00:20:00"
 
 # wandb:
 #   project: <your_wandb_project>

--- a/examples/vlm_finetune/qwen3_5_moe/qwen3_6_35b_lora.yaml
+++ b/examples/vlm_finetune/qwen3_5_moe/qwen3_6_35b_lora.yaml
@@ -130,4 +130,4 @@ optimizer:
 
 ci:
   recipe_owner: HuiyingLi
-  time: "00:30:00"
+  time: "00:15:00"

--- a/examples/vlm_finetune/qwen3_5_moe/qwen3_6_35b_lora.yaml
+++ b/examples/vlm_finetune/qwen3_5_moe/qwen3_6_35b_lora.yaml
@@ -127,3 +127,7 @@ optimizer:
 #   project: <your_wandb_project>
 #   entity: <your_wandb_entity>
 #   name: <your_wandb_name>
+
+ci:
+  recipe_owner: HuiyingLi
+  time: "00:30:00"


### PR DESCRIPTION
## Summary

Fixes AM-576 by adding explicit release CI metadata for the 14 affected recipe configs, while keeping the walltime increases bounded.

Timeout policy after log comparison:

- `35m`: only DeepSeek V4 Pro 64-node TileLang case. Its observed Slurm walltime was around 27-30m, so `30m` was too close for startup/container variance. It keeps the standard release CI step behavior with no `MAX_STEPS` override.
- `20m`: GLM 5.1 LoRA and Qwen3.5 35B neat-packing. GLM passed close to the 15m boundary; Qwen3.5 had already timed out with a 15m budget. Qwen3.5 keeps `MAX_STEPS=10`, matching prior release behavior.
- `15m`: the remaining affected recipes. Their original failures were around the old 10m default, and failed-vs-rerun logs did not show a steady-state training regression.

## Validation

Local checks passed on this branch:

- `uv run python tools/lint_example_yamls.py --automodel-dir /Users/yuhez/Desktop/NVIDIA-NeMo/Automodel`
- `uv run python tests/ci_tests/utils/validate_nightly_recipes.py --automodel-dir /Users/yuhez/Desktop/NVIDIA-NeMo/Automodel`
- `uv run python tests/ci_tests/utils/validate_generate_ci.py --automodel-dir /Users/yuhez/Desktop/NVIDIA-NeMo/Automodel`
- Generated release metadata assertion: all checked affected jobs emit the intended `TIME`; DeepSeek emits `TIME=00:35:00` with no `MAX_STEPS` override; Qwen3.5 neat-packing emits `TIME=00:20:00` and `MAX_STEPS=10`.

Current scoped CI rerun for this commit (`32f70455ea5fbe0a77776c265c7e3b53ad4eee42`) has been triggered:

- LLM release parent/API pipeline: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/56494559
- VLM release parent/API pipeline: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/56494575

Prior scoped PR CI passed before timeout tightening:

- LLM release, 4/4 passed: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/56394339
- VLM release, 10/10 passed: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/56394324

Timing evidence checked:

- Original AM-576 failed job logs from Linear.
- Prior release pipelines: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/56099816 and https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/56099801.
- Alex same-SHA/container rerun: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/56398923 and https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/56398898.

Fixes AM-576.
