### PR TITLE
fix(gemma4_moe): reduce-scatter CP KV grads instead of all-pairs p2p

### DIFF
--- a/examples/vlm_finetune/gemma4/gemma4_31b_tulu3_text_cp8_16k.yaml
+++ b/examples/vlm_finetune/gemma4/gemma4_31b_tulu3_text_cp8_16k.yaml
@@ -108,3 +108,8 @@ wandb:
   entity: <your_wandb_entity>
   name: <your_wandb_name>
   dir: <your_wandb_save_dir>
+
+ci:
+  # max_steps 50 at ~46 s/step measured 47.8 min end-to-end on 8xH100; the
+  # .vlm_finetune_test default of 00:10:00 cannot fit it.
+  time: "01:00:00"

--- a/nemo_automodel/components/models/gemma4_moe/cp_attention.py
+++ b/nemo_automodel/components/models/gemma4_moe/cp_attention.py
@@ -211,34 +211,39 @@ def _route_kv_grads_to_owners(
     cp_rank: int,
     cp_size: int,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Sum each KV owner's dK/dV from every rank whose queries attended it.
+    """Sum each KV owner's dK/dV across every rank that attended it; return the local shard.
 
-    In the ring forward, rank ``r``'s queries attend the chunks owned by ranks
-    ``r, r-1, ..., 0``, so backward produces a dK/dV contribution for each of those
-    owners on rank ``r``. This sends each owner's contribution back to that owner
-    (p2p) and sums them, returning the local rank's accumulated ``(grad_key,
-    grad_value)``. Shared by the Flex and FFPA-varlen ring backward passes.
+    Summing per owner and giving owner ``i`` its slice is a reduce-scatter. It must not be
+    hand-rolled from p2p: that sends to ``cp_rank - distance`` for ``distance 1..cp_size-1``,
+    and NCCL connections are directional, so every peer/direction it uses is one the forward
+    ring (send ``cp_rank + 1``, recv ``cp_rank - 1``) never opened -- including distance 1,
+    which reverses the ring. NCCL allocates those connection buffers lazily on first use,
+    ~0.4 GiB each, outside the caching allocator and at the backward memory peak, and dies
+    with ``Cuda failure 2 'out of memory'``.
+
+    Args:
+        grad_key_by_owner: Per-owner dK of shape ``[batch, kv_heads, seq_local, head_dim]``,
+            keyed by CP rank; must cover every owner in ``range(cp_size)``.
+        grad_value_by_owner: Per-owner dV, same shapes and keys as ``grad_key_by_owner``.
+        cp_group: Context-parallel process group.
+        cp_rank: This rank's index within ``cp_group``.
+        cp_size: Size of ``cp_group``.
+
+    Returns:
+        ``(grad_key, grad_value)`` for the local KV shard, each of shape
+        ``[batch, kv_heads, seq_local, head_dim]``, summed across all CP ranks.
     """
-    grad_key = grad_key_by_owner[cp_rank].contiguous()
-    grad_value = grad_value_by_owner[cp_rank].contiguous()
-    for distance in range(1, cp_size):
-        send_owner = (cp_rank - distance) % cp_size
-        recv_query_rank = (cp_rank + distance) % cp_size
-        recv_grad_key = torch.empty_like(grad_key)
-        recv_grad_value = torch.empty_like(grad_value)
-        _direct_exchange(
-            [
-                (grad_key_by_owner[send_owner], recv_grad_key),
-                (grad_value_by_owner[send_owner], recv_grad_value),
-            ],
-            cp_group=cp_group,
-            cp_rank=cp_rank,
-            send_cp_rank=send_owner,
-            recv_cp_rank=recv_query_rank,
-        )
-        grad_key = grad_key + recv_grad_key
-        grad_value = grad_value + recv_grad_value
-    return grad_key, grad_value
+
+    def _reduce_scatter(grad_by_owner: dict[int, torch.Tensor]) -> torch.Tensor:
+        # cat (not stack) on dim 0: the collective splits dim 0 and requires
+        # output.shape[0] * cp_size == input.shape[0], which [cp_size, batch, ...] would
+        # satisfy only when batch == 1.
+        owner_major = torch.cat([grad_by_owner[owner] for owner in range(cp_size)], dim=0).contiguous()
+        out = torch.empty_like(grad_by_owner[cp_rank])
+        torch.distributed.reduce_scatter_tensor(out, owner_major, group=cp_group)
+        return out
+
+    return _reduce_scatter(grad_key_by_owner), _reduce_scatter(grad_value_by_owner)
 
 
 def _merge_flex_chunk(

--- a/tests/unit_tests/models/gemma4_moe/test_cp_route_kv_grads.py
+++ b/tests/unit_tests/models/gemma4_moe/test_cp_route_kv_grads.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Gradient routing for the Gemma4 CP ring attention backward.
+
+``_route_kv_grads_to_owners`` must stay a reduce-scatter. Hand-rolling it from all-pairs p2p
+makes NCCL allocate connection buffers for every CP peer at the backward memory peak, which
+OOMs. These tests pin both the numerics and the absence of p2p.
+"""
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from nemo_automodel.components.models.gemma4_moe.cp_attention import _route_kv_grads_to_owners
+
+CP_SIZE = 4
+# batch > 1 on purpose: an owner-stacked [cp_size, batch, ...] passes the collective's
+# dim-0 check only when batch == 1, so batch 1 would hide that bug.
+SHAPE = (2, 2, 8, 4)  # [batch, kv_heads, seq_local, head_dim]
+
+
+def _per_owner_grads(rank: int) -> dict[int, torch.Tensor]:
+    """Deterministic per-owner dK for ``rank``: entry o is filled with (rank + 1) * (o + 1)."""
+    return {owner: torch.full(SHAPE, float((rank + 1) * (owner + 1))) for owner in range(CP_SIZE)}
+
+
+def _expected(rank: int) -> torch.Tensor:
+    """Reference: sum over all ranks of their contribution for owner ``rank``."""
+    total = sum((r + 1) * (rank + 1) for r in range(CP_SIZE))
+    return torch.full(SHAPE, float(total))
+
+
+def _worker(rank: int, world_size: int, port: int, out_q) -> None:
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    dist.init_process_group("gloo", rank=rank, world_size=world_size)
+    try:
+        group = dist.group.WORLD
+        grad_key, grad_value = _route_kv_grads_to_owners(
+            _per_owner_grads(rank),
+            _per_owner_grads(rank),
+            cp_group=group,
+            cp_rank=rank,
+            cp_size=world_size,
+        )
+        out_q.put((rank, grad_key.clone(), grad_value.clone()))
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.timeout(180)
+def test_route_kv_grads_matches_reference_reduction():
+    """Each rank must end with the sum of every rank's contribution for its own owner slot."""
+    ctx = mp.get_context("spawn")
+    out_q = ctx.Queue()
+    port = 29623
+    procs = [ctx.Process(target=_worker, args=(r, CP_SIZE, port, out_q)) for r in range(CP_SIZE)]
+    for p in procs:
+        p.start()
+    results = {}
+    for _ in range(CP_SIZE):
+        rank, grad_key, grad_value = out_q.get(timeout=120)
+        results[rank] = (grad_key, grad_value)
+    for p in procs:
+        p.join(timeout=60)
+        assert p.exitcode == 0, f"worker exited with {p.exitcode}"
+
+    assert set(results) == set(range(CP_SIZE))
+    for rank, (grad_key, grad_value) in results.items():
+        expected = _expected(rank)
+        assert grad_key.shape == SHAPE
+        torch.testing.assert_close(grad_key, expected)
+        torch.testing.assert_close(grad_value, expected)
+
+
+def test_route_kv_grads_uses_no_point_to_point(monkeypatch):
+    """Routing must not open per-peer p2p connections; that is what OOMs, not the arithmetic."""
+    import nemo_automodel.components.models.gemma4_moe.cp_attention as cpa
+
+    def _fail(*args, **kwargs):
+        raise AssertionError("_route_kv_grads_to_owners must not use point-to-point exchange")
+
+    monkeypatch.setattr(cpa, "_direct_exchange", _fail)
+    monkeypatch.setattr(torch.distributed, "batch_isend_irecv", _fail)
+
+    grads = {0: torch.full(SHAPE, 3.0)}
+    captured = {}
+
+    def _fake_reduce_scatter(out, inp, group=None):
+        captured["input_shape"] = tuple(inp.shape)
+        out.copy_(inp)
+
+    monkeypatch.setattr(torch.distributed, "reduce_scatter_tensor", _fake_reduce_scatter)
+    grad_key, grad_value = _route_kv_grads_to_owners(grads, grads, cp_group=None, cp_rank=0, cp_size=1)
+
+    assert captured["input_shape"] == SHAPE  # owner-major on dim 0, not a [cp_size, batch, ...] stack
+    torch.testing.assert_close(grad_key, torch.full(SHAPE, 3.0))
+    torch.testing.assert_close(grad_value, torch.full(SHAPE, 3.0))


### PR DESCRIPTION
# What does this PR do ?

Fixes the CUDA OOM inside NCCL `batch_isend_irecv` in the Gemma4 CP ring-attention backward (AMINT-242), which fails `gemma4_31b_tulu3_text_cp8_16k`.

# Issue

```
ncclUnhandledCudaError: Call to CUDA function failed.
Last error: Cuda failure 2 'out of memory'
  cp_attention.py:229 in _route_kv_grads_to_owners
  cp_attention.py:202 in _direct_exchange -> torch.distributed.batch_isend_irecv(ops)
```

`_route_kv_grads_to_owners` returned each owner's dK/dV by looping `distance = 1..cp_size-1`, sending point-to-point to `cp_rank - distance`. NCCL connections are **directional**, and the forward ring only ever sends to `cp_rank + 1` / receives from `cp_rank - 1` — so every peer/direction the routing uses is one the forward never opened, **distance 1 included**, since it reverses the ring. NCCL allocates connection buffers lazily on first use, outside the caching allocator, at the backward memory peak.

Measured on 8xH100. `allocated` and `reserved` stay flat while free CUDA memory falls ~0.38 GiB per exchange, one exchange per distance:

| point | alloc | reserved | cuda_free |
|---|---|---|---|
| before routing | 19.28 | 72.73 | 1.36 |
| after distance 1 | 19.29 | 72.73 | 0.98 |
| after distance 2 | 19.31 | 72.73 | 0.61 |
| after distance 3 | 19.31 | 72.73 | 0.23 |
| during distance 4 | — | — | 0.01 → OOM |

Flat `alloc`/`reserved` with falling `cuda_free` is the signature of memory going to something other than the caching allocator. The payload is not the problem: all 8 owners' dK+dV total **0.12 GiB**.

# Fix

Summing per owner and handing owner `i` its slice **is** a reduce-scatter, so issue one per tensor. It runs over the group's existing collective channels, opens no new peer connections, and replaces `2*(cp_size-1)` p2p round-trips plus their per-iteration buffers with two collectives.

Owner-major `cat` on dim 0, not `stack`: `reduce_scatter_tensor` splits dim 0 and requires `output.shape[0] * cp_size == input.shape[0]`, which a `[cp_size, batch, ...]` stack satisfies only when `batch == 1` (this recipe's value, so a stacked version passes the GPU run and hides the bug).

# Validation

**nemo-ci, `gemma4_31b_tulu3_text_cp8_16k` on eos (8xH100)** — [pipeline 60942996](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/60942996) / [job 383727225](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/383727225):

| | |
|---|---|
| Result | **success**, 47.8 min |
| Steps | 50/50 (`Max train steps: 50`, steps 0 → 49) |
| NCCL / torch OOM | **0** / **0** |
| Loss | 0.6311 → 0.3336 |
| grad_norm | 44.42 → 1.62 |

Local A/B, same recipe / node / container (`pipe.60708098`), 1 node / 8 GPUs:

| | Result |
|---|---|
| BEFORE (`518ea2804`, unmodified) | 2x `Cuda failure 2 'out of memory'`, 0 steps |
| AFTER (this branch) | exit 0, **0 OOM**, 3 steps, loss 2.1737, grad_norm 32.13 |
| `tests/unit_tests/models/gemma4_moe/` | 8/8 pass |
| `ruff format` + `ruff check` | clean |

New tests: a 4-rank gloo run asserting each rank's result equals the analytic cross-rank sum (at `batch=2`, which is what caught the `stack` bug), and a test that fails if the routing reaches for `batch_isend_irecv` — the communication pattern is the defect, not the arithmetic.

# Changelog

- `_route_kv_grads_to_owners` uses `reduce_scatter_tensor` instead of all-pairs p2p.
- New `tests/unit_tests/models/gemma4_moe/test_cp_route_kv_grads.py`.
- `gemma4_31b_tulu3_text_cp8_16k.yaml` gains `ci: time: "01:00:00"`; it declared `max_steps: 50` but no `ci:` block, so it inherited `.vlm_finetune_test`'s `00:10:00`, which the measured 47.8 min run cannot fit.

# Pre checks

- [x] Read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Added tests
- [ ] Documentation — n/a

# Additional Information

- Fixes AMINT-242
- Related: AMINT-241 (separate defect: allocator fragmentation, 13.10 GiB FSDP bucket vs 52.48 GiB reserved-but-unallocated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
