### PR TITLE
fix(transformers): keep custom M3 config when transformers ships its own

### DIFF
--- a/nemo_automodel/_transformers/registry.py
+++ b/nemo_automodel/_transformers/registry.py
@@ -297,19 +297,35 @@ _CUSTOM_CONFIG_REGISTRATIONS: Dict[str, Tuple[str, str]] = {
     "step3p7": ("nemo_automodel.components.models.step3p7.configuration_step3p7", "Step3p7Config"),
 }
 
+# model_types whose custom model implementation reads fields that only our
+# config class provides. When a transformers release starts shipping its own
+# config for one of these model_types (same model_type string, often the same
+# class name), the skip-if-built-in registration below would silently hand the
+# native config to our custom model and break its field protocol at init
+# (transformers 5.12 added minimax_m3_vl whose vision config drops rope_theta
+# -> ``'MiniMaxM3VLVisionConfig' object has no attribute 'rope_theta'``).
+# These entries override the built-in registration instead. Entries NOT listed
+# here keep the built-in config when one exists (mistral4's custom model was
+# written against the native config and runs green with it).
+_CUSTOM_CONFIG_OVERRIDES_BUILTIN = {
+    "minimax_m3_vl",
+}
+
 
 def _register_custom_configs() -> None:
     from transformers import AutoConfig
     from transformers.models.auto.configuration_auto import CONFIG_MAPPING
 
     for model_type, (module_path, cls_name) in _CUSTOM_CONFIG_REGISTRATIONS.items():
-        if model_type not in CONFIG_MAPPING:
-            try:
-                mod = importlib.import_module(module_path)
-                cfg_cls = getattr(mod, cls_name)
-                AutoConfig.register(model_type, cfg_cls)
-            except Exception:
-                logger.debug("Failed to register config for model_type=%s", model_type, exc_info=True)
+        is_builtin = model_type in CONFIG_MAPPING
+        if is_builtin and model_type not in _CUSTOM_CONFIG_OVERRIDES_BUILTIN:
+            continue
+        try:
+            mod = importlib.import_module(module_path)
+            cfg_cls = getattr(mod, cls_name)
+            AutoConfig.register(model_type, cfg_cls, exist_ok=is_builtin)
+        except Exception:
+            logger.debug("Failed to register config for model_type=%s", model_type, exc_info=True)
 
 
 _register_custom_configs()

--- a/tests/unit_tests/_transformers/test_registry.py
+++ b/tests/unit_tests/_transformers/test_registry.py
@@ -411,3 +411,27 @@ def test_all_model_folders_registered_in_auto_map():
         f"in MODEL_ARCH_MAPPING (registry.py). Add an entry for each architecture "
         f"exported by these modules."
     )
+
+
+def test_minimax_m3_vl_config_overrides_transformers_builtin():
+    """Our MiniMaxM3VLConfig must win the AutoConfig registration even when transformers ships its own.
+
+    transformers 5.12 added a native ``minimax_m3_vl`` model_type (same class
+    names as ours). The skip-if-built-in registration then handed the native
+    config to our custom MiniMaxM3SparseForConditionalGeneration, whose vision
+    encoder reads ``config.rope_theta`` that the native vision config does not
+    carry -> AttributeError at model init. ``_CUSTOM_CONFIG_OVERRIDES_BUILTIN``
+    forces our config class for such model_types.
+    """
+    from transformers.models.auto.configuration_auto import CONFIG_MAPPING
+
+    from nemo_automodel.components.models.minimax_m3_vl.config import MiniMaxM3VLConfig
+
+    resolved = CONFIG_MAPPING["minimax_m3_vl"]
+    assert resolved is MiniMaxM3VLConfig, (
+        f"AutoConfig resolves minimax_m3_vl to {resolved.__module__}.{resolved.__name__}; "
+        "expected the nemo_automodel config class. The custom model's vision encoder "
+        "requires our config fields (e.g. rope_theta)."
+    )
+    # The concrete field the crash was about: our vision sub-config must default it.
+    assert MiniMaxM3VLConfig().vision_config.rope_theta is not None


### PR DESCRIPTION
## What

Adds `_CUSTOM_CONFIG_OVERRIDES_BUILTIN` to `_transformers/registry.py`: model_types listed there register our config class with `exist_ok=True`, taking precedence over a transformers built-in config of the same model_type. Only `minimax_m3_vl` is listed.

## Why

transformers 5.12 (repo bump `14d17731`, 2026-07-08, #2873) added a **native** `minimax_m3_vl` model type — same model_type string, same class names as our custom implementation. `_register_custom_configs` skips registration when the model_type is already in `CONFIG_MAPPING`, so `AutoConfig.from_pretrained('MiniMaxAI/MiniMax-M3')` silently started returning the **native** config while `MODEL_ARCH_MAPPING` still routes the architecture to **our** custom `MiniMaxM3SparseForConditionalGeneration`. The native vision config carries no `rope_theta` (and its text config defaults `num_mtp_modules=7`), so model init dies with:

```
AttributeError: 'MiniMaxM3VLVisionConfig' object has no attribute 'rope_theta'
```

The class name in the error is transformers', not ours — which made this look like a config-content problem rather than a registration handoff.

**Timeline / why nobody caught it:** `minimax_m3_vl_sft_cp2_medpix_2k` was green when merged on transformers 5.8.1 (#2551, 2026-06-26; `minimax_m3_vl` not yet built-in). It broke at the 5.12.1 bump, but the recipe only exists at release scope on 16 nodes — nightly never runs it, unit tests don't exercise the AutoConfig+hub path, and no release-scope run touched it between the bump and the CP-parity sweep for #2937 (before jobs 367241563 / after 367239236, identical failure on both merge-base and PR branch — pre-existing on main).

**Scope note:** `mistral4` also collides with a transformers built-in, but its custom model was written against the native config and runs green in nightly — its behavior is intentionally left unchanged. Other `_CUSTOM_CONFIG_REGISTRATIONS` entries (kimi_k25, step3p7, …) will hit this same failure mode whenever transformers ships their model_type; the new set is the place to handle them when it happens.

## Testing

- CPU repro (no GPU needed): `AutoConfig.from_pretrained('MiniMaxAI/MiniMax-M3')` on transformers 5.8.1 vs 5.12.1 — native config loses `rope_theta`; with this fix, 5.12.1 resolves to our config class with `rope_theta=10000.0`.
- New regression test pins `CONFIG_MAPPING['minimax_m3_vl']` to our class; existing registry suite passes.
- nemo-ci validation (16-node recipe on the pytorch 26.04 base): link to follow in comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)