### PR TITLE
fix(checkpoint): save all PEFT EP optimizer parts

### DIFF
--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -612,6 +612,8 @@ class Checkpointer:
         model: nn.Module | list[nn.Module],
         weights_path: str,
         scheduler: Optional[Any] = None,
+        *,
+        optimizer_part_ids: list[int] | None = None,
     ) -> None:
         """
         Save optimizer (and optional scheduler) state to `weights_path/optim` using DCP.
@@ -621,6 +623,8 @@ class Checkpointer:
             model: Model or pipeline model parts providing partitioning context.
             weights_path: Base directory for checkpoints.
             scheduler: Optional LR scheduler to include.
+            optimizer_part_ids: Global pipeline-stage indices corresponding to
+                per-model-part optimizers.
         """
         optimizer_path = os.path.join(weights_path, "optim")
         _ensure_dirs(optimizer_path, process_group=self.process_group)
@@ -631,6 +635,7 @@ class Checkpointer:
             is_peft=self.config.is_peft,
             cpu_offload=self.config.cpu_offload,
             has_expert_parallelism=self.moe_mesh is not None,
+            optimizer_part_ids=optimizer_part_ids,
         )
         state_dict = optimizer_state.state_dict()
         self._optim_ctx.future = self._do_save(state_dict, optimizer_path)
@@ -641,6 +646,8 @@ class Checkpointer:
         model: nn.Module | list[nn.Module],
         weights_path: str,
         scheduler: Optional[Any] = None,
+        *,
+        optimizer_part_ids: list[int] | None = None,
     ) -> None:
         """
         Load optimizer (and optional scheduler) state from `weights_path/optim` using DCP.
@@ -650,6 +657,8 @@ class Checkpointer:
             model: Model or pipeline model parts providing partitioning context.
             weights_path: Base directory for checkpoints.
             scheduler: Optional LR scheduler to populate.
+            optimizer_part_ids: Global pipeline-stage indices corresponding to
+                per-model-part optimizers.
         """
         optimizer_state = OptimizerState(
             model,
@@ -658,6 +667,7 @@ class Checkpointer:
             is_peft=self.config.is_peft,
             cpu_offload=self.config.cpu_offload,
             has_expert_parallelism=self.moe_mesh is not None,
+            optimizer_part_ids=optimizer_part_ids,
         )
         state_dict = optimizer_state.state_dict()
         self._do_load(state_dict, os.path.join(weights_path, "optim"))

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -607,39 +607,57 @@ class Checkpointer:
 
     @torch.no_grad()
     def save_optimizer(
-        self, optimizer: torch.optim.Optimizer, model: nn.Module, weights_path: str, scheduler: Optional[Any] = None
+        self,
+        optimizer: torch.optim.Optimizer | list[torch.optim.Optimizer],
+        model: nn.Module | list[nn.Module],
+        weights_path: str,
+        scheduler: Optional[Any] = None,
     ) -> None:
         """
         Save optimizer (and optional scheduler) state to `weights_path/optim` using DCP.
 
         Args:
-            optimizer: Optimizer whose state will be saved.
-            model: Model providing partitioning context for the optimizer wrapper.
+            optimizer: Optimizer or per-model-part optimizers whose state will be saved.
+            model: Model or pipeline model parts providing partitioning context.
             weights_path: Base directory for checkpoints.
             scheduler: Optional LR scheduler to include.
         """
         optimizer_path = os.path.join(weights_path, "optim")
         _ensure_dirs(optimizer_path, process_group=self.process_group)
         optimizer_state = OptimizerState(
-            model, optimizer, scheduler, is_peft=self.config.is_peft, cpu_offload=self.config.cpu_offload
+            model,
+            optimizer,
+            scheduler,
+            is_peft=self.config.is_peft,
+            cpu_offload=self.config.cpu_offload,
+            has_expert_parallelism=self.moe_mesh is not None,
         )
         state_dict = optimizer_state.state_dict()
         self._optim_ctx.future = self._do_save(state_dict, optimizer_path)
 
     def load_optimizer(
-        self, optimizer: torch.optim.Optimizer, model: nn.Module, weights_path: str, scheduler: Optional[Any] = None
+        self,
+        optimizer: torch.optim.Optimizer | list[torch.optim.Optimizer],
+        model: nn.Module | list[nn.Module],
+        weights_path: str,
+        scheduler: Optional[Any] = None,
     ) -> None:
         """
         Load optimizer (and optional scheduler) state from `weights_path/optim` using DCP.
 
         Args:
-            optimizer: Optimizer to populate.
-            model: Model providing partitioning context for the optimizer wrapper.
+            optimizer: Optimizer or per-model-part optimizers to populate.
+            model: Model or pipeline model parts providing partitioning context.
             weights_path: Base directory for checkpoints.
             scheduler: Optional LR scheduler to populate.
         """
         optimizer_state = OptimizerState(
-            model, optimizer, scheduler, is_peft=self.config.is_peft, cpu_offload=self.config.cpu_offload
+            model,
+            optimizer,
+            scheduler,
+            is_peft=self.config.is_peft,
+            cpu_offload=self.config.cpu_offload,
+            has_expert_parallelism=self.moe_mesh is not None,
         )
         state_dict = optimizer_state.state_dict()
         self._do_load(state_dict, os.path.join(weights_path, "optim"))

