### PR TITLE
cp: feat(models): make Inkling standalone (#3358) into r0.6.0

### DIFF
--- a/examples/vlm_finetune/inkling/inkling_medpix.yaml
+++ b/examples/vlm_finetune/inkling/inkling_medpix.yaml
@@ -17,8 +17,8 @@
 #
 # Inkling is a sparse Mixture-of-Experts VLM (66 layers, 256 routed experts with
 # top-6 routing plus 2 shared experts, hierarchical vision tower + dMel audio
-# tower). NeMo AutoModel reuses the HuggingFace towers/attention verbatim and runs
-# the routed experts through grouped-GEMM with expert parallelism (EP).
+# tower). NeMo AutoModel owns the text, vision, audio, and multimodal modules and
+# runs routed experts through grouped-GEMM with expert parallelism (EP).
 #
 # To run this recipe:
 #   PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \

--- a/nemo_automodel/components/models/inkling/configuration.py
+++ b/nemo_automodel/components/models/inkling/configuration.py
@@ -68,6 +68,7 @@ class InklingTextConfig(PretrainedConfig):
         logits_mup_width_multiplier: float = 24.0,
         rms_norm_eps_moe_gate: float = 1e-6,
         attention_dropout: float = 0.0,
+        use_cache: bool = True,
         initializer_range: float = 0.02,
         pad_token_id: int | None = None,
         bos_token_id: int | None = 1,
@@ -123,6 +124,7 @@ class InklingTextConfig(PretrainedConfig):
         self.logits_mup_width_multiplier = logits_mup_width_multiplier
         self.rms_norm_eps_moe_gate = rms_norm_eps_moe_gate
         self.attention_dropout = attention_dropout
+        self.use_cache = use_cache
         self.initializer_range = initializer_range
         self.num_mtp_layers = num_mtp_layers
         self.chain_hidden_post_norm = chain_hidden_post_norm
@@ -161,6 +163,7 @@ class InklingAudioConfig(PretrainedConfig):
         "num_codebooks": "n_mel_bins",
         "codebook_size": "mel_vocab_size",
         "hidden_size": "text_hidden_size",
+        "text_hidden_size": "decoder_dmodel",
     }
 
     def __init__(
@@ -185,7 +188,11 @@ class InklingVisionConfig(PretrainedConfig):
 
     model_type = "inkling_vision"
     base_config_key = "vision_config"
-    attribute_map = {"num_hidden_layers": "n_layers"}
+    attribute_map = {
+        "num_hidden_layers": "n_layers",
+        "num_channels": "n_channels",
+        "text_hidden_size": "decoder_dmodel",
+    }
 
     def __init__(
         self,
@@ -246,10 +253,10 @@ class InklingConfig(PretrainedConfig):
         self.vision_config = self._coerce_sub_config(vision_config, InklingVisionConfig)
         self.vision_config.text_hidden_size = self.text_config.hidden_size
         self.audio_config.text_hidden_size = self.text_config.hidden_size
-        self.image_token_id = image_token_id
-        self.audio_token_id = audio_token_id
-        self.image_bos_token_id = image_bos_token_id
-        self.audio_bos_token_id = audio_bos_token_id
+        self.image_token_id = 200054 if image_token_id is None else image_token_id
+        self.audio_token_id = 200053 if audio_token_id is None else audio_token_id
+        self.image_bos_token_id = 200005 if image_bos_token_id is None else image_bos_token_id
+        self.audio_bos_token_id = 200020 if audio_bos_token_id is None else audio_bos_token_id
         self.mtp_config = mtp_config
         super().__init__(**kwargs)
 

--- a/nemo_automodel/components/models/inkling/feature_extraction.py
+++ b/nemo_automodel/components/models/inkling/feature_extraction.py
@@ -1,0 +1,213 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Native log-mel feature extraction for Inkling audio inputs."""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from transformers.audio_utils import mel_filter_bank
+from transformers.feature_extraction_sequence_utils import SequenceFeatureExtractor
+from transformers.feature_extraction_utils import BatchFeature
+from transformers.utils import PaddingStrategy, TensorType
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _to_exact_int(value: float, name: str, tolerance: float = 1e-6) -> int:
+    """Convert a floating sample count to an exact integer."""
+    rounded = round(value)
+    if abs(value - rounded) > tolerance:
+        raise ValueError(f"{name} must resolve to an integer sample count, got {value}")
+    return int(rounded)
+
+
+def _to_mono_audio(clip: np.ndarray | torch.Tensor | list[float]) -> torch.Tensor:
+    """Convert one audio clip to a mono fp32 waveform.
+
+    Args:
+        clip: Tensor or array of shape ``[samples]`` or ``[samples, channels]``.
+
+    Returns:
+        Tensor of shape ``[samples]`` in fp32.
+    """
+    waveform = clip if isinstance(clip, torch.Tensor) else torch.as_tensor(np.asarray(clip))
+    waveform = waveform.to(torch.float32)
+    if waveform.ndim == 2:
+        LOGGER.warning("Inkling supports mono audio; averaging the channel axis")
+        waveform = waveform.mean(dim=-1)
+    elif waveform.ndim != 1:
+        raise ValueError(f"Each audio clip must have shape [samples] or [samples, channels], got {waveform.shape}")
+    return waveform
+
+
+class InklingFeatureExtractor(SequenceFeatureExtractor):
+    """Extract log-mel spectrograms for Inkling dMel quantization."""
+
+    model_input_names = ["input_features", "input_features_mask"]
+
+    def __init__(
+        self,
+        feature_size: int = 80,
+        sampling_rate: int = 16_000,
+        padding_value: float = 0.0,
+        audio_token_duration_s: float = 0.05,
+        window_size_multiplier: float = 2.0,
+        n_fft: int | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            feature_size=feature_size,
+            sampling_rate=sampling_rate,
+            padding_value=padding_value,
+            **kwargs,
+        )
+        self.audio_token_duration_s = audio_token_duration_s
+        self.window_size_multiplier = window_size_multiplier
+        self.hop_length = _to_exact_int(
+            audio_token_duration_s * sampling_rate,
+            "audio_token_duration_s * sampling_rate",
+        )
+        self.window_size = _to_exact_int(
+            audio_token_duration_s * window_size_multiplier * sampling_rate,
+            "audio_token_duration_s * window_size_multiplier * sampling_rate",
+        )
+        self.n_fft = n_fft or self.window_size
+        if self.hop_length <= 0 or self.window_size <= 0 or self.n_fft <= 0:
+            raise ValueError("hop_length, window_size, and n_fft must all be positive")
+
+        self.window = torch.hann_window(self.window_size, periodic=True, dtype=torch.float32)
+        mel_filters = mel_filter_bank(
+            num_frequency_bins=self.n_fft // 2 + 1,
+            num_mel_filters=feature_size,
+            min_frequency=0.0,
+            max_frequency=sampling_rate / 2.0,
+            sampling_rate=sampling_rate,
+            norm="slaney",
+            mel_scale="slaney",
+        )
+        self.mel_filters = torch.from_numpy(np.ascontiguousarray(mel_filters.T, dtype=np.float32))
+
+    def _extract_log_mel(self, waveform: torch.Tensor, device: torch.device) -> torch.Tensor:
+        """Compute batched log-mel features.
+
+        Args:
+            waveform: Tensor of shape ``[batch, samples]``.
+            device: Device used for STFT and filter-bank computation.
+
+        Returns:
+            Tensor of shape ``[batch, frames, mel_bins]``.
+        """
+        right_pad = math.ceil(waveform.shape[-1] / self.hop_length) * self.hop_length - waveform.shape[-1]
+        left_pad = max(self.n_fft - self.hop_length, 0)
+        waveform = F.pad(waveform, (left_pad, right_pad))
+        stft = torch.stft(
+            waveform,
+            self.n_fft,
+            hop_length=self.hop_length,
+            win_length=self.window_size,
+            window=self.window.to(device),
+            center=False,
+            return_complex=True,
+        )
+        magnitudes = torch.view_as_real(stft).pow(2).sum(-1).clamp_min(1e-10).sqrt()
+        mel_spectrogram = self.mel_filters.to(device) @ magnitudes
+        return mel_spectrogram.clamp_min(1e-10).log10().transpose(1, 2)
+
+    def __call__(
+        self,
+        raw_speech: np.ndarray | torch.Tensor | list[float] | list[np.ndarray] | list[list[float]],
+        sampling_rate: int | None = None,
+        padding: bool | str | PaddingStrategy = True,
+        max_length: int | None = None,
+        truncation: bool = False,
+        pad_to_multiple_of: int | None = None,
+        return_attention_mask: bool | None = True,
+        return_tensors: str | TensorType | None = None,
+        device: str | torch.device = "cpu",
+        **kwargs: Any,
+    ) -> BatchFeature:
+        """Extract log-mel features from one clip or a batch.
+
+        Args:
+            raw_speech: One waveform of shape ``[samples]`` or ``[samples, channels]``,
+                or a list of such waveforms.
+            sampling_rate: Sampling rate used by the supplied waveform.
+            padding: Transformers padding strategy for the waveform batch.
+            max_length: Optional maximum waveform length in samples.
+            truncation: Whether to truncate waveforms to ``max_length``.
+            pad_to_multiple_of: Optional waveform padding multiple.
+            return_attention_mask: Whether to return a valid-frame mask.
+            return_tensors: Requested output tensor framework.
+            device: Device used for feature extraction.
+            **kwargs: Additional padding arguments.
+
+        Returns:
+            A batch containing ``input_features`` with shape ``[batch, frames, mel_bins]``
+            and optionally ``input_features_mask`` with shape ``[batch, frames]``.
+        """
+        del kwargs
+        if sampling_rate is not None and sampling_rate != self.sampling_rate:
+            raise ValueError(f"Inkling expects audio sampled at {self.sampling_rate} Hz, got {sampling_rate} Hz")
+        if sampling_rate is None:
+            LOGGER.warning("Pass sampling_rate=%s to avoid silent audio errors", self.sampling_rate)
+
+        if isinstance(raw_speech, (np.ndarray, torch.Tensor)):
+            if raw_speech.ndim > 2:
+                raise ValueError(f"A single audio array must have one or two dimensions, got {raw_speech.ndim}")
+            clips: list[Any] = [raw_speech]
+        elif isinstance(raw_speech, (list, tuple)):
+            if not raw_speech:
+                raise ValueError("Received an empty audio input")
+            clips = (
+                [raw_speech] if isinstance(raw_speech[0], (int, float, np.integer, np.floating)) else list(raw_speech)
+            )
+        else:
+            raise TypeError(f"Unsupported audio input type: {type(raw_speech).__name__}")
+
+        waveforms = [_to_mono_audio(clip)[:, None] for clip in clips]
+        audio_lengths = [len(waveform) for waveform in waveforms]
+        padded_inputs = self.pad(
+            BatchFeature({"input_features": waveforms, "audio_lengths": audio_lengths}),
+            padding=padding,
+            max_length=max_length,
+            truncation=truncation,
+            pad_to_multiple_of=pad_to_multiple_of,
+            return_tensors="pt",
+        )
+        input_waveforms = padded_inputs.input_features.squeeze(-1)
+        resolved_device = torch.device(device)
+        input_features = self._extract_log_mel(input_waveforms.to(resolved_device), resolved_device)
+        num_frames = torch.div(
+            padded_inputs.audio_lengths.to(resolved_device) + self.hop_length - 1,
+            self.hop_length,
+            rounding_mode="floor",
+        )
+        input_features_mask = (
+            torch.arange(input_features.shape[1], device=resolved_device)[None, :] < num_frames[:, None]
+        )
+        input_features = input_features * input_features_mask.unsqueeze(-1)
+        data = {"input_features": input_features}
+        if return_attention_mask:
+            data["input_features_mask"] = input_features_mask
+        return BatchFeature(data=data, tensor_type=return_tensors)
+
+
+__all__ = ["InklingFeatureExtractor"]

--- a/nemo_automodel/components/models/inkling/image_processing.py
+++ b/nemo_automodel/components/models/inkling/image_processing.py
@@ -1,0 +1,204 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Native image preprocessing for Inkling's hierarchical vision tower."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import torch
+from transformers.image_processing_backends import TorchvisionBackend
+from transformers.image_processing_utils import BatchFeature
+from transformers.image_utils import ImageInput, PILImageResampling, SizeDict, validate_preprocess_arguments
+from transformers.processing_utils import ImagesKwargs, Unpack
+from transformers.utils import TensorType
+from transformers.utils.constants import OPENAI_CLIP_MEAN, OPENAI_CLIP_STD
+
+
+class InklingImageProcessorKwargs(ImagesKwargs, total=False):
+    """Additional Inkling image preprocessing arguments."""
+
+    rescale_image_frac: float | None
+    rescale_image_max_upscaled_long_edge: int | None
+
+
+def _divide_to_patches(image: torch.Tensor, patch_size: int) -> list[torch.Tensor]:
+    """Divide a channels-first image into possibly incomplete square patches.
+
+    Args:
+        image: Tensor of shape ``[channels, height, width]``.
+        patch_size: Height and width of each patch.
+
+    Returns:
+        Tensors of shape ``[channels, patch_height, patch_width]`` in row-major order.
+    """
+    height, width = image.shape[-2:]
+    num_rows = (height + patch_size - 1) // patch_size
+    num_columns = width // patch_size + 1
+    return [
+        image[..., row * patch_size : (row + 1) * patch_size, column * patch_size : (column + 1) * patch_size]
+        for row in range(num_rows)
+        for column in range(num_columns)
+    ]
+
+
+class InklingImageProcessor(TorchvisionBackend):
+    """Convert images into Inkling's padded spatiotemporal patch layout."""
+
+    resample = PILImageResampling.LANCZOS
+    image_mean = OPENAI_CLIP_MEAN
+    image_std = OPENAI_CLIP_STD
+    default_to_square = False
+    do_convert_rgb = True
+    do_resize = True
+    do_rescale = True
+    do_normalize = True
+    size = {"height": 40, "width": 40}
+    rescale_image_frac = None
+    rescale_image_max_upscaled_long_edge = 2048
+    valid_kwargs = InklingImageProcessorKwargs
+
+    def __init__(self, **kwargs: Unpack[InklingImageProcessorKwargs]) -> None:
+        super().__init__(**kwargs)
+
+    def _validate_preprocess_kwargs(
+        self,
+        do_rescale: bool | None = None,
+        rescale_factor: float | None = None,
+        do_normalize: bool | None = None,
+        image_mean: float | tuple[float, ...] | None = None,
+        image_std: float | tuple[float, ...] | None = None,
+        do_resize: bool | None = None,
+        size: SizeDict | None = None,
+        do_center_crop: bool | None = None,
+        crop_size: SizeDict | None = None,
+        resample: PILImageResampling | int | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Validate model-specific image preprocessing settings."""
+        del kwargs
+        if do_resize is False:
+            raise ValueError("do_resize cannot be False for Inkling")
+        if size is None or size.height != size.width:
+            raise ValueError(f"Inkling requires a square patch size, got {size}")
+        validate_preprocess_arguments(
+            do_rescale=do_rescale,
+            rescale_factor=rescale_factor,
+            do_normalize=do_normalize,
+            image_mean=image_mean,
+            image_std=image_std,
+            do_center_crop=do_center_crop,
+            crop_size=crop_size,
+            do_resize=do_resize,
+            size=size,
+            resample=resample,
+        )
+
+    def preprocess(
+        self,
+        images: ImageInput,
+        **kwargs: Unpack[ImagesKwargs],
+    ) -> BatchFeature:
+        """Convert image inputs into vision-tower patches.
+
+        Args:
+            images: One image or a batch in a supported PIL, NumPy, or tensor layout.
+            **kwargs: Standard Transformers image preprocessing overrides.
+
+        Returns:
+            A batch containing ``pixel_values`` with shape
+            ``[patches, time=2, height, width, channels]`` and ``num_patches``
+            with shape ``[images]``.
+        """
+        return super().preprocess(images, **kwargs)
+
+    def _preprocess(
+        self,
+        images: list[torch.Tensor],
+        size: SizeDict,
+        do_rescale: bool,
+        rescale_factor: float,
+        do_normalize: bool,
+        image_mean: float | list[float] | None,
+        image_std: float | list[float] | None,
+        resample: PILImageResampling | int | None,
+        rescale_image_frac: float | None,
+        rescale_image_max_upscaled_long_edge: int | None,
+        return_tensors: str | TensorType | None,
+        **kwargs: Any,
+    ) -> BatchFeature:
+        """Process normalized channels-first image tensors.
+
+        Args:
+            images: Tensors of shape ``[channels, height, width]``.
+            size: Square patch dimensions.
+            do_rescale: Whether to multiply pixels by ``rescale_factor``.
+            rescale_factor: Pixel rescaling multiplier.
+            do_normalize: Whether to normalize channels.
+            image_mean: Per-channel normalization means.
+            image_std: Per-channel normalization standard deviations.
+            resample: Resize interpolation mode.
+            rescale_image_frac: Optional multiplier for the long image edge.
+            rescale_image_max_upscaled_long_edge: Maximum long edge when upscaling.
+            return_tensors: Requested output tensor framework.
+            **kwargs: Unused common backend arguments.
+
+        Returns:
+            A batch containing ``pixel_values`` with shape
+            ``[patches, time=2, height, width, channels]`` and ``num_patches``
+            with shape ``[images]``.
+        """
+        del kwargs
+        per_image_patches: list[torch.Tensor] = []
+        patch_counts: list[int] = []
+        for image in images:
+            if rescale_image_frac is not None:
+                height, width = image.shape[-2:]
+                long_edge = max(height, width)
+                target_long_edge = long_edge * rescale_image_frac
+                if rescale_image_max_upscaled_long_edge is not None:
+                    target_long_edge = min(target_long_edge, max(rescale_image_max_upscaled_long_edge, long_edge))
+                ratio = target_long_edge / long_edge
+                if ratio != 1.0:
+                    new_size = SizeDict(
+                        height=math.floor(height * ratio + 0.5),
+                        width=math.floor(width * ratio + 0.5),
+                    )
+                    image = self.resize(image, new_size, resample=resample)
+
+            patches = [patch.float() for patch in _divide_to_patches(image, size.height)]
+            patches = self.pad(patches, pad_size=SizeDict(height=size.height, width=size.width), fill_value=-1.0)
+            patch_tensor = torch.stack(patches, dim=0)
+            patch_tensor = self.rescale_and_normalize(
+                patch_tensor,
+                do_rescale,
+                rescale_factor,
+                do_normalize,
+                image_mean,
+                image_std,
+            )
+            patch_tensor = patch_tensor[..., None].repeat(1, 1, 1, 1, 2)
+            per_image_patches.append(patch_tensor)
+            patch_counts.append(patch_tensor.shape[0])
+
+        pixel_values = torch.cat(per_image_patches, dim=0).permute(0, 4, 2, 3, 1)
+        return BatchFeature(
+            data={"pixel_values": pixel_values, "num_patches": torch.tensor(patch_counts)},
+            tensor_type=return_tensors,
+        )
+
+
+__all__ = ["InklingImageProcessor"]

--- a/nemo_automodel/components/models/inkling/layers.py
+++ b/nemo_automodel/components/models/inkling/layers.py
@@ -12,15 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Expert-parallel Mixture-of-Experts layer for the Inkling model.
+"""Native feed-forward and short-convolution layers for Inkling.
 
-Only the MoE feed-forward is reimplemented here; every other Inkling submodule
-(attention, short convolutions, relative-position logits, norms, vision/audio
-towers) is reused verbatim from HuggingFace transformers. The routing math and
-shared-expert formulation mirror ``transformers.models.inkling.modeling_inkling``
-exactly, while the routed experts run through NeMo AutoModel's
-:class:`~nemo_automodel.components.moe.experts.GroupedExperts`, which provides
-grouped-GEMM compute and expert-parallel (EP) sharding.
+The equations follow the published Transformers 5.14 Inkling implementation,
+while the routed experts use NeMo AutoModel's grouped-GEMM and expert-parallel
+implementations.
 """
 
 from __future__ import annotations
@@ -31,37 +27,81 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-try:
-    from transformers.models.inkling.modeling_inkling import (
-        apply_mask_to_padding_states,
-        causal_conv1d_fn,
-        causal_conv1d_update,
-    )
-except ImportError as exc:  # transformers < 5.14 does not ship the Inkling model
-    from nemo_automodel.shared.import_utils import UnavailableError
-
-    raise UnavailableError(
-        "The Inkling model requires a transformers build that ships transformers.models.inkling (transformers >= 5.14)."
-    ) from exc
-
 from nemo_automodel.components.models.common.utils import BackendConfig
 from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.layers import MoE
 from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 
 
+def _mask_padding_states(hidden_states: torch.Tensor, attention_mask: torch.Tensor | None) -> torch.Tensor:
+    """Zero padded tokens before a short convolution.
+
+    Args:
+        hidden_states: Tensor of shape ``[batch, sequence, hidden]``.
+        attention_mask: Optional boolean tensor of shape ``[batch, sequence]`` where
+            ``True`` marks a valid token.
+
+    Returns:
+        Tensor of shape ``[batch, sequence, hidden]``. The output aliases the input
+        when no masking is required.
+    """
+    if attention_mask is None or attention_mask.shape[1] <= 1 or attention_mask.shape[0] <= 1:
+        return hidden_states
+    return (hidden_states * attention_mask[:, :, None]).to(hidden_states.dtype)
+
+
+def _causal_conv1d_update(
+    hidden_states: torch.Tensor,
+    conv_state: torch.Tensor,
+    weight: torch.Tensor,
+) -> torch.Tensor:
+    """Update cached depthwise-convolution state for one decoding step.
+
+    Args:
+        hidden_states: Tensor of shape ``[batch, hidden, sequence]`` containing new tokens.
+        conv_state: Mutable cache tensor of shape ``[batch, hidden, kernel]``.
+        weight: Depthwise weights of shape ``[hidden, 1, kernel]``.
+
+    Returns:
+        Tensor of shape ``[batch, hidden, sequence]``. ``conv_state`` is updated in place.
+    """
+    sequence = hidden_states.shape[-1]
+    state_length = conv_state.shape[-1]
+    full_states = torch.cat((conv_state, hidden_states), dim=-1).to(weight.dtype)
+    conv_state.copy_(full_states[:, :, -state_length:])
+    output = F.conv1d(full_states, weight, padding=0, groups=weight.shape[0])
+    return output[:, :, -sequence:].to(hidden_states.dtype)
+
+
+def _causal_conv1d(hidden_states: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+    """Apply a causal depthwise convolution to a full sequence.
+
+    Args:
+        hidden_states: Tensor of shape ``[batch, hidden, sequence]``.
+        weight: Depthwise weights of shape ``[hidden, 1, kernel]``.
+
+    Returns:
+        Tensor of shape ``[batch, hidden, sequence]``.
+    """
+    sequence = hidden_states.shape[-1]
+    output = F.conv1d(
+        hidden_states.to(weight.dtype),
+        weight=weight,
+        padding=weight.shape[-1] - 1,
+        groups=weight.shape[0],
+    )
+    return output[:, :, :sequence].to(hidden_states.dtype)
+
+
 class _InklingShortConvolutionFP32(nn.Module):
     """Run one short convolution inside a dtype-uniform fp32 FSDP unit."""
 
-    def __init__(self, source: nn.Module) -> None:
+    def __init__(self, hidden_size: int, conv_kernel_size: int, layer_idx: int, conv_idx: int) -> None:
         super().__init__()
-        self.layer_idx = source.layer_idx
-        self.conv_idx = source.conv_idx
-        self.conv_kernel_size = source.conv_kernel_size
-        self.weight = nn.Parameter(
-            source.conv1d.weight.detach(),
-            requires_grad=source.conv1d.weight.requires_grad,
-        )
+        self.layer_idx = layer_idx
+        self.conv_idx = conv_idx
+        self.conv_kernel_size = conv_kernel_size
+        self.weight = nn.Parameter(torch.empty(hidden_size, 1, conv_kernel_size, dtype=torch.float32))
 
     def forward(
         self,
@@ -86,17 +126,17 @@ class _InklingShortConvolutionFP32(nn.Module):
             convolution output).
         """
         residual = hidden_states
-        hidden_states = apply_mask_to_padding_states(hidden_states, conv_mask)
+        hidden_states = _mask_padding_states(hidden_states, conv_mask)
         seq_len = hidden_states.shape[1]
         hidden_states = hidden_states.transpose(1, 2)
-        weight = self.weight.squeeze(1)
+        weight = self.weight
 
         use_precomputed_states = past_key_values is not None and past_key_values.has_previous_state(
             self.layer_idx, self.conv_idx
         )
         if use_precomputed_states and seq_len == 1 and not past_key_values.layers[self.layer_idx].record_past:
             conv_state = past_key_values.layers[self.layer_idx].conv_states[self.conv_idx]
-            hidden_states = causal_conv1d_update(hidden_states, conv_state, weight, None)
+            hidden_states = _causal_conv1d_update(hidden_states, conv_state, weight)
         else:
             if past_key_values is not None:
                 hidden_states = past_key_values.update_conv_state(
@@ -105,19 +145,27 @@ class _InklingShortConvolutionFP32(nn.Module):
                     state_idx=self.conv_idx,
                     conv_kernel_size=self.conv_kernel_size,
                 )
-            hidden_states = causal_conv1d_fn(hidden_states, weight, None, seq_idx=kwargs.get("seq_idx"))
-            if use_precomputed_states:
+            hidden_states = _causal_conv1d(hidden_states, weight)
+            # Initial cached prefills shorter than the kernel are left-padded by
+            # the cache, while later multi-token updates prepend cached state.
+            # In both cases return only the tokens from this invocation.
+            if past_key_values is not None:
                 hidden_states = hidden_states[:, :, -seq_len:]
 
         return hidden_states.transpose(1, 2) + residual
 
 
 class InklingShortConvolution(nn.Module):
-    """Keep short-convolution weights in an existing model-owned fp32 holder."""
+    """Keep short-convolution weights in a model-owned fp32 holder."""
 
-    def __init__(self, source: nn.Module) -> None:
+    def __init__(self, hidden_size: int, conv_kernel_size: int, layer_idx: int, conv_idx: int) -> None:
         super().__init__()
-        self._fp32_params = _InklingShortConvolutionFP32(source)
+        self._fp32_params = _InklingShortConvolutionFP32(hidden_size, conv_kernel_size, layer_idx, conv_idx)
+
+    @torch.no_grad()
+    def init_weights(self, init_std: float) -> None:
+        """Initialize the fp32 depthwise-convolution weights."""
+        nn.init.normal_(self._fp32_params.weight, mean=0.0, std=init_std)
 
     def forward(
         self,
@@ -156,7 +204,7 @@ def build_inkling_moe_config(text_config, backend: BackendConfig) -> MoEConfig:
     neutral defaults.
 
     Args:
-        text_config: HuggingFace ``InklingTextConfig``.
+        text_config: Local ``InklingTextConfig``.
         backend: Backend configuration selecting the expert compute/dispatch kernels.
 
     Returns:

--- a/nemo_automodel/components/models/inkling/model.py
+++ b/nemo_automodel/components/models/inkling/model.py
@@ -12,14 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""NeMo AutoModel wrapper for the Inkling multimodal MoE model.
-
-The wrapper reuses the HuggingFace ``InklingForConditionalGeneration`` towers,
-attention, norms, embeddings, and language-model head. Decoder feed-forwards
-retain the raw checkpoint's fused interleaved projection layout; sparse layers
-also use an expert-parallel :class:`InklingMoE`. This avoids full-size weight
-conversion copies while preserving Transformers numerics.
-"""
+"""Standalone NeMo AutoModel implementation of the Inkling multimodal MoE."""
 
 from __future__ import annotations
 
@@ -28,51 +21,8 @@ from typing import Any
 
 import torch
 import torch.nn as nn
-
-from nemo_automodel.shared.import_utils import UnavailableError, UnavailableMeta
-
-from .configuration import InklingConfig
-
-_INKLING_HF_UNAVAILABLE_MSG = (
-    "The Inkling model requires a transformers build that provides "
-    "transformers.models.inkling and transformers.masking_utils.create_recurrent_attention_mask "
-    "(transformers >= 5.14)."
-)
-
-
-def _make_missing(name: str):
-    return UnavailableMeta(name, (), {"_msg": _INKLING_HF_UNAVAILABLE_MSG})
-
-
-try:
-    from transformers.cache_utils import DynamicCache
-    from transformers.masking_utils import (
-        create_causal_mask,
-        create_recurrent_attention_mask,
-        create_sliding_window_causal_mask,
-    )
-    from transformers.modeling_outputs import BaseModelOutputWithPast
-    from transformers.models.inkling.configuration_inkling import InklingConfig as HFInklingConfig
-    from transformers.models.inkling.modeling_inkling import (
-        InklingForConditionalGeneration as HFInklingForConditionalGeneration,
-    )
-    from transformers.models.inkling.modeling_inkling import InklingMLP as HFInklingMLP
-    from transformers.models.inkling.modeling_inkling import InklingMoE as HFInklingMoE
-    from transformers.models.inkling.modeling_inkling import InklingTextModel as HFInklingTextModel
-
-    InklingConfig = HFInklingConfig
-    _INKLING_HF_AVAILABLE = True
-except ImportError:  # transformers < 5.14 ships neither symbol set
-    DynamicCache = _make_missing("DynamicCache")
-    BaseModelOutputWithPast = _make_missing("BaseModelOutputWithPast")
-    HFInklingForConditionalGeneration = _make_missing("HFInklingForConditionalGeneration")
-    HFInklingMLP = _make_missing("HFInklingMLP")
-    HFInklingMoE = _make_missing("HFInklingMoE")
-    HFInklingTextModel = _make_missing("HFInklingTextModel")
-    create_causal_mask = _make_missing("create_causal_mask")
-    create_recurrent_attention_mask = _make_missing("create_recurrent_attention_mask")
-    create_sliding_window_causal_mask = _make_missing("create_sliding_window_causal_mask")
-    _INKLING_HF_AVAILABLE = False
+import torch.nn.functional as F
+from transformers.utils import ModelOutput
 
 from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.models.common.hf_checkpointing_mixin import HFCheckpointingMixin
@@ -85,105 +35,35 @@ from nemo_automodel.components.moe.config import MoEConfig
 from nemo_automodel.components.moe.fsdp_mixin import MoEFSDPSyncMixin
 from nemo_automodel.shared.utils import dtype_from_str as get_dtype
 
+from .configuration import InklingConfig
+from .layers import build_inkling_moe_config
+from .multimodal import InklingModel
 from .state_dict_adapter import InklingStateDictAdapter
-
-if _INKLING_HF_AVAILABLE:
-    from .layers import InklingDenseMLP, InklingMoE, InklingShortConvolution, build_inkling_moe_config
-else:
-    InklingDenseMLP = _make_missing("InklingDenseMLP")
-    InklingMoE = _make_missing("InklingMoE")
-    InklingShortConvolution = _make_missing("InklingShortConvolution")
-    build_inkling_moe_config = _make_missing("build_inkling_moe_config")
+from .text import InklingDynamicCache
 
 
-class InklingTextModel(HFInklingTextModel):
-    """Inkling text backbone that also accepts AutoModel pipeline stages."""
+@dataclass
+class InklingCausalLMOutputWithPast(ModelOutput):
+    """Inkling logits, optional loss/cache, and multimodal hidden states."""
 
-    def forward(
-        self,
-        input_ids: torch.LongTensor | None = None,
-        attention_mask: torch.Tensor | dict[str, torch.Tensor] | None = None,
-        position_ids: torch.LongTensor | None = None,
-        past_key_values: Any | None = None,
-        inputs_embeds: torch.FloatTensor | None = None,
-        use_cache: bool | None = None,
-        **kwargs: Any,
-    ) -> BaseModelOutputWithPast:
-        if inputs_embeds is None:
-            if self.embed_tokens is None:
-                if input_ids is None or not input_ids.dtype.is_floating_point:
-                    raise ValueError("Pipeline stages without embeddings require hidden states as input")
-                inputs_embeds = input_ids
-                input_ids = None
-            else:
-                if input_ids is None:
-                    raise ValueError("You must provide either input_ids or inputs_embeds")
-                inputs_embeds = self.embed_norm(self.embed_tokens(input_ids))
-        elif input_ids is not None:
-            raise ValueError("You must provide exactly one of input_ids or inputs_embeds")
-
-        use_cache = getattr(self.config, "use_cache", False) if use_cache is None else use_cache
-        if use_cache and past_key_values is None:
-            past_key_values = DynamicCache(config=self.config)
-
-        if position_ids is None:
-            past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
-            position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device) + past_seen_tokens
-            position_ids = position_ids.unsqueeze(0)
-
-        if not isinstance(causal_mask_mapping := attention_mask, dict):
-            mask_kwargs = {
-                "config": self.config,
-                "inputs_embeds": inputs_embeds,
-                "attention_mask": attention_mask,
-                "past_key_values": past_key_values,
-                "position_ids": position_ids,
-            }
-            causal_mask_mapping = {
-                "full_attention": create_causal_mask(**mask_kwargs),
-                "sliding_attention": create_sliding_window_causal_mask(**mask_kwargs),
-                "linear_attention": create_recurrent_attention_mask(**mask_kwargs),
-            }
-
-        hidden_states = inputs_embeds
-        layers = self.layers.values() if isinstance(self.layers, nn.ModuleDict) else self.layers
-        for decoder_layer in layers:
-            attention_type = getattr(decoder_layer, "attention_type", None)
-            if attention_type is None:
-                # Transformers 5.14 renamed this field and uses Inkling layer types.
-                layer_type = decoder_layer.layer_type
-                if layer_type == "hybrid":
-                    attention_type = "full_attention"
-                elif layer_type == "hybrid_sliding":
-                    attention_type = "sliding_attention"
-                else:
-                    raise ValueError(f"Unsupported Inkling layer type: {layer_type!r}")
-            hidden_states = decoder_layer(
-                hidden_states,
-                attention_mask=causal_mask_mapping[attention_type],
-                conv_mask=causal_mask_mapping["linear_attention"],
-                past_key_values=past_key_values,
-                **kwargs,
-            )
-
-        if self.norm is not None:
-            hidden_states = self.norm(hidden_states)
-        return BaseModelOutputWithPast(last_hidden_state=hidden_states, past_key_values=past_key_values)
+    loss: torch.FloatTensor | None = None
+    logits: torch.FloatTensor | None = None
+    past_key_values: InklingDynamicCache | None = None
+    hidden_states: tuple[torch.FloatTensor, ...] | None = None
+    attentions: tuple[torch.FloatTensor, ...] | None = None
+    image_hidden_states: torch.FloatTensor | None = None
 
 
-class InklingForConditionalGeneration(HFCheckpointingMixin, HFInklingForConditionalGeneration, MoEFSDPSyncMixin):
-    """Inkling VLM with expert-parallel MoE feed-forwards."""
+class InklingForConditionalGeneration(HFCheckpointingMixin, nn.Module, MoEFSDPSyncMixin):
+    """Native Inkling VLM with expert-parallel feed-forwards."""
 
-    _msg = _INKLING_HF_UNAVAILABLE_MSG
     tie_word_embeddings_support: TieSupport = TieSupport.UNTIED_ONLY
 
     # The adapter covers every checkpoint tensor. Avoid initializing the 975B
-    # sharded model immediately before loading it, which can also introduce
-    # stage-divergent DTensor collectives under PP.
+    # sharded model immediately before loading it.
     _skip_init_weights_on_load: bool = True
 
-    # Keep the multimodal forward under PP so stage 0 can consume the media
-    # chunks staged by the VLM recipe.
+    # Keep the multimodal forward under PP so stage 0 can consume media chunks.
     _pp_keep_self_forward: bool = True
 
     # Short convolutions and router correction bias use callable fp32 holders.
@@ -204,69 +84,63 @@ class InklingForConditionalGeneration(HFCheckpointingMixin, HFInklingForConditio
         config: InklingConfig,
         moe_config: MoEConfig | None = None,
         backend: BackendConfig | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> "InklingForConditionalGeneration":
+        """Construct an Inkling model from its local AutoModel config."""
         return cls(config, moe_config=moe_config, backend=backend, **kwargs)
 
     @classmethod
     def from_pretrained(
         cls,
         pretrained_model_name_or_path: str,
-        *model_args,
-        **kwargs,
+        *model_args: Any,
+        **kwargs: Any,
     ) -> "InklingForConditionalGeneration":
-        if not _INKLING_HF_AVAILABLE:
-            raise UnavailableError(_INKLING_HF_UNAVAILABLE_MSG)
-        config = InklingConfig.from_pretrained(pretrained_model_name_or_path)
-        return cls.from_config(config, *model_args, **kwargs)
+        """Construct the native model tree for checkpoint loading.
+
+        The NeMo AutoModel bridge and checkpointer own weight loading. This method
+        resolves only the local Inkling config and native module structure.
+        """
+        config = kwargs.pop("config", None)
+        if config is None:
+            config = InklingConfig.from_pretrained(pretrained_model_name_or_path)
+        torch_dtype = kwargs.pop("torch_dtype", getattr(config, "torch_dtype", torch.bfloat16))
+        if isinstance(torch_dtype, str):
+            torch_dtype = get_dtype(torch_dtype, torch.bfloat16)
+        config.torch_dtype = torch_dtype
+        config._name_or_path = pretrained_model_name_or_path
+        model = cls.from_config(config, *model_args, **kwargs)
+        model.name_or_path = pretrained_model_name_or_path
+        return model
 
     def __init__(
         self,
         config: InklingConfig,
         moe_config: MoEConfig | None = None,
         backend: BackendConfig | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
-        if not _INKLING_HF_AVAILABLE:
-            raise UnavailableError(_INKLING_HF_UNAVAILABLE_MSG)
+        super().__init__()
+        del kwargs
         reject_unsupported_tie_word_embeddings(type(self), config)
-        backend = backend or BackendConfig()
-
-        # Propagate the requested top-level dtype to the nested sub-configs so the
-        # HF towers and our MoE parameters are constructed in a consistent dtype.
-        top_dtype = getattr(config, "torch_dtype", None)
-        if top_dtype is not None:
-            for sub_cfg in vars(config).values():
-                if sub_cfg is not config and hasattr(sub_cfg, "torch_dtype"):
-                    sub_cfg.torch_dtype = top_dtype
-
-        super().__init__(config)
-
-        self.backend = backend
-        self.model.language_model.__class__ = InklingTextModel
-        # Router scoring is selection-sensitive; keep it in fp32 unless overridden.
+        self.config = config
+        self.backend = backend or BackendConfig()
         if self.backend.gate_precision is None:
             self.backend.gate_precision = torch.float32
 
+        top_dtype = getattr(config, "torch_dtype", None)
+        if top_dtype is not None:
+            for sub_config in (config.text_config, config.audio_config, config.vision_config):
+                sub_config.torch_dtype = top_dtype
+
         text_config = config.text_config
-        self.moe_config = moe_config or build_inkling_moe_config(text_config, backend)
-        # Exposed on the inner model too so the parallelizer can discover it.
+        self.moe_config = moe_config or build_inkling_moe_config(text_config, self.backend)
+        self.model = InklingModel(config, self.backend, self.moe_config)
         self.model.moe_config = self.moe_config
 
-        # Keep every feed-forward in the raw checkpoint's fused interleaved
-        # layout. This lets distributed checkpoint loading write through
-        # transpose views instead of allocating converted expert tensors.
-        for layer in self.model.language_model.layers:
-            layer.self_attn.k_sconv = InklingShortConvolution(layer.self_attn.k_sconv)
-            layer.self_attn.v_sconv = InklingShortConvolution(layer.self_attn.v_sconv)
-            layer.attn_sconv = InklingShortConvolution(layer.attn_sconv)
-            layer.mlp_sconv = InklingShortConvolution(layer.mlp_sconv)
-            if isinstance(layer.mlp, HFInklingMoE):
-                layer.mlp = InklingMoE(text_config, backend, moe_config=self.moe_config)
-            elif isinstance(layer.mlp, HFInklingMLP):
-                layer.mlp = InklingDenseMLP(text_config)
-
         model_dtype = get_dtype(getattr(text_config, "torch_dtype", None), torch.bfloat16)
+        self.lm_head = nn.Linear(text_config.hidden_size, text_config.vocab_size, bias=False, dtype=model_dtype)
+        self.vocab_size = text_config.vocab_size
         if self.backend.enable_hf_state_dict_adapter:
             self.state_dict_adapter = InklingStateDictAdapter(
                 text_config,
@@ -274,11 +148,35 @@ class InklingForConditionalGeneration(HFCheckpointingMixin, HFInklingForConditio
                 self.backend,
                 dtype=model_dtype,
             )
-
-        # Custom construction bypasses Transformers' from_pretrained dtype plan.
-        # Normalize inherited and replacement modules here while retaining the
-        # short convolutions and router correction-bias holders in strict fp32.
         cast_model_to_dtype(self, model_dtype)
+
+    def get_input_embeddings(self) -> nn.Module:
+        """Return the text token-embedding module."""
+        return self.model.get_input_embeddings()
+
+    def set_input_embeddings(self, embeddings: nn.Module) -> None:
+        """Replace the text token-embedding module."""
+        self.model.language_model.set_input_embeddings(embeddings)
+
+    def get_output_embeddings(self) -> nn.Module | None:
+        """Return the language-model output projection."""
+        return self.lm_head
+
+    def set_output_embeddings(self, embeddings: nn.Module) -> None:
+        """Replace the language-model output projection."""
+        self.lm_head = embeddings
+
+    def get_image_features(self, pixel_values: torch.Tensor, **kwargs: Any) -> Any:
+        """Encode image/video patches through the native vision tower.
+
+        Args:
+            pixel_values: Tensor of shape ``[patches, time, height, width, channels]``.
+            **kwargs: Reserved for the common multimodal calling convention.
+
+        Returns:
+            An output whose pooler output has shape ``[patches, text_hidden]``.
+        """
+        return self.model.get_image_features(pixel_values, **kwargs)
 
     def customize_pipeline_stage_modules(
         self,
@@ -300,21 +198,20 @@ class InklingForConditionalGeneration(HFCheckpointingMixin, HFInklingForConditio
         seq_len: int,
         dtype: torch.dtype,
     ) -> tuple[tuple[torch.Tensor, ...], tuple[torch.Tensor, ...]]:
-        """Return PP metadata using Inkling's unpadded runtime vocabulary."""
+        """Return PP input/output metadata using Inkling's unpadded vocabulary."""
         text_config = self.config.text_config
         hidden_shape = (microbatch_size, seq_len, text_config.hidden_size)
         vocab_size = text_config.unpadded_vocab_size or text_config.vocab_size
-
         if is_first:
             inputs_meta = (torch.empty(microbatch_size, seq_len, device="meta", dtype=torch.long),)
         else:
             inputs_meta = (torch.empty(*hidden_shape, device="meta", dtype=dtype),)
-
         if self.lm_head is None:
             outputs_meta = (torch.empty(*hidden_shape, device="meta", dtype=dtype),)
         else:
-            head_dtype = self.lm_head.weight.dtype
-            outputs_meta = (torch.empty(microbatch_size, seq_len, vocab_size, device="meta", dtype=head_dtype),)
+            outputs_meta = (
+                torch.empty(microbatch_size, seq_len, vocab_size, device="meta", dtype=self.lm_head.weight.dtype),
+            )
         return inputs_meta, outputs_meta
 
     def forward(
@@ -323,7 +220,7 @@ class InklingForConditionalGeneration(HFCheckpointingMixin, HFInklingForConditio
         pixel_values: torch.FloatTensor | None = None,
         attention_mask: torch.Tensor | None = None,
         position_ids: torch.LongTensor | None = None,
-        past_key_values: Any | None = None,
+        past_key_values: InklingDynamicCache | None = None,
         audio_input_ids: torch.LongTensor | None = None,
         audio_input_ids_mask: torch.Tensor | None = None,
         inputs_embeds: torch.FloatTensor | None = None,
@@ -331,25 +228,32 @@ class InklingForConditionalGeneration(HFCheckpointingMixin, HFInklingForConditio
         use_cache: bool | None = None,
         logits_to_keep: int | torch.Tensor = 0,
         **kwargs: Any,
-    ) -> Any:
-        """Run the standard Inkling forward or its pipeline-stage equivalent."""
-        language_model = self.model.language_model
-        if not isinstance(language_model.layers, nn.ModuleDict):
-            return super().forward(
-                input_ids=input_ids,
-                pixel_values=pixel_values,
-                attention_mask=attention_mask,
-                position_ids=position_ids,
-                past_key_values=past_key_values,
-                audio_input_ids=audio_input_ids,
-                audio_input_ids_mask=audio_input_ids_mask,
-                inputs_embeds=inputs_embeds,
-                labels=labels,
-                use_cache=use_cache,
-                logits_to_keep=logits_to_keep,
-                **kwargs,
-            )
+    ) -> InklingCausalLMOutputWithPast | torch.Tensor:
+        """Run native Inkling multimodal conditional generation.
 
+        Args:
+            input_ids: Optional long tensor of shape ``[batch, sequence]``. Non-first
+                pipeline stages may receive hidden states of shape ``[batch, sequence,
+                hidden]`` through this argument.
+            pixel_values: Optional tensor of shape ``[patches, time, height, width, channels]``.
+            attention_mask: Optional padding tensor of shape ``[batch, total_sequence]``.
+            position_ids: Optional long tensor of shape ``[batch, sequence]``.
+            past_key_values: Optional model-owned decoding cache.
+            audio_input_ids: Optional long tensor of shape ``[audios, frames, mel_bins]``.
+            audio_input_ids_mask: Optional boolean tensor of shape ``[audios, frames]``.
+            inputs_embeds: Optional tensor of shape ``[batch, sequence, hidden]``.
+            labels: Optional long tensor of shape ``[batch, sequence]``.
+            use_cache: Whether to allocate and return a decoding cache.
+            logits_to_keep: Number or indices of trailing logits to compute.
+            **kwargs: Additional text-attention arguments.
+
+        Returns:
+            An output whose logits have shape ``[batch, kept_sequence, vocab]`` during
+            normal execution, or a raw tensor with that shape on pipeline stages.
+        """
+        language_model = self.model.language_model
+        pipeline_mode = isinstance(language_model.layers, nn.ModuleDict)
+        effective_use_cache = False if use_cache is None and self.training else use_cache
         if inputs_embeds is None and input_ids is not None and input_ids.dtype.is_floating_point:
             inputs_embeds = input_ids
             input_ids = None
@@ -371,11 +275,10 @@ class InklingForConditionalGeneration(HFCheckpointingMixin, HFInklingForConditio
             position_ids=position_ids,
             past_key_values=past_key_values,
             inputs_embeds=inputs_embeds,
-            use_cache=use_cache,
+            use_cache=effective_use_cache,
             **kwargs,
         )
         hidden_states = outputs.last_hidden_state
-
         if self.lm_head is None:
             return hidden_states
 
@@ -384,9 +287,43 @@ class InklingForConditionalGeneration(HFCheckpointingMixin, HFInklingForConditio
         logits = self.lm_head(hidden_states[:, slice_indices, :])
         unpadded_vocab_size = self.config.text_config.unpadded_vocab_size
         if unpadded_vocab_size is not None and unpadded_vocab_size < logits.shape[-1]:
-            logits = logits[..., :unpadded_vocab_size]
-        return logits
+            logits = logits[..., :unpadded_vocab_size].contiguous()
+        if pipeline_mode:
+            return logits
+
+        loss = None
+        if labels is not None:
+            if logits.shape[1] != labels.shape[1]:
+                raise ValueError("labels require logits_to_keep=0 so sequence lengths match")
+            loss = F.cross_entropy(
+                logits[:, :-1, :].float().reshape(-1, logits.shape[-1]),
+                labels[:, 1:].reshape(-1),
+                ignore_index=-100,
+            )
+        return InklingCausalLMOutputWithPast(
+            loss=loss,
+            logits=logits,
+            past_key_values=outputs.past_key_values,
+            image_hidden_states=outputs.image_hidden_states,
+        )
+
+    @torch.no_grad()
+    def initialize_weights(
+        self,
+        buffer_device: torch.device | None = None,
+        dtype: torch.dtype | None = None,
+    ) -> None:
+        """Initialize every parameter for checkpoint-free construction."""
+        del dtype
+        buffer_device = buffer_device or next(self.parameters()).device
+        self.model.init_weights(buffer_device)
+        nn.init.normal_(self.lm_head.weight, mean=0.0, std=self.config.text_config.initializer_range)
 
     def update_moe_gate_bias(self) -> None:
-        """Inkling uses a trained correction bias, so gate-bias updates are a no-op."""
+        """Keep Inkling's trained router correction bias unchanged."""
         return
+
+
+ModelClass = InklingForConditionalGeneration
+
+__all__ = ["InklingForConditionalGeneration", "ModelClass"]

--- a/nemo_automodel/components/models/inkling/multimodal.py
+++ b/nemo_automodel/components/models/inkling/multimodal.py
@@ -1,0 +1,472 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Native Inkling vision, audio, and multimodal composition modules."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from transformers.modeling_outputs import BaseModelOutputWithPast, BaseModelOutputWithPooling
+
+from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.moe.config import MoEConfig
+from nemo_automodel.shared.utils import dtype_from_str as get_dtype
+
+from .configuration import InklingAudioConfig, InklingConfig, InklingVisionConfig
+from .text import InklingDynamicCache, InklingRMSNorm, InklingTextModel
+
+
+@dataclass
+class InklingModelOutputWithPast(BaseModelOutputWithPast):
+    """Inkling backbone output including projected image features."""
+
+    image_hidden_states: torch.FloatTensor | None = None
+
+
+class InklingAudioEmbeddings(nn.Module):
+    """Embed and sum the independently quantized dMel codebooks."""
+
+    def __init__(self, config: InklingAudioConfig) -> None:
+        super().__init__()
+        model_dtype = get_dtype(getattr(config, "torch_dtype", None), torch.bfloat16)
+        self.embed_audio_tokens = nn.Embedding(
+            config.n_mel_bins * config.mel_vocab_size,
+            config.text_hidden_size,
+            dtype=model_dtype,
+        )
+        self.register_buffer(
+            "audio_tokens_offsets",
+            torch.arange(config.n_mel_bins) * config.mel_vocab_size,
+            persistent=False,
+        )
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        """Embed discretized mel bins.
+
+        Args:
+            input_ids: Long tensor of shape ``[frames, mel_bins]``.
+
+        Returns:
+            Tensor of shape ``[frames, hidden]``.
+        """
+        embeddings = self.embed_audio_tokens(input_ids + self.audio_tokens_offsets)
+        return embeddings.sum(dim=-2)
+
+
+class InklingAudioModel(nn.Module):
+    """Native Inkling audio tower."""
+
+    def __init__(self, config: InklingAudioConfig) -> None:
+        super().__init__()
+        self.config = config
+        model_dtype = get_dtype(getattr(config, "torch_dtype", None), torch.bfloat16)
+        self.embed_audio_tokens = InklingAudioEmbeddings(config)
+        self.norm = InklingRMSNorm(config.text_hidden_size, config.rms_norm_eps, dtype=model_dtype)
+
+    def forward(self, audio_input_ids: torch.Tensor) -> BaseModelOutputWithPooling:
+        """Encode audio tokens.
+
+        Args:
+            audio_input_ids: Long tensor of shape ``[frames, mel_bins]``.
+
+        Returns:
+            An output whose hidden state and pooler output have shape ``[frames, hidden]``.
+        """
+        hidden_states = self.norm(self.embed_audio_tokens(audio_input_ids))
+        return BaseModelOutputWithPooling(last_hidden_state=hidden_states, pooler_output=hidden_states)
+
+    @torch.no_grad()
+    def init_weights(self) -> None:
+        """Initialize the audio embedding and final normalization."""
+        nn.init.normal_(self.embed_audio_tokens.embed_audio_tokens.weight, std=self.config.initializer_range)
+        self.norm.init_weights()
+
+
+class InklingVisionEncoderLayer(nn.Module):
+    """Fold time and space into channels, then project one HMLP stage."""
+
+    def __init__(
+        self,
+        input_dim: int,
+        output_dim: int,
+        temporal_fold: int,
+        spatial_fold: int,
+        add_norm: bool,
+        *,
+        dtype: torch.dtype,
+    ) -> None:
+        super().__init__()
+        self.projection = nn.Linear(input_dim, output_dim, bias=False, dtype=dtype)
+        self.layer_norm = InklingRMSNorm(output_dim, 1e-6, dtype=dtype) if add_norm else None
+        self.spatial_fold = spatial_fold
+        self.temporal_fold = temporal_fold
+
+    def _fold_timespace_to_depth(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Fold time and two spatial axes into the channel dimension.
+
+        Args:
+            hidden_states: Tensor of shape ``[patches, time, height, width, channels]``.
+
+        Returns:
+            Tensor of shape ``[patches, time / temporal_fold, height / spatial_fold,
+            width / spatial_fold, channels * temporal_fold * spatial_fold**2]``.
+        """
+        patches, time, height, width, channels = hidden_states.shape
+        new_time = time // self.temporal_fold
+        new_height = height // self.spatial_fold
+        new_width = width // self.spatial_fold
+        hidden_states = hidden_states.reshape(
+            patches,
+            new_time,
+            self.temporal_fold,
+            new_height,
+            self.spatial_fold,
+            new_width,
+            self.spatial_fold,
+            channels,
+        )
+        hidden_states = hidden_states.permute(0, 1, 3, 5, 2, 4, 6, 7)
+        return hidden_states.reshape(
+            patches,
+            new_time,
+            new_height,
+            new_width,
+            self.temporal_fold * self.spatial_fold * self.spatial_fold * channels,
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Apply one hierarchical vision projection.
+
+        Args:
+            hidden_states: Tensor of shape ``[patches, time, height, width, channels]``.
+
+        Returns:
+            Tensor of shape ``[patches, folded_time, folded_height, folded_width, output_channels]``.
+        """
+        if self.spatial_fold > 1 or self.temporal_fold > 1:
+            hidden_states = self._fold_timespace_to_depth(hidden_states)
+        hidden_states = self.projection(hidden_states)
+        if self.layer_norm is not None:
+            hidden_states = F.gelu(self.layer_norm(hidden_states))
+        return hidden_states
+
+    @torch.no_grad()
+    def init_weights(self, init_std: float) -> None:
+        """Initialize the projection and optional normalization."""
+        nn.init.normal_(self.projection.weight, mean=0.0, std=init_std)
+        if self.layer_norm is not None:
+            self.layer_norm.init_weights()
+
+
+def _prime_factors(number: int) -> list[int]:
+    """Return prime factors in ascending order."""
+    factors = []
+    while number % 2 == 0:
+        factors.append(2)
+        number //= 2
+    for divisor in range(3, math.isqrt(number) + 1, 2):
+        while number % divisor == 0:
+            factors.append(divisor)
+            number //= divisor
+    if number > 1:
+        factors.append(number)
+    return factors
+
+
+def _minimum_cost_scale_indices(cost_matrix: torch.Tensor) -> torch.LongTensor:
+    """Select distinct ordered scales with minimum absolute-log cost.
+
+    Args:
+        cost_matrix: Tensor of shape ``[layers_plus_one, available_scales]``.
+
+    Returns:
+        Long tensor of shape ``[layers_plus_one]`` indexing distinct scales.
+    """
+    rows, columns = cost_matrix.shape
+    costs = torch.full_like(cost_matrix, float("inf"))
+    parents = torch.full((rows, columns), -1, dtype=torch.long, device=cost_matrix.device)
+    costs[0] = cost_matrix[0]
+    for row in range(1, rows):
+        for column in range(row, columns):
+            previous_cost, previous_column = torch.min(costs[row - 1, :column], dim=0)
+            costs[row, column] = cost_matrix[row, column] + previous_cost
+            parents[row, column] = previous_column
+
+    indices = torch.empty(rows, dtype=torch.long, device=cost_matrix.device)
+    indices[-1] = torch.argmin(costs[-1])
+    for row in range(rows - 1, 0, -1):
+        indices[row - 1] = parents[row, indices[row]]
+    return indices
+
+
+def _plan_output_scales(config: InklingVisionConfig) -> torch.LongTensor:
+    """Plan the time, height, width, and channel sizes of every HMLP stage."""
+    # This is construction-time integer bookkeeping, not model state. Keep it
+    # on CPU even when the module tree is being materialized under ``device=meta``.
+    spatial = torch.cumprod(torch.tensor(_prime_factors(config.patch_size)[::-1], device="cpu"), dim=0)
+    temporal = torch.cumprod(
+        torch.tensor(_prime_factors(config.temporal_patch_size)[::-1], device="cpu"),
+        dim=0,
+    )
+    spatial_channels = torch.ceil(spatial**2 * config.num_channels / 64).int() * 64
+    temporal_channels = torch.ceil(spatial[-1] ** 2 * config.num_channels * temporal).int() * 64
+
+    base = torch.tensor([[1, 1, 1, config.num_channels]], device="cpu")
+    spatial_scales = torch.stack((torch.ones_like(spatial), spatial, spatial, spatial_channels), dim=1)
+    temporal_scales = torch.stack(
+        (
+            temporal,
+            torch.full_like(temporal, spatial[-1]),
+            torch.full_like(temporal, spatial[-1]),
+            temporal_channels,
+        ),
+        dim=1,
+    )
+    scales = torch.cat((base, spatial_scales, temporal_scales), dim=0)
+    reductions = torch.prod(scales[:, :-1], dim=1).float()
+    total_elements = config.patch_size**2 * config.temporal_patch_size * config.num_channels
+    ideal = torch.linspace(0, math.log(total_elements), config.num_hidden_layers + 1, device="cpu")
+    cost_matrix = torch.abs(ideal.unsqueeze(1) - torch.log(reductions).unsqueeze(0))
+    if config.num_hidden_layers >= scales.shape[0]:
+        indices = torch.argmin(cost_matrix, dim=1)
+    else:
+        indices = _minimum_cost_scale_indices(cost_matrix)
+    indices[0] = 0
+    indices[-1] = scales.shape[0] - 1
+    return scales[indices]
+
+
+class InklingVisionModel(nn.Module):
+    """Native hierarchical MLP vision tower."""
+
+    def __init__(self, config: InklingVisionConfig) -> None:
+        super().__init__()
+        self.config = config
+        model_dtype = get_dtype(getattr(config, "torch_dtype", None), torch.bfloat16)
+        scales = _plan_output_scales(config)
+        self.register_buffer("scales", scales, persistent=False)
+        self.encoder_layers = nn.ModuleList()
+        for layer_idx, (start_scale, end_scale) in enumerate(zip(scales[:-1], scales[1:])):
+            shuffle_multiplier = int(
+                (end_scale[0] // start_scale[0]) * (end_scale[1] // start_scale[1]) * (end_scale[2] // start_scale[2])
+            )
+            output_dim = config.text_hidden_size if layer_idx == config.num_hidden_layers - 1 else int(end_scale[3])
+            self.encoder_layers.append(
+                InklingVisionEncoderLayer(
+                    input_dim=int(start_scale[3]) * shuffle_multiplier,
+                    output_dim=output_dim,
+                    spatial_fold=int(end_scale[1] // start_scale[1]),
+                    temporal_fold=int(end_scale[0] // start_scale[0]),
+                    add_norm=layer_idx != config.num_hidden_layers - 1,
+                    dtype=model_dtype,
+                )
+            )
+        self.final_norm = InklingRMSNorm(config.text_hidden_size, config.rms_norm_eps, dtype=model_dtype)
+
+    def forward(self, pixel_values: torch.Tensor, **kwargs: Any) -> BaseModelOutputWithPooling:
+        """Encode preprocessed image/video patches.
+
+        Args:
+            pixel_values: Tensor of shape ``[patches, time, height, width, channels]``.
+            **kwargs: Reserved for the common multimodal calling convention.
+
+        Returns:
+            An output whose pooler output has shape ``[patches, text_hidden]``.
+        """
+        del kwargs
+        hidden_states = pixel_values
+        for layer in self.encoder_layers:
+            hidden_states = layer(hidden_states)
+        hidden_states = self.final_norm(hidden_states).reshape(pixel_values.shape[0], -1)
+        return BaseModelOutputWithPooling(last_hidden_state=hidden_states, pooler_output=hidden_states)
+
+    @torch.no_grad()
+    def init_weights(self) -> None:
+        """Initialize every vision projection and normalization."""
+        for layer in self.encoder_layers:
+            layer.init_weights(self.config.initializer_range)
+        self.final_norm.init_weights()
+
+
+class InklingModel(nn.Module):
+    """Compose native text, vision, and audio Inkling towers."""
+
+    def __init__(
+        self,
+        config: InklingConfig,
+        backend: BackendConfig,
+        moe_config: MoEConfig,
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.language_model = InklingTextModel(config.text_config, backend, moe_config)
+        self.audio_tower = InklingAudioModel(config.audio_config)
+        self.vision_tower = InklingVisionModel(config.vision_config)
+
+    def get_input_embeddings(self) -> nn.Module:
+        """Return the text token-embedding module."""
+        return self.language_model.get_input_embeddings()
+
+    def get_image_features(self, pixel_values: torch.Tensor, **kwargs: Any) -> BaseModelOutputWithPooling:
+        """Project image/video patches into text hidden space.
+
+        Args:
+            pixel_values: Tensor of shape ``[patches, time, height, width, channels]``.
+            **kwargs: Reserved for the common multimodal calling convention.
+
+        Returns:
+            An output whose pooler output has shape ``[patches, text_hidden]``.
+        """
+        return self.vision_tower(pixel_values, **kwargs)
+
+    def get_audio_features(
+        self,
+        audio_input_ids: torch.Tensor,
+        audio_input_ids_mask: torch.Tensor | None = None,
+    ) -> BaseModelOutputWithPooling:
+        """Project discretized audio into text hidden space.
+
+        Args:
+            audio_input_ids: Long tensor of shape ``[audios, frames, mel_bins]``.
+            audio_input_ids_mask: Optional boolean tensor of shape ``[audios, frames]``.
+
+        Returns:
+            An output whose hidden state has shape ``[valid_frames, text_hidden]``.
+        """
+        if audio_input_ids_mask is not None:
+            audio_input_ids = audio_input_ids[audio_input_ids_mask.bool()]
+        else:
+            audio_input_ids = audio_input_ids.reshape(-1, audio_input_ids.shape[-1])
+        return self.audio_tower(audio_input_ids)
+
+    def _get_placeholder_mask(
+        self,
+        input_ids: torch.Tensor | None,
+        inputs_embeds: torch.Tensor,
+        features: torch.Tensor,
+        token_id: int,
+    ) -> torch.Tensor:
+        """Match multimodal features to placeholder tokens.
+
+        Args:
+            input_ids: Optional long tensor of shape ``[batch, sequence]``.
+            inputs_embeds: Tensor of shape ``[batch, sequence, hidden]``.
+            features: Tensor of shape ``[placeholders, hidden]``.
+            token_id: Vocabulary ID used as the placeholder.
+
+        Returns:
+            Boolean tensor of shape ``[batch, sequence, hidden]``.
+        """
+        if input_ids is None:
+            token = torch.tensor(token_id, dtype=torch.long, device=inputs_embeds.device)
+            special_mask = (inputs_embeds == self.get_input_embeddings()(token)).all(dim=-1)
+        else:
+            special_mask = input_ids == token_id
+        token_count = int(special_mask.sum().item())
+        expanded_mask = special_mask.unsqueeze(-1).expand_as(inputs_embeds)
+        if inputs_embeds[expanded_mask].numel() != features.numel():
+            raise ValueError(
+                "Multimodal features and placeholder tokens do not match: "
+                f"tokens={token_count}, features={features.shape[0]}"
+            )
+        return expanded_mask
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor | None = None,
+        pixel_values: torch.FloatTensor | None = None,
+        audio_input_ids: torch.LongTensor | None = None,
+        audio_input_ids_mask: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | dict[str, torch.Tensor] | None = None,
+        position_ids: torch.LongTensor | None = None,
+        past_key_values: InklingDynamicCache | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        use_cache: bool | None = None,
+        **kwargs: Any,
+    ) -> InklingModelOutputWithPast:
+        """Merge multimodal features and run the text backbone.
+
+        Args:
+            input_ids: Optional long tensor of shape ``[batch, sequence]``.
+            pixel_values: Optional tensor of shape ``[patches, time, height, width, channels]``.
+            audio_input_ids: Optional long tensor of shape ``[audios, frames, mel_bins]``.
+            audio_input_ids_mask: Optional boolean tensor of shape ``[audios, frames]``.
+            attention_mask: Optional padding tensor of shape ``[batch, total_sequence]``
+                or mapping of prepared attention masks.
+            position_ids: Optional long tensor of shape ``[batch, sequence]``.
+            past_key_values: Optional model-owned decoding cache.
+            inputs_embeds: Optional tensor of shape ``[batch, sequence, hidden]``.
+            use_cache: Whether to allocate and return a decoding cache.
+            **kwargs: Additional text-attention arguments.
+
+        Returns:
+            An output whose last hidden state has shape ``[batch, sequence, hidden]``.
+        """
+        if inputs_embeds is None:
+            if input_ids is None:
+                raise ValueError("You must provide either input_ids or inputs_embeds")
+            inputs_embeds = self.language_model.embed_norm(self.get_input_embeddings()(input_ids))
+        elif input_ids is not None:
+            raise ValueError("You must provide exactly one of input_ids or inputs_embeds")
+
+        image_features = None
+        if pixel_values is not None:
+            if self.vision_tower is None:
+                raise ValueError("pixel_values were provided to a pipeline stage without the vision tower")
+            image_features = self.get_image_features(pixel_values).pooler_output
+            image_features = image_features.to(inputs_embeds.device, inputs_embeds.dtype)
+            image_mask = self._get_placeholder_mask(
+                input_ids, inputs_embeds, image_features, self.config.image_token_id
+            )
+            inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_features)
+
+        if audio_input_ids is not None:
+            if self.audio_tower is None:
+                raise ValueError("audio_input_ids were provided to a pipeline stage without the audio tower")
+            audio_features = self.get_audio_features(audio_input_ids, audio_input_ids_mask).last_hidden_state
+            audio_features = audio_features.to(inputs_embeds.device, inputs_embeds.dtype)
+            audio_mask = self._get_placeholder_mask(
+                input_ids, inputs_embeds, audio_features, self.config.audio_token_id
+            )
+            inputs_embeds = inputs_embeds.masked_scatter(audio_mask, audio_features)
+
+        outputs = self.language_model(
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            use_cache=use_cache,
+            **kwargs,
+        )
+        return InklingModelOutputWithPast(
+            last_hidden_state=outputs.last_hidden_state,
+            past_key_values=outputs.past_key_values,
+            image_hidden_states=image_features,
+        )
+
+    @torch.no_grad()
+    def init_weights(self, buffer_device: torch.device) -> None:
+        """Initialize every tower for checkpoint-free construction."""
+        self.language_model.init_weights(buffer_device)
+        self.audio_tower.init_weights()
+        self.vision_tower.init_weights()
+
+
+__all__ = ["InklingModel", "InklingModelOutputWithPast"]

--- a/nemo_automodel/components/models/inkling/processing.py
+++ b/nemo_automodel/components/models/inkling/processing.py
@@ -12,35 +12,268 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Processor construction helpers for Inkling fine-tuning."""
+"""Native processor construction and multimodal token replacement for Inkling."""
+
+from __future__ import annotations
 
 from typing import Any
 
-from transformers import AutoProcessor
-from transformers.processing_utils import ProcessorMixin
+import numpy as np
+import torch
+from transformers import AutoTokenizer
+from transformers.feature_extraction_utils import BatchFeature
+from transformers.processing_utils import ProcessingKwargs, ProcessorMixin
+from transformers.tokenization_utils_base import PreTrainedTokenizerBase
+
+from .feature_extraction import InklingFeatureExtractor
+from .image_processing import InklingImageProcessor
 
 _INKLING_END_OF_SAMPLING_TOKEN = "<|content_model_end_sampling|>"
 
 
-def build_inkling_processor(pretrained_model_name_or_path: str, **kwargs: Any) -> ProcessorMixin:
-    """Load Inkling's processor and configure padding with an existing token.
+class InklingProcessorKwargs(ProcessingKwargs, total=False):
+    """Processor kwargs with Inkling's reference audio-loading default."""
 
-    The published tokenizer does not declare EOS or padding tokens even though
-    its chat template terminates assistant responses with an existing
-    end-of-sampling token. Reusing that token keeps the checkpoint vocabulary
-    unchanged and enables padded fine-tuning batches.
+    _defaults = {"audio_kwargs": {"load_audio_backend": "torchaudio"}}
+
+
+class InklingProcessor(ProcessorMixin):
+    """Combine the native Inkling image/audio processors with a tokenizer."""
+
+    valid_processor_kwargs = InklingProcessorKwargs
+
+    def __init__(
+        self,
+        feature_extractor: InklingFeatureExtractor,
+        image_processor: InklingImageProcessor,
+        tokenizer: PreTrainedTokenizerBase,
+        chat_template: str | None = None,
+        image_token: str = "<|unused_200054|>",
+        audio_token: str = "<|unused_200053|>",
+        image_bos_token: str = "<|content_image|>",
+        audio_bos_token: str = "<|content_audio_input|>",
+        num_dmel_bins: int = 16,
+        dmel_min_value: float = -7.0,
+        dmel_max_value: float = 2.0,
+        **kwargs: Any,
+    ) -> None:
+        del kwargs
+        self.image_token = getattr(tokenizer, "image_token", image_token)
+        self.image_token_id = tokenizer.encode(self.image_token, add_special_tokens=False)[0]
+        self.audio_token = getattr(tokenizer, "audio_token", audio_token)
+        self.audio_token_id = tokenizer.encode(self.audio_token, add_special_tokens=False)[0]
+        self.image_bos_token = image_bos_token
+        self.image_bos_token_id = tokenizer.encode(image_bos_token, add_special_tokens=False)[0]
+        self.audio_bos_token = audio_bos_token
+        self.audio_bos_token_id = tokenizer.encode(audio_bos_token, add_special_tokens=False)[0]
+        self.num_dmel_bins = num_dmel_bins
+        self.dmel_min_value = dmel_min_value
+        self.dmel_max_value = dmel_max_value
+        self.bin_centers = torch.linspace(dmel_min_value, dmel_max_value, num_dmel_bins, dtype=torch.float64)
+        super().__init__(feature_extractor, image_processor, tokenizer, chat_template=chat_template)
+
+    def __call__(
+        self,
+        images: Any | None = None,
+        text: str | list[str] | None = None,
+        videos: Any | None = None,
+        audio: Any | None = None,
+        **kwargs: Any,
+    ) -> BatchFeature:
+        """Prepare text, image patches, and dMel tokens without version-specific HF hooks.
+
+        Transformers releases before Inkling was upstreamed dispatch audio directly
+        to the feature extractor and do not expand multimodal placeholders. Owning
+        this small dispatcher keeps the checkpoint usable with AutoModel's pinned
+        Transformers version.
+        """
+        if images is None and text is None and videos is None and audio is None:
+            raise ValueError(f"You need to provide at least one input to call {type(self).__name__}")
+        if videos is not None:
+            raise ValueError("Inkling accepts images and audio, but not video inputs")
+
+        merged_kwargs = self._merge_kwargs(
+            self.valid_processor_kwargs,
+            tokenizer_init_kwargs=getattr(self.tokenizer, "init_kwargs", {}),
+            **kwargs,
+        )
+        processed_images: dict[str, Any] = {}
+        image_replacements: list[str] = []
+        if images is not None:
+            processed_images = self.image_processor(images, **merged_kwargs["images_kwargs"])
+            image_replacements = [
+                self.replace_image_token(processed_images, image_idx=idx)
+                for idx in range(len(processed_images["num_patches"]))
+            ]
+
+        processed_audio: dict[str, Any] = {}
+        audio_replacements: list[str] = []
+        if audio is not None:
+            audio_batch = self._normalize_audio_batch(audio)
+            processed_audio, audio_replacements = self._process_audio(
+                audio_batch,
+                **merged_kwargs["audio_kwargs"],
+            )
+
+        text_inputs: dict[str, Any] = {}
+        text_kwargs = merged_kwargs["text_kwargs"]
+        return_tensors = text_kwargs.get("return_tensors")
+        if text is not None:
+            text_batch = [text] if isinstance(text, str) else list(text)
+            text_batch = self._replace_multimodal_tokens(
+                text_batch,
+                image_replacements=image_replacements,
+                audio_replacements=audio_replacements,
+            )
+            text_inputs = self.tokenizer(text_batch, **text_kwargs)
+
+        data = {**text_inputs, **processed_images, **processed_audio}
+        data = {key: value for key, value in data.items() if key not in self.unused_input_names}
+        return BatchFeature(data=data, tensor_type=return_tensors)
+
+    @staticmethod
+    def _normalize_audio_batch(audio: Any) -> list[Any]:
+        """Normalize one waveform or a batch into a list of clips."""
+        if isinstance(audio, (np.ndarray, torch.Tensor)):
+            return [audio]
+        if isinstance(audio, (list, tuple)):
+            if not audio:
+                raise ValueError("Received an empty audio input")
+            if isinstance(audio[0], (int, float, np.integer, np.floating)):
+                return [audio]
+            return list(audio)
+        return [audio]
+
+    def _replace_multimodal_tokens(
+        self,
+        text: list[str],
+        *,
+        image_replacements: list[str],
+        audio_replacements: list[str],
+    ) -> list[str]:
+        """Expand media placeholders once per corresponding input, in batch order."""
+        replacements_by_token = (
+            (self.image_token, image_replacements),
+            (self.audio_token, audio_replacements),
+        )
+        for token, replacements in replacements_by_token:
+            expected = sum(sample.count(token) for sample in text)
+            if replacements and expected != len(replacements):
+                raise ValueError(f"Received {len(replacements)} media inputs for {expected} {token!r} placeholders")
+            if not replacements:
+                continue
+            replacement_iter = iter(replacements)
+            for idx, sample in enumerate(text):
+                parts = sample.split(token)
+                text[idx] = parts[0] + "".join(next(replacement_iter) + part for part in parts[1:])
+        return text
+
+    def _extract_dmel_bins(self, input_features: torch.Tensor) -> torch.Tensor:
+        """Quantize continuous log-mel values into dMel token IDs.
+
+        Args:
+            input_features: Tensor of shape ``[batch, frames, mel_bins]``.
+
+        Returns:
+            Int tensor of shape ``[batch, frames, mel_bins]``.
+        """
+        bin_centers = self.bin_centers.to(input_features.device)
+        mel = input_features.double().clamp(min=self.dmel_min_value, max=self.dmel_max_value)
+        return (mel.unsqueeze(-1) - bin_centers).abs().argmin(dim=-1).to(torch.int32)
+
+    def _process_audio(self, audio: Any, **kwargs: Any) -> tuple[dict[str, torch.Tensor], list[str]]:
+        """Extract, quantize, and count a batch of audio clips."""
+        audio_inputs = self.feature_extractor(audio, **kwargs)
+        processed_audio = {
+            "audio_input_ids": self._extract_dmel_bins(audio_inputs["input_features"]),
+            "audio_input_ids_mask": audio_inputs.get("input_features_mask"),
+        }
+        replacements = [self.replace_audio_token(processed_audio, audio_idx) for audio_idx in range(len(audio))]
+        return processed_audio, replacements
+
+    def replace_image_token(self, image_inputs: dict[str, torch.Tensor], image_idx: int) -> str:
+        """Return one soft placeholder per encoded image patch."""
+        return self.image_token * int(image_inputs["num_patches"][image_idx])
+
+    def replace_audio_token(self, audio_inputs: dict[str, torch.Tensor], audio_idx: int) -> str:
+        """Return one soft placeholder per valid audio frame."""
+        audio_mask = audio_inputs.get("audio_input_ids_mask")
+        token_count = (
+            int(audio_mask[audio_idx].sum())
+            if audio_mask is not None
+            else int(audio_inputs["audio_input_ids"][audio_idx].shape[-2])
+        )
+        return self.audio_token * token_count
+
+    @property
+    def unused_input_names(self) -> list[str]:
+        """Return processor-only fields omitted from model inputs."""
+        return ["num_patches"]
+
+    @property
+    def model_input_names(self) -> list[str]:
+        """Return the deduplicated model input field names."""
+        names = [
+            "audio_input_ids",
+            "audio_input_ids_mask",
+            *self.image_processor.model_input_names,
+            *self.tokenizer.model_input_names,
+        ]
+        return [name for name in dict.fromkeys(names) if name not in self.unused_input_names]
+
+
+def build_inkling_processor(pretrained_model_name_or_path: str, **kwargs: Any) -> InklingProcessor:
+    """Load Inkling's native processor without Transformers model registration.
 
     Args:
         pretrained_model_name_or_path: Hugging Face model ID or local snapshot.
-        **kwargs: Additional arguments forwarded to ``AutoProcessor.from_pretrained``.
+        **kwargs: Download/cache arguments accepted by Transformers ``from_pretrained`` methods.
 
     Returns:
-        The configured Inkling processor.
+        A configured native Inkling processor.
     """
-    processor = AutoProcessor.from_pretrained(pretrained_model_name_or_path, **kwargs)
-    tokenizer = processor.tokenizer
+    load_keys = {
+        "cache_dir",
+        "force_download",
+        "local_files_only",
+        "revision",
+        "subfolder",
+        "token",
+        "trust_remote_code",
+    }
+    load_kwargs = {key: value for key, value in kwargs.items() if key in load_keys}
+    processor_dict, _ = InklingProcessor.get_processor_dict(pretrained_model_name_or_path, **load_kwargs)
+
+    image_config = dict(processor_dict.pop("image_processor", {}))
+    image_config.pop("image_processor_type", None)
+    feature_config = dict(processor_dict.pop("feature_extractor", {}))
+    feature_config.pop("feature_extractor_type", None)
+    processor_dict.pop("processor_class", None)
+
+    tokenizer = AutoTokenizer.from_pretrained(pretrained_model_name_or_path, **load_kwargs)
     if tokenizer.eos_token_id is None:
         tokenizer.eos_token = _INKLING_END_OF_SAMPLING_TOKEN
     if tokenizer.pad_token_id is None:
         tokenizer.pad_token = tokenizer.eos_token
-    return processor
+
+    processor_keys = {
+        "image_token",
+        "audio_token",
+        "image_bos_token",
+        "audio_bos_token",
+        "num_dmel_bins",
+        "dmel_min_value",
+        "dmel_max_value",
+        "chat_template",
+    }
+    processor_kwargs = {key: value for key, value in processor_dict.items() if key in processor_keys}
+    processor_kwargs.update({key: value for key, value in kwargs.items() if key in processor_keys})
+    return InklingProcessor(
+        feature_extractor=InklingFeatureExtractor(**feature_config),
+        image_processor=InklingImageProcessor(**image_config),
+        tokenizer=tokenizer,
+        **processor_kwargs,
+    )
+
+
+__all__ = ["InklingProcessor", "build_inkling_processor"]

--- a/nemo_automodel/components/models/inkling/text.py
+++ b/nemo_automodel/components/models/inkling/text.py
@@ -1,0 +1,730 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Native Inkling text backbone, attention, masks, and decoding cache."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from transformers.modeling_outputs import BaseModelOutputWithPast
+
+from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.moe.config import MoEConfig
+from nemo_automodel.shared.utils import dtype_from_str as get_dtype
+
+from .configuration import InklingTextConfig
+from .layers import InklingDenseMLP, InklingMoE, InklingShortConvolution
+
+
+class _InklingCacheLayer:
+    """Dynamic key/value and short-convolution state for one decoder layer."""
+
+    def __init__(self, *, sliding_window: int | None, number_of_conv_states: int) -> None:
+        self.sliding_window = sliding_window
+        self.keys: torch.Tensor | None = None
+        self.values: torch.Tensor | None = None
+        self.cumulative_length = 0
+        self.conv_states: dict[int, torch.Tensor | None] = dict.fromkeys(range(number_of_conv_states))
+        self._has_previous_conv_state: dict[int, bool] = dict.fromkeys(range(number_of_conv_states), False)
+        self.record_past = False
+
+    def get_seq_length(self) -> int:
+        """Return the number of tokens observed by this layer."""
+        if self.sliding_window is not None:
+            return self.cumulative_length
+        return 0 if self.keys is None else self.keys.shape[-2]
+
+    def get_mask_sizes(self, query_length: int) -> tuple[int, int]:
+        """Return key/value length and absolute offset before appending a query."""
+        if self.sliding_window is None:
+            return self.get_seq_length() + query_length, 0
+        is_full = self.cumulative_length >= self.sliding_window
+        key_offset = max(self.cumulative_length - self.sliding_window + 1, 0)
+        key_length = self.sliding_window - 1 + query_length if is_full else self.cumulative_length + query_length
+        return key_length, key_offset
+
+    def update(self, key_states: torch.Tensor, value_states: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """Append key/value states and return the states visible to this query.
+
+        Args:
+            key_states: Tensor of shape ``[batch, key_value_heads, sequence, head_dim]``.
+            value_states: Tensor of shape ``[batch, key_value_heads, sequence, head_dim]``.
+
+        Returns:
+            A pair of tensors with shape ``[batch, key_value_heads, visible_sequence, head_dim]``.
+        """
+        if self.keys is None:
+            self.keys = key_states[:, :, :0, :]
+            self.values = value_states[:, :, :0, :]
+        full_keys = torch.cat((self.keys, key_states), dim=-2)
+        full_values = torch.cat((self.values, value_states), dim=-2)
+        if self.sliding_window is None:
+            self.keys = full_keys
+            self.values = full_values
+        else:
+            self.cumulative_length += key_states.shape[-2]
+            retained = self.sliding_window - 1
+            self.keys = full_keys[:, :, -retained:, :]
+            self.values = full_values[:, :, -retained:, :]
+        return full_keys, full_values
+
+    def update_conv_state(
+        self,
+        conv_states: torch.Tensor,
+        state_idx: int,
+        conv_kernel_size: int,
+    ) -> torch.Tensor:
+        """Append short-convolution inputs and update the fixed-size cache.
+
+        Args:
+            conv_states: Tensor of shape ``[batch, hidden, sequence]``.
+            state_idx: Index of one of the four convolution states owned by the layer.
+            conv_kernel_size: Number of trailing tokens retained in the cache.
+
+        Returns:
+            Tensor of shape ``[batch, hidden, cached_sequence + sequence]`` used by
+            the current convolution.
+        """
+        cached = self.conv_states[state_idx]
+        if cached is None:
+            cached = torch.zeros(
+                *conv_states.shape[:-1],
+                conv_kernel_size,
+                dtype=conv_states.dtype,
+                device=conv_states.device,
+            )
+            self.conv_states[state_idx] = cached
+
+        if not self._has_previous_conv_state[state_idx]:
+            full_states = conv_states
+            self._has_previous_conv_state[state_idx] = True
+            if full_states.shape[-1] < conv_kernel_size:
+                full_states = F.pad(full_states, (conv_kernel_size - full_states.shape[-1], 0))
+        else:
+            full_states = torch.cat((cached, conv_states), dim=-1)
+
+        cached.copy_(full_states[..., -conv_kernel_size:])
+        return full_states
+
+    def has_previous_state(self, state_idx: int) -> bool:
+        """Return whether a convolution state has seen at least one token."""
+        return self._has_previous_conv_state[state_idx]
+
+    def reorder(self, beam_indices: torch.Tensor) -> None:
+        """Reorder cached batch entries during beam search.
+
+        Args:
+            beam_indices: Long tensor of shape ``[new_batch]`` indexing the old batch axis.
+        """
+        if self.keys is not None:
+            self.keys = self.keys.index_select(0, beam_indices.to(self.keys.device))
+            self.values = self.values.index_select(0, beam_indices.to(self.values.device))
+        for state_idx, state in self.conv_states.items():
+            if state is not None:
+                self.conv_states[state_idx] = state.index_select(0, beam_indices.to(state.device))
+
+
+class InklingDynamicCache:
+    """Model-owned dynamic cache for Inkling attention and short convolutions."""
+
+    def __init__(self, config: InklingTextConfig) -> None:
+        self.layers = [
+            _InklingCacheLayer(
+                sliding_window=config.sliding_window_size if layer_type == "hybrid_sliding" else None,
+                number_of_conv_states=config.number_of_conv_states,
+            )
+            for layer_type in config.layer_types
+        ]
+
+    def get_seq_length(self, layer_idx: int = 0) -> int:
+        """Return the number of tokens observed at a decoder layer."""
+        return self.layers[layer_idx].get_seq_length()
+
+    def get_query_offset(self, layer_idx: int = 0) -> int:
+        """Return the absolute starting position of the next query."""
+        return self.get_seq_length(layer_idx)
+
+    def get_mask_sizes(self, query_length: int, layer_idx: int) -> tuple[int, int]:
+        """Return the key/value length and absolute offset for a decoder layer."""
+        return self.layers[layer_idx].get_mask_sizes(query_length)
+
+    def update(
+        self,
+        key_states: torch.Tensor,
+        value_states: torch.Tensor,
+        layer_idx: int,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Append key/value states at one decoder layer.
+
+        Args:
+            key_states: Tensor of shape ``[batch, key_value_heads, sequence, head_dim]``.
+            value_states: Tensor of shape ``[batch, key_value_heads, sequence, head_dim]``.
+            layer_idx: Decoder-layer index.
+
+        Returns:
+            A pair of tensors with shape ``[batch, key_value_heads, visible_sequence, head_dim]``.
+        """
+        return self.layers[layer_idx].update(key_states, value_states)
+
+    def update_conv_state(
+        self,
+        conv_states: torch.Tensor,
+        layer_idx: int,
+        state_idx: int,
+        conv_kernel_size: int,
+    ) -> torch.Tensor:
+        """Append and cache inputs for one short convolution.
+
+        Args:
+            conv_states: Tensor of shape ``[batch, hidden, sequence]``.
+            layer_idx: Decoder-layer index.
+            state_idx: Convolution index inside that layer.
+            conv_kernel_size: Number of trailing tokens retained.
+
+        Returns:
+            Tensor of shape ``[batch, hidden, cached_sequence + sequence]``.
+        """
+        return self.layers[layer_idx].update_conv_state(conv_states, state_idx, conv_kernel_size)
+
+    def has_previous_state(self, layer_idx: int, state_idx: int) -> bool:
+        """Return whether one short-convolution cache has been populated."""
+        return self.layers[layer_idx].has_previous_state(state_idx)
+
+    def reorder_cache(self, beam_indices: torch.Tensor) -> None:
+        """Reorder every layer cache during beam search.
+
+        Args:
+            beam_indices: Long tensor of shape ``[new_batch]`` indexing the old batch axis.
+        """
+        for layer in self.layers:
+            layer.reorder(beam_indices)
+
+
+class InklingRMSNorm(nn.Module):
+    """RMS normalization with fp32 variance accumulation."""
+
+    def __init__(self, hidden_size: int, eps: float, *, dtype: torch.dtype) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size, dtype=dtype))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Normalize the final hidden axis.
+
+        Args:
+            hidden_states: Tensor of shape ``[..., hidden]`` with arbitrary leading dimensions.
+
+        Returns:
+            Tensor with the same shape and dtype as ``hidden_states``.
+        """
+        input_dtype = hidden_states.dtype
+        variance = hidden_states.float().pow(2).mean(dim=-1, keepdim=True)
+        normalized = hidden_states.float() * torch.rsqrt(variance + self.variance_epsilon)
+        return self.weight * normalized.to(input_dtype)
+
+    @torch.no_grad()
+    def init_weights(self) -> None:
+        """Initialize the learned scale to one."""
+        nn.init.ones_(self.weight)
+
+
+class InklingRelativeLogits(nn.Module):
+    """Project token-conditioned relative-position profiles into attention bias."""
+
+    def __init__(self, d_rel: int, rel_extent: int, *, dtype: torch.dtype) -> None:
+        super().__init__()
+        self.rel_extent = rel_extent
+        self.proj = nn.Parameter(torch.empty(d_rel, rel_extent, dtype=dtype))
+
+    def forward(
+        self,
+        relative_states: torch.Tensor,
+        query_positions: torch.Tensor,
+        key_positions: torch.Tensor,
+    ) -> torch.Tensor:
+        """Materialize the relative-position bias.
+
+        Args:
+            relative_states: Tensor of shape ``[batch, query, heads, relative_dim]``.
+            query_positions: Long tensor of shape ``[query]`` containing absolute positions.
+            key_positions: Long tensor of shape ``[key]`` containing absolute positions.
+
+        Returns:
+            Tensor of shape ``[batch, heads, query, key]``.
+        """
+        relative_logits = (relative_states @ self.proj).transpose(1, 2)
+        distance = (query_positions[:, None] - key_positions[None, :])[None, None, :, :]
+        gather_index = distance.clamp(0, self.rel_extent - 1).expand(*relative_logits.shape[:2], -1, -1)
+        position_bias = relative_logits.gather(-1, gather_index)
+        return position_bias.masked_fill((distance < 0) | (distance >= self.rel_extent), 0.0)
+
+    @torch.no_grad()
+    def init_weights(self, init_std: float) -> None:
+        """Initialize the relative-position profile bank."""
+        nn.init.normal_(self.proj, mean=0.0, std=init_std)
+
+
+def _repeat_key_value(hidden_states: torch.Tensor, repeats: int) -> torch.Tensor:
+    """Repeat grouped key/value heads to match query heads.
+
+    Args:
+        hidden_states: Tensor of shape ``[batch, key_value_heads, sequence, head_dim]``.
+        repeats: Number of query heads sharing each key/value head.
+
+    Returns:
+        Tensor of shape ``[batch, key_value_heads * repeats, sequence, head_dim]``.
+    """
+    if repeats == 1:
+        return hidden_states
+    batch, key_value_heads, sequence, head_dim = hidden_states.shape
+    expanded = hidden_states[:, :, None, :, :].expand(batch, key_value_heads, repeats, sequence, head_dim)
+    return expanded.reshape(batch, key_value_heads * repeats, sequence, head_dim)
+
+
+def _build_attention_mask(
+    inputs_embeds: torch.Tensor,
+    attention_mask: torch.Tensor | None,
+    past_key_values: InklingDynamicCache | None,
+    layer_idx: int,
+    sliding_window: int | None,
+) -> torch.Tensor:
+    """Build an additive causal mask for Inkling eager attention.
+
+    Args:
+        inputs_embeds: Tensor of shape ``[batch, query, hidden]``.
+        attention_mask: Optional tensor of shape ``[batch, total_sequence]`` where nonzero
+            entries are valid keys, or a prepared tensor of shape ``[batch, 1, query, key]``.
+        past_key_values: Optional model-owned decoding cache.
+        layer_idx: Decoder-layer index used to size a hybrid cache.
+        sliding_window: Optional number of visible tokens for local attention.
+
+    Returns:
+        Additive tensor of shape ``[batch, 1, query, key]`` in ``inputs_embeds.dtype``.
+    """
+    if attention_mask is not None and attention_mask.ndim == 4:
+        return attention_mask.to(device=inputs_embeds.device, dtype=inputs_embeds.dtype)
+
+    batch, query_length = inputs_embeds.shape[:2]
+    if past_key_values is None:
+        key_length = attention_mask.shape[-1] if attention_mask is not None else query_length
+        query_offset = 0
+        key_offset = 0
+    else:
+        key_length, key_offset = past_key_values.get_mask_sizes(query_length, layer_idx)
+        query_offset = past_key_values.get_query_offset(layer_idx)
+
+    query_positions = torch.arange(query_length, device=inputs_embeds.device) + query_offset
+    key_positions = torch.arange(key_length, device=inputs_embeds.device) + key_offset
+    allowed = key_positions[None, :] <= query_positions[:, None]
+    if sliding_window is not None:
+        allowed &= key_positions[None, :] > query_positions[:, None] - sliding_window
+
+    allowed = allowed[None, None, :, :].expand(batch, 1, -1, -1)
+    if attention_mask is not None:
+        key_valid = attention_mask.to(device=inputs_embeds.device, dtype=torch.bool)
+        key_valid = key_valid[:, key_offset : key_offset + key_length]
+        allowed = allowed & key_valid[:, None, None, :]
+
+    additive_mask = torch.zeros(allowed.shape, device=inputs_embeds.device, dtype=inputs_embeds.dtype)
+    return additive_mask.masked_fill(~allowed, torch.finfo(inputs_embeds.dtype).min)
+
+
+def _build_conv_mask(attention_mask: torch.Tensor | None, query_length: int) -> torch.Tensor | None:
+    """Extract a local two-dimensional padding mask for short convolutions.
+
+    Args:
+        attention_mask: Optional tensor of shape ``[batch, total_sequence]``.
+        query_length: Length of the current local sequence.
+
+    Returns:
+        Optional boolean tensor of shape ``[batch, query_length]`` where ``True``
+        marks a valid token.
+    """
+    if attention_mask is None or attention_mask.ndim != 2 or torch.all(attention_mask == 1):
+        return None
+    return attention_mask[:, -query_length:].to(dtype=torch.bool).contiguous()
+
+
+class InklingAttention(nn.Module):
+    """Inkling grouped-query attention with learned relative logits."""
+
+    def __init__(self, config: InklingTextConfig, layer_idx: int, backend: BackendConfig) -> None:
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+        self.is_sliding = config.layer_types[layer_idx] == "hybrid_sliding"
+        self.head_dim = config.swa_head_dim if self.is_sliding else config.head_dim
+        self.num_heads = config.swa_num_attention_heads if self.is_sliding else config.num_attention_heads
+        self.num_key_value_heads = config.swa_num_key_value_heads if self.is_sliding else config.num_key_value_heads
+        self.num_key_value_groups = self.num_heads // self.num_key_value_heads
+        self.sliding_window = config.sliding_window_size if self.is_sliding else None
+        self.rel_extent = config.sliding_window_size if self.is_sliding else config.rel_extent
+        self.scaling = 1.0 / self.head_dim
+        self.attention_dropout = config.attention_dropout
+        configured_attention = getattr(config, "_attn_implementation", None)
+        self.attention_backend = configured_attention if configured_attention in {"eager", "sdpa"} else backend.attn
+        model_dtype = get_dtype(getattr(config, "torch_dtype", None), torch.bfloat16)
+
+        self.q_proj = nn.Linear(config.hidden_size, self.num_heads * self.head_dim, bias=False, dtype=model_dtype)
+        self.k_proj = nn.Linear(
+            config.hidden_size, self.num_key_value_heads * self.head_dim, bias=False, dtype=model_dtype
+        )
+        self.v_proj = nn.Linear(
+            config.hidden_size, self.num_key_value_heads * self.head_dim, bias=False, dtype=model_dtype
+        )
+        self.r_proj = nn.Linear(config.hidden_size, self.num_heads * config.d_rel, bias=False, dtype=model_dtype)
+        self.o_proj = nn.Linear(self.num_heads * self.head_dim, config.hidden_size, bias=False, dtype=model_dtype)
+        self.k_sconv = InklingShortConvolution(
+            self.num_key_value_heads * self.head_dim, config.conv_kernel_size, layer_idx, conv_idx=0
+        )
+        self.v_sconv = InklingShortConvolution(
+            self.num_key_value_heads * self.head_dim, config.conv_kernel_size, layer_idx, conv_idx=1
+        )
+        self.q_norm = InklingRMSNorm(self.head_dim, config.rms_norm_eps, dtype=model_dtype)
+        self.k_norm = InklingRMSNorm(self.head_dim, config.rms_norm_eps, dtype=model_dtype)
+        self.rel_logits_proj = InklingRelativeLogits(config.d_rel, self.rel_extent, dtype=model_dtype)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor,
+        conv_mask: torch.Tensor | None = None,
+        past_key_values: InklingDynamicCache | None = None,
+        **kwargs: Any,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Apply self-attention.
+
+        Args:
+            hidden_states: Tensor of shape ``[batch, sequence, hidden]``.
+            attention_mask: Additive tensor of shape ``[batch, 1, query, key]``.
+            conv_mask: Optional boolean tensor of shape ``[batch, sequence]`` where
+                ``True`` marks a valid token.
+            past_key_values: Optional model-owned decoding cache.
+            **kwargs: Backend-compatible attention arguments; currently ignored by eager attention.
+
+        Returns:
+            A pair containing the output tensor of shape ``[batch, sequence, hidden]``
+            and optional attention probabilities of shape ``[batch, heads, query, key]``.
+            The SDPA backend returns ``None`` for probabilities.
+        """
+        input_shape = hidden_states.shape[:-1]
+        query_shape = (*input_shape, self.num_heads, self.head_dim)
+        key_value_shape = (*input_shape, self.num_key_value_heads, self.head_dim)
+
+        query_states = self.q_norm(self.q_proj(hidden_states).view(query_shape)).transpose(1, 2)
+        key_states = self.k_sconv(
+            self.k_proj(hidden_states), past_key_values=past_key_values, conv_mask=conv_mask, **kwargs
+        )
+        value_states = self.v_sconv(
+            self.v_proj(hidden_states), past_key_values=past_key_values, conv_mask=conv_mask, **kwargs
+        )
+        key_states = self.k_norm(key_states.view(key_value_shape)).transpose(1, 2)
+        value_states = value_states.view(key_value_shape).transpose(1, 2)
+
+        # The short-convolution parameters intentionally remain fp32 under FSDP.
+        # Some FSDP policies therefore return their activations in fp32 even
+        # though the attention projections run in bf16.  SDPA requires q/k/v to
+        # share a dtype, so restore the projection compute dtype before caching
+        # or dispatching to either attention backend.
+        attention_dtype = query_states.dtype
+        key_states = key_states.to(dtype=attention_dtype)
+        value_states = value_states.to(dtype=attention_dtype)
+
+        query_length = query_states.shape[2]
+        if past_key_values is None:
+            key_length = key_states.shape[2]
+            query_offset = key_offset = 0
+        else:
+            key_length, key_offset = past_key_values.get_mask_sizes(query_length, self.layer_idx)
+            query_offset = past_key_values.get_query_offset(self.layer_idx)
+            key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx)
+
+        key_positions = torch.arange(key_length, device=hidden_states.device) + key_offset
+        query_positions = torch.arange(query_length, device=hidden_states.device) + query_offset
+        relative_states = self.r_proj(hidden_states).view(*input_shape, self.num_heads, -1)
+        position_bias = self.rel_logits_proj(relative_states, query_positions, key_positions)
+
+        if not self.is_sliding and self.config.log_scaling_n_floor is not None:
+            effective_n = (query_positions + 1).float()
+            tau = 1.0 + self.config.log_scaling_alpha * torch.log(
+                (effective_n / self.config.log_scaling_n_floor).clamp(min=1.0)
+            )
+            tau = tau.view(1, 1, -1, 1)
+            query_states = (query_states.float() * tau).to(query_states.dtype)
+            position_bias = (position_bias.float() * tau).to(position_bias.dtype)
+
+        key_states = _repeat_key_value(key_states, self.num_key_value_groups)
+        value_states = _repeat_key_value(value_states, self.num_key_value_groups)
+        combined_mask = position_bias + attention_mask
+        if self.attention_backend == "sdpa":
+            attention_output = F.scaled_dot_product_attention(
+                query_states,
+                key_states,
+                value_states,
+                attn_mask=combined_mask,
+                dropout_p=self.attention_dropout if self.training else 0.0,
+                scale=self.scaling,
+            )
+            attention_probs = None
+        else:
+            attention_scores = torch.matmul(query_states, key_states.transpose(2, 3)) * self.scaling
+            attention_scores = attention_scores + combined_mask
+            attention_probs = F.softmax(attention_scores, dim=-1, dtype=torch.float32).to(query_states.dtype)
+            attention_probs = F.dropout(attention_probs, p=self.attention_dropout, training=self.training)
+            attention_output = torch.matmul(attention_probs, value_states)
+        attention_output = attention_output.transpose(1, 2).contiguous()
+        attention_output = self.o_proj(attention_output.reshape(*input_shape, -1))
+        return attention_output, attention_probs
+
+    @torch.no_grad()
+    def init_weights(self, init_std: float) -> None:
+        """Initialize projections, norms, relative logits, and convolution weights."""
+        for projection in (self.q_proj, self.k_proj, self.v_proj, self.r_proj, self.o_proj):
+            nn.init.normal_(projection.weight, mean=0.0, std=init_std)
+        self.q_norm.init_weights()
+        self.k_norm.init_weights()
+        self.rel_logits_proj.init_weights(init_std)
+        self.k_sconv.init_weights(init_std)
+        self.v_sconv.init_weights(init_std)
+
+
+class InklingDecoderLayer(nn.Module):
+    """One native Inkling decoder layer."""
+
+    def __init__(
+        self,
+        config: InklingTextConfig,
+        layer_idx: int,
+        backend: BackendConfig,
+        moe_config: MoEConfig,
+    ) -> None:
+        super().__init__()
+        model_dtype = get_dtype(getattr(config, "torch_dtype", None), torch.bfloat16)
+        self.self_attn = InklingAttention(config, layer_idx, backend)
+        self.mlp = (
+            InklingMoE(config, backend, moe_config=moe_config)
+            if config.mlp_layer_types[layer_idx] == "sparse"
+            else InklingDenseMLP(config)
+        )
+        self.input_layernorm = InklingRMSNorm(config.hidden_size, config.rms_norm_eps, dtype=model_dtype)
+        self.post_attention_layernorm = InklingRMSNorm(config.hidden_size, config.rms_norm_eps, dtype=model_dtype)
+        self.layer_type = config.layer_types[layer_idx]
+        self.attention_type = "full_attention" if self.layer_type == "hybrid" else "sliding_attention"
+        self.attn_sconv = InklingShortConvolution(config.hidden_size, config.conv_kernel_size, layer_idx, conv_idx=2)
+        self.mlp_sconv = InklingShortConvolution(config.hidden_size, config.conv_kernel_size, layer_idx, conv_idx=3)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor,
+        conv_mask: torch.Tensor | None = None,
+        past_key_values: InklingDynamicCache | None = None,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        """Apply attention and feed-forward residual blocks.
+
+        Args:
+            hidden_states: Tensor of shape ``[batch, sequence, hidden]``.
+            attention_mask: Additive tensor of shape ``[batch, 1, query, key]``.
+            conv_mask: Optional boolean tensor of shape ``[batch, sequence]`` where
+                ``True`` marks a valid token.
+            past_key_values: Optional model-owned decoding cache.
+            **kwargs: Additional eager-attention arguments.
+
+        Returns:
+            Tensor of shape ``[batch, sequence, hidden]``.
+        """
+        residual = hidden_states
+        normalized_hidden_states = self.input_layernorm(hidden_states).to(dtype=residual.dtype)
+        hidden_states, _ = self.self_attn(
+            normalized_hidden_states,
+            attention_mask=attention_mask,
+            conv_mask=conv_mask,
+            past_key_values=past_key_values,
+            **kwargs,
+        )
+        hidden_states = self.attn_sconv(hidden_states, past_key_values=past_key_values, conv_mask=conv_mask, **kwargs)
+        hidden_states = hidden_states.to(dtype=residual.dtype)
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states).to(dtype=residual.dtype)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = self.mlp_sconv(hidden_states, past_key_values=past_key_values, conv_mask=conv_mask, **kwargs)
+        hidden_states = hidden_states.to(dtype=residual.dtype)
+        return residual + hidden_states
+
+    @torch.no_grad()
+    def init_weights(self, init_std: float, buffer_device: torch.device) -> None:
+        """Initialize all parameters owned by the decoder layer."""
+        self.self_attn.init_weights(init_std)
+        self.input_layernorm.init_weights()
+        self.post_attention_layernorm.init_weights()
+        self.attn_sconv.init_weights(init_std)
+        self.mlp_sconv.init_weights(init_std)
+        self.mlp.init_weights(buffer_device, init_std) if isinstance(self.mlp, InklingMoE) else self.mlp.init_weights(
+            init_std
+        )
+
+
+class InklingTextModel(nn.Module):
+    """Native Inkling text backbone with pipeline-stage support."""
+
+    def __init__(
+        self,
+        config: InklingTextConfig,
+        backend: BackendConfig,
+        moe_config: MoEConfig,
+    ) -> None:
+        super().__init__()
+        self.config = config
+        model_dtype = get_dtype(getattr(config, "torch_dtype", None), torch.bfloat16)
+        self.embed_tokens = nn.Embedding(
+            config.vocab_size,
+            config.hidden_size,
+            padding_idx=config.pad_token_id,
+            dtype=model_dtype,
+        )
+        self.layers = nn.ModuleList(
+            [
+                InklingDecoderLayer(config, layer_idx, backend, moe_config)
+                for layer_idx in range(config.num_hidden_layers)
+            ]
+        )
+        self.norm = InklingRMSNorm(config.hidden_size, config.rms_norm_eps, dtype=model_dtype)
+        self.embed_norm = InklingRMSNorm(config.hidden_size, config.rms_norm_eps, dtype=model_dtype)
+
+    def get_input_embeddings(self) -> nn.Module:
+        """Return the token-embedding module."""
+        return self.embed_tokens
+
+    def set_input_embeddings(self, embeddings: nn.Module) -> None:
+        """Replace the token-embedding module."""
+        self.embed_tokens = embeddings
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor | None = None,
+        attention_mask: torch.Tensor | dict[str, torch.Tensor] | None = None,
+        position_ids: torch.LongTensor | None = None,
+        past_key_values: InklingDynamicCache | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        use_cache: bool | None = None,
+        **kwargs: Any,
+    ) -> BaseModelOutputWithPast:
+        """Run the text backbone.
+
+        Args:
+            input_ids: Optional tensor of shape ``[batch, sequence]``. Pipeline stages
+                without embeddings may instead receive floating hidden states of shape
+                ``[batch, sequence, hidden]`` through this argument.
+            attention_mask: Optional padding tensor of shape ``[batch, total_sequence]``
+                or a mapping from attention type to additive masks of shape
+                ``[batch, 1, query, key]``.
+            position_ids: Optional long tensor of shape ``[batch, sequence]``.
+            past_key_values: Optional model-owned decoding cache.
+            inputs_embeds: Optional tensor of shape ``[batch, sequence, hidden]``.
+            use_cache: Whether to allocate and return a decoding cache.
+            **kwargs: Additional eager-attention arguments.
+
+        Returns:
+            A model output whose ``last_hidden_state`` has shape ``[batch, sequence, hidden]``.
+        """
+        if inputs_embeds is None:
+            if self.embed_tokens is None:
+                if input_ids is None or not input_ids.dtype.is_floating_point:
+                    raise ValueError("Pipeline stages without embeddings require hidden states as input")
+                inputs_embeds = input_ids
+                input_ids = None
+            else:
+                if input_ids is None:
+                    raise ValueError("You must provide either input_ids or inputs_embeds")
+                inputs_embeds = self.embed_norm(self.embed_tokens(input_ids))
+        elif input_ids is not None:
+            raise ValueError("You must provide exactly one of input_ids or inputs_embeds")
+
+        use_cache = getattr(self.config, "use_cache", False) if use_cache is None else use_cache
+        if use_cache and past_key_values is None:
+            past_key_values = InklingDynamicCache(self.config)
+
+        if position_ids is None:
+            past_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
+            position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device) + past_tokens
+            position_ids = position_ids.unsqueeze(0)
+
+        if isinstance(attention_mask, dict):
+            masks = attention_mask
+            conv_mask = masks.get("linear_attention")
+        else:
+            conv_mask = _build_conv_mask(attention_mask, inputs_embeds.shape[1])
+            full_layer_idx = next(
+                (idx for idx, layer_type in enumerate(self.config.layer_types) if layer_type == "hybrid"),
+                0,
+            )
+            sliding_layer_idx = next(
+                (idx for idx, layer_type in enumerate(self.config.layer_types) if layer_type == "hybrid_sliding"),
+                0,
+            )
+            masks = {
+                "full_attention": _build_attention_mask(
+                    inputs_embeds,
+                    attention_mask,
+                    past_key_values,
+                    full_layer_idx,
+                    None,
+                ),
+                "sliding_attention": _build_attention_mask(
+                    inputs_embeds,
+                    attention_mask,
+                    past_key_values,
+                    sliding_layer_idx,
+                    self.config.sliding_window_size,
+                ),
+                "linear_attention": conv_mask,
+            }
+
+        hidden_states = inputs_embeds
+        layers = self.layers.values() if isinstance(self.layers, nn.ModuleDict) else self.layers
+        for decoder_layer in layers:
+            hidden_states = decoder_layer(
+                hidden_states,
+                attention_mask=masks[decoder_layer.attention_type],
+                conv_mask=conv_mask,
+                past_key_values=past_key_values,
+                **kwargs,
+            )
+
+        if self.norm is not None:
+            hidden_states = self.norm(hidden_states)
+        return BaseModelOutputWithPast(last_hidden_state=hidden_states, past_key_values=past_key_values)
+
+    @torch.no_grad()
+    def init_weights(self, buffer_device: torch.device) -> None:
+        """Initialize the text backbone for checkpoint-free construction."""
+        init_std = self.config.initializer_range
+        nn.init.normal_(self.embed_tokens.weight, mean=0.0, std=init_std)
+        if self.embed_tokens.padding_idx is not None:
+            self.embed_tokens.weight[self.embed_tokens.padding_idx].zero_()
+        self.embed_norm.init_weights()
+        self.norm.init_weights()
+        layers = self.layers.values() if isinstance(self.layers, nn.ModuleDict) else self.layers
+        for layer in layers:
+            layer.init_weights(init_std, buffer_device)
+
+
+__all__ = ["InklingDynamicCache", "InklingRMSNorm", "InklingTextModel"]

--- a/tests/unit_tests/models/inkling/parity_check_inkling.py
+++ b/tests/unit_tests/models/inkling/parity_check_inkling.py
@@ -24,12 +24,9 @@ Run directly:  python tests/unit_tests/models/inkling/parity_check_inkling.py
 
 import torch
 import torch.nn.functional as F
-from transformers.models.inkling.configuration_inkling import InklingConfig
-from transformers.models.inkling.modeling_inkling import (
-    InklingForConditionalGeneration as HFInklingForConditionalGeneration,
-)
 
 from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.models.inkling.configuration import InklingConfig
 from nemo_automodel.components.models.inkling.model import InklingForConditionalGeneration
 
 
@@ -73,11 +70,20 @@ def build_tiny_config() -> InklingConfig:
 
 
 def main() -> None:
+    try:
+        from transformers.models.inkling.configuration_inkling import InklingConfig as HFInklingConfig
+        from transformers.models.inkling.modeling_inkling import (
+            InklingForConditionalGeneration as HFInklingForConditionalGeneration,
+        )
+    except ImportError as exc:
+        raise RuntimeError("The development parity script requires Transformers >=5.14 as a reference") from exc
+
     torch.manual_seed(0)
     device, dtype = torch.device("cpu"), torch.float32
     cfg = build_tiny_config()
 
-    hf_model = HFInklingForConditionalGeneration(cfg).to(device=device, dtype=dtype).eval()
+    hf_config = HFInklingConfig.from_dict(cfg.to_dict())
+    hf_model = HFInklingForConditionalGeneration(hf_config).to(device=device, dtype=dtype).eval()
     backend = BackendConfig(attn="sdpa", linear="torch", rms_norm="torch", experts="torch")
     nemo_model = InklingForConditionalGeneration.from_config(cfg, backend=backend).to(device=device, dtype=dtype).eval()
 

--- a/tests/unit_tests/models/inkling/test_inkling_config_registry.py
+++ b/tests/unit_tests/models/inkling/test_inkling_config_registry.py
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 from transformers import AutoConfig
 from transformers.models.auto.configuration_auto import CONFIG_MAPPING
 
 from nemo_automodel._transformers.registry import ModelRegistry
+from nemo_automodel.components.models.common import BackendConfig
 from nemo_automodel.components.models.inkling.configuration import InklingConfig
+from nemo_automodel.components.models.inkling.model import InklingForConditionalGeneration
+
+from .parity_check_inkling import build_tiny_config
 
 
 def test_inkling_config_registered_with_auto_config():
@@ -30,13 +33,29 @@ def test_inkling_config_registered_with_auto_config():
     assert cfg.text_config.model_type == "inkling_text"
 
 
-def test_inkling_architecture_stays_registered_when_hf_inkling_is_unavailable():
-    from nemo_automodel.components.models.inkling.model import _INKLING_HF_AVAILABLE, InklingForConditionalGeneration
-    from nemo_automodel.shared.import_utils import UnavailableError
+def test_inkling_checkpoint_aliases_and_placeholder_defaults():
+    cfg = InklingConfig.from_dict(
+        {
+            "model_type": "inkling_mm_model",
+            "image_token_id": None,
+            "audio_token_id": None,
+            "text_config": {"hidden_size": 64, "num_hidden_layers": 2},
+            "vision_config": {"n_layers": 4, "n_channels": 5, "decoder_dmodel": 64},
+            "audio_config": {"n_mel_bins": 8, "mel_vocab_size": 16, "decoder_dmodel": 64},
+        }
+    )
 
+    assert cfg.image_token_id == 200054
+    assert cfg.audio_token_id == 200053
+    assert cfg.vision_config.num_hidden_layers == 4
+    assert cfg.vision_config.num_channels == 5
+    assert cfg.vision_config.text_hidden_size == 64
+    assert cfg.audio_config.text_hidden_size == 64
+
+
+def test_inkling_architecture_instantiates_from_local_config():
     assert ModelRegistry.has_custom_model("InklingForConditionalGeneration")
-    if _INKLING_HF_AVAILABLE:
-        pytest.skip("This host's transformers build ships Inkling.")
-
-    with pytest.raises(UnavailableError, match="transformers >= 5.14"):
-        InklingForConditionalGeneration.from_config(InklingConfig())
+    backend = BackendConfig(linear="torch", rms_norm="torch", experts="torch", dispatcher="torch")
+    model = InklingForConditionalGeneration.from_config(build_tiny_config(), backend=backend)
+    assert isinstance(model, InklingForConditionalGeneration)
+    assert model.config.model_type == "inkling_mm_model"

--- a/tests/unit_tests/models/inkling/test_inkling_model.py
+++ b/tests/unit_tests/models/inkling/test_inkling_model.py
@@ -20,45 +20,52 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-# The Inkling model ships in transformers >= 5.14; skip the whole module when the
-# installed transformers build predates it (e.g. the pinned release on main).
-pytest.importorskip("transformers.models.inkling", reason="transformers build without the Inkling model")
-
-from transformers.models.inkling.configuration_inkling import InklingConfig  # noqa: E402
-from transformers.models.inkling.modeling_inkling import (  # noqa: E402
-    InklingForConditionalGeneration as HFInklingForConditionalGeneration,
-)
-from transformers.models.inkling.modeling_inkling import InklingMoE as HFInklingMoE  # noqa: E402
-
-from nemo_automodel.components.datasets.vlm.collate_fns import (  # noqa: E402
+from nemo_automodel.components.datasets.vlm.collate_fns import (
     build_labels_from_template,
     default_collate_fn,
 )
-from nemo_automodel.components.models.common import BackendConfig  # noqa: E402
-from nemo_automodel.components.models.common.tie_word_embeddings import TieSupport  # noqa: E402
-from nemo_automodel.components.models.inkling.layers import InklingDenseMLP, InklingMoE  # noqa: E402
-from nemo_automodel.components.models.inkling.model import InklingForConditionalGeneration  # noqa: E402
-from nemo_automodel.components.models.inkling.state_dict_adapter import _interleave  # noqa: E402
+from nemo_automodel.components.models.common import BackendConfig
+from nemo_automodel.components.models.common.tie_word_embeddings import TieSupport
+from nemo_automodel.components.models.inkling.configuration import InklingConfig
+from nemo_automodel.components.models.inkling.layers import InklingDenseMLP, InklingMoE
+from nemo_automodel.components.models.inkling.model import InklingForConditionalGeneration
+from nemo_automodel.components.models.inkling.state_dict_adapter import _interleave
+from nemo_automodel.components.models.inkling.text import InklingAttention
 
-from .parity_check_inkling import build_tiny_config  # noqa: E402
+from .parity_check_inkling import build_tiny_config
+
+
+def _build_native_model():
+    cfg = build_tiny_config()
+    backend = BackendConfig(attn="sdpa", linear="torch", rms_norm="torch", experts="torch", dispatcher="torch")
+    nemo = InklingForConditionalGeneration.from_config(cfg, backend=backend).to(dtype=torch.float32).eval()
+    return cfg, nemo
 
 
 def _build_models():
-    cfg = build_tiny_config()
-    hf = HFInklingForConditionalGeneration(cfg).to(dtype=torch.float32).eval()
-    backend = BackendConfig(attn="sdpa", linear="torch", rms_norm="torch", experts="torch")
-    nemo = InklingForConditionalGeneration.from_config(cfg, backend=backend).to(dtype=torch.float32).eval()
+    pytest.importorskip(
+        "transformers.models.inkling",
+        reason="Reference parity requires a development Transformers build with Inkling",
+    )
+    from transformers.models.inkling.configuration_inkling import InklingConfig as HFInklingConfig
+    from transformers.models.inkling.modeling_inkling import (
+        InklingForConditionalGeneration as HFInklingForConditionalGeneration,
+    )
+
+    cfg, nemo = _build_native_model()
+    hf_config = HFInklingConfig.from_dict(cfg.to_dict())
+    hf = HFInklingForConditionalGeneration(hf_config).to(dtype=torch.float32).eval()
     return cfg, hf, nemo
 
 
 def test_sparse_layers_use_inkling_moe():
-    cfg, _, nemo = _build_models()
+    cfg, nemo = _build_native_model()
     layers = nemo.model.language_model.layers
     mlp_types = cfg.text_config.mlp_layer_types
     for i, layer in enumerate(layers):
         if mlp_types[i] == "sparse":
             assert isinstance(layer.mlp, InklingMoE)
-            assert not isinstance(layer.mlp, HFInklingMoE)
+            assert type(layer.mlp).__module__ == "nemo_automodel.components.models.inkling.layers"
         else:
             assert isinstance(layer.mlp, InklingDenseMLP)
 
@@ -102,6 +109,26 @@ def test_pipeline_metadata_uses_unpadded_vocabulary_size():
     assert outputs_meta[0].shape == (2, 16, cfg.text_config.unpadded_vocab_size)
 
 
+def test_unpadded_logits_match_pipeline_metadata_stride():
+    cfg = build_tiny_config()
+    cfg.text_config.unpadded_vocab_size = cfg.text_config.vocab_size - 8
+    backend = BackendConfig(attn="sdpa", linear="torch", rms_norm="torch", experts="torch", dispatcher="torch")
+    model = InklingForConditionalGeneration.from_config(cfg, backend=backend).eval()
+    model.initialize_weights(buffer_device=torch.device("cpu"))
+    input_ids = torch.randint(0, cfg.text_config.unpadded_vocab_size, (1, 8))
+
+    logits = model(input_ids=input_ids, attention_mask=torch.ones_like(input_ids), use_cache=False).logits
+    _, outputs_meta = model.get_pipeline_stage_metas(
+        is_first=False,
+        microbatch_size=1,
+        seq_len=input_ids.shape[1],
+        dtype=torch.float32,
+    )
+
+    assert logits.shape == outputs_meta[0].shape
+    assert logits.stride() == outputs_meta[0].stride()
+
+
 def test_requested_dtype_preserves_strict_fp32_modules():
     cfg = build_tiny_config()
     cfg.torch_dtype = torch.bfloat16
@@ -117,18 +144,232 @@ def test_requested_dtype_preserves_strict_fp32_modules():
     )
 
 
+def test_native_multimodal_forward_and_backward_are_finite():
+    cfg, model = _build_native_model()
+    model.initialize_weights(buffer_device=torch.device("cpu"))
+    model.train()
+    input_ids = torch.randint(0, cfg.text_config.vocab_size - 2, (1, 12))
+    input_ids[0, 2] = cfg.image_token_id
+    vision = cfg.vision_config
+    pixel_values = torch.randn(
+        1,
+        vision.temporal_patch_size,
+        vision.patch_size,
+        vision.patch_size,
+        vision.num_channels,
+    )
+
+    logits = model(
+        input_ids=input_ids,
+        pixel_values=pixel_values,
+        attention_mask=torch.ones_like(input_ids),
+        use_cache=False,
+    ).logits
+    assert logits.shape == (1, 12, cfg.text_config.vocab_size)
+    assert torch.isfinite(logits).all()
+
+    logits.float().square().mean().backward()
+    assert torch.isfinite(model.model.language_model.embed_tokens.weight.grad).all()
+    sparse_layer = model.model.language_model.layers[2].mlp
+    assert torch.isfinite(sparse_layer.gate.weight.grad).all()
+
+
+def test_native_cached_decode_matches_full_sequence():
+    cfg, model = _build_native_model()
+    model.initialize_weights(buffer_device=torch.device("cpu"))
+    torch.manual_seed(7)
+    input_ids = torch.randint(0, cfg.text_config.vocab_size, (1, 12))
+    attention_mask = torch.ones_like(input_ids)
+
+    with torch.no_grad():
+        full_logits = model(input_ids=input_ids, attention_mask=attention_mask, use_cache=False).logits
+        cache = None
+        cached_logits = []
+        for token_idx in range(input_ids.shape[1]):
+            outputs = model(
+                input_ids=input_ids[:, token_idx : token_idx + 1],
+                attention_mask=attention_mask[:, : token_idx + 1],
+                past_key_values=cache,
+                use_cache=True,
+            )
+            cache = outputs.past_key_values
+            cached_logits.append(outputs.logits)
+
+    torch.testing.assert_close(torch.cat(cached_logits, dim=1), full_logits, rtol=1e-4, atol=1e-5)
+
+
+def test_training_disables_implicit_cache_but_preserves_explicit_request(monkeypatch):
+    _, model = _build_native_model()
+    model.train()
+    captured_use_cache = []
+    original_forward = model.model.forward
+
+    def capture_use_cache(*args, **kwargs):
+        captured_use_cache.append(kwargs.get("use_cache"))
+        return original_forward(*args, **kwargs)
+
+    monkeypatch.setattr(model.model, "forward", capture_use_cache)
+    input_ids = torch.randint(0, model.config.text_config.vocab_size, (1, 8))
+    attention_mask = torch.ones_like(input_ids)
+
+    model(input_ids=input_ids, attention_mask=attention_mask)
+    model(input_ids=input_ids, attention_mask=attention_mask, use_cache=True)
+
+    assert captured_use_cache == [False, True]
+
+
+def test_sdpa_matches_eager_for_batched_inputs():
+    cfg, eager_model = _build_native_model()
+    eager_model.initialize_weights(buffer_device=torch.device("cpu"))
+    sdpa_cfg = build_tiny_config()
+    sdpa_cfg.text_config._attn_implementation = "sdpa"
+    backend = BackendConfig(attn="sdpa", linear="torch", rms_norm="torch", experts="torch", dispatcher="torch")
+    sdpa_model = InklingForConditionalGeneration.from_config(sdpa_cfg, backend=backend).float().eval()
+    sdpa_model.load_state_dict(eager_model.state_dict())
+    input_ids = torch.randint(0, cfg.text_config.vocab_size, (2, 20))
+    attention_mask = torch.ones_like(input_ids)
+
+    with torch.no_grad():
+        eager_logits = eager_model(input_ids=input_ids, attention_mask=attention_mask, use_cache=False).logits
+        sdpa_logits = sdpa_model(input_ids=input_ids, attention_mask=attention_mask, use_cache=False).logits
+
+    assert sdpa_model.model.language_model.layers[0].self_attn.attention_backend == "sdpa"
+    torch.testing.assert_close(sdpa_logits, eager_logits, rtol=1e-4, atol=1e-5)
+
+
+def test_sdpa_casts_fp32_short_convolution_outputs_to_query_dtype(monkeypatch):
+    cfg = build_tiny_config().text_config
+    cfg.torch_dtype = torch.bfloat16
+    cfg._attn_implementation = "sdpa"
+    backend = BackendConfig(attn="sdpa", linear="torch", rms_norm="torch", experts="torch", dispatcher="torch")
+    attention = InklingAttention(cfg, layer_idx=0, backend=backend).eval()
+
+    for short_convolution in (attention.k_sconv, attention.v_sconv):
+        original_forward = short_convolution.forward
+
+        def return_fp32(*args, _forward=original_forward, **kwargs):
+            return _forward(*args, **kwargs).float()
+
+        monkeypatch.setattr(short_convolution, "forward", return_fp32)
+
+    hidden_states = torch.randn(1, 8, cfg.hidden_size, dtype=torch.bfloat16)
+    attention_mask = torch.zeros(1, 1, 8, 8, dtype=torch.bfloat16)
+    output, probabilities = attention(hidden_states, attention_mask)
+
+    assert output.dtype == torch.bfloat16
+    assert probabilities is None
+
+
+def test_decoder_layer_restores_model_dtype_around_fp32_modules(monkeypatch):
+    cfg = build_tiny_config()
+    cfg.torch_dtype = torch.bfloat16
+    cfg.text_config.torch_dtype = torch.bfloat16
+    cfg.text_config._attn_implementation = "sdpa"
+    backend = BackendConfig(attn="sdpa", linear="torch", rms_norm="torch_fp32", experts="torch", dispatcher="torch")
+    model = InklingForConditionalGeneration.from_config(cfg, backend=backend)
+    model.initialize_weights(buffer_device=torch.device("cpu"))
+    layer = model.model.language_model.layers[0].eval()
+
+    for short_convolution in (layer.attn_sconv, layer.mlp_sconv):
+        original_forward = short_convolution.forward
+
+        def return_fp32(*args, _forward=original_forward, **kwargs):
+            return _forward(*args, **kwargs).float()
+
+        monkeypatch.setattr(short_convolution, "forward", return_fp32)
+
+    hidden_states = torch.randn(1, 8, cfg.text_config.hidden_size, dtype=torch.bfloat16)
+    attention_mask = torch.zeros(1, 1, 8, 8, dtype=torch.bfloat16)
+    output = layer(hidden_states, attention_mask)
+
+    assert output.dtype == torch.bfloat16
+
+
+def test_native_state_dict_roundtrip_is_exact():
+    _, model = _build_native_model()
+    model.initialize_weights(buffer_device=torch.device("cpu"))
+    native_state = model.state_dict()
+    raw_state = model.state_dict_adapter.to_hf(native_state)
+    roundtrip_state = model.state_dict_adapter.from_hf(raw_state)
+
+    assert set(roundtrip_state) == set(native_state)
+    for key, value in native_state.items():
+        assert torch.equal(value, roundtrip_state[key]), f"round-trip mismatch for {key}"
+
+
 def test_processor_builder_configures_padding(monkeypatch):
     from nemo_automodel.components.models.inkling import processing
 
+    class FakeProcessor:
+        @classmethod
+        def get_processor_dict(cls, *_args, **_kwargs):
+            return {"image_processor": {}, "feature_extractor": {}}, {}
+
+        def __init__(self, feature_extractor, image_processor, tokenizer, **_kwargs):
+            self.feature_extractor = feature_extractor
+            self.image_processor = image_processor
+            self.tokenizer = tokenizer
+
     tokenizer = SimpleNamespace(eos_token_id=None, pad_token_id=None, eos_token=None, pad_token=None)
-    expected = SimpleNamespace(tokenizer=tokenizer)
-    monkeypatch.setattr(processing.AutoProcessor, "from_pretrained", lambda *_args, **_kwargs: expected)
+    monkeypatch.setattr(processing, "InklingProcessor", FakeProcessor)
+    monkeypatch.setattr(processing, "InklingFeatureExtractor", lambda **_kwargs: "feature")
+    monkeypatch.setattr(processing, "InklingImageProcessor", lambda **_kwargs: "image")
+    monkeypatch.setattr(processing.AutoTokenizer, "from_pretrained", lambda *_args, **_kwargs: tokenizer)
 
     actual = processing.build_inkling_processor("thinkingmachines/Inkling")
 
-    assert actual is expected
+    assert isinstance(actual, FakeProcessor)
+    assert actual.feature_extractor == "feature"
+    assert actual.image_processor == "image"
     assert tokenizer.eos_token == "<|content_model_end_sampling|>"
     assert tokenizer.pad_token == tokenizer.eos_token
+
+
+def test_native_processor_expands_image_and_audio_placeholders():
+    from tokenizers import Tokenizer
+    from tokenizers.models import WordLevel
+    from tokenizers.pre_tokenizers import WhitespaceSplit
+    from transformers import PreTrainedTokenizerFast
+
+    from nemo_automodel.components.models.inkling.feature_extraction import InklingFeatureExtractor
+    from nemo_automodel.components.models.inkling.image_processing import InklingImageProcessor
+    from nemo_automodel.components.models.inkling.processing import InklingProcessor
+
+    vocab = {
+        "[UNK]": 0,
+        "[PAD]": 1,
+        "<|unused_200054|>": 2,
+        "<|unused_200053|>": 3,
+        "<|content_image|>": 4,
+        "<|content_audio_input|>": 5,
+    }
+    tokenizer_backend = Tokenizer(WordLevel(vocab=vocab, unk_token="[UNK]"))
+    tokenizer_backend.pre_tokenizer = WhitespaceSplit()
+    tokenizer = PreTrainedTokenizerFast(
+        tokenizer_object=tokenizer_backend,
+        unk_token="[UNK]",
+        pad_token="[PAD]",
+    )
+    tokenizer.add_special_tokens({"additional_special_tokens": list(vocab)[2:]})
+    processor = InklingProcessor(
+        InklingFeatureExtractor(feature_size=8, sampling_rate=1600, audio_token_duration_s=0.05),
+        InklingImageProcessor(size={"height": 8, "width": 8}),
+        tokenizer,
+    )
+
+    outputs = processor(
+        text=["<|unused_200054|> <|unused_200053|>"],
+        images=[torch.rand(3, 9, 15)],
+        audio=[torch.randn(160)],
+        sampling_rate=1600,
+        return_tensors="pt",
+    )
+
+    assert outputs.pixel_values.shape == (4, 2, 8, 8, 3)
+    assert outputs.audio_input_ids.shape == (1, 2, 8)
+    assert outputs.audio_input_ids_mask.shape == (1, 2)
+    assert (outputs.input_ids == processor.image_token_id).sum() == 4
+    assert (outputs.input_ids == processor.audio_token_id).sum() == 2
 
 
 def test_inkling_collator_does_not_require_qwen_vl_utils(monkeypatch):


### PR DESCRIPTION
## Summary

- cherry-pick #3358 into r0.6.0
- remove the runtime dependency on transformers.models.inkling and create_recurrent_attention_mask
- restore the inkling_medpix recipe with the pinned Transformers 5.12.1 release environment

## Root cause

r0.6.0 contains the original Inkling onboarding (#3095) but not the standalone implementation from #3358. Because r0.6.0 pins Transformers 5.12.1, model construction raises UnavailableError before training.

Tracks AMINT-258.

## Validation

- reproduced on r0.6.0 fedc9086 using the real checkpoint reduced to 4 layers, FSDP2/EP8, 8xH100: exact UnavailableError, exit 1
- post-fix same 4-layer EP8 run: completed 10/10 training steps plus validation, exit 0; step 9 loss 12.6229, grad norm 37.7844, validation loss 12.5480
- Inkling focused unit tests: 21 passed, 6 skipped
- ruff check and ruff format --check: passed
- scoped NeMo-CI inkling_medpix: pending

## Pre-checks

- [x] Cherry-pick records the upstream commit with -x
- [x] DCO sign-off present
- [x] Focused unit tests, lint, and 4-layer training pass