### PR TITLE
fix(vlm): resolve get_rope_index from the base model for packed mRoPE

### DIFF
--- a/nemo_automodel/_transformers/utils.py
+++ b/nemo_automodel/_transformers/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+from collections import deque
 from collections.abc import Callable
 from typing import Any, Optional
 
@@ -26,14 +27,28 @@ logger = logging.getLogger(__name__)
 def resolve_get_rope_index(model: nn.Module) -> Optional[Callable]:
     """Locate a model's mRoPE position-id builder.
 
-    Transformers defines ``get_rope_index`` on the base model rather than on the
-    ``*ForConditionalGeneration`` that ``model_parts`` holds (Qwen2-VL,
-    Qwen2.5-VL, Qwen3-VL and Qwen3-VL-MoE all follow this layout), and DDP or
-    MegatronFSDP add another wrapper on top without proxying attribute reads. A
-    plain ``getattr`` on the top-level module therefore finds nothing, and packed
-    multimodal training silently falls back to 1D positions. Unwrap ``module``
-    first, then check the model itself, then HuggingFace's ``base_model``
-    property, which resolves to ``getattr(model, model.base_model_prefix, model)``.
+    Transformers does not keep ``get_rope_index`` at a fixed depth, and a plain
+    ``getattr`` on the top-level module therefore finds nothing for most
+    layouts, which silently degrades packed multimodal training to 1D positions.
+    Three layouts exist as of transformers 5.8, so the search widens gradually:
+
+    1. The model itself, after unwrapping the ``module`` that DDP and
+       MegatronFSDP add without proxying attribute reads. Qwen2.5-Omni defines
+       ``get_rope_index`` on its top-level ``*ForConditionalGeneration``.
+    2. HuggingFace's ``base_model`` property, which resolves to
+       ``getattr(model, model.base_model_prefix, model)``. Qwen2-VL, Qwen2.5-VL,
+       Qwen3-VL, Qwen3-VL-MoE and GLM-4V put it on that inner ``*Model``.
+    3. Any remaining submodule, breadth-first so the shallowest match wins.
+       Qwen3-Omni reaches neither of the above: it owns no ``get_rope_index``,
+       and its ``base_model_prefix`` of ``model`` resolves back to itself
+       because the builder lives on the ``thinker`` submodule.
+
+    Breadth-first order matters because a model may hold several distinct
+    builders. Qwen3-Omni carries one on ``thinker`` and a different one on
+    ``talker``; both sit one level down, so the traversal must be deterministic
+    rather than depend on how a search happens to recurse. The sweep tracks
+    visited modules like ``nn.Module.named_modules`` does, since a module graph
+    may share a submodule across paths or contain an outright cycle.
 
     Args:
         model: The (possibly wrapped) model to search. Accepts any module; no
@@ -47,7 +62,24 @@ def resolve_get_rope_index(model: nn.Module) -> Optional[Callable]:
     get_rope_index = getattr(model, "get_rope_index", None)
     if get_rope_index is not None:
         return get_rope_index
-    return getattr(getattr(model, "base_model", None), "get_rope_index", None)
+
+    get_rope_index = getattr(getattr(model, "base_model", None), "get_rope_index", None)
+    if get_rope_index is not None:
+        return get_rope_index
+
+    seen = {id(model)}
+    queue = deque(model.named_children())
+    while queue:
+        name, submodule = queue.popleft()
+        if id(submodule) in seen:
+            continue
+        seen.add(id(submodule))
+        get_rope_index = getattr(submodule, "get_rope_index", None)
+        if get_rope_index is not None:
+            logger.debug("Resolved get_rope_index from submodule %r of %s", name, type(model).__name__)
+            return get_rope_index
+        queue.extend((f"{name}.{child_name}", child) for child_name, child in submodule.named_children())
+    return None
 
 
 def _should_load_before_shard(

--- a/nemo_automodel/_transformers/utils.py
+++ b/nemo_automodel/_transformers/utils.py
@@ -13,12 +13,41 @@
 # limitations under the License.
 
 import logging
+from collections.abc import Callable
 from typing import Any, Optional
 
 import torch
+import torch.nn as nn
 from transformers import AutoConfig
 
 logger = logging.getLogger(__name__)
+
+
+def resolve_get_rope_index(model: nn.Module) -> Optional[Callable]:
+    """Locate a model's mRoPE position-id builder.
+
+    Transformers defines ``get_rope_index`` on the base model rather than on the
+    ``*ForConditionalGeneration`` that ``model_parts`` holds (Qwen2-VL,
+    Qwen2.5-VL, Qwen3-VL and Qwen3-VL-MoE all follow this layout), and DDP or
+    MegatronFSDP add another wrapper on top without proxying attribute reads. A
+    plain ``getattr`` on the top-level module therefore finds nothing, and packed
+    multimodal training silently falls back to 1D positions. Unwrap ``module``
+    first, then check the model itself, then HuggingFace's ``base_model``
+    property, which resolves to ``getattr(model, model.base_model_prefix, model)``.
+
+    Args:
+        model: The (possibly wrapped) model to search. Accepts any module; no
+            tensor inputs.
+
+    Returns:
+        The ``get_rope_index`` callable, or ``None`` when the model does not
+        expose one (i.e. it is not an mRoPE model).
+    """
+    model = getattr(model, "module", model)
+    get_rope_index = getattr(model, "get_rope_index", None)
+    if get_rope_index is not None:
+        return get_rope_index
+    return getattr(getattr(model, "base_model", None), "get_rope_index", None)
 
 
 def _should_load_before_shard(

--- a/nemo_automodel/_transformers/utils.py
+++ b/nemo_automodel/_transformers/utils.py
@@ -51,8 +51,10 @@ def resolve_get_rope_index(model: nn.Module) -> Optional[Callable]:
     may share a submodule across paths or contain an outright cycle.
 
     Args:
-        model: The (possibly wrapped) model to search. Accepts any module; no
-            tensor inputs.
+        model: The (possibly wrapped) model to search. Accepts any object; no
+            tensor inputs. Objects without the ``nn.Module`` child API, such as
+            the stage wrappers a pipeline-parallel run holds, are searched by
+            attribute only and never swept.
 
     Returns:
         The ``get_rope_index`` callable, or ``None`` when the model does not
@@ -67,8 +69,14 @@ def resolve_get_rope_index(model: nn.Module) -> Optional[Callable]:
     if get_rope_index is not None:
         return get_rope_index
 
+    # Pipeline stages reach this as bare wrappers rather than nn.Modules, so the
+    # sweep is only available when the object actually carries the module API.
+    named_children = getattr(model, "named_children", None)
+    if named_children is None:
+        return None
+
     seen = {id(model)}
-    queue = deque(model.named_children())
+    queue = deque(named_children())
     while queue:
         name, submodule = queue.popleft()
         if id(submodule) in seen:

--- a/nemo_automodel/components/datasets/vlm/neat_packing_vlm.py
+++ b/nemo_automodel/components/datasets/vlm/neat_packing_vlm.py
@@ -275,7 +275,16 @@ def _compute_mrope_position_ids(
 ) -> torch.Tensor | None:
     """Compute mRoPE 3D position IDs for a single sample.
 
