### PR TITLE
refactor(recipes): add typed tokenizer construction

### DIFF
--- a/examples/retrieval/bi_encoder/llama3_2_1b.yaml
+++ b/examples/retrieval/bi_encoder/llama3_2_1b.yaml
@@ -44,7 +44,7 @@ model:
   do_distributed_inbatch_negative: false
 
 tokenizer:
-  _target_: nemo_automodel.NeMoAutoTokenizer.from_pretrained
+  _target_: nemo_automodel.NeMoAutoTokenizer.Config
   pretrained_model_name_or_path: meta-llama/Llama-3.2-1B
   add_eos_token: false
 

--- a/examples/retrieval/bi_encoder/llama_embed_nemotron_8b/llama_embed_nemotron_8b.yaml
+++ b/examples/retrieval/bi_encoder/llama_embed_nemotron_8b/llama_embed_nemotron_8b.yaml
@@ -36,8 +36,9 @@ model:
   torch_dtype: bfloat16
 
 tokenizer:
-  _target_: transformers.AutoTokenizer.from_pretrained
+  _target_: nemo_automodel.NeMoAutoTokenizer.Config
   pretrained_model_name_or_path: meta-llama/Llama-3.1-8B
+  force_hf: true
 
 dataset:
   _target_: nemo_automodel.components.datasets.llm.retrieval_dataset.RetrievalDatasetConfig

--- a/examples/retrieval/bi_encoder/ministral3_3b_instruct.yaml
+++ b/examples/retrieval/bi_encoder/ministral3_3b_instruct.yaml
@@ -48,7 +48,7 @@ model:
   extract_submodel: language_model
 
 tokenizer:
-  _target_: nemo_automodel.NeMoAutoTokenizer.from_pretrained
+  _target_: nemo_automodel.NeMoAutoTokenizer.Config
   pretrained_model_name_or_path: mistralai/Ministral-3-3B-Instruct-2512
   add_eos_token: false
   padding_side: left

--- a/examples/retrieval/bi_encoder/nemotron_vl_1b/nemotron_vl_1b_example.yaml
+++ b/examples/retrieval/bi_encoder/nemotron_vl_1b/nemotron_vl_1b_example.yaml
@@ -47,7 +47,7 @@ model:
   detach_distributed_inbatch_negatives: false
 
 tokenizer:
-  _target_: nemo_automodel.components.models.llama_nemotron_vl.processor.LlamaNemotronVLProcessor.from_pretrained
+  _target_: nemo_automodel.components.models.llama_nemotron_vl.processor.LlamaNemotronVLProcessor.Config
   pretrained_model_name_or_path: nvidia/llama-nemotron-embed-vl-1b-v2
   q_max_length: 512
   p_max_length: 4096

--- a/examples/retrieval/cross_encoder/llama3_2_1b.yaml
+++ b/examples/retrieval/cross_encoder/llama3_2_1b.yaml
@@ -42,7 +42,7 @@ model:
   torch_dtype: bfloat16
 
 tokenizer:
-  _target_: nemo_automodel.NeMoAutoTokenizer.from_pretrained
+  _target_: nemo_automodel.NeMoAutoTokenizer.Config
   pretrained_model_name_or_path: meta-llama/Llama-3.2-1B
   add_eos_token: false
 

--- a/nemo_automodel/_transformers/auto_processor.py
+++ b/nemo_automodel/_transformers/auto_processor.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Typed Hugging Face processor construction."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from transformers import AutoProcessor as TransformersAutoProcessor
+from transformers import ProcessorMixin
+
+
+class AutoProcessor:
+    """Auto processor factory with implementation-owned configuration."""
+
+    @dataclass(frozen=True, kw_only=True)
+    class Config:
+        """Declarative configuration for Hugging Face ``AutoProcessor``."""
+
+        pretrained_model_name_or_path: str
+        trust_remote_code: bool = False
+        min_pixels: int | None = None
+        max_pixels: int | None = None
+        padding_side: Literal["left", "right"] | None = None
+
+        def build(self) -> ProcessorMixin:
+            """Build the configured processor without mutating config state."""
+            processor_kwargs: dict[str, object] = {}
+            if self.min_pixels is not None:
+                processor_kwargs["min_pixels"] = self.min_pixels
+            if self.max_pixels is not None:
+                processor_kwargs["max_pixels"] = self.max_pixels
+            if self.padding_side is not None:
+                processor_kwargs["padding_side"] = self.padding_side
+            return TransformersAutoProcessor.from_pretrained(
+                pretrained_model_name_or_path=self.pretrained_model_name_or_path,
+                trust_remote_code=self.trust_remote_code,
+                **processor_kwargs,
+            )
+
+
+__all__ = ["AutoProcessor"]

--- a/nemo_automodel/_transformers/auto_tokenizer.py
+++ b/nemo_automodel/_transformers/auto_tokenizer.py
@@ -13,7 +13,11 @@
 # limitations under the License.
 
 import logging
-from typing import Callable, Optional, Type, Union
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Callable, Literal, Optional, Type, Union
+
+if TYPE_CHECKING:
+    from transformers import PreTrainedTokenizerBase
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +72,51 @@ class NeMoAutoTokenizer:
 
     # Make registry accessible at class level
     _registry = None
+
+    @dataclass(frozen=True, kw_only=True)
+    class Config:
+        """Declarative configuration for :class:`NeMoAutoTokenizer`."""
+
+        pretrained_model_name_or_path: str
+        trust_remote_code: bool = False
+        force_default: bool = False
+        force_hf: bool = False
+        add_eos_token: bool | None = None
+        padding_side: Literal["left", "right"] | None = None
+
+        def build(self) -> "PreTrainedTokenizerBase":
+            """Build the configured tokenizer without mutating config state."""
+            if self.add_eos_token is not None and self.padding_side is not None:
+                return NeMoAutoTokenizer.from_pretrained(
+                    pretrained_model_name_or_path=self.pretrained_model_name_or_path,
+                    trust_remote_code=self.trust_remote_code,
+                    force_default=self.force_default,
+                    force_hf=self.force_hf,
+                    add_eos_token=self.add_eos_token,
+                    padding_side=self.padding_side,
+                )
+            if self.add_eos_token is not None:
+                return NeMoAutoTokenizer.from_pretrained(
+                    pretrained_model_name_or_path=self.pretrained_model_name_or_path,
+                    trust_remote_code=self.trust_remote_code,
+                    force_default=self.force_default,
+                    force_hf=self.force_hf,
+                    add_eos_token=self.add_eos_token,
+                )
+            if self.padding_side is not None:
+                return NeMoAutoTokenizer.from_pretrained(
+                    pretrained_model_name_or_path=self.pretrained_model_name_or_path,
+                    trust_remote_code=self.trust_remote_code,
+                    force_default=self.force_default,
+                    force_hf=self.force_hf,
+                    padding_side=self.padding_side,
+                )
+            return NeMoAutoTokenizer.from_pretrained(
+                pretrained_model_name_or_path=self.pretrained_model_name_or_path,
+                trust_remote_code=self.trust_remote_code,
+                force_default=self.force_default,
+                force_hf=self.force_hf,
+            )
 
     @classmethod
     def register(cls, model_type: str, tokenizer_cls: Union[Type, Callable]) -> None:

