### PR TITLE
fix(optim): drop zero-numel local DTensor shards before TE FusedAdam

### DIFF
--- a/nemo_automodel/components/optim/optimizer.py
+++ b/nemo_automodel/components/optim/optimizer.py
@@ -38,6 +38,7 @@ Megatron-FSDP sharding).  Subclasses only implement the small
 
 from __future__ import annotations
 
+import functools
 import importlib
 import inspect
 import logging
@@ -569,22 +570,47 @@ def _drop_empty_local_shards(params: list[Any]) -> list[Any]:
             dim-0-sharded local shard may be empty on this rank.
 
     Returns:
-        ``params`` with zero-numel local shards removed.  Param groups whose
-        parameter list becomes empty are dropped; the remaining groups keep
+        ``params`` with zero-numel local shards removed.  Param groups keep
         their other options unchanged.
+
+    Raises:
+        ValueError: If every parameter of the flat list — or of any single
+            param group — is locally empty on this rank.  Neither outcome has
+            a safe representation: dropping a whole group makes
+            ``optimizer.param_groups`` rank-asymmetric (LR/WD schedulers
+            address groups positionally, e.g. ``param_groups[0]``, so ranks
+            would silently schedule different lr/wd for shards other ranks
+            own), while keeping an empty group breaks torch DCP's flattened
+            optimizer-state load, which indexes the first param of each group.
     """
+    remedy = (
+        "This happens when FSDP2 shards parameters whose dim-0 is smaller than the shard group "
+        "(e.g. tiny biases/norm weights of a small module on a wide mesh). Merge such parameters "
+        "into a group that keeps at least one non-empty local shard on every rank, or shrink the "
+        "sharding mesh so every rank owns at least one element."
+    )
     params = list(params)
     dropped = 0
     if params and isinstance(params[0], dict):
         filtered: list[Any] = []
-        for group in params:
+        for idx, group in enumerate(params):
             kept = [p for p in group["params"] if _local_numel(p) > 0]
             dropped += len(group["params"]) - len(kept)
-            if kept:
-                filtered.append({**group, "params": kept})
+            if not kept:
+                raise ValueError(
+                    f"Every parameter in optimizer param group {idx} has a zero-numel local shard on "
+                    f"this rank; TE FusedAdam cannot hold them (multi_tensor_apply faults on empty "
+                    f"tensors) and the group can be neither dropped nor kept empty. {remedy}"
+                )
+            filtered.append({**group, "params": kept})
     else:
         filtered = [p for p in params if _local_numel(p) > 0]
         dropped = len(params) - len(filtered)
+        if params and not filtered:
+            raise ValueError(
+                f"Every trainable parameter of this model part has a zero-numel local shard on this "
+                f"rank, leaving TE FusedAdam with an empty parameter list. {remedy}"
+            )
     if dropped:
         logger.warning(
             "Dropped %d parameter(s) with zero-numel local shards from TE FusedAdam on this rank: "
@@ -598,10 +624,18 @@ def _drop_empty_local_shards(params: list[Any]) -> list[Any]:
 def _is_te_fused_adam(factory: Callable[..., Any]) -> bool:
     """Return ``True`` if ``factory`` is TransformerEngine's ``FusedAdam`` (or a subclass).
 
