### PR TITLE
fix(distributed): checkpoint linear attention with compile

### DIFF
--- a/nemo_automodel/components/distributed/parallelizer.py
+++ b/nemo_automodel/components/distributed/parallelizer.py
@@ -414,7 +414,7 @@ class DefaultParallelizationStrategy(ParallelizationStrategy):
                 # (and other trainable) weight gradients.  Wrapping must happen BEFORE FSDP2
                 # sharding so the module structure is stable when fully_shard() indexes params.
                 for layer in ac_layers:
-                    for attr in ("self_attn", "attention", "attn", "mlp", "feed_forward", "ffn"):
+                    for attr in ("self_attn", "attention", "attn", "linear_attn", "mlp", "feed_forward", "ffn"):
                         m = getattr(layer, attr, None)
                         if m is not None:
                             setattr(layer, attr, checkpoint_wrapper(m, checkpoint_impl=CheckpointImpl.NO_REENTRANT))

--- a/tests/unit_tests/distributed/test_parallelizer.py
+++ b/tests/unit_tests/distributed/test_parallelizer.py
@@ -1810,7 +1810,13 @@ class TestActivationCheckpointingKVSharing:
             lambda mesh, *a, **kw: MagicMock(),
         )
 
-    def _run_parallelize(self, model, activation_checkpointing=True, activation_checkpointing_scope="all"):
+    def _run_parallelize(
+        self,
+        model,
+        activation_checkpointing=True,
+        activation_checkpointing_scope="all",
+        enable_compile=False,
+    ):
         """Invoke the strategy under test and return the model."""
         from nemo_automodel.components.distributed.parallelizer import DefaultParallelizationStrategy
 
@@ -1824,6 +1830,7 @@ class TestActivationCheckpointingKVSharing:
             device_mesh=mesh,
             activation_checkpointing=activation_checkpointing,
             activation_checkpointing_scope=activation_checkpointing_scope,
+            enable_compile=enable_compile,
         )
 
     # ------------------------------------------------------------------ #
@@ -1892,6 +1899,24 @@ class TestActivationCheckpointingKVSharing:
             assert isinstance(layer.self_attn, self._Wrapped), (
                 "self_attn should be checkpoint-wrapped for standard models"
             )
+
+    def test_linear_attn_wrapped_with_compile(self):
+        """Compile-compatible checkpointing wraps hybrid blocks' ``linear_attn`` mixers."""
+
+        class _LinearAttentionLayer(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear_attn = nn.Linear(16, 16)
+                self.mlp = nn.Linear(16, 16)
+
+        model = _make_model_for_ac(num_kv_shared_layers=0)
+        model.model.layers = nn.ModuleList([_LinearAttentionLayer() for _ in range(2)])
+
+        self._run_parallelize(model, enable_compile=True)
+
+        for layer in model.model.layers:
+            assert isinstance(layer.linear_attn, self._Wrapped)
+            assert isinstance(layer.mlp, self._Wrapped)
 
     def test_mlp_always_wrapped(self):
         """MLP is checkpoint-wrapped regardless of KV sharing."""


### PR DESCRIPTION
# What does this PR do?

Extends the activation-checkpointing fix from #3192 to the
`enable_compile: true` path by checkpoint-wrapping `linear_attn` modules with
the existing non-reentrant compile-compatible wrapper.

# Changelog

- Include `linear_attn` in compile-compatible submodule activation
  checkpointing.
- Add a focused CPU regression test for the compile path.

# Root cause and impact

The compile path uses a separate checkpoint-wrapper loop from the non-compile
path changed by #3192. Without `linear_attn` in that loop, Qwen3.6's 48
GatedDeltaNet mixers are not activation-checkpointed when compile is enabled.

In a controlled 8x H100, FSDP2 DP=8 Qwen3.6-27B training run:

| Revision | Compile | Result | Peak/failed allocation |
|---|---:|---|---:|
| #3192 base (`983bac3`) | off | OOM before step 0 | 72.18 GiB allocated |
| #3192 head (`f3871e3`) | off | 10/10 steps | 39.97 GiB max |
| #3192 head (`f3871e3`) | on | OOM inside compiled `linear_attn` before step 0 | 75.68 GiB allocated |
| Follow-up patch | on | 10/10 steps | 39.97 GiB max |

The training benchmark used the pre-rebase follow-up commit `cc3bf78`. The
current commit `a3b068d` is a history-only rebase onto `main`; `git range-diff`
confirms the patch is unchanged.

After both paths are fixed, compile-on versus compile-off steady-step median
memory differs by only +0.0069 GiB (about 7 MiB). This indicates compile itself
is not a meaningful steady-memory cost here; the separate compile checkpoint
path is what matters.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added a focused regression test.
- [x] Documentation is not required because this does not change public APIs or configuration.
- [x] Ruff format check passed after rebasing onto `main`.
- [x] Ruff check passed after rebasing onto `main`.
- [x] `tests/unit_tests/distributed/test_parallelizer.py`: 141 passed after rebasing onto `main`.
- [x] Real training before/after matrix completed; successful runs had finite losses and gradient norms.

# Additional Information

- Follow-up to #3192 (merged).
