### PR TITLE
fix(tokenizer): make special token insertion opt-in

### DIFF
--- a/examples/llm_finetune/baichuan/baichuan_2_7b_mock_fp8.yaml
+++ b/examples/llm_finetune/baichuan/baichuan_2_7b_mock_fp8.yaml
@@ -46,6 +46,8 @@ tokenizer:
   _target_: nemo_automodel.NeMoAutoTokenizer.from_pretrained
   pretrained_model_name_or_path: baichuan-inc/Baichuan2-7B-Chat
   trust_remote_code: true
+  add_bos_token: true
+  add_eos_token: true
 
 checkpoint:
   enabled: true

--- a/examples/llm_finetune/baichuan/baichuan_2_7b_squad.yaml
+++ b/examples/llm_finetune/baichuan/baichuan_2_7b_squad.yaml
@@ -45,6 +45,8 @@ tokenizer:
   _target_: nemo_automodel.NeMoAutoTokenizer.from_pretrained
   pretrained_model_name_or_path: baichuan-inc/Baichuan2-7B-Chat
   trust_remote_code: true
+  add_bos_token: true
+  add_eos_token: true
 
 checkpoint:
   enabled: true

--- a/examples/llm_finetune/baichuan/baichuan_2_7b_squad_peft.yaml
+++ b/examples/llm_finetune/baichuan/baichuan_2_7b_squad_peft.yaml
@@ -46,6 +46,8 @@ tokenizer:
   _target_: nemo_automodel.NeMoAutoTokenizer.from_pretrained
   pretrained_model_name_or_path: baichuan-inc/Baichuan2-7B-Chat
   trust_remote_code: true
+  add_bos_token: true
+  add_eos_token: true
 
 checkpoint:
   enabled: true

--- a/nemo_automodel/_transformers/auto_tokenizer.py
+++ b/nemo_automodel/_transformers/auto_tokenizer.py
@@ -60,14 +60,17 @@ class NeMoAutoTokenizer:
 
     The dispatch logic is:
     1. If a custom tokenizer is registered for the model type, use it
-    2. Otherwise, fall back to NeMoAutoTokenizerWithBosEosEnforced
+    2. Otherwise, fall back to the wrapped HuggingFace tokenizer
 
     Example:
         >>> # Will use MistralCommonBackend if available for Mistral models
         >>> tokenizer = NeMoAutoTokenizer.from_pretrained("mistralai/Mistral-7B-v0.1")
 
-        >>> # Force using HF AutoTokenizer with BOS/EOS enforcement
+        >>> # Force using the wrapped HF AutoTokenizer instead of a registered tokenizer
         >>> tokenizer = NeMoAutoTokenizer.from_pretrained("gpt2", force_default=True)
+
+        >>> # Explicitly opt in to BOS/EOS insertion
+        >>> tokenizer = NeMoAutoTokenizer.from_pretrained("gpt2", add_bos_token=True, add_eos_token=True)
     """
 
     # Make registry accessible at class level
@@ -99,7 +102,7 @@ class NeMoAutoTokenizer:
 
         Args:
             pretrained_model_name_or_path: Model identifier or path
-            force_default: If True, always use NeMoAutoTokenizerWithBosEosEnforced
+            force_default: If True, always use the wrapped HuggingFace tokenizer.
             force_hf: If True, return the raw HF AutoTokenizer without any wrapping
             trust_remote_code: Whether to trust remote code when loading config
             **kwargs: Additional arguments passed to the tokenizer's from_pretrained
@@ -130,7 +133,8 @@ class NeMoAutoTokenizer:
                 _ensure_pad_token_id(tokenizer, pretrained_model_name_or_path)
                 return tokenizer
 
-        # Fall back to default BOS/EOS enforced tokenizer
+        # Fall back to the default wrapped HuggingFace tokenizer. BOS/EOS insertion
+        # is enabled only when callers opt in via add_bos_token/add_eos_token.
         from nemo_automodel._transformers.tokenization.nemo_auto_tokenizer import NeMoAutoTokenizerWithBosEosEnforced
 
         return NeMoAutoTokenizerWithBosEosEnforced.from_pretrained(

--- a/nemo_automodel/_transformers/tokenization/nemo_auto_tokenizer.py
+++ b/nemo_automodel/_transformers/tokenization/nemo_auto_tokenizer.py
@@ -20,7 +20,7 @@ import shutil
 
 from jinja2.exceptions import TemplateError
 from transformers import AutoTokenizer
-from transformers.tokenization_utils_base import BatchEncoding
+from transformers.tokenization_utils_base import BatchEncoding, PreTrainedTokenizerBase
 
 try:
     from huggingface_hub.errors import StrictDataclassClassValidationError
@@ -345,21 +345,35 @@ def _try_convert_tiktoken_to_native(tokenizer):
 
 class NeMoAutoTokenizerWithBosEosEnforced(AutoTokenizer):
     """
