### PR TITLE
feat(pretrain): add validated Qwen3-8B recipes

### DIFF
--- a/examples/llm_pretrain/qwen3_8b_fineweb_edu_pretrain.yaml
+++ b/examples/llm_pretrain/qwen3_8b_fineweb_edu_pretrain.yaml
@@ -1,0 +1,190 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Full Qwen3-8B random-initialized pretraining on a real FineWeb-Edu corpus.
+# PRETRAIN_DATA must contain Megatron indexed shards produced with the Qwen3-8B
+# tokenizer; see tools/preprocess_megatron_dataset.py. Run on one 8-GPU node:
+#   PRETRAIN_DATA=/path/to/fineweb_edu_qwen3 \
+#     automodel examples/llm_pretrain/qwen3_8b_fineweb_edu_pretrain.yaml \
+#     --nproc-per-node 8
+
+recipe: TrainFinetuneRecipeForNextTokenPrediction
+seed: 1234
+
+step_scheduler:
+  global_batch_size: 8
+  local_batch_size: 1
+  num_epochs: null
+  max_steps: 100000
+  val_every_steps: 1000
+  # A full exact-resume checkpoint is ~93 GiB. Saving every validation interval
+  # makes async checkpoint I/O overlap training continuously; checkpoint less
+  # often while retaining 1k-step validation visibility.
+  ckpt_every_steps: 10000
+  save_checkpoint_every_epoch: false
+  log_remote_every_steps: 10
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 30
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_config
+  config:
+    _target_: transformers.Qwen3Config
+    architectures: [Qwen3ForCausalLM]
+    vocab_size: 151936
+    hidden_size: 4096
+    intermediate_size: 12288
+    num_hidden_layers: 36
+    num_attention_heads: 32
+    num_key_value_heads: 8
+    head_dim: 128
+    max_position_embeddings: 40960
+    max_window_layers: 36
+    hidden_act: silu
+    rms_norm_eps: 1.0e-6
+    initializer_range: 0.02
+    rope_theta: 1000000.0
+    rope_scaling: null
+    sliding_window: null
+    use_sliding_window: false
+    attention_bias: false
+    attention_dropout: 0.0
+    tie_word_embeddings: false
+    bos_token_id: 151643
+    eos_token_id: 151645
+    use_cache: false
+  torch_dtype: bfloat16
+  load_base_model: false
+  force_hf: false
+  use_liger_kernel: false
+  attn_implementation: sdpa
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: sdpa
+    linear: torch
+    rms_norm: torch_fp32
+    rope_fusion: false
+    enable_hf_state_dict_adapter: true
+    enable_fsdp_optimizations: true
+
+checkpoint:
+  enabled: true
+  checkpoint_dir: ${oc.env:PRETRAIN_CHECKPOINT_DIR,checkpoints/qwen3_8b_fineweb_edu}
+  model_save_format: torch_save
+  save_consolidated: false
+  restore_from: LATEST
+  is_async: true
+  wait_for_staging: true
+  max_recent_checkpoints: 2
+
+distributed:
+  strategy: fsdp2
+  dp_size: none
+  tp_size: 2
+  cp_size: 1
+  pp_size: 1
+  sequence_parallel: false
+  activation_checkpointing: true
+  mp_policy:
+    _target_: torch.distributed.fsdp.MixedPrecisionPolicy
+    param_dtype: bfloat16
+    reduce_dtype: float32
+    output_dtype: bfloat16
+    cast_forward_inputs: true
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+clip_grad_norm:
+  max_norm: 1.0
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.megatron_dataset.MegatronPretrainingConfig
+  paths: ${oc.env:PRETRAIN_DATA}/processed_data_*_text_document*
+  index_mapping_dir: ${oc.env:PRETRAIN_INDEX_DIR,./fineweb_edu_qwen3_mapping}
+  tokenizer:
+    _target_: nemo_automodel._transformers.auto_tokenizer.NeMoAutoTokenizer.from_pretrained
+    pretrained_model_name_or_path: Qwen/Qwen3-8B
+  seq_length: 2048
+  seed: 1234
+  split: "999,1,0"
+  splits_to_build: train
+  num_dataset_builder_threads: 4
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: torch.utils.data.default_collate
+  dataloader_type: cyclic
+  # Megatron indexed readers own mmap/file handles and stay in the rank process.
+  num_workers: 0
+  pin_memory: true
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.llm.megatron_dataset.MegatronPretrainingConfig
+  paths: ${oc.env:PRETRAIN_DATA}/processed_data_*_text_document*
+  index_mapping_dir: ${oc.env:PRETRAIN_INDEX_DIR,./fineweb_edu_qwen3_mapping}
+  tokenizer:
+    _target_: nemo_automodel._transformers.auto_tokenizer.NeMoAutoTokenizer.from_pretrained
+    pretrained_model_name_or_path: Qwen/Qwen3-8B
+  seq_length: 2048
+  seed: 1234
+  split: "999,1,0"
+  splits_to_build: validation
+  num_val_samples: 64
+  num_dataset_builder_threads: 4
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  collate_fn: torch.utils.data.default_collate
+  dataloader_type: single
+  num_workers: 0
+  pin_memory: true
+
+optimizer:
+  _target_: transformer_engine.pytorch.optimizers.fused_adam.FusedAdam
+  lr: 3.0e-4
+  betas: [0.9, 0.95]
+  eps: 1.0e-8
+  weight_decay: 0.1
+  adam_w_mode: true
+  bias_correction: true
+  master_weights: true
+  store_param_remainders: true
+  exp_avg_dtype: torch.float32
+  exp_avg_sq_dtype: torch.float32
+
+lr_scheduler:
+  lr_decay_style: cosine
+  lr_warmup_steps: 2000
+  lr_decay_steps: 100000
+  init_lr: 0.0
+  min_lr: 3.0e-5
+
+# Add a wandb block or CLI overrides for remote experiment tracking, e.g.:
+# wandb:
+#   project: automodel
+#   entity: your-team
+#   name: qwen3-8b-fineweb-edu-100k
+#   dir: result/wandb
+
+ci:
+  recipe_owner: akoumpa
+  nodes: 1
+  time: "00:20:00"
+  nproc_per_node: 8
+  cluster_tag: h100
+  env_vars:
+    REQUIRE_FINITE_METRICS: "true"

