### PR TITLE
perf(nemotron): use TE FusedAdam for Super v3 benchmark

### DIFF
--- a/examples/llm_benchmark/nemotron/nemotron_super_v3_te_deepep.yaml
+++ b/examples/llm_benchmark/nemotron/nemotron_super_v3_te_deepep.yaml
@@ -84,13 +84,19 @@ dataloader:
   num_workers: 0
 
 optimizer:
-  _target_: torch.optim.Adam
+  # Transformer Engine FusedAdam avoids the slow native Adam path for
+  # FSDP2-sharded (DTensor) bf16 parameters in torch>=2.12. The native
+  # optimizer accounts for a significant part of the 26.06 performance
+  # regression in this recipe. Keep bf16 optimizer-state semantics to match
+  # the previous torch.optim.Adam configuration.
+  _target_: nemo_automodel.components.optim.optimizer.FusedAdamConfig
   betas:
   - 0.9
   - 0.999
   eps: 1e-8
   lr: 0.0001
   weight_decay: 0
+  master_weights: false
 
 ci:
   time: "00:15:00"


### PR DESCRIPTION
# What does this PR do ?

Fix the AMINT-184 Nemotron Super v3 26.06 performance regression by replacing native Adam with Transformer Engine FusedAdam in the benchmark recipe.

# Changelog

- Use `FusedAdamConfig` for `nemotron_super_v3_te_deepep`.
- Set `master_weights: false` to retain the prior bf16 optimizer-state semantics.
- Keep the HybridEP dispatcher, `torch_mm` experts, and HybridEP dependency unchanged; local component A/B testing showed those paths are not the regression source.

# Validation

- Exact failed container, 8xH100, 8-layer local repro, 10 measured steps: native Adam optimizer 0.05 s and iteration 1.218 s; FusedAdam optimizer 0.02 s and iteration 1.190 s, with identical losses.
- `uv run pytest -q tests/unit_tests/optim/test_fused_adam_empty_local_shards.py`: 10 passed, 1 skipped.
- Same-container full 8-node NeMo-CI proof: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/60680606 (running).

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed Contributor guidelines
- [x] Did you write any new necessary tests? Existing focused optimizer tests cover this config target.
- [x] Did you add or update any necessary documentation? The recipe comment documents the container-specific reason.

# Additional Information

- Linear: AMINT-184