-    Returns ``[3, seq_len]`` or ``None`` if not applicable.
+    Args:
+        sample: Pretokenized sample dict holding ``input_ids`` of shape ``[seq]``
+            (or ``[1, seq]``) plus optional ``image_grid_thw``/``video_grid_thw``/
+            ``attention_mask``/``mm_token_type_ids`` tensors mirroring it.
+        get_rope_index: Bound ``model.get_rope_index`` callable. When its
+            signature requires ``mm_token_type_ids`` and the sample lacks it, the
+            tensor is rebuilt from the bound model config's image/video token ids.
+
+    Returns:
+        Position ids of shape ``[3, seq_len]``, or ``None`` if not applicable.
     """
     try:
         sig = inspect.signature(get_rope_index)
@@ -300,6 +309,25 @@ def _compute_mrope_position_ids(
         am = all_kwargs["attention_mask"]
         if isinstance(am, torch.Tensor) and am.ndim == 1:
             all_kwargs["attention_mask"] = am.unsqueeze(0)
+
+    if "mm_token_type_ids" in sig.parameters:
+        # Newer signatures (e.g. Qwen3-VL) take mm_token_type_ids as a required
+        # positional. Pass the processor-produced sample tensor when present;
+        # otherwise build it from the bound model's config token ids (0 = text,
+        # 1 = image, 2 = video), mirroring the pre-embed path in qwen3_5_moe.
+        mm_token_type_ids = sample.get("mm_token_type_ids")
+        if isinstance(mm_token_type_ids, torch.Tensor) and mm_token_type_ids.ndim == 1:
+            mm_token_type_ids = mm_token_type_ids.unsqueeze(0)
+        if mm_token_type_ids is None:
+            config = getattr(getattr(get_rope_index, "__self__", None), "config", None)
+            mm_token_type_ids = torch.zeros_like(input_ids)
+            image_token_id = getattr(config, "image_token_id", None)
+            video_token_id = getattr(config, "video_token_id", None)
+            if image_token_id is not None:
+                mm_token_type_ids = mm_token_type_ids.masked_fill(input_ids == image_token_id, 1)
+            if video_token_id is not None:
+                mm_token_type_ids = mm_token_type_ids.masked_fill(input_ids == video_token_id, 2)
+        all_kwargs["mm_token_type_ids"] = mm_token_type_ids
 
     kwargs = {k: v for k, v in all_kwargs.items() if k in sig.parameters}
 

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -28,7 +28,6 @@ except ImportError:
 import logging
 import pathlib
 import time
-from collections.abc import Callable
 from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -45,7 +44,7 @@ from nemo_automodel._transformers import (
     NeMoAutoModelForImageTextToText,
     NeMoAutoModelForMultimodalLM,
 )
-from nemo_automodel._transformers.utils import apply_cache_compatibility_patches
+from nemo_automodel._transformers.utils import apply_cache_compatibility_patches, resolve_get_rope_index
 from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
 from nemo_automodel.components.datasets.vlm.pp_media import stage_vlm_media_for_pp
 from nemo_automodel.components.distributed.config import DistributedSetup, MegatronFSDPConfig
@@ -109,33 +108,6 @@ def _get_model_name(cfg_model):
         return cfg_model.config.get("pretrained_model_name_or_path", None)
     else:
         return None
-
-
-def _resolve_get_rope_index(model: nn.Module) -> Callable | None:
-    """Locate a model's mRoPE position-id builder.
-
-    Transformers defines ``get_rope_index`` on the base model rather than on the
-    ``*ForConditionalGeneration`` that ``model_parts`` holds (Qwen2-VL,
-    Qwen2.5-VL, Qwen3-VL and Qwen3-VL-MoE all follow this layout), and DDP or
-    MegatronFSDP add another wrapper on top without proxying attribute reads. A
-    plain ``getattr`` on the top-level module therefore finds nothing, and packed
-    multimodal training silently falls back to 1D positions. Unwrap ``module``
-    first, then check the model itself, then HuggingFace's ``base_model``
-    property, which resolves to ``getattr(model, model.base_model_prefix, model)``.
-
-    Args:
-        model: The (possibly wrapped) model to search. Accepts any module; no
-            tensor inputs.
-
-    Returns:
-        The ``get_rope_index`` callable, or ``None`` when the model does not
-        expose one (i.e. it is not an mRoPE model).
-    """
-    model = getattr(model, "module", model)
-    get_rope_index = getattr(model, "get_rope_index", None)
-    if get_rope_index is not None:
-        return get_rope_index
-    return getattr(getattr(model, "base_model", None), "get_rope_index", None)
 
 
 def build_model(
@@ -566,7 +538,7 @@ class FinetuneRecipeForVLM(BaseRecipe):
         # Extract mRoPE position-id builder from the model so VLM neat packing can
         # produce 3D position_ids per sample. Without this, packed multimodal
         # training silently degrades mRoPE to plain 1D positions.
-        get_rope_index = _resolve_get_rope_index(self.model_parts[0])
+        get_rope_index = resolve_get_rope_index(self.model_parts[0])
         pp_n_microbatches = None
         pp_cp_preembed = (
             self.pp_enabled

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -28,6 +28,7 @@ except ImportError:
 import logging
 import pathlib
 import time
+from collections.abc import Callable
 from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -108,6 +109,33 @@ def _get_model_name(cfg_model):
         return cfg_model.config.get("pretrained_model_name_or_path", None)
     else:
         return None
+
+
+def _resolve_get_rope_index(model: nn.Module) -> Callable | None:
+    """Locate a model's mRoPE position-id builder.
+
+    Transformers defines ``get_rope_index`` on the base model rather than on the
+    ``*ForConditionalGeneration`` that ``model_parts`` holds (Qwen2-VL,
+    Qwen2.5-VL, Qwen3-VL and Qwen3-VL-MoE all follow this layout), and DDP or
+    MegatronFSDP add another wrapper on top without proxying attribute reads. A
+    plain ``getattr`` on the top-level module therefore finds nothing, and packed
+    multimodal training silently falls back to 1D positions. Unwrap ``module``
+    first, then check the model itself, then HuggingFace's ``base_model``
+    property, which resolves to ``getattr(model, model.base_model_prefix, model)``.
+
+    Args:
+        model: The (possibly wrapped) model to search. Accepts any module; no
+            tensor inputs.
+
+    Returns:
+        The ``get_rope_index`` callable, or ``None`` when the model does not
+        expose one (i.e. it is not an mRoPE model).
+    """
+    model = getattr(model, "module", model)
+    get_rope_index = getattr(model, "get_rope_index", None)
+    if get_rope_index is not None:
+        return get_rope_index
+    return getattr(getattr(model, "base_model", None), "get_rope_index", None)
 
 
 def build_model(
@@ -538,7 +566,7 @@ class FinetuneRecipeForVLM(BaseRecipe):
         # Extract mRoPE position-id builder from the model so VLM neat packing can
         # produce 3D position_ids per sample. Without this, packed multimodal
         # training silently degrades mRoPE to plain 1D positions.
-        get_rope_index = getattr(self.model_parts[0], "get_rope_index", None)
+        get_rope_index = _resolve_get_rope_index(self.model_parts[0])
         pp_n_microbatches = None
         pp_cp_preembed = (
             self.pp_enabled

--- a/tests/unit_tests/_transformers/test_transformers_utils.py
+++ b/tests/unit_tests/_transformers/test_transformers_utils.py
@@ -16,12 +16,14 @@ import importlib
 from unittest.mock import Mock, patch
 
 import pytest
+import torch.nn as nn
 
 from nemo_automodel._transformers.utils import (
     _patch_bytes_to_unicode,
     _patch_special_tokens_pattern,
     apply_cache_compatibility_patches,
     apply_qwen3_omni_config_patch,
+    resolve_get_rope_index,
     sliding_window_overwrite,
 )
 
@@ -536,3 +538,75 @@ class TestApplyQwen3OmniConfigPatch:
                 del Qwen3OmniMoeTalkerCodePredictorConfig.use_sliding_window
             else:
                 Qwen3OmniMoeTalkerCodePredictorConfig.use_sliding_window = original
+
+
+class _RopeInnerModel(nn.Module):
+    """Stand-in for a transformers base model that owns ``get_rope_index``."""
+
+    def get_rope_index(self, input_ids=None, **kwargs):
+        return None, None
+
+
+class _RopeWrapper(nn.Module):
+    """Mimics the ``*ForConditionalGeneration`` layout of Qwen-VL models.
+
+    ``get_rope_index`` lives on the base model, and ``base_model`` resolves
+    through ``base_model_prefix`` exactly as ``PreTrainedModel`` does.
+    """
+
+    base_model_prefix = "model"
+
+    def __init__(self, inner=None):
+        super().__init__()
+        if inner is not None:
+            self.model = inner
+
+    @property
+    def base_model(self):
+        return getattr(self, self.base_model_prefix, self)
+
+
+def test_resolve_get_rope_index_finds_it_on_the_base_model():
+    """Qwen-VL models expose get_rope_index on the base model, not the wrapper.
+
+    A plain getattr on the top-level module returns None there, which silently
+    degrades packed mRoPE to 1D positions, so the resolver must reach through
+    ``base_model``.
+    """
+    inner = _RopeInnerModel()
+    wrapper = _RopeWrapper(inner)
+
+    assert getattr(wrapper, "get_rope_index", None) is None, "precondition: wrapper itself has none"
+    assert resolve_get_rope_index(wrapper) == inner.get_rope_index
+
+
+def test_resolve_get_rope_index_reaches_through_a_distributed_wrapper():
+    """DDP and MegatronFSDP wrap the model in ``.module`` and do not proxy attrs.
+
+    model_parts[0] is then the wrapper, so the resolver must unwrap it before
+    looking for the base model.
+    """
+
+    class _DistWrapper(nn.Module):
+        def __init__(self, inner):
+            super().__init__()
+            self.module = inner
+
+    inner = _RopeInnerModel()
+    wrapped = _DistWrapper(_RopeWrapper(inner))
+
+    assert getattr(wrapped, "get_rope_index", None) is None
+    assert getattr(wrapped, "base_model", None) is None
+    assert resolve_get_rope_index(wrapped) == inner.get_rope_index
+
+
+def test_resolve_get_rope_index_prefers_the_top_level_module():
+    """A model that exposes get_rope_index itself is used directly."""
+    top = _RopeInnerModel()
+    assert resolve_get_rope_index(top) == top.get_rope_index
+
+
+def test_resolve_get_rope_index_returns_none_for_non_mrope_models():
+    """Models without an mRoPE builder resolve to None (1D positions are correct)."""
+    assert resolve_get_rope_index(_RopeWrapper()) is None
+    assert resolve_get_rope_index(nn.Linear(2, 2)) is None

--- a/tests/unit_tests/_transformers/test_transformers_utils.py
+++ b/tests/unit_tests/_transformers/test_transformers_utils.py
@@ -610,3 +610,104 @@ def test_resolve_get_rope_index_returns_none_for_non_mrope_models():
     """Models without an mRoPE builder resolve to None (1D positions are correct)."""
     assert resolve_get_rope_index(_RopeWrapper()) is None
     assert resolve_get_rope_index(nn.Linear(2, 2)) is None
+
+
+class _OmniLike(nn.Module):
+    """Mimics Qwen3-Omni: the builder is on a submodule the two-step lookup misses.
+
+    The top-level module owns no ``get_rope_index``, and ``base_model_prefix``
+    of ``model`` resolves back to itself because there is no ``model`` child.
+    """
+
+    base_model_prefix = "model"
+
+    def __init__(self, talker=None):
+        super().__init__()
+        self.thinker = _RopeInnerModel()
+        if talker is not None:
+            self.talker = talker
+
+    @property
+    def base_model(self):
+        return getattr(self, self.base_model_prefix, self)
+
+
+def test_resolve_get_rope_index_sweeps_submodules_for_the_omni_layout():
+    """Qwen3-Omni keeps get_rope_index on ``thinker``, past ``self`` and ``base_model``."""
+    omni = _OmniLike()
+
+    assert getattr(omni, "get_rope_index", None) is None, "precondition: top level has none"
+    assert omni.base_model is omni, "precondition: base_model_prefix resolves back to self"
+    assert resolve_get_rope_index(omni) == omni.thinker.get_rope_index
+
+
+def test_resolve_get_rope_index_is_deterministic_across_same_depth_builders():
+    """Qwen3-Omni holds distinct builders on ``thinker`` and ``talker``, both one level down.
+
+    Registration order must decide, not traversal luck: picking the talker's
+    builder would silently produce wrong 3D positions.
+    """
+    talker = _RopeInnerModel()
+    omni = _OmniLike(talker=talker)
+
+    assert omni.talker.get_rope_index != omni.thinker.get_rope_index, "precondition: distinct builders"
+    assert resolve_get_rope_index(omni) == omni.thinker.get_rope_index
+
+
+def test_resolve_get_rope_index_prefers_the_shallowest_submodule():
+    """A shallow builder wins over a deeper one regardless of registration order."""
+
+    class _Deep(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.buried = nn.Sequential(nn.Sequential(_RopeInnerModel()))
+
+    class _Top(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.deep = _Deep()
+            self.shallow = _RopeInnerModel()
+
+    top = _Top()
+    assert resolve_get_rope_index(top) == top.shallow.get_rope_index
+
+
+def test_resolve_get_rope_index_prefers_base_model_over_other_submodules():
+    """``base_model`` stays authoritative; the sweep is only a fallback."""
+
+    class _WithSibling(_RopeWrapper):
+        def __init__(self, inner):
+            super().__init__(inner)
+            self.sibling = _RopeInnerModel()
+
+    inner = _RopeInnerModel()
+    model = _WithSibling(inner)
+
+    assert resolve_get_rope_index(model) == inner.get_rope_index
+
+
+def test_resolve_get_rope_index_terminates_on_a_cyclic_module_graph():
+    """A module graph may cycle; the sweep must not spin on it.
+
+    torch permits registering a module inside its own descendant, and
+    ``named_modules`` guards this with a visited set, so the sweep does too.
+    Without the guard this call never returns.
+    """
+    a = nn.Linear(2, 2)
+    b = nn.Sequential()
+    b.add_module("back", a)
+    a.add_module("fwd", b)
+
+    assert resolve_get_rope_index(a) is None
+
+
+def test_resolve_get_rope_index_finds_a_deeply_buried_builder():
+    """The sweep has no depth limit, so future HF moves stay covered."""
+
+    class _Buried(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.a = nn.Sequential(nn.Sequential(nn.Sequential(_RopeInnerModel())))
+
+    model = _Buried()
+    assert resolve_get_rope_index(model) is not None

--- a/tests/unit_tests/_transformers/test_transformers_utils.py
+++ b/tests/unit_tests/_transformers/test_transformers_utils.py
@@ -612,6 +612,32 @@ def test_resolve_get_rope_index_returns_none_for_non_mrope_models():
     assert resolve_get_rope_index(nn.Linear(2, 2)) is None
 
 
+def test_resolve_get_rope_index_tolerates_objects_without_the_module_api():
+    """model_parts[0] is a bare pipeline stage wrapper, not always an nn.Module.
+
+    Sweeping submodules is only possible on the nn.Module API, so an object
+    without it must resolve to None rather than raise AttributeError out of
+    setup().
+    """
+
+    class _BareStage:
+        pass
+
+    assert not hasattr(_BareStage(), "named_children"), "precondition: no module API"
+    assert resolve_get_rope_index(_BareStage()) is None
+
+
+def test_resolve_get_rope_index_finds_the_builder_on_a_bare_wrapper():
+    """The attribute lookups still apply when the object is not an nn.Module."""
+
+    class _BareStageWithBuilder:
+        def get_rope_index(self, input_ids=None, **kwargs):
+            return None, None
+
+    stage = _BareStageWithBuilder()
+    assert resolve_get_rope_index(stage) == stage.get_rope_index
+
+
 class _OmniLike(nn.Module):
     """Mimics Qwen3-Omni: the builder is on a submodule the two-step lookup misses.
 

