### PR TITLE
perf(checkpoint): reduce distributed save overhead

### DIFF
--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -591,7 +591,7 @@ class Checkpointer:
         should_write_consolidated = _should_write_consolidated_safetensors(self.config, is_final_checkpoint)
         consolidated_dir = os.path.join(model_dir, "consolidated") if should_write_consolidated else None
         hf_metadata_dir = os.path.join(model_dir, ".hf_metadata") if _should_write_hf_metadata(self.config) else None
-        _ensure_dirs(model_dir, consolidated_dir, hf_metadata_dir, process_group=self.process_group)
+        _ensure_shared_dirs(model_dir, consolidated_dir, hf_metadata_dir, process_group=self.process_group)
 
         # Because this call lies outside of the dcp save call, we need to consolidate on all ranks on the main process
         # of all ranks, which lies on the critical path. Therefore, we can only do this outside of async mode.
@@ -719,7 +719,7 @@ class Checkpointer:
                 per-model-part optimizers.
         """
         optimizer_path = os.path.join(weights_path, "optim")
-        _ensure_dirs(optimizer_path, process_group=self.process_group)
+        _ensure_shared_dirs(optimizer_path, process_group=self.process_group)
         optimizer_state = OptimizerState(
             model,
             optimizer,
@@ -1383,7 +1383,7 @@ class Checkpointer:
         DTensor metadata and writes all shards correctly.
         """
         state_dir = os.path.join(path, state_name)
-        _ensure_dirs(state_dir, process_group=self.process_group)
+        _ensure_shared_dirs(state_dir, process_group=self.process_group)
         state_dict = state.state_dict()
         planner = dcp.DefaultSavePlanner(enable_plan_caching=True)
         process_group = getattr(self, "process_group", None)
@@ -1438,8 +1438,8 @@ class Checkpointer:
         Returns:
             The populated state dictionary (may be replaced for PEFT).
         """
-        # Both model and optimizer saving is done in this function
-        is_model = True if "/model" in path else False
+        # Both model and optimizer loading is done in this function.
+        is_model = _is_model_checkpoint_path(path)
         # PEFT loading is broadcasted from rank0 so it is a special case
         if self.config.is_peft and is_model and (not is_init_step):
             state_dict = _load_safetensors(_adapter_path(path))
@@ -1467,8 +1467,8 @@ class Checkpointer:
         Returns:
             Optional Future object if async mode is enabled.
         """
-        # Both model and optimizer saving is done in this function
-        is_model = True if "/model" in path else False
+        # Both model and optimizer saving is done in this function.
+        is_model = _is_model_checkpoint_path(path)
         # PEFT saving is done on rank0 so it is a special case
         if self.config.is_peft and is_model:
             if not torch.distributed.is_initialized() or torch.distributed.get_rank(group=self.process_group) == 0:
@@ -1919,6 +1919,13 @@ def save_config(config: dict[str, Any], weights_path: str) -> None:
             yaml.dump(config, f, sort_keys=False, default_flow_style=False)
 
 
+def _create_dirs(*dirs: Optional[str]) -> None:
+    """Create local directory paths and ignore cloud paths."""
+    for directory in dirs:
+        if directory and not is_cloud_path(directory):
+            os.makedirs(directory, exist_ok=True)
+
+
 def _ensure_dirs(*dirs: Optional[str], process_group: torch.distributed.ProcessGroup | None = None) -> None:
     """
     Create directories on all ranks and synchronize across ranks.
@@ -1927,14 +1934,31 @@ def _ensure_dirs(*dirs: Optional[str], process_group: torch.distributed.ProcessG
         *dirs: One or more directory paths that should exist.
         process_group: Ranks that must observe the directories before continuing.
     """
