### PR TITLE
fix(speculative): keep DSpark target_layer_ids in [0, N-2] for SGLang

### DIFF
--- a/examples/speculative/dspark/deepseek_v4_flash_dspark.yaml
+++ b/examples/speculative/dspark/deepseek_v4_flash_dspark.yaml
@@ -103,7 +103,7 @@ recipe_args:
   block_size: 5                       # DeepSeek-V4-Flash-DSpark drafts 5 tokens per block
   num_anchors: 512                    # blocks sampled per sequence per step
   mask_token_id: 128799               # reserved V4 token id for non-anchor block positions (in-vocab; < 129280)
-  target_layer_ids: [40, 41, 42]      # 3 late feature layers of the full 43-layer V4 target
+  target_layer_ids: [39, 40, 41]      # 3 late feature layers of the full 43-layer V4 target; stays within [0, N-2] so the checkpoint is SGLang-servable (the last layer 42 has no SGLang aux capture point)
   freeze_embeddings: true             # draft shares + freezes the target embed_tokens and lm_head
   # The V4 draft attention is fixed to the dense SDPA mask path by the config builder,
   # so attention_backend is not used here (flex_attention is the Qwen3 / Gemma4 path).

--- a/examples/speculative/dspark/deepseek_v4_flash_smoke.yaml
+++ b/examples/speculative/dspark/deepseek_v4_flash_smoke.yaml
@@ -9,8 +9,9 @@
 # before the first forward (resident-weight peak, not fixable by seq_length /
 # activation_checkpointing). target_num_hidden_layers=4 loads only the first 4 layers
 # so the whole EP / hidden-capture / draft-training pipeline runs end to end on one
-# node. target_layer_ids=[1,2,3] is the 4-layer equivalent of the full target's late
-# layers [40,41,42]. A draft trained here is a pipeline check, not a usable drafter.
+# node. target_layer_ids=[0,1,2] is the 4-layer equivalent of the full target's late
+# layers [39,40,41] (kept within [0, N-2] for SGLang servability). A draft trained here
+# is a pipeline check, not a usable drafter.
 #
 # Prereq: DeepEP (or HybridEP) installed, 8x>=80GB GPUs, V4-Flash weights local.
 # Run via: tests/functional_tests/speculative/run_deepseek_v4_flash_smoke.sh
@@ -56,7 +57,7 @@ recipe_args:
   block_size: 5
   num_anchors: 16                # smoke: few anchors per sequence
   mask_token_id: 128799
-  target_layer_ids: [1, 2, 3]    # 4-layer equivalent of the full target's late layers [40,41,42]
+  target_layer_ids: [0, 1, 2]    # 4-layer equivalent of the full target's late layers [39,40,41] (within [0, N-2] for SGLang servability)
   freeze_embeddings: true
 
   # --- frozen V4 target backend (the real EP path) ---

--- a/examples/speculative/dspark/qwen3_0.6b_dspark.yaml
+++ b/examples/speculative/dspark/qwen3_0.6b_dspark.yaml
@@ -42,7 +42,7 @@ recipe_args:
   block_size: 7                       # tokens drafted in parallel per block
   num_anchors: 512                    # blocks sampled per sequence per step
   mask_token_id: 151669               # reserved Qwen3 token id for non-anchor block positions
-  target_layer_ids: [1, 7, 14, 21, 27]  # 5 feature layers spread across the 28-layer 0.6B target
+  target_layer_ids: [1, 7, 14, 21, 26]  # 5 feature layers spread across the 28-layer 0.6B target; 26 stays within [0, N-2] so the checkpoint is SGLang-servable (the last layer 27 has no SGLang aux capture point)
   freeze_embeddings: true             # draft shares + freezes the target embed_tokens and lm_head
   attention_backend: flex_attention   # block mask requires flex_attention (GPU)
 

--- a/nemo_automodel/components/speculative/dspark/common.py
+++ b/nemo_automodel/components/speculative/dspark/common.py
@@ -11,11 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
 from dataclasses import dataclass
 from typing import Optional
 
 import torch
 from torch import nn
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -80,6 +83,29 @@ def validate_target_layer_ids(layer_ids, num_target_layers: int):
         )
         assert previous is None or layer_id > previous, "target_layer_ids must be strictly increasing."
         previous = layer_id
+
+    # The standard SGLang runtime captures aux/context features via
+    # ``set_eagle3_layers_to_capture`` (effectively capturing the input of layer
+    # ``id + 1``), so it cannot produce a feature for ``-1`` (no capture point) or
+    # for the last layer ``end`` (capture point ``num_target_layers`` does not
+    # exist in a ``0..end`` decoder loop, and SGLang exposes the post-norm hidden
+    # only as a separate last-hidden, never as an aux slot). A checkpoint trained
+    # with these ids still serves with AutoModel's own ``spec_generate`` (which
+    # follows the HuggingFace ``output_hidden_states`` convention), but not on the
+    # standard SGLang runtime. Warn rather than fail: the ids are valid for
+    # AutoModel, only unservable on SGLang.
+    sglang_unsupported = sorted({layer_id for layer_id in layer_ids if layer_id == -1 or layer_id == end})
+    if sglang_unsupported:
+        logger.warning(
+            "target_layer_ids %s include %s, which the standard SGLang runtime cannot capture "
+            "(-1 is the embedding and the last layer %d is post-norm; neither has an SGLang aux "
+            "capture point). A drafter trained with these ids serves with AutoModel's spec_generate "
+            "but not on standard SGLang; keep target_layer_ids within [0, %d] for SGLang deployment.",
+            layer_ids,
+            sglang_unsupported,
+            end,
+            end - 1,
+        )
     return layer_ids
 
 

