### PR TITLE
fix: Kimi K2 config loading without remote code

### DIFF
--- a/nemo_automodel/_transformers/registry.py
+++ b/nemo_automodel/_transformers/registry.py
@@ -282,7 +282,7 @@ _CUSTOM_CONFIG_REGISTRATIONS: Dict[str, Tuple[str, str]] = {
     "bailing_moe": ("nemo_automodel.components.models.ling_v2.config", "BailingMoeV2Config"),
     "deepseek_v4": ("nemo_automodel.components.models.deepseek_v4.config", "DeepseekV4Config"),
     "hy_v3": ("nemo_automodel.components.models.hy_v3.config", "HYV3Config"),
-    "kimi_k2": ("nemo_automodel.components.models.deepseek_v3.config", "KimiK2Config"),
+    "kimi_k2": ("nemo_automodel.components.models.kimi_k2.config", "KimiK2Config"),
     "kimi_k25": ("nemo_automodel.components.models.kimi_k25_vl.model", "KimiK25VLConfig"),
     "kimi_vl": ("nemo_automodel.components.models.kimivl.model", "KimiVLConfig"),
     "llavaonevision1_5": ("nemo_automodel.components.models.llava_onevision.model", "Llavaonevision1_5Config"),

--- a/nemo_automodel/_transformers/registry.py
+++ b/nemo_automodel/_transformers/registry.py
@@ -282,6 +282,7 @@ _CUSTOM_CONFIG_REGISTRATIONS: Dict[str, Tuple[str, str]] = {
     "bailing_moe": ("nemo_automodel.components.models.ling_v2.config", "BailingMoeV2Config"),
     "deepseek_v4": ("nemo_automodel.components.models.deepseek_v4.config", "DeepseekV4Config"),
     "hy_v3": ("nemo_automodel.components.models.hy_v3.config", "HYV3Config"),
+    "kimi_k2": ("nemo_automodel.components.models.deepseek_v3.config", "KimiK2Config"),
     "kimi_k25": ("nemo_automodel.components.models.kimi_k25_vl.model", "KimiK25VLConfig"),
     "kimi_vl": ("nemo_automodel.components.models.kimivl.model", "KimiVLConfig"),
     "llavaonevision1_5": ("nemo_automodel.components.models.llava_onevision.model", "Llavaonevision1_5Config"),

--- a/nemo_automodel/components/models/deepseek_v3/config.py
+++ b/nemo_automodel/components/models/deepseek_v3/config.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from transformers.models.deepseek_v3.configuration_deepseek_v3 import DeepseekV3Config
+
+
+class KimiK2Config(DeepseekV3Config):
+    """DeepSeek-V3-compatible config for Kimi-K2 checkpoints."""
+
+    model_type = "kimi_k2"

--- a/nemo_automodel/components/models/kimi_k2/__init__.py
+++ b/nemo_automodel/components/models/kimi_k2/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/nemo_automodel/components/models/kimi_k2/config.py
+++ b/nemo_automodel/components/models/kimi_k2/config.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit_tests/_transformers/test_registry.py
+++ b/tests/unit_tests/_transformers/test_registry.py
@@ -302,6 +302,42 @@ def test_custom_config_registrations_in_config_mapping():
     )
 
 
+def test_kimi_k2_config_loads_without_trust_remote_code(tmp_path):
+    """Kimi-K2 uses DeepseekV3Config and should not require remote config code."""
+    import json
+
+    from transformers import AutoConfig
+
+    import nemo_automodel._transformers.registry  # noqa: F401
+
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "architectures": ["DeepseekV3ForCausalLM"],
+                "auto_map": {
+                    "AutoConfig": "configuration_deepseek.DeepseekV3Config",
+                    "AutoModel": "modeling_deepseek.DeepseekV3Model",
+                    "AutoModelForCausalLM": "modeling_deepseek.DeepseekV3ForCausalLM",
+                },
+                "hidden_size": 64,
+                "model_type": "kimi_k2",
+                "num_attention_heads": 8,
+                "num_hidden_layers": 2,
+                "vocab_size": 256,
+            }
+        )
+    )
+
+    cfg = AutoConfig.from_pretrained(tmp_path, trust_remote_code=False)
+
+    from transformers.models.deepseek_v3.configuration_deepseek_v3 import DeepseekV3Config
+
+    assert type(cfg).__name__ == "KimiK2Config"
+    assert isinstance(cfg, DeepseekV3Config)
+    assert cfg.model_type == "kimi_k2"
+    assert cfg.architectures == ["DeepseekV3ForCausalLM"]
+
+
 def test_kimi_k25_arch_alias_in_model_arch_mapping():
     """KimiK25ForConditionalGeneration (checkpoint arch) must map to KimiK25VLForConditionalGeneration."""
     from nemo_automodel._transformers.registry import MODEL_ARCH_MAPPING

