### PR TITLE
fix(datasets): reopen IndexedDataset readers in spawned workers

### DIFF
--- a/nemo_automodel/components/datasets/llm/megatron/indexed_dataset.py
+++ b/nemo_automodel/components/datasets/llm/megatron/indexed_dataset.py
@@ -678,6 +678,25 @@ class IndexedDataset(torch.utils.data.Dataset):
         self.bin_reader = bin_reader
         self.index = index_reader
 
+    def __getstate__(self) -> Dict[str, Any]:
+        """Serialize only the configuration needed to reopen the dataset.
+
+        Memory-mapped readers hold open files, mmap objects, and memoryviews,
+        none of which can be sent to dataloader workers started with ``spawn``.
+        Keep the parent-process readers alive and omit them from the serialized
+        state so each worker can open its own readers after unpickling.
+        """
+        return {
+            "path_prefix": self.path_prefix,
+            "multimodal": self.multimodal,
+            "mmap": self.mmap,
+            "object_storage_config": self.object_storage_config,
+        }
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        """Restore the dataset and reopen process-local readers."""
+        self.initialize(**state)
+
     def __len__(self) -> int:
         return len(self.index)
 

--- a/tests/unit_tests/datasets/llm/test_indexed_dataset.py
+++ b/tests/unit_tests/datasets/llm/test_indexed_dataset.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pickle
+
+import numpy
+import pytest
+import torch
+from torch.utils.data import DataLoader
+
+from nemo_automodel.components.datasets.llm.megatron.indexed_dataset import (
+    IndexedDataset,
+    IndexedDatasetBuilder,
+    get_bin_path,
+    get_idx_path,
+)
+
+
+@pytest.fixture
+def indexed_dataset_prefix(tmp_path):
+    prefix = str(tmp_path / "tiny")
+    builder = IndexedDatasetBuilder(get_bin_path(prefix))
+    builder.add_item(torch.tensor([11, 12, 13], dtype=torch.int64))
+    builder.end_document()
+    builder.add_item(torch.tensor([21, 22], dtype=torch.int64))
+    builder.end_document()
+    builder.finalize(get_idx_path(prefix))
+    return prefix
+
+
+@pytest.mark.parametrize("mmap", [True, False])
+def test_pickle_round_trip_reopens_readers(indexed_dataset_prefix, mmap):
+    dataset = IndexedDataset(indexed_dataset_prefix, mmap=mmap)
+
+    restored = pickle.loads(pickle.dumps(dataset))  # noqa: S301
+
+    assert restored.bin_reader is not dataset.bin_reader
+    assert restored.index is not dataset.index
+    numpy.testing.assert_array_equal(restored[0], dataset[0])
+    numpy.testing.assert_array_equal(restored[1], dataset[1])
+
+
+def test_spawn_dataloader_worker_reads_mmap_dataset(indexed_dataset_prefix):
+    dataset = IndexedDataset(indexed_dataset_prefix, mmap=True)
+    dataloader = DataLoader(
+        dataset,
+        batch_size=None,
+        num_workers=1,
+        multiprocessing_context="spawn",
+    )
+
+    samples = list(dataloader)
+
+    assert len(samples) == 2
+    torch.testing.assert_close(samples[0], torch.tensor([11, 12, 13], dtype=torch.int32))
+    torch.testing.assert_close(samples[1], torch.tensor([21, 22], dtype=torch.int32))


### PR DESCRIPTION
## Summary

- make local Megatron `IndexedDataset` safe to serialize into dataloader workers started with `spawn`
- serialize only immutable dataset configuration and reopen process-local index/bin readers after unpickling
- cover mmap and file-reader pickle round trips plus a real spawned `DataLoader` worker

## Root cause

`IndexedDataset` retained an open `BufferedReader`, mmap objects, and memoryviews in its reader graph. Multiprocessing `spawn` pickles the dataset before starting each worker, so pretraining with `num_workers > 0` failed before the first batch with:

```text
TypeError: cannot pickle 'BufferedReader' instances
```

The successful workaround was `num_workers: 0`; this change fixes the underlying worker path.

## Validation

- reproduced the failure on clean `origin/main` with a real generated `.idx/.bin` dataset
- verified a real `DataLoader(num_workers=1, multiprocessing_context="spawn")` reads all mmap-backed samples
- `31 passed`: focused IndexedDataset and object-storage unit tests
- ruff check and format check passed for both changed files
