### PR TITLE
feat(speculative): support sequence packing in the EAGLE-1/2 draft

### DIFF
--- a/nemo_automodel/components/speculative/eagle/core_v12.py
+++ b/nemo_automodel/components/speculative/eagle/core_v12.py
@@ -94,18 +94,14 @@ class EagleTrainerModule(nn.Module):
     ) -> EagleStepMetrics:
         """Run one EAGLE-1 / EAGLE-2 training step.
 
-        All per-token tensors are ``[B, T]`` (``input_ids`` / ``loss_mask`` /
-        ``attention_mask`` / ``position_ids`` / ``doc_remaining``) except the
-        ``[B, T, H]`` hidden states and ``[B, T, V]`` ``target_logits``.
-
-        Packing (``seq_lens`` ``[B, max_docs]`` long, per-document lengths summing
-        to ``T``) makes the draft's attention document-level block-causal and its
-        RoPE per-document via ``position_ids``. ``doc_remaining`` ``[B, T]`` (real
-        tokens after each slot within its document) gates supervision: a
-        document's last real token (``doc_remaining == 0``) predicts the *next*
-        document's first token through the wrapper's global left-shift, so it is
-        dropped. This is the single-step reduction of the EAGLE-3 TTT gate
-        (``step_idx < doc_remaining`` at ``step_idx == 0``).
+        Per-token tensors are ``[B, T]`` (``position_ids`` / ``doc_remaining``
+        included) except the ``[B, T, H]`` hidden states and ``[B, T, V]``
+        ``target_logits``; ``seq_lens`` is ``[B, max_docs]``. When packing is on,
+        ``position_ids`` / ``seq_lens`` make the draft block-causal and per-document,
+        and ``doc_remaining`` (real tokens after each slot within its document) gates
+        supervision: a document's last real token (``doc_remaining == 0``) is dropped
+        because the wrapper's global left-shift makes its target the next document's
+        first token.
         """
         if self.training and self.feature_noise > 0:
             # EAGLE feature-noise augmentation (see __init__): add

--- a/nemo_automodel/components/speculative/eagle/core_v12.py
+++ b/nemo_automodel/components/speculative/eagle/core_v12.py
@@ -88,8 +88,25 @@ class EagleTrainerModule(nn.Module):
         input_hidden_states: torch.Tensor,
         target_hidden_states: torch.Tensor,
         target_logits: torch.Tensor,
+        position_ids: torch.Tensor | None = None,
+        seq_lens: torch.Tensor | None = None,
+        doc_remaining: torch.Tensor | None = None,
     ) -> EagleStepMetrics:
-        """Run one EAGLE-1 / EAGLE-2 training step."""
+        """Run one EAGLE-1 / EAGLE-2 training step.
+
+        All per-token tensors are ``[B, T]`` (``input_ids`` / ``loss_mask`` /
+        ``attention_mask`` / ``position_ids`` / ``doc_remaining``) except the
+        ``[B, T, H]`` hidden states and ``[B, T, V]`` ``target_logits``.
+
+        Packing (``seq_lens`` ``[B, max_docs]`` long, per-document lengths summing
+        to ``T``) makes the draft's attention document-level block-causal and its
+        RoPE per-document via ``position_ids``. ``doc_remaining`` ``[B, T]`` (real
+        tokens after each slot within its document) gates supervision: a
+        document's last real token (``doc_remaining == 0``) predicts the *next*
+        document's first token through the wrapper's global left-shift, so it is
+        dropped. This is the single-step reduction of the EAGLE-3 TTT gate
+        (``step_idx < doc_remaining`` at ``step_idx == 0``).
+        """
         if self.training and self.feature_noise > 0:
             # EAGLE feature-noise augmentation (see __init__): add
             # U(-feature_noise, feature_noise) to the draft's input features.
@@ -104,10 +121,16 @@ class EagleTrainerModule(nn.Module):
             input_ids=input_ids,
             target_hidden_states=input_hidden_states,
             attention_mask=attention_mask,
+            position_ids=position_ids,
+            seq_lens=seq_lens,
         )
         predicted_logits = self.compute_logits(predicted_hidden_states)
 
         valid_mask = loss_mask.bool()
+        if doc_remaining is not None:
+            # Packing: drop each document's last real token (doc_remaining == 0),
+            # whose left-shifted supervision target belongs to the next document.
+            valid_mask = valid_mask & (doc_remaining > 0)
         position_mask = valid_mask.unsqueeze(-1)
         valid_tokens = valid_mask.sum()
 

--- a/nemo_automodel/components/speculative/eagle/draft_llama_v12.py
+++ b/nemo_automodel/components/speculative/eagle/draft_llama_v12.py
@@ -22,10 +22,13 @@ compatibility.
 
 from __future__ import annotations
 
+from typing import Optional
+
 import torch
 import torch.nn as nn
 from transformers import PretrainedConfig, PreTrainedModel
 
