### PR TITLE
feat(speculative): add periodic real accept-length eval

### DIFF
--- a/examples/speculative/eagle3/qwen3_eagle3_perfectblend.yaml
+++ b/examples/speculative/eagle3/qwen3_eagle3_perfectblend.yaml
@@ -18,6 +18,12 @@ recipe_args:
   num_workers: 0
   num_epochs: 1
   ttt_steps: 7
+  # decode_eval:                   # periodic REAL accept-length eval in a vLLM server (train/tau_real)
+  #   every_steps: 500             # launch cadence (optimizer steps); checked at log points
+  #   cuda_visible_devices: "7"    # REQUIRED: GPU reserved for the eval engine (exclude it from torchrun)
+  #   num_prompts: 32              # fixed prompt set drawn from input_data (default: train_data_path)
+  #   max_new_tokens: 256
+  #   port: 8199
   draft_vocab_size: 32000
   freeze_embeddings: true
   trust_remote_code: false

--- a/examples/speculative/eagle3/qwen3_eagle3_perfectblend.yaml
+++ b/examples/speculative/eagle3/qwen3_eagle3_perfectblend.yaml
@@ -23,7 +23,7 @@ recipe_args:
   #   cuda_visible_devices: "7"    # REQUIRED: GPU reserved for the eval engine (exclude it from torchrun)
   #   num_prompts: 32              # fixed prompt set drawn from input_data (default: train_data_path)
   #   max_new_tokens: 256
-  #   port: 8199
+  #   port: 0                    # auto-select a free loopback port
   draft_vocab_size: 32000
   freeze_embeddings: true
   trust_remote_code: false

--- a/nemo_automodel/components/speculative/decode_eval.py
+++ b/nemo_automodel/components/speculative/decode_eval.py
@@ -42,12 +42,16 @@ from __future__ import annotations
 import json
 import logging
 import os
+import shutil
+import signal
+import socket
 import subprocess
 import sys
 import time
 import urllib.request
 from argparse import Namespace
 from dataclasses import asdict, dataclass, fields
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -90,6 +94,7 @@ class DecodeEvalConfig:
     target_model: str
     input_data: str
     output_dir: str
+    num_speculative_tokens: int
     num_prompts: int = 32
     concurrency: int = 8
     max_new_tokens: int = 256
@@ -100,15 +105,21 @@ class DecodeEvalConfig:
     split: str = "train"
     dataset_name: str | None = None
     shuffle_seed: int = 42
-    port: int = 8199
+    port: int = 0
     gpu_memory_utilization: float = 0.8
-    num_speculative_tokens: int | None = None
     max_model_len: int | None = None
     trust_remote_code: bool = False
     timeout_s: float = 1800.0
 
 
-def resolve_decode_eval_config(recipe_cfg, *, default_target: str, default_input_data: str, output_dir: str):
+def resolve_decode_eval_config(
+    recipe_cfg: Any,
+    *,
+    default_target: str,
+    default_input_data: str | None,
+    default_num_speculative_tokens: int,
+    output_dir: str,
+) -> DecodeEvalConfig | None:
     """Read the optional ``decode_eval:`` block from ``recipe_args``.
 
     Returns ``None`` when the block is absent or ``every_steps`` is unset/0
@@ -123,13 +134,30 @@ def resolve_decode_eval_config(recipe_cfg, *, default_target: str, default_input
     every_steps = int(block.get("every_steps", 0) or 0)
     if every_steps <= 0:
         return None
+    block = block.to_dict() if hasattr(block, "to_dict") else dict(block)
+    unknown = set(block) - {field.name for field in fields(DecodeEvalConfig)}
+    if unknown:
+        raise ValueError(f"Unknown decode_eval option(s): {', '.join(sorted(unknown))}")
     cuda_visible_devices = block.get("cuda_visible_devices", None)
     if cuda_visible_devices is None or str(cuda_visible_devices) == "":
         raise ValueError(
             "decode_eval.cuda_visible_devices is required: the eval engine needs a GPU the training "
             "job does not use (e.g. reserve one card and shrink the torchrun world accordingly)."
         )
-    required = {"every_steps", "cuda_visible_devices", "target_model", "input_data", "output_dir"}
+    input_data = block.get("input_data", None) or default_input_data
+    if not input_data:
+        raise ValueError("decode_eval.input_data is required when recipe_args.train_data_path is not set.")
+    num_speculative_tokens = int(block.get("num_speculative_tokens", None) or default_num_speculative_tokens)
+    if num_speculative_tokens <= 0:
+        raise ValueError("decode_eval.num_speculative_tokens must be greater than 0.")
+    required = {
+        "every_steps",
+        "cuda_visible_devices",
+        "target_model",
+        "input_data",
+        "output_dir",
+        "num_speculative_tokens",
+    }
     overrides = {}
     for field in fields(DecodeEvalConfig):
         if field.name in required:
@@ -141,8 +169,9 @@ def resolve_decode_eval_config(recipe_cfg, *, default_target: str, default_input
         every_steps=every_steps,
         cuda_visible_devices=str(cuda_visible_devices),
         target_model=str(block.get("target_model", None) or default_target),
-        input_data=str(block.get("input_data", None) or default_input_data),
+        input_data=str(input_data),
         output_dir=os.path.join(output_dir, "decode_eval"),
+        num_speculative_tokens=num_speculative_tokens,
         **overrides,
     )
 
@@ -199,10 +228,62 @@ class DecodeEvalRunner:
     def __init__(self, config: DecodeEvalConfig):
         self.config = config
         self._proc: subprocess.Popen | None = None
+        self._worker_log_path: str | None = None
         self._launched_for_step = -1
         self._last_bucket = 0
         self._collected: set[str] = set()
         os.makedirs(config.output_dir, exist_ok=True)
+        for _, step_dir in self._step_dirs():
+            result_path = os.path.join(config.output_dir, step_dir, _RESULT_FILENAME)
+            if os.path.exists(result_path):
+                self._collected.add(result_path)
+                self._cleanup_snapshot(os.path.join(config.output_dir, step_dir))
+
+    def _step_dirs(self) -> list[tuple[int, str]]:
+        """Return valid step directories in numeric order, ignoring stray names."""
+        try:
+            entries = os.listdir(self.config.output_dir)
+        except FileNotFoundError:
+            return []
+        parsed = []
+        for entry in entries:
+            if not entry.startswith("step_"):
+                continue
+            try:
+                parsed.append((int(entry.split("_", 1)[1]), entry))
+            except ValueError:
+                logger.warning("decode_eval: ignoring invalid step directory %s", entry)
+        return sorted(parsed)
+
+    @staticmethod
+    def _cleanup_snapshot(step_dir: str) -> None:
+        """Remove heavyweight weights after an eval no longer needs them."""
+        try:
+            shutil.rmtree(os.path.join(step_dir, "model"))
+        except FileNotFoundError:
+            pass
+        except OSError:
+            logger.exception("decode_eval: failed to remove snapshot under %s", step_dir)
+
+    def _reap_finished_worker(self) -> None:
+        """Report a completed worker and release its Popen state."""
+        if self._proc is None:
+            return
+        return_code = self._proc.poll()
+        if return_code is None:
+            return
+        if return_code != 0:
+            logger.error(
+                "decode_eval: worker for step %d exited with code %d; see %s",
+                self._launched_for_step,
+                return_code,
+                self._worker_log_path,
+            )
+            self._cleanup_snapshot(os.path.join(self.config.output_dir, f"step_{self._launched_for_step}"))
+        else:
+            logger.info("decode_eval: worker for step %d completed", self._launched_for_step)
+        self._proc = None
+        self._worker_log_path = None
 
     def due(self, global_step: int) -> bool:
         """Whether a new eval should launch at this optimizer step."""
@@ -212,6 +293,7 @@ class DecodeEvalRunner:
         """Snapshot the draft and launch the worker if the cadence is due and no eval is running."""
         if not self.due(global_step):
             return False
+        self._reap_finished_worker()
         if self._proc is not None and self._proc.poll() is None:
             logger.info(
                 "decode_eval: previous eval (step %d) still running, skipping launch at step %d",
@@ -219,39 +301,52 @@ class DecodeEvalRunner:
                 global_step,
             )
             return False
-        self._last_bucket = global_step // self.config.every_steps
         step_dir = os.path.join(self.config.output_dir, f"step_{global_step}")
         os.makedirs(step_dir, exist_ok=True)
-        export_draft_snapshot(draft_model, step_dir)
-        # The full config crosses the subprocess boundary as a JSON sidecar next
-        # to the snapshot (one declaration site, and a debugging record of what
-        # the eval ran with); the argv carries only the per-launch paths.
-        config_json = os.path.join(step_dir, _CONFIG_FILENAME)
-        with open(config_json, "w") as f:
-            json.dump(asdict(self.config), f, indent=2)
-        argv = [
-            sys.executable,
-            "-m",
-            "nemo_automodel.components.speculative.decode_eval",
-            "--config-json",
-            config_json,
-            "--draft",
-            step_dir,
-            "--step",
-            str(global_step),
-            "--result-json",
-            os.path.join(step_dir, _RESULT_FILENAME),
-        ]
-        log_path = os.path.join(step_dir, _WORKER_LOG_FILENAME)
-        with open(log_path, "ab") as log_file:
-            self._proc = subprocess.Popen(
-                argv,
-                stdout=log_file,
-                stderr=subprocess.STDOUT,
-                env=_worker_env(self.config.cuda_visible_devices),
-                start_new_session=True,
-            )
+        result_path = os.path.join(step_dir, _RESULT_FILENAME)
+        for stale_path in (result_path, result_path + ".tmp"):
+            try:
+                os.remove(stale_path)
+            except FileNotFoundError:
+                pass
+        self._collected.discard(result_path)
+        self._cleanup_snapshot(step_dir)
+        try:
+            export_draft_snapshot(draft_model, step_dir)
+            # The full config crosses the subprocess boundary as a JSON sidecar next
+            # to the snapshot (one declaration site, and a debugging record of what
+            # the eval ran with); the argv carries only the per-launch paths.
+            config_json = os.path.join(step_dir, _CONFIG_FILENAME)
+            with open(config_json, "w") as f:
+                json.dump(asdict(self.config), f, indent=2)
+            argv = [
+                sys.executable,
+                "-m",
+                "nemo_automodel.components.speculative.decode_eval",
+                "--config-json",
+                config_json,
+                "--draft",
+                step_dir,
+                "--step",
+                str(global_step),
+                "--result-json",
+                result_path,
+            ]
+            log_path = os.path.join(step_dir, _WORKER_LOG_FILENAME)
+            with open(log_path, "ab") as log_file:
+                self._proc = subprocess.Popen(
+                    argv,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                    env=_worker_env(self.config.cuda_visible_devices),
+                    start_new_session=True,
+                )
+        except Exception:
+            self._cleanup_snapshot(step_dir)
+            raise
+        self._last_bucket = global_step // self.config.every_steps
         self._launched_for_step = global_step
+        self._worker_log_path = log_path
         logger.info(
             "decode_eval: launched eval for step %d on CUDA_VISIBLE_DEVICES=%s (pid %d, log %s)",
             global_step,
@@ -263,23 +358,21 @@ class DecodeEvalRunner:
 
     def collect(self) -> list[dict]:
         """Return finished, not-yet-reported eval results in snapshot-step order."""
+        self._reap_finished_worker()
         results = []
-        try:
-            step_dirs = sorted(
-                (d for d in os.listdir(self.config.output_dir) if d.startswith("step_")),
-                key=lambda d: int(d.split("_", 1)[1]),
-            )
-        except (FileNotFoundError, ValueError):
-            return results
-        for step_dir in step_dirs:
+        for step, step_dir in self._step_dirs():
             path = os.path.join(self.config.output_dir, step_dir, _RESULT_FILENAME)
             if path in self._collected or not os.path.exists(path):
                 continue
             try:
                 with open(path) as f:
-                    results.append(json.load(f))
+                    result = json.load(f)
+                if result.get("step") != step:
+                    raise ValueError(f"result step {result.get('step')!r} does not match directory step {step}")
+                results.append(result)
                 self._collected.add(path)
-            except (OSError, json.JSONDecodeError):
+                self._cleanup_snapshot(os.path.join(self.config.output_dir, step_dir))
+            except (OSError, ValueError, json.JSONDecodeError):
                 logger.warning("decode_eval: unreadable result %s, will retry next collect", path)
         return results
 
@@ -290,14 +383,28 @@ class DecodeEvalRunner:
             try:
                 # The worker was started in its own session; signal the whole
                 # group so the vLLM server child goes down with it.
-                os.killpg(os.getpgid(self._proc.pid), 15)
+                process_group = os.getpgid(self._proc.pid)
+                os.killpg(process_group, signal.SIGTERM)
             except (ProcessLookupError, PermissionError):
+                process_group = None
                 self._proc.terminate()
             try:
                 self._proc.wait(timeout=30)
             except subprocess.TimeoutExpired:
-                self._proc.kill()
+                if process_group is not None:
+                    try:
+                        os.killpg(process_group, signal.SIGKILL)
+                    except (ProcessLookupError, PermissionError):
+                        self._proc.kill()
+                else:
+                    self._proc.kill()
+                self._proc.wait()
+        elif self._proc is not None:
+            self._reap_finished_worker()
+        if self._launched_for_step >= 0:
+            self._cleanup_snapshot(os.path.join(self.config.output_dir, f"step_{self._launched_for_step}"))
         self._proc = None
+        self._worker_log_path = None
 
 
 # --------------------------------------------------------------------------- #
@@ -320,6 +427,16 @@ def _wait_for_server(server: str, proc: subprocess.Popen, timeout_s: float) -> N
             pass
         time.sleep(3)
     raise TimeoutError(f"vLLM server did not become healthy within {timeout_s:.0f}s")
+
+
+def _resolve_worker_port(configured_port: int) -> int:
+    """Choose an unused loopback port, or fail if an explicit port is occupied."""
+    with socket.socket() as sock:
+        try:
+            sock.bind(("127.0.0.1", configured_port))
+        except OSError as exc:
+            raise RuntimeError(f"decode_eval port {configured_port} is already in use") from exc
+        return int(sock.getsockname()[1])
 
 
 def _build_parser():
@@ -391,6 +508,7 @@ def main(argv=None) -> int:
     args = _build_parser().parse_args(argv)
     with open(args.config_json) as f:
         cfg = DecodeEvalConfig(**json.load(f))
+    cfg.port = _resolve_worker_port(cfg.port)
     server = f"http://127.0.0.1:{cfg.port}"
     serve_argv = _serve_argv(cfg, args.draft)
     print(f"decode_eval worker: starting engine: {' '.join(serve_argv)}", flush=True)

--- a/nemo_automodel/components/speculative/decode_eval.py
+++ b/nemo_automodel/components/speculative/decode_eval.py
@@ -46,12 +46,13 @@ import subprocess
 import sys
 import time
 import urllib.request
-from dataclasses import dataclass
 from argparse import Namespace
+from dataclasses import asdict, dataclass, fields
 
 logger = logging.getLogger(__name__)
 
 _RESULT_FILENAME = "result.json"
+_CONFIG_FILENAME = "decode_eval_config.json"
 _WORKER_LOG_FILENAME = "worker.log"
 
 # torchrun / elastic / rank state that must NOT leak into the worker: vLLM would
@@ -113,7 +114,8 @@ def resolve_decode_eval_config(recipe_cfg, *, default_target: str, default_input
     Returns ``None`` when the block is absent or ``every_steps`` is unset/0
     (feature disabled). Raises on a partially-configured block so a typo'd GPU
     reservation fails at setup rather than silently evaluating on a training
-    GPU.
+    GPU. Field defaults live on :class:`DecodeEvalConfig` only; the block just
+    overrides the fields it sets.
     """
     block = recipe_cfg.get("decode_eval", None)
     if block is None:
