### PR TITLE
fix(retrieval): repair Ministral3 training recipe

### DIFF
--- a/examples/retrieval/bi_encoder/ministral3_3b_instruct.yaml
+++ b/examples/retrieval/bi_encoder/ministral3_3b_instruct.yaml
@@ -149,4 +149,17 @@ distributed:
 #   project: <your_wandb_project>
 #   entity: <your_wandb_entity>
 #   name: <your_wandb_exp_name>
-#   save_dir: <your_wandb_save_dir> 
+#   save_dir: <your_wandb_save_dir>
+
+ci:
+  recipe_owner: yuhez
+  time: "00:30:00"
+  nodes: 1
+  nproc_per_node: 2
+  nightly:
+    step_scheduler.max_steps: 10
+    step_scheduler.global_batch_size: 8
+    step_scheduler.local_batch_size: 1
+    step_scheduler.val_every_steps: 100
+    lr_scheduler.lr_warmup_steps: 2
+    checkpoint.enabled: false

--- a/examples/retrieval/bi_encoder/ministral3_3b_instruct.yaml
+++ b/examples/retrieval/bi_encoder/ministral3_3b_instruct.yaml
@@ -50,9 +50,7 @@ model:
 tokenizer:
   _target_: nemo_automodel.NeMoAutoTokenizer.from_pretrained
   pretrained_model_name_or_path: mistralai/Ministral-3-3B-Instruct-2512
-  add_eos_token: false
   padding_side: left
-  force_hf: true
 
 dataset:
   _target_: nemo_automodel.components.datasets.llm.retrieval_dataset.RetrievalDatasetConfig

--- a/examples/retrieval/bi_encoder/ministral3_3b_instruct.yaml
+++ b/examples/retrieval/bi_encoder/ministral3_3b_instruct.yaml
@@ -37,7 +37,7 @@ dist_env:
 
 model:
   _target_: nemo_automodel.NeMoAutoModelBiEncoder.from_pretrained
-  pretrained_model_name_or_path: mistralai/Ministral-3-3B-Instruct-2512
+  pretrained_model_name_or_path: mistralai/Ministral-3-3B-Instruct-2512-BF16
   trust_remote_code: true
   pooling: avg
   l2_normalize: true
@@ -49,7 +49,7 @@ model:
 
 tokenizer:
   _target_: nemo_automodel.NeMoAutoTokenizer.from_pretrained
-  pretrained_model_name_or_path: mistralai/Ministral-3-3B-Instruct-2512
+  pretrained_model_name_or_path: mistralai/Ministral-3-3B-Instruct-2512-BF16
   padding_side: left
 
 dataset:

--- a/nemo_automodel/_transformers/retrieval.py
+++ b/nemo_automodel/_transformers/retrieval.py
@@ -22,7 +22,13 @@ from typing import Optional
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from transformers import AutoConfig, AutoModel, AutoModelForSequenceClassification, PreTrainedModel
+from transformers import (
+    AutoConfig,
+    AutoModel,
+    AutoModelForSequenceClassification,
+    FineGrainedFP8Config,
+    PreTrainedModel,
+)
 from transformers.models.auto.modeling_auto import MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING
 from transformers.utils import logging
 
@@ -33,8 +39,8 @@ from nemo_automodel.components.models.common.bidirectional import EncoderStateDi
 logger = logging.get_logger(__name__)
 
 
-def _dequantize_fp8_config_for_training(config) -> bool:
-    """Configure a native FP8 checkpoint to load trainable dense weights.
+def _get_fp8_dequantization_config(config) -> FineGrainedFP8Config | None:
+    """Build the Transformers config for loading trainable dense FP8 weights.
 
     HuggingFace fine-grained FP8 linear modules register scalar scale
     parameters, which FSDP2 cannot shard. Retrieval recipes train the extracted
@@ -46,20 +52,18 @@ def _dequantize_fp8_config_for_training(config) -> bool:
             ``quantization_config``.
 
     Returns:
