### PR TITLE
perf(benchmark): log achieved tflops in summary

### DIFF
--- a/nemo_automodel/recipes/llm/benchmark.py
+++ b/nemo_automodel/recipes/llm/benchmark.py
@@ -43,6 +43,10 @@ def _infer_vocab_size(model_cfg):
     from transformers import AutoConfig
 
     config_section = model_cfg.config
+    vocab_size = getattr(config_section, "vocab_size", None)
+    if vocab_size is not None:
+        return vocab_size
+
     # Recipes may set trust_remote_code either at the model level (nemo_automodel
     # convention) or nested under `config` -- accept either.
     trust_remote_code = getattr(model_cfg, "trust_remote_code", False) or getattr(
@@ -493,6 +497,16 @@ class BenchmarkingRecipeForNextTokenPrediction(TrainFinetuneRecipeForNextTokenPr
                 )
             )
 
+            avg_tflops_per_gpu_per_second = self.tflops / (self.dist_env.world_size * avg_iter_time)
+            logger.info(
+                f"Average TFLOPs/GPU/s: {avg_tflops_per_gpu_per_second:.6f}"
+                + (
+                    f" (excluding first {warmup_steps} warmup iterations)"
+                    if steps > warmup_steps
+                    else f" (all {steps} iterations)"
+                )
+            )
+
             mfu = calculate_mfu(self.tflops, self.dist_env.world_size, avg_iter_time, reference_mfu=peak_tflops)
             logger.info(
                 f"Average MFU: {mfu:.6f}%"
@@ -514,6 +528,7 @@ class BenchmarkingRecipeForNextTokenPrediction(TrainFinetuneRecipeForNextTokenPr
                 "training_time_seconds": iter_time,
                 "avg_iter_time_seconds": avg_iter_time,
                 "avg_mfu_percent": mfu,
+                "avg_tflops_per_gpu_per_second": avg_tflops_per_gpu_per_second,
                 "tflops_per_gpu": self.tflops,
                 "peak_tflops": peak_tflops,
                 "world_size": self.dist_env.world_size,
@@ -538,7 +553,7 @@ class BenchmarkingRecipeForNextTokenPrediction(TrainFinetuneRecipeForNextTokenPr
                         ["Training Time (s)", iter_time],
                         ["Avg Iteration Time (s)", avg_iter_time],
                         ["Avg MFU (%)", mfu],
-                        ["TFLOPs/GPU/s", peak_tflops * mfu / 100],
+                        ["TFLOPs/GPU/s", avg_tflops_per_gpu_per_second],
                         ["Peak TFLOPs", peak_tflops],
                         ["World Size", self.dist_env.world_size],
                         ["Global Batch Size", self.cfg.step_scheduler.global_batch_size],
@@ -553,6 +568,7 @@ class BenchmarkingRecipeForNextTokenPrediction(TrainFinetuneRecipeForNextTokenPr
                     {
                         "summary/avg_iter_time_seconds": avg_iter_time,
                         "summary/avg_mfu_percent": mfu,
+                        "summary/avg_tflops_per_gpu_per_second": avg_tflops_per_gpu_per_second,
                         "summary/training_time_seconds": iter_time,
                         "summary/tflops_per_gpu": self.tflops,
                     }

--- a/tests/ci_tests/scripts/collect_benchmark_artifact.py
+++ b/tests/ci_tests/scripts/collect_benchmark_artifact.py
@@ -45,6 +45,7 @@ def parse_log(log_path: str) -> dict:
         "training_time_seconds": r"Total iteration time.*?:\s+([\d.]+)\s+seconds",
         "avg_iter_time_seconds": r"Average iteration time:\s+([\d.]+)\s+seconds",
         "avg_mfu_percent": r"Average MFU:\s+([\d.]+)%",
+        "avg_tflops_per_gpu_per_second": r"Average TFLOPs/GPU/s:\s+([\d.]+)",
     }
     for key, pattern in summary_patterns.items():
         m = re.search(pattern, content)

--- a/tests/unit_tests/recipes/llm/test_benchmark.py
+++ b/tests/unit_tests/recipes/llm/test_benchmark.py
@@ -101,6 +101,7 @@ def mock_config():
         model=SimpleNamespace(
             config=SimpleNamespace(
                 pretrained_model_name_or_path="gpt2",
+                vocab_size=50257,
             ),
         ),
     )
@@ -177,6 +178,7 @@ class TestBenchmarkingRecipeInitialization:
         """Test that vocab_size is inferred from model config."""
         mock_model_config = MagicMock()
         mock_model_config.vocab_size = 50257
+        delattr(mock_config.model.config, "vocab_size")
 
         with patch("nemo_automodel.recipes.llm.benchmark.TrainFinetuneRecipeForNextTokenPrediction.__init__"):
             with patch("transformers.AutoConfig.from_pretrained", return_value=mock_model_config):
@@ -676,7 +678,7 @@ class TestBenchmarkingRecipeJSONOutput:
 
             assert recipe._bench_json_output_path is None
 
-    def test_log_benchmark_summary_creates_json_file(self, mock_recipe, tmp_path):
+    def test_log_benchmark_summary_creates_json_file(self, mock_recipe, tmp_path, caplog):
         """Test that benchmark summary is written to JSON file."""
         json_file = tmp_path / "benchmark_summary.json"
         mock_recipe._bench_json_output_path = str(json_file)
@@ -690,8 +692,11 @@ class TestBenchmarkingRecipeJSONOutput:
             "iteration_warmup": mock_timer,
         }
 
-        with patch("torch.distributed.barrier"):
-            mock_recipe._log_benchmark_summary(steps=30, warmup_steps=10, peak_tflops=989, rank=0)
+        with caplog.at_level("INFO", logger="nemo_automodel.recipes.llm.benchmark"):
+            with patch("torch.distributed.barrier"):
+                mock_recipe._log_benchmark_summary(steps=30, warmup_steps=10, peak_tflops=989, rank=0)
+
+        assert "Average TFLOPs/GPU/s: 250.000000" in caplog.text
 
         # Verify JSON file was created
         assert json_file.exists()
@@ -712,6 +717,7 @@ class TestBenchmarkingRecipeJSONOutput:
         assert summary_data["seq_len"] == 2048
         assert "avg_iter_time_seconds" in summary_data
         assert "avg_mfu_percent" in summary_data
+        assert summary_data["avg_tflops_per_gpu_per_second"] == 250.0
 
     def test_log_benchmark_summary_skips_json_when_none(self, mock_recipe, tmp_path):
         """Test that JSON output is skipped when path is None."""
@@ -807,6 +813,7 @@ class TestBenchmarkingRecipeSummaryData:
         scalar_metrics = scalar_call[0][0]
         assert "summary/avg_iter_time_seconds" in scalar_metrics
         assert "summary/avg_mfu_percent" in scalar_metrics
+        assert scalar_metrics["summary/avg_tflops_per_gpu_per_second"] == 25.0
         assert "summary/training_time_seconds" in scalar_metrics
         assert "summary/tflops_per_gpu" in scalar_metrics
 


### PR DESCRIPTION
## Summary
- log average achieved TFLOPs/GPU/s next to average MFU in the benchmark summary
- persist avg_tflops_per_gpu_per_second in the benchmark JSON summary and W&B scalar/table output
- teach the benchmark artifact collector to parse the new summary log line
- avoid reloading HF config when benchmark config already provides vocab_size

## Validation
- uv run pytest -q tests/unit_tests/recipes/llm/test_benchmark.py::TestBenchmarkingRecipeJSONOutput::test_log_benchmark_summary_creates_json_file tests/unit_tests/recipes/llm/test_benchmark.py::TestBenchmarkingRecipeSummaryData::test_summary_wandb_table_structure tests/unit_tests/recipes/llm/test_benchmark.py::TestBenchmarkingRecipeSummaryData::test_summary_wandb_scalar_metrics tests/unit_tests/recipes/llm/test_benchmark.py::TestBenchmarkingRecipeInitialization::test_init_infers_vocab_size tests/unit_tests/utils/test_flops_utils.py
- uv run ruff format nemo_automodel/recipes/llm/benchmark.py tests/ci_tests/scripts/collect_benchmark_artifact.py tests/unit_tests/recipes/llm/test_benchmark.py
- uv run ruff check nemo_automodel/recipes/llm/benchmark.py tests/ci_tests/scripts/collect_benchmark_artifact.py tests/unit_tests/recipes/llm/test_benchmark.py
- git diff --check