### PR TITLE
perf(recipes): run GPT-OSS 120B with EP64 and no activation checkpointing

### DIFF
--- a/examples/llm_benchmark/gpt_oss/gptoss_120b_te_deepep.yaml
+++ b/examples/llm_benchmark/gpt_oss/gptoss_120b_te_deepep.yaml
@@ -47,7 +47,7 @@ distributed:
   ep_size: 64
 
   sequence_parallel: false
-  activation_checkpointing: true
+  activation_checkpointing: false
 
   pipeline:
     pp_schedule: interleaved1f1b
@@ -113,6 +113,6 @@ optimizer:
 ci:
   time: "00:30:00"
   nodes: 8
-  ep_size: 16
+  ep_size: 64
   env_vars:
     PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True"

--- a/examples/llm_finetune/gpt_oss/gpt_oss_120b.yaml
+++ b/examples/llm_finetune/gpt_oss/gpt_oss_120b.yaml
@@ -58,6 +58,7 @@ distributed:
   ep_size: 64
 
   sequence_parallel: false
+  activation_checkpointing: false
 
   pipeline:
     pp_schedule: interleaved1f1b

--- a/tests/unit_tests/ci_tests/test_generate_ci_tests.py
+++ b/tests/unit_tests/ci_tests/test_generate_ci_tests.py
@@ -49,6 +49,21 @@ def test_generate_gpt_oss_120b_release_job_uses_ep64():
     assert variables["TEST_NODE_COUNT"] == 8
     assert variables["LOCAL_BATCH_SIZE"] == 8
     assert recipe["distributed"]["ep_size"] == world_size
+    assert recipe["distributed"]["activation_checkpointing"] is False
+
+
+def test_generate_gpt_oss_120b_benchmark_job_uses_ep64_without_activation_checkpointing():
+    config = Path("examples/llm_benchmark/gpt_oss/gptoss_120b_te_deepep.yaml")
+
+    jobs = dict(generate_job(config, {}, "performance", "llm_benchmark", "."))
+    recipe = YAML(typ="safe").load(config)
+
+    variables = jobs[""]["variables"]
+    world_size = variables["TEST_NODE_COUNT"] * 8
+    assert variables["TEST_NODE_COUNT"] == 8
+    assert variables["EP_SIZE"] == world_size
+    assert recipe["distributed"]["ep_size"] == world_size
+    assert recipe["distributed"]["activation_checkpointing"] is False
 
 
 def test_generate_vllm_deploy_time_override(tmp_path):


### PR DESCRIPTION
## What

- run the GPT-OSS 120B DeepEP benchmark with EP64 instead of the CI-only EP16 override
- disable activation checkpointing for both the benchmark and standard SFT recipes
- add CI-generator coverage for the EP64/no-activation-checkpointing invariants

## Why

A clean profiler A/B showed that the remaining GPT-OSS regression came from activation recomputation: disabling activation checkpointing reduced normalized iteration time by 22.6% and cut grouped GEMM calls from 1152 to 576. Separately, the benchmark's nested `ci.ep_size: 16` overrode its top-level EP64 setting in generated CI jobs.

## Checks

- `uv run --no-sync pytest -q tests/unit_tests/ci_tests/test_generate_ci_tests.py` (11 passed)
- NeMo CI benchmark at `63e285ba9`:
  - [parent pipeline 62179803](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/62179803)
  - [LLM benchmark pipeline 62195220](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/62195220)
  - [`gptoss_120b_te_deepep` job 393356449](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/393356449) — passed, Slurm `5830971` completed, 3.936 s/iteration, 27.464954% MFU
- NeMo CI standard SFT at `63e285ba9`:
  - [parent pipeline 62198101](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/62198101)
  - [LLM finetune pipeline 62198198](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/62198198)
  - [`gpt_oss_120b` job 393381913](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/393381913) — passed, Slurm `5831027` completed