-        Whether the config describes an FP8 checkpoint and must be forwarded
-        to ``from_pretrained``.
+        A dequantizing Transformers FP8 config for native FP8 checkpoints,
+        otherwise ``None``.
     """
     quantization_config = getattr(config, "quantization_config", None)
     if isinstance(quantization_config, dict):
         if quantization_config.get("quant_method") != "fp8":
-            return False
-        quantization_config["dequantize"] = True
-        return True
+            return None
+        return FineGrainedFP8Config(dequantize=True)
 
     if getattr(quantization_config, "quant_method", None) != "fp8":
-        return False
-    quantization_config.dequantize = True
-    return True
+        return None
+    return FineGrainedFP8Config(dequantize=True)
 
 
 def _extract_submodel(model: nn.Module, extract_submodel: str) -> PreTrainedModel:
@@ -289,9 +293,10 @@ def build_encoder_backbone(
     if extract_submodel is not None:
         logger.info(f"Loading {model_name_or_path} with HuggingFace Auto classes to extract {extract_submodel}")
         model_load_kwargs = hf_kwargs
-        if _dequantize_fp8_config_for_training(config):
+        fp8_dequantization_config = _get_fp8_dequantization_config(config)
+        if fp8_dequantization_config is not None:
             logger.info("Dequantizing the native FP8 checkpoint for retrieval training")
-            model_load_kwargs = {**hf_kwargs, "config": config}
+            model_load_kwargs = {**hf_kwargs, "quantization_config": fp8_dequantization_config}
         model = AutoModel.from_pretrained(
             model_name_or_path,
             trust_remote_code=trust_remote_code,

--- a/nemo_automodel/_transformers/retrieval.py
+++ b/nemo_automodel/_transformers/retrieval.py
@@ -33,6 +33,35 @@ from nemo_automodel.components.models.common.bidirectional import EncoderStateDi
 logger = logging.get_logger(__name__)
 
 
+def _dequantize_fp8_config_for_training(config) -> bool:
+    """Configure a native FP8 checkpoint to load trainable dense weights.
+
+    HuggingFace fine-grained FP8 linear modules register scalar scale
+    parameters, which FSDP2 cannot shard. Retrieval recipes train the extracted
+    backbone, so materialize the checkpoint weights in the requested dense
+    dtype instead of keeping the inference-only FP8 modules.
+
+    Args:
+        config: HuggingFace model config that may contain a native
+            ``quantization_config``.
+
+    Returns:
+        Whether the config describes an FP8 checkpoint and must be forwarded
+        to ``from_pretrained``.
+    """
+    quantization_config = getattr(config, "quantization_config", None)
+    if isinstance(quantization_config, dict):
+        if quantization_config.get("quant_method") != "fp8":
+            return False
+        quantization_config["dequantize"] = True
+        return True
+
+    if getattr(quantization_config, "quant_method", None) != "fp8":
+        return False
+    quantization_config.dequantize = True
+    return True
+
+
 def _extract_submodel(model: nn.Module, extract_submodel: str) -> PreTrainedModel:
     """Extract a nested submodel from a loaded model using a dotted attribute path."""
     extracted_model = model
@@ -259,7 +288,15 @@ def build_encoder_backbone(
 
     if extract_submodel is not None:
         logger.info(f"Loading {model_name_or_path} with HuggingFace Auto classes to extract {extract_submodel}")
-        model = AutoModel.from_pretrained(model_name_or_path, trust_remote_code=trust_remote_code, **hf_kwargs)
+        model_load_kwargs = hf_kwargs
+        if _dequantize_fp8_config_for_training(config):
+            logger.info("Dequantizing the native FP8 checkpoint for retrieval training")
+            model_load_kwargs = {**hf_kwargs, "config": config}
+        model = AutoModel.from_pretrained(
+            model_name_or_path,
+            trust_remote_code=trust_remote_code,
+            **model_load_kwargs,
+        )
         extracted_model = _extract_submodel(model, extract_submodel)
         return _build_backbone_from_extracted_submodel(
             extracted_model,

--- a/nemo_automodel/components/datasets/llm/retrieval_collator.py
+++ b/nemo_automodel/components/datasets/llm/retrieval_collator.py
@@ -146,13 +146,19 @@ class BiEncoderCollator:
             if self.passage_prefix:
                 doc_examples_flat = [self.passage_prefix + " " + passage for passage in doc_examples_flat]
 
+        # Some tokenizer backends, including MistralCommonBackend, do not support
+        # the return_token_type_ids kwarg and do not advertise token type IDs.
+        token_type_kwargs = {}
+        if "token_type_ids" in getattr(self.tokenizer, "model_input_names", []):
+            token_type_kwargs["return_token_type_ids"] = False
+
         # Tokenize queries (no padding yet)
         query_encodings = self.tokenizer(
             query_examples,
             max_length=self.q_max_len,
             padding=PaddingStrategy.DO_NOT_PAD,
             truncation=True,
-            return_token_type_ids=False,
+            **token_type_kwargs,
         )
 
         # Tokenize documents (no padding yet)
@@ -161,7 +167,7 @@ class BiEncoderCollator:
             max_length=self.p_max_len,
             padding=PaddingStrategy.DO_NOT_PAD,
             truncation=True,
-            return_token_type_ids=False,
+            **token_type_kwargs,
         )
 
         # Merge into features format for unpacking

--- a/tests/ci_tests/configs/retrieval_bi_encoder/nightly_recipes.yml
+++ b/tests/ci_tests/configs/retrieval_bi_encoder/nightly_recipes.yml
@@ -16,4 +16,5 @@ examples_dir: retrieval
 
 configs:
   - bi_encoder/llama3_2_1b.yaml
+  - bi_encoder/ministral3_3b_instruct.yaml
   - bi_encoder/nemotron_vl_1b/nemotron_vl_1b_example.yaml

--- a/tests/unit_tests/_transformers/test_retrieval.py
+++ b/tests/unit_tests/_transformers/test_retrieval.py
@@ -189,13 +189,15 @@ def test_extract_submodel_dequantizes_native_fp8_for_training(monkeypatch):
     )
 
     assert backbone is language_model
-    assert config.quantization_config["dequantize"] is True
-    auto_model_from_pretrained.assert_called_once_with(
-        "org/fp8-vlm",
-        trust_remote_code=True,
-        torch_dtype=torch.bfloat16,
-        config=config,
-    )
+    assert config.quantization_config["dequantize"] is False
+    auto_model_from_pretrained.assert_called_once()
+    (model_name_or_path,) = auto_model_from_pretrained.call_args.args
+    model_load_kwargs = auto_model_from_pretrained.call_args.kwargs
+    assert model_name_or_path == "org/fp8-vlm"
+    assert model_load_kwargs["trust_remote_code"] is True
+    assert model_load_kwargs["torch_dtype"] is torch.bfloat16
+    assert isinstance(model_load_kwargs["quantization_config"], retrieval.FineGrainedFP8Config)
+    assert model_load_kwargs["quantization_config"].dequantize is True
 
 
 def test_extract_submodel_llama_embedding_from_local_vlm_converts_to_supported_backbone(tmp_path):

--- a/tests/unit_tests/_transformers/test_retrieval.py
+++ b/tests/unit_tests/_transformers/test_retrieval.py
@@ -15,6 +15,7 @@
 """Functional tests for retrieval backbone extraction."""
 
 import json
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -161,6 +162,40 @@ def test_extract_submodel_embedding_fallback_is_bidirectional(tmp_path):
     saved_config = json.loads((save_dir / "config.json").read_text())
     assert saved_config["model_type"] == "mistral"
     assert saved_config["is_causal"] is False
+
+
+def test_extract_submodel_dequantizes_native_fp8_for_training(monkeypatch):
+    """FP8 parent checkpoints are materialized without scalar scale parameters."""
+    from nemo_automodel._transformers import retrieval
+
+    config = SimpleNamespace(
+        model_type="mistral3",
+        quantization_config={"quant_method": "fp8", "dequantize": False},
+    )
+    language_model = MagicMock()
+    language_model.config = SimpleNamespace(model_type="unregistered")
+    parent_model = SimpleNamespace(language_model=language_model)
+    auto_config_from_pretrained = MagicMock(return_value=config)
+    auto_model_from_pretrained = MagicMock(return_value=parent_model)
+    monkeypatch.setattr(retrieval.AutoConfig, "from_pretrained", auto_config_from_pretrained)
+    monkeypatch.setattr(retrieval.AutoModel, "from_pretrained", auto_model_from_pretrained)
+
+    backbone = retrieval.build_encoder_backbone(
+        model_name_or_path="org/fp8-vlm",
+        task="embedding",
+        extract_submodel="language_model",
+        trust_remote_code=True,
+        torch_dtype=torch.bfloat16,
+    )
+
+    assert backbone is language_model
+    assert config.quantization_config["dequantize"] is True
+    auto_model_from_pretrained.assert_called_once_with(
+        "org/fp8-vlm",
+        trust_remote_code=True,
+        torch_dtype=torch.bfloat16,
+        config=config,
+    )
 
 
 def test_extract_submodel_llama_embedding_from_local_vlm_converts_to_supported_backbone(tmp_path):

--- a/tests/unit_tests/datasets/llm/test_bi_encoder_collator.py
+++ b/tests/unit_tests/datasets/llm/test_bi_encoder_collator.py
@@ -21,6 +21,8 @@ import nemo_automodel.components.datasets.llm.retrieval_collator as rc
 
 
 class FakeTokenizer:
+    model_input_names = ["input_ids", "attention_mask", "token_type_ids"]
+
     def __call__(
         self,
         texts: List[str],
@@ -69,6 +71,27 @@ class FakeTokenizer:
         }
 
 
+class StrictTokenizerWithoutTokenTypeIds(FakeTokenizer):
+    """Tokenizer that mirrors MistralCommonBackend's supported call surface."""
+
+    model_input_names = ["input_ids", "attention_mask"]
+
+    def __call__(
+        self,
+        texts: List[str],
+        max_length: int,
+        padding: Any,
+        truncation: bool,
+    ) -> Dict[str, List[List[int]]]:
+        return super().__call__(
+            texts,
+            max_length=max_length,
+            padding=padding,
+            truncation=truncation,
+            return_token_type_ids=False,
+        )
+
+
 def test_unpack_doc_values():
     features = [
         {"input_ids": [[1, 2], [3]], "attention_mask": [[1, 1], [1]]},
@@ -115,6 +138,17 @@ def test_collator_end_to_end_no_prefix():
     # Ensure attention masks align with input_ids shapes
     assert out["q_input_ids"].shape == out["q_attention_mask"].shape
     assert out["d_input_ids"].shape == out["d_attention_mask"].shape
+
+
+def test_collator_omits_unsupported_return_token_type_ids_kwarg():
+    collator = rc.BiEncoderCollator(
+        tokenizer=StrictTokenizerWithoutTokenTypeIds(), q_max_len=16, p_max_len=16, padding=True
+    )
+
+    out = collator(_make_batch(num_examples=2, docs_per_example=2))
+
+    assert out["q_input_ids"].shape[0] == 2
+    assert out["d_input_ids"].shape[0] == 4
 
 
 def test_collator_emits_passage_doc_ids_for_complete_nonempty_ids():

--- a/tests/unit_tests/recipes/retrieval/test_ministral3_config.py
+++ b/tests/unit_tests/recipes/retrieval/test_ministral3_config.py
@@ -22,6 +22,7 @@ from nemo_automodel.components.config.loader import ConfigNode
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 CONFIG_PATH = REPO_ROOT / "examples" / "retrieval" / "bi_encoder" / "ministral3_3b_instruct.yaml"
+EXPECTED_CHECKPOINT = "mistralai/Ministral-3-3B-Instruct-2512-BF16"
 
 
 class _Mistral3Config:
@@ -33,9 +34,17 @@ class _FakeMistralTokenizer:
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path: str, *, padding_side: str):
-        assert pretrained_model_name_or_path == "mistralai/Ministral-3-3B-Instruct-2512"
+        assert pretrained_model_name_or_path == EXPECTED_CHECKPOINT
         assert padding_side == "left"
         return cls()
