### PR TITLE
feat(glm_moe_dsa): expose update_moe_gate_bias on GLM MoE DSA models

### DIFF
--- a/nemo_automodel/components/models/glm_moe_dsa/model.py
+++ b/nemo_automodel/components/models/glm_moe_dsa/model.py
@@ -258,6 +258,13 @@ class GlmMoeDsaModel(nn.Module):
             if layer is not None:
                 layer.init_weights(buffer_device=buffer_device)
 
+    def update_moe_gate_bias(self) -> None:
+        """Update the noaux router correction bias of each local MoE layer; dense layers and disabled gates are skipped."""
+        with torch.no_grad():
+            for block in self.layers.values():
+                if isinstance(block.mlp, MoE) and block.mlp.gate.bias_update_factor > 0:
+                    block.mlp.gate.update_bias()
+
 
 class GlmMoeDsaForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
     tie_word_embeddings_support: TieSupport = TieSupport.UNTIED_ONLY
@@ -330,6 +337,10 @@ class GlmMoeDsaForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
 
     def set_output_embeddings(self, new_embeddings):
         self.lm_head = new_embeddings
+
+    def update_moe_gate_bias(self) -> None:
+        """Delegate the noaux router correction-bias update to the inner model."""
+        self.model.update_moe_gate_bias()
 
     def should_pack_validation_with_training(self) -> bool:
         """GLM DSA TileLang kernels require validation to use the THD packed layout."""

--- a/tests/unit_tests/models/glm_moe_dsa/test_glm_moe_dsa_model.py
+++ b/tests/unit_tests/models/glm_moe_dsa/test_glm_moe_dsa_model.py
@@ -580,3 +580,32 @@ class TestIndexShare:
         assert captured["prev_dtype"] == torch.int64  # carry-in cast float32 -> int64 before model
         assert isinstance(out, tuple) and len(out) == 2
         assert out[1].dtype == torch.float32  # carry-out emitted as float32
+
+
+class TestUpdateMoeGateBias:
+    def test_updates_every_local_moe_gate_via_outer_model(self, config, backend_config):
+        """Outer hook delegates to the inner model and updates each sparse layer's gate once."""
+        model = GlmMoeDsaForCausalLM(config, backend=backend_config)
+        moe_layers = [layer for layer in model.model.layers.values() if isinstance(layer.mlp, MoE)]
+        assert len(moe_layers) == 2  # config has 2 sparse + 2 dense layers
+
+        mocks = [patch.object(layer.mlp.gate, "update_bias").start() for layer in moe_layers]
+        try:
+            model.update_moe_gate_bias()
+        finally:
+            patch.stopall()
+        for mock in mocks:
+            mock.assert_called_once_with()
+
+    @pytest.mark.parametrize("kwargs", [{"moe_overrides": {"gate_bias_update_factor": 0.0}}, {}])
+    def test_no_update_when_bias_update_disabled(self, config, backend_config, kwargs):
+        """factor=0 overrides and FakeBalancedGate (factor 0.0) must not call update_bias."""
+        if not kwargs:
+            backend_config.fake_balanced_gate = True
+        model = GlmMoeDsaForCausalLM(config, backend=backend_config, **kwargs)
+        for layer in model.model.layers.values():
+            if isinstance(layer.mlp, MoE):
+                assert layer.mlp.gate.bias_update_factor == 0.0
+                with patch.object(layer.mlp.gate, "update_bias") as mock:
+                    model.update_moe_gate_bias()
+                    mock.assert_not_called()


### PR DESCRIPTION
GLM-5.2 uses noaux_tc MoE load balancing: the FP32 e_score_correction_bias must be updated from per-expert token counts after each optimizer step, but neither GlmMoeDsaModel nor GlmMoeDsaForCausalLM exposed update_moe_gate_bias, so the recipe-side hasattr hook never fired and the bias was never updated.


# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
