### PR TITLE
test(packing): fix stale unsupported-backend test after fa3/fa4 support

### DIFF
--- a/tests/unit_tests/models/common/test_packing.py
+++ b/tests/unit_tests/models/common/test_packing.py
@@ -145,7 +145,7 @@ class TestGetAttnImplementation:
 
 
 class TestConfigurePacking:
-    @pytest.mark.parametrize("attn_implementation", ["sdpa", "flash_attention_3"])
+    @pytest.mark.parametrize("attn_implementation", ["sdpa", "eager"])
     def test_noop_for_unsupported_backends(self, attn_implementation, monkeypatch):
         """configure_packing should not install FA2 shims for unsupported backends."""
         patch_preprocess = MagicMock()
@@ -158,8 +158,9 @@ class TestConfigurePacking:
 
         patch_preprocess.assert_not_called()
 
-    def test_patches_flash_attention_utils(self):
-        """configure_packing should patch _get_unpad_data for flash_attention_2."""
+    @pytest.mark.parametrize("attn_implementation", ["flash_attention_2", "flash_attention_3", "flash_attention_4"])
+    def test_patches_flash_attention_utils(self, attn_implementation):
+        """configure_packing should patch _get_unpad_data for every flash-attention variant."""
         import transformers.masking_utils as masking_utils
         import transformers.modeling_flash_attention_utils as fa_utils
 
@@ -167,7 +168,7 @@ class TestConfigurePacking:
         original_preprocess = masking_utils._preprocess_mask_arguments
         original_flag = getattr(masking_utils, "_nemo_automodel_packing_preprocess_patched", None)
         try:
-            configure_packing("flash_attention_2")
+            configure_packing(attn_implementation)
             assert fa_utils._get_unpad_data is get_unpad_data
         finally:
             fa_utils._get_unpad_data = original


### PR DESCRIPTION
## What

`tests/unit_tests/models/common/test_packing.py::TestConfigurePacking::test_noop_for_unsupported_backends[flash_attention_3]` fails on `main`:

```
AssertionError: Expected 'mock' to not have been called. Called 1 times.
```

## Why

PR #2929 (flash_attention_3 / flash_attention_4 support) added both variants to `_FLASH_ATTN_IMPLEMENTATIONS`, so `configure_packing` now patches the FA2 shim for `flash_attention_3` as well. The test still parametrized `flash_attention_3` as an "unsupported" backend and asserted `_patch_preprocess_mask_arguments_for_packing` was **not** called, so it started failing once fa3 became a supported (patched) backend. The test simply went stale; the production code is correct.

## Fix

- `test_noop_for_unsupported_backends`: replace `flash_attention_3` with genuinely unpatched backends (`sdpa`, `eager`), so the no-op assertion holds.
- `test_patches_flash_attention_utils`: parametrize over `flash_attention_2`, `flash_attention_3`, `flash_attention_4` so the newly supported fa3/fa4 patch paths from #2929 actually have coverage.

Test-only change; no production code touched.

## Testing

```
pytest tests/unit_tests/models/common/test_packing.py::TestConfigurePacking::test_noop_for_unsupported_backends
pytest tests/unit_tests/models/common/test_packing.py::TestConfigurePacking::test_patches_flash_attention_utils
# 5 passed
```

`ruff format` + `ruff check` clean.
