### PR TITLE
feat(speculative): report simulated accept length during EAGLE-3 training

### DIFF
--- a/nemo_automodel/components/speculative/eagle/__init__.py
+++ b/nemo_automodel/components/speculative/eagle/__init__.py
@@ -25,7 +25,7 @@ Import them directly from those modules.
 """
 
 from nemo_automodel.components.speculative.eagle.backend import Eagle3TargetBackend
-from nemo_automodel.components.speculative.eagle.core import Eagle3TrainerModule
+from nemo_automodel.components.speculative.eagle.core import Eagle3TrainerModule, simulated_accept_length
 from nemo_automodel.components.speculative.eagle.core_v12 import EagleTrainerModule
 from nemo_automodel.components.speculative.eagle.draft_gpt_oss import GptOssEagle3DraftModel
 from nemo_automodel.components.speculative.eagle.draft_llama import LlamaEagle3DraftModel
@@ -59,4 +59,5 @@ __all__ = [
     "EAGLE3_DRAFT_REGISTRY",
     "resolve_eagle1_draft_spec",
     "resolve_eagle3_draft_spec",
+    "simulated_accept_length",
 ]

--- a/nemo_automodel/components/speculative/eagle/core.py
+++ b/nemo_automodel/components/speculative/eagle/core.py
@@ -48,36 +48,46 @@ def _compute_target_distribution(
 class Eagle3StepMetrics:
     """Aggregated metrics from one EAGLE-3 training step.
 
-    ``step_correct`` / ``step_valid`` are ``[ttt_steps]`` per-TTT-step top-1 hit
-    and supervised-position counts, kept unreduced so the recipe can accumulate
-    them over a logging window and derive the simulated accept length
-    (:func:`simulated_accept_length`). The P-EAGLE trainer, whose depths are
-    drafted in parallel from one anchor rather than as a TTT chain, leaves
-    them ``None``.
+    ``step_prefix_hits`` / ``step_valid`` are ``[ttt_steps]`` per-TTT-step
+    counts for the simulated accept length (:func:`simulated_accept_length`):
+    ``step_prefix_hits[k]`` counts positions whose greedy draft chain is still
+    fully correct through depth ``k + 1`` (top-1 hit at every step ``<= k``),
+    and ``step_valid[k]`` counts positions supervised at step ``k`` under the
+    shifted loss/document mask. ``step_valid`` deliberately does NOT exclude
+    positions whose target token falls outside the compressed draft
+    vocabulary: serving must reject those tokens (the draft cannot emit
+    them), so they count as chain breaks instead of dropping out of the
+    denominator. Both are kept unreduced so the recipe can accumulate them
+    over a logging window. The P-EAGLE trainer, whose depths are drafted in
+    parallel from one anchor rather than as a TTT chain, leaves them
+    ``None``.
     """
 
     loss: torch.Tensor
     accuracy: torch.Tensor
     valid_tokens: torch.Tensor
-    step_correct: torch.Tensor | None = None
+    step_prefix_hits: torch.Tensor | None = None
     step_valid: torch.Tensor | None = None
 
 
-def simulated_accept_length(step_correct: torch.Tensor, step_valid: torch.Tensor) -> torch.Tensor:
-    """Expected accepted tokens per speculative round, from per-TTT-step accuracies.
+def simulated_accept_length(step_prefix_hits: torch.Tensor, step_valid: torch.Tensor) -> torch.Tensor:
+    """Expected accepted tokens per speculative round, from prefix-hit counts.
 
-    Models greedy chain drafting: step ``i``'s top-1 accuracy ``acc_i``
-    approximates the probability that the ``i``-th drafted token is accepted
-    given every earlier one was, so the expectation is
-    ``1 + sum_k prod_{i<=k} acc_i``. The leading 1 counts the token the target
-    itself emits on every verification round, matching the ``accept_length``
-    convention of the serving benchmarks (``1 + accepted/drafts``). A step
-    with no supervised positions gets zero accuracy from the ``clamp_min``,
-    conservatively truncating the chain there. This is a training-time proxy
-    for greedy chain decoding; engine tree drafting typically accepts more.
+    Models greedy chain drafting: ``step_prefix_hits[k] / step_valid[k]``
+    estimates the joint probability that the first ``k + 1`` drafted tokens
+    all match the target's greedy choices, i.e. that the chain survives depth
+    ``k + 1``, so the expectation is ``1 + sum_k P(survives depth k + 1)``.
+    Joint prefix counts keep the correlation between depths that a product of
+    per-step marginal accuracies discards (coincident and disjoint hits score
+    differently). The leading 1 counts the token the target itself emits on
+    every verification round, matching the ``accept_length`` convention of
+    the serving benchmarks (``1 + accepted/drafts``). A step with no
+    supervised positions contributes zero via the ``clamp_min``. This is a
+    training-time proxy for greedy chain decoding; engine tree drafting
+    typically accepts more.
     """
-    acc = step_correct.float() / step_valid.float().clamp_min(1.0)
-    return 1.0 + acc.cumprod(dim=0).sum()
+    survive = step_prefix_hits.float() / step_valid.float().clamp_min(1.0)
+    return 1.0 + survive.sum()
 
 
 class Eagle3TrainerModule(nn.Module):
@@ -170,13 +180,21 @@ class Eagle3TrainerModule(nn.Module):
             )
 
         running_loss = hidden_states.new_zeros(())
-        step_correct_parts: list[torch.Tensor] = []
+        running_correct = hidden_states.new_zeros(())
+        running_valid = hidden_states.new_zeros(())
+        step_prefix_parts: list[torch.Tensor] = []
         step_valid_parts: list[torch.Tensor] = []
 
         cur_input_ids = input_ids
         cur_position_mask = position_mask
         cur_target_probs = target_probs
         cur_hidden_states = hidden_states
+        # Simulated-accept-length state (see Eagle3StepMetrics). The TTT shift
+        # keeps slot ``j`` anchored to the same chain across steps (step ``k``
+        # at slot ``j`` drafts depth ``k + 1`` from anchor ``j``), so
+        # ``prefix_correct`` can AND per-step hits at the same slot index.
+        cur_loss_mask = loss_mask.bool()
+        prefix_correct: torch.Tensor | None = None
 
         # EAGLE-3 TTT KV cache: a pair of lists [K_list, V_list] that the
         # attention layer appends to on every step. Re-created per batch.
@@ -207,9 +225,11 @@ class Eagle3TrainerModule(nn.Module):
             # Packing: drop supervision whose step_idx-ahead target crosses this
             # slot's document boundary. Gate recomputed per step (depends on step_idx).
             step_position_mask = cur_position_mask
+            chain_valid = cur_loss_mask
             if doc_remaining is not None:
