### PR TITLE
feat(speculative): serve DFlash and JetSpec drafts on vLLM

### DIFF
--- a/nemo_automodel/components/speculative/serve_vllm.py
+++ b/nemo_automodel/components/speculative/serve_vllm.py
@@ -12,14 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Serve an Automodel-trained EAGLE-3 / P-EAGLE drafter with vLLM.
+"""Serve an Automodel-trained EAGLE-3 / P-EAGLE / DFlash drafter with vLLM.
 
 This is the vLLM companion to ``serve_sglang``. It exists because the
 parallel-drafting (P-EAGLE) head produced by the EAGLE-3 recipe with
 ``parallel_drafting: true`` is *not* servable by SGLang today (``serve_sglang``
 rejects it); its inference runtime is vLLM's parallel-drafting path
 (vLLM >= 0.16, https://github.com/vllm-project/speculators/pull/480). The same
-entry point also serves a plain (non-parallel) EAGLE-3 draft under vLLM.
+entry point also serves a plain (non-parallel) EAGLE-3 draft under vLLM, and a
+DFlash-family draft (DFlash / JetSpec; vLLM's ``dflash`` method landed in 0.20).
 
 The EAGLE drafter checkpoints produced by the recipes are written by the
 consolidated checkpointer as an HF-style ``model/`` directory
@@ -72,6 +73,19 @@ Typical usage (after training produces a P-EAGLE checkpoint at
 so for a P-EAGLE head it can be omitted. Pass ``--print-only`` to inspect the
 command without launching it; in that mode the on-disk ``architectures`` rewrite
 is skipped and the printed paths reflect what a real launch would produce.
+
+DFlash family: a draft trained by the DFlash / JetSpec recipes (the config's
+``architectures`` is ``["Qwen3DFlashDraftModel"]``) is auto-detected and served
+with vLLM's ``dflash`` method -- ``--method`` can be omitted. Its weights carry
+no ``model.`` wrapper prefix and no embed/lm_head (vLLM shares the target's), so
+only the ``architectures`` rewrite (to vLLM's registered ``DFlashDraftModel``)
+applies, and K defaults to ``block_size - 1`` (a block is one anchor token plus
+``block_size - 1`` mask slots). A JetSpec draft is the same on-disk format
+trained with *causal* in-block attention: the recipe stamps
+``dflash_config.causal=true`` so vLLM matches it at inference; for a JetSpec
+checkpoint trained before that stamp existed, pass ``--dflash-causal``. A Domino
+draft is rejected: its GRU correction head (``prefix_gru`` / ``embed_proj``) has
+no vLLM runtime.
 """
 
 from __future__ import annotations
@@ -117,6 +131,12 @@ _VLLM_EXPORT_DIRNAME = "vllm_export"
 _AUTOMODEL_DRAFT_ARCHITECTURE = "LlamaEagle3DraftModel"
 _VLLM_DRAFT_ARCHITECTURE = "LlamaForCausalLMEagle3"
 
+# The DFlash recipes (DFlash / Domino / JetSpec all share one draft class) write
+# ``architectures=["Qwen3DFlashDraftModel"]``; vLLM's registry routes every
+# DFlash draft on ``DFlashDraftModel``.
+_AUTOMODEL_DFLASH_ARCHITECTURE = "Qwen3DFlashDraftModel"
+_VLLM_DFLASH_ARCHITECTURE = "DFlashDraftModel"
+
 
 def _check_vllm_available() -> None:
     """Verify the ``vllm`` package can actually be imported, else exit (code 2)."""
@@ -139,10 +159,45 @@ def _load_config(config_path: Path) -> dict[str, Any]:
         return json.load(f)
 
 
