### PR TITLE
fix(bagel): make non-backbone init topology independent

### DIFF
--- a/nemo_automodel/components/models/bagel/hf_backbone_loader.py
+++ b/nemo_automodel/components/models/bagel/hf_backbone_loader.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import gc
 import json
 import logging
+import math
 import pathlib
 from typing import Any, Dict
 
@@ -150,23 +151,19 @@ def _load_siglip_backbone_into_bagel(model, vit_path: str) -> None:
     gc.collect()
 
 
-def initialize_bagel_non_backbone_weights(model: torch.nn.Module) -> None:
-    """Initialize BAGEL-owned modules not loaded from Qwen/SigLIP checkpoints."""
+def initialize_bagel_non_backbone_weights(model: torch.nn.Module, *, seed: int) -> None:
+    """Initialize BAGEL-owned modules from one logical, topology-independent RNG stream."""
     from nemo_automodel.components.models.bagel.embeddings import _get_2d_sincos_pos_embed
 
     bagel = model.model
+    generator = torch.Generator(device="cpu")
+    generator.manual_seed(seed)
 
-    def _reset_linear(module: torch.nn.Module) -> None:
-        if isinstance(module, torch.nn.Linear):
-            module.reset_parameters()
+    def _copy_full_tensor(parameter: torch.nn.Parameter, value: torch.Tensor) -> None:
+        from torch.distributed.tensor import DTensor, distribute_tensor
 
-    def _init_position_embedding(module: torch.nn.Module) -> None:
-        pos_embed = _get_2d_sincos_pos_embed(module.hidden_size, module.max_num_patch_per_side)
-        value = torch.from_numpy(pos_embed).to(dtype=module.pos_embed.dtype)
-        param_data = module.pos_embed.data
-        if type(param_data).__name__ == "DTensor":
-            from torch.distributed.tensor import distribute_tensor
-
+        param_data = parameter.data
+        if isinstance(param_data, DTensor):
             value = distribute_tensor(
                 value,
                 device_mesh=param_data.device_mesh,
@@ -176,11 +173,30 @@ def initialize_bagel_non_backbone_weights(model: torch.nn.Module) -> None:
             value = value.to(device=param_data.device)
         param_data.copy_(value)
 
+    def _reset_linear(module: torch.nn.Module) -> None:
+        if not isinstance(module, torch.nn.Linear):
+            return
+
+        weight = torch.empty(tuple(module.weight.shape), dtype=module.weight.dtype, device="cpu")
+        torch.nn.init.kaiming_uniform_(weight, a=math.sqrt(5), generator=generator)
+        _copy_full_tensor(module.weight, weight)
+        if module.bias is not None:
+            fan_in, _ = torch.nn.init._calculate_fan_in_and_fan_out(weight)
+            bound = 1 / math.sqrt(fan_in) if fan_in > 0 else 0
+            bias = torch.empty(tuple(module.bias.shape), dtype=module.bias.dtype, device="cpu")
+            torch.nn.init.uniform_(bias, -bound, bound, generator=generator)
+            _copy_full_tensor(module.bias, bias)
+
+    def _init_position_embedding(module: torch.nn.Module) -> None:
+        pos_embed = _get_2d_sincos_pos_embed(module.hidden_size, module.max_num_patch_per_side)
+        value = torch.from_numpy(pos_embed).to(dtype=module.pos_embed.dtype)
+        _copy_full_tensor(module.pos_embed, value)
+
     with torch.no_grad():
         if getattr(model.config, "visual_gen", False):
             bagel.time_embedder.apply(_reset_linear)
-            bagel.vae2llm.reset_parameters()
-            bagel.llm2vae.reset_parameters()
+            bagel.vae2llm.apply(_reset_linear)
+            bagel.llm2vae.apply(_reset_linear)
             _init_position_embedding(bagel.latent_pos_embed)
 
         if getattr(model.config, "visual_und", False):

--- a/nemo_automodel/recipes/multimodal/finetune.py
+++ b/nemo_automodel/recipes/multimodal/finetune.py
@@ -336,6 +336,7 @@ class FinetuneRecipeForMultimodal(BaseRecipe):
         artifact_path: str | None,
         stage: int,
         rank_seed: int,
+        init_seed: int,
         freeze_before_infrastructure: bool = False,
     ):
         """Build BAGEL from HF backbones and apply the configured infrastructure."""
@@ -388,7 +389,7 @@ class FinetuneRecipeForMultimodal(BaseRecipe):
                 load_base_model=False,
                 freeze_config=freeze_cfg.to_dict() if freeze_cfg is not None else None,
             )
-            initialize_bagel_non_backbone_weights(model)
+            initialize_bagel_non_backbone_weights(model, seed=init_seed)
             load_bagel_hf_backbone_weights(model, self.cfg.model)
         return model
 
@@ -438,7 +439,8 @@ class FinetuneRecipeForMultimodal(BaseRecipe):
             raise NotImplementedError("Pipeline parallelism is not supported for FinetuneRecipeForMultimodal.")
 
         # -- RNG ----------------------------------------------------------
-        # BAGEL uses a ranked seed: seed = global_seed * world_size + rank.
+        # Runtime RNG is ranked: seed = global_seed * world_size + rank.
+        # BAGEL-owned model weights use global_seed below so initialization is topology independent.
         # PackedDataset applies its own worker reseed at iter-time.
         self.global_seed = int(self.cfg.get("seed", 4396))
         self.data_seed = int(self.cfg.get("dataset.data_seed", 42))