+
+
+def test_ministral3_recipe_uses_bf16_checkpoint() -> None:
+    """The shipped training recipe must use the unquantized checkpoint."""
+    raw_config = yaml.safe_load(CONFIG_PATH.read_text(encoding="utf-8"))
+
+    assert raw_config["model"]["pretrained_model_name_or_path"] == EXPECTED_CHECKPOINT
+    assert raw_config["tokenizer"]["pretrained_model_name_or_path"] == EXPECTED_CHECKPOINT
 
 
 def test_ministral3_tokenizer_config_uses_registered_backend() -> None:

--- a/tests/unit_tests/recipes/retrieval/test_ministral3_config.py
+++ b/tests/unit_tests/recipes/retrieval/test_ministral3_config.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+from nemo_automodel._transformers.tokenization.registry import TokenizerRegistry
+from nemo_automodel.components.config.loader import ConfigNode
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CONFIG_PATH = REPO_ROOT / "examples" / "retrieval" / "bi_encoder" / "ministral3_3b_instruct.yaml"
+
+
+class _Mistral3Config:
+    model_type = "mistral3"
+
+
+class _FakeMistralTokenizer:
+    pad_token_id = 0
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path: str, *, padding_side: str):
+        assert pretrained_model_name_or_path == "mistralai/Ministral-3-3B-Instruct-2512"
+        assert padding_side == "left"
+        return cls()
+
+
+def test_ministral3_tokenizer_config_uses_registered_backend() -> None:
+    """The shipped recipe must avoid unsupported HF Mistral tokenizer kwargs."""
+    raw_config = yaml.safe_load(CONFIG_PATH.read_text(encoding="utf-8"))
+    tokenizer_config = ConfigNode(raw_config["tokenizer"])
+
+    with (
+        patch("transformers.AutoConfig.from_pretrained", return_value=_Mistral3Config()),
+        patch.object(TokenizerRegistry, "get_custom_tokenizer_cls", return_value=_FakeMistralTokenizer),
+        patch(
+            "transformers.AutoTokenizer.from_pretrained",
+            side_effect=AssertionError("the recipe must use AutoModel's registered Mistral tokenizer"),
+        ),
+    ):
+        tokenizer = tokenizer_config.instantiate()
+
+    assert isinstance(tokenizer, _FakeMistralTokenizer)