--- a/nemo_automodel/_transformers/tokenizer_config.py
+++ b/nemo_automodel/_transformers/tokenizer_config.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Typed tokenizer and processor construction."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+
+from transformers import PreTrainedTokenizerBase, ProcessorMixin
+
+TokenizerLike = PreTrainedTokenizerBase | ProcessorMixin
+TokenizerFactory = Callable[..., TokenizerLike]
+
+
+@dataclass(frozen=True)
+class TokenizerConfig:
+    """Declarative tokenizer or processor factory configuration.
+
+    ``factory=None`` represents an explicitly disabled tokenizer. Factory
+    keyword arguments are copied at build time so the serializable config is
+    never mutated or used to cache the runtime object.
+    """
+
+    factory: TokenizerFactory | None = None
+    kwargs: Mapping[str, object] = field(default_factory=dict)
+
+    def build(self) -> TokenizerLike | None:
+        """Build the configured tokenizer or processor.
+
+        Returns:
+            A tokenizer or multimodal processor, or ``None`` when construction
+            is disabled.
+        """
+        if self.factory is None:
+            return None
+        return self.factory(**dict(self.kwargs))
+
+
+__all__ = ["TokenizerConfig", "TokenizerFactory", "TokenizerLike"]

--- a/nemo_automodel/_transformers/tokenizer_config.py
+++ b/nemo_automodel/_transformers/tokenizer_config.py
@@ -12,41 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Typed tokenizer and processor construction."""
+"""Typed tokenizer and processor construction contracts."""
 
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
-from dataclasses import dataclass, field
+from typing import Protocol
 
 from transformers import PreTrainedTokenizerBase, ProcessorMixin
 
 TokenizerLike = PreTrainedTokenizerBase | ProcessorMixin
-TokenizerFactory = Callable[..., TokenizerLike]
 
 
-@dataclass(frozen=True)
-class TokenizerConfig:
-    """Declarative tokenizer or processor factory configuration.
+class TokenizerConfig(Protocol):
+    """Construction contract implemented by tokenizer and processor configs."""
 
-    ``factory=None`` represents an explicitly disabled tokenizer. Factory
-    keyword arguments are copied at build time so the serializable config is
-    never mutated or used to cache the runtime object.
-    """
-
-    factory: TokenizerFactory | None = None
-    kwargs: Mapping[str, object] = field(default_factory=dict)
-
-    def build(self) -> TokenizerLike | None:
+    def build(self) -> TokenizerLike:
         """Build the configured tokenizer or processor.
 
         Returns:
-            A tokenizer or multimodal processor, or ``None`` when construction
-            is disabled.
+            A tokenizer or multimodal processor.
         """
-        if self.factory is None:
-            return None
-        return self.factory(**dict(self.kwargs))
 
 
-__all__ = ["TokenizerConfig", "TokenizerFactory", "TokenizerLike"]
+__all__ = ["TokenizerConfig", "TokenizerLike"]

--- a/nemo_automodel/components/models/llama_nemotron_vl/processor.py
+++ b/nemo_automodel/components/models/llama_nemotron_vl/processor.py
@@ -293,6 +293,28 @@ class LlamaNemotronVLProcessor(ProcessorMixin):
     attributes = ["tokenizer"]
     tokenizer_class = "AutoTokenizer"
 
+    @dataclasses.dataclass(frozen=True, kw_only=True)
+    class Config:
+        """Declarative configuration for :class:`LlamaNemotronVLProcessor`."""
+
+        pretrained_model_name_or_path: str
+        q_max_length: int | None = None
+        p_max_length: int | None = None
+        query_prefix: str = "query:"
+        passage_prefix: str = "passage:"
+        max_input_tiles: int = 6
+
+        def build(self) -> "LlamaNemotronVLProcessor":
+            """Build the configured processor without mutating config state."""
+            return LlamaNemotronVLProcessor.from_pretrained(
+                pretrained_model_name_or_path=self.pretrained_model_name_or_path,
+                q_max_length=self.q_max_length,
+                p_max_length=self.p_max_length,
+                query_prefix=self.query_prefix,
+                passage_prefix=self.passage_prefix,
+                max_input_tiles=self.max_input_tiles,
+            )
+
     def __init__(
         self,
         tokenizer: Any,

--- a/nemo_automodel/recipes/_typed_config.py
+++ b/nemo_automodel/recipes/_typed_config.py
@@ -205,10 +205,13 @@ class RecipeConfig:
         return build_optimizer_config(factory, kwargs)
 
     @cached_property
-    def tokenizer(self) -> "TokenizerConfig":
-        """Resolve the recipe's tokenizer or processor factory configuration."""
+    def tokenizer(self) -> "TokenizerConfig | None":
+        """Resolve the recipe's implementation-owned tokenizer or processor config."""
+        from transformers import AutoProcessor as TransformersAutoProcessor
+        from transformers import AutoTokenizer as TransformersAutoTokenizer
+
+        from nemo_automodel._transformers.auto_processor import AutoProcessor
         from nemo_automodel._transformers.auto_tokenizer import NeMoAutoTokenizer
-        from nemo_automodel._transformers.tokenizer_config import TokenizerConfig
 
         dataset_node = self._raw.get("dataset", None)
         dataset_has_tokenizer = dataset_node is not None and "tokenizer" in _as_dict(dataset_node)
@@ -223,26 +226,39 @@ class RecipeConfig:
         else:
             model_name = _model_name_from_cfg(self._raw.get("model", None))
             if model_name is None:
-                return TokenizerConfig()
-            return TokenizerConfig(
-                factory=NeMoAutoTokenizer.from_pretrained,
-                kwargs={
-                    "pretrained_model_name_or_path": model_name,
-                    "trust_remote_code": _trust_remote_code_from_model(self._raw.get("model", None)),
-                },
+                return None
+            return NeMoAutoTokenizer.Config(
+                pretrained_model_name_or_path=model_name,
+                trust_remote_code=_trust_remote_code_from_model(self._raw.get("model", None)),
             )
 
         if node is None:
-            return TokenizerConfig()
+            return None
 
         kwargs = _as_dict(node)
         target = kwargs.pop("_target_", None)
-        factory = NeMoAutoTokenizer.from_pretrained if target is None else target
-        if not callable(factory):
-            raise TypeError(f"Tokenizer _target_ must resolve to a callable, got {factory!r}")
         if inject_model_trust:
             kwargs.setdefault("trust_remote_code", _trust_remote_code_from_model(self._raw.get("model", None)))
-        return TokenizerConfig(factory=factory, kwargs=kwargs)
+
+        if target is None or target == NeMoAutoTokenizer.from_pretrained:
+            return NeMoAutoTokenizer.Config(**kwargs)
+        if target == TransformersAutoTokenizer.from_pretrained:
+            kwargs["force_hf"] = True
+            return NeMoAutoTokenizer.Config(**kwargs)
+        if target == TransformersAutoProcessor.from_pretrained:
+            return AutoProcessor.Config(**kwargs)
+
+        owner = getattr(target, "__self__", None)
+        config_cls = getattr(owner, "Config", None)
+        if isinstance(config_cls, type):
+            return config_cls(**kwargs)
+        if isinstance(target, type) and callable(getattr(target, "build", None)):
+            return target(**kwargs)
+        raise TypeError(
+            "Tokenizer _target_ must be NeMoAutoTokenizer.from_pretrained, "
+            "transformers.AutoTokenizer.from_pretrained, transformers.AutoProcessor.from_pretrained, "
+            "or a component whose class exposes a nested Config"
+        )
 
     @cached_property
     def dataloader(self) -> "DataloaderConfig" | None:

--- a/nemo_automodel/recipes/_typed_config.py
+++ b/nemo_automodel/recipes/_typed_config.py
@@ -20,9 +20,9 @@ recipe body only ever sees typed component configs and calls
 ``self.cfg.<section>.build(...)`` directly.
 
 Known sections are exposed as cached, typed attributes that own a ``build()`` or
-``apply()``: ``wandb``/``mlflow``/``step_scheduler``/``lr_scheduler``/``prewarm``/
-``embedding_row_repair`` map to component config dataclasses; the ``optimizer``
-and ``loss_fn`` blocks resolve to a component
+``apply()``: ``wandb``/``mlflow``/``tokenizer``/``step_scheduler``/``lr_scheduler``/
+``prewarm``/``embedding_row_repair`` map to component config dataclasses; the
+``optimizer`` and ``loss_fn`` blocks resolve to a component
 :class:`~nemo_automodel.components.optim.optimizer.OptimizerConfig` /
 :class:`~nemo_automodel.components.loss.loss.LossConfig` via
 ``build_optimizer_config`` / ``build_loss_config`` (which own a ``build()``),
@@ -51,6 +51,7 @@ from nemo_automodel.components.optim.optimizer import LRSchedulerConfig
 from nemo_automodel.components.training.step_scheduler import StepSchedulerConfig
 
 if TYPE_CHECKING:
+    from nemo_automodel._transformers.tokenizer_config import TokenizerConfig
     from nemo_automodel.components.checkpoint.config import CheckpointingConfig
     from nemo_automodel.components.config.loader import ConfigNode
     from nemo_automodel.components.datasets.diffusion.loader import DiffusionDataloaderConfig
@@ -66,6 +67,7 @@ if TYPE_CHECKING:
 # Keys present in the YAML ``step_scheduler:`` block that are runtime args passed
 # to ``StepSchedulerConfig.build(...)`` separately (not config fields).
 _STEP_SCHEDULER_RUNTIME_KEYS = ("local_batch_size", "dp_size", "dataloader")
+_MISSING = object()
 
 
 def _section_kwargs(node: Any) -> dict[str, Any]:
@@ -116,6 +118,8 @@ def _target_kwargs(node: Any) -> tuple[Any, dict[str, Any]]:
 
 
 def _model_name_from_cfg(cfg_model: Any) -> str | None:
+    if cfg_model is None:
+        return None
     pretrained = cfg_model.get("pretrained_model_name_or_path", None)
     if pretrained is not None:
         return pretrained
@@ -127,11 +131,31 @@ def _model_name_from_cfg(cfg_model: Any) -> str | None:
     return None
 
 
+def _trust_remote_code_from_model(cfg_model: Any) -> bool:
+    """Resolve the tokenizer's remote-code policy from the model config."""
+    if cfg_model is None:
+        return False
+
+    direct = cfg_model.get("trust_remote_code", _MISSING)
+    if direct is not _MISSING:
+        return bool(direct)
+
+    nested = cfg_model.get("config", None)
+    if nested is not None and not isinstance(nested, str):
+        nested_value = nested.get("trust_remote_code", _MISSING)
+        if nested_value is not _MISSING:
+            return bool(nested_value)
+
+    from nemo_automodel.components.utils.model_utils import resolve_trust_remote_code
+
+    return resolve_trust_remote_code(_model_name_from_cfg(cfg_model))
+
+
 class RecipeConfig:
     """Typed view over the YAML config consumed by recipes.
 
-    ``wandb``, ``mlflow``, ``step_scheduler``, ``lr_scheduler``, ``optimizer``,
-    ``loss_fn`` and ``checkpoint`` are exposed as typed objects that own a
+    ``wandb``, ``mlflow``, ``tokenizer``, ``step_scheduler``, ``lr_scheduler``,
+    ``optimizer``, ``loss_fn`` and ``checkpoint`` are exposed as typed objects that own a
     ``.build(...)`` (``optimizer`` is an
     :class:`~nemo_automodel.components.optim.optimizer.OptimizerConfig`,
     ``checkpoint`` a
@@ -179,6 +203,46 @@ class RecipeConfig:
             return None
         factory, kwargs = _callable_and_kwargs(node)
         return build_optimizer_config(factory, kwargs)
+
+    @cached_property
+    def tokenizer(self) -> "TokenizerConfig":
+        """Resolve the recipe's tokenizer or processor factory configuration."""
+        from nemo_automodel._transformers.auto_tokenizer import NeMoAutoTokenizer
+        from nemo_automodel._transformers.tokenizer_config import TokenizerConfig
+
+        dataset_node = self._raw.get("dataset", None)
+        dataset_has_tokenizer = dataset_node is not None and "tokenizer" in _as_dict(dataset_node)
+        raw_has_tokenizer = "tokenizer" in self._raw.to_dict()
+
+        if dataset_has_tokenizer:
+            node = dataset_node.get("tokenizer", None)
+            inject_model_trust = True
+        elif raw_has_tokenizer:
+            node = self._raw.get("tokenizer", None)
+            inject_model_trust = False
+        else:
+            model_name = _model_name_from_cfg(self._raw.get("model", None))
+            if model_name is None:
+                return TokenizerConfig()
+            return TokenizerConfig(
+                factory=NeMoAutoTokenizer.from_pretrained,
+                kwargs={
+                    "pretrained_model_name_or_path": model_name,
+                    "trust_remote_code": _trust_remote_code_from_model(self._raw.get("model", None)),
+                },
+            )
+
+        if node is None:
+            return TokenizerConfig()
+
+        kwargs = _as_dict(node)
+        target = kwargs.pop("_target_", None)
+        factory = NeMoAutoTokenizer.from_pretrained if target is None else target
+        if not callable(factory):
+            raise TypeError(f"Tokenizer _target_ must resolve to a callable, got {factory!r}")
+        if inject_model_trust:
+            kwargs.setdefault("trust_remote_code", _trust_remote_code_from_model(self._raw.get("model", None)))
+        return TokenizerConfig(factory=factory, kwargs=kwargs)
 
     @cached_property
     def dataloader(self) -> "DataloaderConfig" | None:

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -26,7 +26,6 @@ except ImportError:
     pass
 
 import gc
-import inspect
 import logging
 import pathlib
 import time
@@ -42,7 +41,6 @@ from huggingface_hub import constants as hf_constants
 from torchao.float8 import precompute_float8_dynamic_scale_for_fsdp
 
 from nemo_automodel._transformers import NeMoAutoModelForCausalLM, NeMoAutoModelForSequenceClassification
-from nemo_automodel._transformers.auto_tokenizer import NeMoAutoTokenizer
 from nemo_automodel._transformers.capabilities import ModelSupports
 from nemo_automodel._transformers.infrastructure import (
     apply_model_infrastructure,
@@ -89,7 +87,6 @@ from nemo_automodel.components.utils.flops_utils import calculate_mfu
 from nemo_automodel.components.utils.model_utils import (
     _supports_logits_to_keep,
     filter_forward_kwargs,
-    resolve_trust_remote_code,
 )
 from nemo_automodel.recipes._dist_utils import create_distributed_setup_from_config, shard_optimizers_for_megatron_fsdp
 from nemo_automodel.recipes._typed_config import RecipeConfig
@@ -304,51 +301,6 @@ def build_model(
         logging.info(f"Unfroze parameters matching: {unfreeze_modules}")
 
     return model
-
-
-def compute_trust_remote_code_from_model(cfg_model):
-    """Compute the value of trust_remote_code based on the model configuration.
-
-    Args:
-        cfg_model (ConfigNode): Model configuration.
-
-    Returns:
-        bool: Whether to trust remote code.
-    """
-    if hasattr(cfg_model, "trust_remote_code"):
-        return getattr(cfg_model, "trust_remote_code")
-    elif hasattr(cfg_model, "config") and hasattr(cfg_model.config, "trust_remote_code"):
-        return getattr(cfg_model.config, "trust_remote_code")
-    return resolve_trust_remote_code(_get_model_name(cfg_model))
-
-
-def _build_tokenizer(cfg_model, cfg_ds):
-    trust_remote_code = compute_trust_remote_code_from_model(cfg_model)
-    # if tokenizer is not provided, use the model config to instantiate it
-    if "tokenizer" not in cfg_ds and _get_model_name(cfg_model) is not None:
-        logging.info("Using model config to instantiate tokenizer")
-        tokenizer = NeMoAutoTokenizer.from_pretrained(_get_model_name(cfg_model), trust_remote_code=trust_remote_code)
-    elif cfg_ds.get("tokenizer", None) is None:
-        tokenizer = None
-    elif "_target_" not in cfg_ds.tokenizer:
-        tokenizer_dict = cfg_ds.tokenizer.to_dict()
-        trust_remote_code = tokenizer_dict.pop("trust_remote_code", trust_remote_code)
-        tokenizer = NeMoAutoTokenizer.from_pretrained(**tokenizer_dict, trust_remote_code=trust_remote_code)
-    else:
-        trust_remote_code = cfg_ds.tokenizer.to_dict().pop("trust_remote_code", trust_remote_code)
-        tokenizer = cfg_ds.tokenizer.instantiate(trust_remote_code=trust_remote_code)
-
-    # Finally, check if the dataset target accepts a tokenizer parameter
-    kwargs = {}
-    if tokenizer is not None and callable(cfg_ds._target_):
-        try:
-            sig = inspect.signature(cfg_ds._target_)
-            if "tokenizer" in sig.parameters:
-                kwargs["tokenizer"] = tokenizer
-        except (ValueError, TypeError):
-            # If we can't get the signature, skip adding tokenizer
-            pass
-    return kwargs, tokenizer
 
 
 def _build_pp_collate_wrapper(model: nn.Module, pp_enabled: bool) -> Callable[[CollateFn], CollateFn] | None:
@@ -637,9 +589,9 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
                     f"      attn: te"
                 )
 
-        # Tokenizer + model-derived values are runtime concerns: pass them explicitly to each
+        # Model-derived values are runtime concerns: pass them explicitly to each
         # component-owned DataloaderConfig.build().
-        _, self.tokenizer = _build_tokenizer(self.cfg.model, self.cfg.dataset)
+        self.tokenizer = self.cfg.tokenizer.build()
         train_dataloader_config = self.cfg.dataloader
         if train_dataloader_config is None:
             raise ValueError("An LLM recipe requires a dataset configuration")

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -591,7 +591,8 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
 
         # Model-derived values are runtime concerns: pass them explicitly to each
         # component-owned DataloaderConfig.build().
-        self.tokenizer = self.cfg.tokenizer.build()
+        tokenizer_config = self.cfg.tokenizer
+        self.tokenizer = tokenizer_config.build() if tokenizer_config is not None else None
         train_dataloader_config = self.cfg.dataloader
         if train_dataloader_config is None:
             raise ValueError("An LLM recipe requires a dataset configuration")

--- a/nemo_automodel/recipes/llm/train_seq_cls.py
+++ b/nemo_automodel/recipes/llm/train_seq_cls.py
@@ -38,7 +38,6 @@ from nemo_automodel.recipes._dist_utils import create_distributed_setup_from_con
 from nemo_automodel.recipes._typed_config import RecipeConfig
 from nemo_automodel.recipes.base_recipe import BaseRecipe
 from nemo_automodel.recipes.llm.train_ft import (
-    _build_tokenizer,
     _get_model_name,
     build_model,
 )
@@ -126,7 +125,7 @@ class TrainFinetuneRecipeForSequenceClassification(BaseRecipe):
         self.model_parts = [model]
         self.mfu_calculator = AutoMFU.from_config(self.model_parts[0])
 
-        _, self.tokenizer = _build_tokenizer(self.cfg.model, self.cfg.dataset)
+        self.tokenizer = self.cfg.tokenizer.build()
 
         def materialize_loader(config):
             build_context = nullcontext() if config.dataset_builds_on_all_ranks else FirstRankPerNode()

--- a/nemo_automodel/recipes/llm/train_seq_cls.py
+++ b/nemo_automodel/recipes/llm/train_seq_cls.py
@@ -125,7 +125,8 @@ class TrainFinetuneRecipeForSequenceClassification(BaseRecipe):
         self.model_parts = [model]
         self.mfu_calculator = AutoMFU.from_config(self.model_parts[0])
 
-        self.tokenizer = self.cfg.tokenizer.build()
+        tokenizer_config = self.cfg.tokenizer
+        self.tokenizer = tokenizer_config.build() if tokenizer_config is not None else None
 
         def materialize_loader(config):
             build_context = nullcontext() if config.dataset_builds_on_all_ranks else FirstRankPerNode()

--- a/nemo_automodel/recipes/retrieval/train_bi_encoder.py
+++ b/nemo_automodel/recipes/retrieval/train_bi_encoder.py
@@ -24,7 +24,6 @@ from typing import Any
 import torch
 import torch.nn.functional as F
 import wandb
-from transformers import ProcessorMixin
 
 from nemo_automodel._transformers.utils import apply_cache_compatibility_patches
 from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
@@ -291,11 +290,12 @@ class TrainBiEncoderRecipe(BaseRecipe):
             logger=logger,
         )
 
-        # Might be tokenizer or processor (for VLMs)
-        self.tokenizer = self.cfg.tokenizer.instantiate()
-        tokenizer = self.tokenizer.tokenizer if isinstance(self.tokenizer, ProcessorMixin) else self.tokenizer
+        self.tokenizer = self.cfg.tokenizer.build()
+        if self.tokenizer is None:
+            raise ValueError("Retrieval training requires a tokenizer or processor config")
+        tokenizer = getattr(self.tokenizer, "tokenizer", self.tokenizer)
         if tokenizer.pad_token is None:
-            tokenizer.pad_token = self.tokenizer.eos_token
+            tokenizer.pad_token = tokenizer.eos_token
             tokenizer.padding_side = "left"
 
         dataloader_config = self.cfg.dataloader

--- a/nemo_automodel/recipes/retrieval/train_bi_encoder.py
+++ b/nemo_automodel/recipes/retrieval/train_bi_encoder.py
@@ -290,9 +290,10 @@ class TrainBiEncoderRecipe(BaseRecipe):
             logger=logger,
         )
 
