### PR TITLE
ci(minimax): extend M2.7 LoRA timeout

### DIFF
--- a/examples/llm_finetune/minimax_m2/minimax_m2.7_hellaswag_lora.yaml
+++ b/examples/llm_finetune/minimax_m2/minimax_m2.7_hellaswag_lora.yaml
@@ -113,4 +113,5 @@ optimizer:
 ci:
   # pp_size(1) * ep_size(32) = 32 GPUs => 4 nodes (8 H100/node).
   recipe_owner: hemildesai
+  time: "00:20:00"
   nodes: 4


### PR DESCRIPTION
## Summary

- increase the MiniMax-M2.7 HellaSwag LoRA CI wall-time limit from 10 to 20 minutes
- leave the recipe, training steps, model behavior, and validation thresholds unchanged

## Why

MiniMax-M2.7 has 228.7B total parameters and runs this recipe across 32 H100 GPUs with EP32. Although LoRA makes only 14.8M parameters trainable, CI must still launch four nodes and load, materialize, and shard the full frozen model.

In the previous 10-minute run, training reached 50/50 steps at the exact second Slurm enforced the time limit. Steady-state steps took about two seconds; startup, model initialization, and the first-step warm-up consumed nearly all of the allocation, leaving no time for orderly teardown. The longer limit adds scheduling and shutdown margin rather than masking a training failure.

## Validation

- [Scoped current-main release pipeline](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/61045160): passed
  - `ernie4_5_21b_a3b_hellaswag`
  - `minimax_m2.7_hellaswag_lora` with the 20-minute limit
- [Original timed-out MiniMax job](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/383884664): completed 50/50 training steps before Slurm reported `TIMEOUT`
