### PR TITLE
fix(model): correct Mistral4 attention and distributed MoE routing

### DIFF
--- a/examples/vlm_finetune/mistral4/mistral4_medpix.yaml
+++ b/examples/vlm_finetune/mistral4/mistral4_medpix.yaml
@@ -125,8 +125,10 @@ ci:
     # PP=4 with pp_microbatch_size=1 requires at least four pipeline microbatches.
     step_scheduler.local_batch_size: 4
     check_source_load_parity: true
-    # Native TE/SDPA and vanilla HF follow different BF16 execution paths.
-    # Keep checkpoint reload parity exact while bounding the stable implementation delta.
+    # Fresh PP4/EP8 DCP and consolidated reloads are bit-identical to each other,
+    # but both differ from the still-warm in-memory runtime. Bound that distributed
+    # BF16 execution delta separately from the native-vs-HF implementation delta.
+    kl_threshold: 5e-2
     source_load_kl_threshold: 1e-2
     source_load_mean_kl_threshold: 2e-3
     source_load_cosine_threshold: 0.999

--- a/examples/vlm_finetune/mistral4/mistral4_medpix.yaml
+++ b/examples/vlm_finetune/mistral4/mistral4_medpix.yaml
@@ -125,6 +125,12 @@ ci:
     # PP=4 with pp_microbatch_size=1 requires at least four pipeline microbatches.
     step_scheduler.local_batch_size: 4
     check_source_load_parity: true
+    # Native TE/SDPA and vanilla HF follow different BF16 execution paths.
+    # Keep checkpoint reload parity exact while bounding the stable implementation delta.
+    source_load_kl_threshold: 1e-2
+    source_load_mean_kl_threshold: 2e-3
+    source_load_cosine_threshold: 0.999
+    hf_kl_threshold: 5e-2
     hf_device_map_auto: true
     # Transformers' load-time dequantization leaves Mistral4 expert weights in
     # FP8, while native forward requires an optional kernel absent from CI.

--- a/nemo_automodel/components/models/kimi_k3/model.py
+++ b/nemo_automodel/components/models/kimi_k3/model.py
@@ -1000,7 +1000,21 @@ class KimiK3Gate(Gate):
         token_mask: torch.Tensor,
         cp_mesh: Any = None,
     ) -> tuple[torch.Tensor, torch.Tensor, None]:
-        """Route ``[tokens, hidden]`` states and return fp32 top-k weights."""
+        """Route local token states and return fp32 top-k weights.
+
+        Args:
+            hidden_states: Tensor of shape [tokens, hidden] containing this rank's
+                local token states.
+            token_mask: Boolean tensor of shape [tokens]. Kimi K3 currently routes
+                every supplied token, so this mask is unused.
+            cp_mesh: Optional context-parallel mesh. Kimi K3 currently operates on
+                already-local token states, so this mesh is unused.
+
+        Returns:
+            Tuple containing fp32 routing weights of shape
+            [tokens, activated_experts], expert indices of shape
+            [tokens, activated_experts], and ``None`` for auxiliary loss.
+        """
         del token_mask, cp_mesh
         logits = F.linear(hidden_states.float(), self.weight.float(), None)
         if self.score_func == "sigmoid_with_bias":
@@ -1011,8 +1025,9 @@ class KimiK3Gate(Gate):
             raise ValueError(f"Kimi K3 requires a correction-bias router, got {self.score_func!r}.")
 
         scores_for_choice = scores
-        if self.e_score_correction_bias is not None:
-            scores_for_choice = scores_for_choice + self.e_score_correction_bias.unsqueeze(0)
+        correction_bias = self._local_score_correction_bias()
+        if correction_bias is not None:
+            scores_for_choice = scores_for_choice + correction_bias.unsqueeze(0)
         if self.n_groups > 1 and self.n_groups > self.topk_groups:
             grouped = scores_for_choice.view(hidden_states.shape[0], self.n_groups, -1)
             group_scores = grouped.topk(2, dim=-1)[0].sum(dim=-1)

--- a/nemo_automodel/components/models/mistral4/model.py
+++ b/nemo_automodel/components/models/mistral4/model.py
@@ -31,6 +31,7 @@ from nemo_automodel.components.models.common.tie_word_embeddings import (
     TieSupport,
     reject_unsupported_tie_word_embeddings,
 )
+from nemo_automodel.components.models.common.utils import cast_model_to_dtype
 from nemo_automodel.components.models.deepseek_v3.layers import MLA
 from nemo_automodel.components.models.deepseek_v3.model import Block
 from nemo_automodel.components.models.deepseek_v3.rope_utils import (
@@ -335,6 +336,7 @@ class Mistral4Model(nn.Module):
 
 class Mistral4ForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
     tie_word_embeddings_support: TieSupport = TieSupport.UNTIED_ONLY
+    _keep_in_fp32_modules_strict = ["e_score_correction_bias"]
 
     @dataclass(frozen=True)
     class ModelCapabilities:
@@ -472,7 +474,7 @@ class Mistral4ForCausalLM(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
                     b=cutoff_factor * final_out_std,
                 )
 
-        self.to(dtype)
+        cast_model_to_dtype(self, dtype)
         with buffer_device:
             rope_theta, rope_scaling, _ = get_rope_config(self.config)
             self.model.freqs_cis = precompute_freqs_cis(
@@ -709,6 +711,7 @@ if _HF_MISTRAL3_AVAILABLE:
         # Head lives in the Mistral4 text backbone (separate lm_head, no tie
         # mechanism); the controlling flag is on the nested text_config.
         tie_word_embeddings_support: TieSupport = TieSupport.UNTIED_ONLY
+        _keep_in_fp32_modules_strict = ["e_score_correction_bias"]
 
         @dataclass(frozen=True)
         class ModelCapabilities:
@@ -914,7 +917,7 @@ if _HF_MISTRAL3_AVAILABLE:
                         b=cutoff_factor * final_out_std,
                     )
 
-            self.to(dtype)
+            cast_model_to_dtype(self, dtype)
 
 
 ModelClass = Mistral4ForCausalLM

--- a/nemo_automodel/components/models/mistral4/model.py
+++ b/nemo_automodel/components/models/mistral4/model.py
@@ -58,12 +58,25 @@ def _get_llama_4_attn_scale(position_ids: torch.Tensor, beta: float, max_positio
 class Mistral4MLA(MLA):
     """MLA with Llama 4 attention scaling for Mistral 4.
 
-    Compared to DeepSeek V3 MLA, adds position-dependent scaling to q_pe after RoPE
+    Compared to DeepSeek V3 MLA, adds position-dependent scaling to the query after RoPE
     (llama_4_scaling_beta). RoPE itself uses the same complex-number approach as DSV3.
     """
 
     def __init__(self, config, backend: BackendConfig):
         super().__init__(config, backend)
+        # DeepSeek V3 folds YaRN's mscale into the attention softmax scale. Mistral 4
+        # instead keeps the standard qk head-dimension scale and applies its separate
+        # Llama 4 position-dependent multiplier directly to the query.
+        from nemo_automodel.components.attention.utils import initialize_attn_module_and_func
+
+        self.softmax_scale = self.qk_head_dim**-0.5
+        self.attn_module, self.attn_func = initialize_attn_module_and_func(
+            attn_impl=backend.attn,
+            num_attention_heads=self.n_heads,
+            num_qk_channels=self.qk_head_dim,
+            num_v_channels=self.v_head_dim,
+            softmax_scale=self.softmax_scale,
+        )
         rope_parameters = config.rope_parameters if hasattr(config, "rope_parameters") else config.rope_scaling
         self.llama_4_scaling_beta = rope_parameters.get("llama_4_scaling_beta") if rope_parameters else None
         self.llama_4_orig_max_pos = rope_parameters.get("original_max_position_embeddings") if rope_parameters else None
@@ -74,7 +87,20 @@ class Mistral4MLA(MLA):
         freqs_cis: torch.Tensor,
         attention_mask: torch.Tensor | None = None,
         **attn_kwargs: Any,
-    ):
+    ) -> torch.Tensor:
+        """Apply Mistral 4 multi-head latent attention.
+
+        Args:
+            x: Tensor of shape [batch, sequence, hidden] for BSHD input or [tokens, hidden] for THD input.
+            freqs_cis: Rotary frequencies of shape [batch, sequence, rope_dim / 2] for non-fused BSHD,
+                [tokens, rope_dim / 2] for non-fused THD, or [sequence, 1, 1, rope_dim] for fused RoPE.
+            attention_mask: Optional tensor of shape [batch, sequence] or an explicit mask broadcastable to
+                [batch, heads, query_sequence, key_sequence].
+            **attn_kwargs: Backend metadata such as packed-sequence offsets, position IDs, and CP rank information.
+
+        Returns:
+            Tensor of shape [batch, sequence, hidden] for BSHD input or [tokens, hidden] for THD input.
+        """
         from nemo_automodel.components.attention.utils import (
             postprocess_output_for_attn,
             preprocess_args_and_kwargs_for_attn,
@@ -119,18 +145,18 @@ class Mistral4MLA(MLA):
             cp_rank=attn_kwargs.get("cp_rank", 0),
         )
 
