### PR TITLE
feat(speculative): add DSpark offline cache path

### DIFF
--- a/examples/speculative/README.md
+++ b/examples/speculative/README.md
@@ -155,7 +155,7 @@ recipe_args:
 
 Offline cache is produced by `precompute_eagle3.py`
 (`python -m nemo_automodel.components.speculative.precompute_eagle3 --target-model ... --input-data ... --output-dir ...`),
-then consumed via `cached_target_path`. EAGLE-3 only.
+then consumed via `cached_target_path`. DSpark also supports a text-only offline cache via `precompute_dspark.py` for HF-loadable single-process text targets.
 
 EAGLE drafters learn best when the assistant turns in the training data are
 produced by the **same model** that will serve as the inference target. Most

--- a/examples/speculative/README.md
+++ b/examples/speculative/README.md
@@ -155,7 +155,8 @@ recipe_args:
 
 Offline cache is produced by `precompute_eagle3.py`
 (`python -m nemo_automodel.components.speculative.precompute_eagle3 --target-model ... --input-data ... --output-dir ...`),
-then consumed via `cached_target_path`. DSpark also supports a text-only offline cache via `precompute_dspark.py` for HF-loadable single-process text targets.
+then consumed via `cached_target_path`. DSpark also supports a text-only offline cache via `precompute_dspark.py`
+for HF-loadable single-process text targets.
 
 EAGLE drafters learn best when the assistant turns in the training data are
 produced by the **same model** that will serve as the inference target. Most
@@ -352,7 +353,7 @@ checkpoint cadence: `ckpt_every_steps`, `save_checkpoint_every_epoch`.
 | `draft_attn_implementation` | EAGLE-3 | `eager` (default) or `flash_attention_2`. |
 | `fc_norm`, `norm_output` | EAGLE-3.1 | Both default false; either alone is a valid intermediate config. |
 | `target_model_backend`, `remote_urls`, `target_prefetch_depth`, `remote_timeout`, `remote_max_retries` | EAGLE-3 remote | See Target backends. |
-| `cached_target_path` | EAGLE-3 offline | Path to a `precompute_eagle3` cache. |
+| `cached_target_path` | EAGLE-3 / DSpark offline | Path to a cache produced by `precompute_eagle3.py` or `precompute_dspark.py`. |
 | `parallel_drafting`, `num_depths`, `num_draft_layers`, `down_sample_ratio`, `down_sample_ratio_min`, `mask_token_id`, `sequence_partitions` | P-EAGLE | `mask_token_id` is required (no default). `sequence_partitions > 1` splits each sequence by dependency lineage to bound long-context memory. |
 | `block_size`, `num_anchors`, `loss_decay_gamma`, `mask_token_id`, `target_layer_ids`, `attention_backend` | DFlash (LLM recipe) | Block drafting knobs. |
 | `emb_dim`, `gru_hidden_dim`, `pure_draft_prefix_len`, `shift_label` | Domino | Correction-head knobs on top of the DFlash set. |

--- a/examples/speculative/dspark/qwen3_0.6b_dspark.yaml
+++ b/examples/speculative/dspark/qwen3_0.6b_dspark.yaml
@@ -50,6 +50,17 @@ recipe_args:
   markov_rank: 256
   markov_head_type: vanilla           # vanilla | gated | rnn
 
+  # OFFLINE path: precompute the target supervision once, then stream it here
+  # without loading/running the target model during draft training:
+  #
+  #   python -m nemo_automodel.components.speculative.precompute_dspark \
+  #     --target-model Qwen/Qwen3-0.6B \
+  #     --input-data /path/to/perfectblend_qwen3-0.6b_regen.jsonl \
+  #     --output-dir /data/dspark_cache/qwen3_0.6b \
+  #     --seq-length 4096 --target-layer-ids 1 7 14 21 27
+  #
+  # cached_target_path: /data/dspark_cache/qwen3_0.6b
+
   # --- confidence head (scheduled verification) ---
   confidence_head_alpha: 1.0          # > 0 enables the confidence head
   confidence_head_with_markov: true

--- a/nemo_automodel/components/datasets/llm/dspark_cache.py
+++ b/nemo_automodel/components/datasets/llm/dspark_cache.py
@@ -1,0 +1,250 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""On-disk format and reader for DSpark offline target supervision.
+
+The DSpark online recipe runs a frozen target model every step to capture the
+intermediate target features used by the draft and the final hidden state used
+for the TV / confidence losses. This module owns the disk format that lets a
+precompute job write those tensors once and lets training stream them later via
+``recipe_args.cached_target_path`` without loading the target model.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from types import SimpleNamespace
+from typing import Any, Callable
+
+import torch
+from torch.utils.data import DataLoader, Dataset
+from torch.utils.data.distributed import DistributedSampler
+
+from nemo_automodel.shared.import_utils import safe_import_from
+
+_MANIFEST_NAME = "manifest.json"
+_TARGET_WEIGHTS_NAME = "target_weights.safetensors"
+_SHARD_RE = re.compile(r"^shard-(\d{6})\.safetensors$")
+_FORMAT_VERSION = 1
+
+CACHE_KEYS = (
+    "input_ids",
+    "attention_mask",
+    "loss_mask",
+    "target_hidden_states",
+    "target_last_hidden_states",
+)
+
+DTYPE_MAP = {"bf16": torch.bfloat16, "fp16": torch.float16, "fp32": torch.float32}
+
+
+def _load_safetensors():
+    """Return ``(save_file, safe_open)`` or raise a clear error if safetensors is missing."""
+    has_save, save_file = safe_import_from("safetensors.torch", "save_file")
+    has_open, safe_open = safe_import_from("safetensors", "safe_open")
+    if not (has_save and has_open):
+        raise ImportError(
+            "The DSpark offline cache requires the 'safetensors' package. "
+            "Install it with `uv sync --locked` and re-run."
+        )
+    return save_file, safe_open
+
+
+def _atomic_write(path: str, write_fn: Callable[[str], None]) -> str:
+    """Write through a sibling temporary file, then atomically replace the target path."""
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    tmp_path = path + ".tmp"
+    write_fn(tmp_path)
+    os.replace(tmp_path, path)
+    return path
+
+
+def shard_path(cache_dir: str, shard_index: int) -> str:
+    """Return the path of shard ``shard_index`` inside ``cache_dir``."""
+    return os.path.join(cache_dir, f"shard-{shard_index:06d}.safetensors")
+
+
+def manifest_path(cache_dir: str) -> str:
+    """Return the manifest path inside ``cache_dir``."""
+    return os.path.join(cache_dir, _MANIFEST_NAME)
+
+
+def existing_shard_indices(cache_dir: str) -> set[int]:
+    """Return the shard indices already present in ``cache_dir``."""
+    indices: set[int] = set()
+    if not os.path.isdir(cache_dir):
+        return indices
+    for name in os.listdir(cache_dir):
+        match = _SHARD_RE.match(name)
+        if match is not None:
+            indices.add(int(match.group(1)))
+    return indices
+
+
+def write_manifest(cache_dir: str, manifest: dict[str, Any]) -> str:
+    """Persist the DSpark cache manifest."""
+
+    def _write(tmp_path: str) -> None:
+        with open(tmp_path, "w") as f:
+            json.dump({"format_version": _FORMAT_VERSION, **manifest}, f, indent=2, sort_keys=True)
+
+    return _atomic_write(manifest_path(cache_dir), _write)
+
+
+def read_manifest(cache_dir: str) -> dict[str, Any]:
+    """Load and validate the DSpark cache manifest."""
+    path = manifest_path(cache_dir)
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"DSpark cache manifest not found at {path}. Was the cache fully written?")
+    with open(path) as f:
+        manifest = json.load(f)
+    version = manifest.get("format_version")
+    if version != _FORMAT_VERSION:
+        raise ValueError(
+            f"DSpark cache at {cache_dir} has format_version={version}, expected {_FORMAT_VERSION}. "
+            "Regenerate the cache with the current precompute_dspark."
+        )
+    return manifest
+
+
+def _target_weights_path(cache_dir: str) -> str:
+    return os.path.join(cache_dir, _TARGET_WEIGHTS_NAME)
+
+
+def write_target_weights(cache_dir: str, embed_tokens: torch.nn.Module, lm_head: torch.nn.Module) -> str:
+    """Persist target embedding and lm_head weights for target-free draft initialization."""
+    embed_weight = getattr(embed_tokens, "weight", None)
+    head_weight = getattr(lm_head, "weight", None)
+    if embed_weight is None:
+        raise ValueError("Target input embeddings do not expose a .weight tensor.")
+    if head_weight is None:
+        raise ValueError("Target output embeddings / lm_head do not expose a .weight tensor.")
+    save_file, _ = _load_safetensors()
+    tensors = {
+        "embed_tokens.weight": embed_weight.detach().to(torch.float32).cpu().contiguous(),
+        "lm_head.weight": head_weight.detach().to(torch.float32).cpu().contiguous(),
+    }
+    return _atomic_write(_target_weights_path(cache_dir), lambda tmp: save_file(tensors, tmp))
+
+
+def read_target_weight_modules(cache_dir: str) -> tuple[SimpleNamespace, SimpleNamespace]:
+    """Load target weights and return module-like objects exposing ``.weight``."""
+    _, safe_open = _load_safetensors()
+    path = _target_weights_path(cache_dir)
+    if not os.path.exists(path):
+        raise FileNotFoundError(
+            f"{path} not found. The DSpark offline cache must include target embed_tokens and lm_head "
+            "weights so training can skip loading the target model."
+        )
+    with safe_open(path, framework="pt") as handle:
+        embed_weight = handle.get_tensor("embed_tokens.weight")
+        head_weight = handle.get_tensor("lm_head.weight")
+    return SimpleNamespace(weight=embed_weight), SimpleNamespace(weight=head_weight)
+
+
+def write_shard(cache_dir: str, shard_index: int, samples: dict[str, torch.Tensor]) -> str:
+    """Write one DSpark cache shard."""
+    missing = [key for key in CACHE_KEYS if key not in samples]
+    if missing:
+        raise ValueError(f"write_shard is missing required DSpark cache fields: {missing}")
+    save_file, _ = _load_safetensors()
+    tensors = {key: samples[key].contiguous() for key in CACHE_KEYS}
+    return _atomic_write(shard_path(cache_dir, shard_index), lambda tmp: save_file(tensors, tmp))
+
+
+class CachedDSparkDataset(Dataset):
+    """Read DSpark offline cache shards lazily."""
+
+    def __init__(self, cache_dir: str):
+        self.cache_dir = cache_dir
+        self.manifest = read_manifest(cache_dir)
+        self.shard_size = int(self.manifest["shard_size"])
+        self.num_samples = int(self.manifest["num_samples"])
+        indices = sorted(existing_shard_indices(cache_dir))
+        expected = (self.num_samples + self.shard_size - 1) // self.shard_size
+        expected_indices = list(range(expected))
+        if indices != expected_indices:
+            raise ValueError(
+                f"DSpark cache at {cache_dir} declares {self.num_samples} samples "
+                f"({expected} shards) but found shard indices {indices}."
+            )
+        self._shard_indices = indices
+        self._open_handles: dict[int, Any] = {}
+
+    def __len__(self) -> int:
+        return self.num_samples
+
+    def _handle(self, shard_index: int):
+        handle = self._open_handles.get(shard_index)
+        if handle is None:
+            _, safe_open = _load_safetensors()
+            handle = safe_open(shard_path(self.cache_dir, shard_index), framework="pt")
+            self._open_handles[shard_index] = handle
+        return handle
+
+    def __getitem__(self, index: int) -> dict[str, torch.Tensor]:
+        if index < 0:
+            index += self.num_samples
+        if not 0 <= index < self.num_samples:
+            raise IndexError(index)
+        shard_index = index // self.shard_size
+        offset = index % self.shard_size
+        handle = self._handle(shard_index)
+        return {key: handle.get_slice(key)[offset] for key in CACHE_KEYS}
+
+
+def _collate_cached(features: list[dict[str, torch.Tensor]]) -> dict[str, torch.Tensor]:
+    """Stack per-sample cache dicts into a batch."""
+    return {key: torch.stack([feature[key] for feature in features], dim=0) for key in CACHE_KEYS}
+
+
+def build_cached_dspark_dataloader(
+    *,
+    cache_dir: str,
+    batch_size: int,
+    shuffle: bool,
+    num_workers: int = 0,
+    distributed: bool = False,
+) -> DataLoader:
+    """Build a dataloader over a precomputed DSpark cache directory."""
+    dataset = CachedDSparkDataset(cache_dir)
+    sampler = DistributedSampler(dataset, shuffle=shuffle) if distributed else None
+    return DataLoader(
+        dataset,
+        batch_size=batch_size,
+        sampler=sampler,
+        shuffle=shuffle and sampler is None,
+        num_workers=num_workers,
+        pin_memory=torch.cuda.is_available(),
+        collate_fn=_collate_cached,
+        drop_last=False,
+    )
+
+
+__all__ = [
+    "CACHE_KEYS",
+    "DTYPE_MAP",
+    "CachedDSparkDataset",
+    "build_cached_dspark_dataloader",
+    "existing_shard_indices",
+    "manifest_path",
+    "read_manifest",
+    "read_target_weight_modules",
+    "shard_path",
+    "write_manifest",
+    "write_shard",
+    "write_target_weights",
+]

--- a/nemo_automodel/components/datasets/llm/dspark_cache.py
+++ b/nemo_automodel/components/datasets/llm/dspark_cache.py
@@ -23,26 +23,37 @@ precompute job write those tensors once and lets training stream them later via
 
 from __future__ import annotations
 
-import json
 import os
-import re
 from types import SimpleNamespace
-from typing import Any, Callable
+from typing import Any
 
 import torch
-from torch.utils.data import DataLoader, Dataset
-from torch.utils.data.distributed import DistributedSampler
+from torch.utils.data import DataLoader
 
-from nemo_automodel.shared.import_utils import safe_import_from
+from nemo_automodel.components.datasets.llm.offline_cache import (
+    CachedTensorDataset,
+    atomic_write,
+    build_cached_dataloader,
+    collate_cached,
+    existing_shard_indices,
+    load_safetensors,
+    manifest_path,
+    shard_path,
+    write_tensor_shard,
+)
+from nemo_automodel.components.datasets.llm.offline_cache import (
+    read_manifest as _read_manifest,
+)
+from nemo_automodel.components.datasets.llm.offline_cache import (
+    write_manifest as _write_manifest,
+)
 
-_MANIFEST_NAME = "manifest.json"
 _TARGET_WEIGHTS_NAME = "target_weights.safetensors"
-_SHARD_RE = re.compile(r"^shard-(\d{6})\.safetensors$")
 _FORMAT_VERSION = 1
