### PR TITLE
fix(speculative): correct DFlash anchor error and generated-span slice

### DIFF
--- a/nemo_automodel/components/speculative/dflash/core.py
+++ b/nemo_automodel/components/speculative/dflash/core.py
@@ -81,10 +81,12 @@ def _to_full_tensor(tensor: torch.Tensor) -> torch.Tensor:
 class NoValidAnchorsError(ValueError):
     """Raised when a batch has no sample long enough to form a DFlash block.
 
-    A DFlash anchor needs at least ``block_size + 1`` supervised tokens (the
-    anchor plus its block). Datasets always contain some short conversations;
-    the training loop catches this and skips the offending micro-batch rather
-    than aborting the run.
+    A DFlash anchor is a supervised position (``loss_mask=1``) that still has a
+    full block ahead of it, i.e. one in ``[0, seq_len - block_size]`` (and, when
+    packing, with at least ``block_size - 1`` further real tokens in its own
+    document). Datasets always contain some short conversations; the training
+    loop catches this and skips the offending micro-batch rather than aborting
+    the run.
     """
 
 
@@ -254,9 +256,11 @@ class DFlashTrainerModule(nn.Module):
         # richest sample has exactly one valid anchor and always drop one otherwise.
         max_n = min(self.num_anchors, int(valid_counts.max().item()))
         if max_n <= 0:
+            doc_note = " with block_size-1 further real tokens in its document" if doc_remaining is not None else ""
             raise NoValidAnchorsError(
-                "No valid anchor positions in this batch; every sample has fewer than "
-                f"block_size+1 ({bs + 1}) supervised tokens."
+                f"No valid anchor positions in this batch: no sample has a supervised token "
+                f"(loss_mask=1) in [0, seq_len - block_size] = [0, {max_anchor}]{doc_note} "
+                f"(seq_len={seq_len}, block_size={bs})."
             )
 
         indices = torch.arange(max_anchor + 1, device=device).unsqueeze(0).expand(bsz, -1)

--- a/nemo_automodel/components/speculative/dflash/draft_qwen3.py
+++ b/nemo_automodel/components/speculative/dflash/draft_qwen3.py
@@ -392,8 +392,10 @@ class Qwen3DFlashDraftModel(Qwen3PreTrainedModel):
             ):
                 break
 
-        output_ids = output_ids[:, :max_length]
-        output_ids = output_ids[:, output_ids[0] != self.mask_token_id]
+        # ``start`` indexes the last committed token (the bonus token the target sampled
+        # at the end of the previous block), so the generated sequence is exactly
+        # ``[0, start]``; everything past it is still MASK padding.
+        output_ids = output_ids[:, : min(start + 1, max_length)]
         if stop_token_ids is not None:
             stop_ids = torch.tensor(stop_token_ids, device=output_ids.device)
             stop_indices = torch.isin(output_ids[0][num_input_tokens:], stop_ids).nonzero(as_tuple=True)[0]

--- a/tests/unit_tests/speculative/test_dflash_core.py
+++ b/tests/unit_tests/speculative/test_dflash_core.py
@@ -20,7 +20,11 @@ import pytest
 import torch
 from transformers.models.qwen3.configuration_qwen3 import Qwen3Config
 
-from nemo_automodel.components.speculative.dflash.core import DFlashStepMetrics, DFlashTrainerModule
+from nemo_automodel.components.speculative.dflash.core import (
+    DFlashStepMetrics,
+    DFlashTrainerModule,
+    NoValidAnchorsError,
+)
 from nemo_automodel.components.speculative.dflash.draft_qwen3 import Qwen3DFlashDraftModel
 
 VOCAB = 64
@@ -310,3 +314,35 @@ def test_variable_prefix_loss_uniform_weights_without_gamma():
     )
     expected = (nll * supervised).sum() / (supervised.sum() + 1e-6)
     torch.testing.assert_close(out.loss, expected)
+
+
+def test_no_valid_anchors_error_states_the_actual_condition():
+    """The message must describe what is actually checked, not a token count.
+
+    An anchor is a supervised position with a full block ahead of it, so a batch
+    whose supervision starts too late fails even though it has many supervised
+    tokens; reporting "fewer than block_size+1 supervised tokens" sent readers
+    looking at the wrong thing.
+    """
+    trainer = _build_trainer()
+    seq_len = 8
+    # Plenty of supervised tokens, but all of them past seq_len - block_size.
+    loss_mask = torch.zeros(2, seq_len)
+    loss_mask[:, seq_len - BLOCK_SIZE + 1 :] = 1.0
+    with pytest.raises(NoValidAnchorsError) as excinfo:
+        trainer._sample_anchor_positions(seq_len, loss_mask, torch.device("cpu"))
+    message = str(excinfo.value)
+    assert f"[0, {seq_len - BLOCK_SIZE}]" in message
+    assert f"block_size={BLOCK_SIZE}" in message
+    assert "document" not in message
+
+
+def test_no_valid_anchors_error_mentions_the_document_bound_when_packing():
+    """With packing the block must also fit inside the anchor's own document."""
+    trainer = _build_trainer()
+    seq_len = 16
+    loss_mask = torch.ones(2, seq_len)
+    # Every document is shorter than a block, so no anchor has room for one.
+    doc_remaining = torch.zeros(2, seq_len, dtype=torch.long)
+    with pytest.raises(NoValidAnchorsError, match="document"):
+        trainer._sample_anchor_positions(seq_len, loss_mask, torch.device("cpu"), doc_remaining=doc_remaining)