-        # Llama 4 attention scaling on q_pe (no-op for positions < orig_max_pos)
+        q = torch.cat([q_nope, q_pe], dim=-1)
+
+        # Llama 4 attention scaling on the full query (no-op for positions < orig_max_pos).
         if self.llama_4_scaling_beta is not None:
             position_ids = attn_kwargs.get("position_ids", None)
             if position_ids is not None:
                 attn_scale = _get_llama_4_attn_scale(
                     position_ids, self.llama_4_scaling_beta, self.llama_4_orig_max_pos
-                ).to(q_pe.dtype)
-                q_pe = q_pe * attn_scale.unsqueeze(-1)
+                ).to(q.dtype)
+                q = q * attn_scale.unsqueeze(-1)
 
         k_pe = k_pe.squeeze(head_unsqueeze_dim)
-
-        q = torch.cat([q_nope, q_pe], dim=-1)
 
         kv = self.kv_b_proj(kv)
         if qkv_format == "thd":

--- a/nemo_automodel/components/moe/layers.py
+++ b/nemo_automodel/components/moe/layers.py
@@ -16,7 +16,6 @@ from functools import partial
 from typing import Optional
 
 import torch
-import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.distributed.device_mesh import DeviceMesh
@@ -291,12 +290,6 @@ class Gate(nn.Module):
 
         self.e_score_correction_bias_master = None
 
-        # Runtime-only mesh used to aggregate token counts before updating the
-        # replicated score-correction bias. FSDP2 shards parameters but leaves
-        # buffers as ordinary tensors, so the bias cannot infer its reduction
-        # group from DTensor metadata in the common distributed path.
-        self._expert_load_mesh: Optional[DeviceMesh] = None
-
         # Cumulative expert load is a tensor representing the number of tokens
         # routed to each expert on the current rank, accumulated across gradient
         # accumulation steps.
@@ -315,13 +308,31 @@ class Gate(nn.Module):
         self.routing_core = _GateRoutingCore()
         self.use_routing_core = False
 
-    def _set_expert_load_mesh(self, mesh: Optional[DeviceMesh]) -> None:
-        """Set the runtime mesh used to aggregate expert load before bias updates."""
-        self._expert_load_mesh = mesh
+    def _local_score_correction_bias(self) -> torch.Tensor | None:
+        """Return the local tensor used to adjust this rank's routing scores.
+
+        Returns:
+            Tensor of shape [experts] replicated across the gate's DP/CP mesh, or
+            ``None`` when score correction is disabled. The returned tensor aliases
+            the registered correction-bias buffer.
+        """
+        if isinstance(self.e_score_correction_bias, DTensor):
+            return self.e_score_correction_bias.to_local()
+        return self.e_score_correction_bias
 
     def _route_scores(self, scores: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
-        """Apply fixed-shape expert selection and probability math to router logits."""
+        """Apply fixed-shape expert selection and probability math to router logits.
+
+        Args:
+            scores: Tensor of shape [tokens, experts] containing local router logits.
+
+        Returns:
+            Tuple containing routing weights of shape [tokens, activated_experts],
+            expert indices of shape [tokens, activated_experts], and optional
+            original routing scores of shape [tokens, experts].
+        """
         num_tokens = scores.size(0)
+        correction_bias = self._local_score_correction_bias()
 
         if self.score_func == "softmax":
             if self.softmax_before_topk:
@@ -349,8 +360,8 @@ class Gate(nn.Module):
             original_scores = scores
 
             # Add correction bias for expert SELECTION only
-            if self.e_score_correction_bias is not None:
-                scores_for_choice = scores + self.e_score_correction_bias
+            if correction_bias is not None:
+                scores_for_choice = scores + correction_bias
             else:
                 scores_for_choice = scores
 
@@ -371,8 +382,8 @@ class Gate(nn.Module):
             scores = torch.sqrt(F.softplus(scores.float()))
             original_scores = scores
 
-            if self.e_score_correction_bias is not None:
-                scores = scores + self.e_score_correction_bias
+            if correction_bias is not None:
+                scores = scores + correction_bias
 
             indices = torch.topk(scores, self.topk, dim=-1)[1]
             indices = replay_selection(self.router_replay, indices)
@@ -382,8 +393,8 @@ class Gate(nn.Module):
             original_scores = scores
             scores_for_choice = scores
 
-            if self.e_score_correction_bias is not None:
-                scores_for_choice = scores_for_choice + self.e_score_correction_bias
+            if correction_bias is not None:
+                scores_for_choice = scores_for_choice + correction_bias
 
             if self.n_groups > 1:
                 scores_for_choice = scores_for_choice.view(num_tokens, self.n_groups, -1)
@@ -403,12 +414,12 @@ class Gate(nn.Module):
             original_scores = scores
 
             # Add correction bias to balance tokens across gates.
-            if self.e_score_correction_bias is not None:
-                scores = scores + self.e_score_correction_bias
+            if correction_bias is not None:
+                scores = scores + correction_bias
 
             if self.n_groups > 1:
                 scores = scores.view(num_tokens, self.n_groups, -1)
-                if self.e_score_correction_bias is None:
+                if correction_bias is None:
                     group_scores = scores.amax(dim=-1)
                 else:
                     group_scores = scores.topk(2, dim=-1)[0].sum(dim=-1)
@@ -533,14 +544,6 @@ class Gate(nn.Module):
                 placements=[Partial()] * self.e_score_correction_bias.device_mesh.ndim,
             )
             expert_load = expert_load.full_tensor()
