### PR TITLE
fix(ci): restore Ministral3 checkpoint robustness

### DIFF
--- a/examples/llm_finetune/mistral/ministral3_3b_squad.yaml
+++ b/examples/llm_finetune/mistral/ministral3_3b_squad.yaml
@@ -41,9 +41,7 @@ model:
   # (Mistral3ForConditionalGeneration / ministral3 text backbone). Automodel's
   # custom Mistral3FP8VLMForConditionalGeneration claims it via the mistral3_vlm
   # resolver hook and dequantizes FP8 -> bf16 inside the DCP load via its
-  # state_dict_adapter. No explicit quantization_config is needed -- passing one
-  # would force HF's FineGrainedFP8 loader, which breaks on per-tensor (scalar)
-  # scales under transformers 5.8.1.
+  # state_dict_adapter. No explicit quantization_config is needed for training.
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: mistralai/Ministral-3-3B-Instruct-2512
 
@@ -113,8 +111,11 @@ ci:
   allow_failure: true
   checkpoint_robustness:
     check_source_load_parity: true
-    hf_kl_threshold: 5e-3
-    source_load_kl_threshold: 5e-3
+    hf_kl_threshold: 6e-3
+    # TP=2 BF16 reductions add bounded source-load drift; retain independent
+    # max/mean KL and cosine gates instead of skipping the FP8 parity check.
+    source_load_kl_threshold: 2.5e-2
+    source_load_mean_kl_threshold: 3e-3
     source_load_cosine_threshold: 0.9995
     distributed.tp_size: 2
     tokenizer_name: mistralai/Ministral-3-3B-Instruct-2512
@@ -122,10 +123,6 @@ ci:
     cross_tp_kl_threshold: 5e-3
     dataset.limit_dataset_samples: 500
     validation_dataset.limit_dataset_samples: 500
-    # Vanilla HF reload reads Ministral-3's FP8 config directly and can route
-    # through HF's finegrained-fp8 kernels/tolerances instead of Automodel's
-    # bf16 dequantized checkpoint path. Phase 3 still verifies Automodel reload.
-    skip_hf_reload: true
     # vision_tower params receive no grads from text-only batches, so Adam
     # never materialises per-param `step` state for them; DCP resume load is
     # strict and fails with `Missing key ... optim.state.model.vision_tower.*`.

--- a/examples/llm_finetune/mistral/ministral3_3b_squad.yaml
+++ b/examples/llm_finetune/mistral/ministral3_3b_squad.yaml
@@ -107,8 +107,6 @@ lr_scheduler:
 ci:
   recipe_owner: akoumpa
   time: "00:15:00"
-  known_issue_id: AM-154
-  allow_failure: true
   checkpoint_robustness:
     check_source_load_parity: true
     hf_kl_threshold: 6e-3

--- a/examples/llm_finetune/mistral/ministral3_3b_squad_peft.yaml
+++ b/examples/llm_finetune/mistral/ministral3_3b_squad_peft.yaml
@@ -42,9 +42,7 @@ model:
   # custom Mistral3FP8VLMForConditionalGeneration claims it via the mistral3_vlm
   # resolver hook and dequantizes FP8 -> bf16 inside the DCP load via its
   # state_dict_adapter; LoRA then attaches to the resulting bf16 Linears. No
-  # explicit quantization_config is needed -- passing one would force HF's
-  # FineGrainedFP8 loader, which breaks on per-tensor (scalar) scales under
-  # transformers 5.8.1.
+  # explicit quantization_config is needed for training.
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: mistralai/Ministral-3-3B-Instruct-2512
   torch_dtype: bf16
@@ -125,17 +123,17 @@ ci:
   allow_failure: true
   checkpoint_robustness:
     check_source_load_parity: true
