### PR TITLE
ci: add GPU runner label suffix switch

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -38,8 +38,8 @@ jobs:
   pre-flight:
     uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_cicd_preflight.yml@c1a0837f362a1a696e647238ab1cf916b2a7cf4a # v1.8.6
     with:
-      default_runner_prefix: ${{ vars.DEFAULT_RUNNER_PREFIX }}
-      non_nvidia_runner_prefix: ${{ vars.NON_NVIDIA_RUNNER_PREFIX }}
+      default_runner_prefix: ${{ format('{0}{1}', vars.DEFAULT_RUNNER_PREFIX, vars.GPU_RUNNER_SUFFIX) }}
+      non_nvidia_runner_prefix: ${{ format('{0}{1}', vars.NON_NVIDIA_RUNNER_PREFIX, vars.GPU_RUNNER_SUFFIX) }}
       default_test_data_path: ${{ vars.DEFAULT_TEST_DATA_PATH }}
       non_nvidia_test_data_path: ${{ vars.NON_NVIDIA_TEST_DATA_PATH }}
       sso_users_filename: ${{ vars.SSO_USERS_FILENAME }}

--- a/tests/functional_tests/llm_pretrain_and_kd/customizer_retrieval/test_bi_encoder_checkpoint_restoration.py
+++ b/tests/functional_tests/llm_pretrain_and_kd/customizer_retrieval/test_bi_encoder_checkpoint_restoration.py
@@ -313,7 +313,8 @@ class TestBiEncoderCheckpointRestoration:
             )
             hf_peft_config = PeftConfig(match_all_linear=True, dim=8, alpha=32, use_triton=False)
             apply_lora_to_linear_modules(hf_model, hf_peft_config, quantization_config=None)
-            hf_model.load_state_dict(saved_sd, strict=False, assign=True)
+            hf_full_sd = _load_safetensors_from_dir(save_dir)
+            hf_model.load_state_dict(hf_full_sd, strict=False)
 
             # ---- Step 7: Compare ALL weights (base + LoRA) ----------------
             nemo_sd = nemo_model.model.state_dict()

--- a/tests/functional_tests/llm_pretrain_and_kd/customizer_retrieval/test_bi_encoder_checkpoint_restoration.py
+++ b/tests/functional_tests/llm_pretrain_and_kd/customizer_retrieval/test_bi_encoder_checkpoint_restoration.py
@@ -313,8 +313,7 @@ class TestBiEncoderCheckpointRestoration:
             )
             hf_peft_config = PeftConfig(match_all_linear=True, dim=8, alpha=32, use_triton=False)
             apply_lora_to_linear_modules(hf_model, hf_peft_config, quantization_config=None)
-            hf_full_sd = _load_safetensors_from_dir(save_dir)
-            hf_model.load_state_dict(hf_full_sd, strict=False)
+            hf_model.load_state_dict(saved_sd, strict=False, assign=True)
 
             # ---- Step 7: Compare ALL weights (base + LoRA) ----------------
             nemo_sd = nemo_model.model.state_dict()


### PR DESCRIPTION
# What does this PR do ?

Adds an optional `GPU_RUNNER_SUFFIX` repository variable to the AWS GPU runner label construction in `cicd-main.yml`.

# Changelog

- Append `GPU_RUNNER_SUFFIX` to the default NVIDIA GPU runner prefix.
- Append the same suffix to the non-NVIDIA ephemeral GPU runner prefix.
- Preserve current production labels when the variable is unset or empty.
- Allow `-dev-02` to select `nemo-ci-aws-gpu-x2-dev-02` and `nemo-ci-aws-gpu-x2-ephemeral-dev-02`.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] No new tests are needed for this two-expression workflow change.
- [x] No documentation change is needed; the PR records the switch and rollback values.
- [x] YAML parse passed.
- [x] `git diff --check` passed.
- [x] Commit includes DCO sign-off and a verified Git signature.

# Additional Information

Related to AUT-1335. This PR does not create or change the repository variable; setting or clearing it remains a separate approval-controlled routing action.