### PR TITLE
fix(retrieval): use stock Ministral embedding backbone

### DIFF
--- a/nemo_automodel/_transformers/registry.py
+++ b/nemo_automodel/_transformers/registry.py
@@ -322,6 +322,10 @@ _CUSTOM_CONFIG_REGISTRATIONS: Dict[str, Tuple[str, str]] = {
     "llavaonevision1_5": ("nemo_automodel.components.models.llava_onevision.model", "Llavaonevision1_5Config"),
     "mimo_v2_flash": ("nemo_automodel.components.models.mimo_v2_flash.config", "MiMoV2FlashConfig"),
     "minimax_m3_vl": ("nemo_automodel.components.models.minimax_m3_vl.config", "MiniMaxM3VLConfig"),
+    "ministral3_bidirec": (
+        "nemo_automodel.components.models.ministral_bidirectional.model",
+        "Ministral3BidirectionalConfig",
+    ),
     "mistral4": ("nemo_automodel.components.models.mistral4.configuration", "Mistral4Config"),
     "step3p5v": ("nemo_automodel.components.models.step3p7.configuration_step3p7", "Step3p5VConfig"),
     "step3p7": ("nemo_automodel.components.models.step3p7.configuration_step3p7", "Step3p7Config"),

--- a/nemo_automodel/_transformers/retrieval.py
+++ b/nemo_automodel/_transformers/retrieval.py
@@ -22,7 +22,7 @@ from typing import Optional
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from transformers import AutoConfig, AutoModel, AutoModelForSequenceClassification, PretrainedConfig, PreTrainedModel
+from transformers import AutoConfig, AutoModel, AutoModelForSequenceClassification, PreTrainedModel
 from transformers.models.auto.modeling_auto import MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING, MODEL_MAPPING
 from transformers.utils import logging
 
@@ -31,15 +31,6 @@ from nemo_automodel.components.loss.intermediate_distill import LayerCapture
 from nemo_automodel.components.models.common.bidirectional import EncoderStateDictAdapter
 
 logger = logging.get_logger(__name__)
-
-
-def _clone_pretrained_config(config: PretrainedConfig) -> PretrainedConfig:
-    """Clone a config while retaining private source-revision metadata."""
-    cloned_config = config.__class__.from_dict(config.to_dict())
-    commit_hash = getattr(config, "_commit_hash", None)
-    if commit_hash is not None:
-        cloned_config._commit_hash = commit_hash
-    return cloned_config
 
 
 def _extract_submodel(model: nn.Module, extract_submodel: str) -> PreTrainedModel:
@@ -121,7 +112,7 @@ def _build_backbone_from_extracted_submodel(
         )
 
     if model_type.lower() == "ministral3" and task == "embedding":
-        config = _clone_pretrained_config(text_config)
+        config = text_config.__class__.from_dict(text_config.to_dict())
         config.is_causal = False
         if pooling is not None:
             config.pooling = pooling
@@ -132,7 +123,7 @@ def _build_backbone_from_extracted_submodel(
         except KeyError as exc:
             raise ValueError(f"No HuggingFace base model found for '{model_type}'.") from exc
     elif task == "score" and not has_supported_target:
-        config = _clone_pretrained_config(text_config)
+        config = text_config.__class__.from_dict(text_config.to_dict())
         try:
             backbone_class = MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING[type(config)]
         except KeyError as exc:

--- a/nemo_automodel/_transformers/retrieval.py
+++ b/nemo_automodel/_transformers/retrieval.py
@@ -311,9 +311,6 @@ def build_encoder_backbone(
             source_commit_hash=getattr(config, "_commit_hash", None),
         )
 
-    if model_type.lower() == "ministral3" and task != "embedding":
-        raise ValueError(f"Unsupported task '{task}' for model type '{model_type}'. Available tasks: embedding.")
-
     if model_type.lower() == "ministral3" and task == "embedding":
         config.is_causal = False
         if pooling is not None:

--- a/nemo_automodel/_transformers/retrieval.py
+++ b/nemo_automodel/_transformers/retrieval.py
@@ -98,7 +98,6 @@ def _build_backbone_from_extracted_submodel(
     pooling: Optional[str],
     num_labels: Optional[int],
     temperature: Optional[float],
-    source_commit_hash: Optional[str] = None,
 ) -> PreTrainedModel:
     """Build a task-specific retrieval backbone from an extracted text submodel."""
     text_config = extracted_model.config
@@ -143,11 +142,6 @@ def _build_backbone_from_extracted_submodel(
             config.pooling = pooling
         if temperature is not None:
             config.temperature = temperature
-
-    if source_commit_hash is None:
-        source_commit_hash = getattr(text_config, "_commit_hash", None)
-    if source_commit_hash is not None:
-        config._commit_hash = source_commit_hash
 
     attn_implementation = getattr(text_config, "_attn_implementation", None)
     if attn_implementation is not None:
@@ -284,7 +278,6 @@ def build_encoder_backbone(
             pooling=pooling,
             num_labels=num_labels,
             temperature=temperature,
-            source_commit_hash=getattr(config, "_commit_hash", None),
         )
 
     if model_type.lower() == "ministral3" and task == "embedding":

--- a/nemo_automodel/_transformers/retrieval.py
+++ b/nemo_automodel/_transformers/retrieval.py
@@ -22,8 +22,8 @@ from typing import Optional
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from transformers import AutoConfig, AutoModel, AutoModelForSequenceClassification, PreTrainedModel
-from transformers.models.auto.modeling_auto import MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING
+from transformers import AutoConfig, AutoModel, AutoModelForSequenceClassification, PretrainedConfig, PreTrainedModel
+from transformers.models.auto.modeling_auto import MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING, MODEL_MAPPING
 from transformers.utils import logging
 
 from nemo_automodel._transformers.registry import ModelRegistry
@@ -31,6 +31,15 @@ from nemo_automodel.components.loss.intermediate_distill import LayerCapture
 from nemo_automodel.components.models.common.bidirectional import EncoderStateDictAdapter
 
 logger = logging.get_logger(__name__)
+
+
+def _clone_pretrained_config(config: PretrainedConfig) -> PretrainedConfig:
+    """Clone a config while retaining private source-revision metadata."""
+    cloned_config = config.__class__.from_dict(config.to_dict())
+    commit_hash = getattr(config, "_commit_hash", None)
+    if commit_hash is not None:
+        cloned_config._commit_hash = commit_hash
+    return cloned_config
 
 
 def _extract_submodel(model: nn.Module, extract_submodel: str) -> PreTrainedModel:
@@ -98,20 +107,29 @@ def _build_backbone_from_extracted_submodel(
     pooling: Optional[str],
     num_labels: Optional[int],
     temperature: Optional[float],
+    source_commit_hash: Optional[str] = None,
 ) -> PreTrainedModel:
     """Build a task-specific retrieval backbone from an extracted text submodel."""
     text_config = extracted_model.config
     model_type = getattr(text_config, "model_type", "")
     task_map = SUPPORTED_BACKBONES.get(model_type.lower())
     has_supported_target = task_map is not None and task in task_map
+    uses_stock_ministral_embedding = model_type.lower() == "ministral3" and task == "embedding"
 
     if task_map is not None and not has_supported_target and task != "score":
         raise ValueError(
             f"Unsupported task '{task}' for model type '{model_type}'. Available tasks: {', '.join(task_map)}."
         )
 
-    if task == "score" and not has_supported_target:
-        config = text_config.__class__.from_dict(text_config.to_dict())
+    if uses_stock_ministral_embedding:
+        config = _clone_pretrained_config(text_config)
+        config.is_causal = False
+        try:
+            backbone_class = MODEL_MAPPING[type(config)]
+        except KeyError as exc:
+            raise ValueError(f"No HuggingFace base model found for '{model_type}'.") from exc
+    elif task == "score" and not has_supported_target:
+        config = _clone_pretrained_config(text_config)
         try:
             backbone_class = MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING[type(config)]
         except KeyError as exc:
@@ -128,14 +146,19 @@ def _build_backbone_from_extracted_submodel(
         config_dict.pop("model_type", None)
         config = config_class(**config_dict)
 
+    if source_commit_hash is None:
+        source_commit_hash = getattr(text_config, "_commit_hash", None)
+    if source_commit_hash is not None:
+        config._commit_hash = source_commit_hash
+
     attn_implementation = getattr(text_config, "_attn_implementation", None)
     if attn_implementation is not None:
         config._attn_implementation = attn_implementation
-    if has_supported_target and pooling is not None:
+    if (has_supported_target or uses_stock_ministral_embedding) and pooling is not None:
         config.pooling = pooling
     if num_labels is not None:
         config.num_labels = num_labels
-    if has_supported_target and temperature is not None:
+    if (has_supported_target or uses_stock_ministral_embedding) and temperature is not None:
         config.temperature = temperature
 
     return _load_from_extracted_state(backbone_class, config, extracted_model)
@@ -223,12 +246,13 @@ def build_encoder_backbone(
     When ``extract_submodel`` is set, loads the parent model with HuggingFace
     Auto classes and extracts the dotted path. For supported extracted text
     backbones, it then builds the registered retrieval class for the requested
-    task (bidirectional base model for ``"embedding"``, sequence-classification
-    wrapper for ``"score"``). For unsupported extracted text backbones, it
-    returns the extracted model for ``"embedding"`` and wraps it with
+    task. Extracted Ministral embedding backbones use the stock HuggingFace model
+    with ``is_causal=False``. For unsupported extracted text backbones, it returns
+    the extracted model for ``"embedding"`` and wraps it with
     ``AutoModelForSequenceClassification`` for ``"score"``.
 
-    Without ``extract_submodel``, model types listed in
+    Without ``extract_submodel``, standard Ministral embedding checkpoints use
+    the stock HuggingFace model with ``is_causal=False``. Model types listed in
     :data:`SUPPORTED_BACKBONES` resolve to custom bidirectional classes from
     :class:`ModelRegistry`; all other model types fall back to HuggingFace Auto
     classes.
@@ -266,6 +290,20 @@ def build_encoder_backbone(
             pooling=pooling,
             num_labels=num_labels,
             temperature=temperature,
+            source_commit_hash=getattr(config, "_commit_hash", None),
+        )
+
+    if model_type.lower() == "ministral3" and task == "embedding":
+        config.is_causal = False
+        if pooling is not None:
+            config.pooling = pooling
+        if temperature is not None:
+            config.temperature = temperature
+        return AutoModel.from_pretrained(
+            model_name_or_path,
+            config=config,
+            trust_remote_code=trust_remote_code,
+            **hf_kwargs,
         )
 
     BidirectionalModelClass = _get_supported_backbone_class(model_type, task)
@@ -328,7 +366,7 @@ def save_encoder_pretrained(model: nn.Module, save_directory: str, **kwargs) -> 
     model.model.save_pretrained(save_directory)
 
 
-# HuggingFace model_type -> task -> bidirectional architecture class name in ModelRegistry
+# Model types that require a registered custom retrieval backbone for each task.
 _LLAMA_TASKS = {
     "embedding": "LlamaBidirectionalModel",
     "score": "LlamaBidirectionalForSequenceClassification",
@@ -342,7 +380,6 @@ _LLAMA_NEMOTRON_VL_TASKS = {
 SUPPORTED_BACKBONES = {
     "llama": _LLAMA_TASKS,
     "llama_bidirec": _LLAMA_TASKS,
-    "ministral3": _MINISTRAL3_BIDIREC_TASKS,
     "ministral3_bidirec": _MINISTRAL3_BIDIREC_TASKS,
     "llama_nemotron_vl": _LLAMA_NEMOTRON_VL_TASKS,
 }

--- a/nemo_automodel/_transformers/retrieval.py
+++ b/nemo_automodel/_transformers/retrieval.py
@@ -288,6 +288,7 @@ def build_encoder_backbone(
             "revision",
             "subfolder",
             "token",
+            "use_auth_token",
         )
         if key in hf_kwargs
     }

--- a/nemo_automodel/_transformers/retrieval.py
+++ b/nemo_automodel/_transformers/retrieval.py
@@ -277,7 +277,21 @@ def build_encoder_backbone(
         ValueError: If the task is unsupported for a known model type, or the
             architecture class is missing from :class:`ModelRegistry`.
     """
-    config = AutoConfig.from_pretrained(model_name_or_path, trust_remote_code=trust_remote_code)
+    config_load_kwargs = {
+        key: hf_kwargs[key]
+        for key in (
+            "cache_dir",
+            "code_revision",
+            "force_download",
+            "local_files_only",
+            "proxies",
+            "revision",
+            "subfolder",
+            "token",
+        )
+        if key in hf_kwargs
+    }
+    config = AutoConfig.from_pretrained(model_name_or_path, trust_remote_code=trust_remote_code, **config_load_kwargs)
     model_type = getattr(config, "model_type", "")
 
     if extract_submodel is not None:
@@ -292,6 +306,9 @@ def build_encoder_backbone(
             temperature=temperature,
             source_commit_hash=getattr(config, "_commit_hash", None),
         )
+
+    if model_type.lower() == "ministral3" and task != "embedding":
+        raise ValueError(f"Unsupported task '{task}' for model type '{model_type}'. Available tasks: embedding.")
 
     if model_type.lower() == "ministral3" and task == "embedding":
         config.is_causal = False

--- a/nemo_automodel/_transformers/retrieval.py
+++ b/nemo_automodel/_transformers/retrieval.py
@@ -114,16 +114,19 @@ def _build_backbone_from_extracted_submodel(
     model_type = getattr(text_config, "model_type", "")
     task_map = SUPPORTED_BACKBONES.get(model_type.lower())
     has_supported_target = task_map is not None and task in task_map
-    uses_stock_ministral_embedding = model_type.lower() == "ministral3" and task == "embedding"
 
     if task_map is not None and not has_supported_target and task != "score":
         raise ValueError(
             f"Unsupported task '{task}' for model type '{model_type}'. Available tasks: {', '.join(task_map)}."
         )
 
-    if uses_stock_ministral_embedding:
+    if model_type.lower() == "ministral3" and task == "embedding":
         config = _clone_pretrained_config(text_config)
         config.is_causal = False
+        if pooling is not None:
+            config.pooling = pooling
+        if temperature is not None:
+            config.temperature = temperature
         try:
             backbone_class = MODEL_MAPPING[type(config)]
         except KeyError as exc:
@@ -145,6 +148,10 @@ def _build_backbone_from_extracted_submodel(
         config_dict = text_config.to_dict()
         config_dict.pop("model_type", None)
         config = config_class(**config_dict)
+        if pooling is not None:
+            config.pooling = pooling
+        if temperature is not None:
+            config.temperature = temperature
 
     if source_commit_hash is None:
         source_commit_hash = getattr(text_config, "_commit_hash", None)
@@ -154,12 +161,8 @@ def _build_backbone_from_extracted_submodel(
     attn_implementation = getattr(text_config, "_attn_implementation", None)
     if attn_implementation is not None:
         config._attn_implementation = attn_implementation
-    if (has_supported_target or uses_stock_ministral_embedding) and pooling is not None:
-        config.pooling = pooling
     if num_labels is not None:
         config.num_labels = num_labels
-    if (has_supported_target or uses_stock_ministral_embedding) and temperature is not None:
-        config.temperature = temperature
 
     return _load_from_extracted_state(backbone_class, config, extracted_model)
 

--- a/nemo_automodel/_transformers/retrieval.py
+++ b/nemo_automodel/_transformers/retrieval.py
@@ -280,22 +280,7 @@ def build_encoder_backbone(
         ValueError: If the task is unsupported for a known model type, or the
             architecture class is missing from :class:`ModelRegistry`.
     """
-    config_load_kwargs = {
-        key: hf_kwargs[key]
-        for key in (
-            "cache_dir",
-            "code_revision",
-            "force_download",
-            "local_files_only",
-            "proxies",
-            "revision",
-            "subfolder",
-            "token",
-            "use_auth_token",
-        )
-        if key in hf_kwargs
-    }
-    config = AutoConfig.from_pretrained(model_name_or_path, trust_remote_code=trust_remote_code, **config_load_kwargs)
+    config = AutoConfig.from_pretrained(model_name_or_path, trust_remote_code=trust_remote_code, **hf_kwargs)
     model_type = getattr(config, "model_type", "")
 
     if extract_submodel is not None:
@@ -312,17 +297,17 @@ def build_encoder_backbone(
         )
 
     if model_type.lower() == "ministral3" and task == "embedding":
-        config.is_causal = False
-        if pooling is not None:
-            config.pooling = pooling
-        if temperature is not None:
-            config.temperature = temperature
-        return AutoModel.from_pretrained(
+        backbone = AutoModel.from_pretrained(
             model_name_or_path,
-            config=config,
             trust_remote_code=trust_remote_code,
             **hf_kwargs,
         )
+        backbone.config.is_causal = False
+        if pooling is not None:
+            backbone.config.pooling = pooling
+        if temperature is not None:
+            backbone.config.temperature = temperature
+        return backbone
 
     BidirectionalModelClass = _get_supported_backbone_class(model_type, task)
     if BidirectionalModelClass is not None:

--- a/nemo_automodel/_transformers/retrieval.py
+++ b/nemo_automodel/_transformers/retrieval.py
@@ -113,10 +113,6 @@ def _build_backbone_from_extracted_submodel(
     if model_type.lower() == "ministral3" and task == "embedding":
         config = text_config.__class__.from_dict(text_config.to_dict())
         config.is_causal = False
-        if pooling is not None:
-            config.pooling = pooling
-        if temperature is not None:
-            config.temperature = temperature
         try:
             backbone_class = MODEL_MAPPING[type(config)]
         except KeyError as exc:
@@ -287,10 +283,6 @@ def build_encoder_backbone(
             **hf_kwargs,
         )
         backbone.config.is_causal = False
-        if pooling is not None:
-            backbone.config.pooling = pooling
-        if temperature is not None:
-            backbone.config.temperature = temperature
         return backbone
 
     BidirectionalModelClass = _get_supported_backbone_class(model_type, task)

--- a/nemo_automodel/_transformers/retrieval.py
+++ b/nemo_automodel/_transformers/retrieval.py
@@ -23,7 +23,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from transformers import AutoConfig, AutoModel, AutoModelForSequenceClassification, PreTrainedModel
-from transformers.models.auto.modeling_auto import MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING, MODEL_MAPPING
+from transformers.models.auto.modeling_auto import MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING
 from transformers.utils import logging
 
 from nemo_automodel._transformers.registry import ModelRegistry
@@ -110,20 +110,15 @@ def _build_backbone_from_extracted_submodel(
             f"Unsupported task '{task}' for model type '{model_type}'. Available tasks: {', '.join(task_map)}."
         )
 
-    if model_type.lower() == "ministral3" and task == "embedding":
-        config = text_config.__class__.from_dict(text_config.to_dict())
-        config.is_causal = False
-        try:
-            backbone_class = MODEL_MAPPING[type(config)]
-        except KeyError as exc:
-            raise ValueError(f"No HuggingFace base model found for '{model_type}'.") from exc
-    elif task == "score" and not has_supported_target:
+    if task == "score" and not has_supported_target:
         config = text_config.__class__.from_dict(text_config.to_dict())
         try:
             backbone_class = MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING[type(config)]
         except KeyError as exc:
             raise ValueError(f"No HuggingFace sequence-classification model found for '{model_type}'.") from exc
     elif not has_supported_target:
+        if task == "embedding":
+            extracted_model.config.is_causal = False
         return extracted_model
     else:
         backbone_class = _get_supported_backbone_class(model_type, task)
@@ -230,16 +225,14 @@ def build_encoder_backbone(
     When ``extract_submodel`` is set, loads the parent model with HuggingFace
     Auto classes and extracts the dotted path. For supported extracted text
     backbones, it then builds the registered retrieval class for the requested
-    task. Extracted Ministral embedding backbones use the stock HuggingFace model
-    with ``is_causal=False``. For unsupported extracted text backbones, it returns
-    the extracted model for ``"embedding"`` and wraps it with
+    task. For unsupported extracted text backbones, it returns the extracted model
+    with ``is_causal=False`` for ``"embedding"`` and wraps it with
     ``AutoModelForSequenceClassification`` for ``"score"``.
 
-    Without ``extract_submodel``, standard Ministral embedding checkpoints use
-    the stock HuggingFace model with ``is_causal=False``. Model types listed in
-    :data:`SUPPORTED_BACKBONES` resolve to custom bidirectional classes from
-    :class:`ModelRegistry`; all other model types fall back to HuggingFace Auto
-    classes.
+    Without ``extract_submodel``, model types listed in :data:`SUPPORTED_BACKBONES`
+    resolve to custom bidirectional classes from :class:`ModelRegistry`; all other
+    model types fall back to HuggingFace Auto classes, with embedding backbones
+    configured with ``is_causal=False``.
 
     Args:
         model_name_or_path: Path or HuggingFace Hub identifier.
@@ -276,15 +269,6 @@ def build_encoder_backbone(
             temperature=temperature,
         )
 
-    if model_type.lower() == "ministral3" and task == "embedding":
-        backbone = AutoModel.from_pretrained(
-            model_name_or_path,
-            trust_remote_code=trust_remote_code,
-            **hf_kwargs,
-        )
-        backbone.config.is_causal = False
-        return backbone
-
     BidirectionalModelClass = _get_supported_backbone_class(model_type, task)
     if BidirectionalModelClass is not None:
         if pooling is not None:
@@ -305,7 +289,10 @@ def build_encoder_backbone(
         return AutoModelForSequenceClassification.from_pretrained(
             model_name_or_path, trust_remote_code=trust_remote_code, **hf_kwargs
         )
-    return AutoModel.from_pretrained(model_name_or_path, trust_remote_code=trust_remote_code, **hf_kwargs)
+    backbone = AutoModel.from_pretrained(model_name_or_path, trust_remote_code=trust_remote_code, **hf_kwargs)
+    if task == "embedding":
+        backbone.config.is_causal = False
+    return backbone
 
 
 def save_encoder_pretrained(model: nn.Module, save_directory: str, **kwargs) -> None:

--- a/nemo_automodel/_transformers/retrieval.py
+++ b/nemo_automodel/_transformers/retrieval.py
@@ -129,16 +129,16 @@ def _build_backbone_from_extracted_submodel(
         config_dict = text_config.to_dict()
         config_dict.pop("model_type", None)
         config = config_class(**config_dict)
-        if pooling is not None:
-            config.pooling = pooling
-        if temperature is not None:
-            config.temperature = temperature
 
     attn_implementation = getattr(text_config, "_attn_implementation", None)
     if attn_implementation is not None:
         config._attn_implementation = attn_implementation
+    if has_supported_target and pooling is not None:
+        config.pooling = pooling
     if num_labels is not None:
         config.num_labels = num_labels
+    if has_supported_target and temperature is not None:
+        config.temperature = temperature
 
     return _load_from_extracted_state(backbone_class, config, extracted_model)
 

--- a/nemo_automodel/components/models/ministral_bidirectional/model.py
+++ b/nemo_automodel/components/models/ministral_bidirectional/model.py
@@ -1,11 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0.
 """
-Bidirectional Ministral3 model for embedding tasks.
+Custom bidirectional Ministral3 model for explicit and legacy use.
 
 This module provides a modified Ministral3Model that uses bidirectional (non-causal)
 attention, suitable for generating embeddings where each token should attend
-to all other tokens in the sequence.
+to all other tokens in the sequence. Standard ``ministral3`` embedding checkpoints
+use the stock HuggingFace model with ``is_causal=False``; this custom architecture
+remains available for ``ministral3_bidirec`` checkpoints and future task-specific
+extensions.
 """
 
 from dataclasses import dataclass
@@ -37,7 +40,10 @@ class Ministral3BidirectionalModel(Ministral3Model):
     """
     Ministral3Model modified to use bidirectional (non-causal) attention.
 
-    In standard Ministral3, each token can only attend to previous tokens (causal
+    This class is not selected automatically for standard ``ministral3`` embedding
+    checkpoints. It remains registered for explicit and legacy use.
+
+    In causal Ministral3, each token can only attend to previous tokens (causal
     attention). This model removes that restriction, allowing each token to attend
     to all tokens in the sequence, which is useful for embedding tasks.
 

--- a/nemo_automodel/components/models/ministral_bidirectional/model.py
+++ b/nemo_automodel/components/models/ministral_bidirectional/model.py
@@ -7,8 +7,7 @@ This module provides a modified Ministral3Model that uses bidirectional (non-cau
 attention, suitable for generating embeddings where each token should attend
 to all other tokens in the sequence. Standard ``ministral3`` embedding checkpoints
 use the stock HuggingFace model with ``is_causal=False``; this custom architecture
-remains available for ``ministral3_bidirec`` checkpoints and future task-specific
-extensions.
+remains available for ``ministral3_bidirec`` checkpoints.
 """
 
 from dataclasses import dataclass

--- a/tests/unit_tests/_transformers/test_retrieval.py
+++ b/tests/unit_tests/_transformers/test_retrieval.py
@@ -20,13 +20,13 @@ from unittest.mock import MagicMock
 import pytest
 import torch
 import torch.nn as nn
-from transformers import AutoModel, Mistral3Config
+from transformers import AutoModel, Ministral3Config, Mistral3Config
+from transformers.models.ministral3.modeling_ministral3 import Ministral3Model
 
 from nemo_automodel.components.models.llama_bidirectional.model import (
     LlamaBidirectionalForSequenceClassification,
     LlamaBidirectionalModel,
 )
-from nemo_automodel.components.models.ministral_bidirectional.model import Ministral3BidirectionalModel
 
 
 def test_llama_nemotron_vl_supported_backbone_for_embedding():
@@ -71,6 +71,28 @@ def _save_tiny_vlm(tmp_path, text_model_type: str):
     model.save_pretrained(model_dir)
     language_state_dict = {key: tensor.detach().clone() for key, tensor in model.language_model.state_dict().items()}
     return model_dir, language_state_dict
+
+
+def _save_tiny_ministral_text_model(tmp_path):
+    """Save a tiny stock Ministral text checkpoint and return its weights."""
+    config = Ministral3Config(
+        vocab_size=32,
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=8,
+        max_position_embeddings=64,
+        sliding_window=4,
+        attention_dropout=0.0,
+    )
+    config._attn_implementation = "sdpa"
+    model = Ministral3Model(config)
+    model_dir = tmp_path / "ministral3_text"
+    model.save_pretrained(model_dir)
+    state_dict = {key: tensor.detach().clone() for key, tensor in model.state_dict().items()}
+    return model_dir, state_dict
 
 
 def _assert_state_dict_equal(expected: dict[str, torch.Tensor], actual: dict[str, torch.Tensor]) -> None:
@@ -153,8 +175,81 @@ def test_extract_submodel_llama_embedding_from_local_vlm_converts_to_supported_b
     assert outputs.last_hidden_state.shape == (2, 8, backbone.config.hidden_size)
 
 
+def test_ministral_embedding_uses_stock_bidirectional_model(tmp_path):
+    """Standard Ministral checkpoints use and save the stock non-causal model."""
+    from nemo_automodel._transformers import retrieval
+
+    model_dir, source_state_dict = _save_tiny_ministral_text_model(tmp_path)
+
+    backbone = retrieval.build_encoder_backbone(
+        model_name_or_path=str(model_dir),
+        task="embedding",
+        pooling="avg",
+    )
+
+    assert type(backbone) is Ministral3Model
+    assert backbone.config.model_type == "ministral3"
+    assert backbone.config.is_causal is False
+    assert backbone.config.pooling == "avg"
+    assert backbone.config.sliding_window == 4
+    assert backbone.config._attn_implementation == "sdpa"
+    _assert_state_dict_equal(source_state_dict, backbone.state_dict())
+
+    input_ids = torch.randint(0, backbone.config.vocab_size, (1, 4))
+    attention_mask = torch.ones_like(input_ids)
+    modified_input_ids = input_ids.clone()
+    modified_input_ids[0, -1] = (modified_input_ids[0, -1] + 1) % backbone.config.vocab_size
+    backbone.eval()
+    with torch.no_grad():
+        original_output = backbone(input_ids=input_ids, attention_mask=attention_mask).last_hidden_state
+        modified_output = backbone(input_ids=modified_input_ids, attention_mask=attention_mask).last_hidden_state
+    assert not torch.allclose(original_output[0, 0], modified_output[0, 0])
+
+    save_dir = tmp_path / "saved_stock_ministral"
+    backbone.save_pretrained(save_dir)
+
+    assert not list(save_dir.glob("*.py"))
+    reloaded = AutoModel.from_pretrained(save_dir)
+    assert type(reloaded) is Ministral3Model
+    assert reloaded.config.model_type == "ministral3"
+    assert reloaded.config.is_causal is False
+    assert getattr(reloaded.config, "auto_map", None) is None
+    _assert_state_dict_equal(source_state_dict, reloaded.state_dict())
+
+
+def test_ministral_embedding_uses_bidirectional_flash_attention(tmp_path, monkeypatch):
+    """Stock Ministral selects non-causal attention at the FlashAttention kernel boundary."""
+    from transformers.integrations import flash_attention
+
+    from nemo_automodel._transformers import retrieval
+
+    model_dir, _ = _save_tiny_ministral_text_model(tmp_path)
+    backbone = retrieval.build_encoder_backbone(
+        model_name_or_path=str(model_dir),
+        task="embedding",
+        pooling="avg",
+    )
+    assert backbone.config.is_causal is False
+    backbone.config._attn_implementation = "flash_attention_2"
+    assert all(layer.self_attn.is_causal is True for layer in backbone.layers)
+
+    kernel_calls = []
+
+    def record_flash_attention(query, key, value, attention_mask, **kwargs):
+        kernel_calls.append({"is_causal": kwargs.get("is_causal"), "attention_mask": attention_mask})
+        return torch.zeros_like(query)
+
+    monkeypatch.setattr(flash_attention, "_flash_attention_forward", record_flash_attention)
+
+    input_ids = torch.randint(0, backbone.config.vocab_size, (1, 4))
+    backbone(input_ids=input_ids, attention_mask=torch.ones_like(input_ids))
+
+    assert len(kernel_calls) == backbone.config.num_hidden_layers
+    assert all(call == {"is_causal": False, "attention_mask": None} for call in kernel_calls)
+
+
 def test_extract_submodel_ministral_embedding_from_local_vlm_converts_to_supported_backbone(tmp_path):
-    """The real Ministral3 VLM text backbone path becomes the Ministral bi-encoder."""
+    """A Ministral3 VLM text backbone becomes a stock non-causal Ministral model."""
     from nemo_automodel._transformers import retrieval
 
     model_dir, language_state_dict = _save_tiny_vlm(tmp_path, "ministral3")
@@ -163,10 +258,13 @@ def test_extract_submodel_ministral_embedding_from_local_vlm_converts_to_support
         model_name_or_path=str(model_dir),
         task="embedding",
         extract_submodel="language_model",
+        pooling="avg",
     )
 
-    assert isinstance(backbone, Ministral3BidirectionalModel)
-    assert backbone.config.model_type == "ministral3_bidirec"
+    assert type(backbone) is Ministral3Model
+    assert backbone.config.model_type == "ministral3"
+    assert backbone.config.is_causal is False
+    assert backbone.config.pooling == "avg"
     _assert_state_dict_equal(language_state_dict, backbone.state_dict())
 
     input_ids = torch.randint(0, backbone.config.vocab_size, (2, 8))
@@ -175,6 +273,35 @@ def test_extract_submodel_ministral_embedding_from_local_vlm_converts_to_support
     with torch.no_grad():
         outputs = backbone(input_ids=input_ids, attention_mask=attention_mask)
     assert outputs.last_hidden_state.shape == (2, 8, backbone.config.hidden_size)
+
+
+def test_extracted_ministral_preserves_outer_source_commit_hash(tmp_path, monkeypatch):
+    from nemo_automodel._transformers import retrieval
+
+    model_dir, _ = _save_tiny_ministral_text_model(tmp_path)
+    extracted_model = AutoModel.from_pretrained(model_dir)
+    assert getattr(extracted_model.config, "_commit_hash", None) is None
+
+    parent_model = MagicMock()
+    parent_model.language_model = extracted_model
+    outer_config = MagicMock()
+    outer_config.model_type = "mistral3"
+    outer_config._commit_hash = "source-commit"
+    auto_config_from_pretrained = MagicMock(return_value=outer_config)
+    auto_model_from_pretrained = MagicMock(return_value=parent_model)
+    monkeypatch.setattr(retrieval.AutoConfig, "from_pretrained", auto_config_from_pretrained)
+    monkeypatch.setattr(retrieval.AutoModel, "from_pretrained", auto_model_from_pretrained)
+
+    backbone = retrieval.build_encoder_backbone(
+        model_name_or_path="mistralai/source-model",
+        task="embedding",
+        extract_submodel="language_model",
+        pooling="avg",
+    )
+
+    assert backbone.config._commit_hash == "source-commit"
+    auto_config_from_pretrained.assert_called_once()
+    auto_model_from_pretrained.assert_called_once()
 
 
 def test_extract_submodel_llama_score_from_local_vlm_converts_to_supported_cross_encoder(tmp_path):

--- a/tests/unit_tests/_transformers/test_retrieval.py
+++ b/tests/unit_tests/_transformers/test_retrieval.py
@@ -213,6 +213,7 @@ def test_build_encoder_backbone_forwards_hub_location_kwargs_to_config_and_model
         cache_dir="/cache",
         local_files_only=True,
         use_auth_token="legacy-token",
+        torch_dtype=torch.bfloat16,
     )
     auto_model_from_pretrained.assert_called_once_with(
         "org/model",
@@ -250,6 +251,21 @@ def test_standard_ministral_score_uses_sequence_classification_model(tmp_path):
     with torch.no_grad():
         outputs = backbone(input_ids=input_ids, attention_mask=attention_mask)
     assert outputs.logits.shape == (2, 1)
+
+
+def test_ministral_embedding_preserves_hf_config_overrides(tmp_path):
+    """Valid HuggingFace config overrides retain native loader behavior."""
+    from nemo_automodel._transformers import retrieval
+
+    model_dir, _ = _save_tiny_ministral_text_model(tmp_path)
+
+    backbone = retrieval.build_encoder_backbone(
+        model_name_or_path=str(model_dir),
+        task="embedding",
+        output_attentions=True,
+    )
+
+    assert backbone.config.output_attentions is True
 
 
 def test_ministral_embedding_uses_stock_bidirectional_model(tmp_path):

--- a/tests/unit_tests/_transformers/test_retrieval.py
+++ b/tests/unit_tests/_transformers/test_retrieval.py
@@ -178,8 +178,8 @@ def test_extract_submodel_llama_embedding_from_local_vlm_converts_to_supported_b
     assert outputs.last_hidden_state.shape == (2, 8, backbone.config.hidden_size)
 
 
-def test_ministral_embedding_forwards_hf_kwargs_to_config_and_model(monkeypatch):
-    """Ministral config and weights receive the same native loader options."""
+def test_ministral_embedding_forwards_supported_hf_kwargs_to_config_and_model(monkeypatch):
+    """Ministral config and weights receive the same supported native loader options."""
     from nemo_automodel._transformers import retrieval
 
     config = MagicMock()
@@ -195,7 +195,6 @@ def test_ministral_embedding_forwards_hf_kwargs_to_config_and_model(monkeypatch)
         task="embedding",
         trust_remote_code=True,
         revision="revision-a",
-        use_auth_token="legacy-token",
         subfolder="encoder",
         token="token",
         cache_dir="/cache",
@@ -212,7 +211,6 @@ def test_ministral_embedding_forwards_hf_kwargs_to_config_and_model(monkeypatch)
         token="token",
         cache_dir="/cache",
         local_files_only=True,
-        use_auth_token="legacy-token",
         torch_dtype=torch.bfloat16,
     )
     auto_model_from_pretrained.assert_called_once_with(
@@ -224,7 +222,6 @@ def test_ministral_embedding_forwards_hf_kwargs_to_config_and_model(monkeypatch)
         cache_dir="/cache",
         local_files_only=True,
         torch_dtype=torch.bfloat16,
-        use_auth_token="legacy-token",
     )
 
 

--- a/tests/unit_tests/_transformers/test_retrieval.py
+++ b/tests/unit_tests/_transformers/test_retrieval.py
@@ -21,7 +21,10 @@ import pytest
 import torch
 import torch.nn as nn
 from transformers import AutoModel, Ministral3Config, Mistral3Config
-from transformers.models.ministral3.modeling_ministral3 import Ministral3Model
+from transformers.models.ministral3.modeling_ministral3 import (
+    Ministral3ForSequenceClassification,
+    Ministral3Model,
+)
 
 from nemo_automodel.components.models.llama_bidirectional.model import (
     LlamaBidirectionalForSequenceClassification,
@@ -224,14 +227,29 @@ def test_build_encoder_backbone_forwards_hub_location_kwargs_to_config_and_model
     )
 
 
-@pytest.mark.parametrize("task", ["score", "unsupported"])
-def test_direct_ministral_rejects_non_embedding_tasks(tmp_path, task):
+def test_standard_ministral_score_uses_sequence_classification_model(tmp_path):
+    """Standard Ministral score checkpoints retain the HuggingFace reranker path."""
     from nemo_automodel._transformers import retrieval
 
-    model_dir, _ = _save_tiny_ministral_text_model(tmp_path)
+    model_dir, source_state_dict = _save_tiny_ministral_text_model(tmp_path)
 
-    with pytest.raises(ValueError, match=f"Unsupported task '{task}'.*Available tasks: embedding"):
-        retrieval.build_encoder_backbone(model_name_or_path=str(model_dir), task=task, num_labels=1)
+    backbone = retrieval.build_encoder_backbone(
+        model_name_or_path=str(model_dir),
+        task="score",
+        num_labels=1,
+    )
+
+    assert type(backbone) is Ministral3ForSequenceClassification
+    assert backbone.config.model_type == "ministral3"
+    assert backbone.config.num_labels == 1
+    _assert_state_dict_equal(source_state_dict, backbone.model.state_dict())
+
+    input_ids = torch.randint(0, backbone.config.vocab_size, (2, 4))
+    attention_mask = torch.ones_like(input_ids)
+    backbone.eval()
+    with torch.no_grad():
+        outputs = backbone(input_ids=input_ids, attention_mask=attention_mask)
+    assert outputs.logits.shape == (2, 1)
 
 
 def test_ministral_embedding_uses_stock_bidirectional_model(tmp_path):

--- a/tests/unit_tests/_transformers/test_retrieval.py
+++ b/tests/unit_tests/_transformers/test_retrieval.py
@@ -178,12 +178,12 @@ def test_extract_submodel_llama_embedding_from_local_vlm_converts_to_supported_b
     assert outputs.last_hidden_state.shape == (2, 8, backbone.config.hidden_size)
 
 
-def test_build_encoder_backbone_forwards_hub_location_kwargs_to_config_and_model(monkeypatch):
-    """Config and weights resolve from the same Hub location and revision."""
+def test_ministral_embedding_forwards_hf_kwargs_to_config_and_model(monkeypatch):
+    """Ministral config and weights receive the same native loader options."""
     from nemo_automodel._transformers import retrieval
 
     config = MagicMock()
-    config.model_type = "qwen3"
+    config.model_type = "ministral3"
     backbone = MagicMock()
     auto_config_from_pretrained = MagicMock(return_value=config)
     auto_model_from_pretrained = MagicMock(return_value=backbone)

--- a/tests/unit_tests/_transformers/test_retrieval.py
+++ b/tests/unit_tests/_transformers/test_retrieval.py
@@ -175,6 +175,62 @@ def test_extract_submodel_llama_embedding_from_local_vlm_converts_to_supported_b
     assert outputs.last_hidden_state.shape == (2, 8, backbone.config.hidden_size)
 
 
+def test_build_encoder_backbone_forwards_hub_location_kwargs_to_config_and_model(monkeypatch):
+    """Config and weights resolve from the same Hub location and revision."""
+    from nemo_automodel._transformers import retrieval
+
+    config = MagicMock()
+    config.model_type = "qwen3"
+    backbone = MagicMock()
+    auto_config_from_pretrained = MagicMock(return_value=config)
+    auto_model_from_pretrained = MagicMock(return_value=backbone)
+    monkeypatch.setattr(retrieval.AutoConfig, "from_pretrained", auto_config_from_pretrained)
+    monkeypatch.setattr(retrieval.AutoModel, "from_pretrained", auto_model_from_pretrained)
+
+    result = retrieval.build_encoder_backbone(
+        model_name_or_path="org/model",
+        task="embedding",
+        trust_remote_code=True,
+        revision="revision-a",
+        subfolder="encoder",
+        token="token",
+        cache_dir="/cache",
+        local_files_only=True,
+        torch_dtype=torch.bfloat16,
+    )
+
+    assert result is backbone
+    auto_config_from_pretrained.assert_called_once_with(
+        "org/model",
+        trust_remote_code=True,
+        revision="revision-a",
+        subfolder="encoder",
+        token="token",
+        cache_dir="/cache",
+        local_files_only=True,
+    )
+    auto_model_from_pretrained.assert_called_once_with(
+        "org/model",
+        trust_remote_code=True,
+        revision="revision-a",
+        subfolder="encoder",
+        token="token",
+        cache_dir="/cache",
+        local_files_only=True,
+        torch_dtype=torch.bfloat16,
+    )
+
+
+@pytest.mark.parametrize("task", ["score", "unsupported"])
+def test_direct_ministral_rejects_non_embedding_tasks(tmp_path, task):
+    from nemo_automodel._transformers import retrieval
+
+    model_dir, _ = _save_tiny_ministral_text_model(tmp_path)
+
+    with pytest.raises(ValueError, match=f"Unsupported task '{task}'.*Available tasks: embedding"):
+        retrieval.build_encoder_backbone(model_name_or_path=str(model_dir), task=task, num_labels=1)
+
+
 def test_ministral_embedding_uses_stock_bidirectional_model(tmp_path):
     """Standard Ministral checkpoints use and save the stock non-causal model."""
     from nemo_automodel._transformers import retrieval

--- a/tests/unit_tests/_transformers/test_retrieval.py
+++ b/tests/unit_tests/_transformers/test_retrieval.py
@@ -192,6 +192,7 @@ def test_build_encoder_backbone_forwards_hub_location_kwargs_to_config_and_model
         task="embedding",
         trust_remote_code=True,
         revision="revision-a",
+        use_auth_token="legacy-token",
         subfolder="encoder",
         token="token",
         cache_dir="/cache",
@@ -208,6 +209,7 @@ def test_build_encoder_backbone_forwards_hub_location_kwargs_to_config_and_model
         token="token",
         cache_dir="/cache",
         local_files_only=True,
+        use_auth_token="legacy-token",
     )
     auto_model_from_pretrained.assert_called_once_with(
         "org/model",
@@ -218,6 +220,7 @@ def test_build_encoder_backbone_forwards_hub_location_kwargs_to_config_and_model
         cache_dir="/cache",
         local_files_only=True,
         torch_dtype=torch.bfloat16,
+        use_auth_token="legacy-token",
     )
 
 

--- a/tests/unit_tests/_transformers/test_retrieval.py
+++ b/tests/unit_tests/_transformers/test_retrieval.py
@@ -368,35 +368,6 @@ def test_extract_submodel_ministral_embedding_from_local_vlm_converts_to_support
     assert outputs.last_hidden_state.shape == (2, 8, backbone.config.hidden_size)
 
 
-def test_extracted_ministral_preserves_outer_source_commit_hash(tmp_path, monkeypatch):
-    from nemo_automodel._transformers import retrieval
-
-    model_dir, _ = _save_tiny_ministral_text_model(tmp_path)
-    extracted_model = AutoModel.from_pretrained(model_dir)
-    assert getattr(extracted_model.config, "_commit_hash", None) is None
-
-    parent_model = MagicMock()
-    parent_model.language_model = extracted_model
-    outer_config = MagicMock()
-    outer_config.model_type = "mistral3"
-    outer_config._commit_hash = "source-commit"
-    auto_config_from_pretrained = MagicMock(return_value=outer_config)
-    auto_model_from_pretrained = MagicMock(return_value=parent_model)
-    monkeypatch.setattr(retrieval.AutoConfig, "from_pretrained", auto_config_from_pretrained)
-    monkeypatch.setattr(retrieval.AutoModel, "from_pretrained", auto_model_from_pretrained)
-
-    backbone = retrieval.build_encoder_backbone(
-        model_name_or_path="mistralai/source-model",
-        task="embedding",
-        extract_submodel="language_model",
-        pooling="avg",
-    )
-
-    assert backbone.config._commit_hash == "source-commit"
-    auto_config_from_pretrained.assert_called_once()
-    auto_model_from_pretrained.assert_called_once()
-
-
 def test_extract_submodel_llama_score_from_local_vlm_converts_to_supported_cross_encoder(tmp_path):
     """A supported extracted Llama text backbone becomes the retrieval reranker."""
     from nemo_automodel._transformers import retrieval

--- a/tests/unit_tests/_transformers/test_retrieval.py
+++ b/tests/unit_tests/_transformers/test_retrieval.py
@@ -275,12 +275,14 @@ def test_ministral_embedding_uses_stock_bidirectional_model(tmp_path):
         model_name_or_path=str(model_dir),
         task="embedding",
         pooling="avg",
+        temperature=0.5,
     )
 
     assert type(backbone) is Ministral3Model
     assert backbone.config.model_type == "ministral3"
     assert backbone.config.is_causal is False
-    assert backbone.config.pooling == "avg"
+    assert not hasattr(backbone.config, "pooling")
+    assert not hasattr(backbone.config, "temperature")
     assert backbone.config.sliding_window == 4
     assert backbone.config._attn_implementation == "sdpa"
     _assert_state_dict_equal(source_state_dict, backbone.state_dict())
@@ -349,12 +351,14 @@ def test_extract_submodel_ministral_embedding_from_local_vlm_converts_to_support
         task="embedding",
         extract_submodel="language_model",
         pooling="avg",
+        temperature=0.5,
     )
 
     assert type(backbone) is Ministral3Model
     assert backbone.config.model_type == "ministral3"
     assert backbone.config.is_causal is False
-    assert backbone.config.pooling == "avg"
+    assert not hasattr(backbone.config, "pooling")
+    assert not hasattr(backbone.config, "temperature")
     _assert_state_dict_equal(language_state_dict, backbone.state_dict())
 
     input_ids = torch.randint(0, backbone.config.vocab_size, (2, 8))

--- a/tests/unit_tests/_transformers/test_retrieval.py
+++ b/tests/unit_tests/_transformers/test_retrieval.py
@@ -128,8 +128,8 @@ def test_save_encoder_pretrained_forwards_is_final_checkpoint(tmp_path, kwargs, 
     )
 
 
-def test_extract_submodel_unsupported_embedding_from_local_vlm(tmp_path):
-    """Unsupported extracted text backbones are returned directly for bi-encoder use."""
+def test_extract_submodel_embedding_fallback_is_bidirectional(tmp_path):
+    """Extracted HuggingFace embedding fallbacks use bidirectional attention."""
     from nemo_automodel._transformers import retrieval
 
     model_dir, language_state_dict = _save_tiny_vlm(tmp_path, "mistral")
@@ -142,13 +142,25 @@ def test_extract_submodel_unsupported_embedding_from_local_vlm(tmp_path):
 
     assert backbone.__class__.__name__ == "MistralModel"
     assert backbone.config.model_type == "mistral"
+    assert backbone.config.is_causal is False
     _assert_no_language_model_prefix(backbone)
     _assert_state_dict_equal(language_state_dict, backbone.state_dict())
+
+    input_ids = torch.randint(0, backbone.config.vocab_size, (1, 4))
+    attention_mask = torch.ones_like(input_ids)
+    modified_input_ids = input_ids.clone()
+    modified_input_ids[0, -1] = (modified_input_ids[0, -1] + 1) % backbone.config.vocab_size
+    backbone.eval()
+    with torch.no_grad():
+        original_output = backbone(input_ids=input_ids, attention_mask=attention_mask).last_hidden_state
+        modified_output = backbone(input_ids=modified_input_ids, attention_mask=attention_mask).last_hidden_state
+    assert not torch.allclose(original_output[0, 0], modified_output[0, 0])
 
     save_dir = tmp_path / "mistral_text_backbone"
     backbone.save_pretrained(save_dir)
     saved_config = json.loads((save_dir / "config.json").read_text())
     assert saved_config["model_type"] == "mistral"
+    assert saved_config["is_causal"] is False
 
 
 def test_extract_submodel_llama_embedding_from_local_vlm_converts_to_supported_backbone(tmp_path):
@@ -178,12 +190,12 @@ def test_extract_submodel_llama_embedding_from_local_vlm_converts_to_supported_b
     assert outputs.last_hidden_state.shape == (2, 8, backbone.config.hidden_size)
 
 
-def test_ministral_embedding_forwards_supported_hf_kwargs_to_config_and_model(monkeypatch):
-    """Ministral config and weights receive the same supported native loader options."""
+def test_embedding_fallback_forwards_hf_kwargs_and_disables_causal_attention(monkeypatch):
+    """Embedding fallbacks preserve loader options and disable causal attention."""
     from nemo_automodel._transformers import retrieval
 
     config = MagicMock()
-    config.model_type = "ministral3"
+    config.model_type = "mistral"
     backbone = MagicMock()
     auto_config_from_pretrained = MagicMock(return_value=config)
     auto_model_from_pretrained = MagicMock(return_value=backbone)
@@ -203,6 +215,7 @@ def test_ministral_embedding_forwards_supported_hf_kwargs_to_config_and_model(mo
     )
 
     assert result is backbone
+    assert backbone.config.is_causal is False
     auto_config_from_pretrained.assert_called_once_with(
         "org/model",
         trust_remote_code=True,

--- a/tests/unit_tests/models/bi_encoder/test_ministral_bidirectional_model.py
+++ b/tests/unit_tests/models/bi_encoder/test_ministral_bidirectional_model.py
@@ -15,6 +15,8 @@
 """Unit tests for Ministral3 bidirectional encoder (retrieval / bi-encoder path)."""
 
 import json
+import subprocess
+import sys
 
 import pytest
 import torch
@@ -53,6 +55,26 @@ def test_ministral3_bidirectional_config_fields():
     assert cfg.pooling == "cls"
     assert isinstance(cfg.temperature, float)
     assert cfg.model_type == "ministral3_bidirec"
+
+
+def test_legacy_ministral_checkpoint_loads_in_fresh_process(tmp_path):
+    model_dir = tmp_path / "legacy_ministral"
+    Ministral3BidirectionalModel(tiny_bidirectional_config()).save_pretrained(model_dir)
+
+    code = (
+        "from nemo_automodel._transformers.retrieval import build_encoder_backbone; "
+        f"model = build_encoder_backbone(r'{model_dir}', 'embedding', pooling='avg'); "
+        "assert type(model).__name__ == 'Ministral3BidirectionalModel'; "
+        "assert model.config.model_type == 'ministral3_bidirec'"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", code],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
 
 
 def test_ministral3_bidirectional_model_init_and_mask():
@@ -136,7 +158,7 @@ class FakeLM(nn.Module):
         self.saved.append(out_dir)
 
 
-def test_encoder_build_ministral3_registry_path(tmp_path, monkeypatch):
+def test_encoder_build_legacy_ministral_registry_path(tmp_path, monkeypatch):
     class FakeBidirectionalModel(FakeLM):
         @classmethod
         def from_pretrained(cls, *args, **kwargs):
@@ -147,7 +169,7 @@ def test_encoder_build_ministral3_registry_path(tmp_path, monkeypatch):
 
     model_dir = tmp_path / "model"
     model_dir.mkdir()
-    (model_dir / "config.json").write_text(json.dumps({"model_type": "ministral3"}))
+    (model_dir / "config.json").write_text(json.dumps({"model_type": "ministral3_bidirec"}))
 
     model = BiEncoderModel.build(
         model_name_or_path=str(model_dir),
@@ -161,23 +183,11 @@ def test_encoder_build_ministral3_registry_path(tmp_path, monkeypatch):
     assert any("save1" in p for p in model.model.saved)
 
 
-@pytest.mark.parametrize("top_level_model_type", ["ministral3", "ministral3_bidirec"])
-def test_encoder_build_ministral_supported_model_types(tmp_path, monkeypatch, top_level_model_type):
-    """Hub / local text configs use ministral3; saved bidirectional checkpoints use ministral3_bidirec."""
-    class FakeBidirectionalModel(FakeLM):
-        @classmethod
-        def from_pretrained(cls, *args, **kwargs):
-            return cls(hidden=16)
+def test_ministral_dispatch_uses_custom_class_only_for_legacy_checkpoints():
+    from nemo_automodel._transformers.retrieval import SUPPORTED_BACKBONES
 
-    ModelRegistry.model_arch_name_to_cls["Ministral3BidirectionalModel"] = FakeBidirectionalModel
-    monkeypatch.setattr(ModelRegistry, "model_arch_name_to_cls", ModelRegistry.model_arch_name_to_cls)
-
-    model_dir = tmp_path / "hub" / "checkpoint"
-    model_dir.mkdir(parents=True)
-    (model_dir / "config.json").write_text(json.dumps({"model_type": top_level_model_type}))
-
-    model = BiEncoderModel.build(model_name_or_path=str(model_dir), pooling="avg", l2_normalize=True)
-    assert isinstance(model, BiEncoderModel)
+    assert "ministral3" not in SUPPORTED_BACKBONES
+    assert SUPPORTED_BACKBONES["ministral3_bidirec"]["embedding"] == "Ministral3BidirectionalModel"
 
 
 def test_configure_encoder_metadata_sets_auto_map_for_ministral_retrieval():


### PR DESCRIPTION
# What does this PR do ?

Configure Hugging Face retrieval embedding fallback backbones with bidirectional attention by default while retaining registered custom backbones and existing reranking behavior.

# Changelog

- Configure direct and extracted Hugging Face embedding fallbacks with `is_causal=false`, including the stock `Ministral3Model`.
- Preserve the stock Hugging Face sequence-classification path for standard Ministral score models.
- Keep the custom `ministral3_bidirec` class available only for explicit and legacy checkpoints.
- Preserve native Hugging Face loader options across config discovery and model loading.
- Test generic direct and extracted embedding fallbacks, bidirectional attention, plain Hugging Face save/reload, legacy dispatch, standard score dispatch, and unchanged Llama embedding and cross-encoder dispatch.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

# Additional Information

- This is the architecture-loading prerequisite for the Sentence Transformers export PR.
- The generic extracted-export sharding fix discovered during this work has been split into #3423.
- Focused retrieval, registry, and legacy-model verification: 74 passed, 1 skipped.
- A live regression check with `nvidia/llama-nemotron-rerank-1b-v2` confirmed that the existing Llama cross-encoder path still trains and reloads correctly.