### PR TITLE
fix(gemma4): run SDPA in fp32 to avoid #2208 NaN on Hopper

### DIFF
--- a/nemo_automodel/components/models/gemma4_moe/model.py
+++ b/nemo_automodel/components/models/gemma4_moe/model.py
@@ -97,6 +97,7 @@ from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 
 from .cp_attention import attach_gemma4_cp_ring_attention, gemma4_vision_group_ids
 from .cp_batch import make_contiguous_aux_only_shard_cp_batch_and_ctx
+from .sdpa_fp32 import enable_gemma4_sdpa_fp32
 
 
 class _Gemma4KVShareHolder:
@@ -978,6 +979,10 @@ class Gemma4ForConditionalGeneration(HFCheckpointingMixin, HFGemma4ForConditiona
         if not _GEMMA4_HF_AVAILABLE:
             raise UnavailableError("transformers.models.gemma4 is not available.")
         config = Gemma4Config.from_pretrained(pretrained_model_name_or_path)
+        # #2208: fused bf16 SDPA NaNs on Hopper; run SDPA in fp32 instead.
+        attn_impl = kwargs.get("attn_implementation") or getattr(config, "_attn_implementation", None)
+        if attn_impl == "sdpa":
+            enable_gemma4_sdpa_fp32()
         return cls.from_config(config, *model_args, **kwargs)
 
     def setup_cp_attention(self, cp_mesh) -> None:

--- a/nemo_automodel/components/models/gemma4_moe/sdpa_fp32.py
+++ b/nemo_automodel/components/models/gemma4_moe/sdpa_fp32.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""fp32 SDPA attention for Gemma4 (fix for #2208: fused bf16 SDPA NaNs on Hopper)."""
+
+from typing import Optional
+
+import torch
+from transformers.integrations.sdpa_attention import sdpa_attention_forward
+
+
+def sdpa_fp32_attention_forward(
+    module: torch.nn.Module,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attention_mask: Optional[torch.Tensor] = None,
+    **kwargs,
+) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+    """Run SDPA with fp32 query/key/value and cast the output back to the input dtype."""
+    in_dtype = query.dtype
+    if attention_mask is not None and torch.is_tensor(attention_mask) and attention_mask.dtype.is_floating_point:
+        attention_mask = attention_mask.float()
+    out, weights = sdpa_attention_forward(module, query.float(), key.float(), value.float(), attention_mask, **kwargs)
+    return out.to(in_dtype), (weights.to(in_dtype) if torch.is_tensor(weights) else weights)
+
+
+def enable_gemma4_sdpa_fp32() -> None:
+    """Install :func:`sdpa_fp32_attention_forward` as the process-wide ``"sdpa"`` implementation."""
+    from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+
+    # Newer transformers exposes an ``AttentionInterface`` with ``register()`` and
+    # internal ``_global_mapping``/``_local_mapping`` dicts; older versions are a
+    # plain ``dict`` that supports item assignment. Update every surface the
+    # attention lookup may read from so the fix works across versions.
+    try:
+        ALL_ATTENTION_FUNCTIONS.register("sdpa", sdpa_fp32_attention_forward)
+    except Exception:
+        pass
+    try:
+        ALL_ATTENTION_FUNCTIONS["sdpa"] = sdpa_fp32_attention_forward
+    except Exception:
+        pass
+    for attr in ("_global_mapping", "_local_mapping"):
+        mapping = getattr(ALL_ATTENTION_FUNCTIONS, attr, None)
+        if isinstance(mapping, dict) and "sdpa" in mapping:
+            mapping["sdpa"] = sdpa_fp32_attention_forward

--- a/tests/unit_tests/models/gemma4/test_sdpa_fp32.py
+++ b/tests/unit_tests/models/gemma4/test_sdpa_fp32.py
@@ -1,0 +1,160 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the fp32 SDPA attention fix (issue #2208).
+
+The fused bf16 SDPA kernels are gradient-unstable for Gemma4 on Hopper. These
+tests cover ``sdpa_fp32_attention_forward`` (runs SDPA with fp32 query/key/value
+and casts the output back) and ``enable_gemma4_sdpa_fp32`` (installs it as the
+``"sdpa"`` attention). CPU-only -- the behaviour under test is dtype handling and
+registration, so no GPU is required.
+"""
+
+import torch
+
+from nemo_automodel.components.models.gemma4_moe import sdpa_fp32
+from nemo_automodel.components.models.gemma4_moe.sdpa_fp32 import (
+    enable_gemma4_sdpa_fp32,
+    sdpa_fp32_attention_forward,
+)
+
+
+class _RecordingSDPA:
+    """Stand-in for ``transformers`` ``sdpa_attention_forward`` that records the
+    dtypes it is called with and returns an output of a chosen dtype."""
+
+    def __init__(self, out_dtype=torch.float32):
+        self.calls = []
+        self.out_dtype = out_dtype
+
+    def __call__(self, module, query, key, value, attention_mask=None, **kwargs):
+        self.calls.append(
+            {
+                "q": query.dtype,
+                "k": key.dtype,
+                "v": value.dtype,
+                "mask": None if attention_mask is None else attention_mask.dtype,
+            }
+        )
+        return torch.zeros_like(query, dtype=self.out_dtype), None
+
+
+def _qkv(dtype=torch.bfloat16):
+    t = torch.randn(1, 2, 4, 8, dtype=dtype)
+    return t, t.clone(), t.clone()
+
+
+def test_upcasts_qkv_to_fp32(monkeypatch):
+    rec = _RecordingSDPA()
+    monkeypatch.setattr(sdpa_fp32, "sdpa_attention_forward", rec)
+
+    q, k, v = _qkv(torch.bfloat16)
+    sdpa_fp32_attention_forward(torch.nn.Module(), q, k, v)
+
+    call = rec.calls[0]
+    assert call["q"] == call["k"] == call["v"] == torch.float32
+
+
+def test_casts_output_back_to_input_dtype(monkeypatch):
+    # The underlying SDPA runs in fp32; the wrapper must cast back to the input dtype.
+    monkeypatch.setattr(sdpa_fp32, "sdpa_attention_forward", _RecordingSDPA(out_dtype=torch.float32))
+
+    q, k, v = _qkv(torch.bfloat16)
+    out, weights = sdpa_fp32_attention_forward(torch.nn.Module(), q, k, v)
+
+    assert out.dtype == torch.bfloat16
+    assert weights is None
+
+
+def test_upcasts_floating_point_mask(monkeypatch):
+    rec = _RecordingSDPA()
+    monkeypatch.setattr(sdpa_fp32, "sdpa_attention_forward", rec)
+
+    q, k, v = _qkv(torch.bfloat16)
+    mask = torch.zeros(1, 1, 4, 4, dtype=torch.bfloat16)
+    sdpa_fp32_attention_forward(torch.nn.Module(), q, k, v, attention_mask=mask)
+
+    assert rec.calls[0]["mask"] == torch.float32
+
+
+def test_non_float_mask_left_untouched(monkeypatch):
+    rec = _RecordingSDPA()
+    monkeypatch.setattr(sdpa_fp32, "sdpa_attention_forward", rec)
+
+    q, k, v = _qkv(torch.bfloat16)
+    mask = torch.ones(1, 1, 4, 4, dtype=torch.bool)
+    sdpa_fp32_attention_forward(torch.nn.Module(), q, k, v, attention_mask=mask)
+
+    assert rec.calls[0]["mask"] == torch.bool
+
+
+def _restore_sdpa(registry, fn):
+    try:
+        registry.register("sdpa", fn)
+    except Exception:
+        pass
+    for attr in ("_global_mapping", "_local_mapping"):
+        mapping = getattr(registry, attr, None)
+        if isinstance(mapping, dict) and "sdpa" in mapping:
+            mapping["sdpa"] = fn
+
+
+def test_enable_registers_fp32_sdpa():
+    from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+
+    original = ALL_ATTENTION_FUNCTIONS["sdpa"]
+    try:
+        enable_gemma4_sdpa_fp32()
+        assert ALL_ATTENTION_FUNCTIONS["sdpa"] is sdpa_fp32_attention_forward
+    finally:
+        _restore_sdpa(ALL_ATTENTION_FUNCTIONS, original)
+
+
+# ---------------------------------------------------------------------------
+# Usage: Gemma4ForConditionalGeneration.from_pretrained installs the fp32 SDPA
+# attention only when attn_implementation="sdpa".
+# ---------------------------------------------------------------------------
+def _from_pretrained_calls(monkeypatch, attn_implementation):
+    """Run the from_pretrained hook with model construction stubbed out and
+    return the list recording whether enable_gemma4_sdpa_fp32 was called."""
+    import pytest
+
+    try:
+        from nemo_automodel.components.models.gemma4_moe import model as g4model
+    except ImportError as exc:  # e.g. older torch without FSDPModule, or no gemma4
+        pytest.skip(f"gemma4_moe model unavailable: {exc}")
+
+    if not g4model._GEMMA4_HF_AVAILABLE:
+        pytest.skip("transformers gemma4 is not available")
+
+    calls = []
+    monkeypatch.setattr(g4model, "enable_gemma4_sdpa_fp32", lambda: calls.append(True))
+    monkeypatch.setattr(g4model.Gemma4Config, "from_pretrained", classmethod(lambda cls, *a, **k: object()))
+    monkeypatch.setattr(
+        g4model.Gemma4ForConditionalGeneration, "from_config", classmethod(lambda cls, *a, **k: "MODEL")
+    )
+
+    result = g4model.Gemma4ForConditionalGeneration.from_pretrained(
+        "dummy", attn_implementation=attn_implementation
+    )
+    assert result == "MODEL"
+    return calls
+
+
+def test_from_pretrained_enables_fp32_for_sdpa(monkeypatch):
+    assert _from_pretrained_calls(monkeypatch, "sdpa") == [True]
+
+
+def test_from_pretrained_skips_fp32_for_eager(monkeypatch):
+    assert _from_pretrained_calls(monkeypatch, "eager") == []


### PR DESCRIPTION
## Summary

Fixes NVIDIA-NeMo/Automodel#2208. With `attn_implementation=sdpa` and `local_batch_size >= 2`, Gemma4 training throws a NaN loss after \~20 steps on Hopper (H100). This runs SDPA with fp32 query/key/value so attention is numerically stable, while keeping the memory-efficient SDPA kernel path (unlike eager, which materializes the full attention matrix).

## Root cause

The fused bf16 SDPA kernels are gradient-unstable for Gemma4 on Hopper: `grad_norm` goes NaN at step 22 and the loss follows at step 23. Eager avoids it by upcasting the softmax to fp32. Running SDPA with fp32 inputs gives the same numerical stability without leaving the fused/memory-efficient path.

## Reproduction

Using the reproducer from NVIDIA-NeMo/Automodel#2208 (`nvcr.io/nvidia/nemo-automodel:26.06`, 2×H100):

```
torchrun --nproc-per-node=2 examples/vlm_finetune/finetune.py \
  -c examples/vlm_finetune/gemma4/gemma4_2b.yaml \
  --step_scheduler.local_batch_size 2 --model.attn_implementation sdpa
```

* **Before:** `grad_norm` NaN @ step 22, loss NaN @ step 23.
* **After:** 30 steps clean, loss descending, no NaN.

Note: the NaN only reproduced on H100/Hopper — the same container and command ran clean on A100.

## Changes

* `nemo_automodel/components/models/gemma4_moe/sdpa_fp32.py` — `sdpa_fp32_attention_forward` (SDPA with fp32 q/k/v) and `enable_gemma4_sdpa_fp32()`.
* `nemo_automodel/components/models/gemma4_moe/model.py` — install it from `from_pretrained` when `attn_implementation=sdpa`.