### PR TITLE
fix(glm): select HybridEP for GLM-5.2 recipes

### DIFF
--- a/examples/llm_finetune/glm/glm_5.2_hellaswag_pp.yaml
+++ b/examples/llm_finetune/glm/glm_5.2_hellaswag_pp.yaml
@@ -51,7 +51,7 @@ model:
     linear: te
     rms_norm: torch_fp32
     rope_fusion: false
-    enable_deepep: true
+    dispatcher: hybridep
     gate_precision: float32  # match HF/DeepSeek-V3 fp32 router; stabilizes top-k routing
     fake_balanced_gate: false
     enable_hf_state_dict_adapter: true

--- a/examples/llm_finetune/glm/glm_5.2_tulu3_32k_tilelang_cp8.yaml
+++ b/examples/llm_finetune/glm/glm_5.2_tulu3_32k_tilelang_cp8.yaml
@@ -64,7 +64,7 @@ model:
     linear: torch
     rms_norm: torch_fp32
     rope_fusion: false
-    enable_deepep: true
+    dispatcher: hybridep
     gate_precision: float32
     fake_balanced_gate: false
     enable_hf_state_dict_adapter: true

--- a/examples/llm_finetune/glm/glm_5.2_tulu3_4k_tilelang_100k.yaml
+++ b/examples/llm_finetune/glm/glm_5.2_tulu3_4k_tilelang_100k.yaml
@@ -62,7 +62,7 @@ model:
     linear: torch
     rms_norm: torch_fp32
     rope_fusion: false
-    enable_deepep: true
+    dispatcher: hybridep
     gate_precision: float32
     fake_balanced_gate: false
     enable_hf_state_dict_adapter: true


### PR DESCRIPTION
# What does this PR do ?

Explicitly select HybridEP in all GLM-5.2 finetuning recipes.

## Root cause

`enable_deepep` is no longer a supported backend option. In the 2606 runtime, leaving the dispatcher unset can select DeepEP when it is installed. The full CP1/PP4/EP64 GLM-5.2 run then failed before step 0 in `deep_ep.buffer.internode_dispatch` with:

```text
RuntimeError: DeepEP error: timeout (dispatch CPU)
```

## Fix

Replace `enable_deepep: true` with `dispatcher: hybridep` in:

- `examples/llm_finetune/glm/glm_5.2_hellaswag_pp.yaml`
- `examples/llm_finetune/glm/glm_5.2_tulu3_32k_tilelang_cp8.yaml`
- `examples/llm_finetune/glm/glm_5.2_tulu3_4k_tilelang_100k.yaml`

This makes the intended dispatcher explicit instead of relying on environment-dependent backend selection.

# Changelog

- Configure the GLM-5.2 HellaSwag PP recipe to use HybridEP.
- Configure the GLM-5.2 Tulu3 32K CP8 TileLang recipe to use HybridEP.
- Configure the GLM-5.2 Tulu3 4K TileLang recipe to use HybridEP.

# Test plan

- [x] `python3 tools/lint_example_yamls.py examples/llm_finetune/glm/glm_5.2_hellaswag_pp.yaml examples/llm_finetune/glm/glm_5.2_tulu3_32k_tilelang_cp8.yaml examples/llm_finetune/glm/glm_5.2_tulu3_4k_tilelang_100k.yaml`
- [x] `pytest -q tests/unit_tests/moe/test_backend_config.py` - 51 passed
- [x] [GLM-5.2 Tulu3 4K CP1/PP4/EP64 HybridEP validation](https://wandb.ai/Nemo-automodel/huiyingl_workspace/runs/pssq9x60) - healthy through step 25/100 and past the prior pre-step-0 DeepEP failure point; the full run is still in progress

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines
- [x] Existing backend configuration tests cover explicit HybridEP selection
- [x] Documentation changes are not required; this updates shipped recipes
