### PR TITLE
feat(speculative): support sequence packing in the DeepSeek MLA EAGLE-3 draft

### DIFF
--- a/nemo_automodel/components/datasets/llm/packed_sequence.py
+++ b/nemo_automodel/components/datasets/llm/packed_sequence.py
@@ -399,7 +399,25 @@ def build_block_causal_additive_mask(
     positions are ``finfo(dtype).min``. ``seq_lens`` is the ``[B, max_docs]``
     0-padded per-document length tensor; each row's non-zero entries sum to
     ``seq_length`` (trailing pad folded into the final document).
+
+    Raises ``ValueError`` if ``seq_lens`` is not 2D or any row does not sum to
+    ``seq_length`` -- a malformed row would otherwise silently misbucket the
+    boundary ``cumsum`` (e.g. isolating the final token into a phantom document)
+    and train the draft on wrong-context supervision with no error. This mirrors
+    the fail-loud sum check the FlashAttention varlen path already performs in
+    ``_seq_lens_to_cu_seqlens``.
     """
+    if seq_lens.dim() != 2:
+        raise ValueError(
+            f"build_block_causal_additive_mask expects a 2D [B, max_docs] seq_lens tensor, "
+            f"got shape {tuple(seq_lens.shape)}."
+        )
+    row_sums = seq_lens.sum(dim=1)
+    if not bool(torch.all(row_sums == seq_length)):
+        raise ValueError(
+            f"Packed seq_lens rows must each sum to seq_length={seq_length} (trailing pad folded "
+            f"into the last document), got row sums {row_sums.tolist()}."
+        )
     min_value = torch.finfo(dtype).min
     seq_lens = seq_lens.to(device)
     positions = torch.arange(seq_length, device=device)

--- a/nemo_automodel/components/speculative/eagle/draft_deepseek.py
+++ b/nemo_automodel/components/speculative/eagle/draft_deepseek.py
@@ -430,6 +430,14 @@ class DeepseekV3Eagle3DraftModel(PreTrainedModel):
                 diagonal block is position-wise and stays document-safe; cross-document
                 supervision is masked by the trainer's ``doc_remaining`` gate, not here.
         """
+        if seq_lens is not None and position_ids is None:
+            # Packing needs per-document position_ids: the arange fallback below
+            # would give every document after the first a global (wrong) RoPE
+            # phase. Fail loud, matching the target-side guard in target.py.
+            raise ValueError(
+                "DeepseekV3Eagle3DraftModel: sequence packing (seq_lens) requires per-document "
+                "position_ids (reset to range(doc_len) within each document), but none were provided."
+            )
         if position_ids is None:
             position_ids = torch.arange(input_ids.shape[1], device=input_ids.device, dtype=torch.long).unsqueeze(0)
             position_ids = position_ids.expand(input_ids.shape[0], -1)

--- a/nemo_automodel/components/speculative/eagle/draft_deepseek.py
+++ b/nemo_automodel/components/speculative/eagle/draft_deepseek.py
@@ -34,9 +34,11 @@ projection layout and the interleaved RoPE are taken from the onboarded DeepSeek
 target (``components/models/deepseek_v3``: the ``MLA`` projection structure and
 ``rope_utils``), not reimplemented.
 
-Scope (v1): EAGLE-3 single fused draft layer, eager attention. P-EAGLE
-parallel-drafting, flash-attention, and sequence packing are intentionally left
-to follow-ups (they are orthogonal to the MLA attention this file adds).
+Scope: EAGLE-3 single fused draft layer, eager attention. Sequence packing is
+supported via the shared ``[B, 1, T, T]`` block-causal mask (see
+``forward``); the MLA attention is eager-only, so packing reuses the eager mask
+path rather than a FlashAttention varlen kernel. P-EAGLE parallel-drafting and
+flash-attention remain follow-ups (orthogonal to the MLA attention this file adds).
 """
 
 from __future__ import annotations
@@ -47,6 +49,7 @@ import torch
 import torch.nn as nn
 from transformers import PretrainedConfig, PreTrainedModel
 
+from nemo_automodel.components.datasets.llm.packed_sequence import build_block_causal_additive_mask
 from nemo_automodel.components.models.common import initialize_rms_norm_module
 from nemo_automodel.components.models.deepseek_v3.rope_utils import (
     apply_rotary_emb,
@@ -410,18 +413,45 @@ class DeepseekV3Eagle3DraftModel(PreTrainedModel):
         cache_hidden: Optional[list[list[torch.Tensor]]] = None,
         seq_lens: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        """Run one EAGLE-3 TTT draft step (eager attention; ``seq_lens`` packing not supported in v1)."""
-        if seq_lens is not None:
-            raise NotImplementedError(
-                "DeepseekV3Eagle3DraftModel does not support sequence packing (seq_lens) yet; use the unpacked path."
-            )
+        """Run one EAGLE-3 TTT draft step (eager attention).
+
+        Tensor contracts (batch ``B``, sequence length ``T``):
+
+        - ``input_ids`` ``[B, T]`` long; ``projected_hidden_states`` ``[B, T, H]``
+          (draft hidden size); ``attention_mask`` ``[B, T]`` (1 = real, 0 = pad);
+          ``position_ids`` ``[B, T]`` long or ``None`` (defaults to ``arange``).
+        - ``cache_hidden`` is the EAGLE-3 TTT cache ``[K_list, V_list]``: pass
+          ``[[], []]`` on the first step and the same list on each later step;
+          the attention layer appends per-step K/V. ``None`` allocates a fresh
+          cache (step 0 == a plain causal forward).
+        - ``seq_lens`` ``[B, max_docs]`` long (0-padded per-document lengths that
+          sum to ``T`` per row) turns on sequence packing: Block-1 attention
+          becomes document-level block-causal via
+          :func:`build_block_causal_additive_mask`. The MLA attention is
+          eager-only, so packing takes the eager mask path (no FA2 varlen).
+          Callers must pass per-document ``position_ids`` (reset to
+          ``range(doc_len)`` within each document) so the rotary phase matches the
+          target; the TTT diagonal block is position-wise and stays document-safe.
+          Cross-document TTT supervision is masked by the trainer's
+          ``doc_remaining`` gate, not here.
+        """
         if position_ids is None:
             position_ids = torch.arange(input_ids.shape[1], device=input_ids.device, dtype=torch.long).unsqueeze(0)
             position_ids = position_ids.expand(input_ids.shape[0], -1)
         if cache_hidden is None:
             cache_hidden = [[], []]
 
-        causal_mask = _build_causal_mask(attention_mask=attention_mask, dtype=projected_hidden_states.dtype)
+        if seq_lens is not None:
+            # Packed: document structure comes from seq_lens (block-causal mask),
+            # so the plain causal + padding mask does not apply.
+            causal_mask = build_block_causal_additive_mask(
+                seq_lens,
+                seq_length=input_ids.shape[1],
+                dtype=projected_hidden_states.dtype,
+                device=input_ids.device,
+            )
+        else:
+            causal_mask = _build_causal_mask(attention_mask=attention_mask, dtype=projected_hidden_states.dtype)
         draft_input_embeds = self.embed_input_ids(input_ids)
         hidden_states = self.model.layers[0](
             input_embeds=draft_input_embeds,

--- a/nemo_automodel/components/speculative/eagle/draft_deepseek.py
+++ b/nemo_automodel/components/speculative/eagle/draft_deepseek.py
@@ -415,25 +415,20 @@ class DeepseekV3Eagle3DraftModel(PreTrainedModel):
     ) -> torch.Tensor:
         """Run one EAGLE-3 TTT draft step (eager attention).
 
-        Tensor contracts (batch ``B``, sequence length ``T``):
-
-        - ``input_ids`` ``[B, T]`` long; ``projected_hidden_states`` ``[B, T, H]``
-          (draft hidden size); ``attention_mask`` ``[B, T]`` (1 = real, 0 = pad);
-          ``position_ids`` ``[B, T]`` long or ``None`` (defaults to ``arange``).
-        - ``cache_hidden`` is the EAGLE-3 TTT cache ``[K_list, V_list]``: pass
-          ``[[], []]`` on the first step and the same list on each later step;
-          the attention layer appends per-step K/V. ``None`` allocates a fresh
-          cache (step 0 == a plain causal forward).
-        - ``seq_lens`` ``[B, max_docs]`` long (0-padded per-document lengths that
-          sum to ``T`` per row) turns on sequence packing: Block-1 attention
-          becomes document-level block-causal via
-          :func:`build_block_causal_additive_mask`. The MLA attention is
-          eager-only, so packing takes the eager mask path (no FA2 varlen).
-          Callers must pass per-document ``position_ids`` (reset to
-          ``range(doc_len)`` within each document) so the rotary phase matches the
-          target; the TTT diagonal block is position-wise and stays document-safe.
-          Cross-document TTT supervision is masked by the trainer's
-          ``doc_remaining`` gate, not here.
+        Args (batch ``B``, sequence length ``T``, draft hidden size ``H``):
+            input_ids: ``[B, T]`` long token ids.
+            projected_hidden_states: ``[B, T, H]`` draft-hidden features (``fc`` output).
+            attention_mask: ``[B, T]`` (1 = real, 0 = pad); used on the unpacked path only.
+            position_ids: ``[B, T]`` long, or ``None`` to default to ``arange``.
+                Packing requires per-document positions (reset to ``range(doc_len)``).
+            cache_hidden: EAGLE-3 TTT cache ``[K_list, V_list]`` -- ``[[], []]`` on the
+                first step, the same list on later steps, or ``None`` for a fresh cache.
+            seq_lens: ``[B, max_docs]`` long (0-padded per-document lengths that sum to
+                ``T`` per row) turns on sequence packing -- Block-1 attention becomes
+                document-level block-causal via :func:`build_block_causal_additive_mask`
+                (eager mask path; the MLA attention has no FA2 varlen kernel). The TTT
+                diagonal block is position-wise and stays document-safe; cross-document
+                supervision is masked by the trainer's ``doc_remaining`` gate, not here.
         """
         if position_ids is None:
             position_ids = torch.arange(input_ids.shape[1], device=input_ids.device, dtype=torch.long).unsqueeze(0)
@@ -442,8 +437,7 @@ class DeepseekV3Eagle3DraftModel(PreTrainedModel):
             cache_hidden = [[], []]
 
         if seq_lens is not None:
-            # Packed: document structure comes from seq_lens (block-causal mask),
-            # so the plain causal + padding mask does not apply.
+            # Packed: document structure comes from seq_lens (block-causal mask).
             causal_mask = build_block_causal_additive_mask(
                 seq_lens,
                 seq_length=input_ids.shape[1],

--- a/tests/unit_tests/speculative/test_deepseek_eagle3_draft.py
+++ b/tests/unit_tests/speculative/test_deepseek_eagle3_draft.py
@@ -247,6 +247,98 @@ def test_trainer_integration_trains_on_cpu():
     assert grads and all(torch.isfinite(g).all() for g in grads)
 
 
+def test_packing_matches_padding_loss_and_grads():
+    """Golden parity: packing N docs into one row == N padded single-doc rows.
+
+    Target-free draft-level check: identical per-document aux hidden states and
+    target logits are fed in two layouts through the shared Eagle3TrainerModule --
+      * padding: ``[D, T]`` with each doc's ``L`` real tokens padded to ``T``
+        (per-row causal + padding mask, ``loss_mask``-shift TTT gating);
+      * packing: the same docs as ``[1, T]`` (``D * L == T``) with per-document
+        position_ids, the MLA block-causal mask, and ``doc_remaining`` gating.
+    Both supervise the identical (doc, position, TTT step) triples against
+    identical targets, so loss and every gradient match (CPU/fp32, tight tol).
+    """
+    num_docs, doc_len = 3, 8
+    total = num_docs * doc_len  # packed row width T
+    config = _build_config()
+    config.draft_vocab_size = _VOCAB  # full vocab so every position is supervised
+    config.max_position_embeddings = total
+
+    def build_trainer():
+        torch.manual_seed(123)  # identical draft init for both layouts
+        draft = DeepseekV3Eagle3DraftModel(config).to(torch.float32)
+        selected_token_ids = torch.arange(_VOCAB, dtype=torch.long)
+        selected_token_mask = torch.ones(_VOCAB, dtype=torch.bool)
+        return Eagle3TrainerModule(
+            draft,
+            selected_token_ids=selected_token_ids,
+            selected_token_mask=selected_token_mask,
+            ttt_steps=3,
+        )
+
+    torch.manual_seed(7)
+    doc_ids = [torch.randint(0, _VOCAB, (doc_len,)) for _ in range(num_docs)]
+    doc_aux = [torch.randn(doc_len, _HIDDEN * 3) for _ in range(num_docs)]
+    doc_logits = [torch.randn(doc_len, _VOCAB) for _ in range(num_docs)]
+
+    # Layout A: D padded single-document rows.
+    ids_a = torch.zeros(num_docs, total, dtype=torch.long)
+    aux_a = torch.zeros(num_docs, total, _HIDDEN * 3)
+    logits_a = torch.zeros(num_docs, total, _VOCAB)
+    loss_a = torch.zeros(num_docs, total, dtype=torch.long)
+    attn_a = torch.zeros(num_docs, total, dtype=torch.long)
+    for d in range(num_docs):
+        ids_a[d, :doc_len] = doc_ids[d]
+        aux_a[d, :doc_len] = doc_aux[d]
+        logits_a[d, :doc_len] = doc_logits[d]
+        # Supervise every real token except the doc's last one, which has no
+        # in-document next-token label. In the packed layout that same boundary
+        # is enforced by ``doc_remaining`` (== 0 at each doc's last slot), so this
+        # keeps both layouts on the identical supervised (doc, slot, step) triples.
+        loss_a[d, : doc_len - 1] = 1
+        attn_a[d, :doc_len] = 1
+    trainer_a = build_trainer()
+    metrics_a = trainer_a(
+        input_ids=ids_a,
+        attention_mask=attn_a,
+        loss_mask=loss_a,
+        aux_hidden_states=aux_a,
+        target_logits=logits_a,
+    )
+    metrics_a.loss.backward()
+    grads_a = {n: p.grad.clone() for n, p in trainer_a.named_parameters() if p.grad is not None}
+
+    # Layout B: the same documents packed into one row (no padding).
+    ids_b = torch.cat(doc_ids).unsqueeze(0)
+    aux_b = torch.cat(doc_aux).unsqueeze(0)
+    logits_b = torch.cat(doc_logits).unsqueeze(0)
+    loss_b = torch.ones(1, total, dtype=torch.long)
+    attn_b = torch.ones(1, total, dtype=torch.long)
+    position_ids = torch.cat([torch.arange(doc_len) for _ in range(num_docs)]).unsqueeze(0)
+    doc_remaining = torch.cat([torch.arange(doc_len - 1, -1, -1) for _ in range(num_docs)]).unsqueeze(0)
+    seq_lens = torch.tensor([[doc_len] * num_docs], dtype=torch.long)
+    trainer_b = build_trainer()
+    metrics_b = trainer_b(
+        input_ids=ids_b,
+        attention_mask=attn_b,
+        loss_mask=loss_b,
+        aux_hidden_states=aux_b,
+        target_logits=logits_b,
+        position_ids=position_ids,
+        seq_lens=seq_lens,
+        doc_remaining=doc_remaining,
+    )
+    metrics_b.loss.backward()
+    grads_b = {n: p.grad.clone() for n, p in trainer_b.named_parameters() if p.grad is not None}
+
+    assert metrics_a.valid_tokens.item() == metrics_b.valid_tokens.item()
+    torch.testing.assert_close(metrics_a.loss, metrics_b.loss, rtol=1e-4, atol=1e-5)
+    assert set(grads_a) == set(grads_b)
+    for name in grads_a:
+        torch.testing.assert_close(grads_a[name], grads_b[name], rtol=1e-4, atol=1e-5, msg=f"grad mismatch: {name}")
+
+
 def test_rope_freqs_stays_fp32_after_bf16_cast():
     """``draft.to(bf16)`` must not round the MLA RoPE frequencies.
 

--- a/tests/unit_tests/speculative/test_deepseek_eagle3_draft.py
+++ b/tests/unit_tests/speculative/test_deepseek_eagle3_draft.py
@@ -103,12 +103,100 @@ def test_ttt_cache_recurrence_grows_and_runs_diagonal_path():
     assert torch.isfinite(out1).all()
 
 
-def test_packing_not_supported_yet():
+def test_packed_single_doc_matches_unpacked_forward():
+    """A packed row that is one full-width document must match the plain causal forward.
+
+    ``seq_lens=[[T]]`` with ``position_ids=arange`` builds a block-causal mask that is
+    exactly the lower-triangular causal mask, so the packed path must be bit-identical
+    to the unpacked path (which also uses ``arange`` positions and an all-ones mask).
+    """
     draft = _build_draft().eval()
-    ids = torch.randint(0, _VOCAB, (1, 4))
-    proj = draft.project_hidden_states(torch.randn(1, 4, _HIDDEN * 3))
-    with pytest.raises(NotImplementedError, match="sequence packing"):
-        draft(ids, proj, torch.ones(1, 4, dtype=torch.long), seq_lens=torch.tensor([4]))
+    batch, seq = 1, 6
+    input_ids = torch.randint(0, _VOCAB, (batch, seq))
+    proj = draft.project_hidden_states(torch.randn(batch, seq, _HIDDEN * 3))
+    attn = torch.ones(batch, seq, dtype=torch.long)
+    position_ids = torch.arange(seq, dtype=torch.long).unsqueeze(0)
+
+    out_unpacked = draft(input_ids, proj, attn, position_ids=position_ids, cache_hidden=[[], []])
+    out_packed = draft(
+        input_ids,
+        proj,
+        attn,
+        position_ids=position_ids,
+        cache_hidden=[[], []],
+        seq_lens=torch.tensor([[seq]], dtype=torch.long),
+    )
+    torch.testing.assert_close(out_packed, out_unpacked)
+
+
+def test_packed_draft_attention_isolates_documents():
+    """Block-causal packing must isolate documents: perturbing only doc B's inputs
+    leaves doc A's output bit-identical (cross-document attention is masked)."""
+    torch.manual_seed(0)
+    draft = _build_draft().eval()
+    seq_len = 6
+    seq_lens = torch.tensor([[3, 3]], dtype=torch.long)  # doc A: slots 0..2, doc B: slots 3..5
+    position_ids = torch.tensor([[0, 1, 2, 0, 1, 2]], dtype=torch.long)  # reset per document
+    input_ids = torch.randint(0, _VOCAB, (1, seq_len))
+    projected = draft.project_hidden_states(torch.randn(1, seq_len, _HIDDEN * 3))
+
+    def run(ids, proj):
+        return draft(
+            input_ids=ids,
+            projected_hidden_states=proj,
+            attention_mask=torch.ones(1, seq_len, dtype=torch.long),
+            position_ids=position_ids,
+            cache_hidden=[[], []],
+            seq_lens=seq_lens,
+        )
+
+    out_ref = run(input_ids, projected)
+    # Perturb only document B (slots 3..5).
+    ids_b = input_ids.clone()
+    ids_b[:, 3:] = torch.randint(0, _VOCAB, (1, 3))
+    proj_b = projected.clone()
+    proj_b[:, 3:] = torch.randn(1, 3, _HIDDEN)
+    out_perturbed = run(ids_b, proj_b)
+
+    torch.testing.assert_close(out_ref[:, :3], out_perturbed[:, :3])  # doc A unchanged
+    assert not torch.allclose(out_ref[:, 3:], out_perturbed[:, 3:])  # doc B changed
+
+
+def test_trainer_integration_packed_trains_on_cpu():
+    """The MLA draft trains end to end through the shared trainer with packing metadata
+    (per-document position_ids, block-causal seq_lens, and doc_remaining supervision gate)."""
+    draft = _build_draft()
+    selected_token_ids = torch.arange(_DRAFT_VOCAB, dtype=torch.long)
+    selected_token_mask = torch.zeros(_VOCAB, dtype=torch.bool)
+    selected_token_mask[selected_token_ids] = True
+    module = Eagle3TrainerModule(
+        draft,
+        selected_token_ids=selected_token_ids,
+        selected_token_mask=selected_token_mask,
+        ttt_steps=2,
+    )
+
+    # One packed row: two docs of length 3 over T=6.
+    doc_len, num_docs = 3, 2
+    seq = doc_len * num_docs
+    position_ids = torch.cat([torch.arange(doc_len) for _ in range(num_docs)]).unsqueeze(0)
+    seq_lens = torch.tensor([[doc_len] * num_docs], dtype=torch.long)
+    doc_remaining = torch.cat([torch.arange(doc_len - 1, -1, -1) for _ in range(num_docs)]).unsqueeze(0)
+
+    out = module(
+        input_ids=torch.randint(0, _VOCAB, (1, seq)),
+        attention_mask=torch.ones(1, seq, dtype=torch.long),
+        loss_mask=torch.ones(1, seq, dtype=torch.long),
+        aux_hidden_states=torch.randn(1, seq, _HIDDEN * 3),
+        target_logits=torch.randn(1, seq, _VOCAB),
+        position_ids=position_ids,
+        seq_lens=seq_lens,
+        doc_remaining=doc_remaining,
+    )
+    assert torch.isfinite(out.loss)
+    out.loss.backward()
+    grads = [p.grad for p in draft.parameters() if p.grad is not None]
+    assert grads and all(torch.isfinite(g).all() for g in grads)
 
 
 def test_set_vocab_mapping_builds_d2t_t2d():

--- a/tests/unit_tests/speculative/test_deepseek_eagle3_draft.py
+++ b/tests/unit_tests/speculative/test_deepseek_eagle3_draft.py
@@ -162,6 +162,31 @@ def test_packed_draft_attention_isolates_documents():
     assert not torch.allclose(out_ref[:, 3:], out_perturbed[:, 3:])  # doc B changed
 
 
+def test_packing_requires_position_ids():
+    """Packing without per-document position_ids must fail loud, not silently use arange."""
+    draft = _build_draft().eval()
+    ids = torch.randint(0, _VOCAB, (1, 6))
+    proj = draft.project_hidden_states(torch.randn(1, 6, _HIDDEN * 3))
+    with pytest.raises(ValueError, match="per-document position_ids"):
+        draft(ids, proj, torch.ones(1, 6, dtype=torch.long), seq_lens=torch.tensor([[3, 3]], dtype=torch.long))
+
+
+def test_packing_rejects_seq_lens_not_summing_to_t():
+    """A seq_lens row that does not sum to T must raise, not silently misbucket documents."""
+    draft = _build_draft().eval()
+    ids = torch.randint(0, _VOCAB, (1, 6))
+    proj = draft.project_hidden_states(torch.randn(1, 6, _HIDDEN * 3))
+    position_ids = torch.tensor([[0, 1, 2, 0, 1, 2]], dtype=torch.long)
+    with pytest.raises(ValueError, match="sum to seq_length"):
+        draft(
+            ids,
+            proj,
+            torch.ones(1, 6, dtype=torch.long),
+            position_ids=position_ids,
+            seq_lens=torch.tensor([[3, 2]], dtype=torch.long),  # sums to 5, not 6
+        )
+
+
 def test_set_vocab_mapping_builds_d2t_t2d():
     draft = _build_draft()
     selected = torch.arange(_DRAFT_VOCAB) * 2  # draft id i -> target id 2i

--- a/tests/unit_tests/speculative/test_deepseek_eagle3_draft.py
+++ b/tests/unit_tests/speculative/test_deepseek_eagle3_draft.py
@@ -162,43 +162,6 @@ def test_packed_draft_attention_isolates_documents():
     assert not torch.allclose(out_ref[:, 3:], out_perturbed[:, 3:])  # doc B changed
 
 
-def test_trainer_integration_packed_trains_on_cpu():
-    """The MLA draft trains end to end through the shared trainer with packing metadata
-    (per-document position_ids, block-causal seq_lens, and doc_remaining supervision gate)."""
-    draft = _build_draft()
-    selected_token_ids = torch.arange(_DRAFT_VOCAB, dtype=torch.long)
-    selected_token_mask = torch.zeros(_VOCAB, dtype=torch.bool)
-    selected_token_mask[selected_token_ids] = True
-    module = Eagle3TrainerModule(
-        draft,
-        selected_token_ids=selected_token_ids,
-        selected_token_mask=selected_token_mask,
-        ttt_steps=2,
-    )
-
-    # One packed row: two docs of length 3 over T=6.
-    doc_len, num_docs = 3, 2
-    seq = doc_len * num_docs
-    position_ids = torch.cat([torch.arange(doc_len) for _ in range(num_docs)]).unsqueeze(0)
-    seq_lens = torch.tensor([[doc_len] * num_docs], dtype=torch.long)
-    doc_remaining = torch.cat([torch.arange(doc_len - 1, -1, -1) for _ in range(num_docs)]).unsqueeze(0)
-
-    out = module(
-        input_ids=torch.randint(0, _VOCAB, (1, seq)),
-        attention_mask=torch.ones(1, seq, dtype=torch.long),
-        loss_mask=torch.ones(1, seq, dtype=torch.long),
-        aux_hidden_states=torch.randn(1, seq, _HIDDEN * 3),
-        target_logits=torch.randn(1, seq, _VOCAB),
-        position_ids=position_ids,
-        seq_lens=seq_lens,
-        doc_remaining=doc_remaining,
-    )
-    assert torch.isfinite(out.loss)
-    out.loss.backward()
-    grads = [p.grad for p in draft.parameters() if p.grad is not None]
-    assert grads and all(torch.isfinite(g).all() for g in grads)
-
-
 def test_set_vocab_mapping_builds_d2t_t2d():
     draft = _build_draft()
     selected = torch.arange(_DRAFT_VOCAB) * 2  # draft id i -> target id 2i

--- a/tests/unit_tests/speculative/test_eagle3_packing.py
+++ b/tests/unit_tests/speculative/test_eagle3_packing.py
@@ -103,6 +103,19 @@ def test_block_causal_additive_mask():
     assert m[2, 3] == neg  # doc A query cannot see doc B
 
 
+def test_block_causal_additive_mask_rejects_malformed_seq_lens():
+    """Fail loud (not silently misbucket) on non-2D seq_lens or a row that does not sum to T."""
+    cpu = torch.device("cpu")
+    with pytest.raises(ValueError, match="2D"):
+        build_block_causal_additive_mask(
+            torch.tensor([3, 2], dtype=torch.long), seq_length=5, dtype=torch.float32, device=cpu
+        )
+    with pytest.raises(ValueError, match="sum to seq_length"):
+        build_block_causal_additive_mask(
+            torch.tensor([[3, 1]], dtype=torch.long), seq_length=5, dtype=torch.float32, device=cpu
+        )
+
+
 def test_seq_lens_to_cu_seqlens():
     """cu_seqlens is int32, monotonic, row-major, and sums to B*T; max_seqlen is the longest doc."""
     seq_lens = torch.tensor([[3, 2], [4, 1]], dtype=torch.long)  # B=2, T=5


### PR DESCRIPTION
## What

The DeepSeek MLA EAGLE-3 draft (`DeepseekV3Eagle3DraftModel`) shares the EAGLE-3 trainer (`Eagle3TrainerModule`), which already threads `position_ids` / `seq_lens` / `doc_remaining` for sequence packing, but the draft's `forward` rejected `seq_lens` with `NotImplementedError`. This wires packing through the eager MLA path exactly like the sibling dense Llama draft (`LlamaEagle3DraftModel`).

When `seq_lens` is present, the draft builds the shared `[B, 1, T, T]` block-causal additive mask (`build_block_causal_additive_mask`) instead of the plain causal + padding mask, so Block-1 attention is document-level block-causal. The TTT diagonal block is position-wise and stays document-safe; cross-document supervision is masked by the trainer's `doc_remaining` gate (unchanged). The MLA attention is eager-only, so packing reuses the eager mask path (no FlashAttention varlen kernel). The trainer, recipe, and target wrapper are untouched: enabling packing for a DeepSeek target now works end to end (colocated backend, `cp_size=1`).

## Robustness

Packing inputs now fail loud instead of silently corrupting supervision:

- `build_block_causal_additive_mask` validates that `seq_lens` is 2D and each row sums to `seq_length`, mirroring the check the FlashAttention varlen path already performs in `_seq_lens_to_cu_seqlens`. A row that does not sum to `T` would otherwise misbucket the boundary `cumsum` (isolating the final token into a phantom document). This guard covers every eager packing caller: the MLA draft, the dense Llama draft, and the target wrapper.
- `DeepseekV3Eagle3DraftModel.forward` raises when `seq_lens` is passed without per-document `position_ids` (the global `arange` fallback would give every document after the first a wrong RoPE phase), matching the target-side guard.

## Correctness verification

CPU unit tests (27 pass across the two touched test files), including:

- **Golden parity**: packing N documents into one row produces the same loss and every gradient (tight fp32 tolerance) as N padded single-document rows.
- **Document isolation**: perturbing only document B's inputs leaves document A's draft output bit-identical.
- **Single-doc equivalence**: a full-width single-document packed row matches the plain causal forward.
- **Fail-loud guards**: non-2D / non-summing `seq_lens` and missing `position_ids` raise.

GPU smoke (1x A100-80GB, bf16) with a tiny HF DeepSeek-V3 target wrapped in the real `HFEagle3TargetModel`, draft config derived from the target config exactly as the recipe does: the packed and unpacked paths both train (finite, decreasing loss), and the target's aux hidden states are document-isolated under packing (perturbing document B leaves document A's target aux states bit-identical), confirming the DeepSeek target honors the block-causal mask.

