### PR TITLE
perf(cuda-graphs): share partial capture pools

### DIFF
--- a/nemo_automodel/components/cuda_graphs/partial.py
+++ b/nemo_automodel/components/cuda_graphs/partial.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import enum
 import logging
 from collections.abc import Callable, Iterator, Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any
 
@@ -484,6 +485,7 @@ class _PartialGraphEntry:
         self.captured_call: _CapturedCall | None = None
         self._captured_call_variants: list[_CapturedCall] = []
         self._adapters: tuple[nn.Module, ...] = ()
+        self._replay_forward: Callable[..., Any] | None = None
 
         # Runtime statistics.
         self.capture_count = 0
@@ -554,6 +556,7 @@ class _PartialGraphEntry:
             del reset
 
         self._adapters = ()
+        self._replay_forward = None
         self.captured_call = None
         self._captured_call_variants.clear()
         self._captured_training = None
@@ -682,7 +685,24 @@ class _PartialGraphEntry:
                 self._logged_fallback = True
             return self.original_forward(*args, **kwargs)
 
-        self.target.forward = dispatch
+        self._replay_forward = dispatch
+        self.target.forward = self._replay_forward
+
+    def suspend_replay(self) -> None:
+        """Route this entry through its original eager forward without destroying graphs."""
+        if self._closed:
+            raise RuntimeError(f"Partial CUDA graph entry {self.name!r} is closed")
+        if self._adapters:
+            self.target.forward = self.original_forward
+
+    def resume_replay(self) -> None:
+        """Restore graph dispatch after a manager-wide eager region."""
+        if self._closed:
+            raise RuntimeError(f"Partial CUDA graph entry {self.name!r} is closed")
+        if self._adapters:
+            if self._replay_forward is None:
+                raise RuntimeError(f"Partial CUDA graph entry {self.name!r} has no replay forward")
+            self.target.forward = self._replay_forward
 
 
 def _canonicalize_bf16_fused_attention(
@@ -985,6 +1005,7 @@ class PartialCudaGraphManager:
         self.entries = entries
         self._captured = False
         self._closed = False
+        self._eager_execution_depth = 0
 
     @classmethod
     def from_model_parts(
@@ -1079,6 +1100,30 @@ class PartialCudaGraphManager:
             raise RuntimeError("Partial CUDA graph manager is closed")
         for entry in self.entries:
             entry.start_recording()
+
+    @contextmanager
+    def eager_execution(self) -> Iterator[None]:
+        """Temporarily disable every graph entry as one pooled execution unit.
+
+        Pooled entries cannot fall back independently because doing so would
+        violate the shared private-pool execution order. Validation changes
+        module training mode and runs forward without backward, so the entire
+        manager must execute eagerly for that region.
+        """
+        if self._closed:
+            raise RuntimeError("Partial CUDA graph manager is closed")
+        outermost = self._eager_execution_depth == 0
+        if outermost:
+            for entry in self.entries:
+                entry.suspend_replay()
+        self._eager_execution_depth += 1
+        try:
+            yield
+        finally:
+            self._eager_execution_depth -= 1
+            if outermost and not self._closed:
+                for entry in self.entries:
+                    entry.resume_replay()
 
     def capture(self) -> None:
         """Batch-capture all observed targets in real forward order."""

--- a/nemo_automodel/components/cuda_graphs/partial.py
+++ b/nemo_automodel/components/cuda_graphs/partial.py
@@ -1002,10 +1002,21 @@ class PartialCudaGraphManager:
         ]
         if not enabled_parts:
             return None
-        if pipeline_parallel or len(model_parts) != 1:
+        # Pipeline schedules can run multiple microbatches through the same local
+        # stage before the earlier microbatch has completed backward. The current
+        # partial graph contract owns one static input/output surface per target,
+        # and #2943 additionally shares graph-private pools across layers in a
+        # scope. That combination has not been validated against PP or virtual PP
+        # chunk interleaving, so reject it before any target installs graph hooks.
+        if pipeline_parallel:
             raise RuntimeError(
-                "Partial CUDA graphs require one non-pipeline model root; pipeline stages and virtual "
-                "pipeline chunks can overwrite static graph buffers with in-flight microbatches"
+                "Partial CUDA graphs do not support pipeline parallelism yet; PP schedules can interleave "
+                "microbatches and overwrite static CUDA graph buffers before backward consumes them"
+            )
+        if len(model_parts) != 1:
+            raise RuntimeError(
+                "Partial CUDA graphs require one local model part; virtual pipeline chunks can interleave "
+                "microbatches and overwrite static CUDA graph buffers before backward consumes them"
             )
         if activation_checkpointing:
             if any("attn" in part.backend.cuda_graph.modules for part in enabled_parts):

--- a/nemo_automodel/components/cuda_graphs/partial.py
+++ b/nemo_automodel/components/cuda_graphs/partial.py
@@ -38,6 +38,66 @@ logger = logging.getLogger(__name__)
 _Canonicalizer = Callable[[tuple[Any, ...], dict[str, Any]], tuple[tuple[Any, ...], dict[str, Any]]]
 
 
+@dataclass(frozen=True)
+class _CudaMemoryState:
+    """CUDA allocator usage split between normal and graph-private pools."""
+
+    normal_allocated: int
+    normal_reserved: int
+    private_allocated: int
+    private_reserved: int
+
+
+def _cuda_memory_state() -> _CudaMemoryState | None:
+    """Read allocator state without making CUDA a module-import requirement."""
+    if not torch.cuda.is_available():
+        return None
+
+    allocated = torch.cuda.memory_allocated()
+    reserved = torch.cuda.memory_reserved()
+    private_allocated = 0
+    private_reserved = 0
+    for segment in torch.cuda.memory_snapshot():
+        pool_id = segment.get("segment_pool_id")
+        if pool_id is None or pool_id == (0, 0) or pool_id == [0, 0]:
+            continue
+        private_allocated += int(segment.get("allocated_size", 0))
+        private_reserved += int(segment.get("total_size", 0))
+    return _CudaMemoryState(
+        normal_allocated=max(0, allocated - private_allocated),
+        normal_reserved=max(0, reserved - private_reserved),
+        private_allocated=private_allocated,
+        private_reserved=private_reserved,
+    )
+
+
+def _format_memory_state(state: _CudaMemoryState | None) -> str:
+    """Format allocator bytes as a stable one-line diagnostic."""
+    if state is None:
+        return "unavailable"
+    mib = 1024 * 1024
+    return (
+        f"normal_allocated={state.normal_allocated / mib:.2f}MiB "
+        f"normal_reserved={state.normal_reserved / mib:.2f}MiB "
+        f"private_allocated={state.private_allocated / mib:.2f}MiB "
+        f"private_reserved={state.private_reserved / mib:.2f}MiB"
+    )
+
+
+def _tensor_bytes(tensors: Sequence[torch.Tensor]) -> int:
+    """Return storage bytes for a tensor surface, counting aliases once."""
+    seen: set[tuple[torch.device, int]] = set()
+    total = 0
+    for tensor in tensors:
+        storage = tensor.untyped_storage()
+        storage_key = (tensor.device, storage.data_ptr())
+        if storage_key in seen:
+            continue
+        seen.add(storage_key)
+        total += storage.nbytes()
+    return total
+
+
 def _get_make_graphed_callables() -> Callable[..., Any]:
     """Load Transformer Engine's graph helper only when the feature is enabled."""
     has_te, _transformer_engine = safe_import_te()
@@ -311,10 +371,17 @@ class _ExplicitParameterCallAdapter(nn.Module):
                     f"{name!r} is {type(parameter).__name__}"
                 )
             _require_local_parameter_storage(name, parameter)
