### PR TITLE
refactor(speculative): dispatch all DSpark drafts through the registry

### DIFF
--- a/nemo_automodel/components/speculative/dspark/registry.py
+++ b/nemo_automodel/components/speculative/dspark/registry.py
@@ -22,10 +22,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from transformers import PreTrainedModel
+from torch import nn
 
 from nemo_automodel.components.speculative.dspark.draft_deepseek_v4 import DeepseekV4DSparkModel
+from nemo_automodel.components.speculative.dspark.draft_gemma4 import Gemma4DSparkModel
 from nemo_automodel.components.speculative.dspark.draft_glm_5_2 import Glm5_2DSparkModel
+from nemo_automodel.components.speculative.dspark.draft_minimax_m3 import MiniMaxM3DSparkModel
 from nemo_automodel.components.speculative.dspark.draft_qwen3 import Qwen3DSparkModel
 
 
@@ -33,7 +35,9 @@ from nemo_automodel.components.speculative.dspark.draft_qwen3 import Qwen3DSpark
 class DraftSpec:
     """How to build a DSpark draft model for a particular target architecture."""
 
-    draft_cls: type[PreTrainedModel]
+    # Constructed as ``draft_cls(draft_config)``; some drafts are HF PreTrainedModel
+    # subclasses (Qwen3, Gemma4) while others are plain modules (V4, GLM, MiniMax M3).
+    draft_cls: type[nn.Module]
 
 
 # Qwen3-style dense (and MoE) targets: the draft only consumes the target's
