### PR TITLE
fix(ci): install CUDA torchvision with CUDA torch

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -304,6 +304,9 @@ jobs:
             TORCH_REQUIREMENT="$(
               python scripts/cuda_wheelhouse_lock.py --output torch "${LOCK_ARGS[@]}"
             )"
+            TORCHVISION_REQUIREMENT="$(
+              python scripts/cuda_wheelhouse_lock.py --output torchvision "${LOCK_ARGS[@]}"
+            )"
             BUILD_TOOLS="$(
               python scripts/cuda_wheelhouse_lock.py --output build-tools "${LOCK_ARGS[@]}"
             )"
@@ -314,7 +317,11 @@ jobs:
               "${LOCK_ARGS[@]}" > "${CONSTRAINTS_FILE}"
 
             pip install --find-links "${PIP_FIND_LINKS}" "${BUILD_TOOL_REQUIREMENTS[@]}"
-            pip install --find-links "${PIP_FIND_LINKS}" --index-url ${TORCH_CU_INDEX} "${TORCH_REQUIREMENT}"
+            pip install \
+              --find-links "${PIP_FIND_LINKS}" \
+              --index-url "${TORCH_CU_INDEX}" \
+              "${TORCH_REQUIREMENT}" \
+              "${TORCHVISION_REQUIREMENT}"
             PIP_ARGS=(--no-build-isolation --constraint "${CONSTRAINTS_FILE}")
             export TORCH_CUDA_ARCH_LIST="9.0 10.0 12.0"
           fi

--- a/scripts/cuda_wheelhouse_lock.py
+++ b/scripts/cuda_wheelhouse_lock.py
@@ -47,6 +47,7 @@ class LockedInputs(TypedDict):
     build_tools: list[str]
     constraints: list[str]
     torch: str
+    torchvision: str
     wheels: list[str]
 
 
@@ -116,6 +117,7 @@ def load_locked_inputs(
         "sys_platform": sys_platform,
     }
     torch_package = _select_package(packages, "torch", registry=torch_index, **selection_args)
+    torchvision_package = _select_package(packages, "torchvision", registry=torch_index, **selection_args)
 
     wheel_packages = {name: _select_package(packages, name, **selection_args) for name in _WHEEL_REQUIREMENTS}
     wheels = [
@@ -137,12 +139,14 @@ def load_locked_inputs(
     }
     constraints = list(build_tools)
     constraints.append(_locked_requirement(torch_package))
+    constraints.append(_locked_requirement(torchvision_package))
     constraints.extend(_locked_requirement(runtime_packages[name]) for name in sorted(runtime_packages))
 
     return {
         "build_tools": sorted(build_tools),
         "constraints": sorted(constraints),
         "torch": _locked_requirement(torch_package),
+        "torchvision": _locked_requirement(torchvision_package),
         "wheels": wheels,
     }
 
@@ -183,7 +187,7 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--output",
-        choices=("build-tools", "constraints", "fingerprint", "manifest", "torch", "wheels"),
+        choices=("build-tools", "constraints", "fingerprint", "manifest", "torch", "torchvision", "wheels"),
         required=True,
     )
     parser.add_argument("--lock", type=Path, default=Path("uv.lock"))
@@ -213,6 +217,8 @@ def main() -> None:
         print(json.dumps(locked_inputs, sort_keys=True, separators=(",", ":")))
     elif args.output == "torch":
         print(locked_inputs["torch"])
+    elif args.output == "torchvision":
+        print(locked_inputs["torchvision"])
     elif args.output == "wheels":
         _print_lines(locked_inputs["wheels"])
     elif args.output == "build-tools":

--- a/tests/unit_tests/ci_tests/test_cuda_wheelhouse_lock.py
+++ b/tests/unit_tests/ci_tests/test_cuda_wheelhouse_lock.py
@@ -25,6 +25,7 @@ def _lock_contents(
     *,
     unrelated_version: str = "1.0.0",
     torch_version: str = "2.10.0+cu130",
+    torchvision_version: str = "0.25.0+cu130",
     causal_conv1d_version: str = "1.6.0",
     packaging_version: str = "25.0",
 ) -> str:
@@ -39,6 +40,7 @@ def _lock_contents(
         "pybind11": "3.0.1",
         "setuptools": "80.10.2",
         "torch": torch_version,
+        "torchvision": torchvision_version,
         "transformer-engine": "2.15.0",
         "transformer-engine-cu13": "2.15.0",
         "transformer-engine-torch": "2.15.0",
@@ -46,7 +48,7 @@ def _lock_contents(
     }
     packages = []
     for name, version in versions.items():
-        registry = _TORCH_INDEX if name == "torch" else "https://pypi.org/simple"
+        registry = _TORCH_INDEX if name in {"torch", "torchvision"} else "https://pypi.org/simple"
         packages.append(
             "\n".join(
                 (
@@ -93,10 +95,12 @@ def test_lock_manifest_pins_build_and_runtime_requirements(tmp_path):
     )
 
     assert locked_inputs["torch"] == "torch==2.10.0+cu130"
+    assert locked_inputs["torchvision"] == "torchvision==0.25.0+cu130"
     assert "causal-conv1d==1.6.0" in locked_inputs["wheels"]
     assert "numpy==1.26.4" in locked_inputs["build_tools"]
     assert set(locked_inputs["build_tools"]) <= set(locked_inputs["constraints"])
     assert "torch==2.10.0+cu130" in locked_inputs["constraints"]
+    assert "torchvision==0.25.0+cu130" in locked_inputs["constraints"]
 
 
 def test_unrelated_lock_change_preserves_cache_fingerprint(tmp_path):
@@ -109,6 +113,13 @@ def test_unrelated_lock_change_preserves_cache_fingerprint(tmp_path):
 def test_torch_lock_change_invalidates_cache_fingerprint(tmp_path):
     baseline = _fingerprint(tmp_path, torch_version="2.10.0+cu130")
     updated = _fingerprint(tmp_path, torch_version="2.11.0+cu130")
+
+    assert updated != baseline
+
+
+def test_torchvision_lock_change_invalidates_cache_fingerprint(tmp_path):
+    baseline = _fingerprint(tmp_path, torchvision_version="0.25.0+cu130")
+    updated = _fingerprint(tmp_path, torchvision_version="0.26.0+cu130")
 
     assert updated != baseline
 


### PR DESCRIPTION
# What does this PR do ?

Fixes the CUDA pip installation lane by installing the lock-selected CUDA build of `torchvision` together with CUDA `torch`.

The failing job installed `torch==2.10.0+cu130` from the PyTorch CUDA index, but later resolved the plain PyPI `torchvision==0.25.0` wheel. That binary mismatch prevented torchvision operators from registering and caused the import sweep to fail first with `RuntimeError: operator torchvision::nms does not exist`.

Failing job: https://github.com/NVIDIA-NeMo/Automodel/actions/runs/30378982338/job/90366488809

# Changelog

- Select the CUDA-index torchvision requirement from `uv.lock`.
- Install CUDA torch and torchvision together before installing Automodel extras.
- Include torchvision in CUDA wheelhouse constraints and cache fingerprints.
- Add unit coverage for torchvision selection and fingerprint invalidation.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added focused unit coverage.
- [x] Documentation is not needed for this CI-only fix.

Validation:

- `python -m pytest tests/unit_tests/ci_tests/test_cuda_wheelhouse_lock.py -q` — 6 passed
- `ruff check scripts/cuda_wheelhouse_lock.py tests/unit_tests/ci_tests/test_cuda_wheelhouse_lock.py`
- `ruff format --check scripts/cuda_wheelhouse_lock.py tests/unit_tests/ci_tests/test_cuda_wheelhouse_lock.py`
- Parsed `.github/workflows/install-test.yml` with PyYAML.
- Verified the helper resolves `torch==2.10.0+cu130` and `torchvision==0.25.0+cu130` from the CUDA index.

# Additional Information

The latest `main` Installation Test run reproduces the same failure, confirming this is not specific to the MagiAttention merge: https://github.com/NVIDIA-NeMo/Automodel/actions/runs/30388681449/job/90375564867
