### PR TITLE
docs(speculative): document DSpark, Domino, JetSpec, and the vLLM serve path

### DIFF
--- a/examples/speculative/README.md
+++ b/examples/speculative/README.md
@@ -21,31 +21,45 @@ inference engine (SGLang or vLLM). The training code lives in
 | **EAGLE-3.1** | EAGLE-3 plus two drafter toggles (`fc_norm`, `norm_output`), matching the vLLM EAGLE-3.1 architecture. | `TrainEagle3Recipe` | `eagle3_1/` |
 | **P-EAGLE** | Parallel-drafting EAGLE-3: predicts all `num_depths` tokens in one forward over a COD-subsampled sequence instead of the TTT unroll. Serves on vLLM only. | `TrainEagle3Recipe` (`parallel_drafting: true`) | `p-eagle/` |
 | **DFlash** | Block-parallel drafting: drafts a whole block of `block_size` tokens in one non-causal "denoising" forward over `[anchor, MASK, MASK, ...]`. | `TrainDFlashRecipe` (LLM) / `DiffusionLMSFTRecipe` (DLLM SFT) | `dflash/`, `../dllm_sft/*dflash*` |
+| **Domino** | DFlash backbone plus a serial GRU correction head (`prefix_gru` / `embed_proj`) that refines each block position on the previous ones. | `TrainDominoRecipe` | `dflash/qwen3_domino.yaml` |
+| **JetSpec** | DFlash backbone trained as a *causal* parallel tree drafter: causal in-block attention plus forward-KL distillation against the target distribution. | `TrainJetSpecRecipe` | `jetspec/` |
+| **DSpark** | Semi-autoregressive parallel drafting: a parallel backbone drafts the block, a lightweight serial Markov head adds intra-block dependency, and a confidence head predicts per-position acceptance. | `TrainDSparkRecipe` | `dspark/` |
 
 EAGLE-1/2/3 keep their separate code paths: `*_v12.py` files are the **EAGLE-1/2**
 ("v1/v2") implementation; the unsuffixed files are the EAGLE-3/3.1 path. Inside
 EAGLE-3, `fc_norm`/`norm_output` upgrade to 3.1 and `parallel_drafting` upgrades
-to P-EAGLE, all from the same draft class.
+to P-EAGLE, all from the same draft class. Domino and JetSpec reuse the DFlash
+draft class and checkpoint format; only their training wrappers (and, for
+Domino, the extra head weights) differ.
 
 ## Supported target models
 
 A target's `config.architectures` string selects the draft architecture through a
-registry (`eagle/registry.py`, `dflash/registry.py`). Capability is per registry,
-not per (method, target) pair: the EAGLE-3.1 (`fc_norm` / `norm_output`) and
-P-EAGLE (`parallel_drafting`) toggles ride on the same EAGLE-3 dense draft, so
-they apply to any target the EAGLE-3 registry maps. The shipped example configs
-only cover a subset.
+registry (`eagle/registry.py`, `dflash/registry.py`, `dspark/registry.py`).
+Capability is per registry, not per (method, target) pair: the EAGLE-3.1
+(`fc_norm` / `norm_output`) and P-EAGLE (`parallel_drafting`) toggles ride on the
+same EAGLE-3 dense draft, so they apply to any target the EAGLE-3 registry maps.
+The shipped example configs only cover a subset.
 
 - **EAGLE-1/2/3 (and the EAGLE-3.1 / P-EAGLE toggles on top of EAGLE-3)**:
   `LlamaForCausalLM`, `Phi3ForCausalLM`, `Qwen3ForCausalLM`, `Qwen3MoeForCausalLM`.
 - **gpt-oss** (`GptOssForCausalLM`): EAGLE-3 only, via a dedicated draft class.
-- **DFlash**: `Qwen3ForCausalLM`, `Qwen3MoeForCausalLM`.
+- **DeepSeek-V3** (`DeepseekV3ForCausalLM`): EAGLE-3 only, via a dedicated MLA
+  draft class (eager attention; sequence packing not supported yet).
+- **DFlash / Domino / JetSpec**: `Qwen3ForCausalLM`, `Qwen3MoeForCausalLM`.
+- **DSpark**: `Qwen3ForCausalLM`, `Qwen3MoeForCausalLM`,
+  `DeepseekV4ForCausalLM`, GLM-5.2 (`GlmMoeDsaForCausalLM`), Gemma4
+  (`Gemma4ForConditionalGeneration`, `Gemma4UnifiedForConditionalGeneration`),
+  and MiniMax M3 VL (`MiniMaxM3SparseForConditionalGeneration`, incl. a
+  multimodal data path via `recipe_args.multimodal: true`).
 
 Qwen3-MoE is handled exactly like a dense target: the draft only consumes
 post-block hidden states, never per-expert routing. gpt-oss uses a dedicated
 draft class that reuses the target's YaRN rotary embedding but keeps the on-disk
 `architectures` string as the Llama EAGLE-3 draft so inference engines load it