-    A wrapper around HuggingFace's AutoTokenizer that ensures consistent BOS/EOS token handling.
+    A wrapper around HuggingFace's AutoTokenizer with opt-in BOS/EOS token handling.
 
     There are pre-existing issues with some tokenizers (e.g. GPT2Tokenizer) where the BOS/EOS tokens
-    are not added automatically. This wrapper ensures they are always added when requested.
+    are not added automatically. Set ``add_bos_token`` or ``add_eos_token`` to ``True`` to add them.
     """
 
     @classmethod
-    def from_pretrained(cls, pretrained_model_name_or_path, *args, add_bos_token=True, add_eos_token=True, **kwargs):
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str | os.PathLike[str],
+        *args: object,
+        add_bos_token: bool = False,
+        add_eos_token: bool = False,
+        **kwargs: object,
+    ) -> PreTrainedTokenizerBase:
         """
         Load the HF tokenizer class via AutoTokenizer and (optionally) wrap it to add BOS/EOS.
 
         Args:
-            pretrained_model_name_or_path: Model identifier or path
-            add_bos_token: Whether to add BOS token (default: True)
-            add_eos_token: Whether to add EOS token (default: True)
+            pretrained_model_name_or_path: Model identifier or path.
+            *args: Additional positional arguments passed to the tokenizer's ``from_pretrained`` method.
+            add_bos_token: Set to ``True`` to add a BOS token when the tokenizer does not add one itself. By
+                default, the tokenizer's native setting is preserved.
+            add_eos_token: Set to ``True`` to add an EOS token when the tokenizer does not add one itself. By
+                default, the tokenizer's native setting is preserved.
+            **kwargs: Additional keyword arguments passed to the tokenizer's ``from_pretrained`` method.
+
+        Returns:
+            The loaded tokenizer, wrapped with NeMo's tokenizer compatibility behavior.
         """
         try:
             tokenizer = super().from_pretrained(pretrained_model_name_or_path, *args, **kwargs)

--- a/tests/functional_tests/data/llm/_test_pad_eos_overlap.py
+++ b/tests/functional_tests/data/llm/_test_pad_eos_overlap.py
@@ -18,8 +18,8 @@ When pad_token_id == eos_token_id (e.g. Qwen2.5), a naïve
 ``labels == pad_token_id`` comparison masks **all** EOS tokens, including
 real end-of-sequence markers, causing significant PPL degradation.
 
-These tests load real tokenizers (via ``NeMoAutoTokenizer``, which enforces
-``add_eos_token=True``) from four model families and verify that
+These tests load real tokenizers (via ``NeMoAutoTokenizer`` with
+``add_eos_token=True`` explicitly enabled) from four model families and verify that
 ``_get_right_trailing_pad_mask`` correctly preserves the first (real) EOS in a
 trailing run while masking only the subsequent (padding) positions.
 
@@ -102,7 +102,7 @@ TOKENIZER_MODELS = [
 def tok(request):
     path = Path(request.param)
     assert path.exists(), f"Missing tokenizer data: {path}"
-    return NeMoAutoTokenizer.from_pretrained(request.param, trust_remote_code=True)
+    return NeMoAutoTokenizer.from_pretrained(request.param, trust_remote_code=True, add_eos_token=True)
 
 
 #  Functional tests with real tokenizers (GPT pretrain path)
@@ -297,8 +297,8 @@ _SQUAD_ROWS = {
 class TestSquadCollateEndToEnd:
     """Full SFT pipeline: squad dataset → default_collater → batch verification.
 
