### PR TITLE
perf(cuda-graphs): support selective AC and host-spilled MoE stash

### DIFF
--- a/nemo_automodel/components/cuda_graphs/partial.py
+++ b/nemo_automodel/components/cuda_graphs/partial.py
@@ -348,12 +348,19 @@ class _TensorOnlyCallAdapter(nn.Module):
 class _ExplicitParameterCallAdapter(nn.Module):
     """Present module parameters as graph inputs instead of captured module state."""
 
-    def __init__(self, target: nn.Module, captured_call: _CapturedCall) -> None:
+    def __init__(
+        self,
+        target: nn.Module,
+        captured_call: _CapturedCall,
+        *,
+        share_parameter_storage: bool = False,
+    ) -> None:
         super().__init__()
         self.graph_target = target
         self.__dict__["target"] = target
         self.captured_call = captured_call
         self.dynamic_input_count = len(captured_call.sample_tensors)
+        self.share_parameter_storage = share_parameter_storage
 
         named_parameters = tuple(target.named_parameters())
         if not named_parameters:
@@ -365,6 +372,7 @@ class _ExplicitParameterCallAdapter(nn.Module):
         self.parameter_metadata = tuple(_tensor_metadata(parameter) for _name, parameter in named_parameters)
         self.buffer_storage = _named_buffer_storage(target)
         capture_parameters = []
+        parameter_data_ptrs = []
         for name, parameter in named_parameters:
             if not isinstance(parameter, nn.Parameter):
                 raise RuntimeError(
@@ -372,17 +380,20 @@ class _ExplicitParameterCallAdapter(nn.Module):
                     f"{name!r} is {type(parameter).__name__}"
                 )
             _require_local_parameter_storage(name, parameter)
-            # Always use a fresh leaf, even when the target is not FSDP-owned.
-            # Persistent model Parameters may already own AccumulateGrad nodes
-            # created on the eager stream; capturing those nodes can make TE's
-            # backward graph depend on the wrong stream. TE directly uses this
-            # clone as its static input, so this is one staging allocation rather
-            # than a clone followed by a second TE-owned parameter copy.
-            capture_parameter = parameter.detach().clone(memory_format=torch.preserve_format)
+            parameter_data_ptrs.append(parameter.data_ptr())
+            # A detached tensor is always a fresh autograd leaf, avoiding the
+            # model Parameter's pre-existing AccumulateGrad node during capture.
+            # EP-local experts are explicitly excluded from FSDP and may share
+            # their stable storage. FSDP-owned targets require an independent
+            # static allocation because their gathered storage is transient.
+            capture_parameter = parameter.detach()
+            if not share_parameter_storage:
+                capture_parameter = capture_parameter.clone(memory_format=torch.preserve_format)
             capture_parameter.requires_grad_(parameter.requires_grad)
             capture_parameters.append(capture_parameter)
         self.capture_parameters = tuple(capture_parameters)
-        self.cloned_parameter_bytes = _tensor_bytes(self.capture_parameters)
+        self.parameter_data_ptrs = tuple(parameter_data_ptrs)
+        self.cloned_parameter_bytes = 0 if share_parameter_storage else _tensor_bytes(self.capture_parameters)
 
     def parameters(self, recurse: bool = True) -> Iterator[nn.Parameter]:
         """Hide the registered target parameters from TE module-parameter discovery."""
@@ -425,6 +436,11 @@ class _ExplicitParameterCallAdapter(nn.Module):
                     f"CUDA graph parameter metadata changed for {name!r}: "
                     f"expected {expected_metadata}, got {actual_metadata}"
                 )
+            if self.share_parameter_storage and parameter.data_ptr() != self.parameter_data_ptrs[index]:
+                raise RuntimeError(
+                    f"CUDA graph parameter storage changed for {name!r}: expected data_ptr "
+                    f"{self.parameter_data_ptrs[index]}, got {parameter.data_ptr()}"
+                )
         buffer_storage = _named_buffer_storage(self.target)
         if buffer_storage != self.buffer_storage:
             raise RuntimeError(
@@ -465,6 +481,7 @@ class _PartialGraphEntry:
         pool_group: str | None = None,
         capture_input_variants: int = 1,
         explicit_parameters: bool = False,
+        share_parameter_storage: bool = False,
         capture_owner: nn.Module | None = None,
         retain_graph_in_backward: bool = False,
     ):
@@ -477,6 +494,7 @@ class _PartialGraphEntry:
             raise ValueError("capture_input_variants must be positive")
         self.capture_input_variants = capture_input_variants
         self.explicit_parameters = explicit_parameters
+        self.share_parameter_storage = share_parameter_storage
         self.capture_owner = capture_owner
         self.retain_graph_in_backward = retain_graph_in_backward
         self.original_forward = target.forward
@@ -576,7 +594,11 @@ class _PartialGraphEntry:
         if captured_call is None:
             raise RuntimeError(f"Partial CUDA graph target {self.name!r} was not called during iteration 0")
         if self.explicit_parameters:
-            adapter = _ExplicitParameterCallAdapter(self.target, captured_call)
+            adapter = _ExplicitParameterCallAdapter(
+                self.target,
+                captured_call,
+                share_parameter_storage=self.share_parameter_storage,
+            )
         else:
             adapter = _TensorOnlyCallAdapter(self.target, captured_call)
         adapter.train(self.target.training)
@@ -859,7 +881,7 @@ def _build_whole_attention_entry(
 def _build_te_dpa_entry(
     block: _DiscoveredBlock,
     target: nn.Module,
-    activation_checkpointing: bool,
+    _activation_checkpointing: bool,
 ) -> _PartialGraphEntry:
     """Build one TE fused-attention graph entry."""
     _require_parameterless_target("te_dpa", block, target)
@@ -868,10 +890,9 @@ def _build_te_dpa_entry(
         target=target,
         pool_group="te_dpa",
         canonicalizer=_canonicalize_bf16_fused_attention,
-        # Reentrant checkpointing invokes attention once under no-grad and once
-        # under grad-enabled recompute. Each contract needs its own TE graph
-        # because requires_grad is a replay invariant.
-        capture_input_variants=2 if activation_checkpointing else 1,
+        # AutoModel uses non-reentrant checkpointing: both the original forward
+        # and backward-time recompute are grad-enabled and share one contract.
+        capture_input_variants=1,
     )
 
 
@@ -912,12 +933,15 @@ def _build_moe_execution_entry(
             "Full MoE CUDA graphs do not support nested FSDP expert sharding (ep_shard > 1); "
             "the expert parameters must be owned by the transformer block"
         )
-    capture_owner = block.capture_owner if isinstance(block.capture_owner, FSDPModule) else None
+    share_parameter_storage = bool(getattr(target, "_nemo_cuda_graph_stable_parameter_storage", False))
+    capture_owner = None if share_parameter_storage else block.capture_owner
+    capture_owner = capture_owner if isinstance(capture_owner, FSDPModule) else None
     return _PartialGraphEntry(
         name=f"{block.name}.moe",
         target=target,
         pool_group="moe",
         explicit_parameters=True,
+        share_parameter_storage=share_parameter_storage,
         capture_owner=capture_owner,
         retain_graph_in_backward=True,
     )
@@ -1014,6 +1038,7 @@ class PartialCudaGraphManager:
         *,
         activation_checkpointing: bool = False,
         activation_checkpointing_modules: tuple[str, ...] | None = None,
+        activation_checkpointing_scope: tuple[str, ...] = ("all",),
         pipeline_parallel: bool = False,
     ) -> PartialCudaGraphManager | None:
         """Discover graph targets from an already-built training model."""
@@ -1040,8 +1065,11 @@ class PartialCudaGraphManager:
                 "Partial CUDA graphs require one local model part; virtual pipeline chunks can interleave "
                 "microbatches and overwrite static CUDA graph buffers before backward consumes them"
             )
-        if activation_checkpointing:
-            moe_graph_compatible = activation_checkpointing_modules == ("attention",)
+        decoder_checkpointing = activation_checkpointing and (
+            "all" in activation_checkpointing_scope or "language" in activation_checkpointing_scope
+        )
+        if decoder_checkpointing:
+            moe_graph_compatible = activation_checkpointing_modules == ("attn",)
             if any("attn" in part.backend.cuda_graph.modules for part in enabled_parts):
                 raise RuntimeError(
                     "Whole-attention CUDA graphs do not support activation checkpointing; "

--- a/nemo_automodel/components/cuda_graphs/partial.py
+++ b/nemo_automodel/components/cuda_graphs/partial.py
@@ -1013,6 +1013,7 @@ class PartialCudaGraphManager:
         model_parts: list[nn.Module],
         *,
         activation_checkpointing: bool = False,
+        activation_checkpointing_modules: tuple[str, ...] | None = None,
         pipeline_parallel: bool = False,
     ) -> PartialCudaGraphManager | None:
         """Discover graph targets from an already-built training model."""
@@ -1040,24 +1041,33 @@ class PartialCudaGraphManager:
                 "microbatches and overwrite static CUDA graph buffers before backward consumes them"
             )
         if activation_checkpointing:
+            moe_graph_compatible = activation_checkpointing_modules == ("attention",)
             if any("attn" in part.backend.cuda_graph.modules for part in enabled_parts):
                 raise RuntimeError(
                     "Whole-attention CUDA graphs do not support activation checkpointing; "
                     "use te_dpa or disable activation checkpointing"
                 )
-            if any("moe" in part.backend.cuda_graph.modules for part in enabled_parts):
+            if any("moe" in part.backend.cuda_graph.modules for part in enabled_parts) and not moe_graph_compatible:
                 raise RuntimeError("Full MoE CUDA graphs do not support activation checkpointing")
