### PR TITLE
fix(KD): Fix variable-length teacher PP batches on separate meshes

### DIFF
--- a/examples/llm_kd/llama3_2/llama3_2_1b_kd_separate_mesh_teacher_pp2.yaml
+++ b/examples/llm_kd/llama3_2/llama3_2_1b_kd_separate_mesh_teacher_pp2.yaml
@@ -8,7 +8,7 @@ recipe: KnowledgeDistillationRecipeForNextTokenPrediction
 
 step_scheduler:
   global_batch_size: 32
-  local_batch_size: 1
+  local_batch_size: 2
   ckpt_every_steps: 200
   val_every_steps: 100
   num_epochs: 2

--- a/nemo_automodel/recipes/llm/kd.py
+++ b/nemo_automodel/recipes/llm/kd.py
@@ -509,6 +509,7 @@ class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNe
         with train_ctx(), torch.no_grad():
             if self.pp_enabled:
                 input_ids = batch.pop("input_ids")
+                self.teacher_pp.update_seq_len(input_ids.shape[1])
                 batch_filtered = {
                     key: value
                     for key, value in batch.items()

--- a/tests/unit_tests/recipes/test_kd_separate_mesh_recipe_helpers.py
+++ b/tests/unit_tests/recipes/test_kd_separate_mesh_recipe_helpers.py
@@ -230,6 +230,49 @@ def test_teacher_forward_separate_materializes_logits(monkeypatch, recipe_module
     assert materialized == [(None, 2)]
 
 
+def test_llm_teacher_pp_updates_stage_shapes_for_variable_length_waves(monkeypatch):
+    monkeypatch.setattr(
+        llm_kd,
+        "ContextParallelSharder",
+        lambda model, mesh, batch, **kwargs: SimpleNamespace(shard=lambda actual: (nullcontext, actual)),
+    )
+    monkeypatch.setattr(llm_kd, "materialize_teacher_logits", lambda logits, **kwargs: logits)
+
+    calls = []
+
+    def schedule_eval(input_ids, **kwargs):
+        calls.append(("eval", input_ids.shape[1]))
+
+    teacher_model = SimpleNamespace(_teacher_logits_capture=[None])
+    teacher_pp = SimpleNamespace(
+        info=SimpleNamespace(
+            has_first_stage=True,
+            has_last_stage=True,
+            schedule=SimpleNamespace(eval=schedule_eval),
+        ),
+        update_seq_len=lambda sequence_length: calls.append(("update", sequence_length)),
+    )
+    recipe = object.__new__(llm_kd.KnowledgeDistillationRecipeForNextTokenPrediction)
+    recipe.kd_mesh_bridge = SimpleNamespace(move_to_device=lambda batch: batch)
+    recipe.device_mesh = None
+    recipe.teacher_model = teacher_model
+    recipe.teacher_pp = teacher_pp
+    recipe.pp_enabled = True
+
+    for sequence_length in (195, 186):
+        teacher_model._teacher_logits_capture[0] = [torch.ones(1, sequence_length, 4)]
+        logits = recipe._teacher_forward_separate(
+            {
+                "input_ids": torch.ones(1, sequence_length, dtype=torch.long),
+                "attention_mask": torch.ones(1, sequence_length, dtype=torch.long),
+                "labels": torch.ones(1, sequence_length, dtype=torch.long),
+            }
+        )
+        assert logits.shape == (1, sequence_length, 4)
+
+    assert calls == [("update", 195), ("eval", 195), ("update", 186), ("eval", 186)]
+
+
 @pytest.mark.parametrize("recipe_module,recipe_cls,base_cls", _RECIPE_CASES)
 def test_run_loop_routes_teacher_and_stops_after_student(monkeypatch, recipe_module, recipe_cls, base_cls):
     parent_calls = []

--- a/tests/unit_tests/recipes/test_kd_utils.py
+++ b/tests/unit_tests/recipes/test_kd_utils.py
@@ -131,6 +131,17 @@ def test_kd_yamls_use_torch_optim_with_fp32_student_storage():
         assert cfg["teacher_model"]["torch_dtype"] == "bfloat16"
 
 
+def test_teacher_pp_example_has_enough_microbatches_for_all_stages():
+    cfg = yaml.safe_load(
+        (_REPO_ROOT / "examples/llm_kd/llama3_2/llama3_2_1b_kd_separate_mesh_teacher_pp2.yaml").read_text()
+    )
+    local_batch_size = cfg["step_scheduler"]["local_batch_size"]
+    teacher = cfg["teacher_distributed"]
+    num_microbatches = local_batch_size // teacher["pipeline"]["pp_microbatch_size"]
+
+    assert num_microbatches >= teacher["pp_size"]
+
+
 def test_loss_comparator_rejects_mismatched_kd_settings():
     baseline = {
         "step": 0,


### PR DESCRIPTION
## Summary

- Refresh teacher pipeline stage shapes before every separate-mesh routing wave.
- Set the teacher-PP2 example local batch size to two so its two pipeline stages receive at least two microbatches.
- Add regression coverage for consecutive 195/186-token waves and the example microbatch invariant.

## Root cause

Two student DP ranks route independently padded batches to one teacher PP mesh. The separate-mesh teacher path did not call `update_seq_len`, so the second wave could reuse the first wave pipeline metadata. In the reported repro, stage 1 received 195-token hidden states with a 186-token attention mask.

The shipped PP2 example also used one microbatch for two stages, which PyTorch rejects during schedule construction.

## Validation

- Baseline, 4×H100, SQuAD: reproduced the reported 195/186 attention-mask mismatch.
- Fixed, 4×H100, SQuAD: 10 training steps plus validation completed with finite CE/KD losses and exit code 0.
- NeMo-CI same-container proof using `nemo-automodel:26.06.rc10` and runtime-mounted commit `3aa8944c`:
  - [Parent pipeline](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/60051779) and [QA child pipeline](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/60051861) passed.
  - [Teacher PP2 POR](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/377310747) passed with finite `kd_loss` and `LAYOUT_PASS`.
  - [Teacher TP2 + CP2 POR](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/377310748) passed both companion layouts with finite `kd_loss` and `LAYOUT_PASS`.
- `python -m pytest -q tests/unit_tests/recipes/test_kd_separate_mesh_recipe_helpers.py tests/unit_tests/recipes/test_kd_utils.py` — 45 passed.
- Ruff lint and format checks passed.

Tracking: [AMINT-222](https://linear.app/nvidia/issue/AMINT-222/llama-32-separate-mesh-teacher-pp2-kd-fails-with-195186-attention-mask), [NVBug 6490828](https://nvbugspro.nvidia.com/bug/6490828)