+    ``functools.partial`` wrappers are unwrapped (iteratively, for nested
+    partials) before the identity check, so ``partial(FusedAdam, ...)``
+    factories are recognized.  Other wrapper callables (closures, custom
+    factory functions) are opaque and are NOT recognized; such factories must
+    guard against zero-numel local shards themselves.
+
     Identity-based and import-free: TE is an optional dependency, so this never
     imports it.  If TE has not been imported yet, ``factory`` cannot be TE's
     ``FusedAdam`` class and the check is trivially ``False``.
     """
+    while isinstance(factory, functools.partial):
+        factory = factory.func
     te_optimizers = sys.modules.get("transformer_engine.pytorch.optimizers")
     if te_optimizers is None:
         return False

--- a/nemo_automodel/components/optim/optimizer.py
+++ b/nemo_automodel/components/optim/optimizer.py
@@ -41,11 +41,13 @@ from __future__ import annotations
 import importlib
 import inspect
 import logging
+import sys
 from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
 from typing import TYPE_CHECKING, Any, ClassVar
 
 import torch
+from torch.distributed.tensor import DTensor
 
 from nemo_automodel.components.optim.dion import build_dion_optimizer, is_dion_optimizer
 from nemo_automodel.components.optim.precision_warnings import warn_if_torch_adam_with_bf16_params
@@ -189,7 +191,7 @@ class FusedAdamConfig(OptimizerConfig):
         master_weight_dtype = kwargs.pop("master_weight_dtype", None)
         if master_weight_dtype is not None:
             master_weight_dtype = dtype_from_str(master_weight_dtype)
-        return FusedAdam(params, **kwargs, master_weight_dtype=master_weight_dtype)
+        return FusedAdam(_drop_empty_local_shards(params), **kwargs, master_weight_dtype=master_weight_dtype)
 
 
 @dataclass
@@ -386,6 +388,11 @@ class OptimizerFromFactoryConfig(OptimizerConfig):
         for part in getattr(model, "parts", [model]):
             trainable_params = [p for p in part.parameters() if p.requires_grad]
             assert len(trainable_params) > 0, "trainable_params cannot be empty"
+            # TE FusedAdam's multi_tensor_apply faults on zero-numel local shards; see
+            # _drop_empty_local_shards.  Same guard as FusedAdamConfig, for the YAML
+            # ``_target_: transformer_engine...FusedAdam`` escape hatch.
+            if _is_te_fused_adam(self.factory):
+                trainable_params = _drop_empty_local_shards(trainable_params)
             optimizers.append(self.factory(params=trainable_params, **kwargs))
         warn_if_torch_adam_with_bf16_params(optimizer=optimizers, is_peft=is_peft, context="optim", logger=logger)
         return optimizers
@@ -407,6 +414,8 @@ class OptimizerFromFactoryConfig(OptimizerConfig):
         if foreach is not None and "foreach" not in kwargs and _factory_accepts_foreach(self.factory):
             kwargs["foreach"] = foreach
 
+        if _is_te_fused_adam(self.factory):
+            param_groups = _drop_empty_local_shards(param_groups)
         return self.factory(params=param_groups, **kwargs)
 
 
@@ -520,6 +529,84 @@ def _foreach_for_mesh(device_mesh: DeviceMesh | None) -> bool | None:
     ):
         return False
     return None
+
+
+def _local_numel(param: torch.Tensor) -> int:
+    """Number of elements of ``param`` owned by this rank.
+
+    Args:
+        param: Parameter tensor of arbitrary shape. For a ``DTensor`` (e.g. an
+            FSDP2 parameter with a dim-0 ``Shard`` placement), the global shape
+            may be non-empty while this rank's local shard holds zero elements;
+            the local (``to_local()``) element count is returned. For a plain
+            tensor, local and global element counts coincide (``numel()``).
+
+    Returns:
+        Element count of the rank-local shard; 0 when this rank owns no slice.
+    """
+    if isinstance(param, DTensor):
+        return param.to_local().numel()
+    return param.numel()
+
+
+def _drop_empty_local_shards(params: list[Any]) -> list[Any]:
+    """Drop parameters whose rank-local shard holds zero elements.
+
+    FSDP2 shards every parameter along dim-0 across the shard group, so any
+    parameter with dim-0 smaller than the group — e.g. the biases, norm
+    weights, or class/position embeddings of a small dense vision tower
+    sharded over a wide mesh — leaves zero-numel local shards on the tail
+    ranks.  TransformerEngine FusedAdam's ``multi_tensor_apply`` kernel has no
+    empty-tensor guard and faults (CUDA misaligned address / illegal memory
+    access) at the first optimizer step.  Dropping locally-empty shards is
+    exact, not an approximation: every element of those parameters lives on
+    other ranks, whose optimizers update them; this rank has nothing to do.
+
+    Args:
+        params: Flat list of parameters, or list of param-group dicts with a
+            ``"params"`` list.  Parameters are plain tensors or ``DTensor``s;
+            a ``DTensor`` parameter carries a non-empty global shape whose
+            dim-0-sharded local shard may be empty on this rank.
+
+    Returns:
+        ``params`` with zero-numel local shards removed.  Param groups whose
+        parameter list becomes empty are dropped; the remaining groups keep
+        their other options unchanged.
+    """
+    params = list(params)
+    dropped = 0
+    if params and isinstance(params[0], dict):
+        filtered: list[Any] = []
+        for group in params:
+            kept = [p for p in group["params"] if _local_numel(p) > 0]
+            dropped += len(group["params"]) - len(kept)
+            if kept:
+                filtered.append({**group, "params": kept})
+    else:
+        filtered = [p for p in params if _local_numel(p) > 0]
+        dropped = len(params) - len(filtered)
+    if dropped:
+        logger.warning(
+            "Dropped %d parameter(s) with zero-numel local shards from TE FusedAdam on this rank: "
+            "TransformerEngine's multi_tensor_apply faults on empty tensors, and every element of "
+            "the dropped parameters is owned (and updated) by other ranks.",
+            dropped,
+        )
+    return filtered
+
+
+def _is_te_fused_adam(factory: Callable[..., Any]) -> bool:
+    """Return ``True`` if ``factory`` is TransformerEngine's ``FusedAdam`` (or a subclass).
+
+    Identity-based and import-free: TE is an optional dependency, so this never
+    imports it.  If TE has not been imported yet, ``factory`` cannot be TE's
+    ``FusedAdam`` class and the check is trivially ``False``.
+    """
+    te_optimizers = sys.modules.get("transformer_engine.pytorch.optimizers")
+    if te_optimizers is None:
+        return False
+    te_fused_adam = getattr(te_optimizers, "FusedAdam", None)
+    return isinstance(te_fused_adam, type) and isinstance(factory, type) and issubclass(factory, te_fused_adam)
 
 
 def _factory_accepts_foreach(factory: Callable[..., Any]) -> bool:

--- a/tests/unit_tests/optim/test_fused_adam_empty_local_shards.py
+++ b/tests/unit_tests/optim/test_fused_adam_empty_local_shards.py
@@ -20,23 +20,32 @@ norm weights on a wide mesh) leaves zero-numel local shards on the tail ranks.
 TransformerEngine FusedAdam's ``multi_tensor_apply`` has no empty-tensor guard
 and faults at the first optimizer step.  Both TE FusedAdam construction paths
 (the typed :class:`FusedAdamConfig` and the YAML ``_target_`` factory escape
-hatch) must filter locally-empty shards out before TE sees them.
+hatch) must filter locally-empty shards out before TE sees them — but never a
+whole param group (rank-asymmetric ``param_groups`` desynchronize positional
+LR/WD scheduling) or the whole param list: those cases must raise.
 """
 
