### PR TITLE
feat(speculative): FSDP2-shard dense DSpark target + add Gemma4-31B config

### DIFF
--- a/examples/speculative/dspark/gemma4_31b_dspark.yaml
+++ b/examples/speculative/dspark/gemma4_31b_dspark.yaml
@@ -10,7 +10,7 @@
 # target is ~62 GiB, so training OOMs at the first backward on 80 GiB GPUs. Setting
 # shard_dense_target below makes TrainDSparkRecipe load the dense target through the
 # standard distributed setup (the same FSDP2 path the MoE / VL targets use), which
-# shards it across the world mesh, drops the resident target to ~11 GiB/rank on 8
+# shards it across the world mesh, drops the resident target to ~9 GiB/rank on 8
 # GPUs, and leaves room for the draft's training activations. The
 # draft's per-anchor projection over the 262144-vocab head is the next-largest term,
 # so seq_length and num_anchors are trimmed from the 12B defaults (4096 / 512) to

--- a/examples/speculative/dspark/gemma4_31b_dspark.yaml
+++ b/examples/speculative/dspark/gemma4_31b_dspark.yaml
@@ -8,9 +8,10 @@
 #
 # Memory: a dense target is otherwise replicated on every rank, and the frozen 31B
 # target is ~62 GiB, so training OOMs at the first backward on 80 GiB GPUs. Setting
-# shard_dense_target below makes TrainDSparkRecipe FSDP2-shard the dense target's
-# frozen decoder layers across the world mesh, which drops the resident target to
-# ~11 GiB/rank on 8 GPUs and leaves room for the draft's training activations. The
+# shard_dense_target below makes TrainDSparkRecipe load the dense target through the
+# standard distributed setup (the same FSDP2 path the MoE / VL targets use), which
+# shards it across the world mesh, drops the resident target to ~11 GiB/rank on 8
+# GPUs, and leaves room for the draft's training activations. The
 # draft's per-anchor projection over the 262144-vocab head is the next-largest term,
 # so seq_length and num_anchors are trimmed from the 12B defaults (4096 / 512) to
 # keep peak memory comfortable; raise them if you have more GPUs / headroom.

--- a/examples/speculative/dspark/gemma4_31b_dspark.yaml
+++ b/examples/speculative/dspark/gemma4_31b_dspark.yaml
@@ -1,0 +1,83 @@
+# DSpark draft training for a Gemma4-31B target (online target hidden-state capture).
+#
+# Same method and three-term objective as the Gemma4-12B config; the draft is built
+# from the Gemma4-31B target's text sub-config (60 hidden layers, hidden_size 5376,
+# vocab 262144). Relative to the 12B recipe this only changes the target checkpoint,
+# the five feature layers (rescaled across the 60-layer target), and the sequence /
+# anchor budget.
+#
+# Memory: a dense target is otherwise replicated on every rank, and the frozen 31B
+# target is ~62 GiB, so training OOMs at the first backward on 80 GiB GPUs. Setting
+# shard_dense_target below makes TrainDSparkRecipe FSDP2-shard the dense target's
+# frozen decoder layers across the world mesh, which drops the resident target to
+# ~11 GiB/rank on 8 GPUs and leaves room for the draft's training activations. The
+# draft's per-anchor projection over the 262144-vocab head is the next-largest term,
+# so seq_length and num_anchors are trimmed from the 12B defaults (4096 / 512) to
+# keep peak memory comfortable; raise them if you have more GPUs / headroom.
+#
+# Data: prompts with responses in the tokenizer's 'messages' chat format. For best
+# draft quality the responses should be REGENERATED with the Gemma4-31B target
+# (teacher-forced training); regenerate first.
+#
+# NOTE: requires a Gemma4 checkpoint and a transformers build with Gemma4 support.
+
+recipe: TrainDSparkRecipe
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 30
+
+distributed:
+  strategy: fsdp2
+  defer_fsdp_grad_sync: true
+
+recipe_args:
+  target_model_name_or_path: google/gemma-4-31B-it
+  train_data_path: /path/to/gemma4-31b_messages.jsonl   # regenerate responses with the target first
+  val_data_path: null
+  output_dir: ./outputs/dspark_gemma4_31b
+  seq_length: 2048
+  micro_batch_size: 1
+  grad_accumulation_steps: 8
+  num_workers: 4
+  num_epochs: 10
+
+  shard_dense_target: true               # FSDP2-shard the frozen 31B target so it fits (see header)
+  draft_num_hidden_layers: 5
+  block_size: 7
+  num_anchors: 128
+  mask_token_id: 4                       # reserved Gemma4 token for non-anchor block positions
+  target_layer_ids: [7, 22, 37, 52, 58]  # 5 feature layers across the 60-layer Gemma4-31B target
+  freeze_embeddings: true
+  attention_backend: flex_attention        # draft attention (block mask); requires flex
+  # The Gemma4 target's head_dim (256) exceeds FlashAttention's limit, so run the
+  # target replay / hidden-state capture with sdpa (the draft still uses flex_attention).
+  target_attn_implementation: sdpa
+
+  markov_rank: 256
+  markov_head_type: vanilla
+
+  confidence_head_alpha: 1.0
+  confidence_head_with_markov: true
+
+  ce_loss_alpha: 0.1
+  l1_loss_alpha: 0.9
+  loss_decay_gamma: 4.0
+
+  trust_remote_code: false
+  shuffle_seed: 42
+  log_every_steps: 10
+  max_grad_norm: 1.0
+
+optimizer:
+  lr: 6.0e-4
+  betas: [0.9, 0.95]
+  weight_decay: 0.0
+  warmup_ratio: 0.04
+  min_lr_ratio: 0.1
+
+checkpoint:
+  enabled: true
+  checkpoint_dir: ./outputs/dspark_gemma4_31b/checkpoints
+  model_save_format: safetensors
+  save_consolidated: final

--- a/nemo_automodel/recipes/_dist_utils.py
+++ b/nemo_automodel/recipes/_dist_utils.py
@@ -253,7 +253,14 @@ def _distributed_cfg_to_dict(cfg: Any | None) -> dict:
         if isinstance(distributed_cfg, dict):
             return distributed_cfg.copy()
         return cfg.copy()
-    distributed_cfg = cfg.distributed
+    distributed_cfg = getattr(cfg, "distributed", None)
+    if distributed_cfg is None:
+        # No ``distributed:`` block on a config object: treat it as an empty (default
+        # FSDP2) configuration rather than raising ``AttributeError``. This lets a caller
+        # that opts into sharding without an explicit block (e.g. dspark
+        # ``shard_dense_target`` on a config that omits ``distributed:``) fall back to the
+        # default mesh.
+        return {}
     return distributed_cfg.to_dict() if hasattr(distributed_cfg, "to_dict") else dict(distributed_cfg)
 
 

--- a/nemo_automodel/recipes/_dist_utils.py
+++ b/nemo_automodel/recipes/_dist_utils.py
@@ -253,11 +253,7 @@ def _distributed_cfg_to_dict(cfg: Any | None) -> dict:
         if isinstance(distributed_cfg, dict):
             return distributed_cfg.copy()
         return cfg.copy()
-    distributed_cfg = getattr(cfg, "distributed", None)
-    if distributed_cfg is None:
-        # A config object without a ``distributed:`` block defaults to the empty
-        # (default FSDP2) configuration, matching the dict path above.
-        return {}
+    distributed_cfg = cfg.distributed
     return distributed_cfg.to_dict() if hasattr(distributed_cfg, "to_dict") else dict(distributed_cfg)
 
 

--- a/nemo_automodel/recipes/_dist_utils.py
+++ b/nemo_automodel/recipes/_dist_utils.py
@@ -255,11 +255,8 @@ def _distributed_cfg_to_dict(cfg: Any | None) -> dict:
         return cfg.copy()
     distributed_cfg = getattr(cfg, "distributed", None)
     if distributed_cfg is None:
-        # No ``distributed:`` block on a config object: treat it as an empty (default
-        # FSDP2) configuration rather than raising ``AttributeError``. This lets a caller
-        # that opts into sharding without an explicit block (e.g. dspark
-        # ``shard_dense_target`` on a config that omits ``distributed:``) fall back to the
-        # default mesh.
+        # A config object without a ``distributed:`` block defaults to the empty
+        # (default FSDP2) configuration, matching the dict path above.
         return {}
     return distributed_cfg.to_dict() if hasattr(distributed_cfg, "to_dict") else dict(distributed_cfg)
 

--- a/nemo_automodel/recipes/llm/train_dspark.py
+++ b/nemo_automodel/recipes/llm/train_dspark.py
@@ -59,6 +59,7 @@ from nemo_automodel.components.distributed.activation_checkpointing import (
     apply_submodule_checkpointing,
     is_selective_activation_checkpointing,
 )
+from nemo_automodel.components.distributed.config import FSDP2Config
 from nemo_automodel.components.distributed.init_utils import initialize_distributed
 from nemo_automodel.components.distributed.utils import get_sync_ctx
 from nemo_automodel.components.loggers.log_utils import setup_logging
@@ -101,7 +102,7 @@ from nemo_automodel.components.speculative.dspark.target_utils import (
 )
 from nemo_automodel.components.training.rng import StatefulRNG
 from nemo_automodel.components.utils.model_utils import VLM_INPUT_KEYS
