### PR TITLE
fix(test): use SDPA for Nemotron-H HF reload

### DIFF
--- a/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
+++ b/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
@@ -374,6 +374,56 @@ def _cleanup_source_load_sync(cfg) -> None:
         pass
 
 
+def _hf_reload_sync_paths(cfg) -> tuple[Path, Path]:
+    """Return sync directory and done path for the rank-0-only HF reload."""
+    checkpoint_dir = Path(cfg.checkpoint.checkpoint_dir)
+    sync_dir = checkpoint_dir.parent / f".hf_reload_{_source_load_run_id()}"
+    return sync_dir, sync_dir / "done"
+
+
+def _wait_for_hf_reload_rank0(done_path: Path) -> None:
+    """Wait without an active collective for rank 0 to finish the vanilla-HF reload."""
+    timeout_s = int(os.environ.get("HF_RELOAD_TIMEOUT_SECONDS", "1800"))
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if done_path.exists():
+            return
+        time.sleep(5)
+    raise TimeoutError(f"Timed out waiting {timeout_s}s for rank 0 vanilla-HF reload")
+
+
+def _prepare_hf_reload_sync(cfg) -> tuple[Path, Path] | None:
+    """Prepare ranks for a long rank-0-only HF reload without starting an NCCL wait."""
+    if not dist.is_initialized() or dist.get_world_size() == 1:
+        return None
+
+    sync_dir, done_path = _hf_reload_sync_paths(cfg)
+    if _rank0():
+        sync_dir.mkdir(parents=True, exist_ok=True)
+        done_path.unlink(missing_ok=True)
+    _barrier()  # ensure all ranks released recipe memory and rank 0 reset the marker
+    if not _rank0():
+        _wait_for_hf_reload_rank0(done_path)
+    return sync_dir, done_path
+
+
+def _finish_hf_reload_sync(sync_paths: tuple[Path, Path] | None) -> None:
+    """Release waiting ranks and synchronize after the rank-0-only HF reload."""
+    if sync_paths is None:
+        return
+
+    sync_dir, done_path = sync_paths
+    if _rank0():
+        done_path.write_text("ok\n")
+    _barrier()
+    if _rank0():
+        done_path.unlink(missing_ok=True)
+        try:
+            sync_dir.rmdir()
+        except OSError:
+            pass
+
+
 def _prepare_source_load_reference(
     cfg,
     input_ids: list[int],
@@ -967,7 +1017,7 @@ def test_checkpoint_robustness():
     # Phase 4: Load into vanilla HF (rank 0 only)
     _release_recipe_memory(restored_trainer)
     del restored_trainer
-    _barrier()  # ensure all ranks free memory before rank 0 loads HF model
+    hf_reload_sync_paths = _prepare_hf_reload_sync(cfg)
 
     if skip_hf_reload:
         if _rank0():
@@ -1096,7 +1146,7 @@ def test_checkpoint_robustness():
             f"max per-token KL = {max_kl_hf:.6e} > threshold {hf_kl_threshold:.6e}"
         )
 
-    _barrier()
+    _finish_hf_reload_sync(hf_reload_sync_paths)
 
     # Phase 5 (optional): Cross-TP — reload consolidated with a different TP size
     if cross_tp_size > 0 and not is_peft:

--- a/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
+++ b/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
@@ -190,9 +190,35 @@ def _resolve_source_load_dtype(model_kwargs: dict) -> torch.dtype:
     return torch_dtype
 
 
