### PR TITLE
fix(moe): support EP-free DTensor state-dict conversion

### DIFF
--- a/nemo_automodel/components/moe/state_dict_mixin.py
+++ b/nemo_automodel/components/moe/state_dict_mixin.py
@@ -183,16 +183,15 @@ class MoESplitExpertsStateDictMixin:
         """Split grouped expert weights into per-expert tensors.
 
         Args:
-            weight: Tensor of shape [experts, ...], with arbitrary trailing dimensions. An EP DTensor must shard
-                the experts axis over an ``ep`` mesh dimension. A non-EP DTensor may use any FSDP placement on a
-                mesh without an ``ep`` dimension.
+            weight: Tensor of shape [experts, ...], with arbitrary trailing dimensions. An EP DTensor uses an
+                ``ep`` mesh dimension. A non-EP DTensor may use any FSDP placement on a mesh without ``ep``.
             n_experts: Global number of experts in ``weight``.
 
         Returns:
-            List of ``n_experts`` tensors of shape [...], except on an EP rank where the list contains only that
-            rank's local experts. Non-EP DTensor outputs preserve the input mesh and adjusted placements.
+            Per-expert tensors of shape [...]. A DTensor sharded on the expert axis returns only the experts local
+            to this rank; other DTensors return every expert and preserve adjusted placements.
         """
-        if is_dtensor(weight) and "ep" in weight.device_mesh.mesh_dim_names:
+        if is_dtensor(weight):
             split_weights, expert_ids = split_experts_weights_dtensor_aware(weight, n_experts)
             self._last_expert_ids = expert_ids
             return split_weights

--- a/nemo_automodel/components/moe/state_dict_mixin.py
+++ b/nemo_automodel/components/moe/state_dict_mixin.py
@@ -104,14 +104,18 @@ class MoESplitExpertsStateDictMixin:
     ) -> None:
         """Validate that all required experts are available in the HF state dict before loading.
         Only validates experts needed for the current rank and layers present in the state dict.
+        Expert groups already loaded through registered in-place views validate the rank-local IDs recorded by
+        ``_split_experts_weights``, including when EP is disabled and no MoE mesh is passed to this method.
 
         Args:
-            hf_state_dict: HuggingFace format state dict
-            n_experts: Total number of experts
-            device_mesh: Optional device mesh for expert parallelism
+            hf_state_dict: HuggingFace state mapping. Expert gate/up values are tensors of shape
+                [expert_hidden, hidden], and down values have shape [hidden, expert_hidden]. This method validates
+                their keys only.
+            n_experts: Total number of experts.
+            device_mesh: Optional device mesh whose ``ep`` dimension partitions the experts axis.
 
         Raises:
-            RuntimeError: If required expert weights are missing from the checkpoint
+            RuntimeError: If required expert weights are missing from the checkpoint.
         """
         if device_mesh is not None:
             start_expert, end_expert = get_expert_range_for_rank_from_mesh(device_mesh, n_experts)
@@ -159,18 +163,24 @@ class MoESplitExpertsStateDictMixin:
 
         missing_weights = []
         projection_types = ["gate_proj", "up_proj", "down_proj"] if self._is_gated_moe else ["up_proj", "down_proj"]
+        inplace_loaded_keys: set[str] = getattr(self, "_inplace_loaded_native_keys", None) or set()
+        inplace_expert_ids = getattr(self, "_last_expert_ids", None) or required_experts
+        total_required = 0
 
         for layer_num, prefixes in layers_with_experts.items():
             for prefix in prefixes:
-                for expert_id in required_experts:
-                    for proj_type in projection_types:
+                for proj_type in projection_types:
+                    native_projection = "down_projs" if proj_type == "down_proj" else "gate_and_up_projs"
+                    native_key = f"{prefix}layers.{layer_num}.{expert_segment}.{native_projection}"
+                    experts_to_validate = inplace_expert_ids if native_key in inplace_loaded_keys else required_experts
+                    total_required += len(experts_to_validate)
+                    for expert_id in experts_to_validate:
                         expected_key = f"{prefix}layers.{layer_num}.{expert_segment}.{expert_id}.{proj_type}.weight"
                         if expected_key not in hf_state_dict:
                             missing_weights.append(expected_key)
 
         if missing_weights:
             missing_count = len(missing_weights)