-            clone = parameter.detach().clone(memory_format=torch.preserve_format)
-            clone.requires_grad_(parameter.requires_grad)
-            capture_parameters.append(clone)
+            # Always use a fresh leaf, even when the target is not FSDP-owned.
+            # Persistent model Parameters may already own AccumulateGrad nodes
+            # created on the eager stream; capturing those nodes can make TE's
+            # backward graph depend on the wrong stream. TE directly uses this
+            # clone as its static input, so this is one staging allocation rather
+            # than a clone followed by a second TE-owned parameter copy.
+            capture_parameter = parameter.detach().clone(memory_format=torch.preserve_format)
+            capture_parameter.requires_grad_(parameter.requires_grad)
+            capture_parameters.append(capture_parameter)
         self.capture_parameters = tuple(capture_parameters)
+        self.cloned_parameter_bytes = _tensor_bytes(self.capture_parameters)
 
     def parameters(self, recurse: bool = True) -> Iterator[nn.Parameter]:
         """Hide the registered target parameters from TE module-parameter discovery."""
@@ -394,6 +461,7 @@ class _PartialGraphEntry:
         name: str,
         target: nn.Module,
         canonicalizer: _Canonicalizer | None = None,
+        pool_group: str | None = None,
         capture_input_variants: int = 1,
         explicit_parameters: bool = False,
         capture_owner: nn.Module | None = None,
@@ -403,6 +471,7 @@ class _PartialGraphEntry:
         self.name = name
         self.target = target
         self.canonicalizer = canonicalizer
+        self.pool_group = pool_group or name
         if capture_input_variants <= 0:
             raise ValueError("capture_input_variants must be positive")
         self.capture_input_variants = capture_input_variants
@@ -538,7 +607,12 @@ class _PartialGraphEntry:
             finally:
                 self._capture_owner_unsharded = False
 
-    def install(self, graphed_adapter: nn.Module | Sequence[nn.Module]) -> None:
+    def install(
+        self,
+        graphed_adapter: nn.Module | Sequence[nn.Module],
+        *,
+        allow_eager_fallback: bool = True,
+    ) -> None:
         """Install validated graph replay around the original target forward."""
         if self._closed:
             raise RuntimeError(f"Partial CUDA graph entry {self.name!r} is closed")
@@ -596,6 +670,11 @@ class _PartialGraphEntry:
                     logger.info("Partial CUDA graph replay active for %s", self.name)
                     self._logged_replay = True
                 return adapters[variant_index](*tensors)
