### PR TITLE
fix(speculative): read DeepSeek EAGLE-3 draft rope_theta from rope_parameters

### DIFF
--- a/nemo_automodel/components/speculative/eagle/draft_deepseek.py
+++ b/nemo_automodel/components/speculative/eagle/draft_deepseek.py
@@ -55,6 +55,20 @@ from nemo_automodel.components.models.deepseek_v3.rope_utils import (
 )
 
 
+def _resolve_rope_theta(config: PretrainedConfig) -> float:
+    """Read the RoPE base the way the DeepSeek target does.
+
+    transformers 5.x moved ``rope_theta`` under ``config.rope_parameters`` and
+    dropped the top-level attribute (``DeepseekV3Config(rope_theta=...).rope_theta``
+    raises ``AttributeError``), so a bare ``getattr(config, "rope_theta", 10000.0)``
+    always returns the fallback and the draft's rotary phase silently diverges from
+    any target whose base is not 10000. The top-level read is kept only as a
+    fallback for older configs.
+    """
+    rope_parameters = getattr(config, "rope_parameters", None) or {}
+    return float(rope_parameters.get("rope_theta", getattr(config, "rope_theta", 10000.0)))
+
+
 def _build_causal_mask(attention_mask: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
     """Build a standard ``[B, 1, T, T]`` additive causal + padding mask for eager attention."""
     batch_size, seq_len = attention_mask.shape
@@ -121,7 +135,7 @@ class Eagle3DeepseekMLAAttention(nn.Module):
         freqs = precompute_freqs_cis(
             self.qk_rope_head_dim,
             getattr(config, "max_position_embeddings", 4096),
-            getattr(config, "rope_theta", 10000.0),
+            _resolve_rope_theta(config),
             getattr(config, "rope_scaling", None),
         )
         self.register_buffer("rope_freqs", freqs, persistent=False)
@@ -151,7 +165,7 @@ class Eagle3DeepseekMLAAttention(nn.Module):
             fresh = precompute_freqs_cis(
                 self.qk_rope_head_dim,
                 getattr(self.config, "max_position_embeddings", 4096),
-                getattr(self.config, "rope_theta", 10000.0),
+                _resolve_rope_theta(self.config),
                 getattr(self.config, "rope_scaling", None),
             )
             self.rope_freqs = fresh.to(device=rope_freqs.device, dtype=torch.float32)

--- a/tests/unit_tests/speculative/test_deepseek_eagle3_draft.py
+++ b/tests/unit_tests/speculative/test_deepseek_eagle3_draft.py
@@ -28,8 +28,12 @@ import pytest
 import torch
 from transformers import PretrainedConfig
 
+from nemo_automodel.components.models.deepseek_v3.rope_utils import precompute_freqs_cis
 from nemo_automodel.components.speculative.eagle.core import Eagle3TrainerModule
-from nemo_automodel.components.speculative.eagle.draft_deepseek import DeepseekV3Eagle3DraftModel
+from nemo_automodel.components.speculative.eagle.draft_deepseek import (
+    DeepseekV3Eagle3DraftModel,
+    _resolve_rope_theta,
+)
 from nemo_automodel.components.speculative.eagle.registry import resolve_eagle3_draft_spec
 
 _VOCAB = 64
@@ -178,3 +182,54 @@ def test_rope_freqs_stays_fp32_after_bf16_cast():
         assert torch.allclose(rope_freqs, ref[n], rtol=1e-6, atol=1e-8), n
     # The pin is rope-only: the rest of the draft still casts to bf16.
     assert any(p.dtype == torch.bfloat16 for p in draft.parameters())
+
+
+def test_resolve_rope_theta_prefers_rope_parameters():
+    """transformers 5.x drops the top-level ``rope_theta``; it lives under ``rope_parameters``."""
+    config = PretrainedConfig()
+    config.rope_parameters = {"rope_theta": 123456.0}
+    config.rope_theta = 10000.0  # a stale top-level value must lose to rope_parameters
+    assert _resolve_rope_theta(config) == 123456.0
+
+
+def test_resolve_rope_theta_falls_back_to_top_level_then_default():
+    """Older configs with only a top-level ``rope_theta`` (or none at all) still resolve."""
+    config = PretrainedConfig()
+    config.rope_parameters = None
+    config.rope_theta = 5000.0
+    assert _resolve_rope_theta(config) == 5000.0
+
+    bare = PretrainedConfig()
+    bare.rope_parameters = None
+    assert _resolve_rope_theta(bare) == 10000.0
+
+
+def test_rope_freqs_follow_rope_parameters_theta():
+    """The draft's rotary table must use the target's ``rope_parameters`` base.
+
+    A real ``DeepseekV3Config`` carries ``rope_theta`` only inside
+    ``rope_parameters`` (no top-level attribute), so reading it with a bare
+    ``getattr(config, "rope_theta", 10000.0)`` silently pins the draft's RoPE
+    base to 10000 and dephases it from any target with a different base. Build
+    the draft from such a config and check the frequency table end to end,
+    including the fp32 recompute that follows a bf16 cast.
+    """
+    config = _build_config()
+    del config.rope_theta
+    config.rope_parameters = {"rope_theta": 123456.0}
+    torch.manual_seed(0)
+    draft = DeepseekV3Eagle3DraftModel(config).to(torch.float32)
+
+    expected = precompute_freqs_cis(config.qk_rope_head_dim, config.max_position_embeddings, 123456.0, None)
+    default_theta = precompute_freqs_cis(config.qk_rope_head_dim, config.max_position_embeddings, 10000.0, None)
+    assert not torch.allclose(expected, default_theta)
+
+    freq_names = [n for n, _ in draft.named_buffers() if n.endswith("rope_freqs")]
+    assert freq_names, "expected at least one rope_freqs buffer on the MLA draft"
+    for n in freq_names:
+        assert torch.allclose(draft.get_buffer(n), expected, rtol=1e-6, atol=1e-8), n
+
+    # The post-cast fp32 recompute must resolve the same theta, not the default.
+    draft = draft.to(torch.bfloat16)
+    for n in freq_names:
+        assert torch.allclose(draft.get_buffer(n), expected, rtol=1e-6, atol=1e-8), n


### PR DESCRIPTION
## What does this PR do?

Fixes the RoPE base resolution in the DeepSeek (MLA) EAGLE-3 draft. transformers 5.x moved `rope_theta` under `config.rope_parameters` and dropped the top-level attribute:

```python
>>> DeepseekV3Config(rope_theta=5000000.0).rope_theta
AttributeError
>>> DeepseekV3Config(rope_theta=5000000.0).rope_parameters
{'rope_theta': 5000000.0, 'rope_type': 'default'}
```

The draft read it with a bare `getattr(config, "rope_theta", 10000.0)`, which always returns the 10000 fallback on such configs. Since `train_eagle3` builds the draft config with `type(target_config).from_dict(...)` (a real `DeepseekV3Config` for a DeepSeek target), the draft's rotary base was silently pinned to 10000 regardless of the target. The DeepSeek target itself reads the base through `get_rope_config`, i.e. from `rope_parameters`.

For the stock DeepSeek-V3 base the two values coincide, so nothing breaks today. For any MLA target with a rebased theta (for example a long-context fine-tune), the draft's rotary phase diverges from the target at every position with no error, which erodes draft acceptance.

## Changes

- Add `_resolve_rope_theta`, which reads `rope_parameters["rope_theta"]` first and keeps the top-level read only as a fallback for older configs (same idiom the GLM-5.2 DSpark draft already uses).
- Use it at both frequency-table build sites: the attention constructor and the fp32 recompute in `_apply` that follows a bf16 cast.

## Tests

Three new unit tests in `tests/unit_tests/speculative/test_deepseek_eagle3_draft.py`:

- `_resolve_rope_theta` prefers `rope_parameters` over a stale top-level value.
- Fallback to the top-level attribute, then to the 10000 default.
- End to end: a draft built from a config whose theta lives only in `rope_parameters` gets the matching frequency table, including after the bf16 cast recompute path.

All 12 tests in the file pass; `ruff format` and `ruff check` are clean.