-from nemo_automodel.recipes._dist_utils import create_distributed_setup_from_config
+from nemo_automodel.recipes._dist_utils import create_distributed_setup_from_config, parse_distributed_section
 from nemo_automodel.recipes.base_recipe import (
     BaseRecipe,
     _find_latest_checkpoint,
@@ -335,6 +336,19 @@ def _validate_cached_dspark_manifest(
         )
 
 
+def _distributed_section_dict(cfg) -> dict:
+    """Return the ``distributed:`` section of a top-level recipe config as a plain dict.
+
+    A missing block yields ``{}``, i.e. the default FSDP2 configuration; this keeps the
+    fail-loud missing-block contract of ``create_distributed_setup_from_config`` intact
+    for callers that require an explicit block.
+    """
+    section = cfg.get("distributed", None)
+    if section is None:
+        return {}
+    return section.to_dict() if hasattr(section, "to_dict") else dict(section)
+
+
 class TrainDSparkRecipe(BaseRecipe):
     """Recipe for DSpark draft-model training on Qwen3, Gemma4, DeepSeek V4, GLM-5.2, and MiniMax M3 VL targets."""
 
@@ -359,37 +373,42 @@ class TrainDSparkRecipe(BaseRecipe):
 
         Raises:
             ValueError: if ``shard_dense_target`` is requested together with a model-parallel
-                axis (``tp_size``/``pp_size``/``cp_size``/``ep_size`` > 1). DSpark's
-                forward-hook hidden-state capture needs one non-pipelined ``model(...)`` call
-                per rank (``pp_size > 1`` builds an ``AutoPipeline`` instead of a module), and
-                the other axes are untested for the frozen dense target here.
+                or replication axis (``tp_size``/``pp_size``/``cp_size``/``ep_size``/
+                ``dp_replicate_size`` > 1). DSpark's forward-hook hidden-state capture needs
+                one non-pipelined ``model(...)`` call per rank (``pp_size > 1`` builds an
+                ``AutoPipeline`` instead of a module), the other model-parallel axes are
+                untested for the frozen dense target here, and HSDP replication re-replicates
+                the target across the replicate dimension, defeating the sharding.
         """
         if not bool(recipe_cfg.get("shard_dense_target", False)):
             return False
-        distributed_cfg = self.cfg.get("distributed", None) or {}
-        # Case-fold to match parse_distributed_section's strategy normalization.
-        strategy = str(distributed_cfg.get("strategy", "fsdp2")).lower()
-        if self.dist_env.world_size <= 1 or strategy != "fsdp2":
+        # Reuse the canonical distributed-section parser (strategy case-folding, YAML-null
+        # axis defaulting) instead of re-reading the raw block, so the gate cannot drift
+        # from what create_distributed_setup_from_config later builds.
+        parsed = parse_distributed_section(_distributed_section_dict(self.cfg))
+        if self.dist_env.world_size <= 1 or not isinstance(parsed["strategy_config"], FSDP2Config):
             if self.dist_env.is_main:
                 logger.warning(
                     "recipe_args.shard_dense_target=true is ignored: it requires "
-                    "distributed.strategy='fsdp2' on more than one rank (got strategy=%r, "
+                    "distributed.strategy='fsdp2' on more than one rank (got strategy=%s, "
                     "world_size=%d); the dense target stays replicated per rank.",
-                    strategy,
+                    type(parsed["strategy_config"]).__name__,
                     self.dist_env.world_size,
                 )
             return False
-        model_parallel_axes = {
-            axis: int(distributed_cfg.get(axis, None) or 1) for axis in ("tp_size", "pp_size", "cp_size", "ep_size")
+        unsupported = {
+            axis: parsed[axis]
+            for axis in ("tp_size", "pp_size", "cp_size", "ep_size", "dp_replicate_size")
+            if (parsed[axis] or 1) != 1
         }
-        unsupported = {axis: size for axis, size in model_parallel_axes.items() if size != 1}
         if unsupported:
             raise ValueError(
                 f"recipe_args.shard_dense_target=true only supports a pure FSDP2 data-parallel "
-                f"topology (tp_size=pp_size=cp_size=ep_size=1), got {unsupported}. DSpark's "
-                f"hidden-state capture needs one non-pipelined model call per rank (pp_size>1 "
-                f"builds an AutoPipeline the target wrapper cannot run), and the remaining "
-                f"model-parallel axes are unsupported for the frozen dense target."
+                f"topology (tp_size=pp_size=cp_size=ep_size=dp_replicate_size=1), got {unsupported}. "
+                f"DSpark's hidden-state capture needs one non-pipelined model call per rank "
+                f"(pp_size>1 builds an AutoPipeline the target wrapper cannot run), the remaining "
+                f"model-parallel axes are unsupported for the frozen dense target, and HSDP "
+                f"replication re-replicates the target, defeating the sharding."
             )
         return True
 
@@ -567,8 +586,10 @@ class TrainDSparkRecipe(BaseRecipe):
                     # path the MoE / VL targets use, instead of replicating the whole target on
                     # every rank. embed_tokens / lm_head come back as sharded DTensors and are
                     # gathered to full tensors before the draft copies them (see below).
+                    # A config without a distributed: block resolves to the default FSDP2 setup
+                    # (the helper's cfg=None path) instead of failing on the missing attribute.
                     self.distributed_setup = create_distributed_setup_from_config(
-                        self.cfg,
+                        self.cfg if self.cfg.get("distributed", None) is not None else None,
                         world_size=self.dist_env.world_size,
                     )
                 self.target_model = NeMoAutoModelForCausalLM.from_pretrained(
@@ -808,7 +829,8 @@ class TrainDSparkRecipe(BaseRecipe):
         # Multi-GPU strategy: FSDP2 (default) shards the draft per block, or DDP.
         self.parallel_strategy = "ddp"
         if self.dist_env.world_size > 1:
-            strategy = dist_cfg.get("strategy", "fsdp2") if dist_cfg is not None else "fsdp2"
+            # Case-fold to match parse_distributed_section's strategy normalization.
+            strategy = str(dist_cfg.get("strategy", "fsdp2")).lower() if dist_cfg is not None else "fsdp2"
             self.parallel_strategy = strategy
             if strategy == "fsdp2":
                 from torch.distributed.fsdp import MixedPrecisionPolicy, fully_shard

--- a/nemo_automodel/recipes/llm/train_dspark.py
+++ b/nemo_automodel/recipes/llm/train_dspark.py
@@ -341,6 +341,65 @@ class TrainDSparkRecipe(BaseRecipe):
     def __init__(self, cfg):
         self.cfg = cfg
 
+    def _maybe_shard_dense_target(self, recipe_cfg, is_moe_target: bool) -> bool:
+        """FSDP2-shard a frozen dense target's decoder layers when ``shard_dense_target`` is set.
+
+        A dense target (Qwen3 / Gemma4) is otherwise loaded whole and replicated on
+        every rank. For a large dense target (e.g. Gemma4-31B) the frozen target is
+        ~62 GiB, leaving no room for the draft's training activations, so training OOMs
+        at the first backward on 80 GiB GPUs. The MoE targets already avoid this by
+        sharding through their distributed setup; this mirrors it for a dense target by
+        FSDP2-sharding its frozen decoder layers across the world mesh (forward-only
+        all-gather + reshard). ``embed_tokens`` / ``lm_head`` are intentionally left
+        replicated so the draft copies them as plain tensors, keeping the draft-sharing
+        path (which only gathers DTensors for the MoE targets) unchanged.
+
+        This is opt-in (``recipe_args.shard_dense_target``, default ``False``): sharding
+        adds a per-microbatch all-gather/reshard of the frozen target, which is pure
+        overhead for a target that already fits replicated (e.g. Qwen3-0.6B), so existing
+        configs keep their replicated behavior unless they request it.
+
+        Args:
+            recipe_cfg: The ``recipe_args`` config section.
+            is_moe_target: Whether the target is an MoE model already sharded via its
+                own distributed setup (DeepSeek V4 / GLM-5.2 / MiniMax M3).
+
+        Returns:
+            ``True`` if the dense target was sharded, ``False`` otherwise.
+        """
+        if self.target_wrapper is None or is_moe_target:
+            return False
+        if not bool(recipe_cfg.get("shard_dense_target", False)):
+            return False
+        strategy = (self.cfg.get("distributed", None) or {}).get("strategy", "fsdp2")
+        if self.dist_env.world_size <= 1 or strategy != "fsdp2":
+            if self.dist_env.is_main:
+                logger.warning(
+                    "recipe_args.shard_dense_target=true is ignored: it requires "
+                    "distributed.strategy='fsdp2' on more than one rank (got strategy=%r, "
+                    "world_size=%d); the dense target stays replicated per rank.",
+                    strategy,
+                    self.dist_env.world_size,
+                )
+            return False
+
+        from torch.distributed.fsdp import MixedPrecisionPolicy, fully_shard
+
+        target_mp_policy = MixedPrecisionPolicy(param_dtype=self.compute_dtype, reduce_dtype=self.compute_dtype)
+        # reshard_after_forward=True is required: each layer is fully_shard'd without a
+        # parent FSDP module, so it is its own FSDP root and would otherwise default to
+        # reshard_after_forward=False, keeping every layer unsharded (all-gathered) after
+        # the target's forward and OOMing.
+        for layer in self.target_wrapper._get_transformer_layers():
+            fully_shard(layer, mp_policy=target_mp_policy, reshard_after_forward=True)
+        if self.dist_env.is_main:
+            logger.info(
+                "DSpark: FSDP2-sharded the frozen dense target's %d decoder layers across %d ranks.",
+                self.target_wrapper._num_layers,
+                self.dist_env.world_size,
+            )
+        return True
+
     def setup(self):
         """Build the target model, DSpark draft, data, optimizer, and trainer module."""
         self.dist_env = initialize_distributed(
@@ -544,6 +603,12 @@ class TrainDSparkRecipe(BaseRecipe):
             if self.target_model is not None
             else None
         )
+
+        # Opt-in: FSDP2-shard a large frozen dense target so it stops replicating on
+        # every rank (see _maybe_shard_dense_target). Off by default, so existing
+        # dense-target configs keep their previous replicated behavior.
+        is_moe_target = is_deepseek_v4_target or is_glm_5_2_target or is_minimax_m3_target
+        self._maybe_shard_dense_target(recipe_cfg, is_moe_target=is_moe_target)
 
         self.block_size = int(recipe_cfg.get("block_size", 7))
         self.num_anchors = int(recipe_cfg.get("num_anchors", 512))

--- a/nemo_automodel/recipes/llm/train_dspark.py
+++ b/nemo_automodel/recipes/llm/train_dspark.py
@@ -356,10 +356,21 @@ class TrainDSparkRecipe(BaseRecipe):
         that already fits is pure all-gather overhead. Requires ``distributed.strategy='fsdp2'``
         on more than one rank; otherwise the request is ignored with a warning and the target
         stays replicated.
+
+        Only a pure FSDP2 data-parallel topology is supported: any model-parallel axis
+        (``tp_size`` / ``pp_size`` / ``cp_size`` / ``ep_size`` > 1) raises. DSpark's
+        forward-hook hidden-state capture needs one non-pipelined ``model(...)`` call per
+        rank; with ``pp_size > 1`` AutoModel returns an ``AutoPipeline`` instead of a module,
+        and the other axes are untested for the frozen dense target here.
+
+        Raises:
+            ValueError: if ``shard_dense_target`` is requested together with a
+                model-parallel axis (``tp_size``/``pp_size``/``cp_size``/``ep_size`` > 1).
         """
         if not bool(recipe_cfg.get("shard_dense_target", False)):
             return False
-        strategy = (self.cfg.get("distributed", None) or {}).get("strategy", "fsdp2")
+        distributed_cfg = self.cfg.get("distributed", None) or {}
+        strategy = distributed_cfg.get("strategy", "fsdp2")
         if self.dist_env.world_size <= 1 or strategy != "fsdp2":
             if self.dist_env.is_main:
                 logger.warning(
@@ -370,6 +381,18 @@ class TrainDSparkRecipe(BaseRecipe):
                     self.dist_env.world_size,
                 )
             return False
+        model_parallel_axes = {
+            axis: int(distributed_cfg.get(axis, None) or 1) for axis in ("tp_size", "pp_size", "cp_size", "ep_size")
+        }
+        unsupported = {axis: size for axis, size in model_parallel_axes.items() if size != 1}
+        if unsupported:
+            raise ValueError(
+                f"recipe_args.shard_dense_target=true only supports a pure FSDP2 data-parallel "
+                f"topology (tp_size=pp_size=cp_size=ep_size=1), got {unsupported}. DSpark's "
+                f"hidden-state capture needs one non-pipelined model call per rank (pp_size>1 "
+                f"builds an AutoPipeline the target wrapper cannot run), and the remaining "
+                f"model-parallel axes are unsupported for the frozen dense target."
+            )
         return True
 
     def setup(self):

--- a/nemo_automodel/recipes/llm/train_dspark.py
+++ b/nemo_automodel/recipes/llm/train_dspark.py
@@ -357,20 +357,18 @@ class TrainDSparkRecipe(BaseRecipe):
         on more than one rank; otherwise the request is ignored with a warning and the target
         stays replicated.
 
-        Only a pure FSDP2 data-parallel topology is supported: any model-parallel axis
-        (``tp_size`` / ``pp_size`` / ``cp_size`` / ``ep_size`` > 1) raises. DSpark's
-        forward-hook hidden-state capture needs one non-pipelined ``model(...)`` call per
-        rank; with ``pp_size > 1`` AutoModel returns an ``AutoPipeline`` instead of a module,
-        and the other axes are untested for the frozen dense target here.
-
         Raises:
-            ValueError: if ``shard_dense_target`` is requested together with a
-                model-parallel axis (``tp_size``/``pp_size``/``cp_size``/``ep_size`` > 1).
+            ValueError: if ``shard_dense_target`` is requested together with a model-parallel
+                axis (``tp_size``/``pp_size``/``cp_size``/``ep_size`` > 1). DSpark's
+                forward-hook hidden-state capture needs one non-pipelined ``model(...)`` call
+                per rank (``pp_size > 1`` builds an ``AutoPipeline`` instead of a module), and
+                the other axes are untested for the frozen dense target here.
         """
         if not bool(recipe_cfg.get("shard_dense_target", False)):
             return False
         distributed_cfg = self.cfg.get("distributed", None) or {}
-        strategy = distributed_cfg.get("strategy", "fsdp2")
+        # Case-fold to match parse_distributed_section's strategy normalization.
+        strategy = str(distributed_cfg.get("strategy", "fsdp2")).lower()
         if self.dist_env.world_size <= 1 or strategy != "fsdp2":
             if self.dist_env.is_main:
                 logger.warning(
@@ -420,9 +418,6 @@ class TrainDSparkRecipe(BaseRecipe):
         is_glm_5_2_target = target_model_type == _GLM_5_2_MODEL_TYPE
         is_gemma4_target = target_model_type in _GEMMA4_MODEL_TYPES
         is_minimax_m3_target = target_model_type in _MINIMAX_M3_MODEL_TYPES
-        # Set when a dense target is loaded FSDP2-sharded via distributed_setup (opt-in); its
-        # embed_tokens / lm_head then come back as DTensors and need gathering for the draft.
-        dense_target_sharded = False
         self.cached_target_path = recipe_cfg.get("cached_target_path", None)
         is_multimodal = bool(recipe_cfg.get("multimodal", False))
         if is_multimodal and not is_minimax_m3_target:
@@ -576,25 +571,15 @@ class TrainDSparkRecipe(BaseRecipe):
                         self.cfg,
                         world_size=self.dist_env.world_size,
                     )
-                    self.target_model = NeMoAutoModelForCausalLM.from_pretrained(
-                        target_path,
-                        trust_remote_code=trust_remote_code,
-                        torch_dtype=self.compute_dtype,
-                        force_hf=bool(recipe_cfg.get("target_force_hf", False)),
-                        distributed_setup=self.distributed_setup,
-                        **target_kwargs,
-                    )
-                    dense_target_sharded = True
-                    # A distributed-setup-loaded model already lands correctly placed
-                    # (sharded as DTensors); a blanket .to(device) afterward is redundant.
-                else:
-                    self.target_model = NeMoAutoModelForCausalLM.from_pretrained(
-                        target_path,
-                        trust_remote_code=trust_remote_code,
-                        torch_dtype=self.compute_dtype,
-                        force_hf=bool(recipe_cfg.get("target_force_hf", False)),
-                        **target_kwargs,
-                    )
+                self.target_model = NeMoAutoModelForCausalLM.from_pretrained(
+                    target_path,
+                    trust_remote_code=trust_remote_code,
+                    torch_dtype=self.compute_dtype,
+                    force_hf=bool(recipe_cfg.get("target_force_hf", False)),
+                    distributed_setup=self.distributed_setup,
+                    **target_kwargs,
+                )
+                if self.distributed_setup is None:
                     self.target_model.to(self.device)
             else:
                 self.target_model = None
@@ -790,12 +775,11 @@ class TrainDSparkRecipe(BaseRecipe):
         if embed_src is None or head_src is None:
             embed_src = self.target_wrapper.get_input_embeddings()
             head_src = self.target_wrapper.get_output_embeddings()
-        if (
-            is_deepseek_v4_target or is_glm_5_2_target or is_minimax_m3_target or dense_target_sharded
-        ) and self.cached_target_path is None:
-            # The MoE / VL targets, and an FSDP2-sharded dense target, store embed_tokens /
-            # lm_head as expert-parallel / FSDP-sharded DTensors; gather them to full tensors
-            # before the draft copies them.
+        if self.distributed_setup is not None:
+            # Every distributed-setup-loaded target (MoE / VL / sharded dense) stores
+            # embed_tokens / lm_head as expert-parallel / FSDP-sharded DTensors; gather
+            # them to full tensors before the draft copies them. The offline cached path
+            # never builds a distributed setup, so it is excluded by construction.
             embed_src = gather_full_weight_module(embed_src)
             head_src = gather_full_weight_module(head_src)
         self.draft_model.initialize_embeddings_and_head(

--- a/nemo_automodel/recipes/llm/train_dspark.py
+++ b/nemo_automodel/recipes/llm/train_dspark.py
@@ -341,34 +341,22 @@ class TrainDSparkRecipe(BaseRecipe):
     def __init__(self, cfg):
         self.cfg = cfg
 
-    def _maybe_shard_dense_target(self, recipe_cfg, is_moe_target: bool) -> bool:
-        """FSDP2-shard a frozen dense target's decoder layers when ``shard_dense_target`` is set.
+    def _should_shard_dense_target(self, recipe_cfg) -> bool:
+        """Whether to load a frozen dense target FSDP2-sharded via the standard distributed setup.
 
-        A dense target (Qwen3 / Gemma4) is otherwise loaded whole and replicated on
-        every rank. For a large dense target (e.g. Gemma4-31B) the frozen target is
-        ~62 GiB, leaving no room for the draft's training activations, so training OOMs
-        at the first backward on 80 GiB GPUs. The MoE targets already avoid this by
-        sharding through their distributed setup; this mirrors it for a dense target by
-        FSDP2-sharding its frozen decoder layers across the world mesh (forward-only
-        all-gather + reshard). ``embed_tokens`` / ``lm_head`` are intentionally left
-        replicated so the draft copies them as plain tensors, keeping the draft-sharing
-        path (which only gathers DTensors for the MoE targets) unchanged.
+        Opt-in (``recipe_args.shard_dense_target``, default ``False``). A dense target
+        (Qwen3 / Gemma4) is otherwise loaded whole and replicated on every rank. For a large
+        dense target (e.g. Gemma4-31B) the frozen target is ~62 GiB, leaving no room for the
+        draft's training activations, so training OOMs at the first backward on 80 GiB GPUs.
+        Loading it through ``create_distributed_setup_from_config`` +
+        ``NeMoAutoModelForCausalLM.from_pretrained(distributed_setup=...)`` FSDP2-shards it
+        across the mesh, the same path the MoE / VL targets already use.
 
-        This is opt-in (``recipe_args.shard_dense_target``, default ``False``): sharding
-        adds a per-microbatch all-gather/reshard of the frozen target, which is pure
-        overhead for a target that already fits replicated (e.g. Qwen3-0.6B), so existing
-        configs keep their replicated behavior unless they request it.
-
-        Args:
-            recipe_cfg: The ``recipe_args`` config section.
-            is_moe_target: Whether the target is an MoE model already sharded via its
-                own distributed setup (DeepSeek V4 / GLM-5.2 / MiniMax M3).
-
-        Returns:
-            ``True`` if the dense target was sharded, ``False`` otherwise.
+        A small target (e.g. Qwen3-0.6B) stays replicated by default, since sharding a target
+        that already fits is pure all-gather overhead. Requires ``distributed.strategy='fsdp2'``
+        on more than one rank; otherwise the request is ignored with a warning and the target
+        stays replicated.
         """
-        if self.target_wrapper is None or is_moe_target:
-            return False
         if not bool(recipe_cfg.get("shard_dense_target", False)):
             return False
         strategy = (self.cfg.get("distributed", None) or {}).get("strategy", "fsdp2")
@@ -382,22 +370,6 @@ class TrainDSparkRecipe(BaseRecipe):
                     self.dist_env.world_size,
                 )
             return False
