### PR TITLE
fix(kd): use fp32 master weight copy

### DIFF
--- a/examples/llm_kd/llama3_2/llama3_2_1b_kd_separate_mesh_teacher_cp2.yaml
+++ b/examples/llm_kd/llama3_2/llama3_2_1b_kd_separate_mesh_teacher_cp2.yaml
@@ -26,7 +26,7 @@ rng:
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: meta-llama/Llama-3.2-1B
-  torch_dtype: bfloat16
+  torch_dtype: float32
   attn_implementation: sdpa
 
 # Teacher on global ranks [2, 3].
@@ -70,15 +70,11 @@ kd_loss_fn:
   fp32_upcast: true
 
 optimizer:
-  _target_: transformer_engine.pytorch.optimizers.fused_adam.FusedAdam
+  _target_: torch.optim.Adam
   betas: [0.9, 0.999]
   eps: 1e-8
   lr: 1.0e-5
   weight_decay: 0
-  adam_w_mode: true
-  bias_correction: true
-  master_weights: true
-  master_weight_dtype: torch.float32
 
 dataset:
   _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset

--- a/examples/llm_kd/llama3_2/llama3_2_1b_kd_separate_mesh_teacher_pp2.yaml
+++ b/examples/llm_kd/llama3_2/llama3_2_1b_kd_separate_mesh_teacher_pp2.yaml
@@ -26,7 +26,7 @@ rng:
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: meta-llama/Llama-3.2-1B
-  torch_dtype: bfloat16
+  torch_dtype: float32
   attn_implementation: sdpa
 
 # Teacher on global ranks [2, 3].
@@ -74,15 +74,11 @@ kd_loss_fn:
   fp32_upcast: true
 
 optimizer:
-  _target_: transformer_engine.pytorch.optimizers.fused_adam.FusedAdam
+  _target_: torch.optim.Adam
   betas: [0.9, 0.999]
   eps: 1e-8
   lr: 1.0e-5
   weight_decay: 0
-  adam_w_mode: true
-  bias_correction: true
-  master_weights: true
-  master_weight_dtype: torch.float32
 
 dataset:
   _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset

--- a/examples/llm_kd/llama3_2/llama3_2_1b_kd_separate_mesh_teacher_tp2.yaml
+++ b/examples/llm_kd/llama3_2/llama3_2_1b_kd_separate_mesh_teacher_tp2.yaml
@@ -26,7 +26,7 @@ rng:
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: meta-llama/Llama-3.2-1B
-  torch_dtype: bfloat16
+  torch_dtype: float32
   attn_implementation: sdpa
 
 # Teacher on global ranks [2, 3].
@@ -70,15 +70,11 @@ kd_loss_fn:
   fp32_upcast: true
 
 optimizer:
-  _target_: transformer_engine.pytorch.optimizers.fused_adam.FusedAdam
+  _target_: torch.optim.Adam
   betas: [0.9, 0.999]
   eps: 1e-8
   lr: 1.0e-5
   weight_decay: 0
-  adam_w_mode: true
-  bias_correction: true
-  master_weights: true
-  master_weight_dtype: torch.float32
 
 dataset:
   _target_: nemo_automodel.components.datasets.llm.squad.make_squad_dataset

--- a/examples/vlm_kd/qwen3_5/qwen3_5_vl_4b_kd_separate_mesh_teacher_cp2.yaml
+++ b/examples/vlm_kd/qwen3_5/qwen3_5_vl_4b_kd_separate_mesh_teacher_cp2.yaml
@@ -41,7 +41,7 @@ rng:
 model:
   _target_: nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained
   pretrained_model_name_or_path: Qwen/Qwen3.5-4B
-  torch_dtype: bfloat16
+  torch_dtype: float32
   backend:
     _target_: nemo_automodel.components.models.common.BackendConfig
     attn: sdpa
@@ -107,15 +107,11 @@ kd_loss_fn:
   chunk_size: 512
 
 optimizer:
-  _target_: transformer_engine.pytorch.optimizers.fused_adam.FusedAdam
+  _target_: torch.optim.AdamW
   lr: 5e-5
   weight_decay: 0.01
   betas: [0.9, 0.95]
   eps: 1e-8
-  adam_w_mode: true
-  bias_correction: true
-  master_weights: true
-  master_weight_dtype: torch.float32
 
 lr_scheduler:
   lr_warmup_steps: 30

--- a/examples/vlm_kd/qwen3_5/qwen3_5_vl_4b_kd_separate_mesh_teacher_dp2.yaml
+++ b/examples/vlm_kd/qwen3_5/qwen3_5_vl_4b_kd_separate_mesh_teacher_dp2.yaml
@@ -41,7 +41,7 @@ rng:
 model:
   _target_: nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained
   pretrained_model_name_or_path: Qwen/Qwen3.5-4B
