### PR TITLE
feat(eagle3): on-policy regeneration loop with step-cadence dataloader swap

### DIFF
--- a/nemo_automodel/components/speculative/regen_loop.py
+++ b/nemo_automodel/components/speculative/regen_loop.py
@@ -1,0 +1,470 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""On-policy data regeneration loop for EAGLE-3 draft training (train-with-decode).
+
+EAGLE-3 teacher-forces the draft on a static dataset whose assistant turns were
+often written by a *different* model than the target being distilled, so the
+draft trains against off-distribution supervision (this is why the recipes ship
+an offline ``regenerate.py`` pass). This module runs that regeneration
+*online*, interleaved with training:
+
+* On a cadence (``regen.every_steps``), rank 0 launches a detached **worker
+  subprocess** pinned to a reserved GPU (``regen.cuda_visible_devices``). The
+  worker boots a plain vLLM OpenAI server for the frozen target and drives the
+  existing ``regenerate`` machinery over a prompt slice, writing a fresh
+  directory of parquet shards. Training never blocks; at most one cycle is in
+  flight.
+* At the next epoch boundary the recipe checks for a completed cycle, and if one
+  is ready **all data-parallel ranks** rebuild the training dataloader against
+  the new shard directory in lockstep (the decision is broadcast from rank 0 so
+  the ranks never diverge).
+
+Because the EAGLE target is frozen, the regenerated distribution is stationary:
+the value here is pipelining (regenerate just-in-time instead of one giant
+upfront pass) and freshness (sampling new responses each cycle with
+``temperature > 0``), plus the plumbing a future draft-in-the-loop mode would
+reuse. The trainer process never imports vllm; the worker inherits the training
+env minus the torchrun/elastic variables (see ``decode_eval._worker_env``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import signal
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, fields
+from typing import Any
+
+from nemo_automodel.components.speculative.decode_eval import (
+    _resolve_worker_port,
+    _wait_for_server,
+    _worker_env,
+)
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_FILENAME = "regen_config.json"
+_DONE_FILENAME = "READY"
+_SHARDS_DIRNAME = "shards"
+_WORKER_LOG_FILENAME = "worker.log"
+
+
+@dataclass
+class RegenConfig:
+    """Resolved settings for the online on-policy regeneration loop.
+
+    ``every_steps`` is the launch cadence in optimizer steps; a completed cycle
+    is only swapped in at an epoch boundary (mid-epoch dataloader rebuilds would
+    desync the sampler and the scheduler's step count). ``cuda_visible_devices``
+    is the GPU (or comma list) reserved for the regeneration engine; training
+    must not place work there. ``server_python`` is the interpreter used to
+    launch the vLLM server (the training env need not have vllm installed); the
+    regeneration client runs in the training env over HTTP.
+    """
+
+    every_steps: int
+    cuda_visible_devices: str
+    target_model: str
+    input_data: str
+    output_dir: str
+    served_model_name: str = "target"
+    server_python: str | None = None
+    split: str = "train"
+    messages_column: str = "messages"
+    dataset_name: str | None = None
+    shard_size: int = 1000
+    concurrency: int = 32
+    max_new_tokens: int = 1024
+    temperature: float = 1.0
+    top_p: float = 1.0
+    shuffle_seed: int = 42
+    reasoning: str = "none"
+    port: int = 0
+    gpu_memory_utilization: float = 0.85
+    max_model_len: int | None = None
+    trust_remote_code: bool = False
+    timeout_s: float = 3600.0
+
+
+def resolve_regen_config(
+    recipe_cfg: Any,
+    *,
+    default_target: str,
+    default_input_data: str | None,
+    output_dir: str,
+) -> RegenConfig | None:
+    """Read the optional ``regen:`` block from ``recipe_args``.
+
+    Returns ``None`` when the block is absent or ``every_steps`` is unset/0
+    (feature disabled). Raises on a partially-configured block so a typo'd GPU
+    reservation fails at setup rather than silently regenerating on a training
+    GPU. Field defaults live on :class:`RegenConfig` only; the block just
+    overrides the fields it sets.
+    """
+    block = recipe_cfg.get("regen", None)
+    if block is None:
+        return None
+    every_steps = int(block.get("every_steps", 0) or 0)
+    if every_steps <= 0:
+        return None
+    block = block.to_dict() if hasattr(block, "to_dict") else dict(block)
+    unknown = set(block) - {field.name for field in fields(RegenConfig)}
+    if unknown:
+        raise ValueError(f"Unknown regen option(s): {', '.join(sorted(unknown))}")
+    if "output_dir" in block:
+        raise ValueError(
+            "regen.output_dir is not configurable: shards are always written under "
+            "<run output_dir>/regen. Remove it from the regen block."
+        )
+    cuda_visible_devices = block.get("cuda_visible_devices", None)
+    if cuda_visible_devices is None or str(cuda_visible_devices) == "":
+        raise ValueError(
+            "regen.cuda_visible_devices is required: the regeneration engine needs a GPU the training "
+            "job does not use (e.g. reserve one card and shrink the torchrun world accordingly)."
+        )
+    input_data = block.get("input_data", None) or default_input_data
+    if not input_data:
+        raise ValueError("regen.input_data is required when recipe_args.train_data_path is not set.")
+    required = {"every_steps", "cuda_visible_devices", "target_model", "input_data", "output_dir"}
+    overrides = {}
+    for field in fields(RegenConfig):
+        if field.name in required:
+            continue
+        value = block.get(field.name, None)
+        if value is not None:
+            overrides[field.name] = value
+    return RegenConfig(
+        every_steps=every_steps,
+        cuda_visible_devices=str(cuda_visible_devices),
+        target_model=str(block.get("target_model", None) or default_target),
+        input_data=str(input_data),
+        output_dir=os.path.join(output_dir, "regen"),
+        **overrides,
+    )
+
+
+class RegenRunner:
+    """Rank-0 trainer-side orchestrator: launch regeneration at cadence, hand ready cycles to the recipe.
+
+    At most one regeneration subprocess is alive at a time; a launch that lands
+    while the previous cycle is still running is skipped (the next cadence
+    boundary picks it up). A cycle is "ready" once its worker has written the
+    ``READY`` marker; :meth:`take_ready_shards` returns the newest ready cycle's
+    shard directory exactly once, so the recipe can swap it into the dataloader.
+    """
+
+    def __init__(self, config: RegenConfig):
+        self.config = config
+        self._proc: subprocess.Popen | None = None
+        self._worker_log_path: str | None = None
+        self._launched_for_step = -1
+        self._last_bucket = 0
+        self._consumed: set[str] = set()
+        # The cycle whose shards currently feed training; never deleted while active.
+        self._active_cycle: str | None = None
+        os.makedirs(config.output_dir, exist_ok=True)
+
+    def _cycle_dirs(self) -> list[tuple[int, str]]:
+        """Return valid cycle directories in numeric order, ignoring stray names."""
+        try:
+            entries = os.listdir(self.config.output_dir)
+        except FileNotFoundError:
+            return []
+        parsed = []
+        for entry in entries:
+            if not entry.startswith("cycle_"):
+                continue
+            try:
+                parsed.append((int(entry.split("_", 1)[1]), entry))
+            except ValueError:
+                logger.warning("regen: ignoring invalid cycle directory %s", entry)
+        return sorted(parsed)
+
+    def _reap_finished_worker(self) -> None:
+        """Report a completed worker and release its Popen state."""
+        if self._proc is None:
+            return
+        return_code = self._proc.poll()
+        if return_code is None:
+            return
+        if return_code != 0:
+            logger.error(
+                "regen: worker for step %d exited with code %d; see %s",
+                self._launched_for_step,
+                return_code,
+                self._worker_log_path,
+            )
+        else:
+            logger.info("regen: worker for step %d completed", self._launched_for_step)
+        self._proc = None
+        self._worker_log_path = None
+
+    def due(self, global_step: int) -> bool:
+        """Whether a new regeneration cycle should launch at this optimizer step."""
+        return global_step // self.config.every_steps > self._last_bucket
+
+    def resume_from_step(self, global_step: int) -> None:
+        """Align the launch cadence to a restored ``global_step`` after a resume.
+
+        Without this a resumed run starts with ``_last_bucket == 0`` and
+        :meth:`due` fires immediately, relaunching a redundant cycle for a cadence
+        region that already ran before the checkpoint. Superseded on-disk cycles
+        left by the pre-crash run are reclaimed by :meth:`take_ready_shards` on the
+        next swap (it frees every ready cycle but the newest), so no cycle path
+        needs to be persisted across the checkpoint.
+        """
+        self._last_bucket = global_step // self.config.every_steps
+        self._launched_for_step = global_step
+
+    def maybe_launch(self, global_step: int) -> bool:
+        """Launch a regeneration worker if the cadence is due and none is running."""
+        if not self.due(global_step):
+            return False
+        self._reap_finished_worker()
+        if self._proc is not None and self._proc.poll() is None:
+            logger.info(
+                "regen: previous cycle (step %d) still running, skipping launch at step %d",
+                self._launched_for_step,
+                global_step,
+            )
+            return False
+        cycle_dir = os.path.join(self.config.output_dir, f"cycle_{global_step}")
+        # A half-written cycle from a crashed prior worker (leftover shards and/or a
+        # stale READY marker) must be wiped, not reused: ``regenerate`` aborts on a
+        # non-empty shard dir, and a stale marker could make the cycle look ready.
+        # Start every launch from a clean directory.
+        self._remove_cycle(cycle_dir)
+        os.makedirs(cycle_dir, exist_ok=True)
+        config_json = os.path.join(cycle_dir, _CONFIG_FILENAME)
+        with open(config_json, "w") as f:
+            json.dump(asdict(self.config), f, indent=2)
+        argv = [
+            sys.executable,
+            "-m",
+            "nemo_automodel.components.speculative.regen_loop",
+            "--config-json",
+            config_json,
+            "--cycle-dir",
+            cycle_dir,
+            "--step",
+            str(global_step),
+        ]
+        log_path = os.path.join(cycle_dir, _WORKER_LOG_FILENAME)
+        with open(log_path, "ab") as log_file:
+            self._proc = subprocess.Popen(
+                argv,
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
+                env=_worker_env(self.config.cuda_visible_devices),
+                start_new_session=True,
+            )
+        self._last_bucket = global_step // self.config.every_steps
+        self._launched_for_step = global_step
+        self._worker_log_path = log_path
+        logger.info(
+            "regen: launched cycle for step %d on CUDA_VISIBLE_DEVICES=%s (pid %d, log %s)",
+            global_step,
+            self.config.cuda_visible_devices,
+            self._proc.pid,
+            log_path,
+        )
+        return True
+
+    def take_ready_shards(self) -> str | None:
+        """Return the newest ready, not-yet-consumed cycle's shard directory, or None.
+
+        A cycle is ready once its ``READY`` marker exists. Older ready cycles are
+        marked consumed and skipped so the recipe always trains on the freshest
+        regenerated data rather than replaying stale cycles.
+        """
+        self._reap_finished_worker()
+        # Single directory scan: collect every ready cycle (sorted oldest to newest).
+        ready = []
+        for _, cycle_dir in self._cycle_dirs():
+            cycle_path = os.path.join(self.config.output_dir, cycle_dir)
+            if os.path.exists(os.path.join(cycle_path, _DONE_FILENAME)):
+                ready.append(cycle_path)
+        # Train on the freshest cycle not already consumed; everything ready up to
+        # and including it is marked consumed so stale cycles are never replayed.
+        fresh = [cycle_path for cycle_path in ready if cycle_path not in self._consumed]
+        if not fresh:
+            return None
+        newest = fresh[-1]
+        self._consumed.update(ready)
+        # Free every superseded ready cycle still on disk, not just the previously
+        # active one: when several cycles complete between two swaps only the newest
+        # feeds training, so the intermediate ones would otherwise be stranded and
+        # disk would grow one full dataset per cycle. The newest is kept.
+        for cycle_path in ready:
+            if cycle_path != newest:
+                self._remove_cycle(cycle_path)
+        self._active_cycle = newest
+        return os.path.join(newest, _SHARDS_DIRNAME)
+
+    @staticmethod
+    def _remove_cycle(cycle_path: str) -> None:
+        try:
+            shutil.rmtree(cycle_path)
+        except FileNotFoundError:
+            pass
+        except OSError:
+            logger.exception("regen: failed to remove superseded cycle %s", cycle_path)
+
+    def shutdown(self) -> None:
+        """Terminate a still-running cycle (its vLLM child dies with the session)."""
+        if self._proc is not None and self._proc.poll() is None:
+            logger.info("regen: terminating in-flight cycle (pid %d)", self._proc.pid)
+            try:
+                process_group = os.getpgid(self._proc.pid)
+                os.killpg(process_group, signal.SIGTERM)
+            except (ProcessLookupError, PermissionError):
+                process_group = None
+                self._proc.terminate()
+            try:
+                self._proc.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                if process_group is not None:
+                    try:
+                        os.killpg(process_group, signal.SIGKILL)
+                    except (ProcessLookupError, PermissionError):
+                        self._proc.kill()
+                else:
+                    self._proc.kill()
+                self._proc.wait()
+        elif self._proc is not None:
+            self._reap_finished_worker()
+        self._proc = None
+        self._worker_log_path = None
+
+
+# --------------------------------------------------------------------------- #
+# Worker CLI: runs in its own process on the reserved GPU.
+# --------------------------------------------------------------------------- #
+
+
+def _target_server_argv(cfg: RegenConfig, port: int) -> list[str]:
+    """Build the plain (non-speculative) vLLM OpenAI server argv for the frozen target."""
+    server_python = cfg.server_python or sys.executable
+    argv = [
+        server_python,
+        "-m",
+        "vllm.entrypoints.openai.api_server",
+        "--model",
+        cfg.target_model,
+        "--served-model-name",
+        cfg.served_model_name,
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(port),
+        "--gpu-memory-utilization",
+        str(cfg.gpu_memory_utilization),
+    ]
+    if cfg.max_model_len is not None:
+        argv += ["--max-model-len", str(cfg.max_model_len)]
+    if cfg.trust_remote_code:
+        argv += ["--trust-remote-code"]
+    return argv
+
+
+def _regenerate_argv(cfg: RegenConfig, server: str, shards_dir: str) -> list[str]:
+    """Build the regenerate CLI args to run against the booted target server."""
+    argv = [
+        "--input-data",
+        cfg.input_data,
+        "--output-dir",
+        shards_dir,
+        "--target-server",
+        f"{server}/v1",
+        "--model",
+        cfg.served_model_name,
+        "--messages-column",
+        cfg.messages_column,
+        "--split",
+        cfg.split,
+        "--shuffle-seed",
+        str(cfg.shuffle_seed),
+        "--shard-size",
+        str(cfg.shard_size),
+        "--concurrency",
+        str(cfg.concurrency),
+        "--max-new-tokens",
+        str(cfg.max_new_tokens),
+        "--temperature",
+        str(cfg.temperature),
+        "--top-p",
+        str(cfg.top_p),
+        "--timeout-s",
+        str(cfg.timeout_s),
+        "--reasoning",
+        cfg.reasoning,
+    ]
+    if cfg.dataset_name:
+        argv += ["--dataset-name", cfg.dataset_name]
+    return argv
+
+
+def _build_parser():
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="regen worker: serve the frozen target and regenerate on-policy training shards"
+    )
+    parser.add_argument("--config-json", required=True, help="JSON dump of RegenConfig (written at launch)")
+    parser.add_argument("--cycle-dir", required=True, help="output dir for this cycle (shards + READY marker)")
+    parser.add_argument("--step", type=int, required=True)
+    return parser
+
+
+def main(argv=None) -> int:
+    """Worker entry: boot a target server, regenerate a shard dir, write the READY marker."""
+    from nemo_automodel.components.speculative.regenerate import main as regenerate_main
+
+    args = _build_parser().parse_args(argv)
+    with open(args.config_json) as f:
+        cfg = RegenConfig(**json.load(f))
+    port = _resolve_worker_port(cfg.port)
+    server = f"http://127.0.0.1:{port}"
+    shards_dir = os.path.join(args.cycle_dir, _SHARDS_DIRNAME)
+    # The READY marker is written only after regeneration returns 0, and the
+    # runner only ever hands training a cycle that has the marker, so a
+    # mid-write shard set is never swapped in.
+    server_argv = _target_server_argv(cfg, port)
+    print(f"regen worker: starting target server: {' '.join(server_argv)}", flush=True)
+    proc = subprocess.Popen(server_argv)
+    try:
+        _wait_for_server(server, proc, cfg.timeout_s)
+        rc = regenerate_main(_regenerate_argv(cfg, server, shards_dir))
+        if rc != 0:
+            raise RuntimeError(f"regenerate exited with code {rc}")
+        with open(os.path.join(args.cycle_dir, _DONE_FILENAME), "w") as f:
+            f.write(str(args.step))
+        print(f"regen worker: cycle {args.step} ready at {shards_dir}", flush=True)
+        return 0
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=60)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/nemo_automodel/recipes/llm/train_eagle3.py
+++ b/nemo_automodel/recipes/llm/train_eagle3.py
@@ -59,6 +59,7 @@ from nemo_automodel.components.speculative.eagle import (
 )
 from nemo_automodel.components.speculative.eagle.registry import resolve_eagle3_draft_spec
 from nemo_automodel.components.speculative.eagle.remote import RemoteEagle3TargetModel
