### PR TITLE
fix(pp): route Qwen3.5 MoE pre-embedded inputs

### DIFF
--- a/nemo_automodel/_transformers/registry.py
+++ b/nemo_automodel/_transformers/registry.py
@@ -275,6 +275,10 @@ MODEL_ARCH_MAPPING = OrderedDict(
             ("nemo_automodel.components.models.qwen3_vl.model", "Qwen3VLForConditionalGeneration"),
         ),
         (
+            "Qwen3_5MoeForCausalLM",
+            ("nemo_automodel.components.models.qwen3_5_moe.model", "Qwen3_5MoeForCausalLM"),
+        ),
+        (
             "Qwen3_5MoeForConditionalGeneration",
             ("nemo_automodel.components.models.qwen3_5_moe.model", "Qwen3_5MoeForConditionalGeneration"),
         ),

--- a/nemo_automodel/components/models/qwen3_5_moe/model.py
+++ b/nemo_automodel/components/models/qwen3_5_moe/model.py
@@ -870,7 +870,7 @@ class Qwen3_5MoeForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
 
     def forward(
         self,
-        input_ids: torch.LongTensor | None = None,
+        input_ids: torch.Tensor | None = None,
         attention_mask: torch.Tensor | None = None,
         position_ids: torch.LongTensor | None = None,
         past_key_values: Any | None = None,
@@ -883,6 +883,43 @@ class Qwen3_5MoeForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
         padding_mask: torch.Tensor | None = None,
         **kwargs: Any,
     ) -> Qwen3_5MoeCausalLMOutputWithPast:
+        """Run the text-only causal LM forward pass.
+
+        Args:
+            input_ids: Token ids of shape ``[batch, sequence]``. On a non-first
+                pipeline stage where ``embed_tokens`` is absent, this argument
+                instead carries hidden states of shape
+                ``[batch, sequence, hidden]`` and is routed as ``inputs_embeds``.
+            attention_mask: Optional mask of shape ``[batch, sequence]`` or
+                ``[batch, 1, sequence, sequence]``.
+            position_ids: Optional M-RoPE positions of shape
+                ``[axes, batch, sequence]`` or ``[batch, sequence]``.
+            past_key_values: Optional KV-cache state; caching is not supported
+                by this backend and a non-``None`` value raises.
+            inputs_embeds: Optional hidden inputs of shape
+                ``[batch, sequence, hidden]``.
+            labels: Optional labels of shape ``[batch, sequence]``. Accepted for
+                Hugging Face compatibility; loss is computed outside this model.
+            use_cache: Whether to use a KV cache; ``True`` is unsupported.
+            logits_to_keep: ``0`` to project every position, a positive integer
+                to keep the last positions, or indices of shape
+                ``[kept_sequence]``.
+            output_hidden_states: Whether to include final decoder states in the
+                output for the fused loss path.
+            cache_position: Optional token positions of shape ``[sequence]``.
+            padding_mask: Optional padding mask of shape ``[batch, sequence]``
+                where ``True`` marks padding.
+            **kwargs: Additional attention and packed-sequence metadata forwarded
+                to the decoder and optional MTP layers.
+
+        Returns:
+            A causal-LM output whose logits have shape
+            ``[batch, kept_sequence, vocab]`` (or
+            ``[batch, sequence, hidden]`` on a non-final pipeline stage), whose
+            requested hidden states have shape ``[batch, sequence, hidden]``,
+            and whose optional per-depth MTP tensors each have shape
+            ``[batch, sequence, hidden]``.
+        """
         del labels
         if inputs_embeds is None and self.model.embed_tokens is None and input_ids is not None:
             inputs_embeds = input_ids

--- a/nemo_automodel/components/models/qwen3_5_moe/model.py
+++ b/nemo_automodel/components/models/qwen3_5_moe/model.py
@@ -507,7 +507,7 @@ class Qwen3_5MoeModel(HFQwen3_5MoeModel):
             embed_tokens = self.get_input_embeddings()
             if inputs_embeds is None:
                 if embed_tokens is not None:
