### PR TITLE
perf(benchmark): tune Qwen3-VL LoRA pipeline batches

### DIFF
--- a/examples/vlm_benchmark/qwen/qwen3vl235b_lora.yaml
+++ b/examples/vlm_benchmark/qwen/qwen3vl235b_lora.yaml
@@ -36,7 +36,7 @@ benchmark:
 step_scheduler:
   gc_every_steps: 10
   global_batch_size: 512
-  local_batch_size: 4
+  local_batch_size: 8
   ckpt_every_steps: 1000
   val_every_steps: 1000
   num_epochs: 1
@@ -57,7 +57,7 @@ distributed:
     scale_grads_in_schedule: false
     patch_inner_model: false
     patch_causal_lm_model: false
-    layers_per_stage: 2
+    layers_per_stage: 6
   moe:
     reshard_after_forward: false
     wrap_outer_model: true


### PR DESCRIPTION
## Summary
- Increase `qwen3vl235b_lora` local batch size from 4 to 8.
- Increase `layers_per_stage` from 2 to 6 so the rendered pipeline uses 8 microbatches over 8 stages instead of 4 microbatches over 24 stages.

## Why
AMINT-181 tracks a throughput regression for `qwen3vl235b_lora.yaml`. The previous performance run used GA=4 with a highly underfilled pipeline. This keeps global batch size at 512 while reducing gradient accumulation to 2 and reducing the pipeline bubble.

## Validation
- `python tools/lint_example_yamls.py --automodel-dir .`
- `python tests/ci_tests/utils/validate_generate_ci.py --automodel-dir .`
- `python -m pytest tests/unit_tests/ci_tests/test_generate_ci_tests.py`
- nemo-ci target VLM benchmark leaf passed: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/374049099
  - Rendered config: `local_batch_size: 8`, `layers_per_stage: 6`, `GA steps: 2`, `8 microbatches and 8 stages`.
  - Result: average iteration time `19.147s`, average MFU `17.127597%`, max memory `23.70 GB`.

Note: the parent benchmark pipeline is marked failed because `AUTOMODEL_TEST_FOLDER=benchmark` also generates an LLM benchmark bridge, and the Qwen3-VL-only regex intentionally has no LLM match. The target VLM bridge and leaf are green.

Addresses AMINT-181.