+from nemo_automodel.components.speculative.regen_loop import RegenRunner, resolve_regen_config
 from nemo_automodel.components.training.rng import StatefulRNG
 from nemo_automodel.components.utils.model_utils import print_trainable_parameters
 from nemo_automodel.recipes._dist_utils import create_distributed_setup_from_config
@@ -656,6 +657,10 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
         self.total_optim_steps = total_optim_steps
         self.warmup_steps = warmup_steps
         self.min_lr_ratio = min_lr_ratio
+        # Baseline segment length; the on-policy regen swap warns if a regenerated
+        # cycle differs from it, since the fixed LR horizon assumes an unchanged
+        # per-pass step count (see ``_maybe_swap_regen_dataloader``).
+        self._orig_batches_per_epoch = num_batches_per_epoch
 
         self.runtime = SimpleNamespace(global_step=0)
         self._resume_epoch = 0
@@ -737,6 +742,106 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
             except Exception:
                 logger.exception("decode_eval: launch failed at step %d; training continues", self.runtime.global_step)
 
+    def _setup_regen(self, recipe_cfg, target_path) -> None:
+        """Build the optional on-policy regeneration runner (rank 0, online path only).
+
+        The runner is only constructed on rank 0 (it owns the worker subprocess);
+        every rank participates in the epoch-boundary dataloader swap via the
+        broadcast in :meth:`_maybe_swap_regen_dataloader`, so all ranks must know
+        whether the feature is enabled. ``_regen_enabled`` carries that flag.
+        """
+        self.regen_runner = None
+        self._regen_enabled = False
+        # Derive output_dir from recipe_cfg rather than self.output_dir: this runs
+        # inside _setup_online_target, before the setup body assigns self.output_dir.
+        regen_config = resolve_regen_config(
+            recipe_cfg,
+            default_target=str(target_path),
+            default_input_data=recipe_cfg.get("train_data_path", None),
+            output_dir=str(recipe_cfg.get("output_dir")),
+        )
+        if regen_config is None:
+            return
+        if getattr(self, "peft_config", None) is not None:
+            raise ValueError(
+                "regen is not supported with peft: the LoRA draft is orthogonal to target regeneration; "
+                "regenerate the dataset offline instead."
+            )
+        self._regen_enabled = True
+        if self.dist_env.is_main:
+            self.regen_runner = RegenRunner(regen_config)
+
+    def _maybe_run_regen(self) -> None:
+        """Rank-0 log-point hook: launch a regeneration cycle when the cadence is due."""
+        runner = getattr(self, "regen_runner", None)
+        if runner is None:
+            return
+        try:
+            runner.maybe_launch(self.runtime.global_step)
+        except Exception:
+            logger.exception("regen: launch failed at step %d; training continues", self.runtime.global_step)
+
+    def _build_train_dataloader(self, data_path, split):
+        """Build the train dataloader from ``self.cfg.recipe_args``.
+
+        Reused by the on-policy regen loop to rebuild the train dataloader against a
+        fresh shard directory with identical settings (only ``data_path``/``split`` vary).
+        """
+        recipe_cfg = self.cfg.recipe_args
+        return build_eagle3_dataloader(
+            data_path=data_path,
+            tokenizer=self.tokenizer,
+            seq_length=recipe_cfg.seq_length,
+            batch_size=recipe_cfg.micro_batch_size,
+            shuffle=recipe_cfg.get("train_shuffle", True),
+            num_workers=recipe_cfg.get("num_workers", 0),
+            split=split,
+            distributed=self.dist_env.world_size > 1,
+            shuffle_seed=recipe_cfg.get("shuffle_seed", 42),
+            mask_reasoning_content=recipe_cfg.get("mask_reasoning_content", False),
+            packed_sequence_size=recipe_cfg.get("packed_sequence_size", 0),
+            dp_mesh=self.dp_mesh,
+        )
+
+    def _maybe_swap_regen_dataloader(self) -> bool:
+        """Swap the train dataloader to the newest ready regenerated shard dir; return whether a swap happened.
+
+        Rank 0 decides which directory (if any) is ready and broadcasts it; every
+        rank then rebuilds its dataloader against the same shared-filesystem path
+        so the distributed sampler stays consistent. Called at a grad-accum window
+        boundary (``pending_micro_batches == 0``), so there is no partial window to
+        flush; the caller ends the current segment and rebinds when this returns
+        ``True``. The regenerated slice is expected to keep the original prompt
+        count so steps-per-epoch (and the fixed LR horizon) stay coherent; a
+        differing length is warned about rather than silently trusted.
+        """
+        if not getattr(self, "_regen_enabled", False):
+            return False
+        new_dir: str | None = None
+        if self.dist_env.is_main and self.regen_runner is not None:
+            new_dir = self.regen_runner.take_ready_shards()
+        if self.dist_env.world_size > 1:
+            box = [new_dir]
+            dist.broadcast_object_list(box, src=0)
+            new_dir = box[0]
+        if new_dir is None:
+            return False
+        logger.info("regen: swapping train dataloader to regenerated shards at %s", new_dir)
+        self.train_dataloader = self._build_train_dataloader(new_dir, split=None)
+        orig = getattr(self, "_orig_batches_per_epoch", None)
+        try:
+            new_len = len(self.train_dataloader)
+        except TypeError:
+            new_len = None
+        if orig and new_len is not None and new_len != orig:
+            logger.warning(
+                "regen: regenerated dataloader has %d batches vs the original %d; the fixed LR horizon "
+                "(total_optim_steps) assumes an unchanged per-pass step count, so the cosine schedule may drift.",
+                new_len,
+                orig,
+            )
+        return True
+
     def _setup_online_target(self, recipe_cfg, target_path, target_config):
         """Live path: load the target model and build the live dataloader.
 
@@ -796,20 +901,11 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
         else:  # colocated
             self._setup_colocated_target(recipe_cfg, target_path)
 
-        self.train_dataloader = build_eagle3_dataloader(
-            data_path=recipe_cfg.train_data_path,
-            tokenizer=self.tokenizer,
-            seq_length=recipe_cfg.seq_length,
-            batch_size=recipe_cfg.micro_batch_size,
-            shuffle=recipe_cfg.get("train_shuffle", True),
-            num_workers=recipe_cfg.get("num_workers", 0),
-            split=recipe_cfg.get("train_split", None),
-            distributed=self.dist_env.world_size > 1,
-            shuffle_seed=recipe_cfg.get("shuffle_seed", 42),
-            mask_reasoning_content=recipe_cfg.get("mask_reasoning_content", False),
-            packed_sequence_size=packed_sequence_size,
-            dp_mesh=self.dp_mesh,
+        self.train_dataloader = self._build_train_dataloader(
+            recipe_cfg.train_data_path,
+            recipe_cfg.get("train_split", None),
         )
+        self._setup_regen(recipe_cfg, target_path)
         self.val_dataloader = None
         if recipe_cfg.get("val_data_path", None):
             self.val_dataloader = build_eagle3_dataloader(
@@ -1191,16 +1287,26 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
                 queue.append((batch, handle))
 
         fill()
-        while queue:
-            batch, handle = queue.popleft()
-            target_batch = handle.result()
-            # Refill only after the popped request completed: round-robin makes
-            # its server the next dispatch target, so refilling before the
-            # result would put a second request in flight on a busy server and
-            # break the one-in-flight-per-server invariant that NCCL recv
-            # ordering and the server's hook-based aux capture rely on.
-            fill()
-            yield batch, target_batch
+        try:
+            while queue:
+                batch, handle = queue.popleft()
+                target_batch = handle.result()
+                # Refill only after the popped request completed: round-robin makes
+                # its server the next dispatch target, so refilling before the
+                # result would put a second request in flight on a busy server and
+                # break the one-in-flight-per-server invariant that NCCL recv
+                # ordering and the server's hook-based aux capture rely on.
+                fill()
+                yield batch, target_batch
+        finally:
+            # If the consumer stops early (a mid-epoch regen swap breaks the loop),
+            # the generator is closed with in-flight requests still queued. Drain
+            # (await) them and discard the results: leaving requests un-awaited
+            # would corrupt the one-in-flight-per-server recv ordering for the next
+            # segment, and the batches are stale off-policy data not worth training on.
+            while queue:
+                _, pending_handle = queue.popleft()
+                pending_handle.result()
 
     def _build_checkpointer(self, target_path: str) -> None:
         """Build the checkpointer using the same plumbing as the standard recipes."""
@@ -1500,6 +1606,11 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
             meta = torch.load(meta_path, weights_only=False, map_location="cpu")
             self.runtime.global_step = int(meta.get("global_step", 0))
             self._resume_epoch = int(meta.get("epoch", 0))
+            # Align the regen launch cadence to the restored step so resume does not
+            # immediately fire a redundant cycle for an already-covered region.
+            regen_runner = getattr(self, "regen_runner", None)
+            if regen_runner is not None:
+                regen_runner.resume_from_step(self.runtime.global_step)
             ids = meta.get("selected_token_ids")
             mask = meta.get("selected_token_mask")
             if ids is not None and mask is not None:
@@ -1587,7 +1698,7 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
 
         pbar = self._make_progress_bar(total=self.total_optim_steps, initial=self.runtime.global_step)
         try:
-            self._train_epochs(start_epoch, batches_per_epoch, is_ddp, pbar)
+            self._train_epochs(start_epoch, is_ddp, pbar)
             self._maybe_save_final_checkpoint(self.num_epochs)
             self._finalize_pending_checkpoint()
             if self.dist_env.is_main:
@@ -1616,16 +1727,27 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
         if getattr(self, "decode_eval_runner", None) is not None:
             _best_effort("collecting final decode-eval results", lambda: self._maybe_run_decode_eval(launch=False))
             _best_effort("stopping decode-eval worker", self.decode_eval_runner.shutdown)
+        if getattr(self, "regen_runner", None) is not None:
+            _best_effort("stopping regen worker", self.regen_runner.shutdown)
         if getattr(self, "wandb_run", None) is not None:
             _best_effort("finishing W&B run", self.wandb_run.finish)
 
-    def _train_epochs(self, start_epoch, batches_per_epoch, is_ddp, pbar=None):
+    def _train_epochs(self, start_epoch, is_ddp, pbar=None):
         """Run the epoch loop (extracted so :meth:`run_train_validation_loop` can
-        wrap it in ``try/finally`` and guarantee teardown on any exit path)."""
-        for epoch in range(start_epoch, self.num_epochs):
-            if hasattr(self.train_dataloader.sampler, "set_epoch"):
-                self.train_dataloader.sampler.set_epoch(epoch)
+        wrap it in ``try/finally`` and guarantee teardown on any exit path).
 
+        The run is step-budget driven: it stops when ``global_step`` reaches
+        ``total_optim_steps`` (the horizon the LR schedule was calibrated on), not
+        when the epoch range is exhausted. With on-policy regen enabled an epoch is
+        split into *segments* -- one contiguous pass over each bound dataloader --
+        and a swap to freshly regenerated shards ends the current segment and rebinds
+        a new one. Swaps happen only at a grad-accum window boundary
+        (``pending_micro_batches == 0``), so there is never a partial window to flush
+        or an un-synced gradient at the swap point; the trailing flush below then
+        only ever runs for the single segment that ends by dataloader exhaustion.
+        """
+        reached_budget = False
+        for epoch in range(start_epoch, self.num_epochs):
             running_loss = torch.zeros((), device=self.device)
             running_acc = torch.zeros((), device=self.device)
             # Per-TTT-step prefix-hit/valid counts for the simulated accept
