### PR TITLE
docs: fix remaining broken link sources

### DIFF
--- a/docs/model-coverage/vlm/index.mdx
+++ b/docs/model-coverage/vlm/index.mdx
@@ -45,8 +45,8 @@ NeMo AutoModel supports [AutoModelForImageTextToText](https://huggingface.co/doc
 | InternLM / Shanghai AI Lab | [InternVL](/model-coverage/vision-language-models/internvl) | `InternVLForConditionalGeneration` |
 | Meta | [Llama 4](/model-coverage/vision-language-models/llama-4) | `Llama4ForConditionalGeneration` |
 | HuggingFace | [SmolVLM](/model-coverage/vision-language-models/smolvlm) | `SmolVLMForConditionalGeneration` |
-| LLaVA | [LLaVA](/model-coverage/vision-language-models/llava) | `LlavaForConditionalGeneration`, `LlavaNextForConditionalGeneration`, `LlavaNextVideoForConditionalGeneration`, `LlavaOnevisionForConditionalGeneration` |
-| lmms-lab | [LLaVA-OneVision 1.5](/model-coverage/vision-language-models/llava-onevision) | `LlavaOneVisionForConditionalGeneration` |
+| LLaVA | [LLaVA](/model-coverage/vision-language-models/l-la-va) | `LlavaForConditionalGeneration`, `LlavaNextForConditionalGeneration`, `LlavaNextVideoForConditionalGeneration`, `LlavaOnevisionForConditionalGeneration` |
+| lmms-lab | [LLaVA-OneVision 1.5](/model-coverage/vision-language-models/l-la-va-one-vision) | `LlavaOneVisionForConditionalGeneration` |
 | Stepfun AI | [Step-3.7-Flash](/model-coverage/vision-language-models/step-3-7-flash) | 198B-A13B MoE VLM |
 | MiniMaxAI | [MiniMax-M3](/model-coverage/vision-language-models/minimax-m3) | 428B-A22B MoE VLM |
 

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -44,6 +44,7 @@ from safetensors.torch import load as safetensors_load
 from safetensors.torch import load_file, save_file
 from safetensors.torch import save as safetensors_save
 from torch import nn
+from torch.distributed.checkpoint.storage import StorageReader, StorageWriter
 from torch.distributed.device_mesh import DeviceMesh
 from torch.nn.parallel import DistributedDataParallel
 
@@ -203,9 +204,7 @@ def _load_safetensors(path: str) -> dict[str, torch.Tensor]:
     return load_file(path)
 
 
-def _maybe_msc_reader(
-    path: str, storage_reader: Optional[_HuggingFaceStorageReader]
-) -> Optional[_HuggingFaceStorageReader]:
+def _maybe_msc_reader(path: str, storage_reader: StorageReader | None) -> StorageReader | None:
     """Return an MSC filesystem reader for ``msc://`` paths, else the given reader."""
     if storage_reader is None and is_cloud_path(path):
         _ensure_msc_available()
@@ -213,9 +212,7 @@ def _maybe_msc_reader(
     return storage_reader
 
 
-def _maybe_msc_writer(
-    path: str, storage_writer: Optional[_HuggingFaceStorageWriter]
-) -> Optional[_HuggingFaceStorageWriter]:
+def _maybe_msc_writer(path: str, storage_writer: StorageWriter | None) -> StorageWriter | None:
     """Return an MSC filesystem writer for ``msc://`` paths, else the given writer."""
     if storage_writer is None and is_cloud_path(path):
         _ensure_msc_available()
@@ -266,7 +263,7 @@ def _summarize_state_dict_key_diff(
 
 def _get_checkpoint_metadata_keys(
     path: str,
-    storage_reader: Optional[_HuggingFaceStorageReader] = None,
+    storage_reader: StorageReader | None = None,
 ) -> set[str]:
     """Return checkpoint FQNs present in metadata."""
     reader = storage_reader if storage_reader is not None else FileSystemReader(path)
@@ -1218,7 +1215,7 @@ class Checkpointer:
         self,
         state_dict: dict[str, torch.Tensor],
         path: str,
-        storage_reader: Optional[_HuggingFaceStorageReader] = None,
+        storage_reader: StorageReader | None = None,
         is_init_step: bool = False,
     ) -> dict[str, torch.Tensor]:
         """
@@ -1246,7 +1243,7 @@ class Checkpointer:
         return state_dict
 
     def _do_save(
-        self, state_dict: dict[str, torch.Tensor], path: str, storage_writer: Optional[_HuggingFaceStorageWriter] = None
+        self, state_dict: dict[str, torch.Tensor], path: str, storage_writer: StorageWriter | None = None
     ) -> Optional["AsyncSaveResponse"]:
         """
         Save a state dictionary to `path` using DCP or PEFT special-case logic.
@@ -1504,7 +1501,7 @@ fi
         fqn_to_dtype_mapping: Optional[dict[str, str]],
         model_path: str,
         consolidate_on_all_ranks: bool = False,
-    ) -> Optional[_HuggingFaceStorageWriter]:
+    ) -> StorageWriter | None:
         """
         Construct a Hugging Face storage writer for sharded safetensors.
 
@@ -1516,7 +1513,7 @@ fi
             consolidate_on_all_ranks: If True, consolidate on all ranks on the main process.
 
         Returns:
-            Configured `_HuggingFaceStorageWriter` or None for non-safetensors.
+            Configured storage writer or None for non-safetensors.
         """
         if self.config.model_save_format == SerializationFormat.SAFETENSORS:
             return _HuggingFaceStorageWriter(
@@ -1535,7 +1532,7 @@ fi
         key_mapping: Optional[dict[str, str]],
         is_init_step: bool = False,
         is_safetensors: bool | None = None,
-    ) -> Optional[_HuggingFaceStorageReader]:
+    ) -> StorageReader | None:
         """
         Construct a Hugging Face storage reader when loading safetensors or during init.
 


### PR DESCRIPTION
## What changed

- Point the LLaVA and LLaVA-OneVision model-coverage entries at the routes Fern actually publishes.
- Type checkpoint storage parameters and return values against PyTorch's public `StorageReader` / `StorageWriter` contracts instead of the private in-tree Hugging Face backport implementations.

## Why

[NVBug 6179245](https://nvbugspro.nvidia.com/bug/6179245) remains open after the latest production scan found 85 broken-link rows.

Two source-level causes are still reproducible in production:

- the model-coverage overview links to `/llava` and `/llava-onevision`, while Fern publishes `/l-la-va` and `/l-la-va-one-vision`;
- generated checkpoint API signatures link private `_HuggingFaceStorageReader` and `_HuggingFaceStorageWriter` annotations to an unpublished `_backports/hf_storage` module page.

The concrete reader and writer implementations already implement PyTorch's public DCP storage interfaces, so broadening the annotations removes the invalid generated API links without changing runtime behavior.

The stale `/latest` version train is tracked separately by #2970.

## Validation

- `make -C docs/fern docs-check` — 292 MDX files validated; Fern found 0 errors.
- `python -m pytest -q tests/unit_tests/checkpoint/test_checkpointing.py` — 181 passed, 2 skipped.
- `ruff check nemo_automodel/components/checkpoint/checkpointing.py`
- Verified the two corrected production route targets return HTTP 200.
- Verified the backported reader and writer classes subclass the public DCP storage contracts.
