### PR TITLE
feat(speculative): add bench_vllm acceptance/speedup benchmark

### DIFF
--- a/nemo_automodel/components/speculative/bench_common.py
+++ b/nemo_automodel/components/speculative/bench_common.py
@@ -1,0 +1,196 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Engine-agnostic workload machinery shared by the drafter benchmarks.
+
+``bench_sglang`` and ``bench_vllm`` drive the same OpenAI-style
+chat-completions workload and report the same throughput/speedup numbers; they
+differ only in how each engine exposes its acceptance statistics (SGLang's
+``/server_info`` vs vLLM's Prometheus ``/metrics``). This module holds the
+shared layer: the prompt loader, the timed HTTP workload runner, and the
+throughput / speedup / CLI-bounds helpers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any
+
+# ``GenerationConfig`` (model + sampling params for a chat completion) is shared
+# with the regeneration tool -- same four fields, same meaning -- so reuse it
+# rather than redefining an identical dataclass here.
+from nemo_automodel.components.speculative.regenerate import (
+    GenerationConfig,
+    _extract_prompt_messages,
+    _import_aiohttp,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class WorkloadResult:
+    """Aggregate timing for one workload pass against a server."""
+
+    wall_clock_s: float
+    output_tokens: int
+    completed: int
+    failed: int
+
+
+def _speedup(spec_throughput: float | None, baseline_throughput: float | None) -> float | None:
+    """Return ``spec / baseline`` output throughput, or ``None`` if not computable."""
+    if not spec_throughput or not baseline_throughput or baseline_throughput <= 0:
+        return None
+    return spec_throughput / baseline_throughput
+
+
+def _output_throughput(result: WorkloadResult) -> float | None:
+    """Output tokens per wall-clock second, or ``None`` if nothing was timed."""
+    if result.wall_clock_s <= 0 or result.output_tokens <= 0:
+        return None
+    return result.output_tokens / result.wall_clock_s
+
+
+def _normalize_server_url(url: str) -> str:
+    """Return the server root URL without a trailing slash or ``/v1`` suffix.
+
+    Chat completions live at ``<root>/v1/chat/completions`` and the engine's
+    stats endpoint at its own root-relative path; accept either
+    ``http://host:port`` or the OpenAI-style ``http://host:port/v1`` so the
+    flag is forgiving.
+    """
+    root = url.rstrip("/")
+    if root.endswith("/v1"):
+        root = root[: -len("/v1")]
+    return root
+
+
+async def _chat_completion(
+    session,
+    url: str,
+    payload: dict[str, Any],
+    *,
+    timeout_s: float,
+    max_retries: int,
+) -> int:
+    """POST one chat completion and return its ``completion_tokens`` (0 on no usage)."""
+    aiohttp = _import_aiohttp()
+    last_err: Exception | None = None
+    for attempt in range(max_retries + 1):
+        try:
+            async with session.post(url, json=payload, timeout=aiohttp.ClientTimeout(total=timeout_s)) as resp:
+                if resp.status >= 500 or resp.status == 429:
+                    text = await resp.text()
+                    raise RuntimeError(f"HTTP {resp.status} from {url}: {text[:200]}")
+                resp.raise_for_status()
+                data = await resp.json()
+                usage = data.get("usage") if isinstance(data, dict) else None
+                if isinstance(usage, dict) and isinstance(usage.get("completion_tokens"), int):
+                    return usage["completion_tokens"]
+                return 0
+        except aiohttp.ClientResponseError:
+            # 5xx and 429 are turned into RuntimeError above, so the only status
+            # that reaches raise_for_status() is a non-429 4xx (400/401/403/404,
+            # ...) -- a client error that will not succeed on retry. Surface it
+            # immediately instead of burning the whole retry budget on it.
+            raise
+        except Exception as exc:  # noqa: BLE001 -- retry transport / 5xx / 429 errors
+            last_err = exc
+            if attempt == max_retries:
+                raise
+            await asyncio.sleep(min(2.0**attempt, 30.0))
+    raise RuntimeError(f"Unreachable: retries exhausted without raising. Last error: {last_err}")
+
+
+async def _run_workload(
+    server: str,
+    prompts: list[list[dict[str, Any]]],
+    gen_cfg: GenerationConfig,
+    *,
+    concurrency: int,
+    timeout_s: float,
+    max_retries: int,
+) -> WorkloadResult:
+    """Send every prompt through ``<server>/v1/chat/completions`` and time the pass."""
+    aiohttp = _import_aiohttp()
+    url = _normalize_server_url(server) + "/v1/chat/completions"
+    semaphore = asyncio.Semaphore(concurrency)
+
+    async def _worker(slot: int, prompt: list[dict[str, Any]]) -> int | None:
+        """Return the request's completion-token count, or ``None`` on failure."""
+        payload = {
+            "model": gen_cfg.model,
+            "messages": prompt,
+            "max_tokens": gen_cfg.max_new_tokens,
+            "temperature": gen_cfg.temperature,
+            "top_p": gen_cfg.top_p,
+        }
+        async with semaphore:
+            try:
+                return await _chat_completion(session, url, payload, timeout_s=timeout_s, max_retries=max_retries)
+            except Exception as exc:  # noqa: BLE001 -- one bad request must not abort the run
+                logger.warning("Request %d failed: %s", slot, exc)
+                return None
+
+    async with aiohttp.ClientSession() as session:
+        start = time.perf_counter()
+        token_counts = await asyncio.gather(*[_worker(i, prompt) for i, prompt in enumerate(prompts)])
+        wall_clock_s = time.perf_counter() - start
+
+    completed = [c for c in token_counts if c is not None]
+    return WorkloadResult(
+        wall_clock_s=wall_clock_s,
+        output_tokens=sum(completed),
+        completed=len(completed),
+        failed=len(token_counts) - len(completed),
+    )
+
+
+def _load_prompts(args: argparse.Namespace) -> list[list[dict[str, Any]]]:
+    """Load up to ``--num-prompts`` chat prompts (trailing assistant turn dropped)."""
+    from nemo_automodel.components.datasets.llm.chat_dataset import _load_openai_messages
+
+    dataset = _load_openai_messages(
+        args.input_data,
+        split=args.split,
+        name=args.dataset_name,
+        shuffle_seed=args.shuffle_seed,
+    )
+    prompts: list[list[dict[str, Any]]] = []
+    for row in dataset:
+        prompt = _extract_prompt_messages(row[args.messages_column])
+        if prompt is not None:
+            prompts.append(prompt)
+        if len(prompts) >= args.num_prompts:
+            break
+    return prompts
+
+
+def _validate_workload_args(args: argparse.Namespace) -> None:
+    """Reject invalid values of the CLI flags every benchmark shares."""
+    if args.num_prompts < 1:
+        raise ValueError(f"--num-prompts must be >= 1, got {args.num_prompts}")
+    if args.concurrency < 1:
+        raise ValueError(f"--concurrency must be >= 1, got {args.concurrency}")
+    if args.max_new_tokens < 1:
+        raise ValueError(f"--max-new-tokens must be >= 1, got {args.max_new_tokens}")
+    if args.max_retries < 0:
+        raise ValueError(f"--max-retries must be >= 0, got {args.max_retries}")
+    if args.timeout_s <= 0:
+        raise ValueError(f"--timeout-s must be > 0, got {args.timeout_s}")

--- a/nemo_automodel/components/speculative/bench_sglang.py
+++ b/nemo_automodel/components/speculative/bench_sglang.py
@@ -59,30 +59,26 @@ import asyncio
 import json
 import logging
 import sys
-import time
-from dataclasses import dataclass
 from typing import Any
 
-# ``GenerationConfig`` (model + sampling params for a chat completion) is shared
-# with the regeneration tool -- same four fields, same meaning -- so reuse it
-# rather than redefining an identical dataclass here.
+# The chat-completions workload machinery (prompt loading, the timed HTTP pass,
+# throughput / speedup math, shared CLI bounds) is engine-agnostic and shared
+# with ``bench_vllm``; only the acceptance-statistics source below is SGLang's.
+from nemo_automodel.components.speculative.bench_common import (
+    WorkloadResult,
+    _load_prompts,
+    _normalize_server_url,
+    _output_throughput,
+    _run_workload,
+    _speedup,
+    _validate_workload_args,
+)
 from nemo_automodel.components.speculative.regenerate import (
     GenerationConfig,
-    _extract_prompt_messages,
     _import_aiohttp,
 )
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass
-class WorkloadResult:
-    """Aggregate timing for one workload pass against a server."""
-
-    wall_clock_s: float
-    output_tokens: int
-    completed: int
-    failed: int
 
 
 # ---------------------------------------------------------------------------
@@ -150,119 +146,6 @@ def _acceptance_rate(accept_length: float | None, num_steps: int | None) -> floa
     return max(0.0, (accept_length - 1.0) / num_steps)
 
 
-def _speedup(spec_throughput: float | None, baseline_throughput: float | None) -> float | None:
-    """Return ``spec / baseline`` output throughput, or ``None`` if not computable."""
-    if not spec_throughput or not baseline_throughput or baseline_throughput <= 0:
-        return None
-    return spec_throughput / baseline_throughput
-
-
-def _output_throughput(result: WorkloadResult) -> float | None:
-    """Output tokens per wall-clock second, or ``None`` if nothing was timed."""
-    if result.wall_clock_s <= 0 or result.output_tokens <= 0:
-        return None
-    return result.output_tokens / result.wall_clock_s
-
-
-# ---------------------------------------------------------------------------
-# HTTP workload
-# ---------------------------------------------------------------------------
-
-
-def _normalize_server_url(url: str) -> str:
-    """Return the SGLang root URL without a trailing slash or ``/v1`` suffix.
-
-    Chat completions live at ``<root>/v1/chat/completions`` and server info at
-    ``<root>/server_info``; accept either ``http://host:port`` or the OpenAI-style
-    ``http://host:port/v1`` so the flag is forgiving.
-    """
-    root = url.rstrip("/")
-    if root.endswith("/v1"):
-        root = root[: -len("/v1")]
-    return root
-
-
-async def _chat_completion(
-    session,
-    url: str,
-    payload: dict[str, Any],
-    *,
-    timeout_s: float,
-    max_retries: int,
-) -> int:
-    """POST one chat completion and return its ``completion_tokens`` (0 on no usage)."""
-    aiohttp = _import_aiohttp()
-    last_err: Exception | None = None
-    for attempt in range(max_retries + 1):
-        try:
-            async with session.post(url, json=payload, timeout=aiohttp.ClientTimeout(total=timeout_s)) as resp:
-                if resp.status >= 500 or resp.status == 429:
-                    text = await resp.text()
-                    raise RuntimeError(f"HTTP {resp.status} from {url}: {text[:200]}")
-                resp.raise_for_status()
-                data = await resp.json()
-                usage = data.get("usage") if isinstance(data, dict) else None
-                if isinstance(usage, dict) and isinstance(usage.get("completion_tokens"), int):
-                    return usage["completion_tokens"]
-                return 0
-        except aiohttp.ClientResponseError:
-            # 5xx and 429 are turned into RuntimeError above, so the only status
-            # that reaches raise_for_status() is a non-429 4xx (400/401/403/404,
-            # ...) -- a client error that will not succeed on retry. Surface it
-            # immediately instead of burning the whole retry budget on it.
-            raise
-        except Exception as exc:  # noqa: BLE001 -- retry transport / 5xx / 429 errors
-            last_err = exc
-            if attempt == max_retries:
-                raise
-            await asyncio.sleep(min(2.0**attempt, 30.0))
-    raise RuntimeError(f"Unreachable: retries exhausted without raising. Last error: {last_err}")
-
-
-async def _run_workload(
-    server: str,
-    prompts: list[list[dict[str, Any]]],
-    gen_cfg: GenerationConfig,
-    *,
-    concurrency: int,
-    timeout_s: float,
-    max_retries: int,
-) -> WorkloadResult:
-    """Send every prompt through ``<server>/v1/chat/completions`` and time the pass."""
-    aiohttp = _import_aiohttp()
-    url = _normalize_server_url(server) + "/v1/chat/completions"
-    semaphore = asyncio.Semaphore(concurrency)
-
-    async def _worker(slot: int, prompt: list[dict[str, Any]]) -> int | None:
-        """Return the request's completion-token count, or ``None`` on failure."""
-        payload = {
-            "model": gen_cfg.model,
-            "messages": prompt,
-            "max_tokens": gen_cfg.max_new_tokens,
-            "temperature": gen_cfg.temperature,
-            "top_p": gen_cfg.top_p,
-        }
-        async with semaphore:
-            try:
-                return await _chat_completion(session, url, payload, timeout_s=timeout_s, max_retries=max_retries)
-            except Exception as exc:  # noqa: BLE001 -- one bad request must not abort the run
-                logger.warning("Request %d failed: %s", slot, exc)
-                return None
-
-    async with aiohttp.ClientSession() as session:
-        start = time.perf_counter()
-        token_counts = await asyncio.gather(*[_worker(i, prompt) for i, prompt in enumerate(prompts)])
-        wall_clock_s = time.perf_counter() - start
-
-    completed = [c for c in token_counts if c is not None]
-    return WorkloadResult(
-        wall_clock_s=wall_clock_s,
-        output_tokens=sum(completed),
-        completed=len(completed),
-        failed=len(token_counts) - len(completed),
-    )
-
-
 async def _fetch_server_info(server: str, *, timeout_s: float) -> dict[str, Any] | None:
     """GET ``<server>/server_info``; return the parsed JSON or ``None`` on failure."""
     aiohttp = _import_aiohttp()
@@ -282,26 +165,6 @@ async def _fetch_server_info(server: str, *, timeout_s: float) -> dict[str, Any]
 # ---------------------------------------------------------------------------
 # Orchestration
 # ---------------------------------------------------------------------------
-
-
-def _load_prompts(args: argparse.Namespace) -> list[list[dict[str, Any]]]:
-    """Load up to ``--num-prompts`` chat prompts (trailing assistant turn dropped)."""
-    from nemo_automodel.components.datasets.llm.chat_dataset import _load_openai_messages
-
-    dataset = _load_openai_messages(
-        args.input_data,
-        split=args.split,
-        name=args.dataset_name,
-        shuffle_seed=args.shuffle_seed,
-    )
-    prompts: list[list[dict[str, Any]]] = []
-    for row in dataset:
-        prompt = _extract_prompt_messages(row[args.messages_column])
-        if prompt is not None:
-            prompts.append(prompt)
-        if len(prompts) >= args.num_prompts:
-            break
-    return prompts
 
 
 def _summarize(
@@ -342,16 +205,7 @@ def _summarize(
 
 def _validate_args(args: argparse.Namespace) -> None:
     """Reject invalid CLI values before any network work starts."""
-    if args.num_prompts < 1:
-        raise ValueError(f"--num-prompts must be >= 1, got {args.num_prompts}")
-    if args.concurrency < 1:
-        raise ValueError(f"--concurrency must be >= 1, got {args.concurrency}")
-    if args.max_new_tokens < 1:
-        raise ValueError(f"--max-new-tokens must be >= 1, got {args.max_new_tokens}")
-    if args.max_retries < 0:
-        raise ValueError(f"--max-retries must be >= 0, got {args.max_retries}")
-    if args.timeout_s <= 0:
-        raise ValueError(f"--timeout-s must be > 0, got {args.timeout_s}")
+    _validate_workload_args(args)
     if args.num_steps is not None and args.num_steps < 1:
         raise ValueError(f"--num-steps must be >= 1 when set, got {args.num_steps}")
 

--- a/nemo_automodel/components/speculative/bench_vllm.py
+++ b/nemo_automodel/components/speculative/bench_vllm.py
@@ -1,0 +1,319 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Offline acceptance / speedup benchmark for a trained drafter served by vLLM.
+
+This is the vLLM companion to ``bench_sglang``: the same chat-completions
+workload machinery (which it imports), with the acceptance statistics read from
+vLLM's Prometheus ``/metrics`` endpoint instead of SGLang's ``/server_info``.
+It covers every drafter ``serve_vllm`` can launch -- EAGLE-3, P-EAGLE, and the
+DFlash family -- and reports:
+
+* ``accept_length`` -- mean tokens emitted per target verification step,
+  including the one guaranteed bonus token:
+  ``1 + num_accepted_tokens / num_drafts``.
+* ``acceptance_rate`` -- fraction of proposed draft tokens accepted:
+  ``num_accepted_tokens / num_draft_tokens``.
+* ``output_throughput_tok_s`` -- measured decode throughput (output tokens per
+  wall-clock second).
+* ``speedup`` -- optional: throughput divided by the same workload's throughput
+  against a ``--baseline-server`` running *without* speculation.
+
+The spec-decode counters (``vllm:spec_decode_num_drafts_total``,
+``vllm:spec_decode_num_draft_tokens_total``,
+``vllm:spec_decode_num_accepted_tokens_total``) are snapshotted before and after
+the workload and differenced, so -- unlike SGLang's server-cumulative
+``avg_spec_accept_length`` -- the numbers cover exactly this benchmark's
+requests even on a server that has already handled other traffic.
+
+Typical usage (after ``serve_vllm`` launches the drafter on port 8000):
+
+    python -m nemo_automodel.components.speculative.bench_vllm \\
+        --server http://localhost:8000 \\
+        --model Qwen/Qwen3-8B \\
+        --input-data Aeala/ShareGPT_Vicuna_unfiltered \\
+        --num-prompts 64 --concurrency 16 --max-new-tokens 256
+
+Add ``--baseline-server http://localhost:8001`` (a second server started
+without ``--speculative-config``) to also report the end-to-end speedup.
+
+vLLM is intentionally NOT a dependency of this script -- it talks to the server
+over HTTP, so only ``aiohttp`` is required (already pulled in by the project).
+The server itself must be running separately; see ``serve_vllm``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+from nemo_automodel.components.speculative.bench_common import (
+    WorkloadResult,
+    _load_prompts,
+    _normalize_server_url,
+    _output_throughput,
+    _run_workload,
+    _speedup,
+    _validate_workload_args,
+)
+from nemo_automodel.components.speculative.regenerate import (
+    GenerationConfig,
+    _import_aiohttp,
+)
+
+logger = logging.getLogger(__name__)
+
+# Prometheus sample names of vLLM's spec-decode counters (the ``_total`` suffix
+# is appended by the Prometheus client to every Counter).
+_METRIC_NUM_DRAFTS = "vllm:spec_decode_num_drafts_total"
+_METRIC_NUM_DRAFT_TOKENS = "vllm:spec_decode_num_draft_tokens_total"
+_METRIC_NUM_ACCEPTED_TOKENS = "vllm:spec_decode_num_accepted_tokens_total"
+_SPEC_METRIC_NAMES = (_METRIC_NUM_DRAFTS, _METRIC_NUM_DRAFT_TOKENS, _METRIC_NUM_ACCEPTED_TOKENS)
+
+
+@dataclass(frozen=True)
+class SpecMetrics:
+    """One snapshot of vLLM's cumulative spec-decode counters."""
+
+    num_drafts: float
+    num_draft_tokens: float
+    num_accepted_tokens: float
+
+    def delta(self, before: SpecMetrics) -> SpecMetrics:
+        """Return the counter increase since ``before`` (clamped at zero per counter)."""
+        return SpecMetrics(
+            num_drafts=max(0.0, self.num_drafts - before.num_drafts),
+            num_draft_tokens=max(0.0, self.num_draft_tokens - before.num_draft_tokens),
+            num_accepted_tokens=max(0.0, self.num_accepted_tokens - before.num_accepted_tokens),
+        )
+
+
+def _parse_spec_metrics(metrics_text: str) -> SpecMetrics | None:
+    """Parse the spec-decode counters out of a Prometheus exposition payload.
+
+    Values are summed across label sets (multiple engines / model labels), and
+    ``None`` is returned when the drafts counter is absent -- i.e. the server is
+    not running with speculative decoding.
+    """
+    totals = dict.fromkeys(_SPEC_METRIC_NAMES, 0.0)
+    drafts_seen = False
+    for line in metrics_text.splitlines():
+        if not line or line.startswith("#"):
+            continue
+        name = line.split("{", 1)[0].split(" ", 1)[0]
+        if name not in totals:
+            continue
+        try:
+            totals[name] += float(line.rsplit(" ", 1)[-1])
+        except ValueError:
+            continue
+        drafts_seen = drafts_seen or name == _METRIC_NUM_DRAFTS
+    if not drafts_seen:
+        return None
+    return SpecMetrics(
+        num_drafts=totals[_METRIC_NUM_DRAFTS],
+        num_draft_tokens=totals[_METRIC_NUM_DRAFT_TOKENS],
+        num_accepted_tokens=totals[_METRIC_NUM_ACCEPTED_TOKENS],
+    )
+
+
+async def _fetch_spec_metrics(server: str, *, timeout_s: float) -> SpecMetrics | None:
+    """GET ``<server>/metrics`` and parse the spec-decode counters; ``None`` on failure."""
+    aiohttp = _import_aiohttp()
+    url = _normalize_server_url(server) + "/metrics"
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, timeout=aiohttp.ClientTimeout(total=timeout_s)) as resp:
+                if resp.status != 200:
+                    logger.warning("GET %s returned HTTP %d; acceptance metrics unavailable.", url, resp.status)
+                    return None
+                return _parse_spec_metrics(await resp.text())
+    except Exception as exc:  # noqa: BLE001 -- metrics are best-effort
+        logger.warning("Failed to query %s (%s); acceptance metrics unavailable.", url, exc)
+        return None
+
+
+def _accept_length(delta: SpecMetrics | None) -> float | None:
+    """Mean tokens per verify step incl. the bonus token: ``1 + accepted / drafts``."""
+    if delta is None or delta.num_drafts <= 0:
+        return None
+    return 1.0 + delta.num_accepted_tokens / delta.num_drafts
+
+
+def _acceptance_rate(delta: SpecMetrics | None) -> float | None:
+    """Fraction of proposed draft tokens accepted: ``accepted / draft_tokens``."""
+    if delta is None or delta.num_draft_tokens <= 0:
+        return None
+    return delta.num_accepted_tokens / delta.num_draft_tokens
+
+
+def _summarize(
+    *,
+    gen_cfg: GenerationConfig,
+    spec_result: WorkloadResult,
+    metrics_delta: SpecMetrics | None,
+    baseline_result: WorkloadResult | None,
+) -> dict[str, Any]:
+    """Assemble the metrics dict reported to stdout / ``--output-json``."""
+    spec_throughput = _output_throughput(spec_result)
+    accept_length = _accept_length(metrics_delta)
+
+    summary: dict[str, Any] = {
+        "model": gen_cfg.model,
+        "num_prompts": spec_result.completed + spec_result.failed,
+        "completed": spec_result.completed,
+        "failed": spec_result.failed,
+        "output_tokens": spec_result.output_tokens,
+        "wall_clock_s": round(spec_result.wall_clock_s, 4),
+        "output_throughput_tok_s": round(spec_throughput, 4) if spec_throughput is not None else None,
+        "accept_length": round(accept_length, 4) if accept_length is not None else None,
+        "acceptance_rate": _acceptance_rate(metrics_delta),
+        "num_drafts": int(metrics_delta.num_drafts) if metrics_delta is not None else None,
+        "num_draft_tokens": int(metrics_delta.num_draft_tokens) if metrics_delta is not None else None,
+        "num_accepted_tokens": int(metrics_delta.num_accepted_tokens) if metrics_delta is not None else None,
+    }
+    if baseline_result is not None:
+        baseline_throughput = _output_throughput(baseline_result)
+        summary["baseline_throughput_tok_s"] = (
+            round(baseline_throughput, 4) if baseline_throughput is not None else None
+        )
+        summary["speedup"] = _speedup(spec_throughput, baseline_throughput)
+    return summary
+
+
+async def _run(args: argparse.Namespace) -> int:
+    """Async driver: load prompts, run the workload(s), report metrics. Returns an exit code."""
+    _validate_workload_args(args)
+    gen_cfg = GenerationConfig(
+        model=args.model,
+        max_new_tokens=args.max_new_tokens,
+        temperature=args.temperature,
+        top_p=args.top_p,
+    )
+    prompts = _load_prompts(args)
+    if not prompts:
+        logger.error("No usable prompts loaded from %s; nothing to benchmark.", args.input_data)
+        return 1
+    logger.info("Benchmarking %d prompts against %s", len(prompts), args.server)
+
+    metrics_before = await _fetch_spec_metrics(args.server, timeout_s=args.timeout_s)
+    spec_result = await _run_workload(
+        args.server,
+        prompts,
+        gen_cfg,
+        concurrency=args.concurrency,
+        timeout_s=args.timeout_s,
+        max_retries=args.max_retries,
+    )
+    metrics_after = await _fetch_spec_metrics(args.server, timeout_s=args.timeout_s)
+    metrics_delta = None
+    if metrics_after is not None:
+        # A missing "before" snapshot (e.g. the server came up mid-setup) falls
+        # back to the cumulative counters, which is exact for a fresh server.
+        metrics_delta = metrics_after.delta(metrics_before) if metrics_before is not None else metrics_after
+
+    baseline_result = None
+    if args.baseline_server:
+        logger.info("Running baseline workload against %s", args.baseline_server)
+        baseline_result = await _run_workload(
+            args.baseline_server,
+            prompts,
+            gen_cfg,
+            concurrency=args.concurrency,
+            timeout_s=args.timeout_s,
+            max_retries=args.max_retries,
+        )
+
+    summary = _summarize(
+        gen_cfg=gen_cfg,
+        spec_result=spec_result,
+        metrics_delta=metrics_delta,
+        baseline_result=baseline_result,
+    )
+    if summary["accept_length"] is None:
+        logger.warning(
+            "Server did not report spec-decode counters on /metrics. Is speculative decoding "
+            "enabled on %s? Throughput is still reported.",
+            args.server,
+        )
+
+    rendered = json.dumps(summary, indent=2)
+    print(rendered)
+    if args.output_json:
+        with open(args.output_json, "w") as f:
+            f.write(rendered + "\n")
+        logger.info("Wrote metrics to %s", args.output_json)
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Benchmark a trained drafter served by vLLM (EAGLE-3 / P-EAGLE / DFlash): "
+            "acceptance length, rate, and speedup."
+        ),
+    )
+    parser.add_argument(
+        "--server",
+        required=True,
+        help="Root URL of the running vLLM server hosting the drafter, e.g. http://localhost:8000.",
+    )
+    parser.add_argument(
+        "--model",
+        required=True,
+        help="Served model name to send in the chat payload (the vLLM --served-model-name / --model).",
+    )
+    parser.add_argument(
+        "--input-data",
+        required=True,
+        help="HF dataset id or local path (parquet/dir/json/jsonl) with a chat messages column.",
+    )
+    parser.add_argument(
+        "--baseline-server",
+        default=None,
+        help="Optional second vLLM server running WITHOUT speculation; enables the speedup metric.",
+    )
+    parser.add_argument("--num-prompts", type=int, default=64, help="Number of prompts to send.")
+    parser.add_argument("--concurrency", type=int, default=16, help="Maximum in-flight requests.")
+    parser.add_argument("--max-new-tokens", type=int, default=256, help="max_tokens per request.")
+    parser.add_argument("--temperature", type=float, default=0.0, help="Default 0.0 = greedy.")
+    parser.add_argument("--top-p", type=float, default=1.0)
+    parser.add_argument("--messages-column", default="messages", help="Column holding the OpenAI messages list.")
+    parser.add_argument("--split", default="train", help="HF dataset split (supports slice syntax).")
+    parser.add_argument("--dataset-name", default=None, help="HF dataset configuration name, if any.")
+    parser.add_argument("--shuffle-seed", type=int, default=None, help="Optional shuffle seed before slicing.")
+    parser.add_argument("--timeout-s", type=float, default=600.0, help="Per-request timeout in seconds.")
+    parser.add_argument("--max-retries", type=int, default=3, help="Retries on 5xx / 429 / transport errors.")
+    parser.add_argument("--output-json", default=None, help="Optional path to also write the metrics JSON to.")
+    parser.add_argument("--log-level", default="INFO")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Parses ``argv`` and returns the process exit code."""
+    args = _build_parser().parse_args(argv)
+    logging.basicConfig(
+        level=getattr(logging, args.log_level.upper(), logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    return asyncio.run(_run(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit_tests/speculative/test_bench_sglang.py
+++ b/tests/unit_tests/speculative/test_bench_sglang.py
@@ -27,7 +27,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from nemo_automodel.components.speculative import bench_sglang
+from nemo_automodel.components.speculative import bench_common, bench_sglang
 from nemo_automodel.components.speculative.bench_sglang import (
     GenerationConfig,
     WorkloadResult,
@@ -264,20 +264,22 @@ def _fake_aiohttp(session):
 
 
 def _patch_aiohttp(monkeypatch, session):
+    # _chat_completion/_run_workload live in bench_common; _fetch_server_info in bench_sglang.
+    monkeypatch.setattr(bench_common, "_import_aiohttp", lambda: _fake_aiohttp(session))
     monkeypatch.setattr(bench_sglang, "_import_aiohttp", lambda: _fake_aiohttp(session))
 
     # No real backoff sleeps in retry tests.
     async def _no_sleep(_):
         return None
 
-    monkeypatch.setattr(bench_sglang.asyncio, "sleep", _no_sleep)
+    monkeypatch.setattr(bench_common.asyncio, "sleep", _no_sleep)
 
 
 def test_chat_completion_returns_completion_tokens(monkeypatch):
     session = _FakeSession(post_responses=[_FakeResponse(200, {"usage": {"completion_tokens": 17}})])
     _patch_aiohttp(monkeypatch, session)
     tokens = asyncio.run(
-        bench_sglang._chat_completion(session, "http://x/v1/chat/completions", {}, timeout_s=1.0, max_retries=0)
+        bench_common._chat_completion(session, "http://x/v1/chat/completions", {}, timeout_s=1.0, max_retries=0)
     )
     assert tokens == 17
 
@@ -285,7 +287,7 @@ def test_chat_completion_returns_completion_tokens(monkeypatch):
 def test_chat_completion_missing_usage_returns_zero(monkeypatch):
     session = _FakeSession(post_responses=[_FakeResponse(200, {"choices": []})])
     _patch_aiohttp(monkeypatch, session)
-    tokens = asyncio.run(bench_sglang._chat_completion(session, "http://x", {}, timeout_s=1.0, max_retries=0))
+    tokens = asyncio.run(bench_common._chat_completion(session, "http://x", {}, timeout_s=1.0, max_retries=0))
     assert tokens == 0
 
 
@@ -297,7 +299,7 @@ def test_chat_completion_retries_then_succeeds(monkeypatch):
         ]
     )
     _patch_aiohttp(monkeypatch, session)
-    tokens = asyncio.run(bench_sglang._chat_completion(session, "http://x", {}, timeout_s=1.0, max_retries=2))
+    tokens = asyncio.run(bench_common._chat_completion(session, "http://x", {}, timeout_s=1.0, max_retries=2))
     assert tokens == 5
     assert len(session.post_calls) == 2
 
@@ -306,7 +308,7 @@ def test_chat_completion_raises_after_max_retries(monkeypatch):
     session = _FakeSession(post_responses=[_FakeResponse(503, text="down"), _FakeResponse(503, text="down")])
     _patch_aiohttp(monkeypatch, session)
     with pytest.raises(RuntimeError, match="HTTP 503"):
-        asyncio.run(bench_sglang._chat_completion(session, "http://x", {}, timeout_s=1.0, max_retries=1))
+        asyncio.run(bench_common._chat_completion(session, "http://x", {}, timeout_s=1.0, max_retries=1))
 
 
 def test_chat_completion_does_not_retry_non_retryable_4xx(monkeypatch):
@@ -316,7 +318,7 @@ def test_chat_completion_does_not_retry_non_retryable_4xx(monkeypatch):
     session = _FakeSession(post_responses=[_FakeResponse(404, text="not found")] * 4)
     _patch_aiohttp(monkeypatch, session)
     with pytest.raises(_FakeClientResponseError):
-        asyncio.run(bench_sglang._chat_completion(session, "http://x", {}, timeout_s=1.0, max_retries=3))
+        asyncio.run(bench_common._chat_completion(session, "http://x", {}, timeout_s=1.0, max_retries=3))
     assert len(session.post_calls) == 1
 
 
@@ -408,7 +410,7 @@ def test_load_prompts_caps_and_drops_unusable(monkeypatch):
     )
     # "b" yields no usable prompt and must be skipped; the cap stops at 2.
     monkeypatch.setattr(
-        bench_sglang,
+        bench_common,
         "_extract_prompt_messages",
         lambda m: None if m == "b" else [{"role": "user", "content": m}],
     )

--- a/tests/unit_tests/speculative/test_bench_vllm.py
+++ b/tests/unit_tests/speculative/test_bench_vllm.py
@@ -1,0 +1,339 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from nemo_automodel.components.speculative import bench_vllm
+from nemo_automodel.components.speculative.bench_common import WorkloadResult, _validate_workload_args
+from nemo_automodel.components.speculative.bench_vllm import (
+    SpecMetrics,
+    _accept_length,
+    _acceptance_rate,
+    _fetch_spec_metrics,
+    _parse_spec_metrics,
+    _summarize,
+)
+from nemo_automodel.components.speculative.regenerate import GenerationConfig
+
+_METRICS_TEXT = """\
+# HELP vllm:spec_decode_num_drafts_total Number of spec decoding drafts.
+# TYPE vllm:spec_decode_num_drafts_total counter
+vllm:spec_decode_num_drafts_total{engine="0",model_name="Qwen/Qwen3-8B"} 100.0
+vllm:spec_decode_num_draft_tokens_total{engine="0",model_name="Qwen/Qwen3-8B"} 1500.0
+vllm:spec_decode_num_accepted_tokens_total{engine="0",model_name="Qwen/Qwen3-8B"} 900.0
+vllm:num_requests_running{engine="0"} 0.0
+"""
+
+
+# ---------------------------------------------------------------------------
+# Prometheus parsing
+# ---------------------------------------------------------------------------
+def test_parse_spec_metrics_reads_all_counters():
+    metrics = _parse_spec_metrics(_METRICS_TEXT)
+    assert metrics == SpecMetrics(num_drafts=100.0, num_draft_tokens=1500.0, num_accepted_tokens=900.0)
+
+
+def test_parse_spec_metrics_sums_label_sets():
+    """Counters split across engines (label sets) are summed."""
+    two_engines = _METRICS_TEXT + (
+        'vllm:spec_decode_num_drafts_total{engine="1",model_name="Qwen/Qwen3-8B"} 50.0\n'
+        'vllm:spec_decode_num_accepted_tokens_total{engine="1",model_name="Qwen/Qwen3-8B"} 100.0\n'
+    )
+    metrics = _parse_spec_metrics(two_engines)
+    assert metrics.num_drafts == 150.0
+    assert metrics.num_accepted_tokens == 1000.0
+
+
+def test_parse_spec_metrics_without_spec_counters_returns_none():
+    """A server without speculative decoding exposes no spec counters."""
+    assert _parse_spec_metrics("vllm:num_requests_running 0.0\n") is None
+
+
+def test_parse_spec_metrics_unlabeled_samples():
+    """Samples without a label block (bare `name value`) parse too."""
+    text = (
+        "vllm:spec_decode_num_drafts_total 10\n"
+        "vllm:spec_decode_num_draft_tokens_total 70\n"
+        "vllm:spec_decode_num_accepted_tokens_total 30\n"
+    )
+    assert _parse_spec_metrics(text) == SpecMetrics(10.0, 70.0, 30.0)
+
+
+def test_parse_spec_metrics_skips_malformed_values():
+    text = "vllm:spec_decode_num_drafts_total NaN-ish\nvllm:spec_decode_num_drafts_total 5\n"
+    metrics = _parse_spec_metrics(text)
+    assert metrics is not None
+    assert metrics.num_drafts == 5.0
+
+
+# ---------------------------------------------------------------------------
+# Acceptance math
+# ---------------------------------------------------------------------------
+def test_delta_subtracts_and_clamps():
+    before = SpecMetrics(100.0, 1500.0, 900.0)
+    after = SpecMetrics(160.0, 2400.0, 1500.0)
+    assert after.delta(before) == SpecMetrics(60.0, 900.0, 600.0)
+    # A counter reset (server restart mid-run) clamps at zero instead of going negative.
+    assert before.delta(after) == SpecMetrics(0.0, 0.0, 0.0)
+
+
+def test_accept_length_includes_bonus_token():
+    assert _accept_length(SpecMetrics(num_drafts=100, num_draft_tokens=1500, num_accepted_tokens=900)) == 10.0
+
+
+def test_accept_length_none_cases():
+    assert _accept_length(None) is None
+    assert _accept_length(SpecMetrics(0, 0, 0)) is None
+
+
+def test_acceptance_rate():
+    assert _acceptance_rate(SpecMetrics(100, 1500, 900)) == pytest.approx(0.6)
+    assert _acceptance_rate(None) is None
+    assert _acceptance_rate(SpecMetrics(1, 0, 0)) is None
+
+
+# ---------------------------------------------------------------------------
+# Summary assembly
+# ---------------------------------------------------------------------------
+def _gen_cfg() -> GenerationConfig:
+    return GenerationConfig(model="Qwen/Qwen3-8B", max_new_tokens=64, temperature=0.0, top_p=1.0)
+
+
+def test_summarize_full():
+    summary = _summarize(
+        gen_cfg=_gen_cfg(),
+        spec_result=WorkloadResult(wall_clock_s=2.0, output_tokens=400, completed=8, failed=0),
+        metrics_delta=SpecMetrics(num_drafts=50, num_draft_tokens=750, num_accepted_tokens=450),
+        baseline_result=WorkloadResult(wall_clock_s=4.0, output_tokens=400, completed=8, failed=0),
+    )
+    assert summary["accept_length"] == 10.0
+    assert summary["acceptance_rate"] == pytest.approx(0.6)
+    assert summary["num_drafts"] == 50
+    assert summary["output_throughput_tok_s"] == 200.0
+    assert summary["baseline_throughput_tok_s"] == 100.0
+    assert summary["speedup"] == 2.0
+
+
+def test_summarize_without_metrics_or_baseline():
+    summary = _summarize(
+        gen_cfg=_gen_cfg(),
+        spec_result=WorkloadResult(wall_clock_s=2.0, output_tokens=400, completed=8, failed=0),
+        metrics_delta=None,
+        baseline_result=None,
+    )
+    assert summary["accept_length"] is None
+    assert summary["acceptance_rate"] is None
+    assert summary["num_drafts"] is None
+    assert "speedup" not in summary
+
+
+# ---------------------------------------------------------------------------
+# /metrics fetching (fake aiohttp)
+# ---------------------------------------------------------------------------
+class _FakeResponse:
+    def __init__(self, status, text=""):
+        self.status = status
+        self._text = text
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def text(self):
+        return self._text
+
+
+class _FakeSession:
+    def __init__(self, get_response):
+        self._get_response = get_response
+        self.get_calls: list[str] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def get(self, url, *, timeout=None):
+        self.get_calls.append(url)
+        return self._get_response
+
+
+def _patch_aiohttp(monkeypatch, session):
+    fake = SimpleNamespace(ClientSession=lambda *a, **k: session, ClientTimeout=lambda total=None: None)
+    monkeypatch.setattr(bench_vllm, "_import_aiohttp", lambda: fake)
+
+
+def test_fetch_spec_metrics_hits_metrics_endpoint(monkeypatch):
+    session = _FakeSession(_FakeResponse(200, _METRICS_TEXT))
+    _patch_aiohttp(monkeypatch, session)
+    metrics = asyncio.run(_fetch_spec_metrics("http://localhost:8000/v1", timeout_s=1.0))
+    assert session.get_calls == ["http://localhost:8000/metrics"]
+    assert metrics.num_drafts == 100.0
+
+
+def test_fetch_spec_metrics_non_200_returns_none(monkeypatch):
+    session = _FakeSession(_FakeResponse(404))
+    _patch_aiohttp(monkeypatch, session)
+    assert asyncio.run(_fetch_spec_metrics("http://localhost:8000", timeout_s=1.0)) is None
+
+
+def test_fetch_spec_metrics_transport_error_returns_none(monkeypatch):
+    class _BoomSession(_FakeSession):
+        def get(self, url, *, timeout=None):
+            raise ConnectionError("boom")
+
+    _patch_aiohttp(monkeypatch, _BoomSession(None))
+    assert asyncio.run(_fetch_spec_metrics("http://localhost:8000", timeout_s=1.0)) is None
+
+
+# ---------------------------------------------------------------------------
+# Arg validation + orchestration
+# ---------------------------------------------------------------------------
+def _args(**overrides) -> argparse.Namespace:
+    base = dict(
+        server="http://localhost:8000",
+        model="Qwen/Qwen3-8B",
+        input_data="dummy.jsonl",
+        baseline_server=None,
+        num_prompts=2,
+        concurrency=2,
+        max_new_tokens=8,
+        temperature=0.0,
+        top_p=1.0,
+        messages_column="messages",
+        split="train",
+        dataset_name=None,
+        shuffle_seed=None,
+        timeout_s=5.0,
+        max_retries=0,
+        output_json=None,
+        log_level="INFO",
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("num_prompts", 0),
+        ("concurrency", 0),
+        ("max_new_tokens", 0),
+        ("max_retries", -1),
+        ("timeout_s", 0.0),
+    ],
+)
+def test_validate_args_rejects(field, value):
+    with pytest.raises(ValueError, match=field.replace("_", "-")):
+        _validate_workload_args(_args(**{field: value}))
+
+
+def test_run_reports_delta_based_acceptance(monkeypatch, capsys):
+    """End-to-end orchestration: before/after snapshots difference into the summary."""
+    snapshots = [
+        SpecMetrics(num_drafts=100, num_draft_tokens=1500, num_accepted_tokens=900),
+        SpecMetrics(num_drafts=150, num_draft_tokens=2250, num_accepted_tokens=1300),
+    ]
+
+    async def _fake_fetch(server, *, timeout_s):
+        return snapshots.pop(0)
+
+    async def _fake_workload(server, prompts, gen_cfg, **kwargs):
+        return WorkloadResult(wall_clock_s=1.0, output_tokens=100, completed=2, failed=0)
+
+    monkeypatch.setattr(bench_vllm, "_fetch_spec_metrics", _fake_fetch)
+    monkeypatch.setattr(bench_vllm, "_run_workload", _fake_workload)
+    monkeypatch.setattr(bench_vllm, "_load_prompts", lambda args: [[{"role": "user", "content": "hi"}]] * 2)
+
+    rc = asyncio.run(bench_vllm._run(_args()))
+
+    assert rc == 0
+    summary = json.loads(capsys.readouterr().out)
+    # Delta: 50 drafts, 750 draft tokens, 400 accepted -> accept_length = 1 + 400/50 = 9.
+    assert summary["accept_length"] == 9.0
+    assert summary["acceptance_rate"] == pytest.approx(400 / 750)
+    assert summary["num_drafts"] == 50
+
+
+def test_run_without_before_snapshot_uses_cumulative(monkeypatch, capsys):
+    """If the first /metrics scrape fails, the after-snapshot is used as-is."""
+    snapshots = [None, SpecMetrics(num_drafts=10, num_draft_tokens=150, num_accepted_tokens=50)]
+
+    async def _fake_fetch(server, *, timeout_s):
+        return snapshots.pop(0)
+
+    async def _fake_workload(server, prompts, gen_cfg, **kwargs):
+        return WorkloadResult(wall_clock_s=1.0, output_tokens=100, completed=2, failed=0)
+
+    monkeypatch.setattr(bench_vllm, "_fetch_spec_metrics", _fake_fetch)
+    monkeypatch.setattr(bench_vllm, "_run_workload", _fake_workload)
+    monkeypatch.setattr(bench_vllm, "_load_prompts", lambda args: [[{"role": "user", "content": "hi"}]])
+
+    rc = asyncio.run(bench_vllm._run(_args()))
+
+    assert rc == 0
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["accept_length"] == 6.0
+
+
+def test_run_no_prompts_returns_error(monkeypatch):
+    monkeypatch.setattr(bench_vllm, "_load_prompts", lambda args: [])
+    rc = asyncio.run(bench_vllm._run(_args()))
+    assert rc == 1
+
+
+def test_run_with_baseline_reports_speedup(monkeypatch, capsys, tmp_path):
+    """A baseline server enables speedup; --output-json writes the same payload."""
+    calls = []
+
+    async def _fake_fetch(server, *, timeout_s):
+        return SpecMetrics(num_drafts=10, num_draft_tokens=150, num_accepted_tokens=50)
+
+    async def _fake_workload(server, prompts, gen_cfg, **kwargs):
+        calls.append(server)
+        wall = 1.0 if len(calls) == 1 else 2.0
+        return WorkloadResult(wall_clock_s=wall, output_tokens=100, completed=1, failed=0)
+
+    monkeypatch.setattr(bench_vllm, "_fetch_spec_metrics", _fake_fetch)
+    monkeypatch.setattr(bench_vllm, "_run_workload", _fake_workload)
+    monkeypatch.setattr(bench_vllm, "_load_prompts", lambda args: [[{"role": "user", "content": "hi"}]])
+    out_path = tmp_path / "metrics.json"
+
+    rc = asyncio.run(bench_vllm._run(_args(baseline_server="http://localhost:8001", output_json=str(out_path))))
+
+    assert rc == 0
+    assert calls == ["http://localhost:8000", "http://localhost:8001"]
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["speedup"] == 2.0
+    assert json.loads(out_path.read_text(encoding="utf-8")) == summary
+
+
+def test_main_parses_and_runs(monkeypatch):
+    async def _fake_run(args):
+        assert args.server == "http://localhost:8000"
+        return 0
+
+    monkeypatch.setattr(bench_vllm, "_run", _fake_run)
+    rc = bench_vllm.main(["--server", "http://localhost:8000", "--model", "m", "--input-data", "d.jsonl"])
+    assert rc == 0


### PR DESCRIPTION
## What does this PR do?

Adds `bench_vllm.py`, the vLLM companion to `bench_sglang`: an offline acceptance / speedup benchmark for any drafter served by vLLM (EAGLE-3, P-EAGLE, and the DFlash family once #2913 lands; works with plain `vllm serve --speculative-config` too).

- Acceptance statistics come from vLLM's Prometheus `/metrics` endpoint. The spec-decode counters (`vllm:spec_decode_num_drafts_total`, `..._num_draft_tokens_total`, `..._num_accepted_tokens_total`) are snapshotted before and after the workload and differenced, so the reported numbers cover exactly this benchmark's requests even on a server that has already handled other traffic (unlike SGLang's server-cumulative `avg_spec_accept_length`).
- Reports `accept_length` (`1 + accepted/drafts`, including the bonus token, matching the formula documented in vLLM's `SpecDecodingProm`), `acceptance_rate` (`accepted/draft_tokens`), output throughput, and an optional `speedup` against a `--baseline-server` running without speculation.
- The engine-agnostic workload machinery (prompt loading, the timed chat-completions pass, throughput/speedup math, shared CLI bounds) moves from `bench_sglang` into a new `bench_common` module now that it has two consumers. `bench_sglang` keeps only the SGLang-specific `/server_info` handling; no behavior change on the SGLang path.

## Verified end to end

Ran against a vLLM 0.24.0 server hosting Qwen3-4B with an Automodel-trained DFlash draft (16 prompts, concurrency 4): `accept_length 1.30`, `acceptance_rate 2.0%` (1555 drafts / 23325 draft tokens / 472 accepted), throughput 183.9 tok/s, 16/16 completed. The low acceptance matches the deliberately under-trained smoke draft (1000 optimizer steps); the point is the counters difference into exact per-run numbers.

## Tests

New `tests/unit_tests/speculative/test_bench_vllm.py` (24 tests: Prometheus parsing, delta/acceptance math, /metrics fetching, orchestration incl. baseline and output-json). `test_bench_sglang.py` retargeted to the moved helpers; full speculative suite passes (534 passed, 11 skipped).