@@ -127,28 +129,21 @@ def resolve_decode_eval_config(recipe_cfg, *, default_target: str, default_input
             "decode_eval.cuda_visible_devices is required: the eval engine needs a GPU the training "
             "job does not use (e.g. reserve one card and shrink the torchrun world accordingly)."
         )
+    required = {"every_steps", "cuda_visible_devices", "target_model", "input_data", "output_dir"}
+    overrides = {}
+    for field in fields(DecodeEvalConfig):
+        if field.name in required:
+            continue
+        value = block.get(field.name, None)
+        if value is not None:
+            overrides[field.name] = value
     return DecodeEvalConfig(
         every_steps=every_steps,
         cuda_visible_devices=str(cuda_visible_devices),
         target_model=str(block.get("target_model", None) or default_target),
         input_data=str(block.get("input_data", None) or default_input_data),
         output_dir=os.path.join(output_dir, "decode_eval"),
-        num_prompts=int(block.get("num_prompts", 32)),
-        concurrency=int(block.get("concurrency", 8)),
-        max_new_tokens=int(block.get("max_new_tokens", 256)),
-        temperature=float(block.get("temperature", 0.0)),
-        top_p=float(block.get("top_p", 1.0)),
-        messages_column=str(block.get("messages_column", "messages")),
-        prompt_column=block.get("prompt_column", None),
-        split=str(block.get("split", "train")),
-        dataset_name=block.get("dataset_name", None),
-        shuffle_seed=int(block.get("shuffle_seed", 42)),
-        port=int(block.get("port", 8199)),
-        gpu_memory_utilization=float(block.get("gpu_memory_utilization", 0.8)),
-        num_speculative_tokens=block.get("num_speculative_tokens", None),
-        max_model_len=block.get("max_model_len", None),
-        trust_remote_code=bool(block.get("trust_remote_code", False)),
-        timeout_s=float(block.get("timeout_s", 1800.0)),
+        **overrides,
     )
 
 
@@ -159,6 +154,10 @@ def export_draft_snapshot(draft_model, out_dir: str) -> str:
     the same layout the final checkpoint's consolidated export uses, so
     ``serve_vllm.resolve_draft_artifacts`` can consume it directly (the
     d2t/t2d vocab-mapping buffers ride along in the state dict).
+
+    Assumes the draft is replicated on the calling rank (the EAGLE-3 draft
+    trains under DDP, so rank 0 holds the full weights); a sharded draft would
+    snapshot an incomplete state dict.
 
     Args:
         draft_model: the (unwrapped) draft ``nn.Module``; its parameter and
@@ -207,8 +206,7 @@ class DecodeEvalRunner:
 
     def due(self, global_step: int) -> bool:
         """Whether a new eval should launch at this optimizer step."""
-        bucket = global_step // self.config.every_steps
-        return bucket > self._last_bucket
+        return global_step // self.config.every_steps > self._last_bucket
 
     def maybe_launch(self, global_step: int, draft_model) -> bool:
         """Snapshot the draft and launch the worker if the cadence is due and no eval is running."""
@@ -225,68 +223,39 @@ class DecodeEvalRunner:
         step_dir = os.path.join(self.config.output_dir, f"step_{global_step}")
         os.makedirs(step_dir, exist_ok=True)
         export_draft_snapshot(draft_model, step_dir)
