### PR TITLE
fix(speculative): average DFlash train metrics over the log window

### DIFF
--- a/nemo_automodel/recipes/llm/train_dflash.py
+++ b/nemo_automodel/recipes/llm/train_dflash.py
@@ -460,9 +460,16 @@ class TrainDFlashRecipe(BaseRecipe):
     def _log_extra_train_metrics(self, epoch_idx: int) -> None:
         """Hook for subclasses to log extra per-step metrics at a log point (no-op here)."""
 
-    def _extra_train_wandb_metrics(self, metrics) -> dict[str, float]:
-        """Return algorithm-specific W&B metrics for one training step."""
-        return {"train/accept_len": float(metrics.accept_len)}
+    def _extra_train_metric_sums(self, metrics) -> dict[str, tuple[float, float]]:
+        """Return algorithm-specific training numerator and denominator pairs.
+
+        These are accumulated over the micro-batches between two log points and
+        divided at the log point, the same way ``train/loss`` and
+        ``train/accuracy`` are, so every curve on the dashboard covers the same
+        window. Returning the per-micro-batch mean instead would report a single
+        micro-batch out of ``log_every_steps * grad_accumulation_steps``.
+        """
+        return {"train/accept_len": (float(metrics.accept_len_sum), float(metrics.valid_blocks))}
 
     def _extra_eval_metric_sums(self, metrics) -> dict[str, tuple[torch.Tensor, torch.Tensor]]:
         """Return additional validation numerator and denominator pairs.
@@ -837,6 +844,7 @@ class TrainDFlashRecipe(BaseRecipe):
                 running_loss = 0.0
                 running_acc = 0.0
                 running_micro = 0
+                running_extra: dict[str, list[float]] = {}
                 epoch_loss = 0.0
                 micro_step = 0
                 pending_micro_batches = 0
@@ -884,6 +892,13 @@ class TrainDFlashRecipe(BaseRecipe):
                     running_loss += metrics.loss.detach().item()
                     running_acc += metrics.accuracy.detach().item()
                     running_micro += 1
+                    # Accumulated here, past the skip ``continue`` above, so a
+                    # micro-batch excluded from loss/accuracy is excluded from
+                    # these too.
+                    for name, (numerator, denominator) in self._extra_train_metric_sums(metrics).items():
+                        totals = running_extra.setdefault(name, [0.0, 0.0])
+                        totals[0] += numerator
+                        totals[1] += denominator
                     epoch_loss += metrics.loss.detach().item()
                     micro_step += 1
                     pending_micro_batches += 1
@@ -930,11 +945,18 @@ class TrainDFlashRecipe(BaseRecipe):
                                     "train/lr": current_lr,
                                     "train/epoch": epoch_idx,
                                 }
-                                wandb_data.update(self._extra_train_wandb_metrics(metrics))
+                                wandb_data.update(
+                                    {
+                                        name: numerator / denominator
+                                        for name, (numerator, denominator) in running_extra.items()
+                                        if denominator > 0
+                                    }
+                                )
                                 self._wandb_log(wandb_data, step=self.runtime.global_step)
                             running_loss = 0.0
                             running_acc = 0.0
                             running_micro = 0
+                            running_extra.clear()
 
                 # Flush the trailing partial accumulation window (see EAGLE recipes
                 # for the rescale rationale).

--- a/nemo_automodel/recipes/llm/train_domino.py
+++ b/nemo_automodel/recipes/llm/train_domino.py
@@ -120,16 +120,22 @@ class TrainDominoRecipe(TrainDFlashRecipe):
             float(m.lambda_base),
         )
 
-    def _extra_train_wandb_metrics(self, metrics) -> dict[str, float]:
-        """Return Domino head and curriculum diagnostics for W&B."""
-        values = super()._extra_train_wandb_metrics(metrics)
+    def _extra_train_metric_sums(self, metrics) -> dict[str, tuple[float, float]]:
+        """Return Domino head and curriculum diagnostics as window sums.
+
+        ``lambda_base`` is a schedule value rather than a statistic, so its
+        denominator is the micro-batch count: averaging it over the window is
+        what makes it comparable with the loss curves beside it.
+        """
+        values = super()._extra_train_metric_sums(metrics)
+        valid_tokens = float(metrics.valid_tokens)
         values.update(
             {
-                "train/final_loss": float(metrics.final_loss),
-                "train/base_loss": float(metrics.base_loss),
-                "train/base_accuracy": float(metrics.base_accuracy),
-                "train/base_accept_len": float(metrics.base_accept_len),
-                "train/lambda_base": float(metrics.lambda_base),
+                "train/final_loss": (float(metrics.final_loss), 1.0),
+                "train/base_loss": (float(metrics.base_loss), 1.0),
+                "train/base_accuracy": (float(metrics.base_correct_tokens), valid_tokens),
+                "train/base_accept_len": (float(metrics.base_accept_len_sum), float(metrics.valid_blocks)),
+                "train/lambda_base": (float(metrics.lambda_base), 1.0),
             }
         )
         return values

--- a/tests/unit_tests/recipes/llm/test_train_dflash.py
+++ b/tests/unit_tests/recipes/llm/test_train_dflash.py
@@ -499,3 +499,41 @@ def test_build_trainer_module_loss_type_null_falls_back_to_default():
     recipe = _bare_dflash_recipe()
     module = recipe._build_trainer_module("sdpa", {"loss_type": None})
     assert module.loss_type == "dflash"
+
+
+def test_train_metric_sums_are_additive_not_per_micro_batch():
+    """``train/accept_len`` must be reported over the same window as ``train/loss``.
+
+    Returning ``metrics.accept_len`` (the per-micro-batch mean) reported a single
+    micro-batch out of ``log_every_steps * grad_accumulation_steps``, so the
+    curve was a far noisier sample than the loss curve drawn beside it.
+    """
+    recipe = _bare_dflash_recipe()
+    window = [
+        SimpleNamespace(accept_len_sum=torch.tensor(6.0), valid_blocks=torch.tensor(4.0)),
+        SimpleNamespace(accept_len_sum=torch.tensor(1.0), valid_blocks=torch.tensor(1.0)),
+    ]
+
+    totals = [0.0, 0.0]
+    for metrics in window:
+        numerator, denominator = recipe._extra_train_metric_sums(metrics)["train/accept_len"]
+        totals[0] += numerator
+        totals[1] += denominator
+
+    # Block-weighted over the window (7/5), not the last micro-batch's 1.0.
+    assert totals[0] / totals[1] == pytest.approx(7.0 / 5.0)
+    assert recipe._extra_train_metric_sums(window[-1])["train/accept_len"] == (
+        pytest.approx(1.0),
+        pytest.approx(1.0),
+    )
+
+
+def test_train_metric_sums_denominator_can_be_zero():
+    """A micro-batch with no evaluated blocks must not be averaged into the window.
+
+    The log point divides only when the accumulated denominator is positive, so a
+    zero here has to survive as a zero rather than raising or silently counting.
+    """
+    recipe = _bare_dflash_recipe()
+    metrics = SimpleNamespace(accept_len_sum=torch.tensor(0.0), valid_blocks=torch.tensor(0.0))
+    assert recipe._extra_train_metric_sums(metrics)["train/accept_len"] == (0.0, 0.0)

--- a/tests/unit_tests/recipes/llm/test_train_dflash_noanchor_skip.py
+++ b/tests/unit_tests/recipes/llm/test_train_dflash_noanchor_skip.py
@@ -49,7 +49,14 @@ class _FakeTrainerModule(nn.Module):
         if i in self._raise_on:
             raise NoValidAnchorsError("every sample too short")
         out = self.dummy(torch.randn(1, 4)).sum()
-        return SimpleNamespace(loss=out.abs() + 1.0, accuracy=torch.tensor(0.5))
+        # The acceptance fields mirror DFlashStepMetrics: the training loop
+        # accumulates them per micro-batch to average over the log window.
+        return SimpleNamespace(
+            loss=out.abs() + 1.0,
+            accuracy=torch.tensor(0.5),
+            accept_len_sum=torch.tensor(2.0),
+            valid_blocks=torch.tensor(1.0),
+        )
 
 
 class _FakeTargetWrapper:

--- a/tests/unit_tests/recipes/llm/test_train_domino.py
+++ b/tests/unit_tests/recipes/llm/test_train_domino.py
@@ -180,26 +180,30 @@ def test_log_extra_train_metrics(caplog):
     assert "base_loss=2.3" in caplog.text
 
 
-def test_domino_wandb_metrics_include_head_diagnostics():
+def test_domino_train_sums_include_head_diagnostics():
     recipe = _recipe()
     metrics = SimpleNamespace(
-        accept_len=torch.tensor(2.5),
+        accept_len_sum=torch.tensor(5.0),
+        valid_blocks=torch.tensor(2.0),
+        valid_tokens=torch.tensor(10.0),
         final_loss=torch.tensor(0.9),
         base_loss=torch.tensor(1.2),
-        base_accuracy=torch.tensor(0.4),
-        base_accept_len=torch.tensor(1.8),
+        base_correct_tokens=torch.tensor(4.0),
+        base_accept_len_sum=torch.tensor(3.6),
         lambda_base=torch.tensor(0.25),
     )
 
-    values = recipe._extra_train_wandb_metrics(metrics)
+    values = recipe._extra_train_metric_sums(metrics)
 
+    # Every entry is (numerator, denominator) so the caller can average it over
+    # the same window as train/loss instead of reporting one micro-batch.
     assert values == {
-        "train/accept_len": 2.5,
-        "train/final_loss": pytest.approx(0.9),
-        "train/base_loss": pytest.approx(1.2),
-        "train/base_accuracy": pytest.approx(0.4),
-        "train/base_accept_len": pytest.approx(1.8),
-        "train/lambda_base": 0.25,
+        "train/accept_len": (pytest.approx(5.0), pytest.approx(2.0)),
+        "train/final_loss": (pytest.approx(0.9), 1.0),
+        "train/base_loss": (pytest.approx(1.2), 1.0),
+        "train/base_accuracy": (pytest.approx(4.0), pytest.approx(10.0)),
+        "train/base_accept_len": (pytest.approx(3.6), pytest.approx(2.0)),
+        "train/lambda_base": (pytest.approx(0.25), 1.0),
     }
 
 


### PR DESCRIPTION
## What

`train/accept_len` is reported over a different window than the curves it is plotted next to.

`train/loss` and `train/accuracy` are averaged over the micro-batches accumulated since the last log point (`running_* / running_micro`), which the code comments there are explicit about. `train/accept_len` instead returned `float(metrics.accept_len)`, the per-micro-batch mean from the single most recent micro-batch.

With `grad_accumulation_steps: 4` and `log_every_steps: 10` that is one micro-batch out of forty, drawn on the same dashboard as two curves covering all forty. The acceptance curve therefore looks much noisier than the statistic it estimates actually is, which matters because judging whether acceptance is still improving is the only reason the metric exists.

This is a reporting defect, not a training one. No loss, gradient, or checkpoint behavior changes.

## How

Replace the `_extra_train_wandb_metrics` hook with `_extra_train_metric_sums`, returning `(numerator, denominator)` pairs in the same shape `_extra_eval_metric_sums` already uses for validation, so the two paths now agree on how an extra metric is aggregated.

- The training loop accumulates the pairs into a per-window dict and divides at the log point.
- The accumulation sits after the no-valid-anchors `continue`, so a micro-batch excluded from loss and accuracy is excluded from these too.
- A metric whose denominator stays zero across a whole window is omitted from the log rather than reported as a fabricated zero.
- The window dict is cleared with the other running totals, so nothing leaks across windows.

Domino's overrides move to the same shape, and two of them get more accurate denominators in the process: `base_accuracy` becomes `base_correct_tokens / valid_tokens` and `base_accept_len` becomes `base_accept_len_sum / valid_blocks`, so each is weighted by what it actually measures instead of being averaged per micro-batch. `lambda_base` is a schedule value rather than a statistic, so it averages over the micro-batch count.

Deliberately unchanged: the per-step text logs in the Domino and JetSpec recipes still print the most recent step. Their docstrings already say so, so they are not making a claim the numbers do not support.

## Pre-checks

- [x] Read and followed the contributor guidelines.
- [x] Added regression tests: a two-micro-batch window whose block-weighted average (7/5) differs from the last micro-batch (1.0), and a zero-denominator micro-batch.
- [x] Ran `ruff format` and `ruff check` on the changed files.
- [x] Commit includes DCO sign-off.

## Validation

```text
tests/unit_tests/recipes/llm/test_train_dflash.py + test_train_domino.py:  50 passed
tests/unit_tests/recipes/llm + tests/unit_tests/speculative:              1204 passed, 12 skipped
```

The same two directories on the base commit report `7 failed, 1202 passed` and this branch reports `7 failed, 1204 passed`, with the failing set identical (diffed by test id). Those seven are pre-existing and unrelated to this change.

Updating the stub in `test_train_dflash_noanchor_skip.py` was necessary because the training loop now reads the acceptance fields per micro-batch; the stub was returning a metrics object missing fields that the real `DFlashStepMetrics` has always carried.
