### PR TITLE
ci(convergence): re-baseline Qwen3-MoE IFEval to 0.5989

### DIFF
--- a/examples/convergence/tulu3/models/qwen3-moe-30b/qwen3_moe_30b_ep8_te_fusedadam.yaml
+++ b/examples/convergence/tulu3/models/qwen3-moe-30b/qwen3_moe_30b_ep8_te_fusedadam.yaml
@@ -135,6 +135,11 @@ ci:
     thinking: true
     extra_model_args: "think_end_token=</think>,max_model_len=8192"
     metric: prompt_level_strict_acc
-    baseline: 0.5767
+    # Re-baselined 2026-08-04 on main @ cb5c1734d: 0.5989 over all 541 IFEval prompts.
+    # The previous 0.5767 was measured 2026-07-14, before #3028 disabled TE fused RoPE
+    # globally. Re-enabling rope_fusion on current main reproduces the old 1000-step
+    # loss curve exactly, so the change is attributable to the RoPE path alone -- see
+    # AM-795 for the bisect.
+    baseline: 0.5989
     stderr: 0.0213
     k: 2


### PR DESCRIPTION
# What does this PR do ?

Updates the Qwen3-MoE 30B Tulu-3 convergence gate to `baseline: 0.5989`
(was 0.5767). Obtained after checking on 3 runs and the final ifEval score was consistently around 0.59

IFEval `prompt_level_strict_acc` improved on latest main, where TE fused
RoPE is disabled globally by #3028. The previous baseline was measured
before that PR landed.

Investigation and evidence:
https://linear.app/nvidia/issue/AM-795/slight-discrepancy-in-qwen3-moe-convergence-loss-curve-with-te-rope

# Changelog

- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
