### PR TITLE
fix(checkpoint): recover from pointer quota exhaustion

### DIFF
--- a/nemo_automodel/recipes/base_recipe.py
+++ b/nemo_automodel/recipes/base_recipe.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import errno
 import getpass
 import json
 import logging
@@ -65,6 +66,7 @@ from nemo_automodel.components.training.step_scheduler import StepScheduler
 from nemo_automodel.recipes._typed_config import RecipeConfig
 
 logger = logging.getLogger(__name__)
+_CHECKPOINT_POINTER_CAPACITY_ERRNOS = {errno.EDQUOT, errno.ENOSPC}
 
 
 def has_load_restore_state(object):
@@ -507,7 +509,9 @@ class BaseRecipe:
         try:
             try:
                 os.symlink(relative_target, temp_path)
-            except OSError:
+            except OSError as error:
+                if error.errno in _CHECKPOINT_POINTER_CAPACITY_ERRNOS:
+                    raise
                 if os.path.lexists(temp_path):
                     os.remove(temp_path)
                 # Fallback: publish a text pointer when symbolic links are not supported.
@@ -524,6 +528,22 @@ class BaseRecipe:
                 temp_path = ""
                 if os.path.exists(txt_path):
                     os.remove(txt_path)
+        except OSError as error:
+            if error.errno not in _CHECKPOINT_POINTER_CAPACITY_ERRNOS:
+                raise
+
+            if link_name == "LATEST":
+                self._remove_checkpoint_pointer(link_name)
+                logger.warning(
+                    "Checkpoint storage is full; removed stale %s pointer. "
+                    "Resume will discover the highest-step checkpoint directory instead.",
+                    link_name,
+                )
+            else:
+                logger.warning(
+                    "Checkpoint storage is full; preserving the existing %s pointer instead of updating it.",
+                    link_name,
+                )
         finally:
             if temp_path and os.path.lexists(temp_path):
                 os.remove(temp_path)

--- a/tests/unit_tests/recipes/test_base_recipe.py
+++ b/tests/unit_tests/recipes/test_base_recipe.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import errno
 import logging
 import os
 from types import SimpleNamespace
