### PR TITLE
fix(checkpoint): compare torch versions semantically

### DIFF
--- a/nemo_automodel/components/checkpoint/__init__.py
+++ b/nemo_automodel/components/checkpoint/__init__.py
@@ -11,17 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import torch
-from packaging.version import parse as vparse
-
 from ._torch_backports import apply_async_checkpoint_patch as _nemo__apply_async_patch
 from ._torch_backports import apply_patches as _nemo__apply_patches
-from .config import CheckpointingConfig
+from .config import CheckpointingConfig, _is_geq_torch_2_9, _is_leq_torch_2_7_1
 
 __all__ = ["CheckpointingConfig"]
 
-if vparse(torch.__version__).base_version <= "2.7.1":
+if _is_leq_torch_2_7_1():
     _nemo__apply_patches()
 
-if vparse(torch.__version__).base_version >= "2.9.0":
+if _is_geq_torch_2_9():
     _nemo__apply_async_patch()

--- a/nemo_automodel/components/checkpoint/config.py
+++ b/nemo_automodel/components/checkpoint/config.py
@@ -41,10 +41,18 @@ if TYPE_CHECKING:
 
     from nemo_automodel.components.checkpoint.checkpointing import Checkpointer
 
+_TORCH_2_7_1 = (2, 7, 1)
+_TORCH_2_9 = (2, 9)
+
+
+def _is_leq_torch_2_7_1() -> bool:
+    """Check if the current torch version is less than or equal to 2.7.1."""
+    return parse(torch.__version__).release <= _TORCH_2_7_1
+
 
 def _is_geq_torch_2_9() -> bool:
     """Check if the current torch version is greater than or equal to 2.9.0."""
-    return parse(torch.__version__).base_version >= "2.9.0"
+    return parse(torch.__version__).release >= _TORCH_2_9
 
 
 class SaveConsolidatedMode(str, Enum):

--- a/tests/unit_tests/checkpoint/test_checkpoint_config.py
+++ b/tests/unit_tests/checkpoint/test_checkpoint_config.py
@@ -15,8 +15,13 @@
 """Tests for CheckpointingConfig in config.py."""
 
 import pytest
+import torch
 
-from nemo_automodel.components.checkpoint.config import CheckpointingConfig
+from nemo_automodel.components.checkpoint.config import (
+    CheckpointingConfig,
+    _is_geq_torch_2_9,
+    _is_leq_torch_2_7_1,
+)
 
 
 class TestCheckpointingConfig:
@@ -142,3 +147,51 @@ class TestCheckpointingConfig:
         """Without PEFT, torch_save must be honored."""
         cfg = CheckpointingConfig(model_save_format="torch_save", is_peft=False)
         assert cfg.model_save_format.value == "torch_save"
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        ("2.7.1", True),
+        ("2.8.0", False),
+        ("2.9.0", False),
+        ("2.10.0", False),
+        ("2.12.1+cu130", False),
+    ],
+)
+def test_torch_leq_2_7_gate_uses_semantic_versioning(monkeypatch, version, expected):
+    monkeypatch.setattr(torch, "__version__", version)
+
+    assert _is_leq_torch_2_7_1() is expected
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        ("2.8.0", False),
+        ("2.9.0", True),
+        ("2.10.0", True),
+        ("2.12.1+cu130", True),
+    ],
+)
+def test_torch_geq_2_9_gate_uses_semantic_versioning(monkeypatch, version, expected):
+    monkeypatch.setattr(torch, "__version__", version)
+
+    assert _is_geq_torch_2_9() is expected
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        ("2.8.0", False),
+        ("2.9.0", True),
+        ("2.10.0", True),
+        ("2.12.1+cu130", True),
+    ],
+)
+def test_async_checkpointing_gate_uses_semantic_versioning(monkeypatch, version, expected):
+    monkeypatch.setattr(torch, "__version__", version)
+
+    cfg = CheckpointingConfig(is_async=True, save_consolidated=False)
+
+    assert cfg.is_async is expected


### PR DESCRIPTION
Credits to @AlfredQin

## Summary
- Compare checkpoint torch-version gates using parsed release tuples instead of lexicographic strings.
- Reuse the same gates for checkpoint package import-time patching.
- Add regression coverage for torch 2.10+ and local-version builds such as 2.12.1+cu130.

Fixes #3039.

## Reproduction
Ran the checks in the existing interactive container (`pool0-01810`, `auto2606rc9.sqsh`) before and after the fix.

### Async config gate

```python
import torch
from nemo_automodel.components.checkpoint.config import CheckpointingConfig, _is_geq_torch_2_9

print(f"torch={torch.__version__}")
gate = _is_geq_torch_2_9()
print(f"_is_geq_torch_2_9={gate}")
cfg = CheckpointingConfig(is_async=True, save_consolidated=False)
print(f"config.is_async={cfg.is_async}")
```

On `origin/main` (`ae66147b`), the bug reproduces:

```text
torch=2.12.0a0+0291f960b6.nv26.04.48445190
_is_geq_torch_2_9=False
config.is_async=False
BUG_REPRODUCED: torch >= 2.10 is misclassified and async is disabled
ERROR:root:Async mode is only supported for torch >= 2.9.0, disabling async mode
```

On this PR (`5e44608f`), the same check passes:

```text
torch=2.12.0a0+0291f960b6.nv26.04.48445190
_is_geq_torch_2_9=True
config.is_async=True
FIX_CONFIRMED: torch >= 2.10 is accepted and async stays enabled
```

### Async executor patch gate

```python
import importlib
import torch

ape_mod = importlib.import_module("torch.distributed.checkpoint._async_process_executor")
print("torch=" + torch.__version__)
print("patched_before_import=" + str(getattr(ape_mod, "_NEMO_PATCHED_CREATE_LOCK", False)))
import nemo_automodel.components.checkpoint
print("patched_after_import=" + str(getattr(ape_mod, "_NEMO_PATCHED_CREATE_LOCK", False)))
exec_cls = getattr(ape_mod, "_ProcessBasedAsyncCheckpointExecutor", None)
print("executor_wrapped=" + str(hasattr(exec_cls, "_nemo_orig_execute_save_impl") if exec_cls is not None else None))
```

On `origin/main` (`ae66147b`), the async executor patch is skipped:

```text
torch=2.12.0a0+0291f960b6.nv26.04.48445190
patched_before_import=False
patched_after_import=False
executor_wrapped=False
BUG_REPRODUCED: async checkpoint executor patch gate is skipped
```

On this PR (`5e44608f`), the async executor patch is applied:

```text
torch=2.12.0a0+0291f960b6.nv26.04.48445190
patched_before_import=False
patched_after_import=True
executor_wrapped=True
FIX_CONFIRMED: async checkpoint executor patch gate is applied
```

## Test Plan
- Reproduced the async config bug on `origin/main` before testing the fix.
- Reproduced the async executor patch-gate bug on `origin/main` before testing the fix.
- Confirmed both checks pass on this PR branch.
- `PYTHONDONTWRITEBYTECODE=1 python -m pytest tests/unit_tests/checkpoint/test_checkpoint_config.py -q -p no:cacheprovider` (`23 passed`)
- `python -m ruff check --no-cache nemo_automodel/components/checkpoint/config.py nemo_automodel/components/checkpoint/__init__.py tests/unit_tests/checkpoint/test_checkpoint_config.py`
- `python -m ruff format --check nemo_automodel/components/checkpoint/config.py nemo_automodel/components/checkpoint/__init__.py tests/unit_tests/checkpoint/test_checkpoint_config.py`
- `git diff --check`