### PR TITLE
fix(kimi_k25_vl): don't int4 quantize LoRA adapter keys on save

### DIFF
--- a/nemo_automodel/components/models/kimi_k25_vl/state_dict_adapter.py
+++ b/nemo_automodel/components/models/kimi_k25_vl/state_dict_adapter.py
@@ -266,10 +266,18 @@ class KimiK25VLStateDictAdapter(MoESplitExpertsStateDictMixin, StateDictAdapter)
         return result
 
     def _is_quantized_expert_key(self, key: str) -> bool:
-        if "mlp.experts." in key and ".weight" in key:
+        # ``endswith`` rather than ``in``: a substring test also matches keys that
+        # merely contain ".weight", such as the ".weight_packed"/".weight_scale"
+        # triplet this function's callers emit.
+        if "mlp.experts." in key and key.endswith(".weight"):
             if "shared_experts" in key:
                 return False
             if ".layers.0." in key:
+                return False
+            # LoRA adapter tensors sit under the same expert paths but are not part
+            # of the INT4-quantized checkpoint. PEFT expects plain lora_A/lora_B
+            # weights, and quantizing them makes the saved adapter unloadable.
+            if ".lora_" in key:
                 return False
             return True
         return False

--- a/tests/unit_tests/models/kimi_k25_vl/test_state_dict_adapter.py
+++ b/tests/unit_tests/models/kimi_k25_vl/test_state_dict_adapter.py
@@ -735,6 +735,60 @@ class TestIsQuantizedExpertKeyExtended:
         assert not adapter._is_quantized_expert_key(key)
 
 
+class TestLoRAKeysNotQuantized:
+    """LoRA adapter keys must not be treated as INT4-quantized expert weights.
+
+    Expert LoRA tensors live under the same ``mlp.experts.<i>.<proj>`` paths as the
+    quantized expert weights. Quantizing them rewrites the adapter into
+    ``weight_packed``/``weight_scale``/``weight_shape``, which PEFT cannot load, and
+    ``quantize_to_int4`` asserts on a LoRA rank that is not divisible by 8.
+    """
+
+    @pytest.fixture
+    def adapter(self):
+        """Create adapter for testing."""
+        config = KimiK25VLConfig()
+        moe_config = create_mock_moe_config()
+        backend = BackendConfig(linear="torch", rms_norm="torch", attn="sdpa")
+        return KimiK25VLStateDictAdapter(config, moe_config, backend, dtype=torch.bfloat16)
+
+    def test_lora_keys_not_identified(self, adapter):
+        """LoRA adapter weights under an expert path are not quantizable."""
+        base = "language_model.model.layers.5.mlp.experts.0.gate_proj"
+        for suffix in ("lora_A.weight", "lora_B.weight", "lora_A.default.weight"):
+            key = f"{base}.{suffix}"
+            assert not adapter._is_quantized_expert_key(key), f"{key} should not be quantized"
+
+    def test_plain_expert_weight_still_identified(self, adapter):
+        """The real expert weight is still quantized (guards against over-correcting)."""
+        key = "language_model.model.layers.5.mlp.experts.0.gate_proj.weight"
+        assert adapter._is_quantized_expert_key(key)
+
+    def test_already_quantized_keys_not_reidentified(self, adapter):
+        """Emitted triplet keys must not match again and be expanded a second time."""
+        base = "language_model.model.layers.5.mlp.experts.0.gate_proj"
+        for suffix in ("weight_packed", "weight_scale", "weight_shape"):
+            assert not adapter._is_quantized_expert_key(f"{base}.{suffix}")
+
+    def test_expand_quantized_keys_leaves_lora_untouched(self, adapter):
+        """_expand_quantized_keys passes LoRA tensors through unchanged."""
+        base = "language_model.model.layers.5.mlp.experts.0.gate_proj"
+        lora_a = torch.randn(16, 64)
+        state_dict = {
+            f"{base}.lora_A.weight": lora_a,
+            f"{base}.weight": torch.randn(32, 64),
+        }
+
+        result = adapter._expand_quantized_keys(state_dict)
+
+        # LoRA key survives as-is, with its tensor intact
+        assert f"{base}.lora_A.weight" in result
+        torch.testing.assert_close(result[f"{base}.lora_A.weight"], lora_a)
+        assert not any(".lora_A.weight_packed" in k for k in result)
+        # the real expert weight is still expanded
+        assert f"{base}.weight_packed" in result
+
+
 # =============================================================================
 # Expand Quantized Keys Extended Tests
 # =============================================================================


### PR DESCRIPTION
Fixes #3282.

_is_quantized_expert_key was checking ".weight" as a substring, so expert lora keys like mlp.experts.0.gate_proj.lora_A.weight matched too. so on a peft save the adapter came out as weight_packed/weight_scale/weight_shape and there was nothing left for peft to load. it also blows up in quantize_to_int4 if the lora rank isn't divisible by 8, which kimi25vl_lora.yaml hits (rank 4).

fix is to skip ".lora_" keys and use endswith(".weight") instead of the substring check. the endswith bit also stops the weight_packed/weight_scale keys we just emitted from matching again on the way back through.

before and after, running the actual save path on a peft state dict:

    before: lora_A.weight_packed / weight_scale / weight_shape
            lora_B.weight_packed / weight_scale / weight_shape

    after:  lora_A.weight
            lora_B.weight

expert weights still get quantized exactly like before. @HuiyingLi confirmed on the issue that the hf ckpt is quantized so that bit is on purpose, and I left line 202 alone.

4 new cpu tests, 3 of them fail without the change.