@@ -510,6 +512,7 @@ class FinetuneRecipeForMultimodal(BaseRecipe):
                 artifact_path=artifact_path,
                 stage=stage,
                 rank_seed=rank_seed,
+                init_seed=self.global_seed,
             )
         elif model_init_mode == "auto":
             from nemo_automodel.recipes.vlm.finetune import build_model as build_vlm_model
@@ -551,6 +554,7 @@ class FinetuneRecipeForMultimodal(BaseRecipe):
                     artifact_path=artifact_path,
                     stage=stage,
                     rank_seed=rank_seed,
+                    init_seed=self.global_seed,
                     freeze_before_infrastructure=True,
                 )
                 _maybe_resize_bagel_vocab(

--- a/tests/unit_tests/models/bagel/test_hf_backbone_loader.py
+++ b/tests/unit_tests/models/bagel/test_hf_backbone_loader.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+from torch import nn
+
+from nemo_automodel.components.models.bagel.hf_backbone_loader import initialize_bagel_non_backbone_weights
+
+
+class _PositionEmbedding(nn.Module):
+    def __init__(self, hidden_size: int = 8, max_num_patch_per_side: int = 2) -> None:
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.max_num_patch_per_side = max_num_patch_per_side
+        self.pos_embed = nn.Parameter(
+            torch.empty(max_num_patch_per_side**2, hidden_size),
+            requires_grad=False,
+        )
+
+
+class _BagelOwnedModules(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.time_embedder = nn.Sequential(nn.Linear(3, 8), nn.SiLU(), nn.Linear(8, 8))
+        self.vae2llm = nn.Linear(4, 8)
+        self.llm2vae = nn.Linear(8, 4)
+        self.latent_pos_embed = _PositionEmbedding()
+        self.connector = nn.Sequential(nn.Linear(6, 8), nn.GELU(), nn.Linear(8, 8))
+        self.vit_pos_embed = _PositionEmbedding()
+
+
+class _BagelModel(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.model = _BagelOwnedModules()
+        self.config = SimpleNamespace(visual_gen=True, visual_und=True)
+
+
+def test_non_backbone_initialization_is_seeded_and_does_not_advance_global_rng() -> None:
+    torch.manual_seed(1)
+    first = _BagelModel()
+    torch.manual_seed(2)
+    second = _BagelModel()
+
+    torch.manual_seed(123)
+    expected_next = torch.rand(4)
+    torch.manual_seed(123)
+    initialize_bagel_non_backbone_weights(first, seed=4396)
+    actual_next = torch.rand(4)
+    initialize_bagel_non_backbone_weights(second, seed=4396)
+
+    assert torch.equal(actual_next, expected_next)
+    for name, first_parameter in first.named_parameters():
+        assert torch.equal(first_parameter, dict(second.named_parameters())[name])
+    assert torch.count_nonzero(first.model.llm2vae.weight) == 0
+    assert torch.count_nonzero(first.model.llm2vae.bias) == 0
+
+
+def test_non_backbone_initialization_changes_with_seed() -> None:
+    first = _BagelModel()
+    second = _BagelModel()
+
+    initialize_bagel_non_backbone_weights(first, seed=1)
+    initialize_bagel_non_backbone_weights(second, seed=2)
+
+    assert not torch.equal(first.model.connector[0].weight, second.model.connector[0].weight)
+
+
+def test_non_backbone_initialization_supports_dtensor_parameters() -> None:
+    import torch.distributed as dist
+    from torch.distributed.device_mesh import init_device_mesh
+    from torch.distributed.tensor import DTensor, Shard, distribute_tensor
+
+    started_process_group = False
+    if not dist.is_initialized():
+        dist.init_process_group("gloo", store=dist.HashStore(), rank=0, world_size=1)
+        started_process_group = True
+
+    try:
+        mesh = init_device_mesh("cpu", (1,), mesh_dim_names=("dp",))
+        reference = _BagelModel()
+        sharded = _BagelModel()
+        for module in sharded.modules():
+            for name, parameter in list(module.named_parameters(recurse=False)):
+                distributed = distribute_tensor(parameter.detach(), mesh, [Shard(0)])
+                setattr(module, name, nn.Parameter(distributed, requires_grad=parameter.requires_grad))
+
+        initialize_bagel_non_backbone_weights(reference, seed=4396)
+        initialize_bagel_non_backbone_weights(sharded, seed=4396)
+
+        reference_parameters = dict(reference.named_parameters())
+        for name, parameter in sharded.named_parameters():
+            assert isinstance(parameter, DTensor)
+            assert torch.equal(parameter.full_tensor(), reference_parameters[name])
+    finally:
+        if started_process_group:
+            dist.destroy_process_group()


### PR DESCRIPTION


# What does this PR do ?

Make initialization of BAGEL-owned modules topology-independent for the `hf_backbones` initialization path.

  Previously, these parameters were initialized after FSDP sharding using rank-specific RNG state, so their values depended on world size and sharding topology. This PR initializes each logical parameter from a dedicated CPU generator seeded with the recipe's global seed, then distributes it into the existing DTensor layout.

  Rank-local runtime RNG remains unchanged. This adds initialization-time work only and introduces no per-step or per-microbatch overhead.
