### PR TITLE
fix(checkpoint): validate PEFT adapter-only state

### DIFF
--- a/examples/llm_finetune/nemotron_flash/nemotron_flash_1b_squad_peft.yaml
+++ b/examples/llm_finetune/nemotron_flash/nemotron_flash_1b_squad_peft.yaml
@@ -113,11 +113,11 @@ ci:
   time: "00:15:00"
   checkpoint_robustness:
     hf_kl_threshold: 5e-3
-    # tp_size=2 with bf16 row-parallel all-reduces produces ULP-level drift
-    # (~1e-3) between trainer and restored logits even with bit-identical
-    # weights; relax the Phase-3 threshold accordingly.
     kl_threshold: 5e-3
-    distributed.tp_size: 2
+    # Nemotron Flash's hybrid Mamba/DeltaNet layers do not have a native TP
+    # plan. Keep checkpoint reload and strict resume parity on the recipe's
+    # supported TP=1 topology instead of introducing row-parallel BF16 drift.
+    distributed.tp_size: 1
     tokenizer_name: nvidia/Nemotron-Flash-1B
     trust_remote_code: true
     check_fused_qkv_keys: true

--- a/examples/llm_finetune/qwen/qwen3_moe_30b_lora.yaml
+++ b/examples/llm_finetune/qwen/qwen3_moe_30b_lora.yaml
@@ -107,11 +107,7 @@ ci:
   env_vars:
     PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True"
   checkpoint_robustness:
-    # The vanilla-HF vs optimized EP runtime comparison is not a checkpoint
-    # oracle and is unstable for this recipe (the same image has ranged from
-    # 1e-2 to O(1e1) max KL). Keep exact AutoModel reload and saved-adapter
-    # fingerprint checks as the blocking checkpoint-integrity gates.
-    check_source_load_parity: false
+    check_source_load_parity: true
     # HF+PEFT reload remains gated by exact adapter fingerprints and a successful
     # forward; its live-LoRA logits are not a stable cross-runtime reference (AMINT-216).
     skip_hf_logit_parity: true

--- a/examples/llm_finetune/qwen/qwen3_moe_30b_lora.yaml
+++ b/examples/llm_finetune/qwen/qwen3_moe_30b_lora.yaml
@@ -106,6 +106,7 @@ ci:
   nodes: 1
   env_vars:
     PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True"
+    CHECKPOINT_ROBUSTNESS_VERIFY_SOURCE_EXPERTS: "1"
   checkpoint_robustness:
     check_source_load_parity: true
     # HF+PEFT reload remains gated by exact adapter fingerprints and a successful

--- a/examples/llm_finetune/qwen/qwen3_moe_30b_lora.yaml
+++ b/examples/llm_finetune/qwen/qwen3_moe_30b_lora.yaml
@@ -106,7 +106,6 @@ ci:
   nodes: 1
   env_vars:
     PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True"
-    CHECKPOINT_ROBUSTNESS_VERIFY_SOURCE_EXPERTS: "1"
   checkpoint_robustness:
     check_source_load_parity: true
     # HF+PEFT reload remains gated by exact adapter fingerprints and a successful

--- a/examples/llm_finetune/qwen/qwen3_moe_30b_lora.yaml
+++ b/examples/llm_finetune/qwen/qwen3_moe_30b_lora.yaml
@@ -107,7 +107,11 @@ ci:
   env_vars:
     PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True"
   checkpoint_robustness:
-    check_source_load_parity: true
+    # The vanilla-HF vs optimized EP runtime comparison is not a checkpoint
+    # oracle and is unstable for this recipe (the same image has ranged from
+    # 1e-2 to O(1e1) max KL). Keep exact AutoModel reload and saved-adapter
+    # fingerprint checks as the blocking checkpoint-integrity gates.
+    check_source_load_parity: false
     # HF+PEFT reload remains gated by exact adapter fingerprints and a successful
     # forward; its live-LoRA logits are not a stable cross-runtime reference (AMINT-216).
     skip_hf_logit_parity: true

--- a/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
+++ b/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
@@ -1317,8 +1317,12 @@ def _report_qwen_source_expert_weight_parity(model, cfg) -> None:
     from safetensors import safe_open
 
     named_parameters = dict(unwrapped.named_parameters())
