### PR TITLE
docs(training): mark Mamba prewarm sections for review

### DIFF
--- a/docs/guides/configuration.mdx
+++ b/docs/guides/configuration.mdx
@@ -33,7 +33,7 @@ YAML-native types (such as `step_size: 10` without quotes) are already typed by 
 
 ## Use `_target_` for Instantiation
 
-Any mapping containing a `_target_` key can be instantiated using `ConfigNode.instantiate()`:
+Any mapping containing a `_target_` key can be instantiated using `ConfigNode.instantiate()`.
 
 ```yaml
 model:
@@ -67,7 +67,7 @@ The `distributed:` section is **not** instantiated using `_target_`. Recipes par
 
 {/* docs-review-start: mamba-ssd-prewarm */}
 
-The LLM training, LLM fine-tuning, and VLM fine-tuning recipes accept an optional `prewarm:` section:
+The LLM training, LLM fine-tuning, and VLM fine-tuning recipes accept an optional `prewarm:` section.
 
 ```yaml
 prewarm:
@@ -97,7 +97,7 @@ Triton reuses an autotuned configuration according to each kernel's explicit cac
 
 ## Repair Near-Zero Input Embeddings
 
-The LLM training and fine-tuning recipe can repair a small number of damaged input-embedding rows after loading the base checkpoint and before creating the optimizer:
+The LLM training and fine-tuning recipe can repair a small number of damaged input-embedding rows after loading the base checkpoint and before creating the optimizer.
 
 ```yaml
 embedding_row_repair:
@@ -113,7 +113,7 @@ For diagnosis, safety behavior, verification steps, and performance impact, see 
 
 ### Frozen Multimodal FSDP Policy
 
-FSDP2 uses the correctness-first `root` policy for fully frozen vision/audio towers and multimodal projectors:
+FSDP2 uses the correctness-first `root` policy for fully frozen vision/audio towers and multimodal projectors.
 
 ```yaml
 distributed:
@@ -128,7 +128,7 @@ The supported policies are:
 - `per_layer`: layers inside the frozen multimodal module get their normal FSDP units. This can reduce peak unshard memory, but it is an expert option: every rank in the FSDP group must execute or skip those units the same number of times and in the same order on every microbatch.
 - `replicate`: frozen multimodal parameters are excluded from FSDP and copied on every rank. This removes their collectives at the cost of higher per-rank parameter memory.
 
-This setting does not change modules that contain any trainable parameters. For nested MoE/VLM models, `root` requires `distributed.moe.wrap_outer_model: true` when a fully frozen multimodal module is outside the inner text-model FSDP root. Use `per_layer` or `replicate` if the outer model must remain unwrapped.
+This setting does not change modules that contain any trainable parameters. For nested MoE or VLM models, `root` requires `distributed.moe.wrap_outer_model: true` when a fully frozen multimodal module is outside the inner text-model FSDP root. Use `per_layer` or `replicate` if the outer model must remain unwrapped.
 
 ## Interpolate Environment Variables in YAML
 
@@ -155,6 +155,8 @@ NeMo AutoModel supports env var interpolation inside YAML **string values**.
 
 ### Example (Databricks Delta)
 
+The following configuration shows an example of environment variable interpolation for a Databricks Delta dataset.
+
 ```yaml
 dataset:
   _target_: nemo_automodel.components.datasets.llm.column_mapped_text_instruction_iterable_dataset.ColumnMappedTextInstructionIterableDataset
@@ -167,9 +169,9 @@ dataset:
 
 ## Prevent Secret Leakage in Logs
 
-When an env var placeholder is resolved, the config keeps the original placeholder in an internal `._orig_value` field for **safe printing**:
+When an env var placeholder is resolved, the config keeps the original placeholder in an internal `._orig_value` field for **safe printing**.
 
-- `str(cfg)` / `repr(cfg)` prints placeholders (e.g. `${DATABRICKS_TOKEN}`), not resolved secrets.
+- `str(cfg)` or `repr(cfg)` prints placeholders (for example, `${DATABRICKS_TOKEN}`), not resolved secrets.
 - `cfg.to_yaml_dict(use_orig_values=True, redact_sensitive=True)` is the recommended way to produce a loggable YAML dict.
 
 <Info>

--- a/docs/guides/configuration.mdx
+++ b/docs/guides/configuration.mdx
@@ -65,6 +65,8 @@ The `distributed:` section is **not** instantiated using `_target_`. Recipes par
 
 ## Prewarm One-Time CUDA Initialization
 
+{/* docs-review-start: mamba-ssd-prewarm */}
+
 The LLM training, LLM fine-tuning, and VLM fine-tuning recipes accept an optional `prewarm:` section:
 
 ```yaml
