### PR TITLE
ci: validate dev ephemeral runner routing (do not merge)

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -38,7 +38,7 @@ jobs:
   pre-flight:
     uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_cicd_preflight.yml@c1a0837f362a1a696e647238ab1cf916b2a7cf4a # v1.8.6
     with:
-      default_runner_prefix: ${{ format('{0}{1}', vars.DEFAULT_RUNNER_PREFIX, vars.GPU_RUNNER_SUFFIX) }}
+      default_runner_prefix: ${{ format('{0}{1}', vars.NON_NVIDIA_RUNNER_PREFIX, vars.GPU_RUNNER_SUFFIX) }}
       non_nvidia_runner_prefix: ${{ format('{0}{1}', vars.NON_NVIDIA_RUNNER_PREFIX, vars.GPU_RUNNER_SUFFIX) }}
       default_test_data_path: ${{ vars.DEFAULT_TEST_DATA_PATH }}
       non_nvidia_test_data_path: ${{ vars.NON_NVIDIA_TEST_DATA_PATH }}


### PR DESCRIPTION
> [!CAUTION]
> **VALIDATION ONLY — DO NOT MERGE THIS PR.** Close it after dev ARC and Shadow monitoring evidence is collected.

# What does this PR do ?

Stacks on #3486 and temporarily forces `default_runner_prefix` to use the same `NON_NVIDIA_RUNNER_PREFIX + GPU_RUNNER_SUFFIX` expression as `non_nvidia_runner_prefix`. With the current validation suffix, AWS GPU jobs select the dev ephemeral runner label instead of the regular dev runner label.

# Changelog

- Route default AWS GPU jobs through the non-NVIDIA ephemeral runner prefix.
- Preserve the suffix switch introduced by #3486.
- Exercise the active dev ephemeral runner scale set.
- Generate Automodel workflow activity for the inert Shadow lane to observe without changing allocation or routing.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor and CI/CD guidelines.
- [x] No new tests are needed for this temporary one-expression routing override.
- [x] No documentation update is appropriate because this PR must not be merged.
- [x] Static YAML parsing passed.
- [x] `git diff --check` passed.
- [x] Commit includes DCO sign-off and a verified Git signature.

# Validation and rollback

- Confirm jobs are picked up by the dev ephemeral label and complete successfully.
- Confirm the Shadow lane records observation/audit status for `NVIDIA-NeMo/Automodel` without mutating workloads or capacity.
- Roll back by closing this PR and returning validation to #3486.

# Additional Information

Related to AUT-1335 and stacked on #3486. This PR is intentionally temporary and **must not be merged**.