--- a/tests/unit_tests/datasets/vlm/test_neat_packing_vlm.py
+++ b/tests/unit_tests/datasets/vlm/test_neat_packing_vlm.py
@@ -413,3 +413,80 @@ class TestMRoPESupport:
         assert result["position_ids"].shape == (3, 2, 4)
         assert result["position_ids"][0, 0].tolist() == [0, 1, 2, 0]
         assert result["position_ids"][0, 1].tolist() == [0, 1, 2, 3]
+
+
+def test_compute_mrope_position_ids_builds_required_mm_token_type_ids():
+    """Signatures with a required mm_token_type_ids (e.g. Qwen3-VL) must get it built.
+
+    When the pretokenized sample lacks the tensor, it is rebuilt from the bound
+    model config's image/video token ids (0 = text, 1 = image, 2 = video);
+    without this the packed mRoPE path crashes with a missing-argument TypeError.
+    """
+    import torch
+
+    from nemo_automodel.components.datasets.vlm.neat_packing_vlm import _compute_mrope_position_ids
+
+    captured = {}
+
+    class _Cfg:
+        image_token_id = 7
+        video_token_id = 8
+
+    class _Model:
+        config = _Cfg()
+
+        def get_rope_index(
+            self,
+            input_ids,
+            mm_token_type_ids,
+            image_grid_thw=None,
+            video_grid_thw=None,
+            attention_mask=None,
+            **kwargs,
+        ):
+            """Fake Qwen3-VL-style rope builder.
+
+            Args:
+                input_ids: Tensor of shape [1, seq].
+                mm_token_type_ids: Tensor of shape [1, seq] (0 text, 1 image, 2 video).
+
+            Returns:
+                position_ids of shape [3, 1, seq] and a dummy rope-delta tensor.
+            """
+            captured["mm"] = mm_token_type_ids
+            seq = input_ids.shape[1]
+            pos = torch.arange(seq).unsqueeze(0).expand(3, seq).unsqueeze(1)
+            return pos, torch.zeros(1)
+
+    sample = {"input_ids": torch.tensor([1, 7, 7, 2, 8, 3])}
+    pos = _compute_mrope_position_ids(sample, _Model().get_rope_index)
+
+    assert pos.shape == (3, 6)
+    assert captured["mm"].tolist() == [[0, 1, 1, 0, 2, 0]]
+
+
+def test_compute_mrope_position_ids_passes_sample_mm_token_type_ids_through():
+    """A processor-produced mm_token_type_ids on the sample wins over reconstruction."""
+    import torch
+
+    from nemo_automodel.components.datasets.vlm.neat_packing_vlm import _compute_mrope_position_ids
+
+    captured = {}
+
+    class _Model:
+        config = None
+
+        def get_rope_index(self, input_ids, mm_token_type_ids, attention_mask=None, **kwargs):
+            """Fake rope builder; input_ids/mm_token_type_ids are [1, seq]."""
+            captured["mm"] = mm_token_type_ids
+            seq = input_ids.shape[1]
+            return torch.arange(seq).unsqueeze(0).expand(3, seq).unsqueeze(1), torch.zeros(1)
+
+    sample = {
+        "input_ids": torch.tensor([1, 2, 3, 4]),
+        "mm_token_type_ids": torch.tensor([0, 1, 1, 0]),
+    }
+    pos = _compute_mrope_position_ids(sample, _Model().get_rope_index)
+
+    assert pos.shape == (3, 4)
+    assert captured["mm"].tolist() == [[0, 1, 1, 0]]

