### PR TITLE
fix(vlm): load Tulu-3 directly from HF Hub instead of local meta JSON

### DIFF
--- a/examples/vlm_finetune/gemma4/gemma4_31b_tulu3_text_cp8_16k.yaml
+++ b/examples/vlm_finetune/gemma4/gemma4_31b_tulu3_text_cp8_16k.yaml
@@ -66,8 +66,9 @@ loss_fn:
   _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
 
 dataset:
-  _target_: nemo_automodel.components.datasets.vlm.datasets.make_meta_dataset
-  path_or_dataset: logs/gemma4_tulu3_seqpack_cp/data/tulu3_train_meta.json
+  # Pull Tulu-3 straight from the HF Hub (no meta-JSON / JSONL data-prep step).
+  _target_: nemo_automodel.components.datasets.vlm.datasets.make_tulu3_dataset
+  path_or_dataset: allenai/tulu-3-sft-mixture
   split: train
   truncate: false
 
@@ -100,9 +101,7 @@ freeze_config:
 
 wandb:
   enable: false
-  project: huiyingl_workspace
-  entity: Nemo-automodel
-  name: gemma4_31b_tulu3_text_cp8_16k
-  group: gemma4_31b_tulu3_text_cp8_16k
-  tags: [gemma4-31b, tulu3, text-only, dense, cp8, 16k, single-node]
-  dir: logs/gemma4_31b_tulu3_text_cp8_16k/wandb
+  project: <your_wandb_project>
+  entity: <your_wandb_entity>
+  name: <your_wandb_name>
+  dir: <your_wandb_save_dir>

--- a/examples/vlm_finetune/gemma4/gemma4_e4b_tulu3_text_cp16_64k.yaml
+++ b/examples/vlm_finetune/gemma4/gemma4_e4b_tulu3_text_cp16_64k.yaml
@@ -89,8 +89,9 @@ loss_fn:
   reduction: sum
 
 dataset:
-  _target_: nemo_automodel.components.datasets.vlm.datasets.make_meta_dataset
-  path_or_dataset: logs/gemma4_tulu3_seqpack_cp/data/tulu3_train_meta.json
+  # Pull Tulu-3 straight from the HF Hub (no meta-JSON / JSONL data-prep step).
+  _target_: nemo_automodel.components.datasets.vlm.datasets.make_tulu3_dataset
+  path_or_dataset: allenai/tulu-3-sft-mixture
   split: train
   truncate: false
   inject_fake_images: false
@@ -123,13 +124,10 @@ freeze_config:
 
 wandb:
   enable: false
-  project: huiyingl_workspace
-  entity: Nemo-automodel
-  name: gemma4_e4b_tulu3_text_cp16_64k_2node
-  group: gemma4_e4b_tulu3_text_cp16_64k
-  tags: [gemma4-e4b, tulu3, text-only, dense, cp16, 64k, 2node]
-  dir: logs/gemma4_e4b_tulu3_text_cp16_64k/wandb
-
+  project: <your_wandb_project>
+  entity: <your_wandb_entity>
+  name: <your_wandb_name>
+  dir: <your_wandb_save_dir>
 ci:
   nodes: 2
   time: "00:15:00"

--- a/examples/vlm_finetune/minimax_m3/minimax_m3_vl_sft_tulu3_text_cp8_16k.yaml
+++ b/examples/vlm_finetune/minimax_m3/minimax_m3_vl_sft_tulu3_text_cp8_16k.yaml
@@ -12,22 +12,13 @@
 # descending loss (the cp-correctness baseline is the MedPix cp1-vs-cp2 parity recipe;
 # cp1 at 16k is impractical -- which is the whole reason for CP).
 #
