### PR TITLE
fix(vlm): size qwen3.6 medpix CI configs

### DIFF
--- a/examples/vlm_finetune/qwen3_5/qwen3_6_27b_medpix_cp1_2k_2node_100steps.yaml
+++ b/examples/vlm_finetune/qwen3_5/qwen3_6_27b_medpix_cp1_2k_2node_100steps.yaml
@@ -115,3 +115,9 @@ wandb:
   group: qwen3_6_27b_medpix_dense_cp_parity_2k_2node_100steps
   tags: [qwen3.6-27b, medpix, dense, cp1, 2k, 2node, parity]
   dir: logs/qwen3_6_27b_medpix_cp1_2k_2node_100steps/wandb
+
+ci:
+  recipe_owner: HuiyingLi
+  nodes: 2
+  time: "00:30:00"
+  max_steps: 10

--- a/examples/vlm_finetune/qwen3_5/qwen3_6_27b_medpix_cp2_2k_2node_100steps.yaml
+++ b/examples/vlm_finetune/qwen3_5/qwen3_6_27b_medpix_cp2_2k_2node_100steps.yaml
@@ -115,3 +115,9 @@ wandb:
   group: qwen3_6_27b_medpix_dense_cp_parity_2k_2node_100steps
   tags: [qwen3.6-27b, medpix, dense, cp2, 2k, 2node, parity]
   dir: logs/qwen3_6_27b_medpix_cp2_2k_2node_100steps/wandb
+
+ci:
+  recipe_owner: HuiyingLi
+  nodes: 2
+  time: "00:30:00"
+  max_steps: 10


### PR DESCRIPTION
## Summary
- Add explicit CI sizing to the Qwen3.6 27B MedPix CP1/CP2 2-node recipes.
- Set `nodes: 2`, `time: "00:30:00"`, and `max_steps: 10` for the scoped CI proof shape.

## Root cause
The affected recipes were introduced by AutoModel commit `ba4ec358fecfec3bc3524a3e8a56677a2815878b` but did not include a top-level `ci:` block. Release auto-discovery therefore generated the CP2 job with the default `TEST_NODE_COUNT=1` / `--time 00:10:00`, even though the recipe name and parallelism shape are 2-node.

With `tp_size: 4` and `cp_size: 2`, the one-node run had only 8 GPUs and no practical DP/FSDP shard headroom for this 27B VLM workload. It failed as an OOM-class NCCL/CUDA allocation during distributed reduction: `torch.distributed.DistBackendError` / `Failed to CUDA calloc async 8 bytes`.

## Why this is happening now
This is not an old stable recipe that regressed later. The 2-node MedPix CP recipes were added by `ba4ec358fecfec3bc3524a3e8a56677a2815878b` in the July 19 scheduled CI image. Because the recipe was auto-discovered without a `ci:` block, the first scheduled release run used the default one-node shape and exposed the undersized config.

## Validation
- `git diff --check`
- `uv run python tests/ci_tests/utils/validate_generate_ci.py --automodel-dir .`
- `uv run python tests/ci_tests/utils/generate_ci_tests.py --automodel-dir . --scope release --test-folder vlm_finetune`
  - generated CP1/CP2 jobs include `TEST_NODE_COUNT: 2`, `TIME: "00:30:00"`, and `MAX_STEPS: 10`.

## NeMo-CI
- Reproduced with original failed image: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/372758119
  - original image: `gitlab-master.nvidia.com/dl/joc/nemo-ci/main/automodel:pipe.58641818`
  - generated Slurm shape: `-N 1 --time 00:10:00`
  - failure: `torch.distributed.DistBackendError` / `Failed to CUDA calloc async 8 bytes`
- Same-container fixed proof, 10 steps: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/372773249
  - original image reused: `gitlab-master.nvidia.com/dl/joc/nemo-ci/main/automodel:pipe.58641818`
  - generated Slurm shape: `-N 2 --time 00:30:00`
  - distributed shape: `WORLD_SIZE=16`
  - config/progress: `max_steps: 10`, `Max train steps: 10`, `Training: 100% | 10/10`
  - result: `Job succeeded`