-        self.tokenizer = self.cfg.tokenizer.build()
-        if self.tokenizer is None:
+        tokenizer_config = self.cfg.tokenizer
+        if tokenizer_config is None:
             raise ValueError("Retrieval training requires a tokenizer or processor config")
+        self.tokenizer = tokenizer_config.build()
         tokenizer = getattr(self.tokenizer, "tokenizer", self.tokenizer)
         if tokenizer.pad_token is None:
             tokenizer.pad_token = tokenizer.eos_token

--- a/tests/functional_tests/llm_pretrain_and_kd/customizer_retrieval/recipe.yaml
+++ b/tests/functional_tests/llm_pretrain_and_kd/customizer_retrieval/recipe.yaml
@@ -25,7 +25,7 @@ model:
   torch_dtype: bfloat16
 
 tokenizer:
-  _target_: nemo_automodel._transformers.auto_tokenizer.NeMoAutoTokenizer.from_pretrained
+  _target_: nemo_automodel.NeMoAutoTokenizer.Config
   pretrained_model_name_or_path: /home/TestData/automodel/llama-nemotron-embed-1b-v2/
   trust_remote_code: true
 

--- a/tests/functional_tests/llm_pretrain_and_kd/customizer_retrieval/recipe_ckpt_restore.yaml
+++ b/tests/functional_tests/llm_pretrain_and_kd/customizer_retrieval/recipe_ckpt_restore.yaml
@@ -25,7 +25,7 @@ model:
   torch_dtype: bfloat16
 
 tokenizer:
