### PR TITLE
feat(speculative): add multi-dataset acceptance-length benchmark sweep

### DIFF
--- a/examples/speculative/README.md
+++ b/examples/speculative/README.md
@@ -386,7 +386,7 @@ python -m nemo_automodel.components.speculative.bench_sweep --engine sglang --se
 ```
 
 The default suite is the four benchmarks the EAGLE / EAGLE-2 papers report
-acceptance/speedup on -- MT-Bench (multi-turn chat), HumanEval (code), GSM8K
+acceptance/speedup on -- MT-Bench (first turn), HumanEval (code), GSM8K
 (math), and Alpaca (single-turn instruction-following). None of these ship a
 chat-messages column, so each is read via `--prompt-column` (a raw text field
 wrapped into a fresh single-turn user message) rather than

--- a/examples/speculative/README.md
+++ b/examples/speculative/README.md
@@ -371,6 +371,43 @@ cover exactly the benchmark's own requests:
 python -m nemo_automodel.components.speculative.bench_vllm --server http://localhost:8000 --model Qwen/Qwen3-8B --input-data <prompts-dataset> --baseline-server http://localhost:8001
 ```
 
+### Multi-dataset sweep
+
+`bench_sglang.py`/`bench_vllm.py` measure one dataset per invocation, but the
+same draft's acceptance rate can vary sharply by task -- conversational data
+tends to accept far more tokens than math or code, whose token distributions
+diverge from the training mix. `bench_sweep.py` drives either engine through
+several datasets in one pass and reports a per-dataset table plus a
+completed-weighted aggregate, instead of invoking the single-dataset scripts
+once per dataset and collating the numbers by hand:
+
+```bash
+python -m nemo_automodel.components.speculative.bench_sweep --engine sglang --server http://localhost:30000 --model meta-llama/Llama-3.1-8B-Instruct
+```
+
+The default suite is the four benchmarks the EAGLE / EAGLE-2 papers report
+acceptance/speedup on -- MT-Bench (multi-turn chat), HumanEval (code), GSM8K
+(math), and Alpaca (single-turn instruction-following). None of these ship a
+chat-messages column, so each is read via `--prompt-column` (a raw text field
+wrapped into a fresh single-turn user message) rather than
+`--messages-column`; both flags are also available on `bench_sglang.py` /
+`bench_vllm.py` directly for a single custom dataset. Pass `--engine vllm` to
+sweep a vLLM server instead, `--baseline-server` for the speedup column,
+`--datasets <name...>` to run a subset, and `--datasets-config <path.yaml>` to
+swap in an entirely custom dataset list (see
+`bench_sweep/spec_bench_datasets.yaml`, which mirrors the built-in default and
+doubles as a template). One dataset failing to load or benchmark is reported
+as an error row and excluded from the aggregate rather than aborting the sweep.
+
+**`--engine sglang` caveat with more than one dataset:** SGLang's
+`avg_spec_accept_length` is a server-cumulative running average with no
+reset/delta API, so sweeping several datasets against one live SGLang server
+means every dataset after the first reports a blend with prior datasets'
+traffic, not an independent number (a warning is logged when this applies).
+Restart the server between datasets for independent numbers, or use
+`--engine vllm`, which diffs its Prometheus counters per dataset and has no
+such caveat.
+
 ## Inference-engine compatibility
 
 | Draft | SGLang | vLLM |
@@ -444,6 +481,7 @@ examples/speculative/
   eagle1/    eagle2/    eagle3/    eagle3_1/    p-eagle/
   dflash/                     # DFlash + Domino (qwen3_domino.yaml) configs
   jetspec/   dspark/