--- a/nemo_automodel/components/checkpoint/stateful_wrappers.py
+++ b/nemo_automodel/components/checkpoint/stateful_wrappers.py
@@ -66,6 +66,7 @@ from nemo_automodel.components.checkpoint.utils import (
 )
 
 _PREFIX = "model."
+_OPTIMIZER_PARTS_KEY = "optimizer_parts"
 
 
 def _is_quantized_module(module: torch.nn.Module) -> bool:
@@ -90,6 +91,49 @@ def _has_expert_parallelism(model: torch.nn.Module) -> bool:
     sharded across EP ranks and DCP's state_dict APIs cannot handle them.
     """
     return any(getattr(m, "ep_size", 1) > 1 for m in model.modules())
+
+
+def _zeros_like_optimizer_param(param: torch.Tensor) -> torch.Tensor:
+    """Allocate zero optimizer state matching a parameter.
+
+    Args:
+        param: Tensor of arbitrary shape representing one optimizer parameter.
+
+    Returns:
+        Zero tensor with the same shape, dtype, device, and layout as ``param``.
+    """
+    try:
+        return torch.zeros_like(param, memory_format=torch.preserve_format)
+    except TypeError:
+        return torch.zeros_like(param)
+
+
+def _materialize_missing_adam_state(optimizer: torch.optim.Optimizer) -> None:
+    """Create zero-valued Adam state for parameters that do not have state yet."""
+    if not isinstance(optimizer, (torch.optim.Adam, torch.optim.AdamW)):
+        return
+
+    for group in optimizer.param_groups:
+        step_dtype = (
+            torch.float32
+            if group.get("fused", False)
+            else torch.float64
+            if torch.get_default_dtype() == torch.float64
+            else torch.float32
+        )
+        for param in group["params"]:
+            state = optimizer.state[param]
+            if "step" not in state:
+                if group.get("capturable", False) or group.get("fused", False):
+                    state["step"] = torch.zeros((), dtype=step_dtype, device=param.device)
+                else:
+                    state["step"] = torch.tensor(0.0, dtype=step_dtype)
+            if "exp_avg" not in state:
+                state["exp_avg"] = _zeros_like_optimizer_param(param)
+            if "exp_avg_sq" not in state:
+                state["exp_avg_sq"] = _zeros_like_optimizer_param(param)
+            if group.get("amsgrad", False) and "max_exp_avg_sq" not in state:
+                state["max_exp_avg_sq"] = _zeros_like_optimizer_param(param)
 
 
 def _get_peft_state_dict(model: torch.nn.Module) -> dict[str, Any]:
@@ -519,10 +563,12 @@ class OptimizerState:
     def __init__(
         self,
         model: torch.nn.Module | list[torch.nn.Module],
-        optimizer: torch.optim.Optimizer,
+        optimizer: torch.optim.Optimizer | list[torch.optim.Optimizer],
         scheduler: Optional[Any] = None,
         is_peft: bool = False,
         cpu_offload: bool = False,
+        *,
+        has_expert_parallelism: bool = False,
     ):
         """
         Initialize an OptimizerState instance.
@@ -532,22 +578,31 @@ class OptimizerState:
         and restored by the Distributed Checkpointing (DCP) framework.
 
         Args:
-            model (torch.nn.Module): The neural-network model whose parameters the
-                optimizer updates. Keeping the reference allows DCP to re-establish
-                the model–optimizer relationship when loading a checkpoint.
-            optimizer (torch.optim.Optimizer): Optimizer whose internal buffers
-                (e.g., momentum, Adam moments, step counters) need to be saved and
-                restored.
+            model: Neural-network model or pipeline model parts whose parameters
+                the optimizer updates. Keeping the references allows DCP to
+                re-establish each model–optimizer relationship when loading a
+                checkpoint.
+            optimizer: Optimizer or per-model-part optimizers whose internal
+                buffers (e.g., momentum, Adam moments, step counters) need to be
+                saved and restored.
             scheduler (Optional[Any], optional): Learning-rate scheduler to track
                 alongside the optimizer. Pass ``None`` if no scheduler is used.
             is_peft (bool): Whether the model uses PEFT adapters (e.g. LoRA/QLoRA).
             cpu_offload: Whether DCP should move sharded tensors to CPU before saving.
