### PR TITLE
fix(dllm): remove obsolete DiffusionGemma HF compatibility

### DIFF
--- a/docs/guides/dllm/diffusiongemma.md
+++ b/docs/guides/dllm/diffusiongemma.md
@@ -4,65 +4,66 @@
 
 **DiffusionGemma** is a block-diffusion language model. Unlike an autoregressive (AR)
 model that generates one token at a time left-to-right, a block-diffusion model fills in
-a block of response tokens (a "canvas") by **iteratively denoising** it: the canvas starts
-as noise and is refined over several passes, conditioned on the prompt.
+a block of response tokens (a "canvas") by iteratively denoising the canvas. The canvas
+starts as noise and is refined over several passes, conditioned on the prompt.
 
-This guide covers **supervised fine-tuning (SFT)** of the DiffusionGemma **26B-A4B** model
-(a Mixture-of-Experts model with 26B total / ~4B active parameters) in NeMo AutoModel,
-with both **full fine-tuning** and **LoRA**.
+This guide covers **Supervised Fine-Tuning (SFT)** of the DiffusionGemma **26B-A4B** model,
+which is a Mixture-of-Experts (MoE) model with 26B total and approximately 4B active parameters,
+using NeMo AutoModel with both full fine-tuning and Low-Rank Adaptation (LoRA).
 
 The released checkpoint is available on the Hugging Face Hub:
 [`google/diffusiongemma-26B-A4B-it`](https://huggingface.co/google/diffusiongemma-26B-A4B-it).
 
-### Workflow overview
+### Workflow Overview
 
-| Step | What you do |
-|------|-------------|
-| 1. Install | Install NeMo AutoModel (pip or container) |
-| 2. Configure | Pick an example YAML (full SFT or LoRA) and set your dataset |
-| 3. Train | Launch with `torchrun` on 8 GPUs |
-| 4. Inspect | Read the training/diffusion loss curves |
+| Step | What You Do |
+| :--- | :--- |
+| 1. Install | Install NeMo AutoModel using pip or a container |
+| 2. Configure | Select an example YAML configuration file for full SFT or LoRA, and specify your dataset |
+| 3. Train | Launch training with `torchrun` on eight GPUs |
+| 4. Inspect | Read the training and diffusion loss curves |
 
 ## Model Overview
 
-DiffusionGemma couples a **causal encoder** with a **bidirectional decoder**:
+DiffusionGemma combines a causal encoder and a bidirectional decoder:
 
-- **Encoder** reads the clean prompt + response sequence with causal attention.
-- **Decoder** denoises the **canvas** — the response region — with bidirectional
-  (block-causal) attention, predicting the clean token at every canvas position.
+- **Encoder**: Reads the clean prompt and response sequence with causal attention.
+- **Decoder**: Denoises the canvas (the response region) with bidirectional,
+  block-causal attention, predicting the clean token at every canvas position.
 
-Key training mechanics, all handled by the `DiffusionGemmaSFTRecipe`:
+The `DiffusionGemmaSFTRecipe` handles the following key training mechanics:
 
-- **Uniform-random corruption.** For each example a corruption level `t ~ U(eps, 1)`
-  is sampled; supervised canvas positions are independently replaced with **uniform random
-  vocabulary tokens** (there is no `[MASK]` token). The model learns to recover the clean
-  token at every supervised canvas position.
-- **Self-conditioning.** The decoder optionally conditions on its own previous prediction,
-  mixed in per example during training.
-- **Frozen router.** The MoE router is kept frozen during SFT; experts and dense layers
-  are trained (full SFT) or adapted via LoRA.
-- **Single-turn SFT.** The loss supervises the final response turn; multi-turn histories
+- **Uniform-random corruption**: For each example, a corruption level
+  $t \sim U(\text{eps}, 1)$ is sampled, and supervised canvas positions are independently
+  replaced with uniform random vocabulary tokens (no `[MASK]` token is used). The model
+  learns to recover the clean token at every supervised canvas position.
+- **Self-conditioning**: The decoder optionally conditions on its own previous prediction,
+  which is mixed in per example during training.
+- **Frozen router**: The MoE router is kept frozen during SFT, and experts and dense layers
+  are trained (full SFT) or adapted using LoRA.
+- **Single-turn SFT**: The loss supervises the final response turn, and multi-turn histories
   are masked.
 
-The recipe runs with **FSDP2 + expert parallelism (EP=8)** and **mixed precision**
-(fp32 master weights, bf16 compute), with a canvas length of 256.
+The recipe runs with **Fully Sharded Data Parallel 2 (FSDP2) and expert parallelism (EP=8)**
+and mixed precision (FP32 master weights and BF16 compute) with a canvas length of 256.
 
 ## Launch Training
 
-DiffusionGemma SFT runs on a single 8-GPU node (EP=8). Two example configs are provided
-under `examples/dllm_sft/`:
+DiffusionGemma SFT runs on a single eight-GPU node (EP=8). Two example configuration files
+are provided in the `examples/dllm_sft/` directory:
 
-| Config | Description |
-|--------|-------------|
-| [`diffusion_gemma_sft.yaml`](../../../examples/dllm_sft/diffusion_gemma_sft.yaml) | Full fine-tune on [GSM8K](https://huggingface.co/datasets/openai/gsm8k) |
-| [`diffusion_gemma_lora.yaml`](../../../examples/dllm_sft/diffusion_gemma_lora.yaml) | LoRA fine-tune  |
+| Configuration File | Description |
+| :--- | :--- |
+| [`diffusion_gemma_sft.yaml`](../../../examples/dllm_sft/diffusion_gemma_sft.yaml) | Full fine-tuning on the [GSM8K](https://huggingface.co/datasets/openai/gsm8k) dataset |
+| [`diffusion_gemma_lora.yaml`](../../../examples/dllm_sft/diffusion_gemma_lora.yaml) | LoRA fine-tuning |
 
-Both pull the checkpoint from the Hugging Face Hub
-(`google/diffusiongemma-26B-A4B-it`) automatically. GSM8K is consumed in OpenAI
-chat-messages format, so generate the JSONL once before launching:
+Both configurations automatically pull the checkpoint from the Hugging Face Hub
+(`google/diffusiongemma-26B-A4B-it`). Because the GSM8K dataset is consumed in the OpenAI
+chat-messages format, you must generate the JSONL file (`./gsm8k_chat_train.jsonl`) before
+launching training:
 
 ```bash
-python examples/dllm_sft/prep_gsm8k.py        # writes ./gsm8k_chat_train.jsonl
+python examples/dllm_sft/prep_gsm8k.py
 ```
 
 **Full SFT:**
@@ -84,7 +85,8 @@ torchrun --standalone --nproc-per-node=8 \
 
 ## Training Results
 
-The SFT and LoRA training curves on GSM8K (first 200 steps) are shown below.
+The following sections show the SFT and LoRA training curves on the GSM8K dataset for the
+first 200 steps.
 
 **SFT**
 

--- a/docs/guides/dllm/diffusiongemma.md
+++ b/docs/guides/dllm/diffusiongemma.md
@@ -93,11 +93,3 @@ The SFT and LoRA training curves on GSM8K (first 200 steps) are shown below.
 **LoRA**
 
 ![DiffusionGemma LoRA training curves](./diffusiongemma_lora.png)
-
-
-## Requirements
-
-> **Note:** This recipe requires `transformers >= 5.11.0` — the `DiffusionGemma`
-> model was only added to `transformers` in 5.11, so earlier versions can't load
-> the checkpoint. Please install a compatible `transformers` version in your
-> environment before running this recipe.

--- a/docs/guides/dllm/diffusiongemma.mdx
+++ b/docs/guides/dllm/diffusiongemma.mdx
@@ -97,13 +97,3 @@ The SFT and LoRA training curves on GSM8K (first 200 steps) are shown below.
 <p align="center">
   <img src="https://raw.githubusercontent.com/NVIDIA-NeMo/Automodel/main/docs/guides/dllm/diffusiongemma_lora.png" alt="DiffusionGemma LoRA training curves" width="900" />
 </p>
-
-
-## Requirements
-
-> **Note:** This recipe requires `transformers >= 5.11.0` — the `DiffusionGemma`
-> model was only added to `transformers` in 5.11, so earlier versions can't load
-> **Note:** This recipe requires `transformers >= 5.11.0`. The `DiffusionGemma`
-> model was only added to `transformers` in 5.11, so earlier versions cannot load
-> the checkpoint. Install a compatible `transformers` version in your
-> environment before running this recipe.

--- a/docs/guides/dllm/diffusiongemma.mdx
+++ b/docs/guides/dllm/diffusiongemma.mdx
@@ -4,65 +4,66 @@
 
 **DiffusionGemma** is a block-diffusion language model. Unlike an autoregressive (AR)
 model that generates one token at a time left-to-right, a block-diffusion model fills in
-a block of response tokens (a "canvas") by **iteratively denoising** it: the canvas starts
-as noise and is refined over several passes, conditioned on the prompt.
+a block of response tokens (a "canvas") by iteratively denoising the canvas. The canvas
+starts as noise and is refined over several passes, conditioned on the prompt.
 
-This guide covers **supervised fine-tuning (SFT)** of the DiffusionGemma **26B-A4B** model
-(a Mixture-of-Experts model with 26B total / ~4B active parameters) in NeMo AutoModel,
-with both **full fine-tuning** and **LoRA**.
+This guide covers **Supervised Fine-Tuning (SFT)** of the DiffusionGemma **26B-A4B** model,
+which is a Mixture-of-Experts (MoE) model with 26B total and approximately 4B active parameters,
+using NeMo AutoModel with both full fine-tuning and Low-Rank Adaptation (LoRA).
 
 The released checkpoint is available on the Hugging Face Hub:
 [`google/diffusiongemma-26B-A4B-it`](https://huggingface.co/google/diffusiongemma-26B-A4B-it).
 
 ### Workflow Overview
 
-| Step | What you do |
-|------|-------------|
-| 1. Install | Install NeMo AutoModel (pip or container) |
-| 2. Configure | Pick an example YAML (full SFT or LoRA) and set your dataset |
-| 3. Train | Launch with `torchrun` on 8 GPUs |
-| 4. Inspect | Read the training/diffusion loss curves |
+| Step | What You Do |
+| :--- | :--- |
+| 1. Install | Install NeMo AutoModel using pip or a container |
+| 2. Configure | Select an example YAML configuration file for full SFT or LoRA, and specify your dataset |
+| 3. Train | Launch training with `torchrun` on eight GPUs |
+| 4. Inspect | Read the training and diffusion loss curves |
 
 ## Model Overview
 
-DiffusionGemma couples a **causal encoder** with a **bidirectional decoder**:
+DiffusionGemma combines a causal encoder and a bidirectional decoder:
 
-- **Encoder** reads the clean prompt + response sequence with causal attention.
-- **Decoder** denoises the **canvas** (the response region) with bidirectional
-  (block-causal) attention, predicting the clean token at every canvas position.
+- **Encoder**: Reads the clean prompt and response sequence with causal attention.
+- **Decoder**: Denoises the canvas (the response region) with bidirectional,
+  block-causal attention, predicting the clean token at every canvas position.
 
-Key training mechanics, all handled by the `DiffusionGemmaSFTRecipe`:
+The `DiffusionGemmaSFTRecipe` handles the following key training mechanics:
 
-- **Uniform-random corruption.** For each example a corruption level `t ~ U(eps, 1)`
-  is sampled; supervised canvas positions are independently replaced with **uniform random
-  vocabulary tokens** (there is no `[MASK]` token). The model learns to recover the clean
-  token at every supervised canvas position.
-- **Self-conditioning.** The decoder optionally conditions on its own previous prediction,
-  mixed in per example during training.
-- **Frozen router.** The MoE router is kept frozen during SFT; experts and dense layers
+- **Uniform-random corruption**: For each example, a corruption level
+  $t \sim U(\text{eps}, 1)$ is sampled, and supervised canvas positions are independently
+  replaced with uniform random vocabulary tokens (no `[MASK]` token is used). The model
+  learns to recover the clean token at every supervised canvas position.
+- **Self-conditioning**: The decoder optionally conditions on its own previous prediction,
+  which is mixed in per example during training.
+- **Frozen router**: The MoE router is kept frozen during SFT, and experts and dense layers
   are trained (full SFT) or adapted using LoRA.
-- **Single-turn SFT.** The loss supervises the final response turn; multi-turn histories
+- **Single-turn SFT**: The loss supervises the final response turn, and multi-turn histories
   are masked.
 
-The recipe uses **FSDP2 with expert parallelism (EP=8)** and **mixed precision**
-(fp32 master weights, bf16 compute), with a canvas length of 256.
+The recipe runs with **Fully Sharded Data Parallel 2 (FSDP2) and expert parallelism (EP=8)**
+and mixed precision (FP32 master weights and BF16 compute) with a canvas length of 256.
 
 ## Launch Training
 
-DiffusionGemma SFT runs on a single 8-GPU node (EP=8). Two example configs are provided
-under `examples/dllm_sft/`:
+DiffusionGemma SFT runs on a single eight-GPU node (EP=8). Two example configuration files
+are provided in the `examples/dllm_sft/` directory:
 
-| Config | Description |
-|--------|-------------|
-| [`diffusion_gemma_sft.yaml`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/dllm_sft/diffusion_gemma_sft.yaml) | Full fine-tune on [GSM8K](https://huggingface.co/datasets/openai/gsm8k) |
-| [`diffusion_gemma_lora.yaml`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/dllm_sft/diffusion_gemma_lora.yaml) | LoRA fine-tune  |
+| Configuration File | Description |
+| :--- | :--- |
+| [`diffusion_gemma_sft.yaml`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/dllm_sft/diffusion_gemma_sft.yaml) | Full fine-tuning on the [GSM8K](https://huggingface.co/datasets/openai/gsm8k) dataset |
+| [`diffusion_gemma_lora.yaml`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/dllm_sft/diffusion_gemma_lora.yaml) | LoRA fine-tuning |
 
-Both pull the checkpoint from the Hugging Face Hub
-(`google/diffusiongemma-26B-A4B-it`) automatically. GSM8K is consumed in OpenAI
-chat-messages format, so generate the JSONL once before launching:
+Both configurations automatically pull the checkpoint from the Hugging Face Hub
+(`google/diffusiongemma-26B-A4B-it`). Because the GSM8K dataset is consumed in the OpenAI
+chat-messages format, you must generate the JSONL file (`./gsm8k_chat_train.jsonl`) before
+launching training:
 
 ```bash
-python examples/dllm_sft/prep_gsm8k.py        # writes ./gsm8k_chat_train.jsonl
+python examples/dllm_sft/prep_gsm8k.py
 ```
 
 **Full SFT:**
@@ -84,7 +85,8 @@ torchrun --standalone --nproc-per-node=8 \
 
 ## Training Results
 
-The SFT and LoRA training curves on GSM8K (first 200 steps) are shown below.
+The following sections show the SFT and LoRA training curves on the GSM8K dataset for the
+first 200 steps.
 
 **SFT**
 

--- a/nemo_automodel/components/models/diffusion_gemma/__init__.py
+++ b/nemo_automodel/components/models/diffusion_gemma/__init__.py
@@ -20,18 +20,11 @@ The config classes are the released ``transformers`` ``DiffusionGemmaConfig`` /
 AM owns only the compute (model/layers/adapter).
 """
 
-from nemo_automodel.shared.import_utils import UnavailableMeta
-
-try:
-    from transformers.models.diffusion_gemma.configuration_diffusion_gemma import (
-        DiffusionGemmaConfig as DiffusionGemmaConfig,
-    )
-    from transformers.models.diffusion_gemma.configuration_diffusion_gemma import (
-        DiffusionGemmaTextConfig as DiffusionGemmaTextConfig,
-    )
-except (ModuleNotFoundError, ImportError):
-    _MSG = "transformers.models.diffusion_gemma is not available."
-    DiffusionGemmaConfig = UnavailableMeta("DiffusionGemmaConfig", (), {"_msg": _MSG})
-    DiffusionGemmaTextConfig = UnavailableMeta("DiffusionGemmaTextConfig", (), {"_msg": _MSG})
+from transformers.models.diffusion_gemma.configuration_diffusion_gemma import (
+    DiffusionGemmaConfig as DiffusionGemmaConfig,
+)
+from transformers.models.diffusion_gemma.configuration_diffusion_gemma import (
+    DiffusionGemmaTextConfig as DiffusionGemmaTextConfig,
+)
 
 __all__ = ["DiffusionGemmaConfig", "DiffusionGemmaTextConfig"]

--- a/nemo_automodel/components/models/diffusion_gemma/layers.py
+++ b/nemo_automodel/components/models/diffusion_gemma/layers.py
@@ -41,54 +41,31 @@ from __future__ import annotations
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from transformers.models.diffusion_gemma.configuration_diffusion_gemma import DiffusionGemmaTextConfig
+from transformers.models.diffusion_gemma.modeling_diffusion_gemma import (
+    DiffusionGemmaRMSNorm,
+    apply_rotary_pos_emb,
+    repeat_kv,
+)
+from transformers.models.diffusion_gemma.modeling_diffusion_gemma import (
+    DiffusionGemmaSelfConditioning as DiffusionGemmaSelfConditioning,
+)
+from transformers.models.diffusion_gemma.modeling_diffusion_gemma import (
+    DiffusionGemmaText4MLP as DiffusionGemmaMLP,
+)
+from transformers.models.diffusion_gemma.modeling_diffusion_gemma import (
+    DiffusionGemmaTextRotaryEmbedding as DiffusionGemmaTextRotaryEmbedding,
+)
 
-from nemo_automodel.shared.import_utils import UnavailableMeta
-
-
-def _make_missing(name: str):
-    return UnavailableMeta(name, (), {"_msg": "transformers diffusion_gemma implementation is not available."})
-
+from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.models.gemma4_moe.model import Gemma4MoE
+from nemo_automodel.components.moe.layers import MoEConfig
 
 # Leaf layers are reused directly from the released transformers diffusion_gemma
 # implementation so the model tracks Google's release. ``DiffusionGemmaMLP`` is
 # the reference's ``DiffusionGemmaText4MLP``. ``DiffusionGemmaRMSNorm`` /
 # ``DiffusionGemmaTextRotaryEmbedding`` / ``DiffusionGemmaSelfConditioning`` are
 # re-exported here because ``model.py`` and the backbone compose them.
-try:
-    from transformers.models.diffusion_gemma.configuration_diffusion_gemma import (
-        DiffusionGemmaTextConfig as DiffusionGemmaTextConfig,
-    )
-    from transformers.models.diffusion_gemma.modeling_diffusion_gemma import (
-        DiffusionGemmaRMSNorm as DiffusionGemmaRMSNorm,
-    )
-    from transformers.models.diffusion_gemma.modeling_diffusion_gemma import (
-        DiffusionGemmaSelfConditioning as DiffusionGemmaSelfConditioning,
-    )
-    from transformers.models.diffusion_gemma.modeling_diffusion_gemma import (
-        DiffusionGemmaText4MLP as DiffusionGemmaMLP,
-    )
-    from transformers.models.diffusion_gemma.modeling_diffusion_gemma import (
-        DiffusionGemmaTextRotaryEmbedding as DiffusionGemmaTextRotaryEmbedding,
-    )
-    from transformers.models.diffusion_gemma.modeling_diffusion_gemma import (
-        apply_rotary_pos_emb,
-        repeat_kv,
-    )
-
-    _FORK_AVAILABLE = True
-except (ModuleNotFoundError, ImportError):
-    _FORK_AVAILABLE = False
-    DiffusionGemmaTextConfig = _make_missing("DiffusionGemmaTextConfig")
-    DiffusionGemmaMLP = _make_missing("DiffusionGemmaMLP")
-    DiffusionGemmaRMSNorm = _make_missing("DiffusionGemmaRMSNorm")
-    DiffusionGemmaSelfConditioning = _make_missing("DiffusionGemmaSelfConditioning")
-    DiffusionGemmaTextRotaryEmbedding = _make_missing("DiffusionGemmaTextRotaryEmbedding")
-    apply_rotary_pos_emb = _make_missing("apply_rotary_pos_emb")
-    repeat_kv = _make_missing("repeat_kv")
-
-from nemo_automodel.components.models.common import BackendConfig
-from nemo_automodel.components.models.gemma4_moe.model import Gemma4MoE
-from nemo_automodel.components.moe.layers import MoEConfig
 
 
 def eager_attention_forward(

--- a/nemo_automodel/components/models/diffusion_gemma/model.py
+++ b/nemo_automodel/components/models/diffusion_gemma/model.py
@@ -42,35 +42,14 @@ from typing import Any
 
 import torch
 import torch.nn as nn
-
-from nemo_automodel.shared.import_utils import UnavailableError, UnavailableMeta
-
-
-def _make_missing(name: str):
-    return UnavailableMeta(name, (), {"_msg": "transformers diffusion_gemma backbone is not available."})
-
-
-try:
-    from transformers import PreTrainedModel
-    from transformers.modeling_outputs import CausalLMOutputWithPast
-    from transformers.models.diffusion_gemma.configuration_diffusion_gemma import (
-        DiffusionGemmaConfig as DiffusionGemmaConfig,
-    )
-    from transformers.models.diffusion_gemma.configuration_diffusion_gemma import (
-        DiffusionGemmaTextConfig as DiffusionGemmaTextConfig,
-    )
-    from transformers.models.diffusion_gemma.modeling_diffusion_gemma import (
-        DiffusionGemmaTextScaledWordEmbedding as ScaledWordEmbedding,
-    )
-
-    _TRANSFORMERS_AVAILABLE = True
-except (ModuleNotFoundError, ImportError):
-    _TRANSFORMERS_AVAILABLE = False
-    PreTrainedModel = _make_missing("PreTrainedModel")
-    CausalLMOutputWithPast = _make_missing("CausalLMOutputWithPast")
-    DiffusionGemmaConfig = _make_missing("DiffusionGemmaConfig")
-    DiffusionGemmaTextConfig = _make_missing("DiffusionGemmaTextConfig")
-    ScaledWordEmbedding = _make_missing("ScaledWordEmbedding")
+from transformers import PreTrainedModel
+from transformers.models.diffusion_gemma.configuration_diffusion_gemma import (
+    DiffusionGemmaConfig,
+    DiffusionGemmaTextConfig,
+)
+from transformers.models.diffusion_gemma.modeling_diffusion_gemma import (
+    DiffusionGemmaTextScaledWordEmbedding as ScaledWordEmbedding,
+)
 
 from nemo_automodel._transformers.model_capabilities import ModelCapabilities
 from nemo_automodel.components.models.common import BackendConfig
@@ -79,6 +58,7 @@ from nemo_automodel.components.models.common.utils import cast_model_to_dtype
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
 
+from .fsdp import register_diffusion_gemma_parallel_strategy
 from .layers import (
     DiffusionGemmaMoEDecoderLayer,
     DiffusionGemmaRMSNorm,
@@ -392,8 +372,6 @@ class DiffusionGemmaForBlockDiffusion(HFCheckpointingMixin, MoEFSDPSyncMixin, Pr
         freeze_router: bool | None = None,
         **kwargs: Any,
     ):
-        if not _TRANSFORMERS_AVAILABLE:
-            raise UnavailableError("transformers is not available; cannot construct DiffusionGemmaForBlockDiffusion.")
         # ``canvas_length`` is a declared field on the reference config (and round-trips),
         # so a YAML/from_pretrained override is written back onto it. The training-only
         # flags are NOT reference-config fields (it is a strict dataclass), so they live on
@@ -670,13 +648,10 @@ class DiffusionGemmaForBlockDiffusion(HFCheckpointingMixin, MoEFSDPSyncMixin, Pr
         return DiffusionGemmaOutput(logits=logits, encoder_logits=encoder_logits)
 
 
-if _TRANSFORMERS_AVAILABLE:
-    ModelClass = DiffusionGemmaForBlockDiffusion
+ModelClass = DiffusionGemmaForBlockDiffusion
 
-    # Register the pure-FSDP2 (ep_size=1) parallelization strategy so that
-    # get_parallelization_strategy() selects it for this model. Done here (not in
-    # the package __init__) so the parallelizer import — which pulls torch/FSDP —
-    # only runs in a torch-enabled environment, alongside model construction.
-    from .fsdp import register_diffusion_gemma_parallel_strategy
+# Register the pure-FSDP2 (ep_size=1) parallelization strategy so that
+# get_parallelization_strategy() selects it for this model. Done here (not in
+# the package __init__) so registration runs alongside model construction.
 
-    register_diffusion_gemma_parallel_strategy()
+register_diffusion_gemma_parallel_strategy()

--- a/tests/unit_tests/models/diffusion_gemma/test_diffusion_gemma_model.py
+++ b/tests/unit_tests/models/diffusion_gemma/test_diffusion_gemma_model.py
@@ -16,27 +16,11 @@
 
 These exercise construction, the single-shared-stack two-pass training forward,
 the END-TO-END leakage invariant on the composed forward (design v2 item 2),
-the frozen router, and the state-dict adapter round-trip. They do NOT need the
-transformers 5.8 fork (unlike the parity test), but they DO need torch + the
-``gemma4_moe`` MoE backend, so they only run where those import (the training
-container), not on a stock-transformers login node.
+the frozen router, and the state-dict adapter round-trip against the supported
+Transformers implementation.
 """
 
-import importlib.util
-
-import pytest
 import torch
-
-# The model reuses the fork's leaf layers + config (transformers.models.diffusion_gemma)
-# and the gemma4_moe MoE backend (transformers.models.gemma4); both ship in the 5.8-dev
-# fork wheel, so gate on the fork being importable.
-_FORK_AVAILABLE = importlib.util.find_spec("transformers.models.diffusion_gemma") is not None
-_GEMMA4_AVAILABLE = importlib.util.find_spec("transformers.models.gemma4") is not None
-
-pytestmark = pytest.mark.skipif(
-    not (_FORK_AVAILABLE and _GEMMA4_AVAILABLE),
-    reason="transformers.models.diffusion_gemma (5.8-dev fork) / gemma4 backend not available",
-)
 
 
 def _tiny_model(self_conditioning=True, freeze_router=True):
@@ -61,7 +45,7 @@ def _tiny_model(self_conditioning=True, freeze_router=True):
         top_k_experts=2,
         moe_intermediate_size=16,
     )
-    # self_conditioning/freeze_router are model-construction flags (not strict fork-config
+    # self_conditioning/freeze_router are model-construction flags (not strict HF-config
     # fields), so they are passed to the model, not the config.
     config = DiffusionGemmaConfig(text_config=text_cfg, vision_config=None, canvas_length=4)
     backend = BackendConfig(
@@ -290,7 +274,7 @@ def test_no_leakage_on_composed_forward():
 
 
 def test_state_dict_adapter_round_trip_native():
-    """Native -> HF -> native key/value round-trip (no fork needed)."""
+    """Native -> HF -> native key/value round-trip."""
     model, _ = _tiny_model(freeze_router=False)
     adapter = model.state_dict_adapter
     # The adapter downcasts converted weights to its dtype (the ckpt's bf16 in

--- a/tests/unit_tests/models/diffusion_gemma/test_diffusion_gemma_parity.py
+++ b/tests/unit_tests/models/diffusion_gemma/test_diffusion_gemma_parity.py
@@ -12,51 +12,38 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Numerical parity: native diffusion_gemma vs the transformers 5.8 fork.
+"""Numerical parity: native DiffusionGemma vs the Transformers reference.
 
-Builds a TINY random-config model both ways, loads the fork's weights into the
+Builds a tiny random-config model both ways, loads the reference weights into the
 native model via the state-dict adapter, and asserts that:
 
 1. ``from_hf`` -> ``to_hf`` round-trips the checkpoint keys/values exactly.
 2. The native shared stack (causal encoder pass + bidirectional canvas decode)
-   reproduces the fork's ``DiffusionGemmaForBlockDiffusion.forward`` logits
+   reproduces the reference ``DiffusionGemmaForBlockDiffusion.forward`` logits
    within fp32 tolerance.
 
 The native *training* forward uses a block-causal mask; here we drive the
-native ``encode``/``decode`` building blocks with the fork's **inference** mask
+native ``encode``/``decode`` building blocks with the reference **inference** mask
 (fully bidirectional canvas, causal encoder) so the comparison is apples to
 apples. The block-causal training mask is covered by
 ``test_diffusion_gemma_mask.py``.
 
-Requires the ``transformers`` ``diffusion_gemma`` model -- either the pinned
-5.8-dev fork or mainline transformers >= 5.11 (which upstreamed it). The whole
-module is skipped when it is absent so it does not break collection on a
-stock-transformers environment. ``diffusion_gemma`` is multimodal; the reference
-is built with a tiny throwaway vision tower (see ``_tiny_vision_config_dict``)
-and compared on the text path only.
+``diffusion_gemma`` is multimodal; the reference is built with a tiny throwaway
+vision tower (see ``_tiny_vision_config_dict``) and compared on the text path
+only.
 """
 
-import importlib.util
-import inspect
 import re
 
-import pytest
 import torch
-
-_FORK_AVAILABLE = importlib.util.find_spec("transformers.models.diffusion_gemma") is not None
-
-pytestmark = pytest.mark.skipif(
-    not _FORK_AVAILABLE,
-    reason="transformers.models.diffusion_gemma (5.8-dev fork) not available",
-)
 
 
 def _tiny_text_config_dict() -> dict:
-    """Tiny text-config shared by the fork and native configs.
+    """Tiny text config shared by the reference and native models.
 
     2 layers (one sliding, one full), hidden 64, 4 experts, canvas 8. The
     sliding window is larger than any sequence here so sliding == full
-    attention, matching the fork's eager no-padding inference path (which does
+    attention, matching the reference's eager no-padding inference path (which does
     not truncate by window in eager mode).
     """
     return dict(
@@ -87,15 +74,12 @@ def _tiny_text_config_dict() -> dict:
 def _tiny_vision_config_dict() -> dict:
     """Tiny ``gemma4_vision`` config so the multimodal reference can be built.
 
-    ``diffusion_gemma`` is a multimodal architecture. The pinned 5.8-dev fork
-    guarded the vision tower (``vision_config=None`` -> ``vision_tower=None``),
-    but mainline transformers (>= 5.11) dropped that guard and unconditionally
-    runs ``vision_tower = AutoModel.from_config(config.vision_config)``, so the
-    reference can no longer be constructed with ``vision_config=None``. Hand it a
-    *tiny* vision tower instead: it is built but never exercised -- both models
-    are compared on the text path only (no ``pixel_values``), the native model
-    ignores ``vision_config`` entirely, and the adapter drops all
-    ``model.encoder.*`` (vision) weights -- so it cannot perturb the comparison.
+    ``diffusion_gemma`` is a multimodal architecture, and the supported
+    Transformers implementation unconditionally constructs its vision tower.
+    Hand it a *tiny* tower: it is built but never exercised -- both models are
+    compared on the text path only (no ``pixel_values``), the native model ignores
+    ``vision_config`` entirely, and the adapter drops all ``model.encoder.*``
+    (vision) weights -- so it cannot perturb the comparison.
     """
     return dict(
         model_type="gemma4_vision",
@@ -111,15 +95,13 @@ def _tiny_vision_config_dict() -> dict:
     )
 
 
-def _build_fork_model(text_cfg: dict):
+def _build_hf_model(text_cfg: dict):
     from transformers.models.diffusion_gemma.configuration_diffusion_gemma import DiffusionGemmaConfig
     from transformers.models.diffusion_gemma.modeling_diffusion_gemma import (
         DiffusionGemmaForBlockDiffusion,
     )
 
-    config = DiffusionGemmaConfig(
-        text_config=dict(text_cfg), vision_config=_tiny_vision_config_dict(), canvas_length=8
-    )
+    config = DiffusionGemmaConfig(text_config=dict(text_cfg), vision_config=_tiny_vision_config_dict(), canvas_length=8)
     config._attn_implementation = "eager"
     model = DiffusionGemmaForBlockDiffusion(config).to(torch.float32).eval()
     return model, config
@@ -131,11 +113,9 @@ def _build_native_model(text_cfg: dict):
     from nemo_automodel.components.models.common import BackendConfig
     from nemo_automodel.components.models.diffusion_gemma.model import DiffusionGemmaForBlockDiffusion
 
-    # The native model now reuses the fork's config; self_conditioning/freeze_router are
+    # The native model reuses the HF config; self_conditioning/freeze_router are
     # model-construction flags (not strict config fields), so pass them to the model.
-    config = DiffusionGemmaConfig(
-        text_config=dict(text_cfg), vision_config=_tiny_vision_config_dict(), canvas_length=8
-    )
+    config = DiffusionGemmaConfig(text_config=dict(text_cfg), vision_config=_tiny_vision_config_dict(), canvas_length=8)
     backend = BackendConfig(attn="sdpa", linear="torch", rms_norm="torch_fp32", enable_hf_state_dict_adapter=True)
     model = (
         DiffusionGemmaForBlockDiffusion(config, backend=backend, self_conditioning=True, freeze_router=False)
@@ -146,12 +126,12 @@ def _build_native_model(text_cfg: dict):
 
 
 def test_state_dict_adapter_round_trip():
-    """``from_hf`` -> ``to_hf`` preserves the fork checkpoint keys and values."""
+    """``from_hf`` -> ``to_hf`` preserves the HF checkpoint keys and values."""
     text_cfg = _tiny_text_config_dict()
-    fork_model, _ = _build_fork_model(text_cfg)
+    hf_model, _ = _build_hf_model(text_cfg)
     native_model, _ = _build_native_model(text_cfg)
 
-    hf_sd = {k: v.clone() for k, v in fork_model.state_dict().items()}
+    hf_sd = {k: v.clone() for k, v in hf_model.state_dict().items()}
     adapter = native_model.state_dict_adapter
     # The adapter casts converted weights to its dtype (the ckpt's bf16 in real
     # use, which is correct). Here the reference models are fp32, so run the
@@ -162,7 +142,7 @@ def test_state_dict_adapter_round_trip():
     native_sd = adapter.from_hf(hf_sd)
     roundtrip = adapter.to_hf(native_sd)
 
-    # The fork ships encoder layer_scalar duplicates (tied) and a tied lm_head;
+    # The HF model ships encoder layer_scalar duplicates (tied) and a tied lm_head;
     # those are reconstructed/dropped, so compare on the decoder weights that
     # carry the actual parameters.
     hf_keys = {k for k in hf_sd if k.startswith("model.decoder.")}
@@ -190,17 +170,17 @@ def test_state_dict_adapter_round_trip():
             assert max_diff < 1e-5, f"round-trip mismatch for {key}: max_diff={max_diff}"
 
 
-def test_forward_parity_with_fork():
-    """Native encode+decode logits match the fork's forward within fp32 tol."""
+def test_forward_parity_with_hf():
+    """Native encode+decode logits match the HF forward within fp32 tolerance."""
     torch.manual_seed(0)
     text_cfg = _tiny_text_config_dict()
-    fork_model, fork_config = _build_fork_model(text_cfg)
+    hf_model, _ = _build_hf_model(text_cfg)
     native_model, _ = _build_native_model(text_cfg)
 
-    # Load fork weights into the native model. Run the adapter in fp32 so loaded
+    # Load HF weights into the native model. Run the adapter in fp32 so loaded
     # weights aren't bf16-rounded (the reference + native models are both fp32).
     native_model.state_dict_adapter.dtype = torch.float32
-    native_sd = native_model.state_dict_adapter.from_hf({k: v.clone() for k, v in fork_model.state_dict().items()})
+    native_sd = native_model.state_dict_adapter.from_hf({k: v.clone() for k, v in hf_model.state_dict().items()})
     missing, unexpected = native_model.load_state_dict(native_sd, strict=False)
     # Only non-persistent buffers (embed_scale, rope inv_freq, root_size) may be
     # "missing"; no parameter should be missing or unexpected.
@@ -214,20 +194,14 @@ def test_forward_parity_with_fork():
     canvas_ids = torch.randint(0, vocab, (batch_size, canvas_len))
 
     with torch.no_grad():
-        # ``canvas_ids`` was renamed ``decoder_input_ids`` when diffusion_gemma was
-        # upstreamed (5.8-dev fork -> mainline >= 5.11); pick whichever kwarg this
-        # transformers exposes so the test is version-agnostic.
-        canvas_kwarg = (
-            "decoder_input_ids"
-            if "decoder_input_ids" in inspect.signature(fork_model.forward).parameters
-            else "canvas_ids"
+        hf_out = hf_model(
+            input_ids=input_ids,
+            decoder_input_ids=canvas_ids,
+            self_conditioning_logits=None,
         )
-        fork_out = fork_model(
-            input_ids=input_ids, self_conditioning_logits=None, **{canvas_kwarg: canvas_ids}
-        )
-        fork_logits = fork_out.logits
+        hf_logits = hf_out.logits
 
-        # Native: drive the building blocks with the fork's inference mask
+        # Native: drive the building blocks with the reference inference mask
         # (causal encoder built inside ``encode``; fully-bidirectional canvas
         # = all-zero additive mask). Canvas positions continue after the prompt.
         encoder_position_ids = torch.arange(prompt_len).unsqueeze(0).expand(batch_size, -1)
@@ -245,10 +219,10 @@ def test_forward_parity_with_fork():
         )
         native_logits = native_model._softcap_logits(hidden)
 
-    assert native_logits.shape == fork_logits.shape
-    max_diff = (native_logits - fork_logits).abs().max().item()
+    assert native_logits.shape == hf_logits.shape
+    max_diff = (native_logits - hf_logits).abs().max().item()
     cos = torch.nn.functional.cosine_similarity(
-        native_logits.flatten().float(), fork_logits.flatten().float(), dim=0
+        native_logits.flatten().float(), hf_logits.flatten().float(), dim=0
     ).item()
     # Cosine similarity is the robust structural-parity gate (a real architectural
     # bug tanks it); keep it strict. The max-abs on softcapped logits (|.|<=30) is

--- a/tests/unit_tests/models/diffusion_gemma/test_diffusion_gemma_rope_fp32.py
+++ b/tests/unit_tests/models/diffusion_gemma/test_diffusion_gemma_rope_fp32.py
@@ -18,23 +18,9 @@
 ``{type}_inv_freq`` fp32 buffers. ``initialize_weights(dtype=torch.bfloat16)`` casts
 the model to bf16 via ``cast_model_to_dtype``; the model lists ``"rotary_emb"`` in
 ``_keep_in_fp32_modules`` so those buffers are restored to fp32. Runs on CPU.
-
-Skipped unless the ``transformers.models.diffusion_gemma`` fork is importable (it
-ships in the NGC container, not on PyPI), matching the other diffusion_gemma tests.
 """
 
-import importlib.util
-
-import pytest
 import torch
-
-_FORK_AVAILABLE = importlib.util.find_spec("transformers.models.diffusion_gemma") is not None
-_GEMMA4_AVAILABLE = importlib.util.find_spec("transformers.models.gemma4") is not None
-
-pytestmark = pytest.mark.skipif(
-    not (_FORK_AVAILABLE and _GEMMA4_AVAILABLE),
-    reason="requires the transformers diffusion_gemma fork (NGC container only)",
-)
 
 
 def _tiny_text_config_dict():


### PR DESCRIPTION
# What does this PR do ?

Update after AM upgrades to transformers to 5.12.1
