### PR TITLE
fix(checkpoint): infer Qwen MTP layout from checkpoint keys

### DIFF
--- a/nemo_automodel/components/models/qwen3_5_moe/state_dict_adapter.py
+++ b/nemo_automodel/components/models/qwen3_5_moe/state_dict_adapter.py
@@ -193,6 +193,8 @@ class Qwen3_5MoeStateDictAdapter(StateDictAdapter):
                 configured_layout = "grouped"
             else:
                 raise ValueError(f"Unsupported MTP expert HF layout: {layout!r}")
+        if configured_layout is not None:
+            return configured_layout
 
         inferred_layout = _infer_mtp_expert_hf_layout(checkpoint_keys) if checkpoint_keys is not None else None
         if checkpoint_keys is None and not self._local_checkpoint_layout_checked:
@@ -211,8 +213,6 @@ class Qwen3_5MoeStateDictAdapter(StateDictAdapter):
 
         if self._inferred_mtp_expert_hf_layout is not None:
             return self._inferred_mtp_expert_hf_layout
-        if configured_layout is not None:
-            return configured_layout
 
         model_names = [self.pretrained_model_name_or_path]
         for attr in ("_name_or_path", "name_or_path"):

--- a/nemo_automodel/components/models/qwen3_5_moe/state_dict_adapter.py
+++ b/nemo_automodel/components/models/qwen3_5_moe/state_dict_adapter.py
@@ -37,10 +37,13 @@ model head as ``model.lm_head`` while Automodel registers it on the outer model
 as ``lm_head``.
 """
 
+import json
 import re
-from typing import Any, Optional
+from pathlib import Path
+from typing import Any, Iterable, Optional
 
 import torch
+from safetensors import SafetensorError, safe_open
 from torch.distributed.device_mesh import DeviceMesh
 
 from nemo_automodel.components.checkpoint.state_dict_adapter import StateDictAdapter
@@ -57,6 +60,60 @@ from nemo_automodel.components.models.qwen3_5.state_dict_adapter import (
 )
 from nemo_automodel.components.moe import state_dict_utils
 from nemo_automodel.components.moe.layers import MoEConfig
+
+_MTP_SPLIT_EXPERT_KEY = re.compile(r"mtp\.layers\.\d+\.mlp\.experts\.\d+\.(?:gate_proj|up_proj|down_proj)\.weight")
+_MTP_GROUPED_EXPERT_KEY = re.compile(r"mtp\.layers\.\d+\.mlp\.experts\.(?:gate_up_proj|down_proj)")
+
+
+def _infer_mtp_expert_hf_layout(checkpoint_keys: Iterable[str]) -> str | None:
+    """Infer the MTP expert layout from checkpoint key names."""
+    split_key = None
+    grouped_key = None
+    for key in checkpoint_keys:
+        if split_key is None and _MTP_SPLIT_EXPERT_KEY.fullmatch(key):
+            split_key = key
+        elif grouped_key is None and _MTP_GROUPED_EXPERT_KEY.fullmatch(key):
+            grouped_key = key
+        if split_key is not None and grouped_key is not None:
+            raise ValueError(
+                "Checkpoint contains both split and grouped MTP expert keys; "
+                f"cannot infer one layout (examples: {split_key!r}, {grouped_key!r})"
+            )
+    if split_key is not None:
+        return "split"
+    if grouped_key is not None:
+        return "grouped"
+    return None
+
+
+def _get_local_safetensors_keys(model_path: str | None) -> set[str]:
+    """Read key metadata from a local HF safetensors checkpoint without loading tensors."""
+    if not model_path:
+        return set()
+    checkpoint_dir = Path(model_path)
+    if not checkpoint_dir.is_dir():
+        return set()
+
+    checkpoint_keys: set[str] = set()
+    for index_path in sorted(checkpoint_dir.glob("*.safetensors.index.json")):
+        try:
+            with index_path.open() as index_file:
+                index = json.load(index_file)
+        except (OSError, json.JSONDecodeError):
+            continue
+        weight_map = index.get("weight_map")
+        if isinstance(weight_map, dict):
+            checkpoint_keys.update(key for key in weight_map if isinstance(key, str))
+    if checkpoint_keys:
+        return checkpoint_keys
+
+    for shard_path in sorted(checkpoint_dir.glob("*.safetensors")):
+        try:
+            with safe_open(str(shard_path), framework="pt", device="cpu") as shard:
+                checkpoint_keys.update(shard.keys())
+        except (OSError, SafetensorError):
+            continue
+    return checkpoint_keys
 
 
 def _strip_fp32_params(key: str) -> str:
@@ -111,6 +168,8 @@ class Qwen3_5MoeStateDictAdapter(StateDictAdapter):
         self.dtype = dtype
         self.pretrained_model_name_or_path = pretrained_model_name_or_path
         self.mtp_expert_hf_layout = mtp_expert_hf_layout
+        self._inferred_mtp_expert_hf_layout: str | None = None
+        self._local_checkpoint_layout_checked = False
         self._uses_model_prefix = True
 
         self.hf_to_internal_map = {
@@ -118,20 +177,42 @@ class Qwen3_5MoeStateDictAdapter(StateDictAdapter):
         }
         self.internal_to_hf_map = {v: k for k, v in self.hf_to_internal_map.items()}
 
-    def _get_mtp_expert_hf_layout(self) -> str:
-        """Return whether MTP experts are stored as split or grouped HF tensors."""
+    def _get_mtp_expert_hf_layout(self, checkpoint_keys: Iterable[str] | None = None) -> str:
+        """Resolve and remember whether MTP experts use split or grouped HF keys."""
         layout = self.mtp_expert_hf_layout
         if layout is None:
             config_layout = getattr(self.config, "mtp_expert_hf_layout", None)
             layout = config_layout if isinstance(config_layout, str) else None
 
+        configured_layout = None
         if layout is not None:
             normalized = layout.lower().replace("_", "-")
             if normalized in {"split", "per-expert", "per-expert-safetensors"}:
-                return "split"
-            if normalized in {"grouped", "group"}:
-                return "grouped"
-            raise ValueError(f"Unsupported MTP expert HF layout: {layout!r}")
+                configured_layout = "split"
+            elif normalized in {"grouped", "group"}:
+                configured_layout = "grouped"
+            else:
+                raise ValueError(f"Unsupported MTP expert HF layout: {layout!r}")
+
+        inferred_layout = _infer_mtp_expert_hf_layout(checkpoint_keys) if checkpoint_keys is not None else None
+        if checkpoint_keys is None and not self._local_checkpoint_layout_checked:
+            self._local_checkpoint_layout_checked = True
+            model_paths = [self.pretrained_model_name_or_path]
+            for attr in ("_name_or_path", "name_or_path"):
+                value = getattr(self.config, attr, None)
+                if isinstance(value, str) and value:
+                    model_paths.append(value)
+            for model_path in model_paths:
+                inferred_layout = _infer_mtp_expert_hf_layout(_get_local_safetensors_keys(model_path))
+                if inferred_layout is not None:
+                    break
+        if inferred_layout is not None:
+            self._inferred_mtp_expert_hf_layout = inferred_layout
+
+        if self._inferred_mtp_expert_hf_layout is not None:
+            return self._inferred_mtp_expert_hf_layout
+        if configured_layout is not None:
+            return configured_layout
 
         model_names = [self.pretrained_model_name_or_path]
         for attr in ("_name_or_path", "name_or_path"):
@@ -163,12 +244,22 @@ class Qwen3_5MoeStateDictAdapter(StateDictAdapter):
         return new_state_dict
 
     def to_hf(
-        self, state_dict: dict[str, Any], exclude_key_regex: Optional[str] = None, quantization: bool = False, **kwargs
+        self,
+        state_dict: dict[str, Any],
+        exclude_key_regex: Optional[str] = None,
+        quantization: bool = False,
+        **kwargs,
     ) -> dict[str, Any]:
-        """Rename native keys to HF keys and transpose expert tensors. No comms needed."""
+        """Rename native keys to HF keys and transpose expert tensors."""
+        mtp_expert_hf_layout = self._get_mtp_expert_hf_layout()
         hf_state_dict: dict[str, Any] = {}
         for fqn, tensor in state_dict.items():
-            for key, value in self.convert_single_tensor_to_hf(fqn, tensor, exclude_key_regex=exclude_key_regex):
+            for key, value in self.convert_single_tensor_to_hf(
+                fqn,
+                tensor,
+                exclude_key_regex=exclude_key_regex,
+                mtp_expert_hf_layout=mtp_expert_hf_layout,
+            ):
                 hf_state_dict[key] = value
         return hf_state_dict
 
@@ -183,6 +274,7 @@ class Qwen3_5MoeStateDictAdapter(StateDictAdapter):
         DTensors (DCP path): rename + transpose, no slicing — DCP handles sharding.
         Plain tensors (init path): slice to local EP shard, transpose, create DTensor.
         """