+from nemo_automodel.components.datasets.llm.packed_sequence import build_block_causal_additive_mask
 from nemo_automodel.components.models.common import initialize_rms_norm_module
 from nemo_automodel.components.models.llama.rope_utils import (
     LlamaRotaryEmbedding,
@@ -199,15 +202,42 @@ class LlamaEagleDraftModel(PreTrainedModel):
         input_ids: torch.Tensor,
         target_hidden_states: torch.Tensor,
         attention_mask: torch.Tensor,
+        position_ids: Optional[torch.Tensor] = None,
+        seq_lens: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
+        """Predict the next-step target hidden state for each position.
+
+        Args (batch ``B``, sequence length ``T``, hidden size ``H``):
+            input_ids: ``[B, T]`` long token ids.
+            target_hidden_states: ``[B, T, H]`` target hidden features fed to the draft.
+            attention_mask: ``[B, T]`` (1 = real, 0 = pad); used on the unpacked path only.
+            position_ids: ``[B, T]`` long, or ``None`` to default to ``arange``.
+                Packing requires per-document positions (reset to ``range(doc_len)``).
+            seq_lens: ``[B, max_docs]`` long (0-padded per-document lengths that sum to
+                ``T`` per row) turns on sequence packing -- attention becomes
+                document-level block-causal via :func:`build_block_causal_additive_mask`
+                instead of the plain causal + padding mask, and RoPE uses the per-document
+                ``position_ids`` so each document is rotated from its own origin.
+        """
         inputs_embeds = self.embed_tokens(input_ids).to(target_hidden_states.dtype)
         hidden_states = self.fc(torch.cat((inputs_embeds, target_hidden_states), dim=-1))
 
         batch_size, seq_len, _ = hidden_states.shape
-        position_ids = (
-            torch.arange(seq_len, device=hidden_states.device, dtype=torch.long).unsqueeze(0).expand(batch_size, -1)
-        )
-        causal_mask = _build_causal_mask(attention_mask, hidden_states.dtype)
+        if seq_lens is not None and position_ids is None:
+            raise ValueError(
+                "LlamaEagleDraftModel: sequence packing (seq_lens) requires per-document position_ids "
+                "(reset to range(doc_len) within each document), but none were provided."
+            )
+        if position_ids is None:
+            position_ids = (
+                torch.arange(seq_len, device=hidden_states.device, dtype=torch.long).unsqueeze(0).expand(batch_size, -1)
+            )
+        if seq_lens is not None:
+            causal_mask = build_block_causal_additive_mask(
+                seq_lens, seq_length=seq_len, dtype=hidden_states.dtype, device=hidden_states.device
+            )
+        else:
+            causal_mask = _build_causal_mask(attention_mask, hidden_states.dtype)
 
         for layer in self.layers:
             hidden_states = layer(hidden_states, attention_mask=causal_mask, position_ids=position_ids)

--- a/nemo_automodel/components/speculative/eagle/target_v12.py
+++ b/nemo_automodel/components/speculative/eagle/target_v12.py
@@ -22,6 +22,8 @@ from dataclasses import dataclass
 import torch
 import torch.nn as nn
 
+from nemo_automodel.components.datasets.llm.packed_sequence import build_block_causal_additive_mask
+
 
 def _shift_left_with_zero(tensor: torch.Tensor) -> torch.Tensor:
     """Shift a batched sequence tensor left and zero-fill the tail."""
@@ -42,7 +44,12 @@ def _to_full_tensor(tensor: torch.Tensor) -> torch.Tensor:
 
 @dataclass
 class EagleTargetBatch:
-    """Target-model outputs needed by the EAGLE-1 / EAGLE-2 trainer."""
+    """Target-model outputs needed by the EAGLE-1 / EAGLE-2 trainer.
+
+    ``position_ids`` / ``seq_lens`` / ``doc_remaining`` are ``None`` on the
+    unpacked path and carry the packing metadata (unshifted, indexed by slot)
+    through to the trainer on the packed path.
+    """
 
     input_hidden_states: torch.Tensor
     target_hidden_states: torch.Tensor
@@ -50,6 +57,9 @@ class EagleTargetBatch:
     input_ids: torch.Tensor
     attention_mask: torch.Tensor
     loss_mask: torch.Tensor
+    position_ids: torch.Tensor | None = None
+    seq_lens: torch.Tensor | None = None
+    doc_remaining: torch.Tensor | None = None
 
 
 class HFEagleTargetModel:
@@ -72,8 +82,22 @@ class HFEagleTargetModel:
         input_ids: torch.Tensor,
         attention_mask: torch.Tensor,
         loss_mask: torch.Tensor,
+        position_ids: torch.Tensor | None = None,
+        seq_lens: torch.Tensor | None = None,
+        doc_remaining: torch.Tensor | None = None,
     ) -> EagleTargetBatch:
-        """Run the target transformer and prepare shifted supervision tensors."""
+        """Run the target transformer and prepare shifted supervision tensors.
+
+        All per-token inputs are ``[B, T]``. With ``seq_lens`` (``[B, max_docs]``
+        long, per-document lengths summing to ``T``) the target runs with a
+        document-level block-causal mask and per-document ``position_ids`` so its
+        hidden states do not leak across document boundaries; SDPA/eager targets
+        consume the ``[B, 1, T, T]`` block-causal additive mask, FlashAttention
+        targets infer document boundaries from ``position_ids`` and are passed
+        ``attention_mask=None`` (batch size 1 only). ``position_ids`` / ``seq_lens``
+        / ``doc_remaining`` are carried through (unshifted) so the trainer can build
+        the draft's block-causal mask and drop cross-document supervision.
+        """
         # Strip HF-only flags when the base model doesn't declare them.
         # AutoModel's custom backbones expose a ``**attn_kwargs`` catch-all
         # and silently ignore ``output_*`` / ``use_cache``; HF backbones
