### PR TITLE
ci: route gb200 L2_HF_DCP to the IMEX runner for DeepEP NVLink P2P

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -503,6 +503,11 @@ jobs:
           - test-name: L2_HF_DCP
             test-folder: hf_dcp
             timeout: 40
+            # DeepEP expert-parallel subtest (GPT-OSS MXFP4, ep_size=2) hard-requires
+            # NVLink P2P, which on GB200 comes from the IMEX ComputeDomain channel.
+            # Route to the imex-lease runner; every other gb200 test stays on the
+            # plain (non-IMEX) pool. See nemo-ci-gcp-gpu-x2-imex in TF-States.
+            runner: nemo-ci-gcp-gpu-x2-imex
           - test-name: L2_HF_PEFT
             test-folder: hf_peft
             timeout: 30
@@ -533,7 +538,7 @@ jobs:
             test-folder: moe
             timeout: 20
     needs: [pre-flight, cicd-unit-tests, cicd-container-build]
-    runs-on: nemo-ci-gcp-gpu-x2
+    runs-on: ${{ matrix.runner || 'nemo-ci-gcp-gpu-x2' }}
     name: gb200_${{ matrix.test-name }}
     if: |
       (
@@ -556,7 +561,7 @@ jobs:
           PAT: ${{ secrets.PAT }}
           test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}
           container-image: ${{ env.container-registry-gb200 }}/automodel:${{ github.sha }}
-          runner: nemo-ci-gcp-gpu-x2
+          runner: ${{ matrix.runner || 'nemo-ci-gcp-gpu-x2' }}
 
   Nemo_CICD_Test:
     needs:


### PR DESCRIPTION
## Background

The `gb200_L2_HF_DCP` job fails deterministically on every run (e.g. [run 28913093372](https://github.com/NVIDIA-NeMo/Automodel/actions/runs/28913093372/job/85860355292)). Its GPT-OSS MXFP4 subtest runs expert-parallel (`ep_size=2`) through **DeepEP**, whose `Buffer` init hard-asserts NVLink P2P between the two GPUs:

```
AssertionError: No NVLink connection between GPU 0 and GPU 1, but allow_nvlink_for_normal_mode=True
  deep_ep/utils.py:98  →  pynvml.nvmlDeviceGetP2PStatus(..., NVML_P2P_CAPS_INDEX_NVLINK)
```

On GB200 that P2P is provided by the **IMEX ComputeDomain channel**, not by plain GPU allocation. The `gb200` lane runs on `nemo-ci-gcp-gpu-x2`, which does **not** join the IMEX domain — so NCCL reports `isAllDirectP2p 0`, `0 nvls channels`, and DeepEP aborts. NCCL-only tests degrade to shared-memory and pass, which is why 7/8 subtests are green and only the DeepEP one dies. `NCCL_NVLS_ENABLE=0` does not help — DeepEP's check is an NVML P2P query, independent of NCCL/NVLS.

## What changed

- Route **only** `L2_HF_DCP` to the existing IMEX runner `nemo-ci-gcp-gpu-x2-imex`; every other `gb200` test stays on the non-IMEX pool.
- `runs-on` / the `test-template` `runner:` input now read `${{ matrix.runner || 'nemo-ci-gcp-gpu-x2' }}`, so a per-test `runner` field opts a test onto a different pool with zero churn to the others.

## Details

- **No infra change needed.** `nemo-ci-gcp-gpu-x2-imex` already exists (`spec.maxRunners=8`, `imex_lease="ci-runners"`, `max_runners_per_node=1`); it was idle only because nothing routed to it.
- **DinD IMEX forwarding is handled** by `imex_lease`: it labels the runner `gpu-wrangler.nvidia.com/lease=ci-runners`, Kyverno injects the IMEX channel `ResourceClaim`, and the nested `docker run` job gets `/dev/nvidia-caps-imex-channels/channel0` → `cuMemCreate(FABRIC)` / NVLink P2P succeeds.
- `max_runners_per_node=1` (one IMEX channel per node) caps concurrency for this lane — fine for a single per-PR test.

```yaml
# .github/workflows/cicd-main.yml — cicd-e2e-tests-gb200 (excerpt)
- test-name: L2_HF_DCP
  test-folder: hf_dcp
  timeout: 40
  runner: nemo-ci-gcp-gpu-x2-imex   # DeepEP ep_size=2 → needs NVLink P2P (IMEX)
...
runs-on: ${{ matrix.runner || 'nemo-ci-gcp-gpu-x2' }}
```

## Routing

```mermaid
flowchart LR
  subgraph gb200[cicd-e2e-tests-gb200 matrix]
    dcp[L2_HF_DCP<br/>DeepEP ep_size=2]
    rest[all other gb200 tests<br/>NCCL-only]
  end
  dcp -->|runs-on: nemo-ci-gcp-gpu-x2-imex| imex[imex runner<br/>imex_lease=ci-runners]
  rest -->|runs-on: nemo-ci-gcp-gpu-x2| plain[plain runner<br/>no IMEX]
  imex -->|Kyverno injects IMEX channel<br/>/dev/nvidia-caps-imex-channels/channel0| p2p[NVLink P2P ✅ → DeepEP passes]
  plain -->|no P2P: isAllDirectP2p 0| shmem[NCCL shmem fallback ✅]
```

## Follow-up

- `L2_MoE` (new `gb200` matrix entry, `test-folder: moe`) very likely uses expert parallelism too — if it hits the same DeepEP assertion, give it the same one-line `runner: nemo-ci-gcp-gpu-x2-imex`.

## Tested

- YAML + `actionlint` clean (only pre-existing shellcheck info on unrelated `run:` blocks).
- Validation is the CI run on this PR: `gb200_L2_HF_DCP` should now land on `nemo-ci-gcp-gpu-x2-imex` and the MXFP4 DeepEP subtest should pass; all other `gb200_*` tests unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