-
-        from torch.distributed.fsdp import MixedPrecisionPolicy, fully_shard
-
-        target_mp_policy = MixedPrecisionPolicy(param_dtype=self.compute_dtype, reduce_dtype=self.compute_dtype)
-        # reshard_after_forward=True is required: each layer is fully_shard'd without a
-        # parent FSDP module, so it is its own FSDP root and would otherwise default to
-        # reshard_after_forward=False, keeping every layer unsharded (all-gathered) after
-        # the target's forward and OOMing.
-        for layer in self.target_wrapper._get_transformer_layers():
-            fully_shard(layer, mp_policy=target_mp_policy, reshard_after_forward=True)
-        if self.dist_env.is_main:
-            logger.info(
-                "DSpark: FSDP2-sharded the frozen dense target's %d decoder layers across %d ranks.",
-                self.target_wrapper._num_layers,
-                self.dist_env.world_size,
-            )
         return True
 
     def setup(self):
@@ -425,6 +397,9 @@ class TrainDSparkRecipe(BaseRecipe):
         is_glm_5_2_target = target_model_type == _GLM_5_2_MODEL_TYPE
         is_gemma4_target = target_model_type in _GEMMA4_MODEL_TYPES
         is_minimax_m3_target = target_model_type in _MINIMAX_M3_MODEL_TYPES
