### PR TITLE
fix(pp): preserve VLM media cursor with static metadata

### DIFF
--- a/examples/vlm_finetune/mistral4/mistral4_medpix.yaml
+++ b/examples/vlm_finetune/mistral4/mistral4_medpix.yaml
@@ -119,7 +119,8 @@ wandb:
 ci:
   recipe_owner: akoumpa
   nodes: 4
-  time: "00:30:00"
+  # Checkpoint robustness reaches resume close to 30 minutes on EOS.
+  time: "01:00:00"
   checkpoint_robustness:
     # PP=4 with pp_microbatch_size=1 requires at least four pipeline microbatches.
     step_scheduler.local_batch_size: 4

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -914,7 +914,9 @@ class Checkpointer:
         state_dict = _maybe_adapt_state_dict_to_hf(
             model_state.model[0],
             state_dict,
-            quantization=self.config.dequantize_base_checkpoint,
+            # Training checkpoints are saved from the dequantized native model.
+            # Only base-checkpoint initialization needs FP8 scale destinations.
+            quantization=bool(is_init_step and self.config.dequantize_base_checkpoint),
             device_mesh=self.moe_mesh,
         )
 

--- a/nemo_automodel/components/datasets/vlm/pp_media.py
+++ b/nemo_automodel/components/datasets/vlm/pp_media.py
@@ -320,7 +320,12 @@ def wrap_vlm_collate_for_pp(
 
 
 def _will_run_forward_metadata_inference(pp: Any) -> bool:
-    """Return whether the next schedule step will probe stage 0 with a real forward."""
+    """Return whether the next schedule step will probe stage 0 with a real forward.
+
+    Both the legacy ``_configure_outputs_meta`` API and the newer populated
+    ``_user_meta`` API provide analytical stage metadata, so neither needs a
+    forward probe. An unpopulated ``_user_meta`` still uses dynamic inference.
+    """
     schedule = getattr(pp.info, "schedule", None)
     stages = getattr(pp.info, "stages", None)
     if schedule is None or not stages:
@@ -328,6 +333,14 @@ def _will_run_forward_metadata_inference(pp: Any) -> bool:
 
     first_stage = next((stage for stage in stages if getattr(stage, "is_first", False)), None)
     if first_stage is None or hasattr(first_stage, "_configure_outputs_meta"):
+        return False
+
+    user_meta = getattr(first_stage, "_user_meta", None)
+    if (
+        user_meta is not None
+        and getattr(user_meta, "inputs", None) is not None
+        and getattr(user_meta, "outputs", None) is not None
+    ):
         return False
 
     if hasattr(schedule, "_stage_forward_initialized"):

--- a/tests/ci_tests/configs/vlm_finetune/SUMMARY.md
+++ b/tests/ci_tests/configs/vlm_finetune/SUMMARY.md
@@ -15,7 +15,7 @@ The nightly scope uses only the recipes listed in [nightly_recipes.yml](nightly_
 | gemma4_26b_a4b_moe | 00:30:00 | 1 |
 | internvl_3_5_4b | 00:10:00 | 1 |
 | ministral3_3b_medpix | 00:10:00 | 1 |
-| mistral4_medpix | 00:30:00 | 4 |
+| mistral4_medpix | 01:00:00 | 4 |
 | nemotron_parse_v1_1 | 00:30:00 | 1 |
 | qwen3_5_4b | 00:30:00 | 1 |
 | qwen3_5_35b | 00:30:00 | 1 |

--- a/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
+++ b/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
@@ -865,9 +865,13 @@ def _get_logits_pp(trainer, input_ids, device) -> torch.Tensor:
         if pp_seq_len:
             return pp_seq_len
         for stage in getattr(trainer.pp.info, "stages", None) or ():
-            for meta in getattr(stage, "inputs_meta", None) or ():
-                if meta.ndim >= 2 and meta.shape[1] > 0:
-                    return meta.shape[1]
+            inputs_meta = getattr(stage, "inputs_meta", None)
+            if not inputs_meta:
+                inputs_meta = getattr(getattr(stage, "_user_meta", None), "inputs", None)
+            for meta in inputs_meta or ():
+                shape = getattr(meta, "shape", ())
+                if len(shape) >= 2 and shape[1] > 0:
+                    return shape[1]
         ds_seq_length = trainer.cfg.get("dataset.seq_length", None)
         return ds_seq_length or orig_seq_len
 

--- a/tests/unit_tests/checkpoint/test_checkpointing.py
+++ b/tests/unit_tests/checkpoint/test_checkpointing.py
@@ -1260,6 +1260,103 @@ def test_load_model_uses_state_dict_adapter_from_ddp_module(tmp_path):
     torch.testing.assert_close(encoder.model.weight, checkpoint_weight)
 
 
+@pytest.mark.parametrize(("is_init_step", "expected_quantization"), [(True, True), (False, False)])
+def test_load_model_only_requests_quantized_adapter_keys_for_base_checkpoint(
+    tmp_path, is_init_step, expected_quantization
+):
+    """FP8 source metadata is requested for base initialization, not training resume."""
+    model = torch.nn.Linear(2, 2, bias=False)
+    adapter = MagicMock()
+    model_state_dict = model.state_dict()
+    adapter.to_hf.return_value = model_state_dict
+    adapter.from_hf.return_value = model_state_dict
+    model.state_dict_adapter = adapter
+
+    config = CheckpointingConfig(
+        checkpoint_dir=str(tmp_path),
+        model_cache_dir=str(tmp_path / "cache"),
+        model_repo_id="test/model",
+        save_consolidated=False,
+        dequantize_base_checkpoint=True,
+    )
+    with patch("torch.distributed.is_initialized", return_value=False):
+        checkpointer = Checkpointer(config, dp_rank=0, tp_rank=0, pp_rank=0)
+
+    with (
+        patch("os.path.exists", return_value=True),
+        patch("nemo_automodel.components.checkpoint.checkpointing._is_safetensors_checkpoint", return_value=False),
+        patch("nemo_automodel.components.checkpoint.checkpointing._is_bin_checkpoint", return_value=False),
+        patch.object(checkpointer, "_get_storage_reader", return_value=None),
+        patch.object(checkpointer, "_do_load", return_value=model_state_dict),
+    ):
+        checkpointer.load_model(model, model_path=str(tmp_path / "model"), is_init_step=is_init_step)
+
+    assert adapter.to_hf.call_args.kwargs["quantization"] is expected_quantization
+
+
+def test_training_checkpoint_resume_ignores_base_fp8_metadata(tmp_path):
+    """A dequantized training checkpoint resumes without source-only FP8 scale keys."""
+
+    class QuantizedSourceAdapter:
+        def to_hf(self, state_dict: dict[str, torch.Tensor], **kwargs: object) -> dict[str, torch.Tensor]:
+            """Convert model state while optionally requesting source FP8 metadata.
+
+            Args:
+                state_dict: Mapping whose tensor values have arbitrary model-defined shapes.
+                **kwargs: Adapter options, including whether source quantization metadata is required.
+
+            Returns:
+                Mapping whose tensor values preserve the input tensors' model-defined shapes,
+                plus a scalar source-only activation scale when quantization is requested.
+            """
+            converted = dict(state_dict)
+            if kwargs.get("quantization", False):
+                converted["weight_activation_scale"] = torch.ones(())
+            return converted
+
+        def from_hf(
+            self,
+            state_dict: dict[str, torch.Tensor],
+            device_mesh: object | None = None,
+        ) -> dict[str, torch.Tensor]:
+            """Convert loaded state back to the native model mapping.
+
+            Args:
+                state_dict: Mapping whose tensor values have arbitrary model-defined shapes.
+                device_mesh: Optional mesh describing the tensors' distributed placements.
+
+            Returns:
+                Mapping whose tensor values preserve the input tensors' model-defined shapes.
+            """
+            return {key: value for key, value in state_dict.items() if key != "weight_activation_scale"}
+
+    model = torch.nn.Linear(2, 2, bias=False)
+    model.state_dict_adapter = QuantizedSourceAdapter()
+    expected_weight = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    with torch.no_grad():
+        model.weight.copy_(expected_weight)
+
+    config = CheckpointingConfig(
+        checkpoint_dir=str(tmp_path),
+        model_save_format="torch_save",
+        model_cache_dir=str(tmp_path / "cache"),
+        model_repo_id="test/model",
+        save_consolidated=False,
+        dequantize_base_checkpoint=True,
+    )
+    with patch("torch.distributed.is_initialized", return_value=False):
+        checkpointer = Checkpointer(config, dp_rank=0, tp_rank=0, pp_rank=0)
+
+    checkpoint_path = tmp_path / "step_1"
+    checkpointer.save_model(model, str(checkpoint_path))
+    with torch.no_grad():
+        model.weight.zero_()
+
+    checkpointer.load_model(model, str(checkpoint_path / "model"))
+
+    torch.testing.assert_close(model.weight, expected_weight)
+
+
 # =============================================================================
 # Tests for load_model: custom model uses DCP path, not the fast safetensors path
 # =============================================================================

--- a/tests/unit_tests/ci_tests/test_checkpoint_robustness_hf_kwargs.py
+++ b/tests/unit_tests/ci_tests/test_checkpoint_robustness_hf_kwargs.py
@@ -46,14 +46,23 @@ from tests.functional_tests.checkpoint_robustness.test_checkpoint_vllm_deploy im
 def test_get_logits_pp_pads_prompt_to_static_stage_sequence_length(metadata_api):
     class _Schedule:
         def __init__(self):
-            self._loss_fn = lambda *_args, **_kwargs: None
+            self._loss_fn = None
             self.ids = None
             self.attention_mask = None
 
         def eval(self, ids, *, target, losses, attention_mask):
+            """Capture a padded pipeline batch and invoke the active loss callback.
+
+            Args:
+                ids: Tensor of shape [batch, sequence].
+                target: Tensor of shape [batch, sequence].
+                losses: Optional list populated by the pipeline loss callback.
+                attention_mask: Tensor of shape [batch, sequence].
+            """
             self.ids = ids
             self.attention_mask = attention_mask
             logits = torch.zeros(ids.shape[0], ids.shape[1], 7)
+            assert self._loss_fn is not None
             self._loss_fn(logits, target)
 
     class _PipelineMesh:

--- a/tests/unit_tests/ci_tests/test_checkpoint_robustness_hf_kwargs.py
+++ b/tests/unit_tests/ci_tests/test_checkpoint_robustness_hf_kwargs.py
@@ -28,6 +28,7 @@ from tests.functional_tests.checkpoint_robustness.test_checkpoint_robustness_llm
     _extract_custom_args,
     _finish_hf_reload_sync,
     _get_input_ids,
+    _get_logits_pp,
     _hf_fp32_module_names,
     _hf_model_load_context,
     _hf_source_load_kwargs,
@@ -39,6 +40,66 @@ from tests.functional_tests.checkpoint_robustness.test_checkpoint_robustness_llm
 )
 from tests.functional_tests.checkpoint_robustness.test_checkpoint_robustness_vlm import _get_vlm_input_ids
 from tests.functional_tests.checkpoint_robustness.test_checkpoint_vllm_deploy import _tokenize_for_generation
+
+
+@pytest.mark.parametrize("metadata_api", ["legacy", "user"])
+def test_get_logits_pp_pads_prompt_to_static_stage_sequence_length(metadata_api):
+    class _Schedule:
+        def __init__(self):
+            self._loss_fn = lambda *_args, **_kwargs: None
+            self.ids = None
+            self.attention_mask = None
+
+        def eval(self, ids, *, target, losses, attention_mask):
+            self.ids = ids
+            self.attention_mask = attention_mask
+            logits = torch.zeros(ids.shape[0], ids.shape[1], 7)
+            self._loss_fn(logits, target)
+
+    class _PipelineMesh:
+        @staticmethod
+        def get_group():
+            return object()
+
+        @staticmethod
+        def size():
+            return 1
+
+    if metadata_api == "legacy":
+        stage = SimpleNamespace(inputs_meta=(torch.empty(1, 16),))
+    else:
+        tensor_meta = SimpleNamespace(shape=torch.Size([1, 16]))
+        stage = SimpleNamespace(_user_meta=SimpleNamespace(inputs=(tensor_meta,), outputs=()))
+
+    schedule = _Schedule()
+    trainer = SimpleNamespace(
+        pp=SimpleNamespace(
+            pp_seq_len=None,
+            info=SimpleNamespace(
+                schedule=schedule,
+                stages=[stage],
+                has_first_stage=True,
+                has_last_stage=True,
+            ),
+        ),
+        pipeline_config=SimpleNamespace(pp_batch_size=1),
+        model_parts=[SimpleNamespace(eval=lambda: None, config=SimpleNamespace(vocab_size=7))],
+        device_mesh={"pp": _PipelineMesh()},
+        cfg=SimpleNamespace(get=lambda *_args: None),
+    )
+
+    with (
+        patch(
+            "tests.functional_tests.checkpoint_robustness.test_checkpoint_robustness_llm.dist.get_global_rank",
+            return_value=0,
+        ),
+        patch("tests.functional_tests.checkpoint_robustness.test_checkpoint_robustness_llm.dist.broadcast"),
+    ):
+        logits = _get_logits_pp(trainer, [11, 12, 13], torch.device("cpu"))
+
+    assert schedule.ids.tolist() == [[11, 12, 13] + [0] * 13]
+    assert schedule.attention_mask.shape == (1, 16)
+    assert logits.shape == (1, 3, 7)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
+++ b/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
@@ -3302,6 +3302,37 @@ class TestChunkVlmMedia:
             assert torch.equal(model(), first_chunk)
             assert model._vlm_chunk_idx == 1
 
+    @pytest.mark.parametrize("schedule_flag", ["_stage_forward_initialized", "_stages_forward_initialized"])
+    def test_stage_media_does_not_replay_with_static_user_metadata(self, schedule_flag):
+        class MediaConsumer(nn.Module):
+            def forward(self):
+                chunk = self._vlm_pixel_values_chunks[self._vlm_chunk_idx]
+                self._vlm_chunk_idx += 1
+                return chunk
+
+        model = MediaConsumer()
+        schedule = SimpleNamespace(**{schedule_flag: False})
+        stage = SimpleNamespace(
+            is_first=True,
+            _user_meta=SimpleNamespace(inputs=(object(),), outputs=(object(),)),
+        )
+        pp = SimpleNamespace(
+            info=SimpleNamespace(has_first_stage=True, schedule=schedule, stages=[stage]),
+        )
+        first_chunk = torch.tensor([1.0])
+        second_chunk = torch.tensor([2.0, 3.0])
+        batch = {
+            VLM_PP_MEDIA_KEY: {
+                "pixel_values": [first_chunk, second_chunk],
+                "image_grid_hws": [torch.ones(1), torch.ones(2)],
+            }
+        }
+
+        with stage_vlm_media_for_pp(pp, [model], batch):
+            assert torch.equal(model(), first_chunk)
+            assert torch.equal(model(), second_chunk)
+            assert model._vlm_chunk_idx == 2
+
     def test_prepare_flat_patches_without_image_grid(self):
         pixel_values = torch.arange(5 * 2 * 2 * 2 * 3).reshape(5, 2, 2, 2, 3)
         batch = {


### PR DESCRIPTION
# What does this PR do ?

Fix the VLM pipeline-parallel media cursor for PyTorch's current static metadata API while preserving the static-metadata behavior introduced by #3290, and fix the training-checkpoint resume problem exposed once that path advanced.

PyTorch now exposes configured stage metadata through populated `_user_meta.inputs` and `_user_meta.outputs`. The VLM staging code mistook that state for dynamic metadata inference and installed a one-shot cursor reset hook. Because no metadata-only forward actually runs with static metadata, the hook fired on the first real microbatch and replayed its media for the second microbatch, eventually triggering the CUDA `masked_scatter_size_check` assertion.

This PR keeps static metadata enabled and narrows the cursor reset to the true dynamic-inference path. It also teaches the checkpoint robustness PP probe to discover the locked sequence length from either the legacy `inputs_meta` API or the current `_user_meta.inputs` API.

The later resume failure had a separate but small checkpoint cause: `dequantize_base_checkpoint` was also being applied to training-checkpoint loads. Training checkpoints are saved from the dequantized native model, so their state does not contain source-only FP8 activation-scale metadata. The load path now requests FP8 scale destinations only during base-checkpoint initialization.

# Changelog

- Recognize populated PyTorch `_user_meta` stage metadata as analytical/static metadata.
- Reset the VLM media cursor only when the schedule will actually run a dynamic metadata forward.
- Read the locked PP sequence length from both legacy and current PyTorch metadata APIs in checkpoint robustness testing.
- Request source FP8 scale metadata only when initializing from a base checkpoint, not when resuming a dequantized training checkpoint.
- Raise the tracked Mistral4 checkpoint-robustness CI allocation from 30 minutes to one hour because the resume phase begins near the old limit.
- Add focused CPU coverage for static and dynamic metadata behavior and for short-prompt padding under both APIs.
- Add a real CPU DCP save/resume round trip that fails if a training resume requests source-only FP8 activation scales.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation? (No user-facing documentation change is required.)

Validation:

- Local focused/unit suites: `375 passed, 8 skipped`; the CI generator's focused tests pass, all 19 `(test_folder, scope)` combinations generate successfully, and full-repository Ruff formatting and checks pass.
- [Scoped CI pipeline 60509730](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/60509730): `mistral4_medpix` completed all 50 normal training steps with static PP metadata and no `masked_scatter` assertion. Its short checkpoint-parity PP forward also passed with the prompt padded to the locked 2047-token metadata contract.
- [Scoped CI pipeline 60523142](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/60523142): the identical case used the tracked 30-minute allocation and [timed out](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/380820451) after 1808 seconds, before it could validate resume.
- [Scoped CI pipeline 60528808](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/60528808): the identical `mistral4_medpix` VLM release case ran on commit `9626201af` with no manual `TIME` override. [Leaf job 380859523](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/380859523) used the tracked `TimeLimit=01:00:00` and completed in about 39 minutes. All 50 normal finetuning steps passed with static PP metadata and no `masked_scatter` assertion; the checkpoint loaded successfully during resume with no missing FP8 activation-scale key.

Scoped CI conclusion:

- Validated by this PR: static PP metadata remains enabled; VLM media chunks advance correctly; the short checkpoint-parity prompt follows the locked PP sequence contract; and a dequantized training checkpoint can be restored without requesting source-only FP8 metadata.
- The final job exit was a Phase 6 loss comparison against an independently trained baseline: step 5 passed (`0.00310 < 0.005`), while step 6 differed by `0.01198` (about 0.66% of the baseline loss). This ambiguity is tracked by [AMINT-227](https://linear.app/nvidia/issue/AMINT-227/redesign-checkpoint-resume-robustness-around-a-shared-training), which proposes comparing resume against the checkpoint-producing run's uninterrupted trajectory.
- Mistral4's separate Phase 0/3/4 forward-parity deltas remain out of scope. Nearly identical failures were present before #3290, so they are not regressions from this PR; they will be investigated separately from this branch.

# Additional Information

- Linear: https://linear.app/nvidia/issue/AMINT-230/cuda-device-side-assert-in-masked-scatter-size-check-due-to
- Resume-harness follow-up: https://linear.app/nvidia/issue/AMINT-227/redesign-checkpoint-resume-robustness-around-a-shared-training
- Preserves the purpose of #3290: static PP metadata remains configured and used; only the obsolete assumption that an uninitialized schedule flag always implies a metadata-only forward is corrected.