@@ -1639,102 +1761,137 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
 
             batches_processed = 0
             pending_micro_batches = 0
-            # With prefetch the supervision is fetched asynchronously and paired
-            # with its batch; otherwise the target runs inline (target_batch=None).
-            if self.target_prefetch_depth > 0:
-                batch_source = enumerate(self._prefetched_batches(self.train_dataloader))
-            else:
-                batch_source = ((i, (b, None)) for i, b in enumerate(self.train_dataloader))
-            for batch_idx, (batch, target_batch) in batch_source:
-                if self._peagle_partitioned:
-                    # P-EAGLE sequence partitioning owns its per-segment backward
-                    # and its own no_sync (the all-reduce fires on the last
-                    # segment), so it runs outside the grad-accum sync context.
-                    metrics = self._peagle_partitioned_step(batch)
+
+            # Segment loop: one contiguous pass over the currently-bound dataloader.
+            # A mid-epoch swap to regenerated shards ends the segment and rebinds a
+            # new one (``segment_done`` stays False so the while re-enters); the
+            # epoch's pass is complete only when a dataloader is exhausted without a
+            # swap (the ``for ... else`` path).
+            segment_done = False
+            while not segment_done and not reached_budget:
+                if hasattr(self.train_dataloader.sampler, "set_epoch"):
+                    self.train_dataloader.sampler.set_epoch(epoch)
+                # Recompute the length every segment: after a swap the regen loader
+                # may differ, and should_sync_grads keys the segment's final (partial)
+                # window off it -- a stale value would run the trailing flush on
+                # un-all-reduced gradients and silently desync the DDP replicas.
+                try:
+                    seg_batches_per_epoch = len(self.train_dataloader)
+                except TypeError:
+                    seg_batches_per_epoch = None
+                # With prefetch the supervision is fetched asynchronously and paired
+                # with its batch; otherwise the target runs inline (target_batch=None).
+                if self.target_prefetch_depth > 0:
+                    batch_source = enumerate(self._prefetched_batches(self.train_dataloader))
                 else:
-                    # Skip DDP's per-micro-batch all-reduce on every micro-batch
-                    # except the one an optimizer step immediately follows; that
-                    # step's all-reduce covers the whole locally-accumulated window.
-                    sync_grads = should_sync_grads(
-                        pending_micro_batches=pending_micro_batches,
-                        grad_accumulation_steps=self.grad_accumulation_steps,
-                        batch_idx=batch_idx,
-                        batches_per_epoch=batches_per_epoch,
-                        is_ddp=is_ddp,
-                    )
-                    sync_ctx = nullcontext() if sync_grads else self.trainer_module.no_sync()
-                    with sync_ctx:
-                        metrics = self._forward_batch(batch, target_batch)
-                        loss = metrics.loss / float(self.grad_accumulation_steps)
-                        loss.backward()
+                    batch_source = ((i, (b, None)) for i, b in enumerate(self.train_dataloader))
+                for batch_idx, (batch, target_batch) in batch_source:
+                    if self._peagle_partitioned:
+                        # P-EAGLE sequence partitioning owns its per-segment backward
+                        # and its own no_sync (the all-reduce fires on the last
+                        # segment), so it runs outside the grad-accum sync context.
+                        metrics = self._peagle_partitioned_step(batch)
+                    else:
+                        # Skip DDP's per-micro-batch all-reduce on every micro-batch
+                        # except the one an optimizer step immediately follows; that
+                        # step's all-reduce covers the whole locally-accumulated window.
+                        sync_grads = should_sync_grads(
+                            pending_micro_batches=pending_micro_batches,
+                            grad_accumulation_steps=self.grad_accumulation_steps,
+                            batch_idx=batch_idx,
+                            batches_per_epoch=seg_batches_per_epoch,
+                            is_ddp=is_ddp,
+                        )
+                        sync_ctx = nullcontext() if sync_grads else self.trainer_module.no_sync()
+                        with sync_ctx:
+                            metrics = self._forward_batch(batch, target_batch)
+                            loss = metrics.loss / float(self.grad_accumulation_steps)
+                            loss.backward()
 
-                running_loss = running_loss + metrics.loss.detach()
-                running_acc = running_acc + metrics.accuracy.detach()
-                step_prefix_hits = getattr(metrics, "step_prefix_hits", None)
-                if step_prefix_hits is not None:
-                    if running_step_prefix is None:
-                        running_step_prefix = torch.zeros_like(step_prefix_hits, dtype=torch.float32)
-                        running_step_valid = torch.zeros_like(running_step_prefix)
-                    running_step_prefix += step_prefix_hits.float()
-                    running_step_valid += metrics.step_valid.float()
-                running_steps += 1
-                batches_processed = batch_idx + 1
-                pending_micro_batches += 1
+                    running_loss = running_loss + metrics.loss.detach()
+                    running_acc = running_acc + metrics.accuracy.detach()
+                    step_prefix_hits = getattr(metrics, "step_prefix_hits", None)
+                    if step_prefix_hits is not None:
+                        if running_step_prefix is None:
+                            running_step_prefix = torch.zeros_like(step_prefix_hits, dtype=torch.float32)
+                            running_step_valid = torch.zeros_like(running_step_prefix)
+                        running_step_prefix += step_prefix_hits.float()
+                        running_step_valid += metrics.step_valid.float()
+                    running_steps += 1
+                    batches_processed += 1
+                    pending_micro_batches += 1
 
-                if pending_micro_batches == self.grad_accumulation_steps:
-                    if getattr(self, "cp_group", None) is not None:
-                        self._all_reduce_draft_grads_over_cp()
-                    grad_norm = torch.nn.utils.clip_grad_norm_(self.trainer_module.parameters(), self.max_grad_norm)
-                    self.optimizer.step()
-                    self.lr_scheduler.step()
-                    self.optimizer.zero_grad(set_to_none=True)
-                    self.runtime.global_step += 1
-                    if pbar is not None:
-                        pbar.update(1)
-                    pending_micro_batches = 0
-                    self._maybe_save_step_checkpoint(epoch)
+                    if pending_micro_batches == self.grad_accumulation_steps:
+                        if getattr(self, "cp_group", None) is not None:
+                            self._all_reduce_draft_grads_over_cp()
+                        grad_norm = torch.nn.utils.clip_grad_norm_(self.trainer_module.parameters(), self.max_grad_norm)
+                        self.optimizer.step()
+                        self.lr_scheduler.step()
+                        self.optimizer.zero_grad(set_to_none=True)
+                        self.runtime.global_step += 1
+                        if pbar is not None:
+                            pbar.update(1)
+                        pending_micro_batches = 0
+                        self._maybe_save_step_checkpoint(epoch)
 
-                    if self.runtime.global_step % self.log_every_steps == 0:
-                        mean_loss = _all_reduce_mean(running_loss / max(running_steps, 1))
-                        mean_acc = _all_reduce_mean(running_acc / max(running_steps, 1))
-                        tau_sim = _window_tau_sim(running_step_prefix, running_step_valid)
-                        current_lr = self.lr_scheduler.get_last_lr()[0]
-                        if self.dist_env.is_main:
-                            if pbar is not None:
-                                postfix = {
-                                    "loss": f"{mean_loss.item():.4f}",
-                                    "acc": f"{mean_acc.item():.4f}",
-                                    "lr": f"{current_lr:.2e}",
+                        if self.runtime.global_step % self.log_every_steps == 0:
+                            mean_loss = _all_reduce_mean(running_loss / max(running_steps, 1))
+                            mean_acc = _all_reduce_mean(running_acc / max(running_steps, 1))
+                            tau_sim = _window_tau_sim(running_step_prefix, running_step_valid)
+                            current_lr = self.lr_scheduler.get_last_lr()[0]
+                            if self.dist_env.is_main:
+                                if pbar is not None:
+                                    postfix = {
+                                        "loss": f"{mean_loss.item():.4f}",
+                                        "acc": f"{mean_acc.item():.4f}",
+                                        "lr": f"{current_lr:.2e}",
+                                    }
+                                    if tau_sim is not None:
+                                        postfix["tau"] = f"{tau_sim:.2f}"
+                                    pbar.set_postfix(**postfix)
+                                logger.info(
+                                    "epoch=%s step=%s train_loss=%.6f train_acc=%.6f%s lr=%.3e",
+                                    epoch,
+                                    self.runtime.global_step,
+                                    mean_loss.item(),
+                                    mean_acc.item(),
+                                    "" if tau_sim is None else f" train_tau_sim={tau_sim:.4f}",
+                                    current_lr,
+                                )
+                                wandb_data = {
+                                    "train/loss": mean_loss.item(),
+                                    "train/accuracy": mean_acc.item(),
+                                    "train/lr": current_lr,
+                                    "train/grad_norm": float(grad_norm),
+                                    "train/epoch": epoch,
                                 }
                                 if tau_sim is not None:
-                                    postfix["tau"] = f"{tau_sim:.2f}"
-                                pbar.set_postfix(**postfix)
-                            logger.info(
-                                "epoch=%s step=%s train_loss=%.6f train_acc=%.6f%s lr=%.3e",
-                                epoch,
-                                self.runtime.global_step,
-                                mean_loss.item(),
-                                mean_acc.item(),
-                                "" if tau_sim is None else f" train_tau_sim={tau_sim:.4f}",
-                                current_lr,
-                            )
-                            wandb_data = {
-                                "train/loss": mean_loss.item(),
-                                "train/accuracy": mean_acc.item(),
-                                "train/lr": current_lr,
-                                "train/grad_norm": float(grad_norm),
-                                "train/epoch": epoch,
-                            }
-                            if tau_sim is not None:
-                                wandb_data["train/tau_sim"] = tau_sim
-                            self._wandb_log(wandb_data, step=self.runtime.global_step)
-                            self._maybe_run_decode_eval()
-                        running_loss.zero_()
-                        running_acc.zero_()
-                        if running_step_prefix is not None:
-                            running_step_prefix.zero_()
-                            running_step_valid.zero_()
-                        running_steps = 0
+                                    wandb_data["train/tau_sim"] = tau_sim
+                                self._wandb_log(wandb_data, step=self.runtime.global_step)
+                                self._maybe_run_decode_eval()
+                                self._maybe_run_regen()
+                            running_loss.zero_()
+                            running_acc.zero_()
+                            if running_step_prefix is not None:
+                                running_step_prefix.zero_()
+                                running_step_valid.zero_()
+                            running_steps = 0
+
+                        # Grad-accum window boundary (pending==0, gradients clean):
+                        # the only safe point to stop on the step budget or swap in
+                        # freshly regenerated data. Both branch on ``global_step``,
+                        # which is identical on every rank, so the collective swap
+                        # broadcast stays lockstep.
+                        if self.runtime.global_step >= self.total_optim_steps:
+                            reached_budget = True
+                            break
+                        if self._maybe_swap_regen_dataloader():
+                            break
+                else:
+                    # Dataloader exhausted with no swap and no budget stop: this
+                    # epoch's pass is complete (its trailing partial window, if any,
+                    # is flushed below).
+                    segment_done = True
 
             # Flush the trailing partial accumulation window. When
             # ``batches_per_epoch`` is not a multiple of
@@ -1839,6 +1996,11 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
                     is_final_checkpoint=epoch + 1 >= self.num_epochs,
                 )
                 self._log_saved_checkpoint("epoch", epoch + 1, self.runtime.global_step)
+
+            if reached_budget:
+                # Step budget reached (with regen, one epoch is split into many
+                # segments, so the budget -- not the epoch range -- is the stop).
+                break
 
 
 def main(config_path=None):

--- a/nemo_automodel/recipes/llm/train_eagle3.py
+++ b/nemo_automodel/recipes/llm/train_eagle3.py
@@ -772,7 +772,13 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
             self.regen_runner = RegenRunner(regen_config)
 
     def _maybe_run_regen(self) -> None:
-        """Rank-0 log-point hook: launch a regeneration cycle when the cadence is due."""
+        """Window-boundary hook: launch a regeneration cycle when the cadence is due.
+
+        Called at every grad-accum window boundary (not just log points) so the
+        launch cadence follows ``regen.every_steps`` regardless of
+        ``log_every_steps``. A no-op on non-main ranks, where ``regen_runner``
+        is ``None``.
+        """
         runner = getattr(self, "regen_runner", None)
         if runner is None:
             return
@@ -1869,7 +1875,6 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
                                     wandb_data["train/tau_sim"] = tau_sim
                                 self._wandb_log(wandb_data, step=self.runtime.global_step)
                                 self._maybe_run_decode_eval()
