### PR TITLE
test(ci): accept SHA-pinned claude-review template refs in the policy test

### DIFF
--- a/tests/unit_tests/test_claude_review_policy.py
+++ b/tests/unit_tests/test_claude_review_policy.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
 from pathlib import Path
 
 import pytest
@@ -38,7 +39,12 @@ def test_review_workflow_keeps_main_caller_wiring():
     assert "if" not in job
     assert "concurrency" not in job
     assert job["with"]["model"] == "${{ vars.CLAUDE_MODEL }}"
-    assert job["uses"] == "NVIDIA-NeMo/FW-CI-templates/.github/workflows/_claude_review.yml@v1.7.0"
+    # Pin the callee repo and path exactly, but let the ref move between release
+    # tags and full commit SHAs: the template is repinned routinely, and an exact
+    # ref match breaks this test on every bump (e.g. the v1.8.2/v1.8.3 repins).
+    uses_path, _, uses_ref = job["uses"].partition("@")
+    assert uses_path == "NVIDIA-NeMo/FW-CI-templates/.github/workflows/_claude_review.yml"
+    assert re.fullmatch(r"v\d+\.\d+\.\d+|[0-9a-f]{40}", uses_ref)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What

`test_review_workflow_keeps_main_caller_wiring` asserts the exact `uses:` ref of the claude-review caller workflow (`_claude_review.yml@v1.7.0`). #3013 repinned the template to a full commit SHA (`7d857ec #v1.8.3`) without updating the assertion, so the test now fails on `main` and on every PR whose CI merges with current `main` (first seen as an `aea1fdf` mismatch during the v1.8.2 window, e.g. the `L0_Unit_Tests_CPU` failure on #3002).

This keeps the security intent of the test (the callee repo and workflow path must stay exactly `NVIDIA-NeMo/FW-CI-templates/.github/workflows/_claude_review.yml`) while allowing the ref to move between release tags (`vX.Y.Z`) and full 40-hex commit SHAs, so routine repins of the template no longer break `main`.

## Verification

`tests/unit_tests/test_claude_review_policy.py` passes against the current SHA-pinned workflow (84 passed), and the ref regex still accepts the previous tag form (`v1.7.0`). A `uses:` pointing at any other repo, path, or a non-tag/non-SHA ref still fails the test.
