### PR TITLE
fix(training): prewarm Mamba SSD autotune kernels

### DIFF
--- a/docs/guides/configuration.mdx
+++ b/docs/guides/configuration.mdx
@@ -71,6 +71,7 @@ The LLM training, LLM fine-tuning, and VLM fine-tuning recipes accept an optiona
 prewarm:
   cublas_backward: true
   fla_gdn_autotune: true
+  mamba_ssd_autotune: true
   comm_groups: true
 ```
 
@@ -78,12 +79,15 @@ All options default to `false`. Enable only the warmup associated with an observ
 
 - `cublas_backward` initializes cuBLAS backward workspaces during setup.
 - `fla_gdn_autotune` autotunes flash-linear-attention gated-delta-net Triton kernels during setup.
+- `mamba_ssd_autotune` autotunes Mamba SSD Triton kernels during setup.
 - `comm_groups` initializes the process groups used by gradient-norm collectives.
 
 <Info>
 Prewarming is most useful for long-context or otherwise memory-constrained runs. A run can have enough steady-state memory and still fail on its first training step. Activations and gradients are live while cuBLAS workspaces, Triton autotuning buffers, and NCCL communicators are initialized for the first time. Temporary autotuning allocations are released afterward. Some memory, including NCCL scratch space, is outside PyTorch's caching allocator, so `torch.cuda.memory_allocated()` does not show the complete transient peak.
 
 Adding GPUs helps only when it sufficiently reduces the relevant per-rank tensors. Each rank still initializes its own resources, and additional parallel dimensions can introduce more communication groups. Shorter contexts can leave enough memory for lazy initialization, while longer contexts might require the same initialization during setup. Long-context hybrid-attention MoE workloads are one common case. Enable each prewarm based on the observed first-step failure rather than a model name. Prewarming does not reduce steady-state memory or imply support for a particular context length.
+
+Triton reuses an autotuned configuration according to each kernel's explicit cache key. The Mamba SSD warmup therefore matches the real head, state, group, chunk, and dtype geometry but uses batch size 1 and two chunks. Batch size and sequence length change the launch grid and activation footprint, but they are not cache keys in the pinned Mamba SSD kernels. Keeping those dimensions small is intentional: using the full training batch and sequence would recreate the peak-memory condition that setup prewarming is meant to avoid.
 
 </Info>
 

--- a/docs/guides/llm/finetune.mdx
+++ b/docs/guides/llm/finetune.mdx
@@ -741,7 +741,8 @@ distributed:
 prewarm:
   cublas_backward: false   # initialize cuBLAS backward workspaces during setup
   fla_gdn_autotune: false  # autotune FLA gated-delta-net Triton kernels during setup
-  comm_groups: false      # initialize grad-norm communication groups during setup
+  mamba_ssd_autotune: false # autotune Mamba SSD Triton kernels during setup
+  comm_groups: false       # initialize grad-norm communication groups during setup
 
 # Random Number Generator
 # The recipe constructs its checkpointable, rank-aware StatefulRNG from this seed.

--- a/examples/llm_finetune/nemotron/nemotron_ultra_v3_hellaswag_peft_gb200.yaml
+++ b/examples/llm_finetune/nemotron/nemotron_ultra_v3_hellaswag_peft_gb200.yaml
@@ -40,6 +40,10 @@ dist_env:
   backend: nccl
   timeout_minutes: 120
 
+prewarm:
+  # Autotune Mamba SSD backward kernels before the real batch's activations are live.
+  mamba_ssd_autotune: true
+
 rng:
   _target_: nemo_automodel.components.training.rng.StatefulRNG
   seed: 1111

--- a/nemo_automodel/components/training/_mamba_ssd_prewarm.py
+++ b/nemo_automodel/components/training/_mamba_ssd_prewarm.py
@@ -1,0 +1,207 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Setup-time prewarm for Mamba SSD Triton autotuners."""
+
+from __future__ import annotations
+
+import logging
+from typing import Protocol, runtime_checkable
+
+import torch
+
+from nemo_automodel.components.training._prewarm_utils import _resolve_cuda_device
+from nemo_automodel.shared.import_utils import safe_import_from
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class _MambaSSDContextParallel(Protocol):
+    """Structural type of the local Mamba geometry under context parallelism."""
+
+    num_heads_local: int
+    n_groups_local: int
+
+
+@runtime_checkable
+class _MambaSSDMixer(Protocol):
+    """Structural type of a mixer backed by the Mamba SSD Triton operators."""
+
+    num_heads: int
+    head_dim: int
+    ssm_state_size: int
+    n_groups: int
+    chunk_size: int
+    cp: _MambaSSDContextParallel | None
+
+
+_MambaSSDShape = tuple[int, int, int, int, int, torch.dtype]
+
+
+def _collect_mamba_ssd_autotune_shapes(model_parts: list[torch.nn.Module]) -> dict[_MambaSSDShape, str]:
+    """Discover the unique Mamba SSD kernel geometries in ``model_parts``.
+
+    The pinned Mamba SSD Triton autotuners key their caches on subsets of the
+    head count, head dimension, state size, group count, and chunk size. Batch
+    size and sequence length affect launch-grid size and transient memory, but
+    are not autotune keys.
+
+    Args:
+        model_parts: Model parts to scan for Mamba SSD mixer modules.
+
+    Returns:
+        Mapping of ``(heads, head_dim, state_size, groups, chunk_size, dtype)``
+        to the qualified name of one module with that geometry.
+    """
+    shapes: dict[_MambaSSDShape, str] = {}
+    for part in model_parts:
+        for name, module in part.named_modules():
+            if not isinstance(module, _MambaSSDMixer):
+                continue
+
+            num_heads = int(module.num_heads)
+            n_groups = int(module.n_groups)
+            if module.cp is not None:
+                if not isinstance(module.cp, _MambaSSDContextParallel):
+                    logger.warning("Skipping Mamba SSD prewarm for %s: unrecognized context-parallel geometry.", name)
+                    continue
+                num_heads = int(module.cp.num_heads_local)
+                n_groups = int(module.cp.n_groups_local)
+
+            dtype = torch.bfloat16
+            for param in module.parameters(recurse=True):
+                if param.dtype in (torch.float16, torch.bfloat16, torch.float32):
+                    dtype = param.dtype
+                    break
+            shape = (
+                num_heads,
+                int(module.head_dim),
+                int(module.ssm_state_size),
+                n_groups,
+                int(module.chunk_size),
+                dtype,
+            )
+            shapes.setdefault(shape, name)
+    return shapes
+
+
+def _prewarm_mamba_ssd_autotune(
+    model_parts: list[torch.nn.Module],
+    device: torch.device | int | str | None,
+) -> bool:
+    """Pre-populate Mamba SSD Triton autotune caches before real activations exist.
+
+    Each unique mixer geometry runs through two chunks at batch size one. This
+    reaches the public SSD forward/backward call graph, including inter-chunk
+    state passing, while matching every current autotune key and avoiding the
+    activation footprint of the real batch and sequence length.
+
+    Args:
+        model_parts: Model parts to scan for Mamba SSD mixer modules.
+        device: Target CUDA device (skipped when None or not CUDA).
+
+    Returns:
+        True if the warmup ran for at least one shape.
+    """
+    device = _resolve_cuda_device(device, "Mamba SSD autotune")
+    if device is None:
+        return False
+
+    shapes = _collect_mamba_ssd_autotune_shapes(model_parts)
+    if not shapes:
+        logger.warning("Mamba SSD autotune prewarm enabled but no Mamba SSD mixer modules were found.")
+        return False
+
+    logger.info(
+        "Prewarming Mamba SSD autotune caches for %d unique shape(s): %s",
+        len(shapes),
+        sorted((*shape[:-1], str(shape[-1]), name) for shape, name in shapes.items()),
+    )
+    return _prewarm_mamba_ssd_end_to_end(shapes, device)
+
+
+def _prewarm_mamba_ssd_end_to_end(shapes: dict[_MambaSSDShape, str], device: torch.device) -> bool:
+    """Run a tiny public Mamba SSD forward/backward per unique kernel geometry.
+
+    Synthetic tensors match the training operator contract: ``x`` has layout
+    ``[batch, sequence, heads, head_dim]``; ``dt`` is
+    ``[batch, sequence, heads]``; ``B`` and ``C`` are
+    ``[batch, sequence, groups, state_size]``; ``A`` and ``dt_bias`` are
+    ``[heads]``; and ``D`` is ``[heads]``. The floating-point activation
+    tensors use the mixer's compute dtype, while ``A``, ``D``, and ``dt_bias``
+    use float32 as in the Nemotron Mamba training path.
+
+    Args:
+        shapes: Unique Mamba SSD kernel geometries and representative module
+            names, as returned by :func:`_collect_mamba_ssd_autotune_shapes`.
+        device: Target device. Production callers pass CUDA; CPU is supported
+            so the operator contract can be tested with a stub.
+
+    Returns:
+        True if the warmup ran for at least one shape.
+    """
+    has_mamba_ssd, mamba_chunk_scan_combined = safe_import_from(
+        "mamba_ssm.ops.triton.ssd_combined", "mamba_chunk_scan_combined"
+    )
+    if not has_mamba_ssd:
+        logger.info("Skipping Mamba SSD end-to-end prewarm: mamba_ssm SSD operators are not importable.")
+        return False
+
+    ran = False
+    rng_devices = []
+    if device.type == "cuda":
+        device_index = device.index if device.index is not None else torch.cuda.current_device()
+        rng_devices = [device_index]
+
+    with torch.random.fork_rng(devices=rng_devices), torch.enable_grad():
+        for (num_heads, head_dim, state_size, n_groups, chunk_size, dtype), module_name in shapes.items():
+            seq_len = 2 * chunk_size
+            x = dt = a = b = c = d = dt_bias = seq_idx = out = loss = None
+            try:
+                x = torch.randn((1, seq_len, num_heads, head_dim), device=device, dtype=dtype, requires_grad=True)
+                dt = torch.zeros((1, seq_len, num_heads), device=device, dtype=dtype, requires_grad=True)
+                a = torch.full((num_heads,), -1.0, device=device, dtype=torch.float32, requires_grad=True)
+                b = torch.randn((1, seq_len, n_groups, state_size), device=device, dtype=dtype, requires_grad=True)
+                c = torch.randn((1, seq_len, n_groups, state_size), device=device, dtype=dtype, requires_grad=True)
+                d = torch.ones((num_heads,), device=device, dtype=torch.float32, requires_grad=True)
+                dt_bias = torch.zeros((num_heads,), device=device, dtype=torch.float32, requires_grad=True)
+                seq_idx = torch.zeros((1, seq_len), device=device, dtype=torch.int32)
+                out = mamba_chunk_scan_combined(
+                    x,
+                    dt,
+                    a,
+                    b,
+                    c,
+                    chunk_size,
+                    D=d,
+                    z=None,
+                    dt_bias=dt_bias,
+                    seq_idx=seq_idx,
+                    dt_softplus=True,
+                )
+                loss = out.float().sum()
+                loss.backward()
+                if device.type == "cuda":
+                    torch.cuda.synchronize(device)
+                ran = True
+            except Exception:
+                logger.exception("Mamba SSD end-to-end prewarm failed for %s; continuing.", module_name)
+            finally:
+                del x, dt, a, b, c, d, dt_bias, seq_idx, out, loss
+                if device.type == "cuda":
+                    torch.cuda.empty_cache()
+
+    logger.info("Finished Mamba SSD autotune prewarm.")
+    return ran

--- a/nemo_automodel/components/training/_prewarm_utils.py
+++ b/nemo_automodel/components/training/_prewarm_utils.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared helpers for setup-time prewarms."""
+
+import logging
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_cuda_device(device: torch.device | int | str | None, label: str) -> torch.device | None:
+    """Normalize ``device`` and return it if it is a usable CUDA device, else None."""
+    if device is None:
+        logger.info("Skipping %s prewarm: no device assigned.", label)
+        return None
+    device = torch.device("cuda", device) if isinstance(device, int) else torch.device(device)
+    if not torch.cuda.is_available() or device.type != "cuda":
+        logger.info(
+            "Skipping %s prewarm: device=%s cuda_available=%s",
+            label,
+            device,
+            torch.cuda.is_available(),
+        )
+        return None
+    torch.cuda.set_device(device)
+    return device

--- a/nemo_automodel/components/training/prewarm.py
+++ b/nemo_automodel/components/training/prewarm.py
@@ -20,7 +20,7 @@ Several CUDA runtime components initialize lazily on first use:
   each dtype;
 - Triton autotuners benchmark every candidate config on a kernel's first
   launch (flash-linear-attention's gated-delta-rule backward kernels are the
-  heavy case);
+  heavy case, as are Mamba SSD backward kernels);
 - NCCL creates a process group's communicator (and cudaMallocs its scratch
   buffers outside the torch caching-allocator pool) on the group's first
   collective.
@@ -37,6 +37,7 @@ Prewarms are opt-in from the recipe config::
     prewarm:
       cublas_backward: true
       fla_gdn_autotune: true
+      mamba_ssd_autotune: true
       comm_groups: true
 
 All prewarms are best-effort: failures are logged and never abort setup.
@@ -54,6 +55,8 @@ from typing import Any, Protocol, runtime_checkable
 import torch
 from torch.distributed.device_mesh import DeviceMesh
 
+from nemo_automodel.components.training._mamba_ssd_prewarm import _prewarm_mamba_ssd_autotune
+from nemo_automodel.components.training._prewarm_utils import _resolve_cuda_device
 from nemo_automodel.shared.import_utils import safe_import, safe_import_from
 
 logger = logging.getLogger(__name__)
@@ -69,12 +72,15 @@ class PrewarmConfig:
         fla_gdn_autotune: Pre-populate the flash-linear-attention
             gated-delta-net Triton autotune caches for every GDN shape in the
             model.
+        mamba_ssd_autotune: Pre-populate the Mamba SSD Triton autotune caches
+            for every Mamba mixer shape in the model.
         comm_groups: Eagerly create the NCCL communicators that grad-norm
             clipping will use on its first collective.
     """
 
     cublas_backward: bool = False
     fla_gdn_autotune: bool = False
+    mamba_ssd_autotune: bool = False
     comm_groups: bool = False
 
     def apply(
@@ -82,6 +88,7 @@ class PrewarmConfig:
         *,
         model_parts: list[torch.nn.Module],
         device: torch.device | int | str | None,
+        batch_size: int = 1,
         pp_mesh: DeviceMesh | None = None,
     ) -> None:
         """Run the enabled prewarms.
@@ -90,6 +97,8 @@ class PrewarmConfig:
             model_parts: The (already parallelized) model parts.
             device: The device assigned to this rank, or None when no
                 accelerator is available.
+            batch_size: Per-rank training batch size. FLA keys its dense GDN
+                cumulative-sum autotuner on this value.
             pp_mesh: The pipeline-parallel submesh, if pipeline parallelism is
                 enabled (its process group is warmed for the grad-norm
                 all-reduce).
@@ -101,32 +110,19 @@ class PrewarmConfig:
                 logger.exception("cuBLAS backward prewarm failed; continuing without it.")
         if self.fla_gdn_autotune:
             try:
-                _prewarm_fla_gdn_autotune(model_parts, device)
+                _prewarm_fla_gdn_autotune(model_parts, device, batch_size=batch_size)
             except Exception:
                 logger.exception("fla GDN autotune prewarm failed; continuing without it.")
+        if self.mamba_ssd_autotune:
+            try:
+                _prewarm_mamba_ssd_autotune(model_parts, device)
+            except Exception:
+                logger.exception("Mamba SSD autotune prewarm failed; continuing without it.")
         if self.comm_groups:
             try:
                 _prewarm_comm_groups(model_parts, device, pp_mesh=pp_mesh)
             except Exception:
                 logger.exception("Communication-group prewarm failed; continuing without it.")
-
-
-def _resolve_cuda_device(device: torch.device | int | str | None, label: str) -> torch.device | None:
-    """Normalize ``device`` and return it if it is a usable CUDA device, else None."""
-    if device is None:
-        logger.info("Skipping %s prewarm: no device assigned.", label)
-        return None
-    device = torch.device("cuda", device) if isinstance(device, int) else torch.device(device)
-    if not torch.cuda.is_available() or device.type != "cuda":
-        logger.info(
-            "Skipping %s prewarm: device=%s cuda_available=%s",
-            label,
-            device,
-            torch.cuda.is_available(),
-        )
-        return None
-    torch.cuda.set_device(device)
-    return device
 
 
 def _prewarm_cublas_backward(device: torch.device | int | str | None, size: int = 16) -> bool:
@@ -186,9 +182,10 @@ def _collect_gdn_autotune_shapes(
     """Discover the gated-delta-net kernel shapes present in ``model_parts``.
 
     A module counts as a GDN attention module when it structurally matches
-    :class:`_GDNAttention`. The fla autotune caches are keyed on (H, K, V[,
-    BT]) -- never on sequence length or batch -- so one tiny warmup per unique
-    shape covers the real workload.
+    :class:`_GDNAttention`. Most fla autotune caches are keyed on
+    ``(H, K, V[, BT])`` rather than sequence length. Dense cumulative-sum
+    kernels additionally key on batch size; that runtime value is handled by
+    the warmup rather than shape discovery.
 
     Args:
         model_parts: Model parts to scan for GDN modules.
@@ -217,29 +214,35 @@ def _prewarm_fla_gdn_autotune(
     model_parts: list[torch.nn.Module],
     device: torch.device | int | str | None,
     seq_len: int = 64,
+    batch_size: int = 1,
 ) -> bool:
     """Pre-populate fla gated-delta-net autotune caches before large activations exist.
 
     On its first launch each Triton-autotuned kernel benchmarks all candidate
     configs; when that first launch is the step-1 backward at peak memory, the
     benchmark allocations can fail with ``Triton Error [CUDA]: out of
-    memory``. The autotune cache keys are shape-based -- (H, K, V) and the
-    chunk size, never the sequence length -- so launching each kernel once
-    here with tiny tensors caches the winning configs for the real workload.
+    memory``. The autotune cache keys include shape, chunk size, and
+    variable-length mode, but not sequence length. Dense cumulative-sum
+    kernels additionally key on batch size, so the real per-rank batch size
+    is used for that path.
 
-    Two warmups run per unique GDN shape found in ``model_parts``:
+    Three warmup paths run per unique GDN shape found in ``model_parts``:
 
     1. the context-parallel backward kernels (pre-process and state merge),
-       which the end-to-end warmup below cannot reach, and
-    2. a tiny end-to-end fwd+bwd through the public ``chunk_gated_delta_rule``
-       op, which covers every autotuned kernel in its call graph (per-kernel
-       prewarms alone are whack-a-mole: warming one kernel just moves the
-       step-1 autotune OOM to the next cold kernel).
+       which the end-to-end warmups below cannot reach,
+    2. a dense end-to-end fwd+bwd using the real per-rank batch size, and
+    3. a packed end-to-end fwd+bwd with ``cu_seqlens``.
+
+    The end-to-end paths cover every autotuned kernel in the public
+    ``chunk_gated_delta_rule`` call graph. Per-kernel prewarms alone are
+    whack-a-mole: warming one kernel just moves the step-1 autotune OOM to the
+    next cold kernel.
 
     Args:
         model_parts: Model parts to scan for GDN modules.
         device: Target CUDA device (skipped when None or not CUDA).
         seq_len: Warmup sequence length (not part of the autotune key).
+        batch_size: Per-rank dense training batch size.
 
     Returns:
         True if at least the end-to-end prewarm ran, False if skipped.
@@ -260,7 +263,7 @@ def _prewarm_fla_gdn_autotune(
     )
 
     _prewarm_fla_gdn_cp_kernels(shapes, device, seq_len)
-    return _prewarm_fla_gdn_end_to_end(shapes, device, seq_len)
+    return _prewarm_fla_gdn_end_to_end(shapes, device, seq_len, batch_size)
 
 
 # Keyword arguments the launches in _prewarm_fla_gdn_cp_kernels pass to the
@@ -456,9 +459,9 @@ def _prewarm_fla_gdn_cp_kernels(
             # backward the first CP rank skips pre_process_bwd_kernel_merged
             # and hits merge_fwd_bwd_kernel cold; its autotuner then
             # benchmarks its configs at peak backward memory. The autotune
-            # key is (H, K, V) -- num_ranks and rank are not part of it -- so
-            # a tiny launch here caches the winning config for real world
-            # sizes.
+            # key is (H, K, V, BT, USE_EXP2) -- num_ranks and rank are not
+            # part of it -- so a tiny launch here caches the winning config
+            # for real world sizes.
             #
             # CP-mode indexing inside the kernel: the BWD variant reads
             # all-gathered rank-slices rank+1 .. rank+num_ranks and the FWD
@@ -506,18 +509,24 @@ def _prewarm_fla_gdn_end_to_end(
     shapes: dict[tuple[int, int, int, torch.dtype], str],
     device: torch.device,
     seq_len: int,
+    batch_size: int = 1,
 ) -> bool:
-    """Run a tiny fwd+bwd through ``chunk_gated_delta_rule`` per unique shape.
+    """Run dense and packed fwd+bwd warmups through ``chunk_gated_delta_rule``.
 
     This caches the autotune config of every kernel in the op's call graph
-    (chunk fwd, dqkwg backward, dhu pre-process, ...) while the allocator pool
-    is empty. Must run with grad enabled so the backward kernels fire.
+    (chunk fwd, dqkwg backward, dhu pre-process, ...) for both
+    ``IS_VARLEN=False`` and ``IS_VARLEN=True`` while the allocator pool is
+    empty. Must run with grad enabled so the backward kernels fire. The dense
+    path uses the real per-rank batch size because FLA's cumulative-sum
+    autotuner includes it in its cache key; packed GDN always flattens to
+    batch size 1.
 
     Args:
         shapes: Mapping of ``(num_v_heads, head_k_dim, head_v_dim, dtype)`` to
             a module name, as returned by :func:`_collect_gdn_autotune_shapes`.
         device: Target CUDA device.
         seq_len: Warmup sequence length (not part of the autotune key).
+        batch_size: Per-rank batch size for the dense path.
 
     Returns:
         True if the warmup ran for at least one shape.
@@ -528,25 +537,72 @@ def _prewarm_fla_gdn_end_to_end(
         return False
 
     ran = False
-    device_index = device.index if device.index is not None else torch.cuda.current_device()
-    with torch.random.fork_rng(devices=[device_index]):
+    rng_devices = []
+    if device.type == "cuda":
+        device_index = device.index if device.index is not None else torch.cuda.current_device()
+        rng_devices = [device_index]
+    with torch.random.fork_rng(devices=rng_devices), torch.enable_grad():
         for (num_heads, head_k_dim, head_v_dim, dtype), module_name in shapes.items():
-            q = k = v = g = beta = out = None
-            try:
-                q = torch.randn((1, seq_len, num_heads, head_k_dim), device=device, dtype=dtype, requires_grad=True)
-                k = torch.randn((1, seq_len, num_heads, head_k_dim), device=device, dtype=dtype, requires_grad=True)
-                v = torch.randn((1, seq_len, num_heads, head_v_dim), device=device, dtype=dtype, requires_grad=True)
-                g = torch.zeros((1, seq_len, num_heads), device=device, dtype=torch.float32, requires_grad=True)
-                beta = torch.full((1, seq_len, num_heads), 0.5, device=device, dtype=dtype, requires_grad=True)
-                out, _ = chunk_gated_delta_rule(q, k, v, g=g, beta=beta, use_qk_l2norm_in_kernel=True)
-                out.sum().backward()
-                torch.cuda.synchronize(device)
-                ran = True
-            except Exception:
-                logger.exception("fla GDN end-to-end prewarm failed for %s; continuing.", module_name)
-            finally:
-                del q, k, v, g, beta, out
-                torch.cuda.empty_cache()
+            for mode, warmup_batch_size in (("dense", batch_size), ("packed", 1)):
+                q = k = v = g = beta = cu_seqlens = out = None
+                try:
+                    q = torch.randn(
+                        (warmup_batch_size, seq_len, num_heads, head_k_dim),
+                        device=device,
+                        dtype=dtype,
+                        requires_grad=True,
+                    )
+                    k = torch.randn_like(q, requires_grad=True)
+                    v = torch.randn(
+                        (warmup_batch_size, seq_len, num_heads, head_v_dim),
+                        device=device,
+                        dtype=dtype,
+                        requires_grad=True,
+                    )
+                    g = torch.zeros(
+                        (warmup_batch_size, seq_len, num_heads),
+                        device=device,
+                        dtype=torch.float32,
+                        requires_grad=True,
+                    )
+                    beta = torch.full(
+                        (warmup_batch_size, seq_len, num_heads),
+                        0.5,
+                        device=device,
+                        dtype=dtype,
+                        requires_grad=True,
+                    )
+                    if mode == "packed":
+                        cu_seqlens = torch.tensor([0, seq_len], device=device, dtype=torch.long)
+                    logger.info(
+                        "Prewarming fla GDN %s path | module=%s B=%d H=%d K=%d V=%d dtype=%s",
+                        mode,
+                        module_name,
+                        warmup_batch_size,
+                        num_heads,
+                        head_k_dim,
+                        head_v_dim,
+                        dtype,
+                    )
+                    out, _ = chunk_gated_delta_rule(
+                        q,
+                        k,
+                        v,
+                        g=g,
+                        beta=beta,
+                        use_qk_l2norm_in_kernel=True,
+                        cu_seqlens=cu_seqlens,
+                    )
+                    out.sum().backward()
+                    if device.type == "cuda":
+                        torch.cuda.synchronize(device)
+                    ran = True
+                except Exception:
+                    logger.exception("fla GDN %s end-to-end prewarm failed for %s; continuing.", mode, module_name)
+                finally:
+                    del q, k, v, g, beta, cu_seqlens, out
+                    if device.type == "cuda":
+                        torch.cuda.empty_cache()
 
     logger.info("Finished fla GDN autotune prewarm.")
     return ran

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -627,6 +627,11 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
             self.cfg.prewarm.apply(
                 model_parts=self.model_parts,
                 device=self.dist_env.device,
+                batch_size=(
+                    self.pp.pp_microbatch_size
+                    if self.pp is not None
+                    else self.cfg.get("step_scheduler.local_batch_size", 1)
+                ),
                 pp_mesh=(self.device_mesh["pp"] if self.pp_enabled and self.device_mesh is not None else None),
             )
 

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -590,6 +590,11 @@ class FinetuneRecipeForVLM(BaseRecipe):
             self.cfg.prewarm.apply(
                 model_parts=self.model_parts,
                 device=self.dist_env.device,
+                batch_size=(
+                    self.pp.pp_microbatch_size
+                    if self.pp is not None
+                    else self.cfg.get("step_scheduler.local_batch_size", 1)
+                ),
                 pp_mesh=(self.device_mesh["pp"] if self.pp_enabled and self.device_mesh is not None else None),
             )
 

--- a/tests/unit_tests/components/training/test_prewarm.py
+++ b/tests/unit_tests/components/training/test_prewarm.py
@@ -21,7 +21,12 @@ import pytest
 import torch
 import torch.distributed as dist
 
-from nemo_automodel.components.training import prewarm
+from nemo_automodel.components.training import _mamba_ssd_prewarm, prewarm
+from nemo_automodel.components.training._mamba_ssd_prewarm import (
+    _collect_mamba_ssd_autotune_shapes,
+    _prewarm_mamba_ssd_autotune,
+    _prewarm_mamba_ssd_end_to_end,
+)
 from nemo_automodel.components.training.prewarm import (
     PrewarmConfig,
     _collect_gdn_autotune_shapes,
@@ -46,6 +51,27 @@ class _FakeGDN(torch.nn.Module):
         self.chunk_gated_delta_rule = object()  # presence is what the discovery checks
 
 
+class _FakeMambaSSD(torch.nn.Module):
+    """Minimal stand-in for a mixer backed by the Mamba SSD operators."""
+
+    def __init__(
+        self,
+        num_heads: int = 4,
+        head_dim: int = 8,
+        state_size: int = 16,
+        n_groups: int = 2,
+        chunk_size: int = 32,
+    ):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.ssm_state_size = state_size
+        self.n_groups = n_groups
+        self.chunk_size = chunk_size
+        self.cp = None
+        self.in_proj = torch.nn.Linear(4, 4)
+
+
 @pytest.fixture
 def single_rank_gloo():
     """Initialize a single-rank gloo process group for the duration of a test."""
@@ -67,6 +93,7 @@ def test_prewarm_config_defaults_all_off():
     cfg = PrewarmConfig()
     assert cfg.cublas_backward is False
     assert cfg.fla_gdn_autotune is False
+    assert cfg.mamba_ssd_autotune is False
     assert cfg.comm_groups is False
 
 
@@ -78,19 +105,29 @@ def test_apply_runs_only_enabled_prewarms(monkeypatch):
     )
     monkeypatch.setattr(
         "nemo_automodel.components.training.prewarm._prewarm_fla_gdn_autotune",
-        lambda model_parts, device: calls.append(("fla", device)),
+        lambda model_parts, device, batch_size: calls.append(("fla", device, batch_size)),
+    )
+    monkeypatch.setattr(
+        "nemo_automodel.components.training.prewarm._prewarm_mamba_ssd_autotune",
+        lambda model_parts, device: calls.append(("mamba", device)),
     )
     monkeypatch.setattr(
         "nemo_automodel.components.training.prewarm._prewarm_comm_groups",
         lambda model_parts, device, pp_mesh=None: calls.append(("comm", pp_mesh)),
     )
 
-    PrewarmConfig(cublas_backward=True, comm_groups=True).apply(
+    PrewarmConfig(cublas_backward=True, fla_gdn_autotune=True, mamba_ssd_autotune=True, comm_groups=True).apply(
         model_parts=[torch.nn.Linear(2, 2)],
         device=torch.device("cpu"),
+        batch_size=4,
         pp_mesh="pp-mesh",
     )
-    assert calls == [("cublas", torch.device("cpu")), ("comm", "pp-mesh")]
+    assert calls == [
+        ("cublas", torch.device("cpu")),
+        ("fla", torch.device("cpu"), 4),
+        ("mamba", torch.device("cpu")),
+        ("comm", "pp-mesh"),
+    ]
 
     calls.clear()
     PrewarmConfig().apply(model_parts=[], device=None)
@@ -109,28 +146,36 @@ def test_apply_continues_after_prewarm_failures(monkeypatch, caplog):
 
     monkeypatch.setattr(prewarm, "_prewarm_cublas_backward", fail("cublas"))
     monkeypatch.setattr(prewarm, "_prewarm_fla_gdn_autotune", fail("fla"))
+    monkeypatch.setattr(prewarm, "_prewarm_mamba_ssd_autotune", fail("mamba"))
     monkeypatch.setattr(prewarm, "_prewarm_comm_groups", fail("comm"))
 
     with caplog.at_level(logging.ERROR, logger=prewarm.__name__):
-        PrewarmConfig(cublas_backward=True, fla_gdn_autotune=True, comm_groups=True).apply(
+        PrewarmConfig(
+            cublas_backward=True,
+            fla_gdn_autotune=True,
+            mamba_ssd_autotune=True,
+            comm_groups=True,
+        ).apply(
             model_parts=[torch.nn.Linear(2, 2)],
             device=torch.device("cpu"),
         )
 
-    assert calls == ["cublas", "fla", "comm"]
+    assert calls == ["cublas", "fla", "mamba", "comm"]
     assert "cuBLAS backward prewarm failed" in caplog.text
     assert "fla GDN autotune prewarm failed" in caplog.text
+    assert "Mamba SSD autotune prewarm failed" in caplog.text
     assert "Communication-group prewarm failed" in caplog.text
 
 
 def test_recipe_config_exposes_typed_prewarm_section():
     from nemo_automodel.recipes._typed_config import RecipeConfig
 
-    cfg = RecipeConfig({"prewarm": {"cublas_backward": True, "comm_groups": True}})
+    cfg = RecipeConfig({"prewarm": {"cublas_backward": True, "mamba_ssd_autotune": True, "comm_groups": True}})
     prewarm = cfg.prewarm
     assert isinstance(prewarm, PrewarmConfig)
     assert prewarm.cublas_backward is True
     assert prewarm.fla_gdn_autotune is False
+    assert prewarm.mamba_ssd_autotune is True
     assert prewarm.comm_groups is True
 
     assert RecipeConfig({}).prewarm is None
@@ -196,19 +241,36 @@ def test_fla_prewarm_skips_without_gdn_modules():
     assert _prewarm_fla_gdn_autotune([torch.nn.Linear(2, 2)], device) is False
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires GPU")
 def test_fla_end_to_end_prewarm_preserves_rng_with_stubbed_op(monkeypatch):
-    device = torch.device("cuda", torch.cuda.current_device())
-    output = torch.ones((1, 2, 2, 4), device=device, requires_grad=True)
-    fake_gdn_op = Mock(return_value=(output, None))
+    device = torch.device("cpu")
+    outputs = []
+
+    def fake_gdn_op(q, k, v, **kwargs):
+        output = torch.ones_like(v, requires_grad=True)
+        outputs.append(output)
+        return output, None
+
+    fake_gdn_op = Mock(side_effect=fake_gdn_op)
     monkeypatch.setattr(prewarm, "safe_import_from", lambda *args: (True, fake_gdn_op))
 
-    rng_before = torch.cuda.get_rng_state(device)
-    assert _prewarm_fla_gdn_end_to_end({(2, 4, 4, torch.float32): "gdn"}, device, seq_len=2) is True
-    assert torch.equal(torch.cuda.get_rng_state(device), rng_before)
-    fake_gdn_op.assert_called_once()
-    assert output.grad is not None
-    assert torch.equal(output.grad, torch.ones_like(output))
+    rng_before = torch.random.get_rng_state()
+    assert (
+        _prewarm_fla_gdn_end_to_end(
+            {(2, 4, 4, torch.float32): "gdn"},
+            device,
+            seq_len=2,
+            batch_size=3,
+        )
+        is True
+    )
+    assert torch.equal(torch.random.get_rng_state(), rng_before)
+    assert fake_gdn_op.call_count == 2
+    dense_call, packed_call = fake_gdn_op.call_args_list
+    assert dense_call.args[0].shape == (3, 2, 2, 4)
+    assert dense_call.kwargs["cu_seqlens"] is None
+    assert packed_call.args[0].shape == (1, 2, 2, 4)
+    assert torch.equal(packed_call.kwargs["cu_seqlens"], torch.tensor([0, 2], device=device))
+    assert all(output.grad is not None for output in outputs)
 
 
 def test_triton_kernel_accepts_unwraps_wrappers_and_validates_args():
@@ -252,6 +314,71 @@ def test_fla_cp_kernel_prewarm_skips_on_kernel_signature_mismatch(monkeypatch, c
     assert launches == []  # nothing may be launched on signature drift
     assert "pre_process_bwd_kernel_merged" in caplog.text
     assert "merge_fwd_bwd_kernel" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Mamba SSD autotune prewarm
+# ---------------------------------------------------------------------------
+
+
+def test_collect_mamba_ssd_autotune_shapes_uses_local_cp_geometry_and_dedups():
+    class _Wrapper(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.mamba_a = _FakeMambaSSD()
+            self.mamba_b = _FakeMambaSSD()  # duplicate shape, deduped
+            self.mamba_cp = _FakeMambaSSD(num_heads=8, n_groups=4)
+            self.mamba_cp.cp = SimpleNamespace(num_heads_local=4, n_groups_local=2)
+            self.plain = torch.nn.Linear(4, 4)
+
+    shapes = _collect_mamba_ssd_autotune_shapes([_Wrapper()])
+    assert set(shapes) == {(4, 8, 16, 2, 32, torch.float32)}
+    assert shapes[(4, 8, 16, 2, 32, torch.float32)] == "mamba_a"
+
+
+def test_mamba_ssd_prewarm_skips_without_cuda_device():
+    assert _prewarm_mamba_ssd_autotune([_FakeMambaSSD()], torch.device("cpu")) is False
+
+
+def test_mamba_ssd_end_to_end_matches_keyed_geometry_and_preserves_rng(monkeypatch):
+    captured = {}
+
+    def fake_mamba_ssd_op(x, dt, a, b, c, chunk_size, *, D, z, dt_bias, seq_idx, dt_softplus):
+        captured.update(
+            x=x,
+            dt=dt,
+            a=a,
+            b=b,
+            c=c,
+            chunk_size=chunk_size,
+            d=D,
+            z=z,
+            dt_bias=dt_bias,
+            seq_idx=seq_idx,
+            dt_softplus=dt_softplus,
+        )
+        return x
+
+    monkeypatch.setattr(_mamba_ssd_prewarm, "safe_import_from", lambda *args: (True, fake_mamba_ssd_op))
+    rng_before = torch.random.get_rng_state()
+
+    shapes = {(4, 8, 16, 2, 32, torch.float32): "mamba"}
+    assert _prewarm_mamba_ssd_end_to_end(shapes, torch.device("cpu")) is True
+
+    assert torch.equal(torch.random.get_rng_state(), rng_before)
+    assert captured["x"].shape == (1, 64, 4, 8)
+    assert captured["dt"].shape == (1, 64, 4)
+    assert captured["a"].shape == (4,)
+    assert captured["b"].shape == (1, 64, 2, 16)
+    assert captured["c"].shape == (1, 64, 2, 16)
+    assert captured["d"].shape == (4,)
+    assert captured["dt_bias"].shape == (4,)
+    assert captured["seq_idx"].shape == (1, 64)
+    assert captured["seq_idx"].dtype == torch.int32
+    assert captured["chunk_size"] == 32
+    assert captured["z"] is None
+    assert captured["dt_softplus"] is True
+    assert captured["x"].grad is not None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
+++ b/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
@@ -2922,8 +2922,8 @@ def test_vlm_setup_applies_prewarm_config(monkeypatch):
     _patch_vlm_setup_minimals(monkeypatch, cp_size=1)
     calls = []
 
-    def _record_apply(self, *, model_parts, device, pp_mesh=None):
-        calls.append((self, model_parts, device, pp_mesh))
+    def _record_apply(self, *, model_parts, device, batch_size, pp_mesh=None):
+        calls.append((self, model_parts, device, batch_size, pp_mesh))
 
     monkeypatch.setattr("nemo_automodel.components.training.prewarm.PrewarmConfig.apply", _record_apply)
 
@@ -2931,10 +2931,11 @@ def test_vlm_setup_applies_prewarm_config(monkeypatch):
     trainer.setup()
 
     assert len(calls) == 1
-    prewarm, model_parts, device, pp_mesh = calls[0]
+    prewarm, model_parts, device, batch_size, pp_mesh = calls[0]
     assert prewarm.comm_groups is True
     assert model_parts == trainer.model_parts
     assert device == torch.device("cpu")
+    assert batch_size == 1
     assert pp_mesh is None
 
 


### PR DESCRIPTION
## Context

This PR explores a potential mitigation for the [AMINT-204](https://linear.app/nvidia/issue/AMINT-204/cuda-oom-in-triton-chunk-scan-bwd-kernel-during-mamba-ssd-backward), which reports a CUDA OOM in the Mamba SSD `_chunk_scan_bwd_ddAcs_stable` Triton kernel during the backward pass of the affected Nemotron Ultra GB200 workload.

The working hypothesis is that the OOM occurs while `mamba-ssm` autotunes
`chunk_scan_bwd` on its first representative backward call. At that point,
the model, optimizer, and training activations already occupy most GPU memory,
and candidate autotune configurations may temporarily exceed the remaining
memory.

This change moves that autotuning earlier by prewarming representative Mamba
SSD inputs before the training loop, while more GPU memory is available. The
exact affected workload and a separate Qwen3.5 real-FLA fidelity workload both
pass with the prewarm enabled, providing validation for this mitigation.

## Changelog

- Add opt-in Mamba SSD prewarming with representative inputs matching the
  Triton autotune keys used by the supported `mamba-ssm` implementation.
- Share prewarm utilities and correct GDN prewarming for
  packed-variable-length inputs and the runtime batch autotune key.
- Run configured prewarming before LLM and VLM training begins.
- Enable Mamba SSD prewarming for the affected Nemotron Ultra GB200 recipe.
- Document the configuration and add focused unit coverage.

## Validation

- The exact affected Nemotron Ultra GB200 functional workload passed in the
  [affected-workload NeMo-CI job](ttps://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/379321093) at commit
  [`d34be4a`](https://github.com/NVIDIA-NeMo/Automodel/commit/d34be4a1b7bb8c9d462eb77b8ad6c574e6207b91).
  Mamba SSD prewarming completed before training, and the reported
  `_chunk_scan_bwd` CUDA OOM did not recur.
- A separate `Qwen3.5-4B` VLM nightly fidelity run (because we also updated the GDN prewarm a bit) passed in the
  [fidelity NeMo-CI pipeline](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/60368226), with the
  functional result in the
  [fidelity functional job](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/379709116). The run used the
  same commit and preserved the normal recipe settings, with only
  `FINETUNE_ARGS=--prewarm.fla_gdn_autotune true` added:
  - real FLA CP backward-kernel, dense (`B=1`), and packed (`B=1`) prewarming
    completed for `(H=32, K=128, V=128, bf16)`;
  - all 50 training steps completed with finite losses and gradient norms;
  - validation completed with loss `1.6391`;
  - checkpoint consolidation completed and Slurm exited with code `0`.
- Focused prewarm unit suite: 16 passed, 2 skipped, 4 deselected.
- Final targeted Mamba/GDN checks: 2 passed.
- Ruff checks passed for the changed Python files.