<details>
<summary>GPU smoke log</summary>

```
=== UNPACKED baseline ===
[unpacked] step 0 loss 4.8782 valid 111 acc 0.000
[unpacked] step 1 loss 4.8733 valid 134 acc 0.007
[unpacked] step 2 loss 4.8649 valid 106 acc 0.066
[unpacked] step 3 loss 4.8657 valid 214 acc 0.149
[unpacked] step 4 loss 4.8619 valid 168 acc 0.053
[unpacked] step 5 loss 4.8694 valid 172 acc 0.000
[unpacked] OK: 4.878 -> 4.869
=== PACKED (seq_lens/position_ids/doc_remaining) ===
[packed] step 0 loss 4.8625 valid 71 acc 0.028
[packed] step 1 loss 4.8580 valid 45 acc 0.089
[packed] step 2 loss 4.8699 valid 59 acc 0.000
[packed] step 3 loss 4.8614 valid 36 acc 0.000
[packed] step 4 loss 4.8493 valid 54 acc 0.000
[packed] step 5 loss 4.8562 valid 101 acc 0.000
[packed] OK: 4.862 -> 4.856
=== TARGET-SIDE document isolation ===
[target-isolation] max|dDocA|=0.00e+00  max|dDocB|=0.276
[target-isolation] OK: target honors the [B,1,T,T] block-causal mask (no cross-doc leak)
ALL SMOKE PASSED
```

</details>

## Scope

DeepSeek MLA draft only, per the incremental plan. Extending packing to DFlash / DSpark / EAGLE-1/2 and resolving packing with context parallelism are separate follow-ups (each draft builds attention differently).