@@ -90,6 +92,8 @@ Adding GPUs helps only when it sufficiently reduces the relevant per-rank tensor
 Triton reuses an autotuned configuration according to each kernel's explicit cache key. The Mamba SSD warmup therefore matches the real head, state, group, chunk, and dtype geometry but uses batch size 1 and two chunks. Batch size and sequence length change the launch grid and activation footprint, but they are not cache keys in the pinned Mamba SSD kernels. Keeping those dimensions small is intentional: using the full training batch and sequence would recreate the peak-memory condition that setup prewarming is meant to avoid.
 
 </Info>
+
+{/* docs-review-end: mamba-ssd-prewarm */}
 
 ## Repair Near-Zero Input Embeddings
 

--- a/docs/guides/llm/finetune.mdx
+++ b/docs/guides/llm/finetune.mdx
@@ -734,6 +734,8 @@ distributed:
   sequence_parallel: false # when true, extends TP to also shard activations along
                           # the sequence dimension for additional memory savings
 
+{/* docs-review-start: mamba-ssd-prewarm */}
+
 # Setup Prewarms (optional)
 # Moves selected one-time CUDA and NCCL initialization work out of the first
 # training step. Leave disabled unless the corresponding lazy initialization
@@ -743,6 +745,8 @@ prewarm:
   fla_gdn_autotune: false  # autotune FLA gated-delta-net Triton kernels during setup
   mamba_ssd_autotune: false # autotune Mamba SSD Triton kernels during setup
   comm_groups: false       # initialize grad-norm communication groups during setup
+
+{/* docs-review-end: mamba-ssd-prewarm */}
 
 # Random Number Generator
 # The recipe constructs its checkpointable, rank-aware StatefulRNG from this seed.

