### PR TITLE
fix(speculative): send chat_template_kwargs as a top-level request field

### DIFF
--- a/nemo_automodel/components/speculative/regenerate.py
+++ b/nemo_automodel/components/speculative/regenerate.py
@@ -313,7 +313,10 @@ async def _regenerate_one(
         "top_p": gen_cfg.top_p,
     }
     if gen_cfg.reasoning == "disable":
-        payload["extra_body"] = {"chat_template_kwargs": {"enable_thinking": False}}
+        # Must be a top-level body field: "extra_body" is an OpenAI Python-client
+        # convenience, and this raw-JSON POST would send it literally for the
+        # server to ignore, silently leaving thinking enabled.
+        payload["chat_template_kwargs"] = {"enable_thinking": False}
     msg = await _chat_completion(session, url, payload, timeout_s=timeout_s, max_retries=max_retries)
     resp_msg: dict[str, Any] = {"role": "assistant", "content": msg.get("content", "")}
     if gen_cfg.reasoning == "save":
@@ -515,7 +518,7 @@ def _build_parser() -> argparse.ArgumentParser:
         help=(
             "Reasoning mode: 'none' for standard models (default), "
             "'save' to store reasoning_content from the response, "
-            "or 'disable' to suppress thinking via extra_body chat_template_kwargs."
+            "or 'disable' to suppress thinking via the top-level chat_template_kwargs request field."
         ),
     )
     parser.add_argument(

--- a/tests/unit_tests/speculative/test_regenerate.py
+++ b/tests/unit_tests/speculative/test_regenerate.py
@@ -29,6 +29,7 @@ from nemo_automodel.components.speculative.regenerate import (
     _existing_shard_indices,
     _extract_prompt_messages,
     _process_shard,
+    _regenerate_one,
     _validate_args,
     _write_shard,
 )
@@ -579,3 +580,49 @@ def test_chat_completion_raises_after_max_retries_exhausted(monkeypatch):
     # max_retries=2 → 3 total attempts, 2 sleeps
     assert session.call_count == 3
     assert len(sleep_calls) == 2
+
+
+def test_reasoning_disable_sends_top_level_chat_template_kwargs():
+    """--reasoning disable must land as a top-level request field, not extra_body.
+
+    ``extra_body`` is an OpenAI Python-client convenience merged into the body
+    client-side; this script POSTs raw JSON, so a literal ``extra_body`` key is
+    silently ignored by the server and thinking stays enabled.
+    """
+    session = _FakeSession(lambda payload: "ok")
+    gen_cfg = GenerationConfig(model="m", max_new_tokens=8, temperature=0.0, top_p=1.0, reasoning="disable")
+
+    asyncio.run(
+        _regenerate_one(
+            session,
+            url="http://server/v1/chat/completions",
+            prompt=[{"role": "user", "content": "q"}],
+            gen_cfg=gen_cfg,
+            timeout_s=10.0,
+            max_retries=0,
+        )
+    )
+
+    (call,) = session.calls
+    assert call["json"]["chat_template_kwargs"] == {"enable_thinking": False}
+    assert "extra_body" not in call["json"]
+
+
+def test_reasoning_none_sends_no_chat_template_kwargs():
+    session = _FakeSession(lambda payload: "ok")
+    gen_cfg = GenerationConfig(model="m", max_new_tokens=8, temperature=0.0, top_p=1.0, reasoning="none")
+
+    asyncio.run(
+        _regenerate_one(
+            session,
+            url="http://server/v1/chat/completions",
+            prompt=[{"role": "user", "content": "q"}],
+            gen_cfg=gen_cfg,
+            timeout_s=10.0,
+            max_retries=0,
+        )
+    )
+
+    (call,) = session.calls
+    assert "chat_template_kwargs" not in call["json"]
+    assert "extra_body" not in call["json"]


### PR DESCRIPTION
## What does this PR do?

Fixes `--reasoning disable` in the speculative-decoding data regeneration script, which was a silent no-op.

`regenerate.py` disabled thinking by nesting the flag inside an `extra_body` key:

```python
payload["extra_body"] = {"chat_template_kwargs": {"enable_thinking": False}}
```

`extra_body` is an OpenAI Python-client convenience: the client merges its contents into the request body before sending. This script POSTs the payload as raw JSON over aiohttp, so the server receives a literal `extra_body` field, ignores it, and thinking stays enabled. SGLang and vLLM read `chat_template_kwargs` from the top level of the body.

The practical impact is data quality: regenerating a dataset against a reasoning target with `--reasoning disable` silently keeps the think spans in the assistant turns, and the draft then trains on off-target reasoning tokens with no error anywhere.

## Changes

- Send `chat_template_kwargs` as a top-level request field.
- Update the `--reasoning` help text accordingly.

## Tests

Two new unit tests in `tests/unit_tests/speculative/test_regenerate.py` using the existing `_FakeSession` request capture:

- `--reasoning disable` puts `chat_template_kwargs` at the top level and sends no `extra_body`.
- `--reasoning none` sends neither field.

All 25 tests in the file pass; `ruff format` and `ruff check` are clean.
