### PR TITLE
docs(speculative): document Gemma4, MSD, CP, and during-training tools

### DIFF
--- a/examples/speculative/README.md
+++ b/examples/speculative/README.md
@@ -32,6 +32,16 @@ to P-EAGLE, all from the same draft class. Domino and JetSpec reuse the DFlash
 draft class and checkpoint format; only their training wrappers (and, for
 Domino, the extra head weights) differ.
 
+**Not yet runnable: MSD (multimodal speculative decoding).** `eagle/msd.py`,
+`msd_target.py`, `msd_curriculum.py`, and `msd_decode.py` implement the MSD
+training core, the frozen VLM target wrapper, the two-stage data curriculum, and
+the reference tree-decoding path. MSD extends EAGLE-1/2 feature drafting to
+vision-language targets: text positions keep the usual concatenation of target
+features and next-token embeddings, while image positions feed the target's
+already-projected image embeddings straight into the draft. It is deliberately
+absent from the table above because no recipe or config wires it up yet, so there
+is nothing to launch. The recipe and data pipeline are a follow-up change.
+
 ## Supported target models
 
 A target's `config.architectures` string selects the draft architecture through a
@@ -46,6 +56,13 @@ The shipped example configs only cover a subset.
 - **gpt-oss** (`GptOssForCausalLM`): EAGLE-3 only, via a dedicated draft class.
 - **DeepSeek-V3** (`DeepseekV3ForCausalLM`): EAGLE-3 only, via a dedicated MLA
   draft class (eager attention; sequence packing not supported yet).
+- **Gemma4** (`Gemma4ForConditionalGeneration`): EAGLE-3 only, via a dedicated
+  draft class that reconciles the Gemma4 text config (`hidden_activation`, nested
+  per-attention-type `rope_parameters`). The target is multimodal but the draft is
+  trained on its **text backbone only**: the decoder config is read through
+  `config.get_text_config()` and the draft consumes post-block hidden states, so
+  images do not participate in drafting. Configs: `eagle3/gemma4_e2b_eagle3.yaml`,
+  `gemma4_e4b_eagle3.yaml`, `gemma4_31b_eagle3.yaml`, `gemma4_26b_a4b_eagle3.yaml`.
 - **DFlash / Domino / JetSpec**: `Qwen3ForCausalLM`, `Qwen3MoeForCausalLM`.
 - **DSpark**: `Qwen3ForCausalLM`, `Qwen3MoeForCausalLM`,
   `DeepseekV4ForCausalLM`, GLM-5.2 (`GlmMoeDsaForCausalLM`), Gemma4
@@ -314,6 +331,66 @@ recipe_args:
 Datasets are consumed by `ChatDataset`: a `messages` list of `{role, content}`,
 or a `conversations` column (ShareGPT or OpenAI style) that is auto-converted.
 
+## Context parallelism for draft training
+
+`distributed.cp_size > 1` shards the sequence across ranks for long-context draft
+training. The draft's attention runs as a differentiable ring
+(`eagle/ring_attention.py`, with a load-balanced zig-zag layout in
+`zigzag_ring_attention.py`); `target_cp.py` prepares the target-side inputs.
+
+The constraints are enforced, not advisory: every combination below raises at
+setup rather than training something subtly wrong.
+
+| Constraint | Applies to |
+|---|---|
+| Cannot combine with sequence packing (`packed_sequence_size > 0`); CP shards the sequence and strips the block-causal mask packing relies on | EAGLE-1/2, EAGLE-3, DFlash, DSpark |
+| Colocated target backend only; the remote backend runs the target out-of-process | EAGLE-3 |
+| Cannot combine with tensor parallelism (`tp_size > 1`) | DFlash |
+| Dense Qwen3-style draft only | DSpark |
+| EAGLE-3 draft attention must be the `Eagle3LlamaAttention` ring path; architectures without it (the DeepSeek MLA draft) raise `NotImplementedError` | EAGLE-3 |
+
+## During-training tools (EAGLE-3)
+
+Both are opt-in, off unless their block sets `every_steps`, and both run their
+work in a **detached subprocess on GPUs the training run does not use**, so
+`cuda_visible_devices` is required rather than defaulted.
+
+### Periodic real acceptance length (`decode_eval`)
+
+Training loss and simulated accept length are proxies. The acceptance length that
+matters is the one an inference engine produces from the draft plus the target.
+`decode_eval` snapshots the draft every `every_steps` optimizer steps, serves the
+snapshot, benchmarks it, and reports the engine's real `accept_length` back into
+the training log and W&B.
+
+```yaml
+decode_eval:
+  every_steps: 500
+  cuda_visible_devices: "7"     # required: a GPU the training run is not using
+  target_model: meta-llama/Llama-3.1-8B-Instruct
+  input_data: /path/to/eval.jsonl
+  num_speculative_tokens: 4
+```
+
+A cycle whose predecessor is still running is skipped rather than queued, so a
+cadence faster than one eval takes will simply measure less often.
+
+### On-policy regeneration (`regen`)
+
+The draft is trained against target answers, and those answers age as the draft
+changes what it is asked to draft. `regen` periodically regenerates a slice of the
+corpus with the target and swaps the fresh shards into the dataloader. The swap
+happens at an epoch boundary (a mid-epoch dataloader rebuild would disturb the
+sampler), so a completed cycle waits for the next boundary.
+
+```yaml
+regen:
+  every_steps: 1000
+  cuda_visible_devices: "6"
+  target_model: meta-llama/Llama-3.1-8B-Instruct
+  input_data: /path/to/prompts.jsonl
+```
+
 ## Serve and benchmark a trained draft
 
 ### SGLang
