### PR TITLE
fix(deepseek-v4): accept cu_seqlens for THD packing

### DIFF
--- a/nemo_automodel/components/models/deepseek_v4/model.py
+++ b/nemo_automodel/components/models/deepseek_v4/model.py
@@ -116,6 +116,39 @@ class DeepseekV4CausalLMOutput(CausalLMOutputWithPast):
     mtp_loss_scaling_factor: Optional[float] = None
 
 
+def _seq_lens_from_cu_seqlens(cu_seqlens: torch.Tensor, name: str) -> torch.Tensor:
+    """Convert standard THD cumulative offsets to DSV4's per-row lengths."""
+    if not isinstance(cu_seqlens, torch.Tensor) or cu_seqlens.dim() not in (1, 2):
+        raise ValueError(f"`{name}` must be a rank-1 or rank-2 tensor.")
+    if cu_seqlens.shape[-1] < 2:
+        raise ValueError(f"`{name}` must contain at least the initial and final offsets.")
+
+    seq_lens = torch.diff(cu_seqlens, dim=-1)
+    return seq_lens.unsqueeze(0) if seq_lens.dim() == 1 else seq_lens
+
+
+def _normalize_thd_packing_metadata(attn_kwargs: dict[str, Any]) -> None:
+    """Accept standard THD offsets at the DSV4 model boundary.
+
+    DSV4 internally uses ``seq_lens`` to build document-aware masks. Packed
+    callers commonly provide the equivalent ``cu_seqlens`` representation, so
+    normalize it here when context parallelism has not already produced native
+    padded-BSHD lengths.
+    """
+    if attn_kwargs.get("qkv_format") != "thd":
+        return
+
+    if attn_kwargs.get("seq_lens") is None and attn_kwargs.get("cu_seqlens") is not None:
+        attn_kwargs["seq_lens"] = _seq_lens_from_cu_seqlens(attn_kwargs["cu_seqlens"], "cu_seqlens")
+
+    if attn_kwargs.get("seq_lens_padded") is None:
+        cu_seqlens_padded = attn_kwargs.get("cu_seqlens_padded")
+        if cu_seqlens_padded is not None:
+            attn_kwargs["seq_lens_padded"] = _seq_lens_from_cu_seqlens(cu_seqlens_padded, "cu_seqlens_padded")
+        elif attn_kwargs.get("seq_lens") is not None:
+            attn_kwargs["seq_lens_padded"] = attn_kwargs["seq_lens"]
+
+
 class DeepseekV4Block(nn.Module):
     """Single transformer block for DeepSeek V4.
 
@@ -486,6 +519,7 @@ class DeepseekV4Model(nn.Module):
         # Build the 4D additive causal+padding+SWA mask.  Same band-diagonal
         # pattern HF's ``create_sliding_window_causal_mask`` produces; every
         # layer in the released DSV4-Flash was trained under it.
+        _normalize_thd_packing_metadata(attn_kwargs)
         sliding_window = int(getattr(self.config, "sliding_window", 0) or 0) or None
         packed_seq_lens = None
         if attn_kwargs.get("qkv_format") == "thd":

--- a/tests/unit_tests/models/deepseek_v4/test_dsv4_model_smoke.py
+++ b/tests/unit_tests/models/deepseek_v4/test_dsv4_model_smoke.py
@@ -622,6 +622,31 @@ class TestDeepseekV4ModelSmoke:
 
         assert out.logits.shape == (1, 8, cfg.vocab_size)
 
+    def test_thd_cp1_accepts_standard_cu_seqlens(self, monkeypatch):
+        """A non-CP packed caller should not need to translate metadata for DSV4."""
+        cfg = _tiny_config(num_hidden_layers=0, compress_ratios=[])
+        model = _make_model(cfg)
+        captured = {}
+
+        def fake_packed_mask(seq_lens, seq_len, dtype, device, sliding_window=None):
+            captured["seq_lens"] = seq_lens
+            return torch.zeros(1, 1, seq_len, seq_len, dtype=dtype, device=device)
+
+        monkeypatch.setattr(dsv4_model_module, "build_packed_causal_padding_mask", fake_packed_mask)
+
+        cu_seqlens = torch.tensor([0, 3, 8], dtype=torch.int32)
+        with torch.no_grad():
+            out = model(
+                torch.ones(1, 8, dtype=torch.long),
+                position_ids=torch.tensor([[0, 1, 2, 0, 1, 2, 3, 4]]),
+                qkv_format="thd",
+                cu_seqlens=cu_seqlens,
+                cu_seqlens_padded=cu_seqlens,
+            )
+
+        assert out.logits.shape == (1, 8, cfg.vocab_size)
+        torch.testing.assert_close(captured["seq_lens"], torch.tensor([[3, 5]], dtype=torch.int32))
+
     def test_thd_cp_normalizes_packed_ids_and_derives_padding_mask(self, monkeypatch):
         cfg = _tiny_config(num_hidden_layers=0, compress_ratios=[])
         model = _make_model(cfg)


### PR DESCRIPTION
## What changed

- Normalize standard THD `cu_seqlens` and `cu_seqlens_padded` metadata to DeepSeek-V4's internal `seq_lens` representation at the model boundary.
- Preserve native `seq_lens` / `seq_lens_padded` when a model-owned CP sharder already supplied them.
- Add a regression test covering a CP-size-1/non-CP packed caller that passes only standard cumulative offsets.

## Why

Packed callers use the common AutoModel THD contract (`qkv_format="thd"` plus cumulative sequence offsets), while DeepSeek-V4's document-aware masking only consumed `seq_lens`. CP-size-1 callers do not need context sharding and may call the model directly, so requiring each framework to translate the metadata leaked a model-specific input contract into the caller.

Handling the equivalent representations in DeepSeek-V4 keeps framework inputs generic. The CP>1 path is unchanged: the model-owned sharder still consumes padded-BSHD `seq_lens` so it can repad, shard, and reconstruct the original rows.

## Validation

- `ruff format --check` and `ruff check` on the changed files.
- `22 passed`: `tests/unit_tests/models/deepseek_v4/test_dsv4_model_smoke.py`
- `34 passed`: `tests/unit_tests/models/deepseek_v4/test_dsv4_cp_batch.py`
- Real DeepSeek-V4-Flash four-layer CP1 packed smoke passed directly on this PR against current `main`, using BF16 model loading: 8×H100, DP8+EP8, finite `sft_loss=14.9` and `grad_norm=105` after a full optimizer step.
- [Stock-recipe W&B validation](https://wandb.ai/Nemo-automodel/huiyingl_workspace/runs/7zk0hd57) using `deepseek_v4_flash_packed_sequence_hellaswag.yaml`: 16 H100 nodes (128 GPUs), PP4/EP32/HybridEP, THD packing, and torch AdamW. Completed one HellaSwag epoch (12 steps from 3,253 packs at GBS 256) with all-finite metrics; train loss `2.2446 → 1.4100` and validation loss `1.4039`. This uses the recipe's native `seq_lens` metadata, so it validates the existing packed path but does not exercise the new cumulative-offset normalization branch.
- [PR3231 cu-only W&B validation](https://wandb.ai/Nemo-automodel/huiyingl_workspace/runs/kyhl2wua) on exact head `9e01f8db`: 1 node / 8×H100, four layers, PP1/CP1/EP8 HybridEP, BF16, 1,024-token production HellaSwag THD packs, and torch AdamW. A run-local collater converted the production metadata to rank-1 int32 `cu_seqlens`/`cu_seqlens_padded` only; runtime assertions on all eight ranks proved `seq_lens` was absent at the model boundary and was reconstructed exactly as `diff(cu_seqlens)`. Slurm job `14434365` completed 2/2 optimizer steps with finite loss `16.7965 → 16.6503` and finite grad norm `161.0039 → 152.8703`.
- [Full 16-node cu-only W&B validation](https://wandb.ai/Nemo-automodel/huiyingl_workspace/runs/2m5e7k5r) on exact head `9e01f8db`: 128×H100, full DSV4 model, PP4/CP1/EP32 HybridEP, BF16, GBS 256 / LBS 8, 1,024-token production HellaSwag THD packs, and torch AdamW. A run-local batched collater emitted rank-2 int32 `cu_seqlens`/`cu_seqlens_padded` only; strict runtime assertions and exit audits passed on 128/128 ranks, proving every pipeline rank entered the new branch with `seq_lens` absent and reconstructed it exactly as `diff(cu_seqlens)`. Slurm job `14435261` completed one epoch (12 optimizer steps) with finite train loss `2.2449 → 1.4110`, finite grad norm throughout, and validation loss `1.4047`. Step-0 warm-up was 7:33 versus 8:17 for the native-`seq_lens` stock run; steady-state steps remained about 6–9 seconds.
