### PR TITLE
fix(models): preserve lm-head dtype boundaries

### DIFF
--- a/nemo_automodel/components/models/common/utils.py
+++ b/nemo_automodel/components/models/common/utils.py
@@ -20,6 +20,7 @@ from typing import Any, Literal
 
 import torch
 from torch import nn
+from torch.distributed.fsdp import FSDPModule
 from transformers.modeling_outputs import CausalLMOutputWithPast
 
 from nemo_automodel.shared.import_utils import safe_import_from
@@ -848,8 +849,6 @@ def compute_lm_head_logits(
     is_thd: bool = False,
     fp32_lm_head: bool = False,
     output_hidden_states: bool = False,
-    *,
-    match_lm_head_dtype: bool = False,
 ) -> CausalLMOutputWithPast:
     """Project hidden states through ``lm_head`` and wrap the result.
 
@@ -880,7 +879,10 @@ def compute_lm_head_logits(
       to fp32 (e.g. via the MoE ``lm_head_precision`` setting). The matmul goes
       through ``lm_head`` (``nn.Linear``, DTensor-aware under FSDP2) rather than
       ``F.linear`` so DTensor redistribution is preserved.
-    - ``match_lm_head_dtype``: cast the sliced input to the head weight dtype.
+    - Otherwise, cast the sliced input to the head's effective compute dtype.
+      For a standalone FSDP2 head this comes from its mixed-precision policy,
+      since its sharded weight may still expose the master-copy dtype before the
+      forward pre-hook runs. Other heads use their materialized weight dtype.
     - ``output_hidden_states``: when set, the (full-sequence, THD-restored)
       ``hidden_states`` are attached to the output so the fused cross-entropy
       path can recompute logits over every position; otherwise the field is
@@ -897,7 +899,6 @@ def compute_lm_head_logits(
         fp32_lm_head: Project in fp32 and cast the result back to the input
             dtype. Ignored when ``lm_head`` is ``None``.
         output_hidden_states: Attach the final hidden states to the output.
-        match_lm_head_dtype: Cast the sliced input to the LM-head weight dtype.
 
     Returns:
         A ``CausalLMOutputWithPast`` whose ``logits`` are the projected logits
@@ -918,13 +919,15 @@ def compute_lm_head_logits(
                 sliced = hidden_states[:, slice_indices, :]
         if fp32_lm_head:
             logits = lm_head(sliced.float()).to(hidden_states.dtype)
-        elif match_lm_head_dtype:
-            lm_head_weight = getattr(lm_head, "weight", None)
-            if lm_head_weight is None:
-                raise ValueError("match_lm_head_dtype requires lm_head to expose a weight tensor")
-            logits = lm_head(sliced.to(lm_head_weight.dtype))
         else:
-            logits = lm_head(sliced)
+            compute_dtype = None
+            if isinstance(lm_head, FSDPModule):
+                compute_dtype = lm_head._get_fsdp_state()._mp_policy.param_dtype
+            lm_head_weight = getattr(lm_head, "weight", None)
+            if compute_dtype is None and isinstance(lm_head_weight, torch.Tensor):
+                compute_dtype = lm_head_weight.dtype
+            projection_input = sliced.to(compute_dtype) if compute_dtype is not None else sliced
+            logits = lm_head(projection_input)
     if is_thd and logits.dim() == 2:
         logits = logits.unsqueeze(0)
 

--- a/nemo_automodel/components/models/common/utils.py
+++ b/nemo_automodel/components/models/common/utils.py
@@ -848,6 +848,8 @@ def compute_lm_head_logits(
     is_thd: bool = False,
     fp32_lm_head: bool = False,
     output_hidden_states: bool = False,
+    *,
+    match_lm_head_dtype: bool = False,
 ) -> CausalLMOutputWithPast:
     """Project hidden states through ``lm_head`` and wrap the result.
 
