### PR TITLE
fix(speculative): default DFlash/Domino loss_decay_gamma to the paper value

### DIFF
--- a/nemo_automodel/recipes/llm/train_dflash.py
+++ b/nemo_automodel/recipes/llm/train_dflash.py
@@ -340,7 +340,10 @@ class TrainDFlashRecipe(BaseRecipe):
             block_size=self.block_size,
             attention_backend=attention_backend,
             num_anchors=int(recipe_cfg.get("num_anchors", 512)),
-            loss_decay_gamma=recipe_cfg.get("loss_decay_gamma", None),
+            # Paper default (Appendix A.1) for the shipped block_size=16 configs;
+            # matches DFlashDecayLoss's own default. Set null explicitly in YAML
+            # to disable the position decay (uniform weighting).
+            loss_decay_gamma=recipe_cfg.get("loss_decay_gamma", 7.0),
         )
 
     def _run_trainer_step(self, target_batch):

--- a/nemo_automodel/recipes/llm/train_domino.py
+++ b/nemo_automodel/recipes/llm/train_domino.py
@@ -62,7 +62,10 @@ class TrainDominoRecipe(TrainDFlashRecipe):
             block_size=self.block_size,
             attention_backend=attention_backend,
             num_anchors=int(recipe_cfg.get("num_anchors", 512)),
-            loss_decay_gamma=recipe_cfg.get("loss_decay_gamma", None),
+            # Paper default (Appendix A.1) for the shipped block_size=16 configs;
+            # matches DFlashDecayLoss's own default. Set null explicitly in YAML
+            # to disable the position decay (uniform weighting).
+            loss_decay_gamma=recipe_cfg.get("loss_decay_gamma", 7.0),
             shift_label=self.draft_model.shift_label,
         )
 

--- a/tests/unit_tests/recipes/llm/test_train_dflash.py
+++ b/tests/unit_tests/recipes/llm/test_train_dflash.py
@@ -24,10 +24,50 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+from transformers.models.qwen3.configuration_qwen3 import Qwen3Config
 
-from nemo_automodel.components.speculative.dflash.core import NoValidAnchorsError
+from nemo_automodel.components.speculative.dflash.core import DFlashTrainerModule, NoValidAnchorsError
+from nemo_automodel.components.speculative.dflash.draft_qwen3 import Qwen3DFlashDraftModel
 from nemo_automodel.recipes.llm import train_dflash
 from nemo_automodel.recipes.llm.train_dflash import TrainDFlashRecipe
+
+_VOCAB = 64
+_HIDDEN = 32
+_MASK_ID = _VOCAB - 1
+_TARGET_LAYER_IDS = [1, 3, 5]
+
+
+def _dflash_draft():
+    cfg = Qwen3Config(
+        vocab_size=_VOCAB,
+        hidden_size=_HIDDEN,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        max_position_embeddings=64,
+        attention_bias=False,
+        attention_dropout=0.0,
+        tie_word_embeddings=False,
+    )
+    cfg.num_target_layers = 8
+    cfg.block_size = 4
+    cfg.dflash_config = {"mask_token_id": _MASK_ID, "target_layer_ids": _TARGET_LAYER_IDS}
+    cfg._attn_implementation = "sdpa"
+    return Qwen3DFlashDraftModel(cfg)
+
+
+def _bare_dflash_recipe():
+    recipe = TrainDFlashRecipe.__new__(TrainDFlashRecipe)
+    recipe.draft_model = _dflash_draft()
+    recipe.mask_token_id = _MASK_ID
+    recipe.block_size = 4
+    recipe.target_model = SimpleNamespace(
+        get_output_embeddings=lambda: torch.nn.Linear(_HIDDEN, _VOCAB, bias=False),
+        get_input_embeddings=lambda: torch.nn.Embedding(_VOCAB, _HIDDEN),
+    )
+    return recipe
 
 
 def _ckpt_self(ckpt_every_steps, save_every_epoch, global_step, total_optim_steps=None):
