### PR TITLE
feat(vlm): support packed THD vlm context parallelism

### DIFF
--- a/nemo_automodel/components/datasets/vlm/collate_fns.py
+++ b/nemo_automodel/components/datasets/vlm/collate_fns.py
@@ -1611,11 +1611,12 @@ def packed_sequence_thd_vlm_collater(
     VLM counterpart of ``packed_sequence_thd_collater`` (text-only,
     ``datasets/utils.py``). Packs arrive with variable lengths (no pre-padding)
     from ``neat_pack_dataset_vlm``. This collater pads text tensors to a common
-    length and stacks them to ``[batch, seq]``; derives per-document real lengths
-    (``seq_lens``) from the indexed ``attention_mask`` (values 1, 2, ... per
-    sub-sequence, 0 = padding) and folds each sample's trailing pad into its last
-    document for ``seq_lens_padded``; keeps the mRoPE ``[3, seq]`` layout as
-    ``[3, batch, seq]``; concatenates media tensors; and emits ``qkv_format='thd'``.
+    length and stacks them to ``[batch, seq]``. CP-aware packed samples provide
+    explicit ``seq_lens`` and ``seq_lens_padded`` metadata; older samples derive
+    real lengths from the indexed ``attention_mask`` (values 1, 2, ... per
+    sub-sequence, 0 = padding). The collater folds only batch-level trailing pad
+    into the last document, keeps the mRoPE ``[3, seq]`` layout as
+    ``[3, batch, seq]``, concatenates media tensors, and emits ``qkv_format='thd'``.
 
     Args:
         batch: List of packed sample dicts. Each holds ``input_ids``/``labels``/
@@ -1645,6 +1646,10 @@ def packed_sequence_thd_vlm_collater(
         x["input_ids"].shape[-1] if isinstance(x["input_ids"], torch.Tensor) else len(x["input_ids"]) for x in batch
     )
     max_len = max_length if max_length is not None else batch_max
+    if batch_max > max_len:
+        raise ValueError(
+            f"Packed VLM THD batch requires {batch_max} tokens, exceeding configured max_length={max_len}."
+        )
 
     def _pad_seq(tensor, pad_value, target_len, seq_dim=-1):
         """Pad ``tensor`` along ``seq_dim`` to ``target_len`` with ``pad_value``."""
@@ -1662,13 +1667,35 @@ def packed_sequence_thd_vlm_collater(
     seq_lens_list: list[list[int]] = []
     seq_lens_padded_list: list[list[int]] = []
     for x in batch:
-        am = torch.as_tensor(x["attention_mask"]).to(torch.long)
-        real_len = int(am.shape[0])
-        doc_lens = torch.bincount(am)[1:].tolist()
-        if not doc_lens:
-            doc_lens = [real_len]
-        padded = list(doc_lens)
-        padded[-1] += max_len - real_len
+        has_seq_lens = "seq_lens" in x
+        has_seq_lens_padded = "seq_lens_padded" in x
+        if has_seq_lens != has_seq_lens_padded:
+            raise ValueError("Packed VLM samples must provide both seq_lens and seq_lens_padded, or neither.")
+
+        item_len = int(torch.as_tensor(x["input_ids"]).shape[-1])
+        if has_seq_lens:
+            doc_lens = torch.as_tensor(x["seq_lens"], dtype=torch.long).reshape(-1).tolist()
+            padded = torch.as_tensor(x["seq_lens_padded"], dtype=torch.long).reshape(-1).tolist()
+            invalid_lengths = not padded or any(
+                real < 0 or slots < 0 or real > slots for real, slots in zip(doc_lens, padded)
+            )
+            if len(doc_lens) != len(padded) or invalid_lengths:
+                raise ValueError(
+                    f"Invalid packed VLM THD sequence metadata: seq_lens={doc_lens}, seq_lens_padded={padded}."
+                )
+            if sum(padded) != item_len:
+                raise ValueError(
+                    "Packed VLM THD seq_lens_padded must cover the materialized token stream, "
+                    f"got sum={sum(padded)} and tokens={item_len}."
+                )
+        else:
+            am = torch.as_tensor(x["attention_mask"]).to(torch.long)
+            doc_lens = torch.bincount(am)[1:].tolist()
+            if not doc_lens:
+                doc_lens = [item_len]
+            padded = list(doc_lens)
+
+        padded[-1] += max_len - item_len
         seq_lens_list.append(doc_lens)
         seq_lens_padded_list.append(padded)
 

--- a/nemo_automodel/components/datasets/vlm/loader.py
+++ b/nemo_automodel/components/datasets/vlm/loader.py
@@ -255,7 +255,8 @@ class VlmDataloaderConfig:
             packing_attn_implementation: Resolved attention backend for packed-mask construction.
             pp_n_microbatches: Optional pipeline microbatch count used to pre-chunk media tensors.
             cp_size: Runtime context-parallel world size. Neat-packed CP uses
-                compact document IDs instead of a dense quadratic attention mask.
+                compact document IDs instead of a dense quadratic attention mask;
+                THD packing also accounts for per-document CP alignment.
 
         Returns:
             Named result containing the stateful dataloader and runtime processor.
@@ -284,6 +285,7 @@ class VlmDataloaderConfig:
                 ds_raw=raw_dataset,
                 get_rope_index=get_rope_index,
                 processor=processor,
+                cp_size=cp_size,
             )
             if self.packing.packing_format == "thd":
                 logger.info("Configured VLM THD packing (Transformer Engine, qkv_format=thd)")

--- a/nemo_automodel/components/datasets/vlm/neat_packing_vlm.py
+++ b/nemo_automodel/components/datasets/vlm/neat_packing_vlm.py
@@ -358,19 +358,32 @@ def _shift_sample(sample: dict, has_mrope: bool = False) -> dict:
     return out
 
 
+def _aligned_length(length: int, alignment: int) -> int:
+    """Round ``length`` up to ``alignment`` without changing zero-length samples."""
+    if alignment < 1:
+        raise ValueError(f"sequence_alignment must be at least 1, got {alignment}.")
+    return ((length + alignment - 1) // alignment) * alignment
+
+
 def _build_packed_vlm_sample(
     samples: list[dict],
     pack_size: int,
     padding_idx: int,
     has_mrope: bool = False,
+    sequence_alignment: int = 1,
 ) -> dict:
-    """Concatenate multiple shifted VLM samples into one packed sample."""
+    """Concatenate shifted VLM samples, including per-document alignment padding."""
+    if has_mrope and sequence_alignment > 1:
+        raise NotImplementedError("Context-parallel THD packing for multi-axis mRoPE VLMs is not yet implemented.")
+
     all_input_ids: list[int] = []
     all_labels: list[int] = []
     all_attention_mask: list[int] = []
     all_mm_token_type_ids: list[int] = []
     all_position_ids_1d: list[int] = []
     mrope_position_ids_list: list[torch.Tensor] = []
+    seq_lens: list[int] = []
+    seq_lens_padded: list[int] = []
 
     pixel_values_list: list[torch.Tensor] = []
     image_grid_thw_list: list[torch.Tensor] = []
@@ -390,20 +403,25 @@ def _build_packed_vlm_sample(
             labs = labs.tolist()
 
         seq_len = len(ids)
-        all_input_ids.extend(ids)
-        all_labels.extend(labs)
-        all_attention_mask.extend([seq_idx] * seq_len)
+        padded_seq_len = _aligned_length(seq_len, sequence_alignment)
+        pad = padded_seq_len - seq_len
+        seq_lens.append(seq_len)
+        seq_lens_padded.append(padded_seq_len)
+        all_input_ids.extend(ids + [padding_idx] * pad)
+        all_labels.extend(labs + [-100] * pad)
+        all_attention_mask.extend([seq_idx] * padded_seq_len)
 
         mm_ttids = sample.get("mm_token_type_ids")
         if mm_ttids is not None:
-            all_mm_token_type_ids.extend(mm_ttids.tolist() if isinstance(mm_ttids, torch.Tensor) else mm_ttids)
+            mm_ttids = mm_ttids.tolist() if isinstance(mm_ttids, torch.Tensor) else list(mm_ttids)
+            all_mm_token_type_ids.extend(mm_ttids + [0] * pad)
         else:
-            all_mm_token_type_ids.extend([0] * seq_len)
+            all_mm_token_type_ids.extend([0] * padded_seq_len)
 
         if has_mrope and "position_ids" in sample:
             mrope_position_ids_list.append(sample["position_ids"])
         else:
-            all_position_ids_1d.extend(range(seq_len))
+            all_position_ids_1d.extend(range(padded_seq_len))
 
         if "pixel_values" in sample and sample["pixel_values"] is not None:
             pixel_values_list.append(sample["pixel_values"])
@@ -426,6 +444,8 @@ def _build_packed_vlm_sample(
         "labels": torch.tensor(all_labels, dtype=torch.long),
         "attention_mask": torch.tensor(all_attention_mask, dtype=torch.long),
         "mm_token_type_ids": torch.tensor(all_mm_token_type_ids, dtype=torch.long),
+        "seq_lens": seq_lens,
+        "seq_lens_padded": seq_lens_padded,
         "n_images": n_images,
         "n_videos": n_videos,
     }
@@ -456,6 +476,8 @@ class PackedDatasetWrapperConfig:
 
     pack_size: int = 2048
     """Target packed sequence length (after autoregressive shift)."""
+    sequence_alignment: int = 1
+    """Per-document token alignment applied during materialization."""
     max_retries: int = 10
     """Max retries when a sample fails to tokenize during materialization."""
 
@@ -473,6 +495,7 @@ class PackedDatasetWrapperConfig:
             inner_dataset: The tokenizing dataset (e.g. ``PreTokenizedDatasetWrapper``).
             bins: Bin assignments from ``greedy_knapsack`` / ``neat_pack_dataset_vlm``.
             padding_idx: Runtime tokenizer padding token ID.
+            sequence_alignment: Per-document token alignment from this config.
             get_rope_index: Optional ``model.get_rope_index`` callable for mRoPE support.
         """
         return PackedDatasetWrapper(
@@ -480,6 +503,7 @@ class PackedDatasetWrapperConfig:
             bins=bins,
             pack_size=self.pack_size,
             padding_idx=padding_idx,
+            sequence_alignment=self.sequence_alignment,
             get_rope_index=get_rope_index,
             max_retries=self.max_retries,
         )
@@ -500,6 +524,8 @@ class PackedDatasetWrapper(torch.utils.data.Dataset):
             list of sample indices into ``inner_dataset``.
         pack_size: Target packed sequence length (after shift).
         padding_idx: Token ID for padding.
+        sequence_alignment: Per-document token alignment included in capacity
+            checks and materialization.
         get_rope_index: Optional ``model.get_rope_index`` for mRoPE.
         max_retries: Max retries when a sample fails to tokenize.
     """
@@ -510,6 +536,7 @@ class PackedDatasetWrapper(torch.utils.data.Dataset):
         bins: list[list[int]],
         pack_size: int,
         padding_idx: int = 0,
+        sequence_alignment: int = 1,
         get_rope_index: Callable | None = None,
         max_retries: int = 10,
     ):
@@ -517,8 +544,13 @@ class PackedDatasetWrapper(torch.utils.data.Dataset):
         self.bins = bins
         self.pack_size = pack_size
         self.padding_idx = padding_idx
+        if sequence_alignment < 1:
+            raise ValueError(f"sequence_alignment must be at least 1, got {sequence_alignment}.")
+        self.sequence_alignment = sequence_alignment
         self.get_rope_index = get_rope_index
         self.has_mrope = get_rope_index is not None
+        if self.has_mrope and self.sequence_alignment > 1:
+            raise NotImplementedError("Context-parallel THD packing for multi-axis mRoPE VLMs is not yet implemented.")
         self.max_retries = max_retries
 
     def __len__(self):
@@ -539,13 +571,15 @@ class PackedDatasetWrapper(torch.utils.data.Dataset):
 
             shifted = _shift_sample(sample, has_mrope=self.has_mrope)
             seq_len = shifted["input_ids"].shape[0]
+            aligned_seq_len = _aligned_length(seq_len, self.sequence_alignment)
 
-            # If real length exceeds pack_size after shift, skip this sample
-            if seq_len > self.pack_size:
+            # The aligned length is the actual capacity consumed by THD CP.
+            if aligned_seq_len > self.pack_size:
                 logger.warning(
-                    "Pack %d: sample %d has %d tokens (> pack_size %d), skipping.",
+                    "Pack %d: sample %d needs %d aligned tokens (%d real, pack_size %d), skipping.",
                     pack_idx,
                     sample_idx,
+                    aligned_seq_len,
                     seq_len,
                     self.pack_size,
                 )
@@ -558,14 +592,16 @@ class PackedDatasetWrapper(torch.utils.data.Dataset):
         kept: list[dict] = []
         for s in shifted_samples:
             slen = s["input_ids"].shape[0]
-            if total + slen <= self.pack_size:
+            aligned_slen = _aligned_length(slen, self.sequence_alignment)
+            if total + aligned_slen <= self.pack_size:
                 kept.append(s)
-                total += slen
+                total += aligned_slen
             else:
                 logger.debug(
-                    "Pack %d: dropping overflow sample (%d tokens, %d/%d used).",
+                    "Pack %d: dropping overflow sample (%d real, %d aligned tokens, %d/%d used).",
                     pack_idx,
                     slen,
+                    aligned_slen,
                     total,
                     self.pack_size,
                 )
@@ -574,7 +610,13 @@ class PackedDatasetWrapper(torch.utils.data.Dataset):
             # Fallback: return a padding-only pack
             kept = [{"input_ids": torch.tensor([], dtype=torch.long), "labels": torch.tensor([], dtype=torch.long)}]
 
-        return _build_packed_vlm_sample(kept, self.pack_size, self.padding_idx, has_mrope=self.has_mrope)
+        return _build_packed_vlm_sample(
+            kept,
+            self.pack_size,
+            self.padding_idx,
+            has_mrope=self.has_mrope,
+            sequence_alignment=self.sequence_alignment,
+        )
 
     def robust_collate(self, collate_fn):
         """Wrap collate_fn with retry logic, delegating to inner dataset."""
@@ -621,6 +663,7 @@ class NeatPackConfig:
         ds_raw: torch.utils.data.Dataset | Sequence[dict[str, object]] | None = None,
         get_rope_index: Callable[..., object] | None = None,
         processor: "ProcessorMixin | None" = None,
+        cp_size: int = 1,
     ) -> "PackedDatasetWrapper":
         """Build a neat-packed VLM dataset from this config.
 
@@ -631,7 +674,22 @@ class NeatPackConfig:
                 ``len(dataset)`` when ``None``.
             get_rope_index: Optional ``model.get_rope_index`` callable for mRoPE support.
             processor: Optional HuggingFace processor for accurate media token estimation.
+            cp_size: Runtime context-parallel size. THD packing aligns every
+                document to ``2 * cp_size`` when greater than one.
         """
+        if cp_size < 1:
+            raise ValueError(f"cp_size must be at least 1, got {cp_size}.")
+        sequence_alignment = 2 * cp_size if self.packing_format == "thd" and cp_size > 1 else 1
+        if sequence_alignment > 1:
+            if get_rope_index is not None:
+                raise NotImplementedError(
+                    "Context-parallel THD packing for multi-axis mRoPE VLMs is not yet implemented."
+                )
+            if self.collate_max_length is not None and self.collate_max_length % sequence_alignment != 0:
+                raise ValueError(
+                    "VLM THD collate_max_length must be divisible by 2 * cp_size, "
+                    f"got collate_max_length={self.collate_max_length}, cp_size={cp_size}."
+                )
         return neat_pack_dataset_vlm(
             dataset=dataset,
             pack_size=self.pack_size,
@@ -643,6 +701,7 @@ class NeatPackConfig:
             packing_ratio=self.packing_ratio,
             processor=processor,
             balance_media_tokens=self.balance_media_tokens,
+            sequence_alignment=sequence_alignment,
         )
 
 
@@ -657,6 +716,7 @@ def neat_pack_dataset_vlm(
     packing_ratio: float = 1.0,
     processor=None,
     balance_media_tokens: bool = True,
+    sequence_alignment: int = 1,
 ) -> PackedDatasetWrapper:
     """Create a lazily-packed VLM dataset.
 
@@ -689,10 +749,17 @@ def neat_pack_dataset_vlm(
         balance_media_tokens: If True (default), use VT-balanced knapsack
             that distributes visual tokens evenly across packs.  Falls back
             to standard knapsack if no media tokens are detected.
+        sequence_alignment: Per-document token alignment included in both
+            knapsack capacity and lazy materialization.
 
     Returns:
         A ``PackedDatasetWrapper`` (torch Dataset).
     """
+    if sequence_alignment < 1:
+        raise ValueError(f"sequence_alignment must be at least 1, got {sequence_alignment}.")
+    if get_rope_index is not None and sequence_alignment > 1:
+        raise NotImplementedError("Context-parallel THD packing for multi-axis mRoPE VLMs is not yet implemented.")
+
     # Extract processor configs for accurate media token estimation
     image_cfg = LengthGroupedSampler._extract_image_config(processor) if processor is not None else None
     video_cfg = LengthGroupedSampler._extract_video_config(processor) if processor is not None else None
@@ -734,7 +801,7 @@ def neat_pack_dataset_vlm(
                 video_cfg=video_cfg,
                 return_media_tokens=True,
             )
-            est_len -= 1  # -1 for shift
+            est_len = _aligned_length(max(est_len - 1, 0), sequence_alignment)  # -1 for shift
             if est_len > pack_size:
                 if drop_long_samples:
                     dropped_count += 1
@@ -770,7 +837,8 @@ def neat_pack_dataset_vlm(
         # No raw dataset — use dataset length, assume uniform distribution
         N = len(dataset)
         logger.info("Neat packing VLM: no ds_raw, using uniform estimate for %d samples.", N)
-        estimated_lengths = [knapsack_capacity // 2] * N
+        uniform_estimate = _aligned_length(knapsack_capacity // 2, sequence_alignment)
+        estimated_lengths = [min(uniform_estimate, knapsack_capacity)] * N
         estimated_media_tokens = [0] * N
         valid_indices = list(range(N))
 
@@ -841,7 +909,7 @@ def neat_pack_dataset_vlm(
     )
 
     # ── Return lazy dataset ──────────────────────────────────────
-    return PackedDatasetWrapperConfig(pack_size=pack_size).build(
+    return PackedDatasetWrapperConfig(pack_size=pack_size, sequence_alignment=sequence_alignment).build(
         inner_dataset=dataset,
         bins=bins,
         padding_idx=padding_idx,

--- a/nemo_automodel/components/distributed/context_parallel/utils.py
+++ b/nemo_automodel/components/distributed/context_parallel/utils.py
@@ -554,12 +554,6 @@ def _resolve_cp_sharder(
                 seq_lens_padding_value=seq_lens_padding_value,
                 return_local_indices=True,
             )
-            if local_indices is not None:
-                # Models that splice non-text features after the framework THD
-                # partition need the exact global-token map used for Q/K/V.
-                # Keeping it in the prepared batch avoids recomputing TE's
-                # document-aware load-balanced partition in model code.
-                prepped["_thd_local_indices"] = local_indices
             layout = None
             if local_indices is not None:
                 layout = ShardLayout(

--- a/nemo_automodel/components/distributed/context_parallel/utils.py
+++ b/nemo_automodel/components/distributed/context_parallel/utils.py
@@ -554,6 +554,12 @@ def _resolve_cp_sharder(
                 seq_lens_padding_value=seq_lens_padding_value,
                 return_local_indices=True,
             )
+            if local_indices is not None:
+                # Models that splice non-text features after the framework THD
+                # partition need the exact global-token map used for Q/K/V.
+                # Keeping it in the prepared batch avoids recomputing TE's
+                # document-aware load-balanced partition in model code.
+                prepped["_thd_local_indices"] = local_indices
             layout = None
             if local_indices is not None:
                 layout = ShardLayout(
@@ -862,5 +868,25 @@ def _shard_thd_chunk_for_te(
         output_batch["padding_mask"] = thd_padding_mask_from_token_ids(
             output_batch["input_ids"], padding_token_id
         ).contiguous()
+
+    # Preserve non-token payloads needed by multimodal models. The THD core
+    # consumes the sequence metadata below; media tensors/lists and model-owned
+    # maps must survive the CP partition and remain replicated on every rank.
+    consumed = {
+        "attention_mask",
+        "cu_seqlens",
+        "cu_seqlens_padded",
+        "input_ids",
+        "labels",
+        "max_seqlen",
+        "padding_mask",
+        "position_ids",
+        "qkv_format",
+        "seq_lens",
+        "seq_lens_padded",
+    }
+    for key, value in batch.items():
+        if key not in consumed and key not in output_batch:
+            output_batch[key] = value
 
     return output_batch, local_indices

--- a/nemo_automodel/components/distributed/context_parallel/utils.py
+++ b/nemo_automodel/components/distributed/context_parallel/utils.py
@@ -847,17 +847,26 @@ def _shard_thd_chunk_for_te(
         if key in batch:
             batch[key] = batch[key].index_select(0, local_indices)
 
+    # Keep model-owned payloads (for example VLM media) by default. Only remove
+    # source metadata that is invalid after the THD CP conversion; the update
+    # below replaces every transformed field with its authoritative local value.
+    output_batch = batch.copy()
+    output_batch.pop("attention_mask", None)
+    output_batch.pop("cu_seqlens_padded", None)
+
     max_seqlen = (filtered_cu_seqlens_padded[1:] - filtered_cu_seqlens_padded[:-1]).max().item()
-    output_batch = {
-        "input_ids": batch["input_ids"].to(torch.int64).contiguous(),
-        "labels": batch["labels"].to(torch.int64).contiguous(),
-        "position_ids": batch["position_ids"].to(torch.int64).contiguous(),
-        "cu_seqlens": cu_seqlens_padded.to(torch.int32).contiguous(),
-        "max_seqlen": torch.tensor(max_seqlen).to(torch.int32).to(device=cu_seqlens_padded.device),
-        "qkv_format": qkv_format,
-        "cp_size": cp_size,
-        "cp_rank": cp_rank,
-    }
+    output_batch.update(
+        {
+            "input_ids": batch["input_ids"].to(torch.int64).contiguous(),
+            "labels": batch["labels"].to(torch.int64).contiguous(),
+            "position_ids": batch["position_ids"].to(torch.int64).contiguous(),
+            "cu_seqlens": cu_seqlens_padded.to(torch.int32).contiguous(),
+            "max_seqlen": torch.tensor(max_seqlen).to(torch.int32).to(device=cu_seqlens_padded.device),
+            "qkv_format": qkv_format,
+            "cp_size": cp_size,
+            "cp_rank": cp_rank,
+        }
+    )
 
     # Already partitioned above with the same local_indices as input_ids. Only
     # fall back to the token-value comparison when the caller supplied no mask;
@@ -868,25 +877,5 @@ def _shard_thd_chunk_for_te(
         output_batch["padding_mask"] = thd_padding_mask_from_token_ids(
             output_batch["input_ids"], padding_token_id
         ).contiguous()
-
-    # Preserve non-token payloads needed by multimodal models. The THD core
-    # consumes the sequence metadata below; media tensors/lists and model-owned
-    # maps must survive the CP partition and remain replicated on every rank.
-    consumed = {
-        "attention_mask",
-        "cu_seqlens",
-        "cu_seqlens_padded",
-        "input_ids",
-        "labels",
-        "max_seqlen",
-        "padding_mask",
-        "position_ids",
-        "qkv_format",
-        "seq_lens",
-        "seq_lens_padded",
-    }
-    for key, value in batch.items():
-        if key not in consumed and key not in output_batch:
-            output_batch[key] = value
 
     return output_batch, local_indices

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -859,13 +859,20 @@ class FinetuneRecipeForVLM(BaseRecipe):
                 if k != "input_ids":
                     batch.pop(k, None)
         # THD packed VLM inputs (qkv_format='thd' from the packing collator) use TE
-        # sequence metadata even without context parallelism (#3052); CP over THD for
-        # mRoPE VLMs is not implemented.
+        # sequence metadata even without context parallelism (#3052). Standard
+        # one-dimensional RoPE can follow the generic TE CP partition. Multi-axis
+        # mRoPE still needs axis-aware sharding before it can use this path.
         _use_te_vlm = batch.get("qkv_format", None) == "thd"
-        if _use_te_vlm and self.mesh_context.cp_size > 1:
+        position_ids = batch.get("position_ids")
+        if (
+            _use_te_vlm
+            and self.mesh_context.cp_size > 1
+            and isinstance(position_ids, torch.Tensor)
+            and position_ids.ndim == 3
+        ):
             raise NotImplementedError(
-                "THD packing (packing_format='thd') for VLM currently supports cp_size=1 only; "
-                "context-parallel THD for mRoPE VLMs is not yet implemented."
+                "Context-parallel THD packing for multi-axis mRoPE VLMs is not yet implemented; "
+                "use one-dimensional position_ids or cp_size=1."
             )
         _padding_id = getattr(getattr(getattr(self, "processor", None), "tokenizer", None), "pad_token_id", 0) or 0
         cp_sharder = ContextParallelSharder(

--- a/tests/unit_tests/datasets/vlm/test_collate_fns.py
+++ b/tests/unit_tests/datasets/vlm/test_collate_fns.py
@@ -3276,6 +3276,30 @@ def test_thd_vlm_collater_fixed_max_length_pads():
     assert out["seq_lens_padded"].tolist() == [[8]]
 
 
+def test_thd_vlm_collater_preserves_materialized_cp_document_padding():
+    from nemo_automodel.components.datasets.vlm.collate_fns import packed_sequence_thd_vlm_collater
+    from nemo_automodel.components.distributed.thd_utils import process_input_for_thd
+
+    first = _thd_vlm_make_sample([8])
+    first["seq_lens"] = [3, 2]
+    first["seq_lens_padded"] = [4, 4]
+    first["position_ids"] = torch.arange(8)
+    second = _thd_vlm_make_sample([4])
+    second["seq_lens"] = [4]
+    second["seq_lens_padded"] = [4]
+    second["position_ids"] = torch.arange(4)
+
+    out = packed_sequence_thd_vlm_collater([first, second], padding_idx=0)
+
+    assert out["seq_lens"].tolist() == [[3, 2], [4, -1000]]
+    assert out["seq_lens_padded"].tolist() == [[4, 4], [8, -1000]]
+    thd = process_input_for_thd(
+        {key: out[key] for key in ("input_ids", "labels", "position_ids", "seq_lens", "seq_lens_padded")}
+    )
+    assert thd["cu_seqlens"].tolist() == [0, 3, 5, 9]
+    assert thd["cu_seqlens_padded"].tolist() == [0, 4, 8, 16]
+
+
 def test_thd_vlm_collater_empty_batch():
     from nemo_automodel.components.datasets.vlm.collate_fns import packed_sequence_thd_vlm_collater
 

--- a/tests/unit_tests/datasets/vlm/test_neat_packing_vlm.py
+++ b/tests/unit_tests/datasets/vlm/test_neat_packing_vlm.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import torch
 
 from nemo_automodel.components.datasets.vlm.collate_fns import neat_packed_vlm_collater
 from nemo_automodel.components.datasets.vlm.neat_packing_vlm import (
+    NeatPackConfig,
     _build_packed_vlm_sample,
     _compute_mrope_position_ids,
     _shift_sample,
@@ -149,6 +151,25 @@ class TestBuildPackedVlmSample:
         result = _build_packed_vlm_sample(samples, pack_size=8, padding_idx=0)
         assert result["mm_token_type_ids"].tolist() == [0, 1, 0, 1, 1]
 
+    def test_sequence_alignment_pads_each_document_and_preserves_real_lengths(self):
+        samples = [
+            {"input_ids": torch.tensor([1, 2, 3]), "labels": torch.tensor([11, 12, 13])},
+            {"input_ids": torch.tensor([4, 5]), "labels": torch.tensor([14, 15])},
+        ]
+
+        result = _build_packed_vlm_sample(
+            samples,
+            pack_size=8,
+            padding_idx=0,
+            sequence_alignment=4,
+        )
+
+        assert result["input_ids"].tolist() == [1, 2, 3, 0, 4, 5, 0, 0]
+        assert result["labels"].tolist() == [11, 12, 13, -100, 14, 15, -100, -100]
+        assert result["seq_lens"] == [3, 2]
+        assert result["seq_lens_padded"] == [4, 4]
+        assert result["position_ids"].tolist() == [0, 1, 2, 3, 0, 1, 2, 3]
+
 
 class TestNeatPackDatasetVlm:
     def test_end_to_end(self):
@@ -233,6 +254,60 @@ class TestNeatPackDatasetVlm:
             drop_long_samples=True,
         )
         assert len(packed) == 1
+
+    def test_alignment_is_included_in_knapsack_capacity_and_materialization(self):
+        samples = [_make_vlm_sample(4) for _ in range(3)]  # shifted real length 3 each
+        raw = [{"_text_tokens": 4, "conversation": []} for _ in samples]
+
+        packed = neat_pack_dataset_vlm(
+            _FakeDataset(samples),
+            ds_raw=raw,
+            pack_size=16,
+            padding_idx=0,
+            sequence_alignment=8,
+            balance_media_tokens=False,
+        )
+
+        # Raw lengths total 9 and would fit one pack. CP-aligned lengths total
+        # 24, so the planner must produce two packs instead of overflowing later.
+        assert len(packed) == 2
+        materialized_lengths = sorted(len(packed[i]["input_ids"]) for i in range(len(packed)))
+        assert materialized_lengths == [8, 16]
+        for i in range(len(packed)):
+            item = packed[i]
+            assert sum(item["seq_lens_padded"]) == len(item["input_ids"])
+            assert all(length % 8 == 0 for length in item["seq_lens_padded"])
+
+    def test_thd_config_derives_alignment_from_cp_size(self):
+        samples = [_make_vlm_sample(4)]
+        config = NeatPackConfig(pack_size=16, collate_max_length=16, packing_format="thd")
+
+        packed = config.build(
+            dataset=_FakeDataset(samples),
+            padding_idx=0,
+            ds_raw=[{"_text_tokens": 4, "conversation": []}],
+            cp_size=4,
+        )
+
+        assert packed.sequence_alignment == 8
+        assert packed[0]["seq_lens"] == [3]
+        assert packed[0]["seq_lens_padded"] == [8]
+
+    def test_thd_config_rejects_mrope_cp_and_unaligned_collate_length(self):
+        with pytest.raises(NotImplementedError, match="multi-axis mRoPE"):
+            NeatPackConfig(pack_size=16, packing_format="thd").build(
+                dataset=_FakeDataset([]),
+                padding_idx=0,
+                get_rope_index=lambda: None,
+                cp_size=2,
+            )
+
+        with pytest.raises(ValueError, match=r"collate_max_length must be divisible by 2 \* cp_size"):
+            NeatPackConfig(pack_size=10, collate_max_length=10, packing_format="thd").build(
+                dataset=_FakeDataset([]),
+                padding_idx=0,
+                cp_size=2,
+            )
 
 
 class TestNeatPackedVlmCollater:

--- a/tests/unit_tests/datasets/vlm/test_vlm_loader.py
+++ b/tests/unit_tests/datasets/vlm/test_vlm_loader.py
@@ -243,8 +243,14 @@ def test_recipe_config_resolves_nested_vlm_video_processor():
 
 def test_vlm_dataloader_selects_thd_collater(monkeypatch):
     processor = DummyProcessor()
+    packing_kwargs = {}
+
+    def _build_packing(self, dataset, **kwargs):
+        packing_kwargs.update(kwargs)
+        return dataset
+
     monkeypatch.setattr(PreTokenizedDatasetWrapperConfig, "build", lambda self, dataset, processor: dataset)
-    monkeypatch.setattr(NeatPackConfig, "build", lambda self, dataset, **kwargs: dataset)
+    monkeypatch.setattr(NeatPackConfig, "build", _build_packing)
     config = VlmDataloaderConfig(
         dataset_config=StaticDatasetConfig([]),
         processor_config=VlmProcessorConfig(factory=lambda: processor),
@@ -258,10 +264,12 @@ def test_vlm_dataloader_selects_thd_collater(monkeypatch):
         dp_rank=0,
         dp_world_size=1,
         batch_size=2,
+        cp_size=4,
     )
 
     assert result.dataloader.collate_fn.func is packed_sequence_thd_vlm_collater
     assert result.dataloader.collate_fn.keywords == {"padding_idx": 0, "max_length": None}
+    assert packing_kwargs["cp_size"] == 4
 
 
 def test_vlm_dataloader_skips_dense_neat_packing_mask_under_cp(monkeypatch):

--- a/tests/unit_tests/distributed/test_cp_utils.py
+++ b/tests/unit_tests/distributed/test_cp_utils.py
@@ -648,6 +648,7 @@ def test_shard_thd_chunk_skips_missing_padding_mask(monkeypatch):
 
     assert "input_ids" in result
     assert "attention_mask" not in result
+    assert "cu_seqlens_padded" not in result
     # the partition IS the local-token global index map (mock returns arange)
     assert torch.equal(local_indices, torch.arange(4))
 

--- a/tests/unit_tests/distributed/test_cp_utils.py
+++ b/tests/unit_tests/distributed/test_cp_utils.py
@@ -514,7 +514,6 @@ def test_attach_te_context_parallel_configures_full_and_sliding_attention(monkey
     assert tp_only_model[0].self_attn.attn_module.tp_size == 2
     assert tp_only_model[0].self_attn.attn_module.num_gqa_groups_per_partition == 2
 
-
 # ============================================================================
 # Tests for make_cp_batch_for_te
 # ============================================================================
@@ -538,6 +537,8 @@ def test_make_cp_batch_for_te_basic(monkeypatch):
         "position_ids": position_ids,
         "seq_lens": seq_lens,
         "seq_lens_padded": seq_lens_padded,
+        "pixel_values": torch.randn(1, 3, 8, 12),
+        "_global_vision_mask": input_ids == 7,
     }
 
     def mock_get_rank(group=None):
@@ -580,6 +581,8 @@ def test_make_cp_batch_for_te_basic(monkeypatch):
 
     # Verify cu_seqlens are properly formatted
     assert result["cu_seqlens"].dtype == torch.int32
+    assert result["pixel_values"] is batch["pixel_values"]
+    assert result["_global_vision_mask"] is batch["_global_vision_mask"]
 
 
 def test_make_cp_batch_for_te_multi_chunk(monkeypatch):
@@ -778,6 +781,7 @@ def test_magi_state_is_derived_from_live_model():
 def test_sharder_constructor_derives_te_from_model_and_thd_from_batch(monkeypatch):
     """A TE model and THD batch resolve a sharder without recipe-owned flags."""
     seen = {}
+    local_indices = torch.tensor([1, 0])
 
     def fake_make_cp_batch_for_te(
         cp_mesh, batch, *, padding_token_id, qkv_format, num_chunks, seq_lens_padding_value, return_local_indices=False
@@ -785,7 +789,7 @@ def test_sharder_constructor_derives_te_from_model_and_thd_from_batch(monkeypatc
         seen.update(
             cp_mesh=cp_mesh, pad=padding_token_id, fmt=qkv_format, chunks=num_chunks, sent=seq_lens_padding_value
         )
-        return ({"thd": True}, None) if return_local_indices else {"thd": True}
+        return ({"thd": True}, local_indices) if return_local_indices else {"thd": True}
 
     monkeypatch.setattr(_cu, "make_cp_batch_for_te", fake_make_cp_batch_for_te)
 
@@ -802,7 +806,8 @@ def test_sharder_constructor_derives_te_from_model_and_thd_from_batch(monkeypatc
     assert not seen
     ctx, batch = sharder.shard(batch)
     assert ctx is contextlib.nullcontext
-    assert batch == {"thd": True}
+    assert batch["thd"] is True
+    assert batch["_thd_local_indices"] is local_indices
     assert seen["cp_mesh"] is device_mesh["cp"]
     assert (seen["pad"], seen["fmt"], seen["chunks"], seen["sent"]) == (7, "thd", 3, -1000)
 

--- a/tests/unit_tests/distributed/test_cp_utils.py
+++ b/tests/unit_tests/distributed/test_cp_utils.py
@@ -514,6 +514,7 @@ def test_attach_te_context_parallel_configures_full_and_sliding_attention(monkey
     assert tp_only_model[0].self_attn.attn_module.tp_size == 2
     assert tp_only_model[0].self_attn.attn_module.num_gqa_groups_per_partition == 2
 
+
 # ============================================================================
 # Tests for make_cp_batch_for_te
 # ============================================================================
@@ -807,8 +808,7 @@ def test_sharder_constructor_derives_te_from_model_and_thd_from_batch(monkeypatc
     assert not seen
     ctx, batch = sharder.shard(batch)
     assert ctx is contextlib.nullcontext
-    assert batch["thd"] is True
-    assert batch["_thd_local_indices"] is local_indices
+    assert batch == {"thd": True}
     assert seen["cp_mesh"] is device_mesh["cp"]
     assert (seen["pad"], seen["fmt"], seen["chunks"], seen["sent"]) == (7, "thd", 3, -1000)
 

--- a/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
+++ b/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
@@ -466,7 +466,7 @@ def test_forward_backward_step_routes_thd_batch_through_te(monkeypatch):
     recipe = FinetuneRecipeForVLM.__new__(FinetuneRecipeForVLM)
     recipe.dist_env = SimpleNamespace(device="cpu")
     recipe.device_mesh = None
-    recipe.mesh_context = SimpleNamespace(cp_size=1)
+    recipe.mesh_context = SimpleNamespace(cp_size=2)
     recipe.processor = SimpleNamespace(tokenizer=SimpleNamespace(pad_token_id=7))
     recipe.model_parts = [_TensorModel()]
     recipe.pp_enabled = False
@@ -508,7 +508,7 @@ def test_forward_backward_step_routes_thd_batch_through_te(monkeypatch):
 
 
 @pytest.mark.cuda(False)
-def test_forward_backward_step_rejects_thd_with_context_parallelism():
+def test_forward_backward_step_rejects_mrope_thd_with_context_parallelism():
     recipe = FinetuneRecipeForVLM.__new__(FinetuneRecipeForVLM)
     recipe.dist_env = SimpleNamespace(device="cpu")
     recipe.device_mesh = None
@@ -517,12 +517,13 @@ def test_forward_backward_step_rejects_thd_with_context_parallelism():
     recipe.pp_enabled = False
     recipe.magi = SimpleNamespace(enabled=False)
 
-    with pytest.raises(NotImplementedError, match="currently supports cp_size=1 only"):
+    with pytest.raises(NotImplementedError, match="multi-axis mRoPE"):
         recipe._forward_backward_step(
             idx=0,
             batch={
                 "input_ids": torch.tensor([[1, 2]]),
                 "labels": torch.tensor([[2, -100]]),
+                "position_ids": torch.zeros((3, 1, 2), dtype=torch.long),
                 "qkv_format": "thd",
             },
             loss_buffer=[],


### PR DESCRIPTION
## Summary

- account for Transformer Engine THD's per-document `2 * cp_size` alignment in both VLM knapsack planning and lazy materialization
- emit explicit real and padded document lengths while keeping the VLM collater independent of distributed topology
- retain non-token multimodal payloads during THD context-parallel sharding and expose the exact local-to-global token index map
- allow one-dimensional-position VLM batches to use THD context parallelism while keeping multi-axis mRoPE explicitly unsupported

## Why

Transformer Engine partitions every THD document into `2 * cp_size` chunks. Adding that padding only in the collater makes the planner underestimate each pack and can make a materialized batch exceed its configured hard length. Applying the same alignment during planning and lazy materialization keeps packing capacity accurate and matches the established text-only THD path.

During context-parallel preparation, multimodal payloads and model-owned metadata remain replicated. Models that splice non-text features after partitioning also receive the exact token mapping selected by the document-aware THD sharder.

## Validation

- `python -m pytest -q tests/unit_tests/datasets/vlm/test_neat_packing_vlm.py tests/unit_tests/datasets/vlm/test_collate_fns.py tests/unit_tests/datasets/vlm/test_vlm_loader.py tests/unit_tests/distributed/test_cp_utils.py tests/unit_tests/recipes/test_finetune_vlm_helpers.py` — 308 passed with CUDA visible; fused linear CE tests executed with `cut-cross-entropy 25.1.1`
- `python -m ruff check` on all changed Python files
- `python -m ruff format --check` on all changed Python files
- `git diff --check`