+    _create_dirs(*dirs)
+    if torch.distributed.is_initialized():
+        torch.distributed.barrier(group=process_group)
+
+
+def _ensure_shared_dirs(*dirs: Optional[str], process_group: torch.distributed.ProcessGroup | None = None) -> None:
+    """Create shared DCP directories on group rank zero and synchronize the group.
+
+    Unlike auxiliary per-rank state, DCP checkpoint directories must be visible
+    to every rank through the same filesystem.
+
+    Args:
+        *dirs: One or more shared directory paths that should exist.
+        process_group: Ranks that must observe the directories before continuing.
+    """
     is_dist_initialized = torch.distributed.is_initialized()
-    is_group_rank_0 = not is_dist_initialized or torch.distributed.get_rank(group=process_group) == 0
-    if is_group_rank_0:
-        for d in dirs:
-            if d and not is_cloud_path(d):
-                os.makedirs(d, exist_ok=True)
+    if not is_dist_initialized or torch.distributed.get_rank(group=process_group) == 0:
+        _create_dirs(*dirs)
     if is_dist_initialized:
         torch.distributed.barrier(group=process_group)
+
+
+def _is_model_checkpoint_path(path: str) -> bool:
+    """Return whether a checkpoint path names the model directory."""
+    return Path(path.rstrip("/")).name == "model"
 
 
 def _init_peft_adapters(model: nn.Module, peft_init_method: str) -> None:

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -359,6 +359,14 @@ class _AsyncSaveContext:
     staging_active: bool = False
 
 