--- a/examples/llm_pretrain/qwen3_8b_pretrain.yaml
+++ b/examples/llm_pretrain/qwen3_8b_pretrain.yaml
@@ -1,0 +1,160 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Full Qwen3-8B random-initialized pretraining baseline on one 8-GPU node.
+# The architecture matches the official Qwen/Qwen3-8B config, but pretrained
+# weights are not downloaded or loaded. Run with:
+#   automodel examples/llm_pretrain/qwen3_8b_pretrain.yaml --nproc-per-node 8
+# Observed on 8x H100 with Transformers 5.12.1: validation loss 8.1326 after
+# step 5 and 3.9838 after step 10, 35.35 GiB peak memory per GPU, and roughly
+# 15.7k aggregate tokens/second after warmup.
+
+recipe: TrainFinetuneRecipeForNextTokenPrediction
+seed: 1234
+
+step_scheduler:
+  global_batch_size: 8
+  local_batch_size: 1
+  max_steps: 10
+  val_every_steps: 5
+  ckpt_every_steps: 10
+
+dist_env:
+  backend: nccl
+  timeout_minutes: 30
+
+model:
+  _target_: nemo_automodel.NeMoAutoModelForCausalLM.from_config
+  config:
+    _target_: transformers.Qwen3Config
+    architectures: [Qwen3ForCausalLM]
+    vocab_size: 151936
+    hidden_size: 4096
+    intermediate_size: 12288
+    num_hidden_layers: 36
+    num_attention_heads: 32
+    num_key_value_heads: 8
+    head_dim: 128
+    max_position_embeddings: 40960
+    max_window_layers: 36
+    hidden_act: silu
+    rms_norm_eps: 1.0e-6
+    initializer_range: 0.02
+    rope_theta: 1000000.0
+    rope_scaling: null
+    sliding_window: null
+    use_sliding_window: false
+    attention_bias: false
+    attention_dropout: 0.0
+    tie_word_embeddings: false
+    bos_token_id: 151643
+    eos_token_id: 151645
+    use_cache: false
+  torch_dtype: bfloat16
+  load_base_model: false
+  force_hf: false
+  use_liger_kernel: false
+  attn_implementation: sdpa
+  backend:
+    _target_: nemo_automodel.components.models.common.BackendConfig
+    attn: sdpa
+    linear: torch
+    rms_norm: torch_fp32
+    rope_fusion: false
+    enable_hf_state_dict_adapter: true
+    enable_fsdp_optimizations: true
+
+checkpoint:
+  enabled: false
+
+distributed:
+  strategy: fsdp2
+  dp_size: none
+  tp_size: 2
+  cp_size: 1
+  pp_size: 1
+  sequence_parallel: false
+  activation_checkpointing: true
+  mp_policy:
+    _target_: torch.distributed.fsdp.MixedPrecisionPolicy
+    param_dtype: bfloat16
+    reduce_dtype: float32
+    output_dtype: bfloat16
+    cast_forward_inputs: true
+
+loss_fn:
+  _target_: nemo_automodel.components.loss.masked_ce.MaskedCrossEntropy
+
+clip_grad_norm:
+  max_norm: 1.0
+
+dataset:
+  _target_: nemo_automodel.components.datasets.llm.mock_pretraining.MockPretrainingDatasetConfig
+  # Samples are already tokenized, so do not infer a tokenizer from a model ID.
+  # Replace this block with a production pretraining dataset for a corpus run.
+  tokenizer: null
+  vocab_size: 151936
+  eod_token_id: 151645
+  seq_length: 2048
+  num_samples: 80
+  split: train
+
+dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  batch_size: 1
+  num_workers: 0
+  shuffle: false
+
+validation_dataset:
+  _target_: nemo_automodel.components.datasets.llm.mock_pretraining.MockPretrainingDatasetConfig
+  tokenizer: null
+  vocab_size: 151936
+  eod_token_id: 151645
+  seq_length: 2048
+  num_samples: 8
+  split: validation
+
+validation_dataloader:
+  _target_: torchdata.stateful_dataloader.StatefulDataLoader
+  batch_size: 1
+  num_workers: 0
+  shuffle: false
+
+optimizer:
+  _target_: transformer_engine.pytorch.optimizers.fused_adam.FusedAdam
+  lr: 3.0e-4
+  betas: [0.9, 0.95]
+  eps: 1.0e-8
+  weight_decay: 0.1
+  adam_w_mode: true
+  bias_correction: true
+  master_weights: true
+  store_param_remainders: true
+  exp_avg_dtype: torch.float32
+  exp_avg_sq_dtype: torch.float32
+
+lr_scheduler:
+  lr_decay_style: cosine
+  lr_warmup_steps: 2
+  init_lr: 0.0
+  min_lr: 3.0e-5
+
+ci:
+  recipe_owner: akoumpa
+  nodes: 1
+  time: "00:20:00"
+  nproc_per_node: 8
+  cluster_tag: h100
+  env_vars:
+    REQUIRE_FINITE_METRICS: "true"

