### PR TITLE
ci: add gradient-determinism rule to PR review guidelines

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -301,6 +301,48 @@ jobs:
           - flag `.data` mutation that can bypass autograd; prefer `torch.no_grad()`
             with `copy_()`. Exempt tightly controlled initialization, checkpoint,
             or upstream-compatibility code only when the safety invariant is clear.
+        - Gradient determinism in rewritten tensor math. This check is not gated on
+          distributed or training-loop constructs: apply it to any changed hunk that
+          computes a tensor which later receives a gradient, including a plain
+          elementwise helper inside a model, an expert MLP, or a kernel wrapper, and
+          apply it even when the diff contains no `backward()`, optimizer, hook, or
+          collective. Trigger on the shape of the diff, not the subsystem: a hunk
+          that replaces a per-group `torch.split(...)` + elementwise-op +
+          `torch.cat(...)` loop, or an explicit Python loop, with a single vectorized
+          gather/repeat. That rewrite usually preserves the forward result exactly
+          while turning the backward from a deterministic per-block reduction into an
+          unordered atomic accumulation, so the gradient stays mathematically correct
+          but stops being reproducible. Forward-equivalence assertions,
+          tolerance-based reference comparisons, a green suite, and benchmark tables
+          all pass. "The gradients are equivalent" is true and is not the question;
+          the question is whether two identical runs produce bit-identical gradients.
+          Exactly these accumulate into repeated destination rows and are run-to-run
+          nondeterministic on CUDA: `torch.repeat_interleave` with a tensor `repeats`,
+          and `torch.index_select` / `torch.gather` when the indices repeat. These are
+          NOT in that class and must never be flagged for it: `Tensor.expand` and
+          implicit broadcast, `torch.split` + `torch.cat` loops,
+          `nn.functional.embedding`, and advanced indexing `x[idx]`, whose backwards
+          are sum or sorted-segment reductions. `index_add_`, `scatter_add_`,
+          `index_put_(accumulate=True)`, and `torch.bincount` are nondeterministic in
+          the forward only, and `bincount` has no gradient at all, so never describe
+          those as a backward hazard.
+          Raise the finding only when the accumulating tensor is a trainable
+          parameter, and name the shipped config that reaches it. Require a
+          deterministic segmented reduction — a custom `torch.autograd.Function`, or
+          `torch.segment_reduce` — or retention of the previous path when
+          `requires_grad` is set. Require a regression test that runs the backward
+          twice on CUDA in the training dtype with a random upstream gradient
+          (`out.backward(torch.randn_like(out))`) and imbalanced group sizes, and
+          asserts the parameter gradient is bit-identical across runs. A test using
+          `out.sum().backward()` cannot detect this: an all-ones upstream gradient
+          collapses each parameter row to an exactly representable count, so
+          accumulation order becomes invisible. Treat `assert grad is not None`, a
+          shape/dtype check, or CPU/fp32-only coverage as insufficient here, and never
+          state that test coverage is adequate, since you cannot run the tests.
+          You cannot execute code: describe the hazard as run-to-run variation in that
+          parameter's accumulated gradient, and state the check the author should run.
+          Do not predict which kernel is selected, and do not claim anything raises
+          under `torch.use_deterministic_algorithms`.
         - Distributed autograd and gradient handling. Treat changes to loss
           normalization, `backward()`, gradient accumulation, `no_sync`, FSDP sync
           deferral, gradient hooks, mixed-precision scaling/unscaling, norm


### PR DESCRIPTION
## Why

On #3374 the automated reviewer posted `LGTM`. @HuiyingLi then filed a [P1] it missed: replacing a per-group `split`/`cat` loop in `_apply_bias` with `torch.repeat_interleave` preserves the forward result exactly, but turns the backward into an unordered atomic accumulation — so the **trainable** expert-bias gradient becomes nondeterministic run-to-run on CUDA. Fixed since, in #3387.

