### PR TITLE
fix(bagel): torch2.12 DTensor sharding-prop leak

### DIFF
--- a/examples/multimodal_finetune/bagel/bagel_sft.yaml
+++ b/examples/multimodal_finetune/bagel/bagel_sft.yaml
@@ -145,6 +145,14 @@ optimizer:
   betas: [0.9, 0.95]
   eps: 1.0e-15
   weight_decay: 0.0
+  # foreach=false: on torch>=2.12, AdamW's _foreach_* ops over FSDP2-sharded (DTensor) params
+  # are re-planned by DTensor's sharding propagator every step via the *uncached* path (a
+  # foreach op's list argument isn't cached), leaking OpStrategy/OpSpec + FakeTensor dispatch-
+  # cache entries (~19.6k Python objects/step -> growing gen-2 GC pauses -> throughput sinks
+  # monotonically over a run). Single-tensor ops (foreach=false) hit the sharding cache, so
+  # nothing accumulates; the optimizer is a tiny slice of step time, so the cost is ~0.8%.
+  # Remove once the DTensor foreach path is fixed upstream.
+  foreach: false
 
 lr_scheduler:
   schedule: constant

--- a/examples/multimodal_pretrain/bagel/bagel_pretrain.yaml
+++ b/examples/multimodal_pretrain/bagel/bagel_pretrain.yaml
@@ -149,6 +149,14 @@ optimizer:
   betas: [0.9, 0.95]
   eps: 1.0e-15
   weight_decay: 0.0
+  # foreach=false: on torch>=2.12, AdamW's _foreach_* ops over FSDP2-sharded (DTensor) params
+  # are re-planned by DTensor's sharding propagator every step via the *uncached* path (a
+  # foreach op's list argument isn't cached), leaking OpStrategy/OpSpec + FakeTensor dispatch-
+  # cache entries (~19.6k Python objects/step -> growing gen-2 GC pauses -> throughput sinks
+  # monotonically over a run). Single-tensor ops (foreach=false) hit the sharding cache, so
+  # nothing accumulates; the optimizer is a tiny slice of step time, so the cost is ~0.8%.
+  # Remove once the DTensor foreach path is fixed upstream.
+  foreach: false
 
 lr_scheduler:
   schedule: constant


### PR DESCRIPTION
# What does this PR do ?

On torch>=2.12, AdamW's _foreach_* ops over FSDP2-sharded (DTensor) params are re-planned by DTensor's sharding propagator every step via the *uncached* path (a foreach op's list argument isn't cached). This rebuilds OpStrategy/OpSpec and grows the FakeTensorMode dispatch cache without bound (~19.6k retained Python objects/step), lengthening gen-2 GC pauses so per-step throughput sinks monotonically over a run (observed on 8xH100 pretrain: TPS floor ~36k->19k, CV 3%->16%).

Setting foreach=false routes the optimizer through single-tensor ops whose op-schema is small and stable, so DTensor's sharding-propagation cache hits every step and nothing accumulates. Validated: live objects flat (~1.1M vs 18.7M), CV ~2.9%, zero slow steps, mean TPS within ~0.8% of the pre-regression (old-container) baseline. Workaround for an upstream torch DTensor issue; revert once foreach ops are cached/decomposed there.

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