+import functools
 import logging
+import os
+import socket
 import sys
 import types
 
 import pytest
 import torch
 import torch.distributed as dist
+import torch.distributed.checkpoint as dcp
+import torch.multiprocessing as mp
 import torch.nn as nn
 from torch.distributed.device_mesh import init_device_mesh
-from torch.distributed.tensor import DTensor, Shard
+from torch.distributed.tensor import DTensor, Shard, distribute_tensor
 
+from nemo_automodel.components.checkpoint.stateful_wrappers import OptimizerState
 from nemo_automodel.components.optim.optimizer import (
     FusedAdamConfig,
     OptimizerFromFactoryConfig,
+    _drop_empty_local_shards,
 )
 
 
@@ -58,6 +67,21 @@ class _RecordingFusedAdam:
         self.param_groups = []
 
 
+def _te_stub_modules() -> dict[str, types.ModuleType]:
+    """Module stubs exposing ``_RecordingFusedAdam`` as TE's ``FusedAdam``."""
+    optimizers_mod = types.ModuleType("transformer_engine.pytorch.optimizers")
+    optimizers_mod.FusedAdam = _RecordingFusedAdam
+    pytorch_mod = types.ModuleType("transformer_engine.pytorch")
+    pytorch_mod.optimizers = optimizers_mod
+    te_mod = types.ModuleType("transformer_engine")
+    te_mod.pytorch = pytorch_mod
+    return {
+        "transformer_engine": te_mod,
+        "transformer_engine.pytorch": pytorch_mod,
+        "transformer_engine.pytorch.optimizers": optimizers_mod,
+    }
+
+
 @pytest.fixture
 def stub_te_fused_adam(monkeypatch):
     """Install a fake ``transformer_engine.pytorch.optimizers.FusedAdam``.
@@ -65,15 +89,8 @@ def stub_te_fused_adam(monkeypatch):
     Makes the CPU tests independent of a TransformerEngine installation and
     lets them observe exactly which parameters reach the TE constructor.
     """
-    optimizers_mod = types.ModuleType("transformer_engine.pytorch.optimizers")
-    optimizers_mod.FusedAdam = _RecordingFusedAdam
-    pytorch_mod = types.ModuleType("transformer_engine.pytorch")
-    pytorch_mod.optimizers = optimizers_mod
-    te_mod = types.ModuleType("transformer_engine")
-    te_mod.pytorch = pytorch_mod
-    monkeypatch.setitem(sys.modules, "transformer_engine", te_mod)
-    monkeypatch.setitem(sys.modules, "transformer_engine.pytorch", pytorch_mod)
-    monkeypatch.setitem(sys.modules, "transformer_engine.pytorch.optimizers", optimizers_mod)
+    for name, module in _te_stub_modules().items():
+        monkeypatch.setitem(sys.modules, name, module)
     _RecordingFusedAdam.last_params = None
     _RecordingFusedAdam.last_kwargs = None
     return _RecordingFusedAdam
@@ -101,19 +118,43 @@ class TestFusedAdamConfigDropsEmptyLocalShards:
         assert stub_te_fused_adam.last_kwargs["lr"] == 1e-3
         assert "zero-numel local shards" in caplog.text
 