-  _target_: nemo_automodel._transformers.auto_tokenizer.NeMoAutoTokenizer.from_pretrained
+  _target_: nemo_automodel.NeMoAutoTokenizer.Config
   pretrained_model_name_or_path: /home/TestData/automodel/llama-nemotron-embed-1b-v2/
   trust_remote_code: true
 

--- a/tests/functional_tests/llm_pretrain_and_kd/customizer_retrieval/recipe_peft.yaml
+++ b/tests/functional_tests/llm_pretrain_and_kd/customizer_retrieval/recipe_peft.yaml
@@ -32,7 +32,7 @@ peft:
   use_triton: false
 
 tokenizer:
-  _target_: nemo_automodel._transformers.auto_tokenizer.NeMoAutoTokenizer.from_pretrained
+  _target_: nemo_automodel.NeMoAutoTokenizer.Config
   pretrained_model_name_or_path: /home/TestData/automodel/llama-nemotron-embed-1b-v2/
   trust_remote_code: true
 

--- a/tests/functional_tests/retrieval/recipe_cross_encoder.yaml
+++ b/tests/functional_tests/retrieval/recipe_cross_encoder.yaml
@@ -26,7 +26,7 @@ model:
   torch_dtype: bfloat16
 
 tokenizer:
-  _target_: nemo_automodel._transformers.auto_tokenizer.NeMoAutoTokenizer.from_pretrained
+  _target_: nemo_automodel.NeMoAutoTokenizer.Config
   pretrained_model_name_or_path: /home/TestData/automodel/llama-nemotron-embed-1b-v2/
   trust_remote_code: true
 

--- a/tests/functional_tests/training/test_megatron_data_sharding.py
+++ b/tests/functional_tests/training/test_megatron_data_sharding.py
@@ -53,7 +53,10 @@ def test_megatron_data_sharding():
     # Megatron datasets require a tokenizer; the recipe supplies it via runtime (build(tokenizer=...)),
     # so build it here the same way (from the dataset/model config) instead of relying on the default.
     recipe_config = RecipeConfig(cfg)
