### PR TITLE
fix(speculative): align the decode-eval cadence on resume

### DIFF
--- a/nemo_automodel/components/speculative/decode_eval.py
+++ b/nemo_automodel/components/speculative/decode_eval.py
@@ -289,6 +289,20 @@ class DecodeEvalRunner:
         """Whether a new eval should launch at this optimizer step."""
         return global_step // self.config.every_steps > self._last_bucket
 
+    def resume_from_step(self, global_step: int) -> None:
+        """Align the launch cadence to a restored ``global_step`` after a resume.
+
+        Without this a resumed run starts with ``_last_bucket == 0`` and
+        :meth:`due` fires immediately, spending a full eval (a detached engine
+        server plus its benchmark, on the GPU the training run has just finished
+        reclaiming) on a cadence region that already ran before the checkpoint.
+        Landing on a step whose eval had completed is worse than redundant:
+        :meth:`maybe_launch` clears that step's result before relaunching, so a
+        collected result is discarded to recompute what it already held.
+        """
+        self._last_bucket = global_step // self.config.every_steps
+        self._launched_for_step = global_step
+
     def maybe_launch(self, global_step: int, draft_model) -> bool:
         """Snapshot the draft and launch the worker if the cadence is due and no eval is running."""
         if not self.due(global_step):

--- a/nemo_automodel/recipes/llm/train_eagle3.py
+++ b/nemo_automodel/recipes/llm/train_eagle3.py
@@ -1611,11 +1611,12 @@ class TrainEagle3Recipe(PeagleRecipeMixin, BaseRecipe):
             meta = torch.load(meta_path, weights_only=False, map_location="cpu")
             self.runtime.global_step = int(meta.get("global_step", 0))
             self._resume_epoch = int(meta.get("epoch", 0))
-            # Align the regen launch cadence to the restored step so resume does not
-            # immediately fire a redundant cycle for an already-covered region.
-            regen_runner = getattr(self, "regen_runner", None)
-            if regen_runner is not None:
-                regen_runner.resume_from_step(self.runtime.global_step)
+            # Align the cadence-driven runners to the restored step so resume does
+            # not immediately fire a redundant launch for an already-covered region.
+            for runner_attr in ("regen_runner", "decode_eval_runner"):
+                runner = getattr(self, runner_attr, None)
+                if runner is not None:
+                    runner.resume_from_step(self.runtime.global_step)
             ids = meta.get("selected_token_ids")
             mask = meta.get("selected_token_mask")
             if ids is not None and mask is not None:

--- a/tests/unit_tests/speculative/test_decode_eval.py
+++ b/tests/unit_tests/speculative/test_decode_eval.py
@@ -463,3 +463,43 @@ def test_recipe_hook_contains_optional_eval_failures(caplog):
     recipe._maybe_run_decode_eval()
 
     assert "training continues" in caplog.text
+
+
+def test_resume_from_step_suppresses_immediate_relaunch(tmp_path):
+    """A resumed run must not re-eval a cadence region the pre-crash run covered.
+
+    ``_last_bucket`` starts at 0, so without this alignment ``due`` is true at the
+    first step after a resume, spending a whole eval (a detached engine server plus
+    its benchmark) on a region that already ran.
+    """
+    runner = DecodeEvalRunner(_config(tmp_path, every_steps=10))
+
+    assert runner.due(50) is True
+
+    runner.resume_from_step(50)
+
+    assert runner.due(50) is False
+    # Still inside the same cadence bucket.
+    assert runner.due(59) is False
+    # The next bucket boundary fires normally.
+    assert runner.due(60) is True
+
+
+def test_resume_from_step_keeps_a_collected_result_for_that_step(tmp_path):
+    """Resuming on a step whose eval finished must not discard its result.
+
+    ``maybe_launch`` clears the step's ``result.json`` before relaunching, so an
+    unaligned resume landing on that step recomputes a result it already had.
+    """
+    cfg = _config(tmp_path, every_steps=10)
+    step_dir = os.path.join(cfg.output_dir, "step_50")
+    os.makedirs(step_dir)
+    result_path = os.path.join(step_dir, "result.json")
+    with open(result_path, "w") as f:
+        json.dump({"step": 50, "accept_length": 2.5}, f)
+
+    runner = DecodeEvalRunner(cfg)
+    runner.resume_from_step(50)
+
+    assert runner.due(50) is False
+    assert os.path.exists(result_path)


### PR DESCRIPTION
## What

Every resume of an EAGLE-3 run with decode eval enabled fires a redundant decode eval at the first optimizer step after the restore.

`DecodeEvalRunner` and `RegenRunner` are the same shape: a bucketed cadence over optimizer steps (`global_step // every_steps > _last_bucket`) driving a detached worker. `RegenRunner` has `resume_from_step` for exactly this reason, and `train_eagle3` calls it while restoring `global_step`. `DecodeEvalRunner` was never given the equivalent, so it starts with `_last_bucket == 0` and `due()` is immediately true against any restored step.

```text
DecodeEvalRunner: has resume_from_step?   False
  _last_bucket after __init__           : 0
  due(global_step=5000) on resume       : True
  RegenRunner has resume_from_step?     : True
```

Two costs:

- A decode eval is not cheap. It exports a draft snapshot and launches a detached engine server plus its benchmark, on the GPU the training run has just finished reclaiming, for a cadence region whose result already exists.
- Resuming on a step whose eval had completed loses that result. `maybe_launch` removes the step's `result.json` (and its `.tmp`), discards it from `_collected`, and clears the snapshot before relaunching, so a finished measurement is thrown away to recompute what it already held.

## How

Add `resume_from_step` to `DecodeEvalRunner`, mirroring `RegenRunner`.

At the restore site, drive both runners from one loop rather than adding a second near-identical block. The two runners already share this lifecycle shape, and a third cadence runner added later would otherwise repeat the same omission.

```python
for runner_attr in ("regen_runner", "decode_eval_runner"):
    runner = getattr(self, runner_attr, None)
    if runner is not None:
        runner.resume_from_step(self.runtime.global_step)
```

Both runners are constructed in `setup()`, which precedes `load_checkpoint()`, so both are visible at the restore site.

## Behavior

| | before | after |
|---|---|---|
| `due(50)` on a fresh resume at step 50 | `True` | `False` |
| `due(59)`, same cadence bucket | `True` | `False` |
| `due(60)`, next bucket boundary | `True` | `True` |

The cadence itself is unchanged; only the already-covered region is suppressed.

## Pre-checks

- [x] Read and followed the contributor guidelines.
- [x] Added regression tests for the suppressed relaunch and for a completed result surviving a resume on its own step.
- [x] Ran `ruff format` and `ruff check` on the changed files.
- [x] Commit includes DCO sign-off.

## Validation

```text
tests/unit_tests/speculative/test_decode_eval.py + test_regen_loop.py:   51 passed
tests/unit_tests/speculative + tests/unit_tests/recipes/llm:           1204 passed, 12 skipped
```

The base commit reports `7 failed, 1202 passed` on those two directories and this branch reports `7 failed, 1204 passed`, the two extra passes being the new tests. The failing set is identical and pre-existing.