--- a/tests/unit_tests/_transformers/test_registry.py
+++ b/tests/unit_tests/_transformers/test_registry.py
@@ -309,6 +309,7 @@ def test_kimi_k2_config_loads_without_trust_remote_code(tmp_path):
     from transformers import AutoConfig
 
     import nemo_automodel._transformers.registry  # noqa: F401
+    from nemo_automodel.components.models.kimi_k2.config import KimiK2Config
 
     (tmp_path / "config.json").write_text(
         json.dumps(
@@ -332,7 +333,7 @@ def test_kimi_k2_config_loads_without_trust_remote_code(tmp_path):
 
     from transformers.models.deepseek_v3.configuration_deepseek_v3 import DeepseekV3Config
 
-    assert type(cfg).__name__ == "KimiK2Config"
+    assert isinstance(cfg, KimiK2Config)
     assert isinstance(cfg, DeepseekV3Config)
     assert cfg.model_type == "kimi_k2"
     assert cfg.architectures == ["DeepseekV3ForCausalLM"]


### PR DESCRIPTION
## Summary

Fix Kimi K2 config loading when `moonshotai/Kimi-K2-Base` is resolved through `transformers.AutoConfig.from_pretrained` without `trust_remote_code=True`.

Kimi K2 declares `model_type: kimi_k2` but uses the DeepSeek V3 architecture. The recipe-level `trust_remote_code: true` is applied to the outer AutoModel construction, not the nested `AutoConfig.from_pretrained` call, so Transformers rejects the config before AutoModel can construct the model.

This adds a thin in-tree `KimiK2Config` subclass of `DeepseekV3Config` under the Kimi-owned model package and registers `kimi_k2` in AutoModel's custom config registry, allowing the config to load without executing remote code.

## Validation

- `ruff format nemo_automodel/components/models/kimi_k2/__init__.py nemo_automodel/components/models/kimi_k2/config.py nemo_automodel/_transformers/registry.py tests/unit_tests/_transformers/test_registry.py`
- `ruff check nemo_automodel/components/models/kimi_k2/__init__.py nemo_automodel/components/models/kimi_k2/config.py nemo_automodel/_transformers/registry.py tests/unit_tests/_transformers/test_registry.py`
- `.venv/bin/pytest tests/unit_tests/_transformers/test_registry.py -q`
- Direct repro: `AutoConfig.from_pretrained("moonshotai/Kimi-K2-Base", trust_remote_code=False)` returns `KimiK2Config`
- NeMo-CI no-build same-container check: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/362938611
- NeMo-CI original failed-container check: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/363007299 (leaf pipeline https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/57988960; image `gitlab-master.nvidia.com/dl/joc/nemo-ci/main/automodel:pipe.56098635`; output `KimiK2Config kimi_k2 DeepseekV3ForCausalLM`)
- NeMo-CI reviewer-follow-up same-container check: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/363460235 (leaf pipeline https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/58047357; parent https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/58047217; image `gitlab-master.nvidia.com/dl/joc/nemo-ci/main/automodel:pipe.56098635`; output `AM593_OK 9da845b1 KimiK2Config kimi_k2 DeepseekV3ForCausalLM`)

Note: the scoped reviewer-follow-up CI run filters to the LLM benchmark `kimi_k2_te_deepep`. The selected LLM leaf pipeline passed; the generated AutoModel child also creates an unrelated VLM benchmark bridge, which reports failed because it has no matching job for this LLM-only filter.
