### PR TITLE
cp: backport MoE checkpoint reload parity fixes to r0.6.0

### DIFF
--- a/examples/llm_finetune/nemotron/nemotron_nano_8b_v1_squad.yaml
+++ b/examples/llm_finetune/nemotron/nemotron_nano_8b_v1_squad.yaml
@@ -108,7 +108,8 @@ ci:
   allow_failure: true
   checkpoint_robustness:
     check_source_load_parity: true
-    hf_kl_threshold: 3e-3
+    # Exact-image BF16 HF reload measured 0.00435; retain a narrow parity bound.
+    hf_kl_threshold: 5e-3
     source_load_kl_threshold: 5e-3
     source_load_cosine_threshold: 0.9995
     distributed.tp_size: 2

--- a/examples/llm_finetune/qwen/qwen3_moe_30b_hellaswag.yaml
+++ b/examples/llm_finetune/qwen/qwen3_moe_30b_hellaswag.yaml
@@ -98,8 +98,11 @@ ci:
   checkpoint_robustness:
     check_source_load_parity: true
     hf_kl_threshold: 1e-1
+    # Optimized BF16 MoE execution differs broadly from vanilla HF at source load;
+    # current-stack CI observed max/mean KL 0.0790/0.0113 and cosine 0.9957.
     source_load_kl_threshold: 1e-1
-    source_load_cosine_threshold: 0.9995
+    source_load_mean_kl_threshold: 1.5e-2
+    source_load_cosine_threshold: 0.995
     tokenizer_name: Qwen/Qwen3-30B-A3B
     trust_remote_code: true
     hf_device_map_auto: true

--- a/examples/llm_finetune/qwen/qwen3_moe_30b_lora.yaml
+++ b/examples/llm_finetune/qwen/qwen3_moe_30b_lora.yaml
@@ -107,7 +107,17 @@ ci:
   env_vars:
     PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True"
   checkpoint_robustness:
-    hf_kl_threshold: 7e-2
+    check_source_load_parity: true
+    # HF+PEFT reload remains gated by exact adapter fingerprints and a successful
+    # forward; its live-LoRA logits are not a stable cross-runtime reference (AMINT-216).
+    skip_hf_logit_parity: true
+    # Derive isolated source, train/save, and reload phases from the standard
+    # check/skip options below; no resume phases are selected.
+    process_isolation: true
+    # Exact-image BF16 source parity measured max/mean KL 0.0161/0.00407 and cosine 0.99764.
+    source_load_kl_threshold: 3e-2
+    source_load_mean_kl_threshold: 6e-3
+    source_load_cosine_threshold: 0.997
     tokenizer_name: Qwen/Qwen3-30B-A3B
     trust_remote_code: true
     hf_device_map_auto: true

--- a/examples/llm_finetune/qwen/qwen3_moe_30b_te_deepep.yaml
+++ b/examples/llm_finetune/qwen/qwen3_moe_30b_te_deepep.yaml
@@ -122,11 +122,24 @@ optimizer:
 ci:
   recipe_owner: hemildesai
   node_multiplier: true
-  time: "00:15:00"
+  time: "00:20:00"
   vllm_deploy: true
   vllm_smoke_test: true
   checkpoint_robustness:
-    hf_kl_threshold: 1e-2
+    check_source_load_parity: true
+    # Exact-stack runs measured max/mean KL up to 0.0167/0.00437 and cosine down to 0.99750.
+    source_load_kl_threshold: 3e-2
+    source_load_mean_kl_threshold: 6e-3
+    source_load_cosine_threshold: 0.997
+    # Same-process CI reached KL 0.2667, while controlled fresh-process reloads were stable at 0.0199.
+    hf_kl_threshold: 5e-2
+    # Derive isolated source, train/save, and reload phases from the standard
+    # check/skip options below; no resume phases are selected.
+    process_isolation: true
     tokenizer_name: Qwen/Qwen3-30B-A3B
+    # Match the other Qwen3-MoE references and avoid the real-device fallback
+    # selected by trust_remote_code when no HF device map is provided.
+    trust_remote_code: true
+    hf_device_map_auto: true
     no_check_resume: true
     dataset.num_samples_limit: 500

