### PR TITLE
fix(nemotron-parse): sync RADIO preprocessing

### DIFF
--- a/nemo_automodel/components/models/nemotron_parse/model.py
+++ b/nemo_automodel/components/models/nemotron_parse/model.py
@@ -376,6 +376,8 @@ class RadioWithNeck(nn.Module):
     def __init__(self, config):
         super().__init__()
         self.config = config
+        self.image_processor_normalizes = bool(getattr(config, "image_processor_normalizes", False))
+        self._radio_input_conditioner_externalized = False
 
         # Create RADIO encoder from config (which is now actual RADIOConfig)
         self.model_encoder = AutoModel.from_config(config, trust_remote_code=True)
@@ -391,7 +393,38 @@ class RadioWithNeck(nn.Module):
         self.sum_proj = nn.Linear(3840, last_hidden_state)
         self.layer_norm3 = nn.LayerNorm(last_hidden_state, eps=1e-06, elementwise_affine=True)
 
+    def _externalize_radio_input_conditioner(self) -> None:
+        if not self.image_processor_normalizes or self._radio_input_conditioner_externalized:
+            return
+
+        make_external = getattr(self.model_encoder, "make_preprocessor_external", None)
+        if make_external is None:
+            raise ValueError(
+                "image_processor_normalizes=True requires a RADIO encoder with make_preprocessor_external()."
+            )
+
+        make_external()
+        self._radio_input_conditioner_externalized = True
+
     def forward(self, pixel_values, output_attentions=False, output_hidden_states=False, return_dict=False, **kwargs):
+        """Encode document images into visual tokens.
+
+        Args:
+            pixel_values: Tensor of shape [batch, channels, height, width]. When the image processor normalizes
+                inputs, values must already contain that external normalization.
+            output_attentions: Accepted for model interface compatibility and currently unused.
+            output_hidden_states: Accepted for model interface compatibility and currently unused.
+            return_dict: Accepted for model interface compatibility and currently unused.
+            **kwargs: Additional model arguments accepted for interface compatibility.
+
+        Returns:
+            A DonutSwinModelOutput whose last_hidden_state has shape [batch, image_tokens, hidden].
+        """
+        self._externalize_radio_input_conditioner()
+        if self.image_processor_normalizes:
+            encoder_dtype = next(self.model_encoder.parameters()).dtype
+            pixel_values = pixel_values.to(dtype=encoder_dtype)
+
         radio_output = self.model_encoder(pixel_values)
         summary, feature = radio_output
 

--- a/tests/unit_tests/models/nemotron_parse/test_nemotron_parse_model.py
+++ b/tests/unit_tests/models/nemotron_parse/test_nemotron_parse_model.py
@@ -13,10 +13,81 @@
 # limitations under the License.
 
 
+import pytest
 import torch
 from transformers.models.donut.modeling_donut_swin import DonutSwinModelOutput
 
 from nemo_automodel.components.models.nemotron_parse import model as np_model
+
+
+class _DummyRadioEncoder(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.probe = torch.nn.Parameter(torch.zeros(1, dtype=torch.float32))
+        self.externalize_calls = 0
+        self.input_dtypes = []
+
+    def make_preprocessor_external(self):
+        self.externalize_calls += 1
+
+    def forward(self, pixel_values):
+        """Return deterministic RADIO features for an image batch.
+
+        Args:
+            pixel_values: Tensor of shape [batch, channels, height, width].
+
+        Returns:
+            A tuple containing summary features of shape [batch, 3840] and patch features of shape
+            [batch, height * width, 1280].
+        """
+        self.input_dtypes.append(pixel_values.dtype)
+        batch = pixel_values.shape[0]
+        height = pixel_values.shape[-2]
+        width = pixel_values.shape[-1]
+        summary = torch.zeros(batch, 3840)
+        feature = torch.zeros(batch, height * width, 1280)
+        return summary, feature
+
+
+class _DummyRadioConfig:
+    patch_size = 1
+
+    def __init__(self, image_processor_normalizes):
+        self.image_processor_normalizes = image_processor_normalizes
+
+
+@pytest.mark.parametrize("image_processor_normalizes", [False, True])
+def test_radio_with_neck_respects_processor_normalization(monkeypatch, image_processor_normalizes):
+    radio_encoder = _DummyRadioEncoder()
+    monkeypatch.setattr(np_model.AutoModel, "from_config", lambda *args, **kwargs: radio_encoder)
+    encoder = np_model.RadioWithNeck(_DummyRadioConfig(image_processor_normalizes))
+    pixel_values = torch.zeros(1, 3, 1, 4, dtype=torch.bfloat16 if image_processor_normalizes else torch.float32)
+
+    first_output = encoder(pixel_values)
+    second_output = encoder(pixel_values)
+
+    expected_externalize_calls = 1 if image_processor_normalizes else 0
+    assert radio_encoder.externalize_calls == expected_externalize_calls
+    assert radio_encoder.input_dtypes == [torch.float32, torch.float32]
+    assert first_output.last_hidden_state.shape == (1, 2, 1024)
+    assert second_output.last_hidden_state.shape == (1, 2, 1024)
+
+
+def test_radio_with_neck_requires_external_preprocessor_support(monkeypatch):
+    class RadioEncoderWithoutExternalPreprocessor(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.probe = torch.nn.Parameter(torch.zeros(1))
+
+    monkeypatch.setattr(
+        np_model.AutoModel,
+        "from_config",
+        lambda *args, **kwargs: RadioEncoderWithoutExternalPreprocessor(),
+    )
+    encoder = np_model.RadioWithNeck(_DummyRadioConfig(image_processor_normalizes=True))
+
+    with pytest.raises(ValueError, match="requires a RADIO encoder with make_preprocessor_external"):
+        encoder(torch.zeros(1, 3, 1, 4))
 
 
 def test_nemotron_parse_forward_with_stub_encoder(monkeypatch):


### PR DESCRIPTION
## What

- Honor the Nemotron Parse processor's `image_processor_normalizes` contract in the NeMo RADIO wrapper.
- Externalize RADIO's internal input conditioner once when preprocessing already happened in the processor.
- Cast externally normalized image tensors to the RADIO encoder dtype.
- Add focused coverage for both the legacy and externally normalized processor paths.

## Why

The current `nvidia/NVIDIA-Nemotron-Parse-v1.1` processor revision (`fd1e3c6`) normalizes image pixels before model execution and advertises that through `image_processor_normalizes=true`. The NeMo wrapper continued to run RADIO's internal conditioner as well, so pixels were normalized twice. Base-model generation consequently stopped immediately, and fine-tuning could not reproduce the tutorial results.

The default remains `false`, so older processor configurations retain the existing behavior.

## Reproduction

Full `tutorials/nemotron-parse/finetune.ipynb` execution on cw-dfw, 1 node with 8 H100 GPUs:

| Result | Current `main` | This PR | Tutorial target |
| --- | ---: | ---: | ---: |
| Base average NED | 1.0000 | 0.8157 | ~0.81 |
| Fine-tuned average NED | 0.7722 | 0.0077 | ~0.1 |
| Fine-tuned exact field accuracy | 0/140 (0.0%) | 130/140 (92.9%) | >80% |

The fixed run completed all 50 training steps with final train loss `0.0453` and validation loss `0.0269` (cw-dfw Slurm job `14784564`). A separate real-model H100 inference check recovered the expected invoice number, date, seller, tax ID, and IBAN.

## Checks

- `python -m pytest tests/unit_tests/models/nemotron_parse/test_nemotron_parse_model.py -q` (local: 5 passed)
- Same focused pytest file in the cw-dfw container (5 passed)
- `ruff format --check` on both changed files
- `ruff check` on both changed files
- Complete notebook execution on 8 H100 GPUs
