### PR TITLE
docs(fern): add legacy URL redirects

### DIFF
--- a/docs/fern/docs.yml
+++ b/docs/fern/docs.yml
@@ -59,6 +59,22 @@ redirects:
     destination: "/nemo/automodel/v0.4"
   - source: "/nemo/automodel/index"
     destination: "/nemo/automodel/v0.4"
+  # Legacy Sphinx page aliases. Keep these exact mappings before the version
+  # and global catch-alls so moved pages resolve in a single redirect.
+  - source: "/nemo/automodel/latest/guides/vlm/gemma4"
+    destination: "/nemo/automodel/latest/recipes-e2e-examples/gemma-4"
+  - source: "/nemo/automodel/latest/guides/omni/gemma3-3n"
+    destination: "/nemo/automodel/latest/recipes-e2e-examples/gemma-3-3n"
+  - source: "/nemo/automodel/latest/apidocs/nemo_automodel/nemo_automodel.components.moe.uccl_ep"
+    destination: "/nemo/automodel/latest/nemo-automodel/nemo_automodel/components/moe/uccl_ep"
+  - source: "/nemo/automodel/latest/apidocs/nemo_automodel/nemo_automodel.components.training.timers"
+    destination: "/nemo/automodel/latest/nemo-automodel/nemo_automodel/components/training/timers"
+  - source: "/nemo/automodel/latest/launcher/cluster"
+    destination: "/nemo/automodel/latest/job-launchers/slurm-cluster"
+  - source: "/nemo/automodel/nightly/performance-summary"
+    destination: "/nemo/automodel/nightly/performance/performance-summary"
+  - source: "/nemo/automodel/latest/guides/configuration"
+    destination: "/nemo/automodel/latest/get-started/configuration"
   # Version-root index.html / index — explicit because :path* does not match
   # the empty-path case (NVIDIA-NeMo/Curator#1938). Must fire before the
   # :path*/index.html catch-alls below.


### PR DESCRIPTION
# What does this PR do ?

Adds permanent Fern redirects for seven legacy Sphinx URLs that currently return 404 after the Fern migration. Each redirect points directly to the corresponding live Fern page.

# Changelog

- Redirect legacy Gemma 3, Gemma 4, configuration, launcher, and performance URLs.
- Redirect legacy Sphinx API-reference URLs for UCCL-EP and training timers.
- Keep the exact mappings ahead of the version and global catch-all rules.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] No code tests are required for this docs-only configuration change.
- [x] Updated the Fern redirect configuration.

# Validation

- `make -C docs/fern docs-check` — 292 MDX files validated, 0 errors, 1 expected warning because local redirect validation requires Fern authentication.
- `git diff --check`
- Confirmed all seven redirect destinations return HTTP 200.

# Additional Information

The old URLs use the former Sphinx navigation and API-module path shapes. Fern publishes these pages under new navigation slugs and generated API-reference paths, so explicit redirects are required to preserve existing bookmarks and search traffic.
