### PR TITLE
fix(transformers): gate _tie_weights_nemo on tie_word_embeddings flag

### DIFF
--- a/nemo_automodel/_transformers/model_init.py
+++ b/nemo_automodel/_transformers/model_init.py
@@ -995,6 +995,15 @@ def _tie_weights_nemo(model):
     if not hasattr(model, "_nemo_tied_weights_keys"):
         return
 
+    # Only re-tie when the controlling config flag actually requests tied
+    # embeddings. ``_nemo_tied_weights_keys`` names the *candidate* tied keys
+    # (pre-v5 list-form ``_tied_weights_keys`` semantics); it does not mean the
+    # model is tied. Re-tying an untied model here would alias away the trained
+    # ``lm_head.weight`` that ``from_pretrained`` just loaded (see #2941).
+    config = getattr(model, "config", None)
+    if config is not None and not checkpoint_utils.get_controlling_tie_word_embeddings(config, type(model).__name__):
+        return
+
     def get_module_by_fqn(model, fqn):
         from functools import reduce
 

--- a/tests/unit_tests/_transformers/test_model_init.py
+++ b/tests/unit_tests/_transformers/test_model_init.py
@@ -703,3 +703,85 @@ class TestTryGetRemoteCodeModelCls:
         cfg.auto_map = {"AutoModelForCausalLM": "modeling.MyModel"}
         result = _try_get_remote_code_model_cls(cfg, "/some/path", "AutoModelForCausalLM", {})
         assert result is None
+
+
+class TestTieWeightsNemoConfigGate:
+    """_tie_weights_nemo must honor the controlling tie_word_embeddings flag (#2941).
+
+    ``_nemo_tied_weights_keys`` names the candidate tied keys (pre-v5 list-form
+    ``_tied_weights_keys`` semantics); it does not mean the model is tied.
+    Re-tying an untied model aliases away the trained ``lm_head.weight`` that
+    ``from_pretrained`` just loaded.
+    """
+
+    @staticmethod
+    def _make_model(tie: bool | None) -> nn.Module:
+        from transformers import PretrainedConfig
+
+        class _TinyModel(nn.Module):
+            _nemo_tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
+
+            def __init__(self):
+                super().__init__()
+                self.model = nn.Module()
+                self.model.embed_tokens = nn.Embedding(10, 4)
+                self.lm_head = nn.Linear(4, 10, bias=False)
+
+        model = _TinyModel()
+        if tie is not None:
+            model.config = PretrainedConfig(tie_word_embeddings=tie)
+        return model
+
+    def test_untied_config_keeps_separate_lm_head(self):
+        """tie_word_embeddings=False: the loaded lm_head must not be aliased away."""
+        from nemo_automodel._transformers.model_init import _tie_weights_nemo
+
+        model = self._make_model(tie=False)
+        lm_head_before = model.lm_head.weight.detach().clone()
+
+        _tie_weights_nemo(model)
+
+        assert model.lm_head.weight is not model.model.embed_tokens.weight
+        assert model.lm_head.weight.data_ptr() != model.model.embed_tokens.weight.data_ptr()
+        torch.testing.assert_close(model.lm_head.weight, lm_head_before)
+
+    def test_tied_config_reties(self):
+        """tie_word_embeddings=True: keep the #1817 re-tie behavior."""
+        from nemo_automodel._transformers.model_init import _tie_weights_nemo
+
+        model = self._make_model(tie=True)
+        _tie_weights_nemo(model)
+
+        assert model.lm_head.weight is model.model.embed_tokens.weight
+
+    def test_missing_config_still_reties(self):
+        """No config attribute: fall back to the conservative #1817 re-tie."""
+        from nemo_automodel._transformers.model_init import _tie_weights_nemo
+
+        model = self._make_model(tie=None)
+        _tie_weights_nemo(model)
+
+        assert model.lm_head.weight is model.model.embed_tokens.weight
+
+    def test_untied_state_dict_roundtrip_is_lossless(self):
+        """Resume scenario: distinct lm_head/embed weights must survive construct-then-load.
+
+        Before the fix, construction aliased both params to one storage, so
+        ``load_state_dict`` wrote both checkpoint tensors into the same memory
+        (last writer wins) — corrupting embeddings and/or head on resume.
+        """
+        from nemo_automodel._transformers.model_init import _tie_weights_nemo
+
+        source = self._make_model(tie=False)
+        with torch.no_grad():
+            source.model.embed_tokens.weight.uniform_(-1.0, 1.0)
+            source.lm_head.weight.uniform_(-1.0, 1.0)
+        checkpoint = {k: v.detach().clone() for k, v in source.state_dict().items()}
+
+        resumed = self._make_model(tie=False)
+        _tie_weights_nemo(resumed)  # runs at the end of _init_model, before checkpoint load
+        resumed.load_state_dict(checkpoint)
+
+        torch.testing.assert_close(resumed.lm_head.weight, checkpoint["lm_head.weight"])
+        torch.testing.assert_close(resumed.model.embed_tokens.weight, checkpoint["model.embed_tokens.weight"])
+        assert resumed.lm_head.weight.data_ptr() != resumed.model.embed_tokens.weight.data_ptr()


