### PR TITLE
feat(models): add Laguna model implementation

### DIFF
--- a/nemo_automodel/_transformers/registry.py
+++ b/nemo_automodel/_transformers/registry.py
@@ -145,6 +145,10 @@ MODEL_ARCH_MAPPING = OrderedDict(
             ("nemo_automodel.components.models.mimo_v2_flash.model", "MiMoV2FlashForCausalLM"),
         ),
         (
+            "LagunaForCausalLM",
+            ("nemo_automodel.components.models.laguna.model", "LagunaForCausalLM"),
+        ),
+        (
             "Ministral3ForCausalLM",
             ("nemo_automodel.components.models.mistral3.model", "Ministral3ForCausalLM"),
         ),
@@ -289,6 +293,7 @@ _CUSTOM_CONFIG_REGISTRATIONS: Dict[str, Tuple[str, str]] = {
     "kimi_k2": ("nemo_automodel.components.models.kimi_k2.config", "KimiK2Config"),
     "kimi_k25": ("nemo_automodel.components.models.kimi_k25_vl.model", "KimiK25VLConfig"),
     "kimi_vl": ("nemo_automodel.components.models.kimivl.model", "KimiVLConfig"),
+    "laguna": ("nemo_automodel.components.models.laguna.config", "LagunaConfig"),
     "llavaonevision1_5": ("nemo_automodel.components.models.llava_onevision.model", "Llavaonevision1_5Config"),
     "mimo_v2_flash": ("nemo_automodel.components.models.mimo_v2_flash.config", "MiMoV2FlashConfig"),
     "minimax_m3_vl": ("nemo_automodel.components.models.minimax_m3_vl.config", "MiniMaxM3VLConfig"),
@@ -308,6 +313,7 @@ _CUSTOM_CONFIG_REGISTRATIONS: Dict[str, Tuple[str, str]] = {
 # here keep the built-in config when one exists (mistral4's custom model was
 # written against the native config and runs green with it).
 _CUSTOM_CONFIG_OVERRIDES_BUILTIN = {
+    "laguna",
     "minimax_m3_vl",
 }
 

--- a/nemo_automodel/components/models/laguna/__init__.py
+++ b/nemo_automodel/components/models/laguna/__init__.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nemo_automodel.components.models.laguna.config import LagunaConfig
+from nemo_automodel.components.models.laguna.model import LagunaForCausalLM, LagunaModel, ModelClass
+
+__all__ = ["LagunaConfig", "LagunaForCausalLM", "LagunaModel", "ModelClass"]

--- a/nemo_automodel/components/models/laguna/config.py
+++ b/nemo_automodel/components/models/laguna/config.py
@@ -1,0 +1,187 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import Any
+
+from transformers.configuration_utils import PretrainedConfig
+
+
+def _normalize_layer_list(name: str, value: list[Any] | None, num_hidden_layers: int) -> list[Any] | None:
+    """Return a per-layer list sized for ``num_hidden_layers``.
+
+    ``from_pretrained(..., num_hidden_layers=N)`` is useful for first-layer
+    parity checks against a large checkpoint whose JSON still carries full-length
+    per-layer lists.  Longer lists are clipped; shorter lists remain an error.
+    """
+    if value is None:
+        return None
+    value = list(value)
+    if len(value) < num_hidden_layers:
+        raise ValueError(f"{name} must have at least {num_hidden_layers} entries, got {len(value)}")
+    return value[:num_hidden_layers]
+
+
+_PRE_INIT_OVERRIDE_FIELDS = {
+    "num_hidden_layers",
+    "layer_types",
+    "num_attention_heads_per_layer",
+    "gating_types",
+    "mlp_layer_types",
+    "mlp_only_layers",
+    "rope_parameters",
+    "swa_rope_parameters",
+    "partial_rotary_factor",
+}
+
+
+class LagunaConfig(PretrainedConfig):
+    """Configuration for Poolside Laguna causal language models."""
+
+    model_type = "laguna"
+    keys_to_ignore_at_inference = ["past_key_values"]
+    pad_token_id: int | None = None
+    bos_token_id: int | None = None
+    eos_token_id: int | list[int] | None = None
+
+    @classmethod
+    def from_dict(cls, config_dict: dict[str, Any], **kwargs):
+        config_dict = dict(config_dict)
+        for key in list(kwargs):
+            if key in _PRE_INIT_OVERRIDE_FIELDS:
+                config_dict[key] = kwargs.pop(key)
+        return super().from_dict(config_dict, **kwargs)
+
+    def __init__(
+        self,
+        vocab_size: int = 100352,
+        hidden_size: int = 2048,
+        intermediate_size: int = 8192,
+        num_hidden_layers: int = 48,
+        num_attention_heads: int = 32,
+        num_key_value_heads: int = 8,
+        head_dim: int = 128,
+        qkv_bias: bool = False,
+        attention_bias: bool = False,
+        gating: bool | str = True,
+        gating_types: list[str] | None = None,
+        hidden_act: str = "silu",
+        max_position_embeddings: int = 4096,
+        initializer_range: float = 0.02,
+        rms_norm_eps: float = 1e-6,
+        use_cache: bool = True,
+        tie_word_embeddings: bool = False,
+        rope_parameters: dict[str, Any] | None = None,
+        partial_rotary_factor: float | None = None,
+        attention_dropout: float = 0.0,
+        sliding_window: int | None = None,
+        layer_types: list[str] | None = None,
+        num_attention_heads_per_layer: list[int] | None = None,
+        swa_attention_sink_enabled: bool = False,
+        swa_rope_parameters: dict[str, Any] | None = None,
+        num_experts: int = 256,
+        num_experts_per_tok: int = 16,
+        moe_intermediate_size: int = 1024,
+        shared_expert_intermediate_size: int = 1024,
+        norm_topk_prob: bool = True,
+        decoder_sparse_step: int = 1,
+        mlp_only_layers: list[int] | None = None,
+        mlp_layer_types: list[str] | None = None,
+        router_aux_loss_coef: float = 0.001,
+        moe_routed_scaling_factor: float = 1.0,
+        moe_apply_router_weight_on_input: bool = False,
+        moe_router_logit_softcapping: float = 0.0,
+        output_router_logits: bool = False,
+        torch_dtype: str = "bfloat16",
+        **kwargs,
+    ):
+        if rope_parameters is None:
+            rope_parameters = {"rope_type": "default", "rope_theta": 500000.0}
+        if swa_rope_parameters is None and isinstance(rope_parameters, dict):
+            swa_rope_parameters = rope_parameters.get("sliding_attention")
+
+        if partial_rotary_factor is not None:
+            if isinstance(rope_parameters, dict) and "partial_rotary_factor" not in rope_parameters:
+                rope_parameters = {**rope_parameters, "partial_rotary_factor": partial_rotary_factor}
+            if isinstance(swa_rope_parameters, dict) and "partial_rotary_factor" not in swa_rope_parameters:
+                swa_rope_parameters = {**swa_rope_parameters, "partial_rotary_factor": partial_rotary_factor}
+
+        if layer_types is None:
+            layer_types = ["full_attention"] * num_hidden_layers
+        layer_types = _normalize_layer_list("layer_types", layer_types, num_hidden_layers)
+
+        num_attention_heads_per_layer = _normalize_layer_list(
+            "num_attention_heads_per_layer",
+            num_attention_heads_per_layer,
+            num_hidden_layers,
+        )
+        gating_types = _normalize_layer_list("gating_types", gating_types, num_hidden_layers)
+        mlp_layer_types = _normalize_layer_list("mlp_layer_types", mlp_layer_types, num_hidden_layers)
+
+        if mlp_only_layers is None:
+            if mlp_layer_types is None:
+                mlp_only_layers = [0]
+            else:
+                mlp_only_layers = [idx for idx, layer_type in enumerate(mlp_layer_types) if layer_type == "dense"]
+        else:
+            mlp_only_layers = [idx for idx in mlp_only_layers if idx < num_hidden_layers]
+
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.num_key_value_heads = num_key_value_heads
+        self.head_dim = head_dim
+        self.qkv_bias = qkv_bias
+        self.attention_bias = attention_bias
+        self.gating = gating
+        self.gating_types = gating_types
+        self.hidden_act = hidden_act
+        self.max_position_embeddings = max_position_embeddings
+        self.initializer_range = initializer_range
+        self.rms_norm_eps = rms_norm_eps
+        self.use_cache = use_cache
+        self.rope_parameters = rope_parameters
+        self.partial_rotary_factor = partial_rotary_factor
+        self.attention_dropout = attention_dropout
+        self.sliding_window = sliding_window
+        self.layer_types = layer_types
+        self.num_attention_heads_per_layer = num_attention_heads_per_layer
+        self.swa_attention_sink_enabled = swa_attention_sink_enabled
+        self.swa_rope_parameters = swa_rope_parameters
+        self.num_experts = num_experts
+        self.num_experts_per_tok = num_experts_per_tok
+        self.moe_intermediate_size = moe_intermediate_size
+        self.shared_expert_intermediate_size = shared_expert_intermediate_size
+        self.norm_topk_prob = norm_topk_prob
+        self.decoder_sparse_step = decoder_sparse_step
+        self.mlp_only_layers = mlp_only_layers
+        self.mlp_layer_types = mlp_layer_types
+        self.router_aux_loss_coef = router_aux_loss_coef
+        self.moe_routed_scaling_factor = moe_routed_scaling_factor
+        self.moe_apply_router_weight_on_input = moe_apply_router_weight_on_input
+        self.moe_router_logit_softcapping = moe_router_logit_softcapping
+        self.output_router_logits = output_router_logits
+        self.torch_dtype = torch_dtype
+
+        super().__init__(
+            tie_word_embeddings=tie_word_embeddings,
+            use_cache=use_cache,
+            **kwargs,
+        )
+
+
+__all__ = ["LagunaConfig"]

--- a/nemo_automodel/components/models/laguna/model.py
+++ b/nemo_automodel/components/models/laguna/model.py
@@ -322,11 +322,6 @@ class LagunaAttention(nn.Module):
         else:
             self.g_proj = None
 
-        if self.is_sliding and getattr(config, "swa_attention_sink_enabled", False):
-            self.sink = nn.Parameter(torch.zeros(self.num_heads, dtype=torch.float32))
-        else:
-            self.sink = None
-
         self.q_norm = LagunaRMSNorm(self.head_dim, eps=config.rms_norm_eps, dtype=dtype)
         self.k_norm = LagunaRMSNorm(self.head_dim, eps=config.rms_norm_eps, dtype=dtype)
 
@@ -337,6 +332,20 @@ class LagunaAttention(nn.Module):
         attention_mask: torch.Tensor | None = None,
         **kwargs: Any,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Run Laguna attention for one decoder layer.
+
+        Args:
+            hidden_states: Tensor of shape [batch, sequence, hidden].
+            position_embeddings: Tuple of cosine and sine RoPE tensors, each of shape
+                [batch, sequence, rotary_dim].
+            attention_mask: Optional additive mask broadcastable to
+                [batch, heads, sequence, key_sequence].
+            **kwargs: Additional attention backend arguments.
+
+        Returns:
+            Tuple of attention output [batch, sequence, hidden] and optional attention weights
+            [batch, heads, sequence, key_sequence].
+        """
         batch, seq_len = hidden_states.shape[:2]
         query_states = self.q_proj(hidden_states).view(batch, seq_len, self.num_heads, self.head_dim).transpose(1, 2)
         key_states = self.k_proj(hidden_states).view(
@@ -402,8 +411,6 @@ class LagunaAttention(nn.Module):
                 nn.init.zeros_(linear.bias)
         self.q_norm.reset_parameters()
         self.k_norm.reset_parameters()
-        if self.sink is not None:
-            nn.init.zeros_(self.sink)
 
 
 class LagunaBlock(nn.Module):
@@ -441,6 +448,20 @@ class LagunaBlock(nn.Module):
         padding_mask: torch.Tensor | None = None,
         **kwargs: Any,
     ) -> torch.Tensor:
+        """Run a decoder block.
+
+        Args:
+            hidden_states: Tensor of shape [batch, sequence, hidden].
+            attention_mask: Optional additive attention mask broadcastable to
+                [batch, heads, sequence, key_sequence].
+            position_embeddings: Tuple of cosine and sine RoPE tensors, each of shape
+                [batch, sequence, rotary_dim].
+            padding_mask: Optional bool tensor of shape [batch, sequence], where True marks padding.
+            **kwargs: Additional attention backend arguments.
+
+        Returns:
+            Tensor of shape [batch, sequence, hidden].
+        """
         residual = hidden_states
         hidden_states = self.input_layernorm(hidden_states)
         hidden_states, _ = self.self_attn(
@@ -489,6 +510,8 @@ class LagunaModel(nn.Module):
         self.backend = backend
         if moe_config is not None and moe_overrides is not None:
             raise ValueError("Cannot pass both moe_config and moe_overrides; use one or the other.")
+        if config.swa_attention_sink_enabled:
+            raise NotImplementedError("Laguna swa_attention_sink_enabled=True is not supported in Automodel.")
         if config.moe_apply_router_weight_on_input:
             raise NotImplementedError("Laguna moe_apply_router_weight_on_input=True is not supported in Automodel.")
         if float(config.moe_router_logit_softcapping or 0.0) > 0.0:
@@ -621,6 +644,22 @@ class LagunaModel(nn.Module):
         padding_mask: torch.Tensor | None = None,
         **kwargs: Any,
     ) -> torch.Tensor:
+        """Run the Laguna decoder stack.
+
+        Args:
+            input_ids: Optional token IDs of shape [batch, sequence].
+            inputs_embeds: Optional embeddings of shape [batch, sequence, hidden].
+            position_ids: Optional position IDs of shape [batch, sequence].
+            attention_mask: Optional 2D bool/int mask of shape [batch, sequence], a 4D additive
+                mask, or a mapping with per-attention-type masks keyed by "full_attention" and
+                "sliding_attention".
+            padding_mask: Optional bool tensor of shape [batch, sequence], where True marks tokens
+                excluded from MoE routing.
+            **kwargs: Additional attention backend arguments.
+
+        Returns:
+            Final hidden states of shape [batch, sequence, hidden].
+        """
         if inputs_embeds is None:
             if input_ids is None:
                 raise ValueError("input_ids or inputs_embeds must be provided")
@@ -678,7 +717,7 @@ class LagunaForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
     """Causal LM wrapper for Laguna with Automodel checkpoint adapters."""
 
     tie_word_embeddings_support: TieSupport = TieSupport.UNTIED_ONLY
-    _keep_in_fp32_modules_strict = ["mlp.gate.e_score_correction_bias", "rotary_emb", "sink"]
+    _keep_in_fp32_modules_strict = ["mlp.gate.e_score_correction_bias", "rotary_emb"]
     _skip_init_weights_on_load = True
 
     @dataclass(frozen=True)
@@ -766,6 +805,27 @@ class LagunaForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
         output_hidden_states: Optional[bool] = None,
         **kwargs: Any,
     ) -> CausalLMOutputWithPast:
+        """Run the Laguna causal language model.
+
+        Args:
+            input_ids: Optional token IDs of shape [batch, sequence].
+            inputs_embeds: Optional embeddings of shape [batch, sequence, hidden].
+            position_ids: Optional position IDs of shape [batch, sequence].
+            attention_mask: Optional 2D bool/int mask of shape [batch, sequence], a 4D additive
+                mask, or a mapping with per-attention-type masks keyed by "full_attention" and
+                "sliding_attention".
+            padding_mask: Optional bool tensor of shape [batch, sequence], where True marks tokens
+                excluded from MoE routing.
+            past_key_values: Unsupported KV-cache state.
+            use_cache: Unsupported cache flag.
+            logits_to_keep: If 0, compute logits for all sequence positions. If an int or tensor,
+                compute logits only for the selected trailing positions.
+            output_hidden_states: When true, include final hidden states in the output.
+            **kwargs: Additional attention backend arguments.
+
+        Returns:
+            Causal LM output with logits and optional hidden states.
+        """
         if past_key_values is not None or use_cache:
             raise NotImplementedError("LagunaForCausalLM currently supports training forwards without KV cache.")
         output_hidden_states = (

--- a/nemo_automodel/components/models/laguna/model.py
+++ b/nemo_automodel/components/models/laguna/model.py
@@ -1,0 +1,817 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import copy
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Optional, Union
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from transformers.masking_utils import create_causal_mask, create_sliding_window_causal_mask
+from transformers.modeling_outputs import CausalLMOutputWithPast
+from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
+
+from nemo_automodel.components.models.common import BackendConfig, initialize_linear_module
+from nemo_automodel.components.models.common.hf_checkpointing_mixin import HFCheckpointingMixin
+from nemo_automodel.components.models.common.tie_word_embeddings import (
+    TieSupport,
+    reject_unsupported_tie_word_embeddings,
+)
+from nemo_automodel.components.models.common.utils import (
+    _has_dtensor_params,
+    cast_model_to_dtype,
+    compute_lm_head_logits,
+)
+from nemo_automodel.components.models.laguna.config import LagunaConfig
+from nemo_automodel.components.models.laguna.state_dict_adapter import LagunaStateDictAdapter
+from nemo_automodel.components.moe.config import MoEConfig
+from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
+from nemo_automodel.components.moe.layers import MLP, MoE
+from nemo_automodel.shared.utils import dtype_from_str as get_dtype
+
+
+def _rotate_half(x: torch.Tensor) -> torch.Tensor:
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def _apply_rotary_pos_emb(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    cos = cos.unsqueeze(1)
+    sin = sin.unsqueeze(1)
+    rotary_dim = cos.shape[-1]
+    q_rot, q_pass = q[..., :rotary_dim], q[..., rotary_dim:]
+    k_rot, k_pass = k[..., :rotary_dim], k[..., rotary_dim:]
+    q_embed = (q_rot * cos) + (_rotate_half(q_rot) * sin)
+    k_embed = (k_rot * cos) + (_rotate_half(k_rot) * sin)
+    return torch.cat([q_embed, q_pass], dim=-1), torch.cat([k_embed, k_pass], dim=-1)
+
+
+def _repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
+    batch, num_key_value_heads, seq_len, head_dim = hidden_states.shape
+    if n_rep == 1:
+        return hidden_states
+    hidden_states = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, seq_len, head_dim)
+    return hidden_states.reshape(batch, num_key_value_heads * n_rep, seq_len, head_dim)
+
+
+def _convert_bool_4d_mask_to_additive(attention_mask: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
+    if attention_mask.ndim != 4 or attention_mask.dtype != torch.bool:
+        return attention_mask
+    additive = torch.zeros(attention_mask.shape, dtype=dtype, device=attention_mask.device)
+    return additive.masked_fill(~attention_mask, torch.finfo(dtype).min)
+
+
+def _derive_padding_mask(attention_mask: torch.Tensor) -> torch.Tensor:
+    if attention_mask.ndim == 2:
+        return attention_mask == 0
+    if attention_mask.ndim == 4:
+        diagonal = torch.diagonal(attention_mask[:, 0], dim1=-2, dim2=-1)
+        if attention_mask.dtype == torch.bool:
+            return diagonal.logical_not()
+        return diagonal != 0
+    return attention_mask.bool().logical_not()
+
+
+def _fallback_additive_mask(
+    batch_size: int,
+    seq_len: int,
+    dtype: torch.dtype,
+    device: torch.device,
+    attention_mask: torch.Tensor | None = None,
+    sliding_window: int | None = None,
+) -> torch.Tensor:
+    min_value = torch.finfo(dtype).min
+    idx = torch.arange(seq_len, device=device)
+    masked = idx.unsqueeze(0) > idx.unsqueeze(1)
+    if sliding_window is not None and sliding_window > 0:
+        masked = masked | ((idx.unsqueeze(1) - idx.unsqueeze(0)) >= sliding_window)
+    additive = torch.zeros((seq_len, seq_len), dtype=dtype, device=device).masked_fill(masked, min_value)
+    additive = additive.unsqueeze(0).unsqueeze(0).expand(batch_size, 1, seq_len, seq_len).contiguous()
+    if attention_mask is not None and attention_mask.ndim == 2:
+        pad = attention_mask.to(dtype=dtype, device=device)
+        additive = additive + (1.0 - pad).unsqueeze(1).unsqueeze(2) * min_value
+    return additive
+
+
+def _ensure_additive_mask(
+    mask: torch.Tensor | None,
+    *,
+    batch_size: int,
+    seq_len: int,
+    dtype: torch.dtype,
+    device: torch.device,
+    attention_mask: torch.Tensor | None,
+    sliding_window: int | None,
+) -> torch.Tensor:
+    if mask is None or not isinstance(mask, torch.Tensor):
+        return _fallback_additive_mask(batch_size, seq_len, dtype, device, attention_mask, sliding_window)
+    return _convert_bool_4d_mask_to_additive(mask, dtype)
+
+
+def _eager_attention_forward(
+    module: nn.Module,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attention_mask: torch.Tensor | None,
+    scaling: float,
+    dropout: float = 0.0,
+    **kwargs: Any,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    del kwargs
+    key_states = _repeat_kv(key, module.num_key_value_groups)
+    value_states = _repeat_kv(value, module.num_key_value_groups)
+    attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling
+    if attention_mask is not None:
+        attn_weights = attn_weights + attention_mask[:, :, :, : key_states.shape[-2]]
+    attn_weights = F.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
+    attn_weights = F.dropout(attn_weights, p=dropout, training=module.training)
+    attn_output = torch.matmul(attn_weights, value_states)
+    return attn_output.transpose(1, 2).contiguous(), attn_weights
+
+
+def _sdpa_attention_forward(
+    module: nn.Module,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attention_mask: torch.Tensor | None,
+    scaling: float,
+    dropout: float = 0.0,
+    **kwargs: Any,
+) -> tuple[torch.Tensor, None]:
+    del scaling, kwargs
+    key_states = _repeat_kv(key, module.num_key_value_groups)
+    value_states = _repeat_kv(value, module.num_key_value_groups)
+    attn_output = F.scaled_dot_product_attention(
+        query,
+        key_states,
+        value_states,
+        attn_mask=attention_mask[:, :, :, : key_states.shape[-2]] if attention_mask is not None else None,
+        dropout_p=dropout,
+        is_causal=False,
+    )
+    return attn_output.transpose(1, 2).contiguous(), None
+
+
+def _normalize_gating_mode(gating: bool | str) -> str | None:
+    if isinstance(gating, str):
+        gating = gating.replace("_", "-").lower()
+        if gating in {"false", "none", "off"}:
+            return None
+        if gating in {"per-head", "head"}:
+            return "per-head"
+        if gating in {"true", "per-element", "element"}:
+            return "per-element"
+        raise ValueError(f"Unsupported Laguna attention gating mode: {gating}")
+    return "per-element" if gating else None
+
+
+class LagunaRMSNorm(nn.Module):
+    """RMSNorm with fp32 variance, matching the Laguna reference implementation."""
+
+    def __init__(self, hidden_size: int, eps: float = 1e-6, dtype: torch.dtype = torch.bfloat16):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size, dtype=dtype))
+        self.variance_epsilon = eps
+
+    def reset_parameters(self) -> None:
+        nn.init.ones_(self.weight)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.to(torch.float32)
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        return self.weight * hidden_states.to(input_dtype)
+
+
+class LagunaRotaryEmbedding(nn.Module):
+    """Rotary embedding with Laguna's nested full-attention/SWA RoPE support."""
+
+    inv_freq: torch.Tensor
+
+    def __init__(self, config: LagunaConfig, device: torch.device | None = None):
+        super().__init__()
+        self.max_seq_len_cached = config.max_position_embeddings
+        self.original_max_seq_len = config.max_position_embeddings
+        self.config = config
+        self.rope_type = config.rope_parameters["rope_type"]
+        rope_init_fn: Callable = self._compute_default_rope_parameters
+        if self.rope_type != "default":
+            rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+        inv_freq, self.attention_scaling = rope_init_fn(config, device)
+        self.register_buffer("inv_freq", inv_freq.float(), persistent=False)
+        self.register_buffer("original_inv_freq", inv_freq.float().clone(), persistent=False)
+
+    @staticmethod
+    def _compute_default_rope_parameters(
+        config: LagunaConfig,
+        device: torch.device | None = None,
+        seq_len: int | None = None,
+    ) -> tuple[torch.Tensor, float]:
+        del seq_len
+        base = config.rope_parameters["rope_theta"]
+        partial = config.rope_parameters.get("partial_rotary_factor", 1.0)
+        dim = int(config.head_dim * partial)
+        dim = dim - (dim % 2)
+        if dim <= 0:
+            raise ValueError(f"Invalid rotary dimension {dim} for head_dim={config.head_dim}")
+        arange = torch.arange(0, dim, 2, dtype=torch.int64, device=device).float()
+        inv_freq = 1.0 / (base ** (arange / dim))
+        return inv_freq, 1.0
+
+    @torch.no_grad()
+    @dynamic_rope_update
+    def forward(self, x: torch.Tensor, position_ids: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        inv_freq = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
+        position_ids = position_ids[:, None, :].float()
+        device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+        with torch.autocast(device_type=device_type, enabled=False):
+            freqs = (inv_freq @ position_ids).transpose(1, 2)
+            emb = torch.cat((freqs, freqs), dim=-1)
+            cos = emb.cos() * self.attention_scaling
+            sin = emb.sin() * self.attention_scaling
+        return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
+
+
+class LagunaAttention(nn.Module):
+    """Laguna attention: explicit per-layer heads, QK RMSNorm, and output gating."""
+
+    def __init__(self, config: LagunaConfig, backend: BackendConfig, layer_idx: int):
+        super().__init__()
+        self.config = config
+        self.backend = backend
+        self.layer_idx = layer_idx
+        per_layer_heads = config.num_attention_heads_per_layer
+        self.num_heads = per_layer_heads[layer_idx] if per_layer_heads is not None else config.num_attention_heads
+        self.head_dim = config.head_dim
+        self.num_key_value_heads = config.num_key_value_heads
+        self.num_key_value_groups = self.num_heads // self.num_key_value_heads
+        self.scaling = self.head_dim**-0.5
+        self.attention_dropout = float(config.attention_dropout or 0.0)
+        self.is_causal = True
+
+        layer_types = getattr(config, "layer_types", None)
+        self.attention_type = layer_types[layer_idx] if layer_types is not None else "full_attention"
+        self.is_sliding = self.attention_type == "sliding_attention"
+        self.sliding_window = config.sliding_window if self.is_sliding else None
+
+        dtype = get_dtype(config.torch_dtype, torch.bfloat16)
+        self.q_proj = initialize_linear_module(
+            backend.linear,
+            config.hidden_size,
+            self.num_heads * self.head_dim,
+            bias=config.qkv_bias,
+            dtype=dtype,
+        )
+        self.k_proj = initialize_linear_module(
+            backend.linear,
+            config.hidden_size,
+            self.num_key_value_heads * self.head_dim,
+            bias=config.qkv_bias,
+            dtype=dtype,
+        )
+        self.v_proj = initialize_linear_module(
+            backend.linear,
+            config.hidden_size,
+            self.num_key_value_heads * self.head_dim,
+            bias=config.qkv_bias,
+            dtype=dtype,
+        )
+        self.o_proj = initialize_linear_module(
+            backend.linear,
+            self.num_heads * self.head_dim,
+            config.hidden_size,
+            bias=config.attention_bias,
+            dtype=dtype,
+        )
+
+        gating = config.gating_types[layer_idx] if config.gating_types is not None else config.gating
+        self.gating_mode = _normalize_gating_mode(gating)
+        if self.gating_mode is not None:
+            g_out = self.num_heads if self.gating_mode == "per-head" else self.num_heads * self.head_dim
+            self.g_proj = initialize_linear_module(
+                backend.linear,
+                config.hidden_size,
+                g_out,
+                bias=False,
+                dtype=dtype,
+            )
+        else:
+            self.g_proj = None
+
+        if self.is_sliding and getattr(config, "swa_attention_sink_enabled", False):
+            self.sink = nn.Parameter(torch.zeros(self.num_heads, dtype=torch.float32))
+        else:
+            self.sink = None
+
+        self.q_norm = LagunaRMSNorm(self.head_dim, eps=config.rms_norm_eps, dtype=dtype)
+        self.k_norm = LagunaRMSNorm(self.head_dim, eps=config.rms_norm_eps, dtype=dtype)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        attention_mask: torch.Tensor | None = None,
+        **kwargs: Any,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        batch, seq_len = hidden_states.shape[:2]
+        query_states = self.q_proj(hidden_states).view(batch, seq_len, self.num_heads, self.head_dim).transpose(1, 2)
+        key_states = self.k_proj(hidden_states).view(
+            batch,
+            seq_len,
+            self.num_key_value_heads,
+            self.head_dim,
+        )
+        key_states = key_states.transpose(1, 2)
+        value_states = self.v_proj(hidden_states).view(
+            batch,
+            seq_len,
+            self.num_key_value_heads,
+            self.head_dim,
+        )
+        value_states = value_states.transpose(1, 2)
+
+        query_states = self.q_norm(query_states)
+        key_states = self.k_norm(key_states)
+        cos, sin = position_embeddings
+        query_states, key_states = _apply_rotary_pos_emb(query_states, key_states, cos, sin)
+
+        attention_interface: Callable = _eager_attention_forward
+        attn_impl = getattr(self.config, "_attn_implementation", "eager")
+        if attn_impl == "sdpa":
+            attention_interface = _sdpa_attention_forward
+        elif attn_impl != "eager":
+            from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+
+            attention_interface = ALL_ATTENTION_FUNCTIONS[attn_impl]
+
+        attn_output, attn_weights = attention_interface(
+            self,
+            query_states,
+            key_states,
+            value_states,
+            attention_mask,
+            dropout=0.0 if not self.training else self.attention_dropout,
+            scaling=self.scaling,
+            **kwargs,
+        )
+        attn_output = attn_output.reshape(batch, seq_len, -1).contiguous()
+
+        if self.g_proj is not None:
+            gate = F.softplus(self.g_proj(hidden_states).float()).to(attn_output.dtype)
+            if self.gating_mode == "per-head":
+                attn_shape = attn_output.shape
+                attn_output = (
+                    attn_output.view(*attn_shape[:-1], self.num_heads, self.head_dim) * gate.unsqueeze(-1)
+                ).view(attn_shape)
+            else:
+                attn_output = attn_output * gate
+
+        return self.o_proj(attn_output), attn_weights
+
+    def init_weights(self, buffer_device: torch.device, init_std: float = 0.02) -> None:
+        del buffer_device
+        for linear in (self.q_proj, self.k_proj, self.v_proj, self.o_proj, self.g_proj):
+            if linear is None:
+                continue
+            nn.init.normal_(linear.weight, mean=0.0, std=init_std)
+            if getattr(linear, "bias", None) is not None:
+                nn.init.zeros_(linear.bias)
+        self.q_norm.reset_parameters()
+        self.k_norm.reset_parameters()
+        if self.sink is not None:
+            nn.init.zeros_(self.sink)
+
+
+class LagunaBlock(nn.Module):
+    """Decoder block that uses dense MLP for configured layers and MoE otherwise."""
+
+    def __init__(self, layer_idx: int, config: LagunaConfig, moe_config: MoEConfig, backend: BackendConfig):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.attention_type = config.layer_types[layer_idx]
+        self.self_attn = LagunaAttention(config, backend, layer_idx=layer_idx)
+        dtype = get_dtype(config.torch_dtype, torch.bfloat16)
+        is_moe_layer = layer_idx not in config.mlp_only_layers and (
+            config.num_experts > 0 and (layer_idx + 1) % config.decoder_sparse_step == 0
+        )
+        if is_moe_layer:
+            self.mlp = MoE(moe_config, backend)
+        else:
+            self.mlp = MLP(
+                config.hidden_size,
+                config.intermediate_size,
+                backend.linear,
+                dtype=dtype,
+                activation="swiglu",
+                bias=False,
+            )
+        self.input_layernorm = LagunaRMSNorm(config.hidden_size, eps=config.rms_norm_eps, dtype=dtype)
+        self.post_attention_layernorm = LagunaRMSNorm(config.hidden_size, eps=config.rms_norm_eps, dtype=dtype)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        *,
+        attention_mask: torch.Tensor | None = None,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        padding_mask: torch.Tensor | None = None,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states, _ = self.self_attn(
+            hidden_states,
+            attention_mask=attention_mask,
+            position_embeddings=position_embeddings,
+            **kwargs,
+        )
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        if isinstance(self.mlp, MoE):
+            hidden_states = self.mlp(hidden_states, padding_mask)
+        else:
+            hidden_states = self.mlp(hidden_states)
+        return residual + hidden_states
+
+    def init_weights(self, buffer_device: torch.device) -> None:
+        self.input_layernorm.reset_parameters()
+        self.post_attention_layernorm.reset_parameters()
+        self.self_attn.init_weights(buffer_device, init_std=0.02)
+        self.mlp.init_weights(buffer_device)
+
+
+def _config_with_rope(config: LagunaConfig, rope_parameters: dict[str, Any]) -> LagunaConfig:
+    rope_config = copy.deepcopy(config)
+    rope_config.rope_parameters = dict(rope_parameters)
+    rope_config.partial_rotary_factor = rope_config.rope_parameters.get("partial_rotary_factor")
+    return rope_config
+
+
+class LagunaModel(nn.Module):
+    """Backbone model for Laguna SFT."""
+
+    def __init__(
+        self,
+        config: LagunaConfig,
+        backend: BackendConfig,
+        *,
+        moe_config: MoEConfig | None = None,
+        moe_overrides: dict | None = None,
+    ):
+        super().__init__()
+        self.config = config
+        self.backend = backend
+        if moe_config is not None and moe_overrides is not None:
+            raise ValueError("Cannot pass both moe_config and moe_overrides; use one or the other.")
+        if config.moe_apply_router_weight_on_input:
+            raise NotImplementedError("Laguna moe_apply_router_weight_on_input=True is not supported in Automodel.")
+        if float(config.moe_router_logit_softcapping or 0.0) > 0.0:
+            raise NotImplementedError("Laguna router logit softcapping is not supported in Automodel.")
+        if self.backend.gate_precision is None:
+            self.backend.gate_precision = torch.float32
+
+        dtype = get_dtype(config.torch_dtype, torch.bfloat16)
+        moe_defaults = dict(
+            dim=config.hidden_size,
+            inter_dim=config.intermediate_size,
+            moe_inter_dim=config.moe_intermediate_size,
+            n_routed_experts=config.num_experts,
+            n_shared_experts=1 if config.shared_expert_intermediate_size else 0,
+            n_activated_experts=config.num_experts_per_tok,
+            n_expert_groups=1,
+            n_limited_groups=1,
+            train_gate=True,
+            gate_bias_update_factor=0.0,
+            score_func="sigmoid",
+            route_scale=config.moe_routed_scaling_factor,
+            aux_loss_coeff=config.router_aux_loss_coef,
+            norm_topk_prob=config.norm_topk_prob,
+            router_bias=False,
+            expert_bias=False,
+            expert_activation="swiglu",
+            shared_expert_inter_dim=config.shared_expert_intermediate_size,
+            shared_expert_activation="swiglu",
+            softmax_before_topk=False,
+            force_e_score_correction_bias=True,
+            dtype=dtype,
+        )
+        if moe_overrides:
+            moe_defaults.update(moe_overrides)
+        self.moe_config = moe_config or MoEConfig(**moe_defaults)
+
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, config.pad_token_id, dtype=dtype)
+        self.layers = nn.ModuleDict(
+            {
+                str(layer_id): LagunaBlock(layer_id, config, self.moe_config, backend)
+                for layer_id in range(config.num_hidden_layers)
+            }
+        )
+        self.norm = LagunaRMSNorm(config.hidden_size, eps=config.rms_norm_eps, dtype=dtype)
+
+        rope_parameters = config.rope_parameters
+        full_rope = rope_parameters.get("full_attention") if isinstance(rope_parameters, dict) else None
+        if isinstance(full_rope, dict):
+            self.rotary_emb = LagunaRotaryEmbedding(_config_with_rope(config, full_rope))
+        else:
+            self.rotary_emb = LagunaRotaryEmbedding(config)
+
+        if getattr(config, "swa_rope_parameters", None) is not None:
+            self.swa_rotary_emb = LagunaRotaryEmbedding(_config_with_rope(config, config.swa_rope_parameters))
+        else:
+            self.swa_rotary_emb = None
+        self.has_sliding_layers = "sliding_attention" in config.layer_types
+
+    def _build_causal_mask_mapping(
+        self,
+        inputs_embeds: torch.Tensor,
+        attention_mask: torch.Tensor | dict[str, torch.Tensor] | None,
+        position_ids: torch.Tensor,
+    ) -> dict[str, torch.Tensor]:
+        batch_size, seq_len = inputs_embeds.shape[:2]
+        if isinstance(attention_mask, dict):
+            full = attention_mask.get("full_attention")
+            sliding = attention_mask.get("sliding_attention")
+            if sliding is None:
+                sliding = attention_mask.get("sliding_window_attention")
+            return {
+                "full_attention": _ensure_additive_mask(
+                    full,
+                    batch_size=batch_size,
+                    seq_len=seq_len,
+                    dtype=inputs_embeds.dtype,
+                    device=inputs_embeds.device,
+                    attention_mask=None,
+                    sliding_window=None,
+                ),
+                "sliding_attention": _ensure_additive_mask(
+                    sliding,
+                    batch_size=batch_size,
+                    seq_len=seq_len,
+                    dtype=inputs_embeds.dtype,
+                    device=inputs_embeds.device,
+                    attention_mask=None,
+                    sliding_window=self.config.sliding_window,
+                ),
+            }
+
+        mask_kwargs = {
+            "config": self.config,
+            "inputs_embeds": inputs_embeds,
+            "attention_mask": attention_mask,
+            "past_key_values": None,
+            "position_ids": position_ids,
+        }
+        full = create_causal_mask(**mask_kwargs)
+        sliding = create_sliding_window_causal_mask(**mask_kwargs) if self.has_sliding_layers else None
+        tensor_attention_mask = attention_mask if isinstance(attention_mask, torch.Tensor) else None
+        return {
+            "full_attention": _ensure_additive_mask(
+                full,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                dtype=inputs_embeds.dtype,
+                device=inputs_embeds.device,
+                attention_mask=tensor_attention_mask,
+                sliding_window=None,
+            ),
+            "sliding_attention": _ensure_additive_mask(
+                sliding,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                dtype=inputs_embeds.dtype,
+                device=inputs_embeds.device,
+                attention_mask=tensor_attention_mask,
+                sliding_window=self.config.sliding_window,
+            ),
+        }
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None = None,
+        *,
+        inputs_embeds: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | dict[str, torch.Tensor] | None = None,
+        padding_mask: torch.Tensor | None = None,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        if inputs_embeds is None:
+            if input_ids is None:
+                raise ValueError("input_ids or inputs_embeds must be provided")
+            inputs_embeds = self.embed_tokens(input_ids)
+        if position_ids is None:
+            position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0)
+        if padding_mask is None and isinstance(attention_mask, torch.Tensor):
+            padding_mask = _derive_padding_mask(attention_mask)
+
+        causal_mask_mapping = self._build_causal_mask_mapping(
+            inputs_embeds,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+        )
+
+        hidden_states = inputs_embeds
+        full_position_embeddings = self.rotary_emb(hidden_states, position_ids)
+        if self.has_sliding_layers:
+            sliding_position_embeddings = (
+                self.swa_rotary_emb(hidden_states, position_ids)
+                if self.swa_rotary_emb is not None
+                else full_position_embeddings
+            )
+            position_embeddings_mapping = {
+                "full_attention": full_position_embeddings,
+                "sliding_attention": sliding_position_embeddings,
+            }
+        else:
+            position_embeddings_mapping = {"full_attention": full_position_embeddings}
+
+        for decoder_layer in self.layers.values():
+            hidden_states = decoder_layer(
+                hidden_states,
+                attention_mask=causal_mask_mapping[decoder_layer.attention_type],
+                position_embeddings=position_embeddings_mapping[decoder_layer.attention_type],
+                padding_mask=padding_mask,
+                **kwargs,
+            )
+
+        return self.norm(hidden_states) if self.norm is not None else hidden_states
+
+    @torch.no_grad()
+    def init_weights(self, buffer_device: torch.device | None = None) -> None:
+        buffer_device = buffer_device or torch.device(f"cuda:{torch.cuda.current_device()}")
+        with buffer_device:
+            if self.embed_tokens is not None:
+                nn.init.normal_(self.embed_tokens.weight, mean=0.0, std=self.config.initializer_range)
+            if self.norm is not None:
+                self.norm.reset_parameters()
+        for layer in self.layers.values():
+            layer.init_weights(buffer_device)
+
+
+class LagunaForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
+    """Causal LM wrapper for Laguna with Automodel checkpoint adapters."""
+
+    tie_word_embeddings_support: TieSupport = TieSupport.UNTIED_ONLY
+    _keep_in_fp32_modules_strict = ["mlp.gate.e_score_correction_bias", "rotary_emb", "sink"]
+    _skip_init_weights_on_load = True
+
+    @dataclass(frozen=True)
+    class ModelCapabilities:
+        """Declared parallelism capabilities for this model class."""
+
+        supports_tp: bool = False
+        supports_cp: bool = False
+        supports_pp: bool = False
+        supports_ep: bool = True
+
+    @classmethod
+    def from_config(
+        cls,
+        config: LagunaConfig,
+        moe_config: MoEConfig | None = None,
+        backend: BackendConfig | None = None,
+        **kwargs,
+    ):
+        return cls(config, moe_config, backend, **kwargs)
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str,
+        *model_args,
+        **kwargs,
+    ):
+        config_kwargs = kwargs.pop("config_kwargs", {})
+        config = LagunaConfig.from_pretrained(pretrained_model_name_or_path, **config_kwargs)
+        return cls.from_config(config, *model_args, **kwargs)
+
+    def __init__(
+        self,
+        config: LagunaConfig,
+        moe_config: MoEConfig | None = None,
+        backend: BackendConfig | None = None,
+        **kwargs,
+    ):
+        super().__init__()
+        self.config = config
+        reject_unsupported_tie_word_embeddings(type(self), config)
+        self.backend = backend or BackendConfig()
+        moe_overrides = kwargs.pop("moe_overrides", None)
+        self.model = LagunaModel(config, self.backend, moe_config=moe_config, moe_overrides=moe_overrides)
+        dtype = get_dtype(config.torch_dtype, torch.bfloat16)
+        self.lm_head = initialize_linear_module(
+            self.backend.linear,
+            config.hidden_size,
+            config.vocab_size,
+            bias=False,
+            dtype=dtype,
+        )
+        if self.backend.enable_hf_state_dict_adapter:
+            self.state_dict_adapter = LagunaStateDictAdapter(self.config, self.model.moe_config, self.backend, dtype)
+
+    def get_input_embeddings(self):
+        return self.model.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.model.embed_tokens = value
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def set_output_embeddings(self, new_embeddings):
+        self.lm_head = new_embeddings
+
+    def update_moe_gate_bias(self) -> None:
+        for layer in self.model.layers.values():
+            if isinstance(layer.mlp, MoE) and layer.mlp.gate.bias_update_factor > 0:
+                layer.mlp.gate.update_bias()
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None = None,
+        *,
+        inputs_embeds: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | dict[str, torch.Tensor] | None = None,
+        padding_mask: torch.Tensor | None = None,
+        past_key_values: Any = None,
+        use_cache: bool | None = None,
+        logits_to_keep: Union[int, torch.Tensor] = 0,
+        output_hidden_states: Optional[bool] = None,
+        **kwargs: Any,
+    ) -> CausalLMOutputWithPast:
+        if past_key_values is not None or use_cache:
+            raise NotImplementedError("LagunaForCausalLM currently supports training forwards without KV cache.")
+        output_hidden_states = (
+            output_hidden_states
+            if output_hidden_states is not None
+            else getattr(self.config, "output_hidden_states", False)
+        )
+        hidden = self.model(
+            input_ids=input_ids,
+            inputs_embeds=inputs_embeds,
+            position_ids=position_ids,
+            attention_mask=attention_mask,
+            padding_mask=padding_mask,
+            **kwargs,
+        )
+        return compute_lm_head_logits(
+            self.lm_head,
+            hidden,
+            logits_to_keep,
+            output_hidden_states=output_hidden_states,
+        )
+
+    @torch.no_grad()
+    def initialize_weights(
+        self,
+        buffer_device: torch.device | None = None,
+        dtype: torch.dtype = torch.bfloat16,
+    ) -> None:
+        buffer_device = buffer_device or torch.device(f"cuda:{torch.cuda.current_device()}")
+        with buffer_device:
+            self.model.init_weights(buffer_device)
+            final_out_std = self.config.hidden_size**-0.5
+            cutoff_factor = 3
+            if self.lm_head is not None:
+                nn.init.trunc_normal_(
+                    self.lm_head.weight,
+                    mean=0.0,
+                    std=final_out_std,
+                    a=-cutoff_factor * final_out_std,
+                    b=cutoff_factor * final_out_std,
+                )
+        if _has_dtensor_params(self):
+            return
+        cast_model_to_dtype(self, dtype)
+
+
+ModelClass = LagunaForCausalLM
+
+__all__ = ["LagunaForCausalLM", "LagunaModel", "ModelClass"]