@@ -85,9 +109,33 @@ class HFEagleTargetModel:
             for name in ("output_hidden_states", "output_attentions", "use_cache")
             if name in base_forward_params
         }
+        target_attention_mask = attention_mask
+        if seq_lens is not None:
+            if position_ids is None or "position_ids" not in base_forward_params:
+                raise ValueError(
+                    "EAGLE-1/2 sequence packing requires per-document position_ids, but none were "
+                    "provided or the target model's forward does not accept a `position_ids` argument."
+                )
+            extra_kwargs["position_ids"] = position_ids
+            attn_impl = getattr(self.model.config, "_attn_implementation", None) or ""
+            if "flash" in attn_impl:
+                if input_ids.shape[0] != 1:
+                    raise ValueError(
+                        "EAGLE-1/2 sequence packing with a FlashAttention target only supports "
+                        f"micro_batch_size=1 (got {input_ids.shape[0]}). FlashAttention infers document "
+                        "boundaries from per-document position_ids, which transformers packs only at "
+                        "batch size 1. Set micro_batch_size=1 or load the target with attn_implementation='sdpa'."
+                    )
+                # attention_mask=None + per-document position_ids -> FA varlen packing.
+                target_attention_mask = None
+            else:
+                param_dtype = next(self.model.parameters()).dtype
+                target_attention_mask = build_block_causal_additive_mask(
+                    seq_lens, seq_length=input_ids.shape[1], dtype=param_dtype, device=input_ids.device
+                )
         outputs = base_model(
             input_ids=input_ids,
-            attention_mask=attention_mask,
+            attention_mask=target_attention_mask,
             **extra_kwargs,
         )
         # HF base models return a dataclass whose first item is
@@ -106,4 +154,7 @@ class HFEagleTargetModel:
             input_ids=_shift_left_with_zero(input_ids),
             attention_mask=attention_mask,
             loss_mask=_shift_left_with_zero(loss_mask),
+            position_ids=position_ids,
+            seq_lens=seq_lens,
+            doc_remaining=doc_remaining,
         )

--- a/nemo_automodel/recipes/llm/train_eagle1.py
+++ b/nemo_automodel/recipes/llm/train_eagle1.py
@@ -72,6 +72,30 @@ def _all_reduce_mean(value: torch.Tensor) -> torch.Tensor:
     return value
 
 