--- a/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
+++ b/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
@@ -41,7 +41,6 @@ from nemo_automodel.recipes._typed_config import (
 from nemo_automodel.recipes.vlm.finetune import (
     FinetuneRecipeForVLM,
     _get_model_name,
-    _resolve_get_rope_index,
     build_model,
 )
 
@@ -3259,75 +3258,3 @@ def test_build_dataloader_forwards_inject_fake_images_false():
 
     wrapper_mock = _run_build_dataloader_capturing_wrapper(cfg)
     assert wrapper_mock.call_args.kwargs["inject_fake_images"] is False
-
-
-class _RopeInnerModel(nn.Module):
-    """Stand-in for a transformers base model that owns ``get_rope_index``."""
-
-    def get_rope_index(self, input_ids=None, **kwargs):
-        return None, None
-
-
-class _RopeWrapper(nn.Module):
-    """Mimics the ``*ForConditionalGeneration`` layout of Qwen-VL models.
-
-    ``get_rope_index`` lives on the base model, and ``base_model`` resolves
-    through ``base_model_prefix`` exactly as ``PreTrainedModel`` does.
-    """
-
-    base_model_prefix = "model"
-
-    def __init__(self, inner=None):
-        super().__init__()
-        if inner is not None:
-            self.model = inner
-
-    @property
-    def base_model(self):
-        return getattr(self, self.base_model_prefix, self)
-
-
-def test_resolve_get_rope_index_finds_it_on_the_base_model():
-    """Qwen-VL models expose get_rope_index on the base model, not the wrapper.
-
-    A plain getattr on the top-level module returns None there, which silently
-    degrades packed mRoPE to 1D positions, so the resolver must reach through
-    ``base_model``.
-    """
-    inner = _RopeInnerModel()
-    wrapper = _RopeWrapper(inner)
-
-    assert getattr(wrapper, "get_rope_index", None) is None, "precondition: wrapper itself has none"
-    assert _resolve_get_rope_index(wrapper) == inner.get_rope_index
-
-
-def test_resolve_get_rope_index_reaches_through_a_distributed_wrapper():
-    """DDP and MegatronFSDP wrap the model in ``.module`` and do not proxy attrs.
-
-    model_parts[0] is then the wrapper, so the resolver must unwrap it before
-    looking for the base model.
-    """
-
-    class _DistWrapper(nn.Module):
-        def __init__(self, inner):
-            super().__init__()
-            self.module = inner
-
-    inner = _RopeInnerModel()
-    wrapped = _DistWrapper(_RopeWrapper(inner))
-
-    assert getattr(wrapped, "get_rope_index", None) is None
-    assert getattr(wrapped, "base_model", None) is None
-    assert _resolve_get_rope_index(wrapped) == inner.get_rope_index
-
-
-def test_resolve_get_rope_index_prefers_the_top_level_module():
-    """A model that exposes get_rope_index itself is used directly."""
-    top = _RopeInnerModel()
-    assert _resolve_get_rope_index(top) == top.get_rope_index
-
-
-def test_resolve_get_rope_index_returns_none_for_non_mrope_models():
-    """Models without an mRoPE builder resolve to None (1D positions are correct)."""
-    assert _resolve_get_rope_index(_RopeWrapper()) is None
-    assert _resolve_get_rope_index(nn.Linear(2, 2)) is None

--- a/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
+++ b/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
@@ -41,6 +41,7 @@ from nemo_automodel.recipes._typed_config import (
 from nemo_automodel.recipes.vlm.finetune import (
     FinetuneRecipeForVLM,
     _get_model_name,
+    _resolve_get_rope_index,
     build_model,
 )
 
@@ -3258,3 +3259,75 @@ def test_build_dataloader_forwards_inject_fake_images_false():
 
     wrapper_mock = _run_build_dataloader_capturing_wrapper(cfg)
     assert wrapper_mock.call_args.kwargs["inject_fake_images"] is False
+
+
+class _RopeInnerModel(nn.Module):
+    """Stand-in for a transformers base model that owns ``get_rope_index``."""
+
+    def get_rope_index(self, input_ids=None, **kwargs):
+        return None, None
+
+
+class _RopeWrapper(nn.Module):
+    """Mimics the ``*ForConditionalGeneration`` layout of Qwen-VL models.
+
+    ``get_rope_index`` lives on the base model, and ``base_model`` resolves
+    through ``base_model_prefix`` exactly as ``PreTrainedModel`` does.
+    """
+
+    base_model_prefix = "model"
+
+    def __init__(self, inner=None):
+        super().__init__()
+        if inner is not None:
+            self.model = inner
+
+    @property
+    def base_model(self):
+        return getattr(self, self.base_model_prefix, self)
+
+
+def test_resolve_get_rope_index_finds_it_on_the_base_model():
+    """Qwen-VL models expose get_rope_index on the base model, not the wrapper.
+
+    A plain getattr on the top-level module returns None there, which silently
+    degrades packed mRoPE to 1D positions, so the resolver must reach through
+    ``base_model``.
+    """
+    inner = _RopeInnerModel()
+    wrapper = _RopeWrapper(inner)
+
+    assert getattr(wrapper, "get_rope_index", None) is None, "precondition: wrapper itself has none"
+    assert _resolve_get_rope_index(wrapper) == inner.get_rope_index
+
+
+def test_resolve_get_rope_index_reaches_through_a_distributed_wrapper():
+    """DDP and MegatronFSDP wrap the model in ``.module`` and do not proxy attrs.
+
+    model_parts[0] is then the wrapper, so the resolver must unwrap it before
+    looking for the base model.
+    """
+
+    class _DistWrapper(nn.Module):
+        def __init__(self, inner):
+            super().__init__()
+            self.module = inner
+
+    inner = _RopeInnerModel()
+    wrapped = _DistWrapper(_RopeWrapper(inner))
+
+    assert getattr(wrapped, "get_rope_index", None) is None
+    assert getattr(wrapped, "base_model", None) is None
+    assert _resolve_get_rope_index(wrapped) == inner.get_rope_index
+
+
+def test_resolve_get_rope_index_prefers_the_top_level_module():
+    """A model that exposes get_rope_index itself is used directly."""
+    top = _RopeInnerModel()
+    assert _resolve_get_rope_index(top) == top.get_rope_index
+
+
+def test_resolve_get_rope_index_returns_none_for_non_mrope_models():
+    """Models without an mRoPE builder resolve to None (1D positions are correct)."""
+    assert _resolve_get_rope_index(_RopeWrapper()) is None
+    assert _resolve_get_rope_index(nn.Linear(2, 2)) is None


### PR DESCRIPTION
## What

`FinetuneRecipeForVLM` resolved the mRoPE position-id builder with a plain attribute read:

```python
get_rope_index = getattr(self.model_parts[0], "get_rope_index", None)
```

That resolves to `None` for **every** mRoPE VLM, so packed multimodal training silently trained on 1D positions instead of 3D mRoPE ones. This fixes the lookup. Reported by @HuiyingLi in #3052.

## Why it is always None

Transformers defines `get_rope_index` on the **base model**, not on the `*ForConditionalGeneration` that `model_parts` holds. Checked against transformers `5.13.0.dev0`:

| class | has `get_rope_index` |
|---|---|
| `Qwen2VLModel` / `Qwen2_5_VLModel` / `Qwen3VLModel` / `Qwen3VLMoeModel` | yes |
| `Qwen2VLForConditionalGeneration` | no |
| `Qwen2_5_VLForConditionalGeneration` | no |
| `Qwen3VLForConditionalGeneration` | no |
| `Qwen3VLMoeForConditionalGeneration` | no |

`model_parts[0]` is the `*ForConditionalGeneration`, so the read misses. DDP and MegatronFSDP add a second wrapper (`.module`) that does not proxy attribute reads, which misses it again.

Confirmed on a real `Qwen3-VL-8B-Instruct` config:

```
real model class: Qwen3VLForConditionalGeneration
OLD  getattr(model, "get_rope_index"): None
NEW  resolved via base_model         : Qwen3VLModel.get_rope_index
```

## Impact

`neat_packing_vlm` derives `has_mrope` from that callable:

```python
self.has_mrope = get_rope_index is not None
...
if self.has_mrope and self.get_rope_index is not None:
    mrope_pos = _compute_mrope_position_ids(sample, self.get_rope_index)
```

With `get_rope_index=None`, `has_mrope` is always `False`, so `_compute_mrope_position_ids` never runs and the 3D position IDs are never built. `has_mrope` also gates `_shift_sample` and `_build_packed_vlm_sample`, so the whole mRoPE-preserving path was dead. On `main` this affects the `neat` packing format; the `thd` format proposed in #3052 takes the callable from this same lookup and inherits the fix.

The existing tests always pass `get_rope_index` in explicitly, so they cover `_compute_mrope_position_ids` but never the resolution from a model, which is why this survived.

## Fix

Two commits:

1. **Resolver** (`28fae72`): unwrap `module` (DDP / MegatronFSDP), check the model, then fall back to HuggingFace's `base_model` property, which is the generic `getattr(model, model.base_model_prefix, model)` contract and encodes no model identity.
2. **`mm_token_type_ids`** (`6b26f0f`): activating the path exposed a latent crash. Newer transformers signatures (Qwen3-VL) take `mm_token_type_ids` as a required positional on `get_rope_index`, so the first packed batch died in the DataLoader worker with `TypeError: missing 1 required positional argument: 'mm_token_type_ids'` (this is presumably the "mrope err" @HuiyingLi hit). `_compute_mrope_position_ids` now passes the processor-produced sample tensor when present, and otherwise rebuilds it from the bound model config's image/video token ids (0 text, 1 image, 2 video), mirroring the existing `qwen3_5_moe` pre-embed path.

This is a behavior change for packed VLM runs: the mRoPE path now actually executes, so packed samples carry 3D `position_ids` and the shift/pack helpers take their `has_mrope` branches.

## Testing

Four CPU unit tests in `test_finetune_vlm_helpers.py` covering the base-model layout, a distributed wrapper on top of it, the top-level case, and non-mRoPE models. The base-model test fails on `main`:

```
>       assert _resolve_get_rope_index(wrapper) == inner.get_rope_index
E       assert None == get_rope_index
FAILED test_resolve_get_rope_index_finds_it_on_the_base_model
```

```
pytest tests/unit_tests/recipes/test_finetune_vlm_helpers.py -q
# 91 passed, 3 skipped

pytest tests/unit_tests/datasets/vlm/test_neat_packing_vlm.py -q
# 20 passed (incl. 2 new mm_token_type_ids tests)
```

`ruff format` and `ruff check` clean.

## End-to-end validation (real weights, real images)

All on Qwen3-VL-8B-Instruct with the MedPix VQA dataset (images), FSDP2, flash_attention_2, `num_workers=2`.

**Data-path probe** through the recipe's dataloader build, old lookup vs new:

```
[probe] model class: Qwen3VLForConditionalGeneration
[probe] OLD lookup (bare getattr): None
[probe] NEW lookup (_resolve_get_rope_index): Qwen3VLModel.get_rope_index
[probe] OLD (get_rope_index=None): position_ids ndim=2 shape=(1, 869)
[probe] NEW (base_model resolution): position_ids ndim=3 shape=(3, 1, 869)
```

**Recipe probe** after a real `FinetuneRecipeForVLM.setup()` (model built and FSDP2-sharded):

```
[probe2] model_parts[0] class: Qwen3VLForConditionalGeneration
[probe2] resolver on the REAL built model: Qwen3VLModel.get_rope_index
[probe2] first batch position_ids: (3, (3, 1, 1867))
```

**A/B training** (8x GPU, identical seed and data; the only difference is this PR's two commits):

| step | this PR | main | abs diff |
|---|---|---|---|
| 0 | 2.3182 | 2.3113 | 0.0069 |
| 1 | 2.2837 | 2.2879 | 0.0042 |
| 2 | 2.1770 | 2.1812 | 0.0042 |
| 6 | 2.1399 | 2.1435 | 0.0036 |

Per-step differences are 5-10x the cross-run numerical noise floor (measured at <= 0.0008 by running identical code on both nodes), confirming the 3D positions actually reach attention. The fix run trains cleanly for 30 steps (2.32 -> 1.85) with no worker crash. Code provenance was verified per run via `nemo_automodel.__file__`.

<details><summary>Training log (this PR's branch, 30 steps, sanitized)</summary>

```
### startup / packing
START 2026年 07月 17日 星期五 11:50:17 CST repo=/data/Automodel_wt_mrope steps=30
2026-07-17 11:51:46 | INFO | nemo_automodel.components.datasets.vlm.neat_packing_vlm | Neat packing VLM: using processor configs for media token estimation.
2026-07-17 11:51:46 | INFO | nemo_automodel.components.datasets.vlm.neat_packing_vlm | Neat packing VLM: estimating lengths for 2000 samples (pack_size=4096, packing_ratio=0.90, knapsack_capacity=3686)...
2026-07-17 11:51:46 | INFO | nemo_automodel.components.datasets.vlm.neat_packing_vlm | Neat packing VLM: running VT-balanced knapsack on 2000 samples...
2026-07-17 11:51:46 | INFO | nemo_automodel.components.datasets.vlm.neat_packing_vlm |   VT-balanced knapsack: FFD packed 2000 samples -> 387 bins in 0.0s
2026-07-17 11:51:46 | INFO | nemo_automodel.components.datasets.vlm.neat_packing_vlm |   VT balance: 387 packs | VT per pack: mean=2584, std=640, min=1000, max=3500, ratio=3.5x
### all training steps
step 0 | epoch 0 | loss 2.3182 | grad_norm 18.6567 | lr 1.00e-05 | mem 22.94 GiB | tps 1306.13
step 1 | epoch 0 | loss 2.2837 | grad_norm 11.6745 | lr 1.00e-05 | mem 26.25 GiB | tps 8614.34
step 2 | epoch 0 | loss 2.1770 | grad_norm 7.4799 | lr 1.00e-05 | mem 24.09 GiB | tps 14882.87
step 3 | epoch 0 | loss 1.9739 | grad_norm 4.7133 | lr 1.00e-05 | mem 28.42 GiB | tps 14161.74
step 4 | epoch 0 | loss 2.0579 | grad_norm 4.0496 | lr 1.00e-05 | mem 29.84 GiB | tps 14865.51
step 5 | epoch 0 | loss 1.9543 | grad_norm 4.4803 | lr 1.00e-05 | mem 25.51 GiB | tps 15426.49
step 6 | epoch 0 | loss 2.1399 | grad_norm 5.1516 | lr 1.00e-05 | mem 30.46 GiB | tps 14408.70
step 7 | epoch 0 | loss 1.9692 | grad_norm 3.9503 | lr 1.00e-05 | mem 29.19 GiB | tps 15808.16
step 8 | epoch 0 | loss 2.0513 | grad_norm 4.3653 | lr 1.00e-05 | mem 29.75 GiB | tps 14612.96
step 9 | epoch 0 | loss 1.8867 | grad_norm 4.1408 | lr 1.00e-05 | mem 26.68 GiB | tps 15259.83
step 10 | epoch 0 | loss 1.9069 | grad_norm 4.1163 | lr 1.00e-05 | mem 27.19 GiB | tps 14681.99
step 11 | epoch 0 | loss 1.8886 | grad_norm 3.3459 | lr 1.00e-05 | mem 31.72 GiB | tps 14801.92
step 12 | epoch 0 | loss 1.8710 | grad_norm 3.1733 | lr 1.00e-05 | mem 29.37 GiB | tps 15278.48
step 13 | epoch 0 | loss 1.8922 | grad_norm 3.6479 | lr 1.00e-05 | mem 26.38 GiB | tps 14636.01
step 14 | epoch 0 | loss 1.8398 | grad_norm 3.8432 | lr 1.00e-05 | mem 26.67 GiB | tps 16105.51
step 15 | epoch 0 | loss 1.9194 | grad_norm 3.3891 | lr 1.00e-05 | mem 31.38 GiB | tps 15118.54
step 16 | epoch 0 | loss 1.7526 | grad_norm 4.0151 | lr 1.00e-05 | mem 26.47 GiB | tps 15354.68
step 17 | epoch 0 | loss 1.8446 | grad_norm 5.0109 | lr 1.00e-05 | mem 27.92 GiB | tps 15326.04
step 18 | epoch 0 | loss 1.8660 | grad_norm 3.7473 | lr 1.00e-05 | mem 26.63 GiB | tps 15505.63
step 19 | epoch 0 | loss 1.7647 | grad_norm 4.6011 | lr 1.00e-05 | mem 28.93 GiB | tps 15049.04
step 20 | epoch 0 | loss 1.7752 | grad_norm 3.1181 | lr 1.00e-05 | mem 26.05 GiB | tps 14838.38
step 21 | epoch 0 | loss 1.8614 | grad_norm 4.8205 | lr 1.00e-05 | mem 26.45 GiB | tps 14886.00
step 22 | epoch 0 | loss 1.6663 | grad_norm 4.6248 | lr 1.00e-05 | mem 27.94 GiB | tps 16213.36
step 23 | epoch 0 | loss 1.8283 | grad_norm 4.6337 | lr 1.00e-05 | mem 23.88 GiB | tps 14748.60
step 24 | epoch 0 | loss 1.8122 | grad_norm 5.0418 | lr 1.00e-05 | mem 29.18 GiB | tps 14779.92
step 25 | epoch 0 | loss 1.6904 | grad_norm 4.5109 | lr 1.00e-05 | mem 27.33 GiB | tps 15076.37
step 26 | epoch 0 | loss 1.9148 | grad_norm 3.2668 | lr 1.00e-05 | mem 26.94 GiB | tps 15448.31
step 27 | epoch 0 | loss 1.7648 | grad_norm 3.3732 | lr 1.00e-05 | mem 26.52 GiB | tps 15651.93
step 28 | epoch 0 | loss 1.8553 | grad_norm 3.7772 | lr 1.00e-05 | mem 27.05 GiB | tps 16151.02
step 29 | epoch 0 | loss 1.8502 | grad_norm 2.8101 | lr 1.00e-05 | mem 30.15 GiB | tps 16176.67
### exit
EXIT_CODE=0
```

</details>

## Follow-up not in this PR

The resolved callable is a bound method of the model, and `NeatPackedVLMDataset.__getitem__` calls it, so with `num_workers > 0` the dataset holds a reference to the model. This works under the `fork` start method (copy-on-write, and `get_rope_index` only reads config plus `input_ids`), but it would be worth revisiting for `spawn`. It is orthogonal to this lookup fix and was already latent.
