### PR TITLE
docs: explain embedding row repair

### DIFF
--- a/docs/guides/configuration.mdx
+++ b/docs/guides/configuration.mdx
@@ -5,9 +5,6 @@ position: 4
 ---
 NeMo AutoModel recipes use YAML configs. The YAML parser creates a `ConfigNode` that performs the following actions:
 
-- Translates common scalar strings into typed Python values (e.g., `"10"` → `10`).
-- Resolves `_target_` (and `*_fn`) into Python callables/classes.
-- Supports environment variable interpolation inside YAML strings.
 - Translates common scalar strings into typed Python values (for example, `"10"` → `10`)
 - Resolves `_target_` and `*_fn` into Python callables and classes
 - Supports environment variable interpolation inside YAML strings

--- a/docs/guides/configuration.mdx
+++ b/docs/guides/configuration.mdx
@@ -3,16 +3,19 @@ title: "YAML Configuration"
 description: ""
 position: 4
 ---
-NeMo AutoModel recipes are configured with YAML. Under the hood, YAML is parsed into a `ConfigNode` which:
+NeMo AutoModel recipes use YAML configs. The YAML parser creates a `ConfigNode` that performs the following actions:
 
 - Translates common scalar strings into typed Python values (e.g., `"10"` → `10`).
 - Resolves `_target_` (and `*_fn`) into Python callables/classes.
 - Supports environment variable interpolation inside YAML strings.
-- Tries to make config printing safe by preserving original placeholders (to avoid leaking secrets).
+- Translates common scalar strings into typed Python values (for example, `"10"` → `10`)
+- Resolves `_target_` and `*_fn` into Python callables and classes
+- Supports environment variable interpolation inside YAML strings
+- Makes config printing safer by preserving original placeholders to avoid leaking secrets
 
 ## Load Model and Dataset Configs
 
-Most recipes load YAML configs by using `nemo_automodel.components.config.loader.load_yaml_config()`, which returns a `ConfigNode`.
+Most recipes load YAML configs using `nemo_automodel.components.config.loader.load_yaml_config()`, which returns a `ConfigNode`.
 
 A `ConfigNode` handles values as follows:
 
@@ -56,6 +59,7 @@ Target resolution is intentionally permissive and should be treated as code exec
 
 <Warning>
 Only load configuration files and `_target_` values from trusted sources. A YAML file that names an importable package or Python file can execute arbitrary Python code during target resolution.
+
 </Warning>
 
 ## Distributed Section (Strategy-Based)
@@ -64,7 +68,7 @@ The `distributed:` section is **not** instantiated using `_target_`. Recipes par
 
 ## Prewarm One-Time CUDA Initialization
 
-The LLM training/fine-tuning and VLM fine-tuning recipes accept an optional `prewarm:` section:
+The LLM training, LLM fine-tuning, and VLM fine-tuning recipes accept an optional `prewarm:` section:
 
 ```yaml
 prewarm:
@@ -88,7 +92,7 @@ Adding GPUs helps only when it sufficiently reduces the relevant per-rank tensor
 
 ## Repair Near-Zero Input Embeddings
 
-The LLM training/fine-tuning recipe can repair a small number of damaged input-embedding rows after loading the base checkpoint and before creating the optimizer:
+The LLM training and fine-tuning recipe can repair a small number of damaged input-embedding rows after loading the base checkpoint and before creating the optimizer:
 
 ```yaml
 embedding_row_repair:

--- a/docs/guides/configuration.mdx
+++ b/docs/guides/configuration.mdx
@@ -100,6 +100,8 @@ Rows with a non-finite L2 norm or a norm at or below `min_norm` are replaced wit
 
 This option is intended for diagnosed checkpoint defects where rare token IDs produce extreme input-embedding gradients. It is disabled when the section is absent and is not currently supported with pipeline parallelism.
 
