### PR TITLE
fix(speculative): reject tensor and pipeline parallelism in DSpark

### DIFF
--- a/nemo_automodel/recipes/llm/_dspark_target_build.py
+++ b/nemo_automodel/recipes/llm/_dspark_target_build.py
@@ -44,6 +44,63 @@ from nemo_automodel.recipes._dist_utils import create_distributed_setup_from_con
 logger = logging.getLogger(__name__)
 
 
+def distributed_section_dict(cfg) -> dict:
+    """Return the ``distributed:`` section of a top-level recipe config as a plain dict.
+
+    A missing block yields ``{}``, i.e. the default FSDP2 configuration; this keeps the
+    fail-loud missing-block contract of ``create_distributed_setup_from_config`` intact
+    for callers that require an explicit block.
+    """
+    section = cfg.get("distributed", None)
+    if section is None:
+        return {}
+    return section.to_dict() if hasattr(section, "to_dict") else dict(section)
+
+
+def unsupported_parallel_axes(sizes: dict, axes: tuple[str, ...]) -> dict[str, int]:
+    """Return the entries of ``axes`` whose parallelism size is not 1.
+
+    Reads a raw ``distributed:`` section or a ``parse_distributed_section`` result the
+    same way: an absent key and an explicit YAML null (``tp_size:``) both mean 1.
+    """
+    resolved = {axis: int(sizes.get(axis) or 1) for axis in axes}
+    return {axis: size for axis, size in resolved.items() if size != 1}
+
+
+def validate_dspark_parallelism_axes(cfg) -> None:
+    """Reject the model-parallel axes the DSpark entrypoints cannot honor.
+
+    Both the training recipe and the distributed precompute replicate their work per
+    rank and shard the dataset by rank, so only data-parallel-shaped topologies are
+    correct. Two axes break that silently rather than loudly:
+
+    - ``tp_size > 1``: every rank of a tensor-parallel group must run the target on the
+      SAME micro-batch, but the sampler hands each rank a different one, so the target's
+      sharded attention and MLPs combine activations from unrelated samples.
+    - ``pp_size > 1``: the target is loaded as an ``AutoPipeline`` instead of a module,
+      which the forward-hook hidden-state capture in ``HFDSparkTargetModel`` cannot run.
+
+    Shard a large target with ``ep_size`` / FSDP instead. Context parallelism has its own
+    (supported) path in the training recipe.
+
+    Args:
+        cfg: The top-level recipe config.
+
+    Raises:
+        NotImplementedError: if ``distributed.tp_size`` or ``distributed.pp_size`` > 1.
+    """
+    # Read the raw section rather than parse_distributed_section: the parser rejects
+    # pp_size>1 without a `pipeline` block before this gate could report the axis.
+    unsupported = unsupported_parallel_axes(distributed_section_dict(cfg), ("tp_size", "pp_size"))
+    if unsupported:
+        raise NotImplementedError(
+            f"DSpark does not support {unsupported}: a tensor-parallel target is fed a different "
+            f"micro-batch on each rank of its TP group, and a pipelined target is an AutoPipeline "
+            f"the forward-hook hidden-state capture cannot run. Set tp_size=pp_size=1 and shard a "
+            f"large target with ep_size / FSDP instead."
+        )
+
+
 def gather_full_weight_module(module):
     """Return an object exposing a full (non-DTensor) ``.weight`` tensor.
 
@@ -275,7 +332,10 @@ __all__ = [
     "build_deepseek_v4_target",
     "build_glm_5_2_backend",
     "build_glm_5_2_target",
+    "distributed_section_dict",
     "gather_full_weight_module",
     "repair_glm_5_2_qk_rope_head_dim",
     "resolve_reduced_target_layers",
+    "unsupported_parallel_axes",
+    "validate_dspark_parallelism_axes",
 ]

--- a/nemo_automodel/recipes/llm/precompute_dspark_dist.py
+++ b/nemo_automodel/recipes/llm/precompute_dspark_dist.py
@@ -91,6 +91,7 @@ from nemo_automodel.recipes.llm._dspark_target_build import (
     build_deepseek_v4_target,
     build_glm_5_2_target,
     gather_full_weight_module,
+    validate_dspark_parallelism_axes,
 )
 
 logger = logging.getLogger(__name__)
@@ -213,6 +214,9 @@ def _make_sync_max_steps(world_size: int, device: torch.device):
 
 def run(cfg) -> int:
     """Load the (possibly sharded) target and write the distributed DSpark cache."""
+    # The precompute runs the same forward-hook capture and rank-sharded data split as
+    # training, so it rejects the same model-parallel axes, before any weights load.
+    validate_dspark_parallelism_axes(cfg)
     dist_env = initialize_distributed(
         backend=cfg.get("dist_env", {}).get("backend", "nccl"),
         timeout_minutes=cfg.get("dist_env", {}).get("timeout_minutes", 30),

--- a/nemo_automodel/recipes/llm/train_dspark.py
+++ b/nemo_automodel/recipes/llm/train_dspark.py
@@ -112,9 +112,12 @@ from nemo_automodel.recipes.base_recipe import (
 from nemo_automodel.recipes.llm._dspark_target_build import (
     build_deepseek_v4_target,
     build_glm_5_2_target,
+    distributed_section_dict,
     gather_full_weight_module,
     repair_glm_5_2_qk_rope_head_dim,
     resolve_reduced_target_layers,
+    unsupported_parallel_axes,
+    validate_dspark_parallelism_axes,
 )
 from nemo_automodel.recipes.llm._spec_train_utils import (
     apply_draft_compile,
@@ -368,19 +371,6 @@ def _validate_cached_dspark_manifest(
         )
 
 
-def _distributed_section_dict(cfg) -> dict:
-    """Return the ``distributed:`` section of a top-level recipe config as a plain dict.
-
-    A missing block yields ``{}``, i.e. the default FSDP2 configuration; this keeps the
-    fail-loud missing-block contract of ``create_distributed_setup_from_config`` intact
-    for callers that require an explicit block.
-    """
-    section = cfg.get("distributed", None)
-    if section is None:
-        return {}
-    return section.to_dict() if hasattr(section, "to_dict") else dict(section)
-
-
 def _add_accept_rate_per_position(
     metrics: dict[str, float],
     accept_num: torch.Tensor,
@@ -428,7 +418,7 @@ class TrainDSparkRecipe(BaseRecipe):
         # Reuse the canonical distributed-section parser (strategy case-folding, YAML-null
         # axis defaulting) instead of re-reading the raw block, so the gate cannot drift
         # from what create_distributed_setup_from_config later builds.
-        parsed = parse_distributed_section(_distributed_section_dict(self.cfg))
+        parsed = parse_distributed_section(distributed_section_dict(self.cfg))
         if self.dist_env.world_size <= 1 or not isinstance(parsed["strategy_config"], FSDP2Config):
             if self.dist_env.is_main:
                 logger.warning(
@@ -439,17 +429,13 @@ class TrainDSparkRecipe(BaseRecipe):
                     self.dist_env.world_size,
                 )
             return False
-        unsupported = {
-            axis: parsed[axis]
-            for axis in ("tp_size", "pp_size", "cp_size", "ep_size", "dp_replicate_size")
-            if (parsed[axis] or 1) != 1
-        }
+        # tp_size / pp_size are rejected for every DSpark run by
+        # validate_dspark_parallelism_axes, so only the remaining axes are checked here.
+        unsupported = unsupported_parallel_axes(parsed, ("cp_size", "ep_size", "dp_replicate_size"))
         if unsupported:
             raise ValueError(
                 f"recipe_args.shard_dense_target=true only supports a pure FSDP2 data-parallel "
-                f"topology (tp_size=pp_size=cp_size=ep_size=dp_replicate_size=1), got {unsupported}. "
-                f"DSpark's hidden-state capture needs one non-pipelined model call per rank "
-                f"(pp_size>1 builds an AutoPipeline the target wrapper cannot run), the remaining "
+                f"topology (cp_size=ep_size=dp_replicate_size=1), got {unsupported}. Those "
                 f"model-parallel axes are unsupported for the frozen dense target, and HSDP "
                 f"replication re-replicates the target, defeating the sharding."
             )
@@ -501,6 +487,8 @@ class TrainDSparkRecipe(BaseRecipe):
                 "Sequence packing (packed_sequence_size>0) is only supported on the online text-only "
                 "DSpark path; the VLM and cached-target paths do not carry the packing metadata."
             )
+
+        validate_dspark_parallelism_axes(self.cfg)
 
         # Context parallelism (long-context memory relief): shard only the frozen
         # target forward along the sequence and gather the captured hidden states

--- a/tests/unit_tests/recipes/llm/test_train_dspark_helpers.py
+++ b/tests/unit_tests/recipes/llm/test_train_dspark_helpers.py
@@ -55,6 +55,8 @@ from nemo_automodel.recipes.llm._dspark_target_build import (
     gather_full_weight_module,
     repair_glm_5_2_qk_rope_head_dim,
     resolve_reduced_target_layers,
+    unsupported_parallel_axes,
+    validate_dspark_parallelism_axes,
 )
 from nemo_automodel.recipes.llm.train_dspark import (
     TrainDSparkRecipe,
@@ -998,11 +1000,11 @@ def test_should_shard_dense_target_ignored_on_ddp():
     assert recipe._should_shard_dense_target({"shard_dense_target": True}) is False
 
 
-@pytest.mark.parametrize("axis", ["tp_size", "pp_size", "cp_size", "ep_size", "dp_replicate_size"])
+@pytest.mark.parametrize("axis", ["cp_size", "ep_size", "dp_replicate_size"])
 def test_should_shard_dense_target_rejects_non_pure_dp_axes(axis):
-    # Only a pure FSDP2 data-parallel topology is supported: pp_size>1 builds an
-    # AutoPipeline the target wrapper cannot run, tp/cp/ep are untested here, and
-    # HSDP replication (dp_replicate_size>1) re-replicates the target.
+    # Only a pure FSDP2 data-parallel topology is supported: cp/ep are untested here and
+    # HSDP replication (dp_replicate_size>1) re-replicates the target. tp_size / pp_size
+    # are rejected earlier for every run by validate_dspark_parallelism_axes.
     recipe = _make_shard_recipe(cfg={"distributed": {"strategy": "fsdp2", axis: 2}})
     with pytest.raises(ValueError, match=axis):
         recipe._should_shard_dense_target({"shard_dense_target": True})
@@ -1059,3 +1061,52 @@ def test_dspark_load_extra_state_accepts_legacy_meta_without_mask_token_id(tmp_p
     TrainDSparkRecipe._load_extra_state(obj, str(tmp_path))
     assert obj.runtime.global_step == 3
     assert obj._resume_epoch == 1
+
+
+def test_parallelism_axes_allow_data_and_expert_parallel_topologies():
+    """The supported DSpark topologies (pure DP, EP-sharded target, CP) pass the gate."""
+    for section in (
+        {},
+        {"ep_size": 8},
+        {"tp_size": 1, "pp_size": 1, "cp_size": 2, "ep_size": 1},
+        # explicit YAML nulls (``tp_size:``) must read as the default 1
+        {"tp_size": None, "pp_size": None},
+    ):
+        validate_dspark_parallelism_axes(ConfigNode({"distributed": section}))
+
+
+def test_parallelism_axes_allow_missing_distributed_block():
+    validate_dspark_parallelism_axes(ConfigNode({}))
+
+
+@pytest.mark.parametrize(
+    "section",
+    [
+        {"tp_size": 2},
+        {"pp_size": 2},
+        {"tp_size": 2, "pp_size": 4},
+    ],
+)
+def test_parallelism_axes_reject_tensor_and_pipeline_parallelism(section):
+    """tp_size/pp_size > 1 corrupt the supervision silently, so they must fail loudly.
+
+    A TP group's ranks each get a different micro-batch from the rank-sharded
+    sampler, and a pipelined target is an AutoPipeline the hidden-state capture
+    hooks cannot run.
+    """
+    with pytest.raises(NotImplementedError, match="DSpark does not support"):
+        validate_dspark_parallelism_axes(ConfigNode({"distributed": section}))
+
+
+def test_parallelism_axes_error_names_the_offending_axes():
+    with pytest.raises(NotImplementedError) as excinfo:
+        validate_dspark_parallelism_axes(ConfigNode({"distributed": {"tp_size": 4, "ep_size": 8}}))
+    message = str(excinfo.value)
+    assert "{'tp_size': 4}" in message
+
+
+def test_unsupported_parallel_axes_reads_absent_and_null_sizes_as_one():
+    """Shared by the up-front gate and the shard_dense_target gate, so both agree."""
+    assert unsupported_parallel_axes({}, ("tp_size", "pp_size")) == {}
+    assert unsupported_parallel_axes({"tp_size": None}, ("tp_size",)) == {}
+    assert unsupported_parallel_axes({"cp_size": 2, "ep_size": 1}, ("cp_size", "ep_size")) == {"cp_size": 2}


### PR DESCRIPTION
## What

Reject `distributed.tp_size > 1` and `distributed.pp_size > 1` in the DSpark
training recipe and in the distributed offline precompute, before any weights
are loaded.

## Why

DSpark replicates the trainable draft on every rank and shards the dataset by
rank, so only data-parallel-shaped topologies are correct. Today both axes fail
silently instead of loudly:

| axis | what actually happens |
|---|---|
| `tp_size > 1` | every rank of a TP group must run the frozen target on the **same** micro-batch, but the sampler gives each rank a different one (no `dp` submesh is built outside context parallelism), so the target's sharded attention/MLP combine activations from unrelated samples |
| `pp_size > 1` | the target is loaded as an `AutoPipeline`, not a module, so `HFDSparkTargetModel`'s forward-hook hidden-state capture cannot run |

Neither raises today; training converges and the cost only shows up as lost
acceptance. Sibling recipes already gate this (`train_eagle3.py`'s
`_validate_tp_gates`, `train_dflash.py`'s `dp_mesh` handling); DSpark carried
the constraint only as a YAML comment.

Large targets keep being sharded with `ep_size` / FSDP, which is what every
shipped DSpark example already does, so no example or functional test changes.
Context parallelism keeps its existing supported path.

## Notes

The axis check is shared with the pre-existing `shard_dense_target` gate via
`unsupported_parallel_axes`, so the two cannot drift on how they read a raw
section versus a parsed one. That gate now covers only the axes the new one does
not (`cp` / `ep` / `dp_replicate`).

## Testing

CPU unit tests only; no GPU behavior changes on a supported topology.

- new tests for the gate (supported topologies, YAML nulls, `tp`/`pp` rejection,
  the axes named in the error) and for the shared axis helper
- `pytest tests/unit_tests/recipes/llm tests/unit_tests/speculative` passes
  (`test_benchmark.py` is already red on `main` and is untouched here)
