### PR TITLE
fix(nemotron-v3): recompute deterministic LoRA router

### DIFF
--- a/examples/llm_benchmark/nemotron/nemotron_super_v3_lora.yaml
+++ b/examples/llm_benchmark/nemotron/nemotron_super_v3_lora.yaml
@@ -51,6 +51,9 @@ distributed:
   activation_checkpointing: true
   moe:
     reshard_after_forward: true
+    # fake_balanced_gate makes routing deterministic, so recompute it directly instead of
+    # using the selective router cache around Nemotron V3's nested fp32 FSDP holder.
+    ignore_router_for_ac: false
 
 dist_env:
   backend: nccl


### PR DESCRIPTION
## What changed

Set `distributed.moe.ignore_router_for_ac: false` for the Nemotron Super V3 LoRA benchmark. Because this recipe uses `fake_balanced_gate`, routing is deterministic and can be recomputed safely during activation-checkpoint replay.

## Why

[AMINT-211](https://linear.app/nvidia/issue/AMINT-211/fsdp-split-with-sizes-copydefault-op-missing-during-backward-pass) fails in backward with:

```
RuntimeError: fsdp.split_with_sizes_copy.default encountered during backward but not found in storage
```

The selective router cache changes the checkpoint dispatch stream around Nemotron V3's nested fp32 FSDP holder. Backward replay then introduces the holder's FSDP all-gather operation, which was not stored during forward. This applies the same focused recipe pattern as #3126, which covered Qwen3.5 but not Nemotron.

Original failing job: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/374246485

## Validation

- Exact red reproduction on one interactive node with 8×H100, torch `2.13.0a0+8145d630e8.nv26.06`, the 123.6B Nemotron Super model, EP=8, LoRA, and activation checkpointing: reproduced the same `fsdp.split_with_sizes_copy.default` backward error with `ignore_router_for_ac: true`.
- Exact green rerun with only `ignore_router_for_ac: false`: completed forward, backward, and optimizer step (`loss=13.9294`, peak allocated memory 45.36 GB).
- `python tools/lint_example_yamls.py --automodel-dir . examples/llm_benchmark/nemotron/nemotron_super_v3_lora.yaml`
- `python -m pytest -q tests/unit_tests/config/test_example_yaml_linter.py` (8 passed)
- Full 8-node NeMo-CI: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/59871897
