### PR TITLE
feat: add Kimi Linear model support

### DIFF
--- a/examples/llm_finetune/kimi/kimi_linear_48b_a3b_hellaswag.yaml
+++ b/examples/llm_finetune/kimi/kimi_linear_48b_a3b_hellaswag.yaml
@@ -1,0 +1,138 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# To run this recipe:
+#   HF_HOME=$PWD/.hf_cache automodel examples/llm_finetune/kimi/kimi_linear_48b_a3b_hellaswag.yaml --nproc-per-node 8 --wandb.enable=true
+
+recipe: TrainFinetuneRecipeForNextTokenPrediction
+
+step_scheduler:
+  global_batch_size: 8
+  local_batch_size: 1
+  ckpt_every_steps: 100
+  val_every_steps: 10
+  log_remote_every_steps: 1
+  loss_average_window_steps: 5
+  gc_every_steps: 5
+  num_epochs: 1
+  max_steps: 100
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 30
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 20260721
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: moonshotai/Kimi-Linear-48B-A3B-Instruct
+  trust_remote_code: true
+  torch_dtype: bfloat16
+  kda_mode: chunk
+  kda_unpad_inputs: false
+  kda_use_fused_gate: true
+  kda_use_qk_l2norm_in_kernel: true
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: eager
+    linear: torch
+    rms_norm: torch_fp32
+    experts: torch
+    dispatcher: torch
+    gate_precision: float32
+    fake_balanced_gate: false
+    enable_hf_state_dict_adapter: true
+    enable_fsdp_optimizations: true
+
+checkpoint:
+  enabled: false
+  checkpoint_dir: checkpoints/kimi_linear_48b_a3b_hellaswag
+  model_save_format: safetensors
+  save_consolidated: false
+
+distributed:
+  strategy: fsdp2
+  tp_size: 1
+  cp_size: 1
+  pp_size: 1
+  ep_size: 8
+  sequence_parallel: false
+  activation_checkpointing: false
+  moe:
+    reshard_after_forward: true
+    wrap_outer_model: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.hellaswag.HellaSwag
+  path_or_dataset: rowan/hellaswag
+  split: train
+  tokenizer:
+    _target_: transformers.AutoTokenizer.from_pretrained
+    pretrained_model_name_or_path: moonshotai/Kimi-Linear-48B-A3B-Instruct
+    trust_remote_code: true
+
+packed_sequence:
+  packed_sequence_size: 0
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn:
+    _target_: nemo_automodel.components.datasets.utils.default_collater
+    pad_seq_len_divisible: 64
+  shuffle: true
+  num_workers: 2
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.llm.hellaswag.HellaSwag
+  path_or_dataset: rowan/hellaswag
+  split: validation
+  num_samples_limit: 64
+  tokenizer:
+    _target_: transformers.AutoTokenizer.from_pretrained
+    pretrained_model_name_or_path: moonshotai/Kimi-Linear-48B-A3B-Instruct
+    trust_remote_code: true
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn:
+    _target_: nemo_automodel.components.datasets.utils.default_collater
+    pad_seq_len_divisible: 64
+  shuffle: false
+  drop_last: true
+  num_workers: 2
+
+optimizer:
+  _target_: torch.optim.AdamW
+  betas: [0.9, 0.95]
+  eps: 1e-8
+  lr: 1.0e-5
+  weight_decay: 0.01
+
+wandb:
+  enable: false
+  project: automodel-kimi-linear
+  name: kimi_linear_48b_a3b_hellaswag_ep8
+  mode: online
+  dir: result/wandb
+
+ci:
+  recipe_owner: huiyingl
+  nodes: 1
+  time: "01:00:00"

--- a/examples/llm_finetune/kimi/kimi_linear_48b_a3b_longcontext_cp2.yaml
+++ b/examples/llm_finetune/kimi/kimi_linear_48b_a3b_longcontext_cp2.yaml
@@ -1,0 +1,143 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Long-context Kimi Linear fine-tuning: 32k packed sequences split across a
+# context-parallel group of 2, with EP=8 over the same 8 GPUs.
+#
+# Kimi Linear shards the sequence into contiguous per-rank slices (KDA's recurrent
+# state is passed rank to rank by FLA, MLA gathers the compressed KV latent), and
+# document boundaries from the packed collater are honored by both layer types.
+#
+# To run this recipe:
+#   HF_HOME=$PWD/.hf_cache automodel examples/llm_finetune/kimi/kimi_linear_48b_a3b_longcontext_cp2.yaml --nproc-per-node 8
+
+recipe: TrainFinetuneRecipeForNextTokenPrediction
+
+step_scheduler:
+  global_batch_size: 4
+  local_batch_size: 1
+  ckpt_every_steps: 100
+  val_every_steps: 20
+  log_remote_every_steps: 1
+  loss_average_window_steps: 5
+  gc_every_steps: 5
+  num_epochs: 1
+  max_steps: 100
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 30
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 20260721
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: moonshotai/Kimi-Linear-48B-A3B-Instruct
+  trust_remote_code: true
+  torch_dtype: bfloat16
+  kda_mode: chunk
+  kda_unpad_inputs: false
+  kda_use_fused_gate: true
+  kda_use_qk_l2norm_in_kernel: true
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: eager
+    linear: torch
+    rms_norm: torch_fp32
+    experts: torch
+    dispatcher: torch
+    gate_precision: float32
+    fake_balanced_gate: false
+    enable_hf_state_dict_adapter: true
+    enable_fsdp_optimizations: true
+
+checkpoint:
+  enabled: false
+  checkpoint_dir: checkpoints/kimi_linear_48b_a3b_longcontext_cp2
+  model_save_format: safetensors
+  save_consolidated: false
+
+distributed:
+  strategy: fsdp2
+  tp_size: 1
+  cp_size: 2                 # 32k tokens -> 16k per rank
+  pp_size: 1
+  ep_size: 8                 # EP and CP overlap on the device mesh
+  sequence_parallel: false
+  activation_checkpointing: true
+  moe:
+    reshard_after_forward: true
+    wrap_outer_model: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.hellaswag.HellaSwag
+  path_or_dataset: rowan/hellaswag
+  split: train
+  pad_to_max_length: false
+  tokenizer:
+    _target_: transformers.AutoTokenizer.from_pretrained
+    pretrained_model_name_or_path: moonshotai/Kimi-Linear-48B-A3B-Instruct
+    trust_remote_code: true
+
+packed_sequence:
+  packed_sequence_size: 32768
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.packed_sequence_thd_collater
+  shuffle: true
+  num_workers: 2
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.llm.hellaswag.HellaSwag
+  path_or_dataset: rowan/hellaswag
+  split: validation
+  num_samples_limit: 64
+  pad_to_max_length: false
+  tokenizer:
+    _target_: transformers.AutoTokenizer.from_pretrained
+    pretrained_model_name_or_path: moonshotai/Kimi-Linear-48B-A3B-Instruct
+    trust_remote_code: true
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.packed_sequence_thd_collater
+  shuffle: false
+  drop_last: true
+  num_workers: 2
+
+optimizer:
+  _target_: torch.optim.AdamW
+  betas: [0.9, 0.95]
+  eps: 1e-8
+  lr: 1.0e-5
+  weight_decay: 0.01
+
+wandb:
+  enable: false
+  project: automodel-kimi-linear
+  name: kimi_linear_48b_a3b_longcontext_cp2
+  mode: online
+  dir: result/wandb
+
+ci:
+  recipe_owner: khazic
+  nodes: 1
+  time: "01:00:00"

--- a/examples/llm_finetune/kimi/kimi_linear_48b_a3b_longcontext_tp2_sp.yaml
+++ b/examples/llm_finetune/kimi/kimi_linear_48b_a3b_longcontext_tp2_sp.yaml
@@ -1,0 +1,146 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Long-context Kimi Linear fine-tuning: 32k packed sequences with tensor
+# parallelism of 2 plus sequence parallelism, context parallelism of 2 and EP=8
+# over the same 8 GPUs.
+#
+# Tensor parallelism shards the MLA full-attention layers and the dense MLP; the
+# KDA linear-attention layers stay replicated (their FLA kernels take plain
+# tensors). Sequence parallelism additionally shards the normalization and
+# residual path, all-gathering the sequence for attention and reduce-scattering
+# it at the output projection.
+#
+# To run this recipe:
+#   HF_HOME=$PWD/.hf_cache automodel examples/llm_finetune/kimi/kimi_linear_48b_a3b_longcontext_tp2_sp.yaml --nproc-per-node 8
+
+recipe: TrainFinetuneRecipeForNextTokenPrediction
+
+step_scheduler:
+  global_batch_size: 4
+  local_batch_size: 1
+  ckpt_every_steps: 100
+  val_every_steps: 20
+  log_remote_every_steps: 1
+  loss_average_window_steps: 5
+  gc_every_steps: 5
+  num_epochs: 1
+  max_steps: 100
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 30
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 20260721
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
+  pretrained_model_name_or_path: moonshotai/Kimi-Linear-48B-A3B-Instruct
+  trust_remote_code: true
+  torch_dtype: bfloat16
+  kda_mode: chunk
+  kda_unpad_inputs: false
+  kda_use_fused_gate: true
+  kda_use_qk_l2norm_in_kernel: true
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: eager
+    linear: torch
+    rms_norm: torch_fp32
+    experts: torch
+    dispatcher: torch
+    gate_precision: float32
+    fake_balanced_gate: false
+    enable_hf_state_dict_adapter: true
+    enable_fsdp_optimizations: true
+
+checkpoint:
+  enabled: false
+  checkpoint_dir: checkpoints/kimi_linear_48b_a3b_longcontext_tp2_sp
+  model_save_format: safetensors
+  save_consolidated: false
+
+distributed:
+  strategy: fsdp2
+  tp_size: 2
+  cp_size: 2                 # 32k tokens -> 16k per context-parallel rank
+  pp_size: 1
+  ep_size: 8                 # EP overlaps CP and TP on the device mesh
+  sequence_parallel: true
+  activation_checkpointing: true
+  moe:
+    reshard_after_forward: true
+    wrap_outer_model: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.hellaswag.HellaSwag
+  path_or_dataset: rowan/hellaswag
+  split: train
+  pad_to_max_length: false
+  tokenizer:
+    _target_: transformers.AutoTokenizer.from_pretrained
+    pretrained_model_name_or_path: moonshotai/Kimi-Linear-48B-A3B-Instruct
+    trust_remote_code: true
+
+packed_sequence:
+  packed_sequence_size: 32768
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.packed_sequence_thd_collater
+  shuffle: true
+  num_workers: 2
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.llm.hellaswag.HellaSwag
+  path_or_dataset: rowan/hellaswag
+  split: validation
+  num_samples_limit: 64
+  pad_to_max_length: false
+  tokenizer:
+    _target_: transformers.AutoTokenizer.from_pretrained
+    pretrained_model_name_or_path: moonshotai/Kimi-Linear-48B-A3B-Instruct
+    trust_remote_code: true
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: nemo_automodel.components.datasets.utils.packed_sequence_thd_collater
+  shuffle: false
+  drop_last: true
+  num_workers: 2
+
+optimizer:
+  _target_: torch.optim.AdamW
+  betas: [0.9, 0.95]
+  eps: 1e-8
+  lr: 1.0e-5
+  weight_decay: 0.01
+
+wandb:
+  enable: false
+  project: automodel-kimi-linear
+  name: kimi_linear_48b_a3b_longcontext_tp2_sp
+  mode: online
+  dir: result/wandb
+
+ci:
+  recipe_owner: khazic
+  nodes: 1
+  time: "01:00:00"

--- a/nemo_automodel/_transformers/capabilities.py
+++ b/nemo_automodel/_transformers/capabilities.py
@@ -241,6 +241,7 @@ class ModelSupports:
         +------------------+----------------+---------+
         | Model kind       | Attention      | CP?     |
         +------------------+----------------+---------+
+        | Custom (owns CP) | any            | Yes     |
         | Custom           | TE             | Yes     |
         | Custom           | Magi (FFA)     | Yes     |
         | Custom hybrid    | TE / SDPA      | Yes     |
