### PR TITLE
fix(kd): preserve tensor-valued hidden states

### DIFF
--- a/nemo_automodel/recipes/llm/kd.py
+++ b/nemo_automodel/recipes/llm/kd.py
@@ -58,6 +58,7 @@ from nemo_automodel.components.loggers.metric_logger import MetricsSample
 from nemo_automodel.components.loss.linear_ce import FusedLinearCrossEntropy
 from nemo_automodel.components.loss.utils import calculate_loss
 from nemo_automodel.components.optim.precision_warnings import resolve_storage_dtype
+from nemo_automodel.components.training.model_output_utils import get_final_hidden_states
 from nemo_automodel.components.training.rng import ScopedRNG
 from nemo_automodel.components.training.signal_handler import DistributedSignalHandler
 from nemo_automodel.components.training.utils import (
@@ -640,11 +641,7 @@ class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNe
 
             # Student forward.
             student_batch = filter_forward_kwargs(model, batch)
-            student_keep_last = isinstance(self.loss_fn, FusedLinearCrossEntropy)
-            if student_keep_last:
-                student_out = model(logits_to_keep=1, **student_batch)
-            else:
-                student_out = model(**student_batch)
+            student_out = model(**student_batch)
 
             student_logits = getattr(student_out, "logits", student_out)  # shape (B, S, V)
             if separate_teacher_logits is not None:
@@ -659,7 +656,7 @@ class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNe
                     logits=student_logits,
                     labels=labels,
                     model=model,
-                    hidden_states=student_out.hidden_states[-1] if "hidden_states" in student_out else None,
+                    hidden_states=get_final_hidden_states(student_out),
                     num_label_tokens=num_label_tokens,
                 )
 

--- a/nemo_automodel/recipes/vlm/kd.py
+++ b/nemo_automodel/recipes/vlm/kd.py
@@ -55,9 +55,9 @@ from nemo_automodel.components.distributed.config import DistributedSetup
 from nemo_automodel.components.distributed.context_parallel import ContextParallelSharder
 from nemo_automodel.components.distributed.utils import get_sync_ctx
 from nemo_automodel.components.loggers.metric_logger import MetricsSample
-from nemo_automodel.components.loss.linear_ce import FusedLinearCrossEntropy
 from nemo_automodel.components.moe.megatron.moe_utils import MoEAuxLossAutoScaler
 from nemo_automodel.components.optim.precision_warnings import resolve_storage_dtype
