### PR TITLE
refactor(docker): build torchao & FlashAttention as isolated wheel stages

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -75,13 +75,8 @@ RUN if [ "$INSTALL_TE" = "True" ]; then \
     cd ../ && rm -rf TransformerEngine; \
     fi
 
-# Install HybridEP / DeepEP. Build with apt rdma-core v60 (so build==runtime libibverbs)
-# and RDMA_CORE_HOME symlinked to the system install; create the libnvshmem_host.so->.so.3
-# symlink required for DeepEP fabric handle ops; use the nvshmem wheel 3.6.5 and pin
-# DEEPEP_COMMIT to 42144303 (== 17cfb817 + DeepEP #638), which pads the HybridEP
-# max_num_of_tokens_per_rank up to the combine-kernel chunk size so a per-rank token
-# count that is not a multiple of 64 (e.g. 672) no longer fails the combine-kernel
-# static_assert (MAX_NUM_OF_TOKENS_PER_RANK % NUM_OF_TOKENS_PER_CHUNK == 0).
+# Install HybridEP / DeepEP: apt rdma-core v60 (build==runtime libibverbs), nvshmem wheel 3.6.5.
+# DEEPEP_COMMIT = 17cfb817 + DeepEP #638, padding max_num_of_tokens_per_rank to the combine-kernel chunk size.
 COPY docker/common/deepep.patch /opt/deepep.patch
 ARG DEEPEP_COMMIT=42144303752422ade37f24bca9e2dde12df70e09
 ENV HYBRID_EP_MULTINODE=1
@@ -180,29 +175,8 @@ RUN --mount=type=cache,target=/opt/uv_cache,sharing=locked \
         uv sync --extra $AUTOMODEL_INSTALL --all-groups $UV_SYNC_ARGS && \
     python -c "import importlib.metadata as m; import magi_attention; print('magi-attention', m.version('magi-attention'))"
 
-# MXFP8 MoE training (experts="torch_mm_mxfp8"): the NGC PyTorch base does not bundle
-# torchao and uv-pytorch.toml gates it off (sys_platform=='never'), so `uv sync` skips
-# it. Install explicitly AFTER the sync so it is not pruned.
-#
-# Build FROM SOURCE (not `pip install torchao==0.14.0`): the MXFP8 grouped-GEMM path
-# needs the compiled mxfp8 CUDA kernels (torchao/csrc/cuda/mx_kernels), but PyPI ships
-# only a kernel-less `py3-none-any` wheel and an x86_64-only compiled wheel — no
-# aarch64 wheel and no sdist. On the sbsa/aarch64 build the pip wheel would silently
-# omit the kernels and MXFP8 would fall back to bf16 at runtime. setup.py has no
-# x86-only gate and cross-compiles the sm_100a kernels from the CUDA toolkit version
-# (build_for_sm100a = CUDA>=12.8; base is CUDA 13.x), so source builds on both arches.
-# --no-build-isolation reuses the container's torch ABI.
-# Pin v0.17.0 (NOT v0.14.1): v0.14.1's forward quantizes via EAGER unfused to_mx (no CUDA
-# kernel, ~49ms/iter) — a ~2.5x regression vs bf16. v0.17.0's forward is fully kernelized
-# (triton_to_mxfp8_dim0 for both activation and weight + device-side scale swizzle); it is
-# the torchao blog version (~1.43x MoE-layer speedup). NOT main: main's forward additionally
-# needs the nvidia-cutlass-dsl runtime for its CuTeDSL activation kernel, which this image
-# does not install (and _SM100_KERNELS_AVAILABLE doesn't gate it -> runtime crash); v0.17.0
-# is triton-only with no extra dep. CUTLASS is a git submodule the mxfp8 kernels need, so
-# clone with --recurse-submodules (pip's git+ submodule handling is unreliable). setup.py
-# self-gates the mxfp8/cutlass sm_100a kernels on CUDA>=12.8 and hardcodes their gencode
-# flags; TORCH_CUDA_ARCH_LIST + MAX_JOBS mirror the in-image DeepEP source build (above) to
-# cover torchao's other CUDAExtensions and bound the heavy CUTLASS sm_100 compile.
+# torchao MXFP8 MoE (experts="torch_mm_mxfp8"): not in the NGC base, gated off in uv-pytorch.toml, so install after uv sync.
+# Build from source w/ submodules (PyPI wheels omit mxfp8 CUDA kernels on aarch64); pin v0.17.0 (v0.14.1 ~2.5x slower; main needs nvidia-cutlass-dsl).
 RUN git clone --depth 1 --branch v0.17.0 --recurse-submodules --shallow-submodules \
         https://github.com/pytorch/ao.git /tmp/torchao && \
     TORCH_CUDA_ARCH_LIST="9.0 10.0 12.0" MAX_JOBS=8 \
