### PR TITLE
fix(dspark): omit unmeasured positional acceptance rates

### DIFF
--- a/nemo_automodel/recipes/llm/train_dspark.py
+++ b/nemo_automodel/recipes/llm/train_dspark.py
@@ -382,6 +382,17 @@ def _distributed_section_dict(cfg) -> dict:
     return section.to_dict() if hasattr(section, "to_dict") else dict(section)
 
 
+def _add_accept_rate_per_position(
+    metrics: dict[str, float],
+    accept_num: torch.Tensor,
+    accept_den: torch.Tensor,
+) -> None:
+    """Add measured per-position acceptance rates to a metrics dictionary."""
+    for position, (num, den) in enumerate(zip(accept_num.tolist(), accept_den.tolist())):
+        if den > 0:
+            metrics[f"accept_rate@{position}"] = num / den
+
+
 class TrainDSparkRecipe(BaseRecipe):
     """Recipe for DSpark draft-model training on Qwen3, Gemma4, DeepSeek V4, GLM-5.2, and MiniMax M3 VL targets."""
 
@@ -1469,8 +1480,7 @@ class TrainDSparkRecipe(BaseRecipe):
                             accept_den = pos_den.sum().item()
                             if accept_den > 0:
                                 avg["accept_rate"] = pos_num.sum().item() / accept_den
-                                for k, rate in enumerate((pos_num / pos_den.clamp_min(1.0)).tolist()):
-                                    avg[f"accept_rate@{k}"] = rate
+                                _add_accept_rate_per_position(avg, pos_num, pos_den)
                             if w[5] > 0:
                                 avg["tau"] = w[4] / w[5]
                             if w[9] > 0:

--- a/tests/unit_tests/recipes/llm/test_train_dspark_helpers.py
+++ b/tests/unit_tests/recipes/llm/test_train_dspark_helpers.py
@@ -55,6 +55,7 @@ from nemo_automodel.recipes.llm._dspark_target_build import (
     resolve_reduced_target_layers,
 )
 from nemo_automodel.recipes.llm.train_dspark import (
+    _add_accept_rate_per_position,
     TrainDSparkRecipe,
     _apply_draft_activation_checkpointing,
     _apply_target_chat_template,
@@ -71,6 +72,18 @@ JINJA = (
     "{{ bos_token }}{% for m in messages %}{% if m['role'] == 'assistant' %}"
     "{% generation %}{{ m['content'] }}{% endgeneration %}{% endif %}{% endfor %}"
 )
+
+
+def test_accept_rate_per_position_omits_unmeasured_positions():
+    metrics = {}
+
+    _add_accept_rate_per_position(
+        metrics,
+        accept_num=torch.tensor([3.0, 1.0, 0.0]),
+        accept_den=torch.tensor([4.0, 2.0, 0.0]),
+    )
+
+    assert metrics == {"accept_rate@0": 0.75, "accept_rate@1": 0.5}
 
 
 def _tok(chat_template=None):


### PR DESCRIPTION
## Summary

- omit `accept_rate@k` when no valid samples contributed to that block position
- keep the aggregate acceptance rate unchanged
- add a unit test covering measured and unmeasured positions

## Root cause

The logging path clamped every per-position denominator to one before division. When at least one position was measured, positions with a zero denominator were consequently logged as an acceptance rate of zero even though they had no observations.

## Impact

W&B and metric logs no longer show false zero acceptance rates for unmeasured tail positions.

## Validation

- `ruff format --check nemo_automodel/recipes/llm/train_dspark.py tests/unit_tests/recipes/llm/test_train_dspark_helpers.py`
- `ruff check nemo_automodel/recipes/llm/train_dspark.py`
- `git diff --check`

The focused pytest file could not run locally because the active Python environment does not contain pytest. CI will run the added unit test.
