### PR TITLE
fix(retrieval): guard optional W&B imports

### DIFF
--- a/nemo_automodel/recipes/retrieval/train_bi_encoder.py
+++ b/nemo_automodel/recipes/retrieval/train_bi_encoder.py
@@ -23,7 +23,6 @@ from typing import Any
 
 import torch
 import torch.nn.functional as F
-import wandb
 from transformers import ProcessorMixin
 
 from nemo_automodel._transformers.utils import apply_cache_compatibility_patches
@@ -44,7 +43,10 @@ from nemo_automodel.recipes._dist_utils import (
 )
 from nemo_automodel.recipes._typed_config import RecipeConfig
 from nemo_automodel.recipes.base_recipe import BaseRecipe
+from nemo_automodel.shared.import_utils import safe_import
 from nemo_automodel.shared.te_patches import apply_te_patches
+
+_, wandb = safe_import("wandb")
 
 logger = logging.getLogger(__name__)
 

--- a/nemo_automodel/recipes/retrieval/train_cross_encoder.py
+++ b/nemo_automodel/recipes/retrieval/train_cross_encoder.py
@@ -17,13 +17,15 @@ from contextlib import nullcontext
 
 import torch
 import torch.nn.functional as F
-import wandb
 
 from nemo_automodel.components.config._arg_parser import parse_args_and_load_config
 from nemo_automodel.components.distributed.utils import get_sync_ctx
 from nemo_automodel.components.loggers.metric_logger import MetricsSample
 from nemo_automodel.components.training.rng import ScopedRNG
 from nemo_automodel.recipes.retrieval.train_bi_encoder import TrainBiEncoderRecipe, _get_autocast_ctx
+from nemo_automodel.shared.import_utils import safe_import
+
+_, wandb = safe_import("wandb")
 
 
 @torch.no_grad()

--- a/tests/unit_tests/recipes/test_retrieval_import.py
+++ b/tests/unit_tests/recipes/test_retrieval_import.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_retrieval_package_imports_without_wandb():
+    probe = """
+import sys
+
+sys.modules["wandb"] = None
+import nemo_automodel.recipes.retrieval
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=Path(__file__).parents[3],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
# What does this PR do?

Allow `nemo_automodel.recipes.retrieval` to import when Weights & Biases is not installed.

The retrieval package imports both encoder recipes from its package initializer. Each recipe previously imported `wandb` eagerly, so importing the package failed before any W&B-backed logging was requested.

# Changelog

* Guard the bi-encoder and cross-encoder W&B imports with AutoModel's `safe_import` utility.
* Add a subprocess regression test that imports the retrieval package with `wandb` unavailable.

# Before your PR is "Ready for review"

**Pre checks**:

- [X] Read and followed the contributor guidelines.
- [X] Added a focused CPU unit test for the reported failure.
- [X] No documentation changes are necessary for this import-time bug fix.

# Validation

* `pytest tests/unit_tests/recipes/test_retrieval_import.py -q` — 1 passed.
* `pytest tests/unit_tests/recipes/test_train_cross_encoder.py tests/unit_tests/recipes/test_retrieval_bi_encoder_recipe.py -q` — 15 passed.
* Ruff format check and lint check on all three changed files — passed.

# Additional Information

Fixes NVIDIA-NeMo/Automodel#3326.

Linear: NVIDIA-NeMo/Automodel#3326