### PR TITLE
fix(models): temporarily disable TE fused RoPE globally

### DIFF
--- a/nemo_automodel/components/models/common/utils.py
+++ b/nemo_automodel/components/models/common/utils.py
@@ -233,8 +233,7 @@ class BackendConfig:
         # in some models. See #3027. This is the one chokepoint every BackendConfig passes
         # through, so it also overrides an explicit rope_fusion=True from a recipe/config.
         if self.rope_fusion:
-            if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
-                logger.warning("rope_fusion is temporarily force-disabled globally (see #3027).")
+            logger.warning("rope_fusion is temporarily force-disabled globally (see #3027).")
         self.rope_fusion = False
 
         # Normalize te_fp8: dict -> TEFp8Config, None stays None

--- a/nemo_automodel/components/models/common/utils.py
+++ b/nemo_automodel/components/models/common/utils.py
@@ -228,6 +228,15 @@ class BackendConfig:
     compile_attn: bool = False
 
     def __post_init__(self):
+        # TEMPORARY: force TE fused RoPE off globally. The fused kernel computes cos/sin
+        # in fp32 in-kernel while HF/vLLM rotate with bf16 tables, breaking logprob parity
+        # in some models. See #3027. This is the one chokepoint every BackendConfig passes
+        # through, so it also overrides an explicit rope_fusion=True from a recipe/config.
+        if self.rope_fusion:
+            if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
+                logger.warning("rope_fusion is temporarily force-disabled globally (see #3027).")
+        self.rope_fusion = False
+
         # Normalize te_fp8: dict -> TEFp8Config, None stays None
         if isinstance(self.te_fp8, dict):
             self.te_fp8 = TEFp8Config(**self.te_fp8)

--- a/tests/functional_tests/context_parallel/run_attention_cp.py
+++ b/tests/functional_tests/context_parallel/run_attention_cp.py
@@ -274,7 +274,11 @@ def get_model_config_and_attention(model_type, device):
         from nemo_automodel.components.models.gpt_oss.rope_utils import position_ids_to_freqs_cis
 
         def get_freqs_cis(position_ids, qkv_format, cp_size=1):
-            return position_ids_to_freqs_cis(rope, position_ids, qkv_format, cp_size=cp_size)
+            # Build freqs in the layout the (possibly globally-disabled, see #3027) fused-RoPE
+            # setting actually uses, so the frequencies match the attention's RoPE path.
+            return position_ids_to_freqs_cis(
+                rope, position_ids, qkv_format, for_fused_rope=backend.rope_fusion, cp_size=cp_size
+            )
 
     elif model_type == "deepseek_v3":
         from transformers.models.deepseek_v3.configuration_deepseek_v3 import DeepseekV3Config
@@ -327,7 +331,7 @@ def get_model_config_and_attention(model_type, device):
 
         def get_freqs_cis(position_ids, qkv_format, cp_size=1):
             return freqs_cis_from_position_ids(
-                position_ids, rope_freqs, qkv_format=qkv_format, for_fused_rope=True, cp_size=cp_size
+                position_ids, rope_freqs, qkv_format=qkv_format, for_fused_rope=backend.rope_fusion, cp_size=cp_size
             )
 
     elif model_type == "nemotron_v3":

--- a/tests/unit_tests/models/gpt_oss/test_gptoss_layers.py
+++ b/tests/unit_tests/models/gpt_oss/test_gptoss_layers.py
@@ -231,6 +231,7 @@ class TestGptOssAttention:
 
         assert attention.yarn_concentration is None
 
+    @pytest.mark.skip(reason="TE fused RoPE force-disabled globally in BackendConfig.__post_init__; see #3027")
     def test_yarn_concentration_set_with_rope_fusion(self, gpt_config_with_rope_scaling, backend_config_with_rope_fusion):
         """Test that yarn_concentration is correctly computed when rope_fusion is True."""
         import math
@@ -241,6 +242,7 @@ class TestGptOssAttention:
         expected_concentration = 0.1 * math.log(2.0) + 1.0
         assert abs(attention.yarn_concentration - expected_concentration) < 1e-6
 
+    @pytest.mark.skip(reason="TE fused RoPE force-disabled globally in BackendConfig.__post_init__; see #3027")
     def test_yarn_concentration_different_scaling_factors(self, backend_config_with_rope_fusion):
         """Test yarn_concentration with different scaling factors."""
         import math

--- a/tests/unit_tests/moe/test_backend_config.py
+++ b/tests/unit_tests/moe/test_backend_config.py
@@ -372,3 +372,25 @@ class TestBackendConfigCompileAttn:
         # compile_mla was consolidated into the generic compile_attn flag.
         with pytest.raises(TypeError):
             BackendConfig(compile_mla=True)
+
+
+class TestBackendConfigRopeFusionDisabled:
+    """TE fused RoPE is temporarily force-disabled globally in __post_init__ (see #3027)."""
+
+    def test_rope_fusion_default_forced_false(self):
+        """The default resolves to False regardless of TE/CUDA availability."""
+        assert BackendConfig().rope_fusion is False
+
+    def test_rope_fusion_explicit_true_is_overridden(self, caplog):
+        """An explicit rope_fusion=True is forced back to False and warns once."""
+        with caplog.at_level(logging.WARNING):
+            config = BackendConfig(rope_fusion=True)
+        assert config.rope_fusion is False
+        assert "rope_fusion is temporarily force-disabled globally" in caplog.text
+
+    def test_rope_fusion_explicit_false_no_warning(self, caplog):
+        """An explicit rope_fusion=False stays False and logs no override warning."""
+        with caplog.at_level(logging.WARNING):
+            config = BackendConfig(rope_fusion=False)
+        assert config.rope_fusion is False
+        assert "force-disabled" not in caplog.text


### PR DESCRIPTION
## What

Force `rope_fusion=False` for every `BackendConfig` in `__post_init__`, disabling TE fused RoPE globally.

## Why

The fused RoPE kernel computes cos/sin in fp32 in-kernel while HF/vLLM rotate with bf16 tables, breaking logprob parity in some models (e.g. Qwen3-MoE). Temporary correctness-over-speed workaround until a parity fix lands — see NVIDIA-NeMo/Automodel#3027.

## Notes

* Single chokepoint: overrides both the default and any explicit `rope_fusion: true` in a recipe/config; logs a one-time rank-0 warning when overriding an explicit `True`.
* To re-enable, remove the block in `BackendConfig.__post_init__`.

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)