### PR TITLE
fix(gemma4): enable expandable_segments on the CP tulu3 recipes

### DIFF
--- a/examples/vlm_finetune/gemma4/gemma4_31b_tulu3_text_cp8_16k.yaml
+++ b/examples/vlm_finetune/gemma4/gemma4_31b_tulu3_text_cp8_16k.yaml
@@ -108,3 +108,9 @@ wandb:
   entity: <your_wandb_entity>
   name: <your_wandb_name>
   dir: <your_wandb_save_dir>
+
+ci:
+  time: "01:00:00"
+  env_vars:
+    # CP backward fragments the allocator; NCCL then cannot get its connection buffers, leads to OOM.
+    PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True"

--- a/examples/vlm_finetune/gemma4/gemma4_e4b_tulu3_text_cp16_64k.yaml
+++ b/examples/vlm_finetune/gemma4/gemma4_e4b_tulu3_text_cp16_64k.yaml
@@ -133,4 +133,7 @@ wandb:
   dir: <your_wandb_save_dir>
 ci:
   nodes: 2
-  time: "00:15:00"
+  time: "01:00:00"
+  env_vars:
+    # CP backward fragments the allocator; the FSDP gradient bucket then cannot fit, leads to OOM.
+    PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True"


### PR DESCRIPTION
# What does this PR do ?

Fixes the CUDA OOMs on the two gemma4 CP tulu3 recipes (AMINT-242, AMINT-241).

# Root cause

CP backward leaves the caching allocator heavily fragmented — `reserved 72.73 GiB` vs `allocated 19.31 GiB` on an 80 GiB card. Same cause, two symptoms: `gemma4_31b` fails *outside* the allocator, where NCCL allocates ~0.4 GiB per peer connection during the backward ring exchange; `gemma4_e4b` fails *inside* it, on a 13.10 GiB FSDP gradient bucket against 52.48 GiB reserved-but-unallocated.

Also raises both recipes' `ci.time` to 1 h: each runs 50 steps at ~46 s/step, which the previous budgets (10 min inherited, and 15 min) could not fit.

# Validation

nemo-ci [61061722](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/61061722), eos, branched off `main` with no code change:

| Recipe | Job | Nodes | Steps | OOM | Loss | Time |
|---|---|---|---|---|---|---|
| `gemma4_31b_tulu3_text_cp8_16k` | [384673387](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/384673387) | 1 | 50/50 | 0 | 0.6311 → 0.3358 | 45.4 min |
| `gemma4_e4b_tulu3_text_cp16_64k` | [384673388](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/384673388) | 2 | 50/50 | 0 | 0.8557 → 0.3731 | 46.1 min |

Those runs carried the `env_vars` change plus `TIME=01:00:00` as a pipeline variable; this branch bakes the same 1 h into the recipes.

# Changelog

- `gemma4_31b_tulu3_text_cp8_16k.yaml`: new `ci:` block with `time: "01:00:00"` and `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`.
- `gemma4_e4b_tulu3_text_cp16_64k.yaml`: same env var; `ci.time` 15 min → 1 h.

# Pre checks

- [x] Read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Validated in nemo-ci
- [ ] Documentation — n/a

# Additional Information

- Fixes AMINT-242, AMINT-241

🤖 Generated with [Claude Code](https://claude.com/claude-code)
