### PR TITLE
fix(distributed): restore Nemotron Flash TP2 training

### DIFF
--- a/nemo_automodel/components/distributed/optimized_tp_plans.py
+++ b/nemo_automodel/components/distributed/optimized_tp_plans.py
@@ -758,6 +758,7 @@ PARALLELIZE_FUNCTIONS: Dict[str, Callable[..., Dict[str, ParallelStyle]]] = {
     _get_class_qualname(CustomQwen3ForCausalLM): _parallelize_qwen,
     # trust_remote_code models — matched by bare class __name__ in parallelizer
     # because their qualname includes a snapshot-hash-bearing module path.
+    "NemotronFlashForCausalLM": _parallelize_llama,
     "DeciLMForCausalLM": _parallelize_decilm_nemotron,
     "NemotronLabsDiffusionModel": _parallelize_nemotron_labs_diffusion,
 }

--- a/nemo_automodel/components/distributed/parallelizer.py
+++ b/nemo_automodel/components/distributed/parallelizer.py
@@ -2277,14 +2277,22 @@ def _get_parallel_plan(
             logger.info("Using default base TP plan. Compatible with huggingface llama3-style models.")
 
     # Nemotron-Flash's forward computes `logits / self.lm_head.weight.norm(p=2, dim=1)`.
-    # Under TP, sharding lm_head turns the weight into a DTensor while `logits` is a
-    # plain tensor (output_layouts=Replicate), and the mixed-operand division raises
-    # "aten.div.Tensor got mixed torch.Tensor and DTensor". Drop lm_head from the plan
-    # so its weight stays replicated and the division stays in plain-tensor space.
+    # The logits and weight norm must therefore either both be plain tensors or both
+    # use the same vocab-sharded DTensor layout.  A replicated-output ColwiseParallel
+    # plan mixes a plain logits tensor with a sharded weight norm, so retain the
+    # historical fallback of dropping that plan.  A vocab-sharded output keeps both
+    # operands aligned and is required under FSDP+TP: leaving lm_head unplanned makes
+    # FSDP expose its weight as a DTensor while the input activation remains local.
     if _is_nemotron_flash_config(getattr(model, "config", None)):
         for k in ("lm_head", "language_model.lm_head"):
-            if model_parallel_plan.pop(k, None) is not None:
-                logger.info("Nemotron-Flash: excluding %s from TP plan to keep lm_head.weight replicated.", k)
+            style = model_parallel_plan.get(k)
+            output_layouts = getattr(style, "output_layouts", ())
+            if not isinstance(output_layouts, (tuple, list)):
+                output_layouts = (output_layouts,)
+            if any(isinstance(layout, Shard) for layout in output_layouts):
+                logger.info("Nemotron-Flash: retaining vocab-sharded %s TP plan.", k)
+            elif model_parallel_plan.pop(k, None) is not None:
+                logger.info("Nemotron-Flash: excluding replicated-output %s from TP plan.", k)
 
     # EP=1 uses this generic FSDP2 path rather than the dedicated MoE
     # parallelizer. Apply the same routed-expert ownership validation here so

--- a/tests/unit_tests/distributed/test_get_parallel_plan.py
+++ b/tests/unit_tests/distributed/test_get_parallel_plan.py
@@ -30,6 +30,8 @@ from types import SimpleNamespace
 from typing import Dict
 
 import pytest
+from torch.distributed.tensor.parallel import ColwiseParallel
+from torch.distributed.tensor.placement_types import Replicate, Shard
 
 # Function under test and collaborators
 import nemo_automodel.components.distributed.parallelizer as parallelizer
@@ -249,6 +251,37 @@ class _RemoteCodeDummyModel:
 
 # Mimic HF's dynamic-module convention so the fail-fast guard triggers.
 _RemoteCodeDummyModel.__module__ = "transformers_modules.fake_repo.modeling_fake"
+
+
+def test_nemotron_flash_remote_code_uses_registered_tp_plan():
+    """Nemotron Flash must retain its validated TP2 path after custom-code fail-fast checks."""
+    model_cls = type("NemotronFlashForCausalLM", (), {})
+    model_cls.__module__ = "transformers_modules.nemotron_flash.modeling_nemotron_flash"
+    model = model_cls()
+    model.config = type(
+        "Config",
+        (),
+        {"model_type": "nemotron_flash", "architectures": ["NemotronFlashForCausalLM"]},
+    )()
+
+    result = _get_parallel_plan(model, sequence_parallel=False, tp_size=2)
+
+    assert "model.layers.*.self_attn.qkv_proj" in result
+    assert "model.layers.*.mlp.gate_up_proj" in result
+    assert any(isinstance(layout, Shard) for layout in result["lm_head"].output_layouts)
+    assert result["lm_head"].use_local_output is False
+
+
+def test_nemotron_flash_drops_replicated_output_lm_head_plan():
+    """Nemotron Flash must not mix replicated logits with a sharded lm_head norm."""
+    model_cls = type("NemotronFlashForCausalLM", (), {})
+    model = model_cls()
+    model.config = SimpleNamespace(model_type="nemotron_flash")
+    custom_plan = {"lm_head": ColwiseParallel(output_layouts=Replicate())}
+
+    result = _get_parallel_plan(model, tp_shard_plan=custom_plan, tp_size=2)
+
+    assert "lm_head" not in result
 
 
 def test_default_plan_fallthrough_raises_for_remote_code_at_tp_size_gt_1(monkeypatch):


### PR DESCRIPTION
# What does this PR do ?

Restores the Nemotron-Flash TP2 checkpoint-robustness path that regressed when custom-code architectures without registered tensor-parallel plans began failing fast.

# Changelog

- Register `NemotronFlashForCausalLM` for the validated Llama-shaped tensor-parallel plan.
- Keep the Nemotron-Flash `lm_head` vocab-sharded when its TP output is also sharded, so the model's custom logits/weight-norm division uses compatible DTensors under FSDP+TP.
- Preserve the historical fallback that drops replicated-output `lm_head` plans.
- Add regression coverage for dynamic `trust_remote_code` class-name matching and both `lm_head` layout paths.

# Root cause

The checkpoint-robustness CI overrides the PEFT recipe to TP2. After the custom-code TP-plan fail-fast was introduced, `NemotronFlashForCausalLM` was not registered and training stopped during model setup, before the robustness phase could write `robustness_checkpoint/epoch_*_step_*`. Registering only the backbone plan exposed a second incompatibility: leaving the LoRA-wrapped `lm_head` unplanned under FSDP+TP mixed a local activation with a DTensor weight. The vocab-sharded output plan keeps the custom normalization operands aligned.

# Validation

- `python -m pytest -q tests/unit_tests/distributed/test_get_parallel_plan.py tests/unit_tests/distributed/test_optimized_tp_plans.py` — 62 passed.
- `ruff format --check` and `ruff check` on all changed files — passed.
- Interactive Slurm job `14795660`, existing nightly image, 8x H100, TP2/DP4, real `nvidia/Nemotron-Flash-1B`, LoRA: two finite optimizer steps completed and wrote `epoch_0_step_1` with adapter, optimizer DCP metadata, scheduler, and all DP RNG/dataloader states.
- Reloaded `epoch_0_step_1` on the same TP2/DP4 topology successfully (exit 0).

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation? (No user-facing documentation change is needed.)

# Additional Information

- Linear: AMINT-234