+def _validate_packing_gates(*, cp_size: int, target_attn_impl: str, micro_batch_size: int) -> None:
+    """Reject sequence-packing configs the EAGLE-1/2 path cannot honor (fail fast at setup).
+
+    - Context parallelism shards the sequence and strips the 4D block-causal mask
+      packing relies on, and EAGLE-1/2 has no CP sequence-sharding path, so
+      ``cp_size > 1`` with packing would silently train on wrong supervision.
+    - A FlashAttention target infers document boundaries from per-document
+      ``position_ids``, which transformers packs only at batch size 1.
+    """
+    if cp_size > 1:
+        raise NotImplementedError(
+            "Sequence packing (packed_sequence_size>0) is not supported with context parallelism "
+            "(distributed.cp_size>1) in EAGLE-1/2; CP shards the sequence and strips the 4D block-causal "
+            "mask packing relies on. Set cp_size=1 or packed_sequence_size=0."
+        )
+    if "flash" in target_attn_impl and micro_batch_size > 1:
+        raise ValueError(
+            "Sequence packing with a FlashAttention target requires micro_batch_size=1 "
+            f"(got {micro_batch_size}); FlashAttention infers document boundaries from per-document "
+            "position_ids, which transformers packs only at batch size 1. Set micro_batch_size=1 or "
+            "load the target with attn_implementation='sdpa'."
+        )
+
+
 def _packing_kwargs(batch: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
     """Sequence-packing metadata from a dataloader batch (empty dict when unpacked).
 
@@ -184,6 +208,14 @@ class TrainEagle1Recipe(BaseRecipe):
         # single-step draft both consume the block-causal packing metadata
         # (position_ids / seq_lens / doc_remaining) the packed loader emits.
         packed_sequence_size = int(recipe_cfg.get("packed_sequence_size", 0) or 0)
+        if packed_sequence_size > 0:
+            # Fail fast at setup (before the multi-GPU load + dataloader build) on
+            # packing configs EAGLE-1/2 cannot honor, rather than mid-run.
+            _validate_packing_gates(
+                cp_size=int(self.cfg.get("distributed.cp_size", 1) or 1),
+                target_attn_impl=getattr(self.target_model.config, "_attn_implementation", None) or "",
+                micro_batch_size=int(recipe_cfg.micro_batch_size),
+            )
         self.train_dataloader = build_eagle3_dataloader(
             data_path=recipe_cfg.train_data_path,
             tokenizer=self.tokenizer,

--- a/nemo_automodel/recipes/llm/train_eagle1.py
+++ b/nemo_automodel/recipes/llm/train_eagle1.py
@@ -72,6 +72,23 @@ def _all_reduce_mean(value: torch.Tensor) -> torch.Tensor:
     return value
 
 
+def _packing_kwargs(batch: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+    """Sequence-packing metadata from a dataloader batch (empty dict when unpacked).
+
+    The packed loader (``packed_sequence_size > 0``) emits ``position_ids`` /
+    ``seq_lens`` / ``doc_remaining`` alongside ``input_ids``; the default loader
+    does not. Keyed on ``seq_lens`` so the caller can splat the result into
+    ``HFEagleTargetModel.generate_batch`` unconditionally.
+    """
+    if "seq_lens" not in batch:
+        return {}
+    return {
+        "position_ids": batch["position_ids"],
+        "seq_lens": batch["seq_lens"],
+        "doc_remaining": batch["doc_remaining"],
+    }
+
+
 def _submesh_or_none(device_mesh, name: str):
     """Return the named (flattened) submesh, or None if absent / no mesh.
 
@@ -161,6 +178,12 @@ class TrainEagle1Recipe(BaseRecipe):
         self.target_model.requires_grad_(False)
         self.target_wrapper = HFEagleTargetModel(self.target_model)
 
+        # ``packed_sequence_size > 0`` enables sequence packing (greedy first-fit
+        # of documents into fixed-width rows), removing the padding waste of the
+        # default ``padding="max_length"`` path. The colocated HF target and the
+        # single-step draft both consume the block-causal packing metadata
+        # (position_ids / seq_lens / doc_remaining) the packed loader emits.
+        packed_sequence_size = int(recipe_cfg.get("packed_sequence_size", 0) or 0)
         self.train_dataloader = build_eagle3_dataloader(
             data_path=recipe_cfg.train_data_path,
             tokenizer=self.tokenizer,
@@ -172,6 +195,7 @@ class TrainEagle1Recipe(BaseRecipe):
             distributed=self.dist_env.world_size > 1,
             shuffle_seed=recipe_cfg.get("shuffle_seed", 42),
             mask_reasoning_content=recipe_cfg.get("mask_reasoning_content", False),
+            packed_sequence_size=packed_sequence_size,
             dp_mesh=self.dp_mesh,
         )
         self.val_dataloader = None
@@ -187,6 +211,7 @@ class TrainEagle1Recipe(BaseRecipe):
                 distributed=self.dist_env.world_size > 1,
                 shuffle_seed=recipe_cfg.get("shuffle_seed", 42),
                 mask_reasoning_content=recipe_cfg.get("mask_reasoning_content", False),
+                packed_sequence_size=packed_sequence_size,
                 dp_mesh=self.dp_mesh,
             )
 
@@ -604,6 +629,7 @@ class TrainEagle1Recipe(BaseRecipe):
                     input_ids=batch["input_ids"],
                     attention_mask=batch["attention_mask"],
                     loss_mask=batch["loss_mask"],
+                    **_packing_kwargs(batch),
                 )
                 metrics = self.trainer_module(
                     input_ids=target_batch.input_ids,
@@ -612,6 +638,9 @@ class TrainEagle1Recipe(BaseRecipe):
                     input_hidden_states=target_batch.input_hidden_states,
                     target_hidden_states=target_batch.target_hidden_states,
                     target_logits=target_batch.target_logits,
+                    position_ids=target_batch.position_ids,
+                    seq_lens=target_batch.seq_lens,
+                    doc_remaining=target_batch.doc_remaining,
                 )
                 total_loss += metrics.loss.detach()
                 total_acc += metrics.accuracy.detach()
@@ -667,6 +696,7 @@ class TrainEagle1Recipe(BaseRecipe):
                         input_ids=batch["input_ids"],
                         attention_mask=batch["attention_mask"],
                         loss_mask=batch["loss_mask"],
+                        **_packing_kwargs(batch),
                     )
                     # Skip DDP's per-micro-batch all-reduce on every micro-batch
                     # except the one an optimizer step immediately follows; that
@@ -687,6 +717,9 @@ class TrainEagle1Recipe(BaseRecipe):
                             input_hidden_states=target_batch.input_hidden_states,
                             target_hidden_states=target_batch.target_hidden_states,
                             target_logits=target_batch.target_logits,
+                            position_ids=target_batch.position_ids,
+                            seq_lens=target_batch.seq_lens,
+                            doc_remaining=target_batch.doc_remaining,
                         )
                         loss = metrics.loss / self.grad_accumulation_steps
                         loss.backward()

--- a/tests/unit_tests/recipes/llm/test_eagle_step_checkpoint.py
+++ b/tests/unit_tests/recipes/llm/test_eagle_step_checkpoint.py
@@ -177,7 +177,7 @@ class _ConstantGradModule(nn.Module):
 
 
 class _FakeTargetWrapper:
-    def generate_batch(self, input_ids, attention_mask, loss_mask):
+    def generate_batch(self, input_ids, attention_mask, loss_mask, **packing_kwargs):
         return SimpleNamespace(
             input_ids=input_ids,
             attention_mask=attention_mask,
@@ -185,6 +185,9 @@ class _FakeTargetWrapper:
             input_hidden_states=None,
             target_hidden_states=None,
             target_logits=None,
+            position_ids=None,
+            seq_lens=None,
+            doc_remaining=None,
         )
 
 

