### PR TITLE
fix(glm): own the GLM MoE DSA config so qk_rope_head_dim survives

### DIFF
--- a/examples/llm_finetune/glm/glm_5.2_lora.yaml
+++ b/examples/llm_finetune/glm/glm_5.2_lora.yaml
@@ -43,8 +43,6 @@ model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: ${oc.env:GLM52_MODEL_PATH,zai-org/GLM-5.2}
   trust_remote_code: true
-  config:
-    head_dim: 64
   backend:
     _target_: nemo_automodel.components.models.common.BackendConfig
     attn: tilelang

--- a/examples/llm_finetune/glm/glm_5.2_tulu3_32k_tilelang_cp8.yaml
+++ b/examples/llm_finetune/glm/glm_5.2_tulu3_32k_tilelang_cp8.yaml
@@ -56,8 +56,6 @@ dist_env:
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: zai-org/GLM-5.2
-  config:
-    head_dim: 64
   backend:
     _target_: nemo_automodel.components.models.common.BackendConfig
     attn: tilelang

--- a/examples/llm_finetune/glm/glm_5.2_tulu3_4k_tilelang_100k.yaml
+++ b/examples/llm_finetune/glm/glm_5.2_tulu3_4k_tilelang_100k.yaml
@@ -54,8 +54,6 @@ dist_env:
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
   pretrained_model_name_or_path: zai-org/GLM-5.2
-  config:
-    head_dim: 64
   backend:
     _target_: nemo_automodel.components.models.common.BackendConfig
     attn: tilelang