+_CACHE_NAME = "DSpark"
 
 CACHE_KEYS = (
     "input_ids",
-    "attention_mask",
     "loss_mask",
     "target_hidden_states",
     "target_last_hidden_states",
@@ -51,80 +62,28 @@ CACHE_KEYS = (
 DTYPE_MAP = {"bf16": torch.bfloat16, "fp16": torch.float16, "fp32": torch.float32}
 
 
-def _load_safetensors():
-    """Return ``(save_file, safe_open)`` or raise a clear error if safetensors is missing."""
-    has_save, save_file = safe_import_from("safetensors.torch", "save_file")
-    has_open, safe_open = safe_import_from("safetensors", "safe_open")
-    if not (has_save and has_open):
-        raise ImportError(
-            "The DSpark offline cache requires the 'safetensors' package. "
-            "Install it with `uv sync --locked` and re-run."
-        )
-    return save_file, safe_open
-
-
-def _atomic_write(path: str, write_fn: Callable[[str], None]) -> str:
-    """Write through a sibling temporary file, then atomically replace the target path."""
-    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
-    tmp_path = path + ".tmp"
-    write_fn(tmp_path)
-    os.replace(tmp_path, path)
-    return path
-
-
-def shard_path(cache_dir: str, shard_index: int) -> str:
-    """Return the path of shard ``shard_index`` inside ``cache_dir``."""
-    return os.path.join(cache_dir, f"shard-{shard_index:06d}.safetensors")
-
-
-def manifest_path(cache_dir: str) -> str:
-    """Return the manifest path inside ``cache_dir``."""
-    return os.path.join(cache_dir, _MANIFEST_NAME)
-
-
-def existing_shard_indices(cache_dir: str) -> set[int]:
-    """Return the shard indices already present in ``cache_dir``."""
-    indices: set[int] = set()
-    if not os.path.isdir(cache_dir):
-        return indices
-    for name in os.listdir(cache_dir):
-        match = _SHARD_RE.match(name)
-        if match is not None:
-            indices.add(int(match.group(1)))
-    return indices
-
-
-def write_manifest(cache_dir: str, manifest: dict[str, Any]) -> str:
+def write_manifest(cache_dir: str, manifest: dict) -> str:
     """Persist the DSpark cache manifest."""
-
-    def _write(tmp_path: str) -> None:
-        with open(tmp_path, "w") as f:
-            json.dump({"format_version": _FORMAT_VERSION, **manifest}, f, indent=2, sort_keys=True)
-
-    return _atomic_write(manifest_path(cache_dir), _write)
+    return _write_manifest(cache_dir, manifest, _FORMAT_VERSION)
 
 
 def read_manifest(cache_dir: str) -> dict[str, Any]:
     """Load and validate the DSpark cache manifest."""
-    path = manifest_path(cache_dir)
-    if not os.path.exists(path):
-        raise FileNotFoundError(f"DSpark cache manifest not found at {path}. Was the cache fully written?")
-    with open(path) as f:
-        manifest = json.load(f)
-    version = manifest.get("format_version")
-    if version != _FORMAT_VERSION:
-        raise ValueError(
-            f"DSpark cache at {cache_dir} has format_version={version}, expected {_FORMAT_VERSION}. "
-            "Regenerate the cache with the current precompute_dspark."
-        )
-    return manifest
+    return _read_manifest(
+        cache_dir,
+        cache_name=_CACHE_NAME,
+        format_version=_FORMAT_VERSION,
+        producer_name="precompute_dspark",
+    )
 
 
 def _target_weights_path(cache_dir: str) -> str:
     return os.path.join(cache_dir, _TARGET_WEIGHTS_NAME)
 
 
-def write_target_weights(cache_dir: str, embed_tokens: torch.nn.Module, lm_head: torch.nn.Module) -> str:
+def write_target_weights(
+    cache_dir: str, embed_tokens: torch.nn.Module, lm_head: torch.nn.Module, dtype: torch.dtype
+) -> str:
     """Persist target embedding and lm_head weights for target-free draft initialization."""
     embed_weight = getattr(embed_tokens, "weight", None)
     head_weight = getattr(lm_head, "weight", None)
@@ -132,17 +91,17 @@ def write_target_weights(cache_dir: str, embed_tokens: torch.nn.Module, lm_head:
         raise ValueError("Target input embeddings do not expose a .weight tensor.")
     if head_weight is None:
         raise ValueError("Target output embeddings / lm_head do not expose a .weight tensor.")
-    save_file, _ = _load_safetensors()
+    save_file, _ = load_safetensors(_CACHE_NAME)
     tensors = {
-        "embed_tokens.weight": embed_weight.detach().to(torch.float32).cpu().contiguous(),
-        "lm_head.weight": head_weight.detach().to(torch.float32).cpu().contiguous(),
+        "embed_tokens.weight": embed_weight.detach().to(dtype).cpu().contiguous(),
+        "lm_head.weight": head_weight.detach().to(dtype).cpu().contiguous(),
     }
-    return _atomic_write(_target_weights_path(cache_dir), lambda tmp: save_file(tensors, tmp))
+    return atomic_write(_target_weights_path(cache_dir), lambda tmp: save_file(tensors, tmp))
 
 
 def read_target_weight_modules(cache_dir: str) -> tuple[SimpleNamespace, SimpleNamespace]:
     """Load target weights and return module-like objects exposing ``.weight``."""
-    _, safe_open = _load_safetensors()
+    _, safe_open = load_safetensors(_CACHE_NAME)
     path = _target_weights_path(cache_dir)
     if not os.path.exists(path):
         raise FileNotFoundError(
@@ -157,58 +116,24 @@ def read_target_weight_modules(cache_dir: str) -> tuple[SimpleNamespace, SimpleN
 
 def write_shard(cache_dir: str, shard_index: int, samples: dict[str, torch.Tensor]) -> str:
     """Write one DSpark cache shard."""
-    missing = [key for key in CACHE_KEYS if key not in samples]
-    if missing:
-        raise ValueError(f"write_shard is missing required DSpark cache fields: {missing}")
-    save_file, _ = _load_safetensors()
-    tensors = {key: samples[key].contiguous() for key in CACHE_KEYS}
-    return _atomic_write(shard_path(cache_dir, shard_index), lambda tmp: save_file(tensors, tmp))
+    return write_tensor_shard(cache_dir, shard_index, samples, CACHE_KEYS, _CACHE_NAME)
 
 
-class CachedDSparkDataset(Dataset):
+class CachedDSparkDataset(CachedTensorDataset):
     """Read DSpark offline cache shards lazily."""
 
     def __init__(self, cache_dir: str):
-        self.cache_dir = cache_dir
-        self.manifest = read_manifest(cache_dir)
-        self.shard_size = int(self.manifest["shard_size"])
-        self.num_samples = int(self.manifest["num_samples"])
-        indices = sorted(existing_shard_indices(cache_dir))
-        expected = (self.num_samples + self.shard_size - 1) // self.shard_size
-        expected_indices = list(range(expected))
-        if indices != expected_indices:
-            raise ValueError(
-                f"DSpark cache at {cache_dir} declares {self.num_samples} samples "
-                f"({expected} shards) but found shard indices {indices}."
-            )
-        self._shard_indices = indices
-        self._open_handles: dict[int, Any] = {}
-
-    def __len__(self) -> int:
-        return self.num_samples
-
-    def _handle(self, shard_index: int):
-        handle = self._open_handles.get(shard_index)
-        if handle is None:
-            _, safe_open = _load_safetensors()
-            handle = safe_open(shard_path(self.cache_dir, shard_index), framework="pt")
-            self._open_handles[shard_index] = handle
-        return handle
-
-    def __getitem__(self, index: int) -> dict[str, torch.Tensor]:
-        if index < 0:
-            index += self.num_samples
-        if not 0 <= index < self.num_samples:
-            raise IndexError(index)
-        shard_index = index // self.shard_size
-        offset = index % self.shard_size
-        handle = self._handle(shard_index)
-        return {key: handle.get_slice(key)[offset] for key in CACHE_KEYS}
+        super().__init__(
+            cache_dir=cache_dir,
+            cache_name=_CACHE_NAME,
+            format_version=_FORMAT_VERSION,
+            disk_keys=CACHE_KEYS,
+        )
 
 
 def _collate_cached(features: list[dict[str, torch.Tensor]]) -> dict[str, torch.Tensor]:
     """Stack per-sample cache dicts into a batch."""
-    return {key: torch.stack([feature[key] for feature in features], dim=0) for key in CACHE_KEYS}
+    return collate_cached(features, CACHE_KEYS)
 
 
 def build_cached_dspark_dataloader(
@@ -221,16 +146,13 @@ def build_cached_dspark_dataloader(
 ) -> DataLoader:
     """Build a dataloader over a precomputed DSpark cache directory."""
     dataset = CachedDSparkDataset(cache_dir)
-    sampler = DistributedSampler(dataset, shuffle=shuffle) if distributed else None
-    return DataLoader(
-        dataset,
+    return build_cached_dataloader(
+        dataset=dataset,
         batch_size=batch_size,
-        sampler=sampler,
-        shuffle=shuffle and sampler is None,
-        num_workers=num_workers,
-        pin_memory=torch.cuda.is_available(),
+        shuffle=shuffle,
         collate_fn=_collate_cached,
-        drop_last=False,
+        num_workers=num_workers,
+        distributed=distributed,
     )
 
 

--- a/nemo_automodel/components/datasets/llm/dspark_cache.py
+++ b/nemo_automodel/components/datasets/llm/dspark_cache.py
@@ -93,8 +93,8 @@ def write_target_weights(
         raise ValueError("Target output embeddings / lm_head do not expose a .weight tensor.")
     save_file, _ = load_safetensors(_CACHE_NAME)
     tensors = {
-        "embed_tokens.weight": embed_weight.detach().to(dtype).cpu().contiguous(),
-        "lm_head.weight": head_weight.detach().to(dtype).cpu().contiguous(),
+        "embed_tokens.weight": embed_weight.detach().to(dtype).cpu().contiguous().clone(),
+        "lm_head.weight": head_weight.detach().to(dtype).cpu().contiguous().clone(),
     }
     return atomic_write(_target_weights_path(cache_dir), lambda tmp: save_file(tensors, tmp))
 

--- a/nemo_automodel/components/datasets/llm/eagle3_cache.py
+++ b/nemo_automodel/components/datasets/llm/eagle3_cache.py
@@ -51,21 +51,36 @@ Each ``CachedEagle3Dataset`` item is exactly the keyword arguments
 
 from __future__ import annotations
 
-import json
 import os
-import re
-from typing import Any, Callable
+from typing import Any
 
 import torch
-from torch.utils.data import DataLoader, Dataset
-from torch.utils.data.distributed import DistributedSampler
+from torch.utils.data import DataLoader
 
-from nemo_automodel.shared.import_utils import safe_import_from
+from nemo_automodel.components.datasets.llm.offline_cache import (
+    CachedTensorDataset,
+    atomic_write,
+    build_cached_dataloader,
+    collate_cached,
+    load_safetensors,
+    shard_path,
+)
+from nemo_automodel.components.datasets.llm.offline_cache import (
+    existing_shard_indices as _existing_shard_indices,
+)
+from nemo_automodel.components.datasets.llm.offline_cache import (
+    manifest_path as _manifest_path,
+)
+from nemo_automodel.components.datasets.llm.offline_cache import (
+    read_manifest as _read_manifest,
+)
+from nemo_automodel.components.datasets.llm.offline_cache import (
+    write_manifest as _write_manifest,
+)
 
-_MANIFEST_NAME = "manifest.json"
 _EMBEDDINGS_NAME = "target_embeddings.safetensors"
-_SHARD_RE = re.compile(r"^shard-(\d{6})\.safetensors$")
 _FORMAT_VERSION = 2
+_CACHE_NAME = "EAGLE-3"
 
 # Fields the trainer's precomputed-distribution path consumes (what each
 # ``CachedEagle3Dataset`` item yields). ``target_probs`` is the full draft-vocab
@@ -114,76 +129,29 @@ def reconstruct_target_probs(values: torch.Tensor, indices: torch.Tensor, draft_
     return full.scatter_(-1, indices.to(torch.long), values)
 
 
-def _load_safetensors():
-    """Return ``(save_file, safe_open)`` or raise a clear error if safetensors is missing."""
-    has_save, save_file = safe_import_from("safetensors.torch", "save_file")
-    has_open, safe_open = safe_import_from("safetensors", "safe_open")
-    if not (has_save and has_open):
-        raise ImportError(
-            "The EAGLE-3 offline cache requires the 'safetensors' package. "
-            "Install it with `uv pip install safetensors` and re-run."
-        )
-    return save_file, safe_open
-
-
-def _atomic_write(path: str, write_fn: Callable[[str], None]) -> str:
-    """Run ``write_fn`` against a sibling ``.tmp`` path, then ``os.replace`` it into place.
-
-    A crash mid-write never leaves a half-written file a later run would load.
-    """
-    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
-    tmp_path = path + ".tmp"
-    write_fn(tmp_path)
-    os.replace(tmp_path, path)
-    return path
-
-
-def shard_path(cache_dir: str, shard_index: int) -> str:
-    """Return the path of shard ``shard_index`` inside ``cache_dir``."""
-    return os.path.join(cache_dir, f"shard-{shard_index:06d}.safetensors")
-
-
-def manifest_path(cache_dir: str) -> str:
-    """Return the manifest path inside ``cache_dir``."""
-    return os.path.join(cache_dir, _MANIFEST_NAME)
-
-
-def existing_shard_indices(cache_dir: str) -> set[int]:
-    """Return the set of shard indices already present in ``cache_dir``."""
-    indices: set[int] = set()
-    if not os.path.isdir(cache_dir):
-        return indices
-    for name in os.listdir(cache_dir):
-        match = _SHARD_RE.match(name)
-        if match is not None:
-            indices.add(int(match.group(1)))
-    return indices
-
-
 def write_manifest(cache_dir: str, manifest: dict[str, Any]) -> str:
     """Persist the cache manifest atomically (``.tmp`` + ``os.replace``)."""
-
-    def _write(tmp_path: str) -> None:
-        with open(tmp_path, "w") as f:
-            json.dump({"format_version": _FORMAT_VERSION, **manifest}, f, indent=2, sort_keys=True)
-
-    return _atomic_write(manifest_path(cache_dir), _write)
+    return _write_manifest(cache_dir, manifest, _FORMAT_VERSION)
 
 
 def read_manifest(cache_dir: str) -> dict[str, Any]:
     """Load the cache manifest, raising if it is missing or the wrong format version."""
-    path = manifest_path(cache_dir)
-    if not os.path.exists(path):
-        raise FileNotFoundError(f"EAGLE-3 cache manifest not found at {path}. Was the cache fully written?")
-    with open(path) as f:
-        manifest = json.load(f)
-    version = manifest.get("format_version")
-    if version != _FORMAT_VERSION:
-        raise ValueError(
-            f"EAGLE-3 cache at {cache_dir} has format_version={version}, expected {_FORMAT_VERSION}. "
-            "Regenerate the cache with the current precompute_eagle3."
-        )
-    return manifest
+    return _read_manifest(
+        cache_dir,
+        cache_name=_CACHE_NAME,
+        format_version=_FORMAT_VERSION,
+        producer_name="precompute_eagle3",
+    )
+
+
+def existing_shard_indices(cache_dir: str) -> set[int]:
+    """Return EAGLE-3 shard indices already present in ``cache_dir``."""
+    return _existing_shard_indices(cache_dir)
+
+
+def manifest_path(cache_dir: str) -> str:
+    """Return the EAGLE-3 manifest path inside ``cache_dir``."""
+    return _manifest_path(cache_dir)
 
 
 def write_target_embeddings(cache_dir: str, weight: torch.Tensor) -> str:
@@ -194,14 +162,14 @@ def write_target_embeddings(cache_dir: str, weight: torch.Tensor) -> str:
     concatenates token embeddings with the carried hidden state), so the
     producer stores them once alongside the cache.
     """
-    save_file, _ = _load_safetensors()
+    save_file, _ = load_safetensors(_CACHE_NAME)
     tensors = {"weight": weight.detach().to(torch.float32).cpu().contiguous()}
-    return _atomic_write(os.path.join(cache_dir, _EMBEDDINGS_NAME), lambda tmp: save_file(tensors, tmp))
+    return atomic_write(os.path.join(cache_dir, _EMBEDDINGS_NAME), lambda tmp: save_file(tensors, tmp))
 
 
 def read_target_embeddings(cache_dir: str) -> torch.Tensor:
     """Load the target input-embedding table written by ``write_target_embeddings``."""
-    _, safe_open = _load_safetensors()
+    _, safe_open = load_safetensors(_CACHE_NAME)
     path = os.path.join(cache_dir, _EMBEDDINGS_NAME)
     if not os.path.exists(path):
         raise FileNotFoundError(
@@ -219,7 +187,7 @@ def write_shard(cache_dir: str, shard_index: int, samples: dict[str, torch.Tenso
     representation: the full ``target_probs`` (lossless) or the top-k pair
     ``target_probs_values`` + ``target_probs_indices``.
     """
-    save_file, _ = _load_safetensors()
+    save_file, _ = load_safetensors(_CACHE_NAME)
     has_full = "target_probs" in samples
     has_topk = all(k in samples for k in _TOPK_PROBS_KEYS)
     if int(has_full) + int(has_topk) != 1:
@@ -232,10 +200,10 @@ def write_shard(cache_dir: str, shard_index: int, samples: dict[str, torch.Tenso
     if missing:
         raise ValueError(f"write_shard is missing required cache fields: {missing}")
     tensors = {k: samples[k].contiguous() for k in keys}
-    return _atomic_write(shard_path(cache_dir, shard_index), lambda tmp: save_file(tensors, tmp))
+    return atomic_write(shard_path(cache_dir, shard_index), lambda tmp: save_file(tensors, tmp))
 
 
-class CachedEagle3Dataset(Dataset):
+class CachedEagle3Dataset(CachedTensorDataset):
     """Reads the EAGLE-3 offline cache; each item is one sample's trainer inputs.
 
     Shards are opened lazily with ``safetensors.safe_open`` (memory-mapped) and
@@ -244,35 +212,18 @@ class CachedEagle3Dataset(Dataset):
     """
 
     def __init__(self, cache_dir: str):
-        self.cache_dir = cache_dir
-        self.manifest = read_manifest(cache_dir)
-        self.shard_size = int(self.manifest["shard_size"])
-        self.num_samples = int(self.manifest["num_samples"])
+        manifest = read_manifest(cache_dir)
         # A cache stores target_probs either in full or as its top-k factorization;
         # the reader yields the full distribution either way.
-        self.draft_vocab_size = int(self.manifest["draft_vocab_size"])
-        self._compressed = is_compressed(self.manifest.get("target_probs_topk"), self.draft_vocab_size)
-        self._disk_keys = _COMMON_KEYS + (_TOPK_PROBS_KEYS if self._compressed else _LOSSLESS_PROBS_KEYS)
-        indices = sorted(existing_shard_indices(cache_dir))
-        expected = (self.num_samples + self.shard_size - 1) // self.shard_size
-        if len(indices) != expected:
-            raise ValueError(
-                f"EAGLE-3 cache at {cache_dir} declares {self.num_samples} samples "
-                f"({expected} shards) but found {len(indices)} shard files."
-            )
-        self._shard_indices = indices
-        self._open_handles: dict[int, Any] = {}
-
-    def __len__(self) -> int:
-        return self.num_samples
-
-    def _handle(self, shard_index: int):
-        handle = self._open_handles.get(shard_index)
-        if handle is None:
-            _, safe_open = _load_safetensors()
-            handle = safe_open(shard_path(self.cache_dir, shard_index), framework="pt")
-            self._open_handles[shard_index] = handle
-        return handle
+        self.draft_vocab_size = int(manifest["draft_vocab_size"])
+        self._compressed = is_compressed(manifest.get("target_probs_topk"), self.draft_vocab_size)
+        disk_keys = _COMMON_KEYS + (_TOPK_PROBS_KEYS if self._compressed else _LOSSLESS_PROBS_KEYS)
+        super().__init__(
+            cache_dir=cache_dir,
+            cache_name=_CACHE_NAME,
+            format_version=_FORMAT_VERSION,
+            disk_keys=disk_keys,
+        )
 
     def __getitem__(self, index: int) -> dict[str, torch.Tensor]:
         if index < 0:
@@ -294,7 +245,7 @@ class CachedEagle3Dataset(Dataset):
 
 def _collate_cached(features: list[dict[str, torch.Tensor]]) -> dict[str, torch.Tensor]:
     """Stack per-sample cache dicts into a batch."""
-    return {key: torch.stack([feature[key] for feature in features], dim=0) for key in CACHE_KEYS}
+    return collate_cached(features, CACHE_KEYS)
 
 
 def build_cached_eagle3_dataloader(
@@ -307,14 +258,11 @@ def build_cached_eagle3_dataloader(
 ) -> DataLoader:
     """Build a dataloader over a precomputed EAGLE-3 cache directory."""
     dataset = CachedEagle3Dataset(cache_dir)
-    sampler = DistributedSampler(dataset, shuffle=shuffle) if distributed else None
-    return DataLoader(
-        dataset,
+    return build_cached_dataloader(
+        dataset=dataset,
         batch_size=batch_size,
-        sampler=sampler,
-        shuffle=shuffle and sampler is None,
-        num_workers=num_workers,
-        pin_memory=torch.cuda.is_available(),
+        shuffle=shuffle,
         collate_fn=_collate_cached,
-        drop_last=False,
+        num_workers=num_workers,
+        distributed=distributed,
     )

--- a/nemo_automodel/components/datasets/llm/offline_cache.py
+++ b/nemo_automodel/components/datasets/llm/offline_cache.py
@@ -1,0 +1,292 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared on-disk helpers for speculative offline cache readers."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from typing import Any, Callable
+
+import torch
+from torch.utils.data import DataLoader, Dataset, Subset
+from torch.utils.data.distributed import DistributedSampler
+
+from nemo_automodel.shared.import_utils import safe_import_from
+
+MANIFEST_NAME = "manifest.json"
+SHARD_RE = re.compile(r"^shard-(\d{6})\.safetensors$")
+
+
+def load_safetensors(cache_name: str):
+    """Return ``(save_file, safe_open)`` or raise a clear dependency error."""
+    has_save, save_file = safe_import_from("safetensors.torch", "save_file")
+    has_open, safe_open = safe_import_from("safetensors", "safe_open")
+    if not (has_save and has_open):
+        raise ImportError(
+            f"The {cache_name} offline cache requires the 'safetensors' package. "
+            "Install it with `uv sync --locked` and re-run."
+        )
+    return save_file, safe_open
+
+
+def atomic_write(path: str, write_fn: Callable[[str], None]) -> str:
+    """Write through a sibling temporary file, then atomically replace the target path."""
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    tmp_path = path + ".tmp"
+    write_fn(tmp_path)
+    os.replace(tmp_path, path)
+    return path
+
+
+def shard_path(cache_dir: str, shard_index: int) -> str:
+    """Return the path of shard ``shard_index`` inside ``cache_dir``."""
+    return os.path.join(cache_dir, f"shard-{shard_index:06d}.safetensors")
+
+
+def manifest_path(cache_dir: str) -> str:
+    """Return the manifest path inside ``cache_dir``."""
+    return os.path.join(cache_dir, MANIFEST_NAME)
+
+
+def existing_shard_indices(cache_dir: str) -> set[int]:
+    """Return the shard indices already present in ``cache_dir``."""
+    indices: set[int] = set()
+    if not os.path.isdir(cache_dir):
+        return indices
+    for name in os.listdir(cache_dir):
+        match = SHARD_RE.match(name)
+        if match is not None:
+            indices.add(int(match.group(1)))
+    return indices
+
+
+def write_manifest(cache_dir: str, manifest: dict[str, Any], format_version: int) -> str:
+    """Persist an offline-cache manifest atomically."""
+
+    def _write(tmp_path: str) -> None:
+        with open(tmp_path, "w") as f:
+            json.dump({"format_version": format_version, **manifest}, f, indent=2, sort_keys=True)
+
+    return atomic_write(manifest_path(cache_dir), _write)
+
+
+def read_manifest(
+    cache_dir: str,
+    *,
+    cache_name: str,
+    format_version: int,
+    producer_name: str | None = None,
+) -> dict[str, Any]:
+    """Load and validate an offline-cache manifest."""
+    path = manifest_path(cache_dir)
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"{cache_name} cache manifest not found at {path}. Was the cache fully written?")
+    with open(path) as f:
+        manifest = json.load(f)
+    version = manifest.get("format_version")
+    if version != format_version:
+        producer = producer_name or f"precompute_{cache_name.lower().replace('-', '')}"
+        raise ValueError(
+            f"{cache_name} cache at {cache_dir} has format_version={version}, expected {format_version}. "
+            f"Regenerate the cache with the current {producer}."
+        )
+    return manifest
+
+
+def validate_contiguous_shards(cache_dir: str, cache_name: str, num_samples: int, shard_size: int) -> list[int]:
+    """Return shard indices, requiring exactly ``0..N-1`` for the manifest size."""
+    indices = sorted(existing_shard_indices(cache_dir))
+    expected = (num_samples + shard_size - 1) // shard_size
+    expected_indices = list(range(expected))
+    if indices != expected_indices:
+        raise ValueError(
+            f"{cache_name} cache at {cache_dir} declares {num_samples} samples "
+            f"({expected} shards) but found shard indices {indices}."
+        )
+    return indices
+
+
+def write_tensor_shard(
+    cache_dir: str,
+    shard_index: int,
+    samples: dict[str, torch.Tensor],
+    keys: tuple[str, ...],
+    cache_name: str,
+) -> str:
+    """Write one cache shard containing exactly the requested tensor keys."""
+    missing = [key for key in keys if key not in samples]
+    if missing:
+        raise ValueError(f"write_shard is missing required {cache_name} cache fields: {missing}")
+    save_file, _ = load_safetensors(cache_name)
+    tensors = {key: samples[key].contiguous() for key in keys}
+    return atomic_write(shard_path(cache_dir, shard_index), lambda tmp: save_file(tensors, tmp))
+
+
+class CachedTensorDataset(Dataset):
+    """Lazily read fixed-key safetensors shards by sample index."""
+
+    def __init__(
+        self,
+        *,
+        cache_dir: str,
+        cache_name: str,
+        format_version: int,
+        disk_keys: tuple[str, ...],
+    ) -> None:
+        self.cache_dir = cache_dir
+        self.cache_name = cache_name
+        self.manifest = read_manifest(cache_dir, cache_name=cache_name, format_version=format_version)
+        self.shard_size = int(self.manifest["shard_size"])
+        self.num_samples = int(self.manifest["num_samples"])
+        self._disk_keys = disk_keys
+        self._shard_indices = validate_contiguous_shards(cache_dir, cache_name, self.num_samples, self.shard_size)
+        self._open_handles: dict[int, Any] = {}
+
+    def __len__(self) -> int:
+        return self.num_samples
+
+    def _handle(self, shard_index: int):
+        handle = self._open_handles.get(shard_index)
+        if handle is None:
+            _, safe_open = load_safetensors(self.cache_name)
+            handle = safe_open(shard_path(self.cache_dir, shard_index), framework="pt")
+            self._open_handles[shard_index] = handle
+        return handle
+
+    def __getitem__(self, index: int) -> dict[str, torch.Tensor]:
+        if index < 0:
+            index += self.num_samples
+        if not 0 <= index < self.num_samples:
+            raise IndexError(index)
+        shard_index = index // self.shard_size
+        offset = index % self.shard_size
+        handle = self._handle(shard_index)
+        return {key: handle.get_slice(key)[offset] for key in self._disk_keys}
+
+
+def collate_cached(features: list[dict[str, torch.Tensor]], keys: tuple[str, ...]) -> dict[str, torch.Tensor]:
+    """Stack per-sample cache dicts into a batch."""
+    return {key: torch.stack([feature[key] for feature in features], dim=0) for key in keys}
+
+
+def build_cached_dataloader(
+    *,
+    dataset: Dataset,
+    batch_size: int,
+    shuffle: bool,
+    collate_fn: Callable[[list[dict[str, torch.Tensor]]], dict[str, torch.Tensor]],
+    num_workers: int = 0,
+    distributed: bool = False,
+) -> DataLoader:
+    """Build a dataloader over a precomputed offline cache dataset."""
+    sampler = DistributedSampler(dataset, shuffle=shuffle) if distributed else None
+    return DataLoader(
+        dataset,
+        batch_size=batch_size,
+        sampler=sampler,
+        shuffle=shuffle and sampler is None,
+        num_workers=num_workers,
+        pin_memory=torch.cuda.is_available(),
+        collate_fn=collate_fn,
+        drop_last=False,
+    )
+
+
+def resume_start_sample(existing_shards: set[int], shard_size: int) -> int:
+    """Return the sample index where a deterministic sequential resume should start."""
+    expected = set(range(len(existing_shards)))
+    if existing_shards != expected:
+        raise ValueError(
+            f"--resume expects existing shards to be a contiguous prefix {sorted(expected)}, "
+            f"but found {sorted(existing_shards)}. Delete stale shards or restart from a clean directory."
+        )
+    return len(existing_shards) * shard_size
+
+
+def dataloader_from_sample(dataloader: DataLoader, start_sample: int) -> DataLoader:
+    """Return an equivalent sequential dataloader beginning at ``start_sample``."""
+    if start_sample <= 0:
+        return dataloader
+    dataset = dataloader.dataset
+    batch_size = getattr(dataloader, "batch_size", None) or 1
+    collate_fn = getattr(dataloader, "collate_fn", None)
+    if start_sample >= len(dataset):
+        return DataLoader(
+            Subset(dataset, []),
+            batch_size=batch_size,
+            shuffle=False,
+            num_workers=0,
+            collate_fn=collate_fn,
+            drop_last=False,
+        )
+    worker_kwargs: dict[str, Any] = {}
+    num_workers = int(getattr(dataloader, "num_workers", 0))
+    if num_workers > 0:
+        worker_kwargs["persistent_workers"] = getattr(dataloader, "persistent_workers", False)
+        multiprocessing_context = getattr(dataloader, "multiprocessing_context", None)
+        if multiprocessing_context is not None:
+            worker_kwargs["multiprocessing_context"] = multiprocessing_context
+    return DataLoader(
+        Subset(dataset, range(start_sample, len(dataset))),
+        batch_size=batch_size,
+        shuffle=False,
+        num_workers=num_workers,
+        pin_memory=bool(getattr(dataloader, "pin_memory", False)),
+        collate_fn=collate_fn,
+        drop_last=False,
+        **worker_kwargs,
+    )
+
+
+def write_cache_shards(
+    *,
+    dataloader: DataLoader,
+    output_dir: str,
+    shard_size: int,
+    start_shard_index: int,
+    compute_batch: Callable[[dict[str, torch.Tensor]], dict[str, torch.Tensor]],
+    write_shard_fn: Callable[[str, int, dict[str, torch.Tensor]], str],
+    logger: logging.Logger,
+) -> None:
+    """Run a precompute loop and write sequential cache shards."""
+    shard_index = start_shard_index
+    chunks: list[dict[str, torch.Tensor]] = []
+    buffered = 0
+
+    def _flush(max_samples: int | None = None) -> None:
+        nonlocal shard_index, chunks, buffered
+        if buffered == 0:
+            return
+        samples_to_write = buffered if max_samples is None else min(buffered, max_samples)
+        merged = {k: torch.cat([c[k] for c in chunks], dim=0) for k in chunks[0]}
+        shard = {k: v[:samples_to_write] for k, v in merged.items()}
+        path = write_shard_fn(output_dir, shard_index, shard)
+        logger.info("Wrote %s (%d samples)", path, shard["input_ids"].shape[0])
+        remainder = {k: v[samples_to_write:] for k, v in merged.items()}
+        remaining = buffered - samples_to_write
+        chunks = [remainder] if remaining else []
+        buffered = remaining
+        shard_index += 1
+
+    for batch in dataloader:
+        chunks.append(compute_batch(batch))
+        buffered += batch["input_ids"].shape[0]
+        while buffered >= shard_size:
+            _flush(shard_size)
+
+    _flush()

--- a/nemo_automodel/components/speculative/dspark/target_utils.py
+++ b/nemo_automodel/components/speculative/dspark/target_utils.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared DSpark target-identification and tokenization helpers."""
+
+from __future__ import annotations
+
+from transformers import AutoConfig, PretrainedConfig
+
+from nemo_automodel.components.datasets.llm.formatting_utils import _has_chat_template, _resolve_chat_template
+
+GEMMA4_MODEL_TYPES = ("gemma4", "gemma4_unified")
+DEEPSEEK_V4_MODEL_TYPE = "deepseek_v4"
+GLM_5_2_MODEL_TYPE = "glm_moe_dsa"
+MINIMAX_M3_MODEL_TYPES = ("minimax_m3_vl",)
+
+
+def read_target_model_type(target_path: str, trust_remote_code: bool) -> str:
+    """Return the target HF ``model_type`` without instantiating the model when possible."""
+    try:
+        config_dict, _ = PretrainedConfig.get_config_dict(target_path, trust_remote_code=trust_remote_code)
+        model_type = config_dict.get("model_type")
+        if model_type:
+            return str(model_type)
+    except (OSError, ValueError, KeyError):
+        pass
+    config = AutoConfig.from_pretrained(target_path, trust_remote_code=trust_remote_code)
+    return str(getattr(config, "model_type", "") or "")
+
+
+def apply_target_chat_template(tokenizer, chat_template) -> None:
+    """Attach or validate the chat template used to tokenize messages-format data."""
+    if chat_template is not None:
+        tokenizer.chat_template = _resolve_chat_template(str(chat_template))
+        return
+    if not _has_chat_template(tokenizer):
+        raise ValueError(
+            "The target tokenizer has no chat template and --chat-template was not set. "
+            "DSpark needs the same template for training and offline precompute."
+        )

--- a/nemo_automodel/components/speculative/precompute_dspark.py
+++ b/nemo_automodel/components/speculative/precompute_dspark.py
@@ -1,0 +1,316 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Precompute the DSpark offline target-supervision cache.
+
+The online DSpark recipe runs a frozen target model every step to capture the
+intermediate target hidden states consumed by the draft and the final hidden
+state used by the TV / confidence losses. This script runs that target once and
+writes those tensors to disk. Training can then set
+``recipe_args.cached_target_path`` to stream the cache without loading or
+running the target model.
+
+Typical usage (single device):
+
+    python -m nemo_automodel.components.speculative.precompute_dspark \\
+        --target-model Qwen/Qwen3-0.6B \\
+        --input-data /data/messages.jsonl \\
+        --output-dir /data/dspark_cache/qwen3_06b \\
+        --seq-length 2048 --batch-size 4 --shard-size 256 --dtype bf16
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from typing import Any
+
+import torch
+from transformers import AutoConfig, PretrainedConfig
+
+from nemo_automodel._transformers import NeMoAutoModelForCausalLM
+from nemo_automodel._transformers.auto_tokenizer import NeMoAutoTokenizer
+from nemo_automodel.components.datasets.llm.dspark_cache import (
+    DTYPE_MAP,
+    existing_shard_indices,
+    manifest_path,
+    read_manifest,
+    write_manifest,
+    write_shard,
+    write_target_weights,
+)
+from nemo_automodel.components.datasets.llm.eagle3 import build_eagle3_dataloader
+from nemo_automodel.components.datasets.llm.formatting_utils import (
+    _has_chat_template,
+    _resolve_chat_template,
+)
+from nemo_automodel.components.speculative.dspark.registry import build_target_layer_ids
+from nemo_automodel.components.speculative.dspark.target import HFDSparkTargetModel
+
+logger = logging.getLogger(__name__)
+
+_GEMMA4_MODEL_TYPES = ("gemma4", "gemma4_unified")
+_DEEPSEEK_V4_MODEL_TYPE = "deepseek_v4"
+
+
+def _read_target_model_type(target_path: str, trust_remote_code: bool) -> str:
+    """Return the target HF ``model_type`` without instantiating the model when possible."""
+    try:
+        config_dict, _ = PretrainedConfig.get_config_dict(target_path, trust_remote_code=trust_remote_code)
+        model_type = config_dict.get("model_type")
+        if model_type:
+            return str(model_type)
+    except (OSError, ValueError, KeyError):
+        pass
+    config = AutoConfig.from_pretrained(target_path, trust_remote_code=trust_remote_code)
+    return str(getattr(config, "model_type", "") or "")
+
+
+def _apply_target_chat_template(tokenizer, chat_template) -> None:
+    """Attach or validate the chat template used to tokenize messages-format data."""
+    if chat_template is not None:
+        tokenizer.chat_template = _resolve_chat_template(str(chat_template))
+        return
+    if not _has_chat_template(tokenizer):
+        raise ValueError(
+            "The target tokenizer has no chat template and --chat-template was not set. "
+            "DSpark precompute needs the same template that training uses for messages-format data."
+        )
+
+
+def _compute_batch_cache(
+    target_batch, attention_mask: torch.Tensor, cache_dtype: torch.dtype
+) -> dict[str, torch.Tensor]:
+    """Convert one captured target batch into cache tensors."""
+    return {
+        "input_ids": target_batch.input_ids.to(torch.long).cpu(),
+        "attention_mask": attention_mask.to(torch.long).cpu(),
+        "loss_mask": target_batch.loss_mask.to(torch.long).cpu(),
+        "target_hidden_states": target_batch.target_hidden_states.to(cache_dtype).cpu(),
+        "target_last_hidden_states": target_batch.target_last_hidden_states.to(cache_dtype).cpu(),
+    }
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    """Reject invalid CLI values before loading the target model."""
+    if args.batch_size < 1:
+        raise ValueError(f"--batch-size must be >= 1, got {args.batch_size}")
+    if args.shard_size < 1:
+        raise ValueError(f"--shard-size must be >= 1, got {args.shard_size}")
+    if args.shard_size % args.batch_size != 0:
+        raise ValueError(
+            f"--shard-size ({args.shard_size}) must be a multiple of --batch-size ({args.batch_size}) "
+            "so shards align to batch boundaries."
+        )
+    if args.draft_num_hidden_layers < 1:
+        raise ValueError(f"--draft-num-hidden-layers must be >= 1, got {args.draft_num_hidden_layers}")
+    if args.dtype not in DTYPE_MAP:
+        raise ValueError(f"--dtype must be one of {sorted(DTYPE_MAP)}, got {args.dtype!r}")
+
+
+def _ensure_resume_compatible(cache_dir: str, manifest: dict[str, Any], existing_shards: set[int]) -> None:
+    """Refuse to resume into shards produced with a different configuration."""
+    if not os.path.exists(manifest_path(cache_dir)):
+        if existing_shards:
+            raise ValueError(
+                f"--resume was requested for {cache_dir}, but its manifest is missing, so existing shards "
+                "cannot be verified. Delete the directory and start fresh."
+            )
+        return
+    recorded = read_manifest(cache_dir)
+    recorded.pop("format_version", None)
+    if recorded != manifest:
+        mismatched = sorted(k for k in recorded.keys() | manifest.keys() if recorded.get(k) != manifest.get(k))
+        raise ValueError(
+            f"--resume was requested for {cache_dir}, but the recorded manifest does not match the current "
+            f"run configuration (mismatched fields: {mismatched}). Re-run with the original settings, or "
+            "delete the directory and start fresh."
+        )
+
+
+def _run(args: argparse.Namespace) -> int:
+    """Load the target, scan the dataset once, and write the sharded cache."""
+    _validate_args(args)
+    cache_dtype = DTYPE_MAP[args.dtype]
+
+    present = existing_shard_indices(args.output_dir)
+    if present and not args.resume:
+        raise ValueError(f"{args.output_dir} already has shards; pass --resume to continue or use a fresh dir.")
+    existing = present if args.resume else set()
+    if existing:
+        logger.info("Resume: %d shard(s) already present, will be skipped.", len(existing))
+
+    device = torch.device(args.device)
+    compute_dtype = torch.bfloat16 if device.type == "cuda" else torch.float32
+
+    model_type = _read_target_model_type(args.target_model, args.trust_remote_code)
+    if model_type == _DEEPSEEK_V4_MODEL_TYPE:
+        raise ValueError(
+            "precompute_dspark currently supports HF-loadable single-process targets. "
+            "DeepSeek V4 targets need the distributed online training path."
+        )
+
+    target_config = AutoConfig.from_pretrained(args.target_model, trust_remote_code=args.trust_remote_code)
+    target_text_config = target_config.text_config if model_type in _GEMMA4_MODEL_TYPES else target_config
+    num_target_layers = int(target_text_config.num_hidden_layers)
+    target_layer_ids = list(
+        args.target_layer_ids or build_target_layer_ids(num_target_layers, args.draft_num_hidden_layers)
+    )
+
+    tokenizer = NeMoAutoTokenizer.from_pretrained(args.target_model, trust_remote_code=args.trust_remote_code)
+    _apply_target_chat_template(tokenizer, args.chat_template)
+
+    target_kwargs = {}
+    if args.target_attn_implementation is not None:
+        target_kwargs["attn_implementation"] = args.target_attn_implementation
+    target_model = NeMoAutoModelForCausalLM.from_pretrained(
+        args.target_model,
+        trust_remote_code=args.trust_remote_code,
+        torch_dtype=compute_dtype,
+        force_hf=args.target_force_hf,
+        **target_kwargs,
+    ).to(device)
+    target_model.eval()
+    target_model.requires_grad_(False)
+    target_wrapper = HFDSparkTargetModel(target_model, target_layer_ids=target_layer_ids)
+
+    dataloader = build_eagle3_dataloader(
+        data_path=args.input_data,
+        tokenizer=tokenizer,
+        seq_length=args.seq_length,
+        batch_size=args.batch_size,
+        shuffle=False,
+        num_workers=args.num_workers,
+        split=args.split,
+        distributed=False,
+        shuffle_seed=args.shuffle_seed,
+        mask_reasoning_content=args.mask_reasoning_content,
+    )
+    num_samples = len(dataloader.dataset)
+    hidden_size = int(target_text_config.hidden_size)
+
+    manifest = {
+        "target_model": args.target_model,
+        "target_model_type": model_type,
+        "target_vocab_size": int(target_text_config.vocab_size),
+        "hidden_size": hidden_size,
+        "num_hidden_layers": num_target_layers,
+        "seq_length": args.seq_length,
+        "dtype": args.dtype,
+        "num_samples": num_samples,
+        "shard_size": args.shard_size,
+        "target_hidden_dim": hidden_size * len(target_wrapper.target_layer_ids),
+        "target_last_hidden_dim": hidden_size,
+        "target_layer_ids": list(target_wrapper.target_layer_ids),
+    }
+    if args.resume:
+        _ensure_resume_compatible(args.output_dir, manifest, existing)
+    write_target_weights(args.output_dir, target_model.get_input_embeddings(), target_model.get_output_embeddings())
+    write_manifest(args.output_dir, manifest)
+
+    logger.info(
+        "Precomputing DSpark cache: %d samples, shard_size=%d, layers=%s, dtype=%s -> %s",
+        num_samples,
+        args.shard_size,
+        target_wrapper.target_layer_ids,
+        args.dtype,
+        args.output_dir,
+    )
+
+    shard_index = 0
+    chunks: list[dict[str, torch.Tensor]] = []
+    buffered = 0
+
+    def _flush() -> None:
+        nonlocal shard_index, chunks, buffered
+        if buffered == 0:
+            return
+        if shard_index not in existing:
+            merged = {k: torch.cat([c[k] for c in chunks], dim=0)[: args.shard_size] for k in chunks[0]}
+            path = write_shard(args.output_dir, shard_index, merged)
+            logger.info("Wrote %s (%d samples)", path, merged["input_ids"].shape[0])
+        chunks = []
+        buffered = 0
+        shard_index += 1
+
+    with torch.no_grad():
+        for batch in dataloader:
+            batch_size = batch["input_ids"].shape[0]
+            if shard_index in existing:
+                buffered += batch_size
+                if buffered >= args.shard_size:
+                    chunks = []
+                    buffered -= args.shard_size
+                    shard_index += 1
+                continue
+            batch = {k: v.to(device, non_blocking=True) for k, v in batch.items()}
+            target_batch = target_wrapper.generate_batch(
+                input_ids=batch["input_ids"],
+                attention_mask=batch["attention_mask"],
+                loss_mask=batch["loss_mask"],
+            )
+            chunks.append(_compute_batch_cache(target_batch, batch["attention_mask"], cache_dtype))
+            buffered += batch_size
+            if buffered >= args.shard_size:
+                _flush()
+
+    _flush()
+
+    logger.info("Done. Cache written to %s", args.output_dir)
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Precompute the DSpark offline target-supervision cache.")
+    parser.add_argument("--target-model", required=True, help="Target model path or HF repo id.")
+    parser.add_argument("--input-data", required=True, help="HF dataset id or local chat dataset path.")
+    parser.add_argument("--output-dir", required=True, help="Directory to write cache shards + manifest into.")
+    parser.add_argument("--seq-length", type=int, default=2048, help="Sequence length.")
+    parser.add_argument("--batch-size", type=int, default=4, help="Target forward batch size.")
+    parser.add_argument(
+        "--shard-size", type=int, default=256, help="Samples per shard (must be a multiple of --batch-size)."
+    )
+    parser.add_argument("--dtype", default="bf16", choices=sorted(DTYPE_MAP), help="Cache float dtype.")
+    parser.add_argument("--device", default="cuda", help="Device to run the target on (cuda / cpu).")
+    parser.add_argument("--num-workers", type=int, default=0, help="Dataloader workers.")
+    parser.add_argument("--split", default=None, help="HF dataset split (supports slice syntax).")
+    parser.add_argument("--shuffle-seed", type=int, default=42, help="Dataset ingestion shuffle seed.")
+    parser.add_argument("--draft-num-hidden-layers", type=int, default=5, help="Draft layer count for default layers.")
+    parser.add_argument("--target-layer-ids", type=int, nargs="+", default=None, help="Target layers to capture.")
+    parser.add_argument(
+        "--chat-template", default=None, help="Inline Jinja template or path to template/tokenizer config."
+    )
+    parser.add_argument("--mask-reasoning-content", action="store_true")
+    parser.add_argument("--target-attn-implementation", default=None)
+    parser.add_argument("--target-force-hf", action="store_true")
+    parser.add_argument("--trust-remote-code", action="store_true")
+    parser.add_argument("--resume", action="store_true", help="Skip shard indices already present in --output-dir.")
+    parser.add_argument("--log-level", default="INFO")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Parses ``argv`` and returns the process exit code."""
+    args = _build_parser().parse_args(argv)
+    logging.basicConfig(
+        level=getattr(logging, args.log_level.upper(), logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    return _run(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/nemo_automodel/components/speculative/precompute_dspark.py
+++ b/nemo_automodel/components/speculative/precompute_dspark.py
@@ -67,6 +67,12 @@ from nemo_automodel.components.speculative.dspark.target_utils import (
     GEMMA4_MODEL_TYPES as _GEMMA4_MODEL_TYPES,
 )
 from nemo_automodel.components.speculative.dspark.target_utils import (
+    GLM_5_2_MODEL_TYPE as _GLM_5_2_MODEL_TYPE,
+)
+from nemo_automodel.components.speculative.dspark.target_utils import (
+    MINIMAX_M3_MODEL_TYPES as _MINIMAX_M3_MODEL_TYPES,
+)
+from nemo_automodel.components.speculative.dspark.target_utils import (
     apply_target_chat_template as _apply_target_chat_template,
 )
 from nemo_automodel.components.speculative.dspark.target_utils import (
@@ -74,6 +80,12 @@ from nemo_automodel.components.speculative.dspark.target_utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+_UNSUPPORTED_OFFLINE_TARGET_MODEL_TYPES = (
+    _DEEPSEEK_V4_MODEL_TYPE,
+    _GLM_5_2_MODEL_TYPE,
+    *_MINIMAX_M3_MODEL_TYPES,
+)
 
 
 def _compute_batch_cache(target_batch, cache_dtype: torch.dtype) -> dict[str, torch.Tensor]:
@@ -141,10 +153,10 @@ def _run(args: argparse.Namespace) -> int:
     compute_dtype = torch.bfloat16 if device.type == "cuda" else torch.float32
 
     model_type = _read_target_model_type(args.target_model, args.trust_remote_code)
-    if model_type == _DEEPSEEK_V4_MODEL_TYPE:
+    if model_type in _UNSUPPORTED_OFFLINE_TARGET_MODEL_TYPES:
         raise ValueError(
             "precompute_dspark currently supports HF-loadable single-process targets. "
-            "DeepSeek V4 targets need the distributed online training path."
+            f"model_type={model_type!r} targets need the distributed or multimodal online training path."
         )
 
     target_config = AutoConfig.from_pretrained(args.target_model, trust_remote_code=args.trust_remote_code)

--- a/nemo_automodel/components/speculative/precompute_dspark.py
+++ b/nemo_automodel/components/speculative/precompute_dspark.py
@@ -198,6 +198,8 @@ def _run(args: argparse.Namespace) -> int:
     num_samples = len(dataloader.dataset)
     hidden_size = int(target_text_config.hidden_size)
 
+    # The manifest guards resume for tensor-shaping target/cache settings. If dataset
+    # or tokenization inputs change, use a fresh output directory instead of --resume.
     manifest = {
         "target_model": args.target_model,
         "target_model_type": model_type,

--- a/nemo_automodel/components/speculative/precompute_dspark.py
+++ b/nemo_automodel/components/speculative/precompute_dspark.py
@@ -39,7 +39,7 @@ import sys
 from typing import Any
 
 import torch
-from transformers import AutoConfig, PretrainedConfig
+from transformers import AutoConfig
 
 from nemo_automodel._transformers import NeMoAutoModelForCausalLM
 from nemo_automodel._transformers.auto_tokenizer import NeMoAutoTokenizer
@@ -53,51 +53,33 @@ from nemo_automodel.components.datasets.llm.dspark_cache import (
     write_target_weights,
 )
 from nemo_automodel.components.datasets.llm.eagle3 import build_eagle3_dataloader
-from nemo_automodel.components.datasets.llm.formatting_utils import (
-    _has_chat_template,
-    _resolve_chat_template,
+from nemo_automodel.components.datasets.llm.offline_cache import (
+    dataloader_from_sample,
+    resume_start_sample,
+    write_cache_shards,
 )
 from nemo_automodel.components.speculative.dspark.registry import build_target_layer_ids
 from nemo_automodel.components.speculative.dspark.target import HFDSparkTargetModel
+from nemo_automodel.components.speculative.dspark.target_utils import (
+    DEEPSEEK_V4_MODEL_TYPE as _DEEPSEEK_V4_MODEL_TYPE,
+)
+from nemo_automodel.components.speculative.dspark.target_utils import (
+    GEMMA4_MODEL_TYPES as _GEMMA4_MODEL_TYPES,
+)
+from nemo_automodel.components.speculative.dspark.target_utils import (
+    apply_target_chat_template as _apply_target_chat_template,
+)
+from nemo_automodel.components.speculative.dspark.target_utils import (
+    read_target_model_type as _read_target_model_type,
+)
 
 logger = logging.getLogger(__name__)
 
-_GEMMA4_MODEL_TYPES = ("gemma4", "gemma4_unified")
-_DEEPSEEK_V4_MODEL_TYPE = "deepseek_v4"
 
-
-def _read_target_model_type(target_path: str, trust_remote_code: bool) -> str:
-    """Return the target HF ``model_type`` without instantiating the model when possible."""
-    try:
-        config_dict, _ = PretrainedConfig.get_config_dict(target_path, trust_remote_code=trust_remote_code)
-        model_type = config_dict.get("model_type")
-        if model_type:
-            return str(model_type)
-    except (OSError, ValueError, KeyError):
-        pass
-    config = AutoConfig.from_pretrained(target_path, trust_remote_code=trust_remote_code)
-    return str(getattr(config, "model_type", "") or "")
-
-
-def _apply_target_chat_template(tokenizer, chat_template) -> None:
-    """Attach or validate the chat template used to tokenize messages-format data."""
-    if chat_template is not None:
-        tokenizer.chat_template = _resolve_chat_template(str(chat_template))
-        return
-    if not _has_chat_template(tokenizer):
-        raise ValueError(
-            "The target tokenizer has no chat template and --chat-template was not set. "
-            "DSpark precompute needs the same template that training uses for messages-format data."
-        )
-
-
-def _compute_batch_cache(
-    target_batch, attention_mask: torch.Tensor, cache_dtype: torch.dtype
-) -> dict[str, torch.Tensor]:
+def _compute_batch_cache(target_batch, cache_dtype: torch.dtype) -> dict[str, torch.Tensor]:
     """Convert one captured target batch into cache tensors."""
     return {
         "input_ids": target_batch.input_ids.to(torch.long).cpu(),
-        "attention_mask": attention_mask.to(torch.long).cpu(),
         "loss_mask": target_batch.loss_mask.to(torch.long).cpu(),
         "target_hidden_states": target_batch.target_hidden_states.to(cache_dtype).cpu(),
         "target_last_hidden_states": target_batch.target_last_hidden_states.to(cache_dtype).cpu(),
@@ -123,6 +105,8 @@ def _validate_args(args: argparse.Namespace) -> None:
 
 def _ensure_resume_compatible(cache_dir: str, manifest: dict[str, Any], existing_shards: set[int]) -> None:
     """Refuse to resume into shards produced with a different configuration."""
+    if existing_shards:
+        resume_start_sample(existing_shards, int(manifest["shard_size"]))
     if not os.path.exists(manifest_path(cache_dir)):
         if existing_shards:
             raise ValueError(
@@ -218,7 +202,12 @@ def _run(args: argparse.Namespace) -> int:
     }
     if args.resume:
         _ensure_resume_compatible(args.output_dir, manifest, existing)
-    write_target_weights(args.output_dir, target_model.get_input_embeddings(), target_model.get_output_embeddings())
+    write_target_weights(
+        args.output_dir,
+        target_model.get_input_embeddings(),
+        target_model.get_output_embeddings(),
+        dtype=cache_dtype,
+    )
     write_manifest(args.output_dir, manifest)
 
     logger.info(
@@ -230,44 +219,28 @@ def _run(args: argparse.Namespace) -> int:
         args.output_dir,
     )
 
-    shard_index = 0
-    chunks: list[dict[str, torch.Tensor]] = []
-    buffered = 0
+    start_sample = resume_start_sample(existing, args.shard_size) if existing else 0
+    dataloader = dataloader_from_sample(dataloader, start_sample)
 
-    def _flush() -> None:
-        nonlocal shard_index, chunks, buffered
-        if buffered == 0:
-            return
-        if shard_index not in existing:
-            merged = {k: torch.cat([c[k] for c in chunks], dim=0)[: args.shard_size] for k in chunks[0]}
-            path = write_shard(args.output_dir, shard_index, merged)
-            logger.info("Wrote %s (%d samples)", path, merged["input_ids"].shape[0])
-        chunks = []
-        buffered = 0
-        shard_index += 1
-
-    with torch.no_grad():
-        for batch in dataloader:
-            batch_size = batch["input_ids"].shape[0]
-            if shard_index in existing:
-                buffered += batch_size
-                if buffered >= args.shard_size:
-                    chunks = []
-                    buffered -= args.shard_size
-                    shard_index += 1
-                continue
+    def _compute_from_batch(batch):
+        with torch.no_grad():
             batch = {k: v.to(device, non_blocking=True) for k, v in batch.items()}
             target_batch = target_wrapper.generate_batch(
                 input_ids=batch["input_ids"],
                 attention_mask=batch["attention_mask"],
                 loss_mask=batch["loss_mask"],
             )
-            chunks.append(_compute_batch_cache(target_batch, batch["attention_mask"], cache_dtype))
-            buffered += batch_size
-            if buffered >= args.shard_size:
-                _flush()
+            return _compute_batch_cache(target_batch, cache_dtype)
 
-    _flush()
+    write_cache_shards(
+        dataloader=dataloader,
+        output_dir=args.output_dir,
+        shard_size=args.shard_size,
+        start_shard_index=start_sample // args.shard_size,
+        compute_batch=_compute_from_batch,
+        write_shard_fn=write_shard,
+        logger=logger,
+    )
 
     logger.info("Done. Cache written to %s", args.output_dir)
     return 0

--- a/nemo_automodel/components/speculative/precompute_eagle3.py
+++ b/nemo_automodel/components/speculative/precompute_eagle3.py
@@ -73,6 +73,11 @@ from nemo_automodel.components.datasets.llm.eagle3_cache import (
     write_shard,
     write_target_embeddings,
 )
+from nemo_automodel.components.datasets.llm.offline_cache import (
+    dataloader_from_sample,
+    resume_start_sample,
+    write_cache_shards,
+)
 from nemo_automodel.components.speculative.eagle import HFEagle3TargetModel
 from nemo_automodel.components.speculative.eagle.core import _compute_target_distribution
 
@@ -148,6 +153,8 @@ def _ensure_resume_compatible(cache_dir: str, manifest: dict[str, Any], existing
     the old shards and bless them with the new manifest, silently corrupting the
     supervision that training reads back.
     """
+    if existing_shards:
+        resume_start_sample(existing_shards, int(manifest["shard_size"]))
     if not os.path.exists(manifest_path(cache_dir)):
         if existing_shards:
             raise ValueError(
@@ -252,54 +259,30 @@ def _run(args: argparse.Namespace) -> int:
         args.output_dir,
     )
 
-    shard_index = 0
-    chunks: list[dict[str, torch.Tensor]] = []
-    buffered = 0
+    start_sample = resume_start_sample(existing, args.shard_size) if existing else 0
+    dataloader = dataloader_from_sample(dataloader, start_sample)
 
-    def _flush() -> None:
-        # Slicing to ``shard_size`` is exact for a full shard and a harmless
-        # no-op for the trailing partial shard (fewer rows than the slice bound).
-        nonlocal shard_index, chunks, buffered
-        if buffered == 0:
-            return
-        if shard_index not in existing:
-            # Every chunk came from _compute_batch_cache with the same topk, so they
-            # share one key set (full vs top-k) -- merge whatever that batch produced.
-            merged = {k: torch.cat([c[k] for c in chunks], dim=0)[: args.shard_size] for k in chunks[0]}
-            path = write_shard(args.output_dir, shard_index, merged)
-            logger.info("Wrote %s (%d samples)", path, merged["input_ids"].shape[0])
-        chunks = []
-        buffered = 0
-        shard_index += 1
-
-    with torch.no_grad():
-        for batch in dataloader:
-            batch_size = batch["input_ids"].shape[0]
-            if shard_index in existing:
-                # The whole shard is already cached -- advance past its batches
-                # without paying the target forward.
-                buffered += batch_size
-                if buffered >= args.shard_size:
-                    chunks = []
-                    buffered -= args.shard_size
-                    shard_index += 1
-                continue
+    def _compute_from_batch(batch):
+        with torch.no_grad():
             batch = {k: v.to(device, non_blocking=True) for k, v in batch.items()}
             target_batch = target_wrapper.generate_batch(
                 input_ids=batch["input_ids"],
                 attention_mask=batch["attention_mask"],
                 loss_mask=batch["loss_mask"],
             )
-            chunks.append(
-                _compute_batch_cache(
-                    target_batch, selected_token_ids, selected_token_mask, cache_dtype, args.target_probs_topk
-                )
+            return _compute_batch_cache(
+                target_batch, selected_token_ids, selected_token_mask, cache_dtype, args.target_probs_topk
             )
-            buffered += batch_size
-            if buffered >= args.shard_size:
-                _flush()
 
-    _flush()  # trailing partial shard
+    write_cache_shards(
+        dataloader=dataloader,
+        output_dir=args.output_dir,
+        shard_size=args.shard_size,
+        start_shard_index=start_sample // args.shard_size,
+        compute_batch=_compute_from_batch,
+        write_shard_fn=write_shard,
+        logger=logger,
+    )
 
     logger.info("Done. Cache written to %s", args.output_dir)
     return 0

--- a/nemo_automodel/recipes/llm/train_dspark.py
+++ b/nemo_automodel/recipes/llm/train_dspark.py
@@ -45,6 +45,11 @@ from nemo_automodel.components.checkpoint.checkpointing import (
     save_config,
 )
 from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
+from nemo_automodel.components.datasets.llm.dspark_cache import (
+    build_cached_dspark_dataloader,
+    read_manifest,
+    read_target_weight_modules,
+)
 from nemo_automodel.components.datasets.llm.eagle3 import build_eagle3_dataloader
 from nemo_automodel.components.datasets.llm.formatting_utils import (
     _has_chat_template,
@@ -65,6 +70,7 @@ from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.models.deepseek_v4.config import DeepseekV4Config
 from nemo_automodel.components.models.minimax_m3_vl.processing import build_minimax_m3_vl_processor
 from nemo_automodel.components.optim.optimizer import build_optimizer
+from nemo_automodel.components.speculative.dspark.common import validate_target_layer_ids
 from nemo_automodel.components.speculative.dspark.config import (
     build_deepseek_v4_draft_config,
     build_gemma4_draft_config,
@@ -333,6 +339,36 @@ def _apply_draft_activation_checkpointing(draft_model: torch.nn.Module, mode: bo
         logger.info("Enabled full activation checkpointing on %d draft layers", len(layers))
 
 
+def _validate_cached_dspark_manifest(
+    cache_dir: str, manifest: dict, target_config, target_layer_ids: list[int]
+) -> None:
+    """Validate that a DSpark offline cache matches the configured target/draft shape."""
+    if int(manifest["target_vocab_size"]) != int(target_config.vocab_size):
+        raise ValueError(
+            f"DSpark cache at {cache_dir} was built for target_vocab_size={manifest['target_vocab_size']}, "
+            f"but the configured target has {target_config.vocab_size}. The cache does not match this target."
+        )
+    hidden_size = int(target_config.hidden_size)
+    expected_hidden_dim = hidden_size * len(target_layer_ids)
+    if int(manifest["target_hidden_dim"]) != expected_hidden_dim:
+        raise ValueError(
+            f"DSpark cache at {cache_dir} has target_hidden_dim={manifest['target_hidden_dim']}, "
+            f"but the configured target/layers need {expected_hidden_dim} "
+            f"(hidden_size {hidden_size} x {len(target_layer_ids)} target layers)."
+        )
+    if int(manifest["target_last_hidden_dim"]) != hidden_size:
+        raise ValueError(
+            f"DSpark cache at {cache_dir} has target_last_hidden_dim={manifest['target_last_hidden_dim']}, "
+            f"but the configured target has hidden_size={hidden_size}."
+        )
+    recorded_layer_ids = [int(x) for x in manifest["target_layer_ids"]]
+    if recorded_layer_ids != list(target_layer_ids):
+        raise ValueError(
+            f"DSpark cache at {cache_dir} was built for target_layer_ids={recorded_layer_ids}, "
+            f"but this run requested target_layer_ids={target_layer_ids}."
+        )
+
+
 class TrainDSparkRecipe(BaseRecipe):
     """Recipe for DSpark draft-model training on Qwen3, Gemma4, DeepSeek V4, GLM-5.2, and MiniMax M3 VL targets."""
 
@@ -363,6 +399,7 @@ class TrainDSparkRecipe(BaseRecipe):
         is_glm_5_2_target = target_model_type == _GLM_5_2_MODEL_TYPE
         is_gemma4_target = target_model_type in _GEMMA4_MODEL_TYPES
         is_minimax_m3_target = target_model_type in _MINIMAX_M3_MODEL_TYPES
+        self.cached_target_path = recipe_cfg.get("cached_target_path", None)
         is_multimodal = bool(recipe_cfg.get("multimodal", False))
         if is_multimodal and not is_minimax_m3_target:
             raise ValueError(
@@ -378,12 +415,23 @@ class TrainDSparkRecipe(BaseRecipe):
         self.compute_dtype = torch.bfloat16 if self.device.type == "cuda" else torch.float32
 
         if is_deepseek_v4_target:
-            # Full V4-Flash target loaded with the same expert-parallel / FSDP and
-            # FP8-dequant path as the V4 finetune recipe, so the 256 experts shard
-            # across ranks instead of replicating per rank.
-            target_config, self.target_model = self._build_deepseek_v4_target(
-                target_path, recipe_cfg, trust_remote_code
-            )
+            if self.cached_target_path is None:
+                # Full V4-Flash target loaded with the same expert-parallel / FSDP and
+                # FP8-dequant path as the V4 finetune recipe, so the 256 experts shard
+                # across ranks instead of replicating per rank.
+                target_config, self.target_model = self._build_deepseek_v4_target(
+                    target_path, recipe_cfg, trust_remote_code
+                )
+            else:
+                target_config = DeepseekV4Config.from_pretrained(
+                    target_path, name_or_path=target_path, num_nextn_predict_layers=0
+                )
+                n_reduced = _resolve_reduced_target_layers(
+                    target_config.num_hidden_layers, recipe_cfg.get("target_num_hidden_layers", None)
+                )
+                if n_reduced is not None:
+                    target_config.num_hidden_layers = n_reduced
+                self.target_model = None
             architectures = list(getattr(target_config, "architectures", None) or ["DeepseekV4ForCausalLM"])
         elif is_minimax_m3_target:
             # MiniMax M3 VL is a ~400B-parameter MoE VLM: load it frozen through the
@@ -411,63 +459,86 @@ class TrainDSparkRecipe(BaseRecipe):
             architectures = list(
                 getattr(target_config, "architectures", None) or ["MiniMaxM3SparseForConditionalGeneration"]
             )
-            self.distributed_setup = create_distributed_setup_from_config(
-                self.cfg,
-                world_size=self.dist_env.world_size,
-            )
-            backend = BackendConfig(
-                # M3's sparse-attention layers emit an additive float bias from the
-                # DSA indexer that only SDPA's explicit-mask path accepts; TE's
-                # DotProductAttention treats attention_mask as a boolean padding
-                # mask and crashes on the float bias.
-                attn="sdpa",
-                # The target is frozen / forward-only here, so there is no
-                # throughput reason to pay TE's integration complexity, and plain
-                # linears keep embed_tokens/lm_head as plain-shaped weights.
-                linear="torch",
-                rms_norm="torch_fp32",
-                rope_fusion=False,
-                experts=str(recipe_cfg.get("target_experts", "gmm")),
-                dispatcher="hybridep",
-                enable_hf_state_dict_adapter=True,
-                enable_fsdp_optimizations=True,
-            )
-            self.target_model = NeMoAutoModelForImageTextToText.from_pretrained(
-                target_path,
-                trust_remote_code=trust_remote_code,
-                torch_dtype=self.compute_dtype,
-                distributed_setup=self.distributed_setup,
-                backend=backend,
-                # The released bf16 checkpoint ships no real MTP weights despite the
-                # config declaring some, and DSpark trains its own separate draft
-                # regardless, so disable the target's native MTP modules.
-                text_config=target_text_overrides,
-            )
-            # A distributed-setup-loaded model already lands correctly placed
-            # (sharded as DTensors); a blanket .to(device) afterward is redundant.
+            if self.cached_target_path is None:
+                self.distributed_setup = create_distributed_setup_from_config(
+                    self.cfg,
+                    world_size=self.dist_env.world_size,
+                )
+                backend = BackendConfig(
+                    # M3's sparse-attention layers emit an additive float bias from the
+                    # DSA indexer that only SDPA's explicit-mask path accepts; TE's
+                    # DotProductAttention treats attention_mask as a boolean padding
+                    # mask and crashes on the float bias.
+                    attn="sdpa",
+                    # The target is frozen / forward-only here, so there is no
+                    # throughput reason to pay TE's integration complexity, and plain
+                    # linears keep embed_tokens/lm_head as plain-shaped weights.
+                    linear="torch",
+                    rms_norm="torch_fp32",
+                    rope_fusion=False,
+                    experts=str(recipe_cfg.get("target_experts", "gmm")),
+                    dispatcher="hybridep",
+                    enable_hf_state_dict_adapter=True,
+                    enable_fsdp_optimizations=True,
+                )
+                self.target_model = NeMoAutoModelForImageTextToText.from_pretrained(
+                    target_path,
+                    trust_remote_code=trust_remote_code,
+                    torch_dtype=self.compute_dtype,
+                    distributed_setup=self.distributed_setup,
+                    backend=backend,
+                    # The released bf16 checkpoint ships no real MTP weights despite the
+                    # config declaring some, and DSpark trains its own separate draft
+                    # regardless, so disable the target's native MTP modules.
+                    text_config=target_text_overrides,
+                )
+                # A distributed-setup-loaded model already lands correctly placed
+                # (sharded as DTensors); a blanket .to(device) afterward is redundant.
+            else:
+                self.target_model = None
         elif is_glm_5_2_target:
-            # GLM-5.2 (GlmMoeDsaForCausalLM) is a ~355B-parameter MLA + DSA MoE LM: load
-            # it frozen through the same expert-parallel / FSDP distributed path the GLM
-            # finetune recipe uses, sharding the 256 routed experts across ranks instead
-            # of replicating per rank.
-            target_config, self.target_model = self._build_glm_5_2_target(target_path, recipe_cfg, trust_remote_code)
+            if self.cached_target_path is None:
+                # GLM-5.2 (GlmMoeDsaForCausalLM) is a ~355B-parameter MLA + DSA MoE LM: load
+                # it frozen through the same expert-parallel / FSDP distributed path the GLM
+                # finetune recipe uses, sharding the 256 routed experts across ranks instead
+                # of replicating per rank.
+                target_config, self.target_model = self._build_glm_5_2_target(
+                    target_path, recipe_cfg, trust_remote_code
+                )
+            else:
+                target_config = AutoConfig.from_pretrained(target_path, trust_remote_code=trust_remote_code)
+                raw_config_dict, _ = PretrainedConfig.get_config_dict(target_path, trust_remote_code=trust_remote_code)
+                _repair_glm_5_2_qk_rope_head_dim(target_config, raw_config_dict)
+                n_reduced = _resolve_reduced_target_layers(
+                    target_config.num_hidden_layers,
+                    recipe_cfg.get("target_num_hidden_layers", None),
+                )
+                if n_reduced is not None:
+                    target_config.num_hidden_layers = n_reduced
+                self.target_model = None
             architectures = list(getattr(target_config, "architectures", None) or ["GlmMoeDsaForCausalLM"])
         else:
             target_config = AutoConfig.from_pretrained(target_path, trust_remote_code=trust_remote_code)
             architectures = getattr(target_config, "architectures", []) or []
-            target_attn_implementation = recipe_cfg.get("target_attn_implementation", None)
-            target_kwargs = {}
-            if target_attn_implementation is not None:
-                target_kwargs["attn_implementation"] = target_attn_implementation
-            self.target_model = NeMoAutoModelForCausalLM.from_pretrained(
-                target_path,
-                trust_remote_code=trust_remote_code,
-                torch_dtype=self.compute_dtype,
-                force_hf=bool(recipe_cfg.get("target_force_hf", False)),
-                **target_kwargs,
-            )
-            self.target_model.to(self.device)
-        self.target_model.requires_grad_(False)
+            is_gemma4_target = getattr(target_config, "model_type", "") in _GEMMA4_MODEL_TYPES
+
+            if self.cached_target_path is None:
+                target_attn_implementation = recipe_cfg.get("target_attn_implementation", None)
+                target_kwargs = {}
+                if target_attn_implementation is not None:
+                    target_kwargs["attn_implementation"] = target_attn_implementation
+                self.target_model = NeMoAutoModelForCausalLM.from_pretrained(
+                    target_path,
+                    trust_remote_code=trust_remote_code,
+                    torch_dtype=self.compute_dtype,
+                    force_hf=bool(recipe_cfg.get("target_force_hf", False)),
+                    **target_kwargs,
+                )
+                self.target_model.to(self.device)
+            else:
+                self.target_model = None
+        if self.target_model is not None:
+            self.target_model.requires_grad_(False)
 
         # Resolve the captured target layers once and share them between the
         # target wrapper (what to capture) and the draft config (the ``fc`` input
@@ -481,69 +552,102 @@ class TrainDSparkRecipe(BaseRecipe):
             recipe_cfg.get("target_layer_ids", None)
             or build_target_layer_ids(num_target_layers, draft_num_hidden_layers)
         )
+        target_layer_ids = validate_target_layer_ids(target_layer_ids, num_target_layers)
         # HFDSparkTargetModel validates target_layer_ids against the actual (possibly
         # reduced) layer count via common.validate_target_layer_ids, which also accepts
         # -1 (the embedding output) and enforces strictly-increasing ids.
-        self.target_wrapper = HFDSparkTargetModel(self.target_model, target_layer_ids=target_layer_ids)
+        self.target_layer_ids = target_layer_ids
+        self.target_wrapper = (
+            HFDSparkTargetModel(self.target_model, target_layer_ids=target_layer_ids)
+            if self.target_model is not None
+            else None
+        )
 
         self.block_size = int(recipe_cfg.get("block_size", 7))
         self.num_anchors = int(recipe_cfg.get("num_anchors", 512))
         self.mask_token_id = self._resolve_mask_token_id(recipe_cfg, target_text_config.vocab_size)
 
-        if is_multimodal:
-            # MiniMax M3's vision_tower is its own FSDP2-sharded unit, so a batch
-            # mixing text-only and image-containing samples across DP ranks would
-            # desync the FSDP2 all-gather collective and hang training.
-            # dspark_vlm_collate_fn injects a masked fake image into any text-only
-            # example (mirroring default_collate_fn's own fake-image handling),
-            # so mixed corpora are safe here without any dataset curation.
-            self.processor = build_minimax_m3_vl_processor(target_path, trust_remote_code=trust_remote_code)
-            self.train_dataloader = build_dspark_vlm_dataloader(
-                dataset_cfg=self.cfg.dataset,
-                processor=self.processor,
-                batch_size=recipe_cfg.micro_batch_size,
-                max_length=recipe_cfg.seq_length,
-                shuffle=True,
-                num_workers=recipe_cfg.get("num_workers", 0),
-                distributed=self.dist_env.world_size > 1,
-            )
-            self.val_dataloader = None
-            if self.cfg.get("val_dataset", None) is not None:
-                self.val_dataloader = build_dspark_vlm_dataloader(
-                    dataset_cfg=self.cfg.val_dataset,
+        embed_src = None
+        head_src = None
+        if self.cached_target_path is None:
+            if is_multimodal:
+                # MiniMax M3's vision_tower is its own FSDP2-sharded unit, so a batch
+                # mixing text-only and image-containing samples across DP ranks would
+                # desync the FSDP2 all-gather collective and hang training.
+                # dspark_vlm_collate_fn injects a masked fake image into any text-only
+                # example (mirroring default_collate_fn's own fake-image handling),
+                # so mixed corpora are safe here without any dataset curation.
+                self.processor = build_minimax_m3_vl_processor(target_path, trust_remote_code=trust_remote_code)
+                self.train_dataloader = build_dspark_vlm_dataloader(
+                    dataset_cfg=self.cfg.dataset,
                     processor=self.processor,
                     batch_size=recipe_cfg.micro_batch_size,
                     max_length=recipe_cfg.seq_length,
-                    shuffle=False,
+                    shuffle=True,
                     num_workers=recipe_cfg.get("num_workers", 0),
                     distributed=self.dist_env.world_size > 1,
                 )
-        else:
-            self.train_dataloader = build_eagle3_dataloader(
-                data_path=recipe_cfg.train_data_path,
-                tokenizer=self.tokenizer,
-                seq_length=recipe_cfg.seq_length,
-                batch_size=recipe_cfg.micro_batch_size,
-                shuffle=True,
-                num_workers=recipe_cfg.get("num_workers", 0),
-                split=recipe_cfg.get("train_split", None),
-                distributed=self.dist_env.world_size > 1,
-                shuffle_seed=recipe_cfg.get("shuffle_seed", 42),
-                mask_reasoning_content=recipe_cfg.get("mask_reasoning_content", False),
-            )
-            self.val_dataloader = None
-            if recipe_cfg.get("val_data_path", None):
-                self.val_dataloader = build_eagle3_dataloader(
-                    data_path=recipe_cfg.val_data_path,
+                self.val_dataloader = None
+                if self.cfg.get("val_dataset", None) is not None:
+                    self.val_dataloader = build_dspark_vlm_dataloader(
+                        dataset_cfg=self.cfg.val_dataset,
+                        processor=self.processor,
+                        batch_size=recipe_cfg.micro_batch_size,
+                        max_length=recipe_cfg.seq_length,
+                        shuffle=False,
+                        num_workers=recipe_cfg.get("num_workers", 0),
+                        distributed=self.dist_env.world_size > 1,
+                    )
+            else:
+                self.train_dataloader = build_eagle3_dataloader(
+                    data_path=recipe_cfg.train_data_path,
                     tokenizer=self.tokenizer,
                     seq_length=recipe_cfg.seq_length,
                     batch_size=recipe_cfg.micro_batch_size,
-                    shuffle=False,
+                    shuffle=True,
                     num_workers=recipe_cfg.get("num_workers", 0),
-                    split=recipe_cfg.get("val_split", None),
+                    split=recipe_cfg.get("train_split", None),
                     distributed=self.dist_env.world_size > 1,
                     shuffle_seed=recipe_cfg.get("shuffle_seed", 42),
                     mask_reasoning_content=recipe_cfg.get("mask_reasoning_content", False),
+                )
+                self.val_dataloader = None
+                if recipe_cfg.get("val_data_path", None):
+                    self.val_dataloader = build_eagle3_dataloader(
+                        data_path=recipe_cfg.val_data_path,
+                        tokenizer=self.tokenizer,
+                        seq_length=recipe_cfg.seq_length,
+                        batch_size=recipe_cfg.micro_batch_size,
+                        shuffle=False,
+                        num_workers=recipe_cfg.get("num_workers", 0),
+                        split=recipe_cfg.get("val_split", None),
+                        distributed=self.dist_env.world_size > 1,
+                        shuffle_seed=recipe_cfg.get("shuffle_seed", 42),
+                        mask_reasoning_content=recipe_cfg.get("mask_reasoning_content", False),
+                    )
+        else:
+            manifest = read_manifest(self.cached_target_path)
+            _validate_cached_dspark_manifest(self.cached_target_path, manifest, target_text_config, target_layer_ids)
+            embed_src, head_src = read_target_weight_modules(self.cached_target_path)
+            self.train_dataloader = build_cached_dspark_dataloader(
+                cache_dir=self.cached_target_path,
+                batch_size=recipe_cfg.micro_batch_size,
+                shuffle=True,
+                num_workers=recipe_cfg.get("num_workers", 0),
+                distributed=self.dist_env.world_size > 1,
+            )
+            self.val_dataloader = None
+            if (
+                recipe_cfg.get("val_data_path", None) is not None or self.cfg.get("val_dataset", None) is not None
+            ) and self.dist_env.is_main:
+                logger.warning(
+                    "DSpark cached_target_path is set; validation data is ignored because the target model is not loaded."
+                )
+            if self.dist_env.is_main:
+                logger.info(
+                    "DSpark OFFLINE cache: streaming %d precomputed samples from %s (target model not loaded).",
+                    len(self.train_dataloader.dataset),
+                    self.cached_target_path,
                 )
 
         # The Qwen3 / Gemma4 drafts consume a flex_attention BlockMask during training.
@@ -613,9 +717,10 @@ class TrainDSparkRecipe(BaseRecipe):
         self.draft_model = draft_cls(draft_config_obj).to(device=self.device, dtype=self.compute_dtype)
 
         # training only the backbone, fc, Markov head, and confidence head.
-        embed_src = self.target_wrapper.get_input_embeddings()
-        head_src = self.target_wrapper.get_output_embeddings()
-        if is_deepseek_v4_target or is_glm_5_2_target or is_minimax_m3_target:
+        if embed_src is None or head_src is None:
+            embed_src = self.target_wrapper.get_input_embeddings()
+            head_src = self.target_wrapper.get_output_embeddings()
+        if (is_deepseek_v4_target or is_glm_5_2_target or is_minimax_m3_target) and self.cached_target_path is None:
             # The V4 / GLM / MiniMax M3 target's embed_tokens / lm_head are expert-parallel /
             # FSDP-sharded DTensors; gather them to full tensors before the draft copies them.
             embed_src = _gather_full_weight_module(embed_src)
@@ -1038,7 +1143,7 @@ class TrainDSparkRecipe(BaseRecipe):
                 "block_size": self.block_size,
                 "num_anchors": self.num_anchors,
                 "mask_token_id": self.mask_token_id,
-                "target_layer_ids": list(self.target_wrapper.target_layer_ids),
+                "target_layer_ids": list(self.target_layer_ids),
             },
             os.path.join(path, "dspark_meta.pt"),
         )
@@ -1099,6 +1204,29 @@ class TrainDSparkRecipe(BaseRecipe):
         if self.dist_env.is_main and ckpt_cfg is not None and ckpt_cfg.enabled:
             logger.info("Saved %s checkpoint to %s/epoch_%d_step_%d", kind, ckpt_cfg.checkpoint_dir, epoch, step)
 
+    def _forward_batch(self, batch):
+        """Run one batch through live target capture or the offline cache."""
+        batch = {k: v.to(self.device, non_blocking=True) for k, v in batch.items()}
+        if self.target_wrapper is None:
+            return self.trainer_module(
+                input_ids=batch["input_ids"],
+                target_hidden_states=batch["target_hidden_states"],
+                loss_mask=batch["loss_mask"],
+                target_last_hidden_states=batch["target_last_hidden_states"],
+            )
+        target_batch = self.target_wrapper.generate_batch(
+            input_ids=batch["input_ids"],
+            attention_mask=batch["attention_mask"],
+            loss_mask=batch["loss_mask"],
+            **_extract_mm_kwargs(batch),
+        )
+        return self.trainer_module(
+            input_ids=target_batch.input_ids,
+            target_hidden_states=target_batch.target_hidden_states,
+            loss_mask=target_batch.loss_mask,
+            target_last_hidden_states=target_batch.target_last_hidden_states,
+        )
+
     def _maybe_save_step_checkpoint(self, epoch: int) -> bool:
         """Save a checkpoint mid-epoch when ``ckpt_every_steps`` is configured."""
         every = getattr(self, "ckpt_every_steps", None)
@@ -1137,19 +1265,7 @@ class TrainDSparkRecipe(BaseRecipe):
         total_batches = torch.zeros((), device=self.device)
         with torch.no_grad():
             for batch in self.val_dataloader:
-                batch = {k: v.to(self.device, non_blocking=True) for k, v in batch.items()}
-                target_batch = self.target_wrapper.generate_batch(
-                    input_ids=batch["input_ids"],
-                    attention_mask=batch["attention_mask"],
-                    loss_mask=batch["loss_mask"],
-                    **_extract_mm_kwargs(batch),
-                )
-                metrics = self.trainer_module(
-                    input_ids=target_batch.input_ids,
-                    target_hidden_states=target_batch.target_hidden_states,
-                    loss_mask=target_batch.loss_mask,
-                    target_last_hidden_states=target_batch.target_last_hidden_states,
-                )
+                metrics = self._forward_batch(batch)
                 total_loss += metrics.loss.detach()
                 total_batches += 1
         total_loss = self._dp_allreduce(total_loss)
@@ -1205,24 +1321,12 @@ class TrainDSparkRecipe(BaseRecipe):
                 num_batches = len(self.train_dataloader)
                 for batch_idx, batch in enumerate(self.train_dataloader):
                     last_batch_idx = batch_idx
-                    batch = {k: v.to(self.device, non_blocking=True) for k, v in batch.items()}
-                    target_batch = self.target_wrapper.generate_batch(
-                        input_ids=batch["input_ids"],
-                        attention_mask=batch["attention_mask"],
-                        loss_mask=batch["loss_mask"],
-                        **_extract_mm_kwargs(batch),
-                    )
                     is_optim_step = (pending_micro_batches + 1 == self.grad_accumulation_steps) or (
                         batch_idx == num_batches - 1
                     )
                     # get_sync_ctx handles both DDP (no_sync) and FSDP2 (set_requires_gradient_sync).
                     with get_sync_ctx(self.trainer_module, is_optim_step, self.defer_fsdp_grad_sync):
-                        metrics = self.trainer_module(
-                            input_ids=target_batch.input_ids,
-                            target_hidden_states=target_batch.target_hidden_states,
-                            loss_mask=target_batch.loss_mask,
-                            target_last_hidden_states=target_batch.target_last_hidden_states,
-                        )
+                        metrics = self._forward_batch(batch)
                         loss = metrics.loss / self.grad_accumulation_steps
                         loss.backward()
 

--- a/nemo_automodel/recipes/llm/train_dspark.py
+++ b/nemo_automodel/recipes/llm/train_dspark.py
@@ -46,15 +46,12 @@ from nemo_automodel.components.checkpoint.checkpointing import (
 )
 from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
 from nemo_automodel.components.datasets.llm.dspark_cache import (
+    DTYPE_MAP,
     build_cached_dspark_dataloader,
     read_manifest,
     read_target_weight_modules,
 )
 from nemo_automodel.components.datasets.llm.eagle3 import build_eagle3_dataloader
-from nemo_automodel.components.datasets.llm.formatting_utils import (
-    _has_chat_template,
-    _resolve_chat_template,
-)
 from nemo_automodel.components.datasets.vlm.dspark_collate import build_dspark_vlm_dataloader
 from nemo_automodel.components.distributed.activation_checkpointing import (
     apply_selective_checkpointing_to_layers,
@@ -83,6 +80,24 @@ from nemo_automodel.components.speculative.dspark.registry import (
     resolve_dspark_draft_spec,
 )
 from nemo_automodel.components.speculative.dspark.target import HFDSparkTargetModel
+from nemo_automodel.components.speculative.dspark.target_utils import (
+    DEEPSEEK_V4_MODEL_TYPE as _DEEPSEEK_V4_MODEL_TYPE,
+)
+from nemo_automodel.components.speculative.dspark.target_utils import (
+    GEMMA4_MODEL_TYPES as _GEMMA4_MODEL_TYPES,
+)
+from nemo_automodel.components.speculative.dspark.target_utils import (
+    GLM_5_2_MODEL_TYPE as _GLM_5_2_MODEL_TYPE,
+)
+from nemo_automodel.components.speculative.dspark.target_utils import (
+    MINIMAX_M3_MODEL_TYPES as _MINIMAX_M3_MODEL_TYPES,
+)
+from nemo_automodel.components.speculative.dspark.target_utils import (
+    apply_target_chat_template as _apply_target_chat_template,
+)
+from nemo_automodel.components.speculative.dspark.target_utils import (
+    read_target_model_type as _read_target_model_type,
+)
 from nemo_automodel.components.training.rng import StatefulRNG
 from nemo_automodel.components.utils.model_utils import VLM_INPUT_KEYS
 from nemo_automodel.recipes._dist_utils import create_distributed_setup_from_config
@@ -98,11 +113,6 @@ from nemo_automodel.recipes.llm._spec_train_utils import (
 )
 
 logger = logging.getLogger(__name__)
-
-_GEMMA4_MODEL_TYPES = ("gemma4", "gemma4_unified")
-_MINIMAX_M3_MODEL_TYPES = ("minimax_m3_vl",)
-_DEEPSEEK_V4_MODEL_TYPE = "deepseek_v4"
-_GLM_5_2_MODEL_TYPE = "glm_moe_dsa"
 
 _DSPARK_MM_KEYS = tuple(k for k in VLM_INPUT_KEYS if k != "input_ids")
 
@@ -126,25 +136,6 @@ class _DraftArgs(dict):
             raise AttributeError(key) from exc
 
 
-def _read_target_model_type(target_path: str, trust_remote_code: bool) -> str:
-    """Return the HF ``model_type`` for a target without instantiating the model.
-
-    DeepSeek V4's ``model_type`` ("deepseek_v4") is a custom architecture that stock
-    ``AutoConfig`` may not recognize, so read it straight from the raw config dict
-    (which never requires the type to be registered). Falls back to ``AutoConfig``
-    for any path ``get_config_dict`` cannot resolve.
-    """
-    try:
-        config_dict, _ = PretrainedConfig.get_config_dict(target_path, trust_remote_code=trust_remote_code)
-        model_type = config_dict.get("model_type")
-        if model_type:
-            return str(model_type)
-    except (OSError, ValueError, KeyError):
-        pass
-    config = AutoConfig.from_pretrained(target_path, trust_remote_code=trust_remote_code)
-    return str(getattr(config, "model_type", "") or "")
-
-
 def _gather_full_weight_module(module):
     """Return an object exposing a full (non-DTensor) ``.weight`` tensor.
 
@@ -157,30 +148,6 @@ def _gather_full_weight_module(module):
     if weight is not None and hasattr(weight, "full_tensor"):
         return SimpleNamespace(weight=weight.full_tensor())
     return module
-
-
-def _apply_target_chat_template(tokenizer, chat_template):
-    """Attach a chat template to the target tokenizer for messages-format DSpark data.
-
-    DSpark renders ``messages`` rows with the tokenizer's chat template, but some
-    targets (e.g. DeepSeek-V4-Flash) ship none. ``recipe_args.chat_template`` (an
-    inline Jinja string or a path to a template / tokenizer_config json) overrides
-    it; it must match the template the training responses were generated with and
-    should mark the assistant span with ``{% generation %}`` so only those tokens
-    carry loss. If no template is supplied and the tokenizer has none, raise rather
-    than silently producing an empty / wrong loss mask.
-    """
-    if chat_template is not None:
-        tokenizer.chat_template = _resolve_chat_template(str(chat_template))
-        return
-    if not _has_chat_template(tokenizer):
-        raise ValueError(
-            "The target tokenizer has no chat template and recipe_args.chat_template "
-            "was not set. DSpark trains on 'messages'-format data, which needs a chat "
-            "template (e.g. DeepSeek-V4-Flash ships none). Set recipe_args.chat_template "
-            "to an inline Jinja string or a template file that matches how the training "
-            "responses were generated."
-        )
 
 
 def _resolve_wandb_kwargs(wandb_cfg: dict) -> dict | None:
@@ -340,15 +307,56 @@ def _apply_draft_activation_checkpointing(draft_model: torch.nn.Module, mode: bo
 
 
 def _validate_cached_dspark_manifest(
-    cache_dir: str, manifest: dict, target_config, target_layer_ids: list[int]
+    cache_dir: str,
+    manifest: dict,
+    target_config,
+    target_layer_ids: list[int],
+    *,
+    target_model: str,
+    target_model_type: str,
+    seq_length: int,
+    compute_dtype: torch.dtype,
 ) -> None:
-    """Validate that a DSpark offline cache matches the configured target/draft shape."""
+    """Validate that a DSpark offline cache matches the configured target/draft run."""
+    if str(manifest["target_model"]) != str(target_model):
+        raise ValueError(
+            f"DSpark cache at {cache_dir} was built for target_model={manifest['target_model']!r}, "
+            f"but this run configured target_model={target_model!r}. The cache does not match this target."
+        )
+    if str(manifest["target_model_type"]) != str(target_model_type):
+        raise ValueError(
+            f"DSpark cache at {cache_dir} was built for target_model_type={manifest['target_model_type']!r}, "
+            f"but the configured target has model_type={target_model_type!r}."
+        )
     if int(manifest["target_vocab_size"]) != int(target_config.vocab_size):
         raise ValueError(
             f"DSpark cache at {cache_dir} was built for target_vocab_size={manifest['target_vocab_size']}, "
             f"but the configured target has {target_config.vocab_size}. The cache does not match this target."
         )
     hidden_size = int(target_config.hidden_size)
+    if int(manifest["hidden_size"]) != hidden_size:
+        raise ValueError(
+            f"DSpark cache at {cache_dir} was built for hidden_size={manifest['hidden_size']}, "
+            f"but the configured target has hidden_size={hidden_size}."
+        )
+    if int(manifest["num_hidden_layers"]) != int(target_config.num_hidden_layers):
+        raise ValueError(
+            f"DSpark cache at {cache_dir} was built for num_hidden_layers={manifest['num_hidden_layers']}, "
+            f"but the configured target has num_hidden_layers={target_config.num_hidden_layers}."
+        )
+    if int(manifest["seq_length"]) != int(seq_length):
+        raise ValueError(
+            f"DSpark cache at {cache_dir} was built for seq_length={manifest['seq_length']}, "
+            f"but this run configured seq_length={seq_length}."
+        )
+    cache_dtype = DTYPE_MAP.get(str(manifest["dtype"]))
+    if cache_dtype is None:
+        raise ValueError(f"DSpark cache at {cache_dir} has unsupported dtype={manifest['dtype']!r}.")
+    if compute_dtype == torch.float32 and cache_dtype != torch.float32:
+        raise ValueError(
+            f"DSpark cache at {cache_dir} stores dtype={manifest['dtype']}, but CPU cached training "
+            "requires fp32 cache tensors. Regenerate with --dtype fp32 or train on CUDA."
+        )
     expected_hidden_dim = hidden_size * len(target_layer_ids)
     if int(manifest["target_hidden_dim"]) != expected_hidden_dim:
         raise ValueError(
@@ -627,7 +635,16 @@ class TrainDSparkRecipe(BaseRecipe):
                     )
         else:
             manifest = read_manifest(self.cached_target_path)
-            _validate_cached_dspark_manifest(self.cached_target_path, manifest, target_text_config, target_layer_ids)
+            _validate_cached_dspark_manifest(
+                self.cached_target_path,
+                manifest,
+                target_text_config,
+                target_layer_ids,
+                target_model=target_path,
+                target_model_type=target_model_type,
+                seq_length=recipe_cfg.seq_length,
+                compute_dtype=self.compute_dtype,
+            )
             embed_src, head_src = read_target_weight_modules(self.cached_target_path)
             self.train_dataloader = build_cached_dspark_dataloader(
                 cache_dir=self.cached_target_path,
@@ -1208,6 +1225,8 @@ class TrainDSparkRecipe(BaseRecipe):
         """Run one batch through live target capture or the offline cache."""
         batch = {k: v.to(self.device, non_blocking=True) for k, v in batch.items()}
         if self.target_wrapper is None:
+            batch["target_hidden_states"] = batch["target_hidden_states"].to(self.compute_dtype)
+            batch["target_last_hidden_states"] = batch["target_last_hidden_states"].to(self.compute_dtype)
             return self.trainer_module(
                 input_ids=batch["input_ids"],
                 target_hidden_states=batch["target_hidden_states"],

--- a/nemo_automodel/recipes/llm/train_dspark.py
+++ b/nemo_automodel/recipes/llm/train_dspark.py
@@ -319,9 +319,13 @@ def _validate_cached_dspark_manifest(
 ) -> None:
     """Validate that a DSpark offline cache matches the configured target/draft run."""
     if str(manifest["target_model"]) != str(target_model):
-        raise ValueError(
-            f"DSpark cache at {cache_dir} was built for target_model={manifest['target_model']!r}, "
-            f"but this run configured target_model={target_model!r}. The cache does not match this target."
+        logger.warning(
+            "DSpark cache at %s was built for target_model=%r, but this run configured target_model=%r. "
+            "Continuing because raw paths can differ across machines; structural cache fields will still be "
+            "validated.",
+            cache_dir,
+            manifest["target_model"],
+            target_model,
         )
     if str(manifest["target_model_type"]) != str(target_model_type):
         raise ValueError(
@@ -416,10 +420,13 @@ class TrainDSparkRecipe(BaseRecipe):
             )
 
         self.tokenizer = NeMoAutoTokenizer.from_pretrained(target_path, trust_remote_code=trust_remote_code)
-        # DSpark renders 'messages'-format data with the tokenizer's chat template;
-        # some targets (e.g. DeepSeek-V4-Flash) ship none, so recipe_args.chat_template
-        # supplies / overrides it (see the helper for the matching + loss-span rules).
-        _apply_target_chat_template(self.tokenizer, recipe_cfg.get("chat_template", None))
+        chat_template = recipe_cfg.get("chat_template", None)
+        # Online DSpark renders 'messages'-format data here and needs the tokenizer's
+        # chat template. Offline cached training consumes already-tokenized cache
+        # tensors, so a missing template should not block training; still apply an
+        # explicit override so saved checkpoints carry the requested tokenizer state.
+        if self.cached_target_path is None or chat_template is not None:
+            _apply_target_chat_template(self.tokenizer, chat_template)
         self.compute_dtype = torch.bfloat16 if self.device.type == "cuda" else torch.float32
 
         if is_deepseek_v4_target:

--- a/tests/functional_tests/speculative/test_dspark_trainer_module.py
+++ b/tests/functional_tests/speculative/test_dspark_trainer_module.py
@@ -139,8 +139,13 @@ def test_trainer_module_trains_from_offline_cache(tmp_path):
         target_batch = target_wrapper.generate_batch(input_ids, attention_mask, loss_mask)
 
     cache_dir = str(tmp_path / "dspark-cache")
-    write_target_weights(cache_dir, target_wrapper.get_input_embeddings(), target_wrapper.get_output_embeddings())
-    write_shard(cache_dir, 0, _compute_batch_cache(target_batch, attention_mask, cache_dtype=torch.float32))
+    write_target_weights(
+        cache_dir,
+        target_wrapper.get_input_embeddings(),
+        target_wrapper.get_output_embeddings(),
+        dtype=torch.float32,
+    )
+    write_shard(cache_dir, 0, _compute_batch_cache(target_batch, cache_dtype=torch.float32))
     write_manifest(
         cache_dir,
         {

--- a/tests/functional_tests/speculative/test_dspark_trainer_module.py
+++ b/tests/functional_tests/speculative/test_dspark_trainer_module.py
@@ -23,14 +23,20 @@ import pytest
 import torch
 from transformers import AutoModelForCausalLM, Qwen3Config
 
+from nemo_automodel.components.datasets.llm.dspark_cache import (
+    build_cached_dspark_dataloader,
+    read_target_weight_modules,
+    write_manifest,
+    write_shard,
+    write_target_weights,
+)
 from nemo_automodel.components.speculative.dspark import Qwen3DSparkModel, build_draft_config
 from nemo_automodel.components.speculative.dspark.core import DSparkStepMetrics, DSparkTrainerModule
 from nemo_automodel.components.speculative.dspark.registry import build_target_layer_ids
 from nemo_automodel.components.speculative.dspark.target import HFDSparkTargetModel
+from nemo_automodel.components.speculative.precompute_dspark import _compute_batch_cache
 
-pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available(), reason="FlexAttention backward requires a GPU"
-)
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="FlexAttention backward requires a GPU")
 
 VOCAB = 1024
 HIDDEN = 128
@@ -106,3 +112,86 @@ def test_trainer_module_with_target_wrapper_trains():
         losses.append(out.loss.item())
 
     assert losses[-1] < losses[0], f"loss did not decrease: {losses[0]:.4f} -> {losses[-1]:.4f}"
+
+
+def test_trainer_module_trains_from_offline_cache(tmp_path):
+    device, dtype = "cuda", torch.float32
+    target_config = Qwen3Config(
+        vocab_size=VOCAB,
+        hidden_size=HIDDEN,
+        intermediate_size=2 * HIDDEN,
+        num_hidden_layers=6,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        max_position_embeddings=128,
+    )
+    target_layer_ids = build_target_layer_ids(target_config.num_hidden_layers, 3)
+
+    target = AutoModelForCausalLM.from_config(target_config).to(device=device, dtype=dtype).eval()
+    target.requires_grad_(False)
+    target_wrapper = HFDSparkTargetModel(target, target_layer_ids=target_layer_ids)
+
+    torch.manual_seed(0)
+    input_ids = torch.randint(0, VOCAB, (1, 32), device=device)
+    attention_mask = torch.ones(1, 32, dtype=torch.long, device=device)
+    loss_mask = torch.ones(1, 32, dtype=torch.uint8, device=device)
+    with torch.no_grad():
+        target_batch = target_wrapper.generate_batch(input_ids, attention_mask, loss_mask)
+
+    cache_dir = str(tmp_path / "dspark-cache")
+    write_target_weights(cache_dir, target_wrapper.get_input_embeddings(), target_wrapper.get_output_embeddings())
+    write_shard(cache_dir, 0, _compute_batch_cache(target_batch, attention_mask, cache_dtype=torch.float32))
+    write_manifest(
+        cache_dir,
+        {
+            "target_model": "tiny-qwen3",
+            "target_model_type": "qwen3",
+            "target_vocab_size": VOCAB,
+            "hidden_size": HIDDEN,
+            "num_hidden_layers": target_config.num_hidden_layers,
+            "seq_length": 32,
+            "dtype": "fp32",
+            "num_samples": 1,
+            "shard_size": 1,
+            "target_hidden_dim": HIDDEN * len(target_layer_ids),
+            "target_last_hidden_dim": HIDDEN,
+            "target_layer_ids": list(target_layer_ids),
+        },
+    )
+
+    margs = _Args(
+        num_draft_layers=2,
+        target_layer_ids=target_layer_ids,
+        block_size=4,
+        mask_token_id=7,
+        num_anchors=16,
+        markov_rank=32,
+        markov_head_type="vanilla",
+        confidence_head_alpha=1.0,
+        confidence_head_with_markov=True,
+    )
+    draft = Qwen3DSparkModel(build_draft_config(target_config, margs)).to(device=device, dtype=dtype)
+    embed_src, head_src = read_target_weight_modules(cache_dir)
+    draft.initialize_embeddings_and_head(embed_tokens=embed_src, lm_head=head_src, freeze=True)
+    trainer = DSparkTrainerModule(
+        draft, loss_decay_gamma=4.0, ce_loss_alpha=0.1, l1_loss_alpha=0.9, confidence_head_alpha=1.0
+    ).to(device)
+
+    (batch,) = list(build_cached_dspark_dataloader(cache_dir=cache_dir, batch_size=1, shuffle=False))
+    batch = {k: v.to(device) for k, v in batch.items()}
+    optim = torch.optim.AdamW([p for p in trainer.parameters() if p.requires_grad], lr=5e-3)
+    losses = []
+    for _ in range(20):
+        optim.zero_grad()
+        torch.manual_seed(123)
+        out = trainer(
+            input_ids=batch["input_ids"],
+            target_hidden_states=batch["target_hidden_states"],
+            loss_mask=batch["loss_mask"],
+            target_last_hidden_states=batch["target_last_hidden_states"],
+        )
+        out.loss.backward()
+        optim.step()
+        losses.append(out.loss.item())
+
+    assert losses[-1] < losses[0], f"cached loss did not decrease: {losses[0]:.4f} -> {losses[-1]:.4f}"

--- a/tests/unit_tests/recipes/llm/test_train_dspark_helpers.py
+++ b/tests/unit_tests/recipes/llm/test_train_dspark_helpers.py
@@ -532,7 +532,13 @@ def test_build_glm_5_2_target_requires_cuda(tmp_path):
 
 def _cached_manifest(**overrides):
     manifest = {
+        "target_model": "tiny-qwen3",
+        "target_model_type": "qwen3",
         "target_vocab_size": 64,
+        "hidden_size": 32,
+        "num_hidden_layers": 6,
+        "seq_length": 8,
+        "dtype": "fp32",
         "target_hidden_dim": 96,
         "target_last_hidden_dim": 32,
         "target_layer_ids": [1, 3, 5],
@@ -542,19 +548,39 @@ def _cached_manifest(**overrides):
 
 
 def _target_config(**overrides):
-    fields = {"vocab_size": 64, "hidden_size": 32}
+    fields = {"vocab_size": 64, "hidden_size": 32, "num_hidden_layers": 6}
     fields.update(overrides)
     return SimpleNamespace(**fields)
 
 
+def _validate_cached_manifest(manifest=None, target_config=None, target_layer_ids=None, **kwargs):
+    _validate_cached_dspark_manifest(
+        "/cache",
+        _cached_manifest() if manifest is None else manifest,
+        _target_config() if target_config is None else target_config,
+        [1, 3, 5] if target_layer_ids is None else target_layer_ids,
+        target_model=kwargs.pop("target_model", "tiny-qwen3"),
+        target_model_type=kwargs.pop("target_model_type", "qwen3"),
+        seq_length=kwargs.pop("seq_length", 8),
+        compute_dtype=kwargs.pop("compute_dtype", torch.float32),
+    )
+
+
 def test_cached_dspark_manifest_accepts_matching_shapes():
-    _validate_cached_dspark_manifest("/cache", _cached_manifest(), _target_config(), [1, 3, 5])
+    _validate_cached_manifest()
 
 
 @pytest.mark.parametrize(
     "manifest,target_config,target_layer_ids,pattern",
     [
+        (_cached_manifest(target_model="other-qwen3"), _target_config(), [1, 3, 5], "target_model"),
+        (_cached_manifest(target_model_type="llama"), _target_config(), [1, 3, 5], "target_model_type"),
         (_cached_manifest(target_vocab_size=65), _target_config(), [1, 3, 5], "target_vocab_size"),
+        (_cached_manifest(hidden_size=16), _target_config(), [1, 3, 5], "hidden_size"),
+        (_cached_manifest(num_hidden_layers=7), _target_config(), [1, 3, 5], "num_hidden_layers"),
+        (_cached_manifest(seq_length=16), _target_config(), [1, 3, 5], "seq_length"),
+        (_cached_manifest(dtype="int4"), _target_config(), [1, 3, 5], "dtype"),
+        (_cached_manifest(dtype="bf16"), _target_config(), [1, 3, 5], "CPU cached training"),
         (_cached_manifest(target_hidden_dim=64), _target_config(), [1, 3, 5], "target_hidden_dim"),
         (_cached_manifest(target_last_hidden_dim=16), _target_config(), [1, 3, 5], "target_last_hidden_dim"),
         (_cached_manifest(target_layer_ids=[1, 2, 3]), _target_config(), [1, 3, 5], "target_layer_ids"),
@@ -562,7 +588,11 @@ def test_cached_dspark_manifest_accepts_matching_shapes():
 )
 def test_cached_dspark_manifest_rejects_mismatch(manifest, target_config, target_layer_ids, pattern):
     with pytest.raises(ValueError, match=pattern):
-        _validate_cached_dspark_manifest("/cache", manifest, target_config, target_layer_ids)
+        _validate_cached_manifest(manifest, target_config, target_layer_ids)
+
+
+def test_cached_dspark_manifest_accepts_bf16_cache_on_cuda_dtype():
+    _validate_cached_manifest(manifest=_cached_manifest(dtype="bf16"), compute_dtype=torch.bfloat16)
 
 
 def test_recipe_cached_path_does_not_load_target_model(monkeypatch, tmp_path):
@@ -575,13 +605,12 @@ def test_recipe_cached_path_does_not_load_target_model(monkeypatch, tmp_path):
     cache_dir = str(tmp_path / "cache")
     embed = torch.nn.Embedding(vocab_size, hidden_size)
     head = torch.nn.Linear(hidden_size, vocab_size, bias=False)
-    write_target_weights(cache_dir, embed, head)
+    write_target_weights(cache_dir, embed, head, dtype=torch.float32)
     write_shard(
         cache_dir,
         0,
         {
             "input_ids": torch.randint(0, vocab_size, (1, 8), dtype=torch.long),
-            "attention_mask": torch.ones(1, 8, dtype=torch.long),
             "loss_mask": torch.ones(1, 8, dtype=torch.long),
             "target_hidden_states": torch.randn(1, 8, hidden_size * len(target_layer_ids)),
             "target_last_hidden_states": torch.randn(1, 8, hidden_size),

--- a/tests/unit_tests/recipes/llm/test_train_dspark_helpers.py
+++ b/tests/unit_tests/recipes/llm/test_train_dspark_helpers.py
@@ -44,8 +44,10 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+from transformers import Qwen3Config
 
 from nemo_automodel.components.config.loader import ConfigNode
+from nemo_automodel.components.datasets.llm.dspark_cache import write_manifest, write_shard, write_target_weights
 from nemo_automodel.recipes.llm.train_dspark import (
     TrainDSparkRecipe,
     _apply_draft_activation_checkpointing,
@@ -58,6 +60,7 @@ from nemo_automodel.recipes.llm.train_dspark import (
     _resolve_reduced_target_layers,
     _resolve_wandb_kwargs,
     _resolve_warmup_steps,
+    _validate_cached_dspark_manifest,
 )
 
 JINJA = (
@@ -520,3 +523,161 @@ def test_build_glm_5_2_target_requires_cuda(tmp_path):
     recipe.device = SimpleNamespace(type="cpu")
     with pytest.raises(RuntimeError, match="requires CUDA"):
         recipe._build_glm_5_2_target(str(tmp_path), _opt_cfg(), False)
+
+
+# ---------------------------------------------------------------------------
+# _validate_cached_dspark_manifest
+# ---------------------------------------------------------------------------
+
+
+def _cached_manifest(**overrides):
+    manifest = {
+        "target_vocab_size": 64,
+        "target_hidden_dim": 96,
+        "target_last_hidden_dim": 32,
+        "target_layer_ids": [1, 3, 5],
+    }
+    manifest.update(overrides)
+    return manifest
+
+
+def _target_config(**overrides):
+    fields = {"vocab_size": 64, "hidden_size": 32}
+    fields.update(overrides)
+    return SimpleNamespace(**fields)
+
+
+def test_cached_dspark_manifest_accepts_matching_shapes():
+    _validate_cached_dspark_manifest("/cache", _cached_manifest(), _target_config(), [1, 3, 5])
+
+
+@pytest.mark.parametrize(
+    "manifest,target_config,target_layer_ids,pattern",
+    [
+        (_cached_manifest(target_vocab_size=65), _target_config(), [1, 3, 5], "target_vocab_size"),
+        (_cached_manifest(target_hidden_dim=64), _target_config(), [1, 3, 5], "target_hidden_dim"),
+        (_cached_manifest(target_last_hidden_dim=16), _target_config(), [1, 3, 5], "target_last_hidden_dim"),
+        (_cached_manifest(target_layer_ids=[1, 2, 3]), _target_config(), [1, 3, 5], "target_layer_ids"),
+    ],
+)
+def test_cached_dspark_manifest_rejects_mismatch(manifest, target_config, target_layer_ids, pattern):
+    with pytest.raises(ValueError, match=pattern):
+        _validate_cached_dspark_manifest("/cache", manifest, target_config, target_layer_ids)
+
+
+def test_recipe_cached_path_does_not_load_target_model(monkeypatch, tmp_path):
+    """The recipe-level offline path must skip building the live target wrapper."""
+    import nemo_automodel.recipes.llm.train_dspark as train_dspark_module
+
+    vocab_size = 64
+    hidden_size = 32
+    target_layer_ids = [1, 3]
+    cache_dir = str(tmp_path / "cache")
+    embed = torch.nn.Embedding(vocab_size, hidden_size)
+    head = torch.nn.Linear(hidden_size, vocab_size, bias=False)
+    write_target_weights(cache_dir, embed, head)
+    write_shard(
+        cache_dir,
+        0,
+        {
+            "input_ids": torch.randint(0, vocab_size, (1, 8), dtype=torch.long),
+            "attention_mask": torch.ones(1, 8, dtype=torch.long),
+            "loss_mask": torch.ones(1, 8, dtype=torch.long),
+            "target_hidden_states": torch.randn(1, 8, hidden_size * len(target_layer_ids)),
+            "target_last_hidden_states": torch.randn(1, 8, hidden_size),
+        },
+    )
+    write_manifest(
+        cache_dir,
+        {
+            "target_model": "tiny-qwen3",
+            "target_model_type": "qwen3",
+            "target_vocab_size": vocab_size,
+            "hidden_size": hidden_size,
+            "num_hidden_layers": 4,
+            "seq_length": 8,
+            "dtype": "fp32",
+            "num_samples": 1,
+            "shard_size": 1,
+            "target_hidden_dim": hidden_size * len(target_layer_ids),
+            "target_last_hidden_dim": hidden_size,
+            "target_layer_ids": target_layer_ids,
+        },
+    )
+
+    class _CfgNode(dict):
+        def __getattr__(self, key):
+            try:
+                return self[key]
+            except KeyError as exc:
+                raise AttributeError(key) from exc
+
+        def to_dict(self):
+            return dict(self)
+
+    cfg = _CfgNode(
+        recipe_args=_CfgNode(
+            target_model_name_or_path="tiny-qwen3",
+            cached_target_path=cache_dir,
+            seq_length=8,
+            micro_batch_size=1,
+            mask_token_id=7,
+            num_epochs=1,
+            output_dir=str(tmp_path / "out"),
+            target_layer_ids=target_layer_ids,
+            draft_num_hidden_layers=1,
+            num_anchors=4,
+            block_size=2,
+            markov_rank=8,
+            attention_backend="flex_attention",
+            trust_remote_code=False,
+        ),
+        optimizer=_CfgNode(lr=1e-4, warmup_ratio=0.0, min_lr_ratio=0.1),
+        checkpoint=_CfgNode(enabled=False),
+        raw_config={},
+    )
+    target_config = Qwen3Config(
+        vocab_size=vocab_size,
+        hidden_size=hidden_size,
+        intermediate_size=2 * hidden_size,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        max_position_embeddings=32,
+    )
+    target_config.architectures = ["Qwen3ForCausalLM"]
+
+    monkeypatch.setattr(
+        train_dspark_module,
+        "initialize_distributed",
+        lambda **_kwargs: SimpleNamespace(device=torch.device("cpu"), world_size=1, is_main=True),
+    )
+    monkeypatch.setattr(train_dspark_module, "setup_logging", lambda: None)
+    monkeypatch.setattr(train_dspark_module, "_read_target_model_type", lambda *_args, **_kwargs: "qwen3")
+    monkeypatch.setattr(train_dspark_module.AutoConfig, "from_pretrained", lambda *_args, **_kwargs: target_config)
+    monkeypatch.setattr(
+        train_dspark_module.NeMoAutoTokenizer,
+        "from_pretrained",
+        lambda *_args, **_kwargs: _tok(chat_template=JINJA),
+    )
+    monkeypatch.setattr(
+        train_dspark_module.NeMoAutoModelForCausalLM,
+        "from_pretrained",
+        lambda *_args, **_kwargs: pytest.fail("cached_target_path must not load the target model"),
+    )
+    monkeypatch.setattr(
+        train_dspark_module,
+        "HFDSparkTargetModel",
+        lambda *_args, **_kwargs: pytest.fail("cached_target_path must not build a live target wrapper"),
+    )
+    monkeypatch.setattr(TrainDSparkRecipe, "_build_checkpointer", lambda self, _target_path: None)
+    monkeypatch.setattr(TrainDSparkRecipe, "load_checkpoint", lambda self, restore_from=None: None)
+
+    recipe = TrainDSparkRecipe(cfg)
+    recipe.setup()
+
+    assert recipe.target_model is None
+    assert recipe.target_wrapper is None
+    assert len(recipe.train_dataloader.dataset) == 1
+    torch.testing.assert_close(recipe.draft_model.embed_tokens.weight.detach().cpu(), embed.weight.detach())
+    torch.testing.assert_close(recipe.draft_model.lm_head.weight.detach().cpu(), head.weight.detach())

--- a/tests/unit_tests/recipes/llm/test_train_dspark_helpers.py
+++ b/tests/unit_tests/recipes/llm/test_train_dspark_helpers.py
@@ -570,10 +570,18 @@ def test_cached_dspark_manifest_accepts_matching_shapes():
     _validate_cached_manifest()
 
 
+def test_cached_dspark_manifest_warns_on_target_path_mismatch(caplog):
+    caplog.set_level("WARNING")
+    _validate_cached_manifest(
+        manifest=_cached_manifest(target_model="/precompute/path/to/target"),
+        target_model="/training/path/to/target",
+    )
+    assert "raw paths can differ across machines" in caplog.text
+
+
 @pytest.mark.parametrize(
     "manifest,target_config,target_layer_ids,pattern",
     [
-        (_cached_manifest(target_model="other-qwen3"), _target_config(), [1, 3, 5], "target_model"),
         (_cached_manifest(target_model_type="llama"), _target_config(), [1, 3, 5], "target_model_type"),
         (_cached_manifest(target_vocab_size=65), _target_config(), [1, 3, 5], "target_vocab_size"),
         (_cached_manifest(hidden_size=16), _target_config(), [1, 3, 5], "hidden_size"),
@@ -687,7 +695,7 @@ def test_recipe_cached_path_does_not_load_target_model(monkeypatch, tmp_path):
     monkeypatch.setattr(
         train_dspark_module.NeMoAutoTokenizer,
         "from_pretrained",
-        lambda *_args, **_kwargs: _tok(chat_template=JINJA),
+        lambda *_args, **_kwargs: _tok(chat_template=None),
     )
     monkeypatch.setattr(
         train_dspark_module.NeMoAutoModelForCausalLM,

--- a/tests/unit_tests/speculative/test_dspark_offline_cache.py
+++ b/tests/unit_tests/speculative/test_dspark_offline_cache.py
@@ -20,6 +20,7 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+from torch.utils.data import DataLoader, Dataset
 from transformers import Qwen3Config
 
 from nemo_automodel.components.datasets.llm.dspark_cache import (
@@ -33,6 +34,7 @@ from nemo_automodel.components.datasets.llm.dspark_cache import (
     write_shard,
     write_target_weights,
 )
+from nemo_automodel.components.datasets.llm.offline_cache import dataloader_from_sample
 from nemo_automodel.components.speculative.precompute_dspark import (
     _build_parser,
     _compute_batch_cache,
@@ -59,7 +61,6 @@ def _fake_target_batch(batch_size: int = 2, seq_len: int = 5):
 def _write_tiny_cache(cache_dir: str, num_samples: int = 3, shard_size: int = 2, seq_len: int = 4):
     samples = {
         "input_ids": torch.randint(0, _VOCAB, (num_samples, seq_len), dtype=torch.long),
-        "attention_mask": torch.ones(num_samples, seq_len, dtype=torch.long),
         "loss_mask": torch.ones(num_samples, seq_len, dtype=torch.long),
         "target_hidden_states": torch.randn(num_samples, seq_len, _HIDDEN * len(_LAYERS)),
         "target_last_hidden_states": torch.randn(num_samples, seq_len, _HIDDEN),
@@ -88,12 +89,10 @@ def _write_tiny_cache(cache_dir: str, num_samples: int = 3, shard_size: int = 2,
 
 def test_compute_batch_cache_downcasts_only_float_tensors():
     tb = _fake_target_batch()
-    attention_mask = torch.ones_like(tb.input_ids)
-    cache = _compute_batch_cache(tb, attention_mask, cache_dtype=torch.bfloat16)
+    cache = _compute_batch_cache(tb, cache_dtype=torch.bfloat16)
 
     assert set(cache) == set(CACHE_KEYS)
     assert cache["input_ids"].dtype == torch.long
-    assert cache["attention_mask"].dtype == torch.long
     assert cache["loss_mask"].dtype == torch.long
     assert cache["target_hidden_states"].dtype == torch.bfloat16
     assert cache["target_last_hidden_states"].dtype == torch.bfloat16
@@ -159,17 +158,40 @@ def test_target_weights_round_trip(tmp_path):
     cache_dir = str(tmp_path / "cache")
     embed = torch.nn.Embedding(_VOCAB, _HIDDEN)
     head = torch.nn.Linear(_HIDDEN, _VOCAB, bias=False)
-    write_target_weights(cache_dir, embed, head)
+    write_target_weights(cache_dir, embed, head, dtype=torch.bfloat16)
 
     loaded_embed, loaded_head = read_target_weight_modules(cache_dir)
-    torch.testing.assert_close(loaded_embed.weight, embed.weight.detach().float())
-    torch.testing.assert_close(loaded_head.weight, head.weight.detach().float())
+    assert loaded_embed.weight.dtype == torch.bfloat16
+    assert loaded_head.weight.dtype == torch.bfloat16
+    torch.testing.assert_close(loaded_embed.weight, embed.weight.detach().bfloat16())
+    torch.testing.assert_close(loaded_head.weight, head.weight.detach().bfloat16())
 
 
 def test_existing_shard_indices(tmp_path):
     cache_dir = str(tmp_path / "cache")
     _write_tiny_cache(cache_dir, num_samples=3, shard_size=2, seq_len=4)
     assert existing_shard_indices(cache_dir) == {0, 1}
+
+
+def test_dataloader_from_sample_skips_completed_samples_without_loading_them():
+    class _RecordingDataset(Dataset):
+        def __init__(self):
+            self.seen = []
+
+        def __len__(self):
+            return 6
+
+        def __getitem__(self, index):
+            self.seen.append(index)
+            return {"input_ids": torch.tensor([index])}
+
+    dataset = _RecordingDataset()
+    loader = DataLoader(dataset, batch_size=2, shuffle=False)
+    resumed = dataloader_from_sample(loader, start_sample=4)
+
+    batches = list(resumed)
+    assert [batch["input_ids"].view(-1).tolist() for batch in batches] == [[4, 5]]
+    assert dataset.seen == [4, 5]
 
 
 def _args(**overrides):
@@ -216,7 +238,7 @@ def test_precompute_resume_mismatch_does_not_overwrite_target_weights(monkeypatc
     cache_dir = str(tmp_path / "cache")
     old_embed = torch.nn.Embedding(_VOCAB, _HIDDEN)
     old_head = torch.nn.Linear(_HIDDEN, _VOCAB, bias=False)
-    write_target_weights(cache_dir, old_embed, old_head)
+    write_target_weights(cache_dir, old_embed, old_head, dtype=torch.float32)
     samples = _write_tiny_cache(cache_dir, num_samples=1, shard_size=1, seq_len=4)
     write_shard(cache_dir, 0, {k: v[:1] for k, v in samples.items()})
 

--- a/tests/unit_tests/speculative/test_dspark_offline_cache.py
+++ b/tests/unit_tests/speculative/test_dspark_offline_cache.py
@@ -236,6 +236,33 @@ def test_parser_accepts_required_args():
     assert args.dtype == "bf16"
 
 
+@pytest.mark.parametrize("model_type", ["deepseek_v4", "glm_moe_dsa", "minimax_m3_vl"])
+def test_precompute_rejects_targets_that_need_specialized_online_loading(monkeypatch, tmp_path, model_type):
+    import nemo_automodel.components.speculative.precompute_dspark as precompute_dspark
+
+    monkeypatch.setattr(precompute_dspark, "_read_target_model_type", lambda *_args, **_kwargs: model_type)
+    monkeypatch.setattr(
+        precompute_dspark.AutoConfig,
+        "from_pretrained",
+        lambda *_args, **_kwargs: pytest.fail("unsupported targets should be rejected before loading config"),
+    )
+    args = _build_parser().parse_args(
+        [
+            "--target-model",
+            "special-target",
+            "--input-data",
+            "data.jsonl",
+            "--output-dir",
+            str(tmp_path / "cache"),
+            "--device",
+            "cpu",
+        ]
+    )
+
+    with pytest.raises(ValueError, match=f"model_type='{model_type}'"):
+        _run(args)
+
+
 def test_resume_compatibility_rejects_manifest_mismatch(tmp_path):
     cache_dir = str(tmp_path / "cache")
     _write_tiny_cache(cache_dir, num_samples=2, shard_size=2, seq_len=4)

--- a/tests/unit_tests/speculative/test_dspark_offline_cache.py
+++ b/tests/unit_tests/speculative/test_dspark_offline_cache.py
@@ -1,0 +1,435 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the DSpark offline target-supervision cache."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from transformers import Qwen3Config
+
+from nemo_automodel.components.datasets.llm.dspark_cache import (
+    CACHE_KEYS,
+    CachedDSparkDataset,
+    build_cached_dspark_dataloader,
+    existing_shard_indices,
+    read_manifest,
+    read_target_weight_modules,
+    write_manifest,
+    write_shard,
+    write_target_weights,
+)
+from nemo_automodel.components.speculative.precompute_dspark import (
+    _build_parser,
+    _compute_batch_cache,
+    _ensure_resume_compatible,
+    _run,
+    _validate_args,
+)
+
+_VOCAB = 64
+_HIDDEN = 16
+_LAYERS = [1, 3, 5]
+
+
+def _fake_target_batch(batch_size: int = 2, seq_len: int = 5):
+    torch.manual_seed(0)
+    return SimpleNamespace(
+        input_ids=torch.randint(0, _VOCAB, (batch_size, seq_len)),
+        loss_mask=torch.ones(batch_size, seq_len, dtype=torch.long),
+        target_hidden_states=torch.randn(batch_size, seq_len, _HIDDEN * len(_LAYERS)),
+        target_last_hidden_states=torch.randn(batch_size, seq_len, _HIDDEN),
+    )
+
+
+def _write_tiny_cache(cache_dir: str, num_samples: int = 3, shard_size: int = 2, seq_len: int = 4):
+    samples = {
+        "input_ids": torch.randint(0, _VOCAB, (num_samples, seq_len), dtype=torch.long),
+        "attention_mask": torch.ones(num_samples, seq_len, dtype=torch.long),
+        "loss_mask": torch.ones(num_samples, seq_len, dtype=torch.long),
+        "target_hidden_states": torch.randn(num_samples, seq_len, _HIDDEN * len(_LAYERS)),
+        "target_last_hidden_states": torch.randn(num_samples, seq_len, _HIDDEN),
+    }
+    for shard_index, start in enumerate(range(0, num_samples, shard_size)):
+        write_shard(cache_dir, shard_index, {k: v[start : start + shard_size] for k, v in samples.items()})
+    write_manifest(
+        cache_dir,
+        {
+            "target_model": "tiny",
+            "target_model_type": "qwen3",
+            "target_vocab_size": _VOCAB,
+            "hidden_size": _HIDDEN,
+            "num_hidden_layers": 6,
+            "seq_length": seq_len,
+            "dtype": "fp32",
+            "num_samples": num_samples,
+            "shard_size": shard_size,
+            "target_hidden_dim": _HIDDEN * len(_LAYERS),
+            "target_last_hidden_dim": _HIDDEN,
+            "target_layer_ids": list(_LAYERS),
+        },
+    )
+    return samples
+
+
+def test_compute_batch_cache_downcasts_only_float_tensors():
+    tb = _fake_target_batch()
+    attention_mask = torch.ones_like(tb.input_ids)
+    cache = _compute_batch_cache(tb, attention_mask, cache_dtype=torch.bfloat16)
+
+    assert set(cache) == set(CACHE_KEYS)
+    assert cache["input_ids"].dtype == torch.long
+    assert cache["attention_mask"].dtype == torch.long
+    assert cache["loss_mask"].dtype == torch.long
+    assert cache["target_hidden_states"].dtype == torch.bfloat16
+    assert cache["target_last_hidden_states"].dtype == torch.bfloat16
+    torch.testing.assert_close(cache["input_ids"], tb.input_ids)
+
+
+def test_cache_dataset_round_trip(tmp_path):
+    cache_dir = str(tmp_path / "cache")
+    samples = _write_tiny_cache(cache_dir, num_samples=3, shard_size=2, seq_len=4)
+
+    dataset = CachedDSparkDataset(cache_dir)
+    assert len(dataset) == 3
+    item = dataset[2]
+    assert set(item) == set(CACHE_KEYS)
+    torch.testing.assert_close(item["target_hidden_states"], samples["target_hidden_states"][2])
+    torch.testing.assert_close(item["target_last_hidden_states"], samples["target_last_hidden_states"][2])
+    assert int(item["input_ids"][0]) == int(samples["input_ids"][2][0])
+
+
+def test_cache_dataloader_batches(tmp_path):
+    cache_dir = str(tmp_path / "cache")
+    _write_tiny_cache(cache_dir, num_samples=4, shard_size=2, seq_len=4)
+    loader = build_cached_dspark_dataloader(cache_dir=cache_dir, batch_size=2, shuffle=False)
+
+    batches = list(loader)
+    assert len(batches) == 2
+    assert batches[0]["target_hidden_states"].shape == (2, 4, _HIDDEN * len(_LAYERS))
+    assert batches[0]["target_last_hidden_states"].shape == (2, 4, _HIDDEN)
+
+
+def test_cache_dataset_rejects_missing_shards(tmp_path):
+    cache_dir = str(tmp_path / "cache")
+    _write_tiny_cache(cache_dir, num_samples=4, shard_size=2, seq_len=4)
+    manifest = read_manifest(cache_dir)
+    manifest.pop("format_version", None)
+    manifest["num_samples"] = 99
+    write_manifest(cache_dir, manifest)
+
+    with pytest.raises(ValueError, match="shard indices"):
+        CachedDSparkDataset(cache_dir)
+
+
+def test_cache_dataset_rejects_non_contiguous_shard_indices(tmp_path):
+    cache_dir = str(tmp_path / "cache")
+    samples = _write_tiny_cache(cache_dir, num_samples=2, shard_size=1, seq_len=4)
+    write_shard(cache_dir, 99, {k: v[1:2] for k, v in samples.items()})
+    (tmp_path / "cache" / "shard-000001.safetensors").unlink()
+
+    with pytest.raises(ValueError, match="shard indices"):
+        CachedDSparkDataset(cache_dir)
+
+
+def test_write_shard_rejects_missing_cache_field(tmp_path):
+    cache_dir = str(tmp_path / "cache")
+    samples = _write_tiny_cache(cache_dir, num_samples=1, shard_size=1, seq_len=4)
+    samples.pop("target_last_hidden_states")
+
+    with pytest.raises(ValueError, match="missing required"):
+        write_shard(cache_dir, 1, samples)
+
+
+def test_target_weights_round_trip(tmp_path):
+    cache_dir = str(tmp_path / "cache")
+    embed = torch.nn.Embedding(_VOCAB, _HIDDEN)
+    head = torch.nn.Linear(_HIDDEN, _VOCAB, bias=False)
+    write_target_weights(cache_dir, embed, head)
+
+    loaded_embed, loaded_head = read_target_weight_modules(cache_dir)
+    torch.testing.assert_close(loaded_embed.weight, embed.weight.detach().float())
+    torch.testing.assert_close(loaded_head.weight, head.weight.detach().float())
+
+
+def test_existing_shard_indices(tmp_path):
+    cache_dir = str(tmp_path / "cache")
+    _write_tiny_cache(cache_dir, num_samples=3, shard_size=2, seq_len=4)
+    assert existing_shard_indices(cache_dir) == {0, 1}
+
+
+def _args(**overrides):
+    base = dict(batch_size=4, shard_size=256, draft_num_hidden_layers=5, dtype="bf16")
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+@pytest.mark.parametrize(
+    "overrides,pattern",
+    [
+        ({"batch_size": 0}, "batch-size"),
+        ({"shard_size": 0}, "shard-size"),
+        ({"shard_size": 7}, "multiple"),
+        ({"draft_num_hidden_layers": 0}, "draft-num-hidden-layers"),
+        ({"dtype": "bad"}, "dtype"),
+    ],
+)
+def test_validate_args_rejects_invalid_values(overrides, pattern):
+    with pytest.raises(ValueError, match=pattern):
+        _validate_args(_args(**overrides))
+
+
+def test_parser_accepts_required_args():
+    args = _build_parser().parse_args(["--target-model", "tiny", "--input-data", "data.jsonl", "--output-dir", "out"])
+    assert args.target_model == "tiny"
+    assert args.dtype == "bf16"
+
+
+def test_resume_compatibility_rejects_manifest_mismatch(tmp_path):
+    cache_dir = str(tmp_path / "cache")
+    _write_tiny_cache(cache_dir, num_samples=2, shard_size=2, seq_len=4)
+    manifest = read_manifest(cache_dir)
+    manifest.pop("format_version", None)
+    manifest["seq_length"] = 8
+
+    with pytest.raises(ValueError, match="does not match"):
+        _ensure_resume_compatible(cache_dir, manifest, existing_shards={0})
+
+
+def test_precompute_resume_mismatch_does_not_overwrite_target_weights(monkeypatch, tmp_path):
+    import nemo_automodel.components.speculative.precompute_dspark as precompute_dspark
+
+    cache_dir = str(tmp_path / "cache")
+    old_embed = torch.nn.Embedding(_VOCAB, _HIDDEN)
+    old_head = torch.nn.Linear(_HIDDEN, _VOCAB, bias=False)
+    write_target_weights(cache_dir, old_embed, old_head)
+    samples = _write_tiny_cache(cache_dir, num_samples=1, shard_size=1, seq_len=4)
+    write_shard(cache_dir, 0, {k: v[:1] for k, v in samples.items()})
+
+    old_embed_weight = old_embed.weight.detach().float().clone()
+    old_head_weight = old_head.weight.detach().float().clone()
+
+    class _FakeTargetModel:
+        config = Qwen3Config(
+            vocab_size=_VOCAB,
+            hidden_size=_HIDDEN,
+            intermediate_size=2 * _HIDDEN,
+            num_hidden_layers=6,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            max_position_embeddings=32,
+        )
+
+        def __init__(self):
+            self.embed = torch.nn.Embedding(_VOCAB, _HIDDEN)
+            self.head = torch.nn.Linear(_HIDDEN, _VOCAB, bias=False)
+            with torch.no_grad():
+                self.embed.weight.fill_(123.0)
+                self.head.weight.fill_(456.0)
+
+        def to(self, _device):
+            return self
+
+        def eval(self):
+            return self
+
+        def requires_grad_(self, _requires_grad):
+            return self
+
+        def get_input_embeddings(self):
+            return self.embed
+
+        def get_output_embeddings(self):
+            return self.head
+
+    class _FakeWrapper:
+        def __init__(self, _model, target_layer_ids):
+            self.target_layer_ids = list(target_layer_ids)
+
+        def generate_batch(self, *_args, **_kwargs):
+            raise AssertionError("resume mismatch should fail before target forwards")
+
+    class _FakeLoader:
+        dataset = [object()]
+
+        def __iter__(self):
+            raise AssertionError("resume mismatch should fail before iterating the dataset")
+
+    monkeypatch.setattr(precompute_dspark, "_read_target_model_type", lambda *_args, **_kwargs: "qwen3")
+    monkeypatch.setattr(
+        precompute_dspark.AutoConfig, "from_pretrained", lambda *_args, **_kwargs: _FakeTargetModel.config
+    )
+    monkeypatch.setattr(
+        precompute_dspark.NeMoAutoTokenizer,
+        "from_pretrained",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            chat_template="{{ messages }}", apply_chat_template=lambda *a, **k: None
+        ),
+    )
+    monkeypatch.setattr(
+        precompute_dspark.NeMoAutoModelForCausalLM,
+        "from_pretrained",
+        lambda *_args, **_kwargs: _FakeTargetModel(),
+    )
+    monkeypatch.setattr(precompute_dspark, "HFDSparkTargetModel", _FakeWrapper)
+    monkeypatch.setattr(precompute_dspark, "build_eagle3_dataloader", lambda **_kwargs: _FakeLoader())
+
+    args = SimpleNamespace(
+        target_model="tiny-qwen3",
+        input_data="data.jsonl",
+        output_dir=cache_dir,
+        seq_length=8,
+        batch_size=1,
+        shard_size=1,
+        dtype="fp32",
+        device="cpu",
+        num_workers=0,
+        split=None,
+        shuffle_seed=42,
+        draft_num_hidden_layers=5,
+        target_layer_ids=list(_LAYERS),
+        chat_template=None,
+        mask_reasoning_content=False,
+        target_attn_implementation=None,
+        target_force_hf=False,
+        trust_remote_code=False,
+        resume=True,
+    )
+
+    with pytest.raises(ValueError, match="does not match"):
+        _run(args)
+
+    loaded_embed, loaded_head = read_target_weight_modules(cache_dir)
+    torch.testing.assert_close(loaded_embed.weight, old_embed_weight)
+    torch.testing.assert_close(loaded_head.weight, old_head_weight)
+
+
+def test_precompute_run_writes_cache(monkeypatch, tmp_path):
+    import nemo_automodel.components.speculative.precompute_dspark as precompute_dspark
+
+    class _FakeTargetModel:
+        config = Qwen3Config(
+            vocab_size=_VOCAB,
+            hidden_size=_HIDDEN,
+            intermediate_size=2 * _HIDDEN,
+            num_hidden_layers=6,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            max_position_embeddings=32,
+        )
+
+        def __init__(self):
+            self.embed = torch.nn.Embedding(_VOCAB, _HIDDEN)
+            self.head = torch.nn.Linear(_HIDDEN, _VOCAB, bias=False)
+
+        def to(self, _device):
+            return self
+
+        def eval(self):
+            return self
+
+        def requires_grad_(self, _requires_grad):
+            return self
+
+        def get_input_embeddings(self):
+            return self.embed
+
+        def get_output_embeddings(self):
+            return self.head
+
+    class _FakeWrapper:
+        target_layer_ids = list(_LAYERS)
+
+        def __init__(self, _model, target_layer_ids):
+            self.target_layer_ids = list(target_layer_ids)
+
+        def generate_batch(self, input_ids, attention_mask, loss_mask):
+            batch_size, seq_len = input_ids.shape
+            return SimpleNamespace(
+                input_ids=input_ids,
+                loss_mask=loss_mask,
+                target_hidden_states=torch.ones(batch_size, seq_len, _HIDDEN * len(self.target_layer_ids)),
+                target_last_hidden_states=torch.ones(batch_size, seq_len, _HIDDEN),
+            )
+
+    class _FakeLoader:
+        dataset = [object(), object(), object()]
+
+        def __iter__(self):
+            yield {
+                "input_ids": torch.arange(8, dtype=torch.long).view(2, 4),
+                "attention_mask": torch.ones(2, 4, dtype=torch.long),
+                "loss_mask": torch.ones(2, 4, dtype=torch.long),
+            }
+            yield {
+                "input_ids": torch.arange(4, dtype=torch.long).view(1, 4),
+                "attention_mask": torch.ones(1, 4, dtype=torch.long),
+                "loss_mask": torch.ones(1, 4, dtype=torch.long),
+            }
+
+    fake_model = _FakeTargetModel()
+    monkeypatch.setattr(precompute_dspark, "_read_target_model_type", lambda *_args, **_kwargs: "qwen3")
+    monkeypatch.setattr(precompute_dspark.AutoConfig, "from_pretrained", lambda *_args, **_kwargs: fake_model.config)
+    monkeypatch.setattr(
+        precompute_dspark.NeMoAutoTokenizer,
+        "from_pretrained",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            chat_template="{{ messages }}", apply_chat_template=lambda *a, **k: None
+        ),
+    )
+    monkeypatch.setattr(
+        precompute_dspark.NeMoAutoModelForCausalLM,
+        "from_pretrained",
+        lambda *_args, **_kwargs: fake_model,
+    )
+    monkeypatch.setattr(precompute_dspark, "HFDSparkTargetModel", _FakeWrapper)
+    monkeypatch.setattr(precompute_dspark, "build_eagle3_dataloader", lambda **_kwargs: _FakeLoader())
+
+    cache_dir = str(tmp_path / "cache")
+    args = SimpleNamespace(
+        target_model="tiny-qwen3",
+        input_data="data.jsonl",
+        output_dir=cache_dir,
+        seq_length=4,
+        batch_size=2,
+        shard_size=2,
+        dtype="fp32",
+        device="cpu",
+        num_workers=0,
+        split=None,
+        shuffle_seed=42,
+        draft_num_hidden_layers=5,
+        target_layer_ids=list(_LAYERS),
+        chat_template=None,
+        mask_reasoning_content=False,
+        target_attn_implementation=None,
+        target_force_hf=False,
+        trust_remote_code=False,
+        resume=False,
+    )
+
+    assert _run(args) == 0
+
+    manifest = read_manifest(cache_dir)
+    assert manifest["num_samples"] == 3
+    assert manifest["target_layer_ids"] == _LAYERS
+    dataset = CachedDSparkDataset(cache_dir)
+    assert len(dataset) == 3
+    assert dataset[0]["target_hidden_states"].shape == (4, _HIDDEN * len(_LAYERS))
+    loaded_embed, loaded_head = read_target_weight_modules(cache_dir)
+    torch.testing.assert_close(loaded_embed.weight, fake_model.embed.weight.detach().float())
+    torch.testing.assert_close(loaded_head.weight, fake_model.head.weight.detach().float())

--- a/tests/unit_tests/speculative/test_dspark_offline_cache.py
+++ b/tests/unit_tests/speculative/test_dspark_offline_cache.py
@@ -167,6 +167,21 @@ def test_target_weights_round_trip(tmp_path):
     torch.testing.assert_close(loaded_head.weight, head.weight.detach().bfloat16())
 
 
+def test_target_weights_round_trip_with_tied_cpu_fp32_weights(tmp_path):
+    cache_dir = str(tmp_path / "cache")
+    embed = torch.nn.Embedding(_VOCAB, _HIDDEN)
+    head = torch.nn.Linear(_HIDDEN, _VOCAB, bias=False)
+    head.weight = embed.weight
+
+    write_target_weights(cache_dir, embed, head, dtype=torch.float32)
+
+    loaded_embed, loaded_head = read_target_weight_modules(cache_dir)
+    assert loaded_embed.weight.dtype == torch.float32
+    assert loaded_head.weight.dtype == torch.float32
+    torch.testing.assert_close(loaded_embed.weight, embed.weight.detach())
+    torch.testing.assert_close(loaded_head.weight, embed.weight.detach())
+
+
 def test_existing_shard_indices(tmp_path):
     cache_dir = str(tmp_path / "cache")
     _write_tiny_cache(cache_dir, num_samples=3, shard_size=2, seq_len=4)

--- a/tests/unit_tests/speculative/test_eagle3_offline_cache.py
+++ b/tests/unit_tests/speculative/test_eagle3_offline_cache.py
@@ -30,7 +30,7 @@ import pytest
 import torch
 from transformers import LlamaConfig
 
-from nemo_automodel.components.datasets.llm import eagle3_cache as ec
+from nemo_automodel.components.datasets.llm import offline_cache as oc
 from nemo_automodel.components.datasets.llm.eagle3_cache import (
     CACHE_KEYS,
     CachedEagle3Dataset,
@@ -345,7 +345,7 @@ def test_cache_dataset_rejects_missing_shards(tmp_path):
     manifest.pop("format_version", None)
     manifest["num_samples"] = 99
     write_manifest(cache_dir, manifest)
-    with pytest.raises(ValueError, match="shard files"):
+    with pytest.raises(ValueError, match="shard indices"):
         CachedEagle3Dataset(cache_dir)
 
 
@@ -629,9 +629,9 @@ def test_write_shard_missing_fields_raises(tmp_path):
 
 
 def test_load_safetensors_missing_raises(monkeypatch):
-    monkeypatch.setattr(ec, "safe_import_from", lambda *a, **k: (False, None))
+    monkeypatch.setattr(oc, "safe_import_from", lambda *a, **k: (False, None))
     with pytest.raises(ImportError, match="safetensors"):
-        ec._load_safetensors()
+        oc.load_safetensors("EAGLE-3")
 
 
 def test_trainer_module_rejects_nonpositive_ttt_steps():


### PR DESCRIPTION
# What does this PR do ?

Adds a DSpark offline target-supervision cache path so draft training can reuse precomputed target outputs without loading or running the target model in the draft training loop.

The offline path is text-only in this PR: `precompute_dspark.py` supports HF-loadable single-process text targets, writes DSpark supervision shards plus target `embed_tokens` / `lm_head`, and `train_dspark.py` consumes the cache through `recipe_args.cached_target_path`.

# Changelog

- Add shared offline cache helpers and DSpark cache read/write utilities for sharded target supervision, manifest metadata, and cached target weights.
- Add `nemo_automodel.components.speculative.precompute_dspark` for text-only DSpark target precompute.
- Add `recipe_args.cached_target_path` support in `train_dspark.py` so DSpark training can stream cached target batches and skip constructing the live target wrapper.
- Validate cached DSpark manifests against target model type, vocab/hidden/layer shapes, target layer ids, sequence length, and compute dtype before training starts.
- Relax raw `target_model` path matching to a warning because cache and training paths may differ across machines, while keeping structural manifest validation strict.
- Skip required chat-template setup for cached DSpark training unless an explicit `recipe_args.chat_template` override is provided.
- Clone cached target `embed_tokens` / `lm_head` weights when loading them into the draft model to avoid tied-weight aliasing issues.
- Reject unsupported DSpark offline precompute targets with clear errors instead of silently producing incompatible caches.
- Update the Qwen3 DSpark example and speculative README for DSpark offline cache usage.
- Add unit and functional coverage for DSpark cache serialization, cached dataloading, manifest validation, target-free trainer setup, and cached target weight handling.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

Related issue: #2876

Scope notes:

- This PR targets DSpark text offline caching: precompute target supervision once, then train the draft through `recipe_args.cached_target_path` without constructing the live target wrapper.
- DSpark offline precompute in this PR is intentionally limited to HF-loadable single-process text targets.
- DeepSeek V4, GLM-5.2, and MiniMax M3 are not enabled for DSpark offline precompute in this PR. They require separate large-model/distributed target precompute design and validation.
- MiniMax M3 multimodal offline precompute is out of scope because the current DSpark cache schema and precompute dataloader are text-only.
- Cached training still reads cached target `embed_tokens` / `lm_head` from the cache directory; it does not load or forward the target model.

Latest validation:

- `ruff format --check nemo_automodel/components/speculative/precompute_dspark.py nemo_automodel/recipes/llm/train_dspark.py tests/unit_tests/recipes/llm/test_train_dspark_helpers.py` passed.
- `ruff check nemo_automodel/components/speculative/precompute_dspark.py nemo_automodel/recipes/llm/train_dspark.py tests/unit_tests/recipes/llm/test_train_dspark_helpers.py` passed.
- `pytest tests/unit_tests/recipes/llm/test_train_dspark_helpers.py tests/unit_tests/speculative/test_dspark_offline_cache.py -q` passed: `81 passed`.
- `pytest tests/functional_tests/speculative/test_dspark_trainer_module.py -q` passed: `2 passed`.

Earlier validation:

- `pytest tests/functional_tests/speculative/test_dspark_train_tiny_qwen.py -q` passed: `1 passed`.
- `pytest tests/unit_tests/speculative/test_dspark_core.py -q` passed: `1 passed`.
- Manual real-HF `Qwen/Qwen3-0.6B` DSpark offline E2E smoke completed successfully.