### PR TITLE
ci: add CUDA runtime preflight

### DIFF
--- a/.github/actions/test-template/action.yml
+++ b/.github/actions/test-template/action.yml
@@ -94,6 +94,50 @@ runs:
         bash retry_job.sh
         echo "::endgroup::"
 
+    - name: Validate CUDA runtime compatibility
+      shell: bash -e -u -o pipefail {0}
+      if: ${{ inputs.cpu-only == 'false' }}
+      run: |
+        echo "::group::Validate CUDA runtime compatibility"
+        docker exec nemo_container_${{ github.run_id }} bash -c '
+          set -e
+
+          . /opt/venv/env.sh
+
+          echo "nvidia-smi:"
+          nvidia-smi || true
+
+          python - <<'"'"'PY'"'"'
+        import torch
+
+        print(f"torch={torch.__version__}")
+        print(f"torch.version.cuda={torch.version.cuda}")
+        print(f"cuda_available_probe={torch.cuda.is_available()}")
+
+        try:
+            torch.cuda.init()
+            device_count = torch.cuda.device_count()
+            print(f"cuda_device_count={device_count}")
+            if device_count < 1:
+                raise RuntimeError("no CUDA devices are visible")
+            for idx in range(device_count):
+                name = torch.cuda.get_device_name(idx)
+                capability = torch.cuda.get_device_capability(idx)
+                print(f"cuda_device_{idx}={name}, capability={capability}")
+            torch.empty(1, device="cuda")
+        except Exception as exc:
+            print(
+                "::error title=CUDA runtime incompatible::"
+                "CUDA failed to initialize inside the test container. "
+                "This usually means the host NVIDIA driver is too old for "
+                "the CUDA runtime in the CI image; rerun on an updated GPU runner. "
+                f"error={type(exc).__name__}: {exc}"
+            )
+            raise
+        PY
+        '
+        echo "::endgroup::"
+
     - name: Create run-script
       id: create
       shell: bash


### PR DESCRIPTION
## Summary
- Add a GPU-only CUDA runtime preflight to the shared CI test template.
- Print `nvidia-smi`, Torch, CUDA runtime, and visible GPU details before running the expensive test suite.
- Fail early with a clear `CUDA runtime incompatible` annotation when the host NVIDIA driver cannot initialize the CUDA runtime in the CI container.

## Context
The failing `CICD NeMo` run on `main` hit repeated GPU-test errors from stale GPU hosts, including `RuntimeError: The NVIDIA driver on your system is too old (found version 12080)` and `CUDA driver version is insufficient for CUDA runtime version`. A rerun on a healthy runner passed, so this keeps coverage intact while making the infra mismatch explicit and fast to diagnose.

## Failure References
- Failing run, attempt 1: https://github.com/NVIDIA-NeMo/Automodel/actions/runs/29680549872/attempts/1
- `L0_Unit_Tests_GPU` failed job: https://github.com/NVIDIA-NeMo/Automodel/actions/runs/29680549872/job/88176180382
  - Examples: `tests/unit_tests/_peft/test_lora_kernel.py::{test_forward_kernel,test_da_dx_kernel,test_db_kernel}`, `tests/unit_tests/models/gemma4/test_gemma4_model_cp.py`, `tests/unit_tests/models/bi_encoder/test_bi_encoder_model.py::test_validation_epoch_supports_multi_vector_pooling`, `tests/unit_tests/recipes/test_retrieval_distill_recipe.py::test_validation_epoch_runs_with_tuple_student_output`, and `tests/unit_tests/training/test_rng.py::test_stateful_rng_restores_state`.
- `L2_Pretrain_and_KD` failed job: https://github.com/NVIDIA-NeMo/Automodel/actions/runs/29680549872/job/88177284120
  - Examples: `tests/functional_tests/llm_pretrain_and_kd/customizer_retrieval/test_customizer_retrieval.py::TestCustomizerRetrieval::test_bi_encoder_finetuning_not_degraded` and `test_onnx_export_and_verify[{fp32,bf16}]`.
- Healthy rerun, attempt 2: https://github.com/NVIDIA-NeMo/Automodel/actions/runs/29680549872/attempts/2

## Validation
- `python - <<'PY' ... yaml.safe_load('.github/actions/test-template/action.yml') ... PY`
- `git diff --check`
- Extracted the new step's `run` block, substituted `${{ github.run_id }}`, and verified it with `bash -n`.
