### PR TITLE
fix(ci): enable LTX-2.3 diffusion finetuning

### DIFF
--- a/docs/fern/versions/nightly.yml
+++ b/docs/fern/versions/nightly.yml
@@ -289,6 +289,9 @@ navigation:
           - page: "HunyuanVideo 1.5"
             path: ../../model-coverage/diffusion/hunyuanvideo-community/hunyuanvideo.mdx
             slug: hunyuanvideo-1-5
+          - page: "LTX-2.3"
+            path: ../../model-coverage/diffusion/lightricks/ltx-2-3.mdx
+            slug: ltx-2-3
           - page: "Qwen-Image"
             path: ../../model-coverage/diffusion/qwen/qwen-image.mdx
       - section: "Embedding Models"

--- a/docs/guides/diffusion/finetune.mdx
+++ b/docs/guides/diffusion/finetune.mdx
@@ -5,9 +5,9 @@ position: 16
 ---
 ## Introduction
 
-Diffusion models generate images and videos by learning to reverse a noise process — starting from random noise and iteratively refining it into coherent visual output guided by a text prompt. Pretrained diffusion models (like [FLUX.1-dev](https://huggingface.co/black-forest-labs/FLUX.1-dev) for images or [Wan 2.1](https://huggingface.co/Wan-AI/Wan2.1-T2V-1.3B-Diffusers) for video) produce impressive general-purpose results, but they know nothing about your particular visual domain, style, or subject matter. Fine-tuning bridges that gap — you adapt the model on your own data so it produces outputs that match your requirements, without the cost of training from scratch.
+Diffusion models generate images and videos by learning to reverse a noise process, starting from random noise and iteratively refining it into coherent visual output guided by a text prompt. Pretrained diffusion models, such as [FLUX.1-dev](https://huggingface.co/black-forest-labs/FLUX.1-dev) for images or [Wan 2.1](https://huggingface.co/Wan-AI/Wan2.1-T2V-1.3B-Diffusers) for video, produce impressive general-purpose results, but they know nothing about your particular visual domain, style, or subject matter. Fine-tuning bridges that gap: you adapt the model on your own data so it produces outputs that match your requirements, without the cost of training from scratch.
 
-Under the hood, NeMo AutoModel uses [flow matching](https://arxiv.org/abs/2210.02747), a modern generative framework that learns to transform noise into data by regressing a velocity field along straight interpolation paths. It integrates with [Hugging Face Diffusers](https://huggingface.co/docs/diffusers) to provide distributed fine-tuning for text-to-image and text-to-video models. This guide walks you through the process end-to-end — from installation through training and inference — using [Wan 2.1 T2V 1.3B](https://huggingface.co/Wan-AI/Wan2.1-T2V-1.3B-Diffusers) as a running example.
+Under the hood, NeMo AutoModel uses [flow matching](https://arxiv.org/abs/2210.02747), a modern generative framework that learns to transform noise into data by regressing a velocity field along straight interpolation paths. It integrates with [Hugging Face Diffusers](https://huggingface.co/docs/diffusers) to provide distributed fine-tuning for text-to-image and text-to-video models. This guide walks you through the process end to end, from installation through training and inference, using [Wan 2.1 T2V 1.3B](https://huggingface.co/Wan-AI/Wan2.1-T2V-1.3B-Diffusers) as a running example.
 
 ### Workflow Overview
 
@@ -22,12 +22,12 @@ Under the hood, NeMo AutoModel uses [flow matching](https://arxiv.org/abs/2210.0
 
 | Step | Section | What You Do |
 |------|---------|-------------|
-| **1. Install** | [Install NeMo AutoModel](#install-nemo-automodel) | Install the package with uv or Docker |
+| **1. Install** | [Install NeMo AutoModel](#install-nemo-automodel) | Install the package with `uv` or Docker |
 | **2. Prepare Data** | [Prepare Your Dataset](#prepare-your-dataset) | Encode raw images/videos into latent cache files |
 | **3. Configure** | [Configure Your Training Recipe](#configure-your-training-recipe) | Write a YAML config specifying model, data, and training settings |
 | **4. Train** | [Fine-Tune the Model](#fine-tune-the-model) | Launch training with `torchrun` on a single node |
 | **4b. Multi-Node** | [Multi-Node Training](#multi-node-training) | Scale training across multiple nodes |
-| **5. Generate** | [Generation / Inference](#generation--inference) | Run inference using the fine-tuned checkpoint |
+| **5. Generate** | [Generation and Inference](#generation-and-inference) | Run inference using the fine-tuned checkpoint |
 
 For model-specific configuration (FLUX.1-dev, HunyuanVideo), see [Model-Specific Notes](#model-specific-notes).
 
@@ -46,7 +46,7 @@ All models use FSDP2 for distributed training and flow matching for loss computa
 ## Install NeMo AutoModel
 
 Diffusion fine-tuning needs the `diffusion` extra plus `diffusion-media` (OpenCV
-for image/video preprocessing and imageio-ffmpeg for T2V export):
+Diffusion fine-tuning requires the `diffusion` and `diffusion-media` extras. The `diffusion-media` extra provides OpenCV for image and video preprocessing and imageio-ffmpeg for T2V export:
 
 ```bash
 uv venv
@@ -54,7 +54,7 @@ source .venv/bin/activate
 uv pip install "nemo-automodel[diffusion,diffusion-media]"
 ```
 
-Alternatively, if you run into dependency or driver issues, use the pre-built Docker container:
+Alternatively, if you run into dependency or driver issues, use the prebuilt Docker container:
 
 ```bash
 docker pull nvcr.io/nvidia/nemo-automodel:26.06.00
@@ -67,6 +67,7 @@ Media dependencies are not installed in the Docker container by default. Add the
 ```bash
 cd /opt/Automodel && uv pip install ".[diffusion-media]"
 ```
+
 </Note>
 
 <Info>
@@ -81,13 +82,14 @@ For the full set of installation methods, see the [installation guide](/get-star
 Diffusion models operate in latent space — a compressed representation of visual data — rather than directly on raw images or videos. To avoid re-encoding data on every training step, the preprocessing
   pipeline encodes all inputs ahead of time and saves them as `.meta` or `.pt` cache files.
 
- Each cache file contains:
- - Latent representations produced by a VAE (Variational Autoencoder) from the raw visual data
- - Text embeddings produced by a text encoder from the associated captions/prompts
+Each cache file contains:
+
+- Latent representations produced by a variational autoencoder (VAE) from the raw visual data
+- Text embeddings produced by a text encoder from the associated captions or prompts
 
 Fine-tuning then operates entirely on these pre-encoded cache files, which is significantly faster than encoding on the fly.
 
-Preprocess your data using the built-in tool at [`tools/diffusion/preprocessing_multiprocess.py`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/tools/diffusion/preprocessing_multiprocess.py). The script provides `image` and `video` subcommands:
+Preprocess your data using the built-in tool at [`tools/diffusion/preprocessing_multiprocess.py`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/tools/diffusion/preprocessing_multiprocess.py). The script provides `image` and `video` subcommands.
 
 **Video preprocessing (using Wan 2.1 as a running example):**
 ```bash
@@ -139,9 +141,10 @@ Fine-tuning is driven by two components:
 
 1. A recipe script (e.g., [`train.py`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/nemo_automodel/recipes/diffusion/train.py)) — the Python entry point that orchestrates the training loop: loading the model, building the dataloader, running forward/backward passes, computing the flow matching loss, checkpointing, and logging.
 2. A YAML configuration file — a text file in YAML format that specifies all settings the recipe uses: which model to fine-tune, where the data lives, optimizer hyperparameters, parallelism strategy, etc.
-  You customize training by editing this file rather than modifying code, allowing you to scale from 1 to 100s of GPUs seamlessly.
+1. A recipe script, for example [`train.py`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/nemo_automodel/recipes/diffusion/train.py), is the Python entry point that orchestrates the training loop: loading the model, building the data loader, running forward and backward passes, computing the flow matching loss, checkpointing, and logging.
+2. A YAML configuration file is a text file in YAML format that specifies all settings the recipe uses: which model to fine-tune, where the data lives, optimizer hyperparameters, parallelism strategy, and other settings. You customize training by editing this file rather than modifying code, allowing you to scale seamlessly from 1 to hundreds of GPUs.
 
-Below is the annotated [wan2_1_t2v_flow.yaml](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/diffusion/finetune/wan2_1_t2v_flow.yaml), with each section explained:
+The following annotated [`wan2_1_t2v_flow.yaml`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/diffusion/finetune/wan2_1_t2v_flow.yaml) config explains each section:
 
 ```yaml
 seed: 42
@@ -258,7 +261,7 @@ Adjust `--nproc-per-node` to match the number of GPUs on your node, and ensure `
 
 ## Multi-Node Training
 
-When a single node doesn't provide enough GPUs or memory for your workload, you can scale training across multiple nodes. NeMo AutoModel handles multi-node distributed training through `torchrun` rendezvous and FSDP2 — the same recipe script works on one node or many.
+When a single node does not provide enough GPUs or memory for your workload, you can scale training across multiple nodes. NeMo AutoModel handles multi-node distributed training through `torchrun` rendezvous and FSDP2. The same recipe script works on one node or many.
 
 ### YAML Configuration Changes
 
@@ -298,7 +301,7 @@ torchrun \
 
 ## Model-Specific Notes
 
-Use the table below to pick the right model for your use case:
+Use the following table to select a model for your use case:
 
 | Use Case | Model | Why Choose It |
 |----------|-------|---------------|
@@ -362,9 +365,9 @@ Use the table below to pick the right model for your use case:
 - **Loss**: applies a shared noise level to synchronized video and audio latents and adds the weighted audio loss
 - **Configs**: [full fine-tuning](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/diffusion/finetune/ltx2_3_t2v_flow.yaml) and [LoRA](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/diffusion/finetune/ltx2_3_t2v_flow_lora.yaml)
 
-## Generation / Inference
+## Generation and Inference
 
-Once training is complete, you can use the model to generate images or videos from text prompts. This step is called inference — as opposed to training, where the model learns from data, inference is where it produces new outputs.
+After training is complete, you can use the model to generate images or videos from text prompts. This step is called inference. Unlike training, where the model learns from data, inference is where it produces new outputs.
 
 In diffusion models, generation works by starting from random noise and iteratively denoising it, guided by your text prompt, until a clean image or video emerges.
 
@@ -378,7 +381,7 @@ python examples/diffusion/generate/generate.py \
 
 **Multi-GPU (Wan 2.1 1.3B):**
 
-Wan 2.1 supports tensor parallelism for inference, which shards the transformer across GPUs to reduce per-GPU memory. Pass the `distributed` config via CLI overrides:
+Wan 2.1 supports tensor parallelism for inference, which shards the transformer across GPUs to reduce per-GPU memory. Pass the `distributed` config using CLI overrides:
 
 ```bash
 torchrun --nproc-per-node=8 \
@@ -432,7 +435,7 @@ You can use `--model.checkpoint ./checkpoints/LATEST` to automatically load the 
 
 | Component | Minimum | Recommended |
 |-----------|---------|-------------|
-| GPU | A100 40GB | A100 80GB / H100 |
+| GPU | A100 40 GB | A100 80 GB / H100 |
 | GPUs | 4 | 8 |
 | RAM | 128 GB | 256 GB+ |
 | Storage | 500 GB SSD | 2 TB NVMe |

--- a/docs/guides/diffusion/finetune.mdx
+++ b/docs/guides/diffusion/finetune.mdx
@@ -16,14 +16,14 @@ Under the hood, NeMo AutoModel uses [flow matching](https://arxiv.org/abs/2210.0
 │ 1. Install   │--->│ 2. Prepare   │--->│ 3. Configure │--->│  4. Train    │--->│ 5. Generate  │
 │              │    │    Data      │    │              │    │              │    │              │
 │ uv sync      │    │ Encode to    │    │ YAML recipe  │    │ torchrun     │    │ Run inference│
-│ or Docker    │    │ .meta files  │    │              │    │              │    │ with ckpt    │
+│ or Docker    │    │ cache files  │    │              │    │              │    │ with ckpt    │
 └──────────────┘    └──────────────┘    └──────────────┘    └──────────────┘    └──────────────┘
 ```
 
 | Step | Section | What You Do |
 |------|---------|-------------|
 | **1. Install** | [Install NeMo AutoModel](#install-nemo-automodel) | Install the package with uv or Docker |
-| **2. Prepare Data** | [Prepare Your Dataset](#prepare-your-dataset) | Encode raw images/videos into `.meta` latent files |
+| **2. Prepare Data** | [Prepare Your Dataset](#prepare-your-dataset) | Encode raw images/videos into latent cache files |
 | **3. Configure** | [Configure Your Training Recipe](#configure-your-training-recipe) | Write a YAML config specifying model, data, and training settings |
 | **4. Train** | [Fine-Tune the Model](#fine-tune-the-model) | Launch training with `torchrun` on a single node |
 | **4b. Multi-Node** | [Multi-Node Training](#multi-node-training) | Scale training across multiple nodes |
@@ -39,6 +39,7 @@ For model-specific configuration (FLUX.1-dev, HunyuanVideo), see [Model-Specific
 | Wan 2.2 T2V-A14B (two-stage) | `Wan-AI/Wan2.2-T2V-A14B-Diffusers` | Text-to-Video | 14B + 14B | [wan2_2_t2v_flow.yaml](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/diffusion/finetune/wan2_2_t2v_flow.yaml) |
 | FLUX.1-dev | `black-forest-labs/FLUX.1-dev` | Text-to-Image | 12B | [flux_t2i_flow.yaml](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/diffusion/finetune/flux_t2i_flow.yaml) |
 | HunyuanVideo 1.5 | `hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-720p_t2v` | Text-to-Video | — | [hunyuan_t2v_flow.yaml](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/diffusion/finetune/hunyuan_t2v_flow.yaml) |
+| LTX-2.3 | `diffusers/LTX-2.3-Diffusers` | Text-to-Video with Audio | — | [ltx2_3_t2v_flow.yaml](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/diffusion/finetune/ltx2_3_t2v_flow.yaml) |
 
 All models use FSDP2 for distributed training and flow matching for loss computation.
 
@@ -78,13 +79,13 @@ For the full set of installation methods, see the [installation guide](/get-star
 ## Prepare Your Dataset
 
 Diffusion models operate in latent space — a compressed representation of visual data — rather than directly on raw images or videos. To avoid re-encoding data on every training step, the preprocessing
-  pipeline encodes all inputs ahead of time and saves them as .meta files.
+  pipeline encodes all inputs ahead of time and saves them as `.meta` or `.pt` cache files.
 
- Each .meta file contains:
+ Each cache file contains:
  - Latent representations produced by a VAE (Variational Autoencoder) from the raw visual data
  - Text embeddings produced by a text encoder from the associated captions/prompts
 
-Fine-tuning then operates entirely on these pre-encoded .meta files, which is significantly faster than encoding on the fly.
+Fine-tuning then operates entirely on these pre-encoded cache files, which is significantly faster than encoding on the fly.
 
 Preprocess your data using the built-in tool at [`tools/diffusion/preprocessing_multiprocess.py`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/tools/diffusion/preprocessing_multiprocess.py). The script provides `image` and `video` subcommands:
 
@@ -115,6 +116,20 @@ python -m tools.diffusion.preprocessing_multiprocess video \
     --target_frames 121 \
     --caption_format meta_json
 ```
+
+**Video and audio preprocessing (LTX-2.3):**
+```bash
+python -m tools.diffusion.preprocessing_multiprocess video \
+    --video_dir /data/videos \
+    --output_dir /cache \
+    --processor ltx2 \
+    --num_frames 121 \
+    --output_format pt \
+    --resolution_preset 512p \
+    --caption_format sidecar
+```
+
+LTX-2.3 requires an explicit `8n+1` frame count and uses each source video's audio track. If a clip has no audio stream, preprocessing stores silence of the matching duration.
 
 For the full set of arguments and input format details, see the [Diffusion Dataset Preparation](/datasets/diffusion-dataset) guide.
 
@@ -222,9 +237,9 @@ checkpoint:
 |---------|-----------|----------------|
 | `model` | Yes | Set `pretrained_model_name_or_path` to the Hugging Face model ID. Set `mode: finetune`. |
 | `step_scheduler` | Yes | `global_batch_size` is the effective batch size across all GPUs. `ckpt_every_steps` controls checkpoint frequency. |
-| `data` | Yes | Set `cache_dir` to the path containing your preprocessed `.meta` files. Change `model_type` and `_target_` for different models (see [Model-Specific Notes](#model-specific-notes)). |
+| `data` | Yes | Set `cache_dir` to the path containing your preprocessed cache files. Change `model_type` and `_target_` for different models (see [Model-Specific Notes](#model-specific-notes)). |
 | `optimizer` | Yes | `_target_` selects the optimizer class; `lr: 5e-6` is a good default for fine-tuning. |
-| `flow_matching` | Yes | `adapter_type` must match the model (`simple` for Wan, `flux` for FLUX, `hunyuan` for HunyuanVideo). |
+| `flow_matching` | Yes | `adapter_type` must match the model (`simple` for Wan, `flux` for FLUX, `hunyuan` for HunyuanVideo, or `ltx2` for LTX-2.3). |
 | `fsdp` | Yes | Set `dp_size` to the number of GPUs on your node. |
 | `checkpoint` | Recommended | Set `checkpoint_dir` to a persistent path, especially in Docker. |
 | `wandb` | Optional | Configure to enable Weights & Biases logging. |
@@ -290,6 +305,7 @@ Use the table below to pick the right model for your use case:
 | **Video generation on limited hardware** | [Wan 2.1 T2V 1.3B](#wan-21-t2v-13b) | Smallest model (1.3B params) — fast iteration, fits on a single A100 40GB |
 | **High-quality image generation** | [FLUX.1-dev](#flux1-dev-text-to-image) | State-of-the-art text-to-image with 12B params and guidance-based control |
 | **High-quality video generation** | [HunyuanVideo 1.5](#hunyuanvideo-15) | Larger video model with condition-latent support for richer motion and detail |
+| **Synchronized video and audio generation** | [LTX-2.3](#ltx-23) | Jointly denoises video and audio latents with a dual-stream transformer |
 
 ### Wan 2.1 T2V 1.3B
 
@@ -338,6 +354,14 @@ Use the table below to pick the right model for your use case:
   - Uses `logit_normal` timestep sampling
 - **Config**: [hunyuan_t2v_flow.yaml](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/diffusion/finetune/hunyuan_t2v_flow.yaml)
 
+### LTX-2.3
+
+- **Adapter type**: `ltx2`
+- **Dataloader**: `build_video_multiresolution_dataloader` with `model_type: ltx2`
+- **Preprocessing**: use `--processor ltx2`, an explicit `8n+1` frame count, and `--output_format pt`
+- **Loss**: applies a shared noise level to synchronized video and audio latents and adds the weighted audio loss
+- **Configs**: [full fine-tuning](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/diffusion/finetune/ltx2_3_t2v_flow.yaml) and [LoRA](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/diffusion/finetune/ltx2_3_t2v_flow_lora.yaml)
+
 ## Generation / Inference
 
 Once training is complete, you can use the model to generate images or videos from text prompts. This step is called inference — as opposed to training, where the model learns from data, inference is where it produces new outputs.
@@ -384,6 +408,12 @@ python examples/diffusion/generate/generate.py \
   -c examples/diffusion/generate/configs/generate_hunyuan.yaml
 ```
 
+**LTX-2.3 video with audio:**
+```bash
+python examples/diffusion/generate/generate.py \
+  -c examples/diffusion/generate/configs/generate_ltx2.yaml
+```
+
 ### Available Generation Configs
 
 | Config | Model | Output | GPUs |
@@ -391,6 +421,7 @@ python examples/diffusion/generate/generate.py \
 | [`generate_wan.yaml`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/diffusion/generate/configs/generate_wan.yaml) | Wan 2.1 1.3B | Video | 1 |
 | [`generate_flux.yaml`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/diffusion/generate/configs/generate_flux.yaml) | FLUX.1-dev | Image | 1 |
 | [`generate_hunyuan.yaml`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/diffusion/generate/configs/generate_hunyuan.yaml) | HunyuanVideo | Video | 1 |
+| [`generate_ltx2.yaml`](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/diffusion/generate/configs/generate_ltx2.yaml) | LTX-2.3 | Video with audio | 1 |
 
 <Note>
 You can use `--model.checkpoint ./checkpoints/LATEST` to automatically load the most recent checkpoint.

--- a/docs/model-coverage/diffusion/index.mdx
+++ b/docs/model-coverage/diffusion/index.mdx
@@ -16,6 +16,7 @@ NeMo AutoModel integrates with [Hugging Face Diffusers](https://huggingface.co/d
 | Wan AI | [Wan 2.1 T2V](/model-coverage/diffusion/wan-2-1-t2v) | Text-to-Video | DiT (Flow Matching) |
 | Black Forest Labs | [FLUX.1-dev](/model-coverage/diffusion/flux-1-dev) | Text-to-Image | DiT (Flow Matching) |
 | Hunyuan Community | [HunyuanVideo 1.5](/model-coverage/diffusion/hunyuanvideo-1-5) | Text-to-Video | DiT (Flow Matching) |
+| Lightricks | [LTX-2.3](/model-coverage/diffusion/ltx-2-3) | Text-to-Video with Audio | Dual-stream DiT (Flow Matching) |
 | Qwen / Alibaba Cloud | [Qwen-Image and Qwen-Image-Edit-2511](/model-coverage/diffusion/qwen-image) | Text-to-Image, Image Editing | DiT (Flow Matching) |
 
 ## Supported Workflows

--- a/docs/model-coverage/diffusion/index.mdx
+++ b/docs/model-coverage/diffusion/index.mdx
@@ -7,7 +7,7 @@ position: 6
 
 Diffusion models are a class of generative models that learn to produce images or videos by iteratively denoising samples from a noise distribution. NeMo AutoModel supports training diffusion models using **flow matching**, a framework that regresses velocity fields along straight interpolation paths between noise and data.
 
-NeMo AutoModel integrates with [Hugging Face Diffusers](https://huggingface.co/docs/diffusers) for model loading and generation, while providing its own distributed training infrastructure via the `TrainDiffusionRecipe`. This recipe handles FSDP2 parallelization, flow matching loss computation, multiresolution bucketed dataloading, and checkpoint management.
+NeMo AutoModel integrates with [Hugging Face Diffusers](https://huggingface.co/docs/diffusers) for model loading and generation while providing its own distributed training infrastructure using `TrainDiffusionRecipe`. This recipe handles FSDP2 parallelization, flow matching loss computation, multiresolution bucketed data loading, and checkpoint management.
 
 ## Supported Models
 

--- a/docs/model-coverage/diffusion/lightricks/ltx-2-3.mdx
+++ b/docs/model-coverage/diffusion/lightricks/ltx-2-3.mdx
@@ -16,7 +16,7 @@ description: "Fine-tune and generate synchronized video and audio with LTX-2.3"
 
 ## Available Models
 
-- **LTX-2.3**: full-parameter and LoRA fine-tuning with synchronized video and audio
+LTX-2.3 supports full-parameter and LoRA fine-tuning with synchronized video and audio.
 
 ## Example Recipes
 
@@ -42,7 +42,7 @@ uv run python -m tools.diffusion.preprocessing_multiprocess video \
   --caption_format sidecar
 ```
 
-LTX-2.3 requires an explicit frame count of the form `8n+1`, such as 9, 89, or 121. Clips without an audio stream use silence while preserving the video/audio alignment contract.
+LTX-2.3 requires an explicit frame count of the form `8n+1`, such as 9, 89, or 121. Clips without an audio stream use silence while preserving the video and audio alignment contract.
 
 ## Fine-Tune LTX-2.3
 

--- a/docs/model-coverage/diffusion/lightricks/ltx-2-3.mdx
+++ b/docs/model-coverage/diffusion/lightricks/ltx-2-3.mdx
@@ -1,0 +1,82 @@
+---
+title: "LTX-2.3"
+description: "Fine-tune and generate synchronized video and audio with LTX-2.3"
+---
+[LTX-2.3](https://huggingface.co/Lightricks/LTX-2.3) is a text-to-video diffusion model from Lightricks. Its dual-stream transformer denoises video and audio latents together so generated clips can include synchronized sound.
+
+<Info>
+
+| | |
+|---|---|
+| **Task** | Text-to-Video with Audio |
+| **Architecture** | Dual-stream DiT (Flow Matching) |
+| **HF Org** | [Lightricks](https://huggingface.co/Lightricks) |
+
+</Info>
+
+## Available Models
+
+- **LTX-2.3**: full-parameter and LoRA fine-tuning with synchronized video and audio
+
+## Example Recipes
+
+| Recipe | Description |
+|---|---|
+| [ltx2_3_t2v_flow.yaml](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/diffusion/finetune/ltx2_3_t2v_flow.yaml) | Full fine-tuning with flow matching |
+| [ltx2_3_t2v_flow_lora.yaml](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/diffusion/finetune/ltx2_3_t2v_flow_lora.yaml) | Parameter-efficient LoRA fine-tuning |
+| [generate_ltx2.yaml](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/diffusion/generate/configs/generate_ltx2.yaml) | Generate video and mux the model's audio into the output |
+
+## Prepare Video and Audio Data
+
+Install the diffusion and media dependencies, then preprocess clips with a fixed frame count. LTX-2.3 samples video at 24 FPS and trims or pads each audio track to the matching duration.
+
+```bash
+uv sync --extra diffusion --extra diffusion-media
+uv run python -m tools.diffusion.preprocessing_multiprocess video \
+  --video_dir /path/to/videos \
+  --output_dir /path/to/ltx2-cache \
+  --processor ltx2 \
+  --num_frames 121 \
+  --output_format pt \
+  --resolution_preset 512p \
+  --caption_format sidecar
+```
+
+LTX-2.3 requires an explicit frame count of the form `8n+1`, such as 9, 89, or 121. Clips without an audio stream use silence while preserving the video/audio alignment contract.
+
+## Fine-Tune LTX-2.3
+
+Set `data.dataloader.cache_dir` and `checkpoint.checkpoint_dir` in the selected recipe, then launch one process per GPU.
+
+```bash
+uv run torchrun --nproc-per-node=8 \
+  examples/diffusion/finetune/finetune.py \
+  -c examples/diffusion/finetune/ltx2_3_t2v_flow.yaml
+```
+
+For LoRA, use the LoRA recipe instead:
+
+```bash
+uv run torchrun --nproc-per-node=8 \
+  examples/diffusion/finetune/finetune.py \
+  -c examples/diffusion/finetune/ltx2_3_t2v_flow_lora.yaml
+```
+
+Both recipes use `flow_matching.adapter_type: ltx2`. The adapter applies the same sampled noise level to the video and audio streams and combines their flow-matching losses.
+
+## Generate Video with Audio
+
+Point `model.checkpoint` at a consolidated full-fine-tuning checkpoint, or set `model.lora_weights` for a LoRA checkpoint.
+
+```bash
+uv run python examples/diffusion/generate/generate.py \
+  -c examples/diffusion/generate/configs/generate_ltx2.yaml \
+  --model.checkpoint /path/to/checkpoint
+```
+
+The generation command writes an MP4 and muxes the generated waveform into it. See the [Diffusion Fine-Tuning Guide](/recipes-e2e-examples/diffusion-fine-tuning) and [Diffusion Dataset Preparation](/datasets/diffusion-dataset) guide for shared training and dataset options.
+
+## Hugging Face Model Cards
+
+- [Lightricks/LTX-2.3](https://huggingface.co/Lightricks/LTX-2.3)
+- [diffusers/LTX-2.3-Diffusers](https://huggingface.co/diffusers/LTX-2.3-Diffusers)

--- a/tests/ci_tests/scripts/diffusion_finetune_launcher.sh
+++ b/tests/ci_tests/scripts/diffusion_finetune_launcher.sh
@@ -18,6 +18,9 @@ set -euo pipefail
 #   CONFIG_PATH, TEST_LEVEL, NPROC_PER_NODE, TEST_NODE_COUNT,
 #   MASTER_ADDR, MASTER_PORT, SLURM_JOB_ID, PIPELINE_DIR, TEST_NAME
 
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+source "$SCRIPT_DIR/diffusion_finetune_recipe_config.sh"
+
 DATA_DIR="$PIPELINE_DIR/$TEST_NAME/data"
 CKPT_DIR="$PIPELINE_DIR/$TEST_NAME/checkpoint"
 INFER_DIR="$PIPELINE_DIR/$TEST_NAME/inference_output"
@@ -28,42 +31,7 @@ cd /opt/Automodel
 # Derive model-specific settings from config
 # ============================================
 RECIPE_NAME=$(basename "$CONFIG_PATH" .yaml)
-case "$RECIPE_NAME" in
-    wan2_1_t2v_flow*)
-        MEDIA_TYPE="video"
-        PROCESSOR="wan"
-        GENERATE_CONFIG="examples/diffusion/generate/configs/generate_wan.yaml"
-        MODEL_NAME="Wan-AI/Wan2.1-T2V-14B-Diffusers"
-        INFER_NUM_FRAMES=9
-        PREPROCESS_EXTRA_ARGS=""
-        ;;
-    hunyuan_t2v_flow*)
-        MEDIA_TYPE="video"
-        PROCESSOR="hunyuan"
-        GENERATE_CONFIG="examples/diffusion/generate/configs/generate_hunyuan.yaml"
-        MODEL_NAME="hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-720p_t2v"
-        INFER_NUM_FRAMES=5
-        PREPROCESS_EXTRA_ARGS="--target_frames 13"
-        ;;
-    flux_t2i_flow*)
-        MEDIA_TYPE="image"
-        PROCESSOR="flux"
-        GENERATE_CONFIG="examples/diffusion/generate/configs/generate_flux.yaml"
-        MODEL_NAME="black-forest-labs/FLUX.1-dev"
-        PREPROCESS_EXTRA_ARGS=""
-        ;;
-    qwen_image_t2i_flow*)
-        MEDIA_TYPE="image"
-        PROCESSOR="qwen_image"
-        GENERATE_CONFIG="examples/diffusion/generate/configs/generate_qwen_image.yaml"
-        MODEL_NAME="Qwen/Qwen-Image"
-        PREPROCESS_EXTRA_ARGS=""
-        ;;
-    *)
-        echo "ERROR: Unknown recipe '$RECIPE_NAME'. Add a case to diffusion_finetune_launcher.sh."
-        exit 1
-        ;;
-esac
+configure_diffusion_finetune_recipe "$RECIPE_NAME"
 
 # LoRA recipes are named *_lora.yaml — they save PEFT adapter artifacts
 # (adapter_model.safetensors + adapter_config.json) that generate.py loads via

--- a/tests/ci_tests/scripts/diffusion_finetune_recipe_config.sh
+++ b/tests/ci_tests/scripts/diffusion_finetune_recipe_config.sh
@@ -1,0 +1,62 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+configure_diffusion_finetune_recipe() {
+    local recipe_name="$1"
+
+    case "$recipe_name" in
+        wan2_1_t2v_flow*)
+            MEDIA_TYPE="video"
+            PROCESSOR="wan"
+            GENERATE_CONFIG="examples/diffusion/generate/configs/generate_wan.yaml"
+            MODEL_NAME="Wan-AI/Wan2.1-T2V-14B-Diffusers"
+            INFER_NUM_FRAMES=9
+            PREPROCESS_EXTRA_ARGS=""
+            ;;
+        hunyuan_t2v_flow*)
+            MEDIA_TYPE="video"
+            PROCESSOR="hunyuan"
+            GENERATE_CONFIG="examples/diffusion/generate/configs/generate_hunyuan.yaml"
+            MODEL_NAME="hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-720p_t2v"
+            INFER_NUM_FRAMES=5
+            PREPROCESS_EXTRA_ARGS="--target_frames 13"
+            ;;
+        ltx2_3_t2v_flow*)
+            MEDIA_TYPE="video"
+            PROCESSOR="ltx2"
+            GENERATE_CONFIG="examples/diffusion/generate/configs/generate_ltx2.yaml"
+            MODEL_NAME="diffusers/LTX-2.3-Diffusers"
+            INFER_NUM_FRAMES=9
+            PREPROCESS_EXTRA_ARGS="--num_frames 9 --output_format pt"
+            ;;
+        flux_t2i_flow*)
+            MEDIA_TYPE="image"
+            PROCESSOR="flux"
+            GENERATE_CONFIG="examples/diffusion/generate/configs/generate_flux.yaml"
+            MODEL_NAME="black-forest-labs/FLUX.1-dev"
+            PREPROCESS_EXTRA_ARGS=""
+            ;;
+        qwen_image_t2i_flow*)
+            MEDIA_TYPE="image"
+            PROCESSOR="qwen_image"
+            GENERATE_CONFIG="examples/diffusion/generate/configs/generate_qwen_image.yaml"
+            MODEL_NAME="Qwen/Qwen-Image"
+            PREPROCESS_EXTRA_ARGS=""
+            ;;
+        *)
+            echo "ERROR: Unknown recipe '$recipe_name'. Add a case to diffusion_finetune_recipe_config.sh." >&2
+            return 1
+            ;;
+    esac
+}

--- a/tests/unit_tests/_transformers/test_recipe_doc_coverage.py
+++ b/tests/unit_tests/_transformers/test_recipe_doc_coverage.py
@@ -231,6 +231,7 @@ def test_yaml_recipe_scan_finds_model_ids(recipe_model_ids: set[str]):
 # pages, etc.).
 _HF_ORG_TO_DOC_SLUG = {
     "CohereForAI": "cohere",
+    "diffusers": "lightricks",  # LTX-2.3 conversion shares the Lightricks family page
     "ibm-granite": "ibm",
     "meta-llama": "meta",
     "MiniMaxAI": "minimax",

--- a/tests/unit_tests/ci_tests/test_diffusion_finetune_recipe_config.py
+++ b/tests/unit_tests/ci_tests/test_diffusion_finetune_recipe_config.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CONFIG_SCRIPT = REPO_ROOT / "tests/ci_tests/scripts/diffusion_finetune_recipe_config.sh"
+
+
+def resolve_recipe(recipe_name: str) -> subprocess.CompletedProcess[str]:
+    command = """
+source "$1"
+configure_diffusion_finetune_recipe "$2" || exit $?
+printf '%s|%s|%s|%s|%s|%s' \
+    "$MEDIA_TYPE" "$PROCESSOR" "$GENERATE_CONFIG" "$MODEL_NAME" \
+    "${INFER_NUM_FRAMES:-}" "$PREPROCESS_EXTRA_ARGS"
+"""
+    return subprocess.run(
+        ["bash", "-c", command, "bash", str(CONFIG_SCRIPT), recipe_name],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.parametrize("recipe_name", ["ltx2_3_t2v_flow", "ltx2_3_t2v_flow_lora"])
+def test_ltx2_recipe_configuration(recipe_name: str) -> None:
+    result = resolve_recipe(recipe_name)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == (
+        "video|ltx2|examples/diffusion/generate/configs/generate_ltx2.yaml|"
+        "diffusers/LTX-2.3-Diffusers|9|--num_frames 9 --output_format pt"
+    )
+
+
+@pytest.mark.parametrize(
+    ("recipe_name", "expected_prefix"),
+    [
+        ("wan2_1_t2v_flow", "video|wan|examples/diffusion/generate/configs/generate_wan.yaml|"),
+        ("hunyuan_t2v_flow", "video|hunyuan|examples/diffusion/generate/configs/generate_hunyuan.yaml|"),
+        ("flux_t2i_flow", "image|flux|examples/diffusion/generate/configs/generate_flux.yaml|"),
+        (
+            "qwen_image_t2i_flow",
+            "image|qwen_image|examples/diffusion/generate/configs/generate_qwen_image.yaml|",
+        ),
+    ],
+)
+def test_existing_recipe_configuration_is_preserved(recipe_name: str, expected_prefix: str) -> None:
+    result = resolve_recipe(recipe_name)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.startswith(expected_prefix)
+
+
+def test_unknown_diffusion_recipe_is_rejected() -> None:
+    result = resolve_recipe("unknown_t2v_flow")
+
+    assert result.returncode == 1
+    assert "Unknown recipe 'unknown_t2v_flow'" in result.stderr


### PR DESCRIPTION
# What does this PR do?

Enables the existing LTX-2.3 full-finetuning and LoRA YAML recipes in the diffusion NeMo-CI launcher and documents the supported workflow.

The recipes were already enrolled in nightly CI, but [job 382086958](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/382086958) failed before preprocessing or training because `diffusion_finetune_launcher.sh` rejected `ltx2_3_t2v_flow` as an unknown recipe.

# Changelog

- Add LTX-2.3 launcher settings for synchronized video/audio preprocessing and inference.
- Extract recipe resolution into a sourceable shell helper with focused tests for full, LoRA, existing, and unknown recipes.
- Add LTX-2.3 to diffusion model coverage and the fine-tuning guide.
- Add the LTX-2.3 model page to the nightly Fern navigation.
- Clarify that diffusion preprocessing can produce either `.meta` or `.pt` cache files.

# Validation

- `bash -n tests/ci_tests/scripts/diffusion_finetune_launcher.sh tests/ci_tests/scripts/diffusion_finetune_recipe_config.sh`
- `python -m pytest -q tests/unit_tests/ci_tests/test_diffusion_finetune_recipe_config.py` — 7 passed
- `ruff format --check tests/unit_tests/ci_tests/test_diffusion_finetune_recipe_config.py`
- `ruff check tests/unit_tests/ci_tests/test_diffusion_finetune_recipe_config.py`
- `python tests/ci_tests/utils/validate_nightly_recipes.py --automodel-dir "$PWD"`
- Generated nightly pipeline contains both `ltx2_3_t2v_flow` (`diffusion_sft`) and `ltx2_3_t2v_flow_lora` (`diffusion_peft`).
- `make -C docs/fern docs-check` — 455 MDX files validated, 0 errors
- `git diff --check`

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added focused tests.
- [x] Added and updated the necessary documentation.

# Additional Information

- The existing LTX-2.3 recipe YAMLs remain the canonical examples; this PR fixes their CI execution path rather than adding a duplicate recipe.
