### PR TITLE
fix(gpt-oss): route packed attention through THD

### DIFF
--- a/nemo_automodel/components/models/gpt_oss/layers.py
+++ b/nemo_automodel/components/models/gpt_oss/layers.py
@@ -37,6 +37,12 @@ from nemo_automodel.components.models.gpt_oss.rope_utils import apply_rotary_emb
 from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 
 
+def _has_thd_metadata(attn_kwargs: dict[str, Any]) -> bool:
+    return attn_kwargs.get("cu_seqlens") is not None or (
+        attn_kwargs.get("cu_seqlens_q") is not None and attn_kwargs.get("cu_seqlens_kv") is not None
+    )
+
+
 class GptOssAttention(nn.Module):
     def __init__(self, config: "GptOssConfig", backend: BackendConfig, use_sliding_attention: bool = False):
         super().__init__()
@@ -97,14 +103,15 @@ class GptOssAttention(nn.Module):
         attention_mask: torch.Tensor | None = None,
         **attn_kwargs: Any,
     ) -> torch.Tensor:
-        # Detect THD format: either 2D [T, hidden] or 3D [1, T, hidden] with
-        # cu_seqlens in kwargs (from PP schedule splitting [N, T, hidden] → [1, T, hidden]).
-        if len(x.shape) == 2:
+        # Detect THD format: either 2D [T, hidden], explicit THD metadata, or
+        # 3D [1, T, hidden] with cu_seqlens from PP schedule splitting.
+        explicit_thd = attn_kwargs.get("qkv_format") == "thd" or _has_thd_metadata(attn_kwargs)
+        if len(x.shape) == 2 or explicit_thd:
             qkv_format = "thd"
-            num_tokens = x.shape[0]
-        elif "cu_seqlens" in attn_kwargs and x.shape[0] == 1:
-            qkv_format = "thd"
-            x = x.squeeze(0)
+            if len(x.shape) == 3:
+                if x.shape[0] != 1:
+                    raise ValueError("GPT-OSS THD attention expects a singleton batch dimension before flattening.")
+                x = x.squeeze(0)
             num_tokens = x.shape[0]
         else:
             qkv_format = "bshd"
@@ -145,6 +152,9 @@ class GptOssAttention(nn.Module):
             }
         else:
             updated_attn_kwargs = attn_kwargs
+            if qkv_format == "thd":
+                updated_attn_kwargs = {**updated_attn_kwargs, "qkv_format": "thd"}
+                attention_mask = None
             if self.sliding_window is not None:
                 updated_attn_kwargs["window_size"] = (self.sliding_window, 0)
 

--- a/nemo_automodel/components/models/gpt_oss/model.py
+++ b/nemo_automodel/components/models/gpt_oss/model.py
@@ -33,7 +33,7 @@ from nemo_automodel.components.models.common.tie_word_embeddings import (
     reject_unsupported_tie_word_embeddings,
 )
 from nemo_automodel.components.models.common.utils import cast_model_to_dtype, compute_lm_head_logits
-from nemo_automodel.components.models.gpt_oss.layers import GptOssAttention
+from nemo_automodel.components.models.gpt_oss.layers import GptOssAttention, _has_thd_metadata
 from nemo_automodel.components.models.gpt_oss.rope_utils import RotaryEmbedding, position_ids_to_freqs_cis
 from nemo_automodel.components.models.gpt_oss.state_dict_adapter import GPTOSSStateDictAdapter
 from nemo_automodel.components.moe.config import MoEConfig
@@ -319,8 +319,20 @@ class GptOssForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
             else getattr(self.config, "output_hidden_states", False)
         )
 
-        is_thd = attn_kwargs.get("qkv_format") == "thd"
+        is_thd = attn_kwargs.get("qkv_format") == "thd" or (
+            _has_thd_metadata(attn_kwargs) and (input_ids.ndim == 1 or input_ids.shape[0] == 1)
+        )
         if is_thd:
+            attn_kwargs = {**attn_kwargs, "qkv_format": "thd"}
+            if position_ids is None:
+                if input_ids.ndim == 1:
+                    position_ids = torch.arange(0, input_ids.shape[0], device=input_ids.device)
+                else:
+                    position_ids = (
+                        torch.arange(0, input_ids.shape[1], device=input_ids.device)
+                        .unsqueeze(0)
+                        .expand(input_ids.shape[0], -1)
+                    )
             input_ids, position_ids, padding_mask, attn_kwargs = squeeze_input_for_thd(
                 input_ids, position_ids, padding_mask, attn_kwargs
             )

--- a/tests/unit_tests/models/gpt_oss/test_gptoss_model.py
+++ b/tests/unit_tests/models/gpt_oss/test_gptoss_model.py
@@ -462,6 +462,40 @@ class TestGptOssForCausalLM:
             assert output.ndim == 3
             assert output.shape == (batch_size, seq_len, gpt_config.vocab_size)
 