-  torch_dtype: bfloat16
+  torch_dtype: float32
   backend:
     _target_: nemo_automodel.components.models.common.BackendConfig
     attn: sdpa
@@ -107,15 +107,11 @@ kd_loss_fn:
   chunk_size: 512
 
 optimizer:
-  _target_: transformer_engine.pytorch.optimizers.fused_adam.FusedAdam
+  _target_: torch.optim.AdamW
   lr: 5e-5
   weight_decay: 0.01
   betas: [0.9, 0.95]
   eps: 1e-8
-  adam_w_mode: true
-  bias_correction: true
-  master_weights: true
-  master_weight_dtype: torch.float32
 
 lr_scheduler:
   lr_warmup_steps: 30

--- a/examples/vlm_kd/qwen3_5/qwen3_5_vl_4b_kd_separate_mesh_teacher_tp2.yaml
+++ b/examples/vlm_kd/qwen3_5/qwen3_5_vl_4b_kd_separate_mesh_teacher_tp2.yaml
@@ -41,7 +41,7 @@ rng:
 model:
   _target_: nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained
   pretrained_model_name_or_path: Qwen/Qwen3.5-4B
-  torch_dtype: bfloat16
+  torch_dtype: float32
   backend:
     _target_: nemo_automodel.components.models.common.BackendConfig
     attn: sdpa
@@ -107,15 +107,11 @@ kd_loss_fn:
   chunk_size: 512
 
 optimizer:
-  _target_: transformer_engine.pytorch.optimizers.fused_adam.FusedAdam
+  _target_: torch.optim.AdamW
   lr: 5e-5
   weight_decay: 0.01
   betas: [0.9, 0.95]
   eps: 1e-8
-  adam_w_mode: true
-  bias_correction: true
-  master_weights: true
-  master_weight_dtype: torch.float32
 
 lr_scheduler:
   lr_warmup_steps: 30

