### PR TITLE
fix(docs): avoid literal ampersand in Kimi autodoc

### DIFF
--- a/nemo_automodel/components/models/kimi_k3/tokenization.py
+++ b/nemo_automodel/components/models/kimi_k3/tokenization.py
@@ -19,7 +19,8 @@ from .encoding import build_chat_segments, is_batched_conversation
 
 logger = getLogger(__name__)
 VOCAB_FILES_NAMES = {"vocab_file": "tiktoken.model"}
-_REGEX_SET_INTERSECTION = "&" * 2
+# Fern autodoc emits literal ampersands as invalid MDX.
+_REGEX_SET_INTERSECTION = chr(38) * 2
 _NON_HAN_UPPER_OR_MARK = r"""[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}""" + _REGEX_SET_INTERSECTION + r"""[^\p{Han}]]"""
 _NON_HAN_LOWER_OR_MARK = r"""[\p{Ll}\p{Lm}\p{Lo}\p{M}""" + _REGEX_SET_INTERSECTION + r"""[^\p{Han}]]"""
 


### PR DESCRIPTION
# What does this PR do ?

Prevents Fern from emitting an invalid Kimi tokenizer API-reference page while preserving the exact runtime tokenizer regex.

# Changelog

- construct the Kimi regex set-intersection marker without a literal ampersand in the Python source
- keep the generated `pat_str` byte-for-byte equivalent to the reference regex

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? The existing pattern-equivalence test covers this change.
- [x] Did you add or update any necessary documentation? No user-facing documentation change is required.

# Validation

- `uv run pytest tests/unit_tests/models/kimi_k3/test_encoding.py -q` — 5 passed
- `uv run ruff check nemo_automodel/components/models/kimi_k3/tokenization.py`
- `uv run ruff format --check nemo_automodel/components/models/kimi_k3/tokenization.py`
- `python -m py_compile nemo_automodel/components/models/kimi_k3/tokenization.py`
- `make -C docs/fern docs-mdx-check` — validated 454 MDX files
- confirmed the source file contains no literal ampersands after the change

The cloud-backed `fern docs md generate` command requires the NVIDIA Fern token, so the production generation path remains to be confirmed by CI.

# Additional Information

Follow-up to #3288, which moved the raw `&&` out of `TikTokenTokenizer.pat_str` but left a literal ampersand in the module-level helper. Subsequent `main` publishes continued to fail while parsing the generated Kimi `tokenization.mdx` page.

Failing job: https://github.com/NVIDIA-NeMo/Automodel/actions/runs/30569083907/job/90960900231
