### PR TITLE
cp: backport PEFT v5 adapter output fixes to r0.6.0

### DIFF
--- a/nemo_automodel/components/checkpoint/addons.py
+++ b/nemo_automodel/components/checkpoint/addons.py
@@ -303,30 +303,21 @@ def _get_automodel_peft_metadata(peft_config: "PeftConfig") -> dict:
     return result
 
 
-def _is_qwen3_moe(model: nn.Module) -> bool:
-    """Check whether *model* uses the Qwen3 MoE state-dict adapter."""
-    adapter = getattr(model, "state_dict_adapter", None)
-    if adapter is None:
-        return False
-    from nemo_automodel.components.models.qwen3_moe.state_dict_adapter import Qwen3MoeStateDictAdapter
-
-    return isinstance(adapter, Qwen3MoeStateDictAdapter)
-
-
 def _extract_target_parameters(model: "nn.Module | list[nn.Module]", v4_compatible: bool = False) -> list[str]:
     """Extract ``target_parameters`` for PEFT v0.18+ ParamWrapper format.
 
-    Returns fused expert parameter paths for Qwen3 MoE when not in legacy mode,
-    or an empty list otherwise.
+    Returns fused expert parameter paths for adapters that explicitly opt in
+    to PEFT v5 ParamWrapper export, or an empty list otherwise.
 
     ``model`` may be a single module or a list of PP parts; the check is a
     per-model-class property, so the first part is representative.
     """
-    model = model[0] if isinstance(model, (list, tuple)) else model
+    model_part = model[0] if isinstance(model, (list, tuple)) else model
     if v4_compatible:
         return []
-    if _is_qwen3_moe(model):
-        return ["mlp.experts.gate_up_proj", "mlp.experts.down_proj"]
+    adapter = getattr(model_part, "state_dict_adapter", None)
+    if adapter is not None and isinstance(adapter, MoESplitExpertsStateDictMixin):
+        return list(adapter._v5_peft_target_parameters)
     return []
 
 