-                                self._maybe_run_regen()
                             running_loss.zero_()
                             running_acc.zero_()
                             if running_step_prefix is not None:
@@ -1885,6 +1890,12 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
                         if self.runtime.global_step >= self.total_optim_steps:
                             reached_budget = True
                             break
+                        # The regen launch cadence is checked at every window
+                        # boundary (not inside the log gate above) so it honors
+                        # ``regen.every_steps`` independently of ``log_every_steps``;
+                        # after the budget break so the terminal step never spawns a
+                        # cycle nothing will consume. No-op off rank 0.
+                        self._maybe_run_regen()
                         if self._maybe_swap_regen_dataloader():
                             break
                 else:

--- a/tests/unit_tests/recipes/llm/test_train_eagle3_regen.py
+++ b/tests/unit_tests/recipes/llm/test_train_eagle3_regen.py
@@ -285,6 +285,27 @@ def test_single_epoch_swaps_mid_run_and_stops_at_budget(tmp_path, monkeypatch):
     assert swapped_dirs == ["/regen/cycle_10/shards"]
 
 
+def test_regen_launch_cadence_independent_of_log_every_steps(tmp_path):
+    # The launch-cadence check runs at every optimizer-step boundary, not only at
+    # log points: with log_every_steps far above the step budget, maybe_launch
+    # must still be consulted at every non-terminal step.
+    recipe = _loop_recipe(tmp_path, num_samples=8, grad_accum=2, num_epochs=1)  # 4 optimizer steps
+    recipe.log_every_steps = 100
+    recipe._regen_enabled = True
+
+    launch_steps = []
+    recipe.regen_runner = SimpleNamespace(
+        maybe_launch=lambda step: launch_steps.append(step),
+        take_ready_shards=lambda: None,
+        shutdown=lambda: None,
+    )
+
+    recipe.run_train_validation_loop()
+
+    # Every window boundary except the terminal (budget) step checks the cadence.
+    assert launch_steps == [1, 2, 3]
+
+
 def test_prefetch_drains_in_flight_requests_on_early_break(tmp_path):
     # A mid-epoch swap breaks the consumer loop; the prefetch generator must drain
     # (await) every dispatched-but-unconsumed request so the one-in-flight-per-server