--- a/docs/guides/llm/finetune.mdx
+++ b/docs/guides/llm/finetune.mdx
@@ -366,12 +366,13 @@ The `--nproc-per-node=8` flag specifies the number of GPUs per node. Adjust as n
 
 Alternatively, you can invoke the [`train_ft.py`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/nemo_automodel/recipes/llm/train_ft.py) recipe script directly by using [`torchrun`](https://docs.pytorch.org/docs/stable/elastic/run.html):
 
-``` bash
+```bash
 torchrun --nproc-per-node=8 nemo_automodel/recipes/llm/train_ft.py -c finetune_config.yaml
 ```
 
 ### Sample Output
 Running the recipe with the `automodel` application or by invoking the recipe script directly produces the following log output:
+
 ```
 $ automodel finetune_config.yaml
 INFO:nemo_automodel.cli.app:Config: finetune_config.yaml
@@ -524,7 +525,7 @@ A decreasing validation loss across checkpoints indicates the model is learning.
 
 ### Post-Training Evaluation Using lm-eval-harness
 
-For task-specific benchmarks (e.g., MMLU, GSM8K, and HellaSwag accuracy), use [lm-eval-harness](https://github.com/EleutherAI/lm-evaluation-harness) with the fine-tuned checkpoint. For an intermediate SFT checkpoint, or any SFT run with `save_consolidated: false`, run `bash checkpoints/epoch_0_step_20/model/consolidate.sh` before pointing evaluation at `model/consolidated/`. Create and activate a clean evaluation environment, and then install both model backends before running either command:
+For task-specific benchmarks (for example, MMLU, GSM8K, and HellaSwag accuracy), use [lm-eval-harness](https://github.com/EleutherAI/lm-evaluation-harness) with the fine-tuned checkpoint. For an intermediate SFT checkpoint, or any SFT run with `save_consolidated: false`, run `bash checkpoints/epoch_0_step_20/model/consolidate.sh` before pointing evaluation at `model/consolidated/`. Create and activate a clean evaluation environment, and then install both model backends before running either command:
 
 ```bash
 uv venv --python 3.12 --seed .venv-lm-eval
@@ -553,7 +554,7 @@ load the adapter on top of the base model.
 </Tip>
 
 <Tip>
-Run `lm-eval-harness` on the base model *before* fine-tuning to establish a baseline, and then compare it against the fine-tuned checkpoint.
+Run `lm_eval` on the base model *before* fine-tuning to establish a baseline, and then compare it against the fine-tuned checkpoint.
 
 </Tip>
 
@@ -727,10 +728,10 @@ distributed:
   dp_size: null           # data-parallel group size. null = auto-detect from
                           # world_size ÷ (tp_size × cp_size × pp_size).
   tp_size: 1              # tensor-parallel size: splits weight matrices across GPUs.
-                          # Set to 2, 4, or 8 if the model doesn't fit on one GPU.
+                          # Set to 2, 4, or 8 if the model does not fit on one GPU.
                           # Should divide evenly into the number of attention heads.
   cp_size: 1              # context-parallel size: splits the input sequence across GPUs.
-                          # Increase for very long contexts (e.g., 32k+ tokens).
+                          # Increase for very long contexts (for example, 32k+ tokens).
   sequence_parallel: false # when true, extends TP to also shard activations along
                           # the sequence dimension for additional memory savings
 
@@ -768,7 +769,7 @@ peft:
   _target_: nemo_automodel.components._peft.lora.PeftConfig
   target_modules: "*_proj" # glob pattern matched against fully-qualified layer names;
                            # matches Llama projection layers such as q_proj and down_proj
-  dim: 8                   # low-rank dimension r — controls adapter capacity.
+  dim: 8                   # low-rank dimension r, which controls adapter capacity.
                            # Larger values are more expressive but use more memory.
   alpha: 32                # LoRA scaling factor: adapter output is scaled by alpha/dim.
                            # Higher values give adapters more influence during training.
@@ -781,7 +782,7 @@ peft:
 checkpoint:
   enabled: true            # set to false to skip saving checkpoints entirely
   checkpoint_dir: checkpoints/  # output directory. Docker users: bind-mount this path
-                                # (e.g. -v $(pwd)/checkpoints:/opt/Automodel/checkpoints)
+                                # (for example, -v $(pwd)/checkpoints:/opt/Automodel/checkpoints)
                                 # to persist checkpoints across container restarts.
   model_save_format: safetensors  # "safetensors" (recommended, faster and safer) or
                                   # "torch_save" (legacy pickle-based format)
@@ -809,7 +810,7 @@ validation_dataset:
 # Training Dataloader
 # _target_ → StatefulDataLoader: a checkpointable DataLoader from torchdata that
 # saves and restores iteration state across training restarts, so resumed runs
-# don't re-process already-seen batches.
+# do not re-process already-seen batches.
 dataloader:
   _target_: torchdata.stateful_dataloader.StatefulDataLoader
   collate_fn:
@@ -829,7 +830,7 @@ validation_dataloader:
 
 # Loss Function
 # _target_ → MaskedCrossEntropy: standard cross-entropy loss that automatically
-# ignores padding tokens so they don't affect the gradient.
+# ignores padding tokens so they do not affect the gradient.
 # Other available loss functions (swap _target_ to use):
 #   - nemo_automodel.components.loss.chunked_ce.ChunkedCrossEntropy
 #       Computes CE in chunks along the sequence dimension to reduce peak memory.
@@ -848,7 +849,7 @@ loss_fn:
 # an OptimizerConfig, which receives model parameters when the recipe calls build().
 optimizer:
   _target_: torch.optim.Adam
-  lr: 1.0e-5               # learning rate — the most important hyperparameter to tune
+  lr: 1.0e-5               # learning rate (the most important hyperparameter to tune)
   betas: [0.9, 0.999]      # Adam momentum coefficients (β₁ for mean, β₂ for variance)
   eps: 1e-8                 # small constant added to the denominator for numerical stability
   weight_decay: 0           # L2 regularization strength (0 = no regularization)
@@ -881,7 +882,7 @@ The following table describes the config fields for the fine-tuning recipe.
 | `distributed` | Yes | `dp_size: null` means auto-detect from world size. Adjust `tp_size` for tensor parallelism across GPUs. |
 | `prewarm` | Optional | Enable only the targeted setup warmup associated with a first-step out-of-memory error. See [Prewarm One-Time CUDA Initialization](/get-started/configuration#prewarm-one-time-cuda-initialization). Source: [`prewarm.py`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/nemo_automodel/components/training/prewarm.py). |
 | `checkpoint` | Recommended | Set `checkpoint_dir` to a persistent path, especially in Docker. `save_consolidated` defaults to `final`: intermediate SFT checkpoints are sharded and the final checkpoint also exports consolidated HF weights. |
-| `optimizer` | Yes | Any supported `torch.optim` class can be selected via `_target_`; `RecipeConfig` normalizes it to an `OptimizerConfig` that owns construction. For long fine-tuning, especially full-parameter SFT, see the [mixed-precision training guide](/development/mixed-precision-training) before combining torch AdamW with bf16 resident parameters. |
+| `optimizer` | Yes | Any supported `torch.optim` class can be selected using `_target_`; `RecipeConfig` normalizes it to an `OptimizerConfig` that owns construction. For long fine-tuning, especially full-parameter SFT, see the [mixed-precision training guide](/development/mixed-precision-training) before combining torch AdamW with bf16 resident parameters. |
 | `wandb` | Optional | Uncomment and configure to enable Weights & Biases logging. |
 
 For the fine-tuning recipe itself, see [`train_ft.py`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/nemo_automodel/recipes/llm/train_ft.py).
@@ -1040,7 +1041,7 @@ When choosing a combination, keep these rules in mind:
 - **`world_size` must be evenly divisible by `pp_size × tp_size × cp_size`** so that the quotient is an integer `dp_size`.
 - **`(dp_size × cp_size) % ep_size == 0`**, where EP shares the DP×CP groups.
 - **TP within a node, PP across nodes** is the typical layout. TP requires fast NVLink bandwidth, whereas PP tolerates higher latency.
-- **Start simple.** Use DP-only first. Add TP if the model doesn't fit on one GPU. Add PP for very large models. Add CP for long sequences. Add EP only for MoE architectures.
+- **Start simple.** Use DP-only first. Add TP if the model does not fit on one GPU. Add PP for very large models. Add CP for long sequences. Add EP only for MoE architectures.
 
 ## Next Steps
 


### PR DESCRIPTION
# What does this PR do?

Adds documentation-review markers around the Mamba SSD prewarm documentation that merged in #3296 so Technical Publications can review it in an isolated docs-only PR. This PR does not change the documentation wording.

# Changelog

- Mark the Mamba SSD prewarm section in `docs/guides/configuration.mdx` for documentation review.
- Mark the prewarm configuration example in `docs/guides/llm/finetune.mdx` for documentation review.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] No new tests are needed for marker-only documentation changes.
- [x] Added the documentation-review markers requested for the existing documentation.

# Validation

- `git diff --check` passed.
- MDX syntax validation passed for all 454 MDX files.
- The pinned Fern checker was attempted locally but the login node could not allocate its WebAssembly memory; the PR's Fern CI will run the same check in CI.

# Additional Information

- Follow-up to #3296.
