### PR TITLE
fix(glm): size GLM5.2 release CI jobs

### DIFF
--- a/examples/llm_finetune/glm/glm_5.2_tulu3_32k_tilelang_cp8.yaml
+++ b/examples/llm_finetune/glm/glm_5.2_tulu3_32k_tilelang_cp8.yaml
@@ -110,3 +110,9 @@ optimizer:
 #   project: <your_wandb_project>
 #   entity: <your_wandb_entity>
 #   name: <your_wandb_exp_name>
+
+ci:
+  # 32k CP8 reaches the divisibility floor at 32 nodes, but needs 64 nodes to avoid OOM.
+  recipe_owner: huiyingl
+  nodes: 64
+  time: "01:00:00"

--- a/examples/llm_finetune/glm/glm_5.2_tulu3_4k_tilelang_100k.yaml
+++ b/examples/llm_finetune/glm/glm_5.2_tulu3_4k_tilelang_100k.yaml
@@ -108,3 +108,9 @@ optimizer:
 #   project: <your_wandb_project>
 #   entity: <your_wandb_entity>
 #   name: <your_wandb_exp_name>
+
+ci:
+  # pp4 with ep64 requires 256 ranks.
+  recipe_owner: huiyingl
+  nodes: 32
+  time: "01:00:00"


### PR DESCRIPTION
# What does this PR do ?

Size the GLM-5.2 Tulu3 TileLang release CI jobs to the distributed topology declared in their recipes, so release auto-discovery does not generate impossible one-node jobs.

Root cause: these recipes were auto-discovered by release CI without top-level `ci:` resource metadata, so generated jobs defaulted to one 8-GPU node. That cannot satisfy the mesh constraints for `pp_size: 4`, `cp_size: 8`, and/or `ep_size: 64`. The 32k CP8 recipe also needs 64 nodes in practice: 32 nodes satisfies the divisibility floor but OOMs during training.

# Changelog

- Add `ci.recipe_owner`, `ci.nodes: 64`, and `ci.time: "01:00:00"` to `glm_5.2_tulu3_32k_tilelang_cp8`.
- Add `ci.recipe_owner`, `ci.nodes: 32`, and `ci.time: "01:00:00"` to `glm_5.2_tulu3_4k_tilelang_100k`.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

Validation:

- `uv run python tests/ci_tests/utils/validate_new_recipe_ci.py --automodel-dir . examples/llm_finetune/glm/glm_5.2_tulu3_32k_tilelang_cp8.yaml examples/llm_finetune/glm/glm_5.2_tulu3_4k_tilelang_100k.yaml`
- `uv run python tests/ci_tests/utils/validate_generate_ci.py --automodel-dir .`
- Generated release jobs now emit:
  - `glm_5.2_tulu3_32k_tilelang_cp8`: `TEST_NODE_COUNT=64`, `TIME=01:00:00`, `RECIPE_OWNER=huiyingl`
  - `glm_5.2_tulu3_4k_tilelang_100k`: `TEST_NODE_COUNT=32`, `TIME=01:00:00`, `RECIPE_OWNER=huiyingl`
- `uv run ruff format --check .`
- `uv run ruff check .`

Same-container NeMo-CI proof on final commit `21703aac076491c276d874d1f01a9b364f85d929`:

- Reused old image `gitlab-master.nvidia.com/dl/joc/nemo-ci/main/automodel:pipe.56857516`; no fresh AutoModel image was built.
- Mounted the final AutoModel checkout into the old image at `/opt/Automodel` via `AUTOMODEL_SOURCE_MOUNT_REF=21703aac076491c276d874d1f01a9b364f85d929`.
- `glm_5.2_tulu3_32k_tilelang_cp8`:
  - Parent pipeline: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/59488501
  - Leaf pipeline: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/59488595
  - Passed leaf job: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/373280408
  - Proof: `sbatch -N 64 --time 01:00:00`, `World size: 512`, `max_steps: 10`, `Training: 100% ... 10/10`, `SLURM_STATE=COMPLETED`, `SLURM_EXITCODE=0`.
- `glm_5.2_tulu3_4k_tilelang_100k`:
  - Parent pipeline: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/59489236
  - Leaf pipeline: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/59489412
  - Passed leaf job: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/373286792
  - Proof: `sbatch -N 32 --time 01:00:00`, `World size: 256`, `max_steps: 10`, `Training: 100% ... 10/10`, `SLURM_STATE=COMPLETED`, `SLURM_EXITCODE=0`.

# Additional Information

- Linear: AMINT-12
- Failed reference jobs: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/355015012 and https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/355015013