--- a/nemo_automodel/components/datasets/llm/mock_pretraining.py
+++ b/nemo_automodel/components/datasets/llm/mock_pretraining.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+
+
+class _MockPretrainingDataset(Dataset):
+    """Deterministic document-based samples for pretraining smoke tests."""
+
+    _SPLIT_BOUNDS = {
+        "train": (0.0, 1.0 / 3.0),
+        "validation": (1.0 / 3.0, 2.0 / 3.0),
+        "test": (2.0 / 3.0, 1.0),
+    }
+    _CORPUS_SEED = 0
+    _CORPUS_SIZE = 100_000
+    _MAX_DOCUMENT_LENGTH = 4096
+    _SAMPLE_SEED = 1234
+
+    def __init__(
+        self,
+        *,
+        vocab_size: int,
+        eod_token_id: int,
+        seq_length: int,
+        num_samples: int,
+        split: Literal["train", "validation", "test"],
+    ) -> None:
+        self.vocab_size = vocab_size
+        self.eod_token_id = eod_token_id
+        self.seq_length = seq_length
+        self.num_samples = num_samples
+        self.position_ids = torch.arange(seq_length, dtype=torch.long)
+
+        corpus_rng = np.random.default_rng(seed=self._CORPUS_SEED)
+        sequence_lengths = corpus_rng.integers(
+            low=1,
+            high=self._MAX_DOCUMENT_LENGTH,
+            size=self._CORPUS_SIZE,
+            dtype=np.int32,
+        )
+        split_start, split_end = self._SPLIT_BOUNDS[split]
+        document_ids = np.arange(
+            int(split_start * self._CORPUS_SIZE),
+            int(split_end * self._CORPUS_SIZE),
+            dtype=np.int32,
+        )
+
+        sample_rng = np.random.RandomState(self._SAMPLE_SEED)
+        sample_rng.shuffle(document_ids)
+        self._document_lengths = sequence_lengths[document_ids]
+        self._document_ends = np.cumsum(self._document_lengths, dtype=np.int64)
+
+        available_samples = int((self._document_ends[-1] - 1) // seq_length)
+        if num_samples > available_samples:
+            raise ValueError(
+                f"num_samples={num_samples} exceeds the {available_samples} complete samples "
+                f"available in the {split} split"
+            )
+        shuffle_dtype = np.uint32 if available_samples < np.iinfo(np.uint32).max - 1 else np.int64
+        self._shuffle_index = np.arange(available_samples, dtype=shuffle_dtype)
+        sample_rng.shuffle(self._shuffle_index)
+
+    def __len__(self) -> int:
+        return self.num_samples
+
+    def __getitem__(self, index: int) -> dict[str, torch.Tensor]:
+        """Build one deterministic autoregressive sample."""
+        sample_index = int(self._shuffle_index[index])
+        stream_offset = sample_index * self.seq_length
+        tokens = np.empty(self.seq_length + 1, dtype=np.int64)
+        write_offset = 0
+
+        while write_offset < tokens.size:
+            document_index = int(np.searchsorted(self._document_ends, stream_offset, side="right"))
+            document_start = 0 if document_index == 0 else int(self._document_ends[document_index - 1])
+            offset_in_document = stream_offset - document_start
+            document_length = int(self._document_lengths[document_index])
+            take = min(document_length - offset_in_document, tokens.size - write_offset)
+
+            positions = np.arange(offset_in_document, offset_in_document + take, dtype=np.int64)
+            part = (positions + 1) % self.vocab_size
+            if positions[-1] == document_length - 1:
+                part[-1] = self.eod_token_id
+            tokens[write_offset : write_offset + take] = part
+            stream_offset += take
+            write_offset += take
+
+        token_tensor = torch.from_numpy(tokens)
+        return {
+            "input_ids": token_tensor[:-1],
+            "labels": token_tensor[1:],
+            "position_ids": self.position_ids,
+        }
+
+
+@dataclass(frozen=True)
+class MockPretrainingDatasetConfig:
+    """Configuration for a deterministic document-based pretraining corpus."""
+
+    vocab_size: int = 32000
+    """Tokenizer vocabulary size, including the end-of-document token."""
+    eod_token_id: int | None = None
+    """End-of-document token ID. Defaults to the final vocabulary entry."""
+    seq_length: int = 512
+    """Number of input and label tokens in each shifted sample."""
+    num_samples: int = 100_000
+    """Number of samples exposed by the dataset."""
+    split: Literal["train", "validation", "test"] = "train"
+    """Disjoint document split to expose."""
+
+    def __post_init__(self) -> None:
+        if self.vocab_size < 2:
+            raise ValueError(f"vocab_size must be at least 2, got {self.vocab_size}")
+        if self.eod_token_id is not None and not 0 <= self.eod_token_id < self.vocab_size:
+            raise ValueError(f"eod_token_id must be in [0, {self.vocab_size}), got {self.eod_token_id}")
+        if self.seq_length < 1:
+            raise ValueError(f"seq_length must be positive, got {self.seq_length}")
+        if self.num_samples < 1:
+            raise ValueError(f"num_samples must be positive, got {self.num_samples}")
+        if self.split not in _MockPretrainingDataset._SPLIT_BOUNDS:
+            raise ValueError(f"split must be train, validation, or test, got {self.split!r}")
+
+    def build(self) -> Dataset:
+        """Build the configured deterministic dataset."""
+        return _MockPretrainingDataset(
+            vocab_size=self.vocab_size,
+            eod_token_id=self.vocab_size - 1 if self.eod_token_id is None else self.eod_token_id,
+            seq_length=self.seq_length,
+            num_samples=self.num_samples,
+            split=self.split,
+        )

--- a/tests/unit_tests/datasets/llm/test_mock_pretraining.py
+++ b/tests/unit_tests/datasets/llm/test_mock_pretraining.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from nemo_automodel.components.datasets.llm.mock_pretraining import MockPretrainingDatasetConfig
+
+
+def test_mock_pretraining_dataset_builds_deterministic_shifted_samples() -> None:
+    config = MockPretrainingDatasetConfig(
+        vocab_size=32,
+        seq_length=8,
+        num_samples=4,
+    )
+    first_dataset = config.build()
+    second_dataset = config.build()
+
+    for index in range(len(first_dataset)):
+        first = first_dataset[index]
+        second = second_dataset[index]
+        torch.testing.assert_close(first["input_ids"][1:], first["labels"][:-1])
+        torch.testing.assert_close(first["input_ids"], second["input_ids"])
+        torch.testing.assert_close(first["labels"], second["labels"])
+        torch.testing.assert_close(first["position_ids"], torch.arange(8))
+
+
+def test_mock_pretraining_dataset_uses_distinct_splits() -> None:
+    common = {
+        "vocab_size": 32,
+        "seq_length": 8,
+        "num_samples": 4,
+    }
+    train = MockPretrainingDatasetConfig(**common, split="train").build()
+    validation = MockPretrainingDatasetConfig(**common, split="validation").build()
+
+    assert not torch.equal(train[0]["input_ids"], validation[0]["input_ids"])
+
+
+def test_mock_pretraining_dataset_inserts_end_of_document_tokens() -> None:
+    dataset = MockPretrainingDatasetConfig(
+        vocab_size=5000,
+        eod_token_id=4998,
+        seq_length=512,
+        num_samples=32,
+    ).build()
+
+    assert any(torch.any(dataset[index]["labels"] == 4998) for index in range(len(dataset)))
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("vocab_size", 1, "vocab_size must be at least 2"),
+        ("eod_token_id", 16, "eod_token_id must be in"),
+        ("seq_length", 0, "seq_length must be positive"),
+        ("num_samples", 0, "num_samples must be positive"),
+        ("split", "dev", "split must be train, validation, or test"),
+    ],
+)
+def test_mock_pretraining_dataset_rejects_invalid_config(field: str, value: object, message: str) -> None:
+    kwargs = {"vocab_size": 16, "seq_length": 4, "num_samples": 2, field: value}
+    with pytest.raises(ValueError, match=message):
+        MockPretrainingDatasetConfig(**kwargs)
+
+
+def test_mock_pretraining_dataset_rejects_excess_samples() -> None:
+    config = MockPretrainingDatasetConfig(
+        vocab_size=16,
+        seq_length=512,
+        num_samples=200_000,
+    )
+
+    with pytest.raises(ValueError, match="exceeds the .* complete samples"):
+        config.build()

