### PR TITLE
fix(speculative): make save_consolidated final export the last EAGLE checkpoint

### DIFF
--- a/nemo_automodel/recipes/llm/train_eagle1.py
+++ b/nemo_automodel/recipes/llm/train_eagle1.py
@@ -356,12 +356,17 @@ class TrainEagle1Recipe(BaseRecipe):
         train_loss: float | None = None,
         val_loss: dict[str, float] | None = None,
         best_metric_key: str = "default",
+        is_final_checkpoint: bool = False,
     ) -> None:
         """Persist draft model, optimizer, scheduler, RNG, and EAGLE meta.
 
         Overrides ``BaseRecipe.save_checkpoint`` because EAGLE recipes hold multiple
         ``nn.Module`` attributes (frozen target, target wrapper, trainer module wrapping
         the draft) — only ``draft_model`` should be persisted as the main model.
+
+        ``is_final_checkpoint`` is computed by the caller (this hand-rolled loop
+        has no ``step_scheduler`` for the checkpointer to infer it from);
+        ``save_consolidated: final`` exports HF safetensors only when it is True.
         """
         checkpointer = getattr(self, "checkpointer", None)
         if checkpointer is None or not checkpointer.config.enabled:
@@ -409,8 +414,6 @@ class TrainEagle1Recipe(BaseRecipe):
         if is_dist_initialized:
             dist.barrier()
 
-        step_scheduler = getattr(self, "step_scheduler", None)
-        is_final_checkpoint = bool(getattr(step_scheduler, "is_last_step", False))
         draft_model = self._module().draft_model
         self.checkpointer.save_model(
             draft_model,
@@ -460,12 +463,15 @@ class TrainEagle1Recipe(BaseRecipe):
         every = getattr(self, "ckpt_every_steps", None)
         if every is None or every <= 0 or self.runtime.global_step % every != 0:
             return False
+        total_optim_steps = getattr(self, "total_optim_steps", None)
+        is_final_checkpoint = total_optim_steps is not None and self.runtime.global_step >= total_optim_steps
         self.save_checkpoint(
             epoch=epoch,
             step=self.runtime.global_step,
             train_loss=None,
             val_loss=None,
             best_metric_key="val_loss",
+            is_final_checkpoint=is_final_checkpoint,
         )
         self._log_saved_checkpoint("step", epoch, self.runtime.global_step)
         return True
@@ -494,6 +500,7 @@ class TrainEagle1Recipe(BaseRecipe):
             train_loss=None,
             val_loss=None,
             best_metric_key="val_loss",
+            is_final_checkpoint=True,
         )
         self._log_saved_checkpoint("final", completed_epochs, gs)
         return True
@@ -794,6 +801,7 @@ class TrainEagle1Recipe(BaseRecipe):
                         train_loss=avg_loss,
                         val_loss=eval_metrics,
                         best_metric_key="val_loss",
+                        is_final_checkpoint=epoch_idx + 1 >= self.num_epochs,
                     )
 
             self._maybe_save_final_checkpoint(self.num_epochs)

--- a/nemo_automodel/recipes/llm/train_eagle3.py
+++ b/nemo_automodel/recipes/llm/train_eagle3.py
@@ -866,6 +866,7 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
         train_loss: float | None = None,
         val_loss: dict[str, float] | None = None,
         best_metric_key: str = "default",
+        is_final_checkpoint: bool = False,
     ) -> None:
         """Persist draft model, optimizer, scheduler, RNG, and EAGLE-3 meta.
 
@@ -873,6 +874,10 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
         ``nn.Module`` attributes (frozen target, target wrapper, trainer module wrapping
         the draft) — only ``draft_model`` should be persisted as the main model. The
         EAGLE-3 vocab mapping tensors ride along through ``_save_extra_state``.
+
+        ``is_final_checkpoint`` is computed by the caller (this hand-rolled loop
+        has no ``step_scheduler`` for the checkpointer to infer it from);
+        ``save_consolidated: final`` exports HF safetensors only when it is True.
         """
         checkpointer = getattr(self, "checkpointer", None)
         if checkpointer is None or not checkpointer.config.enabled:
