### PR TITLE
test: clean up KD test process group

### DIFF
--- a/tests/unit_tests/loss/test_kd_loss.py
+++ b/tests/unit_tests/loss/test_kd_loss.py
@@ -536,10 +536,15 @@ def _init_single_process_group() -> Optional[torch.distributed.ProcessGroup]:
 @pytest.fixture(scope="module")
 def trivial_pg():
     """Module-scoped fixture that returns a single-process gloo ProcessGroup."""
+    process_group_already_initialized = torch.distributed.is_initialized()
     pg = _init_single_process_group()
     if pg is None:
         pytest.skip("torch.distributed not available")
-    return pg
+    try:
+        yield pg
+    finally:
+        if not process_group_already_initialized and torch.distributed.is_initialized():
+            torch.distributed.destroy_process_group()
 
 
 def test_kl_forward_tp_matches_non_tp(trivial_pg):


### PR DESCRIPTION
# What does this PR do ?

Clean up the single-rank Gloo process group created by the KD-loss unit-test fixture so distributed state does not leak into tests that run later in the same pytest process.

The fixture now destroys the process group only when it created that group. A process group that was already initialized by another owner is preserved.

# Changelog

- Convert the module-scoped `trivial_pg` fixture to a yield fixture with deterministic teardown.
- Track process-group ownership and avoid destroying pre-existing distributed state.
- Prevent test-order-dependent failures such as the retrieval-distillation failures observed in #3058.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

# Validation

- KD-loss module plus cleanup assertion: 29 passed.
- KD-loss module with a pre-existing process group: 29 passed; the group remained initialized.
- Original cross-file failure order from #3058 with only this cleanup applied: 3 passed.
- `ruff format .`: 633 files unchanged.
- `ruff check --fix .`: all checks passed.

# Additional Information

- Related to #3058