--- a/nemo_automodel/_transformers/registry.py
+++ b/nemo_automodel/_transformers/registry.py
@@ -294,6 +294,7 @@ _CUSTOM_CONFIG_REGISTRATIONS: Dict[str, Tuple[str, str]] = {
     "baichuan": ("nemo_automodel.components.models.baichuan.configuration", "BaichuanConfig"),
     "bailing_moe": ("nemo_automodel.components.models.ling_v2.config", "BailingMoeV2Config"),
     "deepseek_v4": ("nemo_automodel.components.models.deepseek_v4.config", "DeepseekV4Config"),
+    "glm_moe_dsa": ("nemo_automodel.components.models.glm_moe_dsa.config", "GlmMoeDsaConfig"),
     "hy_v3": ("nemo_automodel.components.models.hy_v3.config", "HYV3Config"),
     "inkling_mm_model": ("nemo_automodel.components.models.inkling.configuration", "InklingConfig"),
     "kimi_k2": ("nemo_automodel.components.models.kimi_k2.config", "KimiK2Config"),

--- a/nemo_automodel/components/models/glm_moe_dsa/config.py
+++ b/nemo_automodel/components/models/glm_moe_dsa/config.py
@@ -1,0 +1,171 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Automodel's own GLM MoE DSA config."""
+
+from transformers.configuration_utils import PretrainedConfig
+
+__all__ = ["GlmMoeDsaConfig"]
+
+
+class GlmMoeDsaConfig(PretrainedConfig):
+    """Configuration for GLM MoE DSA (DeepSeek-style sparse attention).
+
+    Standalone rather than a subclass of the transformers config, matching the
+    other Automodel-owned configs: Automodel ships its own GLM DSA modeling
+    code, so its field protocol must not move when transformers releases do.
+    Subclassing also inherited ``attribute_map`` entries, one of which is
+    actively harmful -- transformers maps ``head_dim`` onto ``qk_rope_head_dim``
+    while the released GLM-5.2 ``config.json`` sets both (``head_dim: 192``, the
+    full QK head dim, and ``qk_rope_head_dim: 64``), so the alias overwrote the
+    rope dim with 192 and the DSA indexer's nope split went negative
+    (``index_head_dim - qk_rope_head_dim = 128 - 192``). Only the expert-count
+    alias is kept here.
+    """
+
+    model_type = "glm_moe_dsa"
+    keys_to_ignore_at_inference = ["past_key_values"]
+    attribute_map = {"num_local_experts": "n_routed_experts"}
+
+    def __init__(
+        self,
+        vocab_size: int = 154880,
+        hidden_size: int = 6144,
+        intermediate_size: int = 12288,
+        moe_intermediate_size: int = 2048,
+        num_hidden_layers: int = 78,
+        num_attention_heads: int = 64,
+        num_key_value_heads: int = 64,
+        # MoE routing
+        n_shared_experts: int = 1,
+        n_routed_experts: int = 256,
+        routed_scaling_factor: float = 2.5,
+        n_group: int = 1,
+        topk_group: int = 1,
+        num_experts_per_tok: int = 8,
+        norm_topk_prob: bool = True,
+        mlp_layer_types: list[str] | None = None,
+        # MLA projections
+        kv_lora_rank: int = 512,
+        q_lora_rank: int = 2048,
+        qk_rope_head_dim: int = 64,
+        qk_nope_head_dim: int = 192,
+        v_head_dim: int = 256,
+        # DSA lightning indexer
+        index_topk: int = 2048,
+        index_head_dim: int = 128,
+        index_n_heads: int = 32,
+        indexer_types: list[str] | None = None,
+        index_topk_pattern: str | list[str] | None = None,
+        index_topk_freq: int = 1,
+        # Misc
+        hidden_act: str = "silu",
+        max_position_embeddings: int = 202752,
+        initializer_range: float = 0.02,
+        rms_norm_eps: float = 1e-5,
+        use_cache: bool = True,
+        attention_bias: bool = False,
+        attention_dropout: float = 0.0,
+        rope_parameters: dict | None = None,
+        pad_token_id: int | None = None,
+        bos_token_id: int | None = 0,
+        eos_token_id: int | list[int] | None = 1,
+        tie_word_embeddings: bool = False,
+        **kwargs,
+    ):
+        """Initialize the config.
+
+        Args:
+            mlp_layer_types: Per-layer ``"dense"``/``"sparse"`` MLP pattern.
+                Derived as 3 dense layers then sparse when omitted.
+            indexer_types: Per-layer ``"full"``/``"shared"`` indexer pattern.
+                Derived from ``index_topk_pattern`` / ``index_topk_freq`` when
+                omitted.
+            index_topk_pattern: Indexer pattern as an ``F``/``S`` string or an
+                explicit list.
+            index_topk_freq: Stride used when no pattern is given: layer 0 and
+                every ``index_topk_freq``-th layer after it are ``"full"``.
+            rope_parameters: RoPE settings (``rope_theta``, ``rope_type``, plus
+                the YaRN keys when scaled), carried as a plain dict.
+            **kwargs: Forwarded to :class:`~transformers.PretrainedConfig`;
+                checkpoint keys Automodel does not read stay available on the
+                instance.
+        """
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.moe_intermediate_size = moe_intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.num_key_value_heads = num_key_value_heads
+
+        self.n_shared_experts = n_shared_experts
+        self.n_routed_experts = n_routed_experts
+        self.routed_scaling_factor = routed_scaling_factor
+        self.n_group = n_group
+        self.topk_group = topk_group
+        self.num_experts_per_tok = num_experts_per_tok
+        self.norm_topk_prob = norm_topk_prob
+
+        self.kv_lora_rank = kv_lora_rank
+        self.q_lora_rank = q_lora_rank
+        self.qk_rope_head_dim = qk_rope_head_dim
+        self.qk_nope_head_dim = qk_nope_head_dim
+        self.v_head_dim = v_head_dim
+        # The attention layers size their Q/K projections from the combined
+        # width, so keep it on the config instead of recomputing per layer.
+        self.qk_head_dim = qk_nope_head_dim + qk_rope_head_dim
+
+        self.index_topk = index_topk
+        self.index_head_dim = index_head_dim
+        self.index_n_heads = index_n_heads
+        self.index_topk_pattern = index_topk_pattern
+        self.index_topk_freq = index_topk_freq
+
+        self.hidden_act = hidden_act
+        self.max_position_embeddings = max_position_embeddings
+        self.initializer_range = initializer_range
+        self.rms_norm_eps = rms_norm_eps
+        self.use_cache = use_cache
+        self.attention_bias = attention_bias
+        self.attention_dropout = attention_dropout
+        self.rope_parameters = rope_parameters
+
+        # Released checkpoints spell both lists out; these defaults only cover
+        # configs that omit them.
+        if mlp_layer_types is None:
+            dense_layers = min(3, num_hidden_layers)
+            mlp_layer_types = ["dense"] * dense_layers + ["sparse"] * (num_hidden_layers - dense_layers)
+        self.mlp_layer_types = mlp_layer_types
+
+        if indexer_types is None:
+            if index_topk_pattern is not None:
+                indexer_types = (
+                    [{"F": "full", "S": "shared"}[char] for char in index_topk_pattern]
+                    if isinstance(index_topk_pattern, str)
+                    else list(index_topk_pattern)
+                )
+            else:
+                freq = max(int(index_topk_freq), 1)
+                indexer_types = ["full" if (max(i - 1, 0) % freq) == 0 else "shared" for i in range(num_hidden_layers)]
+        self.indexer_types = indexer_types
+
+        super().__init__(
+            pad_token_id=pad_token_id,
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
+            tie_word_embeddings=tie_word_embeddings,
+            **kwargs,
+        )

--- a/nemo_automodel/components/models/glm_moe_dsa/cp.py
+++ b/nemo_automodel/components/models/glm_moe_dsa/cp.py
@@ -21,7 +21,10 @@ import contextlib
 import torch
 import torch.distributed as dist
 
-from nemo_automodel.components.distributed.context_parallel.sharder import ShardLayout
+from nemo_automodel.components.distributed.context_parallel.sharder import (
+    ShardLayout,
+    contiguous_local_indices,
+)
 from nemo_automodel.components.distributed.thd_utils import split_batch_into_thd_chunks
 
 
@@ -52,26 +55,17 @@ def glm_dsa_cp_all_gather(tensor: torch.Tensor, *, dim: int, cp_group) -> torch.
     return torch.cat(tuple(parts), dim=dim)
 
 
-def _contiguous_cp_indices(total_tokens: int, cp_size: int, cp_rank: int, device: torch.device) -> torch.Tensor:
-    if total_tokens % cp_size != 0:
-        raise ValueError(
-            f"Packed GLM DSA CP requires total tokens divisible by cp_size, got {total_tokens=} {cp_size=}"
-        )
-    local_tokens = total_tokens // cp_size
-    start = cp_rank * local_tokens
-    return torch.arange(start, start + local_tokens, device=device, dtype=torch.long)
-
-
 def _slice_thd_chunk_for_cp(
     chunk: dict[str, torch.Tensor],
     *,
+    cp_mesh,
     cp_group,
     cp_size: int,
     cp_rank: int,
     padding_token_id: int,
 ) -> dict[str, torch.Tensor]:
     total_tokens = int(chunk["input_ids"].shape[0])
-    query_indices = _contiguous_cp_indices(total_tokens, cp_size, cp_rank, chunk["input_ids"].device)
+    query_indices = contiguous_local_indices(cp_mesh, total_tokens, chunk["input_ids"].device)
 
     out: dict[str, torch.Tensor | int | str | object] = {
         "input_ids": chunk["input_ids"].index_select(0, query_indices).to(torch.int64).contiguous(),
@@ -137,6 +131,7 @@ def make_glm_dsa_packed_cp_batch_and_ctx(
     if num_chunks <= 1:
         sliced = _slice_thd_chunk_for_cp(
             thd_batch,
+            cp_mesh=cp_mesh,
             cp_group=cp_group,
             cp_size=cp_size,
             cp_rank=cp_rank,
@@ -150,6 +145,7 @@ def make_glm_dsa_packed_cp_batch_and_ctx(
         chunks.append(
             _slice_thd_chunk_for_cp(
                 chunk,
+                cp_mesh=cp_mesh,
                 cp_group=cp_group,
                 cp_size=cp_size,
                 cp_rank=cp_rank,

--- a/tests/unit_tests/models/glm_moe_dsa/test_glm_moe_dsa_config.py
+++ b/tests/unit_tests/models/glm_moe_dsa/test_glm_moe_dsa_config.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from transformers import AutoConfig
+
+from nemo_automodel._transformers.registry import resolve_custom_config_cls
+from nemo_automodel.components.models.glm_moe_dsa.config import GlmMoeDsaConfig
+
+# The released GLM-5.2 config.json carries both keys; transformers aliases
+# head_dim onto qk_rope_head_dim, so loading it through the built-in config
+# overwrites the rope dim with 192.
+_RELEASED_FIELDS = {
+    "model_type": "glm_moe_dsa",
+    "head_dim": 192,
+    "qk_rope_head_dim": 64,
+    "index_head_dim": 128,
+    "num_hidden_layers": 2,
+}
+
+
+def test_registry_resolves_automodel_glm_config():
+    assert resolve_custom_config_cls("glm_moe_dsa") is GlmMoeDsaConfig
+
+
+def test_released_config_keeps_qk_rope_head_dim(tmp_path):
+    (tmp_path / "config.json").write_text(json.dumps(_RELEASED_FIELDS))
+
+    config = AutoConfig.from_pretrained(tmp_path)
+
+    assert type(config) is GlmMoeDsaConfig
+    assert config.qk_rope_head_dim == 64
+    # The DSA indexer splits Q into [rope, nope]; a clobbered rope dim makes the
+    # nope half negative and torch.split raises.
+    assert config.index_head_dim - config.qk_rope_head_dim == 64
+
+
+def test_expert_count_alias_is_preserved():
+    config = GlmMoeDsaConfig(n_routed_experts=8)
+
+    assert config.num_local_experts == 8
+
+
+def test_head_dim_stays_a_plain_field():
+    # Without the alias, head_dim is just the checkpoint's own value (the full
+    # QK width) and no longer writes through to the rope dim.
+    config = GlmMoeDsaConfig(head_dim=192, qk_rope_head_dim=64, qk_nope_head_dim=128)
+
+    assert config.head_dim == 192
+    assert config.qk_rope_head_dim == 64
+    assert config.qk_head_dim == 192
+
+
+# Every config field Automodel's GLM DSA modeling code reads. The config is
+# standalone, so this list is the field protocol the model depends on; a missing
+# entry means the model breaks at init rather than at load.
+_FIELDS_READ_BY_MODEL = (
+    "hidden_size",
+    "index_head_dim",
+    "index_n_heads",
+    "index_topk",
+    "indexer_types",
+    "intermediate_size",
+    "kv_lora_rank",
+    "max_position_embeddings",
+    "moe_intermediate_size",
+    "mlp_layer_types",
+    "n_group",
+    "n_routed_experts",
+    "n_shared_experts",
+    "norm_topk_prob",
+    "num_attention_heads",
+    "num_experts_per_tok",
+    "num_hidden_layers",
+    "q_lora_rank",
+    "qk_head_dim",
+    "qk_nope_head_dim",
+    "qk_rope_head_dim",
+    "rms_norm_eps",
+    "rope_parameters",
+    "routed_scaling_factor",
+    "topk_group",
+    "v_head_dim",
+    "vocab_size",
+)
+
+
+@pytest.mark.parametrize("field", _FIELDS_READ_BY_MODEL)
+def test_field_protocol_is_complete(field):
+    assert hasattr(GlmMoeDsaConfig(), field), f"GLM DSA modeling reads config.{field}"
+
+
+def test_per_layer_patterns_are_derived_when_absent():
+    config = GlmMoeDsaConfig(num_hidden_layers=6, index_topk_freq=2)
+
+    assert config.mlp_layer_types == ["dense"] * 3 + ["sparse"] * 3
+    # Layer 0 and then every 2nd layer are full; the rest share.
+    assert config.indexer_types == ["full", "full", "shared", "full", "shared", "full"]

--- a/tests/unit_tests/models/glm_moe_dsa/test_glm_moe_dsa_cp.py
+++ b/tests/unit_tests/models/glm_moe_dsa/test_glm_moe_dsa_cp.py
@@ -25,15 +25,19 @@ from nemo_automodel.components.models.glm_moe_dsa import cp as glm_cp
 
 
 class _FakeMesh:
-    def __init__(self, size=2, group="cp-group"):
+    def __init__(self, size=2, group="cp-group", rank=0):
         self._size = size
         self._group = group
+        self._rank = rank
 
     def size(self):
         return self._size
 
     def get_group(self):
         return self._group
+
+    def get_local_rank(self):
+        return self._rank
 
 
 def _thd_chunk(num_tokens=6):
@@ -79,16 +83,24 @@ def test_glm_dsa_cp_all_gather_concatenates_autograd_gather(monkeypatch):
     assert out.tolist() == [[0, 1], [2, 3], [10, 11], [12, 13]]
 
 
-def test_contiguous_cp_indices_requires_even_divisibility():
-    with pytest.raises(ValueError, match="total tokens divisible"):
-        glm_cp._contiguous_cp_indices(total_tokens=5, cp_size=2, cp_rank=0, device=torch.device("cpu"))
-
-    assert glm_cp._contiguous_cp_indices(6, 3, 1, torch.device("cpu")).tolist() == [2, 3]
+def test_slice_thd_chunk_requires_even_divisibility():
+    # The shared contiguous index map owns the divisibility contract; GLM no
+    # longer carries its own copy of the arithmetic.
+    with pytest.raises(ValueError, match="divisible by cp_size"):
+        glm_cp._slice_thd_chunk_for_cp(
+            _thd_chunk(num_tokens=5),
+            cp_mesh=_FakeMesh(size=2, rank=0),
+            cp_group="cp-group",
+            cp_size=2,
+            cp_rank=0,
+            padding_token_id=3,
+        )
 
 
 def test_slice_thd_chunk_for_cp_preserves_global_metadata_and_padding_mask():
     out = glm_cp._slice_thd_chunk_for_cp(
         _thd_chunk(),
+        cp_mesh=_FakeMesh(size=3, rank=1),
         cp_group="cp-group",
         cp_size=3,
         cp_rank=1,


### PR DESCRIPTION
# What does this PR do ?

Gives GLM MoE DSA its own config class so the released GLM-5.2 checkpoint loads correctly without a per-recipe workaround.

> Rebased onto `main` after #3221 landed. That PR derives the override set from `_CUSTOM_CONFIG_REGISTRATIONS`, so registering `glm_moe_dsa` is now sufficient on its own — no explicit override entry needed.

## The bug

transformers' `GlmMoeDsaConfig` declares:

```python
attribute_map = {"num_local_experts": "n_routed_experts", "head_dim": "qk_rope_head_dim"}
```

The released GLM-5.2 `config.json` sets **both** keys — `head_dim: 192` (the full QK head dim, `qk_nope + qk_rope`) and `qk_rope_head_dim: 64`. The alias wins, so the rope dim becomes 192. On `main`, loading the untouched checkpoint:

```python
>>> cfg = AutoConfig.from_pretrained("zai-org/GLM-5.2")
>>> cfg.qk_rope_head_dim, cfg.index_head_dim
(192, 128)
```

The DSA indexer then computes `qk_nope_head_dim = index_head_dim - qk_rope_head_dim = -64` and its split raises:

```
RuntimeError: split_with_sizes expects split_sizes have only non-negative entries,
but got split_sizes=[192, -64]
  at nemo_automodel/components/models/glm_moe_dsa/layers.py:253
```

Automodel ships **no** GLM config class, so the only fix available today lives in recipe YAML:

```yaml
model:
  config:
    head_dim: 64      # writes 64 back through the same alias
```

Three in-tree recipes carry that line. Anything that doesn't know about it — NeMo-RL, molt, or a user calling `from_pretrained` directly — crashes on the official checkpoint. Compare `deepseek_v4`, which owns a config class precisely so its field protocol survives.

## The change

- **`glm_moe_dsa/config.py`** (new): a **standalone** config subclassing `PretrainedConfig`, not the transformers GLM config. Automodel ships its own GLM DSA modeling code, so its field protocol should not move when transformers releases do — and subclassing is exactly what pulled in the harmful alias. This also matches every other Automodel-owned config (`deepseek_v4`, `laguna`, `minimax_m3_vl`, `ling_v2`, `mistral4`, `hy_v3` all subclass `PretrainedConfig`); the previous revision of this PR was the only one that didn't. Only the `num_local_experts -> n_routed_experts` alias is kept. Upstream's `base_model_tp_plan` / `base_model_pp_plan` are deliberately not carried over — Automodel builds its own TP plan in `optimized_tp_plans.py` and never reads them.
- **Registered** in `_CUSTOM_CONFIG_REGISTRATIONS`, which since #3221 is sufficient for it to win over the transformers built-in.
- **Removed** `config: {head_dim: 64}` from the three recipes that carried it — that is the acceptance criterion for this fix.
- **Deleted `_contiguous_cp_indices`**, which duplicated `contiguous_local_indices` line for line (same divisibility check, same `start = rank * local_len`, same arange). `_slice_thd_chunk_for_cp` now takes the CP submesh and uses the shared index map, so the divisibility contract has one owner.

## Validation (transformers 5.8.1)

**Field-by-field diff against the released checkpoint.** Of the 23 config fields Automodel's GLM code reads, the standalone config agrees with the transformers one on 22. The sole difference is the bug:

| field | transformers | this PR |
|---|---|---|
| `qk_rope_head_dim` | 192 (clobbered by the alias) | **64** |

Loading the released checkpoint with **no** YAML override:

```
GLM  class : nemo_automodel.components.models.glm_moe_dsa.config
             (base: transformers.configuration_utils.PreTrainedConfig)
GLM  qk_rope_head_dim: 64 | index_head_dim: 128 | nope: 64
GLM  head_dim: 192 (plain field) | num_local_experts: 256 (alias intact)
GLM  indexer_types: 78 entries | mlp_layer_types: 78 entries
```

- `pytest tests/unit_tests/models/glm_moe_dsa tests/unit_tests/_transformers/test_registry.py` → **193 passed, 1 skipped**
- The 5 `test_glm_moe_dsa_tilelang` failures are **pre-existing and identical on unpatched `main`** (this image has no tile kernels)
- `ruff format --check` / `ruff check` on the touched files

New tests: the config resolves from a checkpoint-style `config.json` carrying both keys and keeps `qk_rope_head_dim == 64` with a positive indexer split; `head_dim` stays a plain field; the expert-count alias still works; the per-layer `mlp_layer_types` / `indexer_types` patterns derive correctly when omitted; a parametrized check asserts every config field the modeling code reads exists on the standalone class (so a dropped field fails the suite rather than the model at init); and the CP slice inherits the shared divisibility error.

## Same-container GLM-5.2 4k NeMo-CI proof

Validated the 4k TileLang Tulu3 recipe on PR #3222 head `8973c6c37550e582fed86037e5032ba25f594c80` using the same old-image/source-mount path:

- Reused old image `gitlab-master.nvidia.com/dl/joc/nemo-ci/main/automodel:pipe.56857516`; no fresh AutoModel image was built.
- Mounted PR #3222 source into the old image at `/opt/Automodel` via `AUTOMODEL_SOURCE_MOUNT_REF=8973c6c37550e582fed86037e5032ba25f594c80`.
- Generated release job used `TEST_NODE_COUNT=32`, `TIME=01:00:00`, `RECIPE_OWNER=huiyingl`.
- Parent pipeline: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/59600940
- Child pipeline: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/59600943
- Leaf pipeline: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/59600960
- Passed leaf job: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/373972197
- Proof: `sbatch -N 32 --time 01:00:00`, `World size: 256`, `max_steps: 10`, `Training: 100% ... 10/10`, `SLURM_STATE=COMPLETED`, `SLURM_EXITCODE=0`.

## Note for reviewers

`_register_custom_configs()` runs at `nemo_automodel._transformers.registry` import time. A bare `import nemo_automodel` is lazy and does **not** trigger it, so if you reproduce with `AutoConfig.from_pretrained` make sure the registry module is imported (every real model-loading path does).

## Not in this PR

`glm4_moe_lite` carries the **same** `head_dim -> qk_rope_head_dim` alias and also has no Automodel config class. It has not been verified against its released checkpoint yet; if it sets both keys it needs the same treatment.

# Before your PR is "Ready for review"

**Pre checks**:

- [X] Make sure you read and followed [Contributor guidelines](<https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md>)
- [X] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)

