### PR TITLE
fix: wrap experts on singleton EP shard meshes

### DIFF
--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -1061,7 +1061,7 @@ def parallelize_model(
             model,
             fsdp_mesh,
             ep_enabled=ep_enabled,
-            ep_shard_enabled=ep_shard_mesh is not None and ep_shard_mesh.size() > 1,
+            ep_shard_enabled=ep_shard_mesh is not None,
             ep_shard_mesh=ep_shard_mesh,
             mp_policy=mp_policy,
             offload_policy=offload_policy,

--- a/tests/unit_tests/moe/test_parallelizer.py
+++ b/tests/unit_tests/moe/test_parallelizer.py
@@ -1330,6 +1330,28 @@ def test_parallelize_model_calls_subsystems_and_validates(monkeypatch):
     assert kwargs.get("frozen_multimodal_sharding") == "root"
 
 
+def test_parallelize_model_wraps_experts_on_singleton_ep_shard_mesh(monkeypatch):
+    P = _import_parallelizer_with_stubs(monkeypatch)
+    apply_fsdp_mock = MagicMock()
+    monkeypatch.setattr(P, "apply_ep", MagicMock())
+    monkeypatch.setattr(P, "apply_fsdp", apply_fsdp_mock)
+
+    world_mesh = FakeWorldMesh({"dp": 2, ("dp",): 2}, mesh_dim_names=["dp"])
+    moe_mesh = FakeMoeMesh({"ep": 2, ("ep_shard",): 1})
+    model = type("Outer", (), {"moe_config": type("MC", (), {"n_routed_experts": 4})()})()
+
+    P.parallelize_model(
+        model=model,
+        world_mesh=world_mesh,
+        moe_mesh=moe_mesh,
+        dp_axis_names=("dp",),
+        ep_axis_name="ep",
+        ep_shard_axis_names=("ep_shard",),
+    )
+
+    assert apply_fsdp_mock.call_args.kwargs["ep_shard_enabled"] is True
+
+
 def test_parallelize_model_passes_frozen_multimodal_sharding_to_apply_fsdp(monkeypatch):
     P = _import_parallelizer_with_stubs(monkeypatch)
     apply_fsdp_mock = MagicMock()


### PR DESCRIPTION
## Summary

- Wrap EP experts with FSDP whenever an EP shard mesh exists, including singleton meshes.
- Add a regression test for the singleton case.

## Why

When EP spans the full world size, the EP shard mesh has size one. The previous size check left the already EP-partitioned experts under the root FSDP unit, aggregating all local expert shards into one large unshard. Per-layer singleton wrappers establish FSDP ownership without extra sharding communication.

## Validation

- `python -m pytest -q tests/unit_tests/moe/test_parallelizer.py` — 85 passed
- Ruff check and format — passed
- 8-GPU EP8/CP8 HybridEP FSDP2 smoke test — 2 training steps passed