### PR TITLE
cp: backport VLM CP gradient and vision sharding fixes to r0.6.0

### DIFF
--- a/docs/guides/cp-vision-frame-sharding.mdx
+++ b/docs/guides/cp-vision-frame-sharding.mdx
@@ -6,19 +6,20 @@ description: "Reduce duplicated vision-tower work by distributing image and vide
 ## Overview
 
 Context parallelism (CP) splits a model's language sequence across multiple GPUs. In a
-vision-language model, however, the vision tower normally processes every image and video
+vision-language model (VLM), the vision tower normally processes every image and video
 on every CP rank before the language sequence is split. This repeats the same vision
 computation on each rank.
 
 Context-parallel vision frame sharding does not apply context-parallel attention inside
 the vision tower. Instead, it distributes independent image and video frames over the
-existing CP ranks. Each rank processes only its assigned frames, the resulting visual
+existing CP ranks. Each rank processes only its assigned frames. The resulting visual
 embeddings are gathered in their original order, and ordinary sequence CP then shards
 the assembled multimodal sequence. This reduces duplicated vision-tower computation
 while preserving the model's input ordering and gradients.
 
 Only vision encoders that compute each image or video frame independently can use this
-feature. The built-in integration currently supports the following model families:
+feature. The built-in integration currently supports the following model families, including
+dense and mixture-of-experts (MoE) variants:
 
 | Model | Support |
 |---|---|
@@ -40,11 +41,12 @@ distributed:
         enabled: true
         mesh_dims: [cp]
         min_tokens: 2048
+        min_frames: 32
         cost_alpha: auto
 ```
 
-Vision frame sharding is disabled by default. A CP size greater than 1 and a supported model are
-required for the sharded path.
+Vision frame sharding is disabled by default. You need a CP size greater than 1 and a supported
+model for the sharded path.
 
 The following example recipes are available:
 
@@ -52,7 +54,7 @@ The following example recipes are available:
 - [Dense Qwen3.5 4B with CP2 and vision frame sharding](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/vlm_finetune/qwen3_5/qwen3_5_4b_cp2_vision_frame_shard.yaml)
 - [Qwen3.5-MoE 122B with EP8, CP32, and 128K packing](https://github.com/NVIDIA-NeMo/Automodel/blob/main/examples/vlm_finetune/qwen3_5_moe/qwen3_5_122b_128k_ep8cp32.yaml)
 
-For example, run the Qwen3-VL recipe on eight GPUs:
+For example, run the Qwen3-VL recipe on 8 GPUs:
 
 ```bash
 uv run automodel --nproc-per-node=8 \
@@ -61,12 +63,20 @@ uv run automodel --nproc-per-node=8 \
 
 ### Configuration Fields
 
+The following table describes the vision frame sharding fields:
+
 | Field | Default | Description |
 |---|---|---|
 | `enabled` | `false` | Enables vision frame sharding across the CP group. |
 | `mesh_dims` | `[cp]` | Selects the device-mesh dimensions used to distribute frames. Only `[cp]` is currently supported. |
-| `min_tokens` | `2048` | Uses the replicated path when the batch has fewer visual tokens than this threshold. Set it to `0` to always exercise vision frame sharding. |
-| `cost_alpha` | `auto` | Controls how frame cost is estimated for load balancing. `auto` uses the vision hidden size and is the recommended setting. A nonnegative integer overrides the inferred value; `0` uses a purely quadratic attention-cost estimate. |
+| `min_tokens` | `2048` | Minimum number of merged visual tokens that can activate sharding. Set it to `0` to always satisfy the token threshold. |
+| `min_frames` | `32` | Minimum number of independent image or video-frame units that can activate sharding even below `min_tokens`. Set it to `0` to always satisfy the frame threshold. |
+| `cost_alpha` | `auto` | Controls how frame cost is estimated for load balancing. `auto` uses the vision hidden size and is the recommended setting. A nonnegative integer overrides the inferred value. Setting it to `0` uses a purely quadratic attention-cost estimate. |
+
+Vision frame sharding uses the replicated path only when both the merged visual-token count is below
+`min_tokens` and the image or frame count is below `min_frames`. The frame threshold
+ensures that long videos can use sharding even when reduced per-frame spatial resolution
+keeps their merged-token count low.
 
 ## How It Works
 
@@ -86,7 +96,7 @@ frames contiguous allows the gathered outputs to be concatenated without reorder
 
 The gather operation supports autograd, so a trainable vision tower receives the same
 gradient contributions as the replicated path. Built-in integrations shard across the CP
-dimension only, even when tensor parallelism is also enabled. This avoids over-counting
+dimension only, even when tensor parallelism (TP) is also enabled. This avoids over-counting
 gradients for vision-tower weights that are replicated across TP ranks.
 
 If a batch contains fewer frames than CP ranks, the implementation adds minimal dummy
@@ -97,8 +107,9 @@ embeddings are discarded and contribute no gradient.
 
 The benefit depends on the amount and shape of visual input, the CP size, activation
 checkpointing, and communication between ranks. Small visual workloads can spend more time
-gathering embeddings than they save in vision computation, which is why `min_tokens`
-defaults to `2048`.
+gathering embeddings than they save in vision computation. The default `min_tokens=2048`
+keeps small image workloads replicated, while `min_frames=32` lets long videos select
+sharding when their frame count still represents substantial vision-tower work.
 
 Compare a sharded run with the replicated baseline by disabling the policy from the command
 line:

--- a/nemo_automodel/_transformers/capabilities.py
+++ b/nemo_automodel/_transformers/capabilities.py
@@ -347,12 +347,18 @@ class ModelSupports:
         MagiAttention dispatches the packed sequence across the CP group with its
         own load-balancing solver and a per-document varlen mask, so it supports
         CP + packing (see ``context_parallel.magi.magi_prepare_packed_cp``). Models
-        with native THD support own their packed CP path in TileLang attention."""
+        with native THD support own their packed CP path in TileLang attention.
+        Models can restrict a model-owned packed CP path to specific attention
+        backends with ``_packed_cp_attn_backends``."""
         model = self._model
         if not self.supports_sequence_packing:
             return False
         if self.cp_size <= 1:
             return True
+        model_owned_backends = getattr(model, "_packed_cp_attn_backends", None)
+        if model_owned_backends is not None:
+            backend_attn = getattr(getattr(model, "backend", None), "attn", None)
+            return _supports_seq_lens(model) and backend_attn in model_owned_backends
         if self.supports_thd:
             backend_attn = getattr(getattr(model, "backend", None), "attn", None)
             return backend_attn == "tilelang"

--- a/nemo_automodel/components/distributed/cp_vision_frame_shard.py
+++ b/nemo_automodel/components/distributed/cp_vision_frame_shard.py
@@ -88,7 +88,11 @@ class CpVisionFrameShardingConfig:
         mesh_dims: Device-mesh dimensions across which frames are distributed. Only
             ``("cp",)`` is currently supported.
         min_tokens: Minimum number of merged visual tokens required to use the sharded
-            path. Smaller workloads stay replicated to avoid collective overhead.
+            path unless ``min_frames`` is reached. Smaller workloads stay replicated
+            to avoid collective overhead.
+        min_frames: Minimum number of independent image/frame units that can select
+            sharding even below ``min_tokens``. Long videos reduce per-frame spatial
+            resolution, so merged-token count alone underestimates their ViT work.
         cost_alpha: Non-negative linear term in the partition cost
             ``p * (p + cost_alpha)``. ``"auto"`` infers ``3 * vision_hidden_size``
             and falls back to ``0`` when the width is unavailable. ``None`` remains
@@ -98,6 +102,7 @@ class CpVisionFrameShardingConfig:
     enabled: bool = False
     mesh_dims: tuple[Literal["cp"]] = ("cp",)
     min_tokens: int = 2048
+    min_frames: int = 32
     cost_alpha: int | Literal["auto"] | None = "auto"
 
     def __post_init__(self) -> None:
@@ -111,6 +116,8 @@ class CpVisionFrameShardingConfig:
             raise ValueError(f'{config_path}.mesh_dims currently supports only ["cp"]')
         if isinstance(self.min_tokens, bool) or not isinstance(self.min_tokens, int) or self.min_tokens < 0:
             raise ValueError(f"{config_path}.min_tokens must be a non-negative integer")
+        if isinstance(self.min_frames, bool) or not isinstance(self.min_frames, int) or self.min_frames < 0:
+            raise ValueError(f"{config_path}.min_frames must be a non-negative integer")
         if self.cost_alpha not in (None, "auto") and (
             isinstance(self.cost_alpha, bool) or not isinstance(self.cost_alpha, int) or self.cost_alpha < 0
         ):