-    tokenizer = recipe_config.tokenizer.build()
+    tokenizer_config = recipe_config.tokenizer
+    if tokenizer_config is None:
+        raise ValueError("Megatron data sharding test requires a tokenizer config")
+    tokenizer = tokenizer_config.build()
     dataset = recipe_config.dataloader.build(
         dp_rank=dp_rank, dp_world_size=dp_world_size, pp_enabled=False, tokenizer=tokenizer
     )

--- a/tests/functional_tests/training/test_megatron_data_sharding.py
+++ b/tests/functional_tests/training/test_megatron_data_sharding.py
@@ -21,7 +21,6 @@ from nemo_automodel.components.config._arg_parser import parse_args_and_load_con
 from nemo_automodel.components.distributed.init_utils import initialize_distributed
 from nemo_automodel.recipes._dist_utils import create_distributed_setup_from_config
 from nemo_automodel.recipes._typed_config import RecipeConfig
-from nemo_automodel.recipes.llm.train_ft import _build_tokenizer
 
 """
 This test is to make sure that JSONL dataset can be checkpointed and loaded correctly.
@@ -53,8 +52,9 @@ def test_megatron_data_sharding():
         setattr(cfg.step_scheduler, key, value)
     # Megatron datasets require a tokenizer; the recipe supplies it via runtime (build(tokenizer=...)),
     # so build it here the same way (from the dataset/model config) instead of relying on the default.
-    _, tokenizer = _build_tokenizer(cfg.model, cfg.dataset)
-    dataset = RecipeConfig(cfg).dataloader.build(
+    recipe_config = RecipeConfig(cfg)
+    tokenizer = recipe_config.tokenizer.build()
+    dataset = recipe_config.dataloader.build(
         dp_rank=dp_rank, dp_world_size=dp_world_size, pp_enabled=False, tokenizer=tokenizer
     )
 

--- a/tests/functional_tests/training/test_megatron_dataset_checkpoint.py
+++ b/tests/functional_tests/training/test_megatron_dataset_checkpoint.py
@@ -23,7 +23,6 @@ from nemo_automodel.components.config._arg_parser import parse_args_and_load_con
 from nemo_automodel.components.distributed.init_utils import initialize_distributed
 from nemo_automodel.recipes._dist_utils import create_distributed_setup_from_config
 from nemo_automodel.recipes._typed_config import RecipeConfig
-from nemo_automodel.recipes.llm.train_ft import _build_tokenizer
 
 """
 This test is to make sure that JSONL dataset can be checkpointed and loaded correctly.
@@ -75,8 +74,9 @@ def test_megatron_dataset_checkpointing():
         setattr(cfg.step_scheduler, key, value)
     # Megatron datasets require a tokenizer; the recipe supplies it via runtime (build(tokenizer=...)),
     # so build it here the same way (from the dataset/model config) instead of relying on the default.
