### PR TITLE
fix(tools): save VLM processor artifacts

### DIFF
--- a/tests/unit_tests/tools/test_merge_lora.py
+++ b/tests/unit_tests/tools/test_merge_lora.py
@@ -620,6 +620,8 @@ class TestMergeLoraFunction:
         mock_auto.from_pretrained.return_value = mock_model
         mock_peft_cls = MagicMock()
         mock_peft_cls.from_pretrained.return_value = mock_peft_model
+        mock_processor_cls = MagicMock()
+        mock_processor_cls.from_pretrained.side_effect = ValueError("no processor")
         mock_tokenizer_cls = MagicMock()
         mock_tokenizer = MagicMock()
         mock_tokenizer_cls.from_pretrained.return_value = mock_tokenizer
@@ -630,6 +632,7 @@ class TestMergeLoraFunction:
                 {
                     "peft": MagicMock(PeftModel=mock_peft_cls),
                     "transformers": MagicMock(
+                        AutoProcessor=mock_processor_cls,
                         AutoTokenizer=mock_tokenizer_cls,
                     ),
                 },
@@ -645,6 +648,107 @@ class TestMergeLoraFunction:
 
         mock_tokenizer_cls.from_pretrained.assert_called_once()
         mock_tokenizer.save_pretrained.assert_called_once()
+
+    @patch("tools.merge_lora.gc")
+    @patch("tools.merge_lora.torch")
+    def test_lora_merge_saves_processor(self, mock_torch, mock_gc, tmp_path):
+        from tools.merge_lora import merge_lora
+
+        mock_torch.float16 = torch.float16
+
+        mock_model = self._make_mock_model()
+        mock_peft_model = MagicMock()
+        mock_peft_model.merge_and_unload.return_value = mock_model
+
+        mock_auto = MagicMock()
+        mock_auto.__name__ = "AutoModelForMultimodalLM"
+        mock_auto.from_pretrained.return_value = mock_model
+        mock_peft_cls = MagicMock()
+        mock_peft_cls.from_pretrained.return_value = mock_peft_model
+        mock_processor_cls = MagicMock()
+        mock_processor = MagicMock()
+        mock_processor_cls.from_pretrained.return_value = mock_processor
+
+        output_dir = str(tmp_path / "out")
+
+        def save_processor(path):
+            output_path = Path(path)
+            output_path.mkdir(parents=True, exist_ok=True)
+            (output_path / "preprocessor_config.json").write_text('{"processor_class": "FakeProcessor"}')
+
+        mock_processor.save_pretrained.side_effect = save_processor
+        with patch("tools.merge_lora._resolve_auto_cls", return_value=mock_auto):
+            with patch.dict(
+                "sys.modules",
+                {
+                    "peft": MagicMock(PeftModel=mock_peft_cls),
+                    "transformers": MagicMock(
+                        AutoProcessor=mock_processor_cls,
+                        AutoTokenizer=MagicMock(),
+                    ),
+                },
+            ):
+                merge_lora(
+                    base_model="/fake/vlm",
+                    adapter_path="/fake/adapter",
+                    output_dir=output_dir,
+                    dtype="float16",
+                    device="cpu",
+                    save_tokenizer=False,
+                    trust_remote_code=True,
+                )
+
+        mock_processor_cls.from_pretrained.assert_called_once_with("/fake/vlm", trust_remote_code=True)
+        mock_processor.save_pretrained.assert_called_once_with(output_dir)
+        assert json.loads((Path(output_dir) / "preprocessor_config.json").read_text()) == {
+            "processor_class": "FakeProcessor"
+        }
+
+    @patch("tools.merge_lora.gc")
+    @patch("tools.merge_lora.torch")
+    def test_lora_merge_processor_failure_falls_back_to_tokenizer(self, mock_torch, mock_gc, tmp_path):
+        from tools.merge_lora import merge_lora
+
+        mock_torch.float16 = torch.float16
+
+        mock_model = self._make_mock_model()
+        mock_peft_model = MagicMock()
+        mock_peft_model.merge_and_unload.return_value = mock_model
+
+        mock_auto = MagicMock()
+        mock_auto.__name__ = "AutoModelForCausalLM"
+        mock_auto.from_pretrained.return_value = mock_model
+        mock_peft_cls = MagicMock()
+        mock_peft_cls.from_pretrained.return_value = mock_peft_model
+        mock_processor_cls = MagicMock()
+        mock_processor_cls.from_pretrained.side_effect = ValueError("no processor")
+        mock_tokenizer_cls = MagicMock()
+        mock_tokenizer = MagicMock()
+        mock_tokenizer_cls.from_pretrained.return_value = mock_tokenizer
+
+        output_dir = str(tmp_path / "out")
+        with patch("tools.merge_lora._resolve_auto_cls", return_value=mock_auto):
+            with patch.dict(
+                "sys.modules",
+                {
+                    "peft": MagicMock(PeftModel=mock_peft_cls),
+                    "transformers": MagicMock(
+                        AutoProcessor=mock_processor_cls,
+                        AutoTokenizer=mock_tokenizer_cls,
+                    ),
+                },
+            ):
+                merge_lora(
+                    base_model="/fake/text-model",
+                    adapter_path="/fake/adapter",
+                    output_dir=output_dir,
+                    dtype="float16",
+                    device="cpu",
+                    save_tokenizer=True,
+                )
+
+        mock_tokenizer_cls.from_pretrained.assert_called_once_with("/fake/text-model", trust_remote_code=False)
+        mock_tokenizer.save_pretrained.assert_called_once_with(output_dir)
 
     @patch("tools.merge_lora.gc")
     @patch("tools.merge_lora.torch")

