### PR TITLE
fix(config): repair GLM-5.2 LoRA recipe

### DIFF
--- a/examples/llm_finetune/glm/glm_5.2_lora.yaml
+++ b/examples/llm_finetune/glm/glm_5.2_lora.yaml
@@ -154,7 +154,7 @@ lr_scheduler:
 
 ci:
   # cp_size(1) with ep_size(128) => 128 GPUs => 16 nodes (8 H100/node).
-  recipe_owner: shahafwa
+  recipe_owner: HuiyingLi
   nodes: 16
   time: "00:20:00"
   release:

--- a/examples/llm_finetune/glm/glm_5.2_lora.yaml
+++ b/examples/llm_finetune/glm/glm_5.2_lora.yaml
@@ -41,7 +41,7 @@ dist_env:
 
 model:
   _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained
-  pretrained_model_name_or_path: ${oc.env:GLM52_MODEL_PATH,zai-org/GLM-5.2}
+  pretrained_model_name_or_path: zai-org/GLM-5.2
   trust_remote_code: true
   backend:
     _target_: nemo_automodel.components.models.common.BackendConfig
@@ -94,8 +94,8 @@ dataset:
   path_or_dataset_id: allenai/tulu-3-sft-mixture
   split: train[:100000]
   shuffle_seed: 42
-  truncation: false
-  seq_length: 200704
+  truncation: true
+  seq_length: 4096
   padding: false
   tokenizer:
     _target_: transformers.AutoTokenizer.from_pretrained
@@ -106,15 +106,15 @@ validation_dataset:
   path_or_dataset_id: allenai/tulu-3-sft-mixture
   split: train[100000:100064]
   shuffle_seed: 42
-  truncation: false
-  seq_length: 200704
+  truncation: true
+  seq_length: 4096
   padding: false
   tokenizer:
     _target_: transformers.AutoTokenizer.from_pretrained
     pretrained_model_name_or_path: zai-org/GLM-5.2
 
 packed_sequence:
-  packed_sequence_size: 0
+  packed_sequence_size: 4096
 
 dataloader:
   _target_: torchdata.stateful_dataloader.StatefulDataLoader

--- a/examples/llm_finetune/glm/glm_5.2_lora.yaml
+++ b/examples/llm_finetune/glm/glm_5.2_lora.yaml
@@ -156,7 +156,7 @@ ci:
   # cp_size(1) with ep_size(128) => 128 GPUs => 16 nodes (8 H100/node).
   recipe_owner: HuiyingLi
   nodes: 16
-  time: "00:20:00"
+  time: "00:25:00"
   release:
     step_scheduler.max_steps: 20
     packed_sequence.max_packs: 2560

--- a/examples/llm_finetune/glm/glm_5.2_lora.yaml
+++ b/examples/llm_finetune/glm/glm_5.2_lora.yaml
@@ -158,4 +158,5 @@ ci:
   nodes: 16
   time: "00:20:00"
   release:
-    packed_sequence.max_packs: 6400
+    step_scheduler.max_steps: 20
+    packed_sequence.max_packs: 2560

--- a/examples/llm_finetune/glm/glm_5.2_lora.yaml
+++ b/examples/llm_finetune/glm/glm_5.2_lora.yaml
@@ -118,9 +118,7 @@ packed_sequence:
 
 dataloader:
   _target_: torchdata.stateful_dataloader.StatefulDataLoader
-  collate_fn:
-    _target_: nemo_automodel.components.datasets.utils.packed_sequence_thd_collater
-    pad_seq_len_divisible: 4096
+  collate_fn: nemo_automodel.components.datasets.utils.packed_sequence_thd_collater
   shuffle: true
   drop_last: false
   num_workers: 0
@@ -128,9 +126,7 @@ dataloader:
 
 validation_dataloader:
   _target_: torchdata.stateful_dataloader.StatefulDataLoader
-  collate_fn:
-    _target_: nemo_automodel.components.datasets.utils.packed_sequence_thd_collater
-    pad_seq_len_divisible: 4096
+  collate_fn: nemo_automodel.components.datasets.utils.packed_sequence_thd_collater
   shuffle: false
   drop_last: false
   num_workers: 0

--- a/examples/llm_finetune/glm/glm_5.2_lora.yaml
+++ b/examples/llm_finetune/glm/glm_5.2_lora.yaml
@@ -29,7 +29,7 @@ distributed:
   ep_size: 128
   sequence_parallel: false
   activation_checkpointing: true
-  reshard_after_forward: false
+  reshard_after_forward: true
   moe:
     reshard_after_forward: true
     wrap_outer_model: false
