### PR TITLE
feat(moe): drive router replay during activation-checkpointing recompute

### DIFF
--- a/nemo_automodel/components/moe/router_replay.py
+++ b/nemo_automodel/components/moe/router_replay.py
@@ -57,7 +57,7 @@ from typing import Iterator, List, Optional
 
 import torch
 
-__all__ = ["RouterReplayMode", "RouterReplay", "replay_selection"]
+__all__ = ["RouterReplayMode", "RouterReplay", "RecomputeReplayDriver", "replay_selection"]
 
 
 class RouterReplayMode(Enum):
@@ -218,6 +218,59 @@ class RouterReplay:
             cls.set_mode(None)
             for inst in cls._registry:
                 inst.target_indices = None
+
+    @classmethod
+    @contextmanager
+    def drive_recompute(cls) -> Iterator["RecomputeReplayDriver"]:
+        """Replay the forward's routing during an activation-checkpointing/pipeline recompute.
+
+        This is the single-step analog of the RL ``record``/``replay`` pair above: instead of a
+        rollout forward and a later training forward, the two passes are the forward and its
+        activation-checkpoint (or pipeline) recompute *within one training step*. Under activation
+        checkpointing the MoE router is re-run during ``backward``; on tie-heavy routing (e.g.
+        mask-dense diffusion data) a near-tie can flip on the recompute, changing a per-rank dispatch
+        buffer's token count by one and raising ``torch.utils.checkpoint.CheckpointError``. Replaying
+        the recorded selection makes the recompute's routing identical to the forward's.
+
+        Gates RECORD their selection during the forward; :meth:`RecomputeReplayDriver.backward` sets
+        each gate's recorded selection as its replay target and runs ``backward`` in REPLAY mode.
+        Drives every gate built with ``enable_routing_replay=True`` (a no-op otherwise). Correct for
+        gradient accumulation because the replay target is refreshed from the freshly recorded
+        selection at each ``backward``. Usage::
+
+            with RouterReplay.drive_recompute() as driver:
+                loss = model(batch)      # forward: RECORD each gate's top-k selection
+                driver.backward(loss)    # backward: REPLAY it during the checkpoint recompute
+        """
+        cls.set_mode(RouterReplayMode.RECORD)
+        try:
+            yield RecomputeReplayDriver()
+        finally:
+            cls.set_mode(None)
+            cls.clear_indices()
+
+
+class RecomputeReplayDriver:
+    """Runs ``backward`` with each gate's recorded selection replayed during recompute.
+
+    Created by :meth:`RouterReplay.drive_recompute`; not instantiated directly.
+    """
+
+    def backward(self, tensor: torch.Tensor, *args, **kwargs) -> None:
+        """Replay the recorded selection during recompute, then run ``tensor.backward(...)``.
+
+        Args:
+            tensor: The scalar loss to call ``backward`` on.
+            *args: Positional args forwarded to ``tensor.backward``.
+            **kwargs: Keyword args forwarded to ``tensor.backward``.
+        """
+        for inst in RouterReplay.instances():
+            inst.target_indices = inst.recorded_indices
+        RouterReplay.set_mode(RouterReplayMode.REPLAY)
+        try:
+            tensor.backward(*args, **kwargs)
+        finally:
+            RouterReplay.set_mode(RouterReplayMode.RECORD)
 
 
 def replay_selection(router_replay: Optional[RouterReplay], indices: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
> **Draft / RFC.** Sharing the mechanism + validation for discussion. Not CI-verified from my
> environment; the equivalent driver is validated in a downstream run (details below).

## Problem

Under activation checkpointing (or pipeline recompute), the MoE layer's router is re-run during
`backward`. GPU math is not bit-identical run-to-run, so on **tie-heavy routing** a near-tie token can
flip its top-k expert on the recompute. Because there is no expert-capacity padding, the per-rank
DeepEP/all-to-all dispatch buffer is sized to the exact token count, so a single cross-rank flip
changes one rank's token count by ±1 and torch's non-reentrant checkpoint raises:

```
CheckpointError: Recomputed values ... have different metadata than during the forward pass
  saved:      [N,   16]   recomputed: [N+1, 16]     # 16 = local experts/rank; token count off by one
```

We hit this reliably on a **hybrid Mamba/Attention/MoE diffusion model** (Nemotron-H, EP=8, DeepEP,
128 experts / top-6) trained on `[MASK]`-saturated data (dense near-ties). Ordinary text has almost no
near-ties, so its recompute reproduces and this never fires — which is why it's easy to miss.

## What already exists vs. the gap

`RouterReplay` already solves the closely-related **RL** case (rollout↔training routing mismatch),
driven manually over two forward passes. But its `record`/`replay` are for two *separate* forwards; it
is **not driven for the activation-checkpointing forward-vs-recompute within a single step**. Enabling
`enable_routing_replay=True` alone does nothing for AC (no mode is active during the recompute, so
`replay_selection` is a no-op).

## The change

Add `RouterReplay.drive_recompute()` — a single-step driver that RECORDs each gate's top-k selection on
the forward and REPLAYs it during the backward recompute, reusing all the existing infrastructure:

```python
with RouterReplay.drive_recompute() as driver:
    loss = model(batch)      # forward: RECORD each gate's top-k selection
    driver.backward(loss)    # backward: REPLAY it during the checkpoint recompute
```

- No-op unless `enable_routing_replay=True` (empty registry ⇒ `set_mode` does nothing).
- Correct under gradient accumulation: the replay target is refreshed from the freshly recorded
  selection at each `backward`.
- Only the discrete selection is pinned; logits/weights are still recomputed, so router grads flow —
  identical to the RL path.

## Validation (downstream)

In our fork we validated the equivalent driver (auto-driven via a backward hook rather than the
explicit `driver.backward`) on the model above: **8 nodes × H100, seq 16384, GBS 256, selective AC,
real routing — crash-free (`CheckpointError=0`, no OOM)** over 20 steps, where plain selective AC
crashes at step 1. Lower-effort attempts that did **not** work, for reference: `ignore_router_for_ac`
(saves logits, not the selection), `MUST_SAVE aten.topk` in the selective-AC policy (didn't reliably
pin the op through the DTensor + DeepEP-custom-`Function` path; also probabilistic so it looked fixed
on tiny data), and `CUBLAS_WORKSPACE_CONFIG` alone.

## RFC questions

1. **Integration point.** `drive_recompute()` needs the training step to call `driver.backward(loss)`.
   Preference for wiring this into the recipe/trainer explicitly, vs. an opt-in auto-hook (wrap
   `torch.autograd.backward`/`Tensor.backward` when routing replay + AC are both on) that needs no
   recipe change? I kept the explicit context manager here to avoid a global side effect.
2. **Config surface.** Reuse `enable_routing_replay`, or a separate `routing_replay_for_recompute` so
   RL and AC uses are independent?
3. Worth a short note in the module docstring + a unit test (record→replay parity across a
   `torch.utils.checkpoint` boundary)? Happy to add if the approach looks right.

Context write-up (root cause, the full fix journey, shapes-only math): available on request.
