### PR TITLE
fix(recipe): shard GPT-OSS 120B across 64 experts

### DIFF
--- a/examples/llm_finetune/gpt_oss/gpt_oss_120b.yaml
+++ b/examples/llm_finetune/gpt_oss/gpt_oss_120b.yaml
@@ -55,7 +55,7 @@ distributed:
   tp_size: 1
   cp_size: 1
   pp_size: 1
-  ep_size: 32
+  ep_size: 64
 
   sequence_parallel: false
 
@@ -113,6 +113,6 @@ optimizer:
 
 ci:
   recipe_owner: hemildesai
-  local_batch_size: 16
-  nodes: 4
+  local_batch_size: 8
+  nodes: 8
   time: "01:00:00"

--- a/tests/unit_tests/ci_tests/test_generate_ci_tests.py
+++ b/tests/unit_tests/ci_tests/test_generate_ci_tests.py
@@ -38,6 +38,19 @@ def test_generate_deepseek_v4_pretrain_release_job():
     assert job["variables"]["TEST_LEVEL"] == "release"
 
 
+def test_generate_gpt_oss_120b_release_job_uses_ep64():
+    config = Path("examples/llm_finetune/gpt_oss/gpt_oss_120b.yaml")
+
+    jobs = dict(generate_job(config, {}, "release", "llm_finetune", "."))
+    recipe = YAML(typ="safe").load(config)
+
+    variables = jobs[""]["variables"]
+    world_size = variables["TEST_NODE_COUNT"] * 8
+    assert variables["TEST_NODE_COUNT"] == 8
+    assert variables["LOCAL_BATCH_SIZE"] == 8
+    assert recipe["distributed"]["ep_size"] == world_size
+
+
 def test_generate_vllm_deploy_time_override(tmp_path):
     config = Path("model_peft.yaml")
     (tmp_path / config).write_text(


### PR DESCRIPTION
# What does this PR do?

Prevent the GPT-OSS 120B release recipe from running out of H100 memory on its first backward pass by sharding it across 64 ranks.

## Root cause

The release job ran the 116.8B-parameter model on 4 nodes (32 H100s) with EP32 and CI local batch size 16. That topology exhausted each GPU during the first backward pass: only 432 MiB remained when PyTorch requested another 1.82 GiB.

An 8-node EP64 source-overlay run completed all 50 training steps with the same global batch size, establishing the memory-safe topology used here.

# Changelog

- Increase the GPT-OSS 120B CI topology from 4 nodes/EP32 to 8 nodes/EP64.
- Reduce the CI local batch size from 16 to 8, preserving global batch 512 with one accumulation step.
- Add a focused CI-generation test that locks the 64-rank topology and generated resource variables.

# Validation

- `python tools/lint_example_yamls.py examples/llm_finetune/gpt_oss/gpt_oss_120b.yaml`
- `python -m pytest tests/unit_tests/ci_tests/test_generate_ci_tests.py -q` (10 passed)
- Prior 50-step topology proof: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/385749871
- Same-container 50-step proof (8 nodes, EP64, local batch 8): https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/392012313
- NeMo-CI lineage: [parent](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/62021837) -> [AutoModel child](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/62021846) -> [LLM leaf](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/62021938) (all passed)

# Before your PR is "Ready for review"

- [x] Read and followed the contributor guidelines.
- [x] Added the necessary focused test.
- [x] No documentation update is needed for this CI resource correction.

# Additional Information

Failure being fixed: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/390380021
