### PR TITLE
perf(bagel): grouped MoT routing + fused SwiGLU/RoPE

### DIFF
--- a/examples/multimodal_finetune/bagel/bagel_sft.yaml
+++ b/examples/multimodal_finetune/bagel/bagel_sft.yaml
@@ -25,9 +25,13 @@ dist_env:
 
 model:
   # Transformer Engine is enabled for BAGEL's language-model Linear and RMSNorm layers.
+  # mot_grouped / fused_swiglu / fused_rope are throughput optimizations (see BagelBackendConfig).
   backend:
     linear: te
     rms_norm: te
+    mot_grouped: true
+    fused_swiglu: true
+    fused_rope: true
   _target_: nemo_automodel.NeMoAutoModelForMultimodalLM.from_pretrained
   pretrained_model_name_or_path: ByteDance-Seed/BAGEL-7B-MoT
   torch_dtype: float32

--- a/examples/multimodal_pretrain/bagel/bagel_pretrain.yaml
+++ b/examples/multimodal_pretrain/bagel/bagel_pretrain.yaml
@@ -27,9 +27,13 @@ tokenizer:
 
 model:
   # Transformer Engine is enabled for BAGEL's language-model Linear and RMSNorm layers.
+  # mot_grouped / fused_swiglu / fused_rope are throughput optimizations (see BagelBackendConfig).
   backend:
     linear: te
     rms_norm: te
+    mot_grouped: true
+    fused_swiglu: true
+    fused_rope: true
   init_mode: hf_backbones
   stage: 2
   llm_path: Qwen/Qwen2.5-7B-Instruct

--- a/nemo_automodel/components/models/bagel/configuration.py
+++ b/nemo_automodel/components/models/bagel/configuration.py
@@ -51,6 +51,12 @@ class BagelBackendConfig:
 
     linear: Literal["torch", "te"] = "torch"
     rms_norm: Literal["torch", "torch_fp32", "te"] = "torch_fp32"
+    # Fuse silu(gate)*up into one compiled pointwise kernel in Qwen2MLP.
+    fused_swiglu: bool = False
+    # Fuse the RoPE rotate/mul/add into one compiled pointwise kernel in attention.
+    fused_rope: bool = False
+    # MLM-style grouped MoT routing: permute und/gen tokens into contiguous blocks once.
+    mot_grouped: bool = False
 
     def __post_init__(self) -> None:
         if self.linear not in {"torch", "te"}:
@@ -72,7 +78,7 @@ def resolve_bagel_backend(backend: Any = None) -> BagelBackendConfig:
         raise TypeError(f"BAGEL backend must be a mapping or BagelBackendConfig, got {type(backend)!r}")
 
     overrides = dict(backend)
-    unknown_fields = sorted(overrides.keys() - {"linear", "rms_norm"})
+    unknown_fields = sorted(overrides.keys() - {"linear", "rms_norm", "fused_swiglu", "fused_rope", "mot_grouped"})
     if unknown_fields:
         raise TypeError(f"Unknown BAGEL backend field(s): {unknown_fields}")
     return BagelBackendConfig(**overrides)

--- a/nemo_automodel/components/models/bagel/model.py
+++ b/nemo_automodel/components/models/bagel/model.py
@@ -447,7 +447,36 @@ class BagelForUnifiedMultimodal(HFCheckpointingMixin, nn.Module):
         packed_sequence = packed_text_embedding.new_zeros(size=(sequence_length, self.hidden_size))
         packed_sequence[packed_text_indexes] = packed_text_embedding
 
-        # --- attention mask ---
+        # --- MLM-style grouped routing: build the und/gen permutation ONCE ---
+        # Reorder the packed sequence so und tokens occupy ``[:Lund]`` and gen tokens
+        # ``[Lund:]`` (contiguous blocks). Every MoT layer then routes the *pointwise* path
+        # (LN / MLP / QKV / O-proj) by a scalar slice boundary instead of per-layer
+        # gather/scatter. Crucially — like MLM — attention still runs in ORIGINAL token order
+        # (so its block-diagonal mask stays block-sparse): each attention layer restores the
+        # original order via ``mot_inv`` before the kernel and re-groups via ``mot_perm``
+        # after. The output is un-permuted at exit so loss/downstream stay in original order.
+        mot_perm = None
+        mot_inv = None
+        if (
+            self.model.backend.mot_grouped
+            and self.use_moe
+            and self.config.visual_gen
+            and packed_vae_token_indexes is not None
+        ):
+            dev = packed_sequence.device
+            und = packed_text_indexes
+            if packed_vit_token_indexes is not None:
+                und = torch.cat([packed_text_indexes, packed_vit_token_indexes], dim=0)
+            gen = packed_vae_token_indexes
+            covered = torch.zeros(sequence_length, dtype=torch.bool, device=dev)
+            covered[und] = True
+            covered[gen] = True
+            rest = torch.nonzero(~covered, as_tuple=False).flatten()
+            mot_perm = torch.cat([und, gen, rest])
+            mot_inv = torch.empty(sequence_length, dtype=torch.long, device=dev)
+            mot_inv[mot_perm] = torch.arange(sequence_length, device=dev)
+
+        # --- attention mask (always ORIGINAL packed order; grouped mode restores order in-layer) ---
         if nested_attention_masks is None:
             if split_lens is None or attn_modes is None:
                 raise ValueError(
@@ -540,6 +569,17 @@ class BagelForUnifiedMultimodal(HFCheckpointingMixin, nn.Module):
             # no VAE tokens — Qwen2Model.forward_train tolerates None and
             # treats the gen-side expert as dormant.
             extra_inputs["packed_gen_token_indexes"] = packed_vae_token_indexes if self.config.visual_gen else None
+            if mot_perm is not None:
+                # Threaded to every MoT layer so attention can restore/re-group token order.
+                extra_inputs["mot_perm"] = mot_perm
+                extra_inputs["mot_inv"] = mot_inv
+
+        # --- apply the grouped permutation to the fully-populated sequence + RoPE ids ---
+        # In grouped mode the MoT layers read only ``packed_und_token_indexes.shape[0]`` as
+        # the und/gen slice boundary, so the (now-stale) index values are unused downstream.
+        if mot_perm is not None:
+            packed_sequence = packed_sequence[mot_perm]
+            packed_position_ids = packed_position_ids[mot_perm]
 
         # --- LM forward ---
         # Route through the language_model's train/inference dispatcher: at
@@ -552,6 +592,10 @@ class BagelForUnifiedMultimodal(HFCheckpointingMixin, nn.Module):
             packed_position_ids=packed_position_ids,
             **extra_inputs,
         )
