### PR TITLE
fix(distributed): omit unset FSDP reshard argument

### DIFF
--- a/nemo_automodel/components/distributed/parallelizer_utils.py
+++ b/nemo_automodel/components/distributed/parallelizer_utils.py
@@ -122,7 +122,7 @@ def _fully_shard(
     mesh: DeviceMesh,
     mp_policy: Optional[MixedPrecisionPolicy],
     offload_policy: Optional[OffloadPolicy],
-    reshard_after_forward: Optional[bool] = None,
+    reshard_after_forward: bool | int | None = None,
 ) -> None:
     if isinstance(module, nn.ModuleList):
         for layer in module:
@@ -214,7 +214,7 @@ def fully_shard_by_dtype(
     mp_policy: Optional[MixedPrecisionPolicy],
     offload_policy: Optional[OffloadPolicy],
     fp32_compute_module_names: Tuple[str, ...] = (),
-    reshard_after_forward: Optional[bool] = None,
+    reshard_after_forward: bool | int | None = None,
 ) -> None:
     """Fully shard a module so every parameter computes in its required dtype.
 
@@ -260,13 +260,14 @@ def fully_shard_by_dtype(
         return
     elif len(grouped_params) == 1:
         key = next(iter(grouped_params))
-        fully_shard(
-            module,
-            mesh=mesh,
-            mp_policy=_mp_policy_with_param_dtype(mp_policy, key[1]),
-            offload_policy=offload_policy,
-            reshard_after_forward=reshard_after_forward,
-        )
+        kwargs = {
+            "mesh": mesh,
+            "mp_policy": _mp_policy_with_param_dtype(mp_policy, key[1]),
+            "offload_policy": offload_policy,
+        }
+        if reshard_after_forward is not None:
+            kwargs["reshard_after_forward"] = reshard_after_forward
+        fully_shard(module, **kwargs)
     else:
         least_items_key = min(grouped_params.items(), key=lambda x: len(x[1]))[0]
         for path, mod, key in iter_maximal_uniform_dtype_subtrees(
@@ -285,10 +286,11 @@ def fully_shard_by_dtype(
                 )
         if len(grouped_params) == 2:
             parent_key = next(key for key in grouped_params if key != least_items_key)
-            fully_shard(
-                module,
-                mesh=mesh,
-                mp_policy=_mp_policy_with_param_dtype(mp_policy, parent_key[1]),
-                offload_policy=offload_policy,
-                reshard_after_forward=reshard_after_forward,
-            )
+            kwargs = {
+                "mesh": mesh,
+                "mp_policy": _mp_policy_with_param_dtype(mp_policy, parent_key[1]),
+                "offload_policy": offload_policy,
+            }
+            if reshard_after_forward is not None:
+                kwargs["reshard_after_forward"] = reshard_after_forward
+            fully_shard(module, **kwargs)

--- a/tests/unit_tests/distributed/test_parallelizer_utils.py
+++ b/tests/unit_tests/distributed/test_parallelizer_utils.py
@@ -295,6 +295,56 @@ def test_fully_shard_by_dtype_single_dtype(monkeypatch):
     assert sub_calls == []  # no fp32-compute carve-outs declared
 
 
+def test_fully_shard_by_dtype_omits_none_reshard_kwarg(monkeypatch):
+    calls: list[tuple[nn.Module, dict]] = []
+
+    def fake_fully_shard(mod, **kwargs):
+        calls.append((mod, kwargs))
+
+    monkeypatch.setattr(
+        "nemo_automodel.components.distributed.parallelizer_utils.fully_shard",
+        fake_fully_shard,
+        raising=True,
+    )
+
+    # Single-dtype branch.
+    uniform = ToyModel(
+        a_dtype=torch.bfloat16,
+        b_dtype_l1=torch.bfloat16,
+        b_dtype_l2=torch.bfloat16,
+    )
+    fully_shard_by_dtype(
+        uniform,
+        mesh=object(),
+        mp_policy=_make_mp_policy(),
+        offload_policy=object(),
+        reshard_after_forward=None,
+    )
+    assert len(calls) == 1
+    assert calls[0][0] is uniform
+    assert "reshard_after_forward" not in calls[0][1]
+
+    # Two-dtype branch: both the minority subtree and parent call must omit
+    # the kwarg. Older supported PyTorch releases and some vendor builds
+    # reject an explicit ``None``.
+    calls.clear()
+    mixed = ToyModel(
+        a_dtype=torch.float32,
+        b_dtype_l1=torch.float16,
+        b_dtype_l2=torch.float16,
+    )
+    _tag_hf_compute_dtype(mixed)
+    fully_shard_by_dtype(
+        mixed,
+        mesh=object(),
+        mp_policy=_make_mp_policy(),
+        offload_policy=object(),
+        reshard_after_forward=None,
+    )
+    assert {mod for mod, _ in calls} == {mixed.a, mixed}
+    assert all("reshard_after_forward" not in kwargs for _, kwargs in calls)
+
+
 def test_fully_shard_by_dtype_storage_equals_compute_keeps_storage_dtype(monkeypatch):
     """Uniform storage that matches the requested compute dtype shards as before."""
     fully_calls: list[tuple[nn.Module, MixedPrecisionPolicy]] = []


### PR DESCRIPTION
# What does this PR do ?

Follow up on #2598 by omitting the optional `reshard_after_forward` argument from the remaining direct `fully_shard` calls when it is unset.

`_fully_shard` already preserves the installed PyTorch default when the value is `None`, but `fully_shard_by_dtype` still passed `None` explicitly in its single-dtype path and its two-dtype parent path. Older supported PyTorch releases and some vendor builds reject an explicit `None`.

# Changelog

- Build kwargs conditionally for both direct `fully_shard` call sites.
- Keep explicit boolean and integer overrides unchanged, and align the annotations with the PyTorch API.
- Add regression coverage for the single-dtype, minority-subtree, and parent call paths.
- Validate with `python -m pytest -q tests/unit_tests/distributed/test_parallelizer_utils.py` (`18 passed`).
- Validate the changed files with Ruff format and lint checks.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation? (No documentation changes are needed for this compatibility fix.)

# Additional Information

- Follow-up to #2598.
- Related prior art: #1305.