--- a/nemo_automodel/components/models/laguna/model.py
+++ b/nemo_automodel/components/models/laguna/model.py
@@ -308,6 +308,14 @@ class LagunaRMSNorm(nn.Module):
         nn.init.ones_(self.weight)
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Apply RMS normalization while computing variance in fp32.
+
+        Args:
+            hidden_states: Tensor of shape [..., hidden].
+
+        Returns:
+            Tensor of shape [..., hidden].
+        """
         input_dtype = hidden_states.dtype
         hidden_states = hidden_states.to(torch.float32)
         variance = hidden_states.pow(2).mean(-1, keepdim=True)
@@ -353,6 +361,15 @@ class LagunaRotaryEmbedding(nn.Module):
     @torch.no_grad()
     @dynamic_rope_update
     def forward(self, x: torch.Tensor, position_ids: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """Compute RoPE cosine and sine tables.
+
+        Args:
+            x: Activation tensor of shape [batch, sequence, hidden], used for device and dtype.
+            position_ids: Position tensor of shape [batch, sequence].
+
+        Returns:
+            Tuple of cosine and sine tensors, each of shape [batch, sequence, rotary_dim].
+        """
         inv_freq = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
         position_ids = position_ids[:, None, :].float()
         device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
@@ -684,6 +701,18 @@ class LagunaModel(nn.Module):
         attention_mask: torch.Tensor | dict[str, torch.Tensor] | None,
         position_ids: torch.Tensor,
     ) -> dict[str, torch.Tensor]:
+        """Build additive attention masks for full and sliding Laguna layers.
+
+        Args:
+            inputs_embeds: Input embedding tensor of shape [batch, sequence, hidden].
+            attention_mask: Optional sequence mask of shape [batch, sequence], 4D bool/additive
+                mask, or mapping with masks keyed by "full_attention" and "sliding_attention".
+            position_ids: Position tensor of shape [batch, sequence].
+
+        Returns:
+            Mapping from attention type to additive masks of shape
+            [batch, heads_or_one, sequence, key_sequence].
+        """
         batch_size, seq_len = inputs_embeds.shape[:2]
         if isinstance(attention_mask, dict):
             full = attention_mask.get("full_attention")

--- a/nemo_automodel/components/models/laguna/model.py
+++ b/nemo_automodel/components/models/laguna/model.py
@@ -46,6 +46,14 @@ from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 
 
 def _rotate_half(x: torch.Tensor) -> torch.Tensor:
+    """Rotate the two halves of the RoPE feature axis.
+
+    Args:
+        x: Tensor of shape [..., rotary_dim], where rotary_dim is even.
+
+    Returns:
+        Tensor of shape [..., rotary_dim].
+    """
     x1 = x[..., : x.shape[-1] // 2]
     x2 = x[..., x.shape[-1] // 2 :]
     return torch.cat((-x2, x1), dim=-1)
@@ -57,6 +65,17 @@ def _apply_rotary_pos_emb(
     cos: torch.Tensor,
     sin: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    """Apply RoPE to query and key states.
