### PR TITLE
test(ci): validate late ARC scale-set registration

### DIFF
--- a/.github/workflows/aut-1331-late-registration.yml
+++ b/.github/workflows/aut-1331-late-registration.yml
@@ -1,0 +1,39 @@
+# Copyright (c) 2026 NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: AUT-1331 late-registration canary
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - ".github/workflows/aut-1331-late-registration.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  late-registration:
+    name: Verify queued job is assigned after scale-set registration
+    runs-on: nemo-ci-aut-1331-late-registration
+    timeout-minutes: 20
+    steps:
+      - name: Record assignment
+        shell: bash
+        run: |
+          echo "repository=${GITHUB_REPOSITORY}"
+          echo "run_id=${GITHUB_RUN_ID}"
+          echo "run_attempt=${GITHUB_RUN_ATTEMPT}"
+          echo "runner_name=${RUNNER_NAME}"
+          echo "AUT-1331 late-registration canary assigned successfully"


### PR DESCRIPTION
# What does this PR do ?

Adds a temporary, non-production GitHub Actions workflow for the AUT-1331 late runner-scale-set registration experiment.

**Do not merge this PR.** It exists only to prove whether GitHub assigns an already-queued job after an ARC runner scale set with the exact job label is created and registered.

# Changelog

- Add one pull-request-only canary job using the unique label `nemo-ci-aut-1331-late-registration`.
- Run no repository code and request no secrets or write permissions.
- Record the workflow run, attempt, and assigned runner identity.

# Test procedure

1. Open this PR while no runner scale set exists for the label.
2. Verify the canary job remains queued and record its job/run identity.
3. Create a temporary ARC scale set with the exact label.
4. Verify GitHub assigns the already-queued job and the job succeeds.
5. Delete the temporary scale set and verify GitHub/Kubernetes cleanup.
6. Close this PR without merging.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines applicable to this test.
- [x] Added the test required by AUT-1331.
- [x] No product documentation change is required because this PR will not merge.

# Additional Information

- Linear: [AUT-1331](https://linear.app/nvidia/issue/AUT-1331)
- Parent design: [AUT-1306](https://linear.app/nvidia/issue/AUT-1306)