+        # Set when a dense target is loaded FSDP2-sharded via distributed_setup (opt-in); its
+        # embed_tokens / lm_head then come back as DTensors and need gathering for the draft.
+        dense_target_sharded = False
         self.cached_target_path = recipe_cfg.get("cached_target_path", None)
         is_multimodal = bool(recipe_cfg.get("multimodal", False))
         if is_multimodal and not is_minimax_m3_target:
@@ -568,14 +543,36 @@ class TrainDSparkRecipe(BaseRecipe):
                 target_kwargs = {}
                 if target_attn_implementation is not None:
                     target_kwargs["attn_implementation"] = target_attn_implementation
-                self.target_model = NeMoAutoModelForCausalLM.from_pretrained(
-                    target_path,
-                    trust_remote_code=trust_remote_code,
-                    torch_dtype=self.compute_dtype,
-                    force_hf=bool(recipe_cfg.get("target_force_hf", False)),
-                    **target_kwargs,
-                )
-                self.target_model.to(self.device)
+                if self._should_shard_dense_target(recipe_cfg):
+                    # Load the frozen dense target FSDP2-sharded through the standard distributed
+                    # setup (device mesh + FSDP2 policy, then a root fully_shard on load), the same
+                    # path the MoE / VL targets use, instead of replicating the whole target on
+                    # every rank. embed_tokens / lm_head come back as sharded DTensors and are
+                    # gathered to full tensors before the draft copies them (see below).
+                    self.distributed_setup = create_distributed_setup_from_config(
+                        self.cfg,
+                        world_size=self.dist_env.world_size,
+                    )
+                    self.target_model = NeMoAutoModelForCausalLM.from_pretrained(
+                        target_path,
+                        trust_remote_code=trust_remote_code,
+                        torch_dtype=self.compute_dtype,
+                        force_hf=bool(recipe_cfg.get("target_force_hf", False)),
+                        distributed_setup=self.distributed_setup,
+                        **target_kwargs,
+                    )
+                    dense_target_sharded = True
+                    # A distributed-setup-loaded model already lands correctly placed
+                    # (sharded as DTensors); a blanket .to(device) afterward is redundant.
+                else:
+                    self.target_model = NeMoAutoModelForCausalLM.from_pretrained(
+                        target_path,
+                        trust_remote_code=trust_remote_code,
+                        torch_dtype=self.compute_dtype,
+                        force_hf=bool(recipe_cfg.get("target_force_hf", False)),
+                        **target_kwargs,
+                    )
+                    self.target_model.to(self.device)
             else:
                 self.target_model = None
         if self.target_model is not None:
@@ -603,12 +600,6 @@ class TrainDSparkRecipe(BaseRecipe):
             if self.target_model is not None
             else None
         )
-
-        # Opt-in: FSDP2-shard a large frozen dense target so it stops replicating on
-        # every rank (see _maybe_shard_dense_target). Off by default, so existing
-        # dense-target configs keep their previous replicated behavior.
-        is_moe_target = is_deepseek_v4_target or is_glm_5_2_target or is_minimax_m3_target
-        self._maybe_shard_dense_target(recipe_cfg, is_moe_target=is_moe_target)
 
         self.block_size = int(recipe_cfg.get("block_size", 7))
         self.num_anchors = int(recipe_cfg.get("num_anchors", 512))
@@ -776,9 +767,12 @@ class TrainDSparkRecipe(BaseRecipe):
         if embed_src is None or head_src is None:
             embed_src = self.target_wrapper.get_input_embeddings()
             head_src = self.target_wrapper.get_output_embeddings()
