### PR TITLE
feat(retrieval): add mining data preparation utilities

### DIFF
--- a/examples/retrieval/data_utils/audit_mined_negatives.py
+++ b/examples/retrieval/data_utils/audit_mined_negatives.py
@@ -1,0 +1,274 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Audit mined retrieval negatives for common false-negative and score issues."""
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+
+def _doc_id(doc: Any) -> str:
+    """Return a document ID from either a raw ID or a {"id": ...} mapping."""
+    raw_id = doc.get("id") if isinstance(doc, dict) else doc
+    if raw_id is None:
+        raise ValueError(f"Document entry is missing an id: {doc!r}")
+    return str(raw_id)
+
+
+def _score_state(doc: Any) -> str:
+    """Classify a mined document score as finite, missing, or non-finite."""
+    if not isinstance(doc, dict) or "score" not in doc:
+        return "missing"
+    try:
+        score = float(doc["score"])
+    except (TypeError, ValueError):
+        return "non_finite"
+    return "finite" if math.isfinite(score) else "non_finite"
+
+
+def audit_records(
+    records: list[dict[str, Any]],
+    *,
+    drop_invalid_negatives: bool = False,
+    max_findings: int = 20,
+    min_negatives: int = 0,
+) -> tuple[dict[str, int], list[dict[str, Any]], list[dict[str, Any]]]:
+    """Audit retrieval records and optionally drop invalid mined negatives.
+
+    Args:
+        records: Retrieval training records from the top-level ``data`` field.
+        drop_invalid_negatives: Drop negatives that duplicate positives, duplicate
+            another negative in the same row, or have a missing/non-finite score.
+        max_findings: Maximum example findings to return.
+        min_negatives: Minimum number of negatives each row must retain after optional cleanup.
+
+    Returns:
+        A tuple of ``(summary, cleaned_records, finding_examples)``.
+    """
+    summary = {
+        "records": len(records),
+        "negatives": 0,
+        "rows_with_findings": 0,
+        "missing_positive_score": 0,
+        "non_finite_positive_score": 0,
+        "negative_is_known_positive": 0,
+        "duplicate_negative": 0,
+        "missing_negative_score": 0,
+        "non_finite_negative_score": 0,
+        "rows_with_too_few_negatives": 0,
+        "dropped_negatives": 0,
+        "total_findings": 0,
+    }
+    cleaned_records = []
+    findings = []
+
+    for row_idx, record in enumerate(records):
+        pos_ids = {_doc_id(doc) for doc in record.get("pos_doc", [])}
+        seen_neg_ids = set()
+        cleaned_negatives = []
+        row_has_findings = False
+
+        for pos_doc in record.get("pos_doc", []):
+            pos_id = _doc_id(pos_doc)
+            score_state = _score_state(pos_doc)
+            if score_state == "missing":
+                summary["missing_positive_score"] += 1
+                row_has_findings = True
+                _append_finding(
+                    findings, max_findings, row_idx, record, pos_id, "missing_positive_score", doc_role="positive"
+                )
+            elif score_state == "non_finite":
+                summary["non_finite_positive_score"] += 1
+                row_has_findings = True
+                _append_finding(
+                    findings, max_findings, row_idx, record, pos_id, "non_finite_positive_score", doc_role="positive"
+                )
+
+        for neg_doc in record.get("neg_doc", []):
+            summary["negatives"] += 1
+            neg_id = _doc_id(neg_doc)
+            should_drop = False
+
+            if neg_id in pos_ids:
+                summary["negative_is_known_positive"] += 1
+                should_drop = True
+                row_has_findings = True
+                _append_finding(findings, max_findings, row_idx, record, neg_id, "negative_is_known_positive")
+
+            if neg_id in seen_neg_ids:
+                summary["duplicate_negative"] += 1
+                should_drop = True
+                row_has_findings = True
+                _append_finding(findings, max_findings, row_idx, record, neg_id, "duplicate_negative")
+            seen_neg_ids.add(neg_id)
+
+            score_state = _score_state(neg_doc)
+            if score_state == "missing":
+                summary["missing_negative_score"] += 1
+                should_drop = True
+                row_has_findings = True
+                _append_finding(findings, max_findings, row_idx, record, neg_id, "missing_negative_score")
+            elif score_state == "non_finite":
+                summary["non_finite_negative_score"] += 1
+                should_drop = True
+                row_has_findings = True
+                _append_finding(findings, max_findings, row_idx, record, neg_id, "non_finite_negative_score")
+
+            if drop_invalid_negatives and should_drop:
+                summary["dropped_negatives"] += 1
+                continue
+            cleaned_negatives.append(neg_doc)
+
+        if len(cleaned_negatives) < min_negatives:
+            summary["rows_with_too_few_negatives"] += 1
+            row_has_findings = True
+            _append_finding(findings, max_findings, row_idx, record, None, "too_few_negatives")
+
+        if row_has_findings:
+            summary["rows_with_findings"] += 1
+        cleaned_record = dict(record)
+        cleaned_record["neg_doc"] = cleaned_negatives
+        cleaned_records.append(cleaned_record)
+
+    summary["total_findings"] = (
+        summary["missing_positive_score"]
+        + summary["non_finite_positive_score"]
+        + summary["negative_is_known_positive"]
+        + summary["duplicate_negative"]
+        + summary["missing_negative_score"]
+        + summary["non_finite_negative_score"]
+        + summary["rows_with_too_few_negatives"]
+    )
+    return summary, cleaned_records, findings
+
+
+def _append_finding(
+    findings: list[dict[str, Any]],
+    max_findings: int,
+    row_idx: int,
+    record: dict[str, Any],
+    doc_id: str | None,
+    issue: str,
+    *,
+    doc_role: str = "negative",
+) -> None:
+    """Append a compact finding example up to the configured limit."""
+    if len(findings) >= max_findings:
+        return
+    id_key = "positive_id" if doc_role == "positive" else "negative_id"
+    finding = {
+        "row": row_idx,
+        "question_id": record.get("question_id"),
+        id_key: doc_id,
+        "issue": issue,
+    }
+    if "original_question_id" in record:
+        finding["original_question_id"] = record["original_question_id"]
+    findings.append(finding)
+
+
+def audit_training_data(
+    training_data: dict[str, Any],
+    *,
+    drop_invalid_negatives: bool = False,
+    max_findings: int = 20,
+    min_negatives: int = 0,
+) -> tuple[dict[str, int], dict[str, Any], list[dict[str, Any]]]:
+    """Audit a top-level retrieval JSON object."""
+    records = training_data.get("data", [])
+    summary, cleaned_records, findings = audit_records(
+        records,
+        drop_invalid_negatives=drop_invalid_negatives,
+        max_findings=max_findings,
+        min_negatives=min_negatives,
+    )
+    cleaned_training_data = dict(training_data)
+    cleaned_training_data["data"] = cleaned_records
+    return summary, cleaned_training_data, findings
+
+
+def main() -> int:
+    """Run the mined-negative audit CLI."""
+    parser = argparse.ArgumentParser(description="Audit mined retrieval negatives before reusing them for training")
+    parser.add_argument("input_file", type=str, help="Path to mined retrieval JSON")
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=str,
+        default=None,
+        help="Optional path to write a cleaned retrieval JSON",
+    )
+    parser.add_argument(
+        "--drop-invalid-negatives",
+        action="store_true",
+        help=(
+            "Drop negatives that are known positives, duplicate row negatives, or have missing/non-finite scores. "
+            "When used with --output, the exit code is based on the cleaned output."
+        ),
+    )
+    parser.add_argument("--max-findings", type=int, default=20, help="Maximum finding examples to print")
+    parser.add_argument(
+        "--min-negatives",
+        type=int,
+        default=0,
+        help="Require at least this many negatives per row after optional cleanup.",
+    )
+    parser.add_argument(
+        "--allow-findings",
+        action="store_true",
+        help="Exit with status 0 even when the audit reports findings",
+    )
+    args = parser.parse_args()
+    if args.min_negatives < 0:
+        parser.error("--min-negatives must be non-negative")
+
+    input_path = Path(args.input_file)
+    with open(input_path, "r") as f:
+        training_data = json.load(f)
+
+    summary, cleaned_training_data, findings = audit_training_data(
+        training_data,
+        drop_invalid_negatives=args.drop_invalid_negatives,
+        max_findings=args.max_findings,
+        min_negatives=args.min_negatives,
+    )
+
+    exit_summary = summary
+    payload = {"summary": summary, "findings": findings}
+    if args.output is not None:
+        output_path = Path(args.output)
+        with open(output_path, "w") as f:
+            json.dump(cleaned_training_data, f, indent=2)
+
+        if args.drop_invalid_negatives:
+            remaining_summary, _, remaining_findings = audit_training_data(
+                cleaned_training_data,
+                drop_invalid_negatives=False,
+                max_findings=args.max_findings,
+                min_negatives=args.min_negatives,
+            )
+            payload["remaining_summary"] = remaining_summary
+            payload["remaining_findings"] = remaining_findings
+            exit_summary = remaining_summary
+
+    print(json.dumps(payload, indent=2))
+
+    return 1 if exit_summary["total_findings"] and not args.allow_findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/retrieval/data_utils/materialize_hf_retrieval_subset.py
+++ b/examples/retrieval/data_utils/materialize_hf_retrieval_subset.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Materialize one AutoModel retrieval HF subset as local corpus JSON for mining."""
+
+import argparse
+import json
+import logging
+import shutil
+import tempfile
+from pathlib import Path
+
+from datasets import Dataset
+
+from nemo_automodel.components.datasets.llm.retrieval_dataset import _load_hf_subset
+
+logger = logging.getLogger(__name__)
+
+
+def main() -> int:
+    """Run the HF subset materialization CLI."""
+    parser = argparse.ArgumentParser(
+        description="Write one AutoModel-schema hf:// retrieval subset as a local corpus-backed JSON file"
+    )
+    parser.add_argument(
+        "repo_id", type=str, help="Hugging Face dataset repo, for example nvidia/embed-nemotron-dataset-v1"
+    )
+    parser.add_argument("subset", type=str, help="Subset name, for example FEVER")
+    parser.add_argument(
+        "output_dir", type=str, help="Directory where train.json and the corpus directory will be written"
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Allow writing into a non-empty output directory.",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO)
+
+    output_dir = Path(args.output_dir)
+    if output_dir.exists():
+        if not output_dir.is_dir():
+            parser.error(f"output_dir must be a directory: {output_dir}")
+        if any(output_dir.iterdir()) and not args.overwrite:
+            parser.error(f"output_dir is not empty: {output_dir}. Pass --overwrite to replace existing files.")
+    else:
+        output_dir.mkdir(parents=True)
+    data_list, corpus_info = _load_hf_subset(args.repo_id, args.subset)
+    corpus_dir = output_dir / f"{args.subset}_corpus"
+    tmp_corpus_dir = Path(tempfile.mkdtemp(prefix=f".{args.subset}_corpus.", dir=output_dir))
+    tmp_train_path = None
+    backup_corpus_dir = None
+    committed = False
+    try:
+        doc_rows = []
+        for doc_id in corpus_info.get_all_ids():
+            document = corpus_info.get_document_by_id(doc_id)
+            doc_rows.append({"id": str(doc_id), "text": document.get("text", "")})
+
+        Dataset.from_list(doc_rows).to_parquet(str(tmp_corpus_dir / "train.parquet"))
+        metadata = {
+            **corpus_info.metadata,
+            "class": "TextQADataset",
+            "corpus_id": corpus_info.corpus_id,
+        }
+        with open(tmp_corpus_dir / "merlin_metadata.json", "w") as f:
+            json.dump(metadata, f, indent=2, sort_keys=True)
+
+        train_json = {
+            "corpus": [{"path": f"./{corpus_dir.name}"}],
+            "data": data_list,
+        }
+        with tempfile.NamedTemporaryFile("w", dir=output_dir, prefix=".train.", suffix=".json", delete=False) as f:
+            tmp_train_path = Path(f.name)
+            json.dump(train_json, f, indent=2)
+
+        if corpus_dir.exists():
+            backup_corpus_dir = Path(tempfile.mkdtemp(prefix=f".{corpus_dir.name}.backup.", dir=output_dir))
+            backup_corpus_dir.rmdir()
+            shutil.move(str(corpus_dir), str(backup_corpus_dir))
+        shutil.move(str(tmp_corpus_dir), str(corpus_dir))
+        tmp_corpus_dir = None
+        tmp_train_path.replace(output_dir / "train.json")
+        tmp_train_path = None
+        committed = True
+    finally:
+        if not committed and backup_corpus_dir is not None and backup_corpus_dir.exists():
+            if corpus_dir.exists():
+                shutil.rmtree(corpus_dir)
+            shutil.move(str(backup_corpus_dir), str(corpus_dir))
+        if tmp_corpus_dir is not None and tmp_corpus_dir.exists():
+            shutil.rmtree(tmp_corpus_dir)
+        if tmp_train_path is not None and tmp_train_path.exists():
+            tmp_train_path.unlink()
+        if committed and backup_corpus_dir is not None and backup_corpus_dir.exists():
+            shutil.rmtree(backup_corpus_dir)
+
+    logger.info("Wrote %s records and %s corpus documents to %s", len(data_list), len(doc_rows), output_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/retrieval/data_utils/unroll_pos_docs.py
+++ b/examples/retrieval/data_utils/unroll_pos_docs.py
@@ -13,10 +13,13 @@
 # limitations under the License.
 
 """
-Unroll training data with multiple positive documents into records with single positive documents.
+Unroll training data with multiple positive documents into records with one supervised positive first.
 
 This script takes training data where each question has multiple positive documents
-and creates a new dataset where each (question, pos_doc) pair becomes its own record.
+and creates a new dataset where each (question, pos_doc[0]) pair becomes its own
+record. The remaining known positives stay in pos_doc after the supervised positive
+so hard-negative mining can exclude the full positive set. AutoModel retrieval
+training uses pos_doc[0] as the supervised positive.
 
 Input Format:
     Expects NeMo Retriever training data format (train.json):
@@ -35,14 +38,18 @@ Input Format:
     }
 
 Output:
-    Same format, but each record has exactly one positive document:
-    {"question_id": "q0_0", "question": "...", "pos_doc": [{"id": "d1"}]}
-    {"question_id": "q0_1", "question": "...", "pos_doc": [{"id": "d2"}]}
+    Same format, but each record starts with a different supervised positive:
+    {"question_id": "q0_0", "original_question_id": "q0", "pos_doc": [{"id": "d1"}, {"id": "d2"}]}
+    {"question_id": "q0_1", "original_question_id": "q0", "pos_doc": [{"id": "d2"}, {"id": "d1"}]}
 
 Usage:
-    python examples/retrieval/data_utils/unroll_pos_docs.py data/nv_pp_dd_sdg_train_eval/train.json
-    python examples/retrieval/data_utils/unroll_pos_docs.py data/nv_pp_dd_sdg_train_eval/train.json --output data/nv_pp_dd_sdg_train_eval/train_unrolled.json
-    python examples/retrieval/data_utils/unroll_pos_docs.py data/nv_pp_dd_sdg_train_eval/train.json --suffix _unrolled
+    uv run python examples/retrieval/data_utils/unroll_pos_docs.py data/nv_pp_dd_sdg_train_eval/train.json
+    uv run python examples/retrieval/data_utils/unroll_pos_docs.py \
+        data/nv_pp_dd_sdg_train_eval/train.json \
+        --output data/nv_pp_dd_sdg_train_eval/train_unrolled.json
+    uv run python examples/retrieval/data_utils/unroll_pos_docs.py \
+        data/nv_pp_dd_sdg_train_eval/train.json \
+        --suffix _unrolled
 """
 
 import argparse
@@ -51,46 +58,67 @@ from pathlib import Path
 from typing import Any
 
 
+def _doc_id(doc: Any) -> str:
+    """Return a document ID from either a raw ID or a {"id": ...} mapping."""
+    raw_id = doc.get("id") if isinstance(doc, dict) else doc
+    if raw_id is None:
+        raise ValueError(f"Document entry is missing an id: {doc!r}")
+    return str(raw_id)
+
+
+def _drop_known_positives_from_negatives(neg_docs: list[Any], pos_docs: list[Any]) -> list[Any]:
+    """Remove any negative whose ID is already known to be positive."""
+    pos_ids = {_doc_id(doc) for doc in pos_docs}
+    return [doc for doc in neg_docs if _doc_id(doc) not in pos_ids]
+
+
 def unroll_training_data(data: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """
     Unroll training records with multiple positive docs into individual records.
+
+    Each output row keeps one supervised positive first, while retaining sibling
+    positives after it for false-negative filtering in downstream mining.
 
     Args:
         data: List of training records with potentially multiple pos_doc entries
 
     Returns:
-        List of training records where each has exactly one pos_doc
+        List of training records where each row has a different pos_doc[0]
     """
     unrolled = []
 
     for record in data:
         pos_docs = record.get("pos_doc", [])
+        neg_docs = _drop_known_positives_from_negatives(record.get("neg_doc", []), pos_docs)
 
         if len(pos_docs) <= 1:
             # Already has single (or zero) pos_doc, keep as-is
-            unrolled.append(record)
+            new_record = dict(record)
+            new_record["neg_doc"] = neg_docs
+            unrolled.append(new_record)
         else:
             # Unroll into multiple records
             base_question_id = record["question_id"]
 
             for idx, pos_doc in enumerate(pos_docs):
+                ordered_pos_docs = [pos_doc] + [other_pos_doc for j, other_pos_doc in enumerate(pos_docs) if j != idx]
                 new_record = {
                     "question_id": f"{base_question_id}_{idx}",
+                    "original_question_id": record.get("original_question_id", base_question_id),
                     "question": record["question"],
                     "corpus_id": record["corpus_id"],
-                    "pos_doc": [pos_doc],
-                    "neg_doc": record.get("neg_doc", []),
+                    "pos_doc": ordered_pos_docs,
+                    "neg_doc": neg_docs,
                 }
                 unrolled.append(new_record)
 
     return unrolled
 
 
-def main():
-    """Run positive-document unrolling from the command line."""
-
+def main() -> None:
+    """Unroll a retrieval dataset and write one record per positive document."""
     parser = argparse.ArgumentParser(
-        description="Unroll training data with multiple positive docs into single-pos-doc records"
+        description="Unroll training data so each sibling positive is supervised first while preserving all positives"
     )
     parser.add_argument("input_file", type=str, help="Path to input training JSON file")
     parser.add_argument(

--- a/nemo_automodel/components/datasets/llm/retrieval_dataset.py
+++ b/nemo_automodel/components/datasets/llm/retrieval_dataset.py
@@ -367,6 +367,7 @@ def load_datasets(
                 raise ValueError(f"Missing required fields: {missing} in train_data item: {item}")
             normalized_item = {
                 "question_id": item["question_id"],
+                "original_question_id": item.get("original_question_id", item["question_id"]),
                 "question": item["question"],
                 "corpus_id": item["corpus_id"],
             }
@@ -510,11 +511,13 @@ def _load_hf_subset(repo_id: str, subset: str):
             f"adapter/preprocessor before using direct hf:// loading."
         )
 
-    # 5. Normalize to the standard {question_id, question, corpus_id, pos_doc, neg_doc} shape
+    # 5. Normalize to the standard {question_id, original_question_id, question, corpus_id, pos_doc, neg_doc} shape
     normalized_data = []
     for idx, item in enumerate(queries_hf):
+        question_id = str(item.get("question_id", f"{subset}:{idx}"))
         normalized_item = {
-            "question_id": str(item.get("question_id", f"{subset}:{idx}")),
+            "question_id": question_id,
+            "original_question_id": str(item.get("original_question_id", question_id)),
             "question": item["question"],
             "corpus_id": corpus_id,
         }

--- a/tests/unit_tests/datasets/llm/test_audit_mined_negatives.py
+++ b/tests/unit_tests/datasets/llm/test_audit_mined_negatives.py
@@ -1,0 +1,228 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import sys
+
+from examples.retrieval.data_utils.audit_mined_negatives import audit_training_data
+from examples.retrieval.data_utils.audit_mined_negatives import main as audit_main
+
+
+def test_audit_mined_negatives_reports_and_cleans_invalid_rows():
+    training_data = {
+        "corpus": {"path": "/corpus"},
+        "data": [
+            {
+                "question_id": "q0_0",
+                "original_question_id": "q0",
+                "question": "Which document is positive?",
+                "corpus_id": "demo",
+                "pos_doc": [{"id": 1, "score": 0.8}],
+                "neg_doc": [
+                    {"id": "1", "score": 0.9},
+                    {"id": "2", "score": 0.4},
+                    {"id": "2", "score": 0.3},
+                    {"id": "3", "score": float("-inf")},
+                    {"id": "4"},
+                ],
+            }
+        ],
+    }
+
+    summary, cleaned, findings = audit_training_data(training_data, drop_invalid_negatives=True)
+
+    assert summary == {
+        "records": 1,
+        "negatives": 5,
+        "rows_with_findings": 1,
+        "missing_positive_score": 0,
+        "non_finite_positive_score": 0,
+        "negative_is_known_positive": 1,
+        "duplicate_negative": 1,
+        "missing_negative_score": 1,
+        "non_finite_negative_score": 1,
+        "rows_with_too_few_negatives": 0,
+        "dropped_negatives": 4,
+        "total_findings": 4,
+    }
+    assert cleaned["corpus"] == training_data["corpus"]
+    assert cleaned["data"] == [
+        {
+            "question_id": "q0_0",
+            "original_question_id": "q0",
+            "question": "Which document is positive?",
+            "corpus_id": "demo",
+            "pos_doc": [{"id": 1, "score": 0.8}],
+            "neg_doc": [{"id": "2", "score": 0.4}],
+        }
+    ]
+    assert findings[0]["original_question_id"] == "q0"
+
+
+def test_audit_mined_negatives_reports_positive_score_findings():
+    training_data = {
+        "data": [
+            {
+                "question_id": "q0",
+                "pos_doc": [{"id": "1"}, {"id": "2", "score": float("nan")}],
+                "neg_doc": [{"id": "3", "score": 0.1}],
+            }
+        ]
+    }
+
+    summary, _, findings = audit_training_data(training_data)
+
+    assert summary["missing_positive_score"] == 1
+    assert summary["non_finite_positive_score"] == 1
+    assert summary["total_findings"] == 2
+    assert findings[0]["positive_id"] == "1"
+    assert findings[1]["positive_id"] == "2"
+
+
+def test_audit_mined_negatives_preserves_records_without_findings():
+    training_data = {
+        "corpus": {"path": "/corpus"},
+        "data": [
+            {
+                "question_id": "q0",
+                "question": "Which document is positive?",
+                "corpus_id": "demo",
+                "pos_doc": [{"id": "1", "score": 0.8}],
+                "neg_doc": [{"id": "2", "score": 0.2}],
+            }
+        ],
+    }
+
+    summary, cleaned, findings = audit_training_data(training_data, drop_invalid_negatives=True)
+
+    assert summary["total_findings"] == 0
+    assert cleaned == training_data
+    assert findings == []
+
+
+def test_audit_cli_writes_cleaned_output_and_exits_zero(tmp_path, monkeypatch, capsys):
+    input_file = tmp_path / "mined.json"
+    output_file = tmp_path / "cleaned.json"
+    input_file.write_text(
+        json.dumps(
+            {
+                "corpus": {"path": "/corpus"},
+                "data": [
+                    {
+                        "question_id": "q0",
+                        "question": "Which document is positive?",
+                        "corpus_id": "demo",
+                        "pos_doc": [{"id": "1", "score": 0.8}],
+                        "neg_doc": [{"id": "1", "score": 1.0}, {"id": "2"}],
+                    }
+                ],
+            }
+        )
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "audit_mined_negatives.py",
+            str(input_file),
+            "--drop-invalid-negatives",
+            "--output",
+            str(output_file),
+        ],
+    )
+
+    assert audit_main() == 0
+    report = json.loads(capsys.readouterr().out)
+    cleaned = json.loads(output_file.read_text())
+
+    assert report["summary"]["total_findings"] == 2
+    assert report["remaining_summary"]["total_findings"] == 0
+    assert cleaned["data"][0]["neg_doc"] == []
+
+
+def test_audit_cli_exits_nonzero_when_findings_remain(tmp_path, monkeypatch):
+    input_file = tmp_path / "mined.json"
+    input_file.write_text(
+        json.dumps(
+            {
+                "data": [
+                    {
+                        "question_id": "q0",
+                        "pos_doc": [{"id": "1", "score": 0.8}],
+                        "neg_doc": [{"id": "1", "score": 1.0}],
+                    }
+                ]
+            }
+        )
+    )
+    monkeypatch.setattr(sys, "argv", ["audit_mined_negatives.py", str(input_file)])
+
+    assert audit_main() == 1
+
+
+def test_audit_cli_allow_findings_exits_zero(tmp_path, monkeypatch):
+    input_file = tmp_path / "mined.json"
+    input_file.write_text(
+        json.dumps(
+            {
+                "data": [
+                    {
+                        "question_id": "q0",
+                        "pos_doc": [{"id": "1", "score": 0.8}],
+                        "neg_doc": [{"id": "1", "score": 1.0}],
+                    }
+                ]
+            }
+        )
+    )
+    monkeypatch.setattr(sys, "argv", ["audit_mined_negatives.py", str(input_file), "--allow-findings"])
+
+    assert audit_main() == 0
+
+
+def test_audit_cli_min_negatives_catches_rows_cleaned_to_empty(tmp_path, monkeypatch, capsys):
+    input_file = tmp_path / "mined.json"
+    output_file = tmp_path / "cleaned.json"
+    input_file.write_text(
+        json.dumps(
+            {
+                "data": [
+                    {
+                        "question_id": "q0",
+                        "pos_doc": [{"id": "1", "score": 0.8}],
+                        "neg_doc": [{"id": "1", "score": 1.0}],
+                    }
+                ]
+            }
+        )
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "audit_mined_negatives.py",
+            str(input_file),
+            "--drop-invalid-negatives",
+            "--output",
+            str(output_file),
+            "--min-negatives",
+            "1",
+        ],
+    )
+
+    assert audit_main() == 1
+    report = json.loads(capsys.readouterr().out)
+
+    assert report["remaining_summary"]["rows_with_too_few_negatives"] == 1
+    assert report["remaining_findings"][0]["issue"] == "too_few_negatives"

--- a/tests/unit_tests/datasets/llm/test_materialize_hf_retrieval_subset.py
+++ b/tests/unit_tests/datasets/llm/test_materialize_hf_retrieval_subset.py
@@ -1,0 +1,204 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import sys
+
+import pytest
+
+from examples.retrieval.data_utils import materialize_hf_retrieval_subset
+
+
+class _FakeCorpusInfo:
+    metadata = {"corpus_id": "demo", "query_instruction": "query:"}
+    corpus_id = "demo"
+
+    def get_all_ids(self):
+        return ["d0"]
+
+    def get_document_by_id(self, doc_id):
+        return {"text": f"document {doc_id}"}
+
+
+def test_materialize_hf_retrieval_subset_writes_local_corpus_json(tmp_path, monkeypatch):
+    data_list = [
+        {
+            "question_id": "q0",
+            "original_question_id": "q0",
+            "question": "What is the document?",
+            "corpus_id": "demo",
+            "pos_doc": [{"id": "d0"}],
+            "neg_doc": [{"id": "d1"}],
+        }
+    ]
+    monkeypatch.setattr(
+        materialize_hf_retrieval_subset,
+        "_load_hf_subset",
+        lambda repo_id, subset: (data_list, _FakeCorpusInfo()),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "materialize_hf_retrieval_subset.py",
+            "nvidia/embed-nemotron-dataset-v1",
+            "FEVER",
+            str(tmp_path),
+        ],
+    )
+
+    assert materialize_hf_retrieval_subset.main() == 0
+
+    train_json = json.loads((tmp_path / "train.json").read_text())
+    metadata = json.loads((tmp_path / "FEVER_corpus" / "merlin_metadata.json").read_text())
+
+    assert train_json["corpus"] == [{"path": "./FEVER_corpus"}]
+    assert train_json["data"] == data_list
+    assert metadata["class"] == "TextQADataset"
+    assert metadata["corpus_id"] == "demo"
+    assert (tmp_path / "FEVER_corpus" / "train.parquet").exists()
+
+
+def test_materialize_hf_retrieval_subset_rejects_non_empty_output_dir(tmp_path, monkeypatch):
+    (tmp_path / "existing.txt").write_text("keep me")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "materialize_hf_retrieval_subset.py",
+            "nvidia/embed-nemotron-dataset-v1",
+            "FEVER",
+            str(tmp_path),
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        materialize_hf_retrieval_subset.main()
+
+    assert exc_info.value.code == 2
+
+
+def test_materialize_hf_retrieval_subset_overwrites_when_requested(tmp_path, monkeypatch):
+    (tmp_path / "existing.txt").write_text("replace allowed")
+    stale_corpus = tmp_path / "FEVER_corpus"
+    stale_corpus.mkdir()
+    (stale_corpus / "train-00000-of-00001.parquet").write_text("stale")
+    data_list = [
+        {
+            "question_id": "q0",
+            "question": "What is the document?",
+            "corpus_id": "demo",
+            "pos_doc": [{"id": "d0"}],
+            "neg_doc": [],
+        }
+    ]
+    monkeypatch.setattr(
+        materialize_hf_retrieval_subset,
+        "_load_hf_subset",
+        lambda repo_id, subset: (data_list, _FakeCorpusInfo()),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "materialize_hf_retrieval_subset.py",
+            "nvidia/embed-nemotron-dataset-v1",
+            "FEVER",
+            str(tmp_path),
+            "--overwrite",
+        ],
+    )
+
+    assert materialize_hf_retrieval_subset.main() == 0
+    assert (tmp_path / "train.json").exists()
+    assert not (tmp_path / "FEVER_corpus" / "train-00000-of-00001.parquet").exists()
+    assert (tmp_path / "FEVER_corpus" / "train.parquet").exists()
+
+
+def test_materialize_hf_retrieval_subset_overwrite_keeps_existing_output_when_load_fails(tmp_path, monkeypatch):
+    existing_train_json = tmp_path / "train.json"
+    existing_train_json.write_text('{"corpus": [{"path": "./FEVER_corpus"}], "data": []}')
+    stale_corpus = tmp_path / "FEVER_corpus"
+    stale_corpus.mkdir()
+    (stale_corpus / "train.parquet").write_text("still valid")
+
+    def raise_load_error(repo_id, subset):
+        raise RuntimeError("temporary load failure")
+
+    monkeypatch.setattr(materialize_hf_retrieval_subset, "_load_hf_subset", raise_load_error)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "materialize_hf_retrieval_subset.py",
+            "nvidia/embed-nemotron-dataset-v1",
+            "FEVER",
+            str(tmp_path),
+            "--overwrite",
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="temporary load failure"):
+        materialize_hf_retrieval_subset.main()
+
+    assert existing_train_json.read_text() == '{"corpus": [{"path": "./FEVER_corpus"}], "data": []}'
+    assert (stale_corpus / "train.parquet").read_text() == "still valid"
+
+
+def test_materialize_hf_retrieval_subset_overwrite_restores_existing_corpus_on_interruption(tmp_path, monkeypatch):
+    existing_train_json = tmp_path / "train.json"
+    existing_train_json.write_text('{"corpus": [{"path": "./FEVER_corpus"}], "data": []}')
+    stale_corpus = tmp_path / "FEVER_corpus"
+    stale_corpus.mkdir()
+    (stale_corpus / "train.parquet").write_text("still valid")
+    data_list = [
+        {
+            "question_id": "q0",
+            "question": "What is the document?",
+            "corpus_id": "demo",
+            "pos_doc": [{"id": "d0"}],
+            "neg_doc": [],
+        }
+    ]
+    monkeypatch.setattr(
+        materialize_hf_retrieval_subset,
+        "_load_hf_subset",
+        lambda repo_id, subset: (data_list, _FakeCorpusInfo()),
+    )
+    original_replace = materialize_hf_retrieval_subset.Path.replace
+
+    def interrupt_train_replace(self, target):
+        if self.name.startswith(".train."):
+            raise KeyboardInterrupt("stop during commit")
+        return original_replace(self, target)
+
+    monkeypatch.setattr(materialize_hf_retrieval_subset.Path, "replace", interrupt_train_replace)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "materialize_hf_retrieval_subset.py",
+            "nvidia/embed-nemotron-dataset-v1",
+            "FEVER",
+            str(tmp_path),
+            "--overwrite",
+        ],
+    )
+
+    with pytest.raises(KeyboardInterrupt, match="stop during commit"):
+        materialize_hf_retrieval_subset.main()
+
+    assert existing_train_json.read_text() == '{"corpus": [{"path": "./FEVER_corpus"}], "data": []}'
+    assert (stale_corpus / "train.parquet").read_text() == "still valid"
+    assert not list(tmp_path.glob(".FEVER_corpus.backup.*"))