-        cfg = self.config
+        # The full config crosses the subprocess boundary as a JSON sidecar next
+        # to the snapshot (one declaration site, and a debugging record of what
+        # the eval ran with); the argv carries only the per-launch paths.
+        config_json = os.path.join(step_dir, _CONFIG_FILENAME)
+        with open(config_json, "w") as f:
+            json.dump(asdict(self.config), f, indent=2)
         argv = [
             sys.executable,
             "-m",
             "nemo_automodel.components.speculative.decode_eval",
+            "--config-json",
+            config_json,
             "--draft",
             step_dir,
-            "--target",
-            cfg.target_model,
             "--step",
             str(global_step),
             "--result-json",
             os.path.join(step_dir, _RESULT_FILENAME),
-            "--input-data",
-            cfg.input_data,
-            "--num-prompts",
-            str(cfg.num_prompts),
-            "--concurrency",
-            str(cfg.concurrency),
-            "--max-new-tokens",
-            str(cfg.max_new_tokens),
-            "--temperature",
-            str(cfg.temperature),
-            "--top-p",
-            str(cfg.top_p),
-            "--messages-column",
-            cfg.messages_column,
-            "--split",
-            cfg.split,
-            "--shuffle-seed",
-            str(cfg.shuffle_seed),
-            "--port",
-            str(cfg.port),
-            "--gpu-memory-utilization",
-            str(cfg.gpu_memory_utilization),
-            "--timeout-s",
-            str(cfg.timeout_s),
         ]
-        if cfg.prompt_column:
-            argv += ["--prompt-column", str(cfg.prompt_column)]
-        if cfg.dataset_name:
-            argv += ["--dataset-name", str(cfg.dataset_name)]
-        if cfg.num_speculative_tokens is not None:
-            argv += ["--num-speculative-tokens", str(cfg.num_speculative_tokens)]
-        if cfg.max_model_len is not None:
-            argv += ["--max-model-len", str(cfg.max_model_len)]
-        if cfg.trust_remote_code:
-            argv += ["--trust-remote-code"]
         log_path = os.path.join(step_dir, _WORKER_LOG_FILENAME)
         with open(log_path, "ab") as log_file:
             self._proc = subprocess.Popen(
                 argv,
                 stdout=log_file,
                 stderr=subprocess.STDOUT,
-                env=_worker_env(cfg.cuda_visible_devices),
+                env=_worker_env(self.config.cuda_visible_devices),
                 start_new_session=True,
             )
         self._launched_for_step = global_step
         logger.info(
             "decode_eval: launched eval for step %d on CUDA_VISIBLE_DEVICES=%s (pid %d, log %s)",
             global_step,
-            cfg.cuda_visible_devices,
+            self.config.cuda_visible_devices,
             self._proc.pid,
             log_path,
         )
@@ -359,73 +328,56 @@ def _build_parser():
     parser = argparse.ArgumentParser(
         description="decode_eval worker: serve the draft snapshot and measure accept length"
     )
-    parser.add_argument("--draft", required=True)
-    parser.add_argument("--target", required=True)
+    parser.add_argument("--config-json", required=True, help="JSON dump of DecodeEvalConfig (written at launch)")
+    parser.add_argument("--draft", required=True, help="snapshot dir containing model/consolidated")
     parser.add_argument("--step", type=int, required=True)
     parser.add_argument("--result-json", required=True)
-    parser.add_argument("--input-data", required=True)
-    parser.add_argument("--num-prompts", type=int, default=32)
-    parser.add_argument("--concurrency", type=int, default=8)
-    parser.add_argument("--max-new-tokens", type=int, default=256)
-    parser.add_argument("--temperature", type=float, default=0.0)
-    parser.add_argument("--top-p", type=float, default=1.0)
-    parser.add_argument("--messages-column", default="messages")
-    parser.add_argument("--prompt-column", default=None)
-    parser.add_argument("--split", default="train")
-    parser.add_argument("--dataset-name", default=None)
-    parser.add_argument("--shuffle-seed", type=int, default=42)
-    parser.add_argument("--port", type=int, default=8199)
-    parser.add_argument("--gpu-memory-utilization", type=float, default=0.8)
-    parser.add_argument("--num-speculative-tokens", type=int, default=None)
-    parser.add_argument("--max-model-len", type=int, default=None)
-    parser.add_argument("--trust-remote-code", action="store_true")
-    parser.add_argument("--timeout-s", type=float, default=1800.0)
     return parser
 
 
-def _serve_argv(args) -> list[str]:
+def _serve_argv(cfg: DecodeEvalConfig, draft: str) -> list[str]:
     """Build the vLLM api_server argv for the snapshot via the serve_vllm library surface."""
     from nemo_automodel.components.speculative.serve_vllm import build_vllm_argv
 
     serve_args = Namespace(
-        target=args.target,
-        draft=args.draft,
+        target=cfg.target_model,
+        draft=draft,
         method=None,
-        num_speculative_tokens=args.num_speculative_tokens,
+        num_speculative_tokens=cfg.num_speculative_tokens,
         dflash_causal=False,
         host="127.0.0.1",
-        port=args.port,
+        port=cfg.port,
         tp_size=1,
         draft_tp_size=1,
-        gpu_memory_utilization=args.gpu_memory_utilization,
+        gpu_memory_utilization=cfg.gpu_memory_utilization,
         dtype="bfloat16",
-        max_model_len=args.max_model_len,
-        trust_remote_code=args.trust_remote_code,
+        max_model_len=cfg.max_model_len,
+        trust_remote_code=cfg.trust_remote_code,
         print_only=False,
         extra=[],
     )
     return build_vllm_argv(serve_args)
 
 
-def _bench_args(args, server: str):
+def _bench_args(cfg: DecodeEvalConfig, server: str) -> Namespace:
     """Assemble the bench_vllm._run_summary argument namespace."""
     return Namespace(
         server=server,
-        model=args.target,
-        input_data=args.input_data,
-        num_prompts=args.num_prompts,
-        concurrency=args.concurrency,
-        max_new_tokens=args.max_new_tokens,
-        temperature=args.temperature,
-        top_p=args.top_p,
-        messages_column=args.messages_column,
-        prompt_column=args.prompt_column,
+        model=cfg.target_model,
+        input_data=cfg.input_data,
+        num_prompts=cfg.num_prompts,
+        concurrency=cfg.concurrency,
+        max_new_tokens=cfg.max_new_tokens,
+        temperature=cfg.temperature,
+        top_p=cfg.top_p,
+        messages_column=cfg.messages_column,
+        prompt_column=cfg.prompt_column,
         prompt_context_column=None,
-        split=args.split,
-        dataset_name=args.dataset_name,
-        shuffle_seed=args.shuffle_seed,
+        split=cfg.split,
+        dataset_name=cfg.dataset_name,
+        shuffle_seed=cfg.shuffle_seed,
         baseline_server=None,
-        timeout_s=args.timeout_s,
+        timeout_s=cfg.timeout_s,
         max_retries=2,
     )
 
@@ -437,13 +389,15 @@ def main(argv=None) -> int:
     from nemo_automodel.components.speculative.bench_vllm import _run_summary
 
     args = _build_parser().parse_args(argv)
-    server = f"http://127.0.0.1:{args.port}"
-    serve_argv = _serve_argv(args)
+    with open(args.config_json) as f:
+        cfg = DecodeEvalConfig(**json.load(f))
+    server = f"http://127.0.0.1:{cfg.port}"
+    serve_argv = _serve_argv(cfg, args.draft)
     print(f"decode_eval worker: starting engine: {' '.join(serve_argv)}", flush=True)
     proc = subprocess.Popen(serve_argv)
     try:
-        _wait_for_server(server, proc, args.timeout_s)
-        summary = asyncio.run(_run_summary(_bench_args(args, server)))
+        _wait_for_server(server, proc, cfg.timeout_s)
+        summary = asyncio.run(_run_summary(_bench_args(cfg, server)))
         if summary is None:
             raise RuntimeError("bench returned no summary (no prompts loaded?)")
         result = {"step": args.step, **summary}