@@ -210,31 +184,12 @@ RUN git clone --depth 1 --branch v0.17.0 --recurse-submodules --shallow-submodul
     rm -rf /tmp/torchao
 
 # ---- FlashAttention-3 (Hopper-only) + FlashAttention-4 (Hopper + Blackwell) ----
-# Installed AFTER uv sync (same reason as torchao: not resolvable by uv), and
-# with `pip` -- NOT `uv pip` -- like the torchao stage above: uv resolves against
-# the venv only and would reinstall torch from PyPI over the base image's torch
-# (FA3's sdist declares a torch dependency; pip sees the system-site torch and
-# leaves it alone; --no-deps additionally guards FA3). Verification uses dist
-# metadata because transformers' is_flash_attn_*_available() requires a visible
-# GPU, which docker builds do not have.
-# FA3 kernels are SM90a-locked (Hopper ISA; they do NOT run on SM100) -- Blackwell
-# is served by FA4, whose CuTe-DSL kernels JIT-compile per-arch at runtime
-# (Sm90 and Sm100 kernel classes ship in the package; no build-time arch work).
-# FA4 must be co-located with flash-attn's `flash_attn` package: it installs the
-# `flash_attn.cute` subpackage, which FA2's __init__.py shadows if the two live in
-# different site-packages prefixes (the PYTORCH_IMAGE base puts flash-attn in
-# /usr/local dist-packages while uv installs to /opt/venv).
-# INSTALL_FA4 defaults to false: flash-attn-4 requires apache-tvm-ffi>=0.1.12,
-# which conflicts with the tilelang-pinned apache-tvm-ffi<=0.1.11 (pyproject cuda
-# extra) -- enabling FA4 disables backend.attn="tilelang" until tilelang ships a
-# release built against ffi 0.1.12.
+# Installed after uv sync via pip --no-deps (uv would clobber base torch); FA4 off by default (apache-tvm-ffi>=0.1.12 conflicts with tilelang pin <=0.1.11).
 ARG FLASH_ATTN_REF=002cce0a1
 ARG INSTALL_FA3=true
 ARG INSTALL_FA4=false
-# TARGETARCH is provided by buildx. FA3 is skipped on arm64 automatically: the
-# arm64 image targets GB200 (Blackwell), where the SM90a-only FA3 kernels are
-# dead weight, and CI cross-builds arm64 under QEMU where the ~25 min nvcc
-# compile is impractical.
+# TARGETARCH (from buildx): FA3 auto-skipped on arm64 — arm64 targets GB200 (Blackwell) where
+# SM90a-only FA3 is dead weight, and QEMU cross-builds make the ~25 min nvcc compile impractical.
 ARG TARGETARCH
 RUN if [ "$TARGETARCH" = "arm64" ]; then INSTALL_FA3=false; fi && \
     if [ "$INSTALL_FA3" = "true" ] || [ "$INSTALL_FA4" = "true" ]; then \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -130,25 +130,6 @@ RUN if [ "$INSTALL_UCCL_EP" = "True" ]; then \
     rm -f /opt/setup_uccl_ep.sh; \
     fi
 
-# Address base image CVE
-RUN pip install "aiohttp>=3.13.3" \
-        "black>=26.3.1" \
-        "GitPython>=3.1.50" \
-        "jaraco-context>=6.1.0" \
-        "jupyter-server>=2.18.0" \
-        "jupyterlab>=4.5.7" \
-        "mistune>=3.2.1" \
-        "nbconvert>=7.17.0" \
-        "notebook>=7.5.6" \
-        "onnx>=1.21.0" \
-        "pillow>=12.2.0" \
-        "protobuf>=6.33.5" \
-        "setuptools>=80.10.2" \
-        "tornado>=6.5.5" \
-        "urllib3>=2.7.0" && \
-    pip uninstall -y nvidia-dali-cuda130 wandb && \
-    rm -rf /opt/pytorch/pytorch/third_party/onnx
-
 # ---- Wheel builders: compile the heavy AOT source packages off the uv-sync path so they
 # build in parallel with uv sync and don't recompile on every uv.lock bump. FROM pytorch = base torch ABI.
 FROM pytorch AS torchao_builder