-# DATA PREP (one-time, no code changes -- the Tulu-3 pipeline is model-agnostic).
-# make_meta_dataset reads JSON/JSONL (not parquet), so dump Tulu-3 conversations to a
-# JSONL whose rows carry a `messages` field, then point a meta JSON at it. The meta JSON
-# already lives at the dataset.path_or_dataset below; only the .jsonl needs generating:
-#   1. Dump Tulu-3 train to JSONL (drop_long_samples + pretokenize below handle >16k
-#      docs, so an explicit prefilter pass is optional):
-#        python -c "from datasets import load_dataset; \
-#          load_dataset('allenai/tulu-3-sft-mixture', split='train') \
-#            .select_columns(['messages']) \
-#            .to_json('logs/m3_tulu3_seqpack/data/tulu3_train.jsonl', lines=True)"
-#   2. (Optional) Validate label-masking/EOS for M3's chat template:
+# DATA (no data-prep step): make_tulu3_dataset pulls allenai/tulu-3-sft-mixture straight
+# from the HF Hub and converts each row's `messages` into the text-only conversation shape.
+# drop_long_samples + pretokenize below handle >16k docs, so no prefilter pass is needed.
+# Requires HF access for Tulu-3 (set HF_TOKEN; do NOT set HF_HUB_OFFLINE).
+#   (Optional) Validate label-masking/EOS for M3's chat template:
 #        python examples/convergence/tulu3/data/validate_data.py \
 #          --dataset allenai/tulu-3-sft-mixture --model MiniMaxAI/MiniMax-M3 --seq_length 16384
-# The meta JSON (logs/m3_tulu3_seqpack/data/tulu3_train_meta.json) points file_name at
-# tulu3_train.jsonl with columns {messages: messages}. Requires HF access for Tulu-3
-# (set HF_TOKEN; do NOT set HF_HUB_OFFLINE for prep).
 
 recipe: FinetuneRecipeForVLM
 seed: 1234
@@ -116,8 +107,9 @@ loss_fn:
   fp32_upcast: false
 
 dataset:
-  _target_: nemo_automodel.components.datasets.vlm.datasets.make_meta_dataset
-  path_or_dataset: logs/m3_tulu3_seqpack/data/tulu3_train_meta.json
+  # Pull Tulu-3 straight from the HF Hub (no meta-JSON / JSONL data-prep step).
+  _target_: nemo_automodel.components.datasets.vlm.datasets.make_tulu3_dataset
+  path_or_dataset: allenai/tulu-3-sft-mixture
   split: train
   truncate: false
 