@@ -157,3 +157,5 @@ ci:
   recipe_owner: shahafwa
   nodes: 16
   time: "00:20:00"
+  release:
+    packed_sequence.max_packs: 6400

--- a/examples/llm_finetune/glm/glm_5.2_lora.yaml
+++ b/examples/llm_finetune/glm/glm_5.2_lora.yaml
@@ -50,7 +50,6 @@ model:
     rms_norm: torch_fp32
     rope_fusion: false
     experts: torch_mm
-    experts_storage: fp8
     dispatcher: hybridep
     gate_precision: float32
     fake_balanced_gate: false

--- a/examples/llm_finetune/glm/glm_5.2_lora.yaml
+++ b/examples/llm_finetune/glm/glm_5.2_lora.yaml
@@ -13,7 +13,7 @@ seed: 42
 longalign: false
 
 step_scheduler:
-  global_batch_size: 32
+  global_batch_size: 128
   local_batch_size: 1
   ckpt_every_steps: 25
   val_every_steps: 5

--- a/nemo_automodel/components/config/loader.py
+++ b/nemo_automodel/components/config/loader.py
@@ -174,6 +174,10 @@ class _OrigValueStr(str):
         obj._no_env_resolve = True
         return obj
 
+    def __reduce_ex__(self, protocol: int) -> tuple[type["_OrigValueStr"], tuple[str, str]]:
+        """Preserve the resolved and original values when copying this string."""
+        return type(self), (str(self), self._orig_value)
+
 
 def resolve_yaml_env_vars(obj: Any) -> Any:
     """Resolve env var references inside a YAML-loaded container.

--- a/nemo_automodel/components/config/loader.py
+++ b/nemo_automodel/components/config/loader.py
@@ -25,7 +25,7 @@ from copy import deepcopy
 from pathlib import Path
 
 # Security/Policy configuration
-from typing import Any, Mapping
+from typing import Any, Mapping, SupportsIndex
 
 import yaml
 
@@ -174,7 +174,7 @@ class _OrigValueStr(str):
         obj._no_env_resolve = True
         return obj
 
-    def __reduce_ex__(self, protocol: int) -> tuple[type["_OrigValueStr"], tuple[str, str]]:
+    def __reduce_ex__(self, protocol: SupportsIndex, /) -> tuple[type["_OrigValueStr"], tuple[str, str]]:
         """Preserve the resolved and original values when copying this string."""
         return type(self), (str(self), self._orig_value)
 

--- a/tests/unit_tests/config/test_loader.py
+++ b/tests/unit_tests/config/test_loader.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import importlib
 import sys
 import textwrap
+from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
@@ -402,6 +403,10 @@ def test_confignode_repr_uses_orig_value_for_oc_env(monkeypatch, tmp_path: Path)
     s = str(cfg)
     assert "${oc.env:SECRET_ENV}" in s
     assert "super_secret_value" not in s
+
+    copied_value = deepcopy(cfg.x)
+    assert copied_value == "super_secret_value"
+    assert copied_value._orig_value == "${oc.env:SECRET_ENV}"
 
 
 def test_load_module_from_file(tmp_path):

--- a/tests/unit_tests/recipes/llm/test_glm_5_2_lora_config.py
+++ b/tests/unit_tests/recipes/llm/test_glm_5_2_lora_config.py
@@ -24,8 +24,8 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 CONFIG_PATH = REPO_ROOT / "examples" / "llm_finetune" / "glm" / "glm_5.2_lora.yaml"
 
 
-def test_glm_5_2_lora_backend_config_instantiates() -> None:
-    """The example's backend block must instantiate through the production config loader."""
+def test_glm_5_2_lora_config_contract() -> None:
+    """The example must preserve its backend, topology, and sequence-length contract."""
     config = load_yaml_config(CONFIG_PATH)
 
     backend = config.model.backend.instantiate()
@@ -34,6 +34,14 @@ def test_glm_5_2_lora_backend_config_instantiates() -> None:
     assert backend.attn == "tilelang"
     assert backend.experts == "torch_mm"
     assert backend.dispatcher == "hybridep"
+    assert config.model.pretrained_model_name_or_path == "zai-org/GLM-5.2"
+    assert config.dataset.seq_length == 4096
+    assert config.dataset.truncation is True
+    assert config.dataset.padding is False
+    assert config.validation_dataset.seq_length == 4096
+    assert config.validation_dataset.truncation is True
+    assert config.validation_dataset.padding is False
+    assert config.packed_sequence.packed_sequence_size == 4096
     assert config.step_scheduler.global_batch_size % (
         config.step_scheduler.local_batch_size * config.distributed.ep_size
     ) == 0

