### PR TITLE
fix(packing): resolve packed mask layout from the built model

### DIFF
--- a/nemo_automodel/components/models/common/packing.py
+++ b/nemo_automodel/components/models/common/packing.py
@@ -156,13 +156,54 @@ def _passthrough_create_causal_mask(
     )
 
 
-def get_attn_implementation(cfg_model):
+def _model_attn_implementation(model) -> str | None:
+    """Return the packing-relevant attention backend an already-built model runs with.
+
+    ``model.config._attn_implementation`` is a Transformers *dispatch key*, whose
+    vocabulary is wider than the mask layouts packing knows about: when flash
+    attention is requested but only the ``kernels`` package provides it,
+    Transformers records a kernels-hub id instead of the mainline name. Those ids
+    are mapped back so a model genuinely running varlen flash attention is packed
+    as such. Any key that still names no known layout yields ``None``, leaving the
+    caller on the configured value.
+    """
+    # DDP does not proxy attribute access to the model it wraps, so read through it.
+    model = getattr(model, "module", model)
+    attn_implementation = getattr(getattr(model, "config", None), "_attn_implementation", None)
+    if attn_implementation in _FLASH_ATTN_IMPLEMENTATIONS or attn_implementation in ("sdpa", "eager"):
+        return attn_implementation
+    try:
+        from transformers.modeling_flash_attention_utils import FLASH_ATTN_KERNEL_FALLBACK
+    except ImportError:
+        return None
+    for mainline, kernel_id in FLASH_ATTN_KERNEL_FALLBACK.items():
+        if kernel_id == attn_implementation:
+            return mainline
+    return None
+
+
+def get_attn_implementation(cfg_model, model=None) -> str:
     """Determine the attention backend from model config.
 
     Custom models store it in ``backend.attn``; HF models use ``attn_implementation``.
+
+    Args:
+        cfg_model: Model config node, which records what was *requested*.
+        model: Optional already-built model, preferred over ``cfg_model`` for HF
+            models because it records what was actually *resolved*. Model
+            construction may pick a different backend than the config asks for:
+            packed runs are force-switched onto flash attention
+            (``_apply_preload_overrides``), an unavailable backend is downgraded
+            on retry, and an omitted key defaults to flash attention rather than
+            to sdpa. None of those are written back to the config. An HF model
+            configured with ``te`` reports ``sdpa`` here, which is what it runs
+            with TE attention injected on top.
     """
     if cfg_model is not None and hasattr(cfg_model, "backend") and hasattr(cfg_model.backend, "attn"):
         return cfg_model.backend.attn
+    resolved = _model_attn_implementation(model)
+    if resolved is not None:
+        return resolved
     if cfg_model is not None:
         return cfg_model.get("attn_implementation", "sdpa")
     return "sdpa"

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -656,7 +656,7 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
         ):
             from nemo_automodel.components.models.common.packing import configure_packing, get_attn_implementation
 
-            attn_implementation = get_attn_implementation(self.cfg.model)
+            attn_implementation = get_attn_implementation(self.cfg.model, model=self.model_parts[0])
             configure_packing(attn_implementation=attn_implementation)
         collate_wrapper = _build_pp_collate_wrapper(self.cfg.model, self.pp_enabled)
 

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -612,7 +612,7 @@ class FinetuneRecipeForVLM(BaseRecipe):
         from nemo_automodel.components.models.common.packing import configure_packing, get_attn_implementation
 
         packing_attn_implementation = dataloader_config.resolve_packing_attn_implementation(
-            model_attn_implementation=get_attn_implementation(self.cfg.model),
+            model_attn_implementation=get_attn_implementation(self.cfg.model, model=self.model_parts[0]),
             cp_size=self.mesh_context.cp_size,
         )
         if dataloader_config.packing is not None and dataloader_config.packing.packing_format != "thd":

--- a/tests/unit_tests/models/common/test_packing.py
+++ b/tests/unit_tests/models/common/test_packing.py
@@ -138,6 +138,52 @@ class TestGetAttnImplementation:
         cfg.get = MagicMock(return_value="flash_attention_2")
         assert get_attn_implementation(cfg) == "te"
 
+    def test_built_model_wins_over_stale_config(self):
+        """A packed run force-switches the model to flash; the config keeps saying sdpa."""
+        cfg = MagicMock()
+        del cfg.backend
+        cfg.get.return_value = "sdpa"
+        model = SimpleNamespace(config=SimpleNamespace(_attn_implementation="flash_attention_2"))
+        assert get_attn_implementation(cfg, model=model) == "flash_attention_2"
+
+    def test_backend_config_wins_over_built_model(self):
+        """Custom models keep naming their backend; ``te`` inits through sdpa."""
+        cfg = SimpleNamespace(backend=SimpleNamespace(attn="te"))
+        model = SimpleNamespace(config=SimpleNamespace(_attn_implementation="sdpa"))
+        assert get_attn_implementation(cfg, model=model) == "te"
+
+    def test_reads_through_ddp_wrapper(self):
+        """DDP holds the model as ``.module`` and does not proxy attribute access."""
+        cfg = MagicMock()
+        del cfg.backend
+        cfg.get.return_value = "sdpa"
+        inner = SimpleNamespace(config=SimpleNamespace(_attn_implementation="flash_attention_2"))
+        assert get_attn_implementation(cfg, model=SimpleNamespace(module=inner)) == "flash_attention_2"
+
+    def test_kernels_hub_id_maps_back_to_mainline_flash(self):
+        """Transformers records a kernels-hub id when only ``kernels`` provides FA2."""
+        cfg = MagicMock()
+        del cfg.backend
+        cfg.get.return_value = "flash_attention_2"
+        model = SimpleNamespace(config=SimpleNamespace(_attn_implementation="kernels-community/flash-attn2"))
+        assert get_attn_implementation(cfg, model=model) == "flash_attention_2"
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            SimpleNamespace(),
+            SimpleNamespace(config=SimpleNamespace()),
+            SimpleNamespace(config=SimpleNamespace(_attn_implementation=None)),
+            # A dispatch key naming no layout packing knows about must not select one.
+            SimpleNamespace(config=SimpleNamespace(_attn_implementation="some_future_backend")),
+        ],
+    )
+    def test_falls_back_to_config_when_model_names_no_known_backend(self, model):
+        cfg = MagicMock()
+        del cfg.backend
+        cfg.get.return_value = "eager"
+        assert get_attn_implementation(cfg, model=model) == "eager"
+
 
 # ---------------------------------------------------------------------------
 # configure_packing


### PR DESCRIPTION
## Problem

NEAT packing chooses its attention-mask layout from the recipe config:

```python
attn_implementation = get_attn_implementation(self.cfg.model)
configure_packing(attn_implementation=attn_implementation)
```

The config records what was *requested*. Model construction can resolve something else and never writes it back:

* `_apply_preload_overrides` force-switches any packed run onto flash attention (`kernel_patches.py`), so `attn_implementation: sdpa` plus packing builds an FA2 model while the config still says `sdpa`.
* `_get_next_fallback_attn` downgrades the backend on an init retry.
* An omitted `attn_implementation` defaults to `flash_attention_2 if HAS_FA`, while `get_attn_implementation` guesses `sdpa`.

So the collator and the model disagree about the mask format.

## Reproducer

Qwen3-4B, single node, 8 GPUs, `packing_strategy: neat`, `packed_sequence_size: 4096`, `attn_implementation: sdpa`. The recipe logs `Setting model's attn_implementation to flash_attention_2`, then `Configured neat packing for attn_implementation=sdpa`, and step 0 dies:

```
File ".../transformers/modeling_flash_attention_utils.py", line 428, in _upad_input
    value_layer = _index_first_axis(value_layer, indices_k)
torch.AcceleratorError: CUDA error: device-side assert triggered
```

`neat_packed_collater` built a 4D block-causal float mask for sdpa and handed it to a model running FA2. None of the checked-in NEAT yamls hit this because they all pin flash attention explicitly.

## Fix

Prefer the backend the built model actually resolved, with the config as the fallback:

```python
attn_implementation = get_attn_implementation(self.cfg.model, model=self.model_parts[0])
```

`model.config._attn_implementation` is where Transformers records the resolution, so this reads the source of truth rather than patching over a symptom. `backend.attn` stays authoritative for custom models, and both recipe call sites (LLM and VLM) are updated; the deprecated free-standing `build_dataloader` has no model in scope and is left alone.

Two details the model value needs before it can be trusted:

* **kernels-hub ids.** When flash attention is requested but only the `kernels` package provides it, Transformers stores `kernels-community/flash-attn2` rather than `flash_attention_2`. Both collators compare against the mainline names, so passing that id through verbatim would have packed a real varlen-FA2 model with a dense mask, turning a working run into a crash. The id is mapped back via `FLASH_ATTN_KERNEL_FALLBACK`.
* **DDP.** `DistributedDataParallel` holds the model as `.module` and does not proxy attribute access, so without unwrapping, the fix would silently no-op under `DDPManager` at world size > 1 while applying at world size 1.

Any dispatch key naming no layout packing knows about (`magi`, a future backend, a composite config) yields no answer and leaves the caller on the configured value, so those paths are unchanged.

## Testing

* New unit tests in `tests/unit_tests/models/common/test_packing.py`: built model wins over a stale config, `backend.attn` still wins over the model, DDP unwrapping, kernels-hub id mapping, and a parametrized fallback for keys that name no known layout.
* `pytest tests/unit_tests/models/common tests/unit_tests/recipes` matches the pre-change baseline exactly (same failures, which are missing optional dependencies in the local environment) plus the new passing cases.
* `ruff format` and `ruff check` clean.
* End to end: the reproducer above trains after the fix. Document isolation under the resulting packed FA2 path was checked against a leakage control, comparing packed logits to per-document logits: max abs delta 0.44 on a 30.1 logit scale, where plain concatenation (genuine cross-document attention) gives 17.3.
