### PR TITLE
feat(speculative): add Gemma4 EAGLE-3 target support

### DIFF
--- a/docs/guides/speculative/eagle.mdx
+++ b/docs/guides/speculative/eagle.mdx
@@ -138,6 +138,34 @@ Key components:
   `0.8^i`, teaching the drafter to make multi-step predictions — exactly what
   speculative decoding needs.
 
+### Supported Target Architectures
+
+The target is resolved from its HF `config.architectures` string through the
+registry in `components/speculative/eagle/registry.py`. Most dense and MoE
+decoders reuse the config-driven Llama-style draft (a one-line registry entry);
+architectures whose RoPE or attention layout the shared draft cannot represent
+get a thin dedicated draft class.
+
+| Target | Draft |
+|--------|-------|
+| Llama, Phi-3, Qwen3 dense, Qwen3-MoE | shared Llama-style dense draft |
+| gpt-oss (`GptOssForCausalLM`) | dedicated draft reproducing gpt-oss YaRN RoPE |
+| DeepSeek-V3 (`DeepseekV3ForCausalLM`) | dedicated MLA draft |
+| Gemma4 (`Gemma4ForConditionalGeneration`) | thin dedicated draft (see below) |
+
+**Gemma4.** Gemma4 ships as a multimodal `Gemma4ForConditionalGeneration` whose
+text decoder config is nested under `config.text_config`; the draft is built
+from that inner config automatically. Set `target_force_hf: true` so the stock
+HuggingFace text-capable model is loaded (the draft hooks the decoder under
+`model.language_model.layers`). The draft consumes only post-block hidden states,
+so it is the same Llama-style dense draft used elsewhere, with two Gemma quirks
+reconciled: the `hidden_activation` (GeGLU) key and Gemma4's nested
+per-attention-type `rope_parameters`, which is flattened to a standard
+full-rotary Llama RoPE on the global (full-attention) base. The saved checkpoint
+keeps the canonical `architectures: ["LlamaEagle3DraftModel"]` layout, so SGLang
+and vLLM serve it with their existing EAGLE-3 Llama head. See
+`examples/speculative/eagle3/gemma4_e2b_eagle3.yaml`.
+
 ### EAGLE-3.1 Drafter Toggles
 
 The same `train_eagle3` recipe supports the EAGLE-3.1 drafter variant via two

--- a/examples/speculative/eagle3/gemma4_e2b_eagle3.yaml
+++ b/examples/speculative/eagle3/gemma4_e2b_eagle3.yaml
@@ -1,0 +1,65 @@
+recipe: TrainEagle3Recipe
+
+# EAGLE-3 draft training against a Gemma4 target (E2B-it).
+#
+# Gemma4 ships as a multimodal ``Gemma4ForConditionalGeneration`` whose text
+# decoder config is nested under ``config.text_config``; the EAGLE-3 draft is
+# built from that inner text config automatically (via ``config.get_text_config()``).
+# Two Gemma-specific knobs:
+#
+#   * ``target_force_hf: true`` -- load the stock HuggingFace text-capable
+#     ``Gemma4ForConditionalGeneration`` (the ``gemma4`` model_type maps to it in
+#     transformers' AutoModelForCausalLM registry). A text-only forward returns
+#     ``.logits`` and the draft hooks the decoder under
+#     ``model.language_model.layers``.
+#   * The draft flattens Gemma4's nested per-attention-type RoPE to a standard
+#     full-rotary Llama RoPE on the global (full-attention) base, so the saved
+#     checkpoint (``architectures: ["LlamaEagle3DraftModel"]``) loads into
+#     SGLang / vLLM with their existing EAGLE-3 Llama head.
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 30
+
+recipe_args:
+  target_model_name_or_path: google/gemma-4-E2B-it
+  target_force_hf: true
+  # Gemma4 interleaves sliding-window and full attention; sdpa handles both
+  # masks cleanly for the frozen target.
+  target_attn_implementation: sdpa
+  draft_attn_implementation: flash_attention_2
+  train_data_path: ./cache/dataset/perfectblend-gemma4-e2b-regen-messages
+  val_data_path: null
+  train_split: "train[:50]"
+  val_split: null
+  output_dir: ./outputs/eagle3_gemma4_e2b
+  seq_length: 4096
+  micro_batch_size: 1
+  grad_accumulation_steps: 1
+  num_workers: 0
+  num_epochs: 1
+  ttt_steps: 7
+  # Gemma4 has a 262k vocab; compress the draft head to the most frequent 32k
+  # target ids (d2t/t2d remap tables are serialized into the checkpoint).
+  draft_vocab_size: 32000
+  freeze_embeddings: true
+  trust_remote_code: false
+  shuffle_seed: 42
+  log_every_steps: 10
+  max_grad_norm: 1.0
+
+  # Sequence packing (EAGLE-3, colocated backend only). > 0 packs variable-length
+  # samples into rows of this width with per-document block-causal attention,
+  # removing padding waste. Set to seq_length (or larger); 0 disables.
+  packed_sequence_size: 4096
+
+optimizer:
+  lr: 1.0e-4
+  betas: [0.9, 0.95]
+  weight_decay: 0.0
+
+checkpoint:
+  enabled: true
+  checkpoint_dir: ./outputs/eagle3_gemma4_e2b/checkpoints
+  model_save_format: safetensors
+  save_consolidated: true

