### PR TITLE
fix: prevent damaged token embeddings from dominating grad clipping

### DIFF
--- a/docs/guides/configuration.mdx
+++ b/docs/guides/configuration.mdx
@@ -86,6 +86,20 @@ Adding GPUs helps only when it sufficiently reduces the relevant per-rank tensor
 
 </Info>
 
+## Repair Near-Zero Input Embeddings
+
+The LLM training/fine-tuning recipe can repair a small number of damaged input-embedding rows after loading the base checkpoint and before creating the optimizer:
+
+```yaml
+embedding_row_repair:
+  min_norm: 1.0e-4
+  max_rows: 256
+```
+
+Rows with a non-finite L2 norm or a norm at or below `min_norm` are replaced with the corresponding output-embedding direction, scaled to the RMS norm of healthy input rows. Setup logs the affected token IDs. `max_rows` is a safety limit: setup aborts instead of rewriting a broadly damaged or mismatched checkpoint.
+
+This option is intended for diagnosed checkpoint defects where rare token IDs produce extreme input-embedding gradients. It is disabled when the section is absent and is not currently supported with pipeline parallelism.
+
 ## Interpolate Environment Variables in YAML
 
 NeMo AutoModel supports env var interpolation inside YAML **string values**.

--- a/examples/llm_finetune/nemotron/nemotron_nano_4b_squad.yaml
+++ b/examples/llm_finetune/nemotron/nemotron_nano_4b_squad.yaml
@@ -41,6 +41,12 @@ model:
   trust_remote_code: true
   force_hf: true
 
+# Repair checkpoint input rows whose near-zero norm can produce extreme gradients
+# when those token IDs first occur during continued pretraining.
+embedding_row_repair:
+  min_norm: 1.0e-4
+  max_rows: 256
+
 compile:
   enabled: false
   mode: "default" # Options: "default", "reduce-overhead", "max-autotune"

--- a/nemo_automodel/components/training/embedding_row_repair.py
+++ b/nemo_automodel/components/training/embedding_row_repair.py
@@ -79,6 +79,17 @@ class EmbeddingRowRepairConfig:
 
 @dataclass(frozen=True)
 class _WeightView:
+    """Local tensor view and DTensor metadata for an embedding matrix.
+
+    Attributes:
+        local: Tensor of shape [local_vocab, local_hidden].
+        global_shape: Global embedding matrix shape [vocab, hidden].
+        local_shape: Rank-local embedding matrix shape [local_vocab, local_hidden].
+        global_offset: Global [vocab, hidden] offset of the rank-local shard.
+        mesh: DTensor device mesh when the weight is distributed.
+        placements: DTensor placements for the [vocab, hidden] axes.
+    """
+
     local: torch.Tensor
     global_shape: tuple[int, ...]
     local_shape: tuple[int, ...]
@@ -88,6 +99,17 @@ class _WeightView:
 
 
 def _weight_view(weight: torch.Tensor, name: str) -> _WeightView:
+    """Create a local view for a regular tensor or DTensor embedding matrix.
+
+    Args:
+        weight: Embedding matrix of shape [vocab, hidden]. For DTensor inputs, the global shape is
+            [vocab, hidden] and each placement must replicate or shard axis 0 (vocab) or axis 1 (hidden).
+        name: Parameter name used in validation errors.
+
+    Returns:
+        View whose ``local`` tensor has shape [local_vocab, local_hidden] and whose shape and offset metadata
+        use the global [vocab, hidden] axis order.
+    """
     if weight.ndim != 2:
         raise ValueError(f"{name} must be a 2-D embedding matrix, got shape={tuple(weight.shape)}")
     if not weight.is_floating_point():
@@ -131,6 +153,16 @@ def _weight_view(weight: torch.Tensor, name: str) -> _WeightView:
 
 
 def _full_row_squared_norms(view: _WeightView) -> torch.Tensor:
+    """Compute complete row squared norms for the local vocabulary shard.
+
+    Args:
+        view: Embedding matrix view with global shape [vocab, hidden] and local tensor shape
+            [local_vocab, local_hidden].
+
+    Returns:
+        Tensor of shape [local_vocab] containing each local vocabulary row's squared L2 norm over the full
+        hidden axis. When the hidden axis is sharded, values are summed across that DTensor shard group.
+    """
     local = view.local.detach().to(torch.float32)
     row_squared_norms = local.square().sum(dim=1, dtype=torch.float64)
     if view.mesh is None:
@@ -146,11 +178,22 @@ def _full_row_squared_norms(view: _WeightView) -> torch.Tensor:
 
 
 def _global_ids(view: _WeightView, local_mask: torch.Tensor) -> list[int]:
+    """Map local vocabulary-row selections to global token IDs.
+
+    Args:
+        view: Embedding matrix view with global shape [vocab, hidden] and local tensor shape
+            [local_vocab, local_hidden].
+        local_mask: Boolean tensor of shape [local_vocab] selecting rows from ``view.local``.
+
+    Returns:
+        Global vocabulary row IDs selected by ``local_mask``.
+    """
     local_ids = torch.nonzero(local_mask, as_tuple=False).flatten().cpu().tolist()
     return [view.global_offset[0] + int(local_id) for local_id in local_ids]
 
 
 def _gather_unique_ids(local_ids: list[int]) -> tuple[int, ...]:
+    """Gather sorted global vocabulary row IDs across all ranks."""
     if not dist.is_initialized():
         return tuple(sorted(set(local_ids)))
 
@@ -160,6 +203,14 @@ def _gather_unique_ids(local_ids: list[int]) -> tuple[int, ...]:
 
 
 def _global_min(value: torch.Tensor) -> float:
+    """Compute the global minimum of a scalar tensor.
+
+    Args:
+        value: Scalar tensor of shape [] containing this rank's local minimum.
+
+    Returns:
+        Minimum scalar value across all distributed ranks.
+    """
     value = value.detach().to(dtype=torch.float64).clone()
     if dist.is_initialized():
         dist.all_reduce(value, op=dist.ReduceOp.MIN)
@@ -167,6 +218,16 @@ def _global_min(value: torch.Tensor) -> float:
 
 
 def _healthy_rms_norm(row_squared_norms: torch.Tensor, healthy_mask: torch.Tensor) -> float:
+    """Compute the RMS norm of healthy input-embedding rows.
+
+    Args:
+        row_squared_norms: Tensor of shape [local_vocab] containing each local vocabulary row's squared L2
+            norm over the full hidden axis.
+        healthy_mask: Boolean tensor of shape [local_vocab] selecting healthy rows from ``row_squared_norms``.
+
+    Returns:
+        RMS L2 norm over all healthy global vocabulary rows.
+    """
     stats = torch.stack(
         (
             row_squared_norms[healthy_mask].sum(dtype=torch.float64),
@@ -181,6 +242,14 @@ def _healthy_rms_norm(row_squared_norms: torch.Tensor, healthy_mask: torch.Tenso
 
 
 def _check_matching_layout(input_view: _WeightView, output_view: _WeightView) -> None:
+    """Validate that input and output embedding shards can be repaired rowwise.
+
+    Args:
+        input_view: Input embedding matrix view with global shape [vocab, hidden] and local tensor shape
+            [local_vocab, local_hidden].
+        output_view: Output embedding matrix view with global shape [vocab, hidden] and local tensor shape
+            [local_vocab, local_hidden].
+    """
     if input_view.global_shape != output_view.global_shape:
         raise ValueError(
             "Input and output embedding shapes must match for row repair, got "
@@ -204,7 +273,8 @@ def repair_input_embedding_rows(
     """Detect and repair near-zero input-embedding rows.
 
     Args:
-        model: Loaded and optionally DTensor-sharded causal language model.
+        model: Loaded and optionally DTensor-sharded causal language model whose input and output embedding
+            weights have shape [vocab, hidden].
         min_norm: Inclusive L2-norm threshold identifying a damaged row.
         max_rows: Safety bound; abort instead of mutating a broadly damaged checkpoint.
 

--- a/nemo_automodel/components/training/embedding_row_repair.py
+++ b/nemo_automodel/components/training/embedding_row_repair.py
@@ -1,0 +1,296 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Repair near-zero input-embedding rows before optimizer construction."""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.distributed.tensor import DTensor, Partial, Replicate, Shard
+from torch.distributed.tensor._utils import compute_local_shape_and_global_offset
+
+from nemo_automodel.shared.tied_weights import (
+    get_input_embeddings_weight_and_name,
+    get_lm_head_weight_and_name,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class EmbeddingRowRepairReport:
+    """Summary of a completed input-embedding repair."""
+
+    input_embedding_name: str
+    output_embedding_name: str | None
+    repaired_row_ids: tuple[int, ...]
+    min_norm_before: float
+    target_norm: float | None
+
+
+@dataclass
+class EmbeddingRowRepairConfig:
+    """Configuration for detecting and repairing damaged input embeddings.
+
+    A row is repaired when its L2 norm is non-finite or no larger than
+    ``min_norm``. Its replacement uses the corresponding output-embedding
+    direction, scaled to the RMS norm of the checkpoint's healthy input rows.
+    This preserves a token-specific direction while restoring the magnitude
+    expected by the pretrained model.
+
+    The operation runs once after base-checkpoint loading and model sharding,
+    before optimizer construction. It supports regular tensors and DTensors
+    whose two matrix dimensions are sharded or replicated.
+    """
+
+    enabled: bool = True
+    min_norm: float = 1.0e-6
+    max_rows: int = 256
+
+    def __post_init__(self) -> None:
+        if not math.isfinite(self.min_norm) or self.min_norm < 0:
+            raise ValueError(f"embedding_row_repair.min_norm must be finite and non-negative, got {self.min_norm}")
+        if self.max_rows <= 0:
+            raise ValueError(f"embedding_row_repair.max_rows must be positive, got {self.max_rows}")
+
+    def apply(self, model: nn.Module) -> EmbeddingRowRepairReport | None:
+        """Repair damaged input-embedding rows in ``model`` when enabled."""
+        if not self.enabled:
+            return None
+        return repair_input_embedding_rows(model, min_norm=self.min_norm, max_rows=self.max_rows)
+
+
+@dataclass(frozen=True)
+class _WeightView:
+    local: torch.Tensor
+    global_shape: tuple[int, ...]
+    local_shape: tuple[int, ...]
+    global_offset: tuple[int, ...]
+    mesh: object | None
+    placements: tuple[object, ...]
+
+
+def _weight_view(weight: torch.Tensor, name: str) -> _WeightView:
+    if weight.ndim != 2:
+        raise ValueError(f"{name} must be a 2-D embedding matrix, got shape={tuple(weight.shape)}")
+    if not weight.is_floating_point():
+        raise ValueError(f"{name} must have a floating-point dtype, got {weight.dtype}")
+
+    if not isinstance(weight, DTensor):
+        shape = tuple(weight.shape)
+        return _WeightView(
+            local=weight,
+            global_shape=shape,
+            local_shape=shape,
+            global_offset=(0, 0),
+            mesh=None,
+            placements=(),
+        )
+
+    placements = tuple(weight.placements)
+    for placement in placements:
+        if isinstance(placement, Partial):
+            raise ValueError(f"{name} has unsupported Partial placement: {placements}")
+        if isinstance(placement, Shard) and placement.dim not in (0, 1, -1, -2):
+            raise ValueError(f"{name} has unsupported placement for a matrix: {placement}")
+        if not isinstance(placement, (Replicate, Shard)):
+            raise ValueError(f"{name} has unsupported DTensor placement: {placement}")
+
+    global_shape = tuple(weight.shape)
+    local_shape, global_offset = compute_local_shape_and_global_offset(global_shape, weight.device_mesh, placements)
+    local = weight.to_local()
+    if tuple(local.shape) != tuple(local_shape):
+        raise RuntimeError(
+            f"{name} local shape mismatch: DTensor metadata says {local_shape}, tensor has {tuple(local.shape)}"
+        )
+    return _WeightView(
+        local=local,
+        global_shape=global_shape,
+        local_shape=tuple(local_shape),
+        global_offset=tuple(global_offset),
+        mesh=weight.device_mesh,
+        placements=placements,
+    )
+
+
+def _full_row_squared_norms(view: _WeightView) -> torch.Tensor:
+    local = view.local.detach().to(torch.float32)
+    row_squared_norms = local.square().sum(dim=1, dtype=torch.float64)
+    if view.mesh is None:
+        return row_squared_norms
+
+    for mesh_dim, placement in enumerate(view.placements):
+        if not isinstance(placement, Shard):
+            continue
+        shard_dim = placement.dim % len(view.global_shape)
+        if shard_dim == 1:
+            dist.all_reduce(row_squared_norms, op=dist.ReduceOp.SUM, group=view.mesh.get_group(mesh_dim=mesh_dim))
+    return row_squared_norms
+
+
+def _global_ids(view: _WeightView, local_mask: torch.Tensor) -> list[int]:
+    local_ids = torch.nonzero(local_mask, as_tuple=False).flatten().cpu().tolist()
+    return [view.global_offset[0] + int(local_id) for local_id in local_ids]
+
+
+def _gather_unique_ids(local_ids: list[int]) -> tuple[int, ...]:
+    if not dist.is_initialized():
+        return tuple(sorted(set(local_ids)))
+
+    gathered: list[list[int] | None] = [None] * dist.get_world_size()
+    dist.all_gather_object(gathered, local_ids)
+    return tuple(sorted({row_id for rank_ids in gathered if rank_ids is not None for row_id in rank_ids}))
+
+
+def _global_min(value: torch.Tensor) -> float:
+    value = value.detach().to(dtype=torch.float64).clone()
+    if dist.is_initialized():
+        dist.all_reduce(value, op=dist.ReduceOp.MIN)
+    return float(value.item())
+
+
+def _healthy_rms_norm(row_squared_norms: torch.Tensor, healthy_mask: torch.Tensor) -> float:
+    stats = torch.stack(
+        (
+            row_squared_norms[healthy_mask].sum(dtype=torch.float64),
+            healthy_mask.sum().to(dtype=torch.float64),
+        )
+    )
+    if dist.is_initialized():
+        dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    if stats[1] == 0:
+        raise ValueError("Cannot repair input embeddings because the checkpoint has no healthy input rows")
+    return math.sqrt(float((stats[0] / stats[1]).item()))
+
+
+def _check_matching_layout(input_view: _WeightView, output_view: _WeightView) -> None:
+    if input_view.global_shape != output_view.global_shape:
+        raise ValueError(
+            "Input and output embedding shapes must match for row repair, got "
+            f"{input_view.global_shape} and {output_view.global_shape}"
+        )
+    if input_view.local_shape != output_view.local_shape or input_view.global_offset != output_view.global_offset:
+        raise ValueError(
+            "Input and output embeddings must have matching local shards for row repair, got "
+            f"input shape/offset={input_view.local_shape}/{input_view.global_offset} and "
+            f"output shape/offset={output_view.local_shape}/{output_view.global_offset}"
+        )
+
+
+@torch.no_grad()
+def repair_input_embedding_rows(
+    model: nn.Module,
+    *,
+    min_norm: float = 1.0e-6,
+    max_rows: int = 256,
+) -> EmbeddingRowRepairReport:
+    """Detect and repair near-zero input-embedding rows.
+
+    Args:
+        model: Loaded and optionally DTensor-sharded causal language model.
+        min_norm: Inclusive L2-norm threshold identifying a damaged row.
+        max_rows: Safety bound; abort instead of mutating a broadly damaged checkpoint.
+
+    Returns:
+        A report containing every repaired global vocabulary row ID.
+    """
+    model = getattr(model, "module", model)
+    input_weight, input_name = get_input_embeddings_weight_and_name(model)
+    if input_weight is None or input_name is None:
+        raise ValueError("Could not locate the model's input embedding weight")
+
+    input_view = _weight_view(input_weight, input_name)
+    input_squared_norms = _full_row_squared_norms(input_view)
+    input_norms = input_squared_norms.sqrt()
+    damaged_local = ~torch.isfinite(input_norms) | (input_norms <= min_norm)
+    damaged_ids = _gather_unique_ids(_global_ids(input_view, damaged_local))
+    min_norm_before = _global_min(input_norms.min())
+
+    if not damaged_ids:
+        logger.info(
+            "Input embedding %s has no rows at or below norm %.3e (minimum %.3e).",
+            input_name,
+            min_norm,
+            min_norm_before,
+        )
+        return EmbeddingRowRepairReport(
+            input_embedding_name=input_name,
+            output_embedding_name=None,
+            repaired_row_ids=(),
+            min_norm_before=min_norm_before,
+            target_norm=None,
+        )
+    if len(damaged_ids) > max_rows:
+        raise ValueError(
+            f"Refusing to repair {len(damaged_ids)} input embedding rows; configured max_rows={max_rows}. "
+            "This likely indicates a mismatched or corrupted checkpoint."
+        )
+
+    output_weight, output_name = get_lm_head_weight_and_name(model)
+    if output_weight is None or output_name is None:
+        raise ValueError("Could not locate a separate output embedding weight to repair damaged input rows")
+    output_view = _weight_view(output_weight, output_name)
+    _check_matching_layout(input_view, output_view)
+
+    output_norms = _full_row_squared_norms(output_view).sqrt()
+    unusable_source_local = damaged_local & (~torch.isfinite(output_norms) | (output_norms <= min_norm))
+    unusable_source_ids = _gather_unique_ids(_global_ids(output_view, unusable_source_local))
+    if unusable_source_ids:
+        raise ValueError(
+            "Cannot repair input embedding rows because the corresponding output rows are also damaged: "
+            f"{list(unusable_source_ids)}"
+        )
+
+    healthy_local = torch.isfinite(input_norms) & (input_norms > min_norm)
+    target_norm = _healthy_rms_norm(input_squared_norms, healthy_local)
+    if not math.isfinite(target_norm) or target_norm <= min_norm:
+        raise ValueError(f"Computed invalid healthy input embedding RMS norm: {target_norm}")
+
+    replacement_scale = target_norm / output_norms[damaged_local]
+    replacement = output_view.local.detach()[damaged_local].to(torch.float32)
+    replacement.mul_(replacement_scale.to(torch.float32).unsqueeze(1))
+    damaged_local_ids = torch.nonzero(damaged_local, as_tuple=False).flatten()
+    input_view.local.index_copy_(0, damaged_local_ids, replacement.to(input_view.local.dtype))
+
+    repaired_norms = _full_row_squared_norms(input_view).sqrt()
+    failed_local = damaged_local & (~torch.isfinite(repaired_norms) | (repaired_norms <= min_norm))
+    failed_ids = _gather_unique_ids(_global_ids(input_view, failed_local))
+    if failed_ids:
+        raise RuntimeError(f"Input embedding row repair did not produce healthy rows: {list(failed_ids)}")
+
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    if rank == 0:
+        logger.warning(
+            "Repaired %d input embedding row(s) in %s from %s: ids=%s, minimum_before=%.3e, target_norm=%.3e",
+            len(damaged_ids),
+            input_name,
+            output_name,
+            list(damaged_ids),
+            min_norm_before,
+            target_norm,
+        )
+
+    return EmbeddingRowRepairReport(
+        input_embedding_name=input_name,
+        output_embedding_name=output_name,
+        repaired_row_ids=damaged_ids,
+        min_norm_before=min_norm_before,
+        target_norm=target_norm,
+    )

--- a/nemo_automodel/components/training/utils.py
+++ b/nemo_automodel/components/training/utils.py
@@ -147,6 +147,8 @@ def _clip_grad_norm_impl(
             g = p.grad
             if isinstance(g, DTensor):
                 g = g.full_tensor() if has_partial else g.to_local()
+            if g.numel() == 0:
+                continue
             g_abs_max = g.detach().abs().max().to(device=target_device, dtype=torch.float64)
             local_max = torch.maximum(local_max, g_abs_max)
 
@@ -168,6 +170,8 @@ def _clip_grad_norm_impl(
             g = p.grad
             if isinstance(g, DTensor):
                 g = g.full_tensor() if has_partial else g.to_local()
+            if g.numel() == 0:
+                continue
             g = g.detach().abs().div(local_max)
             if norm_type == 2.0:
                 local_val = local_val + g.square().sum(dtype=torch.float64)

--- a/nemo_automodel/components/training/utils.py
+++ b/nemo_automodel/components/training/utils.py
@@ -32,6 +32,21 @@ from nemo_automodel.components.models.common.utils import set_is_first_microbatc
 _TE_EXPERT_PARAM_PATTERN = re.compile(r"(^|\.)mlp\.experts\.(gate_up_linear|down_linear)\.(weight|bias)\d+")
 
 
+def _combine_norms(norms: list[torch.Tensor], norm_type: float, target_device: torch.device) -> torch.Tensor:
+    if len(norms) == 0:
+        return torch.tensor(0.0, dtype=torch.float64, device=target_device)
+
+    norm_stack = torch.stack([n.to(device=target_device, dtype=torch.float64) for n in norms])
+    if math.isinf(norm_type):
+        return norm_stack.max()
+
+    max_norm = norm_stack.abs().max()
+    if max_norm == 0 or not torch.isfinite(max_norm):
+        return max_norm
+
+    return max_norm * norm_stack.div(max_norm).pow(norm_type).sum().pow(1.0 / norm_type)
+
+
 @torch.no_grad()
 def count_tail_padding(labels, ignore_label=-100):
     """Counts the total number of padding token in the tail of labels
@@ -70,13 +85,6 @@ def _clip_grad_norm_impl(
     foreach: bool | None = None,
     pp_mesh: DeviceMesh | None = None,
 ) -> torch.Tensor:
-    # Determine target device for all tensor operations
-    # Use current CUDA device if available, otherwise use CPU
-    if torch.cuda.is_available():
-        target_device = torch.device(f"cuda:{torch.cuda.current_device()}")
-    else:
-        target_device = torch.device("cpu")
-
     if isinstance(parameters, torch.Tensor):
         parameters = [parameters]
     else:
@@ -103,6 +111,21 @@ def _clip_grad_norm_impl(
             sharding_groups[key] = []
         sharding_groups[key].append(p)
 
+    target_device = None
+    for group_params in sharding_groups.values():
+        for p in group_params:
+            g = p.grad
+            if g is None:
+                continue
+            if isinstance(g, DTensor):
+                g = g.to_local()
+            target_device = g.device
+            break
+        if target_device is not None:
+            break
+    if target_device is None:
+        target_device = torch.device("cpu")
+
     # Compute norm for each sharding group using a scalar-first reduction:
     # sum(|g_local|^p) locally → single-scalar allreduce per Shard mesh dim.
     # Going through torch.nn.utils.get_total_norm on DTensor grads would stack
@@ -119,49 +142,71 @@ def _clip_grad_norm_impl(
         # those per-grad (each full_tensor() is a same-shape collective, safe).
         has_partial = is_dtensor and any(isinstance(pl, Partial) for pl in first.placements)
 
-        local_val = torch.zeros((), dtype=torch.float32, device=target_device)
+        local_max = torch.zeros((), dtype=torch.float64, device=target_device)
         for p in group_params:
             g = p.grad
             if isinstance(g, DTensor):
                 g = g.full_tensor() if has_partial else g.to_local()
-            g = g.detach().float()
-            if is_inf:
-                local_val = torch.maximum(local_val, g.abs().max())
-            else:
-                local_val = local_val + g.abs().pow(norm_type).sum()
+            g_abs_max = g.detach().abs().max().to(device=target_device, dtype=torch.float64)
+            local_max = torch.maximum(local_max, g_abs_max)
 
         if is_dtensor and not has_partial:
             mesh = first.device_mesh
-            op = torch.distributed.ReduceOp.MAX if is_inf else torch.distributed.ReduceOp.SUM
             for dim_idx, pl in enumerate(first.placements):
                 if isinstance(pl, Replicate):
                     continue
-                torch.distributed.all_reduce(local_val, op=op, group=mesh.get_group(mesh_dim=dim_idx))
+                torch.distributed.all_reduce(
+                    local_max, op=torch.distributed.ReduceOp.MAX, group=mesh.get_group(mesh_dim=dim_idx)
+                )
 
-        group_norms.append(local_val if is_inf else local_val.pow(1.0 / norm_type))
+        if is_inf or local_max == 0 or not torch.isfinite(local_max):
+            group_norms.append(local_max)
+            continue
+
+        local_val = torch.zeros((), dtype=torch.float64, device=target_device)
+        for p in group_params:
+            g = p.grad
+            if isinstance(g, DTensor):
+                g = g.full_tensor() if has_partial else g.to_local()
+            g = g.detach().abs().div(local_max)
+            if norm_type == 2.0:
+                local_val = local_val + g.square().sum(dtype=torch.float64)
+            else:
+                local_val = local_val + g.pow(norm_type).sum(dtype=torch.float64)
+
+        if is_dtensor and not has_partial:
+            mesh = first.device_mesh
+            for dim_idx, pl in enumerate(first.placements):
+                if isinstance(pl, Replicate):
+                    continue
+                torch.distributed.all_reduce(
+                    local_val, op=torch.distributed.ReduceOp.SUM, group=mesh.get_group(mesh_dim=dim_idx)
+                )
+
+        group_norms.append(local_max * local_val.pow(1.0 / norm_type))
 
     # Combine norms across groups (all rank-identical scalars, no comm)
-    if len(group_norms) == 0:
-        total_norm = torch.tensor(0.0, device=target_device)
-    elif len(group_norms) == 1:
-        total_norm = group_norms[0]
-    elif is_inf:
-        total_norm = torch.stack(group_norms).max()
-    else:
-        total_norm = torch.zeros((), dtype=torch.float32, device=target_device)
-        for gn in group_norms:
-            total_norm = total_norm + gn.pow(norm_type)
-        total_norm = total_norm.pow(1.0 / norm_type)
+    total_norm = _combine_norms(group_norms, norm_type, target_device)
 
-    total_norm = total_norm.float().to(target_device)
     # Reduce across pipeline parallel mesh if provided
     if pp_mesh is not None:
         if math.isinf(norm_type):
             torch.distributed.all_reduce(total_norm, op=torch.distributed.ReduceOp.MAX, group=pp_mesh.get_group())
         else:
-            total_norm = total_norm**norm_type
-            torch.distributed.all_reduce(total_norm, op=torch.distributed.ReduceOp.SUM, group=pp_mesh.get_group())
-            total_norm = total_norm ** (1.0 / norm_type)
+            pp_max_norm = total_norm.abs().clone()
+            torch.distributed.all_reduce(pp_max_norm, op=torch.distributed.ReduceOp.MAX, group=pp_mesh.get_group())
+            if pp_max_norm == 0 or not torch.isfinite(pp_max_norm):
+                total_norm = pp_max_norm
+            else:
+                total_norm = total_norm.div(pp_max_norm).pow(norm_type)
+                torch.distributed.all_reduce(total_norm, op=torch.distributed.ReduceOp.SUM, group=pp_mesh.get_group())
+                total_norm = pp_max_norm * total_norm.pow(1.0 / norm_type)
+
+    if error_if_nonfinite and torch.logical_or(total_norm.isnan(), total_norm.isinf()):
+        raise RuntimeError(
+            f"The total norm of order {norm_type} for gradients from `parameters` is non-finite, "
+            "so it cannot be clipped."
+        )
 
     # Clip gradients for each sharding group separately
     # This is necessary because clip_grads_with_norm_ doesn't support mixing tensors from different device meshes

--- a/nemo_automodel/recipes/_typed_config.py
+++ b/nemo_automodel/recipes/_typed_config.py
@@ -19,9 +19,10 @@ The YAML→typed coercion happens **here**, at the recipe input boundary
 recipe body only ever sees typed component configs and calls
 ``self.cfg.<section>.build(...)`` directly.
 
-Known sections are exposed as cached, typed attributes that own a ``build()``:
-``wandb``/``mlflow``/``step_scheduler``/``lr_scheduler``/``prewarm`` map to
-component config dataclasses; the ``optimizer`` and ``loss_fn`` blocks resolve to a component
+Known sections are exposed as cached, typed attributes that own a ``build()`` or
+``apply()``: ``wandb``/``mlflow``/``step_scheduler``/``lr_scheduler``/``prewarm``/
+``embedding_row_repair`` map to component config dataclasses; the ``optimizer``
+and ``loss_fn`` blocks resolve to a component
 :class:`~nemo_automodel.components.optim.optimizer.OptimizerConfig` /
 :class:`~nemo_automodel.components.loss.loss.LossConfig` via
 ``build_optimizer_config`` / ``build_loss_config`` (which own a ``build()``),
@@ -59,6 +60,7 @@ if TYPE_CHECKING:
     from nemo_automodel.components.loss.loss import LossConfig
     from nemo_automodel.components.loss.mtp import MTPLossConfig
     from nemo_automodel.components.optim.optimizer import OptimizerConfig
+    from nemo_automodel.components.training.embedding_row_repair import EmbeddingRowRepairConfig
     from nemo_automodel.components.training.prewarm import PrewarmConfig
 
 # Keys present in the YAML ``step_scheduler:`` block that are runtime args passed
@@ -605,6 +607,13 @@ class RecipeConfig:
 
         node = self._raw.get("prewarm", None)
         return PrewarmConfig(**_section_kwargs(node)) if node else None
+
+    @cached_property
+    def embedding_row_repair(self) -> "EmbeddingRowRepairConfig | None":
+        from nemo_automodel.components.training.embedding_row_repair import EmbeddingRowRepairConfig
+
+        node = self._raw.get("embedding_row_repair", None)
+        return EmbeddingRowRepairConfig(**_section_kwargs(node)) if node else None
 
     @cached_property
     def checkpoint(self) -> "CheckpointingConfig":

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -609,6 +609,12 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
             cfg_qat=self.cfg.get("qat", None),
             sdpa_method=self.cfg.get("sdpa_method", None),
         )
+        self.embedding_row_repair_report = None
+        embedding_row_repair = self.cfg.embedding_row_repair
+        if embedding_row_repair is not None and embedding_row_repair.enabled:
+            if isinstance(model, AutoPipeline):
+                raise ValueError("embedding_row_repair is not currently supported with pipeline parallelism")
+            self.embedding_row_repair_report = embedding_row_repair.apply(model)
         optimizer = self.cfg.optimizer.build(model, device_mesh=self.device_mesh, is_peft=self.peft_config is not None)
         allow_megatron_fsdp_sharding = getattr(self.cfg.optimizer, "supports_megatron_fsdp_sharding", True)
         self.optimizer = shard_optimizers_for_megatron_fsdp(

--- a/tests/unit_tests/components/training/test_embedding_row_repair.py
+++ b/tests/unit_tests/components/training/test_embedding_row_repair.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+from datetime import timedelta
 
 import pytest
 import torch
@@ -27,20 +28,19 @@ from nemo_automodel.recipes._typed_config import RecipeConfig
 
 
 class _TinyLM(torch.nn.Module):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.embed_tokens = torch.nn.Embedding(6, 4)
         self.lm_head = torch.nn.Linear(4, 6, bias=False)
 
-    def get_input_embeddings(self):
+    def get_input_embeddings(self) -> torch.nn.Embedding:
         return self.embed_tokens
 
-    def get_output_embeddings(self):
+    def get_output_embeddings(self) -> torch.nn.Linear:
         return self.lm_head
 
 
-@pytest.fixture
-def damaged_model():
+def _make_damaged_model() -> _TinyLM:
     model = _TinyLM()
     with torch.no_grad():
         model.embed_tokens.weight.copy_(
@@ -68,6 +68,11 @@ def damaged_model():
             )
         )
     return model
+
+
+@pytest.fixture
+def damaged_model():
+    return _make_damaged_model()
 
 
 def test_repair_identifies_rows_and_restores_healthy_scale(damaged_model, caplog):
@@ -169,6 +174,63 @@ def test_repair_supports_single_rank_sharded_dtensors(damaged_model, single_rank
     assert report.repaired_row_ids == (1, 3)
     repaired_norms = torch.linalg.vector_norm(damaged_model.embed_tokens.weight.full_tensor()[[1, 3]], dim=1)
     assert torch.all(repaired_norms > 1.0e-4)
+
+
+def _run_two_rank_sharded_dtensor_repair(rank: int, world_size: int, init_file: str, shard_dim: int) -> None:
+    """Exercise embedding repair with real two-rank DTensor collectives."""
+    from torch.distributed.device_mesh import init_device_mesh
+    from torch.distributed.tensor import Shard, distribute_tensor
+
+    dist.init_process_group(
+        backend="gloo",
+        init_method=f"file://{init_file}",
+        rank=rank,
+        world_size=world_size,
+        timeout=timedelta(seconds=30),
+    )
+    try:
+        mesh = init_device_mesh("cpu", (world_size,))
+        model = _make_damaged_model()
+        before = model.embed_tokens.weight.detach().clone()
+        source = model.lm_head.weight.detach().clone()
+        expected_target = torch.tensor([1.0, 2.0, 3.0, 4.0]).square().mean().sqrt()
+
+        model.embed_tokens.weight = torch.nn.Parameter(
+            distribute_tensor(model.embed_tokens.weight.detach(), mesh, [Shard(shard_dim)])
+        )
+        model.lm_head.weight = torch.nn.Parameter(
+            distribute_tensor(model.lm_head.weight.detach(), mesh, [Shard(shard_dim)])
+        )
+
+        report = repair_input_embedding_rows(model, min_norm=1.0e-4)
+
+        assert report.repaired_row_ids == (1, 3)
+        assert report.min_norm_before == 0.0
+        assert report.target_norm == pytest.approx(expected_target.item())
+
+        repaired_full = model.embed_tokens.weight.full_tensor()
+        torch.testing.assert_close(repaired_full[[0, 2, 4, 5]], before[[0, 2, 4, 5]])
+        repaired_rows = repaired_full[[1, 3]]
+        repaired_norms = torch.linalg.vector_norm(repaired_rows, dim=1)
+        torch.testing.assert_close(repaired_norms, expected_target.expand_as(repaired_norms))
+        torch.testing.assert_close(
+            torch.nn.functional.normalize(repaired_rows, dim=1),
+            torch.nn.functional.normalize(source[[1, 3]], dim=1),
+        )
+        dist.barrier()
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.parametrize("shard_dim", [0, 1])
+def test_repair_supports_two_rank_sharded_dtensors(tmp_path, shard_dim):
+    """Two-rank CPU DTensor repair matches the unsharded row IDs and target norm."""
+    torch.multiprocessing.spawn(
+        _run_two_rank_sharded_dtensor_repair,
+        args=(2, str(tmp_path / f"repair_pg_shard_{shard_dim}"), shard_dim),
+        nprocs=2,
+        join=True,
+    )
 
 
 @pytest.fixture

--- a/tests/unit_tests/components/training/test_embedding_row_repair.py
+++ b/tests/unit_tests/components/training/test_embedding_row_repair.py
@@ -1,0 +1,182 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import pytest
+import torch
+import torch.distributed as dist
+
+from nemo_automodel.components.config.loader import ConfigNode
+from nemo_automodel.components.training.embedding_row_repair import (
+    EmbeddingRowRepairConfig,
+    repair_input_embedding_rows,
+)
+from nemo_automodel.recipes._typed_config import RecipeConfig
+
+
+class _TinyLM(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.embed_tokens = torch.nn.Embedding(6, 4)
+        self.lm_head = torch.nn.Linear(4, 6, bias=False)
+
+    def get_input_embeddings(self):
+        return self.embed_tokens
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+
+@pytest.fixture
+def damaged_model():
+    model = _TinyLM()
+    with torch.no_grad():
+        model.embed_tokens.weight.copy_(
+            torch.tensor(
+                [
+                    [1.0, 0.0, 0.0, 0.0],
+                    [0.0, 0.0, 0.0, 0.0],
+                    [0.0, 2.0, 0.0, 0.0],
+                    [1.0e-8, 0.0, 0.0, 0.0],
+                    [0.0, 0.0, 3.0, 0.0],
+                    [0.0, 0.0, 0.0, 4.0],
+                ]
+            )
+        )
+        model.lm_head.weight.copy_(
+            torch.tensor(
+                [
+                    [1.0, 1.0, 0.0, 0.0],
+                    [1.0, 2.0, 3.0, 4.0],
+                    [0.0, 1.0, 1.0, 0.0],
+                    [4.0, 3.0, 2.0, 1.0],
+                    [1.0, 0.0, 1.0, 0.0],
+                    [0.0, 1.0, 0.0, 1.0],
+                ]
+            )
+        )
+    return model
+
+
+def test_repair_identifies_rows_and_restores_healthy_scale(damaged_model, caplog):
+    before = damaged_model.embed_tokens.weight.detach().clone()
+    source = damaged_model.lm_head.weight.detach().clone()
+    expected_target = torch.tensor([1.0, 2.0, 3.0, 4.0]).square().mean().sqrt()
+
+    with caplog.at_level(logging.WARNING):
+        report = repair_input_embedding_rows(damaged_model, min_norm=1.0e-4)
+
+    assert report.repaired_row_ids == (1, 3)
+    assert report.min_norm_before == 0.0
+    assert report.target_norm == pytest.approx(expected_target.item())
+    torch.testing.assert_close(damaged_model.embed_tokens.weight[[0, 2, 4, 5]], before[[0, 2, 4, 5]])
+
+    repaired = damaged_model.embed_tokens.weight[[1, 3]]
+    repaired_norms = torch.linalg.vector_norm(repaired, dim=1)
+    torch.testing.assert_close(repaired_norms, expected_target.expand_as(repaired_norms))
+    torch.testing.assert_close(
+        torch.nn.functional.normalize(repaired, dim=1),
+        torch.nn.functional.normalize(source[[1, 3]], dim=1),
+    )
+    assert "ids=[1, 3]" in caplog.text
+
+
+def test_repair_is_noop_for_healthy_embeddings(damaged_model):
+    with torch.no_grad():
+        damaged_model.embed_tokens.weight[1].fill_(1.0)
+        damaged_model.embed_tokens.weight[3].fill_(1.0)
+    before = damaged_model.embed_tokens.weight.detach().clone()
+
+    report = repair_input_embedding_rows(damaged_model, min_norm=1.0e-4)
+
+    assert report.repaired_row_ids == ()
+    assert report.target_norm is None
+    torch.testing.assert_close(damaged_model.embed_tokens.weight, before)
+
+
+def test_repair_supports_bfloat16_weights(damaged_model):
+    damaged_model.to(torch.bfloat16)
+
+    report = repair_input_embedding_rows(damaged_model, min_norm=1.0e-4)
+
+    assert report.repaired_row_ids == (1, 3)
+    repaired_norms = torch.linalg.vector_norm(damaged_model.embed_tokens.weight[[1, 3]].float(), dim=1)
+    torch.testing.assert_close(
+        repaired_norms,
+        torch.full_like(repaired_norms, report.target_norm),
+        rtol=5.0e-3,
+        atol=5.0e-3,
+    )
+
+
+def test_repair_aborts_before_mutation_when_too_many_rows_are_damaged(damaged_model):
+    before = damaged_model.embed_tokens.weight.detach().clone()
+
+    with pytest.raises(ValueError, match="Refusing to repair 2 input embedding rows"):
+        repair_input_embedding_rows(damaged_model, min_norm=1.0e-4, max_rows=1)
+
+    torch.testing.assert_close(damaged_model.embed_tokens.weight, before)
+
+
+def test_repair_rejects_damaged_output_source(damaged_model):
+    before = damaged_model.embed_tokens.weight.detach().clone()
+    with torch.no_grad():
+        damaged_model.lm_head.weight[1].zero_()
+
+    with pytest.raises(ValueError, match=r"output rows are also damaged: \[1\]"):
+        repair_input_embedding_rows(damaged_model, min_norm=1.0e-4)
+
+    torch.testing.assert_close(damaged_model.embed_tokens.weight, before)
+
+
+def test_config_validation_and_recipe_typed_view():
+    with pytest.raises(ValueError, match="min_norm"):
+        EmbeddingRowRepairConfig(min_norm=-1.0)
+    with pytest.raises(ValueError, match="max_rows"):
+        EmbeddingRowRepairConfig(max_rows=0)
+
+    recipe = RecipeConfig(ConfigNode({"embedding_row_repair": {"min_norm": 1.0e-4, "max_rows": 8}}))
+    assert recipe.embedding_row_repair == EmbeddingRowRepairConfig(min_norm=1.0e-4, max_rows=8)
+    assert EmbeddingRowRepairConfig(enabled=False).apply(_TinyLM()) is None
+
+
+def test_repair_supports_single_rank_sharded_dtensors(damaged_model, single_rank_gloo):
+    from torch.distributed.device_mesh import init_device_mesh
+    from torch.distributed.tensor import Shard, distribute_tensor
+
+    mesh = init_device_mesh("cpu", (1,))
+    damaged_model.embed_tokens.weight = torch.nn.Parameter(
+        distribute_tensor(damaged_model.embed_tokens.weight.detach(), mesh, [Shard(0)])
+    )
+    damaged_model.lm_head.weight = torch.nn.Parameter(
+        distribute_tensor(damaged_model.lm_head.weight.detach(), mesh, [Shard(0)])
+    )
+
+    report = repair_input_embedding_rows(damaged_model, min_norm=1.0e-4)
+
+    assert report.repaired_row_ids == (1, 3)
+    repaired_norms = torch.linalg.vector_norm(damaged_model.embed_tokens.weight.full_tensor()[[1, 3]], dim=1)
+    assert torch.all(repaired_norms > 1.0e-4)
+
+
+@pytest.fixture
+def single_rank_gloo():
+    if dist.is_initialized():
+        pytest.skip("a process group is already initialized in this session")
+    dist.init_process_group(backend="gloo", rank=0, world_size=1, store=dist.HashStore())
+    try:
+        yield
+    finally:
+        dist.destroy_process_group()

--- a/tests/unit_tests/training/test_train_utils.py
+++ b/tests/unit_tests/training/test_train_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 from unittest.mock import Mock
 
 import pytest
@@ -213,6 +214,24 @@ def test_clip_grad_norm_actually_clips():
     # Verify the actual gradients are clipped
     clipped_norm = torch.sqrt(model.weight.grad.pow(2).sum() + model.bias.grad.pow(2).sum()).item()
     assert abs(clipped_norm - max_norm) < 1e-3
+
+
+def test_clip_grad_norm_large_finite_gradients_do_not_overflow():
+    """Finite rare-token embedding gradients can exceed fp32 squared-norm range."""
+    model = torch.nn.Linear(2, 1, bias=False)
+    model.weight.grad = torch.tensor([[6.0e31, 4.0]], dtype=model.weight.dtype)
+
+    max_norm = 0.3
+    grad_norm = clip_grad_norm(
+        max_grad_norm=max_norm,
+        model_parts=[model],
+        pp_enabled=False,
+    )
+
+    assert math.isfinite(grad_norm)
+    assert grad_norm > 1.0e31
+    assert torch.isfinite(model.weight.grad).all()
+    assert torch.linalg.vector_norm(model.weight.grad.double(), ord=2).item() <= max_norm + 1.0e-6
 
 
 def test_clip_grad_norm_with_inf_norm():

--- a/tests/unit_tests/training/test_train_utils.py
+++ b/tests/unit_tests/training/test_train_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import math
+from datetime import timedelta
 from unittest.mock import Mock
 
 import pytest
@@ -232,6 +233,69 @@ def test_clip_grad_norm_large_finite_gradients_do_not_overflow():
     assert grad_norm > 1.0e31
     assert torch.isfinite(model.weight.grad).all()
     assert torch.linalg.vector_norm(model.weight.grad.double(), ord=2).item() <= max_norm + 1.0e-6
+
+
+def _run_empty_local_shard_clip_worker(rank: int, world_size: int, init_file: str) -> None:
+    """Exercise clipping when one rank owns an empty DTensor gradient shard."""
+    from torch.distributed.device_mesh import init_device_mesh
+    from torch.distributed.tensor import DTensor, Shard
+
+    torch.distributed.init_process_group(
+        backend="gloo",
+        init_method=f"file://{init_file}",
+        rank=rank,
+        world_size=world_size,
+        timeout=timedelta(seconds=30),
+    )
+    try:
+        mesh = init_device_mesh("cpu", (world_size,))
+        local_param = torch.ones(1, 2) if rank == 0 else torch.empty(0, 2)
+        local_grad = torch.tensor([[3.0, 4.0]]) if rank == 0 else torch.empty(0, 2)
+        model = torch.nn.Module()
+        model.weight = torch.nn.Parameter(
+            DTensor.from_local(
+                local_param,
+                mesh,
+                [Shard(0)],
+                run_check=False,
+                shape=(1, 2),
+                stride=(2, 1),
+            )
+        )
+        model.weight.grad = DTensor.from_local(
+            local_grad,
+            mesh,
+            [Shard(0)],
+            run_check=False,
+            shape=(1, 2),
+            stride=(2, 1),
+        )
+
+        grad_norm = clip_grad_norm(
+            max_grad_norm=1.0,
+            model_parts=[model],
+            pp_enabled=False,
+            foreach=False,
+        )
+
+        assert grad_norm == pytest.approx(5.0)
+        if rank == 0:
+            torch.testing.assert_close(model.weight.grad.to_local(), torch.tensor([[0.6, 0.8]]))
+        else:
+            assert model.weight.grad.to_local().numel() == 0
+        torch.distributed.barrier()
+    finally:
+        torch.distributed.destroy_process_group()
+
+
+def test_clip_grad_norm_handles_empty_local_dtensor_shards(tmp_path):
+    """Empty rank-local DTensor shards contribute zero without breaking collectives."""
+    torch.multiprocessing.spawn(
+        _run_empty_local_shard_clip_worker,
+        args=(2, str(tmp_path / "empty_local_shard_pg")),
+        nprocs=2,
+        join=True,
+    )
 
 
 def test_clip_grad_norm_with_inf_norm():


### PR DESCRIPTION
## Summary

Prevent rare damaged input-embedding rows from overwhelming global gradient clipping during CPT, while retaining overflow-safe gradient-norm reporting.

## Root cause

The Nemotron-3 Nano 4B checkpoint has 79 input-embedding rows with L2 norm at or below `1e-4` (73 are exactly zero). When full-vocabulary mock data reaches these tokens, their embedding gradients can reach `6.21e31`.

An overflow-safe norm correctly reports the resulting global norm near `3e32`, but ordinary global clipping to `0.3` then multiplies every model gradient by roughly `1e-33`. That avoids an `inf` value but effectively discards the useful update.

## Changes

- Compute global gradient norms with max scaling and FP64 accumulation, including DTensor-aware reduction.
- Add opt-in `embedding_row_repair` configuration applied once after checkpoint loading and before optimizer construction.
- Identify non-finite or near-zero input-embedding rows and log their global token IDs.
- Replace each damaged row with the corresponding healthy `lm_head` direction, scaled to the RMS norm of healthy input rows.
- Handle replicated, vocabulary-sharded, and hidden-dimension-sharded DTensors without gathering the full embedding table.
- Fail before mutation when the number of damaged rows exceeds `max_rows`, the source output row is also damaged, or layouts are incompatible.
- Enable the repair for the Nemotron Nano 4B example with `min_norm: 1.0e-4` and document the option.

The repair is a one-time startup operation. It does not scan or alter embeddings on every training step.

## Validation

Local:

- `pytest -q tests/unit_tests/components/training/test_embedding_row_repair.py tests/unit_tests/training/test_train_utils.py tests/unit_tests/config/test_example_yaml_linter.py`: 44 passed
- `pytest -q tests/unit_tests/components/training`: 69 passed
- Targeted Ruff formatting and lint checks passed.

cw-dfw, 1 node / 8 H100s, FSDP2, full-vocabulary mock CPT:

| | Step 0 | Step 1 |
|---|---:|---:|
| Before repair, grad norm | `3.0889764e32` | `2.0009568e32` |
| After repair, grad norm | `21.1992` | `15.5722` |
| After repair, loss | `13.7071` | `12.9191` |

The run identified and repaired 79 rows with a healthy-row target norm of `0.77678`. Both steps completed with finite losses and gradients.

The broader `test_train_ft.py` module could not collect in the local system environment because its installed MLflow version expects a different `cachetools` API. The actual recipe setup ordering and multi-rank DTensor path were exercised by the cw-dfw run.