### PR TITLE
fix: filter non-tensor model state before DCP planning

### DIFF
--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -264,6 +264,56 @@ def _get_checkpoint_metadata_keys(
     return set(metadata.state_dict_metadata.keys())
 
 
+def _is_dcp_tensor_like_state_value(value: Any) -> bool:
+    """Return whether a state-dict value can be handled directly by DCP."""
+    if isinstance(value, torch.Tensor):
+        return True
+    # DTensor-like values expose ``to_local`` and are handled elsewhere in the
+    # checkpointing stack, so keep them in DCP state even when torch.distributed
+    # tensor classes are not imported directly here.
+    to_local = getattr(value, "to_local", None)
+    return callable(to_local)
+
+
+def _filter_non_tensor_state_for_dcp(
+    state_dict: dict[str, Any],
+    *,
+    checkpoint_path: str,
+    operation: str,
+) -> dict[str, Any]:
+    """Drop non tensor-like entries before DCP planning.
+
+    DCP is used here to save or load tensor-like model state. Python objects
+    such as module extra state can appear in some adapted state dicts, but DCP
+    planning may need to pickle state and can fail before any tensor operation
+    starts. Filtering those entries keeps DCP planning focused on tensor-like
+    values; dropped entries are logged and remain at their current in-memory
+    state on load.
+    """
+    tensor_state_dict: dict[str, Any] = {}
+    dropped_entries: list[str] = []
+
+    for key, value in state_dict.items():
+        if _is_dcp_tensor_like_state_value(value):
+            tensor_state_dict[key] = value
+            continue
+
+        value_type = type(value)
+        dropped_entries.append(f"{key}:{value_type.__module__}.{value_type.__qualname__}")
+
+    if not dropped_entries:
+        return state_dict
+
+    logger.warning(
+        "Dropping %d non-tensor state_dict entries before DCP %s for %s (examples=%s).",
+        len(dropped_entries),
+        operation,
+        checkpoint_path,
+        dropped_entries[:20],
+    )
+    return tensor_state_dict
+
+
 if _is_geq_torch_2_9():
     from torch.distributed.checkpoint.staging import DefaultStager
     from torch.distributed.checkpoint.state_dict_saver import AsyncCheckpointerType, AsyncSaveResponse
@@ -476,6 +526,9 @@ class Checkpointer:
         )
         # MoE adapters return non-contiguous views; safetensors.save rejects those.
         _materialize_to_hf_views_for_save(state_dict)
+        state_dict = _filter_non_tensor_state_for_dcp(
+            state_dict, checkpoint_path=model_dir, operation="save"
+        )
         # Build the consolidated model.safetensors.index.json if needed
         fqn_to_file_index_mapping = self._maybe_build_consolidated_index(model_state, state_dict)
         fqn_to_dtype_mapping = self._maybe_build_original_dtype_mapping(model_state, state_dict)
@@ -813,6 +866,9 @@ class Checkpointer:
                     missing_checkpoint_keys[:10],
                 )
 
+        state_dict = _filter_non_tensor_state_for_dcp(
+            state_dict, checkpoint_path=model_path, operation="load"
+        )
         state_dict = self._do_load(state_dict, model_path, storage_reader, is_init_step=is_init_step)
 
         if compat_tied_lm_head_source_key is not None and isinstance(lm_head_param_name, str):

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -526,9 +526,7 @@ class Checkpointer:
         )
         # MoE adapters return non-contiguous views; safetensors.save rejects those.
         _materialize_to_hf_views_for_save(state_dict)
-        state_dict = _filter_non_tensor_state_for_dcp(
-            state_dict, checkpoint_path=model_dir, operation="save"
-        )
+        state_dict = _filter_non_tensor_state_for_dcp(state_dict, checkpoint_path=model_dir, operation="save")
         # Build the consolidated model.safetensors.index.json if needed
         fqn_to_file_index_mapping = self._maybe_build_consolidated_index(model_state, state_dict)
         fqn_to_dtype_mapping = self._maybe_build_original_dtype_mapping(model_state, state_dict)
@@ -866,9 +864,7 @@ class Checkpointer:
                     missing_checkpoint_keys[:10],
                 )
 
-        state_dict = _filter_non_tensor_state_for_dcp(
-            state_dict, checkpoint_path=model_path, operation="load"
-        )
+        state_dict = _filter_non_tensor_state_for_dcp(state_dict, checkpoint_path=model_path, operation="load")
         state_dict = self._do_load(state_dict, model_path, storage_reader, is_init_step=is_init_step)
 
         if compat_tied_lm_head_source_key is not None and isinstance(lm_head_param_name, str):