+
+        # --- undo the grouped permutation so loss/downstream see original packed order ---
+        if mot_inv is not None:
+            last_hidden_state = last_hidden_state[mot_inv]
 
         # --- loss: CE (understanding) ---
         ce: Optional[torch.Tensor] = None

--- a/nemo_automodel/components/models/bagel/modeling_qwen2_packed.py
+++ b/nemo_automodel/components/models/bagel/modeling_qwen2_packed.py
@@ -324,10 +324,56 @@ def apply_rotary_pos_emb(
     sin: torch.Tensor,
     position_ids: Optional[torch.Tensor] = None,
     unsqueeze_dim: int = 1,
+    fused: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Apply Rotary Position Embedding to query and key tensors."""
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
+    if fused:
+        return _bagel_fused_rope(q, k, cos, sin)
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed, k_embed
+
+
+# ---------------------------------------------------------------------------
+# Optional fused-kernel helpers. Pure functions; gated by BagelBackendConfig at
+# the call sites (default OFF).
+# ---------------------------------------------------------------------------
+
+
+@torch.compile(dynamic=True)
+def _bagel_fused_silu_mul(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
+    """Fused SwiGLU gate: ``silu(gate) * up`` in a single compiled pointwise kernel.
+
+    Compiling ONLY this pointwise activation — over regular (non-DTensor) activation tensors,
+    not the projections/attention that run on FSDP2 DTensor params — fuses the silu and the
+    multiply into one kernel (fewer launches, no materialization of the silu output) without
+    triggering the DTensor-spec recompile thrash that whole-layer ``torch.compile`` hits.
+    """
+    return torch.nn.functional.silu(gate) * up
+
+
+@torch.compile(dynamic=True)
+def _bagel_fused_rope(
+    q: torch.Tensor, k: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Fused RoPE apply: rotate ``q`` and ``k`` in a single compiled pointwise kernel.
+
+    ``cos``/``sin`` arrive already unsqueezed to broadcast over the head dim. Compiling this
+    pointwise region — like the SwiGLU gate, over regular activation tensors and no FSDP2
+    DTensor parameters — fuses the ``rotate_half`` slice/negate/cat and the mul/add into far
+    fewer kernels than eager ATen, with no recompile thrash.
+
+    Args:
+        q: Query states, shape ``[tokens, heads, head_dim]``.
+        k: Key states, shape ``[tokens, kv_heads, head_dim]``.
+        cos: Cosine table, broadcastable to ``q`` and ``k``.
+        sin: Sine table, broadcastable to ``q`` and ``k``.
+
+    Returns:
+        Tuple of rotated ``(q_embed, k_embed)`` matching the inputs' shapes and dtypes.
+    """
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
     return q_embed, k_embed
@@ -345,9 +391,17 @@ class Qwen2MLP(nn.Module):
         self.up_proj = _initialize_linear(self.backend, self.hidden_size, self.intermediate_size, bias=False)
         self.down_proj = _initialize_linear(self.backend, self.intermediate_size, self.hidden_size, bias=False)
         self.act_fn = ACT2FN[config.hidden_act]
+        # Fuse silu(gate)*up only when the activation is silu (BAGEL/Qwen2 default).
+        self._fuse_silu_mul = (
+            getattr(self.backend, "fused_swiglu", False) and getattr(config, "hidden_act", "silu") == "silu"
+        )
 
     def forward(self, hidden_state: torch.Tensor) -> torch.Tensor:
-        return self.down_proj(self.act_fn(self.gate_proj(hidden_state)) * self.up_proj(hidden_state))
+        gate = self.gate_proj(hidden_state)
+        up = self.up_proj(hidden_state)
+        if self._fuse_silu_mul:
+            return self.down_proj(_bagel_fused_silu_mul(gate, up))
+        return self.down_proj(self.act_fn(gate) * up)
 
 
 # ---------------------------------------------------------------------------
@@ -470,7 +524,12 @@ class PackedAttention(_PackedAttentionBase):
 
         packed_cos, packed_sin = packed_position_embeddings
         packed_query_states, packed_key_states = apply_rotary_pos_emb(
-            packed_query_states, packed_key_states, packed_cos, packed_sin, unsqueeze_dim=1
+            packed_query_states,
+            packed_key_states,
+            packed_cos,
+            packed_sin,
+            unsqueeze_dim=1,
+            fused=self.backend.fused_rope,
         )
 
         if isinstance(attention_mask, list):
@@ -633,88 +692,139 @@ class PackedAttentionMoT(_PackedAttentionBase):
         packed_position_embeddings: Tuple[torch.Tensor, torch.Tensor],
         packed_und_token_indexes: torch.LongTensor,
         packed_gen_token_indexes: torch.LongTensor,
+        mot_perm: Optional[torch.LongTensor] = None,
+        mot_inv: Optional[torch.LongTensor] = None,
     ) -> torch.Tensor:
