### PR TITLE
fix(pp): use static metadata with PyTorch 2.13

### DIFF
--- a/examples/llm_finetune/glm/glm_5.2_hellaswag_pp.yaml
+++ b/examples/llm_finetune/glm/glm_5.2_hellaswag_pp.yaml
@@ -103,3 +103,4 @@ optimizer:
 
 ci:
   nodes: 32
+  time: "00:30:00"

--- a/nemo_automodel/components/distributed/pipelining/functional.py
+++ b/nemo_automodel/components/distributed/pipelining/functional.py
@@ -328,10 +328,11 @@ def _precompute_stage_shapes(
         microbatch_size: Microbatch size used by the pipeline schedule.
         seq_len: Sequence length of the input data.
     """
-    if stages and not hasattr(stages[0], "_configure_outputs_meta"):
-        logger.info(
-            "PipelineStage no longer exposes _configure_outputs_meta; using PyTorch's dynamic stage metadata inference"
-        )
+    if stages and not all(
+        callable(getattr(stage, "_configure_outputs_meta", None)) or getattr(stage, "_user_meta", None) is not None
+        for stage in stages
+    ):
+        logger.info("PipelineStage does not expose a supported static metadata API; using dynamic metadata inference")
         return
 
     hidden_size, vocab_size = _get_hidden_and_vocab_size(model_config)

--- a/tests/unit_tests/distributed/pipelining/test_functional.py
+++ b/tests/unit_tests/distributed/pipelining/test_functional.py
@@ -1328,7 +1328,14 @@ class TestPrecomputeStageShapesModelHook:
         stage_module = __import__("torch.distributed.pipelining.stage", fromlist=["extract_tensor_metas"])
 
         def extract_tensor_metas(tensors):
-            """Capture metadata for tensors with arbitrary leading dimensions."""
+            """Capture shape metadata for tensors of arbitrary rank.
+
+            Args:
+                tensors: Tensors of shape [...], with arbitrary ranks and no constrained axes.
+
+            Returns:
+                Tuple of metadata records preserving each tensor's shape, dtype, and requires-grad state.
+            """
             return tuple(
                 types.SimpleNamespace(shape=tensor.shape, dtype=tensor.dtype, requires_grad=tensor.requires_grad)
                 for tensor in tensors

--- a/tests/unit_tests/distributed/pipelining/test_functional.py
+++ b/tests/unit_tests/distributed/pipelining/test_functional.py
@@ -783,6 +783,20 @@ class TestPrecomputeStageShapes:
         assert stage._user_meta.inputs[1].requires_grad is True
         assert stage._user_meta.outputs[0].requires_grad is True
 
+    def test_unsupported_pipeline_stage_api_uses_dynamic_metadata_inference(self):
+        """PipelineStage APIs without a static metadata hook retain the dynamic fallback."""
+
+        class _Submod:
+            pass
+
+        stage = types.SimpleNamespace(is_first=True, submod=_Submod())
+        config = self._make_config(hidden_size=64, vocab_size=128)
+
+        _precompute_stage_shapes([stage], config, microbatch_size=2, seq_len=16)
+
+        assert not hasattr(stage, "inputs_meta")
+        assert not hasattr(stage, "_outputs_meta")
+
     def test_first_stage_shapes(self):
         """First stage input should be [mb, seq_len] int64, output [mb, seq_len, hidden]."""
         stage = self._make_stage(is_first=True, is_last=False, has_lm_head=False)
@@ -1306,6 +1320,47 @@ class TestResetPpStageShapes:
 
 class TestPrecomputeStageShapesModelHook:
     """Models with non-standard PP tensor contracts can provide their own metas."""
+
+    def test_new_pipeline_api_preserves_value_sensitive_carry_metadata(self, monkeypatch):
+        """PyTorch's new metadata API must keep model-declared index-carry tensors static."""
+        import torch.nn as nn
+
+        stage_module = __import__("torch.distributed.pipelining.stage", fromlist=["extract_tensor_metas"])
+
+        def extract_tensor_metas(tensors):
+            """Capture metadata for tensors with arbitrary leading dimensions."""
+            return tuple(
+                types.SimpleNamespace(shape=tensor.shape, dtype=tensor.dtype, requires_grad=tensor.requires_grad)
+                for tensor in tensors
+            )
+
+        monkeypatch.setattr(stage_module, "extract_tensor_metas", extract_tensor_metas, raising=False)
+
+        class _Submod(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_parameter("_dummy", nn.Parameter(torch.empty(1, dtype=torch.bfloat16)))
+
+            def get_pipeline_stage_metas(self, *, is_first, microbatch_size, seq_len, dtype):
+                assert not is_first
+                hidden = torch.empty(microbatch_size, seq_len, 64, device="meta", dtype=dtype)
+                topk_indices = torch.empty(microbatch_size, seq_len, 8, device="meta", dtype=torch.float32)
+                return (hidden, topk_indices), (hidden, topk_indices)
+
+        stage = types.SimpleNamespace(
+            is_first=False,
+            submod=_Submod(),
+            _user_meta=types.SimpleNamespace(inputs=None, outputs=None),
+        )
+        config = types.SimpleNamespace(hidden_size=64, vocab_size=128)
+
+        _precompute_stage_shapes([stage], config, microbatch_size=2, seq_len=16)
+
+        assert [meta.shape for meta in stage._user_meta.inputs] == [(2, 16, 64), (2, 16, 8)]
+        assert [meta.dtype for meta in stage._user_meta.inputs] == [torch.bfloat16, torch.float32]
+        assert all(meta.requires_grad for meta in stage._user_meta.inputs)
+        assert [meta.shape for meta in stage._user_meta.outputs] == [(2, 16, 64), (2, 16, 8)]
+        assert all(meta.requires_grad for meta in stage._user_meta.outputs)
 
     def test_uses_model_supplied_pipeline_stage_metas(self):
         import torch.nn as nn


### PR DESCRIPTION
# What does this PR do?

Restore static pipeline metadata on PyTorch 2.13 when the replacement
`_user_meta` API is available. This prevents PyTorch's dynamic real-forward
metadata probe from executing GLM stages with uninitialized, value-sensitive
top-k carry tensors and failing in `scatter_`.

The original fallback remains in place for PipelineStage APIs that expose
neither supported static metadata interface.

# Changelog

- Recognize both legacy `_configure_outputs_meta` and PyTorch 2.13 `_user_meta`
  stage metadata APIs.
- Preserve dynamic metadata inference as the fallback for unsupported future
  APIs.
- Add regression coverage for the dynamic fallback and GLM-style hidden/top-k
  carry metadata.

# Validation

- Exact failing runtime: PyTorch `2.13.0a0+8145d630e8.nv26.06`, Transformers
  `5.12.1`: 118 passed (Slurm job `14572939`, exit `0:0`).
- Rebased affected suite: 74 passed, 44 skipped.
- Ruff format/check and `git diff --check` pass.
- Original 32-node GLM reproducer:
  [scoped job 378419119](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/378419119)
  ([pipeline 60195855](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/60195855))
  passed all 50 training steps plus validation with static pipeline shapes
  (`SLURM_STATE=COMPLETED`, 961s); no `ScatterGatherKernel`,
  index-out-of-bounds, device-side assert, or traceback occurred.

# Before your PR is "Ready for review"

- [x] Read and followed the contributor guidelines.
- [x] Added the necessary regression tests.
- [x] Documentation is not required for this internal compatibility fix.
- [x] All commits include DCO sign-off.

# Additional Information

- Related to [AMINT-208](https://linear.app/nvidia/issue/AMINT-208/out-of-bounds-index-access-in-scattergatherkernel-causing-device-side).
- The stale guard originated in the PyTorch 2.13 container upgrade after the
  `_user_meta` compatibility path had landed on `main`.
