### PR TITLE
cp: backport Sentence Transformers metadata export to r0.6.0

### DIFF
--- a/docker/common/uv-pytorch.lock
+++ b/docker/common/uv-pytorch.lock
@@ -4225,6 +4225,7 @@ test = [
     { name = "pytest" },
     { name = "pytest-shard" },
     { name = "ruamel-yaml" },
+    { name = "sentence-transformers" },
 ]
 
 [package.metadata]
@@ -4344,6 +4345,7 @@ test = [
     { name = "pytest" },
     { name = "pytest-shard" },
     { name = "ruamel-yaml" },
+    { name = "sentence-transformers", specifier = ">=5.6.0" },
 ]
 
 [[package]]
@@ -6828,6 +6830,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/70/64b4d7ca92f9cf2e6fc6aaa2eecf80bb9b6b985043a9583f32f8177ea122/scipy-1.16.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ffa6eea95283b2b8079b821dc11f50a17d0571c92b43e2b5b12764dc5f9b285d", size = 38802779, upload-time = "2025-10-28T17:37:59.393Z" },
     { url = "https://files.pythonhosted.org/packages/61/82/8d0e39f62764cce5ffd5284131e109f07cf8955aef9ab8ed4e3aa5e30539/scipy-1.16.3-cp314-cp314t-win_amd64.whl", hash = "sha256:d9f48cafc7ce94cf9b15c6bffdc443a81a27bf7075cf2dcd5c8b40f85d10c4e7", size = 39471128, upload-time = "2025-10-28T17:38:05.259Z" },
     { url = "https://files.pythonhosted.org/packages/64/47/a494741db7280eae6dc033510c319e34d42dd41b7ac0c7ead39354d1a2b5/scipy-1.16.3-cp314-cp314t-win_arm64.whl", hash = "sha256:21d9d6b197227a12dcbf9633320a4e34c6b0e51c57268df255a0942983bac562", size = 26464127, upload-time = "2025-10-28T17:38:11.34Z" },
+]
+
+[[package]]
+name = "sentence-transformers"
+version = "5.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "scikit-learn" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "torch", marker = "sys_platform == 'never'" },
+    { name = "tqdm" },
+    { name = "transformers" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/56/d2cb00765a6b15c994a7fccf20f9032f16e8193ca49147cb5155166ad744/sentence_transformers-5.6.0.tar.gz", hash = "sha256:0e7164d051e416c1853ade7c274ff52af3f9da0f4be7f0b83d734c27699e1057", size = 453194, upload-time = "2026-06-16T14:01:56.42Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/c1/dc1582b79e9a2eb0cddf9559cd9bcdff084f541d6fe881fdd9d98630dba7/sentence_transformers-5.6.0-py3-none-any.whl", hash = "sha256:d2075b5e687a1611005e20ab04a6846994d51adfcf39610aed066af3c0c0b81f", size = 596411, upload-time = "2026-06-16T14:01:55.103Z" },
 ]
 
 [[package]]

--- a/docs/fern/versions/nightly.yml
+++ b/docs/fern/versions/nightly.yml
@@ -303,7 +303,7 @@ navigation:
           - page: "Llama (Bidirectional)"
             path: ../../model-coverage/embedding/nvidia/llama-bidirectional.mdx
             slug: llama-bidirectional
-          - page: "Ministral3 (Bidirectional)"
+          - page: "Ministral3"
             path: ../../model-coverage/embedding/mistralai/ministral3-bidirectional.mdx
             slug: ministral3-bidirectional
       - section: "Reranking Models"

--- a/docs/guides/llm/retrieval-finetune.mdx
+++ b/docs/guides/llm/retrieval-finetune.mdx
@@ -124,21 +124,23 @@ The following table summarizes the supported model families and their effective 
 | Model `config.model_type` | Bi-Encoder Behavior | Cross-Encoder Behavior | Effective Retrieval Keyword Arguments |
 |---------------------------|---------------------|------------------------|----------------------------|
 | `llama`, `llama_bidirec` | Uses `LlamaBidirectionalModel` | Uses `LlamaBidirectionalForSequenceClassification` | Bi-encoder: `pooling`, wrapper-level `l2_normalize`, and top-level recipe `temperature`. Cross-encoder: `pooling`, `num_labels`, and `temperature` on the Llama scoring config. |
-| `ministral3`, `ministral3_bidirec` | Uses `Ministral3BidirectionalModel` | Direct cross-encoder scoring is not supported by the custom retrieval registry today. Use a different direct cross-encoder backbone. | Bi-encoder: `pooling`, wrapper-level `l2_normalize`, and top-level recipe `temperature`. |
+| `ministral3` | Uses the stock Hugging Face `Ministral3Model` with `is_causal: false` | Uses the stock Hugging Face `Ministral3ForSequenceClassification` | Bi-encoder: wrapper-level `pooling` and `l2_normalize`, plus top-level recipe `temperature`. Cross-encoder: forwards `num_labels`; custom `pooling` and `temperature` are ignored. |
+| `ministral3_bidirec` | Uses the legacy custom `Ministral3BidirectionalModel` | Direct cross-encoder scoring is not supported by the custom retrieval registry. | Bi-encoder: `pooling`, wrapper-level `l2_normalize`, and top-level recipe `temperature`. |
 | `llama_nemotron_vl` | Uses `LlamaNemotronVLModel` | Direct cross-encoder scoring is not supported by the custom retrieval registry today. | Bi-encoder: `pooling`, wrapper-level `l2_normalize`, and top-level recipe `temperature`. |
-| Any model type without a retrieval registry entry | Falls back to `AutoModel` | Falls back to `AutoModelForSequenceClassification` | Bi-encoder fallback receives standard Hugging Face `from_pretrained` keyword arguments. `pooling` and `l2_normalize` still apply in the AutoModel wrapper. Cross-encoder fallback forwards only `num_labels`. Custom `pooling` and `temperature` are ignored. |
+| Any model type without a retrieval registry entry | Falls back to `AutoModel` and sets `config.is_causal: false` | Falls back to `AutoModelForSequenceClassification` | Bi-encoder fallback receives standard Hugging Face `from_pretrained` keyword arguments. `pooling` and `l2_normalize` still apply in the AutoModel wrapper. Cross-encoder fallback forwards only `num_labels`. Custom `pooling` and `temperature` are ignored. |
 
 Known model types with a registry entry fail fast when the requested retrieval task is unsupported rather than falling
-back silently. For example, direct `ministral3` loading is supported for bi-encoder embeddings but not for the
-cross-encoder scoring recipe. If you are extracting a text tower from a parent checkpoint, set
-`model.extract_submodel: language_model`. Extracted text backbones use the extraction path, where supported extracted
-types use registered retrieval classes and unsupported extracted types can fall back to Hugging Face sequence
-classification for cross-encoder scoring.
+back silently. For example, the legacy `ministral3_bidirec` type supports bi-encoder embeddings but not cross-encoder
+scoring. The stock `ministral3` type is not a custom registry entry, so it follows the Hugging Face fallback and supports
+both `Ministral3Model` embeddings and `Ministral3ForSequenceClassification` scoring. If you are extracting a text tower
+from a parent checkpoint, set `model.extract_submodel: language_model`. Extracted text backbones use the extraction path,
+where supported extracted types use registered retrieval classes and other extracted types can fall back to Hugging Face
+sequence classification for cross-encoder scoring.
 
-Treat unregistered decoder-only fallback models as an architecture experiment, not just a drop-in model swap. Registered
-retrieval backbones such as the Llama bidirectional path use retrieval-specific attention behavior. A vanilla
-Hugging Face `AutoModel` fallback can keep the source model's original causal behavior, which might be lower quality for
-symmetric embedding retrieval.
+Treat unregistered decoder-only fallback models as an architecture experiment, not just a drop-in model swap. AutoModel
+sets `config.is_causal: false` for embedding fallbacks, while registered retrieval backbones such as the Llama
+bidirectional path use retrieval-specific implementations. Confirm that an unregistered architecture honors the
+`is_causal` flag and produces the expected bidirectional attention before relying on it for symmetric retrieval.
 
 ## Prepare Data
 
@@ -354,11 +356,13 @@ dataloader:
 The following settings control bi-encoder behavior:
 
 - `pooling`: controls how token hidden states become one embedding. Common single-vector choices are `avg`, `cls`,
-  `last`, and `weighted_avg`. The shipped hard-negative miner currently loads the bi-encoder wrapper with its default
-  `avg` pooling and does not expose a mining override. Do not use it for a model trained with a different pooling mode or
-  with `colbert` pooling, which returns token-level embeddings.
+  `last`, and `weighted_avg`. The shipped hard-negative miner does not expose a pooling override. When a checkpoint
+  contains supported Sentence Transformers metadata, the miner restores the saved pooling mode. Otherwise, the loader
+  uses the backbone configuration or `avg`. Do not use the miner with `colbert` pooling, which returns token-level
+  embeddings.
 - `l2_normalize`: normalizes embeddings before scoring. When enabled, the recipe divides scores by `temperature`. The
-  shipped miner currently uses the bi-encoder wrapper default, `true`, and does not expose a mining override.
+  shipped miner does not expose a normalization override. When a checkpoint contains supported Sentence Transformers
+  metadata, the miner restores the saved normalization setting. Otherwise, the loader enables L2 normalization.
 - `q_max_len` and `p_max_len`: set separate truncation lengths for queries and passages.
 - `query_prefix` and `passage_prefix`: add task-specific text before tokenization. Keep these aligned between training,
   hard-negative mining, and inference.
@@ -678,9 +682,11 @@ Match these mining settings to training:
 - Set `use_negatives_from_file` when you want to keep existing negatives before appending mined negatives. Deduplicate
   and audit the combined list.
 
-The miner does not accept `pooling` or `l2_normalize` settings. It uses the bi-encoder wrapper defaults of `avg`
-pooling and L2 normalization. Use this helper only when those settings match training. For other settings, use a custom
-mining workflow that loads the encoder with the required wrapper arguments.
+The miner does not accept `pooling` or `l2_normalize` settings. It calls
+`NeMoAutoModelBiEncoder.from_pretrained` without those arguments. The loader restores pooling and normalization from
+supported Sentence Transformers checkpoint metadata. If the metadata is unavailable, pooling uses the backbone
+configuration or `avg`, and L2 normalization is enabled. Confirm that these fallback settings match training before
+mining from a legacy or external checkpoint.
 
 Use a new, empty `cache_embeddings_dir` for every model, input, prefix, sequence length, `corpus_chunk_size`, and world
 size. The miner reuses expected shard files even when `load_embeddings_from_cache` is `false`, and it does not record

--- a/docs/model-coverage/embedding/index.mdx
+++ b/docs/model-coverage/embedding/index.mdx
@@ -6,7 +6,7 @@ position: 1
 
 ## Introduction
 
-Text embedding models transform text into dense vector representations that power semantic search, dense retrieval, retrieval-augmented generation (RAG), and classification tasks. NeMo AutoModel includes a training recipe for converting Llama decoder-only models into encoder architectures with bidirectional attention, and falls back to Hugging Face AutoModel for other encoder backbones.
+Text embedding models transform text into dense vector representations that power semantic search, dense retrieval, retrieval-augmented generation (RAG), and classification tasks. NeMo AutoModel includes custom bidirectional backbones and configures supported Hugging Face `AutoModel` backbones with non-causal attention for retrieval training.
 
 For cross-encoder pairwise scoring, see [Reranking Models](/model-coverage/reranking-models/overview).
 
@@ -16,12 +16,15 @@ Embedding models use bi-encoders to produce dense representations for queries an
 
 | Owner | Model | Architecture | Auto Class | Tasks |
 |---|---|---|---|---|