+
+            if not allow_eager_fallback:
+                raise RuntimeError(
+                    f"Partial CUDA graph pooled entry {self.name!r} cannot fall back independently: {reason}"
+                )
 
             self.fallback_count += 1
             if not self._logged_fallback:
@@ -744,6 +823,7 @@ def _build_whole_attention_entry(
     return _PartialGraphEntry(
         name=f"{block.name}.attention",
         target=target,
+        pool_group="attn",
         capture_input_variants=1,
         # PyTorch parameters are explicit inputs even without FSDP. Letting TE
         # discover them as static module state can keep AccumulateGrad nodes on
@@ -766,6 +846,7 @@ def _build_te_dpa_entry(
     return _PartialGraphEntry(
         name=f"{block.name}.fused_attention",
         target=target,
+        pool_group="te_dpa",
         canonicalizer=_canonicalize_bf16_fused_attention,
         # Reentrant checkpointing invokes attention once under no-grad and once
         # under grad-enabled recompute. Each contract needs its own TE graph
@@ -785,7 +866,7 @@ def _build_moe_router_entry(
     if getattr(gate, "router_replay", None) is not None or getattr(gate, "e_score_correction_bias", None) is not None:
         raise RuntimeError("Partial MoE router graphs require routing replay and score-correction bias to be disabled")
     _require_parameterless_target("moe_router", block, target)
-    return _PartialGraphEntry(name=f"{block.name}.moe_router", target=target)
+    return _PartialGraphEntry(name=f"{block.name}.moe_router", target=target, pool_group="moe_router")
 
 
 def _build_moe_preprocess_entry(
@@ -795,7 +876,7 @@ def _build_moe_preprocess_entry(
 ) -> _PartialGraphEntry:
     """Build one fused HybridEP metadata-preprocessing graph entry."""
     _require_parameterless_target("moe_preprocess", block, target)
-    return _PartialGraphEntry(name=f"{block.name}.moe_preprocess", target=target)
+    return _PartialGraphEntry(name=f"{block.name}.moe_preprocess", target=target, pool_group="moe_preprocess")
 
 
 def _build_moe_execution_entry(
@@ -815,6 +896,7 @@ def _build_moe_execution_entry(
     return _PartialGraphEntry(
         name=f"{block.name}.moe",
         target=target,
+        pool_group="moe",
         explicit_parameters=True,
         capture_owner=capture_owner,
         retain_graph_in_backward=True,
@@ -1003,46 +1085,116 @@ class PartialCudaGraphManager:
                 f"missing samples for {missing_entries}"
             )
 
-        staged_entries: list[tuple[_PartialGraphEntry, tuple[nn.Module, ...]]] = []
+        staged_groups: dict[tuple[str, bool], list[tuple[_PartialGraphEntry, nn.Module, tuple[torch.Tensor, ...]]]] = {}
+        variant_entries = []
+        for entry in self.entries:
+            captured_calls = entry.captured_calls()
+            entry_before = _cuda_memory_state()
+            staged_adapters = []
+            try:
+                entry.prepare_for_capture()
+                for captured_call in captured_calls:
+                    adapter = entry.build_adapter(captured_call)
+                    capture_inputs = entry.capture_inputs(adapter, captured_call)
+                    staged_adapters.append((adapter, capture_inputs))
+            finally:
+                entry.finish_capture()
+
+            entry_after = _cuda_memory_state()
+            cloned_parameter_bytes = sum(
+                adapter.cloned_parameter_bytes
+                for adapter, _capture_inputs in staged_adapters
+                if isinstance(adapter, _ExplicitParameterCallAdapter)
+            )
+            logger.info(
+                "Partial CUDA graph memory (entry staged): name=%s calls=%d static_input_bytes=%d "
+                "cloned_parameter_bytes=%d before=[%s] after=[%s]",
+                entry.name,
+                len(staged_adapters),
+                sum(_tensor_bytes(capture_inputs) for _adapter, capture_inputs in staged_adapters),
+                cloned_parameter_bytes,
+                _format_memory_state(entry_before),
+                _format_memory_state(entry_after),
+            )
+            if len(staged_adapters) == 1:
+                adapter, capture_inputs = staged_adapters[0]
+                group_key = (entry.pool_group, entry.retain_graph_in_backward)
+                staged_groups.setdefault(group_key, []).append((entry, adapter, capture_inputs))
+            else:
+                variant_entries.append((entry, staged_adapters))
+
         uninstalled_adapters: list[nn.Module] = []
+
+        def capture_group(
+            staged_group: Sequence[tuple[_PartialGraphEntry, nn.Module, tuple[torch.Tensor, ...]]],
+        ) -> tuple[nn.Module, ...]:
+            if not staged_group:
+                return ()
+            group_before = _cuda_memory_state()
+            modules = tuple(adapter for _entry, adapter, _capture_inputs in staged_group)
+            sample_args = tuple(capture_inputs for _entry, _adapter, capture_inputs in staged_group)
+            graph_kwargs: dict[str, Any] = {
+                # TE runs callable-local forward/backward warmups, separate from training-loop warmup steps.
+                "num_warmup_iters": 3,
+                # This disables TE FP8/FP4 quantization, not CUDA graph capture.
+                "enabled": tuple(False for _ in modules),
+            }
+            if staged_group[0][0].retain_graph_in_backward:
+                graph_kwargs["retain_graph_in_backward"] = True
+            names = tuple(entry.name for entry, _adapter, _capture_inputs in staged_group)
+            try:
+                result = _get_make_graphed_callables()(
+                    modules=modules,
+                    sample_args=sample_args,
+                    **graph_kwargs,
+                )
+            except Exception as error:
+                raise RuntimeError(f"Partial CUDA graph capture failed for shared-pool entries {names}") from error
+            if not isinstance(result, tuple):
+                result = (result,)
+            # Track returned graphs before validating the result shape so even a
+            # malformed TE return is reset by the surrounding transaction.
+            uninstalled_adapters.extend(result)
+            if len(result) != len(staged_group) or not all(isinstance(adapter, nn.Module) for adapter in result):
+                raise RuntimeError(
+                    "Transformer Engine must return one nn.Module graph for every partial target; "
+                    f"got {result!r} for {len(staged_group)} targets"
+                )
+            group_after = _cuda_memory_state()
+            logger.info(
+                "Partial CUDA graph memory (shared capture): entries=%d names=%s before=[%s] after=[%s]",
+                len(staged_group),
+                names,
+                _format_memory_state(group_before),
+                _format_memory_state(group_after),
+            )
+            return result
+
+        captured_groups: list[
+            tuple[
+                Sequence[tuple[_PartialGraphEntry, nn.Module, tuple[torch.Tensor, ...]]],
+                tuple[nn.Module, ...],
+            ]
+        ] = []
+        captured_variants: list[tuple[_PartialGraphEntry, tuple[nn.Module, ...]]] = []
         try:
-            for entry in self.entries:
+            # Each scope is captured in one TE invocation. TE captures forwards
+            # in model order and backwards in reverse order, so every layer in
+            # that scope can safely share one private pool.
+            for staged_group in staged_groups.values():
+                captured_groups.append((staged_group, capture_group(staged_group)))
+
+            # Multiple contracts for one physical target are alternatives rather
+            # than a fixed execution sequence, so they must not share a pool.
+            for entry, staged_adapters in variant_entries:
                 graphed_adapters = []
-                try:
-                    entry.prepare_for_capture()
-                    for captured_call in entry.captured_calls():
-                        adapter = entry.build_adapter(captured_call)
-                        graph_kwargs = {
-                            # TE runs callable-local forward/backward warmups, separate from training-loop warmup steps.
-                            "num_warmup_iters": 3,
-                            # This disables TE FP8/FP4 quantization, not CUDA graph capture.
-                            "enabled": (False,),
-                        }
-                        if entry.retain_graph_in_backward:
-                            graph_kwargs["retain_graph_in_backward"] = True
-                        try:
-                            result = _get_make_graphed_callables()(
-                                modules=(adapter,),
-                                sample_args=(entry.capture_inputs(adapter, captured_call),),
-                                **graph_kwargs,
-                            )
-                        except Exception as error:
-                            raise RuntimeError(f"Partial CUDA graph capture failed for {entry.name}") from error
-                        if not isinstance(result, tuple):
-                            result = (result,)
-                        uninstalled_adapters.extend(result)
-                        if len(result) != 1 or not isinstance(result[0], nn.Module):
-                            raise RuntimeError(
-                                "Transformer Engine must return one nn.Module graph for partial target "
-                                f"{entry.name!r}; got {result!r}"
-                            )
-                        graphed_adapters.append(result[0])
-                finally:
-                    entry.finish_capture()
-                staged_entries.append((entry, tuple(graphed_adapters)))
+                for adapter, capture_inputs in staged_adapters:
+                    graphed_adapters.extend(capture_group([(entry, adapter, capture_inputs)]))
+                captured_variants.append((entry, tuple(graphed_adapters)))
         except Exception:
-            # Installation starts only after every target succeeds, so resetting
-            # the staged adapters restores a fully eager model on any failure.
+            # No graph has been installed yet. Release every successfully
+            # captured TE graph so a later group failure cannot leak a private
+            # pool while all user-visible forwards remain eager.
             for graphed_adapter in uninstalled_adapters:
                 reset = getattr(graphed_adapter, "reset", None)
                 if callable(reset):
@@ -1052,7 +1204,11 @@ class PartialCudaGraphManager:
                         logger.exception("Failed to reset an uninstalled partial CUDA graph after capture failure")
             raise
 
-        for entry, graphed_adapters in staged_entries:
+        for staged_group, grouped_results in captured_groups:
+            pooled = len(staged_group) > 1
+            for (entry, _adapter, _capture_inputs), graphed_adapter in zip(staged_group, grouped_results):
+                entry.install(graphed_adapter, allow_eager_fallback=not pooled)
+        for entry, graphed_adapters in captured_variants:
             entry.install(graphed_adapters)
 
         self._captured = True

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -983,6 +983,16 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
                             best_metric_key=self.best_metric_key,
                         )
                     self._maybe_collect_garbage()
+        except BaseException:
+            if self.partial_cuda_graph_manager is not None:
+                try:
+                    self.partial_cuda_graph_manager.close()
+                except Exception:
+                    logger.exception("Failed to close partial CUDA graphs after a training-loop error")
+                finally:
+                    self.partial_cuda_graph_manager = None
+            self._partial_cuda_graph_capture_pending = False
+            raise
         finally:
             if pbar is not None:
                 pbar.close()

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -1314,7 +1314,12 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
             val_name: Name of the validation dataset.
             val_dataloader: DataLoader for the validation dataset.
         """
-        with ScopedRNG(seed=1, ranked=True):
+        graph_context = (
+            self.partial_cuda_graph_manager.eager_execution()
+            if self.partial_cuda_graph_manager is not None
+            else nullcontext()
+        )
+        with graph_context, ScopedRNG(seed=1, ranked=True):
             for mp in self.model_parts:
                 mp.eval()
 

--- a/tests/unit_tests/components/cuda_graphs/test_partial.py
+++ b/tests/unit_tests/components/cuda_graphs/test_partial.py
@@ -631,6 +631,32 @@ def test_pooled_entry_fails_closed_instead_of_skipping_replay(monkeypatch):
     manager.close()
 
 
+def test_manager_wide_eager_execution_supports_eval_then_resumes_training_replay(monkeypatch):
+    _install_fake_graph(monkeypatch)
+    targets = (nn.Identity(), nn.Identity())
+    entries = [
+        partial_graphs._PartialGraphEntry(name=f"attention.{index}", target=target, pool_group="attn")
+        for index, target in enumerate(targets)
+    ]
+    manager = partial_graphs.PartialCudaGraphManager(entries)
+    manager.start_recording()
+    for target in targets:
+        target(torch.ones(2, 3))
+    manager.capture()
+
+    with manager.eager_execution():
+        for target in targets:
+            target.eval()
+            torch.testing.assert_close(target(torch.ones(2, 3)), torch.ones(2, 3))
+
+    for target in targets:
+        target.train()
+        torch.testing.assert_close(target(torch.ones(2, 3)), torch.ones(2, 3))
+
+    assert manager.stats() == {"captured": 2, "replayed": 2, "fallback": 0}
+    manager.close()
+
+
 def test_cuda_memory_state_splits_normal_and_private_pools(monkeypatch):
     monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
     monkeypatch.setattr(torch.cuda, "memory_allocated", lambda: 700)

--- a/tests/unit_tests/components/cuda_graphs/test_partial.py
+++ b/tests/unit_tests/components/cuda_graphs/test_partial.py
@@ -265,6 +265,27 @@ def test_explicit_parameter_adapter_matches_eager_forward_and_backward():
     assert all(parameter.grad is None for parameter in graph_target.parameters())
 
 
+def test_explicit_parameter_adapter_uses_fresh_parameter_storage():
+    target = _Attention()
+    graph_input = torch.randn(2, 4, requires_grad=True)
+    captured_call = partial_graphs._CapturedCall.from_call((graph_input,), {})
+    adapter = partial_graphs._ExplicitParameterCallAdapter(target, captured_call)
+
+    target_parameters = tuple(target.parameters())
+    assert adapter.cloned_parameter_bytes == sum(
+        parameter.untyped_storage().nbytes() for parameter in target_parameters
+    )
+    assert all(capture is not target for capture, target in zip(adapter.capture_parameters, target_parameters))
+    assert all(
+        capture.data_ptr() != target.data_ptr()
+        for capture, target in zip(adapter.capture_parameters, target_parameters)
+    )
+
+    adapter(*adapter.capture_inputs).sum().backward()
+    assert all(parameter.grad is not None for parameter in adapter.capture_parameters)
+    assert all(parameter.grad is None for parameter in target_parameters)
+
+
 def test_explicit_parameter_adapter_rejects_replaced_buffer_storage():
     class _BufferedAttention(_Attention):
         def __init__(self):
@@ -356,7 +377,62 @@ def test_parameter_owner_is_resharded_when_capture_fails(monkeypatch):
     manager.close()
 
 
-def test_capture_failure_resets_staged_graphs_and_keeps_all_targets_eager(monkeypatch):
+def test_all_parameter_owners_are_resharded_before_shared_capture(monkeypatch):
+    events = []
+
+    class _CaptureOwner(nn.Module):
+        def __init__(self, name):
+            super().__init__()
+            self.name = name
+            self.unsharded = False
+
+        def unshard(self, *, async_op):
+            assert async_op is False
+            self.unsharded = True
+            events.append((self.name, "unshard"))
+
+        def reshard(self):
+            self.unsharded = False
+            events.append((self.name, "reshard"))
+
+    owners = (_CaptureOwner("layer0"), _CaptureOwner("layer1"))
+    targets = (_Attention(), _Attention())
+    entries = [
+        partial_graphs._PartialGraphEntry(
+            name=f"attention.{index}",
+            target=target,
+            pool_group="attn",
+            explicit_parameters=True,
+            capture_owner=owner,
+        )
+        for index, (target, owner) in enumerate(zip(targets, owners))
+    ]
+
+    def make_graphed_callables(modules, sample_args, **kwargs):
+        del sample_args, kwargs
+        assert all(not owner.unsharded for owner in owners)
+        for module in modules:
+            module.reset = lambda: None
+        return modules
+
+    monkeypatch.setattr(partial_graphs, "_get_make_graphed_callables", lambda: make_graphed_callables)
+    manager = partial_graphs.PartialCudaGraphManager(entries)
+    manager.start_recording()
+    for target in targets:
+        target(torch.ones(2, 4))
+
+    manager.capture()
+
+    assert events == [
+        ("layer0", "unshard"),
+        ("layer0", "reshard"),
+        ("layer1", "unshard"),
+        ("layer1", "reshard"),
+    ]
+    manager.close()
+
+
+def test_later_capture_group_failure_resets_earlier_graph_and_keeps_eager_forward(monkeypatch):
     reset_adapters = []
     capture_count = 0
 
@@ -365,20 +441,19 @@ def test_capture_failure_resets_staged_graphs_and_keeps_all_targets_eager(monkey
         del sample_args, kwargs
         capture_count += 1
         if capture_count == 2:
-            raise RuntimeError("second target failed")
-        adapter = modules[0]
-        adapter.reset = lambda: reset_adapters.append(adapter)
-        return (adapter,)
+            raise RuntimeError("second scope failed")
+        for module in modules:
+            module.reset = lambda module=module: reset_adapters.append(module)
+        return modules
 
     monkeypatch.setattr(partial_graphs, "_get_make_graphed_callables", lambda: make_graphed_callables)
     targets = (nn.Identity(), nn.Identity())
     original_forwards = tuple(target.forward for target in targets)
-    manager = partial_graphs.PartialCudaGraphManager(
-        [
-            partial_graphs._PartialGraphEntry(name=f"target.{index}", target=target)
-            for index, target in enumerate(targets)
-        ]
-    )
+    entries = [
+        partial_graphs._PartialGraphEntry(name=f"scope.{index}", target=target, pool_group=f"scope{index}")
+        for index, target in enumerate(targets)
+    ]
+    manager = partial_graphs.PartialCudaGraphManager(entries)
     manager.start_recording()
     for target in targets:
         target(torch.ones(2, 3))
@@ -441,6 +516,41 @@ def test_graph_helper_fails_with_actionable_error_when_te_is_unavailable(monkeyp
         partial_graphs._get_make_graphed_callables()
 
 
+def test_malformed_te_result_resets_every_returned_graph(monkeypatch):
+    reset_adapters = []
+
+    def make_graphed_callables(modules, sample_args, **kwargs):
+        del sample_args, kwargs
+        returned = (*modules, nn.Identity())
+
+        def reset(module):
+            reset_adapters.append(module)
+            if module is returned[0]:
+                raise RuntimeError("first reset failed")
+
+        for module in returned:
+            module.reset = lambda module=module: reset(module)
+        return returned
+
+    monkeypatch.setattr(partial_graphs, "_get_make_graphed_callables", lambda: make_graphed_callables)
+    targets = (nn.Identity(), nn.Identity())
+    entries = [
+        partial_graphs._PartialGraphEntry(name=f"attention.{index}", target=target, pool_group="attn")
+        for index, target in enumerate(targets)
+    ]
+    manager = partial_graphs.PartialCudaGraphManager(entries)
+    manager.start_recording()
+    for target in targets:
+        target(torch.ones(2, 3))
+
+    with pytest.raises(RuntimeError, match="one nn.Module graph for every partial target"):
+        manager.capture()
+
+    assert len(reset_adapters) == 3
+    assert manager.stats() == {"captured": 0, "replayed": 0, "fallback": 0}
+    manager.close()
+
+
 def test_capture_replays_matching_input_and_falls_back_on_metadata_change(monkeypatch):
     captured_kwargs = _install_fake_graph(monkeypatch)
     target = nn.Identity()
@@ -461,6 +571,93 @@ def test_capture_replays_matching_input_and_falls_back_on_metadata_change(monkey
         }
     ]
     manager.close()
+
+
+def test_capture_batches_layers_into_one_te_call_per_scope(monkeypatch):
+    captured_groups = []
+
+    def make_graphed_callables(modules, sample_args, **kwargs):
+        captured_groups.append((modules, sample_args, kwargs))
+        for module in modules:
+            module.reset = lambda: None
+        return modules
+
+    monkeypatch.setattr(partial_graphs, "_get_make_graphed_callables", lambda: make_graphed_callables)
+    model = _Model(te_dpa=False, attention=True, moe=True, router=False, preprocess=False, layer_count=2)
+    manager = partial_graphs.PartialCudaGraphManager.from_model_parts([model])
+    assert manager is not None
+    for layer in model.model.layers.values():
+        layer.self_attn(torch.ones(2, 4))
+        layer.mlp.experts(
+            torch.ones(2, 4),
+            torch.ones(2, dtype=torch.bool),
+            torch.ones(2, 2),
+            torch.zeros(2, 2, dtype=torch.long),
+        )
+
+    manager.capture()
+
+    assert len(captured_groups) == 2
+    assert [len(modules) for modules, _sample_args, _kwargs in captured_groups] == [2, 2]
+    attention_modules, moe_modules = (modules for modules, _sample_args, _kwargs in captured_groups)
+    layers = tuple(model.model.layers.values())
+    assert tuple(module.target for module in attention_modules) == tuple(layer.self_attn for layer in layers)
+    assert tuple(module.target for module in moe_modules) == tuple(layer.mlp.experts for layer in layers)
+    assert [kwargs["enabled"] for _modules, _sample_args, kwargs in captured_groups] == [
+        (False, False),
+        (False, False),
+    ]
+    assert all(kwargs["retain_graph_in_backward"] is True for _modules, _sample_args, kwargs in captured_groups)
+    manager.close()
+
+
+def test_pooled_entry_fails_closed_instead_of_skipping_replay(monkeypatch):
+    _install_fake_graph(monkeypatch)
+    targets = (nn.Identity(), nn.Identity())
+    entries = [
+        partial_graphs._PartialGraphEntry(name=f"attention.{index}", target=target, pool_group="attn")
+        for index, target in enumerate(targets)
+    ]
+    manager = partial_graphs.PartialCudaGraphManager(entries)
+    manager.start_recording()
+    for target in targets:
+        target(torch.ones(2, 3))
+    manager.capture()
+
+    with pytest.raises(RuntimeError, match="cannot fall back independently"):
+        targets[0](torch.ones(3, 3))
+
+    assert entries[0].fallback_count == 0
+    manager.close()
+
+
+def test_cuda_memory_state_splits_normal_and_private_pools(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "memory_allocated", lambda: 700)
+    monkeypatch.setattr(torch.cuda, "memory_reserved", lambda: 1000)
+    monkeypatch.setattr(
+        torch.cuda,
+        "memory_snapshot",
+        lambda: [
+            {"segment_pool_id": (0, 0), "allocated_size": 400, "total_size": 600},
+            {"segment_pool_id": (3, 4), "allocated_size": 300, "total_size": 400},
+        ],
+    )
+
+    state = partial_graphs._cuda_memory_state()
+
+    assert state == partial_graphs._CudaMemoryState(
+        normal_allocated=400,
+        normal_reserved=600,
+        private_allocated=300,
+        private_reserved=400,
+    )
+
+
+def test_tensor_bytes_counts_shared_storage_once():
+    storage = torch.empty(16, dtype=torch.float32)
+
+    assert partial_graphs._tensor_bytes((storage[:8], storage[8:])) == storage.untyped_storage().nbytes()
 
 
 def test_capture_preserves_alias_and_non_tensor_control_contract(monkeypatch):

--- a/tests/unit_tests/components/cuda_graphs/test_partial.py
+++ b/tests/unit_tests/components/cuda_graphs/test_partial.py
@@ -728,18 +728,19 @@ def test_rejects_full_moe_with_activation_checkpointing():
         partial_graphs.PartialCudaGraphManager.from_model_parts([model], activation_checkpointing=True)
 
 
-@pytest.mark.parametrize(
-    ("model_parts", "pipeline_parallel"),
-    [
-        ([_Model()], True),
-        ([_Model(), _Model()], False),
-    ],
-)
-def test_rejects_pipeline_stages_and_virtual_chunks(model_parts, pipeline_parallel):
-    with pytest.raises(RuntimeError, match="pipeline stages and virtual pipeline chunks"):
+def test_rejects_pipeline_parallel_until_validated():
+    with pytest.raises(RuntimeError, match="do not support pipeline parallelism yet"):
         partial_graphs.PartialCudaGraphManager.from_model_parts(
-            model_parts,
-            pipeline_parallel=pipeline_parallel,
+            [_Model()],
+            pipeline_parallel=True,
+        )
+
+
+def test_rejects_virtual_pipeline_chunks_until_validated():
+    with pytest.raises(RuntimeError, match="require one local model part"):
+        partial_graphs.PartialCudaGraphManager.from_model_parts(
+            [_Model(), _Model()],
+            pipeline_parallel=False,
         )
 
 

--- a/tests/unit_tests/recipes/test_train_ft_partial_cuda_graphs.py
+++ b/tests/unit_tests/recipes/test_train_ft_partial_cuda_graphs.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
+import torch
 from torch import nn
 
 import nemo_automodel.components.cuda_graphs.partial as partial_graphs
@@ -123,3 +126,64 @@ def test_training_loop_captures_after_first_complete_step_and_closes():
     ]
     assert recipe.partial_cuda_graph_manager is None
     assert not recipe._partial_cuda_graph_capture_pending
+
+
+def test_training_loop_closes_graphs_when_a_step_raises():
+    events = []
+
+    class _OneStepScheduler:
+        step = 0
+        epoch = 0
+        epochs = [0]
+
+        def set_epoch(self, epoch):
+            self.epoch = epoch
+
+        def __iter__(self):
+            yield ["failing-step"]
+
+    recipe = _bare_recipe()
+    recipe.model_parts = [nn.Linear(2, 2)]
+    recipe.step_scheduler = _OneStepScheduler()
+    recipe.max_grad_norm = 1.0
+    recipe.partial_cuda_graph_manager = SimpleNamespace(close=lambda: events.append("close"))
+    recipe._partial_cuda_graph_capture_pending = False
+    recipe._enable_qat_if_delayed = lambda _step: None
+    recipe._run_train_optim_step = MagicMock(side_effect=RuntimeError("step failed"))
+    recipe._make_progress_bar = lambda: None
+
+    with pytest.raises(RuntimeError, match="step failed"):
+        recipe.run_train_validation_loop()
+
+    assert events == ["close"]
+    assert recipe.partial_cuda_graph_manager is None
+
+
+def test_validation_disables_partial_graphs_as_one_eager_region():
+    events = []
+
+    @contextmanager
+    def eager_execution():
+        events.append("enter-eager")
+        try:
+            yield
+        finally:
+            events.append("exit-eager")
+
+    recipe = _bare_recipe()
+    recipe.partial_cuda_graph_manager = SimpleNamespace(eager_execution=eager_execution)
+    recipe.model_parts = [nn.Identity()]
+    recipe.dist_env = SimpleNamespace(device=torch.device("cpu"), is_main=True)
+    recipe.optimizer = [SimpleNamespace(param_groups=[{"lr": 1.0e-3}])]
+    recipe.step_scheduler = SimpleNamespace(step=1, epoch=0)
+    recipe.pp_enabled = False
+    recipe._forward_backward_step = lambda _index, _batch, *, loss_buffer, **_kwargs: loss_buffer.append(
+        torch.tensor(2.0)
+    )
+    recipe._dp_allreduce = lambda value, **_kwargs: value
+    batch = {"labels": torch.tensor([[1, 2, -100]])}
+
+    metrics = recipe._run_validation_epoch([batch])
+
+    assert events == ["enter-eager", "exit-eager"]
+    assert metrics.metrics["val_loss"] == 1.0


### PR DESCRIPTION
## Summary

Stacked on #2932 and linked to #1027.

- batch every single-contract target in a scope into one Transformer Engine `make_graphed_callables()` invocation, giving attention and MoE one shared private pool each instead of one pool per layer
- preserve forward layer order; TE captures the corresponding backward graphs in reverse order
- stage explicit FSDP parameter inputs one owner at a time and reshard before TE capture; the fresh capture leaf is also TE's static input, so there is no additional TE-owned parameter copy
- fail closed when one entry in a shared pool no longer matches its captured input/control/parameter contract
- suspend every pooled entry together for eager validation, then restore graph replay for training
- reject PP/virtual-PP interleaving until static graph buffers have a validated pipeline schedule
- make capture transactional: reset already-created graphs if a later scope fails or TE returns malformed results
- log exact per-entry static-input/parameter-clone bytes and allocator snapshots around staging, plus exact normal/private allocator snapshots around each shared-scope capture

A private-pool delta cannot be attributed honestly to one entry once TE captures the full scope in a single call, so actual graph-pool deltas are reported per scope rather than repeated for every layer.

## H100 experiment

Qwen3-30B-A3B, 8x H100 80GB, BF16, FSDP2 + EP8, TE attention and experts, HybridEP, no AC/PP, mock dataset.

Exact old/new comparison at local/global batch 1/8, sequence length 1024:

| Graph pool layout | Peak allocated / GPU | Avg step | Result |
|---|---:|---:|---|
| per-entry pools | 53.53 GiB | 304.39 ms | pass |
| shared attention/MoE pools | 52.56 GiB | 314.83 ms | pass |

Shared pools reduce peak allocated memory by **0.97 GiB/GPU (1.8%)** at this shape. Runtime is statistically inconclusive in these short runs; this PR's measured benefit is memory/capacity rather than a claimed speedup.

Capacity comparison at local/global batch 2/16, sequence length 1024:

| Mode | Peak allocated / GPU | Avg step | Result |
|---|---:|---:|---|
| eager | 39.00 GiB | 474.43 ms | pass |
| old per-entry attention + MoE graphs | >71.32 GiB allocated at failure | n/a | OOM while capturing layer 45/48 |
| shared attention + MoE pools | 59.49 GiB | 355.56 ms | pass |

At this larger shape, shared capture reduces allocated memory by **at least 11.83 GiB/GPU** relative to the old failure point and turns the previous OOM into successful capture/replay. The completed graph run is **25.1% faster than eager**. Eager and graph loss sequences match to the logged precision across all 15 steps.

Allocator diagnostics after shared capture at local batch 2:

- attention shared pool: 5,177.57 MiB private allocated
- attention + MoE shared pools: 21,194.05 MiB private allocated

The larger local-batch-2, sequence-2048 case still OOMs during the MoE backward warmup. That result identifies retained TE expert backward state as the next memory target; a separate stacked PR will page only marked expert saved activations.

## Validation

- affected partial-graph, recipe, and MoE suites: `355 passed, 55 skipped`
- Ruff and `git diff --check` pass
- independent review covered TE ordering, pooled fail-closed behavior, FSDP storage lifetime, failure cleanup, and memory attribution