+from nemo_automodel.components.training.model_output_utils import get_final_hidden_states
 from nemo_automodel.components.training.rng import ScopedRNG
 from nemo_automodel.components.training.signal_handler import DistributedSignalHandler
 from nemo_automodel.components.training.utils import (
@@ -375,19 +375,13 @@ class KnowledgeDistillationRecipeForVLM(FinetuneRecipeForVLM):
 
             # Student forward.
             student_batch = filter_forward_kwargs(model, batch)
-            student_keep_last = isinstance(self.loss_fn, FusedLinearCrossEntropy)
-            if student_keep_last:
-                student_out = model(logits_to_keep=1, **student_batch)
-            else:
-                student_out = model(**student_batch)
+            student_out = model(**student_batch)
             del student_batch
 
             student_logits = getattr(student_out, "logits", student_out)
             if separate_teacher_logits is not None:
                 teacher_logits = self.kd_mesh_bridge.match_student_vocab_shard(student_logits, teacher_logits)
-            hidden_states = (
-                student_out.hidden_states[-1] if getattr(student_out, "hidden_states", None) is not None else None
-            )
+            hidden_states = get_final_hidden_states(student_out)
             del student_out
 
             # CE loss (skip when kd_ratio >= 1.0).

--- a/tests/unit_tests/recipes/test_kd_separate_mesh_recipe_helpers.py
+++ b/tests/unit_tests/recipes/test_kd_separate_mesh_recipe_helpers.py
@@ -14,12 +14,16 @@
 
 from contextlib import nullcontext
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 import torch
 from torch import nn
+from transformers.modeling_outputs import CausalLMOutputWithPast
 
 from nemo_automodel.components.config.loader import ConfigNode
+from nemo_automodel.components.loss.kd_loss import KDLoss
+from nemo_automodel.components.loss.linear_ce import FusedLinearCrossEntropy
 from nemo_automodel.recipes.llm import kd as llm_kd
 from nemo_automodel.recipes.vlm import kd as vlm_kd
 
@@ -37,6 +41,31 @@ class _Teacher(nn.Module):
         return SimpleNamespace(logits=torch.nn.functional.one_hot(input_ids, num_classes=4).float())
 
 
+class _TensorHiddenStateStudent(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.scale = nn.Parameter(torch.tensor(1.0))
+        self.register_buffer("hidden_states", torch.arange(24, dtype=torch.float32).reshape(2, 3, 4))
+        self.logits_to_keep = None
+
+    def forward(self, input_ids: torch.Tensor, logits_to_keep: int | None = None) -> CausalLMOutputWithPast:
+        """Return logits and a tensor-valued final hidden state.
+
+        Args:
+            input_ids: Tensor of shape [batch, sequence].
+            logits_to_keep: Number of trailing logits requested by the fused-loss path.
+
+        Returns:
+            Model output with logits of shape [batch, sequence, vocab] and
+            tensor-valued hidden states of shape [batch, sequence, hidden].
+        """
+        self.logits_to_keep = logits_to_keep
+        logits = torch.ones(*input_ids.shape, 4, dtype=torch.float32) * self.scale
+        if logits_to_keep is not None:
+            logits = logits[:, -logits_to_keep:]
+        return CausalLMOutputWithPast(logits=logits, hidden_states=self.hidden_states)
+
+
 _RECIPE_CASES = (
     pytest.param(
         llm_kd,
@@ -51,6 +80,72 @@ _RECIPE_CASES = (
         id="vlm",
     ),
 )
+
+
+@pytest.mark.parametrize("recipe_module,recipe_cls,_", _RECIPE_CASES)
+def test_kd_fused_loss_preserves_tensor_valued_hidden_states(monkeypatch, recipe_module, recipe_cls, _):
+    def no_op_sharder(model, mesh, batch, **kwargs):
+        """Return a context-parallel sharder that preserves the input batch.
+
+        Args:
+            model: Student model under test.
+            mesh: Unused device mesh.
+            batch: Mapping containing tensors of shape [batch, sequence].
+            **kwargs: Unused context-parallel options.
+
+        Returns:
+            Object whose shard operation returns the unchanged batch.
+        """
+        del model, mesh, kwargs
+        return SimpleNamespace(shard=lambda actual_batch: (nullcontext, actual_batch))
+
+    calculate_loss = Mock(return_value=torch.tensor(2.0))
+    monkeypatch.setattr(recipe_module, "ContextParallelSharder", no_op_sharder)
+    monkeypatch.setattr(recipe_module, "calculate_loss", calculate_loss)
+
+    student = _TensorHiddenStateStudent()
+    recipe = object.__new__(recipe_cls)
+    recipe.dist_env = SimpleNamespace(device="cpu")
+    recipe.device_mesh = None
+    recipe.pp_enabled = False
+    recipe.distributed_config = SimpleNamespace(defer_fsdp_grad_sync=True)
+    recipe.model_parts = [student]
+    recipe.teacher_model = _Teacher()
+    recipe.loss_fn = FusedLinearCrossEntropy()
+    recipe.kd_loss_fn = KDLoss()
+    recipe.kd_ratio = 0.5
+    recipe._offload_teacher_model = False
+    recipe.separate_meshes = False
+    recipe._get_dp_group_size = lambda include_cp=True: 1
+
+    batch = {
+        "input_ids": torch.tensor([[0, 1, 2], [1, 2, 3]]),
+        "labels": torch.tensor([[0, 1, 2], [1, 2, -100]]),
+    }
+    if recipe_module is vlm_kd:
+        recipe._ce_loss_buffer = []
+        recipe._kd_loss_buffer = []
+        recipe._forward_backward_step(
+            0,
+            batch,
+            loss_buffer=[],
+            num_label_tokens=5,
+            num_batches=1,
+            is_train=False,
+        )
+    else:
+        recipe._forward_backward_step(
+            0,
+            batch,
+            num_label_tokens=5,
+            num_batches=1,
+            is_train=False,
+        )
+
+    received_hidden_states = calculate_loss.call_args.kwargs["hidden_states"]
+    assert student.logits_to_keep is None
+    assert received_hidden_states is student.hidden_states
+    assert received_hidden_states.shape[:-1] == batch["labels"].shape
 
 
 @pytest.mark.parametrize("recipe_module,recipe_cls,parent_cls", _RECIPE_CASES)


### PR DESCRIPTION
# What does this PR do ?

Fixes NVIDIA-NeMo/Automodel#3206 by making both LLM and VLM knowledge-distillation recipes handle tensor-valued final hidden states without dropping the batch dimension.

The VLM finetune call site was already corrected on `main` in NVIDIA-NeMo/Automodel#3211. This PR completes the two KD call sites and also preserves full student logits for the KD term: `FusedLinearCrossEntropy` consumes the final hidden states, while `KDLoss` still requires logits for every sequence position.

# Changelog

* Use `get_final_hidden_states(...)` in both LLM and VLM KD recipes.
* Stop requesting only the last student logit in KD, because the KL loss needs full `[batch, sequence, vocab]` logits.
* Add a parametrized CPU regression covering both recipes with tensor-valued hidden states and real `KDLoss` shape checks.

# Before your PR is "Ready for review"

**Pre checks**:

- [X] Read and followed the contributor guidelines.
- [X] Added focused regression coverage.
- [X] No documentation change is necessary for this internal loss-path fix.

# Validation

* `pytest -q tests/unit_tests/recipes/test_kd_separate_mesh_recipe_helpers.py tests/unit_tests/recipes/test_vlm_kd.py tests/unit_tests/recipes/test_vlm_kd_tp_cp_correctness.py` — 30 passed.
* `ruff format .` and `ruff check --fix .` — passed.
* Targeted `nemo-ci` VLM KD run on 8×H100 with Qwen3.5 4B student / 9B teacher, `FusedLinearCrossEntropy`, and the exact branch SHA: [job 380278818](<https://nv/nemoci/-/jobs/380278818>). One training step and validation completed with finite CE/KD losses; the Slurm job ended `COMPLETED`.
* `nemo-ci` parent/child/leaf pipelines: [60446280](<https://nv/nemoci/-/pipelines/60446280>) → [60446329](<https://nv/nemoci/-/pipelines/60446329>) → [60446352](<https://nv/nemoci/-/pipelines/60446352>), all successful.

# Additional Information

* Fixes NVIDIA-NeMo/Automodel#3206