### PR TITLE
docs(fern): add reusable prose style guidance

### DIFF
--- a/.agents/contributor-skills/fern-docs/SKILL.md
+++ b/.agents/contributor-skills/fern-docs/SKILL.md
@@ -181,6 +181,22 @@ import { BadgeLinks } from "@/components/BadgeLinks";
 
 Page-scoped images live alongside the MDX file (e.g. `docs/guides/audio/qwen_omni_asr.png`). Reference them with relative paths (`./image.png`), not absolute (`/image.png`) — Fern's path resolver doesn't normalize root-relative image paths the same way as link targets. The NVIDIA logos and favicon come from the `nvidia` global theme; do not add them locally.
 
+### Prose Style
+
+Use this checklist for prose added or substantively edited by the current task before sending docs PRs for tech-pubs
+review. Do not rewrite unrelated existing lines solely to apply these preferences; keep broader copy editing in a
+dedicated docs PR.
+
+- For new or substantively edited cross-doc pointers, prefer `Refer to ...` when it reads naturally. Do not
+  mechanically replace every use of `See` or `See also`.
+- Drop polite filler such as `please` from procedural instructions.
+- Use active, present-tense verbs for deterministic steps: `This script downloads...`, not `This script will download...`.
+- Use `and`, not `&`, in headings and section labels.
+- Write task-oriented, Title Case headings, such as `Run the Training Pipeline` or `Download and Prepare the Dataset`.
+- Label examples explicitly, such as `JSONL example (one example per line):` or `Training file example (single JSON):`.
+- Keep product and modality capitalization consistent: `NeMo AutoModel`, `LLM`, `VLM`, `Diffusion Models`.
+- For overview and index pages, make quick links and guide lists representative across all supported task families.
+
 ## Frontmatter
 
 ```yaml


### PR DESCRIPTION
# What does this PR do?

Records reusable tech-pubs prose conventions in the existing Fern contributor skill. The checklist applies to prose added or substantively edited by the current task; it does not authorize drive-by rewrites of unrelated existing lines.

# Changelog

- Prefer `Refer to` for new or substantively edited cross-document pointers when it reads naturally, without mechanically replacing every use of `See` or `See also`.
- Remove polite filler and favor active present tense in newly written or substantively revised procedural text.
- Favor Title Case task headings, explicit example labels, and `and` instead of `&` in in-scope prose.
- Record product/modality capitalization and representative overview/index coverage guidance.
- Direct broader copy editing to a dedicated documentation PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] No runtime tests are required for this one-file skill guidance change.
- [x] All commits include DCO sign-off.

# Validation

- `git diff --check`
- Confirmed the final diff adds one concise section to the current-main Fern contributor skill.
- The generic skill validator stops on the repository-standard existing `when_to_use` frontmatter key; this PR does not alter frontmatter.

# Additional Information

The checklist is distilled from the tech-pubs review on #2306 so future documentation work can apply the same conventions before review without rewriting unrelated existing prose.