--- a/tests/unit_tests/recipes/test_qwen3_8b_pretrain_recipe.py
+++ b/tests/unit_tests/recipes/test_qwen3_8b_pretrain_recipe.py
@@ -20,6 +20,7 @@ from transformers import Qwen3Config, Qwen3ForCausalLM
 
 REPO_ROOT = Path(__file__).parents[3]
 RECIPE_PATH = REPO_ROOT / "examples/llm_pretrain/qwen3_8b_pretrain.yaml"
+FINEWEB_RECIPE_PATH = REPO_ROOT / "examples/llm_pretrain/qwen3_8b_fineweb_edu_pretrain.yaml"
 
 
 def test_qwen3_8b_pretrain_recipe_uses_full_official_architecture() -> None:
@@ -84,3 +85,30 @@ def test_qwen3_8b_pretrain_recipe_has_reproducible_eight_gpu_smoke_shape() -> No
     assert recipe["distributed"]["activation_checkpointing"] is True
     assert recipe["ci"]["nodes"] == 1
     assert recipe["ci"]["nproc_per_node"] == 8
+
+
+def test_qwen3_8b_fineweb_recipe_uses_real_qwen_tokenized_pretraining_data() -> None:
+    recipe = yaml.safe_load(FINEWEB_RECIPE_PATH.read_text(encoding="utf-8"))
+    smoke_recipe = yaml.safe_load(RECIPE_PATH.read_text(encoding="utf-8"))
+
+    assert recipe["model"]["config"] == smoke_recipe["model"]["config"]
+    assert recipe["step_scheduler"]["max_steps"] == 100000
+    assert recipe["step_scheduler"]["num_epochs"] is None
+    assert recipe["step_scheduler"]["val_every_steps"] == 1000
+    assert recipe["step_scheduler"]["ckpt_every_steps"] == 10000
+    assert recipe["dataset"]["_target_"].endswith("MegatronPretrainingConfig")
+    assert recipe["validation_dataset"]["_target_"].endswith("MegatronPretrainingConfig")
+    assert "mock" not in recipe["dataset"]["_target_"].lower()
+    assert recipe["dataset"]["tokenizer"]["pretrained_model_name_or_path"] == "Qwen/Qwen3-8B"
+    assert recipe["dataset"]["seq_length"] == 2048
+    assert recipe["dataset"]["splits_to_build"] == "train"
+    assert recipe["validation_dataset"]["splits_to_build"] == "validation"
+    assert recipe["dataloader"]["dataloader_type"] == "cyclic"
+    assert recipe["dataloader"]["num_workers"] == 0
+    assert recipe["validation_dataloader"]["num_workers"] == 0
+    assert recipe["checkpoint"]["restore_from"] == "LATEST"
+    assert recipe["checkpoint"]["is_async"] is True
+    assert recipe["optimizer"]["master_weights"] is True
+    assert recipe["optimizer"]["store_param_remainders"] is True
+    assert recipe["optimizer"]["exp_avg_dtype"] == "torch.float32"
+    assert recipe["optimizer"]["exp_avg_sq_dtype"] == "torch.float32"