Reproduced on an RTX 5880 Ada (torch 2.10, bf16, random upstream gradient, bitwise compare):

| | old `split`+`cat` | new `repeat_interleave` |
|---|---|---|
| balanced, 64 experts x 64 tok x 512 | 1/10 distinct grad hashes | **10/10**, all 32768 elems vary |
| imbalanced (4096 tok -> 1 expert) | 1/20 | **20/20**, max span 54 |
| **`sum().backward()`** (what the added test did) | 1/20 | **1/20 — perfectly stable** |

That last row is why the PR's own gradient test could never fail: an all-ones upstream gradient collapses each bias row to an exactly representable count.

## Why the existing guidance didn't catch it

`Distributed autograd and gradient handling` already covers a lot, but it did not fire here:

1. **It's gated on training-loop constructs** — `backward()`, `no_sync`, FSDP, hooks, scaler, clipping, optimizer, DTensor, collectives. I checked every term against the #3374 diff: none present; the literal string `backward` appears 0 times in the `nemo_automodel/` hunks. `_apply_bias` is a plain elementwise helper in an expert MLP.
2. **Its checks all ask whether the gradient is *wrong*.** Ordering/exactly-once, reduction domain, rank symmetry, parameter identity, recomputation — an atomic accumulation passes all five, because it returns a *correct* gradient every run, just summed in a different order. The defect is an unstable value, not a wrong one, and `reproduc|bitwise|run-to-run|nondeterm|atomic` appear nowhere in the prompt.
3. The nearest general hook asks for *"comparison against a trusted reference ... with justified tolerances"* — tolerance-based comparison is structurally blind to run-to-run variation.
4. The one bullet that does target this (`custom torch.autograd.Function ... require backward and gradient-parity coverage, not forward-only output checks`) is gated on *having* a custom Function. #3374 has none; #3387, the fix, adds one. It fires on the fix, not the bug.

## What this adds

One **ungated top-level** rule that triggers on the shape of the diff rather than the subsystem, so it applies to model math with no distributed constructs in it. +42/-0, no existing line touched.

The op classification is empirically verified, not assumed — an earlier draft of this rule listed `expand`/implicit broadcast as a hazard, which is **wrong** (its backward is a sum reduction) and would have manufactured false findings across ~151 `.expand(` sites, while also self-negating, since the safe `split`+`cat` baseline *is* a broadcast:

- **nondeterministic backward:** `repeat_interleave` (tensor repeats), `index_select` / `gather` when indices repeat
- **deterministic, must never be flagged:** `expand` and implicit broadcast, `split`+`cat` loops, `embedding`, advanced indexing `x[idx]`
- **forward-only nondeterminism:** `index_add_`, `scatter_add_`, `index_put_(accumulate=True)`, `bincount` (no gradient at all)

Nothing in that set raises under `torch.use_deterministic_algorithms(True)` — it silently picks a slower kernel, so determinism-mode CI doesn't catch this class either. The rule says so explicitly, because a draft that merely warned about the claim still produced it.

## Measured

Replaying the current prompt vs. this one against #3374 at `f8095c30`, same model, review posted as a tool argument:

| Arm | #3374 (the bug) | #3387 (the fix) |
|---|---|---|
| current prompt | **0/2** — no determinism language; one run called it *"a nice vectorization with backward-correctness tests"* and spent its finding on a docstring | — |
| with this rule | **2/2** report it with the correct mechanism + the `sum().backward()` gap | **`LGTM`** — does not attack its own fix |

## Caveats

- Sample sizes are small (2 runs/arm). I could not read `vars.CLAUDE_MODEL` (org-scoped), so the replay used `claude-opus-4-6`; if production uses a different model these numbers may shift.
- This is a hazard-register entry, not a general improvement. A clue-stripped variant that kept the structure but dropped the specific mechanism scored **0/3** — generic "check the backward" is satisfied by any backward reasoning, which is exactly how this shipped.