--- a/tests/unit_tests/recipes/llm/test_glm_5_2_lora_config.py
+++ b/tests/unit_tests/recipes/llm/test_glm_5_2_lora_config.py
@@ -49,7 +49,7 @@ def test_glm_5_2_lora_config_contract() -> None:
     )
     assert config.dataloader.collate_fn is packed_sequence_thd_collater
     assert config.validation_dataloader.collate_fn is packed_sequence_thd_collater
-    assert config.ci.time == "00:20:00"
+    assert config.ci.time == "00:25:00"
     release_overrides = config.ci.release.to_dict()
     assert release_overrides["step_scheduler.max_steps"] == 20
     assert release_overrides["packed_sequence.max_packs"] == 2560

--- a/tests/unit_tests/recipes/llm/test_glm_5_2_lora_config.py
+++ b/tests/unit_tests/recipes/llm/test_glm_5_2_lora_config.py
@@ -42,8 +42,12 @@ def test_glm_5_2_lora_config_contract() -> None:
     assert config.validation_dataset.truncation is True
     assert config.validation_dataset.padding is False
     assert config.packed_sequence.packed_sequence_size == 4096
+    assert config.distributed.reshard_after_forward is True
     assert config.step_scheduler.global_batch_size % (
         config.step_scheduler.local_batch_size * config.distributed.ep_size
     ) == 0
     assert config.dataloader.collate_fn is packed_sequence_thd_collater
     assert config.validation_dataloader.collate_fn is packed_sequence_thd_collater
+    release_overrides = config.ci.release.to_dict()
+    assert "step_scheduler.max_steps" not in release_overrides
+    assert release_overrides["packed_sequence.max_packs"] == 6400

--- a/tests/unit_tests/recipes/llm/test_glm_5_2_lora_config.py
+++ b/tests/unit_tests/recipes/llm/test_glm_5_2_lora_config.py
@@ -43,11 +43,13 @@ def test_glm_5_2_lora_config_contract() -> None:
     assert config.validation_dataset.padding is False
     assert config.packed_sequence.packed_sequence_size == 4096
     assert config.distributed.reshard_after_forward is True
-    assert config.step_scheduler.global_batch_size % (
-        config.step_scheduler.local_batch_size * config.distributed.ep_size
-    ) == 0
+    assert (
+        config.step_scheduler.global_batch_size % (config.step_scheduler.local_batch_size * config.distributed.ep_size)
+        == 0
+    )
     assert config.dataloader.collate_fn is packed_sequence_thd_collater
     assert config.validation_dataloader.collate_fn is packed_sequence_thd_collater
+    assert config.ci.time == "00:20:00"
     release_overrides = config.ci.release.to_dict()
-    assert "step_scheduler.max_steps" not in release_overrides
-    assert release_overrides["packed_sequence.max_packs"] == 6400
+    assert release_overrides["step_scheduler.max_steps"] == 20
+    assert release_overrides["packed_sequence.max_packs"] == 2560

--- a/tests/unit_tests/recipes/llm/test_glm_5_2_lora_config.py
+++ b/tests/unit_tests/recipes/llm/test_glm_5_2_lora_config.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Configuration contract for the GLM-5.2 LoRA example."""
+
+from pathlib import Path
+
+from nemo_automodel.components.config.loader import load_yaml_config
+from nemo_automodel.components.models.common import BackendConfig
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CONFIG_PATH = REPO_ROOT / "examples" / "llm_finetune" / "glm" / "glm_5.2_lora.yaml"
+
+
+def test_glm_5_2_lora_backend_config_instantiates() -> None:
+    """The example's backend block must instantiate through the production config loader."""
+    config = load_yaml_config(CONFIG_PATH)
+
+    backend = config.model.backend.instantiate()
+
+    assert isinstance(backend, BackendConfig)
+    assert backend.attn == "tilelang"
+    assert backend.experts == "torch_mm"
+    assert backend.dispatcher == "hybridep"

--- a/tests/unit_tests/recipes/llm/test_glm_5_2_lora_config.py
+++ b/tests/unit_tests/recipes/llm/test_glm_5_2_lora_config.py
@@ -33,3 +33,6 @@ def test_glm_5_2_lora_backend_config_instantiates() -> None:
     assert backend.attn == "tilelang"
     assert backend.experts == "torch_mm"
     assert backend.dispatcher == "hybridep"
