### PR TITLE
fix(docs): make Fern autodoc metadata MDX-safe

### DIFF
--- a/nemo_automodel/_transformers/auto_model.py
+++ b/nemo_automodel/_transformers/auto_model.py
@@ -684,8 +684,8 @@ class _BaseNeMoAutoModelClass(_BaseAutoModelClass):
                 Accepts both SDPBackend enum values and string names (e.g.
                 ``["flash_attention", "efficient_attention"]``). When ``None``,
                 auto-selects based on CP and activation checkpointing.
-            torch_dtype (str | torch.dtype | Literal["auto"], default="auto"):
-                Data type passed to the underlying `from_pretrained` call.
+            torch_dtype (str | torch.dtype):
+                Data type passed to the underlying `from_pretrained` call. Defaults to `auto`.
             attn_implementation (str, optional):
                 Specifies which attention implementation to use (e.g.,
                 ``"flash_attention_2"``, ``"eager"``). Only applied when the
@@ -813,8 +813,8 @@ class _BaseNeMoAutoModelClass(_BaseAutoModelClass):
                 The configuration object used to build the model.
                 If config is passed as a string (e.g., model-id / local checkpoint),
                 it will create a config internally using AutoConfig.
-            torch_dtype (str | torch.dtype, default="auto"):
-                Data type for model parameters. If "auto", defaults to ``torch.bfloat16``.
+            torch_dtype (str | torch.dtype):
+                Data type for model parameters. Defaults to `auto`, which selects ``torch.bfloat16``.
         """
         _reject_separate_distributed_kwargs(kwargs)
         setup = _resolve_distributed_setup(

--- a/nemo_automodel/components/models/kimi_k3/tokenization.py
+++ b/nemo_automodel/components/models/kimi_k3/tokenization.py
@@ -19,27 +19,27 @@ from .encoding import build_chat_segments, is_batched_conversation
 
 logger = getLogger(__name__)
 VOCAB_FILES_NAMES = {"vocab_file": "tiktoken.model"}
-# Fern autodoc emits literal ampersands as invalid MDX.
-_REGEX_SET_INTERSECTION = chr(38) * 2
-_NON_HAN_UPPER_OR_MARK = r"""[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}""" + _REGEX_SET_INTERSECTION + r"""[^\p{Han}]]"""
-_NON_HAN_LOWER_OR_MARK = r"""[\p{Ll}\p{Lm}\p{Lo}\p{M}""" + _REGEX_SET_INTERSECTION + r"""[^\p{Han}]]"""
 
 
 def _build_kimi_k3_pat_str() -> str:
     """Build the Kimi K3 tiktoken regex without exposing raw set intersections to autodoc."""
 
+    regex_set_intersection = chr(38) * 2
+    non_han_upper_or_mark = r"""[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}""" + regex_set_intersection + r"""[^\p{Han}]]"""
+    non_han_lower_or_mark = r"""[\p{Ll}\p{Lm}\p{Lo}\p{M}""" + regex_set_intersection + r"""[^\p{Han}]]"""
+
     return "|".join(
         [
             r"""[\p{Han}]+""",
             r"""[^\r\n\p{L}\p{N}]?"""
-            + _NON_HAN_UPPER_OR_MARK
+            + non_han_upper_or_mark
             + r"""*"""
-            + _NON_HAN_LOWER_OR_MARK
+            + non_han_lower_or_mark
             + r"""+(?i:'s|'t|'re|'ve|'m|'ll|'d)?""",
             r"""[^\r\n\p{L}\p{N}]?"""
-            + _NON_HAN_UPPER_OR_MARK
+            + non_han_upper_or_mark
             + r"""+"""
-            + _NON_HAN_LOWER_OR_MARK
+            + non_han_lower_or_mark
             + r"""*(?i:'s|'t|'re|'ve|'m|'ll|'d)?""",
             r"""\p{N}{1,3}""",
             r""" ?[^\s\p{L}\p{N}]+[\r\n]*""",
@@ -60,15 +60,16 @@ class TikTokenTokenizer(PreTrainedTokenizer):
     Args:
         vocab_file (`str`):
             The path to the Tiktoken model file.
-        bos_token (`str` or `tokenizers.AddedToken`, *optional*, defaults to `"<|begin_of_text|>",`):
-            The beginning of sequence token that was used during pretraining. Can be used a sequence classifier token.
-        eos_token (`str` or `tokenizers.AddedToken`, *optional*, defaults to `"<|end_of_text|>"`):
-            The end of sequence token.
-        unk_token (`str` or `tokenizers.AddedToken`, *optional*, defaults to `"<|reserved_special_token_249|>"`):
+        bos_token (`str` or `tokenizers.AddedToken`, *optional*):
+            The beginning of sequence token that was used during pretraining. Defaults to `[BOS]`. Can be used as a
+            sequence classifier token.
+        eos_token (`str` or `tokenizers.AddedToken`, *optional*):
+            The end of sequence token. Defaults to `[EOS]`.
+        unk_token (`str` or `tokenizers.AddedToken`, *optional*):
             The unknown token. A token that is not in the vocabulary cannot be converted to an ID and is set to be this
-            token instead. The second to last item in special_tokens.
-        pad_token (`str` or `tokenizers.AddedToken`, *optional*, defaults to `"<|reserved_special_token_250|>"`):
-            The token used for padding, for example when batching sequences of different lengths.
+            token instead. Defaults to `None`.
+        pad_token (`str` or `tokenizers.AddedToken`, *optional*):
+            The token used for padding, for example when batching sequences of different lengths. Defaults to `None`.
         additional_special_tokens (list of `str`, *optional*):
             A tuple or a list of additional tokens, which will be marked as `special`, meaning that they will be
             skipped when decoding if `skip_special_tokens` is set to `True`.

--- a/tests/unit_tests/models/kimi_k3/test_encoding.py
+++ b/tests/unit_tests/models/kimi_k3/test_encoding.py
@@ -14,6 +14,7 @@
 
 import pytest
 
+from nemo_automodel.components.models.kimi_k3 import tokenization as kimi_k3_tokenization
 from nemo_automodel.components.models.kimi_k3.encoding import build_chat_segments
 from nemo_automodel.components.models.kimi_k3.tokenization import TikTokenTokenizer, _build_kimi_k3_pat_str
 
@@ -34,6 +35,9 @@ def test_kimi_k3_tokenizer_pattern_matches_reference_regex():
 
     assert _build_kimi_k3_pat_str() == reference_pattern
     assert "pat_str" not in TikTokenTokenizer.__dict__
+    assert {
+        name: value for name, value in vars(kimi_k3_tokenization).items() if isinstance(value, str) and "&&" in value
+    } == {}
 
 
 def test_medium_thinking_effort_is_rendered():


### PR DESCRIPTION
# What does this PR do ?

Fix Fern library-reference generation failures caused by Kimi K3 tokenizer metadata and quote-bearing autodoc type/default strings.

# Changelog

- Keep Kimi K3 regex set-intersection fragments local to the regex builder so Fern does not emit module-level `&&` values into generated MDX.
- Preserve the exact runtime tokenizer regex and add a regression assertion for exposed module strings.
- Correct the Kimi tokenizer's stale documented defaults and make the generated parameter metadata JSX-safe.
- Move quote-bearing `torch_dtype` defaults from generated type attributes into prose.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added the focused Kimi regex regression assertion.
- [x] Updated the affected autodoc source documentation.

Validation:

- `ruff format .`
- `ruff check --fix .`
- `pytest -q tests/unit_tests/models/kimi_k3/test_encoding.py` (5 passed)
- `make -C docs/fern docs-check` (0 errors)
- Fern 5.89.3 local library generation (605 pages)
- MDX 3 compilation of all generated library pages (609 validated)

# Additional Information

Unblocks the privileged Fern preview build for #3351, which regenerates the Python library reference from `main`.