### PR DESCRIPTION
# What does this PR do?

Fix the shipped Ministral3 bi-encoder retrieval recipe end to end: use the BF16 training checkpoint, repair tokenizer construction, make native-FP8 loading safe when requested explicitly, and support the registered tokenizer backend in the collator.

# Root cause

The recipe forced raw Hugging Face tokenizer dispatch and passed `add_eos_token`. With the current Transformers Tekken dispatch, that resolves to `MistralCommonBackend`, which rejects both `add_eos_token` and Hugging Face's injected `_from_auto` kwarg. AutoModel already has a registered `mistral3` backend with the intended BOS/no-EOS behavior, so the forced raw-HF route was unnecessary.

After tokenizer construction succeeded, scoped CI exposed the original checkpoint's native-FP8 scalar `weight_scale_inv` parameters. FSDP2 cannot shard scalar parameters. The shipped training recipe now uses Mistral's BF16 checkpoint. As a safeguard for users who explicitly select a native-FP8 parent checkpoint, the retrieval loader follows the documented Transformers API and passes `FineGrainedFP8Config(dequantize=True)` before extracting the trainable backbone.

The next scoped run then reached collation and showed that `BiEncoderCollator` always passed `return_token_type_ids=False`, although `MistralCommonBackend` explicitly does not support that kwarg. The collator now passes it only to tokenizers that advertise token-type IDs.

