### PR TITLE
fix(peft): enable v5 expert adapters for Nemotron and MiniMax

### DIFF
--- a/examples/llm_finetune/minimax_m2/minimax_m2.7_hellaswag_lora.yaml
+++ b/examples/llm_finetune/minimax_m2/minimax_m2.7_hellaswag_lora.yaml
@@ -113,5 +113,18 @@ optimizer:
 ci:
   # pp_size(1) * ep_size(32) = 32 GPUs => 4 nodes (8 H100/node).
   recipe_owner: hemildesai
-  time: "00:20:00"
+  time: "00:30:00"
   nodes: 4
+  checkpoint_robustness:
+    # Keep each large-model load in a fresh process so the HF reload has all
+    # local GPU memory available after the distributed train/save phase.
+    process_isolation: true
+    # Exact adapter fingerprints and a successful HF+PEFT forward still run;
+    # live-LoRA cross-runtime logit parity is not a stable quantized reference.
+    skip_hf_logit_parity: true
+    trust_remote_code: true
+    tokenizer_name: MiniMaxAI/MiniMax-M2.7
+    hf_device_map_auto: true
+    no_check_resume: true
+    dataset.num_samples_limit: 500
+    validation_dataset.num_samples_limit: 500

--- a/examples/llm_finetune/minimax_m2/minimax_m2.7_hellaswag_lora.yaml
+++ b/examples/llm_finetune/minimax_m2/minimax_m2.7_hellaswag_lora.yaml
@@ -116,6 +116,9 @@ ci:
   time: "00:30:00"
   nodes: 4
   checkpoint_robustness:
+    # The robustness default local batch is 2; with 32 ranks the global batch
+    # must be at least 64 and divisible by 2 * 32.
+    step_scheduler.global_batch_size: 64
     # Keep each large-model load in a fresh process so the HF reload has all
     # local GPU memory available after the distributed train/save phase.
     process_isolation: true

--- a/examples/llm_finetune/minimax_m2/minimax_m2.7_hellaswag_lora.yaml
+++ b/examples/llm_finetune/minimax_m2/minimax_m2.7_hellaswag_lora.yaml
@@ -61,7 +61,9 @@ model:
 
 peft:
   _target_: nemo_automodel.components._peft.lora.PeftConfig
-  match_all_linear: True
+  # Match grouped experts as well as ordinary linear modules so the exported
+  # PEFT v5 target_parameters are backed by trained and saved adapter tensors.
+  target_modules: ["*"]
   dim: 8
   alpha: 32
   use_triton: True

--- a/examples/llm_finetune/minimax_m2/minimax_m2.7_hellaswag_lora.yaml
+++ b/examples/llm_finetune/minimax_m2/minimax_m2.7_hellaswag_lora.yaml
@@ -61,9 +61,7 @@ model:
 
 peft:
   _target_: nemo_automodel.components._peft.lora.PeftConfig
-  # Match grouped experts as well as ordinary linear modules so the exported
-  # PEFT v5 target_parameters are backed by trained and saved adapter tensors.
-  target_modules: ["*"]
+  match_all_linear: True
   dim: 8
   alpha: 32
   use_triton: True

--- a/examples/llm_finetune/minimax_m2/minimax_m2.7_hellaswag_lora.yaml
+++ b/examples/llm_finetune/minimax_m2/minimax_m2.7_hellaswag_lora.yaml
@@ -125,7 +125,9 @@ ci:
     # Exact adapter fingerprints and a successful HF+PEFT forward still run;
     # live-LoRA cross-runtime logit parity is not a stable quantized reference.
     skip_hf_logit_parity: true
-    trust_remote_code: true
+    # Use Transformers' built-in MiniMax M2 implementation for the HF+PEFT
+    # reload; the checkpoint's remote code targets an older Transformers API.
+    trust_remote_code: false
     tokenizer_name: MiniMaxAI/MiniMax-M2.7
     hf_device_map_auto: true
     no_check_resume: true

--- a/examples/llm_finetune/nemotron/nemotron_super_v3_hellaswag_peft.yaml
+++ b/examples/llm_finetune/nemotron/nemotron_super_v3_hellaswag_peft.yaml
@@ -121,6 +121,9 @@ ci:
     trust_remote_code: true
     tokenizer_name: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
     hf_device_map_auto: true
+    # Vanilla Transformers intentionally omits the training-only MTP modules.
+    # Exact-match every adapter tensor it can instantiate and allow only MTP keys.
+    hf_adapter_ignored_key_prefix: "base_model.model.mtp."
     no_check_resume: true
     dataset.num_samples_limit: 500
     validation_dataset.num_samples_limit: 500

--- a/nemo_automodel/components/checkpoint/addons.py
+++ b/nemo_automodel/components/checkpoint/addons.py
@@ -33,6 +33,9 @@ if TYPE_CHECKING:
     from torch.distributed import ProcessGroup
 
 
+_MOE_LORA_PARAMETER_SUFFIXES = ("lora_gate_and_up_A", "lora_gate_and_up_B", "lora_down_A", "lora_down_B")
+
+
 def _is_group_rank_0(process_group: "ProcessGroup | None") -> bool:
     return not torch.distributed.is_initialized() or torch.distributed.get_rank(group=process_group) == 0
 
