### PR TITLE
fix(moe): raise instead of silently skipping CP setup for unsupported attention

### DIFF
--- a/nemo_automodel/components/moe/parallelizer.py
+++ b/nemo_automodel/components/moe/parallelizer.py
@@ -901,10 +901,19 @@ def apply_cp(model: torch.nn.Module, cp_mesh: DeviceMesh, cp_comm_type: str = "p
                 # installs its own SDPA hook + mask handling.
                 self_attn.setup_cp_attention(cp_mesh)
             else:
-                logger.warning(
-                    "Skipping CP setup for block with unsupported attention module "
-                    "(neither TE DotProductAttention nor model-owned setup_cp_attention): %s",
-                    type(attn_module).__name__ if attn_module is not None else type(self_attn).__name__,
+                # Skipping is not a safe default: the sequence is already sharded across the CP
+                # ranks by the time we get here, so an attention block left without CP silently
+                # attends only this rank's shard. The loss still descends when most blocks are
+                # set up correctly, which makes the resulting model quietly wrong rather than
+                # visibly broken. Fail instead, and say what to do about it.
+                raise ValueError(
+                    f"Context parallelism is enabled (cp_size={cp_mesh.size()}) but block "
+                    f"{_layer_id} has an attention module that provides no CP implementation: "
+                    f"{type(attn_module).__name__ if attn_module is not None else type(self_attn).__name__}. "
+                    "Its queries would attend only this rank's shard of the sequence, silently "
+                    "producing wrong results. Give the module a setup_cp_attention(cp_mesh) "
+                    "method (model-owned CP, as Gemma4 and MiniMax-M3's sparse layers do), or "
+                    "use Transformer Engine attention, or run with cp_size=1."
                 )
         elif layer_type == "mamba":
             from nemo_automodel.components.distributed.context_parallel.mamba import MambaContextParallel


### PR DESCRIPTION
## What

Turn the `else` branch of `apply_cp`'s attention dispatch from a `logger.warning` into a<br>`ValueError`.

## Why

By the time `apply_cp` runs, the sequence has already been sharded across the CP ranks. A block<br>that reaches this branch gets no CP wiring at all, so its queries attend **only this rank's****<br>****shard** — a fraction of the sequence, with a causal structure that no longer matches global<br>positions. Because this usually affects a minority of blocks, the loss still descends and the<br>run looks healthy, so the model comes out quietly wrong instead of visibly broken.

MiniMax-M3 hits this today, and both shipped M3 CP recipes are affected. Full diagnosis with<br>line references in NVIDIA-NeMo/Automodel#3507; the short version:

* `minimax_m3_vl/layers.py` gives layers 3-59 `MiniMaxM3CPSparseAttention` (has<br>`setup_cp_attention`) and layers 0-2 plain `MiniMaxM3Attention` (does not);
* all three M3 recipes run `backend.attn: sdpa`, so the TE branch does not apply either;
* with `ep_size > 1`, `infrastructure.py` gates off the generic dense-SDPA CP pass, so nothing<br>covers layers 0-2;
* they land here and are skipped with a single warning line.

## Scope of this PR

This makes the failure loud. It does **not** implement CP for M3's dense layers — that is the<br>model-side fix discussed in NVIDIA-NeMo/Automodel#3507, and I am happy to write it if maintainers agree on the<br>shape.

## Compatibility

This is a behaviour change: any configuration that currently reaches this branch will now fail<br>at setup instead of training. That is intentional — such a configuration is computing attention<br>over a fraction of its sequence — but it does mean a run that "worked" before may now stop.

Two things I would like maintainer judgement on:

1. Whether a raise is right here, or whether you would prefer an opt-out (env var / config flag)<br>for anyone who has a legitimate reason to skip a block.
2. Whether any in-tree model currently relies on the skip. The branch is only reachable for<br>`layer_type in ("full_attention", "sliding_attention")` with CP enabled, and such a block<br>always needs CP, so I believe the answer is no — but I have only checked the M3 path directly.

## Testing

The change is a single control-flow edit with no new logic; I verified the file parses and the<br>message renders. I have not run the full CI matrix — I do not have the multi-node hardware the<br>CP recipes need (`ep_size: 32` implies 4+ nodes). I have run MiniMax-M3 on a single 8×B300 node<br>at `cp_size=8, ep_size=8, backend.attn: sdpa` with LoRA, which is the configuration that<br>exposed the underlying problem.