@@ -1095,6 +1096,68 @@ def test_checkpoint_pointer_replace_failure_preserves_existing_target(tmp_path, 
 
     assert read_checkpoint_pointer(tmp_path, "LATEST") == old_checkpoint
     assert not list(tmp_path.glob(".LATEST.*.tmp"))
+
+
+def test_latest_pointer_quota_failure_falls_back_to_highest_checkpoint(tmp_path, monkeypatch, caplog):
+    """A quota failure removes stale LATEST so resume restores the completed newer checkpoint."""
+    recipe_inst = _ToyRecipe(tmp_path)
+    x = torch.randn(4, 2)
+    loss = recipe_inst.model(x).sum()
+    loss.backward()
+    recipe_inst.optimizer.step()
+    recipe_inst.save_checkpoint(epoch=0, step=100, train_loss=float(loss.item()))
+
+    recipe_inst.checkpointer.config.is_async = True
+    x = torch.randn(4, 2)
+    loss = recipe_inst.model(x).sum()
+    loss.backward()
+    recipe_inst.optimizer.step()
+    expected_weight = recipe_inst.model.weight.clone()
+    recipe_inst.save_checkpoint(epoch=0, step=200, train_loss=float(loss.item()))
+
+    real_symlink = os.symlink
+
+    def fail_temporary_symlink(source, destination):
+        if os.path.basename(destination).startswith(".LATEST."):
+            raise OSError(errno.EDQUOT, "quota exceeded")
+        return real_symlink(source, destination)
+
+    monkeypatch.setattr(os, "symlink", fail_temporary_symlink)
+
+    with caplog.at_level(logging.WARNING):
+        recipe_inst._finalize_pending_checkpoint()
+
+    assert read_checkpoint_pointer(tmp_path, "LATEST") is None
+    assert find_latest_checkpoint(tmp_path) == tmp_path / "epoch_0_step_200"
+    assert "removed stale LATEST pointer" in caplog.text
+    assert not list(tmp_path.glob(".LATEST.*.tmp"))
+
+    with torch.no_grad():
+        recipe_inst.model.weight.add_(42.0)
+    recipe_inst.load_checkpoint(restore_from="LATEST")
+    assert torch.allclose(recipe_inst.model.weight, expected_weight)
+
+
+def test_non_latest_pointer_quota_failure_preserves_existing_target(tmp_path, monkeypatch, caplog):
+    """Quota failures keep the last published best-checkpoint pointer intact."""
+    recipe_inst = _ToyRecipe(tmp_path)
+    old_checkpoint = tmp_path / "epoch_0_step_100"
+    new_checkpoint = tmp_path / "epoch_0_step_200"
+    old_checkpoint.mkdir()
+    new_checkpoint.mkdir()
+    recipe_inst._update_checkpoint_symlink("LOWEST_VAL", str(old_checkpoint))
+
+    def fail_temporary_symlink(_source, _destination):
+        raise OSError(errno.ENOSPC, "filesystem full")
+
+    monkeypatch.setattr(os, "symlink", fail_temporary_symlink)
+
+    with caplog.at_level(logging.WARNING):
+        recipe_inst._update_checkpoint_symlink("LOWEST_VAL", str(new_checkpoint))
+
+    assert read_checkpoint_pointer(tmp_path, "LOWEST_VAL") == old_checkpoint
+    assert "preserving the existing LOWEST_VAL pointer" in caplog.text
+    assert not list(tmp_path.glob(".LOWEST_VAL.*.tmp"))
 
 
 def test_checkpoint_retention_preserves_lowest_val_after_resume(tmp_path):


### PR DESCRIPTION
# What does this PR do?

Make checkpoint pointer publication resilient to storage-capacity errors so a completed async checkpoint remains resumable even when `LATEST` cannot be atomically replaced.

This addresses the failure observed in [the Qwen3-8B FineWeb-Edu run](https://wandb.ai/Nemo-automodel/automodel/runs/piotr-qwen3-8b-fineweb-edu-100k-20260802):

1. Slurm job `14915246` completed the async `epoch_0_step_69999` payload.
2. Lustre returned `EDQUOT` while creating the temporary `LATEST` pointer, leaving `LATEST -> epoch_0_step_59999`.
3. Jobs `14915247` and `14915248` restored step 59,999, replayed to step 69,999, and failed with `FileExistsError` because the completed step-69,999 directory already existed.
4. Other ranks then waited in a collective until the 30-minute NCCL watchdog timeout.

On `ENOSPC` or `EDQUOT`, this change removes a stale `LATEST` pointer. Existing resume logic then safely falls back to the highest-step checkpoint directory. Capacity failures updating non-`LATEST` pointers preserve their previously published targets.

Normal pointer updates remain atomic, and unrelated I/O errors still propagate.

# Changelog

- Treat `ENOSPC` and `EDQUOT` as checkpoint-pointer capacity failures.
- Remove stale `LATEST` pointers so resume discovers the completed newest checkpoint.
- Preserve existing best or custom checkpoint pointers when capacity prevents an update.
- Add an async save/resume regression that restores the newer checkpoint after simulated quota exhaustion.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added focused CPU unit coverage.
- [x] No documentation update is required; the public configuration and API are unchanged.
- [x] Commit includes DCO sign-off.
- [x] `ruff format .`, `ruff check --fix .`, and `git diff --check`.
- [x] Focused checkpoint tests: 4 passed.
- [x] EAGLE checkpoint-resume suite: 37 passed.
- [ ] Full `test_base_recipe.py` under the local Python 3.10 shell: 64 passed, 5 pre-existing failures because `Path.exists(follow_symlinks=...)` requires a newer Python runtime.

# Additional Information

No checkpoint payloads are deleted or overwritten by this change.
