### PR TITLE
fix(pp): support PyTorch 2.13 metadata inference

### DIFF
--- a/nemo_automodel/components/distributed/pipelining/functional.py
+++ b/nemo_automodel/components/distributed/pipelining/functional.py
@@ -276,6 +276,11 @@ def _get_hidden_and_vocab_size(model_config) -> tuple[int, int]:
     return hidden_size, vocab_size
 
 
+def _supports_stage_shape_precomputation(stages: list[PipelineStage]) -> bool:
+    """Return whether every stage exposes PyTorch's analytical metadata hook."""
+    return all(callable(getattr(stage, "_configure_outputs_meta", None)) for stage in stages)
+
+
 def _precompute_stage_shapes(
     stages: list[PipelineStage],
     model_config,
@@ -289,9 +294,11 @@ def _precompute_stage_shapes(
     stage 0 → send → stage 1 → send → ... → stage N-1.  This is O(N) in the number of
     pipeline stages and becomes a bottleneck for large world sizes.
 
-    This function sets ``inputs_meta`` and ``_outputs_meta`` on each stage *before* the
-    first ``step()`` call, so that ``_shape_inference`` is never invoked and the serial
-    chain is completely eliminated.
+    On PyTorch versions that expose the metadata configuration hook, this function sets
+    ``inputs_meta`` and ``_outputs_meta`` on each stage *before* the first ``step()`` call,
+    so that ``_shape_inference`` is never invoked and the serial chain is completely
+    eliminated. Newer PyTorch versions infer metadata dynamically instead; in that case
+    this function leaves the stages untouched.
 
     Args:
         stages: The local pipeline stages (already parallelized).
@@ -299,6 +306,15 @@ def _precompute_stage_shapes(
         microbatch_size: Microbatch size used by the pipeline schedule.
         seq_len: Sequence length of the input data.
     """
+    # PyTorch 2.13 removed PipelineStage._configure_outputs_meta in favor of
+    # dynamic metadata inference. Keep the analytical optimization where the
+    # upstream hook exists and otherwise use the supported inference path.
+    if not _supports_stage_shape_precomputation(stages):
+        logger.info(
+            "Pipeline stages do not expose analytical metadata configuration; using PyTorch dynamic metadata inference"
+        )
+        return
+
     hidden_size, vocab_size = _get_hidden_and_vocab_size(model_config)
 
     for stage in stages:
@@ -360,10 +376,9 @@ def reset_pp_stage_shapes(
     buffer sizes on the first ``schedule.step()`` call (``_stages_initialized = True``).
     Subsequent steps with a different seq_len therefore hit a shape-mismatch error.
 
-    This function resets the per-stage infrastructure so that ``_initialize_stages`` re-runs
-    on the next ``step()`` call.  It then calls ``_precompute_stage_shapes`` to set the
-    correct shapes analytically — avoiding the expensive real-valued forward pass that
-    ``_shape_inference`` would otherwise perform.
+    This function resets the per-stage infrastructure so that stage initialization re-runs
+    on the next ``step()`` call. It precomputes the new shapes when supported by the installed
+    PyTorch version; otherwise PyTorch infers metadata from the upcoming real microbatch.
 
     Args:
         schedule: The active pipeline schedule.
@@ -372,17 +387,21 @@ def reset_pp_stage_shapes(
         microbatch_size: Per-microbatch batch size used by the schedule.
         seq_len: Sequence length of the upcoming batch (e.g. ``input_ids.shape[1]``).
     """
+    can_precompute_shapes = _supports_stage_shape_precomputation(stages)
+
     for stage in stages:
-        # Allow _configure_outputs_meta to be called again (it asserts _outputs_meta is None)
-        stage._outputs_meta = None
-        # Allow _shape_inference to re-run for non-first stages receiving new shapes
-        stage.inputs_meta = None
+        if can_precompute_shapes:
+            # Allow _configure_outputs_meta to be called again (it asserts _outputs_meta is None)
+            stage._outputs_meta = None
+            # Allow _shape_inference to re-run for non-first stages receiving new shapes
+            stage.inputs_meta = None
         # Clear pre-allocated recv/send buffers; they will be reallocated by _prepare_forward_infra
         stage.args_recv_info = {}
         stage.grad_recv_info = {}
         stage.grad_send_info = None
 
-    # Analytically set shapes for the new seq_len (no forward pass)
+    # Analytically set shapes when the installed PyTorch version supports it.
+    # Otherwise this is a no-op and the next schedule step infers metadata dynamically.
     _precompute_stage_shapes(stages, model_config, microbatch_size, seq_len, tensor_dtype=tensor_dtype)
 
     # Trigger _initialize_stage(s) on the next step() call.

--- a/tests/unit_tests/distributed/pipelining/test_functional.py
+++ b/tests/unit_tests/distributed/pipelining/test_functional.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import types
 from unittest.mock import MagicMock, Mock, patch
 
@@ -884,6 +885,21 @@ class TestPrecomputeStageShapes:
         out_call = stage._configure_outputs_meta.call_args[0][0]
         assert out_call[0].shape == (2, 16, 64)
 
+    def test_new_pipeline_stage_api_uses_dynamic_metadata_inference(self, caplog):
+        """Stages without the removed metadata hook should be left for dynamic inference."""
+        stage = types.SimpleNamespace(
+            is_first=True,
+            is_last=False,
+            submod=Mock(),
+        )
+
+        caplog.set_level(logging.INFO)
+        _precompute_stage_shapes([stage], self._make_config(), microbatch_size=2, seq_len=16)
+
+        assert not hasattr(stage, "inputs_meta")
+        assert not hasattr(stage, "_outputs_meta")
+        assert "using PyTorch dynamic metadata inference" in caplog.text
+
     @patch("nemo_automodel.components.distributed.pipelining.functional.split_model_into_stages")
     @patch("nemo_automodel.components.distributed.pipelining.functional.build_pipeline_schedule")
     def test_pipeline_model_with_seq_len(self, mock_build_schedule, mock_split_stages):
@@ -1118,6 +1134,30 @@ class TestResetPpStageShapes:
         assert stage.args_recv_info == {}
         assert stage.grad_recv_info == {}
         assert stage.grad_send_info is None
+
+    def test_new_pipeline_stage_api_resets_for_dynamic_metadata_inference(self):
+        """New-style stages should reset buffers without recreating removed metadata attributes."""
+        stage = types.SimpleNamespace(
+            is_first=True,
+            is_last=False,
+            submod=Mock(),
+            args_recv_info={"some_key": "some_val"},
+            grad_recv_info={"grad_key": "grad_val"},
+            grad_send_info=Mock(),
+        )
+        schedule = self._make_schedule(initialized=True)
+
+        reset_pp_stage_shapes(schedule, [stage], self._make_config(), microbatch_size=2, seq_len=32)
+
+        assert stage.args_recv_info == {}
+        assert stage.grad_recv_info == {}
+        assert stage.grad_send_info is None
+        assert not hasattr(stage, "inputs_meta")
+        assert not hasattr(stage, "_outputs_meta")
+        assert schedule._stage_forward_initialized is False
+        assert schedule._stage_backward_initialized is False
+        assert schedule._stages_forward_initialized is False
+        assert schedule._stages_backward_initialized is False
 
     def test_multi_stage_reset(self):
         """Reset should work across a full 3-stage pipeline."""


### PR DESCRIPTION
## Summary

- stop calling `PipelineStage._configure_outputs_meta` when the installed PyTorch no longer exposes it
- preserve analytical metadata precomputation on PyTorch versions that support it
- on the newer API, clear pipeline communication buffers and schedule initialization state so PyTorch dynamically infers metadata from the next real microbatch
- cover both API generations without recreating removed private attributes

This fixes a broad `pp_size > 1` regression observed after CI moved to PyTorch `2.13.0a0+8145d630e8.nv26.06`; Mistral4 VLM exposed it, but the affected code is shared by LLM and VLM pipeline training.

I found this regression while rerunning AM-654 scoped CI after the AutoModel CI image was updated to 26.06 on July 17, 2026.

## Validation

- `uv run pytest tests/unit_tests/distributed/pipelining/test_functional.py -q` — 73 passed
- `uv run ruff format .`
- `uv run ruff check --fix .`

Distributed dynamic-sequence PP validation on the PyTorch 2.13 CI image is pending before this leaves draft.