@@ -201,6 +182,25 @@ RUN pip install --no-cache-dir --no-deps /tmp/wheels/*.whl && \
         { [ -e "$FA2_DIR/cute" ] || ln -s "$VENV_CUTE" "$FA2_DIR/cute"; }; \
     fi && \
     rm -rf /tmp/wheels
+
+# Address base image CVE
+RUN pip install "aiohttp>=3.13.3" \
+        "black>=26.3.1" \
+        "GitPython>=3.1.50" \
+        "jaraco-context>=6.1.0" \
+        "jupyter-server>=2.18.0" \
+        "jupyterlab>=4.5.7" \
+        "mistune>=3.2.1" \
+        "nbconvert>=7.17.0" \
+        "notebook>=7.5.6" \
+        "onnx>=1.21.0" \
+        "pillow>=12.2.0" \
+        "protobuf>=6.33.5" \
+        "setuptools>=80.10.2" \
+        "tornado>=6.5.5" \
+        "urllib3>=2.7.0" && \
+    pip uninstall -y nvidia-dali-cuda130 wandb && \
+    rm -rf /opt/pytorch/pytorch/third_party/onnx
 
 COPY pyproject.toml uv.lock /opt/Automodel/
 COPY nemo_automodel/__init__.py nemo_automodel/package_info.py /opt/Automodel/nemo_automodel/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -149,9 +149,58 @@ RUN pip install "aiohttp>=3.13.3" \
     pip uninstall -y nvidia-dali-cuda130 wandb && \
     rm -rf /opt/pytorch/pytorch/third_party/onnx
 
+# ---- Wheel builders: compile the heavy AOT source packages off the uv-sync path so they
+# build in parallel with uv sync and don't recompile on every uv.lock bump. FROM pytorch = base torch ABI.
+FROM pytorch AS torchao_builder
+# torchao MXFP8: build w/ submodules (PyPI wheels omit mxfp8 CUDA kernels on aarch64); pin v0.17.0 (v0.14.1 ~2.5x slower; main needs nvidia-cutlass-dsl).
+ARG TORCHAO_REF=v0.17.0
+RUN mkdir -p /wheels && \
+    git clone --depth 1 --branch ${TORCHAO_REF} --recurse-submodules --shallow-submodules \
+        https://github.com/pytorch/ao.git /tmp/torchao && \
+    TORCH_CUDA_ARCH_LIST="9.0 10.0 12.0" MAX_JOBS=8 \
+        pip wheel --no-cache-dir --no-build-isolation --no-deps -w /wheels /tmp/torchao && \
+    rm -rf /tmp/torchao
+
+# FA3 (Hopper-only, SM90a-locked, ~25 min nvcc) + FA4 cute (Blackwell, lightweight). arm64 -> skip FA3: GB200 target, QEMU cross-build impractical.
+FROM pytorch AS fa_builder
+ARG FLASH_ATTN_REF=002cce0a1
+ARG INSTALL_FA3=true
+ARG INSTALL_FA4=false
+ARG TARGETARCH
+RUN mkdir -p /wheels && \
+    if [ "$TARGETARCH" = "arm64" ]; then INSTALL_FA3=false; fi && \
+    if [ "$INSTALL_FA3" = "true" ] || [ "$INSTALL_FA4" = "true" ]; then \
+        git clone --filter=blob:none https://github.com/Dao-AILab/flash-attention.git /tmp/fa && \
+        cd /tmp/fa && git checkout ${FLASH_ATTN_REF} && \
+        git submodule update --init csrc/cutlass; \
+    fi && \
+    if [ "$INSTALL_FA3" = "true" ]; then \
+        cd /tmp/fa/hopper && \
+        FLASH_ATTENTION_DISABLE_SM80=TRUE MAX_JOBS=$(nproc) NVCC_THREADS=2 \
+        pip wheel --no-cache-dir --no-build-isolation --no-deps -w /wheels . ; \
+    fi && \
+    if [ "$INSTALL_FA4" = "true" ]; then \
+        pip wheel --no-cache-dir --no-deps -w /wheels /tmp/fa/flash_attn/cute ; \
+    fi && \
+    rm -rf /tmp/fa
+
 FROM automodel_dep as automodel_final
 
 WORKDIR /opt/Automodel
+
+# torchao MXFP8 + FA3/FA4: prebuilt wheels from the *_builder stages, installed into system site-packages
+# before uv sync — pip targets system deps, uv the venv (torchao/FA gated `never`), so uv sync won't prune or shadow them.
+COPY --from=torchao_builder /wheels /tmp/wheels/
+COPY --from=fa_builder /wheels /tmp/wheels/
+ARG INSTALL_FA4=false
+RUN pip install --no-cache-dir --no-deps /tmp/wheels/*.whl && \
+    if [ "$INSTALL_FA4" = "true" ]; then \
+        pip install --no-cache-dir "nvidia-cutlass-dsl[cu13]==4.6.0.dev0" && \
+        FA2_DIR=$(python -c "import flash_attn, os; print(os.path.dirname(flash_attn.__file__))") && \
+        VENV_CUTE=/opt/venv/lib/python3.12/site-packages/flash_attn/cute && \
+        { [ -e "$FA2_DIR/cute" ] || ln -s "$VENV_CUTE" "$FA2_DIR/cute"; }; \
+    fi && \
+    rm -rf /tmp/wheels
 
 COPY pyproject.toml uv.lock /opt/Automodel/
 COPY nemo_automodel/__init__.py nemo_automodel/package_info.py /opt/Automodel/nemo_automodel/
@@ -174,43 +223,6 @@ RUN --mount=type=cache,target=/opt/uv_cache,sharing=locked \
         UV_CONCURRENT_INSTALLS=8 \
         uv sync --extra $AUTOMODEL_INSTALL --all-groups $UV_SYNC_ARGS && \
     python -c "import importlib.metadata as m; import magi_attention; print('magi-attention', m.version('magi-attention'))"
-
-# torchao MXFP8 MoE (experts="torch_mm_mxfp8"): not in the NGC base, gated off in uv-pytorch.toml, so install after uv sync.
-# Build from source w/ submodules (PyPI wheels omit mxfp8 CUDA kernels on aarch64); pin v0.17.0 (v0.14.1 ~2.5x slower; main needs nvidia-cutlass-dsl).
-RUN git clone --depth 1 --branch v0.17.0 --recurse-submodules --shallow-submodules \
-        https://github.com/pytorch/ao.git /tmp/torchao && \
-    TORCH_CUDA_ARCH_LIST="9.0 10.0 12.0" MAX_JOBS=8 \
-        pip install --no-cache-dir --no-build-isolation /tmp/torchao && \
-    rm -rf /tmp/torchao
-
-# ---- FlashAttention-3 (Hopper-only) + FlashAttention-4 (Hopper + Blackwell) ----
-# Installed after uv sync via pip --no-deps (uv would clobber base torch); FA4 off by default (apache-tvm-ffi>=0.1.12 conflicts with tilelang pin <=0.1.11).
-ARG FLASH_ATTN_REF=002cce0a1
-ARG INSTALL_FA3=true
-ARG INSTALL_FA4=false
-# TARGETARCH (from buildx): FA3 auto-skipped on arm64 — arm64 targets GB200 (Blackwell) where
-# SM90a-only FA3 is dead weight, and QEMU cross-builds make the ~25 min nvcc compile impractical.
-ARG TARGETARCH
-RUN if [ "$TARGETARCH" = "arm64" ]; then INSTALL_FA3=false; fi && \
-    if [ "$INSTALL_FA3" = "true" ] || [ "$INSTALL_FA4" = "true" ]; then \
-        git clone --filter=blob:none https://github.com/Dao-AILab/flash-attention.git /tmp/fa && \
-        cd /tmp/fa && git checkout ${FLASH_ATTN_REF} && \
-        git submodule update --init csrc/cutlass; \
-    fi && \
-    if [ "$INSTALL_FA3" = "true" ]; then \
-        cd /tmp/fa/hopper && \
-        FLASH_ATTENTION_DISABLE_SM80=TRUE MAX_JOBS=$(nproc) NVCC_THREADS=2 \
-        pip install --no-cache-dir --no-build-isolation --no-deps . && \
-        python -c "import importlib.metadata as m; print('flash-attn-3', m.version('flash-attn-3'))"; \
-    fi && \
-    if [ "$INSTALL_FA4" = "true" ]; then \
-        pip install --no-cache-dir /tmp/fa/flash_attn/cute "nvidia-cutlass-dsl[cu13]==4.6.0.dev0" && \
-        FA2_DIR=$(python -c "import flash_attn, os; print(os.path.dirname(flash_attn.__file__))") && \
-        VENV_CUTE=/opt/venv/lib/python3.12/site-packages/flash_attn/cute && \
-        { [ -e "$FA2_DIR/cute" ] || ln -s "$VENV_CUTE" "$FA2_DIR/cute"; } && \
-        python -c "import importlib.metadata as m; print('flash-attn-4', m.version('flash-attn-4'))"; \
-    fi && \
-    rm -rf /tmp/fa
 
 # Persistent disk cache for FA4's CuTe-DSL JIT (amortizes kernel compiles across restarts)
 ENV FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED=1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -130,26 +130,25 @@ RUN if [ "$INSTALL_UCCL_EP" = "True" ]; then \
     rm -f /opt/setup_uccl_ep.sh; \
     fi
 
-# ---- Wheel builders: compile the heavy AOT source packages off the uv-sync path (cached across uv.lock bumps).
-# FROM automodel_dep so they run after TE/DeepEP/bitsandbytes; MAX_JOBS capped so torchao||FA3 don't OOM the builder.
-FROM automodel_dep AS torchao_builder
+# ---- Wheel builder: compile the heavy AOT source packages off the uv-sync path (cached across uv.lock bumps).
+# torchao then FA3/FA4 as sequential steps so each compiles alone at full MAX_JOBS — no cross-compile OOM. FA3 is the long pole.
+FROM automodel_dep AS wheel_builder
+
 # torchao MXFP8: build w/ submodules (PyPI wheels omit mxfp8 CUDA kernels on aarch64); pin v0.17.0 (v0.14.1 ~2.5x slower; main needs nvidia-cutlass-dsl).
 ARG TORCHAO_REF=v0.17.0
 RUN mkdir -p /wheels && \
     git clone --depth 1 --branch ${TORCHAO_REF} --recurse-submodules --shallow-submodules \
         https://github.com/pytorch/ao.git /tmp/torchao && \
-    TORCH_CUDA_ARCH_LIST="9.0 10.0 12.0" MAX_JOBS=4 \
+    TORCH_CUDA_ARCH_LIST="9.0 10.0 12.0" MAX_JOBS=8 \
         pip wheel --no-cache-dir --no-build-isolation --no-deps -w /wheels /tmp/torchao && \
     rm -rf /tmp/torchao
 
 # FA3 (Hopper-only, SM90a-locked, ~25 min nvcc) + FA4 cute (Blackwell, lightweight). arm64 -> skip FA3: GB200 target, QEMU cross-build impractical.
-FROM automodel_dep AS fa_builder
 ARG FLASH_ATTN_REF=002cce0a1
 ARG INSTALL_FA3=true
 ARG INSTALL_FA4=false
 ARG TARGETARCH
-RUN mkdir -p /wheels && \
-    if [ "$TARGETARCH" = "arm64" ]; then INSTALL_FA3=false; fi && \
+RUN if [ "$TARGETARCH" = "arm64" ]; then INSTALL_FA3=false; fi && \
     if [ "$INSTALL_FA3" = "true" ] || [ "$INSTALL_FA4" = "true" ]; then \
         git clone --filter=blob:none https://github.com/Dao-AILab/flash-attention.git /tmp/fa && \
         cd /tmp/fa && git checkout ${FLASH_ATTN_REF} && \
@@ -157,7 +156,7 @@ RUN mkdir -p /wheels && \
     fi && \
     if [ "$INSTALL_FA3" = "true" ]; then \
         cd /tmp/fa/hopper && \
-        FLASH_ATTENTION_DISABLE_SM80=TRUE MAX_JOBS=4 NVCC_THREADS=2 \
+        FLASH_ATTENTION_DISABLE_SM80=TRUE MAX_JOBS=$(nproc) NVCC_THREADS=2 \
         pip wheel --no-cache-dir --no-build-isolation --no-deps -w /wheels . ; \
     fi && \
     if [ "$INSTALL_FA4" = "true" ]; then \
@@ -169,10 +168,9 @@ FROM automodel_dep as automodel_final
 
 WORKDIR /opt/Automodel
 
-# torchao MXFP8 + FA3/FA4: prebuilt wheels from the *_builder stages, installed into system site-packages
+# torchao MXFP8 + FA3/FA4: prebuilt wheels from the wheel_builder stage, installed into system site-packages
 # before uv sync — pip targets system deps, uv the venv (torchao/FA gated `never`), so uv sync won't prune or shadow them.
-COPY --from=torchao_builder /wheels /tmp/wheels/
-COPY --from=fa_builder /wheels /tmp/wheels/
+COPY --from=wheel_builder /wheels /tmp/wheels/
 ARG INSTALL_FA4=false
 RUN pip install --no-cache-dir --no-deps /tmp/wheels/*.whl && \
     if [ "$INSTALL_FA4" = "true" ]; then \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -130,20 +130,20 @@ RUN if [ "$INSTALL_UCCL_EP" = "True" ]; then \
     rm -f /opt/setup_uccl_ep.sh; \
     fi
 
-# ---- Wheel builders: compile the heavy AOT source packages off the uv-sync path so they
-# build in parallel with uv sync and don't recompile on every uv.lock bump. FROM pytorch = base torch ABI.
-FROM pytorch AS torchao_builder
+# ---- Wheel builders: compile the heavy AOT source packages off the uv-sync path (cached across uv.lock bumps).
+# FROM automodel_dep so they run after TE/DeepEP/bitsandbytes; MAX_JOBS capped so torchao||FA3 don't OOM the builder.
+FROM automodel_dep AS torchao_builder
 # torchao MXFP8: build w/ submodules (PyPI wheels omit mxfp8 CUDA kernels on aarch64); pin v0.17.0 (v0.14.1 ~2.5x slower; main needs nvidia-cutlass-dsl).
 ARG TORCHAO_REF=v0.17.0
 RUN mkdir -p /wheels && \
     git clone --depth 1 --branch ${TORCHAO_REF} --recurse-submodules --shallow-submodules \
         https://github.com/pytorch/ao.git /tmp/torchao && \
-    TORCH_CUDA_ARCH_LIST="9.0 10.0 12.0" MAX_JOBS=8 \
+    TORCH_CUDA_ARCH_LIST="9.0 10.0 12.0" MAX_JOBS=4 \
         pip wheel --no-cache-dir --no-build-isolation --no-deps -w /wheels /tmp/torchao && \
     rm -rf /tmp/torchao
 
 # FA3 (Hopper-only, SM90a-locked, ~25 min nvcc) + FA4 cute (Blackwell, lightweight). arm64 -> skip FA3: GB200 target, QEMU cross-build impractical.
-FROM pytorch AS fa_builder
+FROM automodel_dep AS fa_builder
 ARG FLASH_ATTN_REF=002cce0a1
 ARG INSTALL_FA3=true
 ARG INSTALL_FA4=false
@@ -157,7 +157,7 @@ RUN mkdir -p /wheels && \
     fi && \
     if [ "$INSTALL_FA3" = "true" ]; then \
         cd /tmp/fa/hopper && \
-        FLASH_ATTENTION_DISABLE_SM80=TRUE MAX_JOBS=$(nproc) NVCC_THREADS=2 \
+        FLASH_ATTENTION_DISABLE_SM80=TRUE MAX_JOBS=4 NVCC_THREADS=2 \
         pip wheel --no-cache-dir --no-build-isolation --no-deps -w /wheels . ; \
     fi && \
     if [ "$INSTALL_FA4" = "true" ]; then \


### PR DESCRIPTION
# What does this PR do ?
- Move the torchao (MXFP8) and FlashAttention (FA3/FA4) source compiles into dedicated builder stages that emit wheels, then install those wheels ahead of `uv sync`. The heavy nvcc builds now run in parallel with the other dependency builds and no longer recompile when `uv.lock` changes.
- Group the base-image CVE sweep with the wheel install (both operate on system site-packages, independent of the uv venv), and trim the Dockerfile comment blocks to ≤2 lines.

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