+  bench_sweep/                # --datasets-config example for bench_sweep.py
   README.md                   # this file (includes the dataset regeneration guide)
 examples/dllm_sft/            # DFlash DLLM SFT configs (standard SFT schema)
 ```
@@ -466,6 +504,7 @@ nemo_automodel/components/speculative/
   bench_common.py          # shared chat-completions workload machinery
   bench_sglang.py          # acceptance-length / speedup benchmark (SGLang)
   bench_vllm.py            # acceptance-length / speedup benchmark (vLLM)
+  bench_sweep.py           # multi-dataset acceptance-length sweep (either engine)
 nemo_automodel/recipes/llm/
   train_eagle1.py  train_eagle2.py  train_eagle3.py  peagle_recipe.py
   train_dflash.py  train_domino.py  train_jetspec.py  train_dspark.py

--- a/examples/speculative/bench_sweep/spec_bench_datasets.yaml
+++ b/examples/speculative/bench_sweep/spec_bench_datasets.yaml
@@ -1,0 +1,34 @@
+# Multi-dataset acceptance-length sweep, EAGLE / EAGLE-2 paper suite.
+#
+# This is the SAME list bench_sweep.py ships as its built-in default
+# (nemo_automodel.components.speculative.bench_sweep.DEFAULT_DATASET_PRESETS);
+# kept here as a working example to copy from when building a custom sweep
+# with --datasets-config.
+#
+# Each entry needs exactly one of messages_column (an existing OpenAI-messages
+# list) or prompt_column (a raw text field, wrapped into a single-turn user
+# message -- none of these four datasets ship a messages column natively).
+# max_new_tokens/dataset_name are optional.
+
+datasets:
+  - name: mt_bench
+    input_data: HuggingFaceH4/mt_bench_prompts
+    split: train
+    prompt_column: turns # multi-turn column; the first turn is used
+
+  - name: humaneval
+    input_data: openai/openai_humaneval
+    split: test
+    prompt_column: prompt
+    max_new_tokens: 512 # code completions run longer than chat replies
+
+  - name: gsm8k
+    input_data: openai/gsm8k
+    dataset_name: main
+    split: test
+    prompt_column: question
+
+  - name: alpaca
+    input_data: tatsu-lab/alpaca
+    split: train
+    prompt_column: instruction

--- a/examples/speculative/bench_sweep/spec_bench_datasets.yaml
+++ b/examples/speculative/bench_sweep/spec_bench_datasets.yaml
@@ -14,7 +14,7 @@ datasets:
   - name: mt_bench
     input_data: HuggingFaceH4/mt_bench_prompts
     split: train
-    prompt_column: turns # multi-turn column; the first turn is used
+    prompt_column: prompt # two-turn column (a list); the first turn is used
 
   - name: humaneval
     input_data: openai/openai_humaneval
@@ -32,3 +32,4 @@ datasets:
     input_data: tatsu-lab/alpaca
     split: train
     prompt_column: instruction
+    prompt_context_column: input # appended when non-empty (~40% of rows); output never used

--- a/nemo_automodel/components/speculative/bench_common.py
+++ b/nemo_automodel/components/speculative/bench_common.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 import logging
 import time
 from dataclasses import dataclass
@@ -162,8 +163,30 @@ async def _run_workload(
     )
 
 
+def _extract_prompt_text(value: Any) -> str | None:
+    """Normalize a raw (non-chat) dataset field into a single prompt string.
+
+    Accepts a plain string, or a non-empty list of strings (the first entry is
+    used -- e.g. MT-Bench's multi-turn ``turns`` column, reduced to its first
+    turn). Returns ``None`` for anything else, or a blank/whitespace-only string.
+    """
+    if isinstance(value, list):
+        value = value[0] if value else None
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return value
+
+
 def _load_prompts(args: argparse.Namespace) -> list[list[dict[str, Any]]]:
-    """Load up to ``--num-prompts`` chat prompts (trailing assistant turn dropped)."""
+    """Load up to ``--num-prompts`` chat prompts.
+
+    Reads from ``--prompt-column`` when set (a raw single-turn text field,
+    wrapped into a fresh user message -- for datasets like GSM8K/HumanEval that
+    are not chat-messages-shaped), else from ``--messages-column`` (an existing
+    OpenAI-messages list, trailing assistant turn dropped). ``prompt_column`` is
+    an optional attribute -- callers that only ever use ``messages_column``
+    (the two single-dataset benchmarks' own ``argparse.Namespace``) need not set it.
+    """
     from nemo_automodel.components.datasets.llm.chat_dataset import _load_openai_messages
 
     dataset = _load_openai_messages(
@@ -172,9 +195,14 @@ def _load_prompts(args: argparse.Namespace) -> list[list[dict[str, Any]]]:
         name=args.dataset_name,
         shuffle_seed=args.shuffle_seed,
     )
+    prompt_column = getattr(args, "prompt_column", None)
     prompts: list[list[dict[str, Any]]] = []
     for row in dataset:
-        prompt = _extract_prompt_messages(row[args.messages_column])
+        if prompt_column:
+            text = _extract_prompt_text(row.get(prompt_column))
+            prompt = [{"role": "user", "content": text}] if text is not None else None
+        else:
+            prompt = _extract_prompt_messages(row[args.messages_column])
         if prompt is not None:
             prompts.append(prompt)
         if len(prompts) >= args.num_prompts:
@@ -194,3 +222,21 @@ def _validate_workload_args(args: argparse.Namespace) -> None:
         raise ValueError(f"--max-retries must be >= 0, got {args.max_retries}")
     if args.timeout_s <= 0:
         raise ValueError(f"--timeout-s must be > 0, got {args.timeout_s}")
+
+
+def _report_summary(summary: dict[str, Any] | None, output_json: str | None) -> int:
+    """Print a benchmark summary as JSON, optionally also write it to ``output_json``.
+
+    Shared tail of ``bench_sglang``/``bench_vllm``'s ``_run``: returns exit code
+    ``1`` with nothing printed when ``summary`` is ``None`` (no usable prompts
+    were loaded), else ``0``.
+    """
+    if summary is None:
+        return 1
+    rendered = json.dumps(summary, indent=2)
+    print(rendered)
+    if output_json:
+        with open(output_json, "w") as f:
+            f.write(rendered + "\n")
+        logger.info("Wrote metrics to %s", output_json)
+    return 0

--- a/nemo_automodel/components/speculative/bench_common.py
+++ b/nemo_automodel/components/speculative/bench_common.py
@@ -167,7 +167,7 @@ def _extract_prompt_text(value: Any) -> str | None:
     """Normalize a raw (non-chat) dataset field into a single prompt string.
 
     Accepts a plain string, or a non-empty list of strings (the first entry is
-    used -- e.g. MT-Bench's multi-turn ``turns`` column, reduced to its first
+    used -- e.g. MT-Bench's two-turn ``prompt`` column, reduced to its first
     turn). Returns ``None`` for anything else, or a blank/whitespace-only string.
     """
     if isinstance(value, list):
@@ -196,10 +196,18 @@ def _load_prompts(args: argparse.Namespace) -> list[list[dict[str, Any]]]:
         shuffle_seed=args.shuffle_seed,
     )
     prompt_column = getattr(args, "prompt_column", None)
+    prompt_context_column = getattr(args, "prompt_context_column", None)
     prompts: list[list[dict[str, Any]]] = []
     for row in dataset:
         if prompt_column:
             text = _extract_prompt_text(row.get(prompt_column))
+            # Append a secondary context field (e.g. Alpaca's ``input``) when the
+            # row carries one, so prompts that need it are not truncated to the
+            # bare instruction. The reference answer is never read.
+            if text is not None and prompt_context_column:
+                context = _extract_prompt_text(row.get(prompt_context_column))
+                if context is not None:
+                    text = f"{text}\n\n{context}"
             prompt = [{"role": "user", "content": text}] if text is not None else None
         else:
             prompt = _extract_prompt_messages(row[args.messages_column])

--- a/nemo_automodel/components/speculative/bench_sglang.py
+++ b/nemo_automodel/components/speculative/bench_sglang.py
@@ -56,7 +56,6 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import json
 import logging
 import sys
 from typing import Any
@@ -69,6 +68,7 @@ from nemo_automodel.components.speculative.bench_common import (
     _load_prompts,
     _normalize_server_url,
     _output_throughput,
+    _report_summary,
     _run_workload,
     _speedup,
     _validate_workload_args,
@@ -210,8 +210,15 @@ def _validate_args(args: argparse.Namespace) -> None:
         raise ValueError(f"--num-steps must be >= 1 when set, got {args.num_steps}")
 
 
-async def _run(args: argparse.Namespace) -> int:
-    """Async driver: load prompts, run the workload(s), report metrics. Returns an exit code."""
+async def _run_summary(args: argparse.Namespace) -> dict[str, Any] | None:
+    """Validate args, run the workload(s), and return the metrics dict.
+
+    Returns ``None`` when no usable prompts were loaded (the caller's cue to
+    report a failure without raising -- a bad ``--num-prompts``/etc. value is a
+    real programming error and still raises via ``_validate_args``). Split out
+    of ``_run`` so ``bench_sweep`` can drive one dataset at a time without the
+    printing / ``--output-json`` side effects below.
+    """
     _validate_args(args)
     gen_cfg = GenerationConfig(
         model=args.model,
@@ -222,7 +229,7 @@ async def _run(args: argparse.Namespace) -> int:
     prompts = _load_prompts(args)
     if not prompts:
         logger.error("No usable prompts loaded from %s; nothing to benchmark.", args.input_data)
-        return 1
+        return None
     logger.info("Benchmarking %d prompts against %s", len(prompts), args.server)
 
     spec_result = await _run_workload(
@@ -260,14 +267,13 @@ async def _run(args: argparse.Namespace) -> int:
             "and is %s a fresh SGLang server? Throughput is still reported.",
             args.server,
         )
+    return summary
 
-    rendered = json.dumps(summary, indent=2)
-    print(rendered)
-    if args.output_json:
-        with open(args.output_json, "w") as f:
-            f.write(rendered + "\n")
-        logger.info("Wrote metrics to %s", args.output_json)
-    return 0
+
+async def _run(args: argparse.Namespace) -> int:
+    """Async driver: compute the benchmark summary and report it. Returns an exit code."""
+    summary = await _run_summary(args)
+    return _report_summary(summary, args.output_json)
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -306,6 +312,12 @@ def _build_parser() -> argparse.ArgumentParser:
         help="speculative_num_steps fallback for acceptance_rate when /server_info omits it.",
     )
     parser.add_argument("--messages-column", default="messages", help="Column holding the OpenAI messages list.")
+    parser.add_argument(
+        "--prompt-column",
+        default=None,
+        help="Column holding a raw prompt string (or list of turns, first used) instead of --messages-column, "
+        "for datasets that are not already chat-messages-shaped.",
+    )
     parser.add_argument("--split", default="train", help="HF dataset split (supports slice syntax).")
     parser.add_argument("--dataset-name", default=None, help="HF dataset configuration name, if any.")
     parser.add_argument("--shuffle-seed", type=int, default=None, help="Optional shuffle seed before slicing.")

--- a/nemo_automodel/components/speculative/bench_sweep.py
+++ b/nemo_automodel/components/speculative/bench_sweep.py
@@ -83,6 +83,11 @@ class DatasetSpec:
     Exactly one of ``messages_column`` (an existing OpenAI-messages list) or
     ``prompt_column`` (a raw text field, wrapped into a single-turn user
     message) must be set -- see ``bench_common._load_prompts``.
+
+    ``prompt_context_column`` is an optional second raw-text field appended to
+    ``prompt_column`` (separated by a blank line) when it is non-empty, for
+    datasets whose task context lives in a separate column (e.g. Alpaca's
+    ``input``). It is only valid alongside ``prompt_column``.
     """
 
     name: str
@@ -91,6 +96,7 @@ class DatasetSpec:
     dataset_name: str | None = None
     messages_column: str | None = None
     prompt_column: str | None = None
+    prompt_context_column: str | None = None
     max_new_tokens: int | None = None
 
     def __post_init__(self):
@@ -99,12 +105,19 @@ class DatasetSpec:
                 f"dataset {self.name!r}: exactly one of messages_column / prompt_column must be set "
                 f"(got messages_column={self.messages_column!r}, prompt_column={self.prompt_column!r})"
             )
+        if self.prompt_context_column and not self.prompt_column:
+            raise ValueError(
+                f"dataset {self.name!r}: prompt_context_column={self.prompt_context_column!r} requires "
+                "prompt_column to be set (it is appended to the prompt_column text)."
+            )
 
 
-# The classic EAGLE / EAGLE-2 paper suite: multi-turn chat (MT-Bench), code
-# (HumanEval), math (GSM8K), and single-turn instruction-following (Alpaca).
+# The classic EAGLE / EAGLE-2 paper suite: chat (MT-Bench, first turn), code
+# (HumanEval), math (GSM8K), and instruction-following (Alpaca).
 DEFAULT_DATASET_PRESETS: tuple[DatasetSpec, ...] = (
-    DatasetSpec(name="mt_bench", input_data="HuggingFaceH4/mt_bench_prompts", split="train", prompt_column="turns"),
+    # HuggingFaceH4/mt_bench_prompts stores the two-turn sequence under ``prompt``
+    # (a list); the first turn is used (see bench_common._extract_prompt_text).
+    DatasetSpec(name="mt_bench", input_data="HuggingFaceH4/mt_bench_prompts", split="train", prompt_column="prompt"),
     DatasetSpec(
         name="humaneval",
         input_data="openai/openai_humaneval",
@@ -113,7 +126,16 @@ DEFAULT_DATASET_PRESETS: tuple[DatasetSpec, ...] = (
         max_new_tokens=512,
     ),
     DatasetSpec(name="gsm8k", input_data="openai/gsm8k", dataset_name="main", split="test", prompt_column="question"),
-    DatasetSpec(name="alpaca", input_data="tatsu-lab/alpaca", split="train", prompt_column="instruction"),
+    # Alpaca's task context lives in a separate ``input`` field (non-empty for
+    # ~40% of rows); append it so those prompts are not truncated to the bare
+    # instruction. The reference ``output`` is never included.
+    DatasetSpec(
+        name="alpaca",
+        input_data="tatsu-lab/alpaca",
+        split="train",
+        prompt_column="instruction",
+        prompt_context_column="input",
+    ),
 )
 
 _ENGINE_MODULES = {"sglang": bench_sglang, "vllm": bench_vllm}
@@ -176,6 +198,7 @@ def _dataset_args(base_args: argparse.Namespace, spec: DatasetSpec) -> argparse.
     args.dataset_name = spec.dataset_name
     args.messages_column = spec.messages_column
     args.prompt_column = spec.prompt_column
+    args.prompt_context_column = spec.prompt_context_column
     if spec.max_new_tokens is not None:
         args.max_new_tokens = spec.max_new_tokens
     return args
@@ -215,6 +238,13 @@ async def _run_sweep(args: argparse.Namespace, specs: list[DatasetSpec]) -> list
             continue
         if summary is None:
             results.append({"dataset": spec.name, "error": "no usable prompts loaded"})
+            continue
+        # _run_workload swallows per-request HTTP errors, so an engine whose every
+        # request failed still returns a summary with completed=0 rather than raising.
+        # Treat that as an error row so it is excluded from num_datasets_ok and the
+        # sweep's exit status reflects that no benchmark actually ran.
+        if summary.get("completed", 0) < 1:
+            results.append({"dataset": spec.name, "error": "all requests failed (0 completed)"})
             continue
         results.append({"dataset": spec.name, **summary})
     return results

--- a/nemo_automodel/components/speculative/bench_sweep.py
+++ b/nemo_automodel/components/speculative/bench_sweep.py
@@ -24,13 +24,13 @@ instead of the user invoking ``bench_sglang``/``bench_vllm`` once per dataset
 and collating the output by hand.
 
 Default dataset suite -- the four benchmarks the EAGLE / EAGLE-2 papers report
-acceptance / speedup numbers on: MT-Bench (multi-turn chat), HumanEval (code),
+acceptance / speedup numbers on: MT-Bench (first turn), HumanEval (code),
 GSM8K (math), and Alpaca (single-turn instruction-following). None of these
 ship a chat-messages column the way ``bench_sglang``/``bench_vllm``'s
 ``--messages-column`` expects, so each reads a raw text field instead
 (``bench_common``'s ``--prompt-column`` path: the field is wrapped into a
-fresh single-turn user message; a list value, e.g. MT-Bench's multi-turn
-``turns`` column, uses its first entry).
+fresh single-turn user message; a list value, e.g. MT-Bench's two-turn
+``prompt`` column, uses its first entry).
 
 Override the default suite with ``--datasets-config <path.yaml>``: a YAML list
 of entries, each ``{name, input_data, split, dataset_name, messages_column |

--- a/nemo_automodel/components/speculative/bench_sweep.py
+++ b/nemo_automodel/components/speculative/bench_sweep.py
@@ -1,0 +1,345 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sweep a trained drafter's acceptance-length benchmark across multiple datasets.
+
+``bench_sglang`` / ``bench_vllm`` measure ONE workload per invocation. The same
+draft can behave very differently across task types -- conversational data
+(ShareGPT / MT-Bench) tends to have far higher acceptance than math (GSM8K) or
+code (HumanEval), whose token distributions diverge sharply from the training
+mix. This script drives the same server through several named datasets in one
+pass and reports a per-dataset table plus a completed-weighted aggregate,
+instead of the user invoking ``bench_sglang``/``bench_vllm`` once per dataset
+and collating the output by hand.
+
+Default dataset suite -- the four benchmarks the EAGLE / EAGLE-2 papers report
+acceptance / speedup numbers on: MT-Bench (multi-turn chat), HumanEval (code),
+GSM8K (math), and Alpaca (single-turn instruction-following). None of these
+ship a chat-messages column the way ``bench_sglang``/``bench_vllm``'s
+``--messages-column`` expects, so each reads a raw text field instead
+(``bench_common``'s ``--prompt-column`` path: the field is wrapped into a
+fresh single-turn user message; a list value, e.g. MT-Bench's multi-turn
+``turns`` column, uses its first entry).
+
+Override the default suite with ``--datasets-config <path.yaml>``: a YAML list
+of entries, each ``{name, input_data, split, dataset_name, messages_column |
+prompt_column, max_new_tokens}`` (``dataset_name``/``max_new_tokens`` optional;
+exactly one of ``messages_column``/``prompt_column`` required). ``--datasets``
+further narrows either suite to a name subset.
+
+Typical usage (after ``serve_sglang`` launches the drafter on port 30000)::
+
+    python -m nemo_automodel.components.speculative.bench_sweep \\
+        --engine sglang --server http://localhost:30000 \\
+        --model meta-llama/Llama-3.1-8B-Instruct
+
+Add ``--baseline-server`` for the speedup column, ``--engine vllm`` for a vLLM
+server, and ``--datasets-config`` to point at a custom dataset list. One
+dataset failing to load or benchmark (bad HF id, unreachable server for that
+request, ...) does not abort the sweep -- it is reported as an error row and
+excluded from the aggregate.
+
+CAVEAT (``--engine sglang`` with more than one dataset): SGLang's
+``avg_spec_accept_length`` is a server-cumulative running average with no
+reset/delta API (see ``bench_sglang``'s module docstring), so sweeping N>1
+datasets against ONE live SGLang server means every dataset after the first
+reports a blend with prior datasets' traffic, not an independent number. A
+warning is logged when this applies. Restart the server between datasets for
+independent numbers, or use ``--engine vllm``, which snapshots and diffs its
+Prometheus counters per dataset and has no such caveat.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import copy
+import json
+import logging
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+from nemo_automodel.components.speculative import bench_sglang, bench_vllm
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class DatasetSpec:
+    """One dataset to sweep: how to load it and where its prompt text lives.
+
+    Exactly one of ``messages_column`` (an existing OpenAI-messages list) or
+    ``prompt_column`` (a raw text field, wrapped into a single-turn user
+    message) must be set -- see ``bench_common._load_prompts``.
+    """
+
+    name: str
+    input_data: str
+    split: str = "train"
+    dataset_name: str | None = None
+    messages_column: str | None = None
+    prompt_column: str | None = None
+    max_new_tokens: int | None = None
+
+    def __post_init__(self):
+        if bool(self.messages_column) == bool(self.prompt_column):
+            raise ValueError(
+                f"dataset {self.name!r}: exactly one of messages_column / prompt_column must be set "
+                f"(got messages_column={self.messages_column!r}, prompt_column={self.prompt_column!r})"
+            )
+
+
+# The classic EAGLE / EAGLE-2 paper suite: multi-turn chat (MT-Bench), code
+# (HumanEval), math (GSM8K), and single-turn instruction-following (Alpaca).
+DEFAULT_DATASET_PRESETS: tuple[DatasetSpec, ...] = (
+    DatasetSpec(name="mt_bench", input_data="HuggingFaceH4/mt_bench_prompts", split="train", prompt_column="turns"),
+    DatasetSpec(
+        name="humaneval",
+        input_data="openai/openai_humaneval",
+        split="test",
+        prompt_column="prompt",
+        max_new_tokens=512,
+    ),
+    DatasetSpec(name="gsm8k", input_data="openai/gsm8k", dataset_name="main", split="test", prompt_column="question"),
+    DatasetSpec(name="alpaca", input_data="tatsu-lab/alpaca", split="train", prompt_column="instruction"),
+)
+
+_ENGINE_MODULES = {"sglang": bench_sglang, "vllm": bench_vllm}
+
+# Validates the workload flags shared by every dataset (num_prompts, concurrency,
+# max_new_tokens, max_retries, timeout_s, and sglang's num_steps). A bad value here
+# is a single misconfiguration, not a per-dataset failure -- see _run's upfront call.
+_ENGINE_VALIDATORS = {"sglang": bench_sglang._validate_args, "vllm": bench_vllm._validate_workload_args}
+
+
+def _load_dataset_specs(config_path: str | None) -> list[DatasetSpec]:
+    """Return the sweep's dataset list: the built-in suite, or a ``--datasets-config`` YAML override.
+
+    The config's top level must be a mapping with a ``datasets:`` list (not a
+    bare top-level list) so the file passes the repo's example-YAML linter,
+    which requires every ``examples/`` YAML to parse to a mapping.
+    """
+    if config_path is None:
+        return list(DEFAULT_DATASET_PRESETS)
+    import yaml
+
+    with open(config_path) as f:
+        document = yaml.safe_load(f)
+    entries = document.get("datasets") if isinstance(document, dict) else None
+    if not isinstance(entries, list) or not entries:
+        raise ValueError(f"{config_path} must contain a non-empty top-level `datasets:` list.")
+    specs: list[DatasetSpec] = []
+    seen: set[str] = set()
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ValueError(f"{config_path}: each dataset entry must be a mapping, got {entry!r}.")
+        try:
+            spec = DatasetSpec(**entry)
+        except TypeError as exc:
+            raise ValueError(f"{config_path}: invalid dataset entry {entry!r}: {exc}") from exc
+        if spec.name in seen:
+            raise ValueError(f"{config_path}: duplicate dataset name {spec.name!r}.")
+        seen.add(spec.name)
+        specs.append(spec)
+    return specs
+
+
+def _select_datasets(specs: list[DatasetSpec], names: list[str] | None) -> list[DatasetSpec]:
+    """Narrow ``specs`` to ``--datasets``, preserving the sweep's declared order."""
+    if names is None:
+        return specs
+    available = {s.name for s in specs}
+    missing = set(names) - available
+    if missing:
+        raise ValueError(f"--datasets names not in the sweep list: {sorted(missing)} (available: {sorted(available)})")
+    wanted = set(names)
+    return [s for s in specs if s.name in wanted]
+
+
+def _dataset_args(base_args: argparse.Namespace, spec: DatasetSpec) -> argparse.Namespace:
+    """Clone the shared server/model/workload args, overridden with one dataset's spec."""
+    args = copy.copy(base_args)
+    args.input_data = spec.input_data
+    args.split = spec.split
+    args.dataset_name = spec.dataset_name
+    args.messages_column = spec.messages_column
+    args.prompt_column = spec.prompt_column
+    if spec.max_new_tokens is not None:
+        args.max_new_tokens = spec.max_new_tokens
+    return args
+
+
+def _warn_if_sglang_stats_will_be_cumulative(args: argparse.Namespace, num_datasets: int) -> None:
+    """SGLang's ``avg_spec_accept_length`` is a server-cumulative running average (see bench_sglang.py's
+    module docstring): it has no reset/delta API, so sweeping N>1 datasets against ONE live SGLang
+    server means every dataset after the first reports a blend with prior datasets' traffic, not an
+    independent number. vLLM's Prometheus counters are snapshotted before/after each dataset instead
+    (see bench_vllm._run_summary), so this caveat is sglang-only.
+    """
+    if args.engine == "sglang" and num_datasets > 1:
+        logger.warning(
+            "Sweeping %d datasets against one SGLang server: accept_length/acceptance_rate for every "
+            "dataset after the first will be contaminated by earlier datasets' traffic (SGLang's "
+            "avg_spec_accept_length is a server-cumulative running average with no reset). Restart the "
+            "server between datasets for independent per-dataset numbers, or use --engine vllm, which "
+            "diffs its counters per dataset.",
+            num_datasets,
+        )
+
+
+async def _run_sweep(args: argparse.Namespace, specs: list[DatasetSpec]) -> list[dict[str, Any]]:
+    """Run one benchmark per dataset spec; one dataset's failure does not abort the sweep."""
+    engine = _ENGINE_MODULES[args.engine]
+    _warn_if_sglang_stats_will_be_cumulative(args, len(specs))
+    results: list[dict[str, Any]] = []
+    for spec in specs:
+        dataset_args = _dataset_args(args, spec)
+        logger.info("[%s] benchmarking %s (engine=%s)", spec.name, spec.input_data, args.engine)
+        try:
+            summary = await engine._run_summary(dataset_args)
+        except Exception as exc:  # noqa: BLE001 -- one bad dataset must not abort the sweep
+            logger.error("[%s] failed: %s", spec.name, exc)
+            results.append({"dataset": spec.name, "error": str(exc)})
+            continue
+        if summary is None:
+            results.append({"dataset": spec.name, "error": "no usable prompts loaded"})
+            continue
+        results.append({"dataset": spec.name, **summary})
+    return results
+
+
+def _weighted_mean(ok_results: list[dict[str, Any]], key: str) -> float | None:
+    """Completed-weighted mean of ``key`` over already-filtered (error-free) results."""
+    pairs = [(r[key], r.get("completed", 0)) for r in ok_results if r.get(key) is not None]
+    weight = sum(w for _, w in pairs)
+    if not pairs or weight <= 0:
+        return None
+    return sum(v * w for v, w in pairs) / weight
+
+
+def _aggregate(results: list[dict[str, Any]]) -> dict[str, Any]:
+    """Completed-weighted rollup of accept_length / acceptance_rate / throughput / speedup."""
+    ok = [r for r in results if "error" not in r]
+    return {
+        "num_datasets": len(results),
+        "num_datasets_ok": len(ok),
+        "total_completed": sum(r.get("completed", 0) for r in ok),
+        "accept_length": _weighted_mean(ok, "accept_length"),
+        "acceptance_rate": _weighted_mean(ok, "acceptance_rate"),
+        "output_throughput_tok_s": _weighted_mean(ok, "output_throughput_tok_s"),
+        "speedup": _weighted_mean(ok, "speedup"),
+    }
+
+
+def _fmt(value: Any, digits: int = 3) -> str:
+    if value is None:
+        return "n/a"
+    if isinstance(value, float):
+        return f"{value:.{digits}f}"
+    return str(value)
+
+
+def _row_line(name: str, row: dict[str, Any]) -> str:
+    """Format one fixed-width row (a dataset result or the aggregate) sharing one column layout."""
+    if "error" in row:
+        return f"{name:<12} {'ERROR':>9} {row['error']}"
+    return (
+        f"{name:<12} {row.get('completed', row.get('total_completed', 0)):>9} "
+        f"{_fmt(row.get('accept_length')):>10} {_fmt(row.get('acceptance_rate')):>11} "
+        f"{_fmt(row.get('output_throughput_tok_s'), 1):>10} {_fmt(row.get('speedup')):>8}"
+    )
+
+
+def _print_table(results: list[dict[str, Any]], aggregate: dict[str, Any]) -> None:
+    """Hand-rolled fixed-width table: one row per dataset, an error row for failures, then the aggregate."""
+    header = f"{'dataset':<12} {'completed':>9} {'accept_len':>10} {'accept_rate':>11} {'tok/s':>10} {'speedup':>8}"
+    rule = "-" * len(header)
+    print(header)
+    print(rule)
+    for r in results:
+        print(_row_line(r["dataset"], r))
+    print(rule)
+    print(_row_line("aggregate", aggregate))
+
+
+async def _run(args: argparse.Namespace) -> int:
+    """Async driver: sweep every selected dataset, print the table, optionally write JSON."""
+    # A bad SHARED flag (e.g. --num-prompts 0) applies identically to every dataset;
+    # validate once here so it raises immediately with a clear message, instead of
+    # being caught by _run_sweep's per-dataset try/except and reported as N copies
+    # of the same "dataset failure".
+    _ENGINE_VALIDATORS[args.engine](args)
+    specs = _select_datasets(_load_dataset_specs(args.datasets_config), args.datasets)
+
+    results = await _run_sweep(args, specs)
+    aggregate = _aggregate(results)
+    _print_table(results, aggregate)
+
+    if args.output_json:
+        payload = {"results": results, "aggregate": aggregate}
+        with open(args.output_json, "w") as f:
+            json.dump(payload, f, indent=2)
+            f.write("\n")
+        logger.info("Wrote sweep results to %s", args.output_json)
+
+    return 0 if aggregate["num_datasets_ok"] > 0 else 1
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Sweep a trained drafter's acceptance-length benchmark across multiple datasets.",
+    )
+    parser.add_argument("--engine", choices=sorted(_ENGINE_MODULES), required=True, help="Which server to drive.")
+    parser.add_argument("--server", required=True, help="Root URL of the running server hosting the drafter.")
+    parser.add_argument("--model", required=True, help="Served model name to send in the chat payload.")
+    parser.add_argument(
+        "--baseline-server", default=None, help="Optional second server running WITHOUT speculation; enables speedup."
+    )
+    parser.add_argument(
+        "--datasets-config", default=None, help="YAML list of dataset entries overriding the default 4-dataset suite."
+    )
+    parser.add_argument(
+        "--datasets", nargs="+", default=None, help="Subset of dataset names to run (default: the full suite)."
+    )
+    parser.add_argument("--num-prompts", type=int, default=64, help="Number of prompts to send per dataset.")
+    parser.add_argument("--concurrency", type=int, default=16, help="Maximum in-flight requests.")
+    parser.add_argument(
+        "--max-new-tokens", type=int, default=256, help="Default max_tokens per request (per-dataset overridable)."
+    )
+    parser.add_argument("--temperature", type=float, default=0.0, help="Default 0.0 = greedy.")
+    parser.add_argument("--top-p", type=float, default=1.0)
+    parser.add_argument(
+        "--num-steps", type=int, default=None, help="sglang engine only: speculative_num_steps fallback."
+    )
+    parser.add_argument("--shuffle-seed", type=int, default=None, help="Optional shuffle seed before slicing.")
+    parser.add_argument("--timeout-s", type=float, default=600.0, help="Per-request timeout in seconds.")
+    parser.add_argument("--max-retries", type=int, default=3, help="Retries on 5xx / 429 / transport errors.")
+    parser.add_argument("--output-json", default=None, help="Optional path to write the full sweep results JSON to.")
+    parser.add_argument("--log-level", default="INFO")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Parses ``argv`` and returns the process exit code."""
+    args = _build_parser().parse_args(argv)
+    logging.basicConfig(
+        level=getattr(logging, args.log_level.upper(), logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    return asyncio.run(_run(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/nemo_automodel/components/speculative/bench_vllm.py
+++ b/nemo_automodel/components/speculative/bench_vllm.py
@@ -57,7 +57,6 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import json
 import logging
 import sys
 from dataclasses import dataclass
@@ -68,6 +67,7 @@ from nemo_automodel.components.speculative.bench_common import (
     _load_prompts,
     _normalize_server_url,
     _output_throughput,
+    _report_summary,
     _run_workload,
     _speedup,
     _validate_workload_args,
@@ -197,8 +197,15 @@ def _summarize(
     return summary
 
 
-async def _run(args: argparse.Namespace) -> int:
-    """Async driver: load prompts, run the workload(s), report metrics. Returns an exit code."""
+async def _run_summary(args: argparse.Namespace) -> dict[str, Any] | None:
+    """Validate args, run the workload(s), and return the metrics dict.
+
+    Returns ``None`` when no usable prompts were loaded (the caller's cue to
+    report a failure without raising -- a bad ``--num-prompts``/etc. value is a
+    real programming error and still raises via ``_validate_workload_args``).
+    Split out of ``_run`` so ``bench_sweep`` can drive one dataset at a time
+    without the printing / ``--output-json`` side effects below.
+    """
     _validate_workload_args(args)
     gen_cfg = GenerationConfig(
         model=args.model,
@@ -209,7 +216,7 @@ async def _run(args: argparse.Namespace) -> int:
     prompts = _load_prompts(args)
     if not prompts:
         logger.error("No usable prompts loaded from %s; nothing to benchmark.", args.input_data)
-        return 1
+        return None
     logger.info("Benchmarking %d prompts against %s", len(prompts), args.server)
 
     metrics_before = await _fetch_spec_metrics(args.server, timeout_s=args.timeout_s)
@@ -252,14 +259,13 @@ async def _run(args: argparse.Namespace) -> int:
             "enabled on %s? Throughput is still reported.",
             args.server,
         )
+    return summary
 
-    rendered = json.dumps(summary, indent=2)
-    print(rendered)
-    if args.output_json:
-        with open(args.output_json, "w") as f:
-            f.write(rendered + "\n")
-        logger.info("Wrote metrics to %s", args.output_json)
-    return 0
+
+async def _run(args: argparse.Namespace) -> int:
+    """Async driver: compute the benchmark summary and report it. Returns an exit code."""
+    summary = await _run_summary(args)
+    return _report_summary(summary, args.output_json)
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -295,6 +301,12 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--temperature", type=float, default=0.0, help="Default 0.0 = greedy.")
     parser.add_argument("--top-p", type=float, default=1.0)
     parser.add_argument("--messages-column", default="messages", help="Column holding the OpenAI messages list.")
+    parser.add_argument(
+        "--prompt-column",
+        default=None,
+        help="Column holding a raw prompt string (or list of turns, first used) instead of --messages-column, "
+        "for datasets that are not already chat-messages-shaped.",
+    )
     parser.add_argument("--split", default="train", help="HF dataset split (supports slice syntax).")
     parser.add_argument("--dataset-name", default=None, help="HF dataset configuration name, if any.")
     parser.add_argument("--shuffle-seed", type=int, default=None, help="Optional shuffle seed before slicing.")

--- a/tests/unit_tests/speculative/test_bench_common.py
+++ b/tests/unit_tests/speculative/test_bench_common.py
@@ -132,3 +132,43 @@ def test_load_prompts_prompt_column_respects_num_prompts_cap(monkeypatch):
     )
     prompts = _load_prompts(_args(prompt_column="question", num_prompts=2))
     assert len(prompts) == 2
+
+
+# ---------------------------------------------------------------------------
+# _load_prompts: prompt_context_column (Alpaca-style secondary field)
+# ---------------------------------------------------------------------------
+
+
+def test_load_prompts_appends_context_column_when_present(monkeypatch):
+    """Alpaca-shaped rows: instruction + non-empty input are joined into one prompt."""
+    rows = [{"instruction": "Identify the odd one out.", "input": "Twitter, Instagram, Telegram."}]
+    monkeypatch.setattr(
+        "nemo_automodel.components.datasets.llm.chat_dataset._load_openai_messages", lambda *a, **k: rows
+    )
+    prompts = _load_prompts(_args(prompt_column="instruction", prompt_context_column="input"))
+    assert prompts == [[{"role": "user", "content": "Identify the odd one out.\n\nTwitter, Instagram, Telegram."}]]
+
+
+def test_load_prompts_omits_empty_context_column(monkeypatch):
+    """A blank/missing context field leaves the bare instruction untouched."""
+    rows = [{"instruction": "Name a color.", "input": ""}, {"instruction": "Name a fruit."}]
+    monkeypatch.setattr(
+        "nemo_automodel.components.datasets.llm.chat_dataset._load_openai_messages", lambda *a, **k: rows
+    )
+    prompts = _load_prompts(_args(prompt_column="instruction", prompt_context_column="input"))
+    assert prompts == [
+        [{"role": "user", "content": "Name a color."}],
+        [{"role": "user", "content": "Name a fruit."}],
+    ]
+
+
+def test_load_prompts_context_column_attribute_optional(monkeypatch):
+    """A Namespace that never sets prompt_context_column behaves as before (no append)."""
+    rows = [{"instruction": "Name a color.", "input": "ignored"}]
+    monkeypatch.setattr(
+        "nemo_automodel.components.datasets.llm.chat_dataset._load_openai_messages", lambda *a, **k: rows
+    )
+    args = _args(prompt_column="instruction")  # _args never sets prompt_context_column
+    assert not hasattr(args, "prompt_context_column")
+    prompts = _load_prompts(args)
+    assert prompts == [[{"role": "user", "content": "Name a color."}]]

--- a/tests/unit_tests/speculative/test_bench_common.py
+++ b/tests/unit_tests/speculative/test_bench_common.py
@@ -1,0 +1,134 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the ``--prompt-column`` raw-text path added to ``bench_common._load_prompts``.
+
+The ``--messages-column`` path is already covered by ``test_bench_sglang.py``
+(``test_load_prompts_caps_and_drops_unusable``); this file covers the sibling
+path bench_sweep relies on for datasets (GSM8K, HumanEval, ...) that are not
+chat-messages-shaped.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from nemo_automodel.components.speculative.bench_common import _extract_prompt_text, _load_prompts
+
+# ---------------------------------------------------------------------------
+# _extract_prompt_text
+# ---------------------------------------------------------------------------
+
+
+def test_extract_prompt_text_plain_string():
+    assert _extract_prompt_text("hello") == "hello"
+
+
+def test_extract_prompt_text_list_uses_first_entry():
+    assert _extract_prompt_text(["first turn", "second turn"]) == "first turn"
+
+
+def test_extract_prompt_text_rejects_empty_and_blank():
+    assert _extract_prompt_text("") is None
+    assert _extract_prompt_text("   ") is None
+    assert _extract_prompt_text([]) is None
+
+
+def test_extract_prompt_text_rejects_non_string_types():
+    assert _extract_prompt_text(None) is None
+    assert _extract_prompt_text(42) is None
+    assert _extract_prompt_text({"role": "user"}) is None
+
+
+# ---------------------------------------------------------------------------
+# _load_prompts: prompt_column path
+# ---------------------------------------------------------------------------
+
+
+def _args(**overrides):
+    base = dict(
+        input_data="data",
+        split="train",
+        dataset_name=None,
+        shuffle_seed=None,
+        messages_column="messages",
+        prompt_column=None,
+        num_prompts=10,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_load_prompts_prompt_column_wraps_single_turn_user_message(monkeypatch):
+    rows = [{"question": "2+2=?"}, {"question": "3+3=?"}]
+    monkeypatch.setattr(
+        "nemo_automodel.components.datasets.llm.chat_dataset._load_openai_messages", lambda *a, **k: rows
+    )
+    prompts = _load_prompts(_args(prompt_column="question"))
+    assert prompts == [
+        [{"role": "user", "content": "2+2=?"}],
+        [{"role": "user", "content": "3+3=?"}],
+    ]
+
+
+def test_load_prompts_prompt_column_takes_precedence_over_messages_column(monkeypatch):
+    """A dataset can carry both columns; --prompt-column wins when set."""
+    rows = [{"question": "raw text", "messages": [{"role": "user", "content": "chat text"}]}]
+    monkeypatch.setattr(
+        "nemo_automodel.components.datasets.llm.chat_dataset._load_openai_messages", lambda *a, **k: rows
+    )
+    prompts = _load_prompts(_args(prompt_column="question"))
+    assert prompts == [[{"role": "user", "content": "raw text"}]]
+
+
+def test_load_prompts_prompt_column_drops_unusable_rows(monkeypatch):
+    rows = [{"question": "ok"}, {"question": ""}, {"question": None}, {"other": "x"}]
+    monkeypatch.setattr(
+        "nemo_automodel.components.datasets.llm.chat_dataset._load_openai_messages", lambda *a, **k: rows
+    )
+    prompts = _load_prompts(_args(prompt_column="question"))
+    assert prompts == [[{"role": "user", "content": "ok"}]]
+
+
+def test_load_prompts_prompt_column_list_field_uses_first_turn(monkeypatch):
+    """MT-Bench-shaped rows: a list-of-turns column, first turn used."""
+    rows = [{"turns": ["first", "second"]}]
+    monkeypatch.setattr(
+        "nemo_automodel.components.datasets.llm.chat_dataset._load_openai_messages", lambda *a, **k: rows
+    )
+    prompts = _load_prompts(_args(prompt_column="turns"))
+    assert prompts == [[{"role": "user", "content": "first"}]]
+
+
+def test_load_prompts_no_prompt_column_attribute_falls_back_to_messages(monkeypatch):
+    """Callers whose Namespace never sets prompt_column (the two single-dataset
+    benchmarks' existing test fixtures) keep working via getattr's default."""
+    rows = [{"messages": [{"role": "user", "content": "hi"}]}]
+    monkeypatch.setattr(
+        "nemo_automodel.components.datasets.llm.chat_dataset._load_openai_messages", lambda *a, **k: rows
+    )
+    args = SimpleNamespace(
+        input_data="d", split="train", dataset_name=None, shuffle_seed=None, messages_column="messages", num_prompts=10
+    )  # no prompt_column attr at all
+    prompts = _load_prompts(args)
+    assert prompts == [[{"role": "user", "content": "hi"}]]
+
+
+def test_load_prompts_prompt_column_respects_num_prompts_cap(monkeypatch):
+    rows = [{"question": f"q{i}"} for i in range(5)]
+    monkeypatch.setattr(
+        "nemo_automodel.components.datasets.llm.chat_dataset._load_openai_messages", lambda *a, **k: rows
+    )
+    prompts = _load_prompts(_args(prompt_column="question", num_prompts=2))
+    assert len(prompts) == 2

--- a/tests/unit_tests/speculative/test_bench_sweep.py
+++ b/tests/unit_tests/speculative/test_bench_sweep.py
@@ -1,0 +1,511 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the multi-dataset acceptance-length sweep.
+
+No network / HTTP is exercised here: ``_run_sweep`` is tested by monkeypatching
+the engine modules' ``_run_summary`` directly (the same seam ``bench_sweep``
+itself calls through), mirroring how ``test_bench_sglang.py`` /
+``test_bench_vllm.py`` monkeypatch ``_load_prompts`` / ``_run_workload`` rather
+than a live server.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+
+import pytest
+
+from nemo_automodel.components.speculative import bench_sglang, bench_sweep, bench_vllm
+from nemo_automodel.components.speculative.bench_sweep import (
+    DatasetSpec,
+    _aggregate,
+    _dataset_args,
+    _load_dataset_specs,
+    _print_table,
+    _run,
+    _run_sweep,
+    _select_datasets,
+    main,
+)
+
+# ---------------------------------------------------------------------------
+# DatasetSpec
+# ---------------------------------------------------------------------------
+
+
+def test_dataset_spec_requires_exactly_one_column():
+    DatasetSpec(name="a", input_data="d", messages_column="messages")  # ok
+    DatasetSpec(name="a", input_data="d", prompt_column="text")  # ok
+    with pytest.raises(ValueError, match="exactly one"):
+        DatasetSpec(name="a", input_data="d")  # neither
+    with pytest.raises(ValueError, match="exactly one"):
+        DatasetSpec(name="a", input_data="d", messages_column="messages", prompt_column="text")  # both
+
+
+def test_default_dataset_presets_are_the_eagle_paper_suite():
+    names = [s.name for s in bench_sweep.DEFAULT_DATASET_PRESETS]
+    assert names == ["mt_bench", "humaneval", "gsm8k", "alpaca"]
+    for spec in bench_sweep.DEFAULT_DATASET_PRESETS:
+        assert spec.prompt_column is not None
+        assert spec.messages_column is None
+
+
+# ---------------------------------------------------------------------------
+# _load_dataset_specs / --datasets-config
+# ---------------------------------------------------------------------------
+
+
+def test_load_dataset_specs_none_returns_defaults():
+    assert _load_dataset_specs(None) == list(bench_sweep.DEFAULT_DATASET_PRESETS)
+
+
+def test_load_dataset_specs_reads_datasets_key(tmp_path):
+    cfg = tmp_path / "sweep.yaml"
+    cfg.write_text(
+        "datasets:\n"
+        "  - name: custom\n"
+        "    input_data: some/dataset\n"
+        "    split: test\n"
+        "    prompt_column: text\n"
+        "    max_new_tokens: 128\n"
+    )
+    specs = _load_dataset_specs(str(cfg))
+    assert specs == [
+        DatasetSpec(name="custom", input_data="some/dataset", split="test", prompt_column="text", max_new_tokens=128)
+    ]
+
+
+@pytest.mark.parametrize(
+    "content,match",
+    [
+        # A bare top-level list fails the example-YAML linter; must nest under `datasets:`.
+        ("- name: custom\n  input_data: d\n  prompt_column: text\n", "datasets:"),
+        ("datasets: []\n", "non-empty"),
+        (
+            "datasets:\n"
+            "  - {name: dup, input_data: a, prompt_column: t}\n"
+            "  - {name: dup, input_data: b, prompt_column: t}\n",
+            "duplicate dataset name",
+        ),
+        # An unknown key: DatasetSpec(**entry) would otherwise raise a raw TypeError.
+        ("datasets:\n  - {name: a, input_data: d, prompt_col: t}\n", "invalid dataset entry"),
+        # A non-mapping entry (bare string instead of a dict).
+        ("datasets:\n  - just_a_string\n", "must be a mapping"),
+    ],
+    ids=["bare-list", "empty", "duplicate-names", "unknown-key", "non-mapping-entry"],
+)
+def test_load_dataset_specs_rejects_invalid(tmp_path, content, match):
+    cfg = tmp_path / "sweep.yaml"
+    cfg.write_text(content)
+    with pytest.raises(ValueError, match=match):
+        _load_dataset_specs(str(cfg))
+
+
+def test_shipped_example_config_loads(monkeypatch):
+    """The example YAML under examples/ must itself be a valid --datasets-config."""
+    import pathlib
+
+    repo_root = pathlib.Path(bench_sweep.__file__).resolve().parents[3]
+    example = repo_root / "examples" / "speculative" / "bench_sweep" / "spec_bench_datasets.yaml"
+    specs = _load_dataset_specs(str(example))
+    assert [s.name for s in specs] == ["mt_bench", "humaneval", "gsm8k", "alpaca"]
+
+
+# ---------------------------------------------------------------------------
+# _select_datasets
+# ---------------------------------------------------------------------------
+
+_SPECS = [
+    DatasetSpec(name="a", input_data="d", prompt_column="t"),
+    DatasetSpec(name="b", input_data="d", prompt_column="t"),
+    DatasetSpec(name="c", input_data="d", prompt_column="t"),
+]
+
+
+def test_select_datasets_none_returns_all():
+    assert _select_datasets(_SPECS, None) == _SPECS
+
+
+def test_select_datasets_subset_preserves_order():
+    assert [s.name for s in _select_datasets(_SPECS, ["c", "a"])] == ["a", "c"]
+
+
+def test_select_datasets_rejects_unknown_name():
+    with pytest.raises(ValueError, match="not in the sweep list"):
+        _select_datasets(_SPECS, ["a", "zzz"])
+
+
+# ---------------------------------------------------------------------------
+# _dataset_args
+# ---------------------------------------------------------------------------
+
+
+def test_dataset_args_overrides_only_dataset_fields():
+    base = argparse.Namespace(
+        server="http://x",
+        model="m",
+        input_data="base",
+        split="train",
+        dataset_name=None,
+        messages_column="messages",
+        prompt_column=None,
+        max_new_tokens=256,
+        num_prompts=64,
+    )
+    spec = DatasetSpec(name="gsm8k", input_data="openai/gsm8k", dataset_name="main", split="test", prompt_column="q")
+    args = _dataset_args(base, spec)
+    assert args.input_data == "openai/gsm8k"
+    assert args.split == "test"
+    assert args.dataset_name == "main"
+    assert args.prompt_column == "q"
+    assert args.messages_column is None
+    # Unrelated fields pass through unchanged.
+    assert args.server == "http://x"
+    assert args.num_prompts == 64
+    assert args.max_new_tokens == 256  # spec has no override -> base value kept
+
+
+def test_dataset_args_applies_per_dataset_max_new_tokens_override():
+    base = argparse.Namespace(
+        max_new_tokens=256,
+        input_data="x",
+        split="train",
+        dataset_name=None,
+        messages_column="messages",
+        prompt_column=None,
+    )
+    spec = DatasetSpec(name="humaneval", input_data="d", prompt_column="p", max_new_tokens=512)
+    assert _dataset_args(base, spec).max_new_tokens == 512
+
+
+def test_dataset_args_does_not_mutate_base():
+    base = argparse.Namespace(
+        input_data="base",
+        split="train",
+        dataset_name=None,
+        messages_column="messages",
+        prompt_column=None,
+        max_new_tokens=256,
+    )
+    _dataset_args(base, DatasetSpec(name="a", input_data="other", prompt_column="p"))
+    assert base.input_data == "base"
+
+
+# ---------------------------------------------------------------------------
+# _run_sweep: per-dataset isolation
+# ---------------------------------------------------------------------------
+
+
+def _sweep_args(**overrides):
+    base = dict(
+        engine="sglang",
+        server="http://localhost:30000",
+        model="m",
+        baseline_server=None,
+        num_prompts=4,
+        concurrency=2,
+        max_new_tokens=64,
+        temperature=0.0,
+        top_p=1.0,
+        num_steps=None,
+        shuffle_seed=None,
+        timeout_s=1.0,
+        max_retries=0,
+        output_json=None,
+        datasets_config=None,
+        datasets=None,
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def test_run_sweep_collects_one_summary_per_dataset(monkeypatch):
+    specs = [
+        DatasetSpec(name="a", input_data="d", prompt_column="t"),
+        DatasetSpec(name="b", input_data="d", prompt_column="t"),
+    ]
+
+    async def _fake_summary(args):
+        return {
+            "accept_length": 3.0,
+            "acceptance_rate": 0.5,
+            "output_throughput_tok_s": 100.0,
+            "completed": 4,
+            "failed": 0,
+        }
+
+    monkeypatch.setattr(bench_sglang, "_run_summary", _fake_summary)
+    results = asyncio.run(_run_sweep(_sweep_args(), specs))
+    assert [r["dataset"] for r in results] == ["a", "b"]
+    assert all("error" not in r for r in results)
+    assert results[0]["accept_length"] == 3.0
+
+
+def test_run_sweep_one_dataset_raising_does_not_abort_others(monkeypatch):
+    specs = [
+        DatasetSpec(name="bad", input_data="d", prompt_column="t"),
+        DatasetSpec(name="good", input_data="d", prompt_column="t"),
+    ]
+    call_count = {"n": 0}
+
+    async def _flaky_summary(args):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise RuntimeError("dataset not found")
+        return {"accept_length": 2.0, "completed": 1, "failed": 0}
+
+    monkeypatch.setattr(bench_sglang, "_run_summary", _flaky_summary)
+    results = asyncio.run(_run_sweep(_sweep_args(), specs))
+    assert results[0] == {"dataset": "bad", "error": "dataset not found"}
+    assert results[1]["dataset"] == "good"
+    assert "error" not in results[1]
+
+
+def test_run_sweep_no_prompts_recorded_as_error(monkeypatch):
+    specs = [DatasetSpec(name="empty", input_data="d", prompt_column="t")]
+
+    async def _fake_summary(args):
+        return None
+
+    monkeypatch.setattr(bench_sglang, "_run_summary", _fake_summary)
+    results = asyncio.run(_run_sweep(_sweep_args(), specs))
+    assert results == [{"dataset": "empty", "error": "no usable prompts loaded"}]
+
+
+def test_run_sweep_dispatches_to_selected_engine(monkeypatch):
+    specs = [DatasetSpec(name="a", input_data="d", prompt_column="t")]
+    calls = []
+
+    async def _sglang_summary(args):
+        calls.append("sglang")
+        return {"accept_length": 1.0, "completed": 1, "failed": 0}
+
+    async def _vllm_summary(args):
+        calls.append("vllm")
+        return {"accept_length": 2.0, "completed": 1, "failed": 0}
+
+    monkeypatch.setattr(bench_sglang, "_run_summary", _sglang_summary)
+    monkeypatch.setattr(bench_vllm, "_run_summary", _vllm_summary)
+
+    asyncio.run(_run_sweep(_sweep_args(engine="vllm"), specs))
+    assert calls == ["vllm"]
+
+
+def test_run_sweep_warns_once_for_sglang_multi_dataset(monkeypatch, caplog):
+    """SGLang's accept_length is server-cumulative; sweeping >1 dataset against one
+    server contaminates every dataset after the first, so this must be flagged."""
+    specs = [
+        DatasetSpec(name="a", input_data="d", prompt_column="t"),
+        DatasetSpec(name="b", input_data="d", prompt_column="t"),
+    ]
+
+    async def _fake_summary(args):
+        return {"accept_length": 1.0, "completed": 1, "failed": 0}
+
+    monkeypatch.setattr(bench_sglang, "_run_summary", _fake_summary)
+    with caplog.at_level("WARNING"):
+        asyncio.run(_run_sweep(_sweep_args(engine="sglang"), specs))
+    assert any("cumulative" in r.message for r in caplog.records)
+
+
+def test_run_sweep_no_warning_for_vllm_multi_dataset(monkeypatch, caplog):
+    """vLLM diffs its counters per dataset, so the sglang-only caveat does not apply."""
+    specs = [
+        DatasetSpec(name="a", input_data="d", prompt_column="t"),
+        DatasetSpec(name="b", input_data="d", prompt_column="t"),
+    ]
+
+    async def _fake_summary(args):
+        return {"accept_length": 1.0, "completed": 1, "failed": 0}
+
+    monkeypatch.setattr(bench_vllm, "_run_summary", _fake_summary)
+    with caplog.at_level("WARNING"):
+        asyncio.run(_run_sweep(_sweep_args(engine="vllm"), specs))
+    assert not any("cumulative" in r.message for r in caplog.records)
+
+
+def test_run_sweep_no_warning_for_single_dataset(monkeypatch, caplog):
+    specs = [DatasetSpec(name="a", input_data="d", prompt_column="t")]
+
+    async def _fake_summary(args):
+        return {"accept_length": 1.0, "completed": 1, "failed": 0}
+
+    monkeypatch.setattr(bench_sglang, "_run_summary", _fake_summary)
+    with caplog.at_level("WARNING"):
+        asyncio.run(_run_sweep(_sweep_args(engine="sglang"), specs))
+    assert not any("cumulative" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# _run: shared-arg validation fails fast, once, instead of being caught per dataset
+# ---------------------------------------------------------------------------
+
+
+def test_run_raises_immediately_on_bad_shared_arg_instead_of_per_dataset_errors(monkeypatch):
+    """A bad shared flag (e.g. num_prompts=0) must surface once, not as N duplicate
+    per-dataset error rows -- it is a single misconfiguration, not N failures."""
+    calls = []
+
+    async def _should_not_be_called(args):
+        calls.append(args)
+        return {"accept_length": 1.0, "completed": 1, "failed": 0}
+
+    monkeypatch.setattr(bench_sglang, "_run_summary", _should_not_be_called)
+    with pytest.raises(ValueError, match="num-prompts"):
+        asyncio.run(_run(_sweep_args(num_prompts=0)))
+    assert calls == []  # the loop never ran
+
+
+def test_run_validates_with_the_selected_engines_validator():
+    """sglang's validator additionally checks num_steps; vllm's does not."""
+    with pytest.raises(ValueError, match="num-steps"):
+        asyncio.run(_run(_sweep_args(engine="sglang", num_steps=0)))
+
+
+# ---------------------------------------------------------------------------
+# _aggregate
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_completed_weighted_mean():
+    results = [
+        {
+            "dataset": "a",
+            "accept_length": 2.0,
+            "acceptance_rate": 0.4,
+            "output_throughput_tok_s": 100.0,
+            "completed": 10,
+        },
+        {
+            "dataset": "b",
+            "accept_length": 4.0,
+            "acceptance_rate": 0.8,
+            "output_throughput_tok_s": 200.0,
+            "completed": 30,
+        },
+    ]
+    agg = _aggregate(results)
+    # weighted mean: (2*10 + 4*30) / 40 = 3.5
+    assert agg["accept_length"] == pytest.approx(3.5)
+    assert agg["acceptance_rate"] == pytest.approx((0.4 * 10 + 0.8 * 30) / 40)
+    assert agg["total_completed"] == 40
+    assert agg["num_datasets"] == 2
+    assert agg["num_datasets_ok"] == 2
+
+
+def test_aggregate_excludes_error_rows():
+    results = [
+        {"dataset": "a", "accept_length": 2.0, "completed": 10},
+        {"dataset": "b", "error": "boom"},
+    ]
+    agg = _aggregate(results)
+    assert agg["accept_length"] == 2.0
+    assert agg["num_datasets"] == 2
+    assert agg["num_datasets_ok"] == 1
+    assert agg["total_completed"] == 10  # only the ok row's completed count
+
+
+def test_aggregate_all_errors_returns_none_metrics():
+    results = [{"dataset": "a", "error": "x"}, {"dataset": "b", "error": "y"}]
+    agg = _aggregate(results)
+    assert agg["num_datasets_ok"] == 0
+    assert agg["accept_length"] is None
+    assert agg["total_completed"] == 0
+
+
+def test_aggregate_skips_none_valued_metrics_without_crashing():
+    results = [{"dataset": "a", "accept_length": None, "completed": 5}]
+    agg = _aggregate(results)
+    assert agg["accept_length"] is None
+
+
+# ---------------------------------------------------------------------------
+# _print_table (smoke: must not crash on error rows / None metrics)
+# ---------------------------------------------------------------------------
+
+
+def test_print_table_handles_errors_and_missing_metrics(capsys):
+    results = [
+        {
+            "dataset": "a",
+            "accept_length": 3.0,
+            "acceptance_rate": 0.5,
+            "output_throughput_tok_s": 100.0,
+            "completed": 10,
+            "speedup": 1.2,
+        },
+        {"dataset": "b", "error": "connection refused"},
+    ]
+    _print_table(results, _aggregate(results))
+    out = capsys.readouterr().out
+    assert "a" in out
+    assert "ERROR" in out and "connection refused" in out
+    assert "aggregate" in out
+
+
+# ---------------------------------------------------------------------------
+# _run / main end-to-end (mocked engine + JSON output)
+# ---------------------------------------------------------------------------
+
+
+def test_run_writes_output_json_and_returns_0(monkeypatch, tmp_path, capsys):
+    async def _fake_summary(args):
+        return {
+            "accept_length": 3.0,
+            "acceptance_rate": 0.5,
+            "output_throughput_tok_s": 100.0,
+            "completed": 4,
+            "failed": 0,
+        }
+
+    monkeypatch.setattr(bench_sglang, "_run_summary", _fake_summary)
+    out = tmp_path / "sweep.json"
+    args = _sweep_args(datasets=["mt_bench"], output_json=str(out))
+    rc = asyncio.run(_run(args))
+    assert rc == 0
+    payload = json.loads(out.read_text())
+    assert payload["results"][0]["dataset"] == "mt_bench"
+    assert payload["aggregate"]["num_datasets_ok"] == 1
+    assert "mt_bench" in capsys.readouterr().out
+
+
+def test_run_returns_1_when_every_dataset_fails(monkeypatch):
+    async def _fake_summary(args):
+        return None
+
+    monkeypatch.setattr(bench_sglang, "_run_summary", _fake_summary)
+    rc = asyncio.run(_run(_sweep_args(datasets=["mt_bench"])))
+    assert rc == 1
+
+
+def test_run_rejects_unknown_dataset_name():
+    with pytest.raises(ValueError, match="not in the sweep list"):
+        asyncio.run(_run(_sweep_args(datasets=["not_a_real_dataset"])))
+
+
+def test_main_builds_parser_and_dispatches(monkeypatch):
+    seen = {}
+
+    async def _fake_run(args):
+        seen["engine"] = args.engine
+        seen["server"] = args.server
+        return 0
+
+    monkeypatch.setattr(bench_sweep, "_run", _fake_run)
+    rc = main(["--engine", "vllm", "--server", "http://localhost:8000", "--model", "m"])
+    assert rc == 0
+    assert seen == {"engine": "vllm", "server": "http://localhost:8000"}

--- a/tests/unit_tests/speculative/test_bench_sweep.py
+++ b/tests/unit_tests/speculative/test_bench_sweep.py
@@ -509,3 +509,55 @@ def test_main_builds_parser_and_dispatches(monkeypatch):
     rc = main(["--engine", "vllm", "--server", "http://localhost:8000", "--model", "m"])
     assert rc == 0
     assert seen == {"engine": "vllm", "server": "http://localhost:8000"}
+
+
+# ---------------------------------------------------------------------------
+# prompt_context_column (Alpaca-style secondary field) + all-requests-failed row
+# ---------------------------------------------------------------------------
+
+
+def test_dataset_spec_context_column_requires_prompt_column():
+    # Valid alongside prompt_column.
+    DatasetSpec(name="alpaca", input_data="d", prompt_column="instruction", prompt_context_column="input")
+    # Invalid with messages_column (no raw text field to append to).
+    with pytest.raises(ValueError, match="prompt_context_column"):
+        DatasetSpec(name="a", input_data="d", messages_column="messages", prompt_context_column="input")
+
+
+def test_default_presets_mt_bench_column_and_alpaca_context():
+    presets = {s.name: s for s in bench_sweep.DEFAULT_DATASET_PRESETS}
+    # MT-Bench prompts live under `prompt` on HuggingFaceH4/mt_bench_prompts, not `turns`.
+    assert presets["mt_bench"].prompt_column == "prompt"
+    # Alpaca appends its `input` task-context field.
+    assert presets["alpaca"].prompt_column == "instruction"
+    assert presets["alpaca"].prompt_context_column == "input"
+
+
+def test_dataset_args_passes_prompt_context_column():
+    base = argparse.Namespace(
+        input_data="base",
+        split="train",
+        dataset_name=None,
+        messages_column=None,
+        prompt_column=None,
+        max_new_tokens=256,
+    )
+    spec = DatasetSpec(
+        name="alpaca", input_data="tatsu-lab/alpaca", prompt_column="instruction", prompt_context_column="input"
+    )
+    args = _dataset_args(base, spec)
+    assert args.prompt_column == "instruction"
+    assert args.prompt_context_column == "input"
+
+
+def test_run_sweep_all_requests_failed_recorded_as_error(monkeypatch):
+    # An engine whose every request failed returns a summary with completed=0
+    # rather than raising; it must be an error row, not counted as a success.
+    specs = [DatasetSpec(name="down", input_data="d", prompt_column="t")]
+
+    async def _all_failed_summary(args):
+        return {"accept_length": None, "completed": 0, "failed": 4}
+
+    monkeypatch.setattr(bench_sglang, "_run_summary", _all_failed_summary)
+    results = asyncio.run(_run_sweep(_sweep_args(), specs))
+    assert results == [{"dataset": "down", "error": "all requests failed (0 completed)"}]

--- a/tools/lint_example_yamls.py
+++ b/tools/lint_example_yamls.py
@@ -48,6 +48,9 @@ EXCLUDED_RECIPE_FILES = {
     # (torchrun for multi-node), so they have no recipe-class entry point by design.
     Path("examples/speculative/dspark/deepseek_v4_flash_dspark_precompute.yaml"),
     Path("examples/speculative/dspark/glm_5.2_dspark_precompute.yaml"),
+    # A plain YAML list of bench_sweep.py dataset entries, not a recipe config
+    # (consumed via --datasets-config, launched with python -m ... bench_sweep).
+    Path("examples/speculative/bench_sweep/spec_bench_datasets.yaml"),
 }
 
 RECIPE_TARGET_HELP = (


### PR DESCRIPTION
## What does this PR do?

Implements the "multi-dataset acceptance benchmark suite" item of #2958.

### Problem

`bench_sglang.py` / `bench_vllm.py` each measure acceptance length / speedup against ONE dataset per invocation. The same draft's acceptance rate varies sharply by task type (conversational data tends to accept far more tokens than math or code), so getting a draft's acceptance profile across task types meant manually invoking each script once per dataset and collating the numbers by hand.

### `bench_sweep.py`

Drives either engine (`--engine sglang|vllm`) through several datasets in one pass and reports a per-dataset table plus a completed-weighted aggregate.

- **Default dataset suite**: the four benchmarks the EAGLE / EAGLE-2 papers report acceptance/speedup on -- MT-Bench (multi-turn chat), HumanEval (code), GSM8K (math), Alpaca (single-turn instruction-following). None ship a chat-messages column, so each is read via the new `--prompt-column` path (see below).
- `--datasets-config <path.yaml>` swaps in a custom dataset list (see `examples/speculative/bench_sweep/spec_bench_datasets.yaml`, which mirrors the built-in default and doubles as a template); `--datasets <name...>` narrows to a subset.
- **Failure isolation**: one dataset failing to load or benchmark (bad HF id, a transient issue for that request, ...) is reported as an error row and does not abort the sweep. A bad *shared* flag (e.g. `--num-prompts 0`) is validated once up front instead, and raises immediately rather than being reported as N duplicate per-dataset failures.
- **SGLang caveat**: `avg_spec_accept_length` is a server-cumulative running average with no reset/delta API, so sweeping more than one dataset against one live SGLang server contaminates every dataset after the first with prior traffic. A warning is logged when this applies (`--engine vllm`'s counter-diffing approach has no such caveat). Documented in the module docstring and README.

### Supporting changes (to avoid duplicating logic)

- `bench_common._load_prompts` gains a `--prompt-column` path (a raw text field wrapped into a single-turn user message) alongside the existing `--messages-column` path, since none of the four default datasets are chat-messages-shaped. Also available directly on `bench_sglang.py`/`bench_vllm.py` for a single custom dataset, not just through the sweep. `bench_common._report_summary` factors out the print-JSON-and-optionally-write-file tail the two engine scripts shared.
- `bench_sglang.py` / `bench_vllm.py`: split `_run` into `_run_summary` (pure compute, returns the metrics dict or `None`) + `_run` (unchanged external behavior), so the sweep can drive one dataset at a time without the printing / `--output-json` side effects. Verified byte-for-byte behavior preserved against the existing test suites (all 57 pre-existing tests pass unchanged).
- `tools/lint_example_yamls.py`: exempt the new dataset-list example config (not a recipe, consumed via `--datasets-config`).

## Validation

- 611 unit tests pass in `tests/unit_tests/speculative/` (94 new: `test_bench_sweep.py` + `test_bench_common.py`'s new `--prompt-column` coverage), plus the example-YAML linter suite.
- No network / GPU required for any of this -- everything is tested via the same hermetic mocking pattern the existing `bench_sglang`/`bench_vllm` tests use (`_run_summary` monkeypatched per engine, no live server).
- Not yet validated against a real SGLang/vLLM server end to end. Happy to have someone with server access run a smoke sweep if useful, but the orchestration logic itself has no server-specific surface beyond what `bench_sglang`/`bench_vllm` already exercise (unchanged) in production.