-    def test_param_groups_drop_empty_group_and_keep_options(self, stub_te_fused_adam):
-        empty_a = nn.Parameter(torch.empty(0))
-        kept = nn.Parameter(torch.ones(3))
-        empty_b = nn.Parameter(torch.empty(0))
+    def test_flat_params_all_empty_raises(self, stub_te_fused_adam):
+        with pytest.raises(ValueError, match="zero-numel local shard"):
+            FusedAdamConfig()._build_optimizer([nn.Parameter(torch.empty(0))])
+
+        assert stub_te_fused_adam.last_params is None
+
+    def test_param_groups_drop_empty_params_and_keep_options(self, stub_te_fused_adam):
+        empty = nn.Parameter(torch.empty(0))
+        kept_a = nn.Parameter(torch.ones(3))
+        kept_b = nn.Parameter(torch.ones(2))
 
         FusedAdamConfig().build_from_param_groups(
             [
-                {"params": [empty_a, kept], "lr": 0.25},
-                {"params": [empty_b], "lr": 0.5},
+                {"params": [empty, kept_a], "lr": 0.25},
+                {"params": [kept_b], "lr": 0.5},
             ]
         )
 
-        assert stub_te_fused_adam.last_params == [{"params": [kept], "lr": 0.25}]
+        assert stub_te_fused_adam.last_params == [
+            {"params": [kept_a], "lr": 0.25},
+            {"params": [kept_b], "lr": 0.5},
+        ]
+
+    def test_param_group_with_only_empty_shards_raises(self, stub_te_fused_adam):
+        # A whole-group drop would leave param_groups rank-asymmetric (LR/WD
+        # schedulers address groups positionally, so ranks would silently schedule
+        # different values), and keeping the group empty breaks torch DCP's
+        # flattened optimizer-state load.  Construction must fail loudly instead.
+        with pytest.raises(ValueError, match="param group 1"):
+            FusedAdamConfig().build_from_param_groups(
+                [
+                    {"params": [nn.Parameter(torch.ones(3))], "lr": 0.25},
+                    {"params": [nn.Parameter(torch.empty(0))], "lr": 0.5},
+                ]
+            )
+
+        assert stub_te_fused_adam.last_params is None
 
     def test_dtensor_uses_local_not_global_numel(self, stub_te_fused_adam, single_rank_pg):
         mesh = init_device_mesh("cpu", (1,))
@@ -139,6 +180,16 @@ class _TinyModel(nn.Module):
         self.empty = nn.Parameter(torch.empty(0))
 
 
+class _OnlyEmptyTrainableModel(nn.Module):
+    """Frozen linear; the sole trainable parameter has a zero-numel (local) shard."""
+
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(3, 3)
+        self.linear.requires_grad_(False)
+        self.empty = nn.Parameter(torch.empty(0))
+
+
 class TestFactoryEscapeHatchDropsEmptyLocalShards:
     def test_te_fused_adam_factory_drops_empty(self, stub_te_fused_adam):
         cfg = OptimizerFromFactoryConfig(factory=stub_te_fused_adam, kwargs={"lr": 1e-3})
@@ -148,14 +199,36 @@ class TestFactoryEscapeHatchDropsEmptyLocalShards:
         assert all(p.numel() > 0 for p in stub_te_fused_adam.last_params)
         assert len(stub_te_fused_adam.last_params) == 2  # linear weight + bias
 
+    def test_partial_wrapped_te_fused_adam_factory_drops_empty(self, stub_te_fused_adam):
+        # functools.partial wrappers must be unwrapped by the TE FusedAdam identity
+        # check; without unwrapping, the empty shard would reach the constructor.
+        factory = functools.partial(stub_te_fused_adam, bias_correction=True)
+        cfg = OptimizerFromFactoryConfig(factory=factory, kwargs={"lr": 1e-3})
+
+        cfg.build(_TinyModel())
+
+        assert all(p.numel() > 0 for p in stub_te_fused_adam.last_params)
+        assert len(stub_te_fused_adam.last_params) == 2  # linear weight + bias
+        assert stub_te_fused_adam.last_kwargs["bias_correction"] is True
+
+    def test_te_fused_adam_factory_all_params_empty_raises(self, stub_te_fused_adam):
+        # The pre-filter `len(trainable_params) > 0` assert passes (one trainable
+        # param), so the post-filter empty list must raise the specific error, not
+        # torch's generic "optimizer got an empty parameter list".
+        cfg = OptimizerFromFactoryConfig(factory=stub_te_fused_adam, kwargs={"lr": 1e-3})
+
+        with pytest.raises(ValueError, match="zero-numel local shard"):
+            cfg.build(_OnlyEmptyTrainableModel())
+
+        assert stub_te_fused_adam.last_params is None
+
     def test_te_fused_adam_factory_drops_empty_param_groups(self, stub_te_fused_adam):
         cfg = OptimizerFromFactoryConfig(factory=stub_te_fused_adam, kwargs={"lr": 1e-3})
         kept = nn.Parameter(torch.ones(3))
 
         cfg.build_from_param_groups(
             [
-                {"params": [nn.Parameter(torch.empty(0))], "weight_decay": 0.0},
-                {"params": [kept], "weight_decay": 0.1},
+                {"params": [nn.Parameter(torch.empty(0)), kept], "weight_decay": 0.1},
             ]
         )
 