-    gate_up_name = next(name for name in named_parameters if name.endswith("layers.0.mlp.experts.gate_and_up_projs"))
-    down_name = next(name for name in named_parameters if name.endswith("layers.0.mlp.experts.down_projs"))
+    gate_up_name = next(
+        name for name in named_parameters if "layers.0.mlp.experts" in name and name.endswith("gate_and_up_projs")
+    )
+    down_name = next(
+        name for name in named_parameters if "layers.0.mlp.experts" in name and name.endswith("down_projs")
+    )
     gate_up = named_parameters[gate_up_name].detach()
     down = named_parameters[down_name].detach()
     if isinstance(gate_up, DTensor):

--- a/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
+++ b/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
@@ -1305,6 +1305,65 @@ def _get_logits(model, input_ids, device, trainer=None) -> torch.Tensor:
         return logits.float().cpu()
 
 
+def _report_qwen_source_expert_weight_parity(model, cfg) -> None:
+    """Compare one rank-0 grouped expert directly with its cached HF tensors."""
+    if os.environ.get("CHECKPOINT_ROBUSTNESS_VERIFY_SOURCE_EXPERTS", "0") != "1" or not _rank0():
+        return
+    unwrapped = getattr(model, "module", model)
+    if getattr(getattr(unwrapped, "config", None), "model_type", None) != "qwen3_moe":
+        return
+
+    from huggingface_hub import try_to_load_from_cache
+    from safetensors import safe_open
+
+    named_parameters = dict(unwrapped.named_parameters())
+    gate_up_name = next(name for name in named_parameters if name.endswith("layers.0.mlp.experts.gate_and_up_projs"))
+    down_name = next(name for name in named_parameters if name.endswith("layers.0.mlp.experts.down_projs"))
+    gate_up = named_parameters[gate_up_name].detach()
+    down = named_parameters[down_name].detach()
+    if isinstance(gate_up, DTensor):
+        gate_up = gate_up.to_local()
+    if isinstance(down, DTensor):
+        down = down.to_local()
+
+    model_path = str(cfg.model.pretrained_model_name_or_path)
+    revision = cfg.model.get("revision", None)
+    index_path = try_to_load_from_cache(model_path, "model.safetensors.index.json", revision=revision or "main")
+    assert isinstance(index_path, str), f"No cached safetensors index for {model_path}"
+    weight_map = json.loads(Path(index_path).read_text())["weight_map"]
+    hf_keys = {
+        "gate": "model.layers.0.mlp.experts.0.gate_proj.weight",
+        "up": "model.layers.0.mlp.experts.0.up_proj.weight",
+        "down": "model.layers.0.mlp.experts.0.down_proj.weight",
+    }
+    references = {}
+    for label, key in hf_keys.items():
+        shard_path = try_to_load_from_cache(model_path, weight_map[key], revision=revision or "main")
+        assert isinstance(shard_path, str), f"No cached safetensors shard for {key}"
+        with safe_open(shard_path, framework="pt") as shard:
+            references[label] = shard.get_tensor(key)
+
+    inter_dim = references["gate"].shape[0]
+    candidates = {
+        "gate": gate_up[0, :, :inter_dim].transpose(0, 1).cpu(),
+        "up": gate_up[0, :, inter_dim:].transpose(0, 1).cpu(),
+        "down": down[0].transpose(0, 1).cpu(),
+    }
+    for label in ("gate", "up", "down"):
+        reference = references[label]
+        candidate = candidates[label]
+        difference = candidate.float() - reference.float()
+        print(
+            "[Phase 0] Source expert weight parity: "
+            f"projection={label} exact={torch.equal(candidate, reference)} "
+            f"max_abs={difference.abs().max().item():.6e} "
+            f"mean_abs={difference.abs().mean().item():.6e} "
+            f"candidate_sha256={_tensor_digest(candidate)['sha256']} "
+            f"reference_sha256={_tensor_digest(reference)['sha256']}",
+            flush=True,
+        )
+
+
 def _reinit_rotary_per_module(model, default_device):
     """Recompute DeciLM / Gemma3 style non-persistent rotary buffers on each
     module's own device.
@@ -1850,6 +1909,7 @@ def _run_process_isolated_checkpoint_phase(
 
         source_trainer = recipe_cls(cfg)
         source_trainer.setup()
+        _report_qwen_source_expert_weight_parity(source_trainer.model_parts[0], cfg)
         _report_phase("Isolated Phase 0b source parity: trainer setup complete; starting parity forward")
         if tokenizer_name is not None and dist.is_initialized() and dist.get_world_size() > 1:
             _barrier()

--- a/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
+++ b/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
@@ -34,7 +34,6 @@ import inspect
 import json
 import math
 import os
-import re
 import sys
 import time
 import traceback
@@ -1306,68 +1305,6 @@ def _get_logits(model, input_ids, device, trainer=None) -> torch.Tensor:
         return logits.float().cpu()
 
 
-def _report_qwen_source_expert_weight_parity(model, cfg) -> None:
-    """Compare one rank-0 grouped expert directly with its cached HF tensors."""
-    if os.environ.get("CHECKPOINT_ROBUSTNESS_VERIFY_SOURCE_EXPERTS", "0") != "1" or not _rank0():
-        return
-    unwrapped = getattr(model, "module", model)
-    if getattr(getattr(unwrapped, "config", None), "model_type", None) != "qwen3_moe":
-        return
-
-    from huggingface_hub import try_to_load_from_cache
-    from safetensors import safe_open
-
-    native_state = unwrapped.state_dict()
-    gate_up_name = next(name for name in native_state if name.endswith("mlp.experts.gate_and_up_projs"))
-    layer_num = int(re.search(r"layers\.(\d+)\.", gate_up_name).group(1))
-    down_name = next(
-        name for name in native_state if f"layers.{layer_num}." in name and name.endswith("mlp.experts.down_projs")
-    )
-    gate_up = native_state[gate_up_name].detach()
-    down = native_state[down_name].detach()
-    if isinstance(gate_up, DTensor):
-        gate_up = gate_up.to_local()
-    if isinstance(down, DTensor):
-        down = down.to_local()
-
-    model_path = str(cfg.model.pretrained_model_name_or_path)
-    revision = cfg.model.get("revision", None)
-    index_path = try_to_load_from_cache(model_path, "model.safetensors.index.json", revision=revision or "main")
-    assert isinstance(index_path, str), f"No cached safetensors index for {model_path}"
-    weight_map = json.loads(Path(index_path).read_text())["weight_map"]
-    hf_keys = {
-        "gate": f"model.layers.{layer_num}.mlp.experts.0.gate_proj.weight",
-        "up": f"model.layers.{layer_num}.mlp.experts.0.up_proj.weight",
-        "down": f"model.layers.{layer_num}.mlp.experts.0.down_proj.weight",
-    }
-    references = {}
-    for label, key in hf_keys.items():
-        shard_path = try_to_load_from_cache(model_path, weight_map[key], revision=revision or "main")
-        assert isinstance(shard_path, str), f"No cached safetensors shard for {key}"
-        with safe_open(shard_path, framework="pt") as shard:
-            references[label] = shard.get_tensor(key)
-
-    inter_dim = references["gate"].shape[0]
-    candidates = {
-        "gate": gate_up[0, :, :inter_dim].transpose(0, 1).cpu(),
-        "up": gate_up[0, :, inter_dim:].transpose(0, 1).cpu(),
-        "down": down[0].transpose(0, 1).cpu(),
-    }
-    for label in ("gate", "up", "down"):
-        reference = references[label]
-        candidate = candidates[label]
-        difference = candidate.float() - reference.float()
-        print(
-            "[Phase 0] Source expert weight parity: "
-            f"projection={label} exact={torch.equal(candidate, reference)} "
-            f"max_abs={difference.abs().max().item():.6e} "
-            f"mean_abs={difference.abs().mean().item():.6e} "
-            f"candidate_sha256={_tensor_digest(candidate)['sha256']} "
-            f"reference_sha256={_tensor_digest(reference)['sha256']}",
-            flush=True,
-        )
-
-
 def _reinit_rotary_per_module(model, default_device):
     """Recompute DeciLM / Gemma3 style non-persistent rotary buffers on each
     module's own device.