@@ -249,3 +289,23 @@ def test_load_extra_state_noop_when_meta_missing(tmp_path):
     TrainDFlashRecipe._load_extra_state(obj, str(tmp_path))
     assert obj.runtime.global_step == 0
     assert obj._resume_epoch == 0
+
+
+def test_build_trainer_module_defaults_loss_decay_gamma_to_paper_value():
+    """Regression: an unset ``loss_decay_gamma`` used to fall back to ``None``
+    (uniform weighting, decay silently disabled) instead of the paper default
+    (Appendix A.1, matching ``DFlashDecayLoss``'s own default of 7.0)."""
+    recipe = _bare_dflash_recipe()
+    module = recipe._build_trainer_module("sdpa", {})
+    assert isinstance(module, DFlashTrainerModule)
+    assert module.loss_decay_gamma == 7.0
+
+
+def test_build_trainer_module_respects_explicit_loss_decay_gamma():
+    recipe = _bare_dflash_recipe()
+    module = recipe._build_trainer_module("sdpa", {"loss_decay_gamma": None})
+    assert module.loss_decay_gamma is None
+
+    recipe = _bare_dflash_recipe()
+    module = recipe._build_trainer_module("sdpa", {"loss_decay_gamma": 4.0})
+    assert module.loss_decay_gamma == 4.0

--- a/tests/unit_tests/recipes/llm/test_train_domino.py
+++ b/tests/unit_tests/recipes/llm/test_train_domino.py
@@ -110,6 +110,22 @@ def test_build_trainer_module_is_domino():
     assert module.shift_label is True
 
 
+def test_build_trainer_module_defaults_loss_decay_gamma_to_paper_value():
+    """Regression: an unset ``loss_decay_gamma`` used to fall back to ``None``
+    (uniform weighting, decay silently disabled) instead of the paper default
+    (Appendix A.1, matching ``DFlashDecayLoss``'s own default of 7.0)."""
+    recipe = _recipe()
+    recipe.draft_model = _domino_draft(shift_label=True)
+    recipe.mask_token_id = MASK_ID
+    recipe.block_size = BLOCK_SIZE
+    recipe.target_model = SimpleNamespace(
+        get_output_embeddings=lambda: torch.nn.Linear(HIDDEN, VOCAB, bias=False),
+        get_input_embeddings=lambda: torch.nn.Embedding(VOCAB, HIDDEN),
+    )
+    module = recipe._build_trainer_module("sdpa", {})
+    assert module.loss_decay_gamma == 7.0
+
+
 def test_run_trainer_step_injects_lambda_base():
     recipe = _recipe()
     recipe.runtime = SimpleNamespace(global_step=50)


### PR DESCRIPTION
## What does this PR do?

Fixes `loss_decay_gamma` silently disabling the DFlash/Domino position decay when a config omits it.

`TrainDFlashRecipe._build_trainer_module` and `TrainDominoRecipe._build_trainer_module` read `recipe_args.loss_decay_gamma` with a default of `None`, but `DFlashDecayLoss` treats `loss_gamma=None` as 'disable the Eq. 4 position decay' (uniform weighting over predicted positions). `DFlashDecayLoss`'s own default is `7.0` (the paper's Appendix A.1 value for `block_size=16`), and every shipped example config (`examples/speculative/dflash/*.yaml`) sets it explicitly to `7.0` — so only a hand-written config that omits the field silently lost the decay, with no warning.

## Fix

Default the recipe-level read to `7.0` in both recipes, matching `DFlashDecayLoss`'s own default and every example config. A config that wants uniform weighting can still get it by setting `loss_decay_gamma: null` explicitly in YAML.

## Tests

Added `_build_trainer_module` recipe-level tests for both `TrainDFlashRecipe` and `TrainDominoRecipe`: an unset `loss_decay_gamma` now resolves to `7.0` on the built trainer module, and an explicit value (including `null`) still passes through unchanged.