-| NVIDIA | [Llama (Bidirectional)](/model-coverage/embedding-models/llama-bidirectional) | `LlamaBidirectionalModel` | [`NeMoAutoModelBiEncoder`](https://github.com/NVIDIA-NeMo/Automodel/blob/8dc00dcb4a35c2413c52c6e7eb7ac8f1c24836aa/nemo_automodel/_transformers/auto_model.py#L991) | Embedding, Dense Retrieval |
-| Mistral AI | [Ministral3 (Bidirectional)](/model-coverage/embedding-models/ministral3-bidirectional) | `Ministral3BidirectionalModel` | [`NeMoAutoModelBiEncoder`](https://github.com/NVIDIA-NeMo/Automodel/blob/8dc00dcb4a35c2413c52c6e7eb7ac8f1c24836aa/nemo_automodel/_transformers/auto_model.py#L991) | Embedding, Dense Retrieval |
+| NVIDIA | [Llama (Bidirectional)](/model-coverage/embedding-models/nvidia/llama-bidirectional) | `LlamaBidirectionalModel` | [`NeMoAutoModelBiEncoder`](https://github.com/NVIDIA-NeMo/Automodel/blob/8dc00dcb4a35c2413c52c6e7eb7ac8f1c24836aa/nemo_automodel/_transformers/auto_model.py#L991) | Embedding, Dense Retrieval |
+| NVIDIA | [Llama Nemotron VL](/model-coverage/embedding-models/nvidia/llama-bidirectional) | `LlamaNemotronVLModel` | [`NeMoAutoModelBiEncoder`](https://github.com/NVIDIA-NeMo/Automodel/blob/8dc00dcb4a35c2413c52c6e7eb7ac8f1c24836aa/nemo_automodel/_transformers/auto_model.py#L991) | Embedding, Dense Retrieval |
+| Mistral AI | [Ministral3](/model-coverage/embedding-models/mistralai/ministral3-bidirectional) | `Ministral3Model` with `is_causal: false` | [`NeMoAutoModelBiEncoder`](https://github.com/NVIDIA-NeMo/Automodel/blob/8dc00dcb4a35c2413c52c6e7eb7ac8f1c24836aa/nemo_automodel/_transformers/auto_model.py#L991) | Embedding, Dense Retrieval |
+
+The stock `ministral3` path is preferred. The `ministral3_bidirec` model type remains available for compatibility with legacy checkpoints and resolves to the custom `Ministral3BidirectionalModel`.
 
 ### Hugging Face Auto Backbones
 
-Any Hugging Face model that can be loaded with `AutoModel` can be used as an embedding backbone. This fallback path uses the model's native attention; no bidirectional conversion is applied.
+Any Hugging Face model that can be loaded with `AutoModel` can be used as an embedding backbone. The fallback path sets `config.is_causal: false`; verify that an unregistered architecture honors this flag before using it for retrieval training.
 
 ## Example Recipes
 

--- a/docs/model-coverage/embedding/mistralai/ministral3-bidirectional.mdx
+++ b/docs/model-coverage/embedding/mistralai/ministral3-bidirectional.mdx
@@ -1,33 +1,36 @@
 ---
-title: "Ministral3 (Bidirectional) for Embedding"
+title: "Ministral3 for Embedding"
 description: ""
 ---
 
-NeMo AutoModel provides a bidirectional variant of [Mistral AI's Ministral3](https://mistral.ai/news/ministraux/) for embedding and dense retrieval tasks. Unlike the standard causal (left-to-right) Ministral3 used for text generation, this variant uses **bidirectional attention**, so each token can attend to both past and future tokens in the sequence, producing richer representations for semantic similarity and dense retrieval.
+NeMo AutoModel loads [Mistral AI's Ministral3](https://mistral.ai/news/ministraux/) with the stock Hugging Face `Ministral3Model` and sets `is_causal: false` for embedding and dense retrieval tasks. Each token can therefore attend to both past and future tokens without requiring a custom model implementation.
 
-The bidirectional encoder can be loaded directly from text-only checkpoints (e.g. `mistralai/Ministral-3B-Instruct`) and also automatically extracts the language model from Ministral3 VLM checkpoints (e.g. `mistralai/Ministral-3-3B-Base-2512` or `mistralai/Ministral-3-3B-Instruct-2512`).
+The encoder can be loaded directly from text-only checkpoints (e.g. `mistralai/Ministral-3B-Instruct`) and also automatically extracts the language model from Ministral3 VLM checkpoints (e.g. `mistralai/Ministral-3-3B-Base-2512` or `mistralai/Ministral-3-3B-Instruct-2512`). The custom `Ministral3BidirectionalModel` remains available through the legacy `ministral3_bidirec` model type for compatibility with existing checkpoints.
 
 | | |
 |---|---|
 | **Tasks** | Embedding, Dense Retrieval |
-| **Architecture** | `Ministral3BidirectionalModel` |
+| **Architecture** | `Ministral3Model` with `is_causal: false` (preferred); `Ministral3BidirectionalModel` (legacy) |
 | **Parameters** | 3B |
 | **HF Org** | [mistralai](https://huggingface.co/mistralai) |
 
 ## Available Models
 
-Any Ministral3 checkpoint can be loaded as a bidirectional backbone. The following configurations are tested:
+Any Ministral3 checkpoint can be loaded as a non-causal backbone. The following configurations are tested:
 
 - **Ministral-3-3B-Base-2512** — VLM checkpoint, language model is extracted automatically
 - **Ministral-3-3B-Instruct-2512** — VLM checkpoint, language model is extracted automatically
 
 ## Embedding Models
 
-The bidirectional bi-encoder path is used for embedding generation and dense retrieval.
+The stock non-causal bi-encoder path is used for embedding generation and dense retrieval.
 
 | Architecture | Task | Auto Class | Description |
 |---|---|---|---|
-| `Ministral3BidirectionalModel` | Embedding | [`NeMoAutoModelBiEncoder`](https://github.com/NVIDIA-NeMo/Automodel/blob/8dc00dcb4a35c2413c52c6e7eb7ac8f1c24836aa/nemo_automodel/_transformers/auto_model.py#L991) | Bidirectional Ministral3 with mean pooling for dense embeddings |
+| `Ministral3Model` with `is_causal: false` | Embedding | [`NeMoAutoModelBiEncoder`](https://github.com/NVIDIA-NeMo/Automodel/blob/8dc00dcb4a35c2413c52c6e7eb7ac8f1c24836aa/nemo_automodel/_transformers/auto_model.py#L991) | Preferred stock Hugging Face path for bidirectional dense embeddings |
+| `Ministral3BidirectionalModel` | Embedding | [`NeMoAutoModelBiEncoder`](https://github.com/NVIDIA-NeMo/Automodel/blob/8dc00dcb4a35c2413c52c6e7eb7ac8f1c24836aa/nemo_automodel/_transformers/auto_model.py#L991) | Legacy compatibility path for custom retrieval checkpoints |
+
+For cross-encoder scoring, stock `ministral3` checkpoints use Hugging Face `Ministral3ForSequenceClassification`. The legacy `ministral3_bidirec` type does not provide a cross-encoder scoring class.
 
 ## Pooling Strategies
 
@@ -57,10 +60,9 @@ cd Automodel
 uv sync --locked --all-groups --all-extras
 ```
 
-**2. Run the recipe** from inside the repo (point any Llama bi-encoder recipe at a Ministral3 checkpoint, or write a recipe targeting `mistralai/Ministral-3-3B-Base-2512`):
+**2. Run the Ministral3 recipe** from inside the repo:
 
 ```bash
-uv run automodel examples/retrieval/bi_encoder/llama3_2_1b.yaml --nproc-per-node 8
 uv run automodel examples/retrieval/bi_encoder/ministral3_3b_instruct.yaml --nproc-per-node 8
 ```
 

--- a/nemo_automodel/_transformers/auto_model.py
+++ b/nemo_automodel/_transformers/auto_model.py
@@ -1216,8 +1216,8 @@ class NeMoAutoModelBiEncoder(_NeMoAutoModelForRetrievalBase):
     def from_pretrained(
         cls,
         pretrained_model_name_or_path: str,
-        pooling: str = "avg",
-        l2_normalize: bool = True,
+        pooling: str | None = None,
+        l2_normalize: bool | None = None,
         do_distributed_inbatch_negative: bool = False,
         detach_distributed_inbatch_negatives: bool = True,
         **kwargs,
@@ -1225,12 +1225,15 @@ class NeMoAutoModelBiEncoder(_NeMoAutoModelForRetrievalBase):
         """Load a bi-encoder model with infrastructure.
 
         Accepts all arguments from ``_NeMoAutoModelForRetrievalBase.from_pretrained``
-        plus the bi-encoder-specific parameters below.
+        plus the bi-encoder-specific parameters below. Sentence Transformers export
+        metadata is derived from effective model, tokenizer, and collator settings.
 
         Args:
             pretrained_model_name_or_path: Path to pretrained model or model identifier.
-            pooling: Pooling strategy (``'avg'``, ``'cls'``, ``'last'``, etc.).
-            l2_normalize: Whether to L2-normalize embeddings.
+            pooling: Pooling strategy (``'avg'``, ``'cls'``, ``'last'``, etc.). When omitted, standard
+                Sentence Transformers metadata is restored when available, otherwise defaults to ``'avg'``.
+            l2_normalize: Whether to L2-normalize embeddings. When omitted, the standard Sentence Transformers
+                module stack is restored when available, otherwise defaults to ``True``.
             do_distributed_inbatch_negative: Whether to gather passages across ranks for distributed in-batch
                 negatives during training.
             detach_distributed_inbatch_negatives: Whether to detach remote passage embeddings in distributed

--- a/nemo_automodel/_transformers/retrieval.py
+++ b/nemo_automodel/_transformers/retrieval.py
@@ -27,16 +27,54 @@ from transformers import (
     AutoModel,
     AutoModelForSequenceClassification,
     FineGrainedFP8Config,
+    PretrainedConfig,
     PreTrainedModel,
 )
-from transformers.models.auto.modeling_auto import MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING
+from transformers.models.auto.modeling_auto import MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING, MODEL_MAPPING
 from transformers.utils import logging
 
 from nemo_automodel._transformers.registry import ModelRegistry
+from nemo_automodel._transformers.sentence_transformer_export import (
+    SentenceTransformerExportConfig,
+    SentenceTransformerWrapperOptions,
+    _cache_hub_source_legal_assets,
+    _load_sentence_transformer_wrapper_options,
+    _resolve_cached_source_model_path,
+    _resolve_cached_source_repository_path,
+    _SentenceTransformerMetadataExporter,
+    _supports_standard_sentence_transformer_export,
+)
 from nemo_automodel.components.loss.intermediate_distill import LayerCapture
 from nemo_automodel.components.models.common.bidirectional import EncoderStateDictAdapter
 
 logger = logging.get_logger(__name__)
+
+
+_BI_ENCODER_DEFAULT_POOLING = "avg"
+_BI_ENCODER_DEFAULT_L2_NORMALIZE = True
+
+
+def _canonicalize_bi_encoder_pooling(pooling: str) -> str:
+    """Return the canonical AutoModel name for a bi-encoder pooling alias."""
+    return _BI_ENCODER_DEFAULT_POOLING if pooling == "mean" else pooling
+
+
+def _resolve_bi_encoder_options(
+    config: PretrainedConfig,
+    saved_options: SentenceTransformerWrapperOptions | None,
+    pooling: str | None,
+    l2_normalize: bool | None,
+) -> tuple[str, bool]:
+    """Resolve explicit wrapper arguments, then standard saved metadata, then defaults."""
+    if pooling is None:
+        if saved_options is not None:
+            pooling = saved_options.pooling
+        else:
+            pooling = getattr(config, "pooling", None) or _BI_ENCODER_DEFAULT_POOLING
+    if l2_normalize is None:
+        l2_normalize = saved_options.l2_normalize if saved_options is not None else _BI_ENCODER_DEFAULT_L2_NORMALIZE
+    pooling = _canonicalize_bi_encoder_pooling(pooling)
+    return pooling, l2_normalize
 
 
 def _get_fp8_dequantization_config(config) -> FineGrainedFP8Config | None:
@@ -189,8 +227,7 @@ def pool(last_hidden_states: torch.Tensor, attention_mask: torch.Tensor, pool_ty
         Pooled embeddings [batch_size, hidden_size]
     """
     last_hidden = last_hidden_states.masked_fill(~attention_mask[..., None].bool(), 0.0)
-    if pool_type == "mean":
-        pool_type = "avg"
+    pool_type = _canonicalize_bi_encoder_pooling(pool_type)
 
     if pool_type == "avg":
         emb = last_hidden.sum(dim=1) / attention_mask.sum(dim=1)[..., None]
@@ -251,6 +288,7 @@ def build_encoder_backbone(
     extract_submodel: Optional[str] = None,
     num_labels: Optional[int] = None,
     temperature: Optional[float] = None,
+    loaded_config: PretrainedConfig | None = None,
     **hf_kwargs,
 ) -> PreTrainedModel:
     """Build an encoder backbone from a pretrained checkpoint.
@@ -278,6 +316,7 @@ def build_encoder_backbone(
             (e.g. ``"language_model"`` to extract the text backbone from a VLM).
         num_labels: Number of labels for reranking/classification backbones.
         temperature: Optional retrieval score temperature for custom retrieval backbones.
+        loaded_config: A previously loaded config used to keep model and metadata resolution on the same revision.
         **hf_kwargs: Extra keyword arguments forwarded to ``from_pretrained``.
 
     Returns:
@@ -287,7 +326,13 @@ def build_encoder_backbone(
         ValueError: If the task is unsupported for a known model type, or the
             architecture class is missing from :class:`ModelRegistry`.
     """
-    config = AutoConfig.from_pretrained(model_name_or_path, trust_remote_code=trust_remote_code, **hf_kwargs)
+    config = loaded_config
+    if config is None:
+        config = AutoConfig.from_pretrained(
+            model_name_or_path,
+            trust_remote_code=trust_remote_code,
+            **hf_kwargs,
+        )
     model_type = getattr(config, "model_type", "")
 
     if extract_submodel is not None:
@@ -342,7 +387,8 @@ def save_encoder_pretrained(model: nn.Module, save_directory: str, **kwargs) -> 
 
     If ``checkpointer`` is present in *kwargs*, delegates to
     ``Checkpointer.save_model`` for distributed/FSDP-safe saving.
-    Otherwise falls back to the inner ``PreTrainedModel.save_pretrained``.
+    Otherwise saves the inner ``PreTrainedModel`` and generates standard
+    Sentence Transformers metadata when the encoder can be represented by that format.
 
     The inner model is expected to be stored as ``model.model`` (the
     backbone wrapped by the encoder).
@@ -371,7 +417,44 @@ def save_encoder_pretrained(model: nn.Module, save_directory: str, **kwargs) -> 
         return
 
     logger.info(f"Saving encoder model to {save_directory}")
+    export_config = getattr(model, "sentence_transformer_export_config", None)
+    tokenizer = kwargs.get("tokenizer", None)
+    if export_config is not None and tokenizer is None:
+        logger.warning(
+            "Sentence Transformers metadata export is disabled because no tokenizer was provided; "
+            "saving the standard encoder checkpoint instead."
+        )
+        export_config = None
+    deploy_config = None
+    original_model_path = getattr(model, "source_model_path", None)
+    if original_model_path is None:
+        model_reference = getattr(model.model, "name_or_path", None) or getattr(
+            model.model.config, "name_or_path", None
+        )
+        original_model_path = str(model_reference) if model_reference and os.path.isdir(str(model_reference)) else None
+    if export_config is not None:
+        from nemo_automodel._transformers.sentence_transformer_export import (
+            _save_generated_sentence_transformer_assets,
+            _validate_sentence_transformer_export,
+        )
+
+        try:
+            _validate_sentence_transformer_export(model, tokenizer, original_model_path)
+            deploy_config = model.get_hf_export_config()
+        except (TypeError, ValueError) as exc:
+            logger.warning(
+                "Sentence Transformers metadata export is disabled because this checkpoint cannot be "
+                "represented faithfully; saving the standard encoder checkpoint instead: %s",
+                exc,
+            )
+            export_config = None
     model.model.save_pretrained(save_directory)
+    if export_config is None:
+        return
+
+    deploy_config.save_pretrained(save_directory)
+    tokenizer.save_pretrained(save_directory)
+    _save_generated_sentence_transformer_assets(model, export_config, original_model_path, save_directory, tokenizer)
 
 
 # Model types that require a registered custom retrieval backbone for each task.
@@ -419,9 +502,13 @@ class BiEncoderModel(nn.Module):
         detach_distributed_inbatch_negatives: bool = True,
     ):
         super().__init__()
+        pooling = _canonicalize_bi_encoder_pooling(pooling)
         _init_encoder_common(self, model)
         self.pooling = pooling
         self.l2_normalize = l2_normalize
+        self.sentence_transformer_export_config: SentenceTransformerExportConfig | None = None
+        if _supports_standard_sentence_transformer_export(model, pooling):
+            self.sentence_transformer_export_config = SentenceTransformerExportConfig()
         self.do_distributed_inbatch_negative = do_distributed_inbatch_negative
         self.detach_distributed_inbatch_negatives = detach_distributed_inbatch_negatives
 
@@ -430,8 +517,8 @@ class BiEncoderModel(nn.Module):
         cls,
         model_name_or_path: str,
         task: str = None,
-        pooling: str = "avg",
-        l2_normalize: bool = True,
+        pooling: str | None = None,
+        l2_normalize: bool | None = None,
         do_distributed_inbatch_negative: bool = False,
         detach_distributed_inbatch_negatives: bool = True,
         trust_remote_code: bool = False,
@@ -441,20 +528,127 @@ class BiEncoderModel(nn.Module):
         effective_task = cls._TASK if cls._TASK is not None else task
         if effective_task is None:
             raise ValueError("task must be specified when calling build()")
-
         logger.info(f"Building BiEncoderModel from {model_name_or_path}")
 
+        config = AutoConfig.from_pretrained(
+            model_name_or_path,
+            trust_remote_code=trust_remote_code,
+            **hf_kwargs,
+        )
+        metadata_kwargs = dict(hf_kwargs)
+        commit_hash = getattr(config, "_commit_hash", None)
+        if commit_hash is not None:
+            metadata_kwargs["revision"] = commit_hash
+        saved_options = _load_sentence_transformer_wrapper_options(model_name_or_path, metadata_kwargs)
+        pooling, l2_normalize = _resolve_bi_encoder_options(
+            config,
+            saved_options,
+            pooling,
+            l2_normalize,
+        )
         backbone = build_encoder_backbone(
-            model_name_or_path, effective_task, trust_remote_code=trust_remote_code, pooling=pooling, **hf_kwargs
+            model_name_or_path,
+            effective_task,
+            trust_remote_code=trust_remote_code,
+            pooling=pooling,
+            loaded_config=config,
+            **hf_kwargs,
         )
 
-        return cls(
+        encoder = cls(
             model=backbone,
             pooling=pooling,
             l2_normalize=l2_normalize,
             do_distributed_inbatch_negative=do_distributed_inbatch_negative,
             detach_distributed_inbatch_negatives=detach_distributed_inbatch_negatives,
         )
+        if saved_options is not None:
+            encoder.configure_sentence_transformer_prompts(
+                query_prompt=saved_options.query_prompt or "",
+                document_prompt=saved_options.document_prompt or "",
+            )
+        encoder.source_model_path = _resolve_cached_source_model_path(
+            model_name_or_path,
+            backbone.config,
+            hf_kwargs,
+        )
+        encoder.source_repository_path = _resolve_cached_source_repository_path(
+            model_name_or_path,
+            encoder.source_model_path,
+            hf_kwargs,
+        )
+        if encoder.sentence_transformer_export_config is not None:
+            encoder.source_repository_path = (
+                _cache_hub_source_legal_assets(model_name_or_path, config, hf_kwargs) or encoder.source_repository_path
+            )
+        return encoder
+
+    def configure_sentence_transformer_prompts(self, query_prompt: str, document_prompt: str) -> None:
+        """Set the exact prompts used by the current retrieval pipeline."""
+        export_config = self.sentence_transformer_export_config
+        if export_config is None:
+            return
+        export_config.query_prompt = query_prompt
+        export_config.document_prompt = document_prompt
+
+    def disable_sentence_transformer_export(self) -> None:
+        """Disable standard export when runtime behavior cannot be represented faithfully."""
+        self.sentence_transformer_export_config = None
+
+    def _get_consolidated_hf_metadata_exporter(
+        self,
+        *,
+        tokenizer=None,
+        original_model_path: str | None = None,
+    ) -> _SentenceTransformerMetadataExporter | None:
+        """Return the retrieval-owned exporter for consolidated Hugging Face metadata."""
+        export_config = self.sentence_transformer_export_config
+        if export_config is None:
+            return None
+        if tokenizer is None:
+            logger.warning(
+                "Sentence Transformers metadata export is disabled because no tokenizer was provided; "
+                "saving the standard Hugging Face checkpoint metadata instead."
+            )
+            return None
+        exporter = _SentenceTransformerMetadataExporter(self, export_config)
+        try:
+            exporter.validate(tokenizer=tokenizer, original_model_path=original_model_path)
+            self.get_hf_export_config()
+        except (TypeError, ValueError) as exc:
+            logger.warning(
+                "Sentence Transformers metadata export is disabled because this checkpoint cannot be "
+                "represented faithfully; saving the standard Hugging Face checkpoint metadata instead: %s",
+                exc,
+            )
+            return None
+        return exporter
+
+    def get_hf_export_config(self) -> PretrainedConfig:
+        """Return a deployable Hugging Face config describing the effective bi-encoder."""
+        config_dict = self.config.to_dict()
+        model_type = getattr(type(self.config), "model_type", "")
+        if model_type.endswith("_bidirec"):
+            export_config_class = type(self.config).__mro__[1]
+            if not issubclass(export_config_class, PretrainedConfig):
+                raise TypeError(f"Unable to determine deployable Hugging Face classes for {type(self.model).__name__}.")
+
+            config_dict.pop("model_type", None)
+            config_dict.pop("auto_map", None)
+            export_config = export_config_class.from_dict(config_dict)
+            try:
+                export_model_class = MODEL_MAPPING[type(export_config)]
+            except KeyError as exc:
+                raise TypeError(
+                    f"Unable to determine deployable Hugging Face classes for {type(self.model).__name__}."
+                ) from exc
+            export_config.architectures = [export_model_class.__name__]
+            export_config.is_causal = False
+        else:
+            export_config = self.config.__class__.from_dict(config_dict)
+
+        export_config.pooling = self.pooling
+        return export_config
 
     def save_pretrained(self, save_directory: str, **kwargs):
         save_encoder_pretrained(self, save_directory, **kwargs)

--- a/nemo_automodel/_transformers/sentence_transformer_export.py
+++ b/nemo_automodel/_transformers/sentence_transformer_export.py
@@ -1,0 +1,571 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sentence Transformers metadata interoperability for retrieval models."""
+
+import json
+import os
+import shutil
+from dataclasses import dataclass
+
+from huggingface_hub import hf_hub_download, snapshot_download, try_to_load_from_cache
+from huggingface_hub.utils import EntryNotFoundError, LocalEntryNotFoundError
+from torch import nn
+from transformers import PretrainedConfig
+from transformers.utils import logging
+
+_SENTENCE_TRANSFORMER_POOLING_KEYS = {
+    "avg": "pooling_mode_mean_tokens",
+    "cls": "pooling_mode_cls_token",
+    "last": "pooling_mode_lasttoken",
+}
+_HF_HUB_METADATA_KWARGS = {
+    "cache_dir",
+    "force_download",
+    "local_files_only",
+    "revision",
+    "token",
+}
+_SOURCE_LEGAL_ASSET_PATTERNS = (
+    "LICENSE*",
+    "license*",
+    "NOTICE*",
+    "notice*",
+    "*NOTICE*",
+    "*notice*",
+)
+_SOURCE_LEGAL_ASSET_PREFIXES = ("license", "notice")
+_TEXT_EXPORT_STALE_PROCESSOR_ASSETS = ("processor_config.json", "preprocessor_config.json")
+
+
+logger = logging.get_logger(__name__)
+
+
+@dataclass
+class SentenceTransformerExportConfig:
+    """Effective Sentence Transformers semantics written with a bi-encoder checkpoint.
+
+    Attributes:
+        query_prompt: Exact prompt prepended to queries, or None when no prompt is configured yet.
+        document_prompt: Exact prompt prepended to documents, or None when no prompt is configured yet.
+    """
+
+    query_prompt: str | None = None
+    document_prompt: str | None = None
+
+
+@dataclass(frozen=True)
+class SentenceTransformerWrapperOptions:
+    """Bi-encoder wrapper behavior represented by standard Sentence Transformers modules."""
+
+    pooling: str
+    l2_normalize: bool
+    query_prompt: str | None = None
+    document_prompt: str | None = None
+
+
+def _load_sentence_transformer_json(
+    model_name_or_path: str,
+    filename: str,
+    hf_kwargs: dict,
+) -> object | None:
+    """Load a standard Sentence Transformers JSON asset from a local path or the Hub."""
+    subfolder = hf_kwargs.get("subfolder")
+    if os.path.isdir(model_name_or_path):
+        root = os.path.join(model_name_or_path, subfolder) if subfolder else model_name_or_path
+        asset_path = os.path.join(root, filename)
+        if not os.path.isfile(asset_path):
+            return None
+    else:
+        download_kwargs = {key: hf_kwargs[key] for key in _HF_HUB_METADATA_KWARGS if key in hf_kwargs}
+        if "token" not in download_kwargs and "use_auth_token" in hf_kwargs:
+            download_kwargs["token"] = hf_kwargs["use_auth_token"]
+        try:
+            asset_path = hf_hub_download(
+                repo_id=model_name_or_path,
+                filename=filename,
+                subfolder=subfolder,
+                **download_kwargs,
+            )
+        except LocalEntryNotFoundError as exc:
+            logger.warning(
+                "Unable to discover optional Sentence Transformers metadata %s; using wrapper defaults: %s",
+                filename,
+                exc,
+            )
+            return None
+        except EntryNotFoundError:
+            return None
+        except Exception as exc:
+            logger.warning(
+                "Unable to discover optional Sentence Transformers metadata %s; using wrapper defaults: %s",
+                filename,
+                exc,
+            )
+            return None
+
+    with open(asset_path) as f:
+        return json.load(f)
+
+
+def _load_sentence_transformer_wrapper_options(
+    model_name_or_path: str,
+    hf_kwargs: dict,
+) -> SentenceTransformerWrapperOptions | None:
+    """Restore pooling and normalization from the standard Sentence Transformers module stack."""
+    modules = _load_sentence_transformer_json(model_name_or_path, "modules.json", hf_kwargs)
+    if modules is None:
+        return None
+    if not isinstance(modules, list):
+        raise ValueError("Sentence Transformers modules.json must contain a list of modules.")
+
+    transformer_type = "sentence_transformers.models.Transformer"
+    pooling_type = "sentence_transformers.models.Pooling"
+    normalize_type = "sentence_transformers.models.Normalize"
+    module_types = [module.get("type") if isinstance(module, dict) else None for module in modules]
+    if module_types not in ([transformer_type, pooling_type], [transformer_type, pooling_type, normalize_type]):
+        raise ValueError(
+            "Sentence Transformers metadata must use the exact supported module stack: "
+            "Transformer, Pooling, and optional Normalize."
+        )
+    if modules[0].get("path") != "":
+        raise ValueError("Sentence Transformers Transformer metadata must reference the checkpoint root.")
+
+    sentence_bert_config = _load_sentence_transformer_json(
+        model_name_or_path,
+        "sentence_bert_config.json",
+        hf_kwargs,
+    )
+    if isinstance(sentence_bert_config, dict) and sentence_bert_config.get("do_lower_case"):
+        raise ValueError(
+            "Sentence Transformers checkpoints with do_lower_case=True are unsupported because "
+            "the NeMo inference path does not lowercase text."
+        )
+
+    pooling_path = modules[1].get("path")
+    if not isinstance(pooling_path, str) or not pooling_path:
+        raise ValueError("Sentence Transformers Pooling metadata must reference a module path.")
+    pooling_config = _load_sentence_transformer_json(
+        model_name_or_path,
+        os.path.join(pooling_path, "config.json"),
+        hf_kwargs,
+    )
+    if not isinstance(pooling_config, dict):
+        raise ValueError("Sentence Transformers Pooling config.json is missing or invalid.")
+    if pooling_config.get("include_prompt", True) is False:
+        raise ValueError(
+            "Sentence Transformers checkpoints with include_prompt=False are unsupported because "
+            "the NeMo pooling path includes prompt tokens."
+        )
+
+    active_pooling_keys = {
+        key for key, value in pooling_config.items() if key.startswith("pooling_mode_") and bool(value)
+    }
+    matching_pooling = [
+        pooling
+        for pooling, metadata_key in _SENTENCE_TRANSFORMER_POOLING_KEYS.items()
+        if metadata_key in active_pooling_keys
+    ]
+    if len(active_pooling_keys) != 1 or len(matching_pooling) != 1:
+        raise ValueError(
+            "Sentence Transformers pooling metadata cannot be represented by a single NeMo avg, cls, or last mode."
+        )
+
+    sentence_transformer_config = _load_sentence_transformer_json(
+        model_name_or_path,
+        "config_sentence_transformers.json",
+        hf_kwargs,
+    )
+    query_prompt = None
+    document_prompt = None
+    if sentence_transformer_config is not None:
+        if not isinstance(sentence_transformer_config, dict):
+            raise ValueError("Sentence Transformers config_sentence_transformers.json is invalid.")
+        prompts = sentence_transformer_config.get("prompts", {})
+        if not isinstance(prompts, dict):
+            raise ValueError("Sentence Transformers prompts metadata must contain a mapping.")
+        query_prompt = prompts.get("query")
+        document_prompt = prompts.get("document")
+        if query_prompt is not None and not isinstance(query_prompt, str):
+            raise ValueError("Sentence Transformers query prompt must be a string.")
+        if document_prompt is not None and not isinstance(document_prompt, str):
+            raise ValueError("Sentence Transformers document prompt must be a string.")
+
+    return SentenceTransformerWrapperOptions(
+        pooling=matching_pooling[0],
+        l2_normalize=len(modules) == 3,
+        query_prompt=query_prompt,
+        document_prompt=document_prompt,
+    )
+
+
+def _resolve_cached_source_model_path(model_name_or_path: str, config, hf_kwargs: dict) -> str | None:
+    """Resolve the already-downloaded source snapshot without network access."""
+    subfolder = hf_kwargs.get("subfolder")
+    if os.path.isdir(model_name_or_path):
+        source_path = os.path.join(model_name_or_path, subfolder) if subfolder else model_name_or_path
+        return source_path if os.path.isdir(source_path) else None
+    filename = os.path.join(subfolder, "config.json") if subfolder else "config.json"
+    cached_config = try_to_load_from_cache(
+        model_name_or_path,
+        filename,
+        cache_dir=hf_kwargs.get("cache_dir"),
+        revision=getattr(config, "_commit_hash", None) or hf_kwargs.get("revision"),
+    )
+    if isinstance(cached_config, str) and os.path.isfile(cached_config):
+        return os.path.dirname(cached_config)
+    return None
+
+
+def _resolve_cached_source_repository_path(
+    model_name_or_path: str,
+    source_model_path: str | None,
+    hf_kwargs: dict,
+) -> str | None:
+    """Resolve the repository or snapshot root for a model loaded from a subfolder."""
+    if source_model_path is None:
+        return None
+    subfolder = hf_kwargs.get("subfolder")
+    if not subfolder:
+        return source_model_path
+    if os.path.isdir(model_name_or_path):
+        return model_name_or_path
+
+    repository_path = source_model_path
+    for part in os.path.normpath(subfolder).split(os.sep):
+        if part not in ("", "."):
+            repository_path = os.path.dirname(repository_path)
+    return repository_path
+
+
+def _cache_hub_source_legal_assets(model_name_or_path: str, config, hf_kwargs: dict) -> str | None:
+    """Cache source legal assets while the Hub-backed model is being loaded."""
+    if os.path.isdir(model_name_or_path):
+        return None
+
+    download_kwargs = {
+        key: hf_kwargs[key] for key in ("cache_dir", "force_download", "local_files_only", "token") if key in hf_kwargs
+    }
+    if "token" not in download_kwargs and "use_auth_token" in hf_kwargs:
+        download_kwargs["token"] = hf_kwargs["use_auth_token"]
+    revision = getattr(config, "_commit_hash", None) or hf_kwargs.get("revision")
+    if revision is not None:
+        download_kwargs["revision"] = revision
+    try:
+        return snapshot_download(
+            repo_id=model_name_or_path,
+            allow_patterns=_SOURCE_LEGAL_ASSET_PATTERNS,
+            **download_kwargs,
+        )
+    except Exception as exc:
+        logger.warning("Unable to cache source legal assets for %s: %s", model_name_or_path, exc)
+        return None
+
+
+def _supports_standard_sentence_transformer_export(model: nn.Module, pooling: str) -> bool:
+    """Return whether a backbone can be represented by the standard text module stack."""
+    config = getattr(model, "config", None)
+    hidden_size = getattr(config, "hidden_size", None)
+    return (
+        pooling in _SENTENCE_TRANSFORMER_POOLING_KEYS
+        and getattr(model, "main_input_name", "input_ids") == "input_ids"
+        and isinstance(config, PretrainedConfig)
+        and not bool(getattr(config, "is_composition", False))
+        and isinstance(hidden_size, int)
+        and hidden_size > 0
+    )
+
+
+def _write_json(path: str, value) -> None:
+    """Write deterministic, human-readable JSON metadata."""
+    with open(path, "w") as f:
+        json.dump(value, f, indent=2)
+        f.write("\n")
+
+
+def _copy_source_legal_assets(
+    original_model_path: str | None,
+    hf_metadata_dir: str,
+    source_repository_path: str | None = None,
+) -> None:
+    """Preserve repository- and model-root legal notices without inheriting other source semantics."""
+    source_roots = []
+    for source_root in (source_repository_path, original_model_path):
+        if source_root is None or not os.path.isdir(source_root):
+            continue
+        if any(os.path.samefile(source_root, existing_root) for existing_root in source_roots):
+            continue
+        source_roots.append(source_root)
+
+    for source_root in source_roots:
+        for item in os.scandir(source_root):
+            normalized_name = item.name.lower()
+            is_legal_asset = normalized_name.startswith(_SOURCE_LEGAL_ASSET_PREFIXES) or "notice" in normalized_name
+            if item.is_file() and is_legal_asset:
+                shutil.copy2(item.path, os.path.join(hf_metadata_dir, item.name))
+
+
+def _remove_stale_text_processor_assets(hf_metadata_dir: str) -> None:
+    """Remove source multimodal processor metadata from a text-only export."""
+    for asset_name in _TEXT_EXPORT_STALE_PROCESSOR_ASSETS:
+        asset_path = os.path.join(hf_metadata_dir, asset_name)
+        if os.path.isfile(asset_path):
+            os.remove(asset_path)
+
+
+def _restore_source_tokenizer_serialization_state(
+    original_model_path: str | None,
+    hf_metadata_dir: str,
+    tokenizer,
+) -> None:
+    """Remove training-time tokenizer state while retaining tokenizer edits."""
+    pad_token = getattr(tokenizer, "pad_token", None)
+    tokenizer_json_path = os.path.join(hf_metadata_dir, "tokenizer.json")
+    source_tokenizer_json_path = (
+        os.path.join(original_model_path, "tokenizer.json") if original_model_path is not None else None
+    )
+    if os.path.isfile(tokenizer_json_path):
+        with open(tokenizer_json_path) as f:
+            tokenizer_json = json.load(f)
+        source_tokenizer_json = {}
+        if source_tokenizer_json_path is not None and os.path.isfile(source_tokenizer_json_path):
+            with open(source_tokenizer_json_path) as f:
+                source_tokenizer_json = json.load(f)
+        for key in ("truncation", "padding"):
+            tokenizer_json[key] = source_tokenizer_json.get(key)
+        _write_json(tokenizer_json_path, tokenizer_json)
+
+    tokenizer_config_path = os.path.join(hf_metadata_dir, "tokenizer_config.json")
+    source_tokenizer_config_path = (
+        os.path.join(original_model_path, "tokenizer_config.json") if original_model_path is not None else None
+    )
+    if os.path.isfile(tokenizer_config_path):
+        with open(tokenizer_config_path) as f:
+            tokenizer_config = json.load(f)
+        source_tokenizer_config = {}
+        if source_tokenizer_config_path is not None and os.path.isfile(source_tokenizer_config_path):
+            with open(source_tokenizer_config_path) as f:
+                source_tokenizer_config = json.load(f)
+        if "local_files_only" in source_tokenizer_config:
+            tokenizer_config["local_files_only"] = source_tokenizer_config["local_files_only"]
+        else:
+            tokenizer_config.pop("local_files_only", None)
+        tokenizer_config.pop("processor_class", None)
+        if pad_token is not None:
+            tokenizer_config["pad_token"] = pad_token
+        _write_json(tokenizer_config_path, tokenizer_config)
+
+    special_tokens_map_path = os.path.join(hf_metadata_dir, "special_tokens_map.json")
+    if pad_token is not None and os.path.isfile(special_tokens_map_path):
+        with open(special_tokens_map_path) as f:
+            special_tokens_map = json.load(f)
+        special_tokens_map["pad_token"] = pad_token
+        _write_json(special_tokens_map_path, special_tokens_map)
+
+
+def _read_source_sentence_transformer_max_seq_length(original_model_path: str | None) -> int | None:
+    """Read the source Sentence Transformers deployment limit when present."""
+    if original_model_path is None:
+        return None
+    config_path = os.path.join(original_model_path, "sentence_bert_config.json")
+    if not os.path.isfile(config_path):
+        return None
+    with open(config_path) as f:
+        source_config = json.load(f)
+    value = source_config.get("max_seq_length")
+    if value is None:
+        return None
+    max_seq_length = int(value)
+    if max_seq_length <= 0:
+        raise ValueError("Source sentence_bert_config.json max_seq_length must be positive.")
+    return max_seq_length
+
+
+def _resolve_sentence_transformer_max_seq_length(
+    model_part: nn.Module,
+    tokenizer,
+    original_model_path: str | None = None,
+) -> int:
+    """Resolve deployment sequence length without using training-time truncation."""
+    source_max_seq_length = _read_source_sentence_transformer_max_seq_length(original_model_path)
+    if source_max_seq_length is not None:
+        model_max_seq_length = getattr(getattr(model_part, "config", None), "max_position_embeddings", None)
+        if model_max_seq_length is not None:
+            model_max_seq_length = int(model_max_seq_length)
+            if 0 < model_max_seq_length < 1_000_000_000 and source_max_seq_length > model_max_seq_length:
+                raise ValueError("Source Sentence Transformers max_seq_length exceeds max_position_embeddings.")
+        return source_max_seq_length
+
+    candidates = [
+        getattr(tokenizer, "model_max_length", None),
+        getattr(getattr(model_part, "config", None), "max_position_embeddings", None),
+    ]
+    finite_candidates = []
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        max_seq_length = int(candidate)
+        if 0 < max_seq_length < 1_000_000_000:
+            finite_candidates.append(max_seq_length)
+    if finite_candidates:
+        return min(finite_candidates)
+    raise ValueError("Unable to determine a finite Sentence Transformers deployment max_seq_length.")
+
+
+def _validate_sentence_transformer_export(
+    model_part: nn.Module,
+    tokenizer,
+    original_model_path: str | None = None,
+) -> None:
+    """Validate generated metadata inputs before rank-zero-only checkpoint I/O."""
+    pooling = getattr(model_part, "pooling", None)
+    if pooling not in _SENTENCE_TRANSFORMER_POOLING_KEYS:
+        raise ValueError(f"Pooling mode {pooling!r} cannot be represented by standard Sentence Transformers metadata.")
+
+    model_config = getattr(model_part, "config", None)
+    embedding_dimension = getattr(model_config, "hidden_size", None)
+    if not isinstance(embedding_dimension, int) or embedding_dimension <= 0:
+        raise ValueError("Bi-encoder config must expose a positive hidden_size for Sentence Transformers export.")
+
+    if tokenizer is None:
+        raise ValueError("A tokenizer is required to export a loadable Sentence Transformers checkpoint.")
+
+    _resolve_sentence_transformer_max_seq_length(model_part, tokenizer, original_model_path)
+
+
+def _save_generated_sentence_transformer_assets(
+    model_part: nn.Module,
+    export_config,
+    original_model_path: str | None,
+    hf_metadata_dir: str,
+    tokenizer,
+) -> None:
+    """Generate Sentence Transformers metadata from the effective bi-encoder behavior."""
+    _validate_sentence_transformer_export(model_part, tokenizer, original_model_path)
+    pooling = getattr(model_part, "pooling", None)
+    model_config = getattr(model_part, "config", None)
+    embedding_dimension = getattr(model_config, "hidden_size", None)
+
+    query_prompt = export_config.query_prompt or ""
+    document_prompt = export_config.document_prompt or ""
+
+    normalize = bool(getattr(model_part, "l2_normalize", False))
+    similarity_fn_name = "cosine" if normalize else "dot"
+
+    modules = [
+        {
+            "idx": 0,
+            "name": "0",
+            "path": "",
+            "type": "sentence_transformers.models.Transformer",
+        },
+        {
+            "idx": 1,
+            "name": "1",
+            "path": "1_Pooling",
+            "type": "sentence_transformers.models.Pooling",
+        },
+    ]
+    if normalize:
+        modules.append(
+            {
+                "idx": 2,
+                "name": "2",
+                "path": "2_Normalize",
+                "type": "sentence_transformers.models.Normalize",
+            }
+        )
+
+    pooling_config = {
+        "word_embedding_dimension": embedding_dimension,
+        "pooling_mode_cls_token": False,
+        "pooling_mode_max_tokens": False,
+        "pooling_mode_mean_tokens": False,
+        "pooling_mode_mean_sqrt_len_tokens": False,
+        "pooling_mode_weightedmean_tokens": False,
+        "pooling_mode_lasttoken": False,
+        "include_prompt": True,
+    }
+    pooling_config[_SENTENCE_TRANSFORMER_POOLING_KEYS[pooling]] = True
+
+    max_seq_length = _resolve_sentence_transformer_max_seq_length(model_part, tokenizer, original_model_path)
+
+    os.makedirs(os.path.join(hf_metadata_dir, "1_Pooling"), exist_ok=True)
+    _write_json(os.path.join(hf_metadata_dir, "modules.json"), modules)
+    _write_json(
+        os.path.join(hf_metadata_dir, "config_sentence_transformers.json"),
+        {
+            "prompts": {"query": query_prompt, "document": document_prompt},
+            "default_prompt_name": None,
+            "similarity_fn_name": similarity_fn_name,
+        },
+    )
+    _write_json(
+        os.path.join(hf_metadata_dir, "sentence_bert_config.json"),
+        {"max_seq_length": max_seq_length, "do_lower_case": False},
+    )
+    _write_json(os.path.join(hf_metadata_dir, "1_Pooling", "config.json"), pooling_config)
+    _restore_source_tokenizer_serialization_state(original_model_path, hf_metadata_dir, tokenizer)
+    _remove_stale_text_processor_assets(hf_metadata_dir)
+    _copy_source_legal_assets(
+        original_model_path,
+        hf_metadata_dir,
+        source_repository_path=getattr(model_part, "source_repository_path", None),
+    )
+
+
+class _SentenceTransformerMetadataExporter:
+    """Write consolidated Hugging Face and Sentence Transformers metadata for a bi-encoder."""
+
+    def __init__(self, model_part: nn.Module, export_config) -> None:
+        self.model_part = model_part
+        self.export_config = export_config
+
+    def _source_model_path(self, fallback: str | None) -> str | None:
+        """Prefer the retrieval model source snapshot over generic checkpoint lookup."""
+        source_model_path = getattr(self.model_part, "source_model_path", None)
+        return str(source_model_path) if source_model_path is not None else fallback
+
+    def validate(self, *, tokenizer, original_model_path: str | None) -> None:
+        """Validate export inputs on every distributed rank before filesystem writes."""
+        _validate_sentence_transformer_export(self.model_part, tokenizer, self._source_model_path(original_model_path))
+
+    def save(
+        self,
+        *,
+        hf_metadata_dir: str,
+        tokenizer,
+        original_model_path: str | None,
+    ) -> None:
+        """Write deployable Hugging Face metadata plus standard Sentence Transformers assets."""
+        from nemo_automodel.components.checkpoint.addons import _save_generated_hf_assets
+
+        deploy_config = self.model_part.get_hf_export_config()
+        source_model_path = self._source_model_path(original_model_path)
+        _save_generated_hf_assets(
+            self.model_part,
+            source_model_path,
+            hf_metadata_dir,
+            tokenizer,
+            v4_compatible=False,
+            model_config=deploy_config,
+            save_custom_model_code=bool(getattr(deploy_config, "auto_map", None)),
+        )
+        _save_generated_sentence_transformer_assets(
+            self.model_part,
+            self.export_config,
+            source_model_path,
+            hf_metadata_dir,
+            tokenizer,
+        )

--- a/nemo_automodel/components/checkpoint/addons.py
+++ b/nemo_automodel/components/checkpoint/addons.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Protocol
 
 import torch
 from torch import nn
+from torch.nn.parallel import DistributedDataParallel
 
 from nemo_automodel.components.checkpoint._backports.hf_utils import (
     FQN_TO_DTYPE_MAPPING_FILENAME,
@@ -42,6 +43,67 @@ def _group_barrier(process_group: "ProcessGroup | None") -> None:
         torch.distributed.barrier(group=process_group)
 
 
+def _unwrap_ddp_model(model: nn.Module) -> nn.Module:
+    """Return the module that owns export metadata hidden by DDP."""
+    if isinstance(model, DistributedDataParallel):
+        return model.module
+    return model
+
+
+def _save_generated_hf_assets(
+    model_part: nn.Module,
+    metadata_reference_path: str | None,
+    hf_metadata_dir: str,
+    tokenizer,
+    v4_compatible: bool,
+    model_config=None,
+    save_custom_model_code: bool = True,
+) -> None:
+    """Run the existing generated Hugging Face metadata export path."""
+    if save_custom_model_code:
+        _maybe_save_custom_model_code(metadata_reference_path, hf_metadata_dir, model_part=model_part)
+
+    config = model_config if model_config is not None else getattr(model_part, "config", None)
+    if config is not None:
+        config_name = "config.json"
+        if v4_compatible and _config_exists(metadata_reference_path, config_name):
+            _save_original_config_json(metadata_reference_path, hf_metadata_dir, config_name)
+            config_name = "config.v5.json"
+
+        _maybe_strip_quantization_config(model_part, config=config)
+        with open(os.path.join(hf_metadata_dir, config_name), "w") as f:
+            if hasattr(config, "to_json_string"):
+                # Use ``use_diff=False`` so the full config (not the
+                # diff against class defaults) is serialized. For
+                # remote-code configs registered via
+                # ``register_for_auto_class`` (e.g. DeciLM /
+                # Llama-Nemotron-Super-49B ``model_type='nemotron-nas'``),
+                # ``to_diff_dict`` sees the class-level ``model_type``
+                # attribute as equal to the class default and drops
+                # it from the serialized JSON. Reloading via
+                # ``AutoConfig.from_pretrained`` on the resulting
+                # consolidated directory then raises
+                # ``Unrecognized model ... Should have a 'model_type'
+                # key``. Writing the full dict guarantees
+                # ``model_type``, ``architectures`` and ``auto_map``
+                # land in the saved config regardless of class defaults.
+                f.write(config.to_json_string(use_diff=False))
+            else:
+                # Diffusers models use FrozenDict for config instead of PretrainedConfig
+                json.dump(dict(config), f, indent=2, default=str)
+
+    if getattr(model_part, "generation_config", None) is not None:
+        config_name = "generation_config.json"
+        if v4_compatible and _config_exists(metadata_reference_path, config_name):
+            _save_original_config_json(metadata_reference_path, hf_metadata_dir, config_name)
+            config_name = "generation_config.v5.json"
+        with open(os.path.join(hf_metadata_dir, config_name), "w") as f:
+            f.write(model_part.generation_config.to_json_string())
+
+    if tokenizer is not None:
+        tokenizer.save_pretrained(hf_metadata_dir)
+
+
 class CheckpointAddon(Protocol):
     """
     Optional hooks that run around backend IO (used for PEFT and consolidated HF metadata).
@@ -52,12 +114,31 @@ class CheckpointAddon(Protocol):
     def post_save(self, **kwargs) -> None: ...
 
 
+class _ConsolidatedHFMetadataExporter(Protocol):
+    """Model-provided writer for consolidated Hugging Face metadata."""
+
+    def validate(self, *, tokenizer: object, original_model_path: str | None) -> None:
+        """Validate exporter inputs before any distributed rank writes files."""
+        ...
+
+    def save(
+        self,
+        *,
+        hf_metadata_dir: str,
+        tokenizer: object,
+        original_model_path: str | None,
+    ) -> None:
+        """Write model-specific metadata into the shared Hugging Face metadata directory."""
+        ...
+
+
 class ConsolidatedHFAddon:
     """
     Addon that writes consolidated Hugging Face metadata alongside sharded weights.
 
-    On rank 0, this saves `config.json`, `generation_config.json`, and tokenizer
-    artifacts into the provided consolidated directory, then synchronizes ranks.
+    Models can provide a custom consolidated metadata exporter; all other models
+    retain the generated config, custom-code, and tokenizer path. Rank 0 writes
+    the artifacts, then synchronizes ranks.
     """
 
     def pre_save(self, **kwargs) -> None:
@@ -69,6 +150,7 @@ class ConsolidatedHFAddon:
             hf_metadata_dir (str): Target directory for HF metadata artifacts.
             tokenizer (PreTrainedTokenizerBase | None): Optional tokenizer to save.
             fqn_to_dtype_mapping (dict[str, str] | None): Original HF safetensors dtype map.
+            original_model_path (str | None): Authoritative source checkpoint snapshot.
         """
         model_state = kwargs["model_state"]
         hf_metadata_dir = kwargs["hf_metadata_dir"]
@@ -79,52 +161,38 @@ class ConsolidatedHFAddon:
         original_model_path = kwargs["original_model_path"]
         process_group = kwargs.get("process_group")
 
+        export_model = _unwrap_ddp_model(model_part)
+        get_metadata_exporter = getattr(export_model, "_get_consolidated_hf_metadata_exporter", None)
+        metadata_exporter: _ConsolidatedHFMetadataExporter | None = (
+            get_metadata_exporter(
+                tokenizer=tokenizer,
+                original_model_path=original_model_path,
+            )
+            if callable(get_metadata_exporter)
+            else None
+        )
+        if metadata_exporter is not None:
+            metadata_exporter.validate(
+                tokenizer=tokenizer,
+                original_model_path=original_model_path,
+            )
+
         # Perform save operations on rank 0
         if _is_group_rank_0(process_group):
-            # if the HF model has custom model code, we need to save it as part of the checkpoint
-            _maybe_save_custom_model_code(original_model_path, hf_metadata_dir, model_part=model_part)
-            # save the config.json file
-            if hasattr(model_part, "config"):
-                v4_compatible = kwargs.get("v4_compatible", False)
-                config_name = "config.json"
-                if v4_compatible and _config_exists(original_model_path, config_name):
-                    _save_original_config_json(original_model_path, hf_metadata_dir, config_name)
-                    config_name = "config.v5.json"
-
-                _maybe_strip_quantization_config(model_part)
-                with open(os.path.join(hf_metadata_dir, config_name), "w") as f:
-                    if hasattr(model_part.config, "to_json_string"):
-                        # Use ``use_diff=False`` so the full config (not the
-                        # diff against class defaults) is serialized. For
-                        # remote-code configs registered via
-                        # ``register_for_auto_class`` (e.g. DeciLM /
-                        # Llama-Nemotron-Super-49B ``model_type='nemotron-nas'``),
-                        # ``to_diff_dict`` sees the class-level ``model_type``
-                        # attribute as equal to the class default and drops
-                        # it from the serialized JSON. Reloading via
-                        # ``AutoConfig.from_pretrained`` on the resulting
-                        # consolidated directory then raises
-                        # ``Unrecognized model ... Should have a 'model_type'
-                        # key``. Writing the full dict guarantees
-                        # ``model_type``, ``architectures`` and ``auto_map``
-                        # land in the saved config regardless of class defaults.
-                        f.write(model_part.config.to_json_string(use_diff=False))
-                    else:
-                        # Diffusers models use FrozenDict for config instead of PretrainedConfig
-                        json.dump(dict(model_part.config), f, indent=2, default=str)
-
-            # save the generation_config.json file
-            if getattr(model_part, "generation_config", None) is not None:
-                config_name = "generation_config.json"
-                if v4_compatible and _config_exists(original_model_path, config_name):
-                    _save_original_config_json(original_model_path, hf_metadata_dir, config_name)
-                    config_name = "generation_config.v5.json"
-                with open(os.path.join(hf_metadata_dir, config_name), "w") as f:
-                    f.write(model_part.generation_config.to_json_string())
-
-            # save the tokenizer
-            if tokenizer is not None:
-                tokenizer.save_pretrained(hf_metadata_dir)
+            if metadata_exporter is not None:
+                metadata_exporter.save(
+                    hf_metadata_dir=hf_metadata_dir,
+                    tokenizer=tokenizer,
+                    original_model_path=original_model_path,
+                )
+            else:
+                _save_generated_hf_assets(
+                    model_part,
+                    original_model_path,
+                    hf_metadata_dir,
+                    tokenizer,
+                    v4_compatible=kwargs.get("v4_compatible", False),
+                )
 
             # save the fqn_to_file_index_mapping file
             with open(os.path.join(hf_metadata_dir, FQN_TO_FILE_INDEX_MAPPING_FILENAME), "w") as f:
@@ -441,7 +509,7 @@ def _extract_target_modules(
     return sorted(final_target_modules)
 
 
-def _maybe_strip_quantization_config(model_part: nn.Module) -> None:
+def _maybe_strip_quantization_config(model_part: nn.Module, config=None) -> None:
     """Remove ``quantization_config`` from the HF config when no parameters are quantized.
 
     Models loaded from quantized checkpoints (e.g. mxfp4 GPT-OSS) carry a
@@ -451,7 +519,8 @@ def _maybe_strip_quantization_config(model_part: nn.Module) -> None:
     checkpoint is a clean bf16 checkpoint, consistent with e.g.
     ``unsloth/gpt-oss-20b-BF16``.
     """
-    config = getattr(model_part, "config", None)
+    if config is None:
+        config = getattr(model_part, "config", None)
     if config is None or not hasattr(config, "quantization_config"):
         return
 
@@ -462,7 +531,7 @@ def _maybe_strip_quantization_config(model_part: nn.Module) -> None:
     delattr(config, "quantization_config")
 
 
-def _config_exists(original_model_path: str, config_name: str) -> bool:
+def _config_exists(original_model_path: str | None, config_name: str) -> bool:
     if original_model_path is None or not os.path.isdir(original_model_path):
         return False
     src = os.path.join(original_model_path, config_name)

--- a/nemo_automodel/recipes/retrieval/train_bi_encoder.py
+++ b/nemo_automodel/recipes/retrieval/train_bi_encoder.py
@@ -62,6 +62,40 @@ def _unwrap_model_for_attrs(model):
     return getattr(model, "module", model)
 
 
+def _configure_sentence_transformer_export(model, collate_fn) -> None:
+    """Bind the training collator's exact static prompts to bi-encoder export metadata."""
+    model = _unwrap_model_for_attrs(model)
+    configure_prompts = getattr(model, "configure_sentence_transformer_prompts", None)
+    if configure_prompts is None:
+        return
+    if hasattr(model, "sentence_transformer_export_config") and model.sentence_transformer_export_config is None:
+        return
+
+    if getattr(collate_fn, "use_dataset_instruction", False):
+        disable_export = getattr(model, "disable_sentence_transformer_export", None)
+        if disable_export is not None:
+            disable_export()
+            logger.warning(
+                "Standard Sentence Transformers export is disabled because per-example dataset instructions "
+                "cannot be represented by static checkpoint prompts."
+            )
+        return
+    else:
+        if not hasattr(collate_fn, "query_prefix") or not hasattr(collate_fn, "passage_prefix"):
+            disable_export = getattr(model, "disable_sentence_transformer_export", None)
+            if disable_export is not None:
+                disable_export()
+                logger.warning(
+                    "Standard Sentence Transformers export is disabled because the configured collator "
+                    "does not expose static query_prefix and passage_prefix metadata."
+                )
+            return
+        query_prompt = f"{collate_fn.query_prefix} " if collate_fn.query_prefix else ""
+        document_prompt = f"{collate_fn.passage_prefix} " if collate_fn.passage_prefix else ""
+
+    configure_prompts(query_prompt=query_prompt, document_prompt=document_prompt)
+
+
 def _get_autocast_ctx(distributed_config):
     """Return the optional recipe-level autocast context."""
     autocast_dtype = getattr(distributed_config, "autocast_dtype", None)
@@ -326,6 +360,7 @@ class TrainBiEncoderRecipe(BaseRecipe):
                 )
 
         self.dataloader = materialize_loader(dataloader_config)
+        _configure_sentence_transformer_export(self.model_parts[0], self.dataloader.collate_fn)
         self.train_n_passages = getattr(dataloader_config.dataset_config, "n_passages", 1)
 
         self.val_dataloader = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,7 +222,15 @@ linting = [
     "import-linter~=2.4",
     "ty>=0.0.20",
 ]
-test = ["coverage", "pytest", "pytest-shard", "peft>=0.18.1", "ruamel.yaml", "onnxruntime-gpu; (platform_machine == 'x86_64' and platform_system != 'Darwin')"]
+test = [
+    "coverage",
+    "pytest",
+    "pytest-shard",
+    "peft>=0.18.1",
+    "ruamel.yaml",
+    "onnxruntime-gpu; (platform_machine == 'x86_64' and platform_system != 'Darwin')",
+    "sentence-transformers>=5.6.0",
+]
 dev = [
     "cut-cross-entropy",
     "liger-kernel; (platform_machine == 'x86_64' and platform_system != 'Darwin')",

--- a/tests/unit_tests/_transformers/test_retrieval.py
+++ b/tests/unit_tests/_transformers/test_retrieval.py
@@ -14,6 +14,7 @@
 
 """Functional tests for retrieval backbone extraction."""
 
+import inspect
 import json
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -21,15 +22,30 @@ from unittest.mock import MagicMock
 import pytest
 import torch
 import torch.nn as nn
-from transformers import AutoModel, Ministral3Config, Mistral3Config
+from tokenizers import Tokenizer
+from tokenizers.models import WordLevel
+from tokenizers.pre_tokenizers import Whitespace
+from transformers import (
+    AutoModel,
+    LlamaConfig,
+    Ministral3Config,
+    Mistral3Config,
+    PretrainedConfig,
+    PreTrainedTokenizerFast,
+)
 from transformers.models.ministral3.modeling_ministral3 import (
     Ministral3ForSequenceClassification,
     Ministral3Model,
 )
 
 from nemo_automodel.components.models.llama_bidirectional.model import (
+    LlamaBidirectionalConfig,
     LlamaBidirectionalForSequenceClassification,
     LlamaBidirectionalModel,
+)
+from nemo_automodel.components.models.ministral_bidirectional.model import (
+    Ministral3BidirectionalConfig,
+    Ministral3BidirectionalModel,
 )
 
 
@@ -75,6 +91,22 @@ def _save_tiny_vlm(tmp_path, text_model_type: str):
     model.save_pretrained(model_dir)
     language_state_dict = {key: tensor.detach().clone() for key, tensor in model.language_model.state_dict().items()}
     return model_dir, language_state_dict
+
+
+def _tiny_tokenizer() -> PreTrainedTokenizerFast:
+    tokenizer_backend = Tokenizer(
+        WordLevel(
+            {"[UNK]": 0, "[PAD]": 1, "hello": 2, "world": 3},
+            unk_token="[UNK]",
+        )
+    )
+    tokenizer_backend.pre_tokenizer = Whitespace()
+    return PreTrainedTokenizerFast(
+        tokenizer_object=tokenizer_backend,
+        unk_token="[UNK]",
+        pad_token="[PAD]",
+        model_max_length=32,
+    )
 
 
 def _save_tiny_ministral_text_model(tmp_path):
@@ -127,6 +159,155 @@ def test_save_encoder_pretrained_forwards_is_final_checkpoint(tmp_path, kwargs, 
         tokenizer=None,
         is_final_checkpoint=expected_is_final,
     )
+
+
+def test_bi_encoder_public_api_excludes_export_format_overrides():
+    from nemo_automodel._transformers import auto_model, retrieval
+
+    export_only_parameters = {
+        "query_prompt",
+        "document_prompt",
+        "sentence_transformer_max_seq_length",
+        "similarity_fn_name",
+        "do_lower_case",
+    }
+    for callable_ in (
+        retrieval.BiEncoderModel.__init__,
+        retrieval.BiEncoderModel.build,
+        auto_model.NeMoAutoModelBiEncoder.from_pretrained,
+    ):
+        parameters = inspect.signature(callable_).parameters
+        assert export_only_parameters.isdisjoint(parameters)
+        assert {"pooling", "l2_normalize"} <= parameters.keys()
+
+
+def test_effective_pipeline_prompts_replace_restored_export_defaults():
+    from nemo_automodel._transformers import retrieval
+
+    encoder = SimpleNamespace(
+        sentence_transformer_export_config=retrieval.SentenceTransformerExportConfig(
+            query_prompt="saved query: ",
+            document_prompt="saved document: ",
+        )
+    )
+
+    retrieval.BiEncoderModel.configure_sentence_transformer_prompts(
+        encoder,
+        query_prompt="current query: ",
+        document_prompt="current document: ",
+    )
+
+    assert encoder.sentence_transformer_export_config.query_prompt == "current query: "
+    assert encoder.sentence_transformer_export_config.document_prompt == "current document: "
+
+
+def test_direct_save_without_tokenizer_omits_sentence_transformer_metadata(tmp_path, caplog):
+    from nemo_automodel._transformers import retrieval
+
+    backbone = LlamaBidirectionalModel(
+        LlamaBidirectionalConfig(
+            vocab_size=32,
+            hidden_size=16,
+            intermediate_size=32,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+        )
+    )
+    encoder = retrieval.BiEncoderModel(backbone, pooling="avg", l2_normalize=False)
+    save_dir = tmp_path / "missing_tokenizer"
+
+    encoder.save_pretrained(save_dir)
+
+    assert (save_dir / "config.json").is_file()
+    assert (save_dir / "model.safetensors").is_file()
+    assert not (save_dir / "modules.json").exists()
+    assert "no tokenizer was provided" in caplog.text
+
+
+def test_direct_save_omits_unrepresentable_sentence_transformer_metadata(tmp_path, caplog):
+    from nemo_automodel._transformers import retrieval
+
+    backbone = LlamaBidirectionalModel(
+        LlamaBidirectionalConfig(
+            vocab_size=32,
+            hidden_size=16,
+            intermediate_size=32,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            max_position_embeddings=64,
+        )
+    )
+    encoder = retrieval.BiEncoderModel(backbone, pooling="avg", l2_normalize=True)
+    backbone.config.max_position_embeddings = 1_000_000_000
+    tokenizer = _tiny_tokenizer()
+    tokenizer.model_max_length = int(1e30)
+    save_dir = tmp_path / "unrepresentable_export"
+
+    assert (
+        encoder._get_consolidated_hf_metadata_exporter(tokenizer=tokenizer, original_model_path=None) is None
+    )
+    encoder.save_pretrained(save_dir, tokenizer=tokenizer)
+
+    assert (save_dir / "config.json").is_file()
+    assert (save_dir / "model.safetensors").is_file()
+    assert not (save_dir / "modules.json").exists()
+    assert "cannot be represented faithfully" in caplog.text
+
+
+def test_direct_standard_export_uses_general_sequence_capabilities(tmp_path):
+    from nemo_automodel._transformers import retrieval
+
+    backbone = LlamaBidirectionalModel(
+        LlamaBidirectionalConfig(
+            vocab_size=32,
+            hidden_size=16,
+            intermediate_size=32,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            max_position_embeddings=64,
+        )
+    )
+    encoder = retrieval.BiEncoderModel(backbone, pooling="avg", l2_normalize=True)
+    tokenizer = _tiny_tokenizer()
+    save_dir = tmp_path / "derived_export"
+
+    encoder.save_pretrained(save_dir, tokenizer=tokenizer)
+
+    metadata = json.loads((save_dir / "sentence_bert_config.json").read_text())
+    assert metadata == {"max_seq_length": tokenizer.model_max_length, "do_lower_case": False}
+
+
+def test_direct_standard_export_preserves_cached_source_deployment_limit(tmp_path):
+    from nemo_automodel._transformers import retrieval
+
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / "sentence_bert_config.json").write_text('{"max_seq_length": 16}')
+
+    backbone = LlamaBidirectionalModel(
+        LlamaBidirectionalConfig(
+            vocab_size=32,
+            hidden_size=16,
+            intermediate_size=32,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            max_position_embeddings=32,
+        )
+    )
+    encoder = retrieval.BiEncoderModel(
+        backbone,
+        pooling="avg",
+        l2_normalize=True,
+    )
+    encoder.source_model_path = str(source_dir)
+    save_dir = tmp_path / "source_limit"
+    encoder.save_pretrained(save_dir, tokenizer=_tiny_tokenizer())
+
+    assert json.loads((save_dir / "sentence_bert_config.json").read_text())["max_seq_length"] == 16
 
 
 def test_extract_submodel_embedding_fallback_is_bidirectional(tmp_path):
@@ -315,6 +496,155 @@ def test_ministral_embedding_preserves_hf_config_overrides(tmp_path):
     assert backbone.config.output_attentions is True
 
 
+def test_bi_encoder_build_forwards_native_hf_kwargs_to_config_and_backbone(monkeypatch):
+    """The preliminary config load retains native HuggingFace loader behavior."""
+    from nemo_automodel._transformers import retrieval
+
+    config = PretrainedConfig()
+    config.model_type = "test"
+    backbone = MagicMock(spec=nn.Module)
+    backbone.config = config
+    backbone.main_input_name = "pixel_values"
+    backbone.forward = MagicMock()
+    auto_config_from_pretrained = MagicMock(return_value=config)
+    build_encoder_backbone = MagicMock(return_value=backbone)
+    monkeypatch.setattr(retrieval.AutoConfig, "from_pretrained", auto_config_from_pretrained)
+    monkeypatch.setattr(retrieval, "build_encoder_backbone", build_encoder_backbone)
+    monkeypatch.setattr(retrieval, "_load_sentence_transformer_wrapper_options", MagicMock(return_value=None))
+    monkeypatch.setattr(retrieval, "_resolve_cached_source_model_path", MagicMock(return_value=None))
+
+    retrieval.BiEncoderModel.build(
+        "org/model",
+        task="embedding",
+        revision="revision-a",
+        output_attentions=True,
+        device_map="cpu",
+    )
+
+    auto_config_from_pretrained.assert_called_once_with(
+        "org/model",
+        trust_remote_code=False,
+        revision="revision-a",
+        output_attentions=True,
+        device_map="cpu",
+    )
+    build_encoder_backbone.assert_called_once_with(
+        "org/model",
+        "embedding",
+        trust_remote_code=False,
+        pooling="avg",
+        loaded_config=config,
+        revision="revision-a",
+        output_attentions=True,
+        device_map="cpu",
+    )
+
+
+@pytest.mark.parametrize("pooling", ["weighted_avg", "colbert", "multi_vector"])
+def test_bi_encoder_skips_standard_export_for_unrepresentable_pooling(pooling, tmp_path):
+    from nemo_automodel._transformers import retrieval
+
+    backbone = LlamaBidirectionalModel(
+        LlamaBidirectionalConfig(
+            vocab_size=32,
+            hidden_size=16,
+            intermediate_size=32,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+        )
+    )
+    encoder = retrieval.BiEncoderModel(backbone, pooling=pooling, l2_normalize=True)
+
+    assert encoder.sentence_transformer_export_config is None
+    encoder.configure_sentence_transformer_prompts(query_prompt="query: ", document_prompt="passage: ")
+    save_dir = tmp_path / pooling
+    encoder.save_pretrained(save_dir)
+    assert (save_dir / "config.json").exists()
+    assert not (save_dir / "modules.json").exists()
+
+
+def test_bi_encoder_skips_standard_export_for_multimodal_backbone():
+    from nemo_automodel._transformers import retrieval
+
+    class CompositeBackbone(nn.Module):
+        main_input_name = "pixel_values"
+
+        def __init__(self):
+            super().__init__()
+            self.config = PretrainedConfig()
+            self.config.is_composition = True
+            self.config.llm_config = PretrainedConfig(hidden_size=16)
+            self.config.name_or_path = ""
+
+    encoder = retrieval.BiEncoderModel(CompositeBackbone(), pooling="last", l2_normalize=True)
+
+    assert encoder.sentence_transformer_export_config is None
+    encoder.configure_sentence_transformer_prompts(query_prompt="query: ", document_prompt="passage: ")
+
+
+def test_bi_encoder_export_config_uses_deployable_hf_base_classes():
+    from nemo_automodel._transformers import retrieval
+
+    backbone = LlamaBidirectionalModel(
+        LlamaBidirectionalConfig(
+            vocab_size=32,
+            hidden_size=16,
+            intermediate_size=32,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            pooling="avg",
+        )
+    )
+    encoder = retrieval.BiEncoderModel(backbone, pooling="cls", l2_normalize=True)
+    encoder.configure_sentence_transformer_prompts(query_prompt="query: ", document_prompt="passage: ")
+
+    export_config = encoder.get_hf_export_config()
+
+    assert isinstance(export_config, LlamaConfig)
+    assert not isinstance(export_config, LlamaBidirectionalConfig)
+    assert export_config.model_type == "llama"
+    assert export_config.architectures == ["LlamaModel"]
+    assert getattr(export_config, "auto_map", None) is None
+    assert export_config.is_causal is False
+    assert export_config.pooling == "cls"
+    assert encoder.config.model_type == "llama_bidirec"
+
+
+def test_bi_encoder_export_config_uses_class_model_type_when_source_type_is_retained():
+    from nemo_automodel._transformers import retrieval
+
+    config = Ministral3BidirectionalConfig.from_dict(
+        {
+            "model_type": "ministral3",
+            "vocab_size": 32,
+            "hidden_size": 16,
+            "intermediate_size": 32,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "head_dim": 8,
+            "pooling": "avg",
+        }
+    )
+    backbone = Ministral3BidirectionalModel(config)
+    encoder = retrieval.BiEncoderModel(backbone, pooling="avg", l2_normalize=True)
+
+    assert encoder.config.model_type == "ministral3"
+    assert type(encoder.config).model_type == "ministral3_bidirec"
+
+    export_config = encoder.get_hf_export_config()
+
+    assert isinstance(export_config, Ministral3Config)
+    assert not isinstance(export_config, Ministral3BidirectionalConfig)
+    assert export_config.model_type == "ministral3"
+    assert export_config.architectures == ["Ministral3Model"]
+    assert getattr(export_config, "auto_map", None) is None
+    assert export_config.is_causal is False
+    assert export_config.pooling == "avg"
+
+
 def test_ministral_embedding_uses_stock_bidirectional_model(tmp_path):
     """Standard Ministral checkpoints use and save the stock non-causal model."""
     from nemo_automodel._transformers import retrieval
@@ -347,16 +677,35 @@ def test_ministral_embedding_uses_stock_bidirectional_model(tmp_path):
         modified_output = backbone(input_ids=modified_input_ids, attention_mask=attention_mask).last_hidden_state
     assert not torch.allclose(original_output[0, 0], modified_output[0, 0])
 
+    encoder = retrieval.BiEncoderModel(backbone, pooling="avg", l2_normalize=True)
+    encoder.configure_sentence_transformer_prompts(query_prompt="query: ", document_prompt="")
+    export_config = encoder.get_hf_export_config()
+
+    assert type(export_config) is Ministral3Config
+    assert export_config.architectures == ["Ministral3Model"]
+    assert export_config.is_causal is False
+    assert getattr(export_config, "auto_map", None) is None
+
     save_dir = tmp_path / "saved_stock_ministral"
-    backbone.save_pretrained(save_dir)
+    encoder.save_pretrained(save_dir, tokenizer=_tiny_tokenizer())
 
     assert not list(save_dir.glob("*.py"))
     reloaded = AutoModel.from_pretrained(save_dir)
+    assert (save_dir / "tokenizer.json").exists()
+    assert json.loads((save_dir / "modules.json").read_text()) == [
+        {"idx": 0, "name": "0", "path": "", "type": "sentence_transformers.models.Transformer"},
+        {"idx": 1, "name": "1", "path": "1_Pooling", "type": "sentence_transformers.models.Pooling"},
+        {"idx": 2, "name": "2", "path": "2_Normalize", "type": "sentence_transformers.models.Normalize"},
+    ]
+    assert json.loads((save_dir / "config_sentence_transformers.json").read_text())["prompts"]["query"] == "query: "
+
     assert type(reloaded) is Ministral3Model
     assert reloaded.config.model_type == "ministral3"
+    assert reloaded.config.architectures == ["Ministral3Model"]
     assert reloaded.config.is_causal is False
     assert getattr(reloaded.config, "auto_map", None) is None
     _assert_state_dict_equal(source_state_dict, reloaded.state_dict())
+    assert reloaded.config.sliding_window == 4
 
 
 def test_ministral_embedding_uses_bidirectional_flash_attention(tmp_path, monkeypatch):
@@ -372,22 +721,308 @@ def test_ministral_embedding_uses_bidirectional_flash_attention(tmp_path, monkey
         pooling="avg",
     )
     assert backbone.config.is_causal is False
+    assert hasattr(backbone.config, "_attn_implementation")
     backbone.config._attn_implementation = "flash_attention_2"
     assert all(layer.self_attn.is_causal is True for layer in backbone.layers)
 
     kernel_calls = []
 
     def record_flash_attention(query, key, value, attention_mask, **kwargs):
-        kernel_calls.append({"is_causal": kwargs.get("is_causal"), "attention_mask": attention_mask})
+        kernel_calls.append(
+            {
+                "is_causal": kwargs.get("is_causal"),
+                "attention_mask": attention_mask,
+            }
+        )
         return torch.zeros_like(query)
 
-    monkeypatch.setattr(flash_attention, "_flash_attention_forward", record_flash_attention)
+    monkeypatch.setattr(
+        flash_attention,
+        "_flash_attention_forward",
+        record_flash_attention,
+    )
 
     input_ids = torch.randint(0, backbone.config.vocab_size, (1, 4))
     backbone(input_ids=input_ids, attention_mask=torch.ones_like(input_ids))
 
     assert len(kernel_calls) == backbone.config.num_hidden_layers
-    assert all(call == {"is_causal": False, "attention_mask": None} for call in kernel_calls)
+    for call in kernel_calls:
+        assert call["attention_mask"] is None
+        assert call["is_causal"] is False
+
+
+@pytest.mark.parametrize(
+    ("pooling", "l2_normalize"),
+    [
+        ("avg", True),
+        ("avg", False),
+        ("mean", True),
+        ("mean", False),
+        ("cls", True),
+        ("cls", False),
+        ("last", True),
+        ("last", False),
+    ],
+)
+def test_sentence_transformers_and_nemo_round_trip_generated_ministral_checkpoint(
+    tmp_path,
+    monkeypatch,
+    pooling,
+    l2_normalize,
+):
+    from sentence_transformers import SentenceTransformer
+
+    from nemo_automodel._transformers import auto_model as auto_model_module
+    from nemo_automodel._transformers import retrieval
+
+    model_dir, _ = _save_tiny_ministral_text_model(tmp_path)
+    backbone = retrieval.build_encoder_backbone(
+        model_name_or_path=str(model_dir),
+        task="embedding",
+        pooling=pooling,
+    )
+    encoder = retrieval.BiEncoderModel(backbone, pooling=pooling, l2_normalize=l2_normalize)
+    encoder.configure_sentence_transformer_prompts(query_prompt="query: ", document_prompt="passage: ")
+    tokenizer = _tiny_tokenizer()
+    raw_texts = ["hello", "hello world"]
+    query_texts = [f"query: {text}" for text in raw_texts]
+    document_texts = [f"passage: {text}" for text in raw_texts]
+    encoder.eval()
+    with torch.no_grad():
+        expected_query = encoder(tokenizer(query_texts, padding=True, return_tensors="pt"))
+        expected_document = encoder(tokenizer(document_texts, padding=True, return_tensors="pt"))
+    save_dir = tmp_path / f"sentence_transformers_ministral_{pooling}_{l2_normalize}"
+    encoder.save_pretrained(save_dir, tokenizer=tokenizer)
+
+    sentence_transformer = SentenceTransformer(str(save_dir), device="cpu")
+    actual_query = sentence_transformer.encode_query(raw_texts, convert_to_tensor=True)
+    actual_document = sentence_transformer.encode_document(raw_texts, convert_to_tensor=True)
+    actual_similarity = sentence_transformer.similarity(actual_query, actual_document)
+    if l2_normalize:
+        expected_similarity = torch.nn.functional.cosine_similarity(
+            expected_query[:, None, :], expected_document[None, :, :], dim=-1
+        )
+        expected_similarity_fn = "cosine"
+    else:
+        expected_similarity = expected_query @ expected_document.T
+        expected_similarity_fn = "dot"
+
+    setup = SimpleNamespace(
+        mesh_context=None,
+        strategy_config=None,
+        moe_parallel_config=None,
+        activation_checkpointing=None,
+    )
+    monkeypatch.setattr(auto_model_module, "_resolve_distributed_setup", lambda **_: setup)
+    monkeypatch.setattr(
+        auto_model_module,
+        "instantiate_infrastructure",
+        lambda **_: (None, None, None, None),
+    )
+    monkeypatch.setattr(auto_model_module.torch.cuda, "current_device", lambda: 0)
+    monkeypatch.setattr(auto_model_module, "apply_model_infrastructure", lambda model, **_: model)
+    nemo_reloaded = auto_model_module.NeMoAutoModelBiEncoder.from_pretrained(
+        str(save_dir),
+        attn_implementation="eager",
+        use_liger_kernel=False,
+        use_sdpa_patching=False,
+    )
+    nemo_reloaded.eval()
+    with torch.no_grad():
+        nemo_query = nemo_reloaded(tokenizer(query_texts, padding=True, return_tensors="pt"))
+        nemo_document = nemo_reloaded(tokenizer(document_texts, padding=True, return_tensors="pt"))
+
+    assert encoder.pooling == ("avg" if pooling == "mean" else pooling)
+    assert nemo_reloaded.pooling == ("avg" if pooling == "mean" else pooling)
+    assert nemo_reloaded.l2_normalize is l2_normalize
+    assert sentence_transformer.similarity_fn_name == expected_similarity_fn
+    assert sentence_transformer.max_seq_length == 32
+    assert actual_query.shape == actual_document.shape == nemo_query.shape == nemo_document.shape == (2, 16)
+    torch.testing.assert_close(actual_query, expected_query)
+    torch.testing.assert_close(actual_document, expected_document)
+    torch.testing.assert_close(actual_similarity, expected_similarity)
+    torch.testing.assert_close(nemo_query, expected_query)
+    torch.testing.assert_close(nemo_document, expected_document)
+
+
+def test_consolidated_checkpointer_round_trip_through_sentence_transformers_and_nemo(tmp_path, monkeypatch):
+    from sentence_transformers import SentenceTransformer
+
+    from nemo_automodel._transformers import auto_model as auto_model_module
+    from nemo_automodel._transformers import retrieval
+    from nemo_automodel.components.checkpoint.config import CheckpointingConfig
+
+    model_dir, _ = _save_tiny_ministral_text_model(tmp_path)
+    encoder = retrieval.BiEncoderModel.build(
+        str(model_dir),
+        pooling="last",
+        l2_normalize=False,
+        attn_implementation="eager",
+    )
+    encoder.configure_sentence_transformer_prompts(query_prompt="query: ", document_prompt="passage: ")
+    tokenizer = _tiny_tokenizer()
+    raw_texts = ["hello", "hello world"]
+    query_texts = [f"query: {text}" for text in raw_texts]
+    document_texts = [f"passage: {text}" for text in raw_texts]
+    encoder.eval()
+    with torch.no_grad():
+        expected_query = encoder(tokenizer(query_texts, padding=True, return_tensors="pt"))
+        expected_document = encoder(tokenizer(document_texts, padding=True, return_tensors="pt"))
+
+    checkpoint_config = CheckpointingConfig(
+        enabled=True,
+        checkpoint_dir=str(tmp_path / "checkpoints"),
+        model_save_format="safetensors",
+        model_cache_dir=str(tmp_path),
+        model_repo_id=str(model_dir),
+        save_consolidated="final",
+        is_peft=False,
+    )
+    checkpointer = checkpoint_config.build(dp_rank=0, tp_rank=0, pp_rank=0, moe_mesh=None)
+    step_dir = tmp_path / "checkpoints" / "step_1"
+    try:
+        encoder.save_pretrained(
+            str(step_dir),
+            checkpointer=checkpointer,
+            tokenizer=tokenizer,
+            is_final_checkpoint=True,
+        )
+    finally:
+        checkpointer.close()
+
+    consolidated_dir = step_dir / "model" / "consolidated"
+    for asset in (
+        "config.json",
+        "modules.json",
+        "config_sentence_transformers.json",
+        "sentence_bert_config.json",
+        "1_Pooling/config.json",
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "model.safetensors.index.json",
+    ):
+        assert (consolidated_dir / asset).is_file(), asset
+    assert list(consolidated_dir.glob("*.safetensors"))
+    assert not (consolidated_dir / "2_Normalize").exists()
+
+    sentence_transformer = SentenceTransformer(str(consolidated_dir), device="cpu")
+    actual_query = sentence_transformer.encode_query(raw_texts, convert_to_tensor=True)
+    actual_document = sentence_transformer.encode_document(raw_texts, convert_to_tensor=True)
+
+    setup = SimpleNamespace(
+        mesh_context=None,
+        strategy_config=None,
+        moe_parallel_config=None,
+        activation_checkpointing=None,
+    )
+    monkeypatch.setattr(auto_model_module, "_resolve_distributed_setup", lambda **_: setup)
+    monkeypatch.setattr(auto_model_module, "instantiate_infrastructure", lambda **_: (None, None, None, None))
+    monkeypatch.setattr(auto_model_module.torch.cuda, "current_device", lambda: 0)
+    monkeypatch.setattr(auto_model_module, "apply_model_infrastructure", lambda model, **_: model)
+    nemo_reloaded = auto_model_module.NeMoAutoModelBiEncoder.from_pretrained(
+        str(consolidated_dir),
+        attn_implementation="eager",
+        use_liger_kernel=False,
+        use_sdpa_patching=False,
+    )
+    nemo_reloaded.eval()
+    with torch.no_grad():
+        nemo_query = nemo_reloaded(tokenizer(query_texts, padding=True, return_tensors="pt"))
+        nemo_document = nemo_reloaded(tokenizer(document_texts, padding=True, return_tensors="pt"))
+
+    assert sentence_transformer.similarity_fn_name == "dot"
+    assert nemo_reloaded.pooling == "last"
+    assert nemo_reloaded.l2_normalize is False
+    torch.testing.assert_close(actual_query, expected_query)
+    torch.testing.assert_close(actual_document, expected_document)
+    torch.testing.assert_close(nemo_query, expected_query)
+    torch.testing.assert_close(nemo_document, expected_document)
+
+
+def test_nemo_bi_encoder_explicit_options_override_sentence_transformer_metadata(tmp_path):
+    from nemo_automodel._transformers import retrieval
+
+    model_dir, _ = _save_tiny_ministral_text_model(tmp_path)
+    backbone = retrieval.build_encoder_backbone(
+        model_name_or_path=str(model_dir),
+        task="embedding",
+        pooling="cls",
+    )
+    encoder = retrieval.BiEncoderModel(backbone, pooling="cls", l2_normalize=False)
+    save_dir = tmp_path / "explicit_override"
+    encoder.save_pretrained(save_dir, tokenizer=_tiny_tokenizer())
+
+    reloaded = retrieval.BiEncoderModel.build(
+        str(save_dir),
+        pooling="last",
+        l2_normalize=True,
+    )
+
+    assert reloaded.pooling == "last"
+    assert reloaded.l2_normalize is True
+
+
+def test_nemo_bi_encoder_saved_prompts_round_trip_through_reexport(tmp_path):
+    from nemo_automodel._transformers import retrieval
+
+    model_dir, _ = _save_tiny_ministral_text_model(tmp_path)
+    backbone = retrieval.build_encoder_backbone(
+        model_name_or_path=str(model_dir),
+        task="embedding",
+        pooling="avg",
+    )
+    encoder = retrieval.BiEncoderModel(backbone, pooling="avg", l2_normalize=True)
+    encoder.configure_sentence_transformer_prompts(query_prompt="query: ", document_prompt="passage: ")
+    tokenizer = _tiny_tokenizer()
+    first_export = tmp_path / "first_export"
+    encoder.save_pretrained(first_export, tokenizer=tokenizer)
+
+    reloaded = retrieval.BiEncoderModel.build(str(first_export))
+    assert reloaded.sentence_transformer_export_config.query_prompt == "query: "
+    assert reloaded.sentence_transformer_export_config.document_prompt == "passage: "
+
+    second_export = tmp_path / "second_export"
+    reloaded.save_pretrained(second_export, tokenizer=tokenizer)
+    metadata = json.loads((second_export / "config_sentence_transformers.json").read_text())
+    assert metadata["prompts"] == {"query": "query: ", "document": "passage: "}
+
+
+def test_mean_pooling_alias_matches_avg():
+    from nemo_automodel._transformers import retrieval
+
+    hidden_states = torch.tensor([[[1.0, 2.0], [3.0, 4.0], [100.0, 100.0]]])
+    attention_mask = torch.tensor([[1, 1, 0]])
+
+    torch.testing.assert_close(
+        retrieval.pool(hidden_states, attention_mask, "mean"),
+        retrieval.pool(hidden_states, attention_mask, "avg"),
+    )
+
+
+def test_nemo_bi_encoder_uses_defaults_without_sentence_transformer_metadata():
+    from nemo_automodel._transformers import retrieval
+
+    config = PretrainedConfig()
+
+    assert retrieval._resolve_bi_encoder_options(config, None, None, None) == ("avg", True)
+
+    assert retrieval._resolve_bi_encoder_options(PretrainedConfig(pooling="mean"), None, None, None) == ("avg", True)
+
+
+def test_nemo_bi_encoder_build_canonicalizes_mean_pooling(tmp_path):
+    from nemo_automodel._transformers import retrieval
+
+    model_dir, _ = _save_tiny_ministral_text_model(tmp_path)
+
+    encoder = retrieval.BiEncoderModel.build(
+        str(model_dir),
+        pooling="mean",
+        attn_implementation="eager",
+    )
+
+    assert encoder.pooling == "avg"
+    assert not hasattr(encoder.model.config, "pooling")
+    assert encoder.sentence_transformer_export_config is not None
 
 
 def test_extract_submodel_ministral_embedding_from_local_vlm_converts_to_supported_backbone(tmp_path):

--- a/tests/unit_tests/_transformers/test_sentence_transformer_export.py
+++ b/tests/unit_tests/_transformers/test_sentence_transformer_export.py
@@ -1,0 +1,426 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from tokenizers import Tokenizer
+from tokenizers.models import WordLevel
+from tokenizers.pre_tokenizers import Whitespace
+from transformers import AutoTokenizer, PreTrainedTokenizerFast
+
+from nemo_automodel import NeMoAutoTokenizer
+from nemo_automodel._transformers import sentence_transformer_export
+from nemo_automodel._transformers.sentence_transformer_export import (
+    _resolve_sentence_transformer_max_seq_length,
+    _save_generated_sentence_transformer_assets,
+)
+
+
+def test_generated_sentence_transformer_assets_regenerate_semantics_and_preserve_source_limit(tmp_path):
+    source_dir = tmp_path / "source"
+    metadata_dir = tmp_path / "metadata"
+    source_dir.mkdir()
+    metadata_dir.mkdir()
+    (source_dir / "config_sentence_transformers.json").write_text(
+        json.dumps(
+            {
+                "prompts": {"query": "source query: ", "document": "source document: "},
+                "similarity_fn_name": "cosine",
+            }
+        )
+    )
+    (source_dir / "sentence_bert_config.json").write_text(json.dumps({"max_seq_length": 8192, "do_lower_case": False}))
+    model = SimpleNamespace(
+        pooling="avg",
+        l2_normalize=True,
+        config=SimpleNamespace(hidden_size=8, max_position_embeddings=32768),
+    )
+    export_config = SimpleNamespace(
+        query_prompt=None,
+        document_prompt=None,
+    )
+    tokenizer = SimpleNamespace(model_max_length=512)
+
+    _save_generated_sentence_transformer_assets(
+        model,
+        export_config,
+        str(source_dir),
+        str(metadata_dir),
+        tokenizer,
+    )
+
+    sentence_config = json.loads((metadata_dir / "config_sentence_transformers.json").read_text())
+    assert sentence_config["prompts"] == {"query": "", "document": ""}
+    assert sentence_config["similarity_fn_name"] == "cosine"
+    assert json.loads((metadata_dir / "sentence_bert_config.json").read_text()) == {
+        "max_seq_length": 8192,
+        "do_lower_case": False,
+    }
+    assert json.loads((metadata_dir / "modules.json").read_text())[-1] == {
+        "idx": 2,
+        "name": "2",
+        "path": "2_Normalize",
+        "type": "sentence_transformers.models.Normalize",
+    }
+    pooling_config = json.loads((metadata_dir / "1_Pooling" / "config.json").read_text())
+    assert pooling_config["pooling_mode_mean_tokens"] is True
+
+
+def test_inferred_sentence_transformer_max_seq_length_uses_smallest_finite_capability():
+    model = SimpleNamespace(config=SimpleNamespace(max_position_embeddings=512))
+
+    assert (
+        _resolve_sentence_transformer_max_seq_length(
+            model,
+            SimpleNamespace(model_max_length=4096),
+        )
+        == 512
+    )
+    assert (
+        _resolve_sentence_transformer_max_seq_length(
+            model,
+            SimpleNamespace(model_max_length=256),
+        )
+        == 256
+    )
+
+    with pytest.raises(ValueError, match="Unable to determine"):
+        _resolve_sentence_transformer_max_seq_length(
+            SimpleNamespace(config=SimpleNamespace(max_position_embeddings=None)),
+            SimpleNamespace(model_max_length=10**30),
+        )
+
+
+def test_generated_sentence_transformer_assets_remove_training_tokenizer_state(tmp_path):
+    source_dir = tmp_path / "source"
+    metadata_dir = tmp_path / "metadata"
+    source_dir.mkdir()
+    metadata_dir.mkdir()
+    (source_dir / "tokenizer.json").write_text(json.dumps({"truncation": None, "padding": None, "model": {}}))
+    (source_dir / "tokenizer_config.json").write_text(json.dumps({"local_files_only": False, "model_max_length": 512}))
+    (metadata_dir / "tokenizer.json").write_text(
+        json.dumps({"truncation": {"max_length": 32}, "padding": {"length": 32}, "model": {}})
+    )
+    (metadata_dir / "tokenizer_config.json").write_text(
+        json.dumps({"local_files_only": True, "model_max_length": 512, "processor_class": "PixtralProcessor"})
+    )
+    (metadata_dir / "processor_config.json").write_text('{"processor_class": "PixtralProcessor"}')
+    (metadata_dir / "preprocessor_config.json").write_text('{"image_processor_type": "PixtralImageProcessor"}')
+    model = SimpleNamespace(
+        pooling="avg",
+        l2_normalize=True,
+        config=SimpleNamespace(hidden_size=8, max_position_embeddings=512),
+    )
+    export_config = SimpleNamespace(
+        query_prompt="query: ",
+        document_prompt="passage: ",
+    )
+
+    _save_generated_sentence_transformer_assets(
+        model,
+        export_config,
+        str(source_dir),
+        str(metadata_dir),
+        SimpleNamespace(model_max_length=512),
+    )
+
+    tokenizer_json = json.loads((metadata_dir / "tokenizer.json").read_text())
+    tokenizer_config = json.loads((metadata_dir / "tokenizer_config.json").read_text())
+    assert tokenizer_json["truncation"] is None
+    assert tokenizer_json["padding"] is None
+    assert tokenizer_config["local_files_only"] is False
+    assert "processor_class" not in tokenizer_config
+    assert not (metadata_dir / "processor_config.json").exists()
+    assert not (metadata_dir / "preprocessor_config.json").exists()
+
+
+def test_generated_sentence_transformer_assets_preserve_effective_pad_token(tmp_path):
+    source_dir = tmp_path / "source"
+    metadata_dir = tmp_path / "metadata"
+    source_dir.mkdir()
+    metadata_dir.mkdir()
+    tokenizer_backend = Tokenizer(WordLevel({"[UNK]": 0, "hello": 1, "world": 2}, unk_token="[UNK]"))
+    tokenizer_backend.pre_tokenizer = Whitespace()
+    source_tokenizer = PreTrainedTokenizerFast(
+        tokenizer_object=tokenizer_backend,
+        unk_token="[UNK]",
+        model_max_length=32,
+    )
+    source_tokenizer.save_pretrained(source_dir)
+
+    tokenizer = NeMoAutoTokenizer.from_pretrained(source_dir)
+    assert tokenizer.pad_token == "[UNK]"
+    tokenizer.save_pretrained(metadata_dir)
+
+    model = SimpleNamespace(
+        pooling="avg",
+        l2_normalize=True,
+        config=SimpleNamespace(hidden_size=8, max_position_embeddings=32),
+    )
+    export_config = SimpleNamespace(query_prompt="query: ", document_prompt="passage: ")
+    _save_generated_sentence_transformer_assets(
+        model,
+        export_config,
+        str(source_dir),
+        str(metadata_dir),
+        tokenizer,
+    )
+
+    reloaded = AutoTokenizer.from_pretrained(metadata_dir)
+    assert reloaded.pad_token == tokenizer.pad_token
+    assert reloaded.pad_token_id == tokenizer.pad_token_id
+    assert reloaded(["hello", "hello world"], padding=True)["attention_mask"] == [[1, 0], [1, 1]]
+
+
+def test_generated_sentence_transformer_assets_preserve_repository_and_model_root_legal_assets(tmp_path):
+    repository_root = tmp_path / "repository"
+    model_root = repository_root / "encoder"
+    metadata_dir = tmp_path / "metadata"
+    (repository_root / "legal").mkdir(parents=True)
+    model_root.mkdir()
+    metadata_dir.mkdir()
+    (repository_root / "LICENSE.md").write_text("repository license")
+    (repository_root / "NOTICE.md").write_text("repository notice")
+    (repository_root / "THIRD_PARTY_NOTICES.md").write_text("third-party notices")
+    (repository_root / ".gitattributes").write_text("*.safetensors filter=lfs")
+    (repository_root / "COPYING").write_text("copying")
+    (repository_root / "legal" / "LICENSE.txt").write_text("nested license")
+    (model_root / "LICENSE.md").write_text("model license")
+
+    model = SimpleNamespace(
+        pooling="avg",
+        l2_normalize=True,
+        source_repository_path=str(repository_root),
+        config=SimpleNamespace(hidden_size=8, max_position_embeddings=512),
+    )
+    export_config = SimpleNamespace(
+        query_prompt="",
+        document_prompt="",
+    )
+
+    _save_generated_sentence_transformer_assets(
+        model,
+        export_config,
+        str(model_root),
+        str(metadata_dir),
+        SimpleNamespace(model_max_length=512),
+    )
+
+    assert (metadata_dir / "LICENSE.md").read_text() == "model license"
+    assert (metadata_dir / "NOTICE.md").read_text() == "repository notice"
+    assert (metadata_dir / "THIRD_PARTY_NOTICES.md").read_text() == "third-party notices"
+    assert not (metadata_dir / ".gitattributes").exists()
+    assert not (metadata_dir / "COPYING").exists()
+    assert not (metadata_dir / "LICENSE.txt").exists()
+
+
+def test_generated_sentence_transformer_assets_reject_unrepresentable_pooling(tmp_path):
+    metadata_dir = tmp_path / "metadata"
+    metadata_dir.mkdir()
+    model = SimpleNamespace(
+        pooling="weighted_avg",
+        l2_normalize=False,
+        config=SimpleNamespace(hidden_size=8, max_position_embeddings=512),
+    )
+    export_config = SimpleNamespace(
+        query_prompt="",
+        document_prompt="",
+    )
+
+    with pytest.raises(ValueError, match="cannot be represented"):
+        _save_generated_sentence_transformer_assets(
+            model,
+            export_config,
+            original_model_path=None,
+            hf_metadata_dir=str(metadata_dir),
+            tokenizer=None,
+        )
+
+
+@pytest.mark.parametrize(("l2_normalize", "expected_similarity"), [(False, "dot"), (True, "cosine")])
+def test_generated_sentence_transformer_assets_derive_interoperability_metadata(
+    tmp_path,
+    l2_normalize,
+    expected_similarity,
+):
+    model = SimpleNamespace(
+        pooling="avg",
+        l2_normalize=l2_normalize,
+        config=SimpleNamespace(hidden_size=8, max_position_embeddings=512),
+    )
+    export_config = SimpleNamespace(query_prompt="query: ", document_prompt="passage: ")
+
+    _save_generated_sentence_transformer_assets(
+        model,
+        export_config,
+        original_model_path=None,
+        hf_metadata_dir=str(tmp_path),
+        tokenizer=SimpleNamespace(model_max_length=512),
+    )
+
+    sentence_config = json.loads((tmp_path / "config_sentence_transformers.json").read_text())
+    pooling_config = json.loads((tmp_path / "1_Pooling" / "config.json").read_text())
+    transformer_config = json.loads((tmp_path / "sentence_bert_config.json").read_text())
+    assert sentence_config["similarity_fn_name"] == expected_similarity
+    assert pooling_config["include_prompt"] is True
+    assert transformer_config == {"max_seq_length": 512, "do_lower_case": False}
+
+
+def test_generated_sentence_transformer_assets_require_tokenizer(tmp_path):
+    model = SimpleNamespace(
+        pooling="avg",
+        l2_normalize=True,
+        config=SimpleNamespace(hidden_size=8, max_position_embeddings=512),
+    )
+    export_config = SimpleNamespace(
+        query_prompt="",
+        document_prompt="",
+    )
+
+    with pytest.raises(ValueError, match="tokenizer is required"):
+        _save_generated_sentence_transformer_assets(
+            model,
+            export_config,
+            original_model_path=None,
+            hf_metadata_dir=str(tmp_path),
+            tokenizer=None,
+        )
+
+
+def test_cached_source_model_path_uses_exact_loaded_revision(tmp_path, monkeypatch):
+    local_root = tmp_path / "local"
+    (local_root / "encoder").mkdir(parents=True)
+    assert sentence_transformer_export._resolve_cached_source_model_path(
+        str(local_root), SimpleNamespace(), {"subfolder": "encoder"}
+    ) == str(local_root / "encoder")
+    assert sentence_transformer_export._resolve_cached_source_repository_path(
+        str(local_root), str(local_root / "encoder"), {"subfolder": "encoder"}
+    ) == str(local_root)
+
+    cached_config = tmp_path / "snapshot" / "encoder" / "config.json"
+    cached_config.parent.mkdir(parents=True)
+    cached_config.write_text("{}")
+    cache_lookup = MagicMock(return_value=str(cached_config))
+    monkeypatch.setattr(sentence_transformer_export, "try_to_load_from_cache", cache_lookup)
+
+    result = sentence_transformer_export._resolve_cached_source_model_path(
+        "org/model",
+        SimpleNamespace(_commit_hash="exact-commit"),
+        {"cache_dir": "/cache", "revision": "branch", "subfolder": "encoder"},
+    )
+
+    assert result == str(cached_config.parent)
+    assert sentence_transformer_export._resolve_cached_source_repository_path(
+        "org/model", result, {"subfolder": "encoder"}
+    ) == str(tmp_path / "snapshot")
+    cache_lookup.assert_called_once_with(
+        "org/model",
+        "encoder/config.json",
+        cache_dir="/cache",
+        revision="exact-commit",
+    )
+
+
+def test_cache_hub_source_legal_assets_uses_exact_loaded_revision(monkeypatch):
+    snapshot_download = MagicMock(return_value="/cache/snapshot")
+    monkeypatch.setattr(sentence_transformer_export, "snapshot_download", snapshot_download)
+
+    result = sentence_transformer_export._cache_hub_source_legal_assets(
+        "org/model",
+        SimpleNamespace(_commit_hash="exact-commit"),
+        {
+            "cache_dir": "/cache",
+            "revision": "branch",
+            "use_auth_token": "token",
+            "local_files_only": True,
+        },
+    )
+
+    assert result == "/cache/snapshot"
+    snapshot_download.assert_called_once_with(
+        repo_id="org/model",
+        allow_patterns=sentence_transformer_export._SOURCE_LEGAL_ASSET_PATTERNS,
+        cache_dir="/cache",
+        local_files_only=True,
+        revision="exact-commit",
+        token="token",
+    )
+
+
+def test_sentence_transformer_source_with_unsupported_module_is_rejected(tmp_path):
+    (tmp_path / "1_Pooling").mkdir()
+    (tmp_path / "modules.json").write_text(
+        json.dumps(
+            [
+                {"idx": 0, "path": "", "type": "sentence_transformers.models.Transformer"},
+                {"idx": 1, "path": "1_Pooling", "type": "sentence_transformers.models.Pooling"},
+                {"idx": 2, "path": "2_Dense", "type": "sentence_transformers.models.Dense"},
+            ]
+        )
+    )
+    (tmp_path / "1_Pooling" / "config.json").write_text(json.dumps({"pooling_mode_mean_tokens": True}))
+
+    with pytest.raises(ValueError, match="exact supported module stack"):
+        sentence_transformer_export._load_sentence_transformer_wrapper_options(str(tmp_path), {})
+
+
+def test_sentence_transformer_source_excluding_prompts_is_rejected(tmp_path):
+    (tmp_path / "1_Pooling").mkdir()
+    (tmp_path / "modules.json").write_text(
+        json.dumps(
+            [
+                {"idx": 0, "path": "", "type": "sentence_transformers.models.Transformer"},
+                {"idx": 1, "path": "1_Pooling", "type": "sentence_transformers.models.Pooling"},
+            ]
+        )
+    )
+    (tmp_path / "1_Pooling" / "config.json").write_text(
+        json.dumps({"pooling_mode_mean_tokens": True, "include_prompt": False})
+    )
+
+    with pytest.raises(ValueError, match="include_prompt=False"):
+        sentence_transformer_export._load_sentence_transformer_wrapper_options(str(tmp_path), {})
+
+
+def test_sentence_transformer_source_lowercasing_is_rejected(tmp_path):
+    (tmp_path / "1_Pooling").mkdir()
+    (tmp_path / "modules.json").write_text(
+        json.dumps(
+            [
+                {"idx": 0, "path": "", "type": "sentence_transformers.models.Transformer"},
+                {"idx": 1, "path": "1_Pooling", "type": "sentence_transformers.models.Pooling"},
+            ]
+        )
+    )
+    (tmp_path / "1_Pooling" / "config.json").write_text(json.dumps({"pooling_mode_mean_tokens": True}))
+    (tmp_path / "sentence_bert_config.json").write_text(json.dumps({"do_lower_case": True}))
+
+    with pytest.raises(ValueError, match="do_lower_case=True"):
+        sentence_transformer_export._load_sentence_transformer_wrapper_options(str(tmp_path), {})
+
+
+@pytest.mark.parametrize(
+    "error",
+    [OSError("offline"), sentence_transformer_export.LocalEntryNotFoundError("not cached")],
+)
+def test_sentence_transformer_metadata_discovery_error_falls_back_to_defaults(monkeypatch, caplog, error):
+    monkeypatch.setattr(sentence_transformer_export, "hf_hub_download", MagicMock(side_effect=error))
+
+    result = sentence_transformer_export._load_sentence_transformer_json("org/model", "modules.json", {})
+
+    assert result is None
+    assert "Unable to discover optional Sentence Transformers metadata modules.json" in caplog.text

--- a/tests/unit_tests/checkpoint/test_addons.py
+++ b/tests/unit_tests/checkpoint/test_addons.py
@@ -13,12 +13,16 @@
 # limitations under the License.
 
 import os
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
+import pytest
 import torch
 from torch import nn
+from torch.nn.parallel import DistributedDataParallel
 
 from nemo_automodel.components.checkpoint.addons import (
+    ConsolidatedHFAddon,
     _extract_target_modules,
     _group_barrier,
     _is_group_rank_0,
@@ -97,6 +101,86 @@ def test_maybe_save_custom_model_code_noop_for_none_or_non_dir(tmp_path):
     some_file.write_text("hello")
     _maybe_save_custom_model_code(str(some_file), str(dst_root))
     assert list(dst_root.rglob("*.py")) == []
+
+
+@pytest.mark.parametrize("use_ddp", [False, True])
+def test_consolidated_hf_addon_delegates_to_model_metadata_exporter(tmp_path, use_ddp):
+    metadata_dir = tmp_path / "metadata"
+    metadata_dir.mkdir()
+    exporter = SimpleNamespace(validate=MagicMock(), save=MagicMock())
+    model = nn.Module()
+    model._get_consolidated_hf_metadata_exporter = lambda *, tokenizer, original_model_path: exporter
+    wrapped_model = object.__new__(DistributedDataParallel)
+    nn.Module.__init__(wrapped_model)
+    wrapped_model.module = model
+    tokenizer = MagicMock()
+
+    ConsolidatedHFAddon().pre_save(
+        model_state=SimpleNamespace(model=[wrapped_model if use_ddp else model]),
+        hf_metadata_dir=str(metadata_dir),
+        tokenizer=tokenizer,
+        fqn_to_file_index_mapping={"w": 1},
+        fqn_to_dtype_mapping=None,
+        original_model_path="/source",
+        v4_compatible=True,
+    )
+
+    exporter.validate.assert_called_once_with(tokenizer=tokenizer, original_model_path="/source")
+    exporter.save.assert_called_once_with(
+        hf_metadata_dir=str(metadata_dir),
+        tokenizer=tokenizer,
+        original_model_path="/source",
+    )
+
+
+def test_consolidated_hf_addon_validates_model_exporter_on_nonzero_rank(tmp_path):
+    exporter = SimpleNamespace(
+        validate=MagicMock(side_effect=ValueError("invalid export")),
+        save=MagicMock(),
+    )
+    model = nn.Module()
+    model._get_consolidated_hf_metadata_exporter = lambda *, tokenizer, original_model_path: exporter
+
+    with (
+        patch("torch.distributed.is_initialized", return_value=True),
+        patch("torch.distributed.get_rank", return_value=1),
+        patch("torch.distributed.barrier") as barrier,
+        pytest.raises(ValueError, match="invalid export"),
+    ):
+        ConsolidatedHFAddon().pre_save(
+            model_state=SimpleNamespace(model=[model]),
+            hf_metadata_dir=str(tmp_path),
+            tokenizer=None,
+            fqn_to_file_index_mapping={"w": 1},
+            fqn_to_dtype_mapping=None,
+            original_model_path=None,
+            v4_compatible=False,
+        )
+
+    exporter.save.assert_not_called()
+    barrier.assert_not_called()
+
+
+def test_consolidated_hf_addon_uses_standard_metadata_when_exporter_declines_without_tokenizer(tmp_path):
+    metadata_dir = tmp_path / "metadata"
+    metadata_dir.mkdir()
+    model = nn.Module()
+    model.config = {"model_type": "dummy"}
+    get_metadata_exporter = MagicMock(return_value=None)
+    model._get_consolidated_hf_metadata_exporter = get_metadata_exporter
+
+    ConsolidatedHFAddon().pre_save(
+        model_state=SimpleNamespace(model=[model]),
+        hf_metadata_dir=str(metadata_dir),
+        tokenizer=None,
+        fqn_to_file_index_mapping={"w": 1},
+        fqn_to_dtype_mapping=None,
+        original_model_path=None,
+        v4_compatible=False,
+    )
+
+    get_metadata_exporter.assert_called_once_with(tokenizer=None, original_model_path=None)
+    assert (metadata_dir / "config.json").is_file()
 
 
 def test_model_state_keeps_lm_head_when_storage_not_shared():

--- a/tests/unit_tests/models/bi_encoder/test_bi_encoder_model.py
+++ b/tests/unit_tests/models/bi_encoder/test_bi_encoder_model.py
@@ -150,6 +150,28 @@ def test_from_pretrained_happy_path(monkeypatch):
     assert last_kwargs["some_other_kwarg"] == "x"
 
 
+def test_from_pretrained_defers_omitted_wrapper_options_to_saved_metadata(monkeypatch):
+    last_kwargs = {}
+
+    def fake_build(**kwargs):
+        nonlocal last_kwargs
+        last_kwargs = kwargs
+        return DummyModel()
+
+    _apply_common_mocks(monkeypatch)
+    monkeypatch.setattr(BiEncoderModel, "build", staticmethod(fake_build))
+    monkeypatch.setattr(am, "apply_model_infrastructure", lambda model, **kwargs: model)
+
+    am.NeMoAutoModelBiEncoder.from_pretrained(
+        pretrained_model_name_or_path="some/path",
+        use_liger_kernel=False,
+        use_sdpa_patching=False,
+    )
+
+    assert last_kwargs["pooling"] is None
+    assert last_kwargs["l2_normalize"] is None
+
+
 def _assert_retries_without_liger(monkeypatch, build_model_cls, auto_model_cls):
     """Verify that when liger patching fails, from_pretrained retries without it."""
     calls = {"build": 0, "liger": 0, "sdpa": 0}

--- a/tests/unit_tests/models/bi_encoder/test_llama_bidirectional_model.py
+++ b/tests/unit_tests/models/bi_encoder/test_llama_bidirectional_model.py
@@ -479,6 +479,8 @@ def test_encoder_build_hub_and_errors(tmp_path, monkeypatch):
         return FakeConfig()
 
     monkeypatch.setattr(encoder_module.AutoConfig, "from_pretrained", fake_auto_config_from_pretrained)
+    monkeypatch.setattr(encoder_module, "_load_sentence_transformer_wrapper_options", lambda *args, **kwargs: None)
+    monkeypatch.setattr(encoder_module, "_cache_hub_source_legal_assets", lambda *args, **kwargs: None)
 
     # Hub path
     m1 = BiEncoderModel.build(model_name_or_path="llama-tiny")

--- a/tests/unit_tests/recipes/test_retrieval_bi_encoder_recipe.py
+++ b/tests/unit_tests/recipes/test_retrieval_bi_encoder_recipe.py
@@ -22,6 +22,7 @@ from nemo_automodel.components.distributed.config import DDPConfig, FSDP2Config
 from nemo_automodel.recipes.retrieval import train_bi_encoder
 from nemo_automodel.recipes.retrieval.train_bi_encoder import (
     TrainBiEncoderRecipe,
+    _configure_sentence_transformer_export,
     _get_autocast_ctx,
     _get_model_instantiate_kwargs,
     _unwrap_model_for_attrs,
@@ -65,6 +66,85 @@ def test_retrieval_attrs_accept_unwrapped_model():
 
     assert _unwrap_model_for_attrs(inner) is inner
     assert _uses_multi_vector_scoring(inner) is True
+
+
+def test_configure_sentence_transformer_export_binds_exact_static_collator_prompts():
+    captured = {}
+
+    class _Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def configure_sentence_transformer_prompts(self, **kwargs):
+            captured.update(kwargs)
+
+    collator = SimpleNamespace(
+        query_prefix="query:",
+        passage_prefix="passage:",
+        use_dataset_instruction=False,
+    )
+
+    wrapped = _DDPLikeWrapper(_Model())
+    _configure_sentence_transformer_export(wrapped, collator)
+
+    assert captured == {"query_prompt": "query: ", "document_prompt": "passage: "}
+
+
+def test_configure_sentence_transformer_export_ignores_collator_when_export_is_disabled():
+    class _Model:
+        sentence_transformer_export_config = None
+
+        def configure_sentence_transformer_prompts(self, **kwargs):
+            raise AssertionError(f"disabled export must not configure prompts: {kwargs}")
+
+    _configure_sentence_transformer_export(_Model(), SimpleNamespace())
+
+
+def test_configure_sentence_transformer_export_disables_export_for_dataset_instructions(caplog):
+    class _Model:
+        sentence_transformer_export_config = object()
+
+        def configure_sentence_transformer_prompts(self, **kwargs):
+            raise AssertionError(f"static prompts must not be configured: {kwargs}")
+
+        def disable_sentence_transformer_export(self):
+            self.sentence_transformer_export_config = None
+
+    collator = SimpleNamespace(
+        query_prefix="ignored query:",
+        passage_prefix="ignored passage:",
+        use_dataset_instruction=True,
+    )
+
+    model = _Model()
+    _configure_sentence_transformer_export(model, collator)
+
+    assert model.sentence_transformer_export_config is None
+    assert "per-example dataset instructions" in caplog.text
+
+
+def test_configure_sentence_transformer_export_disables_export_for_custom_collator(caplog):
+    class _Model:
+        sentence_transformer_export_config = object()
+
+        def configure_sentence_transformer_prompts(self, **kwargs):
+            raise AssertionError(f"unknown custom preprocessing must not configure prompts: {kwargs}")
+
+        def disable_sentence_transformer_export(self):
+            self.sentence_transformer_export_config = None
+
+    class _CustomCollator:
+        def __call__(self, examples):
+            return examples
+
+    model = _Model()
+    collator = _CustomCollator()
+    assert callable(collator)
+
+    _configure_sentence_transformer_export(model, collator)
+
+    assert model.sentence_transformer_export_config is None
+    assert "does not expose static query_prefix and passage_prefix metadata" in caplog.text
 
 
 def test_retrieval_autocast_ctx_disabled_by_default(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -4220,6 +4220,7 @@ test = [
     { name = "pytest" },
     { name = "pytest-shard" },
     { name = "ruamel-yaml" },
+    { name = "sentence-transformers" },
 ]
 
 [package.metadata]
@@ -4339,6 +4340,7 @@ test = [
     { name = "pytest" },
     { name = "pytest-shard" },
     { name = "ruamel-yaml" },
+    { name = "sentence-transformers", specifier = ">=5.6.0" },
 ]
 
 [[package]]
@@ -6999,6 +7001,29 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/70/64b4d7ca92f9cf2e6fc6aaa2eecf80bb9b6b985043a9583f32f8177ea122/scipy-1.16.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ffa6eea95283b2b8079b821dc11f50a17d0571c92b43e2b5b12764dc5f9b285d", size = 38802779, upload-time = "2025-10-28T17:37:59.393Z" },
     { url = "https://files.pythonhosted.org/packages/61/82/8d0e39f62764cce5ffd5284131e109f07cf8955aef9ab8ed4e3aa5e30539/scipy-1.16.3-cp314-cp314t-win_amd64.whl", hash = "sha256:d9f48cafc7ce94cf9b15c6bffdc443a81a27bf7075cf2dcd5c8b40f85d10c4e7", size = 39471128, upload-time = "2025-10-28T17:38:05.259Z" },
     { url = "https://files.pythonhosted.org/packages/64/47/a494741db7280eae6dc033510c319e34d42dd41b7ac0c7ead39354d1a2b5/scipy-1.16.3-cp314-cp314t-win_arm64.whl", hash = "sha256:21d9d6b197227a12dcbf9633320a4e34c6b0e51c57268df255a0942983bac562", size = 26464127, upload-time = "2025-10-28T17:38:11.34Z" },
+]
+
+[[package]]
+name = "sentence-transformers"
+version = "5.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "scikit-learn" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.10.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin' and sys_platform != 'linux'" },
+    { name = "torch", version = "2.10.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux'" },
+    { name = "tqdm" },
+    { name = "transformers" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/56/d2cb00765a6b15c994a7fccf20f9032f16e8193ca49147cb5155166ad744/sentence_transformers-5.6.0.tar.gz", hash = "sha256:0e7164d051e416c1853ade7c274ff52af3f9da0f4be7f0b83d734c27699e1057", size = 453194, upload-time = "2026-06-16T14:01:56.42Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/c1/dc1582b79e9a2eb0cddf9559cd9bcdff084f541d6fe881fdd9d98630dba7/sentence_transformers-5.6.0-py3-none-any.whl", hash = "sha256:d2075b5e687a1611005e20ab04a6846994d51adfcf39610aed066af3c0c0b81f", size = 596411, upload-time = "2026-06-16T14:01:55.103Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# What does this PR do?

Manually backports #3021 to `r0.6.0` after the automated cherry-pick run encountered a documentation conflict and left its branch unchanged.

The backport restores Sentence Transformers metadata export for retrieval checkpoints so exported bi-encoders preserve their pooling, normalization, prompt, tokenizer, and deployment metadata across Sentence Transformers and NeMo AutoModel reloads.

# Changelog

- Cherry-pick the merged #3021 change onto the current `r0.6.0` head with DCO sign-off.
- Resolve the sole remaining conflict in `docs/model-coverage/embedding/index.mdx` using the release branch's vendor-scoped Fern routes and #3021's updated model guidance.
- Preserve the exact merged #3021 result for the conflicted documentation file.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Included the tests added by the source PR.
- [x] Included the documentation updates from the source PR.

Validation:

- `130 passed` across the focused retrieval, Sentence Transformers export, checkpoint-addon, bi-encoder, and recipe unit tests.
- Ruff format and lint checks pass for all changed production Python files.
- MDX syntax validation passes for 455 files.
- The pinned Fern CLI reported 0 errors, then the local process exited with a Node/WASM memory-allocation error; the PR docs check will provide the authoritative Fern result.

# Additional Information

- Backport of #3021.
- The failed automated backport attempt was [workflow run 31219469782](https://github.com/NVIDIA-NeMo/Automodel/actions/runs/31219469782).
