### PR TITLE
test(retrieval): add Nemotron VL checkpoint coverage

### DIFF
--- a/docs/guides/llm/retrieval-finetune.mdx
+++ b/docs/guides/llm/retrieval-finetune.mdx
@@ -461,6 +461,11 @@ gradient_accumulation_steps = global_batch_size / (local_batch_size * data_paral
 For the supported data-parallel FSDP2 configuration, `data_parallel_size` is the total GPU count. For example, two
 8-GPU nodes have `data_parallel_size: 16`.
 
+For DDP recipes, keep `distributed.static_graph: false` whenever `gradient_accumulation_steps > 1`. Recalculate the
+accumulation steps after changing the GPU count, `global_batch_size`, or `local_batch_size`. When the result is `1` and
+the model follows the same execution path on every iteration, you can set `distributed.static_graph: true` to reduce
+DDP overhead.
+
 `local_batch_size` is the number of query groups per rank. For memory pressure, reduce
 `step_scheduler.local_batch_size` first, then sequence lengths (`q_max_len`, `p_max_len`, or `rerank_max_length`), then
 `n_passages`. Bi-encoders scale memory with query length plus `local_batch_size * n_passages` passage sequences.

--- a/docs/guides/llm/retrieval-finetune.mdx
+++ b/docs/guides/llm/retrieval-finetune.mdx
@@ -303,7 +303,6 @@ distributed:
 ```
 
 For a cross-encoder, change `recipe`, `model._target_`, `dataset.model_type`, and `dataloader.collate_fn`
-to the cross-encoder values shown below. Also set `model.num_labels: 1`, set the loss temperature under
 to the cross-encoder values in the following example. Also set `model.num_labels: 1`, set the loss temperature under
 `model.temperature`, replace `q_max_len` and `p_max_len` with `rerank_max_length` in the collator, and use a separate
 `checkpoint.checkpoint_dir` such as `./output/llama3_2_1b_cross_encoder/checkpoints`.
@@ -534,10 +533,6 @@ for RAG candidate generation, evaluate against a fixed held-out corpus and qrels
 
 AutoModel does not currently provide a one-command full-corpus retrieval evaluator in this guide. Use your existing
 information retrieval evaluation stack or a small script around the consolidated checkpoint. Report enough run details
-to make the result repeatable: query count, corpus size, qrels source, judged and unjudged handling, exact versus ANN
-search settings, K values, baseline checkpoint, and whether you used confidence intervals or significance tests. At
-minimum, make these script inputs explicit: a consolidated bi-encoder checkpoint, a corpus table with stable document
-IDs, a query table with stable query IDs, qrels keyed by those IDs, the query and passage prefixes and maximum lengths,
 to make the result repeatable. Include the query count, corpus size, qrels source, judged and unjudged handling, exact
 or ANN search settings, K values, and baseline checkpoint. State whether you used confidence intervals or significance
 tests. At minimum, specify a consolidated bi-encoder checkpoint, corpus and query tables with stable IDs, and qrels
@@ -558,9 +553,6 @@ but might not update during a short basic verification test:
 tail -f ./output/llama3_2_1b_encoder/checkpoints/training.jsonl
 ```
 
-Use standard output and error as the live per-step signals today. Watch `loss`, `grad_norm`, learning rate, GPU
-memory, and step time
-before scaling to a longer run. On preempted or timed-out jobs, recent buffered JSONL metrics may be missing even when
 Use standard output and error as the live per-step signals today. Watch `loss`, `grad_norm`, learning rate, GPU memory,
 and step time before scaling to a longer run. On preempted or timed-out jobs, recent buffered JSONL metrics might be
 missing even when standard output and error showed them.
@@ -754,10 +746,8 @@ direct Hugging Face and mining loads expect a real exported model path. If your 
 symlink, read that file and substitute the resolved checkpoint directory before calling `from_pretrained()` or
 `mine_hard_negatives.py`.
 
-PEFT/LoRA runs save adapter artifacts under the checkpoint `model/` directory instead of the full consolidated export
-path above. Resume LoRA training from the AutoModel checkpoint directory. If you need a standalone checkpoint for
-PEFT runs using LoRA save adapter artifacts under the checkpoint `model/` directory instead of the previously described full
-consolidated export path. Resume LoRA training from the AutoModel checkpoint directory. If you need a standalone
+PEFT runs using LoRA save adapter artifacts under the checkpoint `model/` directory instead of the previously described
+full consolidated export path. Resume LoRA training from the AutoModel checkpoint directory. If you need a standalone
 checkpoint for inference or mining, first produce a Hugging Face-loadable merged encoder with your adapter workflow.
 
 The `LATEST` symlink points to the most recent checkpoint when it is valid. To resume from the latest resolved

--- a/docs/guides/llm/retrieval-finetune.mdx
+++ b/docs/guides/llm/retrieval-finetune.mdx
@@ -461,10 +461,11 @@ gradient_accumulation_steps = global_batch_size / (local_batch_size * data_paral
 For the supported data-parallel FSDP2 configuration, `data_parallel_size` is the total GPU count. For example, two
 8-GPU nodes have `data_parallel_size: 16`.
 
-For DDP recipes, keep `distributed.static_graph: false` whenever `gradient_accumulation_steps > 1`. Recalculate the
-accumulation steps after changing the GPU count, `global_batch_size`, or `local_batch_size`. When the result is `1` and
-the model follows the same execution path on every iteration, you can set `distributed.static_graph: true` to reduce
-DDP overhead.
+For DDP recipes, keep `distributed.static_graph: false` whenever `gradient_accumulation_steps > 1`. If the model
+contains parameters that do not contribute to the loss, also set `distributed.find_unused_parameters: true` when the
+static graph is disabled. Recalculate the accumulation steps after changing the GPU count, `global_batch_size`, or
+`local_batch_size`. When the result is `1` and the model follows the same execution path on every iteration, you can
+set `distributed.static_graph: true` to reduce DDP overhead.
 
 `local_batch_size` is the number of query groups per rank. For memory pressure, reduce
 `step_scheduler.local_batch_size` first, then sequence lengths (`q_max_len`, `p_max_len`, or `rerank_max_length`), then

--- a/docs/guides/llm/retrieval-finetune.mdx
+++ b/docs/guides/llm/retrieval-finetune.mdx
@@ -53,7 +53,7 @@ Before running the examples:
 The examples use `automodel`. From a source checkout, prefix these commands with `uv run`. For direct `torchrun`
 commands, use `uv run torchrun ...` from a source checkout or activate an installed environment first.
 
-Run a one-GPU basic verification test first. The timestamped checkpoint directory keeps this command from silently
+Run a single-GPU basic verification test first. The timestamped checkpoint directory keeps this command from silently
 resuming or appending metrics to an older run:
 
 ```bash
@@ -108,7 +108,7 @@ Choose the recipe that matches your retrieval stage:
 
 The following table compares the recipe components:
 
-| Component | Bi-encoder | Cross-encoder |
+| Component | Bi-Encoder | Cross-Encoder |
 |-----------|------------|---------------|
 | Recipe | `TrainBiEncoderRecipe` | `TrainCrossEncoderRecipe` |
 | Model target | `nemo_automodel.NeMoAutoModelBiEncoder.from_pretrained` | `nemo_automodel.NeMoAutoModelCrossEncoder.from_pretrained` |
@@ -121,7 +121,7 @@ query-passage pair into one sequence and predicts a score for each candidate pas
 
 The following table summarizes the supported model families and their effective retrieval keyword arguments:
 
-| Model `config.model_type` | Bi-encoder behavior | Cross-encoder behavior | Effective retrieval keyword arguments |
+| Model `config.model_type` | Bi-Encoder Behavior | Cross-Encoder Behavior | Effective Retrieval Keyword Arguments |
 |---------------------------|---------------------|------------------------|----------------------------|
 | `llama`, `llama_bidirec` | Uses `LlamaBidirectionalModel` | Uses `LlamaBidirectionalForSequenceClassification` | Bi-encoder: `pooling`, wrapper-level `l2_normalize`, and top-level recipe `temperature`. Cross-encoder: `pooling`, `num_labels`, and `temperature` on the Llama scoring config. |
 | `ministral3`, `ministral3_bidirec` | Uses `Ministral3BidirectionalModel` | Direct cross-encoder scoring is not supported by the custom retrieval registry today. Use a different direct cross-encoder backbone. | Bi-encoder: `pooling`, wrapper-level `l2_normalize`, and top-level recipe `temperature`. |
@@ -137,7 +137,7 @@ classification for cross-encoder scoring.
 
 Treat unregistered decoder-only fallback models as an architecture experiment, not just a drop-in model swap. Registered
 retrieval backbones such as the Llama bidirectional path use retrieval-specific attention behavior. A vanilla
-Hugging Face `AutoModel` fallback can keep the source model's original causal behavior, which may be lower quality for
+Hugging Face `AutoModel` fallback can keep the source model's original causal behavior, which might be lower quality for
 symmetric embedding retrieval.
 
 ## Prepare Data
@@ -145,7 +145,7 @@ symmetric embedding retrieval.
 Use the retrieval dataset format described in [Retrieval Dataset](/datasets/retrieval-dataset). Choose the data path that
 matches the workflow you need:
 
-| Data path | Use when | Notes |
+| Data Path | Use When | Notes |
 |-----------|----------|-------|
 | `hf://` AutoModel retrieval schema | You want a tutorial run or shared public dataset | Requires an AutoModel-style HF subset with a companion corpus split. |
 | Inline JSONL | You want a small custom run without hard-negative mining | Documents are embedded directly in each record. Pure inline records do not provide document IDs for same-document masking. |
@@ -165,19 +165,20 @@ for local and Slurm CPU commands.
 
 The key field requirements differ by source:
 
-| Source | Required query field | Required document fields |
+| Source | Required Query Field | Required Document Fields |
 |--------|----------------------|--------------------------|
 | Corpus ID JSON | `question` | `question_id`, `corpus_id`, non-empty `pos_doc`, and present `neg_doc` |
 | `hf://` AutoModel schema | `question` | Non-empty `pos_doc`. `neg_doc` is optional in the source but required before training with negatives. |
-| Inline JSONL | `query` or `question` | non-empty `pos_doc`, and present `neg_doc` |
+| Inline JSONL | `query` or `question` | Non-empty `pos_doc`, and present `neg_doc` |
 
-`neg_doc` must be present for local JSON and JSONL sources. It may be `[]` only when `n_passages: 1`. When
+`neg_doc` must be present for local JSON and JSONL sources. It can be `[]` only when `n_passages: 1`. When
 `n_passages > 1`, provide at least one negative.
 
 <Warning>
 `n_passages: 1` is useful for schema checks or custom negative strategies, but it is not a good default training setup.
 The standard bi-encoder and cross-encoder recipes need at least one negative candidate for meaningful contrastive or
 reranking supervision, unless you add a custom strategy such as qrels-aware in-batch negatives.
+
 </Warning>
 
 For quick custom experiments, inline JSONL is the simplest format. `RetrievalDatasetConfig` selects the inline loading
@@ -303,7 +304,8 @@ distributed:
 
 For a cross-encoder, change `recipe`, `model._target_`, `dataset.model_type`, and `dataloader.collate_fn`
 to the cross-encoder values shown below. Also set `model.num_labels: 1`, set the loss temperature under
-`model.temperature`, replace `q_max_len` / `p_max_len` with `rerank_max_length` in the collator, and use a separate
+to the cross-encoder values in the following example. Also set `model.num_labels: 1`, set the loss temperature under
+`model.temperature`, replace `q_max_len` and `p_max_len` with `rerank_max_length` in the collator, and use a separate
 `checkpoint.checkpoint_dir` such as `./output/llama3_2_1b_cross_encoder/checkpoints`.
 
 ## Configure a Bi-Encoder
@@ -461,7 +463,8 @@ gradient_accumulation_steps = global_batch_size / (local_batch_size * data_paral
 For the supported data-parallel FSDP2 configuration, `data_parallel_size` is the total GPU count. For example, two
 8-GPU nodes have `data_parallel_size: 16`.
 
-For DDP recipes, keep `distributed.static_graph: false` whenever `gradient_accumulation_steps > 1`. If the model
+For Distributed Data Parallel (DDP) recipes, keep `distributed.static_graph: false` whenever
+`gradient_accumulation_steps > 1`. If the model
 contains parameters that do not contribute to the loss, also set `distributed.find_unused_parameters: true` when the
 static graph is disabled. Recalculate the accumulation steps after changing the GPU count, `global_batch_size`, or
 `local_batch_size`. When the result is `1` and the model follows the same execution path on every iteration, you can
@@ -473,12 +476,12 @@ set `distributed.static_graph: true` to reduce DDP overhead.
 Cross-encoders scale with `local_batch_size * n_passages` combined query-passage sequences.
 
 Current retrieval datasets are map-style datasets loaded in each process, not streaming distributed inputs. Pre-cache
-Hugging Face data on each node or use a shared cache, and budget CPU RAM and local disk per rank for corpus-backed datasets.
+Hugging Face data on each node or use a shared cache. Budget CPU RAM and local disk per rank for corpus-backed datasets.
 
 ## Add Validation
 
 Both examples include commented `validation_dataset` and `validation_dataloader` blocks. Enable them when you have a
-held-out retrieval file. Use `RetrievalDatasetConfig` for every supported source; it selects the loading path from the
+held-out retrieval file. Use `RetrievalDatasetConfig` for every supported source. It selects the loading path from the
 source URI and file extension. This corpus-backed example mirrors the shipped configs:
 
 ```yaml
@@ -535,7 +538,10 @@ to make the result repeatable: query count, corpus size, qrels source, judged an
 search settings, K values, baseline checkpoint, and whether you used confidence intervals or significance tests. At
 minimum, make these script inputs explicit: a consolidated bi-encoder checkpoint, a corpus table with stable document
 IDs, a query table with stable query IDs, qrels keyed by those IDs, the query and passage prefixes and maximum lengths,
-and the K values to report.
+to make the result repeatable. Include the query count, corpus size, qrels source, judged and unjudged handling, exact
+or ANN search settings, K values, and baseline checkpoint. State whether you used confidence intervals or significance
+tests. At minimum, specify a consolidated bi-encoder checkpoint, corpus and query tables with stable IDs, and qrels
+keyed by those IDs. Also specify the query and passage prefixes, maximum lengths, and K values to report.
 
 For cross-encoders, freeze a first-stage retriever, rerank its top-K candidates, and report reranking metrics on that
 same candidate set. Also report first-stage candidate recall or coverage: if a query's positive document is missing
@@ -546,7 +552,7 @@ cross-encoder candidate-group validation directly to full-corpus bi-encoder metr
 
 Training metrics are written to `training.jsonl` under `checkpoint.checkpoint_dir`. The file logger buffers records in
 chunks before writing and flushes the remaining records on close, so `tail -f` is useful for completed or longer runs
-but may not update during a short basic verification test:
+but might not update during a short basic verification test:
 
 ```bash
 tail -f ./output/llama3_2_1b_encoder/checkpoints/training.jsonl
@@ -555,7 +561,9 @@ tail -f ./output/llama3_2_1b_encoder/checkpoints/training.jsonl
 Use standard output and error as the live per-step signals today. Watch `loss`, `grad_norm`, learning rate, GPU
 memory, and step time
 before scaling to a longer run. On preempted or timed-out jobs, recent buffered JSONL metrics may be missing even when
-standard output and error showed them.
+Use standard output and error as the live per-step signals today. Watch `loss`, `grad_norm`, learning rate, GPU memory,
+and step time before scaling to a longer run. On preempted or timed-out jobs, recent buffered JSONL metrics might be
+missing even when standard output and error showed them.
 
 The examples include a commented `wandb` block. Enable it when you want remote tracking, and tune
 `step_scheduler.log_remote_every_steps` to control remote logging cadence.
@@ -724,7 +732,7 @@ checkpoint:
   save_consolidated: true
 ```
 
-Each save creates a versioned directory such as:
+Each save creates a versioned directory. The following path is an example:
 
 ```text
 ./output/llama3_2_1b_encoder/checkpoints/epoch_0_step_499/
@@ -734,7 +742,8 @@ Checkpoint directory names use the scheduler step at save time. The saved schedu
 for exact paths prefer the `Saving checkpoint to ...` log line or the `LATEST` pointer over hand-constructing a step
 number.
 
-With `save_consolidated: true` and full fine-tuning, AutoModel also writes a Hugging Face-compatible model under:
+With `save_consolidated: true` and full fine-tuning, AutoModel also writes a Hugging Face-compatible model under the
+following path:
 
 ```text
 ./output/llama3_2_1b_encoder/checkpoints/epoch_0_step_499/model/consolidated/
@@ -747,7 +756,9 @@ symlink, read that file and substitute the resolved checkpoint directory before 
 
 PEFT/LoRA runs save adapter artifacts under the checkpoint `model/` directory instead of the full consolidated export
 path above. Resume LoRA training from the AutoModel checkpoint directory. If you need a standalone checkpoint for
-inference or mining, first produce a Hugging Face-loadable merged encoder with your adapter workflow.
+PEFT runs using LoRA save adapter artifacts under the checkpoint `model/` directory instead of the previously described full
+consolidated export path. Resume LoRA training from the AutoModel checkpoint directory. If you need a standalone
+checkpoint for inference or mining, first produce a Hugging Face-loadable merged encoder with your adapter workflow.
 
 The `LATEST` symlink points to the most recent checkpoint when it is valid. To resume from the latest resolved
 checkpoint, set:

--- a/examples/retrieval/bi_encoder/nemotron_vl_1b/README.md
+++ b/examples/retrieval/bi_encoder/nemotron_vl_1b/README.md
@@ -148,7 +148,7 @@ torchrun --nproc-per-node=8 examples/retrieval/bi_encoder/finetune.py --config e
 ```
 
 The default batch settings use one local batch on each of eight GPUs, so they do not use gradient accumulation and
-`distributed.static_graph: true` is appropriate. If you reduce the GPU count without reducing `global_batch_size`,
+thus `distributed.static_graph: true` is appropriate. If you reduce the GPU count without reducing `global_batch_size`,
 the resulting run uses more than one gradient accumulation step. Update the DDP settings as follows:
 
 ```yaml

--- a/examples/retrieval/bi_encoder/nemotron_vl_1b/README.md
+++ b/examples/retrieval/bi_encoder/nemotron_vl_1b/README.md
@@ -4,7 +4,12 @@ This example shows how to fine-tune an embedding model for visual document retri
 [nvidia/llama-nemotron-embed-vl-1b-v2](https://huggingface.co/nvidia/llama-nemotron-embed-vl-1b-v2). The model can
 embed document pages as image, text, or combined image-text inputs. Documents can be retrieved given a user query in
 text form. The model supports page images containing text, tables, charts, and infographics. Review the model's
-performance on the
+This example shows how to fine-tune the
+[nvidia/llama-nemotron-embed-vl-1b-v2](https://huggingface.co/nvidia/llama-nemotron-embed-vl-1b-v2)
+model for visual document retrieval. The model embeds document pages supplied
+as images, text, or combined image and text inputs. Documents can be retrieved
+from a user query in text form. The model supports page images that contain
+text, tables, charts, and infographics. Review the model's performance on the
 [vision document retrieval and text retrieval benchmarks](https://huggingface.co/nvidia/llama-nemotron-embed-vl-1b-v2#evaluation-results).
 
 ## Fine-Tune for Domain Adaptation
@@ -34,7 +39,9 @@ details, refer to the
         {"id": "69560"},
         {"id": "112685"},
         {"id": "5132"}, ...
-    }, ...
+        {"id": "5132"}
+      ]
+    }
   ]
 }
 ```

--- a/examples/retrieval/bi_encoder/nemotron_vl_1b/README.md
+++ b/examples/retrieval/bi_encoder/nemotron_vl_1b/README.md
@@ -146,3 +146,7 @@ multi-node training on a Slurm cluster, use `sbatch`.
 ```bash
 torchrun --nproc-per-node=8 examples/retrieval/bi_encoder/finetune.py --config examples/retrieval/bi_encoder/nemotron_vl_1b/nemotron_vl_1b_example.yaml
 ```
+
+The default batch settings use one local batch on each of eight GPUs, so they do not use gradient accumulation and
+`distributed.static_graph: true` is appropriate. If you reduce the GPU count without reducing `global_batch_size`,
+set `distributed.static_graph: false` because the resulting run uses more than one gradient accumulation step.

--- a/examples/retrieval/bi_encoder/nemotron_vl_1b/README.md
+++ b/examples/retrieval/bi_encoder/nemotron_vl_1b/README.md
@@ -149,4 +149,13 @@ torchrun --nproc-per-node=8 examples/retrieval/bi_encoder/finetune.py --config e
 
 The default batch settings use one local batch on each of eight GPUs, so they do not use gradient accumulation and
 `distributed.static_graph: true` is appropriate. If you reduce the GPU count without reducing `global_batch_size`,
-set `distributed.static_graph: false` because the resulting run uses more than one gradient accumulation step.
+the resulting run uses more than one gradient accumulation step. Update the DDP settings as follows:
+
+```yaml
+distributed:
+  static_graph: false
+  find_unused_parameters: true
+```
+
+Unused-parameter detection is required because the model retains a SigLIP pooling head that does not participate in
+the retrieval loss.

--- a/examples/retrieval/bi_encoder/nemotron_vl_1b/README.md
+++ b/examples/retrieval/bi_encoder/nemotron_vl_1b/README.md
@@ -1,9 +1,5 @@
 # Fine-Tune the Llama Nemotron VL 1B Embedding Model
 
-This example shows how to fine-tune an embedding model for visual document retrieval:
-[nvidia/llama-nemotron-embed-vl-1b-v2](https://huggingface.co/nvidia/llama-nemotron-embed-vl-1b-v2). The model can
-embed document pages as image, text, or combined image-text inputs. Documents can be retrieved given a user query in
-text form. The model supports page images containing text, tables, charts, and infographics. Review the model's
 This example shows how to fine-tune the
 [nvidia/llama-nemotron-embed-vl-1b-v2](https://huggingface.co/nvidia/llama-nemotron-embed-vl-1b-v2)
 model for visual document retrieval. The model embeds document pages supplied
@@ -38,7 +34,6 @@ details, refer to the
       "neg_doc": [
         {"id": "69560"},
         {"id": "112685"},
-        {"id": "5132"}, ...
         {"id": "5132"}
       ]
     }
@@ -49,24 +44,24 @@ details, refer to the
 The `corpus` path points to a directory that contains the corpus in Parquet format, with a field for the document ID.
 The `data` key contains the training samples for contrastive learning: the question, positive samples (`pos_doc`), and
 negative samples (`neg_doc`). The positive and negative samples are document IDs from the corpus and can represent
-document page images or chunks of text (passages).
+document page images or text passages.
 
 ### Prepare the ColPali Source Data
 
 Run
 [`prepare_dataset_for_vdr/convert_colpali_dataset_for_training.ipynb`](../prepare_dataset_for_vdr/convert_colpali_dataset_for_training.ipynb)
-to prepare the ColPali example. The notebook:
+to prepare the ColPali example. The notebook performs the following tasks:
 
-1. Downloads a [train set](https://huggingface.co/datasets/Tevatron/colpali) with mined hard negatives and its
+1. Downloads a [training set](https://huggingface.co/datasets/Tevatron/colpali) with mined hard negatives and its
    [corpus](https://huggingface.co/datasets/Tevatron/colpali-corpus).
 2. Writes the corpus as local Parquet shards and writes `colpali_train.json` in AutoModel's corpus ID-based schema.
 
-These files are the source data for both loading paths below. The notebook does not create normalized Arrow; that is a
-separate CPU preparation step for full-scale training.
+These files are the source data for both loading methods in this guide. The notebook does not create normalized Arrow
+data. That process is a separate CPU preparation step for full-scale training.
 
 After the notebook finishes, open [`nemotron_vl_1b_example.yaml`](nemotron_vl_1b_example.yaml) and replace the ColPali
 path in `dataset.data_dir_list` with the generated `colpali_train.json` path. The example also includes the
-[MIRACL train set](https://huggingface.co/datasets/nvidia/embed-nemotron-dataset-v1/viewer/MIRACL) for multilingual
+[MIRACL training set](https://huggingface.co/datasets/nvidia/embed-nemotron-dataset-v1/viewer/MIRACL) for multilingual
 text retrieval. Use `num_samples` to control how many examples to load from each source.
 
 ### Choose How Training Loads the Prepared Data
@@ -110,12 +105,12 @@ dataset:
   n_passages: 5
 ```
 
-Starting GPU training directly from a large image corpus can leave every allocated GPU waiting while the corpus is
-loaded and its dataset cache is built. Normalizing on CPU moves that work before the GPU allocation.
+Starting GPU training directly from a large image corpus can leave every allocated GPU waiting while the corpus loads
+and its dataset cache builds. Normalizing on CPU completes that work before GPU allocation.
 
 #### Load the Source Data Directly for Small Runs
 
-For a small verification run or a small dataset, skip normalization and keep the original dataset config. It reads the
+For a small verification run or dataset, skip normalization and keep the original dataset config. The loader reads the
 notebook's JSON and corpus files directly:
 
 ```yaml
@@ -131,8 +126,8 @@ dataset:
   n_passages: 5
 ```
 
-The direct path is usually sufficient for text-only retrieval. If its initial startup is slow, the retrieval data tools
-also provide a CPU cache-warming script that keeps this dataset configuration unchanged.
+The direct path is usually sufficient for text-only retrieval. If startup is slow, the retrieval data tools also provide
+a CPU cache-warming script that keeps this dataset config unchanged.
 
 If you have a Weights & Biases (W&B) account, configure the YAML file to log training metrics during training:
 
@@ -154,9 +149,10 @@ multi-node training on a Slurm cluster, use `sbatch`.
 torchrun --nproc-per-node=8 examples/retrieval/bi_encoder/finetune.py --config examples/retrieval/bi_encoder/nemotron_vl_1b/nemotron_vl_1b_example.yaml
 ```
 
-The default batch settings use one local batch on each of eight GPUs, so they do not use gradient accumulation and
-thus `distributed.static_graph: true` is appropriate. If you reduce the GPU count without reducing `global_batch_size`,
-the resulting run uses more than one gradient accumulation step. Update the DDP settings as follows:
+The default batch settings use one local batch on each of eight GPUs, so gradient accumulation is disabled and
+`distributed.static_graph: true` is appropriate. If you reduce the GPU count without reducing `global_batch_size`, the
+resulting run uses more than one gradient accumulation step. Update the distributed data parallel (DDP) settings as
+follows:
 
 ```yaml
 distributed:

--- a/examples/retrieval/bi_encoder/nemotron_vl_1b/nemotron_vl_1b_example.yaml
+++ b/examples/retrieval/bi_encoder/nemotron_vl_1b/nemotron_vl_1b_example.yaml
@@ -111,7 +111,7 @@ wandb:
 
 ci:
   recipe_owner: yuhez
-  time: "02:00:00"
+  time: "00:45:00"
   nodes: 1
   nightly:
     # CI uses the public text corpus; checkpoint robustness separately tests

--- a/examples/retrieval/bi_encoder/nemotron_vl_1b/nemotron_vl_1b_example.yaml
+++ b/examples/retrieval/bi_encoder/nemotron_vl_1b/nemotron_vl_1b_example.yaml
@@ -135,4 +135,4 @@ ci:
     check_resume: true
     # The current robustness check uses an independently initialized BF16
     # baseline, so allow small distributed-kernel drift in the loss comparison.
-    resume_loss_threshold: 1e-2
+    resume_loss_threshold: 5e-2

--- a/examples/retrieval/bi_encoder/nemotron_vl_1b/nemotron_vl_1b_example.yaml
+++ b/examples/retrieval/bi_encoder/nemotron_vl_1b/nemotron_vl_1b_example.yaml
@@ -120,14 +120,12 @@ ci:
       - path: hf://nvidia/embed-nemotron-dataset-v1/MIRACL
         num_samples: 5000
     dataloader.num_workers: 0
-    distributed.static_graph: false
     lr_scheduler.lr_warmup_steps: 2
   checkpoint_robustness:
     dataset.data_dir_list:
       - path: hf://nvidia/embed-nemotron-dataset-v1/MIRACL
         num_samples: 5000
     dataloader.num_workers: 0
-    distributed.static_graph: false
     lr_scheduler.lr_warmup_steps: 1
     step_scheduler.global_batch_size: 8
     step_scheduler.local_batch_size: 1

--- a/examples/retrieval/bi_encoder/nemotron_vl_1b/nemotron_vl_1b_example.yaml
+++ b/examples/retrieval/bi_encoder/nemotron_vl_1b/nemotron_vl_1b_example.yaml
@@ -108,3 +108,30 @@ wandb:
   name: nemotron_vl_1b_embedding_example
   enable: false
   #save_dir: <your_wandb_save_dir> 
+
+ci:
+  recipe_owner: yuhez
+  time: "02:00:00"
+  nodes: 1
+  nightly:
+    # CI uses the public text corpus; checkpoint robustness separately tests
+    # vanilla-HF reload with both text and image inputs.
+    dataset.data_dir_list:
+      - path: hf://nvidia/embed-nemotron-dataset-v1/MIRACL
+        num_samples: 5000
+    dataloader.num_workers: 0
+    distributed.static_graph: false
+    lr_scheduler.lr_warmup_steps: 2
+  checkpoint_robustness:
+    dataset.data_dir_list:
+      - path: hf://nvidia/embed-nemotron-dataset-v1/MIRACL
+        num_samples: 5000
+    dataloader.num_workers: 0
+    distributed.static_graph: false
+    lr_scheduler.lr_warmup_steps: 1
+    step_scheduler.global_batch_size: 8
+    step_scheduler.local_batch_size: 1
+    cosine_threshold: 0.999
+    hf_cosine_threshold: 0.999
+    check_hf_reload: true
+    check_resume: true

--- a/examples/retrieval/bi_encoder/nemotron_vl_1b/nemotron_vl_1b_example.yaml
+++ b/examples/retrieval/bi_encoder/nemotron_vl_1b/nemotron_vl_1b_example.yaml
@@ -133,3 +133,6 @@ ci:
     hf_cosine_threshold: 0.999
     check_hf_reload: true
     check_resume: true
+    # The current robustness check uses an independently initialized BF16
+    # baseline, so allow small distributed-kernel drift in the loss comparison.
+    resume_loss_threshold: 1e-2

--- a/tests/ci_tests/configs/retrieval_bi_encoder/nightly_recipes.yml
+++ b/tests/ci_tests/configs/retrieval_bi_encoder/nightly_recipes.yml
@@ -16,3 +16,4 @@ examples_dir: retrieval
 
 configs:
   - bi_encoder/llama3_2_1b.yaml
+  - bi_encoder/nemotron_vl_1b/nemotron_vl_1b_example.yaml

--- a/tests/ci_tests/scripts/config_templates/ci_config.yaml
+++ b/tests/ci_tests/scripts/config_templates/ci_config.yaml
@@ -113,14 +113,17 @@ computed:
 # resolved YAML's ci.<phase> block but does not apply them to the top-level.
 fixture_keys:
   checkpoint_robustness:
+    - check_hf_reload
     - check_source_load_parity
     - check_fused_qkv_keys
     - check_phantom_keys
     - check_resume
     - cross_tp_kl_threshold
     - cross_tp_size
+    - cosine_threshold
     - experts_implementation
     - hf_device_map_auto
+    - hf_cosine_threshold
     - hf_kl_threshold
     - kl_threshold
     - hf_source_post_load_dequantize

--- a/tests/ci_tests/scripts/finetune_launcher.sh
+++ b/tests/ci_tests/scripts/finetune_launcher.sh
@@ -95,6 +95,9 @@ if [[ "$HAS_ROBUSTNESS" == "true" ]]; then
 
   ROBUSTNESS_TEST_SCRIPT="tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py"
   case "$CONFIG_PATH" in
+    *retrieval/bi_encoder/*)
+      ROBUSTNESS_TEST_SCRIPT="tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_biencoder.py"
+      ;;
     *vlm_finetune*)
       ROBUSTNESS_TEST_SCRIPT="tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_vlm.py"
       ;;

--- a/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_biencoder.py
+++ b/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_biencoder.py
@@ -19,7 +19,8 @@ next-token logits, so we compare checkpoint fidelity using cosine similarity ins
 KL divergence.
 
 Launch: torchrun --nproc-per-node=<N> -m pytest <this_file> -c <config.yaml>
-    [--cosine_threshold <float>] [--check_resume]
+    [--cosine_threshold <float>] [--hf_cosine_threshold <float>]
+    [--check_hf_reload] [--check_resume]
 """
 
 from __future__ import annotations
@@ -34,23 +35,29 @@ from pathlib import Path
 import torch
 import torch.distributed as dist
 import torch.nn.functional as F
+from PIL import Image
 
 from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
 from nemo_automodel.recipes.retrieval.train_bi_encoder import TrainBiEncoderRecipe
+from tests.functional_tests.checkpoint_robustness.test_checkpoint_robustness_llm import (
+    _finish_hf_reload_sync,
+    _prepare_hf_reload_sync,
+)
 
 # Default test sentence for embedding extraction
 _DEFAULT_PROMPT = "The quick brown fox jumps over the lazy dog"
 
 
-def _extract_custom_args(argv):
+def _extract_custom_args(argv: list[str]) -> tuple[dict[str, str | bool], list[str]]:
     """Separate test-specific CLI flags from config parser arguments."""
     custom_keys = {
         "--cosine_threshold",
+        "--hf_cosine_threshold",
         "--resume_loss_threshold",
     }
-    boolean_keys = {"--check_resume"}
-    custom = {}
-    remaining = []
+    boolean_keys = {"--check_hf_reload", "--check_resume"}
+    custom: dict[str, str | bool] = {}
+    remaining: list[str] = []
     i = 0
     while i < len(argv):
         if argv[i] in custom_keys:
@@ -62,6 +69,28 @@ def _extract_custom_args(argv):
         else:
             remaining.append(argv[i])
             i += 1
+
+    config_path = None
+    for index, arg in enumerate(remaining):
+        if arg == "--config" and index + 1 < len(remaining):
+            config_path = remaining[index + 1]
+            break
+    if config_path:
+        import yaml
+
+        with open(config_path) as f:
+            raw_cfg = yaml.safe_load(f)
+        ci_robustness = raw_cfg.get("ci", {}).get("checkpoint_robustness") or {}
+        for cli_key in custom_keys | boolean_keys:
+            key = cli_key.lstrip("-")
+            if key in custom or key not in ci_robustness:
+                continue
+            value = ci_robustness[key]
+            if isinstance(value, bool):
+                if value:
+                    custom[key] = True
+            else:
+                custom[key] = str(value)
     return custom, remaining
 
 
@@ -89,6 +118,18 @@ def _get_embeddings(model, tokenizer, prompt: str, device) -> torch.Tensor:
     return embeddings.float().cpu()
 
 
+def _get_hf_style_embeddings(model, prompt: str) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return query and image-document embeddings from a raw HF-compatible backbone."""
+    model = getattr(model, "module", model)
+    backbone = getattr(model, "model", model)
+    backbone.eval()
+    image = Image.new("RGB", (64, 64), color=(32, 96, 160))
+    with torch.no_grad():
+        query_embeddings = backbone.encode_queries([prompt])
+        document_embeddings = backbone.encode_documents(images=[image])
+    return query_embeddings.float().cpu(), document_embeddings.float().cpu()
+
+
 def _cosine_similarity(ref: torch.Tensor, cand: torch.Tensor) -> float:
     """Compute cosine similarity between two embedding tensors."""
     return F.cosine_similarity(ref.flatten().unsqueeze(0), cand.flatten().unsqueeze(0)).item()
@@ -108,6 +149,8 @@ def test_checkpoint_robustness_biencoder():
     custom_args, config_argv = _extract_custom_args(sys.argv[1:])
     sys.argv = [sys.argv[0]] + config_argv
     cosine_threshold = float(custom_args.get("cosine_threshold", "0.999"))
+    hf_cosine_threshold = float(custom_args.get("hf_cosine_threshold", "0.999"))
+    check_hf_reload = bool(custom_args.get("check_hf_reload", False))
     check_resume = bool(custom_args.get("check_resume", False))
     resume_loss_threshold = float(custom_args.get("resume_loss_threshold", "5e-3"))
 
@@ -131,6 +174,10 @@ def test_checkpoint_robustness_biencoder():
     device = next(trainer.model_parts[0].parameters()).device
     tokenizer = trainer.tokenizer
     reference_embeddings = _get_embeddings(trainer.model_parts[0], tokenizer, _DEFAULT_PROMPT, device)
+    hf_reference_query = None
+    hf_reference_document = None
+    if check_hf_reload:
+        hf_reference_query, hf_reference_document = _get_hf_style_embeddings(trainer.model_parts[0], _DEFAULT_PROMPT)
     if _rank0():
         print(f"\n[Phase 2] Reference embedding shape: {reference_embeddings.shape}")
         print(f"[Phase 2] Reference embedding norm: {reference_embeddings.norm().item():.6f}")
@@ -173,7 +220,51 @@ def test_checkpoint_robustness_biencoder():
     _barrier()
 
     # ------------------------------------------------------------------
-    # Phase 4 (optional): Training resumption -- verify loss continuity
+    # Phase 4 (optional): Reload with vanilla Hugging Face AutoModel
+    # ------------------------------------------------------------------
+    if check_hf_reload:
+        hf_reload_sync_paths = _prepare_hf_reload_sync(cfg)
+        hf_reload_error = None
+        if _rank0():
+            try:
+                from transformers import AutoModel
+
+                assert hf_reference_query is not None
+                assert hf_reference_document is not None
+                hf_model = AutoModel.from_pretrained(
+                    str(consolidated_dir),
+                    trust_remote_code=True,
+                    torch_dtype=torch.bfloat16,
+                    attn_implementation="flash_attention_2",
+                ).to(device)
+                hf_query, hf_document = _get_hf_style_embeddings(hf_model, _DEFAULT_PROMPT)
+                query_cosine_sim = _cosine_similarity(hf_reference_query, hf_query)
+                document_cosine_sim = _cosine_similarity(hf_reference_document, hf_document)
+                print(
+                    f"\n[Phase 4] HF reload query cosine similarity: {query_cosine_sim:.6f}; "
+                    f"image-document cosine similarity: {document_cosine_sim:.6f} "
+                    f"(threshold: {hf_cosine_threshold})"
+                )
+                if query_cosine_sim < hf_cosine_threshold:
+                    hf_reload_error = (
+                        f"HF-reloaded query embedding cosine similarity too low: "
+                        f"{query_cosine_sim:.6f} < threshold {hf_cosine_threshold}"
+                    )
+                if document_cosine_sim < hf_cosine_threshold:
+                    document_error = (
+                        f"HF-reloaded image-document embedding cosine similarity too low: "
+                        f"{document_cosine_sim:.6f} < threshold {hf_cosine_threshold}"
+                    )
+                    hf_reload_error = "\n".join(filter(None, (hf_reload_error, document_error)))
+                del hf_model
+                torch.cuda.empty_cache()
+            except Exception as exc:
+                hf_reload_error = f"Vanilla HF reload failed: {type(exc).__name__}: {exc}"
+        hf_reload_error = _finish_hf_reload_sync(hf_reload_sync_paths, hf_reload_error)
+        assert hf_reload_error is None, hf_reload_error
+
+    # ------------------------------------------------------------------
+    # Phase 5 (optional): Training resumption -- verify loss continuity
     # ------------------------------------------------------------------
     if check_resume:
         # Baseline: fresh continuous run for max_steps+3, saving losses
@@ -212,8 +303,8 @@ def test_checkpoint_robustness_biencoder():
         # Compare losses at the overlapping steps
         resume_jsonl = checkpoint_dir / "training.jsonl"
         if _rank0():
-            assert baseline_losses, "Phase 4: baseline_losses is empty -- no steps to compare"
-            assert resume_jsonl.exists(), f"Phase 4: {resume_jsonl} not found"
+            assert baseline_losses, "Phase 5: baseline_losses is empty -- no steps to compare"
+            assert resume_jsonl.exists(), f"Phase 5: {resume_jsonl} not found"
 
             resume_losses = {}
             with open(resume_jsonl) as f:
@@ -229,20 +320,17 @@ def test_checkpoint_robustness_biencoder():
                     bl = baseline_losses[step]
                     rl = resume_losses[step]
                     diff = abs(bl - rl)
-                    print(
-                        f"[Phase 4] Step {step}: baseline_loss={bl:.6f}, "
-                        f"resume_loss={rl:.6f}, diff={diff:.6e}"
-                    )
+                    print(f"[Phase 5] Step {step}: baseline_loss={bl:.6f}, resume_loss={rl:.6f}, diff={diff:.6e}")
                     assert diff < resume_loss_threshold, (
                         f"Contrastive loss mismatch after resume at step {step}: "
                         f"baseline={bl:.6f}, resume={rl:.6f}, diff={diff:.6e}"
                     )
 
             assert matched_steps > 0, (
-                f"Phase 4: no overlapping steps found between baseline ({sorted(baseline_losses.keys())}) "
+                f"Phase 5: no overlapping steps found between baseline ({sorted(baseline_losses.keys())}) "
                 f"and resume ({sorted(resume_losses.keys())})"
             )
-            print(f"[Phase 4] Training resumption verified ({matched_steps} steps compared)")
+            print(f"[Phase 5] Training resumption verified ({matched_steps} steps compared)")
 
         del resume_trainer
         torch.cuda.empty_cache()

--- a/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_biencoder.py
+++ b/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_biencoder.py
@@ -275,6 +275,9 @@ def test_checkpoint_robustness_biencoder():
         cfg.step_scheduler.max_steps = resume_max_steps
         cfg.checkpoint.checkpoint_dir = baseline_dir
         cfg.checkpoint.enabled = False
+        # Match the LR schedule used to create the checkpoint. Otherwise, extending
+        # max_steps also extends the baseline decay and changes its first five updates.
+        cfg.lr_scheduler.lr_decay_steps = original_max_steps
         baseline_trainer = TrainBiEncoderRecipe(cfg)
         baseline_trainer.setup()
         baseline_trainer.run_train_validation_loop()

--- a/tests/unit_tests/ci_tests/test_checkpoint_robustness_hf_kwargs.py
+++ b/tests/unit_tests/ci_tests/test_checkpoint_robustness_hf_kwargs.py
@@ -19,6 +19,9 @@ from unittest.mock import patch
 import pytest
 import torch
 
+from tests.functional_tests.checkpoint_robustness.test_checkpoint_robustness_biencoder import (
+    _extract_custom_args as _extract_biencoder_custom_args,
+)
 from tests.functional_tests.checkpoint_robustness.test_checkpoint_robustness_llm import (
     _compare_source_load_parity,
     _dequantize_hf_fp8_weights_in_place,
@@ -373,6 +376,29 @@ def test_hf_reload_wait_has_separate_timeout(tmp_path, monkeypatch):
 
 def test_hf_reload_finish_returns_error_without_distributed_sync():
     assert _finish_hf_reload_sync(None, "HF parity failed") == "HF parity failed"
+
+
+def test_biencoder_robustness_reads_hf_reload_settings_from_config(tmp_path):
+    config_path = tmp_path / "recipe.yaml"
+    config_path.write_text(
+        "ci:\n"
+        "  checkpoint_robustness:\n"
+        "    check_hf_reload: true\n"
+        "    check_resume: true\n"
+        "    cosine_threshold: 0.998\n"
+        "    hf_cosine_threshold: 0.997\n"
+        "    dataloader.num_workers: 0\n"
+    )
+
+    custom, remaining = _extract_biencoder_custom_args(["--config", str(config_path)])
+
+    assert custom == {
+        "check_hf_reload": True,
+        "check_resume": True,
+        "cosine_threshold": "0.998",
+        "hf_cosine_threshold": "0.997",
+    }
+    assert remaining == ["--config", str(config_path)]
 
 
 def test_record_deferred_failure_preserves_all_comparison_failures():


### PR DESCRIPTION
## Summary

Adds scheduled training and checkpoint-robustness coverage for the existing Llama Nemotron VL 1B retrieval recipe. This is the CI-focused subset retained from #2872 after dropping the optimized model implementation; it does not change production model or checkpoint code.

## Why

The retrieval bi-encoder recipe was not selected by the nightly manifest, and the shared launcher routed checkpoint robustness to the LLM harness. As a result, the existing recipe did not continuously verify its consolidated checkpoint through the retrieval-specific reload path, vanilla Hugging Face query/image inference, or training resume.

## Changes

- Select the existing Nemotron VL retrieval recipe for nightly coverage and give its CI runs public MIRACL data plus bounded training overrides.
- Route retrieval bi-encoder configs to the bi-encoder checkpoint-robustness harness.
- Add config-driven vanilla Hugging Face reload checks for both text-query and image-document embeddings.
- Enable consolidated AutoModel reload and resume-continuity coverage.
- Keep the biencoder resume baseline on the same LR decay schedule used to create the checkpoint.
- Set a config-local `5e-2` resume-loss tolerance for expected BF16 drift between
  the independently initialized baseline and checkpoint-producing run. A
  shared-trajectory redesign is tracked in
  [AMINT-227](https://linear.app/nvidia/issue/AMINT-227/redesign-checkpoint-resume-robustness-around-a-shared-training).
- Document the `distributed.static_graph` and unused-parameter settings required when a DDP launch uses gradient accumulation.

## Validation

- 66 focused checkpoint-harness and config-resolver unit tests passed.
- 40 config-resolver tests passed after correcting the DDP CI overrides.
- Changed Python files pass Ruff check and format validation.
- `tests/ci_tests/scripts/finetune_launcher.sh` passes `bash -n`.
- All 454 MDX files pass the repository syntax validator. Full local `fern check` was unavailable because the Fern CLI is not installed in this workspace.
- [Pipeline 60004309](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/60004309) exposed an unnecessary CI override of the base recipe's static-graph setting. [Pipeline 60015913](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/60015913) then passed training, consolidated AutoModel reload, and vanilla Hugging Face text/image reload, but exposed that the biencoder resume baseline recomputed a longer LR decay than the checkpoint-producing run.
- [Pipeline 60138543](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/60138543) confirmed perfect consolidated AutoModel and vanilla Hugging Face text/image reload parity (`1.000000` cosine). Its resume phase used the corrected LR schedule, but the independently initialized baseline had already diverged before checkpointing; the largest post-checkpoint loss difference was `0.03125`, motivating the config-local `0.05` tolerance.
- Exact-head scoped EOS nightly/checkpoint-robustness rerun: after initial attempts were blocked by the EOS outage, [job 378403572](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/378403572) passed against `2f38711e1`. The 50-step finetune and biencoder checkpoint-robustness test completed successfully, covering consolidated AutoModel reload, vanilla Hugging Face query/image reload, and training resume.
