### PR TITLE
perf(moe): page partial graph expert activations

### DIFF
--- a/nemo_automodel/components/models/common/utils.py
+++ b/nemo_automodel/components/models/common/utils.py
@@ -169,10 +169,19 @@ class CudaGraphConfig:
             number of routed tokens per expert. Required by, and only valid
             with, the ``moe`` graph scope. Capacity limiting may drop routed
             expert assignments when an expert is overloaded.
+        moe_paged_stash: Page explicitly marked TE expert saved activations
+            using iteration-0 runtime token counts. Requires the ``moe`` graph
+            scope and expert inputs that participate in autograd.
+        moe_paged_stash_page_size: Number of token rows per paged-stash page.
+        moe_paged_stash_buffer_size_factor: Multiplicative page-buffer headroom
+            over the iteration-0 observed peak. Must be finite and at least one.
     """
 
     modules: list[Literal["attn", "te_dpa", "moe", "moe_router", "moe_preprocess"]] = field(default_factory=list)
     moe_capacity_factor: float | None = None
+    moe_paged_stash: bool = False
+    moe_paged_stash_page_size: int = 64
+    moe_paged_stash_buffer_size_factor: float = 1.1
 
     def __post_init__(self) -> None:
         """Validate the declarative CUDA-graph configuration."""
@@ -203,6 +212,23 @@ class CudaGraphConfig:
                 raise ValueError("'moe' in cuda_graph.modules requires cuda_graph.moe_capacity_factor")
             if any(scope in self.modules for scope in ("moe_router", "moe_preprocess")):
                 raise ValueError("'moe' in cuda_graph.modules cannot be combined with moe_router or moe_preprocess")
+        if self.moe_paged_stash:
+            if "moe" not in self.modules:
+                raise ValueError("cuda_graph.moe_paged_stash requires 'moe' in cuda_graph.modules")
+            if (
+                isinstance(self.moe_paged_stash_page_size, bool)
+                or not isinstance(self.moe_paged_stash_page_size, int)
+                or self.moe_paged_stash_page_size <= 0
+            ):
+                raise ValueError("cuda_graph.moe_paged_stash_page_size must be a positive integer")
+            factor = self.moe_paged_stash_buffer_size_factor
+            if (
+                isinstance(factor, bool)
+                or not isinstance(factor, (int, float))
+                or not math.isfinite(float(factor))
+                or factor < 1.0
+            ):
+                raise ValueError("cuda_graph.moe_paged_stash_buffer_size_factor must be finite and at least 1.0")
 
 
 @dataclass(kw_only=True)

--- a/nemo_automodel/components/moe/experts.py
+++ b/nemo_automodel/components/moe/experts.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import math
+from contextlib import nullcontext
 from functools import partial
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
@@ -1025,6 +1026,15 @@ class GroupedExpertsTE(nn.Module):
         self.dispatcher_async_dispatch = dispatcher_async_dispatch
         self.cuda_graph_moe_enabled = backend is not None and "moe" in backend.cuda_graph.modules
         self.cuda_graph_moe_capacity_factor = backend.cuda_graph.moe_capacity_factor if backend is not None else None
+        self.cuda_graph_moe_paged_stash = backend is not None and backend.cuda_graph.moe_paged_stash
+        if self.cuda_graph_moe_paged_stash:
+            from nemo_automodel.components.moe.paged_stash import get_paged_stash_manager
+
+            get_paged_stash_manager().configure(
+                enabled=True,
+                page_size=backend.cuda_graph.moe_paged_stash_page_size,
+                buffer_size_factor=backend.cuda_graph.moe_paged_stash_buffer_size_factor,
+            )
 
         # Gated (SwiGLU, Quick-GEGLU): out_features = moe_inter_dim * 2
         # Non-gated (ReLU²): out_features = moe_inter_dim
@@ -1548,9 +1558,30 @@ class GroupedExpertsTE(nn.Module):
         """
         permuted_probs = permuted_probs.unsqueeze(-1)
         splits = [tokens_per_local_expert] * self.num_local_experts
-        output1 = self.gate_up_linear(hidden_states, splits)
-        output1 = self.expert_activation(output1, permuted_probs)
-        output2 = self.down_linear(output1, splits)
+        if self.cuda_graph_moe_paged_stash:
+            from nemo_automodel.components.moe.paged_stash import get_paged_stash_manager
+
+            stash_group = get_paged_stash_manager().group(
+                name="te_grouped_mlp",
+                max_num_tokens=hidden_states.shape[0],
+                live_token_mask=permuted_probs.squeeze(-1).ne(0),
+            )
+        else:
+            stash_group = nullcontext()
+
+        if self.cuda_graph_moe_paged_stash:
+            hidden_states = stash_group.start(hidden_states)
+        with stash_group:
+            output1 = self.gate_up_linear(hidden_states, splits)
+            if self.cuda_graph_moe_paged_stash:
+                output1 = stash_group.mark_activation(output1)
+            output1 = self.expert_activation(output1, permuted_probs)
+            if self.cuda_graph_moe_paged_stash:
+                output1 = stash_group.mark_activation(output1)
+            output2 = self.down_linear(output1, splits)
+        if self.cuda_graph_moe_paged_stash:
+            del output1
+            output2 = stash_group.commit(output2)
         if self.expert_bias:
             down_bias = self._get_stacked_bias(self.down_linear)
             if down_bias is not None:

--- a/nemo_automodel/components/moe/paged_stash.py
+++ b/nemo_automodel/components/moe/paged_stash.py
@@ -113,6 +113,13 @@ class _PagedStashBuffer:
 
 @dataclass
 class _RecordedTensor:
+    """Warmup saved tensor and its page-rounded live allocation.
+
+    ``tensor`` is a contiguous activation with shape ``[rows, row_width]``.
+    ``key`` is ``(dtype, row_width)`` and ``charged_tokens`` is rounded to the
+    configured page size until autograd unpacks the tensor.
+    """
+
     tensor: torch.Tensor
     key: tuple[torch.dtype, int]
     charged_tokens: int
@@ -266,7 +273,12 @@ class _GroupState:
 
 @dataclass(frozen=True)
 class _ActivationSurface:
-    """One explicitly registered contiguous activation storage range."""
+    """One explicitly registered contiguous activation storage range.
+
+    The range represents ``num_rows`` contiguous rows of width ``row_width``.
+    ``live_token_mask`` is a boolean tensor with shape ``[num_rows]`` on the
+    same device and selects rows that must be preserved for backward.
+    """
 
     device: torch.device
     dtype: torch.dtype