+            has_expert_parallelism: Whether the distributed topology uses expert
+                parallelism. This runtime topology signal avoids inferring global
+                EP state from only one local pipeline part.
         """
         self.model = [model] if isinstance(model, torch.nn.Module) else model
         self.optimizer = [optimizer] if isinstance(optimizer, torch.optim.Optimizer) else optimizer
         self.scheduler = [scheduler] if isinstance(scheduler, torch.optim.lr_scheduler.LRScheduler) else scheduler
         self.is_peft = is_peft
         self.cpu_offload = cpu_offload
+        self._use_native_optimizer_state = self.is_peft and (
+            has_expert_parallelism
+            or any(_has_expert_parallelism(model_part) for model_part in self.model)
+            or any(_has_quantized_params(model_part) for model_part in self.model)
+        )
 
     def state_dict(self) -> dict[str, Any]:
         """
@@ -562,8 +617,13 @@ class OptimizerState:
         # quantized frozen params (Params4bit/Int8Params) alongside trainable LoRA
         # params, or when expert weights are sharded across EP ranks (MoE+EP) and
         # the optimizer only tracks trainable params. Use native state_dict instead.
-        if self.is_peft and (_has_expert_parallelism(self.model[0]) or _has_quantized_params(self.model[0])):
-            optimizer_state_dict = self.optimizer[0].state_dict()
+        if self._use_native_optimizer_state:
+            for optimizer in self.optimizer:
+                _materialize_missing_adam_state(optimizer)
+            if len(self.optimizer) == 1:
+                optimizer_state_dict = self.optimizer[0].state_dict()
+            else:
+                optimizer_state_dict = {_OPTIMIZER_PARTS_KEY: [optimizer.state_dict() for optimizer in self.optimizer]}
         else:
             # this line automatically manages FSDP FQN's, as well as sets the default state dict type
             # to FSDP.SHARDED_STATE_DICT
@@ -588,9 +648,24 @@ class OptimizerState:
         Args:
             state_dict (dict): State dictionary containing optimizer and scheduler states to load.
         """
-        # For PEFT + quantized or expert-parallel models, use native load to match the native save path.
-        if self.is_peft and (_has_expert_parallelism(self.model[0]) or _has_quantized_params(self.model[0])):
-            self.optimizer[0].load_state_dict(state_dict["optim"])
+        # Mirror state_dict(): PEFT with quantized parameters or EP topology uses native optimizer state.
+        if self._use_native_optimizer_state:
+            optimizer_state_dict = state_dict["optim"]
+            if len(self.optimizer) == 1:
+                self.optimizer[0].load_state_dict(optimizer_state_dict)
+            else:
+                optimizer_parts = optimizer_state_dict.get(_OPTIMIZER_PARTS_KEY)
+                if not isinstance(optimizer_parts, list):
+                    raise ValueError(
+                        f"Multi-part native optimizer checkpoint is missing the '{_OPTIMIZER_PARTS_KEY}' state list."
+                    )
+                if len(optimizer_parts) != len(self.optimizer):
+                    raise ValueError(
+                        "Optimizer checkpoint part count does not match the current pipeline layout: "
+                        f"checkpoint has {len(optimizer_parts)} parts, current layout has {len(self.optimizer)}."
+                    )
+                for optimizer, optimizer_part in zip(self.optimizer, optimizer_parts, strict=True):
+                    optimizer.load_state_dict(optimizer_part)
         else:
             # sets our state dicts on the optimizer, now that we've loaded
             func = partial(

--- a/nemo_automodel/components/checkpoint/stateful_wrappers.py
+++ b/nemo_automodel/components/checkpoint/stateful_wrappers.py
@@ -67,6 +67,7 @@ from nemo_automodel.components.checkpoint.utils import (
 
 _PREFIX = "model."
 _OPTIMIZER_PARTS_KEY = "optimizer_parts"
+_OPTIMIZER_PART_KEY_PREFIX = "stage_"
 
 
 def _is_quantized_module(module: torch.nn.Module) -> bool:
@@ -569,6 +570,7 @@ class OptimizerState:
         cpu_offload: bool = False,
         *,
         has_expert_parallelism: bool = False,
+        optimizer_part_ids: list[int] | None = None,
     ):
         """
         Initialize an OptimizerState instance.
@@ -592,12 +594,24 @@ class OptimizerState:
             has_expert_parallelism: Whether the distributed topology uses expert
                 parallelism. This runtime topology signal avoids inferring global
                 EP state from only one local pipeline part.