+def _get_trust_remote_code_attn_implementation(
+    pretrained_model_name_or_path: str | Path,
+    *,
+    revision: str | None = None,
+    token: str | bool | None = None,
+) -> str:
+    """Select the vanilla-HF attention implementation for a remote-code model."""
+    from transformers import AutoConfig
+
+    config_kwargs: dict[str, str | bool] = {"trust_remote_code": True}
+    if revision is not None:
+        config_kwargs["revision"] = revision
+    if token is not None:
+        config_kwargs["token"] = token
+    config = AutoConfig.from_pretrained(pretrained_model_name_or_path, **config_kwargs)
+
+    # Nemotron-H's remote-code attention passes an ordinary padding mask through
+    # HF's FlashAttention varlen/unpadding path. That path raises a
+    # vectorized_gather_kernel index-OOB device assert for Nemotron-3 Super.
+    # PyTorch SDPA uses its optimized CUDA dispatcher while avoiding the
+    # incompatible varlen route. Other remote-code models (notably
+    # Nemotron-Flash) still require FA2.
+    return "sdpa" if config.model_type == "nemotron_h" else "flash_attention_2"
+
+
 def _hf_source_load_kwargs(
     model_kwargs: dict,
     *,
+    pretrained_model_name_or_path: str | Path,
     source_dtype: torch.dtype,
     trust_remote_code: bool,
     experts_implementation: str | None,
@@ -211,8 +237,12 @@ def _hf_source_load_kwargs(
     hf_kwargs = {k: v for k, v in model_kwargs.items() if k in hf_allowed_keys}
     hf_kwargs["torch_dtype"] = source_dtype
     hf_kwargs["trust_remote_code"] = trust_remote_code or bool(hf_kwargs.get("trust_remote_code", False))
-    if trust_remote_code and "attn_implementation" not in hf_kwargs:
-        hf_kwargs["attn_implementation"] = "flash_attention_2"
+    if hf_kwargs["trust_remote_code"] and "attn_implementation" not in hf_kwargs:
+        hf_kwargs["attn_implementation"] = _get_trust_remote_code_attn_implementation(
+            pretrained_model_name_or_path,
+            revision=hf_kwargs.get("revision"),
+            token=hf_kwargs.get("token"),
+        )
     if experts_implementation and not trust_remote_code:
         hf_kwargs["experts_implementation"] = experts_implementation
         hf_kwargs["trust_remote_code"] = False
@@ -412,6 +442,7 @@ def _prepare_source_load_reference_rank0(
     device = torch.device("cuda", torch.cuda.current_device()) if torch.cuda.is_available() else torch.device("cpu")
     hf_kwargs = _hf_source_load_kwargs(
         model_kwargs,
+        pretrained_model_name_or_path=original_pretrained_path,
         source_dtype=source_dtype,
         trust_remote_code=trust_remote_code,
         experts_implementation=experts_implementation,
@@ -960,13 +991,12 @@ def test_checkpoint_robustness():
             _no_meta = nullcontext()
 
         hf_kwargs = dict(torch_dtype=torch.bfloat16, trust_remote_code=trust_remote_code)
-        # Nemotron-Flash's config ships ``attn_implementation="fused_mha"`` which
-        # transformers 5.x rejects in ``_check_and_adjust_attn_implementation``
-        # (only ``eager`` + registered ALL_ATTENTION_FUNCTIONS keys are accepted).
-        # Force a universally accepted impl; Nemotron-Flash routes
-        # ``flash_attention_2`` through its own fused path internally.
+        # Remote-code models can ship attention names that transformers 5.x
+        # rejects. Select a supported implementation while keeping Nemotron-H
+        # off HF's incompatible FlashAttention varlen path.
         if trust_remote_code and "attn_implementation" not in hf_kwargs:
-            hf_kwargs["attn_implementation"] = "flash_attention_2"
+            config_path = original_pretrained_path if is_peft else consolidated_dir
+            hf_kwargs["attn_implementation"] = _get_trust_remote_code_attn_implementation(config_path)
         if experts_implementation and not trust_remote_code:
             hf_kwargs["experts_implementation"] = experts_implementation
             hf_kwargs["trust_remote_code"] = False

--- a/tests/unit_tests/ci_tests/test_checkpoint_robustness_hf_kwargs.py
+++ b/tests/unit_tests/ci_tests/test_checkpoint_robustness_hf_kwargs.py
@@ -12,13 +12,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import time
+from datetime import timedelta
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
 
+from tests.functional_tests.checkpoint_robustness.test_checkpoint_robustness_llm import _finish_hf_reload_sync
 from tests.functional_tests.checkpoint_robustness.test_checkpoint_robustness_llm import _hf_source_load_kwargs
+from tests.functional_tests.checkpoint_robustness.test_checkpoint_robustness_llm import _prepare_hf_reload_sync
+from tests.functional_tests.checkpoint_robustness.test_checkpoint_robustness_llm import _wait_for_hf_reload_rank0
+
+
+def _run_hf_reload_sync_rank(rank, init_path, checkpoint_dir):
+    os.environ["TORCHELASTIC_RUN_ID"] = "checkpoint-robustness-hf-sync-test"
+    os.environ["HF_RELOAD_TIMEOUT_SECONDS"] = "15"
+    dist.init_process_group(
+        "gloo",
+        init_method=f"file://{init_path}",
+        rank=rank,
+        world_size=2,
+        timeout=timedelta(seconds=3),
+    )
+    try:
+        cfg = SimpleNamespace(checkpoint=SimpleNamespace(checkpoint_dir=checkpoint_dir))
+        sync_paths = _prepare_hf_reload_sync(cfg)
+        if rank == 0:
+            time.sleep(4)
+        _finish_hf_reload_sync(sync_paths)
+    finally:
+        dist.destroy_process_group()
 
 
 @pytest.mark.parametrize(
@@ -62,3 +90,26 @@ def test_explicit_attention_implementation_is_preserved():
         )
 
     assert hf_kwargs["attn_implementation"] == "eager"
+
+
+def test_hf_reload_wait_returns_after_rank0_marker(tmp_path):
+    done_path = tmp_path / "done"
+    done_path.write_text("ok\n")
+
+    _wait_for_hf_reload_rank0(done_path)
+
+
+def test_hf_reload_wait_has_separate_timeout(tmp_path, monkeypatch):
+    monkeypatch.setenv("HF_RELOAD_TIMEOUT_SECONDS", "0")
+
+    with pytest.raises(TimeoutError, match="rank 0 vanilla-HF reload"):
+        _wait_for_hf_reload_rank0(tmp_path / "done")
+
+
+def test_hf_reload_wait_does_not_start_collective_during_rank0_work(tmp_path):
+    mp.spawn(
+        _run_hf_reload_sync_rank,
+        args=(str(tmp_path / "dist-init"), str(tmp_path / "checkpoints")),
+        nprocs=2,
+        join=True,
+    )

--- a/tests/unit_tests/ci_tests/test_checkpoint_robustness_hf_kwargs.py
+++ b/tests/unit_tests/ci_tests/test_checkpoint_robustness_hf_kwargs.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from tests.functional_tests.checkpoint_robustness.test_checkpoint_robustness_llm import _hf_source_load_kwargs
+
+
+@pytest.mark.parametrize(
+    ("model_type", "expected_attn_implementation"),
+    [("nemotron_h", "sdpa"), ("nemotron_flash", "flash_attention_2")],
+)
+def test_remote_code_attention_implementation(model_type, expected_attn_implementation):
+    with patch(
+        "transformers.AutoConfig.from_pretrained",
+        return_value=SimpleNamespace(model_type=model_type),
+    ) as from_pretrained:
+        hf_kwargs = _hf_source_load_kwargs(
+            {"revision": "model-revision", "token": "model-token"},
+            pretrained_model_name_or_path="model-path",
+            source_dtype=torch.bfloat16,
+            trust_remote_code=True,
+            experts_implementation=None,
+            device=torch.device("cpu"),
+            hf_device_map_auto=False,
+        )
+
+    assert hf_kwargs["attn_implementation"] == expected_attn_implementation
+    from_pretrained.assert_called_once_with(
+        "model-path",
+        trust_remote_code=True,
+        revision="model-revision",
+        token="model-token",
+    )
+
+
+def test_explicit_attention_implementation_is_preserved():
+    with patch("transformers.AutoConfig.from_pretrained", side_effect=AssertionError("must not probe config")):
+        hf_kwargs = _hf_source_load_kwargs(
+            {"attn_implementation": "eager"},
+            pretrained_model_name_or_path="model-path",
+            source_dtype=torch.bfloat16,
+            trust_remote_code=True,
+            experts_implementation=None,
+            device=torch.device("cpu"),
+            hf_device_map_auto=False,
+        )
+
+    assert hf_kwargs["attn_implementation"] == "eager"


### PR DESCRIPTION
## What

- select `sdpa` when checkpoint robustness loads a Nemotron-H model through Hugging Face remote code
- preserve `flash_attention_2` for other remote-code models, including Nemotron-Flash
- preserve any explicitly configured attention implementation
- apply the selection to both source-load parity and post-checkpoint HF reloads
- keep nonzero ranks in a long-timeout synchronization while rank 0 performs the slow HF reload

## Why

AM-672 fails while the vanilla-HF reference model runs through Hugging Face's FlashAttention varlen/unpadding path. Nemotron-H triggers a CUDA `vectorized_gather_kernel` index-out-of-bounds assert there. The later tensor-representation error and NCCL failures are secondary symptoms of rank 0's asynchronous CUDA failure.

PyTorch SDPA avoids the incompatible HF varlen path while retaining optimized CUDA attention dispatch. The explicit reload synchronization also prevents other ranks from hitting the default 600-second process-group timeout while rank 0 is still loading the 120B HF reference.

## Validation

- `python -m pytest tests/unit_tests/ci_tests/test_checkpoint_robustness_hf_kwargs.py -q` — 6 passed, including the real two-process synchronization regression
- `ruff format --check` on both changed files
- `ruff check` on both changed files
- Scoped EOS/H100 release job passed: [`nemotron_super_v3_hellaswag_peft` (job 362958206)](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/362958206)
- Combined validation pipeline: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/57979613

The separate vLLM deploy result in that combined pipeline belongs to #3061 / AM-668 and does not affect this HF checkpoint-robustness fix.

Linear: [AM-672](https://linear.app/nvidia/issue/AM-672/cuda-device-side-assert-triggered-during-tensor-representation)
