### PR TITLE
fix(distributed): stabilize SAC replay with TE and FSDP

### DIFF
--- a/nemo_automodel/components/distributed/activation_checkpointing.py
+++ b/nemo_automodel/components/distributed/activation_checkpointing.py
@@ -258,6 +258,18 @@ def _maybe_trace_selective_ac_decision(func, decision, is_alternating: bool, *, 
     logger.info("[selective-ac] %s -> %s", key, verdict)
 
 
+def ignore_sac_ops(ops: list[object | None]) -> None:
+    """Add available operators to PyTorch's selective-AC ignore set.
+
+    Args:
+        ops: Operators that should execute outside SAC replay accounting.
+            Entries may be ``None`` when an optional operator is unavailable.
+    """
+    sac_ignored = getattr(torch.utils.checkpoint, "SAC_IGNORED_OPS", None)
+    if sac_ignored is not None:
+        sac_ignored.update(op for op in ops if op is not None)
+
+
 def ensure_profiler_ops_sac_ignored() -> None:
     """Keep ``torch.ops.profiler`` record-function ops out of SAC's op replay.
 
@@ -280,16 +292,17 @@ def ensure_profiler_ops_sac_ignored() -> None:
     if get_torch_version().release < _TORCH_PROFILER_SAC_IGNORE_MIN_VERSION:
         return
 
-    sac_ignored = getattr(torch.utils.checkpoint, "SAC_IGNORED_OPS", None)
     profiler_ops = getattr(torch.ops, "profiler", None)
-    if sac_ignored is None or profiler_ops is None:
+    if profiler_ops is None:
         return
+    ops_to_ignore = []
     for packet_name in ("_record_function_enter", "_record_function_enter_new", "_record_function_exit"):
         packet = getattr(profiler_ops, packet_name, None)
         if packet is None:
             continue
         for overload_name in packet.overloads():
-            sac_ignored.add(getattr(packet, overload_name))
+            ops_to_ignore.append(getattr(packet, overload_name))
+    ignore_sac_ops(ops_to_ignore)
 
 
 def ensure_fsdp_ops_sac_ignored() -> None:
@@ -302,28 +315,22 @@ def ensure_fsdp_ops_sac_ignored() -> None:
     normally when needed instead of being indexed against the forward's
     selective-AC op stream.
     """
-    sac_ignored = getattr(torch.utils.checkpoint, "SAC_IGNORED_OPS", None)
-    if sac_ignored is None:
-        return
-    for op_name in ("all_gather_copy_in", "split_with_sizes_copy", "chunk_cat", "copy_"):
-        op = _resolve_torch_op("fsdp", op_name)
-        if op is not None:
-            sac_ignored.add(op)
-    all_gather = _resolve_torch_op("c10d", "_allgather_base_")
-    if all_gather is not None:
-        sac_ignored.add(all_gather)
     # FSDP's all-gather copy-out allocates per-parameter outputs and views the
     # flat communication buffer. When forward prefetch has already unsharded
     # the parameters, these setup ops occur only during recomputation. They do
     # not produce model activations: the FSDP copy ops populate the allocations.
-    for op_name, overload_name in (
-        ("empty", "memory_format"),
-        ("empty_like", "default"),
-        ("view", "default"),
-    ):
-        op = _resolve_torch_op("aten", op_name, overload_name)
-        if op is not None:
-            sac_ignored.add(op)
+    ignore_sac_ops(
+        [
+            _resolve_torch_op("fsdp", "all_gather_copy_in"),
+            _resolve_torch_op("fsdp", "split_with_sizes_copy"),
+            _resolve_torch_op("fsdp", "chunk_cat"),
+            _resolve_torch_op("fsdp", "copy_"),
+            _resolve_torch_op("c10d", "_allgather_base_"),
+            _resolve_torch_op("aten", "empty", "memory_format"),
+            _resolve_torch_op("aten", "empty_like"),
+            _resolve_torch_op("aten", "view"),
+        ]
+    )
 
 
 def make_selective_checkpoint_context_fn():

--- a/nemo_automodel/components/distributed/activation_checkpointing.py
+++ b/nemo_automodel/components/distributed/activation_checkpointing.py
@@ -292,9 +292,28 @@ def ensure_profiler_ops_sac_ignored() -> None:
             sac_ignored.add(getattr(packet, overload_name))
 
 
+def ensure_fsdp_ops_sac_ignored() -> None:
+    """Keep FSDP2 parameter-lifecycle ops out of SAC's saved-op replay.
+
+    FSDP2 can prefetch an inner module's parameters before a checkpointed
+    forward, while backward-time recomputation must unshard them from inside
+    the checkpointed region. Its copy-in/copy-out ops are runtime parameter
+    management, not model activations, and must execute normally when needed
+    instead of being indexed against the forward's selective-AC op stream.
+    """
+    sac_ignored = getattr(torch.utils.checkpoint, "SAC_IGNORED_OPS", None)
+    if sac_ignored is None:
+        return
+    for op_name in ("all_gather_copy_in", "split_with_sizes_copy", "chunk_cat", "copy_"):
+        op = _resolve_torch_op("fsdp", op_name)
+        if op is not None:
+            sac_ignored.add(op)
+
+
 def make_selective_checkpoint_context_fn():
     """Build a TorchTitan-style selective activation checkpointing context."""
     ensure_profiler_ops_sac_ignored()
+    ensure_fsdp_ops_sac_ignored()
 
     def selective_checkpointing_context_fn():
         # Count matmuls separately for the forward and recompute passes. torch

--- a/nemo_automodel/components/distributed/activation_checkpointing.py
+++ b/nemo_automodel/components/distributed/activation_checkpointing.py
@@ -146,22 +146,29 @@ def _build_selective_ac_save_ops() -> frozenset:
 
     # Compute ops the partitioner list may not classify as compute-intensive.
     compute_ops = _existing_ops(
-        _resolve_torch_op("aten.mm"),
-        _resolve_torch_op("aten.addmm"),
-        _resolve_torch_op("aten.bmm"),
-        _resolve_torch_op("aten.linear"),
-        _resolve_torch_op("aten._scaled_mm"),
-        _resolve_torch_op("aten._scaled_dot_product_cudnn_attention"),
-        _resolve_torch_op("aten._scaled_dot_product_efficient_attention"),
-        _resolve_torch_op("aten._scaled_dot_product_flash_attention"),
-        _resolve_torch_op("aten._scaled_dot_product_flash_attention_for_cpu"),
-        _resolve_torch_op("aten._scaled_dot_product_fused_attention_overrideable"),
-        _resolve_torch_op("aten.scaled_dot_product_attention"),
-        _resolve_torch_op("aten._flex_attention"),
-        # topk is saved to keep MoE expert assignments stable across recompute;
-        # max is saved for low-precision scaling factors.
-        _resolve_torch_op("aten.topk"),
-        _resolve_torch_op("aten.max"),
+        *list(
+            map(
+                _resolve_torch_op,
+                [
+                    "aten.mm",
+                    "aten.addmm",
+                    "aten.bmm",
+                    "aten.linear",
+                    "aten._scaled_mm",
+                    "aten._scaled_dot_product_cudnn_attention",
+                    "aten._scaled_dot_product_efficient_attention",
+                    "aten._scaled_dot_product_flash_attention",
+                    "aten._scaled_dot_product_flash_attention_for_cpu",
+                    "aten._scaled_dot_product_fused_attention_overrideable",
+                    "aten.scaled_dot_product_attention",
+                    "aten._flex_attention",
+                    # topk is saved to keep MoE expert assignments stable across recompute;
+                    # max is saved for low-precision scaling factors.
+                    "aten.topk",
+                    "aten.max",
+                ],
+            )
+        ),
         # FlexAttention HOP and the inductor compiled-graph HOP (present only when
         # torch.compile is used); custom torch_attn varlen backend.
         _resolve_op_attr(torch, "_higher_order_ops.flex_attention"),
@@ -173,10 +180,17 @@ def _build_selective_ac_save_ops() -> frozenset:
 
     # Communication ops whose outputs should be saved to avoid re-communication.
     comm_ops = _existing_ops(
-        _resolve_torch_op("aten.all_to_all_single"),
-        _resolve_torch_op("aten.reduce_scatter_tensor"),
-        _resolve_torch_op("_c10d_functional.all_to_all_single"),
-        _resolve_torch_op("_c10d_functional.reduce_scatter_tensor"),
+        *list(
+            map(
+                _resolve_torch_op,
+                [
+                    "aten.all_to_all_single",
+                    "aten.reduce_scatter_tensor",
+                    "_c10d_functional.all_to_all_single",
+                    "_c10d_functional.reduce_scatter_tensor",
+                ],
+            )
+        ),
         # Optional expert-parallel comm backends.
         _resolve_op_attr(torch.ops, "deepep.dispatch.default"),
         _resolve_op_attr(torch.ops, "deepep.combine.default"),

--- a/nemo_automodel/components/distributed/activation_checkpointing.py
+++ b/nemo_automodel/components/distributed/activation_checkpointing.py
@@ -25,6 +25,7 @@ other way around -- so the dependency stays one-directional and the central
 parallelizer file stays small.
 """
 
+import functools
 import logging
 import os
 from collections.abc import Callable
@@ -703,7 +704,10 @@ def apply_selective_checkpointing_to_layers(
     # LRU cache to keep graph selection stable across pipeline microbatches.
     if enable_compile:
         _disable_dynamo_lru_cache()
-    context_fn = make_selective_checkpoint_context_fn()
+    context_fn = functools.partial(
+        transformer_engine_attention_backend_snapshot_context_fn,
+        make_selective_checkpoint_context_fn(),
+    )
     for i, layer in enumerate(layers):
         wrapped_layer = checkpoint_wrapper(
             layer,

--- a/nemo_automodel/components/distributed/activation_checkpointing.py
+++ b/nemo_automodel/components/distributed/activation_checkpointing.py
@@ -41,7 +41,7 @@ from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
 from torch.nn.attention import SDPBackend, sdpa_kernel
 from torch.utils.checkpoint import CheckpointPolicy, create_selective_checkpoint_contexts
 
-from nemo_automodel.shared.import_utils import get_torch_version
+from nemo_automodel.shared.import_utils import get_torch_version, safe_import
 
 logger = logging.getLogger(__name__)
 
@@ -397,6 +397,66 @@ def sdpa_backend_snapshot_context_fn() -> tuple[AbstractContextManager, Abstract
         if enabled
     ]
     return nullcontext(), _restore_sdpa_state(captured_sdpa, captured_backends)
+
+
+def _get_transformer_engine_attention_backend_cache() -> dict | None:
+    """Return Transformer Engine's attention-backend cache when available."""
+    available, dot_product_attention = safe_import(
+        "transformer_engine.pytorch.attention.dot_product_attention.dot_product_attention"
+    )
+    if not available:
+        return None
+    cache = getattr(dot_product_attention, "_attention_backends", None)
+    return cache if isinstance(cache, dict) else None
+
+
+@contextmanager
+def _restore_transformer_engine_attention_backend_cache(
+    cache: dict,
+    captured_cache: dict,
+    recompute_context: AbstractContextManager,
+):
+    """Restore the forward-entry TE attention cache only for recomputation."""
+    backward_cache = dict(cache)
+    cache.clear()
+    cache.update(captured_cache)
+    try:
+        with recompute_context:
+            yield
+    finally:
+        cache.clear()
+        cache.update(backward_cache)
+
+
+def transformer_engine_attention_backend_snapshot_context_fn(
+    context_fn: Callable[[], tuple[AbstractContextManager, AbstractContextManager]] | None = None,
+) -> tuple[AbstractContextManager, AbstractContextManager]:
+    """Snapshot Transformer Engine's attention-backend cache for checkpoint replay.
+
+    Transformer Engine caches the parameters and result of attention-backend
+    selection in module-global state. A checkpointed forward can populate that
+    cache, so backward-time recomputation would otherwise enter a different
+    parameter-comparison branch and dispatch a different aten op sequence. The
+    cache is restored to its forward-entry state for recomputation, then reset
+    to the state owned by the surrounding backward pass.
+
+    Args:
+        context_fn: Optional checkpoint context factory to compose inside the
+            cache restoration, such as a selective activation-checkpoint policy.
+
+    Returns:
+        ``(forward_ctx, recompute_ctx)`` with the supplied forward context and a
+        recompute context that restores the captured Transformer Engine cache.
+    """
+    forward_context, recompute_context = context_fn() if context_fn is not None else (nullcontext(), nullcontext())
+    cache = _get_transformer_engine_attention_backend_cache()
+    if cache is None:
+        return forward_context, recompute_context
+    return forward_context, _restore_transformer_engine_attention_backend_cache(
+        cache,
+        dict(cache),
+        recompute_context,
+    )
 
 
 def _registered_child_name(module: nn.Module, attr: str, child: nn.Module) -> str | None:

--- a/nemo_automodel/components/distributed/activation_checkpointing.py
+++ b/nemo_automodel/components/distributed/activation_checkpointing.py
@@ -312,12 +312,18 @@ def ensure_fsdp_ops_sac_ignored() -> None:
     all_gather = _resolve_torch_op("c10d", "_allgather_base_")
     if all_gather is not None:
         sac_ignored.add(all_gather)
-    # FSDP's all-gather copy-out views the flat communication buffer and its
-    # per-parameter outputs. When forward prefetch has already unsharded the
-    # parameters, those alias-only views occur only during recomputation.
-    view = _resolve_torch_op("aten", "view")
-    if view is not None:
-        sac_ignored.add(view)
+    # FSDP's all-gather copy-out allocates per-parameter outputs and views the
+    # flat communication buffer. When forward prefetch has already unsharded
+    # the parameters, these setup ops occur only during recomputation. They do
+    # not produce model activations: the FSDP copy ops populate the allocations.
+    for op_name, overload_name in (
+        ("empty", "memory_format"),
+        ("empty_like", "default"),
+        ("view", "default"),
+    ):
+        op = _resolve_torch_op("aten", op_name, overload_name)
+        if op is not None:
+            sac_ignored.add(op)
 
 
 def make_selective_checkpoint_context_fn():

--- a/nemo_automodel/components/distributed/activation_checkpointing.py
+++ b/nemo_automodel/components/distributed/activation_checkpointing.py
@@ -297,9 +297,10 @@ def ensure_fsdp_ops_sac_ignored() -> None:
 
     FSDP2 can prefetch an inner module's parameters before a checkpointed
     forward, while backward-time recomputation must unshard them from inside
-    the checkpointed region. Its copy-in/copy-out ops are runtime parameter
-    management, not model activations, and must execute normally when needed
-    instead of being indexed against the forward's selective-AC op stream.
+    the checkpointed region. Its copy-in/copy-out and c10d all-gather ops are
+    runtime parameter management, not model activations, and must execute
+    normally when needed instead of being indexed against the forward's
+    selective-AC op stream.
     """
     sac_ignored = getattr(torch.utils.checkpoint, "SAC_IGNORED_OPS", None)
     if sac_ignored is None:
@@ -308,6 +309,9 @@ def ensure_fsdp_ops_sac_ignored() -> None:
         op = _resolve_torch_op("fsdp", op_name)
         if op is not None:
             sac_ignored.add(op)
+    all_gather = _resolve_torch_op("c10d", "_allgather_base_")
+    if all_gather is not None:
+        sac_ignored.add(all_gather)
 
 
 def make_selective_checkpoint_context_fn():

--- a/nemo_automodel/components/distributed/activation_checkpointing.py
+++ b/nemo_automodel/components/distributed/activation_checkpointing.py
@@ -312,6 +312,12 @@ def ensure_fsdp_ops_sac_ignored() -> None:
     all_gather = _resolve_torch_op("c10d", "_allgather_base_")
     if all_gather is not None:
         sac_ignored.add(all_gather)
+    # FSDP's all-gather copy-out views the flat communication buffer and its
+    # per-parameter outputs. When forward prefetch has already unsharded the
+    # parameters, those alias-only views occur only during recomputation.
+    view = _resolve_torch_op("aten", "view")
+    if view is not None:
+        sac_ignored.add(view)
 
 
 def make_selective_checkpoint_context_fn():

--- a/nemo_automodel/components/distributed/activation_checkpointing.py
+++ b/nemo_automodel/components/distributed/activation_checkpointing.py
@@ -60,11 +60,11 @@ def unwrap_checkpoint_wrapper(module: nn.Module) -> nn.Module:
     return getattr(module, "_checkpoint_wrapped_module", module)
 
 
-def _resolve_torch_op(namespace: str, name: str, overload: str = "default"):
-    """Resolve ``torch.ops.<namespace>.<name>.<overload>``, or ``None`` if absent."""
-    ns = getattr(torch.ops, namespace, None)
-    packet = getattr(ns, name, None) if ns is not None else None
-    return getattr(packet, overload, None) if packet is not None else None
+def _resolve_torch_op(dotted_path: str):
+    """Resolve a dotted ``torch.ops`` path, defaulting to the ``default`` overload."""
+    if dotted_path.count(".") == 1:
+        dotted_path = f"{dotted_path}.default"
+    return _resolve_op_attr(torch.ops, dotted_path)
 
 
 def _resolve_op_attr(root: object, dotted_path: str):
@@ -95,10 +95,10 @@ def _existing_ops(*ops):
 # would recompute every expert GEMM, matching full checkpointing and giving no
 # speedup while still paying the policy overhead.
 _SELECTIVE_AC_MATMUL_OPS = _existing_ops(
-    _resolve_torch_op("aten", "mm"),
-    _resolve_torch_op("aten", "linear"),
-    _resolve_torch_op("aten", "_grouped_mm"),
-    _resolve_torch_op("aten", "_scaled_grouped_mm"),
+    _resolve_torch_op("aten.mm"),
+    _resolve_torch_op("aten.linear"),
+    _resolve_torch_op("aten._grouped_mm"),
+    _resolve_torch_op("aten._scaled_grouped_mm"),
 )
 
 
@@ -146,22 +146,22 @@ def _build_selective_ac_save_ops() -> frozenset:
 
     # Compute ops the partitioner list may not classify as compute-intensive.
     compute_ops = _existing_ops(
-        _resolve_torch_op("aten", "mm"),
-        _resolve_torch_op("aten", "addmm"),
-        _resolve_torch_op("aten", "bmm"),
-        _resolve_torch_op("aten", "linear"),
-        _resolve_torch_op("aten", "_scaled_mm"),
-        _resolve_torch_op("aten", "_scaled_dot_product_cudnn_attention"),
-        _resolve_torch_op("aten", "_scaled_dot_product_efficient_attention"),
-        _resolve_torch_op("aten", "_scaled_dot_product_flash_attention"),
-        _resolve_torch_op("aten", "_scaled_dot_product_flash_attention_for_cpu"),
-        _resolve_torch_op("aten", "_scaled_dot_product_fused_attention_overrideable"),
-        _resolve_torch_op("aten", "scaled_dot_product_attention"),
-        _resolve_torch_op("aten", "_flex_attention"),
+        _resolve_torch_op("aten.mm"),
+        _resolve_torch_op("aten.addmm"),
+        _resolve_torch_op("aten.bmm"),
+        _resolve_torch_op("aten.linear"),
+        _resolve_torch_op("aten._scaled_mm"),
+        _resolve_torch_op("aten._scaled_dot_product_cudnn_attention"),
+        _resolve_torch_op("aten._scaled_dot_product_efficient_attention"),
+        _resolve_torch_op("aten._scaled_dot_product_flash_attention"),
+        _resolve_torch_op("aten._scaled_dot_product_flash_attention_for_cpu"),
+        _resolve_torch_op("aten._scaled_dot_product_fused_attention_overrideable"),
+        _resolve_torch_op("aten.scaled_dot_product_attention"),
+        _resolve_torch_op("aten._flex_attention"),
         # topk is saved to keep MoE expert assignments stable across recompute;
         # max is saved for low-precision scaling factors.
-        _resolve_torch_op("aten", "topk"),
-        _resolve_torch_op("aten", "max"),
+        _resolve_torch_op("aten.topk"),
+        _resolve_torch_op("aten.max"),
         # FlexAttention HOP and the inductor compiled-graph HOP (present only when
         # torch.compile is used); custom torch_attn varlen backend.
         _resolve_op_attr(torch, "_higher_order_ops.flex_attention"),
@@ -173,10 +173,10 @@ def _build_selective_ac_save_ops() -> frozenset:
 
     # Communication ops whose outputs should be saved to avoid re-communication.
     comm_ops = _existing_ops(
-        _resolve_torch_op("aten", "all_to_all_single"),
-        _resolve_torch_op("aten", "reduce_scatter_tensor"),
-        _resolve_torch_op("_c10d_functional", "all_to_all_single"),
-        _resolve_torch_op("_c10d_functional", "reduce_scatter_tensor"),
+        _resolve_torch_op("aten.all_to_all_single"),
+        _resolve_torch_op("aten.reduce_scatter_tensor"),
+        _resolve_torch_op("_c10d_functional.all_to_all_single"),
+        _resolve_torch_op("_c10d_functional.reduce_scatter_tensor"),
         # Optional expert-parallel comm backends.
         _resolve_op_attr(torch.ops, "deepep.dispatch.default"),
         _resolve_op_attr(torch.ops, "deepep.combine.default"),
@@ -191,7 +191,7 @@ def _build_selective_ac_save_ops() -> frozenset:
 
 _SELECTIVE_AC_MUST_SAVE_OPS = _build_selective_ac_save_ops()
 
-_SELECTIVE_AC_TO_COPY_OP = _resolve_torch_op("aten", "_to_copy")
+_SELECTIVE_AC_TO_COPY_OP = _resolve_torch_op("aten._to_copy")
 
 
 def is_selective_activation_checkpointing(activation_checkpointing: object) -> bool:
@@ -320,16 +320,21 @@ def ensure_fsdp_ops_sac_ignored() -> None:
     # the parameters, these setup ops occur only during recomputation. They do
     # not produce model activations: the FSDP copy ops populate the allocations.
     ignore_sac_ops(
-        [
-            _resolve_torch_op("fsdp", "all_gather_copy_in"),
-            _resolve_torch_op("fsdp", "split_with_sizes_copy"),
-            _resolve_torch_op("fsdp", "chunk_cat"),
-            _resolve_torch_op("fsdp", "copy_"),
-            _resolve_torch_op("c10d", "_allgather_base_"),
-            _resolve_torch_op("aten", "empty", "memory_format"),
-            _resolve_torch_op("aten", "empty_like"),
-            _resolve_torch_op("aten", "view"),
-        ]
+        list(
+            map(
+                _resolve_torch_op,
+                [
+                    "fsdp.all_gather_copy_in",
+                    "fsdp.split_with_sizes_copy",
+                    "fsdp.chunk_cat",
+                    "fsdp.copy_",
+                    "c10d._allgather_base_",
+                    "aten.empty.memory_format",
+                    "aten.empty_like",
+                    "aten.view",
+                ],
+            )
+        )
     )
 
 

--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -465,14 +465,19 @@ def apply_ac(
             from nemo_automodel.components.distributed.activation_checkpointing import (
                 SELECTIVE_AC_WRAPPER_FLAG,
                 make_selective_checkpoint_context_fn,
+                transformer_engine_attention_backend_snapshot_context_fn,
             )
 
             selective_context_fn = make_selective_checkpoint_context_fn()
+            attention_context_fn = functools.partial(
+                transformer_engine_attention_backend_snapshot_context_fn,
+                selective_context_fn,
+            )
             for parent_layers, layer_id, block in iter_transformer_and_mtp_blocks(model):
                 block = ptd_checkpoint_wrapper(
                     block,
                     preserve_rng_state=True,
-                    context_fn=_preserve_gate_load_during_recompute(block, selective_context_fn),
+                    context_fn=_preserve_gate_load_during_recompute(block, attention_context_fn),
                 )
                 # Tag so _apply_per_layer_compile compiles the wrapper OUTER (keeping the
                 # selective policy visible to the partitioner) instead of unwrapping and
@@ -539,9 +544,15 @@ def apply_ac(
     def selective_checkpointing_context_fn():
         return create_selective_checkpoint_contexts(_custom_policy)
 
-    from nemo_automodel.components.distributed.activation_checkpointing import ensure_profiler_ops_sac_ignored
+    from nemo_automodel.components.distributed.activation_checkpointing import (
+        ensure_profiler_ops_sac_ignored,
+        transformer_engine_attention_backend_snapshot_context_fn,
+    )
 
     ensure_profiler_ops_sac_ignored()
+
+    def _with_attention_backend_snapshot(context_fn=None):
+        return functools.partial(transformer_engine_attention_backend_snapshot_context_fn, context_fn)
 
     # Weight-tied (use_repeated_layer) MTP head blocks must NOT be activation
     # checkpointed: the single physical block is recomputed once per MTP depth in
@@ -568,13 +579,16 @@ def apply_ac(
             block = ptd_checkpoint_wrapper(
                 block,
                 preserve_rng_state=True,
-                context_fn=_preserve_gate_load_during_recompute(block, selective_checkpointing_context_fn),
+                context_fn=_preserve_gate_load_during_recompute(
+                    block,
+                    _with_attention_backend_snapshot(selective_checkpointing_context_fn),
+                ),
             )
         else:
             block = ptd_checkpoint_wrapper(
                 block,
                 preserve_rng_state=True,
-                context_fn=_preserve_gate_load_during_recompute(block),
+                context_fn=_preserve_gate_load_during_recompute(block, _with_attention_backend_snapshot()),
             )
 
         parent_layers.register_module(layer_id, block)

--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -545,11 +545,13 @@ def apply_ac(
         return create_selective_checkpoint_contexts(_custom_policy)
 
     from nemo_automodel.components.distributed.activation_checkpointing import (
+        ensure_fsdp_ops_sac_ignored,
         ensure_profiler_ops_sac_ignored,
         transformer_engine_attention_backend_snapshot_context_fn,
     )
 
     ensure_profiler_ops_sac_ignored()
+    ensure_fsdp_ops_sac_ignored()
 
     def _with_attention_backend_snapshot(context_fn=None):
         return functools.partial(transformer_engine_attention_backend_snapshot_context_fn, context_fn)

--- a/tests/unit_tests/distributed/test_activation_checkpointing.py
+++ b/tests/unit_tests/distributed/test_activation_checkpointing.py
@@ -497,6 +497,15 @@ def _sac_context_factory():
     return lambda: create_selective_checkpoint_contexts(policy)
 
 
+def test_ignore_sac_ops_adds_available_ops(monkeypatch):
+    sac_ignored = set()
+    monkeypatch.setattr(torch.utils.checkpoint, "SAC_IGNORED_OPS", sac_ignored, raising=False)
+
+    ac.ignore_sac_ops([torch.ops.aten.sin.default, None, torch.ops.aten.cos.default])
+
+    assert sac_ignored == {torch.ops.aten.sin.default, torch.ops.aten.cos.default}
+
+
 def test_profiler_ops_sac_ignore_skips_before_torch_2_13(monkeypatch):
     sac_ignored = set()
     monkeypatch.setattr(ac, "get_torch_version", lambda: Version("2.12.0"))

--- a/tests/unit_tests/distributed/test_activation_checkpointing.py
+++ b/tests/unit_tests/distributed/test_activation_checkpointing.py
@@ -169,6 +169,58 @@ def test_transformer_engine_attention_cache_snapshot_preserves_checkpoint_op_seq
     assert attention_cache["backend"] == cache_after_forward["backend"]
 
 
+def test_recompute_only_fsdp_unshard_op_bypasses_selective_ac_replay(monkeypatch):
+    """FSDP prefetch may make copy-in recompute-only; it must execute outside SAC indexing."""
+    import torch.distributed.fsdp._fully_shard._fsdp_collectives  # noqa: F401
+
+    fsdp_copy_in = torch.ops.fsdp.all_gather_copy_in.default
+    sac_ignored = set(torch.utils.checkpoint.SAC_IGNORED_OPS)
+    monkeypatch.setattr(torch.utils.checkpoint, "SAC_IGNORED_OPS", sac_ignored)
+    ac.ensure_fsdp_ops_sac_ignored()
+
+    def policy(ctx, func, *args, **kwargs):
+        if func == fsdp_copy_in:
+            return CheckpointPolicy.MUST_SAVE
+        return CheckpointPolicy.PREFER_RECOMPUTE
+
+    def selective_context_fn():
+        return create_selective_checkpoint_contexts(policy)
+
+    fsdp_state = {"unsharded": False}
+
+    def checkpointed_module(x: torch.Tensor) -> torch.Tensor:
+        if fsdp_state["unsharded"]:
+            all_gather_output = torch.empty_like(x)
+            fsdp_copy_in([x.detach()], all_gather_output, [x.numel()], x.numel(), 0)
+        fsdp_state["unsharded"] = True
+        return x.sin()
+
+    x = torch.randn(8, requires_grad=True)
+    out = checkpoint(checkpointed_module, x, use_reentrant=False, context_fn=selective_context_fn)
+    out.sum().backward()
+
+    assert torch.allclose(x.grad, x.detach().cos())
+
+
+def test_fsdp_runtime_ops_are_all_ignored_by_selective_ac(monkeypatch):
+    """All FSDP2 copy-in/copy-out custom ops must bypass SAC replay accounting."""
+    import torch.distributed.fsdp._fully_shard._fsdp_collectives  # noqa: F401
+    import torch.distributed.fsdp._fully_shard._fsdp_param  # noqa: F401
+
+    sac_ignored = set()
+    monkeypatch.setattr(torch.utils.checkpoint, "SAC_IGNORED_OPS", sac_ignored)
+
+    ac.ensure_fsdp_ops_sac_ignored()
+
+    expected = {
+        torch.ops.fsdp.all_gather_copy_in.default,
+        torch.ops.fsdp.split_with_sizes_copy.default,
+        torch.ops.fsdp.chunk_cat.default,
+        torch.ops.fsdp.copy_.default,
+    }
+    assert expected <= sac_ignored
+
+
 def test_submodule_checkpointing_with_snapshot_context_reruns_recompute_under_forward_backends():
     """Recompute must rerun under the forward-time SDPA backend set even after the pin exits."""
     block = _SdpaVisionBlock()

--- a/tests/unit_tests/distributed/test_activation_checkpointing.py
+++ b/tests/unit_tests/distributed/test_activation_checkpointing.py
@@ -133,33 +133,41 @@ def test_snapshot_context_fn_recompute_ctx_restores_captured_backend_set():
         assert _sdp_backend_state() == (True, True, False, False)
 
 
-def test_transformer_engine_attention_cache_snapshot_preserves_checkpoint_op_sequence(monkeypatch):
-    """TE cache population must not add an aten.ne.Tensor only during recompute."""
+def test_selective_checkpointing_to_layers_preserves_transformer_engine_attention_cache(monkeypatch):
+    """The shared selective-AC wrapper must preserve TE's checkpoint op sequence."""
     attention_cache = {"attention_params": None, "backend": None}
     monkeypatch.setattr(ac, "_get_transformer_engine_attention_backend_cache", lambda: attention_cache)
+    monkeypatch.setattr(
+        ac,
+        "_SELECTIVE_AC_MUST_SAVE_OPS",
+        ac._SELECTIVE_AC_MUST_SAVE_OPS | {torch.ops.aten.ne.Tensor},
+    )
 
-    def policy(ctx, func, *args, **kwargs):
-        if func == torch.ops.aten.ne.Tensor:
-            return CheckpointPolicy.MUST_SAVE
-        return CheckpointPolicy.PREFER_RECOMPUTE
+    class Attention(nn.Module):
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            """Run a cache-dependent attention stand-in.
 
-    def selective_context_fn():
-        return create_selective_checkpoint_contexts(policy)
+            Args:
+                x: Tensor of shape [features].
 
-    def attention(x: torch.Tensor) -> torch.Tensor:
-        params = x.detach()
-        if attention_cache["attention_params"] is None or params != attention_cache["attention_params"]:
-            attention_cache["attention_params"] = params
-            attention_cache["backend"] = "fused"
-        return x.sin()
+            Returns:
+                Tensor of shape [features].
+            """
+            params = x.detach()
+            if attention_cache["attention_params"] is None or params != attention_cache["attention_params"]:
+                attention_cache["attention_params"] = params
+                attention_cache["backend"] = "fused"
+            return x.sin()
+
+    model = nn.Module()
+    model.attention = Attention()
+    layers = [model.attention]
+    ac.apply_selective_checkpointing_to_layers(model, layers, has_kv_sharing=False)
+    assert isinstance(model.attention, CheckpointWrapper)
+    assert layers[0] is model.attention
 
     x = torch.randn(8, requires_grad=True)
-    out = checkpoint(
-        attention,
-        x,
-        use_reentrant=False,
-        context_fn=lambda: ac.transformer_engine_attention_backend_snapshot_context_fn(selective_context_fn),
-    )
+    out = model.attention(x)
     cache_after_forward = dict(attention_cache)
 
     out.sum().backward()
@@ -192,6 +200,14 @@ def test_recompute_only_fsdp_unshard_op_bypasses_selective_ac_replay(monkeypatch
     fsdp_state = {"unsharded": False}
 
     def checkpointed_module(x: torch.Tensor) -> torch.Tensor:
+        """Run a checkpointed FSDP-unshard stand-in.
+
+        Args:
+            x: Tensor of shape [features].
+
+        Returns:
+            Tensor of shape [features].
+        """
         if fsdp_state["unsharded"]:
             all_gather_output = torch.empty_like(x)
             torch.empty(x.shape, dtype=x.dtype, device=x.device)

--- a/tests/unit_tests/distributed/test_activation_checkpointing.py
+++ b/tests/unit_tests/distributed/test_activation_checkpointing.py
@@ -24,7 +24,7 @@ from packaging.version import Version
 from torch import nn
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import CheckpointWrapper, checkpoint_wrapper
 from torch.nn.attention import SDPBackend, sdpa_kernel
-from torch.utils.checkpoint import CheckpointError
+from torch.utils.checkpoint import CheckpointError, CheckpointPolicy, checkpoint, create_selective_checkpoint_contexts
 
 from nemo_automodel.components.distributed import activation_checkpointing as ac
 
@@ -131,6 +131,42 @@ def test_snapshot_context_fn_recompute_ctx_restores_captured_backend_set():
             assert _sdp_backend_state() == _MATH_ONLY
         # The backward-time ambient state is restored once the recompute exits.
         assert _sdp_backend_state() == (True, True, False, False)
+
+
+def test_transformer_engine_attention_cache_snapshot_preserves_checkpoint_op_sequence(monkeypatch):
+    """TE cache population must not add an aten.ne.Tensor only during recompute."""
+    attention_cache = {"attention_params": None, "backend": None}
+    monkeypatch.setattr(ac, "_get_transformer_engine_attention_backend_cache", lambda: attention_cache)
+
+    def policy(ctx, func, *args, **kwargs):
+        if func == torch.ops.aten.ne.Tensor:
+            return CheckpointPolicy.MUST_SAVE
+        return CheckpointPolicy.PREFER_RECOMPUTE
+
+    def selective_context_fn():
+        return create_selective_checkpoint_contexts(policy)
+
+    def attention(x: torch.Tensor) -> torch.Tensor:
+        params = x.detach()
+        if attention_cache["attention_params"] is None or params != attention_cache["attention_params"]:
+            attention_cache["attention_params"] = params
+            attention_cache["backend"] = "fused"
+        return x.sin()
+
+    x = torch.randn(8, requires_grad=True)
+    out = checkpoint(
+        attention,
+        x,
+        use_reentrant=False,
+        context_fn=lambda: ac.transformer_engine_attention_backend_snapshot_context_fn(selective_context_fn),
+    )
+    cache_after_forward = dict(attention_cache)
+
+    out.sum().backward()
+
+    assert torch.allclose(x.grad, x.detach().cos())
+    assert attention_cache["attention_params"] is cache_after_forward["attention_params"]
+    assert attention_cache["backend"] == cache_after_forward["backend"]
 
 
 def test_submodule_checkpointing_with_snapshot_context_reruns_recompute_under_forward_backends():

--- a/tests/unit_tests/distributed/test_activation_checkpointing.py
+++ b/tests/unit_tests/distributed/test_activation_checkpointing.py
@@ -174,13 +174,15 @@ def test_recompute_only_fsdp_unshard_op_bypasses_selective_ac_replay(monkeypatch
     import torch.distributed.fsdp._fully_shard._fsdp_collectives  # noqa: F401
 
     fsdp_copy_in = torch.ops.fsdp.all_gather_copy_in.default
+    fsdp_empty = torch.ops.aten.empty.memory_format
+    fsdp_empty_like = torch.ops.aten.empty_like.default
     fsdp_view = torch.ops.aten.view.default
     sac_ignored = set(torch.utils.checkpoint.SAC_IGNORED_OPS)
     monkeypatch.setattr(torch.utils.checkpoint, "SAC_IGNORED_OPS", sac_ignored)
     ac.ensure_fsdp_ops_sac_ignored()
 
     def policy(ctx, func, *args, **kwargs):
-        if func in (fsdp_copy_in, fsdp_view):
+        if func in (fsdp_copy_in, fsdp_empty, fsdp_empty_like, fsdp_view):
             return CheckpointPolicy.MUST_SAVE
         return CheckpointPolicy.PREFER_RECOMPUTE
 
@@ -192,6 +194,7 @@ def test_recompute_only_fsdp_unshard_op_bypasses_selective_ac_replay(monkeypatch
     def checkpointed_module(x: torch.Tensor) -> torch.Tensor:
         if fsdp_state["unsharded"]:
             all_gather_output = torch.empty_like(x)
+            torch.empty(x.shape, dtype=x.dtype, device=x.device)
             fsdp_copy_in([x.detach()], all_gather_output, [x.numel()], x.numel(), 0)
             x = x.view(-1)
         fsdp_state["unsharded"] = True
@@ -220,6 +223,8 @@ def test_fsdp_runtime_ops_are_all_ignored_by_selective_ac(monkeypatch):
         torch.ops.fsdp.chunk_cat.default,
         torch.ops.fsdp.copy_.default,
         torch.ops.c10d._allgather_base_.default,
+        torch.ops.aten.empty.memory_format,
+        torch.ops.aten.empty_like.default,
         torch.ops.aten.view.default,
     }
     assert expected <= sac_ignored

--- a/tests/unit_tests/distributed/test_activation_checkpointing.py
+++ b/tests/unit_tests/distributed/test_activation_checkpointing.py
@@ -170,16 +170,17 @@ def test_transformer_engine_attention_cache_snapshot_preserves_checkpoint_op_seq
 
 
 def test_recompute_only_fsdp_unshard_op_bypasses_selective_ac_replay(monkeypatch):
-    """FSDP prefetch may make copy-in recompute-only; it must execute outside SAC indexing."""
+    """FSDP prefetch may make unshard ops recompute-only; they must bypass SAC indexing."""
     import torch.distributed.fsdp._fully_shard._fsdp_collectives  # noqa: F401
 
     fsdp_copy_in = torch.ops.fsdp.all_gather_copy_in.default
+    fsdp_view = torch.ops.aten.view.default
     sac_ignored = set(torch.utils.checkpoint.SAC_IGNORED_OPS)
     monkeypatch.setattr(torch.utils.checkpoint, "SAC_IGNORED_OPS", sac_ignored)
     ac.ensure_fsdp_ops_sac_ignored()
 
     def policy(ctx, func, *args, **kwargs):
-        if func == fsdp_copy_in:
+        if func in (fsdp_copy_in, fsdp_view):
             return CheckpointPolicy.MUST_SAVE
         return CheckpointPolicy.PREFER_RECOMPUTE
 
@@ -192,6 +193,7 @@ def test_recompute_only_fsdp_unshard_op_bypasses_selective_ac_replay(monkeypatch
         if fsdp_state["unsharded"]:
             all_gather_output = torch.empty_like(x)
             fsdp_copy_in([x.detach()], all_gather_output, [x.numel()], x.numel(), 0)
+            x = x.view(-1)
         fsdp_state["unsharded"] = True
         return x.sin()
 
@@ -218,6 +220,7 @@ def test_fsdp_runtime_ops_are_all_ignored_by_selective_ac(monkeypatch):
         torch.ops.fsdp.chunk_cat.default,
         torch.ops.fsdp.copy_.default,
         torch.ops.c10d._allgather_base_.default,
+        torch.ops.aten.view.default,
     }
     assert expected <= sac_ignored
 

--- a/tests/unit_tests/distributed/test_activation_checkpointing.py
+++ b/tests/unit_tests/distributed/test_activation_checkpointing.py
@@ -203,7 +203,7 @@ def test_recompute_only_fsdp_unshard_op_bypasses_selective_ac_replay(monkeypatch
 
 
 def test_fsdp_runtime_ops_are_all_ignored_by_selective_ac(monkeypatch):
-    """All FSDP2 copy-in/copy-out custom ops must bypass SAC replay accounting."""
+    """FSDP2 copy and all-gather ops must bypass SAC replay accounting."""
     import torch.distributed.fsdp._fully_shard._fsdp_collectives  # noqa: F401
     import torch.distributed.fsdp._fully_shard._fsdp_param  # noqa: F401
 
@@ -217,6 +217,7 @@ def test_fsdp_runtime_ops_are_all_ignored_by_selective_ac(monkeypatch):
         torch.ops.fsdp.split_with_sizes_copy.default,
         torch.ops.fsdp.chunk_cat.default,
         torch.ops.fsdp.copy_.default,
+        torch.ops.c10d._allgather_base_.default,
     }
     assert expected <= sac_ignored
 

--- a/tests/unit_tests/moe/test_parallelizer.py
+++ b/tests/unit_tests/moe/test_parallelizer.py
@@ -14,6 +14,7 @@
 
 import sys
 import types
+from contextlib import nullcontext
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -431,6 +432,9 @@ def _import_parallelizer_with_stubs(monkeypatch):
 
     activation_checkpointing_stub = types.ModuleType("nemo_automodel.components.distributed.activation_checkpointing")
     activation_checkpointing_stub.ensure_profiler_ops_sac_ignored = lambda: None
+    activation_checkpointing_stub.transformer_engine_attention_backend_snapshot_context_fn = (
+        lambda context_fn=None: context_fn() if context_fn is not None else (nullcontext(), nullcontext())
+    )
     monkeypatch.setitem(
         sys.modules,
         "nemo_automodel.components.distributed.activation_checkpointing",
@@ -653,9 +657,10 @@ def test_apply_ac_wraps_blocks_with_and_without_context(monkeypatch):
     model.layers.registered.clear()
 
     P.apply_ac(model, ignore_router=False, hidden_size=7168, num_experts=256)
-    # context_fn should not be passed (3rd arg remains default None)
+    # Router replay does not need a selective policy, but TE attention still
+    # receives a context that preserves its forward-time backend cache.
     for _, kwargs in wrapper_mock.call_args_list:
-        assert "context_fn" not in kwargs or kwargs["context_fn"] is None
+        assert callable(kwargs["context_fn"])
     assert len(model.layers.registered) == 2
 
 
@@ -2476,6 +2481,7 @@ def test_apply_ac_selective_wraps_blocks_with_shared_policy(monkeypatch):
     dense_stub = types.ModuleType("nemo_automodel.components.distributed.activation_checkpointing")
     dense_stub.make_selective_checkpoint_context_fn = MagicMock(return_value=sentinel_ctx)
     dense_stub.SELECTIVE_AC_WRAPPER_FLAG = sentinel_flag
+    dense_stub.transformer_engine_attention_backend_snapshot_context_fn = lambda context_fn=None: context_fn
     monkeypatch.setitem(sys.modules, "nemo_automodel.components.distributed.activation_checkpointing", dense_stub)
 
     wrapped = []
@@ -2486,7 +2492,8 @@ def test_apply_ac_selective_wraps_blocks_with_shared_policy(monkeypatch):
 
     def fake_wrapper(block, preserve_rng_state, context_fn=None):
         assert preserve_rng_state is True
-        assert context_fn is sentinel_ctx
+        assert callable(context_fn)
+        assert context_fn() is sentinel_ctx
         w = _Wrapper(block)
         wrapped.append(w)
         return w

--- a/tests/unit_tests/moe/test_parallelizer.py
+++ b/tests/unit_tests/moe/test_parallelizer.py
@@ -431,6 +431,7 @@ def _import_parallelizer_with_stubs(monkeypatch):
     monkeypatch.setitem(sys.modules, "nemo_automodel.shared.tied_weights", tied_weights_stub)
 
     activation_checkpointing_stub = types.ModuleType("nemo_automodel.components.distributed.activation_checkpointing")
+    activation_checkpointing_stub.ensure_fsdp_ops_sac_ignored = lambda: None
     activation_checkpointing_stub.ensure_profiler_ops_sac_ignored = lambda: None
     activation_checkpointing_stub.transformer_engine_attention_backend_snapshot_context_fn = (
         lambda context_fn=None: context_fn() if context_fn is not None else (nullcontext(), nullcontext())


### PR DESCRIPTION
## Summary

- restore Transformer Engine's attention-backend cache to its forward-entry state during activation-checkpoint recomputation
- keep FSDP2 parameter-lifecycle communication, allocation, layout, and copy ops outside selective-AC saved-op replay accounting
- centralize SAC ignore-set mutation in `ignore_sac_ops(...)`, with profiler and FSDP callers supplying their operator lists
- add focused regressions for TE cache-dependent op sequences and recompute-only FSDP unshard setup

## Validation

- `python -m pytest -q tests/unit_tests/distributed/test_activation_checkpointing.py tests/unit_tests/moe/test_parallelizer.py` (`105 passed`)
- `ruff format .` and `ruff check --fix .`
- [nemo-ci job 380509607](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/380509607): `nemotron_ultra_v3_squad` completed 17/17 steps on 256 H100 GPUs; Slurm `COMPLETED`, exit code 0

The failure was reproduced on current `main` in [job 380347397](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/380347397) before applying the fix.

## Tracking

- [AMINT-32](https://linear.app/nvidia/issue/AMINT-32/missing-saved-tensor-for-checkpointed-atenne-operation-causes)