+
+    Args:
+        q: Query tensor of shape [batch, heads, sequence, head_dim].
+        k: Key tensor of shape [batch, key_value_heads, sequence, head_dim].
+        cos: Cosine tensor of shape [batch, sequence, rotary_dim].
+        sin: Sine tensor of shape [batch, sequence, rotary_dim].
+
+    Returns:
+        Tuple of rotated query and key tensors with the same shapes as ``q`` and ``k``.
+    """
     cos = cos.unsqueeze(1)
     sin = sin.unsqueeze(1)
     rotary_dim = cos.shape[-1]
@@ -68,6 +87,15 @@ def _apply_rotary_pos_emb(
 
 
 def _repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
+    """Repeat key/value heads for grouped-query attention.
+
+    Args:
+        hidden_states: Tensor of shape [batch, key_value_heads, sequence, head_dim].
+        n_rep: Number of repeats per key/value head.
+
+    Returns:
+        Tensor of shape [batch, key_value_heads * n_rep, sequence, head_dim].
+    """
     batch, num_key_value_heads, seq_len, head_dim = hidden_states.shape
     if n_rep == 1:
         return hidden_states
@@ -76,6 +104,16 @@ def _repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
 
 
 def _convert_bool_4d_mask_to_additive(attention_mask: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
+    """Convert a bool 4D attention mask to additive attention-mask layout.
+
+    Args:
+        attention_mask: Tensor of shape [batch, heads_or_one, sequence, key_sequence].
+            Bool masks use True for visible entries; non-bool masks are already additive.
+        dtype: Floating-point dtype for the additive mask.
+
+    Returns:
+        Additive mask tensor with the same shape, or the original non-bool mask.
+    """
     if attention_mask.ndim != 4 or attention_mask.dtype != torch.bool:
         return attention_mask
     additive = torch.zeros(attention_mask.shape, dtype=dtype, device=attention_mask.device)
@@ -83,6 +121,15 @@ def _convert_bool_4d_mask_to_additive(attention_mask: torch.Tensor, dtype: torch
 
 
 def _derive_padding_mask(attention_mask: torch.Tensor) -> torch.Tensor:
+    """Derive an MoE padding mask from a sequence or attention mask.
+
+    Args:
+        attention_mask: Tensor of shape [batch, sequence] with nonzero valid tokens, or
+            [batch, heads_or_one, sequence, key_sequence] in bool or additive mask layout.
+
+    Returns:
+        Bool tensor of shape [batch, sequence], where True marks padding.
+    """
     if attention_mask.ndim == 2:
         return attention_mask == 0
     if attention_mask.ndim == 4:
@@ -101,6 +148,19 @@ def _fallback_additive_mask(
     attention_mask: torch.Tensor | None = None,
     sliding_window: int | None = None,
 ) -> torch.Tensor:
+    """Build a causal additive attention mask.
+
+    Args:
+        batch_size: Batch size for the returned mask.
+        seq_len: Query and key sequence length.
+        dtype: Floating-point dtype for the additive mask.
+        device: Device for the returned mask.
+        attention_mask: Optional sequence mask of shape [batch, sequence] with nonzero valid tokens.
+        sliding_window: Optional sliding-window size for local attention.
+
+    Returns:
+        Additive mask tensor of shape [batch, 1, sequence, sequence].
+    """
     min_value = torch.finfo(dtype).min
     idx = torch.arange(seq_len, device=device)
     masked = idx.unsqueeze(0) > idx.unsqueeze(1)
@@ -124,6 +184,21 @@ def _ensure_additive_mask(
     attention_mask: torch.Tensor | None,
     sliding_window: int | None,
 ) -> torch.Tensor:
+    """Normalize an optional precomputed mask into additive layout.
+
+    Args:
+        mask: Optional attention mask of shape [batch, heads_or_one, sequence, key_sequence].
+            Bool masks use True for visible entries; additive masks are passed through.
+        batch_size: Batch size used when ``mask`` is absent.
+        seq_len: Query and key sequence length used when ``mask`` is absent.
+        dtype: Floating-point dtype for the additive mask.
+        device: Device for the additive mask.
+        attention_mask: Optional sequence mask of shape [batch, sequence] with nonzero valid tokens.
+        sliding_window: Optional sliding-window size for local attention.
+
+    Returns:
+        Additive mask tensor of shape [batch, heads_or_one, sequence, key_sequence].
+    """
     if mask is None or not isinstance(mask, torch.Tensor):
         return _fallback_additive_mask(batch_size, seq_len, dtype, device, attention_mask, sliding_window)
     return _convert_bool_4d_mask_to_additive(mask, dtype)
@@ -139,6 +214,23 @@ def _eager_attention_forward(
     dropout: float = 0.0,
     **kwargs: Any,
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run eager attention over projected query/key/value states.
+
+    Args:
+        module: Attention module carrying head-repeat metadata.
+        query: Query tensor of shape [batch, heads, sequence, head_dim].
+        key: Key tensor of shape [batch, key_value_heads, key_sequence, head_dim].
+        value: Value tensor of shape [batch, key_value_heads, key_sequence, head_dim].
+        attention_mask: Optional additive mask broadcastable to
+            [batch, heads, sequence, key_sequence].
+        scaling: Multiplicative scale for attention logits.
+        dropout: Attention dropout probability.
+        **kwargs: Ignored attention backend arguments.
+
+    Returns:
+        Tuple of context tensor [batch, sequence, heads, head_dim] and attention weights
+        [batch, heads, sequence, key_sequence].
+    """
     del kwargs
     key_states = _repeat_kv(key, module.num_key_value_groups)
     value_states = _repeat_kv(value, module.num_key_value_groups)
