### PR TITLE
feat(kd): support separate student and teacher meshes

### DIFF
--- a/examples/llm_kd/llama3_2/llama3_2_1b_kd_separate_mesh_teacher_cp2.yaml
+++ b/examples/llm_kd/llama3_2/llama3_2_1b_kd_separate_mesh_teacher_cp2.yaml
@@ -1,0 +1,102 @@
+# Knowledge distillation with disjoint 2-GPU student and teacher meshes.
+# The student uses data parallelism and the teacher uses context parallelism.
+#
+# To run on four GPUs:
+#   automodel examples/llm_kd/llama3_2/llama3_2_1b_kd_separate_mesh_teacher_cp2.yaml --nproc-per-node 4
+
+recipe: KnowledgeDistillationRecipeForNextTokenPrediction
+
+step_scheduler:
+  global_batch_size: 32
+  local_batch_size: 1
+  ckpt_every_steps: 200
+  val_every_steps: 100
+  num_epochs: 2
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 10
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 1111
+  ranked: true
+
+# Student on global ranks [0, 1].
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: meta-llama/Llama-3.2-1B
+  torch_dtype: bf16
+  attn_implementation: sdpa
+
+# Teacher on global ranks [2, 3].
+teacher_model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: meta-llama/Llama-3.2-3B
+  torch_dtype: bf16
+  attn_implementation: sdpa
+
+separate_meshes: true
+distributed:
+  strategy: fsdp2
+  dp_size: 2
+  tp_size: 1
+  cp_size: 1
+  pp_size: 1
+  sequence_parallel: false
+
+teacher_distributed:
+  strategy: fsdp2
+  dp_size: 1
+  tp_size: 1
+  cp_size: 2
+  pp_size: 1
+  sequence_parallel: false
+
+checkpoint:
+  enabled: true
+  checkpoint_dir: checkpoints/llama3_2_1b_kd_separate_mesh_teacher_cp2/
+  model_save_format: safetensors
+  save_consolidated: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+kd_ratio: 0.5
+kd_loss_fn:
+  _target_: nemo_automodel.components.loss.kd_loss.KDLoss
+  ignore_index: -100
+  temperature: 1.0
+  fp32_upcast: true
+
+optimizer:
+  _target_: torch.optim.Adam
+  betas: [0.9, 0.999]
+  eps: 1e-8
+  lr: 1.0e-5
+  weight_decay: 0
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
+  dataset_name: rajpurkar/squad
+  split: train
+  seq_length: 2048
+  padding: max_length
+  truncation: true
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  shuffle: false
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
+  dataset_name: rajpurkar/squad
+  split: validation
+  seq_length: 2048
+  padding: max_length
+  truncation: true
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater

--- a/examples/llm_kd/llama3_2/llama3_2_1b_kd_separate_mesh_teacher_cp2.yaml
+++ b/examples/llm_kd/llama3_2/llama3_2_1b_kd_separate_mesh_teacher_cp2.yaml
@@ -26,14 +26,14 @@ rng:
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: meta-llama/Llama-3.2-1B
-  torch_dtype: bf16
+  torch_dtype: bfloat16
   attn_implementation: sdpa
 
 # Teacher on global ranks [2, 3].
 teacher_model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: meta-llama/Llama-3.2-3B
-  torch_dtype: bf16
+  torch_dtype: bfloat16
   attn_implementation: sdpa
 
 separate_meshes: true
@@ -70,11 +70,15 @@ kd_loss_fn:
   fp32_upcast: true
 
 optimizer:
-  _target_: torch.optim.Adam
+  _target_: transformer_engine.pytorch.optimizers.fused_adam.FusedAdam
   betas: [0.9, 0.999]
   eps: 1e-8
   lr: 1.0e-5
   weight_decay: 0
+  adam_w_mode: true
+  bias_correction: true
+  master_weights: true
+  master_weight_dtype: torch.float32
 
 dataset:
   _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset

--- a/examples/llm_kd/llama3_2/llama3_2_1b_kd_separate_mesh_teacher_pp2.yaml
+++ b/examples/llm_kd/llama3_2/llama3_2_1b_kd_separate_mesh_teacher_pp2.yaml
@@ -1,0 +1,100 @@
+# Knowledge distillation with disjoint 2-GPU student and teacher meshes.
+# The student uses data parallelism and the teacher uses pipeline parallelism.
+#
+# To run on four GPUs:
+#   automodel examples/llm_kd/llama3_2/llama3_2_1b_kd_separate_mesh_teacher_pp2.yaml --nproc-per-node 4
+
+recipe: KnowledgeDistillationRecipeForNextTokenPrediction
+
+step_scheduler:
+  global_batch_size: 32
+  local_batch_size: 1
+  ckpt_every_steps: 200
+  val_every_steps: 100
+  num_epochs: 2
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 10
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 1111
+  ranked: true
+
+# Student on global ranks [0, 1].
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: meta-llama/Llama-3.2-1B
+  torch_dtype: bf16
+  attn_implementation: sdpa
+
+# Teacher on global ranks [2, 3].
+teacher_model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: meta-llama/Llama-3.2-3B
+  torch_dtype: bf16
+  attn_implementation: sdpa
+
+separate_meshes: true
+distributed:
+  strategy: fsdp2
+  dp_size: 2
+  tp_size: 1
+  cp_size: 1
+  pp_size: 1
+  sequence_parallel: false
+
+teacher_distributed:
+  strategy: fsdp2
+  dp_size: 1
+  tp_size: 1
+  cp_size: 1
+  pp_size: 2
+  sequence_parallel: false
+  pipeline:
+    pp_schedule: 1f1b
+    pp_microbatch_size: 1
+    scale_grads_in_schedule: false
+
+checkpoint:
+  enabled: true
+  checkpoint_dir: checkpoints/llama3_2_1b_kd_separate_mesh_teacher_pp2/
+  model_save_format: safetensors
+  save_consolidated: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+kd_ratio: 0.5
+kd_loss_fn:
+  _target_: nemo_automodel.components.loss.kd_loss.KDLoss
+  ignore_index: -100
+  temperature: 1.0
+  fp32_upcast: true
+
+optimizer:
+  _target_: torch.optim.Adam
+  betas: [0.9, 0.999]
+  eps: 1e-8
+  lr: 1.0e-5
+  weight_decay: 0
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
+  dataset_name: rajpurkar/squad
+  split: train
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  shuffle: false
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
+  dataset_name: rajpurkar/squad
+  split: validation
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater

--- a/examples/llm_kd/llama3_2/llama3_2_1b_kd_separate_mesh_teacher_pp2.yaml
+++ b/examples/llm_kd/llama3_2/llama3_2_1b_kd_separate_mesh_teacher_pp2.yaml
@@ -26,14 +26,14 @@ rng:
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: meta-llama/Llama-3.2-1B
-  torch_dtype: bf16
+  torch_dtype: bfloat16
   attn_implementation: sdpa
 
 # Teacher on global ranks [2, 3].
 teacher_model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: meta-llama/Llama-3.2-3B
-  torch_dtype: bf16
+  torch_dtype: bfloat16
   attn_implementation: sdpa
 
 separate_meshes: true
@@ -74,11 +74,15 @@ kd_loss_fn:
   fp32_upcast: true
 
 optimizer:
-  _target_: torch.optim.Adam
+  _target_: transformer_engine.pytorch.optimizers.fused_adam.FusedAdam
   betas: [0.9, 0.999]
   eps: 1e-8
   lr: 1.0e-5
   weight_decay: 0
+  adam_w_mode: true
+  bias_correction: true
+  master_weights: true
+  master_weight_dtype: torch.float32
 
 dataset:
   _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset

--- a/examples/llm_kd/llama3_2/llama3_2_1b_kd_separate_mesh_teacher_tp2.yaml
+++ b/examples/llm_kd/llama3_2/llama3_2_1b_kd_separate_mesh_teacher_tp2.yaml
@@ -26,14 +26,14 @@ rng:
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: meta-llama/Llama-3.2-1B
-  torch_dtype: bf16
+  torch_dtype: bfloat16
   attn_implementation: sdpa
 
 # Teacher on global ranks [2, 3].
 teacher_model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: meta-llama/Llama-3.2-3B
-  torch_dtype: bf16
+  torch_dtype: bfloat16
   attn_implementation: sdpa
 
 separate_meshes: true
@@ -70,11 +70,15 @@ kd_loss_fn:
   fp32_upcast: true
 
 optimizer:
-  _target_: torch.optim.Adam
+  _target_: transformer_engine.pytorch.optimizers.fused_adam.FusedAdam
   betas: [0.9, 0.999]
   eps: 1e-8
   lr: 1.0e-5
   weight_decay: 0
+  adam_w_mode: true
+  bias_correction: true
+  master_weights: true
+  master_weight_dtype: torch.float32
 
 dataset:
   _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset

--- a/examples/llm_kd/llama3_2/llama3_2_1b_kd_separate_mesh_teacher_tp2.yaml
+++ b/examples/llm_kd/llama3_2/llama3_2_1b_kd_separate_mesh_teacher_tp2.yaml
@@ -1,0 +1,96 @@
+# Knowledge distillation with disjoint 2-GPU student and teacher meshes.
+# The student uses data parallelism and the teacher uses tensor parallelism.
+#
+# To run on four GPUs:
+#   automodel examples/llm_kd/llama3_2/llama3_2_1b_kd_separate_mesh_teacher_tp2.yaml --nproc-per-node 4
+
+recipe: KnowledgeDistillationRecipeForNextTokenPrediction
+
+step_scheduler:
+  global_batch_size: 32
+  local_batch_size: 1
+  ckpt_every_steps: 200
+  val_every_steps: 100
+  num_epochs: 2
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 10
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 1111
+  ranked: true
+
+# Student on global ranks [0, 1].
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: meta-llama/Llama-3.2-1B
+  torch_dtype: bf16
+  attn_implementation: sdpa
+
+# Teacher on global ranks [2, 3].
+teacher_model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: meta-llama/Llama-3.2-3B
+  torch_dtype: bf16
+  attn_implementation: sdpa
+
+separate_meshes: true
+distributed:
+  strategy: fsdp2
+  dp_size: 2
+  tp_size: 1
+  cp_size: 1
+  pp_size: 1
+  sequence_parallel: false
+
+teacher_distributed:
+  strategy: fsdp2
+  dp_size: 1
+  tp_size: 2
+  cp_size: 1
+  pp_size: 1
+  sequence_parallel: false
+
+checkpoint:
+  enabled: true
+  checkpoint_dir: checkpoints/llama3_2_1b_kd_separate_mesh_teacher_tp2/
+  model_save_format: safetensors
+  save_consolidated: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+kd_ratio: 0.5
+kd_loss_fn:
+  _target_: nemo_automodel.components.loss.kd_loss.KDLoss
+  ignore_index: -100
+  temperature: 1.0
+  fp32_upcast: true
+
+optimizer:
+  _target_: torch.optim.Adam
+  betas: [0.9, 0.999]
+  eps: 1e-8
+  lr: 1.0e-5
+  weight_decay: 0
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
+  dataset_name: rajpurkar/squad
+  split: train
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  shuffle: false
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset
+  dataset_name: rajpurkar/squad
+  split: validation
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater

--- a/examples/vlm_kd/qwen3_5/qwen3_5_vl_4b_kd_separate_mesh_teacher_cp2.yaml
+++ b/examples/vlm_kd/qwen3_5/qwen3_5_vl_4b_kd_separate_mesh_teacher_cp2.yaml
@@ -1,0 +1,139 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# VLM knowledge distillation with disjoint 2-GPU student and teacher meshes.
+# The student uses data parallelism and the teacher uses context parallelism.
+#
+# To run on four GPUs:
+#   automodel examples/vlm_kd/qwen3_5/qwen3_5_vl_4b_kd_separate_mesh_teacher_cp2.yaml --nproc-per-node 4
+
+recipe: KnowledgeDistillationRecipeForVLM
+
+step_scheduler:
+  global_batch_size: 16
+  local_batch_size: 1
+  ckpt_every_steps: 200
+  val_every_steps: 50
+  num_epochs: 2
+  max_steps: 300
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 10
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 42
+  ranked: true
+
+# Student on global ranks [0, 1].
+model:
+  _target_: nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained
+  pretrained_model_name_or_path: Qwen/Qwen3.5-4B
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: sdpa
+    linear: torch
+    rms_norm: torch
+    rope_fusion: false
+  attn_implementation: sdpa
+
+# Teacher on global ranks [2, 3].
+teacher_model:
+  _target_: nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained
+  pretrained_model_name_or_path: Qwen/Qwen3.5-9B
+  attn_implementation: sdpa
+
+offload_teacher_model: false
+
+processor:
+  _target_: transformers.AutoProcessor.from_pretrained
+  pretrained_model_name_or_path: Qwen/Qwen3.5-4B
+
+separate_meshes: true
+distributed:
+  strategy: fsdp2
+  dp_size: 2
+  tp_size: 1
+  cp_size: 1
+  pp_size: 1
+  sequence_parallel: false
+
+teacher_distributed:
+  strategy: fsdp2
+  dp_size: 1
+  tp_size: 1
+  cp_size: 2
+  pp_size: 1
+  sequence_parallel: false
+
+checkpoint:
+  enabled: true
+  checkpoint_dir: checkpoints/qwen3_5_vl_4b_kd_separate_mesh_teacher_cp2/
+  model_save_format: safetensors
+  save_consolidated: true
+
+clip_grad_norm:
+  max_norm: 1.0
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+kd_ratio: 0.5
+kd_loss_fn:
+  _target_: nemo_automodel.components.loss.kd_loss.KDLoss
+  ignore_index: -100
+  temperature: 1.0
+  fp32_upcast: true
+  chunk_size: 512
+
+optimizer:
+  _target_: torch.optim.AdamW
+  lr: 5e-5
+  weight_decay: 0.01
+  betas: [0.9, 0.95]
+  eps: 1e-8
+
+lr_scheduler:
+  lr_warmup_steps: 30
+  lr_decay_style: cosine
+
+dataset:
+  _target_: nemo_automodel.components.datasets.vlm.datasets.make_medpix_dataset
+  path_or_dataset: mmoukouba/MedPix-VQA
+  split: train
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  num_workers: 0
+  collate_fn:
+    _target_: nemo_automodel.components.datasets.vlm.collate_fns.default_collate_fn
+    max_length: 2048
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.vlm.datasets.make_medpix_dataset
+  path_or_dataset: mmoukouba/MedPix-VQA
+  split: validation
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  num_workers: 0
+  collate_fn:
+    _target_: nemo_automodel.components.datasets.vlm.collate_fns.default_collate_fn
+    max_length: 2048
+
+freeze_config:
+  freeze_vision_tower: true
+  freeze_audio_tower: true
+  freeze_language_model: false

--- a/examples/vlm_kd/qwen3_5/qwen3_5_vl_4b_kd_separate_mesh_teacher_cp2.yaml
+++ b/examples/vlm_kd/qwen3_5/qwen3_5_vl_4b_kd_separate_mesh_teacher_cp2.yaml
@@ -53,6 +53,12 @@ model:
 teacher_model:
   _target_: nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained
   pretrained_model_name_or_path: Qwen/Qwen3.5-9B
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: sdpa
+    linear: torch
+    rms_norm: torch
+    rope_fusion: false
   attn_implementation: sdpa
 
 offload_teacher_model: false

--- a/examples/vlm_kd/qwen3_5/qwen3_5_vl_4b_kd_separate_mesh_teacher_cp2.yaml
+++ b/examples/vlm_kd/qwen3_5/qwen3_5_vl_4b_kd_separate_mesh_teacher_cp2.yaml
@@ -41,6 +41,7 @@ rng:
 model:
   _target_: nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained
   pretrained_model_name_or_path: Qwen/Qwen3.5-4B
+  torch_dtype: bfloat16
   backend:
     _target_: nemo_automodel.components.models.common.BackendConfig
     attn: sdpa
@@ -53,6 +54,7 @@ model:
 teacher_model:
   _target_: nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained
   pretrained_model_name_or_path: Qwen/Qwen3.5-9B
+  torch_dtype: bfloat16
   backend:
     _target_: nemo_automodel.components.models.common.BackendConfig
     attn: sdpa
@@ -105,11 +107,15 @@ kd_loss_fn:
   chunk_size: 512
 
 optimizer:
-  _target_: torch.optim.AdamW
+  _target_: transformer_engine.pytorch.optimizers.fused_adam.FusedAdam
   lr: 5e-5
   weight_decay: 0.01
   betas: [0.9, 0.95]
   eps: 1e-8
+  adam_w_mode: true
+  bias_correction: true
+  master_weights: true
+  master_weight_dtype: torch.float32
 
 lr_scheduler:
   lr_warmup_steps: 30

--- a/examples/vlm_kd/qwen3_5/qwen3_5_vl_4b_kd_separate_mesh_teacher_dp2.yaml
+++ b/examples/vlm_kd/qwen3_5/qwen3_5_vl_4b_kd_separate_mesh_teacher_dp2.yaml
@@ -53,6 +53,12 @@ model:
 teacher_model:
   _target_: nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained
   pretrained_model_name_or_path: Qwen/Qwen3.5-9B
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: sdpa
+    linear: torch
+    rms_norm: torch
+    rope_fusion: false
   attn_implementation: sdpa
 
 offload_teacher_model: false

--- a/examples/vlm_kd/qwen3_5/qwen3_5_vl_4b_kd_separate_mesh_teacher_dp2.yaml
+++ b/examples/vlm_kd/qwen3_5/qwen3_5_vl_4b_kd_separate_mesh_teacher_dp2.yaml
@@ -1,0 +1,137 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# VLM knowledge distillation with disjoint 2-GPU student and teacher meshes.
+# Both models use data parallelism.
+#
+# To run on four GPUs:
+#   automodel examples/vlm_kd/qwen3_5/qwen3_5_vl_4b_kd_separate_mesh_teacher_dp2.yaml --nproc-per-node 4
+
+recipe: KnowledgeDistillationRecipeForVLM
+
+step_scheduler:
+  global_batch_size: 16
+  local_batch_size: 1
+  ckpt_every_steps: 200
+  val_every_steps: 50
+  num_epochs: 2
+  max_steps: 300
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 10
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 42
+  ranked: true
+
+# Student on global ranks [0, 1].
+model:
+  _target_: nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained
+  pretrained_model_name_or_path: Qwen/Qwen3.5-4B
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: sdpa
+    linear: torch
+    rms_norm: torch
+    rope_fusion: false
+  attn_implementation: sdpa
+
+# Teacher on global ranks [2, 3].
+teacher_model:
+  _target_: nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained
+  pretrained_model_name_or_path: Qwen/Qwen3.5-9B
+  attn_implementation: sdpa
+
+offload_teacher_model: false
+
+processor:
+  _target_: transformers.AutoProcessor.from_pretrained
+  pretrained_model_name_or_path: Qwen/Qwen3.5-4B
+
+separate_meshes: true
+distributed:
+  strategy: fsdp2
+  dp_size: 2
+  tp_size: 1
+  cp_size: 1
+  pp_size: 1
+  sequence_parallel: false
+
+teacher_distributed:
+  strategy: fsdp2
+  dp_size: 2
+  tp_size: 1
+  cp_size: 1
+  pp_size: 1
+  sequence_parallel: false
+
+checkpoint:
+  enabled: true
+  checkpoint_dir: checkpoints/qwen3_5_vl_4b_kd_separate_mesh_teacher_dp2/
+  model_save_format: safetensors
+  save_consolidated: true
+
+clip_grad_norm:
+  max_norm: 1.0
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+kd_ratio: 0.5
+kd_loss_fn:
+  _target_: nemo_automodel.components.loss.kd_loss.KDLoss
+  ignore_index: -100
+  temperature: 1.0
+  fp32_upcast: true
+  chunk_size: 512
+
+optimizer:
+  _target_: torch.optim.AdamW
+  lr: 5e-5
+  weight_decay: 0.01
+  betas: [0.9, 0.95]
+  eps: 1e-8
+
+lr_scheduler:
+  lr_warmup_steps: 30
+  lr_decay_style: cosine
+
+dataset:
+  _target_: nemo_automodel.components.datasets.vlm.datasets.make_medpix_dataset
+  path_or_dataset: mmoukouba/MedPix-VQA
+  split: train
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  num_workers: 0
+  collate_fn:
+    _target_: nemo_automodel.components.datasets.vlm.collate_fns.default_collate_fn
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.vlm.datasets.make_medpix_dataset
+  path_or_dataset: mmoukouba/MedPix-VQA
+  split: validation
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  num_workers: 0
+  collate_fn:
+    _target_: nemo_automodel.components.datasets.vlm.collate_fns.default_collate_fn
+
+freeze_config:
+  freeze_vision_tower: true
+  freeze_audio_tower: true
+  freeze_language_model: false

--- a/examples/vlm_kd/qwen3_5/qwen3_5_vl_4b_kd_separate_mesh_teacher_dp2.yaml
+++ b/examples/vlm_kd/qwen3_5/qwen3_5_vl_4b_kd_separate_mesh_teacher_dp2.yaml
@@ -41,6 +41,7 @@ rng:
 model:
   _target_: nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained
   pretrained_model_name_or_path: Qwen/Qwen3.5-4B
+  torch_dtype: bfloat16
   backend:
     _target_: nemo_automodel.components.models.common.BackendConfig
     attn: sdpa
@@ -53,6 +54,7 @@ model:
 teacher_model:
   _target_: nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained
   pretrained_model_name_or_path: Qwen/Qwen3.5-9B
+  torch_dtype: bfloat16
   backend:
     _target_: nemo_automodel.components.models.common.BackendConfig
     attn: sdpa
@@ -105,11 +107,15 @@ kd_loss_fn:
   chunk_size: 512
 
 optimizer:
-  _target_: torch.optim.AdamW
+  _target_: transformer_engine.pytorch.optimizers.fused_adam.FusedAdam
   lr: 5e-5
   weight_decay: 0.01
   betas: [0.9, 0.95]
   eps: 1e-8
+  adam_w_mode: true
+  bias_correction: true
+  master_weights: true
+  master_weight_dtype: torch.float32
 
 lr_scheduler:
   lr_warmup_steps: 30

--- a/examples/vlm_kd/qwen3_5/qwen3_5_vl_4b_kd_separate_mesh_teacher_tp2.yaml
+++ b/examples/vlm_kd/qwen3_5/qwen3_5_vl_4b_kd_separate_mesh_teacher_tp2.yaml
@@ -1,0 +1,137 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# VLM knowledge distillation with disjoint 2-GPU student and teacher meshes.
+# The student uses data parallelism and the teacher uses tensor parallelism.
+#
+# To run on four GPUs:
+#   automodel examples/vlm_kd/qwen3_5/qwen3_5_vl_4b_kd_separate_mesh_teacher_tp2.yaml --nproc-per-node 4
+
+recipe: KnowledgeDistillationRecipeForVLM
+
+step_scheduler:
+  global_batch_size: 16
+  local_batch_size: 1
+  ckpt_every_steps: 200
+  val_every_steps: 50
+  num_epochs: 2
+  max_steps: 300
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 10
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 42
+  ranked: true
+
+# Student on global ranks [0, 1].
+model:
+  _target_: nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained
+  pretrained_model_name_or_path: Qwen/Qwen3.5-4B
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: sdpa
+    linear: torch
+    rms_norm: torch
+    rope_fusion: false
+  attn_implementation: sdpa
+
+# Teacher on global ranks [2, 3].
+teacher_model:
+  _target_: nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained
+  pretrained_model_name_or_path: Qwen/Qwen3.5-9B
+  attn_implementation: sdpa
+
+offload_teacher_model: false
+
+processor:
+  _target_: transformers.AutoProcessor.from_pretrained
+  pretrained_model_name_or_path: Qwen/Qwen3.5-4B
+
+separate_meshes: true
+distributed:
+  strategy: fsdp2
+  dp_size: 2
+  tp_size: 1
+  cp_size: 1
+  pp_size: 1
+  sequence_parallel: false
+
+teacher_distributed:
+  strategy: fsdp2
+  dp_size: 1
+  tp_size: 2
+  cp_size: 1
+  pp_size: 1
+  sequence_parallel: false
+
+checkpoint:
+  enabled: true
+  checkpoint_dir: checkpoints/qwen3_5_vl_4b_kd_separate_mesh_teacher_tp2/
+  model_save_format: safetensors
+  save_consolidated: true
+
+clip_grad_norm:
+  max_norm: 1.0
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+kd_ratio: 0.5
+kd_loss_fn:
+  _target_: nemo_automodel.components.loss.kd_loss.KDLoss
+  ignore_index: -100
+  temperature: 1.0
+  fp32_upcast: true
+  chunk_size: 512
+
+optimizer:
+  _target_: torch.optim.AdamW
+  lr: 5e-5
+  weight_decay: 0.01
+  betas: [0.9, 0.95]
+  eps: 1e-8
+
+lr_scheduler:
+  lr_warmup_steps: 30
+  lr_decay_style: cosine
+
+dataset:
+  _target_: nemo_automodel.components.datasets.vlm.datasets.make_medpix_dataset
+  path_or_dataset: mmoukouba/MedPix-VQA
+  split: train
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  num_workers: 0
+  collate_fn:
+    _target_: nemo_automodel.components.datasets.vlm.collate_fns.default_collate_fn
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.vlm.datasets.make_medpix_dataset
+  path_or_dataset: mmoukouba/MedPix-VQA
+  split: validation
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  num_workers: 0
+  collate_fn:
+    _target_: nemo_automodel.components.datasets.vlm.collate_fns.default_collate_fn
+
+freeze_config:
+  freeze_vision_tower: true
+  freeze_audio_tower: true
+  freeze_language_model: false

--- a/examples/vlm_kd/qwen3_5/qwen3_5_vl_4b_kd_separate_mesh_teacher_tp2.yaml
+++ b/examples/vlm_kd/qwen3_5/qwen3_5_vl_4b_kd_separate_mesh_teacher_tp2.yaml
@@ -53,6 +53,12 @@ model:
 teacher_model:
   _target_: nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained
   pretrained_model_name_or_path: Qwen/Qwen3.5-9B
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: sdpa
+    linear: torch
+    rms_norm: torch
+    rope_fusion: false
   attn_implementation: sdpa
 
 offload_teacher_model: false

--- a/examples/vlm_kd/qwen3_5/qwen3_5_vl_4b_kd_separate_mesh_teacher_tp2.yaml
+++ b/examples/vlm_kd/qwen3_5/qwen3_5_vl_4b_kd_separate_mesh_teacher_tp2.yaml
@@ -41,6 +41,7 @@ rng:
 model:
   _target_: nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained
   pretrained_model_name_or_path: Qwen/Qwen3.5-4B
+  torch_dtype: bfloat16
   backend:
     _target_: nemo_automodel.components.models.common.BackendConfig
     attn: sdpa
@@ -53,6 +54,7 @@ model:
 teacher_model:
   _target_: nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained
   pretrained_model_name_or_path: Qwen/Qwen3.5-9B
+  torch_dtype: bfloat16
   backend:
     _target_: nemo_automodel.components.models.common.BackendConfig
     attn: sdpa
@@ -105,11 +107,15 @@ kd_loss_fn:
   chunk_size: 512
 
 optimizer:
-  _target_: torch.optim.AdamW
+  _target_: transformer_engine.pytorch.optimizers.fused_adam.FusedAdam
   lr: 5e-5
   weight_decay: 0.01
   betas: [0.9, 0.95]
   eps: 1e-8
+  adam_w_mode: true
+  bias_correction: true
+  master_weights: true
+  master_weight_dtype: torch.float32
 
 lr_scheduler:
   lr_warmup_steps: 30

--- a/nemo_automodel/_transformers/auto_model.py
+++ b/nemo_automodel/_transformers/auto_model.py
@@ -522,6 +522,7 @@ class _BaseNeMoAutoModelClass(_BaseAutoModelClass):
 
         model = None  # Ensure 'model' is always bound for the except handler
         is_custom_model = None
+        process_group = getattr(mesh, "process_group", None)
         try:
             with init_ctx:
                 is_custom_model, model = _init_model(
@@ -532,6 +533,7 @@ class _BaseNeMoAutoModelClass(_BaseAutoModelClass):
                     quantization_config,
                     force_hf,
                     *model_args,
+                    _process_group=process_group,
                     **kwargs,
                 )
         except (NotImplementedError, RuntimeError) as e:
@@ -561,6 +563,7 @@ class _BaseNeMoAutoModelClass(_BaseAutoModelClass):
                         quantization_config,
                         force_hf,
                         *model_args,
+                        _process_group=process_group,
                         **kwargs,
                     )
             else:

--- a/nemo_automodel/_transformers/infrastructure.py
+++ b/nemo_automodel/_transformers/infrastructure.py
@@ -528,8 +528,9 @@ def apply_model_infrastructure(
 
     # hold a list copy of the model state dict keys before any parallelization. To be used during checkpoint saving in safetensors format.
     state_dict_adapter = getattr(model, "state_dict_adapter", None)
-    if state_dict_adapter is not None:
-        pre_shard_hf_state_dict_keys = state_dict_adapter.get_hf_state_dict_keys(model.state_dict())
+    get_hf_state_dict_keys = getattr(state_dict_adapter, "get_hf_state_dict_keys", None)
+    if get_hf_state_dict_keys is not None:
+        pre_shard_hf_state_dict_keys = get_hf_state_dict_keys(model.state_dict())
     else:
         pre_shard_hf_state_dict_keys = list(
             _maybe_adapt_state_dict_to_hf(model, model.state_dict(), quantization=False).keys()

--- a/nemo_automodel/_transformers/infrastructure.py
+++ b/nemo_automodel/_transformers/infrastructure.py
@@ -462,6 +462,7 @@ def apply_model_infrastructure(
         0,
         0,
         getattr(model_wrapper, "moe_mesh", None),
+        process_group=getattr(mesh, "process_group", None),
     )
 
     # Handle checkpointer config updates if checkpointer is provided
@@ -592,6 +593,11 @@ def apply_model_infrastructure(
         model_parts = model.parts if hasattr(model, "parts") else [model]
         lora_a_init = getattr(peft_config, "lora_A_init", None)
         for mp in model_parts:
+            if autopipeline is not None and load_base_model:
+                # PP stages own different modules, so HF random initialization can issue
+                # a different number of DTensor RNG collectives on each stage. Every
+                # parameter is about to be populated from the pretrained checkpoint.
+                mp._skip_init_weights_on_load = True
             checkpointer.initialize_model_weights(mp, init_device, peft_init_method=lora_a_init)
 
     # Load the checkpoint if pretrained weights are needed and weren't already loaded

--- a/nemo_automodel/_transformers/infrastructure.py
+++ b/nemo_automodel/_transformers/infrastructure.py
@@ -527,9 +527,13 @@ def apply_model_infrastructure(
         checkpoint_already_loaded = True
 
     # hold a list copy of the model state dict keys before any parallelization. To be used during checkpoint saving in safetensors format.
-    pre_shard_hf_state_dict_keys = list(
-        _maybe_adapt_state_dict_to_hf(model, model.state_dict(), quantization=False).keys()
-    )
+    state_dict_adapter = getattr(model, "state_dict_adapter", None)
+    if state_dict_adapter is not None:
+        pre_shard_hf_state_dict_keys = state_dict_adapter.get_hf_state_dict_keys(model.state_dict())
+    else:
+        pre_shard_hf_state_dict_keys = list(
+            _maybe_adapt_state_dict_to_hf(model, model.state_dict(), quantization=False).keys()
+        )
 
     # Apply freezing before sharding
     freeze_config = _kwargs.get("freeze_config")

--- a/nemo_automodel/_transformers/model_init.py
+++ b/nemo_automodel/_transformers/model_init.py
@@ -352,7 +352,7 @@ def get_is_hf_model(config, force_hf):
     return _resolve_custom_model_cls_for_config(config) is None
 
 
-def _download_model_weights(hf_config, pretrained_model_name_or_path):
+def _download_model_weights(hf_config, pretrained_model_name_or_path, process_group=None):
     if not os.path.isdir(pretrained_model_name_or_path):
         if os.environ.get("HF_HUB_OFFLINE", "0") == "1":
             logger.info(
@@ -370,7 +370,7 @@ def _download_model_weights(hf_config, pretrained_model_name_or_path):
             )
         # Import via module reference (vs bound name) so unit tests can patch
         # `nemo_automodel.components.distributed.utils.FirstRankPerNode`.
-        with dist_utils.FirstRankPerNode():
+        with dist_utils.FirstRankPerNode(group=process_group):
             snapshot_download(pretrained_model_name_or_path)
 
 
@@ -801,6 +801,7 @@ def __init_model(
     # Default ``True`` keeps existing behavior for every recipe that doesn't set
     # it. Pop here so the flag never reaches HF's ``from_pretrained``.
     restore_loaded_dtype = kwargs.pop("_restore_loaded_dtype", True)
+    process_group = kwargs.pop("_process_group", None)
     torch_dtype = dtype_from_str(torch_dtype) if torch_dtype != "auto" else torch_dtype
     is_pretrained_init = isinstance(pretrained_model_name_or_path_or_config, str)  # The caller is .from_pretrained
     hf_config = (
@@ -914,7 +915,7 @@ def __init_model(
         else:
             # Download model weights on local rank 0; skip for from_config or local paths
             if pretrained_model_name_or_path:
-                _download_model_weights(hf_config, pretrained_model_name_or_path)
+                _download_model_weights(hf_config, pretrained_model_name_or_path, process_group=process_group)
             logger.info(f"Using custom model implementation for {architectures[0]}")
             kwargs.pop("trust_remote_code", None)
             # Treat config-related kwargs as config overrides (HF behavior) and

--- a/nemo_automodel/_transformers/model_init.py
+++ b/nemo_automodel/_transformers/model_init.py
@@ -374,8 +374,8 @@ def _download_model_weights(hf_config, pretrained_model_name_or_path, process_gr
             snapshot_download(pretrained_model_name_or_path)
 
 
-def _prepopulate_remote_code_cache(hf_config, pretrained_model_name_or_path, kwargs):
-    """Fully populate HF's dynamic-module (custom code) cache on global rank 0 first.
+def _prepopulate_remote_code_cache(hf_config, pretrained_model_name_or_path, kwargs, process_group=None):
+    """Fully populate HF's dynamic-module cache on the model-local rank 0 first.
 
     ``get_cached_module_file`` copies a custom-code file plus its *direct* relative
     imports, but ``get_class_in_module`` later validates the *transitive* closure. A
@@ -403,7 +403,7 @@ def _prepopulate_remote_code_cache(hf_config, pretrained_model_name_or_path, kwa
             if isinstance(ref, str) and "." in ref:
                 module_files.add(ref.rsplit(".", 1)[0] + ".py")
     src_py = glob.glob(os.path.join(src_dir, "*.py"))
-    with dist_utils.FirstRankPerNode():
+    with dist_utils.FirstRankPerNode(group=process_group):
         for module_file in module_files:
             try:
                 cached = get_cached_module_file(src_dir, module_file)
@@ -934,7 +934,7 @@ def __init_model(
     # 3. fallback to HF model class wrapped with mixin
     model = None
     # Serialize HF custom-code cache population across ranks to avoid a partial-copy race.
-    _prepopulate_remote_code_cache(hf_config, pretrained_model_name_or_path, kwargs)
+    _prepopulate_remote_code_cache(hf_config, pretrained_model_name_or_path, kwargs, process_group=process_group)
     if quantization_config is not None:
         kwargs["quantization_config"] = quantization_config
         _setup_bnb_loading_kwargs(kwargs)

--- a/nemo_automodel/components/checkpoint/_backports/consolidate_hf_safetensors.py
+++ b/nemo_automodel/components/checkpoint/_backports/consolidate_hf_safetensors.py
@@ -1041,7 +1041,7 @@ def consolidate_safetensors_files_on_every_rank(
     # Wait for all ranks to complete
     if dist.is_available() and dist.is_initialized():
         logger.debug("Rank %d: Waiting for all ranks to complete...", rank)
-        dist.barrier()
+        dist.barrier(group=process_group)
         logger.debug("Rank %d: All ranks have completed.", rank)
         if rank == 0:
             logger.debug("Total time taken: %.2f secs.", time.time() - start_time)

--- a/nemo_automodel/components/checkpoint/addons.py
+++ b/nemo_automodel/components/checkpoint/addons.py
@@ -30,6 +30,16 @@ from nemo_automodel.components.moe.state_dict_mixin import MoESplitExpertsStateD
 
 if TYPE_CHECKING:
     from peft import PeftConfig
+    from torch.distributed import ProcessGroup
+
+
+def _is_group_rank_0(process_group: "ProcessGroup | None") -> bool:
+    return not torch.distributed.is_initialized() or torch.distributed.get_rank(group=process_group) == 0
+
+
+def _group_barrier(process_group: "ProcessGroup | None") -> None:
+    if torch.distributed.is_initialized():
+        torch.distributed.barrier(group=process_group)
 
 
 class CheckpointAddon(Protocol):
@@ -67,9 +77,10 @@ class ConsolidatedHFAddon:
         tokenizer = kwargs.get("tokenizer", None)
         model_part = model_state.model[0]  # ModelState already converts to list if needed
         original_model_path = kwargs["original_model_path"]
+        process_group = kwargs.get("process_group")
 
         # Perform save operations on rank 0
-        if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
+        if _is_group_rank_0(process_group):
             # if the HF model has custom model code, we need to save it as part of the checkpoint
             _maybe_save_custom_model_code(original_model_path, hf_metadata_dir, model_part=model_part)
             # save the config.json file
@@ -121,8 +132,7 @@ class ConsolidatedHFAddon:
             if fqn_to_dtype_mapping:
                 with open(os.path.join(hf_metadata_dir, FQN_TO_DTYPE_MAPPING_FILENAME), "w") as f:
                     json.dump(fqn_to_dtype_mapping, f, indent=2, sort_keys=True)
-        if torch.distributed.is_initialized():
-            torch.distributed.barrier()
+        _group_barrier(process_group)
 
     def post_save(self, **kwargs) -> None:
         """
@@ -138,11 +148,12 @@ class ConsolidatedHFAddon:
         """
         consolidated_path = kwargs["consolidated_path"]
         hf_metadata_path = kwargs["hf_metadata_path"]
+        process_group = kwargs.get("process_group")
         if not consolidated_path:
             # in this case we are just saving the sharded HF safetensors
             return
 
-        if (not torch.distributed.is_initialized()) or (torch.distributed.get_rank() == 0):
+        if _is_group_rank_0(process_group):
             # Copy each public metadata item into consolidated_path while keeping
             # .hf_metadata intact for the offline consolidation helper.
             for item_name in os.listdir(hf_metadata_path):
@@ -154,8 +165,7 @@ class ConsolidatedHFAddon:
                     shutil.copytree(src_path, dst_path, dirs_exist_ok=True)
                 else:
                     shutil.copy2(src_path, dst_path)
-        if torch.distributed.is_initialized():
-            torch.distributed.barrier()
+        _group_barrier(process_group)
 
 
 class PeftAddon:
@@ -182,9 +192,10 @@ class PeftAddon:
         peft_config = kwargs["peft_config"]
         original_model_path = kwargs["original_model_path"]
         v4_compatible = kwargs.get("v4_compatible", False)
+        process_group = kwargs.get("process_group")
         hf_peft_config = _get_hf_peft_config(peft_config, model_state, v4_compatible=v4_compatible)
         automodel_peft_metadata = _get_automodel_peft_metadata(peft_config)
-        if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
+        if _is_group_rank_0(process_group):
             # if the HF model has custom model code, we need to save it as part of the checkpoint
             model_part = model_state.model[0] if model_state is not None else None
             _maybe_save_custom_model_code(original_model_path, model_path, model_part=model_part)
@@ -197,8 +208,7 @@ class PeftAddon:
             # save the full PEFT config for inference loading inside Automodel.
             with open(os.path.join(model_path, "automodel_peft_config.json"), "w") as f:
                 json.dump(automodel_peft_metadata, f, indent=2, sort_keys=True)
-        if torch.distributed.is_initialized():
-            torch.distributed.barrier()
+        _group_barrier(process_group)
 
     def post_save(self, **kwargs) -> None:
         pass

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -285,6 +285,19 @@ class _AsyncSaveContext:
     staging_active: bool = False
 
 
+def _new_gloo_process_group(
+    process_group: torch.distributed.ProcessGroup | None,
+) -> torch.distributed.ProcessGroup:
+    """Create a Gloo group with the same membership as ``process_group``."""
+    if process_group is None:
+        return torch.distributed.new_group(backend="gloo")
+    return torch.distributed.new_group(
+        ranks=torch.distributed.get_process_group_ranks(process_group),
+        backend="gloo",
+        use_local_synchronization=True,
+    )
+
+
 def _should_write_hf_metadata(config: CheckpointingConfig) -> bool:
     """Whether to write HF metadata/artifacts for a checkpoint."""
     return config.model_save_format == SerializationFormat.SAFETENSORS and not config.is_peft
@@ -390,7 +403,7 @@ class Checkpointer:
         tp_rank: int,
         pp_rank: int,
         moe_mesh: Optional[DeviceMesh] = None,
-        process_group: Optional[torch.distributed.ProcessGroup] = None,
+        process_group: torch.distributed.ProcessGroup | None = None,
     ) -> None:
         """
         Initialize the checkpointer.
@@ -416,8 +429,8 @@ class Checkpointer:
         if self.config.is_async:
             self._model_ctx.stager = DefaultStager()
             self._optim_ctx.stager = DefaultStager()
-            self._model_ctx.process_group = torch.distributed.new_group(backend="gloo")
-            self._optim_ctx.process_group = torch.distributed.new_group(backend="gloo")
+            self._model_ctx.process_group = _new_gloo_process_group(process_group)
+            self._optim_ctx.process_group = _new_gloo_process_group(process_group)
 
         self._addons = []
         if _should_write_hf_metadata(self.config):
@@ -502,6 +515,7 @@ class Checkpointer:
                 fqn_to_dtype_mapping=fqn_to_dtype_mapping,
                 original_model_path=self._get_original_model_path(model_state),
                 v4_compatible=self.config.v4_compatible,
+                process_group=self.process_group,
             )
         self._maybe_write_offline_consolidation_script(model_dir)
 
@@ -511,7 +525,11 @@ class Checkpointer:
         self._model_ctx.future = self._do_save(state_dict, model_dir, storage_writer)
 
         for addon in self._addons:
-            addon.post_save(consolidated_path=consolidated_dir, hf_metadata_path=hf_metadata_dir)
+            addon.post_save(
+                consolidated_path=consolidated_dir,
+                hf_metadata_path=hf_metadata_dir,
+                process_group=self.process_group,
+            )
 
         if consolidate_on_all_ranks:
             consolidate_safetensors_files_on_every_rank(
@@ -522,6 +540,7 @@ class Checkpointer:
                 use_staging=self.config.staging_dir is not None,
                 staging_dir=self.config.staging_dir,
                 fqn_to_dtype_mapping=fqn_to_dtype_mapping,
+                process_group=self.process_group,
             )
             if self.config.diffusers_compatible:
                 if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
@@ -848,6 +867,7 @@ class Checkpointer:
         model_state.load_state_dict(
             state_dict,
             strict=not (len(model_state.model) > 1 or has_state_dict_adapter or allow_checkpoint_key_subset),
+            broadcast_from_rank0=self.process_group is None,
         )
 
         del state_dict
@@ -1112,6 +1132,11 @@ class Checkpointer:
             self._model_ctx.stager.close()
         if self._optim_ctx.stager is not None:
             self._optim_ctx.stager.close()
+        if torch.distributed.is_initialized():
+            for context in (self._model_ctx, self._optim_ctx):
+                if context.process_group is not None:
+                    torch.distributed.destroy_process_group(context.process_group)
+                    context.process_group = None
 
     def _do_load(
         self,
@@ -1165,10 +1190,10 @@ class Checkpointer:
         is_model = True if "/model" in path else False
         # PEFT saving is done on rank0 so it is a special case
         if self.config.is_peft and is_model:
-            if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
+            if not torch.distributed.is_initialized() or torch.distributed.get_rank(group=self.process_group) == 0:
                 _save_safetensors(state_dict, _adapter_path(path))
             if torch.distributed.is_initialized():
-                torch.distributed.barrier()
+                torch.distributed.barrier(group=self.process_group)
             return
 
         ret = None
@@ -1602,12 +1627,13 @@ def save_config(config: dict[str, Any], weights_path: str) -> None:
             yaml.dump(config, f, sort_keys=False, default_flow_style=False)
 
 
-def _ensure_dirs(*dirs: Optional[str], process_group: Optional[torch.distributed.ProcessGroup] = None) -> None:
+def _ensure_dirs(*dirs: Optional[str], process_group: torch.distributed.ProcessGroup | None = None) -> None:
     """
     Create directories on all ranks and synchronize across ranks.
 
     Args:
         *dirs: One or more directory paths that should exist.
+        process_group: Ranks that must observe the directories before continuing.
     """
     for d in dirs:
         if d:

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -390,6 +390,7 @@ class Checkpointer:
         tp_rank: int,
         pp_rank: int,
         moe_mesh: Optional[DeviceMesh] = None,
+        process_group: Optional[torch.distributed.ProcessGroup] = None,
     ) -> None:
         """
         Initialize the checkpointer.
@@ -400,12 +401,14 @@ class Checkpointer:
             tp_rank: Tensor parallel rank for the current process.
             pp_rank: Pipeline parallel rank for the current process.
             moe_mesh: Optional device mesh used for MoE when adapting state dicts.
+            process_group: Process group used for distributed checkpoint collectives.
         """
         self.config = config
         self.moe_mesh = moe_mesh
         self.dp_rank = dp_rank
         self.tp_rank = tp_rank
         self.pp_rank = pp_rank
+        self.process_group = process_group
 
         # async specific variables
         self._model_ctx = _AsyncSaveContext(stager=None, process_group=None, future=None, staging_active=False)
@@ -453,7 +456,7 @@ class Checkpointer:
         should_write_consolidated = _should_write_consolidated_safetensors(self.config, is_final_checkpoint)
         consolidated_dir = os.path.join(model_dir, "consolidated") if should_write_consolidated else None
         hf_metadata_dir = os.path.join(model_dir, ".hf_metadata") if _should_write_hf_metadata(self.config) else None
-        _ensure_dirs(model_dir, consolidated_dir, hf_metadata_dir)
+        _ensure_dirs(model_dir, consolidated_dir, hf_metadata_dir, process_group=self.process_group)
 
         # Because this call lies outside of the dcp save call, we need to consolidate on all ranks on the main process
         # of all ranks, which lies on the critical path. Therefore, we can only do this outside of async mode.
@@ -541,7 +544,7 @@ class Checkpointer:
             scheduler: Optional LR scheduler to include.
         """
         optimizer_path = os.path.join(weights_path, "optim")
-        _ensure_dirs(optimizer_path)
+        _ensure_dirs(optimizer_path, process_group=self.process_group)
         optimizer_state = OptimizerState(model, optimizer, scheduler, is_peft=self.config.is_peft)
         state_dict = optimizer_state.state_dict()
         self._optim_ctx.future = self._do_save(state_dict, optimizer_path)
@@ -1054,7 +1057,7 @@ class Checkpointer:
             path: Path to save stateful object
         """
         state_dir = os.path.join(path, state_name)
-        _ensure_dirs(state_dir)
+        _ensure_dirs(state_dir, process_group=self.process_group)
         if self.tp_rank == 0 and self.pp_rank == 0:
             torch.save(state.state_dict(), os.path.join(state_dir, f"{state_name}_dp_rank_{self.dp_rank}.pt"))
 
@@ -1083,16 +1086,20 @@ class Checkpointer:
         DTensor metadata and writes all shards correctly.
         """
         state_dir = os.path.join(path, state_name)
-        _ensure_dirs(state_dir)
+        _ensure_dirs(state_dir, process_group=self.process_group)
         state_dict = state.state_dict()
         planner = dcp.DefaultSavePlanner(enable_plan_caching=True)
-        dcp.save(state_dict, checkpoint_id=state_dir, planner=planner)
+        process_group = getattr(self, "process_group", None)
+        process_group_kwargs = {"process_group": process_group} if process_group is not None else {}
+        dcp.save(state_dict, checkpoint_id=state_dir, planner=planner, **process_group_kwargs)
 
     def load_distributed_state(self, state: Any, state_name: str, path: str) -> None:
         """Load a custom stateful object previously saved with DCP."""
         state_dir = os.path.join(path, state_name)
         state_dict = state.state_dict()
-        dcp.load(state_dict, checkpoint_id=state_dir)
+        process_group = getattr(self, "process_group", None)
+        process_group_kwargs = {"process_group": process_group} if process_group is not None else {}
+        dcp.load(state_dict, checkpoint_id=state_dir, **process_group_kwargs)
         state.load_state_dict(state_dict)
 
     def close(self) -> None:
@@ -1132,7 +1139,9 @@ class Checkpointer:
             state_dict = _load_safetensors(_adapter_path(path))
         else:
             storage_reader = _maybe_msc_reader(path, storage_reader)
-            dcp.load(state_dict, checkpoint_id=path, storage_reader=storage_reader)
+            process_group = getattr(self, "process_group", None)
+            process_group_kwargs = {"process_group": process_group} if process_group is not None else {}
+            dcp.load(state_dict, checkpoint_id=path, storage_reader=storage_reader, **process_group_kwargs)
         return state_dict
 
     def _do_save(
@@ -1181,7 +1190,15 @@ class Checkpointer:
             )
             ctx.staging_active = True
         else:
-            dcp.save(state_dict, checkpoint_id=path, storage_writer=storage_writer, planner=planner)
+            process_group = getattr(self, "process_group", None)
+            process_group_kwargs = {"process_group": process_group} if process_group is not None else {}
+            dcp.save(
+                state_dict,
+                checkpoint_id=path,
+                storage_writer=storage_writer,
+                planner=planner,
+                **process_group_kwargs,
+            )
         return ret
 
     def _maybe_write_offline_consolidation_script(self, model_dir: str) -> None:
@@ -1585,7 +1602,7 @@ def save_config(config: dict[str, Any], weights_path: str) -> None:
             yaml.dump(config, f, sort_keys=False, default_flow_style=False)
 
 
-def _ensure_dirs(*dirs: Optional[str]) -> None:
+def _ensure_dirs(*dirs: Optional[str], process_group: Optional[torch.distributed.ProcessGroup] = None) -> None:
     """
     Create directories on all ranks and synchronize across ranks.
 
@@ -1597,7 +1614,7 @@ def _ensure_dirs(*dirs: Optional[str]) -> None:
             if not is_cloud_path(d):
                 os.makedirs(d, exist_ok=True)
     if torch.distributed.is_initialized():
-        torch.distributed.barrier()
+        torch.distributed.barrier(group=process_group)
 
 
 def _init_peft_adapters(model: nn.Module, peft_init_method: str) -> None:

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -404,6 +404,7 @@ class Checkpointer:
         pp_rank: int,
         moe_mesh: Optional[DeviceMesh] = None,
         process_group: torch.distributed.ProcessGroup | None = None,
+        async_process_groups: tuple[torch.distributed.ProcessGroup, torch.distributed.ProcessGroup] | None = None,
     ) -> None:
         """
         Initialize the checkpointer.
@@ -415,6 +416,8 @@ class Checkpointer:
             pp_rank: Pipeline parallel rank for the current process.
             moe_mesh: Optional device mesh used for MoE when adapting state dicts.
             process_group: Process group used for distributed checkpoint collectives.
+            async_process_groups: Optional pre-created model and optimizer Gloo
+                groups used by asynchronous checkpointing.
         """
         self.config = config
         self.moe_mesh = moe_mesh
@@ -429,8 +432,12 @@ class Checkpointer:
         if self.config.is_async:
             self._model_ctx.stager = DefaultStager()
             self._optim_ctx.stager = DefaultStager()
-            self._model_ctx.process_group = _new_gloo_process_group(process_group)
-            self._optim_ctx.process_group = _new_gloo_process_group(process_group)
+            if async_process_groups is None:
+                async_process_groups = (
+                    _new_gloo_process_group(process_group),
+                    _new_gloo_process_group(process_group),
+                )
+            self._model_ctx.process_group, self._optim_ctx.process_group = async_process_groups
 
         self._addons = []
         if _should_write_hf_metadata(self.config):

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -404,7 +404,6 @@ class Checkpointer:
         pp_rank: int,
         moe_mesh: Optional[DeviceMesh] = None,
         process_group: torch.distributed.ProcessGroup | None = None,
-        async_process_groups: tuple[torch.distributed.ProcessGroup, torch.distributed.ProcessGroup] | None = None,
     ) -> None:
         """
         Initialize the checkpointer.
@@ -416,8 +415,6 @@ class Checkpointer:
             pp_rank: Pipeline parallel rank for the current process.
             moe_mesh: Optional device mesh used for MoE when adapting state dicts.
             process_group: Process group used for distributed checkpoint collectives.
-            async_process_groups: Optional pre-created model and optimizer Gloo
-                groups used by asynchronous checkpointing.
         """
         self.config = config
         self.moe_mesh = moe_mesh
@@ -432,12 +429,8 @@ class Checkpointer:
         if self.config.is_async:
             self._model_ctx.stager = DefaultStager()
             self._optim_ctx.stager = DefaultStager()
-            if async_process_groups is None:
-                async_process_groups = (
-                    _new_gloo_process_group(process_group),
-                    _new_gloo_process_group(process_group),
-                )
-            self._model_ctx.process_group, self._optim_ctx.process_group = async_process_groups
+            self._model_ctx.process_group = _new_gloo_process_group(process_group)
+            self._optim_ctx.process_group = _new_gloo_process_group(process_group)
 
         self._addons = []
         if _should_write_hf_metadata(self.config):

--- a/nemo_automodel/components/checkpoint/config.py
+++ b/nemo_automodel/components/checkpoint/config.py
@@ -187,7 +187,6 @@ class CheckpointingConfig:
         pp_rank: int,
         moe_mesh: DeviceMesh | None = None,
         process_group: ProcessGroup | None = None,
-        async_process_groups: tuple[ProcessGroup, ProcessGroup] | None = None,
     ) -> Checkpointer:
         """Build the :class:`Checkpointer` engine for this config.
 
@@ -201,8 +200,6 @@ class CheckpointingConfig:
             pp_rank: Pipeline-parallel rank.
             moe_mesh: Optional device mesh for MoE checkpointing.
             process_group: Process group used for distributed checkpoint collectives.
-            async_process_groups: Optional pre-created model and optimizer Gloo
-                groups used by asynchronous checkpointing.
 
         Returns:
             Configured :class:`Checkpointer`.
@@ -216,35 +213,7 @@ class CheckpointingConfig:
             pp_rank=pp_rank,
             moe_mesh=moe_mesh,
             process_group=process_group,
-            async_process_groups=async_process_groups,
         )
-
-    def initialize_async_process_groups(
-        self,
-        ranks: tuple[int, ...],
-        *,
-        is_member: bool,
-    ) -> tuple[ProcessGroup, ProcessGroup] | None:
-        """Collectively create async checkpoint groups for a subset of ranks.
-
-        Every rank in the default process group must call this method in the
-        same order. Non-members participate in group creation but receive no
-        runtime objects to pass to a checkpointer.
-
-        Args:
-            ranks: Global ranks that own the checkpointer.
-            is_member: Whether the current rank belongs to ``ranks``.
-
-        Returns:
-            Model and optimizer Gloo groups on members, otherwise ``None``.
-        """
-        if not self.is_async:
-            return None
-        model_group = torch.distributed.new_group(ranks=list(ranks), backend="gloo")
-        optim_group = torch.distributed.new_group(ranks=list(ranks), backend="gloo")
-        if not is_member:
-            return None
-        return model_group, optim_group
 
 
 __all__ = ["CheckpointingConfig", "SaveConsolidatedMode"]

--- a/nemo_automodel/components/checkpoint/config.py
+++ b/nemo_automodel/components/checkpoint/config.py
@@ -37,6 +37,7 @@ from packaging.version import parse
 from nemo_automodel.components.checkpoint._backports.filesystem import SerializationFormat
 
 if TYPE_CHECKING:
+    from torch.distributed import ProcessGroup
     from torch.distributed.device_mesh import DeviceMesh
 
     from nemo_automodel.components.checkpoint.checkpointing import Checkpointer
@@ -185,6 +186,7 @@ class CheckpointingConfig:
         tp_rank: int,
         pp_rank: int,
         moe_mesh: DeviceMesh | None = None,
+        process_group: ProcessGroup | None = None,
     ) -> Checkpointer:
         """Build the :class:`Checkpointer` engine for this config.
 
@@ -197,13 +199,21 @@ class CheckpointingConfig:
             tp_rank: Tensor-parallel rank.
             pp_rank: Pipeline-parallel rank.
             moe_mesh: Optional device mesh for MoE checkpointing.
+            process_group: Process group used for distributed checkpoint collectives.
 
         Returns:
             Configured :class:`Checkpointer`.
         """
         from nemo_automodel.components.checkpoint.checkpointing import Checkpointer
 
-        return Checkpointer(config=self, dp_rank=dp_rank, tp_rank=tp_rank, pp_rank=pp_rank, moe_mesh=moe_mesh)
+        return Checkpointer(
+            config=self,
+            dp_rank=dp_rank,
+            tp_rank=tp_rank,
+            pp_rank=pp_rank,
+            moe_mesh=moe_mesh,
+            process_group=process_group,
+        )
 
 
 __all__ = ["CheckpointingConfig", "SaveConsolidatedMode"]

--- a/nemo_automodel/components/checkpoint/config.py
+++ b/nemo_automodel/components/checkpoint/config.py
@@ -187,6 +187,7 @@ class CheckpointingConfig:
         pp_rank: int,
         moe_mesh: DeviceMesh | None = None,
         process_group: ProcessGroup | None = None,
+        async_process_groups: tuple[ProcessGroup, ProcessGroup] | None = None,
     ) -> Checkpointer:
         """Build the :class:`Checkpointer` engine for this config.
 
@@ -200,6 +201,8 @@ class CheckpointingConfig:
             pp_rank: Pipeline-parallel rank.
             moe_mesh: Optional device mesh for MoE checkpointing.
             process_group: Process group used for distributed checkpoint collectives.
+            async_process_groups: Optional pre-created model and optimizer Gloo
+                groups used by asynchronous checkpointing.
 
         Returns:
             Configured :class:`Checkpointer`.
@@ -213,7 +216,35 @@ class CheckpointingConfig:
             pp_rank=pp_rank,
             moe_mesh=moe_mesh,
             process_group=process_group,
+            async_process_groups=async_process_groups,
         )
+
+    def initialize_async_process_groups(
+        self,
+        ranks: tuple[int, ...],
+        *,
+        is_member: bool,
+    ) -> tuple[ProcessGroup, ProcessGroup] | None:
+        """Collectively create async checkpoint groups for a subset of ranks.
+
+        Every rank in the default process group must call this method in the
+        same order. Non-members participate in group creation but receive no
+        runtime objects to pass to a checkpointer.
+
+        Args:
+            ranks: Global ranks that own the checkpointer.
+            is_member: Whether the current rank belongs to ``ranks``.
+
+        Returns:
+            Model and optimizer Gloo groups on members, otherwise ``None``.
+        """
+        if not self.is_async:
+            return None
+        model_group = torch.distributed.new_group(ranks=list(ranks), backend="gloo")
+        optim_group = torch.distributed.new_group(ranks=list(ranks), backend="gloo")
+        if not is_member:
+            return None
+        return model_group, optim_group
 
 
 __all__ = ["CheckpointingConfig", "SaveConsolidatedMode"]

--- a/nemo_automodel/components/checkpoint/state_dict_adapter.py
+++ b/nemo_automodel/components/checkpoint/state_dict_adapter.py
@@ -73,5 +73,14 @@ class StateDictAdapter(ABC):
         pass
 
     def get_hf_state_dict_keys(self, state_dict: dict[str, Any]) -> list[str]:
-        """Return the Hugging Face keys produced by ``to_hf``."""
+        """Return the Hugging Face keys produced by ``to_hf``.
+
+        Args:
+            state_dict: Native model state mapping. Tensor values may have
+                arbitrary rank and axis order and retain their exact parameter
+                or buffer layouts.
+
+        Returns:
+            Hugging Face state-dict keys in adapter iteration order.
+        """
         return list(self.to_hf(state_dict, exclude_key_regex=r".*_extra_state.*", quantization=False))

--- a/nemo_automodel/components/checkpoint/state_dict_adapter.py
+++ b/nemo_automodel/components/checkpoint/state_dict_adapter.py
@@ -71,3 +71,7 @@ class StateDictAdapter(ABC):
             Returns a list because some native tensors may split into multiple HF tensors.
         """
         pass
+
+    def get_hf_state_dict_keys(self, state_dict: dict[str, Any]) -> list[str]:
+        """Return the Hugging Face keys produced by ``to_hf``."""
+        return list(self.to_hf(state_dict, exclude_key_regex=r".*_extra_state.*", quantization=False))

--- a/nemo_automodel/components/checkpoint/stateful_wrappers.py
+++ b/nemo_automodel/components/checkpoint/stateful_wrappers.py
@@ -305,12 +305,21 @@ class ModelState:
 
         return model_state_dict
 
-    def load_state_dict(self, state_dict: dict[str, Any], strict: bool = True) -> None:
+    def load_state_dict(
+        self,
+        state_dict: dict[str, Any],
+        strict: bool = True,
+        broadcast_from_rank0: bool = True,
+    ) -> None:
         """
         Load the state dictionary into the model.
 
         Args:
             state_dict (dict): State dictionary to load.
+            strict: Whether missing or unexpected keys should fail the load.
+            broadcast_from_rank0: Whether rank 0 owns the full PEFT state dict.
+                Set to ``False`` when every rank in a model-local process group
+                loaded the adapter independently.
         """
         if self.is_init_step:
             self._set_base_model_state_dict(state_dict)
@@ -333,7 +342,11 @@ class ModelState:
                 for model_part in self.model:
                     _set_peft_state_dict(model_part, state_dict)
                 return
-            options = StateDictOptions(strict=False, broadcast_from_rank0=True, full_state_dict=True)
+            options = StateDictOptions(
+                strict=False,
+                broadcast_from_rank0=broadcast_from_rank0,
+                full_state_dict=True,
+            )
 
         # If we intentionally skipped saving "lm_head.weight" (tied embeddings)
         # PyTorch will complain during load even with strict=False.

--- a/nemo_automodel/components/checkpoint/stateful_wrappers.py
+++ b/nemo_automodel/components/checkpoint/stateful_wrappers.py
@@ -315,7 +315,9 @@ class ModelState:
         Load the state dictionary into the model.
 
         Args:
-            state_dict (dict): State dictionary to load.
+            state_dict: Model state mapping whose tensor values may have arbitrary
+                rank and axis order and retain each parameter or buffer's exact
+                shape and DTensor placement.
             strict: Whether missing or unexpected keys should fail the load.
             broadcast_from_rank0: Whether rank 0 owns the full PEFT state dict.
                 Set to ``False`` when every rank in a model-local process group

--- a/nemo_automodel/components/distributed/config.py
+++ b/nemo_automodel/components/distributed/config.py
@@ -112,6 +112,7 @@ class DistributedSetup:
         activation_checkpointing: ActivationCheckpointingMode = False,
         world_size: int | None = None,
         timeout_minutes: int | None = None,
+        ranks: list[int] | tuple[int, ...] | None = None,
     ) -> "DistributedSetup":
         """Create a resolved distributed setup from sizes and policy configs.
 
@@ -150,6 +151,7 @@ class DistributedSetup:
             parallelism_sizes=parallelism_sizes,
             world_size=world_size,
             timeout_minutes=timeout_minutes,
+            ranks=ranks,
         )
 
         return cls(

--- a/nemo_automodel/components/distributed/cp_utils.py
+++ b/nemo_automodel/components/distributed/cp_utils.py
@@ -219,6 +219,7 @@ def make_cp_batch_and_ctx(
     padding_token_id: int = 0,
     num_chunks: int = 1,
     seq_lens_padding_value: int = -1000,
+    extra_seq_buffers: dict[str, int] | None = None,
 ):
     """
     Build a CP context manager and shards a batch. If the input device_mesh is None or the size
@@ -257,6 +258,8 @@ def make_cp_batch_and_ctx(
         return cp_make_batch_fn(cp_mesh, tp_mesh, batch, loss_mask=loss_mask, padding_token_id=padding_token_id)
 
     if use_te:
+        if extra_seq_buffers:
+            raise ValueError("extra_seq_buffers are not supported by the TE THD context-parallel path")
         return nullcontext, make_cp_batch_for_te(
             cp_mesh,
             batch,
@@ -333,6 +336,15 @@ def make_cp_batch_and_ctx(
         cp_buffers.append(padding_mask)
         cp_seq_dims.append(1)
         cp_no_restore_buffers.add(padding_mask)
+
+    for key, seq_dim in (extra_seq_buffers or {}).items():
+        if key not in batch:
+            raise KeyError(f"Extra CP sequence buffer {key!r} is missing from the batch")
+        buffer = batch[key]
+        batch_buffer_keys[len(cp_buffers)] = key
+        cp_buffers.append(buffer)
+        cp_seq_dims.append(seq_dim)
+        cp_no_restore_buffers.add(buffer)
 
     # Pad sequence length to be divisible by 2 * cp_size (required by
     # context_parallel load balancing). The inputs_embeds path can hit

--- a/nemo_automodel/components/distributed/cp_utils.py
+++ b/nemo_automodel/components/distributed/cp_utils.py
@@ -221,13 +221,14 @@ def unshard_context_parallel_tensor(
 
     Args:
         cp_mesh: One-dimensional context-parallel mesh of size ``C``.
-        tensor: Per-rank tensor whose sequence axis is in PyTorch's
-            load-balanced CP layout. Its local sequence extent is ``S / C``.
+        tensor: Tensor of shape ``[..., local_sequence, ...]`` whose sequence
+            axis is selected by ``seq_dim`` and uses PyTorch's load-balanced CP
+            layout.
         seq_dim: Axis containing the local sequence extent.
 
     Returns:
-        Replicated tensor with the same axis order and full sequence extent
-        ``S`` on ``seq_dim``.
+        Replicated tensor of shape ``[..., sequence, ...]`` with the same axis
+        order and full sequence extent on ``seq_dim``.
     """
     if cp_mesh.size() <= 1:
         return tensor
@@ -249,20 +250,21 @@ def make_cp_batch_and_ctx(
 ):
     """Build a context-parallel context and register sequence-bearing batch tensors.
 
-    ``batch`` must contain exactly one primary sequence tensor: ``input_ids``
-    with shape ``[B, S]`` or ``inputs_embeds`` with shape ``[B, S, H]``, where
-    ``B`` is batch, ``S`` is sequence, and ``H`` is hidden size. ``labels`` has
-    shape ``[B, S]``. Standard ``position_ids`` have shape ``[B, S]`` while
-    multimodal RoPE positions may have shape ``[M, B, S]``. The returned
-    context shards registered sequence axes across the CP mesh and leaves the
-    corresponding batch entries in their per-rank local layout.
+    The returned context shards registered sequence axes across the CP mesh and
+    leaves the corresponding batch entries in their per-rank local layout.
 
     Args:
         device_mesh: Device mesh containing optional ``cp`` and ``tp`` axes.
-        batch: Mapping containing the primary sequence tensor, ``labels``, and
-            optional sequence-aligned tensors. Tensor dtype and device are
+        batch: Mapping containing ``input_ids`` as a tensor of shape
+            ``[batch, sequence]`` or ``inputs_embeds`` as a tensor of shape
+            ``[batch, sequence, hidden]``; ``labels`` as a tensor of shape
+            ``[batch, sequence]``; and optional sequence-aligned tensors.
+            Standard ``position_ids`` have shape ``[batch, sequence]`` and
+            multimodal RoPE positions have shape
+            ``[position_channels, batch, sequence]``. Dtype and device are
             preserved.
-        loss_mask: Optional ``[B, S]`` tensor sharded with the labels.
+        loss_mask: Optional tensor of shape ``[batch, sequence]`` sharded with
+            the labels.
         use_te: Whether to convert the batch to Transformer Engine's packed THD
             layout instead of PyTorch's padded CP layout.
         padding_token_id: Token id used when padding ``input_ids``.
@@ -270,16 +272,15 @@ def make_cp_batch_and_ctx(
         seq_lens_padding_value: Sentinel used for padded sequence lengths in
             the TE path.
         extra_seq_buffers: Additional batch keys mapped to their sequence axis.
-            For example, ``{"teacher_logits": 1}`` registers logits with shape
-            ``[B, S, V]``, where ``V`` is vocabulary size. Floating-point extra
-            buffers are zero-padded when CP divisibility requires padding.
+            For example, ``{"teacher_logits": 1}`` registers a tensor of shape
+            ``[batch, sequence, vocab]``. Floating-point extra buffers are
+            zero-padded when CP divisibility requires padding.
 
     Returns:
         A pair of ``(context_factory, batch)``. Calling ``context_factory()``
         enters the CP region. Registered tensors retain their semantic axis
-        order with per-rank local sequence extent ``S / C`` while inside the
-        context, where ``C`` is CP size. With CP size one, the batch is returned
-        unchanged.
+        order with a per-rank ``local_sequence`` extent while inside the context.
+        With CP size one, the batch is returned unchanged.
     """
     from contextlib import nullcontext
 

--- a/nemo_automodel/components/distributed/cp_utils.py
+++ b/nemo_automodel/components/distributed/cp_utils.py
@@ -211,6 +211,32 @@ def attach_cp_sdpa_hooks(model: torch.nn.Module, cp_mesh) -> None:
             target.register_forward_hook(_post_hook, always_call=True)
 
 
+def unshard_context_parallel_tensor(
+    cp_mesh: DeviceMesh,
+    tensor: torch.Tensor,
+    *,
+    seq_dim: int,
+) -> torch.Tensor:
+    """Restore a tensor from PyTorch's load-balanced context-parallel layout.
+
+    Args:
+        cp_mesh: One-dimensional context-parallel mesh of size ``C``.
+        tensor: Per-rank tensor whose sequence axis is in PyTorch's
+            load-balanced CP layout. Its local sequence extent is ``S / C``.
+        seq_dim: Axis containing the local sequence extent.
+
+    Returns:
+        Replicated tensor with the same axis order and full sequence extent
+        ``S`` on ``seq_dim``.
+    """
+    if cp_mesh.size() <= 1:
+        return tensor
+    from torch.distributed.tensor.experimental._attention import context_parallel_unshard
+
+    (unsharded,) = context_parallel_unshard(cp_mesh, [tensor], seq_dims=[seq_dim])
+    return unsharded
+
+
 def make_cp_batch_and_ctx(
     device_mesh,
     batch,
@@ -221,19 +247,39 @@ def make_cp_batch_and_ctx(
     seq_lens_padding_value: int = -1000,
     extra_seq_buffers: dict[str, int] | None = None,
 ):
-    """
-    Build a CP context manager and shards a batch. If the input device_mesh is None or the size
-    of the context_parallel submesh is 1, this function is effectively a no-op.
+    """Build a context-parallel context and register sequence-bearing batch tensors.
+
+    ``batch`` must contain exactly one primary sequence tensor: ``input_ids``
+    with shape ``[B, S]`` or ``inputs_embeds`` with shape ``[B, S, H]``, where
+    ``B`` is batch, ``S`` is sequence, and ``H`` is hidden size. ``labels`` has
+    shape ``[B, S]``. Standard ``position_ids`` have shape ``[B, S]`` while
+    multimodal RoPE positions may have shape ``[M, B, S]``. The returned
+    context shards registered sequence axes across the CP mesh and leaves the
+    corresponding batch entries in their per-rank local layout.
 
     Args:
-        cp_mesh (DeviceMesh): The device mesh for context parallel.
-        batch (Dict[str, torch.Tensor]): The input batch containing (string, torch.Tensor)
+        device_mesh: Device mesh containing optional ``cp`` and ``tp`` axes.
+        batch: Mapping containing the primary sequence tensor, ``labels``, and
+            optional sequence-aligned tensors. Tensor dtype and device are
+            preserved.
+        loss_mask: Optional ``[B, S]`` tensor sharded with the labels.
+        use_te: Whether to convert the batch to Transformer Engine's packed THD
+            layout instead of PyTorch's padded CP layout.
+        padding_token_id: Token id used when padding ``input_ids``.
+        num_chunks: Number of packed THD chunks for the TE path.
+        seq_lens_padding_value: Sentinel used for padded sequence lengths in
+            the TE path.
+        extra_seq_buffers: Additional batch keys mapped to their sequence axis.
+            For example, ``{"teacher_logits": 1}`` registers logits with shape
+            ``[B, S, V]``, where ``V`` is vocabulary size. Floating-point extra
+            buffers are zero-padded when CP divisibility requires padding.
 
     Returns:
-        tuple (contextmanager, dict[str, torch.Tensor]): Returns a tuple with a context manager
-        and a new batch. The context manager is either nullcontext (no CP) or CP context manager as
-        returned by `create_context_parallel_ctx`. The batch has also been passed to
-        `create_context_parallel_ctx` and is accordingly sharded.
+        A pair of ``(context_factory, batch)``. Calling ``context_factory()``
+        enters the CP region. Registered tensors retain their semantic axis
+        order with per-rank local sequence extent ``S / C`` while inside the
+        context, where ``C`` is CP size. With CP size one, the batch is returned
+        unchanged.
     """
     from contextlib import nullcontext
 

--- a/nemo_automodel/components/distributed/mesh.py
+++ b/nemo_automodel/components/distributed/mesh.py
@@ -105,12 +105,14 @@ class MeshContext:
     Attributes:
         device_mesh: Device mesh for distributed training.
         moe_mesh: MoE-specific device mesh.
+        process_group: Optional model-local group for recipe-level collectives
+            that must not involve ranks outside this mesh.
     """
 
     # runtime mesh references
     device_mesh: Optional["DeviceMesh"] = field(default=None, repr=False)
     moe_mesh: Optional["DeviceMesh"] = field(default=None, repr=False)
-    process_group: Optional["ProcessGroup"] = field(default=None, repr=False)
+    process_group: "ProcessGroup | None" = field(default=None, repr=False)
 
     def __post_init__(self) -> None:
         _validate_mesh_axis_names(self)

--- a/nemo_automodel/components/distributed/mesh.py
+++ b/nemo_automodel/components/distributed/mesh.py
@@ -29,12 +29,13 @@ YAML / dict parsing belongs in the recipe layer — see
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Dict, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, Optional, Sequence, Tuple
 
 from nemo_automodel.components.distributed.config import DistributedStrategyConfig
 from nemo_automodel.components.distributed.init_utils import get_world_size_safe
 
 if TYPE_CHECKING:
+    from torch.distributed import ProcessGroup
     from torch.distributed.device_mesh import DeviceMesh
 
 
@@ -109,6 +110,7 @@ class MeshContext:
     # runtime mesh references
     device_mesh: Optional["DeviceMesh"] = field(default=None, repr=False)
     moe_mesh: Optional["DeviceMesh"] = field(default=None, repr=False)
+    process_group: Optional["ProcessGroup"] = field(default=None, repr=False)
 
     def __post_init__(self) -> None:
         _validate_mesh_axis_names(self)
@@ -191,6 +193,7 @@ class MeshContext:
         *,
         world_size: int | None = None,
         timeout_minutes: int | None = None,
+        ranks: Sequence[int] | None = None,
     ) -> "MeshContext":
         """Build a topology-only :class:`MeshContext` from parallelism sizes.
 
@@ -203,6 +206,8 @@ class MeshContext:
                 distributed environment.
             timeout_minutes: Optional timeout for process groups created by
                 ``DeviceMesh`` axes.
+            ranks: Optional ordered global ranks to use for the mesh. When
+                omitted, the mesh uses every rank in the default process group.
         """
         if world_size is None:
             world_size = get_world_size_safe()
@@ -216,6 +221,7 @@ class MeshContext:
             parallelism_sizes,
             world_size=world_size,
             timeout_minutes=timeout_minutes,
+            ranks=ranks,
         )
         return cls.from_meshes(device_mesh, moe_mesh)
 

--- a/nemo_automodel/components/distributed/mesh_utils.py
+++ b/nemo_automodel/components/distributed/mesh_utils.py
@@ -15,6 +15,7 @@
 """Device mesh construction and access utilities for distributed training."""
 
 import datetime
+import itertools
 from dataclasses import dataclass, field
 
 import torch
@@ -64,6 +65,7 @@ def _create_device_meshes(
     *,
     world_size: int,
     timeout_minutes: int | None = None,
+    ranks: list[int] | tuple[int, ...] | None = None,
 ) -> tuple[DeviceMesh | None, DeviceMesh | None]:
     """Create raw device meshes based on distributed config type."""
     if (
@@ -78,6 +80,7 @@ def _create_device_meshes(
             parallelism,
             world_size=world_size,
             timeout_minutes=timeout_minutes,
+            ranks=ranks,
         )
     elif isinstance(strategy_config, MegatronFSDPConfig):
         _require_size_one("megatron_fsdp", parallelism.pp_size, "pipeline parallelism")
@@ -86,6 +89,7 @@ def _create_device_meshes(
             parallelism,
             world_size=world_size,
             timeout_minutes=timeout_minutes,
+            ranks=ranks,
         )
         return mesh, None
     elif isinstance(strategy_config, DDPConfig):
@@ -124,16 +128,45 @@ def _mesh_device_type() -> str:
     return "cuda" if torch.cuda.is_available() else "cpu"
 
 
-def _init_named_mesh(spec: _MeshSpec, *, timeout_minutes: int | None = None) -> DeviceMesh:
+def _init_named_mesh(
+    spec: _MeshSpec,
+    *,
+    timeout_minutes: int | None = None,
+    ranks: list[int] | tuple[int, ...] | None = None,
+) -> DeviceMesh:
     _validate_mesh_spec(spec)
     device_type = _mesh_device_type()
-    device_mesh = init_device_mesh(
-        device_type=device_type,
-        mesh_shape=spec.shape,
-        mesh_dim_names=spec.axes,
-        backend_override=_nccl_backend_override(spec.axes, device_type=device_type, timeout_minutes=timeout_minutes),
-    )
-    _register_flattened_axes(device_mesh, spec.flattened_axes, timeout_minutes=timeout_minutes)
+    backend_override = _nccl_backend_override(spec.axes, device_type=device_type, timeout_minutes=timeout_minutes)
+    if ranks is None:
+        device_mesh = init_device_mesh(
+            device_type=device_type,
+            mesh_shape=spec.shape,
+            mesh_dim_names=spec.axes,
+            backend_override=backend_override,
+        )
+    else:
+        expected_size = 1
+        for size in spec.shape:
+            expected_size *= size
+        if len(ranks) != expected_size:
+            raise ValueError(f"mesh ranks ({len(ranks)}) must match mesh size ({expected_size})")
+        if len(set(ranks)) != len(ranks):
+            raise ValueError("mesh ranks must be unique")
+        device_mesh = DeviceMesh(
+            device_type=device_type,
+            mesh=torch.tensor(ranks, dtype=torch.int64).reshape(spec.shape),
+            mesh_dim_names=spec.axes,
+            backend_override=backend_override,
+        )
+    if ranks is None:
+        _register_flattened_axes(device_mesh, spec.flattened_axes, timeout_minutes=timeout_minutes)
+    else:
+        _register_flattened_axes_for_rank_subset(
+            device_mesh,
+            spec,
+            ranks=ranks,
+            timeout_minutes=timeout_minutes,
+        )
     return device_mesh
 
 
@@ -190,11 +223,62 @@ def _register_flattened_axes(
         device_mesh._flatten_mapping.setdefault(flattened_axis, flattened_mesh)
 
 
+def _register_flattened_axes_for_rank_subset(
+    device_mesh: DeviceMesh,
+    spec: _MeshSpec,
+    *,
+    ranks: list[int] | tuple[int, ...],
+    timeout_minutes: int | None,
+) -> None:
+    """Register flattened axes without slicing a mesh on non-member ranks.
+
+    PyTorch cannot slice an explicit ``DeviceMesh`` on ranks outside that mesh.
+    Separate-model jobs still need every global rank to create process groups in
+    the same order, so construct each flattened subgroup explicitly and retain
+    the subgroup local to the current rank.
+    """
+    if not spec.flattened_axes:
+        return
+    if not hasattr(device_mesh, "_flatten_mapping"):
+        device_mesh._flatten_mapping = {}
+
+    rank_tensor = torch.tensor(ranks, dtype=torch.int64).reshape(spec.shape)
+    current_rank = dist.get_rank()
+    for flattened_axis, source_axes in spec.flattened_axes.items():
+        source_indices = tuple(spec.axes.index(axis) for axis in source_axes)
+        other_indices = tuple(index for index in range(len(spec.axes)) if index not in source_indices)
+        other_shapes = tuple(spec.shape[index] for index in other_indices)
+        local_ranks = None
+        local_group = None
+        first_ranks = None
+        for other_coordinate in itertools.product(*(range(size) for size in other_shapes)):
+            index = [slice(None)] * len(spec.axes)
+            for axis_index, coordinate in zip(other_indices, other_coordinate):
+                index[axis_index] = coordinate
+            subgroup_ranks = rank_tensor[tuple(index)].reshape(-1).tolist()
+            first_ranks = first_ranks or subgroup_ranks
+            group = dist.new_group(ranks=subgroup_ranks)
+            if current_rank in subgroup_ranks:
+                local_ranks = subgroup_ranks
+                local_group = group
+
+        flat_ranks = local_ranks or first_ranks
+        flattened_mesh = DeviceMesh(
+            device_mesh.device_type,
+            mesh=torch.tensor(flat_ranks, dtype=torch.int64),
+            mesh_dim_names=(flattened_axis,),
+            _init_backend=False,
+        )
+        flattened_mesh._dim_group_names = [local_group.group_name] if local_group is not None else []
+        device_mesh._flatten_mapping.setdefault(flattened_axis, flattened_mesh)
+
+
 def _create_fsdp2_device_mesh(
     parallelism: ParallelismSizes,
     *,
     world_size: int,
     timeout_minutes: int | None = None,
+    ranks: list[int] | tuple[int, ...] | None = None,
 ) -> tuple[DeviceMesh, DeviceMesh | None]:
     """Create the FSDP2 root mesh and optional MoE mesh."""
     tp_size = _degree(parallelism.tp_size)
@@ -241,6 +325,7 @@ def _create_fsdp2_device_mesh(
             },
         ),
         timeout_minutes=timeout_minutes,
+        ranks=ranks,
     )
 
     moe_mesh = None
@@ -260,6 +345,7 @@ def _create_megatron_fsdp_device_mesh(
     *,
     world_size: int,
     timeout_minutes: int | None = None,
+    ranks: list[int] | tuple[int, ...] | None = None,
 ) -> DeviceMesh:
     """Create the Megatron FSDP mesh."""
     tp_size = _degree(parallelism.tp_size)
@@ -279,6 +365,7 @@ def _create_megatron_fsdp_device_mesh(
             flattened_axes={MeshAxisName.DP_CP: (MeshAxisName.DP, MeshAxisName.CP)} if cp_size > 1 else {},
         ),
         timeout_minutes=timeout_minutes,
+        ranks=ranks,
     )
 
 

--- a/nemo_automodel/components/distributed/mesh_utils.py
+++ b/nemo_automodel/components/distributed/mesh_utils.py
@@ -334,7 +334,9 @@ def _create_fsdp2_device_mesh(
             device_mesh,
             ep_shard_size=ep_shard_size,
             ep_size=ep_size,
+            pp_size=pp_size,
             timeout_minutes=timeout_minutes,
+            ranks=ranks,
         )
 
     return device_mesh, moe_mesh
@@ -374,9 +376,36 @@ def _create_moe_mesh(
     *,
     ep_shard_size: int,
     ep_size: int,
+    pp_size: int = 1,
     timeout_minutes: int | None = None,
+    ranks: list[int] | tuple[int, ...] | None = None,
 ) -> DeviceMesh:
     non_pp_axes = (MeshAxisName.DP_REPLICATE, MeshAxisName.DP_SHARD, MeshAxisName.CP, MeshAxisName.TP)
+    if ranks is not None:
+        current_rank = dist.get_rank()
+        ranks_per_stage = ep_shard_size * ep_size
+        backend_override = _nccl_backend_override(
+            (MeshAxisName.EP_SHARD, MeshAxisName.EP),
+            device_type=device_mesh.device_type,
+            timeout_minutes=timeout_minutes,
+        )
+        local_mesh = None
+        first_mesh = None
+        for stage in range(pp_size):
+            stage_ranks = ranks[stage * ranks_per_stage : (stage + 1) * ranks_per_stage]
+            stage_mesh = DeviceMesh(
+                device_mesh.device_type,
+                mesh=torch.tensor(stage_ranks, dtype=torch.int64).reshape(ep_shard_size, ep_size),
+                mesh_dim_names=(MeshAxisName.EP_SHARD, MeshAxisName.EP),
+                backend_override=backend_override,
+            )
+            if first_mesh is None:
+                first_mesh = stage_mesh
+            if current_rank in stage_ranks:
+                local_mesh = stage_mesh
+        if first_mesh is None:
+            raise RuntimeError("Failed to construct an expert-parallel mesh")
+        return local_mesh if local_mesh is not None else first_mesh
     return _unflatten_compat(
         device_mesh[non_pp_axes]._flatten(),
         axis=0,

--- a/nemo_automodel/components/distributed/utils.py
+++ b/nemo_automodel/components/distributed/utils.py
@@ -27,7 +27,7 @@ from nemo_automodel.components.distributed.config import DDPConfig
 logger = logging.getLogger(__name__)
 
 
-def _create_gloo_group(group: dist.ProcessGroup | None = None) -> dist.ProcessGroup | None:
+def _create_gloo_group() -> dist.ProcessGroup | None:
     """
     Create a Gloo process group for barrier operations.
 
@@ -41,17 +41,7 @@ def _create_gloo_group(group: dist.ProcessGroup | None = None) -> dist.ProcessGr
         return None
 
     try:
-        # ``new_group`` normally requires every default-group rank to call it.
-        # Subset recipes only execute this path on ranks that own the trainable
-        # model, so use local synchronization for an explicit subgroup.
-        if group is None:
-            gloo_group = dist.new_group(backend="gloo")
-        else:
-            gloo_group = dist.new_group(
-                ranks=dist.get_process_group_ranks(group),
-                backend="gloo",
-                use_local_synchronization=True,
-            )
+        gloo_group = dist.new_group(backend="gloo")
         logger.debug("Created Gloo group for barrier operations")
         return gloo_group
     except Exception as e:
@@ -61,10 +51,11 @@ def _create_gloo_group(group: dist.ProcessGroup | None = None) -> dist.ProcessGr
 
 def _barrier_with_timeout(timeout: timedelta, group: dist.ProcessGroup | None = None) -> bool:
     """
-    A timeout wrapper for torch.distributed.barrier() using Gloo backend.
+    Run a barrier using the timeout configured on its process group.
 
-    This approach creates a separate Gloo process group for barrier operations
-    while keeping the main NCCL backend for training operations.
+    Explicit model-local groups are reused directly so subset ranks do not need
+    to create another process group in a globally coordinated order. The default
+    group path uses a temporary Gloo group and ``monitored_barrier``.
 
     Args:
         timeout: Maximum time to wait for the barrier
@@ -76,8 +67,16 @@ def _barrier_with_timeout(timeout: timedelta, group: dist.ProcessGroup | None = 
     if not dist.is_initialized() or dist.get_world_size(group=group) == 1:
         return True
 
+    if group is not None:
+        try:
+            dist.barrier(group=group)
+            return True
+        except Exception as e:
+            logger.warning(f"Barrier failed: {e}")
+            return False
+
     # Use Gloo group for barrier operations
-    gloo_group = _create_gloo_group(group)
+    gloo_group = _create_gloo_group()
     if gloo_group is None:
         # Fallback to regular barrier if Gloo group creation fails
         try:

--- a/nemo_automodel/components/distributed/utils.py
+++ b/nemo_automodel/components/distributed/utils.py
@@ -68,12 +68,8 @@ def _barrier_with_timeout(timeout: timedelta, group: dist.ProcessGroup | None = 
         return True
 
     if group is not None:
-        try:
-            dist.barrier(group=group)
-            return True
-        except Exception as e:
-            logger.warning(f"Barrier failed: {e}")
-            return False
+        dist.barrier(group=group)
+        return True
 
     # Use Gloo group for barrier operations
     gloo_group = _create_gloo_group()

--- a/nemo_automodel/components/distributed/utils.py
+++ b/nemo_automodel/components/distributed/utils.py
@@ -27,7 +27,7 @@ from nemo_automodel.components.distributed.config import DDPConfig
 logger = logging.getLogger(__name__)
 
 
-def _create_gloo_group():
+def _create_gloo_group(group: dist.ProcessGroup | None = None) -> dist.ProcessGroup | None:
     """
     Create a Gloo process group for barrier operations.
 
@@ -41,8 +41,17 @@ def _create_gloo_group():
         return None
 
     try:
-        # Create a Gloo group for barrier operations
-        gloo_group = dist.new_group(backend="gloo")
+        # ``new_group`` normally requires every default-group rank to call it.
+        # Subset recipes only execute this path on ranks that own the trainable
+        # model, so use local synchronization for an explicit subgroup.
+        if group is None:
+            gloo_group = dist.new_group(backend="gloo")
+        else:
+            gloo_group = dist.new_group(
+                ranks=dist.get_process_group_ranks(group),
+                backend="gloo",
+                use_local_synchronization=True,
+            )
         logger.debug("Created Gloo group for barrier operations")
         return gloo_group
     except Exception as e:
@@ -50,7 +59,7 @@ def _create_gloo_group():
         return None
 
 
-def _barrier_with_timeout(timeout: timedelta, group=None):
+def _barrier_with_timeout(timeout: timedelta, group: dist.ProcessGroup | None = None) -> bool:
     """
     A timeout wrapper for torch.distributed.barrier() using Gloo backend.
 
@@ -64,11 +73,11 @@ def _barrier_with_timeout(timeout: timedelta, group=None):
     Returns:
         bool: True if barrier completed successfully, False if timeout occurred
     """
-    if not dist.is_initialized() or dist.get_world_size() == 1:
+    if not dist.is_initialized() or dist.get_world_size(group=group) == 1:
         return True
 
     # Use Gloo group for barrier operations
-    gloo_group = _create_gloo_group()
+    gloo_group = _create_gloo_group(group)
     if gloo_group is None:
         # Fallback to regular barrier if Gloo group creation fails
         try:
@@ -102,7 +111,15 @@ class FirstRankPerNode(ContextDecorator):
       - Works on a single GPU (no env flags, no distributed initialisation).
 
     Note: it is assumed the scoped code is not torch.distributed heavy.
+
+    Args:
+        group: Optional model-local process group. When provided, only members
+            of that group participate in serialization and temporary Gloo
+            barrier creation.
     """
+
+    def __init__(self, group: dist.ProcessGroup | None = None) -> None:
+        self.group = group
 
     def __enter__(self, timeout=timedelta(hours=10)):
         """
@@ -116,18 +133,18 @@ class FirstRankPerNode(ContextDecorator):
         self._node0_group = None
         self._first = True  # default for single-GPU / no-dist case
         self._timeout = timeout
-        if not dist.is_initialized() or dist.get_world_size() == 1:
+        if not dist.is_initialized() or dist.get_world_size(group=self.group) == 1:
             # pure single GPU
             return True
 
         # Figure out rank
-        self._first = dist.get_rank() == 0
+        self._first = dist.get_rank(group=self.group) == 0
 
         # Synchronisation logic
         if not self._first:
             # Non-rank-0 processes wait for their node-rank-0
             # Use Gloo group for monitored_barrier to avoid NCCL timeout issues
-            success = _barrier_with_timeout(timeout=self._timeout)
+            success = _barrier_with_timeout(timeout=self._timeout, group=self.group)
             if not success:
                 logger.warning("Barrier timed out, continuing anyway")
 
@@ -157,7 +174,7 @@ class FirstRankPerNode(ContextDecorator):
             if self._first and dist.is_initialized():
                 # Re-sync the whole world so that non-rank-0s can proceed
                 # Use Gloo group for monitored_barrier to avoid NCCL timeout issues
-                success = _barrier_with_timeout(timeout=self._timeout)
+                success = _barrier_with_timeout(timeout=self._timeout, group=self.group)
                 if not success:
                     logger.warning("Barrier timed out during exit, continuing anyway")
                 if exc_type is not None:

--- a/nemo_automodel/components/loss/kd_loss.py
+++ b/nemo_automodel/components/loss/kd_loss.py
@@ -45,25 +45,46 @@ def _infer_tp_group_from_dtensor(logits: torch.Tensor) -> Optional[torch.distrib
     return None
 
 
+def _forward_kl_from_log_probs(
+    teacher_log_prob: torch.Tensor,
+    student_log_prob: torch.Tensor,
+) -> torch.Tensor:
+    """Compute forward KL from full-vocabulary log probabilities.
+
+    Args:
+        teacher_log_prob: Tensor of shape ``[..., vocab]`` containing teacher
+            log probabilities with arbitrary leading dimensions.
+        student_log_prob: Tensor of shape ``[..., vocab]`` containing student
+            log probabilities on the same dtype and device.
+
+    Returns:
+        Tensor of shape ``[...]`` containing per-token
+        ``KL(P_teacher || P_student)``.
+    """
+    teacher_prob = teacher_log_prob.exp()
+    log_ratio = teacher_log_prob - student_log_prob
+    log_ratio = torch.where(teacher_prob > 0, log_ratio, torch.zeros_like(log_ratio))
+    return (teacher_prob * log_ratio).sum(dim=-1)
+
+
 def _kl_forward_tp(
     t_logits: torch.Tensor,
     s_logits: torch.Tensor,
     tp_group: torch.distributed.ProcessGroup,
 ) -> torch.Tensor:
-    """Compute per-token negative cross-entropy ``sum(P * log Q)`` with tensor parallelism.
-
-    Both ``t_logits`` and ``s_logits`` are **local** vocab-sharded tensors of shape
-    ``[valid_tokens, local_vocab_size]``.  A numerically stable global softmax / log-softmax is
-    computed via ``all_reduce`` over ``tp_group``, avoiding the need to gather the full vocab.
+    """Compute per-token forward KL with tensor parallelism.
 
     Args:
-        t_logits: Local teacher logit shard, shape ``[valid_tokens, local_vocab_size]``.
-        s_logits: Local student logit shard, shape ``[valid_tokens, local_vocab_size]``.
+        t_logits: Tensor of shape ``[tokens, local_vocab]`` containing the local
+            teacher vocabulary shard.
+        s_logits: Tensor of shape ``[tokens, local_vocab]`` containing the local
+            student vocabulary shard.
         tp_group: Process group spanning the tensor-parallel ranks.
 
     Returns:
-        Per-token sum(P * log Q), shape ``[valid_tokens]``.  This is the *negative* KL term;
-        negate and average in the caller to obtain the final loss.
+        Tensor of shape ``[tokens]`` containing per-token forward KL. The local
+        vocabulary axis is a ``Shard(-1)`` across ``tp_group`` and is reduced
+        without gathering the full vocabulary.
     """
     # --- Stable global softmax for teacher: P ---
     teacher_max, _ = torch.max(t_logits, dim=-1, keepdim=True)
@@ -71,7 +92,7 @@ def _kl_forward_tp(
     output_teacher = t_logits - teacher_max
     denom_teacher = torch.sum(torch.exp(output_teacher), dim=-1, keepdim=True)
     torch.distributed.all_reduce(denom_teacher, op=torch.distributed.ReduceOp.SUM, group=tp_group)
-    teacher_prob = torch.exp(output_teacher) / denom_teacher.clamp(min=1e-12)
+    teacher_log_prob = output_teacher - torch.log(denom_teacher.clamp(min=1e-12))
 
     # --- Stable global log-softmax for student: log Q ---
     student_max, _ = torch.max(s_logits, dim=-1, keepdim=True)
@@ -82,13 +103,11 @@ def _kl_forward_tp(
     denom_student = dist_nn_func.all_reduce(denom_student, op=torch.distributed.ReduceOp.SUM, group=tp_group)
     student_log_prob = output_student - torch.log(denom_student.clamp(min=1e-12))
 
-    # --- Per-token sum(P * log Q): local accumulate then global reduce ---
-    # Mask -inf student logits so that 0 * -inf does not produce NaN.
-    inf_mask = torch.isinf(s_logits)
-    ce_local = torch.masked_fill(teacher_prob * student_log_prob, inf_mask, 0.0).sum(dim=-1)
-    ce_local = dist_nn_func.all_reduce(ce_local, op=torch.distributed.ReduceOp.SUM, group=tp_group)
+    # --- Per-token KL: local vocabulary contribution then global reduce ---
+    kl_local = _forward_kl_from_log_probs(teacher_log_prob, student_log_prob)
+    kl_local = dist_nn_func.all_reduce(kl_local, op=torch.distributed.ReduceOp.SUM, group=tp_group)
 
-    return ce_local  # shape: [valid_tokens]
+    return kl_local
 
 
 def _kl_forward_chunked(
@@ -96,18 +115,18 @@ def _kl_forward_chunked(
     s_logits: torch.Tensor,
     chunk_size: int,
 ) -> torch.Tensor:
-    """Compute per-token sum(P * log Q) in chunks to reduce peak memory.
+    """Compute per-token forward KL in chunks to reduce peak memory.
 
     Processes ``chunk_size`` tokens at a time so that only one chunk's worth of the
     ``[chunk_size, vocab_size]`` fp32 probability matrix is live at any moment.
 
     Args:
-        t_logits: Teacher logits, shape ``[num_valid_tokens, vocab_size]``.
-        s_logits: Student logits, shape ``[num_valid_tokens, vocab_size]``.
+        t_logits: Tensor of shape ``[tokens, vocab]`` containing teacher logits.
+        s_logits: Tensor of shape ``[tokens, vocab]`` containing student logits.
         chunk_size: Number of tokens per chunk.
 
     Returns:
-        Per-token sum(P * log Q), shape ``[num_valid_tokens]``.
+        Tensor of shape ``[tokens]`` containing per-token forward KL.
     """
     num_tokens = t_logits.shape[0]
     kl_parts: list[torch.Tensor] = []
@@ -115,10 +134,9 @@ def _kl_forward_chunked(
         end = min(start + chunk_size, num_tokens)
         t_chunk = t_logits[start:end]
         s_chunk = s_logits[start:end]
-        teacher_prob = F.softmax(t_chunk, dim=-1, dtype=torch.float32)
+        teacher_logprob = F.log_softmax(t_chunk, dim=-1, dtype=torch.float32)
         student_logprob = F.log_softmax(s_chunk, dim=-1, dtype=torch.float32)
-        inf_mask = torch.isinf(s_chunk)
-        kl_parts.append(torch.masked_fill(teacher_prob * student_logprob, inf_mask, 0).sum(-1))
+        kl_parts.append(_forward_kl_from_log_probs(teacher_logprob, student_logprob))
     return torch.cat(kl_parts, dim=0)
 
 
@@ -172,15 +190,19 @@ class KDLoss(nn.Module):
         """Compute the KD loss.
 
         Args:
-            student_logits: Shape ``[*, vocab_size]`` or ``[*, local_vocab_size]`` for TP.
-            teacher_logits: Same shape as ``student_logits``.
-            labels: Shape ``[*]``.  Positions equal to ``ignore_index`` are excluded from the loss.
+            student_logits: Tensor of shape ``[..., vocab]`` with arbitrary
+                leading dimensions. Under TP, the local tensor has shape
+                ``[..., local_vocab]`` with ``Shard(-1)`` placement.
+            teacher_logits: Tensor with the same global and local shape contract
+                as ``student_logits``.
+            labels: Tensor of shape ``[...]`` matching the logits' leading
+                dimensions. Positions equal to ``ignore_index`` are excluded.
             num_batch_labels: Total number of valid tokens across all gradient-accumulation steps.
                 When provided the loss is ``sum(kl_per_token) / num_batch_labels``; otherwise it
                 is ``mean(kl_per_token)`` over the valid tokens in this micro-batch.
 
         Returns:
-            Scalar KD loss.
+            Scalar tensor containing zero-based forward KL.
         """
         # Exclude padding / ignored tokens from the loss.
         valid_mask = (labels != self.ignore_index).view(-1)
@@ -227,24 +249,22 @@ class KDLoss(nn.Module):
             t_logits = t_logits.mul(1.0 / self.temperature)
             s_logits = s_logits.mul(1.0 / self.temperature)
 
-        # Compute per-token negative cross-entropy: sum(P * log Q).
+        # Compute per-token forward KL: sum(P * (log P - log Q)).
         if tp_group is not None:
             kl_per_token = _kl_forward_tp(t_logits, s_logits, tp_group)
         elif self.chunk_size > 0:
             kl_per_token = _kl_forward_chunked(t_logits, s_logits, self.chunk_size)
         else:
-            teacher_prob = F.softmax(t_logits, dim=-1, dtype=torch.float32)
+            teacher_logprob = F.log_softmax(t_logits, dim=-1, dtype=torch.float32)
             student_logprob = F.log_softmax(s_logits, dim=-1, dtype=torch.float32)
-            inf_mask = torch.isinf(s_logits)
-            kl_per_token = torch.masked_fill(teacher_prob * student_logprob, inf_mask, 0).sum(-1).view(-1)
+            kl_per_token = _forward_kl_from_log_probs(teacher_logprob, student_logprob).view(-1)
 
         # T² scaling: dividing logits by T scales gradients by 1/T², so we multiply the loss by
         # T² to keep gradient magnitudes independent of temperature (Hinton et al., 2015).
         if self.temperature != 1.0:
             kl_per_token = kl_per_token * (self.temperature**2)
 
-        # kl_per_token = sum(P * log Q) ≤ 0.  Negate to obtain a positive minimisation target.
         if num_batch_labels is not None:
-            return -torch.sum(kl_per_token) / num_batch_labels
+            return torch.sum(kl_per_token) / num_batch_labels
         else:
-            return -torch.mean(kl_per_token)
+            return torch.mean(kl_per_token)

--- a/nemo_automodel/components/models/gemma4_moe/model.py
+++ b/nemo_automodel/components/models/gemma4_moe/model.py
@@ -481,6 +481,29 @@ def _build_unpacked_gemma4_causal_mask_mapping(
     *,
     is_training: bool,
 ) -> dict[str, torch.Tensor]:
+    """Build full and sliding masks for an unpacked Gemma4 batch.
+
+    Args:
+        config: Gemma4 text configuration consumed by Transformers mask builders.
+        inputs_embeds: Tensor of shape ``[batch, sequence, hidden]`` containing
+            input embeddings.
+        attention_mask: Optional tensor of shape ``[batch, sequence]`` for token
+            masks or ``[batch, 1, query, key]`` for additive masks.
+        past_key_values: Optional Transformers cache for the same batch.
+        position_ids: Optional tensor of shape ``[batch, sequence]`` containing
+            token positions.
+        mm_token_type_ids: Optional tensor of shape ``[batch, sequence]``
+            containing multimodal token types.
+        pixel_values: Optional tensor of shape
+            ``[images, channels, height, width]`` containing image pixels. It is
+            forwarded only to the legacy Gemma4 mask builder.
+        is_training: Whether the owning model is in training mode.
+
+    Returns:
+        Mapping from ``full_attention`` and ``sliding_attention`` to tensors of
+        shape ``[batch, 1, query, key]`` or equivalent block masks produced by
+        the active Transformers implementation.
+    """
     from transformers.models.gemma4 import modeling_gemma4
 
     legacy_mask_mapping = getattr(modeling_gemma4, "create_causal_mask_mapping", None)

--- a/nemo_automodel/components/models/gemma4_moe/model.py
+++ b/nemo_automodel/components/models/gemma4_moe/model.py
@@ -470,6 +470,51 @@ def get_block_sequence_ids_for_mask(mm_token_type_ids: torch.Tensor, device: tor
     return block_sequence_ids
 
 
+def _build_unpacked_gemma4_causal_mask_mapping(
+    config,
+    inputs_embeds: torch.Tensor,
+    attention_mask: torch.Tensor | None,
+    past_key_values,
+    position_ids: torch.Tensor | None,
+    mm_token_type_ids: torch.Tensor | None,
+    pixel_values: torch.Tensor | None,
+    *,
+    is_training: bool,
+) -> dict[str, torch.Tensor]:
+    from transformers.models.gemma4 import modeling_gemma4
+
+    legacy_mask_mapping = getattr(modeling_gemma4, "create_causal_mask_mapping", None)
+    if legacy_mask_mapping is not None:
+        return legacy_mask_mapping(
+            config=config,
+            inputs_embeds=inputs_embeds,
+            attention_mask=attention_mask,
+            past_key_values=past_key_values,
+            position_ids=position_ids,
+            mm_token_type_ids=mm_token_type_ids,
+            pixel_values=pixel_values,
+            is_training=is_training,
+        )
+
+    from transformers.masking_utils import create_causal_mask, create_sliding_window_causal_mask
+
+    block_sequence_ids = torch.full(inputs_embeds.shape[:2], -1, device=inputs_embeds.device)
+    if mm_token_type_ids is not None:
+        block_sequence_ids = get_block_sequence_ids_for_mask(mm_token_type_ids, device=inputs_embeds.device)
+    mask_kwargs = {
+        "config": config,
+        "inputs_embeds": inputs_embeds,
+        "attention_mask": attention_mask,
+        "past_key_values": past_key_values,
+        "position_ids": position_ids,
+        "block_sequence_ids": block_sequence_ids,
+    }
+    return {
+        "full_attention": create_causal_mask(**mask_kwargs),
+        "sliding_attention": create_sliding_window_causal_mask(**mask_kwargs),
+    }
+
+
 def _build_packed_gemma4_causal_mask_mapping(
     packed_seq_ids: torch.Tensor,
     mm_token_type_ids: torch.Tensor,
@@ -717,27 +762,16 @@ class Gemma4MoETextModelBackend(nn.Module):
                 flex_block_size=(32, 32) if getattr(self.config, "head_dim", 0) > 256 else 128,
             )
         elif use_vision_bidirectional_mask:
-            from transformers.masking_utils import create_causal_mask, create_sliding_window_causal_mask
-
-            # transformers 5.12 removed gemma4's create_causal_mask_mapping. The
-            # vision-aware behaviour (tokens in the same vision group attend
-            # bidirectionally; text tokens stay causal) is now expressed via
-            # block_sequence_ids passed to the standard mask builders.
-            block_sequence_ids = torch.full(inputs_embeds.shape[:2], -1, device=inputs_embeds.device)
-            if mm_token_type_ids is not None:
-                block_sequence_ids = get_block_sequence_ids_for_mask(mm_token_type_ids, device=inputs_embeds.device)
-            mask_kwargs = {
-                "config": self.config,
-                "inputs_embeds": inputs_embeds,
-                "attention_mask": attention_mask,
-                "past_key_values": past_key_values,
-                "position_ids": position_ids,
-                "block_sequence_ids": block_sequence_ids,
-            }
-            causal_mask_mapping = {
-                "full_attention": create_causal_mask(**mask_kwargs),
-                "sliding_attention": create_sliding_window_causal_mask(**mask_kwargs),
-            }
+            causal_mask_mapping = _build_unpacked_gemma4_causal_mask_mapping(
+                self.config,
+                inputs_embeds,
+                attention_mask,
+                past_key_values,
+                position_ids,
+                mm_token_type_ids,
+                pixel_values,
+                is_training=self.training,
+            )
         else:
             from transformers.masking_utils import create_causal_mask, create_sliding_window_causal_mask
 

--- a/nemo_automodel/components/models/gemma4_moe/state_dict_adapter.py
+++ b/nemo_automodel/components/models/gemma4_moe/state_dict_adapter.py
@@ -229,6 +229,13 @@ class Gemma4MoEStateDictAdapter(StateDictAdapter):
 
         return hf_state_dict
 
+    def get_hf_state_dict_keys(self, state_dict: dict[str, Any]) -> list[str]:
+        meta_state_dict = {
+            key: torch.empty_like(value, device="meta") if isinstance(value, torch.Tensor) else value
+            for key, value in state_dict.items()
+        }
+        return list(self.to_hf(meta_state_dict, exclude_key_regex=r".*_extra_state.*"))
+
     def _gather_expert_tensor(
         self,
         tensor: torch.Tensor,

--- a/nemo_automodel/components/models/gemma4_moe/state_dict_adapter.py
+++ b/nemo_automodel/components/models/gemma4_moe/state_dict_adapter.py
@@ -230,6 +230,17 @@ class Gemma4MoEStateDictAdapter(StateDictAdapter):
         return hf_state_dict
 
     def get_hf_state_dict_keys(self, state_dict: dict[str, Any]) -> list[str]:
+        """Return converted keys without gathering real expert weights.
+
+        Args:
+            state_dict: Native Gemma4 state mapping. Expert tensors have shape
+                ``[local_experts, hidden, 2 * expert_hidden]`` for fused gate-up
+                weights or ``[local_experts, expert_hidden, hidden]`` for down
+                weights. Other tensor values retain their model-owned layouts.
+
+        Returns:
+            Hugging Face state-dict keys in adapter iteration order.
+        """
         meta_state_dict = {
             key: torch.empty_like(value, device="meta") if isinstance(value, torch.Tensor) else value
             for key, value in state_dict.items()

--- a/nemo_automodel/components/models/llama/model.py
+++ b/nemo_automodel/components/models/llama/model.py
@@ -407,7 +407,7 @@ class LlamaForCausalLM(HFCheckpointingMixin, LlamaPreTrainedModel):
         """Declared parallelism capabilities for this model class."""
 
         supports_tp: bool = True
-        supports_cp: bool = False
+        supports_cp: bool = True
         supports_pp: bool = True
         supports_ep: bool = False
 

--- a/nemo_automodel/components/training/signal_handler.py
+++ b/nemo_automodel/components/training/signal_handler.py
@@ -100,16 +100,24 @@ class DistributedSignalHandler:
     Args:
         sig: The signal number to handle (e.g., signal.SIGTERM).
              Defaults to signal.SIGTERM.
+        group: Process group whose ranks participate in signal propagation.
+            Defaults to the global process group.
     """
 
-    def __init__(self, sig: int = signal.SIGTERM) -> None:
+    def __init__(
+        self,
+        sig: int = signal.SIGTERM,
+        group: Optional[torch.distributed.ProcessGroup] = None,
+    ) -> None:
         """
         Constructor for the DistributedSignalHandler.
 
         Args:
             sig (int, optional): The signal to handle. Defaults to signal.SIGTERM.
+            group: Process group whose ranks participate in signal propagation.
         """
         self.sig = sig
+        self.group = group
         self._signal_received = False
         self.released = False
         self.original_handler = None
@@ -124,7 +132,7 @@ class DistributedSignalHandler:
             A list of booleans, where each element indicates if the
             corresponding rank received the signal.
         """
-        all_received = all_gather_item(self._signal_received, dtype=torch.int32)
+        all_received = all_gather_item(self._signal_received, dtype=torch.int32, group=self.group)
         return all_received
 
     def __enter__(self) -> "DistributedSignalHandler":

--- a/nemo_automodel/components/training/signal_handler.py
+++ b/nemo_automodel/components/training/signal_handler.py
@@ -107,7 +107,7 @@ class DistributedSignalHandler:
     def __init__(
         self,
         sig: int = signal.SIGTERM,
-        group: Optional[torch.distributed.ProcessGroup] = None,
+        group: torch.distributed.ProcessGroup | None = None,
     ) -> None:
         """
         Constructor for the DistributedSignalHandler.
@@ -124,7 +124,7 @@ class DistributedSignalHandler:
 
     def signals_received(self) -> list[bool]:
         """
-        Check if any rank in the default group received the signal.
+        Check if any rank in the configured group received the signal.
 
         Uses all_gather to collect the signal status from all ranks.
 

--- a/nemo_automodel/components/training/step_scheduler.py
+++ b/nemo_automodel/components/training/step_scheduler.py
@@ -73,7 +73,7 @@ class StepScheduler(Stateful):
         start_epoch: int = 0,
         num_epochs: Optional[int] = None,
         max_steps: Optional[int] = None,
-        process_group: Optional[ProcessGroup] = None,
+        process_group: ProcessGroup | None = None,
     ):
         """
         Initialize the StepScheduler.

--- a/nemo_automodel/components/training/step_scheduler.py
+++ b/nemo_automodel/components/training/step_scheduler.py
@@ -24,6 +24,7 @@ from torch.distributed.checkpoint.stateful import Stateful
 from nemo_automodel.components.training.signal_handler import DistributedSignalHandler
 
 if TYPE_CHECKING:
+    from torch.distributed import ProcessGroup
     from torch.utils.data import DataLoader
 
 logger = logging.getLogger(__name__)
@@ -72,6 +73,7 @@ class StepScheduler(Stateful):
         start_epoch: int = 0,
         num_epochs: Optional[int] = None,
         max_steps: Optional[int] = None,
+        process_group: Optional[ProcessGroup] = None,
     ):
         """
         Initialize the StepScheduler.
@@ -94,6 +96,7 @@ class StepScheduler(Stateful):
             start_epoch (int): Initial epoch. Used when resuming from checkpoint. Default: 0.
             num_epochs (Optional[int]): Total number of epochs. Default: None or calculated from max_steps if num_epochs is None or 10 if max_steps and num_epochs are both None.
             max_steps (Optional[int]): Maximum number of steps to run. If None, calculated from num_epochs.
+            process_group: Process group whose ranks participate in distributed signal handling.
         """
         if global_batch_size <= 0:
             raise ValueError(f"global_batch_size must be greater than 0, got {global_batch_size}")
@@ -170,7 +173,7 @@ class StepScheduler(Stateful):
         self.ckpt_every_steps = ckpt_every_steps
         self.save_checkpoint_every_epoch = save_checkpoint_every_epoch
 
-        self.sig_handler = DistributedSignalHandler().__enter__()
+        self.sig_handler = DistributedSignalHandler(group=process_group).__enter__()
         self.sigterm_flag = False
 
     def __iter__(self):
@@ -366,13 +369,20 @@ class StepSchedulerConfig:
     start_step: int = 0
     start_epoch: int = 0
 
-    def build(self, dataloader: DataLoader, dp_group_size: int, local_batch_size: int) -> StepScheduler:
+    def build(
+        self,
+        dataloader: DataLoader,
+        dp_group_size: int,
+        local_batch_size: int,
+        process_group: ProcessGroup | None = None,
+    ) -> StepScheduler:
         """Build the step scheduler.
 
         Args:
             dataloader: The training dataloader.
             dp_group_size: The size of the data parallel group.
             local_batch_size: The size of the local batch.
+            process_group: Process group whose ranks participate in distributed signal handling.
 
         Returns:
             Configured StepScheduler.
@@ -381,4 +391,5 @@ class StepSchedulerConfig:
         kwargs["local_batch_size"] = local_batch_size
         kwargs["dp_size"] = dp_group_size
         kwargs["dataloader"] = dataloader
+        kwargs["process_group"] = process_group
         return StepScheduler(**kwargs)

--- a/nemo_automodel/recipes/_dist_utils.py
+++ b/nemo_automodel/recipes/_dist_utils.py
@@ -284,6 +284,7 @@ def create_distributed_setup_from_config(
     world_size: Optional[int] = None,
     *,
     timeout_minutes: int | None = None,
+    ranks: list[int] | tuple[int, ...] | None = None,
     strategy: str | None = None,
     dp_size: int | None = None,
     dp_replicate_size: int | None = None,
@@ -314,6 +315,7 @@ def create_distributed_setup_from_config(
         timeout_minutes: Optional timeout for process groups created by
             ``DeviceMesh`` axes. If omitted and ``cfg`` is a top-level recipe
             config, ``dist_env.timeout_minutes`` is used.
+        ranks: Optional ordered global ranks used by this setup's device mesh.
         strategy: Distributed strategy name (``fsdp2``, ``megatron_fsdp``,
             ``megatron-fsdp``, ``mfsdp``, or ``ddp``).
         dp_size: Data-parallel size. If ``None``, inferred by mesh creation.
@@ -364,6 +366,7 @@ def create_distributed_setup_from_config(
         activation_checkpointing=parsed["activation_checkpointing"],
         world_size=world_size,
         timeout_minutes=mesh_timeout_minutes,
+        ranks=ranks,
     )
 
 

--- a/nemo_automodel/recipes/base_recipe.py
+++ b/nemo_automodel/recipes/base_recipe.py
@@ -199,12 +199,12 @@ def _is_rank_0() -> bool:
     return not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0
 
 
-def _dist_barrier() -> None:
+def _dist_barrier(group=None) -> None:
     """Barrier if torch.distributed is initialized.
     TODO(@akoumpa): deprecate in favor of deviemesh api
     """
     if torch.distributed.is_initialized():
-        torch.distributed.barrier()
+        torch.distributed.barrier(group=group)
 
 
 class BaseRecipe:
@@ -319,7 +319,7 @@ class BaseRecipe:
             # clear and remember the last completed path
             setattr(self, "_last_pending_checkpoint_dir", None)
             if is_dist_initialized:
-                torch.distributed.barrier()
+                _dist_barrier(getattr(getattr(self, "mesh_context", None), "process_group", None))
 
         # If a previous async checkpoint just finished, also update the "best" symlink now (if pending)
         prev_best_pending = getattr(self, "_last_pending_best_checkpoint_info", None)
@@ -328,7 +328,7 @@ class BaseRecipe:
                 self._update_best_symlink(prev_best_pending["path"], float(prev_best_pending["val"]))
             setattr(self, "_last_pending_best_checkpoint_info", None)
             if is_dist_initialized:
-                torch.distributed.barrier()
+                _dist_barrier(getattr(getattr(self, "mesh_context", None), "process_group", None))
 
         path = self.checkpointer.config.checkpoint_dir
         path = os.path.join(path, f"epoch_{epoch}_step_{step}")
@@ -364,7 +364,7 @@ class BaseRecipe:
                     logger.warning("Failed to write checkpoint loss metadata to %s", f.name, exc_info=True)
 
         if is_dist_initialized:
-            torch.distributed.barrier()
+            _dist_barrier(getattr(getattr(self, "mesh_context", None), "process_group", None))
 
         model, optimizer, scheduler, tokenizer, config = None, None, None, None, None
         step_scheduler = getattr(self, "step_scheduler", None)
@@ -448,7 +448,7 @@ class BaseRecipe:
         self.checkpointer.save_optimizer(optimizer, model, path, scheduler)
         save_config(config.raw_config, path)
         if is_dist_initialized:
-            torch.distributed.barrier()
+            _dist_barrier(getattr(getattr(self, "mesh_context", None), "process_group", None))
 
         # Update latest symlink according to sync/async behavior
         if getattr(self.checkpointer.config, "is_async", False):
@@ -464,7 +464,7 @@ class BaseRecipe:
                 if best_val_metric is not None:
                     self._update_best_symlink(path, float(best_val_metric))
             if is_dist_initialized:
-                torch.distributed.barrier()
+                _dist_barrier(getattr(getattr(self, "mesh_context", None), "process_group", None))
 
         # Release NCCL workspace and DCP gather scratch back to the allocator.
         # Without this, the next training step's backward sees a fragmented
@@ -538,14 +538,14 @@ class BaseRecipe:
                 self._update_latest_symlink(prev_pending)
             setattr(self, "_last_pending_checkpoint_dir", None)
             if is_dist_initialized:
-                torch.distributed.barrier()
+                _dist_barrier(getattr(getattr(self, "mesh_context", None), "process_group", None))
         prev_best_pending = getattr(self, "_last_pending_best_checkpoint_info", None)
         if prev_best_pending is not None:
             if is_rank_0 and prev_best_pending.get("val") is not None:
                 self._update_best_symlink(prev_best_pending["path"], float(prev_best_pending["val"]))
             setattr(self, "_last_pending_best_checkpoint_info", None)
             if is_dist_initialized:
-                torch.distributed.barrier()
+                _dist_barrier(getattr(getattr(self, "mesh_context", None), "process_group", None))
 
     def _validate_checkpoint_dir_exists(self, ckpt_dir: str, restore_from: str, is_rank_0: bool) -> None:
         """Validate resolved checkpoint directory exists; raise FileNotFoundError with a helpful message."""
@@ -563,7 +563,7 @@ class BaseRecipe:
             error_msg = f"Checkpoint directory does not exist: {ckpt_dir}"
 
         # Ensure all ranks fail together (before raising)
-        _dist_barrier()
+        _dist_barrier(getattr(getattr(self, "mesh_context", None), "process_group", None))
         raise FileNotFoundError(error_msg)
 
     def _load_checkpoint_tracked_state(self, ckpt_dir: str):

--- a/nemo_automodel/recipes/kd_utils.py
+++ b/nemo_automodel/recipes/kd_utils.py
@@ -22,9 +22,10 @@ from typing import Any
 
 import torch
 import torch.distributed as dist
-from torch.distributed.tensor import DTensor
+from torch.distributed.tensor import DTensor, Shard
 
 from nemo_automodel.components.distributed.config import DDPConfig, DistributedSetup
+from nemo_automodel.components.distributed.cp_utils import unshard_context_parallel_tensor
 from nemo_automodel.recipes._dist_utils import create_distributed_setup_from_config, parse_distributed_section
 
 RUN_TEACHER = 1
@@ -37,14 +38,25 @@ def materialize_teacher_logits(
     device_mesh: Any,
     sequence_length: int,
 ) -> torch.Tensor:
-    """Reconstruct full teacher logits across TP and CP before mesh transport."""
+    """Reconstruct full teacher logits across TP and CP before mesh transport.
+
+    Args:
+        logits: Teacher logits with global semantic shape ``[B, S, V]``, where
+            ``B`` is batch, ``S`` is sequence, and ``V`` is vocabulary. The
+            tensor may be a TP vocab-sharded ``DTensor`` and/or have a per-rank
+            load-balanced CP sequence extent.
+        device_mesh: Teacher mesh containing optional ``tp`` and ``cp`` axes.
+        sequence_length: Unpadded global sequence length to retain.
+
+    Returns:
+        Detached contiguous tensor of shape ``[B, sequence_length, V]``
+        replicated on every rank in the teacher model replica.
+    """
     if isinstance(logits, DTensor):
         logits = logits.full_tensor()
     mesh_dim_names = getattr(device_mesh, "mesh_dim_names", ())
     if device_mesh is not None and "cp" in mesh_dim_names and device_mesh["cp"].size() > 1:
-        from torch.distributed.tensor.experimental._attention import context_parallel_unshard
-
-        (logits,) = context_parallel_unshard(device_mesh["cp"], [logits], seq_dims=[1])
+        logits = unshard_context_parallel_tensor(device_mesh["cp"], logits, seq_dim=1)
     return logits.narrow(1, 0, sequence_length).detach().contiguous()
 
 
@@ -63,6 +75,8 @@ def _mesh_size(distributed_cfg: Any, *, label: str) -> int:
     cfg_dict = _section_to_dict(distributed_cfg)
     parsed = parse_distributed_section(cfg_dict)
     sizes = parsed["parallelism_sizes"]
+    if sizes.ep_size > 1:
+        raise ValueError(f"{label}.ep_size > 1 is not supported with separate KD meshes")
     if sizes.dp_size is None:
         raise ValueError(
             f"{label}.dp_size must be set when separate_meshes=true so the non-overlapping rank split is explicit"
@@ -182,6 +196,12 @@ def _model_replicas(setup: DistributedSetup) -> list[_Replica]:
 
 
 def _tree_spec(value: Any, tensors: list[torch.Tensor]) -> Any:
+    """Describe a nested value while extracting tensor leaves without copies.
+
+    Tensor leaves may have arbitrary rank and axis semantics; each leaf's exact
+    shape and dtype are recorded for allocation on receiving ranks. ``tensors``
+    is populated with aliases of the original leaves in traversal order.
+    """
     if isinstance(value, torch.Tensor):
         index = len(tensors)
         tensors.append(value)
@@ -196,6 +216,11 @@ def _tree_spec(value: Any, tensors: list[torch.Tensor]) -> Any:
 
 
 def _tree_from_spec(spec: Any, tensors: list[torch.Tensor]) -> Any:
+    """Rebuild a nested value from tensor leaves described by ``_tree_spec``.
+
+    Tensor leaves preserve the exact shapes and dtypes encoded in ``spec`` and
+    alias the corresponding entries in ``tensors``.
+    """
     kind = spec[0]
     if kind == "tensor":
         return tensors[spec[1]]
@@ -258,6 +283,52 @@ class KDMeshBridge:
     def is_teacher(self) -> bool:
         return self.rank in self.teacher_ranks
 
+    def move_to_device(self, value: Any) -> Any:
+        """Move every tensor leaf in a nested value to the bridge device.
+
+        Tensor leaves may have arbitrary shapes and axis order. The returned
+        tensors preserve shape and dtype, move to ``self.device``, and do not
+        mutate the input containers. Tensors already on the device may be
+        returned unchanged.
+        """
+        if isinstance(value, torch.Tensor):
+            return value.to(self.device, non_blocking=True)
+        if isinstance(value, dict):
+            return {key: self.move_to_device(item) for key, item in value.items()}
+        if isinstance(value, list):
+            return [self.move_to_device(item) for item in value]
+        if isinstance(value, tuple):
+            return tuple(self.move_to_device(item) for item in value)
+        return value
+
+    @staticmethod
+    def match_student_vocab_shard(
+        student_logits: torch.Tensor,
+        teacher_logits: torch.Tensor,
+    ) -> torch.Tensor:
+        """Match full teacher logits to a TP-sharded student vocabulary.
+
+        Args:
+            student_logits: Student logits with global semantic shape
+                ``[B, S, V]``. A vocab-sharded ``DTensor`` has local shape
+                ``[B, S, V_local]`` and a ``Shard(-1)`` placement on its TP axis.
+            teacher_logits: Replicated teacher logits of shape ``[B, S, V]``.
+
+        Returns:
+            Replicated teacher logits unchanged for a non-TP student, otherwise
+            the contiguous local vocabulary slice ``[B, S, V_local]`` matching
+            this rank's student-logit shard.
+        """
+        if not isinstance(student_logits, DTensor):
+            return teacher_logits
+        vocab_dim = student_logits.ndim - 1
+        for mesh_dim, placement in enumerate(student_logits.placements):
+            if isinstance(placement, Shard) and placement.dim in {-1, vocab_dim}:
+                group = student_logits.device_mesh.get_group(mesh_dim)
+                chunks = torch.tensor_split(teacher_logits, dist.get_world_size(group), dim=-1)
+                return chunks[dist.get_rank(group)].contiguous()
+        return teacher_logits
+
     def broadcast_command(self, command: int | None = None) -> int:
         value = command if self.rank == self.student_ranks[0] else 0
         tensor = torch.tensor(value, dtype=torch.int32, device=self.device)
@@ -269,6 +340,13 @@ class KDMeshBridge:
         dist.barrier(group=self.control_group)
 
     def _broadcast_tree(self, value: Any, route: _Route) -> Any:
+        """Broadcast a nested tensor tree along one route.
+
+        Tensor leaves may have arbitrary shapes and axis order. Receiving ranks
+        allocate exact-shape tensors on ``self.device`` and own their storage;
+        the source rank may reuse its contiguous input tensor. Source dtypes are
+        preserved.
+        """
         if self.rank not in route.ranks:
             return None
         source_tensors: list[torch.Tensor] = []
@@ -302,6 +380,11 @@ class KDMeshBridge:
         return _tree_from_spec(spec, tensors)
 
     def send_batch(self, wave: int, batch: Any | None) -> Any | None:
+        """Send one nested batch from each active student replica to a teacher.
+
+        Batch tensor leaves preserve their original shapes and axis order. Only
+        ranks in the teacher replica assigned to ``wave`` receive a batch.
+        """
         teacher_batch = None
         for route in self.input_routes[wave]:
             received = self._broadcast_tree(batch if self.rank == route.src else None, route)
@@ -310,6 +393,17 @@ class KDMeshBridge:
         return teacher_batch
 
     def send_logits(self, wave: int, logits: torch.Tensor | None) -> torch.Tensor | None:
+        """Send full teacher logits back to the assigned student replica.
+
+        Args:
+            wave: Routing wave index.
+            logits: Full replicated teacher logits ``[B, S, V]`` on the
+                teacher output rank, otherwise ``None``.
+
+        Returns:
+            Replicated logits ``[B, S, V]`` on ranks in the assigned student
+            replica, otherwise ``None``.
+        """
         student_logits = None
         for route in self.output_routes[wave]:
             received = self._broadcast_tree(logits if self.rank == route.src else None, route)

--- a/nemo_automodel/recipes/kd_utils.py
+++ b/nemo_automodel/recipes/kd_utils.py
@@ -75,8 +75,6 @@ def _mesh_size(distributed_cfg: Any, *, label: str) -> int:
     cfg_dict = _section_to_dict(distributed_cfg)
     parsed = parse_distributed_section(cfg_dict)
     sizes = parsed["parallelism_sizes"]
-    if sizes.ep_size > 1:
-        raise ValueError(f"{label}.ep_size > 1 is not supported with separate KD meshes")
     if sizes.dp_size is None:
         raise ValueError(
             f"{label}.dp_size must be set when separate_meshes=true so the non-overlapping rank split is explicit"

--- a/nemo_automodel/recipes/kd_utils.py
+++ b/nemo_automodel/recipes/kd_utils.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import itertools
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any, Protocol
 
 import torch
 import torch.distributed as dist
@@ -28,29 +28,41 @@ from nemo_automodel.components.distributed.config import DDPConfig, DistributedS
 from nemo_automodel.components.distributed.cp_utils import unshard_context_parallel_tensor
 from nemo_automodel.recipes._dist_utils import create_distributed_setup_from_config, parse_distributed_section
 
+if TYPE_CHECKING:
+    from torch.distributed.device_mesh import DeviceMesh
+
 RUN_TEACHER = 1
 STOP_TEACHER = 0
+
+
+class _ConfigLike(Protocol):
+    """Minimal recipe-config interface consumed by KD topology setup."""
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Return one configuration value or ``default``."""
+        ...
 
 
 def materialize_teacher_logits(
     logits: torch.Tensor,
     *,
-    device_mesh: Any,
+    device_mesh: "DeviceMesh",
     sequence_length: int,
 ) -> torch.Tensor:
     """Reconstruct full teacher logits across TP and CP before mesh transport.
 
     Args:
-        logits: Teacher logits with global semantic shape ``[B, S, V]``, where
-            ``B`` is batch, ``S`` is sequence, and ``V`` is vocabulary. The
-            tensor may be a TP vocab-sharded ``DTensor`` and/or have a per-rank
-            load-balanced CP sequence extent.
+        logits: Tensor of global shape ``[batch, sequence, vocab]`` containing
+            teacher logits. It may be a vocabulary-sharded ``DTensor`` with
+            ``Shard(-1)`` placement and/or have a per-rank load-balanced
+            ``local_sequence`` extent under CP.
         device_mesh: Teacher mesh containing optional ``tp`` and ``cp`` axes.
         sequence_length: Unpadded global sequence length to retain.
 
     Returns:
-        Detached contiguous tensor of shape ``[B, sequence_length, V]``
-        replicated on every rank in the teacher model replica.
+        Detached contiguous tensor of shape
+        ``[batch, sequence_length, vocab]`` replicated on every rank in the
+        teacher model replica.
     """
     if isinstance(logits, DTensor):
         logits = logits.full_tensor()
@@ -84,7 +96,15 @@ def _mesh_size(distributed_cfg: Any, *, label: str) -> int:
 
 @dataclass(frozen=True)
 class KDDistributedSetups:
-    """Student/teacher setups plus their disjoint global-rank assignments."""
+    """Student/teacher setups plus their global-rank assignments.
+
+    Attributes:
+        student: Resolved student topology and policies.
+        teacher: Resolved teacher topology and policies.
+        student_ranks: Ordered global ranks assigned to the student.
+        teacher_ranks: Ordered global ranks assigned to the teacher.
+        separate: Whether the assignments are disjoint.
+    """
 
     student: DistributedSetup
     teacher: DistributedSetup
@@ -93,8 +113,17 @@ class KDDistributedSetups:
     separate: bool
 
 
-def create_kd_distributed_setups(cfg: Any, *, world_size: int) -> KDDistributedSetups:
-    """Build shared or explicitly disjoint student and teacher distributed setups."""
+def create_kd_distributed_setups(cfg: _ConfigLike, *, world_size: int) -> KDDistributedSetups:
+    """Build shared or explicitly disjoint student and teacher setups.
+
+    Args:
+        cfg: Recipe configuration containing ``distributed`` and optional
+            ``teacher_distributed`` sections.
+        world_size: Total global process count available to both models.
+
+    Returns:
+        Resolved model setups and their ordered global-rank assignments.
+    """
     separate = bool(cfg.get("separate_meshes", False))
     teacher_cfg = cfg.get("teacher_distributed", None)
     if not separate:
@@ -197,8 +226,16 @@ def _tree_spec(value: Any, tensors: list[torch.Tensor]) -> Any:
     """Describe a nested value while extracting tensor leaves without copies.
 
     Tensor leaves may have arbitrary rank and axis semantics; each leaf's exact
-    shape and dtype are recorded for allocation on receiving ranks. ``tensors``
-    is populated with aliases of the original leaves in traversal order.
+    shape and dtype are recorded for allocation on receiving ranks.
+
+    Args:
+        value: Nested dictionaries, lists, tuples, scalar values, and tensor
+            leaves with arbitrary shape and axis order.
+        tensors: Output list populated with aliases of tensor leaves in traversal
+            order.
+
+    Returns:
+        Pickle-compatible nested metadata describing ``value``.
     """
     if isinstance(value, torch.Tensor):
         index = len(tensors)
@@ -218,6 +255,13 @@ def _tree_from_spec(spec: Any, tensors: list[torch.Tensor]) -> Any:
 
     Tensor leaves preserve the exact shapes and dtypes encoded in ``spec`` and
     alias the corresponding entries in ``tensors``.
+
+    Args:
+        spec: Metadata returned by ``_tree_spec``.
+        tensors: Tensor leaves with the exact recorded shapes and dtypes.
+
+    Returns:
+        Reconstructed nested value whose tensor leaves alias ``tensors``.
     """
     kind = spec[0]
     if kind == "tensor":
@@ -232,9 +276,14 @@ def _tree_from_spec(spec: Any, tensors: list[torch.Tensor]) -> Any:
 
 
 class KDMeshBridge:
-    """Move batches and teacher logits between disjoint model meshes."""
+    """Move batches and teacher logits between disjoint model meshes.
 
-    def __init__(self, setups: KDDistributedSetups, *, device: torch.device):
+    Args:
+        setups: Resolved disjoint student and teacher setups.
+        device: Device used for transport tensors and collectives.
+    """
+
+    def __init__(self, setups: KDDistributedSetups, *, device: torch.device) -> None:
         if not setups.separate:
             raise ValueError("KDMeshBridge is only used for separate meshes")
         self.device = device
@@ -284,10 +333,15 @@ class KDMeshBridge:
     def move_to_device(self, value: Any) -> Any:
         """Move every tensor leaf in a nested value to the bridge device.
 
-        Tensor leaves may have arbitrary shapes and axis order. The returned
-        tensors preserve shape and dtype, move to ``self.device``, and do not
-        mutate the input containers. Tensors already on the device may be
-        returned unchanged.
+        Tensor leaves may have arbitrary shapes and axis order.
+
+        Args:
+            value: Nested dictionaries, lists, tuples, scalar values, and tensor
+                leaves.
+
+        Returns:
+            Equivalent nested value whose tensors preserve shape and dtype on
+            ``self.device``. Input containers are not mutated.
         """
         if isinstance(value, torch.Tensor):
             return value.to(self.device, non_blocking=True)
@@ -307,15 +361,17 @@ class KDMeshBridge:
         """Match full teacher logits to a TP-sharded student vocabulary.
 
         Args:
-            student_logits: Student logits with global semantic shape
-                ``[B, S, V]``. A vocab-sharded ``DTensor`` has local shape
-                ``[B, S, V_local]`` and a ``Shard(-1)`` placement on its TP axis.
-            teacher_logits: Replicated teacher logits of shape ``[B, S, V]``.
+            student_logits: Tensor of global shape
+                ``[batch, sequence, vocab]`` containing student logits. A
+                vocabulary-sharded ``DTensor`` has local shape
+                ``[batch, sequence, local_vocab]`` and ``Shard(-1)`` placement.
+            teacher_logits: Replicated tensor of shape
+                ``[batch, sequence, vocab]`` containing teacher logits.
 
         Returns:
-            Replicated teacher logits unchanged for a non-TP student, otherwise
-            the contiguous local vocabulary slice ``[B, S, V_local]`` matching
-            this rank's student-logit shard.
+            Replicated tensor of shape ``[batch, sequence, vocab]`` for a
+            non-TP student, otherwise a contiguous tensor of shape
+            ``[batch, sequence, local_vocab]`` matching this rank's shard.
         """
         if not isinstance(student_logits, DTensor):
             return teacher_logits
@@ -328,6 +384,15 @@ class KDMeshBridge:
         return teacher_logits
 
     def broadcast_command(self, command: int | None = None) -> int:
+        """Broadcast one worker command from the first student rank.
+
+        Args:
+            command: Command supplied on student ranks. Teacher ranks pass
+                ``None`` while waiting for the broadcast.
+
+        Returns:
+            Broadcast command value on every student and teacher rank.
+        """
         value = command if self.rank == self.student_ranks[0] else 0
         tensor = torch.tensor(value, dtype=torch.int32, device=self.device)
         dist.broadcast(tensor, src=self.student_ranks[0], group=self.control_group)
@@ -340,10 +405,15 @@ class KDMeshBridge:
     def _broadcast_tree(self, value: Any, route: _Route) -> Any:
         """Broadcast a nested tensor tree along one route.
 
-        Tensor leaves may have arbitrary shapes and axis order. Receiving ranks
-        allocate exact-shape tensors on ``self.device`` and own their storage;
-        the source rank may reuse its contiguous input tensor. Source dtypes are
-        preserved.
+        Tensor leaves may have arbitrary shapes and axis order.
+
+        Args:
+            value: Nested source value on ``route.src`` and ``None`` elsewhere.
+            route: Source, membership, and process group for the broadcast.
+
+        Returns:
+            Reconstructed value on route members and ``None`` elsewhere.
+            Receiving tensors preserve source shape and dtype on ``self.device``.
         """
         if self.rank not in route.ranks:
             return None
@@ -380,8 +450,15 @@ class KDMeshBridge:
     def send_batch(self, wave: int, batch: Any | None) -> Any | None:
         """Send one nested batch from each active student replica to a teacher.
 
-        Batch tensor leaves preserve their original shapes and axis order. Only
-        ranks in the teacher replica assigned to ``wave`` receive a batch.
+        Batch tensor leaves preserve their original shapes and axis order.
+
+        Args:
+            wave: Routing wave index.
+            batch: Nested student batch on student ranks and ``None`` on teacher
+                ranks.
+
+        Returns:
+            Assigned nested batch on teacher ranks and ``None`` on student ranks.
         """
         teacher_batch = None
         for route in self.input_routes[wave]:
@@ -395,12 +472,13 @@ class KDMeshBridge:
 
         Args:
             wave: Routing wave index.
-            logits: Full replicated teacher logits ``[B, S, V]`` on the
-                teacher output rank, otherwise ``None``.
+            logits: Tensor of shape ``[batch, sequence, vocab]`` containing full
+                replicated teacher logits on the teacher output rank, otherwise
+                ``None``.
 
         Returns:
-            Replicated logits ``[B, S, V]`` on ranks in the assigned student
-            replica, otherwise ``None``.
+            Replicated tensor of shape ``[batch, sequence, vocab]`` on ranks in
+            the assigned student replica, otherwise ``None``.
         """
         student_logits = None
         for route in self.output_routes[wave]:

--- a/nemo_automodel/recipes/kd_utils.py
+++ b/nemo_automodel/recipes/kd_utils.py
@@ -1,0 +1,318 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Distributed topology and tensor transport helpers for KD recipes."""
+
+from __future__ import annotations
+
+import itertools
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.distributed as dist
+from torch.distributed.tensor import DTensor
+
+from nemo_automodel.components.distributed.config import DDPConfig, DistributedSetup
+from nemo_automodel.recipes._dist_utils import create_distributed_setup_from_config, parse_distributed_section
+
+RUN_TEACHER = 1
+STOP_TEACHER = 0
+
+
+def materialize_teacher_logits(
+    logits: torch.Tensor,
+    *,
+    device_mesh: Any,
+    sequence_length: int,
+) -> torch.Tensor:
+    """Reconstruct full teacher logits across TP and CP before mesh transport."""
+    if isinstance(logits, DTensor):
+        logits = logits.full_tensor()
+    mesh_dim_names = getattr(device_mesh, "mesh_dim_names", ())
+    if device_mesh is not None and "cp" in mesh_dim_names and device_mesh["cp"].size() > 1:
+        from torch.distributed.tensor.experimental._attention import context_parallel_unshard
+
+        (logits,) = context_parallel_unshard(device_mesh["cp"], [logits], seq_dims=[1])
+    return logits.narrow(1, 0, sequence_length).detach().contiguous()
+
+
+def _section_to_dict(section: Any) -> dict:
+    if section is None:
+        return {}
+    if isinstance(section, dict):
+        return section.copy()
+    if hasattr(section, "to_dict"):
+        return section.to_dict()
+    return dict(section)
+
+
+def _mesh_size(distributed_cfg: Any, *, label: str) -> int:
+    """Return the explicitly requested mesh size for a separate KD model."""
+    cfg_dict = _section_to_dict(distributed_cfg)
+    parsed = parse_distributed_section(cfg_dict)
+    sizes = parsed["parallelism_sizes"]
+    if sizes.dp_size is None:
+        raise ValueError(
+            f"{label}.dp_size must be set when separate_meshes=true so the non-overlapping rank split is explicit"
+        )
+    return sizes.dp_size * sizes.tp_size * sizes.pp_size * sizes.cp_size
+
+
+@dataclass(frozen=True)
+class KDDistributedSetups:
+    """Student/teacher setups plus their disjoint global-rank assignments."""
+
+    student: DistributedSetup
+    teacher: DistributedSetup
+    student_ranks: tuple[int, ...]
+    teacher_ranks: tuple[int, ...]
+    separate: bool
+
+
+def create_kd_distributed_setups(cfg: Any, *, world_size: int) -> KDDistributedSetups:
+    """Build shared or explicitly disjoint student and teacher distributed setups."""
+    separate = bool(cfg.get("separate_meshes", False))
+    teacher_cfg = cfg.get("teacher_distributed", None)
+    if not separate:
+        if teacher_cfg is not None:
+            raise ValueError("teacher_distributed requires separate_meshes=true")
+        shared = create_distributed_setup_from_config(cfg, world_size=world_size)
+        ranks = tuple(range(world_size))
+        return KDDistributedSetups(shared, shared, ranks, ranks, False)
+
+    if teacher_cfg is None:
+        raise ValueError("separate_meshes=true requires a teacher_distributed section")
+
+    student_cfg = _section_to_dict(cfg.get("distributed", None))
+    teacher_cfg = _section_to_dict(teacher_cfg)
+    student_size = _mesh_size(student_cfg, label="distributed")
+    teacher_size = _mesh_size(teacher_cfg, label="teacher_distributed")
+    if student_size + teacher_size != world_size:
+        raise ValueError(
+            "Separate KD mesh sizes must use every rank exactly once: "
+            f"student={student_size} + teacher={teacher_size} != world_size={world_size}"
+        )
+
+    student_ranks = tuple(range(student_size))
+    teacher_ranks = tuple(range(student_size, world_size))
+    student = create_distributed_setup_from_config(
+        student_cfg,
+        world_size=student_size,
+        ranks=student_ranks,
+    )
+    teacher = create_distributed_setup_from_config(
+        teacher_cfg,
+        world_size=teacher_size,
+        ranks=teacher_ranks,
+    )
+    if isinstance(student.strategy_config, DDPConfig) or isinstance(teacher.strategy_config, DDPConfig):
+        raise ValueError("Separate KD meshes currently require mesh-backed strategies; DDP is not supported")
+    return KDDistributedSetups(student, teacher, student_ranks, teacher_ranks, True)
+
+
+@dataclass(frozen=True)
+class _Replica:
+    ranks: tuple[int, ...]
+    input_rank: int
+    output_rank: int
+
+
+@dataclass(frozen=True)
+class _Route:
+    src: int
+    ranks: tuple[int, ...]
+    group: dist.ProcessGroup
+
+
+def _model_replicas(setup: DistributedSetup) -> list[_Replica]:
+    mesh = setup.mesh_context.device_mesh
+    if mesh is None:
+        raise ValueError("Separate KD meshes require a DeviceMesh")
+
+    names = tuple(name.value if hasattr(name, "value") else str(name) for name in mesh.mesh_dim_names)
+    rank_mesh = mesh.mesh.cpu()
+    dp_axes = tuple(i for i, name in enumerate(names) if name in {"dp", "dp_replicate", "dp_shard"})
+    if not dp_axes:
+        raise ValueError(f"KD mesh has no data-parallel axis: {names}")
+
+    grouped: dict[tuple[int, ...], list[tuple[tuple[int, ...], int]]] = {}
+    for coordinate in itertools.product(*(range(size) for size in rank_mesh.shape)):
+        dp_coordinate = tuple(coordinate[i] for i in dp_axes)
+        grouped.setdefault(dp_coordinate, []).append((coordinate, int(rank_mesh[coordinate].item())))
+
+    replicas = []
+    pp_axis = names.index("pp") if "pp" in names else None
+    cp_axis = names.index("cp") if "cp" in names else None
+    tp_axis = names.index("tp") if "tp" in names else None
+    for dp_coordinate in sorted(grouped):
+        entries = grouped[dp_coordinate]
+
+        def is_input(coordinate: tuple[int, ...]) -> bool:
+            return all(coordinate[axis] == 0 for axis in (pp_axis, cp_axis, tp_axis) if axis is not None)
+
+        def is_output(coordinate: tuple[int, ...]) -> bool:
+            if pp_axis is not None and coordinate[pp_axis] != rank_mesh.shape[pp_axis] - 1:
+                return False
+            return all(coordinate[axis] == 0 for axis in (cp_axis, tp_axis) if axis is not None)
+
+        input_ranks = [rank for coordinate, rank in entries if is_input(coordinate)]
+        output_ranks = [rank for coordinate, rank in entries if is_output(coordinate)]
+        if len(input_ranks) != 1 or len(output_ranks) != 1:
+            raise RuntimeError(f"Could not identify KD replica endpoints for DP coordinate {dp_coordinate}")
+        replicas.append(
+            _Replica(
+                ranks=tuple(rank for _, rank in entries),
+                input_rank=input_ranks[0],
+                output_rank=output_ranks[0],
+            )
+        )
+    return replicas
+
+
+def _tree_spec(value: Any, tensors: list[torch.Tensor]) -> Any:
+    if isinstance(value, torch.Tensor):
+        index = len(tensors)
+        tensors.append(value)
+        return ("tensor", index, tuple(value.shape), str(value.dtype).removeprefix("torch."))
+    if isinstance(value, dict):
+        return ("dict", [(key, _tree_spec(item, tensors)) for key, item in value.items()])
+    if isinstance(value, list):
+        return ("list", [_tree_spec(item, tensors) for item in value])
+    if isinstance(value, tuple):
+        return ("tuple", [_tree_spec(item, tensors) for item in value])
+    return ("value", value)
+
+
+def _tree_from_spec(spec: Any, tensors: list[torch.Tensor]) -> Any:
+    kind = spec[0]
+    if kind == "tensor":
+        return tensors[spec[1]]
+    if kind == "dict":
+        return {key: _tree_from_spec(item, tensors) for key, item in spec[1]}
+    if kind == "list":
+        return [_tree_from_spec(item, tensors) for item in spec[1]]
+    if kind == "tuple":
+        return tuple(_tree_from_spec(item, tensors) for item in spec[1])
+    return spec[1]
+
+
+class KDMeshBridge:
+    """Move batches and teacher logits between disjoint model meshes."""
+
+    def __init__(self, setups: KDDistributedSetups, *, device: torch.device):
+        if not setups.separate:
+            raise ValueError("KDMeshBridge is only used for separate meshes")
+        self.device = device
+        self.rank = dist.get_rank()
+        self.student_ranks = setups.student_ranks
+        self.teacher_ranks = setups.teacher_ranks
+        self.control_group = dist.new_group(ranks=list(self.student_ranks + self.teacher_ranks))
+        self.student_group = dist.new_group(ranks=list(self.student_ranks))
+        self.teacher_group = dist.new_group(ranks=list(self.teacher_ranks))
+        self.student_replicas = _model_replicas(setups.student)
+        self.teacher_replicas = _model_replicas(setups.teacher)
+        self.num_waves = (len(self.student_replicas) + len(self.teacher_replicas) - 1) // len(self.teacher_replicas)
+
+        self.input_routes: list[list[_Route]] = []
+        self.output_routes: list[list[_Route]] = []
+        for wave in range(self.num_waves):
+            wave_inputs = []
+            wave_outputs = []
+            for teacher_index, teacher_replica in enumerate(self.teacher_replicas):
+                student_index = wave * len(self.teacher_replicas) + teacher_index
+                source_index = student_index if student_index < len(self.student_replicas) else 0
+                source = self.student_replicas[source_index].input_rank
+                input_ranks = tuple(dict.fromkeys((source, *teacher_replica.ranks)))
+                wave_inputs.append(_Route(source, input_ranks, dist.new_group(ranks=list(input_ranks))))
+                if student_index < len(self.student_replicas):
+                    output_ranks = tuple(
+                        dict.fromkeys((teacher_replica.output_rank, *self.student_replicas[student_index].ranks))
+                    )
+                    wave_outputs.append(
+                        _Route(
+                            teacher_replica.output_rank,
+                            output_ranks,
+                            dist.new_group(ranks=list(output_ranks)),
+                        )
+                    )
+            self.input_routes.append(wave_inputs)
+            self.output_routes.append(wave_outputs)
+
+    @property
+    def is_student(self) -> bool:
+        return self.rank in self.student_ranks
+
+    @property
+    def is_teacher(self) -> bool:
+        return self.rank in self.teacher_ranks
+
+    def broadcast_command(self, command: int | None = None) -> int:
+        value = command if self.rank == self.student_ranks[0] else 0
+        tensor = torch.tensor(value, dtype=torch.int32, device=self.device)
+        dist.broadcast(tensor, src=self.student_ranks[0], group=self.control_group)
+        return int(tensor.item())
+
+    def synchronize(self) -> None:
+        """Wait for both model roles without using the default process group."""
+        dist.barrier(group=self.control_group)
+
+    def _broadcast_tree(self, value: Any, route: _Route) -> Any:
+        if self.rank not in route.ranks:
+            return None
+        source_tensors: list[torch.Tensor] = []
+        objects = [None]
+        if self.rank == route.src:
+            objects[0] = _tree_spec(value, source_tensors)
+        dist.broadcast_object_list(objects, src=route.src, group=route.group, device=self.device)
+        spec = objects[0]
+        if self.rank == route.src:
+            tensors = [tensor.to(self.device).contiguous() for tensor in source_tensors]
+        else:
+            tensor_specs: dict[int, tuple[tuple[int, ...], str]] = {}
+
+            def collect(node: Any) -> None:
+                if node[0] == "tensor":
+                    tensor_specs[node[1]] = (node[2], node[3])
+                elif node[0] == "dict":
+                    for _, child in node[1]:
+                        collect(child)
+                elif node[0] in {"list", "tuple"}:
+                    for child in node[1]:
+                        collect(child)
+
+            collect(spec)
+            tensors = [
+                torch.empty(shape, dtype=getattr(torch, dtype_name), device=self.device)
+                for _, (shape, dtype_name) in sorted(tensor_specs.items())
+            ]
+        for tensor in tensors:
+            dist.broadcast(tensor, src=route.src, group=route.group)
+        return _tree_from_spec(spec, tensors)
+
+    def send_batch(self, wave: int, batch: Any | None) -> Any | None:
+        teacher_batch = None
+        for route in self.input_routes[wave]:
+            received = self._broadcast_tree(batch if self.rank == route.src else None, route)
+            if self.is_teacher and self.rank in route.ranks:
+                teacher_batch = received
+        return teacher_batch
+
+    def send_logits(self, wave: int, logits: torch.Tensor | None) -> torch.Tensor | None:
+        student_logits = None
+        for route in self.output_routes[wave]:
+            received = self._broadcast_tree(logits if self.rank == route.src else None, route)
+            if self.is_student and self.rank in route.ranks:
+                student_logits = received
+        return student_logits

--- a/nemo_automodel/recipes/llm/kd.py
+++ b/nemo_automodel/recipes/llm/kd.py
@@ -273,10 +273,6 @@ class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNe
 
         self.kd_mesh_bridge = KDMeshBridge(self.kd_distributed_setups, device=self.dist_env.device)
         self._training_process_group = self.kd_mesh_bridge.student_group
-        self._checkpoint_async_process_groups = self.cfg.checkpoint.initialize_async_process_groups(
-            self.kd_distributed_setups.student_ranks,
-            is_member=self.kd_mesh_bridge.is_student,
-        )
         if self.kd_mesh_bridge.is_student:
             setup = self.kd_distributed_setups.student
             setup.mesh_context.process_group = self.kd_mesh_bridge.student_group

--- a/nemo_automodel/recipes/llm/kd.py
+++ b/nemo_automodel/recipes/llm/kd.py
@@ -41,12 +41,11 @@ from __future__ import annotations
 import logging
 import time
 from contextlib import nullcontext
+from dataclasses import replace
 from typing import Any, Dict, Optional
 
 import torch
-import torch.distributed as dist
 import wandb
-from torch.distributed.tensor import DTensor, Shard
 from torchao.float8 import precompute_float8_dynamic_scale_for_fsdp
 
 from nemo_automodel._transformers.auto_tokenizer import NeMoAutoTokenizer
@@ -59,6 +58,7 @@ from nemo_automodel.components.loggers.metric_logger import MetricsSample
 from nemo_automodel.components.loss.linear_ce import FusedLinearCrossEntropy
 from nemo_automodel.components.loss.utils import calculate_loss
 from nemo_automodel.components.training.rng import ScopedRNG
+from nemo_automodel.components.training.signal_handler import DistributedSignalHandler
 from nemo_automodel.components.training.utils import (
     ScopedModuleOffloading,
     count_tail_padding,
@@ -84,31 +84,6 @@ from nemo_automodel.recipes.llm.train_ft import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-def _move_to_device(value: Any, device: torch.device) -> Any:
-    if isinstance(value, torch.Tensor):
-        return value.to(device, non_blocking=True)
-    if isinstance(value, dict):
-        return {key: _move_to_device(item, device) for key, item in value.items()}
-    if isinstance(value, list):
-        return [_move_to_device(item, device) for item in value]
-    if isinstance(value, tuple):
-        return tuple(_move_to_device(item, device) for item in value)
-    return value
-
-
-def _match_student_vocab_shard(student_logits: torch.Tensor, teacher_logits: torch.Tensor) -> torch.Tensor:
-    """Slice full teacher logits to the student's vocab shard when TP is active."""
-    if not isinstance(student_logits, DTensor):
-        return teacher_logits
-    vocab_dim = student_logits.ndim - 1
-    for mesh_dim, placement in enumerate(student_logits.placements):
-        if isinstance(placement, Shard) and placement.dim in {-1, vocab_dim}:
-            group = student_logits.device_mesh.get_group(mesh_dim)
-            chunks = torch.tensor_split(teacher_logits, dist.get_world_size(group), dim=-1)
-            return chunks[dist.get_rank(group)].contiguous()
-    return teacher_logits
 
 
 def _build_kd_loss_fn(cfg_kd):
@@ -201,6 +176,19 @@ def _build_teacher_model_with_pp(
     teacher_logits_capture = [None]
 
     def _teacher_capture_loss_fn(logits, target, **kwargs):
+        """Capture one teacher PP microbatch.
+
+        Args:
+            logits: Last-stage teacher logits ``[B_m, S, V]``, where ``B_m``
+                is pipeline microbatch, ``S`` is sequence, and ``V`` is vocab.
+            target: Labels ``[B_m, S]`` supplied by the schedule and unused here.
+            **kwargs: Schedule-owned scalar or tensor metadata ignored by the
+                capture path. Tensor metadata, when present, follows the same
+                microbatch axis as ``logits``.
+
+        Returns:
+            Scalar zero tensor on the same dtype and device as ``logits``.
+        """
         if teacher_logits_capture[0] is None:
             teacher_logits_capture[0] = []
         teacher_logits_capture[0].append(logits.detach().clone())
@@ -310,8 +298,11 @@ class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNe
             raise ValueError(
                 "Separate-mesh PP KD requires local_batch_size to be divisible by teacher pp_microbatch_size"
             )
-        self.pipeline_config.pp_batch_size = pp_batch_size
-        self.pipeline_config.pp_microbatch_size = pp_microbatch_size
+        self.pipeline_config = replace(
+            self.pipeline_config,
+            pp_batch_size=pp_batch_size,
+            pp_microbatch_size=pp_microbatch_size,
+        )
 
     def setup(self):  # noqa: C901 – same complexity as parent
         """Build student & teacher, dataloaders, optimizers, etc."""
@@ -409,6 +400,19 @@ class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNe
         recipe_ref = self
 
         def pp_kd_loss_fn(logits, target, **kwargs):
+            """Combine CE and KD for one student PP microbatch.
+
+            Args:
+                logits: Student logits ``[B_m, S, V]`` or local TP shard
+                    ``[B_m, S, V_local]``.
+                target: Labels ``[B_m, S]`` with ``-100`` ignored.
+                **kwargs: Pipeline schedule scalar or tensor metadata. Tensor
+                    metadata, when present, follows the same microbatch axis as
+                    ``logits``.
+
+            Returns:
+                Scalar mixed CE/KD loss for the microbatch.
+            """
             teacher_logits = getattr(recipe_ref, "_current_teacher_logits", None)
             if teacher_logits is None:
                 raise RuntimeError(
@@ -420,7 +424,7 @@ class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNe
                     raise RuntimeError("KD loss wrapper received more student than teacher microbatches")
                 teacher_logits = teacher_logits.pop(0)
             if getattr(recipe_ref, "separate_meshes", False):
-                teacher_logits = _match_student_vocab_shard(logits, teacher_logits)
+                teacher_logits = recipe_ref.kd_mesh_bridge.match_student_vocab_shard(logits, teacher_logits)
             # num_label_tokens is None because
             # _run_train_optim_step_pp applies scale_grads_and_clip_grad_norm
             # (which divides grads by num_label_tokens/dp_group_size) and
@@ -447,6 +451,12 @@ class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNe
         return pp_kd_loss_fn
 
     def _get_separate_teacher_logits(self, batch: dict[str, Any]) -> torch.Tensor:
+        """Request teacher logits for one student batch.
+
+        ``batch`` contains sequence tensors such as ``input_ids`` and ``labels``
+        with shape ``[B, S]`` plus optional nested tensor metadata. Returns full
+        teacher logits ``[B, S, V]`` replicated across the student replica.
+        """
         self.kd_mesh_bridge.broadcast_command(RUN_TEACHER)
         teacher_logits = None
         for wave in range(self.kd_mesh_bridge.num_waves):
@@ -460,7 +470,18 @@ class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNe
 
     @torch.no_grad()
     def _teacher_forward_separate(self, batch: dict[str, Any]) -> torch.Tensor | None:
-        batch = _move_to_device(batch, self.dist_env.device)
+        """Run one teacher batch and materialize transport-ready logits.
+
+        Args:
+            batch: Nested batch with ``input_ids`` and ``labels`` shaped
+                ``[B, S]`` plus optional model inputs. Tensors may initially
+                reside on CPU.
+
+        Returns:
+            Full detached teacher logits ``[B, S, V]`` on the teacher output
+            rank, otherwise ``None`` for PP ranks without the final stage.
+        """
+        batch = self.kd_mesh_bridge.move_to_device(batch)
         sequence_length = batch["labels"].shape[1]
         train_ctx, batch = make_cp_batch_and_ctx(
             self.device_mesh,
@@ -519,13 +540,15 @@ class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNe
         )
 
     def _run_teacher_worker(self) -> None:
-        while self.kd_mesh_bridge.broadcast_command() == RUN_TEACHER:
-            for wave in range(self.kd_mesh_bridge.num_waves):
-                batch = self.kd_mesh_bridge.send_batch(wave, None)
-                if batch is None:
-                    raise RuntimeError("Teacher rank did not receive a batch from the student mesh")
-                logits = self._teacher_forward_separate(batch)
-                self.kd_mesh_bridge.send_logits(wave, logits)
+        """Serve teacher forwards until the student mesh broadcasts stop."""
+        with DistributedSignalHandler(group=self.kd_mesh_bridge.teacher_group):
+            while self.kd_mesh_bridge.broadcast_command() == RUN_TEACHER:
+                for wave in range(self.kd_mesh_bridge.num_waves):
+                    batch = self.kd_mesh_bridge.send_batch(wave, None)
+                    if batch is None:
+                        raise RuntimeError("Teacher rank did not receive a batch from the student mesh")
+                    logits = self._teacher_forward_separate(batch)
+                    self.kd_mesh_bridge.send_logits(wave, logits)
 
     def _forward_backward_step(
         self,
@@ -536,7 +559,12 @@ class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNe
         num_batches,
         is_train: bool = True,
     ):
-        """Override the forward backward step to include knowledge distillation loss."""
+        """Run one non-PP student microbatch with KD.
+
+        ``batch`` contains ``input_ids`` and ``labels`` shaped ``[B, S]`` plus
+        optional model tensors. Teacher and student logits have semantic shape
+        ``[B, S, V]`` and may use local TP/CP layouts inside the step.
+        """
         if self.pp_enabled:
             raise RuntimeError(
                 "_forward_backward_step should not be called when pp_enabled; use _forward_backward_step_pp instead."
@@ -592,7 +620,7 @@ class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNe
 
             student_logits = getattr(student_out, "logits", student_out)  # shape (B, S, V)
             if separate_teacher_logits is not None:
-                teacher_logits = _match_student_vocab_shard(student_logits, teacher_logits)
+                teacher_logits = self.kd_mesh_bridge.match_student_vocab_shard(student_logits, teacher_logits)
 
             # Cross-entropy loss against true labels (skip when kd_ratio >= 1.0).
             if self.kd_ratio >= 1.0:
@@ -636,6 +664,10 @@ class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNe
 
         Teacher logits from the last PP stage are stored in ``self._current_teacher_logits``
         before the student schedule runs, so ``pp_kd_loss_fn`` can read them.
+
+        ``batch`` contains ``input_ids`` and ``labels`` shaped ``[B, S]`` plus
+        optional model tensors. Transported teacher logits have shape
+        ``[B, S, V]`` and are split into ``[B_m, S, V]`` PP microbatches.
         """
         separate_teacher_logits = (
             self._get_separate_teacher_logits(batch) if getattr(self, "separate_meshes", False) else None

--- a/nemo_automodel/recipes/llm/kd.py
+++ b/nemo_automodel/recipes/llm/kd.py
@@ -24,13 +24,9 @@ extends ``FinetuneRecipeForNextTokenPrediction`` adding:
 The training loop is copied from the parent class but the loss becomes:
     loss = (1-kd_ratio) * ce_loss + kd_ratio * kd_loss
 
-Pipeline parallelism (PP) is supported: the teacher is built with the same PP configuration
-as the student. Teacher logits from the last PP stage are captured via a lightweight closure
-and injected into the student's pipeline loss function before each student step.
-
-    NOTE: When pp_microbatch_size < pp_batch_size (multiple microbatches per step),
-    only the last teacher microbatch's logits are retained. This is a known limitation;
-    set pp_microbatch_size == pp_batch_size when using PP with KD.
+Pipeline parallelism (PP) is supported. Teacher logits from every last-stage microbatch
+are captured via a lightweight closure and injected into the corresponding student
+pipeline microbatch.
 
 The file exposes ``KnowledgeDistillationRecipeForNextTokenPrediction`` and a
 ``main`` entry-point so it can be launched exactly the same way as other recipes:
@@ -48,7 +44,9 @@ from contextlib import nullcontext
 from typing import Any, Dict, Optional
 
 import torch
+import torch.distributed as dist
 import wandb
+from torch.distributed.tensor import DTensor, Shard
 from torchao.float8 import precompute_float8_dynamic_scale_for_fsdp
 
 from nemo_automodel._transformers.auto_tokenizer import NeMoAutoTokenizer
@@ -70,6 +68,13 @@ from nemo_automodel.components.training.utils import (
     scale_grads_and_clip_grad_norm,
 )
 from nemo_automodel.components.utils.model_utils import filter_forward_kwargs
+from nemo_automodel.recipes.kd_utils import (
+    RUN_TEACHER,
+    STOP_TEACHER,
+    KDMeshBridge,
+    create_kd_distributed_setups,
+    materialize_teacher_logits,
+)
 from nemo_automodel.recipes.llm.train_ft import (
     TrainFinetuneRecipeForNextTokenPrediction,
     _get_num_thd_chunks,
@@ -79,6 +84,31 @@ from nemo_automodel.recipes.llm.train_ft import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _move_to_device(value: Any, device: torch.device) -> Any:
+    if isinstance(value, torch.Tensor):
+        return value.to(device, non_blocking=True)
+    if isinstance(value, dict):
+        return {key: _move_to_device(item, device) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_move_to_device(item, device) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_move_to_device(item, device) for item in value)
+    return value
+
+
+def _match_student_vocab_shard(student_logits: torch.Tensor, teacher_logits: torch.Tensor) -> torch.Tensor:
+    """Slice full teacher logits to the student's vocab shard when TP is active."""
+    if not isinstance(student_logits, DTensor):
+        return teacher_logits
+    vocab_dim = student_logits.ndim - 1
+    for mesh_dim, placement in enumerate(student_logits.placements):
+        if isinstance(placement, Shard) and placement.dim in {-1, vocab_dim}:
+            group = student_logits.device_mesh.get_group(mesh_dim)
+            chunks = torch.tensor_split(teacher_logits, dist.get_world_size(group), dim=-1)
+            return chunks[dist.get_rank(group)].contiguous()
+    return teacher_logits
 
 
 def _build_kd_loss_fn(cfg_kd):
@@ -146,21 +176,19 @@ def _build_teacher_model_with_pp(
     distributed_setup: DistributedSetup,
     activation_checkpointing: bool,
 ) -> Any:
-    """Build teacher model with same parallelization as student (TP/EP/SP/PP).
+    """Build a frozen teacher model with the supplied distributed setup.
 
     Teacher is built via build_model with pipeline_config so it becomes an AutoPipeline
     when PP is enabled. No PEFT/FP8/QAT. Teacher is frozen and set to eval mode.
 
-    Logit capture: a closure stores logits on the last PP stage each time the pipeline
-    loss function is called. With multiple microbatches, only the last microbatch's logits
-    are retained; set pp_microbatch_size == pp_batch_size to avoid stale KD targets.
+    Logit capture stores every last-stage microbatch in schedule order.
 
     Args:
         cfg_teacher: Configuration for teacher model instantiation.
         seed: Random seed for reproducibility.
         has_packed_sequence: Whether using packed sequences.
-        pipeline_config: PipelineConfig from the student, used as a template.
-        distributed_setup: Student distributed setup, used as a template.
+        pipeline_config: Pipeline configuration for the teacher.
+        distributed_setup: Distributed setup for the teacher.
         activation_checkpointing: Whether to enable activation checkpointing.
 
     Returns:
@@ -169,12 +197,13 @@ def _build_teacher_model_with_pp(
     assert cfg_teacher is not None, "`teacher_model` section missing from YAML config"
     logger.info("Instantiating teacher model (parallelized with TP/EP/SP/PP)")
 
-    # Mutable list so the closure can overwrite it. Overwritten once per microbatch;
-    # only the last microbatch's logits survive when num_microbatches > 1.
+    # Mutable outer list so the closure and recipe can exchange a per-step list.
     teacher_logits_capture = [None]
 
     def _teacher_capture_loss_fn(logits, target, **kwargs):
-        teacher_logits_capture[0] = logits.detach().clone()
+        if teacher_logits_capture[0] is None:
+            teacher_logits_capture[0] = []
+        teacher_logits_capture[0].append(logits.detach().clone())
         return logits.new_tensor(0.0, dtype=logits.dtype)
 
     # Mirror the student pipeline config but swap in the capture loss_fn.
@@ -246,6 +275,44 @@ def _verify_tokenizer_compatibility(student_cfg, teacher_cfg, trust_remote_code=
 class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNextTokenPrediction):
     """Fine-tune a student model via knowledge distillation."""
 
+    def _create_distributed_setup(self) -> DistributedSetup:
+        self.kd_distributed_setups = create_kd_distributed_setups(self.cfg, world_size=self.dist_env.world_size)
+        self.separate_meshes = self.kd_distributed_setups.separate
+        if not self.separate_meshes:
+            self.kd_mesh_bridge = None
+            return self.kd_distributed_setups.student
+
+        self.kd_mesh_bridge = KDMeshBridge(self.kd_distributed_setups, device=self.dist_env.device)
+        self._training_process_group = self.kd_mesh_bridge.student_group
+        if self.kd_mesh_bridge.is_student:
+            setup = self.kd_distributed_setups.student
+            setup.mesh_context.process_group = self.kd_mesh_bridge.student_group
+        else:
+            setup = self.kd_distributed_setups.teacher
+            setup.mesh_context.process_group = self.kd_mesh_bridge.teacher_group
+        return setup
+
+    def _should_setup_training_components(self) -> bool:
+        return not getattr(self, "separate_meshes", False) or self.kd_mesh_bridge.is_student
+
+    def _setup_kd_state(self) -> None:
+        self.kd_loss_fn = _build_kd_loss_fn(self.cfg.get("kd_loss_fn", None))
+        self.kd_ratio = float(self.cfg.get("kd_ratio", 0.5))
+        self._kd_loss_buffer = []
+        self._ce_loss_buffer = []
+
+    def _configure_teacher_pipeline(self) -> None:
+        if not self.pp_enabled:
+            return
+        pp_batch_size = self.cfg.get("step_scheduler.local_batch_size", 1)
+        pp_microbatch_size = self.cfg.get("teacher_distributed.pipeline.pp_microbatch_size", 1)
+        if pp_batch_size % pp_microbatch_size != 0:
+            raise ValueError(
+                "Separate-mesh PP KD requires local_batch_size to be divisible by teacher pp_microbatch_size"
+            )
+        self.pipeline_config.pp_batch_size = pp_batch_size
+        self.pipeline_config.pp_microbatch_size = pp_microbatch_size
+
     def setup(self):  # noqa: C901 – same complexity as parent
         """Build student & teacher, dataloaders, optimizers, etc."""
         # Right now, we only support tokenizer compatibility for the same tokenizer.
@@ -256,6 +323,41 @@ class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNe
         super().setup()
 
         self._offload_teacher_model = self.cfg.get("offload_teacher_model", False)
+        if getattr(self, "separate_meshes", False):
+            if self._offload_teacher_model:
+                raise ValueError("offload_teacher_model is not supported with separate_meshes=true")
+            self._setup_kd_state()
+            if self.kd_mesh_bridge.is_teacher:
+                self._configure_teacher_pipeline()
+                if self.pp_enabled:
+                    self.teacher_model = _build_teacher_model_with_pp(
+                        cfg_teacher=self.cfg.get("teacher_model", None),
+                        seed=self.cfg.get("seed", 42),
+                        has_packed_sequence=self.cfg.get("packed_sequence.packed_sequence_size", 0) > 0,
+                        pipeline_config=self.pipeline_config,
+                        distributed_setup=self.distributed_setup,
+                        activation_checkpointing=self.activation_checkpointing,
+                    )
+                    self.teacher_pp = self.teacher_model
+                else:
+                    self.teacher_model = _build_teacher_model(
+                        cfg_teacher=self.cfg.get("teacher_model", None),
+                        seed=self.cfg.get("seed", 42),
+                        has_packed_sequence=self.cfg.get("packed_sequence.packed_sequence_size", 0) > 0,
+                        distributed_setup=self.distributed_setup,
+                        device=self.dist_env.device,
+                    )
+                    self.teacher_pp = None
+            else:
+                self.teacher_model = None
+                self.teacher_pp = None
+                if self.pp_enabled:
+                    schedule = self.pp.info.schedule
+                    self._original_pp_loss_fn = getattr(schedule, "_loss_fn", None)
+                    schedule._loss_fn = self._make_pp_kd_loss_wrapper()
+            self.kd_mesh_bridge.synchronize()
+            return
+
         teacher_device = self.dist_env.device if not self._offload_teacher_model else "cpu"
 
         if self.pp_enabled:
@@ -274,12 +376,6 @@ class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNe
                 activation_checkpointing=self.activation_checkpointing,
             )
             self.teacher_pp = self.teacher_model
-            if self.pipeline_config.pp_microbatch_size != self.pipeline_config.pp_batch_size:
-                raise ValueError(
-                    "PP with KD requires pp_microbatch_size == pp_batch_size. "
-                    "With multiple microbatches, only the last teacher microbatch's "
-                    "logits are captured, producing incorrect KD targets for earlier microbatches."
-                )
         else:
             self.teacher_model = _build_teacher_model(
                 cfg_teacher=self.cfg.get("teacher_model", None),
@@ -293,15 +389,10 @@ class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNe
         logger.info("Teacher Model: " + str(self.teacher_model))
 
         # KD
-        self.kd_loss_fn = _build_kd_loss_fn(self.cfg.get("kd_loss_fn", None))
-        self.kd_ratio: float = float(self.cfg.get("kd_ratio", 0.5))
+        self._setup_kd_state()
         logger.info("KD Loss config: " + str(self.cfg.get("kd_loss_fn", None)))
         temperature = getattr(self.kd_loss_fn, "temperature", "N/A")
         logger.info(f"Knowledge-distillation enabled: ratio={self.kd_ratio}, T={temperature}")
-
-        # Buffers for per-step logging.
-        self._kd_loss_buffer = []
-        self._ce_loss_buffer = []
 
         if self.pp_enabled:
             schedule = self.pp.info.schedule
@@ -324,6 +415,12 @@ class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNe
                     "KD loss wrapper: _current_teacher_logits not set. "
                     "Teacher pipeline eval must run before student step."
                 )
+            if isinstance(teacher_logits, list):
+                if not teacher_logits:
+                    raise RuntimeError("KD loss wrapper received more student than teacher microbatches")
+                teacher_logits = teacher_logits.pop(0)
+            if getattr(recipe_ref, "separate_meshes", False):
+                teacher_logits = _match_student_vocab_shard(logits, teacher_logits)
             # num_label_tokens is None because
             # _run_train_optim_step_pp applies scale_grads_and_clip_grad_norm
             # (which divides grads by num_label_tokens/dp_group_size) and
@@ -349,6 +446,87 @@ class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNe
 
         return pp_kd_loss_fn
 
+    def _get_separate_teacher_logits(self, batch: dict[str, Any]) -> torch.Tensor:
+        self.kd_mesh_bridge.broadcast_command(RUN_TEACHER)
+        teacher_logits = None
+        for wave in range(self.kd_mesh_bridge.num_waves):
+            self.kd_mesh_bridge.send_batch(wave, batch)
+            received = self.kd_mesh_bridge.send_logits(wave, None)
+            if received is not None:
+                teacher_logits = received
+        if teacher_logits is None:
+            raise RuntimeError("Student rank did not receive teacher logits from the separate KD mesh")
+        return teacher_logits
+
+    @torch.no_grad()
+    def _teacher_forward_separate(self, batch: dict[str, Any]) -> torch.Tensor | None:
+        batch = _move_to_device(batch, self.dist_env.device)
+        sequence_length = batch["labels"].shape[1]
+        train_ctx, batch = make_cp_batch_and_ctx(
+            self.device_mesh,
+            batch,
+            use_te=False,
+        )
+        labels = batch.pop("labels")
+        with train_ctx(), torch.no_grad():
+            if self.pp_enabled:
+                input_ids = batch.pop("input_ids")
+                batch_filtered = {
+                    key: value
+                    for key, value in batch.items()
+                    if value is not None and not (isinstance(value, dict) and not value)
+                }
+                targets = labels.clone() if self.teacher_pp.info.has_last_stage else None
+                losses = [] if self.teacher_pp.info.has_last_stage else None
+                if self.teacher_pp.info.has_first_stage:
+                    self.teacher_pp.info.schedule.eval(
+                        input_ids,
+                        target=targets,
+                        losses=losses,
+                        **batch_filtered,
+                    )
+                else:
+                    self.teacher_pp.info.schedule.eval(target=targets, losses=losses, **batch_filtered)
+                capture = getattr(self.teacher_model, "_teacher_logits_capture", None)
+                captured_logits = capture[0] if capture is not None else None
+                if capture is not None:
+                    capture[0] = None
+                logits = None
+                if captured_logits:
+                    logits = torch.cat(
+                        [
+                            materialize_teacher_logits(
+                                microbatch_logits,
+                                device_mesh=self.device_mesh,
+                                sequence_length=sequence_length,
+                            )
+                            for microbatch_logits in captured_logits
+                        ],
+                        dim=0,
+                    )
+            else:
+                teacher_batch = filter_forward_kwargs(self.teacher_model, batch)
+                output = self.teacher_model(**teacher_batch)
+                logits = getattr(output, "logits", output).detach()
+        if logits is None:
+            return None
+        if self.pp_enabled:
+            return logits
+        return materialize_teacher_logits(
+            logits,
+            device_mesh=self.device_mesh,
+            sequence_length=sequence_length,
+        )
+
+    def _run_teacher_worker(self) -> None:
+        while self.kd_mesh_bridge.broadcast_command() == RUN_TEACHER:
+            for wave in range(self.kd_mesh_bridge.num_waves):
+                batch = self.kd_mesh_bridge.send_batch(wave, None)
+                if batch is None:
+                    raise RuntimeError("Teacher rank did not receive a batch from the student mesh")
+                logits = self._teacher_forward_separate(batch)
+                self.kd_mesh_bridge.send_logits(wave, logits)
+
     def _forward_backward_step(
         self,
         idx,
@@ -363,9 +541,23 @@ class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNe
             raise RuntimeError(
                 "_forward_backward_step should not be called when pp_enabled; use _forward_backward_step_pp instead."
             )
+        separate_teacher_logits = (
+            self._get_separate_teacher_logits(batch) if getattr(self, "separate_meshes", False) else None
+        )
         batch = {k: v.to(self.dist_env.device, non_blocking=True) for k, v in batch.items()}
+        if separate_teacher_logits is not None:
+            batch["teacher_logits"] = separate_teacher_logits
         labels = batch.pop("labels")
-        train_ctx, batch = make_cp_batch_and_ctx(self.device_mesh, batch, labels)
+        if separate_teacher_logits is not None:
+            train_ctx, batch = make_cp_batch_and_ctx(
+                self.device_mesh,
+                batch,
+                labels,
+                extra_seq_buffers={"teacher_logits": 1},
+            )
+        else:
+            train_ctx, batch = make_cp_batch_and_ctx(self.device_mesh, batch, labels)
+        separate_teacher_logits = batch.pop("teacher_logits", None)
 
         model = self.model_parts[0]
         sync_ctx = (
@@ -379,13 +571,16 @@ class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNe
         )
         with train_ctx(), sync_ctx:
             # No grad for teacher forward.
-            with (
-                ScopedModuleOffloading(self.teacher_model, enabled=self._offload_teacher_model),
-                torch.no_grad(),
-            ):
-                teacher_batch = filter_forward_kwargs(self.teacher_model, batch)
-                teacher_logits = self.teacher_model(**teacher_batch)
-                teacher_logits = getattr(teacher_logits, "logits", teacher_logits).detach().clone()
+            if separate_teacher_logits is None:
+                with (
+                    ScopedModuleOffloading(self.teacher_model, enabled=self._offload_teacher_model),
+                    torch.no_grad(),
+                ):
+                    teacher_batch = filter_forward_kwargs(self.teacher_model, batch)
+                    teacher_logits = self.teacher_model(**teacher_batch)
+                    teacher_logits = getattr(teacher_logits, "logits", teacher_logits).detach().clone()
+            else:
+                teacher_logits = separate_teacher_logits
 
             # Student forward.
             student_batch = filter_forward_kwargs(model, batch)
@@ -396,6 +591,8 @@ class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNe
                 student_out = model(**student_batch)
 
             student_logits = getattr(student_out, "logits", student_out)  # shape (B, S, V)
+            if separate_teacher_logits is not None:
+                teacher_logits = _match_student_vocab_shard(student_logits, teacher_logits)
 
             # Cross-entropy loss against true labels (skip when kd_ratio >= 1.0).
             if self.kd_ratio >= 1.0:
@@ -440,6 +637,9 @@ class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNe
         Teacher logits from the last PP stage are stored in ``self._current_teacher_logits``
         before the student schedule runs, so ``pp_kd_loss_fn`` can read them.
         """
+        separate_teacher_logits = (
+            self._get_separate_teacher_logits(batch) if getattr(self, "separate_meshes", False) else None
+        )
         batch = {
             k: (
                 {dk: dv.to(self.dist_env.device, non_blocking=True) for dk, dv in v.items() if dv is not None}
@@ -448,13 +648,17 @@ class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNe
             )
             for k, v in batch.items()
         }
-        train_ctx, batch = make_cp_batch_and_ctx(
-            self.device_mesh,
-            batch,
-            use_te=_uses_te_dot_product_attention(self.cfg.model) and _uses_thd_collater(self.cfg.dataloader),
-            padding_token_id=self.tokenizer.pad_token_id if self.tokenizer else 0,
-            num_chunks=_get_num_thd_chunks(True, self.cfg),
-        )
+        if separate_teacher_logits is not None:
+            batch["teacher_logits"] = separate_teacher_logits
+        cp_kwargs = {
+            "use_te": _uses_te_dot_product_attention(self.cfg.model) and _uses_thd_collater(self.cfg.dataloader),
+            "padding_token_id": self.tokenizer.pad_token_id if self.tokenizer else 0,
+            "num_chunks": _get_num_thd_chunks(True, self.cfg),
+        }
+        if separate_teacher_logits is not None:
+            cp_kwargs["extra_seq_buffers"] = {"teacher_logits": 1}
+        train_ctx, batch = make_cp_batch_and_ctx(self.device_mesh, batch, **cp_kwargs)
+        separate_teacher_logits = batch.pop("teacher_logits", None)
         labels = batch.pop("labels")
         input_ids = batch.pop("input_ids")
         batch_filtered = {k: v for k, v in batch.items() if v is not None and not (isinstance(v, dict) and len(v) == 0)}
@@ -465,23 +669,28 @@ class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNe
         fp8_ctx = self.te_fp8.maybe_te_autocast() if self.te_fp8 is not None else nullcontext()
 
         with train_ctx(), fp8_ctx:
-            # Run teacher under inference_mode; logits captured by _teacher_capture_loss_fn.
-            with torch.inference_mode():
-                teacher_losses = [] if self.teacher_pp.info.has_last_stage else None
-                if self.teacher_pp.info.has_first_stage:
-                    self.teacher_pp.info.schedule.eval(
-                        input_ids, target=targets, losses=teacher_losses, **batch_filtered
-                    )
-                else:
-                    self.teacher_pp.info.schedule.eval(target=targets, losses=teacher_losses, **batch_filtered)
-                # Transfer captured logits into the recipe so pp_kd_loss_fn can read them.
-                capture = getattr(self.teacher_model, "_teacher_logits_capture", None)
-                if capture is not None and capture[0] is not None:
-                    self._current_teacher_logits = capture[0]
-                    capture[0] = None  # Reset for next call.
-                else:
-                    self._current_teacher_logits = None
-                self._current_num_label_tokens = num_label_tokens
+            if separate_teacher_logits is not None:
+                self._current_teacher_logits = list(
+                    torch.split(separate_teacher_logits, self.pipeline_config.pp_microbatch_size, dim=0)
+                )
+            else:
+                # Run teacher under inference_mode; logits captured by _teacher_capture_loss_fn.
+                with torch.inference_mode():
+                    teacher_losses = [] if self.teacher_pp.info.has_last_stage else None
+                    if self.teacher_pp.info.has_first_stage:
+                        self.teacher_pp.info.schedule.eval(
+                            input_ids, target=targets, losses=teacher_losses, **batch_filtered
+                        )
+                    else:
+                        self.teacher_pp.info.schedule.eval(target=targets, losses=teacher_losses, **batch_filtered)
+                    # Transfer captured logits into the recipe so pp_kd_loss_fn can read them.
+                    capture = getattr(self.teacher_model, "_teacher_logits_capture", None)
+                    if capture is not None and capture[0] is not None:
+                        self._current_teacher_logits = capture[0]
+                        capture[0] = None  # Reset for next call.
+                    else:
+                        self._current_teacher_logits = None
+            self._current_num_label_tokens = num_label_tokens
 
             # Run student forward (+ backward if training).
             student_losses = [] if self.pp.info.has_last_stage else None
@@ -738,6 +947,18 @@ class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNe
         )
 
     def run_train_validation_loop(self):
+        """Run the student loop or serve teacher forwards on a separate mesh."""
+        if getattr(self, "separate_meshes", False) and self.kd_mesh_bridge.is_teacher:
+            self._run_teacher_worker()
+            return
+        if getattr(self, "separate_meshes", False):
+            try:
+                return self._run_student_train_validation_loop()
+            finally:
+                self.kd_mesh_bridge.broadcast_command(STOP_TEACHER)
+        return self._run_student_train_validation_loop()
+
+    def _run_student_train_validation_loop(self):
         """Run training loop; skip validation when PP is enabled (not yet supported)."""
         if not self.pp_enabled:
             return super().run_train_validation_loop()

--- a/nemo_automodel/recipes/llm/kd.py
+++ b/nemo_automodel/recipes/llm/kd.py
@@ -179,12 +179,13 @@ def _build_teacher_model_with_pp(
         """Capture one teacher PP microbatch.
 
         Args:
-            logits: Last-stage teacher logits ``[B_m, S, V]``, where ``B_m``
-                is pipeline microbatch, ``S`` is sequence, and ``V`` is vocab.
-            target: Labels ``[B_m, S]`` supplied by the schedule and unused here.
+            logits: Tensor of shape ``[microbatch, sequence, vocab]`` containing
+                last-stage teacher logits.
+            target: Tensor of shape ``[microbatch, sequence]`` containing labels
+                supplied by the schedule and unused here.
             **kwargs: Schedule-owned scalar or tensor metadata ignored by the
-                capture path. Tensor metadata, when present, follows the same
-                microbatch axis as ``logits``.
+                capture path. Tensor values may have arbitrary rank and axis
+                order and are not inspected.
 
         Returns:
             Scalar zero tensor on the same dtype and device as ``logits``.
@@ -403,12 +404,15 @@ class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNe
             """Combine CE and KD for one student PP microbatch.
 
             Args:
-                logits: Student logits ``[B_m, S, V]`` or local TP shard
-                    ``[B_m, S, V_local]``.
-                target: Labels ``[B_m, S]`` with ``-100`` ignored.
+                logits: Tensor of global shape
+                    ``[microbatch, sequence, vocab]`` containing student logits.
+                    Under TP, the local tensor has shape
+                    ``[microbatch, sequence, local_vocab]`` with ``Shard(-1)``.
+                target: Tensor of shape ``[microbatch, sequence]`` containing
+                    labels with ``-100`` ignored.
                 **kwargs: Pipeline schedule scalar or tensor metadata. Tensor
-                    metadata, when present, follows the same microbatch axis as
-                    ``logits``.
+                    values may have arbitrary rank and axis order and are not
+                    inspected.
 
             Returns:
                 Scalar mixed CE/KD loss for the microbatch.
@@ -453,9 +457,14 @@ class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNe
     def _get_separate_teacher_logits(self, batch: dict[str, Any]) -> torch.Tensor:
         """Request teacher logits for one student batch.
 
-        ``batch`` contains sequence tensors such as ``input_ids`` and ``labels``
-        with shape ``[B, S]`` plus optional nested tensor metadata. Returns full
-        teacher logits ``[B, S, V]`` replicated across the student replica.
+        Args:
+            batch: Mapping containing ``input_ids`` and ``labels`` as tensors of
+                shape ``[batch, sequence]``. Other tensor leaves may have
+                arbitrary rank and axis order and are transported unchanged.
+
+        Returns:
+            Replicated tensor of shape ``[batch, sequence, vocab]`` containing
+            full teacher logits.
         """
         self.kd_mesh_bridge.broadcast_command(RUN_TEACHER)
         teacher_logits = None
@@ -473,13 +482,14 @@ class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNe
         """Run one teacher batch and materialize transport-ready logits.
 
         Args:
-            batch: Nested batch with ``input_ids`` and ``labels`` shaped
-                ``[B, S]`` plus optional model inputs. Tensors may initially
-                reside on CPU.
+            batch: Mapping containing ``input_ids`` and ``labels`` as tensors of
+                shape ``[batch, sequence]``. Other tensor leaves may have
+                arbitrary rank and axis order. Tensors may initially reside on
+                CPU.
 
         Returns:
-            Full detached teacher logits ``[B, S, V]`` on the teacher output
-            rank, otherwise ``None`` for PP ranks without the final stage.
+            Detached tensor of shape ``[batch, sequence, vocab]`` on the teacher
+            output rank, otherwise ``None`` for PP ranks without the final stage.
         """
         batch = self.kd_mesh_bridge.move_to_device(batch)
         sequence_length = batch["labels"].shape[1]
@@ -561,9 +571,17 @@ class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNe
     ):
         """Run one non-PP student microbatch with KD.
 
-        ``batch`` contains ``input_ids`` and ``labels`` shaped ``[B, S]`` plus
-        optional model tensors. Teacher and student logits have semantic shape
-        ``[B, S, V]`` and may use local TP/CP layouts inside the step.
+        Args:
+            idx: Zero-based accumulation microbatch index.
+            batch: Mapping containing ``input_ids`` and ``labels`` as tensors of
+                shape ``[batch, sequence]``. Other tensor leaves may have
+                arbitrary rank and axis order.
+            num_label_tokens: Valid-label count across the optimizer step.
+            num_batches: Number of accumulation microbatches in the step.
+            is_train: Whether to run backward.
+
+        Returns:
+            Tuple of scalar tensors containing detached mixed, KL, and CE loss.
         """
         if self.pp_enabled:
             raise RuntimeError(
@@ -665,9 +683,18 @@ class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNe
         Teacher logits from the last PP stage are stored in ``self._current_teacher_logits``
         before the student schedule runs, so ``pp_kd_loss_fn`` can read them.
 
-        ``batch`` contains ``input_ids`` and ``labels`` shaped ``[B, S]`` plus
-        optional model tensors. Transported teacher logits have shape
-        ``[B, S, V]`` and are split into ``[B_m, S, V]`` PP microbatches.
+        Args:
+            idx: Zero-based accumulation microbatch index.
+            batch: Mapping containing ``input_ids`` and ``labels`` as tensors of
+                shape ``[batch, sequence]``. Other tensor leaves may have
+                arbitrary rank and axis order.
+            loss_buffer: Output list receiving one detached scalar tensor.
+            num_label_tokens: Valid-label count across the optimizer step.
+            num_batches: Number of accumulation microbatches in the step.
+            is_train: Whether the pipeline schedule runs backward.
+
+        Transported teacher logits have shape ``[batch, sequence, vocab]`` and
+        are split into ``[microbatch, sequence, vocab]`` pipeline tensors.
         """
         separate_teacher_logits = (
             self._get_separate_teacher_logits(batch) if getattr(self, "separate_meshes", False) else None

--- a/nemo_automodel/recipes/llm/kd.py
+++ b/nemo_automodel/recipes/llm/kd.py
@@ -273,6 +273,10 @@ class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNe
 
         self.kd_mesh_bridge = KDMeshBridge(self.kd_distributed_setups, device=self.dist_env.device)
         self._training_process_group = self.kd_mesh_bridge.student_group
+        self._checkpoint_async_process_groups = self.cfg.checkpoint.initialize_async_process_groups(
+            self.kd_distributed_setups.student_ranks,
+            is_member=self.kd_mesh_bridge.is_student,
+        )
         if self.kd_mesh_bridge.is_student:
             setup = self.kd_distributed_setups.student
             setup.mesh_context.process_group = self.kd_mesh_bridge.student_group

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -445,6 +445,14 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
         self.cfg = cfg if isinstance(cfg, RecipeConfig) else RecipeConfig(cfg)
 
     # ------------------ build phase ------------------
+    def _create_distributed_setup(self) -> DistributedSetup:
+        """Create the distributed setup used by this recipe rank."""
+        return create_distributed_setup_from_config(self.cfg, world_size=self.dist_env.world_size)
+
+    def _should_setup_training_components(self) -> bool:
+        """Whether this rank owns the trainable model and its components."""
+        return True
+
     def setup(self):
         """Builds all components needed for training/validation/logging/checkpointing/etc.
 
@@ -478,9 +486,10 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
             self.pipeline_config,
             self.moe_parallel_config,
             self.activation_checkpointing,
-        ) = self._distributed_setup_attributes(
-            create_distributed_setup_from_config(self.cfg, world_size=self.dist_env.world_size)
-        )
+        ) = self._distributed_setup_attributes(self._create_distributed_setup())
+
+        if not self._should_setup_training_components():
+            return
 
         # MagiAttention (FFA / context-parallel) backend, enabled via
         # model.attn_implementation="magi" (HF) or model.backend.attn="magi" (custom).
@@ -661,7 +670,10 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
         collate_wrapper = _build_pp_collate_wrapper(self.cfg.model, self.pp_enabled)
 
         def materialize_loader(config):
-            build_context = nullcontext() if config.dataset_builds_on_all_ranks else FirstRankPerNode()
+            process_group = getattr(self.mesh_context, "process_group", None)
+            build_context = (
+                nullcontext() if config.dataset_builds_on_all_ranks else FirstRankPerNode(group=process_group)
+            )
             with ScopedRNG(seed=config.seed, ranked=True):
                 return config.build(
                     tokenizer=self.tokenizer,
@@ -700,6 +712,7 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
             self.dataloader,
             self._get_dp_group_size(),
             self.cfg.get("step_scheduler.local_batch_size", 1),
+            process_group=getattr(self, "_training_process_group", None),
         )
         self._setup_garbage_collection(self.step_scheduler)
 

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -585,6 +585,8 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
             tp_rank=self._get_tp_rank(),
             pp_rank=self._get_pp_rank(),
             moe_mesh=self.moe_mesh,
+            process_group=getattr(self.mesh_context, "process_group", None),
+            async_process_groups=getattr(self, "_checkpoint_async_process_groups", None),
         )
 
         # Disable fused RoPE when context parallelism is enabled (cp > 1)
@@ -672,9 +674,7 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
         def materialize_loader(config):
             process_group = getattr(self.mesh_context, "process_group", None)
             build_context = (
-                nullcontext()
-                if config.dataset_builds_on_all_ranks
-                else FirstRankPerNode(group=process_group)
+                nullcontext() if config.dataset_builds_on_all_ranks else FirstRankPerNode(group=process_group)
             )
             with ScopedRNG(seed=config.seed, ranked=True):
                 return config.build(

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -586,7 +586,6 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
             pp_rank=self._get_pp_rank(),
             moe_mesh=self.moe_mesh,
             process_group=getattr(self.mesh_context, "process_group", None),
-            async_process_groups=getattr(self, "_checkpoint_async_process_groups", None),
         )
 
         # Disable fused RoPE when context parallelism is enabled (cp > 1)

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -672,7 +672,9 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
         def materialize_loader(config):
             process_group = getattr(self.mesh_context, "process_group", None)
             build_context = (
-                nullcontext() if config.dataset_builds_on_all_ranks else FirstRankPerNode(group=process_group)
+                nullcontext()
+                if config.dataset_builds_on_all_ranks
+                else FirstRankPerNode(group=process_group)
             )
             with ScopedRNG(seed=config.seed, ranked=True):
                 return config.build(

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -568,7 +568,8 @@ class FinetuneRecipeForVLM(BaseRecipe):
         )
         if dataloader_config.packing is not None:
             configure_packing(attn_implementation=packing_attn_implementation)
-        dataset_build_context = nullcontext() if getattr(self, "separate_meshes", False) else FirstRankPerNode()
+        process_group = getattr(self.mesh_context, "process_group", None)
+        dataset_build_context = FirstRankPerNode(group=process_group)
         with ScopedRNG(seed=self.cfg.get("seed", 42), ranked=True):
             dataloader_build = dataloader_config.build(
                 pretrained_model_name_or_path=_get_model_name(self.cfg.model),
@@ -587,7 +588,7 @@ class FinetuneRecipeForVLM(BaseRecipe):
         self.val_dataloader = None
         validation_config = self.cfg.vlm_validation_dataloader
         if validation_config is not None:
-            validation_build_context = nullcontext() if getattr(self, "separate_meshes", False) else FirstRankPerNode()
+            validation_build_context = FirstRankPerNode(group=process_group)
             with ScopedRNG(seed=self.cfg.get("seed", 42), ranked=True):
                 validation_build = validation_config.build(
                     pretrained_model_name_or_path=_get_model_name(self.cfg.model),

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -398,6 +398,14 @@ class FinetuneRecipeForVLM(BaseRecipe):
         self.cfg = cfg if isinstance(cfg, RecipeConfig) else RecipeConfig(cfg)
 
     # ------------------ build phase ------------------
+    def _create_distributed_setup(self) -> DistributedSetup:
+        """Create the distributed setup used by this recipe rank."""
+        return create_distributed_setup_from_config(self.cfg, world_size=self.dist_env.world_size)
+
+    def _should_setup_training_components(self) -> bool:
+        """Whether this rank owns the trainable model and its components."""
+        return True
+
     def setup(self):
         """Builds all components needed for training/validation/logging/checkpointing/etc.
 
@@ -428,9 +436,10 @@ class FinetuneRecipeForVLM(BaseRecipe):
             self.pipeline_config,
             self.moe_parallel_config,
             self.activation_checkpointing,
-        ) = self._distributed_setup_attributes(
-            create_distributed_setup_from_config(self.cfg, world_size=self.dist_env.world_size)
-        )
+        ) = self._distributed_setup_attributes(self._create_distributed_setup())
+
+        if not self._should_setup_training_components():
+            return
 
         # MagiAttention (FFA) backend for the language backbone; the vision tower
         # stays on SDPA. Enabled via model.attn_implementation="magi" (HF VLMs) or
@@ -559,13 +568,14 @@ class FinetuneRecipeForVLM(BaseRecipe):
         )
         if dataloader_config.packing is not None:
             configure_packing(attn_implementation=packing_attn_implementation)
+        dataset_build_context = nullcontext() if getattr(self, "separate_meshes", False) else FirstRankPerNode()
         with ScopedRNG(seed=self.cfg.get("seed", 42), ranked=True):
             dataloader_build = dataloader_config.build(
                 pretrained_model_name_or_path=_get_model_name(self.cfg.model),
                 dp_rank=self._get_dp_rank(),
                 dp_world_size=self._get_dp_group_size(),
                 batch_size=self.cfg.get("step_scheduler.local_batch_size", 1),
-                dataset_build_context=FirstRankPerNode(),
+                dataset_build_context=dataset_build_context,
                 get_rope_index=get_rope_index,
                 packing_attn_implementation=packing_attn_implementation,
                 pp_n_microbatches=pp_n_microbatches,
@@ -577,13 +587,14 @@ class FinetuneRecipeForVLM(BaseRecipe):
         self.val_dataloader = None
         validation_config = self.cfg.vlm_validation_dataloader
         if validation_config is not None:
+            validation_build_context = nullcontext() if getattr(self, "separate_meshes", False) else FirstRankPerNode()
             with ScopedRNG(seed=self.cfg.get("seed", 42), ranked=True):
                 validation_build = validation_config.build(
                     pretrained_model_name_or_path=_get_model_name(self.cfg.model),
                     dp_rank=self._get_dp_rank(),
                     dp_world_size=self._get_dp_group_size(),
                     batch_size=self.cfg.get("step_scheduler.local_batch_size", 1),
-                    dataset_build_context=FirstRankPerNode(),
+                    dataset_build_context=validation_build_context,
                     get_rope_index=get_rope_index,
                 )
             self.val_dataloader = validation_build.dataloader
@@ -594,6 +605,7 @@ class FinetuneRecipeForVLM(BaseRecipe):
             self.dataloader,
             self._get_dp_group_size(),
             self.cfg.get("step_scheduler.local_batch_size", 1),
+            process_group=getattr(self, "_training_process_group", None),
         )
         self._setup_garbage_collection(self.step_scheduler)
 

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -505,6 +505,8 @@ class FinetuneRecipeForVLM(BaseRecipe):
             tp_rank=self._get_tp_rank(),
             pp_rank=self._get_pp_rank(),
             moe_mesh=self.moe_mesh,
+            process_group=getattr(self.mesh_context, "process_group", None),
+            async_process_groups=getattr(self, "_checkpoint_async_process_groups", None),
         )
 
         # Disable fused RoPE when context parallelism is enabled (cp > 1)

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -506,7 +506,6 @@ class FinetuneRecipeForVLM(BaseRecipe):
             pp_rank=self._get_pp_rank(),
             moe_mesh=self.moe_mesh,
             process_group=getattr(self.mesh_context, "process_group", None),
-            async_process_groups=getattr(self, "_checkpoint_async_process_groups", None),
         )
 
         # Disable fused RoPE when context parallelism is enabled (cp > 1)

--- a/nemo_automodel/recipes/vlm/kd.py
+++ b/nemo_automodel/recipes/vlm/kd.py
@@ -199,10 +199,6 @@ class KnowledgeDistillationRecipeForVLM(FinetuneRecipeForVLM):
             return self.kd_distributed_setups.student
         self.kd_mesh_bridge = KDMeshBridge(self.kd_distributed_setups, device=self.dist_env.device)
         self._training_process_group = self.kd_mesh_bridge.student_group
-        self._checkpoint_async_process_groups = self.cfg.checkpoint.initialize_async_process_groups(
-            self.kd_distributed_setups.student_ranks,
-            is_member=self.kd_mesh_bridge.is_student,
-        )
         if self.kd_mesh_bridge.is_student:
             setup = self.kd_distributed_setups.student
             setup.mesh_context.process_group = self.kd_mesh_bridge.student_group

--- a/nemo_automodel/recipes/vlm/kd.py
+++ b/nemo_automodel/recipes/vlm/kd.py
@@ -46,9 +46,7 @@ from contextlib import nullcontext
 from typing import Any, Optional
 
 import torch
-import torch.distributed as dist
 import wandb
-from torch.distributed.tensor import DTensor, Shard
 from torchao.float8 import precompute_float8_dynamic_scale_for_fsdp
 
 from nemo_automodel._transformers.auto_tokenizer import NeMoAutoTokenizer
@@ -60,6 +58,7 @@ from nemo_automodel.components.loggers.metric_logger import MetricsSample
 from nemo_automodel.components.loss.linear_ce import FusedLinearCrossEntropy
 from nemo_automodel.components.moe.megatron.moe_utils import MoEAuxLossAutoScaler
 from nemo_automodel.components.training.rng import ScopedRNG
+from nemo_automodel.components.training.signal_handler import DistributedSignalHandler
 from nemo_automodel.components.training.utils import (
     ScopedModuleOffloading,
     count_tail_padding,
@@ -79,30 +78,6 @@ from nemo_automodel.recipes.kd_utils import (
 from nemo_automodel.recipes.vlm.finetune import FinetuneRecipeForVLM, build_model, calculate_loss
 
 logger = logging.getLogger(__name__)
-
-
-def _move_to_device(value: Any, device: torch.device) -> Any:
-    if isinstance(value, torch.Tensor):
-        return value.to(device, non_blocking=True)
-    if isinstance(value, dict):
-        return {key: _move_to_device(item, device) for key, item in value.items()}
-    if isinstance(value, list):
-        return [_move_to_device(item, device) for item in value]
-    if isinstance(value, tuple):
-        return tuple(_move_to_device(item, device) for item in value)
-    return value
-
-
-def _match_student_vocab_shard(student_logits: torch.Tensor, teacher_logits: torch.Tensor) -> torch.Tensor:
-    if not isinstance(student_logits, DTensor):
-        return teacher_logits
-    vocab_dim = student_logits.ndim - 1
-    for mesh_dim, placement in enumerate(student_logits.placements):
-        if isinstance(placement, Shard) and placement.dim in {-1, vocab_dim}:
-            group = student_logits.device_mesh.get_group(mesh_dim)
-            chunks = torch.tensor_split(teacher_logits, dist.get_world_size(group), dim=-1)
-            return chunks[dist.get_rank(group)].contiguous()
-    return teacher_logits
 
 
 def _build_kd_loss_fn(cfg_kd):
@@ -286,6 +261,13 @@ class KnowledgeDistillationRecipeForVLM(FinetuneRecipeForVLM):
         logger.info(f"Knowledge-distillation enabled: ratio={self.kd_ratio}, T={temperature}")
 
     def _get_separate_teacher_logits(self, batch: dict[str, Any]) -> torch.Tensor:
+        """Request teacher logits for one student VLM batch.
+
+        Text tensors such as ``input_ids`` and ``labels`` use shape ``[B, S]``;
+        image/video tensors preserve the processor-defined leading dimensions.
+        Returns full teacher logits ``[B, S, V]`` replicated across the student
+        model replica.
+        """
         self.kd_mesh_bridge.broadcast_command(RUN_TEACHER)
         teacher_logits = None
         for wave in range(self.kd_mesh_bridge.num_waves):
@@ -299,7 +281,17 @@ class KnowledgeDistillationRecipeForVLM(FinetuneRecipeForVLM):
 
     @torch.no_grad()
     def _teacher_forward_separate(self, batch: dict[str, Any]) -> torch.Tensor:
-        batch = _move_to_device(batch, self.dist_env.device)
+        """Run one teacher VLM batch and materialize full logits.
+
+        Args:
+            batch: Nested multimodal batch. Text tensors use ``[B, S]``;
+                pixel tensors and grid metadata keep the processor-defined
+                layout consumed by ``VLM_INPUT_KEYS``.
+
+        Returns:
+            Detached full teacher logits ``[B, S, V]`` with CP padding removed.
+        """
+        batch = self.kd_mesh_bridge.move_to_device(batch)
         sequence_length = batch["labels"].shape[1]
         model = self.teacher_model
         cp_active = (
@@ -326,13 +318,15 @@ class KnowledgeDistillationRecipeForVLM(FinetuneRecipeForVLM):
         )
 
     def _run_teacher_worker(self) -> None:
-        while self.kd_mesh_bridge.broadcast_command() == RUN_TEACHER:
-            for wave in range(self.kd_mesh_bridge.num_waves):
-                batch = self.kd_mesh_bridge.send_batch(wave, None)
-                if batch is None:
-                    raise RuntimeError("Teacher rank did not receive a batch from the student mesh")
-                logits = self._teacher_forward_separate(batch)
-                self.kd_mesh_bridge.send_logits(wave, logits)
+        """Serve teacher forwards until the student mesh broadcasts stop."""
+        with DistributedSignalHandler(group=self.kd_mesh_bridge.teacher_group):
+            while self.kd_mesh_bridge.broadcast_command() == RUN_TEACHER:
+                for wave in range(self.kd_mesh_bridge.num_waves):
+                    batch = self.kd_mesh_bridge.send_batch(wave, None)
+                    if batch is None:
+                        raise RuntimeError("Teacher rank did not receive a batch from the student mesh")
+                    logits = self._teacher_forward_separate(batch)
+                    self.kd_mesh_bridge.send_logits(wave, logits)
 
     def _forward_backward_step(
         self,
@@ -344,7 +338,13 @@ class KnowledgeDistillationRecipeForVLM(FinetuneRecipeForVLM):
         num_batches,
         is_train: bool = True,
     ):
-        """Override the forward backward step to include knowledge distillation loss."""
+        """Run one student VLM microbatch with KD.
+
+        Text tensors in ``batch`` use shape ``[B, S]`` while multimodal tensors
+        preserve their processor-defined layouts. Teacher and student logits
+        have semantic shape ``[B, S, V]`` and may use local TP/CP layouts inside
+        the step.
+        """
         separate_teacher_logits = (
             self._get_separate_teacher_logits(batch) if getattr(self, "separate_meshes", False) else None
         )
@@ -422,7 +422,7 @@ class KnowledgeDistillationRecipeForVLM(FinetuneRecipeForVLM):
 
             student_logits = getattr(student_out, "logits", student_out)
             if separate_teacher_logits is not None:
-                teacher_logits = _match_student_vocab_shard(student_logits, teacher_logits)
+                teacher_logits = self.kd_mesh_bridge.match_student_vocab_shard(student_logits, teacher_logits)
             hidden_states = (
                 student_out.hidden_states[-1] if getattr(student_out, "hidden_states", None) is not None else None
             )

--- a/nemo_automodel/recipes/vlm/kd.py
+++ b/nemo_automodel/recipes/vlm/kd.py
@@ -43,10 +43,12 @@ import logging
 import pathlib
 import time
 from contextlib import nullcontext
-from typing import Optional
+from typing import Any, Optional
 
 import torch
+import torch.distributed as dist
 import wandb
+from torch.distributed.tensor import DTensor, Shard
 from torchao.float8 import precompute_float8_dynamic_scale_for_fsdp
 
 from nemo_automodel._transformers.auto_tokenizer import NeMoAutoTokenizer
@@ -67,9 +69,40 @@ from nemo_automodel.components.training.utils import (
     scale_grads_and_clip_grad_norm,
 )
 from nemo_automodel.components.utils.model_utils import VLM_INPUT_KEYS, filter_forward_kwargs
+from nemo_automodel.recipes.kd_utils import (
+    RUN_TEACHER,
+    STOP_TEACHER,
+    KDMeshBridge,
+    create_kd_distributed_setups,
+    materialize_teacher_logits,
+)
 from nemo_automodel.recipes.vlm.finetune import FinetuneRecipeForVLM, build_model, calculate_loss
 
 logger = logging.getLogger(__name__)
+
+
+def _move_to_device(value: Any, device: torch.device) -> Any:
+    if isinstance(value, torch.Tensor):
+        return value.to(device, non_blocking=True)
+    if isinstance(value, dict):
+        return {key: _move_to_device(item, device) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_move_to_device(item, device) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_move_to_device(item, device) for item in value)
+    return value
+
+
+def _match_student_vocab_shard(student_logits: torch.Tensor, teacher_logits: torch.Tensor) -> torch.Tensor:
+    if not isinstance(student_logits, DTensor):
+        return teacher_logits
+    vocab_dim = student_logits.ndim - 1
+    for mesh_dim, placement in enumerate(student_logits.placements):
+        if isinstance(placement, Shard) and placement.dim in {-1, vocab_dim}:
+            group = student_logits.device_mesh.get_group(mesh_dim)
+            chunks = torch.tensor_split(teacher_logits, dist.get_world_size(group), dim=-1)
+            return chunks[dist.get_rank(group)].contiguous()
+    return teacher_logits
 
 
 def _build_kd_loss_fn(cfg_kd):
@@ -183,6 +216,31 @@ def _validate_cp_pre_embed_teacher_compatibility(inputs_embeds: torch.Tensor, te
 class KnowledgeDistillationRecipeForVLM(FinetuneRecipeForVLM):
     """Fine-tune a student VLM via knowledge distillation from a teacher VLM."""
 
+    def _create_distributed_setup(self) -> DistributedSetup:
+        self.kd_distributed_setups = create_kd_distributed_setups(self.cfg, world_size=self.dist_env.world_size)
+        self.separate_meshes = self.kd_distributed_setups.separate
+        if not self.separate_meshes:
+            self.kd_mesh_bridge = None
+            return self.kd_distributed_setups.student
+        self.kd_mesh_bridge = KDMeshBridge(self.kd_distributed_setups, device=self.dist_env.device)
+        self._training_process_group = self.kd_mesh_bridge.student_group
+        if self.kd_mesh_bridge.is_student:
+            setup = self.kd_distributed_setups.student
+            setup.mesh_context.process_group = self.kd_mesh_bridge.student_group
+        else:
+            setup = self.kd_distributed_setups.teacher
+            setup.mesh_context.process_group = self.kd_mesh_bridge.teacher_group
+        return setup
+
+    def _should_setup_training_components(self) -> bool:
+        return not getattr(self, "separate_meshes", False) or self.kd_mesh_bridge.is_student
+
+    def _setup_kd_state(self) -> None:
+        self.kd_loss_fn = _build_kd_loss_fn(self.cfg.get("kd_loss_fn", None))
+        self.kd_ratio = float(self.cfg.get("kd_ratio", 0.5))
+        self._kd_loss_buffer = []
+        self._ce_loss_buffer = []
+
     def setup(self):
         """Build student & teacher, dataloaders, optimizers, etc."""
         _verify_tokenizer_compatibility(self.cfg.get("model", None), self.cfg.get("teacher_model", None))
@@ -193,6 +251,23 @@ class KnowledgeDistillationRecipeForVLM(FinetuneRecipeForVLM):
             raise NotImplementedError("Pipeline parallelism is not supported for VLM knowledge distillation yet.")
 
         self._offload_teacher_model = self.cfg.get("offload_teacher_model", False)
+        if getattr(self, "separate_meshes", False):
+            if self._offload_teacher_model:
+                raise ValueError("offload_teacher_model is not supported with separate_meshes=true")
+            self._setup_kd_state()
+            if self.kd_mesh_bridge.is_teacher:
+                self.teacher_model = _build_teacher_model(
+                    cfg_teacher=self.cfg.get("teacher_model", None),
+                    cfg_freeze=self.cfg.get("teacher_freeze_config", None),
+                    seed=self.cfg.get("seed", 42),
+                    distributed_setup=self.distributed_setup,
+                    device=self.dist_env.device,
+                )
+            else:
+                self.teacher_model = None
+            self.kd_mesh_bridge.synchronize()
+            return
+
         teacher_device = self.dist_env.device if not self._offload_teacher_model else "cpu"
 
         self.teacher_model = _build_teacher_model(
@@ -205,14 +280,59 @@ class KnowledgeDistillationRecipeForVLM(FinetuneRecipeForVLM):
 
         logger.info("Teacher Model: " + str(self.teacher_model))
 
-        self.kd_loss_fn = _build_kd_loss_fn(self.cfg.get("kd_loss_fn", None))
-        self.kd_ratio: float = float(self.cfg.get("kd_ratio", 0.5))
+        self._setup_kd_state()
         logger.info("KD Loss config: " + str(self.cfg.get("kd_loss_fn", None)))
         temperature = getattr(self.kd_loss_fn, "temperature", "N/A")
         logger.info(f"Knowledge-distillation enabled: ratio={self.kd_ratio}, T={temperature}")
 
-        self._kd_loss_buffer: list[torch.Tensor] = []
-        self._ce_loss_buffer: list[torch.Tensor] = []
+    def _get_separate_teacher_logits(self, batch: dict[str, Any]) -> torch.Tensor:
+        self.kd_mesh_bridge.broadcast_command(RUN_TEACHER)
+        teacher_logits = None
+        for wave in range(self.kd_mesh_bridge.num_waves):
+            self.kd_mesh_bridge.send_batch(wave, batch)
+            received = self.kd_mesh_bridge.send_logits(wave, None)
+            if received is not None:
+                teacher_logits = received
+        if teacher_logits is None:
+            raise RuntimeError("Student rank did not receive teacher logits from the separate KD mesh")
+        return teacher_logits
+
+    @torch.no_grad()
+    def _teacher_forward_separate(self, batch: dict[str, Any]) -> torch.Tensor:
+        batch = _move_to_device(batch, self.dist_env.device)
+        sequence_length = batch["labels"].shape[1]
+        model = self.teacher_model
+        cp_active = (
+            self.device_mesh is not None
+            and "cp" in getattr(self.device_mesh, "mesh_dim_names", ())
+            and self.device_mesh["cp"].size() > 1
+        )
+        if cp_active and hasattr(model, "prepare_model_inputs_for_cp"):
+            mm_kwargs = {key: batch[key] for key in VLM_INPUT_KEYS if batch.get(key) is not None}
+            prepared = model(_pre_embed_only=True, **mm_kwargs)
+            for key in VLM_INPUT_KEYS:
+                batch.pop(key, None)
+            batch.update(prepared)
+        train_ctx, batch = make_cp_batch_and_ctx(self.device_mesh, batch)
+        batch.pop("labels")
+        with train_ctx(), torch.no_grad():
+            teacher_batch = filter_forward_kwargs(model, batch)
+            output = model(**teacher_batch)
+            logits = getattr(output, "logits", output).detach()
+        return materialize_teacher_logits(
+            logits,
+            device_mesh=self.device_mesh,
+            sequence_length=sequence_length,
+        )
+
+    def _run_teacher_worker(self) -> None:
+        while self.kd_mesh_bridge.broadcast_command() == RUN_TEACHER:
+            for wave in range(self.kd_mesh_bridge.num_waves):
+                batch = self.kd_mesh_bridge.send_batch(wave, None)
+                if batch is None:
+                    raise RuntimeError("Teacher rank did not receive a batch from the student mesh")
+                logits = self._teacher_forward_separate(batch)
+                self.kd_mesh_bridge.send_logits(wave, logits)
 
     def _forward_backward_step(
         self,
@@ -225,6 +345,9 @@ class KnowledgeDistillationRecipeForVLM(FinetuneRecipeForVLM):
         is_train: bool = True,
     ):
         """Override the forward backward step to include knowledge distillation loss."""
+        separate_teacher_logits = (
+            self._get_separate_teacher_logits(batch) if getattr(self, "separate_meshes", False) else None
+        )
         batch = {
             k: (
                 {dk: dv.to(self.dist_env.device, non_blocking=True) if dv is not None else None for dk, dv in v.items()}
@@ -233,6 +356,8 @@ class KnowledgeDistillationRecipeForVLM(FinetuneRecipeForVLM):
             )
             for k, v in batch.items()
         }
+        if separate_teacher_logits is not None:
+            batch["teacher_logits"] = separate_teacher_logits
 
         _model = self.model_parts[0]
         _cp_active = (
@@ -245,13 +370,21 @@ class KnowledgeDistillationRecipeForVLM(FinetuneRecipeForVLM):
             mm_kwargs = {k: batch[k] for k in VLM_INPUT_KEYS if batch.get(k) is not None}
             with torch.no_grad():
                 prepared = _model(_pre_embed_only=True, **mm_kwargs)
-            if "inputs_embeds" in prepared:
+            if "inputs_embeds" in prepared and not getattr(self, "separate_meshes", False):
                 _validate_cp_pre_embed_teacher_compatibility(prepared["inputs_embeds"], self.teacher_model)
             for k in VLM_INPUT_KEYS:
                 batch.pop(k, None)
             batch.update(prepared)
 
-        train_ctx, batch = make_cp_batch_and_ctx(self.device_mesh, batch)
+        if separate_teacher_logits is not None:
+            train_ctx, batch = make_cp_batch_and_ctx(
+                self.device_mesh,
+                batch,
+                extra_seq_buffers={"teacher_logits": 1},
+            )
+        else:
+            train_ctx, batch = make_cp_batch_and_ctx(self.device_mesh, batch)
+        separate_teacher_logits = batch.pop("teacher_logits", None)
         labels = batch.pop("labels")
 
         model = self.model_parts[0]
@@ -266,14 +399,17 @@ class KnowledgeDistillationRecipeForVLM(FinetuneRecipeForVLM):
         )
         with sync_ctx, train_ctx():
             # Teacher forward (no grad) — free intermediates immediately.
-            with (
-                ScopedModuleOffloading(self.teacher_model, enabled=self._offload_teacher_model),
-                torch.no_grad(),
-            ):
-                teacher_batch = filter_forward_kwargs(self.teacher_model, batch)
-                teacher_out = self.teacher_model(**teacher_batch)
-                teacher_logits = getattr(teacher_out, "logits", teacher_out).detach().clone()
-                del teacher_out, teacher_batch
+            if separate_teacher_logits is None:
+                with (
+                    ScopedModuleOffloading(self.teacher_model, enabled=self._offload_teacher_model),
+                    torch.no_grad(),
+                ):
+                    teacher_batch = filter_forward_kwargs(self.teacher_model, batch)
+                    teacher_out = self.teacher_model(**teacher_batch)
+                    teacher_logits = getattr(teacher_out, "logits", teacher_out).detach().clone()
+                    del teacher_out, teacher_batch
+            else:
+                teacher_logits = separate_teacher_logits
 
             # Student forward.
             student_batch = filter_forward_kwargs(model, batch)
@@ -285,6 +421,8 @@ class KnowledgeDistillationRecipeForVLM(FinetuneRecipeForVLM):
             del student_batch
 
             student_logits = getattr(student_out, "logits", student_out)
+            if separate_teacher_logits is not None:
+                teacher_logits = _match_student_vocab_shard(student_logits, teacher_logits)
             hidden_states = (
                 student_out.hidden_states[-1] if getattr(student_out, "hidden_states", None) is not None else None
             )
@@ -423,6 +561,18 @@ class KnowledgeDistillationRecipeForVLM(FinetuneRecipeForVLM):
                 "temperature": getattr(self.kd_loss_fn, "temperature", float("nan")),
             },
         )
+
+    def run_train_validation_loop(self):
+        """Run the student loop or serve teacher forwards on a separate mesh."""
+        if getattr(self, "separate_meshes", False) and self.kd_mesh_bridge.is_teacher:
+            self._run_teacher_worker()
+            return
+        if getattr(self, "separate_meshes", False):
+            try:
+                return super().run_train_validation_loop()
+            finally:
+                self.kd_mesh_bridge.broadcast_command(STOP_TEACHER)
+        return super().run_train_validation_loop()
 
     @torch.no_grad()
     def _run_validation_epoch(self, val_dataloader):

--- a/nemo_automodel/recipes/vlm/kd.py
+++ b/nemo_automodel/recipes/vlm/kd.py
@@ -263,10 +263,14 @@ class KnowledgeDistillationRecipeForVLM(FinetuneRecipeForVLM):
     def _get_separate_teacher_logits(self, batch: dict[str, Any]) -> torch.Tensor:
         """Request teacher logits for one student VLM batch.
 
-        Text tensors such as ``input_ids`` and ``labels`` use shape ``[B, S]``;
-        image/video tensors preserve the processor-defined leading dimensions.
-        Returns full teacher logits ``[B, S, V]`` replicated across the student
-        model replica.
+        Args:
+            batch: Mapping containing ``input_ids`` and ``labels`` as tensors of
+                shape ``[batch, sequence]``. Multimodal tensor leaves may have
+                arbitrary rank and axis order and are transported unchanged.
+
+        Returns:
+            Replicated tensor of shape ``[batch, sequence, vocab]`` containing
+            full teacher logits.
         """
         self.kd_mesh_bridge.broadcast_command(RUN_TEACHER)
         teacher_logits = None
@@ -284,12 +288,14 @@ class KnowledgeDistillationRecipeForVLM(FinetuneRecipeForVLM):
         """Run one teacher VLM batch and materialize full logits.
 
         Args:
-            batch: Nested multimodal batch. Text tensors use ``[B, S]``;
-                pixel tensors and grid metadata keep the processor-defined
-                layout consumed by ``VLM_INPUT_KEYS``.
+            batch: Mapping containing ``input_ids`` and ``labels`` as tensors of
+                shape ``[batch, sequence]``. Multimodal tensor leaves may have
+                arbitrary rank and axis order; their model processor owns those
+                layouts.
 
         Returns:
-            Detached full teacher logits ``[B, S, V]`` with CP padding removed.
+            Detached tensor of shape ``[batch, sequence, vocab]`` containing
+            full teacher logits with CP padding removed.
         """
         batch = self.kd_mesh_bridge.move_to_device(batch)
         sequence_length = batch["labels"].shape[1]
@@ -340,10 +346,19 @@ class KnowledgeDistillationRecipeForVLM(FinetuneRecipeForVLM):
     ):
         """Run one student VLM microbatch with KD.
 
-        Text tensors in ``batch`` use shape ``[B, S]`` while multimodal tensors
-        preserve their processor-defined layouts. Teacher and student logits
-        have semantic shape ``[B, S, V]`` and may use local TP/CP layouts inside
-        the step.
+        Args:
+            idx: Zero-based accumulation microbatch index.
+            batch: Mapping containing text tensors of shape
+                ``[batch, sequence]``. Multimodal tensor leaves may have
+                arbitrary rank and axis order.
+            loss_buffer: Output list receiving one detached scalar tensor.
+            num_label_tokens: Valid-label count across the optimizer step.
+            num_batches: Number of accumulation microbatches in the step.
+            is_train: Whether to run backward.
+
+        Teacher and student logits have global shape
+        ``[batch, sequence, vocab]`` and may use local TP/CP layouts inside the
+        step.
         """
         separate_teacher_logits = (
             self._get_separate_teacher_logits(batch) if getattr(self, "separate_meshes", False) else None

--- a/nemo_automodel/recipes/vlm/kd.py
+++ b/nemo_automodel/recipes/vlm/kd.py
@@ -199,6 +199,10 @@ class KnowledgeDistillationRecipeForVLM(FinetuneRecipeForVLM):
             return self.kd_distributed_setups.student
         self.kd_mesh_bridge = KDMeshBridge(self.kd_distributed_setups, device=self.dist_env.device)
         self._training_process_group = self.kd_mesh_bridge.student_group
+        self._checkpoint_async_process_groups = self.cfg.checkpoint.initialize_async_process_groups(
+            self.kd_distributed_setups.student_ranks,
+            is_member=self.kd_mesh_bridge.is_student,
+        )
         if self.kd_mesh_bridge.is_student:
             setup = self.kd_distributed_setups.student
             setup.mesh_context.process_group = self.kd_mesh_bridge.student_group

--- a/tests/functional_tests/llm_pretrain_and_kd/compare_kd_sep_mesh_losses.py
+++ b/tests/functional_tests/llm_pretrain_and_kd/compare_kd_sep_mesh_losses.py
@@ -1,0 +1,175 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compare shared- and separate-mesh KD loss traces and publish the result."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+from pathlib import Path
+
+METRICS = ("loss", "ce_loss", "kd_loss")
+
+
+def _read_trace(path: Path) -> list[dict]:
+    rows = [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+    if not rows:
+        raise ValueError(f"No metrics found in {path}")
+    for row in rows:
+        for metric in (*METRICS, "grad_norm"):
+            if not math.isfinite(float(row[metric])):
+                raise ValueError(f"Non-finite {metric} in {path}: {row}")
+        expected = (1.0 - row["kd_ratio"]) * row["ce_loss"] + row["kd_ratio"] * row["kd_loss"]
+        if not math.isclose(row["loss"], expected, rel_tol=0.0, abs_tol=1.0e-5):
+            raise ValueError(f"Mixed loss identity failed in {path}: {row}")
+    return rows
+
+
+def _compare_pair(
+    label: str,
+    baseline: list[dict],
+    candidate: list[dict],
+    absolute_tolerance: float,
+    relative_tolerance: float,
+) -> list[dict]:
+    if len(baseline) != len(candidate):
+        raise ValueError(f"{label}: step count differs: {len(baseline)} != {len(candidate)}")
+    comparisons = []
+    for baseline_row, candidate_row in zip(baseline, candidate):
+        if baseline_row["step"] != candidate_row["step"]:
+            raise ValueError(f"{label}: step mismatch: {baseline_row['step']} != {candidate_row['step']}")
+        comparison = {"layout": label, "step": baseline_row["step"]}
+        failed = {}
+        for metric in METRICS:
+            baseline_value = float(baseline_row[metric])
+            candidate_value = float(candidate_row[metric])
+            absolute_difference = abs(candidate_value - baseline_value)
+            relative_difference = absolute_difference / max(abs(baseline_value), float.fromhex("0x1.0p-1022"))
+            comparison[f"{metric}_abs_diff"] = absolute_difference
+            comparison[f"{metric}_rel_diff"] = relative_difference
+            if not math.isclose(
+                candidate_value,
+                baseline_value,
+                rel_tol=relative_tolerance,
+                abs_tol=absolute_tolerance,
+            ):
+                failed[metric] = {
+                    "baseline": baseline_value,
+                    "candidate": candidate_value,
+                    "abs_diff": absolute_difference,
+                    "rel_diff": relative_difference,
+                }
+        comparisons.append(comparison)
+        if failed:
+            raise ValueError(
+                f"{label} step {baseline_row['step']} exceeds tolerances "
+                f"(atol={absolute_tolerance}, rtol={relative_tolerance}): {failed}"
+            )
+    return comparisons
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--shared-dense", type=Path, required=True)
+    parser.add_argument("--separate-tp", type=Path, required=True)
+    parser.add_argument("--separate-pp", type=Path, required=True)
+    parser.add_argument("--shared-moe", type=Path, required=True)
+    parser.add_argument("--separate-ep", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--absolute-tolerance", type=float, default=1.0e-2)
+    parser.add_argument("--relative-tolerance", type=float, default=1.0e-2)
+    parser.add_argument("--wandb", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    shared_dense = _read_trace(args.shared_dense)
+    shared_moe = _read_trace(args.shared_moe)
+    comparisons = [
+        *_compare_pair(
+            "teacher_tp2",
+            shared_dense,
+            _read_trace(args.separate_tp),
+            args.absolute_tolerance,
+            args.relative_tolerance,
+        ),
+        *_compare_pair(
+            "teacher_pp3",
+            shared_dense,
+            _read_trace(args.separate_pp),
+            args.absolute_tolerance,
+            args.relative_tolerance,
+        ),
+        *_compare_pair(
+            "teacher_ep8",
+            shared_moe,
+            _read_trace(args.separate_ep),
+            args.absolute_tolerance,
+            args.relative_tolerance,
+        ),
+    ]
+    summary = {
+        "pass": True,
+        "absolute_tolerance": args.absolute_tolerance,
+        "relative_tolerance": args.relative_tolerance,
+        "max_abs_diff": {metric: max(row[f"{metric}_abs_diff"] for row in comparisons) for metric in METRICS},
+        "max_rel_diff": {metric: max(row[f"{metric}_rel_diff"] for row in comparisons) for metric in METRICS},
+        "comparisons": comparisons,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n")
+
+    if args.wandb:
+        wandb_dir = args.output.parent / "wandb_summary"
+        wandb_dir.mkdir(parents=True, exist_ok=True)
+        os.environ.setdefault("WANDB_DATA_DIR", str(wandb_dir / "data"))
+        os.environ.setdefault("WANDB_DIR", str(wandb_dir))
+
+        import wandb
+
+        run = wandb.init(
+            entity="Nemo-automodel",
+            project="kd_sep_mesh",
+            name="loss_parity_summary",
+            job_type="validation",
+            tags=["kd", "loss-parity", "cw-dfw"],
+            dir=str(wandb_dir),
+            config={
+                "absolute_tolerance": args.absolute_tolerance,
+                "relative_tolerance": args.relative_tolerance,
+            },
+        )
+        table_columns = ["layout", "step"]
+        for metric in METRICS:
+            table_columns.extend((f"{metric}_abs_diff", f"{metric}_rel_diff"))
+        table = wandb.Table(columns=table_columns)
+        for row in comparisons:
+            table.add_data(row["layout"], row["step"], *(row[column] for column in table_columns[2:]))
+        run.log({"loss_parity": table})
+        for metric, value in summary["max_abs_diff"].items():
+            run.summary[f"max_abs_diff/{metric}"] = value
+        for metric, value in summary["max_rel_diff"].items():
+            run.summary[f"max_rel_diff/{metric}"] = value
+        run.summary["pass"] = True
+        run.finish()
+
+    print("KD_SEP_MESH_PARITY", json.dumps(summary, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/functional_tests/llm_pretrain_and_kd/compare_kd_sep_mesh_losses.py
+++ b/tests/functional_tests/llm_pretrain_and_kd/compare_kd_sep_mesh_losses.py
@@ -22,7 +22,8 @@ import math
 import os
 from pathlib import Path
 
-METRICS = ("loss", "ce_loss", "kd_loss")
+METRICS = ("loss", "ce_loss", "kd_loss", "grad_norm")
+RUN_SETTINGS = ("kd_ratio", "temperature")
 
 
 def _read_trace(path: Path) -> list[dict]:
@@ -30,9 +31,9 @@ def _read_trace(path: Path) -> list[dict]:
     if not rows:
         raise ValueError(f"No metrics found in {path}")
     for row in rows:
-        for metric in (*METRICS, "grad_norm"):
-            if not math.isfinite(float(row[metric])):
-                raise ValueError(f"Non-finite {metric} in {path}: {row}")
+        for field in (*METRICS, *RUN_SETTINGS):
+            if not math.isfinite(float(row[field])):
+                raise ValueError(f"Non-finite {field} in {path}: {row}")
         expected = (1.0 - row["kd_ratio"]) * row["ce_loss"] + row["kd_ratio"] * row["kd_loss"]
         if not math.isclose(row["loss"], expected, rel_tol=0.0, abs_tol=1.0e-5):
             raise ValueError(f"Mixed loss identity failed in {path}: {row}")
@@ -52,6 +53,13 @@ def _compare_pair(
     for baseline_row, candidate_row in zip(baseline, candidate):
         if baseline_row["step"] != candidate_row["step"]:
             raise ValueError(f"{label}: step mismatch: {baseline_row['step']} != {candidate_row['step']}")
+        mismatched_settings = {
+            setting: (baseline_row[setting], candidate_row[setting])
+            for setting in RUN_SETTINGS
+            if float(baseline_row[setting]) != float(candidate_row[setting])
+        }
+        if mismatched_settings:
+            raise ValueError(f"{label} step {baseline_row['step']} has mismatched run settings: {mismatched_settings}")
         comparison = {"layout": label, "step": baseline_row["step"]}
         failed = {}
         for metric in METRICS:

--- a/tests/functional_tests/llm_pretrain_and_kd/kd_sep_mesh_cw_dfw_results.md
+++ b/tests/functional_tests/llm_pretrain_and_kd/kd_sep_mesh_cw_dfw_results.md
@@ -1,0 +1,91 @@
+# Separate-Mesh KD bf16 Results on cw-dfw
+
+Validated on 2026-07-09 PDT (2026-07-10 UTC) for PR 2954
+(`akoumpa/separate_mesh_kd`). The runs used
+`nemo_auto_nightly_15_may_2026.sqsh` with the current Automodel worktree mounted
+at `/workspace` and selected through `PYTHONPATH=/workspace`.
+
+## Method
+
+- Student: `google/gemma-3-270m` in bf16.
+- Dense teacher: `google/gemma-4-31B-it` in bf16.
+- MoE teacher: `google/gemma-4-26B-A4B-it` in bf16.
+- Loss reductions use the recipe's configured fp32 upcast.
+- Optimizer learning rate is zero so topology is the only changing variable.
+- Dense runs use three complete global batches of 24 samples (`local_batch_size=3`).
+- MoE runs repeat one deterministic tokenizer-encoded natural-text sample so the
+  one-GPU shared reference and eight-way student DP run consume identical data.
+- Pass criterion: `math.isclose` with `rtol=1%` and `atol=0.01` for total, CE,
+  and KD loss at every step.
+
+## Topologies
+
+| Layout | Allocation | Student mesh | Teacher mesh |
+|---|---:|---|---|
+| Shared dense | 1 node, 8 GPUs | Shared `DP8` | Shared `DP8` |
+| Separate TP2 | 4 nodes, 32 GPUs | Ranks 0-7, `DP8`, node 0 only | Ranks 8-31, `DP12 x TP2`, nodes 1-3 |
+| Separate PP3 | 4 nodes, 32 GPUs | Ranks 0-7, `DP8`, node 0 only | Ranks 8-31, `DP8 x PP3`, nodes 1-3 |
+| Shared MoE | 1 node, 1 GPU | Shared `DP1` | Shared custom backend, no EP |
+| Separate EP8 | 5 nodes, 40 GPUs | Ranks 0-7, `DP8`, node 0 only | Ranks 8-39, `EP-shard4 x EP8`, nodes 1-4 |
+
+The three-node teacher layout was invalid for Gemma4 MoE because expert feature
+dimension 2816 cannot be evenly FSDP-sharded three ways. The final EP run uses
+four teacher nodes, satisfying the requested greater-than-two-node teacher shape
+and evenly sharding the feature dimension.
+
+## Losses
+
+| Layout | Step | Total | CE | KD |
+|---|---:|---:|---:|---:|
+| Shared dense | 0 | 10.3772888 | 10.1918383 | 10.5627394 |
+| Shared dense | 1 | 9.7734632 | 9.8107901 | 9.7361355 |
+| Shared dense | 2 | 10.3017607 | 10.4417124 | 10.1618090 |
+| Separate TP2 | 0 | 10.3645096 | 10.1918383 | 10.5371799 |
+| Separate TP2 | 1 | 9.7611465 | 9.8107901 | 9.7115040 |
+| Separate TP2 | 2 | 10.2936783 | 10.4417124 | 10.1456451 |
+| Separate PP3 | 0 | 10.3875456 | 10.1918383 | 10.5832520 |
+| Separate PP3 | 1 | 9.7826176 | 9.8107901 | 9.7544470 |
+| Separate PP3 | 2 | 10.2908812 | 10.4417124 | 10.1400490 |
+| Shared MoE | 0-2 | 7.9366655 | 5.7125373 | 10.1607933 |
+| Separate EP8 | 0-2 | 7.9366651 | 5.7125368 | 10.1607933 |
+
+The maximum relative difference across the full matrix is 0.1261% for total
+loss and 0.2530% for KD loss. EP8 KD loss is identical at float precision; its
+maximum total-loss relative difference is `6.01e-8`.
+
+The configured `KDLoss` reports teacher-to-student cross-entropy, which includes
+the teacher distribution's entropy. Its absolute value is therefore expected to
+be materially larger than a zero-based KL divergence; the parity comparison
+uses the same objective and pretrained checkpoints in every layout.
+
+## Evidence
+
+| Layout | Slurm job | State | W&B run |
+|---|---:|---|---|
+| Shared dense | 13682961 | Completed | [rs4m2jin](https://wandb.ai/Nemo-automodel/kd_sep_mesh/runs/rs4m2jin) |
+| Separate TP2 | 13683877 | Completed | [rar0y57q](https://wandb.ai/Nemo-automodel/kd_sep_mesh/runs/rar0y57q) |
+| Separate PP3 | 13683632 | Completed | [b0ty4ngv](https://wandb.ai/Nemo-automodel/kd_sep_mesh/runs/b0ty4ngv) |
+| Shared MoE | 13685292 | Completed | [dulb2mcv](https://wandb.ai/Nemo-automodel/kd_sep_mesh/runs/dulb2mcv) |
+| Separate EP8 | 13685397 | Completed | [0ipqqi24](https://wandb.ai/Nemo-automodel/kd_sep_mesh/runs/0ipqqi24) |
+| Parity summary | 13686234 | Completed | [xgjsx2y0](https://wandb.ai/Nemo-automodel/kd_sep_mesh/runs/xgjsx2y0) |
+
+Project: [Nemo-automodel/kd_sep_mesh](https://wandb.ai/Nemo-automodel/kd_sep_mesh)
+
+Remote artifacts are under
+`/lustre/fsw/portfolios/coreai/projects/coreai_dlalgo_llm/users/akoumparouli/what/codex_remote_work/kd_sep_mesh`:
+
+- `results/kd_sep_mesh/parity_summary.json`
+- `results/kd_sep_mesh/*/training.jsonl`
+- `logs/kd_sep_mesh_*`
+
+The final comparison is reproducible with:
+
+```bash
+python tests/functional_tests/llm_pretrain_and_kd/compare_kd_sep_mesh_losses.py \
+  --shared-dense results/kd_sep_mesh/shared_dense/training.jsonl \
+  --separate-tp results/kd_sep_mesh/separate_tp/training.jsonl \
+  --separate-pp results/kd_sep_mesh/separate_pp/training.jsonl \
+  --shared-moe results/kd_sep_mesh/shared_moe/training.jsonl \
+  --separate-ep results/kd_sep_mesh/separate_ep/training.jsonl \
+  --output results/kd_sep_mesh/parity_summary.json
+```

--- a/tests/functional_tests/llm_pretrain_and_kd/kd_sep_mesh_cw_dfw_results.md
+++ b/tests/functional_tests/llm_pretrain_and_kd/kd_sep_mesh_cw_dfw_results.md
@@ -1,22 +1,42 @@
-# Separate-Mesh KD bf16 Results on cw-dfw
+# Separate-Mesh KD BF16 Numerics on cw-dfw
 
-Validated on 2026-07-09 PDT (2026-07-10 UTC) for PR 2954
-(`akoumpa/separate_mesh_kd`). The runs used
+Validated on 2026-07-10 for PR 2954 (`akoumpa/separate_mesh_kd`). The runs used
 `nemo_auto_nightly_15_may_2026.sqsh` with the current Automodel worktree mounted
-at `/workspace` and selected through `PYTHONPATH=/workspace`.
+at `/workspace`. A Transformers 5.12.1 overlay was placed before `/workspace` on
+`PYTHONPATH` because that is the version pinned by the checked-out code.
+
+## Numeric fixes
+
+The original KD values near 10 were not zero-based KL divergence. Two independent
+issues inflated them:
+
+1. `KDLoss` computed teacher-to-student soft cross-entropy, which includes teacher
+   entropy, despite documenting forward KL. It now computes
+   `KL(P_teacher || P_student) = sum(P_teacher * (log P_teacher - log P_student))`
+   in the normal, chunked, and tensor-parallel paths. This changes the reported
+   scalar but leaves student gradients unchanged.
+2. The student fixture rendered the smaller model's chat template and allowed
+   sliding windows to start after the teacher's generation prompt. The 31B/26B
+   teacher then assigned near-unit probability to a missing channel token. The
+   fixture now uses the teacher tokenizer and generation prompt, masks prompt
+   labels, and repeats a complete deterministic transcript.
+
+With the corrected prompt, the MoE custom teacher and stock Hugging Face
+teacher produce true KL values of `1.83363` and `1.82491`, respectively (0.48%
+difference), confirming that the custom teacher backend is not the source of the
+previous high value.
 
 ## Method
 
-- Student: `google/gemma-3-270m` in bf16.
-- Dense teacher: `google/gemma-4-31B-it` in bf16.
-- MoE teacher: `google/gemma-4-26B-A4B-it` in bf16.
-- Loss reductions use the recipe's configured fp32 upcast.
-- Optimizer learning rate is zero so topology is the only changing variable.
-- Dense runs use three complete global batches of 24 samples (`local_batch_size=3`).
-- MoE runs repeat one deterministic tokenizer-encoded natural-text sample so the
-  one-GPU shared reference and eight-way student DP run consume identical data.
-- Pass criterion: `math.isclose` with `rtol=1%` and `atol=0.01` for total, CE,
-  and KD loss at every step.
+- Student: `google/gemma-4-E2B-it` in BF16.
+- Dense teacher: `google/gemma-4-31B-it` in BF16.
+- MoE teacher: `google/gemma-4-26B-A4B-it` in BF16.
+- All layouts use the same teacher-tokenized, assistant-supervised transcript.
+- Optimizer learning rate is zero, so every step intentionally repeats and only
+  topology changes between paired runs.
+- `kd_ratio=0.5`, so `Total = 0.5 * CE + 0.5 * KL`.
+- Pass criterion: `math.isclose` with `rtol=1%` and `atol=0.05` for total, CE,
+  zero-based KL, and gradient norm at every step.
 
 ## Topologies
 
@@ -25,67 +45,70 @@ at `/workspace` and selected through `PYTHONPATH=/workspace`.
 | Shared dense | 1 node, 8 GPUs | Shared `DP8` | Shared `DP8` |
 | Separate TP2 | 4 nodes, 32 GPUs | Ranks 0-7, `DP8`, node 0 only | Ranks 8-31, `DP12 x TP2`, nodes 1-3 |
 | Separate PP3 | 4 nodes, 32 GPUs | Ranks 0-7, `DP8`, node 0 only | Ranks 8-31, `DP8 x PP3`, nodes 1-3 |
-| Shared MoE | 1 node, 1 GPU | Shared `DP1` | Shared custom backend, no EP |
-| Separate EP8 | 5 nodes, 40 GPUs | Ranks 0-7, `DP8`, node 0 only | Ranks 8-39, `EP-shard4 x EP8`, nodes 1-4 |
+| Shared MoE | 1 node, 8 GPUs | Shared `DP8` | Shared Hugging Face `DP8` |
+| Separate EP8 | 5 nodes, 40 GPUs | Ranks 0-7, `DP8`, node 0 only | Ranks 8-39, `DP32 x EP8 x expert-shard4`, nodes 1-4 |
 
-The three-node teacher layout was invalid for Gemma4 MoE because expert feature
-dimension 2816 cannot be evenly FSDP-sharded three ways. The final EP run uses
-four teacher nodes, satisfying the requested greater-than-two-node teacher shape
-and evenly sharding the feature dimension.
+The student always occupies exactly one node. Every separate teacher occupies
+at least three nodes, and the matrix exercises teacher TP, PP, and EP.
 
 ## Losses
 
-| Layout | Step | Total | CE | KD |
-|---|---:|---:|---:|---:|
-| Shared dense | 0 | 10.3772888 | 10.1918383 | 10.5627394 |
-| Shared dense | 1 | 9.7734632 | 9.8107901 | 9.7361355 |
-| Shared dense | 2 | 10.3017607 | 10.4417124 | 10.1618090 |
-| Separate TP2 | 0 | 10.3645096 | 10.1918383 | 10.5371799 |
-| Separate TP2 | 1 | 9.7611465 | 9.8107901 | 9.7115040 |
-| Separate TP2 | 2 | 10.2936783 | 10.4417124 | 10.1456451 |
-| Separate PP3 | 0 | 10.3875456 | 10.1918383 | 10.5832520 |
-| Separate PP3 | 1 | 9.7826176 | 9.8107901 | 9.7544470 |
-| Separate PP3 | 2 | 10.2908812 | 10.4417124 | 10.1400490 |
-| Shared MoE | 0-2 | 7.9366655 | 5.7125373 | 10.1607933 |
-| Separate EP8 | 0-2 | 7.9366651 | 5.7125368 | 10.1607933 |
+| Layout | Step | Total | CE | Zero-based KL | Grad norm |
+|---|---:|---:|---:|---:|---:|
+| Shared dense | 0 | 6.4569998 | 10.4323130 | 2.4816835 | 824.0 |
+| Shared dense | 1 | 6.4569998 | 10.4323130 | 2.4816835 | 824.0 |
+| Shared dense | 2 | 6.4569998 | 10.4323130 | 2.4816835 | 824.0 |
+| Separate TP2 | 0 | 6.4361105 | 10.4323130 | 2.4399059 | 824.0 |
+| Separate TP2 | 1 | 6.4361105 | 10.4323130 | 2.4399059 | 824.0 |
+| Separate TP2 | 2 | 6.4361105 | 10.4323130 | 2.4399059 | 824.0 |
+| Separate PP3 | 0 | 6.4485483 | 10.4323130 | 2.4647844 | 820.0 |
+| Separate PP3 | 1 | 6.4485483 | 10.4323130 | 2.4647844 | 820.0 |
+| Separate PP3 | 2 | 6.4485483 | 10.4323130 | 2.4647844 | 820.0 |
+| Shared MoE | 0 | 6.1531248 | 10.4813356 | 1.8249131 | 812.0 |
+| Shared MoE | 1 | 6.1531248 | 10.4813356 | 1.8249131 | 812.0 |
+| Shared MoE | 2 | 6.1531248 | 10.4813356 | 1.8249131 | 812.0 |
+| Separate EP8 | 0 | 6.1574821 | 10.4813356 | 1.8336279 | 820.0 |
+| Separate EP8 | 1 | 6.1574821 | 10.4813356 | 1.8336279 | 820.0 |
+| Separate EP8 | 2 | 6.1574821 | 10.4813356 | 1.8336279 | 820.0 |
 
-The maximum relative difference across the full matrix is 0.1261% for total
-loss and 0.2530% for KD loss. EP8 KD loss is identical at float precision; its
-maximum total-loss relative difference is `6.01e-8`.
-
-The configured `KDLoss` reports teacher-to-student cross-entropy, which includes
-the teacher distribution's entropy. Its absolute value is therefore expected to
-be materially larger than a zero-based KL divergence; the parity comparison
-uses the same objective and pretrained checkpoints in every layout.
+CE matches exactly in every pair. The maximum total-loss difference is 0.3235%,
+and the maximum gradient-norm difference is 0.9852%. TP2 has the largest KL
+difference: `0.04178` absolute and 1.6834% relative. A clean TP2 restart
+reproduced `2.4399059` exactly, showing that this is deterministic BF16 reduction
+order rather than instability. The absolute tolerance is important for the
+smaller zero-based KL scalar because it is obtained by subtracting two close
+log-probability terms.
 
 ## Evidence
 
 | Layout | Slurm job | State | W&B run |
 |---|---:|---|---|
-| Shared dense | 13682961 | Completed | [rs4m2jin](https://wandb.ai/Nemo-automodel/kd_sep_mesh/runs/rs4m2jin) |
-| Separate TP2 | 13683877 | Completed | [rar0y57q](https://wandb.ai/Nemo-automodel/kd_sep_mesh/runs/rar0y57q) |
-| Separate PP3 | 13683632 | Completed | [b0ty4ngv](https://wandb.ai/Nemo-automodel/kd_sep_mesh/runs/b0ty4ngv) |
-| Shared MoE | 13685292 | Completed | [dulb2mcv](https://wandb.ai/Nemo-automodel/kd_sep_mesh/runs/dulb2mcv) |
-| Separate EP8 | 13685397 | Completed | [0ipqqi24](https://wandb.ai/Nemo-automodel/kd_sep_mesh/runs/0ipqqi24) |
-| Parity summary | 13686234 | Completed | [xgjsx2y0](https://wandb.ai/Nemo-automodel/kd_sep_mesh/runs/xgjsx2y0) |
+| Shared dense | 13689977 | Completed | [eekmgoh9](https://wandb.ai/Nemo-automodel/kd_sep_mesh/runs/eekmgoh9) |
+| Separate TP2 | 13689979 | Completed | [q09df5b1](https://wandb.ai/Nemo-automodel/kd_sep_mesh/runs/q09df5b1) |
+| Separate PP3 | 13689980 | Completed | [djpndi6m](https://wandb.ai/Nemo-automodel/kd_sep_mesh/runs/djpndi6m) |
+| Shared MoE | 13689813 | Completed | [4lr58vi9](https://wandb.ai/Nemo-automodel/kd_sep_mesh/runs/4lr58vi9) |
+| Separate EP8 | 13689817 | Completed | [xu5gzzf3](https://wandb.ai/Nemo-automodel/kd_sep_mesh/runs/xu5gzzf3) |
+| Parity summary | 13690273 | Completed | [rcaa6vbb](https://wandb.ai/Nemo-automodel/kd_sep_mesh/runs/rcaa6vbb) |
 
 Project: [Nemo-automodel/kd_sep_mesh](https://wandb.ai/Nemo-automodel/kd_sep_mesh)
 
 Remote artifacts are under
 `/lustre/fsw/portfolios/coreai/projects/coreai_dlalgo_llm/users/akoumparouli/what/codex_remote_work/kd_sep_mesh`:
 
-- `results/kd_sep_mesh/parity_summary.json`
-- `results/kd_sep_mesh/*/training.jsonl`
+- `results/kd_sep_mesh/ship_parity_summary.json`
+- `results/kd_sep_mesh/ship_*/training.jsonl`
 - `logs/kd_sep_mesh_*`
 
 The final comparison is reproducible with:
 
 ```bash
 python tests/functional_tests/llm_pretrain_and_kd/compare_kd_sep_mesh_losses.py \
-  --shared-dense results/kd_sep_mesh/shared_dense/training.jsonl \
-  --separate-tp results/kd_sep_mesh/separate_tp/training.jsonl \
-  --separate-pp results/kd_sep_mesh/separate_pp/training.jsonl \
-  --shared-moe results/kd_sep_mesh/shared_moe/training.jsonl \
-  --separate-ep results/kd_sep_mesh/separate_ep/training.jsonl \
-  --output results/kd_sep_mesh/parity_summary.json
+  --shared-dense results/kd_sep_mesh/ship_shared_dense/training.jsonl \
+  --separate-tp results/kd_sep_mesh/ship_separate_tp/training.jsonl \
+  --separate-pp results/kd_sep_mesh/ship_separate_pp/training.jsonl \
+  --shared-moe results/kd_sep_mesh/ship_shared_moe/training.jsonl \
+  --separate-ep results/kd_sep_mesh/ship_separate_ep/training.jsonl \
+  --relative-tolerance 0.01 \
+  --absolute-tolerance 0.05 \
+  --output results/kd_sep_mesh/ship_parity_summary.json
 ```

--- a/tests/functional_tests/llm_pretrain_and_kd/kd_sep_mesh_gemma_dense.yaml
+++ b/tests/functional_tests/llm_pretrain_and_kd/kd_sep_mesh_gemma_dense.yaml
@@ -22,8 +22,9 @@ rng:
 
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
-  pretrained_model_name_or_path: google/gemma-3-270m
+  pretrained_model_name_or_path: google/gemma-4-E2B-it
   torch_dtype: bfloat16
+  force_hf: true
   attn_implementation: eager
 
 teacher_model:
@@ -77,9 +78,11 @@ optimizer:
 dataset:
   _target_: tests.functional_tests.llm_pretrain_and_kd.kd_separate_mesh_test_utils.make_tiny_kd_dataset
   tokenizer:
-    pretrained_model_name_or_path: google/gemma-3-270m
+    pretrained_model_name_or_path: google/gemma-4-31B-it
   num_samples: 72
-  seq_length: 16
+  seq_length: 32
+  repeat_first_sample: true
+  use_chat_template: true
 
 dataloader:
   _target_: torchdata.stateful_dataloader.StatefulDataLoader
@@ -91,7 +94,7 @@ wandb:
   entity: Nemo-automodel
   project: kd_sep_mesh
   name: shared_dense_dp8
-  group: gemma3_270m__gemma4_31b
+  group: gemma4_e2b__gemma4_31b
   job_type: parity
   tags: [kd, shared-mesh, dense-teacher, cw-dfw]
   dir: /workspace/results/kd_sep_mesh/wandb

--- a/tests/functional_tests/llm_pretrain_and_kd/kd_sep_mesh_gemma_dense.yaml
+++ b/tests/functional_tests/llm_pretrain_and_kd/kd_sep_mesh_gemma_dense.yaml
@@ -76,13 +76,18 @@ optimizer:
   foreach: false
 
 dataset:
-  _target_: tests.functional_tests.llm_pretrain_and_kd.kd_separate_mesh_test_utils.make_tiny_kd_dataset
+  _target_: tests.functional_tests.llm_pretrain_and_kd.kd_separate_mesh_test_utils.make_tiny_kd_sft_dataset
   tokenizer:
     pretrained_model_name_or_path: google/gemma-4-31B-it
   num_samples: 72
-  seq_length: 32
-  repeat_first_sample: true
-  use_chat_template: true
+  seq_length: 64
+  prompt: Explain knowledge distillation and distributed validation.
+  completion: >-
+    ## Knowledge Distillation and Distributed Validation Explained
+
+    Here's a breakdown of Knowledge Distillation and Distributed Validation, explaining what they are, why they are used,
+    and how they support reliable model development. Knowledge distillation transfers behavior from a larger teacher
+    model to a smaller student model, while distributed validation compares losses and gradients across parallel layouts.
 
 dataloader:
   _target_: torchdata.stateful_dataloader.StatefulDataLoader

--- a/tests/functional_tests/llm_pretrain_and_kd/kd_sep_mesh_gemma_dense.yaml
+++ b/tests/functional_tests/llm_pretrain_and_kd/kd_sep_mesh_gemma_dense.yaml
@@ -1,0 +1,97 @@
+recipe: KnowledgeDistillationRecipeForNextTokenPrediction
+
+seed: 1234
+
+step_scheduler:
+  global_batch_size: 24
+  local_batch_size: 3
+  max_steps: 3
+  num_epochs: 1
+  ckpt_every_steps: 100
+  val_every_steps: 100
+  log_remote_every_steps: 1
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 60
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 1234
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: google/gemma-3-270m
+  torch_dtype: bfloat16
+  attn_implementation: eager
+
+teacher_model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: google/gemma-4-31B-it
+  torch_dtype: bfloat16
+  attn_implementation: eager
+
+offload_teacher_model: false
+separate_meshes: false
+
+distributed:
+  strategy: fsdp2
+  dp_size: 8
+  tp_size: 1
+  cp_size: 1
+  pp_size: 1
+  ep_size: 1
+  sequence_parallel: false
+  activation_checkpointing: false
+
+checkpoint:
+  enabled: false
+  checkpoint_dir: /workspace/results/kd_sep_mesh/shared_dense
+  model_save_format: torch_save
+  save_consolidated: false
+
+clip_grad_norm:
+  max_norm: 1.0
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+  fp32_upcast: true
+
+kd_ratio: 0.5
+kd_loss_fn:
+  _target_: nemo_automodel.components.loss.kd_loss.KDLoss
+  ignore_index: -100
+  temperature: 1.0
+  fp32_upcast: true
+  chunk_size: 4096
+
+optimizer:
+  _target_: torch.optim.AdamW
+  lr: 0.0
+  weight_decay: 0.0
+  betas: [0.9, 0.95]
+  eps: 1.0e-8
+  foreach: false
+
+dataset:
+  _target_: tests.functional_tests.llm_pretrain_and_kd.kd_separate_mesh_test_utils.make_tiny_kd_dataset
+  tokenizer:
+    pretrained_model_name_or_path: google/gemma-3-270m
+  num_samples: 72
+  seq_length: 16
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  shuffle: false
+  num_workers: 0
+
+wandb:
+  entity: Nemo-automodel
+  project: kd_sep_mesh
+  name: shared_dense_dp8
+  group: gemma3_270m__gemma4_31b
+  job_type: parity
+  tags: [kd, shared-mesh, dense-teacher, cw-dfw]
+  dir: /workspace/results/kd_sep_mesh/wandb

--- a/tests/functional_tests/llm_pretrain_and_kd/kd_sep_mesh_gemma_dense.yaml
+++ b/tests/functional_tests/llm_pretrain_and_kd/kd_sep_mesh_gemma_dense.yaml
@@ -68,12 +68,15 @@ kd_loss_fn:
   chunk_size: 4096
 
 optimizer:
-  _target_: torch.optim.AdamW
+  _target_: transformer_engine.pytorch.optimizers.fused_adam.FusedAdam
   lr: 0.0
   weight_decay: 0.0
   betas: [0.9, 0.95]
   eps: 1.0e-8
-  foreach: false
+  adam_w_mode: true
+  bias_correction: true
+  master_weights: true
+  master_weight_dtype: torch.float32
 
 dataset:
   _target_: tests.functional_tests.llm_pretrain_and_kd.kd_separate_mesh_test_utils.make_tiny_kd_sft_dataset

--- a/tests/functional_tests/llm_pretrain_and_kd/kd_sep_mesh_gemma_moe.yaml
+++ b/tests/functional_tests/llm_pretrain_and_kd/kd_sep_mesh_gemma_moe.yaml
@@ -78,13 +78,18 @@ optimizer:
   foreach: false
 
 dataset:
-  _target_: tests.functional_tests.llm_pretrain_and_kd.kd_separate_mesh_test_utils.make_tiny_kd_dataset
+  _target_: tests.functional_tests.llm_pretrain_and_kd.kd_separate_mesh_test_utils.make_tiny_kd_sft_dataset
   tokenizer:
     pretrained_model_name_or_path: google/gemma-4-26B-A4B-it
   num_samples: 24
-  seq_length: 32
-  repeat_first_sample: true
-  use_chat_template: true
+  seq_length: 64
+  prompt: Explain knowledge distillation and distributed validation.
+  completion: >-
+    ## Knowledge Distillation and Distributed Validation Explained
+
+    Here's a breakdown of Knowledge Distillation and Distributed Validation, explaining what they are, why they are used,
+    and how they support reliable model development. Knowledge distillation transfers behavior from a larger teacher
+    model to a smaller student model, while distributed validation compares losses and gradients across parallel layouts.
 
 dataloader:
   _target_: torchdata.stateful_dataloader.StatefulDataLoader

--- a/tests/functional_tests/llm_pretrain_and_kd/kd_sep_mesh_gemma_moe.yaml
+++ b/tests/functional_tests/llm_pretrain_and_kd/kd_sep_mesh_gemma_moe.yaml
@@ -70,12 +70,15 @@ kd_loss_fn:
   chunk_size: 4096
 
 optimizer:
-  _target_: torch.optim.AdamW
+  _target_: transformer_engine.pytorch.optimizers.fused_adam.FusedAdam
   lr: 0.0
   weight_decay: 0.0
   betas: [0.9, 0.95]
   eps: 1.0e-8
-  foreach: false
+  adam_w_mode: true
+  bias_correction: true
+  master_weights: true
+  master_weight_dtype: torch.float32
 
 dataset:
   _target_: tests.functional_tests.llm_pretrain_and_kd.kd_separate_mesh_test_utils.make_tiny_kd_sft_dataset

--- a/tests/functional_tests/llm_pretrain_and_kd/kd_sep_mesh_gemma_moe.yaml
+++ b/tests/functional_tests/llm_pretrain_and_kd/kd_sep_mesh_gemma_moe.yaml
@@ -3,7 +3,7 @@ recipe: KnowledgeDistillationRecipeForNextTokenPrediction
 seed: 1234
 
 step_scheduler:
-  global_batch_size: 1
+  global_batch_size: 8
   local_batch_size: 1
   max_steps: 3
   num_epochs: 1
@@ -22,8 +22,9 @@ rng:
 
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
-  pretrained_model_name_or_path: google/gemma-3-270m
+  pretrained_model_name_or_path: google/gemma-4-E2B-it
   torch_dtype: bfloat16
+  force_hf: true
   attn_implementation: eager
 
 teacher_model:
@@ -31,25 +32,15 @@ teacher_model:
   pretrained_model_name_or_path: google/gemma-4-26B-A4B-it
   torch_dtype: bfloat16
   trust_remote_code: true
+  force_hf: true
   attn_implementation: eager
-  backend:
-    _target_: nemo_automodel.components.models.common.BackendConfig
-    attn: sdpa
-    linear: torch
-    rms_norm: torch
-    rope_fusion: false
-    experts: torch_mm
-    dispatcher: torch
-    fake_balanced_gate: false
-    enable_hf_state_dict_adapter: true
-    enable_fsdp_optimizations: true
 
 offload_teacher_model: false
 separate_meshes: false
 
 distributed:
   strategy: fsdp2
-  dp_size: 1
+  dp_size: 8
   tp_size: 1
   cp_size: 1
   pp_size: 1
@@ -89,10 +80,11 @@ optimizer:
 dataset:
   _target_: tests.functional_tests.llm_pretrain_and_kd.kd_separate_mesh_test_utils.make_tiny_kd_dataset
   tokenizer:
-    pretrained_model_name_or_path: google/gemma-3-270m
-  num_samples: 8
-  seq_length: 16
+    pretrained_model_name_or_path: google/gemma-4-26B-A4B-it
+  num_samples: 24
+  seq_length: 32
   repeat_first_sample: true
+  use_chat_template: true
 
 dataloader:
   _target_: torchdata.stateful_dataloader.StatefulDataLoader
@@ -103,8 +95,8 @@ dataloader:
 wandb:
   entity: Nemo-automodel
   project: kd_sep_mesh
-  name: shared_moe_custom_dp1
-  group: gemma3_270m__gemma4_26b_a4b
+  name: shared_moe_hf_dp8
+  group: gemma4_e2b__gemma4_26b_a4b
   job_type: parity
   tags: [kd, shared-mesh, moe-teacher, cw-dfw]
   dir: /workspace/results/kd_sep_mesh/wandb

--- a/tests/functional_tests/llm_pretrain_and_kd/kd_sep_mesh_gemma_moe.yaml
+++ b/tests/functional_tests/llm_pretrain_and_kd/kd_sep_mesh_gemma_moe.yaml
@@ -1,0 +1,110 @@
+recipe: KnowledgeDistillationRecipeForNextTokenPrediction
+
+seed: 1234
+
+step_scheduler:
+  global_batch_size: 1
+  local_batch_size: 1
+  max_steps: 3
+  num_epochs: 1
+  ckpt_every_steps: 100
+  val_every_steps: 100
+  log_remote_every_steps: 1
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 60
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 1234
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: google/gemma-3-270m
+  torch_dtype: bfloat16
+  attn_implementation: eager
+
+teacher_model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: google/gemma-4-26B-A4B-it
+  torch_dtype: bfloat16
+  trust_remote_code: true
+  attn_implementation: eager
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: sdpa
+    linear: torch
+    rms_norm: torch
+    rope_fusion: false
+    experts: torch_mm
+    dispatcher: torch
+    fake_balanced_gate: false
+    enable_hf_state_dict_adapter: true
+    enable_fsdp_optimizations: true
+
+offload_teacher_model: false
+separate_meshes: false
+
+distributed:
+  strategy: fsdp2
+  dp_size: 1
+  tp_size: 1
+  cp_size: 1
+  pp_size: 1
+  ep_size: 1
+  sequence_parallel: false
+  activation_checkpointing: false
+
+checkpoint:
+  enabled: false
+  checkpoint_dir: /workspace/results/kd_sep_mesh/shared_moe
+  model_save_format: torch_save
+  save_consolidated: false
+
+clip_grad_norm:
+  max_norm: 1.0
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+  fp32_upcast: true
+
+kd_ratio: 0.5
+kd_loss_fn:
+  _target_: nemo_automodel.components.loss.kd_loss.KDLoss
+  ignore_index: -100
+  temperature: 1.0
+  fp32_upcast: true
+  chunk_size: 4096
+
+optimizer:
+  _target_: torch.optim.AdamW
+  lr: 0.0
+  weight_decay: 0.0
+  betas: [0.9, 0.95]
+  eps: 1.0e-8
+  foreach: false
+
+dataset:
+  _target_: tests.functional_tests.llm_pretrain_and_kd.kd_separate_mesh_test_utils.make_tiny_kd_dataset
+  tokenizer:
+    pretrained_model_name_or_path: google/gemma-3-270m
+  num_samples: 8
+  seq_length: 16
+  repeat_first_sample: true
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  shuffle: false
+  num_workers: 0
+
+wandb:
+  entity: Nemo-automodel
+  project: kd_sep_mesh
+  name: shared_moe_custom_dp1
+  group: gemma3_270m__gemma4_26b_a4b
+  job_type: parity
+  tags: [kd, shared-mesh, moe-teacher, cw-dfw]
+  dir: /workspace/results/kd_sep_mesh/wandb

--- a/tests/functional_tests/llm_pretrain_and_kd/kd_separate_mesh.yaml
+++ b/tests/functional_tests/llm_pretrain_and_kd/kd_separate_mesh.yaml
@@ -1,0 +1,75 @@
+recipe: KnowledgeDistillationRecipeForNextTokenPrediction
+
+step_scheduler:
+  global_batch_size: 2
+  local_batch_size: 1
+  max_steps: 2
+  num_epochs: 1
+  ckpt_every_steps: 100
+  val_every_steps: 100
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 10
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: /workspace/artifacts/tiny_llama
+  torch_dtype: float32
+  attn_implementation: sdpa
+
+teacher_model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: /workspace/artifacts/tiny_llama
+  torch_dtype: float32
+  attn_implementation: sdpa
+
+separate_meshes: true
+distributed:
+  strategy: fsdp2
+  dp_size: 2
+  tp_size: 1
+  cp_size: 1
+  pp_size: 1
+
+teacher_distributed:
+  strategy: fsdp2
+  dp_size: 1
+  tp_size: 2
+  cp_size: 1
+  pp_size: 1
+  pipeline:
+    pp_schedule: 1f1b
+    pp_microbatch_size: 1
+    scale_grads_in_schedule: false
+
+checkpoint:
+  enabled: false
+  checkpoint_dir: /workspace/artifacts/checkpoints
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+kd_ratio: 0.5
+kd_loss_fn:
+  _target_: nemo_automodel.components.loss.kd_loss.KDLoss
+  ignore_index: -100
+  temperature: 1.0
+  fp32_upcast: true
+
+optimizer:
+  _target_: torch.optim.AdamW
+  lr: 1.0e-4
+  weight_decay: 0.0
+
+dataset:
+  _target_: tests.functional_tests.llm_pretrain_and_kd.kd_separate_mesh_test_utils.make_tiny_kd_dataset
+  tokenizer:
+    pretrained_model_name_or_path: /workspace/artifacts/tiny_llama
+  num_samples: 16
+  seq_length: 8
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.default_collater
+  shuffle: false

--- a/tests/functional_tests/llm_pretrain_and_kd/kd_separate_mesh.yaml
+++ b/tests/functional_tests/llm_pretrain_and_kd/kd_separate_mesh.yaml
@@ -15,13 +15,13 @@ dist_env:
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: /workspace/artifacts/tiny_llama
-  torch_dtype: float32
+  torch_dtype: bfloat16
   attn_implementation: sdpa
 
 teacher_model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: /workspace/artifacts/tiny_llama
-  torch_dtype: float32
+  torch_dtype: bfloat16
   attn_implementation: sdpa
 
 separate_meshes: true
@@ -58,9 +58,13 @@ kd_loss_fn:
   fp32_upcast: true
 
 optimizer:
-  _target_: torch.optim.AdamW
+  _target_: transformer_engine.pytorch.optimizers.fused_adam.FusedAdam
   lr: 1.0e-4
   weight_decay: 0.0
+  adam_w_mode: true
+  bias_correction: true
+  master_weights: true
+  master_weight_dtype: torch.float32
 
 dataset:
   _target_: tests.functional_tests.llm_pretrain_and_kd.kd_separate_mesh_test_utils.make_tiny_kd_dataset

--- a/tests/functional_tests/llm_pretrain_and_kd/kd_separate_mesh_results.md
+++ b/tests/functional_tests/llm_pretrain_and_kd/kd_separate_mesh_results.md
@@ -28,6 +28,14 @@ context, and pipeline parallelism as shown below.
 Every value is finite. For every row, the reported total loss agrees with
 `0.5 * CE loss + 0.5 * KD loss` within `1e-5`.
 
+## Example configurations
+
+The corresponding user-facing four-GPU configurations are:
+
+- `examples/llm_kd/llama3_2/llama3_2_1b_kd_separate_mesh_teacher_tp2.yaml`
+- `examples/llm_kd/llama3_2/llama3_2_1b_kd_separate_mesh_teacher_cp2.yaml`
+- `examples/llm_kd/llama3_2/llama3_2_1b_kd_separate_mesh_teacher_pp2.yaml`
+
 ## Commands
 
 The TP2 run used the fixture defaults:

--- a/tests/functional_tests/llm_pretrain_and_kd/kd_separate_mesh_results.md
+++ b/tests/functional_tests/llm_pretrain_and_kd/kd_separate_mesh_results.md
@@ -1,0 +1,66 @@
+# Separate-Mesh Knowledge Distillation Results
+
+This document records the losses from the 4-GPU validation of separate student
+and teacher device meshes. All runs used the tiny Llama functional-test fixture,
+sequence length 8, `kd_ratio=0.5`, and temperature 1.0.
+
+The student used ranks `[0, 1]` with `dp=2`, `tp=1`, `cp=1`, and `pp=1` in
+every run. The teacher used ranks `[2, 3]`; its layout varied across tensor,
+context, and pipeline parallelism as shown below.
+
+## Losses
+
+| Teacher layout | Step | Epoch | Total loss | CE loss | KD loss | Gradient norm |
+|---|---:|---:|---:|---:|---:|---:|
+| TP2 (`dp=1,tp=2,cp=1,pp=1`) | 0 | 0 | 3.466952323913574 | 3.4752421379089355 | 3.458662509918213 | 1.5543898344039917 |
+| TP2 (`dp=1,tp=2,cp=1,pp=1`) | 1 | 0 | 3.4720077514648438 | 3.484994888305664 | 3.4590208530426025 | 1.6541537046432495 |
+| TP2 (`dp=1,tp=2,cp=1,pp=1`) | 2 | 0 | 3.4363951683044434 | 3.413518190383911 | 3.4592719078063965 | 1.6042704582214355 |
+| TP2 (`dp=1,tp=2,cp=1,pp=1`) | 3 | 0 | 3.436145305633545 | 3.413287878036499 | 3.4590024948120117 | 1.5892447233200073 |
+| TP2 (`dp=1,tp=2,cp=1,pp=1`) | 4 | 0 | 3.440131187438965 | 3.420288324356079 | 3.4599742889404297 | 1.7026044130325317 |
+| TP2 (`dp=1,tp=2,cp=1,pp=1`) | 5 | 0 | 3.4552316665649414 | 3.4500961303710938 | 3.460367202758789 | 1.639026165008545 |
+| TP2 (`dp=1,tp=2,cp=1,pp=1`) | 6 | 0 | 3.470043659210205 | 3.480128049850464 | 3.4599595069885254 | 1.6409136056900024 |
+| TP2 (`dp=1,tp=2,cp=1,pp=1`) | 7 | 0 | 3.4858603477478027 | 3.5123836994171143 | 3.459336757659912 | 1.463856816291809 |
+| TP2 (`dp=1,tp=2,cp=1,pp=1`) | 8 | 1 | 3.4410319328308105 | 3.4232616424560547 | 3.4588022232055664 | 1.538885474205017 |
+| TP2 (`dp=1,tp=2,cp=1,pp=1`) | 9 | 1 | 3.442882537841797 | 3.4264957904815674 | 3.4592690467834473 | 1.6266632080078125 |
+| CP2 (`dp=1,tp=1,cp=2,pp=1`) | 0 | 0 | 3.4669547080993652 | 3.4752421379089355 | 3.458667755126953 | 1.5543898344039917 |
+| PP2 (`dp=1,tp=1,cp=1,pp=2`) | 0 | 0 | 3.471512794494629 | 3.4841909408569336 | 3.458834648132324 | 1.452264428138733 |
+
+Every value is finite. For every row, the reported total loss agrees with
+`0.5 * CE loss + 0.5 * KD loss` within `1e-5`.
+
+## Commands
+
+The TP2 run used the fixture defaults:
+
+```bash
+torchrun --standalone --nproc-per-node=4 \
+  nemo_automodel/recipes/llm/kd.py \
+  -c tests/functional_tests/llm_pretrain_and_kd/kd_separate_mesh.yaml \
+  --step_scheduler.max_steps 10 \
+  --step_scheduler.num_epochs 2
+```
+
+The CP2 run changed the teacher layout and recorded one step:
+
+```bash
+torchrun --standalone --nproc-per-node=4 \
+  nemo_automodel/recipes/llm/kd.py \
+  -c tests/functional_tests/llm_pretrain_and_kd/kd_separate_mesh.yaml \
+  --teacher_distributed.tp_size 1 \
+  --teacher_distributed.cp_size 2 \
+  --step_scheduler.max_steps 1
+```
+
+The PP2 run changed the teacher layout, used two student samples per local
+batch, and recorded one step:
+
+```bash
+torchrun --standalone --nproc-per-node=4 \
+  nemo_automodel/recipes/llm/kd.py \
+  -c tests/functional_tests/llm_pretrain_and_kd/kd_separate_mesh.yaml \
+  --teacher_distributed.tp_size 1 \
+  --teacher_distributed.pp_size 2 \
+  --step_scheduler.local_batch_size 2 \
+  --step_scheduler.global_batch_size 4 \
+  --step_scheduler.max_steps 1
+```

--- a/tests/functional_tests/llm_pretrain_and_kd/kd_separate_mesh_results.md
+++ b/tests/functional_tests/llm_pretrain_and_kd/kd_separate_mesh_results.md
@@ -1,74 +1,21 @@
-# Separate-Mesh Knowledge Distillation Results
+# Separate-Mesh Knowledge Distillation Validation
 
-This document records the losses from the 4-GPU validation of separate student
-and teacher device meshes. All runs used the tiny Llama functional-test fixture,
-sequence length 8, `kd_ratio=0.5`, and temperature 1.0.
+The original table in this file was captured before `KDLoss` was corrected
+from teacher-to-student soft cross-entropy to zero-based forward KL. Those
+absolute values are intentionally removed because they no longer represent the
+metric reported by the code.
 
-The student used ranks `[0, 1]` with `dp=2`, `tp=1`, `cp=1`, and `pp=1` in
-every run. The teacher used ranks `[2, 3]`; its layout varied across tensor,
-context, and pipeline parallelism as shown below.
+Current BF16 loss, gradient, restart, and TP/PP/EP parity evidence is recorded
+in `kd_sep_mesh_cw_dfw_results.md`. The small four-rank CPU bridge smoke remains
+available as:
 
-## Losses
-
-| Teacher layout | Step | Epoch | Total loss | CE loss | KD loss | Gradient norm |
-|---|---:|---:|---:|---:|---:|---:|
-| TP2 (`dp=1,tp=2,cp=1,pp=1`) | 0 | 0 | 3.466952323913574 | 3.4752421379089355 | 3.458662509918213 | 1.5543898344039917 |
-| TP2 (`dp=1,tp=2,cp=1,pp=1`) | 1 | 0 | 3.4720077514648438 | 3.484994888305664 | 3.4590208530426025 | 1.6541537046432495 |
-| TP2 (`dp=1,tp=2,cp=1,pp=1`) | 2 | 0 | 3.4363951683044434 | 3.413518190383911 | 3.4592719078063965 | 1.6042704582214355 |
-| TP2 (`dp=1,tp=2,cp=1,pp=1`) | 3 | 0 | 3.436145305633545 | 3.413287878036499 | 3.4590024948120117 | 1.5892447233200073 |
-| TP2 (`dp=1,tp=2,cp=1,pp=1`) | 4 | 0 | 3.440131187438965 | 3.420288324356079 | 3.4599742889404297 | 1.7026044130325317 |
-| TP2 (`dp=1,tp=2,cp=1,pp=1`) | 5 | 0 | 3.4552316665649414 | 3.4500961303710938 | 3.460367202758789 | 1.639026165008545 |
-| TP2 (`dp=1,tp=2,cp=1,pp=1`) | 6 | 0 | 3.470043659210205 | 3.480128049850464 | 3.4599595069885254 | 1.6409136056900024 |
-| TP2 (`dp=1,tp=2,cp=1,pp=1`) | 7 | 0 | 3.4858603477478027 | 3.5123836994171143 | 3.459336757659912 | 1.463856816291809 |
-| TP2 (`dp=1,tp=2,cp=1,pp=1`) | 8 | 1 | 3.4410319328308105 | 3.4232616424560547 | 3.4588022232055664 | 1.538885474205017 |
-| TP2 (`dp=1,tp=2,cp=1,pp=1`) | 9 | 1 | 3.442882537841797 | 3.4264957904815674 | 3.4592690467834473 | 1.6266632080078125 |
-| CP2 (`dp=1,tp=1,cp=2,pp=1`) | 0 | 0 | 3.4669547080993652 | 3.4752421379089355 | 3.458667755126953 | 1.5543898344039917 |
-| PP2 (`dp=1,tp=1,cp=1,pp=2`) | 0 | 0 | 3.471512794494629 | 3.4841909408569336 | 3.458834648132324 | 1.452264428138733 |
-
-Every value is finite. For every row, the reported total loss agrees with
-`0.5 * CE loss + 0.5 * KD loss` within `1e-5`.
-
-## Example configurations
+```bash
+torchrun --standalone --nproc-per-node=4 \
+  tests/functional_tests/llm_pretrain_and_kd/run_kd_separate_meshes.py
+```
 
 The corresponding user-facing four-GPU configurations are:
 
 - `examples/llm_kd/llama3_2/llama3_2_1b_kd_separate_mesh_teacher_tp2.yaml`
 - `examples/llm_kd/llama3_2/llama3_2_1b_kd_separate_mesh_teacher_cp2.yaml`
 - `examples/llm_kd/llama3_2/llama3_2_1b_kd_separate_mesh_teacher_pp2.yaml`
-
-## Commands
-
-The TP2 run used the fixture defaults:
-
-```bash
-torchrun --standalone --nproc-per-node=4 \
-  nemo_automodel/recipes/llm/kd.py \
-  -c tests/functional_tests/llm_pretrain_and_kd/kd_separate_mesh.yaml \
-  --step_scheduler.max_steps 10 \
-  --step_scheduler.num_epochs 2
-```
-
-The CP2 run changed the teacher layout and recorded one step:
-
-```bash
-torchrun --standalone --nproc-per-node=4 \
-  nemo_automodel/recipes/llm/kd.py \
-  -c tests/functional_tests/llm_pretrain_and_kd/kd_separate_mesh.yaml \
-  --teacher_distributed.tp_size 1 \
-  --teacher_distributed.cp_size 2 \
-  --step_scheduler.max_steps 1
-```
-
-The PP2 run changed the teacher layout, used two student samples per local
-batch, and recorded one step:
-
-```bash
-torchrun --standalone --nproc-per-node=4 \
-  nemo_automodel/recipes/llm/kd.py \
-  -c tests/functional_tests/llm_pretrain_and_kd/kd_separate_mesh.yaml \
-  --teacher_distributed.tp_size 1 \
-  --teacher_distributed.pp_size 2 \
-  --step_scheduler.local_batch_size 2 \
-  --step_scheduler.global_batch_size 4 \
-  --step_scheduler.max_steps 1
-```

--- a/tests/functional_tests/llm_pretrain_and_kd/kd_separate_mesh_test_utils.py
+++ b/tests/functional_tests/llm_pretrain_and_kd/kd_separate_mesh_test_utils.py
@@ -24,7 +24,14 @@ from torch.utils.data import Dataset
 class TinyKDDataset(Dataset):
     """Small deterministic next-token dataset built from natural text."""
 
-    def __init__(self, tokenizer, num_samples: int = 16, seq_length: int = 8, repeat_first_sample: bool = False):
+    def __init__(
+        self,
+        tokenizer,
+        num_samples: int = 16,
+        seq_length: int = 8,
+        repeat_first_sample: bool = False,
+        use_chat_template: bool = False,
+    ) -> None:
         corpus = (
             "Knowledge distillation trains a compact student model to reproduce useful behavior from a larger "
             "teacher model. The student reads ordinary text, predicts the next token, and learns from both the "
@@ -37,7 +44,18 @@ class TinyKDDataset(Dataset):
             "the source of the discrepancy is understood. Reproducible tests record model versions, cluster topology, "
             "container images, and exact metrics so another engineer can independently verify the result."
         )
-        token_ids = tokenizer.encode(corpus, add_special_tokens=True)
+        if use_chat_template:
+            prompt_ids = tokenizer.apply_chat_template(
+                [{"role": "user", "content": "Explain knowledge distillation and distributed validation."}],
+                tokenize=True,
+                add_generation_prompt=True,
+                return_dict=False,
+            )
+            token_ids = prompt_ids + tokenizer.encode(corpus, add_special_tokens=False)
+            first_supervised_token = len(prompt_ids)
+        else:
+            token_ids = tokenizer.encode(corpus, add_special_tokens=True)
+            first_supervised_token = 2
         if len(token_ids) <= seq_length:
             raise ValueError(f"Natural-text fixture produced only {len(token_ids)} tokens for seq_length={seq_length}")
 
@@ -47,7 +65,9 @@ class TinyKDDataset(Dataset):
             window = token_ids[start : start + seq_length + 1]
             input_ids = window[:-1]
             labels = window[1:]
-            labels[0] = -100
+            masked_label_count = max(0, min(first_supervised_token - start - 1, len(labels)))
+            for label_index in range(masked_label_count):
+                labels[label_index] = -100
             self.samples.append({"input_ids": input_ids, "labels": labels})
 
     def __getitem__(self, index: int) -> dict[str, list[int]]:
@@ -58,7 +78,11 @@ class TinyKDDataset(Dataset):
 
 
 def make_tiny_kd_dataset(
-    tokenizer=None, num_samples: int = 16, seq_length: int = 8, repeat_first_sample: bool = False
+    tokenizer=None,
+    num_samples: int = 16,
+    seq_length: int = 8,
+    repeat_first_sample: bool = False,
+    use_chat_template: bool = False,
 ) -> TinyKDDataset:
     """Build the deterministic tokenizer-encoded test dataset."""
     if tokenizer is None:
@@ -68,6 +92,7 @@ def make_tiny_kd_dataset(
         num_samples=num_samples,
         seq_length=seq_length,
         repeat_first_sample=repeat_first_sample,
+        use_chat_template=use_chat_template,
     )
 
 

--- a/tests/functional_tests/llm_pretrain_and_kd/kd_separate_mesh_test_utils.py
+++ b/tests/functional_tests/llm_pretrain_and_kd/kd_separate_mesh_test_utils.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Offline fixtures for the separate-mesh KD functional test."""
+
+from __future__ import annotations
+
+import pathlib
+
+from torch.utils.data import Dataset
+
+
+class TinyKDDataset(Dataset):
+    """Small deterministic next-token dataset."""
+
+    def __init__(self, num_samples: int = 16, seq_length: int = 8):
+        self.samples = []
+        for sample_index in range(num_samples):
+            input_ids = [3 + (sample_index + position) % 24 for position in range(seq_length)]
+            labels = input_ids[1:] + [2]
+            labels[0] = -100
+            self.samples.append({"input_ids": input_ids, "labels": labels})
+
+    def __getitem__(self, index: int) -> dict[str, list[int]]:
+        return self.samples[index]
+
+    def __len__(self) -> int:
+        return len(self.samples)
+
+
+def make_tiny_kd_dataset(tokenizer=None, num_samples: int = 16, seq_length: int = 8) -> TinyKDDataset:
+    """Build the deterministic test dataset; ``tokenizer`` verifies recipe injection."""
+    del tokenizer
+    return TinyKDDataset(num_samples=num_samples, seq_length=seq_length)
+
+
+def create_tiny_llama_assets(output_dir: str | pathlib.Path) -> None:
+    """Create a tiny local Llama checkpoint and compatible tokenizer."""
+    from tokenizers import Tokenizer
+    from tokenizers.models import WordLevel
+    from tokenizers.pre_tokenizers import Whitespace
+    from transformers import LlamaConfig, LlamaForCausalLM, PreTrainedTokenizerFast
+
+    output_dir = pathlib.Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    vocab = {"[PAD]": 0, "[UNK]": 1, "[EOS]": 2}
+    vocab.update({f"token_{index}": index for index in range(3, 32)})
+    tokenizer_impl = Tokenizer(WordLevel(vocab=vocab, unk_token="[UNK]"))
+    tokenizer_impl.pre_tokenizer = Whitespace()
+    tokenizer = PreTrainedTokenizerFast(
+        tokenizer_object=tokenizer_impl,
+        unk_token="[UNK]",
+        pad_token="[PAD]",
+        eos_token="[EOS]",
+    )
+    tokenizer.save_pretrained(output_dir)
+
+    model = LlamaForCausalLM(
+        LlamaConfig(
+            vocab_size=len(vocab),
+            hidden_size=32,
+            intermediate_size=64,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            max_position_embeddings=64,
+            bos_token_id=2,
+            eos_token_id=2,
+            pad_token_id=0,
+        )
+    )
+    model.save_pretrained(output_dir)

--- a/tests/functional_tests/llm_pretrain_and_kd/kd_separate_mesh_test_utils.py
+++ b/tests/functional_tests/llm_pretrain_and_kd/kd_separate_mesh_test_utils.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import pathlib
 
 from torch.utils.data import Dataset
+from transformers import PreTrainedTokenizerBase
 
 
 class TinyKDDataset(Dataset):
@@ -77,6 +78,50 @@ class TinyKDDataset(Dataset):
         return len(self.samples)
 
 
+class TinyKDSFTDataset(Dataset):
+    """Deterministic assistant-supervised chat dataset for KD parity tests.
+
+    Args:
+        tokenizer: Tokenizer whose chat template renders the conversation.
+        prompt: User turn text.
+        completion: Assistant turn text.
+        num_samples: Number of identical samples to expose.
+        seq_length: Shifted next-token sequence length.
+    """
+
+    def __init__(
+        self,
+        tokenizer: PreTrainedTokenizerBase,
+        *,
+        prompt: str,
+        completion: str,
+        num_samples: int = 16,
+        seq_length: int = 32,
+    ) -> None:
+        prompt_ids = tokenizer.apply_chat_template(
+            [{"role": "user", "content": prompt}],
+            tokenize=True,
+            add_generation_prompt=True,
+            return_dict=False,
+        )
+        token_ids = prompt_ids + tokenizer.encode(completion, add_special_tokens=False) + [tokenizer.eos_token_id]
+        if len(token_ids) <= seq_length:
+            raise ValueError(f"SFT conversation produced only {len(token_ids)} tokens for seq_length={seq_length}")
+        window = token_ids[: seq_length + 1]
+        input_ids = window[:-1]
+        labels = window[1:]
+        for label_index in range(min(len(prompt_ids) - 1, len(labels))):
+            labels[label_index] = -100
+        sample = {"input_ids": input_ids, "labels": labels, "attention_mask": [1] * len(input_ids)}
+        self.samples = [{key: list(value) for key, value in sample.items()} for _ in range(num_samples)]
+
+    def __getitem__(self, index: int) -> dict[str, list[int]]:
+        return self.samples[index]
+
+    def __len__(self) -> int:
+        return len(self.samples)
+
+
 def make_tiny_kd_dataset(
     tokenizer=None,
     num_samples: int = 16,
@@ -93,6 +138,37 @@ def make_tiny_kd_dataset(
         seq_length=seq_length,
         repeat_first_sample=repeat_first_sample,
         use_chat_template=use_chat_template,
+    )
+
+
+def make_tiny_kd_sft_dataset(
+    tokenizer: PreTrainedTokenizerBase | None = None,
+    *,
+    prompt: str,
+    completion: str,
+    num_samples: int = 16,
+    seq_length: int = 32,
+) -> TinyKDSFTDataset:
+    """Build a deterministic assistant-supervised chat dataset.
+
+    Args:
+        tokenizer: Tokenizer whose chat template renders the conversation.
+        prompt: User turn text.
+        completion: Assistant turn text.
+        num_samples: Number of identical samples to expose.
+        seq_length: Shifted next-token sequence length.
+
+    Returns:
+        Dataset containing repeated, assistant-supervised chat samples.
+    """
+    if tokenizer is None:
+        raise ValueError("TinyKDSFTDataset requires a tokenizer")
+    return TinyKDSFTDataset(
+        tokenizer=tokenizer,
+        prompt=prompt,
+        completion=completion,
+        num_samples=num_samples,
+        seq_length=seq_length,
     )
 
 

--- a/tests/functional_tests/llm_pretrain_and_kd/kd_separate_mesh_test_utils.py
+++ b/tests/functional_tests/llm_pretrain_and_kd/kd_separate_mesh_test_utils.py
@@ -22,13 +22,31 @@ from torch.utils.data import Dataset
 
 
 class TinyKDDataset(Dataset):
-    """Small deterministic next-token dataset."""
+    """Small deterministic next-token dataset built from natural text."""
 
-    def __init__(self, num_samples: int = 16, seq_length: int = 8):
+    def __init__(self, tokenizer, num_samples: int = 16, seq_length: int = 8, repeat_first_sample: bool = False):
+        corpus = (
+            "Knowledge distillation trains a compact student model to reproduce useful behavior from a larger "
+            "teacher model. The student reads ordinary text, predicts the next token, and learns from both the "
+            "ground truth and the teacher distribution. Distributed training can place the student and teacher "
+            "on separate device meshes while preserving the mathematical objective. This test uses deterministic "
+            "language about software engineering, scientific computing, and reliable validation so that pretrained "
+            "language models receive realistic token sequences instead of arbitrary vocabulary identifiers. Careful "
+            "experiments compare every logged loss component across tensor, pipeline, and expert parallel layouts. "
+            "When numerical differences appear, the run is repeated with controlled seeds and controlled precision until "
+            "the source of the discrepancy is understood. Reproducible tests record model versions, cluster topology, "
+            "container images, and exact metrics so another engineer can independently verify the result."
+        )
+        token_ids = tokenizer.encode(corpus, add_special_tokens=True)
+        if len(token_ids) <= seq_length:
+            raise ValueError(f"Natural-text fixture produced only {len(token_ids)} tokens for seq_length={seq_length}")
+
         self.samples = []
         for sample_index in range(num_samples):
-            input_ids = [3 + (sample_index + position) % 24 for position in range(seq_length)]
-            labels = input_ids[1:] + [2]
+            start = 0 if repeat_first_sample else (sample_index * seq_length) % (len(token_ids) - seq_length)
+            window = token_ids[start : start + seq_length + 1]
+            input_ids = window[:-1]
+            labels = window[1:]
             labels[0] = -100
             self.samples.append({"input_ids": input_ids, "labels": labels})
 
@@ -39,10 +57,18 @@ class TinyKDDataset(Dataset):
         return len(self.samples)
 
 
-def make_tiny_kd_dataset(tokenizer=None, num_samples: int = 16, seq_length: int = 8) -> TinyKDDataset:
-    """Build the deterministic test dataset; ``tokenizer`` verifies recipe injection."""
-    del tokenizer
-    return TinyKDDataset(num_samples=num_samples, seq_length=seq_length)
+def make_tiny_kd_dataset(
+    tokenizer=None, num_samples: int = 16, seq_length: int = 8, repeat_first_sample: bool = False
+) -> TinyKDDataset:
+    """Build the deterministic tokenizer-encoded test dataset."""
+    if tokenizer is None:
+        raise ValueError("TinyKDDataset requires a tokenizer")
+    return TinyKDDataset(
+        tokenizer=tokenizer,
+        num_samples=num_samples,
+        seq_length=seq_length,
+        repeat_first_sample=repeat_first_sample,
+    )
 
 
 def create_tiny_llama_assets(output_dir: str | pathlib.Path) -> None:

--- a/tests/functional_tests/llm_pretrain_and_kd/run_kd_separate_meshes.py
+++ b/tests/functional_tests/llm_pretrain_and_kd/run_kd_separate_meshes.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import json
-import os
 
 import torch
 import torch.distributed as dist
@@ -27,24 +26,19 @@ from nemo_automodel.recipes.kd_utils import RUN_TEACHER, KDMeshBridge, create_kd
 
 
 def _teacher_logits(input_ids: torch.Tensor) -> torch.Tensor:
+    """Return deterministic logits ``[B, S, V=3]`` for ids ``[B, S]``."""
     values = input_ids.float()
     return torch.stack((values * 0.5, values * -0.25 + 1.0, values * 0.125 - 0.5), dim=-1)
 
 
 def main() -> None:
-    backend = "nccl" if torch.cuda.is_available() else "gloo"
-    dist.init_process_group(backend=backend)
+    dist.init_process_group(backend="gloo")
     rank = dist.get_rank()
     world_size = dist.get_world_size()
     if world_size != 4:
         raise ValueError(f"This smoke test requires 4 ranks, got {world_size}")
 
-    if backend == "nccl":
-        local_rank = int(os.environ["LOCAL_RANK"])
-        torch.cuda.set_device(local_rank)
-        device = torch.device("cuda", local_rank)
-    else:
-        device = torch.device("cpu")
+    device = torch.device("cpu")
 
     cfg = {
         "separate_meshes": True,

--- a/tests/functional_tests/llm_pretrain_and_kd/run_kd_separate_meshes.py
+++ b/tests/functional_tests/llm_pretrain_and_kd/run_kd_separate_meshes.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Four-rank correctness smoke for KD meshes with different parallelism."""
+
+from __future__ import annotations
+
+import json
+import os
+
+import torch
+import torch.distributed as dist
+
+from nemo_automodel.components.loss.kd_loss import KDLoss
+from nemo_automodel.recipes.kd_utils import RUN_TEACHER, KDMeshBridge, create_kd_distributed_setups
+
+
+def _teacher_logits(input_ids: torch.Tensor) -> torch.Tensor:
+    values = input_ids.float()
+    return torch.stack((values * 0.5, values * -0.25 + 1.0, values * 0.125 - 0.5), dim=-1)
+
+
+def main() -> None:
+    backend = "nccl" if torch.cuda.is_available() else "gloo"
+    dist.init_process_group(backend=backend)
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    if world_size != 4:
+        raise ValueError(f"This smoke test requires 4 ranks, got {world_size}")
+
+    if backend == "nccl":
+        local_rank = int(os.environ["LOCAL_RANK"])
+        torch.cuda.set_device(local_rank)
+        device = torch.device("cuda", local_rank)
+    else:
+        device = torch.device("cpu")
+
+    cfg = {
+        "separate_meshes": True,
+        "distributed": {
+            "strategy": "fsdp2",
+            "dp_size": 2,
+            "tp_size": 1,
+            "cp_size": 1,
+            "pp_size": 1,
+        },
+        "teacher_distributed": {
+            "strategy": "fsdp2",
+            "dp_size": 1,
+            "tp_size": 2,
+            "cp_size": 1,
+            "pp_size": 1,
+        },
+    }
+    setups = create_kd_distributed_setups(cfg, world_size=world_size)
+    bridge = KDMeshBridge(setups, device=device)
+
+    batch = None
+    if bridge.is_student:
+        input_ids = torch.tensor([[rank + 1, rank + 2]], dtype=torch.long, device=device)
+        batch = {"input_ids": input_ids, "labels": input_ids.clone()}
+
+    bridge.broadcast_command(RUN_TEACHER if bridge.is_student else None)
+    received_teacher_logits = None
+    for wave in range(bridge.num_waves):
+        teacher_batch = bridge.send_batch(wave, batch)
+        logits = _teacher_logits(teacher_batch["input_ids"]) if bridge.is_teacher else None
+        received = bridge.send_logits(wave, logits)
+        if received is not None:
+            received_teacher_logits = received
+
+    local_result = None
+    if bridge.is_student:
+        assert received_teacher_logits is not None
+        expected = _teacher_logits(batch["input_ids"])
+        torch.testing.assert_close(received_teacher_logits, expected)
+        scale = torch.tensor(0.75, device=device, requires_grad=True)
+        student_logits = expected.detach() * scale
+        loss = KDLoss()(student_logits, received_teacher_logits, batch["labels"])
+        loss.backward()
+        if not torch.isfinite(loss) or scale.grad is None or not torch.isfinite(scale.grad):
+            raise AssertionError(f"Non-finite KD result on rank {rank}: loss={loss}, grad={scale.grad}")
+        local_result = {"rank": rank, "loss": loss.item(), "grad": scale.grad.item()}
+
+    gathered = [None] * world_size
+    dist.all_gather_object(gathered, local_result)
+    if rank == 0:
+        student_results = [item for item in gathered if item is not None]
+        assert len(student_results) == 2
+        print(
+            "KD_SEPARATE_MESH_RESULT "
+            + json.dumps(
+                {
+                    "pass": True,
+                    "student_ranks": list(setups.student_ranks),
+                    "teacher_ranks": list(setups.teacher_ranks),
+                    "student_dp": 2,
+                    "teacher_tp": 2,
+                    "results": student_results,
+                },
+                sort_keys=True,
+            ),
+            flush=True,
+        )
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/functional_tests/llm_pretrain_and_kd/run_kd_separate_meshes.py
+++ b/tests/functional_tests/llm_pretrain_and_kd/run_kd_separate_meshes.py
@@ -26,7 +26,15 @@ from nemo_automodel.recipes.kd_utils import RUN_TEACHER, KDMeshBridge, create_kd
 
 
 def _teacher_logits(input_ids: torch.Tensor) -> torch.Tensor:
-    """Return deterministic logits ``[B, S, V=3]`` for ids ``[B, S]``."""
+    """Return deterministic teacher logits.
+
+    Args:
+        input_ids: Tensor of shape ``[batch, sequence]`` containing token ids.
+
+    Returns:
+        Tensor of shape ``[batch, sequence, vocab]`` containing logits with
+        ``vocab = 3``.
+    """
     values = input_ids.float()
     return torch.stack((values * 0.5, values * -0.25 + 1.0, values * 0.125 - 0.5), dim=-1)
 

--- a/tests/unit_tests/_transformers/test_model_capabilities.py
+++ b/tests/unit_tests/_transformers/test_model_capabilities.py
@@ -130,6 +130,12 @@ def test_gemma4_dynamic_class_blocks_static_access():
         cls.ModelCapabilities  # noqa: B018  -- attribute access is the test
 
 
+def test_llama_declares_context_parallel_support():
+    """The shipped Llama CP KD example requires the static capability flag."""
+    cls = ModelRegistry.get_model_cls_from_model_arch("LlamaForCausalLM")
+    assert cls.ModelCapabilities().supports_cp is True
+
+
 # ---------------------------------------------------------------------------
 # 3. query_capabilities canonical-type & dispatch behavior
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/_transformers/test_model_init.py
+++ b/tests/unit_tests/_transformers/test_model_init.py
@@ -26,6 +26,7 @@ from nemo_automodel._transformers.model_init import (
     _has_safetensors,
     _init_model,
     _load_config_with_layer_types_fix,
+    _prepopulate_remote_code_cache,
     _propagate_torch_dtype_to_subconfigs,
     _resolve_model_dir,
     _setup_bnb_loading_kwargs,
@@ -203,6 +204,23 @@ class TestBackendDictCoercion:
         assert "_process_group" not in captured
         assert mock_download.call_args.args[1] == "fake/model"
         assert mock_download.call_args.kwargs == {"process_group": process_group}
+
+
+def test_remote_code_cache_serialization_uses_model_process_group(tmp_path):
+    model_dir = tmp_path / "remote_model"
+    model_dir.mkdir()
+    (model_dir / "modeling_remote.py").write_text("class RemoteModel: pass\n")
+    config = MagicMock(auto_map={"AutoModel": "modeling_remote.RemoteModel"})
+    process_group = object()
+
+    with (
+        patch("nemo_automodel._transformers.model_init.dist_utils.FirstRankPerNode") as first_rank,
+        patch("transformers.dynamic_module_utils.get_cached_module_file", return_value="remote/modeling_remote.py"),
+    ):
+        first_rank.return_value.__enter__.return_value = True
+        _prepopulate_remote_code_cache(config, str(model_dir), {}, process_group=process_group)
+
+    first_rank.assert_called_once_with(group=process_group)
 
 
 class TestGetHfConfigNestedKwargs:

--- a/tests/unit_tests/_transformers/test_model_init.py
+++ b/tests/unit_tests/_transformers/test_model_init.py
@@ -193,6 +193,17 @@ class TestBackendDictCoercion:
 
         assert "backend" not in captured
 
+    @patch("nemo_automodel._transformers.model_init._download_model_weights")
+    @patch("nemo_automodel._transformers.model_init._resolve_custom_model_cls_for_config")
+    def test_process_group_is_forwarded_only_to_weight_download(self, mock_resolve_cls, mock_download):
+        process_group = object()
+
+        captured = self._run_init_model(mock_resolve_cls, _process_group=process_group)
+
+        assert "_process_group" not in captured
+        assert mock_download.call_args.args[1] == "fake/model"
+        assert mock_download.call_args.kwargs == {"process_group": process_group}
+
 
 class TestGetHfConfigNestedKwargs:
     """get_hf_config should filter nested dict kwargs from AutoConfig.from_pretrained."""

--- a/tests/unit_tests/checkpoint/test_addons.py
+++ b/tests/unit_tests/checkpoint/test_addons.py
@@ -13,16 +13,39 @@
 # limitations under the License.
 
 import os
+from unittest.mock import patch
 
 import torch
 from torch import nn
 
 from nemo_automodel.components.checkpoint.addons import (
     _extract_target_modules,
+    _group_barrier,
+    _is_group_rank_0,
     _maybe_save_custom_model_code,
     _maybe_strip_quantization_config,
 )
 from nemo_automodel.components.checkpoint.stateful_wrappers import ModelState
+
+
+def test_group_barrier_uses_model_process_group():
+    group = object()
+    with (
+        patch("nemo_automodel.components.checkpoint.addons.torch.distributed.is_initialized", return_value=True),
+        patch("nemo_automodel.components.checkpoint.addons.torch.distributed.barrier") as barrier,
+    ):
+        _group_barrier(group)
+    barrier.assert_called_once_with(group=group)
+
+
+def test_group_rank_zero_is_relative_to_model_process_group():
+    group = object()
+    with (
+        patch("nemo_automodel.components.checkpoint.addons.torch.distributed.is_initialized", return_value=True),
+        patch("nemo_automodel.components.checkpoint.addons.torch.distributed.get_rank", return_value=0) as get_rank,
+    ):
+        assert _is_group_rank_0(group)
+    get_rank.assert_called_once_with(group=group)
 
 
 def _write(path: str, content: str) -> None:
@@ -131,6 +154,24 @@ def test_model_state_drops_lm_head_when_storage_shared():
     state_dict = state.state_dict()
     assert "lm_head.weight" not in state_dict  # dropped because storage is shared
     assert "model.embed_tokens.weight" in state_dict
+
+
+def test_peft_model_state_can_skip_default_group_broadcast():
+    """Subset-mesh ranks already load PEFT state and must not broadcast globally."""
+
+    class _DummyConfig:
+        tie_word_embeddings = False
+
+    model = nn.Linear(2, 2)
+    model.config = _DummyConfig()
+    state = ModelState(model, is_peft=True)
+
+    with patch("nemo_automodel.components.checkpoint.stateful_wrappers.set_model_state_dict") as set_state:
+        state.load_state_dict({}, strict=False, broadcast_from_rank0=False)
+
+    options = set_state.call_args.kwargs["options"]
+    assert options.full_state_dict is True
+    assert options.broadcast_from_rank0 is False
 
 
 # _extract_target_modules tests

--- a/tests/unit_tests/checkpoint/test_checkpointing.py
+++ b/tests/unit_tests/checkpoint/test_checkpointing.py
@@ -2386,6 +2386,7 @@ def _make_ckptr(is_peft=False, is_async=False):
     ckptr.config = config
     ckptr._model_ctx = MagicMock(staging_active=False)
     ckptr._optim_ctx = MagicMock(staging_active=False)
+    ckptr.process_group = None
     return ckptr
 
 
@@ -2431,6 +2432,15 @@ class TestEnsureDirs:
         with patch("os.makedirs") as mock_makedirs:
             _ensure_dirs(target)
         mock_makedirs.assert_called_once_with(target, exist_ok=True)
+
+    def test_distributed_barrier_uses_process_group(self, tmp_path):
+        group = object()
+        with (
+            patch("torch.distributed.is_initialized", return_value=True),
+            patch("torch.distributed.barrier") as barrier,
+        ):
+            _ensure_dirs(str(tmp_path), process_group=group)
+        barrier.assert_called_once_with(group=group)
 
 
 class TestSaveConfig:
@@ -3121,6 +3131,7 @@ class TestSyncAsyncSave:
         ckptr.config = config
         ckptr._model_ctx = MagicMock(staging_active=False)
         ckptr._optim_ctx = MagicMock(staging_active=False)
+        ckptr.process_group = None
         return ckptr
 
     def test_dcp_cloud_sync_calls_dcp_save(self):
@@ -3273,6 +3284,31 @@ class TestSyncAsyncSave:
 
         mock_dcp.save.assert_called_once()
         mock_dcp.async_save.assert_not_called()
+
+    def test_local_sync_passes_model_process_group(self):
+        ckptr = self._make_ckptr(is_async=False)
+        ckptr.process_group = object()
+        sd = {"w": torch.ones(4)}
+
+        with patch("nemo_automodel.components.checkpoint.checkpointing.dcp") as mock_dcp:
+            Checkpointer._do_save(ckptr, sd, "/tmp/step-100/optim")
+
+        assert mock_dcp.save.call_args.kwargs["process_group"] is ckptr.process_group
+
+    def test_peft_sync_barrier_uses_model_process_group(self):
+        ckptr = self._make_ckptr(is_async=False, is_peft=True)
+        ckptr.process_group = object()
+        sd = {"w": torch.ones(4)}
+
+        with (
+            patch("torch.distributed.is_initialized", return_value=True),
+            patch("torch.distributed.get_rank", return_value=0),
+            patch("torch.distributed.barrier") as barrier,
+            patch("nemo_automodel.components.checkpoint.checkpointing._save_safetensors"),
+        ):
+            Checkpointer._do_save(ckptr, sd, "/tmp/step-100/model")
+
+        barrier.assert_called_once_with(group=ckptr.process_group)
 
     def test_local_async_calls_dcp_async_save(self):
         """Local + async: dcp.async_save called, dcp.save NOT called."""

--- a/tests/unit_tests/checkpoint/test_checkpointing.py
+++ b/tests/unit_tests/checkpoint/test_checkpointing.py
@@ -45,6 +45,7 @@ from nemo_automodel.components.checkpoint.checkpointing import (
     _equally_divide_layers,
     _is_custom_model,
     _model_has_dtensors,
+    _new_gloo_process_group,
     _normalize_dtype_mapping_to_state_dict_keys,
     _reinit_non_persistent_buffers,
     _should_write_consolidated_safetensors,
@@ -62,6 +63,21 @@ from nemo_automodel.components.checkpoint.utils import (
 CLOUD_PATH_MODEL = "msc://bucket/step-100/model"
 CLOUD_PATH_OPTIM = "msc://bucket/step-100/optim"
 LOCAL_PATH_MODEL = "/ckpts/step-100/model"
+
+
+def test_new_gloo_process_group_preserves_subset_membership():
+    """Async checkpoint groups use only the supplied model-process ranks."""
+    model_group = object()
+    gloo_group = object()
+    with (
+        patch("torch.distributed.get_process_group_ranks", return_value=[2, 3]) as get_ranks,
+        patch("torch.distributed.new_group", return_value=gloo_group) as new_group,
+    ):
+        result = _new_gloo_process_group(model_group)
+
+    assert result is gloo_group
+    get_ranks.assert_called_once_with(model_group)
+    new_group.assert_called_once_with(ranks=[2, 3], backend="gloo", use_local_synchronization=True)
 
 
 def _make_keys(count: int) -> list[str]:

--- a/tests/unit_tests/distributed/test_cp_utils_inputs_embeds.py
+++ b/tests/unit_tests/distributed/test_cp_utils_inputs_embeds.py
@@ -481,6 +481,33 @@ def test_padding_handles_loss_mask_and_padding_mask(monkeypatch):
         assert buf.shape[1] == expected, f"cp_buffers[{i}] not padded to {expected}: shape={tuple(buf.shape)}"
 
 
+def test_extra_sequence_buffer_is_padded_and_registered(monkeypatch):
+    """Teacher logits ``[B, S, V]`` follow labels through CP padding/sharding."""
+    captured = {}
+
+    def _fake_create_ctx(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(_cu, "create_context_parallel_ctx", _fake_create_ctx)
+    monkeypatch.setattr(_cu, "get_train_context", lambda *a, **kw: "ctx")
+
+    device_mesh = _DummyDeviceMesh(cp_size=2, tp_size=1)
+    teacher_logits = torch.randn(1, 6, 5)
+    batch = {
+        "input_ids": torch.arange(6).unsqueeze(0),
+        "labels": torch.arange(6).unsqueeze(0),
+        "teacher_logits": teacher_logits,
+    }
+
+    _cu.make_cp_batch_and_ctx(device_mesh, batch, extra_seq_buffers={"teacher_logits": 1})
+
+    assert captured["cp_seq_dims"] == [1, 1, 1, 1]
+    assert batch["teacher_logits"].shape == (1, 8, 5)
+    torch.testing.assert_close(batch["teacher_logits"][:, :6], teacher_logits)
+    assert torch.count_nonzero(batch["teacher_logits"][:, 6:]) == 0
+
+
 def test_padding_mask_pad_value_is_True_not_False(monkeypatch):
     """Regression: cp-divisor padding extends the seq with positions that are
     semantically padding.  ``padding_mask`` (bool, ``True`` == "this position

--- a/tests/unit_tests/distributed/test_mesh_utils.py
+++ b/tests/unit_tests/distributed/test_mesh_utils.py
@@ -148,7 +148,9 @@ def test_fsdp2_forwards_nccl_timeout_to_moe_mesh(monkeypatch):
         device_mesh,
         ep_shard_size=4,
         ep_size=2,
+        pp_size=1,
         timeout_minutes=30,
+        ranks=None,
     )
 
 

--- a/tests/unit_tests/distributed/test_utils.py
+++ b/tests/unit_tests/distributed/test_utils.py
@@ -109,6 +109,17 @@ def test_first_rank_per_node_uses_explicit_process_group(monkeypatch, patch_dist
     assert seen_groups == [group, group]
 
 
+def test_barrier_with_timeout_reuses_explicit_process_group(monkeypatch, patch_dist):
+    group = object()
+    seen_groups = []
+    monkeypatch.setattr(du.dist, "get_world_size", lambda group=None: 2, raising=False)
+    monkeypatch.setattr(du.dist, "barrier", lambda group=None: seen_groups.append(group), raising=False)
+    monkeypatch.setattr(du, "_create_gloo_group", lambda: pytest.fail("unexpected Gloo group"))
+
+    assert du._barrier_with_timeout(timeout=du.timedelta(seconds=1), group=group)
+    assert seen_groups == [group]
+
+
 def test_reduce_loss_no_dp(monkeypatch):
     """
     With dp_group=None the routine must simply sum the supplied tensors and

--- a/tests/unit_tests/distributed/test_utils.py
+++ b/tests/unit_tests/distributed/test_utils.py
@@ -14,8 +14,6 @@
 
 from __future__ import annotations
 
-import os
-from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -80,7 +78,6 @@ def patch_dist(monkeypatch):
     yield fake
 
 
-
 def test_first_rank_per_node_single_gpu(monkeypatch, patch_dist):
     """
     In the absence of a distributed init the context manager should behave like
@@ -93,6 +90,23 @@ def test_first_rank_per_node_single_gpu(monkeypatch, patch_dist):
     with du.FirstRankPerNode() as is_first:
         assert is_first is True
 
+
+def test_first_rank_per_node_uses_explicit_process_group(monkeypatch, patch_dist):
+    group = object()
+    seen_groups = []
+    monkeypatch.setattr(du.dist, "get_world_size", lambda group=None: 2, raising=False)
+
+    def get_rank(group=None):
+        seen_groups.append(group)
+        return 0
+
+    monkeypatch.setattr(du.dist, "get_rank", get_rank, raising=False)
+    monkeypatch.setattr(du, "_barrier_with_timeout", lambda timeout, group=None: seen_groups.append(group) or True)
+
+    with du.FirstRankPerNode(group=group) as is_first:
+        assert is_first is True
+
+    assert seen_groups == [group, group]
 
 
 def test_reduce_loss_no_dp(monkeypatch):

--- a/tests/unit_tests/loss/test_kd_loss.py
+++ b/tests/unit_tests/loss/test_kd_loss.py
@@ -20,6 +20,7 @@ from typing import Optional
 
 import pytest
 import torch
+import torch.multiprocessing as mp
 import torch.nn.functional as F
 
 from nemo_automodel.components.loss.kd_loss import (
@@ -30,7 +31,7 @@ from nemo_automodel.components.loss.kd_loss import (
 )
 
 # ---------------------------------------------------------------------------
-# Reference implementation (no TP, no T² scaling applied yet)
+# Reference implementation
 # ---------------------------------------------------------------------------
 
 
@@ -42,7 +43,22 @@ def _reference_kd_loss(
     temperature: float = 1.0,
     num_batch_labels: Optional[int] = None,
 ) -> torch.Tensor:
-    """Standalone implementation mirroring :pyfunc:`KDLoss.forward`."""
+    """Compute a trusted forward-KL reference.
+
+    Args:
+        student_logits: Tensor of shape ``[..., vocab]`` containing student
+            logits with arbitrary leading dimensions.
+        teacher_logits: Tensor of shape ``[..., vocab]`` containing teacher
+            logits with the same shape, dtype, and device.
+        labels: Tensor of shape ``[...]`` matching the logits' leading
+            dimensions.
+        ignore_index: Label value excluded from the loss.
+        temperature: Softmax temperature.
+        num_batch_labels: Optional denominator for valid-token accumulation.
+
+    Returns:
+        Scalar tensor containing zero-based forward KL.
+    """
     valid_mask = (labels != ignore_index).view(-1)
     s_logits = student_logits.view(-1, student_logits.size(-1))[valid_mask]
     t_logits = teacher_logits.view(-1, teacher_logits.size(-1))[valid_mask]
@@ -51,12 +67,12 @@ def _reference_kd_loss(
         s_logits = s_logits / temperature
         t_logits = t_logits / temperature
 
-    teacher_prob = F.softmax(t_logits, dim=-1, dtype=torch.float32)
+    teacher_logprob = F.log_softmax(t_logits, dim=-1, dtype=torch.float32)
     student_logprob = F.log_softmax(s_logits, dim=-1, dtype=torch.float32)
 
     # T² scaling (Hinton et al., 2015)
     scale = temperature**2
-    kl_per_token = -(teacher_prob * student_logprob).sum(-1) * scale  # shape: [n_valid]
+    kl_per_token = F.kl_div(student_logprob, teacher_logprob, reduction="none", log_target=True).sum(-1) * scale
 
     if num_batch_labels is not None:
         return kl_per_token.sum() / num_batch_labels
@@ -118,6 +134,36 @@ def test_kd_loss_num_labels():
     ref = _reference_kd_loss(student_logits, teacher_logits, labels, num_batch_labels=num_labels)
 
     assert torch.allclose(loss, ref, atol=1e-6), f"Expected {ref}, got {loss}"
+
+
+def test_kd_loss_identical_logits_is_zero():
+    logits = torch.randn(4, 16)
+    labels = torch.arange(4)
+
+    loss = KDLoss()(logits, logits, labels)
+
+    torch.testing.assert_close(loss, torch.tensor(0.0), atol=1e-7, rtol=0.0)
+
+
+@pytest.mark.parametrize("temperature", [1.0, 2.5])
+def test_kd_loss_removes_teacher_entropy_without_changing_student_gradient(temperature):
+    torch.manual_seed(17)
+    teacher_logits = torch.randn(5, 11)
+    labels = torch.arange(5)
+    student_for_kl = torch.randn(5, 11, requires_grad=True)
+    student_for_ce = student_for_kl.detach().clone().requires_grad_(True)
+
+    kl_loss = KDLoss(temperature=temperature)(student_for_kl, teacher_logits, labels)
+    scaled_teacher = teacher_logits / temperature
+    scaled_student = student_for_ce / temperature
+    teacher_prob = F.softmax(scaled_teacher, dim=-1)
+    teacher_entropy = -(teacher_prob * F.log_softmax(scaled_teacher, dim=-1)).sum(-1).mean() * temperature**2
+    soft_target_ce = -(teacher_prob * F.log_softmax(scaled_student, dim=-1)).sum(-1).mean() * temperature**2
+
+    torch.testing.assert_close(soft_target_ce, kl_loss.detach() + teacher_entropy)
+    kl_loss.backward()
+    soft_target_ce.backward()
+    torch.testing.assert_close(student_for_kl.grad, student_for_ce.grad)
 
 
 # ---------------------------------------------------------------------------
@@ -420,9 +466,9 @@ def test_kl_forward_chunked_matches_full():
     t_logits = torch.randn(8, 16, dtype=torch.float32)
     s_logits = torch.randn(8, 16, dtype=torch.float32)
 
-    teacher_prob = F.softmax(t_logits, dim=-1)
+    teacher_logprob = F.log_softmax(t_logits, dim=-1)
     student_logprob = F.log_softmax(s_logits, dim=-1)
-    ref = (teacher_prob * student_logprob).sum(-1)
+    ref = F.kl_div(student_logprob, teacher_logprob, reduction="none", log_target=True).sum(-1)
 
     chunked = _kl_forward_chunked(t_logits, s_logits, chunk_size=3)
 
@@ -554,9 +600,9 @@ def test_kl_forward_tp_matches_non_tp(trivial_pg):
     s_logits = torch.randn(6, 16, dtype=torch.float32)
 
     # Non-TP reference
-    teacher_prob = F.softmax(t_logits, dim=-1)
+    teacher_logprob = F.log_softmax(t_logits, dim=-1)
     student_logprob = F.log_softmax(s_logits, dim=-1)
-    ref = (teacher_prob * student_logprob).sum(-1)  # negative CE per token
+    ref = F.kl_div(student_logprob, teacher_logprob, reduction="none", log_target=True).sum(-1)
 
     tp_out = _kl_forward_tp(t_logits, s_logits, trivial_pg)
 
@@ -592,3 +638,31 @@ def test_kd_loss_tp_path_with_temperature(trivial_pg):
     assert torch.allclose(loss_no_tp, loss_tp, atol=1e-5), (
         f"Non-TP loss {loss_no_tp.item():.6f} != TP loss {loss_tp.item():.6f}"
     )
+
+
+def _run_two_process_tp_kl(rank: int, init_file: str) -> None:
+    torch.distributed.init_process_group(
+        backend="gloo",
+        init_method=f"file://{init_file}",
+        rank=rank,
+        world_size=2,
+    )
+    try:
+        torch.manual_seed(29)
+        teacher_logits = torch.randn(6, 16)
+        student_logits = torch.randn(6, 16)
+        local_teacher = teacher_logits.chunk(2, dim=-1)[rank].contiguous()
+        local_student = student_logits.chunk(2, dim=-1)[rank].contiguous()
+
+        actual = _kl_forward_tp(local_teacher, local_student, torch.distributed.group.WORLD)
+        teacher_logprob = F.log_softmax(teacher_logits, dim=-1)
+        student_logprob = F.log_softmax(student_logits, dim=-1)
+        expected = F.kl_div(student_logprob, teacher_logprob, reduction="none", log_target=True).sum(-1)
+
+        torch.testing.assert_close(actual, expected, atol=1e-6, rtol=1e-5)
+    finally:
+        torch.distributed.destroy_process_group()
+
+
+def test_kl_forward_tp_two_process_matches_full_vocab(tmp_path):
+    mp.spawn(_run_two_process_tp_kl, args=(str(tmp_path / "tp_kl"),), nprocs=2, join=True)

--- a/tests/unit_tests/models/gemma4/test_gemma4_model.py
+++ b/tests/unit_tests/models/gemma4/test_gemma4_model.py
@@ -27,6 +27,7 @@ from nemo_automodel.components.models.gemma4_moe.model import (
     Gemma4MoEModel,
     Gemma4MoETextModelBackend,
     _build_packed_gemma4_causal_mask_mapping,
+    _build_unpacked_gemma4_causal_mask_mapping,
     _derive_padding_mask,
 )
 from nemo_automodel.components.moe.config import MoEConfig
@@ -505,6 +506,29 @@ class TestPackedGemma4MaskMapping:
         assert not sliding_allowed[0, 0, 3, 0]
         assert not sliding_allowed[0, 0, 5, 1]
         assert not sliding_allowed[0, 0, 7, 7]
+
+    def test_unpacked_mask_uses_legacy_mapping_when_available(self, monkeypatch):
+        from transformers.models.gemma4 import modeling_gemma4
+
+        expected = {"full_attention": object(), "sliding_attention": object()}
+        legacy_mapping = MagicMock(return_value=expected)
+        monkeypatch.setattr(modeling_gemma4, "create_causal_mask_mapping", legacy_mapping, raising=False)
+        inputs_embeds = torch.zeros(1, 4, 8)
+        mm_token_type_ids = torch.zeros(1, 4, dtype=torch.long)
+
+        actual = _build_unpacked_gemma4_causal_mask_mapping(
+            MagicMock(),
+            inputs_embeds,
+            None,
+            None,
+            None,
+            mm_token_type_ids,
+            None,
+            is_training=False,
+        )
+
+        assert actual is expected
+        assert legacy_mapping.call_args.kwargs["mm_token_type_ids"] is mm_token_type_ids
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/models/gemma4/test_gemma4_model.py
+++ b/tests/unit_tests/models/gemma4/test_gemma4_model.py
@@ -530,6 +530,36 @@ class TestPackedGemma4MaskMapping:
         assert actual is expected
         assert legacy_mapping.call_args.kwargs["mm_token_type_ids"] is mm_token_type_ids
 
+    def test_unpacked_mask_uses_block_ids_when_legacy_mapping_is_unavailable(self, monkeypatch):
+        from transformers import masking_utils
+        from transformers.models.gemma4 import modeling_gemma4
+
+        full_mask = torch.ones(1, 1, 4, 4, dtype=torch.bool)
+        sliding_mask = torch.zeros(1, 1, 4, 4, dtype=torch.bool)
+        create_full = MagicMock(return_value=full_mask)
+        create_sliding = MagicMock(return_value=sliding_mask)
+        monkeypatch.setattr(modeling_gemma4, "create_causal_mask_mapping", None, raising=False)
+        monkeypatch.setattr(masking_utils, "create_causal_mask", create_full)
+        monkeypatch.setattr(masking_utils, "create_sliding_window_causal_mask", create_sliding)
+        inputs_embeds = torch.zeros(1, 4, 8)
+        mm_token_type_ids = torch.tensor([[0, 1, 1, 0]])
+
+        actual = _build_unpacked_gemma4_causal_mask_mapping(
+            MagicMock(),
+            inputs_embeds,
+            None,
+            None,
+            None,
+            mm_token_type_ids,
+            None,
+            is_training=False,
+        )
+
+        assert actual == {"full_attention": full_mask, "sliding_attention": sliding_mask}
+        expected_block_ids = torch.tensor([[-1, 0, 0, -1]])
+        torch.testing.assert_close(create_full.call_args.kwargs["block_sequence_ids"], expected_block_ids)
+        torch.testing.assert_close(create_sliding.call_args.kwargs["block_sequence_ids"], expected_block_ids)
+
 
 # ---------------------------------------------------------------------------
 # Gemma4ForConditionalGeneration tests

--- a/tests/unit_tests/models/gemma4/test_gemma4_state_dict_adapter.py
+++ b/tests/unit_tests/models/gemma4/test_gemma4_state_dict_adapter.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 import torch
@@ -238,6 +238,22 @@ class TestFromHf:
             assert f"model.language_model.layers.{layer_idx}.moe.experts.down_projs" in nemo_sd
             assert f"model.language_model.layers.{layer_idx}.moe.gate.proj.weight" in nemo_sd
             assert f"model.language_model.layers.{layer_idx}.moe.gate.scale" in nemo_sd
+
+
+class TestStateDictKeys:
+    pytestmark = []
+
+    def test_uses_meta_tensors(self, adapter):
+        state_dict = {
+            "model.language_model.layers.0.moe.experts.down_projs": torch.empty(N_EXPERTS, EXPERT_INTER, HIDDEN)
+        }
+
+        with patch.object(adapter, "to_hf", wraps=adapter.to_hf) as to_hf:
+            keys = adapter.get_hf_state_dict_keys(state_dict)
+
+        assert to_hf.call_args.args[0]["model.language_model.layers.0.moe.experts.down_projs"].device.type == "meta"
+        assert "model.language_model.layers.0.experts.down_proj" in keys
+        assert "model.language_model.layers.0.router.per_expert_scale" in keys
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/recipes/test_kd_separate_mesh_recipe_helpers.py
+++ b/tests/unit_tests/recipes/test_kd_separate_mesh_recipe_helpers.py
@@ -1,0 +1,228 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from nemo_automodel.recipes.llm import kd as llm_kd
+from nemo_automodel.recipes.vlm import kd as vlm_kd
+
+
+class _Cfg:
+    def __init__(self, **values):
+        self._values = values
+
+    def get(self, key, default=None):
+        return self._values.get(key, default)
+
+
+class _Teacher(nn.Module):
+    def forward(self, input_ids):
+        return SimpleNamespace(logits=torch.nn.functional.one_hot(input_ids, num_classes=4).float())
+
+
+_RECIPE_CASES = (
+    pytest.param(
+        llm_kd,
+        llm_kd.KnowledgeDistillationRecipeForNextTokenPrediction,
+        llm_kd.TrainFinetuneRecipeForNextTokenPrediction,
+        id="llm",
+    ),
+    pytest.param(
+        vlm_kd,
+        vlm_kd.KnowledgeDistillationRecipeForVLM,
+        vlm_kd.FinetuneRecipeForVLM,
+        id="vlm",
+    ),
+)
+
+
+@pytest.mark.parametrize("recipe_module,recipe_cls,_", _RECIPE_CASES)
+@pytest.mark.parametrize("is_student", (True, False), ids=("student", "teacher"))
+def test_create_distributed_setup_assigns_the_role_process_group(monkeypatch, recipe_module, recipe_cls, _, is_student):
+    student_setup = SimpleNamespace(mesh_context=SimpleNamespace(process_group=None))
+    teacher_setup = SimpleNamespace(mesh_context=SimpleNamespace(process_group=None))
+    setups = SimpleNamespace(separate=True, student=student_setup, teacher=teacher_setup)
+    bridge = SimpleNamespace(
+        is_student=is_student,
+        is_teacher=not is_student,
+        student_group="student-group",
+        teacher_group="teacher-group",
+    )
+    monkeypatch.setattr(recipe_module, "create_kd_distributed_setups", lambda cfg, world_size: setups)
+    monkeypatch.setattr(recipe_module, "KDMeshBridge", lambda built_setups, device: bridge)
+
+    recipe = object.__new__(recipe_cls)
+    recipe.cfg = object()
+    recipe.dist_env = SimpleNamespace(world_size=4, device="cpu")
+
+    result = recipe._create_distributed_setup()
+
+    assert result is (student_setup if is_student else teacher_setup)
+    assert recipe._training_process_group == "student-group"
+    expected_group = "student-group" if is_student else "teacher-group"
+    assert result.mesh_context.process_group == expected_group
+    assert recipe._should_setup_training_components() is is_student
+
+
+@pytest.mark.parametrize("recipe_module,recipe_cls,_", _RECIPE_CASES)
+def test_create_distributed_setup_reuses_the_shared_student_mesh(monkeypatch, recipe_module, recipe_cls, _):
+    student_setup = object()
+    setups = SimpleNamespace(separate=False, student=student_setup)
+    monkeypatch.setattr(recipe_module, "create_kd_distributed_setups", lambda cfg, world_size: setups)
+
+    recipe = object.__new__(recipe_cls)
+    recipe.cfg = object()
+    recipe.dist_env = SimpleNamespace(world_size=2, device="cpu")
+
+    assert recipe._create_distributed_setup() is student_setup
+    assert recipe.kd_mesh_bridge is None
+    assert recipe._should_setup_training_components() is True
+
+
+@pytest.mark.parametrize("recipe_module,recipe_cls,_", _RECIPE_CASES)
+def test_setup_kd_state_builds_loss_and_resets_buffers(monkeypatch, recipe_module, recipe_cls, _):
+    loss = object()
+    monkeypatch.setattr(recipe_module, "_build_kd_loss_fn", lambda cfg: loss)
+    recipe = object.__new__(recipe_cls)
+    recipe.cfg = _Cfg(kd_loss_fn="loss-config", kd_ratio=0.75)
+
+    recipe._setup_kd_state()
+
+    assert recipe.kd_loss_fn is loss
+    assert recipe.kd_ratio == 0.75
+    assert recipe._kd_loss_buffer == []
+    assert recipe._ce_loss_buffer == []
+
+
+@pytest.mark.parametrize("_,recipe_cls,__", _RECIPE_CASES)
+def test_get_separate_teacher_logits_returns_the_received_wave(_, recipe_cls, __):
+    expected = torch.ones(1, 2, 4)
+    received = iter((None, expected))
+    calls = []
+    bridge = SimpleNamespace(
+        num_waves=2,
+        broadcast_command=lambda command: calls.append(("command", command)),
+        send_batch=lambda wave, batch: calls.append(("batch", wave, batch)),
+        send_logits=lambda wave, logits: next(received),
+    )
+    recipe = object.__new__(recipe_cls)
+    recipe.kd_mesh_bridge = bridge
+    batch = {"input_ids": torch.tensor([[1, 2]]), "labels": torch.tensor([[1, 2]])}
+
+    assert recipe._get_separate_teacher_logits(batch) is expected
+    assert calls[0][0] == "command"
+    assert [call[1] for call in calls if call[0] == "batch"] == [0, 1]
+
+
+@pytest.mark.parametrize("_,recipe_cls,__", _RECIPE_CASES)
+def test_get_separate_teacher_logits_rejects_missing_output(_, recipe_cls, __):
+    recipe = object.__new__(recipe_cls)
+    recipe.kd_mesh_bridge = SimpleNamespace(
+        num_waves=1,
+        broadcast_command=lambda command: None,
+        send_batch=lambda wave, batch: None,
+        send_logits=lambda wave, logits: None,
+    )
+
+    with pytest.raises(RuntimeError, match="did not receive teacher logits"):
+        recipe._get_separate_teacher_logits({})
+
+
+@pytest.mark.parametrize("recipe_module,recipe_cls,_", _RECIPE_CASES)
+def test_teacher_worker_serves_each_wave_until_stop(monkeypatch, recipe_module, recipe_cls, _):
+    commands = iter((recipe_module.RUN_TEACHER, recipe_module.STOP_TEACHER))
+    sent = []
+
+    class _SignalHandler:
+        def __init__(self, group):
+            assert group == "teacher-group"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            return False
+
+    monkeypatch.setattr(recipe_module, "DistributedSignalHandler", _SignalHandler)
+    recipe = object.__new__(recipe_cls)
+    recipe.kd_mesh_bridge = SimpleNamespace(
+        teacher_group="teacher-group",
+        num_waves=2,
+        broadcast_command=lambda: next(commands),
+        send_batch=lambda wave, batch: {"wave": wave},
+        send_logits=lambda wave, logits: sent.append((wave, logits)),
+    )
+    recipe._teacher_forward_separate = lambda batch: torch.tensor(batch["wave"])
+
+    recipe._run_teacher_worker()
+
+    assert [wave for wave, _ in sent] == [0, 1]
+
+
+@pytest.mark.parametrize("recipe_module,recipe_cls,_", _RECIPE_CASES)
+def test_teacher_forward_separate_materializes_logits(monkeypatch, recipe_module, recipe_cls, _):
+    monkeypatch.setattr(recipe_module, "make_cp_batch_and_ctx", lambda mesh, batch, **kwargs: (nullcontext, batch))
+    materialized = []
+    monkeypatch.setattr(
+        recipe_module,
+        "materialize_teacher_logits",
+        lambda logits, *, device_mesh, sequence_length: materialized.append((device_mesh, sequence_length)) or logits,
+    )
+    recipe = object.__new__(recipe_cls)
+    recipe.kd_mesh_bridge = SimpleNamespace(move_to_device=lambda batch: batch)
+    recipe.device_mesh = None
+    recipe.teacher_model = _Teacher()
+    if recipe_module is llm_kd:
+        recipe.pp_enabled = False
+
+    logits = recipe._teacher_forward_separate({"input_ids": torch.tensor([[1, 2]]), "labels": torch.tensor([[1, 2]])})
+
+    assert logits.shape == (1, 2, 4)
+    assert materialized == [(None, 2)]
+
+
+@pytest.mark.parametrize("recipe_module,recipe_cls,base_cls", _RECIPE_CASES)
+def test_run_loop_routes_teacher_and_stops_after_student(monkeypatch, recipe_module, recipe_cls, base_cls):
+    parent_calls = []
+    monkeypatch.setattr(base_cls, "run_train_validation_loop", lambda self: parent_calls.append(self) or "trained")
+
+    teacher = object.__new__(recipe_cls)
+    teacher.separate_meshes = True
+    teacher.kd_mesh_bridge = SimpleNamespace(is_teacher=True)
+    teacher_calls = []
+    teacher._run_teacher_worker = lambda: teacher_calls.append("served")
+    assert teacher.run_train_validation_loop() is None
+    assert teacher_calls == ["served"]
+
+    commands = []
+    student = object.__new__(recipe_cls)
+    student.separate_meshes = True
+    student.pp_enabled = False
+    student.kd_mesh_bridge = SimpleNamespace(
+        is_teacher=False,
+        broadcast_command=lambda command: commands.append(command),
+    )
+    assert student.run_train_validation_loop() == "trained"
+    assert commands == [recipe_module.STOP_TEACHER]
+
+    shared = object.__new__(recipe_cls)
+    shared.separate_meshes = False
+    shared.pp_enabled = False
+    assert shared.run_train_validation_loop() == "trained"
+    assert parent_calls == [student, shared]

--- a/tests/unit_tests/recipes/test_kd_utils.py
+++ b/tests/unit_tests/recipes/test_kd_utils.py
@@ -22,6 +22,7 @@ import torch.multiprocessing as mp
 from nemo_automodel.components.distributed.config import DDPConfig, FSDP2Config
 from nemo_automodel.components.loss.kd_loss import KDLoss
 from nemo_automodel.recipes import kd_utils
+from tests.functional_tests.llm_pretrain_and_kd import kd_separate_mesh_test_utils
 from tests.functional_tests.llm_pretrain_and_kd.compare_kd_sep_mesh_losses import _compare_pair
 from tests.functional_tests.llm_pretrain_and_kd.kd_separate_mesh_test_utils import TinyKDDataset
 
@@ -59,6 +60,37 @@ def test_tiny_kd_dataset_preserves_non_chat_first_label_mask():
 
     assert dataset[0]["input_ids"] == list(range(8))
     assert dataset[0]["labels"] == [-100, 2, 3, 4, 5, 6, 7, 8]
+
+
+def test_tiny_kd_sft_dataset_masks_generation_prompt():
+    class Tokenizer:
+        eos_token_id = 2
+
+        def apply_chat_template(self, messages, *, tokenize, add_generation_prompt, return_dict):
+            assert messages == [{"role": "user", "content": "What is KD?"}]
+            assert tokenize is True
+            assert add_generation_prompt is True
+            assert return_dict is False
+            return [10, 11, 12, 13]
+
+        def encode(self, text, *, add_special_tokens):
+            assert text == "KD transfers teacher behavior to a student."
+            assert add_special_tokens is False
+            return [20, 21, 22, 23, 24, 25, 26, 27]
+
+    dataset = kd_separate_mesh_test_utils.make_tiny_kd_sft_dataset(
+        tokenizer=Tokenizer(),
+        prompt="What is KD?",
+        completion="KD transfers teacher behavior to a student.",
+        num_samples=2,
+        seq_length=8,
+    )
+
+    assert dataset[0]["input_ids"] == [10, 11, 12, 13, 20, 21, 22, 23]
+    assert dataset[0]["labels"] == [-100, -100, -100, 20, 21, 22, 23, 24]
+    assert dataset[0]["attention_mask"] == [1] * 8
+    dataset[0]["labels"][3] = -100
+    assert dataset[1]["labels"][3] == 20
 
 
 def test_loss_comparator_rejects_mismatched_kd_settings():

--- a/tests/unit_tests/recipes/test_kd_utils.py
+++ b/tests/unit_tests/recipes/test_kd_utils.py
@@ -16,9 +16,11 @@ from types import SimpleNamespace
 
 import pytest
 import torch
-from torch.distributed.tensor.experimental import _attention
+import torch.distributed as dist
+import torch.multiprocessing as mp
 
 from nemo_automodel.components.distributed.config import DDPConfig, FSDP2Config
+from nemo_automodel.components.loss.kd_loss import KDLoss
 from nemo_automodel.recipes import kd_utils
 
 
@@ -34,13 +36,14 @@ def test_materialize_teacher_logits_unshards_cp_and_removes_padding(monkeypatch)
 
     local = torch.tensor([[[1.0], [2.0]]])
 
-    def unshard(mesh, tensors, seq_dims):
+    def unshard(mesh, tensor, *, seq_dim):
+        """Expand local ``[B=1, S_local=2, V=1]`` logits to full sequence."""
         assert mesh is cp_mesh
-        assert tensors == [local]
-        assert seq_dims == [1]
-        return [torch.tensor([[[1.0], [2.0], [3.0], [0.0]]])]
+        assert tensor is local
+        assert seq_dim == 1
+        return torch.tensor([[[1.0], [2.0], [3.0], [0.0]]])
 
-    monkeypatch.setattr(_attention, "context_parallel_unshard", unshard)
+    monkeypatch.setattr(kd_utils, "unshard_context_parallel_tensor", unshard)
 
     result = kd_utils.materialize_teacher_logits(local, device_mesh=Mesh(), sequence_length=3)
 
@@ -114,6 +117,14 @@ def test_separate_kd_setup_assigns_contiguous_disjoint_ranks(monkeypatch):
             },
             "student=2.*teacher=1 != world_size=4",
         ),
+        (
+            {
+                "separate_meshes": True,
+                "distributed": {"dp_size": 2, "ep_size": 2},
+                "teacher_distributed": {"dp_size": 2},
+            },
+            "distributed.ep_size > 1 is not supported",
+        ),
     ],
 )
 def test_kd_setup_rejects_ambiguous_rank_splits(cfg, message):
@@ -135,3 +146,98 @@ def test_separate_kd_setup_rejects_ddp(monkeypatch):
 
     with pytest.raises(ValueError, match="DDP is not supported"):
         kd_utils.create_kd_distributed_setups(cfg, world_size=4)
+
+
+def _teacher_logits(input_ids: torch.Tensor) -> torch.Tensor:
+    """Return deterministic logits ``[B, S, V=3]`` for ids ``[B, S]``."""
+    values = input_ids.float()
+    return torch.stack((values * 0.5, values * -0.25 + 1.0, values * 0.125 - 0.5), dim=-1)
+
+
+def _run_kd_bridge_worker(rank: int, world_size: int, init_file: str) -> None:
+    dist.init_process_group(
+        backend="gloo",
+        init_method=f"file://{init_file}",
+        rank=rank,
+        world_size=world_size,
+    )
+    try:
+        cfg = {
+            "separate_meshes": True,
+            "distributed": {"strategy": "fsdp2", "dp_size": 2},
+            "teacher_distributed": {"strategy": "fsdp2", "dp_size": 1, "tp_size": 2},
+        }
+        setups = kd_utils.create_kd_distributed_setups(cfg, world_size=world_size)
+        bridge = kd_utils.KDMeshBridge(setups, device=torch.device("cpu"))
+        batch = None
+        if bridge.is_student:
+            input_ids = torch.tensor([[rank + 1, rank + 2]], dtype=torch.long)
+            batch = {"input_ids": input_ids, "labels": input_ids.clone()}
+
+        bridge.broadcast_command(kd_utils.RUN_TEACHER if bridge.is_student else None)
+        received_teacher_logits = None
+        for wave in range(bridge.num_waves):
+            teacher_batch = bridge.send_batch(wave, batch)
+            logits = _teacher_logits(teacher_batch["input_ids"]) if bridge.is_teacher else None
+            received = bridge.send_logits(wave, logits)
+            if received is not None:
+                received_teacher_logits = received
+
+        if bridge.is_student:
+            assert received_teacher_logits is not None
+            expected = _teacher_logits(batch["input_ids"])
+            torch.testing.assert_close(received_teacher_logits, expected)
+            scale = torch.tensor(0.75, requires_grad=True)
+            loss = KDLoss()(expected.detach() * scale, received_teacher_logits, batch["labels"])
+            loss.backward()
+            assert torch.isfinite(loss)
+            assert scale.grad is not None and torch.isfinite(scale.grad)
+
+            from nemo_automodel.components.checkpoint.checkpointing import Checkpointer
+            from nemo_automodel.components.checkpoint.config import CheckpointingConfig
+
+            checkpoint_config = CheckpointingConfig(enabled=False, is_async=True)
+            checkpointer = Checkpointer(
+                checkpoint_config,
+                dp_rank=rank,
+                tp_rank=0,
+                pp_rank=0,
+                process_group=bridge.student_group,
+            )
+            checkpointer.close()
+        bridge.synchronize()
+    finally:
+        dist.destroy_process_group()
+
+
+def test_kd_mesh_bridge_routes_two_student_replicas_through_teacher_tp2(tmp_path):
+    """Exercise explicit subset meshes and bridge collectives on four CPU ranks."""
+    mp.spawn(_run_kd_bridge_worker, args=(4, str(tmp_path / "process_group")), nprocs=4, join=True)
+
+
+def test_pp_kd_wrapper_consumes_teacher_microbatches_in_order():
+    """Shared-mesh PP uses the matching captured teacher logits for each microbatch."""
+    from nemo_automodel.recipes.llm import kd as llm_kd
+
+    recipe = object.__new__(llm_kd.KnowledgeDistillationRecipeForNextTokenPrediction)
+    recipe.kd_ratio = 1.0
+    recipe.kd_loss_fn = KDLoss()
+    recipe._kd_loss_buffer = []
+    recipe._ce_loss_buffer = []
+    recipe.separate_meshes = False
+
+    teacher_logits = [
+        torch.tensor([[[1.0, 0.0, -1.0], [0.5, 0.0, -0.5]]]),
+        torch.tensor([[[-1.0, 0.0, 1.0], [-0.5, 0.0, 0.5]]]),
+    ]
+    recipe._current_teacher_logits = list(teacher_logits)
+    loss_fn = recipe._make_pp_kd_loss_wrapper()
+    labels = torch.tensor([[0, 1]])
+    student_logits = torch.zeros(1, 2, 3, requires_grad=True)
+
+    first = loss_fn(student_logits, labels)
+    second = loss_fn(student_logits, labels)
+
+    torch.testing.assert_close(first, KDLoss()(student_logits, teacher_logits[0], labels, num_batch_labels=1))
+    torch.testing.assert_close(second, KDLoss()(student_logits, teacher_logits[1], labels, num_batch_labels=1))
+    assert recipe._current_teacher_logits == []

--- a/tests/unit_tests/recipes/test_kd_utils.py
+++ b/tests/unit_tests/recipes/test_kd_utils.py
@@ -296,11 +296,6 @@ def _run_kd_bridge_worker(rank: int, world_size: int, init_file: str) -> None:
         bridge = kd_utils.KDMeshBridge(setups, device=torch.device("cpu"))
         checkpointer = None
         batch = None
-        checkpoint_config = CheckpointingConfig(enabled=False, is_async=True)
-        async_process_groups = checkpoint_config.initialize_async_process_groups(
-            setups.student_ranks,
-            is_member=bridge.is_student,
-        )
         if bridge.is_student:
             input_ids = torch.tensor([[rank + 1, rank + 2]], dtype=torch.long)
             batch = {"input_ids": input_ids, "labels": input_ids.clone()}
@@ -326,15 +321,20 @@ def _run_kd_bridge_worker(rank: int, world_size: int, init_file: str) -> None:
 
             from nemo_automodel.components.checkpoint.checkpointing import Checkpointer
 
+            checkpoint_config = CheckpointingConfig(enabled=False, is_async=True)
+
             checkpointer = Checkpointer(
                 checkpoint_config,
                 dp_rank=rank,
                 tp_rank=0,
                 pp_rank=0,
                 process_group=bridge.student_group,
-                async_process_groups=async_process_groups,
             )
         bridge.synchronize()
+        # Barrier completion only guarantees every rank entered the collective;
+        # use the default group to ensure teacher ranks have returned before
+        # students destroy their async checkpoint groups.
+        dist.barrier()
         if checkpointer is not None:
             checkpointer.close()
         # Hold teacher ranks until the student-only checkpoint groups are closed

--- a/tests/unit_tests/recipes/test_kd_utils.py
+++ b/tests/unit_tests/recipes/test_kd_utils.py
@@ -21,7 +21,6 @@ import torch.distributed as dist
 import torch.multiprocessing as mp
 import yaml
 
-from nemo_automodel.components.checkpoint.config import CheckpointingConfig
 from nemo_automodel.components.distributed.config import DDPConfig, FSDP2Config
 from nemo_automodel.components.loss.kd_loss import KDLoss
 from nemo_automodel.recipes import kd_utils
@@ -294,7 +293,6 @@ def _run_kd_bridge_worker(rank: int, world_size: int, init_file: str) -> None:
         }
         setups = kd_utils.create_kd_distributed_setups(cfg, world_size=world_size)
         bridge = kd_utils.KDMeshBridge(setups, device=torch.device("cpu"))
-        checkpointer = None
         batch = None
         if bridge.is_student:
             input_ids = torch.tensor([[rank + 1, rank + 2]], dtype=torch.long)
@@ -319,26 +317,9 @@ def _run_kd_bridge_worker(rank: int, world_size: int, init_file: str) -> None:
             assert torch.isfinite(loss)
             assert scale.grad is not None and torch.isfinite(scale.grad)
 
-            from nemo_automodel.components.checkpoint.checkpointing import Checkpointer
-
-            checkpoint_config = CheckpointingConfig(enabled=False, is_async=True)
-
-            checkpointer = Checkpointer(
-                checkpoint_config,
-                dp_rank=rank,
-                tp_rank=0,
-                pp_rank=0,
-                process_group=bridge.student_group,
-            )
         bridge.synchronize()
-        # Barrier completion only guarantees every rank entered the collective;
-        # use the default group to ensure teacher ranks have returned before
-        # students destroy their async checkpoint groups.
-        dist.barrier()
-        if checkpointer is not None:
-            checkpointer.close()
-        # Hold teacher ranks until the student-only checkpoint groups are closed
-        # before tearing down the default process group.
+        # Ensure every worker has returned from the bridge barrier before the
+        # default process group is destroyed in ``finally``.
         dist.barrier()
     finally:
         dist.destroy_process_group()

--- a/tests/unit_tests/recipes/test_kd_utils.py
+++ b/tests/unit_tests/recipes/test_kd_utils.py
@@ -293,6 +293,7 @@ def _run_kd_bridge_worker(rank: int, world_size: int, init_file: str) -> None:
         }
         setups = kd_utils.create_kd_distributed_setups(cfg, world_size=world_size)
         bridge = kd_utils.KDMeshBridge(setups, device=torch.device("cpu"))
+        checkpointer = None
         batch = None
         if bridge.is_student:
             input_ids = torch.tensor([[rank + 1, rank + 2]], dtype=torch.long)
@@ -328,10 +329,11 @@ def _run_kd_bridge_worker(rank: int, world_size: int, init_file: str) -> None:
                 pp_rank=0,
                 process_group=bridge.student_group,
             )
-            checkpointer.close()
         bridge.synchronize()
-        # Synchronize the default group before tearing it down. The bridge barrier
-        # uses a separate Gloo group, so it does not order default-group cleanup.
+        if checkpointer is not None:
+            checkpointer.close()
+        # Hold teacher ranks until the student-only checkpoint groups are closed
+        # before tearing down the default process group.
         dist.barrier()
     finally:
         dist.destroy_process_group()

--- a/tests/unit_tests/recipes/test_kd_utils.py
+++ b/tests/unit_tests/recipes/test_kd_utils.py
@@ -117,14 +117,6 @@ def test_separate_kd_setup_assigns_contiguous_disjoint_ranks(monkeypatch):
             },
             "student=2.*teacher=1 != world_size=4",
         ),
-        (
-            {
-                "separate_meshes": True,
-                "distributed": {"dp_size": 2, "ep_size": 2},
-                "teacher_distributed": {"dp_size": 2},
-            },
-            "distributed.ep_size > 1 is not supported",
-        ),
     ],
 )
 def test_kd_setup_rejects_ambiguous_rank_splits(cfg, message):
@@ -213,6 +205,42 @@ def _run_kd_bridge_worker(rank: int, world_size: int, init_file: str) -> None:
 def test_kd_mesh_bridge_routes_two_student_replicas_through_teacher_tp2(tmp_path):
     """Exercise explicit subset meshes and bridge collectives on four CPU ranks."""
     mp.spawn(_run_kd_bridge_worker, args=(4, str(tmp_path / "process_group")), nprocs=4, join=True)
+
+
+def _run_subset_ep_mesh_worker(rank: int, world_size: int, init_file: str) -> None:
+    dist.init_process_group(
+        backend="gloo",
+        init_method=f"file://{init_file}",
+        rank=rank,
+        world_size=world_size,
+    )
+    try:
+        cfg = {
+            "separate_meshes": True,
+            "distributed": {"strategy": "fsdp2", "dp_size": 2},
+            "teacher_distributed": {
+                "strategy": "fsdp2",
+                "dp_size": 4,
+                "pp_size": 2,
+                "ep_size": 2,
+                "pipeline": {},
+            },
+        }
+        setups = kd_utils.create_kd_distributed_setups(cfg, world_size=world_size)
+        if rank in setups.teacher_ranks:
+            device_mesh = setups.teacher.mesh_context.device_mesh
+            moe_mesh = setups.teacher.mesh_context.moe_mesh
+            assert device_mesh["pp"].size() == 2
+            assert moe_mesh is not None
+            assert moe_mesh["ep"].size() == 2
+            assert set(dist.get_process_group_ranks(moe_mesh["ep"].get_group())).issubset(setups.teacher_ranks)
+    finally:
+        dist.destroy_process_group()
+
+
+def test_separate_kd_setup_builds_teacher_ep_mesh_on_rank_subset(tmp_path):
+    """Teacher PP and EP groups may occupy ranks disjoint from the student mesh."""
+    mp.spawn(_run_subset_ep_mesh_worker, args=(10, str(tmp_path / "ep_process_group")), nprocs=10, join=True)
 
 
 def test_pp_kd_wrapper_consumes_teacher_microbatches_in_order():

--- a/tests/unit_tests/recipes/test_kd_utils.py
+++ b/tests/unit_tests/recipes/test_kd_utils.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch.distributed.tensor.experimental import _attention
+
+from nemo_automodel.components.distributed.config import DDPConfig, FSDP2Config
+from nemo_automodel.recipes import kd_utils
+
+
+def test_materialize_teacher_logits_unshards_cp_and_removes_padding(monkeypatch):
+    cp_mesh = SimpleNamespace(size=lambda: 2)
+
+    class Mesh:
+        mesh_dim_names = ("cp",)
+
+        def __getitem__(self, name):
+            assert name == "cp"
+            return cp_mesh
+
+    local = torch.tensor([[[1.0], [2.0]]])
+
+    def unshard(mesh, tensors, seq_dims):
+        assert mesh is cp_mesh
+        assert tensors == [local]
+        assert seq_dims == [1]
+        return [torch.tensor([[[1.0], [2.0], [3.0], [0.0]]])]
+
+    monkeypatch.setattr(_attention, "context_parallel_unshard", unshard)
+
+    result = kd_utils.materialize_teacher_logits(local, device_mesh=Mesh(), sequence_length=3)
+
+    assert torch.equal(result, torch.tensor([[[1.0], [2.0], [3.0]]]))
+
+
+def test_shared_kd_setup_keeps_existing_world(monkeypatch):
+    shared = SimpleNamespace(strategy_config=FSDP2Config())
+
+    def build(cfg, **kwargs):
+        return shared
+
+    monkeypatch.setattr(kd_utils, "create_distributed_setup_from_config", build)
+
+    setups = kd_utils.create_kd_distributed_setups({"distributed": {}}, world_size=4)
+
+    assert setups.student is shared
+    assert setups.teacher is shared
+    assert setups.student_ranks == (0, 1, 2, 3)
+    assert setups.teacher_ranks == (0, 1, 2, 3)
+    assert not setups.separate
+
+
+def test_separate_kd_setup_assigns_contiguous_disjoint_ranks(monkeypatch):
+    calls = []
+
+    def build(cfg, **kwargs):
+        calls.append((cfg, kwargs))
+        return SimpleNamespace(strategy_config=FSDP2Config())
+
+    monkeypatch.setattr(kd_utils, "create_distributed_setup_from_config", build)
+    cfg = {
+        "separate_meshes": True,
+        "distributed": {"strategy": "fsdp2", "dp_size": 2},
+        "teacher_distributed": {"strategy": "fsdp2", "dp_size": 1, "tp_size": 2},
+    }
+
+    setups = kd_utils.create_kd_distributed_setups(cfg, world_size=4)
+
+    assert setups.student_ranks == (0, 1)
+    assert setups.teacher_ranks == (2, 3)
+    assert setups.separate
+    assert calls[0][1] == {"world_size": 2, "ranks": (0, 1)}
+    assert calls[1][1] == {"world_size": 2, "ranks": (2, 3)}
+
+
+@pytest.mark.parametrize(
+    ("cfg", "message"),
+    [
+        (
+            {"distributed": {}, "teacher_distributed": {"dp_size": 1}},
+            "teacher_distributed requires separate_meshes=true",
+        ),
+        (
+            {"separate_meshes": True, "distributed": {"dp_size": 2}},
+            "requires a teacher_distributed section",
+        ),
+        (
+            {
+                "separate_meshes": True,
+                "distributed": {"tp_size": 2},
+                "teacher_distributed": {"dp_size": 2},
+            },
+            "distributed.dp_size must be set",
+        ),
+        (
+            {
+                "separate_meshes": True,
+                "distributed": {"dp_size": 2},
+                "teacher_distributed": {"dp_size": 1},
+            },
+            "student=2.*teacher=1 != world_size=4",
+        ),
+    ],
+)
+def test_kd_setup_rejects_ambiguous_rank_splits(cfg, message):
+    with pytest.raises(ValueError, match=message):
+        kd_utils.create_kd_distributed_setups(cfg, world_size=4)
+
+
+def test_separate_kd_setup_rejects_ddp(monkeypatch):
+    monkeypatch.setattr(
+        kd_utils,
+        "create_distributed_setup_from_config",
+        lambda cfg, **kwargs: SimpleNamespace(strategy_config=DDPConfig()),
+    )
+    cfg = {
+        "separate_meshes": True,
+        "distributed": {"strategy": "ddp", "dp_size": 2},
+        "teacher_distributed": {"strategy": "fsdp2", "dp_size": 2},
+    }
+
+    with pytest.raises(ValueError, match="DDP is not supported"):
+        kd_utils.create_kd_distributed_setups(cfg, world_size=4)

--- a/tests/unit_tests/recipes/test_kd_utils.py
+++ b/tests/unit_tests/recipes/test_kd_utils.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
+import yaml
 
 from nemo_automodel.components.distributed.config import DDPConfig, FSDP2Config
 from nemo_automodel.components.loss.kd_loss import KDLoss
@@ -25,6 +27,19 @@ from nemo_automodel.recipes import kd_utils
 from tests.functional_tests.llm_pretrain_and_kd import kd_separate_mesh_test_utils
 from tests.functional_tests.llm_pretrain_and_kd.compare_kd_sep_mesh_losses import _compare_pair
 from tests.functional_tests.llm_pretrain_and_kd.kd_separate_mesh_test_utils import TinyKDDataset
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_KD_FP32_MASTER_YAMLS = (
+    "examples/llm_kd/llama3_2/llama3_2_1b_kd_separate_mesh_teacher_cp2.yaml",
+    "examples/llm_kd/llama3_2/llama3_2_1b_kd_separate_mesh_teacher_pp2.yaml",
+    "examples/llm_kd/llama3_2/llama3_2_1b_kd_separate_mesh_teacher_tp2.yaml",
+    "examples/vlm_kd/qwen3_5/qwen3_5_vl_4b_kd_separate_mesh_teacher_cp2.yaml",
+    "examples/vlm_kd/qwen3_5/qwen3_5_vl_4b_kd_separate_mesh_teacher_dp2.yaml",
+    "examples/vlm_kd/qwen3_5/qwen3_5_vl_4b_kd_separate_mesh_teacher_tp2.yaml",
+    "tests/functional_tests/llm_pretrain_and_kd/kd_separate_mesh.yaml",
+    "tests/functional_tests/llm_pretrain_and_kd/kd_sep_mesh_gemma_dense.yaml",
+    "tests/functional_tests/llm_pretrain_and_kd/kd_sep_mesh_gemma_moe.yaml",
+)
 
 
 def test_tiny_kd_dataset_requests_flat_chat_template_token_ids():
@@ -91,6 +106,19 @@ def test_tiny_kd_sft_dataset_masks_generation_prompt():
     assert dataset[0]["attention_mask"] == [1] * 8
     dataset[0]["labels"][3] = -100
     assert dataset[1]["labels"][3] == 20
+
+
+def test_kd_yamls_use_fp32_optimizer_master_weights():
+    for relative_path in _KD_FP32_MASTER_YAMLS:
+        cfg = yaml.safe_load((_REPO_ROOT / relative_path).read_text())
+
+        optimizer = cfg["optimizer"]
+        assert optimizer["_target_"] == "transformer_engine.pytorch.optimizers.fused_adam.FusedAdam"
+        assert optimizer["master_weights"] is True
+        assert optimizer["master_weight_dtype"] == "torch.float32"
+
+        assert cfg["model"]["torch_dtype"] == "bfloat16"
+        assert cfg["teacher_model"]["torch_dtype"] == "bfloat16"
 
 
 def test_loss_comparator_rejects_mismatched_kd_settings():

--- a/tests/unit_tests/recipes/test_kd_utils.py
+++ b/tests/unit_tests/recipes/test_kd_utils.py
@@ -330,6 +330,9 @@ def _run_kd_bridge_worker(rank: int, world_size: int, init_file: str) -> None:
             )
             checkpointer.close()
         bridge.synchronize()
+        # Synchronize the default group before tearing it down. The bridge barrier
+        # uses a separate Gloo group, so it does not order default-group cleanup.
+        dist.barrier()
     finally:
         dist.destroy_process_group()
 

--- a/tests/unit_tests/recipes/test_kd_utils.py
+++ b/tests/unit_tests/recipes/test_kd_utils.py
@@ -264,6 +264,174 @@ def test_separate_kd_setup_rejects_ddp(monkeypatch):
         kd_utils.create_kd_distributed_setups(cfg, world_size=4)
 
 
+def test_model_replicas_resolves_dp_pipeline_endpoints():
+    mesh = SimpleNamespace(
+        mesh_dim_names=("dp", "pp", "tp"),
+        mesh=torch.arange(8).reshape(2, 2, 2),
+    )
+    setup = SimpleNamespace(mesh_context=SimpleNamespace(device_mesh=mesh))
+
+    replicas = kd_utils._model_replicas(setup)
+
+    assert replicas == [
+        kd_utils._Replica(ranks=(0, 1, 2, 3), input_rank=0, output_rank=2),
+        kd_utils._Replica(ranks=(4, 5, 6, 7), input_rank=4, output_rank=6),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("device_mesh", "message"),
+    [
+        (None, "require a DeviceMesh"),
+        (SimpleNamespace(mesh_dim_names=("tp",), mesh=torch.arange(2)), "no data-parallel axis"),
+    ],
+)
+def test_model_replicas_rejects_missing_mesh_contract(device_mesh, message):
+    setup = SimpleNamespace(mesh_context=SimpleNamespace(device_mesh=device_mesh))
+
+    with pytest.raises(ValueError, match=message):
+        kd_utils._model_replicas(setup)
+
+
+def test_tree_spec_round_trip_preserves_nested_tensor_leaves():
+    first = torch.arange(4).reshape(2, 2)
+    second = torch.tensor([3.0])
+    value = {"items": [first, ("label", second)], "count": 2}
+    tensors = []
+
+    spec = kd_utils._tree_spec(value, tensors)
+    rebuilt = kd_utils._tree_from_spec(spec, tensors)
+
+    assert tensors == [first, second]
+    assert rebuilt["items"][0] is first
+    assert rebuilt["items"][1] == ("label", second)
+    assert rebuilt["count"] == 2
+
+
+def test_kd_mesh_bridge_builds_routes_and_moves_nested_values(monkeypatch):
+    student_replicas = [
+        kd_utils._Replica((0,), 0, 0),
+        kd_utils._Replica((1,), 1, 1),
+    ]
+    teacher_replicas = [kd_utils._Replica((2, 3), 2, 2)]
+    groups = []
+
+    monkeypatch.setattr(dist, "get_rank", lambda: 0)
+    monkeypatch.setattr(dist, "new_group", lambda *, ranks: groups.append(tuple(ranks)) or object())
+    monkeypatch.setattr(kd_utils, "_model_replicas", lambda setup: setup.replicas)
+    setups = SimpleNamespace(
+        separate=True,
+        student_ranks=(0, 1),
+        teacher_ranks=(2, 3),
+        student=SimpleNamespace(replicas=student_replicas),
+        teacher=SimpleNamespace(replicas=teacher_replicas),
+    )
+
+    bridge = kd_utils.KDMeshBridge(setups, device=torch.device("cpu"))
+    nested = {"tensor": torch.ones(2), "items": [torch.zeros(1), ("value",)]}
+    moved = bridge.move_to_device(nested)
+
+    assert bridge.is_student
+    assert not bridge.is_teacher
+    assert bridge.num_waves == 2
+    assert [route.src for wave in bridge.input_routes for route in wave] == [0, 1]
+    assert [route.src for wave in bridge.output_routes for route in wave] == [2, 2]
+    assert groups == [(0, 1, 2, 3), (0, 1), (2, 3), (0, 2, 3), (2, 0), (1, 2, 3), (2, 1)]
+    assert moved is not nested
+    assert moved["tensor"].device.type == "cpu"
+    assert moved["items"][1] == ("value",)
+
+
+def test_kd_mesh_bridge_command_sync_and_non_dtensor_vocab(monkeypatch):
+    bridge = object.__new__(kd_utils.KDMeshBridge)
+    bridge.rank = 0
+    bridge.student_ranks = (0, 1)
+    bridge.teacher_ranks = (2, 3)
+    bridge.device = torch.device("cpu")
+    bridge.control_group = object()
+    broadcasts = []
+    barriers = []
+    monkeypatch.setattr(dist, "broadcast", lambda tensor, **kwargs: broadcasts.append((tensor.clone(), kwargs)))
+    monkeypatch.setattr(dist, "barrier", lambda **kwargs: barriers.append(kwargs))
+
+    assert bridge.broadcast_command(kd_utils.RUN_TEACHER) == kd_utils.RUN_TEACHER
+    bridge.synchronize()
+    teacher_logits = torch.randn(1, 2, 3)
+    assert bridge.match_student_vocab_shard(torch.randn(1, 2, 3), teacher_logits) is teacher_logits
+    assert broadcasts[0][1] == {"src": 0, "group": bridge.control_group}
+    assert barriers == [{"group": bridge.control_group}]
+
+
+def test_match_student_vocab_shard_selects_local_dtensor_chunk(monkeypatch):
+    class FakeShard:
+        def __init__(self, dim):
+            self.dim = dim
+
+    class FakeDTensor:
+        ndim = 3
+        placements = (FakeShard(-1),)
+        device_mesh = SimpleNamespace(get_group=lambda mesh_dim: f"group-{mesh_dim}")
+
+    monkeypatch.setattr(kd_utils, "DTensor", FakeDTensor)
+    monkeypatch.setattr(kd_utils, "Shard", FakeShard)
+    monkeypatch.setattr(dist, "get_world_size", lambda group: 2)
+    monkeypatch.setattr(dist, "get_rank", lambda group: 1)
+    teacher_logits = torch.arange(8).reshape(1, 2, 4)
+
+    result = kd_utils.KDMeshBridge.match_student_vocab_shard(FakeDTensor(), teacher_logits)
+
+    assert torch.equal(result, teacher_logits[..., 2:])
+    assert result.is_contiguous()
+
+
+def test_broadcast_tree_covers_source_receiver_and_nonmember(monkeypatch):
+    bridge = object.__new__(kd_utils.KDMeshBridge)
+    bridge.device = torch.device("cpu")
+    route = kd_utils._Route(src=0, ranks=(0, 1), group=object())
+    value = {"items": [torch.ones(2), (torch.zeros(1),)], "label": "x"}
+    calls = []
+
+    bridge.rank = 0
+    monkeypatch.setattr(dist, "broadcast_object_list", lambda objects, **kwargs: calls.append((objects[0], kwargs)))
+    monkeypatch.setattr(dist, "broadcast", lambda tensor, **kwargs: calls.append((tensor.clone(), kwargs)))
+    source_result = bridge._broadcast_tree(value, route)
+
+    spec_tensors = []
+    spec = kd_utils._tree_spec(value, spec_tensors)
+
+    def receive_spec(objects, **kwargs):
+        objects[0] = spec
+
+    bridge.rank = 1
+    monkeypatch.setattr(dist, "broadcast_object_list", receive_spec)
+    receiver_result = bridge._broadcast_tree(None, route)
+    bridge.rank = 3
+    nonmember_result = bridge._broadcast_tree(None, route)
+
+    assert torch.equal(source_result["items"][0], value["items"][0])
+    assert receiver_result["items"][0].shape == (2,)
+    assert receiver_result["items"][1][0].shape == (1,)
+    assert receiver_result["label"] == "x"
+    assert nonmember_result is None
+    assert calls[0][1] == {"src": 0, "group": route.group, "device": bridge.device}
+
+
+def test_send_batch_and_logits_select_current_role_routes(monkeypatch):
+    route = kd_utils._Route(src=0, ranks=(0, 2), group=object())
+    bridge = object.__new__(kd_utils.KDMeshBridge)
+    bridge.input_routes = [[route]]
+    bridge.output_routes = [[route]]
+    bridge.student_ranks = (0, 1)
+    bridge.teacher_ranks = (2, 3)
+    monkeypatch.setattr(bridge, "_broadcast_tree", lambda value, selected_route: value or "received")
+
+    bridge.rank = 2
+    assert bridge.send_batch(0, None) == "received"
+    bridge.rank = 0
+    logits = torch.ones(1)
+    assert bridge.send_logits(0, logits) is logits
+
+
 def _teacher_logits(input_ids: torch.Tensor) -> torch.Tensor:
     """Return deterministic teacher logits.
 

--- a/tests/unit_tests/recipes/test_kd_utils.py
+++ b/tests/unit_tests/recipes/test_kd_utils.py
@@ -22,6 +22,59 @@ import torch.multiprocessing as mp
 from nemo_automodel.components.distributed.config import DDPConfig, FSDP2Config
 from nemo_automodel.components.loss.kd_loss import KDLoss
 from nemo_automodel.recipes import kd_utils
+from tests.functional_tests.llm_pretrain_and_kd.compare_kd_sep_mesh_losses import _compare_pair
+from tests.functional_tests.llm_pretrain_and_kd.kd_separate_mesh_test_utils import TinyKDDataset
+
+
+def test_tiny_kd_dataset_requests_flat_chat_template_token_ids():
+    class Tokenizer:
+        def apply_chat_template(self, messages, *, tokenize, add_generation_prompt, return_dict):
+            assert messages == [
+                {"role": "user", "content": "Explain knowledge distillation and distributed validation."}
+            ]
+            assert tokenize is True
+            assert add_generation_prompt is True
+            assert return_dict is False
+            return [10, 11, 12, 13]
+
+        def encode(self, text, *, add_special_tokens):
+            assert text.startswith("Knowledge distillation")
+            assert add_special_tokens is False
+            return list(range(20, 84))
+
+    dataset = TinyKDDataset(Tokenizer(), num_samples=1, seq_length=8, use_chat_template=True)
+
+    assert dataset[0]["input_ids"] == [10, 11, 12, 13, 20, 21, 22, 23]
+    assert dataset[0]["labels"] == [-100, -100, -100, 20, 21, 22, 23, 24]
+
+
+def test_tiny_kd_dataset_preserves_non_chat_first_label_mask():
+    class Tokenizer:
+        def encode(self, text, *, add_special_tokens):
+            assert text.startswith("Knowledge distillation")
+            assert add_special_tokens is True
+            return list(range(64))
+
+    dataset = TinyKDDataset(Tokenizer(), num_samples=1, seq_length=8)
+
+    assert dataset[0]["input_ids"] == list(range(8))
+    assert dataset[0]["labels"] == [-100, 2, 3, 4, 5, 6, 7, 8]
+
+
+def test_loss_comparator_rejects_mismatched_kd_settings():
+    baseline = {
+        "step": 0,
+        "loss": 1.0,
+        "ce_loss": 1.0,
+        "kd_loss": 1.0,
+        "grad_norm": 1.0,
+        "kd_ratio": 0.5,
+        "temperature": 1.0,
+    }
+    candidate = baseline | {"temperature": 2.0}
+
+    with pytest.raises(ValueError, match="mismatched run settings"):
+        _compare_pair("teacher_tp2", [baseline], [candidate], 0.01, 0.01)
 
 
 def test_materialize_teacher_logits_unshards_cp_and_removes_padding(monkeypatch):
@@ -37,7 +90,18 @@ def test_materialize_teacher_logits_unshards_cp_and_removes_padding(monkeypatch)
     local = torch.tensor([[[1.0], [2.0]]])
 
     def unshard(mesh, tensor, *, seq_dim):
-        """Expand local ``[B=1, S_local=2, V=1]`` logits to full sequence."""
+        """Expand local logits to the full sequence.
+
+        Args:
+            mesh: Mock context-parallel mesh.
+            tensor: Tensor of shape ``[batch=1, local_sequence=2, vocab=1]``
+                containing local logits.
+            seq_dim: Sequence axis, which must be one.
+
+        Returns:
+            Tensor of shape ``[batch=1, sequence=4, vocab=1]`` containing full
+            logits.
+        """
         assert mesh is cp_mesh
         assert tensor is local
         assert seq_dim == 1
@@ -141,7 +205,15 @@ def test_separate_kd_setup_rejects_ddp(monkeypatch):
 
 
 def _teacher_logits(input_ids: torch.Tensor) -> torch.Tensor:
-    """Return deterministic logits ``[B, S, V=3]`` for ids ``[B, S]``."""
+    """Return deterministic teacher logits.
+
+    Args:
+        input_ids: Tensor of shape ``[batch, sequence]`` containing token ids.
+
+    Returns:
+        Tensor of shape ``[batch, sequence, vocab]`` containing logits with
+        ``vocab = 3``.
+    """
     values = input_ids.float()
     return torch.stack((values * 0.5, values * -0.25 + 1.0, values * 0.125 - 0.5), dim=-1)
 

--- a/tests/unit_tests/recipes/test_kd_utils.py
+++ b/tests/unit_tests/recipes/test_kd_utils.py
@@ -21,6 +21,7 @@ import torch.distributed as dist
 import torch.multiprocessing as mp
 import yaml
 
+from nemo_automodel.components.checkpoint.config import CheckpointingConfig
 from nemo_automodel.components.distributed.config import DDPConfig, FSDP2Config
 from nemo_automodel.components.loss.kd_loss import KDLoss
 from nemo_automodel.recipes import kd_utils
@@ -295,6 +296,11 @@ def _run_kd_bridge_worker(rank: int, world_size: int, init_file: str) -> None:
         bridge = kd_utils.KDMeshBridge(setups, device=torch.device("cpu"))
         checkpointer = None
         batch = None
+        checkpoint_config = CheckpointingConfig(enabled=False, is_async=True)
+        async_process_groups = checkpoint_config.initialize_async_process_groups(
+            setups.student_ranks,
+            is_member=bridge.is_student,
+        )
         if bridge.is_student:
             input_ids = torch.tensor([[rank + 1, rank + 2]], dtype=torch.long)
             batch = {"input_ids": input_ids, "labels": input_ids.clone()}
@@ -319,15 +325,14 @@ def _run_kd_bridge_worker(rank: int, world_size: int, init_file: str) -> None:
             assert scale.grad is not None and torch.isfinite(scale.grad)
 
             from nemo_automodel.components.checkpoint.checkpointing import Checkpointer
-            from nemo_automodel.components.checkpoint.config import CheckpointingConfig
 
-            checkpoint_config = CheckpointingConfig(enabled=False, is_async=True)
             checkpointer = Checkpointer(
                 checkpoint_config,
                 dp_rank=rank,
                 tp_rank=0,
                 pp_rank=0,
                 process_group=bridge.student_group,
+                async_process_groups=async_process_groups,
             )
         bridge.synchronize()
         if checkpointer is not None:


### PR DESCRIPTION
# What does this PR do ?

Adds opt-in knowledge distillation with the student and teacher on disjoint device meshes, allowing each model to use an independent DP/TP/CP/PP layout.

# Changelog

- Add `separate_meshes`, `distributed`, and `teacher_distributed` configuration for KD recipes.
- Build rank-aware student and teacher meshes and validate that their explicit world sizes exactly cover the global world.
- Bridge nested batches and logits between disjoint rank sets, including unequal DP replica counts, TP full-vocabulary logits, CP gather/shard, and PP microbatch capture.
- Use model-specific process groups for checkpoint, signal, scheduler, dataloader serialization, and control collectives.
- Preserve the existing shared-mesh behavior by default.
- Add four-GPU Llama 3.2 example YAMLs for teacher TP2, CP2, and PP2 layouts under [`examples/llm_kd/llama3_2/`](https://github.com/NVIDIA-NeMo/Automodel/tree/akoumpa/separate_mesh_kd/examples/llm_kd/llama3_2).
- Add four-GPU Qwen3.5 VLM example YAMLs for teacher DP2, TP2, and CP2 layouts under [`examples/vlm_kd/qwen3_5/`](https://github.com/NVIDIA-NeMo/Automodel/tree/akoumpa/separate_mesh_kd/examples/vlm_kd/qwen3_5).
- Add unit tests, a 4-rank CPU functional test, a 4-GPU fixture, and [the complete TP2/CP2/PP2 LLM loss table](https://github.com/NVIDIA-NeMo/Automodel/blob/akoumpa/separate_mesh_kd/tests/functional_tests/llm_pretrain_and_kd/kd_separate_mesh_results.md).

# Review findings addressed

Ran an uncapped review against the latest repository review prompt and contributor skills after merging current `main`. Fixed 10 actionable findings:

1. Made synchronous/asynchronous checkpointing, addons, PEFT saves, consolidation, and barriers model-subgroup safe.
2. Made serialized dataset construction process-group aware instead of bypassing it with a boolean trap.
3. Corrected the Llama context-parallel capability declaration used by the new CP example.
4. Pinned the VLM teacher DP/TP/CP examples to the SDPA backend required by their native CP path.
5. Rejected unsupported separate-mesh expert parallelism early with a clear configuration error.
6. Consolidated duplicated LLM/VLM transport and TP vocabulary-shard helpers into `KDMeshBridge`.
7. Added distributed SIGTERM handling to teacher-only worker ranks.
8. Moved the private PyTorch CP unshard integration behind the distributed CP component boundary.
9. Documented tensor shapes, layouts, ownership, and microbatch contracts for new KD/CP helpers.
10. Added real four-process subgroup routing/checkpoint coverage and PP teacher-microbatch ordering coverage.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

Validation:

- `ruff` lint and format checks pass for all changed Python files.
- 146 focused KD/VLM/distributed/training/example tests pass.
- 204 checkpoint tests pass (`11 skipped`).
- The latest focused KD utility run passes (`11 passed`), including a real four-process Gloo test with disjoint student DP2 and teacher TP2 meshes plus subgroup-local async checkpoint initialization.
- The standalone 4-rank CPU bridge test passes with finite KD loss and gradients.
- cw-dfw 4-GPU LLM tests passed for teacher TP2 (10 steps), CP2 (1 step), and PP2 (1 step); every loss was finite and matched `0.5 * CE + 0.5 * KD` within `1e-5`.
- All six separate-mesh example YAMLs pass the example linter and load through the CLI config parser.
- `git diff --check` passes.

# Additional Information

LLM separate meshes support DP, TP, CP, and PP. VLM separate meshes support DP, TP, and CP; VLM PP remains unsupported, matching the existing VLM pipeline-parallel limitation.