--- a/tests/unit_tests/recipes/llm/test_train_eagle1_grad_accum.py
+++ b/tests/unit_tests/recipes/llm/test_train_eagle1_grad_accum.py
@@ -72,7 +72,7 @@ class _ConstantGradModule(nn.Module):
 
 
 class _FakeTargetWrapper:
-    def generate_batch(self, input_ids, attention_mask, loss_mask):
+    def generate_batch(self, input_ids, attention_mask, loss_mask, **packing_kwargs):
         return SimpleNamespace(
             input_ids=input_ids,
             attention_mask=attention_mask,
@@ -80,6 +80,9 @@ class _FakeTargetWrapper:
             input_hidden_states=None,
             target_hidden_states=None,
             target_logits=None,
+            position_ids=None,
+            seq_lens=None,
+            doc_remaining=None,
         )
 
 

--- a/tests/unit_tests/speculative/test_eagle12_feature_noise.py
+++ b/tests/unit_tests/speculative/test_eagle12_feature_noise.py
@@ -38,7 +38,7 @@ class _RecordingDraft(nn.Module):
         self.lin = nn.Linear(_HIDDEN, _HIDDEN)
         self.received = None
 
-    def forward(self, input_ids, target_hidden_states, attention_mask):
+    def forward(self, input_ids, target_hidden_states, attention_mask, position_ids=None, seq_lens=None):
         self.received = target_hidden_states.detach().clone()
         return self.lin(target_hidden_states)
 