-def _vllm_config_updates(config: dict[str, Any]) -> dict[str, Any]:
+def _is_dflash_config(config: dict[str, Any]) -> bool:
+    """True when the draft config identifies a DFlash-family draft (DFlash / Domino / JetSpec)."""
+    architectures = config.get("architectures") or []
+    return any(arch in (_AUTOMODEL_DFLASH_ARCHITECTURE, _VLLM_DFLASH_ARCHITECTURE) for arch in architectures)
+
+
+def _resolve_method(cli_method: str | None, config: dict[str, Any]) -> str:
+    """Resolve the vLLM speculative method: explicit ``--method``, else detect from the draft config."""
+    if cli_method is not None:
+        return cli_method
+    return "dflash" if _is_dflash_config(config) else "eagle3"
+
+
+def _dflash_config_updates(config: dict[str, Any], *, dflash_causal: bool) -> dict[str, Any]:
+    """Return the ``config.json`` key changes needed for vLLM to load a DFlash-family draft.
+
+    Only the ``architectures`` rewrite (to vLLM's registered ``DFlashDraftModel``)
+    is required: the draft weights carry no ``model.`` prefix and vLLM reads
+    ``dflash_config.mask_token_id`` / ``dflash_config.target_layer_ids`` where the
+    recipe already writes them. ``--dflash-causal`` additionally stamps
+    ``dflash_config.causal=true`` (a JetSpec draft trained before the recipe
+    stamped it).
+    """
+    dflash_config = dict(config.get("dflash_config") or {})
+    updates: dict[str, Any] = {}
+    if config.get("architectures") != [_VLLM_DFLASH_ARCHITECTURE]:
+        updates["architectures"] = [_VLLM_DFLASH_ARCHITECTURE]
+    if dflash_causal and not dflash_config.get("causal"):
+        dflash_config["causal"] = True
+        updates["dflash_config"] = dflash_config
+    return updates
+
+
+def _vllm_config_updates(config: dict[str, Any], *, dflash_causal: bool = False) -> dict[str, Any]:
     """Return the ``config.json`` key changes needed for vLLM to load this draft.
 
-    Two fixups bridge the Automodel on-disk format to what vLLM reads:
+    A DFlash-family draft gets the DFlash fixups (see ``_dflash_config_updates``).
+    For an EAGLE draft, two fixups bridge the Automodel on-disk format to what
+    vLLM reads:
 
     * ``architectures`` -> the vLLM-canonical ``LlamaForCausalLMEagle3`` (the
       recipe writes the Automodel class name ``LlamaEagle3DraftModel``, which
@@ -155,6 +210,8 @@ def _vllm_config_updates(config: dict[str, Any]) -> dict[str, Any]:
 
     Returns an empty dict when the config already satisfies vLLM.
     """
+    if _is_dflash_config(config):
+        return _dflash_config_updates(config, dflash_causal=dflash_causal)
     updates: dict[str, Any] = {}
     if config.get("architectures") != [_VLLM_DRAFT_ARCHITECTURE]:
         updates["architectures"] = [_VLLM_DRAFT_ARCHITECTURE]
@@ -173,15 +230,15 @@ def _vllm_config_updates(config: dict[str, Any]) -> dict[str, Any]:
     return updates
 
 
-def _rewrite_config_for_vllm(config_path: Path, config: dict[str, Any]) -> None:
-    """Patch ``config_path`` in place with the keys vLLM needs (architectures, pard_token).
+def _rewrite_config_for_vllm(config_path: Path, config: dict[str, Any], *, dflash_causal: bool = False) -> None:
+    """Patch ``config_path`` in place with the keys vLLM needs (see ``_vllm_config_updates``).
 
     Takes the already-parsed ``config`` so the caller's read is not repeated.
     No-op when the config already satisfies vLLM. The write is staged through a
     sibling ``.tmp`` file and finalized with ``os.replace`` so an interrupted
     write cannot leave the destination half-truncated.
     """
-    updates = _vllm_config_updates(config)
+    updates = _vllm_config_updates(config, dflash_causal=dflash_causal)
     if not updates:
         return
     logger.info("Patching draft config for vLLM: %s", updates)
@@ -320,7 +377,9 @@ def _find_draft_dir(draft_path: Path) -> Path | None:
     return None
 
 
-def resolve_draft_artifacts(draft: str, *, dry_run: bool = False) -> tuple[str, dict[str, Any]]:
+def resolve_draft_artifacts(
+    draft: str, *, dry_run: bool = False, dflash_causal: bool = False
+) -> tuple[str, dict[str, Any]]:
     """Resolve a user-supplied drafter path to the directory and config vLLM expects.
 
     Args:
@@ -329,6 +388,9 @@ def resolve_draft_artifacts(draft: str, *, dry_run: bool = False) -> tuple[str, 
             itself) or a Hugging Face Hub repo id.
         dry_run: When True, no on-disk ``architectures`` rewrite is performed and
             the returned paths reflect what a real launch would produce.
+        dflash_causal: When True, stamp ``dflash_config.causal=true`` on a
+            DFlash-family draft (a JetSpec checkpoint trained before the recipe
+            stamped it).
 
     Returns:
         ``(draft_path, config)`` where ``draft_path`` is what vLLM's
@@ -347,11 +409,21 @@ def resolve_draft_artifacts(draft: str, *, dry_run: bool = False) -> tuple[str, 
         raise ValueError(
             f"--draft {draft!r} exists but no config.json + weights were found under it "
             "(looked in ./, model/, model/consolidated/, consolidated/). Point --draft at the "
-            "checkpoint directory produced by an EAGLE-3 / P-EAGLE recipe."
+            "checkpoint directory produced by an EAGLE-3 / P-EAGLE / DFlash / JetSpec recipe."
         )
 
     config_path = draft_dir / "config.json"
     config = _load_config(config_path)
+
+    # A Domino draft is never servable here (its GRU correction head -- prefix_gru /
+    # embed_proj -- has no vLLM runtime, and serving the bare backbone without the
+    # head it was trained with would be wrong), so reject it in --print-only too.
+    if (config.get("dflash_config") or {}).get("projector_type") == "domino":
+        raise ValueError(
+            "this draft was trained by the Domino recipe (dflash_config.projector_type='domino'): "
+            "vLLM's dflash runtime cannot load its GRU correction head (prefix_gru / embed_proj), "
+            "so it is not servable here. Serve a plain DFlash or JetSpec draft instead."
+        )
 
     # Automodel drafts carry a ``self.model`` wrapper prefix on their weights that
     # vLLM cannot load; those need a remapped export. A draft whose weights are
@@ -363,14 +435,23 @@ def resolve_draft_artifacts(draft: str, *, dry_run: bool = False) -> tuple[str, 
         return str(_export_for_vllm(draft_dir, config)), config
 
     if not dry_run:
-        _rewrite_config_for_vllm(config_path, config)
+        _rewrite_config_for_vllm(config_path, config, dflash_causal=dflash_causal)
     return str(draft_dir), config
 
 
-def _resolve_num_speculative_tokens(cli_value: int | None, config: dict[str, Any]) -> int:
-    """Resolve K (number of speculative tokens), defaulting to the draft's ``num_depths``."""
+def _resolve_num_speculative_tokens(cli_value: int | None, config: dict[str, Any], method: str) -> int:
+    """Resolve K: CLI value, else ``block_size - 1`` (DFlash) / ``num_depths`` (EAGLE)."""
     if cli_value is not None:
         return cli_value
+    if method == "dflash":
+        block_size = config.get("block_size")
+        if block_size is None:
+            raise ValueError(
+                "--num-speculative-tokens is required: the DFlash draft config has no ``block_size`` "
+                "to derive it from. Pass the value explicitly, e.g. --num-speculative-tokens 15."
+            )
+        # A DFlash block is one anchor token plus block_size - 1 mask slots.
+        return int(block_size) - 1
     num_depths = config.get("num_depths")
     if num_depths is None:
         raise ValueError(
@@ -386,12 +467,15 @@ def _build_speculative_config(args: argparse.Namespace, draft_path: str, config:
 
     ``parallel_drafting`` is a SpeculativeConfig field that vLLM defaults to
     False; it must be set here for a P-EAGLE head (the draft's own
-    ``config.json`` flag is not auto-promoted to the speculative config).
+    ``config.json`` flag is not auto-promoted to the speculative config). A
+    DFlash draft needs no such flag: vLLM forces parallel drafting for the
+    ``dflash`` method itself.
     """
+    method = _resolve_method(args.method, config)
     speculative_config: dict[str, Any] = {
-        "method": args.method,
+        "method": method,
         "model": draft_path,
-        "num_speculative_tokens": _resolve_num_speculative_tokens(args.num_speculative_tokens, config),
+        "num_speculative_tokens": _resolve_num_speculative_tokens(args.num_speculative_tokens, config, method),
         "draft_tensor_parallel_size": args.draft_tp_size,
     }
     if config.get("parallel_drafting"):
@@ -401,7 +485,7 @@ def _build_speculative_config(args: argparse.Namespace, draft_path: str, config:
 
 def build_vllm_argv(args: argparse.Namespace) -> list[str]:
     """Build the ``python -m vllm.entrypoints.openai.api_server`` argv for a config."""
-    draft_path, config = resolve_draft_artifacts(args.draft, dry_run=args.print_only)
+    draft_path, config = resolve_draft_artifacts(args.draft, dry_run=args.print_only, dflash_causal=args.dflash_causal)
     speculative_config = _build_speculative_config(args, draft_path, config)
 
     argv: list[str] = [
@@ -437,7 +521,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         prog="serve_vllm",
         description=(
-            "Launch vLLM with an Automodel-trained EAGLE-3 / P-EAGLE drafter. "
+            "Launch vLLM with an Automodel-trained EAGLE-3 / P-EAGLE / DFlash drafter. "
             "Requires `uv pip install vllm` in the current environment; vLLM is not "
             "bundled with the Automodel container."
         ),
@@ -451,22 +535,37 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--draft",
         required=True,
         help=(
-            "Path to the drafter checkpoint directory produced by an EAGLE-3 / P-EAGLE recipe "
-            "(e.g. outputs/peagle/checkpoints/epoch_2_step_44326). The ``model/`` and "
+            "Path to the drafter checkpoint directory produced by an EAGLE-3 / P-EAGLE / DFlash / "
+            "JetSpec recipe (e.g. outputs/peagle/checkpoints/epoch_2_step_44326). The ``model/`` and "
             "``model/consolidated/`` subdirs are auto-selected."
         ),
     )
     parser.add_argument(
         "--method",
-        default="eagle3",
-        choices=["eagle", "eagle3"],
-        help="Speculative method passed to vLLM (P-EAGLE uses eagle3 + parallel_drafting).",
+        default=None,
+        choices=["eagle", "eagle3", "dflash"],
+        help=(
+            "Speculative method passed to vLLM (P-EAGLE uses eagle3 + parallel_drafting). "
+            "Defaults to dflash for a DFlash-family draft (detected from the draft config), else eagle3."
+        ),
     )
     parser.add_argument(
         "--num-speculative-tokens",
         type=int,
         default=None,
-        help="K, number of speculative tokens. Defaults to the draft config's num_depths.",
+        help=(
+            "K, number of speculative tokens. Defaults to the draft config's num_depths "
+            "(EAGLE / P-EAGLE) or block_size - 1 (DFlash)."
+        ),
+    )
+    parser.add_argument(
+        "--dflash-causal",
+        action="store_true",
+        help=(
+            "Stamp dflash_config.causal=true on the draft config: needed for a JetSpec draft "
+            "(trained with causal in-block attention) whose checkpoint predates the recipe "
+            "writing the flag itself."
+        ),
     )
     parser.add_argument("--host", default="0.0.0.0", help="Server bind host.")
     parser.add_argument("--port", type=int, default=8000, help="Server port.")

--- a/nemo_automodel/recipes/llm/train_jetspec.py
+++ b/nemo_automodel/recipes/llm/train_jetspec.py
@@ -46,6 +46,13 @@ logger = logging.getLogger(__name__)
 class TrainJetSpecRecipe(TrainDFlashRecipe):
     """Recipe for JetSpec draft-model training: DFlash backbone + causal mask + forward-KL."""
 
+    def _build_dflash_config(self, recipe_cfg, target_layer_ids: list[int]) -> dict:
+        """Stamp ``causal=true``: JetSpec drafts with causal in-block attention, and a serving
+        engine (vLLM reads ``dflash_config.causal``) must match it at inference."""
+        cfg = super()._build_dflash_config(recipe_cfg, target_layer_ids)
+        cfg["causal"] = True
+        return cfg
+
     def _build_target_wrapper(self, target_layer_ids: list[int]) -> HFDFlashTargetModel:
         """Capture the target's full-vocab logits too -- JetSpec distills against them."""
         return HFDFlashTargetModel(self.target_model, target_layer_ids=target_layer_ids, capture_logits=True)

--- a/tests/unit_tests/recipes/llm/test_train_jetspec.py
+++ b/tests/unit_tests/recipes/llm/test_train_jetspec.py
@@ -100,6 +100,16 @@ def test_jetspec_target_wrapper_captures_logits():
     assert wrapper.target_layer_ids == TARGET_LAYER_IDS
 
 
+def test_build_dflash_config_stamps_causal():
+    """JetSpec stamps causal=true so serving engines match its causal in-block attention."""
+    recipe = _jetspec_recipe()
+    recipe.mask_token_id = 151669
+    cfg = recipe._build_dflash_config({}, TARGET_LAYER_IDS)
+    assert cfg["causal"] is True
+    assert cfg["mask_token_id"] == 151669
+    assert cfg["target_layer_ids"] == TARGET_LAYER_IDS
+
+
 def test_build_trainer_module_is_jetspec():
     recipe = _jetspec_recipe()
     module = recipe._build_trainer_module("sdpa", {"num_anchors": 7, "kd_temperature": 2.0, "kd_chunk_size": 64})

--- a/tests/unit_tests/speculative/test_serve_vllm.py
+++ b/tests/unit_tests/speculative/test_serve_vllm.py
@@ -35,11 +35,12 @@ from nemo_automodel.components.speculative.serve_vllm import (
 def _build_args(
     draft: str,
     *,
-    method: str = "eagle3",
+    method: str | None = "eagle3",
     num_speculative_tokens: int | None = None,
     print_only: bool = False,
     trust_remote_code: bool = False,
     max_model_len: int | None = None,
+    dflash_causal: bool = False,
     extra: list[str] | None = None,
 ) -> argparse.Namespace:
     return argparse.Namespace(
@@ -56,6 +57,7 @@ def _build_args(
         max_model_len=max_model_len,
         trust_remote_code=trust_remote_code,
         print_only=print_only,
+        dflash_causal=dflash_causal,
         extra=extra or [],
     )
 
@@ -92,6 +94,39 @@ def _write_draft_checkpoint(
     config_path = model_dir / "config.json"
     config_path.write_text(json.dumps(config), encoding="utf-8")
     # A tokenizer-ish asset that the export should carry along.
+    (model_dir / "tokenizer_config.json").write_text("{}", encoding="utf-8")
+    return config_path
+
+
+def _write_dflash_checkpoint(
+    model_dir: Path,
+    *,
+    architectures: list[str] | None = None,
+    dflash_config: dict | None = None,
+    block_size: int | None = 16,
+) -> Path:
+    """Write a tiny DFlash-family draft checkpoint (unprefixed weights, no embed/lm_head)."""
+    model_dir.mkdir(parents=True, exist_ok=True)
+    tensors = {
+        "fc.weight": torch.zeros(2, 6),
+        "hidden_norm.weight": torch.zeros(2),
+        "layers.0.self_attn.q_proj.weight": torch.zeros(2, 2),
+        "norm.weight": torch.zeros(2),
+    }
+    save_file(tensors, str(model_dir / "model.safetensors"), metadata={"format": "pt"})
+
+    config = {
+        "architectures": architectures or ["Qwen3DFlashDraftModel"],
+        "model_type": "qwen3",
+        "num_target_layers": 36,
+        "dflash_config": dflash_config
+        if dflash_config is not None
+        else {"mask_token_id": 151669, "target_layer_ids": [1, 18, 34]},
+    }
+    if block_size is not None:
+        config["block_size"] = block_size
+    config_path = model_dir / "config.json"
+    config_path.write_text(json.dumps(config), encoding="utf-8")
     (model_dir / "tokenizer_config.json").write_text("{}", encoding="utf-8")
     return config_path
 
@@ -350,6 +385,109 @@ def test_parse_args_strips_leading_double_dash():
     """A leading ``--`` separator before extras is stripped."""
     args = serve_vllm._parse_args(["--target", "Qwen/Qwen3-8B", "--draft", "/tmp/d", "--", "--enable-chunked-prefill"])
     assert args.extra == ["--enable-chunked-prefill"]
+
+
+# --------------------------------------------------------------------------- #
+# DFlash-family drafts (DFlash / JetSpec).
+# --------------------------------------------------------------------------- #
+def test_build_argv_dflash_autodetects_method_and_derives_k(tmp_path: Path):
+    """A DFlash draft is auto-detected (method=None), K defaults to block_size - 1,
+    and the config's architectures are rewritten in place to vLLM's DFlashDraftModel."""
+    model_dir = tmp_path / "model"
+    config_path = _write_dflash_checkpoint(model_dir, block_size=16)
+
+    argv = build_vllm_argv(_build_args(str(model_dir), method=None))
+    spec = _speculative_config_from_argv(argv)
+
+    assert spec["method"] == "dflash"
+    assert spec["num_speculative_tokens"] == 15
+    assert "parallel_drafting" not in spec
+    # In-place rewrite (no model.-prefixed weights, so no vllm_export/).
+    assert spec["model"] == str(model_dir)
+    assert not (model_dir / "vllm_export").exists()
+    rewritten = json.loads(config_path.read_text(encoding="utf-8"))
+    assert rewritten["architectures"] == ["DFlashDraftModel"]
+
+
+def test_build_argv_dflash_explicit_method_wins(tmp_path: Path):
+    """An explicit --method is not overridden by draft-config detection."""
+    model_dir = tmp_path / "model"
+    _write_dflash_checkpoint(model_dir, block_size=16)
+
+    spec = _speculative_config_from_argv(build_vllm_argv(_build_args(str(model_dir), method="dflash")))
+    assert spec["method"] == "dflash"
+
+
+def test_build_argv_dflash_without_block_size_raises(tmp_path: Path):
+    """A DFlash draft without block_size and without an explicit K fails clearly."""
+    model_dir = tmp_path / "model"
+    _write_dflash_checkpoint(model_dir, block_size=None)
+
+    with pytest.raises(ValueError, match="block_size"):
+        build_vllm_argv(_build_args(str(model_dir), method=None))
+
+
+def test_resolve_dflash_already_vllm_arch_is_untouched(tmp_path: Path):
+    """A draft already carrying vLLM's DFlashDraftModel arch gets no config rewrite."""
+    model_dir = tmp_path / "model"
+    config_path = _write_dflash_checkpoint(model_dir, architectures=["DFlashDraftModel"])
+    before = config_path.read_text(encoding="utf-8")
+
+    draft_path, config = resolve_draft_artifacts(str(model_dir))
+
+    assert draft_path == str(model_dir)
+    assert config_path.read_text(encoding="utf-8") == before
+    assert serve_vllm._resolve_method(None, config) == "dflash"
+
+
+def test_resolve_dflash_causal_stamps_config(tmp_path: Path):
+    """--dflash-causal stamps dflash_config.causal=true (JetSpec ckpt predating the recipe stamp)."""
+    model_dir = tmp_path / "model"
+    config_path = _write_dflash_checkpoint(model_dir)
+
+    resolve_draft_artifacts(str(model_dir), dflash_causal=True)
+
+    rewritten = json.loads(config_path.read_text(encoding="utf-8"))
+    assert rewritten["dflash_config"]["causal"] is True
+    # Existing dflash_config keys survive the stamp.
+    assert rewritten["dflash_config"]["mask_token_id"] == 151669
+
+
+def test_resolve_dflash_causal_already_stamped_is_untouched(tmp_path: Path):
+    """A JetSpec draft whose recipe already stamped causal=true gets no extra rewrite."""
+    model_dir = tmp_path / "model"
+    config_path = _write_dflash_checkpoint(
+        model_dir,
+        architectures=["DFlashDraftModel"],
+        dflash_config={"mask_token_id": 151669, "target_layer_ids": [1, 18, 34], "causal": True},
+    )
+    before = config_path.read_text(encoding="utf-8")
+
+    resolve_draft_artifacts(str(model_dir), dflash_causal=True)
+
+    assert config_path.read_text(encoding="utf-8") == before
+
+
+def test_resolve_domino_draft_raises(tmp_path: Path):
+    """A Domino draft (GRU correction head) is rejected: vLLM has no runtime for it."""
+    model_dir = tmp_path / "model"
+    _write_dflash_checkpoint(
+        model_dir,
+        dflash_config={"mask_token_id": 151669, "target_layer_ids": [1, 18, 34], "projector_type": "domino"},
+    )
+
+    with pytest.raises(ValueError, match="[Dd]omino"):
+        resolve_draft_artifacts(str(model_dir))
+    # Rejected in --print-only (dry_run) too: a printed command must not imply servability.
+    with pytest.raises(ValueError, match="[Dd]omino"):
+        resolve_draft_artifacts(str(model_dir), dry_run=True)
+
+
+def test_resolve_method_defaults_to_eagle3_for_eagle_and_hub_drafts(tmp_path: Path):
+    """Method inference: eagle3 for an EAGLE draft config and for a pass-through Hub id."""
+    assert serve_vllm._resolve_method(None, {"architectures": ["LlamaEagle3DraftModel"]}) == "eagle3"
+    assert serve_vllm._resolve_method(None, {}) == "eagle3"
+    assert serve_vllm._resolve_method("eagle", {"architectures": ["Qwen3DFlashDraftModel"]}) == "eagle"
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## What does this PR do?

`serve_vllm` gains vLLM's `dflash` speculative method (available since vLLM 0.20), closing the gap where DFlash-family drafts trained by the recipes had no serving path.

- A DFlash-family draft (`architectures=["Qwen3DFlashDraftModel"]`) is auto-detected from the draft config, so `--method` can be omitted; an explicit `--method` still wins.
- The config's `architectures` are rewritten to vLLM's registered `DFlashDraftModel`, mirroring the existing EAGLE-3 rewrite. Nothing else is needed: DFlash draft weights carry no `model.` prefix and no embed/lm_head (vLLM shares the target's), and vLLM reads `dflash_config.mask_token_id` / `dflash_config.target_layer_ids` where the recipes already write them.
- `--num-speculative-tokens` defaults to `block_size - 1` for DFlash (a block is one anchor token plus `block_size - 1` mask slots).
- JetSpec drafts share the DFlash on-disk format but are trained with causal in-block attention: `train_jetspec` now stamps `dflash_config.causal=true` so vLLM matches it at inference, and a `--dflash-causal` flag covers checkpoints trained before the stamp existed.
- Domino drafts are rejected with a clear error, including under `--print-only`: their GRU correction head (`prefix_gru` / `embed_proj`) has no vLLM runtime, and serving the bare backbone without the head it was trained with would be wrong.

## Verified end to end

vLLM 0.24.0, Qwen3-4B target, DFlash draft trained by `train_dflash` (Qwen3-4B, block_size 16, 1000-step smoke): the launcher rewrote the config in place, vLLM loaded the draft through the `dflash` method, and speculative decoding is active with K=15 (accept_length 1.30 over 1555 drafts on a 16-prompt workload; low acceptance matches the deliberately short smoke training). Note for large K: vLLM reserves `(1 + K)` query tokens per sequence, so a default `--max-num-seqs` can push `max_num_scheduled_tokens` negative; passing e.g. `-- --max-num-seqs 32` through the extra args resolves it.

JetSpec checkpoints go through the same loading path plus the `dflash_config.causal` flag (read natively by vLLM's DFlash proposer); no GPU end-to-end run was done for JetSpec specifically.

## Tests

`test_serve_vllm.py` gains 8 DFlash cases (method auto-detection, K derivation, arch rewrite both directions, causal stamping both directions, Domino rejection incl. dry-run); `test_train_jetspec.py` covers the causal stamp. Full speculative suite passes.