### PR TITLE
docs(models): add Inkling-Small recipe and coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 </div>
 
 ## 📣 News and Discussions
+- [07/30/2026][**Inkling-Small**](https://huggingface.co/thinkingmachines/Inkling-Small) We now support full-parameter fine-tuning for the 276B-parameter, 12B-active Inkling-Small model on 64 H100 GPUs. Check out the [MedPix EP64 recipe](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/vlm_finetune/inkling/Inkling_small_medpix_ep64.yaml) and [model coverage page](https://github.com/NVIDIA-NeMo/Automodel/blob/main/docs/model-coverage/vlm/thinkingmachines/inkling.mdx).
 - [07/29/2026][**Kimi K3**](https://huggingface.co/moonshotai/Kimi-K3) We now support full-parameter fine-tuning for Moonshot AI's 2.8T-parameter MoE model on NVIDIA GB200. Check out the [HellaSwag EP32/PP8 recipe](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/llm_finetune/kimi/k3_hellaswag.yaml) on 256 GB200.
 - [07/21/2026][**Laguna S 2.1**](https://huggingface.co/poolside/Laguna-S-2.1) We now support finetuning Poolside's 118B-A8B Laguna S 2.1 MoE model. Check out our [HellaSwag EP16 recipe](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/llm_finetune/laguna/laguna_s_2p1_hellaswag_ep16.yaml).
 - [07/18/2026][**Inkling VLM MoE**](https://huggingface.co/thinkingmachines/Inkling) We now support finetuning Inkling. Check out our [MedPix recipe](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/vlm_finetune/inkling/inkling_medpix.yaml).

--- a/docs/model-coverage/vlm/thinkingmachines/inkling.mdx
+++ b/docs/model-coverage/vlm/thinkingmachines/inkling.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Inkling"
-description: "Fine-tune Thinking Machines Lab's 975B multimodal MoE model with pipeline and expert parallelism."
+description: "Fine-tune Thinking Machines Lab's Inkling multimodal MoE family with pipeline and expert parallelism."
 ---
 
-[Inkling](https://huggingface.co/thinkingmachines/Inkling) is a multimodal Mixture-of-Experts model from Thinking Machines Lab. It accepts text, image, video, and audio inputs and generates text.
+[Inkling](https://huggingface.co/thinkingmachines/Inkling) is a multimodal Mixture-of-Experts model family from Thinking Machines Lab. The models accept text, image, video, and audio inputs and generate text. NeMo AutoModel supports both the 975B Inkling checkpoint and the 276B [Inkling-Small](https://huggingface.co/thinkingmachines/Inkling-Small) checkpoint.
 
 <Info>
 
@@ -11,7 +11,7 @@ description: "Fine-tune Thinking Machines Lab's 975B multimodal MoE model with p
 |---|---|
 | **Task** | Image-Text-to-Text / Audio-Text-to-Text |
 | **Architecture** | `InklingForConditionalGeneration` |
-| **Parameters** | 975B total / 41B active |
+| **Parameters** | Inkling: 975B total / 41B active; Inkling-Small: 276B total / 12B active |
 | **Precision** | BF16 |
 | **HF Org** | [thinkingmachines](https://huggingface.co/thinkingmachines) |
 
@@ -19,24 +19,31 @@ description: "Fine-tune Thinking Machines Lab's 975B multimodal MoE model with p
 
 ## Architecture
 
-Inkling uses a 66-layer decoder with hybrid local and global attention. Each sparse feed-forward layer routes a token to 6 of 256 experts and also evaluates 2 shared experts. Images and video use a hierarchical patch encoder, while audio uses discrete dMel tokens.
+Inkling uses a 66-layer decoder with hybrid local and global attention. Inkling-Small uses the same model family with 42 decoder layers and hidden size 4096. Local attention uses a 512-token sliding window, and every sixth layer uses global attention. Both variants use eight key-value heads and short convolutions with kernel size four.
 
-NeMo AutoModel retains the checkpoint's fused expert layout and supports pipeline parallelism and expert parallelism for full-parameter fine-tuning.
+Each sparse feed-forward layer routes a token to 6 of 256 experts and also evaluates 2 shared experts. Images and video use a hierarchical patch encoder, while audio uses discrete dMel tokens.
+
+NeMo AutoModel retains the checkpoint's fused expert layout and supports expert parallelism for both variants. The full Inkling recipe also uses pipeline parallelism.
 
 ## Example HF Models
 
 | Model | HF ID |
 |---|---|
 | Inkling BF16 | [`thinkingmachines/Inkling`](https://huggingface.co/thinkingmachines/Inkling) |
+| Inkling-Small | [`thinkingmachines/Inkling-Small`](https://huggingface.co/thinkingmachines/Inkling-Small) |
 
 ## Example Recipes
 
 | Recipe | Dataset | Description |
 |---|---|---|
 | [inkling_medpix.yaml](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/vlm_finetune/inkling/inkling_medpix.yaml) | MedPix-VQA | Full SFT with PP8 and EP32 |
+| [Inkling_small_medpix_ep64.yaml](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/vlm_finetune/inkling/Inkling_small_medpix_ep64.yaml) | MedPix-VQA | Full SFT with EP64 on 64 H100 GPUs |
 
-The model requires a multi-node launch. Adjust the data, pipeline, and expert-parallel dimensions to the available cluster before running the recipe.
+Both recipes require a multi-node launch. Adjust the data and parallel dimensions to the available cluster before running a recipe.
+
+The Inkling-Small EP64 recipe completed 100 training steps on 64 H100 GPUs with microbatch size 1, global batch size 64, and 512-token MedPix samples. It uses FSDP2, activation checkpointing, HybridEP dispatch, and no context or pipeline parallelism.
 
 ## Hugging Face Model Card
 
 - [thinkingmachines/Inkling](https://huggingface.co/thinkingmachines/Inkling)
+- [thinkingmachines/Inkling-Small](https://huggingface.co/thinkingmachines/Inkling-Small)

--- a/examples/vlm_finetune/inkling/Inkling_small_medpix_ep64.yaml
+++ b/examples/vlm_finetune/inkling/Inkling_small_medpix_ep64.yaml
@@ -1,0 +1,136 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Fine-tune Inkling-Small on MedPix-VQA.
+#
+# Hardware target: 8 nodes x 8 H100 GPUs with FSDP2 and EP64.
+
+recipe: FinetuneRecipeForVLM
+
+step_scheduler:
+  global_batch_size: 64
+  local_batch_size: 1
+  ckpt_every_steps: 500
+  val_every_steps: 50
+  log_remote_every_steps: 1
+  gc_every_steps: 10
+  num_epochs: 2
+  max_steps: 100
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 60
+
+rng:
+  _target_: nemo_automodel.components.training.rng.StatefulRNG
+  seed: 1234
+  ranked: true
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained
+  pretrained_model_name_or_path: thinkingmachines/Inkling-Small
+  torch_dtype: bfloat16
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: sdpa
+    linear: torch
+    rms_norm: torch_fp32
+    gate_precision: float32
+    experts: torch_mm
+    dispatcher: hybridep
+    enable_hf_state_dict_adapter: true
+    enable_fsdp_optimizations: true
+
+processor:
+  _target_: nemo_automodel.components.models.inkling.processing.build_inkling_processor
+  pretrained_model_name_or_path: thinkingmachines/Inkling-Small
+
+checkpoint:
+  enabled: false
+  checkpoint_dir: checkpoints/inkling-small-medpix-ep64/
+  model_save_format: safetensors
+  save_consolidated: false
+
+distributed:
+  strategy: fsdp2
+  tp_size: 1
+  cp_size: 1
+  pp_size: 1
+  dp_replicate_size: 1
+  ep_size: 64
+
+  sequence_parallel: false
+  activation_checkpointing: true
+
+  moe:
+    reshard_after_forward: true
+    wrap_outer_model: true
+
+freeze_config:
+  freeze_vision_tower: true
+  freeze_audio_tower: true
+  freeze_language_model: false
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+dataset:
+  _target_: nemo_automodel.components.datasets.vlm.datasets.make_medpix_dataset
+  path_or_dataset: mmoukouba/MedPix-VQA
+  split: train
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  num_workers: 1
+  collate_fn:
+    _target_: nemo_automodel.components.datasets.vlm.collate_fns.default_collate_fn
+    max_length: 512
+  drop_last: true
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.vlm.datasets.make_medpix_dataset
+  path_or_dataset: mmoukouba/MedPix-VQA
+  split: validation
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  num_workers: 1
+  collate_fn:
+    _target_: nemo_automodel.components.datasets.vlm.collate_fns.default_collate_fn
+    max_length: 512
+  drop_last: true
+
+optimizer:
+  _target_: torch.optim.AdamW
+  betas: [0.9, 0.95]
+  eps: 1e-8
+  lr: 1.0e-5
+  weight_decay: 0.1
+  foreach: false
+
+lr_scheduler:
+  lr_decay_style: cosine
+  min_lr: 1.0e-6
+
+wandb:
+  enable: false
+  project: automodel-inkling-small
+  entity: <your_wandb_entity>
+  name: inkling-small-medpix-ep64
+  dir: wandb
+
+ci:
+  recipe_owner: HuiyingLi
+  nodes: 8
+  time: "01:00:00"

--- a/examples/vlm_finetune/inkling/README.md
+++ b/examples/vlm_finetune/inkling/README.md
@@ -1,0 +1,37 @@
+# Inkling fine-tuning recipes
+
+NeMo AutoModel supports full-parameter fine-tuning for the Inkling multimodal
+Mixture-of-Experts model family.
+
+| Recipe | Model | Dataset | Parallelism |
+|---|---|---|---|
+| [`inkling_medpix.yaml`](./inkling_medpix.yaml) | Inkling | MedPix-VQA | FSDP2, PP8, EP32 |
+| [`Inkling_small_medpix_ep64.yaml`](./Inkling_small_medpix_ep64.yaml) | Inkling-Small | MedPix-VQA | FSDP2, EP64 |
+
+## Inkling-Small
+
+[Inkling-Small](https://huggingface.co/thinkingmachines/Inkling-Small) is a
+276B-parameter, 12B-active model. The default topology uses 8 nodes with 8 H100
+GPUs per node:
+
+```bash
+uv run automodel --nproc-per-node=8 examples/vlm_finetune/inkling/Inkling_small_medpix_ep64.yaml
+```
+
+Submit the command through the cluster launcher so all eight nodes receive the
+same repository, checkpoint, and dataset paths.
+
+The recipe uses:
+
+- FSDP2 with activation checkpointing
+- EP64 with HybridEP dispatch and grouped `torch_mm` experts
+- no context or pipeline parallelism
+- microbatch size 1 and global batch size 64
+- MedPix-VQA padded or truncated to 512 tokens
+- frozen vision and audio towers
+
+This topology completed 100 training steps on 64 H100 GPUs. The run used about
+50.6 GiB of GPU memory after warm-up and finished with validation loss 2.0430.
+
+See the [Inkling model coverage page](https://docs.nvidia.com/nemo/automodel/nightly/model-coverage/vision-language-models/inkling)
+for architecture details.


### PR DESCRIPTION
## Summary

- add an Inkling-Small MedPix fine-tuning recipe for 8 nodes / 64 H100 GPUs
- configure EP64 with HybridEP and the shared MoE modules
- document model coverage, architecture details, topology, and the validated 100-step run
- add the recipe to the Inkling and repository documentation

## Validation

- completed 100 training steps on 64 H100 GPUs
- observed approximately 50.6 GiB GPU memory after warm-up
- final validation loss: 2.0430
