### PR TITLE
fix(ci): use HybridEP for Step 3.5 benchmark

### DIFF
--- a/examples/llm_benchmark/step/step_3.5_flash_te_deepep.yaml
+++ b/examples/llm_benchmark/step/step_3.5_flash_te_deepep.yaml
@@ -80,7 +80,7 @@ model:
     rms_norm: te
     rope_fusion: true
     experts: gmm
-    dispatcher: deepep
+    dispatcher: hybridep  # DeepEP timed out in multi-node EP32 CI.
     fake_balanced_gate: true
     enable_hf_state_dict_adapter: true
     enable_fsdp_optimizations: true


### PR DESCRIPTION
## Summary

Switch the Step 3.5 Flash benchmark MoE dispatcher from DeepEP to HybridEP.

AM-673 failed in `step_3.5_flash_te_deepep` with a DeepEP CPU dispatch timeout during MoE fused all-to-all. The PyTorch pipeline wrapper surfaced the error as a Stage 1 forward failure with a bfloat16 tensor and `position_ids`, but the direct exception is `RuntimeError: DeepEP error: timeout (dispatch CPU)`.

This follows the same mitigation already used by other large multi-node MoE benchmark recipes that retained `_deepep` names but now run with `dispatcher: hybridep`.

## Regression

- Linear: AM-673
- Failing job: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/361011816
- Failing pipeline: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/57693236
- Original container: `gitlab-master.nvidia.com/dl/joc/nemo-ci/main/automodel:pipe.57691354`
- The recipe still used `dispatcher: deepep`; similar large multi-node MoE recipes were previously moved to HybridEP in `50a12b7c` and `5e0ccc1e` after DeepEP timeout failures.

## Validation

- `git diff --check`
- YAML parse smoke check for dispatcher, experts, EP, and PP settings
- Same-container NeMo-CI proof is running:
  - Parent pipeline: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/58041163
  - AutoModel child pipeline: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/58041187
  - Leaf pipeline: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/58041217
  - Leaf job: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/363414082

Same-container proof details:

- `TEST_IMAGE=gitlab-master.nvidia.com/dl/joc/nemo-ci/main/automodel:pipe.57691354`
- `FINETUNE_ARGS=--model.backend.dispatcher=hybridep`
- Trace confirms `dispatcher: hybridep`
- Current status when posted: running, reached iteration 20 with no `DeepEP error` or `RuntimeError` in trace