@@ -161,6 +253,22 @@ def _sdpa_attention_forward(
     dropout: float = 0.0,
     **kwargs: Any,
 ) -> tuple[torch.Tensor, None]:
+    """Run SDPA attention over projected query/key/value states.
+
+    Args:
+        module: Attention module carrying head-repeat metadata.
+        query: Query tensor of shape [batch, heads, sequence, head_dim].
+        key: Key tensor of shape [batch, key_value_heads, key_sequence, head_dim].
+        value: Value tensor of shape [batch, key_value_heads, key_sequence, head_dim].
+        attention_mask: Optional additive mask broadcastable to
+            [batch, heads, sequence, key_sequence].
+        scaling: Ignored because SDPA applies its own scale.
+        dropout: Attention dropout probability.
+        **kwargs: Ignored attention backend arguments.
+
+    Returns:
+        Tuple of context tensor [batch, sequence, heads, head_dim] and ``None`` for weights.
+    """
     del scaling, kwargs
     key_states = _repeat_kv(key, module.num_key_value_groups)
     value_states = _repeat_kv(value, module.num_key_value_groups)

--- a/nemo_automodel/components/models/laguna/state_dict_adapter.py
+++ b/nemo_automodel/components/models/laguna/state_dict_adapter.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import torch
+from torch.distributed.device_mesh import DeviceMesh
+
+from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
+from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.moe.config import MoEConfig
+from nemo_automodel.components.moe.state_dict_mixin import MoESplitExpertsStateDictMixin
+
+_HF_TO_NATIVE_RENAMES: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"\.mlp\.shared_expert\."), ".mlp.shared_experts."),
+    (re.compile(r"\.mlp\.experts\.e_score_correction_bias$"), ".mlp.gate.e_score_correction_bias"),
+)
+_NATIVE_TO_HF_RENAMES: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"\.mlp\.shared_experts\."), ".mlp.shared_expert."),
+    (re.compile(r"\.mlp\.gate\.e_score_correction_bias$"), ".mlp.experts.e_score_correction_bias"),
+)
+
+
+def _apply_renames(key: str, renames: tuple[tuple[re.Pattern[str], str], ...]) -> str:
+    for pattern, replacement in renames:
+        key, count = pattern.subn(replacement, key)
+        if count:
+            break
+    return key
+
+
+class LagunaStateDictAdapter(MoESplitExpertsStateDictMixin, StateDictAdapter):
+    """Convert Laguna HF checkpoints to Automodel's grouped-MoE layout."""
+
+    def __init__(
+        self,
+        config: Any,
+        moe_config: MoEConfig,
+        backend: BackendConfig,
+        dtype: torch.dtype = torch.bfloat16,
+    ):
+        self.config = config
+        self.moe_config = moe_config
+        self.backend = backend
+        self.dtype = dtype
+        self._uses_model_prefix = True
+
+    def from_hf(
+        self,
+        hf_state_dict: dict[str, Any],
+        device_mesh: DeviceMesh | None = None,
+        **kwargs,
+    ) -> dict[str, Any]:
+        del kwargs
+        normalized: dict[str, Any] = {}
+        for key, value in hf_state_dict.items():
+            if ".mlp.experts." in key and key.endswith(".weight"):
+                self._uses_model_prefix = key.startswith("model.")
+            normalized[_apply_renames(key, _HF_TO_NATIVE_RENAMES)] = value
+        return self._from_hf_w_merged_experts(normalized, device_mesh)
+
+    def to_hf(
+        self,
+        state_dict: dict[str, Any],
+        exclude_key_regex: str | None = None,
+        **kwargs,
+    ) -> dict[str, Any]:
+        hf_state_dict: dict[str, Any] = {}
+        for fqn, tensor in state_dict.items():
+            converted_tensors = self.convert_single_tensor_to_hf(
+                fqn,
+                tensor,
+                exclude_key_regex=exclude_key_regex,
+                **kwargs,
+            )
+            for key, value in converted_tensors:
+                hf_state_dict[key] = value
+        return hf_state_dict
+
+    def convert_single_tensor_to_hf(self, fqn: str, tensor: Any, **kwargs) -> list[tuple[str, Any]]:
+        exclude_key_regex = kwargs.get("exclude_key_regex", None)
+        expert_split = self._convert_single_merged_expert_to_hf_split_experts(fqn, tensor, **kwargs)
+        pairs = expert_split if expert_split is not None else [(fqn, tensor)]
+
+        out: list[tuple[str, Any]] = []
+        for key, value in pairs:
+            renamed = _apply_renames(key, _NATIVE_TO_HF_RENAMES)
+            if exclude_key_regex and re.match(exclude_key_regex, renamed):
+                continue
+            out.append((renamed, value))
+        return out
+
+
+__all__ = ["LagunaStateDictAdapter"]

