### PR TITLE
fix: Kimi K3 tokenizer docs generation

### DIFF
--- a/nemo_automodel/components/models/kimi_k3/tokenization.py
+++ b/nemo_automodel/components/models/kimi_k3/tokenization.py
@@ -19,26 +19,27 @@ from .encoding import build_chat_segments, is_batched_conversation
 
 logger = getLogger(__name__)
 VOCAB_FILES_NAMES = {"vocab_file": "tiktoken.model"}
-_REGEX_SET_INTERSECTION = "&" * 2
-_NON_HAN_UPPER_OR_MARK = r"""[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}""" + _REGEX_SET_INTERSECTION + r"""[^\p{Han}]]"""
-_NON_HAN_LOWER_OR_MARK = r"""[\p{Ll}\p{Lm}\p{Lo}\p{M}""" + _REGEX_SET_INTERSECTION + r"""[^\p{Han}]]"""
 
 
 def _build_kimi_k3_pat_str() -> str:
     """Build the Kimi K3 tiktoken regex without exposing raw set intersections to autodoc."""
 
+    regex_set_intersection = "&" * 2
+    non_han_upper_or_mark = r"""[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}""" + regex_set_intersection + r"""[^\p{Han}]]"""
+    non_han_lower_or_mark = r"""[\p{Ll}\p{Lm}\p{Lo}\p{M}""" + regex_set_intersection + r"""[^\p{Han}]]"""
+
     return "|".join(
         [
             r"""[\p{Han}]+""",
             r"""[^\r\n\p{L}\p{N}]?"""
-            + _NON_HAN_UPPER_OR_MARK
+            + non_han_upper_or_mark
             + r"""*"""
-            + _NON_HAN_LOWER_OR_MARK
+            + non_han_lower_or_mark
             + r"""+(?i:'s|'t|'re|'ve|'m|'ll|'d)?""",
             r"""[^\r\n\p{L}\p{N}]?"""
-            + _NON_HAN_UPPER_OR_MARK
+            + non_han_upper_or_mark
             + r"""+"""
-            + _NON_HAN_LOWER_OR_MARK
+            + non_han_lower_or_mark
             + r"""*(?i:'s|'t|'re|'ve|'m|'ll|'d)?""",
             r"""\p{N}{1,3}""",
             r""" ?[^\s\p{L}\p{N}]+[\r\n]*""",

--- a/tests/unit_tests/models/kimi_k3/test_encoding.py
+++ b/tests/unit_tests/models/kimi_k3/test_encoding.py
@@ -14,6 +14,7 @@
 
 import pytest
 
+from nemo_automodel.components.models.kimi_k3 import tokenization as kimi_k3_tokenization
 from nemo_automodel.components.models.kimi_k3.encoding import build_chat_segments
 from nemo_automodel.components.models.kimi_k3.tokenization import TikTokenTokenizer, _build_kimi_k3_pat_str
 
@@ -34,6 +35,9 @@ def test_kimi_k3_tokenizer_pattern_matches_reference_regex():
 
     assert _build_kimi_k3_pat_str() == reference_pattern
     assert "pat_str" not in TikTokenTokenizer.__dict__
+    assert {
+        name: value for name, value in vars(kimi_k3_tokenization).items() if isinstance(value, str) and "&&" in value
+    } == {}
 
 
 def test_medium_thinking_effort_is_rendered():


### PR DESCRIPTION
## Summary

Fixes the Fern publish failure from https://github.com/NVIDIA-NeMo/Automodel/actions/runs/30549121884/job/90892867605.

The failing publish job generated autodoc for `nemo_automodel.components.models.kimi_k3.tokenization` and then Fern failed to parse the generated MDX at `product-docs/nemo-automodel/Full-Library-Reference/nemo-automodel/nemo_automodel/components/models/kimi_k3/tokenization.mdx` because raw regex set-intersection text containing `&&` was exposed through module-level strings.

This patch keeps the Kimi K3 tiktoken regex output unchanged, but builds the `&&` fragments inside `_build_kimi_k3_pat_str()` so autodoc-visible module string attributes no longer contain the raw MDX-hostile fragment.

## Validation

- `pytest tests/unit_tests/models/kimi_k3/test_encoding.py -q`
- `ruff check nemo_automodel/components/models/kimi_k3/tokenization.py tests/unit_tests/models/kimi_k3/test_encoding.py`

Note: I could not run the full local Fern publish path because `fern docs md generate` requires `FERN_TOKEN` outside CI.
