### PR TITLE
fix(distributed): reuse default group for world-sized meshes

### DIFF
--- a/nemo_automodel/components/distributed/mesh_utils.py
+++ b/nemo_automodel/components/distributed/mesh_utils.py
@@ -194,6 +194,11 @@ def _nccl_backend_override(
     return override
 
 
+def _can_reuse_default_group(group_size: int) -> bool:
+    """Return whether a derived mesh dimension spans the default process group."""
+    return dist.is_initialized() and group_size == dist.get_world_size()
+
+
 def _validate_mesh_spec(spec: _MeshSpec) -> None:
     for shape, axis in zip(spec.shape, spec.axes):
         assert isinstance(shape, int), f"Expected {axis} to be an int, but got {type(shape)}"
@@ -216,9 +221,15 @@ def _register_flattened_axes(
         timeout_minutes=timeout_minutes,
     )
     for flattened_axis, source_axes in flattened_axes.items():
-        flattened_mesh = device_mesh[source_axes]._flatten(
+        source_mesh = device_mesh[source_axes]
+        backend_override = backend_overrides.get(flattened_axis) if backend_overrides else None
+        # The default process group already has the configured timeout. Supplying
+        # an override for the same world-sized ranks would allocate another NCCL communicator.
+        if backend_override is not None and _can_reuse_default_group(source_mesh.size()):
+            backend_override = None
+        flattened_mesh = source_mesh._flatten(
             mesh_dim_name=flattened_axis,
-            backend_override=backend_overrides.get(flattened_axis) if backend_overrides else None,
+            backend_override=backend_override,
         )
         device_mesh._flatten_mapping.setdefault(flattened_axis, flattened_mesh)
 
@@ -423,19 +434,30 @@ def _unflatten_compat(
     *,
     timeout_minutes: int | None = None,
 ) -> DeviceMesh:
-    """Unflatten a mesh with its NCCL timeout, including the PyTorch 2.9 fallback."""
+    """Unflatten a mesh with its NCCL timeout, including the PyTorch 2.9 fallback.
+
+    PyTorch reuses the default process group for a world-sized dimension only
+    when no backend override is supplied. The default group already has the
+    configured distributed timeout, so omitting that redundant override avoids
+    allocating another NCCL communicator.
+    """
     if hasattr(flat_mesh, "_unflatten"):
         if timeout_minutes is not None and flat_mesh.device_type == "cuda":
-            return flat_mesh._unflatten(
-                axis,
-                sizes,
+            backend_override = _nccl_backend_override(
                 names,
-                backend_override=_nccl_backend_override(
-                    names,
-                    device_type=flat_mesh.device_type,
-                    timeout_minutes=timeout_minutes,
-                ),
+                device_type=flat_mesh.device_type,
+                timeout_minutes=timeout_minutes,
             )
+            backend_override = {
+                name: backend_override[name] for name, size in zip(names, sizes) if not _can_reuse_default_group(size)
+            }
+            if backend_override:
+                return flat_mesh._unflatten(
+                    axis,
+                    sizes,
+                    names,
+                    backend_override=backend_override,
+                )
         return flat_mesh._unflatten(axis, sizes, names)
     new_mesh_tensor = flat_mesh.mesh.reshape(sizes)
     from torch.distributed.device_mesh import DeviceMesh as _DeviceMesh

--- a/tests/unit_tests/distributed/test_mesh_utils.py
+++ b/tests/unit_tests/distributed/test_mesh_utils.py
@@ -93,15 +93,18 @@ def test_init_named_mesh_omits_backend_override_for_cpu(monkeypatch):
     assert captured["backend_override"] is None
 
 
-def test_flattened_axes_inherit_nccl_timeout():
+def test_flattened_axes_inherit_nccl_timeout(monkeypatch):
     flattened_mesh = Mock()
     source_mesh = Mock()
     source_mesh.device_type = "cuda"
+    source_mesh.size = Mock(return_value=4)
     source_mesh._flatten = Mock(return_value=flattened_mesh)
     device_mesh = Mock()
     device_mesh.device_type = "cuda"
     device_mesh._flatten_mapping = {}
     device_mesh.__getitem__ = Mock(return_value=source_mesh)
+    monkeypatch.setattr(mesh_utils.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(mesh_utils.dist, "get_world_size", lambda: 8)
 
     _register_flattened_axes(
         device_mesh,
@@ -112,6 +115,31 @@ def test_flattened_axes_inherit_nccl_timeout():
     backend, options = source_mesh._flatten.call_args.kwargs["backend_override"]
     assert backend == "nccl"
     assert options._timeout == datetime.timedelta(minutes=30)
+    assert device_mesh._flatten_mapping[MeshAxisName.DP_CP] is flattened_mesh
+
+
+def test_flattened_world_axis_reuses_default_process_group(monkeypatch):
+    flattened_mesh = Mock()
+    source_mesh = Mock()
+    source_mesh.size = Mock(return_value=8)
+    source_mesh._flatten = Mock(return_value=flattened_mesh)
+    device_mesh = Mock()
+    device_mesh.device_type = "cuda"
+    device_mesh._flatten_mapping = {}
+    device_mesh.__getitem__ = Mock(return_value=source_mesh)
+    monkeypatch.setattr(mesh_utils.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(mesh_utils.dist, "get_world_size", lambda: 8)
+
+    _register_flattened_axes(
+        device_mesh,
+        {MeshAxisName.DP_CP: (MeshAxisName.DP_SHARD, MeshAxisName.CP)},
+        timeout_minutes=30,
+    )
+
+    source_mesh._flatten.assert_called_once_with(
+        mesh_dim_name=MeshAxisName.DP_CP,
+        backend_override=None,
+    )
     assert device_mesh._flatten_mapping[MeshAxisName.DP_CP] is flattened_mesh
 
 
@@ -154,7 +182,7 @@ def test_fsdp2_forwards_nccl_timeout_to_moe_mesh(monkeypatch):
     )
 
 
-def test_moe_ep_groups_inherit_nccl_timeout():
+def test_moe_ep_groups_inherit_nccl_timeout(monkeypatch):
     moe_mesh = Mock()
     flat_mesh = Mock()
     flat_mesh.device_type = "cuda"
@@ -164,6 +192,8 @@ def test_moe_ep_groups_inherit_nccl_timeout():
     device_mesh = Mock()
     device_mesh.device_type = "cuda"
     device_mesh.__getitem__ = Mock(return_value=source_mesh)
+    monkeypatch.setattr(mesh_utils.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(mesh_utils.dist, "get_world_size", lambda: 64)
 
     result = _create_moe_mesh(device_mesh, ep_shard_size=4, ep_size=32, timeout_minutes=30)
 
@@ -173,6 +203,29 @@ def test_moe_ep_groups_inherit_nccl_timeout():
         backend, options = unflatten_override[axis]
         assert backend == "nccl"
         assert options._timeout == datetime.timedelta(minutes=30)
+    assert result is moe_mesh
+
+
+def test_moe_world_size_ep_reuses_default_process_group(monkeypatch):
+    moe_mesh = Mock()
+    flat_mesh = Mock()
+    flat_mesh.device_type = "cuda"
+    flat_mesh._unflatten = Mock(return_value=moe_mesh)
+    source_mesh = Mock()
+    source_mesh._flatten = Mock(return_value=flat_mesh)
+    device_mesh = Mock()
+    device_mesh.device_type = "cuda"
+    device_mesh.__getitem__ = Mock(return_value=source_mesh)
+    monkeypatch.setattr(mesh_utils.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(mesh_utils.dist, "get_world_size", lambda: 8)
+
+    result = _create_moe_mesh(device_mesh, ep_shard_size=1, ep_size=8, timeout_minutes=30)
+
+    unflatten_override = flat_mesh._unflatten.call_args.kwargs["backend_override"]
+    assert set(unflatten_override) == {MeshAxisName.EP_SHARD}
+    backend, options = unflatten_override[MeshAxisName.EP_SHARD]
+    assert backend == "nccl"
+    assert options._timeout == datetime.timedelta(minutes=30)
     assert result is moe_mesh
 
 


### PR DESCRIPTION
# What does this PR do?

Fixes the `moonlight_16b_torch` CUDA memory regression introduced by the
derived-mesh timeout propagation in #2846, without removing timeout propagation
for process groups that need it.

## Regression proof

The same CI recipe and hardware configuration was rerun on this PR commit
(`b293f9e4541e24872e67324428312bdf2b2ff99c`):

| Result | CI evidence |
| --- | --- |
| **Before: failed** during backward with CUDA OOM | [`moonlight_16b_torch` job 367418885](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/367418885), reported by [AMINT-228](https://linear.app/nvidia/issue/AMINT-228/cuda-oom-during-backward-pass-in-moonlight-16b-torch) |
| **After: passed** all 30 iterations on EOS, 8x H100 | [`moonlight_16b_torch` job 379767996](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/379767996) |

The successful rerun held steady at **68.92 GB max PyTorch-allocated memory**
after initialization and completed without an OOM.

## Root cause

#2846 passed a `backend_override` containing the configured timeout to every
derived mesh dimension. For a dimension spanning the entire distributed world,
that override prevents PyTorch from reusing the existing default process group
and creates another world-sized NCCL communicator. Its additional device memory
remains resident and leaves insufficient free memory for Moonlight's backward
pass.

## Why this preserves the purpose of #2846

The fix omits `backend_override` only when the derived dimension spans the full
world and can reuse the default process group. That default group was already
created with the configured timeout.

Smaller derived groups still receive the timeout override when their new process
groups are created. Timeout propagation is therefore preserved where it is
needed, while the redundant full-world NCCL communicator is avoided.

# Changelog

- Reuse the default process group for world-sized flattened mesh axes.
- Reuse the default process group for world-sized unflattened mesh dimensions.
- Continue applying the configured timeout to smaller derived process groups.
- Add focused DP and MoE coverage for both reuse and timeout propagation.

# Validation

- **Exact EOS CI rerun:** [`moonlight_16b_torch` job 379767996](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/379767996) — passed 30/30 iterations on 8x H100.
- `pytest tests/unit_tests/distributed/test_mesh_utils.py tests/unit_tests/distributed/test_device_mesh.py -q` — 61 passed.
- `pytest tests/unit_tests/distributed -q` — 1072 passed, 84 skipped.
- `ruff format --check nemo_automodel/components/distributed/mesh_utils.py tests/unit_tests/distributed/test_mesh_utils.py`.
- `ruff check nemo_automodel/components/distributed/mesh_utils.py tests/unit_tests/distributed/test_mesh_utils.py`.
- Independent root-cause reproduction on `cw-dfw-cs-001`, 8x H100, stable 26.06 container (Slurm job `14729457`) — passed with 61.47 GB at step 0 and 68.92 GB at step 1.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added focused tests for the changed behavior.
- [x] Documentation changes are not required for this internal process-group fix.

# Additional Information

- Resolves [AMINT-228](https://linear.app/nvidia/issue/AMINT-228/cuda-oom-during-backward-pass-in-moonlight-16b-torch).
- Preserves the timeout-propagation intent of #2846.
