### PR TITLE
fix(distributed): preserve canonical activation checkpoint keys

### DIFF
--- a/examples/llm_finetune/nemotron/nemotron_nano_v3_singlegpu_lora.yaml
+++ b/examples/llm_finetune/nemotron/nemotron_nano_v3_singlegpu_lora.yaml
@@ -80,3 +80,6 @@ optimizer:
   eps: 1e-8
   lr: 1.0e-5
   weight_decay: 0
+
+ci:
+  nproc_per_node: 1

--- a/examples/llm_finetune/nemotron/nemotron_nano_v3_singlegpu_lora.yaml
+++ b/examples/llm_finetune/nemotron/nemotron_nano_v3_singlegpu_lora.yaml
@@ -82,4 +82,5 @@ optimizer:
   weight_decay: 0
 
 ci:
+  time: "00:30:00"
   nproc_per_node: 1

--- a/examples/llm_finetune/nemotron/nemotron_nano_v3_singlegpu_lora.yaml
+++ b/examples/llm_finetune/nemotron/nemotron_nano_v3_singlegpu_lora.yaml
@@ -82,5 +82,5 @@ optimizer:
   weight_decay: 0
 
 ci:
-  time: "00:30:00"
+  time: "00:20:00"
   nproc_per_node: 1

--- a/nemo_automodel/components/distributed/activation_checkpointing.py
+++ b/nemo_automodel/components/distributed/activation_checkpointing.py
@@ -344,6 +344,16 @@ def sdpa_backend_snapshot_context_fn() -> tuple[AbstractContextManager, Abstract
     return nullcontext(), sdpa_kernel(captured)
 
 
+def _registered_child_name(module: nn.Module, attr: str, child: nn.Module) -> str | None:
+    """Return the registered name for a child reached through an attribute."""
+    if module._modules.get(attr) is child:
+        return attr
+    for child_name, registered_child in module._modules.items():
+        if registered_child is child:
+            return child_name
+    return None
+
+
 def _wrap_first_existing_attr(
     module: nn.Module,
     attr_names: tuple[str, ...],
@@ -351,14 +361,19 @@ def _wrap_first_existing_attr(
     skip: bool = False,
     context_fn: Callable[[], tuple[AbstractContextManager, AbstractContextManager]] | None = None,
 ) -> int:
-    """Checkpoint-wrap the first matching child attr on ``module``."""
+    """Checkpoint-wrap the first matching registered child attr on ``module``."""
     if skip:
         return 0
     checkpoint_kwargs = {} if context_fn is None else {"context_fn": context_fn}
     for attr in attr_names:
         child = getattr(module, attr, None)
         if isinstance(child, nn.Module):
-            setattr(module, attr, checkpoint_wrapper(child, **checkpoint_kwargs))
+            child_name = _registered_child_name(module, attr, child)
+            if child_name is None:
+                continue
+            if hasattr(child, "_checkpoint_wrapped_module"):
+                return 0
+            setattr(module, child_name, checkpoint_wrapper(child, **checkpoint_kwargs))
             return 1
     return 0
 

--- a/tests/unit_tests/distributed/test_activation_checkpointing.py
+++ b/tests/unit_tests/distributed/test_activation_checkpointing.py
@@ -168,6 +168,36 @@ def test_submodule_checkpointing_without_snapshot_context_recompute_sees_diverge
     assert attn.backend_states[1] != _MATH_ONLY
 
 
+def test_submodule_checkpointing_preserves_canonical_state_dict_keys_for_property_aliases():
+    class Mixer(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self._fp32_params = nn.Module()
+            self._fp32_params.A_log = nn.Parameter(torch.ones(2))
+
+    class AliasLayer(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.mixer = Mixer()
+
+        @property
+        def mlp(self):
+            return self.mixer
+
+        @property
+        def self_attn(self):
+            return self.mixer
+
+    layer = AliasLayer()
+
+    ac.apply_submodule_checkpointing([layer], has_kv_sharing=False)
+
+    assert isinstance(layer.mixer, CheckpointWrapper)
+    assert isinstance(ac.unwrap_checkpoint_wrapper(layer.mixer), Mixer)
+    assert [name for name, _ in layer.named_children()] == ["mixer"]
+    assert list(layer.state_dict()) == ["mixer._fp32_params.A_log"]
+
+
 @pytest.mark.skipif(
     not torch.cuda.is_available(),
     reason="Backend-set divergence across checkpoint recompute requires fused CUDA SDPA backends",


### PR DESCRIPTION
# What does this PR do ?

Preserves canonical state-dict keys when activation checkpointing encounters property aliases, and makes the Nemotron Nano v3 single-GPU LoRA CI job actually launch with one process.

The failure in AM-730 was caused by `apply_submodule_checkpointing()` assigning wrappers through the `mlp` and `self_attn` property aliases. PyTorch registered those assignments as new child-module names, so distributed checkpoint loading requested alias-prefixed keys that do not exist in the Hugging Face checkpoint.

# Changelog

- Resolve property aliases back to their registered child-module name before applying `checkpoint_wrapper`.
- Avoid wrapping the same canonical child twice when multiple aliases point to it.
- Set `ci.nproc_per_node: 1` and a measured 20-minute CI time budget for the Nemotron Nano v3 single-GPU LoRA recipe.
- Add a CPU regression test that verifies the canonical `mixer._fp32_params.A_log` state-dict key.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added the necessary regression test.
- [x] Updated the runnable recipe configuration; no separate documentation change is needed.

# Validation

- [Scoped release CI job 369680119](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/369680119) — passed at commit `dc1ff9f641141a517054e91ab9ce960d297735fd`.
  - Launched with `World size: 1`.
  - Applied activation checkpointing to 52 unique canonical children: `{'mlp': 23, 'attention': 29}`.
  - Loaded the full 58.82 GiB checkpoint without the AM-730 alias-prefixed missing-key error.
  - Completed all 50 LoRA steps with finite loss and gradient norm.
  - Used 15m14s of Slurm wall time. The current head only reduces the recipe ceiling from the 30-minute measurement budget to 20 minutes.
- `pytest tests/unit_tests/distributed/test_activation_checkpointing.py -q` — 12 passed, 1 CUDA-only skip.
- `python tests/ci_tests/utils/validate_generate_ci.py --automodel-dir <worktree>` — all 15 scope/folder combinations passed.
- Generated the release `llm_finetune` pipeline and asserted `CONFIG_NPROC_PER_NODE == 1` and `TIME == "00:20:00"` for `nemotron_nano_v3_singlegpu_lora`.
- `ruff format .`
- `ruff check --fix .`

# Additional Information

- Linear fix: [AM-730](https://linear.app/nvidia/issue/AM-730/missing-checkpoint-state-dict-key-causes-keyerror-during-distributed)
- Checkpoint-load performance follow-up: [AM-751](https://linear.app/nvidia/issue/AM-751/profile-and-reduce-nemotron-nano-single-gpu-checkpoint-load-time)