@@ -878,6 +880,7 @@ def compute_lm_head_logits(
       to fp32 (e.g. via the MoE ``lm_head_precision`` setting). The matmul goes
       through ``lm_head`` (``nn.Linear``, DTensor-aware under FSDP2) rather than
       ``F.linear`` so DTensor redistribution is preserved.
+    - ``match_lm_head_dtype``: cast the sliced input to the head weight dtype.
     - ``output_hidden_states``: when set, the (full-sequence, THD-restored)
       ``hidden_states`` are attached to the output so the fused cross-entropy
       path can recompute logits over every position; otherwise the field is
@@ -894,6 +897,7 @@ def compute_lm_head_logits(
         fp32_lm_head: Project in fp32 and cast the result back to the input
             dtype. Ignored when ``lm_head`` is ``None``.
         output_hidden_states: Attach the final hidden states to the output.
+        match_lm_head_dtype: Cast the sliced input to the LM-head weight dtype.
 
     Returns:
         A ``CausalLMOutputWithPast`` whose ``logits`` are the projected logits
@@ -914,6 +918,11 @@ def compute_lm_head_logits(
                 sliced = hidden_states[:, slice_indices, :]
         if fp32_lm_head:
             logits = lm_head(sliced.float()).to(hidden_states.dtype)
+        elif match_lm_head_dtype:
+            lm_head_weight = getattr(lm_head, "weight", None)
+            if lm_head_weight is None:
+                raise ValueError("match_lm_head_dtype requires lm_head to expose a weight tensor")
+            logits = lm_head(sliced.to(lm_head_weight.dtype))
         else:
             logits = lm_head(sliced)
     if is_thd and logits.dim() == 2:

--- a/nemo_automodel/components/models/gemma4_moe/model.py
+++ b/nemo_automodel/components/models/gemma4_moe/model.py
@@ -1272,8 +1272,12 @@ class Gemma4ForConditionalGeneration(HFCheckpointingMixin, HFGemma4ForConditiona
                     **kwargs,
                 )
                 hidden_states = text_outputs.last_hidden_state
-                slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
-                logits = self.lm_head(hidden_states[:, slice_indices, :])
+                logits = compute_lm_head_logits(
+                    self.lm_head,
+                    hidden_states,
+                    logits_to_keep,
+                    match_lm_head_dtype=True,
+                ).logits
                 if (final_logit_softcapping := getattr(text_config, "final_logit_softcapping", None)) is not None:
                     logits = logits / final_logit_softcapping
                     logits = torch.tanh(logits)
@@ -1394,7 +1398,12 @@ class Gemma4ForConditionalGeneration(HFCheckpointingMixin, HFGemma4ForConditiona
 
         hidden_states = outputs.last_hidden_state
 
-        logits = compute_lm_head_logits(self.lm_head, hidden_states, logits_to_keep).logits
+        logits = compute_lm_head_logits(
+            self.lm_head,
+            hidden_states,
+            logits_to_keep,
+            match_lm_head_dtype=True,
+        ).logits
 
         if (final_logit_softcapping := getattr(text_config, "final_logit_softcapping", None)) is not None:
             logits = logits / final_logit_softcapping

--- a/nemo_automodel/components/models/gemma4_moe/model.py
+++ b/nemo_automodel/components/models/gemma4_moe/model.py
@@ -1276,7 +1276,6 @@ class Gemma4ForConditionalGeneration(HFCheckpointingMixin, HFGemma4ForConditiona
                     self.lm_head,
                     hidden_states,
                     logits_to_keep,
-                    match_lm_head_dtype=True,
                 ).logits
                 if (final_logit_softcapping := getattr(text_config, "final_logit_softcapping", None)) is not None:
                     logits = logits / final_logit_softcapping
@@ -1402,7 +1401,6 @@ class Gemma4ForConditionalGeneration(HFCheckpointingMixin, HFGemma4ForConditiona
             self.lm_head,
             hidden_states,
             logits_to_keep,
-            match_lm_head_dtype=True,
         ).logits
 
         if (final_logit_softcapping := getattr(text_config, "final_logit_softcapping", None)) is not None:

--- a/nemo_automodel/components/models/nemotron_omni/model.py
+++ b/nemo_automodel/components/models/nemotron_omni/model.py
@@ -536,6 +536,11 @@ class NemotronOmniForConditionalGeneration(HFCheckpointingMixin, nn.Module, MoEF
         """Set the output embeddings (lm_head) of the language model."""
         self.language_model.set_output_embeddings(new_embeddings)
 
+    @property
+    def lm_head(self) -> nn.Module | None:
+        """Return the nested language-model output head without re-registering it."""
+        return self.language_model.lm_head
+
     # ------------------------------------------------------------------
     # Vision feature extraction
     # ------------------------------------------------------------------

--- a/tests/functional_tests/models/test_nemo_rl_lm_head_dtype_fsdp.py
+++ b/tests/functional_tests/models/test_nemo_rl_lm_head_dtype_fsdp.py
@@ -1,0 +1,220 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NeMo RL mixed-precision LM-head regressions under real FSDP2 hooks.
+
+NeMo RL keeps FP32 master parameters, executes with BF16 parameters, and asks
+FSDP2 to return FP32 module outputs. This exercises the two model layouts from
+PR #3491:
+
+* Gemma4 ties the output head to the input embedding, so the head is owned by
+  the outer FSDP root rather than wrapped independently.
+* Nemotron Omni exposes an untied nested head, allowing the parallelizer to
+  wrap that head as its own FSDP unit.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+
+def _free_port() -> int:
+    """Reserve a free localhost port for process-group rendezvous."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as rendezvous_socket:
+        rendezvous_socket.bind(("127.0.0.1", 0))
+        return int(rendezvous_socket.getsockname()[1])
+
+
+def _backend():
+    from nemo_automodel.components.models.common import BackendConfig
+
+    return BackendConfig(
+        linear="torch",
+        attn="sdpa",
+        rms_norm="torch",
+        experts="torch",
+        dispatcher="torch",
+        fake_balanced_gate=False,
+        enable_hf_state_dict_adapter=False,
+    )
+
+
+def _build_gemma4():
+    from transformers.models.gemma4.configuration_gemma4 import Gemma4Config, Gemma4TextConfig
+
+    from nemo_automodel.components.models.gemma4_moe.model import Gemma4ForConditionalGeneration
+
+    text_config = Gemma4TextConfig(
+        vocab_size=128,
+        hidden_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        num_hidden_layers=2,
+        intermediate_size=128,
+        rms_norm_eps=1e-6,
+        max_position_embeddings=64,
+        enable_moe_block=True,
+        num_experts=4,
+        top_k_experts=2,
+        moe_intermediate_size=64,
+        layer_types=["sliding_attention", "full_attention"],
+        sliding_window=32,
+        hidden_activation="gelu_pytorch_tanh",
+        torch_dtype="float32",
+        tie_word_embeddings=True,
+    )
+    config = Gemma4Config(text_config=text_config, tie_word_embeddings=True)
+    return Gemma4ForConditionalGeneration(config, backend=_backend())
+
+
+class _NemotronConfig:
+    """Small attention/MLP-only Nemotron-H configuration."""
+
+    def __init__(self) -> None:
+        self.num_attention_heads = 4
+        self.num_key_value_heads = 2
+        self.head_dim = 16
+        self.hidden_size = 64
+        self.attention_bias = False
+        self.attention_dropout = 0.0
+        self.intermediate_size = 128
+        self.mlp_bias = False
+        self.mlp_hidden_act = "relu2"
+        self.layer_norm_epsilon = 1e-5
+        self.num_hidden_layers = 2
+        self.vocab_size = 128
+        self.torch_dtype = "float32"
+        self.initializer_range = 0.02
+        self.rescale_prenorm_residual = True
+        self.residual_in_fp32 = False
+        self.layers_block_type = ["attention", "mlp"]
+        self.n_routed_experts = None
+        self.num_nextn_predict_layers = 0
+        self.tie_word_embeddings = False
+        self.output_hidden_states = True
+
+    def to_dict(self) -> dict[str, object]:
+        return vars(self)
+
+
+def _build_nemotron_omni():
+    from nemo_automodel.components.models.nemotron_omni.model import (
+        NemotronOmniForConditionalGeneration,
+        _ModelProxy,
+    )
+    from nemo_automodel.components.models.nemotron_v3.model import NemotronHForCausalLM
+
+    llm_config = _NemotronConfig()
+    language_model = NemotronHForCausalLM(llm_config, backend=_backend())
+
+    # The dtype regression only needs Omni's real text-forward and lm_head
+    # ownership contract; omit the large RADIO/Parakeet towers.
+    model = object.__new__(NemotronOmniForConditionalGeneration)
+    torch.nn.Module.__init__(model)
+    model.config = SimpleNamespace(llm_config=llm_config, tie_word_embeddings=False)
+    model.language_model = language_model
+    model.model = _ModelProxy(language_model)
+    model.cp_mesh = None
+    model.sound_encoder = None
+    return model
+
+
+def _run_case(rank: int, case: str, world_size: int, port: int) -> None:
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    os.environ["RANK"] = str(rank)
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    torch.cuda.set_device(rank)
+    device = torch.device("cuda", rank)
+    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+
+    try:
+        from torch.distributed.device_mesh import init_device_mesh
+        from torch.distributed.fsdp import FSDPModule, MixedPrecisionPolicy
+
+        from nemo_automodel.components.moe.parallelizer import apply_fsdp
+
+        torch.manual_seed(1234)
+        model = (_build_gemma4() if case == "gemma4" else _build_nemotron_omni()).to(device)
+        assert model.lm_head.weight.dtype == torch.float32
+
+        mesh = init_device_mesh("cuda", (world_size,), mesh_dim_names=("dp",))
+        policy = MixedPrecisionPolicy(
+            param_dtype=torch.bfloat16,
+            reduce_dtype=torch.float32,
+            output_dtype=torch.float32,
+            cast_forward_inputs=True,
+        )
+        apply_fsdp(
+            model,
+            fsdp_mesh=mesh,
+            ep_enabled=False,
+            ep_shard_enabled=False,
+            mp_policy=policy,
+            reshard_after_forward=True,
+        )
+
+        observed: dict[str, torch.dtype] = {}
+
+        def record_head_input(module, args):
+            observed["head_input"] = args[0].dtype
+            observed["head_weight"] = module.weight.dtype
+
+        if case == "gemma4":
+            assert model.lm_head.weight is model.model.language_model.embed_tokens.weight
+            assert not isinstance(model.lm_head, FSDPModule)
+
+            def record_hidden(_module, _args, output):
+                observed["hidden"] = output.last_hidden_state.dtype
+
+            model.model.language_model.register_forward_hook(record_hidden)
+        else:
+            assert model.lm_head is model.language_model.lm_head
+            assert isinstance(model.lm_head, FSDPModule)
+
+            def record_hidden(_module, _args, output):
+                observed["hidden"] = output.dtype
+
+            model.language_model.model.register_forward_hook(record_hidden)
+
+        model.lm_head.register_forward_pre_hook(record_head_input)
+        input_ids = torch.randint(0, 128, (2, 8), device=device)
+        outputs = model(input_ids=input_ids, use_cache=False, logits_to_keep=2)
+        outputs.logits.float().square().mean().backward()
+
+        assert observed == {
+            "hidden": torch.float32,
+            "head_input": torch.bfloat16,
+            "head_weight": torch.bfloat16,
+        }
+        assert torch.isfinite(outputs.logits).all()
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@pytest.mark.parametrize("case", ["gemma4", "nemotron_omni"])
+def test_nemo_rl_lm_head_dtype_boundary(case: str) -> None:
+    """Exercise NeMo RL's FP32-output/BF16-compute policy on both model layouts."""
+    world_size = 1
+    mp.spawn(_run_case, args=(case, world_size, _free_port()), nprocs=world_size, join=True)

--- a/tests/unit_tests/models/common/test_model_common_utils.py
+++ b/tests/unit_tests/models/common/test_model_common_utils.py
@@ -352,16 +352,43 @@ class TestComputeLmHeadLogits:
         out = compute_lm_head_logits(None, hidden, fp32_lm_head=True)
         assert out.logits is hidden
 
-    def test_match_lm_head_dtype_casts_after_slicing(self):
+    def test_lm_head_dtype_casts_after_slicing(self):
         lm_head = self._lm_head().to(torch.bfloat16)
         hidden = torch.randn(2, 5, self.HIDDEN, dtype=torch.float32)
 
-        out = compute_lm_head_logits(lm_head, hidden, logits_to_keep=2, match_lm_head_dtype=True)
+        out = compute_lm_head_logits(lm_head, hidden, logits_to_keep=2)
 
         expected = lm_head(hidden[:, -2:, :].to(torch.bfloat16))
         assert out.logits.shape == (2, 2, self.VOCAB)
         assert out.logits.dtype == torch.bfloat16
         torch.testing.assert_close(out.logits, expected)
+
+    def test_fsdp_lm_head_uses_policy_compute_dtype(self):
+        hidden_size = self.HIDDEN
+        vocab_size = self.VOCAB
+
+        class FakeFSDPHead(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = nn.Parameter(torch.randn(vocab_size, hidden_size, dtype=torch.float32))
+
+            def _get_fsdp_state(self):
+                return SimpleNamespace(_mp_policy=SimpleNamespace(param_dtype=torch.bfloat16))
+
+            def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+                """Project hidden states of shape [batch, sequence, hidden]."""
+                assert hidden_states.dtype == torch.bfloat16
+                return hidden_states @ self.weight.to(hidden_states.dtype).T
+
+        lm_head = FakeFSDPHead()
+        hidden = torch.randn(2, 5, self.HIDDEN, dtype=torch.float32)
+
+        with patch("nemo_automodel.components.models.common.utils.FSDPModule", FakeFSDPHead):
+            out = compute_lm_head_logits(lm_head, hidden, logits_to_keep=2)
+
+        assert lm_head.weight.dtype == torch.float32
+        assert out.logits.shape == (2, 2, self.VOCAB)
+        assert out.logits.dtype == torch.bfloat16
 
     def test_output_hidden_states_attaches_hidden(self):
         """output_hidden_states attaches the final hidden states; default leaves them None."""

--- a/tests/unit_tests/models/common/test_model_common_utils.py
+++ b/tests/unit_tests/models/common/test_model_common_utils.py
@@ -352,6 +352,17 @@ class TestComputeLmHeadLogits:
         out = compute_lm_head_logits(None, hidden, fp32_lm_head=True)
         assert out.logits is hidden
 
+    def test_match_lm_head_dtype_casts_after_slicing(self):
+        lm_head = self._lm_head().to(torch.bfloat16)
+        hidden = torch.randn(2, 5, self.HIDDEN, dtype=torch.float32)
+
+        out = compute_lm_head_logits(lm_head, hidden, logits_to_keep=2, match_lm_head_dtype=True)
+
+        expected = lm_head(hidden[:, -2:, :].to(torch.bfloat16))
+        assert out.logits.shape == (2, 2, self.VOCAB)
+        assert out.logits.dtype == torch.bfloat16
+        torch.testing.assert_close(out.logits, expected)
+
     def test_output_hidden_states_attaches_hidden(self):
         """output_hidden_states attaches the final hidden states; default leaves them None."""
         lm_head = self._lm_head()

--- a/tests/unit_tests/models/gemma4_moe/test_gemma4_moe_tied_weights.py
+++ b/tests/unit_tests/models/gemma4_moe/test_gemma4_moe_tied_weights.py
@@ -24,6 +24,8 @@ that behavior for both the tied and untied configs.
 Runs on CPU (no CUDA / TE / DeepEP required).
 """
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 import torch.nn as nn
@@ -103,6 +105,23 @@ def test_tied_lm_head_survives_initialize_weights():
     lm_head = model.lm_head.weight
     assert lm_head is embed
     assert lm_head.dtype == torch.bfloat16
+
+
+def test_tied_lm_head_casts_fp32_hidden_after_logits_slicing(monkeypatch):
+    model = _build(tie_word_embeddings=True).to(torch.bfloat16)
+    hidden = torch.randn(1, 4, model.config.text_config.hidden_size, dtype=torch.float32)
+
+    def fake_language_model_forward(*_args, **_kwargs):
+        return SimpleNamespace(last_hidden_state=hidden)
+
+    monkeypatch.setattr(model.model.language_model, "forward", fake_language_model_forward)
+    outputs = model(
+        inputs_embeds=torch.randn(1, 4, model.config.text_config.hidden_size, dtype=torch.bfloat16),
+        logits_to_keep=2,
+    )
+
+    assert outputs.logits.shape == (1, 2, model.config.text_config.vocab_size)
+    assert outputs.logits.dtype == torch.bfloat16
 
 
 def test_untied_construction_is_rejected():

--- a/tests/unit_tests/models/nemotron_omni/test_nemotron_omni_layers.py
+++ b/tests/unit_tests/models/nemotron_omni/test_nemotron_omni_layers.py
@@ -27,6 +27,7 @@ import torch
 
 from nemo_automodel.components.models.nemotron_omni.model import (
     NemotronOmniConfig,
+    NemotronOmniForConditionalGeneration,
     RMSNorm,
     SoundProjection,
     SquaredReLU,
@@ -156,6 +157,23 @@ def test_nemotron_omni_config_overrides_propagate():
     assert cfg.patch_size == 14
     assert cfg.vit_hidden_size == 2048
     assert cfg.video_pruning_rate == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Model compatibility properties
+# ---------------------------------------------------------------------------
+
+
+def test_lm_head_property_exposes_nested_head_without_registering_alias():
+    """The FSDP-facing property must preserve the nested checkpoint hierarchy."""
+    model = object.__new__(NemotronOmniForConditionalGeneration)
+    torch.nn.Module.__init__(model)
+    model.language_model = torch.nn.Module()
+    model.language_model.lm_head = torch.nn.Linear(4, 8, bias=False)
+
+    assert model.lm_head is model.language_model.lm_head
+    assert "lm_head" not in model._modules
+    assert set(model.state_dict()) == {"language_model.lm_head.weight"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this PR do ?

Prevent mixed-dtype LM-head projections in Gemma4 and expose the nested Nemotron Omni output head through the standard model wrapper contract.

## Problem

With FSDP2 mixed precision, a custom model wrapper can receive FP32 hidden states while its LM-head weight is BF16. These wrapper-owned projections execute outside an autocast region, so `nn.Linear` fails with a `mat1 and mat2 must have the same dtype` error.

Gemma4 has two such custom projection paths. Nemotron Omni also keeps its output head under `language_model.lm_head`, while training consumers expect the conventional top-level `model.lm_head` contract.

# Changelog

- Add an opt-in, keyword-only `match_lm_head_dtype` path to `compute_lm_head_logits` that casts only the sliced projection input to the actual LM-head weight dtype.
- Enable that path for both Gemma4 custom LM-head projections.
- Expose Nemotron Omni's nested LM head through a read-only property without re-registering the module or changing checkpoint keys.
- Add focused CPU regression tests for dtype alignment, Gemma4 logits slicing, and Nemotron Omni module ownership.

# Validation

- `pytest tests/unit_tests/models/common/test_model_common_utils.py::TestComputeLmHeadLogits tests/unit_tests/models/gemma4_moe/test_gemma4_moe_tied_weights.py tests/unit_tests/models/nemotron_omni/test_nemotron_omni_layers.py -q` (`36 passed`)
- `ruff format --check` on all six changed files
- `ruff check` on all three changed production files
- NeMo RL end-to-end regressions: Gemma4 26B (20 steps), Gemma4 31B (20 steps), and Nemotron Omni MMPR (10 steps) completed successfully.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Automodel/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation? (No documentation changes are required for this internal model-boundary fix.)

# Additional Information

This PR targets `main`. The `r0.6.0` label should be retained so the repository's post-merge cherry-pick workflow can create the release backport.