--- a/nemo_automodel/components/speculative/decode_eval.py
+++ b/nemo_automodel/components/speculative/decode_eval.py
@@ -1,0 +1,466 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Periodic real-acceptance-length eval during draft training (decode eval).
+
+Training-time draft metrics (loss, top-1 accuracy, the simulated ``tau_sim``)
+are proxies: the acceptance length that matters is produced by the draft and
+the target interacting inside a real speculative-decoding engine. This module
+closes that gap without touching the training step:
+
+* On a cadence (``decode_eval.every_steps``), rank 0 snapshots the current
+  draft weights to disk and launches a detached **worker subprocess** pinned to
+  a reserved GPU (``decode_eval.cuda_visible_devices``). Training continues
+  immediately; at most one eval is in flight.
+* The worker (this module's CLI) packages the snapshot through the existing
+  ``serve_vllm`` conversion, boots a vLLM OpenAI server as its child, drives a
+  fixed prompt set through it with the existing ``bench_vllm`` workload runner,
+  and writes a JSON result (real ``accept_length`` from the engine's
+  spec-decode counters) next to the snapshot.
+* The trainer's logging block collects finished results and logs them as
+  ``train/tau_real`` (with ``train/tau_real_step`` marking the optimizer step
+  the evaluated snapshot was taken at).
+
+The trainer process never imports vllm; the worker inherits the training env
+minus the torchrun/elastic variables, so the engine initializes as a plain
+single-process job on the reserved GPU.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import sys
+import time
+import urllib.request
+from dataclasses import dataclass
+from argparse import Namespace
+
+logger = logging.getLogger(__name__)
+
+_RESULT_FILENAME = "result.json"
+_WORKER_LOG_FILENAME = "worker.log"
+
+# torchrun / elastic / rank state that must NOT leak into the worker: vLLM would
+# otherwise try to join the training job's process group (or bind its ports).
+_SCRUBBED_ENV_PREFIXES = ("TORCHELASTIC_", "PET_")
+_SCRUBBED_ENV_KEYS = (
+    "RANK",
+    "LOCAL_RANK",
+    "WORLD_SIZE",
+    "LOCAL_WORLD_SIZE",
+    "GROUP_RANK",
+    "GROUP_WORLD_SIZE",
+    "ROLE_RANK",
+    "ROLE_WORLD_SIZE",
+    "ROLE_NAME",
+    "MASTER_ADDR",
+    "MASTER_PORT",
+    "TORCH_NCCL_ASYNC_ERROR_HANDLING",
+)
+
+
+@dataclass
+class DecodeEvalConfig:
+    """Resolved settings for the periodic decode eval.
+
+    ``every_steps`` is the launch cadence in optimizer steps; launches are
+    checked at the recipe's logging points, so it should be a multiple of
+    ``log_every_steps`` (a non-multiple fires at the first log point past the
+    boundary). ``cuda_visible_devices`` is the GPU (or comma list) reserved for
+    the eval engine; training must not place work there.
+    """
+
+    every_steps: int
+    cuda_visible_devices: str
+    target_model: str
+    input_data: str
+    output_dir: str
+    num_prompts: int = 32
+    concurrency: int = 8
+    max_new_tokens: int = 256
+    temperature: float = 0.0
+    top_p: float = 1.0
+    messages_column: str = "messages"
+    prompt_column: str | None = None
+    split: str = "train"
+    dataset_name: str | None = None
+    shuffle_seed: int = 42
+    port: int = 8199
+    gpu_memory_utilization: float = 0.8
+    num_speculative_tokens: int | None = None
+    max_model_len: int | None = None
+    trust_remote_code: bool = False
+    timeout_s: float = 1800.0
+
+
+def resolve_decode_eval_config(recipe_cfg, *, default_target: str, default_input_data: str, output_dir: str):
+    """Read the optional ``decode_eval:`` block from ``recipe_args``.
+
+    Returns ``None`` when the block is absent or ``every_steps`` is unset/0
+    (feature disabled). Raises on a partially-configured block so a typo'd GPU
+    reservation fails at setup rather than silently evaluating on a training
+    GPU.
+    """
+    block = recipe_cfg.get("decode_eval", None)
+    if block is None:
+        return None
+    every_steps = int(block.get("every_steps", 0) or 0)
+    if every_steps <= 0:
+        return None
+    cuda_visible_devices = block.get("cuda_visible_devices", None)
+    if cuda_visible_devices is None or str(cuda_visible_devices) == "":
+        raise ValueError(
+            "decode_eval.cuda_visible_devices is required: the eval engine needs a GPU the training "
+            "job does not use (e.g. reserve one card and shrink the torchrun world accordingly)."
+        )
+    return DecodeEvalConfig(
+        every_steps=every_steps,
+        cuda_visible_devices=str(cuda_visible_devices),
+        target_model=str(block.get("target_model", None) or default_target),
+        input_data=str(block.get("input_data", None) or default_input_data),
+        output_dir=os.path.join(output_dir, "decode_eval"),
+        num_prompts=int(block.get("num_prompts", 32)),
+        concurrency=int(block.get("concurrency", 8)),
+        max_new_tokens=int(block.get("max_new_tokens", 256)),
+        temperature=float(block.get("temperature", 0.0)),
+        top_p=float(block.get("top_p", 1.0)),
+        messages_column=str(block.get("messages_column", "messages")),
+        prompt_column=block.get("prompt_column", None),
+        split=str(block.get("split", "train")),
+        dataset_name=block.get("dataset_name", None),
+        shuffle_seed=int(block.get("shuffle_seed", 42)),
+        port=int(block.get("port", 8199)),
+        gpu_memory_utilization=float(block.get("gpu_memory_utilization", 0.8)),
+        num_speculative_tokens=block.get("num_speculative_tokens", None),
+        max_model_len=block.get("max_model_len", None),
+        trust_remote_code=bool(block.get("trust_remote_code", False)),
+        timeout_s=float(block.get("timeout_s", 1800.0)),
+    )
+
+
+def export_draft_snapshot(draft_model, out_dir: str) -> str:
+    """Write the draft's current weights as a serve-ready consolidated export.
+
+    Produces ``<out_dir>/model/consolidated/{model.safetensors, config.json}``,
+    the same layout the final checkpoint's consolidated export uses, so
+    ``serve_vllm.resolve_draft_artifacts`` can consume it directly (the
+    d2t/t2d vocab-mapping buffers ride along in the state dict).
+
+    Args:
+        draft_model: the (unwrapped) draft ``nn.Module``; its parameter and
+            buffer tensors are copied to CPU, so shapes/layouts are whatever the
+            draft's ``state_dict()`` reports.
+        out_dir: snapshot root; created if missing.
+
+    Returns:
+        The ``model/consolidated`` directory path containing the export.
+    """
+    from safetensors.torch import save_file
+
+    consolidated = os.path.join(out_dir, "model", "consolidated")
+    os.makedirs(consolidated, exist_ok=True)
+    state = {k: v.detach().to("cpu").contiguous() for k, v in draft_model.state_dict().items()}
+    save_file(state, os.path.join(consolidated, "model.safetensors"))
+    draft_model.config.to_json_file(os.path.join(consolidated, "config.json"))
+    return consolidated
+
+
+def _worker_env(cuda_visible_devices: str) -> dict[str, str]:
+    """Training env minus torchrun/elastic state, pinned to the reserved GPU."""
+    env = {
+        k: v for k, v in os.environ.items() if k not in _SCRUBBED_ENV_KEYS and not k.startswith(_SCRUBBED_ENV_PREFIXES)
+    }
+    env["CUDA_VISIBLE_DEVICES"] = cuda_visible_devices
+    return env
+
+
+class DecodeEvalRunner:
+    """Rank-0 trainer-side orchestrator: launch at cadence, collect results.
+
+    At most one eval subprocess is alive at a time; a launch that lands while
+    the previous eval is still running is skipped (the next cadence boundary
+    picks it up). Results are one-line JSON files the worker writes on success;
+    ``collect()`` returns the not-yet-seen ones in step order.
+    """
+
+    def __init__(self, config: DecodeEvalConfig):
+        self.config = config
+        self._proc: subprocess.Popen | None = None
+        self._launched_for_step = -1
+        self._last_bucket = 0
+        self._collected: set[str] = set()
+        os.makedirs(config.output_dir, exist_ok=True)
+
+    def due(self, global_step: int) -> bool:
+        """Whether a new eval should launch at this optimizer step."""
+        bucket = global_step // self.config.every_steps
+        return bucket > self._last_bucket
+
+    def maybe_launch(self, global_step: int, draft_model) -> bool:
+        """Snapshot the draft and launch the worker if the cadence is due and no eval is running."""
+        if not self.due(global_step):
+            return False
+        if self._proc is not None and self._proc.poll() is None:
+            logger.info(
+                "decode_eval: previous eval (step %d) still running, skipping launch at step %d",
+                self._launched_for_step,
+                global_step,
+            )
+            return False
+        self._last_bucket = global_step // self.config.every_steps
+        step_dir = os.path.join(self.config.output_dir, f"step_{global_step}")
+        os.makedirs(step_dir, exist_ok=True)
+        export_draft_snapshot(draft_model, step_dir)
+        cfg = self.config
+        argv = [
+            sys.executable,
+            "-m",
+            "nemo_automodel.components.speculative.decode_eval",
+            "--draft",
+            step_dir,
+            "--target",
+            cfg.target_model,
+            "--step",
+            str(global_step),
+            "--result-json",
+            os.path.join(step_dir, _RESULT_FILENAME),
+            "--input-data",
+            cfg.input_data,
+            "--num-prompts",
+            str(cfg.num_prompts),
+            "--concurrency",
+            str(cfg.concurrency),
+            "--max-new-tokens",
+            str(cfg.max_new_tokens),
+            "--temperature",
+            str(cfg.temperature),
+            "--top-p",
+            str(cfg.top_p),
+            "--messages-column",
+            cfg.messages_column,
+            "--split",
+            cfg.split,
+            "--shuffle-seed",
+            str(cfg.shuffle_seed),
+            "--port",
+            str(cfg.port),
+            "--gpu-memory-utilization",
+            str(cfg.gpu_memory_utilization),
+            "--timeout-s",
+            str(cfg.timeout_s),
+        ]
+        if cfg.prompt_column:
+            argv += ["--prompt-column", str(cfg.prompt_column)]
+        if cfg.dataset_name:
+            argv += ["--dataset-name", str(cfg.dataset_name)]
+        if cfg.num_speculative_tokens is not None:
+            argv += ["--num-speculative-tokens", str(cfg.num_speculative_tokens)]
+        if cfg.max_model_len is not None:
+            argv += ["--max-model-len", str(cfg.max_model_len)]
+        if cfg.trust_remote_code:
+            argv += ["--trust-remote-code"]
+        log_path = os.path.join(step_dir, _WORKER_LOG_FILENAME)
+        with open(log_path, "ab") as log_file:
+            self._proc = subprocess.Popen(
+                argv,
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
+                env=_worker_env(cfg.cuda_visible_devices),
+                start_new_session=True,
+            )
+        self._launched_for_step = global_step
+        logger.info(
+            "decode_eval: launched eval for step %d on CUDA_VISIBLE_DEVICES=%s (pid %d, log %s)",
+            global_step,
+            cfg.cuda_visible_devices,
+            self._proc.pid,
+            log_path,
+        )
+        return True
+
+    def collect(self) -> list[dict]:
+        """Return finished, not-yet-reported eval results in snapshot-step order."""
+        results = []
+        try:
+            step_dirs = sorted(
+                (d for d in os.listdir(self.config.output_dir) if d.startswith("step_")),
+                key=lambda d: int(d.split("_", 1)[1]),
+            )
+        except (FileNotFoundError, ValueError):
+            return results
+        for step_dir in step_dirs:
+            path = os.path.join(self.config.output_dir, step_dir, _RESULT_FILENAME)
+            if path in self._collected or not os.path.exists(path):
+                continue
+            try:
+                with open(path) as f:
+                    results.append(json.load(f))
+                self._collected.add(path)
+            except (OSError, json.JSONDecodeError):
+                logger.warning("decode_eval: unreadable result %s, will retry next collect", path)
+        return results
+
+    def shutdown(self) -> None:
+        """Terminate a still-running eval (its vLLM child dies with the session)."""
+        if self._proc is not None and self._proc.poll() is None:
+            logger.info("decode_eval: terminating in-flight eval (pid %d)", self._proc.pid)
+            try:
+                # The worker was started in its own session; signal the whole
+                # group so the vLLM server child goes down with it.
+                os.killpg(os.getpgid(self._proc.pid), 15)
+            except (ProcessLookupError, PermissionError):
+                self._proc.terminate()
+            try:
+                self._proc.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                self._proc.kill()
+        self._proc = None
+
+
+# --------------------------------------------------------------------------- #
+# Worker CLI: runs in its own process on the reserved GPU.
+# --------------------------------------------------------------------------- #
+
+
+def _wait_for_server(server: str, proc: subprocess.Popen, timeout_s: float) -> None:
+    """Poll the vLLM server's /health until it responds or dies/times out."""
+    deadline = time.monotonic() + timeout_s
+    url = f"{server}/health"
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError(f"vLLM server exited with code {proc.returncode} before becoming healthy")
+        try:
+            with urllib.request.urlopen(url, timeout=5) as resp:
+                if resp.status == 200:
+                    return
+        except OSError:
+            pass
+        time.sleep(3)
+    raise TimeoutError(f"vLLM server did not become healthy within {timeout_s:.0f}s")
+
+
+def _build_parser():
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="decode_eval worker: serve the draft snapshot and measure accept length"
+    )
+    parser.add_argument("--draft", required=True)
+    parser.add_argument("--target", required=True)
+    parser.add_argument("--step", type=int, required=True)
+    parser.add_argument("--result-json", required=True)
+    parser.add_argument("--input-data", required=True)
+    parser.add_argument("--num-prompts", type=int, default=32)
+    parser.add_argument("--concurrency", type=int, default=8)
+    parser.add_argument("--max-new-tokens", type=int, default=256)
+    parser.add_argument("--temperature", type=float, default=0.0)
+    parser.add_argument("--top-p", type=float, default=1.0)
+    parser.add_argument("--messages-column", default="messages")
+    parser.add_argument("--prompt-column", default=None)
+    parser.add_argument("--split", default="train")
+    parser.add_argument("--dataset-name", default=None)
+    parser.add_argument("--shuffle-seed", type=int, default=42)
+    parser.add_argument("--port", type=int, default=8199)
+    parser.add_argument("--gpu-memory-utilization", type=float, default=0.8)
+    parser.add_argument("--num-speculative-tokens", type=int, default=None)
+    parser.add_argument("--max-model-len", type=int, default=None)
+    parser.add_argument("--trust-remote-code", action="store_true")
+    parser.add_argument("--timeout-s", type=float, default=1800.0)
+    return parser
+
+
+def _serve_argv(args) -> list[str]:
+    """Build the vLLM api_server argv for the snapshot via the serve_vllm library surface."""
+    from nemo_automodel.components.speculative.serve_vllm import build_vllm_argv
+
+    serve_args = Namespace(
+        target=args.target,
+        draft=args.draft,
+        method=None,
+        num_speculative_tokens=args.num_speculative_tokens,
+        dflash_causal=False,
+        host="127.0.0.1",
+        port=args.port,
+        tp_size=1,
+        draft_tp_size=1,
+        gpu_memory_utilization=args.gpu_memory_utilization,
+        dtype="bfloat16",
+        max_model_len=args.max_model_len,
+        trust_remote_code=args.trust_remote_code,
+        print_only=False,
+        extra=[],
+    )
+    return build_vllm_argv(serve_args)
+
+
+def _bench_args(args, server: str):
+    """Assemble the bench_vllm._run_summary argument namespace."""
+    return Namespace(
+        server=server,
+        model=args.target,
+        input_data=args.input_data,
+        num_prompts=args.num_prompts,
+        concurrency=args.concurrency,
+        max_new_tokens=args.max_new_tokens,
+        temperature=args.temperature,
+        top_p=args.top_p,
+        messages_column=args.messages_column,
+        prompt_column=args.prompt_column,
+        prompt_context_column=None,
+        split=args.split,
+        dataset_name=args.dataset_name,
+        shuffle_seed=args.shuffle_seed,
+        baseline_server=None,
+        timeout_s=args.timeout_s,
+        max_retries=2,
+    )
+
+
+def main(argv=None) -> int:
+    """Worker entry: boot the engine on the snapshot, bench it, write the result JSON."""
+    import asyncio
+
+    from nemo_automodel.components.speculative.bench_vllm import _run_summary
+
+    args = _build_parser().parse_args(argv)
+    server = f"http://127.0.0.1:{args.port}"
+    serve_argv = _serve_argv(args)
+    print(f"decode_eval worker: starting engine: {' '.join(serve_argv)}", flush=True)
+    proc = subprocess.Popen(serve_argv)
+    try:
+        _wait_for_server(server, proc, args.timeout_s)
+        summary = asyncio.run(_run_summary(_bench_args(args, server)))
+        if summary is None:
+            raise RuntimeError("bench returned no summary (no prompts loaded?)")
+        result = {"step": args.step, **summary}
+        tmp = args.result_json + ".tmp"
+        with open(tmp, "w") as f:
+            json.dump(result, f)
+        os.replace(tmp, args.result_json)
+        print(f"decode_eval worker: wrote {args.result_json}: {json.dumps(result)}", flush=True)
+        return 0
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=60)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/nemo_automodel/recipes/llm/train_eagle3.py
+++ b/nemo_automodel/recipes/llm/train_eagle3.py
@@ -51,6 +51,7 @@ from nemo_automodel.components.distributed.init_utils import initialize_distribu
 from nemo_automodel.components.distributed.mesh_utils import get_flat_mesh
 from nemo_automodel.components.loggers.log_utils import setup_logging
 from nemo_automodel.components.loggers.wandb_utils import init_wandb_run, suppress_wandb_log_messages
