### PR TITLE
fix(glm_moe_dsa): clamp DSA indexer top-k for short sequences

### DIFF
--- a/nemo_automodel/components/models/glm_moe_dsa/kernels/indexer.py
+++ b/nemo_automodel/components/models/glm_moe_dsa/kernels/indexer.py
@@ -43,6 +43,11 @@ class IndexerFunction(torch.autograd.Function):
         _, head_num, _ = index_q.shape
         logits = indexer_fwd_interface(index_q, index_k, weights, cu_seqlen_ks, cu_seqlen_ke, clean_logits=True)
         if topk_indices is None:
+            # Pad logits with -inf when seq_len_kv < topk so torch.topk keeps a fixed k=topk
+            # (static shape); the padded columns become the same -1 sentinel as causal masking.
+            pad = topk - logits.shape[-1]
+            if pad > 0:
+                logits = torch.nn.functional.pad(logits, (0, pad), value=float("-inf"))
             index_score, topk_indices = torch.topk(logits, topk, dim=-1)
             topk_indices = topk_indices.to(torch.int32)
             topk_indices = topk_indices.masked_fill(index_score == -torch.inf, -1)

--- a/tests/unit_tests/models/glm_moe_dsa/test_glm_moe_dsa_tilelang.py
+++ b/tests/unit_tests/models/glm_moe_dsa/test_glm_moe_dsa_tilelang.py
@@ -834,6 +834,40 @@ def test_indexer_topk_matches_dense():
     assert mean_overlap > 0.97, f"indexer top-k set overlap too low: {mean_overlap:.4f}"
 
 
+@requires_kernels
+def test_indexer_topk_short_sequence_below_index_topk():
+    """When the packed sequence has fewer keys than index_topk, the indexer must not
+
+    crash on torch.topk ("selected index k out of range"); it should select the
+    available keys and pad back to the fixed index_topk width with the -1 sentinel so
+    the sparse-MLA kernel still gets a width that is a multiple of block_I (64).
+    """
+    torch.manual_seed(0)
+    dev = "cuda"
+    short_t = TOPK // 2  # e.g. 32 < TOPK (64): triggers the short-sequence path
+    assert short_t < TOPK
+    scale = IDX_DIM**-0.5
+    index_q = torch.randn(short_t, IDX_HEADS, IDX_DIM, device=dev, dtype=torch.bfloat16)
+    index_k = torch.randn(short_t, IDX_DIM, device=dev, dtype=torch.bfloat16)
+    weights_proj = torch.randn(short_t, IDX_HEADS, device=dev, dtype=torch.float32)
+
+    head_weights = (weights_proj * (IDX_HEADS**-0.5) * scale).contiguous()
+    cu_seqlens = torch.tensor([0, short_t], device=dev, dtype=torch.int32)
+    topk_tl = ok.tilelang_indexer_topk(index_q.contiguous(), index_k.contiguous(), head_weights, cu_seqlens, TOPK)
+
+    # Width stays at the fixed index_topk (multiple of block_I) even though only short_t keys exist.
+    assert topk_tl.shape == (short_t, 1, TOPK)
+    assert TOPK % 64 == 0
+    tilelang_topk = topk_tl.squeeze(1)
+    # Every selected (non-sentinel) index must be a valid causal key position (< short_t).
+    valid = tilelang_topk[tilelang_topk != -1]
+    assert int(valid.min()) >= 0 and int(valid.max()) < short_t
+    # Each query keeps at most (its causal window) real keys; the rest are -1 padding.
+    for t in range(short_t):
+        n_real = int((tilelang_topk[t] != -1).sum())
+        assert n_real <= t + 1
+
+
 def _causal_topk_indices(num_tokens, topk, device):
     idx = torch.full((num_tokens, topk), -1, device=device, dtype=torch.int32)
     for t in range(num_tokens):


### PR DESCRIPTION
## Problem

GLM-5.2 DSA training with `backend.attn=tilelang` crashes with
`RuntimeError: selected index k out of range` whenever the packed sequence total
(`seq_len_kv`) is **shorter than `index_topk` (2048)** — i.e. any short-sequence run.

## Root cause

In `glm_moe_dsa/kernels/indexer.py`, `IndexerFunction.forward` calls
`torch.topk(logits, index_topk, dim=-1)` where `logits` is `[seq_len, seq_len_kv]`
and `seq_len_kv` is the total packed key tokens. `torch.topk` raises
`"selected index k out of range"` when `k > logits.shape[-1]`, so any packed batch
with fewer than `index_topk` keys crashes. The dense torch path already guarded this
(`actual_topk = min(index_topk, seq_len)`); only the fused TileLang path was missing it.

## Fix

Clamp `k = min(topk, logits.shape[-1])` for the `topk` call, then pad the indices
back to the fixed `index_topk` width with the `-1` sentinel. The padding is identical
to the causal-masked slots `topk` already emits for early query positions, so
`pytorch_extract_topk_scores` and the backward kernel handle it unchanged. Keeping the
width at `index_topk` preserves the sparse-MLA kernel requirement that
`topk % block_I (64) == 0`.

## Testing

- New GPU regression test `test_indexer_topk_short_sequence_below_index_topk`
  exercises `seq_len_kv < index_topk` (the existing kernel tests used `T=256 > TOPK=64`
  and never hit this path). Full `test_glm_moe_dsa_tilelang.py` passes (37 tests).
- `ruff format` / `ruff check` clean.

### End-to-end scale validation

16-node **ep128 × pp1** GLM-5.2 SFT on HellaSwag, `backend.attn=tilelang`, packed to
**1024** (`< index_topk 2048`, `local_batch_size=1` → every THD forward has
`seq_len_kv=1024`, exercising the fixed path). Trains cleanly with **no crash**:

- step 0 loss **2.49** → step 66 loss **1.28**, smooth decrease, stable grad-norm
- heldout **val loss 1.44** (step 50), ~26k tps, 54 GiB/GPU
- **0** occurrences of `selected index k out of range` / traceback / CUDA error

W&B: https://wandb.ai/Nemo-automodel/huiyingl_workspace/runs/bbgmm64n

🤖 Generated with [Claude Code](https://claude.com/claude-code)