### PR TITLE
fix(checkpoint): harden PP safetensors consolidation

### DIFF
--- a/nemo_automodel/components/checkpoint/_backports/consolidate_hf_safetensors.py
+++ b/nemo_automodel/components/checkpoint/_backports/consolidate_hf_safetensors.py
@@ -971,11 +971,17 @@ def consolidate_safetensors_files_on_every_rank(
         cast_dtype: Optional dtype used to cast floating-point tensors during consolidation.
         fqn_to_dtype_mapping: Optional mapping from tensor FQN to target safetensors dtype string. This can combine
             original HF dtype metadata with model-owned export overrides.
+
+    Raises:
+        RuntimeError: If consolidation fails on any rank of a multi-rank
+            distributed run. The error identifies the originating rank,
+            operation, and exception.
     """
 
     start_time = time.time()
     # Derive rank and world_size from process_group or default distributed environment
-    if dist.is_available() and dist.is_initialized():
+    distributed = dist.is_available() and dist.is_initialized()
+    if distributed:
         rank = dist.get_rank(group=process_group)
         world_size = dist.get_world_size(group=process_group)
     else:
@@ -993,56 +999,90 @@ def consolidate_safetensors_files_on_every_rank(
                 cast_dtype,
             )
 
-    # Find all unique indices in the mapping
-    unique_indices = set(fqn_to_index_mapping.values())
+    indices_for_this_rank: list[int] = []
+    operation = "preparing assigned output shards"
+    local_exception: Exception | None = None
+    local_failure: str | None = None
+    try:
+        # Find all unique indices in the mapping
+        unique_indices = set(fqn_to_index_mapping.values())
 
-    # Distribute indices across ranks
-    indices_for_this_rank = []
-    for idx in unique_indices:
-        # Output shard indices are 1-based. Assign shard 1 to rank 0.
-        if (idx - 1) % world_size == rank:
-            indices_for_this_rank.append(idx)
+        # Distribute indices across ranks
+        for idx in unique_indices:
+            # Output shard indices are 1-based. Assign shard 1 to rank 0.
+            if (idx - 1) % world_size == rank:
+                indices_for_this_rank.append(idx)
 
-    # Filter the fqn_to_index_mapping to only include tensors for this rank
-    filtered_mapping = {fqn: idx for fqn, idx in fqn_to_index_mapping.items() if idx in indices_for_this_rank}
-    logger.debug(
-        "Rank %d/%d: assigned %d of %d output file(s) (%d tensor(s)).",
-        rank,
-        world_size,
-        len(indices_for_this_rank),
-        len(unique_indices),
-        len(filtered_mapping),
-    )
-
-    if filtered_mapping:
-        # Convert index mapping to filename mapping
-        max_index = max(unique_indices)
-        filtered_filename_mapping = {}
-        for fqn, idx in filtered_mapping.items():
-            filename = _gen_file_name(idx, max_index)
-            filtered_filename_mapping[fqn] = filename
-
-        # Call the existing consolidation function with the filtered mapping
-        _consolidate_safetensors_files(
-            input_dir=input_dir,
-            output_dir=output_dir,
-            fqn_to_file_mapping=filtered_filename_mapping,
-            num_threads=num_threads,
-            use_staging=use_staging,
-            staging_dir=staging_dir,
-            cast_dtype=cast_dtype,
-            fqn_to_dtype_mapping=fqn_to_dtype_mapping,
+        # Filter the fqn_to_index_mapping to only include tensors for this rank
+        filtered_mapping = {fqn: idx for fqn, idx in fqn_to_index_mapping.items() if idx in indices_for_this_rank}
+        logger.debug(
+            "Rank %d/%d: assigned %d of %d output file(s) (%d tensor(s)).",
+            rank,
+            world_size,
+            len(indices_for_this_rank),
+            len(unique_indices),
+            len(filtered_mapping),
         )
 
-    # Write overall model.index.safetensors.json file with weight map (rank 0 only)
-    if rank == 0:
-        _write_overall_metadata_file_from_shards(
-            input_dir,
-            output_dir,
-            fqn_to_index_mapping,
-            cast_dtype,
-            fqn_to_dtype_mapping,
-        )
+        if filtered_mapping:
+            operation = "consolidating assigned output shards"
+            # Convert index mapping to filename mapping
+            max_index = max(unique_indices)
+            filtered_filename_mapping = {}
+            for fqn, idx in filtered_mapping.items():
+                filename = _gen_file_name(idx, max_index)
+                filtered_filename_mapping[fqn] = filename
+
+            # Call the existing consolidation function with the filtered mapping
+            _consolidate_safetensors_files(
+                input_dir=input_dir,
+                output_dir=output_dir,
+                fqn_to_file_mapping=filtered_filename_mapping,
+                num_threads=num_threads,
+                use_staging=use_staging,
+                staging_dir=staging_dir,
+                cast_dtype=cast_dtype,
+                fqn_to_dtype_mapping=fqn_to_dtype_mapping,
+            )
+
+        # Write overall model.index.safetensors.json file with weight map (rank 0 only)
+        if rank == 0:
+            operation = "writing the consolidated safetensors index"
+            _write_overall_metadata_file_from_shards(
+                input_dir,
+                output_dir,
+                fqn_to_index_mapping,
+                cast_dtype,
+                fqn_to_dtype_mapping,
+            )
+    except Exception as exc:
+        local_exception = exc
+        local_failure = f"rank {rank} while {operation}: {type(exc).__name__}: {exc}"
+
+    if distributed and world_size > 1:
+        failures: list[str | None] = [None] * world_size
+        try:
+            dist.all_gather_object(failures, local_failure, group=process_group)
+        except Exception as exc:
+            if local_exception is not None:
+                raise RuntimeError(
+                    f"Safetensors consolidation failed on {local_failure}, and rank {rank} could not synchronize "
+                    f"the failure across ranks: {type(exc).__name__}: {exc}"
+                ) from local_exception
+            raise RuntimeError(
+                "Failed to synchronize safetensors consolidation status across ranks. A peer may have exited before "
+                "reporting its original exception; inspect the first failing rank's traceback. "
+                f"Synchronization error: {type(exc).__name__}: {exc}"
+            ) from exc
+
+        reported_failures = [failure for failure in failures if failure is not None]
+        if reported_failures:
+            message = "Safetensors consolidation failed before final synchronization: " + " | ".join(reported_failures)
+            if local_exception is not None:
+                raise RuntimeError(message) from local_exception
+            raise RuntimeError(message)
+    elif local_exception is not None:
+        raise local_exception
 
     logger.debug(
         "Rank %d: Done consolidating. Processed %d unique indices in %.2f secs.",
@@ -1050,11 +1090,5 @@ def consolidate_safetensors_files_on_every_rank(
         len(indices_for_this_rank),
         time.time() - start_time,
     )
-
-    # Wait for all ranks to complete
-    if dist.is_available() and dist.is_initialized():
-        logger.debug("Rank %d: Waiting for all ranks to complete...", rank)
-        dist.barrier(group=process_group)
-        logger.debug("Rank %d: All ranks have completed.", rank)
-        if rank == 0:
-            logger.debug("Total time taken: %.2f secs.", time.time() - start_time)
+    if distributed and rank == 0:
+        logger.debug("Total time taken: %.2f secs.", time.time() - start_time)

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -1400,6 +1400,7 @@ fi
         if not _should_write_hf_metadata(self.config):
             return None
         model = model_state.model[0]
+        excluded_keys: set[str] = set()
         # we first need to find the FQN -> .safetensors mapping
         reference_path = _get_hf_safetensors_reference_path(
             self.config.model_cache_dir,
@@ -1435,6 +1436,7 @@ fi
                 # `uses_tied_lm_head=True` but must still persist their own lm_head.
                 if getattr(model_state, "has_local_tied_lm_head", False):
                     keys_to_remove.append(model_state.lm_head_param_name)
+                excluded_keys.update(keys_to_remove)
                 for key in keys_to_remove:
                     fqn_to_file_index_mapping.pop(key, None)
         else:
@@ -1457,14 +1459,19 @@ fi
                     num_shards,
                 )
 
-        # Add any missing keys from the model_state_dict
-        # These will go to the same file as the last file (or file 1 for single-file models)
+        # Add any missing keys from the global pre-shard HF state dict.
+        # These will go to the same file as the last file (or file 1 for single-file models).
+        # Under PP, each rank's state_dict contains only its local stage. Using it here
+        # produces rank-local mappings for keys that are absent from the source index,
+        # such as model-owned tensors injected while adapting the HF checkpoint.
         # Use default of 1 when mapping is empty (e.g., encoder models with different key prefixes)
         default_index = max(fqn_to_file_index_mapping.values()) if fqn_to_file_index_mapping else 1
 
         # add any additional keys that are not in the base checkpoint
-        for fqn in list(state_dict.keys()):
-            fqn_to_file_index_mapping[fqn] = fqn_to_file_index_mapping.get(fqn, default_index)
+        additional_keys = pre_shard_hf_state_dict_keys or list(state_dict.keys())
+        for fqn in additional_keys:
+            if fqn not in excluded_keys:
+                fqn_to_file_index_mapping[fqn] = fqn_to_file_index_mapping.get(fqn, default_index)
         return fqn_to_file_index_mapping
 
     def _maybe_build_original_dtype_mapping(

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -1459,16 +1459,15 @@ fi
                     num_shards,
                 )
 
-        # Add any missing keys from the global pre-shard HF state dict.
+        # Add any missing keys from the global pre-shard HF state dict and the current state dict.
         # These will go to the same file as the last file (or file 1 for single-file models).
-        # Under PP, each rank's state_dict contains only its local stage. Using it here
-        # produces rank-local mappings for keys that are absent from the source index,
-        # such as model-owned tensors injected while adapting the HF checkpoint.
+        # The global keys keep mappings complete under PP, while the current keys preserve
+        # parameters registered after parallelization, such as test- or application-owned weights.
         # Use default of 1 when mapping is empty (e.g., encoder models with different key prefixes)
         default_index = max(fqn_to_file_index_mapping.values()) if fqn_to_file_index_mapping else 1
 
         # add any additional keys that are not in the base checkpoint
-        additional_keys = pre_shard_hf_state_dict_keys or list(state_dict.keys())
+        additional_keys = dict.fromkeys([*(pre_shard_hf_state_dict_keys or ()), *state_dict])
         for fqn in additional_keys:
             if fqn not in excluded_keys:
                 fqn_to_file_index_mapping[fqn] = fqn_to_file_index_mapping.get(fqn, default_index)

--- a/tests/unit_tests/checkpoint/test_checkpointing.py
+++ b/tests/unit_tests/checkpoint/test_checkpointing.py
@@ -2538,8 +2538,8 @@ class TestSkipInitWeightsOnLoadGate:
         model.initialize_weights.assert_called_once()
 
 
-class TestConsolidatedIndexUnderPPWithoutSourceIndex:
-    """_maybe_build_consolidated_index else-branch (NVIDIA-NeMo/Automodel#1512)."""
+class TestConsolidatedIndexUnderPP:
+    """Global consolidated-index construction under pipeline parallelism."""
 
     def _make_checkpointer(self, tmp_path):
         # empty_cache is created but contains no HF snapshot directory, so
@@ -2639,6 +2639,72 @@ class TestConsolidatedIndexUnderPPWithoutSourceIndex:
                 if idx in indices_for_this_rank:
                     consolidated_keys.add(fqn)
         assert consolidated_keys == set(global_pre_shard_keys)
+
+    @pytest.mark.run_only_on("CPU")
+    def test_source_index_adds_adapter_created_keys_from_global_pre_shard_state(self, tmp_path):
+        """Every PP rank maps adapter-created keys that are absent from the source index."""
+        checkpointer = self._make_checkpointer(tmp_path)
+        source_mapping = {
+            "language_model.model.embed_tokens.weight": 1,
+            "language_model.model.layers.15.mlp.gate.weight": 2,
+        }
+        injected_bias = "language_model.model.layers.15.mlp.gate.e_score_correction_bias"
+        global_pre_shard_keys = [*source_mapping, injected_bias]
+        per_rank_state_dicts = [
+            {"language_model.model.embed_tokens.weight": torch.empty(0)},
+            {
+                "language_model.model.layers.15.mlp.gate.weight": torch.empty(0),
+                injected_bias: torch.empty(0),
+            },
+        ]
+        model_state = self._fake_model_state(global_pre_shard_keys)
+
+        with (
+            patch(
+                "nemo_automodel.components.checkpoint.checkpointing._get_hf_safetensors_reference_path",
+                return_value="/fake/reference",
+            ),
+            patch(
+                "nemo_automodel.components.checkpoint.checkpointing.get_fqn_to_file_index_mapping",
+                side_effect=lambda *_args, **_kwargs: dict(source_mapping),
+            ),
+        ):
+            per_rank_mappings = [
+                checkpointer._maybe_build_consolidated_index(model_state, state_dict)
+                for state_dict in per_rank_state_dicts
+            ]
+
+        expected_mapping = {**source_mapping, injected_bias: 2}
+        assert per_rank_mappings == [expected_mapping, expected_mapping]
+
+    @pytest.mark.run_only_on("CPU")
+    def test_global_pre_shard_state_does_not_readd_excluded_tied_lm_head(self, tmp_path):
+        """A global key list must not undo the local tied-weight alias exclusion."""
+        checkpointer = self._make_checkpointer(tmp_path)
+        source_mapping = {
+            "model.embed_tokens.weight": 1,
+            "lm_head.weight": 1,
+        }
+        model_state = self._fake_model_state(list(source_mapping))
+        model_state.has_local_tied_lm_head = True
+        model_state.lm_head_param_name = "lm_head.weight"
+
+        with (
+            patch(
+                "nemo_automodel.components.checkpoint.checkpointing._get_hf_safetensors_reference_path",
+                return_value="/fake/reference",
+            ),
+            patch(
+                "nemo_automodel.components.checkpoint.checkpointing.get_fqn_to_file_index_mapping",
+                return_value=dict(source_mapping),
+            ),
+        ):
+            mapping = checkpointer._maybe_build_consolidated_index(
+                model_state,
+                {"model.embed_tokens.weight": torch.empty(0)},
+            )
+
+        assert mapping == {"model.embed_tokens.weight": 1}
 
 
 # Tests for cloud storage path support (MSC integration)

--- a/tests/unit_tests/checkpoint/test_checkpointing.py
+++ b/tests/unit_tests/checkpoint/test_checkpointing.py
@@ -2678,6 +2678,31 @@ class TestConsolidatedIndexUnderPP:
         assert per_rank_mappings == [expected_mapping, expected_mapping]
 
     @pytest.mark.run_only_on("CPU")
+    def test_source_index_preserves_key_registered_after_parallelization(self, tmp_path):
+        """The live state dict supplements global keys for parameters registered after setup."""
+        checkpointer = self._make_checkpointer(tmp_path)
+        source_mapping = {"model.embed_tokens.weight": 1}
+        model_state = self._fake_model_state(list(source_mapping))
+        state_dict = {
+            "model.embed_tokens.weight": torch.empty(0),
+            "model.scalar_weight": torch.tensor(3.14159),
+        }
+
+        with (
+            patch(
+                "nemo_automodel.components.checkpoint.checkpointing._get_hf_safetensors_reference_path",
+                return_value="/fake/reference",
+            ),
+            patch(
+                "nemo_automodel.components.checkpoint.checkpointing.get_fqn_to_file_index_mapping",
+                return_value=dict(source_mapping),
+            ),
+        ):
+            mapping = checkpointer._maybe_build_consolidated_index(model_state, state_dict)
+
+        assert mapping == {**source_mapping, "model.scalar_weight": 1}
+
+    @pytest.mark.run_only_on("CPU")
     def test_global_pre_shard_state_does_not_readd_excluded_tied_lm_head(self, tmp_path):
         """A global key list must not undo the local tied-weight alias exclusion."""
         checkpointer = self._make_checkpointer(tmp_path)

--- a/tests/unit_tests/checkpoint/test_consolidate_safetensors.py
+++ b/tests/unit_tests/checkpoint/test_consolidate_safetensors.py
@@ -16,6 +16,8 @@ import builtins
 import json
 import logging
 import os
+from datetime import timedelta
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -467,7 +469,7 @@ def test_resolve_dtype_cast_accepts_aliases_and_none():
 
 
 @pytest.mark.run_only_on("CPU")
-def test_every_rank_consolidation_uses_supplied_group_for_barrier():
+def test_every_rank_consolidation_uses_supplied_group_for_failure_sync():
     process_group = MagicMock()
 
     with (
@@ -487,7 +489,9 @@ def test_every_rank_consolidation_uses_supplied_group_for_barrier():
             "nemo_automodel.components.checkpoint._backports.consolidate_hf_safetensors.dist.get_world_size",
             return_value=2,
         ) as get_world_size,
-        patch("nemo_automodel.components.checkpoint._backports.consolidate_hf_safetensors.dist.barrier") as barrier,
+        patch(
+            "nemo_automodel.components.checkpoint._backports.consolidate_hf_safetensors.dist.all_gather_object"
+        ) as all_gather_object,
         patch(
             "nemo_automodel.components.checkpoint._backports.consolidate_hf_safetensors._consolidate_safetensors_files"
         ),
@@ -505,7 +509,116 @@ def test_every_rank_consolidation_uses_supplied_group_for_barrier():
 
     get_rank.assert_called_once_with(group=process_group)
     get_world_size.assert_called_once_with(group=process_group)
-    barrier.assert_called_once_with(group=process_group)
+    all_gather_object.assert_called_once()
+    failures, local_failure = all_gather_object.call_args.args
+    assert failures == [None, None]
+    assert local_failure is None
+    assert all_gather_object.call_args.kwargs == {"group": process_group}
+
+
+@pytest.mark.run_only_on("CPU")
+def test_every_rank_consolidation_explains_peer_failure_during_sync():
+    process_group = MagicMock()
+
+    with (
+        patch(
+            "nemo_automodel.components.checkpoint._backports.consolidate_hf_safetensors.dist.is_available",
+            return_value=True,
+        ),
+        patch(
+            "nemo_automodel.components.checkpoint._backports.consolidate_hf_safetensors.dist.is_initialized",
+            return_value=True,
+        ),
+        patch(
+            "nemo_automodel.components.checkpoint._backports.consolidate_hf_safetensors.dist.get_rank",
+            return_value=1,
+        ),
+        patch(
+            "nemo_automodel.components.checkpoint._backports.consolidate_hf_safetensors.dist.get_world_size",
+            return_value=2,
+        ),
+        patch(
+            "nemo_automodel.components.checkpoint._backports.consolidate_hf_safetensors.dist.all_gather_object",
+            side_effect=RuntimeError("Connection closed by peer"),
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="A peer may have exited before reporting its original exception") as exc:
+            consolidate_safetensors_files_on_every_rank(
+                input_dir="input",
+                output_dir="output",
+                fqn_to_index_mapping={"weight": 1},
+                process_group=process_group,
+            )
+
+    assert "Synchronization error: RuntimeError: Connection closed by peer" in str(exc.value)
+
+
+def _run_two_rank_consolidation_failure_worker(
+    rank: int,
+    world_size: int,
+    init_file: str,
+    input_dir: str,
+    output_dir: str,
+    error_dir: str,
+) -> None:
+    """Verify that both Gloo ranks receive the originating consolidation error."""
+    os.environ["GLOO_SOCKET_IFNAME"] = "lo"
+    torch.distributed.init_process_group(
+        backend="gloo",
+        init_method=f"file://{init_file}",
+        rank=rank,
+        world_size=world_size,
+        timeout=timedelta(seconds=30),
+    )
+    try:
+        try:
+            consolidate_safetensors_files_on_every_rank(
+                input_dir=input_dir,
+                output_dir=output_dir,
+                fqn_to_index_mapping={"weight": 1},
+            )
+        except RuntimeError as exc:
+            Path(error_dir, f"rank_{rank}.txt").write_text(str(exc))
+        else:
+            raise AssertionError("Expected distributed consolidation to fail")
+    finally:
+        torch.distributed.destroy_process_group()
+
+
+@pytest.mark.run_only_on("CPU")
+def test_every_rank_consolidation_surfaces_originating_rank_error(tmp_path):
+    """A rank-0 index failure is reported identically instead of closing peers."""
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+    output_dir.mkdir()
+    tensors = {
+        "weight": torch.ones(2),
+        "adapter.created.bias": torch.zeros(2),
+    }
+    dcp_metadata = {fqn: {"saved_offsets": [0]} for fqn in tensors}
+    save_file(
+        tensors,
+        input_dir / "model-00001-of-00001.safetensors",
+        metadata={CUSTOM_METADATA_KEY: json.dumps(dcp_metadata)},
+    )
+
+    torch.multiprocessing.spawn(
+        _run_two_rank_consolidation_failure_worker,
+        args=(
+            2,
+            str(tmp_path / "gloo_init"),
+            str(input_dir),
+            str(output_dir),
+            str(tmp_path),
+        ),
+        nprocs=2,
+        join=True,
+    )
+
+    errors = [(tmp_path / f"rank_{rank}.txt").read_text() for rank in range(2)]
+    assert errors[0] == errors[1]
+    assert "rank 0 while writing the consolidated safetensors index: KeyError: 'adapter.created.bias'" in errors[0]
 
 
 # =============================================================================


### PR DESCRIPTION
# What does this PR do ?

Makes consolidated Hugging Face safetensors export use a pipeline-parallel-consistent global key index and propagates the originating consolidation exception to every rank.

The failure was exposed by Mistral4 because its state-dict adapter injects `e_score_correction_bias`, which is absent from the source Hugging Face index. The consolidated mapping was completed from each PP rank's local stage, so rank 0 could miss a key owned by another stage and fail while writing the combined index. Other ranks then surfaced only `Connection closed by peer` at the final barrier.

# Changelog

- Complete consolidated shard mappings from the global pre-shard Hugging Face key set while preserving tied `lm_head` exclusions.
- Replace the final barrier with an all-rank failure handoff that reports the originating rank, operation, exception type, and message.
- Add PP mapping regressions for adapter-created keys and tied weights.
- Add failure-message coverage, including a real two-process CPU/Gloo regression.

# Validation

## Local

- `pytest tests/unit_tests/checkpoint/test_consolidate_safetensors.py --cpu -q` — 21 passed
- `pytest tests/unit_tests/checkpoint/test_checkpointing.py --cpu -q` — 185 passed
- `pytest tests/unit_tests/models/mistral4/test_mistral4_state_dict_adapter.py --cpu -q` — 56 passed
- Ruff format/check and `git diff --check` — passed

## GitHub CI

All reported GitHub checks pass on commit `5db247deae3c4888970622267c9820d55e02b7e6`, including L0 CPU/GPU, both `L2_HF_DCP` lanes, the remaining L2/GB200 suites, lint, type checking, DCO, and Codecov.

## Exact AMINT-22 Mistral4 NeMo-CI reproduction

- [Scoped parent pipeline](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/59849147)
- [Exact `mistral4_medpix` job](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/375700099)
- Tested package: `nemo-automodel==0.5.0+5db247dea`
- Topology: 4 EOS nodes, 32 H100s, `pp_size=4`, `ep_size=8`

The robustness phase crossed the original AMINT-22 failure boundary:

1. Completed its five training steps and began checkpoint save.
2. Began consolidating the approximately 112.6 GiB Mistral4 Hugging Face checkpoint without the original `e_score_correction_bias` `KeyError`.
3. Logged `Successfully exported consolidated HF safetensors`.
4. Continued into the AutoModel and Hugging Face reload phases using the exported consolidated checkpoint.

The exact job later failed in the independent Phase 6 resume-baseline check with CUDA OOM after the rank-0 Hugging Face reload retained allocator pressure. That occurs after successful consolidation and reload and is addressed separately by [#3233](https://github.com/NVIDIA-NeMo/Automodel/pull/3233), which adds generic Phase 4 model cleanup and expandable allocator segments.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added focused unit and real multi-process regression coverage.
- [x] Documentation is not required because there are no public API or configuration changes.
- [x] Commit includes a DCO signoff.

# Additional Information

- Related to [AM-716](https://linear.app/nvidia/issue/AM-716)
- [AMINT-22](https://linear.app/nvidia/issue/AMINT-22) is marked as a duplicate of AM-716.