-        packed_sequence_und = packed_sequence[packed_und_token_indexes]
-        packed_sequence_gen = packed_sequence[packed_gen_token_indexes]
         freeze_und = getattr(self.config, "freeze_und", False)
 
-        packed_query_states = packed_sequence.new_zeros((packed_sequence.shape[0], self.num_heads * self.head_dim))
-        packed_key_states = packed_sequence.new_zeros(
-            (packed_sequence.shape[0], self.num_key_value_heads * self.head_dim)
-        )
-        packed_value_states = packed_sequence.new_zeros(
-            (packed_sequence.shape[0], self.num_key_value_heads * self.head_dim)
-        )
-        _index_put_matching_dtype(packed_query_states, packed_und_token_indexes, self.q_proj(packed_sequence_und))
-        _index_put_matching_dtype(
-            packed_query_states, packed_gen_token_indexes, self.q_proj_moe_gen(packed_sequence_gen)
-        )
-        _index_put_matching_dtype(packed_key_states, packed_und_token_indexes, self.k_proj(packed_sequence_und))
-        _index_put_matching_dtype(packed_key_states, packed_gen_token_indexes, self.k_proj_moe_gen(packed_sequence_gen))
-        _index_put_matching_dtype(packed_value_states, packed_und_token_indexes, self.v_proj(packed_sequence_und))
-        _index_put_matching_dtype(
-            packed_value_states, packed_gen_token_indexes, self.v_proj_moe_gen(packed_sequence_gen)
-        )
+        if mot_perm is not None:
+            # MLM-style: und tokens are [:Lund], gen tokens [Lund:] — slice + concat, no gather/scatter.
+            lund = packed_und_token_indexes.shape[0]
+            seq_und = packed_sequence[:lund]
+            seq_gen = packed_sequence[lund:]
+            q = torch.cat([self.q_proj(seq_und), self.q_proj_moe_gen(seq_gen)], dim=0).view(
+                -1, self.num_heads, self.head_dim
+            )
+            k = torch.cat([self.k_proj(seq_und), self.k_proj_moe_gen(seq_gen)], dim=0).view(
+                -1, self.num_key_value_heads, self.head_dim
+            )
+            packed_value_states = torch.cat([self.v_proj(seq_und), self.v_proj_moe_gen(seq_gen)], dim=0).view(
+                -1, self.num_key_value_heads, self.head_dim
+            )
+            packed_query_states_ = torch.cat(
+                [
+                    _apply_qk_norm(self.q_norm, q[:lund], backend=self.backend, eps=self.config.rms_norm_eps),
+                    _apply_qk_norm(self.q_norm_moe_gen, q[lund:], backend=self.backend, eps=self.config.rms_norm_eps),
+                ],
+                dim=0,
+            )
+            packed_key_states_ = torch.cat(
+                [
+                    _apply_qk_norm(self.k_norm, k[:lund], backend=self.backend, eps=self.config.rms_norm_eps),
+                    _apply_qk_norm(self.k_norm_moe_gen, k[lund:], backend=self.backend, eps=self.config.rms_norm_eps),
+                ],
+                dim=0,
+            )
+            if freeze_und:
+                packed_value_states[:lund] = packed_value_states[:lund].detach()
+                packed_query_states_[:lund] = packed_query_states_[:lund].detach()
+                packed_key_states_[:lund] = packed_key_states_[:lund].detach()
+        else:
+            packed_sequence_und = packed_sequence[packed_und_token_indexes]
+            packed_sequence_gen = packed_sequence[packed_gen_token_indexes]
 