+For diagnosis, safety behavior, verification steps, and performance impact, see [Repair Damaged Input-Embedding Rows](/model-coverage/troubleshooting#repair-damaged-input-embedding-rows).
+
 ## Interpolate Environment Variables in YAML
 
 NeMo AutoModel supports env var interpolation inside YAML **string values**.

--- a/docs/model-coverage/overview.mdx
+++ b/docs/model-coverage/overview.mdx
@@ -9,13 +9,6 @@ NeMo AutoModel integrates with Hugging Face `transformers`. Any LLM or VLM that 
 
 | Auto Class | Task | Status | Details |
 |------------|------|--------|---------|
-| `AutoModelForCausalLM` | Text Generation (LLM) | Supported | See [LLM model list](/model-coverage/large-language-models/overview). |
-| Block-Diffusion LLMs | Text Generation (Diffusion LLM) | Supported | See [Diffusion LLM model list](/model-coverage/dllm/overview). |
-| `AutoModelForImageTextToText` | Image-Text-to-Text (VLM) | Supported | See [VLM model list](/model-coverage/vision-language-models/overview). |
-| Custom multimodal models | Unified multimodal training | Supported | See [Multimodal model list](/model-coverage/multimodal/overview). |
-| `AutoModelForSequenceClassification` | Sequence Classification | WIP | Early support; interfaces may change. |
-| Diffusers Pipelines | Diffusion Generation (T2I, T2V) | Supported | See [Diffusion model list](/model-coverage/diffusion/overview). |
-| `NeMoAutoModelBiEncoder` | Embedding Models | Supported | See [Embedding model list](/model-coverage/embedding-models/overview). |
 | `AutoModelForCausalLM` | Text Generation (LLM) | Supported | See [LLM model list](/model-coverage/large-language-models/overview) |
 | Block-Diffusion LLMs | Text Generation (Diffusion LLM) | Supported | See [Diffusion LLM model list](/model-coverage/dllm/overview) |
 | `AutoModelForImageTextToText` | Image-Text-to-Text (VLM) | Supported | See [VLM model list](/model-coverage/vision-language-models/overview) |
@@ -31,8 +24,6 @@ The table below tracks when model support and key features were added across NeM
 
 | Release | Date | New Models | Key Features |
 |---------|------|------------|--------------|
-| **0.3.0** (upcoming) | — | Kimi-VL, Kimi-K25-VL, Gemma 3n, Nemotron-Parse, Qwen3-VL-MoE, Qwen3-Omni, InternVL 3.5, Ministral3, Phi-4-multimodal, Devstral-Small-2, Step-3.5-Flash, Qwen3-Next, Nemotron-3-Nano-30B, FLUX.1-dev, Wan 2.1 T2V, HunyuanVideo 1.5 | MoE LoRA, expanded VLM coverage, diffusion model training (flow matching) |
-| **0.2.0** | Dec 2025 | GPT-OSS 20B/120B, Qwen3, Qwen3-MoE, GLM-4/4-MoE, Qwen2.5-VL, Qwen3-VL | Single- and multi-turn tool calling, streaming dataset, QAT for SFT, sequence classification, async DCP checkpointing, MLflow, CP + sequence packing for MoE |
 | **0.3.0** (upcoming) | Not announced | Kimi-VL, Kimi-K25-VL, Gemma 3n, Nemotron-Parse, Qwen3-VL-MoE, Qwen3-Omni, InternVL 3.5, Ministral3, Phi-4-multimodal, Devstral-Small-2, Step-3.5-Flash, Qwen3-Next, Nemotron-3-Nano-30B, FLUX.1-dev, Wan 2.1 T2V, HunyuanVideo 1.5 | MoE LoRA, expanded VLM coverage, diffusion model training (flow matching) |
 | **0.2.0** | Dec 2025 | GPT-OSS 20B/120B, Qwen3, Qwen3-MoE, GLM-4/4-MoE, Qwen2.5-VL, Qwen3-VL | Single- and multi-turn tool calling, streaming dataset, QAT for SFT, sequence classification, async DCP checkpointing, MLflow, CP and sequence packing for MoE |
 | **0.1.0** | Oct 2025 | DeepSeek V3/V3.2, more than 40 LLM architectures, Gemma 3 VLM | Pretraining, knowledge distillation, FP8 (torchao), pipeline parallelism, HSDP, auto pipelining, ColumnMapped dataset |

--- a/docs/model-coverage/overview.mdx
+++ b/docs/model-coverage/overview.mdx
@@ -45,4 +45,4 @@ NeMo AutoModel includes a custom model registry that allows teams to:
 
 ## Having Issues?
 
-If a model from the Hub doesn't work as expected, see the [Troubleshooting Unsupported Models](/model-coverage/overview) guide for common issues and solutions.
+If a model from the Hub doesn't work as expected, see [Troubleshooting Models and First Runs](/model-coverage/troubleshooting) for common issues and solutions.

--- a/docs/model-coverage/overview.mdx
+++ b/docs/model-coverage/overview.mdx
@@ -3,7 +3,7 @@ title: "Model Coverage Overview"
 description: ""
 position: 1
 ---
-NeMo AutoModel integrates with Hugging Face `transformers`. Any LLM or VLM that can be instantiated through `transformers` can also be used using NeMo AutoModel, subject to runtime, third-party software dependencies, and feature compatibility.
+NeMo AutoModel integrates with Hugging Face `transformers`. Any LLM or VLM that can be instantiated through `transformers` can also be used with NeMo AutoModel, subject to runtime, third-party software dependencies, and feature compatibility.
 
 ## Supported Hugging Face Auto Classes
 
@@ -16,7 +16,14 @@ NeMo AutoModel integrates with Hugging Face `transformers`. Any LLM or VLM that 
 | `AutoModelForSequenceClassification` | Sequence Classification | WIP | Early support; interfaces may change. |
 | Diffusers Pipelines | Diffusion Generation (T2I, T2V) | Supported | See [Diffusion model list](/model-coverage/diffusion/overview). |
 | `NeMoAutoModelBiEncoder` | Embedding Models | Supported | See [Embedding model list](/model-coverage/embedding-models/overview). |
-| `NeMoAutoModelCrossEncoder` | Reranking Models | Supported | See [Reranking model list](/model-coverage/reranking-models/overview). |
+| `AutoModelForCausalLM` | Text Generation (LLM) | Supported | See [LLM model list](/model-coverage/large-language-models/overview) |
+| Block-Diffusion LLMs | Text Generation (Diffusion LLM) | Supported | See [Diffusion LLM model list](/model-coverage/dllm/overview) |
+| `AutoModelForImageTextToText` | Image-Text-to-Text (VLM) | Supported | See [VLM model list](/model-coverage/vision-language-models/overview) |
+| Custom multimodal models | Unified multimodal training | Supported | See [Multimodal model list](/model-coverage/multimodal/overview) |
+| `AutoModelForSequenceClassification` | Sequence Classification | Work in Progress | Early support. Interfaces might change |
+| Diffusers Pipelines | Diffusion Generation (T2I, T2V) | Supported | See [Diffusion model list](/model-coverage/diffusion/overview) |
+| `NeMoAutoModelBiEncoder` | Embedding Models | Supported | See [Embedding model list](/model-coverage/embedding-models/overview) |
+| `NeMoAutoModelCrossEncoder` | Reranking Models | Supported | See [Reranking model list](/model-coverage/reranking-models/overview) |
 
 ## Release Log
 
@@ -26,14 +33,16 @@ The table below tracks when model support and key features were added across NeM
 |---------|------|------------|--------------|
 | **0.3.0** (upcoming) | — | Kimi-VL, Kimi-K25-VL, Gemma 3n, Nemotron-Parse, Qwen3-VL-MoE, Qwen3-Omni, InternVL 3.5, Ministral3, Phi-4-multimodal, Devstral-Small-2, Step-3.5-Flash, Qwen3-Next, Nemotron-3-Nano-30B, FLUX.1-dev, Wan 2.1 T2V, HunyuanVideo 1.5 | MoE LoRA, expanded VLM coverage, diffusion model training (flow matching) |
 | **0.2.0** | Dec 2025 | GPT-OSS 20B/120B, Qwen3, Qwen3-MoE, GLM-4/4-MoE, Qwen2.5-VL, Qwen3-VL | Single- and multi-turn tool calling, streaming dataset, QAT for SFT, sequence classification, async DCP checkpointing, MLflow, CP + sequence packing for MoE |
-| **0.1.0** | Oct 2025 | DeepSeek V3/V3.2, 40+ LLM architectures, Gemma 3 VLM | Pretraining, knowledge distillation, FP8 (torchao), pipeline parallelism, HSDP, auto pipelining, ColumnMapped dataset |
+| **0.3.0** (upcoming) | Not announced | Kimi-VL, Kimi-K25-VL, Gemma 3n, Nemotron-Parse, Qwen3-VL-MoE, Qwen3-Omni, InternVL 3.5, Ministral3, Phi-4-multimodal, Devstral-Small-2, Step-3.5-Flash, Qwen3-Next, Nemotron-3-Nano-30B, FLUX.1-dev, Wan 2.1 T2V, HunyuanVideo 1.5 | MoE LoRA, expanded VLM coverage, diffusion model training (flow matching) |
+| **0.2.0** | Dec 2025 | GPT-OSS 20B/120B, Qwen3, Qwen3-MoE, GLM-4/4-MoE, Qwen2.5-VL, Qwen3-VL | Single- and multi-turn tool calling, streaming dataset, QAT for SFT, sequence classification, async DCP checkpointing, MLflow, CP and sequence packing for MoE |
+| **0.1.0** | Oct 2025 | DeepSeek V3/V3.2, more than 40 LLM architectures, Gemma 3 VLM | Pretraining, knowledge distillation, FP8 (torchao), pipeline parallelism, HSDP, auto pipelining, ColumnMapped dataset |
 | **0.1.0a0** | Sep 2025 | Initial LLM and VLM support (Llama, Mistral, Qwen2, Gemma, Phi, and more) | MegatronFSDP, packed sequences, Triton LoRA kernels |
 
 ## Day-0 Support
 
 - NeMo AutoModel closely tracks the latest `transformers` version and updates its dependency regularly.
 - New models released on the Hugging Face Hub may require the latest `transformers` version, necessitating a package upgrade.
-- We are working on a CI pipeline that automatically bumps the supported `transformers` version when a new release is detected, enabling even faster day-0 support.
+- The team is developing a CI pipeline that automatically updates the supported `transformers` version when a new release is detected, enabling faster day-0 support.
 
 
 ## Custom Model Registry
@@ -45,4 +54,4 @@ NeMo AutoModel includes a custom model registry that allows teams to:
 
 ## Having Issues?
 
-If a model from the Hub doesn't work as expected, see [Troubleshooting Models and First Runs](/model-coverage/troubleshooting) for common issues and solutions.
+If a model from the Hub does not work as expected, see [Troubleshooting Models and First Runs](/model-coverage/troubleshooting) for common issues and solutions.

--- a/docs/model-coverage/troubleshooting.mdx
+++ b/docs/model-coverage/troubleshooting.mdx
@@ -2,8 +2,8 @@
 title: "Troubleshooting Models and First Runs"
 description: "Diagnose model-loading failures and checkpoint-specific training instability."
 ---
-Sometimes a model listed on the Hugging Face Hub may not work with NeMo AutoModel.
-If you encounter any such model, please open a [GitHub issue](https://github.com/NVIDIA-NeMo/Automodel/issues) with the model ID and any stack trace you see.
+A model listed on the Hugging Face Hub might not work with NeMo AutoModel.
+If you encounter such a model, open a [GitHub issue](https://github.com/NVIDIA-NeMo/Automodel/issues) with the model ID and any stack trace you see.
 
 ## Common Issues
 
@@ -12,15 +12,18 @@ If you encounter any such model, please open a [GitHub issue](https://github.com
 | Model has explicitly disabled training in its definition code | — | Request support via a [GitHub issue](https://github.com/NVIDIA-NeMo/Automodel/issues). We can add the model through our custom registry. |
 | Model requires a newer `transformers` version | `The checkpoint you are trying to load has model type deepseek_v32 but Transformers does not recognize this architecture.` | Upgrade `transformers` (and NeMo AutoModel if needed), or open a GitHub issue. |
 | Model upper-bounds `transformers`, requiring an older version | — | Open a [GitHub issue](https://github.com/NVIDIA-NeMo/Automodel/issues). |
-| Unsupported checkpoint format | `OSError: meta-llama/Llama-2-70b does not appear to have a file named pytorch_model.bin, model.safetensors, ...` | Open a GitHub issue or request the model publisher to share a SafeTensors checkpoint. |
+| Model has explicitly disabled training in its definition code | Not provided | Request support through a [GitHub issue](https://github.com/NVIDIA-NeMo/Automodel/issues). Support can be added through the custom registry |
+| Model requires a newer `transformers` version | `The checkpoint you are trying to load has model type deepseek_v32 but Transformers does not recognize this architecture.` | Upgrade `transformers` (and NeMo AutoModel if needed), or open a GitHub issue |
+| Model upper-bounds `transformers`, requiring an older version | Not provided | Open a [GitHub issue](https://github.com/NVIDIA-NeMo/Automodel/issues) |
+| Unsupported checkpoint format | `OSError: meta-llama/Llama-2-70b does not appear to have a file named pytorch_model.bin, model.safetensors, ...` | Open a GitHub issue or request that the model publisher share a SafeTensors checkpoint |
 
 These cases typically stem from upstream packaging or dependency constraints. You would encounter the same issues when using `transformers` directly, as AutoModel mirrors the familiar load and fine-tune semantics.
 
 ## Steps to Try
 
 1. **Upgrade NeMo AutoModel** to a release that supports the required `transformers` version. See [Install NeMo AutoModel](/get-started/installation).
-2. **Enable remote code** — if the model uses custom code, set `trust_remote_code: true` in your `model:` config. See [Hugging Face API Compatibility](/get-started/hf-compatibility).
-3. **Open a GitHub issue** with the model ID and error so we can prioritize support or add a registry-backed implementation.
+2. **Enable remote code** if the model uses custom code by setting `trust_remote_code: true` in your `model:` config. See [Hugging Face API Compatibility](/get-started/hf-compatibility).
+3. **Open a GitHub issue** with the model ID and error so that the team can prioritize support or add a registry-backed implementation.
 
 ## Repair Damaged Input-Embedding Rows
 
@@ -30,6 +33,7 @@ Gradient clipping does not repair the checkpoint. A very large but finite global
 
 <Warning>
 Use embedding-row repair only for a diagnosed checkpoint defect. It does not correct NaNs caused by invalid data, an unstable loss, an unsuitable precision mode, optimizer state, or another model operation.
+
 </Warning>
 
 ### Why Rare Tokens Expose the Problem Late
@@ -44,11 +48,11 @@ An isolated input-embedding defect is likely when several of these observations 
 
 - The same architecture and data train from random initialization, but training from a particular checkpoint fails.
 - The checkpoint fails in more than one training framework.
-- Failure occurs when a rare token ID first appears; full-vocabulary mock data reproduces it much earlier than real data.
+- Failure occurs when a rare token ID first appears. Full-vocabulary mock data reproduces it much earlier than real data.
 - Most input-embedding rows have similar norms, while a small set is zero, non-finite, or separated from the healthy distribution by several orders of magnitude.
 - The corresponding output rows in `lm_head` are finite and have healthy norms.
 
-Inspect the checkpoint and choose `min_norm` from the observed gap between damaged and healthy rows. There is no model-independent threshold. The [Nemotron Nano 4B example](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/llm_finetune/nemotron/nemotron_nano_4b_squad.yaml) uses `1.0e-4` for its diagnosed checkpoint; the component default is `1.0e-6`.
+Inspect the checkpoint and choose `min_norm` from the observed gap between damaged and healthy rows. There is no model-independent threshold. The [Nemotron Nano 4B example](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/llm_finetune/nemotron/nemotron_nano_4b_squad.yaml) uses `1.0e-4` for its diagnosed checkpoint. The component default is `1.0e-6`.
 
 ### Enable the Repair
 
@@ -66,7 +70,7 @@ The section is optional and repair is disabled when it is absent. When the secti
 - `min_norm` is an inclusive L2-norm threshold. Rows with non-finite norms or norms less than or equal to this value are considered damaged.
 - `max_rows` is a safety bound, not an expected repair count. Setup stops before changing weights when more rows are damaged.
 
-During setup, the LLM training and fine-tuning recipe:
+During setup, the LLM training and fine-tuning recipe performs these steps:
 
 1. Scans the input embedding after checkpoint loading and model sharding, but before optimizer construction.
 2. Collects and logs the damaged global token IDs.
@@ -78,6 +82,7 @@ The operation supports regular tensors and DTensors with replicated or sharded v
 
 <Info>
 Repair changes the in-memory model and is included in checkpoints saved by the training run. It does not modify the source checkpoint.
+
 </Info>
 
 ### Interpret Setup Results
@@ -92,7 +97,7 @@ Setup fails instead of guessing when:
 - A corresponding output row is also damaged.
 - Pipeline parallelism is enabled.
 
-Do not increase `max_rows` merely to bypass the safety error. First verify the checkpoint source, model configuration, tokenizer vocabulary, and input/output embedding shapes. Broad damage usually indicates a mismatched or corrupted checkpoint rather than isolated bad rows.
+Do not increase `max_rows` merely to bypass the safety error. First verify the checkpoint source, model configuration, tokenizer vocabulary, and input and output embedding shapes. Broad damage usually indicates a mismatched or corrupted checkpoint rather than isolated bad rows.
 
 ### Verify Training
 

--- a/docs/model-coverage/troubleshooting.mdx
+++ b/docs/model-coverage/troubleshooting.mdx
@@ -32,6 +32,12 @@ Gradient clipping does not repair the checkpoint. A very large but finite global
 Use embedding-row repair only for a diagnosed checkpoint defect. It does not correct NaNs caused by invalid data, an unstable loss, an unsuitable precision mode, optimizer state, or another model operation.
 </Warning>
 
+### Why Rare Tokens Expose the Problem Late
+
+A rare token is the trigger, not the defect. Its input-embedding row is already damaged in the checkpoint. Because an input embedding receives a gradient only when its token ID is present in a batch, a damaged row for a frequent token fails early while a damaged row for a rare token can remain hidden for hundreds of steps. Full-vocabulary mock data samples those IDs much sooner and therefore reproduces the failure quickly.
+
+Rarity by itself does not mean an embedding is damaged. Reserved or domain-specific tokens can be uncommon and still have healthy rows. Diagnose rows from their non-finite or anomalously small norms and confirm that the corresponding output rows are usable.
+
 ### Diagnose the Failure
 
 An isolated input-embedding defect is likely when several of these observations agree:
@@ -100,4 +106,4 @@ If gradients remain non-finite or extreme after repair, stop and investigate the
 
 ### Performance Impact
 
-Embedding-row repair performs one embedding-table scan and a small number of distributed reductions during setup. It installs no per-step hook and does not rescan rows during training. After setup, gradient clipping follows the normal training path without repeatedly scaling healthy model gradients because of the repaired rows.
+Embedding-row repair performs one embedding-table scan and a small number of distributed reductions during setup. It repairs every row that meets the configured damage threshold, whether its token is frequent, rare, or absent from the current dataset. It deliberately does not count corpus frequencies, install a per-step hook, or rescan rows during training. After setup, gradient clipping follows the normal training path without repeatedly scaling healthy model gradients because of the repaired rows.

--- a/docs/model-coverage/troubleshooting.mdx
+++ b/docs/model-coverage/troubleshooting.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Troubleshooting Unsupported Models"
-description: ""
+title: "Troubleshooting Models and First Runs"
+description: "Diagnose model-loading failures and checkpoint-specific training instability."
 ---
 Sometimes a model listed on the Hugging Face Hub may not work with NeMo AutoModel.
 If you encounter any such model, please open a [GitHub issue](https://github.com/NVIDIA-NeMo/Automodel/issues) with the model ID and any stack trace you see.
@@ -21,3 +21,83 @@ These cases typically stem from upstream packaging or dependency constraints. Yo
 1. **Upgrade NeMo AutoModel** to a release that supports the required `transformers` version. See [Install NeMo AutoModel](/get-started/installation).
 2. **Enable remote code** — if the model uses custom code, set `trust_remote_code: true` in your `model:` config. See [Hugging Face API Compatibility](/get-started/hf-compatibility).
 3. **Open a GitHub issue** with the model ID and error so we can prioritize support or add a registry-backed implementation.
+
+## Repair Damaged Input-Embedding Rows
+
+A pretrained checkpoint can contain a small number of input-embedding rows with zero, near-zero, or non-finite norms. Training can appear healthy until one of the corresponding token IDs occurs. That token can then produce an extreme embedding gradient and dominate the global gradient norm.
+
+Gradient clipping does not repair the checkpoint. A very large but finite global norm causes clipping to scale every parameter gradient down, including otherwise healthy gradients. Lowering the learning rate or clipping threshold can therefore make training stop learning without removing the source of the instability.
+
+<Warning>
+Use embedding-row repair only for a diagnosed checkpoint defect. It does not correct NaNs caused by invalid data, an unstable loss, an unsuitable precision mode, optimizer state, or another model operation.
+</Warning>
+
+### Diagnose the Failure
+
+An isolated input-embedding defect is likely when several of these observations agree:
+
+- The same architecture and data train from random initialization, but training from a particular checkpoint fails.
+- The checkpoint fails in more than one training framework.
+- Failure occurs when a rare token ID first appears; full-vocabulary mock data reproduces it much earlier than real data.
+- Most input-embedding rows have similar norms, while a small set is zero, non-finite, or separated from the healthy distribution by several orders of magnitude.
+- The corresponding output rows in `lm_head` are finite and have healthy norms.
+
+Inspect the checkpoint and choose `min_norm` from the observed gap between damaged and healthy rows. There is no model-independent threshold. The [Nemotron Nano 4B example](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/llm_finetune/nemotron/nemotron_nano_4b_squad.yaml) uses `1.0e-4` for its diagnosed checkpoint; the component default is `1.0e-6`.
+
+### Enable the Repair
+
+Add `embedding_row_repair` at the recipe root:
+
+```yaml
+embedding_row_repair:
+  enabled: true
+  min_norm: 1.0e-4
+  max_rows: 256
+```
+
+The section is optional and repair is disabled when it is absent. When the section is present, `enabled` defaults to `true`.
+
+- `min_norm` is an inclusive L2-norm threshold. Rows with non-finite norms or norms less than or equal to this value are considered damaged.
+- `max_rows` is a safety bound, not an expected repair count. Setup stops before changing weights when more rows are damaged.
+
+During setup, the LLM training and fine-tuning recipe:
+
+1. Scans the input embedding after checkpoint loading and model sharding, but before optimizer construction.
+2. Collects and logs the damaged global token IDs.
+3. Verifies that the output embedding has a matching layout and that each corresponding output row is healthy.
+4. Uses each output row's direction as the replacement and scales it to the RMS norm of healthy input rows.
+5. Verifies the repaired rows before training starts.
+
+The operation supports regular tensors and DTensors with replicated or sharded vocabulary and hidden dimensions. It does not gather the complete embedding table onto one rank.
+
+<Info>
+Repair changes the in-memory model and is included in checkpoints saved by the training run. It does not modify the source checkpoint.
+</Info>
+
+### Interpret Setup Results
+
+Rank zero logs the affected token IDs, the minimum input-row norm before repair, and the target norm. If no row crosses the threshold, setup logs that result and leaves the embedding unchanged.
+
+Setup fails instead of guessing when:
+
+- The number of damaged rows exceeds `max_rows`.
+- A separate output embedding cannot be found.
+- Input and output embedding shapes or distributed layouts do not match.
+- A corresponding output row is also damaged.
+- Pipeline parallelism is enabled.
+
+Do not increase `max_rows` merely to bypass the safety error. First verify the checkpoint source, model configuration, tokenizer vocabulary, and input/output embedding shapes. Broad damage usually indicates a mismatched or corrupted checkpoint rather than isolated bad rows.
+
+### Verify Training
+
+Run a short job with representative data and, when practical, a full-vocabulary mock dataset that reaches rare token IDs quickly. Confirm that:
+
+- Setup reports the expected repaired token IDs.
+- Losses and gradient norms remain finite when those IDs occur.
+- Gradient norms remain in the same general range as steps that do not contain repaired IDs.
+
+If gradients remain non-finite or extreme after repair, stop and investigate the wider forward and backward path. Do not mask the failure by increasing the clipping threshold.
+
+### Performance Impact
+
+Embedding-row repair performs one embedding-table scan and a small number of distributed reductions during setup. It installs no per-step hook and does not rescan rows during training. After setup, gradient clipping follows the normal training path without repeatedly scaling healthy model gradients because of the repaired rows.

--- a/docs/model-coverage/troubleshooting.mdx
+++ b/docs/model-coverage/troubleshooting.mdx
@@ -9,9 +9,6 @@ If you encounter such a model, open a [GitHub issue](https://github.com/NVIDIA-N
 
 | Issue | Example Error | Solution |
 |-------|---------------|----------|
-| Model has explicitly disabled training in its definition code | — | Request support via a [GitHub issue](https://github.com/NVIDIA-NeMo/Automodel/issues). We can add the model through our custom registry. |
-| Model requires a newer `transformers` version | `The checkpoint you are trying to load has model type deepseek_v32 but Transformers does not recognize this architecture.` | Upgrade `transformers` (and NeMo AutoModel if needed), or open a GitHub issue. |
-| Model upper-bounds `transformers`, requiring an older version | — | Open a [GitHub issue](https://github.com/NVIDIA-NeMo/Automodel/issues). |
 | Model has explicitly disabled training in its definition code | Not provided | Request support through a [GitHub issue](https://github.com/NVIDIA-NeMo/Automodel/issues). Support can be added through the custom registry |
 | Model requires a newer `transformers` version | `The checkpoint you are trying to load has model type deepseek_v32 but Transformers does not recognize this architecture.` | Upgrade `transformers` (and NeMo AutoModel if needed), or open a GitHub issue |
 | Model upper-bounds `transformers`, requiring an older version | Not provided | Open a [GitHub issue](https://github.com/NVIDIA-NeMo/Automodel/issues) |


### PR DESCRIPTION
## Summary

- explain why rare tokens can delay exposure of an already damaged embedding row
- document how damaged input-embedding rows can dominate global gradient clipping
- explain how to diagnose the checkpoint defect and configure `embedding_row_repair`
- document repair behavior, fail-fast safeguards, distributed support, verification, and startup-only performance cost
- cross-link the detailed guidance from the YAML configuration reference
- fix the existing model-coverage troubleshooting link

## Placement

The detailed guidance belongs in **Troubleshooting Models and First Runs** because this is an opt-in recovery path for a diagnosed checkpoint defect, not a normal step in random-initialization pretraining. The configuration guide remains the concise schema reference and links to the troubleshooting workflow.

This follows the implementation merged in #3136.

## Validation

- `make -C docs/fern docs-mdx-check`: validated 292 MDX files
- `npx -y fern-api@5.29.0 check`: 0 errors
- `git diff --check`: passed

Fern emitted only the environment warning that redirect validation is skipped without Fern authentication.