--- a/tests/unit_tests/models/laguna/__init__.py
+++ b/tests/unit_tests/models/laguna/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.

--- a/tests/unit_tests/models/laguna/test_config.py
+++ b/tests/unit_tests/models/laguna/test_config.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from nemo_automodel.components.models.laguna.config import LagunaConfig
+
+
+def test_laguna_config_clips_full_checkpoint_layer_lists_for_proxy_models():
+    cfg = LagunaConfig(
+        num_hidden_layers=2,
+        layer_types=["full_attention", "sliding_attention", "full_attention"],
+        num_attention_heads_per_layer=[2, 4, 2],
+        gating_types=["per_head", "per_head", "per_head"],
+        mlp_layer_types=["dense", "sparse", "sparse"],
+    )
+
+    assert cfg.layer_types == ["full_attention", "sliding_attention"]
+    assert cfg.num_attention_heads_per_layer == [2, 4]
+    assert cfg.gating_types == ["per_head", "per_head"]
+    assert cfg.mlp_only_layers == [0]
+
+
+def test_laguna_config_rejects_short_layer_lists():
+    with pytest.raises(ValueError, match="layer_types"):
+        LagunaConfig(num_hidden_layers=3, layer_types=["full_attention"])
+
+
+def test_laguna_config_derives_swa_rope_from_nested_rope_parameters():
+    cfg = LagunaConfig(
+        rope_parameters={
+            "full_attention": {"rope_type": "yarn", "rope_theta": 500000.0, "partial_rotary_factor": 0.5},
+            "sliding_attention": {"rope_type": "default", "rope_theta": 10000.0, "partial_rotary_factor": 1.0},
+        },
+    )
+
+    assert cfg.swa_rope_parameters == {
+        "rope_type": "default",
+        "rope_theta": 10000.0,
+        "partial_rotary_factor": 1.0,
+    }