@@ -246,7 +249,7 @@ def _get_hf_peft_config(peft_config: "PeftConfig", model_state: ModelState, v4_c
     model_part = model_parts[0]
     pp_group = getattr(model_state, "pp_group", None)
     target_modules = _extract_target_modules(model_parts, v4_compatible=v4_compatible, pp_group=pp_group)
-    target_parameters = _extract_target_parameters(model_parts, v4_compatible=v4_compatible)
+    target_parameters = _extract_target_parameters(model_parts, v4_compatible=v4_compatible, pp_group=pp_group)
     try:
         arch_name = model_part.config.architectures[0]
         # "LlamaForCausalLM".split("For") → ["Llama", "CausalLM"]
@@ -303,20 +306,53 @@ def _get_automodel_peft_metadata(peft_config: "PeftConfig") -> dict:
     return result
 
 
-def _extract_target_parameters(model: "nn.Module | list[nn.Module]", v4_compatible: bool = False) -> list[str]:
+def _has_trainable_moe_lora_parameters(
+    model: "nn.Module | list[nn.Module]",
+    pp_group: "torch.distributed.ProcessGroup | None" = None,
+) -> bool:
+    """Return whether any pipeline stage owns trainable grouped-expert LoRA parameters."""
+    model_parts = model if isinstance(model, (list, tuple)) else [model]
+    parameter_endings = tuple(f".{suffix}" for suffix in _MOE_LORA_PARAMETER_SUFFIXES)
+    local_has_moe_lora = any(
+        param.requires_grad and name.endswith(parameter_endings)
+        for model_part in model_parts
+        for name, param in model_part.named_parameters()
+    )
+
+    if pp_group is not None and torch.distributed.get_world_size(group=pp_group) > 1:
+        world = torch.distributed.get_world_size(group=pp_group)
+        gathered = [False] * world
+        torch.distributed.all_gather_object(gathered, local_has_moe_lora, group=pp_group)
+        return any(gathered)
+
+    return local_has_moe_lora
+
+
+def _extract_target_parameters(
+    model: "nn.Module | list[nn.Module]",
+    v4_compatible: bool = False,
+    pp_group: "torch.distributed.ProcessGroup | None" = None,
+) -> list[str]:
     """Extract ``target_parameters`` for PEFT v0.18+ ParamWrapper format.
 
     Returns fused expert parameter paths for adapters that explicitly opt in
-    to PEFT v5 ParamWrapper export, or an empty list otherwise.
+    to PEFT v5 ParamWrapper export and have trainable grouped-expert LoRA
+    parameters, or an empty list otherwise.
 
-    ``model`` may be a single module or a list of PP parts; the check is a
-    per-model-class property, so the first part is representative.
+    ``model`` may be a single module or a list of local PP parts. When a PP
+    group is provided, expert-LoRA presence is unioned across its ranks so all
+    stages emit identical metadata.
     """
     model_part = model[0] if isinstance(model, (list, tuple)) else model
     if v4_compatible:
         return []
     adapter = getattr(model_part, "state_dict_adapter", None)
-    if adapter is not None and isinstance(adapter, MoESplitExpertsStateDictMixin):
+    if (
+        adapter is not None
+        and isinstance(adapter, MoESplitExpertsStateDictMixin)
+        and adapter._v5_peft_target_parameters
+        and _has_trainable_moe_lora_parameters(model, pp_group=pp_group)
+    ):
         return list(adapter._v5_peft_target_parameters)
     return []
 
@@ -356,8 +392,6 @@ def _extract_target_modules(
         "gate_up_proj": ["gate_proj", "up_proj"],
     }
 
-    _MOE_LORA_SUFFIXES = ("lora_gate_and_up_A", "lora_gate_and_up_B", "lora_down_A", "lora_down_B")
-
     final_target_modules = set()
     for _mp in model_parts:
         for name, _ in _mp.named_modules():
@@ -384,7 +418,10 @@ def _extract_target_modules(
     adapter = getattr(model_parts[0], "state_dict_adapter", None)
     _has_split_expert_mixin = isinstance(adapter, MoESplitExpertsStateDictMixin)
     _uses_v5_target_parameters = bool(
-        _has_split_expert_mixin and not v4_compatible and adapter._v5_peft_target_parameters
+        _has_split_expert_mixin
+        and not v4_compatible
+        and adapter._v5_peft_target_parameters
+        and _has_trainable_moe_lora_parameters(model_parts)
     )
     if _has_split_expert_mixin and not _uses_v5_target_parameters:
         seen_expert_groups: set[tuple[str, str]] = set()
@@ -392,7 +429,7 @@ def _extract_target_modules(
             for name, param in _mp.named_parameters():
                 if not param.requires_grad:
                     continue
-                for lora_suffix in _MOE_LORA_SUFFIXES:
+                for lora_suffix in _MOE_LORA_PARAMETER_SUFFIXES:
                     if name.endswith(f".{lora_suffix}"):
                         expert_path = name[: -len(f".{lora_suffix}")]
                         if expert_path.startswith("_orig_mod."):

--- a/nemo_automodel/components/models/minimax_m2/state_dict_adapter.py
+++ b/nemo_automodel/components/models/minimax_m2/state_dict_adapter.py
@@ -44,6 +44,8 @@ NON_QUANTIZED_KEY_PATTERNS = [
 def should_quantize_key(key: str) -> bool:
     if not key.endswith(".weight"):
         return False
+    if ".lora_" in key:
+        return False
     return not any(pattern in key for pattern in NON_QUANTIZED_KEY_PATTERNS)
 
 
@@ -66,6 +68,11 @@ class MiniMaxM2StateDictAdapter(MoESplitExpertsStateDictMixin, StateDictAdapter)
     @property
     def _expert_path_segment(self) -> str:
         return "mlp.experts"
+
+    @property
+    def _v5_peft_target_parameters(self) -> tuple[str, ...]:
+        """MiniMax M2 exposes fused expert parameters under block_sparse_moe in Transformers v5."""
+        return ("block_sparse_moe.experts.gate_up_proj", "block_sparse_moe.experts.down_proj")
 
     def _dequantize(self, state_dict: dict[str, Any]) -> dict[str, Any]:
         scale_inv_keys = []

--- a/nemo_automodel/components/models/minimax_m2/state_dict_adapter.py
+++ b/nemo_automodel/components/models/minimax_m2/state_dict_adapter.py
@@ -71,8 +71,8 @@ class MiniMaxM2StateDictAdapter(MoESplitExpertsStateDictMixin, StateDictAdapter)
 
     @property
     def _v5_peft_target_parameters(self) -> tuple[str, ...]:
-        """MiniMax M2 exposes fused expert parameters under block_sparse_moe in Transformers v5."""
-        return ("block_sparse_moe.experts.gate_up_proj", "block_sparse_moe.experts.down_proj")
+        """MiniMax M2 exposes fused expert parameters under mlp in Transformers v5."""
+        return ("mlp.experts.gate_up_proj", "mlp.experts.down_proj")
 
     def _dequantize(self, state_dict: dict[str, Any]) -> dict[str, Any]:
         scale_inv_keys = []

--- a/nemo_automodel/components/models/nemotron_v3/state_dict_adapter.py
+++ b/nemo_automodel/components/models/nemotron_v3/state_dict_adapter.py
@@ -121,17 +121,34 @@ class NemotronV3StateDictAdapter(MoESplitExpertsStateDictMixin, StateDictAdapter
         """NemotronV3 uses 'mixer.experts' instead of 'mlp.experts'."""
         return "mixer.experts"
 
+    @property
+    def _v5_peft_target_parameters(self) -> tuple[str, ...]:
+        """Nemotron V3 exposes fused non-gated expert parameters in Transformers v5."""
+        return ("mixer.experts.up_proj", "mixer.experts.down_proj")
+
     @staticmethod
     def _native_key_to_hf(key: str) -> str:
         """Normalize a native Nemotron V3 key to its public HF namespace."""
         key = _strip_mamba_fp32_holder_key(key)
-        if key.startswith("model."):
-            key = "backbone." + key[len("model.") :]
-        if key == "backbone.norm.weight":
-            key = "backbone.norm_f.weight"
-        if key == "backbone.embed_tokens.weight":
-            key = "backbone.embeddings.weight"
+        key = re.sub(
+            r"^(?P<outer>base_model\.model\.)?model\.",
+            lambda match: f"{match.group('outer') or ''}backbone.",
+            key,
+        )
+        key = re.sub(r"^((?:base_model\.model\.)?backbone)\.norm\.weight$", r"\1.norm_f.weight", key)
+        key = re.sub(r"^((?:base_model\.model\.)?backbone)\.embed_tokens\.weight$", r"\1.embeddings.weight", key)
         return key
+
+    @staticmethod
+    def _hf_key_to_native(key: str) -> str:
+        """Normalize a public HF Nemotron V3 key to its native namespace."""
+        key = re.sub(r"^((?:base_model\.model\.)?backbone)\.norm_f\.weight$", r"\1.norm.weight", key)
+        key = re.sub(r"^((?:base_model\.model\.)?backbone)\.embeddings\.weight$", r"\1.embed_tokens.weight", key)
+        return re.sub(
+            r"^(?P<outer>base_model\.model\.)?backbone\.",
+            lambda match: f"{match.group('outer') or ''}model.",
+            key,
+        )
 
     def to_hf(self, state_dict: dict[str, Any], exclude_key_regex: Optional[str] = None, **kwargs) -> dict[str, Any]:
         """Convert from internal model state dict to HuggingFace format.
@@ -212,14 +229,7 @@ class NemotronV3StateDictAdapter(MoESplitExpertsStateDictMixin, StateDictAdapter
         renamed_state_dict = {}
         for key in list(backbone_state_dict.keys()):
             value = backbone_state_dict.pop(key)
-            new_key = key
-            if new_key.startswith("backbone."):
-                new_key = "model." + new_key[len("backbone.") :]
-            if new_key == "model.norm_f.weight":
-                new_key = "model.norm.weight"
-            # HF uses 'embeddings' but internal uses 'embed_tokens'
-            if new_key == "model.embeddings.weight":
-                new_key = "model.embed_tokens.weight"
+            new_key = self._hf_key_to_native(key)
 
             new_key = _route_mamba_fp32_holder_key(new_key)
             renamed_state_dict[new_key] = _upcast_mamba_fp32_state_tensor(new_key, value)

--- a/nemo_automodel/components/models/nemotron_v3/state_dict_adapter.py
+++ b/nemo_automodel/components/models/nemotron_v3/state_dict_adapter.py
@@ -130,13 +130,9 @@ class NemotronV3StateDictAdapter(MoESplitExpertsStateDictMixin, StateDictAdapter
     def _native_key_to_hf(key: str) -> str:
         """Normalize a native Nemotron V3 key to its public HF namespace."""
         key = _strip_mamba_fp32_holder_key(key)
-        key = re.sub(
-            r"^(?P<outer>base_model\.model\.)?model\.",
-            lambda match: f"{match.group('outer') or ''}backbone.",
-            key,
-        )
-        key = re.sub(r"^((?:base_model\.model\.)?backbone)\.norm\.weight$", r"\1.norm_f.weight", key)
-        key = re.sub(r"^((?:base_model\.model\.)?backbone)\.embed_tokens\.weight$", r"\1.embeddings.weight", key)
+        key = re.sub(r"^model\.", "backbone.", key)
+        key = re.sub(r"^backbone\.norm\.weight$", "backbone.norm_f.weight", key)
+        key = re.sub(r"^backbone\.embed_tokens\.weight$", "backbone.embeddings.weight", key)
         return key
 
     @staticmethod

--- a/nemo_automodel/components/moe/state_dict_mixin.py
+++ b/nemo_automodel/components/moe/state_dict_mixin.py
@@ -110,6 +110,19 @@ class MoESplitExpertsStateDictMixin:
         """
         return ()
 
+    def _v5_peft_hf_expert_path_segment(self) -> str:
+        """Return the common HF module path that owns the fused expert parameters."""
+        target_parameters = self._v5_peft_target_parameters
+        if not target_parameters:
+            return self._expert_path_segment
+
+        expert_segments = {target.rsplit(".", 1)[0] for target in target_parameters}
+        if len(expert_segments) != 1:
+            raise ValueError(
+                f"PEFT v5 expert target parameters must share one parent module, got {sorted(target_parameters)}"
+            )
+        return next(iter(expert_segments))
+
     def _validate_expert_availability(
         self,
         hf_state_dict: dict[str, Any],
@@ -272,8 +285,9 @@ class MoESplitExpertsStateDictMixin:
           - ``lora_down_B``  (E, r, H) -> ``lora_A.weight``  (r*E, H)  reshape
           - ``lora_down_A``  (E, I, r) -> ``lora_B.weight``  (I, r*E)  permute+reshape
 
-        gate_up_proj (inner wrapper, HAS ``base_layer.`` prefix):
-          - ``lora_gate_and_up_B``  (E, r, 2*I) -> ``base_layer.lora_A.weight``  (r*E, 2*I)  reshape
+        input projection (``gate_up_proj`` or ``up_proj``; inner wrapper, HAS
+        ``base_layer.`` prefix):
+          - ``lora_gate_and_up_B``  (E, r, U) -> ``base_layer.lora_A.weight``  (r*E, U)  reshape
           - ``lora_gate_and_up_A``  (E, H, r)   -> ``base_layer.lora_B.weight``  (H, r*E)    permute+reshape
 
         Returns:
@@ -285,7 +299,7 @@ class MoESplitExpertsStateDictMixin:
 
         prefix = match.group(1)
         layer_num = match.group(2)
-        expert_segment = self._expert_path_segment
+        expert_segment = self._v5_peft_hf_expert_path_segment()
         suffix = fqn.rsplit(".", 1)[-1]
 
         # PEFT ParamWrapper nesting: target_parameters are sorted alphabetically
@@ -321,18 +335,18 @@ class MoESplitExpertsStateDictMixin:
         ParamWrapper-format keys and converts them back to the 3-D grouped
         tensors expected by GroupedExpertsLoRA.
 
-        Reverse transforms (down_proj is outer, gate_up_proj is inner):
+        Reverse transforms (down_proj is outer, the input projection is inner):
           - ``experts.lora_A.weight``            (r*E, H)   -> (E, r, H)    = lora_down_B
           - ``experts.lora_B.weight``            (I, r*E)   -> (E, I, r)    = lora_down_A
           - ``experts.base_layer.lora_A.weight`` (r*E, 2*I) -> (E, r, 2*I)  = lora_gate_and_up_B
           - ``experts.base_layer.lora_B.weight`` (H, r*E)   -> (E, H, r)    = lora_gate_and_up_A
         """
-        expert_segment = re.escape(self._expert_path_segment)
+        hf_expert_segment = re.escape(self._v5_peft_hf_expert_path_segment())
         n_experts = self.moe_config.n_routed_experts
 
         # Detect ParamWrapper keys
         pw_pattern = re.compile(
-            rf"(?P<prefix>.*)layers\.(?P<layer>\d+)\.{expert_segment}\."
+            rf"(?P<prefix>.*)layers\.(?P<layer>\d+)\.{hf_expert_segment}\."
             rf"(?P<pw_suffix>(?:base_layer\.)?lora_[AB]\.weight)$"
         )
 

--- a/tests/unit_tests/checkpoint/test_peft_pp_gather.py
+++ b/tests/unit_tests/checkpoint/test_peft_pp_gather.py
@@ -35,10 +35,11 @@ import pytest
 import torch
 from torch import nn
 
-from nemo_automodel.components.checkpoint.addons import _extract_target_modules
+from nemo_automodel.components.checkpoint.addons import _extract_target_modules, _extract_target_parameters
 from nemo_automodel.components.checkpoint.stateful_wrappers import (
     _gather_peft_state_dict_across_pp,
 )
+from nemo_automodel.components.moe.state_dict_mixin import MoESplitExpertsStateDictMixin
 
 
 class _FakePPGroup:
@@ -47,6 +48,14 @@ class _FakePPGroup:
     def __init__(self, ranks_state_dicts):
         # ranks_state_dicts: list of per-rank payloads the fake all_gather returns.
         self.ranks_state_dicts = ranks_state_dicts
+
+
+class _V5MoEAdapter(MoESplitExpertsStateDictMixin):
+    """Minimal adapter that opts into fused PEFT v5 expert parameters."""
+
+    @property
+    def _v5_peft_target_parameters(self):
+        return ("mlp.experts.gate_up_proj", "mlp.experts.down_proj")
 
 
 def _install_fake_distributed(monkeypatch, per_rank_payloads):
@@ -246,6 +255,19 @@ class TestExtractTargetModulesPPUnion:
         )
         result = _extract_target_modules(model, pp_group=None)
         assert result == ["model.layers.0.self_attn.wq_a"]
+
+
+class TestExtractTargetParametersPPUnion:
+    def test_remote_expert_lora_enables_v5_metadata_on_every_stage(self, monkeypatch):
+        """A PP rank without experts must emit metadata when another rank owns them."""
+        local_model = nn.Module()
+        local_model.state_dict_adapter = _V5MoEAdapter()
+        payloads = [False, True]
+        _install_fake_distributed(monkeypatch, payloads)
+
+        result = _extract_target_parameters(local_model, pp_group=_FakePPGroup(payloads))
+
+        assert result == ["mlp.experts.gate_up_proj", "mlp.experts.down_proj"]
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/models/minimax_m2/test_minimax_m2_state_dict_adapter_dtensor.py
+++ b/tests/unit_tests/models/minimax_m2/test_minimax_m2_state_dict_adapter_dtensor.py
@@ -65,3 +65,13 @@ def test_to_hf_quantization_adds_scale_inv_for_quantized_weights(adapter):
     assert "model.layers.0.self_attn.q_proj.weight_scale_inv" in hf_state_dict
     # q_norm is explicitly excluded from quantization
     assert "model.layers.0.self_attn.q_norm.weight_scale_inv" not in hf_state_dict
+
+
+def test_to_hf_quantization_leaves_lora_weights_unchanged(adapter):
+    lora = torch.randn(8, 64)
+    native_state_dict = {"model.layers.0.mlp.experts.lora_A.weight": lora}
+
+    hf_state_dict = adapter.to_hf(native_state_dict, quantization=True)
+
+    assert set(hf_state_dict) == set(native_state_dict)
+    torch.testing.assert_close(hf_state_dict["model.layers.0.mlp.experts.lora_A.weight"], lora)

--- a/tests/unit_tests/models/nemotron_v3/test_nemotron_v3_state_dict_adapter.py
+++ b/tests/unit_tests/models/nemotron_v3/test_nemotron_v3_state_dict_adapter.py
@@ -603,16 +603,29 @@ class TestNemotronV3AdapterMixerExperts:
 
         assert adapter._expert_path_segment == "mixer.experts"
 
-    def test_default_lora_export_stays_legacy_for_non_gated_experts(self, config, moe_config, backend):
-        """Nemotron V3 must emit its real up_proj path until v5 is validated."""
+    def test_default_lora_export_uses_v5_for_non_gated_experts(self, config, moe_config, backend):
+        """Nemotron V3 emits ParamWrapper weights for its fused up projection."""
         adapter = NemotronV3StateDictAdapter(config, moe_config, backend)
         tensor = torch.randn(moe_config.n_routed_experts, moe_config.dim, 8)
 
         result = adapter.convert_single_tensor_to_hf("model.layers.0.mixer.experts.lora_gate_and_up_A", tensor)
 
         keys = {key for key, _ in result}
+        assert keys == {"backbone.layers.0.mixer.experts.base_layer.lora_B.weight"}
+        assert adapter._v5_peft_target_parameters == ("mixer.experts.up_proj", "mixer.experts.down_proj")
+
+    def test_v4_lora_export_stays_per_expert_for_non_gated_experts(self, config, moe_config, backend):
+        """Explicit v4 compatibility retains the per-expert up projection."""
+        adapter = NemotronV3StateDictAdapter(config, moe_config, backend)
+        tensor = torch.randn(moe_config.n_routed_experts, moe_config.dim, 8)
+
+        result = adapter.convert_single_tensor_to_hf(
+            "model.layers.0.mixer.experts.lora_gate_and_up_A", tensor, v4_compatible=True
+        )
+
+        keys = {key for key, _ in result}
         assert "backbone.layers.0.mixer.experts.0.up_proj.lora_A.weight" in keys
-        assert not any("gate_up_proj" in key or "base_layer.lora_A.weight" in key for key in keys)
+        assert not any("base_layer" in key for key in keys)
 
     def test_from_hf_uses_mixer_experts_path(self, config, moe_config, backend):
         """Test that from_hf correctly parses mixer.experts paths."""

--- a/tests/unit_tests/models/test_moe_peft_v5_state_dict_adapters.py
+++ b/tests/unit_tests/models/test_moe_peft_v5_state_dict_adapters.py
@@ -24,58 +24,46 @@ from nemo_automodel.components.models.nemotron_v3.state_dict_adapter import Nemo
 from nemo_automodel.components.moe.config import MoEConfig
 
 
-def _make_transformers_experts(family: str, num_experts: int, dim: int, inter_dim: int) -> nn.Module:
-    """Instantiate the actual fused expert class shipped by Transformers v5."""
+def _make_transformers_model(family: str, num_experts: int, dim: int, inter_dim: int) -> nn.Module:
+    """Instantiate a tiny causal LM using the actual Transformers v5 module hierarchy."""
     if family == "nemotron_v3":
-        from transformers.models.nemotron_h.modeling_nemotron_h import NemotronHExperts
+        from transformers.models.nemotron_h.configuration_nemotron_h import NemotronHConfig
+        from transformers.models.nemotron_h.modeling_nemotron_h import NemotronHForCausalLM
 
-        config = SimpleNamespace(
+        config = NemotronHConfig(
+            vocab_size=32,
+            layers_block_type=["moe"],
             n_routed_experts=num_experts,
             hidden_size=dim,
             moe_intermediate_size=inter_dim,
+            moe_shared_expert_intermediate_size=inter_dim,
             moe_latent_size=None,
             mlp_hidden_act="relu2",
-            _experts_implementation="eager",
+            num_experts_per_tok=1,
+            n_group=1,
+            topk_group=1,
+            use_mamba_kernels=False,
         )
-        experts = NemotronHExperts(config)
+        return NemotronHForCausalLM(config)
     else:
-        from transformers.models.minimax_m2.modeling_minimax_m2 import MiniMaxM2Experts
+        from transformers.models.minimax_m2.configuration_minimax_m2 import MiniMaxM2Config
+        from transformers.models.minimax_m2.modeling_minimax_m2 import MiniMaxM2ForCausalLM
 
-        config = SimpleNamespace(
+        config = MiniMaxM2Config(
+            vocab_size=32,
             num_local_experts=num_experts,
             hidden_size=dim,
             intermediate_size=inter_dim,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            head_dim=dim // 2,
+            max_position_embeddings=32,
+            num_experts_per_tok=1,
             hidden_act="silu",
-            _experts_implementation="eager",
+            use_cache=False,
         )
-        experts = MiniMaxM2Experts(config)
-
-    for parameter in experts.parameters():
-        nn.init.normal_(parameter)
-    return experts
-
-
-class _TinyFusedPeftModel(nn.Module):
-    """Minimal module trees matching the two Transformers v5 implementations."""
-
-    def __init__(self, family: str, num_experts: int, dim: int, inter_dim: int) -> None:
-        super().__init__()
-        if family == "nemotron_v3":
-            self.backbone = nn.Module()
-            self.backbone.layers = nn.ModuleList([nn.Module()])
-            self.backbone.layers[0].mixer = nn.Module()
-            self.backbone.layers[0].mixer.experts = _make_transformers_experts(family, num_experts, dim, inter_dim)
-        else:
-            self.model = nn.Module()
-            self.model.layers = nn.ModuleList([nn.Module()])
-            self.model.layers[0].block_sparse_moe = nn.Module()
-            self.model.layers[0].block_sparse_moe.experts = _make_transformers_experts(
-                family, num_experts, dim, inter_dim
-            )
-
-    def prepare_inputs_for_generation(self, *args, **kwargs):
-        """Provide the compatibility hook required by PEFT's causal-LM wrapper."""
-        raise NotImplementedError("stub for PEFT compatibility")
+        return MiniMaxM2ForCausalLM(config)
 
 
 def _make_moe_config(*, gated: bool) -> MoEConfig:
@@ -124,6 +112,17 @@ def _make_adapter_and_state(family: str, rank: int):
 
 
 def _paramwrapper_delta(lora_a: torch.Tensor, lora_b: torch.Tensor, num_experts: int, scale: float):
+    """Compute the grouped expert delta represented by PEFT ParamWrapper tensors.
+
+    Args:
+        lora_a: Tensor of shape [rank * experts, input].
+        lora_b: Tensor of shape [output, rank * experts].
+        num_experts: Number of experts folded into the rank axes.
+        scale: LoRA scaling factor.
+
+    Returns:
+        Tensor of shape [experts, input, output].
+    """
     lora_a = lora_a.reshape(num_experts, -1, lora_a.shape[-1])
     lora_b = lora_b.reshape(lora_b.shape[0], -1, num_experts)
     return torch.einsum("ore,eri->eio", lora_b, lora_a) * scale
@@ -142,13 +141,13 @@ def test_peft_v5_load_merge_and_adapter_round_trip(family, tmp_path):
     hf_state_dict = adapter.to_hf(dict(native_state_dict), quantization=family == "minimax_m2")
 
     if family == "nemotron_v3":
-        hf_parent = "base_model.model.backbone.layers.0.mixer.experts"
-        model_parent = "backbone.layers.0.mixer.experts"
+        expert_path = "mixer.experts"
         input_projection = "up_proj"
     else:
-        hf_parent = "base_model.model.model.layers.0.block_sparse_moe.experts"
-        model_parent = "model.layers.0.block_sparse_moe.experts"
+        expert_path = "mlp.experts"
         input_projection = "gate_up_proj"
+    hf_parent = f"base_model.model.model.layers.0.{expert_path}"
+    model_parent = f"model.layers.0.{expert_path}"
 
     assert set(hf_state_dict) == {
         f"{hf_parent}.base_layer.lora_A.weight",
@@ -168,7 +167,7 @@ def test_peft_v5_load_merge_and_adapter_round_trip(family, tmp_path):
     ).save_pretrained(tmp_path)
     save_file(hf_state_dict, str(tmp_path / "adapter_model.safetensors"))
 
-    hf_model = _TinyFusedPeftModel(family, moe_config.n_routed_experts, moe_config.dim, moe_config.moe_inter_dim)
+    hf_model = _make_transformers_model(family, moe_config.n_routed_experts, moe_config.dim, moe_config.moe_inter_dim)
     base_weights = {
         name: parameter.detach().clone()
         for name, parameter in hf_model.named_parameters()

--- a/tests/unit_tests/models/test_moe_peft_v5_state_dict_adapters.py
+++ b/tests/unit_tests/models/test_moe_peft_v5_state_dict_adapters.py
@@ -1,0 +1,228 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.models.minimax_m2.state_dict_adapter import MiniMaxM2StateDictAdapter
+from nemo_automodel.components.models.nemotron_v3.state_dict_adapter import NemotronV3StateDictAdapter
+from nemo_automodel.components.moe.config import MoEConfig
+
+
+def _make_transformers_experts(family: str, num_experts: int, dim: int, inter_dim: int) -> nn.Module:
+    """Instantiate the actual fused expert class shipped by Transformers v5."""
+    if family == "nemotron_v3":
+        from transformers.models.nemotron_h.modeling_nemotron_h import NemotronHExperts
+
+        config = SimpleNamespace(
+            n_routed_experts=num_experts,
+            hidden_size=dim,
+            moe_intermediate_size=inter_dim,
+            moe_latent_size=None,
+            mlp_hidden_act="relu2",
+            _experts_implementation="eager",
+        )
+        experts = NemotronHExperts(config)
+    else:
+        from transformers.models.minimax_m2.modeling_minimax_m2 import MiniMaxM2Experts
+
+        config = SimpleNamespace(
+            num_local_experts=num_experts,
+            hidden_size=dim,
+            intermediate_size=inter_dim,
+            hidden_act="silu",
+            _experts_implementation="eager",
+        )
+        experts = MiniMaxM2Experts(config)
+
+    for parameter in experts.parameters():
+        nn.init.normal_(parameter)
+    return experts
+
+
+class _TinyFusedPeftModel(nn.Module):
+    """Minimal module trees matching the two Transformers v5 implementations."""
+
+    def __init__(self, family: str, num_experts: int, dim: int, inter_dim: int) -> None:
+        super().__init__()
+        if family == "nemotron_v3":
+            self.backbone = nn.Module()
+            self.backbone.layers = nn.ModuleList([nn.Module()])
+            self.backbone.layers[0].mixer = nn.Module()
+            self.backbone.layers[0].mixer.experts = _make_transformers_experts(family, num_experts, dim, inter_dim)
+        else:
+            self.model = nn.Module()
+            self.model.layers = nn.ModuleList([nn.Module()])
+            self.model.layers[0].block_sparse_moe = nn.Module()
+            self.model.layers[0].block_sparse_moe.experts = _make_transformers_experts(
+                family, num_experts, dim, inter_dim
+            )
+
+    def prepare_inputs_for_generation(self, *args, **kwargs):
+        """Provide the compatibility hook required by PEFT's causal-LM wrapper."""
+        raise NotImplementedError("stub for PEFT compatibility")
+
+
+def _make_moe_config(*, gated: bool) -> MoEConfig:
+    return MoEConfig(
+        dim=16,
+        inter_dim=32,
+        moe_inter_dim=8,
+        n_routed_experts=2,
+        n_shared_experts=0,
+        n_activated_experts=1,
+        n_expert_groups=1,
+        n_limited_groups=1,
+        train_gate=False,
+        gate_bias_update_factor=0.0,
+        score_func="softmax",
+        route_scale=1.0,
+        aux_loss_coeff=0.0,
+        norm_topk_prob=False,
+        expert_activation="swiglu" if gated else "relu2",
+        dtype=torch.float32,
+    )
+
+
+def _make_adapter_and_state(family: str, rank: int):
+    gated = family == "minimax_m2"
+    moe_config = _make_moe_config(gated=gated)
+    backend = BackendConfig(linear="torch", attn="sdpa", rms_norm="torch", dispatcher="torch")
+    if gated:
+        adapter = MiniMaxM2StateDictAdapter(SimpleNamespace(), moe_config, backend, dtype=torch.float32)
+        expert_path = "mlp.experts"
+    else:
+        adapter = NemotronV3StateDictAdapter(
+            SimpleNamespace(num_hidden_layers=1), moe_config, backend, dtype=torch.float32
+        )
+        expert_path = "mixer.experts"
+
+    base = f"base_model.model.model.layers.0.{expert_path}"
+    input_width = 2 * moe_config.moe_inter_dim if gated else moe_config.moe_inter_dim
+    state_dict = {
+        f"{base}.lora_gate_and_up_A": torch.randn(moe_config.n_routed_experts, moe_config.dim, rank),
+        f"{base}.lora_gate_and_up_B": torch.randn(moe_config.n_routed_experts, rank, input_width),
+        f"{base}.lora_down_A": torch.randn(moe_config.n_routed_experts, moe_config.moe_inter_dim, rank),
+        f"{base}.lora_down_B": torch.randn(moe_config.n_routed_experts, rank, moe_config.dim),
+    }
+    return adapter, moe_config, state_dict
+
+
+def _paramwrapper_delta(lora_a: torch.Tensor, lora_b: torch.Tensor, num_experts: int, scale: float):
+    lora_a = lora_a.reshape(num_experts, -1, lora_a.shape[-1])
+    lora_b = lora_b.reshape(lora_b.shape[0], -1, num_experts)
+    return torch.einsum("ore,eri->eio", lora_b, lora_a) * scale
+
+
+@pytest.mark.parametrize("family", ["nemotron_v3", "minimax_m2"])
+def test_peft_v5_load_merge_and_adapter_round_trip(family, tmp_path):
+    """The model adapter emits loadable ParamWrapper keys and restores every tensor."""
+    from peft import LoraConfig, PeftModel, TaskType
+    from safetensors.torch import save_file
+
+    torch.manual_seed(42)
+    rank = 4
+    alpha = 8
+    adapter, moe_config, native_state_dict = _make_adapter_and_state(family, rank)
+    hf_state_dict = adapter.to_hf(dict(native_state_dict), quantization=family == "minimax_m2")
+
+    if family == "nemotron_v3":
+        hf_parent = "base_model.model.backbone.layers.0.mixer.experts"
+        model_parent = "backbone.layers.0.mixer.experts"
+        input_projection = "up_proj"
+    else:
+        hf_parent = "base_model.model.model.layers.0.block_sparse_moe.experts"
+        model_parent = "model.layers.0.block_sparse_moe.experts"
+        input_projection = "gate_up_proj"
+
+    assert set(hf_state_dict) == {
+        f"{hf_parent}.base_layer.lora_A.weight",
+        f"{hf_parent}.base_layer.lora_B.weight",
+        f"{hf_parent}.lora_A.weight",
+        f"{hf_parent}.lora_B.weight",
+    }
+
+    LoraConfig(
+        task_type=TaskType.CAUSAL_LM,
+        r=rank,
+        lora_alpha=alpha,
+        lora_dropout=0.0,
+        target_modules=[],
+        target_parameters=list(adapter._v5_peft_target_parameters),
+        bias="none",
+    ).save_pretrained(tmp_path)
+    save_file(hf_state_dict, str(tmp_path / "adapter_model.safetensors"))
+
+    hf_model = _TinyFusedPeftModel(family, moe_config.n_routed_experts, moe_config.dim, moe_config.moe_inter_dim)
+    base_weights = {
+        name: parameter.detach().clone()
+        for name, parameter in hf_model.named_parameters()
+        if name.startswith(model_parent)
+    }
+    hidden_states = torch.randn(3, moe_config.dim)
+    top_k_index = torch.tensor([[0], [1], [0]])
+    top_k_weights = torch.ones_like(top_k_index, dtype=hidden_states.dtype)
+    with torch.no_grad():
+        base_output = hf_model.get_submodule(model_parent)(hidden_states, top_k_index, top_k_weights)
+
+    peft_model = PeftModel.from_pretrained(hf_model, str(tmp_path))
+    loaded_parameters = dict(peft_model.named_parameters())
+    for key, expected in hf_state_dict.items():
+        loaded_key = key.replace(".lora_A.weight", ".lora_A.default.weight").replace(
+            ".lora_B.weight", ".lora_B.default.weight"
+        )
+        assert loaded_key in loaded_parameters, f"PEFT silently dropped {key}"
+        torch.testing.assert_close(loaded_parameters[loaded_key], expected)
+    with torch.no_grad():
+        adapted_output = peft_model.get_submodule(f"base_model.model.{model_parent}")(
+            hidden_states, top_k_index, top_k_weights
+        )
+    assert not torch.allclose(adapted_output, base_output)
+
+    merged = peft_model.merge_and_unload()
+    merged_parameters = dict(merged.named_parameters())
+    scale = alpha / rank
+    input_delta = _paramwrapper_delta(
+        hf_state_dict[f"{hf_parent}.base_layer.lora_A.weight"],
+        hf_state_dict[f"{hf_parent}.base_layer.lora_B.weight"],
+        moe_config.n_routed_experts,
+        scale,
+    )
+    down_delta = _paramwrapper_delta(
+        hf_state_dict[f"{hf_parent}.lora_A.weight"],
+        hf_state_dict[f"{hf_parent}.lora_B.weight"],
+        moe_config.n_routed_experts,
+        scale,
+    )
+    torch.testing.assert_close(
+        merged_parameters[f"{model_parent}.{input_projection}"],
+        base_weights[f"{model_parent}.{input_projection}"] + input_delta,
+    )
+    torch.testing.assert_close(
+        merged_parameters[f"{model_parent}.down_proj"],
+        base_weights[f"{model_parent}.down_proj"] + down_delta,
+    )
+    with torch.no_grad():
+        merged_output = merged.get_submodule(model_parent)(hidden_states, top_k_index, top_k_weights)
+    torch.testing.assert_close(merged_output, adapted_output)
+    assert not any("lora_" in name for name in merged_parameters)
+
+    restored_state_dict = adapter.from_hf(dict(hf_state_dict))
+    assert set(restored_state_dict) == set(native_state_dict)
+    for key, expected in native_state_dict.items():
+        torch.testing.assert_close(restored_state_dict[key], expected)

--- a/tests/unit_tests/models/test_moe_peft_v5_state_dict_adapters.py
+++ b/tests/unit_tests/models/test_moe_peft_v5_state_dict_adapters.py
@@ -22,6 +22,7 @@ from torch import nn
 
 from nemo_automodel.components._peft.lora import PeftConfig, apply_lora_to_linear_modules
 from nemo_automodel.components._peft.lora_experts import GroupedExpertsLoRA
+from nemo_automodel.components.checkpoint.addons import _get_hf_peft_config
 from nemo_automodel.components.checkpoint.stateful_wrappers import ModelState
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.models.minimax_m2.model import MiniMaxM2ForCausalLM as NeMoMiniMaxM2ForCausalLM
@@ -236,8 +237,8 @@ def test_peft_v5_load_merge_and_adapter_round_trip(family, tmp_path):
         torch.testing.assert_close(restored_state_dict[key], expected)
 
 
-def test_minimax_recipe_injects_and_exports_expert_adapters():
-    """The shipped MiniMax recipe must save every expert adapter advertised to PEFT v5."""
+def test_minimax_recipe_does_not_advertise_untrained_expert_adapters():
+    """The dense-only MiniMax recipe must not advertise PEFT v5 expert parameters."""
     from transformers.models.minimax_m2.configuration_minimax_m2 import MiniMaxM2Config
 
     with _MINIMAX_RECIPE.open(encoding="utf-8") as recipe_file:
@@ -246,8 +247,8 @@ def test_minimax_recipe_injects_and_exports_expert_adapters():
     peft_values["use_triton"] = False
     peft_config = PeftConfig(**peft_values)
 
-    assert peft_config.target_modules == ["*"]
-    assert peft_config.match_all_linear is False
+    assert peft_config.target_modules == []
+    assert peft_config.match_all_linear is True
 
     config = MiniMaxM2Config(
         vocab_size=32,
@@ -275,14 +276,14 @@ def test_minimax_recipe_injects_and_exports_expert_adapters():
     model = NeMoMiniMaxM2ForCausalLM(config, backend=backend)
     apply_lora_to_linear_modules(model, peft_config)
 
-    assert isinstance(model.model.layers["0"].mlp.experts, GroupedExpertsLoRA)
+    assert not isinstance(model.model.layers["0"].mlp.experts, GroupedExpertsLoRA)
     model_state = ModelState(model, is_peft=True)
     native_adapter_state = model_state.state_dict()
     hf_adapter_state = model.state_dict_adapter.to_hf(native_adapter_state, v4_compatible=False)
     expert_prefix = "base_model.model.model.layers.0.mlp.experts"
-    assert {key for key in hf_adapter_state if key.startswith(expert_prefix)} == {
-        f"{expert_prefix}.base_layer.lora_A.weight",
-        f"{expert_prefix}.base_layer.lora_B.weight",
-        f"{expert_prefix}.lora_A.weight",
-        f"{expert_prefix}.lora_B.weight",
-    }
+    assert any("lora_" in key for key in hf_adapter_state)
+    assert not [key for key in hf_adapter_state if key.startswith(expert_prefix)]
+
+    hf_peft_config = _get_hf_peft_config(peft_config, model_state)
+    assert hf_peft_config["target_modules"]
+    assert "target_parameters" not in hf_peft_config

--- a/tests/unit_tests/models/test_moe_peft_v5_state_dict_adapters.py
+++ b/tests/unit_tests/models/test_moe_peft_v5_state_dict_adapters.py
@@ -12,16 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 import torch
+import yaml
 from torch import nn
 
+from nemo_automodel.components._peft.lora import PeftConfig, apply_lora_to_linear_modules
+from nemo_automodel.components._peft.lora_experts import GroupedExpertsLoRA
+from nemo_automodel.components.checkpoint.stateful_wrappers import ModelState
 from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.models.minimax_m2.model import MiniMaxM2ForCausalLM as NeMoMiniMaxM2ForCausalLM
 from nemo_automodel.components.models.minimax_m2.state_dict_adapter import MiniMaxM2StateDictAdapter
 from nemo_automodel.components.models.nemotron_v3.state_dict_adapter import NemotronV3StateDictAdapter
 from nemo_automodel.components.moe.config import MoEConfig
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MINIMAX_RECIPE = _REPO_ROOT / "examples/llm_finetune/minimax_m2/minimax_m2.7_hellaswag_lora.yaml"
 
 
 def _make_transformers_model(family: str, num_experts: int, dim: int, inter_dim: int) -> nn.Module:
@@ -225,3 +234,55 @@ def test_peft_v5_load_merge_and_adapter_round_trip(family, tmp_path):
     assert set(restored_state_dict) == set(native_state_dict)
     for key, expected in native_state_dict.items():
         torch.testing.assert_close(restored_state_dict[key], expected)
+
+
+def test_minimax_recipe_injects_and_exports_expert_adapters():
+    """The shipped MiniMax recipe must save every expert adapter advertised to PEFT v5."""
+    from transformers.models.minimax_m2.configuration_minimax_m2 import MiniMaxM2Config
+
+    with _MINIMAX_RECIPE.open(encoding="utf-8") as recipe_file:
+        recipe_peft = yaml.safe_load(recipe_file)["peft"]
+    peft_values = {key: value for key, value in recipe_peft.items() if key != "_target_"}
+    peft_values["use_triton"] = False
+    peft_config = PeftConfig(**peft_values)
+
+    assert peft_config.target_modules == ["*"]
+    assert peft_config.match_all_linear is False
+
+    config = MiniMaxM2Config(
+        vocab_size=32,
+        num_local_experts=2,
+        hidden_size=16,
+        intermediate_size=8,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=8,
+        max_position_embeddings=32,
+        num_experts_per_tok=1,
+        hidden_act="silu",
+        use_cache=False,
+        torch_dtype="float32",
+    )
+    backend = BackendConfig(
+        linear="torch",
+        attn="sdpa",
+        rms_norm="torch",
+        dispatcher="torch",
+        rope_fusion=False,
+        enable_hf_state_dict_adapter=True,
+    )
+    model = NeMoMiniMaxM2ForCausalLM(config, backend=backend)
+    apply_lora_to_linear_modules(model, peft_config)
+
+    assert isinstance(model.model.layers["0"].mlp.experts, GroupedExpertsLoRA)
+    model_state = ModelState(model, is_peft=True)
+    native_adapter_state = model_state.state_dict()
+    hf_adapter_state = model.state_dict_adapter.to_hf(native_adapter_state, v4_compatible=False)
+    expert_prefix = "base_model.model.model.layers.0.mlp.experts"
+    assert {key for key in hf_adapter_state if key.startswith(expert_prefix)} == {
+        f"{expert_prefix}.base_layer.lora_A.weight",
+        f"{expert_prefix}.base_layer.lora_B.weight",
+        f"{expert_prefix}.lora_A.weight",
+        f"{expert_prefix}.lora_B.weight",
+    }

--- a/tests/unit_tests/moe/test_moe_lora_state_dict.py
+++ b/tests/unit_tests/moe/test_moe_lora_state_dict.py
@@ -101,13 +101,14 @@ def _make_moe_config():
     )
 
 
-def _make_tiny_moe_model(device="cpu"):
+def _make_tiny_moe_model(device="cpu", target_modules=None):
     """Build a 2-layer toy model with GroupedExperts + LoRA on experts."""
     moe_cfg = _make_moe_config()
 
     class TinyMoE(nn.Module):
         def __init__(self):
             super().__init__()
+            self.dense = nn.Linear(DIM, DIM, bias=False)
             self.layers = nn.ModuleList()
             for _ in range(N_LAYERS):
                 layer = nn.Module()
@@ -123,7 +124,7 @@ def _make_tiny_moe_model(device="cpu"):
     model = TinyMoE().to(device)
     model.state_dict_adapter = _Adapter()
     peft_config = PeftConfig(
-        target_modules=["*experts*"],
+        target_modules=["*experts*"] if target_modules is None else target_modules,
         dim=LORA_DIM,
         alpha=LORA_ALPHA,
     )
@@ -487,6 +488,13 @@ class TestExtractTargetsV5Defaults:
     def test_target_parameters_empty_without_a_moe_adapter(self):
         """A non-MoE model must not gain fused expert paths."""
         assert _extract_target_parameters(nn.Module()) == []
+
+    def test_target_parameters_empty_when_only_dense_lora_is_injected(self):
+        """A v5-capable model must not advertise expert paths for dense-only LoRA."""
+        model = _make_tiny_moe_model(target_modules=["dense"])
+
+        assert _extract_target_parameters(model) == []
+        assert _extract_target_modules(model) == ["dense"]
 
     def test_accepts_a_list_of_pp_parts(self):
         """Under PP the caller passes this rank's stages; the first is representative."""


### PR DESCRIPTION
# What does this PR do?

Enable the shared Transformers v5 PEFT `target_parameters` export path for Nemotron V3 and MiniMax M2, with adapter save/load/merge coverage against their real fused Transformers expert classes.

This is a follow-up to the PEFT v5 adapter output support merged in #3284.

# Changelog

- Map grouped Nemotron V3 and MiniMax M2 expert LoRA tensors to their Transformers v5 fused expert parameter namespaces.
- Preserve Nemotron's native/Hugging Face key prefixes during adapter round trips.
- Exclude MiniMax LoRA tensors from FP8 weight conversion during export.
- Add targeted PEFT safetensor load, expert-output, merge, and native round-trip tests for both model families.
- Preserve the explicit Transformers v4-compatible legacy export path.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added focused tests for the new behavior.
- [x] Documentation changes are not required for this internal checkpoint-format correction.
- [x] Added DCO sign-off.

# Validation

- Focused unit suite: `63 passed, 2 skipped`.
- Ruff format/check and `git diff --check`: passed.
- Scoped CI for commit `88ad537a36d01518d49c446cd8ceec8e6245945e`: [pipeline 61603609](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/61603609) passed on x86/EOS with exactly:
  - [`nemotron_super_v3_hellaswag_peft`](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/388926116)
  - [`minimax_m2.7_hellaswag_lora`](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/388926115)

# Additional Information

- #3284 has merged into `main`; this PR contains the Nemotron V3 and MiniMax M2 follow-up changes.