@@ -1913,7 +1850,6 @@ def _run_process_isolated_checkpoint_phase(
 
         source_trainer = recipe_cls(cfg)
         source_trainer.setup()
-        _report_qwen_source_expert_weight_parity(source_trainer.model_parts[0], cfg)
         _report_phase("Isolated Phase 0b source parity: trainer setup complete; starting parity forward")
         if tokenizer_name is not None and dist.is_initialized() and dist.get_world_size() > 1:
             _barrier()
@@ -1928,24 +1864,6 @@ def _run_process_isolated_checkpoint_phase(
             device,
             trainer=source_trainer,
         )
-        repeated_trainer_source_logits = _get_logits(
-            source_trainer.model_parts[0],
-            input_ids,
-            device,
-            trainer=source_trainer,
-        )
-        if _rank0():
-            repeat_kl = _kl_divergence_from_logits(trainer_source_logits, repeated_trainer_source_logits)
-            repeat_cosine = _cosine_similarity_from_logits(
-                trainer_source_logits,
-                repeated_trainer_source_logits,
-            )
-            repeat_max_abs = (trainer_source_logits - repeated_trainer_source_logits).abs().max().item()
-            print(
-                "[Phase 0] Constructed-trainer repeated-forward stability: "
-                f"max KL={repeat_kl.max().item():.6e}; mean KL={repeat_kl.mean().item():.6e}; "
-                f"max abs={repeat_max_abs:.6e}; cosine={repeat_cosine:.8f}"
-            )
         source_load_reference = None
         if _rank0():
             metadata = json.loads(metadata_path.read_text())

--- a/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
+++ b/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
@@ -1868,6 +1868,24 @@ def _run_process_isolated_checkpoint_phase(
             device,
             trainer=source_trainer,
         )
+        repeated_trainer_source_logits = _get_logits(
+            source_trainer.model_parts[0],
+            input_ids,
+            device,
+            trainer=source_trainer,
+        )
+        if _rank0():
+            repeat_kl = _kl_divergence_from_logits(trainer_source_logits, repeated_trainer_source_logits)
+            repeat_cosine = _cosine_similarity_from_logits(
+                trainer_source_logits,
+                repeated_trainer_source_logits,
+            )
+            repeat_max_abs = (trainer_source_logits - repeated_trainer_source_logits).abs().max().item()
+            print(
+                "[Phase 0] Constructed-trainer repeated-forward stability: "
+                f"max KL={repeat_kl.max().item():.6e}; mean KL={repeat_kl.mean().item():.6e}; "
+                f"max abs={repeat_max_abs:.6e}; cosine={repeat_cosine:.8f}"
+            )
         source_load_reference = None
         if _rank0():
             metadata = json.loads(metadata_path.read_text())

--- a/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
+++ b/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
@@ -34,6 +34,7 @@ import inspect
 import json
 import math
 import os
+import re
 import sys
 import time
 import traceback
@@ -1316,15 +1317,14 @@ def _report_qwen_source_expert_weight_parity(model, cfg) -> None:
     from huggingface_hub import try_to_load_from_cache
     from safetensors import safe_open
 
-    named_parameters = dict(unwrapped.named_parameters())
-    gate_up_name = next(
-        name for name in named_parameters if "layers.0.mlp.experts" in name and name.endswith("gate_and_up_projs")
-    )
+    native_state = unwrapped.state_dict()
+    gate_up_name = next(name for name in native_state if name.endswith("mlp.experts.gate_and_up_projs"))
+    layer_num = int(re.search(r"layers\.(\d+)\.", gate_up_name).group(1))
     down_name = next(
-        name for name in named_parameters if "layers.0.mlp.experts" in name and name.endswith("down_projs")
+        name for name in native_state if f"layers.{layer_num}." in name and name.endswith("mlp.experts.down_projs")
     )
-    gate_up = named_parameters[gate_up_name].detach()
-    down = named_parameters[down_name].detach()
+    gate_up = native_state[gate_up_name].detach()
+    down = native_state[down_name].detach()
     if isinstance(gate_up, DTensor):
         gate_up = gate_up.to_local()
     if isinstance(down, DTensor):
@@ -1336,9 +1336,9 @@ def _report_qwen_source_expert_weight_parity(model, cfg) -> None:
     assert isinstance(index_path, str), f"No cached safetensors index for {model_path}"
     weight_map = json.loads(Path(index_path).read_text())["weight_map"]
     hf_keys = {
-        "gate": "model.layers.0.mlp.experts.0.gate_proj.weight",
-        "up": "model.layers.0.mlp.experts.0.up_proj.weight",
-        "down": "model.layers.0.mlp.experts.0.down_proj.weight",
+        "gate": f"model.layers.{layer_num}.mlp.experts.0.gate_proj.weight",
+        "up": f"model.layers.{layer_num}.mlp.experts.0.up_proj.weight",
+        "down": f"model.layers.{layer_num}.mlp.experts.0.down_proj.weight",
     }
     references = {}
     for label, key in hf_keys.items():

--- a/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
+++ b/tests/functional_tests/checkpoint_robustness/test_checkpoint_robustness_llm.py
@@ -446,7 +446,11 @@ def _assert_peft_adapter_matches_checkpoint(
     from safetensors import safe_open
 
     assert adapter_path.exists(), f"adapter_model.safetensors not found at {adapter_path}"
-    loaded_adapter = get_peft_model_state_dict(peft_model)
+    # This comparison is against AutoModel's adapter-only safetensors export.
+    # PEFT's default ``save_embedding_layers="auto"`` treats a targeted output
+    # head as an embedding and adds its base-layer weight, even though that
+    # tensor is not adapter state and is intentionally absent from the file.
+    loaded_adapter = get_peft_model_state_dict(peft_model, save_embedding_layers=False)
     normalized_parameter_names = {}
     if any(tensor.is_meta for tensor in loaded_adapter.values()):
         for parameter_name, _ in peft_model.named_parameters():
@@ -462,19 +466,11 @@ def _assert_peft_adapter_matches_checkpoint(
         ignored_missing = [key for key in missing if ignored_key_prefix and key.startswith(ignored_key_prefix)]
         required_missing = sorted(set(missing) - set(ignored_missing))
         unexpected = sorted(loaded_keys - expected_keys)
-        # PEFT can expose the wrapped output head's base-layer tensor from
-        # get_peft_model_state_dict even though it is not adapter state and was
-        # therefore not written to adapter_model.safetensors. Keep unexpected
-        # adapter tensors strict while excluding this base-model-only value.
-        ignored_unexpected = [key for key in unexpected if ".lm_head.base_layer." in key]
-        required_unexpected = sorted(set(unexpected) - set(ignored_unexpected))
-        assert not required_missing and not required_unexpected, (
+        assert not required_missing and not unexpected, (
             "Vanilla PEFT adapter key mismatch: "
-            f"missing={required_missing[:10]}, unexpected={required_unexpected[:10]}, "
-            f"ignored_missing={ignored_missing[:10]}, ignored_non_adapter={ignored_unexpected[:10]}"
+            f"missing={required_missing[:10]}, unexpected={unexpected[:10]}, "
+            f"ignored_missing={ignored_missing[:10]}"
         )
-        if ignored_unexpected:
-            print(f"[HF reload] Ignored PEFT-reported non-adapter base-layer tensors: {ignored_unexpected}")
 
         mismatches = []
         matched_keys = expected_keys - set(ignored_missing)

--- a/tests/unit_tests/ci_tests/test_checkpoint_robustness_hf_kwargs.py
+++ b/tests/unit_tests/ci_tests/test_checkpoint_robustness_hf_kwargs.py
@@ -122,23 +122,29 @@ def test_peft_adapter_fingerprints_match_saved_safetensors(tmp_path):
     assert ignored == 0
 
 
-def test_peft_adapter_fingerprints_ignore_reported_base_layer_tensor(tmp_path):
+def test_peft_adapter_fingerprints_disable_peft_auto_embedding_export(tmp_path):
     from safetensors.torch import save_file
 
     adapter_path = tmp_path / "adapter_model.safetensors"
     adapter_key = "base_model.model.lm_head.lora_A.weight"
     saved_state = {adapter_key: torch.tensor([[1.0, 2.0]], dtype=torch.bfloat16)}
-    loaded_state = {
-        adapter_key: saved_state[adapter_key].clone(),
-        "base_model.model.lm_head.base_layer.weight": torch.tensor([[3.0, 4.0]], dtype=torch.bfloat16),
-    }
     save_file(saved_state, adapter_path)
 
-    with patch("peft.get_peft_model_state_dict", return_value=loaded_state):
-        matched, ignored = _assert_peft_adapter_matches_checkpoint(Mock(), adapter_path)
+    def get_peft_state_dict(_model, *, save_embedding_layers="auto"):
+        loaded_state = {adapter_key: saved_state[adapter_key].clone()}
+        if save_embedding_layers == "auto":
+            loaded_state["base_model.model.lm_head.base_layer.weight"] = torch.tensor(
+                [[3.0, 4.0]], dtype=torch.bfloat16
+            )
+        return loaded_state
+
+    peft_model = Mock()
+    with patch("peft.get_peft_model_state_dict", side_effect=get_peft_state_dict) as get_state_dict:
+        matched, ignored = _assert_peft_adapter_matches_checkpoint(peft_model, adapter_path)
 
     assert matched == 1
     assert ignored == 0
+    get_state_dict.assert_called_once_with(peft_model, save_embedding_layers=False)
 
 
 def test_peft_adapter_fingerprints_allow_configured_hf_unsupported_prefix(tmp_path):

--- a/tests/unit_tests/ci_tests/test_config_resolver.py
+++ b/tests/unit_tests/ci_tests/test_config_resolver.py
@@ -301,6 +301,21 @@ def test_end_to_end_robustness_peft_disables_triton(tmp_path):
     assert resolved["peft"]["use_triton"] is False
 
 
+def test_nemotron_flash_peft_robustness_keeps_supported_tp_topology(tmp_path):
+    """Flash checkpoint reload must not opt into unsupported TP and numerical resume drift."""
+    recipe_path = REPO_ROOT / "examples/llm_finetune/nemotron_flash/nemotron_flash_1b_squad_peft.yaml"
+    out = tmp_path / "resolved.yaml"
+    env = {"PIPELINE_DIR": str(tmp_path), "TEST_NAME": recipe_path.stem}
+    _run_resolver(
+        ["--base", str(recipe_path), "--phase", "checkpoint_robustness", "--output", str(out)],
+        env=env,
+    )
+
+    resolved = yaml.load(out.open())
+    assert resolved["distributed"]["tp_size"] == 1
+    assert "resume_first_loss_threshold" not in resolved["ci"]["checkpoint_robustness"]
+
+
 def test_end_to_end_fixture_keys_not_applied_as_overrides(tmp_path):
     """Non-config fixture-arg keys in ci.checkpoint_robustness must not leak into the top-level config."""
     recipe = tmp_path / "llama_squad.yaml"

--- a/tests/unit_tests/ci_tests/test_config_resolver.py
+++ b/tests/unit_tests/ci_tests/test_config_resolver.py
@@ -316,6 +316,22 @@ def test_nemotron_flash_peft_robustness_keeps_supported_tp_topology(tmp_path):
     assert "resume_first_loss_threshold" not in resolved["ci"]["checkpoint_robustness"]
 
 
+def test_qwen3_moe_lora_robustness_keeps_checkpoint_gates_without_source_parity(tmp_path):
+    """Qwen MoE LoRA retains checkpoint reload coverage without its unstable runtime comparison."""
+    recipe_path = REPO_ROOT / "examples/llm_finetune/qwen/qwen3_moe_30b_lora.yaml"
+    out = tmp_path / "resolved.yaml"
+    env = {"PIPELINE_DIR": str(tmp_path), "TEST_NAME": recipe_path.stem}
+    _run_resolver(
+        ["--base", str(recipe_path), "--phase", "checkpoint_robustness", "--output", str(out)],
+        env=env,
+    )
+
+    robustness = yaml.load(out.open())["ci"]["checkpoint_robustness"]
+    assert robustness["check_source_load_parity"] is False
+    assert "skip_automodel_logit_parity" not in robustness
+    assert robustness["skip_hf_logit_parity"] is True
+
+
 def test_end_to_end_fixture_keys_not_applied_as_overrides(tmp_path):
     """Non-config fixture-arg keys in ci.checkpoint_robustness must not leak into the top-level config."""
     recipe = tmp_path / "llama_squad.yaml"

--- a/tests/unit_tests/ci_tests/test_config_resolver.py
+++ b/tests/unit_tests/ci_tests/test_config_resolver.py
@@ -316,8 +316,8 @@ def test_nemotron_flash_peft_robustness_keeps_supported_tp_topology(tmp_path):
     assert "resume_first_loss_threshold" not in resolved["ci"]["checkpoint_robustness"]
 
 
-def test_qwen3_moe_lora_robustness_keeps_checkpoint_gates_without_source_parity(tmp_path):
-    """Qwen MoE LoRA retains checkpoint reload coverage without its unstable runtime comparison."""
+def test_qwen3_moe_lora_robustness_keeps_source_and_checkpoint_gates(tmp_path):
+    """Qwen MoE LoRA retains both source-load and checkpoint reload coverage."""
     recipe_path = REPO_ROOT / "examples/llm_finetune/qwen/qwen3_moe_30b_lora.yaml"
     out = tmp_path / "resolved.yaml"
     env = {"PIPELINE_DIR": str(tmp_path), "TEST_NAME": recipe_path.stem}
@@ -327,7 +327,7 @@ def test_qwen3_moe_lora_robustness_keeps_checkpoint_gates_without_source_parity(
     )
 
     robustness = yaml.load(out.open())["ci"]["checkpoint_robustness"]
-    assert robustness["check_source_load_parity"] is False
+    assert robustness["check_source_load_parity"] is True
     assert "skip_automodel_logit_parity" not in robustness
     assert robustness["skip_hf_logit_parity"] is True
 


### PR DESCRIPTION
## What

- compare the reloaded PEFT model with the adapter-only state that AutoModel actually writes
- keep strict missing/unexpected adapter-key validation
- keep Nemotron Flash checkpoint robustness on its supported TP=1 topology
- retain Qwen source-load and checkpoint-reload gates

## Root cause

This was a validator mismatch, not adapter corruption. With PEFT 0.18.1, `get_peft_model_state_dict(model)` defaults to `save_embedding_layers="auto"`. These recipes target `"*"`, so PEFT treats the wrapped output head as an embedding-like target and adds `base_model.model.lm_head.base_layer.weight`.

AutoModel intentionally writes adapter-only safetensors, so that base-model tensor is absent from `adapter_model.safetensors`. The validator compared unlike state definitions and reported an unexpected key even though save/reload was exact.

The fix requests `save_embedding_layers=False`, matching the adapter-only export contract. It does not ignore the key: unexpected adapter state remains a hard failure.

## Validation

Local:

- `pytest -q tests/unit_tests/ci_tests/test_checkpoint_robustness_hf_kwargs.py tests/unit_tests/ci_tests/test_config_resolver.py` — 110 passed
- Ruff lint/format and `git diff --check` — passed

Exact Automodel head `06e1cb3057b1eb328d1998d51ee1f409bfcdfbb5`:

- [NeMo CI parent pipeline](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/62243065) — passed
- [leaf pipeline](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/62243325) — passed
- [Ministral 3B PEFT](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/393728827) — passed; 366 saved adapter tensors matched exactly
- [Nemotron Nano 9B PEFT](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/393728828) — passed; 188 saved adapter tensors matched exactly
- [Nemotron Super V3 PEFT](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/393728829) — passed; 466 saved adapter tensors matched exactly
- [Nemotron Flash 1B PEFT](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/393728830) — passed; 154 saved adapter tensors matched exactly
- [Qwen3 MoE 30B PEFT](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/393728831) — passed; source parity passed, AutoModel trainable fingerprints matched on all 8 ranks, and 578 vanilla-PEFT adapter tensors matched exactly

Qwen source-runtime comparison remains enabled. On the final head it passed with max KL 0.01613 (limit 0.03), mean KL 0.00407 (limit 0.006), and cosine 0.99764 (minimum 0.997).