-        elif self._expert_load_mesh is not None and self._expert_load_mesh.size() > 1:
-            for mesh_dim in self._expert_load_mesh.mesh_dim_names:
-                dist.all_reduce(
-                    expert_load,
-                    op=dist.ReduceOp.SUM,
-                    group=self._expert_load_mesh.get_group(mesh_dim),
-                )
-
         # 2) Compute the bias update by comparing the expert load to the average expert load.
         expert_load = expert_load.float()
         average_expert_load = expert_load.mean()

--- a/nemo_automodel/components/moe/layers.py
+++ b/nemo_automodel/components/moe/layers.py
@@ -16,6 +16,7 @@ from functools import partial
 from typing import Optional
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.distributed.device_mesh import DeviceMesh
@@ -290,6 +291,12 @@ class Gate(nn.Module):
 
         self.e_score_correction_bias_master = None
 
+        # Runtime-only mesh used to aggregate token counts before updating the
+        # replicated score-correction bias. FSDP2 shards parameters but leaves
+        # buffers as ordinary tensors, so the bias cannot infer its reduction
+        # group from DTensor metadata in the common distributed path.
+        self._expert_load_mesh: Optional[DeviceMesh] = None
+
         # Cumulative expert load is a tensor representing the number of tokens
         # routed to each expert on the current rank, accumulated across gradient
         # accumulation steps.
@@ -307,6 +314,10 @@ class Gate(nn.Module):
         )
         self.routing_core = _GateRoutingCore()
         self.use_routing_core = False
+
+    def _set_expert_load_mesh(self, mesh: Optional[DeviceMesh]) -> None:
+        """Set the runtime mesh used to aggregate expert load before bias updates."""
+        self._expert_load_mesh = mesh
 
     def _route_scores(self, scores: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
         """Apply fixed-shape expert selection and probability math to router logits."""
@@ -522,6 +533,13 @@ class Gate(nn.Module):
                 placements=[Partial()] * self.e_score_correction_bias.device_mesh.ndim,
             )
             expert_load = expert_load.full_tensor()
+        elif self._expert_load_mesh is not None and self._expert_load_mesh.size() > 1:
+            for mesh_dim in self._expert_load_mesh.mesh_dim_names:
+                dist.all_reduce(
+                    expert_load,
+                    op=dist.ReduceOp.SUM,
+                    group=self._expert_load_mesh.get_group(mesh_dim),
+                )
 
         # 2) Compute the bias update by comparing the expert load to the average expert load.
         expert_load = expert_load.float()

--- a/nemo_automodel/components/moe/layers.py
+++ b/nemo_automodel/components/moe/layers.py
@@ -308,6 +308,73 @@ class Gate(nn.Module):
         self.routing_core = _GateRoutingCore()
         self.use_routing_core = False
 
