### PR TITLE
fix(deepseek-v4): preserve fp32 model dtype

### DIFF
--- a/nemo_automodel/components/models/deepseek_v4/config.py
+++ b/nemo_automodel/components/models/deepseek_v4/config.py
@@ -133,7 +133,6 @@ class DeepseekV4Config(PretrainedConfig):
         self.attention_dropout = attention_dropout
         self.pretraining_tp = pretraining_tp
         self.initializer_range = initializer_range
-        self.torch_dtype = torch_dtype
 
         super().__init__(
             pad_token_id=pad_token_id,
@@ -143,3 +142,4 @@ class DeepseekV4Config(PretrainedConfig):
             use_cache=use_cache,
             **kwargs,
         )
+        self.torch_dtype = torch_dtype

--- a/nemo_automodel/components/models/deepseek_v4/config.py
+++ b/nemo_automodel/components/models/deepseek_v4/config.py
@@ -91,9 +91,14 @@ class DeepseekV4Config(PretrainedConfig):
         pretraining_tp: int = 1,
         tie_word_embeddings: bool = False,
         initializer_range: float = 0.02,
-        torch_dtype: str = "bfloat16",
+        torch_dtype: str | None = None,
         **kwargs,
     ):
+        dtype = kwargs.pop("dtype", None)
+        resolved_dtype = dtype if dtype is not None else torch_dtype
+        if resolved_dtype is None:
+            resolved_dtype = "bfloat16"
+
         self.vocab_size = vocab_size
         self.hidden_size = hidden_size
         self.moe_intermediate_size = moe_intermediate_size
@@ -140,6 +145,6 @@ class DeepseekV4Config(PretrainedConfig):
             eos_token_id=eos_token_id,
             tie_word_embeddings=tie_word_embeddings,
             use_cache=use_cache,
+            dtype=resolved_dtype,
             **kwargs,
         )
-        self.torch_dtype = torch_dtype