+    def test_forward_infers_thd_from_cu_seqlens(self, gpt_config, backend_config, device):
+        """Packed THD metadata should be enough to select the THD model path."""
+        model = GptOssForCausalLM(gpt_config, backend=backend_config)
+        model = model.to(device)
+
+        total_tokens = 16
+        input_ids = torch.randint(0, gpt_config.vocab_size, (1, total_tokens), dtype=torch.long, device=device)
+        position_ids = torch.arange(total_tokens, device=device).unsqueeze(0)
+        attention_mask = torch.ones(1, total_tokens, dtype=torch.bool, device=device)
+        cu_seqlens = torch.tensor([[0, 8, 16]], dtype=torch.int32, device=device)
+
+        with patch.object(model.model, "forward") as mock_model:
+            mock_model.return_value = torch.randn(
+                total_tokens, gpt_config.hidden_size, dtype=torch.bfloat16, device=device
+            )
+
+            output = model(
+                input_ids,
+                position_ids=position_ids,
+                attention_mask=attention_mask,
+                cu_seqlens=cu_seqlens,
+                output_hidden_states=True,
+            )
+
+        actual_input_ids = mock_model.call_args.args[0]
+        actual_kwargs = mock_model.call_args.kwargs
+        assert actual_input_ids.shape == (total_tokens,)
+        assert actual_kwargs["position_ids"].shape == (total_tokens,)
+        assert actual_kwargs["attention_mask"] is None
+        assert actual_kwargs["qkv_format"] == "thd"
+        assert torch.equal(actual_kwargs["cu_seqlens"], torch.tensor([0, 8, 16], dtype=torch.int32, device=device))
+        assert output.logits.shape == (1, total_tokens, gpt_config.vocab_size)
+        assert output.hidden_states.shape == (1, total_tokens, gpt_config.hidden_size)
+
     def test_initialize_weights(self, gpt_config, backend_config, device):
         """Test weight initialization."""
         model = GptOssForCausalLM(gpt_config, backend=backend_config)
@@ -598,6 +632,50 @@ class TestGptOssAttentionTHD:
             # Output should be 2D [T, hidden] (THD flattened)
             assert output.ndim == 2
             assert output.shape[0] == total_tokens
+
+    def test_thd_metadata_clears_attention_mask_before_backend(self, gpt_config, backend_config, device):
+        """THD cu_seqlens must take precedence over padding-mask style TE preprocessing."""
+        import nemo_automodel.components.models.gpt_oss.layers as gpt_oss_layers
+        from nemo_automodel.components.models.gpt_oss.layers import GptOssAttention
+
+        attn = GptOssAttention(gpt_config, backend=backend_config).to(device)
+        attn.backend.attn = "te"
+        total_tokens = 16
+        x = torch.randn(1, total_tokens, gpt_config.hidden_size, dtype=torch.bfloat16, device=device)
+        freqs_cis = torch.randn(total_tokens, gpt_config.head_dim, dtype=torch.bfloat16, device=device)
+        cu_seqlens = torch.tensor([0, 8, 16], dtype=torch.int32, device=device)
+        attention_mask = torch.ones(1, total_tokens, dtype=torch.bool, device=device)
+        captured = {}
+
+        def fake_preprocess(q, k, v, attention_mask, attn_impl, **kwargs):
+            captured["attention_mask"] = attention_mask
+            captured["attn_impl"] = attn_impl
+            captured["kwargs"] = dict(kwargs)
+            return q, k, v, {}
+
+        with (
+            patch.object(gpt_oss_layers, "apply_rotary_emb_qk", side_effect=lambda q, k, *args, **kwargs: (q, k)),
+            patch.object(gpt_oss_layers, "preprocess_args_and_kwargs_for_attn", side_effect=fake_preprocess),
+            patch.object(attn, "attn_func") as mock_attn,
+        ):
+            mock_attn.return_value = torch.randn(
+                total_tokens,
+                gpt_config.num_attention_heads,
+                gpt_config.head_dim,
+                dtype=torch.bfloat16,
+                device=device,
+            )
+            output = attn(
+                x,
+                freqs_cis=freqs_cis,
+                attention_mask=attention_mask,
+                cu_seqlens=cu_seqlens,
+            )
+
+        assert captured["attention_mask"] is None
+        assert captured["kwargs"]["qkv_format"] == "thd"
+        assert torch.equal(captured["kwargs"]["cu_seqlens"], cu_seqlens)
+        assert output.shape == (total_tokens, gpt_config.hidden_size)
 
 
 class TestRopeUtilsTHD:


### PR DESCRIPTION
## Summary

- Infer GPT-OSS THD/packed attention from `cu_seqlens` metadata when `qkv_format` is not explicitly set.
- Preserve singleton-batch packed outputs while passing TE attention `qkv_format=thd` and clearing the padding mask before backend preprocessing.
- Add GPT-OSS regression coverage for packed metadata routing and TE backend preprocessing arguments.

## Root Cause

The packed recipe passed THD metadata through `cu_seqlens`, but `GptOssForCausalLM.forward` only treated the input as packed when `attn_kwargs["qkv_format"] == "thd"`. That left TE preprocessing able to route flattened packed tensors through the BSHD path, which produced the runtime assertion from AMINT-28: `Queries, keys and values must be 4D tensors when qkv_format='bshd'`.

## Validation

- `python -m pytest tests/unit_tests/models/gpt_oss/test_gptoss_model.py tests/unit_tests/models/gpt_oss/test_gptoss_layers.py tests/unit_tests/attention/test_attention_utils.py -q` (`57 passed, 16 skipped`)
- `python -m ruff check nemo_automodel/components/models/gpt_oss/layers.py nemo_automodel/components/models/gpt_oss/model.py tests/unit_tests/models/gpt_oss/test_gptoss_model.py`
- `python -m ruff format --check nemo_automodel/components/models/gpt_oss/layers.py nemo_automodel/components/models/gpt_oss/model.py tests/unit_tests/models/gpt_oss/test_gptoss_model.py && git diff --check`
- Nemo-CI target rerun passed:
  - parent: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/59580947
  - Automodel child: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/59582381
  - LLM leaf: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/59582398
  - target job: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/373859894

Note: the successful Nemo-CI run used the x86 EOS/H100 lane and `INSTALL_FA3=false` to bypass unrelated pre-test `flash_attn_3` container build failures observed in earlier attempts.