-                in_doc = (step_idx < doc_remaining).unsqueeze(-1)
-                step_position_mask = cur_position_mask & in_doc
+                in_doc = step_idx < doc_remaining
+                step_position_mask = cur_position_mask & in_doc.unsqueeze(-1)
+                chain_valid = chain_valid & in_doc
 
             step_loss = masked_soft_cross_entropy(
                 logits=logits,
@@ -220,23 +240,25 @@ class Eagle3TrainerModule(nn.Module):
 
             valid_mask = step_position_mask.squeeze(-1).bool()
             correct = (logits.argmax(dim=-1) == cur_target_probs.argmax(dim=-1)) & valid_mask
-            step_correct_parts.append(correct.sum())
-            step_valid_parts.append(valid_mask.sum())
+            running_correct = running_correct + correct.sum()
+            running_valid = running_valid + valid_mask.sum()
+
+            prefix_correct = correct if prefix_correct is None else prefix_correct & correct
+            step_prefix_parts.append(prefix_correct.sum())
+            step_valid_parts.append(chain_valid.sum())
 
             if step_idx + 1 < self.ttt_steps:
                 cur_input_ids = _shift_left_with_zero(cur_input_ids)
                 cur_position_mask = _shift_left_with_zero(cur_position_mask)
                 cur_target_probs = _shift_left_with_zero(cur_target_probs)
+                cur_loss_mask = _shift_left_with_zero(cur_loss_mask)
 
         avg_loss = running_loss / weight_sum
-        step_correct = torch.stack(step_correct_parts).detach()
-        step_valid = torch.stack(step_valid_parts).detach()
-        running_valid = step_valid.sum()
-        accuracy = step_correct.sum() / running_valid.clamp_min(1.0)
+        accuracy = running_correct / running_valid.clamp_min(1.0)
         return Eagle3StepMetrics(
             loss=avg_loss,
             accuracy=accuracy,
             valid_tokens=running_valid,
-            step_correct=step_correct,
-            step_valid=step_valid,
+            step_prefix_hits=torch.stack(step_prefix_parts).detach(),
+            step_valid=torch.stack(step_valid_parts).detach(),
         )

--- a/nemo_automodel/components/speculative/eagle/core.py
+++ b/nemo_automodel/components/speculative/eagle/core.py
@@ -46,11 +46,38 @@ def _compute_target_distribution(
 
 @dataclass
 class Eagle3StepMetrics:
-    """Aggregated metrics from one EAGLE-3 training step."""
+    """Aggregated metrics from one EAGLE-3 training step.
+
+    ``step_correct`` / ``step_valid`` are ``[ttt_steps]`` per-TTT-step top-1 hit
+    and supervised-position counts, kept unreduced so the recipe can accumulate
+    them over a logging window and derive the simulated accept length
+    (:func:`simulated_accept_length`). The P-EAGLE trainer, whose depths are
+    drafted in parallel from one anchor rather than as a TTT chain, leaves
+    them ``None``.
+    """
 
     loss: torch.Tensor
     accuracy: torch.Tensor
     valid_tokens: torch.Tensor
+    step_correct: torch.Tensor | None = None
+    step_valid: torch.Tensor | None = None
+
+
+def simulated_accept_length(step_correct: torch.Tensor, step_valid: torch.Tensor) -> torch.Tensor:
+    """Expected accepted tokens per speculative round, from per-TTT-step accuracies.
+
+    Models greedy chain drafting: step ``i``'s top-1 accuracy ``acc_i``
+    approximates the probability that the ``i``-th drafted token is accepted
+    given every earlier one was, so the expectation is
+    ``1 + sum_k prod_{i<=k} acc_i``. The leading 1 counts the token the target
+    itself emits on every verification round, matching the ``accept_length``
+    convention of the serving benchmarks (``1 + accepted/drafts``). A step
+    with no supervised positions gets zero accuracy from the ``clamp_min``,
+    conservatively truncating the chain there. This is a training-time proxy
+    for greedy chain decoding; engine tree drafting typically accepts more.
+    """
+    acc = step_correct.float() / step_valid.float().clamp_min(1.0)
+    return 1.0 + acc.cumprod(dim=0).sum()
 
 
 class Eagle3TrainerModule(nn.Module):
@@ -143,8 +170,8 @@ class Eagle3TrainerModule(nn.Module):
             )
 
         running_loss = hidden_states.new_zeros(())
-        running_correct = hidden_states.new_zeros(())
-        running_valid = hidden_states.new_zeros(())
+        step_correct_parts: list[torch.Tensor] = []
+        step_valid_parts: list[torch.Tensor] = []
 
         cur_input_ids = input_ids
         cur_position_mask = position_mask
@@ -193,8 +220,8 @@ class Eagle3TrainerModule(nn.Module):
 
             valid_mask = step_position_mask.squeeze(-1).bool()
             correct = (logits.argmax(dim=-1) == cur_target_probs.argmax(dim=-1)) & valid_mask
-            running_correct = running_correct + correct.sum()
-            running_valid = running_valid + valid_mask.sum()
+            step_correct_parts.append(correct.sum())
+            step_valid_parts.append(valid_mask.sum())
 
             if step_idx + 1 < self.ttt_steps:
                 cur_input_ids = _shift_left_with_zero(cur_input_ids)
@@ -202,5 +229,14 @@ class Eagle3TrainerModule(nn.Module):
                 cur_target_probs = _shift_left_with_zero(cur_target_probs)
 
         avg_loss = running_loss / weight_sum
-        accuracy = running_correct / running_valid.clamp_min(1.0)
-        return Eagle3StepMetrics(loss=avg_loss, accuracy=accuracy, valid_tokens=running_valid)
+        step_correct = torch.stack(step_correct_parts).detach()
+        step_valid = torch.stack(step_valid_parts).detach()
+        running_valid = step_valid.sum()
+        accuracy = step_correct.sum() / running_valid.clamp_min(1.0)
+        return Eagle3StepMetrics(
+            loss=avg_loss,
+            accuracy=accuracy,
+            valid_tokens=running_valid,
+            step_correct=step_correct,
+            step_valid=step_valid,
+        )

--- a/nemo_automodel/components/speculative/eagle/core.py
+++ b/nemo_automodel/components/speculative/eagle/core.py
@@ -52,15 +52,17 @@ class Eagle3StepMetrics:
     counts for the simulated accept length (:func:`simulated_accept_length`):
     ``step_prefix_hits[k]`` counts positions whose greedy draft chain is still
     fully correct through depth ``k + 1`` (top-1 hit at every step ``<= k``),
-    and ``step_valid[k]`` counts positions supervised at step ``k`` under the
-    shifted loss/document mask. ``step_valid`` deliberately does NOT exclude
-    positions whose target token falls outside the compressed draft
-    vocabulary: serving must reject those tokens (the draft cannot emit
-    them), so they count as chain breaks instead of dropping out of the
-    denominator. Both are kept unreduced so the recipe can accumulate them
-    over a logging window. The P-EAGLE trainer, whose depths are drafted in
-    parallel from one anchor rather than as a TTT chain, leaves them
-    ``None``.
+    and ``step_valid[k]`` counts positions supervised at every step ``<= k``
+    under the shifted loss/document masks, so numerator and denominator cover
+    the same chain population (a chain with an unsupervised earlier depth,
+    e.g. from a gappy multi-turn loss mask, can never be a hit and must not
+    count as a miss). ``step_valid`` deliberately does NOT exclude positions
+    whose target token falls outside the compressed draft vocabulary: serving
+    must reject those tokens (the draft cannot emit them), so they count as
+    chain breaks instead of dropping out of the denominator. Both are kept
+    unreduced so the recipe can accumulate them over a logging window. The
+    P-EAGLE trainer, whose depths are drafted in parallel from one anchor
+    rather than as a TTT chain, leaves them ``None``.
     """
 
     loss: torch.Tensor
@@ -191,10 +193,15 @@ class Eagle3TrainerModule(nn.Module):
         cur_hidden_states = hidden_states
         # Simulated-accept-length state (see Eagle3StepMetrics). The TTT shift
         # keeps slot ``j`` anchored to the same chain across steps (step ``k``
-        # at slot ``j`` drafts depth ``k + 1`` from anchor ``j``), so
-        # ``prefix_correct`` can AND per-step hits at the same slot index.
+        # at slot ``j`` drafts depth ``k + 1`` from anchor ``j``), so per-step
+        # hits and validity can be ANDed at the same slot index. Numerator and
+        # denominator must cover the same chain population: ``prefix_valid``
+        # drops a chain as soon as any of its depths is unsupervised (gappy
+        # loss masks make the per-step masks non-nested), since
+        # ``prefix_correct`` can never score such a chain.
         cur_loss_mask = loss_mask.bool()
         prefix_correct: torch.Tensor | None = None
+        prefix_valid: torch.Tensor | None = None
 
         # EAGLE-3 TTT KV cache: a pair of lists [K_list, V_list] that the
         # attention layer appends to on every step. Re-created per batch.
@@ -244,8 +251,9 @@ class Eagle3TrainerModule(nn.Module):
             running_valid = running_valid + valid_mask.sum()
 
             prefix_correct = correct if prefix_correct is None else prefix_correct & correct
+            prefix_valid = chain_valid if prefix_valid is None else prefix_valid & chain_valid
             step_prefix_parts.append(prefix_correct.sum())
-            step_valid_parts.append(chain_valid.sum())
+            step_valid_parts.append(prefix_valid.sum())
 
             if step_idx + 1 < self.ttt_steps:
                 cur_input_ids = _shift_left_with_zero(cur_input_ids)

--- a/nemo_automodel/recipes/llm/train_eagle3.py
+++ b/nemo_automodel/recipes/llm/train_eagle3.py
@@ -52,6 +52,7 @@ from nemo_automodel.components.loggers.wandb_utils import init_wandb_run, suppre
 from nemo_automodel.components.speculative.eagle import (
     Eagle3TrainerModule,
     HFEagle3TargetModel,
+    simulated_accept_length,
 )
 from nemo_automodel.components.speculative.eagle.registry import resolve_eagle3_draft_spec
 from nemo_automodel.components.speculative.eagle.remote import RemoteEagle3TargetModel
@@ -79,6 +80,30 @@ def _all_reduce_mean(value: torch.Tensor) -> torch.Tensor:
         dist.all_reduce(value, op=dist.ReduceOp.SUM)
         value = value / dist.get_world_size()
     return value
+
+
+def _all_reduce_sum(value: torch.Tensor) -> torch.Tensor:
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(value, op=dist.ReduceOp.SUM)
+    return value
+
+
+def _window_tau_sim(step_correct: torch.Tensor | None, step_valid: torch.Tensor | None) -> float | None:
+    """Simulated accept length over a metrics window, reduced across ranks.
+
+    ``step_correct`` / ``step_valid`` are the window's accumulated per-TTT-step
+    hit / supervised counts (``None`` when the trainer does not report them,
+    e.g. P-EAGLE). Counts are extensive, so they are sum-reduced across ranks
+    before forming the per-step accuracies; every rank must therefore call
+    this at the same point. Returns ``None`` when there is nothing to report.
+    """
+    if step_correct is None or step_valid is None:
+        return None
+    correct = _all_reduce_sum(step_correct.clone())
+    valid = _all_reduce_sum(step_valid.clone())
+    if valid.sum().item() <= 0:
+        return None
+    return simulated_accept_length(correct, valid).item()
 
 
 def _submesh_or_none(device_mesh, name: str):
@@ -1130,17 +1155,31 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
         total_loss = torch.zeros((), device=self.device)
         total_acc = torch.zeros((), device=self.device)
         total_batches = torch.zeros((), device=self.device)
+        total_step_correct: torch.Tensor | None = None
+        total_step_valid: torch.Tensor | None = None
         with torch.no_grad():
             for batch in self.val_dataloader:
                 metrics = self._forward_batch(batch)
                 total_loss = total_loss + metrics.loss.detach()
                 total_acc = total_acc + metrics.accuracy.detach()
                 total_batches = total_batches + 1
+                step_correct = getattr(metrics, "step_correct", None)
+                if step_correct is not None:
+                    if total_step_correct is None:
+                        total_step_correct = torch.zeros_like(step_correct, dtype=torch.float32)
+                        total_step_valid = torch.zeros_like(total_step_correct)
+                    total_step_correct += step_correct.float()
+                    total_step_valid += metrics.step_valid.float()
         total_loss = _all_reduce_mean(total_loss)
         total_acc = _all_reduce_mean(total_acc)
         total_batches = _all_reduce_mean(total_batches)
+        tau_sim = _window_tau_sim(total_step_correct, total_step_valid)
         self.trainer_module.train()
-        return (total_loss / total_batches.clamp_min(1.0), total_acc / total_batches.clamp_min(1.0))
+        return (
+            total_loss / total_batches.clamp_min(1.0),
+            total_acc / total_batches.clamp_min(1.0),
+            tau_sim,
+        )
 
     def _wandb_log(self, data: dict, step: int) -> None:
         """Log a metrics dict to W&B when a run is active (rank 0)."""
@@ -1217,6 +1256,11 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
 
             running_loss = torch.zeros((), device=self.device)
             running_acc = torch.zeros((), device=self.device)
+            # Per-TTT-step hit/valid counts for the simulated accept length;
+            # allocated lazily on the first batch that reports them (P-EAGLE
+            # metrics do not) so ttt_steps never has to be threaded here.
+            running_step_correct: torch.Tensor | None = None
+            running_step_valid: torch.Tensor | None = None
             running_steps = 0
             self.optimizer.zero_grad(set_to_none=True)
 
@@ -1253,6 +1297,13 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
 
                 running_loss = running_loss + metrics.loss.detach()
                 running_acc = running_acc + metrics.accuracy.detach()
+                step_correct = getattr(metrics, "step_correct", None)
+                if step_correct is not None:
+                    if running_step_correct is None:
+                        running_step_correct = torch.zeros_like(step_correct, dtype=torch.float32)
+                        running_step_valid = torch.zeros_like(running_step_correct)
+                    running_step_correct += step_correct.float()
+                    running_step_valid += metrics.step_valid.float()
                 running_steps += 1
                 batches_processed = batch_idx + 1
                 pending_micro_batches += 1
@@ -1271,34 +1322,42 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
                     if self.runtime.global_step % self.log_every_steps == 0:
                         mean_loss = _all_reduce_mean(running_loss / max(running_steps, 1))
                         mean_acc = _all_reduce_mean(running_acc / max(running_steps, 1))
+                        tau_sim = _window_tau_sim(running_step_correct, running_step_valid)
                         current_lr = self.lr_scheduler.get_last_lr()[0]
                         if self.dist_env.is_main:
                             if pbar is not None:
-                                pbar.set_postfix(
-                                    loss=f"{mean_loss.item():.4f}",
-                                    acc=f"{mean_acc.item():.4f}",
-                                    lr=f"{current_lr:.2e}",
-                                )
+                                postfix = {
+                                    "loss": f"{mean_loss.item():.4f}",
+                                    "acc": f"{mean_acc.item():.4f}",
+                                    "lr": f"{current_lr:.2e}",
+                                }
+                                if tau_sim is not None:
+                                    postfix["tau"] = f"{tau_sim:.2f}"
+                                pbar.set_postfix(**postfix)
                             logger.info(
-                                "epoch=%s step=%s train_loss=%.6f train_acc=%.6f lr=%.3e",
+                                "epoch=%s step=%s train_loss=%.6f train_acc=%.6f%s lr=%.3e",
                                 epoch,
                                 self.runtime.global_step,
                                 mean_loss.item(),
                                 mean_acc.item(),
+                                "" if tau_sim is None else f" train_tau_sim={tau_sim:.4f}",
                                 current_lr,
                             )
-                            self._wandb_log(
-                                {
-                                    "train/loss": mean_loss.item(),
-                                    "train/accuracy": mean_acc.item(),
-                                    "train/lr": current_lr,
-                                    "train/grad_norm": float(grad_norm),
-                                    "train/epoch": epoch,
-                                },
-                                step=self.runtime.global_step,
-                            )
+                            wandb_data = {
+                                "train/loss": mean_loss.item(),
+                                "train/accuracy": mean_acc.item(),
+                                "train/lr": current_lr,
+                                "train/grad_norm": float(grad_norm),
+                                "train/epoch": epoch,
+                            }
+                            if tau_sim is not None:
+                                wandb_data["train/tau_sim"] = tau_sim
+                            self._wandb_log(wandb_data, step=self.runtime.global_step)
                         running_loss.zero_()
                         running_acc.zero_()
+                        if running_step_correct is not None:
+                            running_step_correct.zero_()
+                            running_step_valid.zero_()
                         running_steps = 0
 
             # Flush the trailing partial accumulation window. When
@@ -1332,28 +1391,33 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
                 if running_steps > 0:
                     mean_loss = _all_reduce_mean(running_loss / max(running_steps, 1))
                     mean_acc = _all_reduce_mean(running_acc / max(running_steps, 1))
+                    tau_sim = _window_tau_sim(running_step_correct, running_step_valid)
                     current_lr = self.lr_scheduler.get_last_lr()[0]
                     if self.dist_env.is_main:
                         logger.info(
-                            "epoch=%s step=%s train_loss=%.6f train_acc=%.6f lr=%.3e (trailing flush)",
+                            "epoch=%s step=%s train_loss=%.6f train_acc=%.6f%s lr=%.3e (trailing flush)",
                             epoch,
                             self.runtime.global_step,
                             mean_loss.item(),
                             mean_acc.item(),
+                            "" if tau_sim is None else f" train_tau_sim={tau_sim:.4f}",
                             current_lr,
                         )
-                        self._wandb_log(
-                            {
-                                "train/loss": mean_loss.item(),
-                                "train/accuracy": mean_acc.item(),
-                                "train/lr": current_lr,
-                                "train/grad_norm": float(grad_norm),
-                                "train/epoch": epoch,
-                            },
-                            step=self.runtime.global_step,
-                        )
+                        wandb_data = {
+                            "train/loss": mean_loss.item(),
+                            "train/accuracy": mean_acc.item(),
+                            "train/lr": current_lr,
+                            "train/grad_norm": float(grad_norm),
+                            "train/epoch": epoch,
+                        }
+                        if tau_sim is not None:
+                            wandb_data["train/tau_sim"] = tau_sim
+                        self._wandb_log(wandb_data, step=self.runtime.global_step)
                     running_loss.zero_()
                     running_acc.zero_()
+                    if running_step_correct is not None:
+                        running_step_correct.zero_()
+                        running_step_valid.zero_()
                     running_steps = 0
 
             if self.dist_env.is_main:
@@ -1367,21 +1431,23 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
             eval_metrics = self._run_eval()
             val_loss_dict: dict[str, float] | None = None
             if eval_metrics is not None:
+                val_loss, val_acc, val_tau_sim = eval_metrics
                 val_loss_dict = {
-                    "val_loss": eval_metrics[0].item(),
-                    "val_accuracy": eval_metrics[1].item(),
+                    "val_loss": val_loss.item(),
+                    "val_accuracy": val_acc.item(),
                 }
                 if self.dist_env.is_main:
                     logger.info(
-                        "epoch=%s val_loss=%.6f val_acc=%.6f",
+                        "epoch=%s val_loss=%.6f val_acc=%.6f%s",
                         epoch,
                         val_loss_dict["val_loss"],
                         val_loss_dict["val_accuracy"],
+                        "" if val_tau_sim is None else f" val_tau_sim={val_tau_sim:.4f}",
                     )
-                    self._wandb_log(
-                        {"val/loss": val_loss_dict["val_loss"], "val/accuracy": val_loss_dict["val_accuracy"]},
-                        step=self.runtime.global_step,
-                    )
+                    wandb_data = {"val/loss": val_loss_dict["val_loss"], "val/accuracy": val_loss_dict["val_accuracy"]}
+                    if val_tau_sim is not None:
+                        wandb_data["val/tau_sim"] = val_tau_sim
+                    self._wandb_log(wandb_data, step=self.runtime.global_step)
             if getattr(self, "save_checkpoint_every_epoch", False):
                 self.save_checkpoint(
                     epoch=epoch + 1,

--- a/nemo_automodel/recipes/llm/train_eagle3.py
+++ b/nemo_automodel/recipes/llm/train_eagle3.py
@@ -88,22 +88,23 @@ def _all_reduce_sum(value: torch.Tensor) -> torch.Tensor:
     return value
 
 
-def _window_tau_sim(step_correct: torch.Tensor | None, step_valid: torch.Tensor | None) -> float | None:
+def _window_tau_sim(step_prefix_hits: torch.Tensor | None, step_valid: torch.Tensor | None) -> float | None:
     """Simulated accept length over a metrics window, reduced across ranks.
 
-    ``step_correct`` / ``step_valid`` are the window's accumulated per-TTT-step
-    hit / supervised counts (``None`` when the trainer does not report them,
-    e.g. P-EAGLE). Counts are extensive, so they are sum-reduced across ranks
-    before forming the per-step accuracies; every rank must therefore call
-    this at the same point. Returns ``None`` when there is nothing to report.
+    ``step_prefix_hits`` / ``step_valid`` are the window's accumulated
+    per-TTT-step prefix-hit / supervised counts (``None`` when the trainer
+    does not report them, e.g. P-EAGLE). Counts are extensive, so they are
+    sum-reduced across ranks before forming the per-step survival rates;
+    every rank must therefore call this at the same point. Returns ``None``
+    when there is nothing to report.
     """
-    if step_correct is None or step_valid is None:
+    if step_prefix_hits is None or step_valid is None:
         return None
-    correct = _all_reduce_sum(step_correct.clone())
+    hits = _all_reduce_sum(step_prefix_hits.clone())
     valid = _all_reduce_sum(step_valid.clone())
     if valid.sum().item() <= 0:
         return None
-    return simulated_accept_length(correct, valid).item()
+    return simulated_accept_length(hits, valid).item()
 
 
 def _submesh_or_none(device_mesh, name: str):
@@ -1155,7 +1156,7 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
         total_loss = torch.zeros((), device=self.device)
         total_acc = torch.zeros((), device=self.device)
         total_batches = torch.zeros((), device=self.device)
-        total_step_correct: torch.Tensor | None = None
+        total_step_prefix: torch.Tensor | None = None
         total_step_valid: torch.Tensor | None = None
         with torch.no_grad():
             for batch in self.val_dataloader:
@@ -1163,17 +1164,17 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
                 total_loss = total_loss + metrics.loss.detach()
                 total_acc = total_acc + metrics.accuracy.detach()
                 total_batches = total_batches + 1
-                step_correct = getattr(metrics, "step_correct", None)
-                if step_correct is not None:
-                    if total_step_correct is None:
-                        total_step_correct = torch.zeros_like(step_correct, dtype=torch.float32)
-                        total_step_valid = torch.zeros_like(total_step_correct)
-                    total_step_correct += step_correct.float()
+                step_prefix_hits = getattr(metrics, "step_prefix_hits", None)
+                if step_prefix_hits is not None:
+                    if total_step_prefix is None:
+                        total_step_prefix = torch.zeros_like(step_prefix_hits, dtype=torch.float32)
+                        total_step_valid = torch.zeros_like(total_step_prefix)
+                    total_step_prefix += step_prefix_hits.float()
                     total_step_valid += metrics.step_valid.float()
         total_loss = _all_reduce_mean(total_loss)
         total_acc = _all_reduce_mean(total_acc)
         total_batches = _all_reduce_mean(total_batches)
-        tau_sim = _window_tau_sim(total_step_correct, total_step_valid)
+        tau_sim = _window_tau_sim(total_step_prefix, total_step_valid)
         self.trainer_module.train()
         return (
             total_loss / total_batches.clamp_min(1.0),
@@ -1256,10 +1257,11 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
 
             running_loss = torch.zeros((), device=self.device)
             running_acc = torch.zeros((), device=self.device)
-            # Per-TTT-step hit/valid counts for the simulated accept length;
-            # allocated lazily on the first batch that reports them (P-EAGLE
-            # metrics do not) so ttt_steps never has to be threaded here.
-            running_step_correct: torch.Tensor | None = None
+            # Per-TTT-step prefix-hit/valid counts for the simulated accept
+            # length; allocated lazily on the first batch that reports them
+            # (P-EAGLE metrics do not) so ttt_steps never has to be threaded
+            # here.
+            running_step_prefix: torch.Tensor | None = None
             running_step_valid: torch.Tensor | None = None
             running_steps = 0
             self.optimizer.zero_grad(set_to_none=True)
@@ -1297,12 +1299,12 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
 
                 running_loss = running_loss + metrics.loss.detach()
                 running_acc = running_acc + metrics.accuracy.detach()
-                step_correct = getattr(metrics, "step_correct", None)
-                if step_correct is not None:
-                    if running_step_correct is None:
-                        running_step_correct = torch.zeros_like(step_correct, dtype=torch.float32)
-                        running_step_valid = torch.zeros_like(running_step_correct)
-                    running_step_correct += step_correct.float()
+                step_prefix_hits = getattr(metrics, "step_prefix_hits", None)
+                if step_prefix_hits is not None:
+                    if running_step_prefix is None:
+                        running_step_prefix = torch.zeros_like(step_prefix_hits, dtype=torch.float32)
+                        running_step_valid = torch.zeros_like(running_step_prefix)
+                    running_step_prefix += step_prefix_hits.float()
                     running_step_valid += metrics.step_valid.float()
                 running_steps += 1
                 batches_processed = batch_idx + 1
@@ -1322,7 +1324,7 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
                     if self.runtime.global_step % self.log_every_steps == 0:
                         mean_loss = _all_reduce_mean(running_loss / max(running_steps, 1))
                         mean_acc = _all_reduce_mean(running_acc / max(running_steps, 1))
-                        tau_sim = _window_tau_sim(running_step_correct, running_step_valid)
+                        tau_sim = _window_tau_sim(running_step_prefix, running_step_valid)
                         current_lr = self.lr_scheduler.get_last_lr()[0]
                         if self.dist_env.is_main:
                             if pbar is not None:
@@ -1355,8 +1357,8 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
                             self._wandb_log(wandb_data, step=self.runtime.global_step)
                         running_loss.zero_()
                         running_acc.zero_()
-                        if running_step_correct is not None:
-                            running_step_correct.zero_()
+                        if running_step_prefix is not None:
+                            running_step_prefix.zero_()
                             running_step_valid.zero_()
                         running_steps = 0
 
@@ -1391,7 +1393,7 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
                 if running_steps > 0:
                     mean_loss = _all_reduce_mean(running_loss / max(running_steps, 1))
                     mean_acc = _all_reduce_mean(running_acc / max(running_steps, 1))
-                    tau_sim = _window_tau_sim(running_step_correct, running_step_valid)
+                    tau_sim = _window_tau_sim(running_step_prefix, running_step_valid)
                     current_lr = self.lr_scheduler.get_last_lr()[0]
                     if self.dist_env.is_main:
                         logger.info(
@@ -1415,8 +1417,8 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
                         self._wandb_log(wandb_data, step=self.runtime.global_step)
                     running_loss.zero_()
                     running_acc.zero_()
-                    if running_step_correct is not None:
-                        running_step_correct.zero_()
+                    if running_step_prefix is not None:
+                        running_step_prefix.zero_()
                         running_step_valid.zero_()
                     running_steps = 0
 

--- a/tests/unit_tests/recipes/llm/test_train_eagle3_tau.py
+++ b/tests/unit_tests/recipes/llm/test_train_eagle3_tau.py
@@ -53,10 +53,10 @@ class _FakeDraftModel(nn.Module):
 class _FakeTrainerModule(nn.Module):
     """Fake trainer whose metrics carry fixed per-TTT-step counts.
 
-    ``step_correct=[2,1]`` / ``step_valid=[4,2]`` give per-step accuracies
-    ``[0.5, 0.5]`` and thus ``tau = 1 + 0.5 + 0.25 = 1.75`` for any window.
-    With ``with_step_counts=False`` the metrics omit the fields entirely,
-    modeling the P-EAGLE trainer.
+    ``step_prefix_hits=[2,1]`` / ``step_valid=[4,4]`` give prefix survival
+    rates ``[0.5, 0.25]`` and thus ``tau = 1 + 0.5 + 0.25 = 1.75`` for any
+    window. With ``with_step_counts=False`` the metrics omit the fields
+    entirely, modeling the P-EAGLE trainer.
     """
 
     def __init__(self, with_step_counts: bool = True):
@@ -73,8 +73,8 @@ class _FakeTrainerModule(nn.Module):
             valid_tokens=torch.tensor(6),
         )
         if self.with_step_counts:
-            metrics.step_correct = torch.tensor([2.0, 1.0])
-            metrics.step_valid = torch.tensor([4.0, 2.0])
+            metrics.step_prefix_hits = torch.tensor([2.0, 1.0])
+            metrics.step_valid = torch.tensor([4.0, 4.0])
         return metrics
 
 
@@ -178,16 +178,16 @@ def test_window_tau_sim_empty_window():
 
 
 def test_window_tau_sim_value():
-    tau = _window_tau_sim(torch.tensor([2.0, 1.0]), torch.tensor([4.0, 2.0]))
+    tau = _window_tau_sim(torch.tensor([2.0, 1.0]), torch.tensor([4.0, 4.0]))
     assert tau == pytest.approx(1.75)
 
 
 def test_window_tau_sim_does_not_mutate_buffers():
-    correct = torch.tensor([2.0, 1.0])
-    valid = torch.tensor([4.0, 2.0])
-    _window_tau_sim(correct, valid)
-    assert correct.tolist() == [2.0, 1.0]
-    assert valid.tolist() == [4.0, 2.0]
+    hits = torch.tensor([2.0, 1.0])
+    valid = torch.tensor([4.0, 4.0])
+    _window_tau_sim(hits, valid)
+    assert hits.tolist() == [2.0, 1.0]
+    assert valid.tolist() == [4.0, 4.0]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/recipes/llm/test_train_eagle3_tau.py
+++ b/tests/unit_tests/recipes/llm/test_train_eagle3_tau.py
@@ -1,0 +1,258 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Coverage for the simulated accept-length (tau) reporting in the EAGLE-3
+recipe: ``_all_reduce_sum`` / ``_window_tau_sim``, the training-window
+accumulation and progress-bar/log wiring, and the ``_run_eval`` tau column.
+
+The trainer-side math (per-step counts, :func:`simulated_accept_length`) is
+covered in ``tests/unit_tests/speculative/test_eagle3.py``; here the trainer
+module is faked and only the recipe plumbing is exercised.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader, TensorDataset
+
+from nemo_automodel.components.speculative.eagle.target import Eagle3TargetBatch
+from nemo_automodel.recipes.llm._spec_train_utils import optim_steps_per_epoch as _optim_steps_per_epoch
+from nemo_automodel.recipes.llm.train_eagle3 import (
+    TrainEagle3Recipe,
+    _all_reduce_sum,
+    _window_tau_sim,
+)
+
+# ---------------------------------------------------------------------------
+# Minimal stand-ins (mirrors test_train_eagle3_flush.py, plus step counts)
+# ---------------------------------------------------------------------------
+
+
+class _FakeDraftModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layer = nn.Linear(4, 4)
+        self.config = SimpleNamespace(save_pretrained=lambda path: None)
+
+
+class _FakeTrainerModule(nn.Module):
+    """Fake trainer whose metrics carry fixed per-TTT-step counts.
+
+    ``step_correct=[2,1]`` / ``step_valid=[4,2]`` give per-step accuracies
+    ``[0.5, 0.5]`` and thus ``tau = 1 + 0.5 + 0.25 = 1.75`` for any window.
+    With ``with_step_counts=False`` the metrics omit the fields entirely,
+    modeling the P-EAGLE trainer.
+    """
+
+    def __init__(self, with_step_counts: bool = True):
+        super().__init__()
+        self.draft_model = _FakeDraftModel()
+        self.dummy = nn.Linear(4, 4)
+        self.with_step_counts = with_step_counts
+
+    def forward(self, **kwargs):
+        out = self.dummy(torch.randn(1, 4)).sum()
+        metrics = SimpleNamespace(
+            loss=out.abs() + 1.0,
+            accuracy=torch.tensor(0.5),
+            valid_tokens=torch.tensor(6),
+        )
+        if self.with_step_counts:
+            metrics.step_correct = torch.tensor([2.0, 1.0])
+            metrics.step_valid = torch.tensor([4.0, 2.0])
+        return metrics
+
+
+class _FakeTargetWrapper:
+    def generate_batch(self, input_ids, attention_mask, loss_mask):
+        bs, sl = input_ids.shape
+        return Eagle3TargetBatch(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            loss_mask=loss_mask,
+            aux_hidden_states=torch.randn(bs, sl, 16),
+            logits=torch.randn(bs, sl, 64),
+        )
+
+    def close(self):
+        pass
+
+
+class _KeyedLoader:
+    def __init__(self, loader):
+        self._loader = loader
+        self.sampler = loader.sampler
+
+    def __iter__(self):
+        for ids, attn, lm in self._loader:
+            yield {"input_ids": ids, "attention_mask": attn, "loss_mask": lm}
+
+    def __len__(self):
+        return len(self._loader)
+
+
+def _make_loader(num_samples: int, sl: int = 6) -> _KeyedLoader:
+    data = TensorDataset(
+        torch.randint(0, 64, (num_samples, sl)),
+        torch.ones(num_samples, sl, dtype=torch.long),
+        torch.ones(num_samples, sl, dtype=torch.long),
+    )
+    return _KeyedLoader(DataLoader(data, batch_size=1))
+
+
+def _build_recipe(tmp_path, num_samples=4, grad_accum=2, with_step_counts=True, with_val=False):
+    trainer_module = _FakeTrainerModule(with_step_counts=with_step_counts)
+
+    recipe = TrainEagle3Recipe.__new__(TrainEagle3Recipe)
+    recipe.device = torch.device("cpu")
+    recipe.dist_env = SimpleNamespace(is_main=True, world_size=1)
+    recipe.trainer_module = trainer_module
+    recipe.target_wrapper = _FakeTargetWrapper()
+    recipe.target_prefetch_depth = 0
+    recipe.train_dataloader = _make_loader(num_samples)
+    recipe.val_dataloader = _make_loader(2) if with_val else None
+    recipe.output_dir = tmp_path
+    recipe.runtime = SimpleNamespace(global_step=0)
+    recipe.grad_accumulation_steps = grad_accum
+    recipe.max_grad_norm = 1.0
+    recipe.num_epochs = 1
+    recipe.log_every_steps = 1
+    recipe.peak_lr = 1e-4
+    recipe.total_optim_steps = _optim_steps_per_epoch(num_samples, grad_accum)
+    recipe.warmup_steps = 1
+    recipe.min_lr_ratio = 0.1
+    recipe.optimizer = torch.optim.AdamW([p for p in trainer_module.parameters() if p.requires_grad], lr=1e-4)
+    recipe.lr_scheduler = torch.optim.lr_scheduler.LambdaLR(recipe.optimizer, lambda s: 1.0)
+    return recipe
+
+
+class _FakeProgressBar:
+    def __init__(self):
+        self.n = 0
+        self.postfix = None
+        self.closed = False
+
+    def update(self, count=1):
+        self.n += count
+
+    def set_postfix(self, **kwargs):
+        self.postfix = kwargs
+
+    def close(self):
+        self.closed = True
+
+
+# ---------------------------------------------------------------------------
+# _all_reduce_sum / _window_tau_sim (non-distributed)
+# ---------------------------------------------------------------------------
+
+
+def test_all_reduce_sum_passthrough():
+    t = torch.tensor([1.0, 2.0])
+    assert _all_reduce_sum(t) is t
+
+
+def test_window_tau_sim_none_inputs():
+    assert _window_tau_sim(None, None) is None
+    assert _window_tau_sim(torch.tensor([1.0]), None) is None
+
+
+def test_window_tau_sim_empty_window():
+    zero = torch.zeros(3)
+    assert _window_tau_sim(zero, zero.clone()) is None
+
+
+def test_window_tau_sim_value():
+    tau = _window_tau_sim(torch.tensor([2.0, 1.0]), torch.tensor([4.0, 2.0]))
+    assert tau == pytest.approx(1.75)
+
+
+def test_window_tau_sim_does_not_mutate_buffers():
+    correct = torch.tensor([2.0, 1.0])
+    valid = torch.tensor([4.0, 2.0])
+    _window_tau_sim(correct, valid)
+    assert correct.tolist() == [2.0, 1.0]
+    assert valid.tolist() == [4.0, 2.0]
+
+
+# ---------------------------------------------------------------------------
+# Training loop wiring
+# ---------------------------------------------------------------------------
+
+
+def test_train_loop_reports_tau_in_postfix_and_wandb(tmp_path, monkeypatch):
+    fake_pbar = _FakeProgressBar()
+    monkeypatch.setattr(TrainEagle3Recipe, "_make_progress_bar", lambda self, **kwargs: fake_pbar)
+    recipe = _build_recipe(tmp_path, num_samples=4, grad_accum=2)
+    logged = []
+    recipe.wandb_run = SimpleNamespace(log=lambda data, step: logged.append(data), finish=lambda: None)
+    recipe.run_train_validation_loop()
+    assert set(fake_pbar.postfix) == {"loss", "acc", "lr", "tau"}
+    assert fake_pbar.postfix["tau"] == "1.75"
+    assert logged and all(entry["train/tau_sim"] == pytest.approx(1.75) for entry in logged)
+
+
+def test_train_loop_without_step_counts_omits_tau(tmp_path, monkeypatch):
+    """P-EAGLE-style metrics (no step counts) must leave the log line unchanged."""
+    fake_pbar = _FakeProgressBar()
+    monkeypatch.setattr(TrainEagle3Recipe, "_make_progress_bar", lambda self, **kwargs: fake_pbar)
+    recipe = _build_recipe(tmp_path, num_samples=4, grad_accum=2, with_step_counts=False)
+    logged = []
+    recipe.wandb_run = SimpleNamespace(log=lambda data, step: logged.append(data), finish=lambda: None)
+    recipe.run_train_validation_loop()
+    assert set(fake_pbar.postfix) == {"loss", "acc", "lr"}
+    assert logged and all("train/tau_sim" not in entry for entry in logged)
+
+
+def test_trailing_flush_reports_tau(tmp_path, monkeypatch):
+    """The trailing partial-window flush must carry the tau column too."""
+    fake_pbar = _FakeProgressBar()
+    monkeypatch.setattr(TrainEagle3Recipe, "_make_progress_bar", lambda self, **kwargs: fake_pbar)
+    # 3 samples / accum 2 -> one full window + one trailing flush.
+    recipe = _build_recipe(tmp_path, num_samples=3, grad_accum=2)
+    logged = []
+    recipe.wandb_run = SimpleNamespace(log=lambda data, step: logged.append(data), finish=lambda: None)
+    recipe.run_train_validation_loop()
+    assert recipe.runtime.global_step == 2
+    assert len(logged) == 2
+    assert all(entry["train/tau_sim"] == pytest.approx(1.75) for entry in logged)
+
+
+# ---------------------------------------------------------------------------
+# _run_eval
+# ---------------------------------------------------------------------------
+
+
+def test_run_eval_returns_tau(tmp_path):
+    recipe = _build_recipe(tmp_path, with_val=True)
+    val_loss, val_acc, val_tau = recipe._run_eval()
+    assert torch.isfinite(val_loss)
+    assert val_acc.item() == pytest.approx(0.5)
+    assert val_tau == pytest.approx(1.75)
+
+
+def test_run_eval_tau_none_without_step_counts(tmp_path):
+    recipe = _build_recipe(tmp_path, with_step_counts=False, with_val=True)
+    val_loss, val_acc, val_tau = recipe._run_eval()
+    assert torch.isfinite(val_loss)
+    assert val_tau is None
+
+
+def test_run_eval_none_without_val_loader(tmp_path):
+    recipe = _build_recipe(tmp_path, with_val=False)
+    assert recipe._run_eval() is None

--- a/tests/unit_tests/speculative/test_eagle3.py
+++ b/tests/unit_tests/speculative/test_eagle3.py
@@ -18,7 +18,11 @@ from transformers import LlamaConfig
 
 from nemo_automodel.components.datasets.llm.eagle3 import build_eagle3_token_mapping
 from nemo_automodel.components.loss.soft_ce import masked_soft_cross_entropy
-from nemo_automodel.components.speculative.eagle.core import Eagle3TrainerModule, _compute_target_distribution
+from nemo_automodel.components.speculative.eagle.core import (
+    Eagle3TrainerModule,
+    _compute_target_distribution,
+    simulated_accept_length,
+)
 from nemo_automodel.components.speculative.eagle.draft_llama import _HAS_FA, LlamaEagle3DraftModel
 from nemo_automodel.components.speculative.eagle.target import _shift_left_with_zero
 
@@ -274,6 +278,72 @@ def test_eagle3_trainer_runs_multi_step_ttt():
         if p.requires_grad
     )
     assert has_grad, "expected at least one parameter to receive a non-zero gradient"
+
+
+def test_simulated_accept_length_hand_values():
+    """The chain formula must match hand-computed expectations."""
+    # Perfect draft: every step accepted -> 1 bonus + ttt_steps drafted.
+    tau = simulated_accept_length(torch.tensor([4.0, 4.0, 4.0]), torch.tensor([4.0, 4.0, 4.0]))
+    assert tau.item() == pytest.approx(4.0)
+    # acc = [0.5, 0.5] -> 1 + 0.5 + 0.25.
+    tau = simulated_accept_length(torch.tensor([2.0, 1.0]), torch.tensor([4.0, 2.0]))
+    assert tau.item() == pytest.approx(1.75)
+    # A step with no supervised positions truncates the chain there:
+    # acc = [0.5, 0, 0.9-ish] -> 1 + 0.5 + 0 + 0.
+    tau = simulated_accept_length(torch.tensor([2.0, 0.0, 9.0]), torch.tensor([4.0, 0.0, 10.0]))
+    assert tau.item() == pytest.approx(1.5)
+    # Hopeless draft: nothing accepted beyond the bonus token.
+    tau = simulated_accept_length(torch.tensor([0.0, 0.0]), torch.tensor([4.0, 4.0]))
+    assert tau.item() == pytest.approx(1.0)
+
+
+def test_eagle3_trainer_reports_per_step_counts():
+    """The trainer must expose per-TTT-step counts consistent with its aggregates."""
+    torch.manual_seed(0)
+    draft = _build_tiny_draft_model()
+    config = draft.config
+
+    selected_token_ids = torch.arange(config.draft_vocab_size, dtype=torch.long)
+    selected_token_mask = torch.zeros(config.vocab_size, dtype=torch.bool)
+    selected_token_mask[selected_token_ids] = True
+
+    ttt_steps = 3
+    trainer = Eagle3TrainerModule(
+        draft,
+        selected_token_ids=selected_token_ids,
+        selected_token_mask=selected_token_mask,
+        ttt_steps=ttt_steps,
+    )
+
+    batch_size, seq_len = 2, 8
+    input_ids = torch.randint(0, config.draft_vocab_size, (batch_size, seq_len))
+    attention_mask = torch.ones(batch_size, seq_len, dtype=torch.long)
+    loss_mask = torch.ones(batch_size, seq_len, dtype=torch.long)
+    aux_hidden_states = torch.randn(batch_size, seq_len, config.hidden_size * 3)
+    target_logits = torch.randn(batch_size, seq_len, config.vocab_size)
+
+    with torch.no_grad():
+        metrics = trainer(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            loss_mask=loss_mask,
+            aux_hidden_states=aux_hidden_states,
+            target_logits=target_logits,
+        )
+
+    assert metrics.step_correct is not None and metrics.step_valid is not None
+    assert metrics.step_correct.shape == (ttt_steps,)
+    assert metrics.step_valid.shape == (ttt_steps,)
+    # The per-step counts must reproduce the aggregate accuracy and valid count.
+    assert metrics.step_valid.sum().item() == metrics.valid_tokens.item()
+    expected_acc = metrics.step_correct.sum().item() / max(metrics.step_valid.sum().item(), 1.0)
+    assert metrics.accuracy.item() == pytest.approx(expected_acc)
+    # Shifting rolls one supervised position out per step, so counts never grow.
+    step_valid = metrics.step_valid.tolist()
+    assert all(a >= b for a, b in zip(step_valid, step_valid[1:]))
+    assert (metrics.step_correct <= metrics.step_valid).all()
+    tau = simulated_accept_length(metrics.step_correct, metrics.step_valid)
+    assert 1.0 <= tau.item() <= 1.0 + ttt_steps
 
 
 def test_eagle3_trainer_single_vs_multi_step_first_step_matches():

--- a/tests/unit_tests/speculative/test_eagle3.py
+++ b/tests/unit_tests/speculative/test_eagle3.py
@@ -281,16 +281,22 @@ def test_eagle3_trainer_runs_multi_step_ttt():
 
 
 def test_simulated_accept_length_hand_values():
-    """The chain formula must match hand-computed expectations."""
-    # Perfect draft: every step accepted -> 1 bonus + ttt_steps drafted.
+    """The prefix-survival formula must match hand-computed expectations."""
+    # Perfect draft: every chain survives every depth -> 1 bonus + ttt_steps.
     tau = simulated_accept_length(torch.tensor([4.0, 4.0, 4.0]), torch.tensor([4.0, 4.0, 4.0]))
     assert tau.item() == pytest.approx(4.0)
-    # acc = [0.5, 0.5] -> 1 + 0.5 + 0.25.
-    tau = simulated_accept_length(torch.tensor([2.0, 1.0]), torch.tensor([4.0, 2.0]))
+    # Survival rates [0.5, 0.25] -> 1 + 0.5 + 0.25.
+    tau = simulated_accept_length(torch.tensor([2.0, 1.0]), torch.tensor([4.0, 4.0]))
     assert tau.item() == pytest.approx(1.75)
-    # A step with no supervised positions truncates the chain there:
-    # acc = [0.5, 0, 0.9-ish] -> 1 + 0.5 + 0 + 0.
-    tau = simulated_accept_length(torch.tensor([2.0, 0.0, 9.0]), torch.tensor([4.0, 0.0, 10.0]))
+    # Depth correlation is preserved: with both depths 50% accurate,
+    # coincident hits (the same 2 chains survive depth 2) accept more than
+    # disjoint hits (no chain survives depth 2).
+    tau = simulated_accept_length(torch.tensor([2.0, 2.0]), torch.tensor([4.0, 4.0]))
+    assert tau.item() == pytest.approx(2.0)
+    tau = simulated_accept_length(torch.tensor([2.0, 0.0]), torch.tensor([4.0, 4.0]))
+    assert tau.item() == pytest.approx(1.5)
+    # A step with no supervised positions contributes zero.
+    tau = simulated_accept_length(torch.tensor([2.0, 0.0, 0.0]), torch.tensor([4.0, 0.0, 10.0]))
     assert tau.item() == pytest.approx(1.5)
     # Hopeless draft: nothing accepted beyond the bonus token.
     tau = simulated_accept_length(torch.tensor([0.0, 0.0]), torch.tensor([4.0, 4.0]))
@@ -298,7 +304,7 @@ def test_simulated_accept_length_hand_values():
 
 
 def test_eagle3_trainer_reports_per_step_counts():
-    """The trainer must expose per-TTT-step counts consistent with its aggregates."""
+    """The trainer must expose prefix-hit and loss-mask-based valid counts."""
     torch.manual_seed(0)
     draft = _build_tiny_draft_model()
     config = draft.config
@@ -331,19 +337,72 @@ def test_eagle3_trainer_reports_per_step_counts():
             target_logits=target_logits,
         )
 
-    assert metrics.step_correct is not None and metrics.step_valid is not None
-    assert metrics.step_correct.shape == (ttt_steps,)
+    assert metrics.step_prefix_hits is not None and metrics.step_valid is not None
+    assert metrics.step_prefix_hits.shape == (ttt_steps,)
     assert metrics.step_valid.shape == (ttt_steps,)
-    # The per-step counts must reproduce the aggregate accuracy and valid count.
-    assert metrics.step_valid.sum().item() == metrics.valid_tokens.item()
-    expected_acc = metrics.step_correct.sum().item() / max(metrics.step_valid.sum().item(), 1.0)
-    assert metrics.accuracy.item() == pytest.approx(expected_acc)
-    # Shifting rolls one supervised position out per step, so counts never grow.
-    step_valid = metrics.step_valid.tolist()
-    assert all(a >= b for a, b in zip(step_valid, step_valid[1:]))
-    assert (metrics.step_correct <= metrics.step_valid).all()
-    tau = simulated_accept_length(metrics.step_correct, metrics.step_valid)
+    # The denominator follows the shifted loss mask, ignoring draft-vocab
+    # coverage: with a full loss mask, one position rolls out per step.
+    assert metrics.step_valid.tolist() == [batch_size * seq_len, batch_size * (seq_len - 1), batch_size * (seq_len - 2)]
+    # The coverage-filtered aggregate can only be smaller.
+    assert metrics.valid_tokens.item() <= metrics.step_valid.sum().item()
+    # Prefix hits are AND-accumulated per slot, so they never grow with depth
+    # and never exceed the supervised count.
+    step_prefix_hits = metrics.step_prefix_hits.tolist()
+    assert all(a >= b for a, b in zip(step_prefix_hits, step_prefix_hits[1:]))
+    assert (metrics.step_prefix_hits <= metrics.step_valid).all()
+    tau = simulated_accept_length(metrics.step_prefix_hits, metrics.step_valid)
     assert 1.0 <= tau.item() <= 1.0 + ttt_steps
+
+
+def test_eagle3_trainer_counts_out_of_vocab_targets_as_rejections():
+    """Targets outside the draft vocabulary stay in the acceptance denominator.
+
+    Serving must reject a target token the compressed draft vocabulary cannot
+    emit, so such positions count as chain breaks. Excluding them (as the CE
+    ``position_mask`` does) would bias tau upward whenever vocabulary
+    coverage is below 100%.
+    """
+    torch.manual_seed(0)
+    draft = _build_tiny_draft_model()
+    config = draft.config
+
+    selected_token_ids = torch.arange(config.draft_vocab_size, dtype=torch.long)
+    selected_token_mask = torch.zeros(config.vocab_size, dtype=torch.bool)
+    selected_token_mask[selected_token_ids] = True
+
+    trainer = Eagle3TrainerModule(
+        draft,
+        selected_token_ids=selected_token_ids,
+        selected_token_mask=selected_token_mask,
+        ttt_steps=1,
+    )
+
+    batch_size, seq_len = 1, 8
+    input_ids = torch.randint(0, config.draft_vocab_size, (batch_size, seq_len))
+    attention_mask = torch.ones(batch_size, seq_len, dtype=torch.long)
+    loss_mask = torch.ones(batch_size, seq_len, dtype=torch.long)
+    aux_hidden_states = torch.randn(batch_size, seq_len, config.hidden_size * 3)
+    # Force the target's greedy token out of the draft vocabulary on the last
+    # four positions; the first four stay in-vocabulary.
+    target_logits = torch.randn(batch_size, seq_len, config.vocab_size)
+    target_logits[:, :4, : config.draft_vocab_size] += 100.0
+    target_logits[:, 4:, config.draft_vocab_size] += 100.0
+
+    with torch.no_grad():
+        metrics = trainer(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            loss_mask=loss_mask,
+            aux_hidden_states=aux_hidden_states,
+            target_logits=target_logits,
+        )
+
+    # CE supervision sees only the four covered positions ...
+    assert metrics.valid_tokens.item() == 4
+    # ... but the acceptance denominator keeps all eight, and the four
+    # out-of-vocabulary targets can never be hits.
+    assert metrics.step_valid.tolist() == [seq_len]
+    assert metrics.step_prefix_hits.item() <= 4
 
 
 def test_eagle3_trainer_single_vs_multi_step_first_step_matches():

--- a/tests/unit_tests/speculative/test_eagle3.py
+++ b/tests/unit_tests/speculative/test_eagle3.py
@@ -340,8 +340,9 @@ def test_eagle3_trainer_reports_per_step_counts():
     assert metrics.step_prefix_hits is not None and metrics.step_valid is not None
     assert metrics.step_prefix_hits.shape == (ttt_steps,)
     assert metrics.step_valid.shape == (ttt_steps,)
-    # The denominator follows the shifted loss mask, ignoring draft-vocab
-    # coverage: with a full loss mask, one position rolls out per step.
+    # The denominator AND-accumulates the shifted loss masks (ignoring
+    # draft-vocab coverage); a full loss mask makes them nested, so one
+    # position rolls out per step.
     assert metrics.step_valid.tolist() == [batch_size * seq_len, batch_size * (seq_len - 1), batch_size * (seq_len - 2)]
     # The coverage-filtered aggregate can only be smaller.
     assert metrics.valid_tokens.item() <= metrics.step_valid.sum().item()
@@ -352,6 +353,53 @@ def test_eagle3_trainer_reports_per_step_counts():
     assert (metrics.step_prefix_hits <= metrics.step_valid).all()
     tau = simulated_accept_length(metrics.step_prefix_hits, metrics.step_valid)
     assert 1.0 <= tau.item() <= 1.0 + ttt_steps
+
+
+def test_eagle3_trainer_prefix_valid_follows_gappy_loss_mask():
+    """Numerator and denominator must cover the same chain population.
+
+    A chain whose earlier depth is unsupervised (prompt tokens, gappy
+    multi-turn loss masks) can never be a prefix hit, so it must leave the
+    denominator too; counting only the current step's mask would report such
+    chains as misses and deflate tau even for a perfect draft.
+    """
+    torch.manual_seed(0)
+    draft = _build_tiny_draft_model()
+    config = draft.config
+
+    selected_token_ids = torch.arange(config.draft_vocab_size, dtype=torch.long)
+    selected_token_mask = torch.zeros(config.vocab_size, dtype=torch.bool)
+    selected_token_mask[selected_token_ids] = True
+
+    ttt_steps = 3
+    trainer = Eagle3TrainerModule(
+        draft,
+        selected_token_ids=selected_token_ids,
+        selected_token_mask=selected_token_mask,
+        ttt_steps=ttt_steps,
+    )
+
+    batch_size, seq_len = 1, 8
+    input_ids = torch.randint(0, config.draft_vocab_size, (batch_size, seq_len))
+    attention_mask = torch.ones(batch_size, seq_len, dtype=torch.long)
+    # Prompt-style mask: the first two positions are unsupervised.
+    loss_mask = torch.tensor([[0, 0, 1, 1, 1, 1, 1, 1]], dtype=torch.long)
+    aux_hidden_states = torch.randn(batch_size, seq_len, config.hidden_size * 3)
+    target_logits = torch.randn(batch_size, seq_len, config.vocab_size)
+
+    with torch.no_grad():
+        metrics = trainer(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            loss_mask=loss_mask,
+            aux_hidden_states=aux_hidden_states,
+            target_logits=target_logits,
+        )
+
+    # AND-accumulated shifted masks: [00111111] -> &[01111110] -> &[11111100].
+    # Per-current-step counts would be [6, 7, 6] instead.
+    assert metrics.step_valid.tolist() == [6, 5, 4]
+    assert (metrics.step_prefix_hits <= metrics.step_valid).all()
 
 
 def test_eagle3_trainer_counts_out_of_vocab_targets_as_rejections():


### PR DESCRIPTION
## What

Adds a training-time **simulated accept length** (`tau_sim`) metric to the EAGLE-3 recipe, the "Training-time acceptance-length metric for EAGLE-3" item from the tracking issue #2958. No engine, no extra forward, no new config knob: the metric is derived from counts the trainer already computes.

## How

- `Eagle3TrainerModule` now returns per-TTT-step top-1 hit / supervised-position counts (`step_correct` / `step_valid`, `[ttt_steps]` tensors) on `Eagle3StepMetrics`; the aggregate `accuracy` / `valid_tokens` are derived from their sums, so the numbers are unchanged.
- New `simulated_accept_length` helper computes the greedy chain expectation `tau = 1 + sum_k prod_{i<=k} acc_i`. Step `i`'s accuracy approximates the probability that the i-th drafted token is accepted given every earlier one was; the leading 1 is the token the target emits on every verification round, matching the `accept_length` convention of `bench_sglang` / `bench_vllm` (`1 + accepted/drafts`) and the DSpark `tau` naming in #2957.
- The recipe accumulates the counts over each logging window and sum-reduces them across ranks (counts are extensive, unlike the mean-reduced loss/accuracy), then reports `train_tau_sim` on the progress bar, the periodic and trailing-flush log lines, and W&B (`train/tau_sim`). `_run_eval` gains the same `val_tau_sim` column.
- P-EAGLE drafts all depths in parallel from one anchor rather than as a TTT chain, so the chain formula does not apply; its trainer leaves the new optional fields `None` and its logging is unchanged (covered by a test).

This is a proxy for greedy chain decoding; engine tree drafting typically accepts more. It is meant for tracking training progress in accept-length units, not for replacing the serving benchmarks.

## Tests

- `tests/unit_tests/speculative/test_eagle3.py`: hand-computed `simulated_accept_length` values (perfect draft, partial, zero-valid step truncation, hopeless draft); trainer forward exposes `[ttt_steps]` counts consistent with the aggregate accuracy/valid_tokens, monotone non-increasing valid counts.
- `tests/unit_tests/recipes/llm/test_train_eagle3_tau.py`: `_all_reduce_sum` / `_window_tau_sim` (None inputs, empty window, value, buffer non-mutation); train loop reports tau in pbar postfix and W&B for both the periodic log and the trailing flush; metrics without step counts (P-EAGLE shape) omit tau everywhere; `_run_eval` returns the tau column and `None` without step counts.

`tests/unit_tests/speculative/` + `tests/unit_tests/recipes/llm/` pass locally (the pre-existing `test_benchmark.py` failures reproduce on clean main and are unrelated). `ruff format` / `ruff check` clean.