--- a/tests/unit_tests/speculative/test_dspark_target.py
+++ b/tests/unit_tests/speculative/test_dspark_target.py
@@ -20,9 +20,12 @@ and the functional tests -- including the last layer (post-norm) and ``-1``
 (embedding output), the two cases a forward hook gets wrong.
 """
 
+import logging
+
 import torch
 from transformers import AutoModelForCausalLM, Qwen3Config
 
+from nemo_automodel.components.speculative.dspark.common import validate_target_layer_ids
 from nemo_automodel.components.speculative.dspark.target import HFDSparkTargetModel
 
 VOCAB = 256
@@ -128,3 +131,22 @@ def test_generate_batch_backward_compatible_without_multimodal_kwargs():
     for key in ("pixel_values", "image_grid_thw", "pixel_values_videos", "video_grid_thw"):
         assert key not in received
     assert set(received) == {"input_ids", "attention_mask", "use_cache"}
+
+
+def test_validate_target_layer_ids_warns_on_sglang_unservable_ids(caplog):
+    # -1 (embedding) and the last layer (post-norm) have no standard-SGLang aux
+    # capture point, so validate_target_layer_ids warns (but still accepts them,
+    # since AutoModel's own spec_generate serves them).
+    with caplog.at_level(logging.WARNING, logger="nemo_automodel.components.speculative.dspark.common"):
+        validate_target_layer_ids([-1, 1, NUM_LAYERS - 1], NUM_LAYERS)
+    assert "SGLang" in caplog.text
+    assert str(NUM_LAYERS - 1) in caplog.text
+    # The ids are still returned unchanged (warning, not error).
+    assert validate_target_layer_ids([-1, 1, NUM_LAYERS - 1], NUM_LAYERS) == [-1, 1, NUM_LAYERS - 1]
+
+
+def test_validate_target_layer_ids_no_warn_within_range(caplog):
+    # Ids within [0, N-2] are captured identically by AutoModel and SGLang -> no warning.
+    with caplog.at_level(logging.WARNING, logger="nemo_automodel.components.speculative.dspark.common"):
+        validate_target_layer_ids([0, 1, NUM_LAYERS - 2], NUM_LAYERS)
+    assert "SGLang" not in caplog.text


### PR DESCRIPTION
Closes #3082.

## What

Keep the shipped DSpark example `target_layer_ids` within `[0, N-2]` so a drafter trained from them is servable on the standard SGLang runtime, and warn when `-1` or the last layer `N-1` is configured.

## Why

`HFDSparkTargetModel` follows the HuggingFace `output_hidden_states` (offset-1) convention: `-1` is the embedding, an interior `k` is layer `k`'s raw output, and the **last layer `N-1` is the post-norm hidden** (the `lm_head` input). This is intentional and unit-tested (`test_capture_matches_output_hidden_states_convention`), and AutoModel's own `spec_generate` is consistent (it builds the context via `extract_context_feature` over `output_hidden_states`).

The standard SGLang runtime captures aux features via `set_eagle3_layers_to_capture`, effectively capturing the input of layer `id+1`. So it cannot produce a feature for `-1` (no capture point) or for `N-1` (capture point `N` does not exist in a `0..N-1` decoder loop; SGLang exposes the post-norm hidden only as a separate last-hidden, never as an aux slot). A DSpark checkpoint whose `target_layer_ids` include `-1` or `N-1` therefore has a last context slot with no SGLang equivalent (feature mismatch / dimension error at load).

Several shipped example configs used the last layer, so their checkpoints were not SGLang-servable:
- `qwen3_0.6b_dspark.yaml` `[1,7,14,21,27]` on 28 layers (`27 = N-1`)
- `deepseek_v4_flash_dspark.yaml` `[40,41,42]` on 43 layers (`42 = N-1`)

## Change

- Move those configs within `[0, N-2]`, keeping the late-layer intent: `qwen3_0.6b -> [1,7,14,21,26]`, `deepseek_v4 -> [39,40,41]` (and its 4-layer smoke `[1,2,3] -> [0,1,2]`). Feature-layer selection only; the DSpark algorithm is unchanged, and `HFDSparkTargetModel` / `extract_context_feature` are untouched (they are correct).
- `validate_target_layer_ids` now emits a `logger.warning` when `-1` or `N-1` is present, explaining they are unservable on standard SGLang. It stays a warning (not an error) because those ids remain valid for AutoModel's own `spec_generate`.

Note: `glm_5.2_dspark.yaml` (`[75,76,77]` on 78 layers) is affected too but is not yet on `main`; it should adopt `[74,75,76]` when it lands.

## Not a duplicate

Checked open PRs and issues; no PR addresses the DSpark SGLang last-layer feature contract. Filed and referenced #3082.

## Testing

```
pytest tests/unit_tests/speculative/test_dspark_target.py -q
# 6 passed (4 existing + 2 new: warns on -1/N-1, no warn within [0, N-2])
```
`ruff format` / `ruff check` clean on the changed files.