-unchanged.
+unchanged. The large-MoE DSpark targets (DeepSeek-V4, GLM-5.2, MiniMax M3) load
+frozen through the same expert-parallel / FSDP paths their finetune recipes use;
+see the per-target notes in `dspark/README_*.md`.
 
 ## Quick start
 
@@ -84,7 +98,8 @@ Pick them through config; all degrade gracefully when a dependency is missing.
 | EAGLE-3 / 3.1 | `eager`, `flash_attention_2` | `recipe_args.draft_attn_implementation` (default `eager`) |
 | EAGLE-1/2 | `eager` only | n/a |
 | P-EAGLE | `flex_attention` (compiled when CUDA + head_dim ≥ 16, else eager flex) | automatic |
-| DFlash | `flex_attention`, `sdpa` | `recipe_args.attention_backend` (default `flex_attention`) |
+| DFlash / Domino / JetSpec | `flex_attention`, `sdpa` | `recipe_args.attention_backend` (default `flex_attention`) |
+| DSpark | `flex_attention` (Qwen3 / Gemma4 / MiniMax M3 drafts), `sdpa` (V4 / GLM MLA drafts, fixed) | `recipe_args.attention_backend` |
 
 For EAGLE-3, FlashAttention-2 is real FA2 over the TTT attention pattern: FA2
 computes the `T×T` causal block and returns `softmax_lse`, and the diagonal
@@ -229,6 +244,8 @@ or a `conversations` column (ShareGPT or OpenAI style) that is auto-converted.
 
 ## Serve and benchmark a trained draft
 
+### SGLang
+
 After training, serve `target + draft` through SGLang:
 
 ```bash
@@ -251,12 +268,46 @@ output throughput, and a `speedup` ratio versus an optional non-speculative
 baseline server. Point it at a freshly started server, since SGLang reports a
 server-cumulative average.
 
+### vLLM
+
+`serve_vllm.py` is the vLLM companion; it serves EAGLE-3, P-EAGLE (vLLM's
+parallel-drafting runtime, vLLM >= 0.16), and the DFlash family (vLLM's `dflash`
+method, vLLM >= 0.20):
+
+```bash
+python -m nemo_automodel.components.speculative.serve_vllm --target Qwen/Qwen3-8B --draft /path/to/run/epoch_0_step_1000 --port 8000
+```
+
+The speculative method is auto-detected from the draft config (`dflash` for a
+DFlash-family draft, else `eagle3`), the draft `architectures` are rewritten to
+vLLM's registered names, and `--num-speculative-tokens` defaults to `num_depths`
+(P-EAGLE) or `block_size - 1` (DFlash). Pass `--print-only` to inspect the
+resolved `vllm serve` command without launching. DFlash notes: vLLM reserves
+`1 + K` query tokens per sequence, so a large block size may need a smaller
+`--max-num-seqs` (forward it via the trailing extra args, e.g.
+`-- --max-num-seqs 32`); a JetSpec draft carries `dflash_config.causal=true` so
+vLLM matches its causal in-block attention (pass `--dflash-causal` for
+checkpoints trained before the recipe stamped it); Domino drafts are rejected
+because their GRU correction head has no vLLM runtime.
+
+`bench_vllm.py` measures the same metrics against a running vLLM server, reading
+the spec-decode counters from vLLM's Prometheus `/metrics` endpoint. The counters
+are snapshotted before and after the workload and differenced, so the numbers
+cover exactly the benchmark's own requests:
+
+```bash
+python -m nemo_automodel.components.speculative.bench_vllm --server http://localhost:8000 --model Qwen/Qwen3-8B --input-data <prompts-dataset> --baseline-server http://localhost:8001
+```
+
 ## Inference-engine compatibility
 
 | Draft | SGLang | vLLM |
 |---|---|---|
 | EAGLE-1/2/3, EAGLE-3.1 | yes | yes |
-| P-EAGLE | no (tracked upstream) | yes (parallel-drafting runtime) |
+| P-EAGLE | no (tracked upstream) | yes (parallel-drafting runtime, >= 0.16) |
+| DFlash, JetSpec | no | yes (`dflash` method, >= 0.20) |
+| Domino | no | no (the GRU correction head has no engine runtime) |
+| DSpark | no | not yet (runtime in development upstream, unreleased) |
 
 `serve_sglang.py` rejects P-EAGLE drafts with an actionable error; serve those on
 vLLM.
@@ -304,6 +355,9 @@ checkpoint cadence: `ckpt_every_steps`, `save_checkpoint_every_epoch`.
 | `cached_target_path` | EAGLE-3 offline | Path to a `precompute_eagle3` cache. |
 | `parallel_drafting`, `num_depths`, `num_draft_layers`, `down_sample_ratio`, `down_sample_ratio_min`, `mask_token_id`, `sequence_partitions` | P-EAGLE | `mask_token_id` is required (no default). `sequence_partitions > 1` splits each sequence by dependency lineage to bound long-context memory. |
 | `block_size`, `num_anchors`, `loss_decay_gamma`, `mask_token_id`, `target_layer_ids`, `attention_backend` | DFlash (LLM recipe) | Block drafting knobs. |
+| `emb_dim`, `gru_hidden_dim`, `pure_draft_prefix_len`, `shift_label` | Domino | Correction-head knobs on top of the DFlash set. |
+| `kd_temperature`, `kd_chunk_size` | JetSpec | Forward-KL distillation knobs on top of the DFlash set. |
+| `markov_rank`, `markov_head_type`, `confidence_head_alpha`, `confidence_head_with_markov`, `ce_loss_alpha` | DSpark | Markov / confidence-head knobs on top of the block-drafting set (`block_size`, `num_anchors`, `mask_token_id`, `target_layer_ids`, ...). |
 
 ## Directory layout
 
@@ -311,7 +365,9 @@ Configs in this folder:
 
 ```
 examples/speculative/
