### PR TITLE
fix(ci): preserve retrieval evaluation schedule

### DIFF
--- a/examples/retrieval/bi_encoder/llama3_2_1b.yaml
+++ b/examples/retrieval/bi_encoder/llama3_2_1b.yaml
@@ -152,8 +152,9 @@ ci:
   nodes: 1
   embed_eval: true
   # The downstream golden-metric evaluation consumes this full-epoch checkpoint.
-  nightly:
+  nightly: &full_epoch_ci
     step_scheduler.max_steps: null
     step_scheduler.ckpt_every_steps: 2000
     step_scheduler.val_every_steps: 500
     lr_scheduler.lr_warmup_steps: 100
+  release: *full_epoch_ci

--- a/examples/retrieval/bi_encoder/llama3_2_1b.yaml
+++ b/examples/retrieval/bi_encoder/llama3_2_1b.yaml
@@ -151,3 +151,9 @@ ci:
   time: "01:30:00"
   nodes: 1
   embed_eval: true
+  # The downstream golden-metric evaluation consumes this full-epoch checkpoint.
+  nightly:
+    step_scheduler.max_steps: null
+    step_scheduler.ckpt_every_steps: 2000
+    step_scheduler.val_every_steps: 500
+    lr_scheduler.lr_warmup_steps: 100

--- a/examples/retrieval/cross_encoder/llama3_2_1b.yaml
+++ b/examples/retrieval/cross_encoder/llama3_2_1b.yaml
@@ -146,8 +146,9 @@ ci:
   nodes: 1
   rerank_eval: true
   # The downstream golden-metric evaluation consumes this full-epoch checkpoint.
-  nightly:
+  nightly: &full_epoch_ci
     step_scheduler.max_steps: null
     step_scheduler.ckpt_every_steps: 2000
     step_scheduler.val_every_steps: 500
     lr_scheduler.lr_warmup_steps: 100
+  release: *full_epoch_ci

--- a/examples/retrieval/cross_encoder/llama3_2_1b.yaml
+++ b/examples/retrieval/cross_encoder/llama3_2_1b.yaml
@@ -145,3 +145,9 @@ ci:
   time: "01:30:00"
   nodes: 1
   rerank_eval: true
+  # The downstream golden-metric evaluation consumes this full-epoch checkpoint.
+  nightly:
+    step_scheduler.max_steps: null
+    step_scheduler.ckpt_every_steps: 2000
+    step_scheduler.val_every_steps: 500
+    lr_scheduler.lr_warmup_steps: 100


### PR DESCRIPTION
## Summary

- keep the Llama 3.2 1B bi-encoder and cross-encoder CI producers on their full one-epoch schedules
- define the workload-specific scheduler values in the AutoModel recipes
- share the recipe-owned schedule between `ci.nightly` and `ci.release`

## Why

[NeMo-CI !2693](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/merge_requests/2693) cleans up the retrieval test harness: it adds support for typed top-level dataset configs and removes hard-coded scheduler CLI overrides. This makes the AutoModel phase config the source of truth for training behavior, which is the cleaner ownership boundary.

The shared nightly and release defaults cap training at 50 steps. These two retrieval jobs are different: they produce consolidated full-epoch checkpoints that downstream embedding and reranking evaluations compare against golden metrics, and historically use 100 warmup steps. This PR makes that existing contract explicit in the recipes so the NeMo-CI cleanup does not change evaluation quality. The release mapping also prepares these recipes for the planned release-discovery follow-up.

## Merge order

Merge this PR first, then [NeMo-CI !2693](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/merge_requests/2693).

## Validation

- resolved both recipes through `config_resolver.py --phase nightly` and verified `max_steps: null`, checkpoint cadence 2000, validation cadence 500, and warmup 100
- verified both `ci.nightly` and `ci.release` mappings parse to the same schedule
- `validate_nightly_recipes.py --automodel-dir .`
- `git diff --check`
- all GitHub PR checks pass, including DCO and `validate-nightly-recipes`