### PR TITLE
fix(datasets): reject non-prefix multiturn mask templates

### DIFF
--- a/nemo_automodel/components/datasets/llm/formatting_utils.py
+++ b/nemo_automodel/components/datasets/llm/formatting_utils.py
@@ -129,6 +129,23 @@ def _maybe_shift_mask_for_left_padding(
     return [0] * pad_len + mask[: len(mask) - pad_len]
 
 
+def _is_consistent_render_prefix(prefix_ids: "list[int]", reference_ids: "list[int]") -> bool:
+    """Check that a prefix render matches the start of the full-conversation render.
+
+    Locating spans by prefix lengths is only correct when
+    ``render(messages[:k])`` reproduces the first tokens of ``render(messages)``.
+    The final prefix token is excluded from the comparison: many templates close
+    the rendered text with a token (an EOS or a trailing newline) that is
+    replaced or merged once the next message is appended, and that one-token
+    boundary fuzziness is already inherent to prefix-length arithmetic.
+    """
+    if not prefix_ids:
+        return True
+    if len(prefix_ids) > len(reference_ids):
+        return False
+    return prefix_ids[:-1] == reference_ids[: len(prefix_ids) - 1]
+
+
 def _build_multiturn_assistant_mask(
     tokenizer: "PreTrainedTokenizer",
     formatted_text: List[Dict[str, Any]],
@@ -137,7 +154,7 @@ def _build_multiturn_assistant_mask(
     tools: Optional[List[Dict]] = None,
     truncation: Union[str, bool] = "do_not_truncate",
     seq_length: Optional[int] = None,
-    full_length: Optional[int] = None,
+    unpadded_full_ids: "list[int] | None" = None,
 ) -> List[int]:
     """Build a fallback loss mask that supervises every assistant turn.
 
@@ -145,33 +162,54 @@ def _build_multiturn_assistant_mask(
     before and after the turn, which is O(turns) ``apply_chat_template`` calls.
     Two reductions keep that from re-doing work:
 
-    - ``full_length`` is the caller's already-known unpadded token count for the
-      whole conversation (``sum(attention_mask)``). When the dialogue ends on an
-      assistant turn its closing boundary is the full conversation, so passing
-      ``full_length`` skips re-tokenizing the entire prefix — the single most
-      expensive call in the loop.
+    - ``unpadded_full_ids`` is the caller's already-known unpadded tokenization
+      of the whole conversation. When the dialogue ends on an assistant turn
+      its closing boundary is the full conversation, so passing it skips
+      re-tokenizing the entire prefix (the single most expensive call in the
+      loop). When omitted, the full conversation is tokenized once here.
     - Prefix lengths are memoized so a boundary shared by adjacent turns (a
       turn's end and the next turn's start) is tokenized at most once.
 
-    Both are exact: ``full_length`` and the memoized values equal what
-    :func:`_tokenized_chat_length` would return, so the mask is unchanged.
+    Every tokenized prefix is validated against ``unpadded_full_ids`` (see
+    :func:`_is_consistent_render_prefix`) and a :class:`ValueError` is raised
+    on mismatch: a rewriting template leaves no way to place assistant spans
+    correctly, so failing loudly is the only alternative to silently
+    mislabeling supervised tokens.
     """
     assistant_mask = [0] * len(input_ids)
     found_assistant = False
 
-    length_cache: Dict[int, int] = {}
-    if full_length is not None:
-        length_cache[len(formatted_text)] = full_length
+    if unpadded_full_ids is None:
+        unpadded_full_ids = _tokenize_chat(
+            tokenizer,
+            formatted_text,
+            tools=tools,
+            truncation=truncation,
+            seq_length=seq_length,
+        )
+    length_cache: Dict[int, int] = {len(formatted_text): len(unpadded_full_ids)}
 
     def prefix_length(k: int) -> int:
         if k not in length_cache:
-            length_cache[k] = _tokenized_chat_length(
+            prefix_ids = _tokenize_chat(
                 tokenizer,
                 formatted_text[:k],
                 tools=tools,
                 truncation=truncation,
                 seq_length=seq_length,
             )
+            if not _is_consistent_render_prefix(prefix_ids, unpadded_full_ids):
+                raise ValueError(
+                    f"Cannot build an answer-only loss mask from conversation prefixes: rendering "
+                    f"the first {k} message(s) alone does not reproduce a prefix of the fully "
+                    f"rendered conversation. The chat template rewrites earlier turns based on "
+                    f"later ones (for example, Qwen3's template drops <think> blocks from "
+                    f"assistant turns that precede the last user turn), so prefix-length "
+                    f"arithmetic would mislabel supervised tokens. Provide a chat template that "
+                    f"wraps assistant turns in {{% generation %}}...{{% endgeneration %}} so the "
+                    f"tokenizer returns the assistant mask directly."
+                )
+            length_cache[k] = len(prefix_ids)
         return length_cache[k]
 
     for idx, message in enumerate(formatted_text):
@@ -227,13 +265,34 @@ def _build_reasoning_mask(
     tools: Optional[List[Dict]] = None,
     truncation: Union[str, bool] = "do_not_truncate",
     seq_length: Optional[int] = None,
+    unpadded_full_ids: "list[int] | None" = None,
 ) -> List[int]:
-    """Build a token mask for reasoning_content spans inside assistant turns."""
+    """Build a token mask for reasoning_content spans inside assistant turns.
+
+    Spans are located from conversation-prefix renders, so each prefix is
+    validated against ``unpadded_full_ids`` (the unpadded tokenization of the
+    whole conversation, tokenized here when omitted; see
+    :func:`_is_consistent_render_prefix`). Turns whose prefix render diverges
+    from the full render are skipped with a warning rather than an error,
+    unlike :func:`_build_multiturn_assistant_mask`: a rewriting template does
+    not render that turn's reasoning content in the full conversation at all,
+    so there is no span to mask, whereas any prefix-based location would punch
+    the hole at the wrong tokens.
+    """
     reasoning_mask = [0] * len(input_ids)
 
     for idx, message in enumerate(formatted_text):
         if message.get("role") != "assistant" or not message.get("reasoning_content"):
             continue
+
+        if unpadded_full_ids is None:
+            unpadded_full_ids = _tokenize_chat(
+                tokenizer,
+                formatted_text,
+                tools=tools,
+                truncation=truncation,
+                seq_length=seq_length,
+            )
 
         prefix_ids = _tokenize_chat(
             tokenizer,
@@ -249,6 +308,19 @@ def _build_reasoning_mask(
             truncation=truncation,
             seq_length=seq_length,
         )
+        if not (
+            _is_consistent_render_prefix(prefix_ids, unpadded_full_ids)
+            and _is_consistent_render_prefix(full_ids, unpadded_full_ids)
+        ):
+            logger.warning(
+                "Skipping reasoning_content masking for assistant message %s: the chat template "
+                "renders the conversation prefix differently inside the full conversation, so the "
+                "reasoning span cannot be located (and is likely not rendered in the full "
+                "conversation at all).",
+                idx,
+            )
+            continue
+
         masked_ids = _tokenize_chat(
             tokenizer,
             formatted_text[:idx] + [_masked_reasoning_message(message)],
@@ -674,15 +746,20 @@ def format_chat_template(
     )
 
     input_ids = tokenized_chat.get("input_ids")
+
+    def _unpadded_full_ids() -> "list[int] | None":
+        """Unpadded full-conversation ids from this tokenization, already known
+        without another tokenizer call; the mask builders use them to skip
+        re-tokenizing the full prefix and to validate prefix renders. None
+        (recompute in the builder) when no attention_mask is available."""
+        attn = tokenized_chat.get("attention_mask")
+        if attn is None:
+            return None
+        return [token for token, keep in zip(input_ids, attn) if keep]
+
     if template_has_generation_kwd:
         mask = tokenized_chat["assistant_masks"]
     elif not template_has_generation_kwd and answer_only_loss_mask:
-        # The unpadded token count of the whole conversation is already known
-        # from this tokenization; pass it so the mask builder need not
-        # re-tokenize the full prefix. Fall back to None (recompute) when no
-        # attention_mask is available.
-        attn_for_len = tokenized_chat.get("attention_mask")
-        full_length = sum(attn_for_len) if attn_for_len is not None else None
         mask = _build_multiturn_assistant_mask(
             tokenizer,
             formatted_text,
@@ -690,7 +767,7 @@ def format_chat_template(
             tools=tools,
             truncation=truncation,
             seq_length=seq_length,
-            full_length=full_length,
+            unpadded_full_ids=_unpadded_full_ids(),
         )
         # _build_multiturn_assistant_mask computes indices from unpadded
         # lengths — shift for left-padding tokenizers.
@@ -719,6 +796,7 @@ def format_chat_template(
             tools=tools,
             truncation=truncation,
             seq_length=seq_length,
+            unpadded_full_ids=_unpadded_full_ids(),
         )
         # _build_reasoning_mask also computes from unpadded lengths.
         reasoning_mask = _maybe_shift_mask_for_left_padding(

--- a/nemo_automodel/components/datasets/llm/formatting_utils.py
+++ b/nemo_automodel/components/datasets/llm/formatting_utils.py
@@ -60,28 +60,6 @@ if TYPE_CHECKING:
 GENERATION_REGEX = re.compile(r"\{%-?\s+generation\s+-?%\}")
 
 
-def _tokenized_chat_length(
-    tokenizer: "PreTrainedTokenizer",
-    messages: List[Dict[str, str]],
-    *,
-    tools: Optional[List[Dict]] = None,
-    truncation: Union[str, bool] = "do_not_truncate",
-    seq_length: Optional[int] = None,
-) -> int:
-    """Return the tokenized chat length for a message prefix without padding."""
-    tokenized_chat = tokenizer.apply_chat_template(
-        messages,
-        tools=tools,
-        tokenize=True,
-        return_dict=True,
-        return_assistant_tokens_mask=False,
-        padding=False,
-        truncation=truncation,
-        max_length=seq_length,
-    )
-    return len(tokenized_chat.get("input_ids", []))
-
-
 def _tokenize_chat(
     tokenizer: "PreTrainedTokenizer",
     messages: List[Dict[str, Any]],
@@ -102,6 +80,18 @@ def _tokenize_chat(
         max_length=seq_length,
     )
     return tokenized_chat.get("input_ids", [])
+
+
+def _tokenized_chat_length(
+    tokenizer: "PreTrainedTokenizer",
+    messages: List[Dict[str, str]],
+    *,
+    tools: Optional[List[Dict]] = None,
+    truncation: Union[str, bool] = "do_not_truncate",
+    seq_length: Optional[int] = None,
+) -> int:
+    """Return the tokenized chat length for a message prefix without padding."""
+    return len(_tokenize_chat(tokenizer, messages, tools=tools, truncation=truncation, seq_length=seq_length))
 
 
 def _maybe_shift_mask_for_left_padding(
@@ -129,21 +119,26 @@ def _maybe_shift_mask_for_left_padding(
     return [0] * pad_len + mask[: len(mask) - pad_len]
 
 
-def _is_consistent_render_prefix(prefix_ids: "list[int]", reference_ids: "list[int]") -> bool:
+def _is_consistent_render_prefix(
+    prefix_ids: "list[int]", reference_ids: "list[int]", *, trailing_token_id: "int | None" = None
+) -> bool:
     """Check that a prefix render matches the start of the full-conversation render.
 
     Locating spans by prefix lengths is only correct when
     ``render(messages[:k])`` reproduces the first tokens of ``render(messages)``.
-    The final prefix token is excluded from the comparison: many templates close
-    the rendered text with a token (an EOS or a trailing newline) that is
-    replaced or merged once the next message is appended, and that one-token
-    boundary fuzziness is already inherent to prefix-length arithmetic.
+    The comparison is exact unless a multi-token prefix ends with a known
+    standalone terminator that is replaced when the next message is appended.
     """
-    if not prefix_ids:
-        return True
     if len(prefix_ids) > len(reference_ids):
         return False
-    return prefix_ids[:-1] == reference_ids[: len(prefix_ids) - 1]
+    if prefix_ids == reference_ids[: len(prefix_ids)]:
+        return True
+    return (
+        len(prefix_ids) > 1
+        and trailing_token_id is not None
+        and prefix_ids[-1] == trailing_token_id
+        and prefix_ids[:-1] == reference_ids[: len(prefix_ids) - 1]
+    )
 
 
 def _build_multiturn_assistant_mask(
@@ -171,10 +166,9 @@ def _build_multiturn_assistant_mask(
       turn's end and the next turn's start) is tokenized at most once.
 
     Every tokenized prefix is validated against ``unpadded_full_ids`` (see
-    :func:`_is_consistent_render_prefix`) and a :class:`ValueError` is raised
-    on mismatch: a rewriting template leaves no way to place assistant spans
-    correctly, so failing loudly is the only alternative to silently
-    mislabeling supervised tokens.
+    :func:`_is_consistent_render_prefix`). A known trailing EOS may differ when
+    the prefix is rendered alone. Any other mismatch raises :class:`ValueError`
+    because prefix arithmetic cannot place the spans safely.
     """
     assistant_mask = [0] * len(input_ids)
     found_assistant = False
@@ -198,7 +192,9 @@ def _build_multiturn_assistant_mask(
                 truncation=truncation,
                 seq_length=seq_length,
             )
-            if not _is_consistent_render_prefix(prefix_ids, unpadded_full_ids):
+            if not _is_consistent_render_prefix(
+                prefix_ids, unpadded_full_ids, trailing_token_id=getattr(tokenizer, "eos_token_id", None)
+            ):
                 raise ValueError(
                     f"Cannot build an answer-only loss mask from conversation prefixes: rendering "
                     f"the first {k} message(s) alone does not reproduce a prefix of the fully "
@@ -269,83 +265,70 @@ def _build_reasoning_mask(
 ) -> List[int]:
     """Build a token mask for reasoning_content spans inside assistant turns.
 
-    Spans are located from conversation-prefix renders, so each prefix is
-    validated against ``unpadded_full_ids`` (the unpadded tokenization of the
-    whole conversation, tokenized here when omitted; see
-    :func:`_is_consistent_render_prefix`). Turns whose prefix render diverges
-    from the full render are skipped with a warning rather than an error,
-    unlike :func:`_build_multiturn_assistant_mask`: a rewriting template does
-    not render that turn's reasoning content in the full conversation at all,
-    so there is no span to mask, whereas any prefix-based location would punch
-    the hole at the wrong tokens.
+    Each span is isolated by comparing the full conversation render with a
+    second full render where only that message's ``reasoning_content`` is
+    cleared. This remains correct when the template rewrites earlier turns
+    based on later messages. If clearing the field does not change the render,
+    that turn's reasoning is not present and no tokens need to be masked.
     """
     reasoning_mask = [0] * len(input_ids)
+
+    if unpadded_full_ids is None:
+        unpadded_full_ids = _tokenize_chat(
+            tokenizer,
+            formatted_text,
+            tools=tools,
+            truncation=truncation,
+            seq_length=seq_length,
+        )
+
+    truncation_enabled = truncation not in (False, None, "do_not_truncate")
+    reference_full_ids = unpadded_full_ids
+    reference_offset = 0
+    if truncation_enabled:
+        reference_full_ids = _tokenize_chat(
+            tokenizer,
+            formatted_text,
+            tools=tools,
+            truncation=False,
+            seq_length=None,
+        )
+        if unpadded_full_ids == reference_full_ids[: len(unpadded_full_ids)]:
+            reference_offset = 0
+        elif unpadded_full_ids == reference_full_ids[-len(unpadded_full_ids) :]:
+            reference_offset = len(reference_full_ids) - len(unpadded_full_ids)
+        else:
+            raise ValueError(
+                "Cannot mask reasoning_content after truncation because the retained tokens are not a contiguous "
+                "prefix or suffix of the untruncated conversation render."
+            )
 
     for idx, message in enumerate(formatted_text):
         if message.get("role") != "assistant" or not message.get("reasoning_content"):
             continue
 
-        if unpadded_full_ids is None:
-            unpadded_full_ids = _tokenize_chat(
-                tokenizer,
-                formatted_text,
-                tools=tools,
-                truncation=truncation,
-                seq_length=seq_length,
-            )
-
-        prefix_ids = _tokenize_chat(
-            tokenizer,
-            formatted_text[:idx],
-            tools=tools,
-            truncation=truncation,
-            seq_length=seq_length,
-        )
-        full_ids = _tokenize_chat(
-            tokenizer,
-            formatted_text[: idx + 1],
-            tools=tools,
-            truncation=truncation,
-            seq_length=seq_length,
-        )
-        if not (
-            _is_consistent_render_prefix(prefix_ids, unpadded_full_ids)
-            and _is_consistent_render_prefix(full_ids, unpadded_full_ids)
-        ):
-            logger.warning(
-                "Skipping reasoning_content masking for assistant message %s: the chat template "
-                "renders the conversation prefix differently inside the full conversation, so the "
-                "reasoning span cannot be located (and is likely not rendered in the full "
-                "conversation at all).",
-                idx,
-            )
-            continue
-
+        masked_messages = formatted_text[:idx] + [_masked_reasoning_message(message)] + formatted_text[idx + 1 :]
         masked_ids = _tokenize_chat(
             tokenizer,
-            formatted_text[:idx] + [_masked_reasoning_message(message)],
+            masked_messages,
             tools=tools,
-            truncation=truncation,
-            seq_length=seq_length,
+            truncation=False if truncation_enabled else truncation,
+            seq_length=None if truncation_enabled else seq_length,
         )
 
-        start = len(prefix_ids)
-        full_segment = full_ids[start:]
-        masked_segment = masked_ids[start:]
-        span = _find_reasoning_span(full_segment, masked_segment)
+        span = _find_reasoning_span(reference_full_ids, masked_ids)
         if span is None:
             logger.warning(
-                "Could not isolate reasoning_content tokens for assistant message %s. "
-                "Leave `mask_reasoning_content=False` or ensure the chat template renders "
-                "reasoning_content in a distinct block.",
+                "Could not isolate reasoning_content tokens for assistant message %s. The chat template may not "
+                "render that field, or it may not render it in a distinct block.",
                 idx,
             )
             continue
 
         reasoning_start, reasoning_end = span
-        for pos in range(
-            min(start + reasoning_start, len(reasoning_mask)), min(start + reasoning_end, len(reasoning_mask))
-        ):
+        reasoning_start = max(0, reasoning_start - reference_offset)
+        reasoning_end = min(len(unpadded_full_ids), reasoning_end - reference_offset)
+        for pos in range(reasoning_start, reasoning_end):
             reasoning_mask[pos] = 1
 
     return reasoning_mask
@@ -747,15 +730,22 @@ def format_chat_template(
 
     input_ids = tokenized_chat.get("input_ids")
 
-    def _unpadded_full_ids() -> "list[int] | None":
-        """Unpadded full-conversation ids from this tokenization, already known
-        without another tokenizer call; the mask builders use them to skip
-        re-tokenizing the full prefix and to validate prefix renders. None
-        (recompute in the builder) when no attention_mask is available."""
-        attn = tokenized_chat.get("attention_mask")
-        if attn is None:
-            return None
-        return [token for token, keep in zip(input_ids, attn) if keep]
+    # Unpadded full-conversation ids from this tokenization, already known
+    # without another tokenizer call; the mask builders use them to skip
+    # re-tokenizing the full prefix and to validate prefix renders. Computed
+    # lazily (the common generation-kwd path never needs it) but memoized so
+    # the multiturn and reasoning-mask builders share one computation instead
+    # of each rebuilding it. None (recompute in the builder) when no
+    # attention_mask is available.
+    _unpadded_full_ids_memo: "dict[str, list[int] | None]" = {}
+
+    def unpadded_full_ids() -> "list[int] | None":
+        if "value" not in _unpadded_full_ids_memo:
+            attn = tokenized_chat.get("attention_mask")
+            _unpadded_full_ids_memo["value"] = (
+                [token for token, keep in zip(input_ids, attn) if keep] if attn is not None else None
+            )
+        return _unpadded_full_ids_memo["value"]
 
     if template_has_generation_kwd:
         mask = tokenized_chat["assistant_masks"]
@@ -767,7 +757,7 @@ def format_chat_template(
             tools=tools,
             truncation=truncation,
             seq_length=seq_length,
-            unpadded_full_ids=_unpadded_full_ids(),
+            unpadded_full_ids=unpadded_full_ids(),
         )
         # _build_multiturn_assistant_mask computes indices from unpadded
         # lengths — shift for left-padding tokenizers.
@@ -796,7 +786,7 @@ def format_chat_template(
             tools=tools,
             truncation=truncation,
             seq_length=seq_length,
-            unpadded_full_ids=_unpadded_full_ids(),
+            unpadded_full_ids=unpadded_full_ids(),
         )
         # _build_reasoning_mask also computes from unpadded lengths.
         reasoning_mask = _maybe_shift_mask_for_left_padding(

--- a/tests/unit_tests/datasets/llm/test_formatting_utils.py
+++ b/tests/unit_tests/datasets/llm/test_formatting_utils.py
@@ -118,10 +118,14 @@ def test_mask_labels_to_last_turn_on_binary_mask():
 def test_is_consistent_render_prefix():
     is_prefix = formatting_utils._is_consistent_render_prefix
     assert is_prefix([], [1, 2, 3])  # empty prefix is trivially consistent
+    assert is_prefix([1], [1, 2, 3])  # single-token exact prefix
     assert is_prefix([1, 2], [1, 2, 3])  # exact token prefix
-    assert is_prefix([1, 9], [1, 2, 3])  # divergence only at the final prefix token is tolerated
+    assert not is_prefix([9], [1, 2, 3])  # single-token divergence still moves the boundary
+    assert not is_prefix([1, 9], [1, 2, 3])  # divergence at the final prefix token
     assert not is_prefix([1, 9, 3], [1, 2, 3])  # divergence before the final token
     assert not is_prefix([1, 2, 3, 4], [1, 2, 3])  # prefix render longer than the full render
+    assert is_prefix([1, 9], [1, 2, 3], trailing_token_id=9)  # known standalone terminator
+    assert not is_prefix([9], [1, 2, 3], trailing_token_id=9)  # no content to validate before terminator
 
 
 class _RewritingTokenizer:
@@ -193,7 +197,7 @@ def test_format_chat_template_raises_on_rewriting_template():
         )
 
 
-def test_reasoning_mask_skips_rewritten_turns_and_masks_stable_ones(caplog):
+def test_reasoning_mask_ignores_absent_rewritten_turns_and_masks_stable_ones(caplog):
     # The early assistant turn is re-rendered without reasoning in the full
     # conversation (nothing to mask there); the final turn is stable and its
     # reasoning tokens must still be masked.
@@ -204,7 +208,7 @@ def test_reasoning_mask_skips_rewritten_turns_and_masks_stable_ones(caplog):
     with caplog.at_level("WARNING"):
         mask = formatting_utils._build_reasoning_mask(tok, formatted, full_ids)
 
-    assert "Skipping reasoning_content masking for assistant message 1" in caplog.text
+    assert "Could not isolate reasoning_content tokens for assistant message 1" in caplog.text
     reasoning_positions = [i for i, token in enumerate(full_ids) if token == tok._REASONING_TOKEN]
     assert reasoning_positions  # the final turn's reasoning is rendered
     assert [i for i, value in enumerate(mask) if value] == reasoning_positions
@@ -212,3 +216,88 @@ def test_reasoning_mask_skips_rewritten_turns_and_masks_stable_ones(caplog):
     # Passing the reference render explicitly must not change the result.
     explicit = formatting_utils._build_reasoning_mask(tok, formatted, full_ids, unpadded_full_ids=list(full_ids))
     assert explicit == mask
+
+
+class _HeaderRewritingTokenizer(_RewritingTokenizer):
+    """Rewrites a header based on message count while preserving all reasoning."""
+
+    truncation_side = "right"
+
+    def apply_chat_template(self, messages, **kwargs):
+        ids = [len(messages)]
+        for msg in messages:
+            ids.append(self._ROLE_TOKEN)
+            if msg["role"] == "assistant" and msg.get("reasoning_content"):
+                ids.extend([self._REASONING_TOKEN] * len(msg["reasoning_content"].split()))
+            ids.extend(self._id_for_token(tok) for tok in str(msg["content"]).split())
+        if kwargs.get("truncation") is True and kwargs.get("max_length") is not None:
+            if self.truncation_side == "left":
+                ids = ids[-kwargs["max_length"] :]
+            else:
+                ids = ids[: kwargs["max_length"]]
+        return {"input_ids": ids, "attention_mask": [1] * len(ids)}
+
+
+def test_reasoning_mask_uses_full_render_when_prefix_header_is_rewritten():
+    tok = _HeaderRewritingTokenizer()
+    formatted = _rewriting_conversation()
+    full_ids = tok.apply_chat_template(formatted)["input_ids"]
+
+    mask = formatting_utils._build_reasoning_mask(tok, formatted, full_ids)
+
+    reasoning_positions = [i for i, token in enumerate(full_ids) if token == tok._REASONING_TOKEN]
+    assert reasoning_positions
+    assert [i for i, value in enumerate(mask) if value] == reasoning_positions
+
+
+def test_reasoning_mask_maps_untruncated_span_into_right_truncated_render():
+    tok = _HeaderRewritingTokenizer()
+    formatted = _rewriting_conversation()
+    full_ids = tok.apply_chat_template(formatted, truncation=True, max_length=8)["input_ids"]
+
+    mask = formatting_utils._build_reasoning_mask(
+        tok,
+        formatted,
+        full_ids,
+        truncation=True,
+        seq_length=8,
+        unpadded_full_ids=full_ids,
+    )
+
+    reasoning_positions = [i for i, token in enumerate(full_ids) if token == tok._REASONING_TOKEN]
+    assert reasoning_positions
+    assert [i for i, value in enumerate(mask) if value] == reasoning_positions
+
+
+def test_reasoning_mask_maps_untruncated_span_into_left_truncated_render():
+    tok = _HeaderRewritingTokenizer()
+    tok.truncation_side = "left"
+    formatted = _rewriting_conversation()
+    full_ids = tok.apply_chat_template(formatted, truncation=True, max_length=8)["input_ids"]
+
+    mask = formatting_utils._build_reasoning_mask(
+        tok,
+        formatted,
+        full_ids,
+        truncation=True,
+        seq_length=8,
+        unpadded_full_ids=full_ids,
+    )
+
+    reasoning_positions = [i for i, token in enumerate(full_ids) if token == tok._REASONING_TOKEN]
+    assert reasoning_positions
+    assert [i for i, value in enumerate(mask) if value] == reasoning_positions
+
+
+def test_reasoning_mask_rejects_noncontiguous_truncation_window():
+    tok = _HeaderRewritingTokenizer()
+
+    with pytest.raises(ValueError, match="not a contiguous prefix or suffix"):
+        formatting_utils._build_reasoning_mask(
+            tok,
+            _rewriting_conversation(),
+            [12345],
+            truncation=True,
+            seq_length=1,
+            unpadded_full_ids=[12345],
+        )

--- a/tests/unit_tests/datasets/llm/test_formatting_utils.py
+++ b/tests/unit_tests/datasets/llm/test_formatting_utils.py
@@ -52,23 +52,23 @@ def _conversation():
     ]
 
 
-def test_multiturn_mask_full_length_matches_recompute():
-    # Passing full_length must produce a byte-identical mask to the recompute path.
+def test_multiturn_mask_unpadded_full_ids_matches_recompute():
+    # Passing unpadded_full_ids must produce a byte-identical mask to the recompute path.
     formatted = _conversation()
     input_ids = list(range(2 * len(formatted)))
 
     baseline = formatting_utils._build_multiturn_assistant_mask(_CountingTokenizer(), formatted, input_ids)
     optimized = formatting_utils._build_multiturn_assistant_mask(
-        _CountingTokenizer(), formatted, input_ids, full_length=len(input_ids)
+        _CountingTokenizer(), formatted, input_ids, unpadded_full_ids=list(input_ids)
     )
     assert optimized == baseline
     # assistant turns at idx 1 (tokens [2, 4)) and idx 3 (tokens [6, 8))
     assert baseline == [0, 0, 1, 1, 0, 0, 1, 1]
 
 
-def test_multiturn_mask_full_length_skips_full_retokenize():
+def test_multiturn_mask_unpadded_full_ids_skips_full_retokenize():
     # When the dialogue ends on an assistant turn, the closing boundary is the
-    # full conversation and must be served from full_length, not a fresh call.
+    # full conversation and must be served from unpadded_full_ids, not a fresh call.
     formatted = _conversation()
     input_ids = list(range(2 * len(formatted)))
 
@@ -76,7 +76,9 @@ def test_multiturn_mask_full_length_skips_full_retokenize():
     formatting_utils._build_multiturn_assistant_mask(baseline_tok, formatted, input_ids)
 
     optimized_tok = _CountingTokenizer()
-    formatting_utils._build_multiturn_assistant_mask(optimized_tok, formatted, input_ids, full_length=len(input_ids))
+    formatting_utils._build_multiturn_assistant_mask(
+        optimized_tok, formatted, input_ids, unpadded_full_ids=list(input_ids)
+    )
     assert optimized_tok.calls == baseline_tok.calls - 1
 
 
@@ -111,3 +113,102 @@ def test_mask_labels_to_last_turn_on_binary_mask():
     mask = [0, 1, 1, 0, 1, 1, 1, 0]
     formatting_utils._mask_labels_to_last_turn(mask, ignore_index=0)
     assert mask == [0, 0, 0, 0, 1, 1, 1, 0]
+
+
+def test_is_consistent_render_prefix():
+    is_prefix = formatting_utils._is_consistent_render_prefix
+    assert is_prefix([], [1, 2, 3])  # empty prefix is trivially consistent
+    assert is_prefix([1, 2], [1, 2, 3])  # exact token prefix
+    assert is_prefix([1, 9], [1, 2, 3])  # divergence only at the final prefix token is tolerated
+    assert not is_prefix([1, 9, 3], [1, 2, 3])  # divergence before the final token
+    assert not is_prefix([1, 2, 3, 4], [1, 2, 3])  # prefix render longer than the full render
+
+
+class _RewritingTokenizer:
+    """Simulates Qwen3-style chat templates that rewrite earlier turns.
+
+    Assistant reasoning tokens render only for turns after the last user
+    message. Once a later user turn arrives, earlier assistant turns re-render
+    without their reasoning tokens, so a prefix render is not a token prefix of
+    the full-conversation render.
+    """
+
+    _ROLE_TOKEN = 90
+    _REASONING_TOKEN = 91
+    eos_token_id = 2
+    chat_template = "<dummy reasoning_content template without generation keyword>"
+
+    def __init__(self):
+        self._vocab = {}
+        self._cursor = 100
+
+    def _id_for_token(self, tok):
+        if tok not in self._vocab:
+            self._vocab[tok] = self._cursor
+            self._cursor += 1
+        return self._vocab[tok]
+
+    def apply_chat_template(self, messages, **kwargs):
+        last_user = max((i for i, msg in enumerate(messages) if msg["role"] == "user"), default=-1)
+        ids = []
+        for i, msg in enumerate(messages):
+            ids.append(self._ROLE_TOKEN)
+            if msg["role"] == "assistant" and i > last_user and msg.get("reasoning_content"):
+                ids.extend([self._REASONING_TOKEN] * len(msg["reasoning_content"].split()))
+            ids.extend(self._id_for_token(tok) for tok in str(msg["content"]).split())
+        return {"input_ids": ids, "attention_mask": [1] * len(ids)}
+
+
+def _rewriting_conversation():
+    return [
+        {"role": "user", "content": "q1"},
+        {"role": "assistant", "content": "a1 done", "reasoning_content": "step one two"},
+        {"role": "user", "content": "q2"},
+        {"role": "assistant", "content": "a2 done", "reasoning_content": "step three"},
+    ]
+
+
+def test_multiturn_mask_raises_on_rewriting_template():
+    # A prefix render that is not a token prefix of the full render would put
+    # assistant spans at the wrong positions; the builder must refuse instead.
+    tok = _RewritingTokenizer()
+    formatted = _rewriting_conversation()
+    full_ids = tok.apply_chat_template(formatted)["input_ids"]
+
+    with pytest.raises(ValueError, match="rewrites earlier turns"):
+        formatting_utils._build_multiturn_assistant_mask(tok, formatted, full_ids)
+
+
+def test_format_chat_template_raises_on_rewriting_template():
+    # End to end: the default answer-only path surfaces the template problem
+    # instead of silently supervising tool/user tokens.
+    tok = _RewritingTokenizer()
+    with pytest.raises(ValueError, match="rewrites earlier turns"):
+        formatting_utils.format_chat_template(
+            tok,
+            formatted_text=_rewriting_conversation(),
+            eos_token_id=tok.eos_token_id,
+            pad_token_id=tok.eos_token_id,
+            answer_only_loss_mask=True,
+        )
+
+
+def test_reasoning_mask_skips_rewritten_turns_and_masks_stable_ones(caplog):
+    # The early assistant turn is re-rendered without reasoning in the full
+    # conversation (nothing to mask there); the final turn is stable and its
+    # reasoning tokens must still be masked.
+    tok = _RewritingTokenizer()
+    formatted = _rewriting_conversation()
+    full_ids = tok.apply_chat_template(formatted)["input_ids"]
+
+    with caplog.at_level("WARNING"):
+        mask = formatting_utils._build_reasoning_mask(tok, formatted, full_ids)
+
+    assert "Skipping reasoning_content masking for assistant message 1" in caplog.text
+    reasoning_positions = [i for i, token in enumerate(full_ids) if token == tok._REASONING_TOKEN]
+    assert reasoning_positions  # the final turn's reasoning is rendered
+    assert [i for i, value in enumerate(mask) if value] == reasoning_positions
+
+    # Passing the reference render explicitly must not change the result.
+    explicit = formatting_utils._build_reasoning_mask(tok, formatted, full_ids, unpadded_full_ids=list(full_ids))
+    assert explicit == mask


### PR DESCRIPTION
# Problem

The fallback answer-only mask locates each assistant turn with tokenized conversation-prefix lengths:

```text
start = len(render(messages[:assistant_index]))
end = len(render(messages[:assistant_index + 1]))
```

This is correct only when every standalone prefix is also an exact token prefix of the fully rendered conversation.

Some chat templates rewrite earlier turns after later messages are appended. Qwen3 is one concrete example: an assistant turn rendered by itself can contain its `<think>` block, but the same turn is rendered without that block once a later user message exists.

```text
render([user_1, assistant_1])
    = user_1 + think_1 + answer_1

render([user_1, assistant_1, user_2, assistant_2])
    = user_1 + answer_1 + user_2 + think_2 + answer_2
```

The old code still used the longer standalone-prefix length as the end of `assistant_1`. The resulting mask extended past the real answer boundary and could silently supervise tokens from `user_2`, tool messages, or later turns. Training continued without an error, but with incorrect labels.

The same unstable-prefix assumption was also used to locate `reasoning_content`. A rewritten prefix could therefore mask the wrong tokens, while simply skipping every rewritten prefix could leave rendered reasoning tokens supervised.

# Fix

- Validate each tokenized prefix against the full-conversation tokenization before using its length as an assistant boundary.
- Require an exact token prefix by default.
- Preserve the existing boundary tolerance only for multi-token prefixes ending in the tokenizer's known EOS token.
- Raise a descriptive `ValueError` when assistant spans cannot be located safely. The error directs users to a chat template with `{% generation %}` blocks instead of producing corrupted labels.
- Locate each reasoning span by comparing two full-conversation renders, with only the target message's `reasoning_content` cleared.
- Map reasoning spans from the untruncated render into left-truncated and right-truncated training windows.
- Reject truncation results that are not a contiguous prefix or suffix of the untruncated render.

For Qwen3-style history rewriting, earlier reasoning that is absent from the final render produces no mask span, while reasoning that remains in the final render is still masked correctly.

# Testing

- `127 passed` across `test_formatting_utils.py`, `test_tokenizer_apply_functions.py`, `test_agent_chat.py`, and agent recipe wiring tests.
- Added focused CPU coverage for Qwen3-style history rewriting, preserved reasoning under unrelated header rewriting, EOS boundary handling, left truncation, right truncation, and invalid noncontiguous truncation.
- `ruff format --check`
- `ruff check`
- `git diff --check`

# Before your PR is "Ready for review"

- [x] Read and followed the contributor guidelines
- [x] Added focused CPU unit tests
- [x] Updated affected documentation and error messages