-    Uses NeMoAutoTokenizer which enforces add_eos_token=True, matching the
-    real training pipeline.  The SFT path pads labels with -100 and tracks
+    Uses NeMoAutoTokenizer with add_eos_token=True explicitly enabled. The SFT
+    path pads labels with -100 and tracks
     attention_mask independently, so it is inherently safe against the
     pad==eos collision.  These tests confirm that invariant holds end-to-end.
     """
@@ -319,8 +319,6 @@ class TestSquadCollateEndToEnd:
         """Each example must have matching-length keys and -100 masked prompts."""
         ds = squad_module.make_squad_dataset(tok, split="train")
         assert len(ds) == len(_SQUAD_ROWS["id"])
-
-        eos_id = tok.eos_token_id
 
         for i in range(len(ds)):
             ex = ds[i]

--- a/tests/functional_tests/data/llm/test_save_pretrained_v4_compat.py
+++ b/tests/functional_tests/data/llm/test_save_pretrained_v4_compat.py
@@ -33,6 +33,7 @@ import os
 from pathlib import Path
 
 import pytest
+from transformers import AutoTokenizer
 
 from nemo_automodel._transformers.auto_tokenizer import NeMoAutoTokenizer
 from nemo_automodel._transformers.tokenization.nemo_auto_tokenizer import (
@@ -98,13 +99,12 @@ class TestSavePretrainedV4Compat:
                 )
 
     def test_no_runtime_overrides_leak_into_saved_config(self, nemotron_nano_path, original_config, tmp_path):
-        """The wrapper forces add_bos_token=True and add_eos_token=True at
-        runtime.  These must NOT appear in the saved config unless the original
-        already had them."""
+        """The wrapper preserves native BOS/EOS behavior and saved config fields."""
+        raw_tok = AutoTokenizer.from_pretrained(nemotron_nano_path)
         tok = NeMoAutoTokenizer.from_pretrained(nemotron_nano_path)
 
-        assert tok.add_bos_token is True, "Wrapper should force add_bos_token=True at runtime"
-        assert tok.add_eos_token is True, "Wrapper should force add_eos_token=True at runtime"
+        assert tok.add_bos_token == raw_tok.add_bos_token
+        assert tok.add_eos_token == raw_tok.add_eos_token
 
         tok.save_pretrained(str(tmp_path))
 

--- a/tests/functional_tests/hf_transformer/test_formatting_utils_options.py
+++ b/tests/functional_tests/hf_transformer/test_formatting_utils_options.py
@@ -38,7 +38,7 @@ def test_format_prompt_completion_options(seq_length, padding, truncation):
     os.environ["HF_HUB_OFFLINE"] = "1"
     TOKENIZER_DIR = f"{os.environ['TEST_DATA_DIR']}/hf_mixtral_2l"
     assert os.path.exists(TOKENIZER_DIR), "Tokenizer directory does not exist"
-    tok = NeMoAutoTokenizer.from_pretrained(TOKENIZER_DIR)
+    tok = NeMoAutoTokenizer.from_pretrained(TOKENIZER_DIR, add_eos_token=True)
     # Only applicable when tokenizer lacks chat template
     assert getattr(tok, "chat_template", None) is None
 
@@ -87,9 +87,9 @@ def test_format_prompt_completion_options(seq_length, padding, truncation):
         assert tok.eos_token_id in labels, "EOS must appear in labels"
 
     # There should be masked (prompt) and supervised (answer) tokens
-    assert any(v== -100 for v in labels), "Must have masked prompt tokens"
+    assert any(v == -100 for v in labels), "Must have masked prompt tokens"
     if truncation is not True:
-        assert any(v!= -100 for v in labels), "Must have supervised answer tokens"
+        assert any(v != -100 for v in labels), "Must have supervised answer tokens"
 
     # Where attention_mask=0, labels must be -100
     if padding == "do_not_pad":
@@ -120,7 +120,6 @@ def test_format_prompt_completion_options(seq_length, padding, truncation):
     ],
 )
 def test_format_chat_template_options(seq_length, padding, truncation):
-
     os.environ["TRANSFORMERS_OFFLINE"] = "1"
     os.environ["HF_HUB_OFFLINE"] = "1"
     TOKENIZER_DIR = f"{os.environ['TEST_DATA_DIR']}/qwen3_4b_instruct_2407"

--- a/tests/unit_tests/_transformers/test_auto_tokenizer.py
+++ b/tests/unit_tests/_transformers/test_auto_tokenizer.py
@@ -31,11 +31,13 @@ from nemo_automodel._transformers.tokenization.nemo_auto_tokenizer import (
 
 
 class _StubHFTokenizer:
-    def __init__(self, bos_id=101, eos_id=102):
+    def __init__(self, bos_id=101, eos_id=102, add_bos_token=False, add_eos_token=False):
         self.bos_token_id = bos_id
         self.eos_token_id = eos_id
-        self.add_bos_token = True
-        self.add_eos_token = True
+        self.bos_token = "<s>" if bos_id is not None else None
+        self.eos_token = "</s>" if eos_id is not None else None
+        self.add_bos_token = add_bos_token
+        self.add_eos_token = add_eos_token
 
     def __call__(self, *args, **kwargs):
         return BatchEncoding(
@@ -77,13 +79,26 @@ class _StubConfig:
 
 
 class TestNeMoAutoTokenizerFromPretrained:
-    def test_patched_adds_bos_eos(self):
+    def test_default_preserves_tokenizer_special_token_behavior(self):
         stub = _StubHFTokenizer()
         with (
             patch("transformers.AutoTokenizer.from_pretrained", return_value=stub),
             patch("transformers.AutoConfig.from_pretrained", return_value=_StubConfig()),
         ):
             tok = NeMoAutoTokenizer.from_pretrained("dummy/model")
+
+        assert tok.add_bos_token is False
+        assert tok.add_eos_token is False
+        assert tok(["x"])["input_ids"] == [[5, 6]]
+        assert tok.encode("x") == [5, 6]
+
+    def test_opt_in_adds_bos_eos(self):
+        stub = _StubHFTokenizer()
+        with (
+            patch("transformers.AutoTokenizer.from_pretrained", return_value=stub),
+            patch("transformers.AutoConfig.from_pretrained", return_value=_StubConfig()),
+        ):
+            tok = NeMoAutoTokenizer.from_pretrained("dummy/model", add_bos_token=True, add_eos_token=True)
             out = tok(["x"])
             assert isinstance(out, BatchEncoding)
             assert out["input_ids"] == [[stub.bos_token_id, 5, 6, stub.eos_token_id]]
@@ -281,7 +296,7 @@ class TestNeMoAutoTokenizerFromPretrained:
             patch("transformers.AutoTokenizer.from_pretrained", return_value=stub),
             patch("transformers.AutoConfig.from_pretrained", return_value=_StubConfig()),
         ):
-            tok = NeMoAutoTokenizer.from_pretrained("dummy/model")
+            tok = NeMoAutoTokenizer.from_pretrained("dummy/model", add_bos_token=True)
             assert tok._add_bos_token is True
 
     def test_add_eos_token_falls_back_on_value_error(self):
@@ -313,7 +328,7 @@ class TestNeMoAutoTokenizerFromPretrained:
             patch("transformers.AutoTokenizer.from_pretrained", return_value=stub),
             patch("transformers.AutoConfig.from_pretrained", return_value=_StubConfig()),
         ):
-            tok = NeMoAutoTokenizer.from_pretrained("dummy/model")
+            tok = NeMoAutoTokenizer.from_pretrained("dummy/model", add_eos_token=True)
             assert tok._add_eos_token is True
 
 
@@ -878,7 +893,7 @@ class TestTikTokenLikeTokenizerGuards:
             patch("transformers.AutoTokenizer.from_pretrained", return_value=stub),
             patch("transformers.AutoConfig.from_pretrained", return_value=_StubConfig()),
         ):
-            tok = NeMoAutoTokenizer.from_pretrained("dummy/model")
+            tok = NeMoAutoTokenizer.from_pretrained("dummy/model", add_bos_token=True, add_eos_token=True)
             assert tok.add_bos_token is True
             assert tok.add_eos_token is True
 

--- a/tests/unit_tests/recipes/llm/test_baichuan_configs.py
+++ b/tests/unit_tests/recipes/llm/test_baichuan_configs.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+BAICHUAN_CONFIGS = (
+    "baichuan_2_7b_mock_fp8.yaml",
+    "baichuan_2_7b_squad.yaml",
+    "baichuan_2_7b_squad_peft.yaml",
+)
+
+
+@pytest.mark.parametrize("config_name", BAICHUAN_CONFIGS)
+def test_baichuan_recipes_preserve_special_token_insertion(config_name: str) -> None:
+    config_path = REPO_ROOT / "examples" / "llm_finetune" / "baichuan" / config_name
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+    assert config["tokenizer"]["add_bos_token"] is True
+    assert config["tokenizer"]["add_eos_token"] is True


### PR DESCRIPTION
## Summary

- stop forcing `add_bos_token=True` and `add_eos_token=True` in the default NeMo tokenizer wrapper
- preserve the underlying HuggingFace tokenizer's native BOS/EOS behavior by default
- retain `add_bos_token=True` and `add_eos_token=True` as explicit opt-ins
- update tokenizer documentation and compatibility tests to reflect the new contract

## Why

`NeMoAutoTokenizerWithBosEosEnforced.from_pretrained()` defaulted both flags to `True`, overriding tokenizers that intentionally disabled BOS or EOS insertion. This changed token sequences even when callers did not request the behavior.

After this change, NeMo only enables the additional insertion when the caller opts in. Tokenizers that natively add special tokens continue to do so.

## Validation

- `pytest -q tests/unit_tests/_transformers/test_auto_tokenizer.py -k 'not test_converts_tiktoken_tokenizer'` — 57 passed
- isolated TikToken conversion regression test — 1 passed
- `pytest -q tests/functional_tests/data/llm/test_save_pretrained_v4_compat.py` — 5 passed
- Ruff checks passed for all changed files
- `git diff --check` passed