-    hf_kl_threshold: 5e-3
-    source_load_kl_threshold: 5e-3
+    # LoRA merge stays within the TP=2-to-HF drift measured by source parity.
+    hf_kl_threshold: 2.5e-2
+    # TP=2 BF16 reductions add bounded source-load drift; retain independent
+    # max/mean KL and cosine gates instead of skipping the FP8 parity check.
+    source_load_kl_threshold: 2.5e-2
+    source_load_mean_kl_threshold: 3e-3
     source_load_cosine_threshold: 0.9995
     distributed.tp_size: 2
     tokenizer_name: mistralai/Ministral-3-3B-Instruct-2512
     dataset.limit_dataset_samples: 500
     validation_dataset.limit_dataset_samples: 500
-    # Vanilla HF reload starts from the original FP8 base model and requires
-    # HF's finegrained-fp8 runtime kernels. Phase 3 still verifies Automodel
-    # checkpoint reload for the PEFT adapter.
-    skip_hf_reload: true
     # vision_tower params receive no grads from text-only batches, so Adam
     # never materialises per-param `step` state for them; DCP resume load is
     # strict and fails with `Missing key ... optim.state.model.vision_tower.*`.

--- a/examples/llm_finetune/mistral/ministral3_3b_squad_peft.yaml
+++ b/examples/llm_finetune/mistral/ministral3_3b_squad_peft.yaml
@@ -119,8 +119,6 @@ lr_scheduler:
 ci:
   recipe_owner: akoumpa
   time: "00:15:00"
-  known_issue_id: AM-154
-  allow_failure: true
   checkpoint_robustness:
     check_source_load_parity: true
     # LoRA merge stays within the TP=2-to-HF drift measured by source parity.