-            total_required = len(required_experts) * len(layers_with_experts) * len(projection_types)
             raise RuntimeError(
                 f"Expert weights missing from checkpoint{rank_info}: {missing_count}/{total_required} required weights not found. "
                 f"Cannot load experts - checkpoint may be incomplete or corrupted. "

--- a/nemo_automodel/components/moe/state_dict_mixin.py
+++ b/nemo_automodel/components/moe/state_dict_mixin.py
@@ -180,11 +180,19 @@ class MoESplitExpertsStateDictMixin:
             )
 
     def _split_experts_weights(self, weight: torch.Tensor, n_experts: int) -> list[torch.Tensor]:
-        """Split grouped expert weights into individual expert weights.
-        For grouped expert weights with shape [n_experts, ...], split into n_experts tensors each with shape [...].
-        Supports both regular tensors and DTensors.
+        """Split grouped expert weights into per-expert tensors.
+
+        Args:
+            weight: Tensor of shape [experts, ...], with arbitrary trailing dimensions. An EP DTensor must shard
+                the experts axis over an ``ep`` mesh dimension. A non-EP DTensor may use any FSDP placement on a
+                mesh without an ``ep`` dimension.
+            n_experts: Global number of experts in ``weight``.
+
+        Returns:
+            List of ``n_experts`` tensors of shape [...], except on an EP rank where the list contains only that
+            rank's local experts. Non-EP DTensor outputs preserve the input mesh and adjusted placements.
         """
-        if is_dtensor(weight):
+        if is_dtensor(weight) and "ep" in weight.device_mesh.mesh_dim_names:
             split_weights, expert_ids = split_experts_weights_dtensor_aware(weight, n_experts)
             self._last_expert_ids = expert_ids
             return split_weights

--- a/nemo_automodel/components/moe/state_dict_utils.py
+++ b/nemo_automodel/components/moe/state_dict_utils.py
@@ -30,22 +30,49 @@ def get_submesh(device_mesh: DeviceMesh, dims: tuple[str, ...]) -> DeviceMesh:
     return device_mesh[dims]
 
 
+def _get_expert_mesh_dim_index(dtensor: DTensor) -> int | None:
+    """Find the device-mesh dimension that partitions a grouped expert tensor.
+
+    Args:
+        dtensor: DTensor with global shape [experts, ...] and arbitrary trailing dimensions. A named ``ep`` mesh
+            dimension owns the expert partition when present; otherwise a ``Shard(0)`` placement identifies an
+            EP-free FSDP partition of the experts axis.
+
+    Returns:
+        Index of the expert-partitioning mesh dimension, or ``None`` when every rank retains all experts.
+    """
+    mesh_dim_names = tuple(dtensor.device_mesh.mesh_dim_names)
+    if "ep" in mesh_dim_names:
+        return mesh_dim_names.index("ep")
+
+    return next(
+        (
+            dim_idx
+            for dim_idx, placement in enumerate(dtensor.placements)
+            if isinstance(placement, Shard) and placement.dim == 0
+        ),
+        None,
+    )
+
+
 def get_expert_slice_for_rank(experts_tensor: torch.Tensor, n_experts: int) -> tuple[torch.Tensor, int, int]:
     """
     Get the slice of experts present on the current rank for a DTensor.
 
     For non-DTensors, returns the full tensor with start_expert=0, end_expert=n_experts.
-    For DTensors sharded along the expert dimension (dim=0), returns only the local experts.
+    For DTensors sharded along the expert dimension (dim=0), returns only the local experts. The mesh dimension
+    may be the explicit ``ep`` dimension or an EP-free FSDP dimension such as ``dp_shard_cp``.
 
     Args:
-        experts_tensor: Input tensor containing expert weights [n_experts, ...]
-        n_experts: Total number of experts across all ranks
+        experts_tensor: Tensor with global shape [experts, ...] and arbitrary trailing dimensions. For a DTensor,
+            the per-rank local shape is [local_experts, ...] when a mesh dimension uses ``Shard(0)``; other
+            placements retain ``experts`` on the first local axis.
+        n_experts: Total number of experts across all ranks.
 
     Returns:
-        tuple of (local_tensor, start_expert_id, end_expert_id)
-        - local_tensor: The local portion of the tensor
-        - start_expert_id: Global ID of the first expert on this rank
-        - end_expert_id: Global ID after the last expert on this rank (exclusive)
+        Tuple containing the local tensor of shape [local_experts, ...], the inclusive global ID of its first
+        expert, and the exclusive global ID after its last expert. The local tensor aliases the input's local
+        storage.
     """
     if not is_dtensor(experts_tensor):
         return experts_tensor, 0, n_experts
@@ -54,14 +81,17 @@ def get_expert_slice_for_rank(experts_tensor: torch.Tensor, n_experts: int) -> t
     local_tensor = dtensor.to_local()
 
     device_mesh = dtensor.device_mesh
-    assert "ep" in device_mesh.mesh_dim_names, "ep mesh dimension not found"
-    ep_mesh = get_submesh(device_mesh, ("ep",))
-    current_rank = ep_mesh.get_local_rank()
+    expert_mesh_dim_idx = _get_expert_mesh_dim_index(dtensor)
+    if expert_mesh_dim_idx is None:
+        return local_tensor, 0, n_experts
 
-    placement = dtensor.placements[-1]  # Assume single device mesh for now
+    expert_mesh_dim_name = device_mesh.mesh_dim_names[expert_mesh_dim_idx]
+    expert_mesh = get_submesh(device_mesh, (expert_mesh_dim_name,))
+    placement = dtensor.placements[expert_mesh_dim_idx]
     if isinstance(placement, Shard) and placement.dim == 0:
         # Tensor is sharded along expert dimension
-        world_size = ep_mesh.size()
+        current_rank = expert_mesh.get_local_rank()
+        world_size = expert_mesh.size()
 
         # Calculate expert range for this rank
         experts_per_rank = n_experts // world_size
@@ -81,26 +111,26 @@ def get_expert_slice_for_rank(experts_tensor: torch.Tensor, n_experts: int) -> t
     elif isinstance(placement, Replicate):
         # Tensor is replicated - all ranks have full data
         return local_tensor, 0, n_experts
-    else:
-        # Other sharding patterns - assume full range for now
-        # Could be extended to handle sharding along other dimensions
-        return local_tensor, 0, n_experts
+    # Other sharding patterns retain every expert on the rank.
+    return local_tensor, 0, n_experts
 
 
 def split_experts_weights_dtensor_aware(weight: torch.Tensor, n_experts: int) -> tuple[list[torch.Tensor], list[int]]:
     """
     Split expert weights, handling both regular tensors and DTensors.
 
-    For DTensors, only splits the experts present on the current rank.
+    For DTensors sharded on the expert axis, only splits the experts present on the current rank. Other DTensor
+    placements retain all experts and are adjusted after removing the expert tensor dimension.
 
     Args:
-        weight: Expert weights tensor [n_experts, ...] (regular tensor or DTensor)
-        n_experts: Total number of experts across all ranks
+        weight: Tensor with global shape [experts, ...] and arbitrary trailing dimensions. A ``Shard(0)`` DTensor
+            has local shape [local_experts, ...]; inner-axis shards retain shape [experts, ...] locally.
+        n_experts: Total number of experts across all ranks.
 
     Returns:
-        tuple of (split_weights, expert_ids)
-        - split_weights: List of individual expert weight tensors
-        - expert_ids: List of global expert IDs corresponding to split_weights
+        Tuple containing per-expert tensors of shape [...] and their global expert IDs. Each output aliases the
+        corresponding local input slice. Any retained DTensor ``Shard(d)`` placement becomes ``Shard(d - 1)``
+        after the experts axis is removed.
     """
     local_tensor, start_expert, end_expert = get_expert_slice_for_rank(weight, n_experts)
     local_n_experts = end_expert - start_expert
@@ -120,19 +150,23 @@ def split_experts_weights_dtensor_aware(weight: torch.Tensor, n_experts: int) ->
         original_placements = weight.placements
         mesh_dim_names = list(weight.device_mesh.mesh_dim_names)
 
-        # 'ep' is guaranteed to be present; remove it
-        ep_dim_idx = mesh_dim_names.index("ep")
-        remaining_mesh_dims = mesh_dim_names[:ep_dim_idx] + mesh_dim_names[ep_dim_idx + 1 :]
+        # Remove the mesh dimension that partitions experts. With EP disabled, this may be an FSDP dimension.
+        expert_mesh_dim_idx = _get_expert_mesh_dim_index(weight)
+        if expert_mesh_dim_idx is None:
+            remaining_mesh_dims = mesh_dim_names
+            new_placements_template = original_placements
+        else:
+            remaining_mesh_dims = mesh_dim_names[:expert_mesh_dim_idx] + mesh_dim_names[expert_mesh_dim_idx + 1 :]
+            new_placements_template = (
+                original_placements[:expert_mesh_dim_idx] + original_placements[expert_mesh_dim_idx + 1 :]
+            )
 
-        # Build device mesh without 'ep'
+        # Build a device mesh without the dimension that partitioned experts.
         if remaining_mesh_dims and any(map(lambda x: get_submesh(device_mesh, (x,)).size() > 1, remaining_mesh_dims)):
             new_device_mesh = get_submesh(device_mesh, tuple(remaining_mesh_dims))
         else:
             new_device_mesh = None
             is_weight_dtensor = False
-
-        # Placements without the 'ep' dimension
-        new_placements_template = original_placements[:ep_dim_idx] + original_placements[ep_dim_idx + 1 :]
 
     for i in range(local_n_experts):
         expert_weight = local_tensor[i]  # Shape: [...] (expert dimension removed)

--- a/tests/unit_tests/moe/test_state_dict_mixin.py
+++ b/tests/unit_tests/moe/test_state_dict_mixin.py
@@ -16,6 +16,9 @@ from unittest.mock import Mock, patch
 
 import pytest
 import torch
+import torch.distributed as dist
+from torch.distributed._tensor import Shard, distribute_tensor
+from torch.distributed.device_mesh import DeviceMesh
 
 skip_if_no_gpu = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for GPU operations")
 
@@ -47,6 +50,41 @@ class MockMoEStateDictMixin(MoESplitExpertsStateDictMixin):
         self.dtype = dtype
         self._uses_model_prefix = uses_model_prefix
         self._last_expert_ids = []
+
+
+def _run_ep_free_dtensor_split(rank: int, world_size: int, init_file: str) -> None:
+    """Verify non-EP DTensors retain every global expert under FSDP-style sharding."""
+    dist.init_process_group("gloo", init_method=f"file://{init_file}", rank=rank, world_size=world_size)
+    try:
+        mesh = DeviceMesh("cpu", torch.arange(world_size), mesh_dim_names=("dp_shard_cp",))
+        full_weight = torch.arange(4 * 6 * 4, dtype=torch.float32).reshape(4, 6, 4)
+        mixin = MockMoEStateDictMixin(n_experts=4, inter_dim=2)
+
+        for shard_dim in (0, 1):
+            weight = distribute_tensor(full_weight, mesh, [Shard(shard_dim)])
+
+            splits = mixin._split_experts_weights(weight, 4)
+
+            assert mixin._last_expert_ids == [0, 1, 2, 3]
+            assert len(splits) == 4
+            for expert_id, expert_weight in enumerate(splits):
+                torch.testing.assert_close(expert_weight.full_tensor(), full_weight[expert_id])
+
+        weight = distribute_tensor(full_weight, mesh, [Shard(0)])
+        converted = dict(
+            mixin._convert_single_merged_expert_to_hf_split_experts(
+                "model.layers.0.mlp.experts.gate_and_up_projs",
+                weight,
+            )
+        )
+        assert len(converted) == 8
+        for expert_id in range(4):
+            gate_key = f"model.layers.0.mlp.experts.{expert_id}.gate_proj.weight"
+            up_key = f"model.layers.0.mlp.experts.{expert_id}.up_proj.weight"
+            torch.testing.assert_close(converted[gate_key].full_tensor(), full_weight[expert_id, :, :2].T)
+            torch.testing.assert_close(converted[up_key].full_tensor(), full_weight[expert_id, :, 2:].T)
+    finally:
+        dist.destroy_process_group()
 
 
 class TestValidateExpertAvailability:
@@ -185,12 +223,21 @@ class TestSplitExpertsWeights:
 
         mixin = MockMoEStateDictMixin()
         mock_weight = Mock()
+        mock_weight.device_mesh.mesh_dim_names = ("ep",)
 
         result = mixin._split_experts_weights(mock_weight, 8)
 
         assert len(result) == 2
         assert mixin._last_expert_ids == [2, 3]
         mock_split_dtensor.assert_called_once_with(mock_weight, 8)
+
+    def test_dtensor_without_ep_mesh_splits_all_experts(self, tmp_path):
+        torch.multiprocessing.spawn(
+            _run_ep_free_dtensor_split,
+            args=(2, str(tmp_path / "ep_free_dtensor_split")),
+            nprocs=2,
+            join=True,
+        )
 
 
 class TestConcatenateExpertWeights:

--- a/tests/unit_tests/moe/test_state_dict_mixin.py
+++ b/tests/unit_tests/moe/test_state_dict_mixin.py
@@ -53,36 +53,44 @@ class MockMoEStateDictMixin(MoESplitExpertsStateDictMixin):
 
 
 def _run_ep_free_dtensor_split(rank: int, world_size: int, init_file: str) -> None:
-    """Verify non-EP DTensors retain every global expert under FSDP-style sharding."""
+    """Verify non-EP DTensors split without collecting full expert weights."""
     dist.init_process_group("gloo", init_method=f"file://{init_file}", rank=rank, world_size=world_size)
     try:
         mesh = DeviceMesh("cpu", torch.arange(world_size), mesh_dim_names=("dp_shard_cp",))
         full_weight = torch.arange(4 * 6 * 4, dtype=torch.float32).reshape(4, 6, 4)
         mixin = MockMoEStateDictMixin(n_experts=4, inter_dim=2)
 
-        for shard_dim in (0, 1):
-            weight = distribute_tensor(full_weight, mesh, [Shard(shard_dim)])
+        expert_sharded_weight = distribute_tensor(full_weight, mesh, [Shard(0)])
+        splits = mixin._split_experts_weights(expert_sharded_weight, 4)
 
-            splits = mixin._split_experts_weights(weight, 4)
+        local_expert_ids = [rank * 2, rank * 2 + 1]
+        assert mixin._last_expert_ids == local_expert_ids
+        assert len(splits) == 2
+        for expert_id, expert_weight in zip(local_expert_ids, splits):
+            assert not hasattr(expert_weight, "placements")
+            torch.testing.assert_close(expert_weight, full_weight[expert_id])
 
-            assert mixin._last_expert_ids == [0, 1, 2, 3]
-            assert len(splits) == 4
-            for expert_id, expert_weight in enumerate(splits):
-                torch.testing.assert_close(expert_weight.full_tensor(), full_weight[expert_id])
+        inner_sharded_weight = distribute_tensor(full_weight, mesh, [Shard(1)])
+        splits = mixin._split_experts_weights(inner_sharded_weight, 4)
 
-        weight = distribute_tensor(full_weight, mesh, [Shard(0)])
+        assert mixin._last_expert_ids == [0, 1, 2, 3]
+        assert len(splits) == 4
+        for expert_id, expert_weight in enumerate(splits):
+            assert expert_weight.placements == (Shard(0),)
+            torch.testing.assert_close(expert_weight.full_tensor(), full_weight[expert_id])
+
         converted = dict(
             mixin._convert_single_merged_expert_to_hf_split_experts(
                 "model.layers.0.mlp.experts.gate_and_up_projs",
-                weight,
+                expert_sharded_weight,
             )
         )
-        assert len(converted) == 8
-        for expert_id in range(4):
+        assert len(converted) == 4
+        for expert_id in local_expert_ids:
             gate_key = f"model.layers.0.mlp.experts.{expert_id}.gate_proj.weight"
             up_key = f"model.layers.0.mlp.experts.{expert_id}.up_proj.weight"
-            torch.testing.assert_close(converted[gate_key].full_tensor(), full_weight[expert_id, :, :2].T)
-            torch.testing.assert_close(converted[up_key].full_tensor(), full_weight[expert_id, :, 2:].T)
+            torch.testing.assert_close(converted[gate_key], full_weight[expert_id, :, :2].T)
+            torch.testing.assert_close(converted[up_key], full_weight[expert_id, :, 2:].T)
     finally:
         dist.destroy_process_group()
 
@@ -231,7 +239,7 @@ class TestSplitExpertsWeights:
         assert mixin._last_expert_ids == [2, 3]
         mock_split_dtensor.assert_called_once_with(mock_weight, 8)
 
-    def test_dtensor_without_ep_mesh_splits_all_experts(self, tmp_path):
+    def test_dtensor_without_ep_mesh_avoids_collecting_experts(self, tmp_path):
         torch.multiprocessing.spawn(
             _run_ep_free_dtensor_split,
             args=(2, str(tmp_path / "ep_free_dtensor_split")),

--- a/tests/unit_tests/moe/test_state_dict_mixin.py
+++ b/tests/unit_tests/moe/test_state_dict_mixin.py
@@ -91,6 +91,23 @@ def _run_ep_free_dtensor_split(rank: int, world_size: int, init_file: str) -> No
             up_key = f"model.layers.0.mlp.experts.{expert_id}.up_proj.weight"
             torch.testing.assert_close(converted[gate_key], full_weight[expert_id, :, :2].T)
             torch.testing.assert_close(converted[up_key], full_weight[expert_id, :, 2:].T)
+
+        full_down_weight = torch.arange(4 * 2 * 6, dtype=torch.float32).reshape(4, 2, 6)
+        down_weight = distribute_tensor(full_down_weight, mesh, [Shard(0)])
+        converted.update(
+            mixin._convert_single_merged_expert_to_hf_split_experts(
+                "model.layers.0.mlp.experts.down_projs",
+                down_weight,
+            )
+        )
+
+        restored = mixin._from_hf_w_merged_experts(converted)
+        assert restored == {}
+        assert mixin.view_loaded_native_keys == {
+            "model.layers.0.mlp.experts.gate_and_up_projs",
+            "model.layers.0.mlp.experts.down_projs",
+        }
+        assert mixin._inplace_loaded_native_keys == set()
     finally:
         dist.destroy_process_group()
 
@@ -126,6 +143,36 @@ class TestValidateExpertAvailability:
                     hf_state_dict[key] = torch.randn(512, 1024)
 
         with pytest.raises(RuntimeError, match="Expert weights missing from checkpoint"):
+            mixin._validate_expert_availability(hf_state_dict, 8)
+
+    def test_inplace_loaded_experts_are_not_reported_missing(self):
+        mixin = MockMoEStateDictMixin()
+        hf_state_dict = {}
+
+        for expert in [0, 1]:
+            for proj in ["gate_proj", "up_proj", "down_proj"]:
+                key = f"model.layers.0.mlp.experts.{expert}.{proj}.weight"
+                hf_state_dict[key] = torch.randn(512, 1024)
+
+        mixin._inplace_loaded_native_keys = {
+            "model.layers.0.mlp.experts.gate_and_up_projs",
+            "model.layers.0.mlp.experts.down_projs",
+        }
+        mixin._last_expert_ids = [0, 1]
+
+        mixin._validate_expert_availability(hf_state_dict, 8)
+
+    def test_inplace_loaded_gate_up_still_validates_down_projection(self):
+        mixin = MockMoEStateDictMixin()
+        hf_state_dict = {
+            "model.layers.0.mlp.experts.0.gate_proj.weight": torch.randn(512, 1024),
+            "model.layers.0.mlp.experts.0.up_proj.weight": torch.randn(512, 1024),
+            "model.layers.0.mlp.experts.0.down_proj.weight": torch.randn(512, 1024),
+        }
+        mixin._inplace_loaded_native_keys = {"model.layers.0.mlp.experts.gate_and_up_projs"}
+        mixin._last_expert_ids = [0]
+
+        with pytest.raises(RuntimeError, match=r"model\.layers\.0\.mlp\.experts\.1\.down_proj\.weight"):
             mixin._validate_expert_availability(hf_state_dict, 8)
 
     def test_without_model_prefix(self):

--- a/tests/unit_tests/moe/test_state_dict_utils.py
+++ b/tests/unit_tests/moe/test_state_dict_utils.py
@@ -37,6 +37,7 @@ class TestIsDtensor:
 
     def test_dtensor_mock(self):
         from torch.distributed._tensor import DTensor
+
         with patch("nemo_automodel.components.moe.state_dict_utils.DTensor", DTensor):
             mock_tensor = Mock(spec=DTensor)
             mock_tensor.__class__ = DTensor
@@ -77,8 +78,9 @@ class TestGetExpertSliceForRank:
 
         # Mock placement - sharded on dim 0
         from torch.distributed._tensor.placement_types import Shard
+
         mock_placement = Shard(0)
-        mock_dtensor.placements = [Mock(), mock_placement]
+        mock_dtensor.placements = [mock_placement, Mock()]
 
         local_tensor, start_expert, end_expert = get_expert_slice_for_rank(mock_dtensor, 8)
 
@@ -104,6 +106,7 @@ class TestGetExpertSliceForRank:
 
         # Mock placement - replicated
         from torch.distributed._tensor.placement_types import Replicate
+
         mock_placement = Replicate()
         mock_dtensor.placements = [mock_placement]
 
@@ -112,6 +115,30 @@ class TestGetExpertSliceForRank:
         assert torch.equal(local_tensor, mock_local_tensor)
         assert start_expert == 0
         assert end_expert == 8
+
+    @patch("nemo_automodel.components.moe.state_dict_utils.is_dtensor")
+    @patch("nemo_automodel.components.moe.state_dict_utils.get_submesh")
+    def test_ep_free_fsdp_sharded_expert_dimension(self, mock_get_submesh, mock_is_dtensor):
+        from torch.distributed._tensor.placement_types import Shard
+
+        mock_is_dtensor.return_value = True
+
+        mock_dtensor = Mock()
+        mock_local_tensor = torch.randn(2, 16, 32)
+        mock_dtensor.to_local.return_value = mock_local_tensor
+        mock_dtensor.device_mesh.mesh_dim_names = ("dp_shard_cp",)
+        mock_dtensor.placements = (Shard(0),)
+
+        mock_dp_mesh = Mock()
+        mock_dp_mesh.get_local_rank.return_value = 2
+        mock_dp_mesh.size.return_value = 4
+        mock_get_submesh.return_value = mock_dp_mesh
+
+        local_tensor, start_expert, end_expert = get_expert_slice_for_rank(mock_dtensor, 8)
+
+        assert torch.equal(local_tensor, mock_local_tensor)
+        assert start_expert == 4
+        assert end_expert == 6
 
 
 class TestSplitExpertsWeightsDtensorAware:
@@ -179,6 +206,7 @@ class TestValidateDtensorExpertSharding:
         mock_dtensor.shape = [8, 16, 32]
 
         from torch.distributed._tensor.placement_types import Shard
+
         mock_placement = Shard(0)
         mock_dtensor.placements = [mock_placement]
 


### PR DESCRIPTION
## Summary

- route EP-free grouped-expert DTensors through the DTensor-aware splitter
- treat FSDP `Shard(0)` as a rank-local expert partition, avoiding the implicit all-gather from `weight[i]`
- preserve adjusted DTensor placements for inner-dimension shards
- validate the recorded rank-local expert IDs after DCP loads through in-place views

## Root cause

The state-dict helper assumed every expert DTensor had an `ep` mesh dimension. With `ep_size=1`, grouped expert parameters instead use the `dp_shard_cp` FSDP mesh. Bypassing the helper removed the assertion but made DTensor indexing collect a full expert on every rank, which OOMed the 30B model. Keeping expert-axis shards rank-local avoids that collective; post-load validation must then use the rank-local IDs already recorded by the adapter.

## Validation

- `pytest -q tests/unit_tests/moe`: 573 passed, 31 skipped
- focused two-process CPU/Gloo coverage for EP-free `Shard(0)`, inner-axis sharding, HF split conversion, and in-place load lifecycle
- Ruff format/check and `git diff --check`
- adversarial review: no remaining findings
- [nemo-ci parent 61041547](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/61041547)
- [Automodel child 61047989](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/61047989)
- [Qwen3-MoE leaf 61048041](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/61048041) / [job 384524736](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/384524736): 8x H100, `ep_size=1`, one training step, finite loss and gradient norm

Fixes #3300

Linear: [AM-784](https://linear.app/nvidia/issue/AM-784/kdmoe-state-dict-adapter-asserts-ep-mesh-dim-at-ep-size1-blocking-all)