--- a/nemo_automodel/components/moe/paged_stash.py
+++ b/nemo_automodel/components/moe/paged_stash.py
@@ -1,0 +1,777 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Paged activation stashing for fixed-capacity Transformer Engine MoE experts.
+
+The actual routed-token count remains a CUDA scalar. Triton kernels consume that
+scalar directly, pack only live rows into fixed page buffers, and restore those
+rows immediately before expert backward. This avoids a device-to-host sync and
+does not freeze expert splits.
+
+This module deliberately owns only explicitly marked TE expert activation
+storage. The first eager forward/backward records peak page usage; call
+:meth:`PagedStashManager.prepare` before partial CUDA graph capture. A
+distributed runner must reduce :meth:`PagedStashManager.check_overflow` across
+ranks, then discard gradients and rerun the whole step eagerly on every rank.
+
+Nested ``saved_tensors_hooks`` (including PyTorch activation checkpointing) are
+not claimed to be supported yet. Callers can use :meth:`PagedStashManager.disabled`
+around such regions until their exact composition has been validated.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import enum
+import math
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+from nemo_automodel.components.moe.paged_stash_ops import (
+    GLOBAL_BLOCK_SIZE,
+    HAVE_TRITON,
+    paged_stash_copy_kernel,
+    paged_stash_pop_kernel,
+)
+
+
+class PagedStashOverflowError(RuntimeError):
+    """Raised after an iteration whose fixed CUDA page capacity was exceeded."""
+
+
+class _PagedStashState(enum.Enum):
+    DISABLED = "disabled"
+    RECORDING = "recording"
+    ACTIVE = "active"
+
+
+def _storage_dtype(dtype: torch.dtype) -> torch.dtype:
+    """Return a bit-preserving dtype accepted by a plain Triton copy kernel."""
+    return torch.uint8 if torch.empty((), dtype=dtype).element_size() == 1 else dtype
+
+
+class _PagedStashBuffer:
+    """One circular GPU page allocator for a dtype and per-token width."""
+
+    def __init__(
+        self,
+        *,
+        num_tokens: int,
+        hidden_size: int,
+        page_size: int,
+        device: torch.device,
+        dtype: torch.dtype,
+        overflow: torch.Tensor,
+    ) -> None:
+        if num_tokens <= 0:
+            raise ValueError(f"Paged stash buffer capacity must be positive, got {num_tokens}")
+        self.hidden_size = hidden_size
+        self.page_size = page_size
+        self.device = device
+        self.dtype = dtype
+        self.overflow = overflow
+        self.num_pages = math.ceil(num_tokens / page_size)
+        self.total_tokens = self.num_pages * page_size
+        self.storage = torch.empty((self.total_tokens, hidden_size), dtype=dtype, device=device)
+        self.free_list = torch.arange(self.num_pages, dtype=torch.int64, device=device)
+        self.head = torch.zeros(1, dtype=torch.int64, device=device)
+        self.tail = torch.full((1,), self.num_pages, dtype=torch.int64, device=device)
+        self.capacity = torch.full((1,), self.num_pages, dtype=torch.int64, device=device)
+        self._reset_free_list = torch.arange(self.num_pages, dtype=torch.int64, device=device)
+        self._reset_tail = torch.full((1,), self.num_pages, dtype=torch.int64, device=device)
+
+    def reset(self) -> None:
+        """Restore the allocator without creating graph-unsafe temporary tensors."""
+        self.free_list.copy_(self._reset_free_list)
+        self.head.zero_()
+        self.tail.copy_(self._reset_tail)
+
+
+@dataclass
+class _RecordedTensor:
+    tensor: torch.Tensor
+    key: tuple[torch.dtype, int]
+    charged_tokens: int
+    released: bool = False
+
+
+class _PagedTensor:
+    """Saved tensor represented by device-counted rows in a page buffer."""
+
+    def __init__(
+        self,
+        tensor: torch.Tensor,
+        *,
+        num_tokens_tensor: torch.Tensor,
+        live_token_mask: torch.Tensor,
+        live_token_offsets: torch.Tensor,
+        max_num_tokens: int,
+        hidden_size: int,
+        page_size: int,
+    ) -> None:
+        if not tensor.is_contiguous():
+            raise RuntimeError("Paged stash only supports contiguous TE grouped saved tensors")
+        self._tensor: torch.Tensor | None = tensor
+        self._original_tensor: torch.Tensor | None = None
+        self.num_tokens_tensor = num_tokens_tensor
+        self.live_token_mask = live_token_mask
+        self.live_token_offsets = live_token_offsets
+        self.max_num_tokens = max_num_tokens
+        self.hidden_size = hidden_size
+        self.page_size = page_size
+        self.original_shape = tuple(tensor.shape)
+        self.dtype = tensor.dtype
+        self.device = tensor.device
+        self.page_record = torch.empty(math.ceil(max_num_tokens / page_size), dtype=torch.int64, device=tensor.device)
+        self._new_head = torch.empty(1, dtype=torch.int64, device=tensor.device)
+        self._new_tail = torch.empty(1, dtype=torch.int64, device=tensor.device)
+
+    def offload(self, buffer: _PagedStashBuffer) -> None:
+        """Pack live rows and release the original activation reference."""
+        if self._tensor is None:
+            raise RuntimeError("Paged tensor was stashed more than once")
+        storage_dtype = _storage_dtype(self.dtype)
+        source = self._tensor.view(storage_dtype).reshape(self.max_num_tokens, self.hidden_size)
+        grid = (max(1, min(self.max_num_tokens, 2048)),)
+        paged_stash_copy_kernel[grid](
+            source,
+            buffer.storage,
+            self.num_tokens_tensor,
+            self.live_token_mask,
+            self.live_token_offsets,
+            buffer.free_list,
+            buffer.head,
+            buffer.tail,
+            buffer.capacity,
+            self.page_record,
+            buffer.overflow,
+            self._new_head,
+            PAGE_SIZE=self.page_size,
+            HIDDEN_SIZE=self.hidden_size,
+            MAX_NUM_TOKENS=self.max_num_tokens,
+            BLOCK_SIZE=GLOBAL_BLOCK_SIZE,
+        )
+        buffer.head.copy_(self._new_head)
+        self._original_tensor = self._tensor
+        self._tensor = None
+
+    def release_original(self) -> None:
+        """Drop the source after its same-stream stash kernel has been enqueued."""
+        self._original_tensor = None
+
+    def reload(self, buffer: _PagedStashBuffer) -> None:
+        """Allocate the original fixed shape and restore its live rows."""
+        if self._tensor is not None:
+            raise RuntimeError("Paged tensor was restored more than once")
+        # Padded rows participate in the fixed-capacity GroupedLinear backward.
+        # They must be zero rather than uninitialized when only live rows are restored.
+        self._tensor = torch.zeros(self.original_shape, dtype=self.dtype, device=self.device)
+        storage_dtype = _storage_dtype(self.dtype)
+        destination = self._tensor.view(storage_dtype).reshape(self.max_num_tokens, self.hidden_size)
+        grid = (max(1, min(self.max_num_tokens, 2048)),)
+        paged_stash_pop_kernel[grid](
+            buffer.storage,
+            destination,
+            self.num_tokens_tensor,
+            self.live_token_mask,
+            self.live_token_offsets,
+            self.page_record,
+            buffer.overflow,
+            buffer.free_list,
+            buffer.tail,
+            buffer.capacity,
+            self._new_tail,
+            PAGE_SIZE=self.page_size,
+            HIDDEN_SIZE=self.hidden_size,
+            MAX_NUM_TOKENS=self.max_num_tokens,
+            BLOCK_SIZE=GLOBAL_BLOCK_SIZE,
+        )
+        buffer.tail.copy_(self._new_tail)
+
+    def unpack(self) -> torch.Tensor:
+        """Return the restored tensor to autograd's unpack hook."""
+        if self._tensor is None:
+            raise RuntimeError("Paged tensor reached backward before its group boundary restored it")
+        return self._tensor
+
+    def release_reloaded(self) -> None:
+        """Drop the restored tensor after every expert backward consumer has run."""
+        if self._tensor is None:
+            raise RuntimeError("Paged tensor reload storage was released before expert backward completed")
+        self._tensor = None
+
+
+@dataclass
+class _GroupState:
+    group_id: int
+    name: str
+    max_num_tokens: int
+    num_tokens_tensor: torch.Tensor
+    live_token_mask: torch.Tensor
+    live_token_offsets: torch.Tensor
+    activation_surfaces: list[_ActivationSurface]
+    observed_saved_metadata: list[tuple[Any, ...]]
+
+
+@dataclass(frozen=True)
+class _ActivationSurface:
+    """One explicitly registered contiguous activation storage range."""
+
+    device: torch.device
+    dtype: torch.dtype
+    storage_ptr: int
+    element_start: int
+    numel: int
+    num_rows: int
+    row_width: int
+    live_token_mask: torch.Tensor
+
+    def match(self, tensor: torch.Tensor) -> tuple[int, torch.Tensor] | None:
+        """Return row count and mask for a contained row-aligned alias."""
+        if tensor.device != self.device or tensor.dtype != self.dtype:
+            return None
+        if (
+            tensor.dim() < 2
+            or tensor.shape[0] <= 0
+            or tensor.untyped_storage().data_ptr() != self.storage_ptr
+            or not tensor.is_contiguous()
+        ):
+            return None
+        tensor_row_width = tensor.numel() // tensor.shape[0]
+        if tensor_row_width != self.row_width:
+            return None
+        relative_start = tensor.storage_offset() - self.element_start
+        if relative_start < 0 or relative_start % self.row_width or tensor.numel() % self.row_width:
+            return None
+        relative_end = relative_start + tensor.numel()
+        if relative_end > self.numel:
+            return None
+        row_start = relative_start // self.row_width
+        num_rows = tensor.numel() // self.row_width
+        return num_rows, self.live_token_mask.narrow(0, row_start, num_rows)
+
+
+class _PagedStashBoundary(torch.autograd.Function):
+    """Stash after expert forward and restore immediately before expert backward."""
+
+    @staticmethod
+    def forward(
+        ctx: Any,
+        output: torch.Tensor,
+        manager: PagedStashManager,
+        group_id: int,
+    ) -> torch.Tensor:
+        ctx.manager = manager
+        ctx.group_id = group_id
+        manager._stash_group(group_id)
+        return output
+
+    @staticmethod
+    def backward(ctx: Any, grad_output: torch.Tensor) -> tuple[torch.Tensor, None, None]:
+        ctx.manager._reload_group(ctx.group_id)
+        return grad_output, None, None
+
+
+class _PagedStashPreBoundary(torch.autograd.Function):
+    """Release restored tensors after the complete expert backward finishes."""
+
+    @staticmethod
+    def forward(
+        ctx: Any,
+        input_: torch.Tensor,
+        manager: PagedStashManager,
+        group_id: int,
+    ) -> torch.Tensor:
+        ctx.manager = manager
+        ctx.group_id = group_id
+        ctx.active = manager.is_active
+        return input_
+
+    @staticmethod
+    def backward(ctx: Any, grad_input: torch.Tensor) -> tuple[torch.Tensor, None, None]:
+        if ctx.active:
+            ctx.manager._finish_group_backward(ctx.group_id)
+        return grad_input, None, None
+
+
+class _PagedStashGroup:
+    """One non-nestable saved-tensor-hook scope around a TE grouped MLP."""
+
+    def __init__(self, manager: PagedStashManager, state: _GroupState | None) -> None:
+        self.manager = manager
+        self.state = state
+        self._hooks: Any = None
+        self._exited = False
+        self._started = False
+
+    def start(self, input_: torch.Tensor) -> torch.Tensor:
+        """Attach the boundary that releases reload storage after expert backward."""
+        if self.state is None:
+            return input_
+        if self._started:
+            raise RuntimeError("Paged stash group start() may only be called once")
+        if not input_.requires_grad:
+            self.manager._abort_group(self.state.group_id, "expert input does not require gradients")
+            raise RuntimeError("Paged stash requires the expert input to require gradients")
+        self._started = True
+        return _PagedStashPreBoundary.apply(
+            input_,
+            self.manager,
+            self.state.group_id,
+        )
+
+    def mark_activation(self, tensor: torch.Tensor) -> torch.Tensor:
+        """Mark one exact GroupedLinear activation input as pageable."""
+        if self.state is None:
+            return tensor
+        if not tensor.is_contiguous() or tensor.dim() < 2 or tensor.shape[0] != self.state.max_num_tokens:
+            raise RuntimeError(
+                "Paged stash activation must be contiguous with the fixed expert-token dimension first; "
+                f"got shape={tuple(tensor.shape)} contiguous={tensor.is_contiguous()}"
+            )
+        row_width = tensor.numel() // tensor.shape[0]
+        self.state.activation_surfaces.append(
+            _ActivationSurface(
+                device=tensor.device,
+                dtype=tensor.dtype,
+                storage_ptr=tensor.untyped_storage().data_ptr(),
+                element_start=tensor.storage_offset(),
+                numel=tensor.numel(),
+                num_rows=tensor.shape[0],
+                row_width=row_width,
+                live_token_mask=self.state.live_token_mask,
+            )
+        )
+        return tensor
+
+    def __enter__(self) -> _PagedStashGroup:
+        if self.state is not None:
+            self._hooks = torch.autograd.graph.saved_tensors_hooks(
+                self.manager._pack_saved_tensor,
+                self.manager._unpack_saved_tensor,
+            )
+            self._hooks.__enter__()
+        return self
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> bool:
+        try:
+            if self._hooks is not None:
+                self._hooks.__exit__(exc_type, exc_value, traceback)
+        finally:
+            self._exited = True
+            if exc_type is not None and self.state is not None:
+                self.manager._abort_group(self.state.group_id, f"group raised {exc_type.__name__}")
+        return False
+
+    def commit(self, output: torch.Tensor) -> torch.Tensor:
+        """Close the forward group and attach its pre-backward restore boundary."""
+        if not self._exited:
+            raise RuntimeError("Paged stash group must exit its context before commit()")
+        if self.state is None:
+            return output
+        if not self._started:
+            raise RuntimeError("Paged stash group requires start() before expert compute")
+        return self.manager._commit_group(self.state.group_id, output)
+
+
+class PagedStashManager:
+    """Process-local page buffers and lifecycle for TE grouped expert activations."""
+
+    def __init__(self) -> None:
+        self._state = _PagedStashState.DISABLED
+        self._disable_depth = 0
+        self._page_size = 64
+        self._buffer_size_factor = 1.1
+        self._next_group_id = 0
+        self._current_group: _GroupState | None = None
+        self._group_tensors: dict[int, list[_PagedTensor]] = {}
+        self._group_saved_tensor_counts: dict[int, int] = {}
+        self._recorded_peak_tokens: dict[tuple[torch.dtype, int], int] = {}
+        self._recorded_current_tokens: dict[tuple[torch.dtype, int], int] = {}
+        self._record_device: torch.device | None = None
+        self._recording_invalid_reason: str | None = None
+        self._buffers: dict[tuple[torch.dtype, int], _PagedStashBuffer] = {}
+        self._overflow: torch.Tensor | None = None
+        self._backward_group_stack: list[int] = []
+        self._backward_in_progress_group_id: int | None = None
+
+    @property
+    def is_enabled(self) -> bool:
+        """Return whether recording or stashing is configured."""
+        return self._state is not _PagedStashState.DISABLED
+
+    @property
+    def is_active(self) -> bool:
+        """Return whether fixed page buffers have been allocated."""
+        return self._state is _PagedStashState.ACTIVE
+
+    def configure(
+        self,
+        *,
+        enabled: bool,
+        page_size: int = 64,
+        buffer_size_factor: float = 1.1,
+    ) -> None:
+        """Enable a recording warmup or disable a quiescent manager.
+
+        Repeated identical enable calls are harmless because every TE expert
+        layer observes the same process-local manager.
+        """
+        if isinstance(page_size, bool) or not isinstance(page_size, int) or page_size <= 0:
+            raise ValueError(f"page_size must be positive, got {page_size}")
+        if isinstance(buffer_size_factor, bool) or not isinstance(buffer_size_factor, (int, float)):
+            raise ValueError(f"buffer_size_factor must be a positive number, got {buffer_size_factor}")
+        if buffer_size_factor <= 0:
+            raise ValueError(f"buffer_size_factor must be positive, got {buffer_size_factor}")
+        if self._current_group is not None or self._group_tensors:
+            raise RuntimeError("Cannot reconfigure paged stash while groups are live")
+        if not enabled:
+            self.close()
+            return
+        if self._state is not _PagedStashState.DISABLED:
+            if page_size != self._page_size or not math.isclose(buffer_size_factor, self._buffer_size_factor):
+                raise RuntimeError("All paged-stash experts must use the same page_size and buffer_size_factor")
+            return
+        self._page_size = page_size
+        self._buffer_size_factor = buffer_size_factor
+        self._state = _PagedStashState.RECORDING
+
+    @contextlib.contextmanager
+    def disabled(self) -> Iterator[None]:
+        """Temporarily bypass hooks, including around unvalidated checkpoint scopes."""
+        self._disable_depth += 1
+        try:
+            yield
+        finally:
+            self._disable_depth -= 1
+
+    def group(
+        self,
+        *,
+        name: str,
+        max_num_tokens: int,
+        live_token_mask: torch.Tensor,
+    ) -> _PagedStashGroup:
+        """Create one saved-tensor scope around a grouped expert invocation."""
+        if not self.is_enabled or self._disable_depth or not torch.is_grad_enabled():
+            return _PagedStashGroup(self, None)
+        if self._current_group is not None:
+            raise RuntimeError("Paged stash groups cannot nest; disable paged stash around outer saved_tensors_hooks")
+        if max_num_tokens <= 0:
+            raise ValueError(f"max_num_tokens must be positive, got {max_num_tokens}")
+        if not isinstance(live_token_mask, torch.Tensor) or live_token_mask.dim() != 1:
+            raise TypeError("live_token_mask must be a one-dimensional Tensor")
+        if live_token_mask.dtype != torch.bool:
+            raise TypeError(f"live_token_mask must have boolean dtype, got {live_token_mask.dtype}")
+        if live_token_mask.numel() != max_num_tokens:
+            raise ValueError(
+                f"live_token_mask has {live_token_mask.numel()} rows, expected max_num_tokens={max_num_tokens}"
+            )
+        live_token_offsets = live_token_mask.to(torch.int64).cumsum(dim=0).sub(1)
+        state = _GroupState(
+            group_id=self._next_group_id,
+            name=name,
+            max_num_tokens=max_num_tokens,
+            num_tokens_tensor=live_token_mask.sum().reshape(1),
+            live_token_mask=live_token_mask,
+            live_token_offsets=live_token_offsets,
+            activation_surfaces=[],
+            observed_saved_metadata=[],
+        )
+        self._next_group_id += 1
+        self._current_group = state
+        self._group_tensors[state.group_id] = []
+        self._group_saved_tensor_counts[state.group_id] = 0
+        return _PagedStashGroup(self, state)
+
+    def _pack_saved_tensor(self, tensor: torch.Tensor) -> Any:
+        group = self._current_group
+        if group is None:
+            raise RuntimeError("Paged stash pack hook ran outside a group")
+        if len(group.observed_saved_metadata) < 16:
+            group.observed_saved_metadata.append(
+                (tensor.device, tensor.dtype, tuple(tensor.shape), tuple(tensor.stride()), tensor.storage_offset())
+            )
+        match = None
+        for surface in group.activation_surfaces:
+            match = surface.match(tensor)
+            if match is not None:
+                break
+        if match is None:
+            return tensor
+        max_rows, live_token_mask = match
+        num_tokens_tensor = live_token_mask.sum().reshape(1)
+        live_token_offsets = live_token_mask.to(torch.int64).cumsum(dim=0).sub(1)
+        if num_tokens_tensor.device != tensor.device:
+            raise RuntimeError(
+                "Paged stash token count and saved tensor must be on the same device, got "
+                f"{num_tokens_tensor.device} and {tensor.device}"
+            )
+        if max_rows <= 0 or tensor.numel() % max_rows:
+            raise RuntimeError(
+                f"TE grouped saved tensor with {tensor.numel()} elements cannot be represented as {max_rows} rows"
+            )
+        key = (tensor.dtype, tensor.numel() // max_rows)
+        self._group_saved_tensor_counts[group.group_id] += 1
+
+        if self._state is _PagedStashState.RECORDING:
+            actual_tokens = int(num_tokens_tensor.item())
+            if actual_tokens < 0 or actual_tokens > max_rows:
+                raise RuntimeError(f"Recorded TE grouped token count {actual_tokens} is outside [0, {max_rows}]")
+            if self._record_device is None:
+                self._record_device = tensor.device
+            elif tensor.device != self._record_device:
+                raise RuntimeError(
+                    f"Paged stash recording changed device from {self._record_device} to {tensor.device}"
+                )
+            # The active allocator cannot share a partial page between saved
+            # tensors. Profile the exact page-rounded charge, rather than raw
+            # live rows, or many small scale tensors understate peak capacity.
+            charged_tokens = math.ceil(actual_tokens / self._page_size) * self._page_size
+            current = self._recorded_current_tokens.get(key, 0) + charged_tokens
+            self._recorded_current_tokens[key] = current
+            self._recorded_peak_tokens[key] = max(self._recorded_peak_tokens.get(key, 0), current)
+            return _RecordedTensor(tensor=tensor, key=key, charged_tokens=charged_tokens)
+
+        if self._state is not _PagedStashState.ACTIVE:
+            return tensor
+        if tensor.device.type != "cuda":
+            raise RuntimeError(f"Active paged stash requires CUDA tensors, got {tensor.device}")
+        if key not in self._buffers:
+            raise RuntimeError(f"TE saved-tensor layout {key} was not observed during paged-stash recording warmup")
+        paged_tensor = _PagedTensor(
+            tensor,
+            num_tokens_tensor=num_tokens_tensor,
+            live_token_mask=live_token_mask,
+            live_token_offsets=live_token_offsets,
+            max_num_tokens=max_rows,
+            hidden_size=key[1],
+            page_size=self._page_size,
+        )
+        self._group_tensors[group.group_id].append(paged_tensor)
+        return paged_tensor
+
+    def _unpack_saved_tensor(self, saved: Any) -> torch.Tensor:
+        if isinstance(saved, _RecordedTensor):
+            if not saved.released:
+                current = self._recorded_current_tokens[saved.key] - saved.charged_tokens
+                if current < 0:
+                    raise RuntimeError(f"Paged stash recording underflow for layout {saved.key}")
+                self._recorded_current_tokens[saved.key] = current
+                saved.released = True
+            return saved.tensor
+        if isinstance(saved, _PagedTensor):
+            return saved.unpack()
+        return saved
+
+    def _commit_group(self, group_id: int, output: torch.Tensor) -> torch.Tensor:
+        if self._current_group is None or self._current_group.group_id != group_id:
+            raise RuntimeError(f"Paged stash group {group_id} committed out of order")
+        group_state = self._current_group
+        self._current_group = None
+        saved_tensor_count = self._group_saved_tensor_counts.pop(group_id)
+        if saved_tensor_count == 0:
+            self._group_tensors.pop(group_id, None)
+            raise RuntimeError(
+                "Paged stash observed no registered TE expert activation storage; "
+                "the selected GroupedLinear path does not save the registered activation surface; "
+                f"registered surfaces={group_state.activation_surfaces}, "
+                f"observed saved metadata={group_state.observed_saved_metadata}"
+            )
+        if self._state is _PagedStashState.RECORDING:
+            self._group_tensors.pop(group_id, None)
+            return output
+        if not self._group_tensors[group_id]:
+            self._group_tensors.pop(group_id)
+            return output
+        return _PagedStashBoundary.apply(output, self, group_id)
+
+    def _abort_group(self, group_id: int, reason: str) -> None:
+        if self._current_group is not None and self._current_group.group_id == group_id:
+            self._current_group = None
+        self._group_tensors.pop(group_id, None)
+        self._group_saved_tensor_counts.pop(group_id, None)
+        if self._state is _PagedStashState.RECORDING:
+            self._recording_invalid_reason = reason
+
+    def _stash_group(self, group_id: int) -> None:
+        tensors = self._group_tensors.get(group_id)
+        if tensors is None:
+            raise RuntimeError(f"Unknown paged stash group {group_id}")
+        for paged_tensor in tensors:
+            key = (paged_tensor.dtype, paged_tensor.hidden_size)
+            paged_tensor.offload(self._buffers[key])
+        for paged_tensor in tensors:
+            paged_tensor.release_original()
+        self._backward_group_stack.append(group_id)
+
+    def _reload_group(self, group_id: int) -> None:
+        if not self._backward_group_stack or self._backward_group_stack[-1] != group_id:
+            expected = self._backward_group_stack[-1] if self._backward_group_stack else None
+            raise RuntimeError(f"Paged stash backward order must be LIFO: expected group {expected}, got {group_id}")
+        if self._backward_in_progress_group_id is not None:
+            raise RuntimeError(
+                f"Paged stash began group {group_id} backward while group "
+                f"{self._backward_in_progress_group_id} is still active"
+            )
+        tensors = self._group_tensors.get(group_id)
+        if tensors is None:
+            raise RuntimeError(f"Unknown paged stash group {group_id} during backward")
+        for paged_tensor in reversed(tensors):
+            key = (paged_tensor.dtype, paged_tensor.hidden_size)
+            paged_tensor.reload(self._buffers[key])
+        self._backward_group_stack.pop()
+        self._backward_in_progress_group_id = group_id
+
+    def _finish_group_backward(self, group_id: int) -> None:
+        """Release restored tensors once the complete expert backward has consumed them."""
+        if self._backward_in_progress_group_id != group_id:
+            raise RuntimeError(f"Paged stash finished group {group_id}, expected {self._backward_in_progress_group_id}")
+        tensors = self._group_tensors.pop(group_id, None)
+        if tensors is None:
+            raise RuntimeError(f"Unknown paged stash group {group_id} after backward")
+        for paged_tensor in tensors:
+            paged_tensor.release_reloaded()
+        self._backward_in_progress_group_id = None
+
+    def prepare(self) -> None:
+        """Allocate fixed CUDA page buffers from one completed eager warmup."""
+        if self._state is not _PagedStashState.RECORDING:
+            raise RuntimeError(f"prepare() requires recording state, got {self._state.value}")
+        if self._recording_invalid_reason is not None:
+            raise RuntimeError(f"Paged stash recording was invalid: {self._recording_invalid_reason}")
+        if self._current_group is not None or self._group_tensors or self._group_saved_tensor_counts:
+            raise RuntimeError("Paged stash warmup still has live groups; run a complete backward before prepare()")
+        nonzero_usage = {key: value for key, value in self._recorded_current_tokens.items() if value}
+        if nonzero_usage:
+            raise RuntimeError(f"Paged stash warmup still has live saved tensors: {nonzero_usage}")
+        if not self._recorded_peak_tokens:
+            raise RuntimeError("Paged stash warmup observed no TE grouped saved tensors")
+        if self._record_device is None or self._record_device.type != "cuda":
+            raise RuntimeError(f"Paged stash page buffers require a CUDA warmup, got {self._record_device}")
+        if not HAVE_TRITON:
+            raise RuntimeError("Paged stash requires Triton")
+
+        self._overflow = torch.zeros(1, dtype=torch.int64, device=self._record_device)
+        for (dtype, hidden_size), peak_tokens in self._recorded_peak_tokens.items():
+            capacity = max(1, math.ceil(peak_tokens * self._buffer_size_factor))
+            storage_dtype = _storage_dtype(dtype)
+            self._buffers[dtype, hidden_size] = _PagedStashBuffer(
+                num_tokens=capacity,
+                hidden_size=hidden_size,
+                page_size=self._page_size,
+                device=self._record_device,
+                dtype=storage_dtype,
+                overflow=self._overflow,
+            )
+        self._state = _PagedStashState.ACTIVE
+
+    def finish_iteration(self) -> None:
+        """Synchronously validate overflow after a single-rank forward/backward.
+
+        Distributed runners must instead stack :meth:`check_overflow` with their
+        other device flags, perform one all-reduce, and only then inspect the
+        result on the host. Calling this rank-local diagnostic before a collective
+        can deadlock when only some ranks overflow.
+        """
+        if self._current_group is not None or self._group_tensors or self._group_saved_tensor_counts:
+            raise RuntimeError("Paged stash iteration finished with live expert groups")
+        if self._backward_group_stack:
+            raise RuntimeError(
+                f"Paged stash iteration finished with pending backward groups {self._backward_group_stack}"
+            )
+        if self._backward_in_progress_group_id is not None:
+            raise RuntimeError(
+                "Paged stash iteration finished while expert backward is still active for group "
+                f"{self._backward_in_progress_group_id}"
+            )
+        if self._overflow is not None and bool(self._overflow.item()):
+            raise PagedStashOverflowError(
+                "MoE paged stash capacity overflowed; discard this attempt and rerun without paged stash"
+            )
+
+    def check_overflow(self) -> torch.Tensor | None:
+        """Return the device-resident overflow flag without synchronizing the host."""
+        return self._overflow
+
+    def reset_after_overflow(self) -> None:
+        """Clear overflow metadata after the graph using these buffers is destroyed."""
+        if self._current_group is not None or self._group_tensors or self._group_saved_tensor_counts:
+            raise RuntimeError("Cannot reset paged stash while groups are live")
+        if self._backward_group_stack or self._backward_in_progress_group_id is not None:
+            raise RuntimeError("Cannot reset paged stash while expert backward is live")
+        if self._overflow is not None:
+            self._overflow.zero_()
+        for buffer in self._buffers.values():
+            buffer.reset()
+
+    def restart_recording(self) -> None:
+        """Drop fixed pages and start a fresh eager profile after graph teardown."""
+        page_size = self._page_size
+        buffer_size_factor = self._buffer_size_factor
+        self.close()
+        self.configure(
+            enabled=True,
+            page_size=page_size,
+            buffer_size_factor=buffer_size_factor,
+        )
+
+    def diagnostics(self) -> dict[str, Any]:
+        """Return bounded lifecycle and allocation diagnostics."""
+        return {
+            "state": self._state.value,
+            "page_size": self._page_size,
+            "buffer_size_factor": self._buffer_size_factor,
+            "recorded_peak_tokens": dict(self._recorded_peak_tokens),
+            "buffer_tokens": {key: buffer.total_tokens for key, buffer in self._buffers.items()},
+            "buffer_bytes": {key: buffer.storage.nbytes for key, buffer in self._buffers.items()},
+            "live_groups": len(self._group_tensors),
+            "backward_schedule_depth": len(self._backward_group_stack),
+            "backward_in_progress_group_id": self._backward_in_progress_group_id,
+        }
+
+    def close(self) -> None:
+        """Release page buffers after every CUDA graph that references them is gone."""
+        if self._current_group is not None or self._group_tensors or self._group_saved_tensor_counts:
+            raise RuntimeError("Cannot close paged stash while groups are live")
+        if self._backward_group_stack:
+            raise RuntimeError("Cannot close paged stash while backward groups are live")
+        if self._backward_in_progress_group_id is not None:
+            raise RuntimeError("Cannot close paged stash while expert backward is live")
+        self._buffers.clear()
+        self._overflow = None
+        self._recorded_peak_tokens.clear()
+        self._recorded_current_tokens.clear()
+        self._record_device = None
+        self._recording_invalid_reason = None
+        self._group_saved_tensor_counts.clear()
+        self._backward_group_stack.clear()
+        self._backward_in_progress_group_id = None
+        self._next_group_id = 0
+        self._disable_depth = 0
+        self._state = _PagedStashState.DISABLED
+
+
+_PAGED_STASH_MANAGER = PagedStashManager()
+
+
+def get_paged_stash_manager() -> PagedStashManager:
+    """Return the process-local TE expert paged-stash manager."""
+    return _PAGED_STASH_MANAGER
+
+
+__all__ = ["PagedStashManager", "PagedStashOverflowError", "get_paged_stash_manager"]

--- a/nemo_automodel/components/moe/paged_stash.py
+++ b/nemo_automodel/components/moe/paged_stash.py
@@ -115,9 +115,10 @@ class _PagedStashBuffer:
 class _RecordedTensor:
     """Warmup saved tensor and its page-rounded live allocation.
 
-    ``tensor`` is a contiguous activation with shape ``[rows, row_width]``.
-    ``key`` is ``(dtype, row_width)`` and ``charged_tokens`` is rounded to the
-    configured page size until autograd unpacks the tensor.
+    ``tensor`` is a contiguous activation with shape ``[rows, ...]`` whose
+    trailing dimensions flatten to ``row_width``. ``key`` is
+    ``(dtype, row_width)`` and ``charged_tokens`` is rounded to the configured
+    page size until autograd unpacks the tensor.
     """
 
     tensor: torch.Tensor

--- a/nemo_automodel/components/moe/paged_stash.py
+++ b/nemo_automodel/components/moe/paged_stash.py
@@ -77,6 +77,16 @@ class _PagedStashBuffer:
         dtype: torch.dtype,
         overflow: torch.Tensor,
     ) -> None:
+        """Allocate one fixed-shape circular page buffer.
+
+        Args:
+            num_tokens: Minimum number of token rows the buffer must hold.
+            hidden_size: Number of storage elements in each token row.
+            page_size: Number of token rows allocated per page.
+            device: CUDA device that owns the page buffer.
+            dtype: Bit-preserving storage dtype for each token element.
+            overflow: Device scalar with shape ``[1]`` shared by every buffer.
+        """
         if num_tokens <= 0:
             raise ValueError(f"Paged stash buffer capacity must be positive, got {num_tokens}")
         self.hidden_size = hidden_size
@@ -123,6 +133,18 @@ class _PagedTensor:
         hidden_size: int,
         page_size: int,
     ) -> None:
+        """Describe one fixed-shape activation whose live rows will be paged.
+
+        Args:
+            tensor: Contiguous saved activation with shape ``[max_num_tokens, ...]``.
+            num_tokens_tensor: Device scalar with shape ``[1]`` containing the number of live rows.
+            live_token_mask: Boolean device tensor with shape ``[max_num_tokens]``.
+            live_token_offsets: Inclusive-prefix offsets with shape ``[max_num_tokens]``; values at live rows
+                identify their packed row indices.
+            max_num_tokens: Static first dimension of ``tensor``.
+            hidden_size: Flattened number of storage elements per token row.
+            page_size: Number of token rows allocated per page.
+        """
         if not tensor.is_contiguous():
             raise RuntimeError("Paged stash only supports contiguous TE grouped saved tensors")
         self._tensor: torch.Tensor | None = tensor
@@ -141,7 +163,12 @@ class _PagedTensor:
         self._new_tail = torch.empty(1, dtype=torch.int64, device=tensor.device)
 
     def offload(self, buffer: _PagedStashBuffer) -> None:
-        """Pack live rows and release the original activation reference."""
+        """Pack live rows and release the original activation reference.
+
+        Args:
+            buffer: Circular page storage with shape ``[num_pages * page_size, hidden_size]``. The copy mutates its
+                free-list head, page storage, and shared overflow scalar on the current CUDA stream.
+        """
         if self._tensor is None:
             raise RuntimeError("Paged tensor was stashed more than once")
         storage_dtype = _storage_dtype(self.dtype)
@@ -174,7 +201,12 @@ class _PagedTensor:
         self._original_tensor = None
 
     def reload(self, buffer: _PagedStashBuffer) -> None:
-        """Allocate the original fixed shape and restore its live rows."""
+        """Allocate the original fixed shape and restore its live rows.
+
+        Args:
+            buffer: Circular page storage used by :meth:`offload`. The pop mutates its free-list tail and restores
+                a tensor with ``original_shape``; rows excluded by ``live_token_mask`` remain zero.
+        """
         if self._tensor is not None:
             raise RuntimeError("Paged tensor was restored more than once")
         # Padded rows participate in the fixed-capacity GroupedLinear backward.
@@ -217,12 +249,17 @@ class _PagedTensor:
 
 @dataclass
 class _GroupState:
+    """Python capture-time state for one fixed-capacity expert call.
+
+    ``live_token_mask`` has shape ``[max_num_tokens]``. Activation surfaces alias
+    tensors whose first dimension is ``max_num_tokens`` and remain valid only for
+    the lifetime of this forward/backward group.
+    """
+
     group_id: int
     name: str
     max_num_tokens: int
-    num_tokens_tensor: torch.Tensor
     live_token_mask: torch.Tensor
-    live_token_offsets: torch.Tensor
     activation_surfaces: list[_ActivationSurface]
     observed_saved_metadata: list[tuple[Any, ...]]
 
@@ -241,7 +278,15 @@ class _ActivationSurface:
     live_token_mask: torch.Tensor
 
     def match(self, tensor: torch.Tensor) -> tuple[int, torch.Tensor] | None:
-        """Return row count and mask for a contained row-aligned alias."""
+        """Match a saved tensor against a registered row-aligned storage alias.
+
+        Args:
+            tensor: Candidate contiguous saved tensor with shape ``[rows, ...]``.
+
+        Returns:
+            The candidate row count and its boolean live-row mask with shape ``[rows]``, or ``None`` when the
+            tensor is not a contained row-aligned alias of this surface.
+        """
         if tensor.device != self.device or tensor.dtype != self.dtype:
             return None
         if (
@@ -275,6 +320,17 @@ class _PagedStashBoundary(torch.autograd.Function):
         manager: PagedStashManager,
         group_id: int,
     ) -> torch.Tensor:
+        """Stash saved activations after returning the unchanged expert output.
+
+        Args:
+            ctx: Autograd context for the expert invocation.
+            output: Expert output with shape ``[tokens, hidden]``.
+            manager: Manager that owns the group's fixed page buffers.
+            group_id: Process-local expert invocation identifier.
+
+        Returns:
+            ``output`` unchanged and with the same shape and strides.
+        """
         ctx.manager = manager
         ctx.group_id = group_id
         manager._stash_group(group_id)
@@ -282,6 +338,15 @@ class _PagedStashBoundary(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx: Any, grad_output: torch.Tensor) -> tuple[torch.Tensor, None, None]:
+        """Restore saved activations before propagating the expert-output gradient.
+
+        Args:
+            ctx: Autograd context populated by :meth:`forward`.
+            grad_output: Output gradient with shape ``[tokens, hidden]``.
+
+        Returns:
+            The unchanged output gradient followed by ``None`` for non-tensor inputs.
+        """
         ctx.manager._reload_group(ctx.group_id)
         return grad_output, None, None
 
@@ -296,6 +361,17 @@ class _PagedStashPreBoundary(torch.autograd.Function):
         manager: PagedStashManager,
         group_id: int,
     ) -> torch.Tensor:
+        """Attach a post-expert-backward cleanup boundary to an input activation.
+
+        Args:
+            ctx: Autograd context for the expert invocation.
+            input_: Fixed-capacity expert input with shape ``[tokens, hidden]``.
+            manager: Manager that owns the group's restored tensors.
+            group_id: Process-local expert invocation identifier.
+
+        Returns:
+            ``input_`` unchanged and with the same shape and strides.
+        """
         ctx.manager = manager
         ctx.group_id = group_id
         ctx.active = manager.is_active
@@ -303,6 +379,15 @@ class _PagedStashPreBoundary(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx: Any, grad_input: torch.Tensor) -> tuple[torch.Tensor, None, None]:
+        """Release restored tensors after propagating the expert-input gradient.
+
+        Args:
+            ctx: Autograd context populated by :meth:`forward`.
+            grad_input: Input gradient with shape ``[tokens, hidden]``.
+
+        Returns:
+            The unchanged input gradient followed by ``None`` for non-tensor inputs.
+        """
         if ctx.active:
             ctx.manager._finish_group_backward(ctx.group_id)
         return grad_input, None, None
@@ -319,7 +404,14 @@ class _PagedStashGroup:
         self._started = False
 
     def start(self, input_: torch.Tensor) -> torch.Tensor:
-        """Attach the boundary that releases reload storage after expert backward."""
+        """Attach the boundary that releases reload storage after expert backward.
+
+        Args:
+            input_: Fixed-capacity expert input with shape ``[max_num_tokens, hidden]``.
+
+        Returns:
+            An autograd alias of ``input_`` with the same shape and strides.
+        """
         if self.state is None:
             return input_
         if self._started:
@@ -335,7 +427,14 @@ class _PagedStashGroup:
         )
 
     def mark_activation(self, tensor: torch.Tensor) -> torch.Tensor:
-        """Mark one exact GroupedLinear activation input as pageable."""
+        """Mark one exact GroupedLinear activation input as pageable.
+
+        Args:
+            tensor: Contiguous activation with shape ``[max_num_tokens, ...]`` and fixed first dimension.
+
+        Returns:
+            ``tensor`` unchanged and with the same shape and strides.
+        """
         if self.state is None:
             return tensor
         if not tensor.is_contiguous() or tensor.dim() < 2 or tensor.shape[0] != self.state.max_num_tokens:
@@ -378,7 +477,14 @@ class _PagedStashGroup:
         return False
 
     def commit(self, output: torch.Tensor) -> torch.Tensor:
-        """Close the forward group and attach its pre-backward restore boundary."""
+        """Close the forward group and attach its pre-backward restore boundary.
+
+        Args:
+            output: Expert output with shape ``[max_num_tokens, hidden]``.
+
+        Returns:
+            An autograd alias of ``output`` with the same shape and strides.
+        """
         if not self._exited:
             raise RuntimeError("Paged stash group must exit its context before commit()")
         if self.state is None:
@@ -430,13 +536,22 @@ class PagedStashManager:
 
         Repeated identical enable calls are harmless because every TE expert
         layer observes the same process-local manager.