--- a/nemo_automodel/components/datasets/vlm/datasets.py
+++ b/nemo_automodel/components/datasets/vlm/datasets.py
@@ -328,6 +328,40 @@ def make_tulu3_magicoder_text_mix_dataset(
     return out
 
 
+def make_tulu3_dataset(
+    path_or_dataset: str = "allenai/tulu-3-sft-mixture",
+    split: str = "train",
+    **kwargs,
+):
+    """Load ``allenai/tulu-3-sft-mixture`` directly from the HF Hub as text-only conversations.
+
+    This avoids the meta-JSON + JSONL data-prep step required by
+    :func:`make_meta_dataset`: point the recipe's ``dataset._target_`` at this
+    function and the Tulu-3 split is pulled straight from the Hub. Each row's
+    ``messages`` field is converted with the same helper the meta-JSON path uses
+    (:func:`_convert_sharegpt_to_conversation`), so the resulting data composition is
+    **identical** to dumping the split to JSONL and loading it via
+    :func:`make_meta_dataset`: no turn cap, ``system`` turns dropped, every row kept
+    in the original split order. Conversations are text-only (no ``image`` entries),
+    so batches carry no ``pixel_values`` / vision tensors.
+
+    The returned dataset stays Arrow-backed (``map``) so the full ~939k-row split is
+    not copied into a Python list.
+
+    Args:
+        path_or_dataset: HF Hub id (or local path) of the Tulu-3 SFT mixture.
+        split: HF split expression (e.g. ``"train"`` or ``"train[:50000]"``).
+        **kwargs: Ignored. Accepted so recipe-level dataset keys (e.g. ``truncate``)
+            that are forwarded to the dataset target do not raise.
+
+    Returns:
+        datasets.Dataset: Rows with a single ``conversation`` column, each a list of
+        ``{"role": "user"|"assistant", "content": [{"type": "text", "text": ...}]}`` turns.
+    """
+    dataset = load_dataset(path_or_dataset, split=split)
+    return dataset.map(_convert_sharegpt_to_conversation, remove_columns=dataset.column_names)
+
+
 def make_unimm_chat_dataset(path_or_dataset="Yirany/UniMM-Chat", split="train", **kwargs):
     """Load and preprocess the UniMM-Chat dataset for image-to-text fine-tuning."""
     dataset = load_dataset(path_or_dataset, split=split)

--- a/tests/unit_tests/datasets/vlm/test_datasets.py
+++ b/tests/unit_tests/datasets/vlm/test_datasets.py
@@ -372,6 +372,105 @@ class TestMakeTulu3MagicoderTextMixDataset:
         assert len(result) == 3
 
 
+class TestMakeTulu3Dataset:
+    """End-to-end checks for ``make_tulu3_dataset``.
+
+    The function loads ``allenai/tulu-3-sft-mixture`` directly from the Hub and
+    delegates row conversion to ``_convert_sharegpt_to_conversation`` — the same
+    helper the meta-JSON path uses — so the data composition matches loading a
+    dumped Tulu-3 JSONL through ``make_meta_dataset``: no turn cap, ``system``
+    turns dropped, and every row kept in split order. ``load_dataset`` is mocked
+    with a real HF ``Dataset`` whose rows carry a ``messages`` field (matching the
+    production schema).
+    """
+
+    def _fake_tulu(self, rows):
+        from datasets import Dataset
+
+        return Dataset.from_list(rows)
+
+    def test_happy_path_text_only(self, monkeypatch):
+        rows = [
+            {
+                "messages": [
+                    {"role": "user", "content": "hi"},
+                    {"role": "assistant", "content": "hello"},
+                ]
+            },
+        ]
+        monkeypatch.setattr(ds, "load_dataset", lambda *a, **k: self._fake_tulu(rows))
+
+        result = ds.make_tulu3_dataset()
+
+        assert len(result) == 1
+        sample = result[0]
+        assert list(sample) == ["conversation"]
+        conv = sample["conversation"]
+        assert conv[0] == {"role": "user", "content": [{"type": "text", "text": "hi"}]}
+        assert conv[1] == {"role": "assistant", "content": [{"type": "text", "text": "hello"}]}
+        # No image entries anywhere (text-only training).
+        for turn in conv:
+            for block in turn["content"]:
+                assert block["type"] == "text"
+
+    def test_system_turns_dropped_like_meta_path(self, monkeypatch):
+        """``_convert_sharegpt_to_conversation`` only maps user/assistant, so a
+        ``system`` turn is dropped — matching the old meta-JSON behavior."""
+        rows = [
+            {
+                "messages": [
+                    {"role": "system", "content": "You are helpful."},
+                    {"role": "user", "content": "hi"},
+                    {"role": "assistant", "content": "hello"},
+                ]
+            }
+        ]
+        monkeypatch.setattr(ds, "load_dataset", lambda *a, **k: self._fake_tulu(rows))
+        result = ds.make_tulu3_dataset()
+        assert len(result) == 1
+        roles = [t["role"] for t in result[0]["conversation"]]
+        assert roles == ["user", "assistant"]
+
+    def test_no_turn_cap_long_conversation_kept(self, monkeypatch):
+        """Unlike the tulu-magicoder mix builder, there is no ``max_turns`` cap:
+        long multi-turn conversations are retained in full."""
+        long_msgs = [
+            {"role": "user", "content": f"u{i}"} if i % 2 == 0 else {"role": "assistant", "content": f"a{i}"}
+            for i in range(40)
+        ]
+        rows = [{"messages": long_msgs}]
+        monkeypatch.setattr(ds, "load_dataset", lambda *a, **k: self._fake_tulu(rows))
+        result = ds.make_tulu3_dataset()
+        assert len(result) == 1
+        assert len(result[0]["conversation"]) == 40
+
+    def test_every_row_kept_in_order(self, monkeypatch):
+        """No rows are filtered out; order matches the source split."""
+        rows = [
+            {"messages": [{"role": "user", "content": f"u{i}"}, {"role": "assistant", "content": f"a{i}"}]}
+            for i in range(5)
+        ]
+        monkeypatch.setattr(ds, "load_dataset", lambda *a, **k: self._fake_tulu(rows))
+        result = ds.make_tulu3_dataset()
+        assert len(result) == 5
+        texts = [r["conversation"][0]["content"][0]["text"] for r in result]
+        assert texts == ["u0", "u1", "u2", "u3", "u4"]
+
+    def test_extra_kwargs_ignored(self, monkeypatch):
+        """Recipe-forwarded keys like ``truncate`` are absorbed, not passed to load_dataset."""
+        rows = [{"messages": [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello"}]}]
+
+        def _fake_load_dataset(path_or_dataset, split="train"):
+            # Signature intentionally does NOT accept **kwargs: if make_tulu3_dataset
+            # forwarded truncate/split here, this would raise TypeError.
+            assert path_or_dataset == "allenai/tulu-3-sft-mixture"
+            return self._fake_tulu(rows)
+
+        monkeypatch.setattr(ds, "load_dataset", _fake_load_dataset)
+        result = ds.make_tulu3_dataset(truncate=False, split="train")
+        assert len(result) == 1
+
+
 def test_make_unimm_chat_dataset(monkeypatch):
     """End-to-end sanity check for `make_unimm_chat_dataset`."""
     fake_ds = [


### PR DESCRIPTION
## Summary

The Tulu-3 VLM SFT recipes loaded data through `make_meta_dataset`, pointed at a **local** `tulu3_train_meta.json` (→ `tulu3_train.jsonl`) that only exists after a one-time data-prep dump. That file is absent in Nemo-CI, so the runs died with `FileNotFoundError`.

This PR adds `make_tulu3_dataset`, which pulls `allenai/tulu-3-sft-mixture` straight from the HF Hub — no meta-JSON / JSONL prep step. It delegates per-row conversion to the **same** helper the meta-JSON path used (`_convert_sharegpt_to_conversation`), so the resulting data composition is identical to dumping the split to JSONL and loading it via `make_meta_dataset`: no turn cap, `system` turns dropped, every row kept in split order, text-only conversations. The dataset stays Arrow-backed (`.map`) so the full split isn't copied into a Python list.

Fixes [AM-628](https://linear.app/nvidia/issue/AM-628/missing-tulu3-train-metajson-file-leads-to-filenotfounderror).

## Affects

* `examples/vlm_finetune/gemma4/gemma4_31b_tulu3_text_cp8_16k.yaml`
* `examples/vlm_finetune/gemma4/gemma4_e4b_tulu3_text_cp16_64k.yaml`
* `examples/vlm_finetune/minimax_m3/minimax_m3_vl_sft_tulu3_text_cp8_16k.yaml`

All three now set `dataset._target_: ...make_tulu3_dataset` with `path_or_dataset: allenai/tulu-3-sft-mixture`.

## Validation

* Added `TestMakeTulu3Dataset` unit tests (happy path, `system`-dropped parity with the meta path, no turn cap, all-rows-kept-in-order, extra-kwargs ignored).
* MiniMax M3: before (local meta JSON, dotted green) vs after (`make_tulu3_dataset`, solid green) loss curves overlay closely, confirming identical composition.

<img width="1010" height="638" alt="Screenshot 2026-07-09 at 10 49 43 PM" src="https://github.com/user-attachments/assets/f407ca88-bb52-4042-a87b-57630c3fed5b" />

* Gemma4 31b (local meta JSON and make_tulu3_dataset matching very closely):

<img width="451" height="303" alt="Screenshot 2026-07-10 at 8 30 39 AM" src="https://github.com/user-attachments/assets/ea187ab0-2734-4922-889b-3ec1f0342ffc" />


* Gemma4 e4b (local meta JSON and make_tulu3_dataset matching very closely):

<img width="432" height="283" alt="Screenshot 2026-07-10 at 8 31 47 AM" src="https://github.com/user-attachments/assets/df5a9124-1278-4561-940a-b7bbaf11973a" />


* `ruff format` / `ruff check` clean.

## Test plan

- [X] Validated all  the three recipes run without `FileNotFoundError`
- [X] `pytest tests/unit_tests/datasets/vlm/test_datasets.py -k TestMakeTulu3Dataset`