--- a/tests/unit_tests/recipes/llm/test_train_eagle3_regen.py
+++ b/tests/unit_tests/recipes/llm/test_train_eagle3_regen.py
@@ -1,0 +1,326 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Recipe-side coverage for the EAGLE-3 on-policy regeneration integration:
+``_setup_regen`` gating, ``_build_train_dataloader`` forwarding,
+``_maybe_swap_regen_dataloader`` (rank-0 decide + rebind + LR-drift warning),
+and the step-budget segment loop that swaps mid-epoch."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader, TensorDataset
+
+from nemo_automodel.components.speculative.eagle.target import Eagle3TargetBatch
+from nemo_automodel.recipes.llm import train_eagle3 as te
+from nemo_automodel.recipes.llm._spec_train_utils import optim_steps_per_epoch as _optim_steps_per_epoch
+from nemo_automodel.recipes.llm.train_eagle3 import TrainEagle3Recipe
+
+
+class _FakeTargetWrapper:
+    def generate_batch(self, input_ids, attention_mask, loss_mask):
+        bs, sl = input_ids.shape
+        return Eagle3TargetBatch(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            loss_mask=loss_mask,
+            aux_hidden_states=torch.randn(bs, sl, 16),
+            logits=torch.randn(bs, sl, 64),
+        )
+
+    def close(self):
+        pass
+
+
+class _FakeTrainerModule(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.dummy = nn.Linear(4, 4)
+        self.register_buffer("selected_token_ids", torch.arange(8))
+        self.register_buffer("selected_token_mask", torch.ones(8, dtype=torch.bool))
+
+    def forward(self, **kwargs):
+        out = self.dummy(torch.randn(1, 4)).sum()
+        return SimpleNamespace(loss=out.abs() + 1.0, accuracy=torch.tensor(0.5), valid_tokens=torch.tensor(4))
+
+
+class _KeyedLoader:
+    """DataLoader wrapper yielding the dict keys the training loop expects."""
+
+    def __init__(self, num_samples, sl=6):
+        data = TensorDataset(
+            torch.randint(0, 64, (num_samples, sl)),
+            torch.ones(num_samples, sl, dtype=torch.long),
+            torch.ones(num_samples, sl, dtype=torch.long),
+        )
+        self._loader = DataLoader(data, batch_size=1)
+        self.sampler = self._loader.sampler
+        self._n = num_samples
+
+    def __iter__(self):
+        for ids, attn, lm in self._loader:
+            yield {"input_ids": ids, "attention_mask": attn, "loss_mask": lm}
+
+    def __len__(self):
+        return self._n
+
+
+def _bare_recipe(tmp_path, is_main=True):
+    recipe = TrainEagle3Recipe.__new__(TrainEagle3Recipe)
+    recipe.output_dir = tmp_path
+    recipe.dist_env = SimpleNamespace(is_main=is_main, world_size=1)
+    return recipe
+
+
+def _loop_recipe(tmp_path, num_samples=4, grad_accum=2, num_epochs=1):
+    """A recipe wired to run the CPU training loop with regen hooks reachable."""
+    recipe = _bare_recipe(tmp_path)
+    tm = _FakeTrainerModule()
+    recipe.device = torch.device("cpu")
+    recipe.trainer_module = tm
+    recipe.target_wrapper = _FakeTargetWrapper()
+    recipe.cp_group = None
+    recipe.target_prefetch_depth = 0
+    recipe.train_dataloader = _KeyedLoader(num_samples)
+    recipe.val_dataloader = None
+    recipe.runtime = SimpleNamespace(global_step=0)
+    recipe.grad_accumulation_steps = grad_accum
+    recipe.max_grad_norm = 1.0
+    recipe.num_epochs = num_epochs
+    recipe.log_every_steps = 1
+    recipe.peak_lr = 1e-4
+    recipe.min_lr_ratio = 0.1
+    recipe.warmup_steps = 1
+    recipe.total_optim_steps = num_epochs * _optim_steps_per_epoch(num_samples, grad_accum)
+    recipe._orig_batches_per_epoch = num_samples
+    recipe._regen_enabled = False
+    recipe.regen_runner = None
+    recipe.optimizer = torch.optim.AdamW([p for p in tm.parameters() if p.requires_grad], lr=1e-4)
+    recipe.lr_scheduler = torch.optim.lr_scheduler.LambdaLR(recipe.optimizer, lambda s: 1.0)
+    return recipe
+
+
+# --------------------------------------------------------------------------- #
+# _setup_regen gating
+# --------------------------------------------------------------------------- #
+
+
+def _regen_cfg(tmp_path, **regen_overrides):
+    regen = {"every_steps": 10, "cuda_visible_devices": "7"}
+    regen.update(regen_overrides)
+    return {"regen": regen, "train_data_path": "/data/train", "output_dir": str(tmp_path)}
+
+
+def test_setup_regen_disabled_leaves_runner_none(tmp_path):
+    recipe = _bare_recipe(tmp_path)
+    recipe._setup_regen({"output_dir": str(tmp_path)}, "/models/target")
+    assert recipe.regen_runner is None
+    assert recipe._regen_enabled is False
+
+
+def test_setup_regen_does_not_read_unset_self_output_dir(tmp_path):
+    # Regression: _setup_regen runs inside _setup_online_target, BEFORE the setup
+    # body assigns self.output_dir, so it must derive output_dir from recipe_cfg.
+    recipe = _bare_recipe(tmp_path)
+    del recipe.output_dir  # _bare_recipe set it; prove _setup_regen doesn't need it
+    recipe._setup_regen(_regen_cfg(tmp_path), "/models/target")
+    assert recipe._regen_enabled is True
+    assert recipe.regen_runner.config.output_dir == str(tmp_path / "regen")
+
+
+def test_setup_regen_enabled_builds_runner_on_rank0(tmp_path):
+    recipe = _bare_recipe(tmp_path)
+    recipe._setup_regen(_regen_cfg(tmp_path), "/models/target")
+    assert recipe._regen_enabled is True
+    assert recipe.regen_runner is not None
+    assert recipe.regen_runner.config.target_model == "/models/target"
+
+
+def test_setup_regen_enabled_but_not_main_has_no_runner(tmp_path):
+    recipe = _bare_recipe(tmp_path, is_main=False)
+    recipe._setup_regen(_regen_cfg(tmp_path), "/models/target")
+    # Every rank knows the feature is on (for the lockstep swap), only rank 0 owns the worker.
+    assert recipe._regen_enabled is True
+    assert recipe.regen_runner is None
+
+
+def test_setup_regen_rejects_peft(tmp_path):
+    recipe = _bare_recipe(tmp_path)
+    recipe.peft_config = object()
+    with pytest.raises(ValueError, match="not supported with peft"):
+        recipe._setup_regen(_regen_cfg(tmp_path), "/models/target")
+
+
+# --------------------------------------------------------------------------- #
+# _build_train_dataloader forwards config to build_eagle3_dataloader
+# --------------------------------------------------------------------------- #
+
+
+def test_build_train_dataloader_forwards_config(tmp_path, monkeypatch):
+    recipe = _bare_recipe(tmp_path)
+    recipe.tokenizer = object()
+    recipe.dp_mesh = object()
+    recipe.dist_env = SimpleNamespace(is_main=True, world_size=4)
+    recipe_args = SimpleNamespace(
+        seq_length=512,
+        micro_batch_size=2,
+        get=lambda k, d=None: {
+            "train_shuffle": False,
+            "num_workers": 3,
+            "shuffle_seed": 7,
+            "mask_reasoning_content": True,
+            "packed_sequence_size": 128,
+        }.get(k, d),
+    )
+    recipe.cfg = SimpleNamespace(recipe_args=recipe_args)
+
+    seen = {}
+    monkeypatch.setattr(te, "build_eagle3_dataloader", lambda **kw: seen.update(kw) or "LOADER")
+
+    out = recipe._build_train_dataloader("/regen/shards", split=None)
+    assert out == "LOADER"
+    assert seen["data_path"] == "/regen/shards"
+    assert seen["split"] is None
+    assert seen["seq_length"] == 512
+    assert seen["batch_size"] == 2
+    assert seen["shuffle"] is False
+    assert seen["distributed"] is True  # world_size=4 > 1
+    assert seen["packed_sequence_size"] == 128
+    assert seen["tokenizer"] is recipe.tokenizer
+    assert seen["dp_mesh"] is recipe.dp_mesh
+
+
+# --------------------------------------------------------------------------- #
+# _maybe_swap_regen_dataloader
+# --------------------------------------------------------------------------- #
+
+
+def test_swap_returns_false_when_disabled(tmp_path):
+    recipe = _bare_recipe(tmp_path)
+    recipe._regen_enabled = False
+    assert recipe._maybe_swap_regen_dataloader() is False
+
+
+def test_swap_returns_false_when_nothing_ready(tmp_path):
+    recipe = _bare_recipe(tmp_path)
+    recipe._regen_enabled = True
+    recipe.regen_runner = SimpleNamespace(take_ready_shards=lambda: None)
+    assert recipe._maybe_swap_regen_dataloader() is False
+
+
+def test_swap_rebinds_and_warns_on_length_mismatch(tmp_path, monkeypatch, caplog):
+    recipe = _bare_recipe(tmp_path)
+    recipe._regen_enabled = True
+    recipe.regen_runner = SimpleNamespace(take_ready_shards=lambda: "/regen/cycle_10/shards")
+    recipe._orig_batches_per_epoch = 100
+    new_loader = _KeyedLoader(40)  # different length than the original 100
+    monkeypatch.setattr(recipe, "_build_train_dataloader", lambda data_path, split: new_loader)
+
+    with caplog.at_level("WARNING"):
+        swapped = recipe._maybe_swap_regen_dataloader()
+
+    assert swapped is True
+    assert recipe.train_dataloader is new_loader
+    assert "40 batches vs the original 100" in caplog.text
+
+
+def test_swap_no_warning_when_length_matches(tmp_path, monkeypatch, caplog):
+    recipe = _bare_recipe(tmp_path)
+    recipe._regen_enabled = True
+    recipe.regen_runner = SimpleNamespace(take_ready_shards=lambda: "/regen/cycle_10/shards")
+    recipe._orig_batches_per_epoch = 40
+    monkeypatch.setattr(recipe, "_build_train_dataloader", lambda data_path, split: _KeyedLoader(40))
+
+    with caplog.at_level("WARNING"):
+        assert recipe._maybe_swap_regen_dataloader() is True
+    assert "batches vs the original" not in caplog.text
+
+
+# --------------------------------------------------------------------------- #
+# Step-budget segment loop: mid-epoch swap trains on regen data and stops at budget
+# --------------------------------------------------------------------------- #
+
+
+def test_single_epoch_swaps_mid_run_and_stops_at_budget(tmp_path, monkeypatch):
+    # num_samples=4, grad_accum=2 -> 2 optimizer steps per pass; num_epochs=1 -> budget 2.
+    recipe = _loop_recipe(tmp_path, num_samples=4, grad_accum=2, num_epochs=1)
+    recipe._regen_enabled = True
+
+    swapped_dirs = []
+
+    def fake_build(data_path, split):
+        swapped_dirs.append(data_path)
+        return _KeyedLoader(4)
+
+    monkeypatch.setattr(recipe, "_build_train_dataloader", fake_build)
+    # A cycle is ready exactly once, after the first optimizer step's swap check.
+    ready = ["/regen/cycle_10/shards"]
+    recipe.regen_runner = SimpleNamespace(
+        maybe_launch=lambda step: False,
+        take_ready_shards=lambda: ready.pop(0) if ready else None,
+        shutdown=lambda: None,
+    )
+
+    recipe.run_train_validation_loop()
+
+    # The budget (2 steps) is honored even though a mid-run swap started a fresh
+    # segment, and the swap actually happened (so regen data was trained on) --
+    # the single-epoch no-op is fixed.
+    assert recipe.runtime.global_step == 2
+    assert swapped_dirs == ["/regen/cycle_10/shards"]
+
+
+def test_prefetch_drains_in_flight_requests_on_early_break(tmp_path):
+    # A mid-epoch swap breaks the consumer loop; the prefetch generator must drain
+    # (await) every dispatched-but-unconsumed request so the one-in-flight-per-server
+    # recv ordering is not corrupted for the next segment.
+    recipe = _bare_recipe(tmp_path)
+    recipe.target_prefetch_depth = 2
+    resolved = []
+    dispatched = {"n": 0}
+
+    class _Handle:
+        def __init__(self, idx):
+            self.idx = idx
+
+        def result(self):
+            resolved.append(self.idx)
+            return f"target_{self.idx}"
+
+    class _AsyncTargetWrapper:
+        def generate_batch_async(self, input_ids, attention_mask, loss_mask):
+            handle = _Handle(dispatched["n"])
+            dispatched["n"] += 1
+            return handle
+
+    recipe.target_wrapper = _AsyncTargetWrapper()
+    gen = recipe._prefetched_batches(_KeyedLoader(5))
+    next(gen)  # consume one; the rest stay in flight up to the prefetch depth
+    gen.close()  # the consumer stopped early (mid-epoch swap)
+
+    # Every dispatched request was awaited exactly once -- none orphaned.
+    assert sorted(resolved) == list(range(dispatched["n"]))
+    assert dispatched["n"] >= 2  # depth-2 prefetch kept multiple in flight
+
+
+def test_regen_disabled_run_is_unchanged(tmp_path):
+    # Backward-compat: with regen off the step-budget guard is a no-op and the run
+    # behaves exactly like the plain epoch loop (5 samples / accum 3 -> 2 steps).
+    recipe = _loop_recipe(tmp_path, num_samples=5, grad_accum=3, num_epochs=1)
+    recipe.run_train_validation_loop()
+    assert recipe.runtime.global_step == 2

--- a/tests/unit_tests/speculative/test_regen_loop.py
+++ b/tests/unit_tests/speculative/test_regen_loop.py
@@ -1,0 +1,551 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the on-policy regeneration loop (config, runner cadence/consume, worker argv/main)."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import types
+from dataclasses import asdict
+
+import pytest
+
+from nemo_automodel.components.speculative.regen_loop import (
+    RegenConfig,
+    RegenRunner,
+    _DONE_FILENAME,
+    _SHARDS_DIRNAME,
+    _regenerate_argv,
+    _target_server_argv,
+    main,
+    resolve_regen_config,
+)
+
+_MODULE = "nemo_automodel.components.speculative.regen_loop"
+
+
+def _config(tmp_path, **overrides):
+    kwargs = dict(
+        every_steps=10,
+        cuda_visible_devices="7",
+        target_model="/models/target",
+        input_data="/data/train.jsonl",
+        output_dir=str(tmp_path / "regen"),
+    )
+    kwargs.update(overrides)
+    return RegenConfig(**kwargs)
+
+
+class _FakeProc:
+    def __init__(self, alive=True, pid=4242, return_code=0):
+        self._alive = alive
+        self.pid = pid
+        self.returncode = None if alive else return_code
+        self.terminated = False
+        self.killed = False
+
+    def poll(self):
+        return None if self._alive else self.returncode
+
+    def wait(self, timeout=None):
+        self._alive = False
+        if self.returncode is None:
+            self.returncode = 0
+        return self.returncode
+
+    def terminate(self):
+        self.terminated = True
+
+    def kill(self):
+        self.killed = True
+        self._alive = False
+        self.returncode = -9
+
+
+def _ready_cycle(cfg, step):
+    """Create a cycle dir with a shards subdir and the READY marker, as a finished worker would."""
+    cycle_dir = os.path.join(cfg.output_dir, f"cycle_{step}")
+    os.makedirs(os.path.join(cycle_dir, _SHARDS_DIRNAME), exist_ok=True)
+    with open(os.path.join(cycle_dir, _DONE_FILENAME), "w") as f:
+        f.write(str(step))
+    return cycle_dir
+
+
+# --------------------------------------------------------------------------- #
+# resolve_regen_config
+# --------------------------------------------------------------------------- #
+
+
+def test_resolve_returns_none_when_absent_or_disabled(tmp_path):
+    common = dict(default_target="/t", default_input_data="/d", output_dir=str(tmp_path))
+    assert resolve_regen_config({}, **common) is None
+    assert resolve_regen_config({"regen": None}, **common) is None
+    assert resolve_regen_config({"regen": {"every_steps": 0}}, **common) is None
+
+
+def test_resolve_requires_reserved_gpu(tmp_path):
+    common = dict(default_target="/t", default_input_data="/d", output_dir=str(tmp_path))
+    with pytest.raises(ValueError, match="cuda_visible_devices is required"):
+        resolve_regen_config({"regen": {"every_steps": 10}}, **common)
+    with pytest.raises(ValueError, match="cuda_visible_devices is required"):
+        resolve_regen_config({"regen": {"every_steps": 10, "cuda_visible_devices": ""}}, **common)
+
+
+def test_resolve_requires_input_data_without_default(tmp_path):
+    with pytest.raises(ValueError, match="input_data is required"):
+        resolve_regen_config(
+            {"regen": {"every_steps": 10, "cuda_visible_devices": "7"}},
+            default_target="/t",
+            default_input_data=None,
+            output_dir=str(tmp_path),
+        )
+
+
+def test_resolve_rejects_unknown_option(tmp_path):
+    with pytest.raises(ValueError, match="Unknown regen option"):
+        resolve_regen_config(
+            {"regen": {"every_steps": 10, "cuda_visible_devices": "7", "bogus": 1}},
+            default_target="/t",
+            default_input_data="/d",
+            output_dir=str(tmp_path),
+        )
+
+
+def test_resolve_rejects_output_dir_override(tmp_path):
+    # output_dir is a RegenConfig field (so it passes the unknown-option check) but
+    # is always derived as <run>/regen; a user-set value must fail loudly, not be
+    # silently discarded.
+    with pytest.raises(ValueError, match="output_dir is not configurable"):
+        resolve_regen_config(
+            {"regen": {"every_steps": 10, "cuda_visible_devices": "7", "output_dir": "/somewhere/else"}},
+            default_target="/t",
+            default_input_data="/d",
+            output_dir=str(tmp_path),
+        )
+
+
+def test_resolve_fills_defaults_and_applies_overrides(tmp_path):
+    resolved = resolve_regen_config(
+        {
+            "regen": {
+                "every_steps": 25,
+                "cuda_visible_devices": "6,7",
+                "temperature": 0.7,
+                "max_new_tokens": 512,
+            }
+        },
+        default_target="/models/target",
+        default_input_data="/data/train.jsonl",
+        output_dir=str(tmp_path / "run"),
+    )
+    assert resolved.every_steps == 25
+    assert resolved.cuda_visible_devices == "6,7"
+    # unset target/input fall back to the recipe-provided defaults
+    assert resolved.target_model == "/models/target"
+    assert resolved.input_data == "/data/train.jsonl"
+    # overrides win, untouched fields keep dataclass defaults
+    assert resolved.temperature == 0.7
+    assert resolved.max_new_tokens == 512
+    assert resolved.top_p == 1.0
+    # output_dir is always nested under <run>/regen
+    assert resolved.output_dir == os.path.join(str(tmp_path / "run"), "regen")
+
+
+def test_resolve_accepts_block_with_to_dict(tmp_path):
+    class _Block:
+        def __init__(self, data):
+            self._data = data
+
+        def get(self, key, default=None):
+            return self._data.get(key, default)
+
+        def to_dict(self):
+            return dict(self._data)
+
+    block = _Block({"every_steps": 10, "cuda_visible_devices": "7", "input_data": "/d"})
+    resolved = resolve_regen_config(
+        {"regen": block},
+        default_target="/t",
+        default_input_data=None,
+        output_dir=str(tmp_path),
+    )
+    assert resolved is not None and resolved.input_data == "/d"
+
+
+# --------------------------------------------------------------------------- #
+# RegenRunner: cadence / launch
+# --------------------------------------------------------------------------- #
+
+
+def _runner_with_fake_popen(tmp_path, monkeypatch, launched):
+    runner = RegenRunner(_config(tmp_path))
+    monkeypatch.setattr(
+        f"{_MODULE}.subprocess.Popen",
+        lambda argv, **kw: launched.append(("popen", argv, kw)) or _FakeProc(),
+    )
+    return runner
+
+
+def test_runner_launches_on_cadence_and_skips_while_running(tmp_path, monkeypatch):
+    launched = []
+    runner = _runner_with_fake_popen(tmp_path, monkeypatch, launched)
+
+    assert not runner.maybe_launch(5)  # before the first cadence boundary
+    assert runner.maybe_launch(10)
+    assert not runner.maybe_launch(10)  # same bucket, no relaunch
+    # A boundary while the previous cycle is still alive is skipped; once the
+    # proc finishes, the next boundary launches again.
+    assert not runner.maybe_launch(20)
+    runner._proc._alive = False
+    runner._proc.returncode = 0
+    assert runner.maybe_launch(30)
+
+    popen_calls = [entry for entry in launched if entry[0] == "popen"]
+    assert len(popen_calls) == 2
+    argv = popen_calls[0][1]
+    assert argv[argv.index("--step") + 1] == "10"
+    config_json = argv[argv.index("--config-json") + 1]
+    with open(config_json) as f:
+        sidecar = json.load(f)
+    assert sidecar["cuda_visible_devices"] == "7"
+    assert sidecar["target_model"] == "/models/target"
+    assert popen_calls[0][2]["env"]["CUDA_VISIBLE_DEVICES"] == "7"
+    assert popen_calls[0][2]["start_new_session"] is True
+
+
+def test_launch_wipes_stale_cycle_dir(tmp_path, monkeypatch):
+    launched = []
+    runner = _runner_with_fake_popen(tmp_path, monkeypatch, launched)
+    # A crashed prior worker left a half-written cycle: partial shards AND a stale
+    # READY marker. Both must be wiped, else regenerate aborts on the non-empty
+    # shard dir and the stale marker could make the cycle look ready.
+    cycle_dir = _ready_cycle(runner.config, 10)
+    stale_shard = os.path.join(cycle_dir, _SHARDS_DIRNAME, "shard-000000.parquet")
+    with open(stale_shard, "w") as f:
+        f.write("stale")
+
+    assert runner.maybe_launch(10)
+    assert not os.path.exists(os.path.join(cycle_dir, _DONE_FILENAME))
+    assert not os.path.exists(stale_shard)  # leftover shards cleared for a clean regenerate
+
+
+def test_reap_reports_failed_worker(tmp_path, caplog):
+    runner = RegenRunner(_config(tmp_path))
+    runner._proc = _FakeProc(alive=False, return_code=2)
+    runner._launched_for_step = 10
+    runner._worker_log_path = os.path.join(runner.config.output_dir, "worker.log")
+
+    with caplog.at_level("ERROR"):
+        runner._reap_finished_worker()
+
+    assert "exited with code 2" in caplog.text
+    assert runner._proc is None
+
+
+def test_resume_from_step_suppresses_immediate_relaunch(tmp_path):
+    runner = RegenRunner(_config(tmp_path))  # every_steps=10
+    # A fresh runner (as rebuilt on resume) would fire at any step past the cadence.
+    assert runner.due(1000)
+    # Aligning to the restored step marks the current cadence region covered, so no
+    # redundant relaunch at resume; the next cadence boundary still fires.
+    runner.resume_from_step(1000)
+    assert not runner.due(1000)
+    assert not runner.due(1009)
+    assert runner.due(1010)
+
+
+def test_reap_is_noop_while_worker_runs(tmp_path):
+    runner = RegenRunner(_config(tmp_path))
+    runner._proc = _FakeProc(alive=True)
+    runner._reap_finished_worker()
+    assert runner._proc is not None  # still alive → not released
+
+
+# --------------------------------------------------------------------------- #
+# RegenRunner: cycle discovery / consumption
+# --------------------------------------------------------------------------- #
+
+
+def test_cycle_dirs_orders_and_ignores_invalid(tmp_path, caplog):
+    runner = RegenRunner(_config(tmp_path))
+    for name in ("cycle_20", "cycle_5", "cycle_100", "cycle_final", "junk"):
+        os.makedirs(os.path.join(runner.config.output_dir, name))
+
+    with caplog.at_level("WARNING"):
+        ordered = runner._cycle_dirs()
+
+    assert [num for num, _ in ordered] == [5, 20, 100]
+    assert "invalid cycle directory cycle_final" in caplog.text
+
+
+def test_take_ready_returns_none_without_marker(tmp_path):
+    runner = RegenRunner(_config(tmp_path))
+    os.makedirs(os.path.join(runner.config.output_dir, "cycle_10", _SHARDS_DIRNAME))  # no READY
+    assert runner.take_ready_shards() is None
+
+
+def test_cycle_dirs_empty_when_output_dir_missing(tmp_path):
+    runner = RegenRunner(_config(tmp_path))
+    shutil.rmtree(runner.config.output_dir)  # e.g. cleaned between runs
+    assert runner._cycle_dirs() == []
+    assert runner.take_ready_shards() is None
+
+
+def test_take_ready_returns_newest_and_consumes_once(tmp_path):
+    runner = RegenRunner(_config(tmp_path))
+    _ready_cycle(runner.config, 10)
+    cycle20 = _ready_cycle(runner.config, 20)
+
+    shards = runner.take_ready_shards()
+    assert shards == os.path.join(cycle20, _SHARDS_DIRNAME)
+    # Both ready cycles are now consumed; a second call yields nothing.
+    assert runner.take_ready_shards() is None
+
+
+def test_take_ready_removes_superseded_active_cycle(tmp_path):
+    runner = RegenRunner(_config(tmp_path))
+    cycle10 = _ready_cycle(runner.config, 10)
+    assert runner.take_ready_shards() == os.path.join(cycle10, _SHARDS_DIRNAME)
+
+    cycle20 = _ready_cycle(runner.config, 20)
+    assert runner.take_ready_shards() == os.path.join(cycle20, _SHARDS_DIRNAME)
+    # The previously active cycle's shards are freed; the new active one stays.
+    assert not os.path.exists(cycle10)
+    assert os.path.exists(cycle20)
+
+
+def test_take_ready_frees_all_intermediate_cycles_in_one_call(tmp_path):
+    runner = RegenRunner(_config(tmp_path))
+    # Several cycles complete within one epoch (cadence < epoch length); only the
+    # freshest feeds training and the rest must not be stranded on disk.
+    cycle10 = _ready_cycle(runner.config, 10)
+    cycle20 = _ready_cycle(runner.config, 20)
+    cycle30 = _ready_cycle(runner.config, 30)
+
+    assert runner.take_ready_shards() == os.path.join(cycle30, _SHARDS_DIRNAME)
+    assert not os.path.exists(cycle10)  # intermediate cycles freed, not just the active one
+    assert not os.path.exists(cycle20)
+    assert os.path.exists(cycle30)
+
+
+def test_remove_cycle_swallows_missing_and_logs_oserror(tmp_path, monkeypatch, caplog):
+    # Missing directory is a no-op.
+    RegenRunner._remove_cycle(str(tmp_path / "does_not_exist"))
+
+    existing = tmp_path / "cycle_10"
+    existing.mkdir()
+    monkeypatch.setattr(f"{_MODULE}.shutil.rmtree", lambda _p: (_ for _ in ()).throw(OSError("busy")))
+    with caplog.at_level("ERROR"):
+        RegenRunner._remove_cycle(str(existing))
+    assert "failed to remove superseded cycle" in caplog.text
+
+
+# --------------------------------------------------------------------------- #
+# RegenRunner: shutdown
+# --------------------------------------------------------------------------- #
+
+
+def test_shutdown_escalates_to_process_group_kill(tmp_path, monkeypatch):
+    runner = RegenRunner(_config(tmp_path))
+    proc = _FakeProc()
+    wait_calls = []
+
+    def _wait(timeout=None):
+        wait_calls.append(timeout)
+        if len(wait_calls) == 1:
+            raise subprocess.TimeoutExpired("worker", 30)
+        return 0
+
+    proc.wait = _wait
+    runner._proc = proc
+    signals = []
+    monkeypatch.setattr(os, "getpgid", lambda _pid: 99)
+    monkeypatch.setattr(os, "killpg", lambda pgid, sig: signals.append((pgid, sig)))
+
+    runner.shutdown()
+
+    assert signals[0][0] == signals[1][0] == 99
+    assert signals[0][1] != signals[1][1]  # SIGTERM then SIGKILL
+    assert runner._proc is None
+
+
+def test_shutdown_reaps_dead_proc_and_noop_when_none(tmp_path):
+    runner = RegenRunner(_config(tmp_path))
+    runner._proc = _FakeProc(alive=False, return_code=0)
+    runner.shutdown()
+    assert runner._proc is None
+    # No proc at all: shutdown must be a safe no-op.
+    runner.shutdown()
+    assert runner._proc is None
+
+
+def _timeout_then_ok_wait():
+    """A wait() that raises TimeoutExpired on its first call, then returns 0."""
+    calls = []
+
+    def _wait(timeout=None):
+        calls.append(timeout)
+        if len(calls) == 1:
+            raise subprocess.TimeoutExpired("worker", 30)
+        return 0
+
+    return _wait
+
+
+def test_shutdown_falls_back_to_terminate_without_pgid(tmp_path, monkeypatch):
+    runner = RegenRunner(_config(tmp_path))
+    proc = _FakeProc()
+    proc.wait = _timeout_then_ok_wait()
+    runner._proc = proc
+    # No process group available: SIGTERM/SIGKILL via killpg are unusable.
+    monkeypatch.setattr(os, "getpgid", lambda _pid: (_ for _ in ()).throw(ProcessLookupError()))
+    killpg_calls = []
+    monkeypatch.setattr(os, "killpg", lambda pgid, sig: killpg_calls.append((pgid, sig)))
+
+    runner.shutdown()
+
+    assert killpg_calls == []  # never reached the group-signal path
+    assert proc.terminated and proc.killed  # terminate(), then kill() after the wait timeout
+    assert runner._proc is None
+
+
+def test_shutdown_kills_directly_when_group_sigkill_fails(tmp_path, monkeypatch):
+    runner = RegenRunner(_config(tmp_path))
+    proc = _FakeProc()
+    proc.wait = _timeout_then_ok_wait()
+    runner._proc = proc
+
+    def _killpg(pgid, sig):
+        if sig == signal.SIGKILL:
+            raise ProcessLookupError()  # group already gone by escalation time
+
+    monkeypatch.setattr(os, "getpgid", lambda _pid: 99)
+    monkeypatch.setattr(os, "killpg", _killpg)
+
+    runner.shutdown()
+
+    assert proc.killed  # SIGKILL on the group failed → direct proc.kill()
+    assert runner._proc is None
+
+
+# --------------------------------------------------------------------------- #
+# Worker CLI: argv builders
+# --------------------------------------------------------------------------- #
+
+
+def test_target_server_argv_includes_optional_flags(tmp_path):
+    base = _target_server_argv(_config(tmp_path), port=8123)
+    assert base[:3] == [sys.executable, "-m", "vllm.entrypoints.openai.api_server"]
+    assert base[base.index("--port") + 1] == "8123"
+    assert "--max-model-len" not in base
+    assert "--trust-remote-code" not in base
+
+    full = _target_server_argv(
+        _config(tmp_path, server_python="/venv/py", max_model_len=4096, trust_remote_code=True),
+        port=8123,
+    )
+    assert full[0] == "/venv/py"
+    assert full[full.index("--max-model-len") + 1] == "4096"
+    assert "--trust-remote-code" in full
+
+
+def test_regenerate_argv_includes_dataset_name_only_when_set(tmp_path):
+    cfg = _config(tmp_path, temperature=0.5, shard_size=250)
+    argv = _regenerate_argv(cfg, server="http://127.0.0.1:8000", shards_dir="/out/shards")
+    assert argv[argv.index("--target-server") + 1] == "http://127.0.0.1:8000/v1"
+    assert argv[argv.index("--output-dir") + 1] == "/out/shards"
+    assert argv[argv.index("--temperature") + 1] == "0.5"
+    assert argv[argv.index("--shard-size") + 1] == "250"
+    assert "--dataset-name" not in argv
+
+    argv_ds = _regenerate_argv(_config(tmp_path, dataset_name="hf/set"), server="http://s", shards_dir="/o")
+    assert argv_ds[argv_ds.index("--dataset-name") + 1] == "hf/set"
+
+
+# --------------------------------------------------------------------------- #
+# Worker CLI: main
+# --------------------------------------------------------------------------- #
+
+
+def _run_main(tmp_path, monkeypatch, regenerate_rc):
+    cfg = _config(tmp_path)
+    cycle_dir = str(tmp_path / "cycle_10")
+    os.makedirs(cycle_dir)
+    config_json = str(tmp_path / "regen_config.json")
+    with open(config_json, "w") as f:
+        json.dump(asdict(cfg), f)
+
+    monkeypatch.setattr(f"{_MODULE}._resolve_worker_port", lambda _p: 12345)
+    monkeypatch.setattr(f"{_MODULE}._wait_for_server", lambda server, proc, timeout: None)
+    monkeypatch.setattr(f"{_MODULE}.subprocess.Popen", lambda argv, **kw: _FakeProc(alive=False, return_code=0))
+
+    calls = {}
+
+    def _fake_regenerate_main(argv):
+        calls["argv"] = argv
+        return regenerate_rc
+
+    fake_mod = types.ModuleType("nemo_automodel.components.speculative.regenerate")
+    fake_mod.main = _fake_regenerate_main
+    monkeypatch.setitem(sys.modules, "nemo_automodel.components.speculative.regenerate", fake_mod)
+
+    argv = ["--config-json", config_json, "--cycle-dir", cycle_dir, "--step", "10"]
+    return cfg, cycle_dir, calls, main(argv)
+
+
+def test_main_writes_ready_marker_on_success(tmp_path, monkeypatch):
+    cfg, cycle_dir, calls, rc = _run_main(tmp_path, monkeypatch, regenerate_rc=0)
+    assert rc == 0
+    ready = os.path.join(cycle_dir, _DONE_FILENAME)
+    assert os.path.exists(ready)
+    with open(ready) as f:
+        assert f.read() == "10"
+    # regenerate ran against the shards subdir of this cycle
+    assert calls["argv"][calls["argv"].index("--output-dir") + 1] == os.path.join(cycle_dir, _SHARDS_DIRNAME)
+
+
+def test_main_raises_and_skips_marker_on_regenerate_failure(tmp_path, monkeypatch):
+    with pytest.raises(RuntimeError, match="regenerate exited with code 3"):
+        _run_main(tmp_path, monkeypatch, regenerate_rc=3)
+    assert not os.path.exists(os.path.join(str(tmp_path / "cycle_10"), _DONE_FILENAME))
+
+
+def test_main_terminates_live_target_server_on_exit(tmp_path, monkeypatch):
+    cfg = _config(tmp_path)
+    cycle_dir = str(tmp_path / "cycle_10")
+    os.makedirs(cycle_dir)
+    config_json = str(tmp_path / "regen_config.json")
+    with open(config_json, "w") as f:
+        json.dump(asdict(cfg), f)
+
+    # Server is still alive when main() returns, and ignores terminate() → must escalate to kill().
+    server = _FakeProc(alive=True)
+    server.wait = _timeout_then_ok_wait()
+    monkeypatch.setattr(f"{_MODULE}._resolve_worker_port", lambda _p: 12345)
+    monkeypatch.setattr(f"{_MODULE}._wait_for_server", lambda s, p, t: None)
+    monkeypatch.setattr(f"{_MODULE}.subprocess.Popen", lambda argv, **kw: server)
+    fake_mod = types.ModuleType("nemo_automodel.components.speculative.regenerate")
+    fake_mod.main = lambda argv: 0
+    monkeypatch.setitem(sys.modules, "nemo_automodel.components.speculative.regenerate", fake_mod)
+
+    rc = main(["--config-json", config_json, "--cycle-dir", cycle_dir, "--step", "10"])
+
+    assert rc == 0
+    assert server.terminated and server.killed


### PR DESCRIPTION
## Summary

Adds the on-policy data regeneration loop for EAGLE-3 draft training ("train-with-decode"), on top of the periodic decode-eval that landed in #3037.

EAGLE-3 teacher-forces the draft on a static dataset whose assistant turns were often written by a different model than the target being distilled, so the draft trains against off-distribution supervision. This feature regenerates that data online, interleaved with training:

- On a step cadence (`regen.every_steps`), a detached rank-0 worker subprocess boots a plain vLLM server for the frozen target on a reserved GPU and regenerates a fresh directory of shards. Training never blocks; at most one cycle is in flight.
- At a grad-accum window boundary (gradients clean, no partial window to flush), all data-parallel ranks rebuild the train dataloader against the new shard directory in lockstep, with the decision broadcast from rank 0. The epoch loop is now step-budget driven, so a single-epoch run trains on regenerated data instead of no-opping.

## Correctness properties

Surfaced by an adversarial code-review pass and fixed:

- Per-segment `batches_per_epoch` recompute after a swap, so `should_sync_grads` and the trailing-window flush stay correct. A stale count would run the flush on un-all-reduced gradients and silently desync the DDP replicas.
- `take_ready_shards` frees every superseded ready cycle, not only the previously-active one, so disk does not grow one dataset per cycle on the shared filesystem.
- On resume, the launch cadence is aligned to the restored `global_step` (`resume_from_step`), so a resumed run does not relaunch a redundant cycle for an already-covered region.
- A crashed cycle's directory is wiped before relaunch, since regenerate aborts on a non-empty shard dir.
- The LR horizon is kept fixed (the step-budget stop keeps the cosine coherent) and warns if a regenerated cycle's length differs from the original.
- A `regen.output_dir` override is rejected loudly instead of being silently discarded.

## Tests

- `tests/unit_tests/speculative/test_regen_loop.py` (28): config resolution and validation, cadence / consume / GC, shutdown signal escalation, resume alignment, worker argv and `main`. 99% line coverage of `regen_loop.py` (only the `__main__` guard uncovered).
- `tests/unit_tests/recipes/llm/test_train_eagle3_regen.py` (13): `_setup_regen` gating, `_build_train_dataloader` forwarding, the swap path (rank-0 decide, rebind, LR-drift warning), the step-budget segment loop swapping mid-epoch, prefetch drain on early break, and regen-off backward compatibility.
- The existing eagle recipe suite (159 tests) still passes.

## GPU validation status

A 2-rank colocated smoke run caught and fixed a real setup-ordering bug: `_setup_regen` read `self.output_dir` before the setup body assigned it, and a unit regression test now covers it. The regen code path is validated through setup, where distributed init, target load, and runner construction all succeed.

Full end-to-end training plus swap plus DDP gradient-sync validation is still pending. The base EAGLE-3 answer-only loss-mask preprocessing currently fails for Qwen3 (it asks for a chat template that wraps assistant turns in generation tags), which reproduces with no regen block and is therefore orthogonal to this feature. Keeping the PR as a draft until that is resolved and the full run is validated.