+    def _load_from_state_dict(
+        self,
+        state_dict: dict[str, torch.Tensor],
+        prefix: str,
+        local_metadata: dict[str, object],
+        strict: bool,
+        missing_keys: list[str],
+        unexpected_keys: list[str],
+        error_msgs: list[str],
+    ) -> None:
+        """Load gate state while preserving the routing-bias DTensor layout.
+
+        Args:
+            state_dict: State mapping whose correction bias is either a full tensor
+                of shape ``[experts]`` or an already distributed tensor.
+            prefix: Prefix applied to this module's state-dict keys.
+            local_metadata: Metadata saved for this module.
+            strict: Whether state-dict keys must match exactly.
+            missing_keys: Missing state-dict keys collected during loading.
+            unexpected_keys: Unexpected state-dict keys collected during loading.
+            error_msgs: State-dict loading errors collected during loading.
+
+        Raises:
+            RuntimeError: If a full correction-bias tensor targets an incompatible
+                shape or a DTensor that is not replicated on every mesh dimension.
+        """
+        bias_key = f"{prefix}e_score_correction_bias"
+        target_bias = self.e_score_correction_bias
+        checkpoint_bias = state_dict.get(bias_key)
+
+        if (
+            isinstance(target_bias, DTensor)
+            and isinstance(checkpoint_bias, torch.Tensor)
+            and not isinstance(checkpoint_bias, DTensor)
+        ):
+            if checkpoint_bias.shape != target_bias.shape:
+                raise RuntimeError(
+                    f"Cannot load {bias_key}: checkpoint shape {checkpoint_bias.shape} does not match "
+                    f"the routing bias global shape {target_bias.shape}."
+                )
+            if not all(isinstance(placement, Replicate) for placement in target_bias.placements):
+                raise RuntimeError(
+                    f"Cannot load a full tensor into {bias_key}: the routing bias DTensor must be replicated "
+                    f"on every mesh dimension, but has placements {target_bias.placements}."
+                )
+
+            local_target = target_bias.to_local()
+            local_bias = checkpoint_bias.to(device=local_target.device, dtype=local_target.dtype)
+            state_dict[bias_key] = DTensor.from_local(
+                local_bias,
+                device_mesh=target_bias.device_mesh,
+                placements=target_bias.placements,
+                run_check=False,
+                shape=target_bias.shape,
+                stride=target_bias.stride(),
+            )
+
+        super()._load_from_state_dict(
+            state_dict,
+            prefix,
+            local_metadata,
+            strict,
+            missing_keys,
+            unexpected_keys,
+            error_msgs,
+        )
+
     def _local_score_correction_bias(self) -> torch.Tensor | None:
         """Return the local tensor used to adjust this rank's routing scores.
 

--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -36,6 +36,7 @@ from nemo_automodel.components.distributed import parallelizer_utils
 from nemo_automodel.components.distributed.pipelining.hf_utils import get_text_module
 from nemo_automodel.components.moe.experts import GroupedExpertsDeepEP, GroupedExpertsTE
 from nemo_automodel.components.moe.layers import (
+    Gate,
     MoE,
 )
 from nemo_automodel.components.moe.tp_plan_validation import _validate_moe_tp_plan
@@ -682,6 +683,12 @@ def apply_fsdp(
 
     for block in _iter_moe_blocks(model, _model):
         moe_module = _get_moe_module(block)
+        gate = getattr(moe_module, "gate", None)
+        if isinstance(gate, Gate):
+            # FSDP2 does not convert buffers to DTensors. Give the learned
+            # load-balancing bias the same DP/CP mesh used for dense state so
+            # every replica applies one globally consistent routing update.
+            gate._set_expert_load_mesh(fsdp_mesh)
         experts_reshard_after_forward = False if id(block) in mtp_block_ids else reshard_after_forward
         if isinstance(moe_module, MoE) and ep_shard_enabled:
             # Apply FSDP on dim=1 for grouped experts since we may have more

--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -28,7 +28,7 @@ from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.fsdp import fully_shard
 from torch.distributed.fsdp._fully_shard import MixedPrecisionPolicy, OffloadPolicy
-from torch.distributed.tensor import Shard, distribute_module, distribute_tensor
+from torch.distributed.tensor import Replicate, Shard, distribute_module, distribute_tensor
 from torch.distributed.tensor.parallel import ParallelStyle, parallelize_module
 from torch.utils.checkpoint import CheckpointPolicy, create_selective_checkpoint_contexts
 
@@ -684,11 +684,15 @@ def apply_fsdp(
     for block in _iter_moe_blocks(model, _model):
         moe_module = _get_moe_module(block)
         gate = getattr(moe_module, "gate", None)
-        if isinstance(gate, Gate):
-            # FSDP2 does not convert buffers to DTensors. Give the learned
-            # load-balancing bias the same DP/CP mesh used for dense state so
-            # every replica applies one globally consistent routing update.
-            gate._set_expert_load_mesh(fsdp_mesh)
+        if isinstance(gate, Gate) and gate.e_score_correction_bias is not None:
+            # FSDP2 does not convert buffers to DTensors. Replicate the routing
+            # bias over the full DP/CP mesh so its existing Partial-to-Replicate
+            # update path aggregates every rank's expert load.
+            gate.e_score_correction_bias = distribute_tensor(
+                gate.e_score_correction_bias,
+                device_mesh=fsdp_mesh,
+                placements=[Replicate()] * fsdp_mesh.ndim,
+            )
         experts_reshard_after_forward = False if id(block) in mtp_block_ids else reshard_after_forward
         if isinstance(moe_module, MoE) and ep_shard_enabled:
             # Apply FSDP on dim=1 for grouped experts since we may have more

--- a/tests/ci_tests/scripts/finetune_launcher.sh
+++ b/tests/ci_tests/scripts/finetune_launcher.sh
@@ -21,9 +21,22 @@
 
 cd /opt/Automodel
 
-# VLM recipes need qwen-vl-utils/opencv from the opt-in vlm-media extra, kept out of the image.
+# VLM recipes need the opt-in vlm-media packages kept out of the image. Install
+# those packages directly instead of resolving the local project again, which
+# can refetch unrelated Git dependencies already present in the image.
 case "$CONFIG_PATH" in
-    *vlm_finetune*) uv pip install ".[vlm-media]" ;;
+    *vlm_finetune*)
+        VLM_MEDIA_PACKAGES=(
+            albumentations
+            "opencv-python-headless==4.10.0.84"
+            qwen-omni-utils
+            qwen-vl-utils
+        )
+        if [[ "$(uname -m)" == "x86_64" ]]; then
+            VLM_MEDIA_PACKAGES+=(decord)
+        fi
+        uv pip install "${VLM_MEDIA_PACKAGES[@]}"
+        ;;
 esac
 
 CONFIG_RESOLVER="python3 /opt/Automodel/tests/ci_tests/scripts/config_resolver.py"

--- a/tests/functional_tests/moe/test_ernie_fp32_router_fsdp.py
+++ b/tests/functional_tests/moe/test_ernie_fp32_router_fsdp.py
@@ -24,7 +24,7 @@ import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
 import torch.nn.functional as F
-from torch.distributed.tensor import DTensor
+from torch.distributed.tensor import DTensor, Replicate
 from transformers.models.ernie4_5_moe.configuration_ernie4_5_moe import Ernie4_5_MoeConfig
 
 from nemo_automodel.components.distributed.config import FSDP2Config
@@ -128,6 +128,8 @@ def _worker(rank: int, port: int) -> None:
 
         assert moe.gate.weight.dtype == torch.float32
         assert moe.gate.e_score_correction_bias.dtype == torch.float32
+        assert isinstance(moe.gate.e_score_correction_bias, DTensor)
+        assert all(isinstance(placement, Replicate) for placement in moe.gate.e_score_correction_bias.placements)
         assert moe.experts.gate_and_up_projs.dtype == torch.bfloat16
 
         gate_observation: dict[str, torch.Tensor] = {}
@@ -174,6 +176,16 @@ def _worker(rank: int, port: int) -> None:
         assert moe.gate.weight.grad is not None
         assert moe.gate.weight.grad.dtype == torch.float32
         assert torch.isfinite(moe.gate.weight.grad.to_local()).all()
+
+        moe.gate.train_gate = True
+        moe.gate.bias_update_factor = 0.1
+        local_expert_load = torch.zeros(moe.gate.n_experts, device=rank)
+        local_expert_load[rank] = 8
+        moe.gate._cumulative_expert_load = local_expert_load
+        moe.gate.update_bias()
+
+        expected_bias = torch.tensor([-0.1, -0.1, 0.1, 0.1], device=rank)
+        torch.testing.assert_close(moe.gate.e_score_correction_bias.to_local(), expected_bias)
     finally:
         if dist.is_initialized():
             dist.destroy_process_group()

--- a/tests/unit_tests/ci_tests/test_config_resolver.py
+++ b/tests/unit_tests/ci_tests/test_config_resolver.py
@@ -374,6 +374,7 @@ def test_vlm_checkpoint_robustness_recipes_resolve(tmp_path, recipe_path):
         assert robustness["hf_device_map_auto"] is True
     if "/mistral4/" in recipe_path:
         assert robustness["hf_source_post_load_dequantize"] is True
+        assert robustness["kl_threshold"] == 5e-2
         assert robustness["source_load_kl_threshold"] == 1e-2
         assert robustness["source_load_mean_kl_threshold"] == 2e-3
         assert robustness["source_load_cosine_threshold"] == 0.999

--- a/tests/unit_tests/ci_tests/test_config_resolver.py
+++ b/tests/unit_tests/ci_tests/test_config_resolver.py
@@ -374,6 +374,10 @@ def test_vlm_checkpoint_robustness_recipes_resolve(tmp_path, recipe_path):
         assert robustness["hf_device_map_auto"] is True
     if "/mistral4/" in recipe_path:
         assert robustness["hf_source_post_load_dequantize"] is True
+        assert robustness["source_load_kl_threshold"] == 1e-2
+        assert robustness["source_load_mean_kl_threshold"] == 2e-3
+        assert robustness["source_load_cosine_threshold"] == 0.999
+        assert robustness["hf_kl_threshold"] == 5e-2
     if Path(recipe_path).stem == "qwen3_vl_moe_30b_te_deepep":
         assert robustness["resume_loss_threshold"] == 1e-2
     if Path(recipe_path).stem == "qwen3_5_35b":
@@ -387,9 +391,7 @@ def test_vlm_checkpoint_robustness_recipes_resolve(tmp_path, recipe_path):
         assert robustness["source_load_cosine_threshold"] == 0.9985
         assert robustness["source_load_kl_threshold"] == 1e-1
         assert robustness["source_load_mean_kl_threshold"] == 1e-2
-        assert resolved["loss_fn"]["_target_"] == (
-            "nemo_automodel.components.loss.chunked_ce.ChunkedCrossEntropy"
-        )
+        assert resolved["loss_fn"]["_target_"] == ("nemo_automodel.components.loss.chunked_ce.ChunkedCrossEntropy")
         assert resolved["model"]["backend"]["experts"] == "torch_mm"
         assert resolved["step_scheduler"]["global_batch_size"] == 16
         assert resolved["step_scheduler"]["local_batch_size"] == 1

--- a/tests/unit_tests/models/mistral4/test_mistral4_attention_contract.py
+++ b/tests/unit_tests/models/mistral4/test_mistral4_attention_contract.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.models.mistral4.configuration import Mistral4Config
+from nemo_automodel.components.models.mistral4.model import Mistral4MLA, _get_llama_4_attn_scale
+
+
+def _tiny_long_context_config() -> Mistral4Config:
+    return Mistral4Config(
+        vocab_size=32,
+        hidden_size=8,
+        intermediate_size=16,
+        moe_intermediate_size=4,
+        num_hidden_layers=1,
+        num_attention_heads=1,
+        num_key_value_heads=1,
+        n_shared_experts=1,
+        n_routed_experts=2,
+        kv_lora_rank=2,
+        q_lora_rank=None,
+        qk_rope_head_dim=2,
+        v_head_dim=2,
+        qk_nope_head_dim=2,
+        n_group=1,
+        topk_group=1,
+        num_experts_per_tok=1,
+        max_position_embeddings=1048576,
+        torch_dtype=torch.float32,
+    )
+
+
+def _torch_backend() -> BackendConfig:
+    return BackendConfig(
+        attn="sdpa",
+        linear="torch",
+        rms_norm="torch",
+        rope_fusion=False,
+        enable_hf_state_dict_adapter=False,
+    )
+
+
+def test_mistral4_uses_standard_qk_attention_scale() -> None:
+    config = _tiny_long_context_config()
+    attention = Mistral4MLA(config, _torch_backend())
+    expected_scale = config.qk_head_dim**-0.5
+
+    assert attention.softmax_scale == pytest.approx(expected_scale)
+
+    query = torch.zeros(1, 1, 1, config.qk_head_dim)
+    key = torch.zeros_like(query)
+    value = torch.zeros(1, 1, 1, config.v_head_dim)
+    with patch("nemo_automodel.components.attention.utils.F.scaled_dot_product_attention") as sdpa:
+        sdpa.return_value = torch.zeros_like(value)
+        attention.attn_func(query, key, value)
+
+    assert sdpa.call_args.kwargs["scale"] == pytest.approx(expected_scale)
+
+
+def test_mistral4_long_context_scale_applies_to_full_query() -> None:
+    config = _tiny_long_context_config()
+    attention = Mistral4MLA(config, _torch_backend())
+    captured_queries: list[torch.Tensor] = []
+
+    def capture_attention(
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        **kwargs: object,
+    ) -> torch.Tensor:
+        """Capture SDPA inputs while returning a shape-compatible result.
+
+        Args:
+            query: Tensor of shape [batch, heads, sequence, qk_head_dim].
+            key: Tensor of shape [batch, heads, sequence, qk_head_dim].
+            value: Tensor of shape [batch, heads, sequence, v_head_dim].
+            **kwargs: Attention metadata unused by this test stand-in.
+
+        Returns:
+            Zero tensor of shape [batch, heads, sequence, v_head_dim].
+        """
+        del key, kwargs
+        captured_queries.append(query.detach().clone())
+        return torch.zeros_like(value)
+
+    attention.attn_func = capture_attention
+    with torch.no_grad():
+        attention.q_proj.weight.zero_()
+        attention.q_proj.weight[: config.qk_head_dim, : config.qk_head_dim].copy_(torch.eye(config.qk_head_dim))
+
+    hidden_states = torch.ones(1, 1, config.hidden_size)
+    freqs_cis = torch.ones(1, 1, config.qk_rope_head_dim // 2, dtype=torch.complex64)
+    original_max_position = config.rope_parameters["original_max_position_embeddings"]
+    low_position_ids = torch.zeros(1, 1, dtype=torch.long)
+    high_position_ids = torch.full((1, 1), original_max_position, dtype=torch.long)
+
+    attention(hidden_states, freqs_cis, position_ids=low_position_ids)
+    attention(hidden_states, freqs_cis, position_ids=high_position_ids)
+
+    expected_scale = _get_llama_4_attn_scale(
+        high_position_ids,
+        config.rope_parameters["llama_4_scaling_beta"],
+        original_max_position,
+    ).item()
+    torch.testing.assert_close(captured_queries[1], captured_queries[0] * expected_scale)

--- a/tests/unit_tests/models/mistral4/test_mistral4_router_bias_fp32.py
+++ b/tests/unit_tests/models/mistral4/test_mistral4_router_bias_fp32.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for Mistral4 adaptive routing-bias precision."""
+
+import pytest
+import torch
+
+from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.models.mistral4.configuration import Mistral4Config
+from nemo_automodel.components.models.mistral4.model import (
+    _HF_MISTRAL3_AVAILABLE,
+    Mistral4ForCausalLM,
+)
+
+
+def _tiny_text_config() -> Mistral4Config:
+    return Mistral4Config(
+        vocab_size=32,
+        hidden_size=8,
+        intermediate_size=16,
+        moe_intermediate_size=4,
+        num_hidden_layers=1,
+        num_attention_heads=1,
+        num_key_value_heads=1,
+        n_shared_experts=1,
+        n_routed_experts=2,
+        kv_lora_rank=2,
+        q_lora_rank=None,
+        qk_rope_head_dim=2,
+        v_head_dim=2,
+        qk_nope_head_dim=2,
+        n_group=1,
+        topk_group=1,
+        num_experts_per_tok=1,
+        max_position_embeddings=16,
+        torch_dtype=torch.float32,
+    )
+
+
+def _torch_backend() -> BackendConfig:
+    return BackendConfig(
+        attn="sdpa",
+        linear="torch",
+        rms_norm="torch",
+        experts="torch",
+        dispatcher="torch",
+        rope_fusion=False,
+        enable_hf_state_dict_adapter=False,
+    )
+
+
+def _assert_router_biases_are_fp32(model: torch.nn.Module) -> None:
+    biases = [(name, buffer) for name, buffer in model.named_buffers() if name.endswith("e_score_correction_bias")]
+
+    assert biases, "Mistral4 should create adaptive routing-bias buffers"
+    for name, bias in biases:
+        assert bias.dtype == torch.float32, f"routing bias {name} was cast to {bias.dtype}"
+        torch.testing.assert_close(bias, torch.zeros_like(bias))
+
+
+def test_text_initialize_weights_bf16_keeps_router_bias_fp32() -> None:
+    model = Mistral4ForCausalLM(_tiny_text_config(), backend=_torch_backend())
+    model.initialize_weights(buffer_device=torch.device("cpu"), dtype=torch.bfloat16)
+
+    _assert_router_biases_are_fp32(model)
+    assert model.lm_head.weight.dtype == torch.bfloat16
+
+
+@pytest.mark.skipif(not _HF_MISTRAL3_AVAILABLE, reason="transformers Mistral3 model is unavailable")
+def test_multimodal_initialize_weights_bf16_keeps_router_bias_fp32() -> None:
+    from transformers.models.mistral3.configuration_mistral3 import Mistral3Config
+
+    from nemo_automodel.components.models.mistral4.model import Mistral3ForConditionalGeneration
+
+    config = Mistral3Config(
+        text_config=_tiny_text_config().to_dict(),
+        vision_config={
+            "model_type": "pixtral",
+            "hidden_size": 8,
+            "intermediate_size": 16,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 1,
+            "num_channels": 3,
+            "image_size": 4,
+            "patch_size": 2,
+        },
+        image_token_index=10,
+        spatial_merge_size=2,
+    )
+    model = Mistral3ForConditionalGeneration(config, backend=_torch_backend())
+    model.initialize_weights(buffer_device=torch.device("cpu"), dtype=torch.bfloat16)
+
+    _assert_router_biases_are_fp32(model)
+    assert model.lm_head.weight.dtype == torch.bfloat16