# Changelog

- Use AutoModel's registered `mistral3` tokenizer backend in `ministral3_3b_instruct.yaml`.
- Use `mistralai/Ministral-3-3B-Instruct-2512-BF16` for the shipped training recipe.
- Dequantize explicitly selected native-FP8 parent checkpoints through Transformers' `FineGrainedFP8Config` API.
- Avoid unsupported token-type kwargs for strict tokenizer backends.
- Add focused tokenizer, FP8 forwarding, and collator regression tests.
- Add a 2-GPU, 10-step nightly smoke for the shipped Ministral3 retrieval recipe.

# Validation

- Current-head tokenizer, retrieval, collator, and CI generator/resolver suite: 79 passed.
- Broader tokenizer, retrieval, and CI coverage before the final collator follow-up: 123 passed.
- `ruff format .`
- `ruff check --fix .`
- Instantiated the edited YAML's real cached tokenizer and verified `MistralCommonBackend`, left padding, BOS insertion, and no EOS insertion.
- Ran the real cached `MistralCommonBackend` from the shipped YAML through `BiEncoderCollator`; query/document tokenization and padding completed with the expected tensor shapes.
- [Scoped pipeline 61449495](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/61449495) reproduced the post-tokenizer FP8/FSDP2 scalar failure.
- [Scoped pipeline 61456885](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/61456885) validated dense FP8 materialization and FSDP2 setup, then exposed the collator kwarg failure.
- [Scoped pipeline 61462370](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/61462370), [exact job 387796860](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/387796860): the earlier FP8-recipe head completed the exact `ministral3_3b_instruct` 2-GPU smoke successfully. All 10/10 training steps had finite loss.
- Direct Transformers 5.12.1 GPU probe of `Mistral3ForConditionalGeneration.from_pretrained(..., quantization_config=FineGrainedFP8Config(dequantize=True))` on the real FP8 checkpoint: zero `weight_scale_inv` parameters, zero FP8 parameters, and finite BF16 language-model weights (Slurm `15241774`).
- [Scoped pipeline 61474644](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/61474644), [exact job 387913544](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/387913544): the current PR head completed the exact shipped BF16 recipe on 2 GPUs. All 10/10 training steps had finite loss (final loss `2.3438`; final rolling average `1.9441`), and the Slurm workload completed with exit code 0.

# Before your PR is "Ready for review"

- [x] Read and followed the contributor guidelines.
- [x] Added focused regression tests.
- [x] Added permanent scoped CI coverage.

# Additional Information

- Related to NVIDIA Bug 6544343.
- The retrieval FP8 failure was exposed by #3103's switch to the stock Ministral3 backbone. The underlying native-FP8/FSDP2 scalar incompatibility predates that PR.