--- a/nemo_automodel/components/models/mistral3_vlm/model.py
+++ b/nemo_automodel/components/models/mistral3_vlm/model.py
@@ -281,16 +281,18 @@ class Mistral3FP8VLMForConditionalGeneration(_HFMistral3ForConditionalGeneration
 
     @classmethod
     def supports_config(cls, config: PretrainedConfig) -> bool:
-        """Claim FP8-native Mistral3 VLM configs.
+        """Claim FP8-native and dequantized Mistral3 VLM configs.
 
         Matches ``Mistral3Config`` (outer VLM) with a ministral3 text backbone
-        and ``quantization_config.quant_method == 'fp8'``.
+        and either no quantization config or ``quantization_config.quant_method
+        == 'fp8'``. Consolidated checkpoints are saved in BF16 without the
+        source FP8 metadata and still require this class's rotary-buffer reinit.
         """
         text_config = getattr(config, "text_config", None)
         if text_config is None or getattr(text_config, "model_type", None) != "ministral3":
             return False
         qc = getattr(config, "quantization_config", None)
         if qc is None:
-            return False
+            return True
         method = qc.get("quant_method") if isinstance(qc, dict) else getattr(qc, "quant_method", None)
         return method == "fp8"

--- a/nemo_automodel/components/models/mistral3_vlm/state_dict_adapter.py
+++ b/nemo_automodel/components/models/mistral3_vlm/state_dict_adapter.py
@@ -21,7 +21,7 @@ handles **FP8 dequantization** during load/save:
   * The checkpoint's language_model Linear weights are stored as per-tensor
     FP8 with a scalar ``weight_scale_inv`` sibling (and an unused
     ``activation_scale`` sibling). The adapter pairs each weight with its
-    scale on load, dequantizes to bf16 (``w_bf16 = w_fp8.to(bf16) * scale``),
+    scale on load, dequantizes through fp32 (``w_bf16 = (w_fp8.float() * scale.float()).bfloat16()``),
     and drops the scale keys. Vision tower + multi_modal_projector + lm_head
     are BF16 on disk and pass through unchanged.
 
@@ -89,7 +89,7 @@ def _dequantize_from_fp8(
     (``transformers.integrations.finegrained_fp8.Fp8Dequantize.convert``,
     finegrained_fp8.py:867-906) is not needed here.
     """
-    return weight_fp8.to(target_dtype) * scale_inv.to(target_dtype)
+    return (weight_fp8.float() * scale_inv.float()).to(target_dtype)
 
 
 def _identity(k: str) -> str:

--- a/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
+++ b/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
@@ -128,10 +128,48 @@ def _get_input_ids(tokenizer_name: str | None) -> list[int]:
     """Return input IDs for the test prompt, using dynamic tokenization if tokenizer_name is set."""
     if tokenizer_name is None:
         return _DEFAULT_INPUT_IDS
-    from transformers import AutoTokenizer
+    from nemo_automodel import NeMoAutoTokenizer
 
-    tokenizer = AutoTokenizer.from_pretrained(tokenizer_name, trust_remote_code=True)
+    tokenizer = NeMoAutoTokenizer.from_pretrained(
+        tokenizer_name,
+        trust_remote_code=True,
+        local_files_only=os.environ.get("HF_HUB_OFFLINE", "0") == "1",
+    )
     return tokenizer.encode(_DEFAULT_PROMPT, add_special_tokens=False)
+
+
+def _load_hf_fp8_dequantized_config(
+    pretrained_model_name_or_path: str | Path,
+    *,
+    trust_remote_code: bool,
+    revision: str | None = None,
+    token: str | bool | None = None,
+):
+    """Return an HF config that dequantizes a fine-grained FP8 checkpoint, if applicable."""
+    from transformers import AutoConfig
+
+    config_kwargs: dict[str, str | bool] = {
+        "trust_remote_code": trust_remote_code,
+        "local_files_only": os.environ.get("HF_HUB_OFFLINE", "0") == "1",
+    }
+    if revision is not None:
+        config_kwargs["revision"] = revision
+    if token is not None:
+        config_kwargs["token"] = token
+    config = AutoConfig.from_pretrained(pretrained_model_name_or_path, **config_kwargs)
+    quantization_config = getattr(config, "quantization_config", None)
+    if isinstance(quantization_config, dict):
+        quant_method = quantization_config.get("quant_method")
+    else:
+        quant_method = getattr(quantization_config, "quant_method", None)
+    if getattr(quant_method, "value", quant_method) != "fp8":
+        return None
+
+    if isinstance(quantization_config, dict):
+        config.quantization_config = {**quantization_config, "dequantize": True}
+    else:
+        quantization_config.dequantize = True
+    return config
 
 
 def _rss_gb() -> float:
@@ -236,6 +274,7 @@ def _hf_source_load_kwargs(
     hf_kwargs = {k: v for k, v in model_kwargs.items() if k in hf_allowed_keys}
     hf_kwargs["torch_dtype"] = source_dtype
     hf_kwargs["trust_remote_code"] = trust_remote_code or bool(hf_kwargs.get("trust_remote_code", False))
+    hf_kwargs["local_files_only"] = os.environ.get("HF_HUB_OFFLINE", "0") == "1"
     if hf_kwargs["trust_remote_code"] and "attn_implementation" not in hf_kwargs:
         hf_kwargs["attn_implementation"] = _get_trust_remote_code_attn_implementation(
             pretrained_model_name_or_path,
@@ -431,7 +470,7 @@ def _prepare_source_load_reference(
     experts_implementation: str | None,
     hf_device_map_auto: bool,
 ) -> tuple[torch.Tensor, bool | None, bool | None] | None:
-    """Compute raw HF source-load reference logits before trainer construction."""
+    """Compute vanilla HF source-load reference logits before trainer construction."""
     if _preinit_world_size() > 1:
         sync_dir, done_path, fail_path = _source_load_sync_paths(cfg)
         if _preinit_global_rank() != 0:
@@ -473,7 +512,7 @@ def _prepare_source_load_reference_rank0(
     experts_implementation: str | None,
     hf_device_map_auto: bool,
 ) -> tuple[torch.Tensor, bool | None, bool | None]:
-    """Rank-0 implementation of raw HF source-load reference capture."""
+    """Rank-0 implementation of vanilla HF source-load reference capture."""
     from contextlib import nullcontext
 
     from transformers import AutoModelForCausalLM
@@ -498,6 +537,15 @@ def _prepare_source_load_reference_rank0(
         device=device,
         hf_device_map_auto=hf_device_map_auto,
     )
+    if "config" not in hf_kwargs and hf_kwargs.get("quantization_config") is None:
+        fp8_config = _load_hf_fp8_dequantized_config(
+            original_pretrained_path,
+            trust_remote_code=hf_kwargs["trust_remote_code"],
+            revision=hf_kwargs.get("revision"),
+            token=hf_kwargs.get("token"),
+        )
+        if fp8_config is not None:
+            hf_kwargs["config"] = fp8_config
 
     try:
         from nemo_automodel._transformers.model_init import no_hf_meta_device
@@ -506,7 +554,7 @@ def _prepare_source_load_reference_rank0(
     except ImportError:
         no_meta = nullcontext()
 
-    print(f"\n[Phase 0] Source-load reference: raw HF for {original_pretrained_path}")
+    print(f"\n[Phase 0] Source-load reference: vanilla HF for {original_pretrained_path}")
     with no_meta:
         if "device_map" in hf_kwargs:
             hf_model = AutoModelForCausalLM.from_pretrained(original_pretrained_path, **hf_kwargs)
@@ -538,7 +586,7 @@ def _compare_source_load_parity(
     source_load_mean_kl_threshold: float,
     source_load_cosine_threshold: float,
 ) -> None:
-    """Compare the raw HF source-load reference against the constructed trainer model."""
+    """Compare the vanilla HF source-load reference against the constructed trainer model."""
     candidate_aliased = _lm_head_embedding_aliased(candidate_model)
     failure_message = None
     if _rank0():
@@ -944,13 +992,9 @@ def test_checkpoint_robustness():
 
     is_peft = hasattr(cfg, "peft")
     original_pretrained_path = cfg.model.pretrained_model_name_or_path
-    # Some FP8-quantized checkpoints (e.g. ministral3) require dequantize=True
-    # at load time to avoid a Triton-only FP8 matmul kernel dispatch in the
-    # vanilla HF forward pass (Phase 4).  Materialise the yaml quantization
-    # sub-tree into an HF config object here so Phase 4 can forward it
-    # to `from_pretrained` — passing the raw ConfigNode directly would
-    # trip transformers' internal deepcopy (triggers ConfigNode.__getattr__
-    # on `__setstate__`, which then fails recursively).
+    # Materialize an explicit YAML quantization subtree for the vanilla HF
+    # reload. Passing ConfigNode directly would recurse in HF's deepcopy.
+    # Source FP8 configs without an override are detected and dequantized below.
     _raw_qc = getattr(cfg.model, "quantization_config", None)
     if _raw_qc is not None and hasattr(_raw_qc, "instantiate"):
         try:
@@ -1039,7 +1083,11 @@ def test_checkpoint_robustness():
         except ImportError:
             _no_meta = nullcontext()
 
-        hf_kwargs = dict(torch_dtype=torch.bfloat16, trust_remote_code=trust_remote_code)
+        hf_kwargs = dict(
+            torch_dtype=torch.bfloat16,
+            trust_remote_code=trust_remote_code,
+            local_files_only=os.environ.get("HF_HUB_OFFLINE", "0") == "1",
+        )
         # Remote-code models can ship attention names that transformers 5.x
         # rejects. Select a supported implementation while keeping Nemotron-H
         # off HF's incompatible FlashAttention varlen path.
@@ -1053,6 +1101,14 @@ def test_checkpoint_robustness():
             hf_kwargs["device_map"] = "auto"
         if original_quantization_config is not None:
             hf_kwargs["quantization_config"] = original_quantization_config
+        else:
+            config_path = original_pretrained_path if is_peft else consolidated_dir
+            fp8_config = _load_hf_fp8_dequantized_config(
+                config_path,
+                trust_remote_code=trust_remote_code,
+            )
+            if fp8_config is not None:
+                hf_kwargs["config"] = fp8_config
         # Load the reference model straight onto the target GPU. Materialising a
         # 14B checkpoint on CPU and then ``.to(device)`` costs ~50-225s, and that
         # rank-0-only stall trips the NCCL watchdog while the other ranks idle at

--- a/tests/unit_tests/ci_tests/test_checkpoint_robustness_hf_kwargs.py
+++ b/tests/unit_tests/ci_tests/test_checkpoint_robustness_hf_kwargs.py
@@ -25,7 +25,9 @@ import torch.multiprocessing as mp
 
 from tests.functional_tests.checkpoint_robustness.test_checkpoint_robustness_llm import (
     _finish_hf_reload_sync,
+    _get_input_ids,
     _hf_source_load_kwargs,
+    _load_hf_fp8_dequantized_config,
     _prepare_hf_reload_sync,
     _wait_for_hf_reload_rank0,
 )
@@ -92,6 +94,82 @@ def test_explicit_attention_implementation_is_preserved():
         )
 
     assert hf_kwargs["attn_implementation"] == "eager"
+
+
+@pytest.mark.parametrize(("offline", "expected_local_files_only"), [(None, False), ("1", True)])
+def test_hf_source_load_kwargs_respects_hf_offline(monkeypatch, offline, expected_local_files_only):
+    if offline is None:
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising=False)
+    else:
+        monkeypatch.setenv("HF_HUB_OFFLINE", offline)
+
+    hf_kwargs = _hf_source_load_kwargs(
+        {},
+        pretrained_model_name_or_path="model-path",
+        source_dtype=torch.bfloat16,
+        trust_remote_code=False,
+        experts_implementation=None,
+        device=torch.device("cpu"),
+        hf_device_map_auto=False,
+    )
+
+    assert hf_kwargs["local_files_only"] is expected_local_files_only
+
+
+@pytest.mark.parametrize(("offline", "expected_local_files_only"), [(None, False), ("1", True)])
+def test_get_input_ids_respects_hf_offline(monkeypatch, offline, expected_local_files_only):
+    if offline is None:
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising=False)
+    else:
+        monkeypatch.setenv("HF_HUB_OFFLINE", offline)
+    tokenizer = SimpleNamespace(encode=lambda *args, **kwargs: [11, 12, 13])
+
+    with patch("nemo_automodel.NeMoAutoTokenizer.from_pretrained", return_value=tokenizer) as from_pretrained:
+        input_ids = _get_input_ids("mistralai/Ministral-3-3B-Instruct-2512")
+
+    assert input_ids == [11, 12, 13]
+    from_pretrained.assert_called_once_with(
+        "mistralai/Ministral-3-3B-Instruct-2512",
+        trust_remote_code=True,
+        local_files_only=expected_local_files_only,
+    )
+
+
+def test_load_hf_fp8_dequantized_config_preserves_checkpoint_quantization_settings(monkeypatch):
+    source_config = SimpleNamespace(
+        quantization_config={
+            "quant_method": "fp8",
+            "activation_scheme": "static",
+            "weight_block_size": None,
+            "dequantize": False,
+        }
+    )
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+
+    with patch("transformers.AutoConfig.from_pretrained", return_value=source_config) as from_pretrained:
+        config = _load_hf_fp8_dequantized_config(
+            "mistralai/Ministral-3-3B-Instruct-2512",
+            trust_remote_code=False,
+        )
+
+    assert config.quantization_config == {
+        "quant_method": "fp8",
+        "activation_scheme": "static",
+        "weight_block_size": None,
+        "dequantize": True,
+    }
+    from_pretrained.assert_called_once_with(
+        "mistralai/Ministral-3-3B-Instruct-2512",
+        trust_remote_code=False,
+        local_files_only=True,
+    )
+
+
+def test_load_hf_fp8_dequantized_config_ignores_non_fp8_checkpoint():
+    source_config = SimpleNamespace(quantization_config={"quant_method": "awq"})
+
+    with patch("transformers.AutoConfig.from_pretrained", return_value=source_config):
+        assert _load_hf_fp8_dequantized_config("model-path", trust_remote_code=False) is None
 
 
 def test_hf_reload_wait_returns_after_rank0_marker(tmp_path):

--- a/tests/unit_tests/models/mistral3_vlm/test_model.py
+++ b/tests/unit_tests/models/mistral3_vlm/test_model.py
@@ -45,7 +45,7 @@ from nemo_automodel.components.models.mistral3_vlm.state_dict_adapter import (
 # supports_config                                                             #
 # --------------------------------------------------------------------------- #
 class TestSupportsConfig:
-    """Claim only FP8-native Mistral3 VLM configs."""
+    """Claim FP8-native and dequantized Mistral3 VLM configs."""
 
     def test_fp8_mistral3_vlm_config_supported_via_dict(self):
         cfg = SimpleNamespace(
@@ -73,9 +73,9 @@ class TestSupportsConfig:
         )
         assert Mistral3FP8VLMForConditionalGeneration.supports_config(cfg) is False
 
-    def test_no_quantization_config_rejected(self):
+    def test_no_quantization_config_supported_for_dequantized_checkpoint(self):
         cfg = SimpleNamespace(text_config=SimpleNamespace(model_type="ministral3"))
-        assert Mistral3FP8VLMForConditionalGeneration.supports_config(cfg) is False
+        assert Mistral3FP8VLMForConditionalGeneration.supports_config(cfg) is True
 
     def test_non_fp8_quantization_method_rejected(self):
         cfg = SimpleNamespace(

--- a/tests/unit_tests/models/mistral3_vlm/test_resolver_hook.py
+++ b/tests/unit_tests/models/mistral3_vlm/test_resolver_hook.py
@@ -15,8 +15,9 @@
 """Unit tests for the mistral3_vlm package-level resolver hook.
 
 Importing the package installs a hook on
-``_resolve_custom_model_cls_for_config`` (model_init.py) that claims FP8
-Mistral3 VLM configs and dispatches to ``Mistral3FP8VLMForConditionalGeneration``.
+``_resolve_custom_model_cls_for_config`` (model_init.py) that claims FP8-native
+and dequantized Mistral3 VLM configs and dispatches to
+``Mistral3FP8VLMForConditionalGeneration``.
 """
 
 from types import SimpleNamespace
@@ -44,19 +45,27 @@ def _make_non_mistral3_cfg():
     )
 
 
+def _make_dequantized_mistral3_cfg():
+    return SimpleNamespace(text_config=SimpleNamespace(model_type="ministral3"))
+
+
 class TestHookInstallation:
     def test_hook_installed_marker(self):
         # Idempotent guard: re-importing must not stack hooks.
-        assert getattr(
-            _mi._resolve_custom_model_cls_for_config,
-            "_mistral3_vlm_hook_installed",
-            False,
-        ) is True
+        assert (
+            getattr(
+                _mi._resolve_custom_model_cls_for_config,
+                "_mistral3_vlm_hook_installed",
+                False,
+            )
+            is True
+        )
 
     def test_reimport_is_idempotent(self):
         before = _mi._resolve_custom_model_cls_for_config
         # The package's _install_resolver_hook short-circuits if already installed.
         from nemo_automodel.components.models.mistral3_vlm import _install_resolver_hook
+
         _install_resolver_hook()
         assert _mi._resolve_custom_model_cls_for_config is before
 
@@ -68,9 +77,12 @@ class TestHookDispatch:
         # Our hook short-circuits before calling the original.
         assert _mi._resolve_custom_model_cls_for_config(cfg) is Mistral3FP8VLMForConditionalGeneration
 
+    def test_claims_dequantized_mistral3_vlm(self):
+        cfg = _make_dequantized_mistral3_cfg()
+        assert _mi._resolve_custom_model_cls_for_config(cfg) is Mistral3FP8VLMForConditionalGeneration
+
     def test_passes_through_non_mistral3_to_original(self):
         cfg = _make_non_mistral3_cfg()
-        sentinel = object()
         # Patch the original (un-hooked) resolver that our hook delegates to.
         # The hook closes over the *original* resolver at install time; we
         # replicate that path by stubbing ModelRegistry interactions.

--- a/tests/unit_tests/models/mistral3_vlm/test_state_dict_adapter.py
+++ b/tests/unit_tests/models/mistral3_vlm/test_state_dict_adapter.py
@@ -94,7 +94,7 @@ class TestIsFp8WeightKey:
 # _dequantize_from_fp8                                                        #
 # --------------------------------------------------------------------------- #
 class TestDequantizeFromFp8:
-    """w_bf16 = w_fp8.to(bf16) * scale_inv.to(bf16)."""
+    """w_bf16 = (w_fp8.float() * scale_inv.float()).bfloat16()."""
 
     def test_per_tensor_scale_multiply(self):
         # FP8 e4m3 has limited precision; pick exact-representable values.
@@ -111,6 +111,17 @@ class TestDequantizeFromFp8:
         out = _dequantize_from_fp8(w_fp8, scale, target_dtype=torch.float32)
         assert out.dtype == torch.float32
         assert torch.allclose(out, torch.tensor([2.0, 4.0]))
+
+    def test_multiplies_in_float32_before_casting(self):
+        w_fp8 = torch.tensor([-240.0], dtype=torch.float8_e4m3fn)
+        scale = torch.tensor(1e-5, dtype=torch.float32)
+
+        out = _dequantize_from_fp8(w_fp8, scale, target_dtype=torch.bfloat16)
+
+        expected = (w_fp8.float() * scale).bfloat16()
+        low_precision = w_fp8.bfloat16() * scale.bfloat16()
+        assert torch.equal(out, expected)
+        assert not torch.equal(out, low_precision)
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
# What does this PR do ?

Restores offline checkpoint-robustness coverage for the Ministral3 full fine-tuning and PEFT recipes without skipping FP8 source or vanilla-HF parity.

The shared Mistral Common tokenizer and fine-grained FP8 reference-load fixes also address the same blockers observed for Mistral4 under AM-654. Mistral4's VLM checkpoint-robustness opt-in and end-to-end validation remain in #3112 after it rebases onto this PR.

# Changelog

- Use the production `NeMoAutoTokenizer` path with offline-local loading in checkpoint robustness for Mistral Common tokenizers, including Ministral3 and Mistral4.
- Load fine-grained FP8 HF references with `dequantize=True` instead of requiring the optional runtime `kernels` package. This matches the BF16-dequantized training path used by both model families.
- Route dequantized Ministral3 consolidated checkpoints through the existing rotary-buffer reinitialization path.
- Keep TP=2 source and HF reload parity enabled with measured max/mean KL and cosine thresholds.
- Add focused regression tests for offline kwargs, FP8 config preservation, resolver dispatch, and FP32 dequantization.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed Contributor guidelines
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

# Validation

- `77 passed` focused unit tests
- Full fine-tuning checkpoint robustness passed on 2 GPUs (Slurm `14083931`)
- PEFT checkpoint robustness passed on 2 GPUs (Slurm `14084265`)
- Ruff format/check passed
- Scoped CI: [pipeline 58375117](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/58375117) passed both Ministral3 full-FT and PEFT checkpoint robustness

Mistral4 has not yet been re-enabled or validated end to end by this PR alone. After #3111 merges, #3112 will rebase, enable the Mistral4 VLM robustness configuration, and run its scoped validation.

# Additional Information

- Linear: [AM-696](https://linear.app/nvidia/issue/AM-696/ministral3-checkpoint-robustness-offline-tokenizer-and-fp8-parity)
- VLM robustness: [AM-654](https://linear.app/nvidia/issue/AM-654/add-checkpoint-robustness-harness-for-vlm-recipes-incl-source-load), #3112
- Follow-up to #2998
