### PR TITLE
ci: add HF hub cache preflight check

### DIFF
--- a/tests/ci_tests/utils/hf_cache_check.py
+++ b/tests/ci_tests/utils/hf_cache_check.py
@@ -16,25 +16,18 @@
 """Check whether every HF repo referenced by a recipe YAML is already present
 in the local Hugging Face Hub cache (``$HF_HOME/hub/``).
 
-This is a *pure inspection* — it never downloads and never modifies the cache.
-The caller (typically a nemo-ci launcher wrapper) reads the JSON output and
-decides whether to flip ``HF_HUB_OFFLINE`` for the actual test run.
+Pure inspection — never downloads, never modifies the cache. The exit code
+IS the decision so the caller shell reduces to::
 
-CLI:
-    --config    Recipe YAML path (raw is fine — the recipe's model IDs are not
-                touched by ``config_resolver.py``).
-    --output    Optional path to write JSON output. When omitted, JSON is written
-                to stdout.
+    python3 hf_cache_check.py --config <recipe> || export HF_HUB_OFFLINE=0
 
-Output schema:
-    {"cached": [<repo_id>, ...], "missing": [<repo_id>, ...], "hf_home": "..."}
-
-The script always exits 0 so a preflight failure never blocks a test; the
-downstream shell inspects the JSON to make its decision.
+Exit codes:
+    0   every referenced HF repo is present in the local cache
+    1   at least one repo is missing, ``$HF_HOME`` is unset, or the check
+        errored — treat as "cache miss, need online"
 """
 
 import argparse
-import json
 import os
 import sys
 from pathlib import Path
@@ -111,48 +104,35 @@ def _has_snapshot(repo_dir: Path) -> bool:
     return False
 
 
-def check_cache(recipe_path: Path, hf_home: Path) -> dict[str, Any]:
-    """Partition the recipe's repo IDs into cached vs missing."""
+def check_cache(recipe_path: Path, hf_home: Path) -> tuple[list[str], list[str]]:
+    """Return ``(cached, missing)`` for the recipe's referenced repo IDs."""
     hub_dir = hf_home / "hub"
     cached: list[str] = []
     missing: list[str] = []
     for repo_id in _extract_repo_ids(recipe_path):
         repo_dir = hub_dir / _repo_folder(repo_id)
         (cached if _has_snapshot(repo_dir) else missing).append(repo_id)
-    return {"cached": cached, "missing": missing, "hf_home": str(hf_home)}
+    return cached, missing
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--config", type=Path, required=True, help="Recipe YAML path")
-    parser.add_argument("--output", type=Path, help="Where to write JSON (default: stdout)")
     args = parser.parse_args()
 
-    hf_home_env = os.environ.get("HF_HOME")
-    if not hf_home_env:
-        # No cache to inspect — treat every referenced repo as missing so the
-        # caller falls back to HF_HUB_OFFLINE=0. Never fail the preflight itself.
-        result: dict[str, Any] = {
-            "cached": [],
-            "missing": _extract_repo_ids(args.config) if args.config.is_file() else [],
-            "hf_home": "",
-        }
-    elif not args.config.is_file():
-        print(f"[hf_cache_check] WARNING: recipe not found: {args.config}", file=sys.stderr)
-        result = {"cached": [], "missing": [], "hf_home": hf_home_env}
-    else:
-        result = check_cache(args.config, Path(hf_home_env))
+    hf_home = os.environ.get("HF_HOME")
+    if not hf_home:
+        print("[hf_cache_check] HF_HOME unset; treating as cache miss", file=sys.stderr)
+        return 1
+    if not args.config.is_file():
+        print(f"[hf_cache_check] recipe not found: {args.config}; treating as cache miss", file=sys.stderr)
+        return 1
 
-    payload = json.dumps(result, indent=2, sort_keys=True) + "\n"
-    if args.output is not None:
-        args.output.parent.mkdir(parents=True, exist_ok=True)
-        args.output.write_text(payload, encoding="utf-8")
-        print(
-            f"[hf_cache_check] {args.config.name}: "
-            f"{len(result['cached'])} cached, {len(result['missing'])} missing → {args.output}"
-        )
-    else:
-        sys.stdout.write(payload)
+    cached, missing = check_cache(args.config, Path(hf_home))
+    if missing:
+        print(f"[hf_cache_check] miss in {hf_home}: {' '.join(missing)}")
+        return 1
+    print(f"[hf_cache_check] all {len(cached)} required repos cached in {hf_home}")
     return 0
 
 

