### PR TITLE
fix(inkling): support HF 5.14 attention fields and embed norm FSDP

### DIFF
--- a/nemo_automodel/components/models/inkling/model.py
+++ b/nemo_automodel/components/models/inkling/model.py
@@ -148,9 +148,19 @@ class InklingTextModel(HFInklingTextModel):
         hidden_states = inputs_embeds
         layers = self.layers.values() if isinstance(self.layers, nn.ModuleDict) else self.layers
         for decoder_layer in layers:
+            attention_type = getattr(decoder_layer, "attention_type", None)
+            if attention_type is None:
+                # Transformers 5.14 renamed this field and uses Inkling layer types.
+                layer_type = decoder_layer.layer_type
+                if layer_type == "hybrid":
+                    attention_type = "full_attention"
+                elif layer_type == "hybrid_sliding":
+                    attention_type = "sliding_attention"
+                else:
+                    raise ValueError(f"Unsupported Inkling layer type: {layer_type!r}")
             hidden_states = decoder_layer(
                 hidden_states,
-                attention_mask=causal_mask_mapping[decoder_layer.attention_type],
+                attention_mask=causal_mask_mapping[attention_type],
                 conv_mask=causal_mask_mapping["linear_attention"],
                 past_key_values=past_key_values,
                 **kwargs,

--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -785,6 +785,7 @@ def apply_fsdp(
             _out.weight = _inp.weight
 
     embed_tokens = getattr(_model, "embed_tokens", None)
+    embed_norm = getattr(_model, "embed_norm", None)
     inner_lm_head = getattr(_model, "lm_head", None)
     outer_lm_head = getattr(model, "lm_head", None) if model is not _model else None
     lm_head = inner_lm_head or outer_lm_head
@@ -793,6 +794,10 @@ def apply_fsdp(
 
     if embed_tokens is not None and not tied_input_output_embeddings:
         fully_shard_default(embed_tokens)
+
+    # The outer VLM forward calls embed_norm before the text FSDP root.
+    if embed_norm is not None:
+        fully_shard_default(embed_norm)
 
     if lm_head is not None and not tied_input_output_embeddings:
         # Use custom mixed precision policy for lm_head if lm_head_precision is specified

--- a/tests/unit_tests/moe/test_parallelizer.py
+++ b/tests/unit_tests/moe/test_parallelizer.py
@@ -68,16 +68,24 @@ class LayerContainer:
 
 
 class DummyModel:
-    def __init__(self, blocks, embed_tokens=None, lm_head=None, audio_tower=None, visual=None):
+    def __init__(self, blocks, embed_tokens=None, embed_norm=None, lm_head=None, audio_tower=None, visual=None):
         self.layers = LayerContainer(blocks)
         self.embed_tokens = embed_tokens
+        self.embed_norm = embed_norm
         self.lm_head = lm_head
         self.audio_tower = audio_tower
         self.visual = visual
 
     def parameters(self):
         """Aggregate child parameters like ``nn.Module.parameters()``."""
-        for child in (self.layers, self.embed_tokens, self.lm_head, self.audio_tower, self.visual):
+        for child in (
+            self.layers,
+            self.embed_tokens,
+            self.embed_norm,
+            self.lm_head,
+            self.audio_tower,
+            self.visual,
+        ):
             child_parameters = getattr(child, "parameters", None)
             if callable(child_parameters):
                 yield from child_parameters()
@@ -706,8 +714,9 @@ def test_apply_fsdp_calls_with_ignored_params_and_shard_for_experts(monkeypatch)
 
     block = DummyBlock(mlp=DummyMoE())
     embed = object()
+    embed_norm = object()
     lm = object()
-    model = DummyModel([block], embed_tokens=embed, lm_head=lm)
+    model = DummyModel([block], embed_tokens=embed, embed_norm=embed_norm, lm_head=lm)
 
     fsdp_mesh = type("Mesh", (), {"size": lambda self: 2})()
     ep_shard_mesh = type("Mesh", (), {"size": lambda self: 2})()
@@ -741,9 +750,12 @@ def test_apply_fsdp_calls_with_ignored_params_and_shard_for_experts(monkeypatch)
     ignored = block_kwargs.get("ignored_params")
     assert isinstance(ignored, set) and len(ignored) == len(list(experts.parameters()))
 
-    # embed, lm_head and model should also be sharded on fsdp_mesh
+    # embed, post-embedding norm, lm_head and model should also be sharded on fsdp_mesh
     embed_call = _find_call_by_first_arg(fully_shard_mock, embed)
     assert embed_call is not None and embed_call[1]["mesh"] is fsdp_mesh
+
+    embed_norm_call = _find_call_by_first_arg(fully_shard_mock, embed_norm)
+    assert embed_norm_call is not None and embed_norm_call[1]["mesh"] is fsdp_mesh
 
     lm_call = _find_call_by_first_arg(fully_shard_mock, lm)
     assert lm_call is not None and lm_call[1]["mesh"] is fsdp_mesh


### PR DESCRIPTION
## Summary

- accept both the legacy `attention_type` field and the Hugging Face 5.14 `layer_type` field when selecting Inkling causal masks
- map `hybrid` and `hybrid_sliding` layer types to their corresponding causal-mask entries
- give an optional text `embed_norm` its own FSDP unit and extend the parallelizer unit test

## Root cause

Hugging Face 5.14 renamed the per-layer attention selector and stores Inkling-specific layer values instead of causal-mask keys. Separately, the multimodal forward invokes `language_model.embed_norm(...)` before entering the text model's FSDP root forward, so a root-owned sharded weight can be used with a plain activation before the root pre-forward unshard hook runs.

## Validation

- targeted parallelizer FSDP unit test
- Inkling logit parity test on Transformers 5.14.1
- one-node, eight-GPU EP8 distributed smoke: two training steps plus validation
- `git diff --check`