@@ -343,8 +334,10 @@ def _extract_target_modules(
     compatibility with vLLM, TensorRT-LLM, and HF PEFT.
 
     For MoE expert LoRA, grouped 3-D adapter parameters are expanded to
-    per-expert HF projection names unless the model is Qwen3 MoE in
-    non-legacy mode (where ``target_parameters`` is used instead).
+    per-expert HF projection names when in v4-compatible mode (where
+    per-expert ``target_modules`` are used).  In v5 mode (``v4_compatible=False``)
+    the expansion is skipped because ``target_parameters`` provides the
+    fused ParamWrapper paths instead.
 
     Strips ``_orig_mod.`` (torch.compile) and ``_checkpoint_wrapped_module.``
     (activation checkpointing) prefixes from module names.
@@ -386,14 +379,14 @@ def _extract_target_modules(
 
     # MoE expert LoRA: adapter weights are nn.Parameter (not nn.Module) so
     # they don't appear in named_modules(). Expand to per-expert HF names,
-    # unless Qwen3 MoE in non-legacy mode (uses target_parameters instead).
-    # The mixin / qwen3 checks are per-model-class properties (identical across
-    # all PP parts), so check the first part.
-    _has_split_expert_mixin = hasattr(model_parts[0], "state_dict_adapter") and isinstance(
-        model_parts[0].state_dict_adapter, MoESplitExpertsStateDictMixin
+    # unless the adapter explicitly opts into v5 fused target_parameters.
+    # Unvalidated MoE adapters keep the legacy expansion as their default.
+    adapter = getattr(model_parts[0], "state_dict_adapter", None)
+    _has_split_expert_mixin = isinstance(adapter, MoESplitExpertsStateDictMixin)
+    _uses_v5_target_parameters = bool(
+        _has_split_expert_mixin and not v4_compatible and adapter._v5_peft_target_parameters
     )
-    _skip_for_qwen3 = not v4_compatible and _is_qwen3_moe(model_parts[0])
-    if _has_split_expert_mixin and not _skip_for_qwen3:
+    if _has_split_expert_mixin and not _uses_v5_target_parameters:
         seen_expert_groups: set[tuple[str, str]] = set()
         for _mp in model_parts:
             for name, param in _mp.named_parameters():

--- a/nemo_automodel/components/models/nemotron_v3/state_dict_adapter.py
+++ b/nemo_automodel/components/models/nemotron_v3/state_dict_adapter.py
@@ -118,6 +118,18 @@ class NemotronV3StateDictAdapter(MoESplitExpertsStateDictMixin, StateDictAdapter
         """NemotronV3 uses 'mixer.experts' instead of 'mlp.experts'."""
         return "mixer.experts"
 
+    @staticmethod
+    def _native_key_to_hf(key: str) -> str:
+        """Normalize a native Nemotron V3 key to its public HF namespace."""
+        key = _strip_mamba_fp32_holder_key(key)
+        if key.startswith("model."):
+            key = "backbone." + key[len("model.") :]
+        if key == "backbone.norm.weight":
+            key = "backbone.norm_f.weight"
+        if key == "backbone.embed_tokens.weight":
+            key = "backbone.embeddings.weight"
+        return key
+
     def to_hf(self, state_dict: dict[str, Any], exclude_key_regex: Optional[str] = None, **kwargs) -> dict[str, Any]:
         """Convert from internal model state dict to HuggingFace format.
 
@@ -255,23 +267,12 @@ class NemotronV3StateDictAdapter(MoESplitExpertsStateDictMixin, StateDictAdapter
         # Try to convert merged expert weights to split experts
         expert_result = self._convert_single_merged_expert_to_hf_split_experts(fqn, tensor, **kwargs)
         if expert_result is not None:
-            result = expert_result
+            # The shared expert converter preserves the native input prefix for
+            # LoRA keys. Route every result through Nemotron's adapter-specific
+            # model -> backbone normalization just like ordinary tensors.
+            result = [(self._native_key_to_hf(key), value) for key, value in expert_result]
         else:
-            # Standard conversion: just rename keys
-            new_fqn = _strip_mamba_fp32_holder_key(fqn)
-
-            # Rename model → backbone
-            if new_fqn.startswith("model."):
-                new_fqn = "backbone." + new_fqn[len("model.") :]
-
-            # Rename norm → norm_f
-            if new_fqn == "backbone.norm.weight":
-                new_fqn = "backbone.norm_f.weight"
-
-            # Internal uses 'embed_tokens' but HF uses 'embeddings'
-            if new_fqn == "backbone.embed_tokens.weight":
-                new_fqn = "backbone.embeddings.weight"
-
+            new_fqn = self._native_key_to_hf(fqn)
             result = [(new_fqn, _upcast_mamba_fp32_state_tensor(new_fqn, tensor))]
 
         if exclude_key_regex:

--- a/nemo_automodel/components/models/qwen3_moe/state_dict_adapter.py
+++ b/nemo_automodel/components/models/qwen3_moe/state_dict_adapter.py
@@ -56,6 +56,11 @@ class Qwen3MoeStateDictAdapter(MoESplitExpertsStateDictMixin, StateDictAdapter):
         self.dtype = dtype
         self._uses_model_prefix = True
 
+    @property
+    def _v5_peft_target_parameters(self) -> tuple[str, ...]:
+        """Qwen3 MoE is validated for fused PEFT v5 ParamWrapper export."""
+        return ("mlp.experts.gate_up_proj", "mlp.experts.down_proj")
+
     def to_hf(
         self, state_dict: dict[str, Any], exclude_key_regex: Optional[str] = None, quantization: bool = False, **kwargs
     ) -> dict[str, Any]:
@@ -111,60 +116,6 @@ class Qwen3MoeStateDictAdapter(MoESplitExpertsStateDictMixin, StateDictAdapter):
 
         return result
 
-    def _convert_lora_to_paramwrapper(self, fqn: str, tensor: torch.Tensor) -> list[tuple[str, torch.Tensor]]:
-        """Convert a single grouped MoE LoRA tensor to PEFT ParamWrapper format.
-
-        ParamWrapper format stores fused 3-D expert LoRA parameters as 2-D
-        tensors with the expert dimension folded into the rank dimension.
-
-        Shape mapping (automodel native -> ParamWrapper):
-
-        down_proj (outer wrapper, NO ``base_layer`` prefix — processed first alphabetically):
-          - ``lora_down_B``  (E, r, H) -> ``lora_A.weight``  (r*E, H)  reshape
-          - ``lora_down_A``  (E, I, r) -> ``lora_B.weight``  (I, r*E)  permute+reshape
-
-        gate_up_proj (inner wrapper, HAS ``base_layer.`` prefix):
-          - ``lora_gate_and_up_B``  (E, r, 2*I) -> ``base_layer.lora_A.weight``  (r*E, 2*I)  reshape
-          - ``lora_gate_and_up_A``  (E, H, r)   -> ``base_layer.lora_B.weight``  (H, r*E)    permute+reshape
-
-        Returns:
-            List containing one ``(fqn, tensor)`` tuple in ParamWrapper format.
-        """
-        match = re.search(r"(.*)layers\.(\d+)\.", fqn)
-        if not match:
-            return [(fqn, tensor)]
-
-        prefix = match.group(1)
-        layer_num = match.group(2)
-        expert_segment = self._expert_path_segment
-        suffix = fqn.rsplit(".", 1)[-1]
-
-        # PEFT ParamWrapper nesting: target_parameters are sorted alphabetically
-        # and wrapped in order. The FIRST wrapped becomes the OUTER ParamWrapper.
-        # "down_proj" < "gate_up_proj", so down_proj is outer (no base_layer prefix)
-        # and gate_up_proj is inner (has base_layer prefix).
-        if suffix == "lora_gate_and_up_B":
-            # (E, r, 2*I) -> (r*E, 2*I)
-            out = tensor.reshape(-1, tensor.shape[2]).contiguous()
-            pw_suffix = "base_layer.lora_A.weight"
-        elif suffix == "lora_gate_and_up_A":
-            # (E, H, r) -> permute(1,2,0) -> (H, r, E) -> (H, r*E)
-            out = tensor.permute(1, 2, 0).contiguous().reshape(tensor.shape[1], -1)
-            pw_suffix = "base_layer.lora_B.weight"
-        elif suffix == "lora_down_B":
-            # (E, r, H) -> (r*E, H)
-            out = tensor.reshape(-1, tensor.shape[2]).contiguous()
-            pw_suffix = "lora_A.weight"
-        elif suffix == "lora_down_A":
-            # (E, I, r) -> permute(1,2,0) -> (I, r, E) -> (I, r*E)
-            out = tensor.permute(1, 2, 0).contiguous().reshape(tensor.shape[1], -1)
-            pw_suffix = "lora_B.weight"
-        else:
-            return [(fqn, tensor)]
-
-        out_fqn = f"{prefix}layers.{layer_num}.{expert_segment}.{pw_suffix}"
-        return [(out_fqn, out)]
-
     def from_hf(
         self,
         hf_state_dict: dict[str, Any],
@@ -188,77 +139,3 @@ class Qwen3MoeStateDictAdapter(MoESplitExpertsStateDictMixin, StateDictAdapter):
         hf_state_dict = self._convert_paramwrapper_to_native(hf_state_dict)
 
         return self._from_hf_w_merged_experts(hf_state_dict, device_mesh)
-
-    def _convert_paramwrapper_to_native(self, state_dict: dict[str, Any]) -> dict[str, Any]:
-        """Convert PEFT ParamWrapper LoRA keys to native grouped MoE LoRA format.
-
-        This is the reverse of ``_convert_lora_to_paramwrapper``.  It detects
-        ParamWrapper-format keys and converts them back to the 3-D grouped
-        tensors expected by GroupedExpertsLoRA.
-
-        Reverse transforms (down_proj is outer, gate_up_proj is inner):
-          - ``experts.lora_A.weight``            (r*E, H)   -> (E, r, H)    = lora_down_B
-          - ``experts.lora_B.weight``            (I, r*E)   -> (E, I, r)    = lora_down_A
-          - ``experts.base_layer.lora_A.weight`` (r*E, 2*I) -> (E, r, 2*I)  = lora_gate_and_up_B
-          - ``experts.base_layer.lora_B.weight`` (H, r*E)   -> (E, H, r)    = lora_gate_and_up_A
-        """
-        expert_segment = re.escape(self._expert_path_segment)
-        n_experts = self.moe_config.n_routed_experts
-
-        # Detect ParamWrapper keys
-        pw_pattern = re.compile(
-            rf"(?P<prefix>.*)layers\.(?P<layer>\d+)\.{expert_segment}\."
-            rf"(?P<pw_suffix>(?:base_layer\.)?lora_[AB]\.weight)$"
-        )
-
-        consumed_keys: set[str] = set()
-        new_entries: dict[str, torch.Tensor] = {}
-
-        for key, tensor in state_dict.items():
-            m = pw_pattern.match(key)
-            if m is None:
-                continue
-
-            pw_suffix = m.group("pw_suffix")
-            # Preserve the full prefix from the input key (e.g. "base_model.model.model.")
-            # so downstream prefix stripping (_drop_outer_prefix) works correctly.
-            prefix = m.group("prefix")
-            layer_num = m.group("layer")
-            base_key = f"{prefix}layers.{layer_num}.{self._expert_path_segment}"
-
-            # down_proj is outer (no base_layer), gate_up_proj is inner (base_layer)
-            if pw_suffix == "lora_A.weight":
-                # (r*E, H) -> (E, r, H) = lora_down_B
-                r = tensor.shape[0] // n_experts
-                out = tensor.reshape(n_experts, r, tensor.shape[1]).contiguous()
-                new_entries[f"{base_key}.lora_down_B"] = out
-
-            elif pw_suffix == "lora_B.weight":
-                # (I, r*E) -> reshape (I, r, E) -> permute(2,0,1) -> (E, I, r) = lora_down_A
-                r = tensor.shape[1] // n_experts
-                out = tensor.reshape(tensor.shape[0], r, n_experts).permute(2, 0, 1).contiguous()
-                new_entries[f"{base_key}.lora_down_A"] = out
-
-            elif pw_suffix == "base_layer.lora_A.weight":
-                # (r*E, 2*I) -> (E, r, 2*I) = lora_gate_and_up_B
-                r = tensor.shape[0] // n_experts
-                out = tensor.reshape(n_experts, r, tensor.shape[1]).contiguous()
-                new_entries[f"{base_key}.lora_gate_and_up_B"] = out
-
-            elif pw_suffix == "base_layer.lora_B.weight":
-                # (H, r*E) -> reshape (H, r, E) -> permute(2,0,1) -> (E, H, r) = lora_gate_and_up_A
-                r = tensor.shape[1] // n_experts
-                out = tensor.reshape(tensor.shape[0], r, n_experts).permute(2, 0, 1).contiguous()
-                new_entries[f"{base_key}.lora_gate_and_up_A"] = out
-
-            else:
-                continue
-
-            consumed_keys.add(key)
-
-        if not consumed_keys:
-            return state_dict
-
-        result = {k: v for k, v in state_dict.items() if k not in consumed_keys}
-        result.update(new_entries)
-        return result

--- a/nemo_automodel/components/moe/state_dict_mixin.py
+++ b/nemo_automodel/components/moe/state_dict_mixin.py
@@ -28,6 +28,9 @@ from nemo_automodel.components.moe.state_dict_utils import (
     split_experts_weights_dtensor_aware,
 )
 
+# Native LoRA suffixes for grouped MoE expert tensors
+_LORA_EXPERT_SUFFIXES = ("lora_gate_and_up_A", "lora_gate_and_up_B", "lora_down_A", "lora_down_B")
+
 
 class MoESplitExpertsStateDictMixin:
     """Mixin class providing MoE state dict conversion utilities.
@@ -95,6 +98,17 @@ class MoESplitExpertsStateDictMixin:
     def _expert_path_segment(self) -> str:
         """Path segment for experts (e.g., 'mlp.experts' or 'mixer.experts'). Override in subclass."""
         return "mlp.experts"
+
+    @property
+    def _v5_peft_target_parameters(self) -> tuple[str, ...]:
+        """Fused expert parameters validated for PEFT v5 ParamWrapper export.
+
+        Adapters opt in by overriding this property. Keeping the default empty
+        preserves the legacy per-expert export for model families whose HF
+        naming, activation layout, or checkpoint post-processing has not been
+        validated against ParamWrapper yet.
+        """
+        return ()
 
     def _validate_expert_availability(
         self,
@@ -245,6 +259,134 @@ class MoESplitExpertsStateDictMixin:
                     return stacked_tensor
 
         return None
+
+    def _convert_lora_to_paramwrapper(self, fqn: str, tensor: torch.Tensor) -> list[tuple[str, torch.Tensor]]:
+        """Convert a single grouped MoE LoRA tensor to PEFT ParamWrapper format.
+
+        ParamWrapper format stores fused 3-D expert LoRA parameters as 2-D
+        tensors with the expert dimension folded into the rank dimension.
+
+        Shape mapping (automodel native -> ParamWrapper):
+
+        down_proj (outer wrapper, NO ``base_layer`` prefix — processed first alphabetically):
+          - ``lora_down_B``  (E, r, H) -> ``lora_A.weight``  (r*E, H)  reshape
+          - ``lora_down_A``  (E, I, r) -> ``lora_B.weight``  (I, r*E)  permute+reshape
+
+        gate_up_proj (inner wrapper, HAS ``base_layer.`` prefix):
+          - ``lora_gate_and_up_B``  (E, r, 2*I) -> ``base_layer.lora_A.weight``  (r*E, 2*I)  reshape
+          - ``lora_gate_and_up_A``  (E, H, r)   -> ``base_layer.lora_B.weight``  (H, r*E)    permute+reshape
+
+        Returns:
+            List containing one ``(fqn, tensor)`` tuple in ParamWrapper format.
+        """
+        match = re.search(r"(.*)layers\.(\d+)\.", fqn)
+        if not match:
+            return [(fqn, tensor)]
+
+        prefix = match.group(1)
+        layer_num = match.group(2)
+        expert_segment = self._expert_path_segment
+        suffix = fqn.rsplit(".", 1)[-1]
+
+        # PEFT ParamWrapper nesting: target_parameters are sorted alphabetically
+        # and wrapped in order. The FIRST wrapped becomes the OUTER ParamWrapper.
+        # "down_proj" < "gate_up_proj", so down_proj is outer (no base_layer prefix)
+        # and gate_up_proj is inner (has base_layer prefix).
+        if suffix == "lora_gate_and_up_B":
+            # (E, r, 2*I) -> (r*E, 2*I)
+            out = tensor.reshape(-1, tensor.shape[2]).contiguous()
+            pw_suffix = "base_layer.lora_A.weight"
+        elif suffix == "lora_gate_and_up_A":
+            # (E, H, r) -> permute(1,2,0) -> (H, r, E) -> (H, r*E)
+            out = tensor.permute(1, 2, 0).contiguous().reshape(tensor.shape[1], -1)
+            pw_suffix = "base_layer.lora_B.weight"
+        elif suffix == "lora_down_B":
+            # (E, r, H) -> (r*E, H)
+            out = tensor.reshape(-1, tensor.shape[2]).contiguous()
+            pw_suffix = "lora_A.weight"
+        elif suffix == "lora_down_A":
+            # (E, I, r) -> permute(1,2,0) -> (I, r, E) -> (I, r*E)
+            out = tensor.permute(1, 2, 0).contiguous().reshape(tensor.shape[1], -1)
+            pw_suffix = "lora_B.weight"
+        else:
+            return [(fqn, tensor)]
+
+        out_fqn = f"{prefix}layers.{layer_num}.{expert_segment}.{pw_suffix}"
+        return [(out_fqn, out)]
+
+    def _convert_paramwrapper_to_native(self, state_dict: dict[str, Any]) -> dict[str, Any]:
+        """Convert PEFT ParamWrapper LoRA keys to native grouped MoE LoRA format.
+
+        This is the reverse of ``_convert_lora_to_paramwrapper``.  It detects
+        ParamWrapper-format keys and converts them back to the 3-D grouped
+        tensors expected by GroupedExpertsLoRA.
+
+        Reverse transforms (down_proj is outer, gate_up_proj is inner):
+          - ``experts.lora_A.weight``            (r*E, H)   -> (E, r, H)    = lora_down_B
+          - ``experts.lora_B.weight``            (I, r*E)   -> (E, I, r)    = lora_down_A
+          - ``experts.base_layer.lora_A.weight`` (r*E, 2*I) -> (E, r, 2*I)  = lora_gate_and_up_B
+          - ``experts.base_layer.lora_B.weight`` (H, r*E)   -> (E, H, r)    = lora_gate_and_up_A
+        """
+        expert_segment = re.escape(self._expert_path_segment)
+        n_experts = self.moe_config.n_routed_experts
+
+        # Detect ParamWrapper keys
+        pw_pattern = re.compile(
+            rf"(?P<prefix>.*)layers\.(?P<layer>\d+)\.{expert_segment}\."
+            rf"(?P<pw_suffix>(?:base_layer\.)?lora_[AB]\.weight)$"
+        )
+
+        consumed_keys: set[str] = set()
+        new_entries: dict[str, torch.Tensor] = {}
+
+        for key, tensor in state_dict.items():
+            m = pw_pattern.match(key)
+            if m is None:
+                continue
+
+            pw_suffix = m.group("pw_suffix")
+            # Preserve the full prefix from the input key (e.g. "base_model.model.model.")
+            # so downstream prefix stripping (_drop_outer_prefix) works correctly.
+            prefix = m.group("prefix")
+            layer_num = m.group("layer")
+            base_key = f"{prefix}layers.{layer_num}.{self._expert_path_segment}"
+
+            # down_proj is outer (no base_layer), gate_up_proj is inner (base_layer)
+            if pw_suffix == "lora_A.weight":
+                # (r*E, H) -> (E, r, H) = lora_down_B
+                r = tensor.shape[0] // n_experts
+                out = tensor.reshape(n_experts, r, tensor.shape[1]).contiguous()
+                new_entries[f"{base_key}.lora_down_B"] = out
+
+            elif pw_suffix == "lora_B.weight":
+                # (I, r*E) -> reshape (I, r, E) -> permute(2,0,1) -> (E, I, r) = lora_down_A
+                r = tensor.shape[1] // n_experts
+                out = tensor.reshape(tensor.shape[0], r, n_experts).permute(2, 0, 1).contiguous()
+                new_entries[f"{base_key}.lora_down_A"] = out
+
+            elif pw_suffix == "base_layer.lora_A.weight":
+                # (r*E, 2*I) -> (E, r, 2*I) = lora_gate_and_up_B
+                r = tensor.shape[0] // n_experts
+                out = tensor.reshape(n_experts, r, tensor.shape[1]).contiguous()
+                new_entries[f"{base_key}.lora_gate_and_up_B"] = out
+
+            elif pw_suffix == "base_layer.lora_B.weight":
+                # (H, r*E) -> reshape (H, r, E) -> permute(2,0,1) -> (E, H, r) = lora_gate_and_up_A
+                r = tensor.shape[1] // n_experts
+                out = tensor.reshape(tensor.shape[0], r, n_experts).permute(2, 0, 1).contiguous()
+                new_entries[f"{base_key}.lora_gate_and_up_A"] = out
+
+            else:
+                continue
+
+            consumed_keys.add(key)
+
+        if not consumed_keys:
+            return state_dict
+
+        result = {k: v for k, v in state_dict.items() if k not in consumed_keys}
+        result.update(new_entries)
+        return result
 
     def _convert_lora_expert_to_hf(
         self,
@@ -611,6 +753,9 @@ class MoESplitExpertsStateDictMixin:
         # Recombine any per-expert HF LoRA keys back to grouped format
         state_dict = self._recombine_lora_expert_keys(state_dict)
 
+        # Convert any ParamWrapper-format LoRA keys to native grouped format
+        state_dict = self._convert_paramwrapper_to_native(state_dict)
+
         return state_dict
 
     def _convert_single_merged_expert_to_hf_split_experts(
@@ -759,11 +904,16 @@ class MoESplitExpertsStateDictMixin:
                 torch.cuda.empty_cache()
             return result
 
-        # MoE expert LoRA keys: split grouped 3-D adapter tensors into per-expert
-        # HF-PEFT-compatible keys so that AutoPeftModelForCausalLM can load & merge.
-        _LORA_EXPERT_SUFFIXES = ("lora_gate_and_up_A", "lora_gate_and_up_B", "lora_down_A", "lora_down_B")
+        # MoE expert LoRA keys: convert to HF-PEFT-compatible format.
+        # When v4_compatible=True: per-expert split keys (v4 format).
+        # When v4_compatible=False and the adapter explicitly opts in: fused
+        # ParamWrapper format (v5). Unvalidated adapters retain the legacy
+        # per-expert format even when v4_compatible is not requested.
+        v4_compatible = kwargs.get("v4_compatible", False)
         for suffix in _LORA_EXPERT_SUFFIXES:
             if f".{expert_segment}.{suffix}" in fqn and fqn.endswith(f".{suffix}"):
+                if not v4_compatible and self._v5_peft_target_parameters:
+                    return self._convert_lora_to_paramwrapper(fqn, tensor)
                 return self._convert_lora_expert_to_hf(fqn, tensor, n_experts, inter_dim, expert_segment)
 
         return None

--- a/tests/functional_tests/hf_peft/test_merge_lora.py
+++ b/tests/functional_tests/hf_peft/test_merge_lora.py
@@ -376,7 +376,10 @@ def _convert_grouped_to_hf_peft(grouped_sd):
     adapter = _Adapter()
     hf_sd = {}
     for fqn, tensor in grouped_sd.items():
-        converted = adapter._convert_single_merged_expert_to_hf_split_experts(fqn, tensor)
+        # This helper exercises the legacy per-expert HF PEFT path. The
+        # production default is the fused transformers v5 ParamWrapper format,
+        # so keep the compatibility mode explicit here.
+        converted = adapter._convert_single_merged_expert_to_hf_split_experts(fqn, tensor, v4_compatible=True)
         if converted:
             for k, v in converted:
                 hf_sd[k] = v

--- a/tests/unit_tests/models/nemotron_v3/test_nemotron_v3_state_dict_adapter.py
+++ b/tests/unit_tests/models/nemotron_v3/test_nemotron_v3_state_dict_adapter.py
@@ -554,6 +554,17 @@ class TestNemotronV3AdapterMixerExperts:
 
         assert adapter._expert_path_segment == "mixer.experts"
 
+    def test_default_lora_export_stays_legacy_for_non_gated_experts(self, config, moe_config, backend):
+        """Nemotron V3 must emit its real up_proj path until v5 is validated."""
+        adapter = NemotronV3StateDictAdapter(config, moe_config, backend)
+        tensor = torch.randn(moe_config.n_routed_experts, moe_config.dim, 8)
+
+        result = adapter.convert_single_tensor_to_hf("model.layers.0.mixer.experts.lora_gate_and_up_A", tensor)
+
+        keys = {key for key, _ in result}
+        assert "backbone.layers.0.mixer.experts.0.up_proj.lora_A.weight" in keys
+        assert not any("gate_up_proj" in key or "base_layer.lora_A.weight" in key for key in keys)
+
     def test_from_hf_uses_mixer_experts_path(self, config, moe_config, backend):
         """Test that from_hf correctly parses mixer.experts paths."""
         adapter = NemotronV3StateDictAdapter(config, moe_config, backend)

--- a/tests/unit_tests/moe/test_moe_lora_state_dict.py
+++ b/tests/unit_tests/moe/test_moe_lora_state_dict.py
@@ -18,12 +18,17 @@ Verifies that GroupedExpertsLoRA adapter weights are correctly converted to
 per-expert HF PEFT format and back, enabling merge via AutoPeftModelForCausalLM.
 """
 
+import re
+
 import pytest
 import torch
 import torch.nn as nn
 
 from nemo_automodel.components._peft.lora import PeftConfig, apply_lora_to_linear_modules
-from nemo_automodel.components.checkpoint.addons import _extract_target_modules
+from nemo_automodel.components.checkpoint.addons import (
+    _extract_target_modules,
+    _extract_target_parameters,
+)
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.layers import GroupedExperts
 from nemo_automodel.components.moe.state_dict_mixin import MoESplitExpertsStateDictMixin
@@ -57,6 +62,18 @@ class _Adapter(MoESplitExpertsStateDictMixin):
         self.dtype = torch.float32
         self._uses_model_prefix = uses_model_prefix
         self._last_expert_ids = []
+
+    @property
+    def _v5_peft_target_parameters(self):
+        return ("mlp.experts.gate_up_proj", "mlp.experts.down_proj")
+
+
+class _LegacyAdapter(_Adapter):
+    """Representative unvalidated adapter that must retain v4-style export."""
+
+    @property
+    def _v5_peft_target_parameters(self):
+        return ()
 
 
 def _make_moe_config():
@@ -139,7 +156,7 @@ class TestMoELoRAToHF:
         tensor = torch.randn(N_EXPERTS, DIM, LORA_DIM)
         fqn = "model.layers.0.mlp.experts.lora_gate_and_up_A"
 
-        result = adapter._convert_single_merged_expert_to_hf_split_experts(fqn, tensor)
+        result = adapter._convert_single_merged_expert_to_hf_split_experts(fqn, tensor, v4_compatible=True)
 
         assert result is not None
         keys = [k for k, _ in result]
@@ -153,7 +170,7 @@ class TestMoELoRAToHF:
         tensor = torch.randn(N_EXPERTS, DIM, LORA_DIM)
         fqn = "model.layers.0.mlp.experts.lora_gate_and_up_A"
 
-        result = dict(adapter._convert_single_merged_expert_to_hf_split_experts(fqn, tensor))
+        result = dict(adapter._convert_single_merged_expert_to_hf_split_experts(fqn, tensor, v4_compatible=True))
 
         for eid in range(N_EXPERTS):
             gate_A = result[f"model.layers.0.mlp.experts.{eid}.gate_proj.lora_A.weight"]
@@ -171,7 +188,7 @@ class TestMoELoRAToHF:
         tensor = torch.randn(N_EXPERTS, LORA_DIM, 2 * MOE_INTER_DIM)
         fqn = "model.layers.0.mlp.experts.lora_gate_and_up_B"
 
-        result = dict(adapter._convert_single_merged_expert_to_hf_split_experts(fqn, tensor))
+        result = dict(adapter._convert_single_merged_expert_to_hf_split_experts(fqn, tensor, v4_compatible=True))
 
         for eid in range(N_EXPERTS):
             gate_B = result[f"model.layers.0.mlp.experts.{eid}.gate_proj.lora_B.weight"]
@@ -187,7 +204,7 @@ class TestMoELoRAToHF:
         tensor = torch.randn(N_EXPERTS, MOE_INTER_DIM, LORA_DIM)
         fqn = "model.layers.0.mlp.experts.lora_down_A"
 
-        result = dict(adapter._convert_single_merged_expert_to_hf_split_experts(fqn, tensor))
+        result = dict(adapter._convert_single_merged_expert_to_hf_split_experts(fqn, tensor, v4_compatible=True))
 
         for eid in range(N_EXPERTS):
             down_A = result[f"model.layers.0.mlp.experts.{eid}.down_proj.lora_A.weight"]
@@ -199,7 +216,7 @@ class TestMoELoRAToHF:
         tensor = torch.randn(N_EXPERTS, LORA_DIM, DIM)
         fqn = "model.layers.0.mlp.experts.lora_down_B"
 
-        result = dict(adapter._convert_single_merged_expert_to_hf_split_experts(fqn, tensor))
+        result = dict(adapter._convert_single_merged_expert_to_hf_split_experts(fqn, tensor, v4_compatible=True))
 
         for eid in range(N_EXPERTS):
             down_B = result[f"model.layers.0.mlp.experts.{eid}.down_proj.lora_B.weight"]
@@ -212,7 +229,7 @@ class TestMoELoRAToHF:
         tensor = torch.randn(N_EXPERTS, DIM, LORA_DIM)
         fqn = "base_model.model.model.layers.0.mlp.experts.lora_gate_and_up_A"
 
-        result = dict(adapter._convert_single_merged_expert_to_hf_split_experts(fqn, tensor))
+        result = dict(adapter._convert_single_merged_expert_to_hf_split_experts(fqn, tensor, v4_compatible=True))
 
         assert "base_model.model.model.layers.0.mlp.experts.0.gate_proj.lora_A.weight" in result
 
@@ -236,14 +253,18 @@ class TestMoELoRAToHF:
 class TestMoELoRAFromHF:
     """Verify _recombine_lora_expert_keys correctly recombines per-expert LoRA keys."""
 
-    def test_round_trip_lora_gate_and_up_A(self):
+    def test_round_trip_lora_gate_and_up_A_v4(self):
         adapter = _Adapter()
         original = torch.randn(N_EXPERTS, DIM, LORA_DIM)
 
-        # to_hf
-        hf = dict(adapter._convert_single_merged_expert_to_hf_split_experts(
-            "model.layers.0.mlp.experts.lora_gate_and_up_A", original,
-        ))
+        # to_hf (v4 mode)
+        hf = dict(
+            adapter._convert_single_merged_expert_to_hf_split_experts(
+                "model.layers.0.mlp.experts.lora_gate_and_up_A",
+                original,
+                v4_compatible=True,
+            )
+        )
 
         # from_hf
         result = adapter._recombine_lora_expert_keys(hf)
@@ -252,13 +273,17 @@ class TestMoELoRAFromHF:
         assert key in result
         torch.testing.assert_close(result[key], original)
 
-    def test_round_trip_lora_gate_and_up_B(self):
+    def test_round_trip_lora_gate_and_up_B_v4(self):
         adapter = _Adapter()
         original = torch.randn(N_EXPERTS, LORA_DIM, 2 * MOE_INTER_DIM)
 
-        hf = dict(adapter._convert_single_merged_expert_to_hf_split_experts(
-            "model.layers.0.mlp.experts.lora_gate_and_up_B", original,
-        ))
+        hf = dict(
+            adapter._convert_single_merged_expert_to_hf_split_experts(
+                "model.layers.0.mlp.experts.lora_gate_and_up_B",
+                original,
+                v4_compatible=True,
+            )
+        )
 
         result = adapter._recombine_lora_expert_keys(hf)
 
@@ -266,13 +291,17 @@ class TestMoELoRAFromHF:
         assert key in result
         torch.testing.assert_close(result[key], original)
 
-    def test_round_trip_lora_down_A(self):
+    def test_round_trip_lora_down_A_v4(self):
         adapter = _Adapter()
         original = torch.randn(N_EXPERTS, MOE_INTER_DIM, LORA_DIM)
 
-        hf = dict(adapter._convert_single_merged_expert_to_hf_split_experts(
-            "model.layers.0.mlp.experts.lora_down_A", original,
-        ))
+        hf = dict(
+            adapter._convert_single_merged_expert_to_hf_split_experts(
+                "model.layers.0.mlp.experts.lora_down_A",
+                original,
+                v4_compatible=True,
+            )
+        )
 
         result = adapter._recombine_lora_expert_keys(hf)
 
@@ -280,13 +309,17 @@ class TestMoELoRAFromHF:
         assert key in result
         torch.testing.assert_close(result[key], original)
 
-    def test_round_trip_lora_down_B(self):
+    def test_round_trip_lora_down_B_v4(self):
         adapter = _Adapter()
         original = torch.randn(N_EXPERTS, LORA_DIM, DIM)
 
-        hf = dict(adapter._convert_single_merged_expert_to_hf_split_experts(
-            "model.layers.0.mlp.experts.lora_down_B", original,
-        ))
+        hf = dict(
+            adapter._convert_single_merged_expert_to_hf_split_experts(
+                "model.layers.0.mlp.experts.lora_down_B",
+                original,
+                v4_compatible=True,
+            )
+        )
 
         result = adapter._recombine_lora_expert_keys(hf)
 
@@ -294,15 +327,15 @@ class TestMoELoRAFromHF:
         assert key in result
         torch.testing.assert_close(result[key], original)
 
-    def test_round_trip_all_lora_keys_with_prefix(self):
-        """Full round-trip for all 4 LoRA parameter types, with PEFT prefix."""
+    def test_round_trip_all_lora_keys_with_prefix_v4(self):
+        """Full round-trip for all 4 LoRA parameter types, with PEFT prefix (v4 mode)."""
         adapter = _Adapter()
         original = _make_grouped_lora_state_dict(prefix="base_model.model.")
 
-        # to_hf: convert all keys
+        # to_hf: convert all keys (v4 mode)
         hf_sd = {}
         for fqn, tensor in original.items():
-            converted = adapter._convert_single_merged_expert_to_hf_split_experts(fqn, tensor)
+            converted = adapter._convert_single_merged_expert_to_hf_split_experts(fqn, tensor, v4_compatible=True)
             if converted:
                 for k, v in converted:
                     hf_sd[k] = v
@@ -322,6 +355,33 @@ class TestMoELoRAFromHF:
         # Verify all original keys are restored
         for k, v in original.items():
             assert k in result, f"Missing key after round-trip: {k}"
+            torch.testing.assert_close(result[k], v, msg=f"Value mismatch for {k}")
+
+    def test_round_trip_v5_paramwrapper(self):
+        """Test v5 ParamWrapper round-trip for all 4 LoRA types."""
+        adapter = _Adapter()
+        original = _make_grouped_lora_state_dict(prefix="base_model.model.")
+
+        # to_hf: convert to ParamWrapper (v5) format
+        pw_sd = {}
+        for fqn, tensor in original.items():
+            converted = adapter._convert_single_merged_expert_to_hf_split_experts(fqn, tensor, v4_compatible=False)
+            if converted:
+                for k, v in converted:
+                    pw_sd[k] = v
+            else:
+                pw_sd[fqn] = tensor
+
+        # Verify ParamWrapper format: keys use lora_[AB].weight pattern
+        for fqn in pw_sd:
+            assert "lora_A.weight" in fqn or "lora_B.weight" in fqn, f"Unexpected key: {fqn}"
+
+        # from_hf: convert back (via _convert_paramwrapper_to_native)
+        result = adapter._convert_paramwrapper_to_native(pw_sd)
+
+        # Verify all original keys are restored
+        for k, v in original.items():
+            assert k in result, f"Missing key after v5 round-trip: {k}"
             torch.testing.assert_close(result[k], v, msg=f"Value mismatch for {k}")
 
     def test_passthrough_non_lora_keys(self):
@@ -359,10 +419,10 @@ class TestMoELoRAFromHF:
 class TestExtractTargetModulesWithMoELoRA:
     """Verify that _extract_target_modules includes per-expert HF module names."""
 
-    def test_includes_per_expert_projections(self):
+    def test_includes_per_expert_projections_v4(self):
         model = _make_tiny_moe_model()
 
-        target_modules = _extract_target_modules(model)
+        target_modules = _extract_target_modules(model, v4_compatible=True)
 
         for layer_idx in range(N_LAYERS):
             for eid in range(N_EXPERTS):
@@ -371,14 +431,90 @@ class TestExtractTargetModulesWithMoELoRA:
                 assert f"{base}.up_proj" in target_modules, f"Missing {base}.up_proj"
                 assert f"{base}.down_proj" in target_modules, f"Missing {base}.down_proj"
 
-    def test_no_grouped_lora_names_in_targets(self):
+    def test_no_grouped_lora_names_in_targets_v4(self):
         model = _make_tiny_moe_model()
 
-        target_modules = _extract_target_modules(model)
+        target_modules = _extract_target_modules(model, v4_compatible=True)
 
         for name in target_modules:
             assert "lora_gate_and_up" not in name
             assert "lora_down" not in name
+
+
+class TestExtractTargetsV5Defaults:
+    """v5 (``v4_compatible=False``) is the production default.
+
+    The v4 tests above all pass ``v4_compatible=True``, so the defaults that
+    actually ship were unasserted: ``target_parameters`` carries the fused
+    ParamWrapper paths and ``target_modules`` skips the per-expert expansion.
+    CPU-only — none of this touches a device.
+    """
+
+    def test_target_parameters_are_the_fused_expert_paths(self):
+        model = _make_tiny_moe_model()
+
+        assert _extract_target_parameters(model) == [
+            "mlp.experts.gate_up_proj",
+            "mlp.experts.down_proj",
+        ]
+
+    def test_target_parameters_empty_in_v4_mode(self):
+        """v4 expresses experts through target_modules instead."""
+        model = _make_tiny_moe_model()
+
+        assert _extract_target_parameters(model, v4_compatible=True) == []
+
+    def test_no_per_expert_expansion_in_v5(self):
+        """The v4 path emits layers.N.mlp.experts.<eid>.*; v5 must not."""
+        model = _make_tiny_moe_model()
+
+        target_modules = _extract_target_modules(model)
+
+        assert not [n for n in target_modules if re.search(r"experts\.\d+\.", n)]
+
+    def test_v4_and_v5_are_mutually_exclusive(self):
+        """Exactly one of the two mechanisms describes the experts."""
+        model = _make_tiny_moe_model()
+
+        v5_modules = _extract_target_modules(model)
+        v5_params = _extract_target_parameters(model)
+        v4_modules = _extract_target_modules(model, v4_compatible=True)
+        v4_params = _extract_target_parameters(model, v4_compatible=True)
+
+        assert v5_params and not v5_modules
+        assert v4_modules and not v4_params
+
+    def test_target_parameters_empty_without_a_moe_adapter(self):
+        """A non-MoE model must not gain fused expert paths."""
+        assert _extract_target_parameters(nn.Module()) == []
+
+    def test_accepts_a_list_of_pp_parts(self):
+        """Under PP the caller passes this rank's stages; the first is representative."""
+        model = _make_tiny_moe_model()
+
+        assert _extract_target_parameters([model]) == _extract_target_parameters(model)
+
+    def test_unvalidated_adapter_keeps_legacy_targets_by_default(self):
+        model = _make_tiny_moe_model()
+        model.state_dict_adapter = _LegacyAdapter()
+
+        assert _extract_target_parameters(model) == []
+        targets = _extract_target_modules(model)
+        assert "layers.0.mlp.experts.0.gate_proj" in targets
+        assert "layers.0.mlp.experts.0.up_proj" in targets
+        assert "layers.0.mlp.experts.0.down_proj" in targets
+
+    def test_unvalidated_adapter_keeps_legacy_state_dict_format_by_default(self):
+        adapter = _LegacyAdapter()
+        tensor = torch.randn(N_EXPERTS, DIM, LORA_DIM)
+
+        converted = adapter._convert_single_merged_expert_to_hf_split_experts(
+            "model.layers.0.mlp.experts.lora_gate_and_up_A", tensor
+        )
+
+        keys = {key for key, _ in converted}
+        assert "model.layers.0.mlp.experts.0.gate_proj.lora_A.weight" in keys
+        assert not any("base_layer.lora_A.weight" in key for key in keys)
 
 
 # ---------------------------------------------------------------------------
@@ -391,12 +527,20 @@ class TestExtractTargetModulesWithMoELoRA:
 # ---------------------------------------------------------------------------
 
 
-def _convert_grouped_to_hf(grouped_sd):
-    """Helper: convert a grouped LoRA state dict to per-expert HF format."""
+def _convert_grouped_to_hf(grouped_sd, v4_compatible=True):
+    """Helper: convert a grouped LoRA state dict to HF format.
+
+    Args:
+        grouped_sd: Grouped native LoRA state dict.
+        v4_compatible: If True, produce per-expert split format (v4).
+            If False, produce ParamWrapper fused format (v5).
+    """
     adapter_obj = _Adapter()
     hf_sd = {}
     for fqn, tensor in grouped_sd.items():
-        converted = adapter_obj._convert_single_merged_expert_to_hf_split_experts(fqn, tensor)
+        converted = adapter_obj._convert_single_merged_expert_to_hf_split_experts(
+            fqn, tensor, v4_compatible=v4_compatible
+        )
         if converted:
             for k, v in converted:
                 hf_sd[k] = v
@@ -437,6 +581,7 @@ def _make_hf_expert_model():
 def _write_adapter_dir(tmp_path, hf_lora_sd, lora_r, lora_alpha, target_modules):
     """Persist adapter_model.safetensors + adapter_config.json to *tmp_path*."""
     import json
+
     from safetensors.torch import save_file
 
     save_file(hf_lora_sd, str(tmp_path / "adapter_model.safetensors"))
@@ -523,8 +668,7 @@ class TestMoELoRASaveRestoreMergeHF:
 
         expected = N_LAYERS * N_EXPERTS * 3  # gate, up, down per expert
         assert changed == expected, (
-            f"Expected all {expected} expert weight tensors to change after merge, "
-            f"got {changed}"
+            f"Expected all {expected} expert weight tensors to change after merge, got {changed}"
         )
 
     # ---- test: merged weights equal base + B @ A * scale exactly ----


### PR DESCRIPTION
## Summary

Manual backport of NVIDIA-NeMo/Automodel#3284 to `r0.6.0`.

The automated backport workflow ran after merge but did not create a branch or  <br>PR. Its parser selected `#1755` from the source title's `fix(#1755)` scope  <br>instead of the trailing merged PR number `#3284`, queried `/pulls/1755`, and  <br>then exited successfully with `Nothing to cherry-pick`.

This draft cleanly cherry-picks source merge commit  <br>`14ef2e0a58255db1cc1fd942d7d1917e4b798cb6` with DCO signoff on top of current  <br>`r0.6.0` (`d89695e3e099a984aef2f39ce0e128a9da7776d4`). No conflict resolution or  <br>release-specific code changes were required.

## Changelog

* Backport shared MoE PEFT v5 ParamWrapper save/load conversion.
* Keep v5 export adapter-owned and opt-in, with Qwen3-MoE enabled.
* Preserve the legacy expert format for unvalidated MoE adapters.
* Backport Nemotron V3 expert-key namespace normalization and focused tests.

## Validation

* Focused MoE, Qwen3-MoE, Nemotron V3, and checkpoint-addon unit tests:  <br>`69 passed, 14 skipped`.
* Ruff format and lint checks passed for all changed production files.
* `git diff --check origin/r0.6.0...HEAD` passed.
* Source PR scoped checkpoint-robustness CI passed:  <br>[Qwen3-MoE LoRA](<https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/387389341>).
* Failed automation run for reference:  <br>[31144094106](<https://github.com/NVIDIA-NeMo/Automodel/actions/runs/31144094106>).

## Pre-checks

- [X] Read and followed the contributor guidelines.
- [X] Retained the source PR's tests unchanged.
- [X] No documentation changes are required for this release backport.

Source PR: NVIDIA-NeMo/Automodel#3284

Related to NVIDIA-NeMo/Automodel#1755