@@ -649,15 +656,19 @@ def maybe_distribute_visual(
     n_units = len(f_patches)
     n_real_tokens = sum(p // sms_sq for p in f_patches)
     min_shard_tokens = scope.config.min_tokens
-    if n_real_tokens < min_shard_tokens:
+    min_shard_frames = scope.config.min_frames
+    if n_real_tokens < min_shard_tokens and n_units < min_shard_frames:
         global _LOGGED_SMALL_FALLBACK
         if not _LOGGED_SMALL_FALLBACK:
             _LOGGED_SMALL_FALLBACK = True
             logger.info(
                 "vision tower using replicated path for small visual workload "
-                "(tokens=%d < distributed.multimodal.vision.frame_sharding.min_tokens=%d)",
+                "(tokens=%d < distributed.multimodal.vision.frame_sharding.min_tokens=%d and "
+                "frames=%d < distributed.multimodal.vision.frame_sharding.min_frames=%d)",
                 n_real_tokens,
                 min_shard_tokens,
+                n_units,
+                min_shard_frames,
             )
         return visual(
             pixel_values,

--- a/nemo_automodel/components/distributed/parallelizer.py
+++ b/nemo_automodel/components/distributed/parallelizer.py
@@ -459,6 +459,14 @@ class DefaultParallelizationStrategy(ParallelizationStrategy):
             root_kwargs["ignored_params"] = root_ignored_params
         model = fully_shard_fn(model, **root_kwargs)
 
+        cp_enabled = "cp" in device_mesh.mesh_dim_names and device_mesh["cp"].size() > 1
+        if cp_enabled:
+            configured_units = parallelizer_utils.configure_fsdp_unused_param_reduction(model)
+            logger.info(
+                "Enabled unused-parameter reduce-scatter on %d FSDP units for context parallelism",
+                configured_units,
+            )
+
         return model
 
 

--- a/nemo_automodel/components/distributed/parallelizer_utils.py
+++ b/nemo_automodel/components/distributed/parallelizer_utils.py
@@ -19,12 +19,46 @@ import torch
 import torch.nn as nn
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.fsdp import (
+    FSDPModule,
     MixedPrecisionPolicy,
     OffloadPolicy,
     fully_shard,
 )
 
+from nemo_automodel.shared.torch_patches import (
+    patch_fsdp_unused_param_reduction as _patch_fsdp_unused_param_reduction,
+)
+
 UniformSubtreeItem = Union[Tuple[nn.Module, torch.dtype], Tuple[str, nn.Module, torch.dtype]]
+
+
+def configure_fsdp_unused_param_reduction(module: nn.Module) -> int:
+    """Reduce zero gradients for FSDP parameters unused on a local CP rank.
+
+    Packed or modality-dependent context-parallel batches may execute a module
+    on only a subset of ranks. FSDP must still issue the same reduce-scatter
+    sequence everywhere; otherwise a rank with ``grad is None`` can omit a
+    collective and discard peer contributions. PyTorch's public API fills the
+    missing local contribution with zero, analogous to DDP unused-parameter
+    handling. AutoModel keeps a compatibility fallback for supported PyTorch
+    versions that predate that public API.
+
+    Args:
+        module: Root module containing the FSDP units to configure.
+
+    Returns:
+        Number of FSDP units configured.
+    """
+    fsdp_modules = [candidate for candidate in module.modules() if isinstance(candidate, FSDPModule)]
+    if not fsdp_modules:
+        return 0
+
+    if hasattr(fsdp_modules[0], "set_reduce_scatter_unused_params"):
+        for fsdp_module in fsdp_modules:
+            fsdp_module.set_reduce_scatter_unused_params(True, recurse=False)
+    else:
+        _patch_fsdp_unused_param_reduction()
+    return len(fsdp_modules)
 
 
 def iter_maximal_uniform_dtype_subtrees(

--- a/nemo_automodel/components/loss/linear_ce.py
+++ b/nemo_automodel/components/loss/linear_ce.py
@@ -66,6 +66,7 @@ from importlib.metadata import version as metadata_version
 from typing import Optional
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 from packaging.version import Version
 
@@ -144,24 +145,104 @@ class FusedLinearCrossEntropy(nn.Module):
         self.logit_softcapping = logit_softcapping
         self.reduction = reduction
 
+    @staticmethod
+    def materialize_lm_weight(
+        lm_weight: torch.Tensor,
+        *,
+        grad_reduce_group: dist.ProcessGroup | None = None,
+    ) -> torch.Tensor:
+        """Materialize an LM-head DTensor with gradient-correct reduction semantics.
+
+        Fused linear CE consumes the LM-head weight outside the owning FSDP
+        module's forward. Each data/context-parallel rank therefore computes a
+        rank-local full-weight gradient. A plain ``DTensor.full_tensor()`` marks
+        that gradient as replicated, so backward only slices the local result
+        into the owned shard instead of combining peer contributions.
+
+        Args:
+            lm_weight: LM-head weight with global shape ``[vocab, hidden]``. A
+                regular tensor is returned unchanged. A DTensor may have any
+                FSDP sharding placement over its device mesh and is gathered to
+                a rank-local regular tensor with the global shape, device, and
+                dtype.
+            grad_reduce_group: Process group whose ranks contribute independent
+                token losses. Its size must match the LM-head DTensor mesh.
+
+        Returns:
+            Regular tensor with shape ``[vocab, hidden]``. For a DTensor input,
+            backward reduce-scatters the averaged peer gradients into the
+            original local shard. The gathered result does not alias the local
+            DTensor shard; a regular-tensor input is returned by identity.
+
+        Raises:
+            ValueError: If a trainable sharded weight has no matching reduction
+                group. This fails closed instead of producing rank-local shards.
+        """
+        if not hasattr(lm_weight, "full_tensor"):
+            return lm_weight
+
+        # Evaluation has no weight gradient to combine, so preserve the ordinary
+        # gather path and do not require a process group from inference callers.
+        if not torch.is_grad_enabled() or not lm_weight.requires_grad:
+            return lm_weight.full_tensor()
+
+        mesh = lm_weight.device_mesh
+        mesh_world_size = mesh.size()
+        reduce_world_size = dist.get_world_size(grad_reduce_group) if grad_reduce_group is not None else 1
+        if mesh_world_size != reduce_world_size:
+            raise ValueError(
+                "FusedLinearCrossEntropy requires grad_reduce_group to match the LM-head "
+                f"DTensor mesh: mesh size={mesh_world_size}, reduction group size={reduce_world_size}. "
+                "Tensor-parallel or hierarchical layouts need an explicit compatible loss path."
+            )
+        if mesh_world_size == 1:
+            return lm_weight.full_tensor()
+
+        from torch.distributed.tensor import Partial
+
+        # ``Partial`` tells DTensor autograd to reduce-scatter the full gradient
+        # directly into the parameter's original FSDP shard. Training recipes
+        # scale the local loss by the reduction world size before backward to
+        # cancel FSDP's averaged-gradient convention, so restore that average
+        # before the reduce-scatter sum.
+        full_weight = lm_weight.full_tensor(
+            grad_placements=tuple(Partial() for _ in range(mesh.ndim)),
+        )
+        full_weight.register_hook(lambda grad: grad / reduce_world_size)
+        return full_weight
+
     def forward(
         self,
         hidden_states: torch.Tensor,
         labels: torch.Tensor,
         lm_weight: torch.Tensor,
         num_label_tokens: Optional[int] = None,
+        grad_reduce_group: dist.ProcessGroup | None = None,
     ) -> torch.Tensor:
-        """
-        Compute fused linear cross entropy loss that matches PyTorch's cross_entropy behavior.
+        """Compute fused linear cross entropy matching PyTorch behavior.
 
         Args:
-            hidden_states: Input hidden states
-            labels: Target labels
-            lm_weight: Weight matrix for linear transformation
-            num_label_tokens: Number of non-padding tokens.
+            hidden_states: Rank-local hidden states with shape
+                ``[batch, sequence, hidden]``.
+            labels: Rank-local target token IDs with shape ``[batch, sequence]``.
+            lm_weight: LM-head weight with global shape ``[vocab, hidden]``.
+                It may be a regular tensor or an FSDP-sharded DTensor.
+            num_label_tokens: Global number of non-padding target tokens used
+                to normalize a sum-reduced loss.
+            grad_reduce_group: Group that contributes independent loss shards
+                when ``lm_weight`` is a sharded DTensor.
+
+        Returns:
+            Scalar loss tensor on the same device as ``hidden_states``. The
+            inputs are not mutated and the result does not alias an input.
         """
         if not HAVE_CUT_CROSS_ENTROPY:
             raise ImportError(MISSING_CUT_CROSS_ENTROPY_MSG)
+
+        lm_weight = self.materialize_lm_weight(
+            lm_weight,
+            grad_reduce_group=grad_reduce_group,
+        )
 
         # First compute loss with sum reduction to handle normalization ourselves
         if self.logit_softcapping == 0:

--- a/nemo_automodel/components/loss/mtp.py
+++ b/nemo_automodel/components/loss/mtp.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 
 from nemo_automodel.components.loss.linear_ce import FusedLinearCrossEntropy
@@ -41,6 +42,7 @@ def calculate_mtp_loss(
     cu_seqlens: Optional[torch.Tensor] = None,
     seq_idx: Optional[torch.Tensor] = None,
     lm_weight: Optional[torch.Tensor] = None,
+    grad_reduce_group: dist.ProcessGroup | None = None,
 ) -> torch.Tensor:
     """Compute the DeepSeek-V3 Multi-Token Prediction auxiliary loss.
 
@@ -72,6 +74,8 @@ def calculate_mtp_loss(
         lm_weight: Optional caller-materialized LM-head weight. Supplying this
             lets the main loss and all MTP depths share one DTensor
             ``full_tensor()`` gather on the FusedLinearCrossEntropy path.
+        grad_reduce_group: Group that contributes independent loss shards when
+            the shared LM-head weight is a DTensor.
 
     Returns:
         Scalar MTP loss with autograd graph.
@@ -101,7 +105,10 @@ def calculate_mtp_loss(
     # numerically identical (same weight); grads from every depth accumulate into
     # it and collapse to a single reduce-scatter on the sharded parameter.
     if isinstance(loss_fn, FusedLinearCrossEntropy) and lm_weight is None:
-        lm_weight = _get_lm_head_weight(model)
+        lm_weight = loss_fn.materialize_lm_weight(
+            _get_lm_head_weight(model),
+            grad_reduce_group=grad_reduce_group,
+        )
 
     if seq_idx is None and cu_seqlens is not None:
         cs = cu_seqlens
@@ -163,6 +170,7 @@ def calculate_mtp_loss(
                 model=model,
                 lm_weight=lm_weight,
                 num_label_tokens=num_label_tokens,
+                grad_reduce_group=grad_reduce_group,
             )
         else:
             lm_head = _get_lm_head_module(model)
@@ -197,12 +205,14 @@ class PipelineCausalLMLoss(nn.Module):
         model: nn.Module,
         scaling_factor: float | None = None,
         ignore_index: int = -100,
+        grad_reduce_group: dist.ProcessGroup | None = None,
     ):
         super().__init__()
         self.loss_fn = loss_fn
         self.model = model
         self.scaling_factor = scaling_factor
         self.ignore_index = ignore_index
+        self.grad_reduce_group = grad_reduce_group
         # Legacy THD-pack fallback used when the model has no seq_idx tail.
         self.cu_seqlens: Optional[torch.Tensor] = None
 
@@ -264,7 +274,12 @@ class PipelineCausalLMLoss(nn.Module):
         # Gather the LM head at most once and thread it through the main loss and
         # every MTP depth (avoids redundant per-call full_tensor() gathers).
         shared_lm_weight = (
-            _get_lm_head_weight(self.model) if isinstance(self.loss_fn, FusedLinearCrossEntropy) else None
+            self.loss_fn.materialize_lm_weight(
+                _get_lm_head_weight(self.model),
+                grad_reduce_group=self.grad_reduce_group,
+            )
+            if isinstance(self.loss_fn, FusedLinearCrossEntropy)
+            else None
         )
         loss = calculate_loss(
             self.loss_fn,
@@ -273,6 +288,7 @@ class PipelineCausalLMLoss(nn.Module):
             model=self.model,
             hidden_states=hidden_states,
             lm_weight=shared_lm_weight,
+            grad_reduce_group=self.grad_reduce_group,
         )
         if (mtp_per_depth_h is not None or mtp_per_depth_logits is not None) and self.model.training:
             scaling_factor = self.scaling_factor if self.scaling_factor is not None else model_scaling_factor
@@ -287,6 +303,7 @@ class PipelineCausalLMLoss(nn.Module):
                 cu_seqlens=self.cu_seqlens,
                 seq_idx=seq_idx_mb,
                 lm_weight=shared_lm_weight,
+                grad_reduce_group=self.grad_reduce_group,
             )
         return loss
 
@@ -304,6 +321,18 @@ class MTPLossConfig:
     scaling_factor: float | None = None
     ignore_index: int = -100
 
-    def build(self, loss_fn: nn.Module, model: nn.Module) -> PipelineCausalLMLoss:
+    def build(
+        self,
+        loss_fn: nn.Module,
+        model: nn.Module,
+        *,
+        grad_reduce_group: dist.ProcessGroup | None = None,
+    ) -> PipelineCausalLMLoss:
         """Build the pipeline-schedule, MTP-aware loss for ``loss_fn``/``model``."""
-        return PipelineCausalLMLoss(loss_fn, model, scaling_factor=self.scaling_factor, ignore_index=self.ignore_index)
+        return PipelineCausalLMLoss(
+            loss_fn,
+            model,
+            scaling_factor=self.scaling_factor,
+            ignore_index=self.ignore_index,
+            grad_reduce_group=grad_reduce_group,
+        )

--- a/nemo_automodel/components/loss/utils.py
+++ b/nemo_automodel/components/loss/utils.py
@@ -38,14 +38,13 @@ def _get_lm_head_module(model: nn.Module) -> Optional[nn.Module]:
 
 
 def _get_lm_head_weight(model: nn.Module) -> torch.Tensor:
-    """Return the model's LM-head weight, materializing DTensor weights when needed."""
+    """Return the model's LM-head weight without changing its distributed layout."""
     lm_head = _get_lm_head_module(model)
     if lm_head is not None:
-        weight = lm_head.weight
-        return weight.full_tensor() if hasattr(weight, "full_tensor") else weight
+        return lm_head.weight
     for name, param in model.named_parameters(remove_duplicate=False):
         if "lm_head" in name and name.endswith(".weight"):
-            return param.full_tensor() if hasattr(param, "full_tensor") else param
+            return param
     raise ValueError("lm_head.weight not found in model")
 
 
@@ -71,15 +70,21 @@ def _get_final_hidden_states(model_output: Any) -> Optional[Any]:
     return hidden_states
 
 
-def calculate_loss(loss_fn, **kwargs) -> torch.Tensor:
-    """Calculate the loss.
+def calculate_loss(loss_fn: nn.Module, **kwargs: Any) -> torch.Tensor:
+    """Calculate a logit-based or fused linear cross-entropy loss.
 
     Args:
-        loss_fn: Loss function.
-        **kwargs: Keyword arguments for the loss function.
+        loss_fn: Loss module. ``FusedLinearCrossEntropy`` consumes
+            ``hidden_states`` with shape ``[batch, sequence, hidden]``, labels
+            with shape ``[batch, sequence]``, and an LM-head weight with global
+            shape ``[vocab, hidden]``. Other loss modules consume logits with
+            shape ``[batch, sequence, vocab]`` and labels.
+        **kwargs: Loss inputs. Rank-local tensors keep their existing layout;
+            ``grad_reduce_group`` describes the ranks contributing independent
+            fused-loss shards. The caller's mapping and tensors are not mutated.
 
     Returns:
-        The loss.
+        Scalar loss tensor that does not alias an input.
     """
     loss_fn_kwargs = {"num_label_tokens": kwargs.pop("num_label_tokens", None)}
     if isinstance(loss_fn, FusedLinearCrossEntropy):
@@ -98,10 +103,12 @@ def calculate_loss(loss_fn, **kwargs) -> torch.Tensor:
                 "hidden_states": kwargs.pop("hidden_states"),
                 "labels": labels,
                 "lm_weight": lm_head,
+                "grad_reduce_group": kwargs.pop("grad_reduce_group", None),
             }
         )
     else:
         kwargs.pop("lm_weight", None)  # logit-based losses do not need the LM head
+        kwargs.pop("grad_reduce_group", None)
         loss_fn_kwargs.update(
             {
                 "logits": kwargs.pop("logits"),

--- a/nemo_automodel/components/models/qwen3_5_moe/model.py
+++ b/nemo_automodel/components/models/qwen3_5_moe/model.py
@@ -1019,6 +1019,10 @@ class Qwen3_5MoeForConditionalGeneration(HFCheckpointingMixin, HFQwen3_5MoeForCo
     tie_word_embeddings_support: TieSupport = TieSupport.UNTIED_ONLY
 
     _keep_in_fp32_modules_strict = ["_fp32_params"]
+    # Packed CP uses the model-owned block-diagonal SDPA dispatch. Generic
+    # hybrid CP also supports TE for unpacked sequences, but TE has no route
+    # through this packed attention contract.
+    _packed_cp_attn_backends = ("sdpa",)
 
     # forward() pulls per-microbatch pixel_values from _vlm_pixel_values_chunks;
     # patch_hf_model_for_pp must not replace it under PP.

--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -1052,3 +1052,9 @@ def parallelize_model(
             wrap_outer_model=wrap_outer_model,
             frozen_multimodal_sharding=frozen_multimodal_sharding,
         )
+        if cp_enabled:
+            configured_units = parallelizer_utils.configure_fsdp_unused_param_reduction(model)
+            logger.info(
+                "Enabled unused-parameter reduce-scatter on %d MoE FSDP units for context parallelism",
+                configured_units,
+            )

--- a/nemo_automodel/recipes/llm/kd.py
+++ b/nemo_automodel/recipes/llm/kd.py
@@ -659,6 +659,7 @@ class KnowledgeDistillationRecipeForNextTokenPrediction(TrainFinetuneRecipeForNe
                     model=model,
                     hidden_states=get_final_hidden_states(student_out),
                     num_label_tokens=num_label_tokens,
+                    grad_reduce_group=self._get_dp_group(include_cp=True) if is_train else None,
                 )
 
             # Reminder: kd_loss is normalized by num_label_tokens, which is typically

--- a/nemo_automodel/recipes/llm/train_ft.py
+++ b/nemo_automodel/recipes/llm/train_ft.py
@@ -878,7 +878,11 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
         if isinstance(self.loss_fn, FusedLinearCrossEntropy):
             last_stage_model._pp_return_hidden_states = True
 
-        self.pp.info.schedule._loss_fn = self.cfg.mtp.build(self.loss_fn, last_stage_model)
+        self.pp.info.schedule._loss_fn = self.cfg.mtp.build(
+            self.loss_fn,
+            last_stage_model,
+            grad_reduce_group=self._get_dp_group(include_cp=True),
+        )
 
     def _setup_qat(self, cfg, model_parts: list[nn.Module]):
         if not cfg.get("qat.enabled", False):
@@ -1100,9 +1104,15 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
                 # Gather the LM head once and share it across the main loss and
                 # all MTP depths (FusedLinearCrossEntropy path) to avoid redundant
                 # full_tensor() gathers that accumulate on-device and OOM.
-                shared_lm_weight = (
-                    _get_lm_head_weight(model) if isinstance(self.loss_fn, FusedLinearCrossEntropy) else None
-                )
+                loss_distributed_kwargs = {}
+                shared_lm_weight = None
+                if isinstance(self.loss_fn, FusedLinearCrossEntropy):
+                    grad_reduce_group = self._get_dp_group(include_cp=True) if is_train else None
+                    shared_lm_weight = self.loss_fn.materialize_lm_weight(
+                        _get_lm_head_weight(model),
+                        grad_reduce_group=grad_reduce_group,
+                    )
+                    loss_distributed_kwargs["grad_reduce_group"] = grad_reduce_group
                 local_loss = calculate_loss(
                     self.loss_fn,
                     logits=getattr(out, "logits", out),
@@ -1111,6 +1121,7 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
                     hidden_states=get_final_hidden_states(out),
                     lm_weight=shared_lm_weight,
                     num_label_tokens=num_label_tokens,
+                    **loss_distributed_kwargs,
                 )
                 mtp_per_depth_h = getattr(out, "mtp_per_depth_h", None)
                 mtp_per_depth_logits = getattr(out, "mtp_per_depth_logits", None)
@@ -1131,6 +1142,7 @@ class TrainFinetuneRecipeForNextTokenPrediction(BaseRecipe):
                         # mask cross-boundary MTP label rolls in THD packing (matches the PP path)
                         cu_seqlens=batch.get("cu_seqlens"),
                         lm_weight=shared_lm_weight,
+                        **loss_distributed_kwargs,
                     )
                 loss_buffer.append(local_loss.clone().detach())
                 if is_train:

--- a/nemo_automodel/recipes/vlm/finetune.py
+++ b/nemo_automodel/recipes/vlm/finetune.py
@@ -68,6 +68,7 @@ from nemo_automodel.components.loggers.wandb_utils import suppress_wandb_log_mes
 from nemo_automodel.components.loss.linear_ce import FusedLinearCrossEntropy
 from nemo_automodel.components.loss.masked_ce import MaskedCrossEntropy
 from nemo_automodel.components.loss.mtp import calculate_mtp_loss
+from nemo_automodel.components.loss.utils import _get_lm_head_weight, calculate_loss
 from nemo_automodel.components.quantization.fp8 import build_fp8_config
 from nemo_automodel.components.training.model_output_utils import get_final_hidden_states
 from nemo_automodel.components.training.rng import ScopedRNG, StatefulRNG
@@ -113,6 +114,15 @@ class _CpVisionFrameShardingCapability(Protocol):
         ...
 
 
+class _CpPackingCapability(Protocol):
+    """Model capability required by packed VLM context parallelism."""
+
+    @property
+    def supports_cp_with_sequence_packing(self) -> bool:
+        """Whether the model's active backend owns packed CP routing."""
+        ...
+
+
 def _validate_cp_vision_frame_sharding_support(
     model: _CpVisionFrameShardingCapability,
     config: CpVisionFrameShardingConfig,
@@ -128,6 +138,23 @@ def _validate_cp_vision_frame_sharding_support(
         "supports_cp_vision_frame_sharding=False. "
         "Disable the policy with distributed.multimodal.vision.frame_sharding.enabled=false "
         "or use a supported model."
+    )
+
+
+def _validate_cp_packing_support(
+    model: _CpPackingCapability,
+    *,
+    packing_enabled: bool,
+    cp_size: int,
+) -> None:
+    """Reject packed CP before dataloader construction when routing is unsupported."""
+    if cp_size <= 1 or not packing_enabled or model.supports_cp_with_sequence_packing:
+        return
+
+    raise ValueError(
+        f"Context parallelism (cp_size={cp_size}) with VLM sequence packing is not supported "
+        f"for {type(model).__name__} with its active attention backend. Disable sequence "
+        "packing, use cp_size=1, or select a model-supported packed-CP backend."
     )
 
 
@@ -362,53 +389,6 @@ def build_dataloader(
     return result.dataloader, result.processor
 
 
-def calculate_loss(loss_fn, **kwargs) -> torch.Tensor:
-    """Calculate the loss.
-
-    Args:
-        loss_fn: Loss function.
-        **kwargs: Keyword arguments for the loss function.
-
-    Returns:
-        The loss.
-    """
-    loss_fn_kwargs = {"num_label_tokens": kwargs.pop("num_label_tokens", None)}
-    if isinstance(loss_fn, FusedLinearCrossEntropy):
-        model = kwargs.pop("model")
-        labels = kwargs.pop("labels")
-
-        # find the lm_head in the model
-        lm_head = None
-        if hasattr(model, "get_output_embeddings"):
-            lm_head = model.get_output_embeddings().weight
-        else:
-            for n, p in model.named_parameters(remove_duplicate=False):
-                if "lm_head" in n and n.endswith(".weight"):
-                    lm_head = p
-                    break
-        if lm_head is None:
-            raise ValueError("lm_head.weight not found in model")
-
-        # unshard the possibly sharded lm_head
-        lm_head = lm_head.full_tensor() if hasattr(lm_head, "full_tensor") else lm_head
-        loss_fn_kwargs.update(
-            {
-                "hidden_states": kwargs.pop("hidden_states"),
-                "labels": labels,
-                "lm_weight": lm_head,
-            }
-        )
-    else:
-        loss_fn_kwargs.update(
-            {
-                "logits": kwargs.pop("logits"),
-                "labels": kwargs.pop("labels"),
-            }
-        )
-
-    return loss_fn(**loss_fn_kwargs)
-
-
 # ---------------------------------------------------------------------------
 #  Trainer class – orchestration only
 # ---------------------------------------------------------------------------
@@ -615,6 +595,11 @@ class FinetuneRecipeForVLM(BaseRecipe):
         dataloader_config = self.cfg.vlm_dataloader
         if dataloader_config is None:
             raise ValueError("VLM training requires a dataset config")
+        _validate_cp_packing_support(
+            self.model_parts[0],
+            packing_enabled=dataloader_config.packing is not None,
+            cp_size=self.mesh_context.cp_size,
+        )
         from nemo_automodel.components.models.common.packing import configure_packing, get_attn_implementation
 
         packing_attn_implementation = dataloader_config.resolve_packing_attn_implementation(
@@ -944,12 +929,23 @@ class FinetuneRecipeForVLM(BaseRecipe):
                 else:
                     out = model(**batch)
 
+                grad_reduce_group = self._get_dp_group(include_cp=True) if is_train else None
+                shared_lm_weight = (
+                    self.loss_fn.materialize_lm_weight(
+                        _get_lm_head_weight(model),
+                        grad_reduce_group=grad_reduce_group,
+                    )
+                    if isinstance(self.loss_fn, FusedLinearCrossEntropy)
+                    else None
+                )
                 local_loss = calculate_loss(
                     self.loss_fn,
                     logits=getattr(out, "logits", out),
                     labels=labels,
                     model=model,
                     hidden_states=get_final_hidden_states(out),
+                    lm_weight=shared_lm_weight,
+                    grad_reduce_group=grad_reduce_group,
                     num_label_tokens=num_label_tokens,
                 )
                 # DSV4-style MTP loss (from main): triggers when the model emits
@@ -970,6 +966,8 @@ class FinetuneRecipeForVLM(BaseRecipe):
                         scaling_factor=scaling_factor,
                         num_label_tokens=num_label_tokens,
                         ignore_index=mtp_cfg.ignore_index,
+                        lm_weight=shared_lm_weight,
+                        grad_reduce_group=grad_reduce_group,
                     )
 
                 # Joint base + drafter co-training (Gemma4WithDrafter and
@@ -1006,7 +1004,11 @@ class FinetuneRecipeForVLM(BaseRecipe):
         if last_stage_model is None:
             raise RuntimeError("Pipeline reports a last stage, but no last-stage model part was found")
 
-        self.pp.info.schedule._loss_fn = self.cfg.mtp.build(self.loss_fn, last_stage_model)
+        self.pp.info.schedule._loss_fn = self.cfg.mtp.build(
+            self.loss_fn,
+            last_stage_model,
+            grad_reduce_group=self._get_dp_group(include_cp=True),
+        )
 
     def _run_train_optim_step(self, batches, max_grad_norm: Optional[float] = None):
         """Execute a single training step.

--- a/nemo_automodel/recipes/vlm/kd.py
+++ b/nemo_automodel/recipes/vlm/kd.py
@@ -394,6 +394,7 @@ class KnowledgeDistillationRecipeForVLM(FinetuneRecipeForVLM):
                     model=model,
                     hidden_states=hidden_states,
                     num_label_tokens=num_label_tokens,
+                    grad_reduce_group=self._get_dp_group(include_cp=True) if is_train else None,
                 )
             del hidden_states
 

--- a/nemo_automodel/shared/torch_patches.py
+++ b/nemo_automodel/shared/torch_patches.py
@@ -28,6 +28,49 @@ _logger = logging.getLogger(__name__)
 _TORCH_PATCHES_APPLIED = False
 
 
+def patch_fsdp_unused_param_reduction() -> None:
+    """Backport FSDP2 unused-parameter reduction when the public API is absent.
+
+    The patch is process-global and idempotent. It only fills a missing local
+    gradient with zeros immediately before FSDP2 post-backward reduction, so
+    ranks that skipped a parameter still participate in the same collective as
+    ranks that used it. Callers must first prefer the public
+    ``FSDPModule.set_reduce_scatter_unused_params`` API.
+
+    Raises:
+        RuntimeError: If the installed PyTorch exposes neither the public API
+            nor the compatible private FSDP2 implementation.
+    """
+    try:
+        import torch
+        from torch.distributed.fsdp._fully_shard._fsdp_common import TrainingState
+        from torch.distributed.fsdp._fully_shard._fsdp_param_group import FSDPParamGroup
+    except ImportError as error:
+        raise RuntimeError(
+            "Context parallelism requires FSDP unused-parameter reduction, but this PyTorch "
+            "version provides neither the public API nor the compatible FSDP2 implementation."
+        ) from error
+
+    original_post_backward = FSDPParamGroup.post_backward
+    if getattr(original_post_backward, "_automodel_reduce_scatter_unused_params", False):
+        return
+
+    def _post_backward_with_unused_param_reduction(self, *args, **kwargs):
+        if self.reduce_grads and self._training_state == TrainingState.PRE_BACKWARD:
+            for fsdp_param in self.fsdp_params:
+                if not hasattr(fsdp_param, "_unsharded_param"):
+                    continue
+                if fsdp_param.unsharded_accumulated_grad is not None:
+                    continue
+                param = fsdp_param.unsharded_param
+                if param.requires_grad and param.grad is None:
+                    param.grad = torch.zeros_like(param, memory_format=torch.preserve_format)
+        return original_post_backward(self, *args, **kwargs)
+
+    _post_backward_with_unused_param_reduction._automodel_reduce_scatter_unused_params = True
+    FSDPParamGroup.post_backward = _post_backward_with_unused_param_reduction
+
+
 def patch_fsdp_accumulated_grad_guard() -> None:
     """Guard FSDP2 post-backward against params that were never unsharded.
 

--- a/tests/functional_tests/training/test_cp_flce_fsdp_correctness.py
+++ b/tests/functional_tests/training/test_cp_flce_fsdp_correctness.py
@@ -1,0 +1,205 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Two-rank gradient parity for CP FLCE and rank-asymmetric FSDP graphs."""
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.fsdp import fully_shard
+from torch.distributed.tensor import DTensor, Shard, distribute_tensor
+
+from nemo_automodel.components.distributed.parallelizer_utils import configure_fsdp_unused_param_reduction
+from nemo_automodel.components.loss.linear_ce import HAVE_CUT_CROSS_ENTROPY, FusedLinearCrossEntropy
+
+_RESULT_PREFIX = "CP_FLCE_FSDP_CORRECTNESS_RESULT "
+
+
+def _full_grad(parameter: nn.Parameter) -> torch.Tensor:
+    """Return a full regular tensor for a sharded or regular parameter gradient."""
+    grad = parameter.grad
+    if grad is None:
+        raise AssertionError("expected parameter gradient, got None")
+    if isinstance(grad, DTensor):
+        grad = grad.full_tensor()
+    return grad.detach().float()
+
+
+def _assert_flce_weight_grad_parity(device: torch.device) -> None:
+    """Compare sharded rank-local FLCE against a full-batch reference."""
+    if not HAVE_CUT_CROSS_ENTROPY:
+        raise RuntimeError("cut-cross-entropy is required for the CP FLCE functional test")
+
+    world = dist.get_world_size()
+    rank = dist.get_rank()
+    mesh = init_device_mesh("cuda", (world,), mesh_dim_names=("dp_cp",))
+    dtype = torch.bfloat16
+    vocab_size, hidden_size, local_tokens = 64, 32, 8
+
+    torch.manual_seed(1234)
+    full_weight_data = torch.randn(vocab_size, hidden_size, device=device, dtype=dtype)
+    weight = nn.Parameter(distribute_tensor(full_weight_data.clone(), mesh, [Shard(0)]))
+
+    all_hidden = []
+    all_labels = []
+    for data_rank in range(world):
+        generator = torch.Generator(device=device).manual_seed(9000 + data_rank)
+        all_hidden.append(torch.randn(local_tokens, hidden_size, device=device, dtype=dtype, generator=generator))
+        all_labels.append(
+            torch.randint(0, vocab_size, (local_tokens,), device=device, generator=generator, dtype=torch.long)
+        )
+
+    loss_fn = FusedLinearCrossEntropy(reduction="sum")
+    local_hidden = all_hidden[rank].clone().requires_grad_(True)
+    local_loss = loss_fn(
+        local_hidden,
+        all_labels[rank],
+        weight,
+        num_label_tokens=world * local_tokens,
+        grad_reduce_group=dist.group.WORLD,
+    )
+    (local_loss * world).backward()
+
+    reference_weight = full_weight_data.clone().requires_grad_(True)
+    reference_loss = loss_fn(
+        torch.cat(all_hidden),
+        torch.cat(all_labels),
+        reference_weight,
+        num_label_tokens=world * local_tokens,
+    )
+    reference_loss.backward()
+
+    actual_local_grad = weight.grad.to_local().float()
+    expected_local_grad = reference_weight.grad.chunk(world, dim=0)[rank].float()
+    torch.testing.assert_close(actual_local_grad, expected_local_grad, rtol=2e-2, atol=2e-2)
+
+
+class _ConditionalFSDPModel(nn.Module):
+    """Tiny model with one rank-conditional parameter-owning branch."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.conditional = nn.Linear(8, 8, bias=False)
+        self.output = nn.Linear(8, 1, bias=False)
+
+    def forward(self, inputs: torch.Tensor, *, use_conditional: bool) -> torch.Tensor:
+        """Run the conditional branch before the always-used output layer."""
+        hidden = self.conditional(inputs) if use_conditional else inputs
+        return self.output(hidden)
+
+
+def _assert_empty_rank_fsdp_grad_parity(device: torch.device) -> None:
+    """Compare a rank-skipped FSDP unit against zero-contribution reference math."""
+    world = dist.get_world_size()
+    rank = dist.get_rank()
+    mesh = init_device_mesh("cuda", (world,), mesh_dim_names=("dp_cp",))
+
+    torch.manual_seed(4321)
+    model = _ConditionalFSDPModel().to(device)
+    reference = _ConditionalFSDPModel().to(device)
+    reference.load_state_dict(model.state_dict())
+
+    fully_shard(model, mesh=mesh, reshard_after_forward=False)
+    configured_units = configure_fsdp_unused_param_reduction(model)
+    assert configured_units >= 1
+
+    inputs = []
+    for data_rank in range(world):
+        generator = torch.Generator(device=device).manual_seed(7000 + data_rank)
+        inputs.append(torch.randn(2, 3, 8, device=device, generator=generator))
+
+    use_conditional = rank == 0
+    model(inputs[rank], use_conditional=use_conditional).sum().backward()
+
+    reference_loss = sum(
+        reference(batch, use_conditional=data_rank == 0).sum() for data_rank, batch in enumerate(inputs)
+    ) / world
+    reference_loss.backward()
+
+    torch.testing.assert_close(
+        _full_grad(model.conditional.weight),
+        reference.conditional.weight.grad.float(),
+        rtol=1e-5,
+        atol=1e-6,
+    )
+
+
+def _run_worker() -> None:
+    dist.init_process_group("nccl")
+    try:
+        if dist.get_world_size() != 2:
+            raise RuntimeError(f"This regression requires exactly 2 ranks, got {dist.get_world_size()}.")
+        local_rank = int(os.environ["LOCAL_RANK"])
+        torch.cuda.set_device(local_rank)
+        device = torch.device("cuda", local_rank)
+
+        _assert_flce_weight_grad_parity(device)
+        dist.barrier()
+        _assert_empty_rank_fsdp_grad_parity(device)
+        dist.barrier()
+
+        if dist.get_rank() == 0:
+            print(_RESULT_PREFIX + "PASS", flush=True)
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires at least 2 CUDA devices")
+def test_cp_flce_and_empty_rank_fsdp_two_rank_gradient_parity() -> None:
+    """FLCE and rank-asymmetric FSDP gradients match full references on two GPUs."""
+    command = [
+        sys.executable,
+        "-m",
+        "torch.distributed.run",
+        "--standalone",
+        "--nproc_per_node=2",
+        str(Path(__file__).resolve()),
+        "--worker",
+    ]
+    env = os.environ.copy()
+    env["CUDA_VISIBLE_DEVICES"] = "0,1"
+    repo_root = str(Path(__file__).resolve().parents[3])
+    env["PYTHONPATH"] = repo_root + os.pathsep + env.get("PYTHONPATH", "")
+    completed = subprocess.run(
+        command,
+        cwd=repo_root,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=180,
+        check=False,
+    )
+    print(completed.stdout)
+    assert completed.returncode == 0, completed.stdout
+    assert _RESULT_PREFIX + "PASS" in completed.stdout
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--worker", action="store_true")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    if _parse_args().worker:
+        _run_worker()

--- a/tests/unit_tests/distributed/test_cp_vision_frame_shard.py
+++ b/tests/unit_tests/distributed/test_cp_vision_frame_shard.py
@@ -90,8 +90,13 @@ def _pixels(grid, in_dim=8, seed=0):
     return torch.randn(total_patches, in_dim, generator=g)
 
 
-def _policy(*, enabled=True, min_tokens=0, cost_alpha="auto"):
-    return vs.CpVisionFrameShardingConfig(enabled=enabled, min_tokens=min_tokens, cost_alpha=cost_alpha)
+def _policy(*, enabled=True, min_tokens=0, min_frames=32, cost_alpha="auto"):
+    return vs.CpVisionFrameShardingConfig(
+        enabled=enabled,
+        min_tokens=min_tokens,
+        min_frames=min_frames,
+        cost_alpha=cost_alpha,
+    )
 
 
 # entries with varied sizes; every patch count (t*h*w) is a multiple of sms_sq=4.
@@ -224,6 +229,10 @@ def test_cost_alpha_override_and_unknown_model_fallback():
     qwen_visual = SimpleNamespace(config=SimpleNamespace(hidden_size=1152))
 
     assert vs.CpVisionFrameShardingConfig().cost_alpha == "auto"
+    assert vs.CpVisionFrameShardingConfig().min_frames == 32
+
+    with pytest.raises(ValueError, match="min_frames must be a non-negative integer"):
+        vs.CpVisionFrameShardingConfig(min_frames=-1)
     assert vs._vision_cost_alpha(qwen_visual, _policy(cost_alpha="auto")) == 3456
     assert vs._vision_cost_alpha(qwen_visual, _policy(cost_alpha=None)) == 3456
     assert vs._vision_cost_alpha(qwen_visual, _policy(cost_alpha=777)) == 777
@@ -432,7 +441,18 @@ def test_all_gather_var_tokens_forward_backward(monkeypatch, world):
 # ======================================================================================
 # D. maybe_distribute_visual end-to-end (simulated ranks) + fallbacks + deepstack
 # ======================================================================================
-def _simulate_maybe_distribute(visual, pixel, grid, world, rank, monkeypatch, *, grad=False, spans_only_cp=True):
+def _simulate_maybe_distribute(
+    visual,
+    pixel,
+    grid,
+    world,
+    rank,
+    monkeypatch,
+    *,
+    grad=False,
+    spans_only_cp=True,
+    policy=None,
+):
     """Drive the real maybe_distribute_visual on `rank` with all ranks' data supplied to a
     mocked all-gather, returning its output object.
 
@@ -510,7 +530,7 @@ def _simulate_maybe_distribute(visual, pixel, grid, world, rank, monkeypatch, *,
 
     tok = vs.set_cp_vision_group(
         object(),
-        config=_policy(),
+        config=policy or _policy(),
         spans_only_cp=spans_only_cp,
     )  # any non-None group activates the path
     try:
@@ -699,13 +719,32 @@ def test_maybe_distribute_falls_back_below_min_tokens(monkeypatch):
     grid = _grid([(1, 2, 2)])
     pixel = _pixels(grid)
     visual = _StubVisual()
-    tok = vs.set_cp_vision_group(object(), config=_policy(min_tokens=999))
+    tok = vs.set_cp_vision_group(object(), config=_policy(min_tokens=999, min_frames=999))
     try:
         out = vs.maybe_distribute_visual(visual, pixel, grid)
     finally:
         vs.reset_cp_vision_group(tok)
 
     assert torch.allclose(out.pooler_output, visual(pixel, grid).pooler_output, atol=1e-6)
+
+
+def test_frame_threshold_shards_long_video_below_token_cutoff(monkeypatch):
+    grid = _grid([(32, 2, 2)])
+    pixel = _pixels(grid, seed=17)
+    visual = _StubVisual()
+    expected = visual(pixel, grid).pooler_output
+    out = _simulate_maybe_distribute(
+        visual,
+        pixel,
+        grid,
+        world=8,
+        rank=0,
+        monkeypatch=monkeypatch,
+        policy=_policy(min_tokens=999, min_frames=32),
+    )
+
+    assert out.pooler_output.shape == expected.shape
+    assert torch.allclose(out.pooler_output, expected, atol=1e-6)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/distributed/test_parallelizer_utils.py
+++ b/tests/unit_tests/distributed/test_parallelizer_utils.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
 from typing import List, Tuple
+from unittest.mock import Mock
 
 import pytest
 import torch
@@ -25,9 +27,80 @@ from nemo_automodel.components.distributed.parallelizer_utils import (
     _group_params_by_dtype,
     _make_compute_dtype_fn,
     _mp_policy_with_param_dtype,
+    configure_fsdp_unused_param_reduction,
     fully_shard_by_dtype,
     iter_maximal_uniform_dtype_subtrees,
 )
+from nemo_automodel.shared.torch_patches import patch_fsdp_unused_param_reduction
+
+
+def test_configure_fsdp_unused_param_reduction_uses_public_fsdp_api(monkeypatch):
+    from nemo_automodel.components.distributed import parallelizer_utils
+
+    class FakeFSDPModule(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.calls = []
+
+        def set_reduce_scatter_unused_params(self, enabled, *, recurse):
+            self.calls.append((enabled, recurse))
+
+    monkeypatch.setattr(parallelizer_utils, "FSDPModule", FakeFSDPModule)
+    model = nn.Sequential(FakeFSDPModule(), nn.Sequential(FakeFSDPModule()))
+
+    assert configure_fsdp_unused_param_reduction(model) == 2
+    assert model[0].calls == [(True, False)]
+    assert model[1][0].calls == [(True, False)]
+
+
+def test_configure_fsdp_unused_param_reduction_uses_legacy_fallback(monkeypatch):
+    from nemo_automodel.components.distributed import parallelizer_utils
+
+    class LegacyFSDPModule(nn.Module):
+        pass
+
+    install_fallback = Mock()
+    monkeypatch.setattr(parallelizer_utils, "FSDPModule", LegacyFSDPModule)
+    monkeypatch.setattr(parallelizer_utils, "_patch_fsdp_unused_param_reduction", install_fallback)
+    model = nn.Sequential(LegacyFSDPModule(), nn.Sequential(LegacyFSDPModule()))
+
+    assert configure_fsdp_unused_param_reduction(model) == 2
+    install_fallback.assert_called_once_with()
+
+
+def test_legacy_fsdp_unused_param_reduction_fills_missing_local_grad(monkeypatch):
+    from torch.distributed.fsdp._fully_shard._fsdp_common import TrainingState
+    from torch.distributed.fsdp._fully_shard._fsdp_param_group import FSDPParamGroup
+
+    calls = []
+
+    def original_post_backward(self, *args, **kwargs):
+        calls.append((self, args, kwargs))
+        return "post-backward-result"
+
+    monkeypatch.setattr(FSDPParamGroup, "post_backward", original_post_backward)
+    patch_fsdp_unused_param_reduction()
+    patched_post_backward = FSDPParamGroup.post_backward
+
+    param = torch.nn.Parameter(torch.ones(2))
+    fsdp_param = SimpleNamespace(
+        _unsharded_param=param,
+        unsharded_accumulated_grad=None,
+        unsharded_param=param,
+    )
+    param_group = SimpleNamespace(
+        reduce_grads=True,
+        _training_state=TrainingState.PRE_BACKWARD,
+        fsdp_params=[fsdp_param, SimpleNamespace()],
+    )
+
+    result = patched_post_backward(param_group, "arg", flag=True)
+    patch_fsdp_unused_param_reduction()
+
+    assert result == "post-backward-result"
+    assert torch.equal(param.grad, torch.zeros_like(param))
+    assert calls == [(param_group, ("arg",), {"flag": True})]
+    assert FSDPParamGroup.post_backward is patched_post_backward
 
 
 def _tag_hf_compute_dtype(model: nn.Module) -> None:

--- a/tests/unit_tests/loss/test_linear_ce.py
+++ b/tests/unit_tests/loss/test_linear_ce.py
@@ -21,6 +21,65 @@ from nemo_automodel.components.loss.linear_ce import (
 )
 
 
+class _FakeMesh:
+    ndim = 1
+
+    @staticmethod
+    def size():
+        return 2
+
+
+class _FakeDTensor:
+    requires_grad = True
+    device_mesh = _FakeMesh()
+
+    def __init__(self):
+        self.grad_placements = None
+        self.full = torch.ones(4, requires_grad=True)
+
+    def full_tensor(self, *, grad_placements=None):
+        self.grad_placements = grad_placements
+        return self.full
+
+
+def test_flce_materialized_weight_reduces_partial_gradient_into_shard(monkeypatch):
+    from torch.distributed.tensor import Partial
+
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda group: 2)
+    weight = _FakeDTensor()
+    raw_grads = []
+
+    def capture_raw_grad(grad):
+        raw_grads.append(grad)
+        return grad
+
+    weight.full.register_hook(capture_raw_grad)
+
+    full = FusedLinearCrossEntropy.materialize_lm_weight(
+        weight,
+        grad_reduce_group=object(),
+    )
+    full.square().sum().backward()
+
+    assert len(weight.grad_placements) == 1
+    assert isinstance(weight.grad_placements[0], Partial)
+    # The normalization hook must return a new tensor instead of modifying the
+    # gradient object received by earlier hooks.
+    assert torch.equal(raw_grads[0], torch.full_like(weight.full, 2.0))
+    # Raw grad is 2; divide by the two-rank reduction world size restores 1.
+    assert torch.equal(weight.full.grad, torch.ones_like(weight.full))
+
+
+def test_flce_materialized_weight_rejects_mismatched_reduction_group(monkeypatch):
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda group: 4)
+
+    with pytest.raises(ValueError, match="mesh size=2, reduction group size=4"):
+        FusedLinearCrossEntropy.materialize_lm_weight(
+            _FakeDTensor(),
+            grad_reduce_group=object(),
+        )
+
+
 @pytest.mark.skipif(not HAVE_CUT_CROSS_ENTROPY, reason="Linear loss CE is not installed")
 def test_fused_cross_entropy():
     """Tests FusedLinearCrossEntropy against PyTorch's CE.
@@ -177,7 +236,7 @@ def test_fused_cross_entropy_normalizes_by_num_tokens(monkeypatch):
     def _fake_linear_ce(hidden, weight, targets=None, **kwargs):  # noqa: D401,E501 - signature match not required
         return torch.tensor(20.0)
 
-    monkeypatch.setattr(linear_ce_mod, "linear_cross_entropy", _fake_linear_ce)
+    monkeypatch.setattr(linear_ce_mod, "linear_cross_entropy", _fake_linear_ce, raising=False)
 
     loss_fn = linear_ce_mod.FusedLinearCrossEntropy(reduction="sum")
 

--- a/tests/unit_tests/loss/test_mtp_cross_boundary.py
+++ b/tests/unit_tests/loss/test_mtp_cross_boundary.py
@@ -258,6 +258,7 @@ def test_thd_flat_labels_squeeze_3d_hidden_states():
             mtp_per_depth_h=mtp_per_depth_h,
             labels=labels,
             model=mock.MagicMock(),
+            lm_weight=torch.zeros((1, H), requires_grad=True),
             scaling_factor=1.0,
             ignore_index=IGNORE,
         )
@@ -292,6 +293,7 @@ def test_2d_labels_and_3d_hidden_states_unchanged():
             mtp_per_depth_h=mtp_per_depth_h,
             labels=labels,
             model=mock.MagicMock(),
+            lm_weight=torch.zeros((1, H), requires_grad=True),
             scaling_factor=1.0,
             ignore_index=IGNORE,
         )

--- a/tests/unit_tests/moe/test_parallelizer.py
+++ b/tests/unit_tests/moe/test_parallelizer.py
@@ -422,6 +422,7 @@ def _import_parallelizer_with_stubs(monkeypatch):
         fully_shard_fn(module, **kwargs)
 
     parallelizer_utils_stub.fully_shard_by_dtype = fully_shard_by_dtype
+    parallelizer_utils_stub.configure_fsdp_unused_param_reduction = lambda module: 0
     monkeypatch.setitem(
         sys.modules,
         "nemo_automodel.components.distributed.parallelizer_utils",

--- a/tests/unit_tests/recipes/test_finetune_vlm_cp_wiring.py
+++ b/tests/unit_tests/recipes/test_finetune_vlm_cp_wiring.py
@@ -118,6 +118,11 @@ class _SupportedVisionModel:
     supports_cp_vision_frame_sharding = True
 
 
+class _PackedCPModel:
+    def __init__(self, *, supported):
+        self.supports_cp_with_sequence_packing = supported
+
+
 def test_cp_vision_frame_sharding_rejects_model_without_capability():
     policy = CpVisionFrameShardingConfig(enabled=True)
 
@@ -138,6 +143,32 @@ def test_disabled_cp_vision_frame_sharding_accepts_model_without_capability():
     policy = CpVisionFrameShardingConfig(enabled=False)
 
     vlm_finetune._validate_cp_vision_frame_sharding_support(_UnsupportedVisionModel(), policy)
+
+
+def test_packed_cp_rejects_unsupported_qwen_backend_before_dataloader_build():
+    with pytest.raises(ValueError, match="Disable sequence packing, use cp_size=1"):
+        vlm_finetune._validate_cp_packing_support(
+            _PackedCPModel(supported=False),
+            packing_enabled=True,
+            cp_size=8,
+        )
+
+
+@pytest.mark.parametrize(("packing_enabled", "cp_size"), [(False, 8), (True, 1)])
+def test_packed_cp_validation_is_inactive_without_composed_path(packing_enabled, cp_size):
+    vlm_finetune._validate_cp_packing_support(
+        _PackedCPModel(supported=False),
+        packing_enabled=packing_enabled,
+        cp_size=cp_size,
+    )
+
+
+def test_packed_cp_accepts_model_owned_backend():
+    vlm_finetune._validate_cp_packing_support(
+        _PackedCPModel(supported=True),
+        packing_enabled=True,
+        cp_size=8,
+    )
 
 
 def test_cp_vision_frame_sharding_context_resets_published_group_after_failure(monkeypatch):

--- a/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
+++ b/tests/unit_tests/recipes/test_finetune_vlm_helpers.py
@@ -1462,12 +1462,13 @@ class TestCalculateLoss:
         hidden_states = torch.randn(2, 5, 32, device="cuda")
         labels = torch.randint(0, 50, (2, 5), device="cuda")
 
-        # Use a plain object that has lm_head but no get_output_embeddings
+        # Use a module that has lm_head parameters but no get_output_embeddings
         # This tests the fallback path in calculate_loss
-        class ModelWithLmHeadOnly:
-            """Non-nn.Module model without get_output_embeddings."""
+        class ModelWithLmHeadOnly(torch.nn.Module):
+            """nn.Module model without get_output_embeddings."""
 
             def __init__(self):
+                super().__init__()
                 self._lm_head = torch.nn.Linear(32, 50).cuda()
 
             def named_parameters(self, remove_duplicate=False):

--- a/tests/unit_tests/recipes/test_kd_separate_mesh_recipe_helpers.py
+++ b/tests/unit_tests/recipes/test_kd_separate_mesh_recipe_helpers.py
@@ -99,8 +99,10 @@ def test_kd_fused_loss_preserves_tensor_valued_hidden_states(monkeypatch, recipe
         del model, mesh, kwargs
         return SimpleNamespace(shard=lambda actual_batch: (nullcontext, actual_batch))
 
-    calculate_loss = Mock(return_value=torch.tensor(2.0))
+    grad_reduce_group = object()
+    calculate_loss = Mock(return_value=torch.tensor(2.0, requires_grad=True))
     monkeypatch.setattr(recipe_module, "ContextParallelSharder", no_op_sharder)
+    monkeypatch.setattr(recipe_module, "get_sync_ctx", lambda *args, **kwargs: nullcontext())
     monkeypatch.setattr(recipe_module, "calculate_loss", calculate_loss)
 
     student = _TensorHiddenStateStudent()
@@ -116,6 +118,7 @@ def test_kd_fused_loss_preserves_tensor_valued_hidden_states(monkeypatch, recipe
     recipe.kd_ratio = 0.5
     recipe._offload_teacher_model = False
     recipe.separate_meshes = False
+    recipe._get_dp_group = lambda include_cp=True: grad_reduce_group
     recipe._get_dp_group_size = lambda include_cp=True: 1
 
     batch = {
@@ -131,7 +134,7 @@ def test_kd_fused_loss_preserves_tensor_valued_hidden_states(monkeypatch, recipe
             loss_buffer=[],
             num_label_tokens=5,
             num_batches=1,
-            is_train=False,
+            is_train=True,
         )
     else:
         recipe._forward_backward_step(
@@ -139,13 +142,14 @@ def test_kd_fused_loss_preserves_tensor_valued_hidden_states(monkeypatch, recipe
             batch,
             num_label_tokens=5,
             num_batches=1,
-            is_train=False,
+            is_train=True,
         )
 
     received_hidden_states = calculate_loss.call_args.kwargs["hidden_states"]
     assert student.logits_to_keep is None
     assert received_hidden_states is student.hidden_states
     assert received_hidden_states.shape[:-1] == batch["labels"].shape
+    assert calculate_loss.call_args.kwargs["grad_reduce_group"] is grad_reduce_group
 
 
 @pytest.mark.parametrize("recipe_module,recipe_cls,parent_cls", _RECIPE_CASES)

--- a/tests/unit_tests/test_validation.py
+++ b/tests/unit_tests/test_validation.py
@@ -81,6 +81,18 @@ class _WithKwargs(nn.Module):
         return input_ids
 
 
+class _ModelOwnedPackedCP(nn.Module):
+    _packed_cp_attn_backends = ("sdpa",)
+    _supports_sdpa = True
+
+    def __init__(self, backend_attn):
+        super().__init__()
+        self.backend = SimpleNamespace(attn=backend_attn)
+
+    def forward(self, input_ids, **kwargs):
+        return input_ids
+
+
 @dataclass(frozen=True)
 class _THDCapabilities:
     supports_tp: bool = False
@@ -419,6 +431,21 @@ class TestModelSupportsGradientCheckpointing:
 
 
 class TestModelSupportsCPWithSequencePacking:
+    @pytest.mark.parametrize(("backend", "expected"), [("sdpa", True), ("te", False)])
+    def test_model_owned_packed_cp_backend_contract(self, backend, expected):
+        model = _ModelOwnedPackedCP(backend)
+        _attach(model)
+        model._mesh = _mesh(cp=2)
+
+        assert model.supports.supports_cp_with_sequence_packing is expected
+
+    def test_model_owned_backend_contract_does_not_restrict_cp1_packing(self):
+        model = _ModelOwnedPackedCP("te")
+        _attach(model)
+        model._mesh = _mesh(cp=1)
+
+        assert model.supports.supports_cp_with_sequence_packing is True
+
     def test_cp1_seq_packing_supported(self):
         """When cp_size=1, just checks seq_lens support."""
         model = _WithSeqLens()


### PR DESCRIPTION
# What does this PR do?

Manually backports #3414 to `r0.6.0` after the automated cherry-pick conflicted in `nemo_automodel/_transformers/capabilities.py` and did not open a PR.

## Why this PR is manual

The `r0.6.0` label was present before #3414 merged, and the [automatic backport workflow](https://github.com/NVIDIA-NeMo/Automodel/actions/runs/31341137681) did run. Its `git cherry-pick -s ae43fd65d303efb91553e047fa5df21e02bde0e5` step failed with a content conflict in `nemo_automodel/_transformers/capabilities.py` because `main` and the release branch had diverged in the packed-CP capability logic.

After the conflict, the automation pushed `cherry-pick-3414-r0.6.0` without the cherry-picked commit, skipped PR creation, and sent only a Slack notification requesting a manual resolution. The workflow handled that failure internally and still concluded as **success**, which is why GitHub showed no failed check and no automatic cherry-pick PR appeared.

This PR restarts from the current `r0.6.0` head, applies #3414, and resolves that single conflict manually.

The backport preserves the release branch's existing capability behavior and adds only #3414's model-owned `_packed_cp_attn_backends` contract. It intentionally does not pull in unrelated `main`-only `_owns_cp_attention` behavior.

# Changelog

Correctness fixes:

- Correct FusedLinearCrossEntropy LM-head gradients when the weight is an FSDP DTensor and independent DP/CP ranks contribute loss shards. The reduction group is threaded through LLM/VLM, MTP, KD, and pipeline loss paths.
- Keep FSDP reduce-scatter collective ordering and peer gradient contributions correct when CP or mixed-modality execution leaves a parameter unused on a local rank.
- Reject VLM sequence packing with CP before dataloader construction when the model's active attention backend does not own a supported packed-CP path.

Optimization and documentation:

- Add the `min_frames` vision-sharding threshold so long videos can shard even when their merged visual-token count remains below `min_tokens`.
- Document the combined `min_tokens` / `min_frames` policy and supported VLM families.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Included the focused tests from #3414.
- [x] Included the documentation updates from #3414.

Validation:

- `490 passed, 11 skipped` across focused CP vision sharding, FSDP unused-parameter, FLCE/MTP, LLM/VLM recipe, KD, and capability unit tests.
- Ruff format and lint checks pass for all 14 changed production Python files.
- Patch range comparison confirms the only source/backport difference is the narrow release-specific conflict resolution described above.
- The original PR's two-GPU correctness test and scoped CI passed before merge; this PR will run release-branch CI on the exact backport commit.

# Additional Information

- Backport of #3414.
- Failed automated backport: https://github.com/NVIDIA-NeMo/Automodel/actions/runs/31341137681