-        if (is_deepseek_v4_target or is_glm_5_2_target or is_minimax_m3_target) and self.cached_target_path is None:
-            # The V4 / GLM / MiniMax M3 target's embed_tokens / lm_head are expert-parallel /
-            # FSDP-sharded DTensors; gather them to full tensors before the draft copies them.
+        if (
+            is_deepseek_v4_target or is_glm_5_2_target or is_minimax_m3_target or dense_target_sharded
+        ) and self.cached_target_path is None:
+            # The MoE / VL targets, and an FSDP2-sharded dense target, store embed_tokens /
+            # lm_head as expert-parallel / FSDP-sharded DTensors; gather them to full tensors
+            # before the draft copies them.
             embed_src = gather_full_weight_module(embed_src)
             head_src = gather_full_weight_module(head_src)
         self.draft_model.initialize_embeddings_and_head(

--- a/tests/functional_tests/speculative/test_dspark_shard_dense_target_fsdp2.py
+++ b/tests/functional_tests/speculative/test_dspark_shard_dense_target_fsdp2.py
@@ -33,7 +33,6 @@ Requires 2 GPUs (FlexAttention has no CPU backward); spawns its own NCCL ranks.
 """
 
 import os
-import socket
 
 import pytest
 import torch
@@ -114,17 +113,13 @@ def _capture(wrapper: HFDSparkTargetModel, input_ids: torch.Tensor):
     return wrapper.generate_batch(input_ids=input_ids, attention_mask=ones, loss_mask=ones)
 
 
-def _rank_worker(rank: int, world_size: int, port: int, model_dir: str) -> None:
+def _rank_worker(rank: int, world_size: int, init_file: str, model_dir: str) -> None:
     """One NCCL rank of the sharded dense-target smoke (spawned; must be top-level)."""
-    os.environ["MASTER_ADDR"] = "127.0.0.1"
-    os.environ["MASTER_PORT"] = str(port)
-    os.environ["RANK"] = str(rank)
     os.environ["LOCAL_RANK"] = str(rank)
-    os.environ["WORLD_SIZE"] = str(world_size)
     torch.cuda.set_device(rank)
     device = torch.device("cuda", rank)
     dtype = torch.bfloat16
-    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+    dist.init_process_group("nccl", init_method=f"file://{init_file}", rank=rank, world_size=world_size)
     try:
         # 1. Sharded loading through the same path the recipe uses for
         # shard_dense_target (ConfigNode top-level config, default FSDP2 block).
@@ -209,8 +204,5 @@ def test_shard_dense_target_two_rank_contract(tmp_path):
     model_dir = str(tmp_path / "tiny_qwen3_target")
     AutoModelForCausalLM.from_config(_tiny_config()).to(torch.bfloat16).save_pretrained(model_dir)
 
-    with socket.socket() as sock:
-        sock.bind(("127.0.0.1", 0))
-        port = sock.getsockname()[1]
-
-    mp.spawn(_rank_worker, args=(_WORLD_SIZE, port, model_dir), nprocs=_WORLD_SIZE, join=True)
+    init_file = str(tmp_path / "dist_init")
+    mp.spawn(_rank_worker, args=(_WORLD_SIZE, init_file, model_dir), nprocs=_WORLD_SIZE, join=True)

--- a/tests/functional_tests/speculative/test_dspark_shard_dense_target_fsdp2.py
+++ b/tests/functional_tests/speculative/test_dspark_shard_dense_target_fsdp2.py
@@ -32,6 +32,7 @@ on two NCCL ranks, with a tiny random Qwen3 target saved to disk (no download):
 Requires 2 GPUs (FlexAttention has no CPU backward); spawns its own NCCL ranks.
 """
 
+import math
 import os
 
 import pytest
@@ -191,7 +192,7 @@ def _rank_worker(rank: int, world_size: int, init_file: str, model_dir: str) -> 
             loss.backward()
             optim.step()
             losses.append(loss.item())
-        assert all(torch.isfinite(torch.tensor(x)) for x in losses), f"non-finite loss: {losses}"
+        assert all(math.isfinite(x) for x in losses), f"non-finite loss: {losses}"
         assert losses[-1] < losses[0], f"loss did not decrease: {losses[0]:.4f} -> {losses[-1]:.4f}"
         dist.barrier()
     finally:

--- a/tests/functional_tests/speculative/test_dspark_shard_dense_target_fsdp2.py
+++ b/tests/functional_tests/speculative/test_dspark_shard_dense_target_fsdp2.py
@@ -1,0 +1,216 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""2-GPU functional test for the FSDP2-sharded dense DSpark target path.
+
+Exercises the real distributed contract behind ``recipe_args.shard_dense_target``
+on two NCCL ranks, with a tiny random Qwen3 target saved to disk (no download):
+
+1. sharded loading: ``create_distributed_setup_from_config`` +
+   ``NeMoAutoModelForCausalLM.from_pretrained(distributed_setup=...)`` must
+   return a target whose parameters are FSDP2 DTensors (not replicated);
+2. embedding / head copying: ``gather_full_weight_module`` must reassemble the
+   sharded ``embed_tokens`` / ``lm_head`` into full plain tensors that are
+   bit-identical to the checkpoint on disk, and the draft must seed from them;
+3. hidden-state capture: ``HFDSparkTargetModel.generate_batch`` through the
+   FSDP2-wrapped target must match the same capture through the default
+   replicated target;
+4. training: the draft trains against that captured supervision with finite,
+   decreasing loss.
+
+Requires 2 GPUs (FlexAttention has no CPU backward); spawns its own NCCL ranks.
+"""
+
+import os
+import socket
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from safetensors.torch import load_file
+from torch.distributed.fsdp import fully_shard
+from torch.distributed.tensor import DTensor
+from transformers import AutoModelForCausalLM, Qwen3Config
+
+from nemo_automodel._transformers import NeMoAutoModelForCausalLM
+from nemo_automodel.components.config.loader import ConfigNode
+from nemo_automodel.components.speculative.dspark import (
+    Qwen3DSparkModel,
+    build_draft_config,
+    compute_dspark_loss,
+)
+from nemo_automodel.components.speculative.dspark.target import HFDSparkTargetModel
+from nemo_automodel.recipes._dist_utils import create_distributed_setup_from_config
+from nemo_automodel.recipes.llm._dspark_target_build import gather_full_weight_module
+
+pytestmark = pytest.mark.skipif(
+    torch.cuda.device_count() < 2, reason="needs 2 GPUs (FSDP2 sharding + FlexAttention backward)"
+)
+
+_VOCAB = 1024
+_HIDDEN = 128
+_SEQ = 32
+_TARGET_LAYER_IDS = [1, 3, 5]
+_WORLD_SIZE = 2
+
+
+class _Args(dict):
+    def __getattr__(self, key):
+        return self[key]
+
+
+def _model_args() -> _Args:
+    return _Args(
+        num_draft_layers=2,
+        target_layer_ids=list(_TARGET_LAYER_IDS),
+        block_size=4,
+        mask_token_id=7,
+        num_anchors=16,
+        markov_rank=32,
+        markov_head_type="vanilla",
+        confidence_head_alpha=1.0,
+        confidence_head_with_markov=True,
+    )
+
+
+def _tiny_config() -> Qwen3Config:
+    return Qwen3Config(
+        vocab_size=_VOCAB,
+        hidden_size=_HIDDEN,
+        intermediate_size=2 * _HIDDEN,
+        num_hidden_layers=6,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        max_position_embeddings=128,
+        tie_word_embeddings=False,
+    )
+
+
+def _capture(wrapper: HFDSparkTargetModel, input_ids: torch.Tensor):
+    """Run one no-grad target capture.
+
+    Args:
+        wrapper: Target wrapper to capture from.
+        input_ids: ``[B, S]`` int64 token ids (``B`` = batch, ``S`` = sequence).
+
+    Returns:
+        ``DSparkTargetBatch`` with ``target_hidden_states`` ``[B, S, F*H]``
+        (``F`` = number of captured feature layers, ``H`` = hidden size) and
+        ``target_last_hidden_states`` ``[B, S, H]``.
+    """
+    ones = torch.ones_like(input_ids)
+    return wrapper.generate_batch(input_ids=input_ids, attention_mask=ones, loss_mask=ones)
+
+
+def _rank_worker(rank: int, world_size: int, port: int, model_dir: str) -> None:
+    """One NCCL rank of the sharded dense-target smoke (spawned; must be top-level)."""
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    os.environ["RANK"] = str(rank)
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    torch.cuda.set_device(rank)
+    device = torch.device("cuda", rank)
+    dtype = torch.bfloat16
+    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+    try:
+        # 1. Sharded loading through the same path the recipe uses for
+        # shard_dense_target (ConfigNode top-level config, default FSDP2 block).
+        setup = create_distributed_setup_from_config(
+            ConfigNode({"distributed": {"strategy": "fsdp2"}}), world_size=world_size
+        )
+        target = NeMoAutoModelForCausalLM.from_pretrained(model_dir, torch_dtype=dtype, distributed_setup=setup)
+        target.requires_grad_(False)
+        params = dict(target.named_parameters())
+        sharded = {name: p for name, p in params.items() if isinstance(p, DTensor)}
+        assert sharded, "distributed_setup load produced no DTensor parameters (target came back replicated)"
+        assert any(p.to_local().numel() < p.numel() for p in sharded.values()), (
+            "DTensor parameters are not actually sharded across ranks"
+        )
+
+        # 2. Embedding / head gathering: full plain tensors, bit-identical to the
+        # checkpoint on disk, then the draft seeds from them.
+        wrapper = HFDSparkTargetModel(target, target_layer_ids=list(_TARGET_LAYER_IDS))
+        embed_src = gather_full_weight_module(wrapper.get_input_embeddings())
+        head_src = gather_full_weight_module(wrapper.get_output_embeddings())
+        reference = load_file(os.path.join(model_dir, "model.safetensors"))
+        for src, key in ((embed_src, "model.embed_tokens.weight"), (head_src, "lm_head.weight")):
+            assert not isinstance(src.weight, DTensor)
+            torch.testing.assert_close(src.weight.detach().cpu(), reference[key], rtol=0, atol=0)
+
+        draft = Qwen3DSparkModel(build_draft_config(_tiny_config(), _model_args())).to(device=device, dtype=dtype)
+        draft.initialize_embeddings_and_head(embed_tokens=embed_src, lm_head=head_src, freeze=True)
+        torch.testing.assert_close(
+            draft.embed_tokens.weight.detach().cpu(), reference["model.embed_tokens.weight"], rtol=0, atol=0
+        )
+
+        # 3. Hidden-state capture through the FSDP2-wrapped target matches the
+        # default replicated load (same class, same kernels, same dtype).
+        generator = torch.Generator().manual_seed(100 + rank)  # per-rank batch, data-parallel style
+        input_ids = torch.randint(0, _VOCAB, (1, _SEQ), generator=generator).to(device)
+        batch = _capture(wrapper, input_ids)
+        replicated = NeMoAutoModelForCausalLM.from_pretrained(model_dir, torch_dtype=dtype).to(device)
+        replicated.requires_grad_(False)
+        reference_batch = _capture(HFDSparkTargetModel(replicated, target_layer_ids=list(_TARGET_LAYER_IDS)), input_ids)
+        assert batch.target_hidden_states.shape == (1, _SEQ, len(_TARGET_LAYER_IDS) * _HIDDEN)
+        assert batch.target_last_hidden_states.shape == (1, _SEQ, _HIDDEN)
+        torch.testing.assert_close(batch.target_hidden_states, reference_batch.target_hidden_states)
+        torch.testing.assert_close(batch.target_last_hidden_states, reference_batch.target_last_hidden_states)
+
+        # 4. The draft trains against the captured supervision (FSDP2-sharded like
+        # the recipe) with finite, decreasing loss.
+        for layer in draft.layers:
+            fully_shard(layer)
+        fully_shard(draft)
+        optim = torch.optim.AdamW([p for p in draft.parameters() if p.requires_grad], lr=5e-3)
+        draft.train()
+        losses = []
+        for _ in range(20):
+            optim.zero_grad()
+            torch.manual_seed(7)  # fixed anchors -> clean overfit signal
+            outputs = draft(
+                input_ids=batch.input_ids.to(device),
+                target_hidden_states=batch.target_hidden_states.to(device=device, dtype=dtype),
+                loss_mask=batch.loss_mask.to(device),
+                target_last_hidden_states=batch.target_last_hidden_states.to(device=device, dtype=dtype),
+            )
+            loss = compute_dspark_loss(
+                outputs=outputs,
+                loss_decay_gamma=4.0,
+                ce_loss_alpha=0.1,
+                l1_loss_alpha=0.9,
+                confidence_head_alpha=1.0,
+            )
+            loss.backward()
+            optim.step()
+            losses.append(loss.item())
+        assert all(torch.isfinite(torch.tensor(x)) for x in losses), f"non-finite loss: {losses}"
+        assert losses[-1] < losses[0], f"loss did not decrease: {losses[0]:.4f} -> {losses[-1]:.4f}"
+        dist.barrier()
+    finally:
+        dist.destroy_process_group()
+
+
+def test_shard_dense_target_two_rank_contract(tmp_path):
+    """Sharded loading, DTensor embed/head gathering, capture parity, one training run."""
+    torch.manual_seed(0)
+    model_dir = str(tmp_path / "tiny_qwen3_target")
+    AutoModelForCausalLM.from_config(_tiny_config()).to(torch.bfloat16).save_pretrained(model_dir)
+
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+
+    mp.spawn(_rank_worker, args=(_WORLD_SIZE, port, model_dir), nprocs=_WORLD_SIZE, join=True)

--- a/tests/unit_tests/recipes/llm/test_train_dspark_helpers.py
+++ b/tests/unit_tests/recipes/llm/test_train_dspark_helpers.py
@@ -808,3 +808,87 @@ def test_recipe_cached_path_does_not_load_target_model(monkeypatch, tmp_path):
     assert len(recipe.train_dataloader.dataset) == 1
     torch.testing.assert_close(recipe.draft_model.embed_tokens.weight.detach().cpu(), embed.weight.detach())
     torch.testing.assert_close(recipe.draft_model.lm_head.weight.detach().cpu(), head.weight.detach())
+
+
+# ---------------------------------------------------------------------------
+# _maybe_shard_dense_target: opt-in FSDP2 sharding of a frozen dense target.
+# ---------------------------------------------------------------------------
+
+
+class _FakeTargetWrapper:
+    """Minimal HFDSparkTargetModel stand-in exposing the layer accessor used for sharding."""
+
+    def __init__(self, num_layers: int):
+        self._layers = [torch.nn.Linear(4, 4) for _ in range(num_layers)]
+        self._num_layers = num_layers
+
+    def _get_transformer_layers(self):
+        return self._layers
+
+
+def _make_shard_recipe(strategy="fsdp2", world_size=8, target_wrapper=None):
+    recipe = TrainDSparkRecipe({"distributed": {"strategy": strategy}})
+    recipe.dist_env = SimpleNamespace(world_size=world_size, is_main=True)
+    recipe.compute_dtype = torch.bfloat16
+    recipe.target_wrapper = _FakeTargetWrapper(4) if target_wrapper is None else target_wrapper
+    return recipe
+
+
+def _patch_fully_shard(monkeypatch):
+    """Record fully_shard calls without touching CUDA / a process group."""
+    import torch.distributed.fsdp as fsdp_mod
+
+    calls = []
+    monkeypatch.setattr(fsdp_mod, "fully_shard", lambda layer, **kwargs: calls.append((layer, kwargs)))
+    monkeypatch.setattr(fsdp_mod, "MixedPrecisionPolicy", lambda **kwargs: ("mp_policy", kwargs))
+    return calls
+
+
+def test_shard_dense_target_off_by_default(monkeypatch):
+    # Existing configs (no shard_dense_target) keep the target replicated: no sharding.
+    calls = _patch_fully_shard(monkeypatch)
+    recipe = _make_shard_recipe()
+    assert recipe._maybe_shard_dense_target({}, is_moe_target=False) is False
+    assert calls == []
+
+
+def test_shard_dense_target_shards_each_layer(monkeypatch):
+    calls = _patch_fully_shard(monkeypatch)
+    recipe = _make_shard_recipe()
+    sharded = recipe._maybe_shard_dense_target({"shard_dense_target": True}, is_moe_target=False)
+    assert sharded is True
+    # Every decoder layer is wrapped, and reshard_after_forward=True is mandatory
+    # (each layer is its own FSDP root and would otherwise stay all-gathered).
+    assert len(calls) == recipe.target_wrapper._num_layers
+    assert all(kwargs.get("reshard_after_forward") is True for _layer, kwargs in calls)
+
+
+def test_shard_dense_target_skips_moe(monkeypatch):
+    # MoE targets are already sharded via their own distributed setup.
+    calls = _patch_fully_shard(monkeypatch)
+    recipe = _make_shard_recipe()
+    assert recipe._maybe_shard_dense_target({"shard_dense_target": True}, is_moe_target=True) is False
+    assert calls == []
+
+
+def test_shard_dense_target_skips_when_no_wrapper(monkeypatch):
+    # Offline cached training loads no target (target_wrapper is None).
+    calls = _patch_fully_shard(monkeypatch)
+    recipe = _make_shard_recipe()
+    recipe.target_wrapper = None
+    assert recipe._maybe_shard_dense_target({"shard_dense_target": True}, is_moe_target=False) is False
+    assert calls == []
+
+
+def test_shard_dense_target_warns_on_single_rank(monkeypatch):
+    calls = _patch_fully_shard(monkeypatch)
+    recipe = _make_shard_recipe(world_size=1)
+    assert recipe._maybe_shard_dense_target({"shard_dense_target": True}, is_moe_target=False) is False
+    assert calls == []
+
+
+def test_shard_dense_target_warns_on_ddp(monkeypatch):
+    calls = _patch_fully_shard(monkeypatch)
+    recipe = _make_shard_recipe(strategy="ddp")
+    assert recipe._maybe_shard_dense_target({"shard_dense_target": True}, is_moe_target=False) is False
+    assert calls == []

--- a/tests/unit_tests/recipes/llm/test_train_dspark_helpers.py
+++ b/tests/unit_tests/recipes/llm/test_train_dspark_helpers.py
@@ -811,84 +811,42 @@ def test_recipe_cached_path_does_not_load_target_model(monkeypatch, tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# _maybe_shard_dense_target: opt-in FSDP2 sharding of a frozen dense target.
+# _should_shard_dense_target: opt-in gate for loading a frozen dense target
+# FSDP2-sharded via the standard distributed setup.
 # ---------------------------------------------------------------------------
 
 
-class _FakeTargetWrapper:
-    """Minimal HFDSparkTargetModel stand-in exposing the layer accessor used for sharding."""
-
-    def __init__(self, num_layers: int):
-        self._layers = [torch.nn.Linear(4, 4) for _ in range(num_layers)]
-        self._num_layers = num_layers
-
-    def _get_transformer_layers(self):
-        return self._layers
-
-
-def _make_shard_recipe(strategy="fsdp2", world_size=8, target_wrapper=None):
+def _make_shard_recipe(strategy="fsdp2", world_size=8):
     recipe = TrainDSparkRecipe({"distributed": {"strategy": strategy}})
     recipe.dist_env = SimpleNamespace(world_size=world_size, is_main=True)
     recipe.compute_dtype = torch.bfloat16
-    recipe.target_wrapper = _FakeTargetWrapper(4) if target_wrapper is None else target_wrapper
     return recipe
 
 
-def _patch_fully_shard(monkeypatch):
-    """Record fully_shard calls without touching CUDA / a process group."""
-    import torch.distributed.fsdp as fsdp_mod
-
-    calls = []
-    monkeypatch.setattr(fsdp_mod, "fully_shard", lambda layer, **kwargs: calls.append((layer, kwargs)))
-    monkeypatch.setattr(fsdp_mod, "MixedPrecisionPolicy", lambda **kwargs: ("mp_policy", kwargs))
-    return calls
-
-
-def test_shard_dense_target_off_by_default(monkeypatch):
-    # Existing configs (no shard_dense_target) keep the target replicated: no sharding.
-    calls = _patch_fully_shard(monkeypatch)
+def test_should_shard_dense_target_off_by_default():
+    # Existing configs (no shard_dense_target) keep the target replicated.
     recipe = _make_shard_recipe()
-    assert recipe._maybe_shard_dense_target({}, is_moe_target=False) is False
-    assert calls == []
+    assert recipe._should_shard_dense_target({}) is False
 
 
-def test_shard_dense_target_shards_each_layer(monkeypatch):
-    calls = _patch_fully_shard(monkeypatch)
+def test_should_shard_dense_target_true_on_fsdp2_multi_rank():
     recipe = _make_shard_recipe()
-    sharded = recipe._maybe_shard_dense_target({"shard_dense_target": True}, is_moe_target=False)
-    assert sharded is True
-    # Every decoder layer is wrapped, and reshard_after_forward=True is mandatory
-    # (each layer is its own FSDP root and would otherwise stay all-gathered).
-    assert len(calls) == recipe.target_wrapper._num_layers
-    assert all(kwargs.get("reshard_after_forward") is True for _layer, kwargs in calls)
+    assert recipe._should_shard_dense_target({"shard_dense_target": True}) is True
 
 
-def test_shard_dense_target_skips_moe(monkeypatch):
-    # MoE targets are already sharded via their own distributed setup.
-    calls = _patch_fully_shard(monkeypatch)
-    recipe = _make_shard_recipe()
-    assert recipe._maybe_shard_dense_target({"shard_dense_target": True}, is_moe_target=True) is False
-    assert calls == []
+def test_should_shard_dense_target_default_strategy_is_fsdp2():
+    # With no explicit distributed.strategy the default is fsdp2, so the flag takes effect.
+    recipe = TrainDSparkRecipe({})
+    recipe.dist_env = SimpleNamespace(world_size=8, is_main=True)
+    recipe.compute_dtype = torch.bfloat16
+    assert recipe._should_shard_dense_target({"shard_dense_target": True}) is True
 
 
-def test_shard_dense_target_skips_when_no_wrapper(monkeypatch):
-    # Offline cached training loads no target (target_wrapper is None).
-    calls = _patch_fully_shard(monkeypatch)
-    recipe = _make_shard_recipe()
-    recipe.target_wrapper = None
-    assert recipe._maybe_shard_dense_target({"shard_dense_target": True}, is_moe_target=False) is False
-    assert calls == []
-
-
-def test_shard_dense_target_warns_on_single_rank(monkeypatch):
-    calls = _patch_fully_shard(monkeypatch)
+def test_should_shard_dense_target_ignored_on_single_rank():
     recipe = _make_shard_recipe(world_size=1)
-    assert recipe._maybe_shard_dense_target({"shard_dense_target": True}, is_moe_target=False) is False
-    assert calls == []
+    assert recipe._should_shard_dense_target({"shard_dense_target": True}) is False
 
 
-def test_shard_dense_target_warns_on_ddp(monkeypatch):
-    calls = _patch_fully_shard(monkeypatch)
+def test_should_shard_dense_target_ignored_on_ddp():
     recipe = _make_shard_recipe(strategy="ddp")
-    assert recipe._maybe_shard_dense_target({"shard_dense_target": True}, is_moe_target=False) is False
-    assert calls == []
+    assert recipe._should_shard_dense_target({"shard_dense_target": True}) is False

--- a/tests/unit_tests/recipes/llm/test_train_dspark_helpers.py
+++ b/tests/unit_tests/recipes/llm/test_train_dspark_helpers.py
@@ -816,10 +816,9 @@ def test_recipe_cached_path_does_not_load_target_model(monkeypatch, tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def _make_shard_recipe(strategy="fsdp2", world_size=8):
-    recipe = TrainDSparkRecipe({"distributed": {"strategy": strategy}})
+def _make_shard_recipe(cfg=None, world_size=8):
+    recipe = TrainDSparkRecipe({"distributed": {"strategy": "fsdp2"}} if cfg is None else cfg)
     recipe.dist_env = SimpleNamespace(world_size=world_size, is_main=True)
-    recipe.compute_dtype = torch.bfloat16
     return recipe
 
 
@@ -835,10 +834,15 @@ def test_should_shard_dense_target_true_on_fsdp2_multi_rank():
 
 
 def test_should_shard_dense_target_default_strategy_is_fsdp2():
-    # With no explicit distributed.strategy the default is fsdp2, so the flag takes effect.
-    recipe = TrainDSparkRecipe({})
-    recipe.dist_env = SimpleNamespace(world_size=8, is_main=True)
-    recipe.compute_dtype = torch.bfloat16
+    # With no distributed: block at all the default is fsdp2, so the flag takes effect
+    # (regression: the missing block must not raise).
+    recipe = _make_shard_recipe(cfg={})
+    assert recipe._should_shard_dense_target({"shard_dense_target": True}) is True
+
+
+def test_should_shard_dense_target_strategy_is_case_folded():
+    # parse_distributed_section case-folds the strategy, so 'FSDP2' is the same topology.
+    recipe = _make_shard_recipe(cfg={"distributed": {"strategy": "FSDP2"}})
     assert recipe._should_shard_dense_target({"shard_dense_target": True}) is True
 
 
@@ -848,26 +852,23 @@ def test_should_shard_dense_target_ignored_on_single_rank():
 
 
 def test_should_shard_dense_target_ignored_on_ddp():
-    recipe = _make_shard_recipe(strategy="ddp")
+    recipe = _make_shard_recipe(cfg={"distributed": {"strategy": "ddp"}})
     assert recipe._should_shard_dense_target({"shard_dense_target": True}) is False
 
 
-@pytest.mark.parametrize("axis", ["tp_size", "pp_size", "cp_size", "ep_size"])
-def test_should_shard_dense_target_rejects_model_parallel_axes(axis):
+@pytest.mark.parametrize("axis", ["tp_size", "pp_size", "cp_size", "ep_size", "dp_replicate_size"])
+def test_should_shard_dense_target_rejects_non_pure_dp_axes(axis):
     # Only a pure FSDP2 data-parallel topology is supported: pp_size>1 builds an
-    # AutoPipeline the target wrapper cannot run, and tp/cp/ep are untested here.
-    recipe = TrainDSparkRecipe({"distributed": {"strategy": "fsdp2", axis: 2}})
-    recipe.dist_env = SimpleNamespace(world_size=8, is_main=True)
-    recipe.compute_dtype = torch.bfloat16
+    # AutoPipeline the target wrapper cannot run, tp/cp/ep are untested here, and
+    # HSDP replication (dp_replicate_size>1) re-replicates the target.
+    recipe = _make_shard_recipe(cfg={"distributed": {"strategy": "fsdp2", axis: 2}})
     with pytest.raises(ValueError, match=axis):
         recipe._should_shard_dense_target({"shard_dense_target": True})
 
 
 def test_should_shard_dense_target_allows_explicit_unit_or_null_axes():
     # Explicit 1s or YAML nulls on the model-parallel axes are the supported topology.
-    recipe = TrainDSparkRecipe(
-        {"distributed": {"strategy": "fsdp2", "tp_size": 1, "pp_size": None, "cp_size": 1, "ep_size": None}}
+    recipe = _make_shard_recipe(
+        cfg={"distributed": {"strategy": "fsdp2", "tp_size": 1, "pp_size": None, "cp_size": 1, "ep_size": None}}
     )
-    recipe.dist_env = SimpleNamespace(world_size=8, is_main=True)
-    recipe.compute_dtype = torch.bfloat16
     assert recipe._should_shard_dense_target({"shard_dense_target": True}) is True

--- a/tests/unit_tests/recipes/llm/test_train_dspark_helpers.py
+++ b/tests/unit_tests/recipes/llm/test_train_dspark_helpers.py
@@ -850,3 +850,24 @@ def test_should_shard_dense_target_ignored_on_single_rank():
 def test_should_shard_dense_target_ignored_on_ddp():
     recipe = _make_shard_recipe(strategy="ddp")
     assert recipe._should_shard_dense_target({"shard_dense_target": True}) is False
+
+
+@pytest.mark.parametrize("axis", ["tp_size", "pp_size", "cp_size", "ep_size"])
+def test_should_shard_dense_target_rejects_model_parallel_axes(axis):
+    # Only a pure FSDP2 data-parallel topology is supported: pp_size>1 builds an
+    # AutoPipeline the target wrapper cannot run, and tp/cp/ep are untested here.
+    recipe = TrainDSparkRecipe({"distributed": {"strategy": "fsdp2", axis: 2}})
+    recipe.dist_env = SimpleNamespace(world_size=8, is_main=True)
+    recipe.compute_dtype = torch.bfloat16
+    with pytest.raises(ValueError, match=axis):
+        recipe._should_shard_dense_target({"shard_dense_target": True})
+
+
+def test_should_shard_dense_target_allows_explicit_unit_or_null_axes():
+    # Explicit 1s or YAML nulls on the model-parallel axes are the supported topology.
+    recipe = TrainDSparkRecipe(
+        {"distributed": {"strategy": "fsdp2", "tp_size": 1, "pp_size": None, "cp_size": 1, "ep_size": None}}
+    )
+    recipe.dist_env = SimpleNamespace(world_size=8, is_main=True)
+    recipe.compute_dtype = torch.bfloat16
+    assert recipe._should_shard_dense_target({"shard_dense_target": True}) is True

--- a/tests/unit_tests/recipes/test_dist_utils.py
+++ b/tests/unit_tests/recipes/test_dist_utils.py
@@ -678,31 +678,28 @@ class TestCreateDistributedSetupFromConfigWorldSizeAutoDetect:
         assert result.strategy_config.sequence_parallel is True
         assert result.strategy_config.defer_fsdp_grad_sync is False
 
-    def test_confignode_without_distributed_block_defaults_to_fsdp2(self, patched_mesh):
-        """Regression: a ConfigNode with no ``distributed:`` block must build the default
-        FSDP2 setup through ``create_distributed_setup_from_config`` rather than raising
-        ``AttributeError`` (the dspark ``shard_dense_target`` multi-rank crash)."""
-        result = create_distributed_setup_from_config(ConfigNode({}), world_size=4)
+    def test_none_cfg_builds_default_fsdp2(self, patched_mesh):
+        """``cfg=None`` resolves to the default FSDP2 setup on the given world size (the
+        path dspark's ``shard_dense_target`` uses when a config omits ``distributed:``)."""
+        result = create_distributed_setup_from_config(None, world_size=4)
 
         assert isinstance(result, DistributedSetup)
         assert isinstance(result.strategy_config, FSDP2Config)
         assert patched_mesh["world_size"] == 4
 
+    def test_confignode_without_distributed_block_fails_loud(self, patched_mesh):
+        """A config object lacking the ``distributed:`` block keeps its fail-loud contract:
+        a mis-nested block in a config that requires one must not silently build a default
+        FSDP2 setup. Callers with an optional block pass ``None`` instead."""
+        with pytest.raises(AttributeError):
+            create_distributed_setup_from_config(ConfigNode({}), world_size=4)
+
     def test_confignode_with_distributed_block_is_honoured(self, patched_mesh):
-        """A present ``distributed:`` block on a ConfigNode is still read, not shadowed by
-        the missing-block fallback."""
-        result = create_distributed_setup_from_config(
-            ConfigNode({"distributed": {"strategy": "ddp"}}), world_size=2
-        )
+        """A present ``distributed:`` block on a ConfigNode is read from the object path."""
+        result = create_distributed_setup_from_config(ConfigNode({"distributed": {"strategy": "ddp"}}), world_size=2)
 
         assert isinstance(result.strategy_config, DDPConfig)
         assert patched_mesh["world_size"] == 2
-
-
-def test_distributed_cfg_to_dict_confignode_without_block_returns_empty():
-    """Regression: the object branch used ``cfg.distributed`` directly, so a ConfigNode
-    without the block raised ``AttributeError``; it must now yield an empty dict."""
-    assert _distributed_cfg_to_dict(ConfigNode({})) == {}
 
 
 def test_distributed_cfg_to_dict_confignode_with_block_returns_block():

--- a/tests/unit_tests/recipes/test_dist_utils.py
+++ b/tests/unit_tests/recipes/test_dist_utils.py
@@ -20,6 +20,7 @@ Typed validation tests live in ``tests/unit_tests/distributed/test_mesh.py``.
 import pytest
 import torch
 
+from nemo_automodel.components.config.loader import ConfigNode
 from nemo_automodel.components.distributed.config import (
     DDPConfig,
     DistributedSetup,
@@ -30,6 +31,7 @@ from nemo_automodel.components.distributed.config import (
 from nemo_automodel.components.distributed.mesh import MeshAxisName, MeshContext, ParallelismSizes
 from nemo_automodel.components.distributed.pipelining.config import PipelineConfig
 from nemo_automodel.recipes._dist_utils import (
+    _distributed_cfg_to_dict,
     create_distributed_setup_from_config,
     parse_distributed_section,
 )
@@ -675,3 +677,34 @@ class TestCreateDistributedSetupFromConfigWorldSizeAutoDetect:
 
         assert result.strategy_config.sequence_parallel is True
         assert result.strategy_config.defer_fsdp_grad_sync is False
+
+    def test_confignode_without_distributed_block_defaults_to_fsdp2(self, patched_mesh):
+        """Regression: a ConfigNode with no ``distributed:`` block must build the default
+        FSDP2 setup through ``create_distributed_setup_from_config`` rather than raising
+        ``AttributeError`` (the dspark ``shard_dense_target`` multi-rank crash)."""
+        result = create_distributed_setup_from_config(ConfigNode({}), world_size=4)
+
+        assert isinstance(result, DistributedSetup)
+        assert isinstance(result.strategy_config, FSDP2Config)
+        assert patched_mesh["world_size"] == 4
+
+    def test_confignode_with_distributed_block_is_honoured(self, patched_mesh):
+        """A present ``distributed:`` block on a ConfigNode is still read, not shadowed by
+        the missing-block fallback."""
+        result = create_distributed_setup_from_config(
+            ConfigNode({"distributed": {"strategy": "ddp"}}), world_size=2
+        )
+
+        assert isinstance(result.strategy_config, DDPConfig)
+        assert patched_mesh["world_size"] == 2
+
+
+def test_distributed_cfg_to_dict_confignode_without_block_returns_empty():
+    """Regression: the object branch used ``cfg.distributed`` directly, so a ConfigNode
+    without the block raised ``AttributeError``; it must now yield an empty dict."""
+    assert _distributed_cfg_to_dict(ConfigNode({})) == {}
+
+
+def test_distributed_cfg_to_dict_confignode_with_block_returns_block():
+    cfg = ConfigNode({"distributed": {"strategy": "fsdp2", "dp_size": 4}})
+    assert _distributed_cfg_to_dict(cfg) == {"strategy": "fsdp2", "dp_size": 4}


### PR DESCRIPTION
## What

A dense DSpark target (Qwen3 / Gemma4) is loaded whole and **replicated on every rank**. For a large dense target that stack alone dominates GPU memory (the frozen Gemma4-31B target is ~62 GiB), leaving no room for the draft's training activations, so training OOMs at the **first backward** on 80 GiB GPUs. The MoE targets (DeepSeek V4 / GLM-5.2 / MiniMax M3) already avoid this by loading through their distributed setup; dense targets had no equivalent.

This PR adds:

1. **`recipe_args.shard_dense_target`** (opt-in, default `False`): loads the frozen dense target through the standard distributed setup (`create_distributed_setup_from_config()` + `NeMoAutoModelForCausalLM.from_pretrained(distributed_setup=...)`), i.e. the same root FSDP2 path the MoE / VL targets already use, instead of replicating the target on every rank. This performs meta-device construction, layer sharding, and sharded checkpoint loading, and shares one device mesh / FSDP2 policy with the draft.
2. **A constrained topology gate** (`_should_shard_dense_target`): the flag requires `strategy=fsdp2` on more than one rank (otherwise it is ignored with a warning), and **only a pure FSDP2 data-parallel topology is supported**: any model-parallel or replication axis (`tp_size` / `pp_size` / `cp_size` / `ep_size` / `dp_replicate_size` > 1) raises a clear `ValueError` at setup. `pp_size > 1` would build an `AutoPipeline` the target wrapper cannot run, the other model-parallel axes are unvalidated for the frozen dense target, and HSDP replication re-replicates the target, defeating the sharding. The gate parses the `distributed:` block with the canonical `parse_distributed_section` (strategy case-folding, YAML-null axis defaulting), so it cannot drift from what the setup construction later builds. A config that omits `distributed:` entirely resolves to the default FSDP2 setup at the DSpark call site; the shared `create_distributed_setup_from_config` helper keeps its fail-loud missing-block contract for every other recipe.
3. Because the standard path root-`fully_shard`s the module, the frozen target's `embed_tokens` / `lm_head` come back as **DTensors**. The gather branch now keys off the general invariant (`self.distributed_setup is not None`, i.e. any distributed-setup-loaded target: MoE / VL / sharded dense), so those weights are gathered to full tensors before the draft seeds its own `embed_tokens` / `lm_head` from them.
4. **`examples/speculative/dspark/gemma4_31b_dspark.yaml`**: a validated 60-layer Gemma4-31B recipe (feature layers rescaled across 60 layers; `seq_length` / `num_anchors` trimmed from the 12B defaults so the draft activations fit alongside the sharded target on 8x80 GiB).
5. **Tests.** Unit: 12 cases for the topology gate (off by default; on for fsdp2 multi-rank incl. case-folded strategy and missing `distributed:` block; ignored on single rank / ddp; `ValueError` for each of tp/pp/cp/ep/dp_replicate_size > 1; explicit 1 / YAML null axes accepted) plus setup-construction regressions in `test_dist_utils.py` (cfg=None default FSDP2, missing-block fail-loud contract preserved). Functional: a **2-GPU test** (`tests/functional_tests/speculative/test_dspark_shard_dense_target_fsdp2.py`) covering the real distributed contract with a tiny on-disk Qwen3 target: sharded loading produces genuinely sharded DTensor parameters, `gather_full_weight_module` reassembles `embed_tokens` / `lm_head` bit-identical to the checkpoint and the draft seeds from them, hidden-state capture through the FSDP2-wrapped target matches the replicated-load capture, and the draft trains to a finite, decreasing loss.

### Notes

- **Off by default.** Existing dense-target configs (`qwen3_0.6b`, `gemma4_12b`) keep their replicated behavior; only configs that set the flag shard.
- **Loading reuses the standard distributed setup**, so the sharded target shares the same device mesh and FSDP2 policy as the draft. There is no manual per-layer `fully_shard`; resharding after forward is handled by the standard root FSDP2 path.

## Validation

**2-GPU functional test.** `tests/functional_tests/speculative/test_dspark_shard_dense_target_fsdp2.py` passes on 2xA800-80GB at the current head `d32590910` in ~2 min: the distributed-setup load produces genuinely sharded DTensor parameters, the gathered `embed_tokens` / `lm_head` are bit-identical to the checkpoint on disk (and the draft seeds from them), hidden-state capture through the FSDP2-wrapped target matches the replicated-load capture, and the draft trains to a finite, decreasing loss.

**8-GPU smoke** on 8xA800-80GB, single node (Gemma4-31B-it target, translation-instruction SFT data), commit `d32590910` (the current head, i.e. including the review fixes). Sharding keeps the resident target at ~9 GiB per rank instead of ~62 GiB replicated; peak training memory is 42.66 GiB per rank and training clears the first backward and converges with finite loss:

```
step 10 | epoch 0 | loss 4.7819 | ce 22.5036 | tv 1.9984 | conf 0.7264 | lr 5.62e-06 | mem 42.66 GiB
step 20 | epoch 0 | loss 3.8703 | ce 20.3773 | tv 1.9981 | conf 0.0204 | lr 1.07e-05 | mem 42.66 GiB
step 30 | epoch 0 | loss 3.2503 | ce 14.0884 | tv 1.9958 | conf 0.0339 | lr 1.58e-05 | mem 42.66 GiB
step 40 | epoch 0 | loss 3.1159 | ce 11.9063 | tv 1.9777 | conf 0.1211 | lr 2.09e-05 | mem 42.66 GiB
step 50 | epoch 0 | loss 3.3956 | ce 11.1157 | tv 1.9543 | conf 0.4562 | lr 2.60e-05 | mem 42.66 GiB
```

~12.1 s/step; the frozen sharded target re-gathers per microbatch, so throughput is all-gather bound on this short-sequence data. Before this change the same config OOMs at the first backward with the ~62 GiB target replicated per rank. The full sanitized log is posted as a PR comment.

Unit tests for the touched areas (`test_train_dspark_helpers.py`, `test_dist_utils.py`): 155 pass locally on CPU.