@@ -54,6 +58,14 @@ DSPARK_DRAFT_REGISTRY["DeepseekV4ForCausalLM"] = DraftSpec(draft_cls=DeepseekV4D
 # Q-LoRA + compressed KV latent + interleaved complex RoPE), with the DSA indexer and MoE
 # dropped. Registered separately because its MLA backbone differs from V4's.
 DSPARK_DRAFT_REGISTRY["GlmMoeDsaForCausalLM"] = DraftSpec(draft_cls=Glm5_2DSparkModel)
+# Gemma4 targets: the MoE VLM (model_type "gemma4") and the encoder-free unified model
+# (model_type "gemma4_unified") share one dense Gemma4 draft built from the target's
+# text sub-config.
+DSPARK_DRAFT_REGISTRY["Gemma4ForConditionalGeneration"] = DraftSpec(draft_cls=Gemma4DSparkModel)
+DSPARK_DRAFT_REGISTRY["Gemma4UnifiedForConditionalGeneration"] = DraftSpec(draft_cls=Gemma4DSparkModel)
+# MiniMax M3 VL target (model_type "minimax_m3_vl"): a dense text-only draft built from
+# the target's text sub-config.
+DSPARK_DRAFT_REGISTRY["MiniMaxM3SparseForConditionalGeneration"] = DraftSpec(draft_cls=MiniMaxM3DSparkModel)
 
 
 def resolve_dspark_draft_spec(architectures: list[str]) -> DraftSpec:

--- a/nemo_automodel/recipes/llm/train_dspark.py
+++ b/nemo_automodel/recipes/llm/train_dspark.py
@@ -72,8 +72,6 @@ from nemo_automodel.components.speculative.dspark.config import (
     build_minimax_m3_draft_config,
 )
 from nemo_automodel.components.speculative.dspark.core import DSparkTrainerModule
-from nemo_automodel.components.speculative.dspark.draft_gemma4 import Gemma4DSparkModel
-from nemo_automodel.components.speculative.dspark.draft_minimax_m3 import MiniMaxM3DSparkModel
 from nemo_automodel.components.speculative.dspark.registry import (
     build_target_layer_ids,
     resolve_dspark_draft_spec,
@@ -410,7 +408,9 @@ class TrainDSparkRecipe(BaseRecipe):
                 )
                 target_config.text_config.num_hidden_layers = n_reduced
                 target_text_overrides["num_hidden_layers"] = n_reduced
-            architectures = getattr(target_config, "architectures", []) or []
+            architectures = list(
+                getattr(target_config, "architectures", None) or ["MiniMaxM3SparseForConditionalGeneration"]
+            )
             self.distributed_setup = create_distributed_setup_from_config(
                 self.cfg,
                 world_size=self.dist_env.world_size,
@@ -573,22 +573,18 @@ class TrainDSparkRecipe(BaseRecipe):
                 # The V4 draft is always dense and fixes _attn_implementation to "sdpa"
                 # inside the builder, so it is not overridden by attention_backend.
                 draft_config_obj = build_deepseek_v4_draft_config(target_config, margs)
-                draft_cls = resolve_dspark_draft_spec(architectures).draft_cls
             elif is_glm_5_2_target:
                 # The GLM draft is always dense and fixes _attn_implementation to "sdpa"
                 # inside the builder, so it is not overridden by attention_backend.
                 draft_config_obj = build_glm_5_2_draft_config(target_config, margs)
-                draft_cls = resolve_dspark_draft_spec(architectures).draft_cls
             elif is_minimax_m3_target:
                 # MiniMax M3 draft is built from the target's text sub-config (text_config).
                 draft_config_obj = build_minimax_m3_draft_config(target_config, margs)
                 draft_config_obj._attn_implementation = attention_backend
-                draft_cls = MiniMaxM3DSparkModel
             else:
                 # Gemma4 draft is built from the target's text sub-config (text_config).
                 draft_config_obj = build_gemma4_draft_config(target_config, margs)
                 draft_config_obj._attn_implementation = attention_backend
-                draft_cls = Gemma4DSparkModel
         else:
             # Qwen3-style draft: a small non-causal stack reusing the target's
             # architecture defaults plus the DSpark-specific fields.
@@ -612,8 +608,8 @@ class TrainDSparkRecipe(BaseRecipe):
             draft_config["tie_word_embeddings"] = False
             draft_config_obj = Qwen3Config.from_dict(draft_config)
             draft_config_obj._attn_implementation = attention_backend
-            draft_cls = resolve_dspark_draft_spec(architectures).draft_cls
 
+        draft_cls = resolve_dspark_draft_spec(architectures).draft_cls
         self.draft_model = draft_cls(draft_config_obj).to(device=self.device, dtype=self.compute_dtype)
 
         # training only the backbone, fc, Markov head, and confidence head.

--- a/tests/unit_tests/speculative/test_dspark_registry.py
+++ b/tests/unit_tests/speculative/test_dspark_registry.py
@@ -17,7 +17,9 @@
 import pytest
 
 from nemo_automodel.components.speculative.dspark.draft_deepseek_v4 import DeepseekV4DSparkModel
+from nemo_automodel.components.speculative.dspark.draft_gemma4 import Gemma4DSparkModel
 from nemo_automodel.components.speculative.dspark.draft_glm_5_2 import Glm5_2DSparkModel
+from nemo_automodel.components.speculative.dspark.draft_minimax_m3 import MiniMaxM3DSparkModel
 from nemo_automodel.components.speculative.dspark.draft_qwen3 import Qwen3DSparkModel
 from nemo_automodel.components.speculative.dspark.registry import (
     build_target_layer_ids,
@@ -36,6 +38,15 @@ def test_resolve_deepseek_v4():
 
 def test_resolve_glm_5_2():
     assert resolve_dspark_draft_spec(["GlmMoeDsaForCausalLM"]).draft_cls is Glm5_2DSparkModel
+
+
+def test_resolve_gemma4():
+    assert resolve_dspark_draft_spec(["Gemma4ForConditionalGeneration"]).draft_cls is Gemma4DSparkModel
+    assert resolve_dspark_draft_spec(["Gemma4UnifiedForConditionalGeneration"]).draft_cls is Gemma4DSparkModel
+
+
+def test_resolve_minimax_m3():
+    assert resolve_dspark_draft_spec(["MiniMaxM3SparseForConditionalGeneration"]).draft_cls is MiniMaxM3DSparkModel
 
 
 def test_resolve_unsupported_raises():


### PR DESCRIPTION
## What does this PR do?

Routes the last two hardcoded DSpark draft classes through `DSPARK_DRAFT_REGISTRY`, so every DSpark target family now resolves its draft the same way.

- Register `Gemma4ForConditionalGeneration`, `Gemma4UnifiedForConditionalGeneration` (both map to `Gemma4DSparkModel`) and `MiniMaxM3SparseForConditionalGeneration` (maps to `MiniMaxM3DSparkModel`) in the registry. Previously `train_dspark.py` assigned these two classes directly in ad-hoc branches while Qwen3, DeepSeek V4, and GLM-5.2 went through the registry.
- With all five branches resolving identically, the per-branch `draft_cls = resolve_dspark_draft_spec(...)` calls collapse into a single call after the draft-config if/else.
- `DraftSpec.draft_cls` is now annotated `type[nn.Module]` instead of `type[PreTrainedModel]`: the V4, GLM, and MiniMax M3 drafts are plain modules, so the old annotation was already inaccurate.
- The MiniMax branch gains the same `architectures` fallback the V4 and GLM special-loader branches already had.

No behavior change: the same draft classes are selected for the same targets.

## Tests

Extended `tests/unit_tests/speculative/test_dspark_registry.py` with resolve tests for the three new architecture strings. `tests/unit_tests/speculative/` passes (506 passed, 11 skipped).