--- a/nemo_automodel/recipes/llm/kd.py
+++ b/nemo_automodel/recipes/llm/kd.py
@@ -313,7 +313,7 @@ class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNe
         _verify_tokenizer_compatibility(self.cfg.get("model", None), self.cfg.get("teacher_model", None))
 
         resolve_storage_dtype(
-            self.cfg.model,
+            self.cfg.get("model"),
             self.cfg.get("optimizer"),
             is_peft=self.cfg.get("peft", None) is not None,
             context="llm-kd",

--- a/nemo_automodel/recipes/llm/kd.py
+++ b/nemo_automodel/recipes/llm/kd.py
@@ -57,6 +57,7 @@ from nemo_automodel.components.distributed.utils import get_sync_ctx
 from nemo_automodel.components.loggers.metric_logger import MetricsSample
 from nemo_automodel.components.loss.linear_ce import FusedLinearCrossEntropy
 from nemo_automodel.components.loss.utils import calculate_loss
+from nemo_automodel.components.optim.precision_warnings import resolve_storage_dtype
 from nemo_automodel.components.training.rng import ScopedRNG
 from nemo_automodel.components.training.signal_handler import DistributedSignalHandler
 from nemo_automodel.components.training.utils import (
@@ -310,6 +311,14 @@ class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNe
         # Right now, we only support tokenizer compatibility for the same tokenizer.
         # We will add support for different tokenizers in the future.
         _verify_tokenizer_compatibility(self.cfg.get("model", None), self.cfg.get("teacher_model", None))
+
+        resolve_storage_dtype(
+            self.cfg.model,
+            self.cfg.get("optimizer"),
+            is_peft=self.cfg.get("peft", None) is not None,
+            context="llm-kd",
+            logger=logger,
+        )
 
         # Let the parent class build *everything* for the student first.
         super().setup()

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -70,7 +70,6 @@ from nemo_automodel.components.loss.masked_ce import MaskedCrossEntropy
 from nemo_automodel.components.loss.mtp import calculate_mtp_loss
 from nemo_automodel.components.loss.utils import _get_lm_head_weight, calculate_loss
 from nemo_automodel.components.moe.megatron.moe_utils import MoEAuxLossAutoScaler
-from nemo_automodel.components.optim.precision_warnings import resolve_storage_dtype
 from nemo_automodel.components.quantization.fp8 import build_fp8_config
 from nemo_automodel.components.training.model_output_utils import get_final_hidden_states
 from nemo_automodel.components.training.rng import ScopedRNG, StatefulRNG
@@ -594,14 +593,6 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
         if self.mesh_context.cp_size > 1 and self.cfg.get("model.backend.rope_fusion", False):
             logging.info("Disabling rope_fusion because cp_size=%d > 1", self.mesh_context.cp_size)
             self.cfg.model.backend.rope_fusion = False
-
-        resolve_storage_dtype(
-            self.cfg.model,
-            self.cfg.get("optimizer"),
-            is_peft=self.peft_config is not None,
-            context="llm",
-            logger=logger,
-        )
 
         model = build_model(
             self.cfg.model,

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -70,6 +70,7 @@ from nemo_automodel.components.loss.masked_ce import MaskedCrossEntropy
 from nemo_automodel.components.loss.mtp import calculate_mtp_loss
 from nemo_automodel.components.loss.utils import _get_lm_head_weight, calculate_loss
 from nemo_automodel.components.moe.megatron.moe_utils import MoEAuxLossAutoScaler
+from nemo_automodel.components.optim.precision_warnings import resolve_storage_dtype
 from nemo_automodel.components.quantization.fp8 import build_fp8_config
 from nemo_automodel.components.training.model_output_utils import get_final_hidden_states
 from nemo_automodel.components.training.rng import ScopedRNG, StatefulRNG
@@ -594,7 +595,13 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
             logging.info("Disabling rope_fusion because cp_size=%d > 1", self.mesh_context.cp_size)
             self.cfg.model.backend.rope_fusion = False
 
-        # fp32 master-weight default planned to be enabled in follow-up PR (resolve_storage_dtype).
+        resolve_storage_dtype(
+            self.cfg.model,
+            self.cfg.optimizer,
+            is_peft=self.peft_config is not None,
+            context="llm",
+            logger=logger,
+        )
 
         model = build_model(
             self.cfg.model,

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -597,7 +597,7 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
 
         resolve_storage_dtype(
             self.cfg.model,
-            self.cfg.optimizer,
+            self.cfg.get("optimizer"),
             is_peft=self.peft_config is not None,
             context="llm",
             logger=logger,

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -64,7 +64,6 @@ from nemo_automodel.components.loss.linear_ce import FusedLinearCrossEntropy
 from nemo_automodel.components.loss.masked_ce import MaskedCrossEntropy
 from nemo_automodel.components.loss.mtp import calculate_mtp_loss
 from nemo_automodel.components.moe.megatron.moe_utils import MoEAuxLossAutoScaler
-from nemo_automodel.components.optim.precision_warnings import resolve_storage_dtype
 from nemo_automodel.components.quantization.fp8 import build_fp8_config
 from nemo_automodel.components.training.model_output_utils import get_final_hidden_states
 from nemo_automodel.components.training.rng import ScopedRNG, StatefulRNG
@@ -514,14 +513,6 @@ class FinetuneRecipeForVLM(BaseRecipe):
         if self.mesh_context.cp_size > 1 and self.cfg.get("model.backend.rope_fusion", False):
             logging.info("Disabling rope_fusion because cp_size=%d > 1", self.mesh_context.cp_size)
             self.cfg.model.backend.rope_fusion = False
-
-        resolve_storage_dtype(
-            self.cfg.model,
-            self.cfg.get("optimizer"),
-            is_peft=self.peft_config is not None,
-            context="vlm",
-            logger=logger,
-        )
 
         model = build_model(
             self.cfg.model,

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -64,6 +64,7 @@ from nemo_automodel.components.loss.linear_ce import FusedLinearCrossEntropy
 from nemo_automodel.components.loss.masked_ce import MaskedCrossEntropy
 from nemo_automodel.components.loss.mtp import calculate_mtp_loss
 from nemo_automodel.components.moe.megatron.moe_utils import MoEAuxLossAutoScaler
+from nemo_automodel.components.optim.precision_warnings import resolve_storage_dtype
 from nemo_automodel.components.quantization.fp8 import build_fp8_config
 from nemo_automodel.components.training.model_output_utils import get_final_hidden_states
 from nemo_automodel.components.training.rng import ScopedRNG, StatefulRNG
@@ -514,7 +515,13 @@ class FinetuneRecipeForVLM(BaseRecipe):
             logging.info("Disabling rope_fusion because cp_size=%d > 1", self.mesh_context.cp_size)
             self.cfg.model.backend.rope_fusion = False
 
-        # fp32 master-weight default planned to be enabled in follow-up PR (resolve_storage_dtype).
+        resolve_storage_dtype(
+            self.cfg.model,
+            self.cfg.optimizer,
+            is_peft=self.peft_config is not None,
+            context="vlm",
+            logger=logger,
+        )
 
         model = build_model(
             self.cfg.model,

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -517,7 +517,7 @@ class FinetuneRecipeForVLM(BaseRecipe):
 
         resolve_storage_dtype(
             self.cfg.model,
-            self.cfg.optimizer,
+            self.cfg.get("optimizer"),
             is_peft=self.peft_config is not None,
             context="vlm",
             logger=logger,

--- a/nemo_automodel/recipes/vlm/kd.py
+++ b/nemo_automodel/recipes/vlm/kd.py
@@ -222,7 +222,7 @@ class KnowledgeDistillationRecipeForVLM(FinetuneRecipeForVLM):
         _verify_tokenizer_compatibility(self.cfg.get("model", None), self.cfg.get("teacher_model", None))
 
         resolve_storage_dtype(
-            self.cfg.model,
+            self.cfg.get("model"),
             self.cfg.get("optimizer"),
             is_peft=self.cfg.get("peft", None) is not None,
             context="vlm-kd",

--- a/nemo_automodel/recipes/vlm/kd.py
+++ b/nemo_automodel/recipes/vlm/kd.py
@@ -57,6 +57,7 @@ from nemo_automodel.components.distributed.utils import get_sync_ctx
 from nemo_automodel.components.loggers.metric_logger import MetricsSample
 from nemo_automodel.components.loss.linear_ce import FusedLinearCrossEntropy
 from nemo_automodel.components.moe.megatron.moe_utils import MoEAuxLossAutoScaler
+from nemo_automodel.components.optim.precision_warnings import resolve_storage_dtype
 from nemo_automodel.components.training.rng import ScopedRNG
 from nemo_automodel.components.training.signal_handler import DistributedSignalHandler
 from nemo_automodel.components.training.utils import (
@@ -219,6 +220,14 @@ class KnowledgeDistillationRecipeForVLM(FinetuneRecipeForVLM):
     def setup(self):
         """Build student & teacher, dataloaders, optimizers, etc."""
         _verify_tokenizer_compatibility(self.cfg.get("model", None), self.cfg.get("teacher_model", None))
+
+        resolve_storage_dtype(
+            self.cfg.model,
+            self.cfg.get("optimizer"),
+            is_peft=self.cfg.get("peft", None) is not None,
+            context="vlm-kd",
+            logger=logger,
+        )
 
         super().setup()
 

--- a/tests/functional_tests/llm_pretrain_and_kd/kd_sep_mesh_gemma_dense.yaml
+++ b/tests/functional_tests/llm_pretrain_and_kd/kd_sep_mesh_gemma_dense.yaml
@@ -23,7 +23,7 @@ rng:
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: google/gemma-4-E2B-it
-  torch_dtype: bfloat16
+  torch_dtype: float32
   force_hf: true
   attn_implementation: eager
 
@@ -68,15 +68,12 @@ kd_loss_fn:
   chunk_size: 4096
 
 optimizer:
-  _target_: transformer_engine.pytorch.optimizers.fused_adam.FusedAdam
+  _target_: torch.optim.AdamW
   lr: 0.0
   weight_decay: 0.0
   betas: [0.9, 0.95]
   eps: 1.0e-8
-  adam_w_mode: true
-  bias_correction: true
-  master_weights: true
-  master_weight_dtype: torch.float32
+  foreach: false
 
 dataset:
   _target_: tests.functional_tests.llm_pretrain_and_kd.kd_separate_mesh_test_utils.make_tiny_kd_sft_dataset

--- a/tests/functional_tests/llm_pretrain_and_kd/kd_sep_mesh_gemma_moe.yaml
+++ b/tests/functional_tests/llm_pretrain_and_kd/kd_sep_mesh_gemma_moe.yaml
@@ -23,7 +23,7 @@ rng:
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: google/gemma-4-E2B-it
-  torch_dtype: bfloat16
+  torch_dtype: float32
   force_hf: true
   attn_implementation: eager
 
@@ -70,15 +70,12 @@ kd_loss_fn:
   chunk_size: 4096
 
 optimizer:
-  _target_: transformer_engine.pytorch.optimizers.fused_adam.FusedAdam
+  _target_: torch.optim.AdamW
   lr: 0.0
   weight_decay: 0.0
   betas: [0.9, 0.95]
   eps: 1.0e-8
-  adam_w_mode: true
-  bias_correction: true
-  master_weights: true
-  master_weight_dtype: torch.float32
+  foreach: false
 
 dataset:
   _target_: tests.functional_tests.llm_pretrain_and_kd.kd_separate_mesh_test_utils.make_tiny_kd_sft_dataset

--- a/tests/functional_tests/llm_pretrain_and_kd/kd_separate_mesh.yaml
+++ b/tests/functional_tests/llm_pretrain_and_kd/kd_separate_mesh.yaml
@@ -15,7 +15,7 @@ dist_env:
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: /workspace/artifacts/tiny_llama
-  torch_dtype: bfloat16
+  torch_dtype: float32
   attn_implementation: sdpa
 
 teacher_model:
@@ -58,13 +58,9 @@ kd_loss_fn:
   fp32_upcast: true
 
 optimizer:
-  _target_: transformer_engine.pytorch.optimizers.fused_adam.FusedAdam
+  _target_: torch.optim.AdamW
   lr: 1.0e-4
   weight_decay: 0.0
-  adam_w_mode: true
-  bias_correction: true
-  master_weights: true
-  master_weight_dtype: torch.float32
 
 dataset:
   _target_: tests.functional_tests.llm_pretrain_and_kd.kd_separate_mesh_test_utils.make_tiny_kd_dataset

--- a/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
+++ b/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
@@ -2855,6 +2855,21 @@ def test_vlm_rope_fusion_unchanged_when_cp_eq_1(monkeypatch):
     assert cfg.model.backend.rope_fusion is True
 
 
+def test_vlm_setup_defaults_torch_optimizer_storage_to_fp32(monkeypatch):
+    cfg = _minimal_vlm_cfg(cp_size=1, rope_fusion=True)
+    _patch_vlm_setup_minimals(monkeypatch, cp_size=1)
+    dummy_opt = SimpleNamespace(param_groups=[{"lr": 0.01}], step=lambda: None, zero_grad=lambda **k: None)
+    monkeypatch.setattr(
+        "nemo_automodel.recipes._typed_config.RecipeConfig.optimizer",
+        property(lambda self: SimpleNamespace(_target_="torch.optim.AdamW", build=lambda *a, **k: [dummy_opt])),
+    )
+
+    trainer = FinetuneRecipeForVLM(cfg)
+    trainer.setup()
+
+    assert cfg.model.torch_dtype == "float32"
+
+
 def test_vlm_rope_fusion_stays_false_when_already_disabled(monkeypatch):
     """rope_fusion=False should stay False in VLM setup regardless of cp_size."""
     cfg = _minimal_vlm_cfg(cp_size=4, rope_fusion=False)

--- a/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
+++ b/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
@@ -2860,12 +2860,11 @@ def test_vlm_rope_fusion_unchanged_when_cp_eq_1(monkeypatch):
     assert cfg.model.backend.rope_fusion is True
 
 
-def test_vlm_setup_defaults_torch_optimizer_storage_to_fp32(monkeypatch):
+def test_vlm_setup_does_not_change_storage_dtype_for_non_kd_recipe(monkeypatch):
     cfg = _minimal_vlm_cfg(cp_size=1, rope_fusion=True, optimizer_target="torch.optim.AdamW")
     _patch_vlm_setup_minimals(monkeypatch, cp_size=1)
     dummy_opt = SimpleNamespace(param_groups=[{"lr": 0.01}], step=lambda: None, zero_grad=lambda **k: None)
     optimizer_config = build_optimizer_config("torch.optim.AdamW", {"lr": 0.01})
-    assert not hasattr(optimizer_config, "_target_")
     monkeypatch.setattr(optimizer_config, "build", lambda *a, **k: [dummy_opt])
     monkeypatch.setattr(
         "nemo_automodel.recipes._typed_config.RecipeConfig.optimizer",
@@ -2875,7 +2874,7 @@ def test_vlm_setup_defaults_torch_optimizer_storage_to_fp32(monkeypatch):
     trainer = FinetuneRecipeForVLM(cfg)
     trainer.setup()
 
-    assert cfg.model.torch_dtype == "float32"
+    assert not hasattr(cfg.model, "torch_dtype")
 
 
 def test_vlm_rope_fusion_stays_false_when_already_disabled(monkeypatch):

--- a/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
+++ b/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
@@ -2794,14 +2794,19 @@ def _patch_vlm_setup_minimals(monkeypatch, cp_size):
     monkeypatch.setattr("nemo_automodel.recipes.vlm.finetune.FinetuneRecipeForVLM._get_pp_rank", lambda self: 0)
 
 
-def _minimal_vlm_cfg(cp_size: int, rope_fusion: bool, prewarm: dict[str, bool] | None = None) -> ConfigNode:
+def _minimal_vlm_cfg(
+    cp_size: int,
+    rope_fusion: bool,
+    prewarm: dict[str, bool] | None = None,
+    optimizer_target: str | None = None,
+) -> ConfigNode:
     cfg = {
         "model": {"backend": {"rope_fusion": rope_fusion}},
         "dataloader": {},
         "dataset": {"path_or_dataset": "dummy"},
         "validation_dataloader": {},
         "step_scheduler": {"local_batch_size": 1, "global_batch_size": 1},
-        "optimizer": {},
+        "optimizer": {"_target_": optimizer_target} if optimizer_target is not None else {},
         "loss_fn": {},
         "checkpoint": {"best_metric_key": "default"},
         "distributed": {"cp_size": cp_size},
@@ -2856,12 +2861,15 @@ def test_vlm_rope_fusion_unchanged_when_cp_eq_1(monkeypatch):
 
 
 def test_vlm_setup_defaults_torch_optimizer_storage_to_fp32(monkeypatch):
-    cfg = _minimal_vlm_cfg(cp_size=1, rope_fusion=True)
+    cfg = _minimal_vlm_cfg(cp_size=1, rope_fusion=True, optimizer_target="torch.optim.AdamW")
     _patch_vlm_setup_minimals(monkeypatch, cp_size=1)
     dummy_opt = SimpleNamespace(param_groups=[{"lr": 0.01}], step=lambda: None, zero_grad=lambda **k: None)
+    optimizer_config = build_optimizer_config("torch.optim.AdamW", {"lr": 0.01})
+    assert not hasattr(optimizer_config, "_target_")
+    monkeypatch.setattr(optimizer_config, "build", lambda *a, **k: [dummy_opt])
     monkeypatch.setattr(
         "nemo_automodel.recipes._typed_config.RecipeConfig.optimizer",
-        property(lambda self: SimpleNamespace(_target_="torch.optim.AdamW", build=lambda *a, **k: [dummy_opt])),
+        property(lambda self: optimizer_config),
     )
 
     trainer = FinetuneRecipeForVLM(cfg)

--- a/tests/unit_tests/recipes/test_kd_separate_mesh_recipe_helpers.py
+++ b/tests/unit_tests/recipes/test_kd_separate_mesh_recipe_helpers.py
@@ -19,6 +19,7 @@ import pytest
 import torch
 from torch import nn
 
+from nemo_automodel.components.config.loader import ConfigNode
 from nemo_automodel.recipes.llm import kd as llm_kd
 from nemo_automodel.recipes.vlm import kd as vlm_kd
 
@@ -50,6 +51,34 @@ _RECIPE_CASES = (
         id="vlm",
     ),
 )
+
+
+@pytest.mark.parametrize("recipe_module,recipe_cls,parent_cls", _RECIPE_CASES)
+def test_kd_setup_defaults_torch_optimizer_storage_to_fp32(monkeypatch, recipe_module, recipe_cls, parent_cls):
+    class SetupStopped(Exception):
+        pass
+
+    cfg = ConfigNode(
+        {
+            "model": {},
+            "teacher_model": {},
+            "optimizer": {"_target_": "torch.optim.AdamW", "lr": 0.01},
+        }
+    )
+
+    def stop_parent_setup(self):
+        raise SetupStopped
+
+    monkeypatch.setattr(recipe_module, "_verify_tokenizer_compatibility", lambda *args, **kwargs: None)
+    monkeypatch.setattr(parent_cls, "setup", stop_parent_setup)
+
+    recipe = object.__new__(recipe_cls)
+    recipe.cfg = cfg
+
+    with pytest.raises(SetupStopped):
+        recipe.setup()
+
+    assert cfg.model.torch_dtype == "float32"
 
 
 @pytest.mark.parametrize("recipe_module,recipe_cls,_", _RECIPE_CASES)

--- a/tests/unit_tests/recipes/test_kd_utils.py
+++ b/tests/unit_tests/recipes/test_kd_utils.py
@@ -40,6 +40,17 @@ _KD_FP32_MASTER_YAMLS = (
     "tests/functional_tests/llm_pretrain_and_kd/kd_sep_mesh_gemma_dense.yaml",
     "tests/functional_tests/llm_pretrain_and_kd/kd_sep_mesh_gemma_moe.yaml",
 )
+_EXPECTED_TORCH_OPTIMIZER_TARGETS = {
+    "examples/llm_kd/llama3_2/llama3_2_1b_kd_separate_mesh_teacher_cp2.yaml": "torch.optim.Adam",
+    "examples/llm_kd/llama3_2/llama3_2_1b_kd_separate_mesh_teacher_pp2.yaml": "torch.optim.Adam",
+    "examples/llm_kd/llama3_2/llama3_2_1b_kd_separate_mesh_teacher_tp2.yaml": "torch.optim.Adam",
+    "examples/vlm_kd/qwen3_5/qwen3_5_vl_4b_kd_separate_mesh_teacher_cp2.yaml": "torch.optim.AdamW",
+    "examples/vlm_kd/qwen3_5/qwen3_5_vl_4b_kd_separate_mesh_teacher_dp2.yaml": "torch.optim.AdamW",
+    "examples/vlm_kd/qwen3_5/qwen3_5_vl_4b_kd_separate_mesh_teacher_tp2.yaml": "torch.optim.AdamW",
+    "tests/functional_tests/llm_pretrain_and_kd/kd_separate_mesh.yaml": "torch.optim.AdamW",
+    "tests/functional_tests/llm_pretrain_and_kd/kd_sep_mesh_gemma_dense.yaml": "torch.optim.AdamW",
+    "tests/functional_tests/llm_pretrain_and_kd/kd_sep_mesh_gemma_moe.yaml": "torch.optim.AdamW",
+}
 
 
 def test_tiny_kd_dataset_requests_flat_chat_template_token_ids():
@@ -108,16 +119,16 @@ def test_tiny_kd_sft_dataset_masks_generation_prompt():
     assert dataset[1]["labels"][3] == 20
 
 
-def test_kd_yamls_use_fp32_optimizer_master_weights():
+def test_kd_yamls_use_torch_optim_with_fp32_student_storage():
     for relative_path in _KD_FP32_MASTER_YAMLS:
         cfg = yaml.safe_load((_REPO_ROOT / relative_path).read_text())
 
         optimizer = cfg["optimizer"]
-        assert optimizer["_target_"] == "transformer_engine.pytorch.optimizers.fused_adam.FusedAdam"
-        assert optimizer["master_weights"] is True
-        assert optimizer["master_weight_dtype"] == "torch.float32"
+        assert optimizer["_target_"] == _EXPECTED_TORCH_OPTIMIZER_TARGETS[relative_path]
+        assert "master_weights" not in optimizer
+        assert "master_weight_dtype" not in optimizer
 
-        assert cfg["model"]["torch_dtype"] == "bfloat16"
+        assert cfg["model"]["torch_dtype"] == "float32"
         assert cfg["teacher_model"]["torch_dtype"] == "bfloat16"
 
 

--- a/tests/unit_tests/recipes/test_train_ft.py
+++ b/tests/unit_tests/recipes/test_train_ft.py
@@ -1035,13 +1035,12 @@ def test_nvtx_false_skips_patching(monkeypatch):
     assert patch_calls == []
 
 
-def test_setup_defaults_torch_optimizer_storage_to_fp32(monkeypatch):
+def test_setup_does_not_change_storage_dtype_for_non_kd_recipe(monkeypatch):
     cfg = _minimal_cfg_with_nvtx(nvtx_value=False, optimizer_target="torch.optim.AdamW")
 
     _patch_setup_minimals(monkeypatch, lambda *a, **k: None)
     dummy_opt = SimpleNamespace(param_groups=[{"lr": 0.01}], step=lambda: None, zero_grad=lambda: None)
     optimizer_config = build_optimizer_config("torch.optim.AdamW", {"lr": 0.01})
-    assert not hasattr(optimizer_config, "_target_")
     monkeypatch.setattr(optimizer_config, "build", lambda *a, **k: [dummy_opt])
     monkeypatch.setattr(
         "nemo_automodel.recipes._typed_config.RecipeConfig.optimizer",
@@ -1051,7 +1050,7 @@ def test_setup_defaults_torch_optimizer_storage_to_fp32(monkeypatch):
     trainer = TrainFinetuneRecipeForNextTokenPrediction(cfg)
     trainer.setup()
 
-    assert cfg.model.torch_dtype == "float32"
+    assert not hasattr(cfg.model, "torch_dtype")
 
 
 def test_nvtx_true_pipeline_patches_all_parts(monkeypatch):

--- a/tests/unit_tests/recipes/test_train_ft.py
+++ b/tests/unit_tests/recipes/test_train_ft.py
@@ -1035,6 +1035,22 @@ def test_nvtx_false_skips_patching(monkeypatch):
     assert patch_calls == []
 
 
+def test_setup_defaults_torch_optimizer_storage_to_fp32(monkeypatch):
+    cfg = _minimal_cfg_with_nvtx(nvtx_value=False)
+
+    _patch_setup_minimals(monkeypatch, lambda *a, **k: None)
+    dummy_opt = SimpleNamespace(param_groups=[{"lr": 0.01}], step=lambda: None, zero_grad=lambda: None)
+    monkeypatch.setattr(
+        "nemo_automodel.recipes._typed_config.RecipeConfig.optimizer",
+        property(lambda self: SimpleNamespace(_target_="torch.optim.AdamW", build=lambda *a, **k: [dummy_opt])),
+    )
+
+    trainer = TrainFinetuneRecipeForNextTokenPrediction(cfg)
+    trainer.setup()
+
+    assert cfg.model.torch_dtype == "float32"
+
+
 def test_nvtx_true_pipeline_patches_all_parts(monkeypatch):
     cfg = _minimal_cfg_with_nvtx(nvtx_value=True)
     patch_calls = []

--- a/tests/unit_tests/recipes/test_train_ft.py
+++ b/tests/unit_tests/recipes/test_train_ft.py
@@ -829,7 +829,7 @@ def test_force_hf_true_disables_meta_init(monkeypatch):
 # -----------------
 # NVTX flag tests
 # -----------------
-def _minimal_cfg_with_nvtx(nvtx_value: bool):
+def _minimal_cfg_with_nvtx(nvtx_value: bool, optimizer_target: str | None = None):
     """Helper to build a minimal ConfigNode for nvtx tests."""
     return ConfigNode(
         {
@@ -839,7 +839,7 @@ def _minimal_cfg_with_nvtx(nvtx_value: bool):
             "dataset": {},
             "validation_dataloader": {},
             "step_scheduler": {"local_batch_size": 1, "global_batch_size": 1},
-            "optimizer": {},
+            "optimizer": {"_target_": optimizer_target} if optimizer_target is not None else {},
             "loss_fn": {},
             "checkpoint": {"best_metric_key": "default"},
             "distributed": {"cp_size": 1},
@@ -1036,13 +1036,16 @@ def test_nvtx_false_skips_patching(monkeypatch):
 
 
 def test_setup_defaults_torch_optimizer_storage_to_fp32(monkeypatch):
-    cfg = _minimal_cfg_with_nvtx(nvtx_value=False)
+    cfg = _minimal_cfg_with_nvtx(nvtx_value=False, optimizer_target="torch.optim.AdamW")
 
     _patch_setup_minimals(monkeypatch, lambda *a, **k: None)
     dummy_opt = SimpleNamespace(param_groups=[{"lr": 0.01}], step=lambda: None, zero_grad=lambda: None)
+    optimizer_config = build_optimizer_config("torch.optim.AdamW", {"lr": 0.01})
+    assert not hasattr(optimizer_config, "_target_")
+    monkeypatch.setattr(optimizer_config, "build", lambda *a, **k: [dummy_opt])
     monkeypatch.setattr(
         "nemo_automodel.recipes._typed_config.RecipeConfig.optimizer",
-        property(lambda self: SimpleNamespace(_target_="torch.optim.AdamW", build=lambda *a, **k: [dummy_opt])),
+        property(lambda self: optimizer_config),
     )
 
     trainer = TrainFinetuneRecipeForNextTokenPrediction(cfg)


### PR DESCRIPTION
# What does this PR do?

Stacked on #2954.

Adds torch.optim Adam/AdamW fp32-master support by keeping full-parameter student model storage in fp32 while FSDP2 mixed precision continues to drive bf16 compute/reduce behavior. This avoids requiring Transformer Engine FusedAdam solely to get fp32 master weights.

# Changelog

- Wire `resolve_storage_dtype` into LLM and VLM finetuning setup before `build_model`.
- Restore KD example and functional configs to `torch.optim.Adam` / `torch.optim.AdamW` with `model.torch_dtype: float32` for the student and `teacher_model.torch_dtype: bfloat16` for the frozen teacher.
- Update KD YAML guard coverage and add lightweight LLM/VLM setup tests for the torch optimizer dtype default.

# Validation

- `git diff --check`
- `uv run --no-sync ruff format --check nemo_automodel/recipes/llm/train_ft.py nemo_automodel/recipes/vlm/finetune.py tests/unit_tests/recipes/test_kd_utils.py tests/unit_tests/recipes/test_train_ft.py tests/unit_tests/recipes/test_finetune_vlm_helpers.py`
- `uv run --no-sync ruff check nemo_automodel/recipes/llm/train_ft.py nemo_automodel/recipes/vlm/finetune.py tests/unit_tests/recipes/test_kd_utils.py tests/unit_tests/recipes/test_train_ft.py tests/unit_tests/recipes/test_finetune_vlm_helpers.py`
- `PYTHONPATH=/tmp/automodel_pytest_shim /usr/bin/python3 -m pytest -q tests/unit_tests/recipes/test_kd_utils.py tests/unit_tests/components/optim/test_precision_warnings.py tests/unit_tests/recipes/test_train_ft.py::test_setup_defaults_torch_optimizer_storage_to_fp32 tests/unit_tests/recipes/test_finetune_vlm_helpers.py::test_vlm_setup_defaults_torch_optimizer_storage_to_fp32` — 30 passed, 19 warnings