--- a/tests/unit_tests/speculative/test_eagle12_packing.py
+++ b/tests/unit_tests/speculative/test_eagle12_packing.py
@@ -1,0 +1,225 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sequence-packing tests for the EAGLE-1 / EAGLE-2 draft, target wrapper, and trainer."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from transformers import LlamaConfig, LlamaForCausalLM
+
+from nemo_automodel.components.speculative.eagle.core_v12 import EagleTrainerModule
+from nemo_automodel.components.speculative.eagle.draft_llama_v12 import LlamaEagleDraftModel
+from nemo_automodel.components.speculative.eagle.target_v12 import HFEagleTargetModel
+
+_HIDDEN = 16
+_VOCAB = 64
+
+
+def _draft_config() -> LlamaConfig:
+    config = LlamaConfig(
+        hidden_size=_HIDDEN,
+        intermediate_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        vocab_size=_VOCAB,
+        max_position_embeddings=64,
+    )
+    config.torch_dtype = torch.float32
+    config.draft_num_hidden_layers = 1
+    return config
+
+
+def _build_draft() -> LlamaEagleDraftModel:
+    torch.manual_seed(0)
+    return LlamaEagleDraftModel(_draft_config()).to(torch.float32)
+
+
+def _build_target(num_hidden_layers: int = 4) -> LlamaForCausalLM:
+    config = LlamaConfig(
+        hidden_size=_HIDDEN,
+        intermediate_size=32,
+        num_hidden_layers=num_hidden_layers,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        vocab_size=_VOCAB,
+        max_position_embeddings=64,
+        attn_implementation="eager",
+    )
+    config.torch_dtype = torch.float32
+    torch.manual_seed(1)
+    return LlamaForCausalLM(config).to(torch.float32).eval()
+
+
+def _uniform_pack_meta(num_docs: int, doc_len: int) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Return ``(position_ids, seq_lens, doc_remaining)`` for ``num_docs`` equal docs over one row."""
+    position_ids = torch.cat([torch.arange(doc_len) for _ in range(num_docs)]).unsqueeze(0)
+    seq_lens = torch.tensor([[doc_len] * num_docs], dtype=torch.long)
+    doc_remaining = torch.cat([torch.arange(doc_len - 1, -1, -1) for _ in range(num_docs)]).unsqueeze(0)
+    return position_ids, seq_lens, doc_remaining
+
+
+def test_packed_single_doc_matches_unpacked_forward():
+    """A packed row that is one full-width document must match the plain causal forward."""
+    draft = _build_draft().eval()
+    batch, seq = 1, 6
+    input_ids = torch.randint(0, _VOCAB, (batch, seq))
+    target_hidden = torch.randn(batch, seq, _HIDDEN)
+    attn = torch.ones(batch, seq, dtype=torch.long)
+    position_ids = torch.arange(seq, dtype=torch.long).unsqueeze(0)
+
+    out_unpacked = draft(input_ids, target_hidden, attn, position_ids=position_ids)
+    out_packed = draft(
+        input_ids, target_hidden, attn, position_ids=position_ids, seq_lens=torch.tensor([[seq]], dtype=torch.long)
+    )
+    torch.testing.assert_close(out_packed, out_unpacked)
+
+
+def test_packed_draft_attention_isolates_documents():
+    """Block-causal packing must isolate documents in the draft forward."""
+    torch.manual_seed(0)
+    draft = _build_draft().eval()
+    seq_len = 6
+    seq_lens = torch.tensor([[3, 3]], dtype=torch.long)
+    position_ids = torch.tensor([[0, 1, 2, 0, 1, 2]], dtype=torch.long)
+    input_ids = torch.randint(0, _VOCAB, (1, seq_len))
+    target_hidden = torch.randn(1, seq_len, _HIDDEN)
+
+    def run(ids, th):
+        return draft(ids, th, torch.ones(1, seq_len, dtype=torch.long), position_ids=position_ids, seq_lens=seq_lens)
+
+    out_ref = run(input_ids, target_hidden)
+    ids_b = input_ids.clone()
+    ids_b[:, 3:] = torch.randint(0, _VOCAB, (1, 3))
+    th_b = target_hidden.clone()
+    th_b[:, 3:] = torch.randn(1, 3, _HIDDEN)
+    out_perturbed = run(ids_b, th_b)
+
+    torch.testing.assert_close(out_ref[:, :3], out_perturbed[:, :3])  # doc A unchanged
+    assert not torch.allclose(out_ref[:, 3:], out_perturbed[:, 3:])  # doc B changed
+
+
+def test_packing_requires_position_ids():
+    """Packing without per-document position_ids must fail loud in the draft."""
+    draft = _build_draft().eval()
+    ids = torch.randint(0, _VOCAB, (1, 6))
+    th = torch.randn(1, 6, _HIDDEN)
+    with pytest.raises(ValueError, match="per-document position_ids"):
+        draft(ids, th, torch.ones(1, 6, dtype=torch.long), seq_lens=torch.tensor([[3, 3]], dtype=torch.long))
+
+
+def test_target_wrapper_packing_isolates_documents_and_carries_metadata():
+    """generate_batch under packing must isolate the target's hidden states per document
+    and carry position_ids / seq_lens / doc_remaining through to the trainer."""
+    torch.manual_seed(2)
+    target = _build_target()
+    wrapper = HFEagleTargetModel(target)
+    num_docs, doc_len = 2, 6
+    seq = num_docs * doc_len
+    position_ids, seq_lens, doc_remaining = _uniform_pack_meta(num_docs, doc_len)
+    input_ids = torch.randint(0, _VOCAB, (1, seq))
+    attn = torch.ones(1, seq, dtype=torch.long)
+    loss = torch.ones(1, seq, dtype=torch.long)
+
+    def input_hidden(ids):
+        b = wrapper.generate_batch(
+            ids, attn, loss, position_ids=position_ids, seq_lens=seq_lens, doc_remaining=doc_remaining
+        )
+        assert b.position_ids is position_ids and b.seq_lens is seq_lens and b.doc_remaining is doc_remaining
+        return b.input_hidden_states
+
+    ref = input_hidden(input_ids)
+    ids_b = input_ids.clone()
+    ids_b[:, doc_len:] = torch.randint(0, _VOCAB, (1, doc_len))
+    pert = input_hidden(ids_b)
+    torch.testing.assert_close(ref[:, :doc_len], pert[:, :doc_len])  # doc A hidden unchanged
+    assert not torch.allclose(ref[:, doc_len:], pert[:, doc_len:])  # doc B hidden changed
+
+
+def _build_trainer(target: LlamaForCausalLM) -> EagleTrainerModule:
+    torch.manual_seed(123)  # identical draft init across layouts
+    draft = LlamaEagleDraftModel(_draft_config()).to(torch.float32)
+    return EagleTrainerModule(draft, target_lm_head=target.lm_head, hidden_loss_weight=1.0, token_loss_weight=0.1)
+
+
+def test_packing_matches_padding_loss_and_grads():
+    """Golden parity: packing N docs into one row == N padded single-doc rows.
+
+    Both layouts run through the real ``HFEagleTargetModel`` + ``EagleTrainerModule``:
+      * padding: ``[D, T]`` with each doc's ``L`` real tokens padded to ``T`` (the
+        wrapper's global left-shift drops each doc's last token via padding);
+      * packing: the same docs as ``[1, T]`` with per-document position_ids, the
+        block-causal target/draft masks, and the ``doc_remaining`` gate.
+    They supervise the identical (doc, position) pairs against identical targets, so
+    loss and every draft gradient match to tight CPU/fp32 tolerance.
+    """
+    num_docs, doc_len = 3, 6
+    total = num_docs * doc_len
+    target = _build_target()
+    wrapper = HFEagleTargetModel(target)
+
+    torch.manual_seed(7)
+    docs = [torch.randint(0, _VOCAB, (doc_len,)) for _ in range(num_docs)]
+
+    # Layout A: D padded single-document rows.
+    ids_a = torch.zeros(num_docs, total, dtype=torch.long)
+    loss_a = torch.zeros(num_docs, total, dtype=torch.long)
+    attn_a = torch.zeros(num_docs, total, dtype=torch.long)
+    for d in range(num_docs):
+        ids_a[d, :doc_len] = docs[d]
+        loss_a[d, :doc_len] = 1
+        attn_a[d, :doc_len] = 1
+    trainer_a = _build_trainer(target)
+    batch_a = wrapper.generate_batch(ids_a, attn_a, loss_a)
+    metrics_a = trainer_a(
+        input_ids=batch_a.input_ids,
+        attention_mask=batch_a.attention_mask,
+        loss_mask=batch_a.loss_mask,
+        input_hidden_states=batch_a.input_hidden_states,
+        target_hidden_states=batch_a.target_hidden_states,
+        target_logits=batch_a.target_logits,
+    )
+    metrics_a.loss.backward()
+    grads_a = {n: p.grad.clone() for n, p in trainer_a.named_parameters() if p.grad is not None}
+
+    # Layout B: the same documents packed into one row.
+    ids_b = torch.cat(docs).unsqueeze(0)
+    loss_b = torch.ones(1, total, dtype=torch.long)
+    attn_b = torch.ones(1, total, dtype=torch.long)
+    position_ids, seq_lens, doc_remaining = _uniform_pack_meta(num_docs, doc_len)
+    trainer_b = _build_trainer(target)
+    batch_b = wrapper.generate_batch(
+        ids_b, attn_b, loss_b, position_ids=position_ids, seq_lens=seq_lens, doc_remaining=doc_remaining
+    )
+    metrics_b = trainer_b(
+        input_ids=batch_b.input_ids,
+        attention_mask=batch_b.attention_mask,
+        loss_mask=batch_b.loss_mask,
+        input_hidden_states=batch_b.input_hidden_states,
+        target_hidden_states=batch_b.target_hidden_states,
+        target_logits=batch_b.target_logits,
+        position_ids=batch_b.position_ids,
+        seq_lens=batch_b.seq_lens,
+        doc_remaining=batch_b.doc_remaining,
+    )
+    metrics_b.loss.backward()
+    grads_b = {n: p.grad.clone() for n, p in trainer_b.named_parameters() if p.grad is not None}
+
+    assert metrics_a.valid_tokens.item() == metrics_b.valid_tokens.item()
+    torch.testing.assert_close(metrics_a.loss, metrics_b.loss, rtol=1e-4, atol=1e-5)
+    assert set(grads_a) == set(grads_b)
+    for name in grads_a:
+        torch.testing.assert_close(grads_a[name], grads_b[name], rtol=1e-4, atol=1e-5, msg=f"grad mismatch: {name}")

--- a/tests/unit_tests/speculative/test_eagle12_packing.py
+++ b/tests/unit_tests/speculative/test_eagle12_packing.py
@@ -121,6 +121,20 @@ def test_packing_requires_position_ids():
         draft(ids, th, torch.ones(1, 6, dtype=torch.long), seq_lens=torch.tensor([[3, 3]], dtype=torch.long))
 
 
+def test_recipe_packing_kwargs_helper():
+    """The recipe helper extracts packing metadata only when the batch is packed."""
+    from nemo_automodel.recipes.llm.train_eagle1 import _packing_kwargs
+
+    assert _packing_kwargs({"input_ids": torch.zeros(1, 4)}) == {}
+    packed = {
+        "input_ids": torch.zeros(1, 4),
+        "position_ids": torch.zeros(1, 4),
+        "seq_lens": torch.tensor([[4]]),
+        "doc_remaining": torch.zeros(1, 4),
+    }
+    assert set(_packing_kwargs(packed)) == {"position_ids", "seq_lens", "doc_remaining"}
+
+
 def test_target_wrapper_packing_isolates_documents_and_carries_metadata():
     """generate_batch under packing must isolate the target's hidden states per document
     and carry position_ids / seq_lens / doc_remaining through to the trainer."""

--- a/tests/unit_tests/speculative/test_eagle12_packing.py
+++ b/tests/unit_tests/speculative/test_eagle12_packing.py
@@ -135,6 +135,50 @@ def test_recipe_packing_kwargs_helper():
     assert set(_packing_kwargs(packed)) == {"position_ids", "seq_lens", "doc_remaining"}
 
 
+def test_recipe_packing_gates_fail_fast():
+    """Packing configs EAGLE-1/2 cannot honor must be rejected at setup, not mid-run."""
+    from nemo_automodel.recipes.llm.train_eagle1 import _validate_packing_gates
+
+    # Compatible: eager/sdpa target, no CP, any batch size -> no raise.
+    _validate_packing_gates(cp_size=1, target_attn_impl="sdpa", micro_batch_size=4)
+    # Context parallelism shards the sequence and strips the block-causal mask.
+    with pytest.raises(NotImplementedError, match="context parallelism"):
+        _validate_packing_gates(cp_size=2, target_attn_impl="sdpa", micro_batch_size=1)
+    # FlashAttention target packs documents only at batch size 1.
+    with pytest.raises(ValueError, match="micro_batch_size=1"):
+        _validate_packing_gates(cp_size=1, target_attn_impl="flash_attention_2", micro_batch_size=2)
+
+
+def test_target_wrapper_packing_requires_position_ids():
+    """The target wrapper must fail loud when packing is requested without position_ids."""
+    wrapper = HFEagleTargetModel(_build_target())
+    ids = torch.randint(0, _VOCAB, (1, 6))
+    with pytest.raises(ValueError, match="per-document position_ids"):
+        wrapper.generate_batch(
+            ids,
+            torch.ones(1, 6, dtype=torch.long),
+            torch.ones(1, 6, dtype=torch.long),
+            seq_lens=torch.tensor([[3, 3]], dtype=torch.long),
+        )
+
+
+def test_target_wrapper_flash_packing_rejects_batch_gt_1():
+    """A FlashAttention target under packing must reject micro_batch_size>1 (varlen needs bs=1)."""
+    target = _build_target()
+    target.config._attn_implementation = "flash_attention_2"
+    wrapper = HFEagleTargetModel(target)
+    bsz, seq = 2, 6
+    position_ids = torch.arange(seq, dtype=torch.long).unsqueeze(0).expand(bsz, -1)
+    with pytest.raises(ValueError, match="micro_batch_size=1"):
+        wrapper.generate_batch(
+            torch.randint(0, _VOCAB, (bsz, seq)),
+            torch.ones(bsz, seq, dtype=torch.long),
+            torch.ones(bsz, seq, dtype=torch.long),
+            position_ids=position_ids,
+            seq_lens=torch.tensor([[seq]] * bsz, dtype=torch.long),
+        )
+
+
 def test_target_wrapper_packing_isolates_documents_and_carries_metadata():
     """generate_batch under packing must isolate the target's hidden states per document
     and carry position_ids / seq_lens / doc_remaining through to the trainer."""


### PR DESCRIPTION
## What

Extends EAGLE-3 sequence packing to the EAGLE-1 / EAGLE-2 draft. The EAGLE-1/2 recipe already builds its dataloader with `build_eagle3_dataloader` but never passed `packed_sequence_size`, so packing was unreachable. This wires it end to end, mirroring the EAGLE-3 packing path:

- **Draft** (`draft_llama_v12.py`): `forward` accepts `position_ids` / `seq_lens`. Under packing it builds the shared `[B, 1, T, T]` block-causal additive mask (`build_block_causal_additive_mask`) instead of the plain causal + padding mask, and uses the per-document `position_ids` for RoPE so each document is rotated from its own origin. Fails loud if `seq_lens` is passed without `position_ids`.
- **Target wrapper** (`target_v12.py`): `generate_batch` accepts `position_ids` / `seq_lens` / `doc_remaining`; under packing the target runs with the block-causal mask (SDPA/eager) or FlashAttention varlen (batch size 1), so its hidden states do not leak across documents, and it carries the packing metadata onto `EagleTargetBatch`.
- **Trainer** (`core_v12.py`): threads `position_ids` / `seq_lens` to the draft and gates supervision with `doc_remaining > 0`. EAGLE-1/2 is single-step, so this is the reduction of the EAGLE-3 TTT gate (`step_idx < doc_remaining`) at `step_idx == 0`: it drops each document's last real token, whose target, under the wrapper's global left-shift, belongs to the next document.
- **Recipe** (`train_eagle1.py`): reads `packed_sequence_size` into both dataloaders, splats the packing metadata into `generate_batch` and the trainer, and validates incompatible configs at setup (`_validate_packing_gates`): packing with context parallelism (`cp_size>1`, which EAGLE-1/2 has no sequence-sharding path for), and a FlashAttention target with `micro_batch_size>1`.

The packed dataset (`build_packed_eagle3_dataset` / `_pack_collate`) is reused unchanged; only the recipe needed to enable it.

## Correctness verification

CPU unit tests (16 pass in the packing file, no regressions in the EAGLE-1/2 suite), including:

- **Golden parity**: packing N documents into one row produces the same loss and every draft gradient (tight fp32 tolerance) as N padded single-document rows, run through the real `HFEagleTargetModel` + `EagleTrainerModule`.
- **Document isolation**: perturbing only document B's inputs leaves document A's draft output, and the target's input hidden states, bit-identical.
- **Single-doc equivalence**, and **fail-loud guards** (missing `position_ids`; FlashAttention target with batch > 1; `cp_size>1` with packing).

GPU recipe smoke (1x A100-80GB, bf16), the full recipe with a real Qwen3-4B target and `packed_sequence_size` enabled:

<details>
<summary>Training log</summary>

```
epoch=0 step=1  loss=2.8629 acc=0.0000 lr=0.0001
epoch=0 step=2  loss=2.2494 acc=0.2143 lr=9.9808e-05
epoch=0 step=3  loss=2.0738 acc=0.3643 lr=9.92338e-05
epoch=0 step=5  loss=1.8130 acc=0.6294 lr=9.69613e-05
epoch=0 step=8  loss=1.6369 acc=0.7857 lr=9.09108e-05
epoch=0 step=12 loss=1.4594 acc=0.7471 lr=7.86894e-05
epoch=0 step=18 loss=1.3350 acc=0.7929 lr=5.5e-05
epoch=0 step=24 loss=1.2639 acc=0.8176 lr=3.13106e-05
epoch=0 step=30 loss=1.2525 acc=0.8357 lr=1.47177e-05
epoch=0 step=35 loss=1.2533 acc=0.8235 lr=1e-05
Finished epoch 1/1 completed_steps=35
```

</details>

Loss falls 2.86 -> 1.25 and next-token accuracy rises 0.0 -> ~0.82 with packing on, exercising the full path (packed dataloader -> target block-causal -> draft block-causal + `doc_remaining` gating).

## Scope

EAGLE-1/2 draft only, per the incremental plan (the DeepSeek MLA EAGLE-3 draft is a separate PR). Extending packing to DFlash / DSpark and resolving packing with context parallelism remain follow-ups.