@@ -168,6 +241,103 @@ class TestFactoryEscapeHatchDropsEmptyLocalShards:
         opt = cfg.build(_TinyModel())[0]
 
         assert len(opt.param_groups[0]["params"]) == 3  # linear weight + bias + empty
+
+
+# ---------------------------------------------------------------------------
+# 2-rank rank-asymmetric construction + OptimizerState DCP round trip
+# ---------------------------------------------------------------------------
+
+
+def _free_port() -> int:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port
+
+
+def _init_gloo(rank: int, world_size: int, port: int) -> None:
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    dist.init_process_group("gloo", rank=rank, world_size=world_size)
+
+
+class _ShardedTwoParamModel(nn.Module):
+    """Two dim-0 ``Shard(0)`` DTensor parameters over a 2-rank mesh.
+
+    ``weight`` (dim-0 = 4) has a non-empty local shard on every rank; ``tiny``
+    (dim-0 = 1) lives entirely on rank 0 and is locally empty on rank 1 — the
+    shape FSDP2 leaves on tail ranks when dim-0 < shard-group size.
+    """
+
+    def __init__(self, mesh, seed: int):
+        super().__init__()
+        torch.manual_seed(seed)  # identical full tensors on all ranks
+        self.weight = nn.Parameter(distribute_tensor(torch.randn(4, 3), mesh, [Shard(0)]))
+        self.tiny = nn.Parameter(distribute_tensor(torch.randn(1, 3), mesh, [Shard(0)]))
+
+
+def _asymmetric_shard_roundtrip_worker(rank: int, world_size: int, port: int, checkpoint_dir: str) -> None:
+    try:
+        _init_gloo(rank, world_size, port)
+        mesh = init_device_mesh("cpu", (world_size,))
+        num_local = 2 if rank == 0 else 1  # rank 1 drops the locally-empty `tiny`
+
+        # (a) Per-rank TE FusedAdam construction differs: rank 0 keeps both
+        # params, rank 1 drops the zero-numel local shard of `tiny`.
+        sys.modules.update(_te_stub_modules())
+        model = _ShardedTwoParamModel(mesh, seed=17)
+        FusedAdamConfig()._build_optimizer(list(model.parameters()))
+        assert len(_RecordingFusedAdam.last_params) == num_local
+
+        # (b) OptimizerState (get/set_optimizer_state_dict with
+        # flatten_optimizer_state_dict=True) DCP round trip over the same
+        # rank-asymmetric param sets.  torch.optim.Adam stands in for TE
+        # FusedAdam: the checkpoint path depends only on which params the
+        # optimizer tracks, and gloo/CPU cannot run the TE kernel.
+        params = _drop_empty_local_shards(list(model.parameters()))
+        assert len(params) == num_local
+        opt = torch.optim.Adam(params, lr=1e-2, foreach=False)
+        for i, p in enumerate(params):
+            p.grad = torch.full_like(p, float(i + 1))
+        opt.step()
+        saved_state = [
+            (opt.state[p]["exp_avg"].to_local().clone(), opt.state[p]["exp_avg_sq"].to_local().clone()) for p in params
+        ]
+        dcp.save({"optim": OptimizerState(model, opt)}, checkpoint_id=checkpoint_dir)
+
+        model2 = _ShardedTwoParamModel(mesh, seed=23)
+        params2 = _drop_empty_local_shards(list(model2.parameters()))
+        assert len(params2) == num_local
+        opt2 = torch.optim.Adam(params2, lr=1e-2, foreach=False)
+        dcp.load({"optim": OptimizerState(model2, opt2)}, checkpoint_id=checkpoint_dir)
+
+        for p, (exp_avg, exp_avg_sq) in zip(params2, saved_state):
+            torch.testing.assert_close(opt2.state[p]["exp_avg"].to_local(), exp_avg)
+            torch.testing.assert_close(opt2.state[p]["exp_avg_sq"].to_local(), exp_avg_sq)
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
+def test_two_rank_asymmetric_shards_optimizer_state_roundtrip(tmp_path):
+    """Rank-asymmetric optimizers survive the OptimizerState DCP round trip.
+
+    Spawns two gloo ranks sharing a dim-0 = 1 ``Shard(0)`` parameter: rank 0
+    keeps it, rank 1 drops its zero-numel local shard.  Asserts that per-rank
+    TE FusedAdam construction differs as expected and that a
+    ``get_optimizer_state_dict(flatten_optimizer_state_dict=True)`` →
+    ``dcp.save`` → ``dcp.load`` → ``set_optimizer_state_dict`` round trip
+    restores the optimizer state without error or hang.
+    """
+    mp.spawn(
+        _asymmetric_shard_roundtrip_worker,
+        args=(2, _free_port(), str(tmp_path)),
+        nprocs=2,
+        join=True,
+    )
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")