-    _, tokenizer = _build_tokenizer(cfg.model, cfg.dataset)
-    dataset = RecipeConfig(cfg).dataloader.build(
+    recipe_config = RecipeConfig(cfg)
+    tokenizer = recipe_config.tokenizer.build()
+    dataset = recipe_config.dataloader.build(
         dp_rank=dp_rank, dp_world_size=dp_world_size, pp_enabled=False, tokenizer=tokenizer
     )
 
@@ -105,7 +105,7 @@ def test_megatron_dataset_checkpointing():
         assert os.access(path, os.R_OK), f"Expected {path} to be readable"
         assert path.stat().st_size > 0, f"Expected {path} to be non-empty"
 
-    dataset = RecipeConfig(cfg).dataloader.build(
+    dataset = recipe_config.dataloader.build(
         dp_rank=dp_rank, dp_world_size=dp_world_size, pp_enabled=False, tokenizer=tokenizer
     )
 

--- a/tests/functional_tests/training/test_megatron_dataset_checkpoint.py
+++ b/tests/functional_tests/training/test_megatron_dataset_checkpoint.py
@@ -75,7 +75,10 @@ def test_megatron_dataset_checkpointing():
     # Megatron datasets require a tokenizer; the recipe supplies it via runtime (build(tokenizer=...)),
     # so build it here the same way (from the dataset/model config) instead of relying on the default.
     recipe_config = RecipeConfig(cfg)
-    tokenizer = recipe_config.tokenizer.build()
+    tokenizer_config = recipe_config.tokenizer
+    if tokenizer_config is None:
+        raise ValueError("Megatron dataset checkpoint test requires a tokenizer config")
+    tokenizer = tokenizer_config.build()
     dataset = recipe_config.dataloader.build(
         dp_rank=dp_rank, dp_world_size=dp_world_size, pp_enabled=False, tokenizer=tokenizer
     )

--- a/tests/unit_tests/recipes/test_train_ft.py
+++ b/tests/unit_tests/recipes/test_train_ft.py
@@ -16,6 +16,7 @@ import logging
 import sys
 import types
 from contextlib import AbstractContextManager, nullcontext
+from dataclasses import dataclass
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -154,6 +155,36 @@ class DummyMapDataset(torch.utils.data.Dataset):
 
     def shuffle(self, seed):
         return self
+
+
+class DummyConfiguredTokenizer:
+    """Test tokenizer factory with implementation-owned configuration."""
+
+    calls: dict[str, object] = {}
+    result: object = object()
+
+    @dataclass(frozen=True, kw_only=True)
+    class Config:
+        """Declarative test tokenizer configuration."""
+
+        revision: str
+        trust_remote_code: bool = False
+
+        def build(self) -> object:
+            """Build the configured test tokenizer."""
+            return DummyConfiguredTokenizer.from_pretrained(
+                revision=self.revision,
+                trust_remote_code=self.trust_remote_code,
+            )
+
+    @classmethod
+    def from_pretrained(cls, *, revision: str, trust_remote_code: bool) -> object:
+        """Capture construction arguments and return the configured test tokenizer."""
+        cls.calls = {
+            "revision": revision,
+            "trust_remote_code": trust_remote_code,
+        }
+        return cls.result
 
 
 def dl_factory_capture(**kwargs):  # returns a sentinel while exposing passed kwargs via attribute
@@ -1245,6 +1276,8 @@ def test_run_train_validation_loop_calls_gc_hook_once_per_step():
 
 
 def test_tokenizer_config_uses_model_fallback_and_direct_trust_policy():
+    from nemo_automodel._transformers.auto_tokenizer import NeMoAutoTokenizer
+
     tokenizer = object()
     raw = ConfigNode(
         {
@@ -1257,22 +1290,28 @@ def test_tokenizer_config_uses_model_fallback_and_direct_trust_policy():
         "nemo_automodel._transformers.auto_tokenizer.NeMoAutoTokenizer.from_pretrained",
         return_value=tokenizer,
     ) as from_pretrained:
-        built = RecipeConfig(raw).tokenizer.build()
+        config = RecipeConfig(raw).tokenizer
+        assert isinstance(config, NeMoAutoTokenizer.Config)
+        built = config.build()
 
     assert built is tokenizer
     from_pretrained.assert_called_once_with(
         pretrained_model_name_or_path="org/model",
         trust_remote_code=False,
+        force_default=False,
+        force_hf=False,
     )
 
 
 def test_tokenizer_config_without_model_or_explicit_factory_is_disabled():
     raw = ConfigNode({"dataset": {"_target_": DummyMapDataset}})
 
-    assert RecipeConfig(raw).tokenizer.build() is None
+    assert RecipeConfig(raw).tokenizer is None
 
 
 def test_tokenizer_config_uses_default_remote_code_policy_for_nvidia_model():
+    from nemo_automodel._transformers.auto_tokenizer import NeMoAutoTokenizer
+
     raw = ConfigNode(
         {
             "model": {"pretrained_model_name_or_path": "nvidia/model"},
@@ -1280,26 +1319,63 @@ def test_tokenizer_config_uses_default_remote_code_policy_for_nvidia_model():
         }
     )
 
-    assert RecipeConfig(raw).tokenizer.kwargs["trust_remote_code"] is True
+    config = RecipeConfig(raw).tokenizer
+    assert isinstance(config, NeMoAutoTokenizer.Config)
+    assert config.trust_remote_code is True
 
 
 def test_tokenizer_config_injects_nested_model_trust_into_dataset_factory():
-    calls = {}
-    tokenizer = object()
-
-    def factory(**kwargs):
-        calls.update(kwargs)
-        return tokenizer
-
     raw = ConfigNode(
         {
             "model": {"config": {"trust_remote_code": True}},
-            "dataset": {"_target_": DummyMapDataset, "tokenizer": {"_target_": factory, "revision": "main"}},
+            "dataset": {
+                "_target_": DummyMapDataset,
+                "tokenizer": {"_target_": DummyConfiguredTokenizer.from_pretrained, "revision": "main"},
+            },
         }
     )
 
-    assert RecipeConfig(raw).tokenizer.build() is tokenizer
-    assert calls == {"revision": "main", "trust_remote_code": True}
+    config = RecipeConfig(raw).tokenizer
+    assert isinstance(config, DummyConfiguredTokenizer.Config)
+    assert config.build() is DummyConfiguredTokenizer.result
+    assert DummyConfiguredTokenizer.calls == {"revision": "main", "trust_remote_code": True}
+
+
+def test_tokenizer_config_maps_hf_tokenizer_to_nemo_owned_config():
+    from transformers import AutoTokenizer as TransformersAutoTokenizer
+
+    from nemo_automodel._transformers.auto_tokenizer import NeMoAutoTokenizer
+
+    raw = ConfigNode(
+        {
+            "model": {"trust_remote_code": True},
+            "dataset": {
+                "_target_": DummyMapDataset,
+                "tokenizer": {
+                    "_target_": TransformersAutoTokenizer.from_pretrained,
+                    "pretrained_model_name_or_path": "org/tokenizer",
+                },
+            },
+        }
+    )
+
+    config = RecipeConfig(raw).tokenizer
+    assert isinstance(config, NeMoAutoTokenizer.Config)
+    assert config.pretrained_model_name_or_path == "org/tokenizer"
+    assert config.trust_remote_code is True
+    assert config.force_hf is True
+
+
+def test_tokenizer_config_rejects_factory_without_owned_config():
+    raw = ConfigNode(
+        {
+            "tokenizer": {"_target_": lambda: object()},
+            "dataset": {"_target_": DummyMapDataset},
+        }
+    )
+
+    with pytest.raises(TypeError, match="nested Config"):
+        _ = RecipeConfig(raw).tokenizer
 
 
 def test_tokenizer_config_explicit_dataset_null_overrides_top_level_factory():
@@ -1312,30 +1388,35 @@ def test_tokenizer_config_explicit_dataset_null_overrides_top_level_factory():
         }
     )
 
-    assert RecipeConfig(raw).tokenizer.build() is None
+    assert RecipeConfig(raw).tokenizer is None
     top_level_factory.assert_not_called()
 
 
 def test_tokenizer_config_builds_top_level_processor_without_recipe_dispatch():
-    calls = {}
+    from transformers import AutoProcessor as TransformersAutoProcessor
+
+    from nemo_automodel._transformers.auto_processor import AutoProcessor
+
     processor = object()
-
-    def factory(**kwargs):
-        calls.update(kwargs)
-        return processor
-
     raw = ConfigNode(
         {
             "model": {"pretrained_model_name_or_path": "org/model", "trust_remote_code": True},
-            "tokenizer": {"_target_": factory, "pretrained_model_name_or_path": "org/processor"},
+            "tokenizer": {
+                "_target_": TransformersAutoProcessor.from_pretrained,
+                "pretrained_model_name_or_path": "org/processor",
+            },
             "dataset": {"_target_": DummyMapDataset},
         }
     )
 
     config = RecipeConfig(raw).tokenizer
-    assert config.build() is processor
-    assert calls == {"pretrained_model_name_or_path": "org/processor"}
-    assert config.kwargs == {"pretrained_model_name_or_path": "org/processor"}
+    assert isinstance(config, AutoProcessor.Config)
+    with patch("transformers.AutoProcessor.from_pretrained", return_value=processor) as from_pretrained:
+        assert config.build() is processor
+    from_pretrained.assert_called_once_with(
+        pretrained_model_name_or_path="org/processor",
+        trust_remote_code=False,
+    )
 
 
 # -----------------

--- a/tests/unit_tests/recipes/test_train_ft.py
+++ b/tests/unit_tests/recipes/test_train_ft.py
@@ -45,7 +45,6 @@ from nemo_automodel.recipes.llm.train_ft import (
     _should_pack_validation,
     _supports_sequence_packing,
     build_model,
-    compute_trust_remote_code_from_model,
 )
 
 
@@ -983,7 +982,11 @@ def _patch_setup_minimals(monkeypatch, patch_fn):
         ),
     )
     monkeypatch.setattr(RecipeConfig, "validation_dataloaders", property(lambda self: {}))
