### PR TITLE
fix(test): use eager attention for Nemotron-H HF loads

### DIFF
--- a/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
+++ b/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
@@ -206,13 +206,12 @@ def _get_trust_remote_code_attn_implementation(
         config_kwargs["token"] = token
     config = AutoConfig.from_pretrained(pretrained_model_name_or_path, **config_kwargs)
 
-    # Nemotron-H's remote-code attention passes an ordinary padding mask through
-    # HF's FlashAttention varlen/unpadding path. That path raises a
-    # vectorized_gather_kernel index-OOB device assert for Nemotron-3 Super.
-    # PyTorch SDPA uses its optimized CUDA dispatcher while avoiding the
-    # incompatible varlen route. Other remote-code models (notably
-    # Nemotron-Flash) still require FA2.
-    return "sdpa" if config.model_type == "nemotron_h" else "flash_attention_2"
+    # Nemotron-H remote-code checkpoints do not share optimized attention backend
+    # support: FlashAttention fails in Nemotron-3 Super's varlen path, while
+    # Nemotron-Nano v2 declares SDPA unsupported. Eager is their common HF
+    # reference path. Other remote-code models (notably Nemotron-Flash) still
+    # require FA2.
+    return "eager" if config.model_type == "nemotron_h" else "flash_attention_2"
 
 
 def _hf_source_load_kwargs(

--- a/tests/unit_tests/ci_tests/test_checkpoint_robustness_hf_kwargs.py
+++ b/tests/unit_tests/ci_tests/test_checkpoint_robustness_hf_kwargs.py
@@ -23,10 +23,12 @@ import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
 
-from tests.functional_tests.checkpoint_robustness.test_checkpoint_robustness_llm import _finish_hf_reload_sync
-from tests.functional_tests.checkpoint_robustness.test_checkpoint_robustness_llm import _hf_source_load_kwargs
-from tests.functional_tests.checkpoint_robustness.test_checkpoint_robustness_llm import _prepare_hf_reload_sync
-from tests.functional_tests.checkpoint_robustness.test_checkpoint_robustness_llm import _wait_for_hf_reload_rank0
+from tests.functional_tests.checkpoint_robustness.test_checkpoint_robustness_llm import (
+    _finish_hf_reload_sync,
+    _hf_source_load_kwargs,
+    _prepare_hf_reload_sync,
+    _wait_for_hf_reload_rank0,
+)
 
 
 def _run_hf_reload_sync_rank(rank, init_path, checkpoint_dir):
@@ -51,7 +53,7 @@ def _run_hf_reload_sync_rank(rank, init_path, checkpoint_dir):
 
 @pytest.mark.parametrize(
     ("model_type", "expected_attn_implementation"),
-    [("nemotron_h", "sdpa"), ("nemotron_flash", "flash_attention_2")],
+    [("nemotron_h", "eager"), ("nemotron_flash", "flash_attention_2")],
 )
 def test_remote_code_attention_implementation(model_type, expected_attn_implementation):
     with patch(


### PR DESCRIPTION
# What does this PR do?

Use eager attention for vanilla-HF Nemotron-H reference loads in the checkpoint robustness test.

The AM-672 fix avoided Nemotron-3 Super's FlashAttention 2 varlen CUDA assertion by selecting SDPA for every remote-code `nemotron_h` checkpoint. NVIDIA-Nemotron-Nano-9B-v2 also uses `model_type=nemotron_h`, but its remote model explicitly rejects SDPA. Eager attention is the implementation supported by both checkpoints and is appropriate for this correctness-focused reference load.

This does not change AutoModel's normal attention backend. Explicit recipe attention settings remain unchanged, and other remote-code model families retain their existing FlashAttention 2 selection.

# Changelog

- Select eager attention for remote-code Nemotron-H HF reference loads.
- Keep explicit attention implementations and non-Nemotron-H behavior unchanged.
- Update the focused HF-kwargs regression test.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Updated the necessary unit test.
- [x] No documentation change is required because this only affects test-harness behavior.
- [x] DCO sign-off is present.

Validation:

- `3 passed`: focused remote-code attention kwargs tests.
- Ruff formatting, lint, and `git diff --check` passed.

# Additional Information

- Linear: [AM-702](https://linear.app/nvidia/issue/AM-702/unsupported-scaled-dot-product-attention-attention-implementation)
- Follow-up to #3060.

# Scoped CI

- [Pipeline 58297182](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/58297182) passed for `ad98ee919cf7953462a427a83ba28a251886f90f`.
  - [`nemotron_nano_9b_squad_peft`](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/365211786): passed
  - [`nemotron_super_v3_hellaswag_peft`](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/365211787): passed