-        packed_query_states = packed_query_states.view(-1, self.num_heads, self.head_dim)
-        packed_key_states = packed_key_states.view(-1, self.num_key_value_heads, self.head_dim)
-        packed_value_states = packed_value_states.view(-1, self.num_key_value_heads, self.head_dim)
-        if freeze_und:
-            packed_value_states[packed_und_token_indexes] = packed_value_states[packed_und_token_indexes].detach()
+            packed_query_states = packed_sequence.new_zeros((packed_sequence.shape[0], self.num_heads * self.head_dim))
+            packed_key_states = packed_sequence.new_zeros(
+                (packed_sequence.shape[0], self.num_key_value_heads * self.head_dim)
+            )
+            packed_value_states = packed_sequence.new_zeros(
+                (packed_sequence.shape[0], self.num_key_value_heads * self.head_dim)
+            )
+            _index_put_matching_dtype(packed_query_states, packed_und_token_indexes, self.q_proj(packed_sequence_und))
+            _index_put_matching_dtype(
+                packed_query_states, packed_gen_token_indexes, self.q_proj_moe_gen(packed_sequence_gen)
+            )
+            _index_put_matching_dtype(packed_key_states, packed_und_token_indexes, self.k_proj(packed_sequence_und))
+            _index_put_matching_dtype(
+                packed_key_states, packed_gen_token_indexes, self.k_proj_moe_gen(packed_sequence_gen)
+            )
+            _index_put_matching_dtype(packed_value_states, packed_und_token_indexes, self.v_proj(packed_sequence_und))
+            _index_put_matching_dtype(
+                packed_value_states, packed_gen_token_indexes, self.v_proj_moe_gen(packed_sequence_gen)
+            )
 
-        packed_query_states_ = packed_query_states.new_zeros(packed_query_states.shape)
-        packed_key_states_ = packed_key_states.new_zeros(packed_key_states.shape)
+            packed_query_states = packed_query_states.view(-1, self.num_heads, self.head_dim)
+            packed_key_states = packed_key_states.view(-1, self.num_key_value_heads, self.head_dim)
+            packed_value_states = packed_value_states.view(-1, self.num_key_value_heads, self.head_dim)
+            if freeze_und:
+                packed_value_states[packed_und_token_indexes] = packed_value_states[packed_und_token_indexes].detach()
 
-        _index_put_matching_dtype(
-            packed_query_states_,
-            packed_und_token_indexes,
-            _apply_qk_norm(
-                self.q_norm,
-                packed_query_states[packed_und_token_indexes],
-                backend=self.backend,
-                eps=self.config.rms_norm_eps,
-            ),
-        )
-        if freeze_und:
-            packed_query_states_[packed_und_token_indexes] = packed_query_states_[packed_und_token_indexes].detach()
-        _index_put_matching_dtype(
-            packed_query_states_,
-            packed_gen_token_indexes,
-            _apply_qk_norm(
-                self.q_norm_moe_gen,
-                packed_query_states[packed_gen_token_indexes],
-                backend=self.backend,
-                eps=self.config.rms_norm_eps,
-            ),
-        )
+            packed_query_states_ = packed_query_states.new_zeros(packed_query_states.shape)
+            packed_key_states_ = packed_key_states.new_zeros(packed_key_states.shape)
 
-        _index_put_matching_dtype(
-            packed_key_states_,
-            packed_und_token_indexes,
-            _apply_qk_norm(
-                self.k_norm,
-                packed_key_states[packed_und_token_indexes],
-                backend=self.backend,
-                eps=self.config.rms_norm_eps,
-            ),
-        )
-        if freeze_und:
-            packed_key_states_[packed_und_token_indexes] = packed_key_states_[packed_und_token_indexes].detach()
-        _index_put_matching_dtype(
-            packed_key_states_,
-            packed_gen_token_indexes,
-            _apply_qk_norm(
-                self.k_norm_moe_gen,
-                packed_key_states[packed_gen_token_indexes],
-                backend=self.backend,
-                eps=self.config.rms_norm_eps,
-            ),
-        )
+            _index_put_matching_dtype(
+                packed_query_states_,
+                packed_und_token_indexes,
+                _apply_qk_norm(
+                    self.q_norm,
+                    packed_query_states[packed_und_token_indexes],
+                    backend=self.backend,
+                    eps=self.config.rms_norm_eps,
+                ),
+            )
+            if freeze_und:
+                packed_query_states_[packed_und_token_indexes] = packed_query_states_[packed_und_token_indexes].detach()
+            _index_put_matching_dtype(
+                packed_query_states_,
+                packed_gen_token_indexes,
+                _apply_qk_norm(
+                    self.q_norm_moe_gen,
+                    packed_query_states[packed_gen_token_indexes],
+                    backend=self.backend,
+                    eps=self.config.rms_norm_eps,
+                ),
+            )
+
+            _index_put_matching_dtype(
+                packed_key_states_,
+                packed_und_token_indexes,
+                _apply_qk_norm(
+                    self.k_norm,
+                    packed_key_states[packed_und_token_indexes],
+                    backend=self.backend,
+                    eps=self.config.rms_norm_eps,
+                ),
+            )
+            if freeze_und:
+                packed_key_states_[packed_und_token_indexes] = packed_key_states_[packed_und_token_indexes].detach()
+            _index_put_matching_dtype(
+                packed_key_states_,
+                packed_gen_token_indexes,
+                _apply_qk_norm(
+                    self.k_norm_moe_gen,
+                    packed_key_states[packed_gen_token_indexes],
+                    backend=self.backend,
+                    eps=self.config.rms_norm_eps,
+                ),
+            )
 
         packed_cos, packed_sin = packed_position_embeddings
         packed_query_states_, packed_key_states_ = apply_rotary_pos_emb(
-            packed_query_states_, packed_key_states_, packed_cos, packed_sin, unsqueeze_dim=1
+            packed_query_states_,
+            packed_key_states_,
+            packed_cos,
+            packed_sin,
+            unsqueeze_dim=1,
+            fused=self.backend.fused_rope,
         )
+
+        if mot_inv is not None:
+            # Restore ORIGINAL token order for the attention kernel so the block-diagonal mask
+            # stays block-sparse (RoPE is already applied in grouped order with original position
+            # values, so this only re-scatters rows). Re-grouped after attention for the O-proj.
+            packed_query_states_ = packed_query_states_[mot_inv]
+            packed_key_states_ = packed_key_states_[mot_inv]
+            packed_value_states = packed_value_states[mot_inv]
 
         if isinstance(attention_mask, list):
             packed_key_states_ = packed_key_states_[:, :, None, :].repeat(1, 1, self.num_key_value_groups, 1)
@@ -739,7 +849,7 @@ class PackedAttentionMoT(_PackedAttentionBase):
                 unpacked_attn_output.append(attn_output.squeeze(0))
             packed_attn_output = torch.cat(unpacked_attn_output, dim=1)
         else:
-            pad_size = sum(sample_lens) - packed_query_states.shape[0]
+            pad_size = sum(sample_lens) - packed_query_states_.shape[0]
             packed_query_states_ = _pad_sequence(packed_query_states_.permute(1, 0, 2), pad_size)
             packed_key_states_ = _pad_sequence(packed_key_states_.permute(1, 0, 2), pad_size)
             packed_value_states = _pad_sequence(packed_value_states.permute(1, 0, 2), pad_size)
@@ -754,6 +864,14 @@ class PackedAttentionMoT(_PackedAttentionBase):
             packed_attn_output = packed_attn_output[0, :, :end_index, :]
 
         packed_attn_output = packed_attn_output.transpose(0, 1).reshape(-1, self.num_heads * self.head_dim)
+        if mot_perm is not None:
+            # Re-group the attention output (original -> [und | gen]) for slice O-proj.
+            packed_attn_output = packed_attn_output[mot_perm]
+            lund = packed_und_token_indexes.shape[0]
+            return torch.cat(
+                [self.o_proj(packed_attn_output[:lund]), self.o_proj_moe_gen(packed_attn_output[lund:])],
+                dim=0,
+            )
         packed_attn_output_ = packed_attn_output.new_zeros(packed_attn_output.shape)
         _index_put_matching_dtype(
             packed_attn_output_,
@@ -1064,7 +1182,42 @@ class Qwen2MoTDecoderLayer(nn.Module):
         packed_position_embeddings: Tuple[torch.Tensor, torch.Tensor],
         packed_und_token_indexes: torch.LongTensor,
         packed_gen_token_indexes: torch.LongTensor,
+        mot_perm: Optional[torch.LongTensor] = None,
+        mot_inv: Optional[torch.LongTensor] = None,
     ) -> torch.Tensor:
+        if mot_perm is not None:
+            # MLM-style slice+concat routing at the scalar und/gen boundary.
+            lund = packed_und_token_indexes.shape[0]
+            residual = packed_sequence
+            packed_sequence_ = torch.cat(
+                [
+                    self.input_layernorm(packed_sequence[:lund]),
+                    self.input_layernorm_moe_gen(packed_sequence[lund:]),
+                ],
+                dim=0,
+            )
+            packed_sequence_ = self.self_attn(
+                packed_sequence=packed_sequence_,
+                sample_lens=sample_lens,
+                attention_mask=attention_mask,
+                packed_position_embeddings=packed_position_embeddings,
+                packed_und_token_indexes=packed_und_token_indexes,
+                packed_gen_token_indexes=packed_gen_token_indexes,
+                mot_perm=mot_perm,
+                mot_inv=mot_inv,
+            )
+            if self.freeze_und:
+                packed_sequence_[:lund] = packed_sequence_[:lund].detach()
+            packed_sequence = residual + packed_sequence_
+            residual = packed_sequence
+            und_out = self.mlp(self.post_attention_layernorm(packed_sequence[:lund]))
+            gen_out = self.mlp_moe_gen(self.post_attention_layernorm_moe_gen(packed_sequence[lund:]))
+            mlp_out = torch.cat([und_out, gen_out], dim=0)
+            if self.freeze_und:
+                mlp_out[:lund] = mlp_out[:lund].detach()
+            packed_sequence = residual + mlp_out
+            return packed_sequence
+
         residual = packed_sequence
         packed_sequence_ = packed_sequence.new_zeros(packed_sequence.shape)
         _index_put_matching_dtype(
@@ -1266,10 +1419,16 @@ class Qwen2Model(Qwen2PreTrainedModel):
         packed_position_ids: torch.Tensor,
         packed_und_token_indexes: Optional[torch.LongTensor] = None,
         packed_gen_token_indexes: Optional[torch.LongTensor] = None,
+        mot_perm: Optional[torch.LongTensor] = None,
+        mot_inv: Optional[torch.LongTensor] = None,
     ) -> torch.Tensor:
         freeze_und = getattr(self.config, "freeze_und", False)
         if freeze_und:
-            packed_sequence[packed_und_token_indexes] = packed_sequence[packed_und_token_indexes].detach()
+            if mot_perm is not None and packed_und_token_indexes is not None:
+                lund = packed_und_token_indexes.shape[0]
+                packed_sequence[:lund] = packed_sequence[:lund].detach()
+            else:
+                packed_sequence[packed_und_token_indexes] = packed_sequence[packed_und_token_indexes].detach()
 
         cos, sin = self.rotary_emb(packed_sequence, packed_position_ids.unsqueeze(0))
         cos = cos.squeeze(0)
@@ -1286,6 +1445,8 @@ class Qwen2Model(Qwen2PreTrainedModel):
                 packed_und_token_indexes=packed_und_token_indexes,
                 packed_gen_token_indexes=packed_gen_token_indexes,
             )
+            if mot_perm is not None:
+                extra_inputs.update(mot_perm=mot_perm, mot_inv=mot_inv)
 
         for decoder_layer in self.layers:
             packed_sequence = decoder_layer(
@@ -1297,6 +1458,14 @@ class Qwen2Model(Qwen2PreTrainedModel):
             )
 
         if self.use_moe:
+            if mot_perm is not None:
+                lund = packed_und_token_indexes.shape[0]
+                packed_sequence_ = torch.cat(
+                    [self.norm(packed_sequence[:lund]), self.norm_moe_gen(packed_sequence[lund:])], dim=0
+                )
+                if freeze_und:
+                    packed_sequence_[:lund] = packed_sequence_[:lund].detach()
+                return packed_sequence_
             packed_sequence_ = torch.zeros_like(packed_sequence)
             _index_put_matching_dtype(
                 packed_sequence_,
@@ -1440,6 +1609,8 @@ class Qwen2ForCausalLM(Qwen2PreTrainedModel):
         packed_position_ids: torch.Tensor,
         packed_und_token_indexes: Optional[torch.LongTensor] = None,
         packed_gen_token_indexes: Optional[torch.LongTensor] = None,
+        mot_perm: Optional[torch.LongTensor] = None,
+        mot_inv: Optional[torch.LongTensor] = None,
     ) -> torch.Tensor:
         # BAGEL's forward_train returns the raw hidden states; the upstream
         # training loop applies lm_head only on text-token positions to save
@@ -1452,6 +1623,8 @@ class Qwen2ForCausalLM(Qwen2PreTrainedModel):
             attention_mask=attention_mask,
             packed_und_token_indexes=packed_und_token_indexes,
             packed_gen_token_indexes=packed_gen_token_indexes,
+            mot_perm=mot_perm,
+            mot_inv=mot_inv,
         )
 
     def forward_inference(

--- a/nemo_automodel/recipes/multimodal/finetune.py
+++ b/nemo_automodel/recipes/multimodal/finetune.py
@@ -59,6 +59,7 @@ from nemo_automodel.components.models.bagel.hf_backbone_loader import (  # noqa:
 from nemo_automodel.components.training.rng import ScopedRNG, StatefulRNG  # noqa: E402
 from nemo_automodel.components.training.step_scheduler import StepScheduler  # noqa: E402
 from nemo_automodel.recipes._dist_utils import create_distributed_setup_from_config  # noqa: E402
+from nemo_automodel.recipes._typed_config import RecipeConfig  # noqa: E402
 from nemo_automodel.recipes.base_recipe import BaseRecipe  # noqa: E402
 
 try:
@@ -562,7 +563,11 @@ class FinetuneRecipeForMultimodal(BaseRecipe):
             self.base_lr = float(optimizer.param_groups[0]["lr"])
 
         # -- dataset + dataloader ----------------------------------------
-        dataloader_config = self.cfg.bagel_dataloader
+        # The recipe holds a raw ConfigNode; ``bagel_dataloader`` is a typed
+        # RecipeConfig property, so resolve it through a RecipeConfig view here
+        # (rather than wrapping self.cfg, which would break the ConfigNode-style
+        # optimizer/wandb access used elsewhere in this recipe).
+        dataloader_config = RecipeConfig(self.cfg).bagel_dataloader
         if dataloader_config is None:
             raise ValueError("BAGEL training requires dataset and dataloader configs")
         dataloader_build = dataloader_config.build(

--- a/tests/unit_tests/models/bagel/test_grouped_routing_and_fusions.py
+++ b/tests/unit_tests/models/bagel/test_grouped_routing_and_fusions.py
@@ -1,0 +1,180 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Parity tests for the config-gated BAGEL throughput optimizations.
+
+Three optimizations are selected via ``BagelBackendConfig`` fields (default OFF,
+set in YAML as ``model.backend.*``):
+
+  * ``fused_swiglu`` — fuse ``silu(gate) * up`` into one compiled kernel.
+  * ``fused_rope``   — fuse the rotary apply into one compiled kernel.
+  * ``mot_grouped``  — route und/gen tokens by contiguous slices instead of
+    per-layer gather/scatter, restoring original token order around the
+    attention kernel.
+
+All three are numerically equivalent to the default path (grouped routing is a
+pure permutation — each token is processed by its correct expert and attention
+runs over the same tokens in the same original order), so the tests assert the
+optimized path matches the default path.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+MODELING = "nemo_automodel.components.models.bagel.modeling_qwen2_packed"
+
+
+def _mot_config():
+    from nemo_automodel.components.models.bagel.modeling_qwen2_packed import Qwen2Config
+
+    return Qwen2Config(
+        vocab_size=32,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        max_position_embeddings=64,
+        rms_norm_eps=1e-6,
+        rope_theta=10000.0,
+        qk_norm=True,
+        layer_module="Qwen2MoTDecoderLayer",
+        hidden_act="silu",
+    )
+
+
+def test_fused_swiglu_matches_eager():
+    """``Qwen2MLP`` with the fused SwiGLU kernel matches the eager path exactly."""
+    from nemo_automodel.components.models.bagel.configuration import BagelBackendConfig
+    from nemo_automodel.components.models.bagel.modeling_qwen2_packed import Qwen2MLP
+
+    # The backend flag drives the fused path.
+    assert Qwen2MLP(_mot_config(), backend=BagelBackendConfig(fused_swiglu=True))._fuse_silu_mul is True
+    assert Qwen2MLP(_mot_config(), backend=BagelBackendConfig(fused_swiglu=False))._fuse_silu_mul is False
+
+    torch.manual_seed(0)
+    mlp = Qwen2MLP(_mot_config()).to(torch.float32).eval()
+    x = torch.randn(16, mlp.hidden_size)
+
+    mlp._fuse_silu_mul = False
+    out_eager = mlp(x)
+    mlp._fuse_silu_mul = True
+    out_fused = mlp(x)
+
+    torch.testing.assert_close(out_fused, out_eager, atol=1e-4, rtol=1e-4)
+
+
+def test_fused_rope_matches_eager():
+    """The fused rotary apply (``fused=True``) matches the eager path."""
+    from nemo_automodel.components.models.bagel.modeling_qwen2_packed import apply_rotary_pos_emb
+
+    torch.manual_seed(0)
+    n, heads, kv_heads, head_dim = 8, 4, 2, 16
+    q = torch.randn(n, heads, head_dim)
+    k = torch.randn(n, kv_heads, head_dim)
+    cos = torch.randn(n, head_dim)
+    sin = torch.randn(n, head_dim)
+
+    q_eager, k_eager = apply_rotary_pos_emb(q, k, cos, sin, unsqueeze_dim=1, fused=False)
+    q_fused, k_fused = apply_rotary_pos_emb(q, k, cos, sin, unsqueeze_dim=1, fused=True)
+
+    torch.testing.assert_close(q_fused, q_eager, atol=1e-4, rtol=1e-4)
+    torch.testing.assert_close(k_fused, k_eager, atol=1e-4, rtol=1e-4)
+
+
+def _interleaved_packed_inputs(hidden_size: int, head_dim: int, device: str):
+    """One packed sample of 8 tokens with und/gen tokens INTERLEAVED.
+
+    und at even positions, gen at odd — so grouped routing genuinely reorders
+    them (a no-op if they were already contiguous). Returns the kwargs for
+    ``Qwen2MoTDecoderLayer.forward_train`` plus the raw und/gen indexes.
+    """
+    torch.manual_seed(0)
+    n = 8
+    packed_sequence = torch.randn(n, hidden_size, dtype=torch.bfloat16, device=device)
+    packed_und_token_indexes = torch.arange(0, n, 2, dtype=torch.long, device=device)  # [0,2,4,6]
+    packed_gen_token_indexes = torch.arange(1, n, 2, dtype=torch.long, device=device)  # [1,3,5,7]
+
+    # Single-sample causal mask (SDPA list path).
+    causal = torch.zeros(n, n, device=device, dtype=torch.bfloat16)
+    causal.masked_fill_(torch.triu(torch.ones(n, n, dtype=torch.bool, device=device), diagonal=1), float("-inf"))
+
+    inv_freq = 1.0 / (10000.0 ** (torch.arange(0, head_dim, 2, device=device).float() / head_dim))
+    pos = torch.arange(n, device=device).float()
+    freqs = torch.outer(pos, inv_freq)
+    emb = torch.cat([freqs, freqs], dim=-1)
+    cos = emb.cos().to(torch.bfloat16)
+    sin = emb.sin().to(torch.bfloat16)
+
+    return dict(
+        packed_sequence=packed_sequence,
+        sample_lens=[n],
+        attention_mask=[causal],
+        packed_position_embeddings=(cos, sin),
+        packed_und_token_indexes=packed_und_token_indexes,
+        packed_gen_token_indexes=packed_gen_token_indexes,
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="MoT attention uses CUDA-only EFFICIENT_ATTENTION")
+def test_grouped_routing_matches_default():
+    """Grouped und/gen routing (permute + slice + restore) matches the default gather/scatter path.
+
+    Grouped routing is a pure permutation: the caller reorders the packed
+    sequence so und/gen tokens are contiguous, every layer routes by slice, and
+    attention is restored to original order around the kernel. Grouped mode is
+    signalled solely by passing ``mot_perm``/``mot_inv`` (the model threads these
+    only when ``backend.mot_grouped`` is set). Feeding the layer the permuted
+    inputs + ``mot_perm``/``mot_inv`` and un-permuting the output must reproduce
+    the default (interleaved gather/scatter) output.
+    """
+    from nemo_automodel.components.models.bagel.modeling_qwen2_packed import Qwen2MoTDecoderLayer
+
+    device = "cuda"
+    cfg = _mot_config()
+    head_dim = cfg.hidden_size // cfg.num_attention_heads
+    # ``forward`` dispatches to ``forward_train`` only in training mode; parity is a
+    # forward-only check so we still wrap the calls in ``torch.no_grad()`` below.
+    layer = Qwen2MoTDecoderLayer(cfg, layer_idx=0).to(device=device, dtype=torch.bfloat16)
+    layer.train()
+
+    base = _interleaved_packed_inputs(cfg.hidden_size, head_dim, device)
+
+    # --- default path: no mot_perm/mot_inv -> gather/scatter routing ---
+    with torch.no_grad():
+        out_default = layer(**base)
+
+    # --- grouped path: permute inputs, pass mot_perm/mot_inv, un-permute output ---
+    perm = torch.cat([base["packed_und_token_indexes"], base["packed_gen_token_indexes"]])
+    inv = torch.empty_like(perm)
+    inv[perm] = torch.arange(perm.numel(), device=device)
+    cos, sin = base["packed_position_embeddings"]
+
+    grouped_inputs = dict(
+        packed_sequence=base["packed_sequence"][perm],
+        sample_lens=base["sample_lens"],
+        attention_mask=base["attention_mask"],
+        packed_position_embeddings=(cos[perm], sin[perm]),
+        packed_und_token_indexes=base["packed_und_token_indexes"],
+        packed_gen_token_indexes=base["packed_gen_token_indexes"],
+        mot_perm=perm,
+        mot_inv=inv,
+    )
+    with torch.no_grad():
+        out_grouped = layer(**grouped_inputs)[inv]  # un-permute back to original order
+
+    # Pure permutation -> near-exact; tolerance covers bf16 attention reduction order.
+    torch.testing.assert_close(out_grouped, out_default, atol=1e-2, rtol=1e-2)

--- a/tests/unit_tests/recipes/test_multimodal_finetune.py
+++ b/tests/unit_tests/recipes/test_multimodal_finetune.py
@@ -61,3 +61,22 @@ def test_bagel_finalizes_pending_checkpoint_before_closing_checkpointer():
     FinetuneRecipeForMultimodal.run_train_validation_loop(recipe)
 
     assert events == ["train", "train_logger_close", "valid_logger_close", "finalize", "checkpointer_close"]
+
+
+def test_bagel_dataloader_resolved_through_recipeconfig():
+    """The recipe stores a raw ConfigNode, but ``bagel_dataloader`` is a typed
+    RecipeConfig property. It must be accessed via ``RecipeConfig(self.cfg)`` — a bare
+    ``self.cfg.bagel_dataloader`` raises AttributeError on a ConfigNode (the real CLI
+    entry hands the recipe a raw ConfigNode), which breaks every BAGEL run in ``setup``.
+    """
+    recipe_path = Path(__file__).resolve().parents[3] / "nemo_automodel/recipes/multimodal/finetune.py"
+    tree = ast.parse(recipe_path.read_text())
+
+    accesses = [node for node in ast.walk(tree) if isinstance(node, ast.Attribute) and node.attr == "bagel_dataloader"]
+    assert accesses, "expected a bagel_dataloader access in the recipe"
+    for node in accesses:
+        assert (
+            isinstance(node.value, ast.Call)
+            and isinstance(node.value.func, ast.Name)
+            and node.value.func.id == "RecipeConfig"
+        ), "bagel_dataloader must be resolved via RecipeConfig(self.cfg), not accessed on a raw ConfigNode"


### PR DESCRIPTION


# What does this PR do ?

 Adds three opt-in throughput optimizations for BAGEL packed Mixture-of-Transformers training, selected via new BagelBackendConfig fields under model.backend (mot_grouped, fused_swiglu, fused_rope): 
- mot_grouped reorders the packed sequence once so und/gen tokens form contiguous blocks, letting every MoT layer route the pointwise path (LayerNorm/MLP/QKV/QK-norm/O-proj) by a scalar slice boundary instead of per-layer gather/scatter, while attention still runs in original token order (restored around the kernel) so its block-diagonal FlexAttention mask stays block-sparse — a pure permutation in which each token is still processed by its correct expert
- fused_swiglu and fused_rope compile silu(gate)*up and the rotary apply into single pointwise kernels over activation tensors only (no FSDP2/DTensor params, so no torch.compile recompile thrash). 

All three are threaded through construction like the existing linear/rms_norm backends and the shipped BAGEL pretrain and SFT example configs enable them; the change also fixes an UnboundLocalError in PackedAttentionMoT.forward_train's FlexAttention path.
