### PR TITLE
fix(attention): constrain large-head FFPA Flex fallback

### DIFF
--- a/nemo_automodel/components/attention/ffpa_attention.py
+++ b/nemo_automodel/components/attention/ffpa_attention.py
@@ -334,6 +334,20 @@ def ffpa_attention_forward(
         flex = _get_flex()
         if flex is None:
             raise RuntimeError("ffpa_attention_forward: flex_attention is unavailable for sliding-window layers")
+        if getattr(module, "head_dim", 0) > 256 and "kernel_options" not in kwargs:
+            kwargs = {
+                **kwargs,
+                "kernel_options": {
+                    "BLOCK_M": 32,
+                    "BLOCK_N": 32,
+                    "BLOCK_M1": 32,
+                    "BLOCK_N1": 32,
+                    "BLOCK_M2": 32,
+                    "BLOCK_N2": 32,
+                    "num_stages": 1,
+                    "num_warps": 4,
+                },
+            }
         return flex(module, query, key, value, attention_mask, scaling=scaling, softcap=softcap, **kwargs)
 
     # Full-attention (head_dim=512) path: run FFPA when eligible, else fall back to SDPA/eager below.

--- a/tests/unit_tests/components/attention/test_ffpa_attention.py
+++ b/tests/unit_tests/components/attention/test_ffpa_attention.py
@@ -253,6 +253,28 @@ def test_block_mask_routes_to_flex_not_sdpa():
     assert weights is None
 
 
+def test_large_head_dim_block_mask_uses_small_flex_kernel_options():
+    q, k, v = _qkv(1, 8, 4, 16, 512)
+    fake_flex = mock.Mock(return_value=(torch.zeros(1, 16, 8, 512), None))
+    with (
+        mock.patch.object(ffpa_mod, "_is_block_mask", return_value=True),
+        mock.patch.object(ffpa_mod, "_get_flex", return_value=fake_flex),
+    ):
+        ffpa_attention_forward(_module(512), q, k, v, attention_mask=object(), scaling=0.0442)
+
+    options = fake_flex.call_args.kwargs["kernel_options"]
+    assert options == {
+        "BLOCK_M": 32,
+        "BLOCK_N": 32,
+        "BLOCK_M1": 32,
+        "BLOCK_N1": 32,
+        "BLOCK_M2": 32,
+        "BLOCK_N2": 32,
+        "num_stages": 1,
+        "num_warps": 4,
+    }
+
+
 def test_block_mask_requires_flex_no_sdpa_fallback():
     q, k, v = _qkv(1, 8, 4, 16, 256)
     with (


### PR DESCRIPTION
# What does this PR do?

Prevents the FFPA-to-FlexAttention fallback from compiling an oversized Triton kernel for Gemma4 layers with large attention head dimensions.

The `gemma4_31b_ffpa_mock_8k` CI job failed on H100 while compiling the image-bidirectional `BlockMask` path:

```text
No valid triton configs. OutOfMemoryError: out of resource:
triton_tem_fused_flex_attention_0 Required: 263168 Hardware limit: 232448
```

For these `head_dim=512` layers, FFPA routes the arbitrary `BlockMask` to FlexAttention. FlexAttention's default generated configuration used `BLOCK_M=64`, `BLOCK_N=32`, and `num_stages=3`, exceeding the H100 per-block shared-memory limit.

Gemma4's direct FlexAttention path already handles large head dimensions with a smaller `32 x 32`, one-stage launch configuration from #1914. The FFPA fallback introduced by #2436 bypasses that model-level handling because the configured attention implementation is `ffpa`, not `flex_attention`.

This change applies the same proven launch settings at the FFPA-to-Flex fallback boundary when `head_dim > 256`. Explicit caller-provided `kernel_options` remain unchanged.

# Changelog

- Pass small forward and backward block sizes, one stage, and four warps to FlexAttention for large-head FFPA `BlockMask` fallbacks.
- Add a focused unit test covering the generated `kernel_options`.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation? Not required for this internal dispatch fix.

# Test Results

## CI reproduction

Reproduced [nemo-ci job 361014948](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/361014948) locally on 8x H100 at exact AutoModel commit `e4e9efd4ace56603a5bed96b840aabddbb52e4f2` with the same `263168 > 232448` Triton shared-memory error.

## End-to-end validation

Validated on current `main` (`80ba6a018`) with local 8x H100:

- Recipe: `examples/vlm_finetune/gemma4/gemma4_31b_ffpa_mock_8k.yaml`
- FSDP2, CP1, 8K sequence length, one mock image per sample
- Activation checkpointing enabled
- `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`
- One complete training step including forward, backward, optimizer, and validation
- Peak memory: 51.91 GiB/GPU
- Exit code: 0

The emitted FlexAttention kernel used `BLOCK_M=32`, `BLOCK_N=32`, and `num_stages=1` for `head_dim=512`.

```text
19 passed in 7.34s
ruff check: passed
ruff format --check: passed
```

## NeMo-CI validation on the failing image

Validated the fix in [pipeline 57985689](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/57985689), with the generated [VLM leaf pipeline 57985729](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/57985729) and [job 362986297](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/362986297) all passing.

This run reused the exact container from the original failing job, `gitlab-master.nvidia.com/dl/joc/nemo-ci/main/automodel:pipe.57691378`, and applied only this PR's patch to AutoModel commit `e4e9efd4ace56603a5bed96b840aabddbb52e4f2` before rebuilding the editable package inside the container.

- Recipe: `gemma4_31b_ffpa_mock_8k`
- Hardware: one `eos` node, 8x H100, `batch` partition
- FSDP2, CP1, 8K sequence length, one mock image per sample
- Activation checkpointing enabled
- `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`
- Completed all 10 training steps plus validation
- Peak memory: 65.67 GiB/GPU
- Final step throughput: 6,272.89 tokens/s aggregate (784.11 tokens/s/GPU)
- Final validation loss: 4.2397
- Job result: passed