@@ -250,6 +251,11 @@ class ModelSupports:
         | HF hybrid (Mamba)| any            | No      |
         +------------------+----------------+---------+
         """
+        if getattr(self._model, "_owns_cp_attention", False):
+            # The model ships its own CP batch sharding and per-layer transport for
+            # every layer type it has (e.g. Kimi Linear's FLA context for KDA plus
+            # gathered-KV FlexAttention for MLA), so no attention backend is required.
+            return True
         if _has_backend(self._model):
             backend_attn = getattr(getattr(self._model, "backend", None), "attn", None)
             if _is_deepseek_v4(self._model) or _is_glm_moe_dsa(self._model):
@@ -282,6 +288,10 @@ class ModelSupports:
             or _uses_te_attention(model)
             or _uses_magi_attention(model)
             or (self.supports_thd and backend_attn == "tilelang")
+            # Models that build their own per-document masks (Kimi Linear's
+            # document-blocked causal mask plus per-document KDA ``cu_seqlens``)
+            # need no packing-aware attention backend.
+            or getattr(model, "_owns_packed_attention", False)
         )
         return _supports_seq_lens(model) and sp_attn_backend
 
@@ -337,11 +347,15 @@ class ModelSupports:
         MagiAttention dispatches the packed sequence across the CP group with its
         own load-balancing solver and a per-document varlen mask, so it supports
         CP + packing (see ``magi_attn_utils.magi_prepare_packed_cp``). Models
-        with native THD support own their packed CP path in TileLang attention."""
+        with native THD support own their packed CP path in TileLang attention.
+        Models that own their CP end to end (``_owns_cp_attention``) shard the
+        packed batch themselves and carry document boundaries into every layer."""
         model = self._model
         if not self.supports_sequence_packing:
             return False
         if self.cp_size <= 1:
+            return True
+        if getattr(model, "_owns_cp_attention", False):
             return True
         if self.supports_thd:
             backend_attn = getattr(getattr(model, "backend", None), "attn", None)

--- a/nemo_automodel/_transformers/registry.py
+++ b/nemo_automodel/_transformers/registry.py
@@ -110,6 +110,10 @@ MODEL_ARCH_MAPPING = OrderedDict(
             ("nemo_automodel.components.models.kimivl.model", "KimiVLForConditionalGeneration"),
         ),
         (
+            "KimiLinearForCausalLM",
+            ("nemo_automodel.components.models.kimi_linear.model", "KimiLinearForCausalLM"),
+        ),
+        (
             "LlamaBidirectionalForSequenceClassification",
             (
                 "nemo_automodel.components.models.llama_bidirectional.model",
@@ -288,6 +292,7 @@ _CUSTOM_CONFIG_REGISTRATIONS: Dict[str, Tuple[str, str]] = {
     "hy_v3": ("nemo_automodel.components.models.hy_v3.config", "HYV3Config"),
     "kimi_k2": ("nemo_automodel.components.models.kimi_k2.config", "KimiK2Config"),
     "kimi_k25": ("nemo_automodel.components.models.kimi_k25_vl.model", "KimiK25VLConfig"),
+    "kimi_linear": ("nemo_automodel.components.models.kimi_linear.config", "KimiLinearConfig"),
     "kimi_vl": ("nemo_automodel.components.models.kimivl.model", "KimiVLConfig"),
     "llavaonevision1_5": ("nemo_automodel.components.models.llava_onevision.model", "Llavaonevision1_5Config"),
     "mimo_v2_flash": ("nemo_automodel.components.models.mimo_v2_flash.config", "MiMoV2FlashConfig"),

--- a/nemo_automodel/components/distributed/optimized_tp_plans.py
+++ b/nemo_automodel/components/distributed/optimized_tp_plans.py
@@ -718,6 +718,24 @@ def _parallelize_falcon_h1(
     )
 
 
+def _parallelize_kimi_linear(
+    model,
+    sequence_parallel: bool = False,
+) -> Dict[str, ParallelStyle]:
+    """Parallelize Kimi Linear (hybrid KDA linear attention + MLA full attention).
+
+    Unlike Qwen3.5 and Falcon-H1, whose linear-attention branches stay
+    replicated, Kimi Linear shards KDA over its heads as well: the delta rule
+    treats heads independently, so the projections, depthwise convolutions and
+    per-head decay parameters all follow the head axis. Routed experts remain
+    owned by expert parallelism. See
+    ``nemo_automodel.components.models.kimi_linear.tp`` for the plan itself.
+    """
+    from nemo_automodel.components.models.kimi_linear.tp import parallelize_kimi_linear
+
+    return parallelize_kimi_linear(model, sequence_parallel=sequence_parallel)
+
+
 # Keyed by qualified class name — see _get_class_qualname for why.
 PARALLELIZE_FUNCTIONS: Dict[str, Callable[..., Dict[str, ParallelStyle]]] = {
     _get_class_qualname(BaichuanForCausalLM): _parallelize_baichuan,
@@ -756,6 +774,10 @@ PARALLELIZE_FUNCTIONS: Dict[str, Callable[..., Dict[str, ParallelStyle]]] = {
     _get_class_qualname(CustomQwen2ForCausalLM): _parallelize_qwen,
     # trust_remote_code models — matched by bare class __name__ in parallelizer
     # because their qualname includes a snapshot-hash-bearing module path.
+    # Custom MoE with hybrid attention; the only custom-MoE architecture with a
+    # tensor-parallel plan, so routed-expert ownership stays with EP.
+    "nemo_automodel.components.models.kimi_linear.model.KimiLinearForCausalLM": _parallelize_kimi_linear,
+    "KimiLinearForCausalLM": _parallelize_kimi_linear,
     "DeciLMForCausalLM": _parallelize_decilm_nemotron,
     "NemotronLabsDiffusionModel": _parallelize_nemotron_labs_diffusion,
 }

--- a/nemo_automodel/components/models/kimi_linear/__init__.py
+++ b/nemo_automodel/components/models/kimi_linear/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/nemo_automodel/components/models/kimi_linear/config.py
+++ b/nemo_automodel/components/models/kimi_linear/config.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Configuration for Moonshot Kimi Linear checkpoints."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from transformers.configuration_utils import PretrainedConfig
+
+
+class KimiLinearConfig(PretrainedConfig):
+    """HF-compatible configuration for Kimi Linear causal LM checkpoints."""
+
+    model_type = "kimi_linear"
+    keys_to_ignore_at_inference = ["past_key_values"]
+
+    def __init__(
+        self,
+        model_type: str = "kimi_linear",
+        vocab_size: int = 163840,
+        hidden_size: int = 4096,
+        head_dim: int | None = None,
+        intermediate_size: int = 11008,
+        num_hidden_layers: int = 32,
+        num_attention_heads: int = 32,
+        num_key_value_heads: int | None = None,
+        hidden_act: str = "silu",
+        initializer_range: float = 0.02,
+        rms_norm_eps: float = 1e-6,
+        use_cache: bool = True,
+        pad_token_id: int = 0,
+        bos_token_id: int = 1,
+        eos_token_id: int = 2,
+        rope_theta: float = 10000.0,
+        rope_scaling: dict[str, Any] | None = None,
+        tie_word_embeddings: bool = False,
+        moe_intermediate_size: int | None = None,
+        moe_renormalize: bool = True,
+        moe_router_activation_func: str = "sigmoid",
+        num_experts: int | None = None,
+        num_experts_per_token: int | None = None,
+        num_shared_experts: int = 0,
+        routed_scaling_factor: float = 1.0,
+        first_k_dense_replace: int = 0,
+        moe_layer_freq: int = 1,
+        use_grouped_topk: bool = True,
+        num_expert_group: int = 1,
+        topk_group: int = 1,
+        q_lora_rank: int | None = None,
+        kv_lora_rank: int | None = None,
+        qk_nope_head_dim: int | None = None,
+        qk_rope_head_dim: int | None = None,
+        v_head_dim: int | None = None,
+        mla_use_nope: bool | None = False,
+        num_nextn_predict_layers: int = 0,
+        linear_attn_config: dict[str, Any] | None = None,
+        kda_mode: str = "chunk",
+        kda_unpad_inputs: bool = True,
+        kda_use_fused_gate: bool = True,
+        kda_use_qk_l2norm_in_kernel: bool = True,
+        **kwargs: Any,
+    ) -> None:
+        self.model_type = model_type
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.head_dim = head_dim if head_dim is not None else hidden_size // num_attention_heads
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.num_key_value_heads = num_attention_heads if num_key_value_heads is None else num_key_value_heads
+        self.hidden_act = hidden_act
+        self.initializer_range = initializer_range
+        self.rms_norm_eps = rms_norm_eps
+        self.use_cache = use_cache
+        self.rope_theta = rope_theta
+        self.rope_scaling = rope_scaling
+
+        self.q_lora_rank = q_lora_rank
+        self.kv_lora_rank = kv_lora_rank
+        self.qk_nope_head_dim = qk_nope_head_dim
+        self.qk_rope_head_dim = qk_rope_head_dim
+        self.v_head_dim = v_head_dim
+        self.mla_use_nope = mla_use_nope
+
+        self.num_experts = num_experts
+        self.num_experts_per_token = num_experts_per_token
+        self.moe_renormalize = moe_renormalize
+        self.num_shared_experts = num_shared_experts
+        self.routed_scaling_factor = routed_scaling_factor
+        self.moe_router_activation_func = moe_router_activation_func
+        if self.moe_router_activation_func not in ("softmax", "sigmoid"):
+            raise ValueError("moe_router_activation_func must be 'softmax' or 'sigmoid'.")
+        self.moe_intermediate_size = moe_intermediate_size
+        self.first_k_dense_replace = first_k_dense_replace
+        self.moe_layer_freq = moe_layer_freq
+        self.use_grouped_topk = use_grouped_topk
+        self.num_expert_group = num_expert_group
+        self.topk_group = topk_group
+        self.num_nextn_predict_layers = num_nextn_predict_layers
+        if kda_mode not in ("chunk", "fused_recurrent"):
+            raise ValueError("kda_mode must be 'chunk' or 'fused_recurrent'.")
+        self.kda_mode = kda_mode
+        self.kda_unpad_inputs = kda_unpad_inputs
+        self.kda_use_fused_gate = kda_use_fused_gate
+        self.kda_use_qk_l2norm_in_kernel = kda_use_qk_l2norm_in_kernel
+
+        if linear_attn_config is not None:
+            if linear_attn_config.get("kda_layers") is None or linear_attn_config.get("full_attn_layers") is None:
+                raise ValueError("linear_attn_config must define kda_layers and full_attn_layers.")
+        self.linear_attn_config = linear_attn_config
+
+        super().__init__(
+            pad_token_id=pad_token_id,
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
+            tie_word_embeddings=tie_word_embeddings,
+            **kwargs,
+        )
+
+    @property
+    def is_mla(self) -> bool:
+        """Return whether full-attention layers use Kimi MLA projection fields."""
+        return (
+            self.q_lora_rank is not None
+            or self.kv_lora_rank is not None
+            or self.qk_nope_head_dim is not None
+            or self.qk_rope_head_dim is not None
+            or self.v_head_dim is not None
+            or self.mla_use_nope is True
+        )
+
+    @property
+    def is_moe(self) -> bool:
+        """Return whether the checkpoint config declares routed experts."""
+        return self.num_experts is not None
+
+    @property
+    def is_linear_attn(self) -> bool:
+        """Return whether any decoder layer uses Kimi Delta Attention."""
+        return not (
+            self.linear_attn_config is None
+            or (
+                isinstance(self.linear_attn_config, dict)
+                and self.linear_attn_config.get("kda_layers") is not None
+                and len(self.linear_attn_config["kda_layers"]) == 0
+            )
+        )
+
+    def is_kda_layer(self, layer_idx: int) -> bool:
+        """Return whether a zero-based layer index is configured as KDA."""
+        return self.linear_attn_config is not None and (layer_idx + 1) in self.linear_attn_config["kda_layers"]

--- a/nemo_automodel/components/models/kimi_linear/cp.py
+++ b/nemo_automodel/components/models/kimi_linear/cp.py
@@ -1,0 +1,520 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Context-parallel and packed-sequence support for Kimi Linear.
+
+Kimi Linear interleaves KDA linear-attention layers with MLA full-attention
+layers, so context parallelism has to satisfy both at once:
+
+* KDA carries a sequential recurrent state, so FLA's context-parallel kernels
+  require every rank to own one **contiguous** slice of the global token stream
+  (rank ``r`` owns ``[r * S / cp, (r + 1) * S / cp)``) and take document
+  boundaries through ``cu_seqlens``. PyTorch's default load-balanced
+  ``context_parallel`` layout (head/tail chunk swap) does not satisfy that, so
+  Kimi Linear owns its batch sharding through ``_cp_make_batch_fn``.
+* MLA attends globally. Under the contiguous layout each rank all-gathers the
+  *compressed* KV latent (``kv_lora_rank + qk_rope_head_dim`` values per token,
+  roughly an order of magnitude smaller than the expanded per-head K/V) and runs
+  FlexAttention with a causal, per-document block mask against the full-sequence
+  keys.
+
+Everything is driven by one ``[batch, sequence]`` document-id map (``0`` marks
+padding, ``1..n`` are 1-based document indices), which is also what makes packed
+sequences work with and without CP.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+
+_PAD_DOC_ID = 0
+
+
+@dataclass
+class KimiPackedContext:
+    """Per-step document layout shared by the KDA and MLA layers.
+
+    Attributes:
+        doc_ids: Global document ids of shape [batch, sequence] covering the full
+            (unsharded) sequence, where 0 marks padding.
+        seq_start: Global sequence offset of the local shard; 0 without CP.
+        cp_size: Number of context-parallel shards the global sequence was split into.
+    """
+
+    doc_ids: torch.Tensor
+    seq_start: int = 0
+    cp_size: int = 1
+
+    def __post_init__(self) -> None:
+        self._cu_seqlens: dict[int, tuple[torch.Tensor, torch.Tensor]] = {}
+
+    @property
+    def cp_enabled(self) -> bool:
+        """Whether the batch was sharded across a context-parallel mesh."""
+        return self.cp_size > 1
+
+    @property
+    def local_doc_ids(self) -> torch.Tensor:
+        """Document ids of shape [batch, local_sequence] for this rank's shard."""
+        if not self.cp_enabled:
+            return self.doc_ids
+        local_len = self.doc_ids.shape[1] // self.cp_size
+        return self.doc_ids[:, self.seq_start : self.seq_start + local_len]
+
+    def row_cu_seqlens(self, row: int) -> tuple[torch.Tensor, torch.Tensor]:
+        """Return the global segment boundaries of one batch row.
+
+        Computed on first use (and cached for the step) because the device-to-host
+        copy is only needed by the context-parallel path.
+
+        Args:
+            row: Batch row to describe.
+
+        Returns:
+            The device and CPU copies of the row's cumulative segment lengths, each
+            of shape [segments + 1].
+        """
+        cached = self._cu_seqlens.get(row)
+        if cached is None:
+            cu_seqlens = segment_cu_seqlens(self.doc_ids[row]).to(torch.long)
+            cached = (cu_seqlens, cu_seqlens.cpu())
+            self._cu_seqlens[row] = cached
+        return cached
+
+
+def doc_ids_from_attention_mask(attention_mask: torch.Tensor) -> torch.Tensor:
+    """Build document ids from a binary or indexed attention mask.
+
+    Args:
+        attention_mask: Tensor of shape [batch, sequence]. A binary mask marks
+            valid tokens with 1; an Automodel packing mask marks document ``i``
+            (1-based) with the value ``i`` and padding with 0.
+
+    Returns:
+        Tensor of shape [batch, sequence] with 1-based document ids and 0 for
+        padding.
+    """
+    return attention_mask.to(torch.int32)
+
+
+def doc_ids_from_seq_lens(seq_lens: torch.Tensor, seq_len: int, *, padding_value: int = -1000) -> torch.Tensor:
+    """Build document ids from the packed-sequence collater's ``seq_lens``.
+
+    Args:
+        seq_lens: Tensor of shape [batch, packs] with per-pack token counts, using
+            ``padding_value`` for unused pack slots.
+        seq_len: Sequence length of the batch's token tensors.
+        padding_value: Sentinel marking unused pack slots.
+
+    Returns:
+        Tensor of shape [batch, sequence] with 1-based document ids and 0 for the
+        trailing positions not covered by any pack.
+    """
+    batch_size = seq_lens.shape[0]
+    doc_ids = torch.zeros((batch_size, seq_len), dtype=torch.int32, device=seq_lens.device)
+    for row in range(batch_size):
+        lengths = seq_lens[row]
+        lengths = lengths[lengths != padding_value]
+        offset = 0
+        for doc_index, length in enumerate(lengths.tolist()):
+            if length <= 0:
+                continue
+            end = min(offset + length, seq_len)
+            doc_ids[row, offset:end] = doc_index + 1
+            offset = end
+    return doc_ids
+
+
+def doc_ids_from_cu_seqlens(cu_seqlens: torch.Tensor, seq_len: int) -> torch.Tensor:
+    """Build single-row document ids from cumulative sequence lengths.
+
+    Args:
+        cu_seqlens: Tensor of shape [segments + 1] with cumulative token counts.
+            THD batches pad unused entries with a negative sentinel, which is
+            dropped here.
+        seq_len: Sequence length of the batch's token tensors.
+
+    Returns:
+        Tensor of shape [1, sequence] with 1-based document ids and 0 for the
+        trailing positions not covered by ``cu_seqlens``.
+    """
+    boundaries = cu_seqlens.to(torch.long)
+    boundaries = boundaries[boundaries >= 0]
+    positions = torch.arange(seq_len, device=cu_seqlens.device)
+    doc_ids = torch.bucketize(positions, boundaries[1:], right=True) + 1
+    doc_ids = torch.where(positions < boundaries[-1], doc_ids, torch.zeros_like(doc_ids))
+    return doc_ids.to(torch.int32).unsqueeze(0)
+
+
+def segment_cu_seqlens(doc_ids_row: torch.Tensor) -> torch.Tensor:
+    """Return segment boundaries for one row of document ids.
+
+    Consecutive runs of the same id -- including runs of padding -- become their
+    own segment so that the boundaries always tile the full row, which is what
+    FLA's context-parallel partitioning expects.
+
+    Args:
+        doc_ids_row: Tensor of shape [sequence] with 1-based document ids.
+
+    Returns:
+        Tensor of shape [segments + 1] with cumulative segment lengths.
+    """
+    seq_len = doc_ids_row.shape[0]
+    if seq_len == 0:
+        return torch.zeros(1, dtype=torch.int32, device=doc_ids_row.device)
+    changed = doc_ids_row[1:] != doc_ids_row[:-1]
+    starts = torch.nonzero(changed, as_tuple=False).flatten() + 1
+    zero = torch.zeros(1, dtype=starts.dtype, device=doc_ids_row.device)
+    end = torch.full((1,), seq_len, dtype=starts.dtype, device=doc_ids_row.device)
+    return torch.cat((zero, starts, end)).to(torch.int32)
+
+
+def build_fla_cp_context(
+    packed_context: KimiPackedContext,
+    row: int,
+    cp_group: Any,
+    conv_kernel_size: int,
+):
+    """Build FLA's per-row context-parallel context for a KDA layer.
+
+    Args:
+        packed_context: Context describing the global document layout.
+        row: Batch row the context is built for.
+        cp_group: Context-parallel process group.
+        conv_kernel_size: Short-convolution kernel size, used by FLA to exchange
+            the conv boundary tokens between neighbouring ranks.
+
+    Returns:
+        The FLA ``FLACPContext`` for this row.
+    """
+    from fla.ops.cp import build_cp_context
+
+    cu_seqlens, cu_seqlens_cpu = packed_context.row_cu_seqlens(row)
+    return build_cp_context(
+        cu_seqlens=cu_seqlens,
+        group=cp_group,
+        conv1d_kernel_size=conv_kernel_size,
+        cu_seqlens_cpu=cu_seqlens_cpu,
+    )
+
+
+class _AllGatherSequence(torch.autograd.Function):
+    """Autograd-aware all-gather of equal-sized shards along the sequence axis."""
+
+    @staticmethod
+    def forward(ctx, local_tensor: torch.Tensor, group: Any, dim: int) -> torch.Tensor:
+        dim = dim if dim >= 0 else local_tensor.ndim + dim
+        world_size = dist.get_world_size(group)
+        local_tensor = local_tensor.contiguous()
+        gathered = [torch.empty_like(local_tensor) for _ in range(world_size)]
+        dist.all_gather(gathered, local_tensor, group=group)
+        ctx.group = group
+        ctx.dim = dim
+        ctx.rank = dist.get_rank(group)
+        ctx.local_size = local_tensor.size(dim)
+        return torch.cat(gathered, dim=dim)
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        grad_full = grad_output.contiguous()
+        dist.all_reduce(grad_full, op=dist.ReduceOp.SUM, group=ctx.group)
+        start = ctx.rank * ctx.local_size
+        return grad_full.narrow(ctx.dim, start, ctx.local_size).contiguous(), None, None
+
+
+def all_gather_sequence(tensor: torch.Tensor, cp_group: Any, *, dim: int = 1) -> torch.Tensor:
+    """All-gather a sequence-sharded tensor while keeping autograd connected.
+
+    Args:
+        tensor: Tensor of shape [..., local_sequence, ...] whose sequence axis is
+            selected by ``dim``. Every rank must contribute the same shape.
+        cp_group: Context-parallel process group.
+        dim: Sequence axis.
+
+    Returns:
+        Tensor with the sequence axis expanded to the full global sequence.
+    """
+    return _AllGatherSequence.apply(tensor, cp_group, dim)
+
+
+def build_document_causal_mask(
+    q_doc_ids: torch.Tensor,
+    kv_doc_ids: torch.Tensor,
+    *,
+    q_global_start: int,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Build the additive causal mask that also blocks cross-document attention.
+
+    Args:
+        q_doc_ids: Tensor of shape [batch, query_sequence] with 1-based document ids.
+        kv_doc_ids: Tensor of shape [batch, key_sequence] with 1-based document ids.
+        q_global_start: Global sequence offset of the first query token.
+        dtype: Floating-point dtype used for the additive mask values.
+
+    Returns:
+        Additive mask tensor of shape [batch, 1, query_sequence, key_sequence].
+    """
+    device = q_doc_ids.device
+    q_positions = torch.arange(q_doc_ids.shape[1], device=device) + q_global_start
+    kv_positions = torch.arange(kv_doc_ids.shape[1], device=device)
+    allowed = kv_positions[None, :] <= q_positions[:, None]
+    allowed = allowed[None, :, :] & (q_doc_ids[:, :, None] == kv_doc_ids[:, None, :]) & (kv_doc_ids[:, None, :] > 0)
+    # A padding query has no document to attend to; let it read position 0 so the
+    # softmax stays finite. Its output is discarded by the loss mask.
+    is_padding_query = (q_doc_ids <= _PAD_DOC_ID)[:, :, None]
+    allowed = torch.where(is_padding_query, kv_positions[None, None, :] == 0, allowed)
+    min_value = torch.finfo(dtype).min
+    return torch.zeros(allowed.shape, dtype=dtype, device=device).masked_fill_(~allowed, min_value).unsqueeze(1)
+
+
+_BLOCK_MASK_CACHE: dict[tuple, Any] = {}
+_BLOCK_MASK_GENERATION: list[Any] = [None, None]
+
+
+def _block_mask_cache_generation(doc_ids: torch.Tensor) -> None:
+    """Drop cached block masks when a new batch (new document map) arrives."""
+    pointer = doc_ids.data_ptr()
+    if pointer != _BLOCK_MASK_GENERATION[0]:
+        _BLOCK_MASK_CACHE.clear()
+        _BLOCK_MASK_GENERATION[0] = pointer
+        # Hold the tensor so the allocator cannot recycle the address mid-step.
+        _BLOCK_MASK_GENERATION[1] = doc_ids
+
+
+def _document_causal_block_mask(
+    q_doc_ids: torch.Tensor,
+    kv_doc_ids: torch.Tensor,
+    *,
+    q_global_start: int,
+):
+    """Build (and cache for the step) the FlexAttention document-causal block mask."""
+    from torch.nn.attention.flex_attention import create_block_mask
+
+    _block_mask_cache_generation(q_doc_ids)
+    key = (
+        int(q_global_start),
+        int(q_doc_ids.shape[0]),
+        int(q_doc_ids.shape[1]),
+        int(kv_doc_ids.shape[1]),
+        q_doc_ids.device.type,
+        q_doc_ids.device.index,
+    )
+    cached = _BLOCK_MASK_CACHE.get(key)
+    if cached is not None:
+        return cached
+
+    def mask_mod(batch_idx, head_idx, q_idx, kv_idx):
+        q_doc = q_doc_ids[batch_idx, q_idx]
+        kv_doc = kv_doc_ids[batch_idx, kv_idx]
+        allowed = (kv_idx <= q_idx + q_global_start) & (q_doc == kv_doc) & (kv_doc > _PAD_DOC_ID)
+        return torch.where(q_doc <= _PAD_DOC_ID, kv_idx == 0, allowed)
+
+    block_mask = create_block_mask(
+        mask_mod,
+        B=q_doc_ids.shape[0],
+        H=None,
+        Q_LEN=q_doc_ids.shape[1],
+        KV_LEN=kv_doc_ids.shape[1],
+        device=q_doc_ids.device,
+    )
+    if len(_BLOCK_MASK_CACHE) >= 64:
+        _BLOCK_MASK_CACHE.pop(next(iter(_BLOCK_MASK_CACHE)))
+    _BLOCK_MASK_CACHE[key] = block_mask
+    return block_mask
+
+
+_COMPILED_FLEX_ATTENTION: list[Any] = [None]
+
+
+def _compiled_flex_attention():
+    if _COMPILED_FLEX_ATTENTION[0] is None:
+        from torch.nn.attention.flex_attention import flex_attention
+
+        _COMPILED_FLEX_ATTENTION[0] = torch.compile(flex_attention, dynamic=True)
+    return _COMPILED_FLEX_ATTENTION[0]
+
+
+def document_causal_flex_attention(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    *,
+    q_doc_ids: torch.Tensor,
+    kv_doc_ids: torch.Tensor,
+    q_global_start: int,
+    scale: float,
+) -> torch.Tensor:
+    """Run causal, per-document attention of local queries against global keys.
+
+    Args:
+        query: Tensor of shape [batch, heads, query_sequence, qk_head_dim].
+        key: Tensor of shape [batch, heads, key_sequence, qk_head_dim].
+        value: Tensor of shape [batch, heads, key_sequence, v_head_dim].
+        q_doc_ids: Tensor of shape [batch, query_sequence] with 1-based document ids.
+        kv_doc_ids: Tensor of shape [batch, key_sequence] with 1-based document ids.
+        q_global_start: Global sequence offset of the first query token.
+        scale: Softmax scale applied to the query-key product.
+
+    Returns:
+        Tensor of shape [batch, heads, query_sequence, v_head_dim].
+    """
+    block_mask = _document_causal_block_mask(q_doc_ids, kv_doc_ids, q_global_start=q_global_start)
+
+    qk_head_dim = query.shape[-1]
+    v_head_dim = value.shape[-1]
+    # FlexAttention kernels require power-of-two head dims; MLA's 192/128 split
+    # is padded here and trimmed back off the output.
+    padded_qk = 1 << (qk_head_dim - 1).bit_length()
+    padded_v = 1 << (v_head_dim - 1).bit_length()
+    if padded_qk != qk_head_dim:
+        query = F.pad(query, (0, padded_qk - qk_head_dim))
+        key = F.pad(key, (0, padded_qk - qk_head_dim))
+    if padded_v != v_head_dim:
+        value = F.pad(value, (0, padded_v - v_head_dim))
+
+    output = _compiled_flex_attention()(
+        query.contiguous(),
+        key.contiguous(),
+        value.contiguous(),
+        block_mask=block_mask,
+        scale=scale,
+    )
+    if padded_v != v_head_dim:
+        output = output[..., :v_head_dim]
+    return output.masked_fill((q_doc_ids <= _PAD_DOC_ID)[:, None, :, None], 0)
+
+
+def _pad_sequence_dim(tensor: torch.Tensor, seq_dim: int, pad_len: int, value: float | int) -> torch.Tensor:
+    if pad_len <= 0:
+        return tensor
+    pad_shape = list(tensor.shape)
+    pad_shape[seq_dim] = pad_len
+    pad = torch.full(pad_shape, value, dtype=tensor.dtype, device=tensor.device)
+    return torch.cat((tensor, pad), dim=seq_dim)
+
+
+def _pad_position_ids(position_ids: torch.Tensor, seq_dim: int, pad_len: int) -> torch.Tensor:
+    if pad_len <= 0:
+        return position_ids
+    last = position_ids.select(seq_dim, position_ids.shape[seq_dim] - 1).unsqueeze(seq_dim)
+    increment_shape = [1] * position_ids.ndim
+    increment_shape[seq_dim] = pad_len
+    increments = torch.arange(1, pad_len + 1, device=position_ids.device, dtype=position_ids.dtype).view(
+        increment_shape
+    )
+    return torch.cat((position_ids, last + increments), dim=seq_dim)
+
+
+def _global_doc_ids_from_batch(batch: dict, seq_len: int, device: torch.device) -> torch.Tensor:
+    """Resolve the global document-id map for a batch about to be CP-sharded."""
+    attention_mask = batch.get("attention_mask")
+    if attention_mask is not None and attention_mask.ndim == 2:
+        return doc_ids_from_attention_mask(attention_mask)
+
+    seq_lens = batch.get("seq_lens_padded", batch.get("seq_lens"))
+    if seq_lens is not None:
+        return doc_ids_from_seq_lens(seq_lens, seq_len)
+
+    batch_size = batch["input_ids"].shape[0]
+    doc_ids = torch.ones((batch_size, seq_len), dtype=torch.int32, device=device)
+    padding_mask = batch.get("padding_mask")
+    if padding_mask is not None:
+        doc_ids = doc_ids.masked_fill(padding_mask.bool(), _PAD_DOC_ID)
+    return doc_ids
+
+
+def shard_batch_for_kimi_cp(cp_mesh, tp_mesh, batch: dict, *, loss_mask=None, padding_token_id: int = 0):
+    """Shard a batch contiguously across the context-parallel mesh for Kimi Linear.
+
+    Attached to the batch as ``_cp_make_batch_fn`` by
+    :meth:`KimiLinearForCausalLM.prepare_model_inputs_for_cp` and invoked by
+    ``cp_utils.make_cp_batch_and_ctx`` instead of the default load-balanced
+    ``context_parallel`` path. Every rank starts from the same full batch, keeps
+    the ``[seq_start, seq_end)`` slice of each sequence-aligned tensor, and gets
+    the (unsharded) global document-id map needed by the KDA and MLA layers.
+
+    Args:
+        cp_mesh: One-dimensional context-parallel mesh, or None.
+        tp_mesh: Tensor-parallel mesh; unused, accepted for interface parity.
+        batch: Batch mapping containing ``input_ids`` of shape [batch, sequence]
+            plus ``labels`` and optional sequence-aligned tensors.
+        loss_mask: Optional tensor of shape [batch, sequence] sharded with the labels.
+        padding_token_id: Token id used when padding ``input_ids``.
+
+    Returns:
+        A pair of ``(context_factory, batch)``; the context factory is a null
+        context because the transport lives in the Kimi Linear layers themselves.
+    """
+    del tp_mesh
+    cp_size = 1 if cp_mesh is None else cp_mesh.size()
+    input_ids = batch["input_ids"]
+    seq_len = input_ids.shape[1]
+    device = input_ids.device
+
+    doc_ids = _global_doc_ids_from_batch(batch, seq_len, device)
+    # The 4D/indexed mask no longer matches the sharded sequence; document
+    # boundaries travel through the document-id map instead.
+    batch.pop("attention_mask", None)
+    for key in ("seq_lens", "seq_lens_padded", "cu_seqlens", "cu_seqlens_padded", "max_seqlen", "qkv_format"):
+        batch.pop(key, None)
+
+    if "position_ids" not in batch:
+        batch["position_ids"] = (
+            torch.arange(seq_len, device=device).unsqueeze(0).expand(input_ids.shape[0], -1).contiguous()
+        )
+    elif batch["position_ids"].ndim == 2 and batch["position_ids"].shape[0] == 1 and input_ids.shape[0] > 1:
+        batch["position_ids"] = batch["position_ids"].expand(input_ids.shape[0], -1).contiguous()
+
+    pad_len = (-seq_len) % cp_size
+    if pad_len:
+        pad_values = {"input_ids": padding_token_id, "labels": -100, "padding_mask": True}
+        for key, pad_value in pad_values.items():
+            if key in batch:
+                batch[key] = _pad_sequence_dim(batch[key], 1, pad_len, pad_value)
+        batch["position_ids"] = _pad_position_ids(batch["position_ids"], 1, pad_len)
+        doc_ids = _pad_sequence_dim(doc_ids, 1, pad_len, _PAD_DOC_ID)
+        if loss_mask is not None:
+            loss_mask = _pad_sequence_dim(loss_mask, 1, pad_len, 0)
+        seq_len += pad_len
+
+    # The MoE router needs to know which tokens are padding; the packed collater
+    # encodes that only in the document map, so mirror it into ``padding_mask``.
+    batch.setdefault("padding_mask", doc_ids <= _PAD_DOC_ID)
+
+    batch["kimi_packed_context"] = KimiPackedContext(
+        doc_ids=doc_ids,
+        seq_start=0 if cp_mesh is None else cp_mesh.get_local_rank() * (seq_len // cp_size),
+        cp_size=cp_size,
+    )
+
+    if cp_size > 1:
+        local_seq_len = seq_len // cp_size
+        seq_start = batch["kimi_packed_context"].seq_start
+        seq_end = seq_start + local_seq_len
+        for key in ("input_ids", "labels", "position_ids", "padding_mask"):
+            if key in batch:
+                batch[key] = batch[key][:, seq_start:seq_end].contiguous()
+        if loss_mask is not None:
+            batch["loss_mask"] = loss_mask[:, seq_start:seq_end].contiguous()
+    elif loss_mask is not None:
+        batch["loss_mask"] = loss_mask
+
+    return contextlib.nullcontext, batch

--- a/nemo_automodel/components/models/kimi_linear/model.py
+++ b/nemo_automodel/components/models/kimi_linear/model.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import copy
 import inspect
 import math
 from dataclasses import dataclass
@@ -914,7 +915,7 @@ class KimiLinearForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
         super().__init__()
         reject_unsupported_tie_word_embeddings(type(self), config)
         self.config = config
-        self.backend = backend or BackendConfig()
+        self.backend = copy.copy(backend) if backend is not None else BackendConfig()
         if self.backend.gate_precision is None:
             self.backend.gate_precision = torch.float32
         moe_overrides = kwargs.pop("moe_overrides", None)

--- a/nemo_automodel/components/models/kimi_linear/model.py
+++ b/nemo_automodel/components/models/kimi_linear/model.py
@@ -84,7 +84,17 @@ def _fused_kda_gate(g: torch.Tensor, a_log: torch.Tensor, head_dim: int, dt_bias
 
 
 def _torch_kda_gate(g: torch.Tensor, a_log: torch.Tensor, head_dim: int, dt_bias: torch.Tensor) -> torch.Tensor:
-    """Torch equivalent of FLA's KDA gate."""
+    """Torch equivalent of FLA's KDA gate.
+
+    Args:
+        g: Tensor of shape [batch, sequence, heads * head_dim] or [batch, sequence, heads, head_dim].
+        a_log: Tensor of shape [1, 1, heads, 1].
+        head_dim: Per-head KDA dimension.
+        dt_bias: Tensor of shape [heads * head_dim].
+
+    Returns:
+        Tensor of shape [batch, sequence, heads, head_dim].
+    """
     gate = g if g.shape[-1] == head_dim else g.reshape(*g.shape[:-1], -1, head_dim)
     num_heads = gate.shape[-2]
     gate = gate.float() + dt_bias.float().view(num_heads, head_dim)
@@ -92,6 +102,15 @@ def _torch_kda_gate(g: torch.Tensor, a_log: torch.Tensor, head_dim: int, dt_bias
 
 
 def _index_first_axis(x: torch.Tensor, indices: torch.Tensor) -> torch.Tensor:
+    """Gather rows from the first axis while preserving trailing tensor layout.
+
+    Args:
+        x: Tensor of shape [tokens, ...], with arbitrary trailing axes.
+        indices: Tensor of shape [selected_tokens] containing first-axis row indices.
+
+    Returns:
+        Tensor of shape [selected_tokens, ...], with the same trailing axes as ``x``.
+    """
     other_shape = x.shape[1:]
     return (
         x.reshape(x.shape[0], -1)
@@ -101,12 +120,31 @@ def _index_first_axis(x: torch.Tensor, indices: torch.Tensor) -> torch.Tensor:
 
 
 def _index_put_first_axis(x: torch.Tensor, indices: torch.Tensor, first_axis_dim: int) -> torch.Tensor:
+    """Scatter rows into the first axis while preserving trailing tensor layout.
+
+    Args:
+        x: Tensor of shape [selected_tokens, ...], with arbitrary trailing axes.
+        indices: Tensor of shape [selected_tokens] containing destination row indices.
+        first_axis_dim: Size of the output first axis.
+
+    Returns:
+        Tensor of shape [first_axis_dim, ...], with the same trailing axes as ``x``.
+    """
     y = torch.zeros(first_axis_dim, *x.shape[1:], device=x.device, dtype=x.dtype)
     y[indices] = x
     return y
 
 
 def _get_unpad_data(attention_mask: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, int]:
+    """Build metadata for converting padded batches to flattened valid tokens.
+
+    Args:
+        attention_mask: Binary mask tensor of shape [batch, sequence] where 1 marks valid tokens.
+
+    Returns:
+        Tuple containing ``indices`` of shape [total_valid_tokens], ``cu_seqlens`` of shape [batch + 1],
+        and ``max_seqlen`` for the longest unpadded sequence.
+    """
     mask = attention_mask.bool()
     lengths = mask.sum(dim=-1, dtype=torch.int32)
     indices = torch.nonzero(mask.flatten(), as_tuple=False).flatten()
@@ -116,6 +154,17 @@ def _get_unpad_data(attention_mask: torch.Tensor) -> tuple[torch.Tensor, torch.T
 
 
 def _pad_input(hidden_states: torch.Tensor, indices: torch.Tensor, batch_size: int, seq_len: int) -> torch.Tensor:
+    """Restore flattened valid tokens to padded batch layout.
+
+    Args:
+        hidden_states: Tensor of shape [total_valid_tokens, ...], with arbitrary trailing axes.
+        indices: Tensor of shape [total_valid_tokens] containing flattened padded-batch row indices.
+        batch_size: Number of sequences in the padded output batch.
+        seq_len: Sequence length in the padded output batch.
+
+    Returns:
+        Tensor of shape [batch, sequence, ...], with the same trailing axes as ``hidden_states``.
+    """
     output = _index_put_first_axis(hidden_states, indices, batch_size * seq_len)
     return output.reshape(batch_size, seq_len, *hidden_states.shape[1:])
 
@@ -126,6 +175,16 @@ def _make_causal_mask(
     *,
     dtype: torch.dtype,
 ) -> torch.Tensor | None:
+    """Create the additive causal attention mask for padded full attention.
+
+    Args:
+        inputs_embeds: Tensor of shape [batch, sequence, hidden].
+        attention_mask: Optional binary mask tensor of shape [batch, sequence] where 1 marks valid tokens.
+        dtype: Floating-point dtype used for the additive mask values.
+
+    Returns:
+        Additive causal mask tensor of shape [batch, 1, sequence, sequence], or None.
+    """
     batch_size, seq_len = inputs_embeds.shape[:2]
     min_value = torch.finfo(dtype).min
     mask = torch.full((seq_len, seq_len), min_value, device=inputs_embeds.device, dtype=dtype)
@@ -159,27 +218,6 @@ class KimiRMSNorm(nn.Module):
         variance = hidden_states.pow(2).mean(-1, keepdim=True)
         hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
         return self.weight * hidden_states.to(input_dtype)
-
-    def reset_parameters(self) -> None:
-        nn.init.ones_(self.weight)
-
-
-class KimiRMSNormGated(nn.Module):
-    """Kimi sigmoid-gated RMSNorm with fp32 variance computation."""
-
-    def __init__(self, hidden_size: int, eps: float = 1e-6, dtype: torch.dtype = torch.bfloat16) -> None:
-        super().__init__()
-        self.weight = nn.Parameter(torch.ones(hidden_size, dtype=dtype))
-        self.variance_epsilon = eps
-
-    def forward(self, hidden_states: torch.Tensor, gate: torch.Tensor) -> torch.Tensor:
-        input_dtype = hidden_states.dtype
-        hidden_states = hidden_states.to(torch.float32)
-        variance = hidden_states.pow(2).mean(-1, keepdim=True)
-        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
-        hidden_states = hidden_states * self.weight.float()
-        hidden_states = hidden_states * gate.float().sigmoid()
-        return hidden_states.to(input_dtype)
 
     def reset_parameters(self) -> None:
         nn.init.ones_(self.weight)

--- a/nemo_automodel/components/models/kimi_linear/model.py
+++ b/nemo_automodel/components/models/kimi_linear/model.py
@@ -1,0 +1,964 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Native Automodel support for Moonshot Kimi Linear causal LM checkpoints."""
+
+from __future__ import annotations
+
+import inspect
+import math
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from transformers.modeling_outputs import CausalLMOutputWithPast
+
+from nemo_automodel.components.distributed.activation_checkpointing import unwrap_checkpoint_wrapper
+from nemo_automodel.components.models.common import BackendConfig, initialize_linear_module
+from nemo_automodel.components.models.common.hf_checkpointing_mixin import HFCheckpointingMixin
+from nemo_automodel.components.models.common.tie_word_embeddings import (
+    TieSupport,
+    reject_unsupported_tie_word_embeddings,
+)
+from nemo_automodel.components.models.common.utils import cast_model_to_dtype, compute_lm_head_logits
+from nemo_automodel.components.models.kimi_linear.config import KimiLinearConfig
+from nemo_automodel.components.models.kimi_linear.state_dict_adapter import KimiLinearStateDictAdapter
+from nemo_automodel.components.moe.config import MoEConfig
+from nemo_automodel.components.moe.experts import GroupedExperts
+from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
+from nemo_automodel.components.moe.layers import MLP, MoE
+from nemo_automodel.components.utils.model_utils import squeeze_input_for_thd
+from nemo_automodel.shared.import_utils import UnavailableError, safe_import_from
+from nemo_automodel.shared.utils import dtype_from_str as get_dtype
+
+_FLA_MSG = "Kimi Linear requires the flash-linear-attention/fla extra. Install with `uv sync --extra fla`."
+_SHORT_CONV_OK, ShortConvolution = safe_import_from("fla.modules", "ShortConvolution", msg=_FLA_MSG)
+_FUSED_RMSNORM_GATED_OK, FusedRMSNormGated = safe_import_from(
+    "fla.modules",
+    "FusedRMSNormGated",
+    msg=_FLA_MSG,
+)
+_CHUNK_KDA_OK, chunk_kda = safe_import_from("fla.ops.kda", "chunk_kda", msg=_FLA_MSG)
+_RECURRENT_KDA_OK, fused_recurrent_kda = safe_import_from("fla.ops.kda", "fused_recurrent_kda", msg=_FLA_MSG)
+_KDA_GATE_OK, fused_kda_gate = safe_import_from("fla.ops.kda.gate", "fused_kda_gate", msg=_FLA_MSG)
+try:
+    _FUSED_KDA_GATE_HAS_G_BIAS = _KDA_GATE_OK and "g_bias" in inspect.signature(fused_kda_gate).parameters
+except (TypeError, ValueError):
+    _FUSED_KDA_GATE_HAS_G_BIAS = False
+
+
+def _require_fla() -> None:
+    if not all((_SHORT_CONV_OK, _FUSED_RMSNORM_GATED_OK, _CHUNK_KDA_OK, _RECURRENT_KDA_OK, _KDA_GATE_OK)):
+        raise UnavailableError(_FLA_MSG)
+
+
+def _fused_kda_gate(g: torch.Tensor, a_log: torch.Tensor, head_dim: int, dt_bias: torch.Tensor) -> torch.Tensor:
+    """Call FLA fused KDA gate across FLA versions.
+
+    Args:
+        g: Tensor of shape [batch, sequence, heads * head_dim].
+        a_log: Tensor of shape [1, 1, heads, 1].
+        head_dim: Per-head KDA dimension.
+        dt_bias: Tensor of shape [heads * head_dim].
+
+    Returns:
+        Tensor of shape [batch, sequence, heads, head_dim].
+    """
+    if _FUSED_KDA_GATE_HAS_G_BIAS:
+        return fused_kda_gate(g, a_log, head_dim, g_bias=dt_bias)
+    gate_input = g if g.shape[-1] == head_dim else g.reshape(*g.shape[:-1], -1, head_dim)
+    return fused_kda_gate(gate_input, a_log, dt_bias=dt_bias)
+
+
+def _torch_kda_gate(g: torch.Tensor, a_log: torch.Tensor, head_dim: int, dt_bias: torch.Tensor) -> torch.Tensor:
+    """Torch equivalent of FLA's KDA gate."""
+    gate = g if g.shape[-1] == head_dim else g.reshape(*g.shape[:-1], -1, head_dim)
+    num_heads = gate.shape[-2]
+    gate = gate.float() + dt_bias.float().view(num_heads, head_dim)
+    return -a_log.float().view(num_heads, 1).exp() * F.softplus(gate)
+
+
+def _index_first_axis(x: torch.Tensor, indices: torch.Tensor) -> torch.Tensor:
+    other_shape = x.shape[1:]
+    return (
+        x.reshape(x.shape[0], -1)
+        .gather(0, indices[:, None].expand(-1, math.prod(other_shape)))
+        .reshape(-1, *other_shape)
+    )
+
+
+def _index_put_first_axis(x: torch.Tensor, indices: torch.Tensor, first_axis_dim: int) -> torch.Tensor:
+    y = torch.zeros(first_axis_dim, *x.shape[1:], device=x.device, dtype=x.dtype)
+    y[indices] = x
+    return y
+
+
+def _get_unpad_data(attention_mask: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, int]:
+    mask = attention_mask.bool()
+    lengths = mask.sum(dim=-1, dtype=torch.int32)
+    indices = torch.nonzero(mask.flatten(), as_tuple=False).flatten()
+    max_seqlen = int(lengths.max().item())
+    cu_seqlens = F.pad(torch.cumsum(lengths, dim=0, dtype=torch.int32), (1, 0))
+    return indices, cu_seqlens, max_seqlen
+
+
+def _pad_input(hidden_states: torch.Tensor, indices: torch.Tensor, batch_size: int, seq_len: int) -> torch.Tensor:
+    output = _index_put_first_axis(hidden_states, indices, batch_size * seq_len)
+    return output.reshape(batch_size, seq_len, *hidden_states.shape[1:])
+
+
+def _make_causal_mask(
+    inputs_embeds: torch.Tensor,
+    attention_mask: torch.Tensor | None,
+    *,
+    dtype: torch.dtype,
+) -> torch.Tensor | None:
+    batch_size, seq_len = inputs_embeds.shape[:2]
+    min_value = torch.finfo(dtype).min
+    mask = torch.full((seq_len, seq_len), min_value, device=inputs_embeds.device, dtype=dtype)
+    mask = torch.triu(mask, diagonal=1)
+    mask = mask[None, None, :, :].expand(batch_size, 1, -1, -1)
+    if attention_mask is not None and attention_mask.ndim == 2:
+        padding = attention_mask[:, None, None, :].to(torch.bool)
+        mask = mask.masked_fill(~padding, min_value)
+    return mask
+
+
+class KimiRMSNorm(nn.Module):
+    """Kimi RMSNorm with fp32 variance computation."""
+
+    def __init__(self, hidden_size: int, eps: float = 1e-6, dtype: torch.dtype = torch.bfloat16) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size, dtype=dtype))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Normalize hidden states.
+
+        Args:
+            hidden_states: Tensor of shape [batch, sequence, hidden].
+
+        Returns:
+            Tensor of shape [batch, sequence, hidden].
+        """
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.to(torch.float32)
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        return self.weight * hidden_states.to(input_dtype)
+
+    def reset_parameters(self) -> None:
+        nn.init.ones_(self.weight)
+
+
+class KimiRMSNormGated(nn.Module):
+    """Kimi sigmoid-gated RMSNorm with fp32 variance computation."""
+
+    def __init__(self, hidden_size: int, eps: float = 1e-6, dtype: torch.dtype = torch.bfloat16) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size, dtype=dtype))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states: torch.Tensor, gate: torch.Tensor) -> torch.Tensor:
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.to(torch.float32)
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        hidden_states = hidden_states * self.weight.float()
+        hidden_states = hidden_states * gate.float().sigmoid()
+        return hidden_states.to(input_dtype)
+
+    def reset_parameters(self) -> None:
+        nn.init.ones_(self.weight)
+
+
+class KimiMLAAttention(nn.Module):
+    """Kimi MLA full-attention layer copied from the HF reference math."""
+
+    def __init__(self, config: KimiLinearConfig, layer_idx: int) -> None:
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+        self.hidden_size = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.num_key_value_heads = config.num_key_value_heads
+        self.num_key_value_groups = self.num_heads // self.num_key_value_heads
+        self.attention_dropout = getattr(config, "attention_dropout", 0.0)
+
+        if config.q_lora_rank is not None:
+            raise ValueError("Kimi Linear Automodel support currently expects q_lora_rank=None.")
+        self.qk_rope_head_dim = config.qk_rope_head_dim
+        self.kv_lora_rank = config.kv_lora_rank
+        self.v_head_dim = config.v_head_dim
+        self.qk_nope_head_dim = config.qk_nope_head_dim
+        self.q_head_dim = self.qk_nope_head_dim + self.qk_rope_head_dim
+        if not config.mla_use_nope:
+            raise ValueError("Kimi Linear Automodel support expects mla_use_nope=True.")
+        self.scaling = self.q_head_dim**-0.5
+
+        dtype = get_dtype(getattr(config, "torch_dtype", None), torch.bfloat16)
+        self.q_proj = nn.Linear(self.hidden_size, self.num_heads * self.q_head_dim, bias=False, dtype=dtype)
+        self.kv_a_proj_with_mqa = nn.Linear(
+            self.hidden_size,
+            self.kv_lora_rank + self.qk_rope_head_dim,
+            bias=False,
+            dtype=dtype,
+        )
+        self.kv_a_layernorm = KimiRMSNorm(self.kv_lora_rank, dtype=dtype)
+        self.kv_b_proj = nn.Linear(
+            self.kv_lora_rank,
+            self.num_heads * (self.q_head_dim - self.qk_rope_head_dim + self.v_head_dim),
+            bias=False,
+            dtype=dtype,
+        )
+        self.o_proj = nn.Linear(self.num_heads * self.v_head_dim, self.hidden_size, bias=False, dtype=dtype)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        """Run MLA full attention.
+
+        Args:
+            hidden_states: Tensor of shape [batch, sequence, hidden].
+            attention_mask: Optional additive attention mask of shape [batch, 1, sequence, sequence].
+            **kwargs: Extra attention options accepted for HF compatibility.
+
+        Returns:
+            Tensor of shape [batch, sequence, hidden].
+        """
+        del kwargs
+        batch_size, seq_length = hidden_states.shape[:-1]
+        query_shape = (batch_size, seq_length, -1, self.q_head_dim)
+        key_shape = (batch_size, seq_length, -1, self.qk_nope_head_dim + self.v_head_dim)
+
+        q_states = self.q_proj(hidden_states).view(query_shape).transpose(1, 2)
+        q_pass, q_rot = torch.split(q_states, [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
+
+        compressed_kv = self.kv_a_proj_with_mqa(hidden_states)
+        k_pass, k_rot = torch.split(compressed_kv, [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
+
+        k_pass = self.kv_b_proj(self.kv_a_layernorm(k_pass)).view(key_shape).transpose(1, 2)
+        k_pass, value_states = torch.split(k_pass, [self.qk_nope_head_dim, self.v_head_dim], dim=-1)
+
+        k_rot = k_rot.view(batch_size, 1, seq_length, self.qk_rope_head_dim)
+        k_rot = k_rot.expand(*k_pass.shape[:-1], -1)
+
+        query_states = torch.cat((q_pass, q_rot), dim=-1)
+        key_states = torch.cat((k_pass, k_rot), dim=-1)
+
+        if self.num_key_value_groups != 1:
+            key_states = key_states[:, :, None, :, :].expand(
+                batch_size,
+                self.num_key_value_heads,
+                self.num_key_value_groups,
+                seq_length,
+                self.q_head_dim,
+            )
+            value_states = value_states[:, :, None, :, :].expand(
+                batch_size,
+                self.num_key_value_heads,
+                self.num_key_value_groups,
+                seq_length,
+                self.v_head_dim,
+            )
+            key_states = key_states.reshape(batch_size, self.num_heads, seq_length, self.q_head_dim)
+            value_states = value_states.reshape(batch_size, self.num_heads, seq_length, self.v_head_dim)
+
+        attn_weights = torch.matmul(query_states, key_states.transpose(2, 3)) * self.scaling
+        if attention_mask is not None:
+            attn_weights = attn_weights + attention_mask[:, :, :, : key_states.shape[-2]]
+        attn_weights = F.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query_states.dtype)
+        attn_weights = F.dropout(attn_weights, p=self.attention_dropout, training=self.training)
+        attn_output = torch.matmul(attn_weights, value_states)
+        attn_output = attn_output.transpose(1, 2).contiguous().reshape(batch_size, seq_length, -1)
+        return self.o_proj(attn_output)
+
+    @torch.no_grad()
+    def init_weights(self, buffer_device: torch.device, init_std: float) -> None:
+        with buffer_device:
+            for module in (self.q_proj, self.kv_a_proj_with_mqa, self.kv_b_proj, self.o_proj):
+                nn.init.normal_(module.weight, mean=0.0, std=init_std)
+            self.kv_a_layernorm.reset_parameters()
+
+
+class _KimiKDAFp32Param:
+    """Descriptor exposing a KDA fp32 parameter from the ``_fp32_params`` holder."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def __get__(
+        self, obj: nn.Module | None, owner: type[nn.Module] | None = None
+    ) -> nn.Parameter | "_KimiKDAFp32Param":
+        del owner
+        if obj is None:
+            return self
+        holder = obj._modules.get("_fp32_params")
+        if holder is not None:
+            return getattr(holder, self.name)
+        param = obj._parameters.get(self.name)
+        if param is not None:
+            return param
+        raise AttributeError(f"{type(obj).__name__} has no KDA fp32 parameter {self.name!r}.")
+
+
+class KimiKDAFp32Params(nn.Module):
+    """Owns Kimi KDA fp32 recurrent-decay parameters and computes the gate."""
+
+    def __init__(self, num_heads: int, projection_size: int) -> None:
+        super().__init__()
+        self.A_log = nn.Parameter(torch.empty(num_heads, dtype=torch.float32).view(1, 1, num_heads, 1))
+        self.dt_bias = nn.Parameter(torch.empty(projection_size, dtype=torch.float32))
+
+    def forward(self, g: torch.Tensor, head_dim: int, use_fused_gate: bool = True) -> torch.Tensor:
+        """Compute KDA decay gate while holder params are unsharded by FSDP."""
+        a_log = self.A_log.contiguous()
+        dt_bias = self.dt_bias.contiguous()
+        if use_fused_gate:
+            return _fused_kda_gate(g, a_log, head_dim, dt_bias)
+        return _torch_kda_gate(g, a_log, head_dim, dt_bias)
+
+
+class KimiDeltaAttention(nn.Module):
+    """Kimi Delta Attention backed by FLA KDA kernels."""
+
+    A_log = _KimiKDAFp32Param("A_log")
+    dt_bias = _KimiKDAFp32Param("dt_bias")
+
+    def __init__(self, config: KimiLinearConfig, layer_idx: int) -> None:
+        _require_fla()
+        super().__init__()
+        self.config = config
+        self.mode = getattr(config, "kda_mode", "chunk")
+        if self.mode not in ("chunk", "fused_recurrent"):
+            raise ValueError(f"Unsupported Kimi KDA mode {self.mode!r}.")
+        self.hidden_size = config.hidden_size
+        self.conv_size = config.linear_attn_config["short_conv_kernel_size"]
+        self.head_dim = config.linear_attn_config["head_dim"]
+        self.num_heads = config.linear_attn_config["num_heads"]
+        self.head_k_dim = self.head_dim
+        self.num_k_heads = self.num_heads
+        self.layer_idx = layer_idx
+
+        projection_k_size = self.head_k_dim * self.num_k_heads
+        projection_size = self.head_dim * self.num_heads
+        dtype = get_dtype(getattr(config, "torch_dtype", None), torch.bfloat16)
+
+        self.q_proj = nn.Linear(self.hidden_size, projection_k_size, bias=False, dtype=dtype)
+        self.k_proj = nn.Linear(self.hidden_size, projection_k_size, bias=False, dtype=dtype)
+        self.v_proj = nn.Linear(self.hidden_size, projection_size, bias=False, dtype=dtype)
+        self.q_conv1d = ShortConvolution(
+            hidden_size=projection_k_size,
+            kernel_size=self.conv_size,
+            activation="silu",
+            dtype=dtype,
+        )
+        self.k_conv1d = ShortConvolution(
+            hidden_size=projection_k_size,
+            kernel_size=self.conv_size,
+            activation="silu",
+            dtype=dtype,
+        )
+        self.v_conv1d = ShortConvolution(
+            hidden_size=projection_size,
+            kernel_size=self.conv_size,
+            activation="silu",
+            dtype=dtype,
+        )
+
+        self._fp32_params = KimiKDAFp32Params(self.num_heads, projection_size)
+        self.f_a_proj = nn.Linear(self.hidden_size, self.head_dim, bias=False, dtype=dtype)
+        self.f_b_proj = nn.Linear(self.head_dim, projection_size, bias=False, dtype=dtype)
+        self.b_proj = nn.Linear(self.hidden_size, self.num_heads, bias=False, dtype=dtype)
+        self.g_a_proj = nn.Linear(self.hidden_size, self.head_dim, bias=False, dtype=dtype)
+        self.g_b_proj = nn.Linear(self.head_dim, projection_size, bias=False, dtype=dtype)
+        self.o_norm = FusedRMSNormGated(self.head_dim, eps=config.rms_norm_eps, activation="sigmoid", dtype=dtype)
+        self.o_proj = nn.Linear(projection_size, self.hidden_size, bias=False, dtype=dtype)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        """Run KDA linear attention.
+
+        Args:
+            hidden_states: Tensor of shape [batch, sequence, hidden].
+            attention_mask: Optional binary padding mask of shape [batch, sequence] where 1 marks valid tokens.
+            **kwargs: Optional KDA kwargs, including ``cu_seqlens`` for packed sequences.
+
+        Returns:
+            Tensor of shape [batch, sequence, hidden].
+        """
+        if attention_mask is not None:
+            if attention_mask.dim() != 2:
+                attention_mask = kwargs.get("padding_mask")
+            if attention_mask is not None and attention_mask.dim() != 2:
+                raise ValueError("Kimi KDA attention_mask must have shape [batch, sequence].")
+
+        batch_size, q_len, _ = hidden_states.shape
+
+        cu_seqlens = kwargs.get("cu_seqlens")
+        indices = None
+        if attention_mask is not None and getattr(self.config, "kda_unpad_inputs", True):
+            indices, cu_seqlens, _ = _get_unpad_data(attention_mask[:, -q_len:])
+            hidden_states = _index_first_axis(hidden_states.reshape(batch_size * q_len, -1), indices).unsqueeze(0)
+        effective_q_len = hidden_states.shape[1]
+        mode = "fused_recurrent" if effective_q_len <= 64 else self.mode
+
+        q, _ = self.q_conv1d(x=self.q_proj(hidden_states), cache=None, output_final_state=False, cu_seqlens=cu_seqlens)
+        k, _ = self.k_conv1d(x=self.k_proj(hidden_states), cache=None, output_final_state=False, cu_seqlens=cu_seqlens)
+        v, _ = self.v_conv1d(x=self.v_proj(hidden_states), cache=None, output_final_state=False, cu_seqlens=cu_seqlens)
+        g = self.f_b_proj(self.f_a_proj(hidden_states)).contiguous()
+        beta = self.b_proj(hidden_states).float().sigmoid()
+
+        q = q.reshape(*q.shape[:-1], self.num_k_heads, self.head_k_dim).contiguous()
+        k = k.reshape(*k.shape[:-1], self.num_k_heads, self.head_k_dim).contiguous()
+        v = v.reshape(*v.shape[:-1], self.num_heads, self.head_dim).contiguous()
+        beta = beta.contiguous()
+        g = self._fp32_params(g, self.head_dim, getattr(self.config, "kda_use_fused_gate", True)).contiguous()
+        use_qk_l2norm_in_kernel = getattr(self.config, "kda_use_qk_l2norm_in_kernel", True)
+        if not use_qk_l2norm_in_kernel:
+            q = F.normalize(q.float(), p=2, dim=-1, eps=1e-6).to(q.dtype)
+            k = F.normalize(k.float(), p=2, dim=-1, eps=1e-6).to(k.dtype)
+
+        if mode == "chunk":
+            o, _ = chunk_kda(
+                q=q,
+                k=k,
+                v=v,
+                g=g,
+                beta=beta,
+                initial_state=None,
+                output_final_state=True,
+                use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+                cu_seqlens=cu_seqlens,
+            )
+        else:
+            o, _ = fused_recurrent_kda(
+                q=q,
+                k=k,
+                v=v,
+                g=g,
+                beta=beta,
+                initial_state=None,
+                output_final_state=True,
+                use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+                cu_seqlens=cu_seqlens,
+            )
+
+        gate = self.g_b_proj(self.g_a_proj(hidden_states)).reshape(*hidden_states.shape[:-1], self.num_heads, -1)
+        o = self.o_norm(o, gate)
+        o = o.reshape(o.shape[0], o.shape[1], -1).contiguous()
+        o = self.o_proj(o)
+        if indices is not None:
+            o = _pad_input(o.squeeze(0), indices, batch_size, q_len)
+        return o
+
+    @torch.no_grad()
+    def init_weights(self, buffer_device: torch.device, init_std: float) -> None:
+        with buffer_device:
+            self.A_log.uniform_(1, 16).log_()
+            self.dt_bias.zero_()
+            for module in (
+                self.q_proj,
+                self.k_proj,
+                self.v_proj,
+                self.f_a_proj,
+                self.f_b_proj,
+                self.b_proj,
+                self.g_a_proj,
+                self.g_b_proj,
+                self.o_proj,
+            ):
+                nn.init.normal_(module.weight, mean=0.0, std=init_std)
+            for conv in (self.q_conv1d, self.k_conv1d, self.v_conv1d):
+                conv.reset_parameters()
+            if hasattr(self.o_norm, "reset_parameters"):
+                self.o_norm.reset_parameters()
+
+
+class KimiDecoderLayer(nn.Module):
+    """Kimi decoder block with KDA/MLA attention and dense or MoE MLP."""
+
+    def __init__(self, config: KimiLinearConfig, layer_idx: int, moe_config: MoEConfig, backend: BackendConfig) -> None:
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.config = config
+        self.layer_idx = layer_idx
+        self.is_linear_attn = config.is_kda_layer(layer_idx)
+        self.is_moe_layer = (
+            config.num_experts is not None
+            and layer_idx >= config.first_k_dense_replace
+            and layer_idx % getattr(config, "moe_layer_freq", 1) == 0
+        )
+        self.self_attn = (
+            KimiDeltaAttention(config, layer_idx) if self.is_linear_attn else KimiMLAAttention(config, layer_idx)
+        )
+
+        dtype = get_dtype(getattr(config, "torch_dtype", None), torch.bfloat16)
+        if self.is_moe_layer:
+            self.block_sparse_moe = MoE(moe_config, backend)
+        else:
+            self.mlp = MLP(config.hidden_size, config.intermediate_size, backend.linear, dtype=dtype)
+        self.input_layernorm = KimiRMSNorm(config.hidden_size, eps=config.rms_norm_eps, dtype=dtype)
+        self.post_attention_layernorm = KimiRMSNorm(config.hidden_size, eps=config.rms_norm_eps, dtype=dtype)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        *,
+        attention_mask: torch.Tensor | None = None,
+        padding_mask: torch.Tensor | None = None,
+        **attn_kwargs: Any,
+    ) -> torch.Tensor:
+        """Run one Kimi decoder layer.
+
+        Args:
+            hidden_states: Tensor of shape [batch, sequence, hidden].
+            attention_mask: KDA layers receive a binary mask [batch, sequence]; MLA layers receive an additive
+                causal mask [batch, 1, sequence, sequence].
+            padding_mask: Optional boolean tensor of shape [batch, sequence], where true marks padding tokens.
+            **attn_kwargs: Extra attention kwargs forwarded to KDA/MLA.
+
+        Returns:
+            Tensor of shape [batch, sequence, hidden].
+        """
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states = self.self_attn(hidden_states=hidden_states, attention_mask=attention_mask, **attn_kwargs)
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        if self.is_moe_layer:
+            if attention_mask is not None and attention_mask.ndim == 2 and padding_mask is None:
+                padding_mask = attention_mask.bool().logical_not()
+            hidden_states = self._moe(hidden_states, padding_mask)
+        else:
+            hidden_states = self.mlp(hidden_states)
+        return residual + hidden_states
+
+    def _moe(self, hidden_states: torch.Tensor, padding_mask: torch.Tensor | None) -> torch.Tensor:
+        moe = unwrap_checkpoint_wrapper(self.block_sparse_moe)
+        if not isinstance(moe, MoE):
+            raise TypeError(f"Expected Kimi MoE layer, got {type(moe).__name__}.")
+        experts = unwrap_checkpoint_wrapper(moe.experts)
+        if (
+            not self.training
+            and padding_mask is None
+            and isinstance(experts, GroupedExperts)
+            and not self._has_dtensor_expert_params(experts)
+        ):
+            return self._moe_infer_hf_order(moe, experts, hidden_states)
+        return self.block_sparse_moe(hidden_states, padding_mask)
+
+    @staticmethod
+    def _has_dtensor_expert_params(experts: GroupedExperts) -> bool:
+        return hasattr(experts.gate_and_up_projs, "to_local") or hasattr(experts.down_projs, "to_local")
+
+    def _moe_infer_hf_order(
+        self,
+        moe: MoE,
+        experts: GroupedExperts,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        orig_shape = hidden_states.shape
+        x = hidden_states.reshape(-1, hidden_states.shape[-1])
+        token_mask = torch.ones(x.shape[0], dtype=torch.bool, device=x.device)
+        weights, indices, _ = moe.gate(x, token_mask, moe.cp_mesh)
+
+        counts = indices.new_zeros((indices.shape[0], experts.n_routed_experts))
+        counts.scatter_(1, indices, 1)
+        tokens_per_expert = counts.sum(dim=0).cpu().tolist()
+        sorted_ids = indices.reshape(-1).argsort()
+        sorted_tokens = x[sorted_ids // indices.shape[1]]
+
+        gate_and_up_projs = experts.gate_and_up_projs.to(x.dtype)
+        down_projs = experts.down_projs.to(x.dtype)
+        gate_up_bias = experts.gate_up_proj_bias.to(x.dtype) if experts.gate_up_proj_bias is not None else None
+        down_bias = experts.down_proj_bias.to(x.dtype) if experts.down_proj_bias is not None else None
+
+        outputs = []
+        start = 0
+        for expert_idx, num_tokens in enumerate(tokens_per_expert):
+            end = start + num_tokens
+            if num_tokens == 0:
+                continue
+            tokens = sorted_tokens[start:end]
+            gate_up = tokens @ gate_and_up_projs[expert_idx]
+            if gate_up_bias is not None:
+                gate_up = gate_up + gate_up_bias[expert_idx]
+            gate, up = torch.chunk(gate_up, 2, dim=-1)
+            expert_out = F.silu(gate) * up
+            expert_out = expert_out @ down_projs[expert_idx]
+            if down_bias is not None:
+                expert_out = expert_out + down_bias[expert_idx]
+            outputs.append(expert_out)
+            start = end
+
+        if outputs:
+            routed = torch.cat(outputs, dim=0)
+        else:
+            routed = sorted_tokens.new_empty((0, x.shape[-1]))
+        unpermuted = torch.empty_like(routed)
+        unpermuted[sorted_ids] = routed
+        y = (
+            unpermuted.view(*indices.shape, -1)
+            .type(weights.dtype)
+            .mul_(weights.unsqueeze(dim=-1))
+            .sum(dim=1)
+            .type(routed.dtype)
+        )
+
+        if moe.shared_experts is not None:
+            shared = moe.shared_experts(x)
+            if moe.shared_expert_gate is not None:
+                shared = torch.sigmoid(moe.shared_expert_gate(x)) * shared
+            y = y + shared
+        return y.view(orig_shape)
+
+    @torch.no_grad()
+    def init_weights(self, buffer_device: torch.device, init_std: float) -> None:
+        self.input_layernorm.reset_parameters()
+        self.post_attention_layernorm.reset_parameters()
+        self.self_attn.init_weights(buffer_device, init_std)
+        if self.is_moe_layer:
+            self.block_sparse_moe.init_weights(buffer_device, init_std)
+        else:
+            self.mlp.init_weights(buffer_device, init_std)
+
+
+def _build_moe_config(
+    config: KimiLinearConfig,
+    model_dtype: torch.dtype,
+    moe_overrides: dict[str, Any] | None,
+) -> MoEConfig:
+    moe_defaults = dict(
+        dim=config.hidden_size,
+        inter_dim=config.intermediate_size,
+        moe_inter_dim=config.moe_intermediate_size,
+        n_routed_experts=config.num_experts,
+        n_shared_experts=config.num_shared_experts or 0,
+        n_activated_experts=config.num_experts_per_token,
+        n_expert_groups=config.num_expert_group,
+        n_limited_groups=config.topk_group,
+        train_gate=True,
+        gate_bias_update_factor=0.0,
+        score_func=config.moe_router_activation_func,
+        route_scale=config.routed_scaling_factor,
+        aux_loss_coeff=0.0,
+        norm_topk_prob=config.moe_renormalize,
+        router_bias=False,
+        expert_bias=False,
+        expert_activation="swiglu",
+        router_topk_sorted=False,
+        router_weights_fp32=True,
+        router_weight_uses_score_correction_bias=True,
+        route_weight_after_down_proj=True,
+        dtype=model_dtype,
+        shared_expert_gate=False,
+        shared_expert_inter_dim=config.moe_intermediate_size,
+        force_e_score_correction_bias=True,
+    )
+    if moe_overrides:
+        moe_defaults.update(moe_overrides)
+    return MoEConfig(**moe_defaults)
+
+
+class KimiLinearModel(nn.Module):
+    """Kimi Linear decoder backbone with trainable Automodel MoE layers."""
+
+    def __init__(
+        self,
+        config: KimiLinearConfig,
+        backend: BackendConfig,
+        *,
+        moe_config: MoEConfig | None = None,
+        moe_overrides: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__()
+        self.backend = backend
+        self.config = config
+        if moe_config is not None and moe_overrides is not None:
+            raise ValueError("Cannot pass both moe_config and moe_overrides; use one or the other.")
+        model_dtype = get_dtype(getattr(config, "torch_dtype", None), torch.bfloat16)
+        self.moe_config = moe_config or _build_moe_config(config, model_dtype, moe_overrides)
+        self.padding_idx = config.pad_token_id
+        self.vocab_size = config.vocab_size
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx, dtype=model_dtype)
+        self.layers = nn.ModuleDict(
+            {
+                str(layer_idx): KimiDecoderLayer(config, layer_idx, self.moe_config, backend)
+                for layer_idx in range(config.num_hidden_layers)
+            }
+        )
+        self.norm = KimiRMSNorm(config.hidden_size, eps=config.rms_norm_eps, dtype=model_dtype)
+
+    def _update_linear_attn_mask(
+        self,
+        attention_mask: torch.Tensor | None,
+        cache_position: torch.Tensor,
+    ) -> torch.Tensor | None:
+        if cache_position[0] > 0 or (attention_mask is not None and torch.all(attention_mask == 1)):
+            return None
+        return attention_mask
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None = None,
+        *,
+        inputs_embeds: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        padding_mask: torch.Tensor | None = None,
+        cache_position: torch.Tensor | None = None,
+        **attn_kwargs: Any,
+    ) -> torch.Tensor:
+        """Run the Kimi Linear decoder.
+
+        Args:
+            input_ids: Optional token ids of shape [batch, sequence].
+            inputs_embeds: Optional embeddings of shape [batch, sequence, hidden].
+            attention_mask: Optional binary padding mask of shape [batch, sequence].
+            position_ids: Optional positions of shape [batch, sequence]; accepted for HF compatibility.
+            padding_mask: Optional boolean tensor of shape [batch, sequence], where true marks padding tokens.
+            cache_position: Optional position vector of shape [sequence].
+            **attn_kwargs: Additional attention kwargs used by packed or THD execution.
+
+        Returns:
+            Tensor of shape [batch, sequence, hidden].
+        """
+        del position_ids
+        if (input_ids is None) == (inputs_embeds is None):
+            raise ValueError("You must specify exactly one of input_ids or inputs_embeds.")
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+        if cache_position is None:
+            cache_position = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device)
+
+        linear_attn_mask = self._update_linear_attn_mask(attention_mask, cache_position)
+        causal_mask = _make_causal_mask(inputs_embeds, attention_mask, dtype=inputs_embeds.dtype)
+        hidden_states = inputs_embeds
+
+        for decoder_layer in self.layers.values():
+            layer_mask = linear_attn_mask if decoder_layer.is_linear_attn else causal_mask
+            layer_padding_mask = padding_mask
+            if decoder_layer.is_linear_attn and layer_mask is not None:
+                layer_padding_mask = layer_mask.bool().logical_not()
+            hidden_states = decoder_layer(
+                hidden_states,
+                attention_mask=layer_mask,
+                padding_mask=layer_padding_mask,
+                **attn_kwargs,
+            )
+
+        return self.norm(hidden_states)
+
+    def update_moe_gate_bias(self) -> None:
+        with torch.no_grad():
+            for block in self.layers.values():
+                if block.is_moe_layer and block.block_sparse_moe.gate.bias_update_factor > 0:
+                    block.block_sparse_moe.gate.update_bias()
+
+    @torch.no_grad()
+    def init_weights(self, buffer_device: torch.device | None = None) -> None:
+        buffer_device = (
+            buffer_device or torch.device(f"cuda:{torch.cuda.current_device()}")
+            if torch.cuda.is_available()
+            else torch.device("cpu")
+        )
+        init_std = self.config.initializer_range
+        with buffer_device:
+            nn.init.normal_(self.embed_tokens.weight, mean=0.0, std=init_std)
+            if self.padding_idx is not None:
+                self.embed_tokens.weight[self.padding_idx].zero_()
+            self.norm.reset_parameters()
+        for layer in self.layers.values():
+            layer.init_weights(buffer_device, init_std)
+
+
+class KimiLinearForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
+    """Kimi Linear causal LM with native trainable MoE layers."""
+
+    tie_word_embeddings_support: TieSupport = TieSupport.UNTIED_ONLY
+    _keep_in_fp32_modules = ["_fp32_params", "e_score_correction_bias"]
+    _keep_in_fp32_modules_strict = ["_fp32_params", "e_score_correction_bias"]
+
+    @dataclass(frozen=True)
+    class ModelCapabilities:
+        """Declared parallelism capabilities for Kimi Linear."""
+
+        supports_tp: bool = False
+        supports_cp: bool = False
+        supports_pp: bool = False
+        supports_ep: bool = True
+
+    @classmethod
+    def from_config(
+        cls,
+        config: KimiLinearConfig,
+        moe_config: MoEConfig | None = None,
+        backend: BackendConfig | None = None,
+        **kwargs: Any,
+    ) -> "KimiLinearForCausalLM":
+        return cls(config, moe_config=moe_config, backend=backend, **kwargs)
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str,
+        *model_args: Any,
+        **kwargs: Any,
+    ) -> "KimiLinearForCausalLM":
+        config = KimiLinearConfig.from_pretrained(pretrained_model_name_or_path)
+        return cls.from_config(config, *model_args, **kwargs)
+
+    def __init__(
+        self,
+        config: KimiLinearConfig,
+        moe_config: MoEConfig | None = None,
+        backend: BackendConfig | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__()
+        reject_unsupported_tie_word_embeddings(type(self), config)
+        self.config = config
+        self.backend = backend or BackendConfig()
+        if self.backend.gate_precision is None:
+            self.backend.gate_precision = torch.float32
+        moe_overrides = kwargs.pop("moe_overrides", None)
+        self.model = KimiLinearModel(config, self.backend, moe_config=moe_config, moe_overrides=moe_overrides)
+        model_dtype = get_dtype(getattr(config, "torch_dtype", None), torch.bfloat16)
+        self.lm_head = initialize_linear_module(
+            self.backend.linear,
+            config.hidden_size,
+            config.vocab_size,
+            bias=False,
+            dtype=model_dtype,
+        )
+        self.vocab_size = config.vocab_size
+        if self.backend.enable_hf_state_dict_adapter:
+            self.state_dict_adapter = KimiLinearStateDictAdapter(
+                self.config,
+                self.model.moe_config,
+                self.backend,
+                dtype=model_dtype,
+            )
+
+    def get_input_embeddings(self) -> nn.Module:
+        return self.model.embed_tokens
+
+    def set_input_embeddings(self, value: nn.Module) -> None:
+        self.model.embed_tokens = value
+
+    def get_output_embeddings(self) -> nn.Module:
+        return self.lm_head
+
+    def set_output_embeddings(self, new_embeddings: nn.Module) -> None:
+        self.lm_head = new_embeddings
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None = None,
+        *,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        padding_mask: torch.Tensor | None = None,
+        logits_to_keep: int | torch.Tensor = 0,
+        output_hidden_states: bool | None = None,
+        **attn_kwargs: Any,
+    ) -> CausalLMOutputWithPast:
+        """Run Kimi Linear causal LM.
+
+        Args:
+            input_ids: Optional token ids of shape [batch, sequence].
+            attention_mask: Optional binary padding mask of shape [batch, sequence].
+            position_ids: Optional positions of shape [batch, sequence].
+            inputs_embeds: Optional embeddings of shape [batch, sequence, hidden].
+            padding_mask: Optional boolean tensor of shape [batch, sequence], where true marks padding tokens.
+            logits_to_keep: Number of trailing sequence logits to compute, or tensor indices.
+            output_hidden_states: Whether to include hidden states in the output.
+            **attn_kwargs: Additional attention kwargs used by packed or THD execution.
+
+        Returns:
+            Causal LM output whose logits have shape [batch, sequence, vocab] unless ``logits_to_keep`` trims sequence.
+        """
+        output_hidden_states = (
+            output_hidden_states
+            if output_hidden_states is not None
+            else getattr(self.config, "output_hidden_states", False)
+        )
+        is_thd = attn_kwargs.get("qkv_format") == "thd"
+        if is_thd:
+            input_ids, position_ids, padding_mask, attn_kwargs = squeeze_input_for_thd(
+                input_ids,
+                position_ids,
+                padding_mask,
+                attn_kwargs,
+            )
+            attention_mask = None
+
+        hidden_states = self.model(
+            input_ids=input_ids,
+            inputs_embeds=inputs_embeds,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            padding_mask=padding_mask,
+            **attn_kwargs,
+        )
+        return compute_lm_head_logits(
+            self.lm_head,
+            hidden_states,
+            logits_to_keep,
+            is_thd=is_thd,
+            output_hidden_states=output_hidden_states,
+        )
+
+    def update_moe_gate_bias(self) -> None:
+        self.model.update_moe_gate_bias()
+
+    @torch.no_grad()
+    def initialize_weights(
+        self,
+        buffer_device: torch.device | None = None,
+        dtype: torch.dtype = torch.bfloat16,
+    ) -> None:
+        buffer_device = (
+            buffer_device or torch.device(f"cuda:{torch.cuda.current_device()}")
+            if torch.cuda.is_available()
+            else torch.device("cpu")
+        )
+        self.model.init_weights(buffer_device)
+        final_out_std = self.config.hidden_size**-0.5
+        cutoff_factor = 3
+        with buffer_device:
+            nn.init.trunc_normal_(
+                self.lm_head.weight,
+                mean=0.0,
+                std=final_out_std,
+                a=-cutoff_factor * final_out_std,
+                b=cutoff_factor * final_out_std,
+            )
+        cast_model_to_dtype(self, dtype, skip_modules=("_fp32_params",))
+
+
+ModelClass = KimiLinearForCausalLM

--- a/nemo_automodel/components/models/kimi_linear/model.py
+++ b/nemo_automodel/components/models/kimi_linear/model.py
@@ -365,7 +365,16 @@ class KimiKDAFp32Params(nn.Module):
         self.dt_bias = nn.Parameter(torch.empty(projection_size, dtype=torch.float32))
 
     def forward(self, g: torch.Tensor, head_dim: int, use_fused_gate: bool = True) -> torch.Tensor:
-        """Compute KDA decay gate while holder params are unsharded by FSDP."""
+        """Compute KDA decay gate while holder params are unsharded by FSDP.
+
+        Args:
+            g: Tensor of shape [batch, sequence, heads * head_dim].
+            head_dim: Per-head KDA dimension.
+            use_fused_gate: Whether to use FLA's fused KDA gate kernel.
+
+        Returns:
+            Tensor of shape [batch, sequence, heads, head_dim].
+        """
         a_log = self.A_log.contiguous()
         dt_bias = self.dt_bias.contiguous()
         if use_fused_gate:
@@ -595,6 +604,15 @@ class KimiDecoderLayer(nn.Module):
         return residual + hidden_states
 
     def _moe(self, hidden_states: torch.Tensor, padding_mask: torch.Tensor | None) -> torch.Tensor:
+        """Run a Kimi MoE layer.
+
+        Args:
+            hidden_states: Tensor of shape [batch, sequence, hidden].
+            padding_mask: Optional boolean tensor of shape [batch, sequence], where true marks padding tokens.
+
+        Returns:
+            Tensor of shape [batch, sequence, hidden].
+        """
         moe = unwrap_checkpoint_wrapper(self.block_sparse_moe)
         if not isinstance(moe, MoE):
             raise TypeError(f"Expected Kimi MoE layer, got {type(moe).__name__}.")
@@ -618,6 +636,16 @@ class KimiDecoderLayer(nn.Module):
         experts: GroupedExperts,
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
+        """Run Kimi inference MoE in the same expert-ordered loop as the HF reference.
+
+        Args:
+            moe: MoE module containing the router and optional shared experts.
+            experts: Grouped routed experts for the layer.
+            hidden_states: Tensor of shape [batch, sequence, hidden].
+
+        Returns:
+            Tensor of shape [batch, sequence, hidden].
+        """
         orig_shape = hidden_states.shape
         x = hidden_states.reshape(-1, hidden_states.shape[-1])
         token_mask = torch.ones(x.shape[0], dtype=torch.bool, device=x.device)
@@ -755,6 +783,15 @@ class KimiLinearModel(nn.Module):
         attention_mask: torch.Tensor | None,
         cache_position: torch.Tensor,
     ) -> torch.Tensor | None:
+        """Select the padding mask passed to KDA layers.
+
+        Args:
+            attention_mask: Optional binary padding mask tensor of shape [batch, sequence].
+            cache_position: Tensor of shape [sequence] containing current token positions.
+
+        Returns:
+            Binary padding mask tensor of shape [batch, sequence], or None when no KDA mask is needed.
+        """
         if cache_position[0] > 0 or (attention_mask is not None and torch.all(attention_mask == 1)):
             return None
         return attention_mask
@@ -818,10 +855,8 @@ class KimiLinearModel(nn.Module):
 
     @torch.no_grad()
     def init_weights(self, buffer_device: torch.device | None = None) -> None:
-        buffer_device = (
-            buffer_device or torch.device(f"cuda:{torch.cuda.current_device()}")
-            if torch.cuda.is_available()
-            else torch.device("cpu")
+        buffer_device = buffer_device or (
+            torch.device(f"cuda:{torch.cuda.current_device()}") if torch.cuda.is_available() else torch.device("cpu")
         )
         init_std = self.config.initializer_range
         with buffer_device:
@@ -980,10 +1015,8 @@ class KimiLinearForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
         buffer_device: torch.device | None = None,
         dtype: torch.dtype = torch.bfloat16,
     ) -> None:
-        buffer_device = (
-            buffer_device or torch.device(f"cuda:{torch.cuda.current_device()}")
-            if torch.cuda.is_available()
-            else torch.device("cpu")
+        buffer_device = buffer_device or (
+            torch.device(f"cuda:{torch.cuda.current_device()}") if torch.cuda.is_available() else torch.device("cpu")
         )
         self.model.init_weights(buffer_device)
         final_out_std = self.config.hidden_size**-0.5

--- a/nemo_automodel/components/models/kimi_linear/model.py
+++ b/nemo_automodel/components/models/kimi_linear/model.py
@@ -30,12 +30,23 @@ from transformers.modeling_outputs import CausalLMOutputWithPast
 from nemo_automodel.components.distributed.activation_checkpointing import unwrap_checkpoint_wrapper
 from nemo_automodel.components.models.common import BackendConfig, initialize_linear_module
 from nemo_automodel.components.models.common.hf_checkpointing_mixin import HFCheckpointingMixin
+from nemo_automodel.components.models.common.packing import get_unpad_data, is_indexed_packed_mask
 from nemo_automodel.components.models.common.tie_word_embeddings import (
     TieSupport,
     reject_unsupported_tie_word_embeddings,
 )
 from nemo_automodel.components.models.common.utils import cast_model_to_dtype, compute_lm_head_logits
 from nemo_automodel.components.models.kimi_linear.config import KimiLinearConfig
+from nemo_automodel.components.models.kimi_linear.cp import (
+    KimiPackedContext,
+    all_gather_sequence,
+    build_document_causal_mask,
+    build_fla_cp_context,
+    doc_ids_from_attention_mask,
+    doc_ids_from_cu_seqlens,
+    document_causal_flex_attention,
+    shard_batch_for_kimi_cp,
+)
 from nemo_automodel.components.models.kimi_linear.state_dict_adapter import KimiLinearStateDictAdapter
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.experts import GroupedExperts
@@ -172,29 +183,60 @@ def _pad_input(hidden_states: torch.Tensor, indices: torch.Tensor, batch_size: i
 
 def _make_causal_mask(
     inputs_embeds: torch.Tensor,
-    attention_mask: torch.Tensor | None,
+    packed_context: "KimiPackedContext | None",
     *,
     dtype: torch.dtype,
 ) -> torch.Tensor | None:
-    """Create the additive causal attention mask for padded full attention.
+    """Create the additive causal attention mask for full-attention layers.
 
     Args:
         inputs_embeds: Tensor of shape [batch, sequence, hidden].
-        attention_mask: Optional binary mask tensor of shape [batch, sequence] where 1 marks valid tokens.
+        packed_context: Optional document layout of the batch. When it marks more
+            than one document per row, the mask is block-diagonal so tokens never
+            attend across packed documents.
         dtype: Floating-point dtype used for the additive mask values.
 
     Returns:
-        Additive causal mask tensor of shape [batch, 1, sequence, sequence], or None.
+        Additive causal mask tensor of shape [batch, 1, sequence, sequence].
     """
     batch_size, seq_len = inputs_embeds.shape[:2]
+    if packed_context is not None:
+        return build_document_causal_mask(
+            packed_context.doc_ids,
+            packed_context.doc_ids,
+            q_global_start=0,
+            dtype=dtype,
+        )
     min_value = torch.finfo(dtype).min
     mask = torch.full((seq_len, seq_len), min_value, device=inputs_embeds.device, dtype=dtype)
     mask = torch.triu(mask, diagonal=1)
-    mask = mask[None, None, :, :].expand(batch_size, 1, -1, -1)
+    return mask[None, None, :, :].expand(batch_size, 1, -1, -1)
+
+
+def _packed_context_from_inputs(
+    inputs_embeds: torch.Tensor,
+    *,
+    attention_mask: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
+) -> KimiPackedContext | None:
+    """Derive the document layout of a batch that was not sharded for context parallelism.
+
+    Args:
+        inputs_embeds: Tensor of shape [batch, sequence, hidden].
+        attention_mask: Optional binary or indexed packing mask of shape [batch, sequence].
+        cu_seqlens: Optional cumulative document lengths of shape [documents + 1] from
+            the THD packed path.
+
+    Returns:
+        The document layout, or None when the batch is a single unpadded document per
+        row and needs no document bookkeeping.
+    """
     if attention_mask is not None and attention_mask.ndim == 2:
-        padding = attention_mask[:, None, None, :].to(torch.bool)
-        mask = mask.masked_fill(~padding, min_value)
-    return mask
+        return KimiPackedContext(doc_ids=doc_ids_from_attention_mask(attention_mask))
+    if cu_seqlens is not None and isinstance(cu_seqlens, torch.Tensor):
+        boundaries = cu_seqlens.squeeze(0) if cu_seqlens.ndim == 2 else cu_seqlens
+        return KimiPackedContext(doc_ids=doc_ids_from_cu_seqlens(boundaries, inputs_embeds.shape[1]))
+    return None
 
 
 class KimiRMSNorm(nn.Module):
@@ -264,25 +306,47 @@ class KimiMLAAttention(nn.Module):
             dtype=dtype,
         )
         self.o_proj = nn.Linear(self.num_heads * self.v_head_dim, self.hidden_size, bias=False, dtype=dtype)
+        self._cp_mesh = None
+
+    def setup_cp_attention(self, cp_mesh) -> None:
+        """Attach the context-parallel mesh used to gather full-sequence keys and values.
+
+        Called by the MoE parallelizer's ``apply_cp`` for every attention block.
+
+        Args:
+            cp_mesh: One-dimensional context-parallel device mesh.
+        """
+        self._cp_mesh = cp_mesh
 
     def forward(
         self,
         hidden_states: torch.Tensor,
         attention_mask: torch.Tensor | None = None,
+        packed_context: "KimiPackedContext | None" = None,
         **kwargs: Any,
     ) -> torch.Tensor:
         """Run MLA full attention.
 
         Args:
-            hidden_states: Tensor of shape [batch, sequence, hidden].
+            hidden_states: Tensor of shape [batch, sequence, hidden]; the sequence axis
+                holds this rank's contiguous shard under context parallelism.
             attention_mask: Optional additive attention mask of shape [batch, 1, sequence, sequence].
+            packed_context: Optional document layout of the batch, required under
+                context parallelism.
             **kwargs: Extra attention options accepted for HF compatibility.
 
         Returns:
             Tensor of shape [batch, sequence, hidden].
         """
         del kwargs
+        if packed_context is not None and packed_context.cp_enabled:
+            return self._forward_with_cp(hidden_states, packed_context)
         batch_size, seq_length = hidden_states.shape[:-1]
+        if attention_mask is None:
+            # Built here rather than in the backbone because sequence parallelism
+            # hands the backbone a sequence shard while this layer runs on the
+            # all-gathered sequence.
+            attention_mask = _make_causal_mask(hidden_states, packed_context, dtype=hidden_states.dtype)
         query_shape = (batch_size, seq_length, -1, self.q_head_dim)
         key_shape = (batch_size, seq_length, -1, self.qk_nope_head_dim + self.v_head_dim)
 
@@ -301,23 +365,7 @@ class KimiMLAAttention(nn.Module):
         query_states = torch.cat((q_pass, q_rot), dim=-1)
         key_states = torch.cat((k_pass, k_rot), dim=-1)
 
-        if self.num_key_value_groups != 1:
-            key_states = key_states[:, :, None, :, :].expand(
-                batch_size,
-                self.num_key_value_heads,
-                self.num_key_value_groups,
-                seq_length,
-                self.q_head_dim,
-            )
-            value_states = value_states[:, :, None, :, :].expand(
-                batch_size,
-                self.num_key_value_heads,
-                self.num_key_value_groups,
-                seq_length,
-                self.v_head_dim,
-            )
-            key_states = key_states.reshape(batch_size, self.num_heads, seq_length, self.q_head_dim)
-            value_states = value_states.reshape(batch_size, self.num_heads, seq_length, self.v_head_dim)
+        key_states, value_states = self._expand_key_value_groups(key_states, value_states, seq_length)
 
         attn_weights = torch.matmul(query_states, key_states.transpose(2, 3)) * self.scaling
         if attention_mask is not None:
@@ -326,6 +374,90 @@ class KimiMLAAttention(nn.Module):
         attn_weights = F.dropout(attn_weights, p=self.attention_dropout, training=self.training)
         attn_output = torch.matmul(attn_weights, value_states)
         attn_output = attn_output.transpose(1, 2).contiguous().reshape(batch_size, seq_length, -1)
+        return self.o_proj(attn_output)
+
+    def _expand_key_value_groups(
+        self,
+        key_states: torch.Tensor,
+        value_states: torch.Tensor,
+        seq_length: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Repeat key/value heads to match the query heads.
+
+        Args:
+            key_states: Tensor of shape [batch, key_value_heads, sequence, qk_head_dim].
+            value_states: Tensor of shape [batch, key_value_heads, sequence, v_head_dim].
+            seq_length: Sequence length of the key/value tensors.
+
+        Returns:
+            Key and value tensors expanded to [batch, heads, sequence, head_dim].
+        """
+        if self.num_key_value_groups == 1:
+            return key_states, value_states
+        batch_size = key_states.shape[0]
+        key_states = key_states[:, :, None, :, :].expand(
+            batch_size, self.num_key_value_heads, self.num_key_value_groups, seq_length, self.q_head_dim
+        )
+        value_states = value_states[:, :, None, :, :].expand(
+            batch_size, self.num_key_value_heads, self.num_key_value_groups, seq_length, self.v_head_dim
+        )
+        return (
+            key_states.reshape(batch_size, self.num_heads, seq_length, self.q_head_dim),
+            value_states.reshape(batch_size, self.num_heads, seq_length, self.v_head_dim),
+        )
+
+    def _forward_with_cp(self, hidden_states: torch.Tensor, packed_context: KimiPackedContext) -> torch.Tensor:
+        """Run MLA attention over a contiguous context-parallel shard.
+
+        Queries stay local while the compressed KV latent -- ``kv_lora_rank +
+        qk_rope_head_dim`` values per token, far smaller than the expanded per-head
+        keys and values -- is all-gathered across the context-parallel group and
+        expanded locally. Attention then runs as FlexAttention with a causal,
+        per-document block mask over the full sequence.
+
+        Args:
+            hidden_states: Tensor of shape [batch, local_sequence, hidden].
+            packed_context: Document layout of the batch.
+
+        Returns:
+            Tensor of shape [batch, local_sequence, hidden].
+        """
+        if self._cp_mesh is None:
+            raise RuntimeError(
+                "Kimi MLA attention received a context-parallel batch but no CP mesh; "
+                "apply_cp must run before the forward pass."
+            )
+        cp_group = self._cp_mesh.get_group()
+        batch_size, local_seq_length = hidden_states.shape[:-1]
+
+        q_states = self.q_proj(hidden_states).view(batch_size, local_seq_length, -1, self.q_head_dim).transpose(1, 2)
+        q_pass, q_rot = torch.split(q_states, [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
+
+        compressed_kv = all_gather_sequence(self.kv_a_proj_with_mqa(hidden_states), cp_group, dim=1)
+        full_seq_length = compressed_kv.shape[1]
+        k_pass, k_rot = torch.split(compressed_kv, [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
+
+        key_shape = (batch_size, full_seq_length, -1, self.qk_nope_head_dim + self.v_head_dim)
+        k_pass = self.kv_b_proj(self.kv_a_layernorm(k_pass)).view(key_shape).transpose(1, 2)
+        k_pass, value_states = torch.split(k_pass, [self.qk_nope_head_dim, self.v_head_dim], dim=-1)
+
+        k_rot = k_rot.view(batch_size, 1, full_seq_length, self.qk_rope_head_dim)
+        k_rot = k_rot.expand(*k_pass.shape[:-1], -1)
+
+        query_states = torch.cat((q_pass, q_rot), dim=-1)
+        key_states = torch.cat((k_pass, k_rot), dim=-1)
+        key_states, value_states = self._expand_key_value_groups(key_states, value_states, full_seq_length)
+
+        attn_output = document_causal_flex_attention(
+            query_states,
+            key_states,
+            value_states,
+            q_doc_ids=packed_context.local_doc_ids,
+            kv_doc_ids=packed_context.doc_ids,
+            q_global_start=packed_context.seq_start,
+            scale=self.scaling,
+        )
+        attn_output = attn_output.transpose(1, 2).contiguous().reshape(batch_size, local_seq_length, -1)
         return self.o_proj(attn_output)
 
     @torch.no_grad()
@@ -438,23 +570,42 @@ class KimiDeltaAttention(nn.Module):
         self.g_b_proj = nn.Linear(self.head_dim, projection_size, bias=False, dtype=dtype)
         self.o_norm = FusedRMSNormGated(self.head_dim, eps=config.rms_norm_eps, activation="sigmoid", dtype=dtype)
         self.o_proj = nn.Linear(projection_size, self.hidden_size, bias=False, dtype=dtype)
+        self._cp_mesh = None
+
+    def setup_cp_attention(self, cp_mesh) -> None:
+        """Attach the context-parallel mesh used to build FLA's CP context.
+
+        Called by the MoE parallelizer's ``apply_cp`` for every attention block.
+
+        Args:
+            cp_mesh: One-dimensional context-parallel device mesh.
+        """
+        self._cp_mesh = cp_mesh
 
     def forward(
         self,
         hidden_states: torch.Tensor,
         attention_mask: torch.Tensor | None = None,
+        packed_context: "KimiPackedContext | None" = None,
         **kwargs: Any,
     ) -> torch.Tensor:
         """Run KDA linear attention.
 
         Args:
-            hidden_states: Tensor of shape [batch, sequence, hidden].
+            hidden_states: Tensor of shape [batch, sequence, hidden]; the sequence axis
+                holds this rank's contiguous shard under context parallelism.
             attention_mask: Optional binary padding mask of shape [batch, sequence] where 1 marks valid tokens.
+            packed_context: Optional document layout of the batch, required under
+                context parallelism and used to reset the recurrent state at every
+                packed-document boundary.
             **kwargs: Optional KDA kwargs, including ``cu_seqlens`` for packed sequences.
 
         Returns:
             Tensor of shape [batch, sequence, hidden].
         """
+        if packed_context is not None and packed_context.cp_enabled:
+            return self._forward_with_cp(hidden_states, packed_context)
+
         if attention_mask is not None:
             if attention_mask.dim() != 2:
                 attention_mask = kwargs.get("padding_mask")
@@ -465,15 +616,76 @@ class KimiDeltaAttention(nn.Module):
 
         cu_seqlens = kwargs.get("cu_seqlens")
         indices = None
-        if attention_mask is not None and getattr(self.config, "kda_unpad_inputs", True):
+        if is_indexed_packed_mask(attention_mask):
+            # Packed rows: unpad to a single flat sequence and reset the recurrent
+            # state per document instead of per row.
+            indices, cu_seqlens, _ = get_unpad_data(attention_mask[:, -q_len:])
+            hidden_states = _index_first_axis(hidden_states.reshape(batch_size * q_len, -1), indices).unsqueeze(0)
+        elif attention_mask is not None and getattr(self.config, "kda_unpad_inputs", True):
             indices, cu_seqlens, _ = _get_unpad_data(attention_mask[:, -q_len:])
             hidden_states = _index_first_axis(hidden_states.reshape(batch_size * q_len, -1), indices).unsqueeze(0)
-        effective_q_len = hidden_states.shape[1]
-        mode = "fused_recurrent" if effective_q_len <= 64 else self.mode
 
-        q, _ = self.q_conv1d(x=self.q_proj(hidden_states), cache=None, output_final_state=False, cu_seqlens=cu_seqlens)
-        k, _ = self.k_conv1d(x=self.k_proj(hidden_states), cache=None, output_final_state=False, cu_seqlens=cu_seqlens)
-        v, _ = self.v_conv1d(x=self.v_proj(hidden_states), cache=None, output_final_state=False, cu_seqlens=cu_seqlens)
+        o = self._kda_core(hidden_states, cu_seqlens=cu_seqlens)
+        if indices is not None:
+            o = _pad_input(o.squeeze(0), indices, batch_size, q_len)
+        return o
+
+    def _forward_with_cp(self, hidden_states: torch.Tensor, packed_context: KimiPackedContext) -> torch.Tensor:
+        """Run KDA over a contiguous context-parallel shard.
+
+        FLA's context-parallel kernels take the *global* ``cu_seqlens`` and derive
+        each rank's local segments, passing the recurrent state (and the short
+        convolution's boundary tokens) rank to rank. Batch rows are processed one
+        at a time because FLA's variable-length path expects a single flattened
+        sequence per call.
+
+        Args:
+            hidden_states: Tensor of shape [batch, local_sequence, hidden].
+            packed_context: Document layout of the batch.
+
+        Returns:
+            Tensor of shape [batch, local_sequence, hidden].
+        """
+        if self._cp_mesh is None:
+            raise RuntimeError(
+                "Kimi KDA attention received a context-parallel batch but no CP mesh; "
+                "apply_cp must run before the forward pass."
+            )
+        cp_group = self._cp_mesh.get_group()
+        outputs = [
+            self._kda_core(
+                hidden_states[row : row + 1],
+                cp_context=build_fla_cp_context(packed_context, row, cp_group, self.conv_size),
+            )
+            for row in range(hidden_states.shape[0])
+        ]
+        return torch.cat(outputs, dim=0)
+
+    def _kda_core(
+        self,
+        hidden_states: torch.Tensor,
+        *,
+        cu_seqlens: torch.Tensor | None = None,
+        cp_context: Any = None,
+    ) -> torch.Tensor:
+        """Run the KDA projections, convolutions and delta-rule kernel.
+
+        Args:
+            hidden_states: Tensor of shape [batch, sequence, hidden]; the batch must be
+                one whenever ``cu_seqlens`` or ``cp_context`` is given.
+            cu_seqlens: Optional cumulative document lengths of shape [documents + 1].
+            cp_context: Optional FLA context-parallel context, which supersedes
+                ``cu_seqlens`` with its per-rank local segments.
+
+        Returns:
+            Tensor of shape [batch, sequence, hidden].
+        """
+        kernel_kwargs: dict[str, Any] = {} if cp_context is None else {"cp_context": cp_context}
+        conv_kwargs = dict(cache=None, output_final_state=False, cu_seqlens=cu_seqlens, **kernel_kwargs)
+
+        q, _ = self.q_conv1d(x=self.q_proj(hidden_states), **conv_kwargs)
+        k, _ = self.k_conv1d(x=self.k_proj(hidden_states), **conv_kwargs)
+        v, _ = self.v_conv1d(x=self.v_proj(hidden_states), **conv_kwargs)
         g = self.f_b_proj(self.f_a_proj(hidden_states)).contiguous()
         beta = self.b_proj(hidden_states).float().sigmoid()
 
@@ -487,38 +699,32 @@ class KimiDeltaAttention(nn.Module):
             q = F.normalize(q.float(), p=2, dim=-1, eps=1e-6).to(q.dtype)
             k = F.normalize(k.float(), p=2, dim=-1, eps=1e-6).to(k.dtype)
 
-        if mode == "chunk":
-            o, _ = chunk_kda(
-                q=q,
-                k=k,
-                v=v,
-                g=g,
-                beta=beta,
-                initial_state=None,
-                output_final_state=True,
-                use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
-                cu_seqlens=cu_seqlens,
-            )
-        else:
-            o, _ = fused_recurrent_kda(
-                q=q,
-                k=k,
-                v=v,
-                g=g,
-                beta=beta,
-                initial_state=None,
-                output_final_state=True,
-                use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
-                cu_seqlens=cu_seqlens,
-            )
+        # The recurrent kernel cannot pass state across ranks, so context parallelism
+        # always runs the chunked kernel.
+        mode = "chunk" if cp_context is not None else self._resolve_mode(hidden_states.shape[1])
+        kernel = chunk_kda if mode == "chunk" else fused_recurrent_kda
+        o, _ = kernel(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            initial_state=None,
+            # Under CP the final state is owned by FLA's rank-to-rank handoff.
+            output_final_state=cp_context is None,
+            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+            cu_seqlens=cu_seqlens,
+            **kernel_kwargs,
+        )
 
         gate = self.g_b_proj(self.g_a_proj(hidden_states)).reshape(*hidden_states.shape[:-1], self.num_heads, -1)
         o = self.o_norm(o, gate)
         o = o.reshape(o.shape[0], o.shape[1], -1).contiguous()
-        o = self.o_proj(o)
-        if indices is not None:
-            o = _pad_input(o.squeeze(0), indices, batch_size, q_len)
-        return o
+        return self.o_proj(o)
+
+    def _resolve_mode(self, seq_len: int) -> str:
+        """Return the KDA kernel to use for a sequence of ``seq_len`` tokens."""
+        return "fused_recurrent" if seq_len <= 64 else self.mode
 
     @torch.no_grad()
     def init_weights(self, buffer_device: torch.device, init_std: float) -> None:
@@ -562,8 +768,11 @@ class KimiDecoderLayer(nn.Module):
         )
 
         dtype = get_dtype(getattr(config, "torch_dtype", None), torch.bfloat16)
+        # Both branches are named ``mlp``: the custom-MoE parallelizer discovers MoE
+        # layers by that attribute (as MiniMax does), and the checkpoint's
+        # ``block_sparse_moe`` naming is handled by the state-dict adapter.
         if self.is_moe_layer:
-            self.block_sparse_moe = MoE(moe_config, backend)
+            self.mlp = MoE(moe_config, backend)
         else:
             self.mlp = MLP(config.hidden_size, config.intermediate_size, backend.linear, dtype=dtype)
         self.input_layernorm = KimiRMSNorm(config.hidden_size, eps=config.rms_norm_eps, dtype=dtype)
@@ -614,7 +823,7 @@ class KimiDecoderLayer(nn.Module):
         Returns:
             Tensor of shape [batch, sequence, hidden].
         """
-        moe = unwrap_checkpoint_wrapper(self.block_sparse_moe)
+        moe = unwrap_checkpoint_wrapper(self.mlp)
         if not isinstance(moe, MoE):
             raise TypeError(f"Expected Kimi MoE layer, got {type(moe).__name__}.")
         experts = unwrap_checkpoint_wrapper(moe.experts)
@@ -625,7 +834,7 @@ class KimiDecoderLayer(nn.Module):
             and not self._has_dtensor_expert_params(experts)
         ):
             return self._moe_infer_hf_order(moe, experts, hidden_states)
-        return self.block_sparse_moe(hidden_states, padding_mask)
+        return self.mlp(hidden_states, padding_mask)
 
     @staticmethod
     def _has_dtensor_expert_params(experts: GroupedExperts) -> bool:
@@ -708,7 +917,7 @@ class KimiDecoderLayer(nn.Module):
         self.post_attention_layernorm.reset_parameters()
         self.self_attn.init_weights(buffer_device, init_std)
         if self.is_moe_layer:
-            self.block_sparse_moe.init_weights(buffer_device, init_std)
+            self.mlp.init_weights(buffer_device, init_std)
         else:
             self.mlp.init_weights(buffer_device, init_std)
 
@@ -806,6 +1015,7 @@ class KimiLinearModel(nn.Module):
         position_ids: torch.Tensor | None = None,
         padding_mask: torch.Tensor | None = None,
         cache_position: torch.Tensor | None = None,
+        kimi_packed_context: KimiPackedContext | None = None,
         **attn_kwargs: Any,
     ) -> torch.Tensor:
         """Run the Kimi Linear decoder.
@@ -813,10 +1023,13 @@ class KimiLinearModel(nn.Module):
         Args:
             input_ids: Optional token ids of shape [batch, sequence].
             inputs_embeds: Optional embeddings of shape [batch, sequence, hidden].
-            attention_mask: Optional binary padding mask of shape [batch, sequence].
+            attention_mask: Optional binary or indexed packing mask of shape [batch, sequence].
             position_ids: Optional positions of shape [batch, sequence]; accepted for HF compatibility.
             padding_mask: Optional boolean tensor of shape [batch, sequence], where true marks padding tokens.
             cache_position: Optional position vector of shape [sequence].
+            kimi_packed_context: Optional document layout attached by
+                :func:`~nemo_automodel.components.models.kimi_linear.cp.shard_batch_for_kimi_cp`;
+                required under context parallelism and otherwise derived here.
             **attn_kwargs: Additional attention kwargs used by packed or THD execution.
 
         Returns:
@@ -830,12 +1043,18 @@ class KimiLinearModel(nn.Module):
         if cache_position is None:
             cache_position = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device)
 
+        packed_context = kimi_packed_context or _packed_context_from_inputs(
+            inputs_embeds,
+            attention_mask=attention_mask,
+            cu_seqlens=attn_kwargs.get("cu_seqlens"),
+        )
         linear_attn_mask = self._update_linear_attn_mask(attention_mask, cache_position)
-        causal_mask = _make_causal_mask(inputs_embeds, attention_mask, dtype=inputs_embeds.dtype)
         hidden_states = inputs_embeds
 
         for decoder_layer in self.layers.values():
-            layer_mask = linear_attn_mask if decoder_layer.is_linear_attn else causal_mask
+            # Full-attention layers build their own additive mask; see
+            # ``KimiMLAAttention.forward``.
+            layer_mask = linear_attn_mask if decoder_layer.is_linear_attn else None
             layer_padding_mask = padding_mask
             if decoder_layer.is_linear_attn and layer_mask is not None:
                 layer_padding_mask = layer_mask.bool().logical_not()
@@ -843,6 +1062,7 @@ class KimiLinearModel(nn.Module):
                 hidden_states,
                 attention_mask=layer_mask,
                 padding_mask=layer_padding_mask,
+                packed_context=packed_context,
                 **attn_kwargs,
             )
 
@@ -851,8 +1071,8 @@ class KimiLinearModel(nn.Module):
     def update_moe_gate_bias(self) -> None:
         with torch.no_grad():
             for block in self.layers.values():
-                if block.is_moe_layer and block.block_sparse_moe.gate.bias_update_factor > 0:
-                    block.block_sparse_moe.gate.update_bias()
+                if block.is_moe_layer and block.mlp.gate.bias_update_factor > 0:
+                    block.mlp.gate.update_bias()
 
     @torch.no_grad()
     def init_weights(self, buffer_device: torch.device | None = None) -> None:
@@ -875,13 +1095,24 @@ class KimiLinearForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
     tie_word_embeddings_support: TieSupport = TieSupport.UNTIED_ONLY
     _keep_in_fp32_modules = ["_fp32_params", "e_score_correction_bias"]
     _keep_in_fp32_modules_strict = ["_fp32_params", "e_score_correction_bias"]
+    # Kimi Linear owns context parallelism end to end: it shards the batch itself
+    # (contiguous slices, as FLA's CP kernels require) and each layer type carries
+    # its own transport, so CP does not depend on the attention backend.
+    _owns_cp_attention = True
+    # Packed documents are masked by the model itself: MLA gets a document-blocked
+    # causal mask and KDA resets its recurrent state on per-document ``cu_seqlens``.
+    _owns_packed_attention = True
+    # The tensor-parallel plan shards the block boundaries (norms, output
+    # projections and the MoE output) along the sequence, so the custom-MoE path
+    # may enable sequence parallelism for this architecture.
+    _supports_sequence_parallel = True
 
     @dataclass(frozen=True)
     class ModelCapabilities:
         """Declared parallelism capabilities for Kimi Linear."""
 
-        supports_tp: bool = False
-        supports_cp: bool = False
+        supports_tp: bool = True
+        supports_cp: bool = True
         supports_pp: bool = False
         supports_ep: bool = True
 
@@ -990,6 +1221,16 @@ class KimiLinearForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
                 attn_kwargs,
             )
             attention_mask = None
+            # THD packing drops the placeholder batch axis, but every Kimi layer
+            # works in [batch, sequence, ...]. Restore it and let ``cu_seqlens``
+            # carry the document boundaries; ``compute_lm_head_logits`` leaves the
+            # already-batched [1, tokens, hidden] result untouched.
+            if input_ids is not None and input_ids.dim() == 1:
+                input_ids = input_ids.unsqueeze(0)
+            if inputs_embeds is not None and inputs_embeds.dim() == 2:
+                inputs_embeds = inputs_embeds.unsqueeze(0)
+            if padding_mask is not None and padding_mask.dim() == 1:
+                padding_mask = padding_mask.unsqueeze(0)
 
         hidden_states = self.model(
             input_ids=input_ids,
@@ -1006,6 +1247,24 @@ class KimiLinearForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
             is_thd=is_thd,
             output_hidden_states=output_hidden_states,
         )
+
+    def prepare_model_inputs_for_cp(self, input_ids: torch.Tensor | None = None, **kwargs: Any) -> dict[str, Any]:
+        """Hand the recipe Kimi Linear's own context-parallel batch sharding.
+
+        KDA's recurrent state (and FLA's CP kernels) require every rank to own one
+        contiguous slice of the sequence, so Kimi Linear replaces the default
+        load-balanced ``context_parallel`` sharding with
+        :func:`~nemo_automodel.components.models.kimi_linear.cp.shard_batch_for_kimi_cp`.
+
+        Args:
+            input_ids: Token ids of the unsharded batch; accepted for interface parity.
+            **kwargs: Additional recipe arguments; accepted for interface parity.
+
+        Returns:
+            Batch updates carrying the model-owned sharding callable.
+        """
+        del input_ids, kwargs
+        return {"_cp_make_batch_fn": shard_batch_for_kimi_cp}
 
     def update_moe_gate_bias(self) -> None:
         self.model.update_moe_gate_bias()

--- a/nemo_automodel/components/models/kimi_linear/state_dict_adapter.py
+++ b/nemo_automodel/components/models/kimi_linear/state_dict_adapter.py
@@ -182,7 +182,17 @@ class KimiLinearStateDictAdapter(MoESplitExpertsStateDictMixin, StateDictAdapter
         return self._from_hf_w_merged_experts(generic_state_dict, device_mesh)
 
     def _split_experts_weights(self, weight: torch.Tensor, n_experts: int) -> list[torch.Tensor]:
-        """Split grouped experts, tolerating DTensors whose mesh dim is not named ``ep``."""
+        """Split grouped experts, tolerating DTensors whose mesh dim is not named ``ep``.
+
+        Args:
+            weight: Grouped routed-expert tensor of shape [experts, ...]. May be a plain tensor or a DTensor
+                sharded or replicated over the expert axis; for Shard(0), the local shard covers this rank's
+                expert slice.
+            n_experts: Global number of routed experts.
+
+        Returns:
+            List of per-expert tensors of shape [...] for the experts local to this rank.
+        """
         from torch.distributed._tensor.placement_types import Replicate, Shard
 
         from nemo_automodel.components.moe.state_dict_utils import get_submesh, is_dtensor

--- a/nemo_automodel/components/models/kimi_linear/state_dict_adapter.py
+++ b/nemo_automodel/components/models/kimi_linear/state_dict_adapter.py
@@ -1,0 +1,226 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""State-dict adapter for Kimi Linear MoE checkpoints."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import torch
+from torch.distributed.device_mesh import DeviceMesh
+
+from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.moe.config import MoEConfig
+from nemo_automodel.components.moe.state_dict_mixin import MoESplitExpertsStateDictMixin
+
+_HF_TO_GENERIC_EXPERT_PROJ = {
+    "w1": "gate_proj",
+    "w2": "down_proj",
+    "w3": "up_proj",
+}
+_GENERIC_TO_HF_EXPERT_PROJ = {value: key for key, value in _HF_TO_GENERIC_EXPERT_PROJ.items()}
+_FP32_KEY_PARTS = ("A_log", "dt_bias", "e_score_correction_bias")
+_KDA_FP32_HOLDER = re.compile(r"(\.self_attn)\._fp32_params\.")
+_KDA_FP32_PARAM_NAMES = ("A_log", "dt_bias")
+
+
+def _upcast_fp32_state_tensor(key: str, value: Any) -> Any:
+    if isinstance(value, torch.Tensor) and any(part in key for part in _FP32_KEY_PARTS):
+        return value.to(torch.float32)
+    return value
+
+
+def _strip_kda_fp32_holder(key: str) -> str:
+    return _KDA_FP32_HOLDER.sub(r"\1.", key)
+
+
+def _route_kda_fp32_holder(key: str) -> str:
+    if not key.endswith(_KDA_FP32_PARAM_NAMES):
+        return key
+    if "._fp32_params." in key:
+        return key
+    if ".self_attn." not in key:
+        return key
+    head, tail = key.rsplit(".self_attn.", 1)
+    return f"{head}.self_attn._fp32_params.{tail}"
+
+
+class KimiLinearStateDictAdapter(MoESplitExpertsStateDictMixin, StateDictAdapter):
+    """Convert Kimi Linear HF split experts to Automodel grouped experts.
+
+    HF stores routed experts as per-expert Kimi names:
+
+    * ``block_sparse_moe.experts.{E}.w1.weight``: SwiGLU gate projection, shape [inter, hidden].
+    * ``block_sparse_moe.experts.{E}.w3.weight``: SwiGLU up projection, shape [inter, hidden].
+    * ``block_sparse_moe.experts.{E}.w2.weight``: down projection, shape [hidden, inter].
+
+    Automodel stores grouped experts as:
+
+    * ``block_sparse_moe.experts.gate_and_up_projs`` with shape [experts, hidden, 2 * inter].
+    * ``block_sparse_moe.experts.down_projs`` with shape [experts, inter, hidden].
+    """
+
+    def __init__(
+        self,
+        config: Any,
+        moe_config: MoEConfig,
+        backend: BackendConfig,
+        dtype: torch.dtype = torch.float32,
+    ) -> None:
+        self.config = config
+        self.moe_config = moe_config
+        self.backend = backend
+        self.dtype = dtype
+        self._uses_model_prefix = True
+
+    @property
+    def _expert_path_segment(self) -> str:
+        return "block_sparse_moe.experts"
+
+    def _map_hf_expert_key_to_generic(self, key: str) -> str:
+        match = re.match(
+            r"(?P<prefix>(?:model\.)?layers\.\d+\.block_sparse_moe\.experts\.\d+)\."
+            r"(?P<proj>w1|w2|w3)\.weight$",
+            key,
+        )
+        if match is None:
+            return key
+        return f"{match.group('prefix')}.{_HF_TO_GENERIC_EXPERT_PROJ[match.group('proj')]}.weight"
+
+    def _map_generic_expert_key_to_hf(self, key: str) -> str:
+        match = re.match(
+            r"(?P<prefix>(?:model\.)?layers\.\d+\.block_sparse_moe\.experts\.\d+)\."
+            r"(?P<proj>gate_proj|up_proj|down_proj)\.weight$",
+            key,
+        )
+        if match is None:
+            return key
+        return f"{match.group('prefix')}.{_GENERIC_TO_HF_EXPERT_PROJ[match.group('proj')]}.weight"
+
+    def to_hf(
+        self,
+        state_dict: dict[str, Any],
+        exclude_key_regex: str | None = None,
+        quantization: bool = False,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Convert Automodel native tensors to Kimi HF checkpoint keys."""
+        previous_device_mesh = getattr(self, "_active_device_mesh", None)
+        self._active_device_mesh = kwargs.get("device_mesh")
+        hf_state_dict: dict[str, Any] = {}
+        try:
+            for fqn, tensor in state_dict.items():
+                converted_tensors = self.convert_single_tensor_to_hf(
+                    fqn,
+                    tensor,
+                    exclude_key_regex=exclude_key_regex,
+                    quantization=quantization,
+                    **kwargs,
+                )
+                for key, value in converted_tensors:
+                    hf_state_dict[key] = value
+        finally:
+            self._active_device_mesh = previous_device_mesh
+        return hf_state_dict
+
+    def convert_single_tensor_to_hf(self, fqn: str, tensor: Any, **kwargs: Any) -> list[tuple[str, Any]]:
+        """Convert one Automodel tensor to one or more Kimi HF tensors.
+
+        Args:
+            fqn: Fully qualified native tensor name.
+            tensor: Native tensor. Grouped routed expert tensors use [experts, hidden, 2 * inter]
+                for gate/up and [experts, inter, hidden] for down.
+            **kwargs: Adapter options forwarded by checkpoint save/load.
+
+        Returns:
+            HF key/tensor pairs. Split expert tensors use Kimi ``w1``/``w2``/``w3`` names.
+        """
+        exclude_key_regex = kwargs.get("exclude_key_regex", None)
+        expert_result = self._convert_single_merged_expert_to_hf_split_experts(fqn, tensor, **kwargs)
+        result = expert_result if expert_result is not None else [(fqn, tensor)]
+        result = [(_strip_kda_fp32_holder(key), value) for key, value in result]
+        result = [(self._map_generic_expert_key_to_hf(key), value) for key, value in result]
+        if exclude_key_regex:
+            result = [(key, value) for key, value in result if not re.match(exclude_key_regex, key)]
+        return result
+
+    def from_hf(
+        self,
+        hf_state_dict: dict[str, Any],
+        device_mesh: DeviceMesh | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Convert Kimi HF checkpoint keys to Automodel native keys.
+
+        Args:
+            hf_state_dict: HF state dict whose routed expert tensors use split Kimi names.
+            device_mesh: Optional EP/FSDP mesh used to load only local expert shards.
+            **kwargs: Adapter options forwarded by checkpoint load.
+
+        Returns:
+            Native state dict with grouped routed expert tensors.
+        """
+        self._uses_model_prefix = any(key.startswith("model.") for key in hf_state_dict)
+        generic_state_dict = {
+            _route_kda_fp32_holder(self._map_hf_expert_key_to_generic(key)): _upcast_fp32_state_tensor(key, value)
+            for key, value in hf_state_dict.items()
+        }
+        return self._from_hf_w_merged_experts(generic_state_dict, device_mesh)
+
+    def _split_experts_weights(self, weight: torch.Tensor, n_experts: int) -> list[torch.Tensor]:
+        """Split grouped experts, tolerating DTensors whose mesh dim is not named ``ep``."""
+        from torch.distributed._tensor.placement_types import Replicate, Shard
+
+        from nemo_automodel.components.moe.state_dict_utils import get_submesh, is_dtensor
+
+        if not is_dtensor(weight) or "ep" in weight.device_mesh.mesh_dim_names:
+            return super()._split_experts_weights(weight, n_experts)
+
+        local_tensor = weight.to_local()
+        placement = weight.placements[-1] if weight.placements else None
+        if isinstance(placement, Replicate):
+            start_expert = 0
+            local_n_experts = n_experts
+        elif isinstance(placement, Shard) and placement.dim == 0:
+            mesh = getattr(self, "_active_device_mesh", None)
+            if mesh is not None and "ep" in mesh.mesh_dim_names:
+                ep_mesh = get_submesh(mesh, ("ep",))
+                mesh_rank = ep_mesh.get_local_rank()
+                mesh_size = ep_mesh.size()
+            else:
+                mesh_rank = weight.device_mesh.get_local_rank()
+                mesh_size = weight.device_mesh.size()
+            experts_per_rank = n_experts // mesh_size
+            remainder = n_experts % mesh_size
+            if mesh_rank < remainder:
+                local_n_experts = experts_per_rank + 1
+                start_expert = mesh_rank * local_n_experts
+            else:
+                local_n_experts = experts_per_rank
+                start_expert = remainder * (experts_per_rank + 1) + (mesh_rank - remainder) * experts_per_rank
+        else:
+            start_expert = 0
+            local_n_experts = local_tensor.shape[0]
+
+        if local_tensor.shape[0] != local_n_experts:
+            raise ValueError(
+                f"Expected local Kimi expert tensor first dimension to be {local_n_experts} "
+                f"(experts {start_expert}:{start_expert + local_n_experts}), got {local_tensor.shape[0]}"
+            )
+
+        self._last_expert_ids = list(range(start_expert, start_expert + local_n_experts))
+        return [local_tensor[i] for i in range(local_n_experts)]

--- a/nemo_automodel/components/models/kimi_linear/state_dict_adapter.py
+++ b/nemo_automodel/components/models/kimi_linear/state_dict_adapter.py
@@ -59,6 +59,27 @@ def _route_kda_fp32_holder(key: str) -> str:
     return f"{head}.self_attn._fp32_params.{tail}"
 
 
+# The decoder block calls its feed-forward ``mlp`` for both the dense and the MoE
+# case, so only the MoE-owned children are renamed. Dense layers keep
+# ``mlp.{gate,up,down}_proj`` on both sides and must not be touched, which is why
+# these are exact path segments rather than a blanket ``mlp`` rewrite.
+_MOE_CHILD_SEGMENTS = ("gate.", "shared_experts.")
+
+
+def _hf_moe_key_to_native(key: str) -> str:
+    """Rewrite a checkpoint MoE key onto the decoder block's ``mlp`` submodule."""
+    for segment in _MOE_CHILD_SEGMENTS:
+        key = key.replace(f".block_sparse_moe.{segment}", f".mlp.{segment}")
+    return key
+
+
+def _native_moe_key_to_hf(key: str) -> str:
+    """Inverse of :func:`_hf_moe_key_to_native`."""
+    for segment in _MOE_CHILD_SEGMENTS:
+        key = key.replace(f".mlp.{segment}", f".block_sparse_moe.{segment}")
+    return key
+
+
 class KimiLinearStateDictAdapter(MoESplitExpertsStateDictMixin, StateDictAdapter):
     """Convert Kimi Linear HF split experts to Automodel grouped experts.
 
@@ -70,8 +91,12 @@ class KimiLinearStateDictAdapter(MoESplitExpertsStateDictMixin, StateDictAdapter
 
     Automodel stores grouped experts as:
 
-    * ``block_sparse_moe.experts.gate_and_up_projs`` with shape [experts, hidden, 2 * inter].
-    * ``block_sparse_moe.experts.down_projs`` with shape [experts, inter, hidden].
+    * ``mlp.experts.gate_and_up_projs`` with shape [experts, hidden, 2 * inter].
+    * ``mlp.experts.down_projs`` with shape [experts, inter, hidden].
+
+    The decoder block names both its dense and its MoE feed-forward ``mlp`` (the
+    naming the custom-MoE parallelizer looks for), so the checkpoint's
+    ``block_sparse_moe`` path segment is translated here in both directions.
     """
 
     def __init__(
@@ -89,27 +114,29 @@ class KimiLinearStateDictAdapter(MoESplitExpertsStateDictMixin, StateDictAdapter
 
     @property
     def _expert_path_segment(self) -> str:
-        return "block_sparse_moe.experts"
+        return "mlp.experts"
 
     def _map_hf_expert_key_to_generic(self, key: str) -> str:
         match = re.match(
-            r"(?P<prefix>(?:model\.)?layers\.\d+\.block_sparse_moe\.experts\.\d+)\."
+            r"(?P<prefix>(?:model\.)?layers\.\d+)\.block_sparse_moe\.experts\.(?P<expert>\d+)\."
             r"(?P<proj>w1|w2|w3)\.weight$",
             key,
         )
         if match is None:
             return key
-        return f"{match.group('prefix')}.{_HF_TO_GENERIC_EXPERT_PROJ[match.group('proj')]}.weight"
+        projection = _HF_TO_GENERIC_EXPERT_PROJ[match.group("proj")]
+        return f"{match.group('prefix')}.mlp.experts.{match.group('expert')}.{projection}.weight"
 
     def _map_generic_expert_key_to_hf(self, key: str) -> str:
         match = re.match(
-            r"(?P<prefix>(?:model\.)?layers\.\d+\.block_sparse_moe\.experts\.\d+)\."
+            r"(?P<prefix>(?:model\.)?layers\.\d+)\.mlp\.experts\.(?P<expert>\d+)\."
             r"(?P<proj>gate_proj|up_proj|down_proj)\.weight$",
             key,
         )
         if match is None:
             return key
-        return f"{match.group('prefix')}.{_GENERIC_TO_HF_EXPERT_PROJ[match.group('proj')]}.weight"
+        projection = _GENERIC_TO_HF_EXPERT_PROJ[match.group("proj")]
+        return f"{match.group('prefix')}.block_sparse_moe.experts.{match.group('expert')}.{projection}.weight"
 
     def to_hf(
         self,
@@ -154,6 +181,7 @@ class KimiLinearStateDictAdapter(MoESplitExpertsStateDictMixin, StateDictAdapter
         result = expert_result if expert_result is not None else [(fqn, tensor)]
         result = [(_strip_kda_fp32_holder(key), value) for key, value in result]
         result = [(self._map_generic_expert_key_to_hf(key), value) for key, value in result]
+        result = [(_native_moe_key_to_hf(key), value) for key, value in result]
         if exclude_key_regex:
             result = [(key, value) for key, value in result if not re.match(exclude_key_regex, key)]
         return result
@@ -176,7 +204,9 @@ class KimiLinearStateDictAdapter(MoESplitExpertsStateDictMixin, StateDictAdapter
         """
         self._uses_model_prefix = any(key.startswith("model.") for key in hf_state_dict)
         generic_state_dict = {
-            _route_kda_fp32_holder(self._map_hf_expert_key_to_generic(key)): _upcast_fp32_state_tensor(key, value)
+            _route_kda_fp32_holder(_hf_moe_key_to_native(self._map_hf_expert_key_to_generic(key))): (
+                _upcast_fp32_state_tensor(key, value)
+            )
             for key, value in hf_state_dict.items()
         }
         return self._from_hf_w_merged_experts(generic_state_dict, device_mesh)

--- a/nemo_automodel/components/models/kimi_linear/tp.py
+++ b/nemo_automodel/components/models/kimi_linear/tp.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tensor- and sequence-parallel plan for Kimi Linear.
+
+Kimi Linear interleaves KDA linear-attention layers with MLA full-attention
+layers, and the two are treated differently:
+
+* **MLA** follows the usual column/row pattern. ``q_proj`` and ``kv_b_proj``
+  expand to per-head features and are column-sharded; ``o_proj`` contracts them
+  and is row-sharded so its partial sums are reduced. ``kv_a_proj_with_mqa`` and
+  ``kv_a_layernorm`` produce the head-shared compressed latent and stay
+  replicated.
+* **KDA stays replicated**, matching how Qwen3.5's GatedDeltaNet and Falcon-H1's
+  Mamba2 mixer are handled. Its heads are arithmetically independent, but the
+  layer runs FLA Triton kernels (short convolution, chunked delta rule) that take
+  plain tensors, so head-sharding it would mean localizing every weight inside
+  the forward rather than expressing it as a parallel style. That is a separate
+  change.
+
+Because the two flavours share module names (both define ``q_proj`` and
+``o_proj``), the plan is emitted per layer from the model's own KDA /
+full-attention split rather than through a wildcard.
+
+Sequence parallelism shards only the normalization and residual path: each block
+all-gathers the sequence before attention and reduce-scatters it back at the
+output projection, so the KDA recurrence still sees whole documents. Routed
+experts stay owned by expert parallelism, so the replicated output of a MoE (or
+KDA) submodule is scattered back onto the sequence-parallel residual stream
+explicitly.
+"""
+
+from __future__ import annotations
+
+import torch.nn as nn
+from torch.distributed.tensor import Replicate, Shard
+from torch.distributed.tensor.parallel import (
+    ColwiseParallel,
+    ParallelStyle,
+    PrepareModuleOutput,
+    RowwiseParallel,
+    SequenceParallel,
+)
+
+from nemo_automodel.components.distributed.optimized_tp_plans import (
+    SequenceParallelAllGatherActivation,
+    VocabParallelEmbedding,
+)
+
+
+def parallelize_kimi_linear(model: nn.Module, sequence_parallel: bool = False) -> dict[str, ParallelStyle]:
+    """Build the tensor-parallel plan for :class:`KimiLinearForCausalLM`.
+
+    Args:
+        model: The model being parallelized; its layer structure decides which
+            blocks receive MLA sharding and which keep a dense MLP.
+        sequence_parallel: Whether to additionally shard block boundaries along
+            the sequence.
+
+    Returns:
+        Mapping of module paths to parallel styles.
+    """
+    plan: dict[str, ParallelStyle] = {
+        "model.embed_tokens": VocabParallelEmbedding(
+            input_layouts=Replicate(),
+            output_layouts=Shard(1) if sequence_parallel else Replicate(),
+        ),
+        "lm_head": ColwiseParallel(
+            input_layouts=Shard(1) if sequence_parallel else Replicate(),
+            output_layouts=Shard(-1),
+            use_local_output=False,
+        ),
+    }
+
+    for layer_id, block in model.model.layers.items():
+        prefix = f"model.layers.{layer_id}"
+        if not block.is_linear_attn:
+            plan[f"{prefix}.self_attn.q_proj"] = ColwiseParallel()
+            plan[f"{prefix}.self_attn.kv_b_proj"] = ColwiseParallel()
+            plan[f"{prefix}.self_attn.o_proj"] = RowwiseParallel(
+                output_layouts=Shard(1) if sequence_parallel else Replicate()
+            )
+        if not block.is_moe_layer:
+            # Dense blocks only: the MoE branch shares the ``mlp`` name but its
+            # routed experts stay owned by expert parallelism.
+            plan[f"{prefix}.mlp.gate_proj"] = ColwiseParallel()
+            plan[f"{prefix}.mlp.up_proj"] = ColwiseParallel()
+            plan[f"{prefix}.mlp.down_proj"] = RowwiseParallel(
+                output_layouts=Shard(1) if sequence_parallel else Replicate()
+            )
+
+        if not sequence_parallel:
+            continue
+
+        # ``use_local_output=True`` everywhere on this boundary: the attention
+        # layers run FLA Triton kernels and replicated helper projections, which
+        # only accept plain tensors.
+        plan[f"{prefix}.input_layernorm"] = SequenceParallelAllGatherActivation(use_local_output=True)
+        plan[f"{prefix}.post_attention_layernorm"] = SequenceParallelAllGatherActivation(use_local_output=True)
+        if block.is_linear_attn:
+            # KDA is replicated, so it emits a full-sequence tensor that has to be
+            # scattered back onto the sequence-parallel residual stream.
+            plan[f"{prefix}.self_attn"] = PrepareModuleOutput(
+                output_layouts=Replicate(),
+                desired_output_layouts=Shard(1),
+                use_local_output=True,
+            )
+        if block.is_moe_layer:
+            # The MoE branch of the block is also named ``mlp``.
+            plan[f"{prefix}.mlp"] = PrepareModuleOutput(
+                output_layouts=Replicate(),
+                desired_output_layouts=Shard(1),
+                use_local_output=True,
+            )
+
+    if sequence_parallel:
+        plan["model.norm"] = SequenceParallel(use_local_output=True)
+
+    return plan

--- a/nemo_automodel/components/moe/config.py
+++ b/nemo_automodel/components/moe/config.py
@@ -51,7 +51,7 @@ class MoEConfig:
     # Default 0.0 preserves the existing ``weighted_bias_swiglu_impl`` path.
     swiglu_limit: float = 0.0
     softmax_before_topk: bool = False
-    router_topk_sorted: bool = True
+    router_topk_sorted: bool = False
     router_weights_fp32: bool = False
     router_weight_uses_score_correction_bias: bool = False
     route_weight_after_down_proj: bool = False

--- a/nemo_automodel/components/moe/config.py
+++ b/nemo_automodel/components/moe/config.py
@@ -51,6 +51,10 @@ class MoEConfig:
     # Default 0.0 preserves the existing ``weighted_bias_swiglu_impl`` path.
     swiglu_limit: float = 0.0
     softmax_before_topk: bool = False
+    router_topk_sorted: bool = True
+    router_weights_fp32: bool = False
+    router_weight_uses_score_correction_bias: bool = False
+    route_weight_after_down_proj: bool = False
     dtype: str | torch.dtype = torch.bfloat16
     shared_expert_gate: bool = False
     shared_expert_inter_dim: int | None = None

--- a/nemo_automodel/components/moe/experts.py
+++ b/nemo_automodel/components/moe/experts.py
@@ -97,6 +97,16 @@ def is_gated_activation(activation: str) -> bool:
     return activation in ("swiglu", "swigluoai", "quick_geglu", "geglu")
 
 
+def _unweighted_swiglu(input: torch.Tensor, *, swiglu_limit: float = 0.0) -> torch.Tensor:
+    gate, up = torch.chunk(input, 2, dim=-1)
+    if swiglu_limit > 0.0:
+        dtype = input.dtype
+        gate = gate.float().clamp(max=swiglu_limit)
+        up = up.float().clamp(min=-swiglu_limit, max=swiglu_limit)
+        return (F.silu(gate) * up).to(dtype)
+    return F.silu(gate) * up
+
+
 def _permute_tokens_for_grouped_mm(
     indices: torch.Tensor,
     weights: torch.Tensor,
@@ -226,7 +236,11 @@ class GroupedExperts(nn.Module):
         self.config = config
         self.n_routed_experts = config.n_routed_experts
         self.expert_bias = config.expert_bias
+        self.route_weight_after_down_proj = config.route_weight_after_down_proj
         self.is_gated = is_gated_activation(config.expert_activation)
+        if self.route_weight_after_down_proj and config.expert_activation != "swiglu":
+            raise ValueError("route_weight_after_down_proj currently supports only swiglu experts.")
+        self.swiglu_limit = config.swiglu_limit
         # "torch_mm_mxfp8" dispatches identically to "torch_mm" but routes the grouped
         # GEMMs through torchao's MXFP8 kernel (see _torch_mm_experts_fwd).
         self.use_torch_mm = backend is not None and backend.experts in ("torch_mm", "torch_mm_mxfp8")
@@ -451,12 +465,20 @@ class GroupedExperts(nn.Module):
             # Weighted activation (routing weight applied BETWEEN up and down projections)
             # Uses WeightedSwiGLUFunction with float32 backward precision
             w = weights[idx, top, None]
-            activated = self.expert_activation_grouped(gate_and_up_out, w)
+            if self.route_weight_after_down_proj:
+                activated = _unweighted_swiglu(gate_and_up_out, swiglu_limit=self.swiglu_limit)
+            else:
+                activated = self.expert_activation_grouped(gate_and_up_out, w)
 
             # Down projection
             expert_out = activated @ down_proj
             if expert_down_proj_bias is not None:
-                expert_out = expert_out + expert_down_proj_bias * w
+                if self.route_weight_after_down_proj:
+                    expert_out = expert_out + expert_down_proj_bias
+                else:
+                    expert_out = expert_out + expert_down_proj_bias * w
+            if self.route_weight_after_down_proj:
+                expert_out = expert_out * w
 
             y.scatter_add_(dim=0, index=idx_b, src=expert_out.float())
 
@@ -464,8 +486,14 @@ class GroupedExperts(nn.Module):
         if active_local_experts == 0:
             dummy_x = torch.zeros_like(x[0]).unsqueeze(0)
             gate_and_up_out = dummy_x @ gate_and_up_projs[0]
-            activated = self.expert_activation_grouped(gate_and_up_out, weights[0, 0, None].unsqueeze(0))
+            dummy_weight = weights[0, 0, None].unsqueeze(0)
+            if self.route_weight_after_down_proj:
+                activated = _unweighted_swiglu(gate_and_up_out, swiglu_limit=self.swiglu_limit)
+            else:
+                activated = self.expert_activation_grouped(gate_and_up_out, dummy_weight)
             expert_out = activated @ down_projs[0]
+            if self.route_weight_after_down_proj:
+                expert_out = expert_out * dummy_weight
             y[0] += expert_out[0]
 
         return y
@@ -511,9 +539,16 @@ class GroupedExperts(nn.Module):
                 grouped_mm = select_grouped_mm(self.use_mxfp8)
                 output1 = grouped_mm(permuted_x, gate_and_up_projs, offs)
                 output1 = _apply_bias(output1, gate_up_proj_bias, tokens_per_expert)
-                output1 = self.expert_activation_grouped(output1, permuted_probs)
+                if self.route_weight_after_down_proj:
+                    output1 = _unweighted_swiglu(output1, swiglu_limit=self.swiglu_limit)
+                else:
+                    output1 = self.expert_activation_grouped(output1, permuted_probs)
                 output2 = grouped_mm(output1, down_projs, offs)
-                output2 = _apply_bias(output2, down_proj_bias, tokens_per_expert, permuted_probs)
+                if self.route_weight_after_down_proj:
+                    output2 = _apply_bias(output2, down_proj_bias, tokens_per_expert)
+                    output2 = output2 * permuted_probs
+                else:
+                    output2 = _apply_bias(output2, down_proj_bias, tokens_per_expert, permuted_probs)
             else:
                 output2 = _torch_mm_experts_fwd(
                     permuted_x,
@@ -523,6 +558,8 @@ class GroupedExperts(nn.Module):
                     permuted_probs,
                     self.expert_activation_grouped,
                     use_mxfp8=self.use_mxfp8,
+                    route_weight_after_down_proj=self.route_weight_after_down_proj,
+                    swiglu_limit=self.swiglu_limit,
                 )
 
             scatter_ids = sorted_token_ids.unsqueeze(1).expand_as(output2)
@@ -530,8 +567,14 @@ class GroupedExperts(nn.Module):
         else:
             # Dummy computation for gradient flow
             output1 = torch.matmul(x[0] * 0, gate_and_up_projs[0])
-            output1_ = self.expert_activation_grouped(output1, weights[0, 0, None].unsqueeze(0))
+            dummy_weight = weights[0, 0, None].unsqueeze(0)
+            if self.route_weight_after_down_proj:
+                output1_ = _unweighted_swiglu(output1, swiglu_limit=self.swiglu_limit)
+            else:
+                output1_ = self.expert_activation_grouped(output1, dummy_weight)
             output2 = torch.matmul(output1_, down_projs[0])
+            if self.route_weight_after_down_proj:
+                output2 = output2 * dummy_weight
             y[0] += output2[0]
 
         return y
@@ -878,6 +921,8 @@ def _torch_mm_experts_fwd(
     permuted_probs,
     activation_fn,
     use_mxfp8=False,
+    route_weight_after_down_proj=False,
+    swiglu_limit=0.0,
 ):
     # torchao's MXFP8 quantizer (mx_tensor.to_mx) strictly asserts is_contiguous() on each
     # operand it quantizes, unlike torch._grouped_mm. select_grouped_mm returns a wrapper
@@ -886,8 +931,13 @@ def _torch_mm_experts_fwd(
     offs = tokens_per_expert.cumsum(dim=0).to(torch.int32)
     grouped_mm = select_grouped_mm(use_mxfp8)
     output1 = grouped_mm(hidden_states, gate_and_up_projs, offs)
-    output1 = activation_fn(output1, permuted_probs)
+    if route_weight_after_down_proj:
+        output1 = _unweighted_swiglu(output1, swiglu_limit=swiglu_limit)
+    else:
+        output1 = activation_fn(output1, permuted_probs)
     output2 = grouped_mm(output1, down_projs, offs)
+    if route_weight_after_down_proj:
+        output2 = output2 * permuted_probs
     return output2
 
 

--- a/nemo_automodel/components/moe/experts.py
+++ b/nemo_automodel/components/moe/experts.py
@@ -98,6 +98,16 @@ def is_gated_activation(activation: str) -> bool:
 
 
 def _unweighted_swiglu(input: torch.Tensor, *, swiglu_limit: float = 0.0) -> torch.Tensor:
+    """Apply SwiGLU to fused gate/up projections without routing weights.
+
+    Args:
+        input: Fused gate/up tensor of shape [..., 2 * inter], with arbitrary leading dimensions. The last
+            dimension is split into gate and up halves of size inter.
+        swiglu_limit: Optional clamp applied to gate/up before activation; disabled when <= 0.
+
+    Returns:
+        Tensor of shape [..., inter].
+    """
     gate, up = torch.chunk(input, 2, dim=-1)
     if swiglu_limit > 0.0:
         dtype = input.dtype

--- a/nemo_automodel/components/moe/experts.py
+++ b/nemo_automodel/components/moe/experts.py
@@ -732,6 +732,12 @@ class GroupedExpertsDeepEP(nn.Module):
         super().__init__()
 
         self.config = config
+        if config.route_weight_after_down_proj:
+            raise ValueError(
+                "route_weight_after_down_proj is not supported by GroupedExpertsDeepEP. "
+                "Use BackendConfig(dispatcher='torch') or implement post-down-projection routing weights "
+                "for the DeepEP expert backend."
+            )
         # "torch_mm_mxfp8" dispatches identically to "torch_mm" but routes the grouped
         # GEMMs through torchao's MXFP8 kernel (see _torch_mm_experts_fwd).
         self.use_torch_mm = backend is not None and backend.experts in ("torch_mm", "torch_mm_mxfp8")
@@ -977,6 +983,13 @@ class GroupedExpertsTE(nn.Module):
             dispatcher_share_token_dispatcher: Whether to share a flex dispatcher communication manager across layers.
             dispatcher_async_dispatch: Whether DeepEP/UCCL-EP dispatch should run asynchronously.
         """
+        if config.route_weight_after_down_proj:
+            raise ValueError(
+                "route_weight_after_down_proj is not supported by GroupedExpertsTE. "
+                "Use BackendConfig(dispatcher='torch') or implement post-down-projection routing weights "
+                "for the TE expert backend."
+            )
+
         from transformer_engine.pytorch import GroupedLinear
 
         from nemo_automodel.components.models.common.utils import _patch_te_modules

--- a/nemo_automodel/components/moe/layers.py
+++ b/nemo_automodel/components/moe/layers.py
@@ -242,6 +242,9 @@ class Gate(nn.Module):
         self.n_experts = config.n_routed_experts
         self.topk = config.n_activated_experts
         self.softmax_before_topk = config.softmax_before_topk
+        self.router_topk_sorted = config.router_topk_sorted
+        self.router_weights_fp32 = config.router_weights_fp32
+        self.router_weight_uses_score_correction_bias = config.router_weight_uses_score_correction_bias
         self.n_groups = config.n_expert_groups
         self.topk_groups = config.n_limited_groups
         self.score_func = config.score_func
@@ -329,11 +332,11 @@ class Gate(nn.Module):
             if self.softmax_before_topk:
                 scores = scores.softmax(dim=-1, dtype=self.gate_precision or torch.float32)
                 original_scores = scores
-                indices = torch.topk(scores, k=self.topk, dim=-1)[1]
+                indices = torch.topk(scores, k=self.topk, dim=-1, sorted=self.router_topk_sorted)[1]
                 indices = replay_selection(self.router_replay, indices)
                 weights = scores.gather(1, indices)
             else:
-                values, indices = torch.topk(scores, k=self.topk, dim=-1)
+                values, indices = torch.topk(scores, k=self.topk, dim=-1, sorted=self.router_topk_sorted)
                 replayed = replay_selection(self.router_replay, indices)
                 if replayed is not indices:
                     # Replay swapped the selection: re-gather the values for the
@@ -360,11 +363,11 @@ class Gate(nn.Module):
                 scores_for_choice = scores_for_choice.view(x.size(0), self.n_groups, -1)
                 group_scores = scores_for_choice.topk(2, dim=-1)[0].sum(dim=-1)
 
-                group_idx = group_scores.topk(self.topk_groups, dim=-1)[1]
+                group_idx = group_scores.topk(self.topk_groups, dim=-1, sorted=self.router_topk_sorted)[1]
                 mask = torch.zeros_like(scores_for_choice[..., 0]).scatter_(1, group_idx, True)
                 scores_for_choice = (scores_for_choice * mask.unsqueeze(-1)).flatten(1)
 
-            indices = torch.topk(scores_for_choice, self.topk, dim=-1)[1]
+            indices = torch.topk(scores_for_choice, self.topk, dim=-1, sorted=self.router_topk_sorted)[1]
             indices = replay_selection(self.router_replay, indices)
             # Final weights gathered from UNBIASED softmax scores
             weights = original_scores.gather(1, indices)
@@ -376,7 +379,7 @@ class Gate(nn.Module):
             if self.e_score_correction_bias is not None:
                 scores = scores + self.e_score_correction_bias
 
-            indices = torch.topk(scores, self.topk, dim=-1)[1]
+            indices = torch.topk(scores, self.topk, dim=-1, sorted=self.router_topk_sorted)[1]
             indices = replay_selection(self.router_replay, indices)
             weights = original_scores.gather(1, indices)
         elif self.score_func == "sigmoid_with_bias":
@@ -390,14 +393,19 @@ class Gate(nn.Module):
             if self.n_groups > 1:
                 scores_for_choice = scores_for_choice.view(x.size(0), self.n_groups, -1)
                 group_scores = scores_for_choice.topk(2, dim=-1)[0].sum(dim=-1)
-                group_idx = torch.topk(group_scores, k=self.topk_groups, dim=-1, sorted=False)[1]
+                group_idx = torch.topk(
+                    group_scores,
+                    k=self.topk_groups,
+                    dim=-1,
+                    sorted=self.router_topk_sorted,
+                )[1]
                 group_mask = torch.zeros_like(group_scores).scatter_(1, group_idx, 1)
                 score_mask = group_mask.unsqueeze(-1).expand_as(scores_for_choice).reshape(x.size(0), -1)
                 scores_for_choice = scores_for_choice.reshape(x.size(0), -1).masked_fill(
                     ~score_mask.bool(), float("-inf")
                 )
 
-            indices = torch.topk(scores_for_choice, k=self.topk, dim=-1, sorted=False)[1]
+            indices = torch.topk(scores_for_choice, k=self.topk, dim=-1, sorted=self.router_topk_sorted)[1]
             indices = replay_selection(self.router_replay, indices)
             weights = original_scores.gather(1, indices)
         else:
@@ -407,6 +415,8 @@ class Gate(nn.Module):
             # Add correction bias to balance tokens across gates.
             if self.e_score_correction_bias is not None:
                 scores = scores + self.e_score_correction_bias
+                if self.router_weight_uses_score_correction_bias:
+                    original_scores = scores
 
             if self.n_groups > 1:
                 scores = scores.view(x.size(0), self.n_groups, -1)
@@ -415,11 +425,11 @@ class Gate(nn.Module):
                 else:
                     group_scores = scores.topk(2, dim=-1)[0].sum(dim=-1)
 
-                indices = group_scores.topk(self.topk_groups, dim=-1)[1]
+                indices = group_scores.topk(self.topk_groups, dim=-1, sorted=self.router_topk_sorted)[1]
                 mask = torch.zeros_like(scores[..., 0]).scatter_(1, indices, True)
                 scores = (scores * mask.unsqueeze(-1)).flatten(1)
 
-            indices = torch.topk(scores, self.topk, dim=-1)[1]
+            indices = torch.topk(scores, self.topk, dim=-1, sorted=self.router_topk_sorted)[1]
             indices = replay_selection(self.router_replay, indices)
             weights = original_scores.gather(1, indices)
 
@@ -431,7 +441,7 @@ class Gate(nn.Module):
 
         weights = weights * self.route_scale
 
-        if self.gate_precision is not None:
+        if self.gate_precision is not None and not self.router_weights_fp32:
             weights = weights.to(dtype=original_dtype)
             original_scores = original_scores.to(dtype=original_dtype)
 
@@ -458,6 +468,8 @@ class Gate(nn.Module):
         if self._track_load_balance and aux_loss is not None:
             self._last_aux_loss = aux_loss.detach()
 
+        if self.router_weights_fp32:
+            return weights.float(), indices, aux_loss
         return weights.type_as(x), indices, aux_loss
 
     def update_bias(self) -> None:

--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -148,10 +148,11 @@ def _resolve_moe_tp_plan(
     MoE path only accepts an explicit plan or an architecture registration and
     always validates routed-expert ownership before applying it.
     """
-    if sequence_parallel:
+    if sequence_parallel and not getattr(model, "_supports_sequence_parallel", False):
         raise ValueError(
-            "sequence_parallel=True is not supported by the custom MoE TP path yet; "
-            "use sequence_parallel=False so replicated router/attention activations remain correct."
+            f"sequence_parallel=True is not supported by '{type(model).__name__}' on the custom MoE TP path; "
+            "use sequence_parallel=False so replicated router/attention activations remain correct, or declare "
+            "_supports_sequence_parallel on a model whose plan shards the block boundaries."
         )
     if tp_size <= 1:
         return {}
@@ -163,7 +164,7 @@ def _resolve_moe_tp_plan(
 
         plan = _get_parallel_plan(
             model,
-            sequence_parallel=False,
+            sequence_parallel=sequence_parallel,
             tp_shard_plan=tp_shard_plan,
             tp_size=tp_size,
         )
@@ -184,7 +185,7 @@ def _resolve_moe_tp_plan(
                 "PARALLELIZE_FUNCTIONS or pass tp_shard_plan explicitly; routed experts must remain EP-owned."
             )
         try:
-            plan = plan_factory(model, False)
+            plan = plan_factory(model, sequence_parallel)
         except Exception as exc:
             raise ValueError(
                 f"The registered tensor-parallel plan for custom MoE model '{model_cls.__name__}' failed: {exc}"

--- a/tests/unit_tests/models/kimi_linear/__init__.py
+++ b/tests/unit_tests/models/kimi_linear/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.

--- a/tests/unit_tests/models/kimi_linear/test_config.py
+++ b/tests/unit_tests/models/kimi_linear/test_config.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import pytest
+from transformers.models.auto.configuration_auto import CONFIG_MAPPING
+
+from nemo_automodel._transformers.registry import _CUSTOM_CONFIG_REGISTRATIONS, MODEL_ARCH_MAPPING
+from nemo_automodel.components.models.kimi_linear.config import KimiLinearConfig
+from nemo_automodel.components.models.kimi_linear.model import KimiLinearForCausalLM
+
+
+def test_kimi_linear_config_flags():
+    config = KimiLinearConfig(
+        hidden_size=64,
+        num_attention_heads=4,
+        num_hidden_layers=3,
+        num_experts=8,
+        num_experts_per_token=2,
+        moe_intermediate_size=32,
+        q_lora_rank=None,
+        kv_lora_rank=16,
+        qk_nope_head_dim=8,
+        qk_rope_head_dim=4,
+        v_head_dim=8,
+        mla_use_nope=True,
+        linear_attn_config={"kda_layers": [1, 3], "full_attn_layers": [2]},
+    )
+
+    assert config.model_type == "kimi_linear"
+    assert config.is_moe
+    assert config.is_mla
+    assert config.is_linear_attn
+    assert config.kda_use_qk_l2norm_in_kernel
+    assert config.is_kda_layer(0)
+    assert not config.is_kda_layer(1)
+    assert config.is_kda_layer(2)
+
+
+def test_kimi_linear_config_rejects_missing_layer_lists():
+    with pytest.raises(ValueError, match="kda_layers and full_attn_layers"):
+        KimiLinearConfig(linear_attn_config={"kda_layers": [1]})
+
+
+def test_kimi_linear_registry_and_capabilities():
+    assert MODEL_ARCH_MAPPING["KimiLinearForCausalLM"] == (
+        "nemo_automodel.components.models.kimi_linear.model",
+        "KimiLinearForCausalLM",
+    )
+    assert _CUSTOM_CONFIG_REGISTRATIONS["kimi_linear"] == (
+        "nemo_automodel.components.models.kimi_linear.config",
+        "KimiLinearConfig",
+    )
+    assert CONFIG_MAPPING["kimi_linear"] is KimiLinearConfig
+
+    capabilities = KimiLinearForCausalLM.ModelCapabilities()
+    assert capabilities.supports_ep
+    assert not capabilities.supports_pp
+    assert not capabilities.supports_tp
+    assert not capabilities.supports_cp

--- a/tests/unit_tests/models/kimi_linear/test_config.py
+++ b/tests/unit_tests/models/kimi_linear/test_config.py
@@ -54,5 +54,5 @@ def test_kimi_linear_registry_and_capabilities():
     capabilities = KimiLinearForCausalLM.ModelCapabilities()
     assert capabilities.supports_ep
     assert not capabilities.supports_pp
-    assert not capabilities.supports_tp
-    assert not capabilities.supports_cp
+    assert capabilities.supports_tp
+    assert capabilities.supports_cp

--- a/tests/unit_tests/models/kimi_linear/test_cp.py
+++ b/tests/unit_tests/models/kimi_linear/test_cp.py
@@ -1,0 +1,234 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import contextlib
+
+import pytest
+import torch
+
+from nemo_automodel.components.models.kimi_linear.cp import (
+    _PAD_DOC_ID,
+    KimiPackedContext,
+    build_document_causal_mask,
+    doc_ids_from_cu_seqlens,
+    doc_ids_from_seq_lens,
+    segment_cu_seqlens,
+    shard_batch_for_kimi_cp,
+)
+
+
+class _FakeCPMesh:
+    """Minimal stand-in for a one-dimensional CP device mesh."""
+
+    def __init__(self, size: int, rank: int) -> None:
+        self._size = size
+        self._rank = rank
+
+    def size(self) -> int:
+        return self._size
+
+    def get_local_rank(self) -> int:
+        return self._rank
+
+
+def _batch(seq_len: int = 8, batch_size: int = 1) -> dict:
+    input_ids = torch.arange(batch_size * seq_len, dtype=torch.long).reshape(batch_size, seq_len)
+    return {"input_ids": input_ids, "labels": input_ids.clone()}
+
+
+def test_segment_cu_seqlens_splits_documents_and_padding():
+    doc_ids = torch.tensor([1, 1, 1, 2, 2, 0, 0], dtype=torch.int32)
+
+    assert segment_cu_seqlens(doc_ids).tolist() == [0, 3, 5, 7]
+
+
+def test_segment_cu_seqlens_single_document_covers_row():
+    doc_ids = torch.ones(6, dtype=torch.int32)
+
+    assert segment_cu_seqlens(doc_ids).tolist() == [0, 6]
+
+
+def test_doc_ids_from_seq_lens_marks_documents_and_trailing_padding():
+    seq_lens = torch.tensor([[3, 2, -1000]], dtype=torch.int32)
+
+    doc_ids = doc_ids_from_seq_lens(seq_lens, seq_len=7)
+
+    assert doc_ids.tolist() == [[1, 1, 1, 2, 2, 0, 0]]
+
+
+def test_doc_ids_from_cu_seqlens_matches_segment_boundaries():
+    cu_seqlens = torch.tensor([0, 3, 5], dtype=torch.int32)
+
+    doc_ids = doc_ids_from_cu_seqlens(cu_seqlens, seq_len=7)
+
+    assert doc_ids.tolist() == [[1, 1, 1, 2, 2, 0, 0]]
+
+
+def test_packed_context_row_cu_seqlens_is_cached():
+    context = KimiPackedContext(doc_ids=torch.tensor([[1, 1, 2, 2]], dtype=torch.int32))
+
+    first = context.row_cu_seqlens(0)
+    second = context.row_cu_seqlens(0)
+
+    assert first[0] is second[0]
+    assert first[0].tolist() == [0, 2, 4]
+    assert first[1].device.type == "cpu"
+
+
+def test_document_causal_mask_blocks_cross_document_and_padding():
+    doc_ids = torch.tensor([[1, 1, 2, 0]], dtype=torch.int32)
+
+    mask = build_document_causal_mask(doc_ids, doc_ids, q_global_start=0, dtype=torch.float32)
+    allowed = mask[0, 0] == 0
+
+    assert allowed.tolist() == [
+        [True, False, False, False],  # first token of document 1
+        [True, True, False, False],  # second token of document 1
+        [False, False, True, False],  # document 2 cannot see document 1
+        [True, False, False, False],  # padding query is redirected to position 0
+    ]
+
+
+def test_document_causal_mask_shifts_queries_by_global_offset():
+    q_doc_ids = torch.tensor([[1, 1]], dtype=torch.int32)
+    kv_doc_ids = torch.tensor([[1, 1, 1, 1]], dtype=torch.int32)
+
+    mask = build_document_causal_mask(q_doc_ids, kv_doc_ids, q_global_start=2, dtype=torch.float32)
+    allowed = mask[0, 0] == 0
+
+    assert allowed.tolist() == [[True, True, True, False], [True, True, True, True]]
+
+
+def test_shard_batch_keeps_contiguous_slice_per_rank():
+    shards = []
+    for rank in range(2):
+        _, batch = shard_batch_for_kimi_cp(_FakeCPMesh(2, rank), None, _batch(seq_len=8))
+        shards.append(batch)
+
+    assert shards[0]["input_ids"].tolist() == [[0, 1, 2, 3]]
+    assert shards[1]["input_ids"].tolist() == [[4, 5, 6, 7]]
+    assert shards[0]["position_ids"].tolist() == [[0, 1, 2, 3]]
+    assert shards[1]["position_ids"].tolist() == [[4, 5, 6, 7]]
+    assert shards[1]["kimi_packed_context"].seq_start == 4
+    # Every rank keeps the full document map so attention can mask gathered keys.
+    assert shards[1]["kimi_packed_context"].doc_ids.shape == (1, 8)
+
+
+def test_shard_batch_pads_sequence_up_to_cp_size():
+    context_factory, batch = shard_batch_for_kimi_cp(_FakeCPMesh(4, 3), None, _batch(seq_len=6), padding_token_id=7)
+
+    assert isinstance(context_factory(), contextlib.nullcontext)
+    assert batch["input_ids"].shape == (1, 2)
+    # Sequence 6 -> 8, so the last rank owns one real and one padded token.
+    assert batch["input_ids"].tolist() == [[7, 7]]
+    assert batch["labels"].tolist() == [[-100, -100]]
+    assert batch["kimi_packed_context"].doc_ids[0, -2:].tolist() == [_PAD_DOC_ID, _PAD_DOC_ID]
+
+
+def test_shard_batch_derives_documents_from_indexed_mask():
+    batch = _batch(seq_len=8)
+    batch["attention_mask"] = torch.tensor([[1, 1, 1, 2, 2, 2, 2, 0]], dtype=torch.int32)
+
+    _, sharded = shard_batch_for_kimi_cp(_FakeCPMesh(2, 0), None, batch)
+
+    assert "attention_mask" not in sharded
+    assert sharded["kimi_packed_context"].doc_ids.tolist() == [[1, 1, 1, 2, 2, 2, 2, 0]]
+    assert sharded["kimi_packed_context"].row_cu_seqlens(0)[0].tolist() == [0, 3, 7, 8]
+
+
+def test_shard_batch_drops_thd_metadata_that_no_longer_matches():
+    batch = _batch(seq_len=8)
+    batch["seq_lens"] = torch.tensor([[5, 3]], dtype=torch.int32)
+    batch["cu_seqlens"] = torch.tensor([0, 5, 8], dtype=torch.int32)
+    batch["qkv_format"] = "thd"
+
+    _, sharded = shard_batch_for_kimi_cp(_FakeCPMesh(2, 1), None, batch)
+
+    assert not {"seq_lens", "cu_seqlens", "qkv_format"} & set(sharded)
+    assert sharded["kimi_packed_context"].doc_ids.tolist() == [[1, 1, 1, 1, 1, 2, 2, 2]]
+
+
+def test_shard_batch_without_cp_mesh_is_a_no_op():
+    batch = _batch(seq_len=6)
+
+    _, sharded = shard_batch_for_kimi_cp(None, None, batch)
+
+    assert sharded["input_ids"].shape == (1, 6)
+    assert not sharded["kimi_packed_context"].cp_enabled
+    assert sharded["kimi_packed_context"].local_doc_ids.shape == (1, 6)
+
+
+def test_local_doc_ids_selects_the_rank_slice():
+    context = KimiPackedContext(
+        doc_ids=torch.tensor([[1, 1, 2, 2]], dtype=torch.int32),
+        seq_start=2,
+        cp_size=2,
+    )
+
+    assert context.cp_enabled
+    assert context.local_doc_ids.tolist() == [[2, 2]]
+
+
+@pytest.mark.parametrize("cp_size", [1, 2, 4])
+def test_shard_batch_shards_loss_mask_with_labels(cp_size):
+    loss_mask = torch.ones(1, 8, dtype=torch.long)
+
+    _, sharded = shard_batch_for_kimi_cp(_FakeCPMesh(cp_size, 0), None, _batch(seq_len=8), loss_mask=loss_mask)
+
+    assert sharded["loss_mask"].shape == (1, 8 // cp_size)
+
+
+def test_kimi_model_reports_cp_and_packing_support():
+    from nemo_automodel._transformers.capabilities import ModelSupports
+    from nemo_automodel.components.models.common import BackendConfig
+    from nemo_automodel.components.models.kimi_linear.model import KimiLinearForCausalLM
+    from tests.unit_tests.models.kimi_linear.test_model import _tiny_kimi_config
+
+    model = KimiLinearForCausalLM(_tiny_kimi_config(), backend=BackendConfig(attn="eager"))
+    supports = ModelSupports(model, None)
+
+    assert supports.supports_cp is True
+    assert supports.supports_sequence_packing is True
+
+
+def test_doc_ids_from_cu_seqlens_drops_thd_padding_sentinels():
+    cu_seqlens = torch.tensor([0, 3, 5, -1000, -1000], dtype=torch.int32)
+
+    doc_ids = doc_ids_from_cu_seqlens(cu_seqlens, seq_len=6)
+
+    assert doc_ids.tolist() == [[1, 1, 1, 2, 2, 0]]
+
+
+def test_document_causal_mask_keeps_every_row_attendable_when_all_padding():
+    """An all-padding shard must not produce a fully masked row (softmax would be NaN)."""
+    doc_ids = torch.zeros(1, 6, dtype=torch.int32)
+
+    mask = build_document_causal_mask(doc_ids, doc_ids, q_global_start=0, dtype=torch.float32)
+
+    allowed = mask[0, 0] == 0
+    assert allowed.any(dim=-1).all()
+    assert allowed[:, 0].all()
+
+
+def test_document_causal_mask_is_finite_for_a_padding_tail():
+    doc_ids = torch.tensor([[1, 1, 1, 0, 0]], dtype=torch.int32)
+
+    mask = build_document_causal_mask(doc_ids, doc_ids, q_global_start=0, dtype=torch.float32)
+
+    assert torch.isfinite(mask).all()
+    assert (mask[0, 0] == 0).any(dim=-1).all()
+
+
+def test_shard_batch_gives_the_trailing_rank_an_all_padding_shard():
+    """Pre-padding a dataset can leave a whole CP rank without a real token."""
+    batch = _batch(seq_len=8)
+    batch["attention_mask"] = torch.tensor([[1, 1, 1, 1, 0, 0, 0, 0]], dtype=torch.int32)
+    batch["labels"] = torch.tensor([[1, 2, 3, 4, -100, -100, -100, -100]])
+
+    _, sharded = shard_batch_for_kimi_cp(_FakeCPMesh(2, 1), None, batch)
+
+    context = sharded["kimi_packed_context"]
+    assert context.local_doc_ids.tolist() == [[0, 0, 0, 0]]
+    assert sharded["labels"].tolist() == [[-100, -100, -100, -100]]
+    assert sharded["padding_mask"].all()
+    # The document map still tiles the full sequence so FLA's CP partitioning lines up.
+    assert context.row_cu_seqlens(0)[0].tolist() == [0, 4, 8]

--- a/tests/unit_tests/models/kimi_linear/test_model.py
+++ b/tests/unit_tests/models/kimi_linear/test_model.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+from unittest.mock import patch
+
+from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.models.kimi_linear.config import KimiLinearConfig
+from nemo_automodel.components.models.kimi_linear.model import KimiLinearForCausalLM
+
+
+def _tiny_kimi_config() -> KimiLinearConfig:
+    return KimiLinearConfig(
+        vocab_size=128,
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        q_lora_rank=None,
+        kv_lora_rank=8,
+        qk_nope_head_dim=4,
+        qk_rope_head_dim=4,
+        v_head_dim=8,
+        mla_use_nope=True,
+        num_experts=4,
+        num_experts_per_token=2,
+        num_shared_experts=0,
+        moe_intermediate_size=8,
+        first_k_dense_replace=1,
+        linear_attn_config={
+            "kda_layers": [1],
+            "full_attn_layers": [2],
+            "num_heads": 2,
+            "head_dim": 8,
+            "short_conv_kernel_size": 4,
+        },
+        torch_dtype="float32",
+    )
+
+
+def _backend_config() -> BackendConfig:
+    return BackendConfig(
+        attn="eager",
+        linear="torch",
+        rms_norm="torch_fp32",
+        experts="torch",
+        dispatcher="torch",
+        enable_hf_state_dict_adapter=True,
+    )
+
+
+def test_update_moe_gate_bias_no_op_when_factor_zero():
+    model = KimiLinearForCausalLM(_tiny_kimi_config(), backend=_backend_config())
+    moe_layer = model.model.layers["1"].block_sparse_moe
+
+    assert moe_layer.gate.bias_update_factor == 0.0
+    with patch.object(moe_layer.gate, "update_bias") as mock_update_bias:
+        model.update_moe_gate_bias()
+
+    mock_update_bias.assert_not_called()
+
+
+def test_kimi_moe_uses_hf_routing_numerics():
+    model = KimiLinearForCausalLM(_tiny_kimi_config(), backend=_backend_config())
+    moe_layer = model.model.layers["1"].block_sparse_moe
+
+    assert not moe_layer.gate.router_topk_sorted
+    assert moe_layer.gate.router_weights_fp32
+    assert moe_layer.gate.router_weight_uses_score_correction_bias
+    assert moe_layer.experts.route_weight_after_down_proj

--- a/tests/unit_tests/models/kimi_linear/test_model.py
+++ b/tests/unit_tests/models/kimi_linear/test_model.py
@@ -2,12 +2,18 @@
 
 from unittest.mock import patch
 
+import pytest
+import torch
+
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.models.kimi_linear.config import KimiLinearConfig
 from nemo_automodel.components.models.kimi_linear.model import KimiLinearForCausalLM
 
 
-def _tiny_kimi_config() -> KimiLinearConfig:
+def _tiny_kimi_config(*, use_kda: bool = False) -> KimiLinearConfig:
+    linear_attn_config = (
+        {"kda_layers": [1], "full_attn_layers": [2]} if use_kda else {"kda_layers": [], "full_attn_layers": [1, 2]}
+    )
     return KimiLinearConfig(
         vocab_size=128,
         hidden_size=16,
@@ -27,14 +33,20 @@ def _tiny_kimi_config() -> KimiLinearConfig:
         moe_intermediate_size=8,
         first_k_dense_replace=1,
         linear_attn_config={
-            "kda_layers": [1],
-            "full_attn_layers": [2],
+            **linear_attn_config,
             "num_heads": 2,
             "head_dim": 8,
             "short_conv_kernel_size": 4,
         },
         torch_dtype="float32",
     )
+
+
+def _require_fla() -> None:
+    pytest.importorskip("fla")
+    pytest.importorskip("fla.modules")
+    pytest.importorskip("fla.ops.kda")
+    pytest.importorskip("fla.ops.kda.gate")
 
 
 def _backend_config() -> BackendConfig:
@@ -59,6 +71,14 @@ def test_update_moe_gate_bias_no_op_when_factor_zero():
     mock_update_bias.assert_not_called()
 
 
+def test_tiny_kimi_with_kda_constructs_when_fla_available():
+    _require_fla()
+
+    model = KimiLinearForCausalLM(_tiny_kimi_config(use_kda=True), backend=_backend_config())
+
+    assert model.model.layers["0"].is_linear_attn
+
+
 def test_kimi_moe_uses_hf_routing_numerics():
     model = KimiLinearForCausalLM(_tiny_kimi_config(), backend=_backend_config())
     moe_layer = model.model.layers["1"].block_sparse_moe
@@ -67,3 +87,39 @@ def test_kimi_moe_uses_hf_routing_numerics():
     assert moe_layer.gate.router_weights_fp32
     assert moe_layer.gate.router_weight_uses_score_correction_bias
     assert moe_layer.experts.route_weight_after_down_proj
+
+
+def test_initialize_weights_respects_explicit_buffer_device_on_cpu():
+    model = KimiLinearForCausalLM(_tiny_kimi_config(), backend=_backend_config())
+    explicit_device = torch.device("meta")
+
+    with (
+        patch("torch.cuda.is_available", return_value=False),
+        patch.object(model.model, "init_weights") as mock_model_init,
+    ):
+        model.initialize_weights(buffer_device=explicit_device, dtype=torch.float32)
+
+    mock_model_init.assert_called_once()
+    assert mock_model_init.call_args.args[0] == explicit_device
+
+
+def test_checkpoint_free_initialize_and_eval_forward_runs_hf_order_moe():
+    model = KimiLinearForCausalLM(_tiny_kimi_config(), backend=_backend_config())
+    model.initialize_weights(buffer_device=torch.device("cpu"), dtype=torch.float32)
+    model.eval()
+
+    for name, tensor in list(model.named_parameters()) + list(model.named_buffers()):
+        if tensor.is_floating_point():
+            assert torch.isfinite(tensor).all(), name
+
+    moe_layer = model.model.layers["1"]
+    input_ids = torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=torch.long)
+    with (
+        patch.object(moe_layer, "_moe_infer_hf_order", wraps=moe_layer._moe_infer_hf_order) as mock_hf_order,
+        torch.inference_mode(),
+    ):
+        output = model(input_ids=input_ids)
+
+    mock_hf_order.assert_called_once()
+    assert output.logits.shape == (2, 3, model.vocab_size)
+    assert torch.isfinite(output.logits).all()

--- a/tests/unit_tests/models/kimi_linear/test_model.py
+++ b/tests/unit_tests/models/kimi_linear/test_model.py
@@ -60,6 +60,12 @@ def _backend_config() -> BackendConfig:
     )
 
 
+def _assert_floating_state_finite(model: torch.nn.Module) -> None:
+    for name, tensor in list(model.named_parameters()) + list(model.named_buffers()):
+        if tensor.is_floating_point():
+            assert torch.isfinite(tensor).all(), name
+
+
 def test_update_moe_gate_bias_no_op_when_factor_zero():
     model = KimiLinearForCausalLM(_tiny_kimi_config(), backend=_backend_config())
     moe_layer = model.model.layers["1"].block_sparse_moe
@@ -71,12 +77,19 @@ def test_update_moe_gate_bias_no_op_when_factor_zero():
     mock_update_bias.assert_not_called()
 
 
-def test_tiny_kimi_with_kda_constructs_when_fla_available():
+def test_tiny_kimi_with_kda_initializes_fp32_params_when_fla_available():
     _require_fla()
 
     model = KimiLinearForCausalLM(_tiny_kimi_config(use_kda=True), backend=_backend_config())
+    model.initialize_weights(buffer_device=torch.device("cpu"), dtype=torch.float32)
+    kda_attn = model.model.layers["0"].self_attn
 
     assert model.model.layers["0"].is_linear_attn
+    assert kda_attn.A_log.dtype == torch.float32
+    assert kda_attn.dt_bias.dtype == torch.float32
+    assert torch.isfinite(kda_attn.A_log).all()
+    assert torch.isfinite(kda_attn.dt_bias).all()
+    _assert_floating_state_finite(model)
 
 
 def test_kimi_moe_uses_hf_routing_numerics():
@@ -87,6 +100,16 @@ def test_kimi_moe_uses_hf_routing_numerics():
     assert moe_layer.gate.router_weights_fp32
     assert moe_layer.gate.router_weight_uses_score_correction_bias
     assert moe_layer.experts.route_weight_after_down_proj
+
+
+def test_kimi_defaults_gate_precision_without_mutating_backend_config():
+    backend = _backend_config()
+
+    model = KimiLinearForCausalLM(_tiny_kimi_config(), backend=backend)
+
+    assert backend.gate_precision is None
+    assert model.backend is not backend
+    assert model.backend.gate_precision == torch.float32
 
 
 def test_initialize_weights_respects_explicit_buffer_device_on_cpu():
@@ -108,9 +131,7 @@ def test_checkpoint_free_initialize_and_eval_forward_runs_hf_order_moe():
     model.initialize_weights(buffer_device=torch.device("cpu"), dtype=torch.float32)
     model.eval()
 
-    for name, tensor in list(model.named_parameters()) + list(model.named_buffers()):
-        if tensor.is_floating_point():
-            assert torch.isfinite(tensor).all(), name
+    _assert_floating_state_finite(model)
 
     moe_layer = model.model.layers["1"]
     input_ids = torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=torch.long)

--- a/tests/unit_tests/models/kimi_linear/test_model.py
+++ b/tests/unit_tests/models/kimi_linear/test_model.py
@@ -144,3 +144,19 @@ def test_checkpoint_free_initialize_and_eval_forward_runs_hf_order_moe():
     mock_hf_order.assert_called_once()
     assert output.logits.shape == (2, 3, model.vocab_size)
     assert torch.isfinite(output.logits).all()
+
+
+def test_hf_order_eval_moe_matches_standard_grouped_experts_path():
+    torch.manual_seed(0)
+    model = KimiLinearForCausalLM(_tiny_kimi_config(), backend=_backend_config())
+    model.initialize_weights(buffer_device=torch.device("cpu"), dtype=torch.float32)
+    model.eval()
+    moe_layer = model.model.layers["1"]
+    moe = moe_layer.block_sparse_moe
+    hidden_states = torch.randn(2, 3, model.config.hidden_size)
+
+    with torch.inference_mode():
+        hf_order = moe_layer._moe_infer_hf_order(moe, moe.experts, hidden_states)
+        standard = moe(hidden_states, None)
+
+    torch.testing.assert_close(hf_order, standard, rtol=1e-5, atol=1e-6)

--- a/tests/unit_tests/models/kimi_linear/test_model.py
+++ b/tests/unit_tests/models/kimi_linear/test_model.py
@@ -68,7 +68,7 @@ def _assert_floating_state_finite(model: torch.nn.Module) -> None:
 
 def test_update_moe_gate_bias_no_op_when_factor_zero():
     model = KimiLinearForCausalLM(_tiny_kimi_config(), backend=_backend_config())
-    moe_layer = model.model.layers["1"].block_sparse_moe
+    moe_layer = model.model.layers["1"].mlp
 
     assert moe_layer.gate.bias_update_factor == 0.0
     with patch.object(moe_layer.gate, "update_bias") as mock_update_bias:
@@ -94,7 +94,7 @@ def test_tiny_kimi_with_kda_initializes_fp32_params_when_fla_available():
 
 def test_kimi_moe_uses_hf_routing_numerics():
     model = KimiLinearForCausalLM(_tiny_kimi_config(), backend=_backend_config())
-    moe_layer = model.model.layers["1"].block_sparse_moe
+    moe_layer = model.model.layers["1"].mlp
 
     assert not moe_layer.gate.router_topk_sorted
     assert moe_layer.gate.router_weights_fp32
@@ -152,7 +152,7 @@ def test_hf_order_eval_moe_matches_standard_grouped_experts_path():
     model.initialize_weights(buffer_device=torch.device("cpu"), dtype=torch.float32)
     model.eval()
     moe_layer = model.model.layers["1"]
-    moe = moe_layer.block_sparse_moe
+    moe = moe_layer.mlp
     hidden_states = torch.randn(2, 3, model.config.hidden_size)
 
     with torch.inference_mode():
@@ -160,3 +160,88 @@ def test_hf_order_eval_moe_matches_standard_grouped_experts_path():
         standard = moe(hidden_states, None)
 
     torch.testing.assert_close(hf_order, standard, rtol=1e-5, atol=1e-6)
+
+
+def test_packed_mask_blocks_attention_across_documents():
+    torch.manual_seed(0)
+    model = KimiLinearForCausalLM(_tiny_kimi_config(), backend=_backend_config())
+    model.initialize_weights(buffer_device=torch.device("cpu"), dtype=torch.float32)
+    model.eval()
+
+    input_ids = torch.tensor([[3, 4, 5, 6, 7, 8]], dtype=torch.long)
+    attention_mask = torch.tensor([[1, 1, 1, 2, 2, 2]], dtype=torch.int32)
+    perturbed = input_ids.clone()
+    perturbed[0, 3:] = torch.tensor([11, 12, 13])
+
+    with torch.inference_mode():
+        baseline = model(input_ids=input_ids, attention_mask=attention_mask).logits
+        changed = model(input_ids=perturbed, attention_mask=attention_mask).logits
+
+    # Document 1 owns positions 0..2 and must not see the rewritten document 2.
+    torch.testing.assert_close(baseline[:, :3], changed[:, :3], rtol=1e-5, atol=1e-6)
+    assert not torch.allclose(baseline[:, 3:], changed[:, 3:])
+
+
+def test_padding_only_query_rows_stay_finite():
+    torch.manual_seed(0)
+    model = KimiLinearForCausalLM(_tiny_kimi_config(), backend=_backend_config())
+    model.initialize_weights(buffer_device=torch.device("cpu"), dtype=torch.float32)
+    model.eval()
+
+    input_ids = torch.tensor([[3, 4, 5, 0]], dtype=torch.long)
+    attention_mask = torch.tensor([[1, 1, 1, 0]], dtype=torch.int32)
+
+    with torch.inference_mode():
+        logits = model(input_ids=input_ids, attention_mask=attention_mask).logits
+
+    assert torch.isfinite(logits).all()
+
+
+def test_prepare_model_inputs_for_cp_attaches_model_owned_sharding():
+    from nemo_automodel.components.models.kimi_linear.cp import shard_batch_for_kimi_cp
+
+    model = KimiLinearForCausalLM(_tiny_kimi_config(), backend=_backend_config())
+
+    updates = model.prepare_model_inputs_for_cp(input_ids=torch.zeros(1, 4, dtype=torch.long))
+
+    assert updates == {"_cp_make_batch_fn": shard_batch_for_kimi_cp}
+    assert model._owns_cp_attention is True
+
+
+def test_setup_cp_attention_records_mesh_on_every_attention_block():
+    _require_fla()
+    model = KimiLinearForCausalLM(_tiny_kimi_config(use_kda=True), backend=_backend_config())
+    sentinel = object()
+
+    for block in model.model.layers.values():
+        block.self_attn.setup_cp_attention(sentinel)
+
+    assert [block.self_attn._cp_mesh for block in model.model.layers.values()] == [sentinel, sentinel]
+
+
+def test_thd_packed_inputs_run_through_the_batched_layers():
+    """THD packing squeezes the batch axis off; the model must restore it."""
+    torch.manual_seed(0)
+    model = KimiLinearForCausalLM(_tiny_kimi_config(), backend=_backend_config())
+    model.initialize_weights(buffer_device=torch.device("cpu"), dtype=torch.float32)
+    model.eval()
+
+    input_ids = torch.tensor([[3, 4, 5, 6, 7, 8]], dtype=torch.long)
+    cu_seqlens = torch.tensor([[0, 3, 6]], dtype=torch.int32)
+
+    with torch.inference_mode():
+        thd = model(
+            input_ids=input_ids,
+            position_ids=torch.tensor([[0, 1, 2, 0, 1, 2]], dtype=torch.long),
+            qkv_format="thd",
+            cu_seqlens=cu_seqlens,
+        ).logits
+        bshd = model(
+            input_ids=input_ids,
+            attention_mask=torch.tensor([[1, 1, 1, 2, 2, 2]], dtype=torch.int32),
+        ).logits
+
+    assert thd.shape == (1, 6, model.vocab_size)
+    assert torch.isfinite(thd).all()
+    # Both routes describe the same two documents, so they must agree.
+    torch.testing.assert_close(thd, bshd, rtol=1e-5, atol=1e-6)

--- a/tests/unit_tests/models/kimi_linear/test_state_dict_adapter.py
+++ b/tests/unit_tests/models/kimi_linear/test_state_dict_adapter.py
@@ -1,0 +1,184 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+from dataclasses import dataclass
+
+import pytest
+import torch
+
+from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.models.kimi_linear.state_dict_adapter import KimiLinearStateDictAdapter
+from nemo_automodel.components.moe.config import MoEConfig
+
+
+@dataclass
+class MockKimiLinearConfig:
+    hidden_size: int = 6
+    intermediate_size: int = 12
+    moe_intermediate_size: int = 4
+    num_experts: int = 3
+    torch_dtype: str = "bfloat16"
+
+
+@pytest.fixture
+def config():
+    return MockKimiLinearConfig()
+
+
+@pytest.fixture
+def moe_config(config):
+    return MoEConfig(
+        dim=config.hidden_size,
+        inter_dim=config.intermediate_size,
+        moe_inter_dim=config.moe_intermediate_size,
+        n_routed_experts=config.num_experts,
+        n_shared_experts=1,
+        n_activated_experts=2,
+        n_expert_groups=1,
+        n_limited_groups=1,
+        train_gate=True,
+        gate_bias_update_factor=0.0,
+        aux_loss_coeff=0.0,
+        score_func="sigmoid",
+        route_scale=2.0,
+        norm_topk_prob=True,
+        router_bias=False,
+        expert_bias=False,
+        expert_activation="swiglu",
+        dtype=torch.bfloat16,
+        force_e_score_correction_bias=True,
+    )
+
+
+@pytest.fixture
+def backend():
+    return BackendConfig(
+        linear="torch",
+        attn="eager",
+        rms_norm="torch_fp32",
+        experts="torch",
+        dispatcher="torch",
+        enable_hf_state_dict_adapter=True,
+    )
+
+
+@pytest.fixture
+def adapter(config, moe_config, backend):
+    return KimiLinearStateDictAdapter(config, moe_config, backend, dtype=torch.bfloat16)
+
+
+def _make_hf_expert_state(n_experts: int, inter_dim: int, dim: int) -> dict[str, torch.Tensor]:
+    state = {}
+    for expert in range(n_experts):
+        base = expert * 1000
+        state[f"model.layers.1.block_sparse_moe.experts.{expert}.w1.weight"] = torch.arange(
+            base, base + inter_dim * dim, dtype=torch.float32
+        ).reshape(inter_dim, dim)
+        state[f"model.layers.1.block_sparse_moe.experts.{expert}.w3.weight"] = torch.arange(
+            base + 100, base + 100 + inter_dim * dim, dtype=torch.float32
+        ).reshape(inter_dim, dim)
+        state[f"model.layers.1.block_sparse_moe.experts.{expert}.w2.weight"] = torch.arange(
+            base + 200, base + 200 + dim * inter_dim, dtype=torch.float32
+        ).reshape(dim, inter_dim)
+    return state
+
+
+def test_from_hf_groups_kimi_w1_w2_w3_experts(adapter, moe_config):
+    hf_state = _make_hf_expert_state(
+        moe_config.n_routed_experts,
+        moe_config.moe_inter_dim,
+        moe_config.dim,
+    )
+
+    native = adapter.from_hf(hf_state)
+
+    gate_up_key = "model.layers.1.block_sparse_moe.experts.gate_and_up_projs"
+    down_key = "model.layers.1.block_sparse_moe.experts.down_projs"
+    assert gate_up_key in native
+    assert down_key in native
+
+    gate_up = native[gate_up_key]
+    down = native[down_key]
+    assert gate_up.shape == (moe_config.n_routed_experts, moe_config.dim, 2 * moe_config.moe_inter_dim)
+    assert down.shape == (moe_config.n_routed_experts, moe_config.moe_inter_dim, moe_config.dim)
+
+    w1 = hf_state["model.layers.1.block_sparse_moe.experts.0.w1.weight"]
+    w3 = hf_state["model.layers.1.block_sparse_moe.experts.0.w3.weight"]
+    w2 = hf_state["model.layers.1.block_sparse_moe.experts.0.w2.weight"]
+    assert torch.equal(gate_up[0, :, : moe_config.moe_inter_dim], w1.T.to(gate_up.dtype))
+    assert torch.equal(gate_up[0, :, moe_config.moe_inter_dim :], w3.T.to(gate_up.dtype))
+    assert torch.equal(down[0], w2.T.to(down.dtype))
+
+
+def test_from_hf_upcasts_kda_and_router_fp32_keys(adapter):
+    hf_state = {
+        "model.layers.0.self_attn.A_log": torch.ones(1, 1, 2, 1, dtype=torch.bfloat16),
+        "model.layers.0.self_attn.dt_bias": torch.ones(8, dtype=torch.bfloat16),
+        "model.layers.1.block_sparse_moe.gate.e_score_correction_bias": torch.ones(3, dtype=torch.bfloat16),
+    }
+
+    native = adapter.from_hf(hf_state)
+
+    assert native["model.layers.0.self_attn._fp32_params.A_log"].dtype is torch.float32
+    assert native["model.layers.0.self_attn._fp32_params.dt_bias"].dtype is torch.float32
+    assert native["model.layers.1.block_sparse_moe.gate.e_score_correction_bias"].dtype is torch.float32
+
+
+def test_to_hf_strips_kda_fp32_holder(adapter):
+    native = {
+        "model.layers.0.self_attn._fp32_params.A_log": torch.ones(1, 1, 2, 1, dtype=torch.float32),
+        "model.layers.0.self_attn._fp32_params.dt_bias": torch.ones(8, dtype=torch.float32),
+    }
+
+    hf_state = adapter.to_hf(native)
+
+    assert "model.layers.0.self_attn.A_log" in hf_state
+    assert "model.layers.0.self_attn.dt_bias" in hf_state
+    assert "model.layers.0.self_attn._fp32_params.A_log" not in hf_state
+    assert "model.layers.0.self_attn._fp32_params.dt_bias" not in hf_state
+
+
+def test_to_hf_splits_grouped_experts_back_to_kimi_names(adapter, moe_config):
+    native = {
+        "model.layers.1.block_sparse_moe.experts.gate_and_up_projs": torch.randn(
+            moe_config.n_routed_experts,
+            moe_config.dim,
+            2 * moe_config.moe_inter_dim,
+        ),
+        "model.layers.1.block_sparse_moe.experts.down_projs": torch.randn(
+            moe_config.n_routed_experts,
+            moe_config.moe_inter_dim,
+            moe_config.dim,
+        ),
+    }
+
+    hf_state = adapter.to_hf(native)
+
+    assert "model.layers.1.block_sparse_moe.experts.0.w1.weight" in hf_state
+    assert "model.layers.1.block_sparse_moe.experts.0.w2.weight" in hf_state
+    assert "model.layers.1.block_sparse_moe.experts.0.w3.weight" in hf_state
+    assert "model.layers.1.block_sparse_moe.experts.0.gate_proj.weight" not in hf_state
+
+    assert hf_state["model.layers.1.block_sparse_moe.experts.0.w1.weight"].shape == (
+        moe_config.moe_inter_dim,
+        moe_config.dim,
+    )
+    assert hf_state["model.layers.1.block_sparse_moe.experts.0.w2.weight"].shape == (
+        moe_config.dim,
+        moe_config.moe_inter_dim,
+    )
+    assert hf_state["model.layers.1.block_sparse_moe.experts.0.w3.weight"].shape == (
+        moe_config.moe_inter_dim,
+        moe_config.dim,
+    )
+
+
+def test_convert_single_tensor_to_hf_respects_exclude_regex(adapter):
+    tensor = torch.randn(1)
+
+    result = adapter.convert_single_tensor_to_hf(
+        "model.layers.1.block_sparse_moe.gate.weight",
+        tensor,
+        exclude_key_regex=r".*gate\.weight$",
+    )
+
+    assert result == []

--- a/tests/unit_tests/models/kimi_linear/test_state_dict_adapter.py
+++ b/tests/unit_tests/models/kimi_linear/test_state_dict_adapter.py
@@ -4,9 +4,11 @@ from dataclasses import dataclass
 
 import pytest
 import torch
+from torch.distributed._tensor.placement_types import Replicate, Shard
 
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.models.kimi_linear.state_dict_adapter import KimiLinearStateDictAdapter
+from nemo_automodel.components.moe import state_dict_utils
 from nemo_automodel.components.moe.config import MoEConfig
 
 
@@ -64,6 +66,40 @@ def backend():
 @pytest.fixture
 def adapter(config, moe_config, backend):
     return KimiLinearStateDictAdapter(config, moe_config, backend, dtype=torch.bfloat16)
+
+
+class _FakeMesh:
+    def __init__(self, *, rank: int, size: int, names: tuple[str, ...]):
+        self._rank = rank
+        self._size = size
+        self.mesh_dim_names = names
+
+    def get_local_rank(self) -> int:
+        return self._rank
+
+    def size(self) -> int:
+        return self._size
+
+
+class _FakeDTensor:
+    def __init__(self, *, local_tensor: torch.Tensor, placement: object, mesh: _FakeMesh):
+        """Create a DTensor-like wrapper for adapter unit tests.
+
+        Args:
+            local_tensor: Rank-local expert tensor of shape [local_experts, ...].
+            placement: DTensor placement metadata attached to the fake value.
+            mesh: Device mesh metadata attached to the fake value.
+        """
+        self._local_tensor = local_tensor
+        self.placements = (placement,)
+        self.device_mesh = mesh
+
+    def to_local(self) -> torch.Tensor:
+        return self._local_tensor
+
+
+def _patch_fake_dtensor(monkeypatch):
+    monkeypatch.setattr(state_dict_utils, "is_dtensor", lambda tensor: isinstance(tensor, _FakeDTensor))
 
 
 def _make_hf_expert_state(n_experts: int, inter_dim: int, dim: int) -> dict[str, torch.Tensor]:
@@ -182,3 +218,83 @@ def test_convert_single_tensor_to_hf_respects_exclude_regex(adapter):
     )
 
     assert result == []
+
+
+def test_split_experts_weights_dtensor_replicate_returns_all_experts(adapter, monkeypatch):
+    _patch_fake_dtensor(monkeypatch)
+    local_tensor = torch.arange(8, dtype=torch.float32).reshape(4, 2)
+    weight = _FakeDTensor(
+        local_tensor=local_tensor,
+        placement=Replicate(),
+        mesh=_FakeMesh(rank=1, size=2, names=("tp",)),
+    )
+
+    split = adapter._split_experts_weights(weight, n_experts=4)
+
+    assert torch.equal(torch.stack(split), local_tensor)
+    assert adapter._last_expert_ids == [0, 1, 2, 3]
+
+
+@pytest.mark.parametrize(
+    ("rank", "expected_ids"),
+    [
+        (0, [0, 1, 2]),
+        (1, [3, 4]),
+    ],
+)
+def test_split_experts_weights_dtensor_shard_uses_uneven_expert_distribution(
+    adapter,
+    monkeypatch,
+    rank,
+    expected_ids,
+):
+    _patch_fake_dtensor(monkeypatch)
+    local_tensor = torch.arange(len(expected_ids) * 2, dtype=torch.float32).reshape(len(expected_ids), 2)
+    weight = _FakeDTensor(
+        local_tensor=local_tensor,
+        placement=Shard(0),
+        mesh=_FakeMesh(rank=rank, size=2, names=("tp",)),
+    )
+
+    split = adapter._split_experts_weights(weight, n_experts=5)
+
+    assert torch.equal(torch.stack(split), local_tensor)
+    assert adapter._last_expert_ids == expected_ids
+
+
+def test_split_experts_weights_dtensor_shard_uses_active_ep_submesh(adapter, monkeypatch):
+    _patch_fake_dtensor(monkeypatch)
+    active_mesh = _FakeMesh(rank=0, size=99, names=("dp", "ep"))
+    ep_mesh = _FakeMesh(rank=2, size=3, names=("ep",))
+    calls = []
+
+    def fake_get_submesh(mesh, dims):
+        calls.append((mesh, dims))
+        return ep_mesh
+
+    monkeypatch.setattr(state_dict_utils, "get_submesh", fake_get_submesh)
+    adapter._active_device_mesh = active_mesh
+    local_tensor = torch.arange(4, dtype=torch.float32).reshape(2, 2)
+    weight = _FakeDTensor(
+        local_tensor=local_tensor,
+        placement=Shard(0),
+        mesh=_FakeMesh(rank=0, size=99, names=("tp",)),
+    )
+
+    split = adapter._split_experts_weights(weight, n_experts=8)
+
+    assert torch.equal(torch.stack(split), local_tensor)
+    assert adapter._last_expert_ids == [6, 7]
+    assert calls == [(active_mesh, ("ep",))]
+
+
+def test_split_experts_weights_dtensor_shard_validates_local_expert_count(adapter, monkeypatch):
+    _patch_fake_dtensor(monkeypatch)
+    weight = _FakeDTensor(
+        local_tensor=torch.zeros(1, 2),
+        placement=Shard(0),
+        mesh=_FakeMesh(rank=0, size=2, names=("tp",)),
+    )
+
+    with pytest.raises(ValueError, match="Expected local Kimi expert tensor first dimension to be 3"):
+        adapter._split_experts_weights(weight, n_experts=5)

--- a/tests/unit_tests/models/kimi_linear/test_state_dict_adapter.py
+++ b/tests/unit_tests/models/kimi_linear/test_state_dict_adapter.py
@@ -127,8 +127,8 @@ def test_from_hf_groups_kimi_w1_w2_w3_experts(adapter, moe_config):
 
     native = adapter.from_hf(hf_state)
 
-    gate_up_key = "model.layers.1.block_sparse_moe.experts.gate_and_up_projs"
-    down_key = "model.layers.1.block_sparse_moe.experts.down_projs"
+    gate_up_key = "model.layers.1.mlp.experts.gate_and_up_projs"
+    down_key = "model.layers.1.mlp.experts.down_projs"
     assert gate_up_key in native
     assert down_key in native
 
@@ -156,7 +156,7 @@ def test_from_hf_upcasts_kda_and_router_fp32_keys(adapter):
 
     assert native["model.layers.0.self_attn._fp32_params.A_log"].dtype is torch.float32
     assert native["model.layers.0.self_attn._fp32_params.dt_bias"].dtype is torch.float32
-    assert native["model.layers.1.block_sparse_moe.gate.e_score_correction_bias"].dtype is torch.float32
+    assert native["model.layers.1.mlp.gate.e_score_correction_bias"].dtype is torch.float32
 
 
 def test_to_hf_strips_kda_fp32_holder(adapter):
@@ -175,12 +175,12 @@ def test_to_hf_strips_kda_fp32_holder(adapter):
 
 def test_to_hf_splits_grouped_experts_back_to_kimi_names(adapter, moe_config):
     native = {
-        "model.layers.1.block_sparse_moe.experts.gate_and_up_projs": torch.randn(
+        "model.layers.1.mlp.experts.gate_and_up_projs": torch.randn(
             moe_config.n_routed_experts,
             moe_config.dim,
             2 * moe_config.moe_inter_dim,
         ),
-        "model.layers.1.block_sparse_moe.experts.down_projs": torch.randn(
+        "model.layers.1.mlp.experts.down_projs": torch.randn(
             moe_config.n_routed_experts,
             moe_config.moe_inter_dim,
             moe_config.dim,
@@ -298,3 +298,23 @@ def test_split_experts_weights_dtensor_shard_validates_local_expert_count(adapte
 
     with pytest.raises(ValueError, match="Expected local Kimi expert tensor first dimension to be 3"):
         adapter._split_experts_weights(weight, n_experts=5)
+
+
+def test_moe_children_map_between_block_sparse_moe_and_mlp(adapter):
+    """The block names its feed-forward ``mlp``; the checkpoint says ``block_sparse_moe``."""
+    hf_state = {
+        "model.layers.1.block_sparse_moe.gate.weight": torch.ones(3, 4),
+        "model.layers.1.block_sparse_moe.shared_experts.down_proj.weight": torch.ones(4, 3),
+        # A dense layer keeps ``mlp`` on both sides and must survive untouched.
+        "model.layers.0.mlp.down_proj.weight": torch.ones(4, 3),
+    }
+
+    native = adapter.from_hf(hf_state)
+
+    assert "model.layers.1.mlp.gate.weight" in native
+    assert "model.layers.1.mlp.shared_experts.down_proj.weight" in native
+    assert "model.layers.0.mlp.down_proj.weight" in native
+
+    round_tripped = adapter.to_hf(native)
+
+    assert set(round_tripped) == set(hf_state)

--- a/tests/unit_tests/models/kimi_linear/test_tp.py
+++ b/tests/unit_tests/models/kimi_linear/test_tp.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import pytest
+from torch.distributed.tensor.parallel import (
+    ColwiseParallel,
+    PrepareModuleOutput,
+    RowwiseParallel,
+    SequenceParallel,
+)
+
+from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.models.kimi_linear.model import KimiLinearForCausalLM
+from nemo_automodel.components.models.kimi_linear.tp import parallelize_kimi_linear
+from tests.unit_tests.models.kimi_linear.test_model import _tiny_kimi_config
+
+
+def _model(use_kda: bool = False):
+    """Build a tiny model; the KDA variant needs the optional FLA kernels."""
+    if use_kda:
+        pytest.importorskip("fla")
+    return KimiLinearForCausalLM(_tiny_kimi_config(use_kda=use_kda), backend=BackendConfig(attn="eager"))
+
+
+def test_plan_shards_full_attention_layers():
+    plan = parallelize_kimi_linear(_model())
+
+    assert isinstance(plan["model.layers.1.self_attn.q_proj"], ColwiseParallel)
+    assert isinstance(plan["model.layers.1.self_attn.kv_b_proj"], ColwiseParallel)
+    assert isinstance(plan["model.layers.1.self_attn.o_proj"], RowwiseParallel)
+    # The head-shared compressed latent is not sharded.
+    assert "model.layers.1.self_attn.kv_a_proj_with_mqa" not in plan
+
+
+def test_plan_leaves_kda_layers_replicated():
+    # kda_layers=[1] is 1-based, so layer 0 is the KDA layer and layer 1 is MLA.
+    plan = parallelize_kimi_linear(_model(use_kda=True))
+
+    assert not any(key.startswith("model.layers.0.self_attn") for key in plan)
+    assert "model.layers.1.self_attn.q_proj" in plan
+
+
+def test_plan_leaves_routed_experts_to_expert_parallelism():
+    plan = parallelize_kimi_linear(_model())
+
+    assert not any("experts" in key for key in plan)
+    # first_k_dense_replace=1, so layer 0 keeps a dense MLP that is sharded, while
+    # layer 1's MoE (also named ``mlp``) gets no projection styles at all.
+    assert isinstance(plan["model.layers.0.mlp.down_proj"], RowwiseParallel)
+    assert "model.layers.1.mlp.down_proj" not in plan
+
+
+def test_sequence_parallel_shards_block_boundaries():
+    plan = parallelize_kimi_linear(_model(use_kda=True), sequence_parallel=True)
+
+    assert isinstance(plan["model.norm"], SequenceParallel)
+    assert isinstance(plan["model.layers.0.input_layernorm"], SequenceParallel)
+    assert isinstance(plan["model.layers.0.post_attention_layernorm"], SequenceParallel)
+    # A replicated KDA layer and the EP-owned MoE both emit full-sequence outputs
+    # that must be scattered back onto the sequence-parallel residual stream.
+    assert isinstance(plan["model.layers.0.self_attn"], PrepareModuleOutput)
+    assert isinstance(plan["model.layers.1.mlp"], PrepareModuleOutput)
+
+
+def test_sequence_parallel_is_absent_without_the_flag():
+    plan = parallelize_kimi_linear(_model())
+
+    assert "model.norm" not in plan
+    assert not any(isinstance(style, (SequenceParallel, PrepareModuleOutput)) for style in plan.values())
+
+
+def test_model_declares_tensor_and_sequence_parallel_support():
+    assert KimiLinearForCausalLM.ModelCapabilities().supports_tp
+    assert KimiLinearForCausalLM._supports_sequence_parallel is True

--- a/tests/unit_tests/moe/test_experts.py
+++ b/tests/unit_tests/moe/test_experts.py
@@ -208,6 +208,105 @@ class TestSwigluClampedDeepEP:
         assert out.shape == (2, 4)
 
 
+class TestGroupedExpertsRouteWeightAfterDown:
+    """Tests for Kimi-style expert output weighting."""
+
+    def _tiny_config(self, *, route_weight_after_down_proj: bool = True, expert_activation: str = "swiglu"):
+        return MoEConfig(
+            n_routed_experts=2,
+            n_shared_experts=0,
+            n_activated_experts=2,
+            n_expert_groups=1,
+            n_limited_groups=1,
+            train_gate=True,
+            gate_bias_update_factor=0.0,
+            aux_loss_coeff=0.0,
+            score_func="sigmoid",
+            route_scale=1.0,
+            dim=2,
+            inter_dim=4,
+            moe_inter_dim=2,
+            norm_topk_prob=False,
+            router_bias=False,
+            expert_bias=True,
+            expert_activation=expert_activation,
+            route_weight_after_down_proj=route_weight_after_down_proj,
+            dtype=torch.float32,
+        )
+
+    def test_loop_matches_reference_weight_after_down_projection(self):
+        config = self._tiny_config()
+        experts = GroupedExperts(config)
+        with torch.no_grad():
+            experts.gate_and_up_projs.copy_(
+                torch.tensor(
+                    [
+                        [[1.0, 0.0, 0.5, 0.0], [0.0, 1.0, 0.0, 0.5]],
+                        [[0.25, -0.5, 1.0, 0.25], [0.75, 0.5, -0.25, 1.0]],
+                    ]
+                )
+            )
+            experts.down_projs.copy_(
+                torch.tensor(
+                    [
+                        [[1.0, 0.5], [-0.25, 0.75]],
+                        [[0.5, -1.0], [1.25, 0.25]],
+                    ]
+                )
+            )
+            experts.gate_up_proj_bias.copy_(torch.tensor([[0.1, -0.2, 0.3, -0.4], [0.2, 0.1, -0.1, 0.4]]))
+            experts.down_proj_bias.copy_(torch.tensor([[0.05, -0.1], [-0.2, 0.15]]))
+
+        x = torch.tensor([[1.0, -2.0], [0.5, 1.5], [-1.0, 0.25]])
+        weights = torch.tensor([[0.2, 0.7], [0.4, 0.3], [0.9, 0.1]])
+        indices = torch.tensor([[0, 1], [1, 0], [0, 1]])
+        token_mask = torch.ones(x.shape[0], dtype=torch.bool)
+
+        output = experts(x, token_mask, weights, indices)
+
+        expected = torch.zeros_like(x)
+        for token_idx in range(x.shape[0]):
+            for top_idx in range(indices.shape[1]):
+                expert_idx = indices[token_idx, top_idx]
+                gate_up = x[token_idx : token_idx + 1] @ experts.gate_and_up_projs[expert_idx]
+                gate_up = gate_up + experts.gate_up_proj_bias[expert_idx]
+                gate, up = torch.chunk(gate_up, 2, dim=-1)
+                expert_out = torch.nn.functional.silu(gate) * up
+                expert_out = expert_out @ experts.down_projs[expert_idx]
+                expert_out = expert_out + experts.down_proj_bias[expert_idx]
+                expected[token_idx] += expert_out.squeeze(0) * weights[token_idx, top_idx]
+
+        torch.testing.assert_close(output, expected)
+
+    def test_default_down_bias_stays_weighted_by_route(self):
+        config = self._tiny_config(route_weight_after_down_proj=False)
+        experts = GroupedExperts(config)
+        with torch.no_grad():
+            experts.gate_and_up_projs.zero_()
+            experts.down_projs.zero_()
+            experts.gate_up_proj_bias.zero_()
+            experts.down_proj_bias.copy_(torch.tensor([[1.0, -2.0], [3.0, 4.0]]))
+
+        x = torch.tensor([[0.5, -1.0], [1.5, 2.0]])
+        weights = torch.tensor([[0.2, 0.7], [0.4, 0.3]])
+        indices = torch.tensor([[0, 1], [1, 0]])
+        token_mask = torch.ones(x.shape[0], dtype=torch.bool)
+
+        output = experts(x, token_mask, weights, indices)
+
+        expected = torch.stack(
+            [
+                experts.down_proj_bias[0] * weights[0, 0] + experts.down_proj_bias[1] * weights[0, 1],
+                experts.down_proj_bias[1] * weights[1, 0] + experts.down_proj_bias[0] * weights[1, 1],
+            ]
+        )
+        torch.testing.assert_close(output, expected)
+
+    def test_route_weight_after_down_projection_requires_swiglu(self):
+        with pytest.raises(ValueError, match="supports only swiglu"):
+            GroupedExperts(self._tiny_config(expert_activation="relu2"))
+
+
 class TestGroupedExpertsZeroActiveExperts:
     """Test GroupedExperts handling of zero active local experts.
 

--- a/tests/unit_tests/moe/test_experts.py
+++ b/tests/unit_tests/moe/test_experts.py
@@ -826,6 +826,13 @@ class TestGroupedExpertsForwardLoopDTensorBias:
 class TestGroupedExpertsDeepEP:
     """Test GroupedExpertsDeepEP module."""
 
+    def test_grouped_experts_deepep_rejects_route_weight_after_down_projection(self, moe_config):
+        """DeepEP must fail loudly until it implements post-down-projection route weights."""
+        moe_config.route_weight_after_down_proj = True
+
+        with pytest.raises(ValueError, match="GroupedExpertsDeepEP"):
+            GroupedExpertsDeepEP(moe_config)
+
     def test_grouped_experts_deepep_init(self, moe_config):
         """Test GroupedExpertsDeepEP initialization."""
         experts = GroupedExpertsDeepEP(moe_config)
@@ -1135,6 +1142,16 @@ class TestNonGatedActivations:
             swiglu_config.dim,
             swiglu_config.moe_inter_dim * 2,
         )
+
+
+def test_grouped_experts_te_rejects_route_weight_after_down_projection_without_te_import(moe_config):
+    """TE must fail loudly before importing optional TE when route weights would be applied incorrectly."""
+    from nemo_automodel.components.moe.experts import GroupedExpertsTE
+
+    moe_config.route_weight_after_down_proj = True
+
+    with pytest.raises(ValueError, match="GroupedExpertsTE"):
+        GroupedExpertsTE(moe_config)
 
 
 @pytest.mark.skipif(SKIP_TE_TESTS, reason="TransformerEngine and CUDA required")

--- a/tests/unit_tests/moe/test_layers.py
+++ b/tests/unit_tests/moe/test_layers.py
@@ -1095,6 +1095,59 @@ class TestGate:
                     f"Expected output dtype {input_dtype} but got {weights.dtype} with gate_precision={gate_precision}"
                 )
 
+    def test_gate_router_weights_fp32_keeps_precision_output(self, moe_config, device):
+        """Test that router_weights_fp32 keeps Kimi-style routing weights in fp32."""
+        moe_config.score_func = "softmax"
+        moe_config.router_weights_fp32 = True
+        gate = Gate(moe_config, gate_precision=torch.float32).to(device)
+
+        with torch.no_grad():
+            gate.weight.normal_(0, 0.02)
+
+        x = torch.randn(8, moe_config.dim, dtype=torch.bfloat16, device=device)
+        token_mask = torch.ones(x.shape[0], dtype=torch.bool, device=device)
+
+        weights, _, _ = gate(x, token_mask, cp_mesh=None)
+
+        assert weights.dtype == torch.float32
+
+    def test_gate_router_weights_can_use_score_correction_bias(self, device):
+        """Test Kimi's HF router behavior where biased scores are also gathered as weights."""
+        config = MoEConfig(
+            n_routed_experts=2,
+            n_shared_experts=0,
+            n_activated_experts=1,
+            n_expert_groups=1,
+            n_limited_groups=1,
+            train_gate=True,
+            gate_bias_update_factor=0.0,
+            aux_loss_coeff=0.0,
+            score_func="sigmoid",
+            route_scale=1.0,
+            dim=2,
+            inter_dim=4,
+            moe_inter_dim=4,
+            norm_topk_prob=False,
+            router_bias=False,
+            expert_bias=False,
+            force_e_score_correction_bias=True,
+            router_weights_fp32=True,
+            router_weight_uses_score_correction_bias=True,
+            dtype=torch.float32,
+        )
+        gate = Gate(config, gate_precision=torch.float32).to(device)
+        with torch.no_grad():
+            gate.weight.zero_()
+            gate.e_score_correction_bias.copy_(torch.tensor([10.0, 0.0], device=device))
+
+        x = torch.zeros(3, config.dim, dtype=torch.bfloat16, device=device)
+        token_mask = torch.ones(x.shape[0], dtype=torch.bool, device=device)
+
+        weights, indices, _ = gate(x, token_mask, cp_mesh=None)
+
+        torch.testing.assert_close(indices, torch.zeros_like(indices))
+        torch.testing.assert_close(weights, torch.full_like(weights, 10.5))
+
     def test_gate_precision_with_sigmoid(self, moe_config, device):
         """Test Gate precision with sigmoid score function."""
         moe_config.score_func = "sigmoid"

--- a/tests/unit_tests/moe/test_parallelizer.py
+++ b/tests/unit_tests/moe/test_parallelizer.py
@@ -2952,3 +2952,39 @@ def test_apply_cp_mixed_full_and_linear_attention(monkeypatch):
     te_attn.set_context_parallel_group.assert_called_once()
     # linear_attention block: cp_mesh attached
     assert linear_attn._cp_mesh is cp_mesh
+
+
+
+def test_resolve_moe_tp_plan_rejects_sequence_parallel_without_opt_in(monkeypatch):
+    """Custom MoE models must declare SP support before the boundary can be sharded."""
+    P = _import_parallelizer_with_stubs(monkeypatch)
+
+    class _Model:
+        pass
+
+    with pytest.raises(ValueError, match="sequence_parallel=True is not supported"):
+        P._resolve_moe_tp_plan(_Model(), sequence_parallel=True, tp_shard_plan=None, tp_size=2)
+
+
+def test_resolve_moe_tp_plan_forwards_sequence_parallel_to_the_registered_plan(monkeypatch):
+    """An opted-in model gets its plan built with the sequence-parallel flag set."""
+    P = _import_parallelizer_with_stubs(monkeypatch)
+
+    class _Model:
+        _supports_sequence_parallel = True
+
+    seen = {}
+
+    def _plan_factory(model, sequence_parallel):
+        seen["sequence_parallel"] = sequence_parallel
+        return {}
+
+    plans_stub = types.ModuleType("nemo_automodel.components.distributed.optimized_tp_plans")
+    plans_stub.PARALLELIZE_FUNCTIONS = {"_Model": _plan_factory}
+    plans_stub._get_class_qualname = lambda cls: cls.__name__
+    monkeypatch.setitem(sys.modules, "nemo_automodel.components.distributed.optimized_tp_plans", plans_stub)
+    monkeypatch.setattr(P, "_validate_moe_tp_plan", lambda plan, model: plan)
+
+    P._resolve_moe_tp_plan(_Model(), sequence_parallel=True, tp_shard_plan=None, tp_size=2)
+
+    assert seen["sequence_parallel"] is True

--- a/tests/unit_tests/test_validation.py
+++ b/tests/unit_tests/test_validation.py
@@ -143,6 +143,24 @@ def _make_moe_cls():
     return _MoE
 
 
+def _make_owns_cp_cls(backend_attn="eager"):
+    """MoE model that ships its own CP transport (Kimi Linear style)."""
+    from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
+
+    class _OwnsCP(MoEFSDPSyncMixin, nn.Module):
+        _owns_cp_attention = True
+        _owns_packed_attention = True
+
+        def __init__(self):
+            super().__init__()
+            self.backend = SimpleNamespace(attn=backend_attn)
+
+        def forward(self, input_ids, seq_lens=None):
+            return input_ids
+
+    return _OwnsCP
+
+
 def _make_moe_te_cls():
     """MoE model whose backend.attn == 'te'."""
     from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
@@ -306,6 +324,12 @@ class TestModelSupportsCP:
         _attach(model)
         assert model.supports.supports_cp is False
 
+    def test_custom_true_when_model_owns_cp(self):
+        """A model owning its CP transport needs no TE/Magi attention backend."""
+        model = _make_owns_cp_cls()()
+        _attach(model)
+        assert model.supports.supports_cp is True
+
     def test_deepseek_v4_true_with_tilelang(self):
         model = _DeepseekV4Like(backend_attn="tilelang")
         _attach(model)
@@ -427,6 +451,13 @@ class TestModelSupportsCPWithSequencePacking:
         _attach(model)
         model._mesh = _mesh(cp=2)
         assert model.supports.supports_cp_with_sequence_packing is False
+
+    def test_cp_gt1_sequence_packing_supported_when_model_owns_cp(self):
+        model = _make_owns_cp_cls()()
+        _attach(model)
+        model._mesh = _mesh(cp=2)
+        assert model.supports.supports_sequence_packing is True
+        assert model.supports.supports_cp_with_sequence_packing is True
 
     def test_deepseek_v4_cp_gt1_sequence_packing_supported_with_tilelang(self):
         model = _DeepseekV4Like()


### PR DESCRIPTION
## Summary

Adds native Automodel support for `moonshotai/Kimi-Linear-48B-A3B-Instruct`:

- Implements the Kimi Linear config, causal LM, KDA attention, MLA attention, HF state-dict adapter, and registry wiring.
- Uses FLA KDA kernels (`fused_kda_gate`, `chunk_kda` / `fused_recurrent_kda`, `ShortConvolution`, `FusedRMSNormGated`) following the HF `trust_remote_code` implementation.
- Keeps KDA `A_log` and `dt_bias` in fp32 via an FSDP-safe holder.
- Adds Kimi-specific MoE routing switches needed for HF parity and EP training, while preserving default MoE behavior.
- Adds an EP=8, PP=1 HellaSwag fine-tuning recipe for the 48B-A3B checkpoint.

## HF Parity

First 8 layers matched against Hugging Face `trust_remote_code=True` implementation for `moonshotai/Kimi-Linear-48B-A3B-Instruct`.

- `kl_batchmean`: `-1.949409e-06` (numerical noise around zero)
- `kl_per_token`: `-1.522976e-08`
- `max_abs_diff`: `0.0`
- `mean_abs_diff`: `0.0`
- logits shape: `[1, 128, 163840]`

The tensor bisect ended with layers 0 through 7 exact on logits and routed MoE gate indices/weights.

## HellaSwag 100-step W&B Run

W&B: https://wandb.ai/Nemo-automodel/automodel-kimi-linear/runs/l4l4eb7d

<img width="493" height="213" alt="image" src="https://github.com/user-attachments/assets/5fababb3-d020-4889-b104-62da14d790b5" />


Run setup: single node, 8x H100 80GB, FSDP2, EP=8, PP=1, `kda_mode=chunk`, `kda_unpad_inputs=false`, W&B online.

- step 0 train loss: `2.7050`
- validation loss trend: `3.2480` at step 9 -> `3.0102` at step 99
- final step 99 train loss: `1.8430`
- final W&B summary: `_step=99`, `loss=1.8429668`, `val_loss=3.0102007`, `grad_norm=5.1753`

## Validation

- `python -m py_compile ...` on touched model/MoE/test files
- `python -m ruff check ...` on touched Python files
- `python -m ruff format --check ...` on touched Python files
- `python tools/lint_example_yamls.py --automodel-dir . examples/llm_finetune/kimi/kimi_linear_48b_a3b_hellaswag.yaml`
- `CUDA_VISIBLE_DEVICES= PYTHONPATH=$PWD python -m pytest -q tests/unit_tests/models/kimi_linear tests/unit_tests/_transformers/test_registry.py` (`34 passed`)
- `CUDA_VISIBLE_DEVICES= PYTHONPATH=$PWD python -m pytest -q tests/unit_tests/moe/test_experts.py::TestGroupedExpertsRouteWeightAfterDown tests/unit_tests/moe/test_layers.py::TestGate::test_gate_router_weights_fp32_keeps_precision_output tests/unit_tests/moe/test_layers.py::TestGate::test_gate_router_weights_can_use_score_correction_bias` (`5 passed`)