@@ -920,8 +925,6 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
         if is_dist_initialized:
             dist.barrier()
 
-        step_scheduler = getattr(self, "step_scheduler", None)
-        is_final_checkpoint = bool(getattr(step_scheduler, "is_last_step", False))
         draft_model = self._module().draft_model
         self.checkpointer.save_model(
             draft_model,
@@ -971,12 +974,15 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
         every = getattr(self, "ckpt_every_steps", None)
         if every is None or every <= 0 or self.runtime.global_step % every != 0:
             return False
+        total_optim_steps = getattr(self, "total_optim_steps", None)
+        is_final_checkpoint = total_optim_steps is not None and self.runtime.global_step >= total_optim_steps
         self.save_checkpoint(
             epoch=epoch,
             step=self.runtime.global_step,
             train_loss=None,
             val_loss=None,
             best_metric_key="val_loss",
+            is_final_checkpoint=is_final_checkpoint,
         )
         self._log_saved_checkpoint("step", epoch, self.runtime.global_step)
         return True
@@ -1005,6 +1011,7 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
             train_loss=None,
             val_loss=None,
             best_metric_key="val_loss",
+            is_final_checkpoint=True,
         )
         self._log_saved_checkpoint("final", completed_epochs, gs)
         return True
@@ -1373,6 +1380,7 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
                     train_loss=None,
                     val_loss=val_loss_dict,
                     best_metric_key="val_loss",
+                    is_final_checkpoint=epoch + 1 >= self.num_epochs,
                 )
                 self._log_saved_checkpoint("epoch", epoch + 1, self.runtime.global_step)
 

--- a/tests/unit_tests/recipes/llm/test_eagle_step_checkpoint.py
+++ b/tests/unit_tests/recipes/llm/test_eagle_step_checkpoint.py
@@ -28,6 +28,7 @@ the added ``ckpt_every_steps`` (save every N optimizer steps) and
 from __future__ import annotations
 
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 import torch
@@ -44,13 +45,14 @@ RECIPE_CLASSES = [TrainEagle1Recipe, TrainEagle3Recipe]
 # ---------------------------------------------------------------------------
 
 
