### PR TITLE
fix: preserve batch dimension in VLM validation

### DIFF
--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -1127,9 +1127,7 @@ class FinetuneRecipeForVLM(BaseRecipe):
                         logits=getattr(out, "logits", out),
                         labels=labels,
                         model=self.model_parts[0],
-                        hidden_states=out.hidden_states[-1]
-                        if getattr(out, "hidden_states", None) is not None
-                        else None,
+                        hidden_states=get_final_hidden_states(out),
                         num_label_tokens=num_label_tokens,
                     )
                     # Mirror training: include the drafter term so validation

--- a/tests/unit_tests/recipes/test_finetune_vlm_cp_wiring.py
+++ b/tests/unit_tests/recipes/test_finetune_vlm_cp_wiring.py
@@ -563,6 +563,56 @@ def test_run_validation_epoch_does_not_sum_tokens_over_cp(monkeypatch):
     assert result.metrics["val_loss"] == pytest.approx(2.0)
 
 
+def test_run_validation_epoch_preserves_tensor_hidden_state_batch_dimension(monkeypatch):
+    """Validation must support models that return final hidden states as a tensor."""
+    from nemo_automodel.components.loss.linear_ce import FusedLinearCrossEntropy
+
+    monkeypatch.setattr(vlm_finetune, "ScopedRNG", lambda *a, **k: nullcontext())
+    monkeypatch.setattr(vlm_finetune.ContextParallelSharder, "shard", _identity_cp_shard)
+    monkeypatch.setattr(vlm_finetune, "filter_forward_kwargs", lambda model, batch: batch)
+
+    captured = {}
+
+    def _capture_loss(*args, hidden_states, labels, **kwargs):
+        captured["hidden_states"] = hidden_states
+        captured["labels"] = labels
+        return torch.tensor(2.0)
+
+    monkeypatch.setattr(vlm_finetune, "calculate_loss", _capture_loss)
+
+    class _Model(torch.nn.Module):
+        def eval(self):
+            return self
+
+        def forward(self, logits_to_keep=None, **batch):
+            assert logits_to_keep == 1
+            return SimpleNamespace(
+                logits=torch.zeros(1, 1, 8),
+                hidden_states=torch.zeros(1, 4, 8),
+            )
+
+    recipe = FinetuneRecipeForVLM.__new__(FinetuneRecipeForVLM)
+    recipe.model_parts = [_Model()]
+    recipe.loss_fn = FusedLinearCrossEntropy()
+    recipe.device_mesh = None
+    recipe.pp_enabled = False
+    recipe.dist_env = SimpleNamespace(device=torch.device("cpu"))
+    recipe.step_scheduler = SimpleNamespace(step=3, epoch=1)
+    recipe.optimizer = [SimpleNamespace(param_groups=[{"lr": 0.001}])]
+    recipe._maybe_add_drafter_loss = lambda *, out, base_loss, labels, model, num_label_tokens: base_loss
+    recipe._dp_allreduce = lambda tensor, include_cp=False: tensor
+
+    batch = {
+        "input_ids": torch.tensor([[1, 2, 3, 4]]),
+        "labels": torch.tensor([[1, 2, -100, 4]]),
+    }
+
+    recipe._run_validation_epoch([batch])
+
+    assert captured["hidden_states"].shape == (1, 4, 8)
+    assert captured["hidden_states"].shape[:-1] == captured["labels"].shape
+
+
 def test_run_validation_epoch_cp_active_runs_pre_embed(monkeypatch):
     """With CP active and a model exposing prepare_model_inputs_for_cp, the
     validation loop must invoke the model's sharder-only CP hook before sharding.


### PR DESCRIPTION
# What does this PR do?

Preserves the batch dimension during VLM validation when a model returns its
final hidden states directly as a `[B, T, H]` tensor.

The training path already uses `get_final_hidden_states(out)`, which supports
both tensor-valued and tuple/list-valued hidden states. This PR uses the same
helper in `_run_validation_epoch()` instead of unconditionally indexing
`out.hidden_states[-1]`.

Fixes #3215.

# Changelog

- Use `get_final_hidden_states(out)` in the VLM validation loss path.
- Add a CPU-only regression test that exercises `_run_validation_epoch()` with
  tensor-valued hidden states and verifies that `[B, T, H]` reaches the loss
  unchanged.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added a regression test for the corrected behavior.
- [x] No documentation change is necessary for this internal validation fix.

# Validation

- `python3 -m py_compile nemo_automodel/recipes/vlm/finetune.py tests/unit_tests/recipes/test_finetune_vlm_cp_wiring.py`
- `git diff --check`

The focused pytest case was not run locally because the local checkout does not
have PyTorch or the project test environment installed. The added test is
CPU-only and is intended to run in the repository CI environment.

# Additional Information

- Related issue: #3215
- Reproduced against `main` commit
  `622cc24ba9206eee9cde6067ca0a50d95dcc8b25`.