--- a/nemo_automodel/components/speculative/eagle/draft_gemma.py
+++ b/nemo_automodel/components/speculative/eagle/draft_gemma.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""EAGLE-3 draft model for Gemma4 targets (``Gemma4ForConditionalGeneration``).
+
+Gemma4 is a multimodal decoder whose *text* backbone differs from a Llama-style
+dense LLM in a handful of ways: a scaled word embedding (``* sqrt(hidden)``),
+zero-centred ``(1 + w)`` RMSNorm, per-head Q/K norm, GeGLU (``gelu_pytorch_tanh``)
+MLPs, alternating sliding-window / full attention with two separate RoPE
+schedules, and (on the E2B/E4B checkpoints) Gemma-3n-style per-layer inputs and
+AltUp. Almost none of that reaches the EAGLE-3 *draft*: the draft is a single
+from-scratch decoder layer that consumes only the post-block auxiliary hidden
+states emitted by the frozen target (via ``register_forward_hook``) and
+re-projects its own Q/K/V, so it never sees the target's sliding mask, per-layer
+inputs, AltUp, or experts -- structurally it is the same Llama-style dense draft
+used for every other registry entry. The draft's own RMSNorms are trained from
+scratch, so the target's zero-centred norm form does not need to be reproduced,
+and the constant embedding scale is normalised away by the draft's
+``input_layernorm`` before the fused ``[embed, hidden]`` attention input.
+
+Three config quirks *do* have to be reconciled before the shared Llama draft can
+build, and that is all this module does (see :func:`_normalize_gemma4_draft_config`):
+
+1. **Activation key.** Gemma text configs name the MLP activation
+   ``hidden_activation`` (``gelu_pytorch_tanh``); the shared MLP reads
+   ``config.hidden_act``. The GeGLU structure is identical to the draft's SwiGLU
+   wiring once the activation is ``gelu_pytorch_tanh``, so we copy the value
+   across.
+2. **RoPE.** Gemma4 stores a nested, per-attention-type ``rope_parameters``
+   (``full_attention``: ``rope_theta=1e6``, ``rope_type="proportional"``,
+   ``partial_rotary_factor=0.25``; ``sliding_attention``: ``rope_theta=1e4``,
+   ``rope_type="default"``) that the shared ``LlamaRotaryEmbedding`` cannot read
+   -- its ``_get_rope_config`` expects a flat ``rope_theta`` and would silently
+   fall back to base ``10000``. The single draft layer runs *full* causal
+   attention over the whole sequence, so it mirrors the target's **global**
+   (full-attention) schedule. We flatten that schedule to a standard
+   full-rotary Llama RoPE (``rope_theta`` = the global theta, ``head_dim`` from
+   the config, no partial rotary). Training and inference are then
+   self-consistent: the saved checkpoint keeps the canonical
+   ``architectures: ["LlamaEagle3DraftModel"]`` string and a flat ``rope_theta``,
+   so SGLang / vLLM reproduce the exact same rotary with their existing EAGLE-3
+   Llama head -- no Gemma-specific inference support is required. (Reproducing
+   the target's ``proportional`` + partial-rotary global schedule instead would
+   be more faithful to the target's long-context frequencies but no inference
+   engine can currently serve it, so it is intentionally not done here.)
+3. **MoE FFN width.** On a MoE Gemma4 (``enable_moe_block``) the config
+   ``intermediate_size`` is the *per-expert* FFN width (e.g. 2112 on 26B-A4B,
+   *below* ``hidden_size`` 2816). The dense draft would otherwise build a
+   contracting MLP and be starved of capacity, so the draft MLP is sized to the
+   target's *active* FFN width (``top_k_experts * intermediate_size``). Dense
+   targets are untouched.
+
+Everything else (GQA, the EAGLE-3 TTT cache attention, the ``fc`` projection,
+the draft ``lm_head`` and vocab mapping) is inherited unchanged from
+:class:`LlamaEagle3DraftModel`, and the on-disk state-dict layout is identical.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from transformers import PretrainedConfig
+
+from nemo_automodel.components.speculative.eagle.draft_llama import LlamaEagle3DraftModel
+
+logger = logging.getLogger(__name__)
+
+# Fallback global RoPE base if a Gemma4 config omits the nested ``rope_parameters``
+# (all shipped Gemma4 checkpoints set it; this only guards a hand-written config).
+_DEFAULT_GLOBAL_ROPE_THETA = 1_000_000.0
+
+
+def _extract_global_rope_theta(config: PretrainedConfig) -> float:
+    """Return the full-attention (global) RoPE base for the Gemma4 text config.
+
+    Gemma4 nests RoPE parameters per attention type under
+    ``config.rope_parameters`` -- ``{"full_attention": {"rope_theta": ...},
+    "sliding_attention": {"rope_theta": ...}}``. The draft runs full causal
+    attention, so it uses the ``full_attention`` base. Falls back to a flat
+    ``rope_theta`` attribute and then to :data:`_DEFAULT_GLOBAL_ROPE_THETA`.
+    """
+    rope_params = getattr(config, "rope_parameters", None)
+    if isinstance(rope_params, dict):
+        full = rope_params.get("full_attention")
+        if isinstance(full, dict) and full.get("rope_theta") is not None:
+            return float(full["rope_theta"])
+    flat_theta = getattr(config, "rope_theta", None)
+    if flat_theta is not None:
+        return float(flat_theta)
+    return _DEFAULT_GLOBAL_ROPE_THETA
+
+
+def _normalize_gemma4_draft_config(config: PretrainedConfig) -> None:
+    """Reconcile Gemma4 text-config quirks in place so the Llama draft can build.
+
+    Sets ``hidden_act`` from Gemma's ``hidden_activation`` and flattens the
+    nested ``rope_parameters`` to a standard full-rotary Llama RoPE keyed on the
+    global (full-attention) ``rope_theta`` (see the module docstring). Mutates
+    ``config`` so the draft's serialized ``config.json`` carries the flattened,
+    inference-reproducible RoPE.
+    """
+    # 1. Activation: gemma names it ``hidden_activation``; the shared MLP reads
+    #    ``hidden_act``. Only set when absent so an explicit override is honored.
+    if getattr(config, "hidden_act", None) is None:
+        hidden_activation = getattr(config, "hidden_activation", None)
+        if hidden_activation is None:
+            raise ValueError(
+                "Gemma4Eagle3DraftModel: config exposes neither 'hidden_act' nor 'hidden_activation'; "
+                "cannot build the draft MLP activation."
+            )
+        config.hidden_act = hidden_activation
+
+    # 2. RoPE: flatten the nested per-attention-type schedule to a standard
+    #    full-rotary Llama RoPE on the global base. Clearing ``rope_parameters``
+    #    routes ``_get_rope_config`` down the flat ``rope_theta`` path.
+    config.rope_theta = _extract_global_rope_theta(config)
+    config.rope_parameters = None
+    config.rope_scaling = None
+    # The draft uses the config ``head_dim`` (256 on all Gemma4 sizes) with full
+    # rotary; the target's global-attention ``partial_rotary_factor`` (0.25) and
+    # larger ``global_head_dim`` (512) apply only inside the frozen target.
+    config.partial_rotary_factor = 1.0
+
+    # 3. MoE targets: the draft is a dense model, but on a MoE Gemma4
+    #    (``enable_moe_block``) the config ``intermediate_size`` is the *per-expert*
+    #    FFN width -- e.g. 2112 on the 26B-A4B target, which is smaller than
+    #    ``hidden_size`` (2816). Left as-is the dense draft would build a
+    #    *contracting* MLP (down-projecting below the residual width), starving it
+    #    of capacity relative to every dense sibling (whose ``intermediate_size``
+    #    is the full ~4x FFN). Size the draft MLP to the target's *active* FFN
+    #    width instead -- ``top_k_experts`` experts run per token -- so it matches
+    #    the per-token feed-forward compute the target actually applies. Dense
+    #    Gemma4 targets have ``enable_moe_block`` False and are left untouched.
+    if getattr(config, "enable_moe_block", False):
+        top_k = int(getattr(config, "top_k_experts", None) or 1)
+        config.intermediate_size = int(config.intermediate_size) * top_k
+
+
+class Gemma4Eagle3DraftModel(LlamaEagle3DraftModel):
+    """EAGLE-3 draft model for Gemma4 targets.
+
+    Identical to :class:`LlamaEagle3DraftModel` except that the Gemma4 text
+    config is normalized (activation key + flattened global RoPE) before the
+    shared draft is constructed. See the module docstring for the rationale;
+    the on-disk checkpoint is byte-for-byte a standard ``LlamaEagle3DraftModel``
+    export so SGLang / vLLM load it with their existing EAGLE-3 Llama head.
+    """
+
+    def __init__(self, config: PretrainedConfig):
+        _normalize_gemma4_draft_config(config)
+        super().__init__(config)