-  eagle1/    eagle2/    eagle3/    eagle3_1/    p-eagle/    dflash/
+  eagle1/    eagle2/    eagle3/    eagle3_1/    p-eagle/
+  dflash/                     # DFlash + Domino (qwen3_domino.yaml) configs
+  jetspec/   dspark/
   README.md                   # this file (includes the dataset regeneration guide)
 examples/dllm_sft/            # DFlash DLLM SFT configs (standard SFT schema)
 ```
@@ -320,14 +376,21 @@ Implementation:
 
 ```
 nemo_automodel/components/speculative/
-  eagle/        core(.py/_v12), draft_llama(.py/_v12), draft_gpt_oss, backend,
-                registry, target(.py/_v12), peagle_*, remote/
-  dflash/       core, draft_qwen3, registry, target
+  eagle/        core(.py/_v12), draft_llama(.py/_v12), draft_gpt_oss,
+                draft_deepseek, backend, registry, target(.py/_v12),
+                peagle_*, remote/
+  dflash/       core, domino_core, jetspec_core, draft_qwen3, registry, target
+  dspark/       core, draft_qwen3, draft_deepseek_v4, draft_glm_5_2,
+                draft_gemma4, draft_minimax_m3, markov_head, registry, target
   regenerate.py            # dataset regeneration with the target model
   precompute_eagle3.py     # offline target-output cache
   serve_target.py          # remote target server (HTTP + NCCL)
   serve_sglang.py          # serve a trained draft via SGLang
-  bench_sglang.py          # acceptance-length / speedup benchmark
+  serve_vllm.py            # serve a trained draft via vLLM (EAGLE-3 / P-EAGLE / DFlash)
+  bench_common.py          # shared chat-completions workload machinery
+  bench_sglang.py          # acceptance-length / speedup benchmark (SGLang)
+  bench_vllm.py            # acceptance-length / speedup benchmark (vLLM)
 nemo_automodel/recipes/llm/
-  train_eagle1.py  train_eagle2.py  train_eagle3.py  train_dflash.py  peagle_recipe.py
+  train_eagle1.py  train_eagle2.py  train_eagle3.py  peagle_recipe.py
+  train_dflash.py  train_domino.py  train_jetspec.py  train_dspark.py
 ```


### PR DESCRIPTION
## What does this PR do?

Brings `examples/speculative/README.md` up to date with the current subsystem. The README predated half of it: the `dspark/`, `jetspec/`, and Domino configs shipped with no mention, `serve_vllm` was absent from the serve-and-benchmark guide, and the target-coverage list was missing DeepSeek-V3 (EAGLE-3) and every DSpark target family.

- Supported-methods table gains Domino, JetSpec, and DSpark rows; their knobs are added to the method-specific `recipe_args` table.
- Target coverage now lists DeepSeek-V3 for EAGLE-3 and the DSpark families (Qwen3, DeepSeek-V4, GLM-5.2, Gemma4, MiniMax M3 VL).
- The serve-and-benchmark section splits into SGLang and vLLM subsections, documenting `serve_vllm` (method auto-detection, K defaults, the DFlash `--max-num-seqs` note, JetSpec causal handling, Domino rejection) and `bench_vllm` (Prometheus counter snapshots).
- The inference-engine compatibility table gains DFlash-family, Domino, and DSpark rows.
- Directory layout refreshed (`jetspec/`, `dspark/`, the new serve/bench modules, the new recipes).

Depends on #2913 (serve_vllm DFlash support) and #2912 (bench_vllm) for the vLLM subsection, and describes the registry-routed DSpark dispatch from #2909; best merged after those three.

Docs only, no code change.