### PR TITLE
fix(ci): grant NVSkills status read permission

### DIFF
--- a/.github/workflows/request-nvskills-ci.yml
+++ b/.github/workflows/request-nvskills-ci.yml
@@ -17,6 +17,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      statuses: read
     uses: NVIDIA/skills/.github/workflows/team-request.yml@2528d5b9d3f125c8bc8cf644ea2134adb4322a51 # main
     secrets:
       NVSKILLS_CI_DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}


### PR DESCRIPTION
# What does this PR do ?

Grants the reusable NVSkills workflow the `statuses: read` permission it declares, allowing `/nvskills-ci` requests to start.

# Changelog

- Add the least-privilege `statuses: read` grant to the `Request NVSkills CI` caller.
- Unblock the signature-generation request for #3333.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] No tests are needed for a one-line workflow permission correction.
- [x] No documentation changes are needed.

# Additional Information

Root cause: the pinned reusable workflow's `require-nvskills-ci` job requests `statuses: read`, but the caller previously allowed `statuses: none`, causing workflow validation to fail before any job was created.

Validation:

- YAML parse
- `git diff --check`
- Failure reproduced in https://github.com/NVIDIA-NeMo/Automodel/actions/runs/30639908781