+
+        Args:
+            enabled: Whether to record and then page explicitly registered activations.
+            page_size: Positive number of token rows per page.
+            buffer_size_factor: Finite allocation headroom relative to recorded peak usage. Values below ``1.0``
+                cannot hold the warmup workload and are rejected.
         """
         if isinstance(page_size, bool) or not isinstance(page_size, int) or page_size <= 0:
             raise ValueError(f"page_size must be positive, got {page_size}")
-        if isinstance(buffer_size_factor, bool) or not isinstance(buffer_size_factor, (int, float)):
-            raise ValueError(f"buffer_size_factor must be a positive number, got {buffer_size_factor}")
-        if buffer_size_factor <= 0:
-            raise ValueError(f"buffer_size_factor must be positive, got {buffer_size_factor}")
+        if (
+            isinstance(buffer_size_factor, bool)
+            or not isinstance(buffer_size_factor, (int, float))
+            or not math.isfinite(float(buffer_size_factor))
+            or buffer_size_factor < 1.0
+        ):
+            raise ValueError(f"buffer_size_factor must be finite and at least 1.0, got {buffer_size_factor}")
         if self._current_group is not None or self._group_tensors:
             raise RuntimeError("Cannot reconfigure paged stash while groups are live")
         if not enabled:
@@ -466,7 +581,17 @@ class PagedStashManager:
         max_num_tokens: int,
         live_token_mask: torch.Tensor,
     ) -> _PagedStashGroup:
-        """Create one saved-tensor scope around a grouped expert invocation."""
+        """Create one saved-tensor scope around a grouped expert invocation.
+
+        Args:
+            name: Stable diagnostic name for the expert invocation.
+            max_num_tokens: Fixed first dimension of every marked activation.
+            live_token_mask: Boolean CUDA tensor with shape ``[max_num_tokens]``. True rows are paged; false
+                padding rows are restored as zeros.
+
+        Returns:
+            A non-nestable context that records or pages marked TE saved tensors.
+        """
         if not self.is_enabled or self._disable_depth or not torch.is_grad_enabled():
             return _PagedStashGroup(self, None)
         if self._current_group is not None:
@@ -481,14 +606,11 @@ class PagedStashManager:
             raise ValueError(
                 f"live_token_mask has {live_token_mask.numel()} rows, expected max_num_tokens={max_num_tokens}"
             )
-        live_token_offsets = live_token_mask.to(torch.int64).cumsum(dim=0).sub(1)
         state = _GroupState(
             group_id=self._next_group_id,
             name=name,
             max_num_tokens=max_num_tokens,
-            num_tokens_tensor=live_token_mask.sum().reshape(1),
             live_token_mask=live_token_mask,
-            live_token_offsets=live_token_offsets,
             activation_surfaces=[],
             observed_saved_metadata=[],
         )
@@ -499,6 +621,15 @@ class PagedStashManager:
         return _PagedStashGroup(self, state)
 
     def _pack_saved_tensor(self, tensor: torch.Tensor) -> Any:
+        """Replace a registered saved activation with recording metadata or a paged handle.
+
+        Args:
+            tensor: Tensor saved by autograd, generally with shape ``[rows, row_width]``.
+
+        Returns:
+            The unchanged tensor when it is not registered, recording metadata during warmup, or a paged handle
+            whose live rows are copied to fixed storage during active execution.
+        """
         group = self._current_group
         if group is None:
             raise RuntimeError("Paged stash pack hook ran outside a group")
@@ -566,6 +697,14 @@ class PagedStashManager:
         return paged_tensor
 
     def _unpack_saved_tensor(self, saved: Any) -> torch.Tensor:
+        """Resolve a saved-tensor hook payload for backward.
+
+        Args:
+            saved: Original tensor, warmup recording metadata, or active paged-tensor handle.
+
+        Returns:
+            The saved activation with its original fixed shape and padded rows restored as zeros when paged.
+        """
         if isinstance(saved, _RecordedTensor):
             if not saved.released:
                 current = self._recorded_current_tokens[saved.key] - saved.charged_tokens
@@ -579,6 +718,15 @@ class PagedStashManager:
         return saved
 
     def _commit_group(self, group_id: int, output: torch.Tensor) -> torch.Tensor:
+        """Validate one completed expert group and attach its stash boundary.
+
+        Args:
+            group_id: Process-local expert invocation identifier.
+            output: Expert output with shape ``[max_num_tokens, hidden]``.
+
+        Returns:
+            ``output`` unchanged during recording, or an autograd alias that stashes before backward when active.
+        """
         if self._current_group is None or self._current_group.group_id != group_id:
             raise RuntimeError(f"Paged stash group {group_id} committed out of order")
         group_state = self._current_group
@@ -705,7 +853,11 @@ class PagedStashManager:
             )
 
     def check_overflow(self) -> torch.Tensor | None:
-        """Return the device-resident overflow flag without synchronizing the host."""
+        """Return the device-resident overflow flag without synchronizing the host.
+
+        Returns:
+            An integer CUDA tensor with shape ``[1]``, or ``None`` before fixed buffers have been prepared.
+        """
         return self._overflow
 
     def reset_after_overflow(self) -> None:

--- a/nemo_automodel/components/moe/paged_stash_ops.py
+++ b/nemo_automodel/components/moe/paged_stash_ops.py
@@ -14,19 +14,23 @@
 
 """Triton kernels for graph-safe, device-counted MoE activation stashing."""
 
-from unittest.mock import MagicMock
+from typing import Any
 
 from nemo_automodel.shared.import_utils import null_decorator, safe_import
 
-_missing_triton = MagicMock()
-_missing_triton.jit = null_decorator
-HAVE_TRITON, triton = safe_import("triton", alt=_missing_triton)
-_, tl = safe_import("triton.language", alt=MagicMock())
+_has_triton, triton = safe_import("triton")
+_has_tl, tl = safe_import("triton.language")
+HAVE_TRITON = _has_triton and _has_tl
+
+# Keep this optional module importable on CPU-only installations. Active paged
+# stash checks HAVE_TRITON before it can launch either undecorated function.
+_triton_jit = triton.jit if HAVE_TRITON else null_decorator
+_triton_constexpr = tl.constexpr if HAVE_TRITON else Any
 
 GLOBAL_BLOCK_SIZE = 1024
 
 
-@triton.jit
+@_triton_jit
 def paged_stash_copy_kernel(
     src_ptr,
     dst_ptr,
@@ -40,12 +44,32 @@ def paged_stash_copy_kernel(
     page_record_ptr,
     overflow_ptr,
     new_free_list_head_ptr,
-    PAGE_SIZE: tl.constexpr,
-    HIDDEN_SIZE: tl.constexpr,
-    MAX_NUM_TOKENS: tl.constexpr,
-    BLOCK_SIZE: tl.constexpr,
+    PAGE_SIZE: _triton_constexpr,
+    HIDDEN_SIZE: _triton_constexpr,
+    MAX_NUM_TOKENS: _triton_constexpr,
+    BLOCK_SIZE: _triton_constexpr,
 ):
-    """Copy a runtime number of rows into pages without a device-to-host sync."""
+    """Copy a runtime number of live rows into pages without a host sync.
+
+    Args:
+        src_ptr: Contiguous source with shape ``[MAX_NUM_TOKENS, HIDDEN_SIZE]``.
+        dst_ptr: Page storage with shape ``[capacity * PAGE_SIZE, HIDDEN_SIZE]``; live rows are written in packed
+            order.
+        num_tokens_ptr: Integer device scalar with shape ``[1]``.
+        live_token_mask_ptr: Boolean live-row mask with shape ``[MAX_NUM_TOKENS]``.
+        live_token_offsets_ptr: Packed row offsets with shape ``[MAX_NUM_TOKENS]``; only live-row values are read.
+        free_list_ptr: Circular array of physical page ids with shape ``[capacity]``.
+        free_list_head_ptr: Integer device scalar with shape ``[1]``; advanced by the allocated page count.
+        free_list_tail_ptr: Integer device scalar with shape ``[1]`` containing the current release position.
+        free_list_capacity_ptr: Integer device scalar with shape ``[1]``.
+        page_record_ptr: Output page ids with shape ``[ceil(MAX_NUM_TOKENS / PAGE_SIZE)]``.
+        overflow_ptr: Shared integer device scalar with shape ``[1]``; set on invalid counts or insufficient pages.
+        new_free_list_head_ptr: Integer output scalar with shape ``[1]`` copied into the persistent head by caller.
+        PAGE_SIZE: Compile-time number of rows per page.
+        HIDDEN_SIZE: Compile-time flattened elements per row.
+        MAX_NUM_TOKENS: Compile-time physical source-row count.
+        BLOCK_SIZE: Compile-time number of elements copied per inner block.
+    """
     program_id = tl.program_id(axis=0)
     num_programs = tl.num_programs(axis=0)
 
@@ -90,7 +114,7 @@ def paged_stash_copy_kernel(
         tl.store(new_free_list_head_ptr, head + required_pages)
 
 
-@triton.jit
+@_triton_jit
 def paged_stash_pop_kernel(
     src_ptr,
     dst_ptr,
@@ -103,12 +127,31 @@ def paged_stash_pop_kernel(
     free_list_tail_ptr,
     free_list_capacity_ptr,
     new_free_list_tail_ptr,
-    PAGE_SIZE: tl.constexpr,
-    HIDDEN_SIZE: tl.constexpr,
-    MAX_NUM_TOKENS: tl.constexpr,
-    BLOCK_SIZE: tl.constexpr,
+    PAGE_SIZE: _triton_constexpr,
+    HIDDEN_SIZE: _triton_constexpr,
+    MAX_NUM_TOKENS: _triton_constexpr,
+    BLOCK_SIZE: _triton_constexpr,
 ):
-    """Restore runtime-counted rows and recycle their pages on the GPU."""
+    """Restore runtime-counted rows and recycle their pages on the GPU.
+
+    Args:
+        src_ptr: Page storage with shape ``[capacity * PAGE_SIZE, HIDDEN_SIZE]``.
+        dst_ptr: Zero-initialized destination with shape ``[MAX_NUM_TOKENS, HIDDEN_SIZE]``; live rows are restored
+            to their original physical positions.
+        num_tokens_ptr: Integer device scalar with shape ``[1]``.
+        live_token_mask_ptr: Boolean live-row mask with shape ``[MAX_NUM_TOKENS]``.
+        live_token_offsets_ptr: Packed row offsets with shape ``[MAX_NUM_TOKENS]``; only live-row values are read.
+        page_record_ptr: Physical page ids with shape ``[ceil(MAX_NUM_TOKENS / PAGE_SIZE)]``.
+        overflow_ptr: Shared integer device scalar with shape ``[1]``; set on invalid counts.
+        free_list_ptr: Circular array of physical page ids with shape ``[capacity]``; released ids are appended.
+        free_list_tail_ptr: Integer device scalar with shape ``[1]`` containing the current release position.
+        free_list_capacity_ptr: Integer device scalar with shape ``[1]``.
+        new_free_list_tail_ptr: Integer output scalar with shape ``[1]`` copied into the persistent tail by caller.
+        PAGE_SIZE: Compile-time number of rows per page.
+        HIDDEN_SIZE: Compile-time flattened elements per row.
+        MAX_NUM_TOKENS: Compile-time physical destination-row count.
+        BLOCK_SIZE: Compile-time number of elements copied per inner block.
+    """
     program_id = tl.program_id(axis=0)
     num_programs = tl.num_programs(axis=0)
 

--- a/nemo_automodel/components/moe/paged_stash_ops.py
+++ b/nemo_automodel/components/moe/paged_stash_ops.py
@@ -1,0 +1,155 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Triton kernels for graph-safe, device-counted MoE activation stashing."""
+
+from unittest.mock import MagicMock
+
+from nemo_automodel.shared.import_utils import null_decorator, safe_import
+
+_missing_triton = MagicMock()
+_missing_triton.jit = null_decorator
+HAVE_TRITON, triton = safe_import("triton", alt=_missing_triton)
+_, tl = safe_import("triton.language", alt=MagicMock())
+
+GLOBAL_BLOCK_SIZE = 1024
+
+
+@triton.jit
+def paged_stash_copy_kernel(
+    src_ptr,
+    dst_ptr,
+    num_tokens_ptr,
+    live_token_mask_ptr,
+    live_token_offsets_ptr,
+    free_list_ptr,
+    free_list_head_ptr,
+    free_list_tail_ptr,
+    free_list_capacity_ptr,
+    page_record_ptr,
+    overflow_ptr,
+    new_free_list_head_ptr,
+    PAGE_SIZE: tl.constexpr,
+    HIDDEN_SIZE: tl.constexpr,
+    MAX_NUM_TOKENS: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Copy a runtime number of rows into pages without a device-to-host sync."""
+    program_id = tl.program_id(axis=0)
+    num_programs = tl.num_programs(axis=0)
+
+    num_tokens = tl.load(num_tokens_ptr)
+    head = tl.load(free_list_head_ptr)
+    tail = tl.load(free_list_tail_ptr)
+    capacity = tl.load(free_list_capacity_ptr)
+    required_pages = tl.cdiv(num_tokens, PAGE_SIZE)
+    overflow = tl.load(overflow_ptr)
+
+    invalid_count = (num_tokens < 0) | (num_tokens > MAX_NUM_TOKENS)
+    insufficient_pages = tail - head < required_pages
+    if (overflow != 0) | invalid_count | insufficient_pages:
+        if program_id == 0:
+            if invalid_count | insufficient_pages:
+                tl.store(overflow_ptr, 1)
+            tl.store(new_free_list_head_ptr, head)
+        return
+
+    physical_token_index = program_id
+    while physical_token_index < MAX_NUM_TOKENS:
+        live = tl.load(live_token_mask_ptr + physical_token_index)
+        live_token_index = tl.load(live_token_offsets_ptr + physical_token_index)
+        page_slot = live_token_index // PAGE_SIZE
+        token_in_page = live_token_index % PAGE_SIZE
+        free_list_index = (head + page_slot) % capacity
+        page_id = tl.load(free_list_ptr + free_list_index, mask=live, other=0)
+        if live & (token_in_page == 0):
+            tl.store(page_record_ptr + page_slot, page_id)
+
+        destination_token_index = page_id * PAGE_SIZE + token_in_page
+        source_base = src_ptr + physical_token_index.to(tl.int64) * HIDDEN_SIZE
+        destination_base = dst_ptr + destination_token_index.to(tl.int64) * HIDDEN_SIZE
+        for block_index in range(tl.cdiv(HIDDEN_SIZE, BLOCK_SIZE)):
+            offsets = tl.arange(0, BLOCK_SIZE) + block_index * BLOCK_SIZE
+            mask = offsets < HIDDEN_SIZE
+            values = tl.load(source_base + offsets, mask=live & mask, other=0)
+            tl.store(destination_base + offsets, values, mask=live & mask)
+        physical_token_index += num_programs
+
+    if program_id == 0:
+        tl.store(new_free_list_head_ptr, head + required_pages)
+
+
+@triton.jit
+def paged_stash_pop_kernel(
+    src_ptr,
+    dst_ptr,
+    num_tokens_ptr,
+    live_token_mask_ptr,
+    live_token_offsets_ptr,
+    page_record_ptr,
+    overflow_ptr,
+    free_list_ptr,
+    free_list_tail_ptr,
+    free_list_capacity_ptr,
+    new_free_list_tail_ptr,
+    PAGE_SIZE: tl.constexpr,
+    HIDDEN_SIZE: tl.constexpr,
+    MAX_NUM_TOKENS: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Restore runtime-counted rows and recycle their pages on the GPU."""
+    program_id = tl.program_id(axis=0)
+    num_programs = tl.num_programs(axis=0)
+
+    num_tokens = tl.load(num_tokens_ptr)
+    tail = tl.load(free_list_tail_ptr)
+    capacity = tl.load(free_list_capacity_ptr)
+    required_pages = tl.cdiv(num_tokens, PAGE_SIZE)
+    overflow = tl.load(overflow_ptr)
+
+    invalid_count = (num_tokens < 0) | (num_tokens > MAX_NUM_TOKENS)
+    if (overflow != 0) | invalid_count:
+        if program_id == 0:
+            if invalid_count:
+                tl.store(overflow_ptr, 1)
+            tl.store(new_free_list_tail_ptr, tail)
+        return
+
+    physical_token_index = program_id
+    while physical_token_index < MAX_NUM_TOKENS:
+        live = tl.load(live_token_mask_ptr + physical_token_index)
+        live_token_index = tl.load(live_token_offsets_ptr + physical_token_index)
+        page_slot = live_token_index // PAGE_SIZE
+        token_in_page = live_token_index % PAGE_SIZE
+        page_id = tl.load(page_record_ptr + page_slot, mask=live, other=0)
+        source_token_index = page_id * PAGE_SIZE + token_in_page
+
+        source_base = src_ptr + source_token_index.to(tl.int64) * HIDDEN_SIZE
+        destination_base = dst_ptr + physical_token_index.to(tl.int64) * HIDDEN_SIZE
+        for block_index in range(tl.cdiv(HIDDEN_SIZE, BLOCK_SIZE)):
+            offsets = tl.arange(0, BLOCK_SIZE) + block_index * BLOCK_SIZE
+            mask = offsets < HIDDEN_SIZE
+            values = tl.load(source_base + offsets, mask=live & mask, other=0)
+            tl.store(destination_base + offsets, values, mask=live & mask)
+
+        if live & (token_in_page == 0):
+            free_list_index = (tail + page_slot) % capacity
+            tl.store(free_list_ptr + free_list_index, page_id)
+        physical_token_index += num_programs
+
+    if program_id == 0:
+        tl.store(new_free_list_tail_ptr, tail + required_pages)
+
+
+__all__ = ["GLOBAL_BLOCK_SIZE", "HAVE_TRITON", "paged_stash_copy_kernel", "paged_stash_pop_kernel"]

--- a/nemo_automodel/recipes/llm/benchmark.py
+++ b/nemo_automodel/recipes/llm/benchmark.py
@@ -344,6 +344,7 @@ class BenchmarkingRecipeForNextTokenPrediction(TrainFinetuneRecipeForNextTokenPr
                 # Gradient accumulation loop
                 num_label_tokens = 0
                 loss_buffer = []
+                iteration_batches = []
                 prepare_for_grad_accumulation(self.model_parts, pp_enabled=self.pp_enabled)
 
                 for ga_step_idx in range(ga_steps):
@@ -352,6 +353,7 @@ class BenchmarkingRecipeForNextTokenPrediction(TrainFinetuneRecipeForNextTokenPr
 
                     # Get batch from dataloader
                     batch = next(dataloader_iter)
+                    iteration_batches.append(batch)
                     torch.cuda.nvtx.range_push(f"iteration_{i}_ga_step_{ga_step_idx}")
 
                     # Accumulate label tokens locally
@@ -371,6 +373,12 @@ class BenchmarkingRecipeForNextTokenPrediction(TrainFinetuneRecipeForNextTokenPr
 
                     if ga_step_idx == 0:
                         prepare_after_first_microbatch()
+
+                loss_buffer = self._rerun_after_paged_stash_overflow(
+                    iteration_batches,
+                    num_label_tokens=None,
+                    loss_buffer=loss_buffer,
+                )
 
                 # Optimizer step
                 with self.timers("optimizer", log_level=2):

--- a/nemo_automodel/recipes/llm/benchmark.py
+++ b/nemo_automodel/recipes/llm/benchmark.py
@@ -341,23 +341,24 @@ class BenchmarkingRecipeForNextTokenPrediction(TrainFinetuneRecipeForNextTokenPr
             # Time the iteration
             iter_timer = "iteration_warmup" if i < warmup_steps else "iteration"
             with self.timers(iter_timer, log_level=1):
-                # Gradient accumulation loop
                 num_label_tokens = 0
                 loss_buffer = []
-                iteration_batches = []
-                prepare_for_grad_accumulation(self.model_parts, pp_enabled=self.pp_enabled)
+                # Materialize the exact retry inputs before snapshotting model
+                # RNG. A dataloader with num_workers=0 may consume the global
+                # Python/NumPy/Torch streams while producing each batch.
+                iteration_batches = [next(dataloader_iter) for _ in range(ga_steps)]
+                for batch in iteration_batches:
+                    num_label_tokens += (batch["labels"] != -100).sum().item()
 
-                for ga_step_idx in range(ga_steps):
+                prepare_for_grad_accumulation(self.model_parts, pp_enabled=self.pp_enabled)
+                paged_stash_rng_state = self._snapshot_paged_stash_rng_state()
+
+                # Gradient accumulation loop
+                for ga_step_idx, batch in enumerate(iteration_batches):
                     if ga_step_idx == ga_steps - 1:
                         prepare_for_final_backward(self.model_parts, pp_enabled=self.pp_enabled)
 
-                    # Get batch from dataloader
-                    batch = next(dataloader_iter)
-                    iteration_batches.append(batch)
                     torch.cuda.nvtx.range_push(f"iteration_{i}_ga_step_{ga_step_idx}")
-
-                    # Accumulate label tokens locally
-                    num_label_tokens += (batch["labels"] != -100).sum().item()
 
                     with self.timers(f"forward_backward_{ga_step_idx}", log_level=2):
                         self._forward_backward_step(
@@ -378,6 +379,7 @@ class BenchmarkingRecipeForNextTokenPrediction(TrainFinetuneRecipeForNextTokenPr
                     iteration_batches,
                     num_label_tokens=None,
                     loss_buffer=loss_buffer,
+                    rng_state=paged_stash_rng_state,
                 )
 
                 # Optimizer step

--- a/nemo_automodel/recipes/llm/benchmark.py
+++ b/nemo_automodel/recipes/llm/benchmark.py
@@ -391,7 +391,27 @@ class BenchmarkingRecipeForNextTokenPrediction(TrainFinetuneRecipeForNextTokenPr
             # Match the training-loop lifecycle: record one complete eager
             # optimizer step, then capture outside the measured iteration.
             if self.partial_cuda_graph_manager is not None and self._partial_cuda_graph_capture_pending:
+                stash_manager = None
+                if self._partial_cuda_graph_paged_stash_enabled:
+                    from nemo_automodel.components.moe.paged_stash import get_paged_stash_manager
+
+                    stash_manager = get_paged_stash_manager()
+                    stash_manager.prepare()
+                    logger.info("Partial MoE paged stash prepared: %s", stash_manager.diagnostics())
                 self.partial_cuda_graph_manager.capture()
+                if stash_manager is not None:
+                    overflow_ranks = self._paged_stash_overflow_rank_count(stash_manager)
+                    if overflow_ranks:
+                        self.partial_cuda_graph_manager.close()
+                        self.partial_cuda_graph_manager = None
+                        stash_manager.close()
+                        self._partial_cuda_graph_paged_stash_enabled = False
+                        self._partial_cuda_graph_capture_pending = False
+                        raise RuntimeError(
+                            "MoE paged stash capacity overflowed during CUDA graph capture on "
+                            f"{overflow_ranks} ranks; partial CUDA graphs were disabled"
+                        )
+                    stash_manager.finish_iteration()
                 self._partial_cuda_graph_capture_pending = False
 
             # Synchronize num_label_tokens across DP ranks
@@ -619,6 +639,12 @@ def main(config_path=None):
         if recipe.partial_cuda_graph_manager is not None:
             recipe.partial_cuda_graph_manager.close()
             recipe.partial_cuda_graph_manager = None
+        recipe._partial_cuda_graph_capture_pending = False
+        if recipe._partial_cuda_graph_paged_stash_enabled:
+            from nemo_automodel.components.moe.paged_stash import get_paged_stash_manager
+
+            get_paged_stash_manager().close()
+            recipe._partial_cuda_graph_paged_stash_enabled = False
 
 
 if __name__ == "__main__":

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -78,7 +78,7 @@ from nemo_automodel.components.loss.utils import _get_lm_head_weight, calculate_
 from nemo_automodel.components.moe.megatron.moe_utils import MoEAuxLossAutoScaler
 from nemo_automodel.components.quantization.fp8 import build_fp8_config
 from nemo_automodel.components.training.model_output_utils import get_final_hidden_states
-from nemo_automodel.components.training.rng import ScopedRNG, StatefulRNG
+from nemo_automodel.components.training.rng import RNGState, ScopedRNG, StatefulRNG
 from nemo_automodel.components.training.utils import (
     count_tail_padding,
     get_expert_tp_replication_factor,
@@ -1166,7 +1166,15 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
         return tensor
 
     def _run_forward_backward_batches(self, batches, *, num_label_tokens: int | None) -> list[torch.Tensor]:
-        """Run one complete gradient-accumulation forward/backward schedule."""
+        """Run one complete gradient-accumulation forward/backward schedule.
+
+        Args:
+            batches: Sequence of microbatches consumed in order by the training schedule.
+            num_label_tokens: Global number of non-ignored labels, or ``None`` when the caller normalizes later.
+
+        Returns:
+            Detached scalar loss tensors, one for each schedule output that reports a loss.
+        """
         loss_buffer: list[torch.Tensor] = []
         num_batches = len(batches)
         prepare_for_grad_accumulation(self.model_parts, pp_enabled=self.pp_enabled)
@@ -1184,14 +1192,59 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
                 prepare_after_first_microbatch()
         return loss_buffer
 
+    def _snapshot_paged_stash_rng_state(self) -> RNGState | None:
+        """Snapshot all recipe-owned RNG streams before an attempt that may be retried.
+
+        Returns:
+            Python, NumPy, PyTorch, and CUDA RNG state when paged stash is active, or ``None`` when no retry can
+            occur.
+        """
+        if not getattr(self, "_partial_cuda_graph_paged_stash_enabled", False):
+            return None
+
+        from nemo_automodel.components.moe.paged_stash import get_paged_stash_manager
+
+        if not get_paged_stash_manager().is_active:
+            return None
+        return self.rng.state_dict()
+
+    def _paged_stash_overflow_rank_count(self, stash_manager) -> int:
+        """Collectively count ranks whose device-resident paged-stash flag is set.
+
+        Args:
+            stash_manager: Active process-local paged-stash manager.
+
+        Returns:
+            Number of overflowing ranks. The only device-to-host synchronization occurs after every rank has
+            entered the collective.
+        """
+        overflow = stash_manager.check_overflow()
+        if overflow is None:
+            raise RuntimeError("Active partial MoE paged stash has no overflow flag")
+        overflow_ranks = overflow.reshape(-1)[0].ne(0).to(dtype=torch.int32)
+        if torch.distributed.is_initialized():
+            torch.distributed.all_reduce(overflow_ranks, op=torch.distributed.ReduceOp.SUM)
+        return int(overflow_ranks.item())
+
     def _rerun_after_paged_stash_overflow(
         self,
         batches,
         *,
         num_label_tokens: int | None,
         loss_buffer: list[torch.Tensor],
+        rng_state: RNGState | None,
     ) -> list[torch.Tensor]:
-        """Globally discard an overflowing graph attempt and rerun the whole step eagerly."""
+        """Globally discard an overflowing graph attempt and rerun the whole step eagerly.
+
+        Args:
+            batches: The exact microbatches consumed by the failed attempt.
+            num_label_tokens: Global number of non-ignored labels, or ``None`` when normalized later.
+            loss_buffer: Detached losses from the failed attempt.
+            rng_state: RNG snapshot taken immediately before the failed attempt.
+
+        Returns:
+            ``loss_buffer`` when no rank overflowed, otherwise losses from a full eager retry of the same batches.
+        """
         if not getattr(self, "_partial_cuda_graph_paged_stash_enabled", False):
             return loss_buffer
 
@@ -1200,20 +1253,17 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
         stash_manager = get_paged_stash_manager()
         if not stash_manager.is_active:
             return loss_buffer
-        overflow = stash_manager.check_overflow()
-        if overflow is None:
-            raise RuntimeError("Active partial MoE paged stash has no overflow flag")
-        overflow_ranks = overflow.reshape(-1)[0].ne(0).to(dtype=torch.int32)
-        if torch.distributed.is_initialized():
-            torch.distributed.all_reduce(overflow_ranks, op=torch.distributed.ReduceOp.SUM)
-        if int(overflow_ranks.item()) == 0:
+        overflow_ranks = self._paged_stash_overflow_rank_count(stash_manager)
+        if overflow_ranks == 0:
             stash_manager.finish_iteration()
             return loss_buffer
+        if rng_state is None:
+            raise RuntimeError("Paged-stash overflow retry is missing the pre-attempt RNG state")
 
         logger.warning(
             "Discarding partial CUDA graph gradients and rerunning the whole step eagerly after paged-stash "
             "overflow on %d ranks",
-            int(overflow_ranks.item()),
+            overflow_ranks,
         )
         self._partial_cuda_graph_paged_stash_reruns += 1
 
@@ -1222,6 +1272,7 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
         self._close_partial_cuda_graphs()
         for optimizer in self.optimizer:
             optimizer.zero_grad()
+        self.rng.load_state_dict(rng_state)
         return self._run_forward_backward_batches(batches, num_label_tokens=num_label_tokens)
 
     def _run_train_optim_step(self, batches, max_grad_norm: Optional[float] = None):
@@ -1264,11 +1315,13 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
         )
         num_tokens_in_batch = self._dp_allreduce(num_tokens_in_batch).item()
 
+        paged_stash_rng_state = self._snapshot_paged_stash_rng_state()
         loss_buffer = self._run_forward_backward_batches(batches, num_label_tokens=num_label_tokens)
         loss_buffer = self._rerun_after_paged_stash_overflow(
             batches,
             num_label_tokens=num_label_tokens,
             loss_buffer=loss_buffer,
+            rng_state=paged_stash_rng_state,
         )
 
         grad_norm = scale_grads_and_clip_grad_norm(

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -459,6 +459,8 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
         # eager optimizer step has supplied representative runtime inputs.
         self.partial_cuda_graph_manager = None
         self._partial_cuda_graph_capture_pending = False
+        self._partial_cuda_graph_paged_stash_enabled = False
+        self._partial_cuda_graph_paged_stash_reruns = 0
 
     # ------------------ build phase ------------------
     def _create_distributed_setup(self) -> DistributedSetup:
@@ -813,8 +815,11 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
             activation_checkpointing=bool(self.activation_checkpointing),
             pipeline_parallel=bool(self.pp_enabled),
         )
-        if self.partial_cuda_graph_manager is not None:
-            self._partial_cuda_graph_capture_pending = True
+        self._partial_cuda_graph_capture_pending = self.partial_cuda_graph_manager is not None
+        enabled_parts = [part for part in self.model_parts if part.backend.cuda_graph.moe_paged_stash]
+        self._partial_cuda_graph_paged_stash_enabled = bool(enabled_parts)
+        if self._partial_cuda_graph_paged_stash_enabled and self.partial_cuda_graph_manager is None:
+            raise RuntimeError("MoE paged stash requires an active partial CUDA graph manager")
         torch.cuda.empty_cache()
 
         # Log step scheduler details
@@ -1160,6 +1165,65 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
         torch.distributed.broadcast(tensor, src=pp_src_rank, group=pp_group)
         return tensor
 
+    def _run_forward_backward_batches(self, batches, *, num_label_tokens: int | None) -> list[torch.Tensor]:
+        """Run one complete gradient-accumulation forward/backward schedule."""
+        loss_buffer: list[torch.Tensor] = []
+        num_batches = len(batches)
+        prepare_for_grad_accumulation(self.model_parts, pp_enabled=self.pp_enabled)
+        for index, batch in enumerate(batches):
+            if index == num_batches - 1:
+                prepare_for_final_backward(self.model_parts, pp_enabled=self.pp_enabled)
+            self._forward_backward_step(
+                index,
+                batch,
+                loss_buffer=loss_buffer,
+                num_label_tokens=num_label_tokens,
+                num_batches=num_batches,
+            )
+            if index == 0:
+                prepare_after_first_microbatch()
+        return loss_buffer
+
+    def _rerun_after_paged_stash_overflow(
+        self,
+        batches,
+        *,
+        num_label_tokens: int | None,
+        loss_buffer: list[torch.Tensor],
+    ) -> list[torch.Tensor]:
+        """Globally discard an overflowing graph attempt and rerun the whole step eagerly."""
+        if not getattr(self, "_partial_cuda_graph_paged_stash_enabled", False):
+            return loss_buffer
+
+        from nemo_automodel.components.moe.paged_stash import get_paged_stash_manager
+
+        stash_manager = get_paged_stash_manager()
+        if not stash_manager.is_active:
+            return loss_buffer
+        overflow = stash_manager.check_overflow()
+        if overflow is None:
+            raise RuntimeError("Active partial MoE paged stash has no overflow flag")
+        overflow_ranks = overflow.reshape(-1)[0].ne(0).to(dtype=torch.int32)
+        if torch.distributed.is_initialized():
+            torch.distributed.all_reduce(overflow_ranks, op=torch.distributed.ReduceOp.SUM)
+        if int(overflow_ranks.item()) == 0:
+            stash_manager.finish_iteration()
+            return loss_buffer
+
+        logger.warning(
+            "Discarding partial CUDA graph gradients and rerunning the whole step eagerly after paged-stash "
+            "overflow on %d ranks",
+            int(overflow_ranks.item()),
+        )
+        self._partial_cuda_graph_paged_stash_reruns += 1
+
+        # Graphs reference the page buffers, so destroy them before disabling
+        # the stash. No clipping or optimizer action has happened yet.
+        self._close_partial_cuda_graphs()
+        for optimizer in self.optimizer:
+            optimizer.zero_grad()
+        return self._run_forward_backward_batches(batches, num_label_tokens=num_label_tokens)
+
     def _run_train_optim_step(self, batches, max_grad_norm: Optional[float] = None):
         """Execute a single training step.
 
@@ -1193,8 +1257,6 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
                 float(self._get_dp_group_size(include_cp=True))
             )
 
-        loss_buffer = []
-
         # number of tokens in the batch, excluding any tail padding.
         num_tokens_in_batch = torch.tensor(
             sum(batch["labels"].numel() - count_tail_padding(batch["labels"]) for batch in batches),
@@ -1202,19 +1264,12 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
         )
         num_tokens_in_batch = self._dp_allreduce(num_tokens_in_batch).item()
 
-        num_batches = len(batches)
-        prepare_for_grad_accumulation(self.model_parts, pp_enabled=self.pp_enabled)
-
-        for i, batch in enumerate(batches):
-            if i == num_batches - 1:
-                prepare_for_final_backward(self.model_parts, pp_enabled=self.pp_enabled)
-
-            self._forward_backward_step(
-                i, batch, loss_buffer=loss_buffer, num_label_tokens=num_label_tokens, num_batches=num_batches
-            )
-
-            if i == 0:
-                prepare_after_first_microbatch()
+        loss_buffer = self._run_forward_backward_batches(batches, num_label_tokens=num_label_tokens)
+        loss_buffer = self._rerun_after_paged_stash_overflow(
+            batches,
+            num_label_tokens=num_label_tokens,
+            loss_buffer=loss_buffer,
+        )
 
         grad_norm = scale_grads_and_clip_grad_norm(
             max_grad_norm,

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -460,7 +460,6 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
         self.partial_cuda_graph_manager = None
         self._partial_cuda_graph_capture_pending = False
         self._partial_cuda_graph_paged_stash_enabled = False
-        self._partial_cuda_graph_paged_stash_reruns = 0
 
     # ------------------ build phase ------------------
     def _create_distributed_setup(self) -> DistributedSetup:
@@ -960,7 +959,27 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
                     # eager optimizer step has completed. This leaves no
                     # pending checkpoint recomputation or GA backward work.
                     if self.partial_cuda_graph_manager is not None and self._partial_cuda_graph_capture_pending:
+                        stash_manager = None
+                        if self._partial_cuda_graph_paged_stash_enabled:
+                            from nemo_automodel.components.moe.paged_stash import get_paged_stash_manager
+
+                            stash_manager = get_paged_stash_manager()
+                            stash_manager.prepare()
+                            logger.info("Partial MoE paged stash prepared: %s", stash_manager.diagnostics())
                         self.partial_cuda_graph_manager.capture()
+                        if stash_manager is not None:
+                            overflow_ranks = self._paged_stash_overflow_rank_count(stash_manager)
+                            if overflow_ranks:
+                                self.partial_cuda_graph_manager.close()
+                                self.partial_cuda_graph_manager = None
+                                stash_manager.close()
+                                self._partial_cuda_graph_paged_stash_enabled = False
+                                self._partial_cuda_graph_capture_pending = False
+                                raise RuntimeError(
+                                    "MoE paged stash capacity overflowed during CUDA graph capture on "
+                                    f"{overflow_ranks} ranks; partial CUDA graphs were disabled"
+                                )
+                            stash_manager.finish_iteration()
                         self._partial_cuda_graph_capture_pending = False
                     # Collect MoE load balance metrics (all ranks participate in all-reduce)
                     self._collect_moe_load_balance()
@@ -1016,6 +1035,11 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
             self.partial_cuda_graph_manager.close()
             self.partial_cuda_graph_manager = None
         self._partial_cuda_graph_capture_pending = False
+        if self._partial_cuda_graph_paged_stash_enabled:
+            from nemo_automodel.components.moe.paged_stash import get_paged_stash_manager
+
+            get_paged_stash_manager().close()
+            self._partial_cuda_graph_paged_stash_enabled = False
 
     # ------------------ helpers ------------------
     def _forward_backward_step(
@@ -1199,7 +1223,7 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
             Python, NumPy, PyTorch, and CUDA RNG state when paged stash is active, or ``None`` when no retry can
             occur.
         """
-        if not getattr(self, "_partial_cuda_graph_paged_stash_enabled", False):
+        if not self._partial_cuda_graph_paged_stash_enabled:
             return None
 
         from nemo_automodel.components.moe.paged_stash import get_paged_stash_manager
@@ -1245,7 +1269,7 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
         Returns:
             ``loss_buffer`` when no rank overflowed, otherwise losses from a full eager retry of the same batches.
         """
-        if not getattr(self, "_partial_cuda_graph_paged_stash_enabled", False):
+        if not self._partial_cuda_graph_paged_stash_enabled:
             return loss_buffer
 
         from nemo_automodel.components.moe.paged_stash import get_paged_stash_manager
@@ -1265,11 +1289,14 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
             "overflow on %d ranks",
             overflow_ranks,
         )
-        self._partial_cuda_graph_paged_stash_reruns += 1
-
         # Graphs reference the page buffers, so destroy them before disabling
         # the stash. No clipping or optimizer action has happened yet.
-        self._close_partial_cuda_graphs()
+        if self.partial_cuda_graph_manager is not None:
+            self.partial_cuda_graph_manager.close()
+            self.partial_cuda_graph_manager = None
+        self._partial_cuda_graph_capture_pending = False
+        stash_manager.close()
+        self._partial_cuda_graph_paged_stash_enabled = False
         for optimizer in self.optimizer:
             optimizer.zero_grad()
         self.rng.load_state_dict(rng_state)

--- a/tests/functional_tests/moe/test_paged_stash_cuda_graph.py
+++ b/tests/functional_tests/moe/test_paged_stash_cuda_graph.py
@@ -301,10 +301,13 @@ def test_te_grouped_linear_paged_stash_matches_eager_across_graph_replays():
         warmup_inputs = _inputs(warmup_mask, seed=123)
         warmup_output = target(*warmup_inputs)
         warmup_output.sum().backward()
-        assert stash_manager.diagnostics()["recorded_peak_tokens"]
+        assert set(stash_manager.diagnostics()["recorded_peak_tokens"]) == {
+            (torch.bfloat16, 4),
+            (torch.bfloat16, 8),
+        }
         optimizer.zero_grad(set_to_none=True)
-        # The manager owns detached sample clones. Drop the eager autograd graph
-        # so its default-stream AccumulateGrad nodes cannot leak into TE capture.
+        # The manager owns detached sample clones after recording, so these local
+        # warmup references are no longer needed.
         del warmup_output, warmup_inputs
 
         stash_manager.prepare()
@@ -355,6 +358,7 @@ def test_te_grouped_linear_paged_stash_matches_eager_across_graph_replays():
                     expected = parameters_before_step[name] - 0.01 * eager_parameter_gradients[name]
                     torch.testing.assert_close(parameter, expected)
             optimizer.zero_grad(set_to_none=True)
+        assert graph_manager.stats() == {"captured": 1, "replayed": 3, "fallback": 0}
     finally:
         graph_manager.close()
         stash_manager.close()

--- a/tests/functional_tests/moe/test_paged_stash_cuda_graph.py
+++ b/tests/functional_tests/moe/test_paged_stash_cuda_graph.py
@@ -14,13 +14,20 @@
 
 """CUDA parity guard for paged TE expert activations under real graph replay."""
 
+import os
+import tempfile
+from types import SimpleNamespace
+
 import pytest
 import torch
+import torch.multiprocessing as mp
 from torch import nn
 
+import nemo_automodel.components.moe.paged_stash as paged_stash
 from nemo_automodel.components.moe.paged_stash import PagedStashManager
 from nemo_automodel.components.moe.paged_stash_ops import HAVE_TRITON
 from nemo_automodel.recipes.llm.partial_cuda_graphs import PartialCudaGraphManager, _PartialGraphEntry
+from nemo_automodel.recipes.llm.train_ft import TrainFinetuneRecipeForNextTokenPrediction
 
 
 class _GraphableTEExperts(nn.Module):
@@ -83,6 +90,70 @@ def _inputs(live_token_mask: torch.Tensor, *, seed: int) -> tuple[torch.Tensor, 
     )
 
 
+def _asymmetric_overflow_worker(rank: int, world_size: int, init_method: str) -> None:
+    """Verify a single-rank overflow makes every rank discard and retry."""
+    torch.cuda.set_device(rank)
+    torch.distributed.init_process_group(
+        backend="nccl",
+        init_method=init_method,
+        rank=rank,
+        world_size=world_size,
+    )
+    events = []
+    stash_manager = SimpleNamespace(
+        is_active=True,
+        check_overflow=lambda: torch.tensor([rank == 0], dtype=torch.int64, device="cuda"),
+        close=lambda: events.append("stash-close"),
+    )
+    paged_stash._PAGED_STASH_MANAGER = stash_manager
+    recipe = TrainFinetuneRecipeForNextTokenPrediction.__new__(TrainFinetuneRecipeForNextTokenPrediction)
+    recipe.partial_cuda_graph_manager = SimpleNamespace(close=lambda: events.append("graph-close"))
+    recipe._partial_cuda_graph_capture_pending = False
+    recipe._partial_cuda_graph_paged_stash_enabled = True
+    recipe._partial_cuda_graph_paged_stash_reruns = 0
+    recipe.optimizer = [SimpleNamespace(zero_grad=lambda: events.append("zero-grad"))]
+    recipe.rng = SimpleNamespace(load_state_dict=lambda state: events.append(("restore-rng", state)))
+    recipe._run_forward_backward_batches = lambda _batches, num_label_tokens: (
+        events.append(("rerun", num_label_tokens)) or [torch.tensor(2.0, device="cuda")]
+    )
+
+    try:
+        result = recipe._rerun_after_paged_stash_overflow(
+            ["same-batch"],
+            num_label_tokens=7,
+            loss_buffer=[torch.tensor(1.0, device="cuda")],
+            rng_state="pre-attempt-state",
+        )
+        assert result[0].item() == 2.0
+        assert recipe._partial_cuda_graph_paged_stash_reruns == 1
+        assert events == [
+            "graph-close",
+            "stash-close",
+            "zero-grad",
+            ("restore-rng", "pre-attempt-state"),
+            ("rerun", 7),
+        ]
+    finally:
+        torch.distributed.destroy_process_group()
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Two CUDA devices are required")
+def test_asymmetric_overflow_retries_on_every_rank():
+    """Exercise the real NCCL overflow reduction with only rank zero set."""
+    with tempfile.NamedTemporaryFile(delete=False) as rendezvous:
+        rendezvous_path = rendezvous.name
+    try:
+        mp.spawn(
+            _asymmetric_overflow_worker,
+            args=(2, f"file://{rendezvous_path}"),
+            nprocs=2,
+            join=True,
+        )
+    finally:
+        if os.path.exists(rendezvous_path):
+            os.unlink(rendezvous_path)
+
+
 @pytest.mark.skipif(not torch.cuda.is_available() or not HAVE_TRITON, reason="CUDA and Triton are required")
 def test_te_grouped_linear_paged_stash_matches_eager_across_graph_replays():
     """Compare BF16 graph output/gradients/update with eager and force page reuse."""
@@ -111,6 +182,9 @@ def test_te_grouped_linear_paged_stash_matches_eager_across_graph_replays():
         warmup_output.sum().backward()
         assert stash_manager.diagnostics()["recorded_peak_tokens"]
         optimizer.zero_grad(set_to_none=True)
+        # The manager owns detached sample clones. Drop the eager autograd graph
+        # so its default-stream AccumulateGrad nodes cannot leak into TE capture.
+        del warmup_output, warmup_inputs
 
         stash_manager.prepare()
         graph_manager.capture()

--- a/tests/functional_tests/moe/test_paged_stash_cuda_graph.py
+++ b/tests/functional_tests/moe/test_paged_stash_cuda_graph.py
@@ -26,8 +26,63 @@ from torch import nn
 import nemo_automodel.components.moe.paged_stash as paged_stash
 from nemo_automodel.components.moe.paged_stash import PagedStashManager
 from nemo_automodel.components.moe.paged_stash_ops import HAVE_TRITON
+from nemo_automodel.components.training.rng import StatefulRNG
 from nemo_automodel.recipes.llm.partial_cuda_graphs import PartialCudaGraphManager, _PartialGraphEntry
 from nemo_automodel.recipes.llm.train_ft import TrainFinetuneRecipeForNextTokenPrediction
+
+
+class _GatedActivation(torch.autograd.Function):
+    """Tiny gated activation that saves the complete marked pre-activation surface."""
+
+    @staticmethod
+    def forward(ctx, gate_up_output: torch.Tensor) -> torch.Tensor:
+        """Apply SwiGLU while saving the complete marked activation.
+
+        Args:
+            ctx: Autograd context for the gated activation.
+            gate_up_output: Contiguous pre-activation with shape ``[tokens, 2 * hidden]``.
+
+        Returns:
+            Activated tensor with shape ``[tokens, hidden]``.
+        """
+        ctx.save_for_backward(gate_up_output)
+        gate, up = gate_up_output.chunk(2, dim=-1)
+        return torch.nn.functional.silu(gate) * up
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor) -> tuple[torch.Tensor]:
+        """Differentiate the gated activation.
+
+        Args:
+            ctx: Autograd context populated by :meth:`forward`.
+            grad_output: Activation gradient with shape ``[tokens, hidden]``.
+
+        Returns:
+            Pre-activation gradient with shape ``[tokens, 2 * hidden]``.
+        """
+        (gate_up_output,) = ctx.saved_tensors
+        gate, up = gate_up_output.chunk(2, dim=-1)
+        sigmoid = torch.sigmoid(gate)
+        silu = gate * sigmoid
+        gate_gradient = grad_output * up * sigmoid * (1 + gate * (1 - sigmoid))
+        up_gradient = grad_output * silu
+        return (torch.cat((gate_gradient, up_gradient), dim=-1),)
+
+
+class _SegmentedSquare(torch.autograd.Function):
+    """Simple saved-tensor consumer used to verify sparse row restoration."""
+
+    @staticmethod
+    def forward(ctx, tensor: torch.Tensor) -> torch.Tensor:
+        """Save and square a tensor with shape ``[tokens, hidden]``."""
+        ctx.save_for_backward(tensor)
+        return tensor.square()
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor) -> tuple[torch.Tensor]:
+        """Return the elementwise gradient with shape ``[tokens, hidden]``."""
+        (tensor,) = ctx.saved_tensors
+        return (2 * tensor * grad_output,)
 
 
 class _GraphableTEExperts(nn.Module):
@@ -36,10 +91,18 @@ class _GraphableTEExperts(nn.Module):
     def __init__(self, stash_manager: PagedStashManager, grouped_linear: type[nn.Module]) -> None:
         super().__init__()
         self.__dict__["stash_manager"] = stash_manager
-        self.grouped_linear = grouped_linear(
+        self.gate_up_linear = grouped_linear(
             num_gemms=2,
             in_features=4,
             out_features=8,
+            bias=False,
+            params_dtype=torch.bfloat16,
+            device="cuda",
+        )
+        self.down_linear = grouped_linear(
+            num_gemms=2,
+            in_features=4,
+            out_features=4,
             bias=False,
             params_dtype=torch.bfloat16,
             device="cuda",
@@ -61,7 +124,7 @@ class _GraphableTEExperts(nn.Module):
             expert_indices: Expert ids with shape ``[6, 1]``; this guard uses expert zero for every live row.
 
         Returns:
-            Grouped expert output with shape ``[6, 8]``.
+            Grouped expert output with shape ``[6, 4]``.
         """
         weighted_states = hidden_states * routing_weights.to(dtype=hidden_states.dtype)
         live_token_mask = token_mask & routing_weights[:, 0].ne(0) & expert_indices[:, 0].eq(0)
@@ -72,12 +135,26 @@ class _GraphableTEExperts(nn.Module):
         )
         weighted_states = group.start(weighted_states)
         with group:
-            output = self.grouped_linear(group.mark_activation(weighted_states), [3, 3])
+            gate_up_output = self.gate_up_linear(weighted_states, [3, 3])
+            gate_up_output = group.mark_activation(gate_up_output)
+            activated = _GatedActivation.apply(gate_up_output)
+            activated = group.mark_activation(activated)
+            output = self.down_linear(activated, [3, 3])
+        del gate_up_output, activated
         return group.commit(output)
 
 
 def _inputs(live_token_mask: torch.Tensor, *, seed: int) -> tuple[torch.Tensor, ...]:
-    """Create one fixed-shape expert call whose padding rows carry zero routing weight."""
+    """Create one fixed-shape expert call whose padding rows carry zero routing weight.
+
+    Args:
+        live_token_mask: Boolean CUDA tensor with shape ``[6]``.
+        seed: Seed for the local CUDA generator that creates inputs.
+
+    Returns:
+        Hidden states ``[6, 4]``, the unchanged token mask ``[6]``, differentiable routing weights ``[6, 1]``,
+        and integer expert indices ``[6, 1]``.
+    """
     generator = torch.Generator(device="cuda").manual_seed(seed)
     hidden_states = torch.randn(6, 4, generator=generator, device="cuda", dtype=torch.bfloat16)
     routing_weights = torch.rand(6, 1, generator=generator, device="cuda", dtype=torch.float32)
@@ -88,6 +165,38 @@ def _inputs(live_token_mask: torch.Tensor, *, seed: int) -> tuple[torch.Tensor, 
         routing_weights.requires_grad_(),
         torch.zeros(6, 1, device="cuda", dtype=torch.int64),
     )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available() or not HAVE_TRITON, reason="CUDA and Triton are required")
+def test_active_stash_restores_sparse_rows_and_zeros_padding():
+    """Validate Triton page copy/pop semantics before composing them with TE graphs."""
+    manager = PagedStashManager()
+    manager.configure(enabled=True, page_size=2, buffer_size_factor=1.5)
+
+    warmup = torch.randn(8, 4, device="cuda", requires_grad=True)
+    warmup_mask = torch.tensor([True, False, True, True, False, True, False, True], device="cuda")
+    warmup_group = manager.group(name="warmup", max_num_tokens=8, live_token_mask=warmup_mask)
+    warmup_for_compute = warmup_group.start(warmup)
+    with warmup_group:
+        warmup_output = _SegmentedSquare.apply(warmup_group.mark_activation(warmup_for_compute))
+    warmup_group.commit(warmup_output).sum().backward()
+    manager.prepare()
+
+    tensor = torch.randn(8, 4, device="cuda", requires_grad=True)
+    live_mask = torch.tensor([True, False, True, False, False, True, False, False], device="cuda")
+    group = manager.group(name="active", max_num_tokens=8, live_token_mask=live_mask)
+    tensor_for_compute = group.start(tensor)
+    with group:
+        output = _SegmentedSquare.apply(group.mark_activation(tensor_for_compute))
+    group.commit(output).sum().backward()
+
+    expected = torch.zeros_like(tensor)
+    expected[live_mask] = 2 * tensor.detach()[live_mask]
+    torch.testing.assert_close(tensor.grad, expected)
+    assert manager.check_overflow() is not None
+    assert manager.check_overflow().item() == 0
+    manager.finish_iteration()
+    manager.close()
 
 
 def _asymmetric_overflow_worker(rank: int, world_size: int, init_method: str) -> None:
@@ -112,27 +221,39 @@ def _asymmetric_overflow_worker(rank: int, world_size: int, init_method: str) ->
     recipe._partial_cuda_graph_paged_stash_enabled = True
     recipe._partial_cuda_graph_paged_stash_reruns = 0
     recipe.optimizer = [SimpleNamespace(zero_grad=lambda: events.append("zero-grad"))]
-    recipe.rng = SimpleNamespace(load_state_dict=lambda state: events.append(("restore-rng", state)))
-    recipe._run_forward_backward_batches = lambda _batches, num_label_tokens: (
-        events.append(("rerun", num_label_tokens)) or [torch.tensor(2.0, device="cuda")]
-    )
+    stateful_rng = StatefulRNG(seed=1234 + rank)
+    rng_state = stateful_rng.state_dict()
+    expected_cuda_draw = torch.rand(3, device="cuda")
+    torch.rand(3, device="cuda")
+
+    def restore_rng(state) -> None:
+        events.append(("restore-rng", state))
+        stateful_rng.load_state_dict(state)
+
+    actual_cuda_draws = []
+
+    def rerun(_batches, num_label_tokens):
+        events.append(("rerun", num_label_tokens))
+        actual_cuda_draws.append(torch.rand(3, device="cuda"))
+        return [torch.tensor(2.0, device="cuda")]
+
+    recipe.rng = SimpleNamespace(load_state_dict=restore_rng)
+    recipe._run_forward_backward_batches = rerun
 
     try:
         result = recipe._rerun_after_paged_stash_overflow(
             ["same-batch"],
             num_label_tokens=7,
             loss_buffer=[torch.tensor(1.0, device="cuda")],
-            rng_state="pre-attempt-state",
+            rng_state=rng_state,
         )
         assert result[0].item() == 2.0
         assert recipe._partial_cuda_graph_paged_stash_reruns == 1
-        assert events == [
-            "graph-close",
-            "stash-close",
-            "zero-grad",
-            ("restore-rng", "pre-attempt-state"),
-            ("rerun", 7),
-        ]
+        assert events[:3] == ["graph-close", "stash-close", "zero-grad"]
+        assert events[3][0] == "restore-rng"
+        assert events[3][1] is rng_state
+        assert events[4] == ("rerun", 7)
+        torch.testing.assert_close(actual_cuda_draws[0], expected_cuda_draw)
     finally:
         torch.distributed.destroy_process_group()
 
@@ -195,6 +316,7 @@ def test_te_grouped_linear_paged_stash_matches_eager_across_graph_replays():
         replay_masks = (
             torch.tensor([True, False, True, True, False, True], device="cuda"),
             torch.tensor([False, True, True, False, True, True], device="cuda"),
+            torch.tensor([True, True, False, True, True, False], device="cuda"),
         )
         for replay_index, live_token_mask in enumerate(replay_masks):
             eager_inputs = _inputs(live_token_mask, seed=456 + replay_index)
@@ -212,9 +334,7 @@ def test_te_grouped_linear_paged_stash_matches_eager_across_graph_replays():
             eager_parameter_gradients = {
                 name: parameter.grad.detach().clone() for name, parameter in target.named_parameters()
             }
-            parameters_before_step = {
-                name: parameter.detach().clone() for name, parameter in target.named_parameters()
-            }
+            parameters_before_step = {name: parameter.detach().clone() for name, parameter in target.named_parameters()}
             optimizer.zero_grad(set_to_none=True)
 
             graph_inputs = tuple(value.detach().clone().requires_grad_(value.requires_grad) for value in eager_inputs)

--- a/tests/functional_tests/moe/test_paged_stash_cuda_graph.py
+++ b/tests/functional_tests/moe/test_paged_stash_cuda_graph.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CUDA parity guard for paged TE expert activations under real graph replay."""
+
+import pytest
+import torch
+from torch import nn
+
+from nemo_automodel.components.moe.paged_stash import PagedStashManager
+from nemo_automodel.components.moe.paged_stash_ops import HAVE_TRITON
+from nemo_automodel.recipes.llm.partial_cuda_graphs import PartialCudaGraphManager, _PartialGraphEntry
+
+
+class _GraphableTEExperts(nn.Module):
+    """Tiny fixed-capacity TE expert boundary with production-style stash hooks."""
+
+    def __init__(self, stash_manager: PagedStashManager, grouped_linear: type[nn.Module]) -> None:
+        super().__init__()
+        self.__dict__["stash_manager"] = stash_manager
+        self.grouped_linear = grouped_linear(
+            num_gemms=2,
+            in_features=4,
+            out_features=8,
+            bias=False,
+            params_dtype=torch.bfloat16,
+            device="cuda",
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        token_mask: torch.Tensor,
+        routing_weights: torch.Tensor,
+        expert_indices: torch.Tensor,
+    ) -> torch.Tensor:
+        """Run two equal-capacity experts while paging live saved rows.
+
+        Args:
+            hidden_states: BF16 expert inputs with shape ``[6, 4]``.
+            token_mask: Boolean valid-token mask with shape ``[6]``.
+            routing_weights: Differentiable routing weights with shape ``[6, 1]``.
+            expert_indices: Expert ids with shape ``[6, 1]``; this guard uses expert zero for every live row.
+
+        Returns:
+            Grouped expert output with shape ``[6, 8]``.
+        """
+        weighted_states = hidden_states * routing_weights.to(dtype=hidden_states.dtype)
+        live_token_mask = token_mask & routing_weights[:, 0].ne(0) & expert_indices[:, 0].eq(0)
+        group = self.stash_manager.group(
+            name="functional_te_grouped_linear",
+            max_num_tokens=hidden_states.shape[0],
+            live_token_mask=live_token_mask,
+        )
+        weighted_states = group.start(weighted_states)
+        with group:
+            output = self.grouped_linear(group.mark_activation(weighted_states), [3, 3])
+        return group.commit(output)
+
+
+def _inputs(live_token_mask: torch.Tensor, *, seed: int) -> tuple[torch.Tensor, ...]:
+    """Create one fixed-shape expert call whose padding rows carry zero routing weight."""
+    generator = torch.Generator(device="cuda").manual_seed(seed)
+    hidden_states = torch.randn(6, 4, generator=generator, device="cuda", dtype=torch.bfloat16)
+    routing_weights = torch.rand(6, 1, generator=generator, device="cuda", dtype=torch.float32)
+    routing_weights[~live_token_mask] = 0
+    return (
+        hidden_states.requires_grad_(),
+        live_token_mask,
+        routing_weights.requires_grad_(),
+        torch.zeros(6, 1, device="cuda", dtype=torch.int64),
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available() or not HAVE_TRITON, reason="CUDA and Triton are required")
+def test_te_grouped_linear_paged_stash_matches_eager_across_graph_replays():
+    """Compare BF16 graph output/gradients/update with eager and force page reuse."""
+    te = pytest.importorskip("transformer_engine.pytorch")
+    stash_manager = PagedStashManager()
+    stash_manager.configure(enabled=True, page_size=2, buffer_size_factor=1.0)
+    target = _GraphableTEExperts(stash_manager, te.GroupedLinear)
+    optimizer = torch.optim.SGD(target.parameters(), lr=0.01)
+    graph_manager = PartialCudaGraphManager(
+        [
+            _PartialGraphEntry(
+                name="functional.te_experts",
+                target=target,
+                pool_group="moe",
+                explicit_parameters=True,
+                retain_graph_in_backward=True,
+            )
+        ]
+    )
+    graph_manager.start_recording()
+
+    try:
+        warmup_mask = torch.ones(6, dtype=torch.bool, device="cuda")
+        warmup_inputs = _inputs(warmup_mask, seed=123)
+        warmup_output = target(*warmup_inputs)
+        warmup_output.sum().backward()
+        assert stash_manager.diagnostics()["recorded_peak_tokens"]
+        optimizer.zero_grad(set_to_none=True)
+
+        stash_manager.prepare()
+        graph_manager.capture()
+        assert stash_manager.check_overflow().item() == 0
+        stash_manager.finish_iteration()
+        optimizer.zero_grad(set_to_none=True)
+
+        replay_masks = (
+            torch.tensor([True, False, True, True, False, True], device="cuda"),
+            torch.tensor([False, True, True, False, True, True], device="cuda"),
+        )
+        for replay_index, live_token_mask in enumerate(replay_masks):
+            eager_inputs = _inputs(live_token_mask, seed=456 + replay_index)
+            with graph_manager.eager_execution(), stash_manager.disabled():
+                eager_output = target(*eager_inputs)
+            output_gradient = torch.linspace(
+                0.25,
+                2.0,
+                eager_output.numel(),
+                device="cuda",
+                dtype=eager_output.dtype,
+            ).reshape_as(eager_output)
+            (eager_output * output_gradient).sum().backward()
+            eager_input_gradients = (eager_inputs[0].grad.detach().clone(), eager_inputs[2].grad.detach().clone())
+            eager_parameter_gradients = {
+                name: parameter.grad.detach().clone() for name, parameter in target.named_parameters()
+            }
+            parameters_before_step = {
+                name: parameter.detach().clone() for name, parameter in target.named_parameters()
+            }
+            optimizer.zero_grad(set_to_none=True)
+
+            graph_inputs = tuple(value.detach().clone().requires_grad_(value.requires_grad) for value in eager_inputs)
+            graph_output = target(*graph_inputs)
+            (graph_output * output_gradient).sum().backward()
+
+            torch.testing.assert_close(graph_output, eager_output)
+            torch.testing.assert_close(graph_inputs[0].grad, eager_input_gradients[0])
+            torch.testing.assert_close(graph_inputs[2].grad, eager_input_gradients[1])
+            for name, parameter in target.named_parameters():
+                torch.testing.assert_close(parameter.grad, eager_parameter_gradients[name])
+
+            assert stash_manager.check_overflow().item() == 0
+            stash_manager.finish_iteration()
+            if replay_index == 0:
+                optimizer.step()
+                for name, parameter in target.named_parameters():
+                    expected = parameters_before_step[name] - 0.01 * eager_parameter_gradients[name]
+                    torch.testing.assert_close(parameter, expected)
+            optimizer.zero_grad(set_to_none=True)
+    finally:
+        graph_manager.close()
+        stash_manager.close()

--- a/tests/functional_tests/moe/test_paged_stash_cuda_graph.py
+++ b/tests/functional_tests/moe/test_paged_stash_cuda_graph.py
@@ -24,10 +24,10 @@ import torch.multiprocessing as mp
 from torch import nn
 
 import nemo_automodel.components.moe.paged_stash as paged_stash
+from nemo_automodel.components.cuda_graphs.partial import PartialCudaGraphManager, _PartialGraphEntry
 from nemo_automodel.components.moe.paged_stash import PagedStashManager
 from nemo_automodel.components.moe.paged_stash_ops import HAVE_TRITON
 from nemo_automodel.components.training.rng import StatefulRNG
-from nemo_automodel.recipes.llm.partial_cuda_graphs import PartialCudaGraphManager, _PartialGraphEntry
 from nemo_automodel.recipes.llm.train_ft import TrainFinetuneRecipeForNextTokenPrediction
 
 
@@ -219,7 +219,6 @@ def _asymmetric_overflow_worker(rank: int, world_size: int, init_method: str) ->
     recipe.partial_cuda_graph_manager = SimpleNamespace(close=lambda: events.append("graph-close"))
     recipe._partial_cuda_graph_capture_pending = False
     recipe._partial_cuda_graph_paged_stash_enabled = True
-    recipe._partial_cuda_graph_paged_stash_reruns = 0
     recipe.optimizer = [SimpleNamespace(zero_grad=lambda: events.append("zero-grad"))]
     stateful_rng = StatefulRNG(seed=1234 + rank)
     rng_state = stateful_rng.state_dict()
@@ -248,7 +247,6 @@ def _asymmetric_overflow_worker(rank: int, world_size: int, init_method: str) ->
             rng_state=rng_state,
         )
         assert result[0].item() == 2.0
-        assert recipe._partial_cuda_graph_paged_stash_reruns == 1
         assert events[:3] == ["graph-close", "stash-close", "zero-grad"]
         assert events[3][0] == "restore-rng"
         assert events[3][1] is rng_state

--- a/tests/unit_tests/moe/test_backend_config.py
+++ b/tests/unit_tests/moe/test_backend_config.py
@@ -567,3 +567,33 @@ class TestBackendConfigPartialCudaGraphs:
                 dispatcher="deepep",
                 cuda_graph=CudaGraphConfig(modules=["moe_router", "moe_preprocess"]),
             )
+
+    def test_moe_paged_stash_requires_moe_scope_and_positive_capacity(self):
+        with pytest.raises(ValueError, match="requires 'moe'"):
+            CudaGraphConfig(moe_paged_stash=True)
+        with pytest.raises(ValueError, match="page_size must be a positive integer"):
+            CudaGraphConfig(
+                modules=["moe"],
+                moe_capacity_factor=1.25,
+                moe_paged_stash=True,
+                moe_paged_stash_page_size=0,
+            )
+        for invalid_factor in (0, 0.5, float("nan"), float("inf")):
+            with pytest.raises(ValueError, match="buffer_size_factor must be finite and at least 1.0"):
+                CudaGraphConfig(
+                    modules=["moe"],
+                    moe_capacity_factor=1.25,
+                    moe_paged_stash=True,
+                    moe_paged_stash_buffer_size_factor=invalid_factor,
+                )
+
+        config = BackendConfig(
+            experts="te",
+            dispatcher="torch",
+            cuda_graph=CudaGraphConfig(
+                modules=["moe"],
+                moe_capacity_factor=1.25,
+                moe_paged_stash=True,
+            ),
+        )
+        assert config.cuda_graph.moe_paged_stash is True

--- a/tests/unit_tests/moe/test_experts.py
+++ b/tests/unit_tests/moe/test_experts.py
@@ -1045,6 +1045,7 @@ class TestGroupedExpertsTECudaGraphMetadata:
         torch.nn.Module.__init__(experts)
         experts.config = config
         experts.cuda_graph_moe_capacity_factor = capacity_factor
+        experts.cuda_graph_moe_paged_stash = False
         return experts
 
     class _FakeGroupedLinear(torch.nn.Module):

--- a/tests/unit_tests/moe/test_paged_stash.py
+++ b/tests/unit_tests/moe/test_paged_stash.py
@@ -1,0 +1,285 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import nemo_automodel.components.moe.paged_stash as paged_stash
+from nemo_automodel.components.moe.paged_stash_ops import HAVE_TRITON
+
+
+class _SaveForBackward(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, tensor):
+        ctx.save_for_backward(tensor)
+        return tensor * 2
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        (tensor,) = ctx.saved_tensors
+        return grad_output + tensor * 0
+
+
+class _SegmentedSquare(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, tensor):
+        ctx.save_for_backward(tensor)
+        return tensor.square()
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        (tensor,) = ctx.saved_tensors
+        return 2 * tensor * grad_output
+
+
+def _record_group(manager, tensor, live_mask, *, name="test"):
+    group = manager.group(name=name, max_num_tokens=tensor.shape[0], live_token_mask=live_mask)
+    tensor = group.start(tensor)
+    with group:
+        marked = group.mark_activation(tensor)
+        output = _SaveForBackward.apply(marked.view_as(marked))
+    return group.commit(output)
+
+
+def test_recording_profiles_page_rounded_sparse_activations():
+    manager = paged_stash.PagedStashManager()
+    manager.configure(enabled=True, page_size=4, buffer_size_factor=1.2)
+
+    first = torch.arange(32.0).reshape(8, 4).detach().requires_grad_()
+    second_input = _record_group(
+        manager, first, torch.tensor([True, False, True, True, False, True, False, True]), name="first"
+    )
+    second = _record_group(
+        manager, second_input, torch.tensor([True, False, False, True, False, False, True, False]), name="second"
+    )
+    second.sum().backward()
+
+    diagnostics = manager.diagnostics()
+    assert diagnostics["recorded_peak_tokens"] == {(torch.float32, 4): 12}
+    assert diagnostics["live_groups"] == 0
+    with pytest.raises(RuntimeError, match="CUDA warmup"):
+        manager.prepare()
+    manager.close()
+
+
+def test_group_fails_closed_when_marked_activation_is_not_saved():
+    manager = paged_stash.PagedStashManager()
+    manager.configure(enabled=True)
+    tensor = torch.ones(8, 4, requires_grad=True)
+    group = manager.group(name="missing", max_num_tokens=8, live_token_mask=torch.ones(8, dtype=torch.bool))
+
+    tensor_for_compute = group.start(tensor)
+    with group:
+        group.mark_activation(tensor_for_compute)
+        output = tensor_for_compute * 2
+
+    with pytest.raises(RuntimeError, match="observed no registered"):
+        group.commit(output)
+    manager.close()
+
+
+def test_activation_surface_matches_only_row_aligned_storage_aliases():
+    tensor = torch.arange(32.0).reshape(8, 4)
+    live_mask = torch.tensor([True, False, True, True, False, True, False, True])
+    surface = paged_stash._ActivationSurface(
+        device=tensor.device,
+        dtype=tensor.dtype,
+        storage_ptr=tensor.untyped_storage().data_ptr(),
+        element_start=tensor.storage_offset(),
+        numel=tensor.numel(),
+        num_rows=tensor.shape[0],
+        row_width=tensor.shape[1],
+        live_token_mask=live_mask,
+    )
+
+    expert_view = tensor.narrow(0, 2, 3)
+    matched_rows, matched_mask = surface.match(expert_view)
+    assert matched_rows == 3
+    torch.testing.assert_close(matched_mask, live_mask[2:5])
+
+    assert surface.match(expert_view.clone()) is None
+    assert surface.match(tensor.flatten()[1:13]) is None
+    assert surface.match(tensor[:, :2]) is None
+    assert surface.match(tensor.view(4, 8)) is None
+
+
+def test_disabled_context_bypasses_hooks():
+    manager = paged_stash.PagedStashManager()
+    manager.configure(enabled=True)
+    tensor = torch.ones(8, 4, requires_grad=True)
+
+    with manager.disabled():
+        output = _record_group(manager, tensor, torch.ones(8, dtype=torch.bool))
+        output.sum().backward()
+
+    assert manager.diagnostics()["recorded_peak_tokens"] == {}
+    manager.close()
+
+
+def test_groups_fail_closed_when_nested():
+    manager = paged_stash.PagedStashManager()
+    manager.configure(enabled=True)
+    outer = manager.group(name="outer", max_num_tokens=8, live_token_mask=torch.ones(8, dtype=torch.bool))
+
+    with pytest.raises(RuntimeError, match="cannot nest"):
+        with outer:
+            manager.group(name="inner", max_num_tokens=8, live_token_mask=torch.ones(8, dtype=torch.bool))
+
+    with pytest.raises(RuntimeError, match="recording was invalid"):
+        manager.prepare()
+    manager.close()
+
+
+@pytest.mark.parametrize(
+    "live_mask",
+    [torch.ones(7, dtype=torch.bool), torch.ones(8), torch.ones(2, 4, dtype=torch.bool)],
+)
+def test_recording_rejects_invalid_live_mask(live_mask):
+    manager = paged_stash.PagedStashManager()
+    manager.configure(enabled=True)
+
+    with pytest.raises((TypeError, ValueError), match="one-dimensional|boolean dtype|expected max_num_tokens"):
+        manager.group(name="invalid", max_num_tokens=8, live_token_mask=live_mask)
+
+    manager.close()
+
+
+def test_configuration_is_idempotent_and_can_restart_recording():
+    manager = paged_stash.PagedStashManager()
+    manager.configure(enabled=True, page_size=32, buffer_size_factor=1.25)
+    manager.configure(enabled=True, page_size=32, buffer_size_factor=1.25)
+    with pytest.raises(RuntimeError, match="same page_size"):
+        manager.configure(enabled=True, page_size=64, buffer_size_factor=1.25)
+
+    manager.restart_recording()
+    diagnostics = manager.diagnostics()
+    assert diagnostics["state"] == "recording"
+    assert diagnostics["page_size"] == 32
+    assert diagnostics["buffer_size_factor"] == 1.25
+    manager.close()
+
+
+def test_device_overflow_api_does_not_require_host_read():
+    manager = paged_stash.PagedStashManager()
+    assert manager.check_overflow() is None
+    manager._overflow = torch.ones(1, dtype=torch.int64)
+    assert manager.check_overflow() is manager._overflow
+    with pytest.raises(paged_stash.PagedStashOverflowError):
+        manager.finish_iteration()
+    manager._overflow = None
+
+
+def test_reload_rejects_non_lifo_backward_order():
+    manager = paged_stash.PagedStashManager()
+    manager._backward_group_stack.extend([3, 4])
+
+    with pytest.raises(RuntimeError, match="expected group 4, got 3"):
+        manager._reload_group(3)
+
+
+def test_pre_boundary_releases_reload_storage_after_expert_consumer_backward():
+    events = []
+
+    class _ExpertConsumer(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, tensor):
+            return tensor.square()
+
+        @staticmethod
+        def backward(ctx, grad_output):
+            events.append("expert-backward")
+            return grad_output
+
+    manager = SimpleNamespace(
+        is_active=True,
+        _finish_group_backward=lambda group_id: events.append(("release", group_id)),
+    )
+    input_ = torch.randn(4, requires_grad=True)
+    bounded = paged_stash._PagedStashPreBoundary.apply(input_, manager, 7)
+
+    _ExpertConsumer.apply(bounded).sum().backward()
+
+    assert events == ["expert-backward", ("release", 7)]
+
+
+def test_group_rejects_frozen_expert_input():
+    manager = paged_stash.PagedStashManager()
+    manager.configure(enabled=True)
+    group = manager.group(name="expert", max_num_tokens=4, live_token_mask=torch.ones(4, dtype=torch.bool))
+
+    with pytest.raises(RuntimeError, match="expert input to require gradients"):
+        group.start(torch.randn(4, 8))
+
+    assert manager._current_group is None
+    assert manager._group_tensors == {}
+    with pytest.raises(RuntimeError, match="recording was invalid"):
+        manager.prepare()
+    manager.close()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available() or not HAVE_TRITON, reason="CUDA and Triton are required")
+def test_cuda_stash_restores_sparse_live_rows_and_zeros_padding():
+    manager = paged_stash.PagedStashManager()
+    manager.configure(enabled=True, page_size=2, buffer_size_factor=1.5)
+
+    warmup = torch.randn(8, 4, device="cuda", requires_grad=True)
+    warmup_mask = torch.tensor([True, False, True, True, False, True, False, True], device="cuda")
+    warmup_output = _record_group(manager, warmup, warmup_mask, name="warmup")
+    warmup_output.sum().backward()
+    manager.prepare()
+
+    tensor = torch.randn(8, 4, device="cuda", requires_grad=True)
+    live_mask = torch.tensor([True, False, True, False, False, True, False, False], device="cuda")
+    group = manager.group(name="active", max_num_tokens=8, live_token_mask=live_mask)
+    tensor_for_compute = group.start(tensor)
+    with group:
+        output = _SegmentedSquare.apply(group.mark_activation(tensor_for_compute))
+    output = group.commit(output)
+    output.sum().backward()
+
+    expected = torch.zeros_like(tensor)
+    expected[live_mask] = 2 * tensor.detach()[live_mask]
+    torch.testing.assert_close(tensor.grad, expected)
+    assert manager.check_overflow() is not None
+    assert manager.check_overflow().item() == 0
+    manager.finish_iteration()
+    manager.close()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_te_grouped_linear_exposes_registered_activation_to_saved_tensor_hooks():
+    te = pytest.importorskip("transformer_engine.pytorch")
+    linear = te.GroupedLinear(
+        num_gemms=2,
+        in_features=4,
+        out_features=8,
+        bias=False,
+        params_dtype=torch.float32,
+        device="cuda",
+    )
+    manager = paged_stash.PagedStashManager()
+    manager.configure(enabled=True, page_size=2)
+    tensor = torch.randn(6, 4, device="cuda", requires_grad=True)
+    group = manager.group(name="te", max_num_tokens=6, live_token_mask=torch.ones(6, dtype=torch.bool, device="cuda"))
+
+    tensor_for_compute = group.start(tensor)
+    with group:
+        output = linear(group.mark_activation(tensor_for_compute), [3, 3])
+    output = group.commit(output)
+    output.sum().backward()
+
+    assert manager.diagnostics()["recorded_peak_tokens"]
+    manager.close()

--- a/tests/unit_tests/moe/test_paged_stash.py
+++ b/tests/unit_tests/moe/test_paged_stash.py
@@ -18,7 +18,6 @@ import pytest
 import torch
 
 import nemo_automodel.components.moe.paged_stash as paged_stash
-from nemo_automodel.components.moe.paged_stash_ops import HAVE_TRITON
 
 
 class _SaveForBackward(torch.autograd.Function):
@@ -31,18 +30,6 @@ class _SaveForBackward(torch.autograd.Function):
     def backward(ctx, grad_output):
         (tensor,) = ctx.saved_tensors
         return grad_output + tensor * 0
-
-
-class _SegmentedSquare(torch.autograd.Function):
-    @staticmethod
-    def forward(ctx, tensor):
-        ctx.save_for_backward(tensor)
-        return tensor.square()
-
-    @staticmethod
-    def backward(ctx, grad_output):
-        (tensor,) = ctx.saved_tensors
-        return 2 * tensor * grad_output
 
 
 def _record_group(manager, tensor, live_mask, *, name="test"):
@@ -235,33 +222,4 @@ def test_group_rejects_frozen_expert_input():
     assert manager._group_tensors == {}
     with pytest.raises(RuntimeError, match="recording was invalid"):
         manager.prepare()
-    manager.close()
-
-
-@pytest.mark.skipif(not torch.cuda.is_available() or not HAVE_TRITON, reason="CUDA and Triton are required")
-def test_cuda_stash_restores_sparse_live_rows_and_zeros_padding():
-    manager = paged_stash.PagedStashManager()
-    manager.configure(enabled=True, page_size=2, buffer_size_factor=1.5)
-
-    warmup = torch.randn(8, 4, device="cuda", requires_grad=True)
-    warmup_mask = torch.tensor([True, False, True, True, False, True, False, True], device="cuda")
-    warmup_output = _record_group(manager, warmup, warmup_mask, name="warmup")
-    warmup_output.sum().backward()
-    manager.prepare()
-
-    tensor = torch.randn(8, 4, device="cuda", requires_grad=True)
-    live_mask = torch.tensor([True, False, True, False, False, True, False, False], device="cuda")
-    group = manager.group(name="active", max_num_tokens=8, live_token_mask=live_mask)
-    tensor_for_compute = group.start(tensor)
-    with group:
-        output = _SegmentedSquare.apply(group.mark_activation(tensor_for_compute))
-    output = group.commit(output)
-    output.sum().backward()
-
-    expected = torch.zeros_like(tensor)
-    expected[live_mask] = 2 * tensor.detach()[live_mask]
-    torch.testing.assert_close(tensor.grad, expected)
-    assert manager.check_overflow() is not None
-    assert manager.check_overflow().item() == 0
-    manager.finish_iteration()
     manager.close()

--- a/tests/unit_tests/moe/test_paged_stash.py
+++ b/tests/unit_tests/moe/test_paged_stash.py
@@ -172,6 +172,14 @@ def test_configuration_is_idempotent_and_can_restart_recording():
     manager.close()
 
 
+@pytest.mark.parametrize("invalid_factor", [0, 0.5, float("nan"), float("inf")])
+def test_configuration_rejects_buffer_factors_that_cannot_hold_warmup(invalid_factor):
+    manager = paged_stash.PagedStashManager()
+
+    with pytest.raises(ValueError, match="finite and at least 1.0"):
+        manager.configure(enabled=True, buffer_size_factor=invalid_factor)
+
+
 def test_device_overflow_api_does_not_require_host_read():
     manager = paged_stash.PagedStashManager()
     assert manager.check_overflow() is None
@@ -256,30 +264,4 @@ def test_cuda_stash_restores_sparse_live_rows_and_zeros_padding():
     assert manager.check_overflow() is not None
     assert manager.check_overflow().item() == 0
     manager.finish_iteration()
-    manager.close()
-
-
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
-def test_te_grouped_linear_exposes_registered_activation_to_saved_tensor_hooks():
-    te = pytest.importorskip("transformer_engine.pytorch")
-    linear = te.GroupedLinear(
-        num_gemms=2,
-        in_features=4,
-        out_features=8,
-        bias=False,
-        params_dtype=torch.float32,
-        device="cuda",
-    )
-    manager = paged_stash.PagedStashManager()
-    manager.configure(enabled=True, page_size=2)
-    tensor = torch.randn(6, 4, device="cuda", requires_grad=True)
-    group = manager.group(name="te", max_num_tokens=6, live_token_mask=torch.ones(6, dtype=torch.bool, device="cuda"))
-
-    tensor_for_compute = group.start(tensor)
-    with group:
-        output = linear(group.mark_activation(tensor_for_compute), [3, 3])
-    output = group.commit(output)
-    output.sum().backward()
-
-    assert manager.diagnostics()["recorded_peak_tokens"]
     manager.close()

--- a/tests/unit_tests/recipes/llm/test_benchmark.py
+++ b/tests/unit_tests/recipes/llm/test_benchmark.py
@@ -151,6 +151,7 @@ def mock_recipe(mock_config, monkeypatch):
         recipe.wandb_run = None
         recipe.partial_cuda_graph_manager = None
         recipe._partial_cuda_graph_capture_pending = False
+        recipe._partial_cuda_graph_paged_stash_enabled = False
         recipe.step_scheduler = SimpleNamespace(step=0, gc_every_steps=None)
         recipe._dp_allreduce = MagicMock(side_effect=lambda x, include_cp=False: x)
         recipe.device_mesh = None
@@ -471,6 +472,10 @@ class TestBenchmarkingRecipeRunBenchmark:
         graph_manager = MagicMock()
         mock_recipe.partial_cuda_graph_manager = graph_manager
         mock_recipe._partial_cuda_graph_capture_pending = True
+        mock_recipe._partial_cuda_graph_paged_stash_enabled = True
+        stash_manager = MagicMock()
+        stash_manager.is_active = False
+        stash_manager.check_overflow.return_value = torch.zeros(1, dtype=torch.int64)
 
         # Mock _forward_backward_step to append loss to loss_buffer
         def mock_forward_backward_step(ga_step_idx, batch, loss_buffer=None, **kwargs):
@@ -504,12 +509,20 @@ class TestBenchmarkingRecipeRunBenchmark:
             )
         )
 
-        with patch("torch.distributed.barrier"):
+        with (
+            patch("torch.distributed.barrier"),
+            patch(
+                "nemo_automodel.components.moe.paged_stash.get_paged_stash_manager",
+                return_value=stash_manager,
+            ),
+        ):
             mock_recipe.run_benchmark()
 
             # Should be called 30 times (once per iteration)
             assert mock_recipe.optimizer[0].step.call_count == 30
+            stash_manager.prepare.assert_called_once_with()
             graph_manager.capture.assert_called_once_with()
+            stash_manager.finish_iteration.assert_called_once_with()
             assert mock_recipe._partial_cuda_graph_capture_pending is False
 
     def test_run_benchmark_calls_gc_hook_per_iteration(self, mock_recipe):
@@ -581,6 +594,7 @@ class TestBenchmarkingRecipeHelpers:
         recipe = MagicMock()
         graph_manager = MagicMock()
         recipe.partial_cuda_graph_manager = graph_manager
+        recipe._partial_cuda_graph_paged_stash_enabled = False
         recipe.setup.side_effect = RuntimeError("setup failed")
 
         with (

--- a/tests/unit_tests/recipes/test_train_ft_partial_cuda_graphs.py
+++ b/tests/unit_tests/recipes/test_train_ft_partial_cuda_graphs.py
@@ -33,7 +33,44 @@ from nemo_automodel.recipes.llm.train_ft import (
 
 
 def _bare_recipe() -> TrainFinetuneRecipeForNextTokenPrediction:
-    return TrainFinetuneRecipeForNextTokenPrediction.__new__(TrainFinetuneRecipeForNextTokenPrediction)
+    recipe = TrainFinetuneRecipeForNextTokenPrediction.__new__(TrainFinetuneRecipeForNextTokenPrediction)
+    recipe.partial_cuda_graph_manager = None
+    recipe._partial_cuda_graph_capture_pending = False
+    recipe._partial_cuda_graph_paged_stash_enabled = False
+    return recipe
+
+
+def _configure_one_step_training_loop(recipe):
+    class _OneStepScheduler:
+        step = 0
+        epoch = 0
+        epochs = [0]
+        is_val_step = False
+        is_ckpt_step = False
+        sigterm_flag = False
+
+        def set_epoch(self, epoch):
+            self.epoch = epoch
+
+        def __iter__(self):
+            yield ["step-0"]
+
+    recipe.model_parts = [nn.Linear(2, 2)]
+    recipe.step_scheduler = _OneStepScheduler()
+    recipe.max_grad_norm = 1.0
+    recipe._enable_qat_if_delayed = lambda _step: None
+    recipe._run_train_optim_step = lambda _batches, _norm: SimpleNamespace(metrics={"loss": 1.0})
+    recipe._collect_moe_load_balance = lambda: None
+    recipe.log_train_metrics = lambda _metrics: None
+    recipe._update_progress_bar = lambda _pbar, _metrics: None
+    recipe._make_progress_bar = lambda: None
+    recipe.val_dataloaders = {}
+    recipe.save_checkpoint = lambda *_args, **_kwargs: None
+    recipe._maybe_collect_garbage = lambda: None
+    recipe.metric_logger_train = SimpleNamespace(close=lambda: None)
+    recipe.metric_logger_valid = {}
+    recipe.checkpointer = SimpleNamespace(close=lambda: None)
+    recipe.best_metric_key = "default"
 
 
 def test_builder_forwards_runtime_safety_context(monkeypatch):
@@ -79,16 +116,21 @@ def test_paged_stash_is_prepared_before_partial_capture(monkeypatch):
         check_overflow=lambda: torch.zeros(1, dtype=torch.int64),
         finish_iteration=lambda: events.append("finish"),
         diagnostics=lambda: {},
+        close=lambda: events.append("stash-close"),
     )
     monkeypatch.setattr(paged_stash, "get_paged_stash_manager", lambda: stash)
     recipe = _bare_recipe()
-    recipe.partial_cuda_graph_manager = SimpleNamespace(capture=lambda: events.append("capture"))
+    recipe.partial_cuda_graph_manager = SimpleNamespace(
+        capture=lambda: events.append("capture"),
+        close=lambda: events.append("graph-close"),
+    )
     recipe._partial_cuda_graph_capture_pending = True
     recipe._partial_cuda_graph_paged_stash_enabled = True
+    _configure_one_step_training_loop(recipe)
 
-    recipe._capture_partial_cuda_graphs_after_eager_step()
+    recipe.run_train_validation_loop()
 
-    assert events == ["prepare", "capture", "finish"]
+    assert events == ["prepare", "capture", "finish", "graph-close", "stash-close"]
 
 
 def test_capture_overflow_is_reduced_before_all_ranks_close_graphs(monkeypatch):
@@ -116,9 +158,10 @@ def test_capture_overflow_is_reduced_before_all_ranks_close_graphs(monkeypatch):
     )
     recipe._partial_cuda_graph_capture_pending = True
     recipe._partial_cuda_graph_paged_stash_enabled = True
+    _configure_one_step_training_loop(recipe)
 
     with pytest.raises(RuntimeError, match="capture on 2 ranks"):
-        recipe._capture_partial_cuda_graphs_after_eager_step()
+        recipe.run_train_validation_loop()
 
     assert events == ["prepare", "capture", "all-reduce", "graph-close", "stash-close"]
     assert recipe.partial_cuda_graph_manager is None
@@ -138,7 +181,6 @@ def test_paged_stash_overflow_closes_graph_discards_gradients_and_reruns(monkeyp
     recipe.partial_cuda_graph_manager = SimpleNamespace(close=lambda: events.append("graph-close"))
     recipe._partial_cuda_graph_capture_pending = False
     recipe._partial_cuda_graph_paged_stash_enabled = True
-    recipe._partial_cuda_graph_paged_stash_reruns = 0
     recipe.optimizer = [SimpleNamespace(zero_grad=lambda: events.append("zero-grad"))]
     recipe.rng = SimpleNamespace(load_state_dict=lambda state: events.append(("restore-rng", state)))
     recipe._run_forward_backward_batches = lambda batches, num_label_tokens: (
@@ -160,7 +202,6 @@ def test_paged_stash_overflow_closes_graph_discards_gradients_and_reruns(monkeyp
         ("rerun", ["same-batch"], 7),
     ]
     assert result[0].item() == 2.0
-    assert recipe._partial_cuda_graph_paged_stash_reruns == 1
     assert recipe.partial_cuda_graph_manager is None
 
 
@@ -191,7 +232,6 @@ def test_overflow_retry_reproduces_python_numpy_and_torch_rng(monkeypatch):
     recipe.partial_cuda_graph_manager = SimpleNamespace(close=lambda: None)
     recipe._partial_cuda_graph_capture_pending = False
     recipe._partial_cuda_graph_paged_stash_enabled = True
-    recipe._partial_cuda_graph_paged_stash_reruns = 0
     recipe.optimizer = [SimpleNamespace(zero_grad=lambda: None)]
     recipe.rng = StatefulRNG(seed=1234)
 
@@ -277,37 +317,6 @@ def test_training_loop_captures_after_first_complete_step_and_closes():
     ]
     assert recipe.partial_cuda_graph_manager is None
     assert not recipe._partial_cuda_graph_capture_pending
-
-
-def test_training_loop_closes_graphs_when_a_step_raises():
-    events = []
-
-    class _OneStepScheduler:
-        step = 0
-        epoch = 0
-        epochs = [0]
-
-        def set_epoch(self, epoch):
-            self.epoch = epoch
-
-        def __iter__(self):
-            yield ["failing-step"]
-
-    recipe = _bare_recipe()
-    recipe.model_parts = [nn.Linear(2, 2)]
-    recipe.step_scheduler = _OneStepScheduler()
-    recipe.max_grad_norm = 1.0
-    recipe.partial_cuda_graph_manager = SimpleNamespace(close=lambda: events.append("close"))
-    recipe._partial_cuda_graph_capture_pending = False
-    recipe._enable_qat_if_delayed = lambda _step: None
-    recipe._run_train_optim_step = MagicMock(side_effect=RuntimeError("step failed"))
-    recipe._make_progress_bar = lambda: None
-
-    with pytest.raises(RuntimeError, match="step failed"):
-        recipe.run_train_validation_loop()
-
-    assert events == ["close"]
-    assert recipe.partial_cuda_graph_manager is None
 
 
 def test_validation_disables_partial_graphs_as_one_eager_region():

--- a/tests/unit_tests/recipes/test_train_ft_partial_cuda_graphs.py
+++ b/tests/unit_tests/recipes/test_train_ft_partial_cuda_graphs.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import random
 from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import numpy as np
 import pytest
 import torch
 from torch import nn
@@ -23,6 +25,7 @@ from torch import nn
 import nemo_automodel.components.cuda_graphs.partial as partial_graphs
 import nemo_automodel.components.moe.paged_stash as paged_stash
 from nemo_automodel.components.models.common import BackendConfig, CudaGraphConfig
+from nemo_automodel.components.training.rng import StatefulRNG
 from nemo_automodel.recipes.llm.train_ft import (
     TrainFinetuneRecipeForNextTokenPrediction,
     _build_partial_cuda_graph_manager,
@@ -73,6 +76,7 @@ def test_paged_stash_is_prepared_before_partial_capture(monkeypatch):
     events = []
     stash = SimpleNamespace(
         prepare=lambda: events.append("prepare"),
+        check_overflow=lambda: torch.zeros(1, dtype=torch.int64),
         finish_iteration=lambda: events.append("finish"),
         diagnostics=lambda: {},
     )
@@ -85,6 +89,40 @@ def test_paged_stash_is_prepared_before_partial_capture(monkeypatch):
     recipe._capture_partial_cuda_graphs_after_eager_step()
 
     assert events == ["prepare", "capture", "finish"]
+
+
+def test_capture_overflow_is_reduced_before_all_ranks_close_graphs(monkeypatch):
+    events = []
+    stash = SimpleNamespace(
+        prepare=lambda: events.append("prepare"),
+        check_overflow=lambda: torch.zeros(1, dtype=torch.int64),
+        finish_iteration=lambda: events.append("finish"),
+        diagnostics=lambda: {},
+        close=lambda: events.append("stash-close"),
+    )
+
+    def all_reduce(overflow_ranks, *, op):
+        assert op is torch.distributed.ReduceOp.SUM
+        events.append("all-reduce")
+        overflow_ranks.fill_(2)
+
+    monkeypatch.setattr(paged_stash, "get_paged_stash_manager", lambda: stash)
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(torch.distributed, "all_reduce", all_reduce)
+    recipe = _bare_recipe()
+    recipe.partial_cuda_graph_manager = SimpleNamespace(
+        capture=lambda: events.append("capture"),
+        close=lambda: events.append("graph-close"),
+    )
+    recipe._partial_cuda_graph_capture_pending = True
+    recipe._partial_cuda_graph_paged_stash_enabled = True
+
+    with pytest.raises(RuntimeError, match="capture on 2 ranks"):
+        recipe._capture_partial_cuda_graphs_after_eager_step()
+
+    assert events == ["prepare", "capture", "all-reduce", "graph-close", "stash-close"]
+    assert recipe.partial_cuda_graph_manager is None
+    assert recipe._partial_cuda_graph_paged_stash_enabled is False
 
 
 def test_paged_stash_overflow_closes_graph_discards_gradients_and_reruns(monkeypatch):
@@ -102,6 +140,7 @@ def test_paged_stash_overflow_closes_graph_discards_gradients_and_reruns(monkeyp
     recipe._partial_cuda_graph_paged_stash_enabled = True
     recipe._partial_cuda_graph_paged_stash_reruns = 0
     recipe.optimizer = [SimpleNamespace(zero_grad=lambda: events.append("zero-grad"))]
+    recipe.rng = SimpleNamespace(load_state_dict=lambda state: events.append(("restore-rng", state)))
     recipe._run_forward_backward_batches = lambda batches, num_label_tokens: (
         events.append(("rerun", batches, num_label_tokens)) or [torch.tensor(2.0)]
     )
@@ -110,12 +149,74 @@ def test_paged_stash_overflow_closes_graph_discards_gradients_and_reruns(monkeyp
         ["same-batch"],
         num_label_tokens=7,
         loss_buffer=[torch.tensor(1.0)],
+        rng_state="pre-attempt-state",
     )
 
-    assert events == ["graph-close", "stash-close", "zero-grad", ("rerun", ["same-batch"], 7)]
+    assert events == [
+        "graph-close",
+        "stash-close",
+        "zero-grad",
+        ("restore-rng", "pre-attempt-state"),
+        ("rerun", ["same-batch"], 7),
+    ]
     assert result[0].item() == 2.0
     assert recipe._partial_cuda_graph_paged_stash_reruns == 1
     assert recipe.partial_cuda_graph_manager is None
+
+
+def test_active_paged_stash_snapshots_recipe_rng(monkeypatch):
+    state = object()
+    monkeypatch.setattr(
+        paged_stash,
+        "get_paged_stash_manager",
+        lambda: SimpleNamespace(is_active=True),
+    )
+    recipe = _bare_recipe()
+    recipe._partial_cuda_graph_paged_stash_enabled = True
+    recipe.rng = SimpleNamespace(state_dict=lambda: state)
+
+    assert recipe._snapshot_paged_stash_rng_state() is state
+
+
+def test_overflow_retry_reproduces_python_numpy_and_torch_rng(monkeypatch):
+    events = []
+    stash = SimpleNamespace(
+        is_active=True,
+        check_overflow=lambda: torch.ones(1, dtype=torch.int64),
+        close=lambda: None,
+    )
+    monkeypatch.setattr(paged_stash, "get_paged_stash_manager", lambda: stash)
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: False)
+    recipe = _bare_recipe()
+    recipe.partial_cuda_graph_manager = SimpleNamespace(close=lambda: None)
+    recipe._partial_cuda_graph_capture_pending = False
+    recipe._partial_cuda_graph_paged_stash_enabled = True
+    recipe._partial_cuda_graph_paged_stash_reruns = 0
+    recipe.optimizer = [SimpleNamespace(zero_grad=lambda: None)]
+    recipe.rng = StatefulRNG(seed=1234)
+
+    rng_state = recipe._snapshot_paged_stash_rng_state()
+    expected_draws = (random.random(), np.random.rand(), torch.rand(3))
+    random.random()
+    np.random.rand()
+    torch.rand(3)
+
+    def rerun(_batches, *, num_label_tokens):
+        assert num_label_tokens == 7
+        events.append((random.random(), np.random.rand(), torch.rand(3)))
+        return [torch.tensor(2.0)]
+
+    recipe._run_forward_backward_batches = rerun
+    recipe._rerun_after_paged_stash_overflow(
+        ["same-batch"],
+        num_label_tokens=7,
+        loss_buffer=[torch.tensor(1.0)],
+        rng_state=rng_state,
+    )
+
+    assert events[0][0] == expected_draws[0]
+    assert events[0][1] == expected_draws[1]
+    torch.testing.assert_close(events[0][2], expected_draws[2])
 
 
 def test_training_loop_captures_after_first_complete_step_and_closes():

--- a/tests/unit_tests/recipes/test_train_ft_partial_cuda_graphs.py
+++ b/tests/unit_tests/recipes/test_train_ft_partial_cuda_graphs.py
@@ -21,6 +21,7 @@ import torch
 from torch import nn
 
 import nemo_automodel.components.cuda_graphs.partial as partial_graphs
+import nemo_automodel.components.moe.paged_stash as paged_stash
 from nemo_automodel.components.models.common import BackendConfig, CudaGraphConfig
 from nemo_automodel.recipes.llm.train_ft import (
     TrainFinetuneRecipeForNextTokenPrediction,
@@ -66,6 +67,55 @@ def test_builder_does_not_use_manager_when_no_scope_is_enabled(monkeypatch):
 
     assert result is None
     discover.assert_not_called()
+
+
+def test_paged_stash_is_prepared_before_partial_capture(monkeypatch):
+    events = []
+    stash = SimpleNamespace(
+        prepare=lambda: events.append("prepare"),
+        finish_iteration=lambda: events.append("finish"),
+        diagnostics=lambda: {},
+    )
+    monkeypatch.setattr(paged_stash, "get_paged_stash_manager", lambda: stash)
+    recipe = _bare_recipe()
+    recipe.partial_cuda_graph_manager = SimpleNamespace(capture=lambda: events.append("capture"))
+    recipe._partial_cuda_graph_capture_pending = True
+    recipe._partial_cuda_graph_paged_stash_enabled = True
+
+    recipe._capture_partial_cuda_graphs_after_eager_step()
+
+    assert events == ["prepare", "capture", "finish"]
+
+
+def test_paged_stash_overflow_closes_graph_discards_gradients_and_reruns(monkeypatch):
+    events = []
+    stash = SimpleNamespace(
+        is_active=True,
+        check_overflow=lambda: torch.ones(1, dtype=torch.int64),
+        close=lambda: events.append("stash-close"),
+    )
+    monkeypatch.setattr(paged_stash, "get_paged_stash_manager", lambda: stash)
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: False)
+    recipe = _bare_recipe()
+    recipe.partial_cuda_graph_manager = SimpleNamespace(close=lambda: events.append("graph-close"))
+    recipe._partial_cuda_graph_capture_pending = False
+    recipe._partial_cuda_graph_paged_stash_enabled = True
+    recipe._partial_cuda_graph_paged_stash_reruns = 0
+    recipe.optimizer = [SimpleNamespace(zero_grad=lambda: events.append("zero-grad"))]
+    recipe._run_forward_backward_batches = lambda batches, num_label_tokens: (
+        events.append(("rerun", batches, num_label_tokens)) or [torch.tensor(2.0)]
+    )
+
+    result = recipe._rerun_after_paged_stash_overflow(
+        ["same-batch"],
+        num_label_tokens=7,
+        loss_buffer=[torch.tensor(1.0)],
+    )
+
+    assert events == ["graph-close", "stash-close", "zero-grad", ("rerun", ["same-batch"], 7)]
+    assert result[0].item() == 2.0
+    assert recipe._partial_cuda_graph_paged_stash_reruns == 1
+    assert recipe.partial_cuda_graph_manager is None
 
 
 def test_training_loop_captures_after_first_complete_step_and_closes():


### PR DESCRIPTION
## Summary

Add an opt-in paged stash for the saved activations inside fixed-capacity Transformer Engine MoE experts captured by partial CUDA graphs.

This PR is intentionally narrow:

- page only the marked TE gate/up pre-activation and down-projection input
- profile required capacity from the first eager forward/backward
- restore in reverse backward order and release restored tensors after expert backward
- keep routed-token masks/counts on device; padded rows are zeroed on restore
- reduce capture-time and replay-time overflow flags across all ranks before any host-side failure or teardown
- restore Python, NumPy, PyTorch, and CUDA RNG state before rerunning the same materialized batches eagerly
- fail closed for activation checkpointing, pipeline parallelism, and frozen expert inputs

This is stacked on #2943 and relates to the main tracking issue #1027.

## Why

Partial TE graph capture retains saved MoE activations in the graph private pool. At realistic batch size, that pool dominates the graph memory increase. The stash moves only validated expert activation rows into bounded page buffers between forward and backward, while leaving routing/dispatch/combine semantics unchanged.

## Attribution

The paged-stash design and fragmentation accounting are adapted from Hemil Desai's commits `72ffb23118b2f3b3daa38d5563464541096d8c54` and `bf89f30c9d5f86dbcf73ad77e71c22a7d0b62bf9`. Hemil is included as a co-author on the commit. This PR does not import the full-iteration graph or side-stream execution paths from that work.

## H100 result

8x H100, Qwen3-30B-A3B, BF16, FSDP2 + EP8, TE attention + TE experts, HybridEP, local batch 2 / global batch 16, sequence length 1024, no AC or PP. Both rows capture 48 attention and 48 MoE scopes using the shared pools from #2943.

| Configuration | Peak allocated / GPU | MoE graph private allocated | Page buffers | Avg step time | Graph stats |
|---|---:|---:|---:|---:|---:|
| #2943 shared pools | 59.49 GiB | 21,194.05 MiB | 0 | 355.56 ms | 96 captured, 0 fallback |
| + paged stash | 57.49 GiB | 16,891.68 MiB | 2.117 GiB | 390.59 ms | 96 captured, 1,344 replayed, 0 fallback |

Net result:

- peak allocation: -2.00 GiB/GPU (-3.36%)
- MoE private allocation: -4,302.37 MiB (-20.30%)
- latency: +9.85%; throughput approximately -8.97%
- logged loss sequence matched the #2943 run at displayed precision

This is a memory/performance trade-off, not a speedup. It remains disabled by default.

H100 jobs:

- original CUDA/Triton + real TE GroupedLinear tests: `5579929` (2 passed)
- end-to-end benchmark: `5579930` (completed, exit 0:0)
- post-review BF16 TE `make_graphed_callables` capture/two-replay parity: CW `14166816` (1 passed)
- initial BF16 TE graph parity + 2-rank asymmetric-overflow NCCL retry: CW `14166833` (2 passed, exit 0:0)
- production-topology BF16 TE graph parity + Triton restore + 2-rank overflow/CUDA-RNG retry: CW `14167825` (3 passed, exit 0:0)

## Known TE capture warning

With the current Torch/TE container, the real graph test emits PyTorch's `AccumulateGrad node's stream does not match` warning. A separate `-W error::UserWarning` run located it inside TE `make_graphed_callables()` while TE captures the backward graph after its three internal warmup iterations. It is not suppressed here: normal capture and all three replays pass exact parity, and the end-to-end memory result above includes this behavior, but the TE/Torch stream-ownership warning remains a follow-up risk.

## Validation

- three independent review rounds covered allocator/free-list state, saved-tensor lifetime, optional imports, distributed teardown ordering, RNG retry, and test sensitivity
- affected MoE/partial-graph CPU suite: `371 passed, 48 skipped`
- final benchmark/RNG/paged-stash CPU suite: `62 passed, 3 skipped`
- CW `14167825`: `3 passed` on 2 GPUs, including two real BF16 TE GroupedLinear layers, exact saved layouts `[rows, 8]` and `[rows, 4]`, graph stats `captured=1/replayed=3/fallback=0`, output/input/routing/parameter-gradient and SGD-update parity, Triton sparse-row restoration, plus rank-0-only overflow causing both ranks to teardown, restore CUDA RNG, and retry
- `uv run ruff format .`, `uv run ruff check --fix .`, and `git diff --check`: passed