@@ -505,12 +582,18 @@ Implementation:
 ```
 nemo_automodel/components/speculative/
   eagle/        core(.py/_v12), draft_llama(.py/_v12), draft_gpt_oss,
-                draft_deepseek, backend, registry, target(.py/_v12),
-                peagle_*, remote/
+                draft_deepseek, draft_gemma, backend, registry,
+                target(.py/_v12), peagle_*, remote/,
+                msd*                        # MSD core (no recipe yet)
+                ring_attention, zigzag_ring_attention   # draft-side CP
+                {sglang,vllm}_target, *_runner          # engine-backed targets
   dflash/       core, domino_core, jetspec_core, draft_qwen3, registry, target
   dspark/       core, draft_qwen3, draft_deepseek_v4, draft_glm_5_2,
                 draft_gemma4, draft_minimax_m3, markov_head, registry, target
   regenerate.py            # dataset regeneration with the target model
+  regen_loop.py            # on-policy regeneration during training (regen block)
+  decode_eval.py           # periodic real accept-length eval (decode_eval block)
+  target_cp.py             # target-side context-parallel input prep
   precompute_eagle3.py     # offline target-output cache
   serve_target.py          # remote target server (HTTP + NCCL)
   serve_sglang.py          # serve a trained draft via SGLang

--- a/examples/speculative/README.md
+++ b/examples/speculative/README.md
@@ -1,4 +1,4 @@
-# Speculative decoding: draft-model training in NeMo AutoModel
+# Train Draft Models for Speculative Decoding in NeMo AutoModel
 
 This directory trains the **draft models** used for speculative decoding. A draft
 proposes several future tokens cheaply, the frozen **target** model verifies them
@@ -6,19 +6,19 @@ in one forward pass, and every accepted token is a step the target never had to
 run autoregressively. The faster and more accurate the draft, the higher the
 acceptance length and the larger the inference speedup.
 
-AutoModel trains the draft; you then serve `draft + target` together in an
+AutoModel trains the draft. You then serve the draft and target together in an
 inference engine (SGLang or vLLM). The training code lives in
 `nemo_automodel/components/speculative/`, the recipes in
 `nemo_automodel/recipes/llm/`, and ready-to-run configs in this folder.
 
-## Supported methods
+## Supported Methods
 
-| Method | What the draft does | Recipe (`recipe:` key) | Configs |
+| Method | What the Draft Does | Recipe (`recipe:` Key) | Configs |
 |---|---|---|---|
-| **EAGLE-1** | Single decoder block that predicts the next target hidden state; supervised by SmoothL1 hidden-state loss plus a token loss through the frozen target `lm_head`. | `TrainEagle1Recipe` | `eagle1/` |
+| **EAGLE-1** | Single decoder block that predicts the next target hidden state. Supervised by SmoothL1 hidden-state loss and a token loss through the frozen target `lm_head`. | `TrainEagle1Recipe` | `eagle1/` |
 | **EAGLE-2** | Same training objective as EAGLE-1 (it differs only in the inference-time tree policy), so the recipe is a thin subclass. | `TrainEagle2Recipe` | `eagle2/` |
 | **EAGLE-3** | Draft with its own `lm_head` over a (optionally compressed) draft vocab, fed three auxiliary target hidden states, trained with a **test-time-training (TTT)** unroll. | `TrainEagle3Recipe` | `eagle3/` |
-| **EAGLE-3.1** | EAGLE-3 plus two drafter toggles (`fc_norm`, `norm_output`), matching the vLLM EAGLE-3.1 architecture. | `TrainEagle3Recipe` | `eagle3_1/` |
+| **EAGLE-3.1** | EAGLE-3 with two drafter toggles (`fc_norm`, `norm_output`), matching the vLLM EAGLE-3.1 architecture. | `TrainEagle3Recipe` | `eagle3_1/` |
 | **P-EAGLE** | Parallel-drafting EAGLE-3: predicts all `num_depths` tokens in one forward over a COD-subsampled sequence instead of the TTT unroll. Serves on vLLM only. | `TrainEagle3Recipe` (`parallel_drafting: true`) | `p-eagle/` |
 | **DFlash** | Block-parallel drafting: drafts a whole block of `block_size` tokens in one non-causal "denoising" forward over `[anchor, MASK, MASK, ...]`. | `TrainDFlashRecipe` (LLM) / `DiffusionLMSFTRecipe` (DLLM SFT) | `dflash/`, `../dllm_sft/*dflash*` |
 | **Domino** | DFlash backbone plus a serial GRU correction head (`prefix_gru` / `embed_proj`) that refines each block position on the previous ones. | `TrainDominoRecipe` | `dflash/qwen3_domino.yaml` |
@@ -26,10 +26,10 @@ inference engine (SGLang or vLLM). The training code lives in
 | **DSpark** | Semi-autoregressive parallel drafting: a parallel backbone drafts the block, a lightweight serial Markov head adds intra-block dependency, and a confidence head predicts per-position acceptance. | `TrainDSparkRecipe` | `dspark/` |
 
 EAGLE-1/2/3 keep their separate code paths: `*_v12.py` files are the **EAGLE-1/2**
-("v1/v2") implementation; the unsuffixed files are the EAGLE-3/3.1 path. Inside
+("v1/v2") implementation. The unsuffixed files are the EAGLE-3/3.1 path. Inside
 EAGLE-3, `fc_norm`/`norm_output` upgrade to 3.1 and `parallel_drafting` upgrades
 to P-EAGLE, all from the same draft class. Domino and JetSpec reuse the DFlash
-draft class and checkpoint format; only their training wrappers (and, for
+draft class and checkpoint format. Only their training wrappers (and, for
 Domino, the extra head weights) differ.
 
 **Not yet runnable: MSD (multimodal speculative decoding).** `eagle/msd.py`,
@@ -42,7 +42,7 @@ already-projected image embeddings straight into the draft. It is deliberately
 absent from the table above because no recipe or config wires it up yet, so there
 is nothing to launch. The recipe and data pipeline are a follow-up change.
 
-## Supported target models
+## Supported Target Models
 
 A target's `config.architectures` string selects the draft architecture through a
 registry (`eagle/registry.py`, `dflash/registry.py`, `dspark/registry.py`).
@@ -53,10 +53,10 @@ The shipped example configs only cover a subset.
 
 - **EAGLE-1/2/3 (and the EAGLE-3.1 / P-EAGLE toggles on top of EAGLE-3)**:
   `LlamaForCausalLM`, `Phi3ForCausalLM`, `Qwen3ForCausalLM`, `Qwen3MoeForCausalLM`.
-- **gpt-oss** (`GptOssForCausalLM`): EAGLE-3 only, via a dedicated draft class.
-- **DeepSeek-V3** (`DeepseekV3ForCausalLM`): EAGLE-3 only, via a dedicated MLA
-  draft class (eager attention; sequence packing not supported yet).
-- **Gemma4** (`Gemma4ForConditionalGeneration`): EAGLE-3 only, via a dedicated
+- **gpt-oss** (`GptOssForCausalLM`): EAGLE-3 only, using a dedicated draft class.
+- **DeepSeek-V3** (`DeepseekV3ForCausalLM`): EAGLE-3 only, using a dedicated MLA
+  draft class (eager attention, sequence packing not supported yet).
+- **Gemma4** (`Gemma4ForConditionalGeneration`): EAGLE-3 only, using a dedicated
   draft class that reconciles the Gemma4 text config (`hidden_activation`, nested
   per-attention-type `rope_parameters`). The target is multimodal but the draft is
   trained on its **text backbone only**: the decoder config is read through
@@ -67,20 +67,22 @@ The shipped example configs only cover a subset.
 - **DSpark**: `Qwen3ForCausalLM`, `Qwen3MoeForCausalLM`,
   `DeepseekV4ForCausalLM`, GLM-5.2 (`GlmMoeDsaForCausalLM`), Gemma4
   (`Gemma4ForConditionalGeneration`, `Gemma4UnifiedForConditionalGeneration`),
-  and MiniMax M3 VL (`MiniMaxM3SparseForConditionalGeneration`, incl. a
-  multimodal data path via `recipe_args.multimodal: true`).
+  and MiniMax M3 VL (`MiniMaxM3SparseForConditionalGeneration`, including a
+  multimodal data path through `recipe_args.multimodal: true`).
 
 Qwen3-MoE is handled exactly like a dense target: the draft only consumes
 post-block hidden states, never per-expert routing. gpt-oss uses a dedicated
 draft class that reuses the target's YaRN rotary embedding but keeps the on-disk
 `architectures` string as the Llama EAGLE-3 draft so inference engines load it
 unchanged. The large-MoE DSpark targets (DeepSeek-V4, GLM-5.2, MiniMax M3) load
-frozen through the same expert-parallel / FSDP paths their finetune recipes use;
-see the per-target notes in `dspark/README_*.md`.
+frozen through the same expert-parallel / FSDP paths their fine-tuning recipes use.
+Per-target notes are in `dspark/README_*.md`.
 
-## Quick start
+## Quickstart
 
-The CLI is `automodel` (alias `am`); it drives `torchrun` internally.
+The CLI is `automodel` (alias `am`). It drives `torchrun` internally.
+
+Train an EAGLE-3 draft model:
 
 ```bash
 automodel examples/speculative/eagle3/llama_eagle3_mvp.yaml --nproc-per-node 8
@@ -92,8 +94,8 @@ Override any config key inline:
 automodel examples/speculative/eagle3/llama_eagle3_perfectblend.yaml --nproc-per-node 8 --recipe_args.micro_batch_size=2
 ```
 
-The DFlash **DLLM SFT** configs under `../dllm_sft/` use the standard AutoModel
-SFT entry script instead:
+Run DFlash **DLLM SFT** configs under `../dllm_sft/` with the standard AutoModel
+SFT entry script:
 
 ```bash
 torchrun --nproc-per-node 8 examples/dllm_sft/finetune.py -c examples/dllm_sft/qwen3_4b_dflash.yaml
@@ -103,14 +105,14 @@ Each config family ships an `*_mvp.yaml` (tiny single-GPU smoke with placeholder
 data paths) and a `*_perfectblend.yaml` (real run on
 `frankleeeee/PerfectBlend-Regenerated-Llama-3.1-8B-Instruct`).
 
-## Operators, kernels, and attention backends
+## Operators, Kernels, and Attention Backends
 
 Beyond the methods themselves, the subsystem supports several compute backends.
-Pick them through config; all degrade gracefully when a dependency is missing.
+Select them in the config. All degrade gracefully when a dependency is missing.
 
-### Draft attention backend
+### Draft Attention Backend
 
-| Method | Backends | How to select |
+| Method | Backends | How to Select |
 |---|---|---|
 | EAGLE-3 / 3.1 | `eager`, `flash_attention_2` | `recipe_args.draft_attn_implementation` (default `eager`) |
 | EAGLE-1/2 | `eager` only | n/a |
@@ -120,14 +122,14 @@ Pick them through config; all degrade gracefully when a dependency is missing.
 
 For EAGLE-3, FlashAttention-2 is real FA2 over the TTT attention pattern: FA2
 computes the `T×T` causal block and returns `softmax_lse`, and the diagonal
-extension columns for cached TTT steps are merged in log space via `logaddexp`.
+extension columns for cached TTT steps are merged in log space through `logaddexp`.
 The draft declares `_supports_flash_attn = True`, FA2 availability is probed
 defensively (`_HAS_FA`), and requesting `flash_attention_2` without `flash-attn`
 installed raises rather than silently falling back. A ready example is
 `eagle3/llama_eagle3_mvp_flash_attn.yaml`. FA2 requires a right-padded attention
 mask (enforced at runtime).
 
-### Fused Triton soft cross-entropy
+### Fused Triton Soft Cross-Entropy
 
 EAGLE-3/P-EAGLE supervise the draft with a masked soft cross-entropy that uses a
 **fused Triton kernel** when Triton is available and the logits are on CUDA
@@ -135,77 +137,77 @@ EAGLE-3/P-EAGLE supervise the draft with a masked soft cross-entropy that uses a
 falling back to a pure-PyTorch `log_softmax` path otherwise. The masked reduction
 normalizes by valid-position count.
 
-### Draft-vocab compression (d2t / t2d)
+### Draft-Vocab Compression (d2t / t2d)
 
 EAGLE-3 can shrink the draft `lm_head` to `draft_vocab_size < target_vocab_size`.
 Training carries two tensors: `selected_token_ids` (draft index to target id, the
 "d2t" direction) and `selected_token_mask` (a boolean membership mask over the
 full target vocab, the "t2d" direction). The mapping is built and cached by
-`components/datasets/llm/eagle3.py`; set `recipe_args.draft_vocab_size` to enable,
+`components/datasets/llm/eagle3.py`. Set `recipe_args.draft_vocab_size` to enable,
 or point `recipe_args.selected_token_ids_path` at a precomputed map. `t2d` is
 unset when the draft vocab is uncompressed.
 
-### FP8 draft training
+### FP8 Draft Training
 
 All spec-decode recipes (EAGLE-1/2, EAGLE-3 / P-EAGLE, DFlash / Domino /
 JetSpec, DSpark) accept the same top-level `fp8:` block as the SFT recipes (see
 `components/quantization/fp8.py`). When enabled, the draft's `nn.Linear` layers
 are swapped to torchao `Float8Linear` before the DDP / FSDP2 wrap, so the
-draft's forward and backward GEMMs run in fp8. Requires SM89+ (H100 or newer);
-`emulate: true` runs the fp8 numerics on older GPUs for testing. The frozen
-target model is never converted (it already supports fp8-quantized checkpoints
-via dequant-on-load in the DSpark V4 / GLM path). Linears with a weight dim not
-divisible by 16 are skipped automatically; use `filter_fqns` to exclude more
-(e.g. `["lm_head"]`). On DSpark's FSDP2 path, `enable_fsdp_float8_all_gather`
-plus `precompute_float8_dynamic_scale_for_fsdp` additionally amortize the
-per-step scale computation, mirroring the SFT recipes. See
+draft's forward and backward GEMMs run in FP8. Requires SM89+ (H100 or newer);
+`emulate: true` runs the FP8 numerics on older GPUs for testing. The frozen
+target model is never converted (it already supports FP8-quantized checkpoints
+through dequant-on-load in the DSpark V4 / GLM path). Linears with a weight dim not
+divisible by 16 are skipped automatically. Use `filter_fqns` to exclude more
+(for example, `["lm_head"]`). On DSpark's FSDP2 path, `enable_fsdp_float8_all_gather`
+and `precompute_float8_dynamic_scale_for_fsdp` reduce the cost of computing
+scales at each step. The SFT recipes use the same optimization. See
 `eagle3/qwen3_eagle3_fp8.yaml`.
 
 **Pair `fp8:` with `compile:`.** The recipes also accept the SFT recipes'
-top-level `compile:` block (`CompileConfig`); the draft is compiled in place
-(`nn.Module.compile()`, so checkpoint keys are unchanged) after the fp8 swap.
-This matters for fp8 throughput: Float8Linear's per-GEMM cast/scale ops are
-memory-bound and only pay off once inductor fuses them into the GEMM
-prologue. In eager mode fp8 draft training is typically SLOWER than bf16
-(measured 0.76x on an H100 EAGLE-3 run); compiled, the same A/B measured
-fp8 at 1.03x over bf16 with byte-equivalent convergence. Expect the fp8
+top-level `compile:` block (`CompileConfig`). The draft is compiled in place
+(`nn.Module.compile()`, so checkpoint keys are unchanged) after the FP8 swap.
+This matters for FP8 throughput: Float8Linear's per-GEMM cast/scale ops are
+memory-bound and only pay off when inductor fuses them into the GEMM
+prologue. In eager mode FP8 draft training is typically slower than BF16
+(measured 0.76x on an H100 EAGLE-3 run). Compiled, the same A/B measured
+FP8 at 1.03x over BF16 with byte-equivalent convergence. Expect the FP8
 gain to scale with draft GEMM size: a single 4096-wide EAGLE-3 layer sits
 near the float8 break-even point, while wider or deeper drafts (DSpark on
 V4/GLM-scale targets) benefit more. `compile:` also works without `fp8:`
-as a plain draft speedup (measured ~1.34x over the eager bf16 baseline in
+as a plain draft speedup (measured ~1.34x over the eager BF16 baseline in
 the same run).
 
-### LoRA draft adaptation (EAGLE-3 only)
+### LoRA Draft Adaptation (EAGLE-3 Only)
 
 The EAGLE-3 recipe accepts the SFT recipes' `peft:` block (`PeftConfig`). The
-base draft is frozen and only `lora_A`/`lora_B` adapters train; checkpoints are
-adapter-only (`adapter_model.safetensors` via the standard PEFT checkpoint
+base draft is frozen and only `lora_A`/`lora_B` adapters train. Checkpoints are
+adapter-only (`adapter_model.safetensors` through the standard PEFT checkpoint
 path). This is for adapting an existing draft to a new domain or dataset:
 point `recipe_args.draft_weights_path` at the consolidated safetensors export
 of a trained draft to warm-start the base weights (adapters over a randomly
-initialized draft are pointless; `draft_weights_path` also works without
+initialized draft are pointless. `draft_weights_path` also works without
 `peft:` for full-FT continued training). With a compressed draft vocab the
-base run's token mapping must be reused via `selected_token_ids_path` (the
-frozen `lm_head` rows are tied to it); a differing mapping fails fast at
-load. The FINAL checkpoint of a LoRA run additionally exports the merged
+base run's token mapping must be reused through `selected_token_ids_path` (the
+frozen `lm_head` rows are tied to it). A differing mapping fails fast at
+load. The final checkpoint of a LoRA run also exports the merged
 draft to `model/consolidated` (serve-ready, same layout as full-FT runs), so
 no external merge step is needed. Not supported with `parallel_drafting`
 (P-EAGLE trains `mask_hidden` and the embeddings, which the LoRA freeze would
 lock), with `freeze_embeddings: false` (same freeze conflict), with `fp8:`,
-or in the DFlash-family / DSpark / EAGLE-1/2 recipes (rejected explicitly;
-their drafts carry trainable non-LoRA heads that the freeze would silently
+or in the DFlash-family / DSpark / EAGLE-1/2 recipes (rejected explicitly.
+Their drafts carry trainable non-LoRA heads that the freeze would silently
 lock, and only EAGLE-3 implements the warm start). See
 `eagle3/qwen3_eagle3_lora.yaml`.
 
-## Target backends
+## Target Backends
 
-The frozen target produces the supervision signal (aux hidden states plus the
+The frozen target produces the supervision signal (aux hidden states and the
 target distribution). EAGLE-3 supports three ways to run it.
 
-| Backend | `recipe_args.target_model_backend` | When to use |
+| Backend | `recipe_args.target_model_backend` | When to Use |
 |---|---|---|
-| **Co-located (default)** | `colocated` | Target and draft share the same GPUs. Simplest; default for every config. |
-| **Remote** | `remote` | Target served on separate GPUs/host; training streams supervision over HTTP (control) + NCCL (data, with a binary wire fallback). Numerically identical to co-located. |
+| **Co-located (default)** | `colocated` | Target and draft share the same GPUs. Simplest, default for every config. |
+| **Remote** | `remote` | Target served on separate GPUs/host. Training streams supervision over HTTP (control) and NCCL (data, with a binary wire fallback). Numerically identical to co-located. |
 | **Offline cache** | set `cached_target_path` | Precompute target outputs once to disk, then train without the target loaded. Disk-heavy and largely superseded by the remote backend. |
 
 Remote serving (`eagle3/llama_eagle3_remote.yaml`): start a server first, then
@@ -224,14 +226,14 @@ recipe_args:
 
 Offline cache is produced by `precompute_eagle3.py`
 (`python -m nemo_automodel.components.speculative.precompute_eagle3 --target-model ... --input-data ... --output-dir ...`),
-then consumed via `cached_target_path`. DSpark also supports a text-only offline cache via `precompute_dspark.py`
+then consumed through `cached_target_path`. DSpark also supports a text-only offline cache through `precompute_dspark.py`
 for HF-loadable single-process text targets.
 
 For DSpark targets too large to fit on one node (DeepSeek-V4-Flash, GLM-5.2), a
 **distributed** precompute (`precompute_dspark_dist.py`) loads the target frozen
-through the same expert-parallel + FSDP2 path as online training and writes the
+through the same expert-parallel and FSDP2 path as online training and writes the
 identical cache. It is config-driven and launched with `torchrun` like multi-node
-training; each rank forwards its own contiguous slice of the dataset and writes its
+training. Each rank forwards its own contiguous slice of the dataset and writes its
 own global-indexed shards straight into the shared `cache_output_dir` (no merge step):
 
 ```bash
@@ -259,24 +261,24 @@ aligned with the target. If a regenerated set already exists on the Hub (for
 example `frankleeeee/PerfectBlend-Regenerated-Llama-3.1-8B-Instruct`), skip this
 and point `recipe_args.train_data_path` straight at it.
 
-### Two-step flow
+### Two-Step Flow
 
 The script talks to an OpenAI-compatible chat-completion endpoint, so the target
-must already be served. The examples use SGLang; vLLM or any other
+must already be served. The examples use SGLang. vLLM or any other
 OpenAI-compatible server works too.
 
-Step 1, start the target server (use `--tp 2` or higher to shard a multi-GPU
-target):
+1. Start the target server (use `--tp 2` or higher to shard a multi-GPU
+   target):
 
-```bash
-python -m sglang.launch_server --model-path meta-llama/Llama-3.1-8B-Instruct --port 30000
-```
+   ```bash
+   python -m sglang.launch_server --model-path meta-llama/Llama-3.1-8B-Instruct --port 30000
+   ```
 
-Step 2, regenerate against the running server:
+2. Regenerate against the running server:
 
-```bash
-python -m nemo_automodel.components.speculative.regenerate --input-data Aeala/ShareGPT_Vicuna_unfiltered --output-dir ./regenerated/sharegpt_llama31_8b --target-server http://localhost:30000/v1 --model meta-llama/Llama-3.1-8B-Instruct --concurrency 64 --shard-size 1000
-```
+   ```bash
+   python -m nemo_automodel.components.speculative.regenerate --input-data Aeala/ShareGPT_Vicuna_unfiltered --output-dir ./regenerated/sharegpt_llama31_8b --target-server http://localhost:30000/v1 --model meta-llama/Llama-3.1-8B-Instruct --concurrency 64 --shard-size 1000
+   ```
 
 For each sample the script loads the `messages` column (HF Hub id, local
 parquet, or JSON/JSONL, same loader as `ChatDataset`), drops every trailing
@@ -302,7 +304,7 @@ recipe_args:
   val_data_path: null
 ```
 
-### Regeneration tuning knobs
+### Regeneration Tuning Knobs
 
 | Flag | Default | Notes |
 |---|---|---|
@@ -313,15 +315,15 @@ recipe_args:
 | `--top-p` | 1.0 | Only relevant with `temperature > 0`. |
 | `--timeout-s` | 600 | Per-request timeout; bump for very long generations. |
 | `--max-retries` | 3 | Retries on 5xx, 429, and transport errors with exponential backoff. |
-| `--split` | `train` | Supports HF slice syntax, e.g. `train[:10000]`. |
+| `--split` | `train` | Supports HF slice syntax, e.g., `train[:10000]`. |
 | `--shuffle-seed` | unset | Optional shuffle before slicing. |
 
-### Regeneration pitfalls
+### Regeneration Pitfalls
 
-- **Wrong model name.** `--model` is the name sent in the OpenAI payload; it must
+- **Wrong model name.** `--model` is the name sent in the OpenAI payload. It must
   match what the server serves. SGLang uses `--model-path` as the served name by
   default, so mirror `--served-model-name` here if you set it.
-- **Server not warm.** Send one curl request to the server first; otherwise the
+- **Server not warm.** Send one curl request to the server first. Otherwise the
   script retries then fails on the first batch.
 - **Tokenizer mismatch.** The regenerated dataset is consumed by `ChatDataset`,
   which applies the target model's chat template at training time. Make sure the
@@ -331,34 +333,34 @@ recipe_args:
 Datasets are consumed by `ChatDataset`: a `messages` list of `{role, content}`,
 or a `conversations` column (ShareGPT or OpenAI style) that is auto-converted.
 
-## Context parallelism for draft training
+## Context Parallelism for Draft Training
 
 `distributed.cp_size > 1` shards the sequence across ranks for long-context draft
 training. The draft's attention runs as a differentiable ring
 (`eagle/ring_attention.py`, with a load-balanced zig-zag layout in
-`zigzag_ring_attention.py`); `target_cp.py` prepares the target-side inputs.
+`zigzag_ring_attention.py`). `target_cp.py` prepares the target-side inputs.
 
 The constraints are enforced, not advisory: every combination below raises at
 setup rather than training something subtly wrong.
 
-| Constraint | Applies to |
+| Constraint | Applies To |
 |---|---|
-| Cannot combine with sequence packing (`packed_sequence_size > 0`); CP shards the sequence and strips the block-causal mask packing relies on | EAGLE-1/2, EAGLE-3, DFlash, DSpark |
-| Colocated target backend only; the remote backend runs the target out-of-process | EAGLE-3 |
+| Cannot combine with sequence packing (`packed_sequence_size > 0`). CP shards the sequence and strips the block-causal mask packing relies on | EAGLE-1/2, EAGLE-3, DFlash, DSpark |
+| Co-located target backend only; the remote backend runs the target out-of-process | EAGLE-3 |
 | Cannot combine with tensor parallelism (`tp_size > 1`) | DFlash |
 | Dense Qwen3-style draft only | DSpark |
 | EAGLE-3 draft attention must be the `Eagle3LlamaAttention` ring path; architectures without it (the DeepSeek MLA draft) raise `NotImplementedError` | EAGLE-3 |
 
-## During-training tools (EAGLE-3)
+## During-Training Tools (EAGLE-3)
 
 Both are opt-in, off unless their block sets `every_steps`, and both run their
 work in a **detached subprocess on GPUs the training run does not use**, so
 `cuda_visible_devices` is required rather than defaulted.
 
-### Periodic real acceptance length (`decode_eval`)
+### Periodic Real Acceptance Length (`decode_eval`)
 
 Training loss and simulated accept length are proxies. The acceptance length that
-matters is the one an inference engine produces from the draft plus the target.
+matters is the one an inference engine produces from the draft and the target.
 `decode_eval` snapshots the draft every `every_steps` optimizer steps, serves the
 snapshot, benchmarks it, and reports the engine's real `accept_length` back into
 the training log and W&B.
@@ -375,7 +377,7 @@ decode_eval:
 A cycle whose predecessor is still running is skipped rather than queued, so a
 cadence faster than one eval takes will simply measure less often.
 
-### On-policy regeneration (`regen`)
+### On-Policy Regeneration (`regen`)
 
 The draft is trained against target answers, and those answers age as the draft
 changes what it is asked to draft. `regen` periodically regenerates a slice of the
@@ -391,11 +393,11 @@ regen:
   input_data: /path/to/prompts.jsonl
 ```
 
-## Serve and benchmark a trained draft
+## Serve and Benchmark a Trained Draft
 
 ### SGLang
 
-After training, serve `target + draft` through SGLang:
+After training, serve the target and draft through SGLang:
 
 ```bash
 python -m nemo_automodel.components.speculative.serve_sglang --target meta-llama/Llama-3.1-8B-Instruct --draft /path/to/run/epoch_0_step_1000/model --algorithm EAGLE3 --num-steps 3 --num-draft-tokens 4
@@ -403,7 +405,7 @@ python -m nemo_automodel.components.speculative.serve_sglang --target meta-llama
 
 `serve_sglang.py` resolves the consolidated `model/` directory, rewrites the
 draft `architectures` to SGLang's canonical name, and regenerates SGLang's
-speculative token map from `eagle_meta.pt` when needed. SGLang is not bundled; the
+speculative token map from `eagle_meta.pt` when needed. SGLang is not bundled. The
 tool exits with an install hint if it is missing.
 
 Measure acceptance length and speedup against the running server:
@@ -413,13 +415,13 @@ python -m nemo_automodel.components.speculative.bench_sglang --server http://loc
 ```
 
 It reports `accept_length` (mean tokens per verify step), `acceptance_rate`,
-output throughput, and a `speedup` ratio versus an optional non-speculative
+output throughput, and a `speedup` ratio compared to an optional non-speculative
 baseline server. Point it at a freshly started server, since SGLang reports a
 server-cumulative average.
 
 ### vLLM
 
-`serve_vllm.py` is the vLLM companion; it serves EAGLE-3, P-EAGLE (vLLM's
+`serve_vllm.py` is the vLLM companion. It serves EAGLE-3, P-EAGLE (vLLM's
 parallel-drafting runtime, vLLM >= 0.16), and the DFlash family (vLLM's `dflash`
 method, vLLM >= 0.20):
 
@@ -432,8 +434,8 @@ DFlash-family draft, else `eagle3`), the draft `architectures` are rewritten to
 vLLM's registered names, and `--num-speculative-tokens` defaults to `num_depths`
 (P-EAGLE) or `block_size - 1` (DFlash). Pass `--print-only` to inspect the
 resolved `vllm serve` command without launching. DFlash notes: vLLM reserves
-`1 + K` query tokens per sequence, so a large block size may need a smaller
-`--max-num-seqs` (forward it via the trailing extra args, e.g.
+`1 + K` query tokens per sequence, so a large block size might need a smaller
+`--max-num-seqs` (forward it through the trailing extra args, for example,
 `-- --max-num-seqs 32`); a JetSpec draft carries `dflash_config.causal=true` so
 vLLM matches its causal in-block attention (pass `--dflash-causal` for
 checkpoints trained before the recipe stamped it); Domino drafts are rejected
@@ -448,24 +450,20 @@ cover exactly the benchmark's own requests:
 python -m nemo_automodel.components.speculative.bench_vllm --server http://localhost:8000 --model Qwen/Qwen3-8B --input-data <prompts-dataset> --baseline-server http://localhost:8001
 ```
 
-### Multi-dataset sweep
+### Multi-Dataset Sweep
 
-`bench_sglang.py`/`bench_vllm.py` measure one dataset per invocation, but the
-same draft's acceptance rate can vary sharply by task -- conversational data
-tends to accept far more tokens than math or code, whose token distributions
-diverge from the training mix. `bench_sweep.py` drives either engine through
-several datasets in one pass and reports a per-dataset table plus a
-completed-weighted aggregate, instead of invoking the single-dataset scripts
-once per dataset and collating the numbers by hand:
+`bench_sglang.py` and `bench_vllm.py` measure one dataset per invocation, but the same draft's acceptance rate can vary sharply by task. A draft tends to accept more tokens on conversational data than on math or code data because their token distributions differ from the training mix.
+
+`bench_sweep.py` drives either engine through several datasets in one pass. It reports a per-dataset table and a completed-weighted aggregate, eliminating the need to run each single-dataset script and collate the results manually:
 
 ```bash
 python -m nemo_automodel.components.speculative.bench_sweep --engine sglang --server http://localhost:30000 --model meta-llama/Llama-3.1-8B-Instruct
 ```
 
 The default suite is the four benchmarks the EAGLE / EAGLE-2 papers report
-acceptance/speedup on -- MT-Bench (first turn), HumanEval (code), GSM8K
+acceptance and speedup on: MT-Bench (first turn), HumanEval (code), GSM8K
 (math), and Alpaca (single-turn instruction-following). None of these ship a
-chat-messages column, so each is read via `--prompt-column` (a raw text field
+chat-messages column, so each is read through `--prompt-column` (a raw text field
 wrapped into a fresh single-turn user message) rather than
 `--messages-column`; both flags are also available on `bench_sglang.py` /
 `bench_vllm.py` directly for a single custom dataset. Pass `--engine vllm` to
@@ -485,7 +483,7 @@ Restart the server between datasets for independent numbers, or use
 `--engine vllm`, which diffs its Prometheus counters per dataset and has no
 such caveat.
 
-## Inference-engine compatibility
+## Inference-Engine Compatibility
 
 | Draft | SGLang | vLLM |
 |---|---|---|
@@ -495,17 +493,17 @@ such caveat.
 | Domino | no | no (the GRU correction head has no engine runtime) |
 | DSpark | no | not yet (runtime in development upstream, unreleased) |
 
-`serve_sglang.py` rejects P-EAGLE drafts with an actionable error; serve those on
+`serve_sglang.py` rejects P-EAGLE drafts with an actionable error. Serve those on
 vLLM.
 
-## Config reference (EAGLE-style schema)
+## Config Reference (EAGLE-Style Schema)
 
 EAGLE-1/2/3/3.1, P-EAGLE, and the LLM DFlash recipe share one schema. The DFlash
 **DLLM SFT** configs under `../dllm_sft/` use the standard AutoModel SFT schema
 (`step_scheduler` / `model._target_` / `dataset._target_` / `dllm` / `dflash`
 blocks) instead.
 
-### Top-level sections
+### Top-Level Sections
 
 | Section | Purpose |
 |---|---|
@@ -515,12 +513,12 @@ blocks) instead.
 | `distributed` | Optional; only for MoE / large targets. `strategy: fsdp2`, `tp_size`, `pp_size`, `cp_size`, `ep_size`, `activation_checkpointing`, `sequence_parallel`. Absent means DDP. |
 | `optimizer` | `lr`, `betas`, `weight_decay`, optional `warmup_ratio` (0.05), `min_lr_ratio` (0.1). |
 | `checkpoint` | `enabled`, `checkpoint_dir`, `model_save_format: safetensors`, `save_consolidated`, optional `restore_from` (`LATEST` / subdir / path). |
-| `fp8` | Optional; torchao FP8 draft training, same surface as the SFT recipes. See "FP8 draft training". |
+| `fp8` | Optional; torchao FP8 draft training, same surface as the SFT recipes. See [FP8 Draft Training](#fp8-draft-training). |
 | `compile` | Optional; in-place torch.compile of the draft (`CompileConfig`). Strongly recommended with `fp8`. |
-| `peft` | Optional, EAGLE-3 only; LoRA draft adaptation (`PeftConfig`). See "LoRA draft adaptation". |
+| `peft` | Optional, EAGLE-3 only; LoRA draft adaptation (`PeftConfig`). See [LoRA Draft Adaptation (EAGLE-3 Only)](#lora-draft-adaptation-eagle-3-only). |
 | `wandb` | Optional; `project`, `entity`, `name`. |
 
-### DFlash-family validation metrics
+### DFlash-Family Validation Metrics
 
 When `recipe_args.val_data_path` is set, DFlash, Domino, and JetSpec report
 globally reduced `val_loss`, token-weighted `val_accuracy`, and block-weighted
@@ -534,7 +532,7 @@ Adding a top-level `wandb:` block uploads these values as `val/loss`,
 Training logs include `train/loss`, `train/accuracy`, `train/accept_len`, and
 the method-specific Domino diagnostics.
 
-### `recipe_args` common to all methods
+### `recipe_args` Common to All Methods
 
 `target_model_name_or_path`, `train_data_path`, `val_data_path`, `train_split`,
 `val_split`, `output_dir`, `seq_length`, `micro_batch_size`,
@@ -542,7 +540,7 @@ the method-specific Domino diagnostics.
 `trust_remote_code`, `shuffle_seed`, `log_every_steps`, `max_grad_norm`. Optional
 checkpoint cadence: `ckpt_every_steps`, `save_checkpoint_every_epoch`.
 
-### Method-specific `recipe_args`
+### Method-Specific `recipe_args`
 
 | Key | Methods | Notes |
 |---|---|---|
@@ -555,17 +553,17 @@ checkpoint cadence: `ckpt_every_steps`, `save_checkpoint_every_epoch`.
 | `draft_attn_implementation` | EAGLE-3 | `eager` (default) or `flash_attention_2`. |
 | `fc_norm`, `norm_output` | EAGLE-3.1 | Both default false; either alone is a valid intermediate config. |
 | `draft_weights_path` | EAGLE-3 | Warm-start the draft from a consolidated safetensors export (file or directory); required for meaningful LoRA adaptation. |
-| `target_model_backend`, `remote_urls`, `target_prefetch_depth`, `remote_timeout`, `remote_max_retries` | EAGLE-3 remote | See Target backends. |
+| `target_model_backend`, `remote_urls`, `target_prefetch_depth`, `remote_timeout`, `remote_max_retries` | EAGLE-3 remote | See [Target Backends](#target-backends). |
 | `cached_target_path` | EAGLE-3 / DSpark offline | Path to a cache produced by `precompute_eagle3.py`, `precompute_dspark.py`, or (large sharded targets) `precompute_dspark_dist.py`. |
 | `parallel_drafting`, `num_depths`, `num_draft_layers`, `down_sample_ratio`, `down_sample_ratio_min`, `mask_token_id`, `sequence_partitions` | P-EAGLE | `mask_token_id` is required (no default). `sequence_partitions > 1` splits each sequence by dependency lineage to bound long-context memory. |
 | `block_size`, `num_anchors`, `loss_decay_gamma`, `mask_token_id`, `target_layer_ids`, `attention_backend` | DFlash (LLM recipe) | Block drafting knobs. |
 | `emb_dim`, `gru_hidden_dim`, `pure_draft_prefix_len`, `shift_label` | Domino | Correction-head knobs on top of the DFlash set. |
 | `kd_temperature`, `kd_chunk_size` | JetSpec | Forward-KL distillation knobs on top of the DFlash set. |
-| `markov_rank`, `markov_head_type`, `confidence_head_alpha`, `confidence_head_with_markov`, `ce_loss_alpha` | DSpark | Markov / confidence-head knobs on top of the block-drafting set (`block_size`, `num_anchors`, `mask_token_id`, `target_layer_ids`, ...). |
+| `markov_rank`, `markov_head_type`, `confidence_head_alpha`, `confidence_head_with_markov`, `ce_loss_alpha` | DSpark | Markov / confidence-head knobs on top of the block-drafting set (`block_size`, `num_anchors`, `mask_token_id`, `target_layer_ids`, and so on). |
 
-## Directory layout
+## Directory Layout
 
-Configs in this folder:
+The following tree shows the configs in this folder:
 
 ```
 examples/speculative/
@@ -577,7 +575,7 @@ examples/speculative/
 examples/dllm_sft/            # DFlash DLLM SFT configs (standard SFT schema)
 ```
 
-Implementation:
+The following tree shows the implementation layout:
 
 ```
 nemo_automodel/components/speculative/
@@ -596,8 +594,8 @@ nemo_automodel/components/speculative/
   target_cp.py             # target-side context-parallel input prep
   precompute_eagle3.py     # offline target-output cache
   serve_target.py          # remote target server (HTTP + NCCL)
-  serve_sglang.py          # serve a trained draft via SGLang
-  serve_vllm.py            # serve a trained draft via vLLM (EAGLE-3 / P-EAGLE / DFlash)
+  serve_sglang.py          # serve a trained draft through SGLang
+  serve_vllm.py            # serve a trained draft through vLLM (EAGLE-3 / P-EAGLE / DFlash)
   bench_common.py          # shared chat-completions workload machinery
   bench_sglang.py          # acceptance-length / speedup benchmark (SGLang)
   bench_vllm.py            # acceptance-length / speedup benchmark (vLLM)


### PR DESCRIPTION
## What

`examples/speculative/README.md` has drifted from what `main` ships. Documentation only; no code changes.

The gaps were found by diffing the README against the registries and the component tree, so each item below is a concrete mismatch rather than a stylistic preference.

### Gemma4 is missing from the EAGLE-3 target list

This is the one that actively misleads. `EAGLE3_DRAFT_REGISTRY` maps `Gemma4ForConditionalGeneration`, and there are four shipped configs (`gemma4_e2b`, `e4b`, `31b`, `26b_a4b`), but the supported-target list stops at Llama, Phi-3, Qwen3, and Qwen3-MoE. A reader concludes EAGLE cannot target Gemma4.

Added, with the limitation stated rather than left to be discovered: the target is multimodal, but the draft is built from `config.get_text_config()` and consumes post-block hidden states, so it trains on the text backbone only and images do not participate in drafting.

### MSD is undocumented

`eagle/msd.py`, `msd_target.py`, `msd_curriculum.py`, and `msd_decode.py` are in `main` and the README does not mention MSD at all.

Putting it in the methods table would imply it is launchable, which it is not: nothing wires it to a recipe or config. Leaving it out entirely leaves four modules unexplained. It is described below the table with an explicit "not yet runnable" note and a pointer to what is missing.

### `decode_eval` and `regen` were invisible

Both are user-facing config blocks with real capability behind them, and neither appeared anywhere in the README, so the features could only be found by reading source.

Documented with their required keys, including why `cuda_visible_devices` has no default: both runners launch a detached engine and must be given GPUs the training run is not using.

### Context parallelism had one table cell

`cp_size` appeared once, in the `distributed` row of the config reference. The draft-side ring attention, its zig-zag layout, and `target_cp.py` were undocumented.

Added a section with the constraint matrix. This is worth stating because every combination listed **raises at setup**, and a reader who hits one otherwise has no way to know the failure was expected:

| Constraint | Applies to |
|---|---|
| No sequence packing | EAGLE-1/2, EAGLE-3, DFlash, DSpark |
| Colocated target backend only | EAGLE-3 |
| No tensor parallelism | DFlash |
| Dense Qwen3-style draft only | DSpark |
| Draft attention must be the ring path (the DeepSeek MLA draft raises) | EAGLE-3 |

### Implementation tree gaps

Added `draft_gemma`, `msd*`, `ring_attention` / `zigzag_ring_attention`, the engine-backed target modules, `regen_loop.py`, `decode_eval.py`, and `target_cp.py`. The `core(.py/_v12)`-style glob entries already cover the `_v12` and `peagle_*` files and were left alone.

## Verification

Every factual claim added here was checked against the source rather than written from memory:

- target lists diffed against `eagle/registry.py`
- config keys (`every_steps`, `cuda_visible_devices`, `target_model`, `input_data`, `num_speculative_tokens`) confirmed present in the resolvers, and `num_speculative_tokens` confirmed to belong to `decode_eval` only
- each CP constraint read off the gate that enforces it in the corresponding recipe
- the epoch-boundary swap and the skip-when-still-running behavior read off `RegenConfig` and `maybe_launch`
- the four Gemma4 config filenames confirmed to exist

One claim was written and then removed: an earlier draft said both cadence runners align to the restored `global_step` on resume. That is true of `RegenRunner` and not of `DecodeEvalRunner` on this base, so documenting it would have introduced exactly the kind of inaccuracy this PR removes.

## Scope

ViSpec is deliberately not documented here. It is still an open PR, and describing an unmerged feature in `main`'s README would leave readers looking for something that is not there. It can be added with its own change once merged.