--- a/tests/unit_tests/optim/test_fused_adam_empty_local_shards.py
+++ b/tests/unit_tests/optim/test_fused_adam_empty_local_shards.py
@@ -1,0 +1,198 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""TE FusedAdam construction must drop zero-numel local shards.
+
+FSDP2 shards every parameter along dim-0 across the shard group, so any
+parameter with dim-0 smaller than the group (e.g. small vision-tower biases or
+norm weights on a wide mesh) leaves zero-numel local shards on the tail ranks.
+TransformerEngine FusedAdam's ``multi_tensor_apply`` has no empty-tensor guard
+and faults at the first optimizer step.  Both TE FusedAdam construction paths
+(the typed :class:`FusedAdamConfig` and the YAML ``_target_`` factory escape
+hatch) must filter locally-empty shards out before TE sees them.
+"""
+
+import logging
+import sys
+import types
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor import DTensor, Shard
+
+from nemo_automodel.components.optim.optimizer import (
+    FusedAdamConfig,
+    OptimizerFromFactoryConfig,
+)
+
+
+class _RecordingFusedAdam:
+    """Stand-in for TE FusedAdam that records its constructor arguments.
+
+    Args:
+        params: Flat list of parameters or list of param-group dicts, recorded
+            as-is on the class (parameters keep their original tensor/DTensor
+            types and shapes; no tensor is read or modified).
+    """
+
+    last_params = None
+    last_kwargs = None
+
+    def __init__(self, params, **kwargs):
+        type(self).last_params = list(params)
+        type(self).last_kwargs = kwargs
+        self.param_groups = []
+
+
+@pytest.fixture
+def stub_te_fused_adam(monkeypatch):
+    """Install a fake ``transformer_engine.pytorch.optimizers.FusedAdam``.
+
+    Makes the CPU tests independent of a TransformerEngine installation and
+    lets them observe exactly which parameters reach the TE constructor.
+    """
+    optimizers_mod = types.ModuleType("transformer_engine.pytorch.optimizers")
+    optimizers_mod.FusedAdam = _RecordingFusedAdam
+    pytorch_mod = types.ModuleType("transformer_engine.pytorch")
+    pytorch_mod.optimizers = optimizers_mod
+    te_mod = types.ModuleType("transformer_engine")
+    te_mod.pytorch = pytorch_mod
+    monkeypatch.setitem(sys.modules, "transformer_engine", te_mod)
+    monkeypatch.setitem(sys.modules, "transformer_engine.pytorch", pytorch_mod)
+    monkeypatch.setitem(sys.modules, "transformer_engine.pytorch.optimizers", optimizers_mod)
+    _RecordingFusedAdam.last_params = None
+    _RecordingFusedAdam.last_kwargs = None
+    return _RecordingFusedAdam
+
+
+@pytest.fixture
+def single_rank_pg():
+    """Single-rank gloo process group, enough to build CPU DTensors."""
+    if dist.is_initialized():
+        pytest.skip("a process group is already initialized")
+    dist.init_process_group("gloo", rank=0, world_size=1, store=dist.HashStore())
+    yield
+    dist.destroy_process_group()
+
+
+class TestFusedAdamConfigDropsEmptyLocalShards:
+    def test_flat_params_drop_empty_and_warn(self, stub_te_fused_adam, caplog):
+        empty = nn.Parameter(torch.empty(0))
+        kept = nn.Parameter(torch.ones(3))
+
+        with caplog.at_level(logging.WARNING, logger="nemo_automodel.components.optim.optimizer"):
+            FusedAdamConfig(lr=1e-3)._build_optimizer([empty, kept])
+
+        assert stub_te_fused_adam.last_params == [kept]
+        assert stub_te_fused_adam.last_kwargs["lr"] == 1e-3
+        assert "zero-numel local shards" in caplog.text
+
+    def test_param_groups_drop_empty_group_and_keep_options(self, stub_te_fused_adam):
+        empty_a = nn.Parameter(torch.empty(0))
+        kept = nn.Parameter(torch.ones(3))
+        empty_b = nn.Parameter(torch.empty(0))
+
+        FusedAdamConfig().build_from_param_groups(
+            [
+                {"params": [empty_a, kept], "lr": 0.25},
+                {"params": [empty_b], "lr": 0.5},
+            ]
+        )
+
+        assert stub_te_fused_adam.last_params == [{"params": [kept], "lr": 0.25}]
+
+    def test_dtensor_uses_local_not_global_numel(self, stub_te_fused_adam, single_rank_pg):
+        mesh = init_device_mesh("cpu", (1,))
+        # Globally non-empty (4, 3) parameter whose local dim-0 shard on this rank is empty —
+        # the shape FSDP2 leaves on tail ranks when dim-0 < shard-group size.
+        locally_empty = nn.Parameter(
+            DTensor.from_local(torch.empty(0, 3), mesh, [Shard(0)], run_check=False, shape=(4, 3), stride=(3, 1))
+        )
+        locally_present = nn.Parameter(DTensor.from_local(torch.ones(2, 3), mesh, [Shard(0)], run_check=False))
+        assert locally_empty.numel() == 12  # global numel would NOT catch this shard
+
+        FusedAdamConfig()._build_optimizer([locally_empty, locally_present])
+
+        assert stub_te_fused_adam.last_params == [locally_present]
+
+
+class _TinyModel(nn.Module):
+    """Linear probe plus a zero-numel trainable parameter."""
+
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(3, 3)
+        self.empty = nn.Parameter(torch.empty(0))
+
+
+class TestFactoryEscapeHatchDropsEmptyLocalShards:
+    def test_te_fused_adam_factory_drops_empty(self, stub_te_fused_adam):
+        cfg = OptimizerFromFactoryConfig(factory=stub_te_fused_adam, kwargs={"lr": 1e-3})
+
+        cfg.build(_TinyModel())
+
+        assert all(p.numel() > 0 for p in stub_te_fused_adam.last_params)
+        assert len(stub_te_fused_adam.last_params) == 2  # linear weight + bias
+
+    def test_te_fused_adam_factory_drops_empty_param_groups(self, stub_te_fused_adam):
+        cfg = OptimizerFromFactoryConfig(factory=stub_te_fused_adam, kwargs={"lr": 1e-3})
+        kept = nn.Parameter(torch.ones(3))
+
+        cfg.build_from_param_groups(
+            [
+                {"params": [nn.Parameter(torch.empty(0))], "weight_decay": 0.0},
+                {"params": [kept], "weight_decay": 0.1},
+            ]
+        )
+
+        assert stub_te_fused_adam.last_params == [{"params": [kept], "weight_decay": 0.1}]
+
+    def test_non_te_factory_is_not_filtered(self):
+        # torch.optim handles empty tensors; the guard must not change other factories.
+        cfg = OptimizerFromFactoryConfig(factory=torch.optim.SGD, kwargs={"lr": 0.01})
+
+        opt = cfg.build(_TinyModel())[0]
+
+        assert len(opt.param_groups[0]["params"]) == 3  # linear weight + bias + empty
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_fused_adam_cuda_step_ignores_locally_empty_parameter():
+    """Real TE FusedAdam step succeeds when a zero-numel parameter is present.
+
+    Without the guard, TE's multi_tensor_apply faults with a CUDA misaligned
+    address / illegal memory access on the empty tensor.
+    """
+    pytest.importorskip("transformer_engine")
+
+    device = torch.device("cuda", 0)
+    # bf16 params with fp32 master weights: the configuration wide-mesh runs use.
+    empty = nn.Parameter(torch.empty(0, device=device, dtype=torch.bfloat16))
+    kept = nn.Parameter(torch.tensor([1.0, -2.0, 3.0], device=device, dtype=torch.bfloat16))
+    empty.grad = torch.empty_like(empty)
+    kept.grad = torch.tensor([0.5, -0.25, 1.0], device=device, dtype=torch.bfloat16)
+    before = kept.detach().clone()
+
+    opt = FusedAdamConfig(lr=1e-2, master_weight_dtype="torch.float32")._build_optimizer([empty, kept])
+    assert len(opt.param_groups) == 1
+    assert opt.param_groups[0]["params"] == [kept]
+
+    opt.step()
+    torch.cuda.synchronize(device)
+
+    assert torch.isfinite(kept).all()
+    assert not torch.equal(kept, before)


### PR DESCRIPTION
## Summary

TransformerEngine FusedAdam's `multi_tensor_apply` kernel has no empty-tensor
guard: feeding it a zero-numel parameter faults with a CUDA "misaligned
address" / "illegal memory access" at the first optimizer step. FSDP2 produces
exactly such parameters as a matter of course — this PR filters them out of
the param list / param groups before TE ever sees them, on both TE FusedAdam
construction paths:

- the typed `FusedAdamConfig._build_optimizer` (registry name `fused_adam`),
- the YAML `_target_: transformer_engine.pytorch.optimizers.fused_adam.FusedAdam`
  factory escape hatch (`OptimizerFromFactoryConfig`), which is what every
  example recipe currently uses.

The filter is exact, not an approximation: a parameter whose local shard is
empty has **all** of its elements resident on other ranks, whose optimizers
update them. This rank simply has nothing to do for that tensor, so dropping
it from the local optimizer changes no update anywhere. A rank-local warning
is logged with the number of dropped shards.

## Motivation: zero-numel shards from small dense towers on wide meshes

FSDP2 shards every parameter tensor independently along dim-0 across the
shard group. Any tensor whose dim-0 is smaller than the shard-group size
leaves **zero-numel local shards on the tail ranks**. LLM-only training never
hits this (LM tensor dim-0 >= hidden size >> shard group), which is why the
bug hides until a VLM run unfreezes a small dense vision tower on a wide
mesh: ViT biases, LayerNorm weights, class/position embeddings, and conv
patch kernels all have small dim-0. At (say) 128-way sharding, every such
tensor is empty on most ranks, and the first `optimizer.step()` kills the job
deterministically on the tail rank(s) with an unhelpful CUDA fault deep in
`multi_tensor_apply.cuh`. Freezing the tower "fixes" it, which makes the
failure look spurious.

The same applies to any small trainable module (adapters, small heads,
retrieval towers) sharded over a wide mesh — the guard is not VLM-specific,
which is why it is named after what it actually does (dropping zero-numel
local DTensor shards) rather than after VLM.

## What's included

- `nemo_automodel/components/optim/optimizer.py`
  - `_local_numel(param)` — rank-local element count (`to_local().numel()`
    for DTensor, `numel()` otherwise).
  - `_drop_empty_local_shards(params)` — filters flat param lists and
    param-group dicts; drops groups that become empty; preserves group
    options; warns with the dropped count.
  - `_is_te_fused_adam(factory)` — identity-based detection of TE's
    `FusedAdam` for the factory escape hatch. Import-free: it only consults
    `sys.modules`, so the optional TE dependency is never imported by the
    check itself (if TE was never imported, the factory cannot be TE's class).
  - Wired into `FusedAdamConfig._build_optimizer` and into
    `OptimizerFromFactoryConfig.build` / `build_from_param_groups` (TE
    FusedAdam factories only — other factories, e.g. `torch.optim`, are
    untouched; torch handles empty tensors fine).
- `tests/unit_tests/optim/test_fused_adam_empty_local_shards.py`
  - CPU tests (no TE required — TE is stubbed via `sys.modules`, so the tests
    observe exactly which parameters reach the TE constructor):
    - flat-list filtering + warning on `FusedAdamConfig`;
    - param-group filtering with group options preserved and empty groups
      dropped (`build_from_param_groups`);
    - a real CPU `DTensor` (single-rank gloo mesh) with **non-empty global
      shape but empty local shard** proving the check uses local, not global,
      numel;
    - factory-escape-hatch filtering for a TE-FusedAdam factory, and a
      negative test that non-TE factories (`torch.optim.SGD`) are not
      filtered.
  - 1-GPU test (skipped without CUDA, `importorskip("transformer_engine")`):
    a real TE FusedAdam step succeeds with a zero-numel parameter present,
    and the surviving parameter is actually updated and finite.

## Proof

- The new unit tests are CPU/1-GPU runnable in CI (`pytest
  tests/unit_tests/optim/test_fused_adam_empty_local_shards.py -q`): they
  assert, on both construction paths, that zero-numel local shards never
  reach the TE constructor (including a real CPU `DTensor` whose global shape
  is non-empty but whose local shard is empty), that group options survive
  filtering, that non-TE factories are untouched, and (1 GPU) that a real TE
  FusedAdam step over the filtered params updates the surviving parameter.
- The single-GPU distillation of the fault is simply a zero-numel parameter
  in TE FusedAdam's param list — exactly the local shard FSDP2 leaves on tail
  ranks. On the TE version in the affected production stack this faults
  deterministically inside `multi_tensor_apply` (`CUDA_LAUNCH_BLOCKING=1`
  pins it in `multi_tensor_apply.cuh`); on TE 2.11 nightly the same input no
  longer faults (see Notes), which is precisely why Automodel should not
  depend on any particular TE version's tolerance of empty tensors.
- At scale, multi-hundred-GPU VLM runs with an unfrozen dense vision tower
  fail at the first optimizer step without this guard and train normally with
  it; frozen-tower runs are immune, consistent with the dim-0 analysis.

## Relationship to TransformerEngine

This is an Automodel-side fix and is intentionally **independent of any
TE-side fix**: skipping locally-empty shards in the optimizer is exact,
avoids pointless kernel launches for tensors this rank does not own, and
protects every TE version users may run (TE's `multi_tensor_apply` chunking
has no *explicit* empty-tensor guard on `main`; empty tensors are only
skipped as an arithmetic side effect of contributing zero chunks).

The fault is confirmed live on a current TE build and root-caused —
**NVIDIA/TransformerEngine#3202**: `multi_tensor_apply`'s "struct full" flush
is only checked inside the per-chunk loop, so a zero-numel tensor landing in
the last `TensorListMetadata` slot skips the flush and subsequent tensors
write their sizes/addresses out of bounds within the kernel-arg struct. With
enough trailing tensors this crashes (CUDA illegal memory access / misaligned
address — reproduced deterministically in 4-GPU and 128-GPU FSDP2 trainings
and in a single-GPU standalone script); with fewer, the metadata corruption
is **silent** and produces wrong optimizer updates with no error. Whether a
given run crashes, silently corrupts, or works depends only on the
numel-sequence-dependent slot position of the empty shard. That is why this
guard rejects the input at the optimizer boundary rather than relying on TE's
implicit handling: it prevents both failure modes on every TE version, and
dropping the empty local shards is mathematically exact. This PR does not
block on the TE-side fix.

Part of #2985.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