--- a/examples/vlm_finetune/qwen3/qwen3_vl_moe_30b_te_deepep.yaml
+++ b/examples/vlm_finetune/qwen3/qwen3_vl_moe_30b_te_deepep.yaml
@@ -120,10 +120,12 @@ ci:
   time: "00:30:00"
   checkpoint_robustness:
     check_source_load_parity: true
-    hf_kl_threshold: 2e-2
+    # Current-stack BF16 CI observed source max/mean KL 0.0165/0.0043 and HF reload KL 0.0201.
+    hf_kl_threshold: 2.5e-2
     hf_device_map_auto: true
-    resume_loss_threshold: 1e-2
-    source_load_kl_threshold: 1e-2
-    source_load_mean_kl_threshold: 3e-3
+    # Current-stack continuation parity observed a 0.0134 loss delta at the first post-checkpoint step.
+    resume_loss_threshold: 2e-2
+    source_load_kl_threshold: 2e-2
+    source_load_mean_kl_threshold: 5e-3
     source_load_cosine_threshold: 0.9985
     tokenizer_name: Qwen/Qwen3-VL-30B-A3B-Instruct

--- a/tests/ci_tests/configs/llm_finetune/SUMMARY.md
+++ b/tests/ci_tests/configs/llm_finetune/SUMMARY.md
@@ -24,7 +24,7 @@ The nightly scope uses only the recipes listed in [nightly_recipes.yml](nightly_
 | nemotron_nano_v3_hellaswag | 00:15:00 | 1 | ✅ | ✅ | ✅ |
 | nemotron_super_v3_hellaswag | 00:15:00 | 4 | ✅ | ✅ | ✅ |
 | qwen3_moe_30b_hellaswag | 00:20:00 | 1 | ✅ | - | - |
-| qwen3_moe_30b_te_deepep | 00:15:00 | 1 | ✅ | ✅ | ✅ |
+| qwen3_moe_30b_te_deepep | 00:20:00 | 1 | ✅ | ✅ | ✅ |
 | step_3.5_flash_hellaswag_pp | 00:30:00 | 16 | - | - | - |
 
 ## PEFT

--- a/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
+++ b/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
@@ -32,6 +32,7 @@ import gc
 import hashlib
 import inspect
 import json
+import math
 import os
 import sys
 import time
@@ -443,11 +444,19 @@ def _assert_peft_adapter_matches_checkpoint(
         ignored_missing = [key for key in missing if ignored_key_prefix and key.startswith(ignored_key_prefix)]
         required_missing = sorted(set(missing) - set(ignored_missing))
         unexpected = sorted(loaded_keys - expected_keys)
-        assert not required_missing and not unexpected, (
+        # PEFT can expose the wrapped output head's base-layer tensor from
+        # get_peft_model_state_dict even though it is not adapter state and was
+        # therefore not written to adapter_model.safetensors. Keep unexpected
+        # adapter tensors strict while excluding this base-model-only value.
+        ignored_unexpected = [key for key in unexpected if ".lm_head.base_layer." in key]
+        required_unexpected = sorted(set(unexpected) - set(ignored_unexpected))
+        assert not required_missing and not required_unexpected, (
             "Vanilla PEFT adapter key mismatch: "
-            f"missing={required_missing[:10]}, unexpected={unexpected[:10]}, "
-            f"ignored_missing={ignored_missing[:10]}"
+            f"missing={required_missing[:10]}, unexpected={required_unexpected[:10]}, "
+            f"ignored_missing={ignored_missing[:10]}, ignored_non_adapter={ignored_unexpected[:10]}"
         )
+        if ignored_unexpected:
+            print(f"[HF reload] Ignored PEFT-reported non-adapter base-layer tensors: {ignored_unexpected}")
 
         mismatches = []
         matched_keys = expected_keys - set(ignored_missing)
@@ -1465,6 +1474,18 @@ def _materialize_hf_quantization_config(cfg):
     return raw_quantization_config
 
 
+def _hf_reload_kl_error(max_kl_hf: float, hf_kl_threshold: float) -> str | None:
+    """Return an actionable HF reload parity error, including non-finite results."""
+    if not math.isfinite(max_kl_hf):
+        return f"HF-loaded model produced non-finite KL divergence: {max_kl_hf}"
+    if max_kl_hf > hf_kl_threshold:
+        return (
+            "KL divergence between original and HF-loaded model too large: "
+            f"max per-token KL = {max_kl_hf:.6e} > threshold {hf_kl_threshold:.6e}"
+        )
+    return None
+
+
 def _run_vanilla_hf_reload(
     cfg,
     input_ids: list[int],
@@ -1513,6 +1534,9 @@ def _run_vanilla_hf_reload(
             trust_remote_code=trust_remote_code,
             local_files_only=os.environ.get("HF_HUB_OFFLINE", "0") == "1",
         )
+        for key in ("revision", "token"):
+            if model_kwargs.get(key) is not None:
+                hf_kwargs[key] = model_kwargs[key]
         # Remote-code models can ship attention names that transformers 5.x
         # rejects. Select a supported implementation while keeping Nemotron-H
         # off HF's incompatible FlashAttention varlen path.
@@ -1544,6 +1568,8 @@ def _run_vanilla_hf_reload(
             hf_config = _load_hf_config(
                 config_path,
                 trust_remote_code=trust_remote_code,
+                revision=model_kwargs.get("revision"),
+                token=model_kwargs.get("token"),
             )
         # Load the reference model straight onto the target GPU. Materialising a
         # 14B checkpoint on CPU and then ``.to(device)`` costs ~50-225s, and that
@@ -1642,11 +1668,7 @@ def _run_vanilla_hf_reload(
         else:
             max_kl_hf = _kl_divergence_from_logits(reference_logits, hf_logits).max().item()
             print(f"[HF reload] HF-loaded max KL: {max_kl_hf:.6e} (threshold: {hf_kl_threshold:.6e})")
-            if max_kl_hf > hf_kl_threshold:
-                hf_reload_error = (
-                    "KL divergence between original and HF-loaded model too large: "
-                    f"max per-token KL = {max_kl_hf:.6e} > threshold {hf_kl_threshold:.6e}"
-                )
+            hf_reload_error = _hf_reload_kl_error(max_kl_hf, hf_kl_threshold)
         del hf_logits
         _release_model_memory()
         return hf_reload_error
@@ -1735,6 +1757,8 @@ def _run_process_isolated_checkpoint_phase(
         raise ValueError(f"Unsupported isolated checkpoint phase {phase!r}; expected one of {sorted(supported_phases)}")
     if int(custom_args.get("cross_tp_size", "0")) > 0:
         raise ValueError("Process-isolated checkpoint mode does not yet support cross_tp_size")
+    if custom_args.get("no_check_resume", False) and phase in {"resume_baseline", "resume"}:
+        raise ValueError(f"Process-isolated phase {phase!r} conflicts with no_check_resume=true")
 
     _disable_distributed_atexit_teardown()
     cfg = parse_args_and_load_config()
@@ -1988,7 +2012,18 @@ def _run_process_isolated_checkpoint_phase(
                 _cleanup_input_ids_sync(cfg)
             _barrier()
 
+        device = next(restored_trainer.model_parts[0].parameters()).device
+        restored_logits = _get_logits(
+            restored_trainer.model_parts[0],
+            input_ids,
+            device,
+            trainer=restored_trainer,
+        )
         if is_peft:
+            # Capture both sides after a forward. FSDP may change a parameter's
+            # rank-local view during its first unshard/reshard lifecycle, so
+            # hashing the restored model immediately after setup is not
+            # comparable to the post-forward training reference.
             artifact_dir = _robustness_artifact_dir(cfg)
             rank = dist.get_rank() if dist.is_initialized() else 0
             expected_digests_path = artifact_dir / f"trainable_parameter_digests_rank_{rank}.json"
@@ -2031,13 +2066,6 @@ def _run_process_isolated_checkpoint_phase(
                     )
             _raise_distributed_failure(failure_message)
 
-        device = next(restored_trainer.model_parts[0].parameters()).device
-        restored_logits = _get_logits(
-            restored_trainer.model_parts[0],
-            input_ids,
-            device,
-            trainer=restored_trainer,
-        )
         failure_message = None
         if _rank0():
             reference_logits = torch.load(reference_path, map_location="cpu", weights_only=True)

--- a/tests/unit_tests/ci_tests/test_checkpoint_robustness_hf_kwargs.py
+++ b/tests/unit_tests/ci_tests/test_checkpoint_robustness_hf_kwargs.py
@@ -33,6 +33,7 @@ from tests.functional_tests.checkpoint_robustness.test_checkpoint_robustness_llm
     _hf_device_map_max_memory,
     _hf_fp32_module_names,
     _hf_model_load_context,
+    _hf_reload_kl_error,
     _hf_source_load_kwargs,
     _keep_hf_modules_in_fp32,
     _lm_head_embedding_aliased,
@@ -118,6 +119,25 @@ def test_peft_adapter_fingerprints_match_saved_safetensors(tmp_path):
         matched, ignored = _assert_peft_adapter_matches_checkpoint(Mock(), adapter_path)
 
     assert matched == 2
+    assert ignored == 0
+
+
+def test_peft_adapter_fingerprints_ignore_reported_base_layer_tensor(tmp_path):
+    from safetensors.torch import save_file
+
+    adapter_path = tmp_path / "adapter_model.safetensors"
+    adapter_key = "base_model.model.lm_head.lora_A.weight"
+    saved_state = {adapter_key: torch.tensor([[1.0, 2.0]], dtype=torch.bfloat16)}
+    loaded_state = {
+        adapter_key: saved_state[adapter_key].clone(),
+        "base_model.model.lm_head.base_layer.weight": torch.tensor([[3.0, 4.0]], dtype=torch.bfloat16),
+    }
+    save_file(saved_state, adapter_path)
+
+    with patch("peft.get_peft_model_state_dict", return_value=loaded_state):
+        matched, ignored = _assert_peft_adapter_matches_checkpoint(Mock(), adapter_path)
+
+    assert matched == 1
     assert ignored == 0
 
 
@@ -694,6 +714,22 @@ def test_process_isolated_hf_reload_runs_rank0_hf_loader(tmp_path):
     )
     raise_distributed_failure.assert_called_once_with(None)
     recipe_cls.assert_not_called()
+
+
+def test_process_isolated_resume_rejects_no_check_resume():
+    with pytest.raises(ValueError, match="conflicts with no_check_resume=true"):
+        _run_process_isolated_checkpoint_phase(
+            "resume",
+            custom_args={"no_check_resume": True},
+            recipe_cls=Mock(),
+            hf_model_cls=Mock(),
+            input_ids_loader=Mock(),
+        )
+
+
+@pytest.mark.parametrize("non_finite_kl", [float("nan"), float("inf"), float("-inf")])
+def test_hf_reload_rejects_non_finite_kl(non_finite_kl):
+    assert "non-finite KL divergence" in _hf_reload_kl_error(non_finite_kl, 7e-2)
 
 
 def test_process_isolated_source_load_reference_persists_hf_artifacts(tmp_path):

--- a/tests/unit_tests/ci_tests/test_config_resolver.py
+++ b/tests/unit_tests/ci_tests/test_config_resolver.py
@@ -341,9 +341,7 @@ def test_end_to_end_fixture_keys_not_applied_as_overrides(tmp_path):
     assert resolved["ci"]["checkpoint_robustness"]["check_source_load_parity"] is True
     assert resolved["ci"]["checkpoint_robustness"]["skip_automodel_logit_parity"] is True
     assert resolved["ci"]["checkpoint_robustness"]["skip_hf_logit_parity"] is True
-    assert (
-        resolved["ci"]["checkpoint_robustness"]["hf_adapter_ignored_key_prefix"] == "base_model.model.mtp."
-    )
+    assert resolved["ci"]["checkpoint_robustness"]["hf_adapter_ignored_key_prefix"] == "base_model.model.mtp."
     assert resolved["ci"]["checkpoint_robustness"]["source_load_kl_threshold"] == 1e-2
     assert resolved["ci"]["checkpoint_robustness"]["source_load_mean_kl_threshold"] == 1e-3
     assert resolved["ci"]["checkpoint_robustness"]["source_load_cosine_threshold"] == 0.999
@@ -391,7 +389,10 @@ def test_vlm_checkpoint_robustness_recipes_resolve(tmp_path, recipe_path):
         assert robustness["source_load_cosine_threshold"] == 0.999
         assert robustness["hf_kl_threshold"] == 5e-2
     if Path(recipe_path).stem == "qwen3_vl_moe_30b_te_deepep":
-        assert robustness["resume_loss_threshold"] == 1e-2
+        assert robustness["hf_kl_threshold"] == 2.5e-2
+        assert robustness["resume_loss_threshold"] == 2e-2
+        assert robustness["source_load_kl_threshold"] == 2e-2
+        assert robustness["source_load_mean_kl_threshold"] == 5e-3
     if Path(recipe_path).stem == "qwen3_5_35b":
         assert robustness["experts_implementation"] == "grouped_mm"
         for key in (

--- a/tests/unit_tests/ci_tests/test_generate_ci_tests.py
+++ b/tests/unit_tests/ci_tests/test_generate_ci_tests.py
@@ -14,6 +14,8 @@
 
 from pathlib import Path
 
+from ruamel.yaml import YAML
+
 from tests.ci_tests.utils.generate_ci_tests import generate_job, generate_pipeline
 
 
@@ -131,3 +133,46 @@ ci:
     jobs = dict(generate_job(config, {}, "release", "llm_finetune", str(tmp_path)))
 
     assert jobs[""]["variables"]["CHECKPOINT_ROBUSTNESS_PHASES"] == "train_and_save automodel_reload"
+
+
+def test_generate_qwen3_moe_lora_uses_isolated_reload_phases():
+    config = Path("examples/llm_finetune/qwen/qwen3_moe_30b_lora.yaml")
+
+    jobs = dict(generate_job(config, {}, "release", "llm_finetune", "."))
+    ci_config = YAML(typ="safe").load(config)["ci"]
+    robustness = ci_config["checkpoint_robustness"]
+
+    variables = jobs[""]["variables"]
+    assert "CHECKPOINT_ROBUSTNESS_PHASES" not in ci_config.get("env_vars", {})
+    assert variables["PYTORCH_CUDA_ALLOC_CONF"] == "expandable_segments:True"
+    assert variables["CHECKPOINT_ROBUSTNESS_PROCESS_ISOLATION"] == "true"
+    assert variables["CHECKPOINT_ROBUSTNESS_PHASES"] == (
+        "source_load_reference source_load_parity train_and_save automodel_reload hf_reload"
+    )
+    assert robustness["check_source_load_parity"] is True
+    assert robustness["skip_hf_logit_parity"] is True
+    assert robustness["source_load_kl_threshold"] == 3e-2
+    assert robustness["source_load_mean_kl_threshold"] == 6e-3
+    assert robustness["source_load_cosine_threshold"] == 0.997
+
+
+def test_generate_qwen3_moe_te_deepep_uses_isolated_source_and_reload_phases():
+    config = Path("examples/llm_finetune/qwen/qwen3_moe_30b_te_deepep.yaml")
+
+    jobs = dict(generate_job(config, {}, "release", "llm_finetune", "."))
+    ci_config = YAML(typ="safe").load(config)["ci"]
+    robustness = ci_config["checkpoint_robustness"]
+
+    variables = jobs[""]["variables"]
+    assert "CHECKPOINT_ROBUSTNESS_PHASES" not in ci_config.get("env_vars", {})
+    assert variables["TIME"] == "00:20:00"
+    assert variables["CHECKPOINT_ROBUSTNESS_PROCESS_ISOLATION"] == "true"
+    assert variables["CHECKPOINT_ROBUSTNESS_PHASES"] == (
+        "source_load_reference source_load_parity train_and_save automodel_reload hf_reload"
+    )
+    assert robustness["check_source_load_parity"] is True
+    assert robustness["source_load_kl_threshold"] == 3e-2
+    assert robustness["source_load_mean_kl_threshold"] == 6e-3
+    assert robustness["source_load_cosine_threshold"] == 0.997
+    assert robustness["trust_remote_code"] is True
+    assert robustness["hf_device_map_auto"] is True


### PR DESCRIPTION
## Summary

Manual backport of #3335 to `r0.6.0`. The automated backport left an unchanged stale branch and did not create a pull request.

This applies source squash commit `cb5c1734dc02c9a46a9de3720c8096451ee66b02` unchanged on top of current `r0.6.0` (`8204ef7de33cafd1c4af728f5d1dc1c886aed6ca`). The stable patch ID matches the source: `6202866923d1810c79b72258c14111039deead3c`.

This is an exact backport only; separate AMINT-238 follow-ups are intentionally out of scope.

## Validation

- Focused checkpoint-robustness unit tests: `116 passed`
- Ruff format and lint checks: passed
- `git diff --check origin/r0.6.0...HEAD`: passed
- Source PR scoped CI: [Qwen3-MoE LoRA](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/383807794)
- Source PR scoped CI: [Qwen3-MoE TE+DeepEP](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/383848096)

Source PR: #3335