--- a/tools/merge_lora.py
+++ b/tools/merge_lora.py
@@ -211,7 +211,7 @@ def merge_lora(
             the class is inferred from the adapter's ``task_type``.
     """
     from peft import PeftModel
-    from transformers import AutoTokenizer
+    from transformers import AutoProcessor, AutoTokenizer
 
     auto_cls = _resolve_auto_cls(adapter_path, model_class)
     torch_dtype = getattr(torch, dtype)
@@ -259,6 +259,13 @@ def merge_lora(
 
     if qlora:
         _clean_quantization_config(output_dir)
+
+    try:
+        processor = AutoProcessor.from_pretrained(base_model, trust_remote_code=trust_remote_code)
+        processor.save_pretrained(output_dir)
+        logger.info("Processor saved to %s", output_dir)
+    except Exception as e:
+        logger.info("No processor saved; continuing with tokenizer-only output: %s", e)
 
     if save_tokenizer:
         try:


### PR DESCRIPTION
# What does this PR do?

Save Hugging Face processor artifacts alongside merged LoRA model weights so
vision-language model outputs remain loadable as standalone model directories.

The merge tool previously saved the model and tokenizer only. VLM-specific
sidecars such as `preprocessor_config.json` were therefore absent from the
merged output.

# Changelog

- Load `AutoProcessor` from the base model with the existing
  `trust_remote_code` setting.
- Save processor artifacts independently of tokenizer saving.
- Gracefully retain tokenizer-only behavior when a model has no processor.
- Add CPU unit coverage for processor artifact creation and fallback behavior.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added necessary unit tests.
- [x] Documentation is not required; the existing CLI and public options are
  unchanged.

# Validation

- `pytest tests/unit_tests/tools/test_merge_lora.py -q` — 39 passed
- `pytest tests/unit_tests/tools/ -q` — 42 passed
- `ruff format --check .` — 692 files already formatted
- `ruff check .` — passed
- `git diff --check` — passed

Scoped `ty check tools/merge_lora.py` continues to report five pre-existing
diagnostics involving optional bitsandbytes, heterogeneous load kwargs, and
tokenizer typing; it reports no diagnostic for the new processor path.

# Additional Information

Closes #3256.