--- a/tests/unit_tests/speculative/test_dflash_draft.py
+++ b/tests/unit_tests/speculative/test_dflash_draft.py
@@ -16,6 +16,8 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import torch
 from transformers.models.qwen3.configuration_qwen3 import Qwen3Config
 
@@ -125,3 +127,59 @@ def test_draft_forward_output_shape():
     out = draft(position_ids=position_ids, attention_mask=None, noise_embedding=noise, target_hidden=target_hidden)
     assert out.shape == (B, Q, H)
     assert torch.isfinite(out).all()
+
+
+class _ConstantTarget(torch.nn.Module):
+    """Minimal stand-in for the verifier: always samples ``forced_token_id``.
+
+    Only the surface ``spec_generate`` touches is implemented (``model.embed_tokens``,
+    ``lm_head``, and a forward returning logits + per-layer hidden states).
+    """
+
+    def __init__(self, cfg: Qwen3Config, forced_token_id: int):
+        super().__init__()
+        self.model = torch.nn.Module()
+        self.model.embed_tokens = torch.nn.Embedding(cfg.vocab_size, cfg.hidden_size)
+        self.lm_head = torch.nn.Linear(cfg.hidden_size, cfg.vocab_size, bias=False)
+        self.num_layers = cfg.num_target_layers
+        self.vocab_size = cfg.vocab_size
+        self.forced_token_id = forced_token_id
+        self.device = torch.device("cpu")
+
+    def forward(
+        self,
+        input_ids,
+        position_ids=None,
+        past_key_values=None,
+        use_cache=True,
+        logits_to_keep=None,
+        output_hidden_states=False,
+    ):
+        hidden = self.model.embed_tokens(input_ids)
+        keep = input_ids.shape[1] if logits_to_keep is None else logits_to_keep
+        logits = torch.zeros(input_ids.shape[0], keep, self.vocab_size)
+        logits[..., self.forced_token_id] = 1.0
+        return SimpleNamespace(logits=logits, hidden_states=[hidden] * (self.num_layers + 1))
+
+
+def test_spec_generate_keeps_generated_tokens_equal_to_the_mask_id():
+    """A generated token that happens to equal ``mask_token_id`` must survive.
+
+    The output buffer is pre-filled with ``mask_token_id`` as padding, so filtering
+    the padding out by value also deleted real tokens of that id and shifted the
+    rest of the sequence left. The generated span is tracked by the commit counter
+    instead.
+    """
+    torch.manual_seed(0)
+    cfg = _draft_cfg(bs=4)
+    draft = Qwen3DFlashDraftModel(cfg)
+    target = _ConstantTarget(cfg, forced_token_id=cfg.dflash_config["mask_token_id"])
+
+    prompt = torch.tensor([[1, 2, 3]])
+    max_new_tokens = 5
+    out = draft.spec_generate(target, prompt, max_new_tokens, stop_token_ids=None, temperature=0.0)
+
+    assert out.shape == (1, prompt.shape[1] + max_new_tokens)
+    torch.testing.assert_close(out[:, : prompt.shape[1]], prompt)
+    generated = out[0, prompt.shape[1] :]
+    assert torch.all(generated == cfg.dflash_config["mask_token_id"])


### PR DESCRIPTION
## What

Two small fixes in the DFlash path: a wrong error message, and an output trim
that can delete a generated token.

## Why

**1. `NoValidAnchorsError` described a condition the code does not check.**
It said "every sample has fewer than block_size+1 supervised tokens", but
`_sample_anchor_positions` requires a supervised position inside
`[0, seq_len - block_size]` (and, when packing, `block_size-1` further real
tokens in the anchor's own document). A batch whose supervision starts late has
plenty of supervised tokens and still raises, so the message pointed at sequence
length instead of supervision placement. It now reports the interval, the
packing bound, and the actual `seq_len` / `block_size`.

**2. `spec_generate` trimmed its output by value.**
`output_ids[:, output_ids[0] != self.mask_token_id]` removes the buffer's MASK
padding, but also any *generated* token equal to `mask_token_id`, shifting the
rest of the sequence left. `mask_token_id` is an ordinary vocabulary id (the
recipe requires a reserved-but-real token), so this is reachable on a normal
run. The generated span now comes from the loop's own commit counter `start`,
which the function already maintains, clamped to `max_length` because the last
block can overshoot.

## Testing

CPU unit tests only; no training-path behavior changes.

- new `spec_generate` regression test with a stub verifier that always samples
  the mask id (verified failing before the fix, passing after)
- two tests pinning the error message to the condition actually evaluated, with
  and without packing
- `pytest tests/unit_tests/speculative tests/unit_tests/recipes/llm/test_train_dflash.py
  tests/unit_tests/recipes/llm/test_train_dflash_noanchor_skip.py` passes