-                    inputs_embeds = embed_tokens(input_ids)
+                    inputs_embeds = self.language_model(input_ids=input_ids, _pre_embed_only=True)
                 elif (
                     input_ids is not None
                     and isinstance(input_ids, torch.Tensor)
@@ -652,7 +652,20 @@ class Qwen3_5MoeTextModelBackend(nn.Module):
         if past_key_values is not None or use_cache:
             raise NotImplementedError("KV cache is not supported for the Qwen3.5-MoE backend implementation.")
 
+        if attn_kwargs.pop("_pre_embed_only", False):
+            if inputs_embeds is not None:
+                return inputs_embeds
+            if input_ids is None:
+                raise ValueError("Either input_ids or inputs_embeds must be provided")
+            if self.embed_tokens is None:
+                raise ValueError("inputs_embeds must be provided for pipeline stages without embed_tokens")
+            return self.embed_tokens(input_ids)
+
         if inputs_embeds is None:
+            if input_ids is None:
+                raise ValueError("Either input_ids or inputs_embeds must be provided")
+            if self.embed_tokens is None:
+                raise ValueError("inputs_embeds must be provided for pipeline stages without embed_tokens")
             inputs_embeds = self.embed_tokens(input_ids)
 
         if cache_position is None:
@@ -736,6 +749,226 @@ class Qwen3_5MoeTextModelBackend(nn.Module):
 
         for layer in self.layers.values():
             layer.init_weights(buffer_device=buffer_device)
+
+
+# ---------------------------------------------------------------------------
+# Top-level text-only causal language model
+# ---------------------------------------------------------------------------
+class Qwen3_5MoeForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
+    """Text-only Qwen3.5-MoE causal language model."""
+
+    _pp_keep_self_forward: bool = True
+
+    @dataclass(frozen=True)
+    class ModelCapabilities:
+        """Declared parallelism capabilities for this model class."""
+
+        supports_tp: bool = False
+        supports_cp: bool = True
+        supports_pp: bool = True
+        supports_ep: bool = True
+
+    @classmethod
+    def from_config(
+        cls,
+        config: Qwen3_5MoeTextConfig,
+        moe_config: MoEConfig | None = None,
+        backend: BackendConfig | None = None,
+        **kwargs: Any,
+    ):
+        return cls(config, moe_config=moe_config, backend=backend, **kwargs)
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str,
+        *model_args: Any,
+        **kwargs: Any,
+    ):
+        if not _QWEN3_5_MOE_HF_AVAILABLE:
+            raise UnavailableError("transformers.models.qwen3_5_moe is not available.")
+        config = Qwen3_5MoeTextConfig.from_pretrained(pretrained_model_name_or_path)
+        return cls.from_config(config, *model_args, **kwargs)
+
+    def __init__(
+        self,
+        config: Qwen3_5MoeTextConfig,
+        moe_config: MoEConfig | None = None,
+        backend: BackendConfig | None = None,
+        mtp_loss_scaling_factor: float = 0.1,
+        num_nextn_predict_layers: int | None = None,
+        **kwargs: Any,
+    ) -> None:
+        if not _QWEN3_5_MOE_HF_AVAILABLE:
+            raise UnavailableError("transformers.models.qwen3_5_moe is not available.")
+        reject_unsupported_tie_word_embeddings(config, type(self).__name__)
+        super().__init__()
+        moe_overrides = kwargs.pop("moe_overrides", None)
+        if kwargs:
+            raise TypeError(f"Unexpected keyword arguments: {sorted(kwargs)}")
+
+        self.config = config
+        self.backend = _qwen3_5_moe_backend(backend)
+        self.model = Qwen3_5MoeTextModelBackend(
+            config,
+            backend=self.backend,
+            moe_config=moe_config,
+            moe_overrides=moe_overrides,
+        )
+
+        dtype = get_dtype(getattr(config, "torch_dtype", None), torch.bfloat16)
+        self.lm_head = initialize_linear_module(
+            self.backend.linear,
+            config.hidden_size,
+            config.vocab_size,
+            bias=False,
+            dtype=dtype,
+        )
+        self.vocab_size = config.vocab_size
+        self.pad_token_id = config.pad_token_id if config.pad_token_id is not None else -1
+
+        self.mtp_config = build_mtp_config_from_hf(
+            config,
+            loss_scaling_factor=mtp_loss_scaling_factor,
+            num_nextn_predict_layers=num_nextn_predict_layers,
+        )
+        self.mtp = (
+            build_qwen3_5_moe_mtp(config, self.mtp_config, self.backend, self.model.moe_config, dtype=dtype)
+            if self.mtp_config.enabled
+            else None
+        )
+        self.moe_config = self.model.moe_config
+
+        keep_fp32 = list(getattr(self, "_keep_in_fp32_modules", None) or [])
+        if "_fp32_params" not in keep_fp32:
+            keep_fp32.append("_fp32_params")
+        self._keep_in_fp32_modules = keep_fp32
+
+        if self.backend.enable_hf_state_dict_adapter:
+            self.state_dict_adapter = Qwen3_5MoeStateDictAdapter(
+                config,
+                self.model.moe_config,
+                self.backend,
+                dtype=dtype,
+                pretrained_model_name_or_path=getattr(config, "_name_or_path", None)
+                or getattr(config, "name_or_path", None),
+                text_only=True,
+            )
+
+    def get_input_embeddings(self) -> nn.Module:
+        return self.model.embed_tokens
+
+    def set_input_embeddings(self, value: nn.Module) -> None:
+        self.model.embed_tokens = value
+
+    def get_output_embeddings(self) -> nn.Module:
+        return self.lm_head
+
+    def set_output_embeddings(self, new_embeddings: nn.Module) -> None:
+        self.lm_head = new_embeddings
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        past_key_values: Any | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        labels: torch.LongTensor | None = None,
+        use_cache: bool | None = None,
+        logits_to_keep: int | torch.Tensor = 0,
+        output_hidden_states: bool | None = None,
+        cache_position: torch.Tensor | None = None,
+        padding_mask: torch.Tensor | None = None,
+        **kwargs: Any,
+    ) -> Qwen3_5MoeCausalLMOutputWithPast:
+        del labels
+        if inputs_embeds is None and self.model.embed_tokens is None and input_ids is not None:
+            inputs_embeds = input_ids
+            input_ids = None
+
+        outputs = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            use_cache=False if use_cache is None else use_cache,
+            cache_position=cache_position,
+            padding_mask=padding_mask,
+            **kwargs,
+        )
+        hidden_states = outputs.last_hidden_state
+        lm_output = compute_lm_head_logits(
+            self.lm_head,
+            hidden_states,
+            logits_to_keep,
+            output_hidden_states=output_hidden_states,
+        )
+
+        mtp_per_depth_h: list[torch.Tensor] | None = None
+        if self.mtp is not None and self.training:
+            source_embeds = inputs_embeds if inputs_embeds is not None else self.model.embed_tokens(input_ids)
+            mtp_position_ids = _split_qwen3_5_moe_position_ids(
+                position_ids,
+                batch_size=source_embeds.shape[0],
+                seq_len=source_embeds.shape[1],
+                device=source_embeds.device,
+                cache_position=cache_position,
+            )
+            if input_ids is None:
+                mtp_per_depth_h = self.mtp(
+                    hidden_states,
+                    embed_inputs=_rolled_embed_inputs(source_embeds, self.mtp.num_depths),
+                    position_ids=mtp_position_ids,
+                    attention_mask=attention_mask,
+                    padding_mask=padding_mask,
+                    rotary_emb=self.model.rotary_emb,
+                    **kwargs,
+                )
+            else:
+                mtp_per_depth_h = self.mtp(
+                    hidden_states,
+                    input_ids=input_ids,
+                    embed_fn=self.model.embed_tokens,
+                    position_ids=mtp_position_ids,
+                    attention_mask=attention_mask,
+                    padding_mask=padding_mask,
+                    rotary_emb=self.model.rotary_emb,
+                    **kwargs,
+                )
+
+        return Qwen3_5MoeCausalLMOutputWithPast(
+            logits=lm_output.logits,
+            hidden_states=lm_output.hidden_states,
+            mtp_per_depth_h=mtp_per_depth_h,
+            mtp_loss_scaling_factor=(self.mtp_config.loss_scaling_factor if mtp_per_depth_h is not None else None),
+        )
+
+    @torch.no_grad()
+    def initialize_weights(
+        self,
+        buffer_device: torch.device | None = None,
+        dtype: torch.dtype = torch.bfloat16,
+    ) -> None:
+        buffer_device = buffer_device or _default_init_device()
+        self.model.init_weights(buffer_device=buffer_device)
+        final_out_std = self.config.hidden_size**-0.5
+        cutoff_factor = 3
+        with buffer_device:
+            if self.lm_head is not None:
+                nn.init.trunc_normal_(
+                    self.lm_head.weight,
+                    mean=0.0,
+                    std=final_out_std,
+                    a=-cutoff_factor * final_out_std,
+                    b=cutoff_factor * final_out_std,
+                )
+            if self.mtp is not None:
+                for sublayer in self.mtp.layers:
+                    sublayer.init_weights(buffer_device=buffer_device)
+            self.model.rotary_emb.device = buffer_device
+        cast_model_to_dtype(self, dtype, skip_modules=("_fp32_params",))
 
 
 # ---------------------------------------------------------------------------