--- a/tests/ci_tests/utils/hf_cache_check.py
+++ b/tests/ci_tests/utils/hf_cache_check.py
@@ -1,0 +1,160 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/usr/bin/env python3
+"""Check whether every HF repo referenced by a recipe YAML is already present
+in the local Hugging Face Hub cache (``$HF_HOME/hub/``).
+
+This is a *pure inspection* — it never downloads and never modifies the cache.
+The caller (typically a nemo-ci launcher wrapper) reads the JSON output and
+decides whether to flip ``HF_HUB_OFFLINE`` for the actual test run.
+
+CLI:
+    --config    Recipe YAML path (raw is fine — the recipe's model IDs are not
+                touched by ``config_resolver.py``).
+    --output    Optional path to write JSON output. When omitted, JSON is written
+                to stdout.
+
+Output schema:
+    {"cached": [<repo_id>, ...], "missing": [<repo_id>, ...], "hf_home": "..."}
+
+The script always exits 0 so a preflight failure never blocks a test; the
+downstream shell inspects the JSON to make its decision.
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+import yaml
+
+# Keys under which recipe YAMLs declare HF repo IDs. Covers:
+#   - model.pretrained_model_name_or_path
+#   - processor.pretrained_model_name_or_path (VLM)
+#   - ci.checkpoint_robustness.model.pretrained_model_name_or_path
+#   - ci.checkpoint_robustness.tokenizer_name
+#   - any future nested block using the same keys
+REPO_ID_KEYS = ("pretrained_model_name_or_path", "tokenizer_name")
+
+
+def _walk_repo_ids(node: Any) -> Iterable[str]:
+    """Yield every string value in ``node`` reached via a key in ``REPO_ID_KEYS``."""
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key in REPO_ID_KEYS and isinstance(value, str):
+                yield value
+            else:
+                yield from _walk_repo_ids(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _walk_repo_ids(item)
+
+
+def _is_hf_repo_id(value: str) -> bool:
+    """Heuristic: exactly one ``/``, no leading ``/`` or ``.``, no whitespace."""
+    if not value or value.startswith("/") or value.startswith("."):
+        return False
+    if any(ch.isspace() for ch in value):
+        return False
+    return value.count("/") == 1
+
+
+def _extract_repo_ids(recipe_path: Path) -> list[str]:
+    """Deduplicated, ordered list of HF-form repo IDs referenced by ``recipe_path``."""
+    with recipe_path.open("r", encoding="utf-8") as f:
+        recipe = yaml.safe_load(f) or {}
+
+    seen: dict[str, None] = {}
+    for value in _walk_repo_ids(recipe):
+        if _is_hf_repo_id(value) and value not in seen:
+            seen[value] = None
+    return list(seen)
+
+
+def _repo_folder(repo_id: str) -> str:
+    """Deterministic cache folder name (``models--<org>--<name>``).
+
+    Prefers ``huggingface_hub.file_download.repo_folder_name`` when available so
+    we stay locked to upstream's convention; falls back to the documented
+    ``models--{org}--{name}`` form otherwise.
+    """
+    try:
+        from huggingface_hub.file_download import repo_folder_name
+
+        return repo_folder_name(repo_id=repo_id, repo_type="model")
+    except Exception:
+        return "models--" + repo_id.replace("/", "--")
+
+
+def _has_snapshot(repo_dir: Path) -> bool:
+    """A cache entry is usable iff ``snapshots/<rev>/`` exists with at least one file."""
+    snapshots = repo_dir / "snapshots"
+    if not snapshots.is_dir():
+        return False
+    for rev in snapshots.iterdir():
+        if rev.is_dir() and any(rev.iterdir()):
+            return True
+    return False
+
+
+def check_cache(recipe_path: Path, hf_home: Path) -> dict[str, Any]:
+    """Partition the recipe's repo IDs into cached vs missing."""
+    hub_dir = hf_home / "hub"
+    cached: list[str] = []
+    missing: list[str] = []
+    for repo_id in _extract_repo_ids(recipe_path):
+        repo_dir = hub_dir / _repo_folder(repo_id)
+        (cached if _has_snapshot(repo_dir) else missing).append(repo_id)
+    return {"cached": cached, "missing": missing, "hf_home": str(hf_home)}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--config", type=Path, required=True, help="Recipe YAML path")
+    parser.add_argument("--output", type=Path, help="Where to write JSON (default: stdout)")
+    args = parser.parse_args()
+
+    hf_home_env = os.environ.get("HF_HOME")
+    if not hf_home_env:
+        # No cache to inspect — treat every referenced repo as missing so the
+        # caller falls back to HF_HUB_OFFLINE=0. Never fail the preflight itself.
+        result: dict[str, Any] = {
+            "cached": [],
+            "missing": _extract_repo_ids(args.config) if args.config.is_file() else [],
+            "hf_home": "",
+        }
+    elif not args.config.is_file():
+        print(f"[hf_cache_check] WARNING: recipe not found: {args.config}", file=sys.stderr)
+        result = {"cached": [], "missing": [], "hf_home": hf_home_env}
+    else:
+        result = check_cache(args.config, Path(hf_home_env))
+
+    payload = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(payload, encoding="utf-8")
+        print(
+            f"[hf_cache_check] {args.config.name}: "
+            f"{len(result['cached'])} cached, {len(result['missing'])} missing → {args.output}"
+        )
+    else:
+        sys.stdout.write(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ci_tests/utils/hf_cache_check.py
+++ b/tests/ci_tests/utils/hf_cache_check.py
@@ -17,14 +17,15 @@
 in the local Hugging Face Hub cache (``$HF_HOME/hub/``).
 
 Pure inspection — never downloads, never modifies the cache. The exit code
-IS the decision so the caller shell reduces to::
-
-    python3 hf_cache_check.py --config <recipe> || export HF_HUB_OFFLINE=0
+IS the decision:
 
 Exit codes:
     0   every referenced HF repo is present in the local cache
-    1   at least one repo is missing, ``$HF_HOME`` is unset, or the check
-        errored — treat as "cache miss, need online"
+    1   at least one referenced repo is missing (cleanly detected)
+    2   the check could not run to completion (HF_HOME unset, recipe file
+        not found, unexpected exception, ...). The caller should treat this
+        as "unknown" and preserve the pipeline default, not silently flip
+        HF_HUB_OFFLINE.
 """
 
 import argparse
@@ -115,6 +116,11 @@ def check_cache(recipe_path: Path, hf_home: Path) -> tuple[list[str], list[str]]
     return cached, missing
 
 
+EXIT_ALL_CACHED = 0
+EXIT_MISS = 1
+EXIT_ERROR = 2
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--config", type=Path, required=True, help="Recipe YAML path")
@@ -122,19 +128,25 @@ def main() -> int:
 
     hf_home = os.environ.get("HF_HOME")
     if not hf_home:
-        print("[hf_cache_check] HF_HOME unset; treating as cache miss", file=sys.stderr)
-        return 1
+        print("[hf_cache_check] ERROR: HF_HOME is not set", file=sys.stderr)
+        return EXIT_ERROR
     if not args.config.is_file():
-        print(f"[hf_cache_check] recipe not found: {args.config}; treating as cache miss", file=sys.stderr)
-        return 1
+        print(f"[hf_cache_check] ERROR: recipe not found: {args.config}", file=sys.stderr)
+        return EXIT_ERROR
 
     cached, missing = check_cache(args.config, Path(hf_home))
     if missing:
         print(f"[hf_cache_check] miss in {hf_home}: {' '.join(missing)}")
-        return 1
+        return EXIT_MISS
     print(f"[hf_cache_check] all {len(cached)} required repos cached in {hf_home}")
-    return 0
+    return EXIT_ALL_CACHED
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    try:
+        sys.exit(main())
+    except SystemExit:
+        raise
+    except BaseException as exc:  # noqa: BLE001 - preflight must never leak a traceback as a "miss" signal
+        print(f"[hf_cache_check] ERROR: unexpected exception: {exc!r}", file=sys.stderr)
+        sys.exit(EXIT_ERROR)

--- a/tests/ci_tests/utils/hf_cache_check.py
+++ b/tests/ci_tests/utils/hf_cache_check.py
@@ -16,16 +16,18 @@
 """Check whether every HF repo referenced by a recipe YAML is already present
 in the local Hugging Face Hub cache (``$HF_HOME/hub/``).
 
-Pure inspection — never downloads, never modifies the cache. The exit code
-IS the decision:
+Pure inspection — never downloads, never modifies the cache. Answers one
+yes/no question via exit code: "should the caller flip HF_HUB_OFFLINE=0?"
 
 Exit codes:
-    0   every referenced HF repo is present in the local cache
-    1   at least one referenced repo is missing (cleanly detected)
-    2   the check could not run to completion (HF_HOME unset, recipe file
-        not found, unexpected exception, ...). The caller should treat this
-        as "unknown" and preserve the pipeline default, not silently flip
-        HF_HUB_OFFLINE.
+    0   YES  a cache miss was affirmatively detected (at least one referenced
+             repo is not in $HF_HOME/hub/); caller should go online
+    1   NO   everything else — all repos cached, HF_HOME unset, recipe file
+             missing, unexpected exception, ... — caller preserves default
+
+The inversion (0 = "please act") lets the caller shell reduce to::
+
+    python3 hf_cache_check.py --config <recipe> && export HF_HUB_OFFLINE=0
 """
 
 import argparse
@@ -116,9 +118,8 @@ def check_cache(recipe_path: Path, hf_home: Path) -> tuple[list[str], list[str]]
     return cached, missing
 
 
-EXIT_ALL_CACHED = 0
-EXIT_MISS = 1
-EXIT_ERROR = 2
+EXIT_MISS_DETECTED = 0
+EXIT_DO_NOTHING = 1
 
 
 def main() -> int:
@@ -128,18 +129,18 @@ def main() -> int:
 
     hf_home = os.environ.get("HF_HOME")
     if not hf_home:
-        print("[hf_cache_check] ERROR: HF_HOME is not set", file=sys.stderr)
-        return EXIT_ERROR
+        print("[hf_cache_check] HF_HOME is not set; cannot verify cache", file=sys.stderr)
+        return EXIT_DO_NOTHING
     if not args.config.is_file():
-        print(f"[hf_cache_check] ERROR: recipe not found: {args.config}", file=sys.stderr)
-        return EXIT_ERROR
+        print(f"[hf_cache_check] recipe not found: {args.config}", file=sys.stderr)
+        return EXIT_DO_NOTHING
 
     cached, missing = check_cache(args.config, Path(hf_home))
     if missing:
         print(f"[hf_cache_check] miss in {hf_home}: {' '.join(missing)}")
-        return EXIT_MISS
+        return EXIT_MISS_DETECTED
     print(f"[hf_cache_check] all {len(cached)} required repos cached in {hf_home}")
-    return EXIT_ALL_CACHED
+    return EXIT_DO_NOTHING
 
 
 if __name__ == "__main__":
@@ -148,5 +149,5 @@ if __name__ == "__main__":
     except SystemExit:
         raise
     except BaseException as exc:  # noqa: BLE001 - preflight must never leak a traceback as a "miss" signal
-        print(f"[hf_cache_check] ERROR: unexpected exception: {exc!r}", file=sys.stderr)
-        sys.exit(EXIT_ERROR)
+        print(f"[hf_cache_check] unexpected exception: {exc!r}", file=sys.stderr)
+        sys.exit(EXIT_DO_NOTHING)

--- a/tests/unit_tests/ci_tests/test_hf_cache_check.py
+++ b/tests/unit_tests/ci_tests/test_hf_cache_check.py
@@ -154,7 +154,8 @@ def test_check_cache_empty_snapshot_dir_counts_as_missing(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# CLI (exit code = decision: 0 = all cached, 1 = miss / error)
+# CLI exit codes:
+#   0 = all cached, 1 = miss (clean), 2 = error (HF_HOME missing / no recipe)
 # ---------------------------------------------------------------------------
 
 
@@ -165,7 +166,7 @@ def test_main_exits_zero_when_all_cached(tmp_path, monkeypatch):
     recipe = _write_recipe(tmp_path, "vlm.yaml", VLM_RECIPE)
 
     monkeypatch.setattr(sys, "argv", ["hf_cache_check.py", "--config", str(recipe)])
-    assert hf_cache_check.main() == 0
+    assert hf_cache_check.main() == hf_cache_check.EXIT_ALL_CACHED
 
 
 def test_main_exits_one_when_any_missing(tmp_path, monkeypatch):
@@ -175,18 +176,24 @@ def test_main_exits_one_when_any_missing(tmp_path, monkeypatch):
     recipe = _write_recipe(tmp_path, "llm.yaml", LLM_RECIPE)
 
     monkeypatch.setattr(sys, "argv", ["hf_cache_check.py", "--config", str(recipe)])
-    assert hf_cache_check.main() == 1
+    assert hf_cache_check.main() == hf_cache_check.EXIT_MISS
 
 
-def test_main_exits_one_when_hf_home_unset(tmp_path, monkeypatch):
+def test_main_exits_two_when_hf_home_unset(tmp_path, monkeypatch):
     monkeypatch.delenv("HF_HOME", raising=False)
     recipe = _write_recipe(tmp_path, "llm.yaml", LLM_RECIPE)
 
     monkeypatch.setattr(sys, "argv", ["hf_cache_check.py", "--config", str(recipe)])
-    assert hf_cache_check.main() == 1
+    assert hf_cache_check.main() == hf_cache_check.EXIT_ERROR
 
 
-def test_main_exits_one_when_recipe_missing(tmp_path, monkeypatch):
+def test_main_exits_two_when_recipe_missing(tmp_path, monkeypatch):
     monkeypatch.setenv("HF_HOME", str(tmp_path / "hf_home"))
     monkeypatch.setattr(sys, "argv", ["hf_cache_check.py", "--config", str(tmp_path / "does_not_exist.yaml")])
-    assert hf_cache_check.main() == 1
+    assert hf_cache_check.main() == hf_cache_check.EXIT_ERROR
+
+
+def test_exit_codes_are_distinct():
+    # Any collision would defeat the shim's tri-state decision.
+    codes = {hf_cache_check.EXIT_ALL_CACHED, hf_cache_check.EXIT_MISS, hf_cache_check.EXIT_ERROR}
+    assert len(codes) == 3

--- a/tests/unit_tests/ci_tests/test_hf_cache_check.py
+++ b/tests/unit_tests/ci_tests/test_hf_cache_check.py
@@ -14,7 +14,6 @@
 
 """Tests for ``tests/ci_tests/utils/hf_cache_check.py``."""
 
-import json
 import sys
 from pathlib import Path
 
@@ -133,11 +132,10 @@ def test_check_cache_partitions_hits_and_misses(tmp_path):
     # 3B-Instruct is deliberately left un-seeded so it registers as missing.
 
     recipe = _write_recipe(tmp_path, "llm.yaml", LLM_RECIPE)
-    result = hf_cache_check.check_cache(recipe, hf_home)
+    cached, missing = hf_cache_check.check_cache(recipe, hf_home)
 
-    assert result["cached"] == ["meta-llama/Llama-3.2-1B"]
-    assert result["missing"] == ["meta-llama/Llama-3.2-3B-Instruct"]
-    assert result["hf_home"] == str(hf_home)
+    assert cached == ["meta-llama/Llama-3.2-1B"]
+    assert missing == ["meta-llama/Llama-3.2-3B-Instruct"]
 
 
 def test_check_cache_empty_snapshot_dir_counts_as_missing(tmp_path):
@@ -146,49 +144,49 @@ def test_check_cache_empty_snapshot_dir_counts_as_missing(tmp_path):
     _seed_cache(hf_home, "meta-llama/Llama-3.2-3B-Instruct", with_file=False)
 
     recipe = _write_recipe(tmp_path, "llm.yaml", LLM_RECIPE)
-    result = hf_cache_check.check_cache(recipe, hf_home)
+    cached, missing = hf_cache_check.check_cache(recipe, hf_home)
 
-    assert result["cached"] == []
-    assert set(result["missing"]) == {
+    assert cached == []
+    assert set(missing) == {
         "meta-llama/Llama-3.2-1B",
         "meta-llama/Llama-3.2-3B-Instruct",
     }
 
 
 # ---------------------------------------------------------------------------
-# CLI
+# CLI (exit code = decision: 0 = all cached, 1 = miss / error)
 # ---------------------------------------------------------------------------
 
 
-def test_main_writes_json_output(tmp_path, monkeypatch, capsys):
+def test_main_exits_zero_when_all_cached(tmp_path, monkeypatch):
     hf_home = tmp_path / "hf_home"
     _seed_cache(hf_home, "Qwen/Qwen3-VL-4B-Thinking")
     monkeypatch.setenv("HF_HOME", str(hf_home))
-
     recipe = _write_recipe(tmp_path, "vlm.yaml", VLM_RECIPE)
-    output = tmp_path / "out.json"
 
-    monkeypatch.setattr(sys, "argv", ["hf_cache_check.py", "--config", str(recipe), "--output", str(output)])
+    monkeypatch.setattr(sys, "argv", ["hf_cache_check.py", "--config", str(recipe)])
     assert hf_cache_check.main() == 0
 
-    payload = json.loads(output.read_text(encoding="utf-8"))
-    assert payload["cached"] == ["Qwen/Qwen3-VL-4B-Thinking"]
-    assert payload["missing"] == []
 
-
-def test_main_without_hf_home_marks_everything_missing(tmp_path, monkeypatch):
-    monkeypatch.delenv("HF_HOME", raising=False)
-
+def test_main_exits_one_when_any_missing(tmp_path, monkeypatch):
+    hf_home = tmp_path / "hf_home"
+    _seed_cache(hf_home, "meta-llama/Llama-3.2-1B")  # only one of two seeded
+    monkeypatch.setenv("HF_HOME", str(hf_home))
     recipe = _write_recipe(tmp_path, "llm.yaml", LLM_RECIPE)
-    output = tmp_path / "out.json"
 
-    monkeypatch.setattr(sys, "argv", ["hf_cache_check.py", "--config", str(recipe), "--output", str(output)])
-    assert hf_cache_check.main() == 0
+    monkeypatch.setattr(sys, "argv", ["hf_cache_check.py", "--config", str(recipe)])
+    assert hf_cache_check.main() == 1
 
-    payload = json.loads(output.read_text(encoding="utf-8"))
-    assert payload["cached"] == []
-    assert set(payload["missing"]) == {
-        "meta-llama/Llama-3.2-1B",
-        "meta-llama/Llama-3.2-3B-Instruct",
-    }
-    assert payload["hf_home"] == ""
+
+def test_main_exits_one_when_hf_home_unset(tmp_path, monkeypatch):
+    monkeypatch.delenv("HF_HOME", raising=False)
+    recipe = _write_recipe(tmp_path, "llm.yaml", LLM_RECIPE)
+
+    monkeypatch.setattr(sys, "argv", ["hf_cache_check.py", "--config", str(recipe)])
+    assert hf_cache_check.main() == 1
+
+
+def test_main_exits_one_when_recipe_missing(tmp_path, monkeypatch):
+    monkeypatch.setenv("HF_HOME", str(tmp_path / "hf_home"))
+    monkeypatch.setattr(sys, "argv", ["hf_cache_check.py", "--config", str(tmp_path / "does_not_exist.yaml")])
+    assert hf_cache_check.main() == 1

--- a/tests/unit_tests/ci_tests/test_hf_cache_check.py
+++ b/tests/unit_tests/ci_tests/test_hf_cache_check.py
@@ -154,46 +154,46 @@ def test_check_cache_empty_snapshot_dir_counts_as_missing(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# CLI exit codes:
-#   0 = all cached, 1 = miss (clean), 2 = error (HF_HOME missing / no recipe)
+# CLI exit codes — inverted convention:
+#   0 = MISS DETECTED (caller should flip HF_HUB_OFFLINE=0)
+#   1 = do nothing (all cached, HF_HOME unset, recipe missing, exception)
 # ---------------------------------------------------------------------------
 
 
-def test_main_exits_zero_when_all_cached(tmp_path, monkeypatch):
-    hf_home = tmp_path / "hf_home"
-    _seed_cache(hf_home, "Qwen/Qwen3-VL-4B-Thinking")
-    monkeypatch.setenv("HF_HOME", str(hf_home))
-    recipe = _write_recipe(tmp_path, "vlm.yaml", VLM_RECIPE)
-
-    monkeypatch.setattr(sys, "argv", ["hf_cache_check.py", "--config", str(recipe)])
-    assert hf_cache_check.main() == hf_cache_check.EXIT_ALL_CACHED
-
-
-def test_main_exits_one_when_any_missing(tmp_path, monkeypatch):
+def test_main_exits_zero_only_when_miss_detected(tmp_path, monkeypatch):
     hf_home = tmp_path / "hf_home"
     _seed_cache(hf_home, "meta-llama/Llama-3.2-1B")  # only one of two seeded
     monkeypatch.setenv("HF_HOME", str(hf_home))
     recipe = _write_recipe(tmp_path, "llm.yaml", LLM_RECIPE)
 
     monkeypatch.setattr(sys, "argv", ["hf_cache_check.py", "--config", str(recipe)])
-    assert hf_cache_check.main() == hf_cache_check.EXIT_MISS
+    assert hf_cache_check.main() == hf_cache_check.EXIT_MISS_DETECTED
 
 
-def test_main_exits_two_when_hf_home_unset(tmp_path, monkeypatch):
+def test_main_exits_nonzero_when_all_cached(tmp_path, monkeypatch):
+    hf_home = tmp_path / "hf_home"
+    _seed_cache(hf_home, "Qwen/Qwen3-VL-4B-Thinking")
+    monkeypatch.setenv("HF_HOME", str(hf_home))
+    recipe = _write_recipe(tmp_path, "vlm.yaml", VLM_RECIPE)
+
+    monkeypatch.setattr(sys, "argv", ["hf_cache_check.py", "--config", str(recipe)])
+    assert hf_cache_check.main() == hf_cache_check.EXIT_DO_NOTHING
+
+
+def test_main_exits_nonzero_when_hf_home_unset(tmp_path, monkeypatch):
     monkeypatch.delenv("HF_HOME", raising=False)
     recipe = _write_recipe(tmp_path, "llm.yaml", LLM_RECIPE)
 
     monkeypatch.setattr(sys, "argv", ["hf_cache_check.py", "--config", str(recipe)])
-    assert hf_cache_check.main() == hf_cache_check.EXIT_ERROR
+    assert hf_cache_check.main() == hf_cache_check.EXIT_DO_NOTHING
 
 
-def test_main_exits_two_when_recipe_missing(tmp_path, monkeypatch):
+def test_main_exits_nonzero_when_recipe_missing(tmp_path, monkeypatch):
     monkeypatch.setenv("HF_HOME", str(tmp_path / "hf_home"))
     monkeypatch.setattr(sys, "argv", ["hf_cache_check.py", "--config", str(tmp_path / "does_not_exist.yaml")])
-    assert hf_cache_check.main() == hf_cache_check.EXIT_ERROR
+    assert hf_cache_check.main() == hf_cache_check.EXIT_DO_NOTHING
 
 
 def test_exit_codes_are_distinct():
-    # Any collision would defeat the shim's tri-state decision.
-    codes = {hf_cache_check.EXIT_ALL_CACHED, hf_cache_check.EXIT_MISS, hf_cache_check.EXIT_ERROR}
-    assert len(codes) == 3
+    # A collision would defeat the shim's binary decision.
+    assert hf_cache_check.EXIT_MISS_DETECTED != hf_cache_check.EXIT_DO_NOTHING

--- a/tests/unit_tests/ci_tests/test_hf_cache_check.py
+++ b/tests/unit_tests/ci_tests/test_hf_cache_check.py
@@ -1,0 +1,194 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ``tests/ci_tests/utils/hf_cache_check.py``."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+UTILS_DIR = Path(__file__).resolve().parents[3] / "tests" / "ci_tests" / "utils"
+if str(UTILS_DIR) not in sys.path:
+    sys.path.insert(0, str(UTILS_DIR))
+
+import hf_cache_check  # noqa: E402
+
+LLM_RECIPE = {
+    "model": {
+        "_target_": "nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained",
+        "pretrained_model_name_or_path": "meta-llama/Llama-3.2-1B",
+    },
+    "dataset": {"path_or_dataset": "rowan/hellaswag"},
+    "ci": {
+        "checkpoint_robustness": {
+            "model": {
+                "pretrained_model_name_or_path": "meta-llama/Llama-3.2-3B-Instruct",
+            },
+            "tokenizer_name": "meta-llama/Llama-3.2-3B-Instruct",
+        },
+    },
+}
+
+VLM_RECIPE = {
+    "model": {
+        "_target_": "nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained",
+        "pretrained_model_name_or_path": "Qwen/Qwen3-VL-4B-Thinking",
+    },
+    "processor": {
+        "_target_": "transformers.AutoProcessor.from_pretrained",
+        "pretrained_model_name_or_path": "Qwen/Qwen3-VL-4B-Thinking",
+    },
+    "dataset": {"path_or_dataset": "mmoukouba/MedPix-VQA"},
+}
+
+LOCAL_PATH_RECIPE = {
+    "model": {"pretrained_model_name_or_path": "/opt/checkpoints/local"},
+    "processor": {"pretrained_model_name_or_path": "./relative/path"},
+    "ci": {"checkpoint_robustness": {"tokenizer_name": "meta-llama/Llama-3.2-1B"}},
+}
+
+
+def _write_recipe(tmp_path: Path, name: str, recipe: dict) -> Path:
+    path = tmp_path / name
+    # sort_keys=False preserves insertion order so the walker's output is stable
+    # (real recipes are hand-authored top-down; sorted dumps would obscure that).
+    path.write_text(yaml.safe_dump(recipe, sort_keys=False), encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Recipe walker
+# ---------------------------------------------------------------------------
+
+
+def test_extract_repo_ids_llm_recipe(tmp_path):
+    path = _write_recipe(tmp_path, "llm.yaml", LLM_RECIPE)
+    assert hf_cache_check._extract_repo_ids(path) == [
+        "meta-llama/Llama-3.2-1B",
+        "meta-llama/Llama-3.2-3B-Instruct",
+    ]
+
+
+def test_extract_repo_ids_vlm_recipe_dedupes(tmp_path):
+    # model + processor reference the same repo — expect one entry.
+    path = _write_recipe(tmp_path, "vlm.yaml", VLM_RECIPE)
+    assert hf_cache_check._extract_repo_ids(path) == ["Qwen/Qwen3-VL-4B-Thinking"]
+
+
+def test_extract_repo_ids_skips_local_paths(tmp_path):
+    # Absolute and relative filesystem paths are not HF repo IDs; the tokenizer
+    # string is the only genuine repo id and should survive.
+    path = _write_recipe(tmp_path, "local.yaml", LOCAL_PATH_RECIPE)
+    assert hf_cache_check._extract_repo_ids(path) == ["meta-llama/Llama-3.2-1B"]
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("meta-llama/Llama-3.2-1B", True),
+        ("Qwen/Qwen3-VL-4B-Thinking", True),
+        ("/opt/checkpoints/local", False),
+        ("./relative/path", False),
+        ("no-slash", False),
+        ("too/many/slashes", False),
+        ("", False),
+        ("has space/name", False),
+    ],
+)
+def test_is_hf_repo_id(value, expected):
+    assert hf_cache_check._is_hf_repo_id(value) is expected
+
+
+# ---------------------------------------------------------------------------
+# Cache inspection
+# ---------------------------------------------------------------------------
+
+
+def _seed_cache(hf_home: Path, repo_id: str, with_file: bool = True) -> None:
+    """Create a ``$HF_HOME/hub/models--<org>--<name>/snapshots/<rev>/`` layout."""
+    folder = "models--" + repo_id.replace("/", "--")
+    rev_dir = hf_home / "hub" / folder / "snapshots" / "abc123"
+    rev_dir.mkdir(parents=True, exist_ok=True)
+    if with_file:
+        (rev_dir / "config.json").write_text("{}", encoding="utf-8")
+
+
+def test_check_cache_partitions_hits_and_misses(tmp_path):
+    hf_home = tmp_path / "hf_home"
+    _seed_cache(hf_home, "meta-llama/Llama-3.2-1B")
+    # 3B-Instruct is deliberately left un-seeded so it registers as missing.
+
+    recipe = _write_recipe(tmp_path, "llm.yaml", LLM_RECIPE)
+    result = hf_cache_check.check_cache(recipe, hf_home)
+
+    assert result["cached"] == ["meta-llama/Llama-3.2-1B"]
+    assert result["missing"] == ["meta-llama/Llama-3.2-3B-Instruct"]
+    assert result["hf_home"] == str(hf_home)
+
+
+def test_check_cache_empty_snapshot_dir_counts_as_missing(tmp_path):
+    hf_home = tmp_path / "hf_home"
+    _seed_cache(hf_home, "meta-llama/Llama-3.2-1B", with_file=False)
+    _seed_cache(hf_home, "meta-llama/Llama-3.2-3B-Instruct", with_file=False)
+
+    recipe = _write_recipe(tmp_path, "llm.yaml", LLM_RECIPE)
+    result = hf_cache_check.check_cache(recipe, hf_home)
+
+    assert result["cached"] == []
+    assert set(result["missing"]) == {
+        "meta-llama/Llama-3.2-1B",
+        "meta-llama/Llama-3.2-3B-Instruct",
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def test_main_writes_json_output(tmp_path, monkeypatch, capsys):
+    hf_home = tmp_path / "hf_home"
+    _seed_cache(hf_home, "Qwen/Qwen3-VL-4B-Thinking")
+    monkeypatch.setenv("HF_HOME", str(hf_home))
+
+    recipe = _write_recipe(tmp_path, "vlm.yaml", VLM_RECIPE)
+    output = tmp_path / "out.json"
+
+    monkeypatch.setattr(sys, "argv", ["hf_cache_check.py", "--config", str(recipe), "--output", str(output)])
+    assert hf_cache_check.main() == 0
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["cached"] == ["Qwen/Qwen3-VL-4B-Thinking"]
+    assert payload["missing"] == []
+
+
+def test_main_without_hf_home_marks_everything_missing(tmp_path, monkeypatch):
+    monkeypatch.delenv("HF_HOME", raising=False)
+
+    recipe = _write_recipe(tmp_path, "llm.yaml", LLM_RECIPE)
+    output = tmp_path / "out.json"
+
+    monkeypatch.setattr(sys, "argv", ["hf_cache_check.py", "--config", str(recipe), "--output", str(output)])
+    assert hf_cache_check.main() == 0
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["cached"] == []
+    assert set(payload["missing"]) == {
+        "meta-llama/Llama-3.2-1B",
+        "meta-llama/Llama-3.2-3B-Instruct",
+    }
+    assert payload["hf_home"] == ""


### PR DESCRIPTION
# What does this PR do ?

Adds tests/ci_tests/utils/hf_cache_check.py — walks a recipe YAML for HF repo IDs (pretrained_model_name_or_path, tokenizer_name) and live-inspects \$HF_HOME/hub/ so the nemo-ci launcher wrappers can decide whether to flip HF_HUB_OFFLINE=0 for a run. Replaces the static offline assumption that would fail any recipe referencing a not-yet-cached model.

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