--- a/tests/unit_tests/checkpoint/test_checkpointing.py
+++ b/tests/unit_tests/checkpoint/test_checkpointing.py
@@ -43,6 +43,7 @@ from nemo_automodel.components.checkpoint.checkpointing import (
     _divide_keys_by_size,
     _ensure_dirs,
     _equally_divide_layers,
+    _filter_non_tensor_state_for_dcp,
     _is_custom_model,
     _model_has_dtensors,
     _normalize_dtype_mapping_to_state_dict_keys,
@@ -64,6 +65,13 @@ CLOUD_PATH_OPTIM = "msc://bucket/step-100/optim"
 LOCAL_PATH_MODEL = "/ckpts/step-100/model"
 
 
+class _FakeDTensorStateValue:
+    """Minimal tensor-like object for DCP filtering tests."""
+
+    def to_local(self):
+        return torch.zeros(1)
+
+
 def _make_keys(count: int) -> list[str]:
     return [f"layer.{i}" for i in range(count)]
 
@@ -73,6 +81,32 @@ def _count_by_shard(mapping: dict[str, int]) -> dict[int, int]:
     for shard_index in mapping.values():
         counts[shard_index] = counts.get(shard_index, 0) + 1
     return counts
+
+
+def test_filter_non_tensor_state_for_dcp_keeps_tensor_like_values(caplog):
+    tensor = torch.zeros(1)
+    dtensor_like = _FakeDTensorStateValue()
+    code = (lambda value: value).__code__
+    state_dict = {
+        "layer.weight": tensor,
+        "layer.dtensor": dtensor_like,
+        "plain.object": object(),
+        "code.object": code,
+        "layer.not_dtensor": SimpleNamespace(to_local=None),
+    }
+
+    caplog.set_level(logging.WARNING)
+    filtered = _filter_non_tensor_state_for_dcp(
+        state_dict, checkpoint_path="/tmp/model", operation="load"
+    )
+
+    assert set(filtered) == {"layer.weight", "layer.dtensor"}
+    assert filtered["layer.weight"] is tensor
+    assert filtered["layer.dtensor"] is dtensor_like
+    assert "Dropping 3 non-tensor state_dict entries before DCP load" in caplog.text
+    assert "plain.object" in caplog.text
+    assert "code.object" in caplog.text
+    assert "layer.not_dtensor" in caplog.text
 
 
 def test_extract_file_index_with_status_supports_hf_and_qwen35_patterns():
@@ -1332,6 +1366,97 @@ class TestLoadModelExtraState:
         assert captured["requested_keys"] == {"layer.weight"}
         assert "module _extra_state keys" in caplog.text
         mock_model_state.load_state_dict.assert_called_once()
+
+    def test_non_tensor_state_entries_are_filtered_before_dcp_save(self, tmp_path, caplog):
+        checkpointer = self._make_checkpointer()
+        checkpointer._addons = []
+        model = SimpleNamespace(state_dict_adapter=object())
+        tensor = torch.zeros(2, 2)
+        dtensor_like = _FakeDTensorStateValue()
+        initial_state_dict = {
+            "layer.weight": tensor,
+            "layer.dtensor": dtensor_like,
+            "layer.extra_object": object(),
+            "layer.code": (lambda value: value).__code__,
+        }
+        captured = {}
+
+        def fake_do_save(state_dict, *args, **kwargs):
+            captured["saved_keys"] = set(state_dict)
+            return None
+
+        caplog.set_level(logging.WARNING)
+        with (
+            patch("nemo_automodel.components.checkpoint.checkpointing.ModelState") as mock_model_state_cls,
+            patch(
+                "nemo_automodel.components.checkpoint.checkpointing._maybe_adapt_state_dict_to_hf",
+                side_effect=lambda module, state_dict, **kwargs: state_dict,
+            ),
+            patch.object(checkpointer, "_maybe_build_consolidated_index", return_value=None),
+            patch.object(checkpointer, "_maybe_build_original_dtype_mapping", return_value=None),
+            patch("nemo_automodel.components.checkpoint.checkpointing._warn_if_large_inline_consolidation"),
+            patch.object(checkpointer, "_get_storage_writer", return_value=object()),
+            patch.object(checkpointer, "_do_save", side_effect=fake_do_save),
+        ):
+            mock_model_state = mock_model_state_cls.return_value
+            mock_model_state.model = [model]
+            mock_model_state.state_dict.return_value = initial_state_dict.copy()
+
+            checkpointer.save_model(model, str(tmp_path))
+
+        assert captured["saved_keys"] == {"layer.weight", "layer.dtensor"}
+        assert "Dropping 2 non-tensor state_dict entries before DCP save" in caplog.text
+        assert "layer.extra_object" in caplog.text
+        assert "layer.code" in caplog.text
+
+    def test_non_tensor_state_entries_are_filtered_before_dcp_load(self, caplog):
+        checkpointer = self._make_checkpointer()
+        model = SimpleNamespace(state_dict_adapter=object())
+        tensor = torch.zeros(2, 2)
+        dtensor_like = _FakeDTensorStateValue()
+        initial_state_dict = {
+            "layer.weight": tensor,
+            "layer.dtensor": dtensor_like,
+            "layer.extra_object": object(),
+            "layer.code": (lambda value: value).__code__,
+        }
+        captured = {}
+
+        def fake_do_load(state_dict, *args, **kwargs):
+            captured["requested_keys"] = set(state_dict)
+            return dict(state_dict)
+
+        caplog.set_level(logging.WARNING)
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("nemo_automodel.components.checkpoint.checkpointing.ModelState") as mock_model_state_cls,
+            patch.object(checkpointer, "_get_storage_reader", return_value=object()),
+            patch(
+                "nemo_automodel.components.checkpoint.checkpointing._maybe_adapt_state_dict_to_hf",
+                side_effect=lambda module, state_dict, **kwargs: state_dict,
+            ),
+            patch(
+                "nemo_automodel.components.checkpoint.checkpointing._maybe_adapt_state_dict_from_hf",
+                side_effect=lambda module, state_dict, **kwargs: state_dict,
+            ),
+            patch.object(checkpointer, "_do_load", side_effect=fake_do_load),
+        ):
+            mock_model_state = mock_model_state_cls.return_value
+            mock_model_state.model = [model]
+            mock_model_state.state_dict.return_value = initial_state_dict.copy()
+
+            checkpointer.load_model(model, model_path="/fake/path")
+
+        assert captured["requested_keys"] == {"layer.weight", "layer.dtensor"}
+        assert "Dropping 2 non-tensor state_dict entries before DCP load" in caplog.text
+        assert "layer.extra_object" in caplog.text
+        assert "layer.code" in caplog.text
+        mock_model_state.load_state_dict.assert_called_once()
+        assert mock_model_state.load_state_dict.call_args.kwargs["strict"] is False
+        assert set(mock_model_state.load_state_dict.call_args.args[0]) == {
+            "layer.weight",
+            "layer.dtensor",
+        }
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Filter non tensor-like entries out of model state dicts before DCP planning on both save and load paths.