--- a/tests/unit_tests/moe/test_gate_dtensor_checkpoint_load.py
+++ b/tests/unit_tests/moe/test_gate_dtensor_checkpoint_load.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Distributed checkpoint-load coverage for the adaptive MoE routing bias."""
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from torch.distributed.checkpoint.state_dict import StateDictOptions, set_model_state_dict
+from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.tensor import DTensor, Replicate, Shard, distribute_tensor
+
+from nemo_automodel.components.moe.config import MoEConfig
+from nemo_automodel.components.moe.layers import Gate
+
+
+def _make_gate() -> Gate:
+    """Construct a tiny gate with a persistent adaptive routing-bias buffer."""
+    return Gate(
+        MoEConfig(
+            n_routed_experts=4,
+            n_shared_experts=0,
+            n_activated_experts=2,
+            n_expert_groups=1,
+            n_limited_groups=1,
+            train_gate=True,
+            gate_bias_update_factor=0.1,
+            aux_loss_coeff=0.0,
+            score_func="softmax_with_bias",
+            route_scale=1.0,
+            dim=8,
+            inter_dim=16,
+            moe_inter_dim=4,
+            norm_topk_prob=True,
+            dtype=torch.bfloat16,
+        )
+    )
+
+
+def _run_replicated_bias_load(rank: int, world_size: int, init_file: str) -> None:
+    """Load plain and distributed routing-bias tensors into a replicated DTensor buffer."""
+    os.environ["GLOO_SOCKET_IFNAME"] = "lo"
+    dist.init_process_group(
+        "gloo",
+        init_method=f"file://{init_file}",
+        rank=rank,
+        world_size=world_size,
+    )
+    try:
+        mesh = DeviceMesh("cpu", torch.arange(world_size), mesh_dim_names=("dp",))
+        gate = _make_gate()
+        gate.e_score_correction_bias = distribute_tensor(
+            gate.e_score_correction_bias,
+            device_mesh=mesh,
+            placements=[Replicate()],
+        )
+
+        plain_bias = torch.tensor([0.25, -0.5, 0.75, -1.0], dtype=torch.float32)
+        set_model_state_dict(
+            gate,
+            {"e_score_correction_bias": plain_bias},
+            options=StateDictOptions(strict=False),
+        )
+
+        assert isinstance(gate.e_score_correction_bias, DTensor)
+        assert gate.e_score_correction_bias.placements == (Replicate(),)
+        assert gate.e_score_correction_bias.dtype == torch.float32
+        torch.testing.assert_close(gate.e_score_correction_bias.to_local(), plain_bias)
+
+        distributed_bias = distribute_tensor(
+            torch.tensor([-1.25, 1.5, -1.75, 2.0], dtype=torch.float32),
+            device_mesh=mesh,
+            placements=[Replicate()],
+        )
+        set_model_state_dict(
+            gate,
+            {"e_score_correction_bias": distributed_bias},
+            options=StateDictOptions(strict=False),
+        )
+        torch.testing.assert_close(gate.e_score_correction_bias.to_local(), distributed_bias.to_local())
+
+        sharded_gate = _make_gate()
+        sharded_gate.e_score_correction_bias = distribute_tensor(
+            sharded_gate.e_score_correction_bias,
+            device_mesh=mesh,
+            placements=[Shard(0)],
+        )
+        try:
+            set_model_state_dict(
+                sharded_gate,
+                {"e_score_correction_bias": plain_bias},
+                options=StateDictOptions(strict=False),
+            )
+        except RuntimeError as error:
+            assert "must be replicated on every mesh dimension" in str(error)
+        else:
+            raise AssertionError("A full routing-bias tensor must not load into a sharded DTensor")
+    finally:
+        dist.destroy_process_group()
+
+
+def test_gate_loads_plain_bias_into_replicated_dtensor(tmp_path) -> None:
+    """A two-rank load accepts HF/adapter tensors and preserves native DCP tensors."""
+    if not dist.is_available() or not dist.is_gloo_available():
+        pytest.skip("torch.distributed with Gloo is unavailable")
+
+    mp.spawn(
+        _run_replicated_bias_load,
+        args=(2, str(tmp_path / "gate_bias_pg")),
+        nprocs=2,
+        join=True,
+    )

--- a/tests/unit_tests/moe/test_layers.py
+++ b/tests/unit_tests/moe/test_layers.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import importlib.util
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
@@ -1026,6 +1026,36 @@ class TestGate:
         assert not torch.equal(gate.e_score_correction_bias, original_bias)
         # Cumulative load should be reset
         assert gate._cumulative_expert_load is None
+
+    def test_gate_update_bias_aggregates_plain_buffer_load(self, moe_config, device):
+        """Plain FSDP buffers aggregate rank-local load before updating routing bias."""
+        moe_config.gate_bias_update_factor = 0.1
+        gate = Gate(moe_config).to(device)
+        gate.train()
+
+        local_load = torch.tensor([8, 0, 0, 0, 0, 0, 0, 0], device=device)
+        remote_load = torch.tensor([0, 8, 0, 0, 0, 0, 0, 0], device=device)
+        gate._cumulative_expert_load = local_load.clone()
+
+        process_group = object()
+        mesh = MagicMock()
+        mesh.size.return_value = 2
+        mesh.mesh_dim_names = ("dp_shard_cp",)
+        mesh.get_group.return_value = process_group
+        gate._set_expert_load_mesh(mesh)
+
+        def _sum_remote_load(expert_load, *, op, group):
+            assert op == torch.distributed.ReduceOp.SUM
+            assert group is process_group
+            expert_load.add_(remote_load)
+
+        with patch("torch.distributed.all_reduce", side_effect=_sum_remote_load) as all_reduce:
+            gate.update_bias()
+
+        all_reduce.assert_called_once()
+        mesh.get_group.assert_called_once_with("dp_shard_cp")
+        expected = torch.tensor([-0.1, -0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1], device=device)
+        torch.testing.assert_close(gate.e_score_correction_bias, expected)
 
     def test_gate_init_weights(self, moe_config, device):
         """Test Gate weight initialization."""

--- a/tests/unit_tests/moe/test_layers.py
+++ b/tests/unit_tests/moe/test_layers.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import importlib.util
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 import torch
@@ -1026,36 +1026,6 @@ class TestGate:
         assert not torch.equal(gate.e_score_correction_bias, original_bias)
         # Cumulative load should be reset
         assert gate._cumulative_expert_load is None
-
-    def test_gate_update_bias_aggregates_plain_buffer_load(self, moe_config, device):
-        """Plain FSDP buffers aggregate rank-local load before updating routing bias."""
-        moe_config.gate_bias_update_factor = 0.1
-        gate = Gate(moe_config).to(device)
-        gate.train()
-
-        local_load = torch.tensor([8, 0, 0, 0, 0, 0, 0, 0], device=device)
-        remote_load = torch.tensor([0, 8, 0, 0, 0, 0, 0, 0], device=device)
-        gate._cumulative_expert_load = local_load.clone()
-
-        process_group = object()
-        mesh = MagicMock()
-        mesh.size.return_value = 2
-        mesh.mesh_dim_names = ("dp_shard_cp",)
-        mesh.get_group.return_value = process_group
-        gate._set_expert_load_mesh(mesh)
-
-        def _sum_remote_load(expert_load, *, op, group):
-            assert op == torch.distributed.ReduceOp.SUM
-            assert group is process_group
-            expert_load.add_(remote_load)
-
-        with patch("torch.distributed.all_reduce", side_effect=_sum_remote_load) as all_reduce:
-            gate.update_bias()
-
-        all_reduce.assert_called_once()
-        mesh.get_group.assert_called_once_with("dp_shard_cp")
-        expected = torch.tensor([-0.1, -0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1], device=device)
-        torch.testing.assert_close(gate.e_score_correction_bias, expected)
 
     def test_gate_init_weights(self, moe_config, device):
         """Test Gate weight initialization."""

--- a/tests/unit_tests/moe/test_parallelizer.py
+++ b/tests/unit_tests/moe/test_parallelizer.py
@@ -316,7 +316,11 @@ def _install_torch_and_layers_stubs(monkeypatch):
     class MoE:
         pass
 
+    class Gate:
+        pass
+
     layers_stub.GroupedExpertsDeepEP = GroupedExpertsDeepEP
+    layers_stub.Gate = Gate
     layers_stub.MoE = MoE
     monkeypatch.setitem(sys.modules, "nemo_automodel.components.moe.layers", layers_stub)
 
@@ -771,6 +775,8 @@ def test_apply_fsdp_calls_with_ignored_params_and_shard_for_experts(monkeypatch)
     monkeypatch.setattr(P, "Shard", fake_shard)
 
     block = DummyBlock(mlp=DummyMoE())
+    block.mlp.gate = P.Gate()
+    block.mlp.gate._set_expert_load_mesh = MagicMock()
     embed = object()
     embed_norm = object()
     lm = object()
@@ -788,6 +794,8 @@ def test_apply_fsdp_calls_with_ignored_params_and_shard_for_experts(monkeypatch)
         ep_shard_mesh=ep_shard_mesh,
         offload_policy=offload_policy,
     )
+
+    block.mlp.gate._set_expert_load_mesh.assert_called_once_with(fsdp_mesh)
 
     # Experts should have a dedicated shard call
     experts = block.mlp.experts

--- a/tests/unit_tests/moe/test_parallelizer.py
+++ b/tests/unit_tests/moe/test_parallelizer.py
@@ -190,8 +190,13 @@ def _install_torch_and_layers_stubs(monkeypatch):
         def __init__(self, *args, **kwargs):
             pass
 
+    class Replicate:
+        def __init__(self, *args, **kwargs):
+            pass
+
     tensor_stub.distribute_module = distribute_module
     tensor_stub.distribute_tensor = distribute_tensor
+    tensor_stub.Replicate = Replicate
     tensor_stub.Shard = Shard
 
     # tensor.parallel
@@ -765,6 +770,9 @@ def test_apply_fsdp_calls_with_ignored_params_and_shard_for_experts(monkeypatch)
     fully_shard_mock = MagicMock()
     mp_policy_mock = MagicMock(return_value="MP_POLICY")
     shard_sentinel = object()
+    replicate_sentinel = object()
+    correction_bias = object()
+    distributed_correction_bias = object()
 
     def fake_shard(dim):
         assert dim == 1
@@ -772,17 +780,20 @@ def test_apply_fsdp_calls_with_ignored_params_and_shard_for_experts(monkeypatch)
 
     monkeypatch.setattr(P, "fully_shard", fully_shard_mock)
     monkeypatch.setattr(P, "MixedPrecisionPolicy", mp_policy_mock)
+    monkeypatch.setattr(P, "Replicate", MagicMock(return_value=replicate_sentinel))
     monkeypatch.setattr(P, "Shard", fake_shard)
+    distribute_tensor_mock = MagicMock(return_value=distributed_correction_bias)
+    monkeypatch.setattr(P, "distribute_tensor", distribute_tensor_mock)
 
     block = DummyBlock(mlp=DummyMoE())
     block.mlp.gate = P.Gate()
-    block.mlp.gate._set_expert_load_mesh = MagicMock()
+    block.mlp.gate.e_score_correction_bias = correction_bias
     embed = object()
     embed_norm = object()
     lm = object()
     model = DummyModel([block], embed_tokens=embed, embed_norm=embed_norm, lm_head=lm)
 
-    fsdp_mesh = type("Mesh", (), {"size": lambda self: 2})()
+    fsdp_mesh = type("Mesh", (), {"ndim": 1, "size": lambda self: 2})()
     ep_shard_mesh = type("Mesh", (), {"size": lambda self: 2})()
     offload_policy = object()
 
@@ -795,7 +806,12 @@ def test_apply_fsdp_calls_with_ignored_params_and_shard_for_experts(monkeypatch)
         offload_policy=offload_policy,
     )
 
-    block.mlp.gate._set_expert_load_mesh.assert_called_once_with(fsdp_mesh)
+    distribute_tensor_mock.assert_called_once_with(
+        correction_bias,
+        device_mesh=fsdp_mesh,
+        placements=[replicate_sentinel],
+    )
+    assert block.mlp.gate.e_score_correction_bias is distributed_correction_bias
 
     # Experts should have a dedicated shard call
     experts = block.mlp.experts


### PR DESCRIPTION
## Summary

The Mistral4 checkpoint-parity test exposed four correctness bugs beyond the already-merged PP metadata fix. This PR:

- corrects Mistral4 attention scaling and long-context query scaling to match Hugging Face
- represents adaptive MoE routing bias as a replicated DTensor over each pipeline stage's DP/CP mesh
- preserves the adaptive routing bias in fp32 through mixed-precision initialization
- loads ordinary HF/adapter routing-bias tensors into the replicated DTensor checkpoint contract
- calibrates Mistral4 Phase 0/3/4 parity bounds only after ruling out checkpoint-state corruption
- installs the declared VLM media packages directly in scoped CI instead of re-resolving the complete project
- adds focused attention, distributed routing-bias, precision, and CI-config regression coverage

## Bugs fixed and impact

### 1. Mistral4 attention math differed from Hugging Face

`Mistral4MLA` inherits the DeepSeek MLA implementation. The inherited backend captured DeepSeek's YaRN-adjusted `mscale**2` softmax scale, changing the official Mistral4 scale from about `0.08839` to `0.19497` (about 2.21x). Mistral4 also applied its long-context multiplier only to the positional query slice, while Hugging Face applies it to the complete concatenated query.

The fix restores standard `qk_head_dim**-0.5` scaling and applies the multiplier to the complete query. This changes Mistral4 forward numerics in both training and inference and restores source-model parity.

### 2. Adaptive MoE routing state diverged across distributed replicas

`Gate.e_score_correction_bias` is a checkpointed routing buffer updated from observed expert-token counts. The update code already knew how to aggregate counts when the bias was a DTensor, but FSDP2 leaves registered buffers as ordinary tensors. The DTensor path therefore was not used in the common distributed configuration, and replicas updated the bias from different local batches.

This is a training correctness issue, not only a checkpoint comparison issue: different biases can change top-k expert selection, expert loads, gradients, and the resulting optimization trajectory. Consolidation retains one logical buffer value, making the divergence especially visible when comparing the warm model with a reload.

The fix explicitly distributes the buffer with `Replicate` placement over the pipeline stage's full DP/CP FSDP mesh. The existing `Partial`-to-`Replicate` update then sums expert load across all mesh dimensions before applying one identical bias update on every replica. Routing uses the bias's local replicated view, keeping ordinary local score operations free of mixed Tensor/DTensor dispatch. This removes the runtime mesh setter and manual collective path; the reduction domain now travels with the buffer itself.

Pipeline stages remain independent. `cp_size=1` is still affected when `dp_size>1`; the reproducing PP4/EP8 job had `DP=8, CP=1`.

The shared behavior change applies to models using `Gate` with `gate_bias_update_factor>0` under multi-rank FSDP2, including Mistral4, DeepSeek V3/V3.2/V4, and selected GLM and MiniMax families. Models with a zero update factor, a one-rank DP/CP mesh, or inference-only execution are unaffected.

### 3. Mistral4 mixed-precision initialization rounded adaptive routing state

AutoModel intentionally enables DeepSeek-style auxiliary-loss-free expert balancing for Mistral4 fine-tuning. The published Hugging Face and native Mistral4 checkpoints do not contain this bias, so the state-dict adapter injects an fp32 zero buffer. Zero preserves the released model's initial routing; AutoModel then adjusts the bias by `1e-3` after each optimizer step to discourage expert overload.

The text and multimodal Mistral4 initializers used a raw whole-model `to(bfloat16)`, which also cast the registered correction-bias buffers to bf16. This violated the shared MoE precision contract: small rounding differences can accumulate in the bias and flip discrete top-k expert selection.

Both wrappers now declare `e_score_correction_bias` as strict fp32 state and use the shared precision-aware model cast. The state remains a persistent registered buffer—not a parameter—and is preserved in fp32 before and after FSDP2/DTensor parallelization. Focused CPU tests exercise both production initialization paths.

### 4. Base-checkpoint loading mixed ordinary tensors with the replicated DTensor

Once the persistent bias became a replicated DTensor, the checkpoint-robustness setup exposed a second state contract. HF adapters produce ordinary full tensors—for Mistral4, the adapter injects an fp32 zero bias because the released checkpoint omits it—while a model that has already been FSDP-parallelized owns a replicated DTensor buffer. PyTorch cannot execute `copy_` with one ordinary tensor and one DTensor, so the base checkpoint failed to load before training or parity evaluation began.

The shared `Gate` loader now converts an ordinary full bias to a replicated DTensor on the live buffer's mesh before PyTorch copies state. It preserves the live fp32 dtype and device, accepts native DCP DTensors without conversion, and fails explicitly for a shape mismatch or any non-replicated placement. Keeping this at the state-owning `Gate` boundary gives Mistral4, ERNIE, MiniMax, HY, and other adapters one checkpoint contract instead of duplicating DTensor knowledge across model-specific adapters.

## Checkpoint-parity conclusion

The remaining Phase 3 delta is not consolidation corruption:

- repeated forwards within each runtime were bit-identical
- two 32-rank fingerprints found identical tensor counts, no missing/extra state, and zero sampled parameter or buffer mismatches
- a fresh native-DCP load and a fresh consolidated load had the same `0.01264910` KL relative to the warm Phase 2 runtime
- the fresh DCP and consolidated logits were bit-identical to each other (`0.00000000` max KL)

Phase 3 therefore bounds the warm-versus-fresh distributed BF16 runtime boundary, not a state-format difference. Post-fix Phase 3 ranged from about `0.0033` to `0.0378`; `kl_threshold: 0.05` provides limited headroom. Phase 4 compares native TE/SDPA/EP execution with vanilla Hugging Face and ranged from about `0.0214` to `0.0424`, also bounded at `0.05`. Phase 0 retains tighter source-parity bounds: max KL `0.01`, mean KL `0.002`, and cosine `0.999`.

Resume-loss behavior remains separately tracked in [AMINT-227](https://linear.app/nvidia/issue/AMINT-227/redesign-checkpoint-resume-robustness-around-a-shared-training).

## CI change

The scoped VLM launcher now installs the already-declared media packages directly instead of re-resolving the complete AutoModel project and an unrelated inaccessible Git dependency. This changes test setup only, not package declarations or runtime model behavior.

## Validation

- Mistral4 unit tests: `60 passed, 70 skipped`
- Mistral4 plus common dtype tests: `104 passed, 70 skipped`
- MoE gate/parallelizer tests on the DTensor head: `171 passed, 3 skipped`
- shared Gate plus Mistral4/ERNIE/MiniMax/HY adapter regression set: `212 passed, 3 skipped`
- real two-rank Gloo checkpoint test covers ordinary fp32 tensor, native DCP DTensor, and rejection of a sharded target: `1 passed`
- CI resolver tests: `40 passed`
- targeted Ruff format/check and `git diff --check`: passed
- one-rank DTensor checkpoint probe round-tripped the replicated buffer exactly
- one-rank meta-device probe preserved DTensor placement through production-style materialization
- the two-rank ERNIE FSDP regression verifies `Replicate` placement, local routing, and a numerically correct globally aggregated bias update
- [Mistral4 pipeline 60880218](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/60880218): the EOS retry reached model setup and exposed the ordinary-Tensor-to-DTensor base-load mismatch before training
- [current Mistral4 pipeline 60960166](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/60960166): exact `mistral4_medpix` checkpoint-robustness rerun on the shared loader fix
- [cross-model MoE pipeline 60960168](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/60960168): exact ERNIE 4.5 checkpoint-robustness and MiniMax M2.7 adaptive-bias training controls
- [gate-bias diagnostic pipeline 60587316](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/60587316): confirmed identical routing bias after DP/CP synchronization
- [state-fingerprint pipeline 60597238](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/60597238): all 32 PP4/EP8 ranks had matching state fingerprints; Phase 3 measured `0.0032946` and resume passed
- [fresh-DCP control pipeline 60600120](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/60600120): native DCP and consolidated reloads produced bit-identical logits; Phase 4 and resume passed
- [final production pipeline 60606401](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/60606401): completed all 50 PP4/EP8 training steps, Phase 0/3/4, and resume with no masked-scatter assertion

The static PP media-cursor, checkpoint-resume metadata, and timeout fixes were merged separately in [#3344](https://github.com/NVIDIA-NeMo/Automodel/pull/3344) and are not part of this PR's effective diff.

Related: AMINT-230, AMINT-227, AM-715