-    monkeypatch.setattr("nemo_automodel.recipes.llm.train_ft._build_tokenizer", lambda cfg_model, cfg_ds: ({}, None))
+    monkeypatch.setattr(
+        RecipeConfig,
+        "tokenizer",
+        property(lambda self: SimpleNamespace(build=lambda: None)),
+    )
     monkeypatch.setattr("nemo_automodel.recipes.llm.train_ft.ScopedRNG", lambda **kwargs: nullcontext())
     monkeypatch.setattr(
         "nemo_automodel.components.training.step_scheduler.StepSchedulerConfig.build",
@@ -1241,37 +1244,98 @@ def test_run_train_validation_loop_calls_gc_hook_once_per_step():
     trainer._maybe_collect_garbage.assert_called_once()
 
 
-def test_compute_trust_remote_code_prefers_cfg_flag():
-    cfg_model = ConfigNode({"trust_remote_code": False, "pretrained_model_name_or_path": "ignored"})
-
-    with patch("nemo_automodel.recipes.llm.train_ft.resolve_trust_remote_code") as mock_resolve:
-        result = compute_trust_remote_code_from_model(cfg_model)
-
-    assert result is False
-    mock_resolve.assert_not_called()
-
-
-def test_compute_trust_remote_code_prefers_nested_config():
-    cfg_model = ConfigNode({"config": {"trust_remote_code": True}})
-
-    with patch("nemo_automodel.recipes.llm.train_ft.resolve_trust_remote_code") as mock_resolve:
-        result = compute_trust_remote_code_from_model(cfg_model)
-
-    assert result is True
-    mock_resolve.assert_not_called()
-
-
-def test_compute_trust_remote_code_falls_back_to_resolve():
-    cfg_model = ConfigNode({"pretrained_model_name_or_path": "nvidia/foo"})
+def test_tokenizer_config_uses_model_fallback_and_direct_trust_policy():
+    tokenizer = object()
+    raw = ConfigNode(
+        {
+            "model": {"pretrained_model_name_or_path": "org/model", "trust_remote_code": False},
+            "dataset": {"_target_": DummyMapDataset},
+        }
+    )
 
     with patch(
-        "nemo_automodel.recipes.llm.train_ft.resolve_trust_remote_code",
-        return_value=True,
-    ) as mock_resolve:
-        result = compute_trust_remote_code_from_model(cfg_model)
+        "nemo_automodel._transformers.auto_tokenizer.NeMoAutoTokenizer.from_pretrained",
+        return_value=tokenizer,
+    ) as from_pretrained:
+        built = RecipeConfig(raw).tokenizer.build()
 
-    assert result is True
-    mock_resolve.assert_called_once_with("nvidia/foo")
+    assert built is tokenizer
+    from_pretrained.assert_called_once_with(
+        pretrained_model_name_or_path="org/model",
+        trust_remote_code=False,
+    )
+
+
+def test_tokenizer_config_without_model_or_explicit_factory_is_disabled():
+    raw = ConfigNode({"dataset": {"_target_": DummyMapDataset}})
+
+    assert RecipeConfig(raw).tokenizer.build() is None
+
+
+def test_tokenizer_config_uses_default_remote_code_policy_for_nvidia_model():
+    raw = ConfigNode(
+        {
+            "model": {"pretrained_model_name_or_path": "nvidia/model"},
+            "dataset": {"_target_": DummyMapDataset},
+        }
+    )
+
+    assert RecipeConfig(raw).tokenizer.kwargs["trust_remote_code"] is True
+
+
+def test_tokenizer_config_injects_nested_model_trust_into_dataset_factory():
+    calls = {}
+    tokenizer = object()
+
+    def factory(**kwargs):
+        calls.update(kwargs)
+        return tokenizer
+
+    raw = ConfigNode(
+        {
+            "model": {"config": {"trust_remote_code": True}},
+            "dataset": {"_target_": DummyMapDataset, "tokenizer": {"_target_": factory, "revision": "main"}},
+        }
+    )
+
+    assert RecipeConfig(raw).tokenizer.build() is tokenizer
+    assert calls == {"revision": "main", "trust_remote_code": True}
+
+
+def test_tokenizer_config_explicit_dataset_null_overrides_top_level_factory():
+    top_level_factory = MagicMock(return_value=object())
+    raw = ConfigNode(
+        {
+            "model": {"pretrained_model_name_or_path": "org/model"},
+            "tokenizer": {"_target_": top_level_factory},
+            "dataset": {"_target_": DummyMapDataset, "tokenizer": None},
+        }
+    )
+
+    assert RecipeConfig(raw).tokenizer.build() is None
+    top_level_factory.assert_not_called()
+
+
+def test_tokenizer_config_builds_top_level_processor_without_recipe_dispatch():
+    calls = {}
+    processor = object()
+
+    def factory(**kwargs):
+        calls.update(kwargs)
+        return processor
+
+    raw = ConfigNode(
+        {
+            "model": {"pretrained_model_name_or_path": "org/model", "trust_remote_code": True},
+            "tokenizer": {"_target_": factory, "pretrained_model_name_or_path": "org/processor"},
+            "dataset": {"_target_": DummyMapDataset},
+        }
+    )
+
+    config = RecipeConfig(raw).tokenizer
+    assert config.build() is processor
+    assert calls == {"pretrained_model_name_or_path": "org/processor"}
+    assert config.kwargs == {"pretrained_model_name_or_path": "org/processor"}
 
 
 # -----------------


### PR DESCRIPTION
## What

- move tokenizer and processor construction into implementation-owned config classes
- add `NeMoAutoTokenizer.Config` and `AutoProcessor.Config`
- add a model-owned `LlamaNemotronVLProcessor.Config` for retrieval
- normalize legacy `from_pretrained` targets, explicit `null`, model fallback, and trust policy at the `RecipeConfig` boundary
- keep LLM, sequence-classification, and retrieval recipes on the typed `config.build()` path
- update retrieval and functional YAMLs to use canonical `.Config` targets

## Why

This is the second follow-up layer on #2390 and depends on #3008. It keeps declarative tokenizer construction out of recipe bodies without representing component construction as an untyped factory-and-keyword bag.

## Validation

- focused recipe and retrieval suite: 151 passed, 7 skipped
- tokenizer implementation suite: 57 passed
- tokenizer config boundary suite: 8 passed
- canonical retrieval and functional YAML tokenizer sections resolve to their implementation-owned config classes
- `ruff format --check .`
- `ruff check .`
- `lint-imports`
- `python -m compileall -q nemo_automodel`

## Stack

- root: #2390
- base: #3008
- this PR

## Checklist

- [x] Followed the contributor and repository review guidance
- [x] Added focused tests
- [x] No documentation change is required for this internal construction refactor