--- a/tests/unit_tests/datasets/llm/test_retrieval_dataset.py
+++ b/tests/unit_tests/datasets/llm/test_retrieval_dataset.py
@@ -169,6 +169,7 @@ def test_load_datasets_normalizes_and_errors(tmp_path, monkeypatch):
         "data": [
             {
                 "question_id": "q1",
+                "original_question_id": "q-root",
                 "question": "What?",
                 "corpus_id": "corpusA",
                 "pos_doc": [{"id": "p1"}],
@@ -183,6 +184,7 @@ def test_load_datasets_normalizes_and_errors(tmp_path, monkeypatch):
     assert len(dataset) == 1
     row = dataset[0]
     assert row["question_id"] == "q1"
+    assert row["original_question_id"] == "q-root"
     assert row["pos_doc"][0]["id"] == "p1"
     assert row["neg_doc"][0]["id"] == "n1" and row["neg_doc"][1]["id"] == "n2"
     assert "corpusA" in corpus_dict
@@ -1383,6 +1385,7 @@ def test_load_hf_subset_synthesizes_question_id(tmp_path, monkeypatch):
 
     data_list, _ = rd._load_hf_subset("org/repo", "MySub")
     assert data_list[0]["question_id"] == "MySub:0"
+    assert data_list[0]["original_question_id"] == "MySub:0"
 
 
 def test_load_hf_subset_allows_empty_neg_doc(tmp_path, monkeypatch):

--- a/tests/unit_tests/datasets/llm/test_unroll_pos_docs.py
+++ b/tests/unit_tests/datasets/llm/test_unroll_pos_docs.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from examples.retrieval.data_utils.unroll_pos_docs import unroll_training_data
+
+
+def test_unroll_preserves_sibling_positives_and_filters_stringified_negatives():
+    records = [
+        {
+            "question_id": "q0",
+            "question": "Which documents are positive?",
+            "corpus_id": "demo",
+            "pos_doc": [{"id": 1}, {"id": "2"}],
+            "neg_doc": [{"id": "1"}, {"id": 2}, {"id": "3"}],
+        }
+    ]
+
+    unrolled = unroll_training_data(records)
+
+    assert unrolled == [
+        {
+            "question_id": "q0_0",
+            "original_question_id": "q0",
+            "question": "Which documents are positive?",
+            "corpus_id": "demo",
+            "pos_doc": [{"id": 1}, {"id": "2"}],
+            "neg_doc": [{"id": "3"}],
+        },
+        {
+            "question_id": "q0_1",
+            "original_question_id": "q0",
+            "question": "Which documents are positive?",
+            "corpus_id": "demo",
+            "pos_doc": [{"id": "2"}, {"id": 1}],
+            "neg_doc": [{"id": "3"}],
+        },
+    ]
+
+
+def test_unroll_keeps_single_positive_question_id_and_filters_negatives():
+    records = [
+        {
+            "question_id": "q0",
+            "question": "Which document is positive?",
+            "corpus_id": "demo",
+            "pos_doc": [{"id": 1}],
+            "neg_doc": [{"id": "1"}, {"id": "2"}],
+        }
+    ]
+
+    assert unroll_training_data(records) == [
+        {
+            "question_id": "q0",
+            "question": "Which document is positive?",
+            "corpus_id": "demo",
+            "pos_doc": [{"id": 1}],
+            "neg_doc": [{"id": "2"}],
+        }
+    ]
+
+
+def test_unroll_raises_for_missing_document_id():
+    records = [
+        {
+            "question_id": "q0",
+            "question": "Which document is positive?",
+            "corpus_id": "demo",
+            "pos_doc": [{"id": "1"}],
+            "neg_doc": [{}],
+        }
+    ]
+
+    with pytest.raises(ValueError, match="missing an id"):
+        unroll_training_data(records)


### PR DESCRIPTION
# What does this PR do?

Adds the data preparation, lineage, and audit tools needed for a train-to-mine-to-retrain retrieval workflow.

# Changelog

- Materialize one AutoModel-schema Hugging Face retrieval subset into local corpus-backed JSON.
- Unroll multi-positive records while retaining every known positive and recording `original_question_id`.
- Preserve query lineage when local and Hugging Face retrieval records are normalized.
- Audit mined negatives for positive collisions, duplicate IDs, missing/non-finite scores, and insufficient negative counts.
- Optionally write a cleaned mined dataset.
- Add focused tests for every utility and lineage path.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added focused CPU-compatible tests.
- [x] Added CLI help and documentation through the companion retrieval guide.
- [x] All commits include DCO sign-off.

# Validation

- `uv run ruff format <changed files>`
- `uv run ruff check --fix <changed files>`
- `uv run pytest tests/unit_tests/datasets/llm/test_audit_mined_negatives.py tests/unit_tests/datasets/llm/test_materialize_hf_retrieval_subset.py tests/unit_tests/datasets/llm/test_retrieval_dataset.py tests/unit_tests/datasets/llm/test_unroll_pos_docs.py -q` (72 passed)
- Ran `--help` for all three utility CLIs.

# Additional Information

Extracted from #2306 so that reusable data tooling can be reviewed independently from the fine-tuning documentation.