### PR TITLE
fix(speculative): validate mask_token_id when resuming DSpark

### DIFF
--- a/nemo_automodel/recipes/llm/train_dspark.py
+++ b/nemo_automodel/recipes/llm/train_dspark.py
@@ -1242,12 +1242,29 @@ class TrainDSparkRecipe(BaseRecipe):
         self._load_extra_state(ckpt_dir)
 
     def _load_extra_state(self, ckpt_dir: str) -> None:
-        """Restore DSpark meta: global_step and epoch."""
+        """Restore DSpark meta: global_step and epoch, and validate mask_token_id."""
         meta_path = os.path.join(ckpt_dir, "dspark_meta.pt")
         if os.path.exists(meta_path):
             meta = torch.load(meta_path, weights_only=False, map_location="cpu")
             self.runtime.global_step = int(meta.get("global_step", 0))
             self._resume_epoch = int(meta.get("epoch", 0))
+            # ``mask_token_id`` comes only from the resume YAML (it is not restored
+            # from the checkpoint); the draft's ``embed_tokens`` row at that id is
+            # the learned "predict here" signal, as _resolve_mask_token_id spells
+            # out. A resume YAML whose ``mask_token_id`` disagrees with the trained
+            # one silently points the mask slots at an untrained embedding row and
+            # degrades acceptance with no error, so fail loudly on a mismatch.
+            # Legacy checkpoints saved before this field existed (``None``) skip
+            # the check. This mirrors the DFlash recipe, whose mask slots work the
+            # same way.
+            saved_mask_token_id = meta.get("mask_token_id", None)
+            if saved_mask_token_id is not None and int(saved_mask_token_id) != int(self.mask_token_id):
+                raise ValueError(
+                    f"mask_token_id mismatch on resume: the checkpoint at {ckpt_dir} was trained with "
+                    f"mask_token_id={int(saved_mask_token_id)}, but recipe_args.mask_token_id="
+                    f"{int(self.mask_token_id)}. The draft's mask-slot embedding was learned at the "
+                    f"checkpoint's id; set recipe_args.mask_token_id={int(saved_mask_token_id)} to resume."
+                )
 
     def _log_saved_checkpoint(self, kind: str, epoch: int, step: int) -> None:
         """Log a saved checkpoint on rank 0 when checkpointing is enabled."""

--- a/tests/unit_tests/recipes/llm/test_train_dspark_helpers.py
+++ b/tests/unit_tests/recipes/llm/test_train_dspark_helpers.py
@@ -1014,3 +1014,48 @@ def test_should_shard_dense_target_allows_explicit_unit_or_null_axes():
         cfg={"distributed": {"strategy": "fsdp2", "tp_size": 1, "pp_size": None, "cp_size": 1, "ep_size": None}}
     )
     assert recipe._should_shard_dense_target({"shard_dense_target": True}) is True
+
+
+def _dspark_resume_self(mask_token_id=7):
+    return SimpleNamespace(
+        runtime=SimpleNamespace(global_step=0),
+        _resume_epoch=0,
+        mask_token_id=mask_token_id,
+    )
+
+
+def _write_dspark_meta(tmp_path, **fields):
+    meta = {"global_step": 5, "epoch": 2, "block_size": 16, "num_anchors": 512, "target_layer_ids": [1, 2]}
+    meta.update(fields)
+    torch.save(meta, tmp_path / "dspark_meta.pt")
+    return str(tmp_path)
+
+
+def test_dspark_load_extra_state_restores_step_and_epoch(tmp_path):
+    ckpt_dir = _write_dspark_meta(tmp_path, mask_token_id=7)
+    obj = _dspark_resume_self(mask_token_id=7)
+    TrainDSparkRecipe._load_extra_state(obj, ckpt_dir)
+    assert obj.runtime.global_step == 5
+    assert obj._resume_epoch == 2
+
+
+def test_dspark_load_extra_state_raises_on_mask_token_id_mismatch(tmp_path):
+    """A resume YAML whose mask_token_id disagrees with the checkpoint must fail loudly.
+
+    The draft's ``embed_tokens`` row at this id is the learned "predict here"
+    signal, so resuming at a different id trains against an untrained row and
+    degrades acceptance silently.
+    """
+    ckpt_dir = _write_dspark_meta(tmp_path, mask_token_id=7)
+    obj = _dspark_resume_self(mask_token_id=99)
+    with pytest.raises(ValueError, match="mask_token_id mismatch on resume"):
+        TrainDSparkRecipe._load_extra_state(obj, ckpt_dir)
+
+
+def test_dspark_load_extra_state_accepts_legacy_meta_without_mask_token_id(tmp_path):
+    """Checkpoints saved before mask_token_id was persisted skip the check."""
+    torch.save({"global_step": 3, "epoch": 1}, tmp_path / "dspark_meta.pt")
+    obj = _dspark_resume_self(mask_token_id=99)
+    TrainDSparkRecipe._load_extra_state(obj, str(tmp_path))
+    assert obj.runtime.global_step == 3
+    assert obj._resume_epoch == 1


### PR DESCRIPTION
## What

Resuming a DSpark run with a `mask_token_id` that disagrees with the trained one is accepted silently and quietly ruins the run.

`_resolve_mask_token_id` in the DSpark recipe already states the contract:

> The draft's `embed_tokens` row at this id is the learned "predict here" signal. It must be a deliberately chosen reserved / unused token id ... and the inference runtime must fill block slots with the same id.

`mask_token_id` is read only from the YAML, never restored from the checkpoint. So a resume whose YAML carries a different id points every mask slot at an embedding row the draft never trained, and acceptance degrades with no error and no warning.

The DFlash recipe, whose mask slots work identically, validates this on resume. DSpark does not, even though it already writes `mask_token_id` into `dspark_meta.pt`: the value needed for the check was sitting in the checkpoint unused.

Same checkpoint meta, same mismatch, the two recipes side by side:

```text
DFlash, trained mask=151669 resume mask=999 : raised: mask_token_id mismatch on resume...
DSpark, trained mask=151669 resume mask=999 : accepted silently (global_step=500)
```

## How

Read `mask_token_id` back in `_load_extra_state` and raise on a mismatch, mirroring the DFlash recipe down to the error message, so the two read the same way when someone hits this.

The legacy escape hatch is mirrored too: a meta saved before the field existed stores `None`, has nothing to compare against, and skips the check rather than refusing to resume.

## Scope

DSpark also persists `block_size`, `num_anchors`, and `target_layer_ids` without reading them back, and DFlash does the same with `block_size` and `target_layer_ids`. Those are worth validating as well, but their failure modes depend on how the changed value interacts with the data, whereas this one is deterministic: a different id is always the wrong embedding row. Keeping this change to the one field keeps it reviewable and matches the guard DFlash already ships. Happy to follow up on the rest separately.

## Pre-checks

- [x] Read and followed the contributor guidelines.
- [x] Added the three tests DFlash has for this: step and epoch restore, mismatch raises, legacy meta without the field is accepted.
- [x] Ran `ruff format` and `ruff check` on the changed files.
- [x] Commit includes DCO sign-off.

## Validation

```text
tests/unit_tests/recipes/llm/test_train_dspark_helpers.py:         83 passed
tests/unit_tests/speculative + tests/unit_tests/recipes/llm:     1205 passed, 12 skipped
```

The base commit reports `7 failed, 1202 passed` on those two directories and this branch reports `7 failed, 1205 passed`, the three extra passes being the new tests. The failing set is identical and pre-existing.
