### PR TITLE
feat(checkpoint): preserve intrinsic fp32 during offline consolidation

### DIFF
--- a/nemo_automodel/components/checkpoint/_backports/consolidate_hf_safetensors.py
+++ b/nemo_automodel/components/checkpoint/_backports/consolidate_hf_safetensors.py
@@ -145,11 +145,24 @@ def _resolve_output_dtype(
 ) -> tuple[torch.dtype, str]:
     """Resolve the output dtype for a tensor.
 
-    Explicit cast_dtype wins for ordinary floating-point tensors. Otherwise,
-    original HF dtype metadata restores ordinary floating-point tensors per FQN
-    when available; checkpoints without that metadata keep the saved dtype.
+    Per-FQN fp32 metadata is an intrinsic model contract and remains authoritative
+    when ``cast_dtype`` is set. The explicit cast wins for other ordinary
+    floating-point tensors. Without a cast, per-FQN metadata restores ordinary
+    floating-point tensors when available; checkpoints without that metadata keep
+    the saved dtype.
     """
     source_dtype = _get_known_dtype(source_dtype_str)
+    mapped_dtype_str = fqn_to_dtype_mapping.get(fqn) if fqn_to_dtype_mapping else None
+    mapped_dtype = _get_known_dtype(mapped_dtype_str) if mapped_dtype_str is not None else None
+
+    if (
+        cast_dtype is not None
+        and mapped_dtype_str is not None
+        and mapped_dtype is torch.float32
+        and _is_regular_floating_dtype(source_dtype)
+    ):
+        return mapped_dtype, mapped_dtype_str
+
     if cast_dtype is not None:
         output_dtype = cast_dtype if _should_cast_dtype(source_dtype, cast_dtype) else source_dtype
         output_dtype_str = (
@@ -157,21 +170,19 @@ def _resolve_output_dtype(
         )
         return output_dtype, output_dtype_str
 
-    if not fqn_to_dtype_mapping or fqn not in fqn_to_dtype_mapping:
+    if mapped_dtype is None or mapped_dtype_str is None:
         return source_dtype, source_dtype_str
 
-    original_dtype_str = fqn_to_dtype_mapping[fqn]
-    original_dtype = _get_known_dtype(original_dtype_str)
-    if original_dtype == source_dtype:
+    if mapped_dtype == source_dtype:
         return source_dtype, source_dtype_str
 
-    if _is_regular_floating_dtype(original_dtype) and torch.empty((), dtype=source_dtype).is_floating_point():
-        return original_dtype, original_dtype_str
+    if _is_regular_floating_dtype(mapped_dtype) and torch.empty((), dtype=source_dtype).is_floating_point():
+        return mapped_dtype, mapped_dtype_str
 
     # If a quantized/packed original tensor was saved as float, keep the float
     # value as a dequantized export instead of pretending we can restore packing.
     if torch.empty((), dtype=source_dtype).is_floating_point() and quantized_dtype_mismatches is not None:
-        quantized_dtype_mismatches.append((fqn, original_dtype_str, source_dtype_str))
+        quantized_dtype_mismatches.append((fqn, mapped_dtype_str, source_dtype_str))
     return source_dtype, source_dtype_str
 
 
@@ -893,15 +904,16 @@ def consolidate_safetensors_files(
                     temporary files will be created in this directory instead of the system temp.
                     Only used when use_staging=True. Useful when system temp has limited space.
         cast_dtype: Optional dtype used to cast floating-point tensors during consolidation.
-        fqn_to_dtype_mapping: Optional mapping from tensor FQN to original HF safetensors dtype string.
+        fqn_to_dtype_mapping: Optional mapping from tensor FQN to target safetensors dtype string. This can combine
+            original HF dtype metadata with model-owned export overrides.
     """
     start_time = time.time()
     logger.info("Consolidating safetensors files from %s to %s.", input_dir, output_dir)
     if cast_dtype is not None:
         logger.info(
             "Requested cast dtype %s for consolidation. Only ordinary floating-point tensors with a different "
-            "source dtype will be cast; tensors already in this dtype, FP8 tensors, and non-floating tensors "
-            "are unchanged.",
+            "source dtype will be cast; tensors mapped to FP32, tensors already in this dtype, FP8 tensors, and "
+            "non-floating tensors are unchanged.",
             cast_dtype,
         )
 
@@ -957,7 +969,8 @@ def consolidate_safetensors_files_on_every_rank(
                     temporary files will be created in this directory instead of the system temp.
                     Only used when use_staging=True. Useful when system temp has limited space.
         cast_dtype: Optional dtype used to cast floating-point tensors during consolidation.
-        fqn_to_dtype_mapping: Optional mapping from tensor FQN to original HF safetensors dtype string.
+        fqn_to_dtype_mapping: Optional mapping from tensor FQN to target safetensors dtype string. This can combine
+            original HF dtype metadata with model-owned export overrides.
     """
 
     start_time = time.time()
@@ -975,8 +988,8 @@ def consolidate_safetensors_files_on_every_rank(
         if cast_dtype is not None:
             logger.info(
                 "Requested cast dtype %s for consolidation. Only ordinary floating-point tensors with a different "
-                "source dtype will be cast; tensors already in this dtype, FP8 tensors, and non-floating tensors "
-                "are unchanged.",
+                "source dtype will be cast; tensors mapped to FP32, tensors already in this dtype, FP8 tensors, and "
+                "non-floating tensors are unchanged.",
                 cast_dtype,
             )
 

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -1459,31 +1459,29 @@ fi
         self, model_state: ModelState, state_dict: dict[str, torch.Tensor]
     ) -> Optional[dict[str, str]]:
         """
-        Build FQN to original HF safetensors dtype mapping for consolidated export.
+        Build FQN to target safetensors dtype mapping for consolidated export.
 
-        Returns None when the run started from config-only weights or the original HF
-        safetensors headers are not available. In that case consolidation keeps the
-        saved checkpoint dtype unless the user explicitly passes CAST_DTYPE to the
-        offline helper.
+        Original HF safetensors headers provide the baseline mapping when available.
+        Model-owned adapter overrides are applied even for config-only runs so
+        intrinsically fp32 tensors retain their required export dtype.
         """
         if not _should_write_hf_metadata(self.config):
             return None
 
+        model = _unwrap_ddp_model(model_state.model[0])
+        normalized_dtype_mapping: dict[str, str] = {}
         reference_path = _get_hf_safetensors_reference_path(
             self.config.model_cache_dir,
             self.config.model_repo_id,
         )
-        if not reference_path:
-            return None
-
-        model = model_state.model[0]
-        dtype_mapping = get_fqn_to_dtype_mapping(reference_path, getattr(model, "_checkpoint_conversion_mapping", None))
-        if not dtype_mapping:
-            return None
-
-        normalized_dtype_mapping = _normalize_dtype_mapping_to_state_dict_keys(
-            dtype_mapping, list(state_dict.keys()), getattr(model, "base_model_prefix", None)
-        )
+        if reference_path:
+            dtype_mapping = get_fqn_to_dtype_mapping(
+                reference_path, getattr(model, "_checkpoint_conversion_mapping", None)
+            )
+            if dtype_mapping:
+                normalized_dtype_mapping = _normalize_dtype_mapping_to_state_dict_keys(
+                    dtype_mapping, list(state_dict.keys()), getattr(model, "base_model_prefix", None)
+                )
         normalized_dtype_mapping = _apply_adapter_forced_dtype_mapping(model, state_dict, normalized_dtype_mapping)
         return normalized_dtype_mapping or None
 

--- a/tests/unit_tests/checkpoint/test_checkpointing.py
+++ b/tests/unit_tests/checkpoint/test_checkpointing.py
@@ -621,6 +621,45 @@ def test_original_dtype_mapping_applies_adapter_forced_dtypes(tmp_path):
     }
 
 
+def test_original_dtype_mapping_applies_adapter_forced_dtypes_without_hf_reference(tmp_path):
+    config = CheckpointingConfig(
+        enabled=True,
+        checkpoint_dir=str(tmp_path),
+        model_save_format="safetensors",
+        model_cache_dir=str(tmp_path / "cache"),
+        model_repo_id="",
+        save_consolidated=False,
+        is_peft=False,
+    )
+
+    class Adapter:
+        def forced_hf_dtype_mapping(self, state_dict):
+            assert set(state_dict) == {
+                "backbone.layers.0.mixer.A_log",
+                "backbone.layers.0.mixer.in_proj.weight",
+            }
+            return {
+                "backbone.layers.0.mixer.A_log": "F32",
+                "absent.weight": "F32",
+            }
+
+    with patch("torch.distributed.is_initialized", return_value=False):
+        checkpointer = Checkpointer(config, dp_rank=0, tp_rank=0, pp_rank=0, moe_mesh=None)
+    model_state = SimpleNamespace(model=[SimpleNamespace(state_dict_adapter=Adapter())])
+    state_dict = {
+        "backbone.layers.0.mixer.A_log": torch.ones(1, dtype=torch.float32),
+        "backbone.layers.0.mixer.in_proj.weight": torch.ones(1, dtype=torch.float32),
+    }
+
+    with patch(
+        "nemo_automodel.components.checkpoint.checkpointing._get_hf_safetensors_reference_path",
+        return_value=None,
+    ):
+        dtype_mapping = checkpointer._maybe_build_original_dtype_mapping(model_state, state_dict)
+
+    assert dtype_mapping == {"backbone.layers.0.mixer.A_log": "F32"}
+
+
 def test_summarize_state_dict_key_diff_reports_missing_and_unexpected():
     summary = _summarize_state_dict_key_diff(
         {"a.weight", "b.bias", "c.weight"},

--- a/tests/unit_tests/checkpoint/test_consolidate_safetensors.py
+++ b/tests/unit_tests/checkpoint/test_consolidate_safetensors.py
@@ -271,6 +271,55 @@ def test_consolidate_cast_dtype_does_not_cast_fp8_tensors(tmp_path):
 
 
 @pytest.mark.run_only_on("CPU")
+def test_consolidate_cast_dtype_preserves_mapped_fp32_tensors(tmp_path):
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+    output_dir.mkdir()
+
+    tensors = {
+        "protected_fp32_weight": torch.arange(4, dtype=torch.float32),
+        "ordinary_weight": torch.arange(4, dtype=torch.float32),
+        "ordinary_with_original_dtype": torch.arange(4, dtype=torch.float32),
+    }
+    dcp_metadata = {name: {"saved_offsets": [0 for _ in tensor.shape]} for name, tensor in tensors.items()}
+    save_file(
+        tensors,
+        input_dir / "model-00001-of-00001.safetensors",
+        metadata={CUSTOM_METADATA_KEY: json.dumps(dcp_metadata)},
+    )
+
+    consolidate_safetensors_files(
+        input_dir=str(input_dir),
+        output_dir=str(output_dir),
+        fqn_to_index_mapping={name: 1 for name in tensors},
+        cast_dtype=torch.float16,
+        fqn_to_dtype_mapping={
+            "protected_fp32_weight": "F32",
+            "ordinary_with_original_dtype": "BF16",
+        },
+    )
+
+    output_tensors = load_file(output_dir / "model-00001-of-00001.safetensors")
+    assert output_tensors["protected_fp32_weight"].dtype is torch.float32
+    assert output_tensors["ordinary_weight"].dtype is torch.float16
+    assert output_tensors["ordinary_with_original_dtype"].dtype is torch.float16
+    torch.testing.assert_close(output_tensors["protected_fp32_weight"], tensors["protected_fp32_weight"])
+    torch.testing.assert_close(output_tensors["ordinary_weight"], tensors["ordinary_weight"].to(torch.float16))
+    torch.testing.assert_close(
+        output_tensors["ordinary_with_original_dtype"], tensors["ordinary_with_original_dtype"].to(torch.float16)
+    )
+
+    with open(output_dir / "model.safetensors.index.json", "r") as f:
+        index = json.load(f)
+    expected_total_size = (
+        tensors["protected_fp32_weight"].numel() * 4
+        + (tensors["ordinary_weight"].numel() + tensors["ordinary_with_original_dtype"].numel()) * 2
+    )
+    assert index["metadata"]["total_size"] == expected_total_size
+
+
+@pytest.mark.run_only_on("CPU")
 def test_consolidate_preserves_original_hf_float_dtypes_when_available(tmp_path):
     input_dir = tmp_path / "input"
     output_dir = tmp_path / "output"

--- a/tools/offline_hf_consolidation.py
+++ b/tools/offline_hf_consolidation.py
@@ -158,7 +158,8 @@ def parse_args() -> argparse.Namespace:
         help=(
             "Optional dtype for floating-point tensors in the consolidated checkpoint. "
             "Supported aliases include bf16, bfloat16, fp16, float16, fp32, and float32. "
-            "Integer tensors keep their original dtype."
+            "Tensors marked as intrinsically fp32 by model export metadata remain fp32; "
+            "FP8 and non-floating tensors keep their original dtype."
         ),
     )
     return parser.parse_args()


### PR DESCRIPTION
## Summary

This is a minor checkpoint-export feature aimed primarily at config-only pretraining runs. The offline Hugging Face consolidation tool can now produce a mostly-BF16 checkpoint with `--cast-dtype bf16` while preserving tensors that AutoModel explicitly requires to remain FP32.

When a run starts from an HF checkpoint, the original per-tensor dtype metadata remains the baseline. For pretraining from config, model-owned dtype overrides are now recorded even when no original HF safetensors are available. During offline consolidation, those intrinsic FP32 entries take precedence over the broad export cast; other ordinary floating-point tensors still use the requested dtype.

## Why

Pretraining users often save distributed checkpoints first and create a consolidated HF checkpoint offline. Requesting a BF16 export should reduce checkpoint size without violating the model's stricter precision contract for protected tensors.

## Validation

- 201 checkpoint and offline-consolidation unit tests passed
- Ruff formatting and lint checks passed
- Real Qwen3.5 0.8B two-shard DCP checkpoint consolidated with `--cast-dtype bf16`:
  - 452 BF16 tensors
  - 36 checkpoint-mapped FP32 tensors preserved on disk
  - 102 uint8 tensors
  - exported config reloads locally through `AutoConfig`
  - full Hugging Face and AutoModel weight reloads completed on H100
  - both loaders completed the same deterministic text forward pass
  - AutoModel restored its stricter 452-BF16/36-FP32 runtime contract, which intentionally differs from the older checkpoint's HF-oriented dtype mapping
  - Hugging Face and AutoModel logits had 0.999812 cosine similarity

## Tracking

[AM-398](https://linear.app/nvidia/issue/AM-398/minor-feature-make-offline-hf-ckpt-consolidate-tool-preserve-intrinsic)