--- a/nemo_automodel/components/models/qwen3_5_moe/model.py
+++ b/nemo_automodel/components/models/qwen3_5_moe/model.py
@@ -507,7 +507,7 @@ class Qwen3_5MoeModel(HFQwen3_5MoeModel):
             embed_tokens = self.get_input_embeddings()
             if inputs_embeds is None:
                 if embed_tokens is not None:
-                    inputs_embeds = self.language_model(input_ids=input_ids, _pre_embed_only=True)
+                    inputs_embeds = embed_tokens(input_ids)
                 elif (
                     input_ids is not None
                     and isinstance(input_ids, torch.Tensor)
@@ -651,15 +651,6 @@ class Qwen3_5MoeTextModelBackend(nn.Module):
     ) -> Qwen3_5MoeModelOutputWithPast:
         if past_key_values is not None or use_cache:
             raise NotImplementedError("KV cache is not supported for the Qwen3.5-MoE backend implementation.")
-
-        if attn_kwargs.pop("_pre_embed_only", False):
-            if inputs_embeds is not None:
-                return inputs_embeds
-            if input_ids is None:
-                raise ValueError("Either input_ids or inputs_embeds must be provided")
-            if self.embed_tokens is None:
-                raise ValueError("inputs_embeds must be provided for pipeline stages without embed_tokens")
-            return self.embed_tokens(input_ids)
 
         if inputs_embeds is None:
             if input_ids is None:

--- a/nemo_automodel/components/models/qwen3_5_moe/model.py
+++ b/nemo_automodel/components/models/qwen3_5_moe/model.py
@@ -757,6 +757,7 @@ class Qwen3_5MoeTextModelBackend(nn.Module):
 class Qwen3_5MoeForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
     """Text-only Qwen3.5-MoE causal language model."""
 
+    tie_word_embeddings_support: TieSupport = TieSupport.UNTIED_ONLY
     _pp_keep_self_forward: bool = True
 
     @dataclass(frozen=True)
@@ -801,7 +802,7 @@ class Qwen3_5MoeForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
     ) -> None:
         if not _QWEN3_5_MOE_HF_AVAILABLE:
             raise UnavailableError("transformers.models.qwen3_5_moe is not available.")
-        reject_unsupported_tie_word_embeddings(config, type(self).__name__)
+        reject_unsupported_tie_word_embeddings(type(self), config)
         super().__init__()
         moe_overrides = kwargs.pop("moe_overrides", None)
         if kwargs:

--- a/nemo_automodel/components/models/qwen3_5_moe/state_dict_adapter.py
+++ b/nemo_automodel/components/models/qwen3_5_moe/state_dict_adapter.py
@@ -162,6 +162,7 @@ class Qwen3_5MoeStateDictAdapter(StateDictAdapter):
         dtype: torch.dtype = torch.float32,
         pretrained_model_name_or_path: str | None = None,
         mtp_expert_hf_layout: str | None = None,
