### PR TITLE
fix: Gemma4-31B CoderForge CP8/64K data processing and recipe

### DIFF
--- a/examples/long_context_validation/gemma4_31B/README.md
+++ b/examples/long_context_validation/gemma4_31B/README.md
@@ -17,6 +17,8 @@ data/
   prefilter.sh           Runner with CoderForge + Gemma4 defaults
   validate_data.py       Token-level correctness assertions on the ChatDataset output
   check_masking.py       Eyeball the assistant-only label mask on real training samples
+gemma4_coderforge_chat_template.jinja
+                         Gemma4 template with {% generation %} blocks for direct assistant masking
 ```
 
 ### Why prefilter (don't truncate)
@@ -59,11 +61,18 @@ higher-length pass is a cheap re-filter (no re-tokenization) that emits a new
   + `tokenizer.json`). Point `--model` at it. The base `google/gemma-4-31B` ships
   **no `chat_template.jinja`** — copy it from `google/gemma-4-31B-it` into the base
   checkpoint dir before running data prep or training (the tokenizer is identical).
-- The Gemma4 template has **no real `{% generation %}` block**, so
-  `return_assistant_tokens_mask` is all-zeros. `ChatDataset` detects this and
-  falls back to `_build_multiturn_assistant_mask`, which supervises every
-  assistant turn (including tool-call turns). Correct, but O(turns) re-tokenization
-  per sample — pre-tokenization is a future optimization for large runs.
+- **Assistant masking uses `gemma4_coderforge_chat_template.jinja`** (in this
+  directory), a copy of the stock Gemma4 template with every assistant turn's body
+  wrapped in `{% generation %}...{% endgeneration %}`. The recipe, `validate_data.py`,
+  and `check_masking.py` point `chat_template` at it, so
+  `apply_chat_template(return_assistant_tokens_mask=True)` returns the assistant
+  mask directly (one `apply_chat_template` call per sample). The rendered token
+  stream is byte-identical to the stock template.
+  The stock Gemma4 template has **no `{% generation %}` block**, so `ChatDataset`
+  would fall back to `_build_multiturn_assistant_mask` — an O(turns) per-sample
+  re-tokenization that #3024's prefix-consistency guard rejects for multi-turn
+  conversations whose rendered prefixes are not exact token prefixes of the full
+  render. The generation-block template is the supported path.
 - The stop token the model must learn is **`<turn|>` (id 106)**, listed in
   `generation_config.eos_token_id=[1,106,50]` — **not** the tokenizer
   `eos_token_id` (1 = `<eos>`). `validate_data.py` checks 106.

--- a/examples/long_context_validation/gemma4_31B/data/check_masking.py
+++ b/examples/long_context_validation/gemma4_31B/data/check_masking.py
@@ -29,6 +29,7 @@ For a few samples it reports:
 """
 
 import argparse
+import os
 
 from transformers import AutoTokenizer
 
@@ -36,6 +37,10 @@ from nemo_automodel.components.datasets.llm.chat_dataset import ChatDataset
 
 GEMMA4 = "/path/to/checkpoints/hf_gemma4_31b"
 JSONL = "/path/to/coderforge_cache/togethercomputer_CoderForge-Preview_filtered_reward1_seq65536/data.jsonl"
+# Generation-block template lives one directory up from this script (data/../).
+_DEFAULT_CHAT_TEMPLATE = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "gemma4_coderforge_chat_template.jinja"
+)
 
 
 def contiguous_spans(labels, keep):
@@ -59,11 +64,22 @@ def main():
     ap.add_argument("--n", type=int, default=4)
     ap.add_argument("--seq-length", type=int, default=65536)
     ap.add_argument("--jsonl", default=JSONL)
+    ap.add_argument(
+        "--chat-template",
+        default=_DEFAULT_CHAT_TEMPLATE,
+        help="Chat template with {% generation %} blocks for direct assistant masking. "
+        "Empty string uses the tokenizer's own template (the prefix-arithmetic fallback).",
+    )
     args = ap.parse_args()
 
     tok = AutoTokenizer.from_pretrained(GEMMA4)
     ds = ChatDataset(
-        path_or_dataset_id=args.jsonl, tokenizer=tok, split="train", seq_length=args.seq_length, padding="do_not_pad"
+        path_or_dataset_id=args.jsonl,
+        tokenizer=tok,
+        split="train",
+        seq_length=args.seq_length,
+        padding="do_not_pad",
+        chat_template=args.chat_template or None,
     )
     print(f"Dataset size: {len(ds)}")
 

--- a/examples/long_context_validation/gemma4_31B/data/validate_data.py
+++ b/examples/long_context_validation/gemma4_31B/data/validate_data.py
@@ -43,8 +43,15 @@ Usage:
 """
 
 import argparse
+import os
 import sys
 from typing import Dict, List, Tuple
+
+# The generation-block template lives one directory up from this script (data/../).
+# Resolve it absolutely so the default works regardless of the caller's CWD.
+_DEFAULT_CHAT_TEMPLATE = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "gemma4_coderforge_chat_template.jinja"
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -60,6 +67,13 @@ def parse_args() -> argparse.Namespace:
         help="Padding strategy. Training uses do_not_pad (the collator pads the batch).",
     )
     parser.add_argument("--split", type=str, default="train", help="Dataset split")
+    parser.add_argument(
+        "--chat_template",
+        type=str,
+        default=_DEFAULT_CHAT_TEMPLATE,
+        help="Chat template (Jinja file or string) with {% generation %} blocks for direct assistant "
+        "masking. Empty string uses the tokenizer's own template (the prefix-arithmetic fallback).",
+    )
     parser.add_argument("--stop_token_id", type=int, default=106, help="Gemma4 turn terminator <turn|> (id 106).")
     parser.add_argument(
         "--terminator_window",
@@ -149,6 +163,7 @@ def main() -> None:
         split=args.split,
         seq_length=args.seq_length,
         padding=args.padding,
+        chat_template=args.chat_template or None,
     )
     print(f"Dataset size: {len(dataset)}")
     print(

--- a/examples/long_context_validation/gemma4_31B/gemma4_31b_base_coderforge_cp8_64k_1e5_800steps.yaml
+++ b/examples/long_context_validation/gemma4_31B/gemma4_31b_base_coderforge_cp8_64k_1e5_800steps.yaml
@@ -81,6 +81,11 @@ dataset:
   split: train
   seq_length: 65536
   padding: do_not_pad
+  # Assistant-only masking comes from a Gemma4 chat template with {% generation %}
+  # blocks (tokenizer returns the assistant mask directly). The stock Gemma4
+  # template has no generation block, forcing the prefix-arithmetic fallback that
+  # #3024's guard rejects for multi-turn conversations. Renders byte-identically.
+  chat_template: examples/long_context_validation/gemma4_31B/gemma4_coderforge_chat_template.jinja
   shuffle_seed: 42
 
 dataloader:

--- a/examples/long_context_validation/gemma4_31B/gemma4_coderforge_chat_template.jinja
+++ b/examples/long_context_validation/gemma4_31B/gemma4_coderforge_chat_template.jinja
@@ -1,0 +1,281 @@
+{#-
+  Gemma4 chat template for CoderForge SFT, derived from the stock
+  google/gemma-4-31B-it `chat_template.jinja`. The ONLY functional change is that
+  every assistant ("model") turn's body -- tool-call block, text content, and the
+  closing `<turn|>` -- is wrapped in `{% generation %}...{% endgeneration %}` so
+  `tokenizer.apply_chat_template(..., return_assistant_tokens_mask=True)` returns
+  the assistant loss mask directly. This avoids the prefix-arithmetic fallback
+  (`_build_multiturn_assistant_mask`) and its O(turns) re-tokenization, and is the
+  supported answer-only-mask path for multi-turn SFT.
+
+  The `<|turn>model\n` role header is intentionally left OUTSIDE the generation
+  block: it is the generation *prompt* (provided at inference), not model output.
+  This template is for training/masking (`add_generation_prompt=False`); the
+  rendered token stream is byte-identical to the stock template.
+-#}
+{%- macro format_parameters(properties, required) -%}
+    {%- set standard_keys = ['description', 'type', 'properties', 'required', 'nullable'] -%}
+    {%- set ns = namespace(found_first=false) -%}
+    {%- for key, value in properties | dictsort -%}
+        {%- set add_comma = false -%}
+        {%- if key not in standard_keys -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {{ key }}:{
+            {%- if value['description'] -%}
+                description:<|"|>{{ value['description'] }}<|"|>
+                {%- set add_comma = true -%}
+            {%- endif -%}
+            {%- if value['nullable'] %}
+                {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                nullable:true
+            {%- endif -%}
+            {%- if value['type'] | upper == 'STRING' -%}
+                {%- if value['enum'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    enum:{{ format_argument(value['enum']) }}
+                {%- endif -%}
+            {%- elif value['type'] | upper == 'OBJECT' -%}
+                ,properties:{
+                {%- if value['properties'] is defined and value['properties'] is mapping -%}
+                    {{- format_parameters(value['properties'], value['required'] | default([])) -}}
+                {%- elif value is mapping -%}
+                    {{- format_parameters(value, value['required'] | default([])) -}}
+                {%- endif -%}
+                }
+                {%- if value['required'] -%}
+                    ,required:[
+                    {%- for item in value['required'] | default([]) -%}
+                        <|"|>{{- item -}}<|"|>
+                        {%- if not loop.last %},{% endif -%}
+                    {%- endfor -%}
+                    ]
+                {%- endif -%}
+            {%- elif value['type'] | upper == 'ARRAY' -%}
+                {%- if value['items'] is mapping and value['items'] -%}
+                    ,items:{
+                    {%- set ns_items = namespace(found_first=false) -%}
+                    {%- for item_key, item_value in value['items'] | dictsort -%}
+                        {%- if item_value is not none -%}
+                            {%- if ns_items.found_first %},{% endif -%}
+                            {%- set ns_items.found_first = true -%}
+                            {%- if item_key == 'properties' -%}
+                                properties:{
+                                {%- if item_value is mapping -%}
+                                    {{- format_parameters(item_value, value['items']['required'] | default([])) -}}
+                                {%- endif -%}
+                                }
+                            {%- elif item_key == 'required' -%}
+                                required:[
+                                {%- for req_item in item_value -%}
+                                    <|"|>{{- req_item -}}<|"|>
+                                    {%- if not loop.last %},{% endif -%}
+                                {%- endfor -%}
+                                ]
+                            {%- elif item_key == 'type' -%}
+                                {%- if item_value is string -%}
+                                    type:{{ format_argument(item_value | upper) }}
+                                {%- else -%}
+                                    type:{{ format_argument(item_value | map('upper') | list) }}
+                                {%- endif -%}
+                            {%- else -%}
+                                {{ item_key }}:{{ format_argument(item_value) }}
+                            {%- endif -%}
+                        {%- endif -%}
+                    {%- endfor -%}
+                    }
+                {%- endif -%}
+            {%- endif -%}
+            {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+            type:<|"|>{{ value['type'] | upper }}<|"|>}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endmacro -%}
+{%- macro format_function_declaration(tool_data) -%}
+    declaration:{{- tool_data['function']['name'] -}}{description:<|"|>{{- tool_data['function']['description'] -}}<|"|>
+    {%- set params = tool_data['function']['parameters'] -%}
+    {%- if params -%}
+        ,parameters:{
+        {%- if params['properties'] -%}
+            properties:{ {{- format_parameters(params['properties'], params['required']) -}} },
+        {%- endif -%}
+        {%- if params['required'] -%}
+            required:[
+            {%- for item in params['required'] -%}
+                <|"|>{{- item -}}<|"|>
+                {{- ',' if not loop.last -}}
+            {%- endfor -%}
+            ],
+        {%- endif -%}
+        {%- if params['type'] -%}
+            type:<|"|>{{- params['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    {%- if 'response' in tool_data['function'] -%}
+        {%- set response_declaration = tool_data['function']['response'] -%}
+        ,response:{
+        {%- if response_declaration['description'] -%}
+            description:<|"|>{{- response_declaration['description'] -}}<|"|>,
+        {%- endif -%}
+        {%- if response_declaration['type'] | upper == 'OBJECT' -%}
+            type:<|"|>{{- response_declaration['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    }
+{%- endmacro -%}
+{%- macro format_argument(argument, escape_keys=True) -%}
+    {%- if argument is string -%}
+        {{- '<|"|>' + argument + '<|"|>' -}}
+    {%- elif argument is boolean -%}
+        {{- 'true' if argument else 'false' -}}
+    {%- elif argument is mapping -%}
+        {{- '{' -}}
+        {%- set ns = namespace(found_first=false) -%}
+        {%- for key, value in argument | dictsort -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {%- if escape_keys -%}
+                {{- '<|"|>' + key + '<|"|>' -}}
+            {%- else -%}
+                {{- key -}}
+            {%- endif -%}
+            :{{- format_argument(value, escape_keys=escape_keys) -}}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- elif argument is sequence -%}
+        {{- '[' -}}
+        {%- for item in argument -%}
+            {{- format_argument(item, escape_keys=escape_keys) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- ']' -}}
+    {%- else -%}
+        {{- argument -}}
+    {%- endif -%}
+{%- endmacro -%}
+{%- macro strip_thinking(text) -%}
+    {%- set ns = namespace(result='') -%}
+    {%- for part in text.split('<channel|>') -%}
+        {%- if '<|channel>' in part -%}
+            {%- set ns.result = ns.result + part.split('<|channel>')[0] -%}
+        {%- else -%}
+            {%- set ns.result = ns.result + part -%}
+        {%- endif -%}
+    {%- endfor -%}
+    {{- ns.result | trim -}}
+{%- endmacro -%}
+{%- macro render_turn_body(message, role) -%}
+    {%- if message['tool_calls'] -%}
+        {%- for tool_call in message['tool_calls'] -%}
+            {%- set function = tool_call['function'] -%}
+            {{- '<|tool_call>call:' + function['name'] + '{' -}}
+            {%- if function['arguments'] is mapping -%}
+                {%- set ns_args = namespace(found_first=false) -%}
+                {%- for key, value in function['arguments'] | dictsort -%}
+                    {%- if ns_args.found_first %},{% endif -%}
+                    {%- set ns_args.found_first = true -%}
+                    {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+                {%- endfor -%}
+            {%- elif function['arguments'] is string -%}
+                {{- function['arguments'] -}}
+            {%- endif -%}
+            {{- '}<tool_call|>' -}}
+        {%- endfor -%}
+    {%- endif -%}
+    {%- if message['tool_responses'] -%}
+        {%- for tool_response in message['tool_responses'] -%}
+            {{- '<|tool_response>' -}}
+            {%- if tool_response['response'] is mapping -%}
+                {{- 'response:' + tool_response['name'] | default('unknown') + '{' -}}
+                {%- for key, value in tool_response['response'] | dictsort -%}
+                    {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+                    {%- if not loop.last %},{% endif -%}
+                {%- endfor -%}
+                {{- '}' -}}
+            {%- else -%}
+                {{- 'response:' + tool_response['name'] | default('unknown') + '{value:' + format_argument(tool_response['response'], escape_keys=False) + '}' -}}
+            {%- endif -%}
+            {{- '<tool_response|>' -}}
+        {%- endfor -%}
+    {%- endif -%}
+    {%- if message['content'] is string -%}
+        {%- if role == 'model' -%}
+            {{- strip_thinking(message['content']) -}}
+        {%- else -%}
+            {{- message['content'] | trim -}}
+        {%- endif -%}
+    {%- elif message['content'] is sequence -%}
+        {%- for item in message['content'] -%}
+            {%- if item['type'] == 'text' -%}
+                {%- if role == 'model' -%}
+                    {{- strip_thinking(item['text']) -}}
+                {%- else -%}
+                    {{- item['text'] | trim -}}
+                {%- endif -%}
+            {%- elif item['type'] == 'image' -%}
+                {{- '\n\n<|image|>\n\n' -}}
+            {%- elif item['type'] == 'audio' -%}
+                {{- '<|audio|>' -}}
+            {%- elif item['type'] == 'video' -%}
+                {{- '\n\n<|video|>\n\n' -}}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endif -%}
+{%- endmacro -%}
+
+{%- set ns = namespace(prev_message_type=None) -%}
+{%- set loop_messages = messages -%}
+{{ bos_token }}
+{#- Handle System/Tool Definitions Block -#}
+{%- if (enable_thinking is defined and enable_thinking) or tools or messages[0]['role'] in ['system', 'developer'] -%}
+    {{- '<|turn>system\n' -}}
+
+    {#- Inject Thinking token at the very top of the FIRST system turn -#}
+    {%- if enable_thinking is defined and enable_thinking -%}
+        {{- '<|think|>' -}}
+        {%- set ns.prev_message_type = 'think' -%}
+    {%- endif -%}
+
+    {%- if messages[0]['role'] in ['system', 'developer'] -%}
+        {{- messages[0]['content'] | trim -}}
+        {%- set loop_messages = messages[1:] -%}
+    {%- endif -%}
+
+    {%- if tools -%}
+        {%- for tool in tools %}
+            {{- '<|tool>' -}}
+            {{- format_function_declaration(tool) | trim -}}
+            {{- '<tool|>' -}}
+        {%- endfor %}
+        {%- set ns.prev_message_type = 'tool' -%}
+    {%- endif -%}
+
+    {{- '<turn|>\n' -}}
+{%- endif %}
+
+{#- Loop through messages -#}
+{%- for message in loop_messages -%}
+    {%- set ns.prev_message_type = None -%}
+    {%- set role = 'model' if message['role'] == 'assistant' else message['role'] -%}
+        {{- '<|turn>' + role + '\n' }}
+        {%- if role == 'model' -%}
+            {% generation %}
+            {{- render_turn_body(message, role) -}}
+            {{- '<turn|>\n' -}}
+            {% endgeneration %}
+        {%- else -%}
+            {{- render_turn_body(message, role) -}}
+            {%- if not (message['tool_responses'] and not message['content']) -%}
+                {{- '<turn|>\n' -}}
+            {%- endif -%}
+        {%- endif -%}
+{%- endfor -%}
+
+{%- if add_generation_prompt -%}
+    {%- if ns.prev_message_type != 'tool_response' -%}
+        {{- '<|turn>model\n' -}}
+    {%- endif -%}
+    {%- if not enable_thinking | default(false) -%}
+        {{- '<|channel>thought\n<channel|>' -}}
+    {%- endif -%}
+{%- endif -%}

--- a/nemo_automodel/components/datasets/vlm/loader.py
+++ b/nemo_automodel/components/datasets/vlm/loader.py
@@ -220,7 +220,12 @@ class VlmDataloaderConfig:
             if isinstance(self.dataset_config, RankedVlmDatasetConfig):
                 dataset = self.dataset_config.build(rank=dp_rank, world_size=dp_world_size)
             elif isinstance(self.dataset_config, TokenizerDatasetConfig):
-                dataset = self.dataset_config.build(tokenizer=processor)
+                # These configs are text datasets (e.g. ChatDataset) that consume a tokenizer,
+                # not the full processor: a ProcessorMixin does not proxy tokenizer attributes
+                # (eos_token_id, pad_token, ...) -- those live on processor.tokenizer. Forward the
+                # wrapped tokenizer so both a genuine processor and a bare tokenizer work.
+                source_tokenizer = processor.tokenizer if isinstance(processor, ProcessorMixin) else processor
+                dataset = self.dataset_config.build(tokenizer=source_tokenizer)
             else:
                 dataset = self.dataset_config.build()
         return dataset, processor

--- a/nemo_automodel/recipes/_typed_config.py
+++ b/nemo_automodel/recipes/_typed_config.py
@@ -375,6 +375,10 @@ class RecipeConfig:
         from nemo_automodel.components.datasets.vlm.neat_packing_vlm import NeatPackConfig
 
         target, dataset_kwargs = _callable_and_kwargs(dataset_node)
+        # `tokenizer`/`processor` are runtime build args, not declarative dataset fields.
+        # Drop them here as the LLM path (`_resolve_dataloader`) does, so a `dataset.tokenizer`
+        # block (valid on the LLM path) does not reach the dataset config, which rejects unknown fields.
+        dataset_kwargs.pop("tokenizer", None)
         chat_template = dataset_kwargs.pop("chat_template", None)
         legacy_packing = dataset_kwargs.pop("packing", None)
         dataset_pretokenize = dataset_kwargs.pop("pretokenize", None)

--- a/tests/unit_tests/datasets/llm/test_formatting_utils.py
+++ b/tests/unit_tests/datasets/llm/test_formatting_utils.py
@@ -11,6 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
+
 import pytest
 
 from nemo_automodel.components.datasets.llm import formatting_utils
@@ -301,3 +303,72 @@ def test_reasoning_mask_rejects_noncontiguous_truncation_window():
             seq_length=1,
             unpadded_full_ids=[12345],
         )
+
+
+class _GenerationBlockTokenizer(_RewritingTokenizer):
+    """A rewriting template that ALSO wraps assistant turns in ``{% generation %}``.
+
+    Same rewrite behavior as :class:`_RewritingTokenizer` (a prefix render is not a
+    token prefix of the full render, so ``_build_multiturn_assistant_mask`` would
+    refuse), but because the template contains the generation keyword the tokenizer
+    returns ``assistant_masks`` directly and the prefix-arithmetic fallback is never
+    consulted. This is the contract the shipped Gemma4 CoderForge template relies on.
+    """
+
+    chat_template = "<dummy template with {% generation %}...{% endgeneration %}>"
+
+    def apply_chat_template(self, messages, return_assistant_tokens_mask=False, **kwargs):
+        last_user = max((i for i, msg in enumerate(messages) if msg["role"] == "user"), default=-1)
+        ids, amask = [], []
+        for i, msg in enumerate(messages):
+            is_asst = msg["role"] == "assistant"
+            ids.append(self._ROLE_TOKEN)  # role header is the generation prompt, never supervised
+            amask.append(0)
+            if is_asst and i > last_user and msg.get("reasoning_content"):
+                reasoning = [self._REASONING_TOKEN] * len(msg["reasoning_content"].split())
+                ids.extend(reasoning)
+                amask.extend([1] * len(reasoning))
+            content = [self._id_for_token(tok) for tok in str(msg["content"]).split()]
+            ids.extend(content)
+            amask.extend([1 if is_asst else 0] * len(content))
+        out = {"input_ids": ids, "attention_mask": [1] * len(ids)}
+        if return_assistant_tokens_mask:
+            out["assistant_masks"] = amask
+        return out
+
+
+def test_format_chat_template_generation_block_uses_direct_assistant_mask():
+    # The same conversation that raises with a no-generation template
+    # (test_format_chat_template_raises_on_rewriting_template) now succeeds: a
+    # generation-block template returns the assistant mask directly, so the
+    # prefix-arithmetic fallback is never reached and labels supervise exactly the
+    # assistant tokens (role header and user/tool tokens stay -100).
+    tok = _GenerationBlockTokenizer()
+    formatted = _rewriting_conversation()
+
+    out = formatting_utils.format_chat_template(
+        tok,
+        formatted_text=formatted,
+        eos_token_id=tok.eos_token_id,
+        pad_token_id=tok.eos_token_id,
+        answer_only_loss_mask=True,
+    )
+
+    full = tok.apply_chat_template(formatted, return_assistant_tokens_mask=True)
+    ids, amask = full["input_ids"], full["assistant_masks"]
+    # Standard shifted NTP: labels drop the first token; labels[i] supervises ids[i+1].
+    expected = [ids[i + 1] if amask[i + 1] else -100 for i in range(len(ids) - 1)]
+    assert out["labels"] == expected
+    assert any(label != -100 for label in out["labels"])  # assistant content is supervised
+    assert tok._ROLE_TOKEN not in out["labels"]  # role-header/scaffolding tokens are not
+
+
+def test_shipped_gemma4_coderforge_template_has_generation_block():
+    # Guard the shipped artifact: the recipe/validate/check_masking point ChatDataset
+    # at this file, and it must trip the generation-keyword path (GENERATION_REGEX)
+    # with balanced tags, or ChatDataset silently falls back to the guarded builder.
+    template = (
+        Path(__file__).parents[4] / "examples/long_context_validation/gemma4_31B/gemma4_coderforge_chat_template.jinja"
+    ).read_text()
+    assert formatting_utils.GENERATION_REGEX.search(template) is not None
+    assert template.count("{% generation %}") == template.count("{% endgeneration %}") >= 1

--- a/tests/unit_tests/datasets/vlm/test_vlm_loader.py
+++ b/tests/unit_tests/datasets/vlm/test_vlm_loader.py
@@ -15,6 +15,7 @@
 from dataclasses import dataclass
 
 import pytest
+from transformers import ProcessorMixin
 
 from nemo_automodel.components.config.loader import ConfigNode
 from nemo_automodel.components.datasets.vlm.collate_fns import (
@@ -286,3 +287,60 @@ def test_vlm_dataloader_skips_dense_neat_packing_mask_under_cp(monkeypatch):
     assert result.dataloader.collate_fn.func is neat_packed_vlm_collater
     assert result.dataloader.collate_fn.keywords["attn_implementation"] == "sdpa"
     assert result.dataloader.collate_fn.keywords["materialize_4d_mask"] is False
+
+
+class _NoEosProcessor(ProcessorMixin):
+    """Processor stub whose tokenizer lives at ``.tokenizer`` and that does not proxy
+    tokenizer attributes (no ``eos_token_id``), matching a real LlavaProcessor."""
+
+    attributes = []
+
+    def __init__(self, tokenizer):
+        self.tokenizer = tokenizer
+
+
+@dataclass
+class _RecordingTokenizerDatasetConfig:
+    """TokenizerDatasetConfig stub (a text dataset) that records the arg it is built with."""
+
+    accepts_tokenizer: bool = True
+    received_tokenizer: object = None
+
+    def build(self, *, tokenizer):
+        self.received_tokenizer = tokenizer
+        return ["sample"]
+
+
+def test_build_source_forwards_processor_tokenizer_to_text_dataset():
+    # A genuine processor does not expose tokenizer attributes (e.g. eos_token_id);
+    # text datasets must receive processor.tokenizer, not the processor itself.
+    inner_tokenizer = object()
+    processor = _NoEosProcessor(inner_tokenizer)
+    ds_cfg = _RecordingTokenizerDatasetConfig()
+    config = VlmDataloaderConfig(
+        dataset_config=ds_cfg,
+        processor_config=VlmProcessorConfig(factory=lambda: processor),
+    )
+
+    dataset, returned_processor = config._build_source(
+        pretrained_model_name_or_path="unused", dp_rank=0, dp_world_size=1, dataset_build_context=None
+    )
+
+    assert ds_cfg.received_tokenizer is inner_tokenizer  # tokenizer, not the processor
+    assert returned_processor is processor  # processor still returned for pretokenization/collation
+    assert dataset == ["sample"]
+
+
+def test_build_source_forwards_bare_tokenizer_unchanged():
+    # When the processor slot holds a bare tokenizer (not a ProcessorMixin), it is
+    # forwarded unchanged so tokenizer-only recipes keep working.
+    bare_tokenizer = object()
+    ds_cfg = _RecordingTokenizerDatasetConfig()
+    config = VlmDataloaderConfig(
+        dataset_config=ds_cfg,
+        processor_config=VlmProcessorConfig(factory=lambda: bare_tokenizer),
+    )
+
+    config._build_source(pretrained_model_name_or_path="unused", dp_rank=0, dp_world_size=1, dataset_build_context=None)
+
+    assert ds_cfg.received_tokenizer is bare_tokenizer

--- a/tests/unit_tests/datasets/vlm/test_vlm_loader.py
+++ b/tests/unit_tests/datasets/vlm/test_vlm_loader.py
@@ -18,6 +18,7 @@ import pytest
 from transformers import ProcessorMixin
 
 from nemo_automodel.components.config.loader import ConfigNode
+from nemo_automodel.components.datasets.llm.chat_dataset import ChatDatasetConfig
 from nemo_automodel.components.datasets.vlm.collate_fns import (
     neat_packed_vlm_collater,
     packed_sequence_thd_vlm_collater,
@@ -329,6 +330,35 @@ def test_build_source_forwards_processor_tokenizer_to_text_dataset():
     assert ds_cfg.received_tokenizer is inner_tokenizer  # tokenizer, not the processor
     assert returned_processor is processor  # processor still returned for pretokenization/collation
     assert dataset == ["sample"]
+
+
+def test_vlm_dataloader_drops_dataset_tokenizer_block():
+    # A `dataset.tokenizer` block is valid on the LLM path (the tokenizer is a runtime
+    # build arg, popped before building the dataset config). The VLM path must drop it
+    # too; otherwise it reaches ChatDatasetConfig, which rejects unknown fields.
+    config = RecipeConfig(
+        ConfigNode(
+            {
+                "dataset": {
+                    "_target_": "nemo_automodel.components.datasets.llm.chat_dataset.ChatDataset",
+                    "path_or_dataset_id": "unused.jsonl",
+                    "seq_length": 512,
+                    "tokenizer": {
+                        "_target_": "transformers.AutoTokenizer.from_pretrained",
+                        "pretrained_model_name_or_path": "unused-model",
+                    },
+                },
+                "dataloader": {
+                    "_target_": "torchdata.stateful_dataloader.StatefulDataLoader",
+                    "num_workers": 0,
+                },
+            }
+        )
+    ).vlm_dataloader
+
+    assert isinstance(config.dataset_config, ChatDatasetConfig)
+    assert config.dataset_config.path_or_dataset_id == "unused.jsonl"
+    assert config.dataset_config.seq_length == 512
 
 
 def test_build_source_forwards_bare_tokenizer_unchanged():


### PR DESCRIPTION
### What

PR #3151's shipped `examples/long_context_validation/gemma4_31B` recipe could not build training batch. Three independent defects on the ChatDataset-on-VLM path are fixed here, each with a CPU regression test.

### Commits

1. **`fix(examples): add Gemma4 CoderForge generation-block chat template for assistant masking`**
   The stock Gemma4 template has no `{% generation %}` block, forcing ChatDataset's prefix-arithmetic mask fallback, which #3024's guard rejects for multi-turn conversations → `ValueError`. Ships `gemma4_coderforge_chat_template.jinja` (stock template + `{% generation %}` around assistant turns; renders byte-identically) and points the recipe / `validate_data.py` / `check_masking.py` at it, so the tokenizer returns the assistant mask directly.

2. **`fix(datasets): forward processor tokenizer to text datasets in VLM dataloader`**
   `_build_source` passed the full processor as `tokenizer=`; text datasets then read `.eos_token_id`, which a `ProcessorMixin` doesn't proxy → `AttributeError`. Now forwards `processor.tokenizer` (bare tokenizers pass through unchanged).

3. **`fix(recipes): drop dataset.tokenizer in VLM dataloader resolution`**
   The VLM resolution path didn't pop `dataset.tokenizer` (a valid LLM-path convention), so it reached `ChatDatasetConfig` → `TypeError: unexpected field 'tokenizer'`. Now popped, matching the LLM path; both accept the same schema.

### Validation

- **Each defect reproduced then re-run green** in the `nemo-automodel:26.08.rc3` container (defect 1 render-equivalence + correct mask on 8 real CoderForge trajectories; defects 2–3 product-only repros from the reports).
- **README data-pipeline flow end-to-end** (RC3): analyze → seq65536 cache → `validate_data.py --num-samples 200` → **200/200 samples pass** all masking assertions.
- **Unit tests:** `test_formatting_utils.py` 17/17, `test_vlm_loader.py` 11/11; `ruff format`/`check` clean.

Fixes: NVBug 6565114, 6565100, 6565111 (masking ValueError, processor AttributeError, dataset.tokenizer TypeError). 

🤖 Generated with [Claude Code](https://claude.com/claude-code)
