### PR TITLE
ci: use NVIDIA inference for Claude review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -12,8 +12,9 @@ permissions:
 
 jobs:
   claude-review:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_claude_review.yml@v0.88.0
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_claude_review.yml@v1.7.0
     with:
+      model: ${{ vars.CLAUDE_MODEL }}
       prompt: |
         Mandatory workflow — never skip or reorder:
         1. Read the PR diff first.
@@ -71,4 +72,5 @@ jobs:
         It's perfectly acceptable to not have anything to comment on.
         If you do not have anything to comment on, post "LGTM".
     secrets:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      NVIDIA_INFERENCE_URL: ${{ secrets.NVIDIA_INFERENCE_URL }}
+      NVIDIA_INFERENCE_KEY: ${{ secrets.NVIDIA_INFERENCE_KEY }}


### PR DESCRIPTION
# What does this PR do ?

Updates the Claude review workflow to use the released FW-CI-templates `v1.7.0` NVIDIA inference configuration.

# Changelog

- Bump `_claude_review.yml` usage to `NVIDIA-NeMo/FW-CI-templates@v1.7.0`.
- Pass `vars.CLAUDE_MODEL` to the reusable workflow.
- Pass `secrets.NVIDIA_INFERENCE_URL` and `secrets.NVIDIA_INFERENCE_KEY` instead of `secrets.ANTHROPIC_API_KEY`.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Did you write any new necessary tests? N/A, workflow secret/tag update only.
- [x] Did you add or update any necessary documentation? N/A.

# Additional Information

- Linear: AUT-644