### PR TITLE
fix(docs): pin Fern VLM model slugs

### DIFF
--- a/.agents/contributor-skills/fern-docs/SKILL.md
+++ b/.agents/contributor-skills/fern-docs/SKILL.md
@@ -202,7 +202,42 @@ Use **version-agnostic** paths — no `/latest/`, `/v0.4/`, or `/nightly/` prefi
 [Llama coverage](/model-coverage/large-language-models/llama)
 ```
 
-The same MDX backs every version slug; a hard-coded prefix sends readers across versions unintentionally. URL slugs come from explicit `slug:` overrides in the version YAML (set during the migration so URLs stay short while sidebar titles match the verbose published H1s) — so `Install NeMo AutoModel` is at `/get-started/installation`, not `/get-started/install-nemo-automodel`.
+These are **Fern site-root routes**, not repository-relative links. They do not
+navigate correctly from GitHub's rendered source view because GitHub resolves a
+leading `/` against `github.com`. This is an expected limitation. Fern does not
+support file-relative `.md` or `.mdx` paths for inter-page links, so do not
+replace a deployed-site route with `./foo.mdx` or `../foo.mdx` to make GitHub
+navigation work. File-relative paths are still required for images and other
+page-scoped media.
+
+The same MDX backs every version slug; a hard-coded prefix sends readers across
+versions unintentionally. Treat the MDX link and the navigation `slug:` as one
+contract:
+
+1. Give every new page targeted by an internal link an explicit `slug:` in the
+   applicable version navigation YAML. Always pin slugs for display names with
+   acronyms, mixed capitalization, punctuation, or numbers; Fern's generated
+   slug may differ from the intended route.
+2. Make the last segment of the MDX link exactly match the explicit slug. For
+   example, `/model-coverage/vision-language-models/llava-onevision` requires
+   `slug: llava-onevision`, even if Fern would generate
+   `l-la-va-one-vision` from the display name.
+3. If the same page is mounted in multiple active version YAMLs, use the same
+   explicit slug in every applicable file. Do not fix only `nightly.yml` while
+   leaving `latest.yml` or a frozen version navigation entry on an implicit,
+   different route.
+4. When changing a published slug, add redirects in `docs/fern/docs.yml` for
+   both previously published versioned URLs and any unversioned URL emitted by
+   earlier Fern builds.
+5. Run `make docs-check`, then inspect the Fern preview for route-sensitive
+   changes. Confirm the rendered `href` includes the selected version and the
+   intended explicit slug. A missing version prefix can indicate that Fern did
+   not resolve the target against its navigation graph.
+
+During Sphinx-to-Fern migration, never translate a working filesystem link by
+guessing its final URL from the filename. First define the destination's
+explicit Fern slug, then update the MDX link to that published site path and
+preserve any former public route with a redirect.
 
 For cross-repo references (yaml configs, Python source), use absolute GitHub URLs:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,6 +249,28 @@ config state or cache runtime objects on the serializable config.
 
 ---
 
+## Fern Documentation Link Contract
+
+- Links between Fern documentation pages in MDX use version-agnostic,
+  site-root paths such as `/model-coverage/large-language-models/llama`. These
+  are Fern routes, not repository-relative paths. They intentionally do not
+  navigate from GitHub's rendered source view.
+- Do not replace Fern inter-page links with file-relative `.mdx` paths such as
+  `./meta/llama.mdx`; Fern does not support file-relative inter-page links.
+  File-relative paths remain correct for images and other page-scoped media.
+- New pages targeted by an internal link must have an explicit `slug:` in the
+  applicable version navigation YAML. Always pin slugs for display names with
+  acronyms, mixed capitalization, punctuation, or numbers; Fern's generated
+  slug may not match the intended URL.
+- Treat an MDX link and its navigation `slug:` as one contract. Keep the slug
+  identical in every active version YAML that mounts that page. When changing
+  a published slug, preserve the former versioned and unversioned routes with
+  redirects in `docs/fern/docs.yml`.
+- Read `.agents/contributor-skills/fern-docs/SKILL.md` before changing Fern
+  content, navigation, slugs, redirects, or versions.
+
+---
+
 ## Available Skills
 
 Skill files give step-by-step instructions an AI agent can follow. Public

--- a/docs/fern/README.md
+++ b/docs/fern/README.md
@@ -146,7 +146,36 @@ Use **version-agnostic paths** (no `/latest/`, `/v0.4/`, or `/nightly/` prefix):
 [LLM model list](/model-coverage/large-language-models/overview)
 ```
 