+class _ModelSavePlanner(dcp.DefaultSavePlanner):
+    """Keep cached model save plans separate from optimizer save plans."""
+
+
+class _OptimizerSavePlanner(dcp.DefaultSavePlanner):
+    """Keep cached optimizer save plans separate from model save plans."""
+
+
 def _new_gloo_process_group(
     process_group: torch.distributed.ProcessGroup | None,
     timeout: timedelta | None = None,
@@ -1470,7 +1478,8 @@ class Checkpointer:
             return
 
         ret = None
-        planner = dcp.DefaultSavePlanner(enable_plan_caching=True)
+        planner_cls = _ModelSavePlanner if is_model else _OptimizerSavePlanner
+        planner = planner_cls(enable_plan_caching=True)
 
         # Routes to MSC storage write for cloud paths
         storage_writer = _maybe_msc_writer(path, storage_writer)
@@ -1918,11 +1927,13 @@ def _ensure_dirs(*dirs: Optional[str], process_group: torch.distributed.ProcessG
         *dirs: One or more directory paths that should exist.
         process_group: Ranks that must observe the directories before continuing.
     """
-    for d in dirs:
-        if d:
-            if not is_cloud_path(d):
+    is_dist_initialized = torch.distributed.is_initialized()
+    is_group_rank_0 = not is_dist_initialized or torch.distributed.get_rank(group=process_group) == 0
+    if is_group_rank_0:
+        for d in dirs:
+            if d and not is_cloud_path(d):
                 os.makedirs(d, exist_ok=True)
-    if torch.distributed.is_initialized():
+    if is_dist_initialized:
         torch.distributed.barrier(group=process_group)
 
 

--- a/nemo_automodel/components/checkpoint/checkpointing.py
+++ b/nemo_automodel/components/checkpoint/checkpointing.py
@@ -19,6 +19,7 @@ import os
 import pickle
 import threading
 import time
+import uuid
 from dataclasses import dataclass
 from datetime import timedelta
 from pathlib import Path
@@ -360,11 +361,19 @@ class _AsyncSaveContext:
 
 
 class _ModelSavePlanner(dcp.DefaultSavePlanner):
-    """Keep cached model save plans separate from optimizer save plans."""
+    """Keep model save plans in one checkpointer-scoped cache namespace."""
+
+    def __init__(self, cache_namespace: str) -> None:
+        super().__init__(enable_plan_caching=True)
+        self._cached_plans_key = f"{cache_namespace}:model"
 
 
 class _OptimizerSavePlanner(dcp.DefaultSavePlanner):
-    """Keep cached optimizer save plans separate from model save plans."""
+    """Keep optimizer save plans in one checkpointer-scoped cache namespace."""
+
+    def __init__(self, cache_namespace: str) -> None:
+        super().__init__(enable_plan_caching=True)
+        self._cached_plans_key = f"{cache_namespace}:optimizer"
 
 
 def _new_gloo_process_group(
@@ -528,6 +537,7 @@ class Checkpointer:
         self.tp_rank = tp_rank
         self.pp_rank = pp_rank
         self.process_group = process_group
+        self._planner_cache_namespace = uuid.uuid4().hex
 
         # async specific variables
         self._model_ctx = _AsyncSaveContext(stager=None, process_group=None, future=None, staging_active=False)
@@ -1479,7 +1489,7 @@ class Checkpointer:
 
         ret = None
         planner_cls = _ModelSavePlanner if is_model else _OptimizerSavePlanner
-        planner = planner_cls(enable_plan_caching=True)
+        planner = planner_cls(self._planner_cache_namespace)
 
         # Routes to MSC storage write for cloud paths
         storage_writer = _maybe_msc_writer(path, storage_writer)

--- a/nemo_automodel/recipes/base_recipe.py
+++ b/nemo_automodel/recipes/base_recipe.py
@@ -447,8 +447,6 @@ class BaseRecipe:
             if is_rank_0:
                 self._update_latest_symlink(prev_pending)
             setattr(self, "_last_pending_checkpoint_dir", None)
-            if is_dist_initialized:
-                _dist_barrier(process_group)
 
         if prev_best_pending is not None:
             if is_rank_0 and prev_best_pending.get("val") is not None:
@@ -458,8 +456,6 @@ class BaseRecipe:
                     prev_best_pending.get("metric_key"),
                 )
             setattr(self, "_last_pending_best_checkpoint_info", None)
-            if is_dist_initialized:
-                _dist_barrier(process_group)
 
         if is_rank_0:
             self._prune_old_checkpoints()

--- a/tests/unit_tests/checkpoint/test_checkpointing.py
+++ b/tests/unit_tests/checkpoint/test_checkpointing.py
@@ -16,6 +16,7 @@ import io
 import json
 import logging
 import os
+import pickle
 import random
 from contextlib import ExitStack
 from datetime import timedelta
@@ -2933,6 +2934,7 @@ def _make_ckptr(is_peft=False, is_async=False):
     ckptr._model_ctx = MagicMock(staging_active=False)
     ckptr._optim_ctx = MagicMock(staging_active=False)
     ckptr.process_group = None
+    ckptr._planner_cache_namespace = "test"
     return ckptr
 
 
@@ -3045,11 +3047,40 @@ def test_model_and_optimizer_saves_use_separate_plan_caches():
     with patch("nemo_automodel.components.checkpoint.checkpointing.dcp.save") as save:
         Checkpointer._do_save(ckptr, {"weight": torch.ones(1)}, "/opt/models/qwen/step_100/model")
         Checkpointer._do_save(ckptr, {"state": torch.ones(1)}, "/opt/models/qwen/step_100/optim")
+        Checkpointer._do_save(ckptr, {"weight": torch.ones(1)}, "/opt/models/qwen/step_200/model")
 
     model_planner = save.call_args_list[0].kwargs["planner"]
     optimizer_planner = save.call_args_list[1].kwargs["planner"]
+    next_model_planner = save.call_args_list[2].kwargs["planner"]
     assert type(model_planner) is not type(optimizer_planner)
     assert model_planner._cached_plans_key != optimizer_planner._cached_plans_key
+    assert model_planner._cached_plans_key == next_model_planner._cached_plans_key
+    assert model_planner._cached_plans_key.encode() in pickle.dumps(model_planner)
+
+
+def test_cross_checkpointer_torch_plan_is_not_reused_for_safetensors(tmp_path):
+    """A torch-save plan from one checkpointer must not leak into a safetensors save from another."""
+    torch_ckpt = CheckpointingConfig(
+        checkpoint_dir=tmp_path / "run_a",
+        model_save_format="torch_save",
+        save_consolidated=False,
+    ).build(0, 0, 0)
+    safe_ckpt = CheckpointingConfig(
+        checkpoint_dir=tmp_path / "run_b",
+        model_save_format="safetensors",
+        save_consolidated=False,
+    ).build(0, 0, 0)
+    model_state = {"weight": torch.ones(4)}
+    torch_model_path = tmp_path / "run_a" / "step_100" / "model"
+    torch_optim_path = tmp_path / "run_a" / "step_100" / "optim"
+    safe_model_path = tmp_path / "run_b" / "step_100" / "model"
+
+    torch_ckpt._do_save(model_state, str(torch_model_path))
+    torch_ckpt._do_save({"state": torch.ones(2)}, str(torch_optim_path))
+    writer = safe_ckpt._get_storage_writer(None, None, None, str(safe_model_path))
+    safe_ckpt._do_save(model_state, str(safe_model_path), writer)
+
+    assert list(safe_model_path.glob("*.safetensors"))
 
 
 class TestSaveConfig:
@@ -3167,6 +3198,7 @@ class TestDoLoad:
         config.is_async = False
         ckptr = MagicMock(spec=Checkpointer)
         ckptr.config = config
+        ckptr._planner_cache_namespace = "test"
         state_dict = {"weight": torch.ones(4)}
         path = "msc://bucket/step-300"
 
@@ -3741,6 +3773,7 @@ class TestSyncAsyncSave:
         ckptr._model_ctx = MagicMock(staging_active=False)
         ckptr._optim_ctx = MagicMock(staging_active=False)
         ckptr.process_group = None
+        ckptr._planner_cache_namespace = "test"
         return ckptr
 
     def test_dcp_cloud_sync_calls_dcp_save(self):

--- a/tests/unit_tests/checkpoint/test_checkpointing.py
+++ b/tests/unit_tests/checkpoint/test_checkpointing.py
@@ -2982,10 +2982,39 @@ class TestEnsureDirs:
         group = object()
         with (
             patch("torch.distributed.is_initialized", return_value=True),
+            patch("torch.distributed.get_rank", return_value=0) as get_rank,
             patch("torch.distributed.barrier") as barrier,
         ):
             _ensure_dirs(str(tmp_path), process_group=group)
+        get_rank.assert_called_once_with(group=group)
         barrier.assert_called_once_with(group=group)
+
+    def test_only_group_rank_zero_creates_distributed_directories(self, tmp_path):
+        """Nonzero group ranks wait for rank zero without issuing shared-filesystem metadata operations."""
+        group = object()
+        target = str(tmp_path / "new")
+        with (
+            patch("torch.distributed.is_initialized", return_value=True),
+            patch("torch.distributed.get_rank", return_value=1),
+            patch("os.makedirs") as makedirs,
+            patch("torch.distributed.barrier") as barrier,
+        ):
+            _ensure_dirs(target, process_group=group)
+        makedirs.assert_not_called()
+        barrier.assert_called_once_with(group=group)
+
+
+def test_model_and_optimizer_saves_use_separate_plan_caches():
+    """Alternating model and optimizer saves must not evict each other's cached DCP plans."""
+    ckptr = _make_ckptr(is_peft=False, is_async=False)
+    with patch("nemo_automodel.components.checkpoint.checkpointing.dcp.save") as save:
+        Checkpointer._do_save(ckptr, {"weight": torch.ones(1)}, "/tmp/checkpoint/model")
+        Checkpointer._do_save(ckptr, {"state": torch.ones(1)}, "/tmp/checkpoint/optim")
+
+    model_planner = save.call_args_list[0].kwargs["planner"]
+    optimizer_planner = save.call_args_list[1].kwargs["planner"]
+    assert type(model_planner) is not type(optimizer_planner)
+    assert model_planner._cached_plans_key != optimizer_planner._cached_plans_key
 
 
 class TestSaveConfig:

--- a/tests/unit_tests/checkpoint/test_checkpointing.py
+++ b/tests/unit_tests/checkpoint/test_checkpointing.py
@@ -47,6 +47,7 @@ from nemo_automodel.components.checkpoint.checkpointing import (
     SaveConsolidatedMode,
     _divide_keys_by_size,
     _ensure_dirs,
+    _ensure_shared_dirs,
     _equally_divide_layers,
     _is_custom_model,
     _load_hf_bin_checkpoint,
@@ -2982,15 +2983,13 @@ class TestEnsureDirs:
         group = object()
         with (
             patch("torch.distributed.is_initialized", return_value=True),
-            patch("torch.distributed.get_rank", return_value=0) as get_rank,
             patch("torch.distributed.barrier") as barrier,
         ):
             _ensure_dirs(str(tmp_path), process_group=group)
-        get_rank.assert_called_once_with(group=group)
         barrier.assert_called_once_with(group=group)
 
-    def test_only_group_rank_zero_creates_distributed_directories(self, tmp_path):
-        """Nonzero group ranks wait for rank zero without issuing shared-filesystem metadata operations."""
+    def test_each_rank_creates_node_local_directories(self, tmp_path):
+        """Every rank creates directories that may live on node-local filesystems."""
         group = object()
         target = str(tmp_path / "new")
         with (
@@ -3000,16 +2999,52 @@ class TestEnsureDirs:
             patch("torch.distributed.barrier") as barrier,
         ):
             _ensure_dirs(target, process_group=group)
+        makedirs.assert_called_once_with(target, exist_ok=True)
+        barrier.assert_called_once_with(group=group)
+
+    def test_only_group_rank_zero_creates_shared_directories(self, tmp_path):
+        """Nonzero group ranks avoid redundant metadata operations on shared filesystems."""
+        group = object()
+        target = str(tmp_path / "new")
+        with (
+            patch("torch.distributed.is_initialized", return_value=True),
+            patch("torch.distributed.get_rank", return_value=1),
+            patch("os.makedirs") as makedirs,
+            patch("torch.distributed.barrier") as barrier,
+        ):
+            _ensure_shared_dirs(target, process_group=group)
         makedirs.assert_not_called()
         barrier.assert_called_once_with(group=group)
+
+
+def test_save_on_dp_ranks_creates_node_local_directory_on_each_writer_rank():
+    """A nonzero distributed rank must create its local directory before writing auxiliary state."""
+    checkpointer = Checkpointer.__new__(Checkpointer)
+    checkpointer.process_group = object()
+    checkpointer.tp_rank = 0
+    checkpointer.pp_rank = 0
+    checkpointer.dp_rank = 1
+    state = SimpleNamespace(state_dict=lambda: {"state": torch.ones(1)})
+
+    with (
+        patch("torch.distributed.is_initialized", return_value=True),
+        patch("os.makedirs") as makedirs,
+        patch("torch.distributed.barrier") as barrier,
+        patch("torch.save") as save,
+    ):
+        checkpointer.save_on_dp_ranks(state, "rng", "/tmp/checkpoint")
+
+    makedirs.assert_called_once_with("/tmp/checkpoint/rng", exist_ok=True)
+    barrier.assert_called_once_with(group=checkpointer.process_group)
+    save.assert_called_once_with({"state": torch.ones(1)}, "/tmp/checkpoint/rng/rng_dp_rank_1.pt")
 
 
 def test_model_and_optimizer_saves_use_separate_plan_caches():
     """Alternating model and optimizer saves must not evict each other's cached DCP plans."""
     ckptr = _make_ckptr(is_peft=False, is_async=False)
     with patch("nemo_automodel.components.checkpoint.checkpointing.dcp.save") as save:
-        Checkpointer._do_save(ckptr, {"weight": torch.ones(1)}, "/tmp/checkpoint/model")
-        Checkpointer._do_save(ckptr, {"state": torch.ones(1)}, "/tmp/checkpoint/optim")
+        Checkpointer._do_save(ckptr, {"weight": torch.ones(1)}, "/opt/models/qwen/step_100/model")
+        Checkpointer._do_save(ckptr, {"state": torch.ones(1)}, "/opt/models/qwen/step_100/optim")
 
     model_planner = save.call_args_list[0].kwargs["planner"]
     optimizer_planner = save.call_args_list[1].kwargs["planner"]

--- a/tests/unit_tests/recipes/llm/test_finalize_pending_checkpoint.py
+++ b/tests/unit_tests/recipes/llm/test_finalize_pending_checkpoint.py
@@ -77,7 +77,7 @@ def test_finalize_uses_recipe_process_group(monkeypatch):
 
     r._finalize_pending_checkpoint()
 
-    assert barriers == [process_group, process_group]
+    assert barriers == [process_group]
 
 
 def test_finalize_is_noop_when_checkpointing_disabled():


### PR DESCRIPTION
# What does this PR do ?

Reduces metadata, planning, and synchronization overhead in distributed exact-resume checkpoint saves without changing checkpoint payloads or restore semantics.

# Changelog

- Create shared DCP checkpoint directories only on process-group rank zero, while preserving per-rank creation for node-local auxiliary state, then synchronize the group once the directories are visible.
- Give model and optimizer DCP save planners separate cache namespaces so alternating saves do not evict each others cached plans.
- Collapse async checkpoint publication from three distributed barriers to one after rank-zero pointer updates and retention pruning.
- Add focused coverage for group-rank directory creation, planner cache separation, and the reduced finalization barrier sequence.

# Performance impact

The shared-filesystem metadata path was measured in a controlled 8-rank A/B on cw-dfw Lustre. Each mode ran eight trials of 25 checkpoint setups with four directory groups per checkpoint.

| Metric | Before | This PR | Improvement |
| --- | ---: | ---: | ---: |
| `mkdir` calls per directory on 8 ranks | 8 | 1 | 87.5% fewer |
| `mkdir` calls for four directory groups | 32 | 4 | 87.5% fewer |
| Median Lustre directory setup per checkpoint | 7.89 ms | 3.06 ms | 61.3% lower; 2.58x faster |
| Async publication barriers | 3 | 1 | 66.7% fewer |
| Alternating model/optimizer plan-cache hit rate after warmup | 0% | 100% | Cross-eviction eliminated |
| Checkpoint tensor payload | Unchanged | Unchanged | No format or exact-resume tradeoff |

The planner-cache result comes from alternating model and optimizer plans through the same sequence used by checkpoint saves. With the shared cache namespace, all four post-warmup requests missed; with separate namespaces, all four hit and sent zero local plan items.

These are checkpoint control-plane improvements. This PR does not reduce the approximately 93 GiB exact-resume payload in the motivating Qwen3-8B configuration, so an end-to-end training TPS improvement during background checkpoint writes is not claimed yet. A full model baseline-vs-PR run is still needed to quantify checkpoint drain time, checkpoint-boundary step latency, and sustained TPS while I/O is active.

# Validation

- `219 passed, 5 skipped`: checkpoint, optimizer-state, and async-finalization tests.
- The suite includes a true two-process Gloo DCP optimizer save/restore round trip with restored-state equality.
- Ruff format and lint checks passed for all changed Python files.
- `git diff --check` passed.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed the Contributor guidelines.
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

# Additional Information

This intentionally leaves checkpoint tensor payloads unchanged. Distributed optimizer state and exact resume remain intact; the change only removes redundant shared-filesystem metadata operations, cache thrashing, and intermediate barriers.