### PR TITLE
fix(test): use the recipe's attention backend for the HF reload parity check

### DIFF
--- a/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
+++ b/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
@@ -1560,6 +1560,12 @@ def _run_vanilla_hf_reload(
         for key in ("revision", "token"):
             if model_kwargs.get(key) is not None:
                 hf_kwargs[key] = model_kwargs[key]
+        # Load HF with the attention backend the recipe pins, the same way the
+        # source-load phase does. Attention backends are not bit-identical in bf16,
+        # so without this the two sides can run different backends and the reload
+        # reports a logit gap that the checkpoint did not cause.
+        if model_kwargs.get("attn_implementation") is not None:
+            hf_kwargs["attn_implementation"] = model_kwargs["attn_implementation"]
         # Remote-code models can ship attention names that transformers 5.x
         # rejects. Select a supported implementation while keeping Nemotron-H
         # off HF's incompatible FlashAttention varlen path.


### PR DESCRIPTION
## Why

Gemma4-2B VLM checkpoint robustness fails Phase 4 (HF reload parity) with max KL `3.489082e-02` against a `2e-2` threshold, reported in NVBug 6513644. The same test passes in nemo-ci since its run with WORLD_SIZE=8 while NVBug has 2. In nemo-ci the KL div falls just below the threshold of 2e-2 and passes. But with 2 GPUs its above the threshold. 

## Root cause

The HF reload phase builds its `from_pretrained` kwargs from scratch and never copies the recipe's `attn_implementation`, so vanilla HF falls back to its own default. `gemma4_2b.yaml` pins `eager`; transformers 5.x resolves to `sdpa`.

Attention backends are not bit-identical in bf16, so the two sides computed different logits from byte-identical weights. The source-load phase does not have this bug -- `_hf_source_load_kwargs` already lists `attn_implementation` in `hf_allowed_keys` -- which is why only the reload phase diverged.

## Fix

Forward the recipe's `attn_implementation` into the reload kwargs, mirroring the source-load phase. The recipe-pinned value wins; the existing remote-code selection stays as the fallback.

## Validation

Same checkpoint, same token IDs, measured against the saved reference logits:

| HF load | resolved backend | max KL vs reference |
|---|---|---|
| default (before this PR) | `sdpa` | 3.489082e-02 |
| `attn_implementation='sdpa'` | `sdpa` | 3.489082e-02 |
| `attn_implementation='eager'` | `eager` | **0.000000e+00** |

Ruled out the checkpoint first: the consolidated export is bit-identical to the training shards (0 mismatches across all 1951 tensors), and the exported config differs from source only in benign transformers defaults.

Full `gemma4_2b` checkpoint robustness run, 8xH100, exit 0:

| Phase | Before | After | Threshold |
|---|---|---|---|
| 0 source-load | 0.0 | 0.0 | 5e-3 |
| 3 automodel reload | 0.0 | 0.0 | 0.0 |
| 4 HF reload | 1.168239e-02 | **0.0** | 2e-2 |
| 6 resume | pass | pass | -- |

The gap scales with the trained weights, so it moves with world size and passing CI runs are affected too: nemo-ci job 390379862 reports Phase 4 `1.168239e-02` against the `2e-2` threshold while Phase 0, which already forwards the backend, is bit-exact. That number reproduces locally at 8 GPUs to all 7 digits; at 2 GPUs the same defect crosses the threshold at `3.489082e-02`. **With the fix both world sizes report `0.0`**

121 recipes pin `attn_implementation`. The source-load phase already passes the same value to the same HF class for all of them, so the load path is proven; the effect on other recipes is to tighten Phase 4, not loosen it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)