### PR TITLE
fix(vlm): gemma4 FFPA mock + e4b cp16 CI recipe fixes (AM-626, AM-627)

### DIFF
--- a/examples/vlm_finetune/gemma4/gemma4_31b_ffpa_mock_8k.yaml
+++ b/examples/vlm_finetune/gemma4/gemma4_31b_ffpa_mock_8k.yaml
@@ -83,6 +83,10 @@ dataset:
   image_size: [896, 896]
   max_length: 8192
   seed: 42
+  # This non-packed recipe feeds raw conversations to gemma4_prefix_collate_fn
+  # (seqlen controlled via collate_fn.max_length), so do NOT pre-tokenize --
+  # PreTokenizedDatasetWrapper would drop the "conversation" key the collate needs.
+  pretokenize: false
 
 validation_dataset:
   _target_: nemo_automodel.components.datasets.vlm.mock.build_mock_vlm_dataset
@@ -91,6 +95,7 @@ validation_dataset:
   image_size: [896, 896]
   max_length: 8192
   seed: 43
+  pretokenize: false
 
 # Gemma4 FFPA without CP does not support sequence packing, so seqlen is controlled
 # exclusively via collate_fn.max_length (forwarded to the HF processor with

--- a/examples/vlm_finetune/gemma4/gemma4_31b_ffpa_mock_packing_cp8_16k.yaml
+++ b/examples/vlm_finetune/gemma4/gemma4_31b_ffpa_mock_packing_cp8_16k.yaml
@@ -99,6 +99,9 @@ validation_dataset:
   image_size: [896, 896]
   max_length: 2048
   seed: 43
+  # Validation is unpacked and uses gemma4_prefix_collate_fn on raw conversations,
+  # so disable pre-tokenization here (training packs via packed_sequence above).
+  pretokenize: false
 
 validation_dataloader:
   _target_: torchdata.stateful_dataloader.StatefulDataLoader

--- a/examples/vlm_finetune/gemma4/gemma4_e4b_tulu3_text_cp16_64k.yaml
+++ b/examples/vlm_finetune/gemma4/gemma4_e4b_tulu3_text_cp16_64k.yaml
@@ -129,3 +129,7 @@ wandb:
   group: gemma4_e4b_tulu3_text_cp16_64k
   tags: [gemma4-e4b, tulu3, text-only, dense, cp16, 64k, 2node]
   dir: logs/gemma4_e4b_tulu3_text_cp16_64k/wandb
+
+ci:
+  nodes: 2
+  time: "00:15:00"


### PR DESCRIPTION
# What does this PR do ?

Fix two gemma4 recipe failures surfaced by the nemo-ci release sweep: a collate `KeyError` (AM-627) and a world-size divisibility error (AM-626).

# Changelog

- **`gemma4_31b_ffpa_mock_8k` / `gemma4_31b_ffpa_mock_packing_cp8_16k`** (AM-627): set `pretokenize: false` on the non-packed (train/validation) dataset blocks. `dataset.max_length` was defaulting `pretokenize=True`, which wrapped the dataset in `PreTokenizedDatasetWrapper` (dropping the `conversation` key) while `gemma4_prefix_collate_fn` still expected raw conversations → `KeyError: 'conversation'`. Recipe 2's training packing (`packed_sequence.pretokenize: true`) is unchanged.
- **`gemma4_e4b_tulu3_text_cp16_64k`** (AM-626): add a `ci:` block requesting `nodes: 2` (16 GPUs). The recipe is dp1×cp16 (16 GPUs) but the sweep ran it on 1 node (world_size=8), not divisible by `tp*cp*pp = 1*16*1 = 16`.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the Contributor guidelines
- [ ] New tests — N/A (CI recipe-config fixes only)
- [ ] Docs — N/A

# Additional Information

- Related to Linear AM-627 and AM-626 (nemo-ci release-testing reconciler).
- Verified locally: `gemma4_prefix_collate_fn` now collates the raw mock dataset with no KeyError (input_ids/labels/pixel_values produced); the cp16 recipe resolves world_size=16 → dp_size=1 at nodes=2.