This avoids stdlib-pickle failures during DCP distributed planning when a model/adapted state dict contains module extra state or adapter-returned Python objects that are not tensor-like.

## Motivation

DCP planning may pickle the target state dict before any tensor operation starts. If the state dict contains Python objects that `pickle` cannot serialize, such as code objects or custom Python state returned by adapters, checkpoint save/load can fail before reaching the actual tensor checkpoint operation.

This PR keeps DCP model checkpointing focused on values DCP can handle directly.

## Changes

- Add `_is_dcp_tensor_like_state_value`.
  - Keeps `torch.Tensor`.
  - Keeps objects with callable `to_local`, used as a DTensor-like duck type.
  - Filters objects that merely have a non-callable `to_local` attribute.
- Add `_filter_non_tensor_state_for_dcp`.
  - Drops non tensor-like state dict entries.
  - Logs dropped keys with type information.
  - Returns the original dict unchanged when nothing is dropped.
- Apply the filter in `Checkpointer.load_model` before `_do_load`.
- Apply the filter in `Checkpointer.save_model` after `_materialize_to_hf_views_for_save` and before consolidation index / dtype mapping construction.
- Preserve existing PEFT/safetensors load behavior.

## Not In Scope

`load_optimizer` / `save_optimizer` and `load_distributed_state` / `save_distributed_state` are not changed in this PR. Those paths are expected to operate on tensor-oriented optimizer/distributed state today. If the same non-tensor DCP planning failure surfaces there, the same helper can be applied symmetrically in a follow-up.

Cloudpickle-based DCP load-plan serialization is also intentionally deferred. That would require a scoped context-manager design to avoid process-global mutation of `torch.distributed.distributed_c10d._pickler`.

## Tests

- `test_filter_non_tensor_state_for_dcp_keeps_tensor_like_values`
- `TestLoadModelExtraState::test_non_tensor_state_entries_are_filtered_before_dcp_save`
- `TestLoadModelExtraState::test_non_tensor_state_entries_are_filtered_before_dcp_load`

Validated with:

```bash
python -m pytest tests/unit_tests/checkpoint/test_checkpointing.py -k "filter_non_tensor_state_for_dcp or non_tensor_state_entries_are_filtered_before_dcp" -v
```

Result:

```text
3 passed
```