+            optimizer_part_ids: Global pipeline-stage indices corresponding to
+                ``optimizer``. These namespace native optimizer state across PP
+                ranks so different stages cannot produce overlapping DCP keys.
         """
         self.model = [model] if isinstance(model, torch.nn.Module) else model
         self.optimizer = [optimizer] if isinstance(optimizer, torch.optim.Optimizer) else optimizer
         self.scheduler = [scheduler] if isinstance(scheduler, torch.optim.lr_scheduler.LRScheduler) else scheduler
         self.is_peft = is_peft
         self.cpu_offload = cpu_offload
+        self.optimizer_part_ids = optimizer_part_ids
+        if self.optimizer_part_ids is not None:
+            if len(self.optimizer_part_ids) != len(self.optimizer):
+                raise ValueError(
+                    "Optimizer part IDs must match the local optimizer layout: "
+                    f"received {len(self.optimizer_part_ids)} IDs for {len(self.optimizer)} optimizers."
+                )
+            if len(set(self.optimizer_part_ids)) != len(self.optimizer_part_ids):
+                raise ValueError(f"Optimizer part IDs must be unique, got {self.optimizer_part_ids}.")
         self._use_native_optimizer_state = self.is_peft and (
             has_expert_parallelism
             or any(_has_expert_parallelism(model_part) for model_part in self.model)
@@ -620,10 +634,20 @@ class OptimizerState:
         if self._use_native_optimizer_state:
             for optimizer in self.optimizer:
                 _materialize_missing_adam_state(optimizer)
-            if len(self.optimizer) == 1:
+            if self.optimizer_part_ids is None:
+                if len(self.optimizer) != 1:
+                    raise ValueError(
+                        "Native optimizer checkpointing requires global optimizer part IDs "
+                        f"when saving {len(self.optimizer)} local optimizer parts."
+                    )
                 optimizer_state_dict = self.optimizer[0].state_dict()
             else:
-                optimizer_state_dict = {_OPTIMIZER_PARTS_KEY: [optimizer.state_dict() for optimizer in self.optimizer]}
+                optimizer_state_dict = {
+                    _OPTIMIZER_PARTS_KEY: {
+                        f"{_OPTIMIZER_PART_KEY_PREFIX}{part_id}": optimizer.state_dict()
+                        for part_id, optimizer in zip(self.optimizer_part_ids, self.optimizer, strict=True)
+                    }
+                }
         else:
             # this line automatically manages FSDP FQN's, as well as sets the default state dict type
             # to FSDP.SHARDED_STATE_DICT
@@ -651,21 +675,27 @@ class OptimizerState:
         # Mirror state_dict(): PEFT with quantized parameters or EP topology uses native optimizer state.
         if self._use_native_optimizer_state:
             optimizer_state_dict = state_dict["optim"]
-            if len(self.optimizer) == 1:
+            if self.optimizer_part_ids is None:
+                if len(self.optimizer) != 1:
+                    raise ValueError(
+                        "Native optimizer checkpointing requires global optimizer part IDs "
+                        f"when loading {len(self.optimizer)} local optimizer parts."
+                    )
                 self.optimizer[0].load_state_dict(optimizer_state_dict)
             else:
                 optimizer_parts = optimizer_state_dict.get(_OPTIMIZER_PARTS_KEY)
-                if not isinstance(optimizer_parts, list):
+                if not isinstance(optimizer_parts, dict):
                     raise ValueError(
-                        f"Multi-part native optimizer checkpoint is missing the '{_OPTIMIZER_PARTS_KEY}' state list."
+                        f"Pipeline native optimizer checkpoint is missing the '{_OPTIMIZER_PARTS_KEY}' state mapping."
                     )
-                if len(optimizer_parts) != len(self.optimizer):
+                expected_part_keys = [f"{_OPTIMIZER_PART_KEY_PREFIX}{part_id}" for part_id in self.optimizer_part_ids]
+                if set(optimizer_parts) != set(expected_part_keys):
                     raise ValueError(
-                        "Optimizer checkpoint part count does not match the current pipeline layout: "
-                        f"checkpoint has {len(optimizer_parts)} parts, current layout has {len(self.optimizer)}."
+                        "Optimizer checkpoint parts do not match the current pipeline layout: "
+                        f"checkpoint has {sorted(optimizer_parts)}, current rank expects {sorted(expected_part_keys)}."
                     )
-                for optimizer, optimizer_part in zip(self.optimizer, optimizer_parts, strict=True):
-                    optimizer.load_state_dict(optimizer_part)
+                for optimizer, part_key in zip(self.optimizer, expected_part_keys, strict=True):
+                    optimizer.load_state_dict(optimizer_parts[part_key])
         else:
             # sets our state dicts on the optimizer, now that we've loaded
             func = partial(

--- a/nemo_automodel/recipes/base_recipe.py
+++ b/nemo_automodel/recipes/base_recipe.py
@@ -381,7 +381,13 @@ class BaseRecipe:
         for opt in optimizers:
             if hasattr(opt, "synchronize_for_checkpoint"):
                 opt.synchronize_for_checkpoint()
-        self.checkpointer.save_optimizer(optimizer, model, path, scheduler)
+        self.checkpointer.save_optimizer(
+            optimizer,
+            model,
+            path,
+            scheduler,
+            optimizer_part_ids=self._get_optimizer_checkpoint_part_ids(),
+        )
         save_config(config.raw_config, path)
         if is_dist_initialized:
             _dist_barrier(getattr(getattr(self, "mesh_context", None), "process_group", None))
@@ -740,7 +746,13 @@ class BaseRecipe:
             candidate.load_pretrained(ckpt_dir, checkpointer=self.checkpointer)
         else:
             self.checkpointer.load_model(model, os.path.join(ckpt_dir, "model"))
-        self.checkpointer.load_optimizer(optimizer, model, ckpt_dir, scheduler)
+        self.checkpointer.load_optimizer(
+            optimizer,
+            model,
+            ckpt_dir,
+            scheduler,
+            optimizer_part_ids=self._get_optimizer_checkpoint_part_ids(),
+        )
 
     def _log_experiment_details(self):
         """Log metadata and config on main rank using YAML markers."""
@@ -980,6 +992,16 @@ class BaseRecipe:
         if dm is None or "pp" not in dm.mesh_dim_names or dm["pp"].size() == 1:
             return None
         return dm["pp"].get_group()
+
+    def _get_optimizer_checkpoint_part_ids(self) -> list[int] | None:
+        """Return globally unique stage indices for local pipeline optimizers."""
+        pipeline = getattr(self, "pp", None)
+        if pipeline is None:
+            return None
+        stages = pipeline.info.stages
+        if stages is None:
+            raise RuntimeError("Pipeline optimizer checkpointing requires AutoPipeline.build() to complete first.")
+        return [stage.stage_index for stage in stages]
 
     def _dp_allreduce(self, tensor, op=dist.ReduceOp.SUM, include_cp: bool = False):
         dp_group = self._get_dp_group(include_cp=include_cp)

--- a/tests/unit_tests/checkpoint/test_optimizer_state.py
+++ b/tests/unit_tests/checkpoint/test_optimizer_state.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from unittest.mock import patch
 
 import pytest
@@ -67,14 +68,54 @@ def _assert_native_state_dicts_equal(actual: dict, expected: dict) -> None:
                 assert actual_value == expected_value
 
 
-def _make_peft_ep_checkpointer(tmp_path) -> Checkpointer:
+def _make_peft_ep_checkpointer(tmp_path, *, pp_rank: int = 0) -> Checkpointer:
     config = CheckpointingConfig(
         checkpoint_dir=tmp_path,
         model_save_format="safetensors",
         save_consolidated=False,
         is_peft=True,
     )
-    return Checkpointer(config, dp_rank=0, tp_rank=0, pp_rank=0, moe_mesh=object())
+    return Checkpointer(config, dp_rank=0, tp_rank=0, pp_rank=pp_rank, moe_mesh=object())
+
+
+def _run_native_pp_optimizer_dcp_round_trip(
+    rank: int,
+    world_size: int,
+    init_file: str,
+    checkpoint_dir: str,
+) -> None:
+    os.environ["GLOO_SOCKET_IFNAME"] = "lo"
+    torch.distributed.init_process_group(
+        "gloo",
+        init_method=f"file://{init_file}",
+        rank=rank,
+        world_size=world_size,
+    )
+    try:
+        source_models, source_optimizers = _make_stepped_adam_parts(count=1)
+        source_optimizers[0].param_groups[0]["lr"] = 0.01 * (rank + 1)
+        source_parameter = source_optimizers[0].param_groups[0]["params"][0]
+        source_optimizers[0].state[source_parameter]["exp_avg"].fill_(rank + 1)
+        source_optimizers[0].state[source_parameter]["exp_avg_sq"].fill_(rank + 2)
+        checkpointer = _make_peft_ep_checkpointer(checkpoint_dir, pp_rank=rank)
+        checkpointer.save_optimizer(
+            source_optimizers,
+            source_models,
+            checkpoint_dir,
+            optimizer_part_ids=[rank],
+        )
+
+        target_models = [nn.Linear(2, 1, bias=False)]
+        target_optimizers = [torch.optim.AdamW(target_models[0].parameters(), lr=0.5)]
+        checkpointer.load_optimizer(
+            target_optimizers,
+            target_models,
+            checkpoint_dir,
+            optimizer_part_ids=[rank],
+        )
+        _assert_adam_states_equal(target_optimizers[0], source_optimizers[0])
+    finally:
+        torch.distributed.destroy_process_group()
 
 
 def test_checkpointer_uses_native_state_for_all_optimizer_parts_with_ep_topology(tmp_path):
@@ -82,13 +123,18 @@ def test_checkpointer_uses_native_state_for_all_optimizer_parts_with_ep_topology
     checkpointer = _make_peft_ep_checkpointer(tmp_path)
 
     with patch.object(checkpointer, "_do_save") as do_save:
-        checkpointer.save_optimizer(optimizers, model_parts, str(tmp_path))
+        checkpointer.save_optimizer(
+            optimizers,
+            model_parts,
+            str(tmp_path),
+            optimizer_part_ids=[0, 8],
+        )
 
     state_dict = do_save.call_args.args[0]
     saved_parts = state_dict["optim"]["optimizer_parts"]
-    assert len(saved_parts) == len(optimizers)
-    for saved_part, optimizer in zip(saved_parts, optimizers, strict=True):
-        _assert_native_state_dicts_equal(saved_part, optimizer.state_dict())
+    assert saved_parts.keys() == {"stage_0", "stage_8"}
+    for part_key, optimizer in zip(("stage_0", "stage_8"), optimizers, strict=True):
+        _assert_native_state_dicts_equal(saved_parts[part_key], optimizer.state_dict())
 
 
 def test_native_single_optimizer_state_preserves_existing_checkpoint_schema():
@@ -106,17 +152,43 @@ def test_native_single_optimizer_state_preserves_existing_checkpoint_schema():
 def test_native_multi_optimizer_state_dcp_round_trip(tmp_path):
     source_models, source_optimizers = _make_stepped_adam_parts()
     checkpointer = _make_peft_ep_checkpointer(tmp_path)
-    checkpointer.save_optimizer(source_optimizers, source_models, str(tmp_path))
+    checkpointer.save_optimizer(
+        source_optimizers,
+        source_models,
+        str(tmp_path),
+        optimizer_part_ids=[0, 2],
+    )
 
     target_models = [nn.Linear(2, 1, bias=False) for _ in source_models]
     target_optimizers = [torch.optim.AdamW(model.parameters(), lr=0.5) for model in target_models]
-    checkpointer.load_optimizer(target_optimizers, target_models, str(tmp_path))
+    checkpointer.load_optimizer(
+        target_optimizers,
+        target_models,
+        str(tmp_path),
+        optimizer_part_ids=[0, 2],
+    )
 
     for target, source in zip(target_optimizers, source_optimizers, strict=True):
         _assert_adam_states_equal(target, source)
 
 
-def test_native_multi_optimizer_load_rejects_pipeline_part_count_mismatch():
+def test_native_pipeline_optimizer_load_rejects_stage_mismatch():
+    model_parts, optimizers = _make_stepped_adam_parts()
+    optimizer_state = OptimizerState(
+        model_parts,
+        optimizers,
+        is_peft=True,
+        has_expert_parallelism=True,
+        optimizer_part_ids=[0, 8],
+    )
+    state_dict = optimizer_state.state_dict()
+    state_dict["optim"]["optimizer_parts"]["stage_7"] = state_dict["optim"]["optimizer_parts"].pop("stage_8")
+
+    with pytest.raises(ValueError, match=r"checkpoint has \['stage_0', 'stage_7'\].*expects \['stage_0', 'stage_8'\]"):
+        optimizer_state.load_state_dict(state_dict)
+
+
+def test_native_multi_optimizer_state_requires_global_part_ids():
     model_parts, optimizers = _make_stepped_adam_parts()
     optimizer_state = OptimizerState(
         model_parts,
@@ -124,8 +196,16 @@ def test_native_multi_optimizer_load_rejects_pipeline_part_count_mismatch():
         is_peft=True,
         has_expert_parallelism=True,
     )
-    state_dict = optimizer_state.state_dict()
-    state_dict["optim"]["optimizer_parts"].pop()
 
-    with pytest.raises(ValueError, match="checkpoint has 1 parts, current layout has 2"):
-        optimizer_state.load_state_dict(state_dict)
+    with pytest.raises(ValueError, match="requires global optimizer part IDs"):
+        optimizer_state.state_dict()
+
+
+def test_native_pipeline_optimizer_state_dcp_round_trip_across_ranks(tmp_path):
+    world_size = 2
+    torch.multiprocessing.spawn(
+        _run_native_pp_optimizer_dcp_round_trip,
+        args=(world_size, str(tmp_path / "dist_init"), str(tmp_path / "checkpoint")),
+        nprocs=world_size,
+        join=True,
+    )

--- a/tests/unit_tests/checkpoint/test_optimizer_state.py
+++ b/tests/unit_tests/checkpoint/test_optimizer_state.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+
+import pytest
+import torch
+from torch import nn
+
+from nemo_automodel.components.checkpoint.checkpointing import Checkpointer, CheckpointingConfig
+from nemo_automodel.components.checkpoint.stateful_wrappers import OptimizerState
+
+
+def _make_stepped_adam_parts(
+    count: int = 2,
+) -> tuple[list[nn.Module], list[torch.optim.AdamW]]:
+    model_parts: list[nn.Module] = []
+    optimizers: list[torch.optim.AdamW] = []
+    for index in range(count):
+        model_part = nn.Linear(2, 1, bias=False)
+        optimizer = torch.optim.AdamW(model_part.parameters(), lr=0.01 * (index + 1))
+        for parameter in model_part.parameters():
+            parameter.grad = torch.full_like(parameter, float(index + 1))
+        optimizer.step()
+        optimizer.zero_grad(set_to_none=True)
+        model_parts.append(model_part)
+        optimizers.append(optimizer)
+    return model_parts, optimizers
+
+
+def _assert_adam_states_equal(
+    actual: torch.optim.AdamW,
+    expected: torch.optim.AdamW,
+) -> None:
+    actual_parameter = actual.param_groups[0]["params"][0]
+    expected_parameter = expected.param_groups[0]["params"][0]
+    actual_state = actual.state[actual_parameter]
+    expected_state = expected.state[expected_parameter]
+
+    torch.testing.assert_close(actual_state["step"], expected_state["step"])
+    torch.testing.assert_close(actual_state["exp_avg"], expected_state["exp_avg"])
+    torch.testing.assert_close(actual_state["exp_avg_sq"], expected_state["exp_avg_sq"])
+    assert actual.param_groups[0]["lr"] == expected.param_groups[0]["lr"]
+
+
+def _assert_native_state_dicts_equal(actual: dict, expected: dict) -> None:
+    assert actual["param_groups"] == expected["param_groups"]
+    assert actual["state"].keys() == expected["state"].keys()
+    for parameter_id in actual["state"]:
+        assert actual["state"][parameter_id].keys() == expected["state"][parameter_id].keys()
+        for state_name, actual_value in actual["state"][parameter_id].items():
+            expected_value = expected["state"][parameter_id][state_name]
+            if isinstance(actual_value, torch.Tensor):
+                torch.testing.assert_close(actual_value, expected_value)
+            else:
+                assert actual_value == expected_value
+
+
+def _make_peft_ep_checkpointer(tmp_path) -> Checkpointer:
+    config = CheckpointingConfig(
+        checkpoint_dir=tmp_path,
+        model_save_format="safetensors",
+        save_consolidated=False,
+        is_peft=True,
+    )
+    return Checkpointer(config, dp_rank=0, tp_rank=0, pp_rank=0, moe_mesh=object())
+
+
+def test_checkpointer_uses_native_state_for_all_optimizer_parts_with_ep_topology(tmp_path):
+    model_parts, optimizers = _make_stepped_adam_parts()
+    checkpointer = _make_peft_ep_checkpointer(tmp_path)
+
+    with patch.object(checkpointer, "_do_save") as do_save:
+        checkpointer.save_optimizer(optimizers, model_parts, str(tmp_path))
+
+    state_dict = do_save.call_args.args[0]
+    saved_parts = state_dict["optim"]["optimizer_parts"]
+    assert len(saved_parts) == len(optimizers)
+    for saved_part, optimizer in zip(saved_parts, optimizers, strict=True):
+        _assert_native_state_dicts_equal(saved_part, optimizer.state_dict())
+
+
+def test_native_single_optimizer_state_preserves_existing_checkpoint_schema():
+    model_parts, optimizers = _make_stepped_adam_parts(count=1)
+    state_dict = OptimizerState(
+        model_parts[0],
+        optimizers[0],
+        is_peft=True,
+        has_expert_parallelism=True,
+    ).state_dict()
+
+    assert state_dict["optim"].keys() == {"state", "param_groups"}
+
+
+def test_native_multi_optimizer_state_dcp_round_trip(tmp_path):
+    source_models, source_optimizers = _make_stepped_adam_parts()
+    checkpointer = _make_peft_ep_checkpointer(tmp_path)
+    checkpointer.save_optimizer(source_optimizers, source_models, str(tmp_path))
+
+    target_models = [nn.Linear(2, 1, bias=False) for _ in source_models]
+    target_optimizers = [torch.optim.AdamW(model.parameters(), lr=0.5) for model in target_models]
+    checkpointer.load_optimizer(target_optimizers, target_models, str(tmp_path))
+
+    for target, source in zip(target_optimizers, source_optimizers, strict=True):
+        _assert_adam_states_equal(target, source)
+
+
+def test_native_multi_optimizer_load_rejects_pipeline_part_count_mismatch():
+    model_parts, optimizers = _make_stepped_adam_parts()
+    optimizer_state = OptimizerState(
+        model_parts,
+        optimizers,
+        is_peft=True,
+        has_expert_parallelism=True,
+    )
+    state_dict = optimizer_state.state_dict()
+    state_dict["optim"]["optimizer_parts"].pop()
+
+    with pytest.raises(ValueError, match="checkpoint has 1 parts, current layout has 2"):
+        optimizer_state.load_state_dict(state_dict)

--- a/tests/unit_tests/recipes/test_base_recipe.py
+++ b/tests/unit_tests/recipes/test_base_recipe.py
@@ -88,16 +88,18 @@ def _patch_checkpoint_ops(monkeypatch):
                 return
             model.load_state_dict(torch.load(os.path.join(model_path, "model.pt"), weights_only=False))
 
-        def save_optimizer(self, optimizer, model, weights_path, scheduler=None):
+        def save_optimizer(self, optimizer, model, weights_path, scheduler=None, *, optimizer_part_ids=None):
             """Save optimizer state dict."""
+            del model, optimizer_part_ids
             if optimizer is None:
                 return
             optim_dir = os.path.join(weights_path, "optim")
             os.makedirs(optim_dir, exist_ok=True)
             torch.save(optimizer.state_dict(), os.path.join(optim_dir, "optimizer.pt"))
 
-        def load_optimizer(self, optimizer, model, weights_path, scheduler=None):
+        def load_optimizer(self, optimizer, model, weights_path, scheduler=None, *, optimizer_part_ids=None):
             """Load optimizer state dict."""
+            del model, scheduler, optimizer_part_ids
             if optimizer is None:
                 return
             optim_path = os.path.join(weights_path, "optim")
@@ -250,6 +252,20 @@ def test_dp_allreduce_uses_world_group_without_device_mesh(tmp_path, monkeypatch
     assert len(calls) == 1
     assert calls[0][0] == torch.distributed.ReduceOp.SUM
     assert calls[0][1] is None
+
+
+def test_optimizer_checkpoint_part_ids_use_global_pipeline_stage_indices(tmp_path):
+    recipe_inst = _ToyRecipe(tmp_path)
+    recipe_inst.pp = SimpleNamespace(
+        info=SimpleNamespace(
+            stages=[
+                SimpleNamespace(stage_index=3),
+                SimpleNamespace(stage_index=11),
+            ]
+        )
+    )
+
+    assert recipe_inst._get_optimizer_checkpoint_part_ids() == [3, 11]
 
 
 def test_find_latest_checkpoint(tmp_path):


### PR DESCRIPTION
# What does this PR do ?

Fix PEFT+expert-parallel optimizer checkpointing when an interleaved pipeline
rank owns multiple local model and optimizer parts.

The failure in AMINT-202 happened because the native fallback inspected only
the first local model part and then saved only the first optimizer. When that
first part was dense, the code incorrectly entered PyTorch's model-aware DCP
optimizer path, which could not construct a consistent parameter-ID-to-FQN
mapping for LoRA parameters over EP-sharded experts and raised `KeyError: 0`.

# Changelog

- Select the native PEFT optimizer fallback from the actual EP topology and all
  local model parts.
- Save and restore every local optimizer part while preserving the existing
  single-optimizer checkpoint schema.
- Namespace multi-part optimizer state by global pipeline stage so different PP
  ranks cannot publish unrelated Adam tensors under the same DCP key.
- Materialize lazy Adam/AdamW state placeholders so DCP can restore native
  optimizer state into a fresh optimizer.
- Reject multi-part checkpoint/layout count mismatches with a clear error.
- Add CPU regression coverage for topology selection, compatibility, DCP
  round-trip restoration, and mismatch handling.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added focused unit tests.
- [x] No documentation update is required for this internal checkpoint fix.
- [x] `ruff format` and `ruff check` pass for the changed files.
- [x] `185 passed, 2 skipped` in `test_optimizer_state.py` and
  `test_checkpointing.py`.

# Additional Information

- Related Linear issue:
  https://linear.app/nvidia/issue/AMINT-202/optimizer-checkpoint-save-fails-with-keyerror-0-when-accessing-fqn-pid
- Scoped 64-GPU Ling NeMo CI passed:
  [ling_1t_lora_pp job 375536631](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/375536631).
  It completed all 50 steps and the final optimizer checkpoint save at step 49.
- CI tested commit `f20a46b` before the DCO-only amendment. Current PR head
  `a9178c1` has the identical source tree (`48fb0ccb`).
