### PR TITLE
ci: sync GitHub Development PRs to Linear

### DIFF
--- a/.github/scripts/sync_linear_development_links.py
+++ b/.github/scripts/sync_linear_development_links.py
@@ -1,0 +1,318 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Mirror GitHub Development-linked pull requests to synced Linear issues."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+from dataclasses import dataclass
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+_GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
+_LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql"
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _PullRequest:
+    number: int
+    url: str
+    closing_issue_urls: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _LinearIssue:
+    id: str
+    identifier: str
+
+
+@dataclass
+class _SyncStats:
+    scanned: int = 0
+    linked: int = 0
+    planned: int = 0
+    existing: int = 0
+    unmapped: int = 0
+
+
+def _as_object(value: object, context: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise RuntimeError(f"Expected {context} to be an object")
+    if not all(isinstance(key, str) for key in value):
+        raise RuntimeError(f"Expected {context} to have string keys")
+    return value
+
+
+def _as_list(value: object, context: str) -> list[object]:
+    if not isinstance(value, list):
+        raise RuntimeError(f"Expected {context} to be a list")
+    return value
+
+
+def _as_string(value: object, context: str) -> str:
+    if not isinstance(value, str):
+        raise RuntimeError(f"Expected {context} to be a string")
+    return value
+
+
+def _as_int(value: object, context: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise RuntimeError(f"Expected {context} to be an integer")
+    return value
+
+
+def _post_graphql(*, endpoint: str, authorization: str, query: str, variables: dict[str, object]) -> dict[str, object]:
+    request = Request(
+        endpoint,
+        data=json.dumps({"query": query, "variables": variables}).encode(),
+        headers={"Authorization": authorization, "Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urlopen(request, timeout=30) as response:
+            decoded: object = json.loads(response.read())
+    except HTTPError as exc:
+        response_body = exc.read().decode(errors="replace")[:2000]
+        raise RuntimeError(f"GraphQL request failed with HTTP {exc.code}: {response_body}") from exc
+    except (URLError, TimeoutError) as exc:
+        raise RuntimeError(f"GraphQL request failed: {exc}") from exc
+
+    payload = _as_object(decoded, "GraphQL response")
+    errors = payload.get("errors")
+    if errors:
+        raise RuntimeError(f"GraphQL returned errors: {json.dumps(errors)}")
+    return _as_object(payload.get("data"), "GraphQL data")
+
+
+class _GitHubClient:
+    def __init__(self, *, token: str, owner: str, repository: str) -> None:
+        self._authorization = f"Bearer {token}"
+        self._owner = owner
+        self._repository = repository
+
+    def pull_requests(self, number: int | None) -> list[_PullRequest]:
+        if number is not None:
+            pull_request = self._pull_request(number)
+            return [pull_request] if pull_request is not None else []
+        return self._open_pull_requests()
+
+    def _pull_request(self, number: int) -> _PullRequest | None:
+        query = """
+        query PullRequest($owner: String!, $repository: String!, $number: Int!) {
+          repository(owner: $owner, name: $repository) {
+            pullRequest(number: $number) {
+              number
+              url
+              closingIssuesReferences(first: 10) { nodes { url } }
+            }
+          }
+        }
+        """
+        data = _post_graphql(
+            endpoint=_GITHUB_GRAPHQL_URL,
+            authorization=self._authorization,
+            query=query,
+            variables={"owner": self._owner, "repository": self._repository, "number": number},
+        )
+        repository = _as_object(data.get("repository"), "GitHub repository")
+        payload = repository.get("pullRequest")
+        return None if payload is None else self._parse_pull_request(payload)
+
+    def _open_pull_requests(self) -> list[_PullRequest]:
+        query = """
+        query PullRequests($owner: String!, $repository: String!, $cursor: String) {
+          repository(owner: $owner, name: $repository) {
+            pullRequests(first: 50, after: $cursor, states: OPEN, orderBy: {field: UPDATED_AT, direction: DESC}) {
+              nodes {
+                number
+                url
+                closingIssuesReferences(first: 10) { nodes { url } }
+              }
+              pageInfo { hasNextPage endCursor }
+            }
+          }
+        }
+        """
+        cursor: str | None = None
+        pull_requests: list[_PullRequest] = []
+        while True:
+            data = _post_graphql(
+                endpoint=_GITHUB_GRAPHQL_URL,
+                authorization=self._authorization,
+                query=query,
+                variables={"owner": self._owner, "repository": self._repository, "cursor": cursor},
+            )
+            repository = _as_object(data.get("repository"), "GitHub repository")
+            connection = _as_object(repository.get("pullRequests"), "GitHub pull request connection")
+            pull_requests.extend(
+                self._parse_pull_request(node) for node in _as_list(connection.get("nodes"), "PR nodes")
+            )
+
+            page_info = _as_object(connection.get("pageInfo"), "GitHub page info")
+            if page_info.get("hasNextPage") is not True:
+                return pull_requests
+            cursor = _as_string(page_info.get("endCursor"), "GitHub end cursor")
+
+    @staticmethod
+    def _parse_pull_request(payload: object) -> _PullRequest:
+        pull_request = _as_object(payload, "GitHub pull request")
+        references = _as_object(pull_request.get("closingIssuesReferences"), "closing issue references")
+        issue_urls = {
+            _as_string(_as_object(node, "closing issue").get("url"), "closing issue URL")
+            for node in _as_list(references.get("nodes"), "closing issue nodes")
+        }
+        return _PullRequest(
+            number=_as_int(pull_request.get("number"), "pull request number"),
+            url=_as_string(pull_request.get("url"), "pull request URL"),
+            closing_issue_urls=tuple(sorted(issue_urls)),
+        )
+
+
+class _LinearClient:
+    def __init__(self, *, token: str, team_key: str) -> None:
+        self._authorization = token
+        self._team_key = team_key
+        self._issue_cache: dict[str, tuple[_LinearIssue, ...]] = {}
+
+    def issues_for_github_url(self, url: str) -> tuple[_LinearIssue, ...]:
+        cached = self._issue_cache.get(url)
+        if cached is not None:
+            return cached
+
+        query = """
+        query AttachmentsForURL($url: String!) {
+          attachmentsForURL(url: $url, first: 50) {
+            nodes { issue { id identifier team { key } } }
+          }
+        }
+        """
+        data = _post_graphql(
+            endpoint=_LINEAR_GRAPHQL_URL,
+            authorization=self._authorization,
+            query=query,
+            variables={"url": url},
+        )
+        connection = _as_object(data.get("attachmentsForURL"), "Linear attachment connection")
+        issues: dict[str, _LinearIssue] = {}
+        for node in _as_list(connection.get("nodes"), "Linear attachment nodes"):
+            attachment = _as_object(node, "Linear attachment")
+            issue = _as_object(attachment.get("issue"), "Linear issue")
+            team = _as_object(issue.get("team"), "Linear team")
+            if _as_string(team.get("key"), "Linear team key") != self._team_key:
+                continue
+            linear_issue = _LinearIssue(
+                id=_as_string(issue.get("id"), "Linear issue ID"),
+                identifier=_as_string(issue.get("identifier"), "Linear issue identifier"),
+            )
+            issues[linear_issue.id] = linear_issue
+
+        result = tuple(sorted(issues.values(), key=lambda issue: issue.identifier))
+        self._issue_cache[url] = result
+        return result
+
+    def link_pull_request(self, *, issue: _LinearIssue, pull_request_url: str) -> None:
+        mutation = """
+        mutation LinkGitHubPR($issueId: String!, $url: String!) {
+          attachmentLinkGitHubPR(issueId: $issueId, url: $url, linkKind: closes) {
+            success
+            attachment { id }
+          }
+        }
+        """
+        data = _post_graphql(
+            endpoint=_LINEAR_GRAPHQL_URL,
+            authorization=self._authorization,
+            query=mutation,
+            variables={"issueId": issue.id, "url": pull_request_url},
+        )
+        payload = _as_object(data.get("attachmentLinkGitHubPR"), "Linear link payload")
+        if payload.get("success") is not True:
+            raise RuntimeError(f"Linear did not link {pull_request_url} to {issue.identifier}")
+
+
+def _sync_pull_requests(
+    pull_requests: list[_PullRequest], linear: _LinearClient, *, dry_run: bool = False
+) -> _SyncStats:
+    stats = _SyncStats()
+    for pull_request in pull_requests:
+        stats.scanned += 1
+        if not pull_request.closing_issue_urls:
+            continue
+
+        existing_issue_ids = {issue.id for issue in linear.issues_for_github_url(pull_request.url)}
+        for github_issue_url in pull_request.closing_issue_urls:
+            linear_issues = linear.issues_for_github_url(github_issue_url)
+            if not linear_issues:
+                stats.unmapped += 1
+                _LOGGER.info("No synced Linear issue for %s", github_issue_url)
+                continue
+
+            for linear_issue in linear_issues:
+                if linear_issue.id in existing_issue_ids:
+                    stats.existing += 1
+                    continue
+                if dry_run:
+                    _LOGGER.info("Would link PR #%d to %s", pull_request.number, linear_issue.identifier)
+                    stats.planned += 1
+                else:
+                    linear.link_pull_request(issue=linear_issue, pull_request_url=pull_request.url)
+                    _LOGGER.info("Linked PR #%d to %s", pull_request.number, linear_issue.identifier)
+                    stats.linked += 1
+                existing_issue_ids.add(linear_issue.id)
+    return stats
+
+
+def _parse_repository(value: str) -> tuple[str, str]:
+    parts = value.split("/")
+    if len(parts) != 2 or not all(parts):
+        raise ValueError(f"Repository must have OWNER/NAME form, got {value!r}")
+    return parts[0], parts[1]
+
+
+def _required_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f"Required environment variable {name} is not set")
+    return value
+
+
+def main() -> None:
+    """Synchronize GitHub Development-linked PRs into native Linear attachments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pr-number", type=int, help="Only synchronize one pull request")
+    parser.add_argument("--dry-run", action="store_true", help="Report missing links without creating them")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    owner, repository = _parse_repository(_required_env("GITHUB_REPOSITORY"))
+    github = _GitHubClient(token=_required_env("GITHUB_TOKEN"), owner=owner, repository=repository)
+    linear = _LinearClient(token=_required_env("LINEAR_API_KEY"), team_key=os.environ.get("LINEAR_TEAM_KEY", "AM"))
+    stats = _sync_pull_requests(github.pull_requests(args.pr_number), linear, dry_run=args.dry_run)
+    _LOGGER.info(
+        "Scanned %d PRs: linked=%d planned=%d existing=%d unmapped=%d",
+        stats.scanned,
+        stats.linked,
+        stats.planned,
+        stats.existing,
+        stats.unmapped,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/sync-linear-development-links.yml
+++ b/.github/workflows/sync-linear-development-links.yml
@@ -1,0 +1,54 @@
+name: Sync GitHub Development links to Linear
+
+on:
+  pull_request_target:
+    types: [opened, reopened, edited, synchronize, ready_for_review, closed]
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Optional pull request number; omit to scan all open pull requests
+        required: false
+        type: number
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+concurrency:
+  group: sync-linear-development-links
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    if: github.repository == 'NVIDIA-NeMo/Automodel'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GITHUB_REPOSITORY: ${{ github.repository }}
+      GITHUB_TOKEN: ${{ github.token }}
+      LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+      LINEAR_TEAM_KEY: AM
+      EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+      INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+    steps:
+      - name: Check out trusted automation code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+          sparse-checkout: .github/scripts/sync_linear_development_links.py
+          sparse-checkout-cone-mode: false
+
+      - name: Sync linked pull requests
+        shell: bash
+        run: |
+          args=()
+          if [[ "$INPUT_PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+            args+=(--pr-number "$INPUT_PR_NUMBER")
+          elif [[ "$EVENT_PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+            args+=(--pr-number "$EVENT_PR_NUMBER")
+          fi
+          python3 .github/scripts/sync_linear_development_links.py "${args[@]}"

--- a/tests/unit_tests/ci/test_sync_linear_development_links.py
+++ b/tests/unit_tests/ci/test_sync_linear_development_links.py
@@ -1,0 +1,123 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT_PATH = Path(__file__).parents[3] / ".github" / "scripts" / "sync_linear_development_links.py"
+_SPEC = importlib.util.spec_from_file_location("sync_linear_development_links", _SCRIPT_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+_SYNC = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = _SYNC
+_SPEC.loader.exec_module(_SYNC)
+
+
+class _FakeLinearClient:
+    def __init__(self, issues_by_url):
+        self.issues_by_url = issues_by_url
+        self.links = []
+
+    def issues_for_github_url(self, url):
+        return self.issues_by_url.get(url, ())
+
+    def link_pull_request(self, *, issue, pull_request_url):
+        self.links.append((issue.identifier, pull_request_url))
+
+
+def test_sync_links_missing_development_attachment():
+    pull_request_url = "https://github.com/NVIDIA-NeMo/Automodel/pull/2929"
+    github_issue_url = "https://github.com/NVIDIA-NeMo/Automodel/issues/2870"
+    linear_issue = _SYNC._LinearIssue(id="linear-584", identifier="AM-584")
+    linear = _FakeLinearClient({pull_request_url: (), github_issue_url: (linear_issue,)})
+
+    stats = _SYNC._sync_pull_requests(
+        [_SYNC._PullRequest(number=2929, url=pull_request_url, closing_issue_urls=(github_issue_url,))], linear
+    )
+
+    assert linear.links == [("AM-584", pull_request_url)]
+    assert stats.scanned == 1
+    assert stats.linked == 1
+    assert stats.planned == 0
+    assert stats.existing == 0
+    assert stats.unmapped == 0
+
+
+def test_sync_is_idempotent_and_skips_unsynced_github_issues():
+    pull_request_url = "https://github.com/NVIDIA-NeMo/Automodel/pull/2929"
+    mapped_issue_url = "https://github.com/NVIDIA-NeMo/Automodel/issues/2870"
+    unmapped_issue_url = "https://github.com/NVIDIA-NeMo/Automodel/issues/9999"
+    linear_issue = _SYNC._LinearIssue(id="linear-584", identifier="AM-584")
+    linear = _FakeLinearClient(
+        {pull_request_url: (linear_issue,), mapped_issue_url: (linear_issue,), unmapped_issue_url: ()}
+    )
+
+    stats = _SYNC._sync_pull_requests(
+        [
+            _SYNC._PullRequest(
+                number=2929,
+                url=pull_request_url,
+                closing_issue_urls=(mapped_issue_url, unmapped_issue_url),
+            )
+        ],
+        linear,
+    )
+
+    assert linear.links == []
+    assert stats.linked == 0
+    assert stats.planned == 0
+    assert stats.existing == 1
+    assert stats.unmapped == 1
+
+
+def test_parse_pull_request_deduplicates_issue_urls():
+    payload = {
+        "number": 2929,
+        "url": "https://github.com/NVIDIA-NeMo/Automodel/pull/2929",
+        "closingIssuesReferences": {
+            "nodes": [
+                {"url": "https://github.com/NVIDIA-NeMo/Automodel/issues/2870"},
+                {"url": "https://github.com/NVIDIA-NeMo/Automodel/issues/2870"},
+            ]
+        },
+    }
+
+    pull_request = _SYNC._GitHubClient._parse_pull_request(payload)
+
+    assert pull_request.closing_issue_urls == ("https://github.com/NVIDIA-NeMo/Automodel/issues/2870",)
+
+
+def test_dry_run_reports_planned_link_without_mutating_linear():
+    pull_request_url = "https://github.com/NVIDIA-NeMo/Automodel/pull/2929"
+    github_issue_url = "https://github.com/NVIDIA-NeMo/Automodel/issues/2870"
+    linear_issue = _SYNC._LinearIssue(id="linear-584", identifier="AM-584")
+    linear = _FakeLinearClient({pull_request_url: (), github_issue_url: (linear_issue,)})
+
+    stats = _SYNC._sync_pull_requests(
+        [_SYNC._PullRequest(number=2929, url=pull_request_url, closing_issue_urls=(github_issue_url,))],
+        linear,
+        dry_run=True,
+    )
+
+    assert linear.links == []
+    assert stats.linked == 0
+    assert stats.planned == 1
+
+
+@pytest.mark.parametrize("value", ["Automodel", "NVIDIA-NeMo/Automodel/extra", "/Automodel"])
+def test_parse_repository_rejects_invalid_values(value):
+    with pytest.raises(ValueError, match="OWNER/NAME"):
+        _SYNC._parse_repository(value)


### PR DESCRIPTION
# What does this PR do ?

Automatically mirrors pull requests linked through a GitHub issue's Development sidebar onto the issue's synced Linear counterpart.

GitHub records a manual Development link as a `ConnectedEvent`, but that event does not trigger GitHub Actions and is not propagated by Linear's GitHub Issues Sync. This left the pull request invisible on the synced Linear issue unless its branch, title, or description independently named the Linear issue.

# Changelog

- Add an idempotent bridge that resolves GitHub issue URLs through Linear's `attachmentsForURL` query and creates native `attachmentLinkGitHubPR` attachments.
- Run on normal pull-request lifecycle events and every 15 minutes to catch Development-sidebar links, which have no Actions trigger.
- Restrict matching to the `AM` Linear team and preserve GitHub's closing semantics.
- Use read-only GitHub permissions, trusted default-branch automation code, an immutable checkout action revision, concurrency control, and a bounded timeout.
- Add focused unit coverage for linking, idempotency, dry-run behavior, unmapped issues, URL deduplication, and repository validation.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines and repository CI guidance.
- [x] Added focused CPU unit tests.
- [x] Documentation is not needed; the workflow is repository-internal.

Validation:

- `uv run pytest -q tests/unit_tests/ci/test_sync_linear_development_links.py` (`7 passed`)
- `uv run ruff format --check` and `uv run ruff check` on the new Python files
- `actionlint` v1.7.12 on the new workflow
- Live targeted dry-run confirmed the repaired example is idempotent
- Live repository-wide dry-run scanned 171 open PRs and found 17 missing AM attachments, 1 existing attachment, and 2 GitHub issues without synced Linear counterparts

# Additional Information

- The encrypted repository Actions secret `LINEAR_API_KEY` is configured.
- The first scheduled run after merge will backfill the 17 currently missing open-PR attachments.