+    assert config.step_scheduler.global_batch_size % (
+        config.step_scheduler.local_batch_size * config.distributed.ep_size
+    ) == 0

--- a/tests/unit_tests/recipes/llm/test_glm_5_2_lora_config.py
+++ b/tests/unit_tests/recipes/llm/test_glm_5_2_lora_config.py
@@ -17,6 +17,7 @@
 from pathlib import Path
 
 from nemo_automodel.components.config.loader import load_yaml_config
+from nemo_automodel.components.datasets.utils import packed_sequence_thd_collater
 from nemo_automodel.components.models.common import BackendConfig
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
@@ -36,3 +37,5 @@ def test_glm_5_2_lora_backend_config_instantiates() -> None:
     assert config.step_scheduler.global_batch_size % (
         config.step_scheduler.local_batch_size * config.distributed.ep_size
     ) == 0
+    assert config.dataloader.collate_fn is packed_sequence_thd_collater
+    assert config.validation_dataloader.collate_fn is packed_sequence_thd_collater


### PR DESCRIPTION
# What does this PR do?

Repairs the public GLM-5.2 LoRA recipe and aligns it with the configuration that was actually validated. The recipe now loads, constructs, and completes scoped training CI with its declared 128-rank topology.

# Changelog

- **Recipe contract:** remove the unsupported `experts_storage: fp8` backend argument, set `global_batch_size: 128`, use the reviewed `zai-org/GLM-5.2` model ID, and configure `packed_sequence_thd_collater` as a direct callable.
- **Data and memory contract:** truncate train and validation examples to 4096 tokens, pack to 4096 tokens, and enable `distributed.reshard_after_forward`.
- **Config loader:** preserve both resolved and original values when environment-backed strings are copied by downstream libraries.
- **CI and regression coverage:** add a focused real-recipe test and bound release CI to 20 steps with exactly 2,560 packs (`20 × global_batch_size(128)`) while leaving the public recipe at 50 steps.

# Root cause

The checked-in YAML had drifted from the private smoke configuration used to validate the original GLM-5.2 LoRA change. The successful reference [W&B run](https://wandb.ai/Nemo-automodel/huiyingl_workspace/runs/jvbvwbya) used no `experts_storage`, a global batch size of 128, fixed 4096-token prepacked inputs, direct THD collaters, and `reshard_after_forward: true`.

The public recipe retained an unsupported backend key and stale topology, collater, sequence-length, and FSDP settings. Exact scoped CI exposed those mismatches one boundary at a time.

# Validation

- GLM config regression plus config loader suite: **41 passed**
- Backend config suite: **52 passed, 2 skipped**
- Example YAML linter: **passed**
- `ruff format .`: **715 files unchanged**
- `ruff check --fix .`: **passed**
- All GitHub checks, including `Validate recipe configs`: **passed** at `7edd128035241e8654e94729a5ec5992931aa54c`
- Final exact scoped CI: [pipeline 60358579](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/60358579) and [job 379639999](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/379639999) **passed**
  - Generated pipeline contained exactly one non-optional `glm_5.2_lora` job.
  - Created exactly 2,560 training packs.
  - Completed all 20/20 steps with finite losses and gradients and stable memory.

<details>
<summary>Scoped CI investigation history</summary>

| Pipeline | Result |
| --- | --- |
| [60314753](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/60314753) | Removed the original `experts_storage` constructor failure; exposed environment-string copying. |
| [60317673](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/60317673) | Passed config copying; exposed the 32-vs-128 global batch mismatch. |
| [60319150](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/60319150) | Passed topology validation; exposed the stale collater argument. |
| [60320733](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/60320733) | Entered training; exposed the unbounded sequence contract in HybridEP/DOCA queue creation. |
| [60346845](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/60346845) | The 4K contract removed the DOCA failure; exposed the remaining FSDP resharding memory mismatch. |
| [60353306](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/60353306) | With resharding aligned, completed 34/50 healthy iterations before the 20-minute limit. |
| [60358579](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/60358579) | Final 20-step scoped run passed. |

</details>

# Before your PR is "Ready for review"

- [x] Read and followed the contributor guidelines.
- [x] Added regression coverage for the corrected public config.
- [x] Completed exact scoped EOS validation.

# Additional Information

- [AMINT-200](https://linear.app/nvidia/issue/AMINT-200/backendconfig-constructor-receives-unsupported-experts-storage-keyword)
- [Original GLM-5.2 LoRA PR](https://github.com/NVIDIA-NeMo/Automodel/pull/3176)
