### PR TITLE
fix(glm_moe_dsa): keep the PP top-k carry gradient dense for P2P

### DIFF
--- a/nemo_automodel/components/models/glm_moe_dsa/model.py
+++ b/nemo_automodel/components/models/glm_moe_dsa/model.py
@@ -44,6 +44,25 @@ from nemo_automodel.components.utils.model_utils import squeeze_input_for_thd
 from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 
 
+def _zero_with_dense_grad(tensor: torch.Tensor) -> torch.Tensor:
+    """Return a ``0.0`` scalar that keeps ``tensor`` in autograd with a *dense* gradient.
+
+    Scaling first makes the multiply's backward allocate a fresh contiguous zero tensor.
+    Reducing first (``tensor.sum() * 0.0``) instead hands back a stride-0 expanded gradient,
+    and since the pipeline's backward P2P recv buffer is allocated from that reported stride,
+    NCCL fails with ``ValueError: Tensors for P2P must be non-overlapping and dense``.
+
+    Args:
+        tensor: Float tensor of arbitrary shape; only its autograd edge, shape, and
+            dtype are used.
+
+    Returns:
+        0-dim tensor holding ``0.0`` with ``tensor``'s dtype, connected to ``tensor``
+        so that ``tensor`` receives a contiguous all-zero gradient.
+    """
+    return (tensor * 0.0).sum()
+
+
 class Block(nn.Module):
     def __init__(self, layer_idx: int, config: GlmMoeDsaConfig, moe_config: MoEConfig, backend: BackendConfig):
         super().__init__()
@@ -523,22 +542,24 @@ class GlmMoeDsaForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
             # torch.distributed.pipelining treats every float inter-stage tensor as an activation
             # and demands a gradient for it on backward. We add zero-weight autograd links so the
             # carry it RECEIVES and the carry it SENDS both get a DEFINED (zero) gradient instead of
-            # ``None`` — values are unchanged (``+ x.sum() * 0.0``).
+            # ``None`` — values are unchanged (``+ _zero_with_dense_grad(x)``). The carry-in link
+            # must keep grad(carry_in) contiguous, since that gradient's stride is what sizes the
+            # previous stage's P2P recv buffer; see _zero_with_dense_grad.
             if self.lm_head is not None:
                 # Last stage: emit logits for the pipeline loss.
                 logits = compute_lm_head_logits(self.lm_head, hidden, logits_to_keep, is_thd=is_thd).logits
                 if carry_in is not None:
-                    logits = logits + (carry_in.float().sum() * 0.0).to(logits.dtype)
+                    logits = logits + _zero_with_dense_grad(carry_in).to(logits.dtype)
                 return logits
             # Non-last stage: emit (hidden, float32 top-k carry) to the next stage. The tensors are
             # already in the backend's natural pipeline shape (THD: [T, H] + [T, 1, topk]; bshd:
             # [B, S, H] + [B, S, topk]) per get_pipeline_stage_metas, so no reshape is needed.
             # (THD requires packed_sequence_size >= index_topk so the tilelang top-k width matches
             # the meta's min(index_topk, seq_len).)
-            zero_from_hidden = hidden.float().sum() * 0.0  # connected to grad-bearing hidden
+            zero_from_hidden = _zero_with_dense_grad(hidden).float()  # connected to grad-bearing hidden
             carry_out = topk_indices.to(torch.float32) + zero_from_hidden  # requires grad, value unchanged
             if carry_in is not None:
-                hidden = hidden + (carry_in.float().sum() * 0.0).to(hidden.dtype)  # defines grad(carry_in)
+                hidden = hidden + _zero_with_dense_grad(carry_in).to(hidden.dtype)  # defines grad(carry_in)
             return hidden, carry_out
 
         return compute_lm_head_logits(

--- a/tests/unit_tests/models/glm_moe_dsa/test_glm_moe_dsa_model.py
+++ b/tests/unit_tests/models/glm_moe_dsa/test_glm_moe_dsa_model.py
@@ -581,6 +581,40 @@ class TestIndexShare:
         assert isinstance(out, tuple) and len(out) == 2
         assert out[1].dtype == torch.float32  # carry-out emitted as float32
 
+    @pytest.mark.parametrize("is_last_stage", [False, True])
+    def test_pp_stage_carry_in_gradient_is_dense(self, config, backend_config, device, is_last_stage):
+        # torch.distributed.pipelining sizes the previous stage's backward P2P recv buffer with
+        # torch.empty_strided(shape, stride) taken from grad(carry_in)'s stride. A stride-0
+        # expanded gradient (what `carry.sum() * 0.0` produces) makes irecv raise
+        # "Tensors for P2P must be non-overlapping and dense", so the zero-weight autograd link
+        # must hand back a contiguous gradient on both the non-last and the last stage.
+        model = GlmMoeDsaForCausalLM(config, backend=backend_config).to(device)
+        model.model.embed_tokens = None  # not first stage -> carry_in is a real stage input
+        if not is_last_stage:
+            model.lm_head = None
+
+        seq_len, topk = 4, 8
+
+        def fake_model_forward(input_ids, *, prev_topk_indices=None, **kw):
+            # [1, seq_len, hidden] carried from input_ids so `hidden` stays grad-bearing.
+            return input_ids * 2.0, torch.zeros(1, seq_len, topk, dtype=torch.int64, device=device)
+
+        carry_in = torch.zeros(1, seq_len, topk, dtype=torch.float32, device=device, requires_grad=True)
+        hidden_in = torch.randn(1, seq_len, config.hidden_size, dtype=torch.bfloat16, device=device).requires_grad_()
+        with patch.object(model.model, "forward", new=fake_model_forward):
+            out = model(hidden_in, carry_in)
+
+        outputs = [out] if is_last_stage else list(out)
+        (carry_grad,) = torch.autograd.grad(outputs, [carry_in], [torch.ones_like(o) for o in outputs])
+        assert carry_grad.shape == carry_in.shape
+        assert torch.count_nonzero(carry_grad) == 0  # the zero link must not perturb gradients
+        # The exact allocation torch.distributed.pipelining makes for the backward P2P recv buffer;
+        # contiguous is the non-overlapping-and-dense layout NCCL requires for irecv.
+        recv_buffer = torch.empty_strided(
+            carry_grad.shape, carry_grad.stride(), dtype=carry_grad.dtype, device=carry_grad.device
+        )
+        assert recv_buffer.is_contiguous(), f"grad(carry_in) stride {carry_grad.stride()} is not dense"
+
 
 class TestUpdateMoeGateBias:
     def test_updates_every_local_moe_gate_via_outer_model(self, config, backend_config):


### PR DESCRIPTION
# What does this PR do ?

Fixes `ValueError: Tensors for P2P must be non-overlapping and dense` on every non-last pipeline stage of the GLM-5 PP benchmark recipes (AMINT-210).

# Why / root cause

GLM MoE DSA threads its non-differentiable IndexShare top-k selection across pipeline stages as a float32 carry, keeping it in the autograd graph with a zero-weight link so `torch.distributed.pipelining` gets a defined gradient:

```python
hidden = hidden + (carry_in.float().sum() * 0.0).to(hidden.dtype)
```

`sum()`'s backward returns `grad.expand(carry_in.shape)` — a **stride-0, overlapping** view. `PipelineStage` reports each stage's input-gradient metadata (shape, **stride**, dtype) upstream, and the previous stage allocates its backward recv buffer with `torch.empty_strided(shape, stride)`. A stride-0 gradient makes that buffer overlapping, so NCCL rejects it on the first `RECV_B`.

This was always malformed; it was masked until torch 2.13 by the static-metadata path, which derives grad metas from the stage's (contiguous) *outputs* rather than the downstream stage's real gradients. #2983 disabled that path on torch >= 2.12, exposing the bug. Independent of #3257 restoring static metadata — the gradient is wrong in either mode, so this fix is needed regardless.

# The fix

Scale before reducing, via a documented `_zero_with_dense_grad()` helper used at all three carry sites: `(carry_in * 0.0).sum()`. The multiply's backward allocates a fresh contiguous zero tensor, so the reported stride is dense.

|  | grad stride | P2P buffer |
|---|---|---|
| `x.float().sum() * 0.0` | `(0, 0, 0)` | rejected |
| `(x * 0.0).sum()` | `(12, 4, 1)` | accepted |

Values are unchanged, and the forward is slightly cheaper than the previous fp32 upcast of the full hidden state.

# Validation

- **nemo-ci performance pipeline (16 + 128 nodes, eos): https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/60154318** — `glm5_lora` and `glm_5_te_deepep` both green, full benchmark summaries, zero P2P errors.
- Single-node A/B (8xH100, scaled-down GLM-5, pp4/ep2, interleaved1f1b, same CI container): pristine `main` reproduces the identical traceback; this branch runs 5 clean steps.
- New regression test fails on `main` with `grad(carry_in) stride (0, 0, 0) is not dense`, passes here. Full `glm_moe_dsa` suite: 154 passed.

# Changelog

- `_zero_with_dense_grad()` in `glm_moe_dsa/model.py`; used for the carry-in links on the last and non-last stages and the carry-out link from `hidden`.
- `test_pp_stage_carry_in_gradient_is_dense`, parametrized over last / non-last stage.

# Pre checks

- [x] Read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Added a regression test
- [ ] Documentation — n/a

# Additional Information

- Fixes AMINT-210
- Related: #2983 (exposed it), #3257 (restores the static-metadata path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
