### PR TITLE
fix(transformers): default missing THD capability

### DIFF
--- a/docs/model-coverage/diffusion/lightricks/ltx-2-3.mdx
+++ b/docs/model-coverage/diffusion/lightricks/ltx-2-3.mdx
@@ -1,6 +1,7 @@
 ---
 title: "LTX-2.3"
 description: "Fine-tune and generate synchronized video and audio with LTX-2.3"
+slug: model-coverage/diffusion/lightricks/ltx-2-3
 ---
 [LTX-2.3](https://huggingface.co/Lightricks/LTX-2.3) is a text-to-video diffusion model from Lightricks. Its dual-stream transformer denoises video and audio latents together so generated clips can include synchronized sound.
 

--- a/nemo_automodel/_transformers/model_capabilities.py
+++ b/nemo_automodel/_transformers/model_capabilities.py
@@ -81,7 +81,7 @@ def _to_canonical(caps_obj) -> ModelCapabilities:
         supports_cp=bool(caps_obj.supports_cp),
         supports_pp=bool(caps_obj.supports_pp),
         supports_ep=bool(caps_obj.supports_ep),
-        supports_thd=bool(caps_obj.supports_thd),
+        supports_thd=bool(getattr(caps_obj, "supports_thd", False)),
         supports_cp_vision_frame_sharding=bool(getattr(caps_obj, "supports_cp_vision_frame_sharding", False)),
     )
 

--- a/tests/unit_tests/_transformers/test_model_capabilities.py
+++ b/tests/unit_tests/_transformers/test_model_capabilities.py
@@ -136,6 +136,16 @@ def test_llama_declares_context_parallel_support():
     assert cls.ModelCapabilities().supports_cp is True
 
 
+def test_query_static_class_without_thd_defaults_to_false():
+    """Static capability declarations predating THD remain queryable."""
+    cls = ModelRegistry.get_model_cls_from_model_arch("LlamaForCausalLM")
+
+    caps = query_capabilities(cls)
+
+    assert type(caps) is ModelCapabilities
+    assert caps.supports_thd is False
+
+
 @pytest.mark.parametrize(
     "arch",
     [


### PR DESCRIPTION
# What does this PR do ?

Restores `query_capabilities()` for model classes whose nested capability dataclass predates the `supports_thd` field.

The canonical conversion now applies the documented `False` default when a model does not declare `supports_thd`, matching the adjacent compatibility handling for `supports_cp_vision_frame_sharding`. This fixes NVBug 6560001, which affects 36 registered model classes in 26.08.rc3.

# Changelog

- Default a missing per-model `supports_thd` capability to `False`.
- Add a public-API regression test using `LlamaForCausalLM`.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added the necessary regression test.
- [x] Documentation is unchanged because this restores the existing documented default.

# Validation

- `pytest tests/unit_tests/_transformers/test_model_capabilities.py -q` — 22 passed
- `ruff format --check nemo_automodel/_transformers/model_capabilities.py tests/unit_tests/_transformers/test_model_capabilities.py`
- `ruff check nemo_automodel/_transformers/model_capabilities.py tests/unit_tests/_transformers/test_model_capabilities.py`
- `git diff --check`

# Additional Information

- NVBug: https://nvbugspro.nvidia.com/bug/6560001