### PR TITLE
fix(docker): cap uv install concurrency to avoid ARM FD exhaustion

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -176,6 +176,7 @@ RUN --mount=type=cache,target=/opt/uv_cache,sharing=locked \
     MAGI_ATTENTION_BUILD_COMPUTE_CAPABILITY="90,100" \
         MAGI_ATTENTION_PREBUILD_FFA=0 \
         MAX_JOBS=8 \
+        UV_CONCURRENT_INSTALLS=8 \
         uv sync --extra $AUTOMODEL_INSTALL --all-groups $UV_SYNC_ARGS && \
     python -c "import importlib.metadata as m; import magi_attention; print('magi-attention', m.version('magi-attention'))"
 


### PR DESCRIPTION
# What does this PR do ?

uv sync's post-install bytecode-compile fans out workers by CPU count under UV_COMPILE_BYTECODE=1; on the high-core ARM builder this exhausts the 1024 nofile soft limit (astral-sh/uv#16999). Scope UV_CONCURRENT_INSTALLS=8 to the big sync RUN

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
