### PR TITLE
fix(speculative): honor --dflash-causal on the vLLM remapping export

### DIFF
--- a/nemo_automodel/components/speculative/serve_vllm.py
+++ b/nemo_automodel/components/speculative/serve_vllm.py
@@ -291,10 +291,22 @@ def _load_safetensors_io():
     return load_file, save_file
 
 
-def _export_is_fresh(draft_dir: Path, export_dir: Path) -> bool:
-    """True when ``export_dir`` holds a complete config + weights newer than the source weights or config."""
+def _export_is_fresh(draft_dir: Path, export_dir: Path, expected_config: dict[str, Any]) -> bool:
+    """True when ``export_dir`` holds a complete export matching ``expected_config``.
+
+    Mtime alone is not sufficient. The exported config also depends on the launch
+    flags (``--dflash-causal``), which leave the source checkpoint untouched, so a
+    cached export can be newer than every source file and still describe a
+    different drafter than the one this launch asked for. Comparing the config
+    content covers both the stale-source and the changed-flags cases.
+    """
     exported_config = export_dir / "config.json"
     if not exported_config.exists() or not _has_hf_weight_file(export_dir):
+        return False
+    try:
+        if _load_config(exported_config) != expected_config:
+            return False
+    except json.JSONDecodeError:
         return False
     src_files = [
         *draft_dir.glob("model-*.safetensors"),
@@ -305,21 +317,28 @@ def _export_is_fresh(draft_dir: Path, export_dir: Path) -> bool:
     return exported_config.stat().st_mtime_ns >= src_mtime
 
 
-def _export_for_vllm(draft_dir: Path, config: dict[str, Any]) -> Path:
+def _export_for_vllm(draft_dir: Path, config: dict[str, Any], *, dflash_causal: bool = False) -> Path:
     """Materialize a vLLM-loadable copy of ``draft_dir`` in a ``vllm_export/`` subdir.
 
     The safetensors keys are remapped to strip the Automodel ``self.model``
     wrapper prefix, the config receives the architectures / pard_token fixups, and
     the tokenizer assets are copied alongside. The source checkpoint is left
     untouched. The export is cached and rebuilt only when stale.
+
+    Args:
+        draft_dir: The HF-style drafter directory to export from.
+        config: The parsed drafter ``config.json``.
+        dflash_causal: Forwarded to the config fixups; stamps
+            ``dflash_config.causal=true`` on a DFlash-family draft.
     """
     export_dir = draft_dir / _VLLM_EXPORT_DIRNAME
-    if _export_is_fresh(draft_dir, export_dir):
+    # Validate the config fixups up front so a bad draft fails before any writes.
+    config_updates = _vllm_config_updates(config, dflash_causal=dflash_causal)
+    exported_config = {**config, **config_updates}
+    if _export_is_fresh(draft_dir, export_dir, exported_config):
         logger.info("Reusing fresh vLLM export at %s", export_dir)
         return export_dir
 
-    # Validate the config fixups up front so a bad draft fails before any writes.
-    config_updates = _vllm_config_updates(config)
     load_file, save_file = _load_safetensors_io()
     export_dir.mkdir(parents=True, exist_ok=True)
 
@@ -337,8 +356,6 @@ def _export_for_vllm(draft_dir: Path, config: dict[str, Any]) -> Path:
         with (export_dir / "model.safetensors.index.json").open("w") as f:
             json.dump(index, f, indent=2)
 
-    exported_config = dict(config)
-    exported_config.update(config_updates)
     with (export_dir / "config.json").open("w") as f:
         json.dump(exported_config, f, indent=2)
 
@@ -432,7 +449,7 @@ def resolve_draft_artifacts(
         export_dir = draft_dir / _VLLM_EXPORT_DIRNAME
         if dry_run:
             return str(export_dir), config
-        return str(_export_for_vllm(draft_dir, config)), config
+        return str(_export_for_vllm(draft_dir, config, dflash_causal=dflash_causal)), config
 
     if not dry_run:
         _rewrite_config_for_vllm(config_path, config, dflash_causal=dflash_causal)

--- a/tests/unit_tests/speculative/test_serve_vllm.py
+++ b/tests/unit_tests/speculative/test_serve_vllm.py
@@ -559,3 +559,67 @@ def test_main_execv_path_replaces_process(tmp_path: Path, monkeypatch):
 
     assert captured["path"] == captured["cmd"][0]
     assert "vllm.entrypoints.openai.api_server" in captured["cmd"]
+
+
+def _write_prefixed_dflash_checkpoint(model_dir: Path) -> Path:
+    """A DFlash draft saved by Automodel: ``model.``-prefixed weights, no ``causal`` stamp."""
+    model_dir.mkdir(parents=True, exist_ok=True)
+    save_file(
+        {
+            "model.fc.weight": torch.zeros(2, 6),
+            "model.layers.0.self_attn.q_proj.weight": torch.zeros(2, 2),
+            "model.norm.weight": torch.zeros(2),
+        },
+        str(model_dir / "model.safetensors"),
+        metadata={"format": "pt"},
+    )
+    config_path = model_dir / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "architectures": ["Qwen3DFlashDraftModel"],
+                "model_type": "qwen3",
+                "block_size": 16,
+                "dflash_config": {"mask_token_id": 151669, "projector_type": "jetspec"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return config_path
+
+
+def test_dflash_causal_reaches_the_exported_config(tmp_path: Path):
+    """``--dflash-causal`` must survive the remapping export, not only the in-place rewrite.
+
+    The flag exists for JetSpec checkpoints trained before the recipe stamped
+    ``causal``. Those come from Automodel, so their weights carry the ``model.``
+    prefix and they always take the export branch: dropping the flag there made
+    it a no-op in exactly the case it was added for, silently serving the draft
+    with the wrong attention semantics.
+    """
+    model_dir = tmp_path / "epoch_0_step_10" / "model" / "consolidated"
+    _write_prefixed_dflash_checkpoint(model_dir)
+
+    draft_path, _ = resolve_draft_artifacts(str(model_dir), dflash_causal=True)
+
+    exported = json.loads((Path(draft_path) / "config.json").read_text(encoding="utf-8"))
+    assert Path(draft_path).name == "vllm_export"
+    assert exported["dflash_config"]["causal"] is True
+
+
+def test_export_is_rebuilt_when_dflash_causal_changes(tmp_path: Path):
+    """The cache keys on the exported config, not just source mtimes.
+
+    ``--dflash-causal`` never touches the source checkpoint, so an mtime-only
+    freshness check would keep serving the previous launch's export.
+    """
+    model_dir = tmp_path / "epoch_0_step_10" / "model" / "consolidated"
+    _write_prefixed_dflash_checkpoint(model_dir)
+
+    def _causal_of(dflash_causal: bool):
+        path, _ = resolve_draft_artifacts(str(model_dir), dflash_causal=dflash_causal)
+        return json.loads((Path(path) / "config.json").read_text(encoding="utf-8"))["dflash_config"].get("causal")
+
+    assert _causal_of(True) is True
+    assert _causal_of(False) is None
+    assert _causal_of(True) is True


### PR DESCRIPTION
## What

`--dflash-causal` is silently dropped for every Automodel-produced draft, which is the only kind of draft it was added for.

`resolve_draft_artifacts` has two branches:

```python
if _needs_weight_remap(_draft_weight_keys(draft_dir)):
    return str(_export_for_vllm(draft_dir, config)), config          # flag not passed
...
_rewrite_config_for_vllm(config_path, config, dflash_causal=dflash_causal)   # flag passed
```

`_export_for_vllm` then recomputed the fixups with `_vllm_config_updates(config)`, taking the default `dflash_causal=False`, so the exported `config.json` never received the `dflash_config.causal` stamp.

The flag exists for JetSpec checkpoints trained before the recipe started stamping `causal` itself. Those checkpoints come out of Automodel, so their weights always carry the `self.model` wrapper prefix, so they always take the export branch. The flag was therefore a no-op in exactly the situation it was written for.

Nothing fails when this happens. vLLM starts and serves the draft with the wrong attention semantics, which shows up as a lower acceptance rate rather than an error.

## Reproduction

Two identical JetSpec drafts, both resolved with `dflash_causal=True`, differing only in whether the weights carry the `model.` prefix:

| weights | branch taken | `dflash_config.causal` in the config vLLM loads |
|---|---|---|
| `model.`-prefixed (Automodel) | `_export_for_vllm` | absent |
| unprefixed | `_rewrite_config_for_vllm` | `True` |

## How

Thread `dflash_causal` into `_export_for_vllm` and on to `_vllm_config_updates`.

The cache needed fixing in the same change. `_export_is_fresh` compared source mtimes only, and the flag never touches the source checkpoint, so a cached export stays "fresh" across launches that ask for different config fixups. Even with the flag correctly threaded, the second launch would reuse the first launch's export. `_export_is_fresh` now also compares the exported `config.json` against the config this launch would write, which subsumes the mtime check's purpose for the config and covers any future fixup that depends on a launch flag.

Computing the fixups once and reusing that dict for both the freshness comparison and the write also removes the duplicated `dict(config)` / `update(...)` at the write site.

## Pre-checks

- [x] Read and followed the contributor guidelines.
- [x] Added regression tests for both halves: the flag reaching the exported config, and the export being rebuilt when the flag flips (on, off, on again).
- [x] Ran `ruff format` and `ruff check` on the changed files.
- [x] Commit includes DCO sign-off.

## Validation

```text
tests/unit_tests/speculative/test_serve_vllm.py:                29 passed
tests/unit_tests/speculative + tests/unit_tests/recipes/llm:  1204 passed, 12 skipped
```

The base commit reports `7 failed, 1202 passed` on those two directories and this branch reports `7 failed, 1204 passed`, the two extra passes being the new tests. The failing set is identical and pre-existing.

`serve_sglang.py` was checked for the same defect and does not have it: it rewrites the config in place on a single path and takes no equivalent flag.
