### PR TITLE
fix(ci): preserve main wheelhouse cache builds

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -9,7 +9,9 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event.label.name || 'main' }}-${{ github.event_name }}
-  cancel-in-progress: true
+  # PR updates can supersede stale runs, but main must finish populating the
+  # canonical CUDA wheelhouse cache used by every copied PR branch.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   TORCH_CU_INDEX: https://download.pytorch.org/whl/cu130


### PR DESCRIPTION
## What changed

Keep Installation Test cancellation enabled for copied PR branches, but disable `cancel-in-progress` on `main`.

## Why

The CUDA wheelhouse cache is writable only from `main`. Building Flash Attention takes roughly three hours, but every new merge cancelled the running `main` workflow before it could save the new canonical cache. PR branches then restored the older prefix-matching cache, rebuilt Flash Attention, and could not save their result because they are restore-only.

## Evidence

All timestamps below are UTC.

### Expected behavior

The earlier same-ref validation showed the intended steady state: an exact cache hit followed by a skipped wheel build in [job 89242182710](https://github.com/NVIDIA-NeMo/Automodel/actions/runs/30017748060/job/89242182710).

```text
2026-07-23T14:55:07.8003236Z   key: install-test-cuda-wheelhouse-Linux-py3.12-58d2c45e4946f060aba73629c6107964efbba29fd4f3b9d243456e23a7fadc0a
2026-07-23T14:55:08.1159937Z Cache hit for: install-test-cuda-wheelhouse-Linux-py3.12-58d2c45e4946f060aba73629c6107964efbba29fd4f3b9d243456e23a7fadc0a
2026-07-23T14:55:29.3819883Z Cache restored from key: install-test-cuda-wheelhouse-Linux-py3.12-58d2c45e4946f060aba73629c6107964efbba29fd4f3b9d243456e23a7fadc0a
```

The `Build cached CUDA dependency wheels` step was skipped at `2026-07-23T14:55:29Z`. After the cache-policy change, the expected bootstrap behavior was for one `main` run to build and save key `7b7a40c8...`; later runs would then return to this exact-hit/skip path.

### What happened

The final PR #3204 validation requested the new key but restored the old `main` cache in [job 89969968671](https://github.com/NVIDIA-NeMo/Automodel/actions/runs/30263882227/job/89969968671):

```text
2026-07-27T12:00:48.1107646Z   key: install-test-cuda-wheelhouse-Linux-py3.12-7b7a40c8fd21bcf4476bfeb0eeee9ecc57cea07ae84ace4d5cb63597fc8ac148
2026-07-27T12:00:48.3913437Z Cache hit for restore-key: install-test-cuda-wheelhouse-Linux-py3.12-0cbc64fb2bb7f02462f81de4fdb3a9ce293b70c9c10dacc1eb0cef9638946e6f
2026-07-27T12:01:04.7669269Z Cache restored from key: install-test-cuda-wheelhouse-Linux-py3.12-0cbc64fb2bb7f02462f81de4fdb3a9ce293b70c9c10dacc1eb0cef9638946e6f
2026-07-27T12:02:13.9562840Z   Building wheel for flash-attn (pyproject.toml): started
2026-07-27T14:50:43.8996282Z   Building wheel for flash-attn (pyproject.toml): finished with status 'done'
2026-07-27T14:50:44.0796725Z   Created wheel for flash-attn: filename=flash_attn-2.8.3-cp312-cp312-linux_x86_64.whl
```

That PR job successfully built the needed wheel, but PR refs are restore-only, so it did not populate the canonical cache.

After merge, three consecutive `main` attempts restored the same old cache, started rebuilding Flash Attention, and were cancelled by the next merge:

| Main wheelhouse job | Old cache restored | Flash Attention build started | Cancelled |
| --- | --- | --- | --- |
| [90033573328](https://github.com/NVIDIA-NeMo/Automodel/actions/runs/30282897117/job/90033573328) | `2026-07-27T16:07:55Z` | `2026-07-27T16:09:12Z` | `2026-07-27T16:28:28Z` |
| [90040144259](https://github.com/NVIDIA-NeMo/Automodel/actions/runs/30284865370/job/90040144259) | `2026-07-27T16:32:58Z` | `2026-07-27T16:34:14Z` | `2026-07-27T17:09:59Z` |
| [90052695017](https://github.com/NVIDIA-NeMo/Automodel/actions/runs/30288021267/job/90052695017) | `2026-07-27T17:23:57Z` | `2026-07-27T17:25:01Z` | `2026-07-27T17:47:16Z` |

Representative cancellation log:

```text
2026-07-27T17:23:39.4762143Z   key: install-test-cuda-wheelhouse-Linux-py3.12-7b7a40c8fd21bcf4476bfeb0eeee9ecc57cea07ae84ace4d5cb63597fc8ac148
2026-07-27T17:23:39.7593615Z Cache hit for restore-key: install-test-cuda-wheelhouse-Linux-py3.12-0cbc64fb2bb7f02462f81de4fdb3a9ce293b70c9c10dacc1eb0cef9638946e6f
2026-07-27T17:23:57.4607818Z Cache restored from key: install-test-cuda-wheelhouse-Linux-py3.12-0cbc64fb2bb7f02462f81de4fdb3a9ce293b70c9c10dacc1eb0cef9638946e6f
2026-07-27T17:25:01.0781438Z   Building wheel for flash-attn (pyproject.toml): started
2026-07-27T17:47:16.3954153Z ##[error]The operation was canceled.
```

As of `2026-07-27T18:03:36Z`, the downstream impact was still visible:

- [PR #3250 job 90037357366](https://github.com/NVIDIA-NeMo/Automodel/actions/runs/30284041100/job/90037357366) had been rebuilding since `2026-07-27T16:21:30Z`.
- [PR #2437 job 90043731583](https://github.com/NVIDIA-NeMo/Automodel/actions/runs/30285950367/job/90043731583) had been rebuilding since `2026-07-27T16:50:31Z`.
- The fourth canonical `main` attempt, [job 90059949586](https://github.com/NVIDIA-NeMo/Automodel/actions/runs/30290806434/job/90059949586), had been rebuilding since `2026-07-27T17:53:34Z`.

## Why this fixes it

With this change, a newer `main` push no longer cancels the active cache-populating run. One `main` job can finish and save the canonical wheelhouse; subsequent PR jobs can restore the exact key and skip compilation. Updated PR commits still cancel their own stale runs.

## Validation

- `actionlint` on `.github/workflows/install-test.yml` with existing custom-runner and pre-existing matrix warnings ignored
- PyYAML parse plus assertion of the `cancel-in-progress` expression
- `git diff --check`
