### PR TITLE
fix(distributed): use non-reentrant activation checkpointing under PP

### DIFF
--- a/nemo_automodel/components/datasets/vlm/pp_media.py
+++ b/nemo_automodel/components/datasets/vlm/pp_media.py
@@ -330,6 +330,14 @@ def _will_run_forward_metadata_inference(pp: Any) -> bool:
     if first_stage is None or hasattr(first_stage, "_configure_outputs_meta"):
         return False
 
+    # Static metadata installed by ``_precompute_stage_shapes`` makes PyTorch skip the
+    # probe entirely. Claiming otherwise arms the cursor reset against the first *real*
+    # microbatch instead, so every later microbatch re-reads media chunk 0 and the media
+    # silently desynchronizes from the text it belongs to.
+    user_meta = getattr(first_stage, "_user_meta", None)
+    if getattr(user_meta, "inputs", None) is not None:
+        return False
+
     if hasattr(schedule, "_stage_forward_initialized"):
         return not schedule._stage_forward_initialized
     if hasattr(schedule, "_stages_forward_initialized"):


### PR DESCRIPTION
# What does this PR do ?

Fixes [AMINT-201](https://linear.app/nvidia/issue/AMINT-201/torchutilscheckpoint-with-use-reentranttrue-incompatible-with-grad-or):
pipeline parallelism combined with activation checkpointing dies on the first
`schedule.step()` with

```
RuntimeError: When use_reentrant=True, torch.utils.checkpoint is incompatible with .grad()
or passing an `inputs` parameter to .backward().
```

Affected recipes: `gemma4_31b_tp4_pp2`, `gemma4_31b_tp4_pp4`, `mistral3p5_128b_medpix_lora`.

**1. Reentrant activation checkpointing is incompatible with PP.**
`torch.distributed.pipelining` resolves a stage's input gradients through
`torch.autograd.grad()` (`_backward._autograd_grad_for_inputs`), because every non-first stage
owes its upstream neighbour `d(loss)/d(stage_input)`. Reentrant `torch.utils.checkpoint` runs its
recomputed block by re-entering the autograd engine, which is only valid under a full backward
traversal — so PyTorch rejects the partial traversal that `.grad()` performs rather than emitting
wrong gradients. HF-native gradient checkpointing now passes `use_reentrant=False` whenever the
device mesh has a `pp` axis > 1; without PP the cheaper reentrant path is unchanged.

This is why only ranks in stages 1..N-1 crashed — stage 0 has no upstream neighbour and never
calls `.grad()`.

**2. `pp_enabled` was read from the wrong mesh.**
It probed `dp_mesh.mesh_dim_names`, but `get_fsdp_dp_mesh` returns a DP-only submesh
(`dp_shard`, `dp_shard_cp`, or `(dp_replicate, dp_shard)`) that never carries a `pp` dimension —
so the flag was always `False`. It now reads the root `device_mesh`. This also un-breaks the
`reshard_after_forward=True` PP warning, which could never fire.

# Reason for regression

AMINT-201 is not a latent bug. The three affected recipes passed six consecutive release
pipelines (06-26 through 07-19) and failed on 07-26. Both runs used identical
`torch 2.13.0a0+8145d630e8.nv26.06` and `transformers 5.12.1`, so this was not a dependency bump.

The trigger is #2983 (`3cd3ed2a1`, 2026-07-20, "bump base container to 26.06-cuda13.3"), which
landed between the two runs. Among its sub-commits — "fix(ci): adapt pipeline metadata to
PyTorch 2.13" — it added an early return to `_precompute_stage_shapes` that fires on every
PyTorch 2.13 run, because 2.13 removed the `PipelineStage._configure_outputs_meta` attribute it
probes for.

That flipped the failure mode. Automodel used to install static stage metadata itself, so
PyTorch never ran its own inference pass. With the precompute disabled, PyTorch falls back to
`_initialize_stage` → `_prepare_backward_infra` → `_backward_metadata_inference` →
`_compute_input_grads` → `_autograd_grad_for_inputs` → `torch.autograd.grad` — the exact frames
in the AMINT-201 traceback. Reentrant checkpointing has never survived a `.grad()` backward; it
simply was never asked to before.

The job logs show the flip directly:

| | 07-19 (pass) | 07-26 (fail) |
|---|---|---|
| `Precomputed pipeline stage shapes … serial shape inference bypassed` | 50× | 0× |
| `no longer exposes _configure_outputs_meta` | 0× | 54× |

Note the fix here is deliberately at the activation-checkpointing layer, not at the precompute:
PyTorch's dynamic metadata path is legitimate, activation checkpointing has to work under it, and
any recipe without a known `seq_len` takes that path regardless.

# Changelog

- `parallelizer.py`: pass `use_reentrant=not pp_enabled` to `gradient_checkpointing_enable()` so
  HF-native activation checkpointing is non-reentrant whenever pipeline parallelism is active.
- `parallelizer.py`: derive `pp_enabled` from the root `device_mesh` instead of the DP submesh
  returned by `get_fsdp_dp_mesh`, which never carries a `pp` dimension.
- `test_parallelizer.py`: add `TestHFNativeGradientCheckpointingAutograd`, which runs a real HF
  Llama through `parallelize()` on a PP-enabled mesh and takes `torch.autograd.grad` w.r.t. the
  stage input, asserting finite gradients that match an uncheckpointed reference. Counts forward
  *pre*-hooks to prove the checkpoint actually engaged — checkpoint early-stop aborts recompute
  before `forward` returns, so a post-hook would miss it.
- `test_parallelizer.py`: add `_make_root_mesh_for_ac(pp_size=...)` and a `pp_size` knob on
  `_run_parallelize`; assert `use_reentrant=False` is requested under PP and `True` without it.
- `test_parallelization_strategies.py`: move the `pp` axis onto the root mesh in
  `test_explicit_reshard_true_warns_with_pipeline_parallelism`, which had encoded the old
  always-`False` probe.

# Test evidence

- Reverting only the `use_reentrant` line reproduces the exact CI error in the new autograd test,
  confirming it covers the regression rather than restating the implementation.
- CPU unit tests in the CI container (`torch 2.13.0a0+8145d630e8.nv26.06`,
  `transformers 5.12.1`): `tests/unit_tests/distributed` 995 passed / 46 skipped,
  `tests/unit_tests/recipes` 1081 passed / 12 skipped; `ruff format` / `ruff check` clean.
- nemo-ci release pipeline
  [59864657](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/59864657) on `eos`,
  scoped to the three AMINT-201 recipes:
  [`gemma4_31b_tp4_pp2`](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/375941103) ✅,
  [`mistral3p5_128b_medpix_lora`](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/375941105) ✅,
  [`gemma4_31b_tp4_pp4`](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/375941104) ❌.
  The `use_reentrant=True` error is gone from all three.

# Known gap

`gemma4_31b_tp4_pp4` clears AMINT-201 but still fails on a **separate** defect: it trains cleanly
to step 48/50 (`loss 2.3717 | grad_norm 54.3274`) and then stalls with no output for 23 minutes
until SLURM kills it at the 30-minute cap. Step cadence is a steady ~3 s right up to the stall, so
this is a hang rather than slowness — more wall time would not help.

It is the only one of the three recipes with `dp_size > 1` (32 GPUs, `tp4 × pp4` → `dp=2`; the
other two are `dp=1`). Diagnosis is currently blocked because the recipe sets
`dist_env.timeout_minutes: 60` against `ci.time: "00:30:00"`, so the NCCL watchdog can never fire
before SLURM kills the job and the hang reports no stuck collective and no rank attribution. An
instrumented run is in flight on `athitten/debug/pp4-hang-diagnostics`.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

# Additional Information

- Fixes [AMINT-201](https://linear.app/nvidia/issue/AMINT-201/torchutilscheckpoint-with-use-reentranttrue-incompatible-with-grad-or)
- Regressed by #2983

