### PR TITLE
fix(tools): save processor artifacts in LoRA merge for #3256

### DIFF
--- a/tests/unit_tests/tools/test_merge_lora.py
+++ b/tests/unit_tests/tools/test_merge_lora.py
@@ -649,14 +649,14 @@ class TestMergeLoraFunction:
     @patch("tools.merge_lora.gc")
     @patch("tools.merge_lora.torch")
     def test_vlm_processor_artifacts_are_reloadable(self, mock_torch, mock_gc, tmp_path):
-        """The merged output contains VLM processor artifacts that AutoProcessor can reload."""
+        """The merged output contains processor artifacts that AutoProcessor can reload."""
         from tokenizers import Tokenizer
         from tokenizers.models import WordLevel
         from tokenizers.pre_tokenizers import Whitespace
         from transformers import (
             AutoProcessor,
-            Idefics3ImageProcessor,
-            Idefics3Processor,
+            CLIPImageProcessor,
+            CLIPProcessor,
             PreTrainedTokenizerFast,
         )
 
@@ -678,16 +678,14 @@ class TestMergeLoraFunction:
             bos_token="<s>",
             eos_token="</s>",
         )
-        image_processor = Idefics3ImageProcessor(
-            size={"longest_edge": 32},
-            max_image_size={"longest_edge": 16},
-            do_image_splitting=False,
+        image_processor = CLIPImageProcessor(
+            size={"shortest_edge": 32},
+            crop_size={"height": 32, "width": 32},
         )
         base_dir = tmp_path / "base"
-        Idefics3Processor(
+        CLIPProcessor(
             image_processor=image_processor,
             tokenizer=tokenizer,
-            image_seq_len=4,
         ).save_pretrained(base_dir)
 
         mock_model = self._make_mock_model()
@@ -695,7 +693,7 @@ class TestMergeLoraFunction:
         mock_peft_model.merge_and_unload.return_value = mock_model
 
         mock_auto = MagicMock()
-        mock_auto.__name__ = "AutoModelForMultimodalLM"
+        mock_auto.__name__ = "AutoModelForImageTextToText"
         mock_auto.from_pretrained.return_value = mock_model
         mock_peft_cls = MagicMock()
         mock_peft_cls.from_pretrained.return_value = mock_peft_model
@@ -721,11 +719,70 @@ class TestMergeLoraFunction:
                 )
 
         reloaded = AutoProcessor.from_pretrained(output_dir)
-        assert isinstance(reloaded, Idefics3Processor)
-        assert isinstance(reloaded.image_processor, Idefics3ImageProcessor)
-        assert reloaded.image_seq_len == 4
-        assert reloaded.image_processor.size["longest_edge"] == 32
-        assert reloaded.image_processor.max_image_size["longest_edge"] == 16
+        assert isinstance(reloaded, CLIPProcessor)
+        assert reloaded.image_processor is not None
+        assert reloaded.image_processor.size["shortest_edge"] == 32
+        assert reloaded.image_processor.crop_size["height"] == 32
+
+    @patch("tools.merge_lora.gc")
+    @patch("tools.merge_lora.torch")
+    def test_processor_save_failure_still_saves_tokenizer(self, mock_torch, mock_gc, tmp_path):
+        """A processor that loads but fails to serialize must not block tokenizer saving."""
+        from tools.merge_lora import merge_lora
+
+        mock_torch.float16 = torch.float16
+
+        mock_model = self._make_mock_model()
+        mock_peft_model = MagicMock()
+        mock_peft_model.merge_and_unload.return_value = mock_model
+
+        mock_auto = MagicMock()
+        mock_auto.__name__ = "AutoModelForMultimodalLM"
+        mock_auto.from_pretrained.return_value = mock_model
+        mock_peft_cls = MagicMock()
+        mock_peft_cls.from_pretrained.return_value = mock_peft_model
+
+        # Processor loads successfully but raises during save_pretrained.
+        mock_processor = MagicMock()
+        mock_processor.save_pretrained.side_effect = OSError("disk full")
+        mock_processor_cls = MagicMock()
+        mock_processor_cls.from_pretrained.return_value = mock_processor
+
+        output_dir = tmp_path / "out"
+
+        def save_tok(path, **kwargs):
+            Path(path).mkdir(parents=True, exist_ok=True)
+            (Path(path) / "tokenizer_config.json").write_text(json.dumps({"tokenizer_class": "StubTokenizer"}))
+
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.save_pretrained.side_effect = save_tok
+        mock_tokenizer_cls = MagicMock()
+        mock_tokenizer_cls.from_pretrained.return_value = mock_tokenizer
+
+        with patch("tools.merge_lora._resolve_auto_cls", return_value=mock_auto):
+            with patch.dict(
+                "sys.modules",
+                {
+                    "peft": MagicMock(PeftModel=mock_peft_cls),
+                    "transformers": MagicMock(
+                        AutoTokenizer=mock_tokenizer_cls,
+                        AutoProcessor=mock_processor_cls,
+                    ),
+                },
+            ):
+                merge_lora(
+                    base_model="/fake/vlm",
+                    adapter_path="/fake/adapter",
+                    output_dir=str(output_dir),
+                    dtype="float16",
+                    device="cpu",
+                    save_tokenizer=True,
+                )
+
+        mock_processor.save_pretrained.assert_called_once()
+        # The processor failure is contained: tokenizer artifacts are still written.
+        mock_tokenizer.save_pretrained.assert_called_once()
+        assert (output_dir / "tokenizer_config.json").is_file()
 
     @patch("tools.merge_lora.gc")
     @patch("tools.merge_lora.torch")

--- a/tests/unit_tests/tools/test_merge_lora.py
+++ b/tests/unit_tests/tools/test_merge_lora.py
@@ -648,6 +648,135 @@ class TestMergeLoraFunction:
 
     @patch("tools.merge_lora.gc")
     @patch("tools.merge_lora.torch")
+    def test_vlm_processor_artifacts_are_reloadable(self, mock_torch, mock_gc, tmp_path):
+        """The merged output contains VLM processor artifacts that AutoProcessor can reload."""
+        from tokenizers import Tokenizer
+        from tokenizers.models import WordLevel
+        from tokenizers.pre_tokenizers import Whitespace
+        from transformers import (
+            AutoProcessor,
+            Idefics3ImageProcessor,
+            Idefics3Processor,
+            PreTrainedTokenizerFast,
+        )
+
+        from tools.merge_lora import merge_lora
+
+        mock_torch.float16 = torch.float16
+
+        tokenizer_backend = Tokenizer(
+            WordLevel(
+                vocab={"<pad>": 0, "<s>": 1, "</s>": 2, "<unk>": 3, "a": 4},
+                unk_token="<unk>",
+            )
+        )
+        tokenizer_backend.pre_tokenizer = Whitespace()
+        tokenizer = PreTrainedTokenizerFast(
+            tokenizer_object=tokenizer_backend,
+            unk_token="<unk>",
+            pad_token="<pad>",
+            bos_token="<s>",
+            eos_token="</s>",
+        )
+        image_processor = Idefics3ImageProcessor(
+            size={"longest_edge": 32},
+            max_image_size={"longest_edge": 16},
+            do_image_splitting=False,
+        )
+        base_dir = tmp_path / "base"
+        Idefics3Processor(
+            image_processor=image_processor,
+            tokenizer=tokenizer,
+            image_seq_len=4,
+        ).save_pretrained(base_dir)
+
+        mock_model = self._make_mock_model()
+        mock_peft_model = MagicMock()
+        mock_peft_model.merge_and_unload.return_value = mock_model
+
+        mock_auto = MagicMock()
+        mock_auto.__name__ = "AutoModelForMultimodalLM"
+        mock_auto.from_pretrained.return_value = mock_model
+        mock_peft_cls = MagicMock()
+        mock_peft_cls.from_pretrained.return_value = mock_peft_model
+        mock_tokenizer_cls = MagicMock()
+        mock_tokenizer_cls.from_pretrained.return_value = MagicMock()
+
+        output_dir = tmp_path / "out"
+        with patch("tools.merge_lora._resolve_auto_cls", return_value=mock_auto):
+            with patch.dict(
+                "sys.modules",
+                {
+                    "peft": MagicMock(PeftModel=mock_peft_cls),
+                    "nemo_automodel._transformers.auto_tokenizer": MagicMock(NeMoAutoTokenizer=mock_tokenizer_cls),
+                },
+            ):
+                merge_lora(
+                    base_model=str(base_dir),
+                    adapter_path="/fake/adapter",
+                    output_dir=str(output_dir),
+                    dtype="float16",
+                    device="cpu",
+                    save_tokenizer=True,
+                )
+
+        reloaded = AutoProcessor.from_pretrained(output_dir)
+        assert isinstance(reloaded, Idefics3Processor)
+        assert isinstance(reloaded.image_processor, Idefics3ImageProcessor)
+        assert reloaded.image_seq_len == 4
+        assert reloaded.image_processor.size["longest_edge"] == 32
+        assert reloaded.image_processor.max_image_size["longest_edge"] == 16
+
+    @patch("tools.merge_lora.gc")
+    @patch("tools.merge_lora.torch")
+    def test_processor_load_failure_falls_back_to_tokenizer(self, mock_torch, mock_gc, tmp_path):
+        """A processor load failure still allows tokenizer artifacts to be saved."""
+        from tools.merge_lora import merge_lora
+
+        mock_torch.float16 = torch.float16
+
+        mock_model = self._make_mock_model()
+        mock_peft_model = MagicMock()
+        mock_peft_model.merge_and_unload.return_value = mock_model
+
+        mock_auto = MagicMock()
+        mock_auto.__name__ = "AutoModelForCausalLM"
+        mock_auto.from_pretrained.return_value = mock_model
+        mock_peft_cls = MagicMock()
+        mock_peft_cls.from_pretrained.return_value = mock_peft_model
+
+        mock_processor_cls = MagicMock()
+        mock_processor_cls.from_pretrained.side_effect = ValueError("no processor")
+
+        mock_tokenizer = MagicMock()
+        mock_tokenizer_cls = MagicMock()
+        mock_tokenizer_cls.from_pretrained.return_value = mock_tokenizer
+
+        with patch("tools.merge_lora._resolve_auto_cls", return_value=mock_auto):
+            with patch.dict(
+                "sys.modules",
+                {
+                    "peft": MagicMock(PeftModel=mock_peft_cls),
+                    "transformers": MagicMock(
+                        AutoTokenizer=mock_tokenizer_cls,
+                        AutoProcessor=mock_processor_cls,
+                    ),
+                },
+            ):
+                merge_lora(
+                    base_model="/fake/text-model",
+                    adapter_path="/fake/adapter",
+                    output_dir=str(tmp_path / "out"),
+                    dtype="float16",
+                    device="cpu",
+                    save_tokenizer=True,
+                )
+
+        mock_processor_cls.from_pretrained.assert_called_once()
+        mock_tokenizer.save_pretrained.assert_called_once()
+
+    @patch("tools.merge_lora.gc")
+    @patch("tools.merge_lora.torch")
     def test_lora_merge_tokenizer_failure_is_warning(self, mock_torch, mock_gc, tmp_path):
         """If tokenizer save fails, merge_lora logs a warning but does not raise."""
         from tools.merge_lora import merge_lora

--- a/tools/merge_lora.py
+++ b/tools/merge_lora.py
@@ -204,7 +204,9 @@ def merge_lora(
         qlora: If True, load the base model in 4-bit and dequantize before merging.
         dtype: Weight dtype for the merged model (``float16``, ``bfloat16``, ``float32``).
         device: ``auto``, ``cpu``, or ``cuda:N``.
-        save_tokenizer: Whether to save the tokenizer alongside the model.
+        save_tokenizer: Whether to save the tokenizer and any processor artifacts
+            available from the base model. If processor loading fails, tokenizer
+            saving is still attempted.
         trust_remote_code: Passed through to ``from_pretrained``.
         model_class: Explicit ``transformers`` Auto class name (e.g.
             ``"AutoModel"``, ``"AutoModelForCausalLM"``).  When ``None``
@@ -261,6 +263,24 @@ def merge_lora(
         _clean_quantization_config(output_dir)
 
     if save_tokenizer:
+        # Save available processor artifacts first so multimodal outputs remain
+        # loadable from the merged directory. Save the tokenizer last so its files
+        # take precedence if processor serialization writes overlapping files.
+        processor = None
+        try:
+            from transformers import AutoProcessor
+
+            processor = AutoProcessor.from_pretrained(base_model, trust_remote_code=trust_remote_code)
+        except Exception as e:
+            logger.info("Could not load processor for %s; continuing without processor artifacts: %s", base_model, e)
+
+        if processor is not None:
+            try:
+                processor.save_pretrained(output_dir)
+                logger.info("Processor saved to %s", output_dir)
+            except Exception as e:
+                logger.warning("Could not save processor artifacts to %s: %s", output_dir, e)
+
         try:
             # Prefer NeMoAutoTokenizer: on transformers>=5 a plain
             # AutoTokenizer.save_pretrained re-serializes the tokenizer and
@@ -332,7 +352,7 @@ def parse_args() -> argparse.Namespace:
         "--no-save-tokenizer",
         action="store_true",
         default=False,
-        help="Skip saving the tokenizer.",
+        help="Skip saving the tokenizer and processor artifacts.",
     )
     parser.add_argument(
         "--trust-remote-code",


### PR DESCRIPTION
# What does this PR do ?

Fixes NVIDIA-NeMo/Automodel#3256

* Save available `AutoProcessor` artifacts alongside merged LoRA models.
* Preserve tokenizer-only fallback when processor loading or saving fails.
* Add an offline Idefics3 processor save/reload unit test.

# Changelog

See above

# Before your PR is "Ready for review"

**Pre checks**:

- [X] Make sure you read and followed [Contributor guidelines](<https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md>)
- [X] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?