+        self._get_mtp_expert_hf_layout(set(hf_state_dict))
         self._uses_model_prefix = any(key.startswith("model.") for key in hf_state_dict if not key.startswith("mtp."))
         model_prefix = "model." if self._uses_model_prefix else ""
 
@@ -329,7 +421,10 @@ class Qwen3_5MoeStateDictAdapter(StateDictAdapter):
         value = tensor
         mtp_gate_up_match = re.match(r"mtp\.layers\.(\d+)\.mlp\.experts\.gate_and_up_projs$", fqn)
         mtp_down_match = re.match(r"mtp\.layers\.(\d+)\.mlp\.experts\.down_projs$", fqn)
-        if self._get_mtp_expert_hf_layout() == "split":
+        mtp_expert_hf_layout = kwargs.get("mtp_expert_hf_layout")
+        if mtp_expert_hf_layout is None:
+            mtp_expert_hf_layout = self._get_mtp_expert_hf_layout()
+        if mtp_expert_hf_layout == "split":
             if mtp_gate_up_match:
                 layer_num = mtp_gate_up_match.group(1)
                 splits, expert_ids = state_dict_utils.split_experts_weights_dtensor_aware(

--- a/tests/unit_tests/models/qwen3_5_moe/test_qwen3_5_moe_state_dict_adapter.py
+++ b/tests/unit_tests/models/qwen3_5_moe/test_qwen3_5_moe_state_dict_adapter.py
@@ -126,6 +126,31 @@ class TestInitialization:
 
         assert adapter._get_mtp_expert_hf_layout() == "grouped"
 
+    @pytest.mark.parametrize("override_source", ["constructor", "config"])
+    def test_mtp_layout_override_takes_precedence_over_local_checkpoint(
+        self, tmp_path, config, moe_config, backend_config, override_source
+    ):
+        split_key = "mtp.layers.0.mlp.experts.0.down_proj.weight"
+        (tmp_path / "model.safetensors.index.json").write_text(
+            json.dumps({"weight_map": {split_key: "model-00001-of-00001.safetensors"}})
+        )
+        config._name_or_path = str(tmp_path)
+        config.name_or_path = str(tmp_path)
+        explicit_layout = None
+        if override_source == "constructor":
+            explicit_layout = "grouped"
+        else:
+            config.mtp_expert_hf_layout = "grouped"
+        adapter = Qwen3_5MoeStateDictAdapter(
+            config=config,
+            moe_config=moe_config,
+            backend=backend_config,
+            pretrained_model_name_or_path=str(tmp_path),
+            mtp_expert_hf_layout=explicit_layout,
+        )
+
+        assert adapter._get_mtp_expert_hf_layout() == "grouped"
+
     def test_mtp_layout_rejects_unknown_override(self, config, moe_config, backend_config):
         adapter = Qwen3_5MoeStateDictAdapter(
             config=config,

--- a/tests/unit_tests/models/qwen3_5_moe/test_qwen3_5_moe_state_dict_adapter.py
+++ b/tests/unit_tests/models/qwen3_5_moe/test_qwen3_5_moe_state_dict_adapter.py
@@ -12,14 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import re
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
 import torch
+from safetensors.torch import save_file
 
 import nemo_automodel.components.models.qwen3_5_moe.model as qwen3_5_moe_model
+from nemo_automodel.components.checkpoint.checkpointing import Checkpointer, CheckpointingConfig
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.models.qwen3_5_moe.state_dict_adapter import Qwen3_5MoeStateDictAdapter
 from nemo_automodel.components.moe.layers import MoEConfig
@@ -133,6 +136,15 @@ class TestInitialization:
 
         with pytest.raises(ValueError, match="Unsupported MTP expert HF layout"):
             adapter._get_mtp_expert_hf_layout()
+
+    def test_mtp_layout_rejects_mixed_checkpoint_keys(self, adapter):
+        checkpoint_keys = {
+            "mtp.layers.0.mlp.experts.down_proj",
+            "mtp.layers.0.mlp.experts.0.down_proj.weight",
+        }
+
+        with pytest.raises(ValueError, match="both split and grouped MTP expert keys"):
+            adapter._get_mtp_expert_hf_layout(checkpoint_keys)
 
 
 # ---------------------------------------------------------------------------
@@ -275,6 +287,92 @@ class TestToHF:
 
         for key in hf_state:
             torch.testing.assert_close(roundtrip[key], hf_state[key])
+
+    @pytest.mark.parametrize(
+        ("checkpoint_layout", "misleading_checkpoint_name", "use_index"),
+        [
+            ("split", "Qwen3.6-35B-A3B-consolidated", True),
+            ("grouped", "Qwen3.5-35B-A3B-consolidated", False),
+        ],
+    )
+    def test_consolidated_round_trip_infers_mtp_layout_from_checkpoint_keys(
+        self,
+        tmp_path,
+        config,
+        moe_config,
+        backend_config,
+        checkpoint_layout,
+        misleading_checkpoint_name,
+        use_index,
+    ):
+        gate_up = torch.arange(4 * 8 * 128, dtype=torch.float32).reshape(4, 8, 128)
+        down = torch.arange(4 * 64 * 8, dtype=torch.float32).reshape(4, 64, 8)
+        native_state = {
+            "mtp.layers.0.mlp.experts.gate_and_up_projs": gate_up,
+            "mtp.layers.0.mlp.experts.down_projs": down,
+        }
+        writer_adapter = Qwen3_5MoeStateDictAdapter(
+            config=config,
+            moe_config=moe_config,
+            backend=backend_config,
+            mtp_expert_hf_layout=checkpoint_layout,
+        )
+        checkpoint_state = writer_adapter.to_hf(native_state)
+        checkpoint_path = tmp_path / misleading_checkpoint_name
+        checkpoint_path.mkdir()
+        shard_name = "model-00001-of-00001.safetensors" if use_index else "model.safetensors"
+        save_file(
+            {key: value.contiguous() for key, value in checkpoint_state.items()},
+            checkpoint_path / shard_name,
+        )
+        if use_index:
+            weight_map = {key: shard_name for key in checkpoint_state}
+            (checkpoint_path / "model.safetensors.index.json").write_text(json.dumps({"weight_map": weight_map}))
+
+        target = torch.nn.Module()
+        target.mtp = torch.nn.Module()
+        target.mtp.layers = torch.nn.ModuleList([torch.nn.Module()])
+        target.mtp.layers[0].mlp = torch.nn.Module()
+        target.mtp.layers[0].mlp.experts = torch.nn.Module()
+        target.mtp.layers[0].mlp.experts.gate_and_up_projs = torch.nn.Parameter(torch.zeros_like(gate_up))
+        target.mtp.layers[0].mlp.experts.down_projs = torch.nn.Parameter(torch.zeros_like(down))
+        checkpoint_model_path = str(checkpoint_path)
+        local_config = SimpleNamespace(
+            _name_or_path=checkpoint_model_path,
+            name_or_path=checkpoint_model_path,
+        )
+        target.state_dict_adapter = Qwen3_5MoeStateDictAdapter(
+            config=local_config,
+            moe_config=moe_config,
+            backend=backend_config,
+            pretrained_model_name_or_path=checkpoint_model_path,
+        )
+
+        checkpointing_config = CheckpointingConfig(
+            enabled=True,
+            checkpoint_dir=str(tmp_path),
+            model_save_format="safetensors",
+            model_cache_dir=str(tmp_path / "cache"),
+            model_repo_id="test/model",
+            save_consolidated=False,
+            is_peft=False,
+        )
+        with patch("torch.distributed.is_initialized", return_value=False):
+            checkpointer = Checkpointer(
+                checkpointing_config,
+                dp_rank=0,
+                tp_rank=0,
+                pp_rank=0,
+                moe_mesh=None,
+            )
+        checkpointer.load_model(target, model_path=str(checkpoint_path))
+
+        torch.testing.assert_close(target.mtp.layers[0].mlp.experts.gate_and_up_projs, gate_up)
+        torch.testing.assert_close(target.mtp.layers[0].mlp.experts.down_projs, down)
+        roundtrip_state = target.state_dict_adapter.to_hf(target.state_dict())
+        assert set(roundtrip_state) == set(checkpoint_state)
+        for key in checkpoint_state:
+            torch.testing.assert_close(roundtrip_state[key], checkpoint_state[key])
 
     def test_exclude_regex_filters_expert_key(self, adapter):
         """exclude_key_regex should filter expert keys after rename."""
@@ -561,9 +659,9 @@ class TestFromHF:
         expected_gate_up = []
         expected_down = []
         for expert_id in range(adapter.moe_config.n_routed_experts):
-            gate = torch.randn(32, 64)
-            up = torch.randn(32, 64)
-            down = torch.randn(64, 32)
+            gate = torch.randn(64, 64)
+            up = torch.randn(64, 64)
+            down = torch.randn(64, 64)
             hf_state[f"mtp.layers.0.mlp.experts.{expert_id}.gate_proj.weight"] = gate
             hf_state[f"mtp.layers.0.mlp.experts.{expert_id}.up_proj.weight"] = up
             hf_state[f"mtp.layers.0.mlp.experts.{expert_id}.down_proj.weight"] = down
@@ -580,6 +678,10 @@ class TestFromHF:
             out["mtp.layers.0.mlp.experts.down_projs"],
             torch.stack(expected_down, dim=0).to(adapter.dtype),
         )
+        roundtrip = adapter.to_hf(out)
+        assert set(roundtrip) == set(hf_state)
+        for key in hf_state:
+            torch.testing.assert_close(roundtrip[key], hf_state[key])
 
     def test_expert_parallel_sharding(self, adapter, monkeypatch):
         """When device_mesh is provided, from_hf should slice experts by rank."""


### PR DESCRIPTION
## Summary

- infer the Qwen3.5 MoE MTP expert layout from checkpoint metadata keys during safetensors loading
- let only adapters that need checkpoint key metadata opt into the extra metadata read
- preserve the detected split/grouped layout for later HF export and reject mixed layouts
- add split and grouped consolidated-checkpoint round-trip coverage, including misleading local model paths

## Problem

AMINT-198 fails when a consolidated Qwen3.5 MoE checkpoint is reloaded from a local path. The state-dict adapter previously inferred the MTP expert layout from the model name/path. After consolidation that path no longer identifies the original model, so the adapter could request grouped keys such as `mtp.layers.0.mlp.experts.down_proj` while the checkpoint contains per-expert split keys such as `mtp.layers.0.mlp.experts.0.down_proj.weight`. DCP then reports a missing checkpoint key.

This change derives the layout from the checkpoint's own keys instead of adding a public config field, so other inference engines and config consumers are unaffected.

Linear: https://linear.app/nvidia/issue/AMINT-198/checkpoint-loading-fails-due-to-missing-key-mtplayers0mlpexpertsdown

## Validation

- Ruff passed on the changed files.
- Targeted checkpoint and Qwen3.5 MoE adapter unit tests: **245 passed, 2 skipped**.
- Exact NeMo-CI reproduction using the original image `gitlab-master.nvidia.com/dl/joc/nemo-ci/main/automodel:pipe.59210842`, with only the three production fix files mounted: [pipeline 59607966](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/59607966), [leaf job 374012089](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/374012089).
- The original failure path completed successfully: 67 GiB consolidation followed by fresh local reload reported `[Phase 3] Automodel-from-consolidated max KL: 0.000000e+00`; the log contains no `Missing key in checkpoint state_dict` or `mtp.layers.0.mlp.experts.down_proj` error.
- The leaf job later failed in the independent Phase 6 resume-baseline training check with CUDA OOM while allocating 3.79 GiB in masked cross entropy. The top-level pipeline is green only because this case is configured as allow-failure; this PR does not claim the leaf job passed.