--- a/tests/unit_tests/recipes/test_qwen3_8b_pretrain_recipe.py
+++ b/tests/unit_tests/recipes/test_qwen3_8b_pretrain_recipe.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+import torch
+import yaml
+from transformers import Qwen3Config, Qwen3ForCausalLM
+
+REPO_ROOT = Path(__file__).parents[3]
+RECIPE_PATH = REPO_ROOT / "examples/llm_pretrain/qwen3_8b_pretrain.yaml"
+
+
+def test_qwen3_8b_pretrain_recipe_uses_full_official_architecture() -> None:
+    recipe = yaml.safe_load(RECIPE_PATH.read_text(encoding="utf-8"))
+
+    assert recipe["model"]["_target_"] == "nemo_automodel.NeMoAutoModelForCausalLM.from_config"
+    model_config = recipe["model"]["config"]
+    assert model_config == {
+        "_target_": "transformers.Qwen3Config",
+        "architectures": ["Qwen3ForCausalLM"],
+        "vocab_size": 151936,
+        "hidden_size": 4096,
+        "intermediate_size": 12288,
+        "num_hidden_layers": 36,
+        "num_attention_heads": 32,
+        "num_key_value_heads": 8,
+        "head_dim": 128,
+        "max_position_embeddings": 40960,
+        "max_window_layers": 36,
+        "hidden_act": "silu",
+        "rms_norm_eps": 1.0e-6,
+        "initializer_range": 0.02,
+        "rope_theta": 1000000.0,
+        "rope_scaling": None,
+        "sliding_window": None,
+        "use_sliding_window": False,
+        "attention_bias": False,
+        "attention_dropout": 0.0,
+        "tie_word_embeddings": False,
+        "bos_token_id": 151643,
+        "eos_token_id": 151645,
+        "use_cache": False,
+    }
+    assert recipe["model"]["load_base_model"] is False
+    assert recipe["model"]["force_hf"] is False
+    assert recipe["dataset"]["tokenizer"] is None
+    assert recipe["validation_dataset"]["tokenizer"] is None
+    assert recipe["dataset"]["vocab_size"] == 151936
+    assert recipe["dataset"]["eod_token_id"] == 151645
+
+    config_kwargs = dict(model_config)
+    config_kwargs.pop("_target_")
+    with torch.device("meta"):
+        model = Qwen3ForCausalLM(Qwen3Config(**config_kwargs))
+    assert sum(parameter.numel() for parameter in model.parameters()) == 8_190_735_360
+
+
+def test_qwen3_8b_pretrain_recipe_has_reproducible_eight_gpu_smoke_shape() -> None:
+    recipe = yaml.safe_load(RECIPE_PATH.read_text(encoding="utf-8"))
+
+    assert recipe["seed"] == 1234
+    assert recipe["step_scheduler"] == {
+        "global_batch_size": 8,
+        "local_batch_size": 1,
+        "max_steps": 10,
+        "val_every_steps": 5,
+        "ckpt_every_steps": 10,
+    }
+    assert recipe["dataset"]["seq_length"] == 2048
+    assert recipe["distributed"]["strategy"] == "fsdp2"
+    assert recipe["distributed"]["tp_size"] == 2
+    assert recipe["distributed"]["activation_checkpointing"] is True
+    assert recipe["ci"]["nodes"] == 1
+    assert recipe["ci"]["nproc_per_node"] == 8