-The same MDX backs every version slug — a hard-coded prefix would jump readers across versions. Page slugs come from explicit `slug:` overrides in the version YAML, not from the (often verbose) display title — so `Install NeMo AutoModel` is at `/get-started/installation`, not `/get-started/install-nemo-automodel`.
+These are **Fern site-root routes**, not repository-relative links. A link that
+starts with `/` will not navigate correctly when the MDX is rendered on
+GitHub, because GitHub resolves it against `github.com`. That limitation is
+expected: Fern requires the published site path for inter-page links and does
+not support file-relative links such as `./meta/llama.mdx`. Do not trade a
+working Fern deployment for GitHub source-view navigation. File-relative paths
+remain correct for images and other page-scoped media. See Fern's
+[Markdown link rules](https://buildwithfern.com/learn/docs/writing-content/markdown-basics#links-in-markdown).
+
+The same MDX backs every version slug, so a hard-coded version prefix would
+jump readers across versions. Page routes are determined by `slug:` values in
+the version navigation YAML, not by the source filename. Treat every internal
+link and its destination `slug:` as one contract:
+
+- Give every new page targeted by an internal link an explicit `slug:`. Always
+  pin the slug when the display name contains acronyms, mixed capitalization,
+  punctuation, or numbers; Fern's generated value may differ from the intended
+  route.
+- Make the MDX link path exactly match the explicit navigation slug. For
+  example, `[LLaVA-OneVision](/model-coverage/vision-language-models/llava-onevision)`
+  requires `slug: llava-onevision` on that page entry.
+- If a page is mounted by more than one active version YAML, keep the explicit
+  slug identical in each applicable file (`nightly.yml`, `latest.yml`, and a
+  frozen version YAML).
+- If a published slug changes, add redirects in `docs.yml` for the former
+  versioned and unversioned URLs before publishing the new route.
+
+Run `make docs-check` after changing links or slugs. For route-sensitive
+changes, also inspect the Fern preview and confirm that the rendered `href`
+contains the selected version and the intended explicit slug.
 
 ### Cross-Repo References (YAML Configs, Source Files)
 

--- a/docs/fern/docs.yml
+++ b/docs/fern/docs.yml
@@ -78,6 +78,29 @@ redirects:
     destination: "/nemo/automodel/v0.4"
   - source: "/nemo/automodel/0.4/index"
     destination: "/nemo/automodel/v0.4"
+  # Preserve the auto-generated Fern routes replaced by explicit model slugs.
+  # Versioned rules keep readers on their selected documentation train; the
+  # unversioned rules preserve direct links emitted by earlier Fern builds.
+  - source: "/nemo/automodel/:version/model-coverage/vision-language-models/ministral-3-vl"
+    destination: "/nemo/automodel/:version/model-coverage/vision-language-models/ministral3-vl"
+  - source: "/nemo/automodel/model-coverage/vision-language-models/ministral-3-vl"
+    destination: "/nemo/automodel/model-coverage/vision-language-models/ministral3-vl"
+  - source: "/nemo/automodel/:version/model-coverage/vision-language-models/intern-vl"
+    destination: "/nemo/automodel/:version/model-coverage/vision-language-models/internvl"
+  - source: "/nemo/automodel/model-coverage/vision-language-models/intern-vl"
+    destination: "/nemo/automodel/model-coverage/vision-language-models/internvl"
+  - source: "/nemo/automodel/:version/model-coverage/vision-language-models/smol-vlm"
+    destination: "/nemo/automodel/:version/model-coverage/vision-language-models/smolvlm"
+  - source: "/nemo/automodel/model-coverage/vision-language-models/smol-vlm"
+    destination: "/nemo/automodel/model-coverage/vision-language-models/smolvlm"
+  - source: "/nemo/automodel/:version/model-coverage/vision-language-models/l-la-va"
+    destination: "/nemo/automodel/:version/model-coverage/vision-language-models/llava"
+  - source: "/nemo/automodel/model-coverage/vision-language-models/l-la-va"
+    destination: "/nemo/automodel/model-coverage/vision-language-models/llava"
+  - source: "/nemo/automodel/:version/model-coverage/vision-language-models/l-la-va-one-vision"
+    destination: "/nemo/automodel/:version/model-coverage/vision-language-models/llava-onevision"
+  - source: "/nemo/automodel/model-coverage/vision-language-models/l-la-va-one-vision"
+    destination: "/nemo/automodel/model-coverage/vision-language-models/llava-onevision"
   # Older un-migrated versions (0.3.0, 0.2.0, 0.1.0) — fold all paths into
   # /latest/<same-path>. We don't host their content trees on Fern; this
   # keeps old bookmarks and search-engine results landing on the closest

--- a/docs/fern/versions/latest.yml
+++ b/docs/fern/versions/latest.yml
@@ -177,20 +177,25 @@ navigation:
             path: ./v0.4/pages/model-coverage/vlm/nvidia/nemotron-parse.mdx
           - page: "Ministral3 VL"
             path: ./v0.4/pages/model-coverage/vlm/mistralai/ministral3-vl.mdx
+            slug: ministral3-vl
           - page: "Mistral Medium 3.5"
             path: ./v0.4/pages/model-coverage/vlm/mistralai/mistral-medium-3-5.mdx
           - page: "Mistral-Small-4"
             path: ./v0.4/pages/model-coverage/vlm/mistralai/mistral-small-4.mdx
           - page: "InternVL"
             path: ./v0.4/pages/model-coverage/vlm/internlm/internvl.mdx
+            slug: internvl
           - page: "Llama 4"
             path: ./v0.4/pages/model-coverage/vlm/meta/llama4.mdx
           - page: "LLaVA-OneVision"
             path: ./v0.4/pages/model-coverage/vlm/lmms-lab/llava-onevision.mdx
+            slug: llava-onevision
           - page: "SmolVLM"
             path: ./v0.4/pages/model-coverage/vlm/huggingface/smolvlm.mdx
+            slug: smolvlm
           - page: "LLaVA"
             path: ./v0.4/pages/model-coverage/vlm/llava-hf/llava.mdx
+            slug: llava
       - section: "Omni Models"
         slug: omni
         contents:

--- a/docs/fern/versions/nightly.yml
+++ b/docs/fern/versions/nightly.yml
@@ -212,6 +212,7 @@ navigation:
             path: ../../model-coverage/vlm/nvidia/nemotron-parse.mdx
           - page: "Ministral3 VL"
             path: ../../model-coverage/vlm/mistralai/ministral3-vl.mdx
+            slug: ministral3-vl
           - page: "Mistral Medium 3.5"
             path: ../../model-coverage/vlm/mistralai/mistral-medium-3-5.mdx
             slug: mistral-medium-3-5
@@ -219,14 +220,18 @@ navigation:
             path: ../../model-coverage/vlm/mistralai/mistral-small-4.mdx
           - page: "InternVL"
             path: ../../model-coverage/vlm/internlm/internvl.mdx
+            slug: internvl
           - page: "Llama 4"
             path: ../../model-coverage/vlm/meta/llama4.mdx
           - page: "LLaVA-OneVision"
             path: ../../model-coverage/vlm/lmms-lab/llava-onevision.mdx
+            slug: llava-onevision
           - page: "SmolVLM"
             path: ../../model-coverage/vlm/huggingface/smolvlm.mdx
+            slug: smolvlm
           - page: "LLaVA"
             path: ../../model-coverage/vlm/llava-hf/llava.mdx
+            slug: llava
           - page: "Step-3.7-Flash"
             path: ../../model-coverage/vlm/stepfun-ai/step-3-7.mdx
             slug: step-3-7-flash

--- a/docs/fern/versions/v0.4.yml
+++ b/docs/fern/versions/v0.4.yml
@@ -177,20 +177,25 @@ navigation:
             path: ./v0.4/pages/model-coverage/vlm/nvidia/nemotron-parse.mdx
           - page: "Ministral3 VL"
             path: ./v0.4/pages/model-coverage/vlm/mistralai/ministral3-vl.mdx
+            slug: ministral3-vl
           - page: "Mistral Medium 3.5"
             path: ./v0.4/pages/model-coverage/vlm/mistralai/mistral-medium-3-5.mdx
           - page: "Mistral-Small-4"
             path: ./v0.4/pages/model-coverage/vlm/mistralai/mistral-small-4.mdx
           - page: "InternVL"
             path: ./v0.4/pages/model-coverage/vlm/internlm/internvl.mdx
+            slug: internvl
           - page: "Llama 4"
             path: ./v0.4/pages/model-coverage/vlm/meta/llama4.mdx
           - page: "LLaVA-OneVision"
             path: ./v0.4/pages/model-coverage/vlm/lmms-lab/llava-onevision.mdx
+            slug: llava-onevision
           - page: "SmolVLM"
             path: ./v0.4/pages/model-coverage/vlm/huggingface/smolvlm.mdx
+            slug: smolvlm
           - page: "LLaVA"
             path: ./v0.4/pages/model-coverage/vlm/llava-hf/llava.mdx
+            slug: llava
       - section: "Omni Models"
         slug: omni
         contents:


### PR DESCRIPTION
## Summary

- pin the five VLM page slugs that Fern currently derives differently from their authored model-coverage links
- apply the same explicit slugs to nightly, latest, and v0.4 navigation
- redirect the previous auto-generated versioned and unversioned URLs to preserve existing bookmarks
- document the Fern site-root link requirement, GitHub source-view limitation, explicit-slug criteria, and version/redirect checklist in `AGENTS.md`, the Fern README, and the contributor skill

## Root cause

The Fern migration converted working Sphinx file links into version-agnostic URL paths based on the source filenames. The corresponding navigation entries did not receive explicit `slug:` values, so Fern instead generated routes from display names such as `InternVL` and `LLaVA-OneVision`. Those generated routes (`intern-vl`, `l-la-va-one-vision`, and similar) did not match the authored links (`internvl`, `llava-onevision`), causing the unresolved links to render without a version prefix and return 404.

## Impact

The VLM overview links for Ministral3 VL, InternVL, SmolVLM, LLaVA, and LLaVA-OneVision resolve within the reader's selected documentation version. Existing links to Fern's previously generated routes continue to work through redirects.

Future contributors and agents are explicitly warned not to replace Fern inter-page routes with GitHub-friendly file-relative links, and to keep linked slugs aligned across every applicable version navigation file.

This addresses the VLM model-coverage subset reported in NVBug 6179245.

## Validation

- `make -C docs/fern docs-check`
  - stitched the frozen v0.4 pages from `docs-archive`
  - validated 290 MDX files
  - `fern check`: 0 errors (the optional historical-redirect check warned because the remote Fern registry was unavailable)
- targeted consistency check confirming each authored VLM link has the same explicit slug in nightly, latest, and v0.4 navigation
- `git diff --check`