-            if any(
-                "moe_router" in part.backend.cuda_graph.modules or "moe_preprocess" in part.backend.cuda_graph.modules
-                for part in enabled_parts
+            if (
+                any(
+                    "moe_router" in part.backend.cuda_graph.modules
+                    or "moe_preprocess" in part.backend.cuda_graph.modules
+                    for part in enabled_parts
+                )
+                and not moe_graph_compatible
             ):
                 raise RuntimeError(
                     "PyTorch activation checkpointing cannot recompute across the partial MoE router/preprocess "
                     "CUDA graph scope; use attention-only graphs or disable router/preprocess graphs"
                 )
             logger.info(
-                "Partial CUDA graphs are enabled with PyTorch activation checkpointing; "
-                "checkpoint recomputation will use the same guarded graph entry points"
+                "Partial CUDA graphs are enabled with PyTorch activation checkpointing; %s",
+                (
+                    "MoE execution remains outside the attention-only checkpoint boundary"
+                    if moe_graph_compatible
+                    else "checkpoint recomputation will use the same guarded graph entry points"
+                ),
             )
         model = model_parts[0]
         backend = model.backend

--- a/nemo_automodel/components/distributed/activation_checkpointing.py
+++ b/nemo_automodel/components/distributed/activation_checkpointing.py
@@ -437,6 +437,7 @@ def apply_submodule_checkpointing(
     layers: List[nn.Module],
     has_kv_sharing: bool,
     *,
+    checkpoint_modules: tuple[str, ...] | None = None,
     context_fn: Callable[[], tuple[AbstractContextManager, AbstractContextManager]] | None = (
         sdpa_backend_snapshot_context_fn
     ),
@@ -454,11 +455,17 @@ def apply_submodule_checkpointing(
     Args:
         layers: Transformer decoder layers to wrap (mutated in place).
         has_kv_sharing: Whether the model reuses K/V across layers via the cache.
+        checkpoint_modules: Optional structural subset. ``("attn",)``
+            wraps attention only; ``None`` preserves the existing attention,
+            MLP, norm, and MoT behavior.
         context_fn: Factory returning ``(forward_ctx, recompute_ctx)`` for the
             attention and MLP checkpoint wrappers. Defaults to restoring the
             forward-time SDPA state; pass ``None`` to disable it. Norm wrappers
             stay plain because they dispatch no SDPA.
     """
+    if checkpoint_modules not in (None, ("attn",)):
+        raise ValueError("checkpoint_modules currently supports only ('attn',)")
+    attention_only = checkpoint_modules == ("attn",)
     wrapped_counts: dict[str, int] = {
         "mlp": 0,
         "attention": 0,
@@ -467,7 +474,10 @@ def apply_submodule_checkpointing(
         "mot": 0,
     }
     for layer in layers:
-        wrapped_counts["mlp"] += _wrap_first_existing_attr(layer, ("mlp", "feed_forward", "ffn"), context_fn=context_fn)
+        if not attention_only:
+            wrapped_counts["mlp"] += _wrap_first_existing_attr(
+                layer, ("mlp", "feed_forward", "ffn"), context_fn=context_fn
+            )
         wrapped_counts["attention"] += _wrap_first_existing_attr(
             layer,
             # "linear_attn" covers hybrid linear-attention blocks (e.g. Qwen3-Next /
@@ -479,26 +489,27 @@ def apply_submodule_checkpointing(
             skip=has_kv_sharing,
             context_fn=context_fn,
         )
-        wrapped_counts["pre_norm"] += _wrap_first_existing_attr(
-            layer,
-            ("input_layernorm", "attention_norm", "layer_norm1", "norm1"),
-        )
-        wrapped_counts["post_norm"] += _wrap_first_existing_attr(
-            layer,
-            ("post_attention_layernorm", "ffn_norm", "layer_norm2", "norm2"),
-        )
+        if not attention_only:
+            wrapped_counts["pre_norm"] += _wrap_first_existing_attr(
+                layer,
+                ("input_layernorm", "attention_norm", "layer_norm1", "norm1"),
+            )
+            wrapped_counts["post_norm"] += _wrap_first_existing_attr(
+                layer,
+                ("post_attention_layernorm", "ffn_norm", "layer_norm2", "norm2"),
+            )
 
         # MoT (mixture-of-transformers) sibling submodules -- present in BAGEL's
         # Qwen2MoTDecoderLayer for the generation expert. mlp_moe_gen is a full
         # Qwen2MLP duplicate (same size as mlp), so omitting it from AC roughly
         # doubles per-layer activation memory in Stage-2 BAGEL training.
-        if hasattr(layer, "mlp_moe_gen"):
+        if not attention_only and hasattr(layer, "mlp_moe_gen"):
             layer.mlp_moe_gen = checkpoint_wrapper(layer.mlp_moe_gen)  # type: ignore
             wrapped_counts["mot"] += 1
-        if hasattr(layer, "input_layernorm_moe_gen"):
+        if not attention_only and hasattr(layer, "input_layernorm_moe_gen"):
             layer.input_layernorm_moe_gen = checkpoint_wrapper(layer.input_layernorm_moe_gen)  # type: ignore
             wrapped_counts["mot"] += 1
-        if hasattr(layer, "post_attention_layernorm_moe_gen"):
+        if not attention_only and hasattr(layer, "post_attention_layernorm_moe_gen"):
             layer.post_attention_layernorm_moe_gen = checkpoint_wrapper(layer.post_attention_layernorm_moe_gen)  # type: ignore
             wrapped_counts["mot"] += 1
     logger.info("Applied submodule activation checkpointing to %d layers: %s", len(layers), wrapped_counts)

--- a/nemo_automodel/components/distributed/config.py
+++ b/nemo_automodel/components/distributed/config.py
@@ -168,17 +168,44 @@ class DistributedSetup:
 
 @dataclass
 class MoEParallelizerConfig:
-    """Configuration for MoE model parallelization (EP + FSDP settings)."""
+    """Configuration for MoE model parallelization (EP + FSDP settings).
+
+    Attributes:
+        ignore_router_for_ac: Preserve router outputs across activation-checkpoint
+            recompute so routing metadata remains stable.
+        activation_checkpointing_modules: Optional decoder submodule boundaries to
+            checkpoint instead of wrapping the complete block. The first supported
+            boundary is ``"attention"``; leaving this unset preserves the existing
+            whole-block behavior.
+    """
 
     # Default True: under activation checkpointing the MoE router projection and top-k outputs
     # must be saved rather than recomputed. Recomputing tied top-k selections can route a
     # different number of tokens per expert than the forward pass, which makes
     # torch.utils.checkpoint raise a CheckpointError on the backward recompute.
     ignore_router_for_ac: bool = True
+    activation_checkpointing_modules: list[str] | tuple[str, ...] | None = None
     reshard_after_forward: bool = False
     lm_head_precision: Optional[Union[str, torch.dtype]] = None
     wrap_outer_model: bool = True
     mp_policy: Optional[MixedPrecisionPolicy] = None
+
+    def __post_init__(self) -> None:
+        if self.activation_checkpointing_modules is None:
+            return
+        if not isinstance(self.activation_checkpointing_modules, (list, tuple)):
+            raise ValueError("MoE activation_checkpointing_modules must be a list or tuple of module names.")
+        if not all(isinstance(module, str) for module in self.activation_checkpointing_modules):
+            raise ValueError("MoE activation_checkpointing_modules entries must be strings.")
+        modules = tuple(dict.fromkeys(self.activation_checkpointing_modules))
+        unsupported = set(modules) - {"attention"}
+        if unsupported:
+            raise ValueError(
+                f"MoE activation_checkpointing_modules currently supports only 'attention'; got {sorted(unsupported)}."
+            )
+        if not modules:
+            raise ValueError("MoE activation_checkpointing_modules must not be empty when specified.")
+        self.activation_checkpointing_modules = modules
 
     def to_dict(self) -> Dict[str, Any]:
         return {f.name: getattr(self, f.name) for f in fields(self)}

--- a/nemo_automodel/components/distributed/config.py
+++ b/nemo_automodel/components/distributed/config.py
@@ -175,7 +175,7 @@ class MoEParallelizerConfig:
             recompute so routing metadata remains stable.
         activation_checkpointing_modules: Optional decoder submodule boundaries to
             checkpoint instead of wrapping the complete block. The first supported
-            boundary is ``"attention"``; leaving this unset preserves the existing
+            boundary is ``"attn"``; leaving this unset preserves the existing
             whole-block behavior.
     """
 
@@ -198,10 +198,10 @@ class MoEParallelizerConfig:
         if not all(isinstance(module, str) for module in self.activation_checkpointing_modules):
             raise ValueError("MoE activation_checkpointing_modules entries must be strings.")
         modules = tuple(dict.fromkeys(self.activation_checkpointing_modules))
-        unsupported = set(modules) - {"attention"}
+        unsupported = set(modules) - {"attn"}
         if unsupported:
             raise ValueError(
-                f"MoE activation_checkpointing_modules currently supports only 'attention'; got {sorted(unsupported)}."
+                f"MoE activation_checkpointing_modules currently supports only 'attn'; got {sorted(unsupported)}."
             )
         if not modules:
             raise ValueError("MoE activation_checkpointing_modules must not be empty when specified.")

--- a/nemo_automodel/components/models/common/utils.py
+++ b/nemo_automodel/components/models/common/utils.py
@@ -174,7 +174,11 @@ class CudaGraphConfig:
             scope and expert inputs that participate in autograd.
         moe_paged_stash_page_size: Number of token rows per paged-stash page.
         moe_paged_stash_buffer_size_factor: Multiplicative page-buffer headroom
-            over the iteration-0 observed peak. Must be finite and at least one.
+            over the iteration-0 observed peak allocated in CUDA memory. It may
+            be below one when host spill supplies the remaining capacity.
+        moe_paged_stash_buffer_size_factor_cpu: Fraction of the iteration-0
+            observed peak allocated in pinned host memory. Zero disables host
+            spill; CUDA and host factors must sum to at least one.
     """
 
     modules: list[Literal["attn", "te_dpa", "moe", "moe_router", "moe_preprocess"]] = field(default_factory=list)
@@ -182,6 +186,7 @@ class CudaGraphConfig:
     moe_paged_stash: bool = False
     moe_paged_stash_page_size: int = 64
     moe_paged_stash_buffer_size_factor: float = 1.1
+    moe_paged_stash_buffer_size_factor_cpu: float = 0.0
 
     def __post_init__(self) -> None:
         """Validate the declarative CUDA-graph configuration."""
@@ -226,9 +231,19 @@ class CudaGraphConfig:
                 isinstance(factor, bool)
                 or not isinstance(factor, (int, float))
                 or not math.isfinite(float(factor))
-                or factor < 1.0
+                or factor <= 0.0
             ):
-                raise ValueError("cuda_graph.moe_paged_stash_buffer_size_factor must be finite and at least 1.0")
+                raise ValueError("cuda_graph.moe_paged_stash_buffer_size_factor must be positive and finite")
+            host_factor = self.moe_paged_stash_buffer_size_factor_cpu
+            if (
+                isinstance(host_factor, bool)
+                or not isinstance(host_factor, (int, float))
+                or not math.isfinite(float(host_factor))
+                or host_factor < 0.0
+            ):
+                raise ValueError("cuda_graph.moe_paged_stash_buffer_size_factor_cpu must be non-negative and finite")
+            if factor + host_factor < 1.0:
+                raise ValueError("CUDA and host paged-stash buffer factors must provide at least 1.0x total capacity")
 
 
 @dataclass(kw_only=True)

--- a/nemo_automodel/components/moe/experts.py
+++ b/nemo_automodel/components/moe/experts.py
@@ -1034,6 +1034,7 @@ class GroupedExpertsTE(nn.Module):
                 enabled=True,
                 page_size=backend.cuda_graph.moe_paged_stash_page_size,
                 buffer_size_factor=backend.cuda_graph.moe_paged_stash_buffer_size_factor,
+                host_buffer_size_factor=backend.cuda_graph.moe_paged_stash_buffer_size_factor_cpu,
             )
 
         # Gated (SwiGLU, Quick-GEGLU): out_features = moe_inter_dim * 2

--- a/nemo_automodel/components/moe/paged_stash.py
+++ b/nemo_automodel/components/moe/paged_stash.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import contextlib
 import enum
+import logging
 import math
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -48,9 +49,11 @@ from nemo_automodel.components.moe.paged_stash_ops import (
     paged_stash_pop_kernel,
 )
 
+logger = logging.getLogger(__name__)
+
 
 class PagedStashOverflowError(RuntimeError):
-    """Raised after an iteration whose fixed CUDA page capacity was exceeded."""
+    """Raised after an iteration whose fixed CUDA and host page capacity was exceeded."""
 
 
 class _PagedStashState(enum.Enum):
@@ -65,7 +68,7 @@ def _storage_dtype(dtype: torch.dtype) -> torch.dtype:
 
 
 class _PagedStashBuffer:
-    """One circular GPU page allocator for a dtype and per-token width."""
+    """CUDA pages plus optional pinned-host spill pages for one activation layout."""
 
     def __init__(
         self,
@@ -76,6 +79,8 @@ class _PagedStashBuffer:
         device: torch.device,
         dtype: torch.dtype,
         overflow: torch.Tensor,
+        host_spill: torch.Tensor,
+        num_host_tokens: int = 0,
     ) -> None:
         """Allocate one fixed-shape circular page buffer.
 
@@ -86,6 +91,8 @@ class _PagedStashBuffer:
             device: CUDA device that owns the page buffer.
             dtype: Bit-preserving storage dtype for each token element.
             overflow: Device scalar with shape ``[1]`` shared by every buffer.
+            host_spill: Device scalar with shape ``[1]`` set when any tensor spills to host.
+            num_host_tokens: Minimum number of token rows the pinned-host spill buffer must hold.
         """
         if num_tokens <= 0:
             raise ValueError(f"Paged stash buffer capacity must be positive, got {num_tokens}")
@@ -94,19 +101,32 @@ class _PagedStashBuffer:
         self.device = device
         self.dtype = dtype
         self.overflow = overflow
-        self.num_pages = math.ceil(num_tokens / page_size)
-        self.total_tokens = self.num_pages * page_size
-        self.storage = torch.empty((self.total_tokens, hidden_size), dtype=dtype, device=device)
-        self.free_list = torch.arange(self.num_pages, dtype=torch.int64, device=device)
-        self.head = torch.zeros(1, dtype=torch.int64, device=device)
-        self.tail = torch.full((1,), self.num_pages, dtype=torch.int64, device=device)
-        self.capacity = torch.full((1,), self.num_pages, dtype=torch.int64, device=device)
-        self._reset_free_list = torch.arange(self.num_pages, dtype=torch.int64, device=device)
-        self._reset_tail = torch.full((1,), self.num_pages, dtype=torch.int64, device=device)
+        self.host_spill = host_spill
+
+        self.num_cuda_pages = math.ceil(num_tokens / page_size)
+        self.total_cuda_tokens = self.num_cuda_pages * page_size
+        self.cuda_storage = torch.empty((self.total_cuda_tokens, hidden_size), dtype=dtype, device=device)
+        self.num_host_pages = math.ceil(num_host_tokens / page_size) if num_host_tokens > 0 else 0
+        self.total_host_tokens = self.num_host_pages * page_size
+        self.host_storage = (
+            torch.empty((self.total_host_tokens, hidden_size), dtype=dtype, device="cpu", pin_memory=True)
+            if self.num_host_pages
+            else None
+        )
+
+        self.free_list_cuda = torch.arange(self.num_cuda_pages, dtype=torch.int64, device=device)
+        self.free_list_host = torch.arange(self.num_host_pages, dtype=torch.int64, device=device)
+        self.head = torch.zeros(2, dtype=torch.int64, device=device)
+        self.tail = torch.tensor([self.num_cuda_pages, self.num_host_pages], dtype=torch.int64, device=device)
+        self.capacity = torch.tensor([self.num_cuda_pages, self.num_host_pages], dtype=torch.int64, device=device)
+        self._reset_free_list_cuda = torch.arange(self.num_cuda_pages, dtype=torch.int64, device=device)
+        self._reset_free_list_host = torch.arange(self.num_host_pages, dtype=torch.int64, device=device)
+        self._reset_tail = torch.tensor([self.num_cuda_pages, self.num_host_pages], dtype=torch.int64, device=device)
 
     def reset(self) -> None:
         """Restore the allocator without creating graph-unsafe temporary tensors."""
-        self.free_list.copy_(self._reset_free_list)
+        self.free_list_cuda.copy_(self._reset_free_list_cuda)
+        self.free_list_host.copy_(self._reset_free_list_host)
         self.head.zero_()
         self.tail.copy_(self._reset_tail)
 
@@ -124,6 +144,7 @@ class _RecordedTensor:
     tensor: torch.Tensor
     key: tuple[torch.dtype, int]
     charged_tokens: int
+    allocation_id: int
     released: bool = False
 
 
@@ -167,38 +188,46 @@ class _PagedTensor:
         self.dtype = tensor.dtype
         self.device = tensor.device
         self.page_record = torch.empty(math.ceil(max_num_tokens / page_size), dtype=torch.int64, device=tensor.device)
-        self._new_head = torch.empty(1, dtype=torch.int64, device=tensor.device)
-        self._new_tail = torch.empty(1, dtype=torch.int64, device=tensor.device)
+        self.spilled_to_host = torch.empty(1, dtype=torch.int64, device=tensor.device)
+        self._new_head = torch.empty(2, dtype=torch.int64, device=tensor.device)
+        self._new_tail = torch.empty(2, dtype=torch.int64, device=tensor.device)
 
     def offload(self, buffer: _PagedStashBuffer) -> None:
         """Pack live rows and release the original activation reference.
 
         Args:
-            buffer: Circular page storage with shape ``[num_pages * page_size, hidden_size]``. The copy mutates its
-                free-list head, page storage, and shared overflow scalar on the current CUDA stream.
+            buffer: CUDA and optional pinned-host circular page storage. The copy mutates its free-list heads, page
+                storage, and shared overflow scalar on the current CUDA stream.
         """
         if self._tensor is None:
             raise RuntimeError("Paged tensor was stashed more than once")
         storage_dtype = _storage_dtype(self.dtype)
         source = self._tensor.view(storage_dtype).reshape(self.max_num_tokens, self.hidden_size)
         grid = (max(1, min(self.max_num_tokens, 2048)),)
+        self.spilled_to_host.zero_()
+        host_storage = buffer.host_storage if buffer.host_storage is not None else buffer.cuda_storage
         paged_stash_copy_kernel[grid](
             source,
-            buffer.storage,
+            buffer.cuda_storage,
+            host_storage,
             self.num_tokens_tensor,
             self.live_token_mask,
             self.live_token_offsets,
-            buffer.free_list,
+            buffer.free_list_cuda,
+            buffer.free_list_host,
             buffer.head,
             buffer.tail,
             buffer.capacity,
             self.page_record,
             buffer.overflow,
+            buffer.host_spill,
+            self.spilled_to_host,
             self._new_head,
             PAGE_SIZE=self.page_size,
             HIDDEN_SIZE=self.hidden_size,
             MAX_NUM_TOKENS=self.max_num_tokens,
             BLOCK_SIZE=GLOBAL_BLOCK_SIZE,
+            HAS_HOST_BUFFER=buffer.host_storage is not None,
         )
         buffer.head.copy_(self._new_head)
         self._original_tensor = self._tensor
@@ -223,15 +252,19 @@ class _PagedTensor:
         storage_dtype = _storage_dtype(self.dtype)
         destination = self._tensor.view(storage_dtype).reshape(self.max_num_tokens, self.hidden_size)
         grid = (max(1, min(self.max_num_tokens, 2048)),)
+        host_storage = buffer.host_storage if buffer.host_storage is not None else buffer.cuda_storage
         paged_stash_pop_kernel[grid](
-            buffer.storage,
+            buffer.cuda_storage,
+            host_storage,
             destination,
             self.num_tokens_tensor,
             self.live_token_mask,
             self.live_token_offsets,
             self.page_record,
+            self.spilled_to_host,
             buffer.overflow,
-            buffer.free_list,
+            buffer.free_list_cuda,
+            buffer.free_list_host,
             buffer.tail,
             buffer.capacity,
             self._new_tail,
@@ -515,16 +548,20 @@ class PagedStashManager:
         self._disable_depth = 0
         self._page_size = 64
         self._buffer_size_factor = 1.1
+        self._host_buffer_size_factor = 0.0
         self._next_group_id = 0
         self._current_group: _GroupState | None = None
         self._group_tensors: dict[int, list[_PagedTensor]] = {}
         self._group_saved_tensor_counts: dict[int, int] = {}
         self._recorded_peak_tokens: dict[tuple[torch.dtype, int], int] = {}
         self._recorded_current_tokens: dict[tuple[torch.dtype, int], int] = {}
+        self._recorded_events: dict[tuple[torch.dtype, int], list[tuple[str, int, int]]] = {}
+        self._next_recorded_allocation_id = 0
         self._record_device: torch.device | None = None
         self._recording_invalid_reason: str | None = None
         self._buffers: dict[tuple[torch.dtype, int], _PagedStashBuffer] = {}
         self._overflow: torch.Tensor | None = None
+        self._host_spill: torch.Tensor | None = None
         self._backward_group_stack: list[int] = []
         self._backward_in_progress_group_id: int | None = None
 
@@ -544,6 +581,7 @@ class PagedStashManager:
         enabled: bool,
         page_size: int = 64,
         buffer_size_factor: float = 1.1,
+        host_buffer_size_factor: float = 0.0,
     ) -> None:
         """Enable a recording warmup or disable a quiescent manager.
 
@@ -553,8 +591,10 @@ class PagedStashManager:
         Args:
             enabled: Whether to record and then page explicitly registered activations.
             page_size: Positive number of token rows per page.
-            buffer_size_factor: Finite allocation headroom relative to recorded peak usage. Values below ``1.0``
-                cannot hold the warmup workload and are rejected.
+            buffer_size_factor: Fraction of recorded peak usage allocated in CUDA memory. It must be positive; when
+                it is below one, ``host_buffer_size_factor`` must provide enough total capacity.
+            host_buffer_size_factor: Fraction of recorded peak usage allocated in pinned host memory. Zero disables
+                host spill. CUDA and host factors must sum to at least one.
         """
         if isinstance(page_size, bool) or not isinstance(page_size, int) or page_size <= 0:
             raise ValueError(f"page_size must be positive, got {page_size}")
@@ -562,20 +602,37 @@ class PagedStashManager:
             isinstance(buffer_size_factor, bool)
             or not isinstance(buffer_size_factor, (int, float))
             or not math.isfinite(float(buffer_size_factor))
-            or buffer_size_factor < 1.0
+            or buffer_size_factor <= 0.0
         ):
-            raise ValueError(f"buffer_size_factor must be finite and at least 1.0, got {buffer_size_factor}")
+            raise ValueError(f"buffer_size_factor must be positive and finite, got {buffer_size_factor}")
+        if (
+            isinstance(host_buffer_size_factor, bool)
+            or not isinstance(host_buffer_size_factor, (int, float))
+            or not math.isfinite(float(host_buffer_size_factor))
+            or host_buffer_size_factor < 0.0
+        ):
+            raise ValueError(f"host_buffer_size_factor must be non-negative and finite, got {host_buffer_size_factor}")
+        if buffer_size_factor + host_buffer_size_factor < 1.0:
+            raise ValueError("buffer_size_factor and host_buffer_size_factor must provide at least 1.0x total capacity")
         if self._current_group is not None or self._group_tensors:
             raise RuntimeError("Cannot reconfigure paged stash while groups are live")
         if not enabled:
             self.close()
             return
         if self._state is not _PagedStashState.DISABLED:
-            if page_size != self._page_size or not math.isclose(buffer_size_factor, self._buffer_size_factor):
-                raise RuntimeError("All paged-stash experts must use the same page_size and buffer_size_factor")
+            if (
+                page_size != self._page_size
+                or not math.isclose(buffer_size_factor, self._buffer_size_factor)
+                or not math.isclose(host_buffer_size_factor, self._host_buffer_size_factor)
+            ):
+                raise RuntimeError(
+                    "All paged-stash experts must use the same page_size, buffer_size_factor, and "
+                    "host_buffer_size_factor"
+                )
             return
         self._page_size = page_size
         self._buffer_size_factor = buffer_size_factor
+        self._host_buffer_size_factor = host_buffer_size_factor
         self._state = _PagedStashState.RECORDING
 
     @contextlib.contextmanager
@@ -689,7 +746,15 @@ class PagedStashManager:
             current = self._recorded_current_tokens.get(key, 0) + charged_tokens
             self._recorded_current_tokens[key] = current
             self._recorded_peak_tokens[key] = max(self._recorded_peak_tokens.get(key, 0), current)
-            return _RecordedTensor(tensor=tensor, key=key, charged_tokens=charged_tokens)
+            allocation_id = self._next_recorded_allocation_id
+            self._next_recorded_allocation_id += 1
+            self._recorded_events.setdefault(key, []).append(("allocate", allocation_id, charged_tokens))
+            return _RecordedTensor(
+                tensor=tensor,
+                key=key,
+                charged_tokens=charged_tokens,
+                allocation_id=allocation_id,
+            )
 
         if self._state is not _PagedStashState.ACTIVE:
             return tensor
@@ -724,6 +789,7 @@ class PagedStashManager:
                 if current < 0:
                     raise RuntimeError(f"Paged stash recording underflow for layout {saved.key}")
                 self._recorded_current_tokens[saved.key] = current
+                self._recorded_events[saved.key].append(("release", saved.allocation_id, saved.charged_tokens))
                 saved.released = True
             return saved.tensor
         if isinstance(saved, _PagedTensor):
@@ -827,19 +893,98 @@ class PagedStashManager:
         if not HAVE_TRITON:
             raise RuntimeError("Paged stash requires Triton")
 
-        self._overflow = torch.zeros(1, dtype=torch.int64, device=self._record_device)
-        for (dtype, hidden_size), peak_tokens in self._recorded_peak_tokens.items():
-            capacity = max(1, math.ceil(peak_tokens * self._buffer_size_factor))
-            storage_dtype = _storage_dtype(dtype)
-            self._buffers[dtype, hidden_size] = _PagedStashBuffer(
-                num_tokens=capacity,
-                hidden_size=hidden_size,
-                page_size=self._page_size,
-                device=self._record_device,
-                dtype=storage_dtype,
-                overflow=self._overflow,
+        capacity_plan: dict[tuple[torch.dtype, int], tuple[int, int]] = {}
+        for key, peak_tokens in self._recorded_peak_tokens.items():
+            cuda_capacity = math.ceil(peak_tokens * self._buffer_size_factor / self._page_size) * self._page_size
+            host_capacity = (
+                math.ceil(peak_tokens * self._host_buffer_size_factor / self._page_size) * self._page_size
+                if self._host_buffer_size_factor
+                else 0
             )
+            self._validate_recorded_placement(key, cuda_capacity, host_capacity)
+            capacity_plan[key] = (cuda_capacity, host_capacity)
+
+        cuda_bytes = {}
+        host_bytes = {}
+        for (dtype, hidden_size), (cuda_capacity, host_capacity) in capacity_plan.items():
+            element_size = torch.empty((), dtype=_storage_dtype(dtype)).element_size()
+            cuda_bytes[dtype, hidden_size] = cuda_capacity * hidden_size * element_size
+            host_bytes[dtype, hidden_size] = host_capacity * hidden_size * element_size
+        logger.info(
+            "Paged stash allocation plan: cuda_bytes=%s total_cuda_bytes=%d host_bytes=%s total_host_bytes=%d",
+            cuda_bytes,
+            sum(cuda_bytes.values()),
+            host_bytes,
+            sum(host_bytes.values()),
+        )
+
+        overflow = torch.zeros(1, dtype=torch.int64, device=self._record_device)
+        host_spill = torch.zeros(1, dtype=torch.int64, device=self._record_device)
+        buffers: dict[tuple[torch.dtype, int], _PagedStashBuffer] = {}
+        try:
+            for (dtype, hidden_size), (capacity, host_capacity) in capacity_plan.items():
+                storage_dtype = _storage_dtype(dtype)
+                try:
+                    buffers[dtype, hidden_size] = _PagedStashBuffer(
+                        num_tokens=capacity,
+                        hidden_size=hidden_size,
+                        page_size=self._page_size,
+                        device=self._record_device,
+                        dtype=storage_dtype,
+                        overflow=overflow,
+                        host_spill=host_spill,
+                        num_host_tokens=host_capacity,
+                    )
+                except Exception as error:
+                    raise RuntimeError(
+                        f"Paged stash allocation failed for layout {(dtype, hidden_size)}: "
+                        f"cuda_bytes={cuda_bytes[dtype, hidden_size]}, "
+                        f"pinned_host_bytes={host_bytes[dtype, hidden_size]}"
+                    ) from error
+        except Exception:
+            buffers.clear()
+            raise
+        self._overflow = overflow
+        self._host_spill = host_spill
+        self._buffers = buffers
         self._state = _PagedStashState.ACTIVE
+
+    def _validate_recorded_placement(
+        self,
+        key: tuple[torch.dtype, int],
+        cuda_capacity: int,
+        host_capacity: int,
+    ) -> None:
+        """Simulate CUDA-first whole-tensor placement for one recorded layout."""
+        available = {"cuda": cuda_capacity, "host": host_capacity}
+        allocations: dict[int, tuple[str, int]] = {}
+        for event, allocation_id, charged_tokens in self._recorded_events.get(key, []):
+            if event == "allocate":
+                if available["cuda"] >= charged_tokens:
+                    tier = "cuda"
+                elif available["host"] >= charged_tokens:
+                    tier = "host"
+                else:
+                    raise RuntimeError(
+                        "Paged stash CUDA/host factors cannot reproduce the recorded whole-tensor allocation "
+                        f"order for layout {key}: allocation={charged_tokens} rows, "
+                        f"available_cuda={available['cuda']}, available_host={available['host']}. "
+                        "Increase one buffer factor; CUDA and host free pages are not fungible within one tensor."
+                    )
+                available[tier] -= charged_tokens
+                allocations[allocation_id] = (tier, charged_tokens)
+                continue
+            if event != "release" or allocation_id not in allocations:
+                raise RuntimeError(f"Invalid paged-stash recording event for layout {key}: {(event, allocation_id)}")
+            tier, expected_tokens = allocations.pop(allocation_id)
+            if charged_tokens != expected_tokens:
+                raise RuntimeError(
+                    f"Paged-stash recording release changed size for layout {key}: "
+                    f"expected {expected_tokens}, got {charged_tokens}"
+                )
+            available[tier] += charged_tokens
+        if allocations:
+            raise RuntimeError(f"Paged-stash recording has unreleased allocations for layout {key}: {allocations}")
 
     def finish_iteration(self) -> None:
         """Synchronously validate overflow after a single-rank forward/backward.
@@ -864,6 +1009,14 @@ class PagedStashManager:
             raise PagedStashOverflowError(
                 "MoE paged stash capacity overflowed; discard this attempt and rerun without paged stash"
             )
+        for key, buffer in self._buffers.items():
+            available_pages = buffer.tail - buffer.head
+            if not torch.equal(available_pages, buffer.capacity):
+                raise RuntimeError(
+                    f"Paged stash allocator did not recover every CUDA/host page for layout {key}: "
+                    f"head={buffer.head.tolist()}, tail={buffer.tail.tolist()}, "
+                    f"capacity={buffer.capacity.tolist()}"
+                )
 
     def check_overflow(self) -> torch.Tensor | None:
         """Return the device-resident overflow flag without synchronizing the host.
@@ -873,6 +1026,36 @@ class PagedStashManager:
         """
         return self._overflow
 
+    def check_host_spill(self) -> torch.Tensor | None:
+        """Return whether host pages were used since the flag was last cleared.
+
+        Returns:
+            An integer CUDA tensor with shape ``[1]``, or ``None`` before fixed buffers have been prepared.
+        """
+        return self._host_spill
+
+    def check_allocator_imbalance(self) -> torch.Tensor | None:
+        """Return a device flag when any CUDA or host free list remains charged.
+
+        Returns:
+            An integer CUDA tensor with shape ``[1]``, or ``None`` before fixed buffers have been prepared.
+        """
+        if self._overflow is None:
+            return None
+        if not self._buffers:
+            return torch.zeros_like(self._overflow)
+        return (
+            torch.stack([(buffer.tail - buffer.head).ne(buffer.capacity).any() for buffer in self._buffers.values()])
+            .any()
+            .to(dtype=torch.int64)
+            .reshape(1)
+        )
+
+    def clear_host_spill(self) -> None:
+        """Clear the host-use diagnostic after its distributed result has been consumed."""
+        if self._host_spill is not None:
+            self._host_spill.zero_()
+
     def reset_after_overflow(self) -> None:
         """Clear overflow metadata after the graph using these buffers is destroyed."""
         if self._current_group is not None or self._group_tensors or self._group_saved_tensor_counts:
@@ -881,6 +1064,8 @@ class PagedStashManager:
             raise RuntimeError("Cannot reset paged stash while expert backward is live")
         if self._overflow is not None:
             self._overflow.zero_()
+        if self._host_spill is not None:
+            self._host_spill.zero_()
         for buffer in self._buffers.values():
             buffer.reset()
 
@@ -888,11 +1073,13 @@ class PagedStashManager:
         """Drop fixed pages and start a fresh eager profile after graph teardown."""
         page_size = self._page_size
         buffer_size_factor = self._buffer_size_factor
+        host_buffer_size_factor = self._host_buffer_size_factor
         self.close()
         self.configure(
             enabled=True,
             page_size=page_size,
             buffer_size_factor=buffer_size_factor,
+            host_buffer_size_factor=host_buffer_size_factor,
         )
 
     def diagnostics(self) -> dict[str, Any]:
@@ -901,9 +1088,15 @@ class PagedStashManager:
             "state": self._state.value,
             "page_size": self._page_size,
             "buffer_size_factor": self._buffer_size_factor,
+            "host_buffer_size_factor": self._host_buffer_size_factor,
             "recorded_peak_tokens": dict(self._recorded_peak_tokens),
-            "buffer_tokens": {key: buffer.total_tokens for key, buffer in self._buffers.items()},
-            "buffer_bytes": {key: buffer.storage.nbytes for key, buffer in self._buffers.items()},
+            "buffer_tokens": {key: buffer.total_cuda_tokens for key, buffer in self._buffers.items()},
+            "buffer_bytes": {key: buffer.cuda_storage.nbytes for key, buffer in self._buffers.items()},
+            "host_buffer_tokens": {key: buffer.total_host_tokens for key, buffer in self._buffers.items()},
+            "host_buffer_bytes": {
+                key: buffer.host_storage.nbytes if buffer.host_storage is not None else 0
+                for key, buffer in self._buffers.items()
+            },
             "live_groups": len(self._group_tensors),
             "backward_schedule_depth": len(self._backward_group_stack),
             "backward_in_progress_group_id": self._backward_in_progress_group_id,
@@ -919,14 +1112,17 @@ class PagedStashManager:
             raise RuntimeError("Cannot close paged stash while expert backward is live")
         self._buffers.clear()
         self._overflow = None
+        self._host_spill = None
         self._recorded_peak_tokens.clear()
         self._recorded_current_tokens.clear()
+        self._recorded_events.clear()
         self._record_device = None
         self._recording_invalid_reason = None
         self._group_saved_tensor_counts.clear()
         self._backward_group_stack.clear()
         self._backward_in_progress_group_id = None
         self._next_group_id = 0
+        self._next_recorded_allocation_id = 0
         self._disable_depth = 0
         self._state = _PagedStashState.DISABLED
 

--- a/nemo_automodel/components/moe/paged_stash_ops.py
+++ b/nemo_automodel/components/moe/paged_stash_ops.py
@@ -33,61 +33,105 @@ GLOBAL_BLOCK_SIZE = 1024
 @_triton_jit
 def paged_stash_copy_kernel(
     src_ptr,
-    dst_ptr,
+    cuda_dst_ptr,
+    host_dst_ptr,
     num_tokens_ptr,
     live_token_mask_ptr,
     live_token_offsets_ptr,
-    free_list_ptr,
+    free_list_cuda_ptr,
+    free_list_host_ptr,
     free_list_head_ptr,
     free_list_tail_ptr,
     free_list_capacity_ptr,
     page_record_ptr,
     overflow_ptr,
+    host_spill_ptr,
+    spilled_to_host_ptr,
     new_free_list_head_ptr,
     PAGE_SIZE: _triton_constexpr,
     HIDDEN_SIZE: _triton_constexpr,
     MAX_NUM_TOKENS: _triton_constexpr,
     BLOCK_SIZE: _triton_constexpr,
+    HAS_HOST_BUFFER: _triton_constexpr,
 ):
-    """Copy a runtime number of live rows into pages without a host sync.
+    """Copy live rows to CUDA pages or a pinned-host spill buffer.
 
     Args:
         src_ptr: Contiguous source with shape ``[MAX_NUM_TOKENS, HIDDEN_SIZE]``.
-        dst_ptr: Page storage with shape ``[capacity * PAGE_SIZE, HIDDEN_SIZE]``; live rows are written in packed
-            order.
+        cuda_dst_ptr: CUDA page storage with shape ``[cuda_capacity * PAGE_SIZE, HIDDEN_SIZE]``.
+        host_dst_ptr: Pinned-host page storage with shape ``[host_capacity * PAGE_SIZE, HIDDEN_SIZE]``. The CUDA
+            buffer is passed as a harmless placeholder when host spill is disabled.
         num_tokens_ptr: Integer device scalar with shape ``[1]``.
         live_token_mask_ptr: Boolean live-row mask with shape ``[MAX_NUM_TOKENS]``.
         live_token_offsets_ptr: Packed row offsets with shape ``[MAX_NUM_TOKENS]``; only live-row values are read.
-        free_list_ptr: Circular array of physical page ids with shape ``[capacity]``.
-        free_list_head_ptr: Integer device scalar with shape ``[1]``; advanced by the allocated page count.
-        free_list_tail_ptr: Integer device scalar with shape ``[1]`` containing the current release position.
-        free_list_capacity_ptr: Integer device scalar with shape ``[1]``.
+        free_list_cuda_ptr: Circular CUDA-page ids with shape ``[cuda_capacity]``.
+        free_list_host_ptr: Circular host-page ids with shape ``[host_capacity]``.
+        free_list_head_ptr: Integer device tensor with shape ``[2]`` for CUDA and host allocation heads.
+        free_list_tail_ptr: Integer device tensor with shape ``[2]`` for CUDA and host release tails.
+        free_list_capacity_ptr: Integer device tensor with shape ``[2]`` for CUDA and host page counts.
         page_record_ptr: Output page ids with shape ``[ceil(MAX_NUM_TOKENS / PAGE_SIZE)]``.
         overflow_ptr: Shared integer device scalar with shape ``[1]``; set on invalid counts or insufficient pages.
-        new_free_list_head_ptr: Integer output scalar with shape ``[1]`` copied into the persistent head by caller.
+        host_spill_ptr: Shared integer device scalar set when any tensor uses pinned-host storage.
+        spilled_to_host_ptr: Per-tensor integer device scalar; zero selects CUDA pages and one selects host pages.
+        new_free_list_head_ptr: Integer output with shape ``[2]`` copied into the persistent heads by the caller.
         PAGE_SIZE: Compile-time number of rows per page.
         HIDDEN_SIZE: Compile-time flattened elements per row.
         MAX_NUM_TOKENS: Compile-time physical source-row count.
         BLOCK_SIZE: Compile-time number of elements copied per inner block.
+        HAS_HOST_BUFFER: Whether ``host_dst_ptr`` and its free list are active.
     """
     program_id = tl.program_id(axis=0)
     num_programs = tl.num_programs(axis=0)
 
     num_tokens = tl.load(num_tokens_ptr)
-    head = tl.load(free_list_head_ptr)
-    tail = tl.load(free_list_tail_ptr)
-    capacity = tl.load(free_list_capacity_ptr)
+    head_cuda = tl.load(free_list_head_ptr)
+    head_host = tl.load(free_list_head_ptr + 1)
+    tail_cuda = tl.load(free_list_tail_ptr)
+    capacity_cuda = tl.load(free_list_capacity_ptr)
     required_pages = tl.cdiv(num_tokens, PAGE_SIZE)
     overflow = tl.load(overflow_ptr)
 
     invalid_count = (num_tokens < 0) | (num_tokens > MAX_NUM_TOKENS)
-    insufficient_pages = tail - head < required_pages
-    if (overflow != 0) | invalid_count | insufficient_pages:
+    if (overflow != 0) | invalid_count:
         if program_id == 0:
-            if invalid_count | insufficient_pages:
+            if invalid_count:
                 tl.store(overflow_ptr, 1)
-            tl.store(new_free_list_head_ptr, head)
+            tl.store(new_free_list_head_ptr, head_cuda)
+            tl.store(new_free_list_head_ptr + 1, head_host)
         return
+
+    use_cuda = tail_cuda - head_cuda >= required_pages
+    spilled_to_host = 0
+    destination_ptr = cuda_dst_ptr
+    free_list_ptr = free_list_cuda_ptr
+    head = head_cuda
+    capacity = capacity_cuda
+    new_head_cuda = head_cuda + required_pages
+    new_head_host = head_host
+
+    if not use_cuda:
+        tail_host = tl.load(free_list_tail_ptr + 1)
+        capacity_host = tl.load(free_list_capacity_ptr + 1)
+        use_host = HAS_HOST_BUFFER == 1 and tail_host - head_host >= required_pages
+        if use_host:
+            spilled_to_host = 1
+            destination_ptr = host_dst_ptr
+            free_list_ptr = free_list_host_ptr
+            head = head_host
+            capacity = capacity_host
+            new_head_cuda = head_cuda
+            new_head_host = head_host + required_pages
+        else:
+            if program_id == 0:
+                tl.store(overflow_ptr, 1)
+                tl.store(new_free_list_head_ptr, head_cuda)
+                tl.store(new_free_list_head_ptr + 1, head_host)
+            return
+
+    if program_id == 0:
+        tl.store(spilled_to_host_ptr, spilled_to_host)
+        if spilled_to_host == 1:
+            tl.store(host_spill_ptr, 1)
 
     physical_token_index = program_id
     while physical_token_index < MAX_NUM_TOKENS:
@@ -102,7 +146,7 @@ def paged_stash_copy_kernel(
 
         destination_token_index = page_id * PAGE_SIZE + token_in_page
         source_base = src_ptr + physical_token_index.to(tl.int64) * HIDDEN_SIZE
-        destination_base = dst_ptr + destination_token_index.to(tl.int64) * HIDDEN_SIZE
+        destination_base = destination_ptr + destination_token_index.to(tl.int64) * HIDDEN_SIZE
         for block_index in range(tl.cdiv(HIDDEN_SIZE, BLOCK_SIZE)):
             offsets = tl.arange(0, BLOCK_SIZE) + block_index * BLOCK_SIZE
             mask = offsets < HIDDEN_SIZE
@@ -111,19 +155,23 @@ def paged_stash_copy_kernel(
         physical_token_index += num_programs
 
     if program_id == 0:
-        tl.store(new_free_list_head_ptr, head + required_pages)
+        tl.store(new_free_list_head_ptr, new_head_cuda)
+        tl.store(new_free_list_head_ptr + 1, new_head_host)
 
 
 @_triton_jit
 def paged_stash_pop_kernel(
-    src_ptr,
+    cuda_src_ptr,
+    host_src_ptr,
     dst_ptr,
     num_tokens_ptr,
     live_token_mask_ptr,
     live_token_offsets_ptr,
     page_record_ptr,
+    spilled_to_host_ptr,
     overflow_ptr,
-    free_list_ptr,
+    free_list_cuda_ptr,
+    free_list_host_ptr,
     free_list_tail_ptr,
     free_list_capacity_ptr,
     new_free_list_tail_ptr,
@@ -132,21 +180,25 @@ def paged_stash_pop_kernel(
     MAX_NUM_TOKENS: _triton_constexpr,
     BLOCK_SIZE: _triton_constexpr,
 ):
-    """Restore runtime-counted rows and recycle their pages on the GPU.
+    """Restore live rows from CUDA or pinned-host pages and recycle them.
 
     Args:
-        src_ptr: Page storage with shape ``[capacity * PAGE_SIZE, HIDDEN_SIZE]``.
+        cuda_src_ptr: CUDA page storage with shape ``[cuda_capacity * PAGE_SIZE, HIDDEN_SIZE]``.
+        host_src_ptr: Pinned-host page storage with shape ``[host_capacity * PAGE_SIZE, HIDDEN_SIZE]``. The CUDA
+            buffer is passed as a harmless placeholder when host spill is disabled.
         dst_ptr: Zero-initialized destination with shape ``[MAX_NUM_TOKENS, HIDDEN_SIZE]``; live rows are restored
             to their original physical positions.
         num_tokens_ptr: Integer device scalar with shape ``[1]``.
         live_token_mask_ptr: Boolean live-row mask with shape ``[MAX_NUM_TOKENS]``.
         live_token_offsets_ptr: Packed row offsets with shape ``[MAX_NUM_TOKENS]``; only live-row values are read.
         page_record_ptr: Physical page ids with shape ``[ceil(MAX_NUM_TOKENS / PAGE_SIZE)]``.
+        spilled_to_host_ptr: Per-tensor integer device scalar selecting CUDA or host pages.
         overflow_ptr: Shared integer device scalar with shape ``[1]``; set on invalid counts.
-        free_list_ptr: Circular array of physical page ids with shape ``[capacity]``; released ids are appended.
-        free_list_tail_ptr: Integer device scalar with shape ``[1]`` containing the current release position.
-        free_list_capacity_ptr: Integer device scalar with shape ``[1]``.
-        new_free_list_tail_ptr: Integer output scalar with shape ``[1]`` copied into the persistent tail by caller.
+        free_list_cuda_ptr: Circular CUDA-page ids with shape ``[cuda_capacity]``.
+        free_list_host_ptr: Circular host-page ids with shape ``[host_capacity]``.
+        free_list_tail_ptr: Integer device tensor with shape ``[2]`` for CUDA and host release tails.
+        free_list_capacity_ptr: Integer device tensor with shape ``[2]`` for CUDA and host page counts.
+        new_free_list_tail_ptr: Integer output with shape ``[2]`` copied into the persistent tails by the caller.
         PAGE_SIZE: Compile-time number of rows per page.
         HIDDEN_SIZE: Compile-time flattened elements per row.
         MAX_NUM_TOKENS: Compile-time physical destination-row count.
@@ -156,8 +208,10 @@ def paged_stash_pop_kernel(
     num_programs = tl.num_programs(axis=0)
 
     num_tokens = tl.load(num_tokens_ptr)
-    tail = tl.load(free_list_tail_ptr)
-    capacity = tl.load(free_list_capacity_ptr)
+    spilled_to_host = tl.load(spilled_to_host_ptr)
+    tail_cuda = tl.load(free_list_tail_ptr)
+    tail_host = tl.load(free_list_tail_ptr + 1)
+    capacity_cuda = tl.load(free_list_capacity_ptr)
     required_pages = tl.cdiv(num_tokens, PAGE_SIZE)
     overflow = tl.load(overflow_ptr)
 
@@ -166,8 +220,30 @@ def paged_stash_pop_kernel(
         if program_id == 0:
             if invalid_count:
                 tl.store(overflow_ptr, 1)
-            tl.store(new_free_list_tail_ptr, tail)
+            tl.store(new_free_list_tail_ptr, tail_cuda)
+            tl.store(new_free_list_tail_ptr + 1, tail_host)
         return
+
+    source_ptr = cuda_src_ptr
+    free_list_ptr = free_list_cuda_ptr
+    tail = tail_cuda
+    capacity = capacity_cuda
+    new_tail_cuda = tail_cuda + required_pages
+    new_tail_host = tail_host
+    if spilled_to_host == 1:
+        capacity_host = tl.load(free_list_capacity_ptr + 1)
+        if capacity_host == 0:
+            if program_id == 0:
+                tl.store(overflow_ptr, 1)
+                tl.store(new_free_list_tail_ptr, tail_cuda)
+                tl.store(new_free_list_tail_ptr + 1, tail_host)
+            return
+        source_ptr = host_src_ptr
+        free_list_ptr = free_list_host_ptr
+        tail = tail_host
+        capacity = capacity_host
+        new_tail_cuda = tail_cuda
+        new_tail_host = tail_host + required_pages
 
     physical_token_index = program_id
     while physical_token_index < MAX_NUM_TOKENS:
@@ -178,7 +254,7 @@ def paged_stash_pop_kernel(
         page_id = tl.load(page_record_ptr + page_slot, mask=live, other=0)
         source_token_index = page_id * PAGE_SIZE + token_in_page
 
-        source_base = src_ptr + source_token_index.to(tl.int64) * HIDDEN_SIZE
+        source_base = source_ptr + source_token_index.to(tl.int64) * HIDDEN_SIZE
         destination_base = dst_ptr + physical_token_index.to(tl.int64) * HIDDEN_SIZE
         for block_index in range(tl.cdiv(HIDDEN_SIZE, BLOCK_SIZE)):
             offsets = tl.arange(0, BLOCK_SIZE) + block_index * BLOCK_SIZE
@@ -192,7 +268,8 @@ def paged_stash_pop_kernel(
         physical_token_index += num_programs
 
     if program_id == 0:
-        tl.store(new_free_list_tail_ptr, tail + required_pages)
+        tl.store(new_free_list_tail_ptr, new_tail_cuda)
+        tl.store(new_free_list_tail_ptr + 1, new_tail_host)
 
 
 __all__ = ["GLOBAL_BLOCK_SIZE", "HAVE_TRITON", "paged_stash_copy_kernel", "paged_stash_pop_kernel"]

--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -86,7 +86,7 @@ def _is_selective_ac(activation_checkpointing: object) -> bool:
 
 def _apply_attention_only_ac(
     model: nn.Module,
-    activation_checkpointing_scope: str | list[str] | tuple[str, ...],
+    scopes: tuple[str, ...],
 ) -> None:
     """Checkpoint decoder attention while leaving every MoE sublayer outside recompute.
 
@@ -96,28 +96,39 @@ def _apply_attention_only_ac(
 
     Args:
         model: MoE model whose decoder attention modules are wrapped in place.
-        activation_checkpointing_scope: Layer groups selected for activation
-            checkpointing. Decoder attention is wrapped for ``"all"`` or
-            ``"language"``; multimodal towers retain their existing policy.
+        scopes: Normalized layer groups selected for activation checkpointing.
+            Decoder attention is wrapped for ``"all"`` or ``"language"``;
+            multimodal towers retain their existing policy.
     """
-    from nemo_automodel.components.distributed.config import normalize_activation_checkpointing_scope
+    from nemo_automodel.components.distributed.activation_checkpointing import (
+        apply_submodule_checkpointing,
+        detect_kv_sharing_and_maybe_disable_cache,
+        sdpa_backend_snapshot_context_fn,
+    )
 
-    scopes = normalize_activation_checkpointing_scope(activation_checkpointing_scope)
-    wrapped = 0
     if "all" in scopes or "language" in scopes:
-        for _parent_layers, _layer_id, block in _iter_transformer_and_mtp_blocks(model):
-            for name in ("self_attn", "attention", "attn"):
-                attention = getattr(block, name, None)
-                if isinstance(attention, nn.Module):
-                    setattr(block, name, ptd_checkpoint_wrapper(attention, preserve_rng_state=True))
-                    wrapped += 1
-                    break
-        if wrapped == 0:
-            raise RuntimeError("activation_checkpointing_modules=['attention'] found no decoder attention modules")
+        blocks = [block for _parent_layers, _layer_id, block in iter_transformer_and_mtp_blocks(model)]
+        if not any(
+            isinstance(getattr(block, name, None), nn.Module)
+            for block in blocks
+            for name in ("self_attn", "attention", "attn")
+        ):
+            raise RuntimeError("activation_checkpointing_modules=['attn'] found no decoder attention modules")
+        if detect_kv_sharing_and_maybe_disable_cache(model):
+            raise RuntimeError(
+                "activation_checkpointing_modules=['attn'] does not support KV-sharing models because "
+                "attention recompute would write shared K/V state twice"
+            )
+        apply_submodule_checkpointing(
+            blocks,
+            has_kv_sharing=False,
+            checkpoint_modules=("attn",),
+            context_fn=sdpa_backend_snapshot_context_fn,
+        )
         logger.info(
             "Applied attention-only activation checkpointing to %d decoder layers; MoE sublayers remain outside "
             "the checkpoint boundary",
-            wrapped,
+            len(blocks),
         )
     _apply_multimodal_tower_ac(model, scopes)
 
@@ -452,7 +463,7 @@ def apply_ac(
     selective: bool = False,
     activation_checkpointing_modules: tuple[str, ...] | None = None,
     activation_checkpointing_scope: str | list[str] | tuple[str, ...] = "all",
-):
+) -> None:
     """Apply activation checkpointing to the model.
 
     Args:
@@ -468,7 +479,7 @@ def apply_ac(
             ``ignore_router``; the shared policy already saves expert-parallel communication
             collectives and ``topk``, so it composes with expert parallelism.
         activation_checkpointing_modules: Optional structural checkpoint boundaries.
-            ``("attention",)`` checkpoints decoder attention only and keeps MoE
+            ``("attn",)`` checkpoints decoder attention only and keeps MoE
             execution outside recompute so full-MoE CUDA graphs remain replay-safe.
         activation_checkpointing_scope: Which layer groups to checkpoint -- the same field
             and semantics as the generic FSDP2/DDP path. ``"all"`` (the default) checkpoints
@@ -495,9 +506,9 @@ def apply_ac(
             raise ValueError(
                 "activation_checkpointing_modules cannot be combined with operator-level selective checkpointing"
             )
-        if activation_checkpointing_modules != ("attention",):
-            raise ValueError("MoE activation_checkpointing_modules currently supports only ('attention',)")
-        _apply_attention_only_ac(model, activation_checkpointing_scope)
+        if activation_checkpointing_modules != ("attn",):
+            raise ValueError("MoE activation_checkpointing_modules currently supports only ('attn',)")
+        _apply_attention_only_ac(model, scopes)
         return
     if checkpoint_decoder and not selective and not ignore_router:
         logger.warning(
@@ -758,6 +769,13 @@ def apply_fsdp(
         ignored_params = None
         if isinstance(moe_module, MoE) and ep_enabled:
             ignored_params = set(moe_module.experts.parameters())
+            if not ep_shard_enabled:
+                # EP already partitions whole experts across ranks. These local
+                # parameters are intentionally excluded from every FSDP unit,
+                # so their storage addresses remain stable across iterations.
+                # Partial MoE CUDA graphs use this marker to avoid a second
+                # long-lived copy of every expert weight.
+                moe_module.experts._nemo_cuda_graph_stable_parameter_storage = True
 
         # Reuse the dense dtype-aware path for model-owned fp32 contracts while
         # leaving EP-owned experts out of the block's dtype and FSDP ownership.
@@ -985,6 +1003,16 @@ def parallelize_model(
 ) -> None:
     """Apply tensor, context, expert, activation-checkpointing, and FSDP parallelism."""
 
+    if activation_checkpointing_modules is not None:
+        if activation_checkpointing_modules != ("attn",):
+            raise ValueError("activation_checkpointing_modules currently supports only ('attn',)")
+        if not activation_checkpointing:
+            raise ValueError("activation_checkpointing_modules requires activation_checkpointing to be enabled")
+        if _is_selective_ac(activation_checkpointing):
+            raise ValueError(
+                "activation_checkpointing_modules cannot be combined with operator-level selective checkpointing"
+            )
+
     tp_enabled = tp_axis_name is not None and world_mesh[tp_axis_name].size() > 1
     if tp_enabled:
         if enable_async_tensor_parallel:
@@ -1039,9 +1067,6 @@ def parallelize_model(
         )
 
         apply_ep(model, moe_mesh[ep_axis_name], moe_mesh=moe_mesh)
-
-    if activation_checkpointing_modules is not None and not activation_checkpointing:
-        raise ValueError("activation_checkpointing_modules requires activation_checkpointing to be enabled")
 
     if activation_checkpointing:
         apply_ac(

--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -84,6 +84,44 @@ def _is_selective_ac(activation_checkpointing: object) -> bool:
     )
 
 
+def _apply_attention_only_ac(
+    model: nn.Module,
+    activation_checkpointing_scope: str | list[str] | tuple[str, ...],
+) -> None:
+    """Checkpoint decoder attention while leaving every MoE sublayer outside recompute.
+
+    The structural boundary is required by full-MoE CUDA graphs: checkpointing
+    the complete decoder block would replay the expert graph during backward and
+    invalidate its paged saved-tensor lifecycle.
+
+    Args:
+        model: MoE model whose decoder attention modules are wrapped in place.
+        activation_checkpointing_scope: Layer groups selected for activation
+            checkpointing. Decoder attention is wrapped for ``"all"`` or
+            ``"language"``; multimodal towers retain their existing policy.
+    """
+    from nemo_automodel.components.distributed.config import normalize_activation_checkpointing_scope
+
+    scopes = normalize_activation_checkpointing_scope(activation_checkpointing_scope)
+    wrapped = 0
+    if "all" in scopes or "language" in scopes:
+        for _parent_layers, _layer_id, block in _iter_transformer_and_mtp_blocks(model):
+            for name in ("self_attn", "attention", "attn"):
+                attention = getattr(block, name, None)
+                if isinstance(attention, nn.Module):
+                    setattr(block, name, ptd_checkpoint_wrapper(attention, preserve_rng_state=True))
+                    wrapped += 1
+                    break
+        if wrapped == 0:
+            raise RuntimeError("activation_checkpointing_modules=['attention'] found no decoder attention modules")
+        logger.info(
+            "Applied attention-only activation checkpointing to %d decoder layers; MoE sublayers remain outside "
+            "the checkpoint boundary",
+            wrapped,
+        )
+    _apply_multimodal_tower_ac(model, scopes)
+
+
 def _is_deepseek_v4_model(model: torch.nn.Module) -> bool:
     config = getattr(model, "config", None)
     if getattr(config, "model_type", None) == "deepseek_v4":
@@ -412,6 +450,7 @@ def apply_ac(
     hidden_size: int | None = None,
     num_experts: int | None = None,
     selective: bool = False,
+    activation_checkpointing_modules: tuple[str, ...] | None = None,
     activation_checkpointing_scope: str | list[str] | tuple[str, ...] = "all",
 ):
     """Apply activation checkpointing to the model.
@@ -428,6 +467,9 @@ def apply_ac(
             (shared with the dense FSDP2 path) to each block. Takes precedence over
             ``ignore_router``; the shared policy already saves expert-parallel communication
             collectives and ``topk``, so it composes with expert parallelism.
+        activation_checkpointing_modules: Optional structural checkpoint boundaries.
+            ``("attention",)`` checkpoints decoder attention only and keeps MoE
+            execution outside recompute so full-MoE CUDA graphs remain replay-safe.
         activation_checkpointing_scope: Which layer groups to checkpoint -- the same field
             and semantics as the generic FSDP2/DDP path. ``"all"`` (the default) checkpoints
             the text/MoE decoder blocks plus the trainable vision tower; ``"language"`` the
@@ -448,6 +490,15 @@ def apply_ac(
 
     scopes = normalize_activation_checkpointing_scope(activation_checkpointing_scope)
     checkpoint_decoder = "all" in scopes or "language" in scopes
+    if activation_checkpointing_modules is not None:
+        if selective:
+            raise ValueError(
+                "activation_checkpointing_modules cannot be combined with operator-level selective checkpointing"
+            )
+        if activation_checkpointing_modules != ("attention",):
+            raise ValueError("MoE activation_checkpointing_modules currently supports only ('attention',)")
+        _apply_attention_only_ac(model, activation_checkpointing_scope)
+        return
     if checkpoint_decoder and not selective and not ignore_router:
         logger.warning(
             "Activation checkpointing is enabled with ignore_router_for_ac=False. The MoE "
@@ -920,6 +971,7 @@ def parallelize_model(
     ep_shard_axis_names: tuple[str, ...] | None = None,
     activation_checkpointing: bool | str = False,
     ignore_router_for_ac: bool = True,
+    activation_checkpointing_modules: tuple[str, ...] | None = None,
     activation_checkpointing_scope: str | list[str] | tuple[str, ...] = "all",
     reshard_after_forward: bool = False,
     lm_head_precision: str | torch.dtype | None = None,
@@ -988,11 +1040,15 @@ def parallelize_model(
 
         apply_ep(model, moe_mesh[ep_axis_name], moe_mesh=moe_mesh)
 
+    if activation_checkpointing_modules is not None and not activation_checkpointing:
+        raise ValueError("activation_checkpointing_modules requires activation_checkpointing to be enabled")
+
     if activation_checkpointing:
         apply_ac(
             model,
             ignore_router=ignore_router_for_ac,
             selective=_is_selective_ac(activation_checkpointing),
+            activation_checkpointing_modules=activation_checkpointing_modules,
             activation_checkpointing_scope=activation_checkpointing_scope,
         )
 

--- a/nemo_automodel/recipes/_dist_utils.py
+++ b/nemo_automodel/recipes/_dist_utils.py
@@ -105,6 +105,19 @@ def parse_distributed_section(cfg_dict: dict) -> dict:
     pipeline_dict: Optional[dict] = cfg.pop("pipeline", None)
     moe_dict: Optional[dict] = cfg.pop("moe", None)
     activation_checkpointing = _normalize_activation_checkpointing(cfg.pop("activation_checkpointing", False))
+    activation_checkpointing_modules = (
+        moe_dict.get("activation_checkpointing_modules") if moe_dict is not None else None
+    )
+    if activation_checkpointing_modules is not None:
+        if not activation_checkpointing:
+            raise ValueError(
+                "distributed.moe.activation_checkpointing_modules requires activation_checkpointing to be enabled"
+            )
+        if activation_checkpointing == "selective":
+            raise ValueError(
+                "distributed.moe.activation_checkpointing_modules cannot be combined with "
+                "activation_checkpointing='selective'"
+            )
 
     # Strip Hydra / OmegaConf meta keys (e.g. ``_target_``, ``_recursive_``,
     # ``_convert_``) that may leak from YAML configs.  They have no meaning
@@ -198,6 +211,8 @@ def parse_distributed_section(cfg_dict: dict) -> dict:
             pp_size,
         )
         pipeline_dict = None
+    if moe_dict is not None and moe_dict.get("activation_checkpointing_modules") is not None and ep_size <= 1:
+        raise ValueError("distributed.moe.activation_checkpointing_modules requires ep_size > 1")
     if moe_dict is not None and ep_size <= 1:
         moe_dict = None
 

--- a/nemo_automodel/recipes/llm/benchmark.py
+++ b/nemo_automodel/recipes/llm/benchmark.py
@@ -389,8 +389,13 @@ class BenchmarkingRecipeForNextTokenPrediction(TrainFinetuneRecipeForNextTokenPr
                     logger.debug("Optimizer step")
 
             # Match the training-loop lifecycle: record one complete eager
-            # optimizer step, then capture outside the measured iteration.
+            # optimizer step, then capture outside the measured iteration. The
+            # training recipe has already cleared gradients at this point; do
+            # the same here so graph staging does not overlap a complete model
+            # gradient set with its long-lived static input surfaces.
             if self.partial_cuda_graph_manager is not None and self._partial_cuda_graph_capture_pending:
+                for opt in self.optimizer:
+                    opt.zero_grad(set_to_none=True)
                 stash_manager = None
                 if self._partial_cuda_graph_paged_stash_enabled:
                     from nemo_automodel.components.moe.paged_stash import get_paged_stash_manager
@@ -400,7 +405,22 @@ class BenchmarkingRecipeForNextTokenPrediction(TrainFinetuneRecipeForNextTokenPr
                     logger.info("Partial MoE paged stash prepared: %s", stash_manager.diagnostics())
                 self.partial_cuda_graph_manager.capture()
                 if stash_manager is not None:
-                    overflow_ranks = self._paged_stash_overflow_rank_count(stash_manager)
+                    overflow_ranks, host_spill_ranks, imbalance_ranks = self._paged_stash_rank_counts(stash_manager)
+                    if host_spill_ranks:
+                        logger.info(
+                            "MoE paged stash used pinned-host pages during capture on %d ranks",
+                            host_spill_ranks,
+                        )
+                    if imbalance_ranks:
+                        self.partial_cuda_graph_manager.close()
+                        self.partial_cuda_graph_manager = None
+                        stash_manager.close()
+                        self._partial_cuda_graph_paged_stash_enabled = False
+                        self._partial_cuda_graph_capture_pending = False
+                        raise RuntimeError(
+                            "MoE paged stash did not recover every page during CUDA graph capture on "
+                            f"{imbalance_ranks} ranks; partial CUDA graphs were disabled"
+                        )
                     if overflow_ranks:
                         self.partial_cuda_graph_manager.close()
                         self.partial_cuda_graph_manager = None

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -812,6 +812,9 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
         self.partial_cuda_graph_manager = _build_partial_cuda_graph_manager(
             self.model_parts,
             activation_checkpointing=bool(self.activation_checkpointing),
+            activation_checkpointing_modules=getattr(
+                getattr(self, "moe_parallel_config", None), "activation_checkpointing_modules", None
+            ),
             pipeline_parallel=bool(self.pp_enabled),
         )
         self._partial_cuda_graph_capture_pending = self.partial_cuda_graph_manager is not None

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -403,6 +403,8 @@ def _build_partial_cuda_graph_manager(
     model_parts: list[nn.Module],
     *,
     activation_checkpointing: bool,
+    activation_checkpointing_modules: tuple[str, ...] | None = None,
+    activation_checkpointing_scope: tuple[str, ...] = ("all",),
     pipeline_parallel: bool,
 ) -> PartialCudaGraphManager | None:
     """Build partial CUDA-graph state only for explicitly enabled model backends.
@@ -410,6 +412,8 @@ def _build_partial_cuda_graph_manager(
     Args:
         model_parts: Fully initialized model roots or pipeline-local model parts.
         activation_checkpointing: Whether PyTorch activation checkpointing is enabled.
+        activation_checkpointing_modules: Selective checkpointing boundary, when configured.
+        activation_checkpointing_scope: Model scopes covered by activation checkpointing.
         pipeline_parallel: Whether pipeline parallelism is enabled.
 
     Returns:
@@ -425,6 +429,8 @@ def _build_partial_cuda_graph_manager(
     return PartialCudaGraphManager.from_model_parts(
         model_parts,
         activation_checkpointing=activation_checkpointing,
+        activation_checkpointing_modules=activation_checkpointing_modules,
+        activation_checkpointing_scope=activation_checkpointing_scope,
         pipeline_parallel=pipeline_parallel,
     )
 
@@ -460,6 +466,7 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
         self.partial_cuda_graph_manager = None
         self._partial_cuda_graph_capture_pending = False
         self._partial_cuda_graph_paged_stash_enabled = False
+        self._partial_cuda_graph_logged_host_spill = False
 
     # ------------------ build phase ------------------
     def _create_distributed_setup(self) -> DistributedSetup:
@@ -812,9 +819,12 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
         self.partial_cuda_graph_manager = _build_partial_cuda_graph_manager(
             self.model_parts,
             activation_checkpointing=bool(self.activation_checkpointing),
-            activation_checkpointing_modules=getattr(
-                getattr(self, "moe_parallel_config", None), "activation_checkpointing_modules", None
+            activation_checkpointing_modules=(
+                self.moe_parallel_config.activation_checkpointing_modules
+                if self.moe_parallel_config is not None
+                else None
             ),
+            activation_checkpointing_scope=self.distributed_config.activation_checkpointing_scope,
             pipeline_parallel=bool(self.pp_enabled),
         )
         self._partial_cuda_graph_capture_pending = self.partial_cuda_graph_manager is not None
@@ -971,7 +981,24 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
                             logger.info("Partial MoE paged stash prepared: %s", stash_manager.diagnostics())
                         self.partial_cuda_graph_manager.capture()
                         if stash_manager is not None:
-                            overflow_ranks = self._paged_stash_overflow_rank_count(stash_manager)
+                            overflow_ranks, host_spill_ranks, imbalance_ranks = self._paged_stash_rank_counts(
+                                stash_manager
+                            )
+                            if host_spill_ranks:
+                                logger.info(
+                                    "MoE paged stash used pinned-host pages during capture on %d ranks",
+                                    host_spill_ranks,
+                                )
+                            if imbalance_ranks:
+                                self.partial_cuda_graph_manager.close()
+                                self.partial_cuda_graph_manager = None
+                                stash_manager.close()
+                                self._partial_cuda_graph_paged_stash_enabled = False
+                                self._partial_cuda_graph_capture_pending = False
+                                raise RuntimeError(
+                                    "MoE paged stash did not recover every page during CUDA graph capture on "
+                                    f"{imbalance_ranks} ranks; partial CUDA graphs were disabled"
+                                )
                             if overflow_ranks:
                                 self.partial_cuda_graph_manager.close()
                                 self.partial_cuda_graph_manager = None
@@ -1235,23 +1262,33 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
             return None
         return self.rng.state_dict()
 
-    def _paged_stash_overflow_rank_count(self, stash_manager) -> int:
-        """Collectively count ranks whose device-resident paged-stash flag is set.
+    def _paged_stash_rank_counts(self, stash_manager) -> tuple[int, int, int]:
+        """Collectively count overflow, host-spill, and allocator-imbalance ranks.
 
         Args:
             stash_manager: Active process-local paged-stash manager.
 
         Returns:
-            Number of overflowing ranks. The only device-to-host synchronization occurs after every rank has
-            entered the collective.
+            A tuple ``(overflow_ranks, host_spill_ranks, imbalance_ranks)``. The only device-to-host synchronization
+            occurs after every rank has entered the collective.
         """
         overflow = stash_manager.check_overflow()
-        if overflow is None:
-            raise RuntimeError("Active partial MoE paged stash has no overflow flag")
-        overflow_ranks = overflow.reshape(-1)[0].ne(0).to(dtype=torch.int32)
+        host_spill = stash_manager.check_host_spill()
+        imbalance = stash_manager.check_allocator_imbalance()
+        if overflow is None or host_spill is None or imbalance is None:
+            raise RuntimeError("Active partial MoE paged stash has incomplete device status flags")
+        rank_flags = torch.stack(
+            (
+                overflow.reshape(-1)[0].ne(0),
+                host_spill.reshape(-1)[0].ne(0),
+                imbalance.reshape(-1)[0].ne(0),
+            )
+        ).to(dtype=torch.int32)
         if torch.distributed.is_initialized():
-            torch.distributed.all_reduce(overflow_ranks, op=torch.distributed.ReduceOp.SUM)
-        return int(overflow_ranks.item())
+            torch.distributed.all_reduce(rank_flags, op=torch.distributed.ReduceOp.SUM)
+        counts = tuple(int(count) for count in rank_flags.tolist())
+        stash_manager.clear_host_spill()
+        return counts
 
     def _rerun_after_paged_stash_overflow(
         self,
@@ -1280,7 +1317,21 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
         stash_manager = get_paged_stash_manager()
         if not stash_manager.is_active:
             return loss_buffer
-        overflow_ranks = self._paged_stash_overflow_rank_count(stash_manager)
+        overflow_ranks, host_spill_ranks, imbalance_ranks = self._paged_stash_rank_counts(stash_manager)
+        if host_spill_ranks and not self._partial_cuda_graph_logged_host_spill:
+            logger.info("MoE paged stash is spilling activations to pinned host memory on %d ranks", host_spill_ranks)
+            self._partial_cuda_graph_logged_host_spill = True
+        if imbalance_ranks:
+            if self.partial_cuda_graph_manager is not None:
+                self.partial_cuda_graph_manager.close()
+                self.partial_cuda_graph_manager = None
+            self._partial_cuda_graph_capture_pending = False
+            stash_manager.close()
+            self._partial_cuda_graph_paged_stash_enabled = False
+            raise RuntimeError(
+                "MoE paged stash did not recover every CUDA/host page on "
+                f"{imbalance_ranks} ranks; partial CUDA graphs were disabled"
+            )
         if overflow_ranks == 0:
             stash_manager.finish_iteration()
             return loss_buffer

--- a/tests/functional_tests/moe/test_paged_stash_cuda_graph.py
+++ b/tests/functional_tests/moe/test_paged_stash_cuda_graph.py
@@ -199,6 +199,45 @@ def test_active_stash_restores_sparse_rows_and_zeros_padding():
     manager.close()
 
 
+@pytest.mark.skipif(not torch.cuda.is_available() or not HAVE_TRITON, reason="CUDA and Triton are required")
+def test_active_stash_spills_complete_tensor_to_pinned_host():
+    """Force the live tensor past CUDA capacity and verify pinned-host restore parity."""
+    manager = PagedStashManager()
+    manager.configure(
+        enabled=True,
+        page_size=2,
+        buffer_size_factor=0.25,
+        host_buffer_size_factor=1.0,
+    )
+
+    warmup = torch.randn(8, 4, device="cuda", requires_grad=True)
+    warmup_mask = torch.tensor([True, False, True, True, False, True, False, True], device="cuda")
+    warmup_group = manager.group(name="warmup", max_num_tokens=8, live_token_mask=warmup_mask)
+    warmup_for_compute = warmup_group.start(warmup)
+    with warmup_group:
+        warmup_output = _SegmentedSquare.apply(warmup_group.mark_activation(warmup_for_compute))
+    warmup_group.commit(warmup_output).sum().backward()
+    manager.prepare()
+
+    # Five live rows require three pages. The CUDA fraction above allocates one
+    # page, so the kernel must place this complete saved tensor in host pages.
+    tensor = torch.randn(8, 4, device="cuda", requires_grad=True)
+    live_mask = torch.tensor([True, True, False, True, False, True, False, True], device="cuda")
+    group = manager.group(name="active", max_num_tokens=8, live_token_mask=live_mask)
+    tensor_for_compute = group.start(tensor)
+    with group:
+        output = _SegmentedSquare.apply(group.mark_activation(tensor_for_compute))
+    group.commit(output).sum().backward()
+
+    expected = torch.zeros_like(tensor)
+    expected[live_mask] = 2 * tensor.detach()[live_mask]
+    torch.testing.assert_close(tensor.grad, expected)
+    assert manager.check_overflow().item() == 0
+    assert manager.check_host_spill().item() == 1
+    manager.finish_iteration()
+    manager.close()
+
+
 def _asymmetric_overflow_worker(rank: int, world_size: int, init_method: str) -> None:
     """Verify a single-rank overflow makes every rank discard and retry."""
     torch.cuda.set_device(rank)
@@ -212,6 +251,9 @@ def _asymmetric_overflow_worker(rank: int, world_size: int, init_method: str) ->
     stash_manager = SimpleNamespace(
         is_active=True,
         check_overflow=lambda: torch.tensor([rank == 0], dtype=torch.int64, device="cuda"),
+        check_host_spill=lambda: torch.zeros(1, dtype=torch.int64, device="cuda"),
+        check_allocator_imbalance=lambda: torch.zeros(1, dtype=torch.int64, device="cuda"),
+        clear_host_spill=lambda: None,
         close=lambda: events.append("stash-close"),
     )
     paged_stash._PAGED_STASH_MANAGER = stash_manager
@@ -274,11 +316,24 @@ def test_asymmetric_overflow_retries_on_every_rank():
 
 
 @pytest.mark.skipif(not torch.cuda.is_available() or not HAVE_TRITON, reason="CUDA and Triton are required")
-def test_te_grouped_linear_paged_stash_matches_eager_across_graph_replays():
-    """Compare BF16 graph output/gradients/update with eager and force page reuse."""
+@pytest.mark.parametrize(
+    ("cuda_buffer_factor", "host_buffer_factor", "expect_host_spill"),
+    [(1.0, 0.0, False), (0.25, 1.0, True)],
+)
+def test_te_grouped_linear_paged_stash_matches_eager_across_graph_replays(
+    cuda_buffer_factor: float,
+    host_buffer_factor: float,
+    expect_host_spill: bool,
+):
+    """Compare BF16 graph output/gradients/update with CUDA and host page reuse."""
     te = pytest.importorskip("transformer_engine.pytorch")
     stash_manager = PagedStashManager()
-    stash_manager.configure(enabled=True, page_size=2, buffer_size_factor=1.0)
+    stash_manager.configure(
+        enabled=True,
+        page_size=2,
+        buffer_size_factor=cuda_buffer_factor,
+        host_buffer_size_factor=host_buffer_factor,
+    )
     target = _GraphableTEExperts(stash_manager, te.GroupedLinear)
     optimizer = torch.optim.SGD(target.parameters(), lr=0.01)
     graph_manager = PartialCudaGraphManager(
@@ -311,7 +366,10 @@ def test_te_grouped_linear_paged_stash_matches_eager_across_graph_replays():
         stash_manager.prepare()
         graph_manager.capture()
         assert stash_manager.check_overflow().item() == 0
+        assert bool(stash_manager.check_host_spill().item()) is expect_host_spill
+        assert stash_manager.check_allocator_imbalance().item() == 0
         stash_manager.finish_iteration()
+        stash_manager.clear_host_spill()
         optimizer.zero_grad(set_to_none=True)
 
         replay_masks = (
@@ -349,7 +407,10 @@ def test_te_grouped_linear_paged_stash_matches_eager_across_graph_replays():
                 torch.testing.assert_close(parameter.grad, eager_parameter_gradients[name])
 
             assert stash_manager.check_overflow().item() == 0
+            assert bool(stash_manager.check_host_spill().item()) is expect_host_spill
+            assert stash_manager.check_allocator_imbalance().item() == 0
             stash_manager.finish_iteration()
+            stash_manager.clear_host_spill()
             if replay_index == 0:
                 optimizer.step()
                 for name, parameter in target.named_parameters():

--- a/tests/unit_tests/_transformers/test_infrastructure.py
+++ b/tests/unit_tests/_transformers/test_infrastructure.py
@@ -834,10 +834,11 @@ def test_apply_model_infrastructure_configures_dense_thd_te_for_tp_without_cp():
 def test_instantiate_infrastructure_threads_ac_scope_into_moe_parallelize_fn():
     """Expert-parallel configs must inherit the strategy config's normalized AC scope."""
     from nemo_automodel._transformers.infrastructure import instantiate_infrastructure
-    from nemo_automodel.components.distributed.config import DDPConfig
+    from nemo_automodel.components.distributed.config import DDPConfig, MoEParallelizerConfig
     from nemo_automodel.components.moe.parallelizer import parallelize_model
 
     distributed_config = DDPConfig(activation_checkpointing=True, activation_checkpointing_scope="vision")
+    moe_config = MoEParallelizerConfig(activation_checkpointing_modules=["attn"])
     mesh = SimpleNamespace(ep_size=2, pp_size=1, device_mesh=None, moe_mesh=None)
 
     # The manager needs an initialized process group; the scope is read from the
@@ -845,6 +846,7 @@ def test_instantiate_infrastructure_threads_ac_scope_into_moe_parallelize_fn():
     with patch(f"{_INFRA_MODULE}._instantiate_distributed", return_value=None):
         _, _, parallelize_fn, _ = instantiate_infrastructure(
             distributed_config=distributed_config,
+            moe_parallel_config=moe_config,
             mesh=mesh,
         )
 
@@ -852,3 +854,4 @@ def test_instantiate_infrastructure_threads_ac_scope_into_moe_parallelize_fn():
     assert parallelize_fn.keywords["activation_checkpointing"] is True
     # DDPConfig.__post_init__ normalizes the scope; the partial must carry it through.
     assert parallelize_fn.keywords["activation_checkpointing_scope"] == ("vision",)
+    assert parallelize_fn.keywords["activation_checkpointing_modules"] == ("attn",)

--- a/tests/unit_tests/components/cuda_graphs/test_partial.py
+++ b/tests/unit_tests/components/cuda_graphs/test_partial.py
@@ -754,6 +754,19 @@ def test_rejects_full_moe_with_activation_checkpointing():
         partial_graphs.PartialCudaGraphManager.from_model_parts([model], activation_checkpointing=True)
 
 
+def test_allows_full_moe_outside_attention_checkpoint_boundary():
+    model = _Model(te_dpa=False, moe=True, router=False, preprocess=False)
+    manager = partial_graphs.PartialCudaGraphManager.from_model_parts(
+        [model],
+        activation_checkpointing=True,
+        activation_checkpointing_modules=("attention",),
+    )
+
+    assert manager is not None
+    assert [entry.name for entry in manager.entries] == ["test_moe.layers.0.moe"]
+    manager.close()
+
+
 def test_rejects_pipeline_parallel_until_validated():
     with pytest.raises(RuntimeError, match="do not support pipeline parallelism yet"):
         partial_graphs.PartialCudaGraphManager.from_model_parts(

--- a/tests/unit_tests/components/cuda_graphs/test_partial.py
+++ b/tests/unit_tests/components/cuda_graphs/test_partial.py
@@ -186,6 +186,7 @@ def test_full_moe_scope_uses_explicit_parameters(monkeypatch):
 
     monkeypatch.setattr(partial_graphs, "_get_make_graphed_callables", lambda: make_graphed_callables)
     model = _Model(te_dpa=False, moe=True, router=False, preprocess=False)
+    model.model.layers["0"].mlp.experts._nemo_cuda_graph_stable_parameter_storage = True
     manager = partial_graphs.PartialCudaGraphManager.from_model_parts([model])
     assert manager is not None
     entry = manager.entries[0]
@@ -200,6 +201,7 @@ def test_full_moe_scope_uses_explicit_parameters(monkeypatch):
 
     assert entry.name == "test_moe.layers.0.moe"
     assert entry.explicit_parameters is True
+    assert entry.share_parameter_storage is True
     assert len(captured_sample_args[0][0]) == 5
     manager.close()
 
@@ -284,6 +286,43 @@ def test_explicit_parameter_adapter_uses_fresh_parameter_storage():
     adapter(*adapter.capture_inputs).sum().backward()
     assert all(parameter.grad is not None for parameter in adapter.capture_parameters)
     assert all(parameter.grad is None for parameter in target_parameters)
+
+
+def test_explicit_parameter_adapter_can_alias_stable_parameter_storage():
+    target = _Attention()
+    graph_input = torch.randn(2, 4, requires_grad=True)
+    captured_call = partial_graphs._CapturedCall.from_call((graph_input,), {})
+    adapter = partial_graphs._ExplicitParameterCallAdapter(
+        target,
+        captured_call,
+        share_parameter_storage=True,
+    )
+
+    target_parameters = tuple(target.parameters())
+    assert adapter.cloned_parameter_bytes == 0
+    assert all(capture is not target for capture, target in zip(adapter.capture_parameters, target_parameters))
+    assert all(
+        capture.data_ptr() == target.data_ptr()
+        for capture, target in zip(adapter.capture_parameters, target_parameters)
+    )
+
+    with torch.no_grad():
+        target_parameters[0].add_(1)
+    torch.testing.assert_close(adapter.capture_parameters[0], target_parameters[0])
+
+
+def test_explicit_parameter_adapter_rejects_replaced_shared_parameter_storage():
+    target = _Attention()
+    captured_call = partial_graphs._CapturedCall.from_call((torch.ones(2, 4),), {})
+    adapter = partial_graphs._ExplicitParameterCallAdapter(
+        target,
+        captured_call,
+        share_parameter_storage=True,
+    )
+    target.q_proj.weight = nn.Parameter(target.q_proj.weight.detach().clone())
+
+    with pytest.raises(RuntimeError, match="parameter storage changed"):
+        adapter.replay_inputs((torch.ones(2, 4),))
 
 
 def test_explicit_parameter_adapter_rejects_replaced_buffer_storage():
@@ -759,7 +798,20 @@ def test_allows_full_moe_outside_attention_checkpoint_boundary():
     manager = partial_graphs.PartialCudaGraphManager.from_model_parts(
         [model],
         activation_checkpointing=True,
-        activation_checkpointing_modules=("attention",),
+        activation_checkpointing_modules=("attn",),
+    )
+
+    assert manager is not None
+    assert [entry.name for entry in manager.entries] == ["test_moe.layers.0.moe"]
+    manager.close()
+
+
+def test_allows_full_moe_when_checkpointing_excludes_decoder():
+    model = _Model(te_dpa=False, moe=True, router=False, preprocess=False)
+    manager = partial_graphs.PartialCudaGraphManager.from_model_parts(
+        [model],
+        activation_checkpointing=True,
+        activation_checkpointing_scope=("vision",),
     )
 
     assert manager is not None

--- a/tests/unit_tests/moe/test_attention_only_checkpointing.py
+++ b/tests/unit_tests/moe/test_attention_only_checkpointing.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+
+import torch
+from torch import nn
+
+from nemo_automodel.components.moe.parallelizer import _apply_attention_only_ac
+
+
+class _Block(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.self_attn = nn.Linear(4, 4, bias=False)
+        self.mlp = nn.Linear(4, 4, bias=False)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Apply residual attention and MLP transformations.
+
+        Args:
+            hidden_states: Tensor of shape [batch, hidden].
+
+        Returns:
+            Tensor of shape [batch, hidden].
+        """
+        hidden_states = hidden_states + self.self_attn(hidden_states)
+        return hidden_states + self.mlp(hidden_states)
+
+
+class _Inner(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.layers = nn.ModuleList([_Block(), _Block()])
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Run decoder blocks.
+
+        Args:
+            hidden_states: Tensor of shape [batch, hidden].
+
+        Returns:
+            Tensor of shape [batch, hidden].
+        """
+        for layer in self.layers:
+            hidden_states = layer(hidden_states)
+        return hidden_states
+
+
+class _Model(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.model = _Inner()
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Run the decoder.
+
+        Args:
+            hidden_states: Tensor of shape [batch, hidden].
+
+        Returns:
+            Tensor of shape [batch, hidden].
+        """
+        return self.model(hidden_states)
+
+
+def test_attention_only_checkpointing_matches_eager_forward_and_backward() -> None:
+    torch.manual_seed(1234)
+    eager = _Model()
+    checkpointed = copy.deepcopy(eager)
+    eager_input = torch.randn(3, 4, requires_grad=True)
+    checkpointed_input = eager_input.detach().clone().requires_grad_(True)
+
+    eager_output = eager(eager_input)
+    eager_output.sum().backward()
+    _apply_attention_only_ac(checkpointed, "language")
+    checkpointed_output = checkpointed(checkpointed_input)
+    checkpointed_output.sum().backward()
+
+    torch.testing.assert_close(checkpointed_output, eager_output)
+    torch.testing.assert_close(checkpointed_input.grad, eager_input.grad)
+    for checkpointed_parameter, eager_parameter in zip(checkpointed.parameters(), eager.parameters(), strict=True):
+        torch.testing.assert_close(checkpointed_parameter.grad, eager_parameter.grad)
+    for block in checkpointed.model.layers:
+        assert hasattr(block.self_attn, "_checkpoint_wrapped_module")
+        assert not hasattr(block.mlp, "_checkpoint_wrapped_module")

--- a/tests/unit_tests/moe/test_attention_only_checkpointing.py
+++ b/tests/unit_tests/moe/test_attention_only_checkpointing.py
@@ -13,18 +13,58 @@
 # limitations under the License.
 
 import copy
+from types import SimpleNamespace
 
+import pytest
 import torch
 from torch import nn
 
 from nemo_automodel.components.moe.parallelizer import _apply_attention_only_ac
 
 
+class _Attention(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.projection = nn.Linear(4, 4, bias=False)
+        self.dropout = nn.Dropout(p=0.25)
+        self.calls = 0
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Apply projection and dropout while counting executions.
+
+        Args:
+            hidden_states: Tensor of shape [batch, hidden].
+
+        Returns:
+            Tensor of shape [batch, hidden].
+        """
+        self.calls += 1
+        return self.dropout(self.projection(hidden_states))
+
+
+class _MLP(nn.Linear):
+    def __init__(self) -> None:
+        super().__init__(4, 4, bias=False)
+        self.calls = 0
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Apply the MLP projection while counting executions.
+
+        Args:
+            hidden_states: Tensor of shape [batch, hidden].
+
+        Returns:
+            Tensor of shape [batch, hidden].
+        """
+        self.calls += 1
+        return super().forward(hidden_states)
+
+
 class _Block(nn.Module):
     def __init__(self) -> None:
         super().__init__()
-        self.self_attn = nn.Linear(4, 4, bias=False)
-        self.mlp = nn.Linear(4, 4, bias=False)
+        self.self_attn = _Attention()
+        self.mlp = _MLP()
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         """Apply residual attention and MLP transformations.
@@ -82,16 +122,31 @@ def test_attention_only_checkpointing_matches_eager_forward_and_backward() -> No
     eager_input = torch.randn(3, 4, requires_grad=True)
     checkpointed_input = eager_input.detach().clone().requires_grad_(True)
 
+    torch.manual_seed(5678)
     eager_output = eager(eager_input)
     eager_output.sum().backward()
-    _apply_attention_only_ac(checkpointed, "language")
+    eager_rng_state = torch.get_rng_state()
+    _apply_attention_only_ac(checkpointed, ("language",))
+    torch.manual_seed(5678)
     checkpointed_output = checkpointed(checkpointed_input)
     checkpointed_output.sum().backward()
+    checkpointed_rng_state = torch.get_rng_state()
 
     torch.testing.assert_close(checkpointed_output, eager_output)
     torch.testing.assert_close(checkpointed_input.grad, eager_input.grad)
+    torch.testing.assert_close(checkpointed_rng_state, eager_rng_state)
     for checkpointed_parameter, eager_parameter in zip(checkpointed.parameters(), eager.parameters(), strict=True):
         torch.testing.assert_close(checkpointed_parameter.grad, eager_parameter.grad)
     for block in checkpointed.model.layers:
         assert hasattr(block.self_attn, "_checkpoint_wrapped_module")
         assert not hasattr(block.mlp, "_checkpoint_wrapped_module")
+        assert block.self_attn._checkpoint_wrapped_module.calls == 2
+        assert block.mlp.calls == 1
+
+
+def test_attention_only_checkpointing_rejects_kv_sharing() -> None:
+    model = _Model()
+    model.config = SimpleNamespace(num_kv_shared_layers=1)
+
+    with pytest.raises(RuntimeError, match="does not support KV-sharing"):
+        _apply_attention_only_ac(model, ("language",))

--- a/tests/unit_tests/moe/test_backend_config.py
+++ b/tests/unit_tests/moe/test_backend_config.py
@@ -187,6 +187,7 @@ class TestBackendConfigExpertsDispatcherValidation:
                 cuda_graph=CudaGraphConfig(modules=["moe"], moe_capacity_factor=capacity_factor),
             )
 
+
 class TestBackendConfigFakeGateNoise:
     """Test BackendConfig fake_gate_noise field."""
 
@@ -578,13 +579,28 @@ class TestBackendConfigPartialCudaGraphs:
                 moe_paged_stash=True,
                 moe_paged_stash_page_size=0,
             )
-        for invalid_factor in (0, 0.5, float("nan"), float("inf")):
-            with pytest.raises(ValueError, match="buffer_size_factor must be finite and at least 1.0"):
+        for invalid_factor in (0, float("nan"), float("inf")):
+            with pytest.raises(ValueError, match="buffer_size_factor must be positive and finite"):
                 CudaGraphConfig(
                     modules=["moe"],
                     moe_capacity_factor=1.25,
                     moe_paged_stash=True,
                     moe_paged_stash_buffer_size_factor=invalid_factor,
+                )
+        with pytest.raises(ValueError, match="at least 1.0x total capacity"):
+            CudaGraphConfig(
+                modules=["moe"],
+                moe_capacity_factor=1.25,
+                moe_paged_stash=True,
+                moe_paged_stash_buffer_size_factor=0.5,
+            )
+        for invalid_host_factor in (-0.1, float("nan"), float("inf")):
+            with pytest.raises(ValueError, match="buffer_size_factor_cpu must be non-negative and finite"):
+                CudaGraphConfig(
+                    modules=["moe"],
+                    moe_capacity_factor=1.25,
+                    moe_paged_stash=True,
+                    moe_paged_stash_buffer_size_factor_cpu=invalid_host_factor,
                 )
 
         config = BackendConfig(
@@ -597,3 +613,17 @@ class TestBackendConfigPartialCudaGraphs:
             ),
         )
         assert config.cuda_graph.moe_paged_stash is True
+
+        spill_config = BackendConfig(
+            experts="te",
+            dispatcher="torch",
+            cuda_graph=CudaGraphConfig(
+                modules=["moe"],
+                moe_capacity_factor=1.25,
+                moe_paged_stash=True,
+                moe_paged_stash_buffer_size_factor=0.25,
+                moe_paged_stash_buffer_size_factor_cpu=0.8,
+            ),
+        )
+        assert spill_config.cuda_graph.moe_paged_stash_buffer_size_factor == 0.25
+        assert spill_config.cuda_graph.moe_paged_stash_buffer_size_factor_cpu == 0.8

--- a/tests/unit_tests/moe/test_paged_stash.py
+++ b/tests/unit_tests/moe/test_paged_stash.py
@@ -146,35 +146,94 @@ def test_recording_rejects_invalid_live_mask(live_mask):
 
 def test_configuration_is_idempotent_and_can_restart_recording():
     manager = paged_stash.PagedStashManager()
-    manager.configure(enabled=True, page_size=32, buffer_size_factor=1.25)
-    manager.configure(enabled=True, page_size=32, buffer_size_factor=1.25)
+    manager.configure(enabled=True, page_size=32, buffer_size_factor=0.25, host_buffer_size_factor=0.8)
+    manager.configure(enabled=True, page_size=32, buffer_size_factor=0.25, host_buffer_size_factor=0.8)
     with pytest.raises(RuntimeError, match="same page_size"):
-        manager.configure(enabled=True, page_size=64, buffer_size_factor=1.25)
+        manager.configure(enabled=True, page_size=64, buffer_size_factor=0.25, host_buffer_size_factor=0.8)
 
     manager.restart_recording()
     diagnostics = manager.diagnostics()
     assert diagnostics["state"] == "recording"
     assert diagnostics["page_size"] == 32
-    assert diagnostics["buffer_size_factor"] == 1.25
+    assert diagnostics["buffer_size_factor"] == 0.25
+    assert diagnostics["host_buffer_size_factor"] == 0.8
     manager.close()
 
 
-@pytest.mark.parametrize("invalid_factor", [0, 0.5, float("nan"), float("inf")])
-def test_configuration_rejects_buffer_factors_that_cannot_hold_warmup(invalid_factor):
+@pytest.mark.parametrize("invalid_factor", [0, float("nan"), float("inf")])
+def test_configuration_rejects_invalid_cuda_buffer_factors(invalid_factor):
     manager = paged_stash.PagedStashManager()
 
-    with pytest.raises(ValueError, match="finite and at least 1.0"):
+    with pytest.raises(ValueError, match="positive and finite"):
         manager.configure(enabled=True, buffer_size_factor=invalid_factor)
+
+
+@pytest.mark.parametrize("invalid_factor", [-0.1, float("nan"), float("inf")])
+def test_configuration_rejects_invalid_host_buffer_factors(invalid_factor):
+    manager = paged_stash.PagedStashManager()
+
+    with pytest.raises(ValueError, match="non-negative and finite"):
+        manager.configure(enabled=True, host_buffer_size_factor=invalid_factor)
+
+
+def test_configuration_requires_combined_capacity_for_warmup():
+    manager = paged_stash.PagedStashManager()
+
+    with pytest.raises(ValueError, match="at least 1.0x total capacity"):
+        manager.configure(enabled=True, buffer_size_factor=0.5, host_buffer_size_factor=0.4)
 
 
 def test_device_overflow_api_does_not_require_host_read():
     manager = paged_stash.PagedStashManager()
     assert manager.check_overflow() is None
+    assert manager.check_host_spill() is None
+    assert manager.check_allocator_imbalance() is None
     manager._overflow = torch.ones(1, dtype=torch.int64)
+    manager._host_spill = torch.ones(1, dtype=torch.int64)
     assert manager.check_overflow() is manager._overflow
+    assert manager.check_host_spill() is manager._host_spill
+    manager.clear_host_spill()
+    assert manager._host_spill.item() == 0
     with pytest.raises(paged_stash.PagedStashOverflowError):
         manager.finish_iteration()
     manager._overflow = None
+    manager._host_spill = None
+
+
+def test_allocator_balance_uses_ring_availability_not_equal_cursors():
+    manager = paged_stash.PagedStashManager()
+    manager._overflow = torch.zeros(1, dtype=torch.int64)
+    manager._buffers = {
+        (torch.float32, 4): SimpleNamespace(
+            head=torch.tensor([2, 3]),
+            tail=torch.tensor([7, 9]),
+            capacity=torch.tensor([5, 6]),
+        )
+    }
+
+    assert manager.check_allocator_imbalance().item() == 0
+    manager.finish_iteration()
+
+    manager._buffers[(torch.float32, 4)].tail[1] -= 1
+    assert manager.check_allocator_imbalance().item() == 1
+    with pytest.raises(RuntimeError, match="did not recover every CUDA/host page"):
+        manager.finish_iteration()
+
+
+def test_recorded_placement_accounts_for_whole_tensor_tiers():
+    manager = paged_stash.PagedStashManager()
+    key = (torch.float32, 4)
+    manager._recorded_events[key] = [
+        ("allocate", 0, 4),
+        ("allocate", 1, 6),
+        ("release", 1, 6),
+        ("release", 0, 4),
+    ]
+
+    with pytest.raises(RuntimeError, match="free pages are not fungible"):
+        manager._validate_recorded_placement(key, cuda_capacity=6, host_capacity=4)
+
+    manager._validate_recorded_placement(key, cuda_capacity=4, host_capacity=6)
 
 
 def test_reload_rejects_non_lifo_backward_order():

--- a/tests/unit_tests/moe/test_parallelizer.py
+++ b/tests/unit_tests/moe/test_parallelizer.py
@@ -1306,7 +1306,11 @@ def test_parallelize_model_calls_subsystems_and_validates(monkeypatch):
     apply_ep_mock.assert_called_once()
     # AC enabled
     apply_ac_mock.assert_called_once_with(
-        model, ignore_router=True, selective=False, activation_checkpointing_scope="all"
+        model,
+        ignore_router=True,
+        selective=False,
+        activation_checkpointing_modules=None,
+        activation_checkpointing_scope="all",
     )
     # FSDP called with combined flags and derived meshes
     args, kwargs = apply_fsdp_mock.call_args
@@ -2463,6 +2467,50 @@ def test_parallelize_model_passes_selective_to_apply_ac(monkeypatch):
     _, kwargs = apply_ac_mock.call_args
     assert kwargs.get("selective") is True
     assert kwargs.get("ignore_router") is True
+
+
+def test_apply_ac_attention_boundary_keeps_moe_outside_checkpoint(monkeypatch):
+    P = _import_parallelizer_with_stubs(monkeypatch)
+
+    class Attention(P.nn.Module):
+        pass
+
+    blocks = [DummyBlock(), DummyBlock()]
+    attentions = []
+    for block in blocks:
+        block.self_attn = Attention()
+        attentions.append(block.self_attn)
+    model = DummyModel(blocks)
+    wrappers = [object(), object()]
+    wrapper_mock = MagicMock(side_effect=wrappers)
+    monkeypatch.setattr(P, "ptd_checkpoint_wrapper", wrapper_mock)
+
+    P.apply_ac(
+        model,
+        activation_checkpointing_modules=("attention",),
+        activation_checkpointing_scope="language",
+    )
+
+    assert [call.args[0] for call in wrapper_mock.call_args_list] == attentions
+    assert all(call.kwargs == {"preserve_rng_state": True} for call in wrapper_mock.call_args_list)
+    assert [block.self_attn for block in blocks] == wrappers
+    assert all(isinstance(block.mlp, DummyMoE) for block in blocks)
+    assert model.layers.registered == {}
+
+
+def test_parallelize_model_rejects_checkpoint_modules_without_checkpointing(monkeypatch):
+    P = _import_parallelizer_with_stubs(monkeypatch)
+    world_mesh = FakeWorldMesh({("dp",): 2}, mesh_dim_names=["dp"])
+
+    with pytest.raises(ValueError, match="requires activation_checkpointing"):
+        P.parallelize_model(
+            model=DummyModel([]),
+            world_mesh=world_mesh,
+            moe_mesh=None,
+            dp_axis_names=("dp",),
+            activation_checkpointing=False,
+            activation_checkpointing_modules=("attention",),
+        )
 
 
 def test_apply_ac_selective_wraps_blocks_with_shared_policy(monkeypatch):

--- a/tests/unit_tests/moe/test_parallelizer.py
+++ b/tests/unit_tests/moe/test_parallelizer.py
@@ -807,6 +807,7 @@ def test_apply_fsdp_calls_with_ignored_params_and_shard_for_experts(monkeypatch)
     assert block_kwargs["mp_policy"] == "MP_POLICY"
     ignored = block_kwargs.get("ignored_params")
     assert isinstance(ignored, set) and len(ignored) == len(list(experts.parameters()))
+    assert not hasattr(experts, "_nemo_cuda_graph_stable_parameter_storage")
 
     # embed, post-embedding norm, lm_head and model should also be sharded on fsdp_mesh
     embed_call = _find_call_by_first_arg(fully_shard_mock, embed)
@@ -2469,48 +2470,41 @@ def test_parallelize_model_passes_selective_to_apply_ac(monkeypatch):
     assert kwargs.get("ignore_router") is True
 
 
-def test_apply_ac_attention_boundary_keeps_moe_outside_checkpoint(monkeypatch):
-    P = _import_parallelizer_with_stubs(monkeypatch)
-
-    class Attention(P.nn.Module):
-        pass
-
-    blocks = [DummyBlock(), DummyBlock()]
-    attentions = []
-    for block in blocks:
-        block.self_attn = Attention()
-        attentions.append(block.self_attn)
-    model = DummyModel(blocks)
-    wrappers = [object(), object()]
-    wrapper_mock = MagicMock(side_effect=wrappers)
-    monkeypatch.setattr(P, "ptd_checkpoint_wrapper", wrapper_mock)
-
-    P.apply_ac(
-        model,
-        activation_checkpointing_modules=("attention",),
-        activation_checkpointing_scope="language",
-    )
-
-    assert [call.args[0] for call in wrapper_mock.call_args_list] == attentions
-    assert all(call.kwargs == {"preserve_rng_state": True} for call in wrapper_mock.call_args_list)
-    assert [block.self_attn for block in blocks] == wrappers
-    assert all(isinstance(block.mlp, DummyMoE) for block in blocks)
-    assert model.layers.registered == {}
-
-
-def test_parallelize_model_rejects_checkpoint_modules_without_checkpointing(monkeypatch):
+@pytest.mark.parametrize(
+    ("activation_checkpointing", "modules", "message"),
+    [
+        (False, ("attn",), "requires activation_checkpointing"),
+        ("selective", ("attn",), "cannot be combined"),
+        (True, ("mlp",), "supports only"),
+    ],
+)
+def test_parallelize_model_rejects_invalid_checkpoint_modules_before_mutation(
+    monkeypatch,
+    activation_checkpointing,
+    modules,
+    message,
+):
     P = _import_parallelizer_with_stubs(monkeypatch)
     world_mesh = FakeWorldMesh({("dp",): 2}, mesh_dim_names=["dp"])
+    apply_ep_mock = MagicMock()
+    apply_cp_mock = MagicMock()
+    parallelize_module_mock = MagicMock()
+    monkeypatch.setattr(P, "apply_ep", apply_ep_mock)
+    monkeypatch.setattr(P, "apply_cp", apply_cp_mock)
+    monkeypatch.setattr(P, "parallelize_module", parallelize_module_mock)
 
-    with pytest.raises(ValueError, match="requires activation_checkpointing"):
+    with pytest.raises(ValueError, match=message):
         P.parallelize_model(
             model=DummyModel([]),
             world_mesh=world_mesh,
             moe_mesh=None,
             dp_axis_names=("dp",),
-            activation_checkpointing=False,
-            activation_checkpointing_modules=("attention",),
+            activation_checkpointing=activation_checkpointing,
+            activation_checkpointing_modules=modules,
         )
+    apply_ep_mock.assert_not_called()
+    apply_cp_mock.assert_not_called()
+    parallelize_module_mock.assert_not_called()
 
 
 def test_apply_ac_selective_wraps_blocks_with_shared_policy(monkeypatch):
@@ -2898,6 +2892,7 @@ def test_apply_fsdp_uses_moe_for_ignored_params(monkeypatch):
     assert isinstance(ignored, set)
     moe_params = set(moe.experts.parameters())
     assert ignored == moe_params
+    assert moe.experts._nemo_cuda_graph_stable_parameter_storage is True
 
 
 def test_parallelize_model_passes_mp_policy_to_apply_fsdp(monkeypatch):

--- a/tests/unit_tests/recipes/llm/test_benchmark.py
+++ b/tests/unit_tests/recipes/llm/test_benchmark.py
@@ -425,8 +425,11 @@ class TestBenchmarkingRecipeRunBenchmark:
             assert mock_recipe._forward_backward_step.call_count == 30 * expected_ga_steps
 
     def test_run_benchmark_zero_grads_per_iteration(self, mock_recipe):
-        """Test that gradients are zeroed at the start of each iteration."""
+        """Test that capture also clears the completed eager step's gradients."""
         mock_recipe._get_dp_group_size = MagicMock(return_value=8)
+        graph_manager = MagicMock()
+        mock_recipe.partial_cuda_graph_manager = graph_manager
+        mock_recipe._partial_cuda_graph_capture_pending = True
 
         # Mock _forward_backward_step to append loss to loss_buffer
         def mock_forward_backward_step(ga_step_idx, batch, loss_buffer=None, **kwargs):
@@ -463,8 +466,11 @@ class TestBenchmarkingRecipeRunBenchmark:
         with patch("torch.distributed.barrier"):
             mock_recipe.run_benchmark()
 
-            # Should be called 30 times (once per iteration)
-            assert mock_recipe.optimizer[0].zero_grad.call_count == 30
+            # Thirty iteration-start clears plus one post-step clear immediately
+            # before the first partial CUDA graph capture.
+            assert mock_recipe.optimizer[0].zero_grad.call_count == 31
+            assert mock_recipe.optimizer[0].zero_grad.call_args_list[1].kwargs == {"set_to_none": True}
+            graph_manager.capture.assert_called_once_with()
 
     def test_run_benchmark_optimizer_step_per_iteration(self, mock_recipe):
         """Test that optimizer step is called once per iteration."""
@@ -476,6 +482,8 @@ class TestBenchmarkingRecipeRunBenchmark:
         stash_manager = MagicMock()
         stash_manager.is_active = False
         stash_manager.check_overflow.return_value = torch.zeros(1, dtype=torch.int64)
+        stash_manager.check_host_spill.return_value = torch.zeros(1, dtype=torch.int64)
+        stash_manager.check_allocator_imbalance.return_value = torch.zeros(1, dtype=torch.int64)
 
         # Mock _forward_backward_step to append loss to loss_buffer
         def mock_forward_backward_step(ga_step_idx, batch, loss_buffer=None, **kwargs):

--- a/tests/unit_tests/recipes/test_dist_utils.py
+++ b/tests/unit_tests/recipes/test_dist_utils.py
@@ -296,6 +296,16 @@ class TestMoE:
         assert result["moe_parallel_config"].reshard_after_forward is True
         assert result["moe_parallel_config"].wrap_outer_model is False
 
+    def test_attention_checkpoint_boundary_is_normalized(self):
+        cfg = {"ep_size": 2, "moe": {"activation_checkpointing_modules": ["attention", "attention"]}}
+        result = parse_distributed_section(cfg)
+        assert result["moe_parallel_config"].activation_checkpointing_modules == ("attention",)
+
+    @pytest.mark.parametrize("modules", [[], ["mlp"], "attention", [1]])
+    def test_attention_checkpoint_boundary_rejects_unsupported_values(self, modules):
+        with pytest.raises(ValueError, match="activation_checkpointing_modules"):
+            parse_distributed_section({"ep_size": 2, "moe": {"activation_checkpointing_modules": modules}})
+
     def test_empty_moe_dict_uses_defaults(self):
         result = parse_distributed_section({"ep_size": 2, "moe": {}})
         assert isinstance(result["moe_parallel_config"], MoEParallelizerConfig)

--- a/tests/unit_tests/recipes/test_dist_utils.py
+++ b/tests/unit_tests/recipes/test_dist_utils.py
@@ -297,14 +297,45 @@ class TestMoE:
         assert result["moe_parallel_config"].wrap_outer_model is False
 
     def test_attention_checkpoint_boundary_is_normalized(self):
-        cfg = {"ep_size": 2, "moe": {"activation_checkpointing_modules": ["attention", "attention"]}}
+        cfg = {
+            "ep_size": 2,
+            "activation_checkpointing": True,
+            "moe": {"activation_checkpointing_modules": ["attn", "attn"]},
+        }
         result = parse_distributed_section(cfg)
-        assert result["moe_parallel_config"].activation_checkpointing_modules == ("attention",)
+        assert result["moe_parallel_config"].activation_checkpointing_modules == ("attn",)
+
+    def test_attention_checkpoint_boundary_requires_expert_parallelism(self):
+        with pytest.raises(ValueError, match="requires ep_size > 1"):
+            parse_distributed_section(
+                {
+                    "ep_size": 1,
+                    "activation_checkpointing": True,
+                    "moe": {"activation_checkpointing_modules": ["attn"]},
+                }
+            )
+
+    @pytest.mark.parametrize("activation_checkpointing", [False, "selective"])
+    def test_attention_checkpoint_boundary_rejects_incompatible_ac(self, activation_checkpointing):
+        with pytest.raises(ValueError, match="activation_checkpointing_modules"):
+            parse_distributed_section(
+                {
+                    "ep_size": 2,
+                    "activation_checkpointing": activation_checkpointing,
+                    "moe": {"activation_checkpointing_modules": ["attn"]},
+                }
+            )
 
     @pytest.mark.parametrize("modules", [[], ["mlp"], "attention", [1]])
     def test_attention_checkpoint_boundary_rejects_unsupported_values(self, modules):
         with pytest.raises(ValueError, match="activation_checkpointing_modules"):
-            parse_distributed_section({"ep_size": 2, "moe": {"activation_checkpointing_modules": modules}})
+            parse_distributed_section(
+                {
+                    "ep_size": 2,
+                    "activation_checkpointing": True,
+                    "moe": {"activation_checkpointing_modules": modules},
+                }
+            )
 
     def test_empty_moe_dict_uses_defaults(self):
         result = parse_distributed_section({"ep_size": 2, "moe": {}})

--- a/tests/unit_tests/recipes/test_train_ft_partial_cuda_graphs.py
+++ b/tests/unit_tests/recipes/test_train_ft_partial_cuda_graphs.py
@@ -90,6 +90,7 @@ def test_builder_forwards_runtime_safety_context(monkeypatch):
     discover.assert_called_once_with(
         model_parts,
         activation_checkpointing=True,
+        activation_checkpointing_modules=None,
         pipeline_parallel=False,
     )
     assert result is manager

--- a/tests/unit_tests/recipes/test_train_ft_partial_cuda_graphs.py
+++ b/tests/unit_tests/recipes/test_train_ft_partial_cuda_graphs.py
@@ -37,6 +37,7 @@ def _bare_recipe() -> TrainFinetuneRecipeForNextTokenPrediction:
     recipe.partial_cuda_graph_manager = None
     recipe._partial_cuda_graph_capture_pending = False
     recipe._partial_cuda_graph_paged_stash_enabled = False
+    recipe._partial_cuda_graph_logged_host_spill = False
     return recipe
 
 
@@ -91,6 +92,7 @@ def test_builder_forwards_runtime_safety_context(monkeypatch):
         model_parts,
         activation_checkpointing=True,
         activation_checkpointing_modules=None,
+        activation_checkpointing_scope=("all",),
         pipeline_parallel=False,
     )
     assert result is manager
@@ -110,11 +112,39 @@ def test_builder_does_not_use_manager_when_no_scope_is_enabled(monkeypatch):
     discover.assert_not_called()
 
 
+def test_builder_forwards_attention_checkpoint_boundary(monkeypatch):
+    model_parts = [nn.Linear(2, 2)]
+    model_parts[0].backend = SimpleNamespace(cuda_graph=SimpleNamespace(modules=["moe"]))
+    manager = SimpleNamespace(capture=MagicMock())
+    discover = MagicMock(return_value=manager)
+    monkeypatch.setattr(partial_graphs.PartialCudaGraphManager, "from_model_parts", discover)
+
+    result = _build_partial_cuda_graph_manager(
+        model_parts,
+        activation_checkpointing=True,
+        activation_checkpointing_modules=("attn",),
+        activation_checkpointing_scope=("language",),
+        pipeline_parallel=False,
+    )
+
+    discover.assert_called_once_with(
+        model_parts,
+        activation_checkpointing=True,
+        activation_checkpointing_modules=("attn",),
+        activation_checkpointing_scope=("language",),
+        pipeline_parallel=False,
+    )
+    assert result is manager
+
+
 def test_paged_stash_is_prepared_before_partial_capture(monkeypatch):
     events = []
     stash = SimpleNamespace(
         prepare=lambda: events.append("prepare"),
         check_overflow=lambda: torch.zeros(1, dtype=torch.int64),
+        check_host_spill=lambda: torch.zeros(1, dtype=torch.int64),
+        check_allocator_imbalance=lambda: torch.zeros(1, dtype=torch.int64),
+        clear_host_spill=lambda: None,
         finish_iteration=lambda: events.append("finish"),
         diagnostics=lambda: {},
         close=lambda: events.append("stash-close"),
@@ -139,15 +169,18 @@ def test_capture_overflow_is_reduced_before_all_ranks_close_graphs(monkeypatch):
     stash = SimpleNamespace(
         prepare=lambda: events.append("prepare"),
         check_overflow=lambda: torch.zeros(1, dtype=torch.int64),
+        check_host_spill=lambda: torch.zeros(1, dtype=torch.int64),
+        check_allocator_imbalance=lambda: torch.zeros(1, dtype=torch.int64),
+        clear_host_spill=lambda: None,
         finish_iteration=lambda: events.append("finish"),
         diagnostics=lambda: {},
         close=lambda: events.append("stash-close"),
     )
 
-    def all_reduce(overflow_ranks, *, op):
+    def all_reduce(rank_flags, *, op):
         assert op is torch.distributed.ReduceOp.SUM
         events.append("all-reduce")
-        overflow_ranks.fill_(2)
+        rank_flags.copy_(torch.tensor([2, 0, 0], dtype=torch.int32))
 
     monkeypatch.setattr(paged_stash, "get_paged_stash_manager", lambda: stash)
     monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
@@ -169,11 +202,73 @@ def test_capture_overflow_is_reduced_before_all_ranks_close_graphs(monkeypatch):
     assert recipe._partial_cuda_graph_paged_stash_enabled is False
 
 
+def test_paged_stash_host_spill_is_consumed_without_disabling_graphs(monkeypatch):
+    clear_host_spill = MagicMock()
+    finish_iteration = MagicMock()
+    stash = SimpleNamespace(
+        is_active=True,
+        check_overflow=lambda: torch.zeros(1, dtype=torch.int64),
+        check_host_spill=lambda: torch.ones(1, dtype=torch.int64),
+        check_allocator_imbalance=lambda: torch.zeros(1, dtype=torch.int64),
+        clear_host_spill=clear_host_spill,
+        finish_iteration=finish_iteration,
+    )
+    monkeypatch.setattr(paged_stash, "get_paged_stash_manager", lambda: stash)
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: False)
+    recipe = _bare_recipe()
+    recipe._partial_cuda_graph_paged_stash_enabled = True
+
+    loss_buffer = [torch.tensor(1.0)]
+    result = recipe._rerun_after_paged_stash_overflow(
+        ["same-batch"],
+        num_label_tokens=7,
+        loss_buffer=loss_buffer,
+        rng_state=None,
+    )
+
+    assert result is loss_buffer
+    assert recipe._partial_cuda_graph_logged_host_spill is True
+    clear_host_spill.assert_called_once_with()
+    finish_iteration.assert_called_once_with()
+
+
+def test_paged_stash_allocator_imbalance_disables_graphs(monkeypatch):
+    events = []
+    stash = SimpleNamespace(
+        is_active=True,
+        check_overflow=lambda: torch.zeros(1, dtype=torch.int64),
+        check_host_spill=lambda: torch.zeros(1, dtype=torch.int64),
+        check_allocator_imbalance=lambda: torch.ones(1, dtype=torch.int64),
+        clear_host_spill=lambda: events.append("clear-host-spill"),
+        close=lambda: events.append("stash-close"),
+    )
+    monkeypatch.setattr(paged_stash, "get_paged_stash_manager", lambda: stash)
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: False)
+    recipe = _bare_recipe()
+    recipe.partial_cuda_graph_manager = SimpleNamespace(close=lambda: events.append("graph-close"))
+    recipe._partial_cuda_graph_capture_pending = False
+    recipe._partial_cuda_graph_paged_stash_enabled = True
+
+    with pytest.raises(RuntimeError, match="did not recover every CUDA/host page"):
+        recipe._rerun_after_paged_stash_overflow(
+            ["same-batch"],
+            num_label_tokens=7,
+            loss_buffer=[torch.tensor(1.0)],
+            rng_state=None,
+        )
+
+    assert events == ["clear-host-spill", "graph-close", "stash-close"]
+    assert recipe.partial_cuda_graph_manager is None
+
+
 def test_paged_stash_overflow_closes_graph_discards_gradients_and_reruns(monkeypatch):
     events = []
     stash = SimpleNamespace(
         is_active=True,
         check_overflow=lambda: torch.ones(1, dtype=torch.int64),
+        check_host_spill=lambda: torch.zeros(1, dtype=torch.int64),
+        check_allocator_imbalance=lambda: torch.zeros(1, dtype=torch.int64),
+        clear_host_spill=lambda: None,
         close=lambda: events.append("stash-close"),
     )
     monkeypatch.setattr(paged_stash, "get_paged_stash_manager", lambda: stash)
@@ -225,6 +320,9 @@ def test_overflow_retry_reproduces_python_numpy_and_torch_rng(monkeypatch):
     stash = SimpleNamespace(
         is_active=True,
         check_overflow=lambda: torch.ones(1, dtype=torch.int64),
+        check_host_spill=lambda: torch.zeros(1, dtype=torch.int64),
+        check_allocator_imbalance=lambda: torch.zeros(1, dtype=torch.int64),
+        clear_host_spill=lambda: None,
         close=lambda: None,
     )
     monkeypatch.setattr(paged_stash, "get_paged_stash_manager", lambda: stash)


### PR DESCRIPTION
## Summary

This is the fifth PR in the partial CUDA graph stack and is based on #2944.

- add an attention-only activation-checkpoint boundary so full MoE graphs remain outside checkpoint recompute;
- avoid a second long-lived copy of EP-local expert parameters when their storage is already stable;
- add an opt-in two-tier paged stash that uses CUDA pages first and spills whole saved tensors to pinned host memory;
- make the stash allocation plan deterministic across ranks and fail closed on overflow or allocator imbalance;
- release benchmark gradients before graph capture to reduce avoidable capture-time pressure.

This targets the MoE-specific work tracked by #1027. It does not add full-iteration CUDA graphs.

## Why

At Qwen3-235B scale, attention and MoE graphs can both capture, but the graph-private pools, MoE saved tensors, activation checkpoint recompute, and FSDP2 gradient buffers do not fit together under the existing full-block checkpoint boundary. The structural boundary in this PR checkpoints attention while leaving MoE forward/backward and its paged saved-tensor lifecycle outside recompute.

Pinned-host spill is a last-resort capacity tier. The allocator preserves a fixed capture contract: allocation order is recorded during iteration 0, CUDA and host capacities are prepared before capture, CUDA is preferred, and overflow or cross-rank disagreement raises instead of silently changing replay semantics.

## Qwen3-235B S4096 result

Environment: 8 nodes x 4 GB200 (32 GPUs), BF16, Qwen3-235B-A22B, S4096, LBS1, GBS2048, GA64, EP32, TE attention/experts, HybridEP, attention-only AC, mock data, 2 warmup + 3 measured steps. The jobs used tree `c961ce5e`; the current signed-off head `e1729dec` is code-identical.

Both sides use `defer_fsdp_grad_sync: false`. The graph side enables `[te_dpa, moe]`, capacity factor 1.0, and a tuned paged stash with 0.90x CUDA + 0.15x pinned-host capacity.

| Mode | Step time | MFU | Label tokens/s | Peak allocated |
|---|---:|---:|---:|---:|
| Eager | 78.529 s | 19.767% | 106,795 | 135.85 GB |
| TE DPA + MoE graphs | 62.498 s | 24.837% | 134,189 | 170.01 GB |

- step time: **-20.41%**;
- throughput: **+25.65%**;
- peak allocated memory: **+34.16 GB/GPU**;
- loss samples match exactly between the paired runs: `12.1905, 12.1905, 12.1905, 12.0654, 12.0654`;
- 188 entries captured (94 attention + 94 MoE), 72,192 replays, 0 contract fallbacks;
- planned stash capacity: 25,548,816,384 CUDA bytes and 4,258,529,280 pinned-host bytes; all 32 ranks reported host spill.

The spill ratio matters. A feasibility setting with 0.01x CUDA + 1.04x host completed at 114.513 s/step, so host capacity should be kept to the minimum needed for the workload.

### Memory findings

- The standard S4096/LBS4/full-AC eager recipe completes at 213.712 s/step, 29.053% MFU, and 130.87 GB peak allocated.
- Full-AC TE DPA captured all 94 attention entries, then OOMed during checkpoint replay at about 182.14 GiB process memory.
- Attention-only AC with device-only TE DPA + MoE graphs also captured and replayed all entries, but missed a backward allocation by less than 1 GiB.
- `reshard_after_forward: true` lowered forward residency but did not remove the backward peak.
- Immediate FSDP grad sync removes unsharded accumulated-gradient residency; a small pinned-host stash tier then provides the remaining replay headroom.

## Validation

- local focused/unit suite: 399 passed, 3 skipped;
- full-repository Ruff format/check and `git diff --check` pass;
- single-H100 real CUDA graph test: 4 passed, 1 skipped, including forced pinned-host TE GroupedLinear replay parity for outputs, input/routing/parameter gradients, and optimizer updates;
- 8x H100 Qwen3-MoE 30B S4096 A/B: 0.5523 s eager vs 0.4971 s graph (+11.11% throughput), 96 captures, 4,176 replays, 0 fallbacks;
- 32x GB200 Qwen3-235B result above: complete benchmark, 0 fallbacks.

## Scope and limitations

- opt-in only; default behavior is unchanged;
- decoder structural checkpoint scope currently supports `attn` only;
- PP, CP, packing, KV sharing, and full-block AC with full MoE graphs remain unsupported or unvalidated;
- the 235B result is a short performance/parity benchmark, not a convergence claim;
- pinned-host spill is capacity-sensitive and may regress performance when over-provisioned.

Stack: #2917 -> #2932 -> #2943 -> #2944 -> this PR.