+from nemo_automodel.components.speculative.decode_eval import DecodeEvalRunner, resolve_decode_eval_config
 from nemo_automodel.components.speculative.eagle import (
     Eagle3TrainerModule,
     HFEagle3TargetModel,
@@ -663,6 +664,62 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
                 self.cfg.to_dict(),
                 default_name="eagle3_" + str(target_path).rstrip("/").split("/")[-1],
             )
+
+        # Optional periodic real-acceptance-length eval (rank 0 only): snapshot
+        # the current draft on a cadence and measure accept_length inside an
+        # actual vLLM speculative server on a reserved GPU, asynchronously to
+        # training. Logged as train/tau_real next to the simulated tau_sim.
+        self.decode_eval_runner = None
+        decode_eval_config = resolve_decode_eval_config(
+            recipe_cfg,
+            default_target=str(target_path),
+            default_input_data=str(recipe_cfg.train_data_path),
+            output_dir=str(self.output_dir),
+        )
+        if decode_eval_config is not None:
+            if getattr(self, "peft_config", None) is not None:
+                raise ValueError(
+                    "decode_eval is not supported with peft: the draft snapshot would need an adapter "
+                    "merge per eval; bench a merged checkpoint offline instead."
+                )
+            if self.dist_env.is_main:
+                self.decode_eval_runner = DecodeEvalRunner(decode_eval_config)
+
+    def _maybe_run_decode_eval(self) -> None:
+        """Rank-0 log-point hook: collect finished decode-eval results, launch the next one when due.
+
+        Runs outside any collective path (pure subprocess/file I/O), so only
+        rank 0 calls it. Results are logged at the CURRENT optimizer step (wandb
+        steps must not go backwards); ``train/tau_real_step`` records the step
+        the evaluated snapshot was actually taken at.
+        """
+        # getattr: bare recipe objects in the loop unit tests skip setup().
+        runner = getattr(self, "decode_eval_runner", None)
+        if runner is None:
+            return
+        for result in runner.collect():
+            accept_length = result.get("accept_length", None)
+            logger.info(
+                "decode_eval: step=%s accept_length=%s acceptance_rate=%s completed=%s failed=%s",
+                result.get("step"),
+                "n/a" if accept_length is None else f"{accept_length:.4f}",
+                result.get("acceptance_rate"),
+                result.get("completed"),
+                result.get("failed"),
+            )
+            if accept_length is not None:
+                self._wandb_log(
+                    {
+                        "train/tau_real": accept_length,
+                        "train/tau_real_step": result.get("step"),
+                        "train/tau_real_acceptance_rate": result.get("acceptance_rate"),
+                    },
+                    step=self.runtime.global_step,
+                )
+        try:
+            runner.maybe_launch(self.runtime.global_step, self.draft_model)
+        except OSError:
+            logger.exception("decode_eval: launch failed at step %d; training continues", self.runtime.global_step)
 
     def _setup_online_target(self, recipe_cfg, target_path, target_config):
         """Live path: load the target model and build the live dataloader.
@@ -1540,6 +1597,9 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
         """
         if getattr(self, "target_wrapper", None) is not None:
             _best_effort("closing target backend", self.target_wrapper.close)
+        if getattr(self, "decode_eval_runner", None) is not None:
+            _best_effort("collecting final decode-eval results", self._maybe_run_decode_eval)
+            _best_effort("stopping decode-eval worker", self.decode_eval_runner.shutdown)
         if getattr(self, "wandb_run", None) is not None:
             _best_effort("finishing W&B run", self.wandb_run.finish)
 