--- a/nemo_automodel/components/speculative/eagle/registry.py
+++ b/nemo_automodel/components/speculative/eagle/registry.py
@@ -41,6 +41,7 @@ from dataclasses import dataclass
 from transformers import PreTrainedModel
 
 from nemo_automodel.components.speculative.eagle.draft_deepseek import DeepseekV3Eagle3DraftModel
+from nemo_automodel.components.speculative.eagle.draft_gemma import Gemma4Eagle3DraftModel
 from nemo_automodel.components.speculative.eagle.draft_gpt_oss import GptOssEagle3DraftModel
 from nemo_automodel.components.speculative.eagle.draft_llama import LlamaEagle3DraftModel
 from nemo_automodel.components.speculative.eagle.draft_llama_v12 import LlamaEagleDraftModel
@@ -83,6 +84,18 @@ EAGLE3_DRAFT_REGISTRY["GptOssForCausalLM"] = DraftSpec(draft_cls=GptOssEagle3Dra
 # q/k head dim) cannot be represented by the Llama-style dense draft, so it gets a
 # dedicated MLA draft -- see ``draft_deepseek.py``. Only EAGLE-3 is wired up.
 EAGLE3_DRAFT_REGISTRY["DeepseekV3ForCausalLM"] = DraftSpec(draft_cls=DeepseekV3Eagle3DraftModel)
+
+# Gemma4 multimodal target (``Gemma4ForConditionalGeneration``). The draft is
+# Llama-style dense (it consumes only post-block hidden states from the frozen
+# target's text backbone), but the Gemma4 *text* config needs two quirks
+# reconciled before the shared draft can build -- the ``hidden_activation`` key
+# and the nested per-attention-type ``rope_parameters`` -- so it gets a thin
+# dedicated draft class. See ``draft_gemma.py`` for the rationale. The target's
+# decoder config is nested under ``config.text_config`` (the draft is built from
+# it via ``config.get_text_config()`` in the recipe) and its decoder layers live
+# under ``model.language_model.layers`` (handled by the target wrapper's
+# ``_get_transformer_layers``). Only EAGLE-3 is wired up.
+EAGLE3_DRAFT_REGISTRY["Gemma4ForConditionalGeneration"] = DraftSpec(draft_cls=Gemma4Eagle3DraftModel)
 
 
 EAGLE1_DRAFT_REGISTRY: dict[str, DraftSpec] = {

--- a/nemo_automodel/components/speculative/eagle/target.py
+++ b/nemo_automodel/components/speculative/eagle/target.py
@@ -191,12 +191,26 @@ class HFEagle3TargetModel(Eagle3TargetBackend):
                 f"Expected {len(self.aux_layer_ids)} captured aux layers but got {len(captured)}: {sorted(captured)}"
             )
 
+    def _num_hidden_layers(self) -> int:
+        """Return the target's decoder depth.
+
+        Multimodal targets (e.g. ``Gemma4ForConditionalGeneration``) carry no
+        top-level ``num_hidden_layers``; the text backbone's depth lives on
+        ``config.text_config``. Text-only targets (and the lightweight config
+        stubs used in tests) expose ``num_hidden_layers`` directly.
+        """
+        config = self.model.config
+        text_config = getattr(config, "text_config", None)
+        if text_config is not None and getattr(text_config, "num_hidden_layers", None) is not None:
+            return text_config.num_hidden_layers
+        return config.num_hidden_layers
+
     def _default_aux_layer_ids(self) -> list[int]:
-        return default_eagle3_aux_layer_ids(self.model.config.num_hidden_layers)
+        return default_eagle3_aux_layer_ids(self._num_hidden_layers())
 
     def _validate_aux_layer_ids(self, aux_layer_ids: Sequence[int]) -> list[int]:
         """Validate aux-layer selection before any forward hooks are registered."""
-        return validate_eagle3_aux_layer_ids(aux_layer_ids, self.model.config.num_hidden_layers)
+        return validate_eagle3_aux_layer_ids(aux_layer_ids, self._num_hidden_layers())
 
     def _get_transformer_layers(self) -> list[nn.Module]:
         """Return decoder layers as an ordered list indexable by integer.
@@ -208,11 +222,21 @@ class HFEagle3TargetModel(Eagle3TargetBackend):
         ``register_forward_hook`` calls.
         """
         # Common HF causal-LM layouts:
-        #   model.model.layers              (Llama, Qwen, Mistral, Gemma, Phi, ...)
-        #   model.layers                    (some VLM text backbones exposed directly)
-        #   model.transformer.h             (GPT2 / Falcon-style)
+        #   model.model.layers                     (Llama, Qwen, Mistral, Gemma, Phi, ...)
+        #   model.model.language_model.layers      (multimodal wrappers: Gemma4ForConditionalGeneration)
+        #   model.language_model.layers            (some VLM text backbones nested one level up)
+        #   model.layers                           (some VLM text backbones exposed directly)
+        #   model.transformer.h                    (GPT2 / Falcon-style)
         if hasattr(self.model, "model") and hasattr(self.model.model, "layers"):
             container = self.model.model.layers
+        elif (
+            hasattr(self.model, "model")
+            and hasattr(self.model.model, "language_model")
+            and hasattr(self.model.model.language_model, "layers")
+        ):
+            container = self.model.model.language_model.layers
+        elif hasattr(self.model, "language_model") and hasattr(self.model.language_model, "layers"):
+            container = self.model.language_model.layers
         elif hasattr(self.model, "layers"):
             container = self.model.layers
         elif hasattr(self.model, "transformer") and hasattr(self.model.transformer, "h"):

--- a/nemo_automodel/recipes/llm/peagle_recipe.py
+++ b/nemo_automodel/recipes/llm/peagle_recipe.py
@@ -37,7 +37,7 @@ class PeagleRecipeMixin:
     # the train loop then drives the per-segment forward/backward step.
     _peagle_partitioned = False
 
-    def _configure_peagle_draft_config(self, recipe_cfg, draft_config, target_config) -> int:
+    def _configure_peagle_draft_config(self, recipe_cfg, draft_config, draft_base_config) -> int:
         """Validate P-EAGLE recipe args and populate ``draft_config``; return ``mask_token_id``.
 
         Mutates ``draft_config`` in place with the P-EAGLE keys (``mask_token_id``,
@@ -63,10 +63,10 @@ class PeagleRecipeMixin:
                 "at serve time."
             )
         mask_token_id = int(mask_token_id)
-        if not 0 <= mask_token_id < target_config.vocab_size:
+        if not 0 <= mask_token_id < draft_base_config.vocab_size:
             raise ValueError(
                 f"mask_token_id={mask_token_id} is out of range for the target vocab "
-                f"[0, {target_config.vocab_size}); it indexes the draft embed_tokens table."
+                f"[0, {draft_base_config.vocab_size}); it indexes the draft embed_tokens table."
             )
         draft_config["mask_token_id"] = mask_token_id
         draft_config["num_depths"] = int(recipe_cfg.get("num_depths", 8))

--- a/nemo_automodel/recipes/llm/train_eagle3.py
+++ b/nemo_automodel/recipes/llm/train_eagle3.py
@@ -409,6 +409,14 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
         # ``DraftSpec``) in ``components/speculative/eagle/registry.py``;
         # no recipe change required.
         draft_spec = resolve_eagle3_draft_spec(architectures)
+        # The EAGLE-3 draft mirrors only the text decoder. For a multimodal target
+        # that config is nested under ``text_config`` (a top-level ``Gemma4Config``
+        # has no ``vocab_size`` / ``hidden_size`` / ``num_hidden_layers`` at all);
+        # text-only targets have none, so fall back to the config itself. Every
+        # draft-side dimension (vocab_size, hidden_size, heads, head_dim, rope, ...)
+        # is read from this base config.
+        _text_config = getattr(target_config, "text_config", None)
+        draft_base_config = _text_config if _text_config is not None else target_config
 
         self.tokenizer = NeMoAutoTokenizer.from_pretrained(
             target_path,
@@ -441,7 +449,9 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
         self.cp_mesh = None
         self.dp_mesh = None
         if self.cached_target_path is None:
-            selected_token_ids, selected_token_mask = self._setup_online_target(recipe_cfg, target_path, target_config)
+            selected_token_ids, selected_token_mask = self._setup_online_target(
+                recipe_cfg, target_path, draft_base_config
+            )
         else:
             # The cached-target path never builds a cp mesh (only the colocated
             # target does), so cp_size>1 here would silently fall back to plain DP
@@ -451,11 +461,11 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
                     "Context parallelism (cp_size>1) is not supported with a cached target; the "
                     "cached path does not build a cp mesh. Use the colocated target or set cp_size=1."
                 )
-            selected_token_ids, selected_token_mask = self._setup_cached_target(recipe_cfg, target_config)
+            selected_token_ids, selected_token_mask = self._setup_cached_target(recipe_cfg, draft_base_config)
 
-        draft_config = target_config.to_dict()
+        draft_config = draft_base_config.to_dict()
         draft_config["draft_vocab_size"] = int(selected_token_ids.numel())
-        draft_config["target_hidden_size"] = target_config.hidden_size
+        draft_config["target_hidden_size"] = draft_base_config.hidden_size
         draft_config["architectures"] = ["LlamaEagle3DraftModel"]
         # The draft owns an independent ``lm_head`` whose vocab can differ
         # from ``embed_tokens`` (vocab shrinking, ``draft_vocab_size <
@@ -492,16 +502,16 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
         draft_config["parallel_drafting"] = parallel_drafting
         mask_token_id = None
         if parallel_drafting:
-            mask_token_id = self._configure_peagle_draft_config(recipe_cfg, draft_config, target_config)
+            mask_token_id = self._configure_peagle_draft_config(recipe_cfg, draft_config, draft_base_config)
         # Cast to the target's compute dtype so every linear / embedding / norm
         # in the draft matches the bf16 (cuda) or fp32 (cpu) hidden states fed
         # in from the target. Without this, ``initialize_rms_norm_module`` defaults
         # to bf16 while ``nn.Linear`` defaults to fp32, and ``model.fc`` errors
         # with ``expected mat1 and mat2 to have the same dtype``.
-        # Reuse the target's concrete config class (LlamaConfig / Phi3Config / ...)
-        # so architecture-specific defaults like attention_bias and head_dim
-        # flow into the draft.
-        draft_config_obj = type(target_config).from_dict(draft_config)
+        # Reuse the base config's concrete class (LlamaConfig / Phi3Config /
+        # Gemma4TextConfig / ...) so architecture-specific defaults like
+        # attention_bias and head_dim flow into the draft.
+        draft_config_obj = type(draft_base_config).from_dict(draft_config)
         self.draft_model = draft_spec.draft_cls(draft_config_obj).to(device=self.device, dtype=self.compute_dtype)
         # Seed draft embeddings from the target: directly from the live target,
         # or from the embeddings stored alongside the offline cache.
@@ -848,7 +858,7 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
             )
         return True
 
-    def _setup_online_target(self, recipe_cfg, target_path, target_config):
+    def _setup_online_target(self, recipe_cfg, target_path, draft_base_config):
         """Live path: load the target model and build the live dataloader.
 
         Sets ``self.target_model`` / ``self.target_wrapper`` /
@@ -942,7 +952,7 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
         # mapping -- so the cache only matters for cold starts.
         selected_token_ids, selected_token_mask = load_or_build_eagle3_token_mapping(
             self.train_dataloader,
-            target_vocab_size=target_config.vocab_size,
+            target_vocab_size=draft_base_config.vocab_size,
             draft_vocab_size=recipe_cfg.get("draft_vocab_size", None),
             special_token_ids=special_token_ids,
             cache_path=recipe_cfg.get("selected_token_ids_path", None),
@@ -1115,7 +1125,7 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
             logger.info("Capping target_prefetch_depth %d -> %d (one in-flight request per server).", depth, capped)
         return capped
 
-    def _setup_cached_target(self, recipe_cfg, target_config):
+    def _setup_cached_target(self, recipe_cfg, draft_base_config):
         """Offline path: stream a precomputed cache; no target model is loaded.
 
         Reads the cache manifest for the draft-vocab mapping and loads the stored
@@ -1128,24 +1138,24 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
         self.target_model = None
         self.target_wrapper = None
         manifest = read_manifest(self.cached_target_path)
-        if int(manifest["target_vocab_size"]) != int(target_config.vocab_size):
+        if int(manifest["target_vocab_size"]) != int(draft_base_config.vocab_size):
             raise ValueError(
                 f"EAGLE-3 cache at {self.cached_target_path} was built for target_vocab_size="
-                f"{manifest['target_vocab_size']}, but the configured target has {target_config.vocab_size}. "
+                f"{manifest['target_vocab_size']}, but the configured target has {draft_base_config.vocab_size}. "
                 "The cache does not match this target."
             )
         # The draft's ``fc`` consumes ``target_hidden_size * 3`` aux features; a
         # cache from a different-width target would otherwise crash deep inside
         # ``fc`` with a confusing shape error.
-        expected_aux_dim = int(target_config.hidden_size) * 3
+        expected_aux_dim = int(draft_base_config.hidden_size) * 3
         if int(manifest["aux_hidden_dim"]) != expected_aux_dim:
             raise ValueError(
                 f"EAGLE-3 cache at {self.cached_target_path} has aux_hidden_dim={manifest['aux_hidden_dim']}, "
-                f"but the configured target needs {expected_aux_dim} (hidden_size {target_config.hidden_size} x 3 "
+                f"but the configured target needs {expected_aux_dim} (hidden_size {draft_base_config.hidden_size} x 3 "
                 "aux layers). The cache was built for a different target."
             )
         selected_token_ids = torch.tensor(manifest["selected_token_ids"], dtype=torch.long)
-        selected_token_mask = torch.zeros(int(target_config.vocab_size), dtype=torch.bool)
+        selected_token_mask = torch.zeros(int(draft_base_config.vocab_size), dtype=torch.bool)
         selected_token_mask[selected_token_ids] = True
         self._cached_embed_source = SimpleNamespace(weight=read_target_embeddings(self.cached_target_path))
 

--- a/tests/unit_tests/speculative/test_eagle3_gemma_draft.py
+++ b/tests/unit_tests/speculative/test_eagle3_gemma_draft.py
@@ -1,0 +1,211 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the Gemma4 EAGLE-3 draft model and its target-side plumbing."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+from nemo_automodel.components.speculative.eagle.draft_gemma import (
+    Gemma4Eagle3DraftModel,
+    _extract_global_rope_theta,
+    _normalize_gemma4_draft_config,
+)
+from nemo_automodel.components.speculative.eagle.registry import (
+    EAGLE3_DRAFT_REGISTRY,
+    resolve_eagle3_draft_spec,
+)
+from nemo_automodel.components.speculative.eagle.target import HFEagle3TargetModel
+
+Gemma4TextConfig = pytest.importorskip("transformers").Gemma4TextConfig
+
+# The full-attention (global) base the draft must adopt; the sliding base (1e4)
+# must NOT leak through.
+_GLOBAL_ROPE_THETA = 1_000_000.0
+_LOCAL_ROPE_THETA = 10_000.0
+
+
+def _tiny_gemma4_text_config() -> Gemma4TextConfig:
+    """A small ``Gemma4TextConfig`` carrying Gemma4's nested per-type RoPE layout."""
+    config = Gemma4TextConfig(
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        vocab_size=128,
+        max_position_embeddings=64,
+        hidden_activation="gelu_pytorch_tanh",
+    )
+    # Gemma4TextConfig populates the nested rope_parameters by default, but pin it
+    # explicitly so the test is independent of transformers' defaults.
+    config.rope_parameters = {
+        "full_attention": {
+            "rope_type": "proportional",
+            "partial_rotary_factor": 0.25,
+            "rope_theta": _GLOBAL_ROPE_THETA,
+        },
+        "sliding_attention": {"rope_type": "default", "rope_theta": _LOCAL_ROPE_THETA},
+    }
+    # Fields the recipe injects when deriving the draft config from the target.
+    config.torch_dtype = torch.float32
+    config.draft_vocab_size = 16
+    config.target_hidden_size = config.hidden_size
+    return config
+
+
+# ── Registry wiring ──────────────────────────────────────────────────────
+
+
+def test_registry_contains_gemma4():
+    assert "Gemma4ForConditionalGeneration" in EAGLE3_DRAFT_REGISTRY
+    assert EAGLE3_DRAFT_REGISTRY["Gemma4ForConditionalGeneration"].draft_cls is Gemma4Eagle3DraftModel
+
+
+def test_resolve_eagle3_gemma4():
+    spec = resolve_eagle3_draft_spec(["Gemma4ForConditionalGeneration"])
+    assert spec.draft_cls is Gemma4Eagle3DraftModel
+
+
+# ── Config normalization ─────────────────────────────────────────────────
+
+
+def test_extract_global_rope_theta_from_nested():
+    config = _tiny_gemma4_text_config()
+    assert _extract_global_rope_theta(config) == _GLOBAL_ROPE_THETA
+
+
+def test_extract_global_rope_theta_flat_fallback():
+    config = SimpleNamespace(rope_parameters=None, rope_theta=1234.0)
+    assert _extract_global_rope_theta(config) == 1234.0
+
+
+def test_extract_global_rope_theta_default():
+    config = SimpleNamespace(rope_parameters=None)
+    assert _extract_global_rope_theta(config) == _GLOBAL_ROPE_THETA
+
+
+def test_normalize_sets_hidden_act_and_flattens_rope():
+    config = _tiny_gemma4_text_config()
+    _normalize_gemma4_draft_config(config)
+    assert config.hidden_act == "gelu_pytorch_tanh"
+    assert config.rope_parameters is None
+    assert config.rope_scaling is None
+    assert config.rope_theta == _GLOBAL_ROPE_THETA
+    assert config.partial_rotary_factor == 1.0
+
+
+def test_normalize_honors_explicit_hidden_act():
+    config = _tiny_gemma4_text_config()
+    config.hidden_act = "silu"
+    _normalize_gemma4_draft_config(config)
+    assert config.hidden_act == "silu"
+
+
+def test_normalize_dense_leaves_intermediate_size():
+    # Dense Gemma4 (no MoE block): intermediate_size is the real FFN width, untouched.
+    config = _tiny_gemma4_text_config()
+    original = config.intermediate_size
+    _normalize_gemma4_draft_config(config)
+    assert config.intermediate_size == original
+
+
+def test_normalize_moe_expands_intermediate_to_active_width():
+    # MoE target: config intermediate_size is per-expert (here 20, below hidden 32).
+    # The draft MLP must be sized to the active FFN width (top_k_experts * per-expert),
+    # not the contracting per-expert width.
+    config = _tiny_gemma4_text_config()
+    config.intermediate_size = 20
+    config.enable_moe_block = True
+    config.top_k_experts = 4
+    _normalize_gemma4_draft_config(config)
+    assert config.intermediate_size == 80  # 20 * 4, now well above hidden_size (32)
+
+
+# ── Draft model ──────────────────────────────────────────────────────────
+
+
+def test_gemma4_eagle3_draft_forward_shape():
+    config = _tiny_gemma4_text_config()
+    model = Gemma4Eagle3DraftModel(config)
+
+    batch_size, seq_len = 2, 8
+    input_ids = torch.randint(0, config.vocab_size, (batch_size, seq_len))
+    aux_hidden_states = torch.randn(batch_size, seq_len, config.hidden_size * 3)
+    attention_mask = torch.ones(batch_size, seq_len, dtype=torch.long)
+
+    hidden_states = model(
+        input_ids=input_ids,
+        projected_hidden_states=model.project_hidden_states(aux_hidden_states),
+        attention_mask=attention_mask,
+    )
+    logits = model.compute_logits(hidden_states)
+
+    assert hidden_states.shape == (batch_size, seq_len, config.hidden_size)
+    assert logits.shape == (batch_size, seq_len, config.draft_vocab_size)
+
+
+def test_gemma4_draft_rope_uses_global_theta_not_local():
+    """The draft's single full-attention layer must adopt the global base (1e6),
+    a standard full-rotary Llama RoPE -- not the sliding base (1e4) nor a base-10000
+    fallback from the unread nested ``rope_parameters``."""
+    config = _tiny_gemma4_text_config()
+    draft_rope = Gemma4Eagle3DraftModel(config).model.layers[0].self_attn.rotary_emb
+
+    head_dim = config.head_dim
+    expected = 1.0 / (_GLOBAL_ROPE_THETA ** (torch.arange(0, head_dim, 2, dtype=torch.float32) / head_dim))
+    torch.testing.assert_close(draft_rope.inv_freq.float(), expected, rtol=1e-6, atol=1e-6)
+
+
+# ── Target-side layer extraction (nested language_model backbone) ─────────
+
+
+def _make_stub_gemma_target(num_layers: int = 8) -> nn.Module:
+    """A minimal stand-in for a loaded ``Gemma4ForConditionalGeneration``.
+
+    Mirrors the module tree the target wrapper must walk:
+    ``model.model.language_model.layers`` with the depth on the nested
+    ``config.text_config.num_hidden_layers`` (a multimodal ``Gemma4Config`` has no
+    top-level ``num_hidden_layers``).
+    """
+    language_model = nn.Module()
+    language_model.layers = nn.ModuleList([nn.Identity() for _ in range(num_layers)])
+    inner = nn.Module()
+    inner.language_model = language_model
+    model = nn.Module()
+    model.model = inner
+    model.config = SimpleNamespace(text_config=SimpleNamespace(num_hidden_layers=num_layers))
+    model.get_input_embeddings = lambda: None
+    return model
+
+
+def test_target_locates_nested_language_model_layers():
+    stub = _make_stub_gemma_target(num_layers=8)
+    wrapper = HFEagle3TargetModel(stub)
+    layers = wrapper._get_transformer_layers()
+    assert len(layers) == 8
+    assert layers is not stub.model.language_model.layers  # returns a plain list
+    assert all(layers[i] is stub.model.language_model.layers[i] for i in range(8))
+
+
+def test_target_num_hidden_layers_from_text_config():
+    stub = _make_stub_gemma_target(num_layers=10)
+    wrapper = HFEagle3TargetModel(stub)
+    assert wrapper._num_hidden_layers() == 10
+    # Default aux ids are the standard [1, n//2-1, n-4] offsets, in-bounds for n=10.
+    assert wrapper.aux_layer_ids == [1, 4, 6]


### PR DESCRIPTION
## What

Adds **Gemma4** (`Gemma4ForConditionalGeneration`) as an EAGLE-3 target so `train_eagle3.py` can train a draft against Gemma4 checkpoints. First PR in a per-size series (E2B here; E4B / 31B / 26B-A4B follow). Advances the "More EAGLE-3 target families" item in #2958.

## How

Gemma4 ships as a multimodal `Gemma4ForConditionalGeneration` whose text decoder config is nested under `config.text_config` (the top-level `Gemma4Config` has no `hidden_size` / `vocab_size` / `num_hidden_layers`), and whose decoder layers live under `model.language_model.layers`. The EAGLE-3 draft consumes only post-block hidden states from the frozen target, so it is the same Llama-style dense draft used elsewhere; a thin `Gemma4Eagle3DraftModel` reconciles two Gemma config quirks:

- **Activation** — Gemma names the GeGLU activation `hidden_activation`; the shared MLP reads `hidden_act`.
- **RoPE** — Gemma4 stores a nested per-attention-type `rope_parameters` (`full_attention`: `rope_theta=1e6`, `proportional`, `partial_rotary_factor=0.25`; `sliding_attention`: `1e4`, `default`). The single draft layer runs full causal attention, so it mirrors the **global** schedule, flattened to a standard full-rotary Llama RoPE on `rope_theta=1e6`. The saved checkpoint keeps `architectures: ["LlamaEagle3DraftModel"]` and a flat `rope_theta`, so **SGLang / vLLM reproduce the exact rotary with their existing EAGLE-3 Llama head** — no Gemma-specific inference support is required. (Reproducing the target's `proportional` + partial-rotary schedule would be more faithful but no engine can serve it today.)
- **MoE FFN width** — on a MoE Gemma4 target (`enable_moe_block`) the config `intermediate_size` is the *per-expert* FFN width, which can be *below* `hidden_size` (2112 vs 2816 on 26B-A4B). Left as-is the dense draft would build a contracting, capacity-starved MLP, so the draft MLP is sized to the target's active FFN width (`top_k_experts * intermediate_size`). Dense targets are untouched.

Target-side plumbing: the draft config is built from the text backbone via `config.get_text_config()` (returns the nested `text_config`, or the config itself for text-only targets), threaded through the online / cached / P-EAGLE setup paths so `vocab_size` / `hidden_size` are read from it; the target wrapper locates the decoder under `model.language_model.layers` and reads depth from `get_text_config()`. Set `target_force_hf: true` to load the stock HF text-capable model.

## Testing

- **Unit** (`tests/unit_tests/speculative/test_eagle3_gemma_draft.py`, 13 tests, CPU): registry resolution, RoPE-theta extraction + config normalization (global theta, cleared `rope_parameters`, full rotary, `hidden_act`), draft forward shapes, draft rotary uses the global 1e6 base (not the sliding 1e4), and target-side nested-`language_model` layer extraction + depth from `get_text_config()`.
- **End-to-end smoke** (Gemma4-E2B-it, 1× A100, colocated `target_force_hf`): trained the draft to completion under all three attention/packing combinations the example supports — draft `eager`, draft `flash_attention_2`, and `flash_attention_2` + sequence packing — each `EXIT_CODE=0`. The consolidated checkpoint's `config.json` is verified SGLang-loadable: `architectures: ["LlamaEagle3DraftModel"]`, `rope_theta: 1000000.0`, `rope_parameters: null`, `partial_rotary_factor: 1.0`, `hidden_act: gelu_pytorch_tanh`, `head_dim: 256`.

A longer run (256 samples, `lr: 5e-5`, `seq_length: 1024`) shows healthy convergence — loss falls, accuracy and simulated accept-length rise (draft 498M params):

```
step  8: loss 10.61  acc 0.000  tau_sim 1.000
step 48: loss  7.51  acc 0.044  tau_sim 1.041
step 96: loss  6.57  acc 0.059  tau_sim 1.075
step168: loss  6.35  acc 0.111  tau_sim 1.120
step216: loss  6.09  acc 0.107  tau_sim 1.124
```

(The runs use a Llama-regenerated slice — pipeline/stability validation, not a full convergence run on target-regenerated data.)

Part of #2958.