-def _helper_self(ckpt_every_steps, global_step):
+def _helper_self(ckpt_every_steps, global_step, total_optim_steps=None):
     """A minimal stand-in carrying just the attributes the helper reads."""
     calls = []
     return (
         SimpleNamespace(
             ckpt_every_steps=ckpt_every_steps,
             runtime=SimpleNamespace(global_step=global_step),
+            total_optim_steps=total_optim_steps,
             dist_env=SimpleNamespace(is_main=True),
             checkpoint_config=None,
             save_checkpoint=lambda **kw: calls.append(kw),
@@ -98,6 +100,22 @@ def test_maybe_save_step_checkpoint_missing_attr_is_noop(recipe_cls):
     assert recipe_cls._maybe_save_step_checkpoint(obj, epoch=0) is False
 
 
+@pytest.mark.parametrize("recipe_cls", RECIPE_CLASSES)
+@pytest.mark.parametrize(
+    "total,step,expect_final",
+    [
+        (None, 4, False),  # unknown total (e.g. unsized dataloader) -> never final
+        (6, 4, False),  # mid-run step save
+        (4, 4, True),  # save lands exactly on the last optimizer step
+    ],
+)
+def test_step_checkpoint_final_flag_tracks_total_optim_steps(recipe_cls, total, step, expect_final):
+    """The step save's final flag tracks ``total_optim_steps``."""
+    obj, calls = _helper_self(2, step, total_optim_steps=total)
+    assert recipe_cls._maybe_save_step_checkpoint(obj, epoch=0) is True
+    assert calls[0]["is_final_checkpoint"] is expect_final
+
+
 def _final_self(ckpt_every_steps, save_every_epoch, global_step):
     calls = []
     return (
@@ -133,6 +151,7 @@ def test_final_checkpoint_fires_unless_final_step_already_saved(recipe_cls, ever
     if should_fire:
         assert calls[0]["epoch"] == 3
         assert calls[0]["step"] == gs
+        assert calls[0]["is_final_checkpoint"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -204,7 +223,7 @@ def _build_eagle1_recipe(num_batches, grad_accum, num_epochs, ckpt_every_steps, 
     recipe.lr_scheduler = torch.optim.lr_scheduler.LambdaLR(recipe.optimizer, lambda s: 1.0)
 
     saves = []
-    recipe.save_checkpoint = lambda **kw: saves.append((kw["epoch"], kw["step"], kw["val_loss"] is not None))
+    recipe.save_checkpoint = lambda **kw: saves.append((kw["epoch"], kw["step"], kw["is_final_checkpoint"]))
     return recipe, saves
 
 
@@ -234,13 +253,13 @@ def test_save_checkpoint_every_epoch_false_skips_epoch_save():
 
 def test_only_final_checkpoint_when_both_unset():
     # Neither cadence set -> exactly one save, at the end of the whole run,
-    # labeled with num_epochs and the final global_step.
+    # labeled with num_epochs and the final global_step, flagged final.
     recipe, saves = _build_eagle1_recipe(
         num_batches=6, grad_accum=2, num_epochs=2, ckpt_every_steps=None, save_every_epoch=False
     )
     recipe.run_train_validation_loop()
     assert recipe.runtime.global_step == 6
-    assert saves == [(2, 6, False)]
+    assert saves == [(2, 6, True)]
 
 
 def test_step_only_saves_final_when_last_step_off_cadence():
@@ -252,7 +271,8 @@ def test_step_only_saves_final_when_last_step_off_cadence():
     )
     recipe.run_train_validation_loop()
     assert recipe.runtime.global_step == 3
-    assert [(e, s) for (e, s, _) in saves] == [(0, 2), (1, 3)]
+    # only the safety-net save is final; the mid-epoch step save is not
+    assert saves == [(0, 2, False), (1, 3, True)]
 
 
 def test_step_only_no_final_duplicate_when_last_step_on_cadence():
@@ -263,7 +283,8 @@ def test_step_only_no_final_duplicate_when_last_step_on_cadence():
     )
     recipe.run_train_validation_loop()
     assert recipe.runtime.global_step == 3
-    assert [(e, s) for (e, s, _) in saves] == [(0, 3)]
+    # the on-cadence save IS the run's last checkpoint, so it must be final
+    assert saves == [(0, 3, True)]
 
 
 def test_only_epoch_checkpoints_no_final_duplicate():
@@ -274,5 +295,40 @@ def test_only_epoch_checkpoints_no_final_duplicate():
     )
     recipe.run_train_validation_loop()
     assert recipe.runtime.global_step == 6
-    # one save per epoch boundary, labeled epoch+1, never a num_epochs final extra
-    assert [(e, s) for (e, s, _) in saves] == [(1, 3), (2, 6)]
+    # one save per epoch boundary, labeled epoch+1, never a num_epochs final
+    # extra; only the last epoch's save is flagged final
+    assert saves == [(1, 3, False), (2, 6, True)]
+
+
+# ---------------------------------------------------------------------------
+# save_checkpoint forwards is_final_checkpoint to the checkpointer
+# ---------------------------------------------------------------------------
+
+
+def _saving_recipe(recipe_cls, tmp_path):
+    """A recipe stub with just enough state to run the real ``save_checkpoint``."""
+    recipe = recipe_cls.__new__(recipe_cls)
+    recipe.checkpointer = MagicMock()
+    recipe.checkpointer.config = SimpleNamespace(enabled=True, is_async=False)
+    recipe.checkpoint_config = SimpleNamespace(checkpoint_dir=str(tmp_path))
+    recipe.tokenizer = object()
+    recipe.optimizer = MagicMock()
+    recipe.lr_scheduler = MagicMock()
+    recipe.rng = MagicMock()
+    recipe._module = lambda: SimpleNamespace(draft_model=nn.Linear(2, 2))
+    recipe._save_extra_state = lambda path, epoch: None
+    recipe._update_latest_symlink = lambda path: None
+    recipe.cfg = SimpleNamespace()  # no raw_config -> the config snapshot is skipped
+    return recipe
+
+
+@pytest.mark.parametrize("recipe_cls", RECIPE_CLASSES)
+@pytest.mark.parametrize("is_final", [True, False])
+def test_save_checkpoint_forwards_final_flag_to_checkpointer(recipe_cls, is_final, tmp_path):
+    """Regression: ``save_checkpoint`` used to derive the flag from a
+    ``step_scheduler`` attribute these hand-rolled recipes never set, so the
+    checkpointer never saw ``is_final_checkpoint=True`` and
+    ``save_consolidated: final`` never exported the HF safetensors."""
+    recipe = _saving_recipe(recipe_cls, tmp_path)
+    recipe.save_checkpoint(epoch=1, step=5, is_final_checkpoint=is_final)
+    assert recipe.checkpointer.save_model.call_args.kwargs["is_final_checkpoint"] is is_final

--- a/tests/unit_tests/recipes/llm/test_train_eagle3_flush.py
+++ b/tests/unit_tests/recipes/llm/test_train_eagle3_flush.py
@@ -291,3 +291,15 @@ def test_progress_bar_advances_per_optim_step(tmp_path, monkeypatch):
     assert fake.n == recipe.runtime.global_step == 2
     assert fake.closed
     assert set(fake.postfix) == {"loss", "acc", "lr"}
+
+
+def test_epoch_save_final_flag_only_on_last_epoch(tmp_path):
+    """With ``save_checkpoint_every_epoch`` over multiple epochs, only the last
+    epoch's save is the run's final checkpoint -- ``save_consolidated: final``
+    keys its HF safetensors export off that flag."""
+    recipe = _build_recipe(tmp_path, num_samples=4, grad_accum=2, num_epochs=2)
+    recipe.save_checkpoint_every_epoch = True
+    saves = []
+    recipe.save_checkpoint = lambda **kw: saves.append((kw["epoch"], kw["is_final_checkpoint"]))
+    recipe.run_train_validation_loop()
+    assert saves == [(1, False), (2, True)]


### PR DESCRIPTION
## What does this PR do?

Fixes `checkpoint.save_consolidated: final` being dead in the EAGLE-1/2/3 recipes.

`save_checkpoint` in `train_eagle1.py` and `train_eagle3.py` derived the flag from `getattr(self, "step_scheduler", None)`, but these recipes hand-roll their training loops and never assign that attribute, so `is_final_checkpoint` was always `False`. With `save_consolidated: final` (the natural setting to avoid exporting HF weights on every intermediate save), the consolidated safetensors export was skipped on every save including the end-of-run one: a finished run left only sharded DCP checkpoints, nothing vLLM or SGLang could load, and no warning (`_maybe_log_final_offline_consolidation_hint` only fires for `save_consolidated: false`). The default `save_consolidated: true` used by the example configs masks the bug, which is why it went unnoticed. EAGLE-2 inherits from EAGLE-1, so it was affected too.

## Fix

Replace the dead lookup with an explicit `is_final_checkpoint` parameter computed at each call site, mirroring the pattern `train_dflash.py` and `train_dspark.py` already use:

- step-cadence saves compare `runtime.global_step` against `self.total_optim_steps` (already stored by `setup` for the LR schedule), so an on-cadence save landing on the last optimizer step carries the flag;
- the `save_checkpoint_every_epoch` save flags the last epoch;
- the end-of-run safety-net save (`_maybe_save_final_checkpoint`) passes `True`.

## Tests

Extended `tests/unit_tests/recipes/llm/test_eagle_step_checkpoint.py` and `test_train_eagle3_flush.py`:

- helper level: the step save's final flag tracks `total_optim_steps` (unknown total, mid-run, exact-boundary cases) and the safety-net save always passes `True`, parametrized over both recipe classes;
- `save_checkpoint` level: the real method forwards the flag to `checkpointer.save_model` for both recipes (the direct regression for the dead `step_scheduler` read);
- loop level: driven through both recipes' real training loops, only the run's last save carries the flag, across step-cadence, epoch-cadence, and no-cadence configurations.