### PR TITLE
fix(checkpoint): restore adapters through DDP wrappers

### DIFF
--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -45,6 +45,7 @@ from safetensors.torch import load_file, save_file
 from safetensors.torch import save as safetensors_save
 from torch import nn
 from torch.distributed.device_mesh import DeviceMesh
+from torch.nn.parallel import DistributedDataParallel
 
 from nemo_automodel.components.checkpoint._backports.consolidate_hf_safetensors import (
     consolidate_safetensors_files_on_every_rank,
@@ -105,6 +106,13 @@ logger = logging.getLogger(__name__)
 # `grep -n nemotron-singlegpu-lora` finds every affected site.
 
 
+def _unwrap_ddp_model(model: nn.Module) -> nn.Module:
+    """Return the module that owns model metadata hidden by DDP."""
+    if isinstance(model, DistributedDataParallel):
+        return model.module
+    return model
+
+
 def _normalize_dtype_mapping_to_state_dict_keys(
     fqn_to_dtype_mapping: dict[str, str], state_dict_keys: list[str], base_model_prefix: str | None = None
 ) -> dict[str, str]:
@@ -132,6 +140,7 @@ def _apply_adapter_forced_dtype_mapping(
     fqn_to_dtype_mapping: dict[str, str],
 ) -> dict[str, str]:
     """Let model adapters override original HF dtype metadata for export-only keys."""
+    model = _unwrap_ddp_model(model)
     adapter = getattr(model, "state_dict_adapter", None)
     forced_dtype_mapping = getattr(adapter, "forced_hf_dtype_mapping", None)
     if not callable(forced_dtype_mapping):
@@ -667,7 +676,7 @@ class Checkpointer:
 
         # Check if this model requires tensor merging (e.g., Mixtral with grouped experts)
         model_type = getattr(getattr(model_state.model[0], "config", None), "model_type", None)
-        has_state_dict_adapter = hasattr(model_state.model[0], "state_dict_adapter")
+        has_state_dict_adapter = hasattr(_unwrap_ddp_model(model_state.model[0]), "state_dict_adapter")
 
         # For models that need tensor merging and don't have an adapter, try using transformers' conversion
         if is_init_step and model_type and requires_tensor_merging(model_type) and not has_state_dict_adapter:
@@ -889,7 +898,7 @@ class Checkpointer:
         # them), so they are absent from the returned state_dict but ARE loaded. The adapter
         # tracks them (reset + populated entirely inside from_hf); count them as loaded for the
         # diff to avoid false "missing" warnings while genuinely unloaded params are still flagged.
-        _adapter = getattr(model_state.model[0], "state_dict_adapter", None)
+        _adapter = getattr(_unwrap_ddp_model(model_state.model[0]), "state_dict_adapter", None)
         loaded_keys_for_diff |= getattr(_adapter, "view_loaded_native_keys", None) or set()
         if allow_checkpoint_key_subset:
             # Keys deliberately kept at init were already warned about above; keep
@@ -2159,7 +2168,7 @@ def _maybe_adapt_state_dict_to_hf(
     """
     Custom models use state dict adapters to convert the state dict to the Hugging Face format.
     """
-    adapter = getattr(model_part, "state_dict_adapter", None)
+    adapter = getattr(_unwrap_ddp_model(model_part), "state_dict_adapter", None)
     if adapter:
         return adapter.to_hf(state_dict, exclude_key_regex=r".*_extra_state.*", quantization=quantization, **kwargs)
     return state_dict
@@ -2382,7 +2391,7 @@ def _maybe_adapt_state_dict_from_hf(
     """
     Custom models use state dict adapters to convert the state dict from the Hugging Face format to the native format.
     """
-    adapter = getattr(model_part, "state_dict_adapter", None)
+    adapter = getattr(_unwrap_ddp_model(model_part), "state_dict_adapter", None)
     if adapter:
         ep_mesh_dims = [dim for dim in moe_mesh.mesh_dim_names if dim != "pp"] if moe_mesh is not None else []
         ep_mesh = moe_mesh[tuple(ep_mesh_dims)] if ep_mesh_dims else moe_mesh

--- a/tests/unit_tests/checkpoint/test_checkpointing.py
+++ b/tests/unit_tests/checkpoint/test_checkpointing.py
@@ -23,8 +23,10 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 import torch
+import torch.distributed.checkpoint as dcp
 import yaml
 from safetensors.torch import save_file
+from torch.nn.parallel import DistributedDataParallel
 
 from nemo_automodel.components.checkpoint._backports.hf_storage import (
     _DIFFUSERS_INDEX_FN,
@@ -1083,6 +1085,49 @@ class TestModelHasDtensors:
         """If all parameters are regular tensors, returns False."""
         model = torch.nn.Sequential(torch.nn.Linear(4, 4), torch.nn.Linear(4, 4))
         assert _model_has_dtensors(model) is False
+
+
+# =============================================================================
+# Tests for load_model: DDP-wrapped state dict adapters
+# =============================================================================
+
+
+def test_load_model_uses_state_dict_adapter_from_ddp_module(tmp_path):
+    """A DDP-wrapped encoder restores HF-format checkpoint keys through its adapter."""
+    from nemo_automodel.components.models.common.bidirectional import EncoderStateDictAdapter
+
+    class Encoder(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.model = torch.nn.Linear(2, 2, bias=False)
+            self.state_dict_adapter = EncoderStateDictAdapter()
+
+    encoder = Encoder()
+    # DDP's checkpoint traversal only depends on the registered ``module`` child;
+    # bypass process-group setup so this key-conversion regression stays a CPU unit test.
+    ddp_model = object.__new__(DistributedDataParallel)
+    torch.nn.Module.__init__(ddp_model)
+    ddp_model.module = encoder
+
+    model_path = tmp_path / "model"
+    checkpoint_weight = torch.full_like(encoder.model.weight, 7.0)
+    dcp.save({"weight": checkpoint_weight}, checkpoint_id=str(model_path))
+
+    config = CheckpointingConfig(
+        enabled=True,
+        checkpoint_dir=str(tmp_path),
+        model_save_format="safetensors",
+        model_cache_dir=str(tmp_path / "cache"),
+        model_repo_id="test/model",
+        save_consolidated=False,
+        is_peft=False,
+    )
+    with patch("torch.distributed.is_initialized", return_value=False):
+        checkpointer = Checkpointer(config, dp_rank=0, tp_rank=0, pp_rank=0, moe_mesh=None)
+
+    checkpointer.load_model(ddp_model, model_path=str(model_path))
+
+    torch.testing.assert_close(encoder.model.weight, checkpoint_weight)
 
 
 # =============================================================================


### PR DESCRIPTION
# What does this PR do?

Restore checkpoint state-dict adapters through `DistributedDataParallel` wrappers.

DDP stores the wrapped model under `.module` and does not forward arbitrary model attributes. During resume, checkpoint loading inspected the outer wrapper, missed the biencoder's `state_dict_adapter`, and requested native keys such as `model.embed_tokens.weight` from a checkpoint containing HF-format keys such as `embed_tokens.weight`.

The checkpoint component now resolves the underlying DDP module when discovering and invoking state-dict adapters, while preserving the DDP wrapper as the owner passed to PyTorch distributed state-dict APIs.

# Changelog

- Resolve state-dict adapters and adapter-owned dtype metadata through DDP wrappers.
- Preserve existing DDP state ownership for distributed model loading.
- Add a CPU DCP round-trip regression covering an encoder adapter hidden under DDP.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added a focused regression test.
- [x] Ran repository-wide Ruff formatting and lint checks.
- [x] Ran `tests/unit_tests/checkpoint/test_checkpointing.py` (176 passed, 2 skipped).
- [x] Ran a real two-GPU Llama-3.2-1B DDP save/restart/resume smoke.
- [x] Commit includes DCO signoff.
- [x] No documentation update is needed for this internal checkpoint fix.

# Additional Information

Reported from a multi-rank DDP biencoder `checkpoint.restore_from` failure. FSDP2 was unaffected because it does not hide the adapter behind a DDP `.module` wrapper.

## Real DDP resume evidence

Validated commit `68fee7f5cf9f4c25c1a59009fa8458553d970770` on two H100 GPUs using the NeMo 26.06 release container, PyTorch `2.12.0a0+0291f960b6.nv26.04.48445190`, and Transformers `5.12.1`.

- Full Llama-3.2-1B bidirectional architecture: 1,235,814,400 parameters, deterministic random initialization.
- Save job `14217766`: two finite DDP steps completed and wrote step-0/step-1 model, optimizer, dataloader, scheduler, and RNG state.
- Resume job `14217855`: a separate Slurm allocation and fresh two-rank process group explicitly loaded `epoch_0_step_1`, restored optimizer/scheduler state, continued at step 2, and exited 0.
- Resumed metrics were finite: loss `1.2109375`, gradient norm `310.0`.
- Saved model FQN metadata contains `embed_tokens.weight` and not `model.embed_tokens.weight`, directly exercising the DDP-hidden adapter conversion fixed here.
- `LATEST` advanced to `epoch_0_step_2`; artifact validation passed.