### PR DESCRIPTION
# What does this PR do ?

Fixes #2941: `_tie_weights_nemo` re-tied `lm_head.weight` to the input embeddings for any model exposing
`_nemo_tied_weights_keys`, without consulting the controlling `config.tie_word_embeddings` flag.
`_nemo_tied_weights_keys` records candidate tied keys from pre-v5/list-form `_tied_weights_keys`; it does not prove
that the checkpoint is actually tied.

Impact is real for shipped untied remote-code force-HF recipes. Confirmed affected:

- `examples/llm_finetune/nemotron/nemotron_nano_4b_squad.yaml`
- `examples/llm_finetune/nemotron/nemotron_nano_9b_squad.yaml`
- `examples/llm_finetune/nemotron/nemotron_nano_9b_squad_peft.yaml`

Those recipes load Nemotron Nano 4B/9B through `trust_remote_code: true` + `force_hf: true`. The hub configs set
`tie_word_embeddings=False`, the checkpoints contain separate trained `lm_head.weight` and
`backbone.embeddings.weight`, and the recipe compatibility patch converts remote list-form
`_tied_weights_keys = ["lm_head.weight"]` into `_nemo_tied_weights_keys`. Before this PR, `_tie_weights_nemo` then
forced an alias and discarded the trained head.

The fix gates the re-tie on the canonical `get_controlling_tie_word_embeddings` resolver. Tied models, such as the
Nemotron-Flash case #1817 was written for, keep the existing re-tie behavior unchanged. Models without a `config`
attribute conservatively fall back to re-tying.

## Before / after

**Real recipe-path source load: `nvidia/NVIDIA-Nemotron-Nano-9B-v2`.**

Using the same recipe condition that exposes the bug (`apply_cache_compatibility_patches()` + `trust_remote_code=True`
+ `force_hf=True`), compare a raw HF source load against a NeMoAuto source load on a seeded 128-token prompt:

| branch | `lm_head` aliased? | max abs diff vs HF | mean abs diff vs HF | cosine |
|---|---:|---:|---:|---:|
| main | `true` | `22.5625` | `2.9893` | `-0.0224` |
| this PR | `false` | `0.25` | `0.0141` | about `1.000` |

This is the silent manifestation: the model loads successfully, but logits diverge from the raw HF reference immediately
on main because the trained untied `lm_head` is aliased away.

**Unit/mechanism coverage.**

The regression tests fail on main and pass on this branch:

- `test_untied_config_keeps_separate_lm_head`
- `test_untied_state_dict_roundtrip_is_lossless`
- `test_tied_config_reties`
- `test_missing_config_still_reties`

Targeted result on this branch: `4 passed`.

**Resume smoke note.**

A real 9B FSDP2 DCP recipe resume smoke was also run. This PR produced a checkpoint at step 3, then main and this PR
both resumed one step from that same checkpoint. Both resumed step 4 at `loss=0.466808`.

That result means the DCP checkpoint resume path was correct in this smoke. It does not cover the bug fixed here: on
main, the model is already wrong immediately after the initial NeMoAuto source load, before any training checkpoint is
saved or resumed. This is also why the current checkpoint robustness test can miss the issue: it captures reference
logits from the already-loaded NeMo model, then validates checkpoint reloads against that reference. We should add a
separate source-load parity check that compares raw HF source load vs NeMoAuto source load before training starts.

# Changelog

- `_tie_weights_nemo` now returns early when the controlling `tie_word_embeddings` flag is `False`, preserving
  separately loaded `lm_head.weight` for untied models.
- Added `TestTieWeightsNemoConfigGate` regression tests: untied preservation, tied re-tie, missing-config fallback, and
  lossless construct-then-load round-trip.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed the [Contributor
      Guide](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md).
- [x] Did you write any new necessary tests?
  - `tests/unit_tests/_transformers/test_model_init.py::TestTieWeightsNemoConfigGate`
- [x] Did you add or update any necessary documentation?
  - No public API change.
- [x] Does this PR introduce a breaking change?
  - No. This restores the checkpoint-config contract for untied models and preserves tied behavior.

# Additional Information
* Related to #2935 but intentionally kept as a minimal correctness fix instead of refactoring the full tie-weight
  pipeline.
* Introduced by the #1817-era workaround for pre-v5/list-form `_tied_weights_keys`. That workaround is still needed for
  tied remote-code models; this PR only adds the missing config gate for untied checkpoints.
* Existing checkpoint robustness coverage does not exercise this exact source-load failure. It captures reference logits
  from the already-constructed NeMo model, then compares checkpoint reloads against that reference. If the source load is
  already corrupted, the corrupted model can become the baseline. We should add an opt-in raw-HF-source vs
  NeMoAuto-source parity check for remote-code/force-HF recipes.