### PR DESCRIPTION
# What does this PR do ?

Adds full Qwen3-8B pretraining examples for deterministic smoke testing and real FineWeb-Edu training.

# Changelog

- Add a random-initialized Qwen3-8B smoke recipe using the official 8.19B-parameter architecture.
- Add deterministic mock pretraining data for reproducible recipe validation without external downloads.
- Add a real FineWeb-Edu recipe configured for 100k resumable steps on one 8-GPU node.
- Keep validation every 1k steps and async exact-resume checkpoints every 10k steps to avoid continuous checkpoint-I/O overlap.
- Preserve Transformer Engine master-weight remainders and FP32 Adam moments for exact optimizer resume.
- Add architecture, schedule, dataset, optimizer-state, and YAML configuration tests.

# Validation

- `20 passed`: mock dataset, Qwen3-8B recipe, and example YAML-linter tests.
- Ruff format and lint checks passed for all changed Python files.
- `git diff --check` passed.
- The real-data recipe was exercised on one 8-H100 node with TP=2 and DP=4. This validated finite training, checkpoint/resume configuration, and the checkpoint-I/O throughput diagnosis; the full 100k-step completion remains ongoing.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed the Contributor guidelines.
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

# Additional Information

The recipe expects Megatron-indexed shards produced with the Qwen3-8B tokenizer. Dataset and checkpoint locations are supplied through environment variables.