### PR TITLE
feat(cuda-graphs): capture fixed-capacity MoE execution

### DIFF
--- a/nemo_automodel/components/cuda_graphs/partial.py
+++ b/nemo_automodel/components/cuda_graphs/partial.py
@@ -806,6 +806,11 @@ def _build_moe_execution_entry(
     """Build one fixed-capacity post-router MoE graph entry."""
     from torch.distributed.fsdp import FSDPModule
 
+    if isinstance(target, FSDPModule):
+        raise RuntimeError(
+            "Full MoE CUDA graphs do not support nested FSDP expert sharding (ep_shard > 1); "
+            "the expert parameters must be owned by the transformer block"
+        )
     capture_owner = block.capture_owner if isinstance(block.capture_owner, FSDPModule) else None
     return _PartialGraphEntry(
         name=f"{block.name}.moe",

--- a/nemo_automodel/components/cuda_graphs/partial.py
+++ b/nemo_automodel/components/cuda_graphs/partial.py
@@ -804,10 +804,14 @@ def _build_moe_execution_entry(
     _activation_checkpointing: bool,
 ) -> _PartialGraphEntry:
     """Build one fixed-capacity post-router MoE graph entry."""
+    from torch.distributed.fsdp import FSDPModule
+
+    capture_owner = block.capture_owner if isinstance(block.capture_owner, FSDPModule) else None
     return _PartialGraphEntry(
         name=f"{block.name}.moe",
         target=target,
         explicit_parameters=True,
+        capture_owner=capture_owner,
         retain_graph_in_backward=True,
     )
 

--- a/nemo_automodel/components/cuda_graphs/partial.py
+++ b/nemo_automodel/components/cuda_graphs/partial.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Component-owned partial CUDA graphs for fixed-shape attention and MoE preprocessing.
+"""Component-owned partial CUDA graphs for fixed-shape attention and MoE execution.
 
-Attention, the parameterless router core, and HybridEP metadata preprocessing
-may be captured. Dynamic dispatch, expert compute, and combine remain eager.
+Attention, fixed-capacity post-router MoE execution, the parameterless router
+core, and HybridEP metadata preprocessing may be captured.
 """
 
 from __future__ import annotations
@@ -82,9 +82,9 @@ def _named_buffer_storage(target: nn.Module) -> tuple[tuple[Any, ...], ...]:
         try:
             data_ptr = buffer.data_ptr()
         except (RuntimeError, TypeError) as error:
-            raise RuntimeError(f"whole-attention buffer {name!r} has no stable local storage") from error
+            raise RuntimeError(f"CUDA graph buffer {name!r} has no stable local storage") from error
         if buffer.numel() > 0 and data_ptr == 0:
-            raise RuntimeError(f"whole-attention buffer {name!r} has no stable local storage")
+            raise RuntimeError(f"CUDA graph buffer {name!r} has no stable local storage")
         signatures.append((name, id(buffer), data_ptr, _tensor_metadata(buffer)))
     return tuple(signatures)
 
@@ -95,8 +95,8 @@ def _require_local_parameter_storage(name: str, parameter: nn.Parameter) -> None
         data_ptr = parameter.data_ptr()
     except (RuntimeError, TypeError) as error:
         raise RuntimeError(
-            "Whole-attention CUDA graph capture requires materialized parameters with stable local storage; "
-            f"{name!r} is not materialized. Nested FSDP attention ownership is not supported."
+            "Parameterized CUDA graph capture requires materialized parameters with stable local storage; "
+            f"{name!r} is not materialized. Nested FSDP ownership is not supported."
         ) from error
     if parameter.numel() > 0 and data_ptr == 0:
         raise RuntimeError(
@@ -296,10 +296,10 @@ class _ExplicitParameterCallAdapter(nn.Module):
 
         named_parameters = tuple(target.named_parameters())
         if not named_parameters:
-            raise RuntimeError("Whole-attention CUDA graph target has no parameters")
+            raise RuntimeError("Parameterized CUDA graph target has no parameters")
         all_parameter_names = tuple(name for name, _parameter in target.named_parameters(remove_duplicate=False))
         if len(all_parameter_names) != len(named_parameters):
-            raise RuntimeError("Whole-attention CUDA graphs do not support tied or aliased parameters")
+            raise RuntimeError("Parameterized CUDA graphs do not support tied or aliased parameters")
         self.parameter_names = tuple(name for name, _parameter in named_parameters)
         self.parameter_metadata = tuple(_tensor_metadata(parameter) for _name, parameter in named_parameters)
         self.buffer_storage = _named_buffer_storage(target)
@@ -307,7 +307,7 @@ class _ExplicitParameterCallAdapter(nn.Module):
         for name, parameter in named_parameters:
             if not isinstance(parameter, nn.Parameter):
                 raise RuntimeError(
-                    "Whole-attention CUDA graph capture requires materialized nn.Parameter values; "
+                    "Parameterized CUDA graph capture requires materialized nn.Parameter values; "
                     f"{name!r} is {type(parameter).__name__}"
                 )
             _require_local_parameter_storage(name, parameter)
@@ -342,26 +342,25 @@ class _ExplicitParameterCallAdapter(nn.Module):
         parameter_names = tuple(name for name, _parameter in named_parameters)
         if parameter_names != self.parameter_names:
             raise RuntimeError(
-                f"whole-attention parameter names changed: expected {self.parameter_names}, got {parameter_names}"
+                f"CUDA graph parameter names changed: expected {self.parameter_names}, got {parameter_names}"
             )
         for index, (name, parameter) in enumerate(named_parameters):
             if not isinstance(parameter, nn.Parameter):
                 raise RuntimeError(
-                    "whole-attention parameters are not materialized for replay: "
-                    f"{name!r} is {type(parameter).__name__}"
+                    f"CUDA graph parameters are not materialized for replay: {name!r} is {type(parameter).__name__}"
                 )
             _require_local_parameter_storage(name, parameter)
             actual_metadata = _tensor_metadata(parameter)
             expected_metadata = self.parameter_metadata[index]
             if actual_metadata != expected_metadata:
                 raise RuntimeError(
-                    f"whole-attention parameter metadata changed for {name!r}: "
+                    f"CUDA graph parameter metadata changed for {name!r}: "
                     f"expected {expected_metadata}, got {actual_metadata}"
                 )
         buffer_storage = _named_buffer_storage(self.target)
         if buffer_storage != self.buffer_storage:
             raise RuntimeError(
-                f"whole-attention buffer storage changed: expected {self.buffer_storage}, got {buffer_storage}"
+                f"CUDA graph buffer storage changed: expected {self.buffer_storage}, got {buffer_storage}"
             )
         return dynamic_inputs + tuple(parameter for _name, parameter in named_parameters)
 
@@ -525,9 +524,9 @@ class _PartialGraphEntry:
             for name, parameter in self.target.named_parameters():
                 if not isinstance(parameter, nn.Parameter):
                     raise RuntimeError(
-                        "Whole-attention CUDA graph capture requires the selected FSDP owner to materialize "
+                        "Parameterized CUDA graph capture requires the selected FSDP owner to materialize "
                         f"every target parameter; {name!r} remains {type(parameter).__name__}. "
-                        "Nested FSDP attention ownership is not supported."
+                        "Nested FSDP ownership is not supported."
                     )
                 _require_local_parameter_storage(name, parameter)
 
@@ -719,6 +718,14 @@ def _find_moe_preprocess(block: _DiscoveredBlock) -> nn.Module | None:
     return None
 
 
+def _find_moe_execution(block: _DiscoveredBlock) -> nn.Module | None:
+    """Find the dispatch, TE GroupedLinear, and combine boundary after routing."""
+    experts = getattr(block.moe, "experts", None)
+    return (
+        experts if isinstance(experts, nn.Module) and getattr(experts, "_supports_full_moe_cuda_graph", False) else None
+    )
+
+
 def _require_parameterless_target(module_name: str, block: _DiscoveredBlock, target: nn.Module) -> None:
     """Reject graph boundaries that own parameters managed outside the graph."""
     if any(True for _ in target.parameters()):
@@ -791,6 +798,20 @@ def _build_moe_preprocess_entry(
     return _PartialGraphEntry(name=f"{block.name}.moe_preprocess", target=target)
 
 
+def _build_moe_execution_entry(
+    block: _DiscoveredBlock,
+    target: nn.Module,
+    _activation_checkpointing: bool,
+) -> _PartialGraphEntry:
+    """Build one fixed-capacity post-router MoE graph entry."""
+    return _PartialGraphEntry(
+        name=f"{block.name}.moe",
+        target=target,
+        explicit_parameters=True,
+        retain_graph_in_backward=True,
+    )
+
+
 @dataclass(frozen=True)
 class _GraphModuleSpec:
     """Discovery and entry-construction contract for one user-facing graph module."""
@@ -802,6 +823,7 @@ class _GraphModuleSpec:
 _GRAPH_MODULE_SPECS = {
     "attn": _GraphModuleSpec(_find_attention, _build_whole_attention_entry),
     "te_dpa": _GraphModuleSpec(_find_te_dpa, _build_te_dpa_entry),
+    "moe": _GraphModuleSpec(_find_moe_execution, _build_moe_execution_entry),
     "moe_router": _GraphModuleSpec(_find_moe_router, _build_moe_router_entry),
     "moe_preprocess": _GraphModuleSpec(_find_moe_preprocess, _build_moe_preprocess_entry),
 }
@@ -900,6 +922,8 @@ class PartialCudaGraphManager:
                     "Whole-attention CUDA graphs do not support activation checkpointing; "
                     "use te_dpa or disable activation checkpointing"
                 )
+            if any("moe" in part.backend.cuda_graph.modules for part in enabled_parts):
+                raise RuntimeError("Full MoE CUDA graphs do not support activation checkpointing")
             if any(
                 "moe_router" in part.backend.cuda_graph.modules or "moe_preprocess" in part.backend.cuda_graph.modules
                 for part in enabled_parts

--- a/nemo_automodel/components/models/common/utils.py
+++ b/nemo_automodel/components/models/common/utils.py
@@ -14,6 +14,7 @@
 
 import importlib.util
 import logging
+import math
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass, field
 from typing import Any, Literal
@@ -160,12 +161,18 @@ class CudaGraphConfig:
     Attributes:
         modules: Per-layer modules to capture with Transformer Engine, following
             Megatron Core's module names. AutoModel supports whole ``attn``,
-            ``moe_router``, and ``moe_preprocess`` scopes, plus the
+            ``moe``, ``moe_router``, and ``moe_preprocess`` scopes, plus the
             AutoModel-specific narrow ``te_dpa`` scope. An empty list disables
-            CUDA graphs.
+            CUDA graphs. The ``moe`` scope captures dispatch, local TE experts,
+            and combine after eager routing.
+        moe_capacity_factor: Drop-and-pad capacity relative to the average
+            number of routed tokens per expert. Required by, and only valid
+            with, the ``moe`` graph scope. Capacity limiting may drop routed
+            expert assignments when an expert is overloaded.
     """
 
-    modules: list[Literal["attn", "te_dpa", "moe_router", "moe_preprocess"]] = field(default_factory=list)
+    modules: list[Literal["attn", "te_dpa", "moe", "moe_router", "moe_preprocess"]] = field(default_factory=list)
+    moe_capacity_factor: float | None = None
 
     def __post_init__(self) -> None:
         """Validate the declarative CUDA-graph configuration."""
@@ -173,7 +180,7 @@ class CudaGraphConfig:
             raise TypeError("cuda_graph.modules must be a list")
         if not all(isinstance(module, str) for module in self.modules):
             raise TypeError("cuda_graph.modules entries must be strings")
-        supported_modules = {"attn", "te_dpa", "moe_router", "moe_preprocess"}
+        supported_modules = {"attn", "te_dpa", "moe", "moe_router", "moe_preprocess"}
         unknown_modules = set(self.modules) - supported_modules
         if unknown_modules:
             raise ValueError(
@@ -186,6 +193,16 @@ class CudaGraphConfig:
             raise ValueError("cuda_graph.modules cannot contain both 'attn' and 'te_dpa'")
         if "moe_preprocess" in self.modules and "moe_router" not in self.modules:
             raise ValueError("'moe_preprocess' in cuda_graph.modules requires 'moe_router'")
+        if self.moe_capacity_factor is not None:
+            if not math.isfinite(self.moe_capacity_factor) or self.moe_capacity_factor <= 0:
+                raise ValueError("cuda_graph.moe_capacity_factor must be positive and finite")
+            if "moe" not in self.modules:
+                raise ValueError("cuda_graph.moe_capacity_factor requires 'moe' in cuda_graph.modules")
+        if "moe" in self.modules:
+            if self.moe_capacity_factor is None:
+                raise ValueError("'moe' in cuda_graph.modules requires cuda_graph.moe_capacity_factor")
+            if any(scope in self.modules for scope in ("moe_router", "moe_preprocess")):
+                raise ValueError("'moe' in cuda_graph.modules cannot be combined with moe_router or moe_preprocess")
 
 
 @dataclass(kw_only=True)
@@ -298,6 +315,16 @@ class BackendConfig:
         if isinstance(self.gate_precision, str):
             self.gate_precision = dtype_from_str(self.gate_precision, default=None)
 
+        graph_modules = self.cuda_graph.modules
+        moe_cuda_graph_enabled = "moe" in graph_modules
+        if moe_cuda_graph_enabled:
+            if self.experts != "te":
+                raise ValueError("'moe' in cuda_graph.modules requires experts='te'")
+            if self.dispatcher not in ("torch", "hybridep"):
+                raise ValueError("'moe' in cuda_graph.modules currently requires dispatcher='torch' or 'hybridep'")
+            if self.te_fp8 is not None:
+                raise ValueError("'moe' in cuda_graph.modules currently supports BF16 TE GroupedLinear only")
+
         # enable_deepep was removed. It is no longer honored; warn (once, on rank 0) if a stale
         # config still sets it so the user migrates to explicit dispatcher/experts. The field is
         # retained only so loading an old config does not crash this kw_only dataclass.
@@ -312,7 +339,12 @@ class BackendConfig:
             self.enable_deepep = None
 
         # Backward compatibility
-        if self.experts in ("te", "gmm") and self.dispatcher not in ("deepep", "hybridep", "uccl_ep"):
+        local_fixed_te_moe = self.experts == "te" and self.dispatcher == "torch" and moe_cuda_graph_enabled
+        if (
+            self.experts in ("te", "gmm")
+            and self.dispatcher not in ("deepep", "hybridep", "uccl_ep")
+            and not local_fixed_te_moe
+        ):
             if (
                 torch.distributed.is_initialized() and torch.distributed.get_rank() == 0
             ) or not torch.distributed.is_initialized():
@@ -324,7 +356,6 @@ class BackendConfig:
             self.dispatcher = "torch"
             self.experts = "torch_mm"
 
-        graph_modules = self.cuda_graph.modules
         attention_graph_modules = {"attn", "te_dpa"}.intersection(graph_modules)
         if attention_graph_modules and self.attn != "te":
             raise ValueError(f"{sorted(attention_graph_modules)} in cuda_graph.modules requires attn='te'")

--- a/nemo_automodel/components/moe/experts.py
+++ b/nemo_automodel/components/moe/experts.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 from functools import partial
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
@@ -33,6 +34,8 @@ except ImportError:
 
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.megatron.moe_utils import (
+    permute,
+    unpermute,
     weighted_bias_geglu_impl,
     weighted_bias_swiglu_impl,
 )
@@ -973,6 +976,8 @@ class GroupedExpertsTE(nn.Module):
         down_linear (GroupedLinear): Down projection.
     """
 
+    _supports_full_moe_cuda_graph = True
+
     def __init__(
         self,
         config: MoEConfig,
@@ -1011,6 +1016,7 @@ class GroupedExpertsTE(nn.Module):
         self.dispatcher_num_sms = dispatcher_num_sms
         self.dispatcher_share_token_dispatcher = dispatcher_share_token_dispatcher
         self.dispatcher_async_dispatch = dispatcher_async_dispatch
+        self.cuda_graph_moe_capacity_factor = backend.cuda_graph.moe_capacity_factor if backend is not None else None
 
         # Gated (SwiGLU, Quick-GEGLU): out_features = moe_inter_dim * 2
         # Non-gated (ReLU²): out_features = moe_inter_dim
@@ -1048,6 +1054,7 @@ class GroupedExpertsTE(nn.Module):
         self.ep_mesh = None
         self.moe_mesh = None
         self.ep_rank = 0
+        self.ep_size = 1
 
     def _get_stacked_weight(self, linear: "GroupedLinear", transpose: bool = False) -> torch.Tensor:
         weights = []
@@ -1339,6 +1346,146 @@ class GroupedExpertsTE(nn.Module):
         self.fp8_padding = Fp8Padding(self.num_local_experts)
         self.fp8_unpadding = Fp8Unpadding(self.num_local_experts)
 
+    def _cuda_graph_source_expert_capacity(self, num_tokens: int) -> int:
+        """Return the fixed number of assignments retained per source expert."""
+        if self.cuda_graph_moe_capacity_factor is None:
+            raise RuntimeError("MoE CUDA graph capacity is not configured")
+        capacity = math.ceil(
+            num_tokens
+            * self.config.n_activated_experts
+            * self.cuda_graph_moe_capacity_factor
+            / self.config.n_routed_experts
+        )
+        if capacity <= 0 or capacity > num_tokens:
+            raise RuntimeError(
+                "MoE CUDA graph expert capacity must be in [1, num_tokens]; "
+                f"got capacity={capacity}, num_tokens={num_tokens}"
+            )
+        return capacity
+
+    def _local_drop_and_pad_metadata(
+        self,
+        token_mask: torch.Tensor,
+        weights: torch.Tensor,
+        indices: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Convert top-k routing to a dense map while retaining routing gradients."""
+        num_tokens = indices.size(0)
+        valid = token_mask.unsqueeze(-1) & (indices >= 0) & (indices < self.config.n_routed_experts)
+        safe_indices = indices.clamp(min=0, max=self.config.n_routed_experts - 1)
+
+        routing_counts = torch.zeros(
+            (num_tokens, self.config.n_routed_experts),
+            dtype=torch.int32,
+            device=indices.device,
+        ).scatter_add(1, safe_indices, valid.to(torch.int32))
+        routing_map = routing_counts > 0
+        routing_probs = torch.zeros(
+            (num_tokens, self.config.n_routed_experts),
+            dtype=torch.float32,
+            device=weights.device,
+        ).scatter_add(1, safe_indices, weights.float() * valid)
+        return routing_map, routing_probs
+
+    def _forward_local_cuda_graph_moe(
+        self,
+        x: torch.Tensor,
+        token_mask: torch.Tensor,
+        weights: torch.Tensor,
+        indices: torch.Tensor,
+    ) -> torch.Tensor:
+        """Run local dispatch, fixed-capacity TE experts, and combine at EP=1."""
+        from transformer_engine.pytorch.quantization import FP8GlobalStateManager
+
+        if FP8GlobalStateManager.is_fp8_enabled():
+            raise RuntimeError("The initial full MoE CUDA graph path supports BF16 TE GroupedLinear only")
+        if self.ep_size != 1 or self.token_dispatcher is not None:
+            raise RuntimeError("Local MoE CUDA graph dispatch requires EP=1")
+
+        capacity = self._cuda_graph_source_expert_capacity(x.size(0))
+        routing_map, routing_probs = self._local_drop_and_pad_metadata(token_mask, weights, indices)
+        num_permuted_tokens = capacity * self.num_local_experts
+        permuted_hidden, permuted_probs, sorted_indices = permute(
+            x,
+            routing_map,
+            probs=routing_probs,
+            num_out_tokens=num_permuted_tokens,
+            fused=False,
+            drop_and_pad=True,
+        )
+        assert permuted_probs is not None
+        output2 = self._forward_fixed_capacity_te_experts(
+            permuted_hidden,
+            permuted_probs,
+            tokens_per_local_expert=capacity,
+        )
+
+        return unpermute(
+            output2,
+            sorted_indices,
+            restore_shape=x.shape,
+            fused=False,
+            drop_and_pad=True,
+        )
+
+    def _forward_hybridep_cuda_graph_moe(
+        self,
+        x: torch.Tensor,
+        token_mask: torch.Tensor,
+        weights: torch.Tensor,
+        indices: torch.Tensor,
+    ) -> torch.Tensor:
+        """Run fixed-capacity HybridEP dispatch, local TE experts, and combine."""
+        from transformer_engine.pytorch.quantization import FP8GlobalStateManager
+
+        if FP8GlobalStateManager.is_fp8_enabled():
+            raise RuntimeError("The initial full MoE CUDA graph path supports BF16 TE GroupedLinear only")
+        if self.ep_size <= 1 or self.token_dispatcher is None:
+            raise RuntimeError("HybridEP MoE CUDA graph dispatch requires EP>1")
+        if self.dispatcher_backend != "hybridep":
+            raise RuntimeError("Full MoE CUDA graphs with EP>1 require dispatcher='hybridep'")
+
+        source_capacity = self._cuda_graph_source_expert_capacity(x.size(0))
+        self.token_dispatcher.set_cuda_graph_expert_capacity(source_capacity)
+        indices = indices.masked_fill(~token_mask.unsqueeze(-1), -1)
+        permuted_hidden, _tokens_per_expert, permuted_probs = self.token_dispatcher.token_permutation2(
+            hidden_states=x,
+            num_local_tokens=x.size(0),
+            token_probs=weights,
+            token_indices=indices,
+        )
+        output = self._forward_fixed_capacity_te_experts(
+            permuted_hidden,
+            permuted_probs,
+            tokens_per_local_expert=source_capacity * self.ep_size,
+        )
+        return self.token_dispatcher.token_unpermutation(output)
+
+    def _forward_fixed_capacity_te_experts(
+        self,
+        hidden_states: torch.Tensor,
+        permuted_probs: torch.Tensor,
+        *,
+        tokens_per_local_expert: int,
+    ) -> torch.Tensor:
+        """Execute TE GroupedLinear with an identical static split for each local expert."""
+        permuted_probs = permuted_probs.unsqueeze(-1)
+        splits = [tokens_per_local_expert] * self.num_local_experts
+        output1 = self.gate_up_linear(hidden_states, splits)
+        output1 = self.expert_activation(output1, permuted_probs)
+        output2 = self.down_linear(output1, splits)
+        if self.expert_bias:
+            down_bias = self._get_stacked_bias(self.down_linear)
+            if down_bias is not None:
+                split_tensor = torch.full(
+                    (self.num_local_experts,),
+                    tokens_per_local_expert,
+                    dtype=torch.int64,
+                    device=output2.device,
+                )
+                output2 = _apply_bias(output2, down_bias, split_tensor, permuted_probs - 1.0)
+        return output2
+
     def forward(
         self,
         x: torch.Tensor,
@@ -1362,6 +1509,11 @@ class GroupedExpertsTE(nn.Module):
         assert self.config.n_routed_experts % self.ep_size == 0, (
             f"Number of experts must be divisible by ep_size (ep_size={self.ep_size})"
         )
+
+        if self.cuda_graph_moe_capacity_factor is not None:
+            if self.ep_size == 1:
+                return self._forward_local_cuda_graph_moe(x, token_mask, weights, indices)
+            return self._forward_hybridep_cuda_graph_moe(x, token_mask, weights, indices)
 
         indices = indices.masked_fill(~token_mask.unsqueeze(-1), -1)
 

--- a/nemo_automodel/components/moe/experts.py
+++ b/nemo_automodel/components/moe/experts.py
@@ -164,23 +164,32 @@ def _apply_bias(value, bias, tokens_per_expert, permuted_probs=None):
     (bias * permuted_probs) which native bias support wouldn't handle.
 
     Args:
-        value: Output from grouped GEMM, shape [total_tokens, features].
-        bias: Per-expert bias, shape [num_experts, features].
-        tokens_per_expert: Token counts per expert.
-        permuted_probs: If provided, bias is weighted by routing probs (for down projection).
+        value: Tensor of shape [total_tokens, features] containing grouped GEMM output,
+            with tokens laid out contiguously by expert.
+        bias: Tensor or sequence of tensors with one entry per expert, each of shape [features].
+        tokens_per_expert: Tensor or sequence with shape [num_experts] containing the number
+            of contiguous tokens assigned to each expert. Passing a CUDA tensor requires a
+            device-to-host conversion; graph-captured fixed-capacity paths should pass a
+            Python sequence instead.
+        permuted_probs: Optional tensor of shape [total_tokens, 1] or [total_tokens, features].
+            If provided, the bias is weighted by routing probabilities for down projection.
+
+    Returns:
+        Tensor of shape [total_tokens, features] with per-expert bias applied.
     """
     if bias is None:
         return value
     shape = value.shape
+    split_sizes = tokens_per_expert.tolist() if isinstance(tokens_per_expert, torch.Tensor) else list(tokens_per_expert)
     if permuted_probs is not None:
         output = (
             torch.cat(
                 [
                     t + b * p
                     for t, b, p in zip(
-                        torch.split(value.view(-1, shape[-1]), tokens_per_expert.tolist()),
+                        torch.split(value.view(-1, shape[-1]), split_sizes),
                         bias,
-                        torch.split(permuted_probs, tokens_per_expert.tolist()),
+                        torch.split(permuted_probs, split_sizes),
                     )
                 ]
             )
@@ -195,9 +204,7 @@ def _apply_bias(value, bias, tokens_per_expert, permuted_probs=None):
                     for t, b in zip(
                         torch.split(
                             value.view(-1, shape[-1]),
-                            tokens_per_expert.tolist()
-                            if isinstance(tokens_per_expert, torch.Tensor)
-                            else tokens_per_expert,
+                            split_sizes,
                         ),
                         bias,
                     )
@@ -1016,6 +1023,7 @@ class GroupedExpertsTE(nn.Module):
         self.dispatcher_num_sms = dispatcher_num_sms
         self.dispatcher_share_token_dispatcher = dispatcher_share_token_dispatcher
         self.dispatcher_async_dispatch = dispatcher_async_dispatch
+        self.cuda_graph_moe_enabled = backend is not None and "moe" in backend.cuda_graph.modules
         self.cuda_graph_moe_capacity_factor = backend.cuda_graph.moe_capacity_factor if backend is not None else None
 
         # Gated (SwiGLU, Quick-GEGLU): out_features = moe_inter_dim * 2
@@ -1368,8 +1376,25 @@ class GroupedExpertsTE(nn.Module):
         token_mask: torch.Tensor,
         weights: torch.Tensor,
         indices: torch.Tensor,
+        capacity: int,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Convert top-k routing to a dense map while retaining routing gradients."""
+        """Convert local top-k routing to dense drop-and-pad metadata.
+
+        Downstream drop-and-pad keeps at most the fixed capacity for each expert.
+        Overflow routed assignments are dropped rather than losslessly padded.
+
+        Args:
+            token_mask: Tensor of shape [tokens] indicating valid source tokens.
+            weights: Tensor of shape [tokens, top_k] containing routing probabilities.
+            indices: Tensor of shape [tokens, top_k] containing global expert ids.
+            capacity: Maximum number of routed assignments retained per expert.
+
+        Returns:
+            Tuple containing:
+                - routing_map: Boolean tensor of shape [tokens, num_experts].
+                - routing_probs: Tensor of shape [tokens, num_experts] retaining gradients
+                  to selected routing probabilities.
+        """
         num_tokens = indices.size(0)
         valid = token_mask.unsqueeze(-1) & (indices >= 0) & (indices < self.config.n_routed_experts)
         safe_indices = indices.clamp(min=0, max=self.config.n_routed_experts - 1)
@@ -1385,6 +1410,18 @@ class GroupedExpertsTE(nn.Module):
             dtype=torch.float32,
             device=weights.device,
         ).scatter_add(1, safe_indices, weights.float() * valid)
+        # Match Megatron's probability-based capacity policy and the HybridEP
+        # path: retain the highest-probability assignments for every expert,
+        # rather than whichever token indices happen to sort first.
+        capacity_indices = torch.topk(
+            routing_probs.masked_fill(~routing_map, -torch.inf),
+            k=capacity,
+            dim=0,
+            sorted=False,
+        ).indices
+        capacity_map = torch.zeros_like(routing_map).scatter(0, capacity_indices, True)
+        routing_map = routing_map & capacity_map
+        routing_probs = routing_probs * routing_map
         return routing_map, routing_probs
 
     def _forward_local_cuda_graph_moe(
@@ -1394,7 +1431,20 @@ class GroupedExpertsTE(nn.Module):
         weights: torch.Tensor,
         indices: torch.Tensor,
     ) -> torch.Tensor:
-        """Run local dispatch, fixed-capacity TE experts, and combine at EP=1."""
+        """Run local fixed-capacity dispatch, TE experts, and combine at EP=1.
+
+        Capacity limiting may drop routed expert assignments when an expert receives
+        more than the configured fixed-capacity slots.
+
+        Args:
+            x: Tensor of shape [tokens, hidden] containing local source tokens.
+            token_mask: Tensor of shape [tokens] indicating valid source tokens.
+            weights: Tensor of shape [tokens, top_k] containing routing probabilities.
+            indices: Tensor of shape [tokens, top_k] containing global expert ids.
+
+        Returns:
+            Tensor of shape [tokens, hidden] containing the combined local MoE output.
+        """
         from transformer_engine.pytorch.quantization import FP8GlobalStateManager
 
         if FP8GlobalStateManager.is_fp8_enabled():
@@ -1403,7 +1453,7 @@ class GroupedExpertsTE(nn.Module):
             raise RuntimeError("Local MoE CUDA graph dispatch requires EP=1")
 
         capacity = self._cuda_graph_source_expert_capacity(x.size(0))
-        routing_map, routing_probs = self._local_drop_and_pad_metadata(token_mask, weights, indices)
+        routing_map, routing_probs = self._local_drop_and_pad_metadata(token_mask, weights, indices, capacity)
         num_permuted_tokens = capacity * self.num_local_experts
         permuted_hidden, permuted_probs, sorted_indices = permute(
             x,
@@ -1435,7 +1485,22 @@ class GroupedExpertsTE(nn.Module):
         weights: torch.Tensor,
         indices: torch.Tensor,
     ) -> torch.Tensor:
-        """Run fixed-capacity HybridEP dispatch, local TE experts, and combine."""
+        """Run fixed-capacity HybridEP dispatch, local TE experts, and combine.
+
+        Capacity limiting may drop routed expert assignments when an expert receives
+        more than the configured fixed-capacity slots. HybridEP capacity is fixed after the first graph-captured shape. A later
+        token-count change is fail-closed instead of falling back to dynamic eager
+        dispatch because replay requires the static receive shape to stay unchanged.
+
+        Args:
+            x: Tensor of shape [tokens, hidden] containing local source tokens.
+            token_mask: Tensor of shape [tokens] indicating valid source tokens.
+            weights: Tensor of shape [tokens, top_k] containing routing probabilities.
+            indices: Tensor of shape [tokens, top_k] containing global expert ids.
+
+        Returns:
+            Tensor of shape [tokens, hidden] containing the combined MoE output.
+        """
         from transformer_engine.pytorch.quantization import FP8GlobalStateManager
 
         if FP8GlobalStateManager.is_fp8_enabled():
@@ -1468,7 +1533,19 @@ class GroupedExpertsTE(nn.Module):
         *,
         tokens_per_local_expert: int,
     ) -> torch.Tensor:
-        """Execute TE GroupedLinear with an identical static split for each local expert."""
+        """Execute TE GroupedLinear with an identical static split per local expert.
+
+        Args:
+            hidden_states: Tensor of shape [num_local_experts * capacity, hidden]
+                containing tokens grouped contiguously by local expert.
+            permuted_probs: Tensor of shape [num_local_experts * capacity] containing
+                routing probabilities in the same grouped order as ``hidden_states``.
+            tokens_per_local_expert: Static number of rows assigned to every local expert.
+
+        Returns:
+            Tensor of shape [num_local_experts * capacity, hidden] containing expert outputs
+            in grouped local-expert order.
+        """
         permuted_probs = permuted_probs.unsqueeze(-1)
         splits = [tokens_per_local_expert] * self.num_local_experts
         output1 = self.gate_up_linear(hidden_states, splits)
@@ -1477,13 +1554,15 @@ class GroupedExpertsTE(nn.Module):
         if self.expert_bias:
             down_bias = self._get_stacked_bias(self.down_linear)
             if down_bias is not None:
-                split_tensor = torch.full(
-                    (self.num_local_experts,),
-                    tokens_per_local_expert,
-                    dtype=torch.int64,
-                    device=output2.device,
+                output_dtype = output2.dtype
+                output_shape = output2.shape
+                output2_by_expert = output2.reshape(self.num_local_experts, tokens_per_local_expert, output_shape[-1])
+                probs_by_expert = permuted_probs.reshape(self.num_local_experts, tokens_per_local_expert, 1)
+                output2 = (
+                    (output2_by_expert + down_bias[:, None, :] * (probs_by_expert - 1.0))
+                    .reshape(output_shape)
+                    .to(output_dtype)
                 )
-                output2 = _apply_bias(output2, down_bias, split_tensor, permuted_probs - 1.0)
         return output2
 
     def forward(
@@ -1497,20 +1576,20 @@ class GroupedExpertsTE(nn.Module):
         Forward pass using TE's GroupedLinear with native FP8 support.
 
         Args:
-            x: [num_tokens, model_dim] input tensor
-            token_mask: [num_tokens] boolean mask for valid tokens
-            weights: [num_tokens, num_activated_experts] routing weights
-            indices: [num_tokens, num_activated_experts] expert indices
+            x: Tensor of shape [tokens, hidden] containing local source tokens.
+            token_mask: Tensor of shape [tokens] indicating valid source tokens.
+            weights: Tensor of shape [tokens, top_k] containing routing probabilities.
+            indices: Tensor of shape [tokens, top_k] containing global expert ids.
 
         Returns:
-            [num_tokens, model_dim] output tensor
+            Tensor of shape [tokens, hidden] containing the combined MoE output.
         """
         assert not isinstance(x, DTensor), "Input should not be a DTensor"
         assert self.config.n_routed_experts % self.ep_size == 0, (
             f"Number of experts must be divisible by ep_size (ep_size={self.ep_size})"
         )
 
-        if self.cuda_graph_moe_capacity_factor is not None:
+        if self.cuda_graph_moe_enabled:
             if self.ep_size == 1:
                 return self._forward_local_cuda_graph_moe(x, token_mask, weights, indices)
             return self._forward_hybridep_cuda_graph_moe(x, token_mask, weights, indices)

--- a/nemo_automodel/components/moe/layers.py
+++ b/nemo_automodel/components/moe/layers.py
@@ -668,7 +668,24 @@ class MoE(nn.Module):
         else:
             self.gate = Gate(config, gate_precision=backend.gate_precision)
             self.gate.use_routing_core = "moe_router" in backend.cuda_graph.modules
-        if backend.dispatcher in ("deepep", "hybridep", "uccl_ep") and get_world_size_safe() == 1:
+        world_size = get_world_size_safe()
+        local_fixed_te_moe = (
+            backend.experts == "te"
+            and "moe" in backend.cuda_graph.modules
+            and (backend.dispatcher == "torch" or (backend.dispatcher == "hybridep" and world_size == 1))
+        )
+        if local_fixed_te_moe:
+            # EP=1 fixed-capacity execution uses local TE experts even when the
+            # surrounding transformer block is sharded over a data-parallel FSDP2 mesh.
+            self.experts = GroupedExpertsTE(
+                config,
+                backend=backend,
+                dispatcher_backend=backend.dispatcher,
+                dispatcher_num_sms=backend.dispatcher_num_sms,
+                dispatcher_share_token_dispatcher=backend.dispatcher_share_token_dispatcher,
+                dispatcher_async_dispatch=backend.dispatcher_async_dispatch,
+            )
+        elif backend.dispatcher in ("deepep", "hybridep", "uccl_ep") and world_size == 1:
             warnings.warn(
                 f"'{backend.dispatcher}' dispatcher is enabled in config, but world size is 1. "
                 "Expert parallelism requires multiple GPUs. Falling back to standard GroupedExperts.",

--- a/nemo_automodel/components/moe/layers.py
+++ b/nemo_automodel/components/moe/layers.py
@@ -218,7 +218,19 @@ class _GateRoutingCore(nn.Module):
     """
 
     def forward(self, scores: torch.Tensor, gate: "Gate") -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
-        """Select experts and compute routing probabilities from projected scores."""
+        """Select experts and compute routing probabilities from projected scores.
+
+        Args:
+            scores: Tensor of shape [tokens, num_experts] containing projected router logits.
+            gate: Owning gate whose routing policy is applied to ``scores``.
+
+        Returns:
+            Tuple containing:
+                - weights: Tensor of shape [tokens, top_k] containing selected-expert routing weights.
+                - indices: Tensor of shape [tokens, top_k] containing selected expert ids.
+                - original_scores: Tensor of shape [tokens, num_experts] containing the full expert scores used
+                  for load-balancing statistics.
+        """
         return gate._route_scores(scores)
 
 
@@ -309,7 +321,18 @@ class Gate(nn.Module):
         self.use_routing_core = False
 
     def _route_scores(self, scores: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
-        """Apply fixed-shape expert selection and probability math to router logits."""
+        """Apply fixed-shape expert selection and probability math to router logits.
+
+        Args:
+            scores: Tensor of shape [tokens, num_experts] containing projected router logits.
+
+        Returns:
+            Tuple containing:
+                - weights: Tensor of shape [tokens, top_k] containing selected-expert routing weights.
+                - indices: Tensor of shape [tokens, top_k] containing selected expert ids.
+                - original_scores: Tensor of shape [tokens, num_experts] containing the full expert scores used
+                  for load-balancing statistics.
+        """
         num_tokens = scores.size(0)
 
         if self.score_func == "softmax":

--- a/nemo_automodel/components/moe/megatron/token_dispatcher.py
+++ b/nemo_automodel/components/moe/megatron/token_dispatcher.py
@@ -336,12 +336,25 @@ class _HybridEPMetadataProcessor(nn.Module):
         if self.expert_capacity is not None and self.expert_capacity != expert_capacity:
             raise RuntimeError(
                 "HybridEP expert capacity changed after initialization: "
-                f"expected {self.expert_capacity}, got {expert_capacity}"
+                f"expected {self.expert_capacity}, got {expert_capacity}. "
+                "Fixed-capacity MoE CUDA graphs are fail-closed on dynamic token-count changes."
             )
         self.expert_capacity = expert_capacity
 
     def forward(self, token_indices: torch.Tensor, token_probs: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-        """Convert compact top-k indices and probabilities to multihot tensors."""
+        """Convert compact top-k metadata to dense HybridEP routing tensors.
+
+        Args:
+            token_indices: Tensor of shape [tokens, top_k] containing global expert ids, with
+                negative values indicating masked or dropped assignments.
+            token_probs: Tensor of shape [tokens, top_k] containing routing probabilities.
+
+        Returns:
+            Tuple containing:
+                - routing_map: Boolean tensor of shape [tokens, num_experts].
+                - multihot_probs: Tensor of shape [tokens, num_experts] retaining gradients
+                  to selected routing probabilities.
+        """
         if self.permute_fusion:
             routing_map, multihot_probs = fused_indices_to_multihot(token_indices, token_probs, self.num_experts)
         else:
@@ -437,7 +450,8 @@ class _HybridEPManager(_DispatchManager):
         if self.expert_capacity is not None and self.expert_capacity != expert_capacity:
             raise RuntimeError(
                 "HybridEP expert capacity changed after initialization: "
-                f"expected {self.expert_capacity}, got {expert_capacity}"
+                f"expected {self.expert_capacity}, got {expert_capacity}. "
+                "Fixed-capacity MoE CUDA graphs are fail-closed on dynamic token-count changes."
             )
         self.expert_capacity = expert_capacity
         ep_size = self.group.size()

--- a/nemo_automodel/components/moe/megatron/token_dispatcher.py
+++ b/nemo_automodel/components/moe/megatron/token_dispatcher.py
@@ -321,34 +321,66 @@ class _DeepepManager(_DispatchManager):
 
 
 class _HybridEPMetadataProcessor(nn.Module):
-    """Fixed-shape conversion from top-k metadata to HybridEP metadata."""
+    """Convert top-k metadata and optionally drop-and-pad it to fixed capacity."""
 
     def __init__(self, *, num_experts: int, permute_fusion: bool):
         super().__init__()
         self.num_experts = num_experts
         self.permute_fusion = permute_fusion
+        self.expert_capacity: Optional[int] = None
+
+    def set_expert_capacity(self, expert_capacity: int) -> None:
+        """Select exactly this many source-token slots for every global expert."""
+        if expert_capacity <= 0:
+            raise ValueError("HybridEP expert capacity must be positive")
+        if self.expert_capacity is not None and self.expert_capacity != expert_capacity:
+            raise RuntimeError(
+                "HybridEP expert capacity changed after initialization: "
+                f"expected {self.expert_capacity}, got {expert_capacity}"
+            )
+        self.expert_capacity = expert_capacity
 
     def forward(self, token_indices: torch.Tensor, token_probs: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         """Convert compact top-k indices and probabilities to multihot tensors."""
         if self.permute_fusion:
-            return fused_indices_to_multihot(token_indices, token_probs, self.num_experts)
+            routing_map, multihot_probs = fused_indices_to_multihot(token_indices, token_probs, self.num_experts)
+        else:
+            batch_size = token_indices.shape[0]
+            valid = (token_indices >= 0) & (token_indices < self.num_experts)
+            safe_indices = token_indices.clamp(min=0, max=self.num_experts - 1)
+            routing_counts = torch.zeros(
+                (batch_size, self.num_experts),
+                dtype=torch.int32,
+                device=token_indices.device,
+            ).scatter_add(1, safe_indices, valid.to(torch.int32))
+            routing_map = routing_counts > 0
+            multihot_probs = torch.zeros(
+                (batch_size, self.num_experts),
+                dtype=torch.float,
+                device=token_indices.device,
+            ).scatter_add(1, safe_indices, token_probs.float() * valid)
 
-        batch_size = token_indices.shape[0]
-        routing_map = torch.zeros(
-            (batch_size, self.num_experts),
-            dtype=torch.bool,
-            device=token_indices.device,
+        if self.expert_capacity is None:
+            return routing_map, multihot_probs
+
+        if self.expert_capacity > token_indices.shape[0]:
+            raise RuntimeError(
+                "HybridEP expert capacity cannot exceed the number of source tokens: "
+                f"capacity={self.expert_capacity}, tokens={token_indices.shape[0]}"
+            )
+
+        # Match Megatron's drop-and-pad contract: retain the highest-probability
+        # assignments and use zero-probability token slots to fill every expert to
+        # exactly the same source capacity. HybridEP can then allocate and dispatch a
+        # constant number of rows without a CPU synchronization.
+        _, capacity_indices = torch.topk(
+            multihot_probs,
+            k=self.expert_capacity,
+            dim=0,
+            sorted=False,
         )
-        multihot_probs = torch.zeros(
-            (batch_size, self.num_experts),
-            dtype=torch.float,
-            device=token_indices.device,
-        )
-        mask = token_indices != -1
-        valid_indices = token_indices[mask]
-        row_indices = torch.arange(batch_size, device=token_indices.device).repeat_interleave(mask.sum(dim=1))
-        routing_map[row_indices, valid_indices] = True
-        multihot_probs[row_indices, valid_indices] = token_probs[mask]
+        routing_map = torch.zeros_like(routing_map).scatter(0, capacity_indices, True)
+        multihot_probs = multihot_probs * routing_map
         return routing_map, multihot_probs
 
 
@@ -383,6 +415,7 @@ class _HybridEPManager(_DispatchManager):
         self.permute_fusion = permute_fusion
         self.moe_hybridep_num_sms = moe_hybridep_num_sms
         self.num_permuted_tokens = None
+        self.expert_capacity: Optional[int] = None
 
         # Metadata
         self.token_probs: Optional[torch.Tensor] = None
@@ -396,6 +429,24 @@ class _HybridEPManager(_DispatchManager):
                 "HybridEP is not installed. Please install HybridEP package from "
                 "https://github.com/deepseek-ai/DeepEP/tree/hybrid-ep."
             )
+
+    def set_expert_capacity(self, expert_capacity: int) -> None:
+        """Configure the fixed receive shape used by drop-and-pad routing."""
+        if expert_capacity <= 0:
+            raise ValueError("HybridEP expert capacity must be positive")
+        if self.expert_capacity is not None and self.expert_capacity != expert_capacity:
+            raise RuntimeError(
+                "HybridEP expert capacity changed after initialization: "
+                f"expected {self.expert_capacity}, got {expert_capacity}"
+            )
+        self.expert_capacity = expert_capacity
+        ep_size = self.group.size()
+        self.num_permuted_tokens = expert_capacity * ep_size * self.num_local_experts
+        self.tokens_per_expert = torch.full(
+            (self.num_local_experts,),
+            expert_capacity * ep_size,
+            dtype=torch.long,
+        )
 
     def setup_metadata(self, routing_map: torch.Tensor, probs: torch.Tensor):
         """Process routing map and probabilities to prepare dispatch metadata."""
@@ -438,9 +489,10 @@ class _HybridEPManager(_DispatchManager):
         async_finish: bool = True,  # noqa: ARG002 - not supported by HybridEP backend
         allocate_on_comm_stream: bool = True,  # noqa: ARG002 - not supported by HybridEP backend
     ) -> torch.Tensor:
-        # Reset num_permuted_tokens to None to avoid reusing cached state from a prior dispatch.
-        # This can happen in non-reentrant activation checkpointing mode.
-        self.num_permuted_tokens = None
+        # Dynamic routing must not reuse a prior receive size. Drop-and-pad routing
+        # deliberately preserves its statically configured receive size.
+        if self.expert_capacity is None:
+            self.num_permuted_tokens = None
         if self.token_probs.dtype != torch.float32:
             self.token_probs = self.token_probs.float()
         dispatched_hidden, self.dispatched_probs, _, tokens_per_expert, self.handle = hybrid_ep_dispatch(
@@ -455,8 +507,9 @@ class _HybridEPManager(_DispatchManager):
             pad_multiple=self.pad_multiple,
         )
 
-        self.tokens_per_expert = tokens_per_expert
-        self.num_permuted_tokens = self.tokens_per_expert.sum()
+        if self.expert_capacity is None:
+            self.tokens_per_expert = tokens_per_expert
+            self.num_permuted_tokens = self.tokens_per_expert.sum()
 
         return dispatched_hidden
 
@@ -473,7 +526,8 @@ class _HybridEPManager(_DispatchManager):
             pad_multiple=self.pad_multiple,
         )
         self.handle = None
-        self.num_permuted_tokens = None
+        if self.expert_capacity is None:
+            self.num_permuted_tokens = None
         return hidden_states
 
     def get_dispatched_metadata(self) -> torch.Tensor:
@@ -653,6 +707,13 @@ class MoEFlexTokenDispatcher:
             raise ValueError(
                 f"Invalid backend: {backend}. Please set moe_flex_dispatcher_backend='deepep', 'hybridep', or 'uccl_ep'"
             )
+
+    def set_cuda_graph_expert_capacity(self, expert_capacity: int) -> None:
+        """Configure fixed-capacity HybridEP metadata and communication shapes."""
+        if not isinstance(self._comm_manager, _HybridEPManager) or self.hybridep_metadata_processor is None:
+            raise RuntimeError("Full MoE CUDA graphs with EP>1 require the HybridEP dispatcher")
+        self.hybridep_metadata_processor.set_expert_capacity(expert_capacity)
+        self._comm_manager.set_expert_capacity(expert_capacity)
 
     def _initialize_metadata(self, num_local_tokens: int, probs: torch.Tensor) -> torch.Tensor:
         """

--- a/tests/unit_tests/components/cuda_graphs/test_partial.py
+++ b/tests/unit_tests/components/cuda_graphs/test_partial.py
@@ -204,6 +204,26 @@ def test_full_moe_scope_uses_explicit_parameters(monkeypatch):
     manager.close()
 
 
+def test_full_moe_scope_uses_the_fsdp_block_as_capture_owner(monkeypatch):
+    class _FSDPBlock(nn.Module):
+        pass
+
+    monkeypatch.setattr(torch.distributed.fsdp, "FSDPModule", _FSDPBlock)
+    owner = _FSDPBlock()
+    target = _MoeExecution()
+    block = partial_graphs._DiscoveredBlock(
+        name="test.layers.0",
+        module=owner,
+        capture_owner=owner,
+        moe=None,
+        is_mtp=False,
+    )
+
+    entry = partial_graphs._build_moe_execution_entry(block, target, False)
+
+    assert entry.capture_owner is owner
+
+
 def test_explicit_parameter_adapter_matches_eager_forward_and_backward():
     torch.manual_seed(123)
     eager_target = _Attention()

--- a/tests/unit_tests/components/cuda_graphs/test_partial.py
+++ b/tests/unit_tests/components/cuda_graphs/test_partial.py
@@ -224,6 +224,24 @@ def test_full_moe_scope_uses_the_fsdp_block_as_capture_owner(monkeypatch):
     assert entry.capture_owner is owner
 
 
+def test_full_moe_scope_rejects_nested_fsdp_expert_owner(monkeypatch):
+    class _FakeFSDPModule(nn.Module):
+        pass
+
+    monkeypatch.setattr(torch.distributed.fsdp, "FSDPModule", _FakeFSDPModule)
+    target = _FakeFSDPModule()
+    block = partial_graphs._DiscoveredBlock(
+        name="model.layers.0",
+        module=nn.Module(),
+        capture_owner=_FakeFSDPModule(),
+        moe=nn.Module(),
+        is_mtp=False,
+    )
+
+    with pytest.raises(RuntimeError, match="nested FSDP expert sharding"):
+        partial_graphs._build_moe_execution_entry(block, target, False)
+
+
 def test_explicit_parameter_adapter_matches_eager_forward_and_backward():
     torch.manual_seed(123)
     eager_target = _Attention()

--- a/tests/unit_tests/components/cuda_graphs/test_partial.py
+++ b/tests/unit_tests/components/cuda_graphs/test_partial.py
@@ -19,6 +19,7 @@ import torch
 from torch import nn
 
 import nemo_automodel.components.cuda_graphs.partial as partial_graphs
+from nemo_automodel.components.moe.experts import GroupedExpertsTE
 
 
 class _RouterCore(nn.Module):
@@ -53,18 +54,28 @@ class _Attention(nn.Module):
         return self.o_proj(self.attn_module.fused_attention(self.q_proj(hidden_states)))
 
 
+class _MoeExecution(GroupedExpertsTE):
+    def __init__(self):
+        nn.Module.__init__(self)
+        self.weight = nn.Parameter(torch.eye(4))
+        self.token_dispatcher = SimpleNamespace(hybridep_metadata_processor=_Preprocess())
+
+    def forward(self, hidden_states, token_mask, weights, indices):
+        del token_mask, weights, indices
+        return hidden_states @ self.weight
+
+
 class _Layer(nn.Module):
     def __init__(self):
         super().__init__()
         self.self_attn = _Attention()
         self.mlp = nn.Module()
         self.mlp.gate = _Router()
-        self.mlp.experts = nn.Module()
-        self.mlp.experts.token_dispatcher = SimpleNamespace(hybridep_metadata_processor=_Preprocess())
+        self.mlp.experts = _MoeExecution()
 
 
 class _Model(nn.Module):
-    def __init__(self, *, te_dpa=True, attention=False, router=True, preprocess=True, layer_count=1):
+    def __init__(self, *, te_dpa=True, attention=False, moe=False, router=True, preprocess=True, layer_count=1):
         super().__init__()
         self.config = SimpleNamespace(model_type="test_moe")
         cuda_graph_modules = []
@@ -72,6 +83,8 @@ class _Model(nn.Module):
             cuda_graph_modules.append("te_dpa")
         if attention:
             cuda_graph_modules.append("attn")
+        if moe:
+            cuda_graph_modules.append("moe")
         if router:
             cuda_graph_modules.append("moe_router")
         if preprocess:
@@ -158,6 +171,36 @@ def test_whole_attention_scope_uses_explicit_parameters_on_single_device(monkeyp
     assert entry.explicit_parameters is True
     assert len(captured_sample_args) == 1
     assert len(captured_sample_args[0][0]) == 3
+    manager.close()
+
+
+def test_full_moe_scope_uses_explicit_parameters(monkeypatch):
+    captured_sample_args = []
+
+    def make_graphed_callables(modules, sample_args, **kwargs):
+        captured_sample_args.append(sample_args)
+        assert kwargs["retain_graph_in_backward"] is True
+        for module in modules:
+            module.reset = lambda: None
+        return modules
+
+    monkeypatch.setattr(partial_graphs, "_get_make_graphed_callables", lambda: make_graphed_callables)
+    model = _Model(te_dpa=False, moe=True, router=False, preprocess=False)
+    manager = partial_graphs.PartialCudaGraphManager.from_model_parts([model])
+    assert manager is not None
+    entry = manager.entries[0]
+    model.model.layers["0"].mlp.experts(
+        torch.ones(2, 4),
+        torch.ones(2, dtype=torch.bool),
+        torch.ones(2, 2),
+        torch.zeros(2, 2, dtype=torch.long),
+    )
+
+    manager.capture()
+
+    assert entry.name == "test_moe.layers.0.moe"
+    assert entry.explicit_parameters is True
+    assert len(captured_sample_args[0][0]) == 5
     manager.close()
 
 
@@ -441,6 +484,12 @@ def test_rejects_router_and_preprocess_with_activation_checkpointing():
 def test_rejects_whole_attention_with_activation_checkpointing():
     model = _Model(te_dpa=False, attention=True, router=False, preprocess=False)
     with pytest.raises(RuntimeError, match="Whole-attention CUDA graphs do not support activation checkpointing"):
+        partial_graphs.PartialCudaGraphManager.from_model_parts([model], activation_checkpointing=True)
+
+
+def test_rejects_full_moe_with_activation_checkpointing():
+    model = _Model(te_dpa=False, moe=True, router=False, preprocess=False)
+    with pytest.raises(RuntimeError, match="Full MoE CUDA graphs do not support activation checkpointing"):
         partial_graphs.PartialCudaGraphManager.from_model_parts([model], activation_checkpointing=True)
 
 

--- a/tests/unit_tests/moe/test_backend_config.py
+++ b/tests/unit_tests/moe/test_backend_config.py
@@ -101,6 +101,92 @@ class TestBackendConfigExpertsDispatcherValidation:
         assert config.experts == "torch_mm"
         assert config.dispatcher == "deepep"
 
+    def test_local_te_experts_are_valid_for_full_moe_graph(self):
+        config = BackendConfig(
+            experts="te",
+            dispatcher="torch",
+            cuda_graph=CudaGraphConfig(modules=["moe"], moe_capacity_factor=1.25),
+        )
+
+        assert config.experts == "te"
+        assert config.dispatcher == "torch"
+
+    def test_hybridep_te_experts_are_valid_for_full_moe_graph(self):
+        config = BackendConfig(
+            experts="te",
+            dispatcher="hybridep",
+            cuda_graph=CudaGraphConfig(modules=["moe"], moe_capacity_factor=1.25),
+        )
+
+        assert config.experts == "te"
+        assert config.dispatcher == "hybridep"
+
+    def test_combined_attention_and_moe_graphs_are_valid(self):
+        config = BackendConfig(
+            attn="te",
+            linear="torch",
+            rms_norm="torch",
+            rope_fusion=False,
+            experts="te",
+            dispatcher="torch",
+            cuda_graph=CudaGraphConfig(modules=["attn", "moe"], moe_capacity_factor=1.0),
+        )
+
+        assert config.cuda_graph.modules == ["attn", "moe"]
+
+    def test_full_moe_graph_rejects_legacy_deepep(self):
+        with pytest.raises(ValueError, match="requires dispatcher='torch' or 'hybridep'"):
+            BackendConfig(
+                experts="te",
+                dispatcher="deepep",
+                cuda_graph=CudaGraphConfig(modules=["moe"], moe_capacity_factor=1.0),
+            )
+
+    def test_full_moe_graph_requires_capacity(self):
+        with pytest.raises(ValueError, match=r"requires cuda_graph\.moe_capacity_factor"):
+            BackendConfig(experts="te", dispatcher="torch", cuda_graph=CudaGraphConfig(modules=["moe"]))
+
+    def test_capacity_factor_requires_full_moe_graph(self):
+        with pytest.raises(ValueError, match=r"requires 'moe' in cuda_graph\.modules"):
+            BackendConfig(
+                experts="te",
+                dispatcher="torch",
+                cuda_graph=CudaGraphConfig(moe_capacity_factor=1.0),
+            )
+
+    def test_full_moe_graph_requires_te_experts(self):
+        with pytest.raises(ValueError, match="requires experts='te'"):
+            BackendConfig(
+                experts="torch_mm",
+                dispatcher="torch",
+                cuda_graph=CudaGraphConfig(modules=["moe"], moe_capacity_factor=1.0),
+            )
+
+    def test_full_moe_graph_rejects_split_moe_scopes(self):
+        with pytest.raises(ValueError, match="cannot be combined"):
+            BackendConfig(
+                experts="te",
+                dispatcher="hybridep",
+                cuda_graph=CudaGraphConfig(modules=["moe", "moe_router"], moe_capacity_factor=1.0),
+            )
+
+    def test_full_moe_graph_capacity_must_be_positive(self):
+        with pytest.raises(ValueError, match="must be positive"):
+            BackendConfig(
+                experts="te",
+                dispatcher="torch",
+                cuda_graph=CudaGraphConfig(modules=["moe"], moe_capacity_factor=0.0),
+            )
+
+    @pytest.mark.parametrize("capacity_factor", [float("nan"), float("inf"), -float("inf")])
+    def test_full_moe_graph_capacity_must_be_finite(self, capacity_factor):
+        with pytest.raises(ValueError, match="positive and finite"):
+            BackendConfig(
+                experts="te",
+                dispatcher="torch",
+                cuda_graph=CudaGraphConfig(modules=["moe"], moe_capacity_factor=capacity_factor),
+            )
+
 
 class TestBackendConfigFakeGateNoise:
     """Test BackendConfig fake_gate_noise field."""

--- a/tests/unit_tests/moe/test_backend_config.py
+++ b/tests/unit_tests/moe/test_backend_config.py
@@ -187,7 +187,6 @@ class TestBackendConfigExpertsDispatcherValidation:
                 cuda_graph=CudaGraphConfig(modules=["moe"], moe_capacity_factor=capacity_factor),
             )
 
-
 class TestBackendConfigFakeGateNoise:
     """Test BackendConfig fake_gate_noise field."""
 

--- a/tests/unit_tests/moe/test_experts.py
+++ b/tests/unit_tests/moe/test_experts.py
@@ -27,6 +27,7 @@ from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.experts import (
     GroupedExperts,
     GroupedExpertsDeepEP,
+    GroupedExpertsTE,
     _apply_bias,
     _permute_tokens_for_grouped_mm,
     _torch_mm_experts_fwd,
@@ -1035,6 +1036,42 @@ class TestNonGatedActivations:
             swiglu_config.n_routed_experts,
             swiglu_config.dim,
             swiglu_config.moe_inter_dim * 2,
+        )
+
+
+class TestGroupedExpertsTECudaGraphMetadata:
+    def _make_experts(self, config, capacity_factor=1.0):
+        experts = GroupedExpertsTE.__new__(GroupedExpertsTE)
+        torch.nn.Module.__init__(experts)
+        experts.config = config
+        experts.cuda_graph_moe_capacity_factor = capacity_factor
+        return experts
+
+    def test_capacity_is_derived_from_fixed_input_shape(self, moe_config):
+        experts = self._make_experts(moe_config, capacity_factor=1.25)
+
+        assert experts._cuda_graph_source_expert_capacity(16) == 5
+
+    def test_capacity_rejects_more_slots_than_source_tokens(self, moe_config):
+        experts = self._make_experts(moe_config, capacity_factor=5.0)
+
+        with pytest.raises(RuntimeError, match="must be in"):
+            experts._cuda_graph_source_expert_capacity(2)
+
+    def test_local_metadata_masks_padding_and_preserves_weight_gradients(self, moe_config):
+        experts = self._make_experts(moe_config)
+        token_mask = torch.tensor([True, False, True])
+        indices = torch.tensor([[0, 2], [1, 3], [2, 4]])
+        weights = torch.tensor([[0.6, 0.4], [0.7, 0.3], [0.8, 0.2]], requires_grad=True)
+
+        routing_map, routing_probs = experts._local_drop_and_pad_metadata(token_mask, weights, indices)
+
+        assert routing_map.nonzero().tolist() == [[0, 0], [0, 2], [2, 2], [2, 4]]
+        torch.testing.assert_close(routing_probs.sum(), torch.tensor(2.0))
+        routing_probs.sum().backward()
+        torch.testing.assert_close(
+            weights.grad,
+            torch.tensor([[1.0, 1.0], [0.0, 0.0], [1.0, 1.0]]),
         )
 
 

--- a/tests/unit_tests/moe/test_experts.py
+++ b/tests/unit_tests/moe/test_experts.py
@@ -1047,6 +1047,25 @@ class TestGroupedExpertsTECudaGraphMetadata:
         experts.cuda_graph_moe_capacity_factor = capacity_factor
         return experts
 
+    class _FakeGroupedLinear(torch.nn.Module):
+        def __init__(self, biases=None):
+            super().__init__()
+            self.use_bias = biases is not None
+            self.num_gemms = len(biases) if biases is not None else 0
+            if biases is not None:
+                for index, bias in enumerate(biases):
+                    self.register_parameter(f"bias{index}", torch.nn.Parameter(bias.clone()))
+
+        def forward(self, hidden_states, splits):
+            chunks = torch.split(hidden_states, splits)
+            outputs = []
+            for index, chunk in enumerate(chunks):
+                if self.use_bias:
+                    outputs.append(chunk + getattr(self, f"bias{index}"))
+                else:
+                    outputs.append(chunk)
+            return torch.cat(outputs)
+
     def test_capacity_is_derived_from_fixed_input_shape(self, moe_config):
         experts = self._make_experts(moe_config, capacity_factor=1.25)
 
@@ -1064,7 +1083,7 @@ class TestGroupedExpertsTECudaGraphMetadata:
         indices = torch.tensor([[0, 2], [1, 3], [2, 4]])
         weights = torch.tensor([[0.6, 0.4], [0.7, 0.3], [0.8, 0.2]], requires_grad=True)
 
-        routing_map, routing_probs = experts._local_drop_and_pad_metadata(token_mask, weights, indices)
+        routing_map, routing_probs = experts._local_drop_and_pad_metadata(token_mask, weights, indices, capacity=3)
 
         assert routing_map.nonzero().tolist() == [[0, 0], [0, 2], [2, 2], [2, 4]]
         torch.testing.assert_close(routing_probs.sum(), torch.tensor(2.0))
@@ -1073,6 +1092,62 @@ class TestGroupedExpertsTECudaGraphMetadata:
             weights.grad,
             torch.tensor([[1.0, 1.0], [0.0, 0.0], [1.0, 1.0]]),
         )
+
+    def test_local_metadata_keeps_highest_probability_assignments(self, moe_config):
+        experts = self._make_experts(moe_config)
+        token_mask = torch.ones(4, dtype=torch.bool)
+        indices = torch.zeros((4, 1), dtype=torch.long)
+        weights = torch.tensor([[0.1], [0.9], [0.8], [0.2]], requires_grad=True)
+
+        routing_map, routing_probs = experts._local_drop_and_pad_metadata(
+            token_mask,
+            weights,
+            indices,
+            capacity=2,
+        )
+
+        assert routing_map[:, 0].tolist() == [False, True, True, False]
+        torch.testing.assert_close(routing_probs[:, 0], torch.tensor([0.0, 0.9, 0.8, 0.0]))
+        routing_probs.sum().backward()
+        torch.testing.assert_close(weights.grad, torch.tensor([[0.0], [1.0], [1.0], [0.0]]))
+
+    def test_fixed_capacity_down_bias_is_weighted_without_split_tensor(self, moe_config):
+        experts = self._make_experts(moe_config)
+        experts.num_local_experts = 2
+        experts.expert_bias = True
+        experts.gate_up_linear = self._FakeGroupedLinear()
+        experts.down_linear = self._FakeGroupedLinear(
+            biases=[
+                torch.tensor([10.0, 20.0]),
+                torch.tensor([30.0, 40.0]),
+            ]
+        )
+        experts.expert_activation = lambda output, _probs: output
+        hidden_states = torch.tensor(
+            [
+                [1.0, 2.0],
+                [3.0, 4.0],
+                [5.0, 6.0],
+                [7.0, 8.0],
+            ]
+        )
+        permuted_probs = torch.tensor([0.25, 0.5, 0.75, 1.0])
+
+        output = experts._forward_fixed_capacity_te_experts(
+            hidden_states,
+            permuted_probs,
+            tokens_per_local_expert=2,
+        )
+
+        expected = torch.tensor(
+            [
+                [3.5, 7.0],
+                [8.0, 14.0],
+                [27.5, 36.0],
+                [37.0, 48.0],
+            ]
+        )
+        torch.testing.assert_close(output, expected)
 
 
 @pytest.mark.skipif(SKIP_TE_TESTS, reason="TransformerEngine and CUDA required")

--- a/tests/unit_tests/moe/test_layers.py
+++ b/tests/unit_tests/moe/test_layers.py
@@ -19,7 +19,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.models.common import BackendConfig, CudaGraphConfig
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.experts import (
     GroupedExperts,
@@ -1304,6 +1304,23 @@ class TestMoE:
 
         assert isinstance(moe.gate, Gate)
         assert isinstance(moe.experts, GroupedExperts)
+
+    def test_ep1_fixed_te_experts_are_kept_under_multi_rank_fsdp(self, moe_config):
+        backend = BackendConfig(
+            experts="te",
+            dispatcher="torch",
+            cuda_graph=CudaGraphConfig(modules=["moe"], moe_capacity_factor=1.0),
+        )
+        fixed_te_experts = torch.nn.Identity()
+        with patch(
+            "nemo_automodel.components.moe.layers.GroupedExpertsTE",
+            return_value=fixed_te_experts,
+        ) as grouped_experts_te:
+            with patch("nemo_automodel.components.moe.layers.get_world_size_safe", return_value=2):
+                moe = MoE(moe_config, backend)
+
+        assert moe.experts is fixed_te_experts
+        grouped_experts_te.assert_called_once()
 
     @pytest.mark.skipif(SKIP_TE_TESTS, reason="TransformerEngine and CUDA required")
     def test_moe_init_with_deepep_multi_device(self, moe_config, backend_config):

--- a/tests/unit_tests/moe/test_layers.py
+++ b/tests/unit_tests/moe/test_layers.py
@@ -1322,6 +1322,23 @@ class TestMoE:
         assert moe.experts is fixed_te_experts
         grouped_experts_te.assert_called_once()
 
+    def test_ep1_hybridep_moe_graph_keeps_local_te_experts(self, moe_config):
+        backend = BackendConfig(
+            experts="te",
+            dispatcher="hybridep",
+            cuda_graph=CudaGraphConfig(modules=["moe"], moe_capacity_factor=1.0),
+        )
+        fixed_te_experts = torch.nn.Identity()
+        with patch(
+            "nemo_automodel.components.moe.layers.GroupedExpertsTE",
+            return_value=fixed_te_experts,
+        ) as grouped_experts_te:
+            with patch("nemo_automodel.components.moe.layers.get_world_size_safe", return_value=1):
+                moe = MoE(moe_config, backend)
+
+        assert moe.experts is fixed_te_experts
+        grouped_experts_te.assert_called_once()
+
     @pytest.mark.skipif(SKIP_TE_TESTS, reason="TransformerEngine and CUDA required")
     def test_moe_init_with_deepep_multi_device(self, moe_config, backend_config):
         """DeepEP dispatcher enabled and world size > 1 should use GroupedExpertsTE."""

--- a/tests/unit_tests/moe/test_token_dispatcher.py
+++ b/tests/unit_tests/moe/test_token_dispatcher.py
@@ -135,6 +135,13 @@ class TestHybridEPFixedCapacity:
             torch.tensor([[1.0, 1.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]),
         )
 
+    def test_metadata_capacity_change_fails_closed(self):
+        processor = _HybridEPMetadataProcessor(num_experts=3, permute_fusion=False)
+        processor.set_expert_capacity(2)
+
+        with pytest.raises(RuntimeError, match="fail-closed"):
+            processor.set_expert_capacity(3)
+
     def test_manager_keeps_static_receive_shape_through_dispatch_and_combine(self):
         group = Mock()
         group.size.return_value = 2
@@ -172,3 +179,19 @@ class TestHybridEPFixedCapacity:
         assert combine_calls[0]["num_permuted_tokens"] == 8
         assert manager.num_permuted_tokens == 8
         torch.testing.assert_close(manager.tokens_per_expert, torch.tensor([4, 4]))
+
+    def test_manager_capacity_change_fails_closed(self):
+        group = Mock()
+        group.size.return_value = 2
+
+        with patch("nemo_automodel.components.moe.megatron.token_dispatcher.hybrid_ep_dispatch", lambda *a, **kw: None):
+            manager = _HybridEPManager(
+                group=group,
+                num_local_experts=2,
+                num_experts=4,
+                router_topk=2,
+            )
+            manager.set_expert_capacity(2)
+
+        with pytest.raises(RuntimeError, match="fail-closed"):
+            manager.set_expert_capacity(3)

--- a/tests/unit_tests/moe/test_token_dispatcher.py
+++ b/tests/unit_tests/moe/test_token_dispatcher.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 import torch
@@ -109,3 +109,66 @@ class TestIndicesToMultihot:
         assert routing_map.shape == (1, 8)
         assert routing_map.sum() == 2
         assert routing_map[0, 0] and routing_map[0, 7]
+
+
+class TestHybridEPFixedCapacity:
+    def test_metadata_drops_and_pads_every_expert_to_capacity(self):
+        processor = _HybridEPMetadataProcessor(num_experts=3, permute_fusion=False)
+        processor.set_expert_capacity(2)
+        indices = torch.tensor([[0, 1], [0, 2], [0, 2], [1, 2]])
+        probs = torch.tensor(
+            [[0.9, 0.1], [0.8, 0.2], [0.3, 0.7], [0.6, 0.4]],
+            requires_grad=True,
+        )
+
+        routing_map, routing_probs = processor(indices, probs)
+
+        torch.testing.assert_close(routing_map.sum(dim=0), torch.full((3,), 2))
+        assert routing_map[:, 0].tolist() == [True, True, False, False]
+        assert routing_map[:, 1].tolist() == [True, False, False, True]
+        assert routing_map[:, 2].tolist() == [False, False, True, True]
+        torch.testing.assert_close(routing_probs.sum(dim=0), torch.tensor([1.7, 0.7, 1.1]))
+
+        routing_probs.sum().backward()
+        torch.testing.assert_close(
+            probs.grad,
+            torch.tensor([[1.0, 1.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]),
+        )
+
+    def test_manager_keeps_static_receive_shape_through_dispatch_and_combine(self):
+        group = Mock()
+        group.size.return_value = 2
+        dispatch_calls = []
+        combine_calls = []
+
+        def fake_dispatch(**kwargs):
+            dispatch_calls.append(kwargs)
+            rows = kwargs["num_permuted_tokens"]
+            hidden = kwargs["x"].new_zeros((rows, kwargs["x"].shape[-1]))
+            probs = kwargs["probs"].new_zeros((rows,))
+            return hidden, probs, None, torch.tensor([3, 5]), ("handle",)
+
+        def fake_combine(**kwargs):
+            combine_calls.append(kwargs)
+            return kwargs["x"]
+
+        with (
+            patch("nemo_automodel.components.moe.megatron.token_dispatcher.hybrid_ep_dispatch", fake_dispatch),
+            patch("nemo_automodel.components.moe.megatron.token_dispatcher.hybrid_ep_combine", fake_combine),
+        ):
+            manager = _HybridEPManager(
+                group=group,
+                num_local_experts=2,
+                num_experts=4,
+                router_topk=2,
+            )
+            manager.set_expert_capacity(2)
+            manager.routing_map = torch.ones(4, 4, dtype=torch.bool)
+            manager.token_probs = torch.ones(4, 4)
+            dispatched = manager.dispatch(torch.ones(4, 8))
+            manager.combine(dispatched)
+
+        assert dispatch_calls[0]["num_permuted_tokens"] == 8
+        assert combine_calls[0]["num_permuted_tokens"] == 8
+        assert manager.num_permuted_tokens == 8
+        torch.testing.assert_close(manager.tokens_per_expert, torch.tensor([4, 4]))


### PR DESCRIPTION
# What does this PR do ?

Adds a fixed-capacity `moe` CUDA Graph scope on top of #2917. The captured boundary starts after routing and includes token dispatch, local Transformer Engine `GroupedLinear` experts, and token combine. Attention and MoE scopes can be enabled together with `cuda_graph_modules: [attn, moe]` under FSDP2.

This is part of #1027. It is built on #2917, whose scoped partial-capture implementation credits @hemildesai as co-author.

Stack note: #2943 is the follow-up for shared graph-pool memory. Transactional capture rollback now lives in the #2917 base, so this PR no longer relies on #2943 for failure cleanup.

# Changelog

- Add `cuda_graph_modules: [moe]` and `cuda_graph_moe_capacity_factor` configuration.
- Support EP=1 with local drop-and-pad permutation, fixed TE expert splits, and local unpermutation, including multi-rank FSDP2 jobs.
- Support EP>1 through HybridEP with Megatron-style per-expert drop-and-pad routing.
- Set the static HybridEP receive size to `source_capacity * ep_size * num_local_experts`, avoiding `tokens_per_expert.sum()` and its host synchronization.
- Pass attention and TE expert parameters as explicit graph inputs and guard replay with the existing tensor/control contract checks.
- Unshard the owning FSDP2 transformer block while capturing attention or MoE, then replay with the live materialized parameters inside the block pre-forward lifecycle.
- Keep BF16, activation checkpointing, dynamic shapes, and unsupported dispatcher combinations fail-closed.
- Gate fixed-capacity TE MoE execution on `cuda_graph_modules: [moe]`; setting `cuda_graph_moe_capacity_factor` alone is rejected.
- Avoid CUDA tensor `.tolist()` in the fixed-capacity down-bias path.
- Clarify that HybridEP capacity changes are fail-closed and that capacity limiting may drop routed assignments.

# Design notes

For `N` source tokens, top-k `K`, `E` global experts, and capacity factor `F`, source capacity is:

`ceil(N * K * F / E)`

Every source rank selects exactly that many token slots for every global expert. Real assignments are selected by routing probability; unused slots have zero routing probability. Therefore every local expert receives exactly `source_capacity * ep_size` rows and TE receives constant `m_splits`.

This follows the Megatron Core `moe_pad_expert_input_to_capacity` / HybridEP path. Legacy DeepEP remains rejected: its current dispatch path waits on dynamic communication metadata on the CPU, and padding only after dispatch cannot make capture safe. A DeepEP v2 static-buffer integration would be separate work.

# CUDA experiments

## Combined-scope attribution

Tiny Qwen3-MoE, 2 layers, hidden size 512, 8 experts, top-2, BF16, sequence length 512, local/global batch size 2/4, FSDP2 over 2 H100s. Timing is 8 measured forward/backward/Adam steps after 4 warmup steps.

| Scope | Iteration | Latency vs eager | Throughput vs eager | Peak allocated | Graph stats |
|---|---:|---:|---:|---:|---:|
| eager | 27.072 ms | - | - | 0.35 GB | - |
| `attn` | 24.882 ms | -8.1% | +8.8% | 0.53 GB | captured=2, replayed=22, fallback=0 |
| `moe` | 23.702 ms | -12.4% | +14.2% | 0.40 GB | captured=2, replayed=22, fallback=0 |
| `attn, moe` | 20.920 ms | -22.7% | +29.4% | 0.60 GB | captured=4, replayed=44, fallback=0 |

All four modes report the same 12-step loss sequence. This tiny-model run is useful for attribution, but launch overhead is overrepresented.

These numbers compare dynamic eager routing with fixed-capacity graph execution. They therefore include both CUDA Graph launch savings and the change to capacity-limited drop-and-pad work; they are not a pure graph-on/graph-off attribution. Capacity limiting may drop routed assignments when an expert exceeds its configured slots.

## Qwen3-30B-A3B low-load sanity check

`Qwen/Qwen3-30B-A3B`, 48 layers, BF16, sequence length 1024, local/global batch size 1/8, FSDP2 + EP8 HybridEP over 8 H100s, real learned router, 25 forward/backward/Adam steps with 5 warmup steps. The order was eager 1, graph 1, graph 2, eager 2. Setup, TE compilation, and graph capture are excluded from steady-state iteration timing.

| Mode | Run 1 | Run 2 | Mean | Mean MFU | Peak allocated |
|---|---:|---:|---:|---:|---:|
| eager | 457.622 ms | 455.914 ms | 456.768 ms | 4.39% | 32.56 GB |
| `attn, moe` | 304.391 ms | 300.639 ms | 302.515 ms | 6.63% | 53.53 GB |

Mean latency decreases by 33.8%; equivalent training throughput increases by 51.0%. Each graph run captured all 96 entries (attention + MoE for 48 layers), replayed 2,304 calls, and had zero fallback. This is a deliberately underloaded launch-overhead result (4.39% eager MFU), not a production-throughput claim.

The memory cost is material: +20.97 GB/GPU in this configuration. Capture is also a one-time startup cost and is not included in the steady-state speedup.

For a controlled replay parity check, the same 30B configuration was run with `lr=0` for 6 steps. Eager and graph produced the same reported loss on every step: `10.3457, 10.3424, 10.3292, 10.3191, 10.3709, 10.3198`. The graph run captured 96 entries, replayed 480 calls, and had zero fallback. With nonzero learning rate, repeated distributed HybridEP/BF16 runs are not bitwise deterministic, so the controlled no-update run is the forward/replay parity check.

## Existing-recipe scaling check

The repository H100 recipe uses local batch 4, sequence length 4096, TE projections/norm/RoPE, DeepEP, and activation checkpointing. It cannot be used as a pure graph-on/graph-off comparison yet: whole-attention graph currently requires torch projections, torch RMSNorm, and unfused RoPE; full MoE graph requires HybridEP and rejects activation checkpointing.

Using the closest currently supported backend on 8 H100-80GB GPUs (`linear: torch`, `rms_norm: torch`, `rope_fusion: false`, TE attention/experts, HybridEP, FSDP2 + EP8), the doubled-batch result is:

| Scope | Local batch x sequence | Iteration | Latency vs eager | Throughput vs eager | Peak allocated | Graph stats |
|---|---:|---:|---:|---:|---:|---:|
| eager | 2 x 1024 | 481.675 ms | - | - | 39.00 GB | - |
| `attn` | 2 x 1024 | 441.681 ms | -8.3% | +9.1% | 45.50 GB | captured=48, replayed=672, fallback=0 |
| `moe` | 2 x 1024 | 405.294 ms | -15.9% | +18.9% | 54.00 GB | captured=48, replayed=672, fallback=0 |
| `attn, moe` | 2 x 1024 | OOM during capture | - | - | 75.43 GiB process usage | failed at layer 45 MoE |

At local batch 2 x sequence 2048, eager runs at 539.834 ms (15.80% MFU, 53.61 GB), but combined capture OOMs earlier at layer 27 attention with 75.37 GiB process usage. At 2 x 1024, combined capture reaches layer 45 before OOM. This identifies cumulative graph-pool memory across 96 per-layer entries as the immediate scaling blocker. Both 48-entry single scopes fit and replay without fallback.

# Validation

- `uv run ruff format .`
- `uv run ruff check --fix .`
- `uv run pytest -q tests/unit_tests/moe tests/unit_tests/recipes/test_partial_cuda_graphs.py`
  - 539 passed, 54 skipped.
- Slurm job 5579217: 2-H100 FSDP2 eager/attention/MoE/combined attribution.
- Slurm job 5579222: 8-H100 Qwen3-30B-A3B symmetric repeated E2E benchmark.
- Slurm job 5579279: 8-H100 Qwen3-30B-A3B controlled `lr=0` replay parity.
- Slurm jobs 5579426 and 5579467: recipe-derived combined-capture memory scaling at 2 x 2048 and 2 x 1024.
- Slurm job 5579620: recipe-derived attention-only and MoE-only attribution at 2 x 1024.

# Known limitations

- Fixed input shape and explicit opt-in only.
- BF16 TE experts only; FP8 is rejected.
- Activation checkpointing and pipeline parallelism are rejected for the full MoE scope.
- Legacy DeepEP is not graph-safe and is rejected; EP>1 currently requires HybridEP.
- Whole-attention graph currently requires torch projections, torch RMSNorm, and unfused RoPE, while the existing H100 recipe uses the TE variants.
- The Qwen3-30B run validates FSDP2 for the transformer blocks and EP8 distribution for experts. Additional FSDP sharding of each rank's local expert weights (`ep_shard > 1`) is not validated.
- CUDA Graph pools increase persistent GPU memory; the 30B combined run used 53.53 GB/GPU versus 32.56 GB/GPU eager.
- Combined attention + MoE capture does not fit at local batch 2 even with sequence length 1024 on H100-80GB; graph-pool sharing/reuse is required before matching existing recipe operating points. Follow-up #2943 addresses this with shared-pool capture and transactional cleanup.

# Before your PR is "Ready for review"

- [x] Read and followed contributor guidelines.
- [x] Added unit coverage for config, capacity/drop-and-pad metadata, static HybridEP sizing, combined scopes, and FSDP2 graph lifecycle.
- [ ] Add user documentation after the API and supported matrix are agreed.

# Additional Information

- Based on #2917
- Related to #1027