--- a/tests/unit_tests/models/laguna/test_model.py
+++ b/tests/unit_tests/models/laguna/test_model.py
@@ -71,6 +71,15 @@ def _dense_tiny_config() -> LagunaConfig:
     return cfg
 
 
+def _patch_weighted_swiglu(monkeypatch) -> None:
+    def weighted_swiglu_eager(y: torch.Tensor, weights: torch.Tensor) -> torch.Tensor:
+        y1, y2 = torch.chunk(y, 2, -1)
+        return (torch.nn.functional.silu(y1) * y2 * weights).to(y.dtype)
+
+    # Keep Laguna CPU smokes independent of torch.compile availability; shared MoE tests cover the compiled helper.
+    monkeypatch.setattr(moe_utils, "weighted_swiglu", weighted_swiglu_eager)
+
+
 def test_laguna_forward_tiny_config():
     model = LagunaForCausalLM(_dense_tiny_config(), backend=_backend())
     model.eval()
@@ -84,12 +93,7 @@ def test_laguna_forward_tiny_config():
 
 
 def test_laguna_forward_tiny_config_with_moe_layer(monkeypatch):
-    def weighted_swiglu_eager(y: torch.Tensor, weights: torch.Tensor) -> torch.Tensor:
-        y1, y2 = torch.chunk(y, 2, -1)
-        return (torch.nn.functional.silu(y1) * y2 * weights).to(y.dtype)
-
-    # Keep this Laguna smoke independent of torch.compile availability; shared MoE tests cover the compiled helper.
-    monkeypatch.setattr(moe_utils, "weighted_swiglu", weighted_swiglu_eager)
+    _patch_weighted_swiglu(monkeypatch)
     model = LagunaForCausalLM(_tiny_config(), backend=_backend())
     model.eval()
 