--- a/nemo_automodel/components/models/deepseek_v4/fsdp.py
+++ b/nemo_automodel/components/models/deepseek_v4/fsdp.py
@@ -202,12 +202,22 @@ def fully_shard_deepseek_v4(module: nn.Module, mesh, mp_policy, offload_policy=N
     This is intentionally model-specific.  DeepSeek-V4 keeps a small set of
     reference-sensitive tensors in fp32, while the existing DeepEP path expects
     the transformer block itself to remain the main FSDP unit.
+
+    Uniform fp32 storage does not necessarily mean fp32 compute: full-parameter
+    training commonly keeps fp32 master weights while the FSDP mixed-precision
+    policy requests bf16 compute.  In that case, preserve fp32 compute only for
+    the explicitly listed reference-sensitive islands and let the parent block
+    use the caller's bf16 policy.
     """
     is_dsv4 = _is_deepseek_v4_module(module)
     if is_dsv4:
         _attach_hca_param_sync_group(module, mesh)
 
-    if _floating_param_dtypes(module) == {torch.float32}:
+    policy_param_dtype = getattr(mp_policy, "param_dtype", None)
+    use_all_fp32_fast_path = _floating_param_dtypes(module) == {torch.float32} and (
+        not is_dsv4 or policy_param_dtype in (None, torch.float32)
+    )
+    if use_all_fp32_fast_path:
         fsdp_kwargs = _fp32_module_fsdp_kwargs(module, fsdp_kwargs)
         return _fully_shard_once(
             module,

--- a/nemo_automodel/components/models/deepseek_v4/layers.py
+++ b/nemo_automodel/components/models/deepseek_v4/layers.py
@@ -80,6 +80,7 @@ from nemo_automodel.components.models.deepseek_v4.optimized_kernels import (
     dsv4_sinkhorn_normalize,
     dsv4_sparse_attention,
 )
+from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 
 
 def _full_tensor_if_dtensor(tensor: torch.Tensor) -> torch.Tensor:
@@ -713,6 +714,7 @@ class DeepseekV4Indexer(nn.Module):
     def __init__(self, config: DeepseekV4Config, backend: BackendConfig | None = None):
         super().__init__()
         self.backend = backend or BackendConfig()
+        model_dtype = get_dtype(config.torch_dtype, torch.bfloat16)
         self.compress_ratio = 4
         # Indexer's pool is always at compress_ratio==4, which means overlap mode
         # (matching the released checkpoint's ``indexer.compressor.{ape,wkv,wgate}``
@@ -727,7 +729,9 @@ class DeepseekV4Indexer(nn.Module):
         self.wkv = nn.Linear(config.hidden_size, proj_dim, bias=False, dtype=torch.float32)
         self.wgate = nn.Linear(config.hidden_size, proj_dim, bias=False, dtype=torch.float32)
         self.ape_param = DeepseekV4FP32Parameter(torch.zeros(self.compress_ratio, proj_dim, dtype=torch.float32))
-        self.kv_norm = initialize_rms_norm_module("torch_fp32", self.head_dim, eps=config.rms_norm_eps)
+        self.kv_norm = initialize_rms_norm_module(
+            "torch_fp32", self.head_dim, eps=config.rms_norm_eps, dtype=model_dtype
+        )
         self.wq_b = nn.Linear(config.q_lora_rank, self.n_heads * self.head_dim, bias=False)
         self.weights_proj = nn.Linear(config.hidden_size, self.n_heads, bias=False)
 
@@ -854,6 +858,7 @@ class DeepseekV4Compressor(nn.Module):
     ):
         super().__init__()
         self.backend = backend or BackendConfig()
+        model_dtype = get_dtype(config.torch_dtype, torch.bfloat16)
         self.compress_ratio = compress_ratio
         self.head_dim = head_dim
         self.rope_head_dim = config.qk_rope_head_dim
@@ -869,7 +874,7 @@ class DeepseekV4Compressor(nn.Module):
         self.wkv = nn.Linear(config.hidden_size, proj_dim, bias=False, dtype=torch.float32)
         self.wgate = nn.Linear(config.hidden_size, proj_dim, bias=False, dtype=torch.float32)
         self.ape_param = DeepseekV4FP32Parameter(torch.zeros(compress_ratio, proj_dim, dtype=torch.float32))
-        self.kv_norm = initialize_rms_norm_module("torch_fp32", head_dim, eps=config.rms_norm_eps)
+        self.kv_norm = initialize_rms_norm_module("torch_fp32", head_dim, eps=config.rms_norm_eps, dtype=model_dtype)
         self.indexer: DeepseekV4Indexer | None = (
             DeepseekV4Indexer(config, backend=self.backend) if compress_ratio == 4 else None
         )
@@ -1204,6 +1209,7 @@ class DeepseekV4Attention(nn.Module):
         super().__init__()
         self.config = config
         self.backend = backend or BackendConfig()
+        model_dtype = get_dtype(config.torch_dtype, torch.bfloat16)
         self.layer_idx = layer_idx
         self.compress_ratio = int(config.compress_ratios[layer_idx]) if config.compress_ratios else 0
         self.num_heads = config.num_attention_heads
@@ -1217,10 +1223,14 @@ class DeepseekV4Attention(nn.Module):
         self.scaling = self.head_dim**-0.5
 
         self.wq_a = nn.Linear(config.hidden_size, config.q_lora_rank, bias=False)
-        self.q_norm = initialize_rms_norm_module("torch_fp32", config.q_lora_rank, eps=config.rms_norm_eps)
+        self.q_norm = initialize_rms_norm_module(
+            "torch_fp32", config.q_lora_rank, eps=config.rms_norm_eps, dtype=model_dtype
+        )
         self.wq_b = nn.Linear(config.q_lora_rank, self.num_heads * self.head_dim, bias=False)
         self.wkv = nn.Linear(config.hidden_size, self.head_dim, bias=False)
-        self.kv_norm = initialize_rms_norm_module("torch_fp32", self.head_dim, eps=config.rms_norm_eps)
+        self.kv_norm = initialize_rms_norm_module(
+            "torch_fp32", self.head_dim, eps=config.rms_norm_eps, dtype=model_dtype
+        )
         self.wo_a = DeepseekV4GroupedLinear(
             self.num_heads * self.head_dim // config.o_groups,
             config.o_groups * config.o_lora_rank,

--- a/tests/unit_tests/models/deepseek_v4/test_dsv4_model_smoke.py
+++ b/tests/unit_tests/models/deepseek_v4/test_dsv4_model_smoke.py
@@ -101,13 +101,6 @@ def _make_model(config: DeepseekV4Config) -> DeepseekV4ForCausalLM:
         experts="torch_mm",
     )
     model = DeepseekV4ForCausalLM(config, backend=backend)
-    # The model mixes per-module dtype defaults (``embed_tokens`` is built bf16
-    # via the now-deprecated ``config.torch_dtype`` path; bare ``nn.Linear``
-    # sub-modules pick up the global fp32 default).  Force everything to a
-    # single fp32 dtype for the smoke test so matmuls don't hit dtype mismatch.
-    # ``DeepseekV4HyperConnection`` keeps its parameters in fp32 explicitly —
-    # ``model.float()`` is a no-op for those.
-    model = model.float()
     # Zero all float params: Gate/GroupedExperts use torch.empty (uninitialized memory
     # that may contain NaN bit patterns). initialize_weights() is not called in smoke tests.
     with torch.no_grad():
@@ -116,6 +109,20 @@ def _make_model(config: DeepseekV4Config) -> DeepseekV4ForCausalLM:
                 p.zero_()
     model.eval()
     return model
+
+
+def test_fp32_config_constructs_all_floating_parameters_in_fp32():
+    """An fp32 config must not leave RMSNorm weights in the bf16 helper default."""
+    config = _tiny_config(num_hidden_layers=1, num_hash_layers=0, compress_ratios=[4])
+    model = _make_model(config)
+
+    mismatches = {
+        name: param.dtype
+        for name, param in model.named_parameters()
+        if param.is_floating_point() and param.dtype != torch.float32
+    }
+
+    assert not mismatches
 
 
 class TestDeepseekV4ModelSmoke:
@@ -166,7 +173,7 @@ class TestDeepseekV4ModelSmoke:
         assert dsv4_fsdp._hca_param_sync_group_from_1d_mesh(TwoDimMesh()) is None
         assert dsv4_fsdp._hca_param_sync_group_from_1d_mesh(NamedOneDimMesh()) is named_hca_group
 
-    def test_dsv4_fsdp_attaches_hca_group_before_all_fp32_fast_path(self, monkeypatch):
+    def test_dsv4_fsdp_uses_bf16_compute_for_uniform_fp32_master_weights(self, monkeypatch):
         cfg = _tiny_config(num_hidden_layers=1, num_hash_layers=0, compress_ratios=[128])
         model = _make_model(cfg)
         block = model.model.layers["0"]
@@ -204,6 +211,35 @@ class TestDeepseekV4ModelSmoke:
         )
 
         assert block.self_attn.compressor._hca_param_sync_group is hca_group
+        assert calls[-1][0] is block
+        assert calls[-1][1]["mp_policy"].param_dtype == torch.bfloat16
+        assert calls[-1][1]["mp_policy"].reduce_dtype == torch.float32
+        assert any(module is not block and kwargs["mp_policy"].param_dtype == torch.float32 for module, kwargs in calls)
+
+    def test_dsv4_fsdp_preserves_explicit_all_fp32_compute_fast_path(self, monkeypatch):
+        cfg = _tiny_config(num_hidden_layers=1, num_hash_layers=0, compress_ratios=[128])
+        block = _make_model(cfg).model.layers["0"]
+        calls = []
+
+        def fake_fully_shard(module, **kwargs):
+            calls.append((module, kwargs))
+            return module
+
+        monkeypatch.setattr(dsv4_fsdp, "fully_shard", fake_fully_shard)
+
+        input_policy = MixedPrecisionPolicy(
+            param_dtype=torch.float32,
+            reduce_dtype=torch.float32,
+            output_dtype=torch.float32,
+        )
+
+        dsv4_fsdp.fully_shard_deepseek_v4(
+            block,
+            mesh=object(),
+            mp_policy=input_policy,
+            offload_policy=object(),
+        )
+
         assert len(calls) == 1
         assert calls[0][0] is block
         assert calls[0][1]["mp_policy"].param_dtype == torch.float32

--- a/tests/unit_tests/models/deepseek_v4/test_dsv4_model_smoke.py
+++ b/tests/unit_tests/models/deepseek_v4/test_dsv4_model_smoke.py
@@ -125,6 +125,22 @@ def test_fp32_config_constructs_all_floating_parameters_in_fp32():
     assert not mismatches
 
 
+def test_config_honors_canonical_dtype_argument():
+    config = DeepseekV4Config(dtype="float32")
+
+    assert config.dtype == torch.float32
+    assert config.torch_dtype == torch.float32
+
+
+def test_config_preserves_fp32_dtype_through_serialization_round_trip():
+    config = DeepseekV4Config(dtype="float32")
+
+    restored = DeepseekV4Config.from_dict(config.to_dict())
+
+    assert restored.dtype == torch.float32
+    assert restored.torch_dtype == torch.float32
+
+
 class TestDeepseekV4ModelSmoke:
     def test_dsv4_hca_param_sync_group_uses_only_1d_mesh(self):
         named_hca_group = object()


### PR DESCRIPTION
## Summary

- preserve an explicit DeepSeek V4 `torch_dtype` after `PretrainedConfig` initialization
- initialize torch-fp32 RMSNorm modules in the requested model dtype so fp32 construction is uniform
- distinguish fp32 parameter/master-weight storage from the FSDP compute policy, while retaining fp32 compute for reference-sensitive islands
- add regression coverage for fp32 construction, bf16 compute with fp32 master weights, and the explicit all-fp32 fast path

## Root cause

`PretrainedConfig.__init__` overwrote the dtype assigned by `DeepseekV4Config`, torch-fp32 RMSNorm construction fell back to bf16, and the DSV4 all-fp32 FSDP fast path conflated uniform fp32 storage/master weights with fp32 compute. Together these prevented a uniform fp32 instantiation and ignored an explicit bf16 FSDP compute policy.

## Validation

- Scoped Ruff format/check: passed
- DSV4 unit suite in `auto2606rc9.sqsh` with TileLang 0.1.9 overlay: `205 passed, 2 skipped`
- Full 43-layer model: 284,332,230,231 total parameters / 284,106,500,055 trainable parameters
- 100-step distributed run: Slurm `14370695`, `COMPLETED`, exit `0:0`, wall time `00:10:19`
  - 16 nodes / 128 H100, EP128, PP1, CP1, HybridEP + TileLang
  - `torch.optim.AdamW`, fp32 parameter/master-weight storage, bf16 FSDP compute
  - fixed-length dataset padding to keep HybridEP all-gather shapes symmetric
  - all 100 logged losses and grad norms finite; no NaN/Inf, OOM, traceback, or NCCL timeout
  - step 0: loss 2.3385, grad norm 7.0413
  - step 99: loss 1.7022, grad norm 1.6035
- W&B: https://wandb.ai/Nemo-automodel/huiyingl_workspace/runs/prbffcy5