### PR TITLE
fix(ci): register flux2/wan2.2/qwen-image-edit diffusion recipes in CI

### DIFF
--- a/examples/diffusion/finetune/flux2_t2i_flow.yaml
+++ b/examples/diffusion/finetune/flux2_t2i_flow.yaml
@@ -94,5 +94,5 @@ checkpoint:
   checkpoint_dir: PATH_TO_YOUR_CKPT_DIR
   model_save_format: safetensors
   save_consolidated: final
-  diffusers_compatible: false
+  diffusers_compatible: true
   restore_from: null

--- a/examples/diffusion/finetune/flux2_t2i_flow_lora.yaml
+++ b/examples/diffusion/finetune/flux2_t2i_flow_lora.yaml
@@ -98,7 +98,7 @@ flow_matching:
 step_scheduler:
   num_epochs: 1000
   local_batch_size: 1
-  global_batch_size: 4
+  global_batch_size: 8
   ckpt_every_steps: 500
   log_remote_every_steps: 10
   # max_steps: null  # Set to limit training to a specific number of steps

--- a/tests/ci_tests/scripts/diffusion_finetune_launcher.sh
+++ b/tests/ci_tests/scripts/diffusion_finetune_launcher.sh
@@ -55,7 +55,11 @@ DIFFUSION_EXTRAS="--extra diffusion --extra diffusion-media"
 echo "============================================"
 echo "[data] Resolving dataset..."
 echo "============================================"
-if [ "$MEDIA_TYPE" = "image" ]; then
+if [ "$MEDIA_TYPE" = "image_edit" ]; then
+    # The image-edit preprocess CLI resolves its HF dataset itself (via
+    # HF_HOME), so there is no separate download stage.
+    echo "[data] image-edit dataset is resolved by the preprocess stage"
+elif [ "$MEDIA_TYPE" = "image" ]; then
     RAW_DATA_DIR="$DATA_DIR/raw"
     uv run $DIFFUSION_EXTRAS python -c "
 from datasets import load_dataset
@@ -93,7 +97,13 @@ fi
 echo "============================================"
 echo "[preprocess] Converting ${MEDIA_TYPE}s to latents..."
 echo "============================================"
-if [ "$MEDIA_TYPE" = "image" ]; then
+if [ "$MEDIA_TYPE" = "image_edit" ]; then
+    uv run $DIFFUSION_EXTRAS python -m tools.diffusion.preprocessing_multiprocess image-edit \
+        --output_dir "$DATA_DIR/cache" \
+        --processor "$PROCESSOR" \
+        --model_name "$MODEL_NAME" \
+        $PREPROCESS_EXTRA_ARGS
+elif [ "$MEDIA_TYPE" = "image" ]; then
     uv run $DIFFUSION_EXTRAS python -m tools.diffusion.preprocessing_multiprocess image \
         --image_dir "$RAW_DATA_DIR" \
         --output_dir "$DATA_DIR/cache" \
@@ -130,6 +140,7 @@ CONFIG="--config /opt/Automodel/${CONFIG_PATH} \
     --step_scheduler.max_steps ${MAX_STEPS:-100} \
     --step_scheduler.ckpt_every_steps 100 \
     --step_scheduler.save_checkpoint_every_epoch false \
+    --lr_scheduler.lr_warmup_steps ${LR_WARMUP_STEPS:-10} \
     ${DIST_OVERRIDE} \
     --wandb.mode disabled"
 
@@ -158,15 +169,27 @@ if [ "$IS_LORA" = "true" ]; then
     CKPT_FLAG="--model.lora_weights"
     CKPT_STEP_DIR="$CKPT_STEP_DIR/model"
 else
-    CKPT_FLAG="--model.checkpoint"
+    # Two-transformer pipelines (Wan2.2) reject --model.checkpoint; their recipe
+    # config sets CKPT_FLAG_OVERRIDE to the stage flag matching model.stage and
+    # GENERATE_EXTRA_ARGS to reset the other stage to hub-pretrained weights.
+    CKPT_FLAG="${CKPT_FLAG_OVERRIDE:---model.checkpoint}"
 fi
 
-if [ "$MEDIA_TYPE" = "image" ]; then
+if [ "$MEDIA_TYPE" = "image" ] || [ "$MEDIA_TYPE" = "image_edit" ]; then
+    # Edit pipelines require one source image per prompt; reuse a source image
+    # materialized by the image-edit preprocess stage.
+    INPUT_IMAGES_OVERRIDE=""
+    if [ "$MEDIA_TYPE" = "image_edit" ]; then
+        # -print -quit avoids a SIGPIPE from `find | head` under pipefail.
+        SOURCE_IMAGE=$(find "$DATA_DIR/cache/_hf_dataset" \( -name '*.png' -o -name '*.jpg' \) -print -quit)
+        INPUT_IMAGES_OVERRIDE="--inference.input_images [\"$SOURCE_IMAGE\"]"
+    fi
     uv run $DIFFUSION_EXTRAS python examples/diffusion/generate/generate.py \
         --config "$GENERATE_CONFIG" \
         --model.pretrained_model_name_or_path "$MODEL_NAME" \
         $CKPT_FLAG "$CKPT_STEP_DIR" \
         --inference.num_inference_steps 5 \
+        $INPUT_IMAGES_OVERRIDE \
         --output.output_dir "$INFER_DIR" \
         --vae.enable_slicing true \
         --vae.enable_tiling true
@@ -182,6 +205,7 @@ else
         --config "$GENERATE_CONFIG" \
         --model.pretrained_model_name_or_path "$MODEL_NAME" \
         $CKPT_FLAG "$CKPT_STEP_DIR" \
+        ${GENERATE_EXTRA_ARGS:-} \
         --inference.num_inference_steps 5 \
         --inference.pipeline_kwargs.num_frames "$INFER_NUM_FRAMES" \
         --output.output_dir "$INFER_DIR" \

--- a/tests/ci_tests/scripts/diffusion_finetune_recipe_config.sh
+++ b/tests/ci_tests/scripts/diffusion_finetune_recipe_config.sh
@@ -47,12 +47,47 @@ configure_diffusion_finetune_recipe() {
             MODEL_NAME="black-forest-labs/FLUX.1-dev"
             PREPROCESS_EXTRA_ARGS=""
             ;;
+        flux2_t2i_flow*)
+            MEDIA_TYPE="image"
+            PROCESSOR="flux2"
+            GENERATE_CONFIG="examples/diffusion/generate/configs/generate_flux2.yaml"
+            MODEL_NAME="black-forest-labs/FLUX.2-dev"
+            PREPROCESS_EXTRA_ARGS=""
+            ;;
+        qwen_image_edit_2511_flow*)
+            # Image-edit training consumes source->target pairs, not the tuxemon
+            # T2I set; MagicBrush is the dataset documented for this recipe
+            # (docs/model-coverage/diffusion/qwen/qwen-image.mdx).
+            MEDIA_TYPE="image_edit"
+            PROCESSOR="qwen_image_edit"
+            GENERATE_CONFIG="examples/diffusion/generate/configs/generate_qwen_image_edit.yaml"
+            MODEL_NAME="Qwen/Qwen-Image-Edit-2511"
+            PREPROCESS_EXTRA_ARGS="--dataset_name osunlp/MagicBrush --dataset_split dev \
+                --dataset_media_mapping target=target_img \
+                --dataset_media_mapping context=source_img \
+                --dataset_media_mapping condition=source_img \
+                --dataset_caption_column instruction \
+                --max_items 64 --max_pixels 1048576 --max_sequence_length 512"
+            ;;
         qwen_image_t2i_flow*)
             MEDIA_TYPE="image"
             PROCESSOR="qwen_image"
             GENERATE_CONFIG="examples/diffusion/generate/configs/generate_qwen_image.yaml"
             MODEL_NAME="Qwen/Qwen-Image"
             PREPROCESS_EXTRA_ARGS=""
+            ;;
+        wan2_2_t2v_flow*)
+            MEDIA_TYPE="video"
+            PROCESSOR="wan2.2"
+            GENERATE_CONFIG="examples/diffusion/generate/configs/generate_wan22.yaml"
+            MODEL_NAME="Wan-AI/Wan2.2-T2V-A14B-Diffusers"
+            INFER_NUM_FRAMES=9
+            PREPROCESS_EXTRA_ARGS="--target_frames 13"
+            # The recipe trains the high-noise stage; keep the low-noise stage
+            # at hub-pretrained weights (the generate config's default paths
+            # are placeholders).
+            CKPT_FLAG_OVERRIDE="--model.checkpoint_high_noise"
+            GENERATE_EXTRA_ARGS="--model.checkpoint_low_noise None"
             ;;
         *)
             echo "ERROR: Unknown recipe '$recipe_name'. Add a case to diffusion_finetune_recipe_config.sh." >&2


### PR DESCRIPTION
# What does this PR do ?

Fixes the five failing nightly diffusion CI jobs (`flux2_t2i_flow`, `flux2_t2i_flow_lora`, `qwen_image_edit_2511_flow`, `wan2_2_t2v_flow`, `flux_t2i_flow_lora`) by registering the new recipes in the CI scripts and correcting the flux2 recipe configs.

# Changelog

- `tests/ci_tests/scripts/diffusion_finetune_recipe_config.sh`: add recipe cases for `flux2_t2i_flow*` (FLUX.2-dev, flux2 processor, image), `qwen_image_edit_2511_flow*` (Qwen-Image-Edit-2511, image-edit media type, MagicBrush dataset), and `wan2_2_t2v_flow*` (Wan2.2-T2V-A14B, wan2.2 processor, video, two-stage checkpoint flags for inference). Previously these jobs failed at recipe routing with `Unknown recipe`.
- `tests/ci_tests/scripts/diffusion_finetune_launcher.sh`: add `--lr_scheduler.lr_warmup_steps ${LR_WARMUP_STEPS:-10}` override — `OptimizerParamScheduler` asserts `lr_warmup_steps < lr_decay_steps`, and the CI `max_steps=100` cap makes production warmup values (100–500) trip the assertion (this is the `flux_t2i_flow_lora` nightly failure). Also add the `image_edit` media type and `CKPT_FLAG_OVERRIDE`/`GENERATE_EXTRA_ARGS` support for Wan2.2 two-transformer inference.
- `examples/diffusion/finetune/flux2_t2i_flow.yaml`: `diffusers_compatible` false → true so the consolidated checkpoint uses the diffusers index name that `generate.py` can load.
- `examples/diffusion/finetune/flux2_t2i_flow_lora.yaml`: `global_batch_size` 4 → 8 to be divisible by the recipe's declared `local_batch_size 1 × dp_size 8` topology.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?

# Additional Information

- All five recipes validated end-to-end on 8xGPU with the nightly container (data → preprocess → 100-step finetune → inference smoke test): PASS.
- Nightly jobs will additionally need `black-forest-labs/FLUX.2-dev` (gated), `Qwen/Qwen-Image-Edit-2511`, `Wan-AI/Wan2.2-T2V-A14B-Diffusers`, and `osunlp/MagicBrush` seeded into the CI HF cache; the HF-cache preflight falls back to live download otherwise, which will not fit the shorter job time limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)