### PR TITLE
fix(docs): hide Kimi tokenizer regex from autodoc

### DIFF
--- a/nemo_automodel/components/models/kimi_k3/tokenization.py
+++ b/nemo_automodel/components/models/kimi_k3/tokenization.py
@@ -19,6 +19,34 @@ from .encoding import build_chat_segments, is_batched_conversation
 
 logger = getLogger(__name__)
 VOCAB_FILES_NAMES = {"vocab_file": "tiktoken.model"}
+_REGEX_SET_INTERSECTION = "&" * 2
+_NON_HAN_UPPER_OR_MARK = r"""[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}""" + _REGEX_SET_INTERSECTION + r"""[^\p{Han}]]"""
+_NON_HAN_LOWER_OR_MARK = r"""[\p{Ll}\p{Lm}\p{Lo}\p{M}""" + _REGEX_SET_INTERSECTION + r"""[^\p{Han}]]"""
+
+
+def _build_kimi_k3_pat_str() -> str:
+    """Build the Kimi K3 tiktoken regex without exposing raw set intersections to autodoc."""
+
+    return "|".join(
+        [
+            r"""[\p{Han}]+""",
+            r"""[^\r\n\p{L}\p{N}]?"""
+            + _NON_HAN_UPPER_OR_MARK
+            + r"""*"""
+            + _NON_HAN_LOWER_OR_MARK
+            + r"""+(?i:'s|'t|'re|'ve|'m|'ll|'d)?""",
+            r"""[^\r\n\p{L}\p{N}]?"""
+            + _NON_HAN_UPPER_OR_MARK
+            + r"""+"""
+            + _NON_HAN_LOWER_OR_MARK
+            + r"""*(?i:'s|'t|'re|'ve|'m|'ll|'d)?""",
+            r"""\p{N}{1,3}""",
+            r""" ?[^\s\p{L}\p{N}]+[\r\n]*""",
+            r"""\s*[\r\n]+""",
+            r"""\s+(?!\S)""",
+            r"""\s+""",
+        ]
+    )
 
 
 class TikTokenTokenizer(PreTrainedTokenizer):
@@ -53,19 +81,6 @@ class TikTokenTokenizer(PreTrainedTokenizer):
 
     num_reserved_special_tokens = 256
 
-    pat_str = "|".join(
-        [
-            r"""[\p{Han}]+""",
-            r"""[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]*[\p{Ll}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]+(?i:'s|'t|'re|'ve|'m|'ll|'d)?""",
-            r"""[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]+[\p{Ll}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]*(?i:'s|'t|'re|'ve|'m|'ll|'d)?""",
-            r"""\p{N}{1,3}""",
-            r""" ?[^\s\p{L}\p{N}]+[\r\n]*""",
-            r"""\s*[\r\n]+""",
-            r"""\s+(?!\S)""",
-            r"""\s+""",
-        ]
-    )
-
     def __init__(
         self,
         vocab_file,
@@ -99,6 +114,7 @@ class TikTokenTokenizer(PreTrainedTokenizer):
         self.vocab_file = vocab_file
         mergeable_ranks = load_tiktoken_bpe(vocab_file)
         num_base_tokens = len(mergeable_ranks)
+        self.pat_str = _build_kimi_k3_pat_str()
         self.special_tokens = {
             special_tokens_mapping.get(i, f"<|reserved_token_{i}|>"): i
             for i in range(num_base_tokens, num_base_tokens + self.num_reserved_special_tokens)

--- a/tests/unit_tests/models/kimi_k3/test_encoding.py
+++ b/tests/unit_tests/models/kimi_k3/test_encoding.py
@@ -15,7 +15,25 @@
 import pytest
 
 from nemo_automodel.components.models.kimi_k3.encoding import build_chat_segments
-from nemo_automodel.components.models.kimi_k3.tokenization import TikTokenTokenizer
+from nemo_automodel.components.models.kimi_k3.tokenization import TikTokenTokenizer, _build_kimi_k3_pat_str
+
+
+def test_kimi_k3_tokenizer_pattern_matches_reference_regex():
+    reference_pattern = "|".join(
+        [
+            r"""[\p{Han}]+""",
+            r"""[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]*[\p{Ll}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]+(?i:'s|'t|'re|'ve|'m|'ll|'d)?""",
+            r"""[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]+[\p{Ll}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]*(?i:'s|'t|'re|'ve|'m|'ll|'d)?""",
+            r"""\p{N}{1,3}""",
+            r""" ?[^\s\p{L}\p{N}]+[\r\n]*""",
+            r"""\s*[\r\n]+""",
+            r"""\s+(?!\S)""",
+            r"""\s+""",
+        ]
+    )
+
+    assert _build_kimi_k3_pat_str() == reference_pattern
+    assert "pat_str" not in TikTokenTokenizer.__dict__
 
 
 def test_medium_thinking_effort_is_rendered():


### PR DESCRIPTION
## Summary
- Move Kimi K3 tokenizer regex construction out of the public class attribute so Fern autodoc does not emit the raw `&&` regex set intersections into generated MDX.
- Preserve the runtime tiktoken pattern by assigning the same pattern to tokenizer instances during initialization.

## Root cause
- `Publish Fern Docs` failed on main at `758f04c` while parsing generated `product-docs/.../kimi_k3/tokenization.mdx`.
- The generated page came from `nemo_automodel/components/models/kimi_k3/tokenization.py`, where the public `TikTokenTokenizer.pat_str` class attribute contained raw `&&` regex set intersections. Fern generated 593 library pages after Kimi K3 landed and then failed MDX parsing on that page.

Failing job: https://github.com/NVIDIA-NeMo/Automodel/actions/runs/30438121072/job/90530696973

## Validation
- `ruff format --check nemo_automodel/components/models/kimi_k3/tokenization.py`
- `ruff check nemo_automodel/components/models/kimi_k3/tokenization.py`
- `python -m py_compile nemo_automodel/components/models/kimi_k3/tokenization.py`
- Pattern-equivalence assertion against the previous literal regex
- `python -m pytest tests/unit_tests/models/kimi_k3/test_encoding.py -q` (`4 passed`)