### PR TITLE
ci: add rolling release shards to nightly

### DIFF
--- a/tests/ci_tests/README.md
+++ b/tests/ci_tests/README.md
@@ -30,6 +30,15 @@ ci_tests/
 - **release** -- All recipe YAMLs in auto-discovered folders, or recipes listed
   in `release_recipes.yml` for explicitly managed folders such as `llm_pretrain`
 
+Nightly generation can additionally include one rolling shard of the release-only
+recipes. `--rolling-release-shards 5 --rolling-release-shard N` keeps every
+explicit nightly recipe and adds shard `N` of the recipes in `release` but not
+`nightly`. Shards are deterministic and balanced using each recipe's declared
+`ci.nodes * ci.time`; generated variants such as vLLM deployment are included in
+the estimate. Overrides and blocking known issues are applied before assignment.
+The default shard count is zero, so existing pipelines are unchanged unless the
+rolling overlay is explicitly enabled.
+
 **Stage assignment** is based on recipe type and configuration:
 
 | Stage | Criteria |

--- a/tests/ci_tests/utils/generate_ci_tests.py
+++ b/tests/ci_tests/utils/generate_ci_tests.py
@@ -116,6 +116,97 @@ def detect_yml_configurations(automodel_dir: str, scope: str, test_folder: str) 
     return _discover_via_recipe_list(automodel_dir, scope, test_folder)
 
 
