### PR TITLE
fix(perf): use GPT-OSS head dimension in FLOPs accounting

### DIFF
--- a/nemo_automodel/components/utils/flops_utils.py
+++ b/nemo_automodel/components/utils/flops_utils.py
@@ -837,7 +837,9 @@ def gpt_oss_flops(config, gbs=1, seq_len=None):
         config.moe_ffn_hidden_size if hasattr(config, "moe_ffn_hidden_size") else config.intermediate_size
     )
     moe_router_topk = config.num_experts_per_tok
-    kv_channels = config.kv_channels if hasattr(config, "kv_channels") else (hidden_size // num_attention_heads)
+    kv_channels = getattr(config, "head_dim", None)
+    if kv_channels is None:
+        kv_channels = getattr(config, "kv_channels", hidden_size // num_attention_heads)
     swa_window_size = config.window_size[0] if hasattr(config, "window_size") and config.window_size else 128
     window_attn_skip_freq = config.window_attn_skip_freq if hasattr(config, "window_attn_skip_freq") else 2
 

--- a/tests/unit_tests/utils/test_flops_utils.py
+++ b/tests/unit_tests/utils/test_flops_utils.py
@@ -232,6 +232,23 @@ def test_flops_formulas_with_precomputed_values(name, func, cfg_factory, kwargs,
     assert actual == expected, f"{name}: expected {expected}, got {actual}"
 
 
+def test_gpt_oss_flops_uses_head_dim_from_hf_config():
+    config = SimpleNamespace(
+        num_hidden_layers=1,
+        hidden_size=24,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        num_experts_per_tok=2,
+        intermediate_size=16,
+        vocab_size=32,
+        head_dim=8,
+    )
+
+    assert not hasattr(config, "kv_channels")
+    assert config.head_dim != config.hidden_size // config.num_attention_heads
+    assert int(flops_utils.gpt_oss_flops(config, gbs=1, seq_len=8)) == 271872
+
+
 @pytest.mark.parametrize(
     "tflops, world_size, time_seconds, reference_mfu, expected_mfu",
     [


### PR DESCRIPTION
# What does this PR do ?

Correct GPT-OSS theoretical FLOPs accounting to use the Hugging Face
`GptOssConfig.head_dim` value used by the actual attention layers.

The stock GPT-OSS-20B config has `hidden_size=2880`, 64 attention heads, and
`head_dim=64`, but it does not define `kv_channels`. The previous fallback
therefore inferred `2880 // 64 = 45`, under-counting Q/K/V/O projection and
attention FLOPs even though the model executes with head dimension 64.

# Changelog

- Prefer `config.head_dim` in `gpt_oss_flops`.
- Preserve compatibility with normalized configs that expose only
  `kv_channels`, followed by the legacy hidden-size fallback.
- Add a CPU unit regression with an HF-shaped config that has no synthetic
  `kv_channels` and whose `head_dim` intentionally differs from
  `hidden_size // num_attention_heads`.

# Audit evidence

For the official GPT-OSS-20B dimensions at sequence length 4096 and GBS 1:

| Calculator input | TF/step |
| --- | ---: |
| Previous inferred head dimension (`45`) | 87.640983797760 |
| Correct config head dimension (`64`) | 93.848227282944 |

The previous path under-reported theoretical FLOPs, and therefore MFU, by
`6.614130%` relative to the corrected value.

The focused tiny regression produces `271,872` FLOPs with `head_dim=8`; the old
fallback (`24 // 4 = 6`) produces `240,768`, so the test distinguishes the
broken and corrected paths. The existing legacy `kv_channels` fixture remains
unchanged at `7,356,800,827,392` FLOPs.

Supporting references:

- [Official GPT-OSS-20B config](https://huggingface.co/openai/gpt-oss-20b/blob/main/config.json)
- [AutoModel attention layers use `config.head_dim`](https://github.com/NVIDIA-NeMo/Automodel/blob/0a0433ded1cc35d3471948b6daca99b20f4ab44c/nemo_automodel/components/models/gpt_oss/layers.py#L40-L66)
- [AutoModel ↔ Megatron Bridge TFLOPs audit in MB-812](https://linear.app/nvidia/issue/MB-812/qwen3-30b-a3b-base-sft-parity-automodel-vs-megatron-bridge)
- The Bridge-side GDN+MTP finding from the same audit is already fixed by merged [Megatron-Bridge #4834](https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/4834).

# Validation

- PASS: stdlib execution of the changed calculator functions against the tiny
  regression, legacy compatibility fixture, and official GPT-OSS-20B dimensions.
- PASS: Python compilation of both changed files.
- PASS: `git diff --check`.
- Local repository pytest/ruff were not run because the available checkout has
  no pytest, torch, transformers, or ruff installation. No dependency sync,
  installation, container launch, or environment mutation was performed; PR CI
  will run the repository gates.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added a focused CPU unit regression.
- [x] No documentation update is necessary; this restores the calculator to the
  model config contract.

# Additional Information

- Audit follow-up for MB-812.
- Signed-off commit included.
