### PR TITLE
fix(retrieval): register Llama classifier auto class

### DIFF
--- a/nemo_automodel/components/models/llama_bidirectional/model.py
+++ b/nemo_automodel/components/models/llama_bidirectional/model.py
@@ -320,7 +320,7 @@ def _register_with_hf_auto_classes():
     This is needed so that AutoModel.from_config(LlamaBidirectionalConfig)
     works inside LlamaForSequenceClassification.__init__.
     """
-    from transformers import AutoConfig, AutoModel
+    from transformers import AutoConfig, AutoModel, AutoModelForSequenceClassification
 
     try:
         AutoConfig.register(LlamaBidirectionalConfig.model_type, LlamaBidirectionalConfig)
@@ -328,6 +328,12 @@ def _register_with_hf_auto_classes():
         pass  # Already registered
     try:
         AutoModel.register(LlamaBidirectionalConfig, LlamaBidirectionalModel)
+    except ValueError:
+        pass  # Already registered
+    try:
+        AutoModelForSequenceClassification.register(
+            LlamaBidirectionalConfig, LlamaBidirectionalForSequenceClassification
+        )
     except ValueError:
         pass  # Already registered
 

--- a/nemo_automodel/components/models/llama_bidirectional/model.py
+++ b/nemo_automodel/components/models/llama_bidirectional/model.py
@@ -315,10 +315,10 @@ ModelClass = [LlamaBidirectionalModel, LlamaBidirectionalForSequenceClassificati
 
 
 def _register_with_hf_auto_classes():
-    """Register bidirectional models with HuggingFace Auto classes.
+    """Register bidirectional Llama types with Hugging Face Auto classes.
 
-    This is needed so that AutoModel.from_config(LlamaBidirectionalConfig)
-    works inside LlamaForSequenceClassification.__init__.
+    Enables ``AutoConfig``, ``AutoModel``, and ``AutoModelForSequenceClassification``
+    to resolve their corresponding bidirectional config and model classes.
     """
     from transformers import AutoConfig, AutoModel, AutoModelForSequenceClassification
 

--- a/tests/unit_tests/models/bi_encoder/test_llama_bidirectional_model.py
+++ b/tests/unit_tests/models/bi_encoder/test_llama_bidirectional_model.py
@@ -17,7 +17,7 @@ import pytest
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from transformers import AutoModelForSequenceClassification
+from transformers import AutoConfig, AutoModel, AutoModelForSequenceClassification
 from transformers.modeling_outputs import BaseModelOutputWithPast, SequenceClassifierOutputWithPast
 
 from nemo_automodel._transformers.registry import ModelRegistry
@@ -32,6 +32,7 @@ from nemo_automodel.components.models.llama_bidirectional.model import (
     LlamaBidirectionalConfig,
     LlamaBidirectionalForSequenceClassification,
     LlamaBidirectionalModel,
+    _register_with_hf_auto_classes,
 )
 from nemo_automodel.recipes.retrieval.train_bi_encoder import contrastive_scores_and_labels
 
@@ -105,6 +106,29 @@ def test_llama_bidirectional_sequence_classification_auto_class_registration():
     model = AutoModelForSequenceClassification.from_config(config)
 
     assert isinstance(model, LlamaBidirectionalForSequenceClassification)
+
+
+def test_llama_bidirectional_auto_class_registration_ignores_duplicate_errors(monkeypatch):
+    calls = []
+
+    def duplicate_register(name):
+        def register(*args, **kwargs):
+            calls.append(name)
+            raise ValueError("already registered")
+
+        return register
+
+    monkeypatch.setattr(AutoConfig, "register", duplicate_register("config"))
+    monkeypatch.setattr(AutoModel, "register", duplicate_register("model"))
+    monkeypatch.setattr(
+        AutoModelForSequenceClassification,
+        "register",
+        duplicate_register("sequence_classification"),
+    )
+
+    _register_with_hf_auto_classes()
+
+    assert calls == ["config", "model", "sequence_classification"]
 
 
 def test_llama_bidirectional_model_init_and_mask():

--- a/tests/unit_tests/models/bi_encoder/test_llama_bidirectional_model.py
+++ b/tests/unit_tests/models/bi_encoder/test_llama_bidirectional_model.py
@@ -17,6 +17,7 @@ import pytest
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from transformers import AutoModelForSequenceClassification
 from transformers.modeling_outputs import BaseModelOutputWithPast, SequenceClassifierOutputWithPast
 
 from nemo_automodel._transformers.registry import ModelRegistry
@@ -89,6 +90,21 @@ def test_llama_bidirectional_config_fields():
     assert cfg.pooling == "cls"
     # Some downstream configs may overwrite; just ensure attribute exists and is float-like
     assert isinstance(cfg.temperature, float)
+
+
+def test_llama_bidirectional_sequence_classification_auto_class_registration():
+    config = LlamaBidirectionalConfig(
+        vocab_size=64,
+        hidden_size=16,
+        num_hidden_layers=1,
+        num_attention_heads=1,
+        intermediate_size=32,
+        num_labels=2,
+    )
+
+    model = AutoModelForSequenceClassification.from_config(config)
+
+    assert isinstance(model, LlamaBidirectionalForSequenceClassification)
 
 
 def test_llama_bidirectional_model_init_and_mask():


### PR DESCRIPTION
# What does this PR do?

Registers `LlamaBidirectionalConfig` with Hugging Face `AutoModelForSequenceClassification` so callers can construct the NeMo bidirectional classifier through the standard auto class.

Without this registration, `AutoModelForSequenceClassification.from_config(LlamaBidirectionalConfig(...))` raises `ValueError: Unrecognized configuration class`, even though the same config is already registered for `AutoConfig` and `AutoModel`.

# Changelog

- Register `LlamaBidirectionalForSequenceClassification` for `LlamaBidirectionalConfig`.
- Add a focused regression test for construction through the Hugging Face auto class.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Rebased onto latest `main`.
- [x] Added a focused CPU-compatible regression test.
- [x] Ran adjacent retrieval and registry unit tests.
- [x] Commit includes DCO sign-off.

# Validation

- `ruff format --check nemo_automodel/components/models/llama_bidirectional/model.py tests/unit_tests/models/bi_encoder/test_llama_bidirectional_model.py`
- `ruff check nemo_automodel/components/models/llama_bidirectional/model.py tests/unit_tests/models/bi_encoder/test_llama_bidirectional_model.py`
- `python3 -m pytest tests/unit_tests/models/bi_encoder/test_llama_bidirectional_model.py -q` (24 passed)
- `python3 -m pytest tests/unit_tests/_transformers/test_registry.py tests/unit_tests/_transformers/test_retrieval.py -q` (97 passed, 1 skipped)
- `git diff --check`

# Additional information

The original retrieval-export-metadata scope was superseded by #3021, which merged a stronger standard Sentence Transformers metadata contract and end-to-end round-trip coverage. This PR is intentionally narrowed to the remaining independent compatibility fix.