@@ -101,6 +105,24 @@ def test_laguna_forward_tiny_config_with_moe_layer(monkeypatch):
         output = model(input_ids=input_ids, attention_mask=attention_mask)
 
     assert output.logits.shape == (1, 4, 32)
+
+
+def test_laguna_initialize_weights_cpu_path(monkeypatch):
+    _patch_weighted_swiglu(monkeypatch)
+    model = LagunaForCausalLM(_tiny_config(), backend=_backend())
+
+    model.initialize_weights(buffer_device=torch.device("cpu"), dtype=torch.float32)
+    sparse_layer = model.model.layers["1"].mlp
+
+    assert sparse_layer.gate.e_score_correction_bias.dtype == torch.float32
+    assert all(torch.isfinite(param).all().item() for param in model.parameters())
+
+    input_ids = torch.tensor([[1, 2, 3, 4]])
+    attention_mask = torch.ones_like(input_ids)
+    with torch.no_grad():
+        output = model(input_ids=input_ids, attention_mask=attention_mask)
+
+    assert torch.isfinite(output.logits).all()
 
 
 def test_laguna_moe_defaults_match_checkpoint_routing():

--- a/tests/unit_tests/models/laguna/test_model.py
+++ b/tests/unit_tests/models/laguna/test_model.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import torch
 
 from nemo_automodel.components.models.common import BackendConfig
@@ -93,6 +94,14 @@ def test_laguna_moe_defaults_match_checkpoint_routing():
     assert model.model.moe_config.n_shared_experts == 1
     assert sparse_layer.gate.e_score_correction_bias is not None
     assert model.backend.gate_precision is torch.float32
+
+
+def test_laguna_rejects_unsupported_swa_attention_sink():
+    cfg = _tiny_config()
+    cfg.swa_attention_sink_enabled = True
+
+    with pytest.raises(NotImplementedError, match="swa_attention_sink_enabled=True"):
+        LagunaForCausalLM(cfg, backend=_backend())
 
 
 def test_laguna_attention_uses_per_layer_head_counts_and_per_head_gate():

--- a/tests/unit_tests/models/laguna/test_model.py
+++ b/tests/unit_tests/models/laguna/test_model.py
@@ -62,8 +62,15 @@ def _tiny_config() -> LagunaConfig:
     return cfg
 
 
+def _dense_tiny_config() -> LagunaConfig:
+    cfg = _tiny_config()
+    cfg.mlp_layer_types = ["dense", "dense"]
+    cfg.mlp_only_layers = [0, 1]
+    return cfg
+
+
 def test_laguna_forward_tiny_config():
-    model = LagunaForCausalLM(_tiny_config(), backend=_backend())
+    model = LagunaForCausalLM(_dense_tiny_config(), backend=_backend())
     model.eval()
 
     input_ids = torch.tensor([[1, 2, 3, 4]])

--- a/tests/unit_tests/models/laguna/test_model.py
+++ b/tests/unit_tests/models/laguna/test_model.py
@@ -19,6 +19,7 @@ from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.models.laguna.config import LagunaConfig
 from nemo_automodel.components.models.laguna.model import LagunaForCausalLM
 from nemo_automodel.components.moe.layers import MoE
+from nemo_automodel.components.moe.megatron import moe_utils
 
 
 def _backend() -> BackendConfig:
@@ -73,6 +74,26 @@ def _dense_tiny_config() -> LagunaConfig:
 def test_laguna_forward_tiny_config():
     model = LagunaForCausalLM(_dense_tiny_config(), backend=_backend())
     model.eval()
+
+    input_ids = torch.tensor([[1, 2, 3, 4]])
+    attention_mask = torch.ones_like(input_ids)
+    with torch.no_grad():
+        output = model(input_ids=input_ids, attention_mask=attention_mask)
+
+    assert output.logits.shape == (1, 4, 32)
+
+
+def test_laguna_forward_tiny_config_with_moe_layer(monkeypatch):
+    def weighted_swiglu_eager(y: torch.Tensor, weights: torch.Tensor) -> torch.Tensor:
+        y1, y2 = torch.chunk(y, 2, -1)
+        return (torch.nn.functional.silu(y1) * y2 * weights).to(y.dtype)
+
+    # Keep this Laguna smoke independent of torch.compile availability; shared MoE tests cover the compiled helper.
+    monkeypatch.setattr(moe_utils, "weighted_swiglu", weighted_swiglu_eager)
+    model = LagunaForCausalLM(_tiny_config(), backend=_backend())
+    model.eval()
+
+    assert isinstance(model.model.layers["1"].mlp, MoE)
 
     input_ids = torch.tensor([[1, 2, 3, 4]])
     attention_mask = torch.ones_like(input_ids)

