### PR TITLE
fix(distributed): preserve ERNIE router and dense Qwen3.5 SSM precision

### DIFF
--- a/examples/llm_finetune/ernie4_5/ernie4_5_21b_a3b_hellaswag.yaml
+++ b/examples/llm_finetune/ernie4_5/ernie4_5_21b_a3b_hellaswag.yaml
@@ -104,7 +104,7 @@ ci:
   time: "00:20:00"
   checkpoint_robustness:
     check_source_load_parity: true
-    hf_kl_threshold: 1.1e-2
+    hf_kl_threshold: 5e-3
     source_load_kl_threshold: 5e-3
     source_load_cosine_threshold: 0.9995
     tokenizer_name: baidu/ERNIE-4.5-21B-A3B-PT

--- a/nemo_automodel/components/distributed/parallelizer_utils.py
+++ b/nemo_automodel/components/distributed/parallelizer_utils.py
@@ -99,11 +99,15 @@ def iter_maximal_uniform_dtype_subtrees(
 def _group_params_by_dtype(
     layer: nn.Module,
     dtype_of: Optional[Callable[[torch.Tensor], torch.dtype]] = None,
+    ignored_params: Optional[Set[nn.Parameter]] = None,
 ) -> Dict[torch.dtype, List[nn.Parameter]]:
     if dtype_of is None:
         dtype_of = lambda t: t.dtype
+    ignored_param_ids = {id(param) for param in ignored_params or ()}
     ans: Dict[torch.dtype, List[nn.Parameter]] = {}
     for name, param in layer.named_parameters():
+        if id(param) in ignored_param_ids:
+            continue
         dtype = dtype_of(param)
         if dtype not in ans:
             ans[dtype] = []
@@ -123,19 +127,59 @@ def _fully_shard(
     mp_policy: Optional[MixedPrecisionPolicy],
     offload_policy: Optional[OffloadPolicy],
     reshard_after_forward: bool | int | None = None,
+    ignored_params: Optional[Set[nn.Parameter]] = None,
+    fully_shard_fn: Optional[Callable[..., object]] = None,
 ) -> None:
     if isinstance(module, nn.ModuleList):
         for layer in module:
-            _fully_shard(layer, mesh, mp_policy, offload_policy, reshard_after_forward)
+            _fully_shard(
+                layer,
+                mesh,
+                mp_policy,
+                offload_policy,
+                reshard_after_forward,
+                ignored_params,
+                fully_shard_fn,
+            )
     else:
-        kwargs = {
-            "mesh": mesh,
-            "mp_policy": mp_policy,
-            "offload_policy": offload_policy,
-        }
-        if reshard_after_forward is not None:
-            kwargs["reshard_after_forward"] = reshard_after_forward
-        fully_shard(module, **kwargs)
+        _call_fully_shard(
+            module,
+            mesh,
+            mp_policy,
+            offload_policy,
+            reshard_after_forward,
+            ignored_params,
+            fully_shard_fn,
+        )
+
+
+def _call_fully_shard(
+    module: nn.Module,
+    mesh: DeviceMesh,
+    mp_policy: Optional[MixedPrecisionPolicy],
+    offload_policy: Optional[OffloadPolicy],
+    reshard_after_forward: bool | int | None = None,
+    ignored_params: Optional[Set[nn.Parameter]] = None,
+    fully_shard_fn: Optional[Callable[..., object]] = None,
+) -> None:
+    if fully_shard_fn is None:
+        fully_shard_fn = fully_shard
+
+    kwargs = {
+        "mesh": mesh,
+        "mp_policy": mp_policy,
+        "offload_policy": offload_policy,
+    }
+    if reshard_after_forward is not None:
+        kwargs["reshard_after_forward"] = reshard_after_forward
+
+    if ignored_params:
+        module_param_ids = {id(param) for param in module.parameters()}
+        module_ignored_params = {param for param in ignored_params if id(param) in module_param_ids}
+        if module_ignored_params:
+            kwargs["ignored_params"] = module_ignored_params
+
+    fully_shard_fn(module, **kwargs)
 
 
 def _mp_policy_with_param_dtype(
@@ -153,6 +197,7 @@ def _make_compute_dtype_fn(
     module: nn.Module,
     mp_policy: Optional[MixedPrecisionPolicy],
     fp32_compute_module_names: Tuple[str, ...],
+    ignored_params: Optional[Set[nn.Parameter]] = None,
 ) -> Callable[[torch.Tensor], torch.dtype]:
     """Build the per-parameter *compute* dtype resolver used to group FSDP units.
 
@@ -184,13 +229,18 @@ def _make_compute_dtype_fn(
     # The policy fallback only represents "fp32 master weights -> compute in policy
     # dtype" when the module's floating storage is uniform. If storage is already
     # mixed, unhinted params keep their storage dtype instead (see precedence above).
-    floating_storage_dtypes = {t.dtype for t in (*module.parameters(), *module.buffers()) if t.dtype.is_floating_point}
+    ignored_param_ids = {id(param) for param in ignored_params or ()}
+    floating_storage_dtypes = {
+        tensor.dtype
+        for tensor in (*module.parameters(), *module.buffers())
+        if id(tensor) not in ignored_param_ids and tensor.dtype.is_floating_point
+    }
     storage_is_uniform = len(floating_storage_dtypes) <= 1
 
     pinned_ids: Set[int] = set()
     if fp32_compute_module_names:
         for name, tensor in (*module.named_parameters(), *module.named_buffers()):
-            if any(token in name for token in fp32_compute_module_names):
+            if id(tensor) not in ignored_param_ids and any(token in name for token in fp32_compute_module_names):
                 pinned_ids.add(id(tensor))
 
     def compute_dtype_of(t: torch.Tensor) -> torch.dtype:
@@ -215,6 +265,8 @@ def fully_shard_by_dtype(
     offload_policy: Optional[OffloadPolicy],
     fp32_compute_module_names: Tuple[str, ...] = (),
     reshard_after_forward: bool | int | None = None,
+    ignored_params: Optional[Set[nn.Parameter]] = None,
+    fully_shard_fn: Optional[Callable[..., object]] = None,
 ) -> None:
     """Fully shard a module so every parameter computes in its required dtype.
 
@@ -241,8 +293,20 @@ def fully_shard_by_dtype(
             Sourced from the model's ``_keep_in_fp32_modules_strict``.
         reshard_after_forward: Optional FSDP2 reshard override for this module.
             ``None`` leaves the caller's default FSDP2 behavior unchanged.
+        ignored_params: Parameters already owned by another FSDP or parallelism
+            unit. They are excluded from dtype grouping and forwarded to the
+            enclosing FSDP unit.
+        fully_shard_fn: Optional model-specific replacement for ``fully_shard``.
+            Every FSDP unit created by this function uses this callback.
     """
-    compute_dtype_of = _make_compute_dtype_fn(module, mp_policy, fp32_compute_module_names)
+    ignored_params = set(ignored_params or ())
+    ignored_param_ids = {id(param) for param in ignored_params}
+    compute_dtype_of = _make_compute_dtype_fn(
+        module,
+        mp_policy,
+        fp32_compute_module_names,
+        ignored_params=ignored_params,
+    )
 
     # FSDP2 requires every param group to be uniform in *storage* (original) dtype
     # -- ``_init_mp_dtypes`` asserts ``{p.orig_dtype}`` is a singleton -- while a group's
@@ -255,42 +319,98 @@ def fully_shard_by_dtype(
 
     # calling _group_params_by_dtype is not optimal here, because we may
     # end up with two traversals over the module, but this code is not in the hot path.
-    grouped_params = _group_params_by_dtype(module, dtype_of=group_key_of)
+    grouped_params = _group_params_by_dtype(
+        module,
+        dtype_of=group_key_of,
+        ignored_params=ignored_params,
+    )
     if len(grouped_params) == 0:
+        if ignored_params:
+            _call_fully_shard(
+                module,
+                mesh,
+                mp_policy,
+                offload_policy,
+                reshard_after_forward,
+                ignored_params,
+                fully_shard_fn,
+            )
         return
     elif len(grouped_params) == 1:
         key = next(iter(grouped_params))
-        kwargs = {
-            "mesh": mesh,
-            "mp_policy": _mp_policy_with_param_dtype(mp_policy, key[1]),
-            "offload_policy": offload_policy,
-        }
-        if reshard_after_forward is not None:
-            kwargs["reshard_after_forward"] = reshard_after_forward
-        fully_shard(module, **kwargs)
+        _call_fully_shard(
+            module,
+            mesh,
+            _mp_policy_with_param_dtype(mp_policy, key[1]),
+            offload_policy,
+            reshard_after_forward,
+            ignored_params,
+            fully_shard_fn,
+        )
     else:
         least_items_key = min(grouped_params.items(), key=lambda x: len(x[1]))[0]
-        for path, mod, key in iter_maximal_uniform_dtype_subtrees(
-            module,
-            tensor_pred=torch.is_floating_point,
-            dtype_of=group_key_of,
-            return_paths=True,
-        ):
-            if (len(grouped_params) == 2 and key == least_items_key) or len(grouped_params) > 2:
-                _fully_shard(
-                    _get_module_from_path(module, path),
-                    mesh=mesh,
-                    mp_policy=_mp_policy_with_param_dtype(mp_policy, key[1]),
-                    offload_policy=offload_policy,
-                    reshard_after_forward=reshard_after_forward,
-                )
+        uniform_subtrees = list(
+            iter_maximal_uniform_dtype_subtrees(
+                module,
+                tensor_pred=lambda tensor: torch.is_floating_point(tensor) and id(tensor) not in ignored_param_ids,
+                dtype_of=group_key_of,
+                return_paths=True,
+            )
+        )
+        selected_subtrees = [
+            (path, mod, key)
+            for path, mod, key in uniform_subtrees
+            if (len(grouped_params) == 2 and key == least_items_key) or len(grouped_params) > 2
+        ]
+
+        expected_keys = {least_items_key} if len(grouped_params) == 2 else set(grouped_params)
+        expected_param_ids = {id(param) for key in expected_keys for param in grouped_params[key]}
+        covered_param_ids = {
+            id(param)
+            for _, subtree, _ in selected_subtrees
+            for param in subtree.parameters()
+            if id(param) not in ignored_param_ids
+        }
+        unresolved_param_ids = expected_param_ids - covered_param_ids
+        if unresolved_param_ids:
+            unresolved_names = [name for name, param in module.named_parameters() if id(param) in unresolved_param_ids]
+            raise ValueError(
+                "FSDP could not isolate parameters with a distinct dtype from siblings in the same module: "
+                f"{', '.join(unresolved_names)}. Place them in a dedicated parameter-owning module."
+            )
+
+        for path, _, key in selected_subtrees:
+            subtree_kwargs = {
+                "mesh": mesh,
+                "mp_policy": _mp_policy_with_param_dtype(mp_policy, key[1]),
+                "offload_policy": offload_policy,
+                "reshard_after_forward": reshard_after_forward,
+            }
+            if ignored_params:
+                subtree_kwargs["ignored_params"] = ignored_params
+            if fully_shard_fn is not None:
+                subtree_kwargs["fully_shard_fn"] = fully_shard_fn
+            _fully_shard(_get_module_from_path(module, path), **subtree_kwargs)
         if len(grouped_params) == 2:
             parent_key = next(key for key in grouped_params if key != least_items_key)
-            kwargs = {
-                "mesh": mesh,
-                "mp_policy": _mp_policy_with_param_dtype(mp_policy, parent_key[1]),
-                "offload_policy": offload_policy,
-            }
-            if reshard_after_forward is not None:
-                kwargs["reshard_after_forward"] = reshard_after_forward
-            fully_shard(module, **kwargs)
+            _call_fully_shard(
+                module,
+                mesh,
+                _mp_policy_with_param_dtype(mp_policy, parent_key[1]),
+                offload_policy,
+                reshard_after_forward,
+                ignored_params,
+                fully_shard_fn,
+            )
+        elif ignored_params:
+            # Preserve the caller's FSDP ownership boundary after every managed
+            # parameter has been assigned to a dtype-specific child unit.
+            _call_fully_shard(
+                module,
+                mesh,
+                mp_policy,
+                offload_policy,
+                reshard_after_forward,
+                ignored_params,
+                fully_shard_fn,
+            )

--- a/nemo_automodel/components/distributed/parallelizer_utils.py
+++ b/nemo_automodel/components/distributed/parallelizer_utils.py
@@ -99,7 +99,7 @@ def iter_maximal_uniform_dtype_subtrees(
 def _group_params_by_dtype(
     layer: nn.Module,
     dtype_of: Optional[Callable[[torch.Tensor], torch.dtype]] = None,
-    ignored_params: Optional[Set[nn.Parameter]] = None,
+    ignored_params: set[nn.Parameter] | None = None,
 ) -> Dict[torch.dtype, List[nn.Parameter]]:
     if dtype_of is None:
         dtype_of = lambda t: t.dtype
@@ -127,8 +127,8 @@ def _fully_shard(
     mp_policy: Optional[MixedPrecisionPolicy],
     offload_policy: Optional[OffloadPolicy],
     reshard_after_forward: bool | int | None = None,
-    ignored_params: Optional[Set[nn.Parameter]] = None,
-    fully_shard_fn: Optional[Callable[..., object]] = None,
+    ignored_params: set[nn.Parameter] | None = None,
+    fully_shard_fn: Callable[..., None] | None = None,
 ) -> None:
     if isinstance(module, nn.ModuleList):
         for layer in module:
@@ -159,8 +159,8 @@ def _call_fully_shard(
     mp_policy: Optional[MixedPrecisionPolicy],
     offload_policy: Optional[OffloadPolicy],
     reshard_after_forward: bool | int | None = None,
-    ignored_params: Optional[Set[nn.Parameter]] = None,
-    fully_shard_fn: Optional[Callable[..., object]] = None,
+    ignored_params: set[nn.Parameter] | None = None,
+    fully_shard_fn: Callable[..., None] | None = None,
 ) -> None:
     if fully_shard_fn is None:
         fully_shard_fn = fully_shard
@@ -190,6 +190,10 @@ def _mp_policy_with_param_dtype(
         return None
     mp_policy_copy = copy(mp_policy)
     object.__setattr__(mp_policy_copy, "param_dtype", param_dtype)
+    if param_dtype == torch.float32:
+        object.__setattr__(mp_policy_copy, "reduce_dtype", torch.float32)
+        object.__setattr__(mp_policy_copy, "output_dtype", torch.float32)
+        object.__setattr__(mp_policy_copy, "cast_forward_inputs", False)
     return mp_policy_copy
 
 
@@ -197,7 +201,7 @@ def _make_compute_dtype_fn(
     module: nn.Module,
     mp_policy: Optional[MixedPrecisionPolicy],
     fp32_compute_module_names: Tuple[str, ...],
-    ignored_params: Optional[Set[nn.Parameter]] = None,
+    ignored_params: set[nn.Parameter] | None = None,
 ) -> Callable[[torch.Tensor], torch.dtype]:
     """Build the per-parameter *compute* dtype resolver used to group FSDP units.
 
@@ -265,8 +269,8 @@ def fully_shard_by_dtype(
     offload_policy: Optional[OffloadPolicy],
     fp32_compute_module_names: Tuple[str, ...] = (),
     reshard_after_forward: bool | int | None = None,
-    ignored_params: Optional[Set[nn.Parameter]] = None,
-    fully_shard_fn: Optional[Callable[..., object]] = None,
+    ignored_params: set[nn.Parameter] | None = None,
+    fully_shard_fn: Callable[..., None] | None = None,
 ) -> None:
     """Fully shard a module so every parameter computes in its required dtype.
 
@@ -358,8 +362,8 @@ def fully_shard_by_dtype(
             )
         )
         selected_subtrees = [
-            (path, mod, key)
-            for path, mod, key in uniform_subtrees
+            (path, key, subtree)
+            for path, subtree, key in uniform_subtrees
             if (len(grouped_params) == 2 and key == least_items_key) or len(grouped_params) > 2
         ]
 
@@ -367,7 +371,7 @@ def fully_shard_by_dtype(
         expected_param_ids = {id(param) for key in expected_keys for param in grouped_params[key]}
         covered_param_ids = {
             id(param)
-            for _, subtree, _ in selected_subtrees
+            for _, _, subtree in selected_subtrees
             for param in subtree.parameters()
             if id(param) not in ignored_param_ids
         }
@@ -379,7 +383,7 @@ def fully_shard_by_dtype(
                 f"{', '.join(unresolved_names)}. Place them in a dedicated parameter-owning module."
             )
 
-        for path, _, key in selected_subtrees:
+        for path, key, _ in selected_subtrees:
             subtree_kwargs = {
                 "mesh": mesh,
                 "mp_policy": _mp_policy_with_param_dtype(mp_policy, key[1]),

--- a/nemo_automodel/components/distributed/parallelizer_utils.py
+++ b/nemo_automodel/components/distributed/parallelizer_utils.py
@@ -193,6 +193,9 @@ def _mp_policy_with_param_dtype(
     if param_dtype == torch.float32:
         object.__setattr__(mp_policy_copy, "reduce_dtype", torch.float32)
         object.__setattr__(mp_policy_copy, "output_dtype", torch.float32)
+        # FP32 compute modules own any required input cast. Casting at the nested
+        # FSDP boundary changes the module-visible input dtype and can make an
+        # activation-checkpoint recompute disagree with the original forward.
         object.__setattr__(mp_policy_copy, "cast_forward_inputs", False)
     return mp_policy_copy
 
@@ -294,7 +297,9 @@ def fully_shard_by_dtype(
     Args:
         fp32_compute_module_names: Parameter/buffer name substrings that must compute in
             fp32 (e.g. ``("_fp32_params",)`` for Qwen3.5's GatedDeltaNet fp32 holder).
-            Sourced from the model's ``_keep_in_fp32_modules_strict``.
+            Sourced from the model's ``_keep_in_fp32_modules_strict``. Matched callable
+            modules must cast their own inputs when required; their nested FP32 FSDP
+            units preserve the parent activation dtype at the module boundary.
         reshard_after_forward: Optional FSDP2 reshard override for this module.
             ``None`` leaves the caller's default FSDP2 behavior unchanged.
         ignored_params: Parameters already owned by another FSDP or parallelism

--- a/nemo_automodel/components/models/ernie4_5/model.py
+++ b/nemo_automodel/components/models/ernie4_5/model.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import Any, Optional, Union
 
 import torch
@@ -328,12 +329,12 @@ class Ernie4_5_MoeModel(nn.Module):
     ):
         super().__init__()
         self.config = config
-        self.backend = backend
         # HF disables autocast for ERNIE's router projection and computes the
         # routing probabilities in fp32. Keep the same default while preserving
         # an explicit backend override.
-        if self.backend.gate_precision is None:
-            self.backend.gate_precision = torch.float32
+        if backend.gate_precision is None:
+            backend = replace(backend, gate_precision=torch.float32)
+        self.backend = backend
         if moe_config is not None and moe_overrides is not None:
             raise ValueError("Cannot pass both moe_config and moe_overrides; use one or the other.")
 
@@ -536,6 +537,7 @@ class Ernie4_5_MoeForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin)
     _tp_plan = {"lm_head": "colwise_rep"}
     _pp_plan = {"lm_head": (["hidden_states"], ["logits"])}
     _keep_in_fp32_modules_strict = ["mlp.gate.weight", "mlp.gate.e_score_correction_bias"]
+    _keep_in_fp32_modules = ["rotary_emb"]
 
     @classmethod
     def get_capabilities(cls, config) -> ModelCapabilities:

--- a/nemo_automodel/components/models/ernie4_5/model.py
+++ b/nemo_automodel/components/models/ernie4_5/model.py
@@ -39,6 +39,7 @@ from nemo_automodel.components.models.common.tie_word_embeddings import (
     TieSupport,
     reject_unsupported_tie_word_embeddings,
 )
+from nemo_automodel.components.models.common.utils import cast_model_to_dtype
 from nemo_automodel.components.models.ernie4_5.rope_utils import Ernie4_5RotaryEmbedding, apply_rotary_pos_emb
 from nemo_automodel.components.models.ernie4_5.state_dict_adapter import (
     Ernie4_5_MoeStateDictAdapter,
@@ -328,6 +329,11 @@ class Ernie4_5_MoeModel(nn.Module):
         super().__init__()
         self.config = config
         self.backend = backend
+        # HF disables autocast for ERNIE's router projection and computes the
+        # routing probabilities in fp32. Keep the same default while preserving
+        # an explicit backend override.
+        if self.backend.gate_precision is None:
+            self.backend.gate_precision = torch.float32
         if moe_config is not None and moe_overrides is not None:
             raise ValueError("Cannot pass both moe_config and moe_overrides; use one or the other.")
 
@@ -529,6 +535,7 @@ class Ernie4_5_MoeForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin)
     _nemo_tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
     _tp_plan = {"lm_head": "colwise_rep"}
     _pp_plan = {"lm_head": (["hidden_states"], ["logits"])}
+    _keep_in_fp32_modules_strict = ["mlp.gate.weight", "mlp.gate.e_score_correction_bias"]
 
     @classmethod
     def get_capabilities(cls, config) -> ModelCapabilities:
@@ -597,6 +604,7 @@ class Ernie4_5_MoeForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin)
         )
         if getattr(config, "tie_word_embeddings", True):
             self.lm_head.weight = self.model.embed_tokens.weight
+        cast_model_to_dtype(self, _config_dtype(config))
         if self.backend.enable_hf_state_dict_adapter:
             self.state_dict_adapter = Ernie4_5_MoeStateDictAdapter(
                 self.config,

--- a/nemo_automodel/components/models/qwen3_5_moe/model.py
+++ b/nemo_automodel/components/models/qwen3_5_moe/model.py
@@ -1244,8 +1244,8 @@ class Qwen3_5MoeForConditionalGeneration(HFCheckpointingMixin, HFQwen3_5MoeForCo
 
         # Skip the SSM-gating holders so they keep fp32 storage (master weights):
         # cast_model_to_dtype cannot reliably restore fp32 once FSDP2-sharded, so it
-        # detaches them and never casts them. Each holder is its own fp32 FSDP group
-        # (moe/parallelizer._shard_fp32_param_holders), so this is dtype-uniform-safe.
+        # detaches them and never casts them. The MoE parallelizer's dtype-aware
+        # sharder places each holder in its own fp32 FSDP group.
         cast_model_to_dtype(self, dtype, skip_modules=("_fp32_params",))
 
         with buffer_device:

--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -32,6 +32,7 @@ from torch.distributed.tensor import Shard, distribute_module, distribute_tensor
 from torch.distributed.tensor.parallel import ParallelStyle, parallelize_module
 from torch.utils.checkpoint import CheckpointPolicy, create_selective_checkpoint_contexts
 
+from nemo_automodel.components.distributed import parallelizer_utils
 from nemo_automodel.components.distributed.pipelining.hf_utils import get_text_module
 from nemo_automodel.components.moe.experts import GroupedExpertsDeepEP, GroupedExpertsTE
 from nemo_automodel.components.moe.layers import (
@@ -596,44 +597,6 @@ def apply_ac(
     _apply_multimodal_tower_ac(model, scopes)
 
 
-def _shard_fp32_param_holders(block, fsdp_mesh, reshard_after_forward, offload_policy):
-    """Shard each ``_fp32_params`` holder in ``block`` as its own fp32 FSDP unit.
-
-    Model implementations own the architecture-specific decision to create these
-    holders (for example Qwen3.5/Qwen3-Next GatedDeltaNet ``A_log``/``dt_bias``).
-    FSDP only treats the holder as a dtype-uniform fp32 unit and excludes its params
-    from the block's bf16 FSDP unit.
-
-    Returns the set of holder parameters to exclude from the block's FSDP wrap.
-    Blocks that do not expose ``named_modules`` (e.g. non-``nn.Module`` test
-    stubs) cannot hold fp32 holders, so an empty set is returned.
-    """
-    if not hasattr(block, "named_modules"):
-        return set()
-    fp32_mp_policy = MixedPrecisionPolicy(
-        param_dtype=torch.float32,
-        reduce_dtype=torch.float32,
-        output_dtype=torch.float32,
-        cast_forward_inputs=False,
-    )
-    ignored: set = set()
-    for name, sub in block.named_modules():
-        if not name.endswith("_fp32_params"):
-            continue
-        holder_params = list(sub.parameters(recurse=False))
-        if not holder_params:
-            continue
-        fully_shard(
-            sub,
-            mesh=fsdp_mesh,
-            reshard_after_forward=reshard_after_forward,
-            mp_policy=fp32_mp_policy,
-            offload_policy=offload_policy,
-        )
-        ignored.update(holder_params)
-    return ignored
-
-
 def apply_fsdp(
     model: torch.nn.Module,
     fsdp_mesh: DeviceMesh,
@@ -664,6 +627,7 @@ def apply_fsdp(
             output_dtype=torch.bfloat16,
             cast_forward_inputs=True,
         )
+    fp32_compute_module_names = tuple(getattr(model, "_keep_in_fp32_modules_strict", None) or ())
 
     fully_shard_impl = fully_shard
     if _is_deepseek_v4_model(model):
@@ -759,12 +723,18 @@ def apply_fsdp(
         if isinstance(moe_module, MoE) and ep_enabled:
             ignored_params = set(moe_module.experts.parameters())
 
-        # Shard model-owned fp32 holders on their own and exclude their params from
-        # the block's FSDP unit to keep the block dtype-uniform.
-        fp32_ignored = _shard_fp32_param_holders(block, fsdp_mesh, reshard_after_forward, offload_policy)
-        if fp32_ignored:
-            ignored_params = (ignored_params or set()) | fp32_ignored
-        fully_shard_default(block, ignored_params=ignored_params)
+        # Reuse the dense dtype-aware path for model-owned fp32 contracts while
+        # leaving EP-owned experts out of the block's dtype and FSDP ownership.
+        parallelizer_utils.fully_shard_by_dtype(
+            block,
+            mesh=fsdp_mesh,
+            mp_policy=mp_policy,
+            offload_policy=offload_policy,
+            fp32_compute_module_names=fp32_compute_module_names,
+            reshard_after_forward=reshard_after_forward,
+            ignored_params=ignored_params,
+            fully_shard_fn=fully_shard_impl,
+        )
 
     # Re-establish weight tying before detecting it: a device/dtype move during
     # from_pretrained (HF replaces param tensors) can silently break a tie set in

--- a/tests/functional_tests/moe/test_ernie_fp32_router_fsdp.py
+++ b/tests/functional_tests/moe/test_ernie_fp32_router_fsdp.py
@@ -23,6 +23,7 @@ import pytest
 import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
+import torch.nn.functional as F
 from transformers.models.ernie4_5_moe.configuration_ernie4_5_moe import Ernie4_5_MoeConfig
 
 from nemo_automodel.components.distributed.config import FSDP2Config
@@ -94,6 +95,21 @@ def _worker(rank: int, port: int) -> None:
                 if parameter.is_floating_point():
                     parameter.normal_(mean=0.0, std=0.02)
 
+        moe = model.model.layers["1"].mlp
+        router_input = torch.randn(8, model.config.hidden_size, device=rank, dtype=torch.bfloat16)
+        token_mask = torch.ones(router_input.shape[0], device=rank, dtype=torch.bool)
+        with torch.no_grad():
+            reference_scores = F.linear(router_input.float(), moe.gate.weight)
+            reference_probabilities = reference_scores.softmax(dim=-1)
+            reference_choice_scores = reference_probabilities + moe.gate.e_score_correction_bias
+            reference_indices = reference_choice_scores.topk(moe.gate.topk, dim=-1).indices
+            reference_weights = reference_probabilities.gather(1, reference_indices)
+            reference_weights /= reference_weights.sum(dim=-1, keepdim=True) + 1e-20
+            reference_weights = reference_weights.to(torch.bfloat16)
+            actual_weights, actual_indices, _ = moe.gate(router_input, token_mask, cp_mesh=None)
+        torch.testing.assert_close(actual_indices, reference_indices, rtol=0, atol=0)
+        torch.testing.assert_close(actual_weights, reference_weights, rtol=0, atol=0)
+
         mesh_context = MeshContext.build(
             FSDP2Config(),
             ParallelismSizes(dp_size=_WORLD_SIZE, ep_size=_WORLD_SIZE),
@@ -107,7 +123,6 @@ def _worker(rank: int, port: int) -> None:
             **mesh_context.parallelize_axis_kwargs(),
         )
 
-        moe = model.model.layers["1"].mlp
         assert moe.gate.weight.dtype == torch.float32
         assert moe.gate.e_score_correction_bias.dtype == torch.float32
         assert moe.experts.gate_and_up_projs.dtype == torch.bfloat16

--- a/tests/functional_tests/moe/test_ernie_fp32_router_fsdp.py
+++ b/tests/functional_tests/moe/test_ernie_fp32_router_fsdp.py
@@ -1,0 +1,134 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Two-rank regression for ERNIE's strict-fp32 router under EP and FSDP2."""
+
+from __future__ import annotations
+
+import os
+import socket
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from transformers.models.ernie4_5_moe.configuration_ernie4_5_moe import Ernie4_5_MoeConfig
+
+from nemo_automodel.components.distributed.config import FSDP2Config
+from nemo_automodel.components.distributed.mesh import MeshContext, ParallelismSizes
+from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.models.ernie4_5.model import Ernie4_5_MoeForCausalLM
+from nemo_automodel.components.moe.parallelizer import parallelize_model
+
+_WORLD_SIZE = 2
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _tiny_config() -> Ernie4_5_MoeConfig:
+    return Ernie4_5_MoeConfig(
+        vocab_size=64,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        max_position_embeddings=64,
+        rms_norm_eps=1e-6,
+        rope_theta=10000.0,
+        use_bias=False,
+        tie_word_embeddings=True,
+        pad_token_id=0,
+        moe_intermediate_size=16,
+        moe_k=2,
+        moe_num_experts=4,
+        moe_num_shared_experts=0,
+        moe_layer_start_index=1,
+        moe_layer_end_index=1,
+        moe_layer_interval=1,
+        router_aux_loss_coef=0.0,
+        torch_dtype=torch.bfloat16,
+    )
+
+
+def _worker(rank: int, port: int) -> None:
+    try:
+        os.environ["MASTER_ADDR"] = "127.0.0.1"
+        os.environ["MASTER_PORT"] = str(port)
+        os.environ["RANK"] = str(rank)
+        os.environ["WORLD_SIZE"] = str(_WORLD_SIZE)
+        torch.cuda.set_device(rank)
+        dist.init_process_group("nccl", rank=rank, world_size=_WORLD_SIZE)
+
+        torch.manual_seed(1234)
+        model = Ernie4_5_MoeForCausalLM(
+            _tiny_config(),
+            backend=BackendConfig(
+                attn="sdpa",
+                linear="torch",
+                rms_norm="torch",
+                experts="torch",
+                dispatcher="torch",
+                rope_fusion=False,
+                enable_hf_state_dict_adapter=False,
+            ),
+        ).cuda(rank)
+        with torch.no_grad():
+            for parameter in model.parameters():
+                if parameter.is_floating_point():
+                    parameter.normal_(mean=0.0, std=0.02)
+
+        mesh_context = MeshContext.build(
+            FSDP2Config(),
+            ParallelismSizes(dp_size=_WORLD_SIZE, ep_size=_WORLD_SIZE),
+            world_size=_WORLD_SIZE,
+        )
+        parallelize_model(
+            model,
+            mesh_context.device_mesh,
+            mesh_context.moe_mesh,
+            activation_checkpointing=True,
+            **mesh_context.parallelize_axis_kwargs(),
+        )
+
+        moe = model.model.layers["1"].mlp
+        assert moe.gate.weight.dtype == torch.float32
+        assert moe.gate.e_score_correction_bias.dtype == torch.float32
+        assert moe.experts.gate_and_up_projs.dtype == torch.bfloat16
+
+        input_ids = torch.tensor([[1, 2, 3, 4]], device=rank)
+        logits = model(input_ids).logits
+        loss = logits.float().square().mean()
+        assert torch.isfinite(loss)
+        loss.backward()
+
+        assert moe.gate.weight.grad is not None
+        assert moe.gate.weight.grad.dtype == torch.float32
+        assert torch.isfinite(moe.gate.weight.grad.to_local()).all()
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.device_count() < _WORLD_SIZE,
+    reason="requires two CUDA devices",
+)
+def test_ernie_router_stays_fp32_through_ep_fsdp_forward_backward():
+    mp.spawn(_worker, args=(_free_port(),), nprocs=_WORLD_SIZE, join=True)

--- a/tests/functional_tests/moe/test_ernie_fp32_router_fsdp.py
+++ b/tests/functional_tests/moe/test_ernie_fp32_router_fsdp.py
@@ -127,6 +127,11 @@ def _worker(rank: int, port: int) -> None:
         assert moe.gate.e_score_correction_bias.dtype == torch.float32
         assert moe.experts.gate_and_up_projs.dtype == torch.bfloat16
 
+        with torch.no_grad():
+            sharded_weights, sharded_indices, _ = moe.gate(router_input, token_mask, cp_mesh=None)
+        torch.testing.assert_close(sharded_indices, reference_indices, rtol=0, atol=0)
+        torch.testing.assert_close(sharded_weights, reference_weights, rtol=0, atol=0)
+
         input_ids = torch.tensor([[1, 2, 3, 4]], device=rank)
         logits = model(input_ids).logits
         loss = logits.float().square().mean()

--- a/tests/functional_tests/moe/test_ernie_fp32_router_fsdp.py
+++ b/tests/functional_tests/moe/test_ernie_fp32_router_fsdp.py
@@ -24,6 +24,7 @@ import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
 import torch.nn.functional as F
+from torch.distributed.tensor import DTensor
 from transformers.models.ernie4_5_moe.configuration_ernie4_5_moe import Ernie4_5_MoeConfig
 
 from nemo_automodel.components.distributed.config import FSDP2Config
@@ -110,6 +111,8 @@ def _worker(rank: int, port: int) -> None:
         torch.testing.assert_close(actual_indices, reference_indices, rtol=0, atol=0)
         torch.testing.assert_close(actual_weights, reference_weights, rtol=0, atol=0)
 
+        reference_gate_weight = moe.gate.weight.detach().clone()
+        reference_correction_bias = moe.gate.e_score_correction_bias.detach().clone()
         mesh_context = MeshContext.build(
             FSDP2Config(),
             ParallelismSizes(dp_size=_WORLD_SIZE, ep_size=_WORLD_SIZE),
@@ -127,13 +130,43 @@ def _worker(rank: int, port: int) -> None:
         assert moe.gate.e_score_correction_bias.dtype == torch.float32
         assert moe.experts.gate_and_up_projs.dtype == torch.bfloat16
 
-        with torch.no_grad():
-            sharded_weights, sharded_indices, _ = moe.gate(router_input, token_mask, cp_mesh=None)
-        torch.testing.assert_close(sharded_indices, reference_indices, rtol=0, atol=0)
-        torch.testing.assert_close(sharded_weights, reference_weights, rtol=0, atol=0)
+        gate_observation: dict[str, torch.Tensor] = {}
+
+        def capture_gate_io(_module, inputs, output) -> None:
+            gate_input = inputs[0]
+            gate_weights, gate_indices, _ = output
+            gate_observation["input"] = gate_input.detach().clone()
+            gate_observation["weights"] = gate_weights.detach().clone()
+            gate_observation["indices"] = gate_indices.detach().clone()
 
         input_ids = torch.tensor([[1, 2, 3, 4]], device=rank)
-        logits = model(input_ids).logits
+        gate_hook = moe.gate.register_forward_hook(capture_gate_io)
+        try:
+            logits = model(input_ids).logits
+        finally:
+            gate_hook.remove()
+
+        captured_input = gate_observation["input"]
+        captured_weights = gate_observation["weights"]
+        captured_indices = gate_observation["indices"]
+        if isinstance(captured_input, DTensor):
+            captured_input = captured_input.to_local()
+        if isinstance(captured_weights, DTensor):
+            captured_weights = captured_weights.to_local()
+        if isinstance(captured_indices, DTensor):
+            captured_indices = captured_indices.to_local()
+
+        with torch.no_grad():
+            sharded_reference_scores = F.linear(captured_input.float(), reference_gate_weight)
+            sharded_reference_probabilities = sharded_reference_scores.softmax(dim=-1)
+            sharded_reference_choice_scores = sharded_reference_probabilities + reference_correction_bias
+            sharded_reference_indices = sharded_reference_choice_scores.topk(moe.gate.topk, dim=-1).indices
+            sharded_reference_weights = sharded_reference_probabilities.gather(1, sharded_reference_indices)
+            sharded_reference_weights /= sharded_reference_weights.sum(dim=-1, keepdim=True) + 1e-20
+            sharded_reference_weights = sharded_reference_weights.to(torch.bfloat16)
+        torch.testing.assert_close(captured_indices, sharded_reference_indices, rtol=0, atol=0)
+        torch.testing.assert_close(captured_weights, sharded_reference_weights, rtol=0, atol=0)
+
         loss = logits.float().square().mean()
         assert torch.isfinite(loss)
         loss.backward()

--- a/tests/unit_tests/distributed/test_parallelizer_utils.py
+++ b/tests/unit_tests/distributed/test_parallelizer_utils.py
@@ -228,9 +228,27 @@ def test_mp_policy_with_param_dtype_copies_policy():
 
     assert copied_policy is not mp_policy
     assert copied_policy.param_dtype == torch.float32
-    assert copied_policy.reduce_dtype == mp_policy.reduce_dtype
-    assert copied_policy.output_dtype == mp_policy.output_dtype
+    assert copied_policy.reduce_dtype == torch.float32
+    assert copied_policy.output_dtype == torch.float32
+    assert copied_policy.cast_forward_inputs is False
     assert mp_policy.param_dtype == torch.bfloat16
+
+
+def test_mp_policy_with_bf16_param_dtype_preserves_policy():
+    mp_policy = MixedPrecisionPolicy(
+        param_dtype=torch.float32,
+        reduce_dtype=torch.float32,
+        output_dtype=torch.bfloat16,
+        cast_forward_inputs=True,
+    )
+
+    copied_policy = _mp_policy_with_param_dtype(mp_policy, torch.bfloat16)
+
+    assert copied_policy is not mp_policy
+    assert copied_policy.param_dtype == torch.bfloat16
+    assert copied_policy.reduce_dtype == torch.float32
+    assert copied_policy.output_dtype == torch.bfloat16
+    assert copied_policy.cast_forward_inputs is True
 
 
 def test_fully_shard_by_dtype_no_params(monkeypatch):
@@ -592,6 +610,48 @@ def test_fully_shard_by_dtype_excludes_ep_params_and_uses_custom_sharder():
     assert calls[1][1]["mp_policy"].param_dtype == torch.bfloat16
     assert calls[1][1]["ignored_params"] == expert_params
     assert all(module is not block.experts for module, _ in calls)
+
+
+def test_fully_shard_by_dtype_fp32_holder_uses_full_fp32_policy():
+    """Callable fp32 holders keep fp32 inputs, reductions, and outputs under FSDP."""
+
+    class Fp32Holder(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = nn.Parameter(torch.zeros(4, dtype=torch.float32))
+
+        def forward(self, value: torch.Tensor) -> torch.Tensor:
+            return value.float() * self.weight
+
+    class HybridBlock(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.input_projection = nn.Linear(4, 4, bias=False).to(torch.bfloat16)
+            self.output_projection = nn.Linear(4, 4, bias=False).to(torch.bfloat16)
+            self._fp32_params = Fp32Holder()
+
+    block = HybridBlock()
+    calls: list[tuple[nn.Module, dict]] = []
+
+    fully_shard_by_dtype(
+        block,
+        mesh=object(),
+        mp_policy=MixedPrecisionPolicy(
+            param_dtype=torch.bfloat16,
+            reduce_dtype=torch.bfloat16,
+            output_dtype=torch.bfloat16,
+            cast_forward_inputs=True,
+        ),
+        offload_policy=object(),
+        fp32_compute_module_names=("_fp32_params",),
+        fully_shard_fn=lambda module, **kwargs: calls.append((module, kwargs)),
+    )
+
+    holder_policy = next(kwargs["mp_policy"] for module, kwargs in calls if module is block._fp32_params)
+    assert holder_policy.param_dtype == torch.float32
+    assert holder_policy.reduce_dtype == torch.float32
+    assert holder_policy.output_dtype == torch.float32
+    assert holder_policy.cast_forward_inputs is False
 
 
 def test_fully_shard_by_dtype_ignored_params_do_not_change_uniform_storage_fallback():

--- a/tests/unit_tests/distributed/test_parallelizer_utils.py
+++ b/tests/unit_tests/distributed/test_parallelizer_utils.py
@@ -14,6 +14,7 @@
 
 from typing import List, Tuple
 
+import pytest
 import torch
 import torch.nn as nn
 from torch.distributed.fsdp import MixedPrecisionPolicy
@@ -548,6 +549,98 @@ def test_fully_shard_by_dtype_two_dtypes(monkeypatch):
     # The least common dtype is float32 ('a'), so only 'a' subtree should be sharded individually
     assert [mod for mod, _ in sub_calls] == [model.a]
     assert sub_calls[0][1].param_dtype == torch.float32
+
+
+def test_fully_shard_by_dtype_excludes_ep_params_and_uses_custom_sharder():
+    """Ignored EP experts do not affect grouping and remain excluded from the block unit."""
+
+    class Router(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = nn.Parameter(torch.zeros(4, dtype=torch.float32))
+            self.register_buffer("e_score_correction_bias", torch.zeros(4, dtype=torch.float32))
+
+    class MoEBlock(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.bulk_1 = nn.Linear(4, 4, bias=False).to(torch.bfloat16)
+            self.bulk_2 = nn.Linear(4, 4, bias=False).to(torch.bfloat16)
+            self.gate = Router()
+            self.experts = nn.Linear(4, 4, bias=False).to(torch.bfloat16)
+
+    block = MoEBlock()
+    expert_params = set(block.experts.parameters())
+    calls: list[tuple[nn.Module, dict]] = []
+
+    def custom_fully_shard(module, **kwargs):
+        calls.append((module, kwargs))
+
+    fully_shard_by_dtype(
+        block,
+        mesh=object(),
+        mp_policy=_make_mp_policy(),
+        offload_policy=object(),
+        fp32_compute_module_names=("gate.weight", "gate.e_score_correction_bias"),
+        reshard_after_forward=False,
+        ignored_params=expert_params,
+        fully_shard_fn=custom_fully_shard,
+    )
+
+    assert [module for module, _ in calls] == [block.gate, block]
+    assert calls[0][1]["mp_policy"].param_dtype == torch.float32
+    assert "ignored_params" not in calls[0][1]
+    assert calls[1][1]["mp_policy"].param_dtype == torch.bfloat16
+    assert calls[1][1]["ignored_params"] == expert_params
+    assert all(module is not block.experts for module, _ in calls)
+
+
+def test_fully_shard_by_dtype_ignored_params_do_not_change_uniform_storage_fallback():
+    """An ignored expert dtype must not make uniform managed master weights look mixed."""
+
+    class BlockWithIgnoredExperts(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.managed = nn.Linear(4, 4, bias=False).to(torch.float32)
+            self.experts = nn.Linear(4, 4, bias=False).to(torch.bfloat16)
+
+    block = BlockWithIgnoredExperts()
+    expert_params = set(block.experts.parameters())
+    calls: list[tuple[nn.Module, dict]] = []
+
+    fully_shard_by_dtype(
+        block,
+        mesh=object(),
+        mp_policy=_make_mp_policy(),
+        offload_policy=object(),
+        ignored_params=expert_params,
+        fully_shard_fn=lambda module, **kwargs: calls.append((module, kwargs)),
+    )
+
+    assert [module for module, _ in calls] == [block]
+    assert calls[0][1]["mp_policy"].param_dtype == torch.bfloat16
+    assert calls[0][1]["ignored_params"] == expert_params
+
+
+def test_fully_shard_by_dtype_rejects_unisolatable_mixed_parameter_owner():
+    """A direct fp32 parameter sharing an owner with bf16 siblings fails early."""
+
+    class MixedRouter(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = nn.Parameter(torch.zeros(4, dtype=torch.float32))
+            self.bias = nn.Parameter(torch.zeros(4, dtype=torch.bfloat16))
+
+    router = MixedRouter()
+
+    with pytest.raises(ValueError, match="could not isolate parameters with a distinct dtype"):
+        fully_shard_by_dtype(
+            router,
+            mesh=object(),
+            mp_policy=_make_mp_policy(),
+            offload_policy=object(),
+            fp32_compute_module_names=("weight",),
+            fully_shard_fn=lambda *args, **kwargs: None,
+        )
 
 
 def test_fully_shard_by_dtype_three_dtypes(monkeypatch):

--- a/tests/unit_tests/distributed/test_parallelizer_utils.py
+++ b/tests/unit_tests/distributed/test_parallelizer_utils.py
@@ -613,7 +613,7 @@ def test_fully_shard_by_dtype_excludes_ep_params_and_uses_custom_sharder():
 
 
 def test_fully_shard_by_dtype_fp32_holder_uses_full_fp32_policy():
-    """Callable fp32 holders keep fp32 inputs, reductions, and outputs under FSDP."""
+    """Callable fp32 holders keep fp32 parameters, reductions, and outputs under FSDP."""
 
     class Fp32Holder(nn.Module):
         def __init__(self):

--- a/tests/unit_tests/models/ernie4_5/test_ernie4_5_model.py
+++ b/tests/unit_tests/models/ernie4_5/test_ernie4_5_model.py
@@ -27,6 +27,7 @@ from transformers.models.ernie4_5.configuration_ernie4_5 import Ernie4_5Config
 from transformers.models.ernie4_5_moe.configuration_ernie4_5_moe import Ernie4_5_MoeConfig
 
 from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.models.common.utils import cast_model_to_dtype
 from nemo_automodel.components.models.ernie4_5.model import (
     Ernie4_5_MoeForCausalLM,
     Ernie4_5_MoeModel,
@@ -215,6 +216,17 @@ class TestErnie4_5Model:
 # MoE model
 # ---------------------------------------------------------------------------
 class TestErnie4_5_MoeModel:
+    def test_gate_precision_defaults_to_fp32(self, moe_hf_config, backend_config):
+        assert backend_config.gate_precision is None
+        model = Ernie4_5_MoeModel(moe_hf_config, backend_config)
+        assert backend_config.gate_precision == torch.float32
+        assert model.layers["1"].mlp.gate.gate_precision == torch.float32
+
+    def test_gate_precision_respects_explicit_override(self, moe_hf_config, backend_config):
+        backend_config.gate_precision = torch.bfloat16
+        model = Ernie4_5_MoeModel(moe_hf_config, backend_config)
+        assert model.layers["1"].mlp.gate.gate_precision == torch.bfloat16
+
     def test_moe_config_defaults_from_hf_config(self, moe_hf_config, backend_config):
         model = Ernie4_5_MoeModel(moe_hf_config, backend_config)
         assert hasattr(model, "moe_config")
@@ -424,6 +436,40 @@ class TestErnie4_5_MoeForCausalLM:
         assert model.lm_head.weight is not model.model.embed_tokens.weight
         model.tie_weights()
         assert model.lm_head.weight is model.model.embed_tokens.weight
+
+    def test_router_fp32_contract_preserves_checkpoint_precision(self, moe_hf_config, backend_config):
+        model = Ernie4_5_MoeForCausalLM(moe_hf_config, backend=backend_config)
+        moe = model.model.layers["1"].mlp
+
+        assert "mlp.gate.weight" in model._keep_in_fp32_modules_strict
+        assert "mlp.gate.e_score_correction_bias" in model._keep_in_fp32_modules_strict
+        assert moe.gate.weight.dtype == torch.float32
+        assert moe.gate.e_score_correction_bias.dtype == torch.float32
+        assert moe.experts.gate_and_up_projs.dtype == torch.bfloat16
+
+        reference_weight = torch.linspace(
+            -0.1234567,
+            0.7654321,
+            moe.gate.weight.numel(),
+            dtype=torch.float32,
+        ).reshape_as(moe.gate.weight)
+        assert not torch.equal(reference_weight, reference_weight.to(torch.bfloat16).float())
+
+        model.load_state_dict({"model.layers.1.mlp.gate.weight": reference_weight}, strict=False)
+        cast_model_to_dtype(model, torch.bfloat16)
+
+        assert moe.gate.weight.dtype == torch.float32
+        assert torch.equal(moe.gate.weight, reference_weight)
+
+    def test_router_fp32_contract_applies_to_meta_construction(self, moe_hf_config, backend_config):
+        with torch.device("meta"):
+            model = Ernie4_5_MoeForCausalLM(moe_hf_config, backend=backend_config)
+
+        moe = model.model.layers["1"].mlp
+        assert moe.gate.weight.device.type == "meta"
+        assert moe.gate.weight.dtype == torch.float32
+        assert moe.gate.e_score_correction_bias.dtype == torch.float32
+        assert moe.experts.gate_and_up_projs.dtype == torch.bfloat16
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/models/ernie4_5/test_ernie4_5_model.py
+++ b/tests/unit_tests/models/ernie4_5/test_ernie4_5_model.py
@@ -219,7 +219,8 @@ class TestErnie4_5_MoeModel:
     def test_gate_precision_defaults_to_fp32(self, moe_hf_config, backend_config):
         assert backend_config.gate_precision is None
         model = Ernie4_5_MoeModel(moe_hf_config, backend_config)
-        assert backend_config.gate_precision == torch.float32
+        assert backend_config.gate_precision is None
+        assert model.backend.gate_precision == torch.float32
         assert model.layers["1"].mlp.gate.gate_precision == torch.float32
 
     def test_gate_precision_respects_explicit_override(self, moe_hf_config, backend_config):
@@ -443,9 +444,11 @@ class TestErnie4_5_MoeForCausalLM:
 
         assert "mlp.gate.weight" in model._keep_in_fp32_modules_strict
         assert "mlp.gate.e_score_correction_bias" in model._keep_in_fp32_modules_strict
+        assert "rotary_emb" in model._keep_in_fp32_modules
         assert moe.gate.weight.dtype == torch.float32
         assert moe.gate.e_score_correction_bias.dtype == torch.float32
         assert moe.experts.gate_and_up_projs.dtype == torch.bfloat16
+        assert model.model.rotary_emb.inv_freq.dtype == torch.float32
 
         reference_weight = torch.linspace(
             -0.1234567,
@@ -470,6 +473,7 @@ class TestErnie4_5_MoeForCausalLM:
         assert moe.gate.weight.dtype == torch.float32
         assert moe.gate.e_score_correction_bias.dtype == torch.float32
         assert moe.experts.gate_and_up_projs.dtype == torch.bfloat16
+        assert model.model.rotary_emb.inv_freq.dtype == torch.float32
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/moe/test_parallelizer.py
+++ b/tests/unit_tests/moe/test_parallelizer.py
@@ -335,6 +335,7 @@ def _import_parallelizer_with_stubs(monkeypatch):
         "nemo_automodel.components.distributed.pipelining.config",
         "nemo_automodel.components.distributed.pipelining.hf_utils",
         "nemo_automodel.components.distributed.mesh_utils",
+        "nemo_automodel.components.distributed.parallelizer_utils",
     ]:
         if mod in sys.modules:
             sys.modules.pop(mod)
@@ -375,6 +376,39 @@ def _import_parallelizer_with_stubs(monkeypatch):
     mesh_utils_stub.get_submesh = lambda mesh, axis_names: mesh[axis_names]
     mesh_utils_stub.get_fsdp_dp_mesh = lambda mesh, *_axis_names: mesh[("dp_replicate", "dp_shard_cp")]
     monkeypatch.setitem(sys.modules, "nemo_automodel.components.distributed.mesh_utils", mesh_utils_stub)
+
+    parallelizer_utils_stub = types.ModuleType("nemo_automodel.components.distributed.parallelizer_utils")
+
+    def fully_shard_by_dtype(
+        module,
+        *,
+        mesh,
+        mp_policy,
+        offload_policy,
+        fp32_compute_module_names=(),
+        reshard_after_forward=None,
+        ignored_params=None,
+        fully_shard_fn=None,
+    ):
+        kwargs = {
+            "mesh": mesh,
+            "mp_policy": mp_policy,
+            "offload_policy": offload_policy,
+        }
+        if reshard_after_forward is not None:
+            kwargs["reshard_after_forward"] = reshard_after_forward
+        if ignored_params:
+            kwargs["ignored_params"] = ignored_params
+        fully_shard_fn(module, **kwargs)
+
+    parallelizer_utils_stub.fully_shard_by_dtype = fully_shard_by_dtype
+    monkeypatch.setitem(
+        sys.modules,
+        "nemo_automodel.components.distributed.parallelizer_utils",
+        parallelizer_utils_stub,
+    )
+    distributed_package = importlib.import_module("nemo_automodel.components.distributed")
+    monkeypatch.setattr(distributed_package, "parallelizer_utils", parallelizer_utils_stub, raising=False)
 
     # Stub dtype_from_str utility
     shared_utils_stub = types.ModuleType("nemo_automodel.shared.utils")
@@ -771,84 +805,45 @@ def test_apply_fsdp_installs_accumulated_grad_guard(monkeypatch):
     guard_mock.assert_called_once_with()
 
 
-def test_shard_fp32_param_holders_shards_each_holder(monkeypatch):
-    """``_shard_fp32_param_holders`` fully_shards each model-owned fp32 holder."""
-    P = _import_parallelizer_with_stubs(monkeypatch)
-
-    fully_shard_mock = MagicMock()
-    monkeypatch.setattr(P, "fully_shard", fully_shard_mock)
-
-    holder_param = object()
-
-    class Holder:
-        def parameters(self, recurse=False):
-            return iter([holder_param])
-
-    holder = Holder()
-    block = type(
-        "Block",
-        (),
-        {"named_modules": lambda self: iter([("", self), ("linear_attn._fp32_params", holder)])},
-    )()
-
-    mesh = object()
-    ignored = P._shard_fp32_param_holders(block, mesh, reshard_after_forward=False, offload_policy=None)
-
-    assert ignored == {holder_param}
-    holder_call = _find_call_by_first_arg(fully_shard_mock, holder)
-    assert holder_call is not None
-    _, kwargs = holder_call
-    assert kwargs["mesh"] is mesh
-    assert kwargs["reshard_after_forward"] is False
-
-
-def test_apply_fsdp_shards_model_owned_fp32_holders(monkeypatch):
-    """apply_fsdp shards each model-owned ``_fp32_params`` holder per block."""
+def test_apply_fsdp_routes_strict_fp32_contract_and_expert_exclusions_to_shared_sharder(monkeypatch):
+    """MoE uses the dense dtype-aware sharder with the model and EP contracts."""
     P = _import_parallelizer_with_stubs(monkeypatch)
     monkeypatch.setattr(P, "MoE", DummyMoE)
     fully_shard_mock = MagicMock()
     monkeypatch.setattr(P, "fully_shard", fully_shard_mock)
-    monkeypatch.setattr(P, "MixedPrecisionPolicy", MagicMock(return_value="FP32_MP"))
+    shared_sharder_mock = MagicMock()
+    monkeypatch.setattr(P.parallelizer_utils, "fully_shard_by_dtype", shared_sharder_mock)
 
-    holder_param = object()
-
-    class Holder:
-        def parameters(self, recurse=False):
-            return iter([holder_param])
-
-    holder = Holder()
-
-    class BlockWithHolder:
-        def __init__(self):
-            self.mlp = DummyMoE()
-
-        def named_modules(self):
-            return iter([("", self), ("linear_attn._fp32_params", holder)])
-
-    block = BlockWithHolder()
+    block = DummyBlock(mlp=DummyMoE())
     model = DummyModel([block])
+    model._keep_in_fp32_modules_strict = ["mlp.gate.weight", "mlp.gate.e_score_correction_bias"]
     fsdp_mesh = object()
     mp_policy = MagicMock()
+    offload_policy = object()
 
     P.apply_fsdp(
         model=model,
         fsdp_mesh=fsdp_mesh,
-        ep_enabled=False,
+        ep_enabled=True,
         ep_shard_enabled=False,
-        ep_shard_mesh=None,
         mp_policy=mp_policy,
+        offload_policy=offload_policy,
+        reshard_after_forward=True,
     )
 
-    # The holder is sharded as its own fp32 unit before the block-level shard.
-    holder_call = _find_call_by_first_arg(fully_shard_mock, holder)
-    assert holder_call is not None
-    _, holder_kwargs = holder_call
-    assert holder_kwargs["mesh"] is fsdp_mesh
-    assert holder_kwargs["mp_policy"] == "FP32_MP"
-
-    block_call = _find_call_by_first_arg(fully_shard_mock, block)
-    assert block_call is not None
-    assert holder_param in block_call[1]["ignored_params"]
+    shared_sharder_mock.assert_called_once_with(
+        block,
+        mesh=fsdp_mesh,
+        mp_policy=mp_policy,
+        offload_policy=offload_policy,
+        fp32_compute_module_names=(
+            "mlp.gate.weight",
+            "mlp.gate.e_score_correction_bias",
+        ),
+        reshard_after_forward=True,
+        ignored_params=set(block.mlp.experts.parameters()),
+        fully_shard_fn=fully_shard_mock,
+    )
 
 
 def test_apply_fsdp_skips_separate_wrapping_for_tied_embeddings(monkeypatch):


### PR DESCRIPTION
# What does this PR do?

Preserve model-owned FP32 storage and compute contracts across BF16 construction, checkpoint loading, and FSDP2, including ERNIE 4.5's MoE router and dense Qwen3.5's SSM gate.

HF keeps ERNIE's router `gate.weight`, correction bias, and non-persistent RoPE `inv_freq` in FP32 during a BF16 checkpoint load. AutoModel previously stored `gate.weight` in BF16. Casting that value back to FP32 during routing cannot recover precision lost during loading.

The MoE sharder previously handled FP32 parameters only when models placed them in dedicated `_fp32_params` holder modules. That covers contracts such as Qwen3.5's GDN parameters, but not ordinary strict-FP32 parameters such as ERNIE's router weight. It now reuses the shared dtype-aware FSDP grouping, which groups model-owned parameters by storage and compute dtype, isolates compatible FP32 units, and preserves FP32 parameters, reductions, and outputs.

# Changelog

- Declare `mlp.gate.weight` and `mlp.gate.e_score_correction_bias` as ERNIE's strict FP32 parameter contract.
- Preserve ERNIE's `rotary_emb` buffers in FP32 during the model-wide BF16 cast.
- Default ERNIE router computation to FP32 without mutating the caller-owned `BackendConfig`.
- Reuse the shared `fully_shard_by_dtype()` path for MoE transformer blocks while excluding EP-owned experts.
- Apply FP32 parameter, reduction, and output policies to model-owned FP32 compute units, with module-owned input casting so activation-checkpoint forward and recompute observe the same parent activation dtype.
- Retain model-specific sharders such as DeepSeek V4's and fail early when one parameter owner requests compute dtypes that cannot be represented by a single FSDP policy.
- Restore ERNIE's HF-reload KL threshold from the relaxed `1.1e-2` to the harness default `5e-3` after validating the complete precision contract.
- Add model, policy, and two-rank EP/FSDP2 regressions, including explicit FP32 router/top-k numerical parity before and after full-model sharding and FP32 storage/gradient checks.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added focused unit and distributed regression coverage.
- [x] No user-facing documentation changes are required.

# Additional Information

- Linear: [AMINT-207](https://linear.app/nvidia/issue/AMINT-207/kl-divergence-exceeds-threshold-when-reloading-ernie4-model-from-hf)

## Validation

- Rebased with `main` in `039385b06`, including DeepSeek V4's model-owned FSDP handling from #3227.
- `ruff check` and `git diff --check` pass.
- Post-rebase focused suite: 56 passed, 3 skipped.
- Two-rank H100 EP/FSDP2/activation-checkpointing regression passes in Slurm job `14486166`.
- The exact production `ernie4_5_21b_a3b_hellaswag` checkpoint-robustness job passed: [leaf job 376922646](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/376922646), [pipeline 60000628](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/60000628). The test reported `1 passed` in 460.99 seconds.
- The scoped Qwen3.5 release validation passed on PR head `372099ad3`: [dense `qwen3_5_4b` leaf job 378345604](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/378345604), [MoE `qwen3_5_35b` leaf job 378345605](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/378345605), [VLM leaf pipeline 60187305](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/60187305), and [parent pipeline 60187081](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/60187081).

## Checkpoint-robustness metrics

The successful production job used the harness-default HF KL threshold of `5e-3` and reported:

- source-load maximum per-token KL: `1.187141e-3` (threshold `5e-3`)
- source-load mean per-token KL: `2.602303e-4` (threshold `1e-3`)
- source-load p95 KL: `8.557549e-4`
- source-load cosine similarity: `0.99977142` (threshold `0.9995`)
- AutoModel consolidated-reload maximum KL: `0.0` (threshold `0.0`)
- HF-reload maximum per-token KL: `1.280195e-3` (threshold `5e-3`)
- resume-loss differences: `0.0` for all three compared steps

The CI ran on validation SHA `4b21fcdfb8e8305a5a85a8751b73c177e4f45b27`, based on PR head `712a937dd`, with only two validation changes: restoring `hf_kl_threshold: 5e-3` and adding pytest `-rP` so passing-test metrics were visible. The validated threshold change is included in this PR as `497d864ef`.

These corrected metrics show that the earlier ERNIE-specific `1.1e-2` relaxation is no longer justified.

## Why the earlier tiny probe matched exactly

The diagnostic probe called `HF_model.to(bfloat16)` and restored only HF's persistent strict-FP32 router tensors. That blanket cast also rounded HF's non-persistent `inv_freq`, while AutoModel's model-wide cast rounded its copy. The state-dict comparison could not see `inv_freq` because it is non-persistent. After switching the MoE multiplication order, the probe compared two models that shared the same RoPE bug, so exact equality was conditional and did not prove the production residual came only from MoE ordering.

The probe now preserves and asserts the HF-style FP32 RoPE contract. The checkpoint-robustness harness already constructs HF with its dtype-aware `from_pretrained(..., torch_dtype=...)` path rather than blanket-casting an instantiated model.

## Why FP32 holders may reshard normally

FP32 holders were initially forced to `reshard_after_forward=False` because returning raw parameter storage could let FSDP reshard that storage before the parent finished consuming it. PR #2598 subsequently changed Nemotron and shared GDN holder outputs to cloned tensors and intentionally restored normal caller-controlled resharding. `NemotronV3MambaFP32Params.forward()` calls `_full_tensor_if_dtensor()` for every returned parameter, and that helper always clones the value while preserving the gradient path. The returned tensors therefore do not alias storage that FSDP may reshard.