@@ -1652,6 +1712,7 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
                             if tau_sim is not None:
                                 wandb_data["train/tau_sim"] = tau_sim
                             self._wandb_log(wandb_data, step=self.runtime.global_step)
+                            self._maybe_run_decode_eval()
                         running_loss.zero_()
                         running_acc.zero_()
                         if running_step_prefix is not None:

--- a/nemo_automodel/recipes/llm/train_eagle3.py
+++ b/nemo_automodel/recipes/llm/train_eagle3.py
@@ -673,7 +673,10 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
         decode_eval_config = resolve_decode_eval_config(
             recipe_cfg,
             default_target=str(target_path),
-            default_input_data=str(recipe_cfg.train_data_path),
+            default_input_data=recipe_cfg.get("train_data_path", None),
+            default_num_speculative_tokens=int(
+                recipe_cfg.get("num_depths", 8) if parallel_drafting else recipe_cfg.ttt_steps
+            ),
             output_dir=str(self.output_dir),
         )
         if decode_eval_config is not None:
@@ -685,7 +688,7 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
             if self.dist_env.is_main:
                 self.decode_eval_runner = DecodeEvalRunner(decode_eval_config)
 
-    def _maybe_run_decode_eval(self) -> None:
+    def _maybe_run_decode_eval(self, *, launch: bool = True) -> None:
         """Rank-0 log-point hook: collect finished decode-eval results, launch the next one when due.
 
         Runs outside any collective path (pure subprocess/file I/O), so only
@@ -716,10 +719,11 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
                     },
                     step=self.runtime.global_step,
                 )
-        try:
-            runner.maybe_launch(self.runtime.global_step, self.draft_model)
-        except OSError:
-            logger.exception("decode_eval: launch failed at step %d; training continues", self.runtime.global_step)
+        if launch:
+            try:
+                runner.maybe_launch(self.runtime.global_step, self.draft_model)
+            except Exception:
+                logger.exception("decode_eval: launch failed at step %d; training continues", self.runtime.global_step)
 
     def _setup_online_target(self, recipe_cfg, target_path, target_config):
         """Live path: load the target model and build the live dataloader.
@@ -1598,7 +1602,7 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
         if getattr(self, "target_wrapper", None) is not None:
             _best_effort("closing target backend", self.target_wrapper.close)
         if getattr(self, "decode_eval_runner", None) is not None:
-            _best_effort("collecting final decode-eval results", self._maybe_run_decode_eval)
+            _best_effort("collecting final decode-eval results", lambda: self._maybe_run_decode_eval(launch=False))
             _best_effort("stopping decode-eval worker", self.decode_eval_runner.shutdown)
         if getattr(self, "wandb_run", None) is not None:
             _best_effort("finishing W&B run", self.wandb_run.finish)

--- a/tests/unit_tests/speculative/test_decode_eval.py
+++ b/tests/unit_tests/speculative/test_decode_eval.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 import json
 import os
+import socket
+import subprocess
 from types import SimpleNamespace
 
 import pytest
@@ -28,6 +30,7 @@ from nemo_automodel.components.speculative.decode_eval import (
     DecodeEvalConfig,
     DecodeEvalRunner,
     _bench_args,
+    _resolve_worker_port,
     _serve_argv,
     _worker_env,
     export_draft_snapshot,
@@ -43,6 +46,7 @@ def _config(tmp_path, **overrides):
         target_model="/models/target",
         input_data="/data/train.jsonl",
         output_dir=str(tmp_path / "decode_eval"),
+        num_speculative_tokens=7,
     )
     kwargs.update(overrides)
     return DecodeEvalConfig(**kwargs)
@@ -50,30 +54,84 @@ def _config(tmp_path, **overrides):
 
 def test_resolve_returns_none_when_absent_or_disabled(tmp_path):
     assert (
-        resolve_decode_eval_config({}, default_target="/t", default_input_data="/d", output_dir=str(tmp_path)) is None
+        resolve_decode_eval_config(
+            {},
+            default_target="/t",
+            default_input_data="/d",
+            default_num_speculative_tokens=4,
+            output_dir=str(tmp_path),
+        )
+        is None
     )
     cfg = {"decode_eval": {"every_steps": 0, "cuda_visible_devices": "7"}}
     assert (
-        resolve_decode_eval_config(cfg, default_target="/t", default_input_data="/d", output_dir=str(tmp_path)) is None
+        resolve_decode_eval_config(
+            cfg,
+            default_target="/t",
+            default_input_data="/d",
+            default_num_speculative_tokens=4,
+            output_dir=str(tmp_path),
+        )
+        is None
     )
 
 
 def test_resolve_requires_reserved_gpu(tmp_path):
     cfg = {"decode_eval": {"every_steps": 100}}
     with pytest.raises(ValueError, match="cuda_visible_devices"):
-        resolve_decode_eval_config(cfg, default_target="/t", default_input_data="/d", output_dir=str(tmp_path))
+        resolve_decode_eval_config(
+            cfg,
+            default_target="/t",
+            default_input_data="/d",
+            default_num_speculative_tokens=4,
+            output_dir=str(tmp_path),
+        )
 
 
 def test_resolve_fills_defaults_from_recipe(tmp_path):
     cfg = {"decode_eval": {"every_steps": 250, "cuda_visible_devices": 6}}
     resolved = resolve_decode_eval_config(
-        cfg, default_target="/models/qwen", default_input_data="/data/messages", output_dir=str(tmp_path)
+        cfg,
+        default_target="/models/qwen",
+        default_input_data="/data/messages",
+        default_num_speculative_tokens=7,
+        output_dir=str(tmp_path),
     )
     assert resolved.every_steps == 250
     assert resolved.cuda_visible_devices == "6"
     assert resolved.target_model == "/models/qwen"
     assert resolved.input_data == "/data/messages"
     assert resolved.output_dir == os.path.join(str(tmp_path), "decode_eval")
+    assert resolved.num_speculative_tokens == 7
+    assert resolved.port == 0
+
+
+def test_resolve_validates_input_tokens_and_unknown_options(tmp_path):
+    base = {"every_steps": 10, "cuda_visible_devices": "7"}
+    with pytest.raises(ValueError, match="input_data"):
+        resolve_decode_eval_config(
+            {"decode_eval": base},
+            default_target="/t",
+            default_input_data=None,
+            default_num_speculative_tokens=4,
+            output_dir=str(tmp_path),
+        )
+    with pytest.raises(ValueError, match="num_speculative_tokens"):
+        resolve_decode_eval_config(
+            {"decode_eval": {**base, "num_speculative_tokens": 0}},
+            default_target="/t",
+            default_input_data="/d",
+            default_num_speculative_tokens=0,
+            output_dir=str(tmp_path),
+        )
+    with pytest.raises(ValueError, match="num_prompt"):
+        resolve_decode_eval_config(
+            {"decode_eval": {**base, "num_prompt": 8}},
+            default_target="/t",
+            default_input_data="/d",
+            default_num_speculative_tokens=4,
+            output_dir=str(tmp_path),
+        )
 
 
 def test_export_draft_snapshot_is_serve_resolvable(tmp_path):
@@ -112,12 +170,29 @@ def test_worker_env_scrubs_torchrun_state(monkeypatch):
 
 
 class _FakeProc:
-    def __init__(self, alive=True, pid=4242):
+    def __init__(self, alive=True, pid=4242, return_code=0):
         self._alive = alive
         self.pid = pid
+        self.returncode = None if alive else return_code
+        self.terminated = False
+        self.killed = False
 
     def poll(self):
-        return None if self._alive else 0
+        return None if self._alive else self.returncode
+
+    def wait(self, timeout=None):
+        self._alive = False
+        if self.returncode is None:
+            self.returncode = 0
+        return self.returncode
+
+    def terminate(self):
+        self.terminated = True
+
+    def kill(self):
+        self.killed = True
+        self._alive = False
+        self.returncode = -9
 
 
 def _runner_with_fake_launch(tmp_path, monkeypatch, launched):