+def _slurm_time_seconds(value: str) -> int:
+    """Convert an HH:MM:SS Slurm duration to seconds."""
+    try:
+        hours, minutes, seconds = (int(part) for part in value.split(":"))
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Invalid Slurm duration {value!r}; expected HH:MM:SS") from exc
+    if hours < 0 or not 0 <= minutes < 60 or not 0 <= seconds < 60:
+        raise ValueError(f"Invalid Slurm duration {value!r}; expected HH:MM:SS")
+    return hours * 3600 + minutes * 60 + seconds
+
+
+def _rolling_release_weight(automodel_dir: str, config: Path) -> int:
+    """Estimate node-seconds for a release recipe and its generated variants."""
+    with open(Path(automodel_dir) / config, "r", encoding="utf-8") as f:
+        ci_config = (yaml.load(f) or {}).get("ci") or {}
+
+    nodes = int(ci_config.get("nodes", 1))
+    if nodes <= 0:
+        raise ValueError(f"Invalid ci.nodes={nodes!r} in {config}; expected a positive integer")
+    weight = nodes * _slurm_time_seconds(str(ci_config.get("time", "00:10:00")))
+    if ci_config.get("vllm_deploy") and not ci_config.get("vllm_deploy_known_issue_id"):
+        weight += _slurm_time_seconds(str(ci_config.get("vllm_deploy_time", "00:10:00")))
+    return weight
+
+
+def _is_rolling_release_candidate(
+    automodel_dir: str,
+    config: Path,
+    config_override: Dict[str, Any],
+) -> bool:
+    """Return whether a release-only recipe is runnable before shard assignment."""
+    config_path = Path(automodel_dir) / config
+    if not config_path.is_file():
+        return False
+
+    exempt_models = set(config_override.get("exempt_models") or [])
+    exempt_configs = set(config_override.get("exempt_configs") or [])
+    if config.parent.name in exempt_models or config.stem in exempt_configs:
+        return False
+
+    with open(config_path, "r", encoding="utf-8") as f:
+        ci_config = (yaml.load(f) or {}).get("ci") or {}
+    return not (ci_config.get("known_issue_id") and not ci_config.get("allow_failure"))
+
+
+def _select_rolling_release_configs(
+    automodel_dir: str,
+    test_folder: str,
+    nightly_configs: list[Path],
+    config_override: Dict[str, Any],
+    shard_count: int,
+    shard_index: int,
+) -> list[Path]:
+    """Select one deterministic, cost-balanced shard of release-only recipes."""
+    if shard_count <= 0:
+        raise ValueError(f"rolling release shard count must be positive, got {shard_count}")
+    if not 0 <= shard_index < shard_count:
+        raise ValueError(f"rolling release shard index must be in [0, {shard_count}), got {shard_index}")
+
+    nightly_set = set(nightly_configs)
+    release_configs = detect_yml_configurations(automodel_dir, "release", test_folder)
+    candidates = [
+        config
+        for config in release_configs
+        if config not in nightly_set and _is_rolling_release_candidate(automodel_dir, config, config_override)
+    ]
+
+    shard_configs: list[list[Path]] = [[] for _ in range(shard_count)]
+    shard_weights = [0] * shard_count
+    weighted_configs = sorted(
+        ((_rolling_release_weight(automodel_dir, config), config) for config in candidates),
+        key=lambda item: (-item[0], str(item[1])),
+    )
+    for weight, config in weighted_configs:
+        target_shard = min(
+            range(shard_count),
+            key=lambda index: (shard_weights[index], len(shard_configs[index]), index),
+        )
+        shard_configs[target_shard].append(config)
+        shard_weights[target_shard] += weight
+
+    selected = sorted(shard_configs[shard_index])
+    print(
+        f"Selected rolling release shard {shard_index}/{shard_count}: "
+        f"{len(selected)} of {len(candidates)} release-only recipes "
+        f"({shard_weights[shard_index] / 60:.0f} node-minutes)",
+        file=sys.stderr,
+    )
+    return selected
+
+
 # Recipe ci: section keys mapped to the CI variables they populate on the base job.
 CI_KEY_TO_VAR = {
     "time": "TIME",
@@ -293,14 +384,23 @@ def generate_job(
     return variants
 
 
-def generate_pipeline(automodel_dir: str, scope: str, test_folder: str) -> Dict[str, Any]:
+def generate_pipeline(
+    automodel_dir: str,
+    scope: str,
+    test_folder: str,
+    *,
+    rolling_release_shards: int = 0,
+    rolling_release_shard: int = 0,
+) -> Dict[str, Any]:
     """
     Generate a complete CI test pipeline YAML for the given test folder and scope.
 
     Args:
         automodel_dir: Path to the Automodel directory
         scope: Scope of the testing (nightly, release, convergence)
-        test_folder: Name of the test folder under Automodel/examples
+        test_folder: Name of the test folder under Automodel/examples.
+        rolling_release_shards: Number of cost-balanced release-only shards to overlay on nightly.
+        rolling_release_shard: Zero-based release-only shard to overlay on nightly.
 
     Returns:
         pipeline: Dictionary defining the CI test pipeline
@@ -309,8 +409,23 @@ def generate_pipeline(automodel_dir: str, scope: str, test_folder: str) -> Dict[
     with open(override_path, "r", encoding="utf-8") as f:
         config_override = yaml.load(f) or {}
 
+    if not rolling_release_shards and rolling_release_shard:
+        raise ValueError("rolling release shard requires a positive rolling release shard count")
+    if rolling_release_shards and scope != "nightly":
+        raise ValueError("rolling release shards can only be added to the nightly scope")
+
     # Empty yml_configs is fine -- some (folder, scope) combos have no recipes.
     yml_configs = detect_yml_configurations(automodel_dir, scope, test_folder)
+    if rolling_release_shards:
+        rolling_configs = _select_rolling_release_configs(
+            automodel_dir,
+            test_folder,
+            yml_configs,
+            config_override,
+            rolling_release_shards,
+            rolling_release_shard,
+        )
+        yml_configs = list(dict.fromkeys([*yml_configs, *rolling_configs]))
 
     exempt_models = set(config_override.get("exempt_models") or [])
     exempt_configs = set(config_override.get("exempt_configs") or [])
@@ -346,9 +461,27 @@ def main():
     parser.add_argument("--automodel-dir", type=str, required=True, help="Path to Automodel directory")
     parser.add_argument("--scope", type=_normalize_scope, required=True, help="Scope of the tests (nightly, release)")
     parser.add_argument("--test-folder", type=str, required=True, help="Target folder to search")
+    parser.add_argument(
+        "--rolling-release-shards",
+        type=int,
+        default=0,
+        help="Number of cost-balanced release-only shards to overlay on nightly (0 disables the overlay)",
+    )
+    parser.add_argument(
+        "--rolling-release-shard",
+        type=int,
+        default=0,
+        help="Zero-based release-only shard to overlay on nightly",
+    )
     args = parser.parse_args()
 
-    pipeline = generate_pipeline(args.automodel_dir, args.scope, args.test_folder)
+    pipeline = generate_pipeline(
+        args.automodel_dir,
+        args.scope,
+        args.test_folder,
+        rolling_release_shards=args.rolling_release_shards,
+        rolling_release_shard=args.rolling_release_shard,
+    )
     with open(f"generated_automodel_{args.test_folder}_tests.yml", "w") as f:
         yaml.dump(pipeline, f)
     job_count = sum(1 for k in pipeline if k != "include")

--- a/tests/unit_tests/ci_tests/test_generate_ci_tests.py
+++ b/tests/unit_tests/ci_tests/test_generate_ci_tests.py
@@ -14,7 +14,42 @@
 
 from pathlib import Path
 
+import pytest
+
 from tests.ci_tests.utils.generate_ci_tests import generate_job, generate_pipeline
+
+
+def _write_ci_recipe(
+    automodel_dir: Path,
+    name: str,
+    *,
+    time: str,
+    nodes: int = 1,
+    extra_ci: str = "",
+) -> Path:
+    recipe = automodel_dir / "examples" / "llm_finetune" / "family" / f"{name}.yaml"
+    recipe.parent.mkdir(parents=True, exist_ok=True)
+    recipe.write_text(
+        f'ci:\n  time: "{time}"\n  nodes: {nodes}\n  recipe_owner: test\n{extra_ci}',
+        encoding="utf-8",
+    )
+    return recipe
+
+
+def _write_ci_lists(automodel_dir: Path, nightly_names: list[str], *, exempt_configs: list[str] | None = None) -> None:
+    config_dir = automodel_dir / "tests" / "ci_tests" / "configs" / "llm_finetune"
+    config_dir.mkdir(parents=True)
+    nightly_lines = "\n".join(f"  - family/{name}.yaml" for name in nightly_names)
+    (config_dir / "nightly_recipes.yml").write_text(f"configs:\n{nightly_lines}\n", encoding="utf-8")
+    exempt_lines = "\n".join(f"  {name}:\n    reason: test" for name in (exempt_configs or []))
+    (config_dir / "override_recipes.yml").write_text(
+        f"exempt_configs:\n{exempt_lines}\n" if exempt_lines else "exempt_configs: {}\n",
+        encoding="utf-8",
+    )
+
+
+def _job_names(pipeline: dict) -> set[str]:
+    return set(pipeline) - {"include"}
 
 
 def test_generate_deepseek_v4_pretrain_nightly_job():
@@ -52,3 +87,66 @@ ci:
 
     assert jobs[""]["variables"]["TIME"] == "00:25:00"
     assert jobs["_vllm_deploy"]["variables"]["TIME"] == "00:30:00"
+
+
+def test_rolling_release_shards_preserve_nightly_and_cover_release_only(tmp_path):
+    _write_ci_lists(tmp_path, ["core"], exempt_configs=["excluded"])
+    _write_ci_recipe(tmp_path, "core", time="00:10:00")
+    for index in range(5):
+        _write_ci_recipe(tmp_path, f"release_{index}", time=f"00:{index + 11:02d}:00")
+    _write_ci_recipe(tmp_path, "excluded", time="01:00:00")
+    _write_ci_recipe(tmp_path, "known_issue", time="01:00:00", extra_ci="  known_issue_id: AM-123\n")
+
+    rolling_jobs = []
+    for shard_index in range(5):
+        pipeline = generate_pipeline(
+            str(tmp_path),
+            "nightly",
+            "llm_finetune",
+            rolling_release_shards=5,
+            rolling_release_shard=shard_index,
+        )
+        assert pipeline["core"]["variables"]["TEST_LEVEL"] == "nightly"
+        rolling_jobs.append(_job_names(pipeline) - {"core"})
+
+    assert set.union(*rolling_jobs) == {f"release_{index}" for index in range(5)}
+    assert sum(len(jobs) for jobs in rolling_jobs) == 5
+
+
+def test_rolling_release_shards_balance_declared_node_time(tmp_path):
+    _write_ci_lists(tmp_path, ["core"])
+    _write_ci_recipe(tmp_path, "core", time="00:10:00")
+    recipe_minutes = {"r60": 60, "r50": 50, "r40": 40, "r30": 30, "r20": 20, "r10": 10}
+    for name, minutes in recipe_minutes.items():
+        _write_ci_recipe(tmp_path, name, time=f"{minutes // 60:02d}:{minutes % 60:02d}:00")
+
+    shard_costs = []
+    for shard_index in range(2):
+        pipeline = generate_pipeline(
+            str(tmp_path),
+            "nightly",
+            "llm_finetune",
+            rolling_release_shards=2,
+            rolling_release_shard=shard_index,
+        )
+        shard_costs.append(sum(recipe_minutes[name] for name in _job_names(pipeline) - {"core"}))
+
+    assert sorted(shard_costs) == [100, 110]
+
+
+def test_rolling_release_rejects_invalid_scope_or_shard(tmp_path):
+    _write_ci_lists(tmp_path, ["core"])
+    _write_ci_recipe(tmp_path, "core", time="00:10:00")
+
+    with pytest.raises(ValueError, match="only be added to the nightly scope"):
+        generate_pipeline(str(tmp_path), "release", "llm_finetune", rolling_release_shards=5)
+    with pytest.raises(ValueError, match="requires a positive rolling release shard count"):
+        generate_pipeline(str(tmp_path), "nightly", "llm_finetune", rolling_release_shard=1)
+    with pytest.raises(ValueError, match=r"must be in \[0, 5\)"):
+        generate_pipeline(
+            str(tmp_path),
+            "nightly",
+            "llm_finetune",
+            rolling_release_shards=5,
+            rolling_release_shard=5,
+        )


### PR DESCRIPTION
## What

- preserve the explicit nightly recipe set and overlay one selected release-only shard
- partition release-only recipes deterministically using declared `ci.nodes * ci.time`
- account for generated vLLM deployment variants and filter exemptions/blocking known issues before assignment
- add focused coverage for preservation, full five-shard coverage, cost balance, and invalid configuration

## Why

The Automodel nightly schedule should exercise approximately 20% of release-only coverage per run without replacing the stable nightly smoke set or changing the full release pipeline.

The feature is disabled by default. The companion `nemo-ci` change supplies the schedule-controlled shard count and index: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/merge_requests/2752

## Validation

- `uv run --no-sync pytest -q tests/unit_tests/ci_tests/test_generate_ci_tests.py` — 6 passed
- `uv run --no-sync ruff check tests/ci_tests/utils/generate_ci_tests.py tests/unit_tests/ci_tests/test_generate_ci_tests.py`
- `python3 tests/ci_tests/utils/validate_generate_ci.py --automodel-dir .` — all 19 scope/folder combinations generated successfully