+        text_only: bool = False,
     ):
         self.config = config
         self.moe_config = moe_config
@@ -169,6 +170,7 @@ class Qwen3_5MoeStateDictAdapter(StateDictAdapter):
         self.dtype = dtype
         self.pretrained_model_name_or_path = pretrained_model_name_or_path
         self.mtp_expert_hf_layout = mtp_expert_hf_layout
+        self.text_only = text_only
         self._inferred_mtp_expert_hf_layout: str | None = None
         self._local_checkpoint_layout_checked = False
         self._uses_model_prefix = True
@@ -312,7 +314,7 @@ class Qwen3_5MoeStateDictAdapter(StateDictAdapter):
                 continue
 
             match = re.match(
-                r"(?:model\.)?language_model\.layers\.(\d+)\.mlp\.experts\.(gate_up_proj|down_proj)$",
+                r"(?:model\.)?(?:language_model\.)?layers\.(\d+)\.mlp\.experts\.(gate_up_proj|down_proj)$",
                 key,
             )
             mtp_match = re.match(r"mtp\.layers\.(\d+)\.mlp\.experts\.(gate_up_proj|down_proj)$", key)
@@ -323,7 +325,8 @@ class Qwen3_5MoeStateDictAdapter(StateDictAdapter):
                 if mtp_match:
                     native_key = f"mtp.layers.{layer_num}.mlp.experts."
                 else:
-                    native_key = f"{model_prefix}language_model.layers.{layer_num}.mlp.experts."
+                    language_model_prefix = "" if self.text_only else "language_model."
+                    native_key = f"{model_prefix}{language_model_prefix}layers.{layer_num}.mlp.experts."
                 native_key += "gate_and_up_projs" if which == "gate_up_proj" else "down_projs"
 
                 if state_dict_utils.is_dtensor(value):

