### PR TITLE
fix(moe): preserve top-k routing under full AC

### DIFF
--- a/nemo_automodel/components/distributed/config.py
+++ b/nemo_automodel/components/distributed/config.py
@@ -167,10 +167,10 @@ class DistributedSetup:
 class MoEParallelizerConfig:
     """Configuration for MoE model parallelization (EP + FSDP settings)."""
 
-    # Default True: under activation checkpointing the MoE router output must be saved
-    # rather than recomputed. Recomputing the router can route a different number of tokens
-    # per expert than the forward pass, which makes torch.utils.checkpoint raise a
-    # CheckpointError on the backward recompute.
+    # Default True: under activation checkpointing the MoE router projection and top-k outputs
+    # must be saved rather than recomputed. Recomputing tied top-k selections can route a
+    # different number of tokens per expert than the forward pass, which makes
+    # torch.utils.checkpoint raise a CheckpointError on the backward recompute.
     ignore_router_for_ac: bool = True
     reshard_after_forward: bool = False
     lm_head_precision: Optional[Union[str, torch.dtype]] = None

--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -377,9 +377,9 @@ def apply_ac(
 
     Args:
         model: The model to apply activation checkpointing to.
-        ignore_router: If True (the default), saves the MoE router output so the dispatch
-            is not recomputed under activation checkpointing (avoids a CheckpointError from
-            non-deterministic re-routing on recompute). If False, a warning is emitted.
+        ignore_router: If True (the default), saves the MoE router projection and top-k
+            outputs so recompute preserves expert assignments (avoids a CheckpointError from
+            non-deterministic re-routing changing dispatch shapes). If False, a warning is emitted.
         hidden_size: Hidden dimension size. If None, derived from model.config.hidden_size.
         num_experts: Number of routed experts. If None, derived from moe_config.n_routed_experts
             first, then falls back to model.config attributes.
@@ -414,7 +414,7 @@ def apply_ac(
             "different number of tokens per expert than the forward pass and crash with "
             "torch.utils.checkpoint.CheckpointError ('Recomputed values ... have different "
             "metadata'). Set ignore_router_for_ac=True (the default) to save the router "
-            "output and keep routing consistent across recompute."
+            "projection and top-k outputs and keep routing consistent across recompute."
         )
 
     if selective:
@@ -484,8 +484,10 @@ def apply_ac(
             return len(args) >= 2 and args[1].shape == (num_experts, hidden_size)
         return False
 
+    router_topk = getattr(getattr(torch.ops.aten, "topk", None), "default", None)
+
     def _custom_policy(ctx, func, *args, **kwargs):
-        if _is_router_projection(func, args):
+        if (router_topk is not None and func == router_topk) or _is_router_projection(func, args):
             return CheckpointPolicy.MUST_SAVE
         return CheckpointPolicy.PREFER_RECOMPUTE
 

--- a/tests/unit_tests/moe/test_parallelizer.py
+++ b/tests/unit_tests/moe/test_parallelizer.py
@@ -209,8 +209,11 @@ def _install_torch_and_layers_stubs(monkeypatch):
     utils_checkpoint_stub.CheckpointPolicy = CheckpointPolicy
     utils_checkpoint_stub.create_selective_checkpoint_contexts = create_selective_checkpoint_contexts
 
-    # ops.aten.mm.default sentinel
-    aten = types.SimpleNamespace(mm=types.SimpleNamespace(default=object()))
+    # Router ops used by the targeted activation-checkpointing policy.
+    aten = types.SimpleNamespace(
+        mm=types.SimpleNamespace(default=object()),
+        topk=types.SimpleNamespace(default=object()),
+    )
     torch_stub.ops = types.SimpleNamespace(aten=aten)
 
     # dtype and device classes for type annotations
@@ -220,8 +223,12 @@ def _install_torch_and_layers_stubs(monkeypatch):
     class device:
         pass
 
+    class Tensor:
+        pass
+
     torch_stub.dtype = dtype
     torch_stub.device = device
+    torch_stub.Tensor = Tensor
 
     # common dtypes referenced by code
     torch_stub.bfloat16 = object()
@@ -293,7 +300,11 @@ def _import_parallelizer_with_stubs(monkeypatch):
 
     _install_torch_and_layers_stubs(monkeypatch)
 
-    # Stub the pipelining module and hf_utils
+    # Stub the distributed package, config normalization, pipelining module, and hf_utils.
+    distributed_stub = types.ModuleType("nemo_automodel.components.distributed")
+    distributed_stub.__path__ = []
+    config_stub = types.ModuleType("nemo_automodel.components.distributed.config")
+    config_stub.normalize_activation_checkpointing_scope = lambda scope: (scope,) if isinstance(scope, str) else tuple(scope)
     pipelining_stub = types.ModuleType("nemo_automodel.components.distributed.pipelining")
     hf_utils_stub = types.ModuleType("nemo_automodel.components.distributed.pipelining.hf_utils")
 
@@ -306,6 +317,8 @@ def _import_parallelizer_with_stubs(monkeypatch):
     hf_utils_stub.get_text_module = get_text_module
     pipelining_stub.hf_utils = hf_utils_stub
 
+    monkeypatch.setitem(sys.modules, "nemo_automodel.components.distributed", distributed_stub)
+    monkeypatch.setitem(sys.modules, "nemo_automodel.components.distributed.config", config_stub)
     monkeypatch.setitem(sys.modules, "nemo_automodel.components.distributed.pipelining", pipelining_stub)
     monkeypatch.setitem(sys.modules, "nemo_automodel.components.distributed.pipelining.hf_utils", hf_utils_stub)
 
@@ -542,7 +555,7 @@ def test_apply_ac_warns_when_router_is_recomputed(monkeypatch):
     assert logger_mock.warning.call_count == 1
     assert "ignore_router_for_ac" in logger_mock.warning.call_args[0][0]
 
-    # ignore_router=True (the default) saves the router output -> no warning.
+    # ignore_router=True (the default) saves the router projection and top-k outputs -> no warning.
     logger_mock.reset_mock()
     P.apply_ac(DummyModel([DummyBlock()]), ignore_router=True, hidden_size=7168, num_experts=256)
     logger_mock.warning.assert_not_called()
@@ -574,7 +587,7 @@ def test_apply_ac_uses_generic_wrapper_even_when_block_local_checkpointing_is_av
     assert model.layers.registered["0"] is wrapped
 
 
-def test_apply_ac_custom_policy_respects_hidden_and_expert_dims(monkeypatch):
+def test_apply_ac_custom_policy_saves_router_projection_and_topk(monkeypatch):
     P = _import_parallelizer_with_stubs(monkeypatch)
 
     captured_policy = None
@@ -607,10 +620,12 @@ def test_apply_ac_custom_policy_respects_hidden_and_expert_dims(monkeypatch):
 
     policy = captured_policy
     must_save = policy(None, torch_stub.ops.aten.mm.default, object(), rhs_match)
+    must_save_topk = policy(None, torch_stub.ops.aten.topk.default, object(), 2)
     prefer_recompute_shape = policy(None, torch_stub.ops.aten.mm.default, object(), rhs_mismatch)
     prefer_recompute_func = policy(None, object(), object(), rhs_match)
 
     assert must_save == P.CheckpointPolicy.MUST_SAVE
+    assert must_save_topk == P.CheckpointPolicy.MUST_SAVE
     assert prefer_recompute_shape == P.CheckpointPolicy.PREFER_RECOMPUTE
     assert prefer_recompute_func == P.CheckpointPolicy.PREFER_RECOMPUTE
 


### PR DESCRIPTION
# What does this PR do ?

Preserve MoE top-k routing decisions under full activation checkpointing.

The existing `ignore_router_for_ac=True` policy saved the router projection but recomputed `aten.topk`. Exact tied scores could therefore select different experts during backward recomputation, changing DeepEP routed-token buffer shapes and raising `CheckpointError`.

# Changelog

- Save `aten.topk` outputs alongside the router projection in the full-AC MoE policy.
- Clarify the `ignore_router_for_ac` routing-stability contract.
- Extend focused unit coverage for router projection and top-k policy decisions.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added focused unit coverage.
- [x] Updated the affected configuration and API documentation.

# Validation

- `pytest tests/unit_tests/moe/test_parallelizer.py -q` — 74 passed
- `ruff format --check .`
- `ruff check .`

# Additional Information

The motivating failure was observed with tie-heavy `GroupedExpertsDeepEP` routing under EP: recomputed top-k assignments changed the routed-token count by one.