--- a/tests/unit_tests/models/laguna/test_model.py
+++ b/tests/unit_tests/models/laguna/test_model.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.models.laguna.config import LagunaConfig
+from nemo_automodel.components.models.laguna.model import LagunaForCausalLM
+from nemo_automodel.components.moe.layers import MoE
+
+
+def _backend() -> BackendConfig:
+    return BackendConfig(
+        attn="eager",
+        linear="torch",
+        rms_norm="torch_fp32",
+        experts="torch",
+        dispatcher="torch",
+        enable_hf_state_dict_adapter=True,
+    )
+
+
+def _tiny_config() -> LagunaConfig:
+    cfg = LagunaConfig(
+        vocab_size=32,
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_attention_heads_per_layer=[2, 4],
+        num_key_value_heads=1,
+        head_dim=4,
+        gating="per-head",
+        gating_types=["per_head", "per_head"],
+        layer_types=["full_attention", "sliding_attention"],
+        sliding_window=4,
+        rope_parameters={
+            "full_attention": {"rope_type": "default", "rope_theta": 10000.0, "partial_rotary_factor": 0.5},
+            "sliding_attention": {"rope_type": "default", "rope_theta": 10000.0, "partial_rotary_factor": 1.0},
+        },
+        num_experts=4,
+        num_experts_per_tok=2,
+        moe_intermediate_size=8,
+        shared_expert_intermediate_size=8,
+        moe_routed_scaling_factor=2.5,
+        mlp_layer_types=["dense", "sparse"],
+        router_aux_loss_coef=0.0,
+        torch_dtype="float32",
+    )
+    cfg._attn_implementation = "eager"
+    return cfg
+
+
+def test_laguna_forward_tiny_config():
+    model = LagunaForCausalLM(_tiny_config(), backend=_backend())
+    model.eval()
+
+    input_ids = torch.tensor([[1, 2, 3, 4]])
+    attention_mask = torch.ones_like(input_ids)
+    with torch.no_grad():
+        output = model(input_ids=input_ids, attention_mask=attention_mask)
+
+    assert output.logits.shape == (1, 4, 32)
+
+
+def test_laguna_moe_defaults_match_checkpoint_routing():
+    model = LagunaForCausalLM(_tiny_config(), backend=_backend())
+    sparse_layer = model.model.layers["1"].mlp
+
+    assert isinstance(sparse_layer, MoE)
+    assert model.model.moe_config.score_func == "sigmoid"
+    assert model.model.moe_config.softmax_before_topk is False
+    assert model.model.moe_config.norm_topk_prob is True
+    assert model.model.moe_config.route_scale == 2.5
+    assert model.model.moe_config.n_shared_experts == 1
+    assert sparse_layer.gate.e_score_correction_bias is not None
+    assert model.backend.gate_precision is torch.float32
+
+
+def test_laguna_attention_uses_per_layer_head_counts_and_per_head_gate():
+    model = LagunaForCausalLM(_tiny_config(), backend=_backend())
+
+    layer0_attn = model.model.layers["0"].self_attn
+    layer1_attn = model.model.layers["1"].self_attn
+
+    assert layer0_attn.q_proj.weight.shape == (8, 16)
+    assert layer0_attn.g_proj.weight.shape == (2, 16)
+    assert layer1_attn.q_proj.weight.shape == (16, 16)
+    assert layer1_attn.g_proj.weight.shape == (4, 16)

--- a/tests/unit_tests/models/laguna/test_state_dict_adapter.py
+++ b/tests/unit_tests/models/laguna/test_state_dict_adapter.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.models.laguna.config import LagunaConfig
+from nemo_automodel.components.models.laguna.state_dict_adapter import LagunaStateDictAdapter
+from nemo_automodel.components.moe.config import MoEConfig
+
+
+def _adapter() -> LagunaStateDictAdapter:
+    config = LagunaConfig(
+        hidden_size=4,
+        intermediate_size=8,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=2,
+        num_experts=2,
+        num_experts_per_tok=1,
+        moe_intermediate_size=3,
+        shared_expert_intermediate_size=3,
+        mlp_layer_types=["dense", "sparse"],
+        torch_dtype="float32",
+    )
+    moe_config = MoEConfig(
+        dim=4,
+        inter_dim=8,
+        moe_inter_dim=3,
+        n_routed_experts=2,
+        n_shared_experts=1,
+        n_activated_experts=1,
+        n_expert_groups=1,
+        n_limited_groups=1,
+        train_gate=True,
+        gate_bias_update_factor=0.0,
+        aux_loss_coeff=0.0,
+        score_func="sigmoid",
+        route_scale=2.5,
+        norm_topk_prob=True,
+        force_e_score_correction_bias=True,
+        dtype=torch.float32,
+    )
+    backend = BackendConfig(
+        attn="eager",
+        linear="torch",
+        rms_norm="torch_fp32",
+        experts="torch",
+        dispatcher="torch",
+    )
+    return LagunaStateDictAdapter(config, moe_config, backend, dtype=torch.float32)
+
+
+def test_laguna_adapter_merges_hf_split_experts_and_renames_shared_expert():
+    adapter = _adapter()
+    hf_state = {
+        "model.layers.1.mlp.gate.weight": torch.ones(2, 4),
+        "model.layers.1.mlp.experts.e_score_correction_bias": torch.arange(2, dtype=torch.float32),
+        "model.layers.1.mlp.shared_expert.gate_proj.weight": torch.ones(3, 4),
+        "model.layers.1.mlp.shared_expert.up_proj.weight": torch.ones(3, 4) * 2,
+        "model.layers.1.mlp.shared_expert.down_proj.weight": torch.ones(4, 3),
+    }
+    for expert_id in range(2):
+        base = f"model.layers.1.mlp.experts.{expert_id}"
+        hf_state[f"{base}.gate_proj.weight"] = torch.full((3, 4), float(expert_id + 1))
+        hf_state[f"{base}.up_proj.weight"] = torch.full((3, 4), float(expert_id + 3))
+        hf_state[f"{base}.down_proj.weight"] = torch.full((4, 3), float(expert_id + 5))
+
+    native = adapter.from_hf(dict(hf_state))
+
+    assert native["model.layers.1.mlp.experts.gate_and_up_projs"].shape == (2, 4, 6)
+    assert native["model.layers.1.mlp.experts.down_projs"].shape == (2, 3, 4)
+    assert "model.layers.1.mlp.shared_experts.gate_proj.weight" in native
+    assert "model.layers.1.mlp.gate.e_score_correction_bias" in native
+    torch.testing.assert_close(
+        native["model.layers.1.mlp.experts.gate_and_up_projs"][0, :, :3],
+        hf_state["model.layers.1.mlp.experts.0.gate_proj.weight"].T,
+    )
+    torch.testing.assert_close(
+        native["model.layers.1.mlp.experts.down_projs"][1],
+        hf_state["model.layers.1.mlp.experts.1.down_proj.weight"].T,
+    )
+
+
+def test_laguna_adapter_splits_native_experts_back_to_hf_names():
+    adapter = _adapter()
+    gate_and_up = torch.arange(2 * 4 * 6, dtype=torch.float32).reshape(2, 4, 6)
+    down = torch.arange(2 * 3 * 4, dtype=torch.float32).reshape(2, 3, 4)
+
+    hf = adapter.to_hf(
+        {
+            "model.layers.1.mlp.experts.gate_and_up_projs": gate_and_up,
+            "model.layers.1.mlp.experts.down_projs": down,
+            "model.layers.1.mlp.shared_experts.gate_proj.weight": torch.ones(3, 4),
+            "model.layers.1.mlp.gate.e_score_correction_bias": torch.arange(2, dtype=torch.float32),
+        }
+    )
+
+    assert "model.layers.1.mlp.experts.0.gate_proj.weight" in hf
+    assert "model.layers.1.mlp.experts.0.up_proj.weight" in hf
+    assert "model.layers.1.mlp.experts.1.down_proj.weight" in hf
+    assert "model.layers.1.mlp.shared_expert.gate_proj.weight" in hf
+    assert "model.layers.1.mlp.experts.e_score_correction_bias" in hf
+    torch.testing.assert_close(hf["model.layers.1.mlp.experts.0.gate_proj.weight"], gate_and_up[0, :, :3].T)
+    torch.testing.assert_close(hf["model.layers.1.mlp.experts.0.up_proj.weight"], gate_and_up[0, :, 3:].T)
+    torch.testing.assert_close(hf["model.layers.1.mlp.experts.1.down_proj.weight"], down[1].T)


### PR DESCRIPTION
## Summary
- Add native Laguna config, model, and state-dict adapter.
- Register `LagunaForCausalLM` and the `laguna` config type with AutoModel.
- Add Laguna unit tests for config loading, tiny forward, MoE defaults, and HF/native state-dict conversion.

## Notes
- This PR is based directly on `main` and does not include the docs/recipe PR commits.
- Debug helper scripts under `tools/` are intentionally excluded.

## Validation
- EP8 first-4-layer parity passed locally against the reference implementation.
- EP16 HellaSwag SFT 100-step Slurm run completed.

<img width="486" height="211" alt="image" src="https://github.com/user-attachments/assets/5d5a3c5d-4fbe-4075-bf3e-e73a250197c9" />

- Scoped pytest was not rerun to completion in this turn after the request to push immediately.