--- a/tests/unit_tests/_transformers/test_doc_coverage.py
+++ b/tests/unit_tests/_transformers/test_doc_coverage.py
@@ -75,6 +75,7 @@ _DOC_ARCH_ALIASES = {
     # arch name; the registry wires their MoE backbones under these keys.
     "Qwen3OmniMoeForConditionalGeneration": "Qwen3OmniForConditionalGeneration",
     "Qwen3VLMoeForConditionalGeneration": "Qwen3VLForConditionalGeneration",
+    "Qwen3_5MoeForCausalLM": "Qwen3_5MoeVLForConditionalGeneration",
     "Qwen3_5MoeForConditionalGeneration": "Qwen3_5MoeVLForConditionalGeneration",
     # Dense Qwen3.5 text/VL backbone; grouped with the VL variants on the
     # Qwen3.5-VL page.

--- a/tests/unit_tests/models/qwen3_5_moe/test_qwen3_5_moe_causal_lm.py
+++ b/tests/unit_tests/models/qwen3_5_moe/test_qwen3_5_moe_causal_lm.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU-safe execution coverage for the Qwen3.5-MoE text-only causal LM."""
+
+import pytest
+import torch
+
+pytest.importorskip("transformers.models.qwen3_5_moe")
+
+from transformers.models.qwen3_5_moe.configuration_qwen3_5_moe import Qwen3_5MoeTextConfig
+
+from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.models.qwen3_5_moe.model import Qwen3_5MoeForCausalLM
+from nemo_automodel.components.moe.layers import MoEConfig
+
+
+def test_qwen3_5_moe_causal_lm_cpu_forward_backward():
+    """A tiny text-only model can initialize and execute without VLM state."""
+    config = Qwen3_5MoeTextConfig(
+        vocab_size=64,
+        hidden_size=16,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=8,
+        intermediate_size=32,
+        moe_intermediate_size=16,
+        shared_expert_intermediate_size=16,
+        num_experts=2,
+        num_experts_per_tok=1,
+        max_position_embeddings=8,
+        rms_norm_eps=1e-6,
+        router_aux_loss_coef=0.01,
+        pad_token_id=0,
+        tie_word_embeddings=False,
+        layer_types=["full_attention"],
+    )
+    moe_config = MoEConfig(
+        dim=config.hidden_size,
+        inter_dim=config.hidden_size,
+        moe_inter_dim=config.moe_intermediate_size,
+        n_routed_experts=config.num_experts,
+        n_shared_experts=1,
+        n_activated_experts=config.num_experts_per_tok,
+        n_expert_groups=0,
+        n_limited_groups=0,
+        train_gate=True,
+        gate_bias_update_factor=0.0,
+        score_func="softmax",
+        route_scale=1.0,
+        aux_loss_coeff=config.router_aux_loss_coef,
+        norm_topk_prob=True,
+        expert_bias=False,
+        router_bias=False,
+        expert_activation="swiglu",
+        softmax_before_topk=True,
+        shared_expert_gate=True,
+        shared_expert_inter_dim=config.shared_expert_intermediate_size,
+    )
+    backend = BackendConfig(
+        linear="torch",
+        attn="sdpa",
+        rms_norm="torch",
+        dispatcher="torch",
+        fake_balanced_gate=False,
+        enable_hf_state_dict_adapter=False,
+    )
+
+    model = Qwen3_5MoeForCausalLM.from_config(config, moe_config=moe_config, backend=backend)
+    model.initialize_weights(buffer_device=torch.device("cpu"), dtype=torch.float32)
+    model.train()
+
+    input_ids = torch.randint(0, config.vocab_size, (2, 6))
+    position_ids = torch.arange(6).view(1, 1, 6).expand(3, 2, 6)
+    output = model(input_ids=input_ids, position_ids=position_ids, output_hidden_states=True)
+    loss = output.logits.square().mean()
+    loss.backward()
+
+    embedding_grad = model.get_input_embeddings().weight.grad
+    assert output.logits.shape == (2, 6, config.vocab_size)
+    assert torch.isfinite(output.logits).all()
+    assert torch.isfinite(loss)
+    assert embedding_grad is not None
+    assert torch.isfinite(embedding_grad).all()
+    assert embedding_grad.abs().sum() > 0

--- a/tests/unit_tests/models/qwen3_5_moe/test_qwen3_5_moe_model.py
+++ b/tests/unit_tests/models/qwen3_5_moe/test_qwen3_5_moe_model.py
@@ -709,7 +709,10 @@ class TestQwen3_5MoeModelVLPath:
             batch, seq_len, vl_config.text_config.hidden_size, device=device, dtype=model_dtype
         )
 
-        with patch.object(HFQwen3_5MoeModel, "forward", return_value=mock_output) as mock_hf_forward:
+        with (
+            patch.object(HFQwen3_5MoeModel, "forward", return_value=mock_output) as mock_hf_forward,
+            patch.object(core.language_model, "forward") as mock_language_forward,
+        ):
             result = core.forward(
                 input_ids=input_ids,
                 pixel_values=pixel_values,
@@ -717,6 +720,7 @@ class TestQwen3_5MoeModelVLPath:
             )
 
         mock_hf_forward.assert_called_once()
+        mock_language_forward.assert_not_called()
         kw = mock_hf_forward.call_args.kwargs
         assert kw["pixel_values"] is pixel_values
         assert kw["input_ids"] is None
@@ -886,17 +890,6 @@ class TestTextModelBackendInputsEmbedsPath:
 
         assert isinstance(output, Qwen3_5MoeModelOutputWithPast)
         assert output.last_hidden_state.shape == (batch, seq_len, text_config.hidden_size)
-
-    def test_pre_embed_only_returns_embeddings(self, text_config, backend_config, moe_config, device):
-        """VLM wrappers can enter the backend FSDP root before using embed_tokens."""
-        model = Qwen3_5MoeTextModelBackend(text_config, backend=backend_config, moe_config=moe_config).to(device)
-
-        input_ids = torch.randint(0, text_config.vocab_size, (2, 3), device=device)
-
-        output = model(input_ids=input_ids, _pre_embed_only=True)
-
-        expected = model.embed_tokens(input_ids)
-        torch.testing.assert_close(output, expected)
 
     def test_forward_requires_inputs_embeds_when_embed_tokens_absent(
         self, text_config, backend_config, moe_config, device

--- a/tests/unit_tests/models/qwen3_5_moe/test_qwen3_5_moe_model.py
+++ b/tests/unit_tests/models/qwen3_5_moe/test_qwen3_5_moe_model.py
@@ -37,6 +37,7 @@ from nemo_automodel.components.models.qwen3_5_moe.model import (
     Fp32SafeQwen3_5MoeVisionRotaryEmbedding,
     ModelClass,
     Qwen3_5MoeBlock,
+    Qwen3_5MoeForCausalLM,
     Qwen3_5MoeForConditionalGeneration,
     Qwen3_5MoeModel,
     Qwen3_5MoeTextModelBackend,
@@ -885,6 +886,82 @@ class TestTextModelBackendInputsEmbedsPath:
 
         assert isinstance(output, Qwen3_5MoeModelOutputWithPast)
         assert output.last_hidden_state.shape == (batch, seq_len, text_config.hidden_size)
+
+    def test_pre_embed_only_returns_embeddings(self, text_config, backend_config, moe_config, device):
+        """VLM wrappers can enter the backend FSDP root before using embed_tokens."""
+        model = Qwen3_5MoeTextModelBackend(text_config, backend=backend_config, moe_config=moe_config).to(device)
+
+        input_ids = torch.randint(0, text_config.vocab_size, (2, 3), device=device)
+
+        output = model(input_ids=input_ids, _pre_embed_only=True)
+
+        expected = model.embed_tokens(input_ids)
+        torch.testing.assert_close(output, expected)
+
+    def test_forward_requires_inputs_embeds_when_embed_tokens_absent(
+        self, text_config, backend_config, moe_config, device
+    ):
+        """The shared backend stays strict; wrappers route PP hidden states explicitly."""
+        model = Qwen3_5MoeTextModelBackend(text_config, backend=backend_config, moe_config=moe_config).to(device)
+        model.embed_tokens = None
+
+        batch, seq_len = 2, 3
+        hidden_states = torch.randn(batch, seq_len, text_config.hidden_size, device=device)
+
+        with pytest.raises(ValueError, match="inputs_embeds must be provided"):
+            model(input_ids=hidden_states)
+
+    def test_forward_does_not_reinterpret_float_input_ids_when_embed_tokens_present(
+        self, text_config, backend_config, moe_config, device
+    ):
+        """Full/first stages still pass input_ids through embed_tokens regardless of dtype."""
+        model = Qwen3_5MoeTextModelBackend(text_config, backend=backend_config, moe_config=moe_config).to(device)
+
+        class RecordingEmbedding(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.seen_input = None
+
+            def forward(self, input_ids):
+                self.seen_input = input_ids
+                raise RuntimeError("embed_tokens called")
+
+        embed_tokens = RecordingEmbedding()
+        model.embed_tokens = embed_tokens
+        float_input = torch.randn(2, 3, text_config.hidden_size, device=device)
+
+        with pytest.raises(RuntimeError, match="embed_tokens called"):
+            model(input_ids=float_input)
+
+        assert embed_tokens.seen_input is float_input
+
+
+class TestQwen3_5MoeForCausalLMPipelineRouting:
+    def test_forward_routes_positional_hidden_states_when_embed_tokens_absent(
+        self, text_config, backend_config, moe_config, device
+    ):
+        """Text-only CausalLM handles non-first PP stage routing before the shared backend."""
+        model = Qwen3_5MoeForCausalLM(text_config, backend=backend_config, moe_config=moe_config).to(device)
+        model.eval()
+        model.model.embed_tokens = None
+
+        batch, seq_len = 2, 3
+        hidden_states = torch.randn(
+            batch, seq_len, text_config.hidden_size, device=device, dtype=model.lm_head.weight.dtype
+        )
+
+        with patch.object(model.model, "forward") as mock_model_forward:
+            mock_model_forward.return_value = Qwen3_5MoeModelOutputWithPast(
+                last_hidden_state=hidden_states,
+                past_key_values=None,
+                rope_deltas=None,
+            )
+
+            model(input_ids=hidden_states)
+
+        call_kwargs = mock_model_forward.call_args.kwargs
+        assert call_kwargs["input_ids"] is None
+        assert call_kwargs["inputs_embeds"] is hidden_states
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/models/qwen3_5_moe/test_qwen3_5_moe_state_dict_adapter.py
+++ b/tests/unit_tests/models/qwen3_5_moe/test_qwen3_5_moe_state_dict_adapter.py
@@ -313,6 +313,36 @@ class TestToHF:
         for key in hf_state:
             torch.testing.assert_close(roundtrip[key], hf_state[key])
 
+    def test_text_only_expert_round_trip_preserves_keys_and_values(self, config, moe_config, backend_config):
+        """The causal-LM adapter keeps model.layers keys free of a language_model prefix."""
+        adapter = Qwen3_5MoeStateDictAdapter(
+            config=config,
+            moe_config=moe_config,
+            backend=backend_config,
+            dtype=torch.float32,
+            text_only=True,
+        )
+        gate_up_hf = torch.randn(4, 128, 64)
+        down_hf = torch.randn(4, 64, 64)
+        hf_state = {
+            "model.layers.0.mlp.experts.gate_up_proj": gate_up_hf,
+            "model.layers.0.mlp.experts.down_proj": down_hf,
+        }
+
+        native = adapter.from_hf(hf_state)
+
+        gate_up_native_key = "model.layers.0.mlp.experts.gate_and_up_projs"
+        down_native_key = "model.layers.0.mlp.experts.down_projs"
+        assert set(native) == {gate_up_native_key, down_native_key}
+        torch.testing.assert_close(native[gate_up_native_key], gate_up_hf.transpose(1, 2))
+        torch.testing.assert_close(native[down_native_key], down_hf.transpose(1, 2))
+
+        roundtrip = adapter.to_hf(native)
+
+        assert set(roundtrip) == set(hf_state)
+        for key, value in hf_state.items():
+            torch.testing.assert_close(roundtrip[key], value)
+
     @pytest.mark.parametrize(
         ("checkpoint_layout", "misleading_checkpoint_name", "use_index"),
         [

--- a/tests/unit_tests/models/qwen3_5_moe/test_qwen3_5_moe_tie_guard.py
+++ b/tests/unit_tests/models/qwen3_5_moe/test_qwen3_5_moe_tie_guard.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU-safe tests for the Qwen3.5-MoE causal-LM embedding-tie policy."""
+
+import pytest
+
+pytest.importorskip("transformers.models.qwen3_5_moe")
+
+from transformers.models.qwen3_5_moe.configuration_qwen3_5_moe import Qwen3_5MoeTextConfig
+
+from nemo_automodel.components.models.qwen3_5_moe.model import Qwen3_5MoeForCausalLM
+
+
+def test_qwen3_5_moe_causal_lm_rejects_tied_word_embeddings():
+    """The separate-head architecture rejects tying before allocating the model."""
+    config = Qwen3_5MoeTextConfig(tie_word_embeddings=True)
+
+    with pytest.raises(NotImplementedError, match="does not support tie_word_embeddings=True"):
+        Qwen3_5MoeForCausalLM(config)


### PR DESCRIPTION
Summary:
- Route Qwen3.5 MoE pre-embedded tensors across pipeline stages.
- Keep multimodal pre-embedding on the separately sharded embedding module, avoiding duplicate text FSDP-root forwards.
- Add focused Qwen3.5 MoE PP routing and text-only state-adapter coverage.

Validation:
- 4x H100: PP2 x DP2, FSDP2, real multimodal inputs, 8 training steps; finite losses and non-zero finite embedding gradients.
- /opt/venv/bin/python -m pytest -q tests/unit_tests/models/qwen3_5_moe/test_qwen3_5_moe_model.py (53 passed)
- pytest -q tests/unit_tests/models/qwen3_5_moe (102 passed, 55 skipped; before removal of the isolated _pre_embed_only unit test)
- ruff check/format on changed Python files