### PR TITLE
fix(transformers): custom configs override builtin ones by default

### DIFF
--- a/nemo_automodel/_transformers/registry.py
+++ b/nemo_automodel/_transformers/registry.py
@@ -316,7 +316,11 @@ _CUSTOM_CONFIG_REGISTRATIONS: Dict[str, Tuple[str, str]] = {
 # silently collapses the DSV4 context-parallel shard multiple to 1.
 # Only list a model_type here once its custom model is verified to run on the
 # native config (mistral4 was written against it and runs green).
-_KEEP_BUILTIN_CONFIG = {  # pragma: no cover - static policy data
+# Policy summary:
+# - registered Automodel configs win by default;
+# - transformers-native configs win only for explicit opt-outs;
+# - opt-outs require model-specific verification against the native schema.
+_KEEP_BUILTIN_CONFIG = {
     "mistral4",
 }
 
@@ -326,16 +330,16 @@ def resolve_custom_config_cls(model_type: str) -> Type[PretrainedConfig] | None:
     if model_type not in _CUSTOM_CONFIG_REGISTRATIONS:
         return None
 
-    if model_type in _KEEP_BUILTIN_CONFIG:  # pragma: no cover - covered by focused registry tests
+    if model_type in _KEEP_BUILTIN_CONFIG:
         from transformers.models.auto.configuration_auto import CONFIG_MAPPING
 
         if model_type in CONFIG_MAPPING:
             return None
 
-    module_path, cls_name = _CUSTOM_CONFIG_REGISTRATIONS[model_type]  # pragma: no cover
+    module_path, cls_name = _CUSTOM_CONFIG_REGISTRATIONS[model_type]
     try:
         mod = importlib.import_module(module_path)
-        return getattr(mod, cls_name)  # pragma: no cover
+        return getattr(mod, cls_name)
     except Exception:
         logger.debug("Failed to resolve custom config for model_type=%s", model_type, exc_info=True)
         return None

--- a/nemo_automodel/_transformers/registry.py
+++ b/nemo_automodel/_transformers/registry.py
@@ -304,19 +304,20 @@ _CUSTOM_CONFIG_REGISTRATIONS: Dict[str, Tuple[str, str]] = {
     "step3p7": ("nemo_automodel.components.models.step3p7.configuration_step3p7", "Step3p7Config"),
 }
 
-# model_types whose custom model implementation reads fields that only our
-# config class provides. When a transformers release starts shipping its own
-# config for one of these model_types (same model_type string, often the same
-# class name), the skip-if-built-in registration below would silently hand the
-# native config to our custom model and break its field protocol at init
-# (transformers 5.12 added minimax_m3_vl whose vision config drops rope_theta
-# -> ``'MiniMaxM3VLVisionConfig' object has no attribute 'rope_theta'``).
-# These entries override the built-in registration instead. Entries NOT listed
-# here keep the built-in config when one exists (mistral4's custom model was
-# written against the native config and runs green with it).
-_CUSTOM_CONFIG_OVERRIDES_BUILTIN = {
-    "laguna",
-    "minimax_m3_vl",
+# model_types registered above that must keep the transformers built-in config
+# when one exists. A registration means the custom model reads fields only our
+# config class provides, so the built-in must NOT win by default: when a
+# transformers release starts shipping a config for a registered model_type
+# (same model_type string, often the same class name) it would silently replace
+# ours and break the model's field protocol at init -- e.g. transformers 5.12
+# added minimax_m3_vl whose vision config drops rope_theta
+# (``'MiniMaxM3VLVisionConfig' object has no attribute 'rope_theta'``), and its
+# deepseek_v4 config renames ``compress_ratios`` to ``compress_rates``, which
+# silently collapses the DSV4 context-parallel shard multiple to 1.
+# Only list a model_type here once its custom model is verified to run on the
+# native config (mistral4 was written against it and runs green).
+_KEEP_BUILTIN_CONFIG = {
+    "mistral4",
 }
 
 
@@ -325,11 +326,11 @@ def resolve_custom_config_cls(model_type: str) -> Type[PretrainedConfig] | None:
     if model_type not in _CUSTOM_CONFIG_REGISTRATIONS:
         return None
 
-    from transformers.models.auto.configuration_auto import CONFIG_MAPPING
+    if model_type in _KEEP_BUILTIN_CONFIG:
+        from transformers.models.auto.configuration_auto import CONFIG_MAPPING
 
-    is_builtin = model_type in CONFIG_MAPPING
-    if is_builtin and model_type not in _CUSTOM_CONFIG_OVERRIDES_BUILTIN:
-        return None
+        if model_type in CONFIG_MAPPING:
+            return None
 
     module_path, cls_name = _CUSTOM_CONFIG_REGISTRATIONS[model_type]
     try:

--- a/nemo_automodel/_transformers/registry.py
+++ b/nemo_automodel/_transformers/registry.py
@@ -316,7 +316,7 @@ _CUSTOM_CONFIG_REGISTRATIONS: Dict[str, Tuple[str, str]] = {
 # silently collapses the DSV4 context-parallel shard multiple to 1.
 # Only list a model_type here once its custom model is verified to run on the
 # native config (mistral4 was written against it and runs green).
-_KEEP_BUILTIN_CONFIG = {
+_KEEP_BUILTIN_CONFIG = {  # pragma: no cover - static policy data
     "mistral4",
 }
 

--- a/nemo_automodel/_transformers/registry.py
+++ b/nemo_automodel/_transformers/registry.py
@@ -326,16 +326,16 @@ def resolve_custom_config_cls(model_type: str) -> Type[PretrainedConfig] | None:
     if model_type not in _CUSTOM_CONFIG_REGISTRATIONS:
         return None
 
-    if model_type in _KEEP_BUILTIN_CONFIG:
+    if model_type in _KEEP_BUILTIN_CONFIG:  # pragma: no cover - covered by focused registry tests
         from transformers.models.auto.configuration_auto import CONFIG_MAPPING
 
         if model_type in CONFIG_MAPPING:
             return None
 
-    module_path, cls_name = _CUSTOM_CONFIG_REGISTRATIONS[model_type]
+    module_path, cls_name = _CUSTOM_CONFIG_REGISTRATIONS[model_type]  # pragma: no cover
     try:
         mod = importlib.import_module(module_path)
-        return getattr(mod, cls_name)
+        return getattr(mod, cls_name)  # pragma: no cover
     except Exception:
         logger.debug("Failed to resolve custom config for model_type=%s", model_type, exc_info=True)
         return None

--- a/nemo_automodel/_transformers/registry.py
+++ b/nemo_automodel/_transformers/registry.py
@@ -304,24 +304,20 @@ _CUSTOM_CONFIG_REGISTRATIONS: Dict[str, Tuple[str, str]] = {
     "step3p7": ("nemo_automodel.components.models.step3p7.configuration_step3p7", "Step3p7Config"),
 }
 
-# model_types registered above that must keep the transformers built-in config
-# when one exists. A registration means the custom model reads fields only our
-# config class provides, so the built-in must NOT win by default: when a
-# transformers release starts shipping a config for a registered model_type
-# (same model_type string, often the same class name) it would silently replace
-# ours and break the model's field protocol at init -- e.g. transformers 5.12
-# added minimax_m3_vl whose vision config drops rope_theta
+# model_types whose custom model implementation should win over a transformers
+# built-in config when one exists. A registration means the custom model reads
+# fields only our config class provides, so the built-in must NOT win by
+# default: when a transformers release starts shipping a config for a registered
+# model_type (same model_type string, often the same class name) it would
+# silently replace ours and break the model's field protocol at init -- e.g.
+# transformers 5.12 added minimax_m3_vl whose vision config drops rope_theta
 # (``'MiniMaxM3VLVisionConfig' object has no attribute 'rope_theta'``), and its
 # deepseek_v4 config renames ``compress_ratios`` to ``compress_rates``, which
 # silently collapses the DSV4 context-parallel shard multiple to 1.
-# Only list a model_type here once its custom model is verified to run on the
+# Remove a model_type only once its custom model is verified to run on the
 # native config (mistral4 was written against it and runs green).
-# Policy summary:
-# - registered Automodel configs win by default;
-# - transformers-native configs win only for explicit opt-outs;
-# - opt-outs require model-specific verification against the native schema.
-_KEEP_BUILTIN_CONFIG = {
-    "mistral4",
+_CUSTOM_CONFIG_OVERRIDES_BUILTIN = {
+    *(_CUSTOM_CONFIG_REGISTRATIONS.keys() - {"mistral4"}),
 }
 
 
@@ -330,11 +326,11 @@ def resolve_custom_config_cls(model_type: str) -> Type[PretrainedConfig] | None:
     if model_type not in _CUSTOM_CONFIG_REGISTRATIONS:
         return None
 
-    if model_type in _KEEP_BUILTIN_CONFIG:
-        from transformers.models.auto.configuration_auto import CONFIG_MAPPING
+    from transformers.models.auto.configuration_auto import CONFIG_MAPPING
 
-        if model_type in CONFIG_MAPPING:
-            return None
+    is_builtin = model_type in CONFIG_MAPPING
+    if is_builtin and model_type not in _CUSTOM_CONFIG_OVERRIDES_BUILTIN:
+        return None
 
     module_path, cls_name = _CUSTOM_CONFIG_REGISTRATIONS[model_type]
     try:

--- a/tests/unit_tests/_transformers/test_model_init.py
+++ b/tests/unit_tests/_transformers/test_model_init.py
@@ -597,7 +597,7 @@ class TestResolveCustomConfigRegistry:
         from nemo_automodel._transformers import registry as reg
 
         monkeypatch.setitem(reg._CUSTOM_CONFIG_REGISTRATIONS, "bert", ("fake.config_module", "FakeConfig"))
-        monkeypatch.setattr(reg, "_KEEP_BUILTIN_CONFIG", {"bert"})
+        monkeypatch.setattr(reg, "_CUSTOM_CONFIG_OVERRIDES_BUILTIN", set())
 
         assert reg.resolve_custom_config_cls("bert") is None
 
@@ -609,7 +609,7 @@ class TestResolveCustomConfigRegistry:
 
         fake_module = types.SimpleNamespace(FakeConfig=FakeConfig)
         monkeypatch.setitem(reg._CUSTOM_CONFIG_REGISTRATIONS, "bert", ("fake.config_module", "FakeConfig"))
-        monkeypatch.setattr(reg, "_KEEP_BUILTIN_CONFIG", set())
+        monkeypatch.setattr(reg, "_CUSTOM_CONFIG_OVERRIDES_BUILTIN", {"bert"})
         monkeypatch.setattr(
             reg.importlib, "import_module", lambda name: fake_module if name == "fake.config_module" else None
         )

--- a/tests/unit_tests/_transformers/test_model_init.py
+++ b/tests/unit_tests/_transformers/test_model_init.py
@@ -15,6 +15,7 @@
 """Tests for nested config override handling in get_hf_config and _consume_config_overrides."""
 
 import os
+import types
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -582,6 +583,38 @@ class TestGetHfConfigCustomRegistry:
 
         assert result is fallback_config
         mock_auto_config.assert_called_once()
+
+
+class TestResolveCustomConfigRegistry:
+    """resolve_custom_config_cls should prefer Automodel configs unless explicitly opted out."""
+
+    def test_unregistered_model_type_returns_none(self):
+        from nemo_automodel._transformers import registry as reg
+
+        assert reg.resolve_custom_config_cls("not_registered") is None
+
+    def test_keep_builtin_config_defers_to_transformers_builtin(self, monkeypatch):
+        from nemo_automodel._transformers import registry as reg
+
+        monkeypatch.setitem(reg._CUSTOM_CONFIG_REGISTRATIONS, "bert", ("fake.config_module", "FakeConfig"))
+        monkeypatch.setattr(reg, "_KEEP_BUILTIN_CONFIG", {"bert"})
+
+        assert reg.resolve_custom_config_cls("bert") is None
+
+    def test_registered_builtin_uses_automodel_config_by_default(self, monkeypatch):
+        from nemo_automodel._transformers import registry as reg
+
+        class FakeConfig:
+            pass
+
+        fake_module = types.SimpleNamespace(FakeConfig=FakeConfig)
+        monkeypatch.setitem(reg._CUSTOM_CONFIG_REGISTRATIONS, "bert", ("fake.config_module", "FakeConfig"))
+        monkeypatch.setattr(reg, "_KEEP_BUILTIN_CONFIG", set())
+        monkeypatch.setattr(
+            reg.importlib, "import_module", lambda name: fake_module if name == "fake.config_module" else None
+        )
+
+        assert reg.resolve_custom_config_cls("bert") is FakeConfig
 
 
 class TestDictConfigOverrideKeepsCustomPath:

--- a/tests/unit_tests/_transformers/test_registry.py
+++ b/tests/unit_tests/_transformers/test_registry.py
@@ -233,11 +233,17 @@ def test_resolve_custom_config_cls_returns_none_for_unregistered_model_type():
     assert reg.resolve_custom_config_cls("not_registered") is None
 
 
+def test_custom_config_overrides_default_to_registered_models_except_verified_opt_outs():
+    from nemo_automodel._transformers import registry as reg
+
+    assert reg._CUSTOM_CONFIG_OVERRIDES_BUILTIN == set(reg._CUSTOM_CONFIG_REGISTRATIONS) - {"mistral4"}
+
+
 def test_resolve_custom_config_cls_defers_to_builtin_only_when_opted_out(monkeypatch):
     from nemo_automodel._transformers import registry as reg
 
     monkeypatch.setitem(reg._CUSTOM_CONFIG_REGISTRATIONS, "bert", ("fake.config_module", "FakeConfig"))
-    monkeypatch.setattr(reg, "_KEEP_BUILTIN_CONFIG", {"bert"})
+    monkeypatch.setattr(reg, "_CUSTOM_CONFIG_OVERRIDES_BUILTIN", set())
 
     assert reg.resolve_custom_config_cls("bert") is None
 
@@ -250,7 +256,7 @@ def test_resolve_custom_config_cls_overrides_transformers_builtin_by_default(mon
 
     fake_module = types.SimpleNamespace(FakeConfig=FakeConfig)
     monkeypatch.setitem(reg._CUSTOM_CONFIG_REGISTRATIONS, "bert", ("fake.config_module", "FakeConfig"))
-    monkeypatch.setattr(reg, "_KEEP_BUILTIN_CONFIG", set())
+    monkeypatch.setattr(reg, "_CUSTOM_CONFIG_OVERRIDES_BUILTIN", {"bert"})
     monkeypatch.setattr(
         reg.importlib, "import_module", lambda name: fake_module if name == "fake.config_module" else None
     )
@@ -265,7 +271,7 @@ def test_resolve_custom_config_cls_returns_none_when_registered_import_fails(mon
         raise ImportError(name)
 
     monkeypatch.setitem(reg._CUSTOM_CONFIG_REGISTRATIONS, "am_broken", ("fake.missing_module", "MissingConfig"))
-    monkeypatch.setattr(reg, "_KEEP_BUILTIN_CONFIG", set())
+    monkeypatch.setattr(reg, "_CUSTOM_CONFIG_OVERRIDES_BUILTIN", {"am_broken"})
     monkeypatch.setattr(reg.importlib, "import_module", raise_import_error)
 
     assert reg.resolve_custom_config_cls("am_broken") is None
@@ -277,11 +283,12 @@ def test_registered_config_wins_over_transformers_builtin(model_type):
 
     A registration means the custom model reads fields only our config provides,
     so a transformers release that starts shipping the same ``model_type`` must
-    not silently take over. Opt-outs live in ``_KEEP_BUILTIN_CONFIG``.
+    not silently take over. Model types absent from
+    ``_CUSTOM_CONFIG_OVERRIDES_BUILTIN`` opt out to the transformers-native config.
     """
     from nemo_automodel._transformers import registry as reg
 
-    if model_type in reg._KEEP_BUILTIN_CONFIG:
+    if model_type not in reg._CUSTOM_CONFIG_OVERRIDES_BUILTIN:
         pytest.skip(f"{model_type} is verified to run on the transformers built-in config")
 
     resolved = reg.resolve_custom_config_cls(model_type)
@@ -502,8 +509,8 @@ def test_minimax_m3_vl_config_overrides_transformers_builtin():
     config to our custom MiniMaxM3SparseForConditionalGeneration, whose vision
     encoder reads ``config.rope_theta`` that the native vision config does not
     carry -> AttributeError at model init. Automodel now prefers registered
-    local config classes by default; only model_types in ``_KEEP_BUILTIN_CONFIG``
-    opt out to the transformers-native config.
+    local config classes by default; only model_types absent from
+    ``_CUSTOM_CONFIG_OVERRIDES_BUILTIN`` opt out to the transformers-native config.
     """
     from transformers.models.auto.configuration_auto import CONFIG_MAPPING
 

--- a/tests/unit_tests/_transformers/test_registry.py
+++ b/tests/unit_tests/_transformers/test_registry.py
@@ -16,6 +16,8 @@ import types
 
 import pytest
 
+from nemo_automodel._transformers.registry import _CUSTOM_CONFIG_REGISTRATIONS
+
 
 def _new_registry_instance(registry_module):
     """Create a fresh registry with an empty auto_map for testing."""
@@ -225,15 +227,16 @@ def test_resolve_custom_config_cls_uses_registry_for_non_builtin(monkeypatch):
     assert reg.resolve_custom_config_cls("am_future") is FakeConfig
 
 
-def test_resolve_custom_config_cls_defers_to_transformers_builtin(monkeypatch):
+def test_resolve_custom_config_cls_defers_to_builtin_only_when_opted_out(monkeypatch):
     from nemo_automodel._transformers import registry as reg
 
     monkeypatch.setitem(reg._CUSTOM_CONFIG_REGISTRATIONS, "bert", ("fake.config_module", "FakeConfig"))
+    monkeypatch.setattr(reg, "_KEEP_BUILTIN_CONFIG", {"bert"})
 
     assert reg.resolve_custom_config_cls("bert") is None
 
 
-def test_resolve_custom_config_cls_can_override_transformers_builtin(monkeypatch):
+def test_resolve_custom_config_cls_overrides_transformers_builtin_by_default(monkeypatch):
     from nemo_automodel._transformers import registry as reg
 
     class FakeConfig:
@@ -241,12 +244,32 @@ def test_resolve_custom_config_cls_can_override_transformers_builtin(monkeypatch
 
     fake_module = types.SimpleNamespace(FakeConfig=FakeConfig)
     monkeypatch.setitem(reg._CUSTOM_CONFIG_REGISTRATIONS, "bert", ("fake.config_module", "FakeConfig"))
-    monkeypatch.setattr(reg, "_CUSTOM_CONFIG_OVERRIDES_BUILTIN", {"bert"})
+    monkeypatch.setattr(reg, "_KEEP_BUILTIN_CONFIG", set())
     monkeypatch.setattr(
         reg.importlib, "import_module", lambda name: fake_module if name == "fake.config_module" else None
     )
 
     assert reg.resolve_custom_config_cls("bert") is FakeConfig
+
+
+@pytest.mark.parametrize("model_type", sorted(_CUSTOM_CONFIG_REGISTRATIONS))
+def test_registered_config_wins_over_transformers_builtin(model_type):
+    """A registered model_type must resolve to Automodel's config, not the built-in.
+
+    A registration means the custom model reads fields only our config provides,
+    so a transformers release that starts shipping the same ``model_type`` must
+    not silently take over. Opt-outs live in ``_KEEP_BUILTIN_CONFIG``.
+    """
+    from nemo_automodel._transformers import registry as reg
+
+    if model_type in reg._KEEP_BUILTIN_CONFIG:
+        pytest.skip(f"{model_type} is verified to run on the transformers built-in config")
+
+    resolved = reg.resolve_custom_config_cls(model_type)
+    assert resolved is not None, f"{model_type} resolves to no config class"
+    assert resolved.__module__.startswith("nemo_automodel"), (
+        f"{model_type} resolves to {resolved.__module__}.{resolved.__name__}, not Automodel's config"
+    )
 
 
 def test_resolve_custom_model_cls_found():

--- a/tests/unit_tests/_transformers/test_registry.py
+++ b/tests/unit_tests/_transformers/test_registry.py
@@ -227,6 +227,12 @@ def test_resolve_custom_config_cls_uses_registry_for_non_builtin(monkeypatch):
     assert reg.resolve_custom_config_cls("am_future") is FakeConfig
 
 
+def test_resolve_custom_config_cls_returns_none_for_unregistered_model_type():
+    from nemo_automodel._transformers import registry as reg
+
+    assert reg.resolve_custom_config_cls("not_registered") is None
+
+
 def test_resolve_custom_config_cls_defers_to_builtin_only_when_opted_out(monkeypatch):
     from nemo_automodel._transformers import registry as reg
 
@@ -250,6 +256,19 @@ def test_resolve_custom_config_cls_overrides_transformers_builtin_by_default(mon
     )
 
     assert reg.resolve_custom_config_cls("bert") is FakeConfig
+
+
+def test_resolve_custom_config_cls_returns_none_when_registered_import_fails(monkeypatch):
+    from nemo_automodel._transformers import registry as reg
+
+    def raise_import_error(name):
+        raise ImportError(name)
+
+    monkeypatch.setitem(reg._CUSTOM_CONFIG_REGISTRATIONS, "am_broken", ("fake.missing_module", "MissingConfig"))
+    monkeypatch.setattr(reg, "_KEEP_BUILTIN_CONFIG", set())
+    monkeypatch.setattr(reg.importlib, "import_module", raise_import_error)
+
+    assert reg.resolve_custom_config_cls("am_broken") is None
 
 
 @pytest.mark.parametrize("model_type", sorted(_CUSTOM_CONFIG_REGISTRATIONS))

--- a/tests/unit_tests/_transformers/test_registry.py
+++ b/tests/unit_tests/_transformers/test_registry.py
@@ -482,8 +482,9 @@ def test_minimax_m3_vl_config_overrides_transformers_builtin():
     names as ours). The skip-if-built-in registration then handed the native
     config to our custom MiniMaxM3SparseForConditionalGeneration, whose vision
     encoder reads ``config.rope_theta`` that the native vision config does not
-    carry -> AttributeError at model init. ``_CUSTOM_CONFIG_OVERRIDES_BUILTIN``
-    forces our config class for such model_types.
+    carry -> AttributeError at model init. Automodel now prefers registered
+    local config classes by default; only model_types in ``_KEEP_BUILTIN_CONFIG``
+    opt out to the transformers-native config.
     """
     from transformers.models.auto.configuration_auto import CONFIG_MAPPING
 


### PR DESCRIPTION
# What does this PR do ?

Makes a registered custom config win over a transformers built-in of the same `model_type`, instead of silently deferring to it.

`_CUSTOM_CONFIG_REGISTRATIONS` exists because those models read fields only Automodel's config provides. But `resolve_custom_config_cls` defaulted the other way — if transformers shipped a config for the same `model_type`, ours was dropped unless the `model_type` was *also* listed in an opt-in `_CUSTOM_CONFIG_OVERRIDES_BUILTIN` set. That set is hand-maintained and has only ever grown after an incident, so each new upstream config silently replaces ours rather than failing.

## The bug this surfaces

Two registered models are already in that state on transformers 5.8.1:

**`deepseek_v4`** — on `main`:

```python
>>> resolve_custom_config_cls("deepseek_v4")
None
>>> type(AutoConfig.from_pretrained("deepseek-ai/DeepSeek-V4-Flash"))
transformers.models.deepseek_v4.configuration_deepseek_v4.DeepseekV4Config
>>> hasattr(cfg, "compress_ratios"), hasattr(cfg, "compress_rates")
(False, True)
```

Upstream renamed `compress_ratios` (list) to `compress_rates` (dict). `deepseek_v4/cp.py` reads `compress_ratios`:

```python
ratios = [int(r) for r in (getattr(config, "compress_ratios", None) or []) if int(r) > 0]
```

so it gets an empty list and `dsv4_cp_local_seq_multiple` returns 1 — the DSV4 **context-parallel shard multiple silently collapses to 1**. No exception, just a wrong shard geometry.

**`hy_v3`** — same skip. Its model reads `first_k_dense_replace`, `route_norm` and `moe_router_enable_expert_bias`; the built-in config provides none of them.

Note on reproducing: check built-in status with `CONFIG_MAPPING_NAMES`, not `CONFIG_MAPPING` — the latter is mutated by our own `AutoConfig.register` at import, so everything looks built-in after `import nemo_automodel`.

## The change

Invert the default and keep an explicit opt-out:

```python
_KEEP_BUILTIN_CONFIG = {"mistral4"}   # verified to run on the native config
```

`mistral4` is the only member, carried over from the note in the previous comment. This also protects the 11 registered `model_type`s transformers does not ship yet — each would have degraded the same silent way the day upstream adds one.

Aligns with `CLAUDE.md`, which already states a `model_type` should be registered when "Automodel needs a local config class to preserve its model contract", and asks for a focused test proving `AutoConfig` resolves the local config.

## Validation

- `pytest tests/unit_tests/_transformers/test_registry.py` → **42 passed, 1 skipped** (the `mistral4` opt-out)
- `pytest tests/unit_tests/_transformers/test_model_init.py` → 5 `TestStreamLoadBnbWeights` failures, **identical on unpatched `main`** (pre-existing, bitsandbytes-related)
- After the change: `deepseek_v4` → `DeepseekV4Config`, `hy_v3` → `HYV3Config`, `mistral4` → `None`; loading DeepSeek-V4-Flash now exposes `compress_ratios`
- `ruff format --check` / `ruff check` on both touched files

New test `test_registered_config_wins_over_transformers_builtin` is parametrized over every registered `model_type` and asserts it resolves to a class under `nemo_automodel`. A future upstream config addition now fails the suite instead of quietly downgrading the model — which is how these two went unnoticed.

## Not in this PR

- `glm_moe_dsa` has **no** Automodel config class at all, so it always uses the built-in and inherits `attribute_map = {"head_dim": "qk_rope_head_dim"}`; the official GLM-5.2 `config.json` sets both keys, so `qk_rope_head_dim` becomes 192 and the DSA indexer computes `split_sizes=[192, -64]`. Today the only fix is `config: {head_dim: 64}` in the recipe YAML, so any downstream consumer that doesn't know that line hard-crashes. Needs a new config class — separate PR.
- Registering the `model_type`s that own a config class but are absent from `_CUSTOM_CONFIG_REGISTRATIONS` (`deepseek_v32`, `hy_mt2`, `ministral3`, ...). Nothing is broken today; it needs a per-model pass on which are top-level vs sub-configs.

# Before your PR is "Ready for review"

**Pre checks**:

- [X] Make sure you read and followed [Contributor guidelines](<https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md>)
- [X] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)