@@ -146,6 +221,7 @@ def test_runner_launches_on_cadence_and_skips_while_running(tmp_path, monkeypatc
     # boundary launches again.
     assert not runner.maybe_launch(20, model)
     runner._proc._alive = False
+    runner._proc.returncode = 0
     assert runner.maybe_launch(30, model)
 
     popen_calls = [entry for entry in launched if entry[0] == "popen"]
@@ -181,6 +257,89 @@ def test_runner_collect_returns_each_result_once(tmp_path):
     assert [r["step"] for r in second] == [20]
 
 
+def test_runner_resume_ignores_old_results_and_removes_snapshot(tmp_path):
+    cfg = _config(tmp_path)
+    step_dir = os.path.join(cfg.output_dir, "step_10")
+    os.makedirs(os.path.join(step_dir, "model"))
+    result_path = os.path.join(step_dir, "result.json")
+    with open(result_path, "w") as f:
+        json.dump({"step": 10, "accept_length": 1.5}, f)
+
+    runner = DecodeEvalRunner(cfg)
+
+    assert runner.collect() == []
+    assert not os.path.exists(os.path.join(step_dir, "model"))
+
+
+def test_runner_ignores_invalid_step_directory(tmp_path):
+    runner = DecodeEvalRunner(_config(tmp_path))
+    os.makedirs(os.path.join(runner.config.output_dir, "step_final"))
+    step_dir = os.path.join(runner.config.output_dir, "step_20")
+    os.makedirs(step_dir)
+    with open(os.path.join(step_dir, "result.json"), "w") as f:
+        json.dump({"step": 20, "accept_length": 2.0}, f)
+
+    assert [result["step"] for result in runner.collect()] == [20]
+
+
+def test_failed_launch_retries_same_bucket_and_cleans_snapshot(tmp_path, monkeypatch):
+    runner = DecodeEvalRunner(_config(tmp_path))
+    step_dir = os.path.join(runner.config.output_dir, "step_10")
+
+    def _export(_model, out_dir):
+        os.makedirs(os.path.join(out_dir, "model"))
+        raise RuntimeError("snapshot failed")
+
+    monkeypatch.setattr("nemo_automodel.components.speculative.decode_eval.export_draft_snapshot", _export)
+    with pytest.raises(RuntimeError, match="snapshot failed"):
+        runner.maybe_launch(10, object())
+
+    assert runner.due(10)
+    assert not os.path.exists(os.path.join(step_dir, "model"))
+
+
+def test_failed_worker_is_reported_and_snapshot_removed(tmp_path, caplog):
+    runner = DecodeEvalRunner(_config(tmp_path))
+    step_dir = os.path.join(runner.config.output_dir, "step_10")
+    os.makedirs(os.path.join(step_dir, "model"))
+    runner._proc = _FakeProc(alive=False, return_code=2)
+    runner._launched_for_step = 10
+    runner._worker_log_path = os.path.join(step_dir, "worker.log")
+
+    runner.collect()
+
+    assert "exited with code 2" in caplog.text
+    assert runner._proc is None
+    assert not os.path.exists(os.path.join(step_dir, "model"))
+
+
+def test_shutdown_escalates_to_process_group_kill(tmp_path, monkeypatch):
+    runner = DecodeEvalRunner(_config(tmp_path))
+    step_dir = os.path.join(runner.config.output_dir, "step_10")
+    os.makedirs(os.path.join(step_dir, "model"))
+    runner._launched_for_step = 10
+    proc = _FakeProc()
+    wait_calls = []
+
+    def _wait(timeout=None):
+        wait_calls.append(timeout)
+        if len(wait_calls) == 1:
+            raise subprocess.TimeoutExpired("worker", 30)
+        return 0
+
+    proc.wait = _wait
+    runner._proc = proc
+    signals = []
+    monkeypatch.setattr(os, "getpgid", lambda _pid: 99)
+    monkeypatch.setattr(os, "killpg", lambda pgid, sig: signals.append((pgid, sig)))
+
+    runner.shutdown()
+
+    assert signals[0][0] == signals[1][0] == 99
+    assert signals[0][1] != signals[1][1]
+    assert not os.path.exists(os.path.join(step_dir, "model"))
+
+
 def test_serve_argv_builds_speculative_server_command(tmp_path, monkeypatch):
     """The worker must drive serve_vllm's library surface, not reimplement it."""
     seen = {}
@@ -197,6 +356,17 @@ def test_serve_argv_builds_speculative_server_command(tmp_path, monkeypatch):
     assert seen["draft"] == str(tmp_path / "step_10")
     assert seen["port"] == 8199
     assert seen["host"] == "127.0.0.1"
+    assert seen["num_speculative_tokens"] == 7
+
+
+def test_worker_port_auto_selects_and_rejects_collision():
+    port = _resolve_worker_port(0)
+    assert port > 0
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        occupied = sock.getsockname()[1]
+        with pytest.raises(RuntimeError, match="already in use"):
+            _resolve_worker_port(occupied)
 
 
 def test_bench_args_carry_workload_settings(tmp_path):
@@ -255,3 +425,41 @@ def test_recipe_hook_noop_without_runner():
 
     recipe = TrainEagle3Recipe.__new__(TrainEagle3Recipe)
     recipe._maybe_run_decode_eval()  # must not raise (bare object, no setup)
+
+
+def test_recipe_hook_can_collect_without_launching():
+    from nemo_automodel.recipes.llm.train_eagle3 import TrainEagle3Recipe
+
+    recipe = TrainEagle3Recipe.__new__(TrainEagle3Recipe)
+    recipe.runtime = SimpleNamespace(global_step=42)
+    recipe._wandb_log = lambda *_args, **_kwargs: None
+
+    class _StubRunner:
+        def collect(self):
+            return []
+
+        def maybe_launch(self, *_args):
+            raise AssertionError("final collection must not launch a worker")
+
+    recipe.decode_eval_runner = _StubRunner()
+    recipe._maybe_run_decode_eval(launch=False)
+
+
+def test_recipe_hook_contains_optional_eval_failures(caplog):
+    from nemo_automodel.recipes.llm.train_eagle3 import TrainEagle3Recipe
+
+    recipe = TrainEagle3Recipe.__new__(TrainEagle3Recipe)
+    recipe.runtime = SimpleNamespace(global_step=42)
+    recipe.draft_model = object()
+
+    class _StubRunner:
+        def collect(self):
+            return []
+
+        def maybe_launch(self, *_args):
+            raise RuntimeError("snapshot failed")
+
+    recipe.decode_eval_runner = _StubRunner()
+    recipe._maybe_run_decode_eval()
+
+    assert "training continues" in caplog.text

--- a/tests/unit_tests/speculative/test_decode_eval.py
+++ b/tests/unit_tests/speculative/test_decode_eval.py
@@ -152,6 +152,11 @@ def test_runner_launches_on_cadence_and_skips_while_running(tmp_path, monkeypatc
     assert len(popen_calls) == 2
     argv = popen_calls[0][1]
     assert "--step" in argv and argv[argv.index("--step") + 1] == "10"
+    config_json = argv[argv.index("--config-json") + 1]
+    with open(config_json) as f:
+        sidecar = json.load(f)
+    assert sidecar["cuda_visible_devices"] == "7"
+    assert sidecar["target_model"] == "/models/target"
     assert popen_calls[0][2]["env"]["CUDA_VISIBLE_DEVICES"] == "7"
     assert popen_calls[0][2]["start_new_session"] is True
 
@@ -185,16 +190,8 @@ def test_serve_argv_builds_speculative_server_command(tmp_path, monkeypatch):
         return ["python", "-m", "vllm.entrypoints.openai.api_server"]
 
     monkeypatch.setattr("nemo_automodel.components.speculative.serve_vllm.build_vllm_argv", _fake_build)
-    args = SimpleNamespace(
-        target="/models/target",
-        draft=str(tmp_path / "step_10"),
-        num_speculative_tokens=None,
-        port=8199,
-        gpu_memory_utilization=0.8,
-        max_model_len=None,
-        trust_remote_code=False,
-    )
-    argv = _serve_argv(args)
+    cfg = _config(tmp_path, port=8199)
+    argv = _serve_argv(cfg, str(tmp_path / "step_10"))
     assert argv[0] == "python"
     assert seen["target"] == "/models/target"
     assert seen["draft"] == str(tmp_path / "step_10")
@@ -202,28 +199,23 @@ def test_serve_argv_builds_speculative_server_command(tmp_path, monkeypatch):
     assert seen["host"] == "127.0.0.1"
 
 
-def test_bench_args_carry_workload_settings():
-    args = SimpleNamespace(
-        target="/models/target",
-        input_data="/data/train.jsonl",
-        num_prompts=16,
-        concurrency=4,
-        max_new_tokens=128,
-        temperature=0.0,
-        top_p=1.0,
-        messages_column="messages",
-        prompt_column=None,
-        split="train",
-        dataset_name=None,
-        shuffle_seed=42,
-        timeout_s=600.0,
-    )
-    bench = _bench_args(args, "http://127.0.0.1:8199")
+def test_bench_args_carry_workload_settings(tmp_path):
+    cfg = _config(tmp_path, num_prompts=16, concurrency=4, max_new_tokens=128, timeout_s=600.0)
+    bench = _bench_args(cfg, "http://127.0.0.1:8199")
     assert bench.server == "http://127.0.0.1:8199"
     assert bench.model == "/models/target"
     assert bench.num_prompts == 16
     assert bench.baseline_server is None
     assert bench.prompt_context_column is None
+
+
+def test_config_json_roundtrips_through_the_worker_boundary(tmp_path):
+    """The sidecar the launcher writes must reconstruct the exact config."""
+    import dataclasses
+
+    cfg = _config(tmp_path, num_prompts=7, prompt_column="question")
+    rebuilt = DecodeEvalConfig(**json.loads(json.dumps(dataclasses.asdict(cfg))))
+    assert rebuilt == cfg
 
 
 def test_recipe_hook_collects_logs_and_launches(monkeypatch):

--- a/tests/unit_tests/speculative/test_decode_eval.py
+++ b/tests/unit_tests/speculative/test_decode_eval.py
@@ -1,0 +1,265 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the periodic decode eval (config, snapshot export, runner, worker argv)."""
+
+from __future__ import annotations
+
+import json
+import os
+from types import SimpleNamespace
+
+import pytest
+import torch
+from transformers import LlamaConfig
+
+from nemo_automodel.components.speculative.decode_eval import (
+    DecodeEvalConfig,
+    DecodeEvalRunner,
+    _bench_args,
+    _serve_argv,
+    _worker_env,
+    export_draft_snapshot,
+    resolve_decode_eval_config,
+)
+from nemo_automodel.components.speculative.serve_vllm import _find_draft_dir
+
+
+def _config(tmp_path, **overrides):
+    kwargs = dict(
+        every_steps=10,
+        cuda_visible_devices="7",
+        target_model="/models/target",
+        input_data="/data/train.jsonl",
+        output_dir=str(tmp_path / "decode_eval"),
+    )
+    kwargs.update(overrides)
+    return DecodeEvalConfig(**kwargs)
+
+
+def test_resolve_returns_none_when_absent_or_disabled(tmp_path):
+    assert (
+        resolve_decode_eval_config({}, default_target="/t", default_input_data="/d", output_dir=str(tmp_path)) is None
+    )
+    cfg = {"decode_eval": {"every_steps": 0, "cuda_visible_devices": "7"}}
+    assert (
+        resolve_decode_eval_config(cfg, default_target="/t", default_input_data="/d", output_dir=str(tmp_path)) is None
+    )
+
+
+def test_resolve_requires_reserved_gpu(tmp_path):
+    cfg = {"decode_eval": {"every_steps": 100}}
+    with pytest.raises(ValueError, match="cuda_visible_devices"):
+        resolve_decode_eval_config(cfg, default_target="/t", default_input_data="/d", output_dir=str(tmp_path))
+
+
+def test_resolve_fills_defaults_from_recipe(tmp_path):
+    cfg = {"decode_eval": {"every_steps": 250, "cuda_visible_devices": 6}}
+    resolved = resolve_decode_eval_config(
+        cfg, default_target="/models/qwen", default_input_data="/data/messages", output_dir=str(tmp_path)
+    )
+    assert resolved.every_steps == 250
+    assert resolved.cuda_visible_devices == "6"
+    assert resolved.target_model == "/models/qwen"
+    assert resolved.input_data == "/data/messages"
+    assert resolved.output_dir == os.path.join(str(tmp_path), "decode_eval")
+
+
+def test_export_draft_snapshot_is_serve_resolvable(tmp_path):
+    """The snapshot must land in the model/consolidated layout serve_vllm probes."""
+
+    class _TinyDraft(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.fc = torch.nn.Linear(4, 4)
+            self.register_buffer("d2t", torch.arange(4))
+            self.config = LlamaConfig(hidden_size=4, num_attention_heads=1, num_hidden_layers=1)
+
+    out_dir = str(tmp_path / "step_10")
+    consolidated = export_draft_snapshot(_TinyDraft(), out_dir)
+    assert os.path.exists(os.path.join(consolidated, "model.safetensors"))
+    assert os.path.exists(os.path.join(consolidated, "config.json"))
+    from safetensors import safe_open
+
+    with safe_open(os.path.join(consolidated, "model.safetensors"), framework="pt") as f:
+        keys = set(f.keys())
+    assert "d2t" in keys  # vocab-mapping buffers ride along
+    assert _find_draft_dir(__import__("pathlib").Path(out_dir)) is not None
+
+
+def test_worker_env_scrubs_torchrun_state(monkeypatch):
+    monkeypatch.setenv("RANK", "3")
+    monkeypatch.setenv("WORLD_SIZE", "8")
+    monkeypatch.setenv("MASTER_ADDR", "10.0.0.1")
+    monkeypatch.setenv("TORCHELASTIC_RUN_ID", "abc")
+    monkeypatch.setenv("HF_HOME", "/cache/hf")
+    env = _worker_env("5")
+    assert env["CUDA_VISIBLE_DEVICES"] == "5"
+    assert env["HF_HOME"] == "/cache/hf"
+    for key in ("RANK", "WORLD_SIZE", "MASTER_ADDR", "TORCHELASTIC_RUN_ID"):
+        assert key not in env
+
+
+class _FakeProc:
+    def __init__(self, alive=True, pid=4242):
+        self._alive = alive
+        self.pid = pid
+
+    def poll(self):
+        return None if self._alive else 0
+
+
+def _runner_with_fake_launch(tmp_path, monkeypatch, launched):
+    runner = DecodeEvalRunner(_config(tmp_path))
+    monkeypatch.setattr(
+        "nemo_automodel.components.speculative.decode_eval.export_draft_snapshot",
+        lambda model, out_dir: launched.append(("export", out_dir)) or out_dir,
+    )
+    monkeypatch.setattr(
+        "nemo_automodel.components.speculative.decode_eval.subprocess.Popen",
+        lambda argv, **kw: launched.append(("popen", argv, kw)) or _FakeProc(),
+    )
+    return runner
+
+
+def test_runner_launches_on_cadence_and_skips_while_running(tmp_path, monkeypatch):
+    launched = []
+    runner = _runner_with_fake_launch(tmp_path, monkeypatch, launched)
+    model = object()
+
+    assert not runner.maybe_launch(5, model)  # before the first boundary
+    assert runner.maybe_launch(10, model)
+    assert not runner.maybe_launch(10, model)  # same bucket, no relaunch
+    # Next boundary while the previous eval is still alive: skipped, but the
+    # bucket does not advance past it forever - once the proc finishes the next
+    # boundary launches again.
+    assert not runner.maybe_launch(20, model)
+    runner._proc._alive = False
+    assert runner.maybe_launch(30, model)
+
+    popen_calls = [entry for entry in launched if entry[0] == "popen"]
+    assert len(popen_calls) == 2
+    argv = popen_calls[0][1]
+    assert "--step" in argv and argv[argv.index("--step") + 1] == "10"
+    assert popen_calls[0][2]["env"]["CUDA_VISIBLE_DEVICES"] == "7"
+    assert popen_calls[0][2]["start_new_session"] is True
+
+
+def test_runner_collect_returns_each_result_once(tmp_path):
+    runner = DecodeEvalRunner(_config(tmp_path))
+    step_dir = os.path.join(runner.config.output_dir, "step_10")
+    os.makedirs(step_dir)
+    with open(os.path.join(step_dir, "result.json"), "w") as f:
+        json.dump({"step": 10, "accept_length": 1.83}, f)
+
+    first = runner.collect()
+    assert len(first) == 1 and first[0]["accept_length"] == 1.83
+    assert runner.collect() == []
+
+    # A later result is picked up in step order.
+    step_dir2 = os.path.join(runner.config.output_dir, "step_20")
+    os.makedirs(step_dir2)
+    with open(os.path.join(step_dir2, "result.json"), "w") as f:
+        json.dump({"step": 20, "accept_length": 2.01}, f)
+    second = runner.collect()
+    assert [r["step"] for r in second] == [20]
+
+
+def test_serve_argv_builds_speculative_server_command(tmp_path, monkeypatch):
+    """The worker must drive serve_vllm's library surface, not reimplement it."""
+    seen = {}
+
+    def _fake_build(serve_args):
+        seen.update(vars(serve_args))
+        return ["python", "-m", "vllm.entrypoints.openai.api_server"]
+
+    monkeypatch.setattr("nemo_automodel.components.speculative.serve_vllm.build_vllm_argv", _fake_build)
+    args = SimpleNamespace(
+        target="/models/target",
+        draft=str(tmp_path / "step_10"),
+        num_speculative_tokens=None,
+        port=8199,
+        gpu_memory_utilization=0.8,
+        max_model_len=None,
+        trust_remote_code=False,
+    )
+    argv = _serve_argv(args)
+    assert argv[0] == "python"
+    assert seen["target"] == "/models/target"
+    assert seen["draft"] == str(tmp_path / "step_10")
+    assert seen["port"] == 8199
+    assert seen["host"] == "127.0.0.1"
+
+
+def test_bench_args_carry_workload_settings():
+    args = SimpleNamespace(
+        target="/models/target",
+        input_data="/data/train.jsonl",
+        num_prompts=16,
+        concurrency=4,
+        max_new_tokens=128,
+        temperature=0.0,
+        top_p=1.0,
+        messages_column="messages",
+        prompt_column=None,
+        split="train",
+        dataset_name=None,
+        shuffle_seed=42,
+        timeout_s=600.0,
+    )
+    bench = _bench_args(args, "http://127.0.0.1:8199")
+    assert bench.server == "http://127.0.0.1:8199"
+    assert bench.model == "/models/target"
+    assert bench.num_prompts == 16
+    assert bench.baseline_server is None
+    assert bench.prompt_context_column is None
+
+
+def test_recipe_hook_collects_logs_and_launches(monkeypatch):
+    """The rank-0 log-point hook must log finished results to wandb (at the
+    current step) and hand the launch decision to the runner."""
+    from nemo_automodel.recipes.llm.train_eagle3 import TrainEagle3Recipe
+
+    recipe = TrainEagle3Recipe.__new__(TrainEagle3Recipe)
+    recipe.runtime = SimpleNamespace(global_step=42)
+    recipe.draft_model = object()
+    logged = []
+    recipe._wandb_log = lambda data, step: logged.append((data, step))
+
+    calls = SimpleNamespace(launch=[])
+
+    class _StubRunner:
+        def collect(self):
+            return [{"step": 30, "accept_length": 1.9, "acceptance_rate": 0.45, "completed": 32, "failed": 0}]
+
+        def maybe_launch(self, step, model):
+            calls.launch.append((step, model))
+            return True
+
+    recipe.decode_eval_runner = _StubRunner()
+    recipe._maybe_run_decode_eval()
+
+    assert calls.launch == [(42, recipe.draft_model)]
+    assert len(logged) == 1
+    data, step = logged[0]
+    assert step == 42  # wandb steps must not go backwards
+    assert data["train/tau_real"] == 1.9
+    assert data["train/tau_real_step"] == 30
+
+
+def test_recipe_hook_noop_without_runner():
+    from nemo_automodel.recipes.llm.train_eagle3 import TrainEagle3Recipe
+
+    recipe = TrainEagle3Recipe.__new__(TrainEagle3Recipe)
+    recipe._maybe_run_decode_eval()  # must not raise (bare object, no setup)


### PR DESCRIPTION
## Summary

1. Add an optional decode_eval recipe block that periodically snapshots the EAGLE-3 draft and measures real engine accept length on a reserved GPU.
2. Run vLLM and the benchmark in an isolated worker process while training continues, then log completed results as train/tau_real.
3. Harden worker lifecycle, resume behavior, port selection, snapshot cleanup, and optional-eval failure containment.

## Testing

1. ruff check and ruff format check passed on all changed Python files.
2. 123 related unit tests passed, including decode eval, serve and bench integration, EAGLE-3